### PR TITLE
refactor(android): centralize avdmanager execution

### DIFF
--- a/src/utils/android-cmdline-tools/AvdManagerClient.ts
+++ b/src/utils/android-cmdline-tools/AvdManagerClient.ts
@@ -1,0 +1,269 @@
+import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { ActionableError } from "../../models";
+import { defaultTimer, type Timer } from "../SystemTimer";
+import { logger } from "../logger";
+import {
+  detectAndroidCommandLineTools,
+  getAndroidHomeWithSystemImages,
+  getBestAndroidToolsLocation,
+  getCmdlineToolsRoot,
+  isHomebrewToolsPath,
+  validateRequiredTools,
+  type AndroidToolsLocation,
+} from "./detection";
+import type { AvdInfo, CreateAvdParams, DeviceProfile } from "./avdmanager";
+
+export interface AvdManagerExecutionOptions {
+  signal?: AbortSignal;
+}
+
+export interface AvdManagerClientDependencies {
+  spawn: (command: string, args: string[], options: SpawnOptions) => ChildProcess;
+  existsSync: typeof existsSync;
+  logger: Pick<typeof logger, "info" | "warn" | "error">;
+  detectAndroidCommandLineTools: typeof detectAndroidCommandLineTools;
+  getAndroidHomeWithSystemImages: typeof getAndroidHomeWithSystemImages;
+  getBestAndroidToolsLocation: typeof getBestAndroidToolsLocation;
+  validateRequiredTools: typeof validateRequiredTools;
+  timer: Timer;
+  environment: NodeJS.ProcessEnv;
+}
+
+const SDK_ROOT_MARKERS = ["system-images", "platforms", "platform-tools", "build-tools"];
+const OLD_TOOLS_BIN_MARKER = "/tools/bin/";
+const CMDLINE_TOOLS_MARKER = "/cmdline-tools/";
+const JAXB_ERROR_MARKERS = ["javax/xml/bind/annotation/XmlSchema", "javax.xml.bind.annotation.XmlSchema", "javax/xml/bind", "javax.xml.bind"];
+
+function defaults(): AvdManagerClientDependencies {
+  return {
+    spawn,
+    existsSync,
+    logger,
+    detectAndroidCommandLineTools,
+    getAndroidHomeWithSystemImages,
+    getBestAndroidToolsLocation,
+    validateRequiredTools,
+    timer: defaultTimer,
+    environment: process.env,
+  };
+}
+
+function normalizePath(value: string): string {
+  return value.replace(/\\/g, "/");
+}
+
+function getFailureSummary(result: CommandResult): string {
+  return result.stderr.trim() || result.stdout.trim() || "Unknown error";
+}
+
+function incompatibleMessage(path: string, output: string): string | null {
+  const normalized = normalizePath(output);
+  const jaxb = JAXB_ERROR_MARKERS.some(marker => normalized.includes(marker));
+  const deprecated = normalizePath(path).includes(OLD_TOOLS_BIN_MARKER) && !normalizePath(path).includes(CMDLINE_TOOLS_MARKER);
+  if (!jaxb && !deprecated) {return null;}
+
+  const header = jaxb
+    ? "Error: Android SDK tools are outdated and incompatible with Java 11+."
+    : "Error: Detected deprecated Android SDK Tools (tools/bin).";
+  const issue = jaxb
+    ? "Issue: Detected javax.xml.bind (JAXB) errors. This usually means the deprecated \"Android SDK Tools\" package (tools/bin) is in use."
+    : "Issue: Old \"Android SDK Tools\" package (deprecated since 2017).";
+  return [
+    header, "", `Current avdmanager: ${path}`, issue, "", "Fix:",
+    "1. Download \"Android SDK Command-line Tools\" from:",
+    "   https://developer.android.com/studio#command-line-tools-only",
+    "2. Extract to: $ANDROID_SDK_ROOT/cmdline-tools/latest/",
+    "3. Ensure ANDROID_SDK_ROOT/ANDROID_HOME point to your SDK root and remove tools/bin from PATH."
+  ].join("\n");
+}
+
+interface CommandResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+}
+
+export class AvdManagerClient {
+  private static readonly homebrewWarningLoggers = new WeakSet<object>();
+
+  constructor(private readonly dependencies: AvdManagerClientDependencies = defaults()) {}
+
+  async listDeviceImages(options: AvdManagerExecutionOptions = {}): Promise<AvdInfo[]> {
+    const { path, env } = await this.resolve();
+    const result = await this.execute(path, ["list", "avd"], { env, timeoutMs: 60_000 }, options);
+    this.throwIfUnsuccessful("Failed to list AVDs", path, result);
+    return this.parseAvdList(result.stdout);
+  }
+
+  async createAvd(params: CreateAvdParams, options: AvdManagerExecutionOptions = {}): Promise<{ success: boolean; message: string; avdName?: string }> {
+    try {
+      const { path, env } = await this.resolve();
+      const args = ["create", "avd", "-n", params.name, "-k", params.package];
+      if (params.device) {args.push("-d", params.device);}
+      if (params.force) {args.push("--force");}
+      if (params.path) {args.push("-p", params.path);}
+      if (params.tag) {args.push("-t", params.tag);}
+      if (params.abi) {args.push("--abi", params.abi);}
+      const result = await this.execute(path, args, { input: "\n", env, timeoutMs: 300_000 }, options);
+      if (result.exitCode === 0) {return { success: true, message: `AVD ${params.name} created successfully`, avdName: params.name };}
+      return { success: false, message: incompatibleMessage(path, `${result.stderr}\n${result.stdout}`) ?? `AVD creation failed: ${getFailureSummary(result)}` };
+    } catch (error) {
+      const message = `Failed to create AVD ${params.name}: ${(error as Error).message}`;
+      this.dependencies.logger.error(message);
+      return { success: false, message };
+    }
+  }
+
+  async deleteAvd(name: string, options: AvdManagerExecutionOptions = {}): Promise<{ success: boolean; message: string }> {
+    try {
+      const { path, env } = await this.resolve();
+      const result = await this.execute(path, ["delete", "avd", "-n", name], { env, timeoutMs: 60_000 }, options);
+      if (result.exitCode === 0) {return { success: true, message: `AVD ${name} deleted successfully` };}
+      return { success: false, message: incompatibleMessage(path, `${result.stderr}\n${result.stdout}`) ?? `AVD deletion failed: ${getFailureSummary(result)}` };
+    } catch (error) {
+      const message = `Failed to delete AVD ${name}: ${(error as Error).message}`;
+      this.dependencies.logger.error(message);
+      return { success: false, message };
+    }
+  }
+
+  async listDevices(options: AvdManagerExecutionOptions = {}): Promise<DeviceProfile[]> {
+    const { path, env } = await this.resolve();
+    const result = await this.execute(path, ["list", "device"], { env, timeoutMs: 60_000 }, options);
+    this.throwIfUnsuccessful("Failed to list devices", path, result);
+    return this.parseDeviceList(result.stdout);
+  }
+
+  private async resolve(): Promise<{ path: string; env?: NodeJS.ProcessEnv }> {
+    const locations = await this.dependencies.detectAndroidCommandLineTools();
+    const location = this.dependencies.getBestAndroidToolsLocation(locations);
+    if (!location) {throw new Error("Android command line tools not found. Tool installation functionality has been removed. Please install Android SDK manually from https://developer.android.com/studio or using Homebrew: brew install --cask android-commandlinetools");}
+    const validation = this.dependencies.validateRequiredTools(location, ["avdmanager"]);
+    if (!validation.valid) {throw new Error(`Missing required tools: ${validation.missing.join(", ")}. Tool installation functionality has been removed. Please install Android SDK manually.`);}
+    this.warnHomebrewMismatch(location);
+    return { path: this.resolveExecutable(location), env: this.getAndroidSdkEnv(location) };
+  }
+
+  private resolveExecutable(location: AndroidToolsLocation): string {
+    const executable = join(location.path, "bin", "avdmanager");
+    if (this.dependencies.existsSync(executable)) {return executable;}
+    const batch = join(location.path, "bin", "avdmanager.bat");
+    if (this.dependencies.existsSync(batch)) {return batch;}
+    throw new Error(`AVD manager not found at ${location.path}`);
+  }
+
+  private getAndroidSdkEnv(location: AndroidToolsLocation): NodeJS.ProcessEnv | undefined {
+    const env = this.dependencies.environment;
+    const candidates = [
+      env.ANDROID_SDK_ROOT,
+      env.ANDROID_HOME,
+      env.ANDROID_SDK_HOME,
+      this.stripCmdlineToolsPath(location.path),
+      location.path,
+      resolve(location.path, ".."),
+      resolve(location.path, "..", ".."),
+      ...this.typicalSdkPaths(),
+    ].filter(Boolean) as string[];
+    const sdkRoot = candidates.find(candidate => this.dependencies.existsSync(join(candidate, "system-images"))) ?? candidates.find(candidate => this.looksLikeSdkRoot(candidate));
+    return sdkRoot ? { ...env, ANDROID_HOME: sdkRoot, ANDROID_SDK_ROOT: sdkRoot } : undefined;
+  }
+
+  private stripCmdlineToolsPath(path: string): string | undefined {
+    const normalized = normalizePath(path);
+    return normalized.endsWith("/cmdline-tools/latest") ? normalized.replace(/\/cmdline-tools\/latest$/, "") : undefined;
+  }
+
+  private typicalSdkPaths(): string[] {
+    const home = this.dependencies.environment.HOME ?? this.dependencies.environment.USERPROFILE;
+    if (process.platform === "darwin") {return [...(home ? [join(home, "Library/Android/sdk")] : []), "/opt/android-sdk", "/usr/local/android-sdk"];}
+    if (process.platform === "linux") {return [...(home ? [join(home, "Android/Sdk")] : []), "/opt/android-sdk", "/usr/local/android-sdk"];}
+    if (process.platform === "win32") {return [...(home ? [join(home, "AppData/Local/Android/Sdk")] : []), "C:/Android/Sdk", "C:/android-sdk"];}
+    return [];
+  }
+
+  private looksLikeSdkRoot(path: string): boolean {
+    return this.dependencies.existsSync(path) && SDK_ROOT_MARKERS.filter(marker => this.dependencies.existsSync(join(path, marker))).length >= 2;
+  }
+
+  private warnHomebrewMismatch(location: AndroidToolsLocation): void {
+    if (!isHomebrewToolsPath(location.path)) {return;}
+    const info = this.dependencies.getAndroidHomeWithSystemImages();
+    if (!info || normalizePath(getCmdlineToolsRoot(location.path)) === normalizePath(info.androidHome)) {return;}
+    if (AvdManagerClient.homebrewWarningLoggers.has(this.dependencies.logger)) {return;}
+    this.dependencies.logger.warn(`Warning: Homebrew Android cmdline-tools detected, but system images are in ANDROID_HOME. avdmanager may report missing system images because Homebrew sets com.android.sdkmanager.toolsdir to its own root. avdmanager location: ${location.path} ANDROID_HOME: ${info.androidHome} System images: ${info.systemImagesPath} Fix: ensure cmdline-tools are present under ANDROID_HOME.`);
+    AvdManagerClient.homebrewWarningLoggers.add(this.dependencies.logger);
+  }
+
+  private async execute(path: string, args: string[], inputOptions: { input?: string; env?: NodeJS.ProcessEnv; timeoutMs: number }, options: AvdManagerExecutionOptions): Promise<CommandResult> {
+    return new Promise((resolvePromise, reject) => {
+      if (options.signal?.aborted) {return reject(new Error("avdmanager command cancelled"));}
+      const child = this.dependencies.spawn(path, args, { env: inputOptions.env, stdio: ["pipe", "pipe", "pipe"] });
+      let settled = false;
+      let stdout = "";
+      let stderr = "";
+      const settle = (callback: () => void) => {
+        if (settled) {return;}
+        settled = true;
+        this.dependencies.timer.clearTimeout(timeout);
+        options.signal?.removeEventListener("abort", onAbort);
+        callback();
+      };
+      const onAbort = () => settle(() => { child.kill("SIGTERM"); reject(new Error("avdmanager command cancelled")); });
+      options.signal?.addEventListener("abort", onAbort, { once: true });
+      const timeout = this.dependencies.timer.setTimeout(() => settle(() => {
+        child.kill("SIGTERM");
+        reject(new Error(`avdmanager command timed out after ${inputOptions.timeoutMs}ms`));
+      }), inputOptions.timeoutMs);
+      this.dependencies.logger.info(`Executing: ${path} ${args.join(" ")}`);
+      child.stdout?.on("data", data => {
+        const output = data.toString();
+        stdout += output;
+        if (output.trim()) {this.dependencies.logger.info(`[${path}] ${output.trim()}`);}
+      });
+      child.stderr?.on("data", data => {
+        const output = data.toString();
+        stderr += output;
+        if (output.trim()) {this.dependencies.logger.warn(`[${path}] ${output.trim()}`);}
+      });
+      child.on("close", code => settle(() => resolvePromise({ stdout, stderr, exitCode: code })));
+      child.on("error", error => settle(() => reject(new Error(`Failed to spawn avdmanager: ${error.message}`))));
+      if (inputOptions.input) { child.stdin?.write(inputOptions.input); child.stdin?.end(); }
+    });
+  }
+
+  private throwIfUnsuccessful(prefix: string, path: string, result: CommandResult): void {
+    if (result.exitCode === 0) {return;}
+    const compatibility = incompatibleMessage(path, `${result.stderr}\n${result.stdout}`);
+    throw compatibility ? new ActionableError(compatibility) : new Error(`${prefix}: ${getFailureSummary(result)}`);
+  }
+
+  private parseAvdList(output: string): AvdInfo[] {
+    const avds: AvdInfo[] = [];
+    let current: Partial<AvdInfo> = {};
+    for (const line of output.split("\n")) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith("Name:")) {
+        if (current.name) {avds.push(current as AvdInfo);}
+        current = { name: trimmed.slice("Name:".length).trim() };
+      } else if (trimmed.startsWith("Path:")) {current.path = trimmed.slice("Path:".length).trim();} else if (trimmed.startsWith("Target:")) {current.target = trimmed.slice("Target:".length).trim();} else if (trimmed.startsWith("Based on:")) {current.basedOn = trimmed.slice("Based on:".length).trim();} else if (trimmed.startsWith("Error:")) {current.error = trimmed.slice("Error:".length).trim();}
+    }
+    if (current.name) {avds.push(current as AvdInfo);}
+    return avds;
+  }
+
+  private parseDeviceList(output: string): DeviceProfile[] {
+    const devices: DeviceProfile[] = [];
+    let current: Partial<DeviceProfile> = {};
+    for (const line of output.split("\n")) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith("id:")) {
+        if (current.id) {devices.push(current as DeviceProfile);}
+        current = { id: trimmed.slice(3).trim() };
+      } else if (trimmed.startsWith("Name:")) {current.name = trimmed.slice(5).trim();} else if (trimmed.startsWith("OEM:")) {current.oem = trimmed.slice(4).trim();}
+    }
+    if (current.id) {devices.push(current as DeviceProfile);}
+    return devices;
+  }
+}

--- a/src/utils/android-cmdline-tools/AvdManagerClient.ts
+++ b/src/utils/android-cmdline-tools/AvdManagerClient.ts
@@ -60,6 +60,13 @@ function getFailureSummary(result: CommandResult): string {
   return result.stderr.trim() || result.stdout.trim() || "Unknown error";
 }
 
+function quoteForWindowsCmd(value: string): string {
+  if (/[\r\n"]/.test(value)) {
+    throw new Error("avdmanager arguments cannot contain Windows command-line quotes or newlines");
+  }
+  return `"${value.replace(/%/g, "%%")}"`;
+}
+
 function incompatibleMessage(path: string, output: string): string | null {
   const normalized = normalizePath(output);
   const jaxb = JAXB_ERROR_MARKERS.some(marker => normalized.includes(marker));
@@ -201,12 +208,11 @@ export class AvdManagerClient {
   private async execute(path: string, args: string[], inputOptions: { input?: string; env?: NodeJS.ProcessEnv; timeoutMs: number }, options: AvdManagerExecutionOptions): Promise<CommandResult> {
     return new Promise((resolvePromise, reject) => {
       if (options.signal?.aborted) {return reject(new Error("avdmanager command cancelled"));}
-      const needsWindowsShell = this.dependencies.platform === "win32" && path.toLowerCase().endsWith(".bat");
-      const child = this.dependencies.spawn(path, args, {
+      const invocation = this.windowsBatchInvocation(path, args, inputOptions.env);
+      const child = this.dependencies.spawn(invocation.command, invocation.args, {
         env: inputOptions.env,
         stdio: ["pipe", "pipe", "pipe"],
-        // Windows cannot execute .bat files directly; retain argv at the client boundary.
-        shell: needsWindowsShell,
+        shell: false,
       });
       let settled = false;
       let stdout = "";
@@ -239,6 +245,18 @@ export class AvdManagerClient {
       child.on("error", error => settle(() => reject(new Error(`Failed to spawn avdmanager: ${error.message}`))));
       if (inputOptions.input) { child.stdin?.write(inputOptions.input); child.stdin?.end(); }
     });
+  }
+
+  private windowsBatchInvocation(path: string, args: string[], environment?: NodeJS.ProcessEnv): { command: string; args: string[] } {
+    if (this.dependencies.platform !== "win32" || !path.toLowerCase().endsWith(".bat")) {
+      return { command: path, args };
+    }
+
+    const command = [quoteForWindowsCmd(path), ...args.map(quoteForWindowsCmd)].join(" ");
+    return {
+      command: environment?.ComSpec ?? environment?.COMSPEC ?? "cmd.exe",
+      args: ["/d", "/v:off", "/s", "/c", command],
+    };
   }
 
   private throwIfUnsuccessful(prefix: string, path: string, result: CommandResult): void {

--- a/src/utils/android-cmdline-tools/AvdManagerClient.ts
+++ b/src/utils/android-cmdline-tools/AvdManagerClient.ts
@@ -29,6 +29,7 @@ export interface AvdManagerClientDependencies {
   validateRequiredTools: typeof validateRequiredTools;
   timer: Timer;
   environment: NodeJS.ProcessEnv;
+  platform: NodeJS.Platform;
 }
 
 const SDK_ROOT_MARKERS = ["system-images", "platforms", "platform-tools", "build-tools"];
@@ -47,6 +48,7 @@ function defaults(): AvdManagerClientDependencies {
     validateRequiredTools,
     timer: defaultTimer,
     environment: process.env,
+    platform: process.platform,
   };
 }
 
@@ -177,9 +179,9 @@ export class AvdManagerClient {
 
   private typicalSdkPaths(): string[] {
     const home = this.dependencies.environment.HOME ?? this.dependencies.environment.USERPROFILE;
-    if (process.platform === "darwin") {return [...(home ? [join(home, "Library/Android/sdk")] : []), "/opt/android-sdk", "/usr/local/android-sdk"];}
-    if (process.platform === "linux") {return [...(home ? [join(home, "Android/Sdk")] : []), "/opt/android-sdk", "/usr/local/android-sdk"];}
-    if (process.platform === "win32") {return [...(home ? [join(home, "AppData/Local/Android/Sdk")] : []), "C:/Android/Sdk", "C:/android-sdk"];}
+    if (this.dependencies.platform === "darwin") {return [...(home ? [join(home, "Library/Android/sdk")] : []), "/opt/android-sdk", "/usr/local/android-sdk"];}
+    if (this.dependencies.platform === "linux") {return [...(home ? [join(home, "Android/Sdk")] : []), "/opt/android-sdk", "/usr/local/android-sdk"];}
+    if (this.dependencies.platform === "win32") {return [...(home ? [join(home, "AppData/Local/Android/Sdk")] : []), "C:/Android/Sdk", "C:/android-sdk"];}
     return [];
   }
 
@@ -199,7 +201,13 @@ export class AvdManagerClient {
   private async execute(path: string, args: string[], inputOptions: { input?: string; env?: NodeJS.ProcessEnv; timeoutMs: number }, options: AvdManagerExecutionOptions): Promise<CommandResult> {
     return new Promise((resolvePromise, reject) => {
       if (options.signal?.aborted) {return reject(new Error("avdmanager command cancelled"));}
-      const child = this.dependencies.spawn(path, args, { env: inputOptions.env, stdio: ["pipe", "pipe", "pipe"] });
+      const needsWindowsShell = this.dependencies.platform === "win32" && path.toLowerCase().endsWith(".bat");
+      const child = this.dependencies.spawn(path, args, {
+        env: inputOptions.env,
+        stdio: ["pipe", "pipe", "pipe"],
+        // Windows cannot execute .bat files directly; retain argv at the client boundary.
+        shell: needsWindowsShell,
+      });
       let settled = false;
       let stdout = "";
       let stderr = "";

--- a/src/utils/android-cmdline-tools/avdmanager.ts
+++ b/src/utils/android-cmdline-tools/avdmanager.ts
@@ -460,6 +460,7 @@ function createAvdManagerClient(dependencies: AvdManagerDependencies): AvdManage
     ...dependencies,
     timer: defaultTimer,
     environment: process.env,
+    platform: process.platform,
   });
 }
 

--- a/src/utils/android-cmdline-tools/avdmanager.ts
+++ b/src/utils/android-cmdline-tools/avdmanager.ts
@@ -1,7 +1,6 @@
 import { spawn } from "child_process";
 import { existsSync } from "fs";
 import { join, resolve } from "path";
-import { ActionableError } from "../../models";
 import { logger } from "../logger";
 import { defaultTimer } from "../SystemTimer";
 import {
@@ -13,6 +12,7 @@ import {
   validateRequiredTools,
   type AndroidToolsLocation
 } from "./detection";
+import { AvdManagerClient } from "./AvdManagerClient";
 
 // Dependencies interface for dependency injection
 export interface AvdManagerDependencies {
@@ -37,82 +37,10 @@ const createDefaultDependencies = (): AvdManagerDependencies => ({
 });
 
 const SDK_ROOT_MARKERS = ["system-images", "platforms", "platform-tools", "build-tools"];
-const OLD_TOOLS_BIN_MARKER = "/tools/bin/";
-const CMDLINE_TOOLS_MARKER = "/cmdline-tools/";
-const JAXB_ERROR_MARKERS = [
-  "javax/xml/bind/annotation/XmlSchema",
-  "javax.xml.bind.annotation.XmlSchema",
-  "javax/xml/bind",
-  "javax.xml.bind"
-];
 let hasWarnedHomebrewSystemImagesMismatch = false;
 
 function normalizePath(value: string): string {
   return value.replace(/\\/g, "/");
-}
-
-function isOldAndroidToolsPath(pathValue: string): boolean {
-  const normalized = normalizePath(pathValue);
-  return normalized.includes(OLD_TOOLS_BIN_MARKER) && !normalized.includes(CMDLINE_TOOLS_MARKER);
-}
-
-function hasJaxbError(output: string): boolean {
-  if (!output) {
-    return false;
-  }
-
-  const normalized = normalizePath(output);
-  return JAXB_ERROR_MARKERS.some(marker => normalized.includes(marker));
-}
-
-function formatIncompatibleAvdManagerMessage(avdmanagerPath: string, reason: "jaxb" | "deprecated"): string {
-  const header = reason === "jaxb"
-    ? "Error: Android SDK tools are outdated and incompatible with Java 11+."
-    : "Error: Detected deprecated Android SDK Tools (tools/bin).";
-  const issue = reason === "jaxb"
-    ? "Issue: Detected javax.xml.bind (JAXB) errors. This usually means the deprecated \"Android SDK Tools\" package (tools/bin) is in use."
-    : "Issue: Old \"Android SDK Tools\" package (deprecated since 2017).";
-
-  return [
-    header,
-    "",
-    `Current avdmanager: ${avdmanagerPath}`,
-    issue,
-    "",
-    "Fix:",
-    "1. Download \"Android SDK Command-line Tools\" from:",
-    "   https://developer.android.com/studio#command-line-tools-only",
-    "2. Extract to: $ANDROID_SDK_ROOT/cmdline-tools/latest/",
-    "3. Ensure ANDROID_SDK_ROOT/ANDROID_HOME point to your SDK root and remove tools/bin from PATH."
-  ].join("\n");
-}
-
-function getIncompatibleAvdManagerMessage(avdmanagerPath: string, output: string): string | null {
-  if (hasJaxbError(output)) {
-    return formatIncompatibleAvdManagerMessage(avdmanagerPath, "jaxb");
-  }
-
-  if (isOldAndroidToolsPath(avdmanagerPath)) {
-    return formatIncompatibleAvdManagerMessage(avdmanagerPath, "deprecated");
-  }
-
-  return null;
-}
-
-function getCommandOutputForDetection(result: { stdout: string; stderr: string }): string {
-  return [result.stderr, result.stdout].filter(Boolean).join("\n");
-}
-
-function getCommandFailureSummary(result: { stdout: string; stderr: string }): string {
-  const stderr = result.stderr.trim();
-  if (stderr) {
-    return stderr;
-  }
-  const stdout = result.stdout.trim();
-  if (stdout) {
-    return stdout;
-  }
-  return "Unknown error";
 }
 
 function maybeWarnHomebrewSystemImagesMismatch(
@@ -375,22 +303,6 @@ async function ensureToolsAvailable(dependencies = createDefaultDependencies()):
 }
 
 /**
- * Get the avdmanager executable path
- */
-function getAvdManagerPath(location: AndroidToolsLocation, dependencies = createDefaultDependencies()): string {
-  const avdmanagerPath = join(location.path, "bin", "avdmanager");
-  const avdmanagerBatPath = join(location.path, "bin", "avdmanager.bat");
-
-  if (dependencies.existsSync(avdmanagerPath)) {
-    return avdmanagerPath;
-  } else if (dependencies.existsSync(avdmanagerBatPath)) {
-    return avdmanagerBatPath;
-  }
-
-  throw new Error(`AVD manager not found at ${location.path}`);
-}
-
-/**
  * Get the sdkmanager executable path
  */
 function getSdkManagerPath(location: AndroidToolsLocation, dependencies = createDefaultDependencies()): string {
@@ -503,22 +415,7 @@ export async function installSystemImage(packageName: string, acceptLicense = tr
  */
 export async function listDeviceImages(dependencies = createDefaultDependencies()): Promise<AvdInfo[]> {
   try {
-    const location = await ensureToolsAvailable(dependencies);
-    const avdmanagerPath = getAvdManagerPath(location, dependencies);
-    const env = getAndroidSdkEnv(location, dependencies);
-
-    const result = await spawnCommand(avdmanagerPath, ["list", "avd"], { env }, dependencies);
-
-    if (result.exitCode !== 0) {
-      const detectionOutput = getCommandOutputForDetection(result);
-      const compatibilityMessage = getIncompatibleAvdManagerMessage(avdmanagerPath, detectionOutput);
-      if (compatibilityMessage) {
-        throw new ActionableError(compatibilityMessage);
-      }
-      throw new Error(`Failed to list AVDs: ${getCommandFailureSummary(result)}`);
-    }
-
-    return parseAvdList(result.stdout);
+    return await createAvdManagerClient(dependencies).listDeviceImages();
   } catch (error) {
     dependencies.logger.error(`Failed to list AVDs: ${(error as Error).message}`);
     throw error;
@@ -533,78 +430,7 @@ export async function createAvd(params: CreateAvdParams, dependencies = createDe
   message: string;
   avdName?: string;
 }> {
-  try {
-    const location = await ensureToolsAvailable(dependencies);
-    const avdmanagerPath = getAvdManagerPath(location, dependencies);
-    const env = getAndroidSdkEnv(location, dependencies);
-
-    const {
-      name,
-      package: packageName,
-      device,
-      force = false,
-      path: avdPath,
-      tag,
-      abi
-    } = params;
-
-    dependencies.logger.info(`Creating AVD: ${name} with package ${packageName}`);
-
-    const args = ["create", "avd", "-n", name, "-k", packageName];
-
-    if (device) {
-      args.push("-d", device);
-    }
-
-    if (force) {
-      args.push("--force");
-    }
-
-    if (avdPath) {
-      args.push("-p", avdPath);
-    }
-
-    if (tag) {
-      args.push("-t", tag);
-    }
-
-    if (abi) {
-      args.push("--abi", abi);
-    }
-
-    const result = await spawnCommand(avdmanagerPath, args, {
-      input: "\n", // Default response to any prompts
-      timeout: 300000, // 5 minute timeout
-      env
-    }, dependencies);
-
-    if (result.exitCode === 0) {
-      dependencies.logger.info(`Successfully created AVD: ${name}`);
-      return {
-        success: true,
-        message: `AVD ${name} created successfully`,
-        avdName: name
-      };
-    }
-
-    const detectionOutput = getCommandOutputForDetection(result);
-    const compatibilityMessage = getIncompatibleAvdManagerMessage(avdmanagerPath, detectionOutput);
-    if (compatibilityMessage) {
-      return {
-        success: false,
-        message: compatibilityMessage
-      };
-    }
-
-    return {
-      success: false,
-      message: `AVD creation failed: ${getCommandFailureSummary(result)}`
-    };
-  } catch (error) {
-    const message = `Failed to create AVD ${params.name}: ${(error as Error).message}`;
-    dependencies.logger.error(message);
-    return { success: false, message };
-  }
+  return createAvdManagerClient(dependencies).createAvd(params);
 }
 
 /**
@@ -614,32 +440,7 @@ export async function deleteAvd(name: string, dependencies = createDefaultDepend
   success: boolean;
   message: string;
 }> {
-  try {
-    const location = await ensureToolsAvailable(dependencies);
-    const avdmanagerPath = getAvdManagerPath(location, dependencies);
-    const env = getAndroidSdkEnv(location, dependencies);
-
-    dependencies.logger.info(`Deleting AVD: ${name}`);
-
-    const result = await spawnCommand(avdmanagerPath, ["delete", "avd", "-n", name], { env }, dependencies);
-
-    if (result.exitCode === 0) {
-      dependencies.logger.info(`Successfully deleted AVD: ${name}`);
-      return { success: true, message: `AVD ${name} deleted successfully` };
-    }
-
-    const detectionOutput = getCommandOutputForDetection(result);
-    const compatibilityMessage = getIncompatibleAvdManagerMessage(avdmanagerPath, detectionOutput);
-    if (compatibilityMessage) {
-      return { success: false, message: compatibilityMessage };
-    }
-
-    return { success: false, message: `AVD deletion failed: ${getCommandFailureSummary(result)}` };
-  } catch (error) {
-    const message = `Failed to delete AVD ${name}: ${(error as Error).message}`;
-    dependencies.logger.error(message);
-    return { success: false, message };
-  }
+  return createAvdManagerClient(dependencies).deleteAvd(name);
 }
 
 /**
@@ -647,26 +448,19 @@ export async function deleteAvd(name: string, dependencies = createDefaultDepend
  */
 export async function listDevices(dependencies = createDefaultDependencies()): Promise<DeviceProfile[]> {
   try {
-    const location = await ensureToolsAvailable(dependencies);
-    const avdmanagerPath = getAvdManagerPath(location, dependencies);
-    const env = getAndroidSdkEnv(location, dependencies);
-
-    const result = await spawnCommand(avdmanagerPath, ["list", "device"], { env }, dependencies);
-
-    if (result.exitCode !== 0) {
-      const detectionOutput = getCommandOutputForDetection(result);
-      const compatibilityMessage = getIncompatibleAvdManagerMessage(avdmanagerPath, detectionOutput);
-      if (compatibilityMessage) {
-        throw new ActionableError(compatibilityMessage);
-      }
-      throw new Error(`Failed to list devices: ${getCommandFailureSummary(result)}`);
-    }
-
-    return parseDeviceList(result.stdout);
+    return await createAvdManagerClient(dependencies).listDevices();
   } catch (error) {
     dependencies.logger.error(`Failed to list devices: ${(error as Error).message}`);
     throw error;
   }
+}
+
+function createAvdManagerClient(dependencies: AvdManagerDependencies): AvdManagerClient {
+  return new AvdManagerClient({
+    ...dependencies,
+    timer: defaultTimer,
+    environment: process.env,
+  });
 }
 
 /**
@@ -735,76 +529,6 @@ function matchesFilter(image: SystemImage, filter: SystemImageFilter): boolean {
     return false;
   }
   return true;
-}
-
-/**
- * Parse AVD list from avdmanager output
- */
-function parseAvdList(output: string): AvdInfo[] {
-  const avds: AvdInfo[] = [];
-  const lines = output.split("\n");
-
-  let currentAvd: Partial<AvdInfo> = {};
-
-  for (const line of lines) {
-    const trimmedLine = line.trim();
-
-    if (trimmedLine.startsWith("Name:")) {
-      // Start of new AVD entry
-      if (currentAvd.name) {
-        avds.push(currentAvd as AvdInfo);
-      }
-      currentAvd = { name: trimmedLine.substring(5).trim() };
-    } else if (trimmedLine.startsWith("Path:")) {
-      currentAvd.path = trimmedLine.substring(5).trim();
-    } else if (trimmedLine.startsWith("Target:")) {
-      currentAvd.target = trimmedLine.substring(7).trim();
-    } else if (trimmedLine.startsWith("Based on:")) {
-      currentAvd.basedOn = trimmedLine.substring(9).trim();
-    } else if (trimmedLine.startsWith("Error:")) {
-      currentAvd.error = trimmedLine.substring(6).trim();
-    }
-  }
-
-  // Add the last AVD if exists
-  if (currentAvd.name) {
-    avds.push(currentAvd as AvdInfo);
-  }
-
-  return avds;
-}
-
-/**
- * Parse device profiles from avdmanager output
- */
-function parseDeviceList(output: string): DeviceProfile[] {
-  const devices: DeviceProfile[] = [];
-  const lines = output.split("\n");
-
-  let currentDevice: Partial<DeviceProfile> = {};
-
-  for (const line of lines) {
-    const trimmedLine = line.trim();
-
-    if (trimmedLine.startsWith("id:")) {
-      // Start of new device entry
-      if (currentDevice.id) {
-        devices.push(currentDevice as DeviceProfile);
-      }
-      currentDevice = { id: trimmedLine.substring(3).trim() };
-    } else if (trimmedLine.startsWith("Name:")) {
-      currentDevice.name = trimmedLine.substring(5).trim();
-    } else if (trimmedLine.startsWith("OEM:")) {
-      currentDevice.oem = trimmedLine.substring(4).trim();
-    }
-  }
-
-  // Add the last device if exists
-  if (currentDevice.id) {
-    devices.push(currentDevice as DeviceProfile);
-  }
-
-  return devices;
 }
 
 // Type definitions

--- a/test/lint/avdManagerExecutionBoundary.test.ts
+++ b/test/lint/avdManagerExecutionBoundary.test.ts
@@ -6,9 +6,12 @@ const ROOT = join(import.meta.dir, "..", "..");
 const CLIENT = "src/utils/android-cmdline-tools/AvdManagerClient.ts";
 
 function directlyExecutesAvdManager(source: string): boolean {
-  const executesProcess = /\b(?:spawn|spawnCommand)\s*\(/.test(source);
-  const avdmanagerPath = /(?:\b(?:const|let|var)\s+(?:\w*(?:path|command|executable)\w*)\s*=\s*[^;\n]*["'`]avdmanager(?:\.bat)?["'`]|\b(?:join|resolve)\s*\([^\n]*["'`]avdmanager(?:\.bat)?["'`]|\b(?:spawn|spawnCommand)\s*\(\s*["'`][^"'`]*avdmanager)/i.test(source);
-  return executesProcess && avdmanagerPath;
+  const launcher = /\b(?:spawn|spawnSync|spawnCommand|exec|execFile|execFileSync|Bun\.spawn)\s*\(/;
+  const directLiteral = /\b(?:spawn|spawnSync|spawnCommand|exec|execFile|execFileSync)\s*\(\s*["'`][^"'`]*avdmanager/i;
+  const constructedPath = /\b(?:join|resolve)\s*\([^;\n]*["'`]avdmanager(?:\.bat)?["'`]/i;
+  const variableNames = [...source.matchAll(/\b(?:const|let|var)\s+(\w+)\s*=\s*[^;]*?(?:\b(?:join|resolve)\s*\([^;]*?)?["'`]avdmanager(?:\.bat)?["'`][^;]*;/gi)].map(match => match[1]);
+  const variableLaunch = variableNames.some(name => new RegExp(`\\b(?:spawn|spawnSync|spawnCommand|exec|execFile|execFileSync)\\s*\\(\\s*${name}\\b|\\bBun\\.spawn\\s*\\(\\s*\\[\\s*${name}\\b`).test(source));
+  return directLiteral.test(source) || (launcher.test(source) && constructedPath.test(source) && variableLaunch);
 }
 
 function sourceFiles(directory: string): string[] {
@@ -39,6 +42,15 @@ describe("avdmanager execution boundary (issue #4051)", () => {
   test("detects a resolved avdmanager path passed to spawn", () => {
     expect(directlyExecutesAvdManager(
       'const command = join(sdkRoot, "bin", "avdmanager"); spawn(command, args);'
+    )).toBe(true);
+  });
+
+  test("detects arbitrary path variable names and alternate launch APIs", () => {
+    expect(directlyExecutesAvdManager(
+      'const binary = join(sdkRoot, "bin", "avdmanager"); execFile(binary, args);'
+    )).toBe(true);
+    expect(directlyExecutesAvdManager(
+      'const tool = join(sdkRoot, "bin", "avdmanager"); Bun.spawn([tool, ...args]);'
     )).toBe(true);
   });
 

--- a/test/lint/avdManagerExecutionBoundary.test.ts
+++ b/test/lint/avdManagerExecutionBoundary.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const ROOT = join(import.meta.dir, "..", "..");
+const CLIENT = "src/utils/android-cmdline-tools/AvdManagerClient.ts";
+
+function directlyExecutesAvdManager(source: string): boolean {
+  const executesProcess = /\b(?:spawn|spawnCommand)\s*\(/.test(source);
+  const avdmanagerPath = /(?:\b(?:const|let|var)\s+(?:\w*(?:path|command|executable)\w*)\s*=\s*[^;\n]*["'`]avdmanager(?:\.bat)?["'`]|\b(?:join|resolve)\s*\([^\n]*["'`]avdmanager(?:\.bat)?["'`]|\b(?:spawn|spawnCommand)\s*\(\s*["'`][^"'`]*avdmanager)/i.test(source);
+  return executesProcess && avdmanagerPath;
+}
+
+function sourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {return sourceFiles(path);}
+    return entry.name.endsWith(".ts") ? [path] : [];
+  });
+}
+
+describe("avdmanager execution boundary (issue #4051)", () => {
+  test("only AvdManagerClient directly executes avdmanager", () => {
+    const exceptions = new Map<string, string>([
+      // Diagnostic-only references are allowed only with a concrete reason here.
+    ]);
+    const offenders = sourceFiles(join(ROOT, "src")).flatMap(file => {
+      const repoPath = relative(ROOT, file);
+      if (repoPath === CLIENT || exceptions.has(repoPath)) {return [];}
+      const source = readFileSync(file, "utf8");
+      return directlyExecutesAvdManager(source)
+        ? [`${repoPath} directly executes avdmanager; route it through ${CLIENT} instead.`]
+        : [];
+    });
+
+    expect(offenders, offenders.join("\n")).toEqual([]);
+  });
+
+  test("detects a resolved avdmanager path passed to spawn", () => {
+    expect(directlyExecutesAvdManager(
+      'const command = join(sdkRoot, "bin", "avdmanager"); spawn(command, args);'
+    )).toBe(true);
+  });
+
+  test("every documented exception still exists", () => {
+    const exceptions = new Map<string, string>([
+      // Keep this list empty unless a production diagnostic cannot use the client.
+    ]);
+    expect([...exceptions.keys()].filter(path => !sourceFiles(join(ROOT, "src")).some(file => relative(ROOT, file) === path))).toEqual([]);
+  });
+});

--- a/test/lint/avdManagerExecutionBoundary.test.ts
+++ b/test/lint/avdManagerExecutionBoundary.test.ts
@@ -11,7 +11,8 @@ function directlyExecutesAvdManager(source: string): boolean {
   const constructedPath = /\b(?:join|resolve)\s*\([^;\n]*["'`]avdmanager(?:\.bat)?["'`]/i;
   const variableNames = [...source.matchAll(/\b(?:const|let|var)\s+(\w+)\s*=\s*[^;]*?(?:\b(?:join|resolve)\s*\([^;]*?)?["'`]avdmanager(?:\.bat)?["'`][^;]*;/gi)].map(match => match[1]);
   const variableLaunch = variableNames.some(name => new RegExp(`\\b(?:spawn|spawnSync|spawnCommand|exec|execFile|execFileSync)\\s*\\(\\s*${name}\\b|\\bBun\\.spawn\\s*\\(\\s*\\[\\s*${name}\\b`).test(source));
-  return directLiteral.test(source) || (launcher.test(source) && constructedPath.test(source) && variableLaunch);
+  const inlineLaunch = /\b(?:spawn|spawnSync|spawnCommand|exec|execFile|execFileSync)\s*\(\s*(?:join|resolve)\s*\([^;\n]*["'`]avdmanager|\bBun\.spawn\s*\(\s*\[\s*(?:join|resolve)\s*\([^;\n]*["'`]avdmanager/i;
+  return directLiteral.test(source) || inlineLaunch.test(source) || (launcher.test(source) && constructedPath.test(source) && variableLaunch);
 }
 
 function sourceFiles(directory: string): string[] {
@@ -51,6 +52,15 @@ describe("avdmanager execution boundary (issue #4051)", () => {
     )).toBe(true);
     expect(directlyExecutesAvdManager(
       'const tool = join(sdkRoot, "bin", "avdmanager"); Bun.spawn([tool, ...args]);'
+    )).toBe(true);
+  });
+
+  test("detects inline resolved paths passed to launch APIs", () => {
+    expect(directlyExecutesAvdManager(
+      'spawn(join(sdkRoot, "bin", "avdmanager"), args);'
+    )).toBe(true);
+    expect(directlyExecutesAvdManager(
+      'Bun.spawn([join(sdkRoot, "bin", "avdmanager"), ...args]);'
     )).toBe(true);
   });
 

--- a/test/utils/android-cmdline-tools/AvdManagerClient.test.ts
+++ b/test/utils/android-cmdline-tools/AvdManagerClient.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "bun:test";
+import type { ChildProcess } from "node:child_process";
+import { AvdManagerClient } from "../../../src/utils/android-cmdline-tools/AvdManagerClient";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+class FakeChild {
+  readonly stdout = { on: (_event: string, callback: (data: Buffer) => void) => { this.stdoutCallback = callback; } };
+  readonly stderr = { on: (_event: string, callback: (data: Buffer) => void) => { this.stderrCallback = callback; } };
+  readonly stdin = {
+    write: (value: string) => { this.stdinWrites.push(value); },
+    end: () => { this.stdinEnded = true; }
+  };
+  readonly kills: NodeJS.Signals[] = [];
+  readonly stdinWrites: string[] = [];
+  stdinEnded = false;
+  private stdoutCallback?: (data: Buffer) => void;
+  private stderrCallback?: (data: Buffer) => void;
+  private closeCallback?: (code: number | null) => void;
+  private errorCallback?: (error: Error) => void;
+
+  on(event: string, callback: (value: never) => void): this {
+    if (event === "close") {this.closeCallback = callback as (code: number | null) => void;}
+    if (event === "error") {this.errorCallback = callback as (error: Error) => void;}
+    return this;
+  }
+
+  kill(signal: NodeJS.Signals): boolean {
+    this.kills.push(signal);
+    return true;
+  }
+
+  close(code: number | null): void { this.closeCallback?.(code); }
+  stdoutText(value: string): void { this.stdoutCallback?.(Buffer.from(value)); }
+  stderrText(value: string): void { this.stderrCallback?.(Buffer.from(value)); }
+  fail(error: Error): void { this.errorCallback?.(error); }
+}
+
+function createClient(overrides: Partial<ConstructorParameters<typeof AvdManagerClient>[0]> = {}) {
+  const child = new FakeChild();
+  const timer = new FakeTimer();
+  const calls: Array<{ command: string; args: string[]; env?: NodeJS.ProcessEnv }> = [];
+  const client = new AvdManagerClient({
+    detectAndroidCommandLineTools: async () => [{
+      path: "/sdk/cmdline-tools/latest",
+      source: "manual",
+      available_tools: ["avdmanager"]
+    }],
+    getBestAndroidToolsLocation: locations => locations[0] ?? null,
+    validateRequiredTools: () => ({ valid: true, missing: [] }),
+    existsSync: path => path.endsWith("avdmanager") || path.endsWith("system-images"),
+    spawn: (command, args, options) => {
+      calls.push({ command, args, env: options.env });
+      return child as unknown as ChildProcess;
+    },
+    logger: { info() {}, warn() {}, error() {} },
+    timer,
+    environment: { ANDROID_HOME: "/sdk" },
+    ...overrides
+  });
+  return { client, child, timer, calls };
+}
+
+describe("AvdManagerClient", () => {
+  test("passes AVD names and paths as discrete argv values", async () => {
+    const { client, child, calls } = createClient();
+    const pending = client.createAvd({
+      name: "pixel; touch should-not-run",
+      package: "system-images;android-36;google_apis;x86_64",
+      path: "/tmp/AVD name;$(nope)"
+    });
+    await new Promise<void>(resolve => setImmediate(resolve));
+    child.close(0);
+
+    await expect(pending).resolves.toMatchObject({ success: true });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      command: "/sdk/cmdline-tools/latest/bin/avdmanager",
+      args: [
+        "create", "avd", "-n", "pixel; touch should-not-run", "-k",
+        "system-images;android-36;google_apis;x86_64", "-p", "/tmp/AVD name;$(nope)"
+      ]
+    });
+    expect(child.stdinWrites).toEqual(["\n"]);
+    expect(child.stdinEnded).toBe(true);
+  });
+
+  test("uses the Windows batch executable when that is the resolved tool", async () => {
+    const { client, child, calls } = createClient({
+      existsSync: path => path.endsWith("avdmanager.bat") || path.endsWith("system-images")
+    });
+    const pending = client.listDeviceImages();
+    await new Promise<void>(resolve => setImmediate(resolve));
+    child.close(0);
+
+    await expect(pending).resolves.toEqual([]);
+    expect(calls[0]?.command).toBe("/sdk/cmdline-tools/latest/bin/avdmanager.bat");
+  });
+
+  test("requires avdmanager without coupling AVD operations to sdkmanager", async () => {
+    const validations: string[][] = [];
+    const { client, child } = createClient({
+      validateRequiredTools: (_location, tools) => {
+        validations.push([...tools]);
+        return { valid: true, missing: [] };
+      }
+    });
+    const pending = client.listDeviceImages();
+    await new Promise<void>(resolve => setImmediate(resolve));
+    child.close(0);
+
+    await expect(pending).resolves.toEqual([]);
+    expect(validations).toEqual([["avdmanager"]]);
+  });
+
+  test("rejects null exits and retains stderr-only diagnostics", async () => {
+    const { client, child } = createClient();
+    const pending = client.listDeviceImages();
+    await new Promise<void>(resolve => setImmediate(resolve));
+    child.stderrText("configuration failed");
+    child.close(null);
+
+    await expect(pending).rejects.toThrow("configuration failed");
+  });
+
+  test("cancels the child once and ignores a late close", async () => {
+    const { client, child } = createClient();
+    const abort = new AbortController();
+    const pending = client.listDeviceImages({ signal: abort.signal });
+    await new Promise<void>(resolve => setImmediate(resolve));
+    abort.abort();
+    child.close(0);
+
+    await expect(pending).rejects.toThrow("cancelled");
+    expect(child.kills).toEqual(["SIGTERM"]);
+  });
+
+  test("terminates a timed-out list command and ignores its late close", async () => {
+    const { client, child, timer } = createClient();
+    const pending = client.listDeviceImages();
+    await new Promise<void>(resolve => setImmediate(resolve));
+    timer.advanceTime(60_000);
+    child.close(0);
+
+    await expect(pending).rejects.toThrow("timed out after 60000ms");
+    expect(child.kills).toEqual(["SIGTERM"]);
+  });
+});

--- a/test/utils/android-cmdline-tools/AvdManagerClient.test.ts
+++ b/test/utils/android-cmdline-tools/AvdManagerClient.test.ts
@@ -38,7 +38,7 @@ class FakeChild {
 function createClient(overrides: Partial<ConstructorParameters<typeof AvdManagerClient>[0]> = {}) {
   const child = new FakeChild();
   const timer = new FakeTimer();
-  const calls: Array<{ command: string; args: string[]; env?: NodeJS.ProcessEnv }> = [];
+  const calls: Array<{ command: string; args: string[]; env?: NodeJS.ProcessEnv; shell?: string | boolean }> = [];
   const client = new AvdManagerClient({
     detectAndroidCommandLineTools: async () => [{
       path: "/sdk/cmdline-tools/latest",
@@ -49,12 +49,13 @@ function createClient(overrides: Partial<ConstructorParameters<typeof AvdManager
     validateRequiredTools: () => ({ valid: true, missing: [] }),
     existsSync: path => path.endsWith("avdmanager") || path.endsWith("system-images"),
     spawn: (command, args, options) => {
-      calls.push({ command, args, env: options.env });
+      calls.push({ command, args, env: options.env, shell: options.shell });
       return child as unknown as ChildProcess;
     },
     logger: { info() {}, warn() {}, error() {} },
     timer,
     environment: { ANDROID_HOME: "/sdk" },
+    platform: "linux",
     ...overrides
   });
   return { client, child, timer, calls };
@@ -86,7 +87,8 @@ describe("AvdManagerClient", () => {
 
   test("uses the Windows batch executable when that is the resolved tool", async () => {
     const { client, child, calls } = createClient({
-      existsSync: path => path.endsWith("avdmanager.bat") || path.endsWith("system-images")
+      existsSync: path => path.endsWith("avdmanager.bat") || path.endsWith("system-images"),
+      platform: "win32"
     });
     const pending = client.listDeviceImages();
     await new Promise<void>(resolve => setImmediate(resolve));
@@ -94,6 +96,7 @@ describe("AvdManagerClient", () => {
 
     await expect(pending).resolves.toEqual([]);
     expect(calls[0]?.command).toBe("/sdk/cmdline-tools/latest/bin/avdmanager.bat");
+    expect(calls[0]).toMatchObject({ args: ["list", "avd"], shell: true });
   });
 
   test("requires avdmanager without coupling AVD operations to sdkmanager", async () => {

--- a/test/utils/android-cmdline-tools/AvdManagerClient.test.ts
+++ b/test/utils/android-cmdline-tools/AvdManagerClient.test.ts
@@ -98,9 +98,9 @@ describe("AvdManagerClient", () => {
     child.close(0);
 
     await expect(pending).resolves.toEqual([]);
+    expect(normalizePath(calls[0]?.args[4] ?? "")).toBe('"/sdk/cmdline-tools/latest/bin/avdmanager.bat" "list" "avd"');
     expect(calls[0]).toMatchObject({
       command: "cmd.exe",
-      args: ["/d", "/v:off", "/s", "/c", '"/sdk/cmdline-tools/latest/bin/avdmanager.bat" "list" "avd"'],
       shell: false
     });
   });

--- a/test/utils/android-cmdline-tools/AvdManagerClient.test.ts
+++ b/test/utils/android-cmdline-tools/AvdManagerClient.test.ts
@@ -3,6 +3,8 @@ import type { ChildProcess } from "node:child_process";
 import { AvdManagerClient } from "../../../src/utils/android-cmdline-tools/AvdManagerClient";
 import { FakeTimer } from "../../fakes/FakeTimer";
 
+const normalizePath = (value: string): string => value.replace(/\\/g, "/");
+
 class FakeChild {
   readonly stdout = { on: (_event: string, callback: (data: Buffer) => void) => { this.stdoutCallback = callback; } };
   readonly stderr = { on: (_event: string, callback: (data: Buffer) => void) => { this.stderrCallback = callback; } };
@@ -75,12 +77,13 @@ describe("AvdManagerClient", () => {
     await expect(pending).resolves.toMatchObject({ success: true });
     expect(calls).toHaveLength(1);
     expect(calls[0]).toMatchObject({
-      command: "/sdk/cmdline-tools/latest/bin/avdmanager",
       args: [
         "create", "avd", "-n", "pixel; touch should-not-run", "-k",
         "system-images;android-36;google_apis;x86_64", "-p", "/tmp/AVD name;$(nope)"
       ]
     });
+    expect(typeof calls[0]?.command).toBe("string");
+    expect(normalizePath(calls[0]?.command as string)).toBe("/sdk/cmdline-tools/latest/bin/avdmanager");
     expect(child.stdinWrites).toEqual(["\n"]);
     expect(child.stdinEnded).toBe(true);
   });
@@ -95,7 +98,7 @@ describe("AvdManagerClient", () => {
     child.close(0);
 
     await expect(pending).resolves.toEqual([]);
-    expect(calls[0]?.command).toBe("/sdk/cmdline-tools/latest/bin/avdmanager.bat");
+    expect(normalizePath(calls[0]?.command ?? "")).toBe("/sdk/cmdline-tools/latest/bin/avdmanager.bat");
     expect(calls[0]).toMatchObject({ args: ["list", "avd"], shell: true });
   });
 

--- a/test/utils/android-cmdline-tools/AvdManagerClient.test.ts
+++ b/test/utils/android-cmdline-tools/AvdManagerClient.test.ts
@@ -88,7 +88,7 @@ describe("AvdManagerClient", () => {
     expect(child.stdinEnded).toBe(true);
   });
 
-  test("uses the Windows batch executable when that is the resolved tool", async () => {
+  test("executes a Windows batch file through cmd without enabling a shell", async () => {
     const { client, child, calls } = createClient({
       existsSync: path => path.endsWith("avdmanager.bat") || path.endsWith("system-images"),
       platform: "win32"
@@ -98,8 +98,46 @@ describe("AvdManagerClient", () => {
     child.close(0);
 
     await expect(pending).resolves.toEqual([]);
-    expect(normalizePath(calls[0]?.command ?? "")).toBe("/sdk/cmdline-tools/latest/bin/avdmanager.bat");
-    expect(calls[0]).toMatchObject({ args: ["list", "avd"], shell: true });
+    expect(calls[0]).toMatchObject({
+      command: "cmd.exe",
+      args: ["/d", "/v:off", "/s", "/c", '"/sdk/cmdline-tools/latest/bin/avdmanager.bat" "list" "avd"'],
+      shell: false
+    });
+  });
+
+  test("quotes Windows batch arguments before passing them to cmd", async () => {
+    const { client, child, calls } = createClient({
+      existsSync: path => path.endsWith("avdmanager.bat") || path.endsWith("system-images"),
+      platform: "win32"
+    });
+    const pending = client.createAvd({
+      name: "pixel & echo injected %PATH%!",
+      package: "system-images;android-36;google_apis;x86_64",
+      path: "C:\\AVDs\\with & percent%"
+    });
+    await new Promise<void>(resolve => setImmediate(resolve));
+    child.close(0);
+
+    await expect(pending).resolves.toMatchObject({ success: true });
+    expect(calls[0]?.shell).toBe(false);
+    expect(calls[0]?.args.at(-1)).toContain('"pixel & echo injected %%PATH%%!"');
+    expect(calls[0]?.args.at(-1)).toContain('"C:\\AVDs\\with & percent%%"');
+  });
+
+  test("rejects Windows batch arguments that could terminate quoting", async () => {
+    const { client, calls } = createClient({
+      existsSync: path => path.endsWith("avdmanager.bat") || path.endsWith("system-images"),
+      platform: "win32"
+    });
+
+    await expect(client.createAvd({
+      name: 'pixel" & echo injected',
+      package: "system-images;android-36;google_apis;x86_64"
+    })).resolves.toMatchObject({
+      success: false,
+      message: expect.stringContaining("cannot contain Windows command-line quotes or newlines")
+    });
+    expect(calls).toEqual([]);
   });
 
   test("requires avdmanager without coupling AVD operations to sdkmanager", async () => {


### PR DESCRIPTION
## Summary

Centralizes `avdmanager` resolution and execution in an injected `AvdManagerClient` while retaining the existing service and functional APIs as migration facades. The client uses argv for dynamic AVD values, owns environment resolution, stdin, timeouts, cancellation cleanup, Windows batch resolution, and actionable Homebrew/JAXB diagnostics. A source-scan guard prevents new direct production execution outside this owner.

## Linked Issue

Closes #4051

## Validation

- [x] `bun run lint`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run turbo:validate` (8,132 passing tests; 11 expected device-dependent skips)
- [x] New code uses injected dependencies, fakes, and `FakeTimer`; focused unit tests remain fast
- [x] Rebased onto latest `main`, conflicts resolved

## Device Verification

Not applicable: this is a host-side command-client refactor covered by fake-process unit tests.
