### PR TITLE
refactor(android): centralize emulator launch contract

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1037,6 +1037,11 @@ jobs:
           mkdir -p ci-logs
           turbo run lint --output-logs=errors-only --log-order=grouped 2>&1 | tee "ci-logs/bun-lint-${{ matrix.os }}.log"
 
+      - name: "Check Android emulator execution boundary"
+        if: env.RUN_MCP_BUILD_TEST == 'true'
+        shell: bash
+        run: bun run check:android-emulator-boundary
+
       - name: "Run Build"
         if: env.RUN_MCP_BUILD_TEST == 'true'
         shell: bash

--- a/docs/design-docs/plat/android/emulator-startup.md
+++ b/docs/design-docs/plat/android/emulator-startup.md
@@ -40,7 +40,7 @@ actionable message instead of `code: null`, pointing you at
 | Variable | Values | Effect |
 |----------|--------|--------|
 | `AUTOMOBILE_EMULATOR_HEADLESS` | `true` / `false` / unset | Force headless (`-no-window -no-audio`), force windowed, or auto-detect (default). |
-| `AUTOMOBILE_EMULATOR_ARGS` | space-separated args | Extra arguments appended to the `emulator` command (e.g. `-gpu swiftshader_indirect`). |
+| `AUTOMOBILE_EMULATOR_ARGS` | JSON argv array | Extra arguments appended to the `emulator` command (e.g. `["-gpu", "swiftshader_indirect"]`). Each JSON entry is one literal argument; whitespace is never shell-split. |
 
 ### Running emulators in CI
 
@@ -50,5 +50,5 @@ explicitly for clarity:
 ```bash
 export AUTOMOBILE_EMULATOR_HEADLESS=true
 # optionally, for software rendering on hosts without a GPU:
-export AUTOMOBILE_EMULATOR_ARGS="-gpu swiftshader_indirect -no-snapshot"
+export AUTOMOBILE_EMULATOR_ARGS='["-gpu", "swiftshader_indirect", "-no-snapshot"]'
 ```

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "validate:yaml": "bun scripts/validate-yaml.ts",
     "check:stdlib-first": "bash scripts/check-stdlib-first.sh",
     "check:simctl-boundary": "bash scripts/check-no-new-direct-simctl.sh",
+    "check:android-emulator-boundary": "bash scripts/check-android-emulator-boundary.sh",
     "dead-code:ts": "bash scripts/detect-dead-code-ts.sh",
     "dead-code:ts:prune": "bash -o pipefail -c 'bunx ts-prune --project tsconfig.dead-code.json -i src/db/migrations | (grep -v \"(used in module)\" || true) | bash scripts/filter-ts-prune-allowlist.sh'",
     "dead-code:ts:knip": "bunx knip",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "dead-code:ts:knip": "bunx knip",
     "prepublishOnly": "cp README.md README.md.backup && bun scripts/npm/transform-readme.js",
     "postpublish": "mv README.md.backup README.md || true",
-    "turbo:validate": "turbo run lint build test",
+    "turbo:validate": "turbo run lint build test check:android-emulator-boundary",
     "turbo:build": "turbo run build",
     "turbo:lint": "turbo run lint",
     "turbo:test": "turbo run test"

--- a/scripts/check-android-emulator-boundary.sh
+++ b/scripts/check-android-emulator-boundary.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Keep emulator process execution behind AndroidEmulatorClient. This deliberately
+# checks only literal emulator invocations: scripts and path-discovery diagnostics
+# are outside the production TypeScript runtime boundary.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OWNER="src/utils/android-cmdline-tools/AndroidEmulatorClient.ts"
+
+cd "$ROOT_DIR"
+
+pattern="(?:spawn|execFile|exec)\\s*\\(\\s*(?:[\\\"'\\\`][^\\\"'\\\`]*emulator[^\\\"'\\\`]*[\\\"'\\\`]|(?=[A-Za-z0-9_$]*[Ee]mulator)[A-Za-z_$][A-Za-z0-9_$]*)"
+violations="$(rg -n -P "$pattern" src \
+  --glob '*.ts' \
+  --glob "!${OWNER}" \
+  || true)"
+
+if [[ -n "$violations" ]]; then
+  echo "error: Android emulator execution must use AndroidEmulatorClient:" >&2
+  echo "$violations" >&2
+  exit 1
+fi
+
+echo "android-emulator-boundary: no direct production emulator invocations."

--- a/scripts/check-android-emulator-boundary.sh
+++ b/scripts/check-android-emulator-boundary.sh
@@ -12,7 +12,7 @@ cd "$ROOT_DIR"
 
 violations=""
 while IFS= read -r source_file; do
-  matches="$(rg -n -P '\b(?:spawn|execFile)\s*\(' "$source_file" || true)"
+  matches="$(rg -n -e 'spawn[[:space:]]*\(' -e 'execFile[[:space:]]*\(' "$source_file" || true)"
   if [[ -n "$matches" ]]; then
     violations+="${source_file#src/}: ${matches}"$'\n'
   fi

--- a/scripts/check-android-emulator-boundary.sh
+++ b/scripts/check-android-emulator-boundary.sh
@@ -1,27 +1,10 @@
 #!/usr/bin/env bash
-# Keep emulator process execution behind AndroidEmulatorClient. This deliberately
-# checks only literal emulator invocations: scripts and path-discovery diagnostics
-# are outside the production TypeScript runtime boundary.
+# Keep emulator process execution behind AndroidEmulatorClient. The TypeScript
+# scanner distinguishes process execution from unrelated calls such as RegExp.exec.
 
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-OWNER="src/utils/android-cmdline-tools/AndroidEmulatorClient.ts"
-
 cd "$ROOT_DIR"
 
-violations=""
-while IFS= read -r source_file; do
-  matches="$(grep -nE 'spawn[[:space:]]*\(|execFile[[:space:]]*\(' "$source_file" || true)"
-  if [[ -n "$matches" ]]; then
-    violations+="${source_file#src/}: ${matches}"$'\n'
-  fi
-done < <(find src -type f -name '*.ts' ! -path "$OWNER" -exec grep -il 'emulator' {} +)
-
-if [[ -n "$violations" ]]; then
-  echo "error: Android emulator execution must use AndroidEmulatorClient:" >&2
-  echo "$violations" >&2
-  exit 1
-fi
-
-echo "android-emulator-boundary: no direct production emulator invocations."
+exec bun scripts/check-android-emulator-boundary.ts

--- a/scripts/check-android-emulator-boundary.sh
+++ b/scripts/check-android-emulator-boundary.sh
@@ -10,11 +10,13 @@ OWNER="src/utils/android-cmdline-tools/AndroidEmulatorClient.ts"
 
 cd "$ROOT_DIR"
 
-pattern="(?:spawn|execFile|exec)\\s*\\(\\s*(?:[\\\"'\\\`][^\\\"'\\\`]*emulator[^\\\"'\\\`]*[\\\"'\\\`]|(?=[A-Za-z0-9_$]*[Ee]mulator)[A-Za-z_$][A-Za-z0-9_$]*)"
-violations="$(rg -n -P "$pattern" src \
-  --glob '*.ts' \
-  --glob "!${OWNER}" \
-  || true)"
+violations=""
+while IFS= read -r source_file; do
+  matches="$(rg -n -P '\b(?:spawn|execFile)\s*\(' "$source_file" || true)"
+  if [[ -n "$matches" ]]; then
+    violations+="${source_file#src/}: ${matches}"$'\n'
+  fi
+done < <(rg -il 'emulator' src --glob '*.ts' --glob "!${OWNER}")
 
 if [[ -n "$violations" ]]; then
   echo "error: Android emulator execution must use AndroidEmulatorClient:" >&2

--- a/scripts/check-android-emulator-boundary.sh
+++ b/scripts/check-android-emulator-boundary.sh
@@ -12,11 +12,11 @@ cd "$ROOT_DIR"
 
 violations=""
 while IFS= read -r source_file; do
-  matches="$(rg -n -e 'spawn[[:space:]]*\(' -e 'execFile[[:space:]]*\(' "$source_file" || true)"
+  matches="$(grep -nE 'spawn[[:space:]]*\(|execFile[[:space:]]*\(' "$source_file" || true)"
   if [[ -n "$matches" ]]; then
     violations+="${source_file#src/}: ${matches}"$'\n'
   fi
-done < <(rg -il 'emulator' src --glob '*.ts' --glob "!${OWNER}")
+done < <(find src -type f -name '*.ts' ! -path "$OWNER" -exec grep -il 'emulator' {} +)
 
 if [[ -n "$violations" ]]; then
   echo "error: Android emulator execution must use AndroidEmulatorClient:" >&2

--- a/scripts/check-android-emulator-boundary.ts
+++ b/scripts/check-android-emulator-boundary.ts
@@ -1,0 +1,173 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import ts from "typescript";
+
+const SOURCE_ROOT = "src";
+const OWNER = "src/utils/android-cmdline-tools/AndroidEmulatorClient.ts";
+const CHILD_PROCESS_MODULES = new Set(["child_process", "node:child_process"]);
+
+interface Violation {
+  readonly file: string;
+  readonly line: number;
+  readonly column: number;
+  readonly text: string;
+}
+
+function sourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return sourceFiles(path);
+    }
+    return entry.isFile() && entry.name.endsWith(".ts") ? [path] : [];
+  });
+}
+
+function isProcessExecutorType(type: ts.TypeNode | undefined): boolean {
+  return (
+    !!type &&
+    ts.isTypeReferenceNode(type) &&
+    ts.isIdentifier(type.typeName) &&
+    type.typeName.text === "ProcessExecutor"
+  );
+}
+
+function receiverName(
+  expression: ts.Expression,
+  processExecutors: Set<string>,
+  childProcessNamespaces: Set<string>,
+): string | null {
+  if (ts.isIdentifier(expression)) {
+    return processExecutors.has(expression.text) ||
+      childProcessNamespaces.has(expression.text)
+      ? expression.text
+      : null;
+  }
+  if (
+    ts.isPropertyAccessExpression(expression) &&
+    expression.expression.kind === ts.SyntaxKind.ThisKeyword &&
+    processExecutors.has(expression.name.text)
+  ) {
+    return expression.getText();
+  }
+  return null;
+}
+
+function findViolations(file: string): Violation[] {
+  const source = readFileSync(file, "utf8");
+  if (!/emulator/i.test(source)) {
+    return [];
+  }
+
+  const sourceFile = ts.createSourceFile(
+    file,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const processExecutors = new Set<string>();
+  const childProcessNamespaces = new Set<string>();
+  const childProcessFunctions = new Set<string>();
+  const violations: Violation[] = [];
+
+  const record = (node: ts.CallExpression): void => {
+    const { line, character } = sourceFile.getLineAndCharacterOfPosition(
+      node.getStart(sourceFile),
+    );
+    violations.push({
+      file,
+      line: line + 1,
+      column: character + 1,
+      text: node.getText(sourceFile),
+    });
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isImportDeclaration(node) &&
+      ts.isStringLiteral(node.moduleSpecifier) &&
+      CHILD_PROCESS_MODULES.has(node.moduleSpecifier.text)
+    ) {
+      const bindings = node.importClause?.namedBindings;
+      if (bindings && ts.isNamespaceImport(bindings)) {
+        childProcessNamespaces.add(bindings.name.text);
+      }
+      if (bindings && ts.isNamedImports(bindings)) {
+        for (const specifier of bindings.elements) {
+          const imported = specifier.propertyName?.text ?? specifier.name.text;
+          if (
+            imported === "spawn" ||
+            imported === "execFile" ||
+            imported === "exec"
+          ) {
+            childProcessFunctions.add(specifier.name.text);
+          }
+        }
+      }
+    }
+
+    if (
+      (ts.isVariableDeclaration(node) ||
+        ts.isParameter(node) ||
+        ts.isPropertyDeclaration(node)) &&
+      ts.isIdentifier(node.name) &&
+      isProcessExecutorType(node.type)
+    ) {
+      processExecutors.add(node.name.text);
+    }
+
+    if (ts.isCallExpression(node)) {
+      const expression = node.expression;
+      if (
+        ts.isIdentifier(expression) &&
+        (expression.text === "spawn" ||
+          expression.text === "execFile" ||
+          childProcessFunctions.has(expression.text))
+      ) {
+        record(node);
+      } else if (ts.isPropertyAccessExpression(expression)) {
+        if (
+          expression.name.text === "spawn" ||
+          expression.name.text === "execFile"
+        ) {
+          record(node);
+        } else if (
+          expression.name.text === "exec" &&
+          receiverName(
+            expression.expression,
+            processExecutors,
+            childProcessNamespaces,
+          )
+        ) {
+          record(node);
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return violations;
+}
+
+const violations = sourceFiles(SOURCE_ROOT)
+  .filter(file => file !== OWNER)
+  .flatMap(findViolations);
+
+if (violations.length > 0) {
+  console.error(
+    "error: Android emulator execution must use AndroidEmulatorClient:",
+  );
+  for (const violation of violations) {
+    console.error(
+      `${relative(SOURCE_ROOT, violation.file)}:${violation.line}:${violation.column}: ${violation.text}`,
+    );
+  }
+  process.exit(1);
+}
+
+console.log(
+  "android-emulator-boundary: no direct production emulator invocations.",
+);

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -888,6 +888,9 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       }
     } catch (error) {
       request.signal?.removeEventListener("abort", dispose);
+      if (disposed) {
+        throw new ActionableError(`Android emulator launch for '${request.avdName}' was cancelled`);
+      }
       throw error;
     }
     if (process && request.deviceId) {

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -874,7 +874,12 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     request.signal?.addEventListener("abort", dispose, { once: true });
 
     try {
-      process = await this.startEmulatorProcess(request.avdName, request.extraArgs);
+      process = await this.startEmulatorProcess(request.avdName, request.extraArgs, spawnedProcess => {
+        process = spawnedProcess;
+        if (disposed && !spawnedProcess.killed) {
+          spawnedProcess.kill();
+        }
+      });
       if (disposed) {
         if (process && !process.killed) {
           process.kill();
@@ -913,6 +918,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
   private async startEmulatorProcess(
     avdName: string,
     requestedExtraArgs?: readonly string[],
+    onSpawn?: (process: ChildProcess) => void,
   ): Promise<ChildProcess | null> {
     logger.info(`Using local emulator for AVD: ${avdName}`);
     const perf = createGlobalPerformanceTracker();
@@ -973,6 +979,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       perf.startOperation("spawnEmulator");
       const child = this.spawnFn(this.emulatorPath, args);
       perf.endOperation("spawnEmulator");
+      onSpawn?.(child);
 
       // Buffer to collect initial output for PANIC detection
       let initialOutput = "";

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -16,7 +16,30 @@ import type { FormFactor } from "../../models/DeviceMatchCriteria";
  * Interface for Android Emulator (AVD) management
  * Provides emulator lifecycle and control capabilities
  */
-interface AndroidEmulator {
+export interface AndroidEmulatorLaunchRequest {
+  /** The configured Android Virtual Device to launch. */
+  avdName: string;
+  /**
+   * The expected ADB serial, when the caller already knows it. This remains
+   * authoritative during readiness checks instead of relying on AVD-name
+   * discovery from a concurrently starting emulator.
+   */
+  deviceId?: string;
+  /** Additional, already-tokenized emulator arguments. */
+  extraArgs?: readonly string[];
+  /** Cancels a launch that has not begun, or disposes a completed launch. */
+  signal?: AbortSignal;
+}
+
+export interface AndroidEmulatorLaunchHandle {
+  readonly avdName: string;
+  readonly process: ChildProcess | null;
+  readonly targetDeviceId?: string;
+  /** Stops the emulator only when this launch created its process. */
+  dispose(): void;
+}
+
+export interface AndroidEmulator {
   /**
    * Execute an emulator command
    * @param command - The command to execute
@@ -57,6 +80,9 @@ interface AndroidEmulator {
    * @returns Promise with the spawned child process
    */
   startEmulator(avdName: string): Promise<ChildProcess | null>;
+
+  /** Launch an AVD with structured context and an owned lifecycle handle. */
+  launchEmulator(request: AndroidEmulatorLaunchRequest): Promise<AndroidEmulatorLaunchHandle>;
 
   /**
    * Kill a running emulator
@@ -132,6 +158,33 @@ export function resolveHeadlessMode(
   }
 
   return { headless: false, reason: "usable display detected" };
+}
+
+/**
+ * Parse `AUTOMOBILE_EMULATOR_ARGS` as a JSON argv array.
+ *
+ * This deliberately does not split on whitespace: a value such as
+ * `"swiftshader indirect"` must remain a single argv member, and shell-style
+ * quoting is not a portable or safe configuration language. Callers that
+ * construct launches programmatically should use `extraArgs` instead.
+ */
+export function parseExtraEmulatorArguments(raw: string): string[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new ActionableError(
+      "AUTOMOBILE_EMULATOR_ARGS must be a JSON array of emulator arguments, for example [\"-gpu\", \"swiftshader_indirect\"]"
+    );
+  }
+
+  if (!Array.isArray(parsed) || parsed.some(argument => typeof argument !== "string" || argument.length === 0)) {
+    throw new ActionableError(
+      "AUTOMOBILE_EMULATOR_ARGS must be a JSON array containing non-empty string arguments"
+    );
+  }
+
+  return [...parsed];
 }
 
 const execAsync = async (file: string, args: string[], signal?: AbortSignal): Promise<ExecResult> => {
@@ -798,8 +851,68 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    * @param avdName - The AVD name to start
    * @returns Promise with the spawned child process
    */
-  async startEmulator(
+  async startEmulator(avdName: string): Promise<ChildProcess | null> {
+    return (await this.launchEmulator({ avdName })).process;
+  }
+
+  async launchEmulator(request: AndroidEmulatorLaunchRequest): Promise<AndroidEmulatorLaunchHandle> {
+    if (request.signal?.aborted) {
+      throw new ActionableError(`Android emulator launch for '${request.avdName}' was cancelled`);
+    }
+
+    let process: ChildProcess | null = null;
+    let disposed = false;
+    const dispose = () => {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      if (process && !process.killed) {
+        process.kill();
+      }
+    };
+    request.signal?.addEventListener("abort", dispose, { once: true });
+
+    try {
+      process = await this.startEmulatorProcess(request.avdName, request.extraArgs);
+      if (disposed) {
+        if (process && !process.killed) {
+          process.kill();
+        }
+        throw new ActionableError(`Android emulator launch for '${request.avdName}' was cancelled`);
+      }
+    } catch (error) {
+      request.signal?.removeEventListener("abort", dispose);
+      throw error;
+    }
+    if (process && request.deviceId) {
+      this.launchTargetDeviceIds.set(process, request.deviceId);
+    }
+
+    const release = () => {
+      if (!disposed) {
+        disposed = true;
+      }
+      request.signal?.removeEventListener("abort", dispose);
+    };
+
+    const client = this;
+    return {
+      avdName: request.avdName,
+      process,
+      get targetDeviceId() {
+        return process ? client.launchTargetDeviceIds.get(process) : request.deviceId;
+      },
+      dispose: () => {
+        dispose();
+        release();
+      },
+    };
+  }
+
+  private async startEmulatorProcess(
     avdName: string,
+    requestedExtraArgs?: readonly string[],
   ): Promise<ChildProcess | null> {
     logger.info(`Using local emulator for AVD: ${avdName}`);
     const perf = createGlobalPerformanceTracker();
@@ -848,8 +961,10 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       args.push("-no-window", "-no-audio");
     }
     const extraArgsRaw = process.env.AUTOMOBILE_EMULATOR_ARGS;
-    if (extraArgsRaw) {
-      args.push(...extraArgsRaw.split(/\s+/).filter(Boolean));
+    if (requestedExtraArgs) {
+      args.push(...requestedExtraArgs);
+    } else if (extraArgsRaw) {
+      args.push(...parseExtraEmulatorArguments(extraArgsRaw));
     }
     logger.info(`Starting emulator with AVD: ${avdName}`);
     logger.debug(`Emulator command: ${this.emulatorPath} ${args.join(" ")}`);

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -874,12 +874,17 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     request.signal?.addEventListener("abort", dispose, { once: true });
 
     try {
-      process = await this.startEmulatorProcess(request.avdName, request.extraArgs, spawnedProcess => {
-        process = spawnedProcess;
-        if (disposed && !spawnedProcess.killed) {
-          spawnedProcess.kill();
-        }
-      });
+      process = await this.startEmulatorProcess(
+        request.avdName,
+        request.extraArgs,
+        spawnedProcess => {
+          process = spawnedProcess;
+          if (disposed && !spawnedProcess.killed) {
+            spawnedProcess.kill();
+          }
+        },
+        () => disposed,
+      );
       if (disposed) {
         if (process && !process.killed) {
           process.kill();
@@ -918,10 +923,17 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     };
   }
 
+  private throwIfLaunchCancelled(avdName: string, isCancelled?: () => boolean): void {
+    if (isCancelled?.()) {
+      throw new ActionableError(`Android emulator launch for '${avdName}' was cancelled`);
+    }
+  }
+
   private async startEmulatorProcess(
     avdName: string,
     requestedExtraArgs?: readonly string[],
     onSpawn?: (process: ChildProcess) => void,
+    isCancelled?: () => boolean,
   ): Promise<ChildProcess | null> {
     logger.info(`Using local emulator for AVD: ${avdName}`);
     const perf = createGlobalPerformanceTracker();
@@ -977,6 +989,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     }
     logger.info(`Starting emulator with AVD: ${avdName}`);
     logger.debug(`Emulator command: ${this.emulatorPath} ${args.join(" ")}`);
+    this.throwIfLaunchCancelled(avdName, isCancelled);
 
     return new Promise((resolve, reject) => {
       perf.startOperation("spawnEmulator");

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -303,7 +303,10 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
 
     switch (device.platform) {
       case "android":
-        return this.emulator.startEmulator(device.name);
+        return (await this.emulator.launchEmulator({
+          avdName: device.name,
+          deviceId: device.deviceId,
+        })).process;
       case "ios":
         return this.simctl.startSimulator(device.deviceId ?? device.name, timeoutMs);
       default:

--- a/test/bats/check-android-emulator-boundary.bats
+++ b/test/bats/check-android-emulator-boundary.bats
@@ -31,3 +31,12 @@ teardown() {
   [ "$status" -eq 1 ]
   [[ "$output" == *"EmulatorBoundaryFixture.ts"* ]]
 }
+
+@test "rejects a direct production emulator spawn through an unrelated alias" {
+  printf '%s\n' 'const executable = "emulator"; spawn(executable, ["-avd", avdName]);' > "$FIXTURE"
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"EmulatorBoundaryFixture.ts"* ]]
+}

--- a/test/bats/check-android-emulator-boundary.bats
+++ b/test/bats/check-android-emulator-boundary.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+
+SCRIPT="scripts/check-android-emulator-boundary.sh"
+FIXTURE="src/utils/EmulatorBoundaryFixture.ts"
+
+teardown() {
+  rm -f "$FIXTURE"
+}
+
+@test "allows AndroidEmulatorClient to own the emulator process boundary" {
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no direct production emulator invocations"* ]]
+}
+
+@test "rejects a direct production emulator spawn outside the owner" {
+  printf '%s\n' 'spawn("emulator", ["-list-avds"]);' > "$FIXTURE"
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"EmulatorBoundaryFixture.ts"* ]]
+}
+
+@test "rejects a direct production emulator spawn through a path variable" {
+  printf '%s\n' 'spawn(emulatorPath, ["-avd", avdName]);' > "$FIXTURE"
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"EmulatorBoundaryFixture.ts"* ]]
+}

--- a/test/bats/check-android-emulator-boundary.bats
+++ b/test/bats/check-android-emulator-boundary.bats
@@ -40,3 +40,20 @@ teardown() {
   [ "$status" -eq 1 ]
   [[ "$output" == *"EmulatorBoundaryFixture.ts"* ]]
 }
+
+@test "rejects a shell-based ProcessExecutor emulator launch" {
+  printf '%s\n' 'const processExecutor: ProcessExecutor = {} as ProcessExecutor; processExecutor.exec("emulator -avd Pixel");' > "$FIXTURE"
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"EmulatorBoundaryFixture.ts"* ]]
+}
+
+@test "allows unrelated RegExp exec calls in an emulator-related file" {
+  printf '%s\n' 'const match = /emulator/.exec(deviceId);' > "$FIXTURE"
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+}

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { Readable } from "node:stream";
+import type { ChildProcess } from "node:child_process";
+import {
+  AndroidEmulatorClient,
+  parseExtraEmulatorArguments,
+} from "../../../src/utils/android-cmdline-tools/AndroidEmulatorClient";
+import type { DeviceInfo, ExecResult } from "../../../src/models";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+const execResult = (stdout = ""): ExecResult => ({
+  stdout,
+  stderr: "",
+  toString: () => stdout,
+  trim: () => stdout.trim(),
+  includes: value => stdout.includes(value),
+});
+
+function createChild(): ChildProcess & EventEmitter {
+  const child = new EventEmitter() as ChildProcess & EventEmitter;
+  child.stdout = new Readable({ read() {} }) as never;
+  child.stderr = new Readable({ read() {} }) as never;
+  child.killed = false;
+  child.kill = (() => {
+    child.killed = true;
+    return true;
+  }) as ChildProcess["kill"];
+  return child;
+}
+
+function createClient(spawnFn: (command: string, args: string[]) => ChildProcess): AndroidEmulatorClient {
+  const client = new AndroidEmulatorClient(
+    async () => execResult(),
+    spawnFn as never,
+    new FakeTimer(),
+  );
+  (client as unknown as { ensureEmulatorPath: () => Promise<string> }).ensureEmulatorPath = async () => "emulator";
+  (client as unknown as { listAvds: () => Promise<DeviceInfo[]> }).listAvds = async () => [
+    { name: "Pixel 9", platform: "android", isRunning: false },
+  ];
+  (client as unknown as { isAvdRunning: () => Promise<boolean> }).isAvdRunning = async () => false;
+  (client as unknown as { isAvdStarting: () => Promise<boolean> }).isAvdStarting = async () => false;
+  (client as unknown as { checkArchitectureCompatibility: () => Promise<{ compatible: boolean }> }).checkArchitectureCompatibility = async () => ({ compatible: true });
+  return client;
+}
+
+describe("AndroidEmulatorClient launch contract", () => {
+  test("uses a JSON argv array so values containing spaces remain one argument", () => {
+    expect(parseExtraEmulatorArguments('["-gpu", "swiftshader indirect"]')).toEqual([
+      "-gpu",
+      "swiftshader indirect",
+    ]);
+  });
+
+  test("rejects the legacy whitespace-delimited extra-argument value", () => {
+    expect(() => parseExtraEmulatorArguments("-gpu swiftshader_indirect")).toThrow(
+      "AUTOMOBILE_EMULATOR_ARGS must be a JSON array",
+    );
+  });
+
+  test("returns a typed launch handle correlated to the requested adb serial", async () => {
+    const child = createChild();
+    const client = createClient(() => {
+      queueMicrotask(() => child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n")));
+      return child;
+    });
+
+    const handle = await client.launchEmulator({ avdName: "Pixel 9", deviceId: "emulator-5560" });
+
+    expect(handle.avdName).toBe("Pixel 9");
+    expect(handle.targetDeviceId).toBe("emulator-5560");
+    expect(handle.process).toBe(child);
+  });
+
+  test("does not spawn when launch has already been cancelled", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    let spawns = 0;
+    const client = createClient(() => {
+      spawns += 1;
+      return createChild();
+    });
+
+    await expect(client.launchEmulator({ avdName: "Pixel 9", signal: controller.signal })).rejects.toThrow("cancelled");
+    expect(spawns).toBe(0);
+  });
+
+  test("cancels and cleans up when aborted while startup validation is pending", async () => {
+    const controller = new AbortController();
+    const child = createChild();
+    let spawned = false;
+    const client = createClient(() => {
+      spawned = true;
+      return child;
+    });
+
+    const launch = client.launchEmulator({ avdName: "Pixel 9", signal: controller.signal });
+    while (!spawned) {
+      await Promise.resolve();
+    }
+    controller.abort();
+    child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
+
+    await expect(launch).rejects.toThrow("cancelled");
+    expect(child.killed).toBe(true);
+  });
+
+  test("disposal kills a process launched by this handle", async () => {
+    const child = createChild();
+    const client = createClient(() => {
+      queueMicrotask(() => child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n")));
+      return child;
+    });
+
+    const handle = await client.launchEmulator({ avdName: "Pixel 9" });
+    handle.dispose();
+
+    expect(child.killed).toBe(true);
+  });
+
+  test("cancellation after launch disposes the owned process", async () => {
+    const controller = new AbortController();
+    const child = createChild();
+    const client = createClient(() => {
+      queueMicrotask(() => child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n")));
+      return child;
+    });
+
+    await client.launchEmulator({ avdName: "Pixel 9", signal: controller.signal });
+    controller.abort();
+
+    expect(child.killed).toBe(true);
+  });
+});

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
@@ -86,6 +86,34 @@ describe("AndroidEmulatorClient launch contract", () => {
     expect(spawns).toBe(0);
   });
 
+  test("does not spawn when cancellation happens during startup validation", async () => {
+    const controller = new AbortController();
+    let releaseAvdLookup: (devices: DeviceInfo[]) => void = () => {};
+    const availableAvds = new Promise<DeviceInfo[]>(resolve => {
+      releaseAvdLookup = resolve;
+    });
+    let validating = false;
+    let spawns = 0;
+    const client = createClient(() => {
+      spawns += 1;
+      return createChild();
+    });
+    (client as unknown as { listAvds: () => Promise<DeviceInfo[]> }).listAvds = async () => {
+      validating = true;
+      return availableAvds;
+    };
+
+    const launch = client.launchEmulator({ avdName: "Pixel 9", signal: controller.signal });
+    while (!validating) {
+      await Promise.resolve();
+    }
+    controller.abort();
+    releaseAvdLookup([{ name: "Pixel 9", platform: "android", isRunning: false }]);
+
+    await expect(launch).rejects.toThrow("cancelled");
+    expect(spawns).toBe(0);
+  });
+
   test("cancels and cleans up when aborted while startup validation is pending", async () => {
     const controller = new AbortController();
     const child = createChild();

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
@@ -106,6 +106,29 @@ describe("AndroidEmulatorClient launch contract", () => {
     await expect(launch).rejects.toThrow("cancelled");
   });
 
+  test("reports cancellation when aborting causes the child to exit during startup validation", async () => {
+    const controller = new AbortController();
+    const child = createChild();
+    child.kill = (() => {
+      child.killed = true;
+      child.emit("exit", null);
+      return true;
+    }) as ChildProcess["kill"];
+    let spawned = false;
+    const client = createClient(() => {
+      spawned = true;
+      return child;
+    });
+
+    const launch = client.launchEmulator({ avdName: "Pixel 9", signal: controller.signal });
+    while (!spawned) {
+      await Promise.resolve();
+    }
+    controller.abort();
+
+    await expect(launch).rejects.toThrow("cancelled");
+  });
+
   test("disposal kills a process launched by this handle", async () => {
     const child = createChild();
     const client = createClient(() => {

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-launchContract.test.ts
@@ -100,10 +100,10 @@ describe("AndroidEmulatorClient launch contract", () => {
       await Promise.resolve();
     }
     controller.abort();
+    expect(child.killed).toBe(true);
     child.stdout!.emit("data", Buffer.from("Detected GPU type: host\n"));
 
     await expect(launch).rejects.toThrow("cancelled");
-    expect(child.killed).toBe(true);
   });
 
   test("disposal kills a process launched by this handle", async () => {

--- a/turbo.json
+++ b/turbo.json
@@ -52,6 +52,16 @@
       "env": ["AUTOMOBILE_TEST_MODE"],
       "passThroughEnv": ["CI", "GITHUB_ACTIONS", "DEBUG_ADB_EXEC"]
     },
+    "check:android-emulator-boundary": {
+      "description": "Prevent Android emulator execution outside AndroidEmulatorClient",
+      "inputs": [
+        "src/**",
+        "scripts/check-android-emulator-boundary.sh",
+        "package.json"
+      ],
+      "outputs": [],
+      "outputLogs": "new-only"
+    },
     "test:coverage": {
       "description": "Run tests with coverage reporting to coverage/",
       "inputs": [


### PR DESCRIPTION
## Summary

- centralize structured Android emulator launch ownership in `AndroidEmulatorClient`
- add typed launch handles, ADB-serial correlation, cancellation cleanup, and JSON argv configuration
- guard direct production emulator invocations and document the configuration migration

## Validation

- `bun run turbo:validate`
- `bun run typecheck`
- `bun run check:android-emulator-boundary`
- `bats test/bats/check-android-emulator-boundary.bats`
- `shellcheck scripts/check-android-emulator-boundary.sh`

Closes #4050
