### PR TITLE
ci(ios): remove no-op Xcode re-selection from the 26.5 leg (#4114)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1541,15 +1541,9 @@ jobs:
         if: always()
         run: xcrun simctl shutdown all || true
 
-      - name: "Select Xcode 26.5"
-        if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "26.5"
-
-      - name: "Ensure iOS Simulator runtime (Xcode 26.5)"
-        if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
-        uses: ./.github/actions/ensure-ios-simulator-runtime
+      # No Xcode re-selection here: the job selects 26.5 up front and, since the
+      # 26.2 leg was dropped (#4110), nothing switches the toolchain afterwards.
+      # Re-selecting and re-ensuring the runtime were pure no-ops (#4114).
 
       - name: "Boot iOS Simulator (Xcode 26.5)"
         if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
@@ -1005,8 +1005,6 @@ private func assertWorkflowSecondRemindersBringUpRunsWhenNotCancelled(
     }
 
     for stepName in [
-        "Select Xcode 26.5",
-        "Ensure iOS Simulator runtime (Xcode 26.5)",
         "Boot iOS Simulator (Xcode 26.5)",
         "Ensure AutoMobile daemon ready (Xcode 26.5)",
     ] {

--- a/test/bats/xctest-shared-prereq-gate.bats
+++ b/test/bats/xctest-shared-prereq-gate.bats
@@ -73,8 +73,6 @@ step_if_condition() {
 # unrelated step gained one and the suite would stay green.
 xcode_265_leg_steps() {
   cat <<'STEPS'
-Select Xcode 26.5
-Ensure iOS Simulator runtime (Xcode 26.5)
 Boot iOS Simulator (Xcode 26.5)
 Ensure AutoMobile daemon ready (Xcode 26.5)
 Warm up iOS CtrlProxy (Xcode 26.5)


### PR DESCRIPTION
Closes #4114. Also **dissolves #4115** — see below.

## Problem

The job selects Xcode 26.5 up front and ensures the runtime. The leg then re-selected the *same* toolchain and re-ensured the *same* runtime:

```yaml
- name: "Select Xcode 26.5"                      # job-initial, :1457
- name: "Ensure iOS Simulator runtime"           # job-initial, :1462
...
- name: "Select Xcode 26.5"                      # leg, :1544  <- no-op
- name: "Ensure iOS Simulator runtime (Xcode 26.5)" # leg, :1550  <- no-op
```

Those leg steps existed only to undo the 26.2 leg's toolchain switch. Since #4110 dropped that leg, nothing changes the toolchain anymore.

## Change

Removes both, plus the two surfaces that enumerate the leg's steps — `xcode_265_leg_steps()` in the bats guard and the Swift bring-up fallback list. Leaving either behind would have failed on a step that no longer exists, which is why #4114 called out that they must move together.

## This dissolves #4115

`Select Xcode 26.5` is now **unique** in the job. The duplicate name was the entire reason step-extraction needed a positional anchor — an unanchored scan matched the job-initial (unguarded) occurrence and reported a false violation. With the duplicate gone, the anchor is no longer load-bearing for correctness.

I've left the anchor in place here rather than ripping it out in the same PR: #4116 (collapsing the duplicate shutdown steps) is what actually wants it gone, and removing it is a separate, testable step. #4115 should be re-scoped from "re-anchor onto something semantically meaningful" to "the anchor can now simply be deleted" — I'll update that issue.

## Verification

- **Anti-vacuity**: the trimmed step list could easily have gone vacuous. Stripping the build guard from a *remaining* leg step still fails the per-step assertion, with the mutation anchor asserted before mutating so a silent no-op probe couldn't masquerade as proof.
- bats 5/5, Swift 27/27, YAML parses.

No behavioral change intended — these steps did nothing.