### PR TITLE
ci(nightly): push SHA256 checksum updates straight to main

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,6 +38,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           lfs: false
+          # Full history so the direct push to main isn't rejected as a shallow
+          # update, and the admin token so it bypasses the green-main ruleset.
+          fetch-depth: 0
+          token: ${{ secrets.AUTO_MOBILE_PR_TOKEN }}
 
       - name: "Setup Bun"
         uses: oven-sh/setup-bun@v2
@@ -166,16 +170,7 @@ jobs:
             echo "needed=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: "Update release constants"
-        if: steps.check.outputs.needed == 'true'
-        env:
-          APK_SHA256_CHECKSUM: ${{ needs.build-control-proxy-apk.outputs.sha256 }}
-          IOS_CTRL_PROXY_SHA256_CHECKSUM: ${{ needs.build-ctrl-proxy-ios-ipa.outputs.sha256 }}
-          IOS_CTRL_PROXY_RUNNER_SHA256: ${{ needs.build-ctrl-proxy-ios-ipa.outputs.runner_sha256 }}
-          VIDEO_JAR_SHA256: ${{ needs.build-video-server-jar.outputs.sha256 }}
-        run: bash scripts/generate-release-constants.sh
-
-      - name: "Build PR title"
+      - name: "Build commit subject"
         if: steps.check.outputs.needed == 'true'
         id: pr-title
         run: |
@@ -183,11 +178,12 @@ jobs:
           IPA_CHANGED="${{ steps.check.outputs.ipa_changed }}"
           RUNNER_CHANGED="${{ steps.check.outputs.runner_changed }}"
 
-          # The CtrlProxy artifact titles are matched EXACTLY by the sha256-only PR
-          # classifier in pull_request.yml (which skips heavy CI for these). Keep
-          # these strings verbatim. When the video-server jar also changed it is
-          # reflected in the PR body table below; only the jar-ONLY case gets its
-          # own title (also registered in the pull_request.yml classifier).
+          # These become the commit subject of the direct-to-main push below. They
+          # are ALSO matched EXACTLY by the sha256-only PR classifier in
+          # pull_request.yml, which still skips heavy CI for hand-opened checksum
+          # PRs — keep these strings verbatim. When the video-server jar also
+          # changed it is reflected in the commit body table below; only the
+          # jar-ONLY case gets its own subject.
           if [ "$APK_CHANGED" = "true" ] && [ "$IPA_CHANGED" = "true" ] && [ "$RUNNER_CHANGED" = "true" ]; then
             echo "title=chore: update CtrlProxy APK, iOS IPA, and iOS runner SHA256" >> "$GITHUB_OUTPUT"
           elif [ "$APK_CHANGED" = "true" ] && [ "$IPA_CHANGED" = "true" ]; then
@@ -207,59 +203,44 @@ jobs:
             echo "title=chore: update video-server jar SHA256" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: "Create PR for SHA256 update"
+      - name: "Commit and push SHA256 update to main"
         if: steps.check.outputs.needed == 'true'
-        id: create-pr
-        uses: peter-evans/create-pull-request@v8
-        with:
-          token: ${{ secrets.AUTO_MOBILE_PR_TOKEN }}
-          commit-message: |
+        shell: bash
+        env:
+          APK_SHA256_CHECKSUM: ${{ needs.build-control-proxy-apk.outputs.sha256 }}
+          IOS_CTRL_PROXY_SHA256_CHECKSUM: ${{ needs.build-ctrl-proxy-ios-ipa.outputs.sha256 }}
+          IOS_CTRL_PROXY_RUNNER_SHA256: ${{ needs.build-ctrl-proxy-ios-ipa.outputs.runner_sha256 }}
+          VIDEO_JAR_SHA256: ${{ needs.build-video-server-jar.outputs.sha256 }}
+          RELEASE_CONSTANTS_COMMIT_MESSAGE: |
             ${{ steps.pr-title.outputs.title }}
-
-            APK: ${{ steps.current.outputs.apk_sha256 || '(empty)' }} -> ${{ needs.build-control-proxy-apk.outputs.sha256 }}${{ steps.check.outputs.apk_changed == 'true' && ' (changed)' || ' (unchanged)' }}
-            IPA: ${{ steps.current.outputs.ipa_sha256 || '(empty)' }} -> ${{ needs.build-ctrl-proxy-ios-ipa.outputs.sha256 }}${{ steps.check.outputs.ipa_changed == 'true' && ' (changed)' || ' (unchanged)' }}
-            iOS Runner: ${{ steps.current.outputs.runner_sha256 || '(empty)' }} -> ${{ needs.build-ctrl-proxy-ios-ipa.outputs.runner_sha256 }}${{ steps.check.outputs.runner_changed == 'true' && ' (changed)' || ' (unchanged)' }}
-            video-server jar: ${{ steps.current.outputs.video_jar_sha256 || '(empty)' }} -> ${{ needs.build-video-server-jar.outputs.sha256 }}${{ steps.check.outputs.video_jar_changed == 'true' && ' (changed)' || ' (unchanged)' }}
-          title: ${{ steps.pr-title.outputs.title }}
-          body: |
-            ## Automated Checksum Update
 
             The nightly build produced artifacts with updated SHA256 checksums.
 
             | Artifact | Previous | New | Changed |
             |----------|----------|-----|---------|
-            | **APK** | `${{ steps.current.outputs.apk_sha256 || '(empty)' }}` | `${{ needs.build-control-proxy-apk.outputs.sha256 }}` | ${{ steps.check.outputs.apk_changed == 'true' && '✅ Yes' || 'No' }} |
-            | **IPA** | `${{ steps.current.outputs.ipa_sha256 || '(empty)' }}` | `${{ needs.build-ctrl-proxy-ios-ipa.outputs.sha256 }}` | ${{ steps.check.outputs.ipa_changed == 'true' && '✅ Yes' || 'No' }} |
-            | **iOS Runner** | `${{ steps.current.outputs.runner_sha256 || '(empty)' }}` | `${{ needs.build-ctrl-proxy-ios-ipa.outputs.runner_sha256 }}` | ${{ steps.check.outputs.runner_changed == 'true' && '✅ Yes' || 'No' }} |
-            | **video-server jar** | `${{ steps.current.outputs.video_jar_sha256 || '(empty)' }}` | `${{ needs.build-video-server-jar.outputs.sha256 }}` | ${{ steps.check.outputs.video_jar_changed == 'true' && '✅ Yes' || 'No' }} |
+            | **APK** | `${{ steps.current.outputs.apk_sha256 || '(empty)' }}` | `${{ needs.build-control-proxy-apk.outputs.sha256 }}` | ${{ steps.check.outputs.apk_changed == 'true' && 'Yes' || 'No' }} |
+            | **IPA** | `${{ steps.current.outputs.ipa_sha256 || '(empty)' }}` | `${{ needs.build-ctrl-proxy-ios-ipa.outputs.sha256 }}` | ${{ steps.check.outputs.ipa_changed == 'true' && 'Yes' || 'No' }} |
+            | **iOS Runner** | `${{ steps.current.outputs.runner_sha256 || '(empty)' }}` | `${{ needs.build-ctrl-proxy-ios-ipa.outputs.runner_sha256 }}` | ${{ steps.check.outputs.runner_changed == 'true' && 'Yes' || 'No' }} |
+            | **video-server jar** | `${{ steps.current.outputs.video_jar_sha256 || '(empty)' }}` | `${{ needs.build-video-server-jar.outputs.sha256 }}` | ${{ steps.check.outputs.video_jar_changed == 'true' && 'Yes' || 'No' }} |
 
-            ### Why did this happen?
+            Checksums change when source in `android/control-proxy/src/`,
+            `android/video-server/src/`, or `ios/control-proxy/`, the build
+            configuration, or the dependency/SDK versions change.
 
-            SHA256 checksums change when any of these change:
-            - Source code in `android/control-proxy/src/`, `android/video-server/src/`, or `ios/control-proxy/`
-            - Build configuration (`build.gradle.kts` or `project.yml`)
-            - Dependencies or SDK versions
-
-            ### What to do
-
-            1. Review this PR to ensure the changes are expected
-            2. Merge when ready
-            3. Future releases will use these checksums for artifact verification
-
-            ---
-            Auto-generated by the `nightly` workflow
-          branch: auto-update/nightly-sha256
-          delete-branch: true
-          labels: |
-            automated
-            release engineering
-
-      - name: "Enable auto-merge on PR"
-        if: steps.check.outputs.needed == 'true' && steps.create-pr.outputs.pull-request-number != ''
-        env:
-          GH_TOKEN: ${{ secrets.AUTO_MOBILE_PR_TOKEN }}
+            Auto-generated by the `nightly` workflow.
         run: |
-          gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} --auto --squash
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # AUTO_MOBILE_PR_TOKEN is an admin actor and bypasses the green-main
+          # ruleset, so this lands on main with no PR — no external code review
+          # is spent on a machine-generated constant bump, and there is no
+          # auto-merge to wedge. The script re-syncs to origin/main and
+          # regenerates from scratch each attempt, so a concurrent push can
+          # never leave a conflicted tree.
+          bash scripts/push-release-constants.sh
 
   # =============================================================================
   # Full iOS Xcode-version sweep

--- a/scripts/push-release-constants.sh
+++ b/scripts/push-release-constants.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Regenerate the release constants on top of the latest origin/main and push the
+# result straight to main, retrying if a concurrent push wins the race first.
+#
+# Why direct-to-main instead of a PR:
+#   The nightly checksum update used to open a PR and enable auto-merge. That
+#   burned an external code review on a machine-generated one-line constant bump,
+#   and the PR could wedge: opening the PR with labels fired several
+#   `pull_request` events in the same second, and when `cancel-in-progress`
+#   cancelled the run that had already registered its check runs, those cancelled
+#   checks stayed pinned to the head SHA and the green-main ruleset never saw the
+#   required contexts satisfied. Auto-merge then parked forever (PR #4090).
+#
+#   AUTO_MOBILE_PR_TOKEN is an admin actor and bypasses the green-main ruleset,
+#   so the push lands with no PR and no status checks — the same mechanism
+#   push-readme-badges.sh already uses for the README badge commit.
+#
+# Why re-sync + regenerate instead of rebase-and-push:
+#   Each attempt hard-resets to the latest origin/main and regenerates the
+#   constants from scratch, so there is never anything to merge or rebase and a
+#   concurrent push can never leave a conflicted tree (the failure mode that
+#   issue #3590 fixed for the badge push).
+set -euo pipefail
+
+attempts="${RELEASE_CONSTANTS_PUSH_ATTEMPTS:-3}"
+retry_sleep="${RELEASE_CONSTANTS_RETRY_SLEEP:-5}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+generate_script="${RELEASE_CONSTANTS_GENERATE_SCRIPT:-${script_dir}/generate-release-constants.sh}"
+
+if [ -z "${RELEASE_CONSTANTS_COMMIT_MESSAGE:-}" ]; then
+  echo "RELEASE_CONSTANTS_COMMIT_MESSAGE must be set" >&2
+  exit 1
+fi
+
+for attempt in $(seq 1 "${attempts}"); do
+  git fetch origin main
+  git reset --hard origin/main
+
+  bash "${generate_script}"
+
+  if git diff --quiet; then
+    echo "Release constants already up to date with origin/main"
+    exit 0
+  fi
+
+  # Stage tracked modifications only. The job's working tree also holds the
+  # downloaded APK/IPA/jar artifacts, which `git add -A` would sweep in.
+  git add -u
+  git commit -m "${RELEASE_CONSTANTS_COMMIT_MESSAGE}"
+
+  if git push origin HEAD:main; then
+    echo "Pushed release constants update to main"
+    exit 0
+  fi
+
+  echo "Push attempt ${attempt} lost a race with origin/main; retrying..." >&2
+  sleep "${retry_sleep}"
+done
+
+echo "Failed to push release constants update to main after ${attempts} attempts" >&2
+exit 1

--- a/test/bats/push-release-constants.bats
+++ b/test/bats/push-release-constants.bats
@@ -1,0 +1,120 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/push-release-constants.sh.
+#
+# The nightly checksum update pushes straight to main instead of opening a PR
+# (which burned an external code review on a generated constant bump and could
+# wedge auto-merge behind cancelled check runs — PR #4090). Like the badge push
+# it must never rebase, so a concurrent push can never leave a conflicted tree.
+
+SCRIPT="scripts/push-release-constants.sh"
+WORKFLOW=".github/workflows/nightly.yml"
+
+setup() {
+  TEST_ROOT="$(mktemp -d)"
+  BIN_DIR="${TEST_ROOT}/bin"
+  mkdir -p "$BIN_DIR"
+  GIT_LOG="${TEST_ROOT}/git.log"
+  GIT_STATE="${TEST_ROOT}/push.state"
+
+  # Fake `git` shadowing the real one; other coreutils stay real.
+  cat > "${BIN_DIR}/git" <<'FAKE'
+#!/usr/bin/env bash
+echo "$*" >> "${FAKE_GIT_LOG}"
+case "$1" in
+  diff)  exit "${FAKE_GIT_DIFF_RC:-1}" ;;  # `git diff --quiet`
+  push)
+    state="${FAKE_GIT_STATE}"
+    n="$(cat "$state" 2>/dev/null || echo 0)"; n=$((n + 1)); echo "$n" > "$state"
+    [ "${FAKE_GIT_PUSH_ALWAYS_FAIL:-0}" = "1" ] && exit 1
+    [ "$n" -le "${FAKE_GIT_PUSH_FAIL_UNTIL:-0}" ] && exit 1
+    exit 0 ;;
+  *) exit 0 ;;
+esac
+FAKE
+  chmod +x "${BIN_DIR}/git"
+
+  # Fake constants generator: the fake `git diff` decides whether a change
+  # exists, so this only needs to succeed.
+  GENERATE_SCRIPT="${TEST_ROOT}/fake-generate.sh"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$GENERATE_SCRIPT"
+  chmod +x "$GENERATE_SCRIPT"
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT"
+}
+
+run_push() {
+  run env PATH="${BIN_DIR}:${PATH}" \
+    FAKE_GIT_LOG="$GIT_LOG" FAKE_GIT_STATE="$GIT_STATE" \
+    RELEASE_CONSTANTS_GENERATE_SCRIPT="$GENERATE_SCRIPT" \
+    RELEASE_CONSTANTS_COMMIT_MESSAGE="chore: update CtrlProxy APK SHA256" \
+    RELEASE_CONSTANTS_RETRY_SLEEP=0 "$@" \
+    bash "$SCRIPT"
+}
+
+@test "pushes on the first attempt when the constants changed" {
+  run_push FAKE_GIT_DIFF_RC=1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Pushed release constants update to main"* ]]
+  grep -q "reset --hard origin/main" "$GIT_LOG"
+  grep -q "push origin HEAD:main" "$GIT_LOG"
+  ! grep -q "rebase" "$GIT_LOG"
+}
+
+@test "no-op (no push) when constants already match main" {
+  run_push FAKE_GIT_DIFF_RC=0
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already up to date"* ]]
+  ! grep -q "push origin" "$GIT_LOG"
+}
+
+@test "stages tracked edits only, never the downloaded artifacts" {
+  # `git add -A` would sweep in untracked build artifacts left in the work tree.
+  run_push FAKE_GIT_DIFF_RC=1
+  [ "$status" -eq 0 ]
+  grep -q "add -u" "$GIT_LOG"
+  ! grep -q "add -A" "$GIT_LOG"
+}
+
+@test "refuses to run without a commit message" {
+  run env PATH="${BIN_DIR}:${PATH}" \
+    FAKE_GIT_LOG="$GIT_LOG" FAKE_GIT_STATE="$GIT_STATE" \
+    RELEASE_CONSTANTS_GENERATE_SCRIPT="$GENERATE_SCRIPT" \
+    bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"RELEASE_CONSTANTS_COMMIT_MESSAGE must be set"* ]]
+  [ ! -s "$GIT_LOG" ]
+}
+
+@test "retries after losing a race, then succeeds — without rebasing" {
+  run_push FAKE_GIT_DIFF_RC=1 FAKE_GIT_PUSH_FAIL_UNTIL=1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"lost a race"* ]]
+  [[ "$output" == *"Pushed release constants update to main"* ]]
+  # Two push attempts, each preceded by a fresh reset (no lingering rebase state).
+  [ "$(grep -c 'push origin HEAD:main' "$GIT_LOG")" -eq 2 ]
+  [ "$(grep -c 'reset --hard origin/main' "$GIT_LOG")" -eq 2 ]
+  ! grep -q "rebase" "$GIT_LOG"
+}
+
+@test "fails cleanly after exhausting all attempts" {
+  run_push FAKE_GIT_DIFF_RC=1 FAKE_GIT_PUSH_ALWAYS_FAIL=1
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Failed to push release constants update to main after 3 attempts"* ]]
+  [ "$(grep -c 'push origin HEAD:main' "$GIT_LOG")" -eq 3 ]
+  ! grep -q "rebase" "$GIT_LOG"
+}
+
+@test "nightly.yml pushes to main instead of opening a checksum PR" {
+  grep -q "bash scripts/push-release-constants.sh" "$WORKFLOW"
+  # The admin token + full history are what let the push bypass green-main.
+  grep -q "token: \${{ secrets.AUTO_MOBILE_PR_TOKEN }}" "$WORKFLOW"
+  grep -q "fetch-depth: 0" "$WORKFLOW"
+  # The PR path must not come back: it spent an external code review on a
+  # generated constant bump and wedged behind cancelled check runs (PR #4090).
+  ! grep -q "peter-evans/create-pull-request" "$WORKFLOW"
+  ! grep -q "gh pr merge" "$WORKFLOW"
+  ! grep -q "auto-update/nightly-sha256" "$WORKFLOW"
+}


### PR DESCRIPTION
## Summary

The nightly checksum bump opened a PR and enabled auto-merge. That spent an external code review on a machine-generated one-line constant bump, and the PR could wedge permanently. This switches it to a direct push to `main`, via a new `scripts/push-release-constants.sh` that mirrors the existing `scripts/push-readme-badges.sh`.

`AUTO_MOBILE_PR_TOKEN` is an admin actor and bypasses the `green-main` ruleset, so there is no PR to review and no auto-merge to wedge — the same mechanism the README badge commit has been using.

## Linked Issue

No issue — diagnosed directly from #4090, which is still open and blocked.

## Bug / Regression Context

- **Prior attempts:** none; the PR-based flow has worked most nights by luck of a race.
- **Observed symptom:** #4090 sat at `mergeable: MERGEABLE` / `mergeStateStatus: BLOCKED` indefinitely with auto-merge enabled and **no actual test failure**. `gh pr checks` looked largely green.
- **Repro steps / conditions:**
  1. `create-pull-request` opens the PR **with two labels**. `pull_request.yml` listens to `[opened, synchronize, reopened, labeled]`, so `opened` + two `labeled` events fire in the same second — four "Pull Request" runs were created for the same SHA.
  2. `cancel-in-progress: true` culls all but one, but the survivor is not reliably the newest: a run created at `01:30:47` survived while the `01:30:48` run was cancelled.
  3. The cancelled run had already reached "Set up job" and **registered check runs** for ~30 required contexts, stamped `cancelled`/`failure`.
  4. Those stay pinned to the head SHA, so the rollup holds both a `success` and a `cancelled` check run per required context. `green-main` never sees them satisfied; auto-merge parks silently.

Verify with `gh api repos/kaeawc/auto-mobile/commits/6dca46f/check-runs` — duplicate names with differing conclusions.

## What a reviewer should know

- **The exact-string title contract is intact.** The titles now serve as the **commit subject**, and the artifact table moves from the PR body into the **commit body**, so the `release-workflow-wiring.bats` greps over `nightly.yml` keep passing untouched. This was the main constraint shaping the diff.
- **`sha256_only` in `pull_request.yml` is deliberately retained** — nightly no longer routes through it, but it still skips heavy CI for hand-opened checksum PRs, and bats pins it.
- **`git add -u`, not `git add -A`.** The job's work tree holds the downloaded APK/IPA/jar; `-A` would sweep them in. There's a test for this.
- **The pre-generate step is dropped as dead** — the push script hard-resets to `origin/main`, discarding its output.
- **Trade-off:** the bump now lands with no pre-merge CI. In practice this is near-identical to today, since the `sha256_only` classifier already skipped every heavy job on these PRs, and `merge.yml` runs on `main` afterward either way.
- **Follow-up not in this PR:** #4090 itself is still wedged. `gh run rerun 29793313914` unwedges it, or it can simply be closed as redundant once this lands — the next nightly re-derives the checksums.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes — all 17 checks green (run in full per `.github/CLAUDE.md`, since this touches a workflow)
- [x] Full `bats test/bats/` suite: **409 tests, 0 failures**, including the 17 release-wiring tests and 7 new ones
- [x] New generic code reuses an existing project helper — `push-release-constants.sh` mirrors `push-readme-badges.sh` rather than inventing a new push pattern; no new dependency
- [x] Rebased onto latest `main`, no conflicts
- [ ] `bun run typecheck` — N/A, no TypeScript changed
- [ ] Android/iOS validation — N/A
- [ ] Interfaces + fakes + FakeTimer — N/A; the new tests use the established bats fake-`git` harness copied from `push-readme-badges.bats`

## Device Verification

N/A — CI-only change.
