### PR TITLE
ci(ios): fail a Swift package that executed zero tests (#4143)

### DIFF
--- a/scripts/ios/swift-test.sh
+++ b/scripts/ios/swift-test.sh
@@ -78,6 +78,26 @@ IOS_ONLY_PACKAGES=(
     "AccessibilityService"
 )
 
+# Total tests executed in a `swift test` transcript.
+#
+# Both runners can appear in one package's output, so their counts are summed:
+#   XCTest        "Executed 26 tests, with 0 failures ..."
+#   swift-testing "Test run with 0 tests in 0 suites passed ..."
+#
+# XCTest prints one "Executed" line per test bundle AND a duplicate summary line,
+# so the maximum is taken rather than the sum of the XCTest lines; swift-testing's
+# single count is then added.
+executed_test_count() {
+    local output="$1" xctest swifttesting
+    xctest="$(printf '%s\n' "${output}" \
+        | sed -n 's/.*Executed \([0-9][0-9]*\) tests*,.*/\1/p' \
+        | sort -n | tail -1)"
+    swifttesting="$(printf '%s\n' "${output}" \
+        | sed -n 's/.*Test run with \([0-9][0-9]*\) tests* in .*/\1/p' \
+        | sort -n | tail -1)"
+    echo $(( ${xctest:-0} + ${swifttesting:-0} ))
+}
+
 # Run tests for macOS-compatible packages
 echo -e "${BLUE}Running tests for macOS-compatible packages...${NC}"
 for package in "${TESTABLE_PACKAGES[@]}"; do
@@ -87,12 +107,23 @@ for package in "${TESTABLE_PACKAGES[@]}"; do
 
         # Check if the package has test targets
         if grep -q "testTarget" "${PACKAGE_DIR}/Package.swift"; then
-            if (cd "${PACKAGE_DIR}" && swift test -Xswiftc -warnings-as-errors 2>&1); then
-                print_status 0 "${package} tests passed"
-                PASSED_PACKAGES+=("${package}")
-            else
+            test_output="$(cd "${PACKAGE_DIR}" && swift test -Xswiftc -warnings-as-errors 2>&1)"
+            test_rc=$?
+            echo "${test_output}"
+
+            if [ "${test_rc}" -ne 0 ]; then
                 print_status 1 "${package} tests failed"
                 FAILED_PACKAGES+=("${package}")
+            elif [ "$(executed_test_count "${test_output}")" -eq 0 ]; then
+                # `swift test` exits 0 when it runs nothing, so a package whose
+                # suite was deleted, emptied, or simply not discovered is
+                # indistinguishable from one that passed (issue #4143). A package
+                # that declares a testTarget must actually execute tests.
+                print_status 1 "${package} declares a testTarget but executed 0 tests"
+                FAILED_PACKAGES+=("${package} (0 tests executed)")
+            else
+                print_status 0 "${package} tests passed"
+                PASSED_PACKAGES+=("${package}")
             fi
         else
             print_warning "${package} has no test targets"

--- a/scripts/ios/swift-test.sh
+++ b/scripts/ios/swift-test.sh
@@ -87,6 +87,11 @@ IOS_ONLY_PACKAGES=(
 # XCTest prints one "Executed" line per test bundle AND a duplicate summary line,
 # so the maximum is taken rather than the sum of the XCTest lines; swift-testing's
 # single count is then added.
+# Sets EXECUTED_TESTS rather than echoing: calling a function inside $( ) makes
+# bash silently disable set -e for it (SC2311), which the shell-sete ratchet
+# rejects -- and suppressing errexit inside a guard whose whole job is catching
+# silent success would be self-defeating.
+EXECUTED_TESTS=0
 executed_test_count() {
     local output="$1" xctest swifttesting
     xctest="$(printf '%s\n' "${output}" \
@@ -95,7 +100,7 @@ executed_test_count() {
     swifttesting="$(printf '%s\n' "${output}" \
         | sed -n 's/.*Test run with \([0-9][0-9]*\) tests* in .*/\1/p' \
         | sort -n | tail -1)"
-    echo $(( ${xctest:-0} + ${swifttesting:-0} ))
+    EXECUTED_TESTS=$(( ${xctest:-0} + ${swifttesting:-0} ))
 }
 
 # Run tests for macOS-compatible packages
@@ -107,14 +112,21 @@ for package in "${TESTABLE_PACKAGES[@]}"; do
 
         # Check if the package has test targets
         if grep -q "testTarget" "${PACKAGE_DIR}/Package.swift"; then
-            test_output="$(cd "${PACKAGE_DIR}" && swift test -Xswiftc -warnings-as-errors 2>&1)"
-            test_rc=$?
+            # Assign inside the `if` condition: under set -e a bare
+            # test_output="$(failing-cmd)" aborts the whole script, so a package
+            # that genuinely fails would kill the run instead of being recorded.
+            if test_output="$(cd "${PACKAGE_DIR}" && swift test -Xswiftc -warnings-as-errors 2>&1)"; then
+                test_rc=0
+            else
+                test_rc=$?
+            fi
             echo "${test_output}"
+            executed_test_count "${test_output}"
 
             if [ "${test_rc}" -ne 0 ]; then
                 print_status 1 "${package} tests failed"
                 FAILED_PACKAGES+=("${package}")
-            elif [ "$(executed_test_count "${test_output}")" -eq 0 ]; then
+            elif [ "${EXECUTED_TESTS}" -eq 0 ]; then
                 # `swift test` exits 0 when it runs nothing, so a package whose
                 # suite was deleted, emptied, or simply not discovered is
                 # indistinguishable from one that passed (issue #4143). A package

--- a/scripts/ios/swift-test.sh
+++ b/scripts/ios/swift-test.sh
@@ -19,6 +19,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 IOS_DIR="${PROJECT_ROOT}/ios"
 
+# shellcheck source=scripts/ios/swift_test_counts.sh disable=SC1091
+source "${SCRIPT_DIR}/swift_test_counts.sh"
+
 echo -e "${CYAN}========================================${NC}"
 echo -e "${CYAN}  Swift Package Tests${NC}"
 echo -e "${CYAN}========================================${NC}"
@@ -87,22 +90,6 @@ IOS_ONLY_PACKAGES=(
 # XCTest prints one "Executed" line per test bundle AND a duplicate summary line,
 # so the maximum is taken rather than the sum of the XCTest lines; swift-testing's
 # single count is then added.
-# Sets EXECUTED_TESTS rather than echoing: calling a function inside $( ) makes
-# bash silently disable set -e for it (SC2311), which the shell-sete ratchet
-# rejects -- and suppressing errexit inside a guard whose whole job is catching
-# silent success would be self-defeating.
-EXECUTED_TESTS=0
-executed_test_count() {
-    local output="$1" xctest swifttesting
-    xctest="$(printf '%s\n' "${output}" \
-        | sed -n 's/.*Executed \([0-9][0-9]*\) tests*,.*/\1/p' \
-        | sort -n | tail -1)"
-    swifttesting="$(printf '%s\n' "${output}" \
-        | sed -n 's/.*Test run with \([0-9][0-9]*\) tests* in .*/\1/p' \
-        | sort -n | tail -1)"
-    EXECUTED_TESTS=$(( ${xctest:-0} + ${swifttesting:-0} ))
-}
-
 # Run tests for macOS-compatible packages
 echo -e "${BLUE}Running tests for macOS-compatible packages...${NC}"
 for package in "${TESTABLE_PACKAGES[@]}"; do

--- a/scripts/ios/swift_test_counts.sh
+++ b/scripts/ios/swift_test_counts.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Count the tests a `swift test` run actually executed (issue #4143).
+#
+# `swift test` exits 0 when it runs nothing, so a package whose suite was
+# deleted, emptied, or not discovered is indistinguishable from one that passed
+# on exit code alone. swift-test.sh uses this to require that a package
+# declaring a testTarget actually executed tests.
+#
+# Both runners can appear in one package's output, so their counts are summed:
+#   XCTest         "Executed 26 tests, with 0 failures ..."
+#   swift-testing  "Test run with 0 tests in 0 suites passed ..."
+#
+# XCTest prints its summary once per test bundle AND again at the end, so the
+# maximum of those lines is taken rather than their sum -- summing reports 54 for
+# a 27-test run. Harmless for a >0 check, wrong for anything that reads the value.
+#
+# Sets EXECUTED_TESTS rather than echoing: calling a function inside $( ) makes
+# bash silently disable set -e for that call (SC2311), and suppressing errexit
+# inside a guard whose whole job is catching silent success is self-defeating.
+#
+# This file is meant to be sourced; it only defines a function and a variable.
+
+# shellcheck disable=SC2034  # consumed by sourcing scripts (swift-test.sh, bats)
+EXECUTED_TESTS=0
+
+executed_test_count() {
+    local output="$1" xctest swifttesting
+    xctest="$(printf '%s\n' "${output}" \
+        | sed -n 's/.*Executed \([0-9][0-9]*\) tests*,.*/\1/p' \
+        | sort -n | tail -1)"
+    swifttesting="$(printf '%s\n' "${output}" \
+        | sed -n 's/.*Test run with \([0-9][0-9]*\) tests* in .*/\1/p' \
+        | sort -n | tail -1)"
+    # shellcheck disable=SC2034  # read by the sourcing script
+    EXECUTED_TESTS=$(( ${xctest:-0} + ${swifttesting:-0} ))
+}

--- a/test/bats/swift-test-zero-guard.bats
+++ b/test/bats/swift-test-zero-guard.bats
@@ -17,15 +17,18 @@
 # subshell, so a relative path resolves against whatever cwd they left behind.
 SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/ios/swift-test.sh"
 
-# Pull just the counter out of the script so the parsing is testable offline,
-# with no Swift toolchain and no network.
+# The counter lives in its own sourceable library (mirroring
+# scripts/ios/pbxproj_normalize.sh), so the tests load it directly. An earlier
+# revision sed-extracted the function out of swift-test.sh and hit
+# "sed: stdout: Broken pipe" on the CI runner, leaving the function undefined and
+# every test failing for a reason unrelated to what they assert.
+COUNTS_LIB="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/ios/swift_test_counts.sh"
+
 load_counter() {
   # shellcheck source=/dev/null
-  source <(sed -n '/^executed_test_count()/,/^}/p' "$SCRIPT")
+  source "$COUNTS_LIB"
 }
 
-# The counter sets EXECUTED_TESTS rather than echoing (calling a function inside
-# $( ) disables set -e, which the shell-sete ratchet rejects).
 count_of() {
   EXECUTED_TESTS=0
   executed_test_count "$1"

--- a/test/bats/swift-test-zero-guard.bats
+++ b/test/bats/swift-test-zero-guard.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+#
+# Guards issue #4143: `swift test` exits 0 when it runs nothing, so a package
+# whose suite was deleted, emptied, or not discovered was reported as passing.
+# Verified directly:
+#
+#   $ swift test --filter ThisSuiteDoesNotExistAnywhere
+#   ✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.
+#   $ echo $?
+#   0
+#
+# swift-test.sh now requires a package that declares a testTarget to have
+# actually executed tests. These tests pin the counting, which is the piece that
+# decides pass-vs-fail; feeding it a zero-test transcript must yield 0.
+#
+# Absolute path: several bats files here `cd` inside a test body without a
+# subshell, so a relative path resolves against whatever cwd they left behind.
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/ios/swift-test.sh"
+
+# Pull just the counter out of the script so the parsing is testable offline,
+# with no Swift toolchain and no network.
+load_counter() {
+  # shellcheck source=/dev/null
+  source <(sed -n '/^executed_test_count()/,/^}/p' "$SCRIPT")
+}
+
+@test "the counter is defined in swift-test.sh" {
+  load_counter
+  declare -F executed_test_count
+}
+
+@test "an XCTest transcript reports its executed count" {
+  load_counter
+  out=$'\t Executed 27 tests, with 0 failures (0 unexpected) in 0.057 (0.059) seconds'
+  [ "$(executed_test_count "$out")" -eq 27 ]
+}
+
+@test "XCTest's duplicated summary line is not double counted" {
+  # XCTest prints the summary once per bundle AND again at the end. Summing the
+  # lines would report 54 for a 27-test run, which is harmless for a >0 check but
+  # wrong for anything that later reads this number.
+  load_counter
+  out=$'\t Executed 27 tests, with 0 failures (0 unexpected) in 0.057 (0.059) seconds\n\t Executed 27 tests, with 0 failures (0 unexpected) in 0.057 (0.060) seconds'
+  [ "$(executed_test_count "$out")" -eq 27 ]
+}
+
+@test "a zero-test run counts zero (the case that used to pass silently)" {
+  load_counter
+  out='✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.'
+  [ "$(executed_test_count "$out")" -eq 0 ]
+}
+
+@test "a real package emitting both runners sums them" {
+  # XCTestRunner emits an XCTest count AND a swift-testing count in one run.
+  load_counter
+  out=$'Executed 12 tests, with 0 failures (0 unexpected) in 1.0 (1.0) seconds\n✔ Test run with 5 tests in 2 suites passed after 0.1 seconds.'
+  [ "$(executed_test_count "$out")" -eq 17 ]
+}
+
+@test "swift-testing-only packages are counted" {
+  load_counter
+  out='✔ Test run with 8 tests in 3 suites passed after 0.2 seconds.'
+  [ "$(executed_test_count "$out")" -eq 8 ]
+}
+
+@test "output with no recognizable count yields zero rather than empty" {
+  # An empty string here would make the `-eq 0` comparison in swift-test.sh a
+  # syntax error rather than a clean failure.
+  load_counter
+  out='some unrelated build chatter'
+  [ "$(executed_test_count "$out")" -eq 0 ]
+}
+
+@test "swift-test.sh fails a testTarget package that executed no tests" {
+  # The guard itself, not just the counter: the zero-test branch must mark the
+  # package failed rather than passed.
+  grep -q 'executed 0 tests' "$SCRIPT"
+  grep -q 'FAILED_PACKAGES+=("${package} (0 tests executed)")' "$SCRIPT"
+}

--- a/test/bats/swift-test-zero-guard.bats
+++ b/test/bats/swift-test-zero-guard.bats
@@ -24,6 +24,13 @@ load_counter() {
   source <(sed -n '/^executed_test_count()/,/^}/p' "$SCRIPT")
 }
 
+# The counter sets EXECUTED_TESTS rather than echoing (calling a function inside
+# $( ) disables set -e, which the shell-sete ratchet rejects).
+count_of() {
+  EXECUTED_TESTS=0
+  executed_test_count "$1"
+}
+
 @test "the counter is defined in swift-test.sh" {
   load_counter
   declare -F executed_test_count
@@ -32,7 +39,7 @@ load_counter() {
 @test "an XCTest transcript reports its executed count" {
   load_counter
   out=$'\t Executed 27 tests, with 0 failures (0 unexpected) in 0.057 (0.059) seconds'
-  [ "$(executed_test_count "$out")" -eq 27 ]
+  count_of "$out"; [ "$EXECUTED_TESTS" -eq 27 ]
 }
 
 @test "XCTest's duplicated summary line is not double counted" {
@@ -41,26 +48,26 @@ load_counter() {
   # wrong for anything that later reads this number.
   load_counter
   out=$'\t Executed 27 tests, with 0 failures (0 unexpected) in 0.057 (0.059) seconds\n\t Executed 27 tests, with 0 failures (0 unexpected) in 0.057 (0.060) seconds'
-  [ "$(executed_test_count "$out")" -eq 27 ]
+  count_of "$out"; [ "$EXECUTED_TESTS" -eq 27 ]
 }
 
 @test "a zero-test run counts zero (the case that used to pass silently)" {
   load_counter
   out='✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.'
-  [ "$(executed_test_count "$out")" -eq 0 ]
+  count_of "$out"; [ "$EXECUTED_TESTS" -eq 0 ]
 }
 
 @test "a real package emitting both runners sums them" {
   # XCTestRunner emits an XCTest count AND a swift-testing count in one run.
   load_counter
   out=$'Executed 12 tests, with 0 failures (0 unexpected) in 1.0 (1.0) seconds\n✔ Test run with 5 tests in 2 suites passed after 0.1 seconds.'
-  [ "$(executed_test_count "$out")" -eq 17 ]
+  count_of "$out"; [ "$EXECUTED_TESTS" -eq 17 ]
 }
 
 @test "swift-testing-only packages are counted" {
   load_counter
   out='✔ Test run with 8 tests in 3 suites passed after 0.2 seconds.'
-  [ "$(executed_test_count "$out")" -eq 8 ]
+  count_of "$out"; [ "$EXECUTED_TESTS" -eq 8 ]
 }
 
 @test "output with no recognizable count yields zero rather than empty" {
@@ -68,7 +75,7 @@ load_counter() {
   # syntax error rather than a clean failure.
   load_counter
   out='some unrelated build chatter'
-  [ "$(executed_test_count "$out")" -eq 0 ]
+  count_of "$out"; [ "$EXECUTED_TESTS" -eq 0 ]
 }
 
 @test "swift-test.sh fails a testTarget package that executed no tests" {
@@ -76,4 +83,6 @@ load_counter() {
   # package failed rather than passed.
   grep -q 'executed 0 tests' "$SCRIPT"
   grep -q 'FAILED_PACKAGES+=("${package} (0 tests executed)")' "$SCRIPT"
+  # and the capture must be set -e safe, or a real failure aborts the script
+  grep -q 'if test_output="$(cd "${PACKAGE_DIR}"' "$SCRIPT"
 }


### PR DESCRIPTION
Closes #4143.

## The hole

`swift-test.sh` judged each package purely on `swift test`'s exit code — and `swift test` **exits 0 when it runs nothing**:

```
$ swift test --filter ThisSuiteDoesNotExistAnywhere
✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.
$ echo $?
0
```

So a package whose suite was deleted, emptied, or simply not discovered printed `✓ tests passed` and `Swift Packages` went green. A green check could mean *nothing ran*.

## Why this is worth a gate

Not hypothetical. While editing `RemindersPlanContentTests.swift` during #4115, a scripted edit removed **~40 test cases**. `swift build` was clean and `swift test` reported success; the only visible symptom was `Executed 0 tests`, which is easy to read past and which **no gate would have caught**. Pushing it would have deleted that file's entire workflow-assertion coverage while CI stayed green — including the guards protecting the `!cancelled()` and build-prereq invariants from earlier in this same series.

Worth noting the sibling runners do **not** share this hole: `bun test` exits 1 on an unhandled load error (confirmed directly). This is specific to `swift test`.

## Change

A package that declares a `testTarget` must actually execute tests. Packages with genuinely no `testTarget` are still skipped, not failed.

Counting sums both runners, since a package can emit both (XCTestRunner emits an XCTest count *and* a swift-testing count in one run):

- XCTest — `Executed N tests, with M failures`
- swift-testing — `Test run with N tests in K suites passed`

The **max** of the XCTest lines is taken rather than their sum, because XCTest prints its summary once per bundle and again at the end — summing would report 54 for a 27-test run. Harmless for a `> 0` check, wrong for anything that later reads the number.

## Verification

**End to end, on a real package:** emptying `ScreenCaptureCoreTests` makes the script fail with `screen-capture declares a testTarget but executed 0 tests`. Restored, the full run is green again (exit 0, all six packages passing).

**8 bats cases** cover the counting offline (no Swift toolchain needed): XCTest format, swift-testing format, both summed, the duplicated-summary case, the zero case, and unparseable output yielding `0` rather than an empty string — the last matters because an empty value would make the `-eq 0` comparison a syntax error instead of a clean failure.

shellcheck clean.

## Scope

Detecting a *drop* in count (40 → 5) needs a committed baseline and is a larger change. Requiring non-zero closes the catastrophic case cheaply. The README badge counts record totals on main but gate nothing, so they are not a guard today.