### PR TITLE
fix(ci,ios): boot gate rejected every healthy simulator boot (#4078 regression)

### DIFF
--- a/scripts/ios/boot-simulator.sh
+++ b/scripts/ios/boot-simulator.sh
@@ -127,20 +127,32 @@ DEVICE_NAME=$(xcrun simctl list devices available -j \
 
 echo "Ensuring ${DEVICE_NAME} (${UDID}) is booted..." >&2
 
-# bootstatus can "Finish" with an internal failure status -- e.g. it stalls in
-# "Waiting on System App" for tens of minutes and then reports
-# "Status=4294967295, isTerminal=YES" -- while still exiting 0. Pressing on
-# would print "Booted:" for a wedged simulator that hangs every downstream step
-# (issue #4078). Capture the outcome and treat a failing exit OR that terminal
-# error status as a hard boot failure.
+# `bootstatus` alone is not a trustworthy success signal, in BOTH directions:
+#
+#   * It can exit 0 on a wedged boot (the case #4078 set out to catch), and
+#   * on macOS 26 / Xcode 26 a perfectly HEALTHY boot ends with
+#     "Status=4294967295, isTerminal=YES" followed by "Finished" -- that code is
+#     just how CoreSimulator reports its terminal state here. It appears in 100%
+#     of boots, so it cannot distinguish a good boot from a bad one. Keying on it
+#     rejected healthy 17-71s boots and failed every iOS PR.
+#
+# So verify the post-condition instead: the device must actually be in the
+# "Booted" state. This mirrors how the Android emulator path proves readiness
+# (independent signals rather than one command's exit code).
 set +e
 boot_log="$(xcrun simctl bootstatus "${UDID}" -b 2>&1)"
 boot_rc=$?
 set -e
 printf '%s\n' "${boot_log}" >&2
 
-if [[ ${boot_rc} -ne 0 ]] || printf '%s' "${boot_log}" | grep -q 'Status=4294967295'; then
-  echo "error: simulator ${UDID} failed to boot (bootstatus rc=${boot_rc})" >&2
+BOOT_STATE="$(xcrun simctl list devices -j \
+  | jq -r --arg udid "${UDID}" '
+      .devices | to_entries[] | .value[]
+      | select(.udid == $udid) | .state
+    ' | head -1)"
+
+if [[ ${boot_rc} -ne 0 ]] || [[ "${BOOT_STATE}" != "Booted" ]]; then
+  echo "error: simulator ${UDID} failed to boot (bootstatus rc=${boot_rc}, state=${BOOT_STATE:-unknown})" >&2
   exit 1
 fi
 

--- a/test/bats/boot-simulator.bats
+++ b/test/bats/boot-simulator.bats
@@ -71,9 +71,12 @@ elif [ "$1" = "simctl" ] && [ "$2" = "list" ] && [ "$3" = "runtimes" ]; then
     echo "iOS 26.4 (26.4 - 23D1) - com.apple.CoreSimulator.SimRuntime.iOS-26-4"
   fi
 elif [ "$1" = "simctl" ] && [ "$2" = "list" ] && [ "$3" = "devices" ]; then
-  echo '{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-26-4":[{"name":"iPhone 16","udid":"FAKE-UDID","state":"Shutdown"}]}}'
+  echo '{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-26-4":[{"name":"iPhone 16","udid":"FAKE-UDID","state":"Booted"}]}}'
 elif [ "$1" = "simctl" ] && [ "$2" = "bootstatus" ]; then
   [ "$4" = "-b" ] || exit 2
+  # Real simctl on macOS 26 prints this terminal line on a HEALTHY boot.
+  echo "[2026-07-20 13:11:14 +0000] Status=4294967295, isTerminal=YES, Elapsed=01:04."
+  echo "	Finished"
   exit 0
 fi
 SCRIPT
@@ -97,9 +100,39 @@ SCRIPT
   grep -q '.identifier' "$SCRIPT"
 }
 
-@test "fails when bootstatus reports a wedged boot (Status=4294967295) but exits 0" {
-  # Regression for #4078: a stalled boot can print a terminal error status and
-  # still exit 0. The script must not report "Booted:" and press on.
+@test "REGRESSION: a healthy boot that prints Status=4294967295 is NOT rejected" {
+  # The first #4078 attempt keyed on the literal string "Status=4294967295" as a
+  # wedge sentinel. On macOS 26 / Xcode 26 that terminal status is printed by
+  # EVERY boot, including healthy ones (observed in 106/106 CI boots, 102 of
+  # which booted fine), so the gate failed 100% of iOS PRs and killed boots as
+  # fast as 17s. A healthy boot must pass even though it prints that line.
+  cat > "${MOCK_BIN}/xcrun" <<'SCRIPT'
+#!/bin/sh
+if [ "$1" = "--sdk" ] && [ "$2" = "iphonesimulator" ] && [ "$3" = "--show-sdk-version" ]; then
+  echo "26.5"
+elif [ "$1" = "simctl" ] && [ "$2" = "list" ] && [ "$3" = "runtimes" ]; then
+  echo '{"runtimes":[{"version":"26.5.0","identifier":"com.apple.CoreSimulator.SimRuntime.iOS-26-5"}]}'
+elif [ "$1" = "simctl" ] && [ "$2" = "list" ] && [ "$3" = "devices" ]; then
+  echo '{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-26-5":[{"name":"iPhone 17 Pro","udid":"HEALTHY-UDID","state":"Booted"}]}}'
+elif [ "$1" = "simctl" ] && [ "$2" = "bootstatus" ]; then
+  echo "[2026-07-20 13:11:14 +0000] Status=4294967295, isTerminal=YES, Elapsed=01:04."
+  echo "	Finished"
+  exit 0
+fi
+SCRIPT
+  chmod +x "${MOCK_BIN}/xcrun"
+  export PATH="${MOCK_BIN}:${PATH}"
+
+  run bash "$SCRIPT" --ios-version 26.5
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"HEALTHY-UDID"* ]]
+  [[ "$output" != *"failed to boot"* ]]
+}
+
+@test "fails when bootstatus exits 0 but the device never reaches Booted (wedge)" {
+  # Regression for #4078: a stalled boot exits 0 and prints the same terminal
+  # status line a healthy boot does. Only the device STATE distinguishes them,
+  # so the script must verify the post-condition, not the status code.
   cat > "${MOCK_BIN}/xcrun" <<'SCRIPT'
 #!/bin/sh
 if [ "$1" = "--sdk" ] && [ "$2" = "iphonesimulator" ] && [ "$3" = "--show-sdk-version" ]; then
@@ -109,7 +142,6 @@ elif [ "$1" = "simctl" ] && [ "$2" = "list" ] && [ "$3" = "runtimes" ]; then
 elif [ "$1" = "simctl" ] && [ "$2" = "list" ] && [ "$3" = "devices" ]; then
   echo '{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-26-2":[{"name":"iPhone 17 Pro","udid":"WEDGED-UDID","state":"Shutdown"}]}}'
 elif [ "$1" = "simctl" ] && [ "$2" = "bootstatus" ]; then
-  # Wedged boot: prints a terminal failure status yet exits 0.
   echo "[2026-07-20 15:00:16 +0000] Status=4294967295, isTerminal=YES, Elapsed=32:06."
   echo "	Finished"
   exit 0
@@ -121,6 +153,7 @@ SCRIPT
   run bash "$SCRIPT" --ios-version 26.2
   [ "$status" -eq 1 ]
   [[ "$output" == *"failed to boot"* ]]
+  [[ "$output" == *"state=Shutdown"* ]]
   [[ "$output" != *"Booted: "* ]]
 }
 
@@ -161,6 +194,8 @@ elif [ "$1" = "simctl" ] && [ "$2" = "boot" ]; then
 elif [ "$1" = "simctl" ] && [ "$2" = "bootstatus" ]; then
   [ "$3" = "BOOTED-UDID" ] || exit 2
   [ "$4" = "-b" ] || exit 2
+  echo "[2026-07-20 13:11:14 +0000] Status=4294967295, isTerminal=YES, Elapsed=01:04."
+  echo "	Finished"
   exit 0
 fi
 SCRIPT


### PR DESCRIPTION
**Urgent** — fixes a regression I introduced in #4086. iOS-touching PRs are currently failing 100% at the simulator boot step.

## What went wrong

#4086 keyed its wedge detector on the literal string `Status=4294967295`:

```bash
if [[ ${boot_rc} -ne 0 ]] || printf '%s' "${boot_log}" | grep -q 'Status=4294967295'; then
```

On macOS 26 / Xcode 26 that terminal status is what CoreSimulator prints for **every** boot — healthy ones included. From a **successful** pre-fix job (88360742012):

```
[2026-07-20 13:11:14 +0000] Status=4294967295, isTerminal=YES, Elapsed=01:04.
	Finished
Booted: iPhone 17 Pro (FD9EC0F9-…)
```

Across 106 CI boots the string appeared **106 times**, and **102** of those booted fine. The gate killed boots completing in **17s, 23s, 71s, 129s** — at or below the median. My original justification ("bootstatus exits 0 on a wedge") is true, but the status code is not what distinguishes the two cases, and I shipped it without validating the sentinel against a passing run.

## Fix

Verify the **post-condition** instead of the status code — after `bootstatus`, the device must actually be in the `Booted` state:

```bash
BOOT_STATE="$(xcrun simctl list devices -j | jq -r --arg udid "$UDID" '…|.state' | head -1)"
if [[ ${boot_rc} -ne 0 ]] || [[ "${BOOT_STATE}" != "Booted" ]]; then …
```

That is the signal that genuinely differs: a real wedge exits 0 with the device still `Shutdown`. It also mirrors how the Android emulator path proves readiness — independent signals rather than one command's exit code — which is the pattern iOS should have followed from the start.

## Tests

- Mocks now emit the real terminal line healthy boots print.
- **New REGRESSION case**: a healthy boot printing `Status=4294967295` must be accepted.
- Verified that case — and the pre-existing *"already-booted simulators are accepted"* case — **fail against the current main script**, reproducing the live 100%-failure behavior.
- 11/11 bats pass; shellcheck clean.

`timeout-minutes: 15` from #4086 is kept — CI data puts boot p95 at ~307s (max observed 818s, noted as a follow-up concern).