### PR TITLE
fix: use IPv4 for Android CtrlProxy forwarding

### DIFF
--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -40,7 +40,7 @@ import { HierarchyNavigationDetector } from "../../navigation/HierarchyNavigatio
 import { InstalledAppsRepository, InstalledAppsStore } from "../../../db/installedAppsRepository";
 import { getDbWriteBarrier } from "../../../db/dbWriteBarrier";
 import { DefaultWorkProfileMonitor, WorkProfileMonitor } from "../../../utils/WorkProfileMonitor";
-import { PortManager } from "../../../utils/PortManager";
+import { IOS_CTRL_PROXY_RESERVED_PORTS, PortManager } from "../../../utils/PortManager";
 import { requireBootedDevice } from "../../../utils/requireBootedDevice";
 import { getDeviceDataStreamServer } from "../../../daemon/deviceDataStreamSocketServer";
 import {
@@ -959,7 +959,9 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     this.crashEventSink = crashEventSink ?? new FailureEventRepository();
     this.deviceConnectionLostNotifier =
       deviceConnectionLostNotifier ?? observationStreamDeviceConnectionLostNotifier;
-    this.localPort = PortManager.allocate(device.deviceId);
+    this.localPort = PortManager.allocate(device.deviceId, {
+      reservedPorts: IOS_CTRL_PROXY_RESERVED_PORTS,
+    });
     AndroidCtrlProxyManager.getInstance(device);
   }
 
@@ -1206,7 +1208,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   // ===========================================================================
 
   protected getWebSocketUrl(): string {
-    return `ws://localhost:${this.localPort}/ws`;
+    return `ws://127.0.0.1:${this.localPort}/ws`;
   }
 
   protected async handleMessage(data: WebSocket.Data): Promise<void> {
@@ -2129,7 +2131,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     const additionalReservedPorts = currentPortIsAvailable ? [] : [this.localPort];
     PortManager.release(this.device.deviceId);
     const nextPort = PortManager.allocate(this.device.deviceId, {
-      reservedPorts: additionalReservedPorts,
+      reservedPorts: [
+        ...IOS_CTRL_PROXY_RESERVED_PORTS,
+        ...additionalReservedPorts,
+      ],
     });
     if (nextPort !== this.localPort) {
       logger.info(

--- a/src/utils/PortManager.ts
+++ b/src/utils/PortManager.ts
@@ -176,7 +176,7 @@ export class PortManager {
    */
   public static getWebSocketUrl(deviceId: string): string {
     const port = this.allocate(deviceId);
-    return `ws://localhost:${port}/ws`;
+    return `ws://127.0.0.1:${port}/ws`;
   }
 
   /**

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -399,7 +399,36 @@ describe("AndroidCtrlProxyClient", function() {
     });
   });
 
-  test("setupPortForwarding reallocates when the current local port becomes busy before adb forward", async function() {
+  test("allocates an Android forwarding port while skipping the iOS SDK hierarchy server port", async function() {
+    await accessibilityServiceClient.close();
+    AndroidCtrlProxyClient.resetInstances();
+    PortManager.reset();
+
+    const checkedPorts: number[] = [];
+    PortManager.setPortAvailabilityCheckerForTesting({
+      isPortAvailable: (port: number) => {
+        checkedPorts.push(port);
+        return port !== 8765;
+      },
+    });
+    try {
+      accessibilityServiceClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        createSuccessWebSocketFactory(),
+        fakeTimer
+      );
+
+      expect(checkedPorts).toEqual([8765, 8767]);
+      expect((accessibilityServiceClient as unknown as { getWebSocketUrl: () => string }).getWebSocketUrl()).toBe(
+        "ws://127.0.0.1:8767/ws"
+      );
+    } finally {
+      PortManager.setPortAvailabilityCheckerForTesting(null);
+    }
+  });
+
+  test("setupPortForwarding reallocates while preserving Android's reserved ports", async function() {
     await accessibilityServiceClient.close();
     AndroidCtrlProxyClient.resetInstances();
     PortManager.reset();
@@ -426,11 +455,11 @@ describe("AndroidCtrlProxyClient", function() {
         getWebSocketUrl: () => string;
       }).setupPortForwarding();
 
-      expect(checkedPorts).toEqual([8765, 8765, 8766]);
-      expect(fakeAdb.getExecutedCommands()).toContain("forward --remove tcp:8766");
-      expect(fakeAdb.getExecutedCommands()).toContain("forward tcp:8766 tcp:8765");
+      expect(checkedPorts).toEqual([8765, 8765, 8767]);
+      expect(fakeAdb.getExecutedCommands()).toContain("forward --remove tcp:8767");
+      expect(fakeAdb.getExecutedCommands()).toContain("forward tcp:8767 tcp:8765");
       expect((accessibilityServiceClient as unknown as { getWebSocketUrl: () => string }).getWebSocketUrl()).toBe(
-        "ws://localhost:8766/ws"
+        "ws://127.0.0.1:8767/ws"
       );
     } finally {
       PortManager.setPortAvailabilityCheckerForTesting(null);

--- a/test/utils/PortManager.test.ts
+++ b/test/utils/PortManager.test.ts
@@ -152,8 +152,8 @@ describe("PortManager", () => {
     const url1 = PortManager.getWebSocketUrl("device-1");
     const url2 = PortManager.getWebSocketUrl("device-2");
 
-    expect(url1).toBe("ws://localhost:8765/ws");
-    expect(url2).toBe("ws://localhost:8766/ws");
+    expect(url1).toBe("ws://127.0.0.1:8765/ws");
+    expect(url2).toBe("ws://127.0.0.1:8766/ws");
   });
 
   test("should return allocations map", () => {


### PR DESCRIPTION
## Summary

Make Android CtrlProxy forwarding use IPv4 loopback, matching the address bound by `adb forward`. Reserve the iOS SDK hierarchy-server port (8766) in Android's initial and recovery allocations so an Android forward cannot collide with it.

## Linked Issue

Closes #4039

## Bug / Regression Context

- **Prior attempts:** None.
- **Observed symptom:** Android `observe` could connect to an unrelated IPv6 listener through `localhost`, then time out with a misleading accessibility-service error.
- **Repro steps / conditions:** An Android forward chooses port 8766 while a booted iOS simulator has its hierarchy server on that port; macOS resolves `localhost` to IPv6 first.

## Validation

- [x] Focused regression tests: `bun test test/utils/PortManager.test.ts test/features/observe/CtrlProxyClient.test.ts`
- [x] `bun run lint`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run turbo:validate` (lint, build, full test suite: 8,123 passed; 11 expected integration skips)
- [x] New code uses existing allocation APIs and fakes; no new dependency or generic helper
- [x] Started from freshly fetched `origin/main`

## Device Verification

Not run locally; the regression is covered by focused allocation and WebSocket-URL unit tests.
