### PR TITLE
fix(tooling): harden simctl boundary ratchet

### DIFF
--- a/scripts/check-no-new-direct-simctl.sh
+++ b/scripts/check-no-new-direct-simctl.sh
@@ -10,14 +10,22 @@ owner="src/utils/ios-cmdline-tools/SimCtlClient.ts"
 violations=()
 
 if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
-  printf 'Cannot check new simctl calls: base ref %s does not exist.\n' "$base_ref" >&2
-  exit 2
+  # GitHub Actions checks out a PR merge commit without retaining origin/main.
+  # Its first parent is the checked-out base, so retain the ratchet in CI
+  # instead of silently skipping it. Non-CI callers still fail closed.
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]] && git rev-parse --verify --quiet 'HEAD^1^{commit}' >/dev/null; then
+    base_ref='HEAD^1'
+  else
+    printf 'Cannot check new simctl calls: base ref %s does not exist.\n' "$base_ref" >&2
+    exit 2
+  fi
 fi
 
 # Newlines are normalized below so argv calls formatted over multiple lines are
-# checked as one expression. `execFile`/`spawn` only match when their xcrun argv
-# begins with `simctl`, avoiding unrelated xcrun tools such as `devicectl`.
-pattern='((spawn|execFile)\([[:space:]]*"xcrun"[[:space:]]*,[[:space:]]*\[[[:space:]]*"simctl"|exec\([^)]*"xcrun simctl|"/bin/sh".*xcrun simctl)'
+# checked as one expression. Block all direct xcrun argv calls outside the
+# owner: variable argv values cannot be proven to be non-simctl statically,
+# and the conservative boundary prevents an easy bypass.
+pattern='((spawn|execFile)\([[:space:]]*"xcrun"|exec\([^)]*"xcrun simctl|"/bin/sh".*xcrun simctl)'
 
 while IFS= read -r file; do
   [[ "$file" == "$owner" ]] && continue

--- a/scripts/check-no-new-direct-simctl.sh
+++ b/scripts/check-no-new-direct-simctl.sh
@@ -8,22 +8,26 @@ set -euo pipefail
 base_ref="${1:-origin/main}"
 owner="src/utils/ios-cmdline-tools/SimCtlClient.ts"
 violations=()
-# An argv-form xcrun execution is also forbidden outside the owner. The strict
-# xcrun match deliberately covers future simctl calls even when the argv array
-# is split across multiple added lines.
-pattern='(spawn\([[:space:]]*"xcrun"|execFile\([^)]*"xcrun"|exec\([^)]*"xcrun simctl|"/bin/sh".*xcrun simctl)'
+
+if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
+  printf 'Cannot check new simctl calls: base ref %s does not exist.\n' "$base_ref" >&2
+  exit 2
+fi
+
+# Newlines are normalized below so argv calls formatted over multiple lines are
+# checked as one expression. `execFile`/`spawn` only match when their xcrun argv
+# begins with `simctl`, avoiding unrelated xcrun tools such as `devicectl`.
+pattern='((spawn|execFile)\([[:space:]]*"xcrun"[[:space:]]*,[[:space:]]*\[[[:space:]]*"simctl"|exec\([^)]*"xcrun simctl|"/bin/sh".*xcrun simctl)'
 
 while IFS= read -r file; do
   [[ "$file" == "$owner" ]] && continue
   [[ "$file" == test/* ]] && continue
 
-  added_lines="$(git diff --unified=0 "$base_ref" -- "$file" | awk '/^\+[^+]/ { print substr($0, 2) }')"
+  added_lines="$(git diff --unified=0 "$base_ref" -- "$file" | awk '/^\+[^+]/ { printf "%s ", substr($0, 2) }')"
   [[ -z "$added_lines" ]] && continue
 
-  if grep -nE "$pattern" <<<"$added_lines" >/dev/null; then
-    while IFS= read -r match; do
-      violations+=("$file:$match")
-    done < <(grep -nE "$pattern" <<<"$added_lines")
+  if grep -Eq "$pattern" <<<"$added_lines"; then
+    violations+=("$file")
   fi
 done < <(git diff --name-only "$base_ref" -- src)
 

--- a/scripts/check-no-new-direct-simctl.sh
+++ b/scripts/check-no-new-direct-simctl.sh
@@ -10,12 +10,15 @@ owner="src/utils/ios-cmdline-tools/SimCtlClient.ts"
 violations=()
 
 if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
-  # GitHub Actions checks out a PR merge commit without retaining origin/main.
-  # Its first parent is the checked-out base, so retain the ratchet in CI
-  # instead of silently skipping it. Non-CI callers still fail closed.
-  if [[ "${GITHUB_ACTIONS:-}" == "true" ]] && git rev-parse --verify --quiet 'HEAD^1^{commit}' >/dev/null; then
-    base_ref='HEAD^1'
-  else
+  # pull_request checkouts are shallow by default, so neither origin/main nor
+  # HEAD^1 is guaranteed to exist. Fetch the actual PR base before comparing.
+  if [[ "$base_ref" == 'origin/main' && "${GITHUB_ACTIONS:-}" == 'true' && -n "${GITHUB_BASE_REF:-}" ]]; then
+    base_ref="origin/$GITHUB_BASE_REF"
+    git fetch --no-tags --depth=1 origin \
+      "refs/heads/$GITHUB_BASE_REF:refs/remotes/origin/$GITHUB_BASE_REF"
+  fi
+
+  if ! git rev-parse --verify --quiet "${base_ref}^{commit}" >/dev/null; then
     printf 'Cannot check new simctl calls: base ref %s does not exist.\n' "$base_ref" >&2
     exit 2
   fi

--- a/test/bats/check-no-new-direct-simctl.bats
+++ b/test/bats/check-no-new-direct-simctl.bats
@@ -25,3 +25,20 @@ teardown() {
   [ "$status" -eq 1 ]
   [[ "$output" == *"bypass.ts"* ]]
 }
+
+@test "rejects a multiline argv-form xcrun simctl execution" {
+  printf '%s\n' 'execFile(' '  "xcrun",' '  [' '    "simctl",' '    "list",' '    "devices",' '  ],' ');' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-simctl.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
+@test "fails closed when the base ref is absent" {
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-simctl.sh origin/main' _ "$repo_dir"
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"base ref origin/main does not exist"* ]]
+}

--- a/test/bats/check-no-new-direct-simctl.bats
+++ b/test/bats/check-no-new-direct-simctl.bats
@@ -10,6 +10,7 @@ setup() {
   touch "$repo_dir/src/existing.ts"
   git -C "$repo_dir" add .
   git -C "$repo_dir" commit -qm baseline
+  git -C "$repo_dir" commit --allow-empty -qm head
 }
 
 teardown() {
@@ -36,9 +37,25 @@ teardown() {
   [[ "$output" == *"bypass.ts"* ]]
 }
 
+@test "rejects a variable argv-form xcrun simctl execution" {
+  printf '%s\n' 'const args = ["simctl", "list", "devices"];' 'execFile("xcrun", args);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-simctl.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
 @test "fails closed when the base ref is absent" {
   run bash -c 'cd "$1" && bash scripts/check-no-new-direct-simctl.sh origin/main' _ "$repo_dir"
 
   [ "$status" -eq 2 ]
   [[ "$output" == *"base ref origin/main does not exist"* ]]
+}
+
+@test "uses the PR merge base in GitHub Actions when origin main is absent" {
+  run bash -c 'cd "$1" && GITHUB_ACTIONS=true bash scripts/check-no-new-direct-simctl.sh' _ "$repo_dir"
+
+  [ "$status" -eq 0 ]
 }

--- a/test/bats/check-no-new-direct-simctl.bats
+++ b/test/bats/check-no-new-direct-simctl.bats
@@ -15,6 +15,7 @@ setup() {
 
 teardown() {
   rm -rf "$repo_dir"
+  rm -rf "${remote_dir:-}" "${shallow_dir:-}"
 }
 
 @test "rejects a new argv-form xcrun execution" {
@@ -54,8 +55,28 @@ teardown() {
   [[ "$output" == *"base ref origin/main does not exist"* ]]
 }
 
-@test "uses the PR merge base in GitHub Actions when origin main is absent" {
-  run bash -c 'cd "$1" && GITHUB_ACTIONS=true bash scripts/check-no-new-direct-simctl.sh' _ "$repo_dir"
+@test "fetches the GitHub Actions PR base from a depth-one checkout" {
+  remote_dir="$(mktemp -d)"
+  shallow_dir="$(mktemp -d)"
+  git -C "$repo_dir" branch -M main
+  git -C "$repo_dir" remote add origin "$remote_dir"
+  git -C "$remote_dir" init --bare -q
+  git -C "$repo_dir" push -q origin main
+  git -C "$repo_dir" checkout -qb feature
+  printf '%s\n' 'export const noop = true;' > "$repo_dir/src/change.ts"
+  git -C "$repo_dir" add src/change.ts
+  git -C "$repo_dir" commit -qm feature
+  git -C "$repo_dir" push -q origin feature
+  rmdir "$shallow_dir"
+  git clone --depth 1 --branch feature -q "file://$remote_dir" "$shallow_dir"
+
+  run git -C "$shallow_dir" rev-parse --verify --quiet 'HEAD^1^{commit}'
+  [ "$status" -ne 0 ]
+  run git -C "$shallow_dir" rev-parse --verify --quiet 'origin/main^{commit}'
+  [ "$status" -ne 0 ]
+
+  run bash -c 'cd "$1" && GITHUB_ACTIONS=true GITHUB_BASE_REF=main bash scripts/check-no-new-direct-simctl.sh' _ "$shallow_dir"
 
   [ "$status" -eq 0 ]
+  git -C "$shallow_dir" rev-parse --verify --quiet 'origin/main^{commit}'
 }


### PR DESCRIPTION
## Summary

Fixes the two unresolved review findings from #4071: the SimCtl boundary ratchet now detects multiline argv-form `execFile`/`spawn` calls and fails closed when its comparison base ref is unavailable.

## Linked Issue

Follow-up to #4071.

## Validation

- [x] `bats test/bats/check-no-new-direct-simctl.bats`
- [x] `shellcheck scripts/check-no-new-direct-simctl.sh`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] Rebased onto latest `main`, conflicts resolved
