### PR TITLE
ci(ios): gate Xcode 26.5 leg on shared CtrlProxy build to stop failure cascade (#4082)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1496,6 +1496,7 @@ jobs:
         background: true
 
       - name: "Build CtrlProxy iOS for Testing"
+        id: build-ctrlproxy
         run: ./scripts/ios/ctrl-proxy-build-for-testing.sh
 
       - name: "Verify CtrlProxy iOS Artifacts"
@@ -1569,17 +1570,17 @@ jobs:
         run: xcrun simctl shutdown all || true
 
       - name: "Select Xcode 26.5"
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: "26.5"
 
       - name: "Ensure iOS Simulator runtime (Xcode 26.5)"
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
         uses: ./.github/actions/ensure-ios-simulator-runtime
 
       - name: "Boot iOS Simulator (Xcode 26.5)"
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
         # A wedged simulator boot has stalled this step ~30 min, pushing the job
         # past its 45-min cap (issue #4078). Bound it well above the observed p95
         # (~9 min) so a real slow boot still passes but a hang fails here.
@@ -1595,28 +1596,28 @@ jobs:
       # This is a freshly-booted sim, so re-confirm the daemon and warm CtrlProxy
       # again before the second Reminders run (same rationale as the 26.2 block).
       - name: "Ensure AutoMobile daemon ready (Xcode 26.5)"
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
         run: ./scripts/ci/ensure-daemon-ready.sh
 
       - name: "Warm up iOS CtrlProxy (Xcode 26.5)"
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
         timeout-minutes: 12
         run: ./scripts/ci/ensure-ctrl-proxy-ready.sh
 
       # Pre-build the XCTest bundle before the second leg's warm-up too (same rationale
       # as the 26.2 leg above); the freshly-booted 26.5 sim is cold again here.
       - name: "Pre-build Reminders XCTest bundle (Xcode 26.5)"
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
         timeout-minutes: 15
         run: ./scripts/ci/prebuild-reminders-xctest-bundle.sh
 
       - name: "Warm up Reminders target app (Xcode 26.5)"
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
         timeout-minutes: 5
         run: ./scripts/ci/warm-reminders-target-app.sh
 
       - name: "Run Reminders integration tests (Xcode 26.5)"
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
         timeout-minutes: 10
         env:
           AUTOMOBILE_TEST_PLAN: "Plans/launch-reminders-app.yaml"

--- a/test/bats/xctest-shared-prereq-gate.bats
+++ b/test/bats/xctest-shared-prereq-gate.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+#
+# Guards issue #4082: the Xcode 26.5 leg of `ios-xctest-runner-simulator-tests`
+# uses `if: !cancelled()` so it runs even when the *26.2* leg's tests failed
+# (deliberate leg-independence). But a bare `!cancelled()` also bypasses a
+# SHARED-prerequisite failure (XcodeGen drift check / CtrlProxy build), so the
+# 26.5 block ran on a broken build and emitted misleading secondary failures
+# (e.g. a spurious "Run Reminders integration tests (Xcode 26.5)" failure whose
+# real cause was the drift check).
+#
+# The fix gates every such step additionally on the shared CtrlProxy build
+# succeeding. This test pins both halves of that invariant.
+
+WORKFLOW=".github/workflows/pull_request.yml"
+
+@test "the shared CtrlProxy build step carries the build-ctrlproxy id" {
+  # The step the 26.5 leg keys off of must exist and be identified.
+  run grep -A1 'name: "Build CtrlProxy iOS for Testing"' "$WORKFLOW"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"id: build-ctrlproxy"* ]]
+}
+
+@test "no step uses a bare 'if: !cancelled()' without gating on the shared build" {
+  # A bare !cancelled() is the anti-pattern: it runs after ANY failure, including
+  # a doomed shared prerequisite. Every !cancelled() must be conjoined with the
+  # build-outcome guard.
+  bare="$(grep -n 'if: ${{ !cancelled() }}' "$WORKFLOW" || true)"
+  if [ -n "$bare" ]; then
+    echo "Bare '!cancelled()' conditions found (must gate on build-ctrlproxy):" >&2
+    echo "$bare" >&2
+  fi
+  [ -z "$bare" ]
+}
+
+@test "the 26.5 leg gates on steps.build-ctrlproxy.outcome == success" {
+  # The eight 26.5-leg steps that were !cancelled() now carry the shared-build guard.
+  count="$(grep -c "!cancelled() && steps.build-ctrlproxy.outcome == 'success'" "$WORKFLOW")"
+  [ "$count" -ge 8 ]
+}


### PR DESCRIPTION
Closes #4082.

## Problem

In `ios-xctest-runner-simulator-tests`, the Xcode 26.5 leg guards every step with `if: ${{ !cancelled() }}`. That's deliberate **leg-independence** — the 26.2 leg runs first with default `success()` gating, so without `!cancelled()` a 26.2 test failure would skip the entire 26.5 leg and lose that coverage.

But a bare `!cancelled()` also fails to short-circuit on a **shared-prerequisite** failure. When `Check CtrlProxy XcodeGen Project Drift` or `Build CtrlProxy iOS for Testing` failed, the 26.5 block ran anyway on a broken build and produced a **misleading secondary failure** — e.g. a spurious `Run Reminders integration tests (Xcode 26.5)` whose real cause was the drift check — burning ~5 min per already-doomed run. All 6 XcodeGen-drift failures in the 5-day window showed this double-failure signature.

## Change

Give `Build CtrlProxy iOS for Testing` the id `build-ctrlproxy`, and gate every 26.5-leg step on it:

```yaml
if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
```

- **Shared prereq fails** (drift → build skipped, or build fails): `outcome != 'success'` → 26.5 leg **skips**. No cascade.
- **Only the 26.2 leg's tests fail**: build still succeeded → 26.5 leg **runs**. Independence preserved.

## Scope

Intentionally narrow: this fixes the *shared-prerequisite* cascade (the documented failure). I did **not** add intra-leg step chaining (a 26.5 boot failure still lets later 26.5 steps attempt) — that needs per-step outcome gating, is higher-risk, and the boot step's new `timeout-minutes` (#4078) already bounds its worst case. Left for a follow-up if it proves necessary.

## Test

`test/bats/xctest-shared-prereq-gate.bats` pins both halves (the `build-ctrlproxy` id and the gated conditions; no bare `!cancelled()` remains). Verified non-vacuous.

## Validation caveat

Workflow-conditional change — the bats guard proves the wiring, but the actual skip-on-prereq-failure behavior only exercises on a real runner when a drift/build failure occurs.