### PR TITLE
fix(ci): make XcodeGen drift check tolerant of PBXProject target-array reorder (#4080)

### DIFF
--- a/scripts/ios/pbxproj_normalize.sh
+++ b/scripts/ios/pbxproj_normalize.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Canonicalize the member order of a pbxproj `targets = ( ... );` array.
+#
+# Why (issue #4080): XcodeGen 2.46.0 emits the PBXProject `targets` array in one
+# of two stable-but-environment-dependent orders for the same spec + version --
+# declaration order (CtrlProxyApp, ObjCExceptionCatcher, CtrlProxy, ...) on some
+# runners and alphabetical order (CtrlProxy, CtrlProxyApp, ...) on others. The
+# committed file flip-flopped between the two across #3969/#3983/#3981, and the
+# drift check reported each pure reorder as staleness even though not one byte of
+# real content changed. Pinning the XcodeGen *version* did not fix it because
+# both orders come out of the same pinned version. This normalizer folds that one
+# array's ordering out so the drift check can stay strict about everything else.
+#
+# `normalize_pbxproj_targets` reads a pbxproj on stdin and writes an identical
+# copy to stdout with the members of every `targets = ( ... );` block sorted
+# (LC_ALL=C, byte order). Every other line is preserved verbatim, so a genuine
+# content change still shows up. Members carry stable UUID + comment strings, so
+# sorting yields the same output regardless of which order XcodeGen chose.
+#
+# In a pbxproj the `targets` key belongs to PBXProject only (scheme targets live
+# in .xcscheme files, not here), so normalizing every `targets = (` block is
+# safe -- other arrays (files, children, dependencies) are left untouched.
+#
+# This file is meant to be sourced (it only defines a function; no side effects).
+# It can also be run directly as a stdin->stdout filter for manual inspection.
+
+normalize_pbxproj_targets() {
+    local line
+    local -a block=()
+    local in_block=0
+
+    while IFS= read -r line || [ -n "${line}" ]; do
+        if [ "${in_block}" -eq 0 ]; then
+            printf '%s\n' "${line}"
+            if [[ "${line}" =~ ^[[:space:]]*targets[[:space:]]*=[[:space:]]*\($ ]]; then
+                in_block=1
+                block=()
+            fi
+            continue
+        fi
+
+        if [[ "${line}" =~ ^[[:space:]]*\)\; ]]; then
+            if [ ${#block[@]} -gt 0 ]; then
+                printf '%s\n' "${block[@]}" | LC_ALL=C sort
+            fi
+            printf '%s\n' "${line}"
+            in_block=0
+        else
+            block+=("${line}")
+        fi
+    done
+}
+
+# When executed (not sourced), act as a stdin->stdout filter.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    normalize_pbxproj_targets
+fi

--- a/scripts/ios/xcodegen-drift-check.sh
+++ b/scripts/ios/xcodegen-drift-check.sh
@@ -9,6 +9,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/ios/xcodegen_version.sh disable=SC1091
 source "${SCRIPT_DIR}/xcodegen_version.sh"
+# shellcheck source=scripts/ios/pbxproj_normalize.sh disable=SC1091
+source "${SCRIPT_DIR}/pbxproj_normalize.sh"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 IOS_DIR="${PROJECT_ROOT}/ios"
 CTRL_PROXY_DIR="${PROJECT_ROOT}/ios/control-proxy"
@@ -66,6 +68,41 @@ if [ -z "${STATUS_OUTPUT}" ]; then
     exit 0
 fi
 
+# A changed project file is not automatically drift. XcodeGen 2.46.0 emits the
+# PBXProject `targets = (...)` array in one of two environment-dependent orders
+# for the same spec + pinned version (issue #4080), so a pure reorder must not
+# fail the gate. Fold that one array's order out (normalize_pbxproj_targets) and
+# compare against the committed bytes; anything that still differs is genuine
+# staleness and is reported below.
+REAL_DRIFT_PATHS=()
+while IFS= read -r status_line; do
+    [ -n "${status_line}" ] || continue
+    # porcelain is "XY <path>"; a rename is "XY <old> -> <new>".
+    path="${status_line:3}"
+    path="${path##* -> }"
+
+    if ! committed="$(git show "HEAD:${path}" 2>/dev/null)"; then
+        # No committed version (new/untracked file) -- always real drift.
+        REAL_DRIFT_PATHS+=("${path}")
+        continue
+    fi
+
+    committed_norm="$(printf '%s' "${committed}" | normalize_pbxproj_targets)"
+    generated_norm="$(normalize_pbxproj_targets < "${path}")"
+    if [ "${committed_norm}" = "${generated_norm}" ]; then
+        # Only the target-array order changed. Restore the committed bytes so the
+        # working tree is clean for the build steps that run after this gate.
+        git checkout -- "${path}"
+    else
+        REAL_DRIFT_PATHS+=("${path}")
+    fi
+done <<< "${STATUS_OUTPUT}"
+
+if [ ${#REAL_DRIFT_PATHS[@]} -eq 0 ]; then
+    echo "XcodeGen project files are in sync (PBXProject target-array order normalized, #4080)"
+    exit 0
+fi
+
 echo "Error: XcodeGen project files are out of date after generation." >&2
 # The pinned-version gate runs before generation, so a version skew can no
 # longer explain reaching this line -- the project file is genuinely stale.
@@ -75,6 +112,6 @@ if [ "${SCOPE}" = "--ctrl-proxy" ]; then
 else
     echo "Run scripts/ios/xcodegen-generate.sh and commit the regenerated project files." >&2
 fi
-git status --short -- "${DRIFT_PATHS[@]}" >&2
-git diff -- "${DRIFT_PATHS[@]}" >&2
+git status --short -- "${REAL_DRIFT_PATHS[@]}" >&2
+git diff -- "${REAL_DRIFT_PATHS[@]}" >&2
 exit 1

--- a/test/bats/pbxproj-normalize.bats
+++ b/test/bats/pbxproj-normalize.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+#
+# Tests for normalize_pbxproj_targets in scripts/ios/pbxproj_normalize.sh
+#
+# Regression guard for #4080: XcodeGen 2.46.0 emits the PBXProject
+# `targets = (...)` array in one of two environment-dependent orders for the
+# same spec + pinned version (declaration order on some runners, alphabetical on
+# others). The drift check reported each pure reorder as staleness, failing PRs
+# nondeterministically. normalize_pbxproj_targets folds that one array's order
+# out so a reorder compares equal while any real content change still differs.
+
+setup() {
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  LIB="$REPO_ROOT/scripts/ios/pbxproj_normalize.sh"
+  # shellcheck source=/dev/null
+  source "$LIB"
+
+  # The two orders XcodeGen actually alternates between (#4080). Same five
+  # members, same UUIDs + comments, different order.
+  DECLARATION_ORDER="$BATS_TEST_TMPDIR/decl.pbxproj"
+  ALPHABETICAL_ORDER="$BATS_TEST_TMPDIR/alpha.pbxproj"
+
+  cat > "$DECLARATION_ORDER" <<'EOF'
+		projectRoot = "";
+		targets = (
+			829FFB06AC273BEE7049A7F2 /* CtrlProxyApp */,
+			E35F925D729B7056D4E4B501 /* ObjCExceptionCatcher */,
+			61A21F82A43E4D436CD13CCD /* CtrlProxy */,
+			D665478F817F2DF283B43BFB /* CtrlProxyTests */,
+			2B5458099134F47AA1A7C4DA /* CtrlProxyUITests */,
+		);
+	};
+EOF
+
+  cat > "$ALPHABETICAL_ORDER" <<'EOF'
+		projectRoot = "";
+		targets = (
+			61A21F82A43E4D436CD13CCD /* CtrlProxy */,
+			829FFB06AC273BEE7049A7F2 /* CtrlProxyApp */,
+			D665478F817F2DF283B43BFB /* CtrlProxyTests */,
+			2B5458099134F47AA1A7C4DA /* CtrlProxyUITests */,
+			E35F925D729B7056D4E4B501 /* ObjCExceptionCatcher */,
+		);
+	};
+EOF
+}
+
+@test "two target orderings of the same members normalize to identical output" {
+  local a b
+  a="$(normalize_pbxproj_targets < "$DECLARATION_ORDER")"
+  b="$(normalize_pbxproj_targets < "$ALPHABETICAL_ORDER")"
+  [ "$a" = "$b" ]
+}
+
+@test "normalization is idempotent" {
+  local once twice
+  once="$(normalize_pbxproj_targets < "$ALPHABETICAL_ORDER")"
+  twice="$(printf '%s' "$once" | normalize_pbxproj_targets)"
+  [ "$once" = "$twice" ]
+}
+
+@test "a real target change is NOT hidden by normalization" {
+  local changed="$BATS_TEST_TMPDIR/changed.pbxproj"
+  # Same order as declaration, but one target renamed -- a genuine content diff.
+  sed 's/CtrlProxyTests/CtrlProxyRenamed/g' "$DECLARATION_ORDER" > "$changed"
+  local base other
+  base="$(normalize_pbxproj_targets < "$DECLARATION_ORDER")"
+  other="$(normalize_pbxproj_targets < "$changed")"
+  [ "$base" != "$other" ]
+}
+
+@test "lines outside the targets array are preserved verbatim and in place" {
+  run normalize_pbxproj_targets < "$DECLARATION_ORDER"
+  [ "$status" -eq 0 ]
+  # First non-array line stays first; closing brace stays last.
+  [ "${lines[0]}" = '		projectRoot = "";' ]
+  [ "${lines[${#lines[@]}-1]}" = '	};' ]
+}
+
+@test "a non-targets array is left untouched (only 'targets' is normalized)" {
+  local input="$BATS_TEST_TMPDIR/files.pbxproj"
+  cat > "$input" <<'EOF'
+		files = (
+			ZZZ /* z */,
+			AAA /* a */,
+		);
+EOF
+  run normalize_pbxproj_targets < "$input"
+  [ "$status" -eq 0 ]
+  # Order of the files array must be unchanged (ZZZ still before AAA).
+  [ "${lines[1]}" = '			ZZZ /* z */,' ]
+  [ "${lines[2]}" = '			AAA /* a */,' ]
+}

--- a/test/scripts/xcodegenDriftCheck.test.ts
+++ b/test/scripts/xcodegenDriftCheck.test.ts
@@ -7,8 +7,27 @@ import { spawnSync } from "node:child_process";
 const repoRoot = join(import.meta.dir, "../..");
 const driftCheckScript = join(repoRoot, "scripts/ios/xcodegen-drift-check.sh");
 const versionScript = join(repoRoot, "scripts/ios/xcodegen_version.sh");
+const normalizeScript = join(repoRoot, "scripts/ios/pbxproj_normalize.sh");
 const workflowPath = join(repoRoot, ".github/workflows/pull_request.yml");
 const tempDirs: string[] = [];
+
+// A minimal PBXProject `targets = (...)` block in two of the orders XcodeGen
+// 2.46.0 alternates between for the same spec (issue #4080). Same members, same
+// UUIDs, different order — a pure reorder that must NOT be reported as drift.
+const declarationOrderProject = `// !$*UTF8*$!
+	targets = (
+		829FFB06AC273BEE7049A7F2 /* CtrlProxyApp */,
+		E35F925D729B7056D4E4B501 /* ObjCExceptionCatcher */,
+		61A21F82A43E4D436CD13CCD /* CtrlProxy */,
+	);
+`;
+const alphabeticalOrderProject = `// !$*UTF8*$!
+	targets = (
+		61A21F82A43E4D436CD13CCD /* CtrlProxy */,
+		829FFB06AC273BEE7049A7F2 /* CtrlProxyApp */,
+		E35F925D729B7056D4E4B501 /* ObjCExceptionCatcher */,
+	);
+`;
 
 // The drift check sources xcodegen_version.sh and gates on the pinned version
 // before generating (issue #3975), so the sandbox must carry the real pin —
@@ -54,6 +73,8 @@ function createTempRepo(): string {
   chmodSync(join(tempDir, "scripts/ios/xcodegen-drift-check.sh"), 0o755);
   // The drift check sources this for the pin and the require_pinned gate.
   cpSync(versionScript, join(tempDir, "scripts/ios/xcodegen_version.sh"));
+  // ...and this for the #4080 target-array order normalization.
+  cpSync(normalizeScript, join(tempDir, "scripts/ios/pbxproj_normalize.sh"));
   writeFileSync(
     join(tempDir, "scripts/ios/xcodegen-generate.sh"),
     `#!/bin/bash
@@ -104,6 +125,11 @@ case "\${FAKE_XCODEGEN_BEHAVIOR:-unchanged}" in
     modify)
         printf 'regenerated project\\n' > CtrlProxy.xcodeproj/project.pbxproj
         ;;
+    reorder)
+        # Emit the committed project with only the PBXProject targets array
+        # reordered — the #4080 nondeterminism the drift check must tolerate.
+        printf '%s' "\${FAKE_REORDERED_PROJECT}" > CtrlProxy.xcodeproj/project.pbxproj
+        ;;
     recreate)
         rm -f CtrlProxy.xcodeproj/project.pbxproj
         printf 'committed project\\n' > CtrlProxy.xcodeproj/project.pbxproj
@@ -151,6 +177,23 @@ if [[ "$1" == "diff" && "\${2:-}" == "--" && "\${3:-}" == "\${tracked_path}" ]];
     echo "diff --git a/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj b/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj"
     echo "-committed project"
     echo "+regenerated project"
+    exit 0
+fi
+
+# \`git show HEAD:<path>\` returns the committed bytes (modeled by baseline). An
+# untracked (??) path is absent from HEAD, so show must fail like real git.
+if [[ "$1" == "show" && "\${2:-}" == "HEAD:\${tracked_path}" ]]; then
+    if [[ "\${FAKE_GIT_STATUS_OUTPUT:-}" == "??"* ]]; then
+        echo "fatal: path '\${tracked_path}' does not exist in 'HEAD'" >&2
+        exit 128
+    fi
+    cat "\${baseline}"
+    exit 0
+fi
+
+# \`git checkout -- <path>\` restores the committed bytes (baseline) into the tree.
+if [[ "$1" == "checkout" && "\${2:-}" == "--" && "\${3:-}" == "\${tracked_path}" ]]; then
+    cp "\${baseline}" "\${project}"
     exit 0
 fi
 
@@ -249,6 +292,34 @@ describe("xcodegen drift check", () => {
 
     expectExitStatus(result, 0);
     expect(result.stdout + result.stderr).toContain("XcodeGen project files are in sync");
+  });
+
+  test("ctrl-proxy scope passes when only the PBXProject target order changed (#4080)", () => {
+    // XcodeGen 2.46.0 emits the targets array in one of two environment-dependent
+    // orders for the same spec + pinned version. A pure reorder is not drift, so
+    // the check must normalize it away and pass — not fail like a stale project.
+    const repoDir = createTempRepo();
+    const projectPath = join(repoDir, "ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj");
+    // Commit the declaration order; the fake generator emits the alphabetical one.
+    writeFileSync(projectPath, declarationOrderProject);
+    writeFileSync(join(repoDir, "baseline/project.pbxproj"), declarationOrderProject);
+
+    const result = spawnSync("bash", ["scripts/ios/xcodegen-drift-check.sh", "--ctrl-proxy"], {
+      cwd: repoDir,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        FAKE_REPO_ROOT: repoDir,
+        FAKE_XCODEGEN_BEHAVIOR: "reorder",
+        FAKE_REORDERED_PROJECT: alphabeticalOrderProject,
+        PATH: `${join(repoDir, "bin")}:${process.env.PATH ?? ""}`,
+      },
+    });
+
+    expectExitStatus(result, 0);
+    expect(result.stdout + result.stderr).toContain("target-array order normalized");
+    // The benign reorder must be restored to the committed bytes, not left dirty.
+    expect(readFileSync(projectPath, "utf8")).toBe(declarationOrderProject);
   });
 
   test("all scope uses the repo-wide generator for wider iOS build gates", () => {


### PR DESCRIPTION
Closes #4080.

## Root cause

`Check CtrlProxy XcodeGen Project Drift` fails nondeterministically because XcodeGen 2.46.0 emits the PBXProject `targets = ( ... )` array in **one of two stable-but-environment-dependent orders** for the same spec + pinned version:

- **declaration**: `CtrlProxyApp, ObjCExceptionCatcher, CtrlProxy, CtrlProxyTests, CtrlProxyUITests`
- **alphabetical**: `CtrlProxy, CtrlProxyApp, CtrlProxyTests, CtrlProxyUITests, ObjCExceptionCatcher`

Same 5 targets, same UUIDs, **zero content change**. Git history proves it: the committed file flip-flopped between the two orders across #3969 → #3983 → #3981. **Pinning the version did not help** because both orders come out of the *same* pinned version — the signature of Swift `Dictionary` hash-seed ordering during the spec parse. Committing "the right order" can't fix it either: each environment is internally deterministic but they disagree, so a commit just moves the drift.

## Fix

Make the drift check **order-insensitive for that one array**, strict about everything else:

- New sourceable `scripts/ios/pbxproj_normalize.sh` → `normalize_pbxproj_targets` (stdin→stdout): byte-sorts (`LC_ALL=C`) the members of every `targets = ( ... );` block and passes every other byte through verbatim. `targets` is a PBXProject-only key (scheme targets live in `.xcscheme`), so this is safe; `files`/`children`/`dependencies` are untouched.
- `xcodegen-drift-check.sh`: for each changed path, compare `normalize(HEAD:path)` vs `normalize(working tree)`. Equal → pure reorder → `git checkout` restores the committed bytes (keeps the tree clean for the build steps after the gate) and the gate passes. Different, or untracked/new file → genuine drift, reported exactly as before.

## Tests

- `test/bats/pbxproj-normalize.bats` (5): two orders normalize equal, idempotent, a real target change is **not** hidden, surrounding lines preserved in place, non-`targets` arrays untouched.
- `test/scripts/xcodegenDriftCheck.test.ts` (9, extended): benign-reorder → exit 0 + tree restored; renamed target → still flagged as real drift.
- shellcheck clean on both scripts.

## Validation caveat

The reorder could **not be reproduced locally** (my arch produces only declaration order across 30+ runs), so the alphabetical↔declaration equivalence is verified via a synthetic alphabetical fixture + git-history evidence, not a live CI reorder. The fix is robust regardless of the precise trigger: it neutralizes *any* same-set reorder of `targets` while staying strict on real content. Same-set reorder is the only thing tolerated — a target added/removed changes the set and is still caught.