### PR TITLE
fix(ios,video): bounded retry + diagnostics on recordVideo start (#4076)

### DIFF
--- a/src/features/video/FfmpegVideoProcessingBackend.ts
+++ b/src/features/video/FfmpegVideoProcessingBackend.ts
@@ -51,6 +51,13 @@ const IOS_RECORDING_FILE_READY_INITIAL_BACKOFF_MS = 100;
 const IOS_RECORDING_FILE_READY_MAX_BACKOFF_MS = 1000;
 const FFMPEG_POST_PROCESS_TIMEOUT_MS = 60000;
 const IOS_RECORDING_START_TIMEOUT_MS = 30000;
+// A cold or loaded simulator can silently miss the very first `recordVideo`
+// start handshake (#4076): simctl produces no "Recording started" and no error,
+// and the single attempt times out. Retry the start a bounded number of times
+// before failing, capturing simulator state on each miss so a genuine wedge is
+// diagnosable rather than surfacing as a bare timeout.
+const IOS_RECORDING_START_MAX_ATTEMPTS = 2;
+const IOS_RECORDING_DIAGNOSTIC_TIMEOUT_MS = 5000;
 // `simctl` emits this only after processing its first video frame. The earlier
 // "Defaulting to display" diagnostic proves only display selection, which can
 // still produce a zero-byte capture on a cold simulator.
@@ -281,6 +288,9 @@ export async function waitForStderrMessage(
 export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
   private ffmpegPath: string = "ffmpeg";
   private hwAccelCache: Map<string, HardwareAccelInfo> = new Map();
+  // Overridable in tests so the retry path can be exercised without real waits.
+  private readonly iosRecordingStartTimeoutMs: number = IOS_RECORDING_START_TIMEOUT_MS;
+  private readonly iosRecordingStartMaxAttempts: number = IOS_RECORDING_START_MAX_ATTEMPTS;
 
   constructor(
     private readonly adbFactory: AdbClientFactory = defaultAdbClientFactory,
@@ -452,57 +462,99 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
       capturePath,
     ];
 
-    const captureProcess = await simctl.startCommandArgs(args, { stdio: ["ignore", "ignore", "pipe"] });
+    const maxAttempts = Math.max(1, this.iosRecordingStartMaxAttempts);
+    const attemptFailures: string[] = [];
 
-    try {
-      await waitForSpawn(captureProcess);
-    } catch (error) {
-      throw new ActionableError(`Failed to start iOS recording: ${error}`);
-    }
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const captureProcess = await simctl.startCommandArgs(args, { stdio: ["ignore", "ignore", "pipe"] });
 
-    const captureTracker = trackProcess(captureProcess);
-
-    try {
-      await waitForStderrMessage(
-        captureTracker,
-        IOS_RECORDING_START_MESSAGES,
-        IOS_RECORDING_START_TIMEOUT_MS
-      );
-    } catch (error) {
-      let stopError: unknown;
       try {
-        await waitForExit(captureTracker.process, captureTracker.exitPromise);
-      } catch (cleanupError) {
-        stopError = cleanupError;
+        await waitForSpawn(captureProcess);
+      } catch (error) {
+        // A spawn failure is a simctl/environment problem, not a cold-simulator
+        // miss — retrying won't help, so fail fast.
+        throw new ActionableError(`Failed to start iOS recording: ${error}`);
       }
 
-      const cleanupSuffix = stopError
-        ? `; cleanup failed: ${stopError}`
-        : "";
-      throw new ActionableError(
-        this.buildProcessFailureMessage(
-          `Failed to start iOS recording: ${error}${cleanupSuffix}`,
-          "xcrun simctl",
-          args,
-          captureTracker
-        )
-      );
+      const captureTracker = trackProcess(captureProcess);
+
+      try {
+        await waitForStderrMessage(
+          captureTracker,
+          IOS_RECORDING_START_MESSAGES,
+          this.iosRecordingStartTimeoutMs
+        );
+
+        const backendHandle: FfmpegBackendHandle = {
+          kind: "ffmpeg",
+          platform: "ios",
+          captureTracker,
+          capturePath,
+          config,
+        };
+
+        return {
+          recordingId: config.recordingId,
+          outputPath: config.outputPath,
+          startedAt: config.startedAt,
+          backendHandle,
+        };
+      } catch (error) {
+        // The handshake timed out. Tear down this attempt's process, snapshot the
+        // simulator so a genuine wedge is diagnosable, then retry if budget remains.
+        let stopError: unknown;
+        try {
+          await waitForExit(captureTracker.process, captureTracker.exitPromise);
+        } catch (cleanupError) {
+          stopError = cleanupError;
+        }
+
+        const cleanupSuffix = stopError ? `; cleanup failed: ${stopError}` : "";
+        const diagnostics = await this.captureSimulatorDiagnostics(simctl, device);
+        attemptFailures.push(
+          `attempt ${attempt}/${maxAttempts}: ${error}${cleanupSuffix}; ${diagnostics}`
+        );
+        logger.warn(
+          `[FfmpegVideo] iOS recording start attempt ${attempt}/${maxAttempts} failed: ${error} (${diagnostics})`
+        );
+
+        if (attempt >= maxAttempts) {
+          throw new ActionableError(
+            this.buildProcessFailureMessage(
+              `Failed to start iOS recording after ${maxAttempts} attempt(s): ${attemptFailures.join(" | ")}`,
+              "xcrun simctl",
+              args,
+              captureTracker
+            )
+          );
+        }
+      }
     }
 
-    const backendHandle: FfmpegBackendHandle = {
-      kind: "ffmpeg",
-      platform: "ios",
-      captureTracker,
-      capturePath,
-      config,
-    };
+    // Loop always returns or throws above; this satisfies the type checker.
+    throw new ActionableError("Failed to start iOS recording: exhausted start attempts.");
+  }
 
-    return {
-      recordingId: config.recordingId,
-      outputPath: config.outputPath,
-      startedAt: config.startedAt,
-      backendHandle,
-    };
+  /**
+   * Best-effort snapshot of the target simulator's state, used only to enrich a
+   * start-timeout failure. Never throws: a diagnostics failure must not mask the
+   * original recording error.
+   */
+  private async captureSimulatorDiagnostics(
+    simctl: SimCtl,
+    device: BootedDevice
+  ): Promise<string> {
+    try {
+      const result = await simctl.executeCommandArgs(
+        ["list", "devices", device.deviceId],
+        IOS_RECORDING_DIAGNOSTIC_TIMEOUT_MS
+      );
+      const text = (result.stdout || result.stderr || "").replace(/\s+/g, " ").trim();
+      return text ? `simulator state: ${text.slice(0, 500)}` : "simulator state: (empty)";
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      return `simulator state unavailable: ${reason}`;
+    }
   }
 
   private async postProcessRecording(backendHandle: FfmpegBackendHandle): Promise<void> {

--- a/test/features/video/FfmpegVideoProcessingBackend.test.ts
+++ b/test/features/video/FfmpegVideoProcessingBackend.test.ts
@@ -143,6 +143,100 @@ describe("FfmpegVideoProcessingBackend - Unit Tests", function() {
     expect(receivedOptions).toEqual({ stdio: ["ignore", "ignore", "pipe"] });
   });
 
+  // A fake capture process: emits "spawn" then, when asked, the recordVideo start
+  // handshake. kill() emits "exit" so waitForExit's SIGINT teardown resolves.
+  function makeCaptureChild(emitHandshake: boolean): ChildProcess {
+    const stderr = new PassThrough();
+    const child = new EventEmitter() as ChildProcess;
+    Object.assign(child, {
+      stderr,
+      stdout: null,
+      stdin: null,
+      killed: false,
+      kill: () => {
+        (child as unknown as { killed: boolean }).killed = true;
+        queueMicrotask(() => child.emit("exit", 0, "SIGINT"));
+        return true;
+      },
+    });
+    defaultTimer.setTimeout(() => {
+      child.emit("spawn");
+      if (emitHandshake) {
+        stderr.write("Recording started\n");
+      }
+    }, 0);
+    return child;
+  }
+
+  function diagnosticsExecResult(state: string) {
+    return {
+      stdout: state,
+      stderr: "",
+      toString: () => state,
+      trim: () => state,
+      includes: (s: string) => state.includes(s),
+    };
+  }
+
+  test("retries the iOS recording start handshake and succeeds on a later attempt (#4076)", async function() {
+    const started: ChildProcess[] = [];
+    let diagnosticCalls = 0;
+    const simctl = {
+      isAvailable: async () => true,
+      // First attempt never emits the handshake (cold-simulator miss); the retry does.
+      startCommandArgs: async () => {
+        const child = makeCaptureChild(started.length >= 1);
+        started.push(child);
+        return child;
+      },
+      executeCommandArgs: async () => {
+        diagnosticCalls++;
+        return diagnosticsExecResult("iPhone 17 Pro (udid) (Booted)");
+      },
+    } as unknown as SimCtl;
+
+    backend = new FfmpegVideoProcessingBackend(undefined, () => simctl);
+    (backend as any).ensureFfmpegAvailable = async () => {};
+    (backend as any).iosRecordingStartTimeoutMs = 25;
+    mockConfig.device = { ...mockDevice, platform: "ios", deviceId: "ios-retry-udid" };
+
+    const handle = await backend.start(mockConfig);
+
+    expect(handle.recordingId).toBe("test-recording");
+    expect(started.length).toBe(2); // one retry after the first miss
+    expect(diagnosticCalls).toBe(1); // diagnostics captured once, on the miss
+  });
+
+  test("fails after exhausting start attempts and reports simulator diagnostics (#4076)", async function() {
+    let starts = 0;
+    const simctl = {
+      isAvailable: async () => true,
+      startCommandArgs: async () => {
+        starts++;
+        return makeCaptureChild(false); // never emits the handshake
+      },
+      executeCommandArgs: async () => diagnosticsExecResult("iPhone 17 Pro (udid) (Shutdown)"),
+    } as unknown as SimCtl;
+
+    backend = new FfmpegVideoProcessingBackend(undefined, () => simctl);
+    (backend as any).ensureFfmpegAvailable = async () => {};
+    (backend as any).iosRecordingStartTimeoutMs = 25;
+    mockConfig.device = { ...mockDevice, platform: "ios", deviceId: "ios-wedge-udid" };
+
+    let error: Error | undefined;
+    try {
+      await backend.start(mockConfig);
+    } catch (caught) {
+      error = caught as Error;
+    }
+
+    expect(error).toBeDefined();
+    expect(error!.message).toContain("after 2 attempt(s)");
+    expect(error!.message).toContain("simulator state");
+    expect(error!.message).toContain("Shutdown");
+    expect(starts).toBe(2); // exhausted the bounded retry budget
+  });
+
   describe("Hardware Acceleration Detection", function() {
     test("should detect platform capabilities", async function() {
       const osPlatform = platform();


### PR DESCRIPTION
Closes #4076.

## Problem

The `Run videoRecording MP4 integration test` step (`XCTestRunner Simulator Tests`) is the single largest failure bucket for that job — **7 failures in 5 days** — all with the same signature:

```
Failed to start iOS recording: Error: Timed out waiting for Recording started
command: xcrun simctl io <UDID> recordVideo …-raw.mov
exitCode: null   signal: SIGINT   stderr: (empty)
```

A cold or loaded simulator silently misses the first `recordVideo` start handshake: `simctl` emits neither `Recording started` nor an error, so the single attempt times out. The bare timeout was also undiagnosable — empty stderr, no simulator state.

## Change (`startIos`)

- **Bounded retry**: retry the start handshake up to `IOS_RECORDING_START_MAX_ATTEMPTS` (2), tearing down each timed-out attempt's process (SIGINT via `waitForExit`) before the next. A one-off cold-boot miss is absorbed; a genuine break still fails deterministically on every attempt.
- **Diagnostics on miss**: capture a best-effort `simctl list devices <udid>` snapshot on each timeout and fold it into the failure message, so the next occurrence shows whether the simulator was wedged or merely slow. The snapshot never throws — it can't mask the original error.
- **Fail fast on spawn errors**: a spawn failure (vs a handshake miss) is an environment problem; retrying is pointless, so it throws immediately.
- Start timeout + attempt count are injectable so the retry path is unit-tested without real waits.

## Tests

Two new `FfmpegVideoProcessingBackend` tests — retry-then-succeed and exhaust-with-diagnostics — both verified to **fail when attempts are forced back to 1**. Full suite: 35 pass, stable across 3 runs.

## Validation caveat

The unit tests prove the retry/diagnostics logic against fakes. Whether the retry actually eliminates the real-simulator flake can only be confirmed on the CI runners over time — a green PR here validates the mechanics, not the flake's disappearance. Direction 1 of the issue (diagnostics) is now also satisfied, which will make any recurrence far easier to triage.