### PR TITLE
fix(android): quote Windows avdmanager command

### DIFF
--- a/src/utils/android-cmdline-tools/AvdManagerClient.ts
+++ b/src/utils/android-cmdline-tools/AvdManagerClient.ts
@@ -252,7 +252,7 @@ export class AvdManagerClient {
       return { command: path, args };
     }
 
-    const command = [quoteForWindowsCmd(path), ...args.map(quoteForWindowsCmd)].join(" ");
+    const command = `"${[quoteForWindowsCmd(path), ...args.map(quoteForWindowsCmd)].join(" ")}"`;
     return {
       command: environment?.ComSpec ?? environment?.COMSPEC ?? "cmd.exe",
       args: ["/d", "/v:off", "/s", "/c", command],

--- a/test/utils/android-cmdline-tools/AvdManagerClient.test.ts
+++ b/test/utils/android-cmdline-tools/AvdManagerClient.test.ts
@@ -90,6 +90,11 @@ describe("AvdManagerClient", () => {
 
   test("executes a Windows batch file through cmd without enabling a shell", async () => {
     const { client, child, calls } = createClient({
+      detectAndroidCommandLineTools: async () => [{
+        path: "/Program Files/Android/Sdk/cmdline-tools/latest",
+        source: "manual",
+        available_tools: ["avdmanager"]
+      }],
       existsSync: path => path.endsWith("avdmanager.bat") || path.endsWith("system-images"),
       platform: "win32"
     });
@@ -98,7 +103,7 @@ describe("AvdManagerClient", () => {
     child.close(0);
 
     await expect(pending).resolves.toEqual([]);
-    expect(normalizePath(calls[0]?.args[4] ?? "")).toBe('"/sdk/cmdline-tools/latest/bin/avdmanager.bat" "list" "avd"');
+    expect(normalizePath(calls[0]?.args[4] ?? "")).toBe('""/Program Files/Android/Sdk/cmdline-tools/latest/bin/avdmanager.bat" "list" "avd""');
     expect(calls[0]).toMatchObject({
       command: "cmd.exe",
       shell: false


### PR DESCRIPTION
Fixes the Windows batch invocation identified after #4073 merged.

The `cmd /s /c` command string is outer-wrapped so SDK paths containing spaces retain their executable quoting.

Validation:
- `bun test test/utils/android-cmdline-tools/AvdManagerClient.test.ts test/lint/avdManagerExecutionBoundary.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run turbo:validate`
