### PR TITLE
ci(ios): drop the Xcode 26.2 Reminders leg from PR CI (#4078)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1529,47 +1529,12 @@ jobs:
         if: always()
         run: xcrun simctl shutdown all || true
 
-      # Select Xcode → ensure runtime → boot sim → pre-start the daemon and wait
-      # for readiness so a startup failure surfaces loudly here instead of
-      # silently skipping the test (#2730). `auto-mobile` (installed to ~/.bun/bin
-      # by `bun add -g .`) is thereby on PATH for the swift-test step.
-      - name: "iOS simulator bring-up (Xcode 26.2)"
-        uses: ./.github/actions/ios-simulator-bring-up
-        with:
-          xcode-version: "26.2"
-
-      # Launch CtrlProxy on the booted sim now (a slow, one-time xcodebuild launch)
-      # so the test's first `observe` doesn't pay that cost inside its short
-      # waitFor window and time out (#2730 follow-up).
-      - name: "Warm up iOS CtrlProxy"
-        # Worst case ≈ 3 × (observe floor 150s + delay); bound the step so a
-        # pathological hang points here instead of at the 45-min job cap.
-        timeout-minutes: 12
-        run: ./scripts/ci/ensure-ctrl-proxy-ready.sh
-
-      # Compile the XCTest bundle BEFORE the target-app warm-up. Otherwise `swift test`
-      # in the timed Reminders step spends tens of seconds compiling first, letting the
-      # freshly-warmed simulator/app go cold again and reintroducing the cold observe
-      # timeout (#3851 direction 4). Runs after the leg's Xcode is selected (by the
-      # bring-up above) so the build cache matches the `swift test` that follows.
-      - name: "Pre-build Reminders XCTest bundle (Xcode 26.2)"
-        timeout-minutes: 15
-        run: ./scripts/ci/prebuild-reminders-xctest-bundle.sh
-
-      # Keep target-app cold bring-up outside the timed Reminders plan. CtrlProxy
-      # is already warm above; this leaves Reminders foregrounded so the plan's
-      # first launch/observe no longer pays the first app launch cost (#3028).
-      - name: "Warm up Reminders target app (Xcode 26.2)"
-        timeout-minutes: 5
-        run: ./scripts/ci/warm-reminders-target-app.sh
-
-      - name: "Run Reminders integration tests (Xcode 26.2)"
-        timeout-minutes: 10
-        env:
-          AUTOMOBILE_TEST_PLAN: "Plans/launch-reminders-app.yaml"
-          AUTOMOBILE_TEST_RETRY_COUNT: "1"
-        run: ./scripts/ci/run-reminders-launch-plan-tests.sh
-
+      # The Xcode 26.2 Reminders leg used to run here. It was dropped from PRs
+      # (issue #4078): it made the 26.5 Reminders run the job's THIRD simulator
+      # boot, which owned the entire slow tail (median 221s vs 81-100s for boots
+      # 1-2; every boot ≥300s was that one) and pushed the job past its 45-minute
+      # cap. Xcode-toolchain drift coverage for 26.2 is kept in nightly.yml, where
+      # it does not gate merges (see also #3592).
       - name: "Shutdown iOS Simulators"
         if: always()
         run: xcrun simctl shutdown all || true
@@ -1598,24 +1563,38 @@ jobs:
           brew list ffmpeg >/dev/null 2>&1 || brew install ffmpeg
           ./scripts/ios/video-recording-start-stop-integration.sh
 
-      # This is a freshly-booted sim, so re-confirm the daemon and warm CtrlProxy
-      # again before the second Reminders run (same rationale as the 26.2 block).
+      # This is a freshly-booted sim, so bring the daemon to ready and warm
+      # CtrlProxy before the Reminders run. Pre-starting the daemon and waiting
+      # for readiness makes a startup failure surface loudly here instead of
+      # silently skipping the test (#2730); `auto-mobile` (installed to ~/.bun/bin
+      # by `bun add -g .`) is thereby on PATH for the swift-test step.
       - name: "Ensure AutoMobile daemon ready (Xcode 26.5)"
         if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
         run: ./scripts/ci/ensure-daemon-ready.sh
 
+      # Launch CtrlProxy on the booted sim now (a slow, one-time xcodebuild launch)
+      # so the test's first `observe` doesn't pay that cost inside its short
+      # waitFor window and time out (#2730 follow-up). Worst case ≈ 3 × (observe
+      # floor 150s + delay); bound the step so a pathological hang points here
+      # instead of at the 45-min job cap.
       - name: "Warm up iOS CtrlProxy (Xcode 26.5)"
         if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
         timeout-minutes: 12
         run: ./scripts/ci/ensure-ctrl-proxy-ready.sh
 
-      # Pre-build the XCTest bundle before the second leg's warm-up too (same rationale
-      # as the 26.2 leg above); the freshly-booted 26.5 sim is cold again here.
+      # Compile the XCTest bundle BEFORE the target-app warm-up. Otherwise `swift test`
+      # in the timed Reminders step spends tens of seconds compiling first, letting the
+      # freshly-warmed simulator/app go cold again and reintroducing the cold observe
+      # timeout (#3851 direction 4). Runs after the leg's Xcode is selected so the build
+      # cache matches the `swift test` that follows.
       - name: "Pre-build Reminders XCTest bundle (Xcode 26.5)"
         if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
         timeout-minutes: 15
         run: ./scripts/ci/prebuild-reminders-xctest-bundle.sh
 
+      # Keep target-app cold bring-up outside the timed Reminders plan. CtrlProxy
+      # is already warm above; this leaves Reminders foregrounded so the plan's
+      # first launch/observe no longer pays the first app launch cost (#3028).
       - name: "Warm up Reminders target app (Xcode 26.5)"
         if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
         timeout-minutes: 5

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
@@ -250,11 +250,6 @@ final class RemindersPlanContentTests: XCTestCase {
         assertWorkflowUsesLocalCtrlProxyBuildForRemindersRun(workflow)
         assertWorkflowWarmsTargetAppBeforeRemindersRun(
             workflow,
-            warmupStepName: "Warm up Reminders target app (Xcode 26.2)",
-            runStepName: "Run Reminders integration tests (Xcode 26.2)"
-        )
-        assertWorkflowWarmsTargetAppBeforeRemindersRun(
-            workflow,
             warmupStepName: "Warm up Reminders target app (Xcode 26.5)",
             runStepName: "Run Reminders integration tests (Xcode 26.5)"
         )
@@ -270,12 +265,6 @@ final class RemindersPlanContentTests: XCTestCase {
 
         assertWorkflowPreBuildsXCTestBundleBeforeWarmUp(
             workflow,
-            preBuildStepName: "Pre-build Reminders XCTest bundle (Xcode 26.2)",
-            afterCtrlProxyStepName: "Warm up iOS CtrlProxy",
-            warmupStepName: "Warm up Reminders target app (Xcode 26.2)"
-        )
-        assertWorkflowPreBuildsXCTestBundleBeforeWarmUp(
-            workflow,
             preBuildStepName: "Pre-build Reminders XCTest bundle (Xcode 26.5)",
             afterCtrlProxyStepName: "Warm up iOS CtrlProxy (Xcode 26.5)",
             warmupStepName: "Warm up Reminders target app (Xcode 26.5)"
@@ -287,15 +276,7 @@ final class RemindersPlanContentTests: XCTestCase {
 
         assertWorkflowRetriesRemindersRunOnce(
             workflow,
-            runStepName: "Run Reminders integration tests (Xcode 26.2)"
-        )
-        assertWorkflowRetriesRemindersRunOnce(
-            workflow,
             runStepName: "Run Reminders integration tests (Xcode 26.5)"
-        )
-        assertWorkflowRunsGuardedRemindersTest(
-            workflow,
-            runStepName: "Run Reminders integration tests (Xcode 26.2)"
         )
         assertWorkflowRunsGuardedRemindersTest(
             workflow,
@@ -303,25 +284,51 @@ final class RemindersPlanContentTests: XCTestCase {
         )
     }
 
-    func testPullRequestWorkflowRunsSecondRemindersLegAfterFirstLegFailureUnlessCancelled() throws {
+    /// The PR job dropped its Xcode 26.2 Reminders leg (#4078), so the 26.5 leg is now the
+    /// only one. Its `!cancelled()` guards still matter: they keep the Reminders segment
+    /// independent of the CtrlProxy UI test that runs earlier in the same job, while still
+    /// skipping on cancellation (and, via #4082, on a doomed shared CtrlProxy build).
+    func testPullRequestWorkflowRunsRemindersLegAfterEarlierFailureUnlessCancelled() throws {
         let workflow = try loadRepositoryFile(".github/workflows/pull_request.yml")
 
-        assertWorkflowSecondRemindersBringUpRunsWhenNotCancelled(workflow)
+        assertWorkflowSecondRemindersBringUpRunsWhenNotCancelled(
+            workflow,
+            afterStepName: pullRequestRemindersLegAnchorStep
+        )
         assertWorkflowStepRunsWhenNotCancelled(
             workflow,
             stepName: "Warm up iOS CtrlProxy (Xcode 26.5)",
-            afterStepName: "Run Reminders integration tests (Xcode 26.2)"
+            afterStepName: pullRequestRemindersLegAnchorStep
         )
         assertWorkflowStepRunsWhenNotCancelled(
             workflow,
             stepName: "Warm up Reminders target app (Xcode 26.5)",
-            afterStepName: "Run Reminders integration tests (Xcode 26.2)"
+            afterStepName: pullRequestRemindersLegAnchorStep
         )
         assertWorkflowStepRunsWhenNotCancelled(
             workflow,
             stepName: "Run Reminders integration tests (Xcode 26.5)",
-            afterStepName: "Run Reminders integration tests (Xcode 26.2)"
+            afterStepName: pullRequestRemindersLegAnchorStep
         )
+    }
+
+    /// The PR workflow must not reintroduce the Xcode 26.2 leg that #4078 removed: it made
+    /// the 26.5 Reminders run the job's third simulator boot, which owned the job's entire
+    /// slow tail. 26.2 coverage lives in nightly.yml, which does not gate merges.
+    func testPullRequestWorkflowHasNoXcode262RemindersLeg() throws {
+        let workflow = try loadRepositoryFile(".github/workflows/pull_request.yml")
+
+        for stepName in [
+            "iOS simulator bring-up (Xcode 26.2)",
+            "Pre-build Reminders XCTest bundle (Xcode 26.2)",
+            "Warm up Reminders target app (Xcode 26.2)",
+            "Run Reminders integration tests (Xcode 26.2)",
+        ] {
+            XCTAssertFalse(
+                workflowHasStep(workflow, stepName: stepName),
+                "pull_request.yml must not reintroduce the Xcode 26.2 Reminders leg (step: \(stepName))"
+            )
+        }
     }
 
     /// Xcode 26.5 can turn a filtered SwiftPM XCTest run into "Executed 0 tests" when the custom
@@ -786,8 +793,8 @@ private func assertWorkflowUsesLocalCtrlProxyBuildForRemindersRun(
         XCTFail("Workflow is missing the XCTestRunner simulator job", file: file, line: line)
         return
     }
-    guard let runRange = workflow.range(of: #"name: "Run Reminders integration tests (Xcode 26.2)""#) else {
-        XCTFail("Workflow is missing the Xcode 26.2 Reminders run step", file: file, line: line)
+    guard let runRange = workflow.range(of: #"name: "Run Reminders integration tests (Xcode 26.5)""#) else {
+        XCTFail("Workflow is missing the Xcode 26.5 Reminders run step", file: file, line: line)
         return
     }
 
@@ -967,12 +974,25 @@ private func assertWorkflowRunsGuardedRemindersTest(
     )
 }
 
+/// Scan anchor for the PR workflow's Reminders leg.
+///
+/// Several step names occur twice in `ios-xctest-runner-simulator-tests` (e.g. "Select Xcode
+/// 26.5" is both the job's initial toolchain selection, which has no `if:`, and the Reminders
+/// leg's re-selection, which does), so the assertions below must start scanning after the leg
+/// begins. This was "Run Reminders integration tests (Xcode 26.2)" until #4078 dropped that
+/// leg; the unique `if: always()` teardown directly above the leg replaces it. Mirrors
+/// ANCHOR_STEP in test/bats/xctest-shared-prereq-gate.bats.
+private let pullRequestRemindersLegAnchorStep = "Shutdown iOS Simulators"
+
+/// `afterStepName` defaults to the Xcode 26.2 Reminders run step, which nightly.yml still has
+/// (it deliberately keeps both legs — the coverage is free there because it does not gate
+/// merges). pull_request.yml passes `pullRequestRemindersLegAnchorStep` instead.
 private func assertWorkflowSecondRemindersBringUpRunsWhenNotCancelled(
     _ workflow: String,
+    afterStepName: String = "Run Reminders integration tests (Xcode 26.2)",
     file: StaticString = #filePath,
     line: UInt = #line
 ) {
-    let afterStepName = "Run Reminders integration tests (Xcode 26.2)"
     if workflowHasStep(workflow, stepName: "iOS simulator bring-up (Xcode 26.5)", afterStepName: afterStepName) {
         assertWorkflowStepRunsWhenNotCancelled(
             workflow,

--- a/test/bats/xctest-shared-prereq-gate.bats
+++ b/test/bats/xctest-shared-prereq-gate.bats
@@ -1,8 +1,10 @@
 #!/usr/bin/env bats
 #
 # Guards issue #4082: the Xcode 26.5 leg of `ios-xctest-runner-simulator-tests`
-# uses `if: !cancelled()` so it runs even when the *26.2* leg's tests failed
-# (deliberate leg-independence). But a bare `!cancelled()` also bypasses a
+# uses `if: !cancelled()` so it runs even when an earlier step in the job failed
+# (deliberate independence from the CtrlProxy UI test that precedes it; before
+# #4078 this also covered the now-removed Xcode 26.2 Reminders leg). But a bare
+# `!cancelled()` also bypasses a
 # SHARED-prerequisite failure (XcodeGen drift check / CtrlProxy build), so the
 # 26.5 block ran on a broken build and emitted misleading secondary failures
 # (e.g. a spurious "Run Reminders integration tests (Xcode 26.5)" failure whose
@@ -34,15 +36,22 @@ WORKFLOW=".github/workflows/pull_request.yml"
 
 # Print the active `if:` value for a named step, or nothing when the step has none.
 #
-# Scanning starts only AFTER the 26.2 leg's final step: several step names occur
-# twice in the job (e.g. "Select Xcode 26.5" is both the job's initial toolchain
-# selection, which has no `if:`, and the 26.5 leg's re-selection, which does).
-# Without the anchor the first, unguarded occurrence matches and the assertion
-# reports a false violation. This mirrors `afterStepName` in the Swift helper.
+# Scanning starts only AFTER the step that immediately precedes the 26.5 leg:
+# several step names occur twice in the job (e.g. "Select Xcode 26.5" is both the
+# job's initial toolchain selection, which has no `if:`, and the 26.5 leg's
+# re-selection, which does). Without the anchor the first, unguarded occurrence
+# matches and the assertion reports a false violation. This mirrors
+# `afterStepName` in the Swift helper.
+#
+# The anchor was "Run Reminders integration tests (Xcode 26.2)" until #4078 dropped
+# the 26.2 leg from PRs. "Shutdown iOS Simulators" replaces it: it is the unique
+# `if: always()` teardown that still sits directly above the 26.5 leg. If it ever
+# stops being unique or moves, the step-lookup below fails loudly (no `if:` found)
+# rather than silently matching the wrong occurrence.
 #
 # awk, not sed -- BSD sed lacks the range forms this needs. A step block runs from
 # its `- name: "<step>"` line to the next step start or a step-indent comment.
-ANCHOR_STEP='Run Reminders integration tests (Xcode 26.2)'
+ANCHOR_STEP='Shutdown iOS Simulators'
 
 step_if_condition() {
   awk -v want="      - name: \"$1\"" -v anchor="      - name: \"$ANCHOR_STEP\"" '
@@ -73,6 +82,14 @@ Pre-build Reminders XCTest bundle (Xcode 26.5)
 Warm up Reminders target app (Xcode 26.5)
 Run Reminders integration tests (Xcode 26.5)
 STEPS
+}
+
+@test "the extraction anchor step exists exactly once" {
+  # Everything below scans from this anchor. A missing anchor makes every lookup
+  # return nothing (which fails loudly), but a DUPLICATED anchor would silently
+  # shift the scan window and could re-admit the wrong occurrence of a step name.
+  count="$(grep -c "^      - name: \"$ANCHOR_STEP\"\$" "$WORKFLOW" || true)"
+  [ "$count" -eq 1 ]
 }
 
 @test "every 26.5-leg step individually gates on steps.build-ctrlproxy.outcome == success" {


### PR DESCRIPTION
Addresses #4078 by removing a leg rather than splitting the job.

## Why

`ios-xctest-runner-simulator-tests` ran two Xcode legs sequentially in one job. Measured over 106 CI boots:

| Boot | median | max |
|---|---|---|
| #1 — 26.5 CtrlProxy (background) | 100s | 210s |
| #2 — 26.2 leg | 81s | 130s |
| **#3 — 26.5 main boot** | **221s** | **818s** |

**All 9 boots ≥300s were boot #3** — the 26.5 boot, third on an already-loaded runner. Dropping the 26.2 leg removes a boot *and* the accumulated load before the 26.5 leg, which is what the tail actually tracks. #3592 reached the same conclusion independently ("all recent flakes are the 26.2 leg; drop it or make it non-blocking").

This is a smaller, lower-risk change than the matrix split originally proposed, and it does not double the shared prologue cost.

## Scope

**Removed from `pull_request.yml` only** — the 26.2 bring-up, CtrlProxy warm-up, XCTest pre-build, target-app warm-up, and Reminders run, replaced by a tombstone comment.

**`nightly.yml` is untouched** (verified: empty diff). Toolchain-drift coverage for 26.2 lives there, where it costs nothing because it doesn't gate merges.

**The 26.5 steps' `if:` conditions are deliberately unchanged.** With 26.2 gone the leg-independence rationale weakens, but `!cancelled() && steps.build-ctrlproxy.outcome == 'success'` still buys independence from the CtrlProxy UI test — and rewriting those conditions is exactly what caused the #4088 regression. Minimal change.

Four rationale comments (#2730, #2730-follow-up, #3851, #3028) existed only on the deleted 26.2 steps while their 26.5 twins said "same rationale as the 26.2 block". Those were **moved, not rewritten**, so the surviving steps don't carry dangling references.

Two dependencies checked before deleting: `ensure-daemon-ready.sh` starts the daemon itself (idempotent), so the 26.5 daemon step being the job's first is fine; and `Run videoRecording MP4 integration test` drives the sim directly via `bun test`, with no dependency on the removed leg.

## Tests

- Swift helpers gained an `afterStepName` parameter **defaulting to the 26.2 step**, so every nightly call site is unchanged and still asserts exactly what it did. No helper deleted.
- `testPullRequestWorkflowHasNoXcode262RemindersLeg` added so the leg can't be silently reintroduced.
- The bats extraction anchor moved from the (now-deleted) 26.2 Reminders step to `Shutdown iOS Simulators`, plus a new test asserting the anchor occurs **exactly once** — a missing anchor already fails loudly, but a duplicated one would silently shift the scan window.
- **Anti-vacuity, independently re-run:** stripping the build guard from a 26.5 step fails the per-step assertion and names the step; deleting the `if:` from the leg's `Select Xcode 26.5` (the duplicate-name case the anchor exists for) fails too — proving the anchor resolves the *leg* occurrence, not the job-initial one.
- 27 Swift tests, 5 bats in this suite, plus the 8 other suites that read `pull_request.yml` (68 tests) — all green. YAML parses. No new SwiftLint/SwiftFormat violations vs main.

## Known follow-ups (deliberately not here)

1. The leg's `Select Xcode 26.5` and `Ensure iOS Simulator runtime (Xcode 26.5)` are now **no-ops** — nothing changes the toolchain after the job-initial selection. Removing them means touching 26.5 steps plus both test step-lists; out of scope.
2. `Shutdown CtrlProxy UI test simulator` and `Shutdown iOS Simulators` are now **adjacent and redundant**. The latter is load-bearing as the test anchor, so collapsing them needs the anchor moved first (the uniqueness test will catch it if someone tries).
3. `docs/design-docs/plat/ios/xctestrunner/ci-integration.md:47` mentions `Select Xcode 26.2`, but that's a generic consumer-facing example, not this job.

## Validation caveat

That the 26.5 leg is actually faster as the job's *second* boot rather than third can only be confirmed on real runners. The measured data says it should be, but this PR proves the wiring, not the speedup.