### PR TITLE
fix(ci): repair simctl-ratchet bats test that reds all PR CI (#4074 follow-up)

### DIFF
--- a/test/bats/check-no-new-direct-simctl.bats
+++ b/test/bats/check-no-new-direct-simctl.bats
@@ -49,7 +49,12 @@ teardown() {
 }
 
 @test "fails closed when the base ref is absent" {
-  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-simctl.sh origin/main' _ "$repo_dir"
+  # Neutralize the CI environment: on a GitHub Actions runner GITHUB_ACTIONS
+  # and GITHUB_BASE_REF are set, which would send the script down its
+  # fetch-the-PR-base branch (and die at `git fetch` in this remote-less temp
+  # repo, exit 128) instead of the fail-closed path this test exercises.
+  run env -u GITHUB_ACTIONS -u GITHUB_BASE_REF \
+    bash -c 'cd "$1" && bash scripts/check-no-new-direct-simctl.sh origin/main' _ "$repo_dir"
 
   [ "$status" -eq 2 ]
   [[ "$output" == *"base ref origin/main does not exist"* ]]


### PR DESCRIPTION
## Blocker

PR #4074 (`fix(tooling): harden simctl boundary ratchet`) merged to main with a bats test — `check-no-new-direct-simctl.bats` → *"fails closed when the base ref is absent"* — that **passes locally but fails on every GitHub Actions runner**. Since PR CI runs the merge-commit (PR branch + current main), **every open PR now fails Fast Validation + BATS Shell Tests** and cannot merge. Main's own `On Merge` was green (full checkout, different check set), which is why it landed.

## Root cause

On a runner, `GITHUB_ACTIONS=true` and `GITHUB_BASE_REF` are set. The script's absent-base-ref handler then takes its *fetch-the-PR-base* branch:

```sh
if [[ "$base_ref" == 'origin/main' && "${GITHUB_ACTIONS:-}" == 'true' && -n "${GITHUB_BASE_REF:-}" ]]; then
  base_ref="origin/$GITHUB_BASE_REF"
  git fetch --no-tags --depth=1 origin "refs/heads/$GITHUB_BASE_REF:refs/remotes/origin/$GITHUB_BASE_REF"
fi
```

The test's temp repo has no `origin` remote, so `git fetch` dies (`exit 128`) instead of reaching the `exit 2` the test asserts. Locally the two env vars are unset, the branch is skipped, and the test passes — hence local-green / CI-red.

```
-- CI env (GITHUB_ACTIONS=true GITHUB_BASE_REF=main) --
fatal: 'origin' does not appear to be a git repository
exit=128        # test asserts 2 -> FAIL
-- env neutralized --
Cannot check new simctl calls: base ref origin/main does not exist.
exit=2          # PASS
```

## Fix

Run the script under `env -u GITHUB_ACTIONS -u GITHUB_BASE_REF` in that one test so it deterministically exercises the fail-closed path regardless of environment. **Script behavior is unchanged.** The sibling test *"fetches the GitHub Actions PR base from a depth-one checkout"* already sets the GH env explicitly and covers the fetch path.

Verified all 5 tests pass both plain and under simulated CI env (`GITHUB_ACTIONS=true GITHUB_BASE_REF=main bats …`).