### PR TITLE
docs: link GitHub issue and PR references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ Bun TypeScript MCP server providing Android & iOS device automation capabilities
 
 ## Key Rules
 - TypeScript only (no JavaScript)
+- Always write GitHub issue and pull request references as clickable Markdown links.
 - After implementation changes, run relevant validation commands
 - Write terminal output to `scratch/` when not visible
 - Local validation scripts live under `scripts/` and should almost always be written in bash with shellcheck validation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,7 @@ Node TypeScript MCP server providing Android Debug Bridge (ADB) capabilities thr
 
 ## Key Rules
 - TypeScript only (no JavaScript)
+- Always write GitHub issue and pull request references as clickable Markdown links.
 - After implementation changes, run relevant validation commands
 - Write terminal output to `scratch/` when not visible
 - Local validation scripts live under `scripts/` and should almost always be written in bash with shellcheck validation


### PR DESCRIPTION
## What changed

- Require clickable Markdown links whenever GitHub issues or pull requests are referenced in the root agent instructions.

## Why

This keeps GitHub references immediately navigable in future agent responses.

## Validation

- `git diff --check`