### PR TITLE
refactor(android): centralize ADB execution and user targeting

### DIFF
--- a/src/features/action/ClearAppData.ts
+++ b/src/features/action/ClearAppData.ts
@@ -1,5 +1,6 @@
 import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import { AndroidUserTargetResolver } from "../../utils/android-cmdline-tools/AndroidUserTargetResolver";
 import { BootedDevice, ClearAppDataResult } from "../../models";
 import { logger } from "../../utils/logger";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
@@ -22,27 +23,10 @@ export class ClearAppData {
 
     // Auto-detect target user if not specified
     const targetUserId = await perf.track("detectTargetUser", async () => {
-      if (userId !== undefined) {
-        return userId;
-      }
-
-      // Check if app is in foreground and get its user
-      const foregroundApp = await this.adb.getForegroundApp();
-      if (foregroundApp && foregroundApp.packageName === packageName) {
-        return foregroundApp.userId;
-      }
-
-      // Get list of users and prefer work profile
-      const users = await this.adb.listUsers();
-
-      // Find first work profile (userId > 0 and running)
-      const workProfile = users.find(u => u.userId > 0 && u.running);
-      if (workProfile) {
-        return workProfile.userId;
-      }
-
-      // Fall back to primary user
-      return 0;
+      return (await new AndroidUserTargetResolver(this.adb).resolve({
+        packageName,
+        explicitUserId: userId,
+      })).userId;
     });
 
     try {

--- a/src/features/action/GrantAndroidPermissions.ts
+++ b/src/features/action/GrantAndroidPermissions.ts
@@ -1,5 +1,6 @@
 import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import { AndroidUserTargetResolver } from "../../utils/android-cmdline-tools/AndroidUserTargetResolver";
 import { BootedDevice, GrantAndroidPermissionItemResult, GrantAndroidPermissionsResult } from "../../models";
 import { logger } from "../../utils/logger";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
@@ -51,22 +52,7 @@ export class GrantAndroidPermissions {
     }
 
     const targetUserId = await perf.track("detectTargetUser", async () => {
-      if (input.userId !== undefined) {
-        return input.userId;
-      }
-
-      const foregroundApp = await this.adb.getForegroundApp();
-      if (foregroundApp && foregroundApp.packageName === packageName) {
-        return foregroundApp.userId;
-      }
-
-      const users = await this.adb.listUsers();
-      const workProfile = users.find(u => u.userId > 0 && u.running);
-      if (workProfile) {
-        return workProfile.userId;
-      }
-
-      return 0;
+      return (await new AndroidUserTargetResolver(this.adb).resolve({ packageName, explicitUserId: input.userId })).userId;
     });
 
     const results: GrantAndroidPermissionItemResult[] = [];

--- a/src/features/action/LaunchApp.ts
+++ b/src/features/action/LaunchApp.ts
@@ -601,12 +601,12 @@ export class LaunchApp extends BaseVisualChange {
     if (isRunning) {
       if (clearAppData) {
         await perf.track("clearAppData", async () => {
-          return new ClearAppData(this.device).execute(packageName);
+          return new ClearAppData(this.device).execute(packageName, targetUserId);
         });
         didTerminateOrClear = true;
       } else if (coldBoot) {
         await perf.track("terminateApp", async () => {
-          return new TerminateApp(this.device).execute(packageName, { skipObservation: true });
+          return new TerminateApp(this.device).execute(packageName, { skipObservation: true, userId: targetUserId });
         });
         didTerminateOrClear = true;
       }
@@ -629,7 +629,7 @@ export class LaunchApp extends BaseVisualChange {
     } else {
       if (clearAppData) {
         await perf.track("clearAppData", async () => {
-          return new ClearAppData(this.device).execute(packageName);
+          return new ClearAppData(this.device).execute(packageName, targetUserId);
         });
         didTerminateOrClear = true;
       }

--- a/src/features/action/LaunchApp.ts
+++ b/src/features/action/LaunchApp.ts
@@ -1,4 +1,5 @@
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
+import { AndroidUserTargetResolver } from "../../utils/android-cmdline-tools/AndroidUserTargetResolver";
 import { BaseVisualChange } from "./BaseVisualChange";
 import { BootedDevice, ClearAppDataResult, LaunchAppResult, ObserveResult } from "../../models";
 import { ActionableError } from "../../models";
@@ -514,30 +515,12 @@ export class LaunchApp extends BaseVisualChange {
     packageName: string,
     userId?: number
   ): Promise<number> {
-    if (userId !== undefined) {
-      return userId;
-    }
-
-    // Check if app is in foreground and get its user
-    const foregroundApp = await this.adb.getForegroundApp();
-    if (foregroundApp && foregroundApp.packageName === packageName) {
-      logger.info(`[LaunchApp] App is in foreground in user ${foregroundApp.userId}`);
-      return foregroundApp.userId;
-    }
-
-    // Get list of users and prefer work profile
-    const users = await this.adb.listUsers();
-
-    // Find first work profile (userId > 0 and running)
-    const workProfile = users.find(u => u.userId > 0 && u.running);
-    if (workProfile) {
-      logger.info(`[LaunchApp] Using work profile: user ${workProfile.userId}`);
-      return workProfile.userId;
-    }
-
-    // Fall back to primary user
-    logger.info(`[LaunchApp] Using primary user: user 0`);
-    return 0;
+    const target = await new AndroidUserTargetResolver(this.adb).resolve({
+      packageName,
+      explicitUserId: userId,
+    });
+    logger.info(`[LaunchApp] Using ${target.source}: user ${target.userId}`);
+    return target.userId;
   }
 
   private async listInstalledApps(): Promise<string[]> {

--- a/src/features/action/TerminateApp.ts
+++ b/src/features/action/TerminateApp.ts
@@ -1,4 +1,5 @@
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
+import { AndroidUserTargetResolver } from "../../utils/android-cmdline-tools/AndroidUserTargetResolver";
 import { BaseVisualChange, ProgressCallback } from "./BaseVisualChange";
 import { BootedDevice, TerminateAppResult } from "../../models";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
@@ -69,27 +70,7 @@ export class TerminateApp extends BaseVisualChange {
     const terminateLogic = async (): Promise<TerminateAppResult> => {
       // Auto-detect target user if not specified
       const targetUserId = await perf.track("detectTargetUser", async () => {
-        if (options?.userId !== undefined) {
-          return options.userId;
-        }
-
-        // Check if app is in foreground and get its user
-        const foregroundApp = await this.adb.getForegroundApp();
-        if (foregroundApp && foregroundApp.packageName === packageName) {
-          return foregroundApp.userId;
-        }
-
-        // Get list of users and prefer work profile
-        const users = await this.adb.listUsers();
-
-        // Find first work profile (userId > 0 and running)
-        const workProfile = users.find(u => u.userId > 0 && u.running);
-        if (workProfile) {
-          return workProfile.userId;
-        }
-
-        // Fall back to primary user
-        return 0;
+        return (await new AndroidUserTargetResolver(this.adb).resolve({ packageName, explicitUserId: options?.userId })).userId;
       });
 
       // Check if app is installed

--- a/src/features/action/UninstallApp.ts
+++ b/src/features/action/UninstallApp.ts
@@ -151,12 +151,7 @@ export class UninstallApp {
       // Auto-detect target user if not specified
       const targetUserId = (await new AndroidUserTargetResolver(this.adb).resolve({ packageName, explicitUserId: userId })).userId;
 
-      // Check if app is installed. Keep the cache disabled so the pre-uninstall
-      // check always reflects live device state (the previous executor-arg path
-      // left caching off; passing the default factory would silently enable it).
-      const listApps = new ListInstalledApps(this.device, this.adbFactory, null, { cacheEnabled: false });
-
-      const installed = (await listApps.execute()).find(app => app === packageName) !== undefined;
+      const installed = await this.isInstalledForUser(packageName, targetUserId);
 
       if (!installed) {
         return {
@@ -178,7 +173,7 @@ export class UninstallApp {
       await this.adb.executeCommand(cmd);
 
       // Verify the app was uninstalled
-      const isStillInstalled = (await listApps.execute()).find(app => app === packageName) !== undefined;
+      const isStillInstalled = await this.isInstalledForUser(packageName, targetUserId);
 
       if (isStillInstalled) {
         return {
@@ -207,5 +202,15 @@ export class UninstallApp {
         error: "Error occurred during application uninstallation"
       };
     }
+  }
+
+  private async isInstalledForUser(packageName: string, userId: number): Promise<boolean> {
+    const result = await this.adb.executeCommand(
+      `shell pm list packages --user ${userId}`,
+      undefined,
+      undefined,
+      true
+    );
+    return result.stdout.split("\n").some(line => line.trim() === `package:${packageName}`);
   }
 }

--- a/src/features/action/UninstallApp.ts
+++ b/src/features/action/UninstallApp.ts
@@ -1,5 +1,6 @@
 import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import { AndroidUserTargetResolver } from "../../utils/android-cmdline-tools/AndroidUserTargetResolver";
 import { UninstallAppResult } from "../../models/UninstallAppResult";
 import { BootedDevice } from "../../models";
 import { ListInstalledApps } from "../observe/ListInstalledApps";
@@ -148,26 +149,7 @@ export class UninstallApp {
   private async executeAndroid(packageName: string, keepData: boolean, userId?: number): Promise<UninstallAppResult> {
     try {
       // Auto-detect target user if not specified
-      let targetUserId = userId;
-      if (targetUserId === undefined) {
-        // Check if app is in foreground and get its user
-        const foregroundApp = await this.adb.getForegroundApp();
-        if (foregroundApp && foregroundApp.packageName === packageName) {
-          targetUserId = foregroundApp.userId;
-        } else {
-          // Get list of users and prefer work profile
-          const users = await this.adb.listUsers();
-
-          // Find first work profile (userId > 0 and running)
-          const workProfile = users.find(u => u.userId > 0 && u.running);
-          if (workProfile) {
-            targetUserId = workProfile.userId;
-          } else {
-            // Fall back to primary user
-            targetUserId = 0;
-          }
-        }
-      }
+      const targetUserId = (await new AndroidUserTargetResolver(this.adb).resolve({ packageName, explicitUserId: userId })).userId;
 
       // Check if app is installed. Keep the cache disabled so the pre-uninstall
       // check always reflects live device state (the previous executor-arg path

--- a/src/features/record/android/DualTrackRecorder.ts
+++ b/src/features/record/android/DualTrackRecorder.ts
@@ -265,7 +265,7 @@ export class DualTrackRecorder {
     const scaler = buildScaler(ranges);
 
     return new GetEventReader({
-      deviceId: this.device.deviceId,
+      adb,
       touchNode: node,
       scaler,
       density,

--- a/src/features/record/android/GetEventReader.ts
+++ b/src/features/record/android/GetEventReader.ts
@@ -1,6 +1,5 @@
-import { spawn } from "node:child_process";
-import type { ChildProcess } from "node:child_process";
 import { logger } from "../../../utils/logger";
+import type { AdbExecutor, AdbProcess } from "../../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import type { GestureEmitter, GestureEvent } from "./types";
 import type { TouchInputNode } from "./TouchNodeDiscovery";
 import type { CoordScaler } from "./AxisRanges";
@@ -8,57 +7,71 @@ import { TouchFrameReconstructor } from "./TouchFrameReconstructor";
 import { GestureClassifier } from "./GestureClassifier";
 
 interface GetEventReaderOptions {
-  deviceId: string;
+  adb: AdbExecutor;
   touchNode: TouchInputNode;
   scaler: CoordScaler;
   /** Display density in dp multiplier (e.g. 2.75 for 440dpi) */
   density: number;
-  /** Override for testing — defaults to `spawn` from node:child_process */
-  spawnFn?: typeof spawn;
-  /** Override ADB binary path for testing — defaults to "adb" */
-  adbPath?: string;
 }
 
 /**
- * Spawns `adb -s <deviceId> shell getevent -lt <touchNode.path>` and pipes
+ * Spawns `adb shell getevent -lt <touchNode.path>` through AdbClient and pipes
  * the output through TouchFrameReconstructor → GestureClassifier.
  *
  * Implements GestureEmitter so it can be replaced with a fake in tests.
  */
 export class GetEventReader implements GestureEmitter {
-  private child: ChildProcess | null = null;
-  private readonly spawnFn: typeof spawn;
-  private readonly adbPath: string;
+  private child: AdbProcess | null = null;
+  private starting = false;
 
-  constructor(private readonly opts: GetEventReaderOptions) {
-    this.spawnFn = opts.spawnFn ?? spawn;
-    this.adbPath = opts.adbPath ?? "adb";
-  }
+  constructor(private readonly opts: GetEventReaderOptions) {}
 
   start(
     onGesture: (event: GestureEvent) => void,
     onError?: (err: Error) => void
   ): void {
-    if (this.child) {return;} // already running
+    if (this.child || this.starting) {return;} // already running
+    this.starting = true;
+    void this.startProcess(onGesture, onError);
+  }
+
+  private async startProcess(
+    onGesture: (event: GestureEvent) => void,
+    onError?: (err: Error) => void
+  ): Promise<void> {
 
     const reconstructor = new TouchFrameReconstructor();
     const classifier = new GestureClassifier(this.opts.scaler, this.opts.density);
 
     const args = [
-      "-s",
-      this.opts.deviceId,
       "shell",
       "getevent",
       "-lt",
       this.opts.touchNode.path,
     ];
 
-    logger.debug(`[GetEventReader] Spawning: ${this.adbPath} ${args.join(" ")}`);
-    this.child = this.spawnFn(this.adbPath, args);
+    logger.debug(`[GetEventReader] Spawning: ${args.join(" ")}`);
+    try {
+      const child = await this.opts.adb.spawn(args);
+      if (!this.starting) {
+        child.kill();
+        return;
+      }
+      this.child = child;
+    } catch (error) {
+      this.starting = false;
+      const normalized = error instanceof Error ? error : new Error(String(error));
+      logger.error(`[GetEventReader] spawn error: ${normalized.message}`);
+      onError?.(normalized);
+      return;
+    }
+    this.starting = false;
+    const child = this.child;
+    if (!child) {return;}
 
     let lineBuffer = "";
 
-    this.child.stdout?.on("data", (data: Buffer) => {
+    child.stdout.on("data", (data: Buffer) => {
       lineBuffer += data.toString();
       const lines = lineBuffer.split("\n");
       // Keep the incomplete last fragment in the buffer
@@ -80,16 +93,16 @@ export class GetEventReader implements GestureEmitter {
       }
     });
 
-    this.child.stderr?.on("data", (data: Buffer) => {
+    child.stderr.on("data", (data: Buffer) => {
       logger.debug(`[GetEventReader] stderr: ${data.toString().trim()}`);
     });
 
-    this.child.on("error", (err: Error) => {
+    child.on("error", (err: Error) => {
       logger.error(`[GetEventReader] spawn error: ${err.message}`);
       onError?.(err);
     });
 
-    this.child.on("close", (code: number | null) => {
+    child.on("exit", (code: number | null) => {
       if (code !== null && code !== 0) {
         logger.warn(`[GetEventReader] getevent exited with code ${code}`);
       }
@@ -98,6 +111,7 @@ export class GetEventReader implements GestureEmitter {
   }
 
   stop(): void {
+    this.starting = false;
     if (this.child && !this.child.killed) {
       logger.debug("[GetEventReader] Stopping getevent process");
       this.child.kill();

--- a/src/features/video/FfmpegVideoProcessingBackend.ts
+++ b/src/features/video/FfmpegVideoProcessingBackend.ts
@@ -356,20 +356,16 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
     config: VideoCaptureConfig
   ): Promise<RecordingHandle> {
     const adb = this.adbFactory.create(device);
-    const { adbPath, baseArgs } = await adb.getBaseCommandParts();
 
     const screenrecordArgs = [
-      ...baseArgs,
       "exec-out",
       "screenrecord",
       "-",
     ];
 
-    logger.info(`[FfmpegVideo] Starting screenrecord: ${adbPath} ${screenrecordArgs.join(" ")}`);
+    logger.info(`[FfmpegVideo] Starting screenrecord: ${screenrecordArgs.join(" ")}`);
 
-    const captureProcess = spawn(adbPath, screenrecordArgs, {
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const captureProcess = await adb.spawn(screenrecordArgs);
 
     captureProcess.stderr.on("data", chunk => {
       const text = chunk.toString();

--- a/src/features/video/FfmpegVideoProcessingBackend.ts
+++ b/src/features/video/FfmpegVideoProcessingBackend.ts
@@ -381,7 +381,6 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
     });
 
     try {
-      await waitForSpawn(captureProcess);
       logger.info(`[FfmpegVideo] screenrecord process spawned`);
     } catch (error) {
       logger.error(`[FfmpegVideo] Failed to spawn screenrecord: ${error}`);

--- a/src/features/video/PlatformVideoCaptureBackend.ts
+++ b/src/features/video/PlatformVideoCaptureBackend.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { spawn } from "node:child_process";
 import path from "node:path";
 import { promises as fsPromises } from "node:fs";
 import { pathExists } from "../../utils/filesystem/DefaultFileSystem";
@@ -28,7 +28,7 @@ import { ANDROID_SCREENRECORD_MAX_SECONDS } from "./androidScreenrecord";
 
 interface AndroidBackendHandle {
   kind: "android";
-  process: ChildProcessWithoutNullStreams;
+  process: TrackedChildProcess;
   exitState: ProcessExitState;
   exitPromise: Promise<void>;
   stderr: string[];
@@ -152,10 +152,8 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
       // Pull the file from the device
       logger.info(`[VideoCapture] Pulling file from device: ${backendHandle.deviceTempPath} -> ${handle.outputPath}`);
       const adb = this.adbFactory.create(backendHandle.device);
-      const { adbPath, baseArgs } = await adb.getBaseCommandParts();
-
-      const pullArgs = [...baseArgs, "pull", backendHandle.deviceTempPath, handle.outputPath];
-      const pullProcess = spawn(adbPath, pullArgs, { stdio: ["ignore", "pipe", "pipe"] });
+      const pullArgs = ["pull", backendHandle.deviceTempPath, handle.outputPath];
+      const pullProcess = await adb.spawn(pullArgs);
 
       await new Promise<void>((resolve, reject) => {
         pullProcess.once("exit", code => {
@@ -171,8 +169,8 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
 
       // Clean up temp file on device
       logger.info(`[VideoCapture] Cleaning up temp file on device`);
-      const rmArgs = [...baseArgs, "shell", "rm", backendHandle.deviceTempPath];
-      const rmProcess = spawn(adbPath, rmArgs, { stdio: ["ignore", "pipe", "pipe"] });
+      const rmArgs = ["shell", "rm", backendHandle.deviceTempPath];
+      const rmProcess = await adb.spawn(rmArgs);
 
       await new Promise<void>(resolve => {
         rmProcess.once("exit", () => {
@@ -218,7 +216,6 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
     config: VideoCaptureConfig
   ): Promise<RecordingHandle> {
     const adb = this.adbFactory.create(device);
-    const { adbPath, baseArgs } = await adb.getBaseCommandParts();
     const bitrateKbps = clampBitrateKbps(config);
     const bitrateBps = Math.max(1, Math.round(bitrateKbps * 1000));
     const timeLimitSeconds = this.resolveAndroidTimeLimit(config.maxDurationSeconds);
@@ -234,7 +231,6 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
     const deviceTempPath = `/sdcard/auto-mobile-${config.recordingId}.mp4`;
 
     const args = [
-      ...baseArgs,
       "shell",
       "screenrecord",
       "--bit-rate",
@@ -249,12 +245,12 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
 
     args.push(deviceTempPath);
 
-    logger.info(`[VideoCapture] Starting Android recording: ${adbPath} ${args.join(" ")}`);
+    logger.info(`[VideoCapture] Starting Android recording: ${args.join(" ")}`);
     logger.info(`[VideoCapture] Device temp path: ${deviceTempPath}`);
     logger.info(`[VideoCapture] Output path: ${config.outputPath}`);
     logger.info(`[VideoCapture] Bitrate: ${bitrateKbps}kbps (${bitrateBps}bps), Time limit: ${timeLimitSeconds}s`);
 
-    const process = spawn(adbPath, args, { stdio: ["ignore", "pipe", "pipe"] });
+    const process = await adb.spawn(args);
 
     try {
       await waitForSpawn(process);

--- a/src/features/video/PlatformVideoCaptureBackend.ts
+++ b/src/features/video/PlatformVideoCaptureBackend.ts
@@ -252,12 +252,6 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
 
     const process = await adb.spawn(args);
 
-    try {
-      await waitForSpawn(process);
-    } catch (error) {
-      throw new ActionableError(`Failed to start Android recording: ${error}`);
-    }
-
     const stderr: string[] = [];
     const { exitState, exitPromise } = createExitTracker(process, stderr);
 

--- a/src/features/webrtc/AndroidH264Source.ts
+++ b/src/features/webrtc/AndroidH264Source.ts
@@ -125,6 +125,13 @@ export class AndroidH264Source implements H264CaptureSource {
     );
 
     const process = await adb.spawn(args);
+    // stop() may run while the async ADB boundary resolves the child. Do not
+    // retain a late stream after its owner has stopped; terminate only this
+    // host-side exec-out process, never device-wide screenrecord.
+    if (!this.running) {
+      process.kill("SIGINT");
+      return;
+    }
     this.current = process;
     this.segmentCount++;
 

--- a/src/features/webrtc/AndroidH264Source.ts
+++ b/src/features/webrtc/AndroidH264Source.ts
@@ -5,9 +5,9 @@ import {
   defaultAdbClientFactory,
   type AdbClientFactory,
 } from "../../utils/android-cmdline-tools/AdbClientFactory";
+import type { AdbProcess } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { ANDROID_SCREENRECORD_MAX_SECONDS } from "../video/androidScreenrecord";
 import type { H264CaptureSource, H264CaptureSourceOptions } from "./H264CaptureSource";
-import { defaultProcessSpawner, type ProcessSpawner, type SpawnedProcess } from "./processSpawner";
 
 export type { ProcessSpawner, SpawnedProcess } from "./processSpawner";
 
@@ -21,7 +21,6 @@ export const ANDROID_STREAM_SEGMENT_ROTATE_MS = (ANDROID_SCREENRECORD_MAX_SECOND
 export interface AndroidH264SourceOptions extends H264CaptureSourceOptions {
   adbFactory?: AdbClientFactory;
   timer?: Timer;
-  spawner?: ProcessSpawner;
   /** Override the per-segment time limit (seconds); capped at the screenrecord max. */
   segmentTimeLimitSeconds?: number;
   /** Override when to proactively rotate to the next segment (ms). */
@@ -34,17 +33,16 @@ export interface AndroidH264SourceOptions extends H264CaptureSourceOptions {
  * `screenrecord` caps each run at 180s, segments are rotated automatically: a
  * new segment is started shortly before the current one hits the cap so the
  * downstream RTP writer keeps receiving frames. The source is device-facing but
- * fully injectable (adb factory, spawner, timer) for tests.
+ * fully injectable (ADB factory and timer) for tests.
  */
 export class AndroidH264Source implements H264CaptureSource {
   private readonly options: AndroidH264SourceOptions;
   private readonly adbFactory: AdbClientFactory;
   private readonly timer: Timer;
-  private readonly spawner: ProcessSpawner;
   private readonly segmentTimeLimitSeconds: number;
   private readonly segmentRotateMs: number;
 
-  private current: SpawnedProcess | null = null;
+  private current: AdbProcess | null = null;
   private rotateHandle: NodeJS.Timeout | null = null;
   private running = false;
   private segmentCount = 0;
@@ -53,7 +51,6 @@ export class AndroidH264Source implements H264CaptureSource {
     this.options = options;
     this.adbFactory = options.adbFactory ?? defaultAdbClientFactory;
     this.timer = options.timer ?? defaultTimer;
-    this.spawner = options.spawner ?? defaultProcessSpawner;
     this.segmentTimeLimitSeconds = Math.min(
       options.segmentTimeLimitSeconds ?? ANDROID_SCREENRECORD_MAX_SECONDS,
       ANDROID_SCREENRECORD_MAX_SECONDS
@@ -102,17 +99,13 @@ export class AndroidH264Source implements H264CaptureSource {
 
   private async startSegment(): Promise<void> {
     const adb = this.adbFactory.create(this.options.device);
-    const adbPath = await adb.getAdbPathOnly();
     // stop() may have run while we awaited adb setup; it returns early when
     // `current` is still null, so spawning now would leak a screenrecord process
     // that no later stop() would kill.
     if (!this.running) {
       return;
     }
-    const baseArgs = this.options.device.deviceId ? ["-s", this.options.device.deviceId] : [];
-
     const args = [
-      ...baseArgs,
       "exec-out",
       "screenrecord",
       "--output-format=h264",
@@ -128,10 +121,10 @@ export class AndroidH264Source implements H264CaptureSource {
     args.push("-");
 
     logger.info(
-      `[AndroidH264Source] starting screenrecord segment ${this.segmentCount + 1}: ${adbPath} ${args.join(" ")}`
+      `[AndroidH264Source] starting screenrecord segment ${this.segmentCount + 1}: ${args.join(" ")}`
     );
 
-    const process = this.spawner(adbPath, args);
+    const process = await adb.spawn(args);
     this.current = process;
     this.segmentCount++;
 
@@ -165,7 +158,7 @@ export class AndroidH264Source implements H264CaptureSource {
   }
 
   private handleSegmentExit(
-    process: SpawnedProcess,
+    process: AdbProcess,
     code: number | null,
     signal: NodeJS.Signals | null
   ): void {

--- a/src/features/webrtc/PersistentEncoderH264Source.ts
+++ b/src/features/webrtc/PersistentEncoderH264Source.ts
@@ -228,9 +228,7 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
   }
 
   private buildServerArgs(): string[] {
-    const baseArgs = this.options.device.deviceId ? ["-s", this.options.device.deviceId] : [];
     const args = [
-      ...baseArgs,
       "shell",
       `CLASSPATH=${VIDEO_SERVER_REMOTE_JAR_PATH}`,
       "app_process",

--- a/src/features/webrtc/PersistentEncoderH264Source.ts
+++ b/src/features/webrtc/PersistentEncoderH264Source.ts
@@ -6,8 +6,8 @@ import {
   defaultAdbClientFactory,
   type AdbClientFactory,
 } from "../../utils/android-cmdline-tools/AdbClientFactory";
+import type { AdbProcess } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import type { H264CaptureSource } from "./H264CaptureSource";
-import { defaultProcessSpawner, type ProcessSpawner, type SpawnedProcess } from "./processSpawner";
 import {
   VIDEO_SERVER_CODEC_ID_H264,
   VIDEO_SERVER_CODEC_ID_PCM16,
@@ -59,7 +59,6 @@ export interface PersistentEncoderH264SourceOptions {
   /** Local path to the built `automobile-video.jar`. Required to run. */
   jarPath: string;
   adbFactory?: AdbClientFactory;
-  spawner?: ProcessSpawner;
   connector?: SocketConnector;
   timer?: Timer;
   /** How long to wait for the server to signal readiness (ms). */
@@ -78,17 +77,16 @@ const DEFAULT_READY_TIMEOUT_MS = 10_000;
  * Lifecycle: push the jar, launch the server, wait for its readiness line,
  * `adb forward` an ephemeral local port to the server's abstract LocalSocket,
  * connect, and parse the binary framing into Annex-B payloads. Fully injectable
- * (adb factory, spawner, socket connector, timer) for device-free unit tests.
+ * (ADB factory, socket connector, timer) for device-free unit tests.
  */
 export class PersistentEncoderH264Source implements H264CaptureSource {
   private readonly options: PersistentEncoderH264SourceOptions;
   private readonly adbFactory: AdbClientFactory;
-  private readonly spawner: ProcessSpawner;
   private readonly connector: SocketConnector;
   private readonly timer: Timer;
   private readonly readyTimeoutMs: number;
 
-  private server: SpawnedProcess | null = null;
+  private server: AdbProcess | null = null;
   private socket: StreamSocket | null = null;
   private forwardedPort: number | null = null;
   private running = false;
@@ -98,7 +96,6 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
   constructor(options: PersistentEncoderH264SourceOptions) {
     this.options = options;
     this.adbFactory = options.adbFactory ?? defaultAdbClientFactory;
-    this.spawner = options.spawner ?? defaultProcessSpawner;
     this.connector = options.connector ?? defaultConnector;
     this.timer = options.timer ?? defaultTimer;
     this.readyTimeoutMs = options.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS;
@@ -134,7 +131,6 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
 
   private async launch(): Promise<void> {
     const adb = this.adbFactory.create(this.options.device);
-    const adbPath = await adb.getAdbPathOnly();
     if (!this.running) {
       return;
     }
@@ -143,7 +139,7 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     await adb.executeCommand(`push "${this.options.jarPath}" ${VIDEO_SERVER_REMOTE_JAR_PATH}`);
 
     // Launch the persistent server as a long-lived process.
-    const server = this.spawner(adbPath, this.buildServerArgs());
+    const server = await adb.spawn(this.buildServerArgs());
     this.server = server;
     server.stderr.on("data", (chunk: Buffer) => {
       const text = chunk.toString().trim();
@@ -255,7 +251,7 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     return args;
   }
 
-  private waitForReady(server: SpawnedProcess): Promise<void> {
+  private waitForReady(server: AdbProcess): Promise<void> {
     return this.waitForServerLine(
       server,
       READY_MARKER,
@@ -264,7 +260,7 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     );
   }
 
-  private waitForStreamingStarted(server: SpawnedProcess): Promise<void> {
+  private waitForStreamingStarted(server: AdbProcess): Promise<void> {
     return this.waitForServerLine(
       server,
       STREAMING_STARTED_MARKER,
@@ -325,7 +321,7 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
   }
 
   private waitForServerLine(
-    server: SpawnedProcess,
+    server: AdbProcess,
     marker: string,
     timeoutMessage: string,
     exitMessagePrefix: string

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -331,6 +331,9 @@ export class AdbClient implements AdbExecutor {
     }
 
     const { adbPath, baseArgs } = await this.getBaseCommandParts();
+    if (signal?.aborted) {
+      throw this.getAbortError(signal);
+    }
     const fullArgs = [...baseArgs, ...args];
     const child = this.spawnFn(adbPath, fullArgs, { stdio: ["ignore", "pipe", "pipe"] });
     this.activeProcesses.add(child);

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -340,6 +340,7 @@ export class AdbClient implements AdbExecutor {
 
     let timeoutId: NodeJS.Timeout | undefined;
     let cleaned = false;
+    let settleStart: ((error?: Error) => void) | undefined;
     const cleanup = () => {
       if (cleaned) {
         return;
@@ -361,6 +362,7 @@ export class AdbClient implements AdbExecutor {
     const onAbort = () => {
       if (!cleaned) {
         child.kill("SIGTERM");
+        settleStart?.(this.getAbortError(signal));
         cleanup();
       }
     };
@@ -371,6 +373,25 @@ export class AdbClient implements AdbExecutor {
     if (options.timeoutMs) {
       timeoutId = this.timer.setTimeout(onAbort, options.timeoutMs);
     }
+
+    await new Promise<void>((resolve, reject) => {
+      const onSpawn = () => {
+        child.off("error", onInitialError);
+        settleStart = undefined;
+        resolve();
+      };
+      const onInitialError = (error: Error) => {
+        child.off("spawn", onSpawn);
+        settleStart = undefined;
+        reject(error);
+      };
+      settleStart = error => error ? reject(error) : resolve();
+      child.once("spawn", onSpawn);
+      child.once("error", onInitialError);
+      if (signal?.aborted) {
+        onAbort();
+      }
+    });
 
     // eslint-disable-next-line auto-mobile/no-unknown-cast -- the public interface deliberately exposes only lifecycle, stdio, and kill.
     return child as unknown as AdbProcess;

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -3,7 +3,12 @@ import { promisify } from "util";
 import { logger } from "../logger";
 import { BootedDevice, ExecResult, AndroidUser } from "../../models";
 import { detectAndroidCommandLineTools, getBestAndroidToolsLocation } from "./detection";
-import { AdbExecutor } from "./interfaces/AdbExecutor";
+import {
+  AdbExecutor,
+  type AdbExecuteOptions,
+  type AdbProcess,
+  type AdbSpawnOptions,
+} from "./interfaces/AdbExecutor";
 import { getAbortSignal } from "../AbortContext";
 import { OPERATION_CANCELLED_MESSAGE } from "../constants";
 import { RetryExecutor, defaultRetryExecutor } from "../retry/RetryExecutor";
@@ -300,9 +305,15 @@ export class AdbClient implements AdbExecutor {
     noRetry?: boolean,
     signal?: AbortSignal
   ): Promise<ExecResult> {
+    return this.execute(this.parseCommandArgs(command), { timeoutMs, maxBuffer, noRetry, signal });
+  }
+
+  async execute(args: string[], options: AdbExecuteOptions = {}): Promise<ExecResult> {
+    const { timeoutMs, maxBuffer, noRetry, signal } = options;
     const startTime = this.timer.now();
-    const result = await this.executeCommandImpl(command, timeoutMs, maxBuffer, 0, noRetry, signal);
+    const result = await this.executeArgsImpl(args, timeoutMs, maxBuffer, noRetry, signal);
     const duration = this.timer.now() - startTime;
+    const command = args.join(" ");
 
     // Only log longer commands or ones that take significant time
     if (duration > 10 || command.includes("screencap") || command.includes("uiautomator") || command.includes("getevent")) {
@@ -311,6 +322,55 @@ export class AdbClient implements AdbExecutor {
     }
 
     return result;
+  }
+
+  async spawn(args: string[], options: AdbSpawnOptions = {}): Promise<AdbProcess> {
+    const signal = options.signal ?? getAbortSignal();
+    if (signal?.aborted) {
+      throw this.getAbortError(signal);
+    }
+
+    const { adbPath, baseArgs } = await this.getBaseCommandParts();
+    const fullArgs = [...baseArgs, ...args];
+    const child = this.spawnFn(adbPath, fullArgs, { stdio: ["ignore", "pipe", "pipe"] });
+    this.activeProcesses.add(child);
+
+    let timeoutId: NodeJS.Timeout | undefined;
+    let cleaned = false;
+    const cleanup = () => {
+      if (cleaned) {
+        return;
+      }
+      cleaned = true;
+      this.activeProcesses.delete(child);
+      child.off("exit", onExit);
+      child.off("error", onError);
+      signal?.removeEventListener("abort", onAbort);
+      if (timeoutId) {
+        this.timer.clearTimeout(timeoutId);
+      }
+    };
+    const onExit = () => cleanup();
+    const onError = (error: Error) => {
+      this.notifyMissingDeviceIfNeeded(error);
+      cleanup();
+    };
+    const onAbort = () => {
+      if (!cleaned) {
+        child.kill("SIGTERM");
+        cleanup();
+      }
+    };
+
+    child.once("exit", onExit);
+    child.once("error", onError);
+    signal?.addEventListener("abort", onAbort, { once: true });
+    if (options.timeoutMs) {
+      timeoutId = this.timer.setTimeout(onAbort, options.timeoutMs);
+    }
+
+    // eslint-disable-next-line auto-mobile/no-unknown-cast -- the public interface deliberately exposes only lifecycle, stdio, and kill.
+    return child as unknown as AdbProcess;
   }
 
   /**
@@ -443,17 +503,16 @@ export class AdbClient implements AdbExecutor {
    * @param noRetry - Optional flag to disable retry logic for commands expected to fail
    * @returns Promise with command output
    */
-  private async executeCommandImpl(
-    command: string,
+  private async executeArgsImpl(
+    commandArgs: string[],
     timeoutMs?: number,
     maxBuffer?: number,
-    _attempt: number = 0,
     noRetry?: boolean,
     signal?: AbortSignal
   ): Promise<ExecResult> {
     const { adbPath, baseArgs } = await this.getBaseCommandParts();
-    const commandArgs = this.parseCommandArgs(command);
     const fullArgs = [...baseArgs, ...commandArgs];
+    const command = commandArgs.join(" ");
     const startTime = this.timer.now();
     const resolvedSignal = signal ?? getAbortSignal();
 

--- a/src/utils/android-cmdline-tools/AndroidUserTargetResolver.ts
+++ b/src/utils/android-cmdline-tools/AndroidUserTargetResolver.ts
@@ -1,0 +1,45 @@
+import type { AdbExecutor } from "./interfaces/AdbExecutor";
+
+export type UserTargetSource = "explicit" | "foregroundPackage" | "managedProfile" | "primaryFallback";
+
+export interface ResolvedUserTarget {
+  userId: number;
+  source: UserTargetSource;
+}
+
+export interface UserTargetRequest {
+  packageName?: string;
+  explicitUserId?: number;
+  signal?: AbortSignal;
+}
+
+/**
+ * Resolves the user for one public operation. Explicit IDs (including zero)
+ * win; otherwise a foreground instance of the requested package wins, followed
+ * by a running managed profile and finally the primary user. A secondary user
+ * is never treated as managed solely because its ID is nonzero.
+ */
+export class AndroidUserTargetResolver {
+  constructor(private readonly adb: AdbExecutor) {}
+
+  async resolve(request: UserTargetRequest = {}): Promise<ResolvedUserTarget> {
+    if (request.explicitUserId !== undefined) {
+      return { userId: request.explicitUserId, source: "explicit" };
+    }
+
+    if (request.packageName) {
+      const foreground = await this.adb.getForegroundApp(request.signal);
+      if (foreground?.packageName === request.packageName) {
+        return { userId: foreground.userId, source: "foregroundPackage" };
+      }
+    }
+
+    const users = await this.adb.listUsers(request.signal);
+    const managedProfile = users.find(user => user.running && (user.flags & 0x30) === 0x30);
+    if (managedProfile) {
+      return { userId: managedProfile.userId, source: "managedProfile" };
+    }
+
+    return { userId: 0, source: "primaryFallback" };
+  }
+}

--- a/src/utils/android-cmdline-tools/AndroidUserTargetResolver.ts
+++ b/src/utils/android-cmdline-tools/AndroidUserTargetResolver.ts
@@ -35,7 +35,7 @@ export class AndroidUserTargetResolver {
     }
 
     const users = await this.adb.listUsers(request.signal);
-    const managedProfile = users.find(user => user.running && (user.flags & 0x30) === 0x30);
+    const managedProfile = users.find(user => user.running && (user.flags & 0x20) !== 0);
     if (managedProfile) {
       return { userId: managedProfile.userId, source: "managedProfile" };
     }

--- a/src/utils/android-cmdline-tools/interfaces/AdbExecutor.ts
+++ b/src/utils/android-cmdline-tools/interfaces/AdbExecutor.ts
@@ -17,6 +17,7 @@ export interface AdbProcess {
   once(event: "error", listener: (error: Error) => void): this;
   off(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;
   off(event: "error", listener: (error: Error) => void): this;
+  off(event: "spawn", listener: () => void): this;
   removeListener(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;
   removeListener(event: "error", listener: (error: Error) => void): this;
 }

--- a/src/utils/android-cmdline-tools/interfaces/AdbExecutor.ts
+++ b/src/utils/android-cmdline-tools/interfaces/AdbExecutor.ts
@@ -1,10 +1,48 @@
 import { BootedDevice, ExecResult, AndroidUser } from "../../../models";
+import type { Readable, Writable } from "node:stream";
+
+/** The intentionally small process surface exposed by ADB streaming commands. */
+export interface AdbProcess {
+  readonly stdin: Writable | null;
+  readonly stdout: Readable;
+  readonly stderr: Readable;
+  readonly exitCode: number | null;
+  readonly signalCode: NodeJS.Signals | null;
+  readonly killed: boolean;
+  kill(signal?: NodeJS.Signals | number): boolean;
+  once(event: "spawn", listener: () => void): this;
+  on(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;
+  on(event: "error", listener: (error: Error) => void): this;
+  once(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;
+  once(event: "error", listener: (error: Error) => void): this;
+  off(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;
+  off(event: "error", listener: (error: Error) => void): this;
+  removeListener(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): this;
+  removeListener(event: "error", listener: (error: Error) => void): this;
+}
+
+export interface AdbExecuteOptions {
+  timeoutMs?: number;
+  maxBuffer?: number;
+  noRetry?: boolean;
+  signal?: AbortSignal;
+}
+
+export interface AdbSpawnOptions {
+  timeoutMs?: number;
+  signal?: AbortSignal;
+}
 
 /**
  * Interface for executing ADB commands
  * Enables dependency injection and testing with fakes
  */
 export interface AdbExecutor {
+  /** Execute argv directly. Device selection and executable lookup stay internal. */
+  execute(args: string[], options?: AdbExecuteOptions): Promise<ExecResult>;
+
+  /** Spawn a long-lived ADB command. Spawned commands deliberately never retry. */
+  spawn(args: string[], options?: AdbSpawnOptions): Promise<AdbProcess>;
   /**
    * Execute an ADB command
    * @param command - The ADB command to execute (without "adb -s <device>" prefix)
@@ -43,13 +81,13 @@ export interface AdbExecutor {
    * List all Android users on the device (personal, work profiles, etc.)
    * @returns Promise with array of Android users
    */
-  listUsers(): Promise<AndroidUser[]>;
+  listUsers(signal?: AbortSignal): Promise<AndroidUser[]>;
 
   /**
    * Get the current foreground app package name and user ID
    * @returns Promise with { packageName: string, userId: number } or null if no app in foreground
    */
-  getForegroundApp(): Promise<{ packageName: string; userId: number } | null>;
+  getForegroundApp(signal?: AbortSignal): Promise<{ packageName: string; userId: number } | null>;
 
   /**
    * Resolve and return the path to the `adb` binary without executing a command.

--- a/test/features/action/UninstallApp.test.ts
+++ b/test/features/action/UninstallApp.test.ts
@@ -242,7 +242,7 @@ describe("UninstallApp (Android)", () => {
     fakeAdb.setForegroundApp(null);
     fakeAdb.setUsers([
       { userId: 0, name: "Owner", running: true },
-      { userId: 10, name: "Work", running: true }
+      { userId: 10, name: "Work", flags: 0x30, running: true }
     ]);
     // App installed under work profile (userId 10)
     setupNoApp(fakeAdb, 0);

--- a/test/features/webrtc/AndroidH264Source.test.ts
+++ b/test/features/webrtc/AndroidH264Source.test.ts
@@ -3,7 +3,6 @@ import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
 import {
   AndroidH264Source,
-  type ProcessSpawner,
   type SpawnedProcess,
 } from "../../../src/features/webrtc/AndroidH264Source";
 import type { AdbClientFactory } from "../../../src/utils/android-cmdline-tools/AdbClientFactory";
@@ -25,7 +24,11 @@ class FakeProcess extends EventEmitter implements SpawnedProcess {
   }
 }
 
-function fakeAdbFactory(commands: string[] = []): AdbClientFactory {
+function fakeAdbFactory(
+  commands: string[] = [],
+  spawnArgs: string[][] = [],
+  processes: FakeProcess[] = []
+): AdbClientFactory {
   return {
     create() {
       return {
@@ -33,6 +36,12 @@ function fakeAdbFactory(commands: string[] = []): AdbClientFactory {
         executeCommand: async (command: string) => {
           commands.push(command);
           return { stdout: "", stderr: "", exitCode: 0 };
+        },
+        spawn: async (args: string[]) => {
+          spawnArgs.push(args);
+          const process = new FakeProcess();
+          processes.push(process);
+          return process;
         },
       } as unknown as ReturnType<AdbClientFactory["create"]>;
     },
@@ -46,19 +55,11 @@ function makeSource(overrides: Partial<Parameters<typeof AndroidH264Source.proto
   const timer = new FakeTimer();
   const spawnArgs: string[][] = [];
 
-  const spawner: ProcessSpawner = (_command, args) => {
-    spawnArgs.push(args);
-    const proc = new FakeProcess();
-    processes.push(proc);
-    return proc;
-  };
-
   const source = new AndroidH264Source({
     device: DEVICE,
     onData: chunk => chunks.push(chunk),
-    adbFactory: fakeAdbFactory(commands),
+    adbFactory: fakeAdbFactory(commands, spawnArgs, processes),
     timer,
-    spawner,
     segmentRotateMs: 1000,
     ...overrides,
   });
@@ -74,7 +75,7 @@ describe("AndroidH264Source", () => {
     expect(processes).toHaveLength(1);
     const args = spawnArgs[0].join(" ");
     expect(args).toContain("exec-out screenrecord --output-format=h264");
-    expect(args).toContain("-s emulator-5554");
+    expect(args).not.toContain("-s emulator-5554");
     expect(args.endsWith(" -")).toBe(true);
 
     processes[0].stdout.write(Buffer.from([0, 0, 0, 1, 0x67]));
@@ -178,9 +179,9 @@ describe("AndroidH264Source", () => {
     const adbFactory = {
       create() {
         return {
-          getAdbPathOnly: () =>
-            new Promise<string>(resolve => {
-              resolveAdb = () => resolve("adb");
+          spawn: () =>
+            new Promise<SpawnedProcess>(resolve => {
+              resolveAdb = () => resolve(new FakeProcess());
             }),
           executeCommand: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
         } as unknown as ReturnType<AdbClientFactory["create"]>;
@@ -188,7 +189,7 @@ describe("AndroidH264Source", () => {
     } as unknown as AdbClientFactory;
 
     const { source, processes } = makeSource({ adbFactory });
-    const startPromise = source.start(); // suspends on getAdbPathOnly
+    const startPromise = source.start(); // suspends on adb.spawn
     await source.stop(); // running=false while current is still null
     resolveAdb!(); // startSegment resumes after setup
     await startPromise;

--- a/test/features/webrtc/AndroidH264Source.test.ts
+++ b/test/features/webrtc/AndroidH264Source.test.ts
@@ -176,12 +176,13 @@ describe("AndroidH264Source", () => {
 
   test("stop during adb setup aborts the spawn (no orphan process)", async () => {
     let resolveAdb: (() => void) | undefined;
+    const lateProcess = new FakeProcess();
     const adbFactory = {
       create() {
         return {
           spawn: () =>
             new Promise<SpawnedProcess>(resolve => {
-              resolveAdb = () => resolve(new FakeProcess());
+              resolveAdb = () => resolve(lateProcess);
             }),
           executeCommand: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
         } as unknown as ReturnType<AdbClientFactory["create"]>;
@@ -195,6 +196,7 @@ describe("AndroidH264Source", () => {
     await startPromise;
 
     expect(processes).toHaveLength(0); // no screenrecord spawned
+    expect(lateProcess.killed).toEqual(["SIGINT"]);
     expect(source.isRunning).toBe(false);
   });
 

--- a/test/features/webrtc/PersistentEncoderH264Source.test.ts
+++ b/test/features/webrtc/PersistentEncoderH264Source.test.ts
@@ -185,7 +185,7 @@ describe("PersistentEncoderH264Source", () => {
     expect(ctx.commands).toContain(`forward tcp:0 localabstract:${VIDEO_SERVER_SOCKET_NAME}`);
 
     const args = ctx.spawnArgs[0].join(" ");
-    expect(args).toContain("-s emulator-5554");
+    expect(args).not.toContain("-s emulator-5554");
     expect(args).toContain("CLASSPATH=/data/local/tmp/automobile-video.jar app_process /");
     expect(args).toContain("--quality low");
     expect(args).toContain("--bit-rate 1500000");

--- a/test/features/webrtc/PersistentEncoderH264Source.test.ts
+++ b/test/features/webrtc/PersistentEncoderH264Source.test.ts
@@ -7,7 +7,7 @@ import {
   type SocketConnector,
   type StreamSocket,
 } from "../../../src/features/webrtc/PersistentEncoderH264Source";
-import type { ProcessSpawner, SpawnedProcess } from "../../../src/features/webrtc/processSpawner";
+import type { SpawnedProcess } from "../../../src/features/webrtc/processSpawner";
 import {
   VIDEO_SERVER_CODEC_ID_AMUX,
   VIDEO_SERVER_CODEC_ID_H264,
@@ -115,15 +115,14 @@ function makeSource(overrides: Record<string, unknown> = {}) {
           }
           return { stdout: "", stderr: "", exitCode: 0 };
         },
+        spawn: async (args: string[]) => {
+          spawnArgs.push(args);
+          const process = new FakeProcess();
+          processes.push(process);
+          return process;
+        },
       } as unknown as ReturnType<AdbClientFactory["create"]>;
     },
-  };
-
-  const spawner: ProcessSpawner = (_command, args) => {
-    spawnArgs.push(args);
-    const proc = new FakeProcess();
-    processes.push(proc);
-    return proc;
   };
 
   const connector: SocketConnector = async () => {
@@ -140,7 +139,6 @@ function makeSource(overrides: Record<string, unknown> = {}) {
     onError: error => errors.push(error),
     jarPath: "/tmp/automobile-video.jar",
     adbFactory,
-    spawner,
     connector,
     timer,
     ...overrides,

--- a/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
+++ b/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
@@ -120,7 +120,9 @@ describe("AdbClient.getBootedAndroidDevices", () => {
     const pending = adb.spawn(["exec-out", "screenrecord", "--output-format=h264", "-"], {
       signal: controller.signal,
     });
-    setTimeout(() => child.emit("spawn"), 0);
+    await Promise.resolve();
+    await Promise.resolve();
+    child.emit("spawn");
     const process = await pending;
     controller.abort();
     child.emit("exit", null, "SIGTERM");

--- a/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
+++ b/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
@@ -117,9 +117,11 @@ describe("AdbClient.getBootedAndroidDevices", () => {
     );
     const controller = new AbortController();
 
-    const process = await adb.spawn(["exec-out", "screenrecord", "--output-format=h264", "-"], {
+    const pending = adb.spawn(["exec-out", "screenrecord", "--output-format=h264", "-"], {
       signal: controller.signal,
     });
+    setTimeout(() => child.emit("spawn"), 0);
+    const process = await pending;
     controller.abort();
     child.emit("exit", null, "SIGTERM");
 

--- a/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
+++ b/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { EventEmitter } from "events";
+import { PassThrough } from "stream";
 import { AdbClient, resetAdbClientCaches } from "../../../src/utils/android-cmdline-tools/AdbClient";
 import type { ExecResult } from "../../../src/models";
 import { isAdbMissingDeviceError } from "../../../src/utils/android-cmdline-tools/AdbDeviceHealth";
@@ -76,5 +78,54 @@ describe("AdbClient.getBootedAndroidDevices", () => {
 
     await expect(adb.executeCommand("shell true", undefined, undefined, true, controller.signal))
       .rejects.toThrow("Operation cancelled");
+  });
+
+  test("executes argv with one device selector and the resolved executable", async () => {
+    let received: { file: string; args: string[] } | undefined;
+    const adb = new AdbClient(
+      { name: "Pixel 8", platform: "android", deviceId: "emulator-5554" },
+      async (file: string, args: string[], _maxBuffer?: number): Promise<ExecResult> => {
+        received = { file, args };
+        return createExecResult("ok");
+      }
+    );
+
+    await adb.execute(["shell", "getprop", "ro.product.model"], { noRetry: true });
+
+    expect(received?.file).toEndWith("adb");
+    expect(received?.args).toEqual([
+      "-s", "emulator-5554", "shell", "getprop", "ro.product.model",
+    ]);
+  });
+
+  test("spawns argv without retry and terminates only its child on abort", async () => {
+    const child = Object.assign(new EventEmitter(), {
+      stdin: null,
+      stdout: new PassThrough(),
+      stderr: new PassThrough(),
+      killCalls: [] as string[],
+      kill(signal?: string) { this.killCalls.push(signal ?? "SIGTERM"); return true; },
+    });
+    let received: { file: string; args: string[] } | undefined;
+    const adb = new AdbClient(
+      { name: "Pixel 8", platform: "android", deviceId: "emulator-5554" },
+      async (): Promise<ExecResult> => createExecResult(""),
+      ((file: string, args: string[]) => {
+        received = { file, args };
+        return child;
+      }) as never
+    );
+    const controller = new AbortController();
+
+    const process = await adb.spawn(["exec-out", "screenrecord", "--output-format=h264", "-"], {
+      signal: controller.signal,
+    });
+    controller.abort();
+    child.emit("exit", null, "SIGTERM");
+
+    expect(process.stdout).toBe(child.stdout);
+    expect(received?.file).toEndWith("adb");
+    expect(received?.args).toEqual(["-s", "emulator-5554", "exec-out", "screenrecord", "--output-format=h264", "-"]);
+    expect(child.killCalls).toEqual(["SIGTERM"]);
   });
 });

--- a/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
+++ b/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
@@ -128,4 +128,26 @@ describe("AdbClient.getBootedAndroidDevices", () => {
     expect(received?.args).toEqual(["-s", "emulator-5554", "exec-out", "screenrecord", "--output-format=h264", "-"]);
     expect(child.killCalls).toEqual(["SIGTERM"]);
   });
+
+  test("does not spawn when cancellation arrives during executable resolution", async () => {
+    let resolveBase: ((value: { adbPath: string; baseArgs: string[] }) => void) | undefined;
+    let spawnCalls = 0;
+    const adb = new AdbClient(
+      null,
+      async (): Promise<ExecResult> => createExecResult(""),
+      (() => {
+        spawnCalls++;
+        throw new Error("must not spawn");
+      }) as never
+    );
+    (adb as unknown as { getBaseCommandParts: () => Promise<{ adbPath: string; baseArgs: string[] }> }).getBaseCommandParts = () =>
+      new Promise(resolve => { resolveBase = resolve; });
+    const controller = new AbortController();
+    const pending = adb.spawn(["get-state"], { signal: controller.signal });
+    controller.abort();
+    resolveBase!({ adbPath: "adb", baseArgs: [] });
+
+    await expect(pending).rejects.toThrow("Operation cancelled");
+    expect(spawnCalls).toBe(0);
+  });
 });

--- a/test/utils/android-cmdline-tools/AndroidUserTargetResolver.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidUserTargetResolver.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { AndroidUserTargetResolver } from "../../../src/utils/android-cmdline-tools/AndroidUserTargetResolver";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+
+describe("AndroidUserTargetResolver", () => {
+  test("preserves an explicit primary user", async () => {
+    const resolver = new AndroidUserTargetResolver(new FakeAdbExecutor());
+    expect(await resolver.resolve({ explicitUserId: 0 })).toEqual({ userId: 0, source: "explicit" });
+  });
+
+  test("uses the package's foreground user before profile fallback", async () => {
+    const adb = new FakeAdbExecutor();
+    adb.setForegroundApp({ packageName: "com.example.app", userId: 12 });
+    const resolver = new AndroidUserTargetResolver(adb);
+    expect(await resolver.resolve({ packageName: "com.example.app" })).toEqual({ userId: 12, source: "foregroundPackage" });
+  });
+
+  test("ignores a running non-managed secondary user", async () => {
+    const adb = new FakeAdbExecutor();
+    adb.setUsers([{ userId: 0, name: "Owner", flags: 13, running: true }, { userId: 10, name: "Secondary", flags: 0, running: true }]);
+    const resolver = new AndroidUserTargetResolver(adb);
+    expect(await resolver.resolve()).toEqual({ userId: 0, source: "primaryFallback" });
+  });
+
+  test("selects the first running managed profile and ignores paused profiles", async () => {
+    const adb = new FakeAdbExecutor();
+    adb.setUsers([
+      { userId: 11, name: "Paused work", flags: 0x30, running: false },
+      { userId: 12, name: "Work", flags: 0x30, running: true },
+      { userId: 13, name: "Other work", flags: 0x30, running: true },
+    ]);
+    const resolver = new AndroidUserTargetResolver(adb);
+    expect(await resolver.resolve()).toEqual({ userId: 12, source: "managedProfile" });
+  });
+});

--- a/test/utils/android-cmdline-tools/AndroidUserTargetResolver.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidUserTargetResolver.test.ts
@@ -26,7 +26,7 @@ describe("AndroidUserTargetResolver", () => {
     const adb = new FakeAdbExecutor();
     adb.setUsers([
       { userId: 11, name: "Paused work", flags: 0x30, running: false },
-      { userId: 12, name: "Work", flags: 0x30, running: true },
+      { userId: 12, name: "Work", flags: 0x20, running: true },
       { userId: 13, name: "Other work", flags: 0x30, running: true },
     ]);
     const resolver = new AndroidUserTargetResolver(adb);


### PR DESCRIPTION
## Summary\n- add argv-first, tracked ADB execution and spawning\n- migrate Android video, WebRTC, and recording process paths\n- centralize managed-profile-aware target-user selection\n\n## Validation\n- bun run lint\n- bun run typecheck\n- focused Android transport, capture, recording, and action tests\n\nCloses #4048