### PR TITLE
fix(ci): cover sync process boundary bypasses

### DIFF
--- a/scripts/check-android-emulator-boundary.ts
+++ b/scripts/check-android-emulator-boundary.ts
@@ -94,6 +94,21 @@ function findViolations(file: string): Violation[] {
   const childProcessFunctions = new Set<string>();
   const violations: Violation[] = [];
 
+  const isChildProcessRequire = (expression: ts.Expression): boolean =>
+    ts.isCallExpression(expression) &&
+    ts.isIdentifier(expression.expression) &&
+    expression.expression.text === "require" &&
+    expression.arguments.length === 1 &&
+    ts.isStringLiteral(expression.arguments[0]) &&
+    CHILD_PROCESS_MODULES.has(expression.arguments[0].text);
+
+  const isChildProcessFunction = (expression: ts.Expression): boolean =>
+    (ts.isIdentifier(expression) &&
+      childProcessFunctions.has(expression.text)) ||
+    (ts.isPropertyAccessExpression(expression) &&
+      CHILD_PROCESS_FUNCTIONS.has(expression.name.text) &&
+      isChildProcessNamespace(expression.expression, childProcessNamespaces));
+
   const record = (node: ts.CallExpression): void => {
     const { line, character } = sourceFile.getLineAndCharacterOfPosition(
       node.getStart(sourceFile),
@@ -127,6 +142,32 @@ function findViolations(file: string): Violation[] {
     }
 
     if (
+      ts.isImportEqualsDeclaration(node) &&
+      ts.isExternalModuleReference(node.moduleReference) &&
+      node.moduleReference.expression &&
+      ts.isStringLiteral(node.moduleReference.expression) &&
+      CHILD_PROCESS_MODULES.has(node.moduleReference.expression.text)
+    ) {
+      childProcessNamespaces.add(node.name.text);
+    }
+
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer
+    ) {
+      if (
+        isChildProcessRequire(node.initializer) ||
+        isChildProcessNamespace(node.initializer, childProcessNamespaces)
+      ) {
+        childProcessNamespaces.add(node.name.text);
+      }
+      if (isChildProcessFunction(node.initializer)) {
+        childProcessFunctions.add(node.name.text);
+      }
+    }
+
+    if (
       (ts.isVariableDeclaration(node) ||
         ts.isParameter(node) ||
         ts.isPropertyDeclaration(node)) &&
@@ -154,11 +195,7 @@ function findViolations(file: string): Violation[] {
               processExecutors,
               childProcessNamespaces,
             )) ||
-          (expression.name.text === "execSync" &&
-            isChildProcessNamespace(
-              expression.expression,
-              childProcessNamespaces,
-            ))
+          isChildProcessFunction(expression)
         ) {
           record(node);
         }

--- a/scripts/check-android-emulator-boundary.ts
+++ b/scripts/check-android-emulator-boundary.ts
@@ -5,6 +5,20 @@ import ts from "typescript";
 const SOURCE_ROOT = "src";
 const OWNER = "src/utils/android-cmdline-tools/AndroidEmulatorClient.ts";
 const CHILD_PROCESS_MODULES = new Set(["child_process", "node:child_process"]);
+const CHILD_PROCESS_FUNCTIONS = new Set([
+  "spawn",
+  "spawnSync",
+  "exec",
+  "execSync",
+  "execFile",
+  "execFileSync",
+]);
+const DIRECT_CHILD_PROCESS_FUNCTIONS = new Set([
+  "spawn",
+  "spawnSync",
+  "execFile",
+  "execFileSync",
+]);
 
 interface Violation {
   readonly file: string;
@@ -53,6 +67,15 @@ function receiverName(
   return null;
 }
 
+function isChildProcessNamespace(
+  expression: ts.Expression,
+  childProcessNamespaces: Set<string>,
+): boolean {
+  return (
+    ts.isIdentifier(expression) && childProcessNamespaces.has(expression.text)
+  );
+}
+
 function findViolations(file: string): Violation[] {
   const source = readFileSync(file, "utf8");
   if (!/emulator/i.test(source)) {
@@ -96,11 +119,7 @@ function findViolations(file: string): Violation[] {
       if (bindings && ts.isNamedImports(bindings)) {
         for (const specifier of bindings.elements) {
           const imported = specifier.propertyName?.text ?? specifier.name.text;
-          if (
-            imported === "spawn" ||
-            imported === "execFile" ||
-            imported === "exec"
-          ) {
+          if (CHILD_PROCESS_FUNCTIONS.has(imported)) {
             childProcessFunctions.add(specifier.name.text);
           }
         }
@@ -121,24 +140,25 @@ function findViolations(file: string): Violation[] {
       const expression = node.expression;
       if (
         ts.isIdentifier(expression) &&
-        (expression.text === "spawn" ||
-          expression.text === "execFile" ||
+        (DIRECT_CHILD_PROCESS_FUNCTIONS.has(expression.text) ||
           childProcessFunctions.has(expression.text))
       ) {
         record(node);
       } else if (ts.isPropertyAccessExpression(expression)) {
-        if (
-          expression.name.text === "spawn" ||
-          expression.name.text === "execFile"
-        ) {
+        if (DIRECT_CHILD_PROCESS_FUNCTIONS.has(expression.name.text)) {
           record(node);
         } else if (
-          expression.name.text === "exec" &&
-          receiverName(
-            expression.expression,
-            processExecutors,
-            childProcessNamespaces,
-          )
+          (expression.name.text === "exec" &&
+            receiverName(
+              expression.expression,
+              processExecutors,
+              childProcessNamespaces,
+            )) ||
+          (expression.name.text === "execSync" &&
+            isChildProcessNamespace(
+              expression.expression,
+              childProcessNamespaces,
+            ))
         ) {
           record(node);
         }

--- a/scripts/check-no-new-direct-simctl.sh
+++ b/scripts/check-no-new-direct-simctl.sh
@@ -28,7 +28,7 @@ fi
 # checked as one expression. Block all direct xcrun argv calls outside the
 # owner: variable argv values cannot be proven to be non-simctl statically,
 # and the conservative boundary prevents an easy bypass.
-pattern='((spawn|spawnSync|execFile|execFileSync)\([[:space:]]*"xcrun"|exec(Sync)?\([^)]*"xcrun simctl|"/bin/sh".*xcrun simctl)'
+pattern='((spawn|spawnSync|execFile|execFileSync)\([[:space:]]*"xcrun"|exec(Sync)?\([^)]*("|`)xcrun simctl|"/bin/sh".*xcrun simctl)'
 
 while IFS= read -r file; do
   [[ "$file" == "$owner" ]] && continue

--- a/scripts/check-no-new-direct-simctl.sh
+++ b/scripts/check-no-new-direct-simctl.sh
@@ -28,7 +28,7 @@ fi
 # checked as one expression. Block all direct xcrun argv calls outside the
 # owner: variable argv values cannot be proven to be non-simctl statically,
 # and the conservative boundary prevents an easy bypass.
-pattern='((spawn|spawnSync|execFile|execFileSync)\([[:space:]]*"xcrun"|exec(Sync)?\([^)]*("|`)xcrun simctl|"/bin/sh".*xcrun simctl)'
+pattern="((spawn|spawnSync|execFile|execFileSync)\\([[:space:]]*\"xcrun\"|exec(Sync)?\\([^)]*(\"|\`|')xcrun simctl|\"/bin/sh\".*xcrun simctl)"
 
 while IFS= read -r file; do
   [[ "$file" == "$owner" ]] && continue

--- a/scripts/check-no-new-direct-simctl.sh
+++ b/scripts/check-no-new-direct-simctl.sh
@@ -28,7 +28,7 @@ fi
 # checked as one expression. Block all direct xcrun argv calls outside the
 # owner: variable argv values cannot be proven to be non-simctl statically,
 # and the conservative boundary prevents an easy bypass.
-pattern='((spawn|execFile)\([[:space:]]*"xcrun"|exec\([^)]*"xcrun simctl|"/bin/sh".*xcrun simctl)'
+pattern='((spawn|spawnSync|execFile|execFileSync)\([[:space:]]*"xcrun"|exec(Sync)?\([^)]*"xcrun simctl|"/bin/sh".*xcrun simctl)'
 
 while IFS= read -r file; do
   [[ "$file" == "$owner" ]] && continue

--- a/scripts/check-no-new-direct-simctl.sh
+++ b/scripts/check-no-new-direct-simctl.sh
@@ -28,7 +28,7 @@ fi
 # checked as one expression. Block all direct xcrun argv calls outside the
 # owner: variable argv values cannot be proven to be non-simctl statically,
 # and the conservative boundary prevents an easy bypass.
-pattern="((spawn|spawnSync|execFile|execFileSync)\\([[:space:]]*\"xcrun\"|exec(Sync)?\\([^)]*(\"|\`|')xcrun simctl|\"/bin/sh\".*xcrun simctl)"
+pattern="((spawn|spawnSync|execFile|execFileSync)\\([[:space:]]*(\"|\`|')xcrun|exec(Sync)?\\([^)]*(\"|\`|')xcrun simctl|\"/bin/sh\".*xcrun simctl)"
 
 while IFS= read -r file; do
   [[ "$file" == "$owner" ]] && continue

--- a/test/bats/check-android-emulator-boundary.bats
+++ b/test/bats/check-android-emulator-boundary.bats
@@ -50,6 +50,42 @@ teardown() {
   [[ "$output" == *"EmulatorBoundaryFixture.ts"* ]]
 }
 
+@test "rejects a synchronous child_process exec emulator launch" {
+  printf '%s\n' 'import { execSync } from "node:child_process"; execSync("emulator -avd Pixel");' > "$FIXTURE"
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"EmulatorBoundaryFixture.ts"* ]]
+}
+
+@test "rejects a synchronous child_process execFile emulator launch" {
+  printf '%s\n' 'import { execFileSync } from "node:child_process"; execFileSync("emulator", ["-avd", "Pixel"]);' > "$FIXTURE"
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"EmulatorBoundaryFixture.ts"* ]]
+}
+
+@test "rejects a synchronous child_process spawn emulator launch" {
+  printf '%s\n' 'import { spawnSync } from "node:child_process"; spawnSync("emulator", ["-avd", "Pixel"]);' > "$FIXTURE"
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"EmulatorBoundaryFixture.ts"* ]]
+}
+
+@test "rejects a synchronous child_process namespace emulator launch" {
+  printf '%s\n' 'import * as childProcess from "node:child_process"; childProcess.execSync("emulator -avd Pixel");' > "$FIXTURE"
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"EmulatorBoundaryFixture.ts"* ]]
+}
+
 @test "allows unrelated RegExp exec calls in an emulator-related file" {
   printf '%s\n' 'const match = /emulator/.exec(deviceId);' > "$FIXTURE"
 

--- a/test/bats/check-android-emulator-boundary.bats
+++ b/test/bats/check-android-emulator-boundary.bats
@@ -86,6 +86,42 @@ teardown() {
   [[ "$output" == *"EmulatorBoundaryFixture.ts"* ]]
 }
 
+@test "rejects a local alias of a synchronous child_process function" {
+  printf '%s\n' 'import { execFileSync } from "node:child_process"; const launch = execFileSync; launch("emulator", ["-avd", "Pixel"]);' > "$FIXTURE"
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"EmulatorBoundaryFixture.ts"* ]]
+}
+
+@test "rejects a local alias of a synchronous child_process namespace method" {
+  printf '%s\n' 'import * as childProcess from "node:child_process"; const launch = childProcess.execSync; launch("emulator -avd Pixel");' > "$FIXTURE"
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"EmulatorBoundaryFixture.ts"* ]]
+}
+
+@test "rejects a CommonJS child_process namespace launch" {
+  printf '%s\n' 'const childProcess = require("node:child_process"); childProcess.execSync("emulator -avd Pixel");' > "$FIXTURE"
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"EmulatorBoundaryFixture.ts"* ]]
+}
+
+@test "rejects an import-equals child_process namespace launch" {
+  printf '%s\n' 'import childProcess = require("node:child_process"); childProcess.execSync("emulator -avd Pixel");' > "$FIXTURE"
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"EmulatorBoundaryFixture.ts"* ]]
+}
+
 @test "allows unrelated RegExp exec calls in an emulator-related file" {
   printf '%s\n' 'const match = /emulator/.exec(deviceId);' > "$FIXTURE"
 

--- a/test/bats/check-no-new-direct-simctl.bats
+++ b/test/bats/check-no-new-direct-simctl.bats
@@ -58,6 +58,16 @@ teardown() {
   [[ "$output" == *"bypass.ts"* ]]
 }
 
+@test "rejects a single-quoted shell-form xcrun simctl execution" {
+  printf '%s\n' "execSync('xcrun simctl list devices');" > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-simctl.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
 @test "rejects a multiline argv-form xcrun simctl execution" {
   printf '%s\n' 'execFile(' '  "xcrun",' '  [' '    "simctl",' '    "list",' '    "devices",' '  ],' ');' > "$repo_dir/src/bypass.ts"
   git -C "$repo_dir" add src/bypass.ts

--- a/test/bats/check-no-new-direct-simctl.bats
+++ b/test/bats/check-no-new-direct-simctl.bats
@@ -38,6 +38,26 @@ teardown() {
   [[ "$output" == *"bypass.ts"* ]]
 }
 
+@test "rejects a template-literal argv-form xcrun execution" {
+  printf '%s\n' 'execFileSync(`xcrun`, ["simctl", "list", "devices"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-simctl.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
+@test "rejects a single-quoted argv-form xcrun execution" {
+  printf '%s\n' "execFileSync('xcrun', [\"simctl\", \"list\", \"devices\"]);" > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-simctl.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
 @test "rejects a synchronous shell-form xcrun simctl execution" {
   printf '%s\n' 'execSync("xcrun simctl list devices");' > "$repo_dir/src/bypass.ts"
   git -C "$repo_dir" add src/bypass.ts

--- a/test/bats/check-no-new-direct-simctl.bats
+++ b/test/bats/check-no-new-direct-simctl.bats
@@ -28,6 +28,26 @@ teardown() {
   [[ "$output" == *"bypass.ts"* ]]
 }
 
+@test "rejects a synchronous argv-form xcrun execution" {
+  printf '%s\n' 'execFileSync("xcrun", ["simctl", "list", "devices"]);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-simctl.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
+@test "rejects a synchronous shell-form xcrun simctl execution" {
+  printf '%s\n' 'execSync("xcrun simctl list devices");' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-simctl.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
 @test "rejects a multiline argv-form xcrun simctl execution" {
   printf '%s\n' 'execFile(' '  "xcrun",' '  [' '    "simctl",' '    "list",' '    "devices",' '  ],' ');' > "$repo_dir/src/bypass.ts"
   git -C "$repo_dir" add src/bypass.ts

--- a/test/bats/check-no-new-direct-simctl.bats
+++ b/test/bats/check-no-new-direct-simctl.bats
@@ -48,6 +48,16 @@ teardown() {
   [[ "$output" == *"bypass.ts"* ]]
 }
 
+@test "rejects a template-literal shell-form xcrun simctl execution" {
+  printf '%s\n' 'execSync(`xcrun simctl list devices`);' > "$repo_dir/src/bypass.ts"
+  git -C "$repo_dir" add src/bypass.ts
+
+  run bash -c 'cd "$1" && bash scripts/check-no-new-direct-simctl.sh HEAD' _ "$repo_dir"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bypass.ts"* ]]
+}
+
 @test "rejects a multiline argv-form xcrun simctl execution" {
   printf '%s\n' 'execFile(' '  "xcrun",' '  [' '    "simctl",' '    "list",' '    "devices",' '  ],' ');' > "$repo_dir/src/bypass.ts"
   git -C "$repo_dir" add src/bypass.ts


### PR DESCRIPTION
## Summary

- cover synchronous `child_process` emulator launches in the Android emulator boundary guard
- strengthen the analogous SimCtl bypass ratchet for synchronous process APIs
- add focused BATS regressions for direct and namespace invocation forms

## Validation

- `bun run check:android-emulator-boundary`
- `bats test/bats/check-android-emulator-boundary.bats test/bats/check-no-new-direct-simctl.bats`
- `shellcheck scripts/check-android-emulator-boundary.sh scripts/check-no-new-direct-simctl.sh`
- `bun run lint`
- `bun run build`

Follow-up to merged PR #4072.
