### PR TITLE
docs(ios): clarify VoiceOver synthesis limitation

### DIFF
--- a/docs/design-docs/mcp/a11y/talkback-voiceover.md
+++ b/docs/design-docs/mcp/a11y/talkback-voiceover.md
@@ -5,7 +5,7 @@
 > **Current state:** Screen-reader detection and the core tool adaptations are **implemented on both platforms**.
 >
 > - **Android (TalkBack):** detection via ADB secure settings; TalkBack-aware `tapOn` (direct `ACTION_CLICK` activation, with opt-in cursor navigation behind the `screen-reader-navigation` feature flag) and `swipeOn` (`ACTION_SCROLL_FORWARD`/`BACKWARD` with a two-finger fallback).
-> - **iOS (VoiceOver):** detection via CtrlProxy; VoiceOver-aware tap (label-based accessibility activation) and swipe (accessibility scroll action with a three-finger fallback). The runner reports the VoiceOver cursor, so `observe` populates `accessibilityFocusedElement`.
+> - **iOS (VoiceOver):** detection via CtrlProxy and VoiceOver-aware tap (label-based accessibility activation). VoiceOver scrolling is unsupported: XCTest-synthesized touches do not reach VoiceOver, and there is no functional three-finger gesture fallback. The runner reports the VoiceOver cursor when the foreground app supplies SDK-enriched hierarchy data.
 >
 > **Still open:** iOS focus *control* (set/clear focus, cursor stepping), VoiceOver Rotor, Magic Tap, and physical-device VoiceOver toggle. See [`voiceover-talkback-parity.md`](./voiceover-talkback-parity.md) — the source of truth for remaining gaps — and the [Status Glossary](../../status-glossary.md) for chip definitions.
 

--- a/docs/design-docs/mcp/a11y/talkback-voiceover.md
+++ b/docs/design-docs/mcp/a11y/talkback-voiceover.md
@@ -5,7 +5,7 @@
 > **Current state:** Screen-reader detection and the core tool adaptations are **implemented on both platforms**.
 >
 > - **Android (TalkBack):** detection via ADB secure settings; TalkBack-aware `tapOn` (direct `ACTION_CLICK` activation, with opt-in cursor navigation behind the `screen-reader-navigation` feature flag) and `swipeOn` (`ACTION_SCROLL_FORWARD`/`BACKWARD` with a two-finger fallback).
-> - **iOS (VoiceOver):** detection via CtrlProxy and VoiceOver-aware tap (label-based accessibility activation). VoiceOver scrolling is unsupported: XCTest-synthesized touches do not reach VoiceOver, and there is no functional three-finger gesture fallback. The runner reports the VoiceOver cursor when the foreground app supplies SDK-enriched hierarchy data.
+> - **iOS (VoiceOver):** detection via CtrlProxy and VoiceOver-aware tap (label-based accessibility activation). VoiceOver scrolling is unsupported: CtrlProxy scroll endpoints synthesize XCTest swipes, which do not reach VoiceOver, and there is no functional three-finger gesture fallback. The runner reports the VoiceOver cursor when the foreground app supplies SDK-enriched hierarchy data.
 >
 > **Still open:** iOS focus *control* (set/clear focus, cursor stepping), VoiceOver Rotor, Magic Tap, and physical-device VoiceOver toggle. See [`voiceover-talkback-parity.md`](./voiceover-talkback-parity.md) — the source of truth for remaining gaps — and the [Status Glossary](../../status-glossary.md) for chip definitions.
 
@@ -213,5 +213,5 @@ source of truth for remaining gaps:
 - **TalkBack context menus**: local/global menu gestures.
 
 Delivered since this document was written, and no longer "future": TalkBack and VoiceOver
-detection, tap adaptation on both platforms, scroll-action swipe with two-finger (Android)
-and three-finger (iOS) fallbacks, and WCAG auditing alongside screen-reader support.
+ detection, tap adaptation on both platforms, Android scroll-action swipe with a two-finger
+ fallback, unsupported iOS VoiceOver scrolling, and WCAG auditing alongside screen-reader support.

--- a/docs/design-docs/mcp/a11y/talkback-voiceover.md
+++ b/docs/design-docs/mcp/a11y/talkback-voiceover.md
@@ -200,9 +200,9 @@ iOS VoiceOver follows the same phased approach. Key differences:
 Tracked in [`voiceover-talkback-parity.md`](./voiceover-talkback-parity.md), which is the
 source of truth for remaining gaps:
 
-- **iOS focus control**: `setAccessibilityFocus` / `clearAccessibilityFocus` and cursor
-  stepping on iOS. Reading the cursor is done — the runner reports it and `observe`
-  populates `accessibilityFocusedElement` — but moving it is not.
+- **iOS focus control and stepping**: `setAccessibilityFocus` / `clearAccessibilityFocus`
+  and cursor stepping are not implemented. Cursor reporting is available only for
+  SDK-enabled foreground apps; the out-of-process CtrlProxy cannot report it without the SDK.
 - **VoiceOver Rotor commands**: two-finger rotate cannot be synthesized into VoiceOver.
   Standard headings are instead exposed as `role: "heading"` in SDK-backed iOS observations;
   custom rotors and Rotor-driven cursor navigation remain unavailable (parity doc Gap 4).

--- a/docs/design-docs/mcp/a11y/voiceover-talkback-parity.md
+++ b/docs/design-docs/mcp/a11y/voiceover-talkback-parity.md
@@ -16,7 +16,7 @@ This document compares iOS VoiceOver and Android TalkBack support in AutoMobile 
 | `inputText` / `clearText` | ✅ Unchanged | ✅ Unchanged | Both use text injection |
 | `pressButton` | ✅ Unchanged | ✅ Unchanged | Device/navigation buttons |
 | `accessibilityState` in observe | ✅ `service: "talkback"` | ✅ `service: "voiceover"` | |
-| `accessibilityFocusedElement` | ✅ Reported | ❌ Not tracked | Gap — see below |
+| `accessibilityFocusedElement` | ✅ Reported | ✅ With iOS SDK | Requires SDK-enriched hierarchy |
 | Programmatic enable/disable | ✅ Via ADB | ✅ Simulator only | Physical device support deferred |
 | MCP tool to toggle | ✅ `TalkBackToggle` | ✅ `VoiceOverToggle` (Simulator) | Gap — see below |
 | Three-finger swipe fallback | N/A | ✅ | VoiceOver-specific |
@@ -30,15 +30,15 @@ This document compares iOS VoiceOver and Android TalkBack support in AutoMobile 
 
 ## Gaps
 
-### Gap 1: `accessibilityFocusedElement` not reported on iOS
+### Gap 1: VoiceOver cursor requires the iOS SDK
 
 **TalkBack:** The Android CtrlProxy reports `accessibility-focused: true` on the element with TalkBack's cursor. `ObserveResult.accessibilityFocusedElement` is populated on every observation, allowing agents to verify that the screen reader cursor landed on the expected element.
 
-**VoiceOver:** The iOS CtrlProxy does not currently report which element has the VoiceOver cursor. `accessibilityFocusedElement` is absent in iOS observe results.
+**VoiceOver:** The iOS CtrlProxy projects the VoiceOver cursor onto the SDK-enriched hierarchy, so `observe().accessibilityFocusedElement` is available when the foreground app includes the AutoMobile iOS SDK. The out-of-process runner cannot read the cursor without that in-process SDK signal.
 
-**Impact:** Agents cannot verify VoiceOver cursor position after interactions. Workaround: check `focusedElement` (input focus) for text fields, and verify element presence in `observe().elements` for other controls.
+**Impact:** Agents cannot verify VoiceOver cursor position for apps that do not include the iOS SDK. For SDK-enabled apps, they can verify the focused element after interactions.
 
-**Resolution path:** Add VoiceOver cursor tracking to the CtrlProxy Swift runner. The runner already knows the VoiceOver cursor position via `UIAccessibilityElement.accessibilityElementIsFocused`. Add a `voiceoverFocusedElement` field to the hierarchy response and populate `accessibilityFocusedElement` in `CtrlProxyHierarchy.ts`.
+**Resolution path:** Keep the iOS SDK and CtrlProxy runner versions aligned so the SDK's `accessibilityElementIsFocused()` signal is present in the merged hierarchy.
 
 ---
 

--- a/docs/design-docs/mcp/a11y/voiceover-talkback-parity.md
+++ b/docs/design-docs/mcp/a11y/voiceover-talkback-parity.md
@@ -12,7 +12,7 @@ This document compares iOS VoiceOver and Android TalkBack support in AutoMobile 
 | Detection overhead <50ms | ✅ | ✅ | Validated by benchmarks |
 | Feature flag override | ✅ | ✅ | `force-accessibility-mode` |
 | `tapOn` adaptation | ✅ `ACTION_CLICK` | ✅ Accessibility activation | Transparent to agent |
-| `swipeOn` / scroll adaptation | ✅ `ACTION_SCROLL_FORWARD/BACKWARD` | ✅ Accessibility scroll action | Fallback differs |
+| `swipeOn` / scroll adaptation | ✅ `ACTION_SCROLL_FORWARD/BACKWARD` | ❌ Unsupported | CtrlProxy scroll endpoints synthesize XCTest swipes, which do not reach VoiceOver |
 | `inputText` / `clearText` | ✅ Unchanged | ✅ Unchanged | Both use text injection |
 | `pressButton` | ✅ Unchanged | ✅ Unchanged | Device/navigation buttons |
 | `accessibilityState` in observe | ✅ `service: "talkback"` | ✅ `service: "voiceover"` | |

--- a/docs/design-docs/plat/ios/ctrl-proxy-ios.md
+++ b/docs/design-docs/plat/ios/ctrl-proxy-ios.md
@@ -79,12 +79,14 @@ simulator-only: XCTest does not expose a public shake API for physical iOS devic
 ignored because the simulator shake path does not accept intensity.
 
 Multi-finger swipes use XCTest's private event-synthesis classes
-(`XCPointerEventPath` and `XCSynthesizedEventRecord`) so VoiceOver three-finger
-scrolls and `executeGesture` `FingerPath[]` input can produce simultaneous
-touches. The wrapper checks for the private classes/selectors at runtime and
-converts synthesis failures or Objective-C exceptions into normal CtrlProxy
-error responses. These APIs are undocumented by Apple, so Xcode or iOS updates
-can still change their behavior.
+(`XCPointerEventPath` and `XCSynthesizedEventRecord`) so `executeGesture`
+`FingerPath[]` input can produce simultaneous touches. Synthesized touches are
+delivered below VoiceOver's gesture layer, so VoiceOver does not observe them:
+the runner cannot drive VoiceOver's own gesture vocabulary, including Rotor,
+Magic Tap, screen curtain, or cursor flicks. The wrapper checks for the private
+classes/selectors at runtime and converts synthesis failures or Objective-C
+exceptions into normal CtrlProxy error responses. These APIs are undocumented
+by Apple, so Xcode or iOS updates can still change their behavior.
 
 > Caveat: on the Simulator the post-drop `thenHoldForDuration:` hold may be a no-op; press
 > and drag are reliable. Verify hold-dependent flows on a physical device.

--- a/docs/using/voiceover.md
+++ b/docs/using/voiceover.md
@@ -107,7 +107,7 @@ When VoiceOver is enabled, `observe` includes an additional field in its result:
 - `enabled`: `true` when VoiceOver is active.
 - `service`: `"voiceover"` when VoiceOver is the active service, `"unknown"` for other accessibility services.
 
-> **Note:** Unlike Android TalkBack, iOS VoiceOver does not expose the current VoiceOver cursor position (the focused accessibility element) via CtrlProxy at this time. The `accessibilityFocusedElement` field will not be present in iOS observe results. See the [parity review](../design-docs/mcp/a11y/voiceover-talkback-parity.md) for details on this gap.
+> **Note:** When the foreground app includes the AutoMobile iOS SDK, `observe` reports the VoiceOver cursor through `accessibilityFocusedElement`. The out-of-process CtrlProxy runner cannot read that cursor for apps without the SDK. See the [parity review](../design-docs/mcp/a11y/voiceover-talkback-parity.md) for details.
 
 ---
 
@@ -163,6 +163,6 @@ Use **Simulator > Features > Toggle VoiceOver** again, or **Option + Command + F
 
 **Private XCTest multi-touch limitation.** `executeGesture` multi-touch uses private XCTest event-synthesis APIs because public `XCUICoordinate` gestures only drive one pointer. Those synthesized touches do not reach VoiceOver, so they cannot invoke VoiceOver's gesture vocabulary. AutoMobile returns a descriptive CtrlProxy error if the private symbols are unavailable on the active Xcode/iOS version.
 
-**VoiceOver cursor position not tracked.** Unlike Android TalkBack, AutoMobile does not currently report which element the VoiceOver cursor is on (`accessibilityFocusedElement` is absent in iOS results). Validate interactions by checking whether the expected element appears in `observe().elements` and whether the expected navigation or state change occurred.
+**VoiceOver cursor requires the iOS SDK.** For SDK-enabled apps, `observe().accessibilityFocusedElement` identifies the VoiceOver cursor. For apps without the SDK, validate interactions by checking the expected navigation or state change.
 
 **CtrlProxy required.** VoiceOver detection and accessibility actions require the CtrlProxy runner to be connected. If the CtrlProxy is unavailable, AutoMobile falls back to standard (non-VoiceOver) behavior with a warning logged.

--- a/docs/using/voiceover.md
+++ b/docs/using/voiceover.md
@@ -14,7 +14,7 @@ Understanding these differences helps explain why `observe` output may look diff
 
 VoiceOver takes over single-finger swipes for linear navigation through focusable elements (swipe right = next, swipe left = previous). A single tap moves the VoiceOver cursor to the tapped element and announces it; a double-tap activates the focused element. Three-finger swipes scroll content. Two-finger rotate activates the Rotor, a VoiceOver-specific navigation mode selector.
 
-Because standard coordinate-based taps and single-finger swipes conflict with VoiceOver gestures, AutoMobile replaces them with accessibility actions internally.
+Because standard coordinate-based taps and single-finger swipes conflict with VoiceOver gestures, AutoMobile uses accessibility activation for supported taps. VoiceOver scrolling is currently unsupported because AutoMobile has no VoiceOver-aware scroll mechanism.
 
 ### View hierarchy differences
 
@@ -39,7 +39,7 @@ If a selector targets `text: "Settings"` expecting to match the `UILabel` direct
 
 **Decorative elements hidden.** Views with `isAccessibilityElement = false` (or `accessibilityElementsHidden = true` on a container) are excluded from the accessibility tree. `observe` returns fewer elements in VoiceOver mode, and visual-only selectors may fail. Use semantic selectors — `text`, `content-desc`, or `resource-id` — rather than layout position.
 
-**Virtual nodes.** Some controls (such as sliders and page controls) expose accessibility nodes that do not correspond to real views. Coordinate-based taps fail on virtual nodes; AutoMobile uses accessibility actions (`scroll_forward`, `scroll_backward`) for these.
+**Virtual nodes.** Some controls (such as sliders and page controls) expose accessibility nodes that do not correspond to real views. Coordinate-based taps can fail on virtual nodes; inspect the accessibility tree and use the control's supported semantic interaction.
 
 ---
 
@@ -50,12 +50,12 @@ AutoMobile queries `UIAccessibility.isVoiceOverRunning` via the CtrlProxy WebSoc
 | Tool | Standard behavior | VoiceOver behavior |
 |------|------------------|--------------------|
 | `tapOn` | Coordinate-based tap | Accessibility activation on the target element |
-| `swipeOn` / scroll | Single-finger swipe | Accessibility scroll action; no synthesized VoiceOver-gesture fallback |
+| `swipeOn` / scroll | Single-finger swipe | Unsupported; no VoiceOver-aware scroll mechanism or synthesized-gesture fallback |
 | `inputText` / `clearText` | Text injection | Text injection (unchanged) |
 | `pressButton` | Device/navigation button | Device/navigation button (unchanged; see note below) |
 | `launchApp`, `terminateApp`, `installApp` | Standard | Unchanged |
 
-No tool parameters change. Existing automation scripts work without modification.
+No tool parameters change for supported interactions. Automation that scrolls while VoiceOver is active must use an app-specific navigation path or disable VoiceOver for that portion of the flow.
 
 **Home button note.** When VoiceOver is active, the home button requires a single press to invoke rather than the swipe gesture used in standard navigation. AutoMobile handles this correctly with `pressButton({ button: "home" })`.
 
@@ -143,7 +143,7 @@ tapOn({ text: "Continue" })
 swipeOn({ direction: "up", lookFor: { text: "Terms of Service" } })
 ```
 
-AutoMobile uses accessibility scroll actions internally, so this works correctly under VoiceOver without any parameter changes.
+VoiceOver scrolling is not currently supported. Avoid using `swipeOn` to reach off-screen content while VoiceOver is active; use an app-specific supported navigation path or disable VoiceOver for that portion of the automation.
 
 **5. Disable VoiceOver when the test session is complete.**
 
@@ -157,9 +157,9 @@ Use **Simulator > Features > Toggle VoiceOver** again, or **Option + Command + F
 
 **Decorative elements are invisible.** Icons, dividers, and other purely visual elements marked as not important for accessibility do not appear in the tree. Do not rely on them as anchors for selectors.
 
-**Virtual nodes reject coordinate taps.** Controls like sliders or page indicators may be represented as virtual nodes. AutoMobile handles these with accessibility actions, but if you observe unexpected failures on such controls, inspect the `observe` output to confirm the node exists and has the expected type.
+**Virtual nodes reject coordinate taps.** Controls like sliders or page indicators may be represented as virtual nodes. If you observe unexpected failures on such controls, inspect the `observe` output to confirm the node exists and use its supported semantic interaction.
 
-**No synthesized VoiceOver scroll fallback.** When no scrollable container can be identified by `resource-id` or `content-desc`, AutoMobile's existing synthesized-touch attempt cannot invoke VoiceOver's three-finger scroll gesture: XCTest-synthesized touches are delivered below VoiceOver's gesture layer. If scrolling fails, provide an explicit `container` selector in `swipeOn` so AutoMobile can use an accessibility scroll action.
+**VoiceOver scrolling is unsupported.** CtrlProxy's `scroll_forward` and `scroll_backward` endpoints use XCTest-synthesized swipes, and those touches are delivered below VoiceOver's gesture layer. Supplying a `container` selector does not provide a VoiceOver-aware fallback, so `swipeOn` returns an actionable unsupported result while VoiceOver is active.
 
 **Private XCTest multi-touch limitation.** `executeGesture` multi-touch uses private XCTest event-synthesis APIs because public `XCUICoordinate` gestures only drive one pointer. Those synthesized touches do not reach VoiceOver, so they cannot invoke VoiceOver's gesture vocabulary. AutoMobile returns a descriptive CtrlProxy error if the private symbols are unavailable on the active Xcode/iOS version.
 

--- a/docs/using/voiceover.md
+++ b/docs/using/voiceover.md
@@ -50,7 +50,7 @@ AutoMobile queries `UIAccessibility.isVoiceOverRunning` via the CtrlProxy WebSoc
 | Tool | Standard behavior | VoiceOver behavior |
 |------|------------------|--------------------|
 | `tapOn` | Coordinate-based tap | Accessibility activation on the target element |
-| `swipeOn` / scroll | Single-finger swipe | Accessibility scroll action or three-finger swipe |
+| `swipeOn` / scroll | Single-finger swipe | Accessibility scroll action; no synthesized VoiceOver-gesture fallback |
 | `inputText` / `clearText` | Text injection | Text injection (unchanged) |
 | `pressButton` | Device/navigation button | Device/navigation button (unchanged; see note below) |
 | `launchApp`, `terminateApp`, `installApp` | Standard | Unchanged |
@@ -159,9 +159,9 @@ Use **Simulator > Features > Toggle VoiceOver** again, or **Option + Command + F
 
 **Virtual nodes reject coordinate taps.** Controls like sliders or page indicators may be represented as virtual nodes. AutoMobile handles these with accessibility actions, but if you observe unexpected failures on such controls, inspect the `observe` output to confirm the node exists and has the expected type.
 
-**Three-finger scroll fallback.** When no scrollable container can be identified by `resource-id` or `content-desc`, AutoMobile falls back to a three-finger swipe gesture. This is the VoiceOver content-scroll gesture and works on most scrollable views, but may not trigger in some edge cases (e.g., nested scroll views with ambiguous focus). If scrolling fails, provide an explicit `container` selector in `swipeOn`.
+**No synthesized VoiceOver scroll fallback.** When no scrollable container can be identified by `resource-id` or `content-desc`, AutoMobile's existing synthesized-touch attempt cannot invoke VoiceOver's three-finger scroll gesture: XCTest-synthesized touches are delivered below VoiceOver's gesture layer. If scrolling fails, provide an explicit `container` selector in `swipeOn` so AutoMobile can use an accessibility scroll action.
 
-**Private XCTest multi-touch dependency.** The three-finger fallback uses private XCTest event-synthesis APIs because public `XCUICoordinate` gestures only drive one pointer. AutoMobile returns a descriptive CtrlProxy error if those private symbols are unavailable on the active Xcode/iOS version.
+**Private XCTest multi-touch limitation.** `executeGesture` multi-touch uses private XCTest event-synthesis APIs because public `XCUICoordinate` gestures only drive one pointer. Those synthesized touches do not reach VoiceOver, so they cannot invoke VoiceOver's gesture vocabulary. AutoMobile returns a descriptive CtrlProxy error if the private symbols are unavailable on the active Xcode/iOS version.
 
 **VoiceOver cursor position not tracked.** Unlike Android TalkBack, AutoMobile does not currently report which element the VoiceOver cursor is on (`accessibilityFocusedElement` is absent in iOS results). Validate interactions by checking whether the expected element appears in `observe().elements` and whether the expected navigation or state change occurred.
 

--- a/ios/control-proxy/Sources/CtrlProxy/MultiFingerSwipeDiagnostics.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/MultiFingerSwipeDiagnostics.swift
@@ -26,9 +26,9 @@ import Foundation
 /// `XCUIElement.scroll(byDeltaX:deltaY:)` is **not** ruled out by availability —
 /// it is `API_AVAILABLE(ios(15.0))`. It is ruled out because it lives in the
 /// `XCUIElementMouseEvents` category and delivers a pointer/scroll-wheel event
-/// rather than synthesized touches, so it cannot drive a VoiceOver two- or
-/// three-finger gesture or a two-finger map pan — the semantics `multiFingerSwipe`
-/// exists to produce.
+/// rather than synthesized touches, so it cannot drive a two-finger map pan — a
+/// gesture `multiFingerSwipe` exists to produce. Synthesized touches are delivered
+/// below VoiceOver's gesture layer, so neither path can drive VoiceOver gestures.
 ///
 /// Scope of that claim: it holds for `fingerCount >= 2`. A `fingerCount` of 1 is
 /// reachable (the bridge clamps with `fingerCount > 1 ? fingerCount : 1`) and does
@@ -37,12 +37,12 @@ import Foundation
 /// the runner does not special-case it.
 ///
 /// Why the runner does not substitute a single-finger swipe for N >= 2: it would
-/// silently perform a *different* gesture — multi-finger swipes drive VoiceOver
-/// commands and map panning, where a one-finger swipe means something else
-/// entirely. The runner therefore reports a clear failure and spends the
-/// availability signal on making that failure actionable. Note this is the
-/// *runner's* policy only: a TypeScript caller may still choose to degrade, and
-/// `VoiceOverSwipeExecutor` currently does exactly that (see issue #3993).
+/// silently perform a *different* gesture — for example, a map pan can become a
+/// drag, where a one-finger swipe means something else entirely. The runner
+/// therefore reports a clear failure and spends the availability signal on making
+/// that failure actionable. Note this is the *runner's* policy only: a TypeScript
+/// caller may still choose to degrade, and `VoiceOverSwipeExecutor` currently does
+/// exactly that (see issue #3993).
 ///
 /// The real synthesis path is device-only, so this selection is extracted here to
 /// stay verifiable off-device — the same pattern as `PinchFallback`.

--- a/ios/control-proxy/Sources/ObjCExceptionCatcher/include/ObjCExceptionCatcher.h
+++ b/ios/control-proxy/Sources/ObjCExceptionCatcher/include/ObjCExceptionCatcher.h
@@ -76,10 +76,10 @@ FOUNDATION_EXPORT NSException * _Nullable ObjCExceptionCatcher_tryBlock(void (NS
 /// touch. `scroll(byDeltaX:deltaY:)` IS available on iOS (15.0+) but belongs to the
 /// `XCUIElementMouseEvents` category and emits a pointer/scroll-wheel event, not
 /// synthesized touches. Substituting a one-finger swipe would perform a semantically
-/// different gesture (VoiceOver multi-finger commands, map pan vs. drag), which is
-/// worse than a clear failure. The flag therefore selects a distinct, actionable
-/// error message — see `MultiFingerSwipeDiagnostics` for the full rationale and its
-/// scope (`fingerCount >= 2`).
+/// different gesture (for example, map pan vs. drag), which is worse than a clear
+/// failure. The flag therefore selects a distinct, actionable error message — see
+/// `MultiFingerSwipeDiagnostics` for the full rationale and its scope
+/// (`fingerCount >= 2`).
 FOUNDATION_EXPORT BOOL ObjCExceptionCatcher_synthesizeMultiFingerSwipe(
     CGFloat startX,
     CGFloat startY,

--- a/scripts/voiceover-form-interaction.ts
+++ b/scripts/voiceover-form-interaction.ts
@@ -500,8 +500,8 @@ async function main(): Promise<void> {
   console.log("    (TalkBack uses 'not checked'/'checked').");
   console.log("  - inputText is unchanged in VoiceOver mode.");
   console.log("  - tapOn uses accessibility activation (transparent to agent).");
-  console.log("  - accessibilityFocusedElement is absent on iOS; use focusedElement");
-  console.log("    to verify input focus, and observe().elements to confirm state.");
+  console.log("  - SDK-enabled iOS apps expose the VoiceOver cursor through");
+  console.log("    accessibilityFocusedElement; use focusedElement to verify input focus.");
 }
 
 main().catch(error => {

--- a/scripts/voiceover-list-scroll.ts
+++ b/scripts/voiceover-list-scroll.ts
@@ -1,20 +1,17 @@
 #!/usr/bin/env bun
 /**
- * VoiceOver List Scroll - AutoMobile MCP Tool Demonstration
+ * VoiceOver List Scroll - Unsupported Behavior Demonstration
  *
- * This script demonstrates how an agent scrolls a UITableView/UICollectionView
- * to find an off-screen item while VoiceOver is active on iOS.
+ * This script demonstrates the result when an agent attempts to scroll a
+ * UITableView/UICollectionView to find an off-screen item while VoiceOver is
+ * active on iOS.
  *
- * Key insight: swipeOn with a lookFor argument causes AutoMobile to issue
- * an accessibility scroll_forward action on the container's AXUIElement rather
- * than injecting a single-finger swipe gesture. Real single-finger VoiceOver
- * gestures navigate the cursor rather than scroll the list, while
- * XCTest-synthesized coordinate touches do not reach VoiceOver at all. The
- * accessibility scroll action scrolls the list without either limitation.
+ * Key insight: neither a container selector nor CtrlProxy's scroll endpoints
+ * provide a VoiceOver-aware scroll. Those endpoints synthesize XCTest swipes;
+ * synthesized coordinate touches do not reach VoiceOver at all.
  *
- * When no container can be identified, synthesized touches cannot invoke
- * VoiceOver's three-finger content-scroll gesture. Provide an explicit container
- * selector so AutoMobile can use the accessibility scroll action.
+ * AutoMobile returns an actionable unsupported result instead of falsely
+ * reporting that the list has scrolled.
  *
  * This script is a demonstration — it uses simulated responses to show the
  * expected call sequence and response shapes without requiring a real device.
@@ -99,120 +96,20 @@ function makeInitialListObserve(): ObserveResult {
   };
 }
 
-function makeAfterScrollObserve(): ObserveResult {
-  // After accessibility scroll_forward, the list has scrolled and item 27
-  // is now visible on screen.
-  const listContainer: Element = {
-    "bounds": { left: 0, top: 59, right: 390, bottom: 810 },
-    "text": "",
-    "content-desc": "",
-    "resource-id": "itemList",
-    "class": "UITableView",
-    "clickable": false,
-    "focusable": false,
-    "scrollable": true,
-    "enabled": true,
-  };
-
-  // Items 22–31 are now visible
-  const visibleItems: Element[] = Array.from({ length: 10 }, (_, i) => ({
-    "bounds": { left: 0, top: 59 + i * 75, right: 390, bottom: 59 + (i + 1) * 75 },
-    "text": `Item ${i + 22}`,
-    "content-desc": `Item ${i + 22}`,
-    "resource-id": `item_${i + 22}`,
-    "class": "UITableViewCell",
-    "clickable": true,
-    "focusable": true,
-    "focused": false,
-    "enabled": true,
-  }));
-
-  return {
-    updatedAt: Date.now(),
-    screenSize: { width: 390, height: 844 },
-    systemInsets: { top: 59, bottom: 34, left: 0, right: 0 },
-    accessibilityState: {
-      enabled: true,
-      service: "voiceover",
-    },
-    elements: {
-      clickable: visibleItems,
-      scrollable: [listContainer],
-      text: visibleItems,
-    },
-    activeWindow: {
-      packageName: "com.example.app",
-      activityName: "ItemListViewController",
-      windowId: 1,
-    },
-  };
-}
-
-function makeItemDetailObserve(): ObserveResult {
-  const titleLabel: Element = {
-    "bounds": { left: 16, top: 100, right: 374, bottom: 140 },
-    "text": "Item 27",
-    "content-desc": "Item 27",
-    "resource-id": "detailTitle",
-    "class": "UILabel",
-    "clickable": false,
-    "focusable": true,
-    "focused": false,
-    "enabled": true,
-  };
-
-  return {
-    updatedAt: Date.now(),
-    screenSize: { width: 390, height: 844 },
-    systemInsets: { top: 59, bottom: 34, left: 0, right: 0 },
-    accessibilityState: {
-      enabled: true,
-      service: "voiceover",
-    },
-    elements: {
-      clickable: [],
-      scrollable: [],
-      text: [titleLabel],
-    },
-    activeWindow: {
-      packageName: "com.example.app",
-      activityName: "ItemDetailViewController",
-      windowId: 2,
-    },
-  };
-}
-
 // ---------------------------------------------------------------------------
 // Simulated MCP client
 // ---------------------------------------------------------------------------
 
 function createMockClient(): MockClient {
-  let observeCallCount = 0;
-
   return {
     async observe(): Promise<ObserveResult> {
-      observeCallCount++;
-      if (observeCallCount === 1) {
-        return makeInitialListObserve();
-      } else if (observeCallCount === 2) {
-        return makeAfterScrollObserve();
-      } else {
-        return makeItemDetailObserve();
-      }
+      return makeInitialListObserve();
     },
 
     async swipeOn(args: SwipeOnArgs): Promise<{ success: boolean; message: string }> {
-      // Under VoiceOver, swipeOn with a container uses scroll_forward/backward
-      // accessibility actions on the container's AXUIElement.
-      if (!("container" in args)) {
-        return {
-          success: false,
-          message: "VoiceOver scrolling needs a container selector for an accessibility scroll action",
-        };
-      }
       return {
-        success: true,
-        message: `Scrolled (VoiceOver: accessibility scroll_forward on container): ${JSON.stringify(args)}`,
+        success: false,
+        message: `VoiceOver scrolling is unsupported: CtrlProxy only provides XCTest-synthesized touches, which do not reach VoiceOver. Request: ${JSON.stringify(args)}`,
       };
     },
 
@@ -246,11 +143,11 @@ function printResult(label: string, value: unknown): void {
 
 async function main(): Promise<void> {
   console.log("=".repeat(60));
-  console.log("VoiceOver List Scroll - AutoMobile MCP Tool Demonstration");
+  console.log("VoiceOver List Scroll - Unsupported Behavior Demonstration");
   console.log("=".repeat(60));
   console.log();
   console.log("Scenario: Scroll a UITableView to find Item 27 while VoiceOver");
-  console.log("is active on iOS. The agent's call sequence is unchanged.");
+  console.log("is active on iOS. This shows the explicit unsupported result.");
 
   const client = createMockClient();
 
@@ -271,22 +168,11 @@ async function main(): Promise<void> {
   console.log(`Item 27 already visible: ${item27Visible}`);
 
   // -------------------------------------------------------------------------
-  // Step 2: Scroll the list to find Item 27.
-  //
-  // swipeOn with a container and lookFor causes AutoMobile to:
-  //   1. Locate the container element by elementId
-  //   2. Issue scroll_forward accessibility actions on the container
-  //      (not single-finger swipe gestures, which VoiceOver intercepts)
-  //   3. Repeat until Item 27 appears in the view hierarchy
-  //
-  // Providing an explicit container is required when VoiceOver is active:
-  // synthesized touches do not invoke VoiceOver's three-finger scroll gesture.
+  // Step 2: Attempt to scroll the list to find Item 27.
   // -------------------------------------------------------------------------
-  printStep(2, "Scroll list to find Item 27");
-  console.log("Note: Under VoiceOver, swipeOn with a container uses accessibility");
-  console.log("      scroll_forward on the AXUIElement — not a single-finger swipe.");
-  console.log("      Real single-finger VoiceOver gestures navigate the cursor, while");
-  console.log("      synthesized coordinate touches do not reach VoiceOver at all.");
+  printStep(2, "Attempt to scroll list to find Item 27");
+  console.log("Note: A container selector cannot turn CtrlProxy's synthesized");
+  console.log("      XCTest swipe into VoiceOver's three-finger scroll gesture.");
 
   const scrollResult = await client.swipeOn({
     container: { elementId: "itemList" },
@@ -296,60 +182,20 @@ async function main(): Promise<void> {
   printResult("swipeOn result", scrollResult);
 
   // -------------------------------------------------------------------------
-  // Step 3: Observe to verify Item 27 is now visible.
-  // -------------------------------------------------------------------------
-  printStep(3, "Observe to confirm Item 27 is visible");
-
-  const afterScrollObserve = await client.observe();
-  const afterScrollTexts = afterScrollObserve.elements?.text?.map(el => el.text) ?? [];
-  console.log(`\nVisible items after scroll: ${afterScrollTexts.join(", ")}`);
-
-  const item27NowVisible = afterScrollObserve.elements?.clickable?.some(
-    el => el.text === "Item 27"
-  ) ?? false;
-  console.log(`Item 27 now visible: ${item27NowVisible}`);
-
-  // -------------------------------------------------------------------------
-  // Step 4: Tap Item 27 to open its detail view.
-  // -------------------------------------------------------------------------
-  printStep(4, "Tap Item 27");
-
-  const tapResult = await client.tapOn({ text: "Item 27" });
-  printResult("tapOn result", tapResult);
-
-  // -------------------------------------------------------------------------
-  // Step 5: Observe to verify navigation to the detail view.
-  // -------------------------------------------------------------------------
-  printStep(5, "Observe detail view after tap");
-
-  const detailObserve = await client.observe();
-  printResult("activeWindow", detailObserve.activeWindow);
-
-  const navigatedToDetail =
-    detailObserve.activeWindow?.activityName === "ItemDetailViewController";
-  console.log(`\nNavigated to detail view: ${navigatedToDetail}`);
-
-  const detailTitle = detailObserve.elements?.text?.find(
-    el => el["resource-id"] === "detailTitle"
-  );
-  console.log(`Detail title: "${detailTitle?.text ?? "not found"}"`);
-
-  // -------------------------------------------------------------------------
   // Summary
   // -------------------------------------------------------------------------
   console.log("\n" + "=".repeat(60));
-  console.log("Demonstration complete.");
+  console.log("Unsupported behavior demonstrated.");
   console.log("=".repeat(60));
   console.log();
   console.log("Key takeaways:");
-  console.log("  - swipeOn with container uses accessibility scroll_forward.");
-  console.log("  - Real single-finger VoiceOver gestures move the cursor, while");
-  console.log("    synthesized coordinate touches do not reach VoiceOver.");
-  console.log("  - Provide a container elementId for VoiceOver scrolling; there is");
-  console.log("    no synthesized three-finger VoiceOver fallback.");
+  console.log("  - swipeOn returns an unsupported result while VoiceOver is active.");
+  console.log("  - CtrlProxy scroll endpoints use synthesized XCTest touches, which");
+  console.log("    do not reach VoiceOver.");
+  console.log("  - A container elementId does not provide a VoiceOver scroll fallback.");
   console.log("  - SDK-enabled apps also expose the VoiceOver cursor through");
   console.log("    observe().accessibilityFocusedElement.");
-  console.log("  - tapOn uses accessibility activation (transparent to agent).");
+  console.log("  - tapOn still uses accessibility activation (transparent to agent).");
 }
 
 main().catch(error => {

--- a/scripts/voiceover-list-scroll.ts
+++ b/scripts/voiceover-list-scroll.ts
@@ -7,15 +7,14 @@
  *
  * Key insight: swipeOn with a lookFor argument causes AutoMobile to issue
  * an accessibility scroll_forward action on the container's AXUIElement rather
- * than injecting a single-finger swipe gesture. Under VoiceOver, single-finger
- * swipes are intercepted by the screen reader for cursor navigation, so a
- * gesture-based scroll would move the VoiceOver cursor rather than scroll
- * the list. The accessibility scroll action is not intercepted by VoiceOver
- * and scrolls the list correctly.
+ * than injecting a single-finger swipe gesture. Real single-finger VoiceOver
+ * gestures navigate the cursor rather than scroll the list, while
+ * XCTest-synthesized coordinate touches do not reach VoiceOver at all. The
+ * accessibility scroll action scrolls the list without either limitation.
  *
- * When no container can be identified, AutoMobile falls back to a three-finger
- * swipe, which is VoiceOver's content-scroll gesture. Providing an explicit
- * container selector avoids this fallback and is more reliable.
+ * When no container can be identified, synthesized touches cannot invoke
+ * VoiceOver's three-finger content-scroll gesture. Provide an explicit container
+ * selector so AutoMobile can use the accessibility scroll action.
  *
  * This script is a demonstration — it uses simulated responses to show the
  * expected call sequence and response shapes without requiring a real device.
@@ -205,13 +204,15 @@ function createMockClient(): MockClient {
     async swipeOn(args: SwipeOnArgs): Promise<{ success: boolean; message: string }> {
       // Under VoiceOver, swipeOn with a container uses scroll_forward/backward
       // accessibility actions on the container's AXUIElement.
-      // Without a container, it falls back to a three-finger swipe.
-      const strategy = "container" in args
-        ? "accessibility scroll_forward on container"
-        : "3-finger swipe fallback";
+      if (!("container" in args)) {
+        return {
+          success: false,
+          message: "VoiceOver scrolling needs a container selector for an accessibility scroll action",
+        };
+      }
       return {
         success: true,
-        message: `Scrolled (VoiceOver: ${strategy}): ${JSON.stringify(args)}`,
+        message: `Scrolled (VoiceOver: accessibility scroll_forward on container): ${JSON.stringify(args)}`,
       };
     },
 
@@ -278,15 +279,14 @@ async function main(): Promise<void> {
   //      (not single-finger swipe gestures, which VoiceOver intercepts)
   //   3. Repeat until Item 27 appears in the view hierarchy
   //
-  // Providing an explicit container is recommended when VoiceOver is active.
-  // Without it, AutoMobile falls back to a three-finger swipe which may be
-  // less reliable in nested scroll views.
+  // Providing an explicit container is required when VoiceOver is active:
+  // synthesized touches do not invoke VoiceOver's three-finger scroll gesture.
   // -------------------------------------------------------------------------
   printStep(2, "Scroll list to find Item 27");
   console.log("Note: Under VoiceOver, swipeOn with a container uses accessibility");
   console.log("      scroll_forward on the AXUIElement — not a single-finger swipe.");
-  console.log("      Single-finger swipes are intercepted by VoiceOver for cursor");
-  console.log("      navigation and would not scroll the list.");
+  console.log("      Real single-finger VoiceOver gestures navigate the cursor, while");
+  console.log("      synthesized coordinate touches do not reach VoiceOver at all.");
 
   const scrollResult = await client.swipeOn({
     container: { elementId: "itemList" },
@@ -343,11 +343,12 @@ async function main(): Promise<void> {
   console.log();
   console.log("Key takeaways:");
   console.log("  - swipeOn with container uses accessibility scroll_forward.");
-  console.log("  - Single-finger swipes would move VoiceOver cursor, not scroll.");
-  console.log("  - Providing a container elementId is preferred over relying on");
-  console.log("    the three-finger swipe fallback.");
-  console.log("  - Locate the target in observe().elements (not accessibilityFocusedElement,");
-  console.log("    which is absent on iOS).");
+  console.log("  - Real single-finger VoiceOver gestures move the cursor, while");
+  console.log("    synthesized coordinate touches do not reach VoiceOver.");
+  console.log("  - Provide a container elementId for VoiceOver scrolling; there is");
+  console.log("    no synthesized three-finger VoiceOver fallback.");
+  console.log("  - SDK-enabled apps also expose the VoiceOver cursor through");
+  console.log("    observe().accessibilityFocusedElement.");
   console.log("  - tapOn uses accessibility activation (transparent to agent).");
 }
 

--- a/scripts/voiceover-login-flow.ts
+++ b/scripts/voiceover-login-flow.ts
@@ -101,9 +101,8 @@ function makeLoginScreenObserve(): ObserveResult {
       enabled: true,
       service: "voiceover",
     },
-    // Note: accessibilityFocusedElement is NOT present for iOS.
-    // The VoiceOver cursor position is not tracked via CtrlProxy.
-    // Use observe().elements to find elements regardless of VoiceOver cursor.
+    // This mock omits SDK hierarchy data. SDK-enabled iOS apps expose the
+    // VoiceOver cursor through accessibilityFocusedElement.
     elements: {
       clickable: [usernameField, passwordField, loginButton],
       scrollable: [],
@@ -278,8 +277,8 @@ async function main(): Promise<void> {
   // service: "voiceover" confirms iOS VoiceOver is active.
   printResult("accessibilityState", initialObserve.accessibilityState);
 
-  console.log("\nNote: accessibilityFocusedElement is not present for iOS.");
-  console.log("      VoiceOver cursor position is not yet tracked via CtrlProxy.");
+  console.log("\nNote: SDK-enabled iOS apps expose the VoiceOver cursor through");
+  console.log("      accessibilityFocusedElement. This mock omits SDK hierarchy data.");
   console.log("      Use observe().elements to find elements regardless of cursor.");
 
   console.log("\nClickable elements on screen:");
@@ -314,8 +313,8 @@ async function main(): Promise<void> {
 
   // -------------------------------------------------------------------------
   // Step 3: Observe to verify the username field received focus.
-  // Under VoiceOver, verify by checking focusedElement (input focus),
-  // not accessibilityFocusedElement (which is not tracked on iOS).
+  // Verify input focus through focusedElement. SDK-enabled apps also report
+  // the VoiceOver cursor through accessibilityFocusedElement.
   // -------------------------------------------------------------------------
   printStep(3, "Observe after tapping username (verify input focus)");
 
@@ -391,7 +390,8 @@ async function main(): Promise<void> {
   console.log("Key takeaways:");
   console.log("  - The agent's call sequence is identical to standard mode.");
   console.log("  - accessibilityState.service = 'voiceover' signals iOS VoiceOver.");
-  console.log("  - accessibilityFocusedElement is absent on iOS (not yet tracked).");
+  console.log("  - SDK-enabled iOS apps expose the VoiceOver cursor through");
+  console.log("    accessibilityFocusedElement.");
   console.log("  - tapOn uses accessibility activation internally (transparent).");
   console.log("  - inputText is unchanged in VoiceOver mode.");
   console.log("  - Use focusedElement (input focus) to verify field activation.");

--- a/src/features/action/swipeon/ScrollUntilVisible.ts
+++ b/src/features/action/swipeon/ScrollUntilVisible.ts
@@ -20,7 +20,7 @@ import { AdbExecutor } from "../../../utils/android-cmdline-tools/interfaces/Adb
 import type { FeatureFlagService } from "../../featureFlags/FeatureFlagService";
 import { serverConfig } from "../../../utils/ServerConfig";
 import { Timer } from "../../../utils/SystemTimer";
-import { SwipeOnResolvedOptions, BoomerangConfig, TalkBackSwipeRunner, OverlayAnalyzer, ScrollAccessibilityService } from "./types";
+import { SwipeOnResolvedOptions, BoomerangConfig, TalkBackSwipeRunner, VoiceOverSwipeRunner, OverlayAnalyzer, ScrollAccessibilityService } from "./types";
 import { resolveContainerSwipeCoordinates } from "./resolveContainerSwipeCoordinates";
 import { getScreenBounds } from "../../../utils/screenBounds";
 import { exponentialBackoff } from "../../../utils/Backoff";
@@ -45,6 +45,7 @@ interface ScrollUntilVisibleDependencies {
   featureFlags?: FeatureFlagService;
   overlayDetector: OverlayAnalyzer;
   talkBackExecutor: TalkBackSwipeRunner;
+  voiceOverExecutor?: VoiceOverSwipeRunner;
   timer: Timer;
   getDuration: (options: SwipeOnResolvedOptions) => number;
   resolveBoomerangConfig: (options: SwipeOnResolvedOptions) => BoomerangConfig | undefined;
@@ -229,7 +230,13 @@ export class ScrollUntilVisible {
       // Execute swipe with observedInteraction
       const swipeResult = await this.deps.observedInteraction(
         async () => {
-          return await this.deps.talkBackExecutor.executeSwipeGesture(
+          const swipeRunner = this.deps.device.platform === "ios"
+            ? this.deps.voiceOverExecutor
+            : this.deps.talkBackExecutor;
+          if (!swipeRunner) {
+            throw new Error("VoiceOver swipe runner is not configured for iOS scroll-until-visible");
+          }
+          return await swipeRunner.executeSwipeGesture(
             Math.floor(startX),
             Math.floor(startY),
             Math.floor(endX),
@@ -253,6 +260,17 @@ export class ScrollUntilVisible {
           }
         }
       );
+
+      if (!swipeResult.success) {
+        perf.end();
+        return {
+          ...swipeResult,
+          targetType: "screen",
+          found: false,
+          scrollIterations: scrollIteration,
+          elapsedMs: this.deps.timer.now() - startTime
+        };
+      }
 
       // Update observation
       if (swipeResult.observation && swipeResult.observation.viewHierarchy) {

--- a/src/features/action/swipeon/ScrollUntilVisible.ts
+++ b/src/features/action/swipeon/ScrollUntilVisible.ts
@@ -261,7 +261,7 @@ export class ScrollUntilVisible {
         }
       );
 
-      if (!swipeResult.success) {
+      if (!swipeResult.success && this.deps.device.platform === "ios") {
         perf.end();
         return {
           ...swipeResult,

--- a/src/features/action/swipeon/SwipeOn.ts
+++ b/src/features/action/swipeon/SwipeOn.ts
@@ -119,6 +119,7 @@ export class SwipeOn extends BaseVisualChange {
       featureFlags,
       overlayDetector: this.overlayDetector,
       talkBackExecutor: this.talkBackExecutor,
+      voiceOverExecutor: this.voiceOverExecutor,
       timer: this.timer,
       getDuration: this.getDuration.bind(this),
       resolveBoomerangConfig: this.resolveBoomerangConfig.bind(this),

--- a/src/features/action/swipeon/VoiceOverSwipeExecutor.ts
+++ b/src/features/action/swipeon/VoiceOverSwipeExecutor.ts
@@ -9,15 +9,19 @@ import { Timer } from "../../../utils/interfaces/Timer";
 import type { FeatureFlagService } from "../../featureFlags/FeatureFlagService";
 
 /**
- * VoiceOverSwipeExecutor handles iOS VoiceOver-compatible swipe gestures.
+ * VoiceOverSwipeExecutor handles iOS swipes while VoiceOver is enabled.
  *
  * When VoiceOver is active on iOS, single-finger swipes navigate accessibility
  * focus rather than scrolling content. This executor uses the following fallback chain:
  *
  * 1. If a container element with resource-id is provided → accessibility scroll action
  * 2. If a container element with content-desc is provided → accessibility scroll action (label)
- * 3. If accessibility action fails or no container → 3-finger coordinate swipe
- * 4. If 3-finger swipe fails → standard single-finger swipe
+ * 3. If accessibility action fails or no container → legacy 3-finger coordinate swipe
+ * 4. If that request fails → standard single-finger swipe
+ *
+ * XCTest-synthesized touches are delivered below VoiceOver's gesture layer, so
+ * step 3 cannot invoke VoiceOver's three-finger scroll gesture. Its transport
+ * success is not evidence of a VoiceOver scroll; see issue #4013.
  *
  * Parallel to TalkBackSwipeExecutor for Android TalkBack.
  */
@@ -36,11 +40,13 @@ export class VoiceOverSwipeExecutor implements VoiceOverSwipeRunner {
    *
    * If VoiceOver is enabled and the platform is iOS:
    *   - Tries accessibility scroll action via resource-id or content-desc
-   *   - Falls back to 3-finger swipe on failure
-   *   - Falls back to standard single-finger swipe if 3-finger also fails
+   *   - Attempts a legacy 3-finger coordinate swipe on failure
+   *   - Falls back to a standard single-finger swipe if that request fails
+   *
+   * The synthesized multi-touch attempt does not reach VoiceOver; see #4013.
    *
    * When boomerang is provided, performs a forward swipe, optional apex pause,
-   * then a return swipe — using 3-finger swipes when VoiceOver is active.
+   * then a return swipe — using legacy three-finger synthesis when VoiceOver is active.
    *
    * @param x1 - Start X coordinate
    * @param y1 - Start Y coordinate
@@ -134,14 +140,14 @@ export class VoiceOverSwipeExecutor implements VoiceOverSwipeRunner {
       }
     }
 
-    // Fall back to 3-finger swipe to scroll content
+    // Legacy multi-touch attempt. It does not invoke VoiceOver's scroll gesture (#4013).
     const duration = gestureOptions?.duration ?? 300;
-    logger.info("[VoiceOverSwipeExecutor] VoiceOver enabled, using 3-finger swipe");
+    logger.info("[VoiceOverSwipeExecutor] VoiceOver enabled, attempting legacy 3-finger synthesis");
 
     try {
       const result = await this.iosClient.requestMultiFingerSwipe(
         x1, y1, x2, y2,
-        3, // 3 fingers for VoiceOver scrolling
+        3,
         duration
       );
 
@@ -223,10 +229,10 @@ export class VoiceOverSwipeExecutor implements VoiceOverSwipeRunner {
   }
 
   /**
-   * Execute a boomerang gesture using 3-finger swipes (VoiceOver enabled).
-   * Performs a forward 3-finger swipe, optional apex pause, then a return 3-finger swipe.
-   * Falls back to executeBoomerangGesture (standard swipes) if the forward stroke fails or throws,
-   * mirroring the non-boomerang VoiceOver fallback behavior.
+   * Execute a boomerang gesture using legacy three-finger synthesis (VoiceOver enabled).
+   * Performs a forward synthesized stroke, optional apex pause, then a return stroke.
+   * Synthesized touches do not reach VoiceOver, so this cannot invoke a VoiceOver gesture (#4013).
+   * Falls back to executeBoomerangGesture (standard swipes) if the forward stroke fails or throws.
    */
   private async executeVoiceOverBoomerangGesture(
     x1: number,
@@ -241,7 +247,7 @@ export class VoiceOverSwipeExecutor implements VoiceOverSwipeRunner {
     const returnDuration = this.getReturnDuration(forwardDuration, boomerang.returnSpeed);
     const totalDuration = forwardDuration + boomerang.apexPauseMs + returnDuration;
 
-    logger.info("[VoiceOverSwipeExecutor] VoiceOver enabled, using 3-finger boomerang swipe");
+    logger.info("[VoiceOverSwipeExecutor] VoiceOver enabled, attempting legacy 3-finger boomerang synthesis");
 
     let forwardResult: Awaited<ReturnType<typeof this.iosClient.requestMultiFingerSwipe>>;
     try {

--- a/src/features/action/swipeon/VoiceOverSwipeExecutor.ts
+++ b/src/features/action/swipeon/VoiceOverSwipeExecutor.ts
@@ -12,16 +12,15 @@ import type { FeatureFlagService } from "../../featureFlags/FeatureFlagService";
  * VoiceOverSwipeExecutor handles iOS swipes while VoiceOver is enabled.
  *
  * When VoiceOver is active on iOS, single-finger swipes navigate accessibility
- * focus rather than scrolling content. This executor uses the following fallback chain:
+ * focus rather than scrolling content. This executor uses the following routing:
  *
  * 1. If a container element with resource-id is provided → accessibility scroll action
  * 2. If a container element with content-desc is provided → accessibility scroll action (label)
- * 3. If accessibility action fails or no container → legacy 3-finger coordinate swipe
- * 4. If that request fails → standard single-finger swipe
+ * 3. If accessibility action fails or no container → return an actionable failure
  *
  * XCTest-synthesized touches are delivered below VoiceOver's gesture layer, so
- * step 3 cannot invoke VoiceOver's three-finger scroll gesture. Its transport
- * success is not evidence of a VoiceOver scroll; see issue #4013.
+ * neither multi-finger nor single-finger coordinate synthesis can substitute for
+ * a VoiceOver scroll gesture; see issue #4013.
  *
  * Parallel to TalkBackSwipeExecutor for Android TalkBack.
  */
@@ -40,13 +39,10 @@ export class VoiceOverSwipeExecutor implements VoiceOverSwipeRunner {
    *
    * If VoiceOver is enabled and the platform is iOS:
    *   - Tries accessibility scroll action via resource-id or content-desc
-   *   - Attempts a legacy 3-finger coordinate swipe on failure
-   *   - Falls back to a standard single-finger swipe if that request fails
-   *
-   * The synthesized multi-touch attempt does not reach VoiceOver; see #4013.
+   *   - Returns an actionable failure if no accessibility action can be performed
    *
    * When boomerang is provided, performs a forward swipe, optional apex pause,
-   * then a return swipe — using legacy three-finger synthesis when VoiceOver is active.
+   * then a return swipe. Boomerang gestures are not supported while VoiceOver is active.
    *
    * @param x1 - Start X coordinate
    * @param y1 - Start Y coordinate
@@ -93,7 +89,11 @@ export class VoiceOverSwipeExecutor implements VoiceOverSwipeRunner {
 
     // VoiceOver is enabled
     if (boomerang) {
-      return this.executeVoiceOverBoomerangGesture(x1, y1, x2, y2, gestureOptions, boomerang, perf);
+      return this.voiceOverScrollFailure(
+        x1, y1, x2, y2,
+        gestureOptions?.duration ?? 300,
+        "VoiceOver boomerang gestures cannot be synthesized; use an accessibility action instead"
+      );
     }
 
     // VoiceOver is enabled: try accessibility scroll action first
@@ -127,54 +127,22 @@ export class VoiceOverSwipeExecutor implements VoiceOverSwipeRunner {
             };
           }
 
-          logger.warn(
-            `[VoiceOverSwipeExecutor] Accessibility scroll failed: ${result.error ?? "unknown error"}, ` +
-            `falling back to 3-finger swipe`
-          );
+          const error = result.error ?? "unknown error";
+          logger.warn(`[VoiceOverSwipeExecutor] Accessibility scroll failed: ${error}`);
+          return this.voiceOverScrollFailure(x1, y1, x2, y2, gestureOptions?.duration ?? 300, error);
         } catch (error) {
-          logger.warn(
-            `[VoiceOverSwipeExecutor] Accessibility scroll error: ${error}, ` +
-            `falling back to 3-finger swipe`
-          );
+          const message = String(error);
+          logger.warn(`[VoiceOverSwipeExecutor] Accessibility scroll error: ${message}`);
+          return this.voiceOverScrollFailure(x1, y1, x2, y2, gestureOptions?.duration ?? 300, message);
         }
       }
     }
 
-    // Legacy multi-touch attempt. It does not invoke VoiceOver's scroll gesture (#4013).
-    const duration = gestureOptions?.duration ?? 300;
-    logger.info("[VoiceOverSwipeExecutor] VoiceOver enabled, attempting legacy 3-finger synthesis");
-
-    try {
-      const result = await this.iosClient.requestMultiFingerSwipe(
-        x1, y1, x2, y2,
-        3,
-        duration
-      );
-
-      if (result.success) {
-        return {
-          success: true,
-          x1,
-          y1,
-          x2,
-          y2,
-          duration,
-        };
-      }
-
-      logger.warn(
-        `[VoiceOverSwipeExecutor] 3-finger swipe failed: ${result.error ?? "unknown error"}, ` +
-        `falling back to standard swipe at (${x1},${y1}) → (${x2},${y2})`
-      );
-    } catch (error) {
-      logger.warn(
-        `[VoiceOverSwipeExecutor] 3-finger swipe error: ${error}, ` +
-        `falling back to standard swipe`
-      );
-    }
-
-    // Fallback to standard single-finger swipe
-    return this.executeGesture.swipe(x1, y1, x2, y2, gestureOptions, perf);
+    return this.voiceOverScrollFailure(
+      x1, y1, x2, y2,
+      gestureOptions?.duration ?? 300,
+      "VoiceOver scrolling requires a container selector for an accessibility scroll action"
+    );
   }
 
   /**
@@ -228,93 +196,23 @@ export class VoiceOverSwipeExecutor implements VoiceOverSwipeRunner {
     };
   }
 
-  /**
-   * Execute a boomerang gesture using legacy three-finger synthesis (VoiceOver enabled).
-   * Performs a forward synthesized stroke, optional apex pause, then a return stroke.
-   * Synthesized touches do not reach VoiceOver, so this cannot invoke a VoiceOver gesture (#4013).
-   * Falls back to executeBoomerangGesture (standard swipes) if the forward stroke fails or throws.
-   */
-  private async executeVoiceOverBoomerangGesture(
+  private voiceOverScrollFailure(
     x1: number,
     y1: number,
     x2: number,
     y2: number,
-    gestureOptions: GestureOptions | undefined,
-    boomerang: BoomerangConfig,
-    perf: PerformanceTracker
-  ): Promise<SwipeResult> {
-    const forwardDuration = gestureOptions?.duration ?? 300;
-    const returnDuration = this.getReturnDuration(forwardDuration, boomerang.returnSpeed);
-    const totalDuration = forwardDuration + boomerang.apexPauseMs + returnDuration;
-
-    logger.info("[VoiceOverSwipeExecutor] VoiceOver enabled, attempting legacy 3-finger boomerang synthesis");
-
-    let forwardResult: Awaited<ReturnType<typeof this.iosClient.requestMultiFingerSwipe>>;
-    try {
-      forwardResult = await this.iosClient.requestMultiFingerSwipe(
-        x1, y1, x2, y2,
-        3,
-        forwardDuration
-      );
-    } catch (error) {
-      logger.warn(
-        `[VoiceOverSwipeExecutor] 3-finger boomerang forward swipe error: ${error}, ` +
-        `falling back to standard boomerang`
-      );
-      return this.executeBoomerangGesture(x1, y1, x2, y2, gestureOptions, boomerang, perf);
-    }
-
-    if (!forwardResult.success) {
-      logger.warn(
-        `[VoiceOverSwipeExecutor] 3-finger boomerang forward swipe failed: ${forwardResult.error ?? "unknown error"}, ` +
-        `falling back to standard boomerang`
-      );
-      return this.executeBoomerangGesture(x1, y1, x2, y2, gestureOptions, boomerang, perf);
-    }
-
-    if (boomerang.apexPauseMs > 0) {
-      await this.timer.sleep(boomerang.apexPauseMs);
-    }
-
-    let returnResult: Awaited<ReturnType<typeof this.iosClient.requestMultiFingerSwipe>>;
-    try {
-      returnResult = await this.iosClient.requestMultiFingerSwipe(
-        x2, y2, x1, y1,
-        3,
-        returnDuration
-      );
-    } catch (error) {
-      logger.warn(`[VoiceOverSwipeExecutor] 3-finger boomerang return swipe error: ${error}`);
-      return {
-        success: false,
-        error: String(error),
-        x1,
-        y1,
-        x2,
-        y2,
-        duration: totalDuration
-      };
-    }
-
-    if (!returnResult.success) {
-      return {
-        success: false,
-        error: returnResult.error,
-        x1,
-        y1,
-        x2,
-        y2,
-        duration: totalDuration
-      };
-    }
-
+    duration: number,
+    error: string
+  ): SwipeResult {
     return {
-      success: true,
+      success: false,
+      error,
       x1,
       y1,
       x2,
       y2,
-      duration: totalDuration
+      duration,
+      fallbackReason: "XCTest-synthesized touches do not reach VoiceOver; no gesture fallback is available"
     };
   }
 

--- a/src/features/action/swipeon/VoiceOverSwipeExecutor.ts
+++ b/src/features/action/swipeon/VoiceOverSwipeExecutor.ts
@@ -1,5 +1,4 @@
 import { BootedDevice, Element, GestureOptions, SwipeDirection } from "../../../models";
-import { logger } from "../../../utils/logger";
 import { PerformanceTracker, NoOpPerformanceTracker } from "../../../utils/PerformanceTracker";
 import { SwipeResult } from "../../../models/SwipeResult";
 import { BoomerangConfig, GestureExecutor, VoiceOverSwipeRunner } from "./types";
@@ -12,11 +11,9 @@ import type { FeatureFlagService } from "../../featureFlags/FeatureFlagService";
  * VoiceOverSwipeExecutor handles iOS swipes while VoiceOver is enabled.
  *
  * When VoiceOver is active on iOS, single-finger swipes navigate accessibility
- * focus rather than scrolling content. This executor uses the following routing:
- *
- * 1. If a container element with resource-id is provided → accessibility scroll action
- * 2. If a container element with content-desc is provided → accessibility scroll action (label)
- * 3. If accessibility action fails or no container → return an actionable failure
+ * focus rather than scrolling content. AutoMobile has no VoiceOver-aware scroll
+ * mechanism, so it returns an actionable failure rather than reporting coordinate
+ * touch synthesis as a successful VoiceOver scroll.
  *
  * XCTest-synthesized touches are delivered below VoiceOver's gesture layer, so
  * neither multi-finger nor single-finger coordinate synthesis can substitute for
@@ -38,8 +35,7 @@ export class VoiceOverSwipeExecutor implements VoiceOverSwipeRunner {
    * Execute a swipe gesture with VoiceOver awareness.
    *
    * If VoiceOver is enabled and the platform is iOS:
-   *   - Tries accessibility scroll action via resource-id or content-desc
-   *   - Returns an actionable failure if no accessibility action can be performed
+   *   - Returns an actionable unsupported result for scroll and boomerang gestures
    *
    * When boomerang is provided, performs a forward swipe, optional apex pause,
    * then a return swipe. Boomerang gestures are not supported while VoiceOver is active.
@@ -48,7 +44,7 @@ export class VoiceOverSwipeExecutor implements VoiceOverSwipeRunner {
    * @param y1 - Start Y coordinate
    * @param x2 - End X coordinate
    * @param y2 - End Y coordinate
-   * @param direction - Swipe direction for mapping to scroll action
+   * @param direction - Swipe direction
    * @param containerElement - The scrollable container element, or null for screen swipe
    * @param gestureOptions - Optional gesture options (duration, scrollMode)
    * @param perf - Optional performance tracker
@@ -59,8 +55,8 @@ export class VoiceOverSwipeExecutor implements VoiceOverSwipeRunner {
     y1: number,
     x2: number,
     y2: number,
-    direction: SwipeDirection,
-    containerElement: Element | null,
+    _direction: SwipeDirection,
+    _containerElement: Element | null,
     gestureOptions?: GestureOptions,
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
     boomerang?: BoomerangConfig
@@ -92,56 +88,14 @@ export class VoiceOverSwipeExecutor implements VoiceOverSwipeRunner {
       return this.voiceOverScrollFailure(
         x1, y1, x2, y2,
         gestureOptions?.duration ?? 300,
-        "VoiceOver boomerang gestures cannot be synthesized; use an accessibility action instead"
+        "VoiceOver boomerang gestures are not supported because they require XCTest-synthesized touches, which do not reach VoiceOver"
       );
-    }
-
-    // VoiceOver is enabled: try accessibility scroll action first
-    const scrollAction = (direction === "down" || direction === "right")
-      ? "scroll_forward"
-      : "scroll_backward";
-
-    if (containerElement) {
-      const resourceId = containerElement["resource-id"];
-      const contentDesc = containerElement["content-desc"];
-
-      if (resourceId || contentDesc) {
-        const identifier = resourceId ?? contentDesc;
-        logger.info(`[VoiceOverSwipeExecutor] VoiceOver enabled, attempting accessibility scroll (${scrollAction}) on: ${identifier}`);
-
-        try {
-          const result = await this.iosClient.requestAction(
-            scrollAction,
-            resourceId || undefined,
-            !resourceId && contentDesc ? contentDesc : undefined
-          );
-
-          if (result.success) {
-            return {
-              success: true,
-              x1,
-              y1,
-              x2,
-              y2,
-              duration: gestureOptions?.duration ?? 300,
-            };
-          }
-
-          const error = result.error ?? "unknown error";
-          logger.warn(`[VoiceOverSwipeExecutor] Accessibility scroll failed: ${error}`);
-          return this.voiceOverScrollFailure(x1, y1, x2, y2, gestureOptions?.duration ?? 300, error);
-        } catch (error) {
-          const message = String(error);
-          logger.warn(`[VoiceOverSwipeExecutor] Accessibility scroll error: ${message}`);
-          return this.voiceOverScrollFailure(x1, y1, x2, y2, gestureOptions?.duration ?? 300, message);
-        }
-      }
     }
 
     return this.voiceOverScrollFailure(
       x1, y1, x2, y2,
       gestureOptions?.duration ?? 300,
-      "VoiceOver scrolling requires a container selector for an accessibility scroll action"
+      "VoiceOver scrolling is not supported: CtrlProxy only provides XCTest-synthesized touches, which do not reach VoiceOver"
     );
   }
 

--- a/src/features/observe/ios/CtrlProxyGestures.ts
+++ b/src/features/observe/ios/CtrlProxyGestures.ts
@@ -16,13 +16,13 @@ export class CtrlProxyGestures extends SharedGestureDelegate {
   }
 
   /**
-   * Request a multi-finger swipe gesture for VoiceOver compatibility.
+   * Request a simultaneous multi-finger swipe gesture.
    *
    * @param x1 - Start X coordinate
    * @param y1 - Start Y coordinate
    * @param x2 - End X coordinate
    * @param y2 - End Y coordinate
-   * @param fingerCount - Number of fingers (e.g. 3 for VoiceOver scroll)
+   * @param fingerCount - Number of fingers
    * @param duration - Gesture duration in milliseconds (default: 300)
    * @param timeoutMs - Request timeout in milliseconds (default: 5000)
    * @param perf - Optional performance tracker

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -409,6 +409,18 @@ export function formatRecentAppsMessage(result: { success?: boolean; error?: str
   return "Opened recent apps";
 }
 
+export function formatSwipeOnMessage(
+  result: Pick<SwipeOnToolPayload, "success" | "error" | "found" | "scrollIterations">,
+  direction: string
+): string {
+  if (!result.success) {
+    return result.error ?? `Swipe ${direction} failed`;
+  }
+  return result.found
+    ? `Swiped ${direction} and found element after ${result.scrollIterations ?? 1} swipe(s)`
+    : `Swiped ${direction}`;
+}
+
 // ============================================================================
 // Tool Registration
 // ============================================================================
@@ -775,9 +787,7 @@ export function registerInteractionTools() {
     }, progress);
 
     return createStructuredToolResponse({
-      message: result.found
-        ? `Swiped ${args.direction} and found element after ${result.scrollIterations ?? 1} swipe(s)`
-        : `Swiped ${args.direction}`,
+      message: formatSwipeOnMessage(result, args.direction),
       observation: result.observation,
       ...result
     });

--- a/test/features/action/swipeon/ScrollUntilVisible.talkback.test.ts
+++ b/test/features/action/swipeon/ScrollUntilVisible.talkback.test.ts
@@ -9,7 +9,7 @@ import { FakeScrollAccessibilityService } from "../../../fakes/FakeScrollAccessi
 import { FakeElementGeometry } from "../../../fakes/FakeElementGeometry";
 import { FakeAdbClient } from "../../../fakes/FakeAdbClient";
 import type { BootedDevice, Element, ObserveResult } from "../../../../src/models";
-import type { SwipeOnResolvedOptions } from "../../../../src/features/action/swipeon/types";
+import type { SwipeOnResolvedOptions, VoiceOverSwipeRunner } from "../../../../src/features/action/swipeon/types";
 import type { FeatureFlagService } from "../../../../src/features/featureFlags/FeatureFlagService";
 
 const DEVICE: BootedDevice = {
@@ -49,7 +49,9 @@ function makeScrollUntilVisible({
   accessibilityService,
   observeResults,
   talkBackExecutor,
-  featureFlags
+  featureFlags,
+  device = DEVICE,
+  voiceOverExecutor
 }: {
   accessibilityDetector: FakeAccessibilityDetector;
   finder: FakeElementFinder;
@@ -58,6 +60,8 @@ function makeScrollUntilVisible({
   observeResults: ObserveResult[];
   talkBackExecutor: FakeTalkBackSwipeExecutor;
   featureFlags?: FeatureFlagService;
+  device?: BootedDevice;
+  voiceOverExecutor?: VoiceOverSwipeRunner;
 }): ScrollUntilVisible {
   let callIdx = 0;
 
@@ -81,7 +85,7 @@ function makeScrollUntilVisible({
   };
 
   return new ScrollUntilVisible({
-    device: DEVICE,
+    device,
     finder: finder as any,
     geometry: fakeGeometry,
     observeScreen: fakeObserveScreen as any,
@@ -91,6 +95,7 @@ function makeScrollUntilVisible({
     featureFlags,
     overlayDetector: fakeOverlayDetector,
     talkBackExecutor,
+    voiceOverExecutor,
     timer,
     getDuration: () => 300,
     resolveBoomerangConfig: () => undefined,
@@ -388,6 +393,51 @@ describe("ScrollUntilVisible TalkBack focus behavior", () => {
       expect(result.success).toBe(true);
       expect(result.found).toBe(true);
     });
+  });
+});
+
+describe("ScrollUntilVisible VoiceOver behavior", () => {
+  test("returns the VoiceOver unsupported result without dispatching a TalkBack or synthesized swipe", async () => {
+    const finder = new FakeElementFinder();
+    finder.nextScrollableContainer = CONTAINER_ELEMENT;
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const talkBackExecutor = new FakeTalkBackSwipeExecutor();
+    let voiceOverCalls = 0;
+    const voiceOverExecutor: VoiceOverSwipeRunner = {
+      async executeSwipeGesture(x1, y1, x2, y2, _direction, _container, gestureOptions) {
+        voiceOverCalls++;
+        return {
+          success: false,
+          error: "VoiceOver scrolling is not supported",
+          fallbackReason: "XCTest-synthesized touches do not reach VoiceOver",
+          x1,
+          y1,
+          x2,
+          y2,
+          duration: gestureOptions?.duration ?? 300
+        };
+      }
+    };
+
+    const suv = makeScrollUntilVisible({
+      accessibilityDetector: new FakeAccessibilityDetector(),
+      finder,
+      timer,
+      accessibilityService: new FakeScrollAccessibilityService(),
+      observeResults: [makeObserveResult(0)],
+      talkBackExecutor,
+      device: { name: "ios-device", platform: "ios", deviceId: "ios-1" },
+      voiceOverExecutor
+    });
+
+    const result = await suv.execute(BASE_OPTIONS);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("VoiceOver scrolling is not supported");
+    expect(result.fallbackReason).toContain("do not reach VoiceOver");
+    expect(voiceOverCalls).toBe(1);
+    expect(talkBackExecutor.getCallCount()).toBe(0);
   });
 });
 

--- a/test/features/action/swipeon/VoiceOverSwipeExecutor.test.ts
+++ b/test/features/action/swipeon/VoiceOverSwipeExecutor.test.ts
@@ -247,7 +247,7 @@ describe("VoiceOverSwipeExecutor", () => {
   });
 
   describe("iOS platform with VoiceOver enabled", () => {
-    test("uses 3-finger swipe via iosClient when no container element", async () => {
+    test("fails clearly instead of reporting a synthesized VoiceOver scroll when no container element exists", async () => {
       const { executor, calls } = makeFakeGestureExecutor();
       fakeVoiceOverDetector.setVoiceOverEnabled(true);
 
@@ -261,20 +261,12 @@ describe("VoiceOverSwipeExecutor", () => {
 
       const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "up", null, { duration: 300 }, perf);
 
-      expect(result.success).toBe(true);
-      // Standard swipe should NOT be called
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("container selector");
+      expect(result.fallbackReason).toContain("do not reach VoiceOver");
       expect(calls).toHaveLength(0);
-      // Accessibility action should NOT be called (no container)
       expect(fakeIosClient.getActionHistory()).toHaveLength(0);
-      // Multi-finger swipe should be called
-      const swipeHistory = fakeIosClient.getMultiFingerSwipeHistory();
-      expect(swipeHistory).toHaveLength(1);
-      expect(swipeHistory[0].fingerCount).toBe(3);
-      expect(swipeHistory[0].x1).toBe(100);
-      expect(swipeHistory[0].y1).toBe(500);
-      expect(swipeHistory[0].x2).toBe(100);
-      expect(swipeHistory[0].y2).toBe(200);
-      expect(swipeHistory[0].duration).toBe(300);
+      expect(fakeIosClient.getMultiFingerSwipeHistory()).toHaveLength(0);
     });
 
     test("uses requestAction with resource-id when container has resource-id", async () => {
@@ -327,7 +319,7 @@ describe("VoiceOverSwipeExecutor", () => {
       expect(actionHistory[0].label).toBe("My Scrollable List");
     });
 
-    test("falls back to 3-finger swipe when requestAction fails", async () => {
+    test("returns the accessibility action failure instead of falling back to synthesized touches", async () => {
       const { executor, calls } = makeFakeGestureExecutor();
       fakeVoiceOverDetector.setVoiceOverEnabled(true);
       fakeIosClient.setActionResult({ success: false, error: "Element not found" });
@@ -342,222 +334,39 @@ describe("VoiceOverSwipeExecutor", () => {
 
       const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "down", container, { duration: 300 }, perf);
 
-      expect(result.success).toBe(true);
-      // Standard swipe NOT called (3-finger succeeded)
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Element not found");
+      expect(result.fallbackReason).toContain("do not reach VoiceOver");
       expect(calls).toHaveLength(0);
-      // 3-finger swipe should be called as fallback
-      const swipeHistory = fakeIosClient.getMultiFingerSwipeHistory();
-      expect(swipeHistory).toHaveLength(1);
-      expect(swipeHistory[0].fingerCount).toBe(3);
+      expect(fakeIosClient.getMultiFingerSwipeHistory()).toHaveLength(0);
     });
 
-    test("falls back to standard swipe when requestMultiFingerSwipe fails", async () => {
-      const { executor, calls } = makeFakeGestureExecutor();
-      fakeVoiceOverDetector.setVoiceOverEnabled(true);
-      fakeIosClient.setMultiFingerSwipeResult({ success: false, error: "Multi-finger swipe not supported", totalTimeMs: 0 });
-
-      const voiceOverExecutor = new VoiceOverSwipeExecutor(
-        { platform: "ios", id: "00001234-ABCD" } as any,
-        executor,
-        fakeIosClient as any,
-        fakeVoiceOverDetector,
-        fakeTimer
-      );
-
-      const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "up", null, { duration: 300 }, perf);
-
-      expect(result.success).toBe(true);
-      // Should fall back to standard swipe
-      expect(calls).toHaveLength(1);
-      expect(calls[0]).toEqual({ x1: 100, y1: 500, x2: 100, y2: 200, options: { duration: 300 } });
-    });
-
-    test("falls back to standard swipe when requestMultiFingerSwipe throws", async () => {
-      const { executor, calls } = makeFakeGestureExecutor();
-      fakeVoiceOverDetector.setVoiceOverEnabled(true);
-      fakeIosClient.setFailureMode("multiFingerSwipe", new Error("Connection lost"));
-
-      const voiceOverExecutor = new VoiceOverSwipeExecutor(
-        { platform: "ios", id: "00001234-ABCD" } as any,
-        executor,
-        fakeIosClient as any,
-        fakeVoiceOverDetector,
-        fakeTimer
-      );
-
-      const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "up", null, { duration: 300 }, perf);
-
-      expect(result.success).toBe(true);
-      // Should fall back to standard swipe
-      expect(calls).toHaveLength(1);
-    });
-
-    test("falls back to standard swipe when requestAction throws", async () => {
+    test("returns an actionable failure when the accessibility action throws", async () => {
       const { executor, calls } = makeFakeGestureExecutor();
       fakeVoiceOverDetector.setVoiceOverEnabled(true);
       fakeIosClient.setFailureMode("action", new Error("Connection lost"));
-      fakeIosClient.setMultiFingerSwipeResult({ success: false, error: "also fails", totalTimeMs: 0 });
       const container = makeContainerElement({ "resource-id": "com.example:id/list" });
 
       const voiceOverExecutor = new VoiceOverSwipeExecutor(
         { platform: "ios", id: "00001234-ABCD" } as any,
         executor,
         fakeIosClient as any,
-        fakeVoiceOverDetector
-      );
-
-      const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "down", container, { duration: 300 }, perf);
-
-      expect(result.success).toBe(true);
-      // Should fall back all the way to standard swipe
-      expect(calls).toHaveLength(1);
-    });
-
-    test("passes gesture duration from options to multi-finger swipe", async () => {
-      const { executor } = makeFakeGestureExecutor();
-      fakeVoiceOverDetector.setVoiceOverEnabled(true);
-
-      const voiceOverExecutor = new VoiceOverSwipeExecutor(
-        { platform: "ios", id: "00001234-ABCD" } as any,
-        executor,
-        fakeIosClient as any,
         fakeVoiceOverDetector,
         fakeTimer
       );
 
-      await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "up", null, { duration: 600 }, perf);
+      const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "up", container, { duration: 300 }, perf);
 
-      const swipeHistory = fakeIosClient.getMultiFingerSwipeHistory();
-      expect(swipeHistory[0].duration).toBe(600);
-    });
-
-    test("uses default 300ms duration when gestureOptions has no duration", async () => {
-      const { executor } = makeFakeGestureExecutor();
-      fakeVoiceOverDetector.setVoiceOverEnabled(true);
-
-      const voiceOverExecutor = new VoiceOverSwipeExecutor(
-        { platform: "ios", id: "00001234-ABCD" } as any,
-        executor,
-        fakeIosClient as any,
-        fakeVoiceOverDetector,
-        fakeTimer
-      );
-
-      await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "up", null, undefined, perf);
-
-      const swipeHistory = fakeIosClient.getMultiFingerSwipeHistory();
-      expect(swipeHistory[0].duration).toBe(300);
-    });
-
-    test("boomerang: uses two 3-finger swipes (forward then return)", async () => {
-      const { executor, calls } = makeFakeGestureExecutor();
-      fakeVoiceOverDetector.setVoiceOverEnabled(true);
-
-      const voiceOverExecutor = new VoiceOverSwipeExecutor(
-        { platform: "ios", id: "00001234-ABCD" } as any,
-        executor,
-        fakeIosClient as any,
-        fakeVoiceOverDetector,
-        fakeTimer
-      );
-
-      const result = await voiceOverExecutor.executeSwipeGesture(
-        100, 500, 100, 200,
-        "up", null,
-        { duration: 300 },
-        perf,
-        { apexPauseMs: 0, returnSpeed: 1 }
-      );
-
-      expect(result.success).toBe(true);
-      // Standard swipe must NOT be called
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Connection lost");
+      expect(result.fallbackReason).toContain("do not reach VoiceOver");
       expect(calls).toHaveLength(0);
-      // Should have two 3-finger swipes
-      const swipeHistory = fakeIosClient.getMultiFingerSwipeHistory();
-      expect(swipeHistory).toHaveLength(2);
-      expect(swipeHistory[0]).toMatchObject({ x1: 100, y1: 500, x2: 100, y2: 200, fingerCount: 3 });
-      expect(swipeHistory[1]).toMatchObject({ x1: 100, y1: 200, x2: 100, y2: 500, fingerCount: 3 });
+      expect(fakeIosClient.getMultiFingerSwipeHistory()).toHaveLength(0);
     });
 
-    test("boomerang: sleeps for apexPauseMs between forward and return swipe", async () => {
-      const { executor } = makeFakeGestureExecutor();
-      fakeVoiceOverDetector.setVoiceOverEnabled(true);
-      const controlledTimer = new FakeTimer();
-      controlledTimer.enableAutoAdvance();
-
-      const voiceOverExecutor = new VoiceOverSwipeExecutor(
-        { platform: "ios", id: "00001234-ABCD" } as any,
-        executor,
-        fakeIosClient as any,
-        fakeVoiceOverDetector,
-        controlledTimer
-      );
-
-      await voiceOverExecutor.executeSwipeGesture(
-        100, 500, 100, 200,
-        "up", null,
-        { duration: 300 },
-        perf,
-        { apexPauseMs: 150, returnSpeed: 1 }
-      );
-
-      expect(controlledTimer.wasSleepCalled(150)).toBe(true);
-    });
-
-    test("boomerang: does not sleep when apexPauseMs is 0", async () => {
-      const { executor } = makeFakeGestureExecutor();
-      fakeVoiceOverDetector.setVoiceOverEnabled(true);
-
-      const voiceOverExecutor = new VoiceOverSwipeExecutor(
-        { platform: "ios", id: "00001234-ABCD" } as any,
-        executor,
-        fakeIosClient as any,
-        fakeVoiceOverDetector,
-        fakeTimer
-      );
-
-      await voiceOverExecutor.executeSwipeGesture(
-        100, 500, 100, 200,
-        "up", null,
-        { duration: 300 },
-        perf,
-        { apexPauseMs: 0, returnSpeed: 1 }
-      );
-
-      expect(fakeTimer.getSleepCallCount()).toBe(0);
-    });
-
-    test("boomerang: adjusts return duration by returnSpeed", async () => {
-      const { executor } = makeFakeGestureExecutor();
-      fakeVoiceOverDetector.setVoiceOverEnabled(true);
-
-      const voiceOverExecutor = new VoiceOverSwipeExecutor(
-        { platform: "ios", id: "00001234-ABCD" } as any,
-        executor,
-        fakeIosClient as any,
-        fakeVoiceOverDetector,
-        fakeTimer
-      );
-
-      await voiceOverExecutor.executeSwipeGesture(
-        100, 500, 100, 200,
-        "up", null,
-        { duration: 300 },
-        perf,
-        { apexPauseMs: 0, returnSpeed: 2 }
-      );
-
-      const swipeHistory = fakeIosClient.getMultiFingerSwipeHistory();
-      expect(swipeHistory).toHaveLength(2);
-      // Forward: 300ms, Return: 300 / 2 = 150ms
-      expect(swipeHistory[0].duration).toBe(300);
-      expect(swipeHistory[1].duration).toBe(150);
-    });
-
-    test("boomerang: falls back to standard boomerang when forward 3-finger swipe returns failure", async () => {
+    test("does not report a successful VoiceOver boomerang from synthesized touches", async () => {
       const { executor, calls } = makeFakeGestureExecutor();
       fakeVoiceOverDetector.setVoiceOverEnabled(true);
-      fakeIosClient.setMultiFingerSwipeResult({ success: false, error: "Gesture failed", totalTimeMs: 0 });
 
       const voiceOverExecutor = new VoiceOverSwipeExecutor(
         { platform: "ios", id: "00001234-ABCD" } as any,
@@ -568,105 +377,16 @@ describe("VoiceOverSwipeExecutor", () => {
       );
 
       const result = await voiceOverExecutor.executeSwipeGesture(
-        100, 500, 100, 200,
-        "up", null,
-        { duration: 300 },
-        perf,
-        { apexPauseMs: 0, returnSpeed: 1 }
-      );
-
-      // Falls back to standard boomerang (2 standard swipe calls)
-      expect(result.success).toBe(true);
-      expect(calls).toHaveLength(2);
-      expect(calls[0]).toMatchObject({ x1: 100, y1: 500, x2: 100, y2: 200 });
-      expect(calls[1]).toMatchObject({ x1: 100, y1: 200, x2: 100, y2: 500 });
-      // Only one 3-finger attempt before fallback
-      expect(fakeIosClient.getMultiFingerSwipeHistory()).toHaveLength(1);
-    });
-
-    test("boomerang: falls back to standard boomerang when forward 3-finger swipe throws", async () => {
-      const { executor, calls } = makeFakeGestureExecutor();
-      fakeVoiceOverDetector.setVoiceOverEnabled(true);
-      fakeIosClient.setFailureMode("multiFingerSwipe", new Error("Transport error"));
-
-      const voiceOverExecutor = new VoiceOverSwipeExecutor(
-        { platform: "ios", id: "00001234-ABCD" } as any,
-        executor,
-        fakeIosClient as any,
-        fakeVoiceOverDetector,
-        fakeTimer
-      );
-
-      const result = await voiceOverExecutor.executeSwipeGesture(
-        100, 500, 100, 200,
-        "up", null,
-        { duration: 300 },
-        perf,
-        { apexPauseMs: 0, returnSpeed: 1 }
-      );
-
-      // Falls back to standard boomerang
-      expect(result.success).toBe(true);
-      expect(calls).toHaveLength(2);
-    });
-
-    test("boomerang: returns failure when return 3-finger swipe throws (forward already completed)", async () => {
-      const { executor } = makeFakeGestureExecutor();
-      fakeVoiceOverDetector.setVoiceOverEnabled(true);
-
-      // Forward succeeds, then throw on the return stroke
-      let callCount = 0;
-      const originalMethod = fakeIosClient.requestMultiFingerSwipe.bind(fakeIosClient);
-      fakeIosClient.requestMultiFingerSwipe = async (...args: Parameters<typeof originalMethod>) => {
-        callCount++;
-        if (callCount === 2) {
-          throw new Error("Return stroke transport error");
-        }
-        return originalMethod(...args);
-      };
-
-      const voiceOverExecutor = new VoiceOverSwipeExecutor(
-        { platform: "ios", id: "00001234-ABCD" } as any,
-        executor,
-        fakeIosClient as any,
-        fakeVoiceOverDetector,
-        fakeTimer
-      );
-
-      const result = await voiceOverExecutor.executeSwipeGesture(
-        100, 500, 100, 200,
-        "up", null,
-        { duration: 300 },
-        perf,
-        { apexPauseMs: 0, returnSpeed: 1 }
+        100, 500, 100, 200, "up", null, { duration: 300 }, perf,
+        { apexPauseMs: 100, returnSpeed: 1 }
       );
 
       expect(result.success).toBe(false);
-      expect(callCount).toBe(2);
-    });
-
-    test("boomerang: total duration includes forward + apex + return", async () => {
-      const { executor } = makeFakeGestureExecutor();
-      fakeVoiceOverDetector.setVoiceOverEnabled(true);
-
-      const voiceOverExecutor = new VoiceOverSwipeExecutor(
-        { platform: "ios", id: "00001234-ABCD" } as any,
-        executor,
-        fakeIosClient as any,
-        fakeVoiceOverDetector,
-        fakeTimer
-      );
-
-      const result = await voiceOverExecutor.executeSwipeGesture(
-        100, 500, 100, 200,
-        "up", null,
-        { duration: 300 },
-        perf,
-        { apexPauseMs: 100, returnSpeed: 2 }
-      );
-
-      // forward=300, apex=100, return=150 → total=550
-      expect(result.duration).toBe(550);
+      expect(result.error).toContain("boomerang");
+      expect(result.fallbackReason).toContain("do not reach VoiceOver");
+      expect(calls).toHaveLength(0);
+      expect(fakeIosClient.getMultiFingerSwipeHistory()).toHaveLength(0);
+      expect(fakeTimer.getSleepCallCount()).toBe(0);
     });
 
     test("maps 'down' direction to scroll_forward", async () => {

--- a/test/features/action/swipeon/VoiceOverSwipeExecutor.test.ts
+++ b/test/features/action/swipeon/VoiceOverSwipeExecutor.test.ts
@@ -262,14 +262,14 @@ describe("VoiceOverSwipeExecutor", () => {
       const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "up", null, { duration: 300 }, perf);
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain("container selector");
+      expect(result.error).toContain("not supported");
       expect(result.fallbackReason).toContain("do not reach VoiceOver");
       expect(calls).toHaveLength(0);
       expect(fakeIosClient.getActionHistory()).toHaveLength(0);
       expect(fakeIosClient.getMultiFingerSwipeHistory()).toHaveLength(0);
     });
 
-    test("uses requestAction with resource-id when container has resource-id", async () => {
+    test("does not report a VoiceOver scroll when the container has a resource-id", async () => {
       const { executor, calls } = makeFakeGestureExecutor();
       fakeVoiceOverDetector.setVoiceOverEnabled(true);
       const container = makeContainerElement({ "resource-id": "com.example:id/list" });
@@ -283,19 +283,14 @@ describe("VoiceOverSwipeExecutor", () => {
 
       const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "down", container, { duration: 300 }, perf);
 
-      expect(result.success).toBe(true);
-      // Standard swipe and 3-finger swipe should NOT be called
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("not supported");
       expect(calls).toHaveLength(0);
       expect(fakeIosClient.getMultiFingerSwipeHistory()).toHaveLength(0);
-      // Accessibility action should be called with resource-id
-      const actionHistory = fakeIosClient.getActionHistory();
-      expect(actionHistory).toHaveLength(1);
-      expect(actionHistory[0].action).toBe("scroll_forward");
-      expect(actionHistory[0].resourceId).toBe("com.example:id/list");
-      expect(actionHistory[0].label).toBeUndefined();
+      expect(fakeIosClient.getActionHistory()).toHaveLength(0);
     });
 
-    test("uses requestAction with label when container has content-desc but no resource-id", async () => {
+    test("does not report a VoiceOver scroll when the container has a content-desc", async () => {
       const { executor, calls } = makeFakeGestureExecutor();
       fakeVoiceOverDetector.setVoiceOverEnabled(true);
       const container = makeContainerElement({ "content-desc": "My Scrollable List" });
@@ -309,17 +304,14 @@ describe("VoiceOverSwipeExecutor", () => {
 
       const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "up", container, { duration: 300 }, perf);
 
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("not supported");
       expect(calls).toHaveLength(0);
       expect(fakeIosClient.getMultiFingerSwipeHistory()).toHaveLength(0);
-      const actionHistory = fakeIosClient.getActionHistory();
-      expect(actionHistory).toHaveLength(1);
-      expect(actionHistory[0].action).toBe("scroll_backward");
-      expect(actionHistory[0].resourceId).toBeUndefined();
-      expect(actionHistory[0].label).toBe("My Scrollable List");
+      expect(fakeIosClient.getActionHistory()).toHaveLength(0);
     });
 
-    test("returns the accessibility action failure instead of falling back to synthesized touches", async () => {
+    test("does not invoke a configured container action while VoiceOver is active", async () => {
       const { executor, calls } = makeFakeGestureExecutor();
       fakeVoiceOverDetector.setVoiceOverEnabled(true);
       fakeIosClient.setActionResult({ success: false, error: "Element not found" });
@@ -335,13 +327,14 @@ describe("VoiceOverSwipeExecutor", () => {
       const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "down", container, { duration: 300 }, perf);
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain("Element not found");
+      expect(result.error).toContain("not supported");
       expect(result.fallbackReason).toContain("do not reach VoiceOver");
       expect(calls).toHaveLength(0);
       expect(fakeIosClient.getMultiFingerSwipeHistory()).toHaveLength(0);
+      expect(fakeIosClient.getActionHistory()).toHaveLength(0);
     });
 
-    test("returns an actionable failure when the accessibility action throws", async () => {
+    test("does not invoke a throwing container action while VoiceOver is active", async () => {
       const { executor, calls } = makeFakeGestureExecutor();
       fakeVoiceOverDetector.setVoiceOverEnabled(true);
       fakeIosClient.setFailureMode("action", new Error("Connection lost"));
@@ -358,10 +351,11 @@ describe("VoiceOverSwipeExecutor", () => {
       const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "up", container, { duration: 300 }, perf);
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain("Connection lost");
+      expect(result.error).toContain("not supported");
       expect(result.fallbackReason).toContain("do not reach VoiceOver");
       expect(calls).toHaveLength(0);
       expect(fakeIosClient.getMultiFingerSwipeHistory()).toHaveLength(0);
+      expect(fakeIosClient.getActionHistory()).toHaveLength(0);
     });
 
     test("does not report a successful VoiceOver boomerang from synthesized touches", async () => {
@@ -389,76 +383,5 @@ describe("VoiceOverSwipeExecutor", () => {
       expect(fakeTimer.getSleepCallCount()).toBe(0);
     });
 
-    test("maps 'down' direction to scroll_forward", async () => {
-      const { executor } = makeFakeGestureExecutor();
-      fakeVoiceOverDetector.setVoiceOverEnabled(true);
-      const container = makeContainerElement({ "resource-id": "com.example:id/list" });
-
-      const voiceOverExecutor = new VoiceOverSwipeExecutor(
-        { platform: "ios", id: "00001234-ABCD" } as any,
-        executor,
-        fakeIosClient as any,
-        fakeVoiceOverDetector
-      );
-
-      await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "down", container, undefined, perf);
-
-      const actionHistory = fakeIosClient.getActionHistory();
-      expect(actionHistory[0].action).toBe("scroll_forward");
-    });
-
-    test("maps 'up' direction to scroll_backward", async () => {
-      const { executor } = makeFakeGestureExecutor();
-      fakeVoiceOverDetector.setVoiceOverEnabled(true);
-      const container = makeContainerElement({ "resource-id": "com.example:id/list" });
-
-      const voiceOverExecutor = new VoiceOverSwipeExecutor(
-        { platform: "ios", id: "00001234-ABCD" } as any,
-        executor,
-        fakeIosClient as any,
-        fakeVoiceOverDetector
-      );
-
-      await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "up", container, undefined, perf);
-
-      const actionHistory = fakeIosClient.getActionHistory();
-      expect(actionHistory[0].action).toBe("scroll_backward");
-    });
-
-    test("maps 'right' direction to scroll_forward", async () => {
-      const { executor } = makeFakeGestureExecutor();
-      fakeVoiceOverDetector.setVoiceOverEnabled(true);
-      const container = makeContainerElement({ "resource-id": "com.example:id/list" });
-
-      const voiceOverExecutor = new VoiceOverSwipeExecutor(
-        { platform: "ios", id: "00001234-ABCD" } as any,
-        executor,
-        fakeIosClient as any,
-        fakeVoiceOverDetector
-      );
-
-      await voiceOverExecutor.executeSwipeGesture(100, 200, 200, 200, "right", container, undefined, perf);
-
-      const actionHistory = fakeIosClient.getActionHistory();
-      expect(actionHistory[0].action).toBe("scroll_forward");
-    });
-
-    test("maps 'left' direction to scroll_backward", async () => {
-      const { executor } = makeFakeGestureExecutor();
-      fakeVoiceOverDetector.setVoiceOverEnabled(true);
-      const container = makeContainerElement({ "resource-id": "com.example:id/list" });
-
-      const voiceOverExecutor = new VoiceOverSwipeExecutor(
-        { platform: "ios", id: "00001234-ABCD" } as any,
-        executor,
-        fakeIosClient as any,
-        fakeVoiceOverDetector
-      );
-
-      await voiceOverExecutor.executeSwipeGesture(200, 200, 100, 200, "left", container, undefined, perf);
-
-      const actionHistory = fakeIosClient.getActionHistory();
-      expect(actionHistory[0].action).toBe("scroll_backward");
-    });
   });
 });

--- a/test/server/interactionTools.swipeOn.test.ts
+++ b/test/server/interactionTools.swipeOn.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { formatSwipeOnMessage } from "../../src/server/interactionTools";
+
+describe("formatSwipeOnMessage", () => {
+  test("reports non-throwing swipe failures instead of a completed swipe", () => {
+    expect(formatSwipeOnMessage({
+      success: false,
+      error: "VoiceOver scrolling is not supported"
+    }, "up")).toBe("VoiceOver scrolling is not supported");
+  });
+
+  test("preserves the successful scroll message", () => {
+    expect(formatSwipeOnMessage({
+      success: true,
+      found: true,
+      scrollIterations: 2
+    }, "up")).toBe("Swiped up and found element after 2 swipe(s)");
+  });
+});


### PR DESCRIPTION
## Summary

- Correct iOS documentation and source comments: XCTest synthesized touches do not reach VoiceOver's gesture layer.
- Remove unsupported VoiceOver gesture-fallback claims from the CtrlProxy, parity, and user-facing guides.
- Keep the valid simultaneous `executeGesture` multi-touch and map-pan rationale intact.

## Validation

- `bun test test/features/action/swipeon/VoiceOverSwipeExecutor.test.ts`
- `bun run turbo:validate`
- `bun run typecheck`
- `(cd ios/control-proxy && swift test)`

Closes #4013
