### PR TITLE
fix(ios): wait for VoiceOver enable confirmation

### DIFF
--- a/src/features/accessibility/VoiceOverToggle.ts
+++ b/src/features/accessibility/VoiceOverToggle.ts
@@ -6,13 +6,18 @@ import { iosVoiceOverDetector } from "../../utils/IosVoiceOverDetector";
 import type { ProcessExecutor } from "../../utils/ProcessExecutor";
 import { DefaultProcessExecutor } from "../../utils/ProcessExecutor";
 import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
+import { type Timer, defaultTimer } from "../../utils/SystemTimer";
 import { IOSCtrlProxyClient } from "../observe/ios";
+
+const VOICEOVER_CONFIRMATION_TIMEOUT_MS = 10_000;
+const VOICEOVER_CONFIRMATION_POLL_INTERVAL_MS = 500;
 
 export class VoiceOverToggle {
   constructor(
     private readonly device: BootedDevice,
     private readonly detector: IosVoiceOverDetector = iosVoiceOverDetector,
-    private readonly processExecutor: ProcessExecutor = new DefaultProcessExecutor()
+    private readonly processExecutor: ProcessExecutor = new DefaultProcessExecutor(),
+    private readonly timer: Timer = defaultTimer
   ) {}
 
   async toggle(enabled: boolean): Promise<VoiceOverResult> {
@@ -67,10 +72,9 @@ export class VoiceOverToggle {
     // did not land, `applied` reflects the real post-apply state rather than the
     // requested one (#3921). Detection failure maps to `false`, so a confirmation
     // that cannot be read reports the toggle as not-applied (conservative).
-    this.detector.invalidateCache(this.device.deviceId);
     // Resolve lazily so the iOS singleton is only touched on the iOS path.
     const client = IOSCtrlProxyClient.getInstance(this.device);
-    const confirmedEnabled = await this.detector.isVoiceOverEnabled(this.device.deviceId, client);
+    const confirmedEnabled = await this.waitForState(enabled, client);
 
     return {
       supported: true,
@@ -81,6 +85,25 @@ export class VoiceOverToggle {
 
   private isSimulator(): boolean {
     return isIosSimulatorUdid(this.device.deviceId);
+  }
+
+  /**
+   * CtrlProxy can observe VoiceOver before its launchctl job has fully started.
+   * Poll the post-apply confirmation through the injectable timer so a successful
+   * enable is not reported as failed merely because its service is still starting.
+   */
+  private async waitForState(enabled: boolean, client: IOSCtrlProxyClient): Promise<boolean> {
+    const startTime = this.timer.now();
+
+    while (true) {
+      this.detector.invalidateCache(this.device.deviceId);
+      const confirmedEnabled = await this.detector.isVoiceOverEnabled(this.device.deviceId, client);
+      if (confirmedEnabled === enabled || this.timer.now() - startTime >= VOICEOVER_CONFIRMATION_TIMEOUT_MS) {
+        return confirmedEnabled;
+      }
+
+      await this.timer.sleep(VOICEOVER_CONFIRMATION_POLL_INTERVAL_MS);
+    }
   }
 
   private isServiceAlreadyStopped(error: unknown): boolean {

--- a/src/features/accessibility/VoiceOverToggle.ts
+++ b/src/features/accessibility/VoiceOverToggle.ts
@@ -93,16 +93,27 @@ export class VoiceOverToggle {
    * enable is not reported as failed merely because its service is still starting.
    */
   private async waitForState(enabled: boolean, client: IOSCtrlProxyClient): Promise<boolean> {
-    const startTime = this.timer.now();
+    const deadline = this.timer.now() + VOICEOVER_CONFIRMATION_TIMEOUT_MS;
+    let confirmedEnabled = false;
 
     while (true) {
-      this.detector.invalidateCache(this.device.deviceId);
-      const confirmedEnabled = await this.detector.isVoiceOverEnabled(this.device.deviceId, client);
-      if (confirmedEnabled === enabled || this.timer.now() - startTime >= VOICEOVER_CONFIRMATION_TIMEOUT_MS) {
+      const remainingMs = deadline - this.timer.now();
+      if (remainingMs <= 0) {
         return confirmedEnabled;
       }
 
-      await this.timer.sleep(VOICEOVER_CONFIRMATION_POLL_INTERVAL_MS);
+      this.detector.invalidateCache(this.device.deviceId);
+      confirmedEnabled = await this.detector.isVoiceOverEnabled(
+        this.device.deviceId,
+        client,
+        undefined,
+        remainingMs
+      );
+      if (confirmedEnabled === enabled || this.timer.now() >= deadline) {
+        return confirmedEnabled;
+      }
+
+      await this.timer.sleep(Math.min(VOICEOVER_CONFIRMATION_POLL_INTERVAL_MS, deadline - this.timer.now()));
     }
   }
 

--- a/src/utils/IosVoiceOverDetector.ts
+++ b/src/utils/IosVoiceOverDetector.ts
@@ -34,8 +34,8 @@ export class DefaultIosVoiceOverDetector implements IIosVoiceOverDetector {
    * @returns Promise resolving to true if VoiceOver is enabled
    */
   async isVoiceOverEnabled(
-   deviceId: string,
-   client: IOSCtrlProxy,
+    deviceId: string,
+    client: IOSCtrlProxy,
     featureFlags?: FeatureFlagService,
     timeoutMs?: number
   ): Promise<boolean> {

--- a/src/utils/IosVoiceOverDetector.ts
+++ b/src/utils/IosVoiceOverDetector.ts
@@ -34,9 +34,10 @@ export class DefaultIosVoiceOverDetector implements IIosVoiceOverDetector {
    * @returns Promise resolving to true if VoiceOver is enabled
    */
   async isVoiceOverEnabled(
-    deviceId: string,
-    client: IOSCtrlProxy,
-    featureFlags?: FeatureFlagService
+   deviceId: string,
+   client: IOSCtrlProxy,
+    featureFlags?: FeatureFlagService,
+    timeoutMs?: number
   ): Promise<boolean> {
     // Check feature flag override first
     if (featureFlags?.isEnabled("force-accessibility-mode")) {
@@ -60,7 +61,7 @@ export class DefaultIosVoiceOverDetector implements IIosVoiceOverDetector {
     // Detect current state
     logger.debug(`[IosVoiceOverDetector] Detecting VoiceOver state for device ${deviceId}`);
     const startTime = this.timer.now();
-    const detected = await this.detectVoiceOverState(deviceId, client);
+    const detected = await this.detectVoiceOverState(deviceId, client, timeoutMs);
     const detectionTime = this.timer.now() - startTime;
 
     if (detectionTime > 50) {
@@ -102,9 +103,13 @@ export class DefaultIosVoiceOverDetector implements IIosVoiceOverDetector {
    * completed (connection failure, timeout, or error response from CtrlProxy).
    * Null results are not cached so the next call will retry.
    */
-  private async detectVoiceOverState(deviceId: string, client: IOSCtrlProxy): Promise<boolean | null> {
+  private async detectVoiceOverState(
+    deviceId: string,
+    client: IOSCtrlProxy,
+    timeoutMs?: number
+  ): Promise<boolean | null> {
     try {
-      const result = await client.requestVoiceOverState();
+      const result = await client.requestVoiceOverState(timeoutMs);
       if (!result.success) {
         logger.warn(`[IosVoiceOverDetector] VoiceOver detection failed for ${deviceId}: ${result.error}`);
         return null;

--- a/src/utils/interfaces/IosVoiceOverDetector.ts
+++ b/src/utils/interfaces/IosVoiceOverDetector.ts
@@ -15,9 +15,10 @@ export interface IosVoiceOverDetector {
    * @returns Promise resolving to true if VoiceOver is enabled
    */
   isVoiceOverEnabled(
-    deviceId: string,
-    client: IOSCtrlProxy,
-    featureFlags?: FeatureFlagService
+   deviceId: string,
+   client: IOSCtrlProxy,
+    featureFlags?: FeatureFlagService,
+    timeoutMs?: number
   ): Promise<boolean>;
 
   /**

--- a/test/fakes/FakeIosVoiceOverDetector.ts
+++ b/test/fakes/FakeIosVoiceOverDetector.ts
@@ -14,6 +14,8 @@ export class FakeIosVoiceOverDetector implements IosVoiceOverDetector {
 
   /** Records the `featureFlags` argument passed to each isVoiceOverEnabled call (regression guard for #3925). */
   public readonly isVoiceOverEnabledFeatureFlagsArgs: Array<FeatureFlagService | undefined> = [];
+  /** Records the request budget passed to each detection attempt. */
+  public readonly isVoiceOverEnabledTimeoutMsArgs: Array<number | undefined> = [];
 
   /**
    * Configure VoiceOver enabled state for all devices
@@ -50,15 +52,18 @@ export class FakeIosVoiceOverDetector implements IosVoiceOverDetector {
     this.callCount = 0;
     this.invalidatedDevices = [];
     this.isVoiceOverEnabledFeatureFlagsArgs.length = 0;
+    this.isVoiceOverEnabledTimeoutMsArgs.length = 0;
   }
 
   async isVoiceOverEnabled(
     _deviceId: string,
     _client: IOSCtrlProxy,
-    featureFlags?: FeatureFlagService
+    featureFlags?: FeatureFlagService,
+    timeoutMs?: number
   ): Promise<boolean> {
     this.callCount++;
     this.isVoiceOverEnabledFeatureFlagsArgs.push(featureFlags);
+    this.isVoiceOverEnabledTimeoutMsArgs.push(timeoutMs);
     return this.voiceOverEnabledResults.shift() ?? this.voiceOverEnabled;
   }
 

--- a/test/fakes/FakeIosVoiceOverDetector.ts
+++ b/test/fakes/FakeIosVoiceOverDetector.ts
@@ -8,6 +8,7 @@ import type { FeatureFlagService } from "../../src/features/featureFlags/Feature
  */
 export class FakeIosVoiceOverDetector implements IosVoiceOverDetector {
   private voiceOverEnabled: boolean = false;
+  private readonly voiceOverEnabledResults: boolean[] = [];
   private callCount: number = 0;
   private invalidatedDevices: string[] = [];
 
@@ -19,6 +20,11 @@ export class FakeIosVoiceOverDetector implements IosVoiceOverDetector {
    */
   setVoiceOverEnabled(enabled: boolean): void {
     this.voiceOverEnabled = enabled;
+  }
+
+  /** Configure successive detection results, falling back to the configured state when exhausted. */
+  enqueueVoiceOverEnabledResults(...results: boolean[]): void {
+    this.voiceOverEnabledResults.push(...results);
   }
 
   /**
@@ -40,6 +46,7 @@ export class FakeIosVoiceOverDetector implements IosVoiceOverDetector {
    */
   reset(): void {
     this.voiceOverEnabled = false;
+    this.voiceOverEnabledResults.length = 0;
     this.callCount = 0;
     this.invalidatedDevices = [];
     this.isVoiceOverEnabledFeatureFlagsArgs.length = 0;
@@ -52,7 +59,7 @@ export class FakeIosVoiceOverDetector implements IosVoiceOverDetector {
   ): Promise<boolean> {
     this.callCount++;
     this.isVoiceOverEnabledFeatureFlagsArgs.push(featureFlags);
-    return this.voiceOverEnabled;
+    return this.voiceOverEnabledResults.shift() ?? this.voiceOverEnabled;
   }
 
   invalidateCache(deviceId: string): void {

--- a/test/features/accessibility/VoiceOverToggle.test.ts
+++ b/test/features/accessibility/VoiceOverToggle.test.ts
@@ -91,6 +91,7 @@ describe("VoiceOverToggle", () => {
         SIMULATOR_DEVICE.deviceId,
         SIMULATOR_DEVICE.deviceId
       ]);
+      expect(fakeDetector.isVoiceOverEnabledTimeoutMsArgs).toEqual([10_000, 9_500]);
       expect(fakeTimer.getSleepHistory()).toEqual([500]);
     });
 
@@ -104,7 +105,8 @@ describe("VoiceOverToggle", () => {
 
       expect(result).toMatchObject({ supported: true, applied: false, currentState: false });
       expect(fakeTimer.getCurrentTime()).toBe(10_000);
-      expect(fakeDetector.getCallCount()).toBe(21);
+      expect(fakeDetector.getCallCount()).toBe(20);
+      expect(fakeDetector.isVoiceOverEnabledTimeoutMsArgs.at(-1)).toBe(500);
     });
 
     test("runs correct xcrun simctl spawn commands when enabling", async () => {

--- a/test/features/accessibility/VoiceOverToggle.test.ts
+++ b/test/features/accessibility/VoiceOverToggle.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { VoiceOverToggle } from "../../../src/features/accessibility/VoiceOverToggle";
 import { FakeIosVoiceOverDetector } from "../../fakes/FakeIosVoiceOverDetector";
 import { FakeProcessExecutor } from "../../fakes/FakeProcessExecutor";
+import { FakeTimer } from "../../fakes/FakeTimer";
 import type { BootedDevice } from "../../../src/models";
 
 const SIMULATOR_DEVICE: BootedDevice = {
@@ -65,8 +66,10 @@ describe("VoiceOverToggle", () => {
       // simctl write ran but the confirmation re-detect still reports off — the
       // toggle must not claim success optimistically (#3921).
       fakeDetector.setVoiceOverEnabled(false);
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
 
-      const toggle = new VoiceOverToggle(SIMULATOR_DEVICE, fakeDetector, fakeExec);
+      const toggle = new VoiceOverToggle(SIMULATOR_DEVICE, fakeDetector, fakeExec, fakeTimer);
       const result = await toggle.toggle(true);
 
       expect(result.supported).toBe(true);
@@ -74,8 +77,39 @@ describe("VoiceOverToggle", () => {
       expect(result.currentState).toBe(false);
     });
 
+    test("retries confirmation until VoiceOver becomes detectable", async () => {
+      fakeDetector.enqueueVoiceOverEnabledResults(false, true);
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+
+      const toggle = new VoiceOverToggle(SIMULATOR_DEVICE, fakeDetector, fakeExec, fakeTimer);
+      const result = await toggle.toggle(true);
+
+      expect(result).toMatchObject({ supported: true, applied: true, currentState: true });
+      expect(fakeDetector.getCallCount()).toBe(2);
+      expect(fakeDetector.getInvalidatedDevices()).toEqual([
+        SIMULATOR_DEVICE.deviceId,
+        SIMULATOR_DEVICE.deviceId
+      ]);
+      expect(fakeTimer.getSleepHistory()).toEqual([500]);
+    });
+
+    test("returns the conservative result after the bounded confirmation timeout", async () => {
+      fakeDetector.setVoiceOverEnabled(false);
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+
+      const toggle = new VoiceOverToggle(SIMULATOR_DEVICE, fakeDetector, fakeExec, fakeTimer);
+      const result = await toggle.toggle(true);
+
+      expect(result).toMatchObject({ supported: true, applied: false, currentState: false });
+      expect(fakeTimer.getCurrentTime()).toBe(10_000);
+      expect(fakeDetector.getCallCount()).toBe(21);
+    });
+
     test("runs correct xcrun simctl spawn commands when enabling", async () => {
       const udid = SIMULATOR_DEVICE.deviceId;
+      fakeDetector.setVoiceOverEnabled(true);
 
       const toggle = new VoiceOverToggle(SIMULATOR_DEVICE, fakeDetector, fakeExec);
       await toggle.toggle(true);
@@ -112,12 +146,15 @@ describe("VoiceOverToggle", () => {
 
   describe("disable VoiceOver on simulator", () => {
     test("returns supported:true applied:true", async () => {
-      const toggle = new VoiceOverToggle(SIMULATOR_DEVICE, fakeDetector, fakeExec);
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+      const toggle = new VoiceOverToggle(SIMULATOR_DEVICE, fakeDetector, fakeExec, fakeTimer);
       const result = await toggle.toggle(false);
 
       expect(result.supported).toBe(true);
       expect(result.applied).toBe(true);
       expect(result.currentState).toBe(false);
+      expect(fakeTimer.getSleepHistory()).toEqual([]);
     });
 
     test("runs correct xcrun simctl spawn commands when disabling", async () => {
@@ -176,6 +213,7 @@ describe("VoiceOverToggle", () => {
 
   describe("cache invalidation", () => {
     test("invalidates detector cache after applying", async () => {
+      fakeDetector.setVoiceOverEnabled(true);
       const toggle = new VoiceOverToggle(SIMULATOR_DEVICE, fakeDetector, fakeExec);
       await toggle.toggle(true);
 

--- a/test/utils/IosVoiceOverDetector.test.ts
+++ b/test/utils/IosVoiceOverDetector.test.ts
@@ -12,9 +12,11 @@ class FakeCtrlProxyService {
   voiceOverEnabled = false;
   shouldFail = false;
   callCount = 0;
+  readonly timeoutMsArgs: number[] = [];
 
-  async requestVoiceOverState(): Promise<CtrlProxyVoiceOverResult> {
+  async requestVoiceOverState(timeoutMs: number = 5000): Promise<CtrlProxyVoiceOverResult> {
     this.callCount++;
+    this.timeoutMsArgs.push(timeoutMs);
     if (this.shouldFail) {
       return { success: false, enabled: false, error: "Fake service error" };
     }
@@ -25,6 +27,7 @@ class FakeCtrlProxyService {
     this.voiceOverEnabled = false;
     this.shouldFail = false;
     this.callCount = 0;
+    this.timeoutMsArgs.length = 0;
   }
 }
 
@@ -90,6 +93,17 @@ describe("IosVoiceOverDetector - Unit Tests", () => {
 
       expect(enabled).toBe(false);
       expect(fakeClient.callCount).toBe(1);
+    });
+
+    test("forwards a caller-provided detection deadline to CtrlProxy", async () => {
+      await detector.isVoiceOverEnabled(
+        "device123",
+        fakeClient as unknown as IOSCtrlProxy,
+        undefined,
+        1_250
+      );
+
+      expect(fakeClient.timeoutMsArgs).toEqual([1_250]);
     });
 
     test("returns false when CtrlProxy reports failure", async () => {


### PR DESCRIPTION
## Summary

Poll iOS VoiceOver state after toggling instead of treating the first post-`kickstart` observation as final. The confirmation uses the existing injectable timer, retries for up to 10 seconds at 500 ms intervals, and retains the conservative result if VoiceOver never becomes detectable.

## Linked Issue

Closes #4045

## Bug / Regression Context

- **Prior attempts:** #3959 added post-apply confirmation; #4019 explicitly starts the VoiceOver service.
- **Observed symptom:** A successful enable could return `applied: false` because CtrlProxy observed the service before `launchctl kickstart` completed.
- **Repro steps / conditions:** Enable VoiceOver on an iOS Simulator, then inspect the immediate tool result before the service becomes detectable.

## Validation

- [x] `bun run turbo:validate` passes (lint, build, and full test suite)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] No Android/iOS runner source changed
- [x] New code uses the existing `Timer` interface plus fakes and `FakeTimer`; focused unit tests are fast
- [x] No new dependency or generic helper was added
- [x] Rebased onto latest `main`, conflicts resolved

## Device Verification

- [ ] Not run locally; the issue includes iOS Simulator reproduction evidence.

## Follow-ups

- [x] No follow-up issue needed
