### PR TITLE
perf(installer): overlap independent setup

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3343,12 +3343,34 @@ start_ios_runtime_probe() {
     IOS_RUNTIME_PROBE_PID=$!
 }
 
+# Seconds to wait for the background runtime probe before abandoning it.
+# Overridable so the tests can exercise the timeout path without a real stall.
+IOS_RUNTIME_PROBE_TIMEOUT_SECONDS="${IOS_RUNTIME_PROBE_TIMEOUT_SECONDS:-20}"
+
 finish_ios_runtime_probe() {
     if [[ -z "${IOS_RUNTIME_PROBE_PID}" ]]; then
         return 0
     fi
 
-    local probe_status=0
+    # `xcrun simctl list` can stall indefinitely on a loaded macOS runner -- the
+    # hazard #3943 documents and the reason FakeDeviceSessionManager exists. This
+    # probe only decorates output with the installed runtimes, so an unbounded
+    # `wait` traded a cosmetic detail for a hang: on CI it pinned a BATS job for
+    # 6 hours until the runner cancelled it. Bound the join and degrade to
+    # "runtimes unknown" instead.
+    local probe_status=0 waited=0
+    while kill -0 "${IOS_RUNTIME_PROBE_PID}" 2>/dev/null; do
+        if ((waited >= IOS_RUNTIME_PROBE_TIMEOUT_SECONDS)); then
+            kill "${IOS_RUNTIME_PROBE_PID}" 2>/dev/null || true
+            wait "${IOS_RUNTIME_PROBE_PID}" 2>/dev/null || true
+            IOS_RUNTIME_PROBE_PID=""
+            rm -f "${IOS_RUNTIME_PROBE_FILE}"
+            return 0
+        fi
+        sleep 1
+        waited=$((waited + 1))
+    done
+
     if wait "${IOS_RUNTIME_PROBE_PID}"; then
         :
     else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,9 +2,6 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-# Handle Ctrl-C (SIGINT) - exit immediately
-trap 'echo ""; echo "Installation cancelled."; exit 130' INT
-
 # Handle piped execution (curl | bash) where BASH_SOURCE is empty
 if [[ -n "${BASH_SOURCE[0]:-}" ]]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -57,6 +54,11 @@ MCP_CLIENT_LIST=()
 SELECTED_MCP_CLIENTS=()
 PRESET_CLIENT_FILTER=""  # When set, auto-select clients matching this prefix
 IOS_RUNTIME_NAMES=()
+IOS_RUNTIME_PROBE_PID=""
+IOS_RUNTIME_PROBE_FILE=""
+POST_BUN_SETUP_PID=""
+POST_BUN_SETUP_LOG_FILE=""
+POST_BUN_SETUP_STATE_FILE=""
 
 # ============================================================================
 # Original Global State
@@ -94,6 +96,52 @@ fi
 
 command_exists() {
     command -v "$1" >/dev/null 2>&1
+}
+
+# Stop a process tree after first freezing it. Killing only a background Bash
+# subshell leaves its active `bun` child running as an orphan, so capture each
+# descendant before any parent can exit and re-parent it.
+terminate_process_tree() {
+    local pid="$1"
+    kill -0 "${pid}" 2>/dev/null || return 0
+
+    kill -STOP "${pid}" 2>/dev/null || true
+
+    local children=()
+    local child
+    if command_exists pgrep; then
+        while IFS= read -r child; do
+            [[ -n "${child}" ]] && children+=("${child}")
+        done < <(pgrep -P "${pid}" . 2>/dev/null || true)
+    fi
+
+    # Bash 3 treats an empty array as unset with `set -u` enabled.
+    for child in "${children[@]:-}"; do
+        terminate_process_tree "${child}"
+    done
+
+    # A stopped process holds SIGTERM pending until it is resumed. These are
+    # installer-owned worker processes, so use SIGKILL after the recursive
+    # walk to guarantee cancellation cannot leave a Bun or daemon child alive.
+    kill -KILL "${pid}" 2>/dev/null || true
+}
+
+# Reap installer background work and remove its temporary files. The runtime
+# probe and post-Bun setup are always awaited during a normal install; this is
+# only the cancellation/error path that prevents an orphaned child process.
+cleanup_background_installer_work() {
+    local pid
+    for pid in "${IOS_RUNTIME_PROBE_PID}" "${POST_BUN_SETUP_PID}"; do
+        if [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null; then
+            terminate_process_tree "${pid}"
+            wait "${pid}" 2>/dev/null || true
+        fi
+    done
+
+    [[ -n "${IOS_RUNTIME_PROBE_FILE}" ]] && rm -f "${IOS_RUNTIME_PROBE_FILE}"
+    [[ -n "${POST_BUN_SETUP_LOG_FILE}" ]] && rm -f "${POST_BUN_SETUP_LOG_FILE}"
+    [[ -n "${POST_BUN_SETUP_STATE_FILE}" ]] && rm -f "${POST_BUN_SETUP_STATE_FILE}"
+    return 0
 }
 
 # Detect the Git project containing the directory where the installer was run.
@@ -2962,22 +3010,40 @@ _install_dev_tools_brew() {
         return 0
     fi
 
-    local missing=0
+    # Homebrew serializes writes to its prefix, so separate background `brew`
+    # processes would contend for the same lock. One invocation avoids repeated
+    # startup work and lets Homebrew schedule the complete dependency set.
+    local brew_status=0
+    if run_spinner "Installing ${#to_install[@]} development tools" brew install "${to_install[@]}"; then
+        :
+    else
+        brew_status=$?
+    fi
+
+    local installed_after
+    installed_after=$(brew list --formula -1 2>/dev/null || true)
+    local missing_packages=()
     for pkg in "${to_install[@]}"; do
-        if run_spinner "Installing ${pkg}" brew install "${pkg}"; then
-            CHANGES_MADE=true
-        else
-            log_warn "Failed to install ${pkg}"
-            ((missing++)) || true
+        if ! printf '%s\n' "${installed_after}" | grep -qx "${pkg}"; then
+            missing_packages+=("${pkg}")
         fi
     done
 
-    if [[ ${missing} -gt 0 ]]; then
-        log_warn "${missing} dev tool(s) could not be installed"
+    if [[ ${#missing_packages[@]} -gt 0 ]]; then
+        for pkg in "${missing_packages[@]}"; do
+            log_warn "Failed to install ${pkg}"
+        done
+        log_warn "${#missing_packages[@]} dev tool(s) could not be installed"
         return 1
-    else
-        log_info "Development tools ready."
     fi
+
+    if [[ ${brew_status} -ne 0 ]]; then
+        log_warn "Homebrew reported an error after installing all requested development tools"
+        return "${brew_status}"
+    fi
+
+    CHANGES_MADE=true
+    log_info "Development tools ready."
 }
 
 _install_dev_tools_apt() {
@@ -3073,6 +3139,64 @@ handle_bun_setup() {
     fi
 
     return 0
+}
+
+# In non-interactive contributor installs, the CLI/daemon path is independent
+# of Homebrew runtime and development tools once Bun is ready. Capture its
+# output so concurrent work does not corrupt the installer UI, then replay it
+# in order when the parent joins the task.
+start_post_bun_setup() {
+    if [[ "${NON_INTERACTIVE}" != "true" ]] \
+        || [[ "${DRY_RUN}" == "true" ]] \
+        || [[ "${INSTALL_CLAUDE_MARKETPLACE}" == "true" ]] \
+        || { [[ "${INSTALL_AUTOMOBILE_CLI}" != "true" ]] && [[ "${START_DAEMON}" != "true" ]]; }; then
+        return 0
+    fi
+
+    POST_BUN_SETUP_LOG_FILE=$(mktemp "${TMPDIR:-/tmp}/auto-mobile-post-bun-log.XXXXXX")
+    POST_BUN_SETUP_STATE_FILE=$(mktemp "${TMPDIR:-/tmp}/auto-mobile-post-bun-state.XXXXXX")
+
+    (
+        CHANGES_MADE=false
+
+        if [[ "${INSTALL_AUTOMOBILE_CLI}" == "true" ]]; then
+            install_auto_mobile_cli
+        fi
+
+        migrate_stale_daemon
+
+        if [[ "${START_DAEMON}" == "true" ]]; then
+            start_mcp_daemon
+        fi
+
+        printf '%s\n' "${CHANGES_MADE}" >"${POST_BUN_SETUP_STATE_FILE}"
+    ) >"${POST_BUN_SETUP_LOG_FILE}" 2>&1 &
+    POST_BUN_SETUP_PID=$!
+}
+
+finish_post_bun_setup() {
+    if [[ -z "${POST_BUN_SETUP_PID}" ]]; then
+        return 0
+    fi
+
+    local setup_status=0
+    if wait "${POST_BUN_SETUP_PID}"; then
+        :
+    else
+        setup_status=$?
+    fi
+    POST_BUN_SETUP_PID=""
+
+    cat "${POST_BUN_SETUP_LOG_FILE}"
+
+    if [[ ${setup_status} -eq 0 ]] && [[ "$(cat "${POST_BUN_SETUP_STATE_FILE}")" == "true" ]]; then
+        CHANGES_MADE=true
+    fi
+
+    rm -f "${POST_BUN_SETUP_LOG_FILE}" "${POST_BUN_SETUP_STATE_FILE}"
+    POST_BUN_SETUP_LOG_FILE=""
+    POST_BUN_SETUP_STATE_FILE=""
+    return ${setup_status}
 }
 
 # Check if the public npm registry is reachable. If not (e.g. corporate
@@ -3199,6 +3323,50 @@ ios_check_command_line_tools() {
     fi
 
     return 1
+}
+
+# Listing simulator runtimes can wake CoreSimulator and take close to a minute
+# on a fresh macOS host. It is informational at this point, so start it while
+# the installer continues with independent setup work.
+start_ios_runtime_probe() {
+    local os
+    os=$(detect_os)
+    if [[ "${os}" != "macos" ]]; then
+        return 0
+    fi
+    if ! command -v xcrun >/dev/null 2>&1; then
+        return 0
+    fi
+
+    IOS_RUNTIME_PROBE_FILE=$(mktemp "${TMPDIR:-/tmp}/auto-mobile-ios-runtimes.XXXXXX")
+    xcrun simctl list runtimes >"${IOS_RUNTIME_PROBE_FILE}" 2>/dev/null &
+    IOS_RUNTIME_PROBE_PID=$!
+}
+
+finish_ios_runtime_probe() {
+    if [[ -z "${IOS_RUNTIME_PROBE_PID}" ]]; then
+        return 0
+    fi
+
+    local probe_status=0
+    if wait "${IOS_RUNTIME_PROBE_PID}"; then
+        :
+    else
+        probe_status=$?
+    fi
+    IOS_RUNTIME_PROBE_PID=""
+
+    if [[ ${probe_status} -eq 0 ]]; then
+        local runtimes
+        runtimes=$(grep -o 'iOS [0-9.]*' "${IOS_RUNTIME_PROBE_FILE}" | tr '\n' ',' | sed 's/,$//' || true)
+        if [[ -n "${runtimes}" ]]; then
+            log_info "iOS runtimes available: ${runtimes}"
+        fi
+    fi
+
+    rm -f "${IOS_RUNTIME_PROBE_FILE}"
+    IOS_RUNTIME_PROBE_FILE=""
+    return 0
 }
 
 ios_get_installed_runtimes() {
@@ -4033,12 +4201,10 @@ main() {
                 clt_path=$(xcode-select -p 2>/dev/null || true)
                 log_info "Command Line Tools path: ${clt_path}"
 
-                # Check iOS runtimes
-                local runtimes
-                runtimes=$(xcrun simctl list runtimes 2>/dev/null | grep -o 'iOS [0-9.]*' | tr '\n' ',' | sed 's/,$//' || true)
-                if [[ -n "${runtimes}" ]]; then
-                    log_info "iOS runtimes available: ${runtimes}"
-                fi
+                # Listing simulator runtimes may start CoreSimulator and is
+                # slow on a fresh host. It has no bearing on setup readiness,
+                # so collect it while the remaining installer work proceeds.
+                start_ios_runtime_probe
 
                 # Check devicectl (Xcode 15+ physical device control)
                 spin_check "Checking devicectl" "xcrun devicectl --version >/dev/null 2>&1" || true
@@ -4269,6 +4435,8 @@ main() {
         fi
     fi
 
+    start_post_bun_setup
+
     # Runtime dependencies (needed for AutoMobile features)
     show_installation_progress 5
     install_runtime_deps
@@ -4318,7 +4486,7 @@ main() {
 
     # CLI installation
     show_installation_progress 7
-    if [[ "${INSTALL_AUTOMOBILE_CLI}" == "true" ]]; then
+    if [[ -z "${POST_BUN_SETUP_PID}" && "${INSTALL_AUTOMOBILE_CLI}" == "true" ]]; then
         install_auto_mobile_cli
     fi
 
@@ -4327,13 +4495,19 @@ main() {
         install_claude_marketplace
     fi
 
-    # Migrate stale daemon (restart if running an older version)
-    migrate_stale_daemon
+    if [[ -n "${POST_BUN_SETUP_PID}" ]]; then
+        finish_post_bun_setup
+    else
+        # Migrate stale daemon (restart if running an older version)
+        migrate_stale_daemon
 
-    # Daemon startup
-    if [[ "${START_DAEMON}" == "true" ]]; then
-        start_mcp_daemon
+        # Daemon startup
+        if [[ "${START_DAEMON}" == "true" ]]; then
+            start_mcp_daemon
+        fi
     fi
+
+    finish_ios_runtime_probe
 
     # Write environment state for callers (e.g., hot-reload.sh)
     write_env_file
@@ -4356,5 +4530,7 @@ main() {
 # executing the installer. The default (unset) path still runs main for both
 # `bash install.sh` and piped `curl | bash` invocations.
 if [[ "${INSTALL_SH_SOURCE_ONLY:-}" != "true" ]]; then
+    trap 'cleanup_background_installer_work; echo ""; echo "Installation cancelled."; exit 130' INT TERM
+    trap cleanup_background_installer_work EXIT
     main "$@"
 fi

--- a/test/bats/install-background-work.bats
+++ b/test/bats/install-background-work.bats
@@ -26,6 +26,36 @@ teardown() {
   rm -rf "${TEST_DIR}"
 }
 
+@test "a stalled iOS runtime probe is abandoned instead of hanging the run" {
+  # Regression: `xcrun simctl list` can stall indefinitely on a loaded macOS
+  # runner (#3943). The join was an unbounded `wait`, which pinned a CI BATS job
+  # for 6 hours until the runner cancelled it. A stall must be abandoned.
+  cat > "${STUB_BIN}/xcrun" <<'STUB'
+#!/usr/bin/env bash
+# exec so the stub IS the stalled process: killing the probe PID must actually
+# stop it, not orphan a child that keeps the inherited fd open.
+exec sleep 300
+STUB
+  chmod +x "${STUB_BIN}/xcrun"
+
+  detect_os() { printf 'macos\n'; }
+  IOS_RUNTIME_PROBE_TIMEOUT_SECONDS=1
+
+  start_ios_runtime_probe
+  [ -n "${IOS_RUNTIME_PROBE_PID}" ]
+
+  local started ended elapsed status=0
+  started=$(date +%s)
+  finish_ios_runtime_probe >/dev/null 2>&1 || status=$?
+  ended=$(date +%s)
+  elapsed=$((ended - started))
+
+  # Returns promptly and cleanly rather than blocking on the stalled child.
+  [ "$status" -eq 0 ]
+  [ "$elapsed" -lt 30 ]
+  [ -z "${IOS_RUNTIME_PROBE_PID}" ]
+}
+
 @test "iOS runtime probe runs in the background and reports its completed result" {
   cat > "${STUB_BIN}/xcrun" <<'STUB'
 #!/usr/bin/env bash

--- a/test/bats/install-background-work.bats
+++ b/test/bats/install-background-work.bats
@@ -1,0 +1,185 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_DIR="$(mktemp -d)"
+  STUB_BIN="${TEST_DIR}/bin"
+  mkdir -p "${STUB_BIN}"
+
+  ORIG_PATH="${PATH}"
+  PGREP="$(command -v pgrep)"
+  export PATH="${STUB_BIN}:/usr/bin:/bin"
+  export INSTALL_SH_SOURCE_ONLY=true
+  # shellcheck source=/dev/null
+  source scripts/install.sh
+
+  log_info() { printf '[INFO] %s\n' "$1"; }
+}
+
+assert_process_is_not_active() {
+  local state
+  state=$(ps -o stat= -p "$1" 2>/dev/null || true)
+  [[ -z "${state}" || "${state}" == *Z* ]]
+}
+
+teardown() {
+  export PATH="${ORIG_PATH}"
+  rm -rf "${TEST_DIR}"
+}
+
+@test "iOS runtime probe runs in the background and reports its completed result" {
+  cat > "${STUB_BIN}/xcrun" <<'STUB'
+#!/usr/bin/env bash
+sleep 0.1
+printf 'iOS 26.5 - Available\n'
+STUB
+  chmod +x "${STUB_BIN}/xcrun"
+
+  detect_os() { printf 'macos\n'; }
+
+  start_ios_runtime_probe
+  [ -n "${IOS_RUNTIME_PROBE_PID}" ]
+  [ -f "${IOS_RUNTIME_PROBE_FILE}" ]
+
+  local output_file="${TEST_DIR}/runtime-output"
+  local status=0
+  finish_ios_runtime_probe >"${output_file}" 2>&1 || status=$?
+  local output
+  output=$(cat "${output_file}")
+
+  [ "${status}" -eq 0 ]
+  [[ "$output" == *"iOS runtimes available: iOS 26.5"* ]]
+  [ -z "${IOS_RUNTIME_PROBE_PID}" ]
+  [ -z "${IOS_RUNTIME_PROBE_FILE}" ]
+}
+
+@test "post-Bun setup propagates changes and replays output after joining" {
+  NON_INTERACTIVE=true
+  INSTALL_AUTOMOBILE_CLI=true
+  START_DAEMON=true
+  INSTALL_CLAUDE_MARKETPLACE=false
+  CHANGES_MADE=false
+
+  install_auto_mobile_cli() {
+    printf 'cli complete\n'
+    CHANGES_MADE=true
+  }
+  migrate_stale_daemon() { printf 'daemon migration complete\n'; }
+  start_mcp_daemon() { printf 'daemon healthy\n'; }
+
+  start_post_bun_setup
+  [ -n "${POST_BUN_SETUP_PID}" ]
+
+  local output_file="${TEST_DIR}/post-bun-output"
+  local status=0
+  finish_post_bun_setup >"${output_file}" 2>&1 || status=$?
+  local output
+  output=$(cat "${output_file}")
+
+  [ "${status}" -eq 0 ]
+  [[ "$output" == *"cli complete"* ]]
+  [[ "$output" == *"daemon healthy"* ]]
+  [ "${CHANGES_MADE}" = "true" ]
+  [ -z "${POST_BUN_SETUP_PID}" ]
+}
+
+@test "post-Bun setup reports a daemon startup failure" {
+  NON_INTERACTIVE=true
+  INSTALL_AUTOMOBILE_CLI=false
+  START_DAEMON=true
+  INSTALL_CLAUDE_MARKETPLACE=false
+
+  migrate_stale_daemon() { :; }
+  start_mcp_daemon() {
+    printf 'daemon startup failed\n' >&2
+    return 17
+  }
+
+  start_post_bun_setup
+
+  local output_file="${TEST_DIR}/post-bun-failure-output"
+  local status=0
+  finish_post_bun_setup >"${output_file}" 2>&1 || status=$?
+  local output
+  output=$(cat "${output_file}")
+
+  [ "${status}" -eq 17 ]
+  [[ "$output" == *"daemon startup failed"* ]]
+}
+
+@test "cancellation terminates the post-Bun worker and its active child" {
+  NON_INTERACTIVE=true
+  INSTALL_AUTOMOBILE_CLI=true
+  START_DAEMON=false
+  INSTALL_CLAUDE_MARKETPLACE=false
+
+  install_auto_mobile_cli() { sleep 20; }
+
+  start_post_bun_setup
+  local worker_pid="${POST_BUN_SETUP_PID}"
+  local child_pid
+  child_pid=$("${PGREP}" -P "${worker_pid}" sleep)
+
+  cleanup_background_installer_work
+
+  assert_process_is_not_active "${worker_pid}"
+  assert_process_is_not_active "${child_pid}"
+}
+
+@test "cancellation passes a pattern to BSD pgrep when finding children" {
+  NON_INTERACTIVE=true
+  INSTALL_AUTOMOBILE_CLI=true
+  START_DAEMON=false
+  INSTALL_CLAUDE_MARKETPLACE=false
+
+  install_auto_mobile_cli() { sleep 20; }
+
+  start_post_bun_setup
+  local worker_pid="${POST_BUN_SETUP_PID}"
+  local child_pid
+  child_pid=$("${PGREP}" -P "${worker_pid}" sleep)
+
+  cat > "${STUB_BIN}/pgrep" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-P" && "${2:-}" == "${WORKER_PID}" && "${3:-}" == "." ]]; then
+  printf '%s\n' "${CHILD_PID}"
+  exit 0
+fi
+exit 1
+STUB
+  chmod +x "${STUB_BIN}/pgrep"
+  export WORKER_PID="${worker_pid}"
+  export CHILD_PID="${child_pid}"
+
+  cleanup_background_installer_work
+
+  assert_process_is_not_active "${worker_pid}"
+  assert_process_is_not_active "${child_pid}"
+}
+
+@test "background cleanup succeeds when no work was started" {
+  cleanup_background_installer_work
+}
+
+@test "dry-run setup stays synchronous so its plan remains in the parent shell" {
+  NON_INTERACTIVE=true
+  DRY_RUN=true
+  INSTALL_AUTOMOBILE_CLI=true
+  START_DAEMON=true
+  INSTALL_CLAUDE_MARKETPLACE=false
+
+  install_auto_mobile_cli() { DRY_RUN_LOG+=("[DRY-RUN] Install AutoMobile CLI with Bun"); }
+  migrate_stale_daemon() { DRY_RUN_LOG+=("[DRY-RUN] Restart daemon for version upgrade"); }
+  start_mcp_daemon() { DRY_RUN_LOG+=("[DRY-RUN] Start MCP daemon"); }
+
+  start_post_bun_setup
+
+  [ -z "${POST_BUN_SETUP_PID}" ]
+
+  # This is the synchronous branch main takes when no background PID exists.
+  install_auto_mobile_cli
+  migrate_stale_daemon
+  start_mcp_daemon
+  [[ "${DRY_RUN_LOG[*]}" == *"Install AutoMobile CLI with Bun"* ]]
+  [[ "${DRY_RUN_LOG[*]}" == *"Restart daemon for version upgrade"* ]]
+  [[ "${DRY_RUN_LOG[*]}" == *"Start MCP daemon"* ]]
+}

--- a/test/bats/install-dev-tools.bats
+++ b/test/bats/install-dev-tools.bats
@@ -52,6 +52,70 @@ STUB
   [[ "$output" == *"dev tool(s) could not be installed"* ]]
 }
 
+@test "macOS development tools are installed in one Homebrew invocation" {
+  local brew_args="${TEST_DIR}/brew-args"
+  local installed_formulae="${TEST_DIR}/installed-formulae"
+
+  cat > "${STUB_BIN}/brew" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "list" ]]; then
+  [[ -f "${INSTALLED_FORMULAE}" ]] && cat "${INSTALLED_FORMULAE}"
+  exit 0
+fi
+
+if [[ "${1:-}" == "install" ]]; then
+  shift
+  printf '%s\n' "$@" > "${BREW_ARGS}"
+  printf '%s\n' "$@" > "${INSTALLED_FORMULAE}"
+  exit 0
+fi
+
+exit 1
+STUB
+  "$CHMOD" +x "${STUB_BIN}/brew"
+
+  export BREW_ARGS="${brew_args}"
+  export INSTALLED_FORMULAE="${installed_formulae}"
+  run _install_dev_tools_brew
+
+  [ "$status" -eq 0 ]
+  [ "$(wc -l < "${brew_args}")" -eq 12 ]
+  grep -qx "shellcheck" "${brew_args}"
+  grep -qx "ideviceinstaller" "${brew_args}"
+}
+
+@test "macOS development tool installer fails when Homebrew fails after listing packages" {
+  local install_attempted="${TEST_DIR}/install-attempted"
+
+  cat > "${STUB_BIN}/brew" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "list" ]]; then
+  if [[ -f "${INSTALL_ATTEMPTED}" ]]; then
+    printf '%s\n' shellcheck jq ripgrep yq gum hadolint xmlstarlet swiftformat swiftlint xcodegen libusbmuxd ideviceinstaller
+  fi
+  exit 0
+fi
+
+if [[ "${1:-}" == "install" ]]; then
+  touch "${INSTALL_ATTEMPTED}"
+  exit 42
+fi
+
+exit 1
+STUB
+  "$CHMOD" +x "${STUB_BIN}/brew"
+  export INSTALL_ATTEMPTED="${install_attempted}"
+
+  run _install_dev_tools_brew
+
+  [ "$status" -eq 42 ]
+  [[ "$output" == *"Homebrew reported an error"* ]]
+}
+
 @test "Linux development tool installer fails when any apt package install fails" {
   cat > "${STUB_BIN}/apt-get" <<'STUB'
 #!/usr/bin/env bash


### PR DESCRIPTION
## Summary

- overlap the informational iOS simulator-runtime probe with the rest of installer setup
- install missing macOS development tools in one Homebrew transaction and verify every requested formula afterward
- overlap the non-interactive contributor CLI and daemon path with independent Homebrew work while preserving output and failure propagation

## Why

The macOS development installer spent most of its time waiting serially for CoreSimulator and repeated Homebrew startup. These operations do not depend on the Bun CLI/daemon path once Bun is available.

## Validation

- `bash -n scripts/install.sh`
- `shellcheck scripts/install.sh`
- `bats test/bats/`
- `git diff --check`
