### PR TITLE
ci(ios): bound simulator boot + fail fast on a wedged boot (#4078)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1580,6 +1580,10 @@ jobs:
 
       - name: "Boot iOS Simulator (Xcode 26.5)"
         if: ${{ !cancelled() }}
+        # A wedged simulator boot has stalled this step ~30 min, pushing the job
+        # past its 45-min cap (issue #4078). Bound it well above the observed p95
+        # (~9 min) so a real slow boot still passes but a hang fails here.
+        timeout-minutes: 15
         run: ./scripts/ios/boot-simulator.sh
 
       - name: "Run videoRecording MP4 integration test"

--- a/scripts/ios/boot-simulator.sh
+++ b/scripts/ios/boot-simulator.sh
@@ -126,7 +126,23 @@ DEVICE_NAME=$(xcrun simctl list devices available -j \
     ')
 
 echo "Ensuring ${DEVICE_NAME} (${UDID}) is booted..." >&2
-xcrun simctl bootstatus "${UDID}" -b >&2
+
+# bootstatus can "Finish" with an internal failure status -- e.g. it stalls in
+# "Waiting on System App" for tens of minutes and then reports
+# "Status=4294967295, isTerminal=YES" -- while still exiting 0. Pressing on
+# would print "Booted:" for a wedged simulator that hangs every downstream step
+# (issue #4078). Capture the outcome and treat a failing exit OR that terminal
+# error status as a hard boot failure.
+set +e
+boot_log="$(xcrun simctl bootstatus "${UDID}" -b 2>&1)"
+boot_rc=$?
+set -e
+printf '%s\n' "${boot_log}" >&2
+
+if [[ ${boot_rc} -ne 0 ]] || printf '%s' "${boot_log}" | grep -q 'Status=4294967295'; then
+  echo "error: simulator ${UDID} failed to boot (bootstatus rc=${boot_rc})" >&2
+  exit 1
+fi
 
 echo "Booted: ${DEVICE_NAME} (${UDID})" >&2
 

--- a/test/bats/boot-simulator.bats
+++ b/test/bats/boot-simulator.bats
@@ -97,6 +97,55 @@ SCRIPT
   grep -q '.identifier' "$SCRIPT"
 }
 
+@test "fails when bootstatus reports a wedged boot (Status=4294967295) but exits 0" {
+  # Regression for #4078: a stalled boot can print a terminal error status and
+  # still exit 0. The script must not report "Booted:" and press on.
+  cat > "${MOCK_BIN}/xcrun" <<'SCRIPT'
+#!/bin/sh
+if [ "$1" = "--sdk" ] && [ "$2" = "iphonesimulator" ] && [ "$3" = "--show-sdk-version" ]; then
+  echo "26.2"
+elif [ "$1" = "simctl" ] && [ "$2" = "list" ] && [ "$3" = "runtimes" ]; then
+  echo '{"runtimes":[{"version":"26.2.0","identifier":"com.apple.CoreSimulator.SimRuntime.iOS-26-2"}]}'
+elif [ "$1" = "simctl" ] && [ "$2" = "list" ] && [ "$3" = "devices" ]; then
+  echo '{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-26-2":[{"name":"iPhone 17 Pro","udid":"WEDGED-UDID","state":"Shutdown"}]}}'
+elif [ "$1" = "simctl" ] && [ "$2" = "bootstatus" ]; then
+  # Wedged boot: prints a terminal failure status yet exits 0.
+  echo "[2026-07-20 15:00:16 +0000] Status=4294967295, isTerminal=YES, Elapsed=32:06."
+  echo "	Finished"
+  exit 0
+fi
+SCRIPT
+  chmod +x "${MOCK_BIN}/xcrun"
+  export PATH="${MOCK_BIN}:${PATH}"
+
+  run bash "$SCRIPT" --ios-version 26.2
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"failed to boot"* ]]
+  [[ "$output" != *"Booted: "* ]]
+}
+
+@test "fails when bootstatus exits non-zero" {
+  cat > "${MOCK_BIN}/xcrun" <<'SCRIPT'
+#!/bin/sh
+if [ "$1" = "--sdk" ] && [ "$2" = "iphonesimulator" ] && [ "$3" = "--show-sdk-version" ]; then
+  echo "26.2"
+elif [ "$1" = "simctl" ] && [ "$2" = "list" ] && [ "$3" = "runtimes" ]; then
+  echo '{"runtimes":[{"version":"26.2.0","identifier":"com.apple.CoreSimulator.SimRuntime.iOS-26-2"}]}'
+elif [ "$1" = "simctl" ] && [ "$2" = "list" ] && [ "$3" = "devices" ]; then
+  echo '{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-26-2":[{"name":"iPhone 17 Pro","udid":"FAIL-UDID","state":"Shutdown"}]}}'
+elif [ "$1" = "simctl" ] && [ "$2" = "bootstatus" ]; then
+  echo "bootstatus: device failed to boot" >&2
+  exit 164
+fi
+SCRIPT
+  chmod +x "${MOCK_BIN}/xcrun"
+  export PATH="${MOCK_BIN}:${PATH}"
+
+  run bash "$SCRIPT" --ios-version 26.2
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"failed to boot"* ]]
+}
+
 @test "uses bootstatus -b so already-booted simulators are accepted" {
   cat > "${MOCK_BIN}/xcrun" <<'SCRIPT'
 #!/bin/sh


### PR DESCRIPTION
Addresses the timeout portion of #4078.

## Problem

`XCTestRunner Simulator Tests` hit its 45-min job cap 3× (2026-07-15). Root cause: `Boot iOS Simulator (Xcode 26.5)` has **no `timeout-minutes`**, and a wedged boot stalled it ~30 min:

```
Status=0        Booting
Status=4        Waiting on System App
Status=4294967295, isTerminal=YES, Elapsed=32:06.  Finished
```

`bootstatus` reported that terminal **error** status but still **exited 0**, so `boot-simulator.sh` printed `Booted:` and every downstream step ran against a dead simulator until the job cap killed it.

## Change

Two independent guards:

1. **`scripts/ios/boot-simulator.sh`** captures the `bootstatus` outcome and treats a non-zero exit **or** the `Status=4294967295` terminal error as a hard boot failure — instead of printing `Booted:` and pressing on. Covers both boot call sites (foreground + the background CtrlProxy boot).
2. **`timeout-minutes: 15`** on the foreground `Boot iOS Simulator (Xcode 26.5)` step (well above the ~9-min p95, below the 45-min cap) so the boot itself is bounded and a hang fails *at the boot step* rather than 30 min into the job.

Scope note: I left the background `Boot iOS Simulator for CtrlProxy UI tests` step's `background: true` wiring untouched (step-level `timeout-minutes` semantics on a background step are murky, and its consumer UI-test step already carries its own timeout); the script-level guard protects it regardless. The matrix-split idea from #4078 is intentionally **not** included here — larger and riskier, worth its own change.

## Test

Two new `boot-simulator.bats` cases — wedged-boot-exits-0 and bootstatus-nonzero — both verified to **fail against the pre-fix script**. All 10 boot-simulator tests + shellcheck pass.

## Validation caveat

The bats cases prove the script logic. The `timeout-minutes` and the real wedge only exercise on an actual runner, so a green PR here confirms the mechanics but not that a live 30-min wedge is now caught — that proves out the next time a boot stalls.