### PR TITLE
feat(device): gate simulator/emulator auto-creation behind a flag + env var (#4093)

### DIFF
--- a/docs/using/environment-variables.md
+++ b/docs/using/environment-variables.md
@@ -73,6 +73,31 @@ here for discoverability; most are diagnostic or for advanced testing.
 | `AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD` | Skips Android and iOS CtrlProxy downloads/prefetches when set to `1` or `true`. |
 | `AUTOMOBILE_SKIP_ACCESSIBILITY_DOWNLOAD_IF_INSTALLED` | Skips the accessibility service download when it is already installed. |
 
+## Device provisioning opt-in
+
+AutoMobile never creates a simulator or emulator by default — spawning devices on
+a developer's machine is a side effect they did not ask for. Turn it on
+explicitly, per run or per environment.
+
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `AUTOMOBILE_ALLOW_DEVICE_CREATE` | When `1` or `true`, `startDevice` creates a device (iOS: `simctl create`; Android: `avdmanager create avd`) instead of failing when nothing matches the requested criteria. | unset (off) |
+
+The equivalent per-call flag is `--create-if-missing` on the device-start path:
+
+```bash
+auto-mobile --cli startDevice --platform ios --create-if-missing
+```
+
+**Precedence:** an explicit flag wins over the env var, in *both* directions —
+`--create-if-missing false` disables creation even when
+`AUTOMOBILE_ALLOW_DEVICE_CREATE=1`. With no flag, the env var decides. With
+neither, creation is off.
+
+Created devices are named `AutoMobile-<model>-<id>` so they are easy to find and
+clean up (`xcrun simctl delete <udid>` / `avdmanager delete avd -n <name>`), and
+the resolved device type and runtime are logged at creation time.
+
 ## WebRTC screen streaming (`AUTOMOBILE_WEBRTC_*`)
 
 Defaults for pushing a device's screen to a coordination server over WebRTC/WHIP.

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -5996,6 +5996,10 @@
         "timeoutMs": {
           "description": "Boot timeout in ms",
           "type": "number"
+        },
+        "createIfMissing": {
+          "description": "Create a device when nothing matches (CLI: --create-if-missing). Default off; AUTOMOBILE_ALLOW_DEVICE_CREATE=1 enables it when this flag is not supplied, and the flag wins.",
+          "type": "boolean"
         }
       },
       "required": [

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -352,6 +352,7 @@ Examples:
   bunx ${installSpecifier} --cli observe
   bunx ${installSpecifier} --cli tapOn --text "Submit"
   bunx ${installSpecifier} --cli startDevice --avdName "pixel_7_api_34"
+  bunx ${installSpecifier} --cli startDevice --platform ios --create-if-missing
   bunx ${installSpecifier} --cli --session-uuid abc-123-uuid observe
   bunx ${installSpecifier} --cli --session-uuid $SESSION_UUID tapOn --text "Submit"
 

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -17,6 +17,8 @@ import { createPerformanceTracker } from "../utils/PerformanceTracker";
 import { platformSchema } from "./toolSchemaHelpers";
 import { DefaultDeviceMatcher, type DeviceMatcher } from "./deviceMatcher";
 import { DEVICE_POOL_MATCHING, isDevicePoolAutolockEnabled } from "../daemon/poolConfig";
+import { DEVICE_CREATE_ENV_VAR, getDeviceCreationGate, type DeviceCreationGate } from "../utils/deviceCreationGate";
+import { createDefaultDeviceProvisioner, type DeviceProvisioner } from "../utils/deviceProvisioning";
 import { DaemonState } from "../daemon/daemonState";
 
 // Schema definitions
@@ -41,6 +43,10 @@ const startDeviceParametersSchema = z.object({
   deviceId: z.string().optional(),
   preferRunning: z.boolean().optional().describe("Prefer already-booted device (default true)"),
   timeoutMs: z.number().optional().describe("Boot timeout in ms"),
+  createIfMissing: z.boolean().optional().describe(
+    `Create a device when nothing matches (CLI: --create-if-missing). Default off; ` +
+    `${DEVICE_CREATE_ENV_VAR}=1 enables it when this flag is not supplied, and the flag wins.`
+  ),
 });
 
 export const startDeviceSchema = z.preprocess(input => {
@@ -81,6 +87,7 @@ export interface StartDeviceArgs {
   deviceId?: string;
   preferRunning?: boolean;
   timeoutMs?: number;
+  createIfMissing?: boolean;
   __mcpSessionId?: string;
 }
 
@@ -101,6 +108,8 @@ export interface DeviceToolsDependencies {
   deviceMatcherFactory: () => DeviceMatcher;
   notifyResourcesChanged: () => Promise<void>;
   ensureCtrlProxyReady?: (device: BootedDevice, perf: ReturnType<typeof createPerformanceTracker>) => Promise<void>;
+  deviceCreationGateFactory: () => DeviceCreationGate;
+  deviceProvisionerFactory: () => DeviceProvisioner;
 }
 
 async function defaultNotifyResourcesChanged(): Promise<void> {
@@ -117,6 +126,8 @@ function getDeviceToolsDependencies(): DeviceToolsDependencies {
       deviceManagerFactory: () => new MultiPlatformDeviceManager(),
       deviceMatcherFactory: () => new DefaultDeviceMatcher(),
       notifyResourcesChanged: defaultNotifyResourcesChanged,
+      deviceCreationGateFactory: () => getDeviceCreationGate(),
+      deviceProvisionerFactory: () => createDefaultDeviceProvisioner(),
     };
   }
   return moduleDependencies;
@@ -129,6 +140,8 @@ export function setDeviceToolsDependencies(deps: Partial<DeviceToolsDependencies
     deviceMatcherFactory: deps.deviceMatcherFactory ?? currentDeps.deviceMatcherFactory,
     notifyResourcesChanged: deps.notifyResourcesChanged ?? currentDeps.notifyResourcesChanged,
     ensureCtrlProxyReady: deps.ensureCtrlProxyReady ?? currentDeps.ensureCtrlProxyReady,
+    deviceCreationGateFactory: deps.deviceCreationGateFactory ?? currentDeps.deviceCreationGateFactory,
+    deviceProvisionerFactory: deps.deviceProvisionerFactory ?? currentDeps.deviceProvisionerFactory,
   };
 }
 
@@ -278,7 +291,25 @@ export function registerDeviceTools() {
         return await bootAndRespond(imageMatch, deviceUtils, perf, progress, args);
       }
 
-      // No match at all
+      // No match at all — provision one only when the opt-in gate is on.
+      const gate = deps.deviceCreationGateFactory();
+      if (gate.isCreationAllowed(args.createIfMissing)) {
+        logger.info(
+          `[startDevice] No ${args.platform} device matched; creating one ` +
+          `(gate: ${gate.describeSource(args.createIfMissing)})`
+        );
+        const provisioned = await deps.deviceProvisionerFactory().provision(criteria);
+        const createdImage: DeviceInfo = {
+          name: provisioned.name,
+          platform: provisioned.platform,
+          deviceId: provisioned.deviceId,
+          isRunning: false,
+          formFactor: args.formFactor,
+        } as DeviceInfo;
+        await getDeviceToolsDependencies().notifyResourcesChanged();
+        return await bootAndRespond(createdImage, deviceUtils, perf, progress, args);
+      }
+
       throw new ActionableError(
         `No ${args.platform} device matching criteria found. ` +
         (args.minOsVersion ? `minOsVersion>=${args.minOsVersion} ` : "") +

--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -10,6 +10,8 @@ import { IOSCtrlProxyManager, CtrlProxyIosManager } from "./IOSCtrlProxyManager"
 import { AndroidEmulatorClient } from "./android-cmdline-tools/AndroidEmulatorClient";
 import type { AdbExecutor } from "./android-cmdline-tools/interfaces/AdbExecutor";
 import { PlatformDeviceManager } from "./interfaces/DeviceUtils";
+import { getDeviceCreationGate } from "./deviceCreationGate";
+import { createDefaultDeviceProvisioner } from "./deviceProvisioning";
 import { AndroidCtrlProxyClient } from "../features/observe/android";
 import type { AndroidCtrlProxy } from "../features/observe/android/AndroidCtrlProxyClient";
 import { IOSCtrlProxyClient } from "../features/observe/ios";
@@ -876,6 +878,23 @@ export class DeviceSessionManager implements DeviceSessionManager {
     allDevices.sort((a, b) => (a.deviceId || "").localeCompare(b.deviceId || ""));
 
     if (allDevices.length === 0) {
+      // No CLI flag reaches this path, so the opt-in is env-var only here.
+      const gate = getDeviceCreationGate();
+      if (gate.isCreationAllowed()) {
+        logger.info(
+          `[DeviceSessionManager] No iOS simulators found; creating one (gate: ${gate.describeSource()})`
+        );
+        const provisioner = createDefaultDeviceProvisioner(() => this.simctl);
+        const provisioned = await provisioner.provision({ platform: "ios" });
+        perf.startOperation("bootSimulator");
+        const createdDevice = await this.simctl.bootSimulator(provisioned.deviceId!);
+        perf.endOperation("bootSimulator");
+        perf.startOperation("verifyDevice");
+        await this.verifyIosDevice(provisioned.deviceId!, options);
+        perf.endOperation("verifyDevice");
+        return createdDevice;
+      }
+
       throw new ActionableError(
         "No iOS simulators are available. Please create an iOS simulator using Xcode or the Simulator app."
       );

--- a/src/utils/android-cmdline-tools/avdmanager.ts
+++ b/src/utils/android-cmdline-tools/avdmanager.ts
@@ -376,6 +376,35 @@ export async function listSystemImages(filter?: SystemImageFilter, dependencies 
 }
 
 /**
+ * List system images that are already **installed** in the SDK.
+ *
+ * {@link listSystemImages} deliberately reports the downloadable "Available
+ * Packages" catalogue. AVD creation needs the installed set instead: passing
+ * `avdmanager create avd -k` a package that is not on disk fails.
+ */
+export async function listInstalledSystemImages(
+  filter?: SystemImageFilter,
+  dependencies = createDefaultDependencies()
+): Promise<SystemImage[]> {
+  try {
+    const location = await ensureToolsAvailable(dependencies);
+    const sdkmanagerPath = getSdkManagerPath(location, dependencies);
+    const env = getAndroidSdkEnv(location, dependencies);
+
+    const result = await spawnCommand(sdkmanagerPath, ["--list"], { env }, dependencies);
+
+    if (result.exitCode !== 0) {
+      throw new Error(`Failed to list installed system images: ${result.stderr}`);
+    }
+
+    return parseSystemImages(result.stdout, filter, "installed");
+  } catch (error) {
+    dependencies.logger.error(`Failed to list installed system images: ${(error as Error).message}`);
+    throw error;
+  }
+}
+
+/**
  * Download and install a system image
  */
 export async function installSystemImage(packageName: string, acceptLicense = true, dependencies = createDefaultDependencies()): Promise<{
@@ -467,27 +496,38 @@ function createAvdManagerClient(dependencies: AvdManagerDependencies): AvdManage
 /**
  * Parse system images from sdkmanager output
  */
-function parseSystemImages(output: string, filter?: SystemImageFilter): SystemImage[] {
+export function parseSystemImages(
+  output: string,
+  filter?: SystemImageFilter,
+  section: SdkManagerSection = "available"
+): SystemImage[] {
   const lines = output.split("\n");
   const images: SystemImage[] = [];
-  let inSystemImagesSection = false;
+  let currentSection: SdkManagerSection | null = null;
 
   for (const line of lines) {
     const trimmedLine = line.trim();
 
     if (trimmedLine.includes("Available Packages:")) {
-      inSystemImagesSection = true;
+      currentSection = "available";
       continue;
     }
 
     if (trimmedLine.includes("Installed packages:")) {
-      inSystemImagesSection = false;
+      currentSection = "installed";
       continue;
     }
 
-    if (inSystemImagesSection && trimmedLine.startsWith("system-images;")) {
+    if (trimmedLine.includes("Available Updates:")) {
+      currentSection = null;
+      continue;
+    }
+
+    if (currentSection === section && trimmedLine.startsWith("system-images;")) {
+      // The "Installed packages" table is pipe-delimited, the "Available Packages"
+      // listing is whitespace-delimited; split on either so both shapes parse.
       const parts = trimmedLine.split(/\s+/);
-      const packageName = parts[0];
+      const packageName = parts[0].split("|")[0];
       const versionInfo = parts.slice(1).join(" ");
 
       // Parse package name: system-images;android-XX;tag;abi
@@ -539,6 +579,9 @@ export interface SystemImageFilter {
   tag?: string;
   abi?: string;
 }
+
+/** Which `sdkmanager --list` section a parse should read from. */
+export type SdkManagerSection = "available" | "installed";
 
 export interface SystemImage {
   packageName: string;

--- a/src/utils/deviceCreationGate.ts
+++ b/src/utils/deviceCreationGate.ts
@@ -1,0 +1,98 @@
+/**
+ * Opt-in gate for provisioning (creating) simulators/emulators.
+ *
+ * Auto-creating devices is deliberately NOT default product behaviour — spawning
+ * a simulator on a developer's machine is a side effect they did not ask for.
+ * The capability is therefore expressed two equivalent ways so both MCP/CLI and
+ * containerised CI can turn it on:
+ *
+ *   1. `--create-if-missing` on the device-start path (surfaces as the
+ *      `createIfMissing` startDevice parameter).
+ *   2. `AUTOMOBILE_ALLOW_DEVICE_CREATE=1` (or `true`) for environments that
+ *      cannot easily thread flags.
+ *
+ * Precedence: an explicit flag — either value — wins over the env var. Default
+ * is off on both platforms.
+ *
+ * The gate is an injectable seam so call sites never read `process.env`
+ * directly and unit tests never have to mutate the real environment.
+ */
+
+/** Env var that enables device creation when no explicit flag is supplied. */
+export const DEVICE_CREATE_ENV_VAR = "AUTOMOBILE_ALLOW_DEVICE_CREATE";
+
+/** Values accepted as "on" for {@link DEVICE_CREATE_ENV_VAR}. */
+const TRUTHY_ENV_VALUES = new Set(["1", "true"]);
+
+/** Prefix applied to every device AutoMobile creates, so they are identifiable/cleanable. */
+export const CREATED_DEVICE_NAME_PREFIX = "AutoMobile";
+
+/** Narrow read-only view of the environment, so tests never touch `process.env`. */
+export interface EnvironmentReader {
+  get(name: string): string | undefined;
+}
+
+export class ProcessEnvironmentReader implements EnvironmentReader {
+  get(name: string): string | undefined {
+    return process.env[name];
+  }
+}
+
+export interface DeviceCreationGate {
+  /**
+   * @param explicitFlag - the value of `--create-if-missing` / `createIfMissing`
+   *                       when the caller supplied it, otherwise `undefined`.
+   * @returns whether the caller is allowed to create a device.
+   */
+  isCreationAllowed(explicitFlag?: boolean): boolean;
+
+  /** Human-readable reason for the current decision, for logging. */
+  describeSource(explicitFlag?: boolean): string;
+}
+
+export class EnvDeviceCreationGate implements DeviceCreationGate {
+  constructor(private readonly environment: EnvironmentReader = new ProcessEnvironmentReader()) {}
+
+  isCreationAllowed(explicitFlag?: boolean): boolean {
+    if (typeof explicitFlag === "boolean") {
+      return explicitFlag;
+    }
+    return isTruthyCreationEnvValue(this.environment.get(DEVICE_CREATE_ENV_VAR));
+  }
+
+  describeSource(explicitFlag?: boolean): string {
+    if (typeof explicitFlag === "boolean") {
+      return `--create-if-missing=${explicitFlag}`;
+    }
+    const raw = this.environment.get(DEVICE_CREATE_ENV_VAR);
+    if (raw === undefined) {
+      return "default (off)";
+    }
+    return `${DEVICE_CREATE_ENV_VAR}=${raw}`;
+  }
+}
+
+/** `1` and `true` (case-insensitive, whitespace-tolerant) mean on; everything else is off. */
+export function isTruthyCreationEnvValue(raw: string | undefined): boolean {
+  if (raw === undefined) {
+    return false;
+  }
+  return TRUTHY_ENV_VALUES.has(raw.trim().toLowerCase());
+}
+
+let moduleGate: DeviceCreationGate | null = null;
+
+export function getDeviceCreationGate(): DeviceCreationGate {
+  if (!moduleGate) {
+    moduleGate = new EnvDeviceCreationGate();
+  }
+  return moduleGate;
+}
+
+export function setDeviceCreationGate(gate: DeviceCreationGate): void {
+  moduleGate = gate;
+}
+
+export function resetDeviceCreationGate(): void {
+  moduleGate = null;
+}

--- a/src/utils/deviceProvisioning.ts
+++ b/src/utils/deviceProvisioning.ts
@@ -1,0 +1,343 @@
+/**
+ * Device provisioning — creating a simulator/emulator when none matches.
+ *
+ * This module owns *selection* (which device type / runtime / system image) and
+ * delegates *execution* to the existing primitives:
+ *   - iOS:     `SimCtlClient.createSimulator` (all simctl stays inside the client)
+ *   - Android: `AvdManagerClient.createAvd` via the avdmanager module
+ *
+ * Nothing here decides whether provisioning is allowed — that is
+ * {@link DeviceCreationGate}'s job, checked by the caller.
+ */
+
+import { ActionableError, toActionableError } from "../models/ActionableError";
+import type { DeviceMatchCriteria } from "../models/DeviceMatchCriteria";
+import type { AppleDeviceType } from "./ios-cmdline-tools/SimCtlClient";
+import type { CreateAvdParams, SystemImage } from "./android-cmdline-tools/avdmanager";
+import { createAvd, listInstalledSystemImages } from "./android-cmdline-tools/avdmanager";
+import { SimCtlClient } from "./ios-cmdline-tools/SimCtlClient";
+import { CREATED_DEVICE_NAME_PREFIX } from "./deviceCreationGate";
+import { defaultIdGenerator, type IdGenerator } from "./IdGenerator";
+import { logger } from "./logger";
+
+/** What was created, for logging and for handing straight to the boot path. */
+export interface ProvisionedDevice {
+  platform: "android" | "ios";
+  /** Device name (iOS simulator name / AVD name). */
+  name: string;
+  /** Simulator UDID; Android AVDs are addressed by name, so this is undefined there. */
+  deviceId?: string;
+  /** iOS device type identifier, or the Android system-image package. */
+  deviceType: string;
+  /** iOS runtime identifier, or the Android API level. */
+  runtime: string;
+}
+
+/** Exactly the SimCtlClient surface provisioning needs. */
+export interface IosSimulatorCreator {
+  getDeviceTypes(): Promise<AppleDeviceType[]>;
+  resolveRuntimeIdentifier(requestedVersion?: string): Promise<string>;
+  createSimulator(name: string, deviceType: string, runtime: string): Promise<string>;
+}
+
+/** Exactly the avdmanager surface provisioning needs. */
+export interface AndroidAvdCreator {
+  listInstalledSystemImages(): Promise<SystemImage[]>;
+  createAvd(params: CreateAvdParams): Promise<{ success: boolean; message: string; avdName?: string }>;
+}
+
+export interface DeviceProvisioner {
+  provision(criteria: DeviceMatchCriteria): Promise<ProvisionedDevice>;
+}
+
+// ---------------------------------------------------------------------------
+// Naming
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a recognisable, unique name so created devices can be found and cleaned
+ * up later. Uniqueness comes from the injected {@link IdGenerator} rather than a
+ * bare `randomUUID()` so tests are deterministic.
+ */
+export function buildCreatedDeviceName(
+  baseName: string,
+  idGenerator: IdGenerator = defaultIdGenerator
+): string {
+  const slug = baseName.replace(/[^A-Za-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "device";
+  const suffix = idGenerator.next().replace(/-/g, "").slice(0, 8);
+  return `${CREATED_DEVICE_NAME_PREFIX}-${slug}-${suffix}`;
+}
+
+/** True when `name` looks like a device AutoMobile provisioned. */
+export function isCreatedDeviceName(name: string): boolean {
+  return name.startsWith(`${CREATED_DEVICE_NAME_PREFIX}-`);
+}
+
+// ---------------------------------------------------------------------------
+// iOS selection
+// ---------------------------------------------------------------------------
+
+const IOS_FAMILY_BY_FORM_FACTOR: Record<"phone" | "tablet", string> = {
+  phone: "iPhone",
+  tablet: "iPad",
+};
+
+/** Highest numeric token in a device-type name ("iPhone 17 Pro" -> 17). */
+function highestNumericToken(name: string): number {
+  const matches = name.match(/\d+/g);
+  if (!matches) {
+    return -1;
+  }
+  return matches.reduce((best, token) => Math.max(best, Number.parseInt(token, 10)), -1);
+}
+
+/**
+ * Choose a simulator device type.
+ *
+ * An explicit `name` wins (case-insensitive exact match on the device-type
+ * name). Otherwise pick the newest model in the requested family, preferring the
+ * base model over "Pro"/"Max" variants so the choice is stable and predictable.
+ */
+export function pickIosDeviceType(
+  deviceTypes: AppleDeviceType[],
+  criteria: Pick<DeviceMatchCriteria, "name" | "formFactor">
+): AppleDeviceType {
+  if (deviceTypes.length === 0) {
+    throw new ActionableError(
+      "No iOS simulator device types are available from 'xcrun simctl list devicetypes'. " +
+      "Install an iOS platform via Xcode > Settings > Components."
+    );
+  }
+
+  if (criteria.name) {
+    const wanted = criteria.name.trim().toLowerCase();
+    const exact = deviceTypes.find(type => type.name.toLowerCase() === wanted);
+    if (exact) {
+      return exact;
+    }
+  }
+
+  const family = IOS_FAMILY_BY_FORM_FACTOR[criteria.formFactor ?? "phone"];
+  const candidates = deviceTypes.filter(
+    type => type.productFamily === family || type.name.startsWith(family)
+  );
+
+  if (candidates.length === 0) {
+    throw new ActionableError(
+      `No ${family} simulator device type is available. ` +
+      `Available device types: ${deviceTypes.map(type => type.name).join(", ")}.`
+    );
+  }
+
+  return [...candidates].sort((a, b) => {
+    const versionDelta = highestNumericToken(b.name) - highestNumericToken(a.name);
+    if (versionDelta !== 0) {
+      return versionDelta;
+    }
+    // Shorter name = base model ("iPhone 17" before "iPhone 17 Pro Max").
+    const lengthDelta = a.name.length - b.name.length;
+    if (lengthDelta !== 0) {
+      return lengthDelta;
+    }
+    return a.name.localeCompare(b.name);
+  })[0];
+}
+
+// ---------------------------------------------------------------------------
+// Android selection
+// ---------------------------------------------------------------------------
+
+/** Preferred system-image tags, best first. */
+const ANDROID_TAG_PREFERENCE = ["google_apis_playstore", "google_apis", "default"];
+
+function tagRank(tag: string): number {
+  const index = ANDROID_TAG_PREFERENCE.indexOf(tag);
+  return index === -1 ? ANDROID_TAG_PREFERENCE.length : index;
+}
+
+/** ABIs that can run on the host, best first. */
+export function preferredAbis(architecture: string): string[] {
+  return architecture === "arm64" ? ["arm64-v8a", "x86_64"] : ["x86_64", "x86"];
+}
+
+function abiRank(abi: string, preferences: string[]): number {
+  const index = preferences.indexOf(abi);
+  return index === -1 ? preferences.length : index;
+}
+
+function parseApiLevel(version: string | undefined): number | undefined {
+  if (!version) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(version.trim().split(".")[0], 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/**
+ * Choose an installed system image: newest API level within the requested
+ * range, preferring a host-runnable ABI and a Google APIs tag.
+ */
+export function pickAndroidSystemImage(
+  images: SystemImage[],
+  criteria: Pick<DeviceMatchCriteria, "minOsVersion" | "maxOsVersion">,
+  architecture: string
+): SystemImage {
+  const min = parseApiLevel(criteria.minOsVersion);
+  const max = parseApiLevel(criteria.maxOsVersion);
+
+  const inRange = images.filter(image => {
+    if (min !== undefined && image.apiLevel < min) {
+      return false;
+    }
+    if (max !== undefined && image.apiLevel > max) {
+      return false;
+    }
+    return true;
+  });
+
+  if (inRange.length === 0) {
+    throw new ActionableError(
+      "No installed Android system image matches the requested API range " +
+      `(min=${criteria.minOsVersion ?? "any"}, max=${criteria.maxOsVersion ?? "any"}). ` +
+      `Installed images: ${images.map(image => image.packageName).join(", ") || "none"}. ` +
+      "Install one with 'sdkmanager \"system-images;android-<api>;google_apis;<abi>\"'."
+    );
+  }
+
+  const preferences = preferredAbis(architecture);
+  const runnable = inRange.filter(image => preferences.includes(image.abi));
+  const candidates = runnable.length > 0 ? runnable : inRange;
+
+  return [...candidates].sort((a, b) => {
+    const apiDelta = b.apiLevel - a.apiLevel;
+    if (apiDelta !== 0) {
+      return apiDelta;
+    }
+    const abiDelta = abiRank(a.abi, preferences) - abiRank(b.abi, preferences);
+    if (abiDelta !== 0) {
+      return abiDelta;
+    }
+    const tagDelta = tagRank(a.tag) - tagRank(b.tag);
+    if (tagDelta !== 0) {
+      return tagDelta;
+    }
+    return a.packageName.localeCompare(b.packageName);
+  })[0];
+}
+
+// ---------------------------------------------------------------------------
+// Provisioner
+// ---------------------------------------------------------------------------
+
+export interface DefaultDeviceProvisionerDependencies {
+  iosCreator: () => IosSimulatorCreator | undefined;
+  androidCreator: () => AndroidAvdCreator;
+  idGenerator?: IdGenerator;
+  architecture?: string;
+}
+
+export class DefaultDeviceProvisioner implements DeviceProvisioner {
+  private readonly idGenerator: IdGenerator;
+  private readonly architecture: string;
+
+  constructor(private readonly dependencies: DefaultDeviceProvisionerDependencies) {
+    this.idGenerator = dependencies.idGenerator ?? defaultIdGenerator;
+    this.architecture = dependencies.architecture ?? process.arch;
+  }
+
+  async provision(criteria: DeviceMatchCriteria): Promise<ProvisionedDevice> {
+    if (criteria.platform === "ios") {
+      return this.provisionIos(criteria);
+    }
+    if (criteria.platform === "android") {
+      return this.provisionAndroid(criteria);
+    }
+    throw new ActionableError(
+      `Device creation requires an explicit platform; got '${criteria.platform}'.`
+    );
+  }
+
+  private async provisionIos(criteria: DeviceMatchCriteria): Promise<ProvisionedDevice> {
+    const simctl = this.dependencies.iosCreator();
+    if (!simctl) {
+      throw new ActionableError(
+        "Cannot create an iOS simulator: iOS simulator tools (xcrun simctl) are not available."
+      );
+    }
+
+    const deviceTypes = await simctl.getDeviceTypes();
+    const deviceType = pickIosDeviceType(deviceTypes, criteria);
+    const runtime = await simctl.resolveRuntimeIdentifier(criteria.minOsVersion);
+    const name = buildCreatedDeviceName(deviceType.name, this.idGenerator);
+
+    let deviceId: string;
+    try {
+      deviceId = await simctl.createSimulator(name, deviceType.identifier, runtime);
+    } catch (error) {
+      throw toActionableError(
+        error,
+        `Failed to create iOS simulator '${name}' (deviceType=${deviceType.identifier}, runtime=${runtime})`
+      );
+    }
+
+    logger.info(
+      `[DeviceProvisioner] Created iOS simulator '${name}' ` +
+      `(udid=${deviceId}, deviceType=${deviceType.identifier}, runtime=${runtime}). ` +
+      "Delete it with 'xcrun simctl delete " + deviceId + "' when no longer needed."
+    );
+
+    return { platform: "ios", name, deviceId, deviceType: deviceType.identifier, runtime };
+  }
+
+  private async provisionAndroid(criteria: DeviceMatchCriteria): Promise<ProvisionedDevice> {
+    const avdManager = this.dependencies.androidCreator();
+
+    let installed: SystemImage[];
+    try {
+      installed = await avdManager.listInstalledSystemImages();
+    } catch (error) {
+      throw toActionableError(error, "Failed to list installed Android system images for AVD creation");
+    }
+
+    const image = pickAndroidSystemImage(installed, criteria, this.architecture);
+    const name = buildCreatedDeviceName(criteria.name ?? `android-${image.apiLevel}`, this.idGenerator);
+
+    const result = await avdManager.createAvd({ name, package: image.packageName });
+    if (!result.success) {
+      throw new ActionableError(
+        `Failed to create Android AVD '${name}' from ${image.packageName}: ${result.message}`
+      );
+    }
+
+    logger.info(
+      `[DeviceProvisioner] Created Android AVD '${name}' ` +
+      `(systemImage=${image.packageName}, apiLevel=${image.apiLevel}, tag=${image.tag}, abi=${image.abi}). ` +
+      `Delete it with 'avdmanager delete avd -n ${name}' when no longer needed.`
+    );
+
+    return {
+      platform: "android",
+      name,
+      deviceType: image.packageName,
+      runtime: `android-${image.apiLevel}`,
+    };
+  }
+}
+
+/** The avdmanager functional API, adapted to the narrow creator interface. */
+export function createDefaultAndroidAvdCreator(): AndroidAvdCreator {
+  return {
+    listInstalledSystemImages: () => listInstalledSystemImages(),
+    createAvd: params => createAvd(params),
+  };
+}
+
+/** Production provisioner wired to the real simctl/avdmanager primitives. */
+export function createDefaultDeviceProvisioner(
+  iosCreator: () => IosSimulatorCreator | undefined = () => new SimCtlClient(null)
+): DeviceProvisioner {
+  return new DefaultDeviceProvisioner({
+    iosCreator,
+    androidCreator: createDefaultAndroidAvdCreator,
+  });
+}

--- a/src/utils/deviceProvisioning.ts
+++ b/src/utils/deviceProvisioning.ts
@@ -147,8 +147,20 @@ export function pickIosDeviceType(
 // Android selection
 // ---------------------------------------------------------------------------
 
-/** Preferred system-image tags, best first. */
-const ANDROID_TAG_PREFERENCE = ["google_apis_playstore", "google_apis", "default"];
+/**
+ * Preferred system-image tags, best first.
+ *
+ * `google_apis_playstore` is ranked LAST on purpose: Play Store images refuse
+ * `adb root`, and AutoMobile needs a root shell for the root-backed system-locale
+ * path (see AndroidSystemConfigurationAdapter, which fails with "the target
+ * emulator is not root-capable or does not allow root ADB"). Auto-provisioning a
+ * Play Store image would therefore hand the user a device that silently cannot
+ * run `changeLocalization` on the API levels that require it.
+ *
+ * `google_apis` is preferred over `default` because it is rootable AND carries
+ * the Google APIs some flows expect.
+ */
+const ANDROID_TAG_PREFERENCE = ["google_apis", "default", "google_apis_playstore"];
 
 function tagRank(tag: string): number {
   const index = ANDROID_TAG_PREFERENCE.indexOf(tag);

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -1122,8 +1122,18 @@ export class SimCtlClient implements SimCtl {
       throw new ActionableError(`Failed to create iOS simulator ${name}`);
     }
 
+    // A freshly created simulator must be visible to the very next
+    // listSimulatorImages() call, otherwise the provisioning path boots off a
+    // snapshot that predates the device it just created.
+    SimCtlClient.invalidateDeviceListCache();
+
     logger.debug(`Created iOS simulator ${name} with UDID: ${simulatorUdid}`);
     return simulatorUdid;
+  }
+
+  /** Drop the shared device-list snapshot so the next list re-reads simctl. */
+  static invalidateDeviceListCache(): void {
+    SimCtlClient.deviceListCache = null;
   }
 
   /**

--- a/test/fakes/FakeDeviceCreationGate.ts
+++ b/test/fakes/FakeDeviceCreationGate.ts
@@ -1,0 +1,34 @@
+import type { DeviceCreationGate, EnvironmentReader } from "../../src/utils/deviceCreationGate";
+
+/** In-memory {@link EnvironmentReader} so tests never mutate `process.env`. */
+export class FakeEnvironmentReader implements EnvironmentReader {
+  constructor(private readonly values: Record<string, string | undefined> = {}) {}
+
+  get(name: string): string | undefined {
+    return this.values[name];
+  }
+
+  set(name: string, value: string | undefined): void {
+    this.values[name] = value;
+  }
+}
+
+/** Gate with a fixed answer, recording what flag it was asked about. */
+export class FakeDeviceCreationGate implements DeviceCreationGate {
+  public readonly calls: (boolean | undefined)[] = [];
+
+  constructor(private allowed: boolean = false) {}
+
+  setAllowed(allowed: boolean): void {
+    this.allowed = allowed;
+  }
+
+  isCreationAllowed(explicitFlag?: boolean): boolean {
+    this.calls.push(explicitFlag);
+    return this.allowed;
+  }
+
+  describeSource(explicitFlag?: boolean): string {
+    return `fake(allowed=${this.allowed}, flag=${String(explicitFlag)})`;
+  }
+}

--- a/test/fakes/FakeDeviceProvisioner.ts
+++ b/test/fakes/FakeDeviceProvisioner.ts
@@ -1,0 +1,87 @@
+import type { DeviceMatchCriteria } from "../../src/models/DeviceMatchCriteria";
+import type {
+  AndroidAvdCreator,
+  DeviceProvisioner,
+  IosSimulatorCreator,
+  ProvisionedDevice,
+} from "../../src/utils/deviceProvisioning";
+import type { AppleDeviceType } from "../../src/utils/ios-cmdline-tools/SimCtlClient";
+import type { CreateAvdParams, SystemImage } from "../../src/utils/android-cmdline-tools/avdmanager";
+
+/** Records provisioning requests and returns a canned device. */
+export class FakeDeviceProvisioner implements DeviceProvisioner {
+  public readonly requests: DeviceMatchCriteria[] = [];
+  private result: ProvisionedDevice;
+  private failure: Error | null = null;
+
+  constructor(result?: Partial<ProvisionedDevice>) {
+    this.result = {
+      platform: "ios",
+      name: "AutoMobile-iPhone-17-abcd1234",
+      deviceId: "CREATED-UDID",
+      deviceType: "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+      runtime: "com.apple.CoreSimulator.SimRuntime.iOS-26-3",
+      ...result,
+    };
+  }
+
+  setResult(result: ProvisionedDevice): void {
+    this.result = result;
+  }
+
+  setFailure(failure: Error | null): void {
+    this.failure = failure;
+  }
+
+  async provision(criteria: DeviceMatchCriteria): Promise<ProvisionedDevice> {
+    this.requests.push(criteria);
+    if (this.failure) {
+      throw this.failure;
+    }
+    return this.result;
+  }
+}
+
+/** Simctl creation surface with scripted device types/runtime. */
+export class FakeIosSimulatorCreator implements IosSimulatorCreator {
+  public readonly createCalls: { name: string; deviceType: string; runtime: string }[] = [];
+
+  constructor(
+    private readonly deviceTypes: AppleDeviceType[] = [],
+    private readonly runtime: string = "com.apple.CoreSimulator.SimRuntime.iOS-26-3",
+    private readonly udid: string = "CREATED-UDID",
+  ) {}
+
+  async getDeviceTypes(): Promise<AppleDeviceType[]> {
+    return this.deviceTypes;
+  }
+
+  async resolveRuntimeIdentifier(): Promise<string> {
+    return this.runtime;
+  }
+
+  async createSimulator(name: string, deviceType: string, runtime: string): Promise<string> {
+    this.createCalls.push({ name, deviceType, runtime });
+    return this.udid;
+  }
+}
+
+/** avdmanager creation surface with scripted installed images. */
+export class FakeAndroidAvdCreator implements AndroidAvdCreator {
+  public readonly createCalls: CreateAvdParams[] = [];
+  public result: { success: boolean; message: string; avdName?: string } = {
+    success: true,
+    message: "created",
+  };
+
+  constructor(private readonly images: SystemImage[] = []) {}
+
+  async listInstalledSystemImages(): Promise<SystemImage[]> {
+    return this.images;
+  }
+
+  async createAvd(params: CreateAvdParams): Promise<{ success: boolean; message: string; avdName?: string }> {
+    this.createCalls.push(params);
+    return { ...this.result, avdName: this.result.avdName ?? params.name };
+  }
+}

--- a/test/server/deviceTools.createIfMissing.test.ts
+++ b/test/server/deviceTools.createIfMissing.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import {
+  setDeviceToolsDependencies,
+  resetDeviceToolsDependencies,
+  registerDeviceTools,
+  startDeviceSchema,
+} from "../../src/server/deviceTools";
+import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
+import { FakeDeviceMatcher } from "../fakes/FakeDeviceMatcher";
+import { FakeDeviceCreationGate } from "../fakes/FakeDeviceCreationGate";
+import { FakeDeviceProvisioner } from "../fakes/FakeDeviceProvisioner";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { DaemonState } from "../../src/daemon/daemonState";
+
+describe("startDevice --create-if-missing wiring", () => {
+  let fakeDeviceUtils: FakeDeviceUtils;
+  let fakeMatcher: FakeDeviceMatcher;
+  let fakeGate: FakeDeviceCreationGate;
+  let fakeProvisioner: FakeDeviceProvisioner;
+
+  beforeEach(() => {
+    fakeDeviceUtils = new FakeDeviceUtils();
+    fakeMatcher = new FakeDeviceMatcher();
+    fakeGate = new FakeDeviceCreationGate(false);
+    fakeProvisioner = new FakeDeviceProvisioner();
+
+    // Nothing booted, nothing to match: every run reaches the "no match" branch.
+    fakeDeviceUtils.setBootedDevices("ios", []);
+    fakeDeviceUtils.setDeviceImages("ios", []);
+    fakeDeviceUtils.setBootedDevices("android", []);
+    fakeDeviceUtils.setDeviceImages("android", []);
+    fakeMatcher.setBootedResult(null);
+    fakeMatcher.setImageResult(null);
+
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => fakeDeviceUtils,
+      deviceMatcherFactory: () => fakeMatcher,
+      notifyResourcesChanged: async () => {},
+      ensureCtrlProxyReady: async () => {},
+      deviceCreationGateFactory: () => fakeGate,
+      deviceProvisionerFactory: () => fakeProvisioner,
+    });
+
+    registerDeviceTools();
+  });
+
+  afterEach(() => {
+    resetDeviceToolsDependencies();
+    DaemonState.getInstance().reset();
+  });
+
+  async function callStartDevice(args: Record<string, unknown>): Promise<Record<string, unknown>> {
+    const tool = ToolRegistry.getTool("startDevice");
+    if (!tool) {throw new Error("startDevice not registered");}
+    const result = await tool.handler(args);
+    return JSON.parse(typeof result === "string" ? result : (result as any).content?.[0]?.text ?? "{}");
+  }
+
+  it("accepts createIfMissing through the tool schema", () => {
+    const parsed = startDeviceSchema.parse({ platform: "ios", createIfMissing: true });
+    expect((parsed as Record<string, unknown>).createIfMissing).toBe(true);
+  });
+
+  it("does NOT create anything when the gate is off (default)", async () => {
+    await expect(callStartDevice({ platform: "ios" })).rejects.toThrow(
+      /No ios device matching criteria found/
+    );
+    expect(fakeProvisioner.requests).toEqual([]);
+    expect(fakeDeviceUtils.getExecutedOperations().some(op => op.startsWith("startDevice:"))).toBe(false);
+  });
+
+  it("does NOT create anything when the flag is explicitly false", async () => {
+    await expect(callStartDevice({ platform: "ios", createIfMissing: false })).rejects.toThrow(
+      /No ios device matching criteria found/
+    );
+    expect(fakeProvisioner.requests).toEqual([]);
+    // The handler forwards the explicit flag to the gate so precedence is decided there.
+    expect(fakeGate.calls).toEqual([false]);
+  });
+
+  it("creates and boots an iOS simulator when the gate is on", async () => {
+    fakeGate.setAllowed(true);
+
+    const result = await callStartDevice({ platform: "ios", createIfMissing: true });
+
+    expect(fakeProvisioner.requests).toHaveLength(1);
+    expect(fakeProvisioner.requests[0].platform).toBe("ios");
+    expect(fakeGate.calls).toEqual([true]);
+    expect(result.name).toBe("AutoMobile-iPhone-17-abcd1234");
+    expect(result.deviceId).toBe("CREATED-UDID");
+    expect(result.source).toBe("cold-boot");
+    expect(fakeDeviceUtils.getExecutedOperations().some(op => op.startsWith("startDevice:"))).toBe(true);
+  });
+
+  it("creates an Android AVD when the gate is on", async () => {
+    fakeGate.setAllowed(true);
+    fakeProvisioner.setResult({
+      platform: "android",
+      name: "AutoMobile-android-34-abcd1234",
+      deviceType: "system-images;android-34;google_apis;arm64-v8a",
+      runtime: "android-34",
+    });
+
+    const result = await callStartDevice({ platform: "android", createIfMissing: true });
+
+    expect(fakeProvisioner.requests[0].platform).toBe("android");
+    expect(result.name).toBe("AutoMobile-android-34-abcd1234");
+    expect(result.source).toBe("cold-boot");
+  });
+
+  it("forwards the matching criteria to the provisioner", async () => {
+    fakeGate.setAllowed(true);
+
+    await callStartDevice({
+      platform: "ios",
+      createIfMissing: true,
+      minOsVersion: "26.0",
+      formFactor: "tablet",
+      name: "iPad Pro 13-inch (M4)",
+    });
+
+    expect(fakeProvisioner.requests[0]).toMatchObject({
+      platform: "ios",
+      minOsVersion: "26.0",
+      formFactor: "tablet",
+      name: "iPad Pro 13-inch (M4)",
+    });
+  });
+
+  it("consults the gate with undefined when the flag is not supplied (env var can decide)", async () => {
+    fakeGate.setAllowed(true);
+
+    await callStartDevice({ platform: "ios" });
+
+    expect(fakeGate.calls).toEqual([undefined]);
+    expect(fakeProvisioner.requests).toHaveLength(1);
+  });
+});

--- a/test/utils/DeviceSessionManager.createIfMissing.test.ts
+++ b/test/utils/DeviceSessionManager.createIfMissing.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { DeviceSessionManager } from "../../src/utils/DeviceSessionManager";
+import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
+import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
+import { FakeDeviceClientProvider } from "../fakes/FakeDeviceClientProvider";
+import { FakeDeviceCreationGate } from "../fakes/FakeDeviceCreationGate";
+import { resetDeviceCreationGate, setDeviceCreationGate } from "../../src/utils/deviceCreationGate";
+import type { SimCtlClient } from "../../src/utils/ios-cmdline-tools/SimCtlClient";
+import type { BootedDevice } from "../../src/models";
+
+interface SimctlRecorder {
+  createCalls: { name: string; deviceType: string; runtime: string }[];
+  bootCalls: string[];
+}
+
+/**
+ * Minimal simctl stub reporting an EMPTY simulator list — the condition that
+ * makes findOrStartIosDevice either throw or (when gated on) provision.
+ */
+function makeEmptySimctl(recorder: SimctlRecorder): SimCtlClient {
+  return {
+    listSimulatorImages: async () => [],
+    getBootedSimulators: async () => [],
+    getDeviceTypes: async () => [
+      {
+        name: "iPhone 17",
+        identifier: "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+        productFamily: "iPhone",
+        bundlePath: "/tmp",
+        minRuntimeVersion: 0,
+        maxRuntimeVersion: 0,
+      },
+    ],
+    resolveRuntimeIdentifier: async () => "com.apple.CoreSimulator.SimRuntime.iOS-26-3",
+    createSimulator: async (name: string, deviceType: string, runtime: string) => {
+      recorder.createCalls.push({ name, deviceType, runtime });
+      return "CREATED-UDID";
+    },
+    bootSimulator: async (udid: string): Promise<BootedDevice> => {
+      recorder.bootCalls.push(udid);
+      return { deviceId: udid, name: "AutoMobile-iPhone-17", platform: "ios" };
+    },
+    // verifyIosDevice returns early for a non-Booted, available device.
+    getDeviceInfo: async () => ({ name: "AutoMobile-iPhone-17", isAvailable: true, state: "Shutdown" }),
+  } as unknown as SimCtlClient;
+}
+
+describe("findOrStartIosDevice creation gate", () => {
+  let recorder: SimctlRecorder;
+  let manager: DeviceSessionManager;
+
+  beforeEach(() => {
+    recorder = { createCalls: [], bootCalls: [] };
+    const provider = new FakeDeviceClientProvider(
+      new FakeAdbExecutor(),
+      new FakeDeviceUtils(),
+      makeEmptySimctl(recorder),
+    );
+    manager = new DeviceSessionManager(provider);
+  });
+
+  afterEach(() => {
+    resetDeviceCreationGate();
+  });
+
+  test("keeps the existing error and creates nothing when the gate is off", async () => {
+    setDeviceCreationGate(new FakeDeviceCreationGate(false));
+
+    await expect(manager.findOrStartIosDevice()).rejects.toThrow(
+      "No iOS simulators are available. Please create an iOS simulator using Xcode or the Simulator app."
+    );
+    expect(recorder.createCalls).toEqual([]);
+    expect(recorder.bootCalls).toEqual([]);
+  });
+
+  test("creates and boots a simulator when the gate is on", async () => {
+    setDeviceCreationGate(new FakeDeviceCreationGate(true));
+
+    const device = await manager.findOrStartIosDevice();
+
+    expect(recorder.createCalls).toHaveLength(1);
+    expect(recorder.createCalls[0].deviceType).toBe("com.apple.CoreSimulator.SimDeviceType.iPhone-17");
+    expect(recorder.createCalls[0].runtime).toBe("com.apple.CoreSimulator.SimRuntime.iOS-26-3");
+    expect(recorder.createCalls[0].name).toStartWith("AutoMobile-iPhone-17-");
+    expect(recorder.bootCalls).toEqual(["CREATED-UDID"]);
+    expect(device.deviceId).toBe("CREATED-UDID");
+  });
+
+  test("consults the gate with no explicit flag (env var only on this path)", async () => {
+    const gate = new FakeDeviceCreationGate(false);
+    setDeviceCreationGate(gate);
+
+    await expect(manager.findOrStartIosDevice()).rejects.toThrow(/No iOS simulators are available/);
+    expect(gate.calls).toEqual([undefined]);
+  });
+});

--- a/test/utils/android-cmdline-tools/avdmanager.test.ts
+++ b/test/utils/android-cmdline-tools/avdmanager.test.ts
@@ -237,6 +237,61 @@ Available Packages:
     });
   });
 
+  describe("listInstalledSystemImages", () => {
+    const SDKMANAGER_LIST_OUTPUT = `
+Installed packages:
+  Path                                           | Version | Description
+  -------                                        | ------- | -------
+  system-images;android-34;google_apis;arm64-v8a | 12      | Google APIs ARM 64 v8a System Image
+  platform-tools                                 | 35.0.0  | Android SDK Platform-Tools
+
+Available Packages:
+  system-images;android-35;google_apis;x86_64    | 5
+  system-images;android-36;google_apis;x86_64    | 2
+`;
+
+    function respondWithList(mockDeps: any, fakeTimer: any): void {
+      const originalSpawn = mockDeps.spawn;
+      mockDeps.spawn = (command: string, args: string[], options?: any) => {
+        const child: any = originalSpawn(command, args, options);
+        fakeTimer.setTimeout(() => {
+          child.triggerStdout(Buffer.from(SDKMANAGER_LIST_OUTPUT));
+          child.triggerClose(0);
+        }, 0);
+        return child;
+      };
+    }
+
+    test("returns only the installed section", async () => {
+      const mockDeps = createDependencies();
+      const fakeTimer = createFakeTimer();
+      respondWithList(mockDeps, fakeTimer);
+
+      const result = await resolveWithFakeTimer(
+        fakeTimer,
+        avdmanager.listInstalledSystemImages(undefined, mockDeps)
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].packageName).toBe("system-images;android-34;google_apis;arm64-v8a");
+      expect(result[0].apiLevel).toBe(34);
+      expect(result[0].abi).toBe("arm64-v8a");
+    });
+
+    test("listSystemImages still returns only the available section", async () => {
+      const mockDeps = createDependencies();
+      const fakeTimer = createFakeTimer();
+      respondWithList(mockDeps, fakeTimer);
+
+      const result = await resolveWithFakeTimer(
+        fakeTimer,
+        avdmanager.listSystemImages(undefined, mockDeps)
+      );
+
+      expect(result.map((image: any) => image.apiLevel)).toEqual([35, 36]);
+    });
+  });
+
   describe("createAvd", () => {
     test("should create AVD successfully", async () => {
       const mockDeps = createDependencies();

--- a/test/utils/deviceCreationGate.test.ts
+++ b/test/utils/deviceCreationGate.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import {
+  DEVICE_CREATE_ENV_VAR,
+  EnvDeviceCreationGate,
+  getDeviceCreationGate,
+  isTruthyCreationEnvValue,
+  resetDeviceCreationGate,
+  setDeviceCreationGate,
+} from "../../src/utils/deviceCreationGate";
+import { FakeDeviceCreationGate, FakeEnvironmentReader } from "../fakes/FakeDeviceCreationGate";
+
+function gateWithEnv(value: string | undefined): EnvDeviceCreationGate {
+  return new EnvDeviceCreationGate(new FakeEnvironmentReader({ [DEVICE_CREATE_ENV_VAR]: value }));
+}
+
+describe("device creation gate", () => {
+  afterEach(() => {
+    resetDeviceCreationGate();
+  });
+
+  it("is off by default when neither flag nor env var is set", () => {
+    expect(gateWithEnv(undefined).isCreationAllowed()).toBe(false);
+    expect(gateWithEnv(undefined).isCreationAllowed(undefined)).toBe(false);
+  });
+
+  describe("precedence matrix (flag x env)", () => {
+    const cases: { flag: boolean | undefined; env: string | undefined; expected: boolean }[] = [
+      { flag: undefined, env: undefined, expected: false },
+      { flag: undefined, env: "1", expected: true },
+      { flag: undefined, env: "true", expected: true },
+      { flag: undefined, env: "0", expected: false },
+      { flag: undefined, env: "false", expected: false },
+      { flag: true, env: undefined, expected: true },
+      { flag: true, env: "0", expected: true },
+      { flag: true, env: "false", expected: true },
+      { flag: false, env: undefined, expected: false },
+      { flag: false, env: "1", expected: false },
+      { flag: false, env: "true", expected: false },
+    ];
+
+    for (const { flag, env, expected } of cases) {
+      it(`flag=${String(flag)} env=${String(env)} -> ${expected}`, () => {
+        expect(gateWithEnv(env).isCreationAllowed(flag)).toBe(expected);
+      });
+    }
+  });
+
+  it("accepts 1/true case-insensitively and tolerates whitespace", () => {
+    expect(isTruthyCreationEnvValue("TRUE")).toBe(true);
+    expect(isTruthyCreationEnvValue("  1 ")).toBe(true);
+    expect(isTruthyCreationEnvValue("True")).toBe(true);
+    expect(isTruthyCreationEnvValue("yes")).toBe(false);
+    expect(isTruthyCreationEnvValue("on")).toBe(false);
+    expect(isTruthyCreationEnvValue("")).toBe(false);
+    expect(isTruthyCreationEnvValue(undefined)).toBe(false);
+  });
+
+  it("describes which source decided", () => {
+    expect(gateWithEnv(undefined).describeSource()).toBe("default (off)");
+    expect(gateWithEnv("1").describeSource()).toBe(`${DEVICE_CREATE_ENV_VAR}=1`);
+    expect(gateWithEnv("1").describeSource(false)).toBe("--create-if-missing=false");
+  });
+
+  it("supports injecting a gate through the module seam", () => {
+    const fake = new FakeDeviceCreationGate(true);
+    setDeviceCreationGate(fake);
+    expect(getDeviceCreationGate().isCreationAllowed()).toBe(true);
+    resetDeviceCreationGate();
+    // Back to the real env-backed gate, which is off in the test environment.
+    expect(getDeviceCreationGate().isCreationAllowed(false)).toBe(false);
+  });
+});

--- a/test/utils/deviceProvisioning.test.ts
+++ b/test/utils/deviceProvisioning.test.ts
@@ -78,6 +78,35 @@ describe("pickIosDeviceType", () => {
   });
 });
 
+describe("pickAndroidSystemImage tag preference", () => {
+  // Play Store images refuse `adb root`, and AutoMobile needs a root shell for the
+  // root-backed system-locale path (AndroidSystemConfigurationAdapter). Auto-creating
+  // one would hand the user a device that cannot run changeLocalization on the API
+  // levels that require root, so it must rank BELOW google_apis and default.
+  it("prefers a rootable google_apis image over a same-API playstore image", () => {
+    const images = [
+      systemImage(35, "google_apis_playstore", "arm64-v8a"),
+      systemImage(35, "google_apis", "arm64-v8a"),
+      systemImage(35, "default", "arm64-v8a"),
+    ];
+
+    expect(pickAndroidSystemImage(images, {}, "arm64").packageName).toBe(
+      "system-images;android-35;google_apis;arm64-v8a"
+    );
+  });
+
+  it("prefers default over playstore when google_apis is unavailable", () => {
+    const images = [
+      systemImage(35, "google_apis_playstore", "arm64-v8a"),
+      systemImage(35, "default", "arm64-v8a"),
+    ];
+
+    expect(pickAndroidSystemImage(images, {}, "arm64").packageName).toBe(
+      "system-images;android-35;default;arm64-v8a"
+    );
+  });
+});
+
 describe("pickAndroidSystemImage", () => {
   const images = [
     systemImage(33, "default", "arm64-v8a"),

--- a/test/utils/deviceProvisioning.test.ts
+++ b/test/utils/deviceProvisioning.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from "bun:test";
+import {
+  DefaultDeviceProvisioner,
+  buildCreatedDeviceName,
+  isCreatedDeviceName,
+  pickAndroidSystemImage,
+  pickIosDeviceType,
+  preferredAbis,
+} from "../../src/utils/deviceProvisioning";
+import { CountingIdGenerator } from "../../src/utils/IdGenerator";
+import { ActionableError } from "../../src/models/ActionableError";
+import type { AppleDeviceType } from "../../src/utils/ios-cmdline-tools/SimCtlClient";
+import type { SystemImage } from "../../src/utils/android-cmdline-tools/avdmanager";
+import { FakeAndroidAvdCreator, FakeIosSimulatorCreator } from "../fakes/FakeDeviceProvisioner";
+
+function deviceType(name: string, productFamily = "iPhone"): AppleDeviceType {
+  return {
+    name,
+    identifier: `com.apple.CoreSimulator.SimDeviceType.${name.replace(/\s+/g, "-")}`,
+    productFamily,
+    bundlePath: "/tmp",
+    minRuntimeVersion: 0,
+    maxRuntimeVersion: 0,
+  };
+}
+
+function systemImage(apiLevel: number, tag: string, abi: string): SystemImage {
+  return {
+    packageName: `system-images;android-${apiLevel};${tag};${abi}`,
+    apiLevel,
+    tag,
+    abi,
+    versionInfo: "",
+  };
+}
+
+describe("buildCreatedDeviceName", () => {
+  it("uses a recognizable prefix and a deterministic injected suffix", () => {
+    const name = buildCreatedDeviceName("iPhone 17 Pro", new CountingIdGenerator("uuid"));
+    expect(name).toBe("AutoMobile-iPhone-17-Pro-uuid1");
+    expect(isCreatedDeviceName(name)).toBe(true);
+    expect(isCreatedDeviceName("Pixel_7_API_34")).toBe(false);
+  });
+
+  it("falls back to a placeholder when the base name has no usable characters", () => {
+    expect(buildCreatedDeviceName("///", new CountingIdGenerator("x"))).toBe("AutoMobile-device-x1");
+  });
+});
+
+describe("pickIosDeviceType", () => {
+  const types = [
+    deviceType("iPhone 16"),
+    deviceType("iPhone 17"),
+    deviceType("iPhone 17 Pro Max"),
+    deviceType("iPad Pro 13-inch (M4)", "iPad"),
+  ];
+
+  it("prefers the newest base iPhone model by default", () => {
+    expect(pickIosDeviceType(types, {}).name).toBe("iPhone 17");
+  });
+
+  it("honours an explicit name (case-insensitive)", () => {
+    expect(pickIosDeviceType(types, { name: "iphone 16" }).name).toBe("iPhone 16");
+  });
+
+  it("selects an iPad for the tablet form factor", () => {
+    expect(pickIosDeviceType(types, { formFactor: "tablet" }).name).toBe("iPad Pro 13-inch (M4)");
+  });
+
+  it("throws an actionable error when no device types exist", () => {
+    expect(() => pickIosDeviceType([], {})).toThrow(ActionableError);
+  });
+
+  it("throws an actionable error when the requested family is absent", () => {
+    expect(() => pickIosDeviceType([deviceType("iPhone 17")], { formFactor: "tablet" })).toThrow(
+      /No iPad simulator device type/
+    );
+  });
+});
+
+describe("pickAndroidSystemImage", () => {
+  const images = [
+    systemImage(33, "default", "arm64-v8a"),
+    systemImage(34, "google_apis", "arm64-v8a"),
+    systemImage(34, "google_apis", "x86_64"),
+    systemImage(35, "google_apis", "x86_64"),
+  ];
+
+  it("prefers the newest API level with a host-runnable ABI", () => {
+    expect(pickAndroidSystemImage(images, {}, "x64").packageName).toBe(
+      "system-images;android-35;google_apis;x86_64"
+    );
+  });
+
+  it("prefers the host ABI when several API levels tie", () => {
+    expect(pickAndroidSystemImage(images.slice(0, 3), {}, "arm64").packageName).toBe(
+      "system-images;android-34;google_apis;arm64-v8a"
+    );
+  });
+
+  it("respects the requested API range", () => {
+    expect(pickAndroidSystemImage(images, { maxOsVersion: "34" }, "x64").apiLevel).toBe(34);
+    expect(pickAndroidSystemImage(images, { minOsVersion: "35" }, "x64").apiLevel).toBe(35);
+  });
+
+  it("throws an actionable error when nothing is installed in range", () => {
+    expect(() => pickAndroidSystemImage(images, { minOsVersion: "99" }, "x64")).toThrow(
+      /No installed Android system image/
+    );
+  });
+
+  it("maps host architecture to runnable ABIs", () => {
+    expect(preferredAbis("arm64")[0]).toBe("arm64-v8a");
+    expect(preferredAbis("x64")[0]).toBe("x86_64");
+  });
+});
+
+describe("DefaultDeviceProvisioner", () => {
+  it("creates an iOS simulator with the resolved device type and runtime", async () => {
+    const simctl = new FakeIosSimulatorCreator(
+      [deviceType("iPhone 17")],
+      "com.apple.CoreSimulator.SimRuntime.iOS-26-3",
+      "NEW-UDID"
+    );
+    const provisioner = new DefaultDeviceProvisioner({
+      iosCreator: () => simctl,
+      androidCreator: () => new FakeAndroidAvdCreator(),
+      idGenerator: new CountingIdGenerator("uuid"),
+      architecture: "arm64",
+    });
+
+    const created = await provisioner.provision({ platform: "ios" });
+
+    expect(created).toEqual({
+      platform: "ios",
+      name: "AutoMobile-iPhone-17-uuid1",
+      deviceId: "NEW-UDID",
+      deviceType: "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+      runtime: "com.apple.CoreSimulator.SimRuntime.iOS-26-3",
+    });
+    expect(simctl.createCalls).toEqual([
+      {
+        name: "AutoMobile-iPhone-17-uuid1",
+        deviceType: "com.apple.CoreSimulator.SimDeviceType.iPhone-17",
+        runtime: "com.apple.CoreSimulator.SimRuntime.iOS-26-3",
+      },
+    ]);
+  });
+
+  it("creates an Android AVD from an installed system image", async () => {
+    const avd = new FakeAndroidAvdCreator([systemImage(34, "google_apis", "arm64-v8a")]);
+    const provisioner = new DefaultDeviceProvisioner({
+      iosCreator: () => undefined,
+      androidCreator: () => avd,
+      idGenerator: new CountingIdGenerator("uuid"),
+      architecture: "arm64",
+    });
+
+    const created = await provisioner.provision({ platform: "android" });
+
+    expect(created).toEqual({
+      platform: "android",
+      name: "AutoMobile-android-34-uuid1",
+      deviceType: "system-images;android-34;google_apis;arm64-v8a",
+      runtime: "android-34",
+    });
+    expect(avd.createCalls).toEqual([
+      { name: "AutoMobile-android-34-uuid1", package: "system-images;android-34;google_apis;arm64-v8a" },
+    ]);
+  });
+
+  it("surfaces an actionable error when AVD creation fails", async () => {
+    const avd = new FakeAndroidAvdCreator([systemImage(34, "google_apis", "arm64-v8a")]);
+    avd.result = { success: false, message: "package not installed" };
+    const provisioner = new DefaultDeviceProvisioner({
+      iosCreator: () => undefined,
+      androidCreator: () => avd,
+      idGenerator: new CountingIdGenerator("uuid"),
+      architecture: "arm64",
+    });
+
+    await expect(provisioner.provision({ platform: "android" })).rejects.toThrow(
+      /Failed to create Android AVD .*package not installed/
+    );
+  });
+
+  it("reports an actionable error when simctl is unavailable", async () => {
+    const provisioner = new DefaultDeviceProvisioner({
+      iosCreator: () => undefined,
+      androidCreator: () => new FakeAndroidAvdCreator(),
+    });
+
+    await expect(provisioner.provision({ platform: "ios" })).rejects.toThrow(
+      /iOS simulator tools \(xcrun simctl\) are not available/
+    );
+  });
+});


### PR DESCRIPTION
Closes #4093.

## Scope correction

The issue as filed said "there is no `simctl create` anywhere in `src/`". **That was wrong** — my error, from a grep that failed with a shell glob error and returned empty output I read as absence. A [correcting comment](https://github.com/kaeawc/auto-mobile/issues/4093) records the accurate state. Both primitives already existed:

- `SimCtlClient.createSimulator` (`SimCtlClient.ts:1116`)
- `AvdManagerClient.createAvd` (`AvdManagerClient.ts:109`)

So this PR is **gating and wiring only**. What was actually missing: no gate existed anywhere, and `createSimulator` had no callers outside the client — `findOrStartIosDevice()` threw *"No iOS simulators are available…"* rather than creating one.

## Gate (default OFF)

`DeviceCreationGate` (`src/utils/deviceCreationGate.ts`) reads through an injected `EnvironmentReader`, so no call site touches `process.env`:

- CLI flag `--create-if-missing` — the parser already maps kebab→camel and treats a bare flag as `true`, so no parser change was needed.
- Env var `AUTOMOBILE_ALLOW_DEVICE_CREATE` (`1`/`true`, case-insensitive, trimmed).
- **The flag wins in both directions** — `--create-if-missing false` beats `AUTOMOBILE_ALLOW_DEVICE_CREATE=1`.
- When off, both platforms' error messages are byte-identical to today.

`describeSource()` feeds the log line so a user can see *which* input enabled it. Created devices carry an `AutoMobile-<model>-<id>` prefix (id from the injected `IdGenerator`, not a bare `randomUUID()`), with `isCreatedDeviceName()` for cleanup.

## Android: Play Store images ranked **last** — a real defect caught in review

The initial tag preference was `google_apis_playstore > google_apis > default`. Play Store images **refuse `adb root`**, and AutoMobile needs a root shell for the root-backed system-locale path — `AndroidSystemConfigurationAdapter` fails with *"the target emulator is not root-capable or does not allow root ADB"* on the API levels that require it. Auto-provisioning one would have handed users a device that silently cannot run `changeLocalization`.

Now `google_apis > default > google_apis_playstore`, with two tests pinning it, **both verified to fail under the previous ranking**.

## Two support changes worth review

- **`listInstalledSystemImages()`** — the existing `listSystemImages()` parses only the *"Available Packages"* (downloadable) section, and `avdmanager create avd -k` fails on a package that isn't on disk. `parseSystemImages` is now section-parameterized; a test pins that `listSystemImages` still returns only the available section.
- **`createSimulator` now invalidates the static `deviceListCache`** — without it, a create-then-list would boot off a snapshot predating the device just created.

## Deliberately out of scope

- The `deviceId` direct-lookup branch does **not** provision — asking for a specific UDID and silently getting a different, newly-created device is wrong; it still throws "not found".
- No auto-install of system images/runtimes; you get an actionable error naming the `sdkmanager` command. Downloading multi-GB images is well outside "create if missing".
- No cleanup/GC of created devices. The name prefix and `isCreatedDeviceName()` make it possible; nothing sweeps them. Worth a follow-up if CI adopts this.

## Verification

91 pass / 0 fail across all changed test files (**0 unhandled errors** — checked explicitly, see below); full suite 8198 pass; lint clean; both the simctl and emulator boundary ratchets pass; typecheck shows no new errors from these files.

Non-vacuity, each with an asserted mutation anchor and `trap`-based restore: gate forced true → default-off tests fail; provision unconditionally → default-off fails; never provision → gate-enables fails (both `startDevice` and `DeviceSessionManager`); playstore-first ordering → both tag tests fail.

One process note: an earlier revision of the tag tests used `test(...)` in a file importing `it`, which Bun reported as `16 pass / 0 fail / **1 error**` — a green-looking summary while those tests never ran. Verification now asserts the error count and exit code, not just pass/fail.