### PR TITLE
test(ios): match Reminders run: invocation as a property, not a literal (#4102)

### DIFF
--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
@@ -792,6 +792,8 @@ private func assertWorkflowUsesLocalCtrlProxyBuildForRemindersRun(
     }
 
     let jobBlock = workflow[jobRange.lowerBound ..< runRange.lowerBound]
+    // Deliberately exact: this is a boolean switch, and "true" is the only value
+    // that means "skip the release-IPA download". There is no narrower property.
     XCTAssertTrue(
         jobBlock.contains("AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD: \"true\""),
         "The PR XCTestRunner job must use the locally built CtrlProxy artifacts instead of downloading a release IPA",
@@ -873,6 +875,9 @@ private func assertWorkflowWarmsTargetAppBeforeRemindersRun(
     let nextStepRange = workflow[runRange.upperBound...].range(of: "\n      - name:")
     let runBlockEnd = nextStepRange?.lowerBound ?? workflow.endIndex
     let runBlock = workflow[runRange.lowerBound ..< runBlockEnd]
+    // Deliberately exact: 10 minutes is the number
+    // `assertRemindersTimeoutFitsWorkflowStepCap` computes its 600s budget
+    // against. A looser matcher would let the two drift apart silently.
     XCTAssertTrue(
         runBlock.contains("timeout-minutes: 10"),
         "\(runStepName) must keep the Reminders step cap aligned with the retry timeout guard",
@@ -935,6 +940,9 @@ private func assertWorkflowRetriesRemindersRunOnce(
     line: UInt = #line
 ) {
     let runBlock = workflowStepBlock(workflow, stepName: runStepName, file: file, line: line)
+    // Deliberately exact: the whole point of this assertion is that the retry
+    // budget is exactly one. `2` or `0` are both regressions, so any looser
+    // matcher (prefix/contains) would defeat the test rather than harden it.
     XCTAssertTrue(
         stepBlockHasActiveEnvValue(runBlock, key: "AUTOMOBILE_TEST_RETRY_COUNT", value: "\"1\""),
         "\(runStepName) must enable exactly one bounded retry for cold first-leg bring-up flakes",
@@ -951,12 +959,9 @@ private func assertWorkflowRunsGuardedRemindersTest(
 ) {
     let runBlock = workflowStepBlock(workflow, stepName: runStepName, file: file, line: line)
     XCTAssertTrue(
-        stepBlockHasActiveTopLevelValue(
-            runBlock,
-            key: "run",
-            value: "./scripts/ci/run-reminders-launch-plan-tests.sh"
-        ),
-        "\(runStepName) must fail when the filtered Reminders test command executes zero XCTest cases",
+        stepBlockRunsScript(runBlock, script: "./scripts/ci/run-reminders-launch-plan-tests.sh"),
+        "\(runStepName) must run the guarded Reminders runner, which fails when the filtered "
+            + "Reminders test command executes zero XCTest cases",
         file: file,
         line: line
     )
@@ -1072,8 +1077,25 @@ private func stepBlockActiveTopLevelValue(_ stepBlock: Substring, key: String) -
     return nil
 }
 
-private func stepBlockHasActiveTopLevelValue(_ stepBlock: Substring, key: String, value: String) -> Bool {
-    return stepBlockActiveTopLevelValue(stepBlock, key: key) == value
+/// Whether a step's `run:` invokes `script` as its command.
+///
+/// Pinning the whole `run:` value by equality was a landmine (#4102): adding any
+/// flag or argument to the invocation broke every call site at once, even though
+/// the property under test -- that this step shells out to the guarded Reminders
+/// runner -- was unchanged. That is the same shape of false failure #4088 caused
+/// for `if:` conditions.
+///
+/// So match the invocation instead of the literal: the script must be the *first*
+/// token of the command. Arguments stay free to come and go, while repointing the
+/// step at a different script, or merely mentioning this script as an argument to
+/// something else, still fails. Callers that care about a specific argument should
+/// assert that argument explicitly rather than widening this matcher.
+///
+/// A multi-line `run: |` block is deliberately not accepted: these are
+/// single-command steps, and the value of a block scalar is `|`, not a command.
+private func stepBlockRunsScript(_ stepBlock: Substring, script: String) -> Bool {
+    guard let command = stepBlockActiveTopLevelValue(stepBlock, key: "run") else { return false }
+    return command.split(separator: " ", maxSplits: 1).first.map(String.init) == script
 }
 
 /// Whether a step's `if:` guarantees cancellation skips it.


### PR DESCRIPTION
Closes #4102.

## Problem

`RemindersPlanContentTests` pinned

```yaml
run: ./scripts/ci/run-reminders-launch-plan-tests.sh
```

by **exact equality** across four call sites. Adding any flag or argument to that invocation would break all four at once, even though the property under test — that the step shells out to the guarded Reminders runner — is unchanged.

This is the same shape of false failure #4088 caused for `if:` conditions, which took CI down and was fixed in #4100 by encoding the property instead of the literal.

## Fix

`stepBlockRunsScript` matches the **invocation**: the script must be the *first token* of the command.

```swift
private func stepBlockRunsScript(_ stepBlock: Substring, script: String) -> Bool {
    guard let command = stepBlockActiveTopLevelValue(stepBlock, key: "run") else { return false }
    return command.split(separator: " ", maxSplits: 1).first.map(String.init) == script
}
```

Arguments stay free; repointing the step, demoting the script to an argument of something else (`bash ./script.sh`), or deleting the key all still fail.

`stepBlockHasActiveTopLevelValue` had exactly one caller, so it was **replaced rather than duplicated** — `stepBlockActiveTopLevelValue` remains the single extraction core, with `stepBlockRunsScript` and `stepBlockRespectsCancellation` as the two property matchers on top of it.

## Deliberately left exact (each now says why in a comment)

- `AUTOMOBILE_TEST_RETRY_COUNT: "1"` — the test's name *is* "retries once"; `0` and `2` are both regressions, so loosening defeats the test.
- `timeout-minutes: 10` — the exact number `assertRemindersTimeoutFitsWorkflowStepCap` computes its 600s budget against; loosening lets the two drift silently.
- `AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD: "true"` — boolean switch, no narrower property exists.

Swept the rest of the file: every other `XCTAssertEqual` is on plan JSON or `RemindersIntegrationBase` properties, not workflow YAML; the other YAML assertions were already `contains`-based.

## Non-vacuity (the important part)

A converted assertion that can no longer fail is worse than the landmine it replaced, so each direction was checked by mutating the workflow and restoring:

| Mutation | Expected | Result |
|---|---|---|
| repoint to a different script | fail | **fails** |
| append ` --xcode 26.2` (the #4102 landmine) | pass | **passes** |
| `bash ./script.sh` (script no longer the command) | fail | **fails** |
| delete the `run:` line | fail | **fails** |

26/26 tests pass; SwiftLint reports only the pre-existing `contains_over_range_nil_comparison` warning, no new violations. I re-ran the suite and the repoint case independently rather than taking the numbers on trust.