### PR TITLE
test(ios): drop the positional anchor now that step names are unique (#4115)

### DIFF
--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
@@ -293,22 +293,19 @@ final class RemindersPlanContentTests: XCTestCase {
 
         assertWorkflowSecondRemindersBringUpRunsWhenNotCancelled(
             workflow,
-            afterStepName: pullRequestRemindersLegAnchorStep
+            afterStepName: nil
         )
         assertWorkflowStepRunsWhenNotCancelled(
             workflow,
-            stepName: "Warm up iOS CtrlProxy (Xcode 26.5)",
-            afterStepName: pullRequestRemindersLegAnchorStep
+            stepName: "Warm up iOS CtrlProxy (Xcode 26.5)"
         )
         assertWorkflowStepRunsWhenNotCancelled(
             workflow,
-            stepName: "Warm up Reminders target app (Xcode 26.5)",
-            afterStepName: pullRequestRemindersLegAnchorStep
+            stepName: "Warm up Reminders target app (Xcode 26.5)"
         )
         assertWorkflowStepRunsWhenNotCancelled(
             workflow,
-            stepName: "Run Reminders integration tests (Xcode 26.5)",
-            afterStepName: pullRequestRemindersLegAnchorStep
+            stepName: "Run Reminders integration tests (Xcode 26.5)"
         )
     }
 
@@ -976,20 +973,20 @@ private func assertWorkflowRunsGuardedRemindersTest(
 
 /// Scan anchor for the PR workflow's Reminders leg.
 ///
-/// Several step names occur twice in `ios-xctest-runner-simulator-tests` (e.g. "Select Xcode
-/// 26.5" is both the job's initial toolchain selection, which has no `if:`, and the Reminders
-/// leg's re-selection, which does), so the assertions below must start scanning after the leg
-/// begins. This was "Run Reminders integration tests (Xcode 26.2)" until #4078 dropped that
-/// leg; the unique `if: always()` teardown directly above the leg replaces it. Mirrors
-/// ANCHOR_STEP in test/bats/xctest-shared-prereq-gate.bats.
-private let pullRequestRemindersLegAnchorStep = "Shutdown iOS Simulators"
-
-/// `afterStepName` defaults to the Xcode 26.2 Reminders run step, which nightly.yml still has
-/// (it deliberately keeps both legs — the coverage is free there because it does not gate
-/// merges). pull_request.yml passes `pullRequestRemindersLegAnchorStep` instead.
+/// `afterStepName` anchors the scan past duplicated step names. nightly.yml is a
+/// matrix and genuinely repeats names ("Select Xcode ${{ matrix.config.xcode }}",
+/// "Ensure iOS Simulator runtime", ...), so it keeps the anchor and passes the
+/// Xcode 26.2 Reminders run step it still has.
+///
+/// pull_request.yml passes nil: #4114 removed the leg's redundant "Select Xcode
+/// 26.5" / "Ensure iOS Simulator runtime (Xcode 26.5)", which were its only
+/// duplicated step names, so a plain by-name lookup is unambiguous there. That
+/// invariant is enforced by the no-duplicate-step-names test in
+/// test/bats/xctest-shared-prereq-gate.bats -- if a duplicate is reintroduced,
+/// the lookup would silently resolve to the first occurrence.
 private func assertWorkflowSecondRemindersBringUpRunsWhenNotCancelled(
     _ workflow: String,
-    afterStepName: String = "Run Reminders integration tests (Xcode 26.2)",
+    afterStepName: String? = "Run Reminders integration tests (Xcode 26.2)",
     file: StaticString = #filePath,
     line: UInt = #line
 ) {

--- a/test/bats/xctest-shared-prereq-gate.bats
+++ b/test/bats/xctest-shared-prereq-gate.bats
@@ -36,27 +36,18 @@ WORKFLOW=".github/workflows/pull_request.yml"
 
 # Print the active `if:` value for a named step, or nothing when the step has none.
 #
-# Scanning starts only AFTER the step that immediately precedes the 26.5 leg:
-# several step names occur twice in the job (e.g. "Select Xcode 26.5" is both the
-# job's initial toolchain selection, which has no `if:`, and the 26.5 leg's
-# re-selection, which does). Without the anchor the first, unguarded occurrence
-# matches and the assertion reports a false violation. This mirrors
-# `afterStepName` in the Swift helper.
-#
-# The anchor was "Run Reminders integration tests (Xcode 26.2)" until #4078 dropped
-# the 26.2 leg from PRs. "Shutdown iOS Simulators" replaces it: it is the unique
-# `if: always()` teardown that still sits directly above the 26.5 leg. If it ever
-# stops being unique or moves, the step-lookup below fails loudly (no `if:` found)
-# rather than silently matching the wrong occurrence.
+# No positional anchor: #4114 removed the leg's redundant "Select Xcode 26.5" and
+# "Ensure iOS Simulator runtime (Xcode 26.5)", which were the only duplicated step
+# names in this job. Every step name is now unique, so a plain by-name lookup
+# cannot match the wrong occurrence. The uniqueness test below is what keeps that
+# true -- if a duplicate is ever reintroduced, this lookup would silently resolve
+# to the first one.
 #
 # awk, not sed -- BSD sed lacks the range forms this needs. A step block runs from
 # its `- name: "<step>"` line to the next step start or a step-indent comment.
-ANCHOR_STEP='Shutdown iOS Simulators'
 
 step_if_condition() {
-  awk -v want="      - name: \"$1\"" -v anchor="      - name: \"$ANCHOR_STEP\"" '
-    !past && $0 == anchor { past = 1; next }
-    !past { next }
+  awk -v want="      - name: \"$1\"" '
     $0 == want { inblock = 1; next }
     inblock && /^      [-#]/ { exit }
     inblock && /^        if:/ {
@@ -82,12 +73,23 @@ Run Reminders integration tests (Xcode 26.5)
 STEPS
 }
 
-@test "the extraction anchor step exists exactly once" {
-  # Everything below scans from this anchor. A missing anchor makes every lookup
-  # return nothing (which fails loudly), but a DUPLICATED anchor would silently
-  # shift the scan window and could re-admit the wrong occurrence of a step name.
-  count="$(grep -c "^      - name: \"$ANCHOR_STEP\"\$" "$WORKFLOW" || true)"
-  [ "$count" -eq 1 ]
+@test "no step name is duplicated in the XCTestRunner job" {
+  # The by-name lookup above is only safe while names are unique. A duplicate
+  # would resolve to the FIRST occurrence -- historically the job-initial,
+  # unguarded "Select Xcode 26.5" -- and silently assert against the wrong step.
+  # This replaces the old anchor-uniqueness guard (#4115): the anchor existed
+  # solely to work around the duplication that #4114 removed.
+  dupes="$(awk '
+    /^  ios-xctest-runner-simulator-tests:/ { injob = 1; next }
+    injob && /^  [a-z][a-z0-9_-]*:$/ { exit }
+    injob && /^      - name: "/ { print }
+  ' "$WORKFLOW" | sort | uniq -d)"
+
+  if [ -n "$dupes" ]; then
+    echo "Duplicated step names (by-name lookup would resolve to the first):" >&2
+    echo "$dupes" >&2
+  fi
+  [ -z "$dupes" ]
 }
 
 @test "every 26.5-leg step individually gates on steps.build-ctrlproxy.outcome == success" {


### PR DESCRIPTION
Closes #4115. **Unblocks #4116.**

## The anchor dissolved rather than moved

It existed for exactly one reason: `Select Xcode 26.5` appeared twice in `ios-xctest-runner-simulator-tests` — the job-initial toolchain selection (unguarded) and the leg re-selection (guarded) — so an unanchored by-name lookup matched the wrong one and reported a false violation.

#4114 removed the leg copy as a no-op. There are now **no duplicated step names in that job at all**, so the anchor has nothing left to disambiguate. That is why this issue was re-scoped from "re-anchor onto something semantically meaningful" to "delete it".

- **bats**: `ANCHOR_STEP` and the anchored scan are gone; the lookup is plain by-name.
- **Swift**: `pull_request.yml` call sites pass `afterStepName: nil`. **`nightly.yml` keeps its anchor** — it is a matrix and genuinely repeats step names (`Select Xcode ${{ matrix.config.xcode }}`, `Ensure iOS Simulator runtime`, …), so its duplication is real and permanent.

## The guard is replaced, not dropped

Removing the anchor makes the lookup *depend* on uniqueness, so deleting its guard outright would have traded one silent-failure mode for another. `"the extraction anchor step exists exactly once"` becomes:

```
@test "no step name is duplicated in the XCTestRunner job"
```

A reintroduced duplicate now fails loudly instead of silently resolving to the first occurrence — which is precisely the bug the anchor was compensating for.

## Verification

Both properties proven non-vacuous by mutation (anchor asserted present before each mutation, restored after):

| Mutation | Expected | Result |
|---|---|---|
| strip a build guard from a 26.5 step | fail | tests 2 and 4 fail |
| add a duplicate `Select Xcode 26.5` | fail | test 3 fails |

bats 5/5, Swift 27/27.

Note the Swift file is unchanged in test count (27 before and after) — the edit only touches the helper signature, four call sites, and a doc comment.