### PR TITLE
perf(ci): background the fast-validation dependency install (#4125)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -607,6 +607,25 @@ jobs:
           # contain the base commit and the diff would fail.
           fetch-depth: 0
 
+      # Pure network/disk and independent of everything below, so background it
+      # here and let the JDK download and the npm-package setup (Bun + ripgrep +
+      # `bun install` + build, ~60-120s) overlap it. The `wait` barrier re-syncs
+      # before the first consumer: the aggregator's `xml` check shells out to
+      # xmlstarlet, and the BATS step needs bats. No dpkg-lock contention — this
+      # is the only apt user in the job (setup-java unpacks a tarball and
+      # setup-ripgrep installs a pre-built binary). Mechanism per #3779.
+      - name: "Install fast validation dependencies"
+        shell: bash
+        background: true
+        id: install-fast-validation-deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xmlstarlet
+          if ! command -v bats &>/dev/null; then
+            git clone --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats-core
+            sudo /tmp/bats-core/install.sh /usr/local
+          fi
+
       # Pin the JDK so the ktfmt check formats deterministically (project targets
       # Java 21) instead of relying on the runner image's default JDK.
       - name: "Set up JDK"
@@ -617,15 +636,7 @@ jobs:
 
       - uses: ./.github/actions/setup-auto-mobile-npm-package
 
-      - name: "Install fast validation dependencies"
-        shell: bash
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y xmlstarlet
-          if ! command -v bats &>/dev/null; then
-            git clone --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats-core
-            sudo /tmp/bats-core/install.sh /usr/local
-          fi
+      - wait: install-fast-validation-deps
 
       - name: "Run fast validation checks"
         shell: bash

--- a/test/helpers/workflowSteps.ts
+++ b/test/helpers/workflowSteps.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { load } from "js-yaml";
+
+/**
+ * Helpers for asserting the *structure* of a GitHub Actions job's steps.
+ *
+ * Workflow guards must parse the YAML rather than line-match it (CLAUDE.md:
+ * don't regex-parse YAML when a structured parser exists — `js-yaml` is already
+ * a direct dependency). Parsing also makes the assertions immune to reflows,
+ * comments, and text that happens to appear inside another step's block scalar.
+ *
+ * Extracted when the second consumer arrived (the parallel-steps guards for
+ * #4124 and #4125); keep the surface to what those guards actually need.
+ */
+
+export interface WorkflowStep {
+  name?: string;
+  id?: string;
+  run?: string;
+  uses?: string;
+  /** Native parallel-steps: run this step asynchronously. */
+  background?: boolean;
+  /** Native parallel-steps barrier: a single step id or a list of them. */
+  wait?: string | string[];
+}
+
+const repoRoot = join(import.meta.dir, "../..");
+
+/**
+ * Steps of one job, or an empty array when the workflow or job is missing.
+ *
+ * Callers should assert the result is non-empty before ordering assertions —
+ * otherwise a renamed job would let every other assertion pass vacuously.
+ */
+export function loadJobSteps(workflowRelativePath: string, jobId: string): WorkflowStep[] {
+  const document = load(readFileSync(join(repoRoot, workflowRelativePath), "utf8")) as {
+    jobs?: Record<string, { steps?: WorkflowStep[] } | undefined>;
+  };
+  return document.jobs?.[jobId]?.steps ?? [];
+}
+
+export function stepNamed(steps: WorkflowStep[], name: string): WorkflowStep | undefined {
+  return steps.find(step => step.name === name);
+}
+
+export function indexOfNamed(steps: WorkflowStep[], name: string): number {
+  return steps.findIndex(step => step.name === name);
+}
+
+/** Index of the first step invoking `uses`, for the unnamed `- uses:` steps. */
+export function indexOfUses(steps: WorkflowStep[], uses: string): number {
+  return steps.findIndex(step => step.uses === uses);
+}
+
+/**
+ * Index of the `wait` barrier targeting `id`. A wait step carries no name, and
+ * `wait` accepts either a single id or a list, so normalize before comparing.
+ */
+export function indexOfWaitOn(steps: WorkflowStep[], id: string): number {
+  return steps.findIndex(step => {
+    if (step.wait === undefined) {
+      return false;
+    }
+    return (Array.isArray(step.wait) ? step.wait : [step.wait]).includes(id);
+  });
+}

--- a/test/scripts/fastValidationDepsHoist.test.ts
+++ b/test/scripts/fastValidationDepsHoist.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import {
+  indexOfNamed,
+  indexOfUses,
+  indexOfWaitOn,
+  loadJobSteps,
+  stepNamed,
+} from "../helpers/workflowSteps";
+
+// Guards issue #4125: in `fast-validation` the apt/bats dependency install ran
+// serially *after* two slow setup steps it does not depend on —
+// `Set up JDK` (a download) and `setup-auto-mobile-npm-package`
+// (Bun + ripgrep + `bun install` + build, ~60-120s). The install is pure
+// network/disk (~30-60s), so it now runs backgrounded from just after checkout
+// and re-syncs at a `wait` barrier before its first consumer.
+//
+// `Fast Validation` is a required check, so a misplaced barrier would break
+// every PR: the ordering below is the guard against that.
+
+const WORKFLOW = ".github/workflows/pull_request.yml";
+const JOB_ID = "fast-validation";
+const INSTALL_STEP = "Install fast validation dependencies";
+const INSTALL_ID = "install-fast-validation-deps";
+
+const steps = loadJobSteps(WORKFLOW, JOB_ID);
+
+describe("#4125 fast-validation dependency install hoist", () => {
+  // Without this, a renamed job would leave `steps` empty and every ordering
+  // assertion below would pass vacuously.
+  test("the job under test exists and has steps", () => {
+    expect(steps.length).toBeGreaterThan(0);
+  });
+
+  test("the dependency install is backgrounded and carries its id", () => {
+    const install = stepNamed(steps, INSTALL_STEP);
+    expect(install).toBeDefined();
+    expect(install?.background).toBe(true);
+    expect(install?.id).toBe(INSTALL_ID);
+  });
+
+  test("the install starts before the JDK and npm-package setup it overlaps", () => {
+    // AC1: to run concurrently with them it must be started earlier in the list.
+    const installIndex = indexOfNamed(steps, INSTALL_STEP);
+    const jdkIndex = indexOfNamed(steps, "Set up JDK");
+    const npmPackageIndex = indexOfUses(steps, "./.github/actions/setup-auto-mobile-npm-package");
+
+    expect(installIndex).toBeGreaterThanOrEqual(0);
+    expect(jdkIndex).toBeGreaterThanOrEqual(0);
+    expect(npmPackageIndex).toBeGreaterThanOrEqual(0);
+
+    expect(installIndex).toBeLessThan(jdkIndex);
+    expect(installIndex).toBeLessThan(npmPackageIndex);
+  });
+
+  test("the wait barrier precedes the fast validation checks and the BATS step", () => {
+    // AC2: the aggregator's `xml` check shells out to xmlstarlet, and the BATS
+    // step needs bats — both come from the backgrounded install.
+    const waitIndex = indexOfWaitOn(steps, INSTALL_ID);
+    const checksIndex = indexOfNamed(steps, "Run fast validation checks");
+    const batsIndex = indexOfNamed(steps, "Run BATS Tests (Ubuntu)");
+
+    expect(waitIndex).toBeGreaterThanOrEqual(0);
+    expect(checksIndex).toBeGreaterThanOrEqual(0);
+    expect(batsIndex).toBeGreaterThanOrEqual(0);
+
+    expect(waitIndex).toBeLessThan(checksIndex);
+    expect(waitIndex).toBeLessThan(batsIndex);
+  });
+
+  test("the JDK setup still precedes the checks that need it", () => {
+    // The JDK is pinned so the ktfmt check inside `Run fast validation checks`
+    // formats deterministically. Hoisting the install must not reorder that.
+    const jdkIndex = indexOfNamed(steps, "Set up JDK");
+    const checksIndex = indexOfNamed(steps, "Run fast validation checks");
+
+    expect(jdkIndex).toBeGreaterThanOrEqual(0);
+    expect(jdkIndex).toBeLessThan(checksIndex);
+  });
+});

--- a/test/scripts/ffmpegInstallHoist.test.ts
+++ b/test/scripts/ffmpegInstallHoist.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-import { load } from "js-yaml";
+import { indexOfNamed, indexOfWaitOn, loadJobSteps, stepNamed } from "../helpers/workflowSteps";
 
 // Guards issue #4124: `ios-xctest-runner-simulator-tests` used to install FFmpeg
 // *inside* the videoRecording test step:
@@ -22,35 +20,10 @@ import { load } from "js-yaml";
 // pin the job's actual `steps` semantics — a comment, a reflow, or text inside
 // some other step's block scalar can neither satisfy nor break them.
 
-const repoRoot = join(import.meta.dir, "../..");
-const workflowPath = join(repoRoot, ".github/workflows/pull_request.yml");
+const WORKFLOW = ".github/workflows/pull_request.yml";
 const JOB_ID = "ios-xctest-runner-simulator-tests";
 
-interface WorkflowStep {
-  name?: string;
-  id?: string;
-  run?: string;
-  background?: boolean;
-  wait?: string | string[];
-}
-
-const workflow = load(readFileSync(workflowPath, "utf8")) as {
-  jobs: Record<string, { steps: WorkflowStep[] }>;
-};
-const steps: WorkflowStep[] = workflow.jobs?.[JOB_ID]?.steps ?? [];
-
-const indexOfNamed = (name: string): number => steps.findIndex(s => s.name === name);
-const stepNamed = (name: string): WorkflowStep | undefined => steps.find(s => s.name === name);
-
-// A `wait` step carries no name, so match on the barrier's target id. `wait`
-// accepts a single id or a list, so normalize before comparing.
-const indexOfWaitOn = (id: string): number =>
-  steps.findIndex(s => {
-    if (s.wait === undefined) {
-      return false;
-    }
-    return (Array.isArray(s.wait) ? s.wait : [s.wait]).includes(id);
-  });
+const steps = loadJobSteps(WORKFLOW, JOB_ID);
 
 describe("#4124 ffmpeg install hoist", () => {
   // If the job is ever renamed, every other assertion would vacuously pass
@@ -60,7 +33,7 @@ describe("#4124 ffmpeg install hoist", () => {
   });
 
   test("the ffmpeg install is a backgrounded step carrying the install-ffmpeg id", () => {
-    const install = stepNamed("Install ffmpeg");
+    const install = stepNamed(steps, "Install ffmpeg");
     expect(install).toBeDefined();
     expect(install?.background).toBe(true);
     expect(install?.id).toBe("install-ffmpeg");
@@ -69,8 +42,8 @@ describe("#4124 ffmpeg install hoist", () => {
   test("the ffmpeg install starts before the Xcode 26.5 simulator boot", () => {
     // AC1: it must run concurrently with the boot, so it has to be started
     // earlier in the step list than the boot it overlaps.
-    const installIndex = indexOfNamed("Install ffmpeg");
-    const bootIndex = indexOfNamed("Boot iOS Simulator (Xcode 26.5)");
+    const installIndex = indexOfNamed(steps, "Install ffmpeg");
+    const bootIndex = indexOfNamed(steps, "Boot iOS Simulator (Xcode 26.5)");
 
     expect(installIndex).toBeGreaterThanOrEqual(0);
     expect(bootIndex).toBeGreaterThanOrEqual(0);
@@ -80,8 +53,8 @@ describe("#4124 ffmpeg install hoist", () => {
   test("a wait barrier on install-ffmpeg precedes the videoRecording test", () => {
     // AC1: without the barrier the test could start before ffmpeg finished
     // installing — the exact failure backgrounding would otherwise introduce.
-    const waitIndex = indexOfWaitOn("install-ffmpeg");
-    const testIndex = indexOfNamed("Run videoRecording MP4 integration test");
+    const waitIndex = indexOfWaitOn(steps, "install-ffmpeg");
+    const testIndex = indexOfNamed(steps, "Run videoRecording MP4 integration test");
 
     expect(waitIndex).toBeGreaterThanOrEqual(0);
     expect(testIndex).toBeGreaterThanOrEqual(0);
@@ -90,7 +63,7 @@ describe("#4124 ffmpeg install hoist", () => {
 
   test("the videoRecording test step no longer installs ffmpeg inline", () => {
     // AC2: the step's 10-minute budget must cover the test alone.
-    const videoStep = stepNamed("Run videoRecording MP4 integration test");
+    const videoStep = stepNamed(steps, "Run videoRecording MP4 integration test");
     expect(videoStep).toBeDefined();
     expect(videoStep?.run).toBeDefined();
     expect(videoStep?.run).not.toContain("brew");


### PR DESCRIPTION
## Summary

In `fast-validation`, the apt/bats dependency install ran serially **after** two slow setup steps it does not depend on — `Set up JDK` (a download) and `setup-auto-mobile-npm-package` (Bun + ripgrep + `bun install` + build, ~60-120s). The install itself is pure network/disk (~30-60s).

It now runs backgrounded from just after checkout, so the JDK and npm-package setup overlap it, and re-syncs at a `wait` barrier before its first consumer.

```yaml
- name: "Install fast validation dependencies"
  shell: bash
  background: true
  id: install-fast-validation-deps
  run: |
    sudo apt-get update
    sudo apt-get install -y xmlstarlet
    ...
- name: "Set up JDK" ...              # overlaps the install
- uses: ./.github/actions/setup-auto-mobile-npm-package
- wait: install-fast-validation-deps
- name: "Run fast validation checks"  # first xmlstarlet consumer
```

`Fast Validation` is a **required** check, so this is on every PR's critical path — and equally, a misplaced barrier would break every PR. That is why the ordering is pinned by tests rather than left to review.

## Linked Issue

Closes #4125

## Why it's safe
- **First consumer covered:** the aggregator's `xml` check shells out to xmlstarlet (`scripts/xml/validate_xml.sh`) and `Run BATS Tests (Ubuntu)` needs bats. The barrier precedes both.
- **ktfmt pin preserved:** `Set up JDK` still precedes `Run fast validation checks`, so the deterministic ktfmt formatting is unaffected. Pinned by its own test.
- **No dpkg-lock contention:** this is the only apt user in the job. `actions/setup-java` unpacks a tarball; `setup-ripgrep` installs a pre-built binary. A grep across all of `.github/actions/` finds zero `apt-get`/`dpkg` usage.

## Testing

New `test/scripts/fastValidationDepsHoist.test.ts` (parsed YAML, not line matching):

| Acceptance criterion | Test |
| --- | --- |
| Install runs concurrently with JDK + npm-package setup | asserts `background: true` + `id`, and index **before** both `Set up JDK` and the npm-package step |
| `wait` precedes the fast-validation checks (and therefore BATS) | asserts a `wait` step targeting the id, indexed before both consumers |
| Fast Validation stays green | not unit-testable — verified by this PR's own run |

Plus a regression guard that `Set up JDK` still precedes the checks, and an anti-vacuous guard so a renamed job fails loudly instead of passing against an empty step list.

Confirmed **red before** the change (3 failing). Mutation-verified after: dropping the `wait`, removing `background`, or moving the install back after the npm-package step each fail exactly one test.

**Refactor:** the workflow-step assertions are now shared with the #4124 guard via `test/helpers/workflowSteps.ts`. Extracted only now that a second consumer exists, per CLAUDE.md's "grow the interface when the second consumer arrives".

## Validation

- [x] `scripts/all_fast_validate_checks.sh` — **17/17 pass**
- [x] `bun test` — 8,221 pass, 0 fail
- [ ] `bun run typecheck` — one pre-existing error (`PlanSchemaValidator.ts` TS2345, ajv) unrelated to this diff; **zero** errors from the new helper or tests. Local `node_modules` skew in the shared clone (`ajv` 8.20.0 vs nested `ajv-formats/node_modules/ajv` 8.17.1); CI installs with `--frozen-lockfile`.
- [x] Rebased onto latest `main`

## Notes for reviewers

Noticed but deliberately **not** fixed here: `.github/actions/setup-auto-mobile-npm-package/action.yml` declares `name: "gradle-task-run"` — a copy-paste mislabel. Pre-existing and unrelated to this change.
