### PR TITLE
ci(ios): bounded retry + diagnostics on simulator boot (#4095)

### DIFF
--- a/scripts/ios/boot-simulator.sh
+++ b/scripts/ios/boot-simulator.sh
@@ -139,20 +139,57 @@ echo "Ensuring ${DEVICE_NAME} (${UDID}) is booted..." >&2
 # So verify the post-condition instead: the device must actually be in the
 # "Booted" state. This mirrors how the Android emulator path proves readiness
 # (independent signals rather than one command's exit code).
-set +e
-boot_log="$(xcrun simctl bootstatus "${UDID}" -b 2>&1)"
-boot_rc=$?
-set -e
-printf '%s\n' "${boot_log}" >&2
+# A wedge is usually transient runner state, not a broken simulator definition, so
+# a single failure should not red the build (issue #4095). Retry a bounded number
+# of times: shut the device down, and before the final attempt erase it to clear
+# corrupt per-device state. Both knobs are env-tunable so the tests can exercise
+# the retry path without real sleeps.
+MAX_BOOT_ATTEMPTS="${BOOT_SIMULATOR_MAX_ATTEMPTS:-2}"
+RETRY_DELAY_SECONDS="${BOOT_SIMULATOR_RETRY_DELAY_SECONDS:-5}"
 
-BOOT_STATE="$(xcrun simctl list devices -j \
-  | jq -r --arg udid "${UDID}" '
-      .devices | to_entries[] | .value[]
-      | select(.udid == $udid) | .state
-    ' | head -1)"
+device_state() {
+  xcrun simctl list devices -j \
+    | jq -r --arg udid "$1" '
+        .devices | to_entries[] | .value[]
+        | select(.udid == $udid) | .state
+      ' \
+    | head -1
+}
 
-if [[ ${boot_rc} -ne 0 ]] || [[ "${BOOT_STATE}" != "Booted" ]]; then
-  echo "error: simulator ${UDID} failed to boot (bootstatus rc=${boot_rc}, state=${BOOT_STATE:-unknown})" >&2
+booted=0
+BOOT_STATE=""
+for attempt in $(seq 1 "${MAX_BOOT_ATTEMPTS}"); do
+  set +e
+  boot_log="$(xcrun simctl bootstatus "${UDID}" -b 2>&1)"
+  boot_rc=$?
+  set -e
+  printf '%s\n' "${boot_log}" >&2
+
+  BOOT_STATE="$(device_state "${UDID}")"
+  if [[ ${boot_rc} -eq 0 && "${BOOT_STATE}" == "Booted" ]]; then
+    booted=1
+    break
+  fi
+
+  echo "warning: boot attempt ${attempt}/${MAX_BOOT_ATTEMPTS} failed for ${UDID} (bootstatus rc=${boot_rc}, state=${BOOT_STATE:-unknown})" >&2
+  # Diagnostics: without these a recurrence is only ever inferred from the bare
+  # timeout, which is what made the original wedge so hard to characterize.
+  xcrun simctl list devices 2>/dev/null | grep -F "${UDID}" >&2 || true
+
+  if [[ ${attempt} -lt ${MAX_BOOT_ATTEMPTS} ]]; then
+    xcrun simctl shutdown "${UDID}" >/dev/null 2>&1 || true
+    if [[ ${attempt} -eq $((MAX_BOOT_ATTEMPTS - 1)) ]]; then
+      echo "Erasing ${UDID} to clear per-device state before the final attempt..." >&2
+      xcrun simctl erase "${UDID}" >/dev/null 2>&1 || true
+    fi
+    if [[ "${RETRY_DELAY_SECONDS}" -gt 0 ]]; then
+      sleep "${RETRY_DELAY_SECONDS}"
+    fi
+  fi
+done
+
+if [[ ${booted} -ne 1 ]]; then
+  echo "error: simulator ${UDID} failed to boot after ${MAX_BOOT_ATTEMPTS} attempt(s) (last state=${BOOT_STATE:-unknown})" >&2
   exit 1
 fi
 

--- a/test/bats/boot-simulator.bats
+++ b/test/bats/boot-simulator.bats
@@ -8,6 +8,8 @@ SCRIPT="scripts/ios/boot-simulator.sh"
 setup() {
   MOCK_BIN="$(mktemp -d)"
   ORIG_PATH="$PATH"
+  # Exercise the retry path without real sleeps (#4095).
+  export BOOT_SIMULATOR_RETRY_DELAY_SECONDS=0
 }
 
 teardown() {
@@ -127,6 +129,67 @@ SCRIPT
   [ "$status" -eq 0 ]
   [[ "$output" == *"HEALTHY-UDID"* ]]
   [[ "$output" != *"failed to boot"* ]]
+}
+
+@test "retries a wedged boot and succeeds on the second attempt (#4095)" {
+  # A wedge is usually transient runner state: the first bootstatus leaves the
+  # device Shutdown, the retry brings it up. The build must not go red for that.
+  cat > "${MOCK_BIN}/state" <<'STATE'
+Shutdown
+STATE
+  cat > "${MOCK_BIN}/xcrun" <<'SCRIPT'
+#!/bin/sh
+STATE_FILE="$(dirname "$0")/state"
+if [ "$1" = "--sdk" ] && [ "$2" = "iphonesimulator" ] && [ "$3" = "--show-sdk-version" ]; then
+  echo "26.5"
+elif [ "$1" = "simctl" ] && [ "$2" = "list" ] && [ "$3" = "runtimes" ]; then
+  echo '{"runtimes":[{"version":"26.5.0","identifier":"com.apple.CoreSimulator.SimRuntime.iOS-26-5"}]}'
+elif [ "$1" = "simctl" ] && [ "$2" = "list" ] && [ "$3" = "devices" ]; then
+  echo "{\"devices\":{\"com.apple.CoreSimulator.SimRuntime.iOS-26-5\":[{\"name\":\"iPhone 17 Pro\",\"udid\":\"RETRY-UDID\",\"state\":\"$(cat "$STATE_FILE")\"}]}}"
+elif [ "$1" = "simctl" ] && [ "$2" = "bootstatus" ]; then
+  # First attempt leaves it Shutdown; after the shutdown/erase cycle it comes up.
+  if [ "$(cat "$STATE_FILE")" = "Shutdown" ]; then
+    echo "[..] Status=4294967295, isTerminal=YES, Elapsed=32:06."
+    echo "	Finished"
+  fi
+  exit 0
+elif [ "$1" = "simctl" ] && [ "$2" = "erase" ]; then
+  echo "Booted" > "$STATE_FILE"
+fi
+SCRIPT
+  chmod +x "${MOCK_BIN}/xcrun"
+  export PATH="${MOCK_BIN}:${PATH}"
+
+  run bash "$SCRIPT" --ios-version 26.5
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"RETRY-UDID"* ]]
+  [[ "$output" == *"boot attempt 1/2 failed"* ]]
+  [[ "$output" == *"Booted: "* ]]
+}
+
+@test "gives up after the bounded attempt budget and reports the last state" {
+  cat > "${MOCK_BIN}/xcrun" <<'SCRIPT'
+#!/bin/sh
+if [ "$1" = "--sdk" ] && [ "$2" = "iphonesimulator" ] && [ "$3" = "--show-sdk-version" ]; then
+  echo "26.5"
+elif [ "$1" = "simctl" ] && [ "$2" = "list" ] && [ "$3" = "runtimes" ]; then
+  echo '{"runtimes":[{"version":"26.5.0","identifier":"com.apple.CoreSimulator.SimRuntime.iOS-26-5"}]}'
+elif [ "$1" = "simctl" ] && [ "$2" = "list" ] && [ "$3" = "devices" ]; then
+  echo '{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-26-5":[{"name":"iPhone 17 Pro","udid":"DEAD-UDID","state":"Shutdown"}]}}'
+elif [ "$1" = "simctl" ] && [ "$2" = "bootstatus" ]; then
+  exit 0
+fi
+SCRIPT
+  chmod +x "${MOCK_BIN}/xcrun"
+  export PATH="${MOCK_BIN}:${PATH}"
+
+  BOOT_SIMULATOR_MAX_ATTEMPTS=3 run bash "$SCRIPT" --ios-version 26.5
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"after 3 attempt(s)"* ]]
+  [[ "$output" == *"last state=Shutdown"* ]]
+  [[ "$output" == *"boot attempt 3/3 failed"* ]]
 }
 
 @test "fails when bootstatus exits 0 but the device never reaches Booted (wedge)" {


### PR DESCRIPTION
Addresses the retry + diagnostics portion of #4095.

## Problem

A wedged simulator boot is usually transient runner state, not a broken simulator definition. Since #4092 the gate correctly *detects* a wedge (device never reaches `Booted`) — but with no retry, a single transient failure goes straight to red and needs a manual rerun. That is better than the original 30-minute hang, and still not good enough.

The original failure was also hard to characterize because nothing captured simulator state at the moment it failed.

## Change

Retry a bounded number of times before giving up:

- **shutdown** between attempts, and **erase before the final attempt** to clear corrupt per-device state
- **dump the device's `simctl` listing on every failed attempt**, so the next recurrence is characterizable rather than inferred from a bare timeout
- report the attempt budget and last observed state in the failure message

Both knobs are env-tunable — `BOOT_SIMULATOR_MAX_ATTEMPTS` (default 2) and `BOOT_SIMULATOR_RETRY_DELAY_SECONDS` (default 5) — so the bats suite exercises the retry path with **zero sleeps**; the whole file still runs in ~1.1s.

## Scope

Script only. The **inter-leg CoreSimulator reclamation** idea from #4095 stays with the #4078 matrix-split work, so the two changes don't both rewrite `pull_request.yml`. The matrix split is the bigger lever anyway — it removes "boot #3", which owns the entire slow tail (median 221s vs 81–100s for boots #1/#2, max 818s, all 9 boots ≥300s).

## Tests

- `retries a wedged boot and succeeds on the second attempt` — verified to **fail** when attempts are forced to 1.
- `gives up after the bounded attempt budget and reports the last state`.
- The #4092 **healthy-boot regression guard still passes**, so the `Status=4294967295` false positive has not crept back — that is the specific re-regression I most wanted covered here.
- 13/13 bats, shellcheck clean.

## Validation caveat

The retry logic is proven against mocked `xcrun`. Whether it actually converts real wedges into non-events can only be confirmed on the runners over time — no genuine wedge has occurred since #4092 landed, so the live wedge path remains unexercised.