### PR TITLE
feat(skills): streamline PR review follow-through

### DIFF
--- a/.agents/skills/auto-mobile-code-review/SKILL.md
+++ b/.agents/skills/auto-mobile-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: auto-mobile-code-review
-description: "Use this workflow skill to review an AutoMobile change (a PR number or the current branch diff) the way this repo demands: ground every finding in file:line, reproduce before asserting, separate real bugs from daemon-session/environment artifacts, prefer reusing existing repo helpers and conventions over new code, and catch the regression or false-negative a fix can introduce."
+description: "Review and follow through an AutoMobile PR or branch diff: collect all GitHub feedback and exact-head CI evidence, apply two stable baseline review lenses plus one diff-specific lens, verify findings in code, address authorized in-scope issues, and resolve only truly addressed threads without posting review comments."
 ---
 
 # AutoMobile Code Review

--- a/.agents/skills/auto-mobile-code-review/agents/openai.yaml
+++ b/.agents/skills/auto-mobile-code-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "AutoMobile Code Review"
-  short_description: "Verified AutoMobile PR and diff review"
-  default_prompt: "Use $auto-mobile-code-review to review the current branch diff or a specific AutoMobile PR with verified, file:line findings."
+  short_description: "Baseline plus diff-specific PR review"
+  default_prompt: "Use $auto-mobile-code-review to review the current AutoMobile PR without posting comments."

--- a/.agents/skills/github-pr-feedback/SKILL.md
+++ b/.agents/skills/github-pr-feedback/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: github-pr-feedback
+description: "Collect, triage, and safely resolve GitHub pull-request feedback with `gh` and the GitHub API without posting comments. Use for a PR's conversation comments, review submissions, inline comments, or unresolved review threads, especially before addressing feedback or declaring a PR ready."
+---
+
+# GitHub PR Feedback
+
+Read and follow the canonical GitHub PR feedback skill at
+`../../../skills/github-pr-feedback/SKILL.md`.
+
+Treat that file as the source of truth for the workflow. This wrapper only
+exposes the shared repo skill through Codex's `.agents/skills` discovery path.

--- a/.agents/skills/github-pr-feedback/agents/openai.yaml
+++ b/.agents/skills/github-pr-feedback/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "GitHub PR Feedback"
+  short_description: "Read and safely clear PR feedback"
+  default_prompt: "Use $github-pr-feedback to collect and safely resolve eligible pull-request feedback without posting comments."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ Bun TypeScript MCP server providing Android & iOS device automation capabilities
 
 ## Key Rules
 - TypeScript only (no JavaScript)
+- Always write GitHub issue and pull request references as clickable Markdown links.
 - After implementation changes, run relevant validation commands
 - Write terminal output to `scratch/` when not visible
 - Local validation scripts live under `scripts/` and should almost always be written in bash with shellcheck validation
@@ -131,6 +132,7 @@ not visible even though they are present in the shade.
 
 ### Workflow Skills
 - check-ci: Inspect PR checks, fetch failing logs, reproduce likely failures locally, and summarize next steps. Path: `skills/check-ci/SKILL.md`.
+- github-pr-feedback: Collect every PR discussion and review thread, triage it, and safely resolve feedback after verified fixes without posting comments. Path: `skills/github-pr-feedback/SKILL.md`.
 - dead-code: Detect and remove dead code using repo scripts and targeted validation. Path: `skills/dead-code/SKILL.md`.
 - observe: Inspect the current connected device state through AutoMobile observation tooling. Path: `skills/observe/SKILL.md`.
 - test: Run targeted or full test suites with the narrowest relevant command first. Path: `skills/test/SKILL.md`.

--- a/skills/auto-mobile-code-review/SKILL.md
+++ b/skills/auto-mobile-code-review/SKILL.md
@@ -1,11 +1,45 @@
 ---
 name: auto-mobile-code-review
-description: Use this workflow skill to review an AutoMobile change (a PR number or the current branch diff) the way this repo demands — ground every finding in file:line, reproduce before asserting, separate real bugs from daemon-session/environment artifacts, prefer reusing existing repo helpers and conventions over new code, and catch the regression or false-negative a fix can introduce. Deliver few verified findings, not many speculative ones.
+description: "Review and follow through an AutoMobile PR or branch diff: collect all GitHub feedback and exact-head CI evidence, apply two stable baseline review lenses plus one diff-specific lens, verify findings in code, address authorized in-scope issues, and resolve only truly addressed threads without posting review comments. Use for PR review, feedback cleanup, CI triage, or pre-merge regression review."
 ---
 
 # AutoMobile Code Review
 
-Review a change — a PR (its number passed as the argument) or, with no argument, the current branch's diff vs `origin/main` — for correctness, regressions, and fit with AutoMobile's architecture and conventions. The deliverable is a **verified, actionable** review.
+Review a change — a PR (its number passed as the argument) or, with no argument,
+the current branch's diff vs `origin/main` — for correctness, regressions, and
+fit with AutoMobile's architecture and conventions. For an eligible PR, one
+invocation performs the full review-follow-through loop; the deliverable is a
+**verified, actionable** review or a clean, evidence-backed PR state.
+
+## Authority and modes
+
+- A bare invocation for an active PR authored by the authenticated GitHub user
+  uses **follow-through mode**: collect feedback and CI, review, fix only
+  verified in-scope issues, validate, push, and resolve threads safely.
+- A PR authored by someone else is **read/triage-only**. Do not resolve its
+  threads through this skill. A user can also request review-only mode for their
+  own PR.
+- A merged or closed PR is **historical read-only** even when owned by the
+  caller. Compare its merge commit and current `origin/main`, report whether a
+  finding was remediated later, and require explicit authorization for any new
+  follow-up branch or GitHub mutation.
+- Never resolve a thread, rerun a job, push code, or declare CI green without
+  the evidence and conditions in `github-pr-feedback` and `check-ci`.
+- Never post a review, inline comment, conversation comment, or reply as part
+  of this skill's review or follow-through process. Report findings to the user
+  instead. Post only when the user separately and explicitly requests it.
+
+## PR intake comes before review
+
+For a PR, first invoke `github-pr-feedback` and `check-ci`. Capture one action
+ledger covering the PR body/linked issue, all conversation and inline comments,
+review submissions, every GraphQL review thread (including unresolved and
+outdated state), current-head check runs, workflow runs/jobs, live/completed
+logs, and relevant artifacts. Do this before assessing the diff; do not let a
+flat comment list or aggregate green status hide feedback or duplicate/cancelled
+checks.
+
+After every push, discard the old ledger and repeat intake for the new head SHA.
 
 ## What a review is for
 
@@ -21,7 +55,40 @@ The verification discipline below is the floor, not the point. Automation and pl
 - `git fetch origin main` first — always review against **latest main**, not a stale base.
 - For a PR number: `gh pr view <n> --json title,body,headRefOid,files,closingIssuesReferences`, `gh pr diff <n>`, then read the changed files on disk and the **issue it claims to close**. A PR's reviewed head can differ from what squash-**merged**, and a "fix" PR can merge **test-only** — check `git log origin/main` for what actually landed.
 - No argument: `git diff origin/main...HEAD`, then read the changed files in full (the hunk lies by omission).
-- Use the `github-cli` and `pr-analysis` skills for the mechanics of fetching PR metadata and posting review comments.
+- Use `github-cli`, `github-pr-feedback`, `check-ci`, and `pr-analysis` for
+  GitHub mechanics and state. The review owns the final technical disposition.
+
+## Review lenses
+
+Use two stable baseline lenses on a substantive PR:
+
+1. **Correctness and cross-layer contract** — verify the issue criteria, public
+   API/schema, callers, platform boundaries, and release/deliverability where
+   relevant.
+2. **Regression and test adequacy** — probe negative paths, compatibility,
+   lifecycle/concurrency/cleanup, test oracles, generated artifacts, and the
+   regression or false-negative a change can introduce.
+
+Generate one **diff-specific lens** after reading the issue criteria, changed
+paths, action ledger, and CI evidence. Give it a concrete title and charter that
+covers a risk the baseline lenses are less likely to focus on. Select it from
+the actual change, for example: wire payload/default semantics; runner release
+delivery; state-machine disposal; static-boundary bypasses; workflow and runner
+environment semantics; security/data boundaries; or CI causality and
+reproducibility. Do not use a generic third reviewer.
+
+Measure the change with `git diff --numstat origin/main...HEAD` (or the PR
+equivalent). For a PR of **100 changed lines or fewer**, use only the first
+baseline lens by default; add the diff-specific lens only when the change or
+feedback exposes a nontrivial risk. For larger or riskier PRs, run both baseline
+lenses plus the generated lens.
+
+When delegation is available, assign one lens per agent. Give each the issue
+criteria, current head SHA, changed files, action ledger, and a precise
+exclusion list naming the other lenses. Agents return evidence only and never
+edit. Report the selected diff-specific lens and its rationale in the review
+summary. An optional caller-supplied concern is input to its selection, not a
+substitute for it.
 
 ## Review principles (verify, don't speculate)
 
@@ -45,6 +112,30 @@ The verification discipline below is the floor, not the point. Automation and pl
 - **CtrlProxy capability gate:** every tool is gated by the runner's `connected` handshake `supportedCommands`. The daemon **downloads a pinned release runner** (version-agnostic cache), so local runner changes need overrides — Android: `AUTOMOBILE_SKIP_ACCESSIBILITY_DOWNLOAD_IF_INSTALLED` / `AUTOMOBILE_CTRL_PROXY_APK_PATH`; iOS: `AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH`. When iOS runner source changes, the release + checksum registry (`src/constants/release.ts`) must be re-cut or the feature is undeliverable. A mismatch between advertised `supportedCommands` and what TS routes is a real bug (e.g. `pinchOn` refuses iOS while the runner advertises `request_pinch`).
 - **Release-build SDK gating:** debug-only SDK behavior (network-mock enforcement, DB inspector, highlight overlay) MUST be `#if DEBUG`-gated. Verify a **release** build can't ship it — check the enforcement path, not just the rule-setting route.
 - **Schema drift:** `schemas/tool-definitions.json` is generated and silently drifts. The generator must register the **same** `register*Tools` categories as `src/server/index.ts`; flag any production tool missing from the artifact (and any gated/daemon-only tool falsely advertised). No CI drift guard exists.
+- **Deliverability:** a source change under `ios/control-proxy` or another
+  downloaded runner is not shipped until its signed release/version/checksum
+  path is updated. Source tests alone do not prove ordinary users receive it.
+- **Wire contracts:** for shared codecs, DTOs, defaults, aliases, or
+  serialization configuration, inspect every transport boundary and assert raw
+  payloads, including omitted defaults and explicit `null`; decoder-only tests
+  can hide a breaking encoder change.
+- **Negotiation and partial creation:** offer/answer or capability work must
+  exercise a remote rejection, fail the public operation early, and clean up any
+  resource created before the rejection.
+- **State machines and artifacts:** streaming/UI work must cover clean terminal
+  EOF, error/unavailable, queued asynchronous work completing after terminal
+  state, and disposal while work is pending. For generated recordings/downloads,
+  verify the real artifact invariant (for example non-empty and decodable), not
+  a proxy log line.
+- **Boundary ratchets:** a process/API boundary check must inventory sync and
+  async forms, named and namespace imports, and literal and variable arguments.
+  Prefer an existing structured parser over a line regexp; add a bypass matrix
+  so moving one call form behind a helper does not leave an equivalent escape.
+- **Workflow controls:** test CI gates against both failing and healthy runner
+  evidence, including the GitHub Actions environment. Assert the intended
+  post-condition or per-step semantic property, not an incidental status/log
+  sentinel, exact expression string, or global count that can be compensated
+  elsewhere.
 - **Relative paths under a detached daemon:** after the daemon `chdir`s to a stable cwd, a relative path arg MUST go through `resolvePathFromDaemonLaunchWorkingDirectory`. Grep for raw `fs.stat`/`copyFile`/`readFile` on a user-supplied relative path.
 - **Per-device singletons:** managers use `getInstance(device)` keyed by deviceId; an instance-level cache persists across calls — verify a cache fix persists where it's read.
 - **Plan vs MCP tool lookup:** plan/criticalSection execution must resolve via `getToolForPlan()`, not `getTool()` (the MCP-visibility gate) — otherwise `planExecutable`-but-hidden tools won't resolve inside a plan.
@@ -56,26 +147,12 @@ The verification discipline below is the floor, not the point. Automation and pl
 
 For **each** finding, cover three things in plain prose: your read on the change (is it a real bug, does the fix hold, are you confident or only suspicious), where it is (`file:line`, and how you checked — reproduced, read the code, checked main, `git blame`), and how to fix it (a named existing helper/convention where one fits, the manual device check that would confirm it, and any regression or false-negative the change risks).
 
-When reviewing a PR, post findings as **inline review comments** anchored to the changed line (via `gh api .../pulls/<n>/reviews` with a `comments[]` array, `event: COMMENT`) plus a short summary body — not one monolithic comment.
+In follow-through mode, triage the ledger, make only verified in-scope fixes,
+run the targeted validation, commit and push, then resolve through
+`github-pr-feedback` when the resolution conditions hold. In review-only mode,
+present findings to the user. In both modes, do not post review comments.
 
-### Write the comment so a busy author acts on it
-
-The finding can be correct and still land badly if it's a wall of text. Word each inline comment so the author sees the finding, the ask, and the repro without decoding a paragraph:
-
-- **Open with a question when it earns its place — otherwise state the finding flat.** A question is right when you genuinely don't understand the code, or when walking the author down your reasoning before you answer it reads better than asserting. When the finding is clear, just say what the bug is in one plain sentence — no `Found a bug`, no severity label. `Nit:` is the only label; reserve it for the genuinely minor.
-- **State the mechanism as the finding, not under it.** One plain sentence — `X does A, so B never happens` — every symbol, file, and flag in backticks, an em-dash for the consequence. Don't bury the finding beneath a paragraph of trace; the mechanism *is* the lede.
-- **Offer a `Suggested change for <reason>` with a ```suggestion block when the fix is a concrete line edit.** Let the author accept or reject it inline instead of re-typing your prose into code.
-- **Skip the `Verdict:`/`Evidence:`/`Fix:` labels and the enum verbatim in the posted comment.** That structure is a checklist of what to cover — your read on the change, where it is, how to fix it — not a template to stamp into GitHub. Write it as ordinary prose, loose with wording and capitalization; `this basically double-frees the handle` beats `**Verdict:** Confirmed bug`. Drop how-you-verified parentheticals (`(verified by reading code)`, "a concern I checked and dropped") — the `file:line` citation carries that, and they read as defensive.
-- **Put the reproduction on its own line.** A concrete repro is the most valuable thing in a bug comment — make it separable so the author can run it without re-deriving your claim.
-- **Keep every comment tight.** Say the thing in as few words as it takes; don't re-enumerate findings or restate the diff — the reader can find and read them.
-- **Say whether it blocks in plain words.** `this should block` or `not a blocker`, as a normal clause in the finding — don't spin up a label or severity track for it.
-- **If a thread's already been addressed, resolve it — don't write a comment.** A resolved thread already says "done"; a new comment saying so is noise.
-
-A worked rewrite — the wall first, the same finding second:
-
-> ❌ I looked into this and I believe there may be an issue where the timer scheduled by `scheduleAutoStop` ends up calling `this.stop()` (verified by reading the code), which as far as I can tell finalizes the session but does not appear to remove it from `byHandle`, so this could potentially be a concern.
->
-> ✅ The auto-stop timer calls `this.stop()`, which finalizes the session but never removes it from `byHandle` — that delete lives only in `stopAndRemove`, which auto-stop doesn't go through, so an auto-stopped session stays registered forever.
-> Set `maxDuration`, never call stop — after the timer fires, `byHandle` still holds the entry.
-
-Close with a one-paragraph **summary verdict** and the single most important thing to verify first. Stay skeptical: a verified "couldn't reproduce" beats an unverified bug report.
+Close with a one-paragraph **summary verdict**, the single most important thing
+to verify first, and the action ledger's remaining blocker (feedback, CI,
+authorization, or pending job). Stay skeptical: a verified "couldn't reproduce"
+beats an unverified bug report.

--- a/skills/auto-mobile-code-review/agents/openai.yaml
+++ b/skills/auto-mobile-code-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "AutoMobile Code Review"
-  short_description: "Verified AutoMobile PR and diff review"
-  default_prompt: "Use $auto-mobile-code-review to review the current branch diff or a specific AutoMobile PR with verified, file:line findings."
+  short_description: "Baseline plus diff-specific PR review"
+  default_prompt: "Use $auto-mobile-code-review to review the current AutoMobile PR without posting comments."

--- a/skills/check-ci/SKILL.md
+++ b/skills/check-ci/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: check-ci
-description: "Use this workflow skill for PR CI triage: inspect failing or pending checks, mergeability, and related review feedback, then reproduce likely failures locally and summarize next steps."
+description: "Use this workflow skill for PR CI triage: inspect pending and failed checks for the exact PR head, read live or completed job logs and artifacts, classify causality, reproduce likely failures locally, and summarize the safe next step."
 ---
 
 # Check CI
@@ -12,13 +12,33 @@ Use this for PR health checks and failure triage.
 
 ## Workflow
 
-1. Resolve the PR number from an argument or the current branch with `gh pr view --json number`.
-2. Inspect checks with `gh pr checks <pr>` and save verbose output to `scratch/check-ci-<pr>.log` when needed.
-3. If checks failed, fetch failed-job logs with `gh run view <run-id> --log-failed`.
-4. Check mergeability and branch drift with `gh pr view --json mergeable,mergeStateStatus` plus local `git fetch origin`.
-5. Gather review comments and unresolved feedback that may explain the failing state.
-6. Reproduce the most likely failure locally using the narrowest relevant command.
-7. Summarize current state, root cause, local repro status, and next fix steps.
+1. Resolve the PR number and snapshot `headRefOid`, `baseRefOid`, mergeability,
+   and merge state. Use this SHA for every subsequent query; an empty legacy
+   combined status is inconclusive, not green.
+2. Collect `gh pr checks <pr> --json name,state,bucket,link,workflow` and
+   paginated REST check runs for `repos/<owner>/<repo>/commits/<head-sha>/check-runs`.
+   Flag duplicate check names with different conclusions on the same head (for
+   example, a cancelled older run plus a successful newer one).
+3. Enumerate paginated Actions runs for that head SHA, then each run's jobs.
+   Ignore obsolete runs for older SHAs. Keep queued/in-progress jobs as pending;
+   they are never implicitly green.
+4. For a completed failed job, use `gh run view <run-id> --job <job-id>
+   --log-failed`. For an active job, poll its job endpoint to a bounded deadline
+   and retrieve any available log archive through `gh api
+   "repos/<owner>/<repo>/actions/jobs/<job-id>/logs"`, saving it under `scratch/`.
+   Do not use `gh api --follow` (the installed CLI does not support it); report
+   the exact run/job if it remains pending.
+5. If console output is truncated or lacks the failure body, list the run's
+   artifacts and inspect the relevant log artifact. If `gh run download` is
+   unauthorized, state that exact blocker and use an available GitHub connector
+   artifact download capability when one exists; do not infer a root cause.
+6. Classify every red result as PR-caused, pre-existing, transient/infrastructure,
+   or unproven. Ground that classification in the job log, changed paths, and
+   current `origin/main`; rerun a job only when the evidence supports a transient
+   failure. Never change code for an unrelated or unproven failure.
+7. Reproduce a PR-caused failure locally with the narrowest authoritative command.
+   After a push, restart at step 1 because all checks and feedback are scoped to
+   the previous SHA.
 
 ## Repo Validation Mapping
 
@@ -31,7 +51,8 @@ Use this for PR health checks and failure triage.
 ## Output Structure
 
 - Current CI state
-- Failing checks and likely root cause
+- Run/job/head-SHA ledger, including pending jobs and duplicate/stale checks
+- Failing checks, evidence, and causal classification
 - Mergeability or conflict status
-- Review feedback that is still actionable
+- Artifact or authorization limitations
 - Recommended next action

--- a/skills/github-cli/SKILL.md
+++ b/skills/github-cli/SKILL.md
@@ -5,11 +5,21 @@ description: Helper skill for GitHub operations in this repo; use it when anothe
 
 # GitHub CLI Usage
 
-Use `gh` for GitHub work in this repo.
+Use `gh` for GitHub work in this repo. Resolve `owner/repo` once with
+`gh repo view --json nameWithOwner -q .nameWithOwner`; record a PR's
+`headRefOid` before correlating comments, checks, runs, or jobs.
 
 - Prefer `gh pr view`, `gh pr list`, `gh pr create`, and `gh pr edit` for pull requests.
 - Prefer `gh issue list` and `gh issue view` for issues.
-- Prefer `gh pr checks` and `gh run view` for CI status and logs.
-- Use `gh api` or GraphQL only when `gh` subcommands do not expose the data or mutation you need.
+- Prefer `gh pr checks` and `gh run view` for CI status and completed-job logs.
+- Use paginated REST calls for comments, inline comments, review submissions,
+  check runs, workflow runs/jobs, and artifacts. Use GraphQL for review-thread
+  resolution/outdated state and the `resolveReviewThread` mutation; flat
+  comments cannot provide it.
+- For a job that is still running, poll its job state and retrieve an available
+  log archive with `gh api "repos/<owner>/<repo>/actions/jobs/<job-id>/logs"`
+  into `scratch/`; do not wait for `gh run view --log` to become available.
+- Use `gh api` or GraphQL only when `gh` subcommands do not expose the data or mutation you need. Preserve command/API failures such as artifact-download
+  authorization; they are evidence, not permission to guess.
 - When command output is long, write it to `scratch/` and summarize the result.
 - Treat this as a shared dependency for `check-ci`, `pr-analysis`, `push-pr`, and `push-my-prs`.

--- a/skills/github-pr-feedback/SKILL.md
+++ b/skills/github-pr-feedback/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: github-pr-feedback
+description: "Collect, triage, and safely resolve GitHub pull-request feedback with `gh` and the GitHub API without posting comments. Use for a PR's conversation comments, review submissions, inline comments, or unresolved review threads, especially before addressing feedback or declaring a PR ready."
+---
+
+# GitHub PR Feedback
+
+Build one complete, head-SHA-scoped feedback ledger before judging or changing a
+pull request. Flat PR comment views are insufficient: an unresolved review
+thread can be absent from them, and an outdated thread still needs a deliberate
+disposition.
+
+## Intake
+
+1. Resolve the immutable PR snapshot with `gh pr view <pr> --json
+   number,url,state,mergedAt,mergeCommit,title,body,author,headRefName,headRefOid,baseRefName,mergeable,mergeStateStatus,reviewDecision,closingIssuesReferences`.
+   Record the `headRefOid`; never apply a disposition to a later head without
+   collecting a fresh snapshot.
+   Resolve the authenticated user with `gh api user -q .login` and record
+   whether this is an open PR authored by that user.
+2. If the PR is merged or closed, use historical read-only mode: compare its
+   merge commit and the current `origin/main`, classify feedback/CI as historical,
+   remediated, or still-open work, and do not push, resolve, or rerun
+   without explicit user authorization for a new follow-up scope.
+3. Read every linked issue with `gh issue view <issue> --json
+   number,title,state,body,comments,url`, then fetch every paginated feedback surface for this
+   PR and save large snapshots under `scratch/`:
+
+   - Conversation comments: `gh api --paginate "repos/<owner>/<repo>/issues/<pr>/comments?per_page=100"`
+   - Review submissions: `gh api --paginate "repos/<owner>/<repo>/pulls/<pr>/reviews?per_page=100"`
+   - Inline comments: `gh api --paginate "repos/<owner>/<repo>/pulls/<pr>/comments?per_page=100"`
+   - GraphQL review threads, paginated with `first: 100`, `$endCursor`, and
+     `pageInfo`. Request each thread's `id`, `isResolved`, `isOutdated`, `path`,
+     `line`, `originalLine`, `diffSide`, and all comment authors, bodies, URLs,
+     and timestamps.
+
+   Use GraphQL thread state even if the flat inline-comment list is empty.
+4. Make an action ledger for every current unresolved thread, review request,
+   inline comment, and conversation comment: source URL, head SHA, requested
+   behavior, file/line if applicable, disposition (`fix`, `already addressed`,
+   `not actionable`, `duplicate`, `ambiguous`, or `out of scope`), evidence,
+   targeted validation, and whether resolution is allowed.
+
+## Triage and resolution boundary
+
+- Verify each claim against the current source and PR intent. Do not treat an
+  automated reviewer or a stale diff position as proof by itself.
+- For a merged/closed PR, retain an unresolved thread as an explicit historical
+  disposition. It is not implicitly addressed merely because a later PR changed
+  adjacent code.
+- Treat an unresolved, non-outdated thread as actionable until evidence says
+  otherwise. Treat an outdated thread as a prompt to check whether the current
+  head already fixes its underlying behavior; do not silently discard it.
+- Never post a conversation comment, reply, inline comment, or review. Return
+  the disposition and evidence to the user instead.
+- Resolve only after all of the following: the in-scope fix is committed and
+  pushed, targeted validation passed, the fresh PR head still contains the fix,
+  the PR is open and authored by the authenticated GitHub user, and the
+  resolution directly answers that thread. Leave ambiguous, conflicting, or
+  out-of-scope threads unresolved and report the reason.
+- Resolve through GitHub GraphQL, not by guessing from a flat comment ID:
+
+  ```graphql
+  mutation($threadId: ID!) {
+    resolveReviewThread(input: {threadId: $threadId}) {
+      thread { id isResolved }
+    }
+  }
+  ```
+
+- After a push, repeat intake from the new head SHA. Do not resolve threads or
+  call CI green based on the previous head.
+
+## Handoff
+
+Return the action ledger and the exact remaining blockers. Pair this skill with
+`check-ci` for workflow state and `auto-mobile-code-review` for code-level
+verification and follow-through.

--- a/skills/github-pr-feedback/agents/openai.yaml
+++ b/skills/github-pr-feedback/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "GitHub PR Feedback"
+  short_description: "Read and safely clear PR feedback"
+  default_prompt: "Use $github-pr-feedback to collect and safely resolve eligible pull-request feedback without posting comments."

--- a/skills/pr-analysis/SKILL.md
+++ b/skills/pr-analysis/SKILL.md
@@ -10,8 +10,11 @@ Perform a read-only PR review that covers intent, correctness, regression risk, 
 ## Workflow
 
 1. Resolve the PR with `gh pr view <pr> --json ...` and capture the head branch, base branch, title, and body.
-2. Gather context with `gh pr diff`, `gh pr diff --stat`, `gh pr checks`, review comments, conversation comments, and review verdicts.
-3. Use `gh api graphql` only when you need unresolved review thread state.
+2. Gather context with `gh pr diff`, `gh pr diff --stat`, `gh pr checks`, all
+   paginated review/inline/conversation comments, and review verdicts.
+3. Always collect GraphQL review-thread state for PR analysis: unresolved and
+   outdated threads are not represented reliably by flat comment views. Reuse
+   `github-pr-feedback` for the collection and ledger.
 4. Read full changed files from the PR branch and the base branch, not just diff hunks.
 5. Find related callers, interfaces, and tests in the local codebase.
 6. If validation is warranted, run the lightest relevant repo validation rather than a blanket heavy build.

--- a/skills/ship-issue/SKILL.md
+++ b/skills/ship-issue/SKILL.md
@@ -39,11 +39,11 @@ Two phases are hard STOP gates; do not cross them without the stated condition.
 6. **PR.** Verify isolation with `git diff --name-only origin/main...HEAD` (intended paths
    only). Create the PR with the repo template if present, linking `Closes #<n>`.
    Do not enable auto-merge yet.
-7. **Review (triage).** Run `auto-mobile-code-review`; spawn three review lenses
-   (regression, test adequacy, API/interface contract) given the diff + criteria;
-   read all PR/inline comments and failing CI (`check-ci`). Triage each finding —
-   fix confirmed, reject artifacts with a reason, defer out-of-scope. Never blanket
-   "address all"; never grow scope to satisfy a suggestion.
+7. **Review (triage).** Run `auto-mobile-code-review` in follow-through mode.
+   It owns the fixed review lenses, all PR/thread feedback, and exact-head CI
+   triage. Triage each finding — fix confirmed, reject artifacts with a reason,
+   defer out-of-scope. Never blanket "address all"; never grow scope to satisfy
+   a suggestion.
 8. **Merge (conditional).** Push all review edits first; only then, on green CI,
    touch auto-merge. Auto-merge only low-risk changes; for DB/migration/runner/
    schema surfaces, STOP and hand the merge decision to the user.


### PR DESCRIPTION
## Summary

- add complete GitHub PR feedback intake and safe thread-resolution workflow
- make AutoMobile review follow-through read all feedback and exact-head CI without posting review comments
- use two stable review lenses plus one diff-specific lens, with a smaller PR path for changes of 100 lines or fewer
- improve CI triage for live jobs, artifacts, head-SHA correlation, and causality

## Validation

- `bash scripts/validate_codex_skills.sh`
- `git diff --check`
