### PR TITLE
fix(a11y): detect disabled TalkBack package

### DIFF
--- a/src/features/accessibility/TalkBackToggle.ts
+++ b/src/features/accessibility/TalkBackToggle.ts
@@ -187,32 +187,26 @@ export class TalkBackToggle {
   }
 
   /**
-   * Run `dumpsys accessibility` to check whether TalkBack is installed on the
-   * device.  Returns the full service component name to use in settings commands,
-   * or null if TalkBack is not present.
+   * Check PackageManager for TalkBack rather than `dumpsys accessibility`.
+   * The latter only reports enabled services, so it cannot discover the
+   * installed-but-disabled TalkBack that this toggle needs to enable.
    */
   private async detectInstalledService(): Promise<string | null> {
     try {
-      const result = await this.adb.executeCommand("shell dumpsys accessibility");
-      const output = result.stdout;
+      const result = await this.adb.executeCommand(`shell pm list packages ${TALKBACK_PACKAGE}`);
+      const installed = result.stdout
+        .split("\n")
+        .some(line => line.trim() === `package:${TALKBACK_PACKAGE}`);
 
-      if (!output.includes(TALKBACK_PACKAGE) && !output.includes("TalkBackService")) {
-        logger.debug("[TalkBackToggle] TalkBack not found in dumpsys output");
+      if (!installed) {
+        logger.debug("[TalkBackToggle] TalkBack package not found");
         return null;
       }
 
-      // Prefer extracting the exact component name from the dump
-      const match = /com\.google\.android\.marvin\.talkback\/[\w.]+TalkBackService/.exec(output);
-      if (match) {
-        logger.debug(`[TalkBackToggle] Detected service component: ${match[0]}`);
-        return match[0];
-      }
-
-      // Package found but component name could not be parsed — use known fallback
-      logger.debug("[TalkBackToggle] Using hardcoded TalkBack service component name");
+      logger.debug("[TalkBackToggle] TalkBack package found; using known service component");
       return TALKBACK_SERVICE_FALLBACK;
     } catch (error) {
-      logger.error("[TalkBackToggle] Failed to detect TalkBack service via dumpsys:", error);
+      logger.error("[TalkBackToggle] Failed to detect TalkBack package:", error);
       return null;
     }
   }

--- a/src/features/accessibility/TalkBackToggle.ts
+++ b/src/features/accessibility/TalkBackToggle.ts
@@ -26,14 +26,19 @@ export class TalkBackToggle {
   }
 
   async toggle(enabled: boolean): Promise<TalkBackResult> {
-    // Step 1: Verify TalkBack is installed on this device
-    const serviceComponent = await this.detectInstalledService();
-    if (!serviceComponent) {
-      return {
-        supported: false,
-        applied: false,
-        reason: "TalkBack service not installed on this device"
-      };
+    // Step 1: Verify the Google TalkBack package before enabling it. Disabling
+    // relies on the active-service detector so it also removes vendor/AOSP
+    // TalkBack components that use the same TalkBackService contract.
+    let serviceComponent: string | null = null;
+    if (enabled) {
+      serviceComponent = await this.detectInstalledService();
+      if (!serviceComponent) {
+        return {
+          supported: false,
+          applied: false,
+          reason: "TalkBack service not installed on this device"
+        };
+      }
     }
 
     // Step 2: Idempotency — invalidate stale cache, then check if TalkBack is
@@ -55,7 +60,7 @@ export class TalkBackToggle {
     // other paths (#3921).
     try {
       if (enabled) {
-        await this.enableTalkBack(serviceComponent);
+        await this.enableTalkBack(serviceComponent!);
         // Step 4: Best-effort permission dialog dismissal
         await this.dismissPermissionDialog();
       } else {

--- a/test/features/accessibility/TalkBackToggle.test.ts
+++ b/test/features/accessibility/TalkBackToggle.test.ts
@@ -400,8 +400,7 @@ describe("TalkBackToggle", () => {
 
   describe("ADB error during apply phase", () => {
     test("returns a typed failure (not an uncaught throw) when an apply-phase ADB command fails", async () => {
-      // dumpsys succeeds so detectInstalledService() passes (TalkBack is found)
-      fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
+      // The default PackageManager response confirms that TalkBack is installed.
       // The apply phase reads the current services list; make that command throw
       fakeAdb.setCommandError(
         "settings get secure enabled_accessibility_services",

--- a/test/features/accessibility/TalkBackToggle.test.ts
+++ b/test/features/accessibility/TalkBackToggle.test.ts
@@ -22,10 +22,8 @@ Installed Services:
   (none)
 `;
 
-const DUMPSYS_WITH_TALKBACK_NO_COMPONENT = `
-Installed Services:
-  Service[label=TalkBack]
-    Package: com.google.android.marvin.talkback
+const PACKAGE_LIST_WITH_TALKBACK = `
+package:com.google.android.marvin.talkback
 `;
 
 const DIALOG_XML_WITH_BUTTON1 = `<?xml version="1.0" encoding="UTF-8"?>
@@ -61,6 +59,10 @@ describe("TalkBackToggle", () => {
     fakeDetector = new FakeAccessibilityDetector();
     fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
+    fakeAdb.setCommandResponse(
+      "pm list packages com.google.android.marvin.talkback",
+      makeExecResult(PACKAGE_LIST_WITH_TALKBACK)
+    );
   });
 
   afterEach(() => {
@@ -356,10 +358,10 @@ describe("TalkBackToggle", () => {
   });
 
   describe("TalkBack not installed", () => {
-    test("returns supported:false when dumpsys contains no TalkBack entry", async () => {
+    test("returns supported:false when package manager contains no TalkBack entry", async () => {
       fakeAdb.setCommandResponse(
-        "dumpsys accessibility",
-        makeExecResult(DUMPSYS_WITHOUT_TALKBACK)
+        "pm list packages com.google.android.marvin.talkback",
+        makeExecResult("")
       );
 
       const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
@@ -372,8 +374,8 @@ describe("TalkBackToggle", () => {
 
     test("does not run settings commands when TalkBack is not installed", async () => {
       fakeAdb.setCommandResponse(
-        "dumpsys accessibility",
-        makeExecResult(DUMPSYS_WITHOUT_TALKBACK)
+        "pm list packages com.google.android.marvin.talkback",
+        makeExecResult("")
       );
 
       const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
@@ -382,8 +384,11 @@ describe("TalkBackToggle", () => {
       expect(fakeAdb.wasCommandExecuted("accessibility_enabled")).toBe(false);
     });
 
-    test("returns supported:false when dumpsys command throws", async () => {
-      fakeAdb.setDefaultError(new Error("ADB connection failed"));
+    test("returns supported:false when package manager command throws", async () => {
+      fakeAdb.setCommandError(
+        "pm list packages com.google.android.marvin.talkback",
+        new Error("ADB connection failed")
+      );
 
       const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
       const result = await toggle.toggle(true);
@@ -415,14 +420,19 @@ describe("TalkBackToggle", () => {
     });
   });
 
-  describe("service component name detection", () => {
-    test("extracts service component from dumpsys output", async () => {
-      fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
-      fakeDetector.setDefaultResult(false);
+  describe("TalkBack service component", () => {
+    test("enables an installed but disabled TalkBack that is absent from dumpsys", async () => {
+      fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITHOUT_TALKBACK));
+      fakeDetector.enqueueDetectMethodResults("unknown", "talkback");
 
       const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
-      await toggle.toggle(true);
+      const result = await toggle.toggle(true);
 
+      expect(result).toEqual({ supported: true, applied: true, currentState: true });
+      expect(
+        fakeAdb.wasCommandExecuted("shell pm list packages com.google.android.marvin.talkback")
+      ).toBe(true);
+      expect(fakeAdb.wasCommandExecuted("shell dumpsys accessibility")).toBe(false);
       expect(
         fakeAdb.wasCommandExecuted(
           "shell settings put secure enabled_accessibility_services com.google.android.marvin.talkback/com.google.android.marvin.talkback.TalkBackService"
@@ -430,11 +440,7 @@ describe("TalkBackToggle", () => {
       ).toBe(true);
     });
 
-    test("falls back to hardcoded component when package present but component unparseable", async () => {
-      fakeAdb.setCommandResponse(
-        "dumpsys accessibility",
-        makeExecResult(DUMPSYS_WITH_TALKBACK_NO_COMPONENT)
-      );
+    test("uses the known TalkBack service component", async () => {
       fakeDetector.setDefaultResult(false);
 
       const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);

--- a/test/features/accessibility/TalkBackToggle.test.ts
+++ b/test/features/accessibility/TalkBackToggle.test.ts
@@ -267,6 +267,30 @@ describe("TalkBackToggle", () => {
   });
 
   describe("disable TalkBack", () => {
+    test("disables an active non-Google TalkBack service even when Google's package is absent", async () => {
+      const vendorTalkBackService = "com.android.talkback/com.android.talkback.TalkBackService";
+      fakeAdb.setCommandResponse(
+        "pm list packages com.google.android.marvin.talkback",
+        makeExecResult("")
+      );
+      fakeAdb.setCommandResponse(
+        "settings get secure enabled_accessibility_services",
+        makeExecResult(vendorTalkBackService)
+      );
+      fakeDetector.enqueueDetectMethodResults("talkback", "unknown");
+
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const result = await toggle.toggle(false);
+
+      expect(result).toEqual({ supported: true, applied: true, currentState: false });
+      expect(
+        fakeAdb.wasCommandExecuted("shell pm list packages com.google.android.marvin.talkback")
+      ).toBe(false);
+      expect(
+        fakeAdb.wasCommandExecuted("shell settings delete secure enabled_accessibility_services")
+      ).toBe(true);
+    });
+
     test("returns supported:true applied:true when TalkBack is installed and currently enabled", async () => {
       fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
       // Idempotency: talkback (currently on) -> proceed to disable. Confirmation:


### PR DESCRIPTION
## Summary

Detect TalkBack installation through PackageManager instead of `dumpsys accessibility`.
`dumpsys` only exposes enabled services, so an installed-but-disabled TalkBack on stock
emulators was incorrectly reported as absent. The toggle now uses the known TalkBack
service component after PackageManager confirms the package is installed.

## Linked Issue

Closes #4042

## Bug / Regression Context

- **Prior attempts:** None; this is a long-standing detector behavior.
- **Observed symptom:** `accessibility --talkback true` returned “TalkBack service not installed on this device” when TalkBack was installed but disabled.
- **Repro steps / conditions:** On a stock `sdk_gphone64_arm64` emulator, invoke the TalkBack toggle before it has been enabled.

## Validation

- [x] `bun test test/features/accessibility/TalkBackToggle.test.ts` (25 tests)
- [x] `bun run turbo:validate` (lint, build, full test suite)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] The unit tests use the existing fake ADB executor, accessibility detector, and FakeTimer.
- [x] Rebased onto current `origin/main` before implementation.

## Device Verification

- [ ] Not run: this is covered by the stock-emulator regression test; no device was available in this worktree.

## Follow-ups

- [x] No out-of-scope gaps identified.
