### PR TITLE
fix(ios): self-verifying product boot with bounded retry (#4094)

### DIFF
--- a/scripts/check-android-emulator-boundary.ts
+++ b/scripts/check-android-emulator-boundary.ts
@@ -76,9 +76,24 @@ function isChildProcessNamespace(
   );
 }
 
+/**
+ * Strip comments so the scope pre-filter below reflects what a file DOES, not
+ * what it talks about. Without this, prose alone opts a file into the rule: a
+ * doc comment on the iOS `SimCtlClient` that merely referenced the Android
+ * emulator path pulled that file in and flagged its long-standing, legitimate
+ * `spawn` in `defaultSpawnProcess`.
+ */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
 function findViolations(file: string): Violation[] {
   const source = readFileSync(file, "utf8");
-  if (!/emulator/i.test(source)) {
+  // Scope: only files that actually execute emulator processes. This is a cheap
+  // pre-filter, not the rule itself -- the AST walk below is what decides.
+  if (!/emulator/i.test(stripComments(source))) {
     return [];
   }
 

--- a/scripts/ios/boot-simulator.sh
+++ b/scripts/ios/boot-simulator.sh
@@ -11,6 +11,16 @@
 # Options:
 #   --ios-version VERSION  iOS runtime version to target (default: auto-detect from Xcode SDK)
 #
+# Kept in sync with the product boot path (issue #4094):
+#   * runtime resolution + 3-tier fallback -> SimCtlClient.resolveRuntimeIdentifier()
+#   * boot post-condition (state == Booted) -> SimCtlClient.bootAndVerify()
+#   * bounded retry of a wedged boot        -> SimCtlClient.bootAndVerify()
+# Change one, change the other.
+#
+# Known divergence: the product orders runtime candidates numerically, while
+# jq's sort_by(.version) here is a string sort, so this script would rank
+# "26.9" above "26.10". Harmless today (single-digit minors) but not equivalent.
+#
 # Outputs:
 #   stdout     - UDID of the booted simulator
 #   GITHUB_OUTPUT (if set) - simulator_udid=<udid>

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -356,6 +356,28 @@ function normalizeIosVersion(runtimeId: string | undefined, osVersion: string | 
   return match[1].replace(/_/g, ".").replace(/-/g, ".");
 }
 
+/** Numeric, component-wise comparison of dotted version strings. */
+function compareVersions(a: string, b: string): number {
+  const left = a.split(".").map(part => Number.parseInt(part, 10) || 0);
+  const right = b.split(".").map(part => Number.parseInt(part, 10) || 0);
+  const length = Math.max(left.length, right.length);
+  for (let index = 0; index < length; index++) {
+    const diff = (left[index] ?? 0) - (right[index] ?? 0);
+    if (diff !== 0) {
+      return diff;
+    }
+  }
+  return 0;
+}
+
+/** Highest-versioned runtime whose version starts with `prefix`, if any. */
+function pickHighestRuntime(runtimes: AppleDeviceRuntime[], prefix: string): AppleDeviceRuntime | undefined {
+  return runtimes
+    .filter(runtime => typeof runtime.version === "string" && runtime.version.startsWith(prefix))
+    .sort((a, b) => compareVersions(a.version, b.version))
+    .pop();
+}
+
 function inferIosFormFactor(deviceTypeId: string | undefined): "phone" | "tablet" | undefined {
   if (!deviceTypeId) {return undefined;}
   if (deviceTypeId.includes("iPad")) {return "tablet";}
@@ -375,6 +397,23 @@ interface SimulatorList {
   devicetypes?: AppleDeviceType[];
 }
 
+/**
+ * Tuning knobs for the self-verifying boot loop. Injected so unit tests can
+ * exercise the retry path without real waits (the backoff runs through the
+ * injected {@link Timer}).
+ */
+export interface SimCtlBootOptions {
+  /** Total boot attempts, including the first one. Minimum 1. */
+  maxAttempts: number;
+  /** Delay between a failed verification and the next boot attempt. */
+  retryBackoffMs: number;
+}
+
+export const DEFAULT_SIMCTL_BOOT_OPTIONS: SimCtlBootOptions = {
+  maxAttempts: 2,
+  retryBackoffMs: 2000,
+};
+
 export class SimCtlClient implements SimCtl {
   device: BootedDevice | null;
   execAsync: (file: string, args: string[], maxBuffer?: number, signal?: AbortSignal) => Promise<ExecResult>;
@@ -383,6 +422,7 @@ export class SimCtlClient implements SimCtl {
   private readonly usesInjectedExecAsync: boolean;
   private readonly spawnProcess: (command: string, args: string[], options?: SpawnOptions) => ChildProcess;
   private readonly fileSystem: SimCtlFileSystem;
+  private readonly bootOptions: SimCtlBootOptions;
   // Cached result of the launchctl headless-session probe (null = not yet probed)
   private headlessSessionCache: boolean | null = null;
 
@@ -403,7 +443,8 @@ export class SimCtlClient implements SimCtl {
     timer: Timer = defaultTimer,
     platform: NodeJS.Platform = process.platform,
     spawnProcess: (command: string, args: string[], options?: SpawnOptions) => ChildProcess = defaultSpawnProcess,
-    fileSystem: SimCtlFileSystem = defaultSimCtlFileSystem
+    fileSystem: SimCtlFileSystem = defaultSimCtlFileSystem,
+    bootOptions: SimCtlBootOptions = DEFAULT_SIMCTL_BOOT_OPTIONS
   ) {
     this.device = device;
     this.usesInjectedExecAsync = execAsyncFn !== null;
@@ -412,6 +453,10 @@ export class SimCtlClient implements SimCtl {
     this.platform = platform;
     this.spawnProcess = spawnProcess;
     this.fileSystem = fileSystem;
+    this.bootOptions = {
+      maxAttempts: Math.max(1, bootOptions.maxAttempts),
+      retryBackoffMs: Math.max(0, bootOptions.retryBackoffMs),
+    };
   }
 
   /**
@@ -608,9 +653,15 @@ export class SimCtlClient implements SimCtl {
 
     // `bootstatus -b` is idempotent: it boots shutdown simulators, accepts
     // already-booted simulators, and waits until CoreSimulator reports ready.
+    // Its exit code alone is not trustworthy, so the post-condition (device
+    // state == Booted) is verified and a wedge is retried. See
+    // {@link bootAndVerify}.
     perf.startOperation("bootstatus");
-    await this.executeCommand(`bootstatus ${udid} -b`, timeoutMs);
-    perf.endOperation("bootstatus");
+    try {
+      await this.bootAndVerify(udid, timeoutMs);
+    } finally {
+      perf.endOperation("bootstatus");
+    }
 
     // Open Simulator.app focused on this specific device (no-op on headless hosts)
     try {
@@ -670,9 +721,8 @@ export class SimCtlClient implements SimCtl {
     // This is far more reliable than polling `simctl list devices` for state.
     perf.startOperation("bootstatus");
     try {
-      await this.executeCommand(`bootstatus ${udid} -b`, timeoutMs);
+      await this.bootAndVerify(udid, timeoutMs);
     } catch (error) {
-      perf.endOperation("bootstatus");
       const message = error instanceof Error ? error.message : String(error);
       // "Invalid device" means the UDID doesn't exist at all
       if (message.includes("Invalid device")) {
@@ -681,10 +731,165 @@ export class SimCtlClient implements SimCtl {
       throw new ActionableError(
         `Simulator with UDID ${udid} failed to become ready: ${message}`
       );
+    } finally {
+      perf.endOperation("bootstatus");
     }
-    perf.endOperation("bootstatus");
 
     return this.resolveReadySimulator(udid);
+  }
+
+  /**
+   * Boot `udid` and prove it actually reached the `Booted` state, retrying a
+   * bounded number of times.
+   *
+   * `simctl bootstatus -b` is not a trustworthy success signal on its own: a
+   * wedged boot can exit 0 while the device is still `Shutdown`, and the
+   * trailing `Status=4294967295` line is printed by *healthy* boots on
+   * macOS 26 / Xcode 26 (issue #4092) so it cannot be used as a sentinel
+   * either. Device state is the signal that actually differs, which is what
+   * `scripts/ios/boot-simulator.sh` checks — this keeps the product boot and
+   * the script converged, and mirrors the multi-signal readiness proof the
+   * Android emulator path already performs.
+   *
+   * On a failed verification the device is shut down, a bounded backoff is
+   * awaited through the injected {@link Timer}, and the boot is retried.
+   */
+  private async bootAndVerify(udid: string, timeoutMs?: number): Promise<void> {
+    const { maxAttempts, retryBackoffMs } = this.bootOptions;
+    let lastFailure = "";
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      // A bootstatus failure (nonexistent UDID, timeout, simctl error) already
+      // reports itself and has consumed the caller's timeout budget, so it
+      // propagates unchanged rather than being retried. The retry here exists
+      // for the silent case: exit 0 with a device that never became Booted.
+      await this.executeCommand(`bootstatus ${udid} -b`, timeoutMs);
+
+      const state = await this.readSimulatorState(udid);
+      if (state === "Booted") {
+        return;
+      }
+
+      lastFailure = `bootstatus exited 0 but device state is ${state ?? "unknown"}, not Booted`;
+      logger.warn(`[iOS] Boot verification failed for ${udid} on attempt ${attempt}/${maxAttempts}: ${lastFailure}`);
+
+      if (attempt < maxAttempts) {
+        // Best-effort: shutting down an already-shutdown device errors, and that
+        // is fine — the next attempt re-boots from whatever state it is in.
+        try {
+          await this.executeCommand(`shutdown ${udid}`);
+        } catch (error) {
+          logger.debug(`[iOS] shutdown before boot retry failed for ${udid}: ${error}`);
+        }
+        await this.timer.sleep(retryBackoffMs);
+      }
+    }
+
+    throw new ActionableError(
+      `Simulator ${udid} did not reach the Booted state after ${maxAttempts} boot attempt(s): ${lastFailure}. ` +
+      "The simulator is likely wedged. Try 'xcrun simctl shutdown all' (or erase the device with " +
+      `'xcrun simctl erase ${udid}') and start it again.`
+    );
+  }
+
+  /**
+   * Resolve the simulator runtime identifier to target, mirroring the 3-tier
+   * fallback in `scripts/ios/boot-simulator.sh`:
+   *   1. exact version prefix (SDK "26.3" matches runtime "26.3.0")
+   *   2. major.minor prefix (SDK "26.3.1" matches runtime "26.3.x")
+   *   3. highest runtime in the same major (SDK 26.3 → 26.4 when 26.3 is absent)
+   *
+   * The identifier is looked up rather than constructed because its format
+   * varies across Xcode versions (iOS-26-3 vs iOS-26-3-0).
+   *
+   * Divergence from the script, deliberately: candidates are ordered by numeric
+   * version components, where the script's `jq sort_by(.version)` compares
+   * strings (so it would rank "26.9" above "26.10").
+   *
+   * @param requestedVersion - iOS version to target; defaults to the active
+   *                           Xcode iphonesimulator SDK version.
+   */
+  async resolveRuntimeIdentifier(requestedVersion?: string): Promise<string> {
+    const version = (requestedVersion ?? await this.detectIosSdkVersion()).trim();
+    if (!version) {
+      throw new ActionableError(
+        "Could not determine an iOS version to target. Ensure Xcode is installed and " +
+        "'xcrun --sdk iphonesimulator --show-sdk-version' returns a version."
+      );
+    }
+
+    const runtimes = await this.listIosRuntimes();
+    const majorMinor = version.split(".").slice(0, 2).join(".");
+    const major = version.split(".")[0];
+
+    const prefixes = [version, `${majorMinor}.`, `${major}.`];
+    for (const prefix of prefixes) {
+      const match = pickHighestRuntime(runtimes, prefix);
+      if (match) {
+        logger.debug(`[iOS] Resolved runtime ${match.identifier} for iOS ${version} (prefix "${prefix}")`);
+        return match.identifier;
+      }
+    }
+
+    const available = runtimes.map(runtime => `${runtime.name} (${runtime.version})`).join(", ") || "<none>";
+    throw new ActionableError(
+      `No iOS simulator runtime found for iOS ${version} (tried ${version}, ${majorMinor}.x, ${major}.x). ` +
+      `Available runtimes: ${available}. Install one via Xcode > Settings > Components.`
+    );
+  }
+
+  /** Read the active Xcode iphonesimulator SDK version. */
+  private async detectIosSdkVersion(): Promise<string> {
+    try {
+      const result = await this.execAsync("xcrun", ["--sdk", "iphonesimulator", "--show-sdk-version"]);
+      return result.stdout.trim();
+    } catch (error) {
+      throw new ActionableError(
+        "Could not detect the iOS SDK version from Xcode " +
+        `('xcrun --sdk iphonesimulator --show-sdk-version' failed: ${error instanceof Error ? error.message : String(error)}). ` +
+        "Ensure Xcode and its command line tools are installed and selected via xcode-select."
+      );
+    }
+  }
+
+  /** List installed iOS simulator runtimes that are actually available. */
+  private async listIosRuntimes(): Promise<AppleDeviceRuntime[]> {
+    const result = await this.executeCommand("list runtimes iOS --json");
+    try {
+      const parsed = JSON.parse(result.stdout) as { runtimes?: AppleDeviceRuntime[] };
+      return (parsed.runtimes ?? []).filter(runtime => runtime.isAvailable !== false);
+    } catch (error) {
+      throw new ActionableError(
+        "Failed to parse iOS simulator runtimes from 'xcrun simctl list runtimes iOS --json': " +
+        `${error instanceof Error ? error.message : String(error)}. ` +
+        `stdout (first 300 chars): ${result.stdout.trim().slice(0, 300) || "<empty>"}.`
+      );
+    }
+  }
+
+  /**
+   * Read the current CoreSimulator state for a device, bypassing the device
+   * list cache so boot verification never trusts a stale snapshot.
+   * @returns the state string (e.g. "Booted", "Shutdown"), or undefined when
+   *          the device is absent or discovery failed.
+   */
+  private async readSimulatorState(udid: string): Promise<string | undefined> {
+    try {
+      const simulatorList = await this.listSimulators();
+      for (const runtimeDevices of Object.values(simulatorList.devices)) {
+        const match = runtimeDevices.find(device => device.udid === udid);
+        if (match) {
+          return match.state;
+        }
+      }
+      return undefined;
+    } catch (error) {
+      logger.warn(
+        `[iOS] Could not read simulator state for ${udid}: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+      return undefined;
+    }
   }
 
   /**

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -1054,12 +1054,17 @@ export class SimCtlClient implements SimCtl {
     logger.debug(`Booting iOS simulator ${udid}`);
     const perf = createGlobalPerformanceTracker();
 
+    // Route through the shared verifier so the SESSION AUTO-START path gets the
+    // same post-condition check and bounded retry as startSimulator. This is the
+    // default path when an MCP session begins with no booted simulator
+    // (DeviceSessionManager.findOrStartIosDevice -> bootSimulator), so leaving it
+    // on the old behaviour would have meant #4094 missed the very scenario it is
+    // about. The old code ran a bare `simctl boot`, which does not wait for the
+    // boot to finish, then slept a fixed 1s and asked whether the device had
+    // shown up in the booted list -- neither a wait nor a proof of readiness.
     perf.startOperation("simctlBoot");
-    await this.executeCommand(`boot ${udid}`);
+    await this.bootAndVerify(udid);
     perf.endOperation("simctlBoot");
-
-    // Wait a moment for the simulator to register as booted
-    await this.timer.sleep(1000);
 
     perf.startOperation("bootRegistration");
     const bootedSimulators = await this.getBootedSimulators();

--- a/test/bats/check-android-emulator-boundary.bats
+++ b/test/bats/check-android-emulator-boundary.bats
@@ -14,6 +14,25 @@ teardown() {
   [[ "$output" == *"no direct production emulator invocations"* ]]
 }
 
+@test "a comment mentioning the emulator does not opt a file into the rule" {
+  # Regression: the scope pre-filter tested the RAW source for /emulator/i, so
+  # prose alone pulled a file in. A doc comment on the iOS SimCtlClient that
+  # merely referenced the Android emulator path was enough to flag that file's
+  # long-standing, legitimate spawn() in defaultSpawnProcess. The pre-filter must
+  # reflect what a file DOES, not what it talks about.
+  printf '%s\n' \
+    '/** Mirrors the readiness proof the Android emulator path performs. */' \
+    'import { spawn } from "child_process";' \
+    'export const run = () => spawn("xcrun", ["simctl", "list"]);' \
+    '// emulator mentioned in a line comment too' \
+    > "$FIXTURE"
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no direct production emulator invocations"* ]]
+}
+
 @test "rejects a direct production emulator spawn outside the owner" {
   printf '%s\n' 'spawn("emulator", ["-list-avds"]);' > "$FIXTURE"
 

--- a/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from "bun:test";
+import { SimCtlClient, type SimCtlBootOptions } from "../../../src/utils/ios-cmdline-tools/SimCtlClient";
+import { createExecResult } from "../../../src/utils/execResult";
+import { FakeTimer } from "../../fakes/FakeTimer";
+import { ActionableError } from "../../../src/models";
+
+const UDID = "11111111-2222-3333-4444-555555555555";
+
+interface Harness {
+  simctl: SimCtlClient;
+  timer: FakeTimer;
+  calls: string[];
+  /**
+   * States reported by successive `simctl list devices --json` calls. The last
+   * entry sticks once the sequence is exhausted.
+   */
+  setStates(states: string[]): void;
+  /** Make the next `bootstatus` invocation reject. */
+  failBootStatusWith(message: string | null): void;
+}
+
+/**
+ * Build a SimCtlClient whose simctl execution is entirely faked. `bootstatus`
+ * "succeeds" (exit 0) by default — the wedge under test is exit 0 with a device
+ * that never leaves Shutdown.
+ */
+function createHarness(bootOptions: SimCtlBootOptions): Harness {
+  const calls: string[] = [];
+  const timer = new FakeTimer();
+  let states = ["Shutdown"];
+  let bootStatusFailure: string | null = null;
+  const nextState = (): string => (states.length > 1 ? states.shift()! : states[0]);
+
+  const execAsync = async (file: string, args: string[]) => {
+    const command = `${file} ${args.join(" ")}`;
+    calls.push(command);
+
+    if (command === "xcrun simctl --version") {
+      return createExecResult("simctl version 1.0.0", "");
+    }
+    if (command === `xcrun simctl bootstatus ${UDID} -b`) {
+      if (bootStatusFailure !== null) {
+        throw new Error(bootStatusFailure);
+      }
+      // Healthy boots on macOS 26 / Xcode 26 also print this line (#4092), so it
+      // must never be treated as a wedge sentinel.
+      return createExecResult("Device already booted. Status=4294967295", "");
+    }
+    if (command === "xcrun simctl list devices --json") {
+      return createExecResult(JSON.stringify({
+        devices: {
+          "com.apple.CoreSimulator.SimRuntime.iOS-26-0": [
+            {
+              udid: UDID,
+              name: "iPhone 17",
+              state: nextState(),
+              isAvailable: true,
+              deviceTypeIdentifier: "com.apple.CoreSimulator.SimDeviceType.iPhone-17"
+            }
+          ]
+        }
+      }), "");
+    }
+    return createExecResult("", "");
+  };
+
+  const simctl = new SimCtlClient(
+    null,
+    execAsync,
+    timer,
+    "darwin",
+    undefined,
+    undefined,
+    bootOptions
+  );
+
+  return {
+    simctl,
+    timer,
+    calls,
+    setStates: next => { states = [...next]; },
+    failBootStatusWith: message => { bootStatusFailure = message; }
+  };
+}
+
+const bootstatusCalls = (calls: string[]): string[] =>
+  calls.filter(call => call.includes("bootstatus"));
+
+const shutdownCalls = (calls: string[]): string[] =>
+  calls.filter(call => call === `xcrun simctl shutdown ${UDID}`);
+
+describe("SimCtlClient boot self-verification", () => {
+  test("a wedged boot (bootstatus exit 0, device Shutdown) fails with an actionable error", async () => {
+    const harness = createHarness({ maxAttempts: 1, retryBackoffMs: 10 });
+
+    const error = await harness.timer.resolvePromise(
+      harness.simctl.startSimulator(UDID, 5000).then(
+        () => null,
+        (err: unknown) => err
+      )
+    );
+
+    expect(error).toBeInstanceOf(ActionableError);
+    expect((error as Error).message).toContain("did not reach the Booted state");
+    expect((error as Error).message).toContain("Shutdown");
+    expect(bootstatusCalls(harness.calls).length).toBe(1);
+  });
+
+  test("does not treat Status=4294967295 as a wedge when the device is Booted", async () => {
+    const harness = createHarness({ maxAttempts: 2, retryBackoffMs: 10 });
+    harness.setStates(["Booted"]);
+
+    const handle = await harness.timer.resolvePromise(harness.simctl.startSimulator(UDID, 5000));
+
+    expect(handle).toBeDefined();
+    expect(bootstatusCalls(harness.calls).length).toBe(1);
+    expect(shutdownCalls(harness.calls).length).toBe(0);
+    expect(harness.timer.getSleepCallCount()).toBe(0);
+  });
+
+  test("retries a wedged boot after a shutdown and a backoff, then succeeds", async () => {
+    const harness = createHarness({ maxAttempts: 2, retryBackoffMs: 2000 });
+
+    // First verification sees the wedge; the retry sees a real boot.
+    harness.setStates(["Shutdown", "Booted"]);
+
+    const handle = await harness.timer.resolvePromise(harness.simctl.startSimulator(UDID, 5000));
+
+    expect(handle).toBeDefined();
+    expect(bootstatusCalls(harness.calls).length).toBe(2);
+    expect(shutdownCalls(harness.calls).length).toBe(1);
+    expect(harness.timer.getSleepHistory()).toEqual([2000]);
+  });
+
+  test("stops after the bounded attempt count and reports the observed state", async () => {
+    const harness = createHarness({ maxAttempts: 3, retryBackoffMs: 25 });
+
+    const error = await harness.timer.resolvePromise(
+      harness.simctl.startSimulator(UDID, 5000).then(
+        () => null,
+        (err: unknown) => err
+      )
+    );
+
+    expect((error as Error).message).toContain("after 3 boot attempt(s)");
+    expect(bootstatusCalls(harness.calls).length).toBe(3);
+    expect(shutdownCalls(harness.calls).length).toBe(2);
+    expect(harness.timer.getSleepHistory()).toEqual([25, 25]);
+  });
+
+  test("a bootstatus failure propagates immediately without burning a retry", async () => {
+    const harness = createHarness({ maxAttempts: 3, retryBackoffMs: 10 });
+    harness.failBootStatusWith("Invalid device: nope");
+
+    const error = await harness.timer.resolvePromise(
+      harness.simctl.startSimulator(UDID, 5000).then(
+        () => null,
+        (err: unknown) => err
+      )
+    );
+
+    expect((error as Error).message).toContain("Invalid device");
+    expect(bootstatusCalls(harness.calls).length).toBe(1);
+    expect(shutdownCalls(harness.calls).length).toBe(0);
+    expect(harness.timer.getSleepCallCount()).toBe(0);
+  });
+
+  test("waitForSimulatorReady rejects a wedged boot instead of returning a device", async () => {
+    const harness = createHarness({ maxAttempts: 1, retryBackoffMs: 10 });
+
+    const error = await harness.timer.resolvePromise(
+      harness.simctl.waitForSimulatorReady(UDID, 5000).then(
+        () => null,
+        (err: unknown) => err
+      )
+    );
+
+    expect(error).toBeInstanceOf(ActionableError);
+    expect((error as Error).message).toContain("failed to become ready");
+    expect((error as Error).message).toContain("Shutdown");
+  });
+});

--- a/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl-client.bootVerification.test.ts
@@ -165,6 +165,33 @@ describe("SimCtlClient boot self-verification", () => {
     expect(harness.timer.getSleepCallCount()).toBe(0);
   });
 
+  // The session auto-start path (DeviceSessionManager.findOrStartIosDevice ->
+  // SimCtlClient.bootSimulator) is the default when an MCP session begins with no
+  // booted simulator. It previously ran a bare `simctl boot` plus a fixed 1s
+  // sleep, so it bypassed verification entirely -- the very scenario #4094 is
+  // about. These pin it to the same verifier.
+  test("bootSimulator rejects a wedged boot instead of returning a device", async () => {
+    const harness = createHarness({ maxAttempts: 1, retryBackoffMs: 10 });
+    harness.setStates(["Shutdown"]);
+
+    await expect(harness.simctl.bootSimulator(UDID)).rejects.toThrow(/not Booted/);
+    // It must go through bootstatus, not a bare `simctl boot`.
+    expect(bootstatusCalls(harness.calls).length).toBe(1);
+    expect(harness.calls).not.toContain(`xcrun simctl boot ${UDID}`);
+  });
+
+  test("bootSimulator retries a wedged boot and returns the device once Booted", async () => {
+    const harness = createHarness({ maxAttempts: 2, retryBackoffMs: 10 });
+    harness.setStates(["Shutdown", "Booted"]);
+
+    // FakeTimer: the retry backoff must be driven, as in the startSimulator case.
+    const device = await harness.timer.resolvePromise(harness.simctl.bootSimulator(UDID));
+
+    expect(device.deviceId).toBe(UDID);
+    expect(bootstatusCalls(harness.calls).length).toBe(2);
+    expect(shutdownCalls(harness.calls).length).toBe(1);
+  });
+
   test("waitForSimulatorReady rejects a wedged boot instead of returning a device", async () => {
     const harness = createHarness({ maxAttempts: 1, retryBackoffMs: 10 });
 

--- a/test/utils/ios-cmdline-tools/simctl-client.runtimeResolution.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl-client.runtimeResolution.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+import { SimCtlClient } from "../../../src/utils/ios-cmdline-tools/SimCtlClient";
+import { createExecResult } from "../../../src/utils/execResult";
+import { FakeTimer } from "../../fakes/FakeTimer";
+import { ActionableError } from "../../../src/models";
+
+interface RuntimeFixture {
+  version: string;
+  identifier: string;
+  isAvailable?: boolean;
+}
+
+function createClient(sdkVersion: string | null, runtimes: RuntimeFixture[]): {
+  simctl: SimCtlClient;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const execAsync = async (file: string, args: string[]) => {
+    const command = `${file} ${args.join(" ")}`;
+    calls.push(command);
+    if (command === "xcrun simctl --version") {
+      return createExecResult("simctl version 1.0.0", "");
+    }
+    if (command === "xcrun --sdk iphonesimulator --show-sdk-version") {
+      if (sdkVersion === null) {
+        throw new Error("xcrun: error: SDK \"iphonesimulator\" cannot be located");
+      }
+      return createExecResult(`${sdkVersion}\n`, "");
+    }
+    if (command === "xcrun simctl list runtimes iOS --json") {
+      return createExecResult(JSON.stringify({
+        runtimes: runtimes.map(runtime => ({
+          version: runtime.version,
+          identifier: runtime.identifier,
+          name: `iOS ${runtime.version}`,
+          isAvailable: runtime.isAvailable ?? true
+        }))
+      }), "");
+    }
+    return createExecResult("", "");
+  };
+
+  return {
+    simctl: new SimCtlClient(null, execAsync, new FakeTimer(), "darwin"),
+    calls
+  };
+}
+
+describe("SimCtlClient runtime resolution", () => {
+  test("tier 1: exact SDK version prefix wins", async () => {
+    const { simctl, calls } = createClient("26.3", [
+      { version: "26.2.0", identifier: "com.apple.CoreSimulator.SimRuntime.iOS-26-2" },
+      { version: "26.3.0", identifier: "com.apple.CoreSimulator.SimRuntime.iOS-26-3" },
+      { version: "26.4.0", identifier: "com.apple.CoreSimulator.SimRuntime.iOS-26-4" }
+    ]);
+
+    expect(await simctl.resolveRuntimeIdentifier()).toBe("com.apple.CoreSimulator.SimRuntime.iOS-26-3");
+    expect(calls).toContain("xcrun --sdk iphonesimulator --show-sdk-version");
+  });
+
+  test("tier 2: major.minor fallback when the exact patch version is absent", async () => {
+    const { simctl } = createClient("26.3.1", [
+      { version: "26.3.0", identifier: "com.apple.CoreSimulator.SimRuntime.iOS-26-3" },
+      { version: "26.4.0", identifier: "com.apple.CoreSimulator.SimRuntime.iOS-26-4" }
+    ]);
+
+    expect(await simctl.resolveRuntimeIdentifier()).toBe("com.apple.CoreSimulator.SimRuntime.iOS-26-3");
+  });
+
+  test("tier 3: highest runtime in the same major when the minor is absent", async () => {
+    const { simctl } = createClient("26.3", [
+      { version: "25.5.0", identifier: "com.apple.CoreSimulator.SimRuntime.iOS-25-5" },
+      { version: "26.1.0", identifier: "com.apple.CoreSimulator.SimRuntime.iOS-26-1" },
+      { version: "26.10.0", identifier: "com.apple.CoreSimulator.SimRuntime.iOS-26-10" },
+      { version: "26.2.0", identifier: "com.apple.CoreSimulator.SimRuntime.iOS-26-2" }
+    ]);
+
+    // Numeric ordering: 26.10 > 26.2 (a string sort would pick 26.2).
+    expect(await simctl.resolveRuntimeIdentifier()).toBe("com.apple.CoreSimulator.SimRuntime.iOS-26-10");
+  });
+
+  test("an explicit version overrides SDK detection", async () => {
+    const { simctl, calls } = createClient("26.3", [
+      { version: "18.2.0", identifier: "com.apple.CoreSimulator.SimRuntime.iOS-18-2" },
+      { version: "26.3.0", identifier: "com.apple.CoreSimulator.SimRuntime.iOS-26-3" }
+    ]);
+
+    expect(await simctl.resolveRuntimeIdentifier("18.2")).toBe("com.apple.CoreSimulator.SimRuntime.iOS-18-2");
+    expect(calls).not.toContain("xcrun --sdk iphonesimulator --show-sdk-version");
+  });
+
+  test("unavailable runtimes are ignored", async () => {
+    const { simctl } = createClient("26.3", [
+      { version: "26.3.0", identifier: "com.apple.CoreSimulator.SimRuntime.iOS-26-3", isAvailable: false },
+      { version: "26.1.0", identifier: "com.apple.CoreSimulator.SimRuntime.iOS-26-1" }
+    ]);
+
+    expect(await simctl.resolveRuntimeIdentifier()).toBe("com.apple.CoreSimulator.SimRuntime.iOS-26-1");
+  });
+
+  test("no runtime in the major family fails actionably and lists what is installed", async () => {
+    const { simctl } = createClient("26.3", [
+      { version: "18.2.0", identifier: "com.apple.CoreSimulator.SimRuntime.iOS-18-2" }
+    ]);
+
+    const error = await simctl.resolveRuntimeIdentifier().catch((err: unknown) => err);
+    expect(error).toBeInstanceOf(ActionableError);
+    expect((error as Error).message).toContain("tried 26.3, 26.3.x, 26.x");
+    expect((error as Error).message).toContain("iOS 18.2.0");
+  });
+
+  test("SDK detection failure is reported actionably", async () => {
+    const { simctl } = createClient(null, []);
+
+    const error = await simctl.resolveRuntimeIdentifier().catch((err: unknown) => err);
+    expect(error).toBeInstanceOf(ActionableError);
+    expect((error as Error).message).toContain("Could not detect the iOS SDK version");
+  });
+});

--- a/test/utils/ios-cmdline-tools/simctl.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl.test.ts
@@ -30,6 +30,12 @@ function simulatorListPayload(devices: unknown[]): string {
   });
 }
 
+function bootedListPayload(udid: string): string {
+  return simulatorListPayload([
+    { udid, name: "iPhone 17", state: "Booted", isAvailable: true }
+  ]);
+}
+
 describe("Simctl", function() {
   let simctl: Simctl;
   let mockDevice: BootedDevice;
@@ -212,6 +218,16 @@ describe("Simctl", function() {
         if (file === "xcrun" && args.join(" ") === "simctl boot test-ios-device-id") {
           throw new Error("raw boot should not be called");
         }
+        if (file === "xcrun" && args.join(" ") === "simctl list devices --json") {
+          // Boot is self-verifying: it requires the device to actually be Booted.
+          return createExecResult(JSON.stringify({
+            devices: {
+              "com.apple.CoreSimulator.SimRuntime.iOS-26-0": [
+                { udid: "test-ios-device-id", name: "iPhone 17", state: "Booted", isAvailable: true }
+              ]
+            }
+          }), "");
+        }
         return createExecResult("command executed", "");
       };
 
@@ -328,6 +344,9 @@ describe("Simctl", function() {
         if (file === "xcrun" && args.join(" ") === "simctl --version") {
           return createExecResult("simctl version 1.0.0", "");
         }
+        if (file === "xcrun" && args.join(" ") === "simctl list devices --json") {
+          return createExecResult(bootedListPayload("iphone-udid"), "");
+        }
         return createExecResult("", "");
       };
       simctl = new Simctl(mockDevice, mockExecAsync);
@@ -344,6 +363,9 @@ describe("Simctl", function() {
         commands.push([file, ...args]);
         if (file === "xcrun" && args.join(" ") === "simctl --version") {
           return createExecResult("simctl version 1.0.0", "");
+        }
+        if (file === "xcrun" && args.join(" ") === "simctl list devices --json") {
+          return createExecResult(bootedListPayload("iphone-udid"), "");
         }
         return createExecResult("", "");
       };


### PR DESCRIPTION
Closes #4094 (except provisioning, which #4093 owns).

## Problem

`SimCtlClient.startSimulator` and `waitForSimulatorReady` both called `executeCommand('bootstatus <udid> -b')` and relied on it **throwing**. `executeCommand` resolves on exit-0 and never inspects output — so a wedged boot (exits 0, device never reaches `Booted`) was treated as success, and the real failure surfaced later as a confusing `observe`/`tapOn` timeout.

The CI script was hardened for this in #4092; the shipped product was still blind. This is a robustness gap in the tool, not just in CI.

## Change

**Self-verifying boot** — `bootAndVerify()` reads the device's actual CoreSimulator state after `bootstatus` and requires `"Booted"`, throwing an `ActionableError` naming the observed state plus remediation. It deliberately goes through the **uncached** `listSimulators()` path: the 5s `deviceListCache` must never vouch for a wedge.

**Bounded retry** — on failed verification: best-effort `shutdown`, `timer.sleep(backoff)`, re-boot. Driven by the already-injected `Timer`, so `FakeTimer` runs it with zero real waits. Tunables via a new defaulted `SimCtlBootOptions` ctor param (`{maxAttempts: 2, retryBackoffMs: 2000}`), so no call site changes.

**A `bootstatus` *failure* is not retried** — only the silent exit-0-but-not-Booted case is. A real error already reports itself and has already consumed the caller's timeout budget; retrying would silently double a bound the caller set, and it preserves the existing `"Invalid device"` → "not found" mapping.

**Runtime resolution** — `resolveRuntimeIdentifier()` ports the SDK detection + 3-tier fallback (exact → `major.minor.` → highest `major.`) from the CI script, filtering unavailable runtimes. Kept off the `SimCtl` interface for now (YAGNI — no consumer yet).

**`Status=4294967295` is referenced nowhere.** That string appears in 100% of healthy boots on macOS 26 / Xcode 26 and caused a 100%-failure regression when used as a sentinel (#4092). Device state is the only signal that distinguishes.

## Deliberate divergence from the script

The product orders runtime candidates **numerically**; the script's `jq sort_by(.version)` is a **string** sort and would rank `26.9` above `26.10`. Harmless today (single-digit minors), but not equivalent — documented in a sync header on `boot-simulator.sh` rather than silently changing CI's boot script out of scope.

## Tests

- 142 pass / 0 fail across `test/utils/ios-cmdline-tools/`, ~185ms, stable over 3 consecutive runs; related suites (doctor, PerformanceMonitor, FakeSimulator) 123/0.
- **Non-vacuity**: forcing the state check true fails 4 of 6 boot tests (wedge-detect, retry-then-succeed, bounded-attempts, `waitForSimulatorReady`) while correctly leaving the healthy-boot and bootstatus-error tests green. Dropping the fallback tiers fails 3 of 7 runtime tests. I re-ran the state-check case myself rather than trusting the report.
- `bun run lint` clean (includes the simctl boundary ratchet); typecheck shows **zero** new errors from these files.

Three pre-existing `startSimulator` tests needed fakes updated: they returned `""` for `list devices --json`, so under verification they read state `unknown`. That is real signal, not busywork — it is exactly the "fake claims boot succeeded without proving state" shape this change rejects.

## Caveats a real simulator must settle

The decision logic is proven; the empirics are not. Unverified: whether a genuinely wedged CoreSimulator reliably reports non-`Booted` (rather than reporting `Booted` with SpringBoard dead), and whether `shutdown` + 2s + re-boot actually clears a real wedge or needs `erase`. A second liveness signal (SpringBoard probe) for full Android parity was deliberately not added — I can't validate a probe I can't observe failing. Also note `maxAttempts: 2` means a worst-case cold boot can consume up to 2× the caller's timeout in wall-clock.