### PR TITLE
ci: speed Windows Bun dependency setup

### DIFF
--- a/.github/workflows/prime-bun-cache.yml
+++ b/.github/workflows/prime-bun-cache.yml
@@ -1,0 +1,47 @@
+name: "Prime Bun Package Cache"
+
+on:
+  # A cache created on main is available to pull-request jobs. Run only when
+  # its inputs or installation behavior change so this does not add routine
+  # Windows work after unrelated merges.
+  push:
+    branches: [main]
+    paths:
+      - bun.lock
+      - scripts/ci/install-bun-deps.sh
+      - .github/workflows/prime-bun-cache.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  prime-windows-bun-package-cache:
+    name: "Prime Bun Package Cache (windows-latest)"
+    runs-on: windows-latest
+    timeout-minutes: 5
+    steps:
+      - name: "Git Checkout"
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+
+      - name: "Setup Bun"
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      # Keep this key and path aligned with the PR matrix. The package store
+      # is platform-specific (native dependencies are included), while a
+      # default-branch cache prevents every PR from starting cold.
+      - name: "Cache Bun dependencies"
+        uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: bun-windows-latest-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-windows-latest-
+
+      - name: "Install Bun dependencies"
+        shell: bash
+        run: bash scripts/ci/install-bun-deps.sh

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1000,9 +1000,11 @@ jobs:
         if: env.RUN_MCP_BUILD_TEST == 'true'
         uses: actions/cache@v5
         with:
-          path: |
-            ~/.bun/install/cache
-            node_modules
+          # Restoring node_modules is notably expensive on Windows because the
+          # archive contains thousands of small files. Bun can materialize it
+          # from its package store with platform-native links, so cache only
+          # that smaller store.
+          path: ~/.bun/install/cache
           key: bun-${{ matrix.os }}-${{ hashFiles('bun.lock') }}
           restore-keys: |
             bun-${{ matrix.os }}-

--- a/scripts/ci/install-bun-deps.sh
+++ b/scripts/ci/install-bun-deps.sh
@@ -7,7 +7,11 @@
 
 set -euo pipefail
 
-bun install --frozen-lockfile --force || {
+# Do not use --force on the normal path: CI may have restored a valid
+# node_modules tree, and --force reinstalls every dependency even when it is
+# already present. A normal frozen install verifies that tree and only repairs
+# what is missing. Keep the forced rebuild as the corruption-recovery path.
+bun install --frozen-lockfile || {
   bun pm cache rm
   bun install --frozen-lockfile --force
 }


### PR DESCRIPTION
## Summary

- stop forcing Bun to reinstall every dependency after a cache restore
- cache only Bun's package store in the cross-platform PR job, avoiding the expensive Windows `node_modules` archive
- prime the Windows package-store cache on `main` when its lockfile or install behavior changes

## Why

Windows dependency setup was a dominant portion of the TypeScript job. A restored `node_modules` archive was large and slow to extract, while `bun install --force` then reinstalled all dependencies anyway. PR-scoped caches also meant Windows did not have a refreshed default-branch cache to restore.

The package store remains OS-specific, preserving native dependency correctness. Bun materializes `node_modules` from that store with platform-native links.

## Validation

- `bun run bootstrap:worktree`
- `bash scripts/ci/install-bun-deps.sh` (warm verification: 67 ms)
- `shellcheck scripts/ci/install-bun-deps.sh`
- `actionlint -shellcheck= .github/workflows/prime-bun-cache.yml`
- `bats test/bats/release-workflow-wiring.bats test/bats/diagnostic-log-upload-nonfatal.bats`
- `git diff --check`
