### PR TITLE
perf(ci): background the BATS install in bats-tests (#4126)

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -306,17 +306,15 @@ jobs:
         with:
           lfs: false
 
-      - name: "Setup Bun"
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.9
-
-      - name: "Install Bun dependencies"
-        shell: bash
-        run: scripts/ci/install-bun-deps.sh
-
+      # Pure network/disk (`brew install bats-core` on macOS, a source install on
+      # Linux) and independent of the Bun setup below, which only writes
+      # node_modules. Background it so the two overlap, then re-sync at the
+      # barrier before `bats test/bats/`, the sole consumer of both. Mechanism
+      # per #3779.
       - name: "Install BATS"
         shell: bash
+        background: true
+        id: install-bats
         run: |
           if command -v bats &>/dev/null; then
             echo "bats already installed: $(bats --version)"
@@ -328,6 +326,18 @@ jobs:
             git clone --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats-core
             sudo /tmp/bats-core/install.sh /usr/local
           fi
+
+      - name: "Setup Bun"
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      # Stays in the foreground: it appends node_modules/.bin to $GITHUB_PATH.
+      - name: "Install Bun dependencies"
+        shell: bash
+        run: scripts/ci/install-bun-deps.sh
+
+      - wait: install-bats
 
       - name: "Run BATS Tests"
         run: bats test/bats/

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -749,17 +749,15 @@ jobs:
         with:
           lfs: false
 
-      - name: "Setup Bun"
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.9
-
-      - name: "Install Bun dependencies"
-        shell: bash
-        run: scripts/ci/install-bun-deps.sh
-
+      # Pure network/disk (`brew install bats-core` on macOS, a source install on
+      # Linux) and independent of the Bun setup below, which only writes
+      # node_modules. Background it so the two overlap, then re-sync at the
+      # barrier before `bats test/bats/`, the sole consumer of both. Mechanism
+      # per #3779.
       - name: "Install BATS"
         shell: bash
+        background: true
+        id: install-bats
         run: |
           if command -v bats &>/dev/null; then
             echo "bats already installed: $(bats --version)"
@@ -771,6 +769,18 @@ jobs:
             git clone --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats-core
             sudo /tmp/bats-core/install.sh /usr/local
           fi
+
+      - name: "Setup Bun"
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      # Stays in the foreground: it appends node_modules/.bin to $GITHUB_PATH.
+      - name: "Install Bun dependencies"
+        shell: bash
+        run: scripts/ci/install-bun-deps.sh
+
+      - wait: install-bats
 
       - name: "Run BATS Tests"
         run: bats test/bats/

--- a/test/scripts/batsInstallHoist.test.ts
+++ b/test/scripts/batsInstallHoist.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { indexOfNamed, indexOfWaitOn, loadJobSteps, stepNamed } from "../helpers/workflowSteps";
+
+// Guards issue #4126: the `bats-tests` job installed BATS serially after the Bun
+// setup, even though the two are independent. `Install BATS` is
+// `brew install bats-core` on macOS (tens of seconds) or a `git clone` +
+// source install on Linux — pure network/disk — while `install-bun-deps.sh`
+// only runs `bun install --frozen-lockfile` into `node_modules`. Disjoint
+// targets, and `bats test/bats/` is the sole consumer of both.
+//
+// The install is now backgrounded from just after checkout and re-synced at a
+// `wait` barrier before the test step. `BATS Shell Tests (macos-latest)` is a
+// required check, so the barrier placement is pinned here rather than left to
+// review.
+//
+// Scoped by job id, which matters: pull_request.yml ALSO runs bats inside
+// `fast-validation` (as "Run BATS Tests (Ubuntu)"), and a whole-file search
+// would conflate the two.
+
+const JOB_ID = "bats-tests";
+const INSTALL_STEP = "Install BATS";
+const INSTALL_ID = "install-bats";
+const CONSUMER_STEP = "Run BATS Tests";
+
+const WORKFLOWS = [
+  { label: "pull_request.yml", path: ".github/workflows/pull_request.yml" },
+  { label: "merge.yml", path: ".github/workflows/merge.yml" },
+];
+
+for (const workflow of WORKFLOWS) {
+  describe(`#4126 BATS install hoist (${workflow.label})`, () => {
+    const steps = loadJobSteps(workflow.path, JOB_ID);
+
+    // Without this, a renamed job would leave `steps` empty and every ordering
+    // assertion below would pass vacuously.
+    test("the bats-tests job exists and has steps", () => {
+      expect(steps.length).toBeGreaterThan(0);
+    });
+
+    test("the BATS install is backgrounded and carries its id", () => {
+      const install = stepNamed(steps, INSTALL_STEP);
+      expect(install).toBeDefined();
+      expect(install?.background).toBe(true);
+      expect(install?.id).toBe(INSTALL_ID);
+    });
+
+    test("the BATS install starts before the Bun setup it overlaps", () => {
+      // AC1: to run concurrently with them it must be started earlier in the list.
+      const installIndex = indexOfNamed(steps, INSTALL_STEP);
+      const setupBunIndex = indexOfNamed(steps, "Setup Bun");
+      const bunDepsIndex = indexOfNamed(steps, "Install Bun dependencies");
+
+      expect(installIndex).toBeGreaterThanOrEqual(0);
+      expect(setupBunIndex).toBeGreaterThanOrEqual(0);
+      expect(bunDepsIndex).toBeGreaterThanOrEqual(0);
+
+      expect(installIndex).toBeLessThan(setupBunIndex);
+      expect(installIndex).toBeLessThan(bunDepsIndex);
+    });
+
+    test("the wait barrier precedes the BATS test step", () => {
+      // AC2: without it the suite could start before bats finished installing.
+      const waitIndex = indexOfWaitOn(steps, INSTALL_ID);
+      const consumerIndex = indexOfNamed(steps, CONSUMER_STEP);
+
+      expect(waitIndex).toBeGreaterThanOrEqual(0);
+      expect(consumerIndex).toBeGreaterThanOrEqual(0);
+      expect(waitIndex).toBeLessThan(consumerIndex);
+    });
+
+    test("install-bun-deps still precedes the test step (it writes GITHUB_PATH)", () => {
+      // `install-bun-deps.sh` appends node_modules/.bin to $GITHUB_PATH, so it
+      // must stay in the foreground ahead of the consumer — hoisting the BATS
+      // install must not reorder it past the tests.
+      const bunDepsIndex = indexOfNamed(steps, "Install Bun dependencies");
+      const consumerIndex = indexOfNamed(steps, CONSUMER_STEP);
+
+      expect(bunDepsIndex).toBeGreaterThanOrEqual(0);
+      expect(bunDepsIndex).toBeLessThan(consumerIndex);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

The `bats-tests` job installed BATS serially after the Bun setup, in both `pull_request.yml` and `merge.yml`, even though the two are independent.

`Install BATS` is `brew install bats-core` on macOS (tens of seconds) or a `git clone` + source install on Linux — pure network/disk. `install-bun-deps.sh` only runs `bun install --frozen-lockfile` into `node_modules`. Disjoint targets, and `bats test/bats/` is the sole consumer of both.

Resulting order in both workflows:

```
Git Checkout -> Install BATS (background) -> Setup Bun -> Install Bun dependencies -> wait: install-bats -> Run BATS Tests
```

`BATS Shell Tests (macos-latest)` is a **required** check, and `pull_request.yml`'s matrix is macOS-only — which is exactly where the slow `brew` path lives, so that is where the win lands.

## Linked Issue

Closes #4126

## Why it's safe
- **Disjoint targets** — verified `scripts/ci/install-bun-deps.sh` contains no `brew`/`bats` usage; it is `bun install --frozen-lockfile` plus a `$GITHUB_PATH` append.
- **`install-bun-deps.sh` stays in the foreground** because it writes `$GITHUB_PATH`; only the BATS install is backgrounded. Pinned by its own test.
- **Barrier precedes the sole consumer** in both files.

## Testing

New `test/scripts/batsInstallHoist.test.ts`, parameterized over **both** workflows and using the shared `test/helpers/workflowSteps.ts` extractor (parsed YAML, not line matching):

| Acceptance criterion | Test |
| --- | --- |
| Install overlaps Setup Bun + `bun install`, both workflows | asserts `background: true` + `id`, and index before `Setup Bun` and `Install Bun dependencies` |
| `wait: install-bats` precedes `Run BATS Tests`, both workflows | asserts a `wait` targeting the id, indexed before the consumer |
| BATS Shell Tests green on both legs | not unit-testable — verified by this PR's own run |

Plus a regression guard that `Install Bun dependencies` still precedes the test step, and an anti-vacuous guard so a renamed job fails loudly.

Confirmed **red before** the change: 6 failures (3 per workflow — exactly the AC assertions), with the 4 pre-existing-invariant tests passing as expected.

**Scoping note:** the guard is scoped by job id. `pull_request.yml` also runs bats inside `fast-validation` (as `Run BATS Tests (Ubuntu)`), so a whole-file search would have conflated the two.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` — **17/17 pass**
- [x] `bun test` — 8,231 pass, 0 fail
- [x] `bats test/bats/` — 490 tests, 2 failures, both reproducing on a pristine `origin/main` checkout (formatter version pin; local ffmpeg absence) and unrelated to this change
- [ ] `bun run typecheck` — one pre-existing `PlanSchemaValidator.ts` TS2345 (ajv) unrelated to this diff, which touches no `src/`. Local `node_modules` skew in the shared clone; CI installs with `--frozen-lockfile`.
- [x] Rebased onto latest `main`
