### PR TITLE
ci(ios): collapse the duplicate simulator shutdown steps (#4116)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1540,16 +1540,15 @@ jobs:
             -destination "id=${{ steps.ctrlproxy-simulator.outputs.simulator_udid }}" \
             -only-testing:CtrlProxyUITests/PrivacyResourceMappingTests
 
-      - name: "Shutdown CtrlProxy UI test simulator"
-        if: always()
-        run: xcrun simctl shutdown all || true
-
-      # The Xcode 26.2 Reminders leg used to run here. It was dropped from PRs
-      # (issue #4078): it made the 26.5 Reminders run the job's THIRD simulator
-      # boot, which owned the entire slow tail (median 221s vs 81-100s for boots
-      # 1-2; every boot ≥300s was that one) and pushed the job past its 45-minute
-      # cap. Xcode-toolchain drift coverage for 26.2 is kept in nightly.yml, where
-      # it does not gate merges (see also #3592).
+      # One teardown, not two. These were separate because the Xcode 26.2 leg sat
+      # between them: the first released the CtrlProxy UI simulator before 26.2
+      # started, the second released 26.2's before 26.5 started. #4110 dropped
+      # that leg (it made the 26.5 Reminders run the job's THIRD boot, which owned
+      # the entire slow tail -- median 221s vs 81-100s for boots 1-2, every boot
+      # ≥300s was that one -- and pushed the job past its 45-minute cap), so the
+      # second `shutdown all` had nothing left to shut down. Xcode-toolchain drift
+      # coverage for 26.2 lives in nightly.yml, where it does not gate merges
+      # (see also #3592).
       - name: "Shutdown iOS Simulators"
         if: always()
         run: xcrun simctl shutdown all || true


### PR DESCRIPTION
Closes #4116. Last item in the post-26.2-drop cleanup chain (#4114 → #4115 → this).

## Problem

`Shutdown CtrlProxy UI test simulator` and `Shutdown iOS Simulators` were **byte-identical** (`if: always()`, `xcrun simctl shutdown all || true`) and adjacent.

They were separate for a real reason once: the Xcode 26.2 leg sat between them. The first released the CtrlProxy UI simulator before 26.2 started; the second released 26.2's before 26.5 started. #4110 dropped that leg, so the second had nothing left to shut down.

## Why this was blocked

`Shutdown iOS Simulators` was the **positional anchor** for the 26.5-leg step extraction in both the bats guard and the Swift assertions — deleting it would have silently broken them. #4115 removed the anchor entirely (step names became unambiguous once #4114 dropped the redundant re-selection steps). I verified nothing references that step name before touching it.

## Change

One teardown, keeping the more general name and the #4110 rationale, so the tombstone explaining *why* one suffices survives rather than leaving a bare unexplained step.

## Verification

- `xctest-shared-prereq-gate.bats` 5/5 — including the uniqueness invariant #4115 added.
- Swift `RemindersPlanContentTests` 27/27.
- The four other bats suites that read `pull_request.yml` (`pr-gate-wiring`, `workflow-artifact-name-uniqueness`, `diagnostic-log-upload-nonfatal`, `validate-workflow-assertion-triggers`) all clean.
- YAML parses.

No behavioral change: `shutdown all` twice in a row is `shutdown all` once.