### PR TITLE
fix(ios,test): unbreak workflow assertion after the #4082 prereq guard

### DIFF
--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
@@ -1009,14 +1009,8 @@ private func assertWorkflowStepRunsWhenNotCancelled(
         file: file,
         line: line
     )
-    // Assert the clause this helper is about -- `!cancelled()`, i.e. the step runs
-    // after an earlier leg FAILS but is skipped on cancellation -- rather than the
-    // whole condition. #4082 conjoined a shared-prerequisite guard
-    // (`&& steps.build-ctrlproxy.outcome == 'success'`) which does not change the
-    // failure-vs-cancellation semantics under test here; that guard has its own
-    // coverage in test/bats/xctest-shared-prereq-gate.bats.
     XCTAssertTrue(
-        stepBlockHasActiveTopLevelValueContaining(stepBlock, key: "if", substring: "!cancelled()"),
+        stepBlockRespectsCancellation(stepBlock),
         "\(stepName) must run after an earlier Reminders leg fails, but still respect cancellation",
         file: file,
         line: line
@@ -1065,30 +1059,38 @@ private func workflowStepBlock(
     return workflow[stepRange.lowerBound ..< stepBlockEnd]
 }
 
-private func stepBlockHasActiveTopLevelValue(_ stepBlock: Substring, key: String, value: String) -> Bool {
-    return stepBlockActiveLines(stepBlock).contains { line in
+/// The value of an active top-level `key:` in a step block, or nil when absent.
+/// Single place that knows the step-key indent, so the matchers below cannot
+/// drift apart.
+private func stepBlockActiveTopLevelValue(_ stepBlock: Substring, key: String) -> String? {
+    let prefix = "\(key): "
+    for line in stepBlockActiveLines(stepBlock) where line.hasPrefix("        \(key):") {
         let trimmed = line.trimmingCharacters(in: .whitespaces)
-        return line.hasPrefix("        \(key):") && trimmed == "\(key): \(value)"
+        guard trimmed.hasPrefix(prefix) else { continue }
+        return String(trimmed.dropFirst(prefix.count))
     }
+    return nil
 }
 
-/// Like `stepBlockHasActiveTopLevelValue`, but matches a *substring* of the value.
+private func stepBlockHasActiveTopLevelValue(_ stepBlock: Substring, key: String, value: String) -> Bool {
+    return stepBlockActiveTopLevelValue(stepBlock, key: key) == value
+}
+
+/// Whether a step's `if:` guarantees cancellation skips it.
 ///
-/// Step conditions legitimately grow extra conjuncts (issue #4082 added a
+/// Asserting the whole condition by equality is too strict -- #4082 conjoined a
 /// shared-prerequisite guard, making the 26.5 leg
-/// `${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}`). An
-/// exact-equality assertion turns any such addition into a false failure even
-/// when the semantics under test are unchanged, so assertions about *one* clause
-/// should match that clause rather than the whole expression.
-private func stepBlockHasActiveTopLevelValueContaining(
-    _ stepBlock: Substring,
-    key: String,
-    substring: String
-) -> Bool {
-    return stepBlockActiveLines(stepBlock).contains { line in
-        let trimmed = line.trimmingCharacters(in: .whitespaces)
-        return line.hasPrefix("        \(key):") && trimmed.contains(substring)
-    }
+/// `${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}`, which does
+/// not change the failure-vs-cancellation semantics. But a bare `contains` is too
+/// loose: it is operator-blind, and `${{ !cancelled() || X }}` evaluates to `X`
+/// when cancelled, so the step can still run -- exactly what callers forbid.
+///
+/// So require `!cancelled()` as the leading term of a `${{ ... }}` expression
+/// (the braces were pinned by the old equality assertion and are kept) and reject
+/// any disjunction. Extra `&&` conjuncts remain free to come and go.
+private func stepBlockRespectsCancellation(_ stepBlock: Substring) -> Bool {
+    guard let condition = stepBlockActiveTopLevelValue(stepBlock, key: "if") else { return false }
+    return condition.hasPrefix("${{ !cancelled()") && !condition.contains("||")
 }
 
 private func stepBlockHasActiveEnvValue(_ stepBlock: Substring, key: String, value: String) -> Bool {

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
@@ -1009,8 +1009,14 @@ private func assertWorkflowStepRunsWhenNotCancelled(
         file: file,
         line: line
     )
+    // Assert the clause this helper is about -- `!cancelled()`, i.e. the step runs
+    // after an earlier leg FAILS but is skipped on cancellation -- rather than the
+    // whole condition. #4082 conjoined a shared-prerequisite guard
+    // (`&& steps.build-ctrlproxy.outcome == 'success'`) which does not change the
+    // failure-vs-cancellation semantics under test here; that guard has its own
+    // coverage in test/bats/xctest-shared-prereq-gate.bats.
     XCTAssertTrue(
-        stepBlockHasActiveTopLevelValue(stepBlock, key: "if", value: "${{ !cancelled() }}"),
+        stepBlockHasActiveTopLevelValueContaining(stepBlock, key: "if", substring: "!cancelled()"),
         "\(stepName) must run after an earlier Reminders leg fails, but still respect cancellation",
         file: file,
         line: line
@@ -1063,6 +1069,25 @@ private func stepBlockHasActiveTopLevelValue(_ stepBlock: Substring, key: String
     return stepBlockActiveLines(stepBlock).contains { line in
         let trimmed = line.trimmingCharacters(in: .whitespaces)
         return line.hasPrefix("        \(key):") && trimmed == "\(key): \(value)"
+    }
+}
+
+/// Like `stepBlockHasActiveTopLevelValue`, but matches a *substring* of the value.
+///
+/// Step conditions legitimately grow extra conjuncts (issue #4082 added a
+/// shared-prerequisite guard, making the 26.5 leg
+/// `${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}`). An
+/// exact-equality assertion turns any such addition into a false failure even
+/// when the semantics under test are unchanged, so assertions about *one* clause
+/// should match that clause rather than the whole expression.
+private func stepBlockHasActiveTopLevelValueContaining(
+    _ stepBlock: Substring,
+    key: String,
+    substring: String
+) -> Bool {
+    return stepBlockActiveLines(stepBlock).contains { line in
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        return line.hasPrefix("        \(key):") && trimmed.contains(substring)
     }
 }
 

--- a/test/bats/xctest-shared-prereq-gate.bats
+++ b/test/bats/xctest-shared-prereq-gate.bats
@@ -32,8 +32,84 @@ WORKFLOW=".github/workflows/pull_request.yml"
   [ -z "$bare" ]
 }
 
-@test "the 26.5 leg gates on steps.build-ctrlproxy.outcome == success" {
-  # The eight 26.5-leg steps that were !cancelled() now carry the shared-build guard.
-  count="$(grep -c "!cancelled() && steps.build-ctrlproxy.outcome == 'success'" "$WORKFLOW")"
-  [ "$count" -ge 8 ]
+# Print the active `if:` value for a named step, or nothing when the step has none.
+#
+# Scanning starts only AFTER the 26.2 leg's final step: several step names occur
+# twice in the job (e.g. "Select Xcode 26.5" is both the job's initial toolchain
+# selection, which has no `if:`, and the 26.5 leg's re-selection, which does).
+# Without the anchor the first, unguarded occurrence matches and the assertion
+# reports a false violation. This mirrors `afterStepName` in the Swift helper.
+#
+# awk, not sed -- BSD sed lacks the range forms this needs. A step block runs from
+# its `- name: "<step>"` line to the next step start or a step-indent comment.
+ANCHOR_STEP='Run Reminders integration tests (Xcode 26.2)'
+
+step_if_condition() {
+  awk -v want="      - name: \"$1\"" -v anchor="      - name: \"$ANCHOR_STEP\"" '
+    !past && $0 == anchor { past = 1; next }
+    !past { next }
+    $0 == want { inblock = 1; next }
+    inblock && /^      [-#]/ { exit }
+    inblock && /^        if:/ {
+      sub(/^        if:[[:space:]]*/, "")
+      print
+      exit
+    }
+  ' "$WORKFLOW"
+}
+
+# Every Xcode 26.5 leg step that must not run on a doomed shared prerequisite.
+# Named explicitly: a global count cannot tell "each of these is guarded" from
+# "the total happens to add up", so one step could lose its guard while an
+# unrelated step gained one and the suite would stay green.
+xcode_265_leg_steps() {
+  cat <<'STEPS'
+Select Xcode 26.5
+Ensure iOS Simulator runtime (Xcode 26.5)
+Boot iOS Simulator (Xcode 26.5)
+Ensure AutoMobile daemon ready (Xcode 26.5)
+Warm up iOS CtrlProxy (Xcode 26.5)
+Pre-build Reminders XCTest bundle (Xcode 26.5)
+Warm up Reminders target app (Xcode 26.5)
+Run Reminders integration tests (Xcode 26.5)
+STEPS
+}
+
+@test "every 26.5-leg step individually gates on steps.build-ctrlproxy.outcome == success" {
+  local offenders=""
+  while IFS= read -r step; do
+    [ -n "$step" ] || continue
+    condition="$(step_if_condition "$step")"
+    if [ -z "$condition" ]; then
+      offenders="${offenders}${step}: no 'if:' condition"$'\n'
+    elif [[ "$condition" != *"steps.build-ctrlproxy.outcome == 'success'"* ]]; then
+      offenders="${offenders}${step}: ${condition}"$'\n'
+    fi
+  done < <(xcode_265_leg_steps)
+
+  if [ -n "$offenders" ]; then
+    echo "26.5-leg steps missing the shared-build guard:" >&2
+    echo "$offenders" >&2
+  fi
+  [ -z "$offenders" ]
+}
+
+@test "every 26.5-leg step still respects cancellation" {
+  # The other half of the condition. RemindersPlanContentTests owns this too (via
+  # stepBlockRespectsCancellation); asserted here so a Swift-only or bats-only run
+  # cannot lose the property silently.
+  local offenders=""
+  while IFS= read -r step; do
+    [ -n "$step" ] || continue
+    condition="$(step_if_condition "$step")"
+    if [[ "$condition" != *"!cancelled()"* ]] || [[ "$condition" == *"||"* ]]; then
+      offenders="${offenders}${step}: ${condition:-<none>}"$'\n'
+    fi
+  done < <(xcode_265_leg_steps)
+
+  if [ -n "$offenders" ]; then
+    echo "26.5-leg steps that do not skip on cancellation:" >&2
+    echo "$offenders" >&2
+  fi
+  [ -z "$offenders" ]
 }


### PR DESCRIPTION
**Unblocks iOS CI.** Follow-up to a regression I introduced in #4088.

## Problem

#4088 (issue #4082) conjoined a shared-prerequisite guard onto the Xcode 26.5 leg conditions:

```yaml
# before
if: ${{ !cancelled() }}
# after
if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
```

`RemindersPlanContentTests` asserted that condition with **exact string equality**, so every 26.5 step now fails `testPullRequestWorkflowRunsSecondRemindersLegAfterFirstLegFailureUnlessCancelled`, reddening **Swift Packages** on any PR that triggers the iOS job set.

The semantics the test *names* were never broken: after a 26.2 Reminders failure with a good build the condition is still true, and cancellation still skips. Only the string differs.

### Correction on how it reached main

An earlier draft of this description claimed the Swift job "didn't run on #4088". **That was wrong.** Review established that the `ios` paths-filter already includes `.github/workflows/pull_request.yml`, and `Swift Packages (Xcode 26.5)` **did run and did fail** on #4088 at `23:02:27Z` — the PR auto-merged at `23:02:32Z`, five seconds later.

The actual cause is that the `green-main` ruleset's required contexts include neither `Swift Packages (Xcode 26.5)` nor the `iOS` / `iOS Build` rollups, so automerge did not wait on them. That is a governance gap well beyond this PR and is filed separately.

## Fix

`stepBlockRespectsCancellation` encodes the property instead of string-matching it:

```swift
private func stepBlockRespectsCancellation(_ stepBlock: Substring) -> Bool {
    guard let condition = stepBlockActiveTopLevelValue(stepBlock, key: "if") else { return false }
    return condition.hasPrefix("${{ !cancelled()") && !condition.contains("||")
}
```

- Requires `!cancelled()` to **lead** a `${{ ... }}` expression — restoring the `${{` wrapper the old equality assertion pinned.
- **Rejects disjunctions**: `!cancelled() || X` evaluates to `X` when cancelled, so the step can still run. A bare `contains` was operator-blind and accepted it.
- Extra `&&` conjuncts stay free to come and go, which is the whole point.
- Both matchers now delegate to one `stepBlockActiveTopLevelValue` extraction core, so the step-key indent literal lives in a single place.

### BATS: the guard is now asserted per-step

The previous `grep -c ... >= 8` was a **global count**. A reviewer reproduced the false negative: strip the guard from one 26.5 step, add a guarded step elsewhere, the count returns to 8 and **everything stays green** — the #4082 regression landing fully clean. Replaced with per-step assertions over the eight named steps, plus a companion per-step cancellation assertion so that property is not owned solely by the Swift suite.

## Verification (run locally, not assumed)

- `swift test --filter RemindersPlanContentTests` → **26/26** (was failing).
- `bats test/bats/xctest-shared-prereq-gate.bats` → **4/4**.
- **Non-vacuity, each case reproduced:** dropping `!cancelled()` fails the Swift assertion; injecting `!cancelled() || …` fails it; the two-edit count trick fails the new per-step bats assertion.
- SwiftLint: one pre-existing `contains_over_range_nil_comparison` **warning**, no new violations (independently confirmed by a reviewer against both PR-head and main).

## Known gaps, deliberately not in scope

- The same relaxed helper backs the **nightly** assertion (`:411`), but the bats guard is `pull_request.yml`-only. `nightly.yml` has no `build-ctrlproxy` step, so the conjunct that forced this change cannot appear there; the new predicate still enforces the `${{ !cancelled()` prefix and the no-disjunction rule there.
- `RemindersPlanContentTests.swift:954` pins `run: ./scripts/ci/run-reminders-launch-plan-tests.sh` by exact equality across four call sites — same landmine class, filed separately.