### PR TITLE
ci(observability): reproducible CI failure-rate and step-duration measurement (#4122)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -114,6 +114,41 @@ Regenerate the fixture by re-running the `observe` MCP tool against an Android
 home screen and re-committing the pretty-printed JSON; treat it as a frozen
 baseline and only refresh it deliberately when the observe output format changes.
 
+## CI Failure-Rate and Step-Duration Measurement
+
+`scripts/ci/measure-ci.sh` turns the ad-hoc "how flaky is this job / how long
+does that step take" analysis into a reproducible command (issue #4122). Over a
+bounded window of workflow runs it reports per-job outcome tallies ranked by
+failure rate, per-step duration percentiles (min / median / p90 / p95 / max),
+and the rerun-success rate — a job that failed and then passed unchanged on a
+later attempt of the same head SHA.
+
+```bash
+scripts/ci/measure-ci.sh --limit 60                    # human summary
+scripts/ci/measure-ci.sh --limit 100 --json > win.json # diffable JSON
+scripts/ci/measure-ci.sh --limit 100 --cache /tmp/ci.json  # resumable fetch
+```
+
+Two properties matter and are pinned by `test/bats/measure-ci.bats`:
+
+- **Repeated steps keep their ordinal.** A job that boots a simulator three
+  times reports `Boot #1`, `Boot #2`, `Boot #3` separately. Grouping by name
+  alone destroys the signal that justified dropping the Xcode 26.2 leg
+  ("all 9 boots >= 300s were the *third* boot").
+- **Percentiles are nearest-rank**, not interpolated: `index = ceil(p/100 * n)`.
+
+The script is two separable layers. `--fetch-only` emits the normalized bundle
+JSON from the Actions jobs API; `--from-file` aggregates a pre-fetched bundle
+with no network access at all, which is how the BATS suite drives it. Step
+conclusions and timestamps come from the structured jobs API; the only log-text
+path is the opt-in `--sentinel` / `--sentinel-job` pair, for strings that appear
+solely in job output (e.g. `Status=4294967295`).
+
+`--limit` is bounded by `--max-runs` (default 200) and exceeding it is a loud
+error rather than a silent truncation. `gh api --paginate` over workflow runs is
+deliberately avoided — it hangs and returns nothing; pages are requested
+explicitly with a cap.
+
 ## Startup Benchmark
 
 Measure MCP server and daemon startup time (cold/warm) with optional baseline comparison:

--- a/scripts/ci/measure-ci.sh
+++ b/scripts/ci/measure-ci.sh
@@ -385,7 +385,20 @@ fetch_bundle() {
   local have_cache=0
   if [ -n "$CACHE_FILE" ] && [ -f "$CACHE_FILE" ]; then
     have_cache=1
-    echo "Cache: $(jq '(.runs // []) | length' "$CACHE_FILE") runs available for reuse from ${CACHE_FILE}" >&2
+    # Sentinel flags are computed at fetch time and stored per job, so a cache
+    # built under a different sentinel config cannot be reused: the run id and
+    # attempt would still match while every cached job carried a stale (usually
+    # null) sentinel value. The bundle would then claim meta.sentinel while
+    # reporting no hits -- a measurement that looks valid and is not.
+    local cached_sentinel cached_sentinel_job
+    cached_sentinel="$(jq -r '.meta.sentinel // ""' "$CACHE_FILE")"
+    cached_sentinel_job="$(jq -r '.meta.sentinel_job // ""' "$CACHE_FILE")"
+    if [ "$cached_sentinel" != "$SENTINEL" ] || [ "$cached_sentinel_job" != "$SENTINEL_JOB" ]; then
+      have_cache=0
+      echo "Cache: sentinel config differs from ${CACHE_FILE}; refetching rather than serving stale sentinel values" >&2
+    else
+      echo "Cache: $(jq '(.runs // []) | length' "$CACHE_FILE") runs available for reuse from ${CACHE_FILE}" >&2
+    fi
   fi
 
   local run_ids run_id total idx=0 attempt reused=0
@@ -421,10 +434,12 @@ fetch_bundle() {
     --arg workflow "$WORKFLOW" \
     --arg branch "$BRANCH" \
     --arg sentinel "$SENTINEL" \
+    --arg sentinel_job "$SENTINEL_JOB" \
     --argjson limit "$LIMIT" \
     --slurpfile runs "$out_jsonl" \
     '{ meta: { repo: $repo, workflow: $workflow, branch: (if $branch == "" then null else $branch end),
                limit: $limit, sentinel: (if $sentinel == "" then null else $sentinel end),
+               sentinel_job: (if $sentinel_job == "" then null else $sentinel_job end),
                fetched_at: (now | todateiso8601) },
        runs: $runs }' > "$out_bundle"
 }
@@ -471,7 +486,9 @@ def round3: (. * 1000 | round) / 1000;
     | $steps[$i] as $s
     | { job: $job.name,
         step: $s.name,
-        ordinal: ( [ $steps[0:$i][] | select(.name == $s.name) ] | length ) + 1,
+        # Parenthesized as a whole: jq 1.7 (Ubuntu runners) rejects a top-level
+        # binary operator in an object value, while 1.8 (local macOS) accepts it.
+        ordinal: (( [ $steps[0:$i][] | select(.name == $s.name) ] | length ) + 1),
         conclusion: $s.conclusion,
         run_id: $run.id,
         run_attempt: $job.run_attempt,

--- a/scripts/ci/measure-ci.sh
+++ b/scripts/ci/measure-ci.sh
@@ -1,0 +1,682 @@
+#!/usr/bin/env bash
+#
+# measure-ci.sh — reproducible CI failure-rate and step-duration measurement
+# (issue #4122).
+#
+# Every recent CI judgment call ("is the iOS rollup safe to require?",
+# "what should timeout-minutes be?") needed the same three numbers, and every
+# time they were re-derived by hand and thrown away. This script makes that
+# measurement a command.
+#
+# Over a bounded window of workflow runs it reports:
+#
+#   1. Per-job outcome tally      — executed / passed / failed / skipped /
+#                                   cancelled, ranked by failure rate.
+#   2. Per-step duration spread   — min / median / p90 / p95 / max, keyed by
+#                                   (job, step name, ORDINAL). The ordinal is
+#                                   load-bearing: "all 9 boots >= 300s were the
+#                                   THIRD boot" is invisible under a naive
+#                                   group-by-name.
+#   3. Rerun-success rate         — a job that failed and then passed unchanged
+#                                   on a later attempt of the same head SHA.
+#                                   The cleanest flake signal available.
+#   4. Optional log sentinel      — fraction of matching jobs whose log contains
+#                                   a pattern (opt-in; the only path that reads
+#                                   log text rather than the jobs API).
+#
+# The script is two separable layers:
+#
+#   fetch      gh -> a normalized "bundle" JSON document (--fetch-only, --cache)
+#   aggregate  bundle JSON -> summary or --json (--from-file)
+#
+# so the aggregation math is testable offline against fixtures with no API
+# access at all (see test/bats/measure-ci.bats).
+#
+# Usage:
+#   scripts/ci/measure-ci.sh --limit 50
+#   scripts/ci/measure-ci.sh --limit 100 --json > window-a.json
+#   scripts/ci/measure-ci.sh --fetch-only --limit 100 > bundle.json
+#   scripts/ci/measure-ci.sh --from-file bundle.json --json
+#   scripts/ci/measure-ci.sh --limit 100 --cache /tmp/ci.json      # resumable
+#   scripts/ci/measure-ci.sh --limit 40 --sentinel 'Status=4294967295' \
+#                            --sentinel-job 'XCTestRunner'
+#
+# Notes on API usage:
+#   * `gh api --paginate` over all workflow runs hangs for minutes and returns
+#     nothing useful. This script pages explicitly with a hard cap instead.
+#   * One `gh run list` call plus one jobs call per run (a second page only when
+#     a run has >100 jobs). A 100-run window is ~101 calls.
+#   * --max-runs is a loud ceiling: asking for more than it allows is an error,
+#     not a silent truncation.
+
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+WORKFLOW="Pull Request"
+LIMIT=50
+MAX_RUNS=200
+REPO=""
+BRANCH=""
+FROM_FILE=""
+CACHE_FILE=""
+FETCH_ONLY=0
+JSON_OUTPUT=0
+TOP_STEPS=25
+STEP_FILTER=""
+JOB_FILTER=""
+MIN_SAMPLES=3
+SENTINEL=""
+SENTINEL_JOB=""
+# Hard cap on jobs-API pages per run (100 jobs/page). 5 pages = 500 jobs.
+MAX_JOB_PAGES=5
+# Set on the fetch path only (main); declared here so `set -u` and shellcheck agree.
+API_PREFIX=""
+# Scratch dir for the fetch layer; created in main, removed by an EXIT trap.
+WORK_DIR=""
+
+usage() {
+  cat >&2 << EOF
+Usage: ${SCRIPT_NAME} [options]
+
+Window selection (fetch layer):
+  --workflow NAME     Workflow name to measure (default: "${WORKFLOW}")
+  --limit N           Number of most recent runs to fetch (default: ${LIMIT})
+  --max-runs N        Hard ceiling on --limit (default: ${MAX_RUNS}); exceeding
+                      it is a loud error, not a silent truncation
+  --repo OWNER/REPO   Repository (default: gh's current repo)
+  --branch NAME       Restrict to one head branch
+
+Layer control:
+  --fetch-only        Fetch and print the normalized bundle JSON, then exit
+  --from-file PATH    Aggregate a pre-fetched bundle instead of calling the API
+                      ("-" reads stdin). No network access.
+  --cache PATH        Read/write the bundle at PATH; runs already present are
+                      reused and only missing runs are fetched (resume)
+
+Output:
+  --json              Emit the aggregate as JSON (default: human summary)
+  --top N             Steps to show in the human summary (default: ${TOP_STEPS})
+  --min-samples N     Hide step keys with fewer than N samples (default: ${MIN_SAMPLES})
+  --step-filter RE    Only report steps whose name matches this regex
+  --job-filter RE     Only report jobs whose name matches this regex
+
+Log sentinel (opt-in; the only log-text path):
+  --sentinel RE       Count jobs whose log contains this regex
+  --sentinel-job RE   Restrict sentinel log fetches to jobs matching this regex
+                      (strongly recommended: one extra API call per job)
+
+  -h, --help          Show this help
+EOF
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" > /dev/null 2>&1 || die "required command not found: $1"
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+need_value() {
+  [ "$2" -ge 2 ] || die "$1 requires a value"
+}
+
+require_positive_int() {
+  case "$2" in
+    '' | *[!0-9]*) die "$1 expects a positive integer, got: $2" ;;
+  esac
+  [ "$2" -gt 0 ] || die "$1 expects a positive integer, got: $2"
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --workflow)
+      need_value "$1" "$#"
+      WORKFLOW="$2"
+      shift 2
+      ;;
+    --limit)
+      need_value "$1" "$#"
+      require_positive_int "$1" "$2"
+      LIMIT="$2"
+      shift 2
+      ;;
+    --max-runs)
+      need_value "$1" "$#"
+      require_positive_int "$1" "$2"
+      MAX_RUNS="$2"
+      shift 2
+      ;;
+    --repo)
+      need_value "$1" "$#"
+      REPO="$2"
+      shift 2
+      ;;
+    --branch)
+      need_value "$1" "$#"
+      BRANCH="$2"
+      shift 2
+      ;;
+    --from-file)
+      need_value "$1" "$#"
+      FROM_FILE="$2"
+      shift 2
+      ;;
+    --cache)
+      need_value "$1" "$#"
+      CACHE_FILE="$2"
+      shift 2
+      ;;
+    --fetch-only)
+      FETCH_ONLY=1
+      shift
+      ;;
+    --json)
+      JSON_OUTPUT=1
+      shift
+      ;;
+    --top)
+      need_value "$1" "$#"
+      require_positive_int "$1" "$2"
+      TOP_STEPS="$2"
+      shift 2
+      ;;
+    --min-samples)
+      need_value "$1" "$#"
+      require_positive_int "$1" "$2"
+      MIN_SAMPLES="$2"
+      shift 2
+      ;;
+    --step-filter)
+      need_value "$1" "$#"
+      STEP_FILTER="$2"
+      shift 2
+      ;;
+    --job-filter)
+      need_value "$1" "$#"
+      JOB_FILTER="$2"
+      shift 2
+      ;;
+    --sentinel)
+      need_value "$1" "$#"
+      SENTINEL="$2"
+      shift 2
+      ;;
+    --sentinel-job)
+      need_value "$1" "$#"
+      SENTINEL_JOB="$2"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+require_cmd jq
+
+if [ "$LIMIT" -gt "$MAX_RUNS" ]; then
+  die "--limit ${LIMIT} exceeds --max-runs ${MAX_RUNS}. This window would cost ~$((LIMIT + 1)) API calls; raise --max-runs deliberately if that is intended."
+fi
+
+if [ -n "$FROM_FILE" ] && [ "$FETCH_ONLY" -eq 1 ]; then
+  die "--from-file and --fetch-only are mutually exclusive"
+fi
+
+# ---------------------------------------------------------------------------
+# Fetch layer
+#
+# Everything below this banner talks to the network. Its sole output is a
+# "bundle" document:
+#
+#   { "meta": { repo, workflow, limit, branch, fetched_at },
+#     "runs": [ { id, number, head_sha, head_branch, event, status, conclusion,
+#                 run_attempt, created_at, updated_at,
+#                 jobs: [ { id, name, run_attempt, status, conclusion,
+#                           started_at, completed_at, sentinel (bool|null),
+#                           steps: [ { name, number, status, conclusion,
+#                                      started_at, completed_at } ] } ] } ] }
+#
+# The aggregation layer consumes exactly this and nothing else.
+# ---------------------------------------------------------------------------
+
+gh_json() {
+  # Single-page gh api call; caller supplies the full path.
+  gh api -H "Accept: application/vnd.github+json" "$@"
+}
+
+fetch_run_jobs() {
+  # $1 = run id, $2 = output file. Writes a JSON array of raw job objects.
+  #
+  # Pages are accumulated through files, never through a shell variable: a
+  # 60-run window's job payload blows past ARG_MAX the moment it reaches a
+  # `jq --argjson`, and the failure mode is a late, opaque
+  # "Argument list too long".
+  local run_id="$1"
+  local out_file="$2"
+  local page_dir="${WORK_DIR}/pages-${run_id}"
+  local page=1
+  local total=0
+  local fetched=0
+
+  mkdir -p "$page_dir"
+  while [ "$page" -le "$MAX_JOB_PAGES" ]; do
+    gh_json "${API_PREFIX}/actions/runs/${run_id}/jobs?filter=all&per_page=100&page=${page}" \
+      > "${page_dir}/${page}.json"
+    total="$(jq -r '.total_count // 0' "${page_dir}/${page}.json")"
+    fetched=$((fetched + $(jq '(.jobs // []) | length' "${page_dir}/${page}.json")))
+    if [ "$fetched" -ge "$total" ]; then
+      break
+    fi
+    page=$((page + 1))
+  done
+
+  if [ "$fetched" -lt "$total" ]; then
+    echo "WARN: run ${run_id} has ${total} jobs, capped at ${fetched} (${MAX_JOB_PAGES} pages)" >&2
+  fi
+
+  jq -c -s 'map(.jobs // []) | add // []' "${page_dir}"/*.json > "$out_file"
+  rm -rf "$page_dir"
+}
+
+normalize_jobs() {
+  # stdin: raw jobs array -> stdout: normalized jobs array.
+  jq -c '[ .[] | {
+    id: .id,
+    name: .name,
+    run_attempt: (.run_attempt // 1),
+    status: .status,
+    conclusion: .conclusion,
+    started_at: .started_at,
+    completed_at: .completed_at,
+    sentinel: null,
+    steps: [ (.steps // [])[] | {
+      name: .name,
+      number: .number,
+      status: .status,
+      conclusion: .conclusion,
+      started_at: .started_at,
+      completed_at: .completed_at
+    } ]
+  } ]'
+}
+
+fetch_sentinel_flags() {
+  # $1 = normalized jobs file, updated in place: .sentinel becomes true/false
+  # for jobs whose name matches SENTINEL_JOB (and stays null otherwise).
+  #
+  # This is the ONLY path in the script that reads log text. Everything else
+  # comes from the structured jobs API.
+  local jobs_file="$1"
+  [ -n "$SENTINEL" ] || return 0
+
+  local ids job_id hit log_file="${WORK_DIR}/sentinel.log"
+  ids="$(jq -r --arg re "${SENTINEL_JOB:-.}" '.[] | select(.name | test($re)) | .id' "$jobs_file")"
+
+  for job_id in $ids; do
+    hit=false
+    # A 404/410 here means the logs expired; treat that as "not observed"
+    # rather than failing the whole window.
+    if gh api "${API_PREFIX}/actions/jobs/${job_id}/logs" > "$log_file" 2> /dev/null; then
+      if grep -Eq -- "$SENTINEL" "$log_file"; then
+        hit=true
+      fi
+    else
+      echo "WARN: could not fetch logs for job ${job_id} (expired?)" >&2
+      continue
+    fi
+    jq -c --argjson id "$job_id" --argjson hit "$hit" \
+      'map(if .id == $id then .sentinel = $hit else . end)' "$jobs_file" \
+      > "${jobs_file}.tmp"
+    mv "${jobs_file}.tmp" "$jobs_file"
+  done
+}
+
+fetch_bundle() {
+  # $1 = output bundle file.
+  require_cmd gh
+
+  local out_bundle="$1"
+  local runs_file="${WORK_DIR}/runs.json"
+  local run_file="${WORK_DIR}/run.json"
+  local jobs_file="${WORK_DIR}/jobs.json"
+  local raw_jobs_file="${WORK_DIR}/jobs-raw.json"
+  # Newline-delimited JSON: one completed run object per line, slurped at the
+  # end. Appending to a file keeps the loop O(n) instead of re-serializing the
+  # whole accumulator on every iteration.
+  local out_jsonl="${WORK_DIR}/out.jsonl"
+  : > "$out_jsonl"
+
+  local run_args=()
+  run_args+=(--workflow "$WORKFLOW" --limit "$LIMIT")
+  [ -n "$REPO" ] && run_args+=(--repo "$REPO")
+  [ -n "$BRANCH" ] && run_args+=(--branch "$BRANCH")
+
+  echo "Fetching up to ${LIMIT} \"${WORKFLOW}\" runs..." >&2
+  gh run list "${run_args[@]}" \
+    --json databaseId,number,headSha,headBranch,event,status,conclusion,attempt,createdAt,updatedAt \
+    | jq -c '[ .[] | {
+        id: .databaseId,
+        number: .number,
+        head_sha: .headSha,
+        head_branch: .headBranch,
+        event: .event,
+        status: .status,
+        conclusion: .conclusion,
+        run_attempt: (.attempt // 1),
+        created_at: .createdAt,
+        updated_at: .updatedAt,
+        jobs: []
+      } ]' > "$runs_file"
+
+  local have_cache=0
+  if [ -n "$CACHE_FILE" ] && [ -f "$CACHE_FILE" ]; then
+    have_cache=1
+    echo "Cache: $(jq '(.runs // []) | length' "$CACHE_FILE") runs available for reuse from ${CACHE_FILE}" >&2
+  fi
+
+  local run_ids run_id total idx=0 attempt reused=0
+  run_ids="$(jq -r '.[].id' "$runs_file")"
+  total="$(jq 'length' "$runs_file")"
+
+  for run_id in $run_ids; do
+    idx=$((idx + 1))
+    jq -c --argjson id "$run_id" '.[] | select(.id == $id)' "$runs_file" > "$run_file"
+    attempt="$(jq '.run_attempt' "$run_file")"
+
+    # Resume: a cached run is reused only when it already carries jobs AND its
+    # attempt count still matches, so a run re-run since the last fetch is
+    # re-fetched rather than silently served stale.
+    if [ "$have_cache" -eq 1 ] && jq -e -c --argjson id "$run_id" --argjson attempt "$attempt" \
+      '(.runs // []) | map(select(.id == $id and (.jobs | length) > 0 and .run_attempt == $attempt))[0] // empty' \
+      "$CACHE_FILE" >> "$out_jsonl"; then
+      reused=$((reused + 1))
+      continue
+    fi
+
+    echo "  [${idx}/${total}] run ${run_id}" >&2
+    fetch_run_jobs "$run_id" "$raw_jobs_file"
+    normalize_jobs < "$raw_jobs_file" > "$jobs_file"
+    fetch_sentinel_flags "$jobs_file"
+    jq -c --slurpfile jobs "$jobs_file" '. + { jobs: $jobs[0] }' "$run_file" >> "$out_jsonl"
+  done
+
+  [ "$reused" -gt 0 ] && echo "Cache: reused ${reused} run(s)" >&2
+
+  jq -n \
+    --arg repo "${REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner 2> /dev/null || echo '')}" \
+    --arg workflow "$WORKFLOW" \
+    --arg branch "$BRANCH" \
+    --arg sentinel "$SENTINEL" \
+    --argjson limit "$LIMIT" \
+    --slurpfile runs "$out_jsonl" \
+    '{ meta: { repo: $repo, workflow: $workflow, branch: (if $branch == "" then null else $branch end),
+               limit: $limit, sentinel: (if $sentinel == "" then null else $sentinel end),
+               fetched_at: (now | todateiso8601) },
+       runs: $runs }' > "$out_bundle"
+}
+
+# ---------------------------------------------------------------------------
+# Aggregation layer
+#
+# Pure jq over a bundle. No network, no shell state. This is what BATS drives.
+# ---------------------------------------------------------------------------
+
+# Quoted heredoc: every $ inside is a jq variable, and shfmt leaves heredoc
+# bodies untouched (it rewrites \( ... ) sequences inside ordinary strings).
+JQ_AGGREGATE="$(
+  cat << 'JQ_PROGRAM'
+# --- helpers ---------------------------------------------------------------
+
+# GitHub emits RFC3339 "Z" timestamps; strip any fractional seconds defensively.
+def ts: if . == null then null else (sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) end;
+
+# Nearest-rank percentile over an ASCENDING-sorted array.
+#   index = ceil(p/100 * n), 1-based, clamped to [1, n]
+# Deliberately NOT interpolated: with n=10, p90 is the 9th value, and that is
+# the value the pinning test in test/bats/measure-ci.bats asserts.
+def pct($p): . as $a | ($a | length) as $n
+  | if $n == 0 then null
+    else $a[ ([ ([ ((($p / 100) * $n) | ceil), 1 ] | max), $n ] | min) - 1 ]
+    end;
+
+def round1: (. * 10 | round) / 10;
+def round3: (. * 1000 | round) / 1000;
+
+# --- flattened records -----------------------------------------------------
+
+[ .runs[] | . as $run | ($run.jobs // [])[] | { run: $run, job: . } ] as $jobrecs
+
+# Every executed step, tagged with the ordinal of its name WITHIN its job.
+# Steps are ordered by .number first so the ordinal is positional, and the
+# ordinal (not .number) is the key: inserting an unrelated step earlier in the
+# job shifts .number but must not renumber "boot #3".
+| [ $jobrecs[]
+    | .job as $job | .run as $run
+    | ($job.steps // [] | sort_by(.number)) as $steps
+    | range(0; $steps | length) as $i
+    | $steps[$i] as $s
+    | { job: $job.name,
+        step: $s.name,
+        ordinal: ( [ $steps[0:$i][] | select(.name == $s.name) ] | length ) + 1,
+        conclusion: $s.conclusion,
+        run_id: $run.id,
+        run_attempt: $job.run_attempt,
+        started: ($s.started_at | ts),
+        completed: ($s.completed_at | ts) }
+  ] as $steprecs
+
+# --- 1. per-job outcome tally ---------------------------------------------
+
+| ( $jobrecs
+    | map(.job)
+    | select(length >= 0)
+    | group_by(.name)
+    | map( (map(select(.conclusion == "skipped")) | length) as $skipped
+         | { job: .[0].name,
+             total: length,
+             executed: (length - $skipped),
+             passed: (map(select(.conclusion == "success")) | length),
+             failed: (map(select(.conclusion == "failure")) | length),
+             skipped: $skipped,
+             cancelled: (map(select(.conclusion == "cancelled")) | length),
+             other: (map(select(.conclusion as $c
+                          | ($c == null) or ([ "success","failure","skipped","cancelled" ]
+                                             | index($c) | not))) | length) }
+         | .failure_rate = (if .executed > 0 then (.failed / .executed | round3) else 0 end) )
+    | sort_by(-.failure_rate, -.failed, .job) ) as $jobs
+
+# --- 2. per-step duration distribution ------------------------------------
+# Skipped steps are excluded (they have no meaningful duration); success,
+# failure and cancelled are all kept, because a killed step IS the tail.
+
+| ( $steprecs
+    | map(select(.conclusion != "skipped" and .started != null and .completed != null))
+    | map(. + { seconds: (.completed - .started) })
+    | map(select(.seconds >= 0))
+    | group_by([ .job, .step, .ordinal ])
+    | map( (map(.seconds) | sort) as $d
+         | { job: .[0].job,
+             step: .[0].step,
+             ordinal: .[0].ordinal,
+             samples: ($d | length),
+             failed: (map(select(.conclusion == "failure")) | length),
+             min: ($d | pct(0) | round1),
+             median: ($d | pct(50) | round1),
+             p90: ($d | pct(90) | round1),
+             p95: ($d | pct(95) | round1),
+             max: ($d | pct(100) | round1) } )
+    | sort_by(-.p95, -.max) ) as $steps
+
+# --- 3. rerun-success rate -------------------------------------------------
+# A "unit" is (head SHA, job name). It is retried when the same unit has a
+# failing attempt and at least one later attempt. It is a rerun-success when the
+# highest attempt succeeded — i.e. the code was unchanged and it passed anyway.
+
+| ( $jobrecs
+    | map({ sha: .run.head_sha, job: .job.name,
+            attempt: .job.run_attempt, conclusion: .job.conclusion })
+    | group_by([ .sha, .job ])
+    | map(sort_by(.attempt))
+    | map(select( (map(.attempt) | unique | length) > 1
+                  and (any(.[]; .conclusion == "failure")) ))
+    | map({ sha: .[0].sha, job: .[0].job,
+            attempts: (map(.attempt) | unique | length),
+            final: (sort_by(.attempt) | last | .conclusion),
+            rerun_passed: ((sort_by(.attempt) | last | .conclusion) == "success") }) ) as $retried
+
+| ( $retried
+    | group_by(.job)
+    | map({ job: .[0].job,
+            retried: length,
+            rerun_passed: (map(select(.rerun_passed)) | length),
+            rerun_success_rate: ((map(select(.rerun_passed)) | length) / length | round3) })
+    | sort_by(-.retried, .job) ) as $rerun_by_job
+
+# --- 4. log sentinel (opt-in) ---------------------------------------------
+
+| ( $jobrecs | map(.job) | map(select(.sentinel != null)) ) as $sentinel_jobs
+| ( if ($sentinel_jobs | length) == 0 then null
+    else { pattern: ($meta.sentinel // null),
+           observed: ($sentinel_jobs | length),
+           hits: ($sentinel_jobs | map(select(.sentinel)) | length),
+           hit_rate: (($sentinel_jobs | map(select(.sentinel)) | length)
+                      / ($sentinel_jobs | length) | round3) }
+    end ) as $sentinel
+
+# --- assembly --------------------------------------------------------------
+
+| { window: {
+      repo: $meta.repo, workflow: $meta.workflow, branch: $meta.branch,
+      runs: (.runs | length),
+      job_records: ($jobrecs | length),
+      step_records: ($steprecs | length),
+      reruns_observed: (.runs | map(select(.run_attempt > 1)) | length),
+      oldest_run_at: (.runs | map(.created_at) | sort | first),
+      newest_run_at: (.runs | map(.created_at) | sort | last),
+      fetched_at: $meta.fetched_at },
+    jobs: ($jobs | map(select(.job | test($jobFilter)))),
+    steps: ($steps | map(select(.samples >= $minSamples
+                                and (.step | test($stepFilter))
+                                and (.job | test($jobFilter))))),
+    reruns: { retried_units: ($retried | length),
+              rerun_passed: ($retried | map(select(.rerun_passed)) | length),
+              rerun_success_rate: (if ($retried | length) > 0
+                                   then ($retried | map(select(.rerun_passed)) | length)
+                                        / ($retried | length) | round3
+                                   else null end),
+              by_job: $rerun_by_job,
+              units: $retried },
+    sentinel: $sentinel }
+JQ_PROGRAM
+)"
+
+aggregate() {
+  # stdin: bundle JSON -> stdout: aggregate JSON
+  jq \
+    --arg stepFilter "${STEP_FILTER:-.}" \
+    --arg jobFilter "${JOB_FILTER:-.}" \
+    --argjson minSamples "$MIN_SAMPLES" \
+    '(.meta // {}) as $meta | '"$JQ_AGGREGATE"
+}
+
+# ---------------------------------------------------------------------------
+# Human-readable rendering (pure: aggregate JSON in, text out)
+# ---------------------------------------------------------------------------
+
+render() {
+  jq -r --argjson top "$TOP_STEPS" '
+    def pad($n): tostring | . + (" " * ($n - length));
+    def lpad($n): tostring | (" " * ($n - length)) + .;
+    def pctstr: if . == null then "n/a" else ((. * 1000 | round) / 10 | tostring) + "%" end;
+
+    "== CI measurement: \(.window.workflow) @ \(.window.repo // "?") ==",
+    "Runs: \(.window.runs)   job records: \(.window.job_records)   step records: \(.window.step_records)",
+    "Window: \(.window.oldest_run_at // "?") .. \(.window.newest_run_at // "?")",
+    "",
+    "-- Per-job outcomes (ranked by failure rate) --",
+    "  \("rate" | lpad(7))  \("exec" | lpad(5)) \("pass" | lpad(5)) \("fail" | lpad(5)) \("skip" | lpad(5)) \("canc" | lpad(5))  job",
+    ( .jobs[]
+      | "  \(.failure_rate | pctstr | lpad(7))  \(.executed | lpad(5)) \(.passed | lpad(5)) \(.failed | lpad(5)) \(.skipped | lpad(5)) \(.cancelled | lpad(5))  \(.job)" ),
+    "",
+    "-- Step durations, seconds (ranked by p95; #N = Nth occurrence of that step in the job) --",
+    "  \("n" | lpad(4)) \("min" | lpad(7)) \("med" | lpad(7)) \("p90" | lpad(7)) \("p95" | lpad(7)) \("max" | lpad(7))  step",
+    ( .steps[0:$top][]
+      | "  \(.samples | lpad(4)) \(.min | lpad(7)) \(.median | lpad(7)) \(.p90 | lpad(7)) \(.p95 | lpad(7)) \(.max | lpad(7))  \(.job) / \(.step) #\(.ordinal)" ),
+    ( if (.steps | length) > $top then "  ... \((.steps | length) - $top) more step keys (raise --top)" else empty end ),
+    "",
+    "-- Rerun success (same head SHA failed, then passed on a later attempt) --",
+    "  retried (sha, job) units: \(.reruns.retried_units)",
+    "  passed on rerun:          \(.reruns.rerun_passed)   rate: \(.reruns.rerun_success_rate | pctstr)",
+    ( .reruns.by_job[]
+      | "    \(.rerun_passed)/\(.retried)  \(.rerun_success_rate | pctstr | lpad(6))  \(.job)" ),
+    ( if .sentinel == null then empty
+      else "",
+           "-- Log sentinel --",
+           "  pattern: \(.sentinel.pattern // "?")",
+           "  \(.sentinel.hits)/\(.sentinel.observed) jobs matched  (\(.sentinel.hit_rate | pctstr))"
+      end )
+  '
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+  # Bundles reach tens of megabytes for a 100-run window, so they live in a
+  # file and are piped, never held in a shell variable or passed as an argv
+  # (jq --argjson on a large bundle dies with "Argument list too long").
+  WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/measure-ci.XXXXXX")"
+  trap 'rm -rf "$WORK_DIR"' EXIT
+  local bundle_file="${WORK_DIR}/bundle.json"
+
+  if [ -n "$FROM_FILE" ]; then
+    if [ "$FROM_FILE" = "-" ]; then
+      cat > "$bundle_file"
+    else
+      [ -f "$FROM_FILE" ] || die "bundle file not found: $FROM_FILE"
+      cp -- "$FROM_FILE" "$bundle_file"
+    fi
+    jq -e 'has("runs") and (.runs | type == "array")' "$bundle_file" > /dev/null 2>&1 \
+      || die "bundle is not valid JSON with a .runs array: $FROM_FILE"
+  else
+    # API_PREFIX is only needed on the fetch path.
+    if [ -z "$REPO" ]; then
+      require_cmd gh
+      REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+    fi
+    API_PREFIX="/repos/${REPO}"
+    fetch_bundle "$bundle_file"
+    if [ -n "$CACHE_FILE" ]; then
+      cp "$bundle_file" "$CACHE_FILE"
+      echo "Cache: wrote ${CACHE_FILE}" >&2
+    fi
+  fi
+
+  if [ "$FETCH_ONLY" -eq 1 ]; then
+    cat "$bundle_file"
+    return 0
+  fi
+
+  if [ "$JSON_OUTPUT" -eq 1 ]; then
+    aggregate < "$bundle_file"
+  else
+    aggregate < "$bundle_file" | render
+  fi
+}
+
+main

--- a/test/bats/measure-ci.bats
+++ b/test/bats/measure-ci.bats
@@ -12,6 +12,18 @@
 # and fails in the full run.
 SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/ci/measure-ci.sh"
 
+# Assert the run succeeded, and on failure surface the script's status AND output.
+# Bare `assert_ok` reports only the assertion line, which made a CI-only
+# failure undiagnosable from the logs (the whole point of #4077).
+assert_ok() {
+  if [ "$status" -ne 0 ]; then
+    echo "--- command failed: status=$status ---" >&2
+    echo "$output" >&2
+    echo "--- env: PWD=$PWD jq=$(command -v jq || echo MISSING) bash=$BASH_VERSION ---" >&2
+    return 1
+  fi
+}
+
 setup() {
   TEST_ROOT="$(mktemp -d)"
 }
@@ -72,7 +84,7 @@ bundle_from_durations() {
 
 @test "--help prints usage and exits 0" {
   run bash "$SCRIPT" --help
-  [ "$status" -eq 0 ]
+  assert_ok
   [[ "$output" == *"--from-file"* ]]
   [[ "$output" == *"--max-runs"* ]]
 }
@@ -122,14 +134,14 @@ bundle_from_durations() {
   chmod +x "${TEST_ROOT}/bin/gh"
   bundle_from_durations '[10,20,30]' > "${TEST_ROOT}/b.json"
   run env PATH="${TEST_ROOT}/bin:$PATH" bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --min-samples 1
-  [ "$status" -eq 0 ]
+  assert_ok
   [[ "$output" != *"gh was called"* ]]
 }
 
 @test "reads a bundle from stdin with --from-file -" {
   bundle_from_durations '[10,20,30]' > "${TEST_ROOT}/b.json"
   run bash -c "cat '${TEST_ROOT}/b.json' | bash '$SCRIPT' --from-file - --min-samples 1"
-  [ "$status" -eq 0 ]
+  assert_ok
   [[ "$output" == *"iOS / Boot #1"* ]]
 }
 
@@ -154,7 +166,7 @@ bundle_from_durations() {
                 job("Never"; "skipped") ] } ]' | mk_bundle > "${TEST_ROOT}/b.json"
 
   run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --json
-  [ "$status" -eq 0 ]
+  assert_ok
   [ "$(echo "$output" | jq -r '.jobs[0].job')" = "Flaky" ]
   [ "$(echo "$output" | jq -r '.jobs[0].executed')" = "2" ]
   [ "$(echo "$output" | jq -r '.jobs[0].passed')" = "1" ]
@@ -170,7 +182,7 @@ bundle_from_durations() {
 @test "human summary prints the per-job table" {
   bundle_from_durations '[10,20,30]' > "${TEST_ROOT}/b.json"
   run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --min-samples 1
-  [ "$status" -eq 0 ]
+  assert_ok
   [[ "$output" == *"Per-job outcomes"* ]]
   [[ "$output" == *"iOS"* ]]
 }
@@ -186,7 +198,7 @@ bundle_from_durations() {
   # off-by-one index would give 80 / 90 — both fail this assertion.
   bundle_from_durations '[10,20,30,40,50,60,70,80,90,100]' > "${TEST_ROOT}/b.json"
   run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --json
-  [ "$status" -eq 0 ]
+  assert_ok
   [ "$(echo "$output" | jq -r '.steps[0].samples')" = "10" ]
   [ "$(echo "$output" | jq -r '.steps[0].min')" = "10" ]
   [ "$(echo "$output" | jq -r '.steps[0].median')" = "50" ]
@@ -198,7 +210,7 @@ bundle_from_durations() {
 @test "percentiles are order-independent (input sorted before ranking)" {
   bundle_from_durations '[100,30,70,10,90,50,20,80,40,60]' > "${TEST_ROOT}/b.json"
   run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --json
-  [ "$status" -eq 0 ]
+  assert_ok
   [ "$(echo "$output" | jq -r '.steps[0].median')" = "50" ]
   [ "$(echo "$output" | jq -r '.steps[0].p90')" = "90" ]
   [ "$(echo "$output" | jq -r '.steps[0].p95')" = "100" ]
@@ -207,7 +219,7 @@ bundle_from_durations() {
 @test "a single sample collapses every percentile to that value" {
   bundle_from_durations '[42]' > "${TEST_ROOT}/b.json"
   run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --min-samples 1 --json
-  [ "$status" -eq 0 ]
+  assert_ok
   [ "$(echo "$output" | jq -r '.steps[0].min')" = "42" ]
   [ "$(echo "$output" | jq -r '.steps[0].p95')" = "42" ]
   [ "$(echo "$output" | jq -r '.steps[0].max')" = "42" ]
@@ -233,7 +245,7 @@ bundle_from_durations() {
                   steps: [ $s1, $s2, $s3 ] } ] } ]' | mk_bundle > "${TEST_ROOT}/b.json"
 
   run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --min-samples 1 --json
-  [ "$status" -eq 0 ]
+  assert_ok
   [ "$(echo "$output" | jq '[.steps[] | select(.step == "Boot")] | length')" = "3" ]
   [ "$(echo "$output" | jq -r '.steps[] | select(.ordinal == 1) | .max')" = "20" ]
   [ "$(echo "$output" | jq -r '.steps[] | select(.ordinal == 2) | .max')" = "90" ]
@@ -254,7 +266,7 @@ bundle_from_durations() {
                   steps: [ $s1, $s2 ] } ] } ]' | mk_bundle > "${TEST_ROOT}/b.json"
 
   run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --min-samples 1
-  [ "$status" -eq 0 ]
+  assert_ok
   [[ "$output" == *"iOS / Boot #1"* ]]
   [[ "$output" == *"iOS / Boot #2"* ]]
 }
@@ -280,7 +292,7 @@ bundle_from_durations() {
     [ run(1; [ $a1, $a2 ]), run(2; [ $b0, $b1, $b2 ]) ]' | mk_bundle > "${TEST_ROOT}/b.json"
 
   run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --min-samples 2 --json
-  [ "$status" -eq 0 ]
+  assert_ok
   # Both boots pair up across runs: two buckets of two samples each.
   [ "$(echo "$output" | jq '[.steps[] | select(.step == "Boot")] | length')" = "2" ]
   [ "$(echo "$output" | jq -r '.steps[] | select(.step == "Boot" and .ordinal == 1) | .samples')" = "2" ]
@@ -300,7 +312,7 @@ bundle_from_durations() {
                   steps: [ $s1, $s2 ] } ] } ]' | mk_bundle > "${TEST_ROOT}/b.json"
 
   run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --min-samples 1 --json
-  [ "$status" -eq 0 ]
+  assert_ok
   [ "$(echo "$output" | jq '[.steps[] | select(.step == "Boot")] | length')" = "1" ]
   [ "$(echo "$output" | jq -r '.steps[0].ordinal')" = "1" ]
 }
@@ -322,7 +334,7 @@ bundle_from_durations() {
         jobs: [ job(1; "failure"), job(2; "success") ] } ]' | mk_bundle > "${TEST_ROOT}/b.json"
 
   run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --json
-  [ "$status" -eq 0 ]
+  assert_ok
   [ "$(echo "$output" | jq -r '.reruns.retried_units')" = "1" ]
   [ "$(echo "$output" | jq -r '.reruns.rerun_passed')" = "1" ]
   [ "$(echo "$output" | jq -r '.reruns.rerun_success_rate')" = "1" ]
@@ -343,7 +355,7 @@ bundle_from_durations() {
         jobs: [ job(1; "failure"), job(2; "failure") ] } ]' | mk_bundle > "${TEST_ROOT}/b.json"
 
   run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --json
-  [ "$status" -eq 0 ]
+  assert_ok
   [ "$(echo "$output" | jq -r '.reruns.retried_units')" = "1" ]
   [ "$(echo "$output" | jq -r '.reruns.rerun_passed')" = "0" ]
   [ "$(echo "$output" | jq -r '.reruns.rerun_success_rate')" = "0" ]
@@ -360,7 +372,7 @@ bundle_from_durations() {
                   steps: [] } ] } ]' | mk_bundle > "${TEST_ROOT}/b.json"
 
   run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --json
-  [ "$status" -eq 0 ]
+  assert_ok
   [ "$(echo "$output" | jq -r '.reruns.retried_units')" = "0" ]
   [ "$(echo "$output" | jq -r '.reruns.rerun_success_rate')" = "null" ]
 }
@@ -372,25 +384,25 @@ bundle_from_durations() {
 @test "--min-samples hides thin step buckets" {
   bundle_from_durations '[10]' > "${TEST_ROOT}/b.json"
   run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --min-samples 3 --json
-  [ "$status" -eq 0 ]
+  assert_ok
   [ "$(echo "$output" | jq '.steps | length')" = "0" ]
 }
 
 @test "--step-filter and --job-filter narrow the report" {
   bundle_from_durations '[10,20,30]' > "${TEST_ROOT}/b.json"
   run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --min-samples 1 --step-filter "Nothing" --json
-  [ "$status" -eq 0 ]
+  assert_ok
   [ "$(echo "$output" | jq '.steps | length')" = "0" ]
 
   run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --min-samples 1 --job-filter "iOS" --json
-  [ "$status" -eq 0 ]
+  assert_ok
   [ "$(echo "$output" | jq '.jobs | length')" = "1" ]
 }
 
 @test "--json emits a stable top-level shape for diffing across windows" {
   bundle_from_durations '[10,20,30]' > "${TEST_ROOT}/b.json"
   run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --min-samples 1 --json
-  [ "$status" -eq 0 ]
+  assert_ok
   [ "$(echo "$output" | jq -r 'keys | join(",")')" = "jobs,reruns,sentinel,steps,window" ]
   [ "$(echo "$output" | jq -r '.window.runs')" = "3" ]
   [ "$(echo "$output" | jq -r '.window.workflow')" = "Pull Request" ]
@@ -414,14 +426,14 @@ bundle_from_durations() {
     > "${TEST_ROOT}/b.json"
 
   run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --json
-  [ "$status" -eq 0 ]
+  assert_ok
   [ "$(echo "$output" | jq -r '.sentinel.observed')" = "3" ]
   [ "$(echo "$output" | jq -r '.sentinel.hits')" = "2" ]
   [ "$(echo "$output" | jq -r '.sentinel.hit_rate')" = "0.667" ]
   [ "$(echo "$output" | jq -r '.sentinel.pattern')" = "Status=4294967295" ]
 
   run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json"
-  [ "$status" -eq 0 ]
+  assert_ok
   [[ "$output" == *"Log sentinel"* ]]
   [[ "$output" == *"2/3 jobs matched"* ]]
 }
@@ -430,6 +442,6 @@ bundle_from_durations() {
   echo '{"meta":{"repo":"o/r","workflow":"Pull Request","branch":null,"limit":0,"sentinel":null,"fetched_at":"2026-07-21T00:00:00Z"},"runs":[]}' \
     > "${TEST_ROOT}/b.json"
   run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json"
-  [ "$status" -eq 0 ]
+  assert_ok
   [[ "$output" == *"Runs: 0"* ]]
 }

--- a/test/bats/measure-ci.bats
+++ b/test/bats/measure-ci.bats
@@ -6,7 +6,11 @@
 # bundle, so nothing here touches the network or the GitHub API. The fetch layer
 # is deliberately separable for exactly this reason.
 
-SCRIPT="scripts/ci/measure-ci.sh"
+# Absolute path: several bats files in this directory `cd` inside a test body
+# without a subshell, and they sort before this one. A relative SCRIPT path then
+# resolves against whatever cwd they left behind -- the suite passes in isolation
+# and fails in the full run.
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/ci/measure-ci.sh"
 
 setup() {
   TEST_ROOT="$(mktemp -d)"

--- a/test/bats/measure-ci.bats
+++ b/test/bats/measure-ci.bats
@@ -1,0 +1,431 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/ci/measure-ci.sh (issue #4122).
+#
+# Every test drives the AGGREGATION layer through --from-file with a fixture
+# bundle, so nothing here touches the network or the GitHub API. The fetch layer
+# is deliberately separable for exactly this reason.
+
+SCRIPT="scripts/ci/measure-ci.sh"
+
+setup() {
+  TEST_ROOT="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT"
+}
+
+# --------------------------------------------------------------------------
+# Fixture builders
+# --------------------------------------------------------------------------
+
+# mk_step NAME NUMBER CONCLUSION START_OFFSET_S DURATION_S
+# Emits one step object; timestamps are derived from a fixed epoch so durations
+# are exact.
+mk_step() {
+  jq -n --arg name "$1" --argjson number "$2" --arg conclusion "$3" \
+    --argjson start "$4" --argjson dur "$5" '
+    (1767225600 + $start) as $s
+    | { name: $name, number: $number, status: "completed", conclusion: $conclusion,
+        started_at: (if $conclusion == "skipped" then null else ($s | todateiso8601) end),
+        completed_at: (if $conclusion == "skipped" then null else ($s + $dur | todateiso8601) end) }'
+}
+
+# mk_bundle < runs-json  -> a full bundle with default meta
+mk_bundle() {
+  jq -n --argjson runs "$(cat)" '
+    { meta: { repo: "o/r", workflow: "Pull Request", branch: null, limit: 10,
+              sentinel: null, fetched_at: "2026-07-21T00:00:00Z" },
+      runs: $runs }'
+}
+
+# A bundle of N runs, each with one job "iOS" containing one step "Boot" whose
+# duration is taken from the passed JSON array. Used to pin the percentile math.
+bundle_from_durations() {
+  jq -n --argjson d "$1" '
+    [ range(0; $d | length) as $i
+      | { id: (100 + $i), number: $i, head_sha: "sha\($i)", head_branch: "b",
+          event: "pull_request", status: "completed", conclusion: "success",
+          run_attempt: 1,
+          created_at: (1767225600 + $i * 3600 | todateiso8601),
+          updated_at: (1767225600 + $i * 3600 | todateiso8601),
+          jobs: [ { id: (1000 + $i), name: "iOS", run_attempt: 1,
+                    status: "completed", conclusion: "success",
+                    started_at: (1767225600 | todateiso8601),
+                    completed_at: (1767225600 + $d[$i] | todateiso8601),
+                    sentinel: null,
+                    steps: [ { name: "Boot", number: 1, status: "completed",
+                               conclusion: "success",
+                               started_at: (1767225600 | todateiso8601),
+                               completed_at: (1767225600 + $d[$i] | todateiso8601) } ] } ] } ]
+  ' | mk_bundle
+}
+
+# --------------------------------------------------------------------------
+# CLI contract
+# --------------------------------------------------------------------------
+
+@test "--help prints usage and exits 0" {
+  run bash "$SCRIPT" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--from-file"* ]]
+  [[ "$output" == *"--max-runs"* ]]
+}
+
+@test "rejects an unknown argument" {
+  run bash "$SCRIPT" --nope
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unknown argument"* ]]
+}
+
+@test "fails loudly when --limit exceeds --max-runs instead of truncating" {
+  run bash "$SCRIPT" --limit 500 --max-runs 100
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"exceeds --max-runs"* ]]
+  [[ "$output" == *"API calls"* ]]
+}
+
+@test "rejects a non-numeric --limit" {
+  run bash "$SCRIPT" --limit abc
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"positive integer"* ]]
+}
+
+@test "--from-file and --fetch-only are mutually exclusive" {
+  run bash "$SCRIPT" --from-file /dev/null --fetch-only
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"mutually exclusive"* ]]
+}
+
+@test "errors when the bundle file is missing" {
+  run bash "$SCRIPT" --from-file "${TEST_ROOT}/nope.json"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "errors when the bundle is not a bundle" {
+  echo '{"nope":1}' > "${TEST_ROOT}/bad.json"
+  run bash "$SCRIPT" --from-file "${TEST_ROOT}/bad.json"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"runs"* ]]
+}
+
+@test "aggregation needs no network: works with gh unavailable" {
+  # A shim that fails on any gh invocation proves --from-file never shells out.
+  mkdir -p "${TEST_ROOT}/bin"
+  printf '#!/bin/sh\necho "gh was called" >&2\nexit 99\n' > "${TEST_ROOT}/bin/gh"
+  chmod +x "${TEST_ROOT}/bin/gh"
+  bundle_from_durations '[10,20,30]' > "${TEST_ROOT}/b.json"
+  run env PATH="${TEST_ROOT}/bin:$PATH" bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --min-samples 1
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"gh was called"* ]]
+}
+
+@test "reads a bundle from stdin with --from-file -" {
+  bundle_from_durations '[10,20,30]' > "${TEST_ROOT}/b.json"
+  run bash -c "cat '${TEST_ROOT}/b.json' | bash '$SCRIPT' --from-file - --min-samples 1"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"iOS / Boot #1"* ]]
+}
+
+# --------------------------------------------------------------------------
+# 1. Per-job failure rate
+# --------------------------------------------------------------------------
+
+@test "tallies per-job outcomes and ranks by failure rate" {
+  jq -n '
+    def job($name; $conc): { id: 1, name: $name, run_attempt: 1, status: "completed",
+      conclusion: $conc, started_at: "2026-01-01T00:00:00Z",
+      completed_at: "2026-01-01T00:01:00Z", sentinel: null, steps: [] };
+    [ { id: 1, number: 1, head_sha: "a", head_branch: "b", event: "pull_request",
+        status: "completed", conclusion: "failure", run_attempt: 1,
+        created_at: "2026-01-01T00:00:00Z", updated_at: "2026-01-01T00:01:00Z",
+        jobs: [ job("Flaky"; "failure"), job("Solid"; "success"),
+                job("Never"; "skipped") ] },
+      { id: 2, number: 2, head_sha: "c", head_branch: "b", event: "pull_request",
+        status: "completed", conclusion: "success", run_attempt: 1,
+        created_at: "2026-01-01T01:00:00Z", updated_at: "2026-01-01T01:01:00Z",
+        jobs: [ job("Flaky"; "success"), job("Solid"; "success"),
+                job("Never"; "skipped") ] } ]' | mk_bundle > "${TEST_ROOT}/b.json"
+
+  run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --json
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.jobs[0].job')" = "Flaky" ]
+  [ "$(echo "$output" | jq -r '.jobs[0].executed')" = "2" ]
+  [ "$(echo "$output" | jq -r '.jobs[0].passed')" = "1" ]
+  [ "$(echo "$output" | jq -r '.jobs[0].failed')" = "1" ]
+  [ "$(echo "$output" | jq -r '.jobs[0].failure_rate')" = "0.5" ]
+  # Skipped runs are excluded from the executed denominator, so a job that never
+  # ran does not dilute anyone's rate and reports 0/0 rather than a false 0%.
+  [ "$(echo "$output" | jq -r '.jobs[] | select(.job == "Never") | .executed')" = "0" ]
+  [ "$(echo "$output" | jq -r '.jobs[] | select(.job == "Never") | .skipped')" = "2" ]
+  [ "$(echo "$output" | jq -r '.jobs[] | select(.job == "Solid") | .failure_rate')" = "0" ]
+}
+
+@test "human summary prints the per-job table" {
+  bundle_from_durations '[10,20,30]' > "${TEST_ROOT}/b.json"
+  run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --min-samples 1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Per-job outcomes"* ]]
+  [[ "$output" == *"iOS"* ]]
+}
+
+# --------------------------------------------------------------------------
+# 2. Percentile math (pinned)
+# --------------------------------------------------------------------------
+
+@test "percentiles use nearest-rank over a known 10-sample input" {
+  # Durations 10..100. Nearest-rank: idx = ceil(p/100 * 10).
+  #   p50 -> 5th  = 50    p90 -> 9th  = 90    p95 -> ceil(9.5)=10th = 100
+  # An interpolating implementation would give 91 / 95.5 here, and an
+  # off-by-one index would give 80 / 90 — both fail this assertion.
+  bundle_from_durations '[10,20,30,40,50,60,70,80,90,100]' > "${TEST_ROOT}/b.json"
+  run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --json
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.steps[0].samples')" = "10" ]
+  [ "$(echo "$output" | jq -r '.steps[0].min')" = "10" ]
+  [ "$(echo "$output" | jq -r '.steps[0].median')" = "50" ]
+  [ "$(echo "$output" | jq -r '.steps[0].p90')" = "90" ]
+  [ "$(echo "$output" | jq -r '.steps[0].p95')" = "100" ]
+  [ "$(echo "$output" | jq -r '.steps[0].max')" = "100" ]
+}
+
+@test "percentiles are order-independent (input sorted before ranking)" {
+  bundle_from_durations '[100,30,70,10,90,50,20,80,40,60]' > "${TEST_ROOT}/b.json"
+  run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --json
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.steps[0].median')" = "50" ]
+  [ "$(echo "$output" | jq -r '.steps[0].p90')" = "90" ]
+  [ "$(echo "$output" | jq -r '.steps[0].p95')" = "100" ]
+}
+
+@test "a single sample collapses every percentile to that value" {
+  bundle_from_durations '[42]' > "${TEST_ROOT}/b.json"
+  run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --min-samples 1 --json
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.steps[0].min')" = "42" ]
+  [ "$(echo "$output" | jq -r '.steps[0].p95')" = "42" ]
+  [ "$(echo "$output" | jq -r '.steps[0].max')" = "42" ]
+}
+
+# --------------------------------------------------------------------------
+# 3. Repeated-step ORDINAL preservation
+# --------------------------------------------------------------------------
+
+@test "repeated same-named steps are reported separately by ordinal" {
+  # Three "Boot" steps in one job with distinct durations. A group-by-name
+  # implementation collapses these into one row and destroys the "third boot
+  # owns the tail" signal that justified dropping the Xcode 26.2 leg.
+  jq -n --argjson s1 "$(mk_step Boot 1 success 0 20)" \
+    --argjson s2 "$(mk_step Boot 2 success 30 90)" \
+    --argjson s3 "$(mk_step Boot 3 success 150 400)" '
+    [ { id: 1, number: 1, head_sha: "a", head_branch: "b", event: "pull_request",
+        status: "completed", conclusion: "success", run_attempt: 1,
+        created_at: "2026-01-01T00:00:00Z", updated_at: "2026-01-01T01:00:00Z",
+        jobs: [ { id: 9, name: "iOS", run_attempt: 1, status: "completed",
+                  conclusion: "success", started_at: "2026-01-01T00:00:00Z",
+                  completed_at: "2026-01-01T01:00:00Z", sentinel: null,
+                  steps: [ $s1, $s2, $s3 ] } ] } ]' | mk_bundle > "${TEST_ROOT}/b.json"
+
+  run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --min-samples 1 --json
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq '[.steps[] | select(.step == "Boot")] | length')" = "3" ]
+  [ "$(echo "$output" | jq -r '.steps[] | select(.ordinal == 1) | .max')" = "20" ]
+  [ "$(echo "$output" | jq -r '.steps[] | select(.ordinal == 2) | .max')" = "90" ]
+  [ "$(echo "$output" | jq -r '.steps[] | select(.ordinal == 3) | .max')" = "400" ]
+  # The tail belongs to boot #3 and nothing else: ranking is by p95.
+  [ "$(echo "$output" | jq -r '.steps[0].ordinal')" = "3" ]
+}
+
+@test "human summary labels repeated steps with #ordinal" {
+  jq -n --argjson s1 "$(mk_step Boot 1 success 0 20)" \
+    --argjson s2 "$(mk_step Boot 2 success 30 400)" '
+    [ { id: 1, number: 1, head_sha: "a", head_branch: "b", event: "pull_request",
+        status: "completed", conclusion: "success", run_attempt: 1,
+        created_at: "2026-01-01T00:00:00Z", updated_at: "2026-01-01T01:00:00Z",
+        jobs: [ { id: 9, name: "iOS", run_attempt: 1, status: "completed",
+                  conclusion: "success", started_at: "2026-01-01T00:00:00Z",
+                  completed_at: "2026-01-01T01:00:00Z", sentinel: null,
+                  steps: [ $s1, $s2 ] } ] } ]' | mk_bundle > "${TEST_ROOT}/b.json"
+
+  run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --min-samples 1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"iOS / Boot #1"* ]]
+  [[ "$output" == *"iOS / Boot #2"* ]]
+}
+
+@test "ordinal is positional, not the step number: an inserted step does not renumber boots" {
+  # Run 1: Boot, Boot          (numbers 1,2)
+  # Run 2: Setup, Boot, Boot   (numbers 1,2,3) — every Boot number shifts by one.
+  # Keying on .number would split each boot into two one-sample buckets.
+  jq -n \
+    --argjson a1 "$(mk_step Boot 1 success 0 10)" \
+    --argjson a2 "$(mk_step Boot 2 success 20 300)" \
+    --argjson b0 "$(mk_step Setup 1 success 0 5)" \
+    --argjson b1 "$(mk_step Boot 2 success 10 12)" \
+    --argjson b2 "$(mk_step Boot 3 success 30 310)" '
+    def run($id; $steps): { id: $id, number: $id, head_sha: "sha\($id)",
+      head_branch: "b", event: "pull_request", status: "completed",
+      conclusion: "success", run_attempt: 1,
+      created_at: "2026-01-01T00:00:00Z", updated_at: "2026-01-01T01:00:00Z",
+      jobs: [ { id: $id, name: "iOS", run_attempt: 1, status: "completed",
+                conclusion: "success", started_at: "2026-01-01T00:00:00Z",
+                completed_at: "2026-01-01T01:00:00Z", sentinel: null,
+                steps: $steps } ] };
+    [ run(1; [ $a1, $a2 ]), run(2; [ $b0, $b1, $b2 ]) ]' | mk_bundle > "${TEST_ROOT}/b.json"
+
+  run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --min-samples 2 --json
+  [ "$status" -eq 0 ]
+  # Both boots pair up across runs: two buckets of two samples each.
+  [ "$(echo "$output" | jq '[.steps[] | select(.step == "Boot")] | length')" = "2" ]
+  [ "$(echo "$output" | jq -r '.steps[] | select(.step == "Boot" and .ordinal == 1) | .samples')" = "2" ]
+  [ "$(echo "$output" | jq -r '.steps[] | select(.step == "Boot" and .ordinal == 1) | .max')" = "12" ]
+  [ "$(echo "$output" | jq -r '.steps[] | select(.step == "Boot" and .ordinal == 2) | .max')" = "310" ]
+}
+
+@test "skipped steps are excluded from the duration distribution" {
+  jq -n --argjson s1 "$(mk_step Boot 1 success 0 20)" \
+    --argjson s2 "$(mk_step Boot 2 skipped 0 0)" '
+    [ { id: 1, number: 1, head_sha: "a", head_branch: "b", event: "pull_request",
+        status: "completed", conclusion: "success", run_attempt: 1,
+        created_at: "2026-01-01T00:00:00Z", updated_at: "2026-01-01T01:00:00Z",
+        jobs: [ { id: 9, name: "iOS", run_attempt: 1, status: "completed",
+                  conclusion: "success", started_at: "2026-01-01T00:00:00Z",
+                  completed_at: "2026-01-01T01:00:00Z", sentinel: null,
+                  steps: [ $s1, $s2 ] } ] } ]' | mk_bundle > "${TEST_ROOT}/b.json"
+
+  run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --min-samples 1 --json
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq '[.steps[] | select(.step == "Boot")] | length')" = "1" ]
+  [ "$(echo "$output" | jq -r '.steps[0].ordinal')" = "1" ]
+}
+
+# --------------------------------------------------------------------------
+# 4. Rerun-success rate
+# --------------------------------------------------------------------------
+
+@test "counts a job that failed then passed on a later attempt of the same SHA" {
+  jq -n '
+    def job($attempt; $conc): { id: (10 + $attempt), name: "iOS",
+      run_attempt: $attempt, status: "completed", conclusion: $conc,
+      started_at: "2026-01-01T00:00:00Z", completed_at: "2026-01-01T00:10:00Z",
+      sentinel: null, steps: [] };
+    [ { id: 1, number: 1, head_sha: "flaky", head_branch: "b",
+        event: "pull_request", status: "completed", conclusion: "success",
+        run_attempt: 2, created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T01:00:00Z",
+        jobs: [ job(1; "failure"), job(2; "success") ] } ]' | mk_bundle > "${TEST_ROOT}/b.json"
+
+  run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --json
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.reruns.retried_units')" = "1" ]
+  [ "$(echo "$output" | jq -r '.reruns.rerun_passed')" = "1" ]
+  [ "$(echo "$output" | jq -r '.reruns.rerun_success_rate')" = "1" ]
+  [ "$(echo "$output" | jq -r '.reruns.by_job[0].job')" = "iOS" ]
+  [ "$(echo "$output" | jq -r '.reruns.units[0].sha')" = "flaky" ]
+}
+
+@test "a job that fails on every attempt is retried but not a rerun-success" {
+  jq -n '
+    def job($attempt; $conc): { id: (10 + $attempt), name: "iOS",
+      run_attempt: $attempt, status: "completed", conclusion: $conc,
+      started_at: "2026-01-01T00:00:00Z", completed_at: "2026-01-01T00:10:00Z",
+      sentinel: null, steps: [] };
+    [ { id: 1, number: 1, head_sha: "broken", head_branch: "b",
+        event: "pull_request", status: "completed", conclusion: "failure",
+        run_attempt: 2, created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T01:00:00Z",
+        jobs: [ job(1; "failure"), job(2; "failure") ] } ]' | mk_bundle > "${TEST_ROOT}/b.json"
+
+  run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --json
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.reruns.retried_units')" = "1" ]
+  [ "$(echo "$output" | jq -r '.reruns.rerun_passed')" = "0" ]
+  [ "$(echo "$output" | jq -r '.reruns.rerun_success_rate')" = "0" ]
+}
+
+@test "a single-attempt failure is not a rerun unit" {
+  jq -n '
+    [ { id: 1, number: 1, head_sha: "x", head_branch: "b", event: "pull_request",
+        status: "completed", conclusion: "failure", run_attempt: 1,
+        created_at: "2026-01-01T00:00:00Z", updated_at: "2026-01-01T01:00:00Z",
+        jobs: [ { id: 9, name: "iOS", run_attempt: 1, status: "completed",
+                  conclusion: "failure", started_at: "2026-01-01T00:00:00Z",
+                  completed_at: "2026-01-01T00:10:00Z", sentinel: null,
+                  steps: [] } ] } ]' | mk_bundle > "${TEST_ROOT}/b.json"
+
+  run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --json
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.reruns.retried_units')" = "0" ]
+  [ "$(echo "$output" | jq -r '.reruns.rerun_success_rate')" = "null" ]
+}
+
+# --------------------------------------------------------------------------
+# Filters, JSON shape, sentinel
+# --------------------------------------------------------------------------
+
+@test "--min-samples hides thin step buckets" {
+  bundle_from_durations '[10]' > "${TEST_ROOT}/b.json"
+  run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --min-samples 3 --json
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq '.steps | length')" = "0" ]
+}
+
+@test "--step-filter and --job-filter narrow the report" {
+  bundle_from_durations '[10,20,30]' > "${TEST_ROOT}/b.json"
+  run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --min-samples 1 --step-filter "Nothing" --json
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq '.steps | length')" = "0" ]
+
+  run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --min-samples 1 --job-filter "iOS" --json
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq '.jobs | length')" = "1" ]
+}
+
+@test "--json emits a stable top-level shape for diffing across windows" {
+  bundle_from_durations '[10,20,30]' > "${TEST_ROOT}/b.json"
+  run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --min-samples 1 --json
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r 'keys | join(",")')" = "jobs,reruns,sentinel,steps,window" ]
+  [ "$(echo "$output" | jq -r '.window.runs')" = "3" ]
+  [ "$(echo "$output" | jq -r '.window.workflow')" = "Pull Request" ]
+  [ "$(echo "$output" | jq -r '.window.step_records')" = "3" ]
+  [ "$(echo "$output" | jq -r '.sentinel')" = "null" ]
+}
+
+@test "reports the log-sentinel hit rate when the bundle carries sentinel flags" {
+  jq -n '
+    def job($id; $hit): { id: $id, name: "iOS", run_attempt: 1,
+      status: "completed", conclusion: "success",
+      started_at: "2026-01-01T00:00:00Z", completed_at: "2026-01-01T00:10:00Z",
+      sentinel: $hit, steps: [] };
+    { meta: { repo: "o/r", workflow: "Pull Request", branch: null, limit: 1,
+              sentinel: "Status=4294967295", fetched_at: "2026-07-21T00:00:00Z" },
+      runs: [ { id: 1, number: 1, head_sha: "a", head_branch: "b",
+                event: "pull_request", status: "completed", conclusion: "success",
+                run_attempt: 1, created_at: "2026-01-01T00:00:00Z",
+                updated_at: "2026-01-01T01:00:00Z",
+                jobs: [ job(1; true), job(2; true), job(3; false) ] } ] }' \
+    > "${TEST_ROOT}/b.json"
+
+  run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json" --json
+  [ "$status" -eq 0 ]
+  [ "$(echo "$output" | jq -r '.sentinel.observed')" = "3" ]
+  [ "$(echo "$output" | jq -r '.sentinel.hits')" = "2" ]
+  [ "$(echo "$output" | jq -r '.sentinel.hit_rate')" = "0.667" ]
+  [ "$(echo "$output" | jq -r '.sentinel.pattern')" = "Status=4294967295" ]
+
+  run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Log sentinel"* ]]
+  [[ "$output" == *"2/3 jobs matched"* ]]
+}
+
+@test "an empty window aggregates without crashing" {
+  echo '{"meta":{"repo":"o/r","workflow":"Pull Request","branch":null,"limit":0,"sentinel":null,"fetched_at":"2026-07-21T00:00:00Z"},"runs":[]}' \
+    > "${TEST_ROOT}/b.json"
+  run bash "$SCRIPT" --from-file "${TEST_ROOT}/b.json"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Runs: 0"* ]]
+}

--- a/test/bats/measure-ci.bats
+++ b/test/bats/measure-ci.bats
@@ -438,6 +438,42 @@ bundle_from_durations() {
   [[ "$output" == *"2/3 jobs matched"* ]]
 }
 
+@test "a cache built without a sentinel is not reused for a sentinel run" {
+  # Sentinel flags are computed at fetch time and stored per job. Reusing a cache
+  # keyed only on run id + attempt produced a bundle that claimed meta.sentinel
+  # while every job's sentinel stayed null -- a measurement that looks valid and
+  # is not.
+  mkdir -p "${TEST_ROOT}/bin"
+  cat > "${TEST_ROOT}/bin/gh" <<'SHIM'
+#!/bin/sh
+case "$*" in
+  *"run list"*) echo '[{"databaseId":111,"headSha":"abc","createdAt":"2026-07-21T00:00:00Z","conclusion":"success","status":"completed","headBranch":"m","displayTitle":"t","attempt":1}]' ;;
+  # /logs BEFORE /jobs: the log URL is /actions/jobs/<id>/logs and would
+  # otherwise be swallowed by the /jobs pattern, silently serving jobs JSON
+  # as the log body.
+  *"/logs"*)    echo "line with SENTINEL here" ;;
+  *"/jobs"*)    echo '{"jobs":[{"id":9,"name":"iOS","status":"completed","conclusion":"success","run_attempt":1,"started_at":"2026-07-21T00:00:00Z","completed_at":"2026-07-21T00:01:00Z","steps":[]}]}' ;;
+  *"repo view"*) echo "o/r" ;;
+  *) echo "" ;;
+esac
+SHIM
+  chmod +x "${TEST_ROOT}/bin/gh"
+
+  run env PATH="${TEST_ROOT}/bin:$PATH" bash "$SCRIPT" \
+    --cache "${TEST_ROOT}/c.json" --fetch-only --limit 1
+  assert_ok
+
+  # stdout only: bats merges stderr into $output, and the fetch layer logs
+  # progress there, so parse the bundle from a file rather than $output.
+  run env PATH="${TEST_ROOT}/bin:$PATH" bash -c \
+    "bash '$SCRIPT' --cache '${TEST_ROOT}/c.json' --sentinel SENTINEL --sentinel-job iOS --fetch-only --limit 1 > '${TEST_ROOT}/b2.json'"
+  assert_ok
+
+  # The sentinel must actually have been measured, not inherited as null.
+  [ "$(jq -r '.meta.sentinel' "${TEST_ROOT}/b2.json")" = "SENTINEL" ]
+  [ "$(jq -r '.runs[0].jobs[0].sentinel' "${TEST_ROOT}/b2.json")" = "true" ]
+}
+
 @test "an empty window aggregates without crashing" {
   echo '{"meta":{"repo":"o/r","workflow":"Pull Request","branch":null,"limit":0,"sentinel":null,"fetched_at":"2026-07-21T00:00:00Z"},"runs":[]}' \
     > "${TEST_ROOT}/b.json"


### PR DESCRIPTION
Closes #4122.

## Why

Several recent decisions needed CI failure/duration data, and each required a bespoke, hand-rolled analysis that was thrown away afterwards. Two open questions are still blocked on exactly this data: whether the `iOS` rollup can become a required check (#4101) and what `timeout-minutes` should be (#4095).

One of those ad-hoc analyses is also what caught that `Status=4294967295` appears in **106/106** boots — disproving a sentinel that had shipped and was failing 100% of iOS PRs (#4092). That measurement was worth having and is now reproducible.

## Interface

```
Window:        --workflow NAME (default "Pull Request")  --limit N  --max-runs N  --repo  --branch
Layers:        --fetch-only        emit the normalized bundle and stop
               --from-file PATH    aggregate a pre-fetched bundle ("-" = stdin); no network
               --cache PATH        reuse unchanged runs (resume)
Output:        --json | --top N | --min-samples N | --step-filter RE | --job-filter RE
Log sentinel:  --sentinel RE --sentinel-job RE   (opt-in; the only log-text path)
```

Reports per-job outcome rates, per-step duration distributions, and rerun-success rate (same SHA failed then passed — the cleanest flake signal available).

## Design notes

- **Fetch and aggregation are separated by a normalized bundle document.** The aggregator is a pure `jq` program that knows nothing about `gh`, so all 26 BATS tests run offline; one installs a `gh` shim that exits 99 and asserts it is never invoked.
- **Repeated-step ordinals are preserved positionally**, not via `.number`. This matters: "all 9 boots ≥300s were the **third** boot" was only visible because same-named steps were distinguished by position. A naive group-by-name destroys precisely the signal worth having, and using `.number` would look correct while silently re-bucketing the moment a job gains a step. A test pins that two runs with different step counts still pair their boots correctly.
- **Percentiles are nearest-rank, not interpolated** — including the median. Consistent across p90/p95 and pinned by test, but worth knowing before comparing against a hand-computed median.
- Uses `/actions/runs/{id}/jobs?filter=all`, which returns every attempt tagged with `run_attempt`, making rerun analysis one call per run.
- Deliberately avoids `gh api --paginate` over all runs — during this work it hung for minutes and returned nothing useful.

## Verification

26/26 BATS (exit 0, zero `not ok`, checked explicitly rather than by pass tally); `shellcheck`, `shfmt`, and the repo's shell-portability and set-e validators all clean full-tree.

**Live run:** 60 runs in 88s (~61 API calls); resume via `--cache` re-ran in **5.4s**. Sentinel path verified against real job logs.

**A bug only the live run could find:** at 15 runs everything passed; at 60 it died with `jq: Argument list too long` — the accumulator was a shell variable passed via `--argjson`. Rewritten to stream through a temp dir, which also made it O(n) instead of O(n²). Good argument for keeping the live run in the acceptance criteria rather than trusting fixtures alone.

**Non-vacuity** (trap-based restore, inner timeout, mutation anchor asserted before mutating):
- `ceil` → `floor` in the percentile helper → both percentile tests fail. The single-sample test correctly survives.
- ordinal computation → constant `1` (the naive group-by-name) → all three ordinal tests fail.

## Already useful

Pointed at a post-26.2-drop window it shows `Boot iOS Simulator (Xcode 26.5)` median **64s** (vs 221s when it was the third boot), while p90/p95/max all sit at **680s** on n=9 — a single outlier holding up the tail, close to the 900s cap. That is the distribution #4095 needs, and it is a two-minute command instead of an investigation.