### PR TITLE
ci: make diagnostic log/heap uploads non-fatal (#4083)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -670,6 +670,7 @@ jobs:
 
       - name: "Upload Fast Validation Logs"
         if: failure()
+        continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
           name: fast-validation-logs
@@ -813,6 +814,7 @@ jobs:
 
       - name: "Upload Logs"
         if: env.RUN_INSTALLER == 'true' && (env.INSTALL_EXIT_CODE != '0' || env.UNINSTALL_EXIT_CODE != '0' || failure())
+        continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
           name: installer-minimal-${{ matrix.os }}-logs
@@ -882,6 +884,7 @@ jobs:
 
       - name: "Upload Logs"
         if: env.RUN_INSTALLER == 'true' && (steps.run-installer-development.outputs.install_exit_code != '0' || failure())
+        continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
           name: installer-development-${{ matrix.os }}-logs
@@ -1070,6 +1073,7 @@ jobs:
 
       - name: "Upload Build/Test Logs"
         if: env.RUN_MCP_BUILD_TEST == 'true' && (failure() || cancelled() || matrix.os == 'windows-latest')
+        continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
           name: mcp-build-test-logs-${{ matrix.os }}
@@ -1095,6 +1099,7 @@ jobs:
 
       - name: "Upload Heap Snapshots"
         if: failure()
+        continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
           name: heap-snapshots
@@ -1198,6 +1203,7 @@ jobs:
 
       - name: "Upload Build/Test Logs"
         if: failure() || cancelled()
+        continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
           name: mcp-build-test-logs-ubuntu-latest
@@ -1620,6 +1626,7 @@ jobs:
       # is required because the logs live under the dot-dir ~/.auto-mobile.
       - name: "Upload AutoMobile daemon logs"
         if: failure()
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: automobile-daemon-logs-xctestrunner
@@ -1681,6 +1688,7 @@ jobs:
           release-key-password: ${{ secrets.RELEASE_KEY_PASSWORD }}
       - name: "Upload Heap Dumps"
         if: failure()
+        continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
           name: junit-runner-heap-dumps-unit
@@ -1709,6 +1717,7 @@ jobs:
 
       - name: "Upload Compatibility Logs"
         if: failure()
+        continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
           name: junit-runner-kotlin-consumer-compatibility-logs
@@ -1750,6 +1759,7 @@ jobs:
           release-key-password: ${{ secrets.RELEASE_KEY_PASSWORD }}
       - name: "Upload Heap Dumps"
         if: failure()
+        continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
           name: junit-runner-heap-dumps-emulator
@@ -1826,6 +1836,7 @@ jobs:
 
       - name: "Upload Heap Dumps"
         if: failure()
+        continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
           name: junit-runner-emulator-wtf-heap-dumps

--- a/test/bats/diagnostic-log-upload-nonfatal.bats
+++ b/test/bats/diagnostic-log-upload-nonfatal.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+#
+# Guards issue #4083: a transient GitHub egress flap on a *diagnostic* artifact
+# upload (ENOTFOUND while running actions/upload-artifact) must not turn an
+# otherwise-green job red. The build and tests have already run by the time logs
+# or heap dumps are uploaded; their upload is best-effort diagnostics.
+#
+# Observed failure (Node TypeScript Build and Test, windows-latest):
+#   Upload Build/Test Logs | ##[error]Failed to CreateArtifact: ... ENOTFOUND
+#
+# Every step in pull_request.yml whose name marks it as a diagnostic upload
+# (Logs / Heap Snapshots / Heap Dumps) must carry `continue-on-error: true`.
+# Functional-deliverable uploads (APK, coverage badges, plugin ZIP, test-result
+# bundles that feed a report gate) are intentionally excluded -- their upload
+# failing is meaningful.
+
+WORKFLOW=".github/workflows/pull_request.yml"
+
+# Print, one per line, "<name>|<has_continue_on_error>" for every step whose
+# name matches a diagnostic-upload pattern. A step block runs from its
+# "      - name:" line to the next step start ("      - ") or a step-indent
+# comment ("      #"). awk, not sed -- BSD sed lacks the range forms this needs.
+diagnostic_upload_steps() {
+  awk '
+    function flush() {
+      if (name != "" && block ~ /upload-artifact/ &&
+          name ~ /Upload .*(Logs|Heap Snapshots|Heap Dumps)/) {
+        printf "%s|%s\n", name, (block ~ /continue-on-error: true/ ? "yes" : "no")
+      }
+      name = ""; block = ""
+    }
+    /^      [-#]/ { flush() }
+    /^      - name:/ {
+      line = $0
+      sub(/^[^"]*"/, "", line); sub(/".*$/, "", line)
+      name = line
+    }
+    { block = block $0 "\n" }
+    END { flush() }
+  ' "$WORKFLOW"
+}
+
+@test "diagnostic upload steps are present in pull_request.yml" {
+  run diagnostic_upload_steps
+  [ "$status" -eq 0 ]
+  # Sanity floor: we expect at least the known diagnostic upload sites.
+  [ "$(echo "$output" | grep -c .)" -ge 8 ]
+}
+
+@test "every diagnostic log/heap upload is continue-on-error: true" {
+  local offenders
+  offenders="$(diagnostic_upload_steps | grep '|no$' || true)"
+  if [ -n "$offenders" ]; then
+    echo "Diagnostic upload steps missing 'continue-on-error: true':" >&2
+    echo "$offenders" >&2
+  fi
+  [ -z "$offenders" ]
+}

--- a/test/bats/workflow-artifact-name-uniqueness.bats
+++ b/test/bats/workflow-artifact-name-uniqueness.bats
@@ -146,11 +146,16 @@ YAML
 @test "junit-runner heap dump uploads stay failure-gated and tolerant" {
   # The rename must not disturb the surrounding step wiring: these dumps only
   # exist after a crash, so an unconditional upload would warn on every run.
+  # Tolerant now also means continue-on-error (issue #4083): a diagnostic
+  # upload flaking on a transient egress error must not red the job. The window
+  # spans the four step keys above the artifact `name:` (if / continue-on-error
+  # / uses / with).
   block="$(awk '
-    /name: junit-runner-heap-dumps/ { print prev3 "\n" prev2 "\n" prev1 "\n" $0 }
-    { prev3 = prev2; prev2 = prev1; prev1 = $0 }
+    /name: junit-runner-heap-dumps/ { print prev4 "\n" prev3 "\n" prev2 "\n" prev1 "\n" $0 }
+    { prev4 = prev3; prev3 = prev2; prev2 = prev1; prev1 = $0 }
   ' ".github/workflows/pull_request.yml")"
   [ -n "$block" ]
   [ "$(echo "$block" | grep -c 'if: failure()')" -eq 2 ]
+  [ "$(echo "$block" | grep -c 'continue-on-error: true')" -eq 2 ]
   [ "$(echo "$block" | grep -c 'uses: actions/upload-artifact@v[0-9]')" -eq 2 ]
 }


### PR DESCRIPTION
Closes #4083.

## Problem

A `Node TypeScript Build and Test (windows-latest)` job failed on its **log-upload** step — not on any build or test:

```
Upload Build/Test Logs | ##[error]Failed to CreateArtifact: Unable to make request: ENOTFOUND
```

The build and tests had already passed; a transient GitHub egress flap on a diagnostic-artifact upload reddened an otherwise-green job.

## Change

Add `continue-on-error: true` to every **diagnostic** upload step in `pull_request.yml` — Logs, Heap Snapshots, Heap Dumps (11 steps). Their upload failing is best-effort and should never fail a build.

**Left fatal on purpose:** functional-deliverable uploads (CtrlProxy APK, coverage badges, IDE plugin ZIP, test-result bundles that feed a Publish Test Report gate) — their upload failing is meaningful.

## Test

`test/bats/diagnostic-log-upload-nonfatal.bats` asserts every step named `Upload … (Logs|Heap Snapshots|Heap Dumps)` carries `continue-on-error: true`. Verified non-vacuous: reverting a single guard fails the test. This also locks the invariant so future diagnostic uploads inherit the protection.