### PR TITLE
perf(ci): parallelize the CtrlProxy IPA tool installs (#4127)

### DIFF
--- a/.github/workflows/build-ctrl-proxy-ios-ipa.yml
+++ b/.github/workflows/build-ctrl-proxy-ios-ipa.yml
@@ -28,11 +28,17 @@ jobs:
         with:
           xcode-version: "26.5"
 
-      - name: "Ensure iOS Simulator runtime"
-        uses: ./.github/actions/ensure-ios-simulator-runtime
-
+      # Both installs are network I/O and independent of the simulator-runtime
+      # ensure below, so background them and let it overlap. The single barrier
+      # before the build is load-bearing rather than cosmetic:
+      # ctrl-proxy-create-ipa.sh re-invokes install-xcodegen.sh and pipes to
+      # xcpretty, and install-xcodegen.sh documents the concurrent-prefix race
+      # two installs cause against one prefix ("File exists", nested
+      # share/xcodegen/xcodegen/). Mechanism per #3779.
       - name: "Install XcodeGen"
         run: ./scripts/ios/install-xcodegen.sh
+        background: true
+        id: install-xcodegen
 
       - name: "Cache Ruby gems"
         uses: actions/cache@v5
@@ -40,8 +46,20 @@ jobs:
           path: ~/.gem
           key: gems-xcpretty-${{ runner.os }}
 
+      # Must stay AFTER the cache restore -- `gem install` writes ~/.gem, which
+      # is exactly what that step restores. Backgrounding it is fine; hoisting
+      # it above the cache is not.
       - name: "Install xcpretty"
         run: gem install xcpretty
+        background: true
+        id: install-xcpretty
+
+      # Foreground, and now overlapped by both installs. Stays after
+      # `Select Xcode 26.5` because it resolves against the selected toolchain.
+      - name: "Ensure iOS Simulator runtime"
+        uses: ./.github/actions/ensure-ios-simulator-runtime
+
+      - wait: [install-xcodegen, install-xcpretty]
 
       - name: "Build CtrlProxy iOS IPA"
         id: checksum

--- a/test/scripts/ipaInstallFanOut.test.ts
+++ b/test/scripts/ipaInstallFanOut.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+import { indexOfNamed, indexOfWaitOn, loadJobSteps, stepNamed } from "../helpers/workflowSteps";
+
+// Guards issue #4127: `build-ctrl-proxy-ios-ipa.yml` ran its tool installs
+// serially. Both are network I/O and independent of the simulator-runtime
+// ensure, so they now run backgrounded and re-sync at one barrier before the
+// build. High leverage — this reusable workflow is called by nightly.yml,
+// release.yml and prepare-release.yml.
+//
+// Two constraints make the ordering load-bearing rather than cosmetic:
+//
+//  1. `gem install xcpretty` writes ~/.gem, so it must stay AFTER
+//     `Cache Ruby gems`. It may be backgrounded, but never hoisted above the
+//     cache restore.
+//  2. The barrier prevents corruption, not just mis-ordering:
+//     ctrl-proxy-create-ipa.sh re-invokes install-xcodegen.sh, and
+//     install-xcodegen.sh documents the concurrent-prefix race that causes
+//     ("File exists", nested share/xcodegen/xcodegen/) when two installs run
+//     against one prefix. Without the wait, the backgrounded install races the
+//     build's own invocation.
+
+const WORKFLOW = ".github/workflows/build-ctrl-proxy-ios-ipa.yml";
+const JOB_ID = "build";
+
+const XCODEGEN_STEP = "Install XcodeGen";
+const XCODEGEN_ID = "install-xcodegen";
+const XCPRETTY_STEP = "Install xcpretty";
+const XCPRETTY_ID = "install-xcpretty";
+const CACHE_STEP = "Cache Ruby gems";
+const RUNTIME_STEP = "Ensure iOS Simulator runtime";
+const BUILD_STEP = "Build CtrlProxy iOS IPA";
+
+const steps = loadJobSteps(WORKFLOW, JOB_ID);
+
+describe("#4127 CtrlProxy IPA install fan-out", () => {
+  // Without this, a renamed job would leave `steps` empty and every ordering
+  // assertion below would pass vacuously.
+  test("the build job exists and has steps", () => {
+    expect(steps.length).toBeGreaterThan(0);
+  });
+
+  test("both installs are backgrounded and carry their ids", () => {
+    const xcodegen = stepNamed(steps, XCODEGEN_STEP);
+    expect(xcodegen).toBeDefined();
+    expect(xcodegen?.background).toBe(true);
+    expect(xcodegen?.id).toBe(XCODEGEN_ID);
+
+    const xcpretty = stepNamed(steps, XCPRETTY_STEP);
+    expect(xcpretty).toBeDefined();
+    expect(xcpretty?.background).toBe(true);
+    expect(xcpretty?.id).toBe(XCPRETTY_ID);
+  });
+
+  test("the XcodeGen install starts before the gem cache and runtime ensure", () => {
+    const xcodegenIndex = indexOfNamed(steps, XCODEGEN_STEP);
+    const cacheIndex = indexOfNamed(steps, CACHE_STEP);
+    const runtimeIndex = indexOfNamed(steps, RUNTIME_STEP);
+
+    expect(xcodegenIndex).toBeGreaterThanOrEqual(0);
+    expect(cacheIndex).toBeGreaterThanOrEqual(0);
+    expect(runtimeIndex).toBeGreaterThanOrEqual(0);
+
+    expect(xcodegenIndex).toBeLessThan(cacheIndex);
+    expect(xcodegenIndex).toBeLessThan(runtimeIndex);
+  });
+
+  test("the xcpretty install stays after the gem cache but still overlaps the runtime ensure", () => {
+    // Constraint 1: `gem install` writes ~/.gem, which the cache restores.
+    // Backgrounding it is fine; hoisting it above the cache is not.
+    const xcprettyIndex = indexOfNamed(steps, XCPRETTY_STEP);
+    const cacheIndex = indexOfNamed(steps, CACHE_STEP);
+    const runtimeIndex = indexOfNamed(steps, RUNTIME_STEP);
+
+    expect(xcprettyIndex).toBeGreaterThan(cacheIndex);
+    expect(xcprettyIndex).toBeLessThan(runtimeIndex);
+  });
+
+  test("one barrier covers both installs and precedes the build", () => {
+    // Constraint 2: the build re-invokes install-xcodegen.sh, so the wait must
+    // land before it or the two installs corrupt the shared prefix.
+    const waitXcodegen = indexOfWaitOn(steps, XCODEGEN_ID);
+    const waitXcpretty = indexOfWaitOn(steps, XCPRETTY_ID);
+    const buildIndex = indexOfNamed(steps, BUILD_STEP);
+
+    expect(waitXcodegen).toBeGreaterThanOrEqual(0);
+    expect(waitXcpretty).toBeGreaterThanOrEqual(0);
+    // A single list barrier, not two separate ones.
+    expect(waitXcodegen).toBe(waitXcpretty);
+
+    expect(buildIndex).toBeGreaterThanOrEqual(0);
+    expect(waitXcodegen).toBeLessThan(buildIndex);
+  });
+
+  test("Xcode selection still precedes the simulator runtime ensure", () => {
+    // The runtime ensure resolves against the selected toolchain, so the
+    // reorder must not float it above `Select Xcode 26.5`.
+    const selectIndex = indexOfNamed(steps, "Select Xcode 26.5");
+    const runtimeIndex = indexOfNamed(steps, RUNTIME_STEP);
+
+    expect(selectIndex).toBeGreaterThanOrEqual(0);
+    expect(selectIndex).toBeLessThan(runtimeIndex);
+  });
+});


### PR DESCRIPTION
## Summary

`build-ctrl-proxy-ios-ipa.yml` installed XcodeGen and xcpretty serially even though both are network I/O and independent of the simulator-runtime ensure. Both are now backgrounded, the runtime ensure overlaps them, and one barrier re-syncs before the build.

```
Checkout -> Select Xcode 26.5
  -> Install XcodeGen (background)      # overlaps everything below
  -> Cache Ruby gems
  -> Install xcpretty (background)      # overlaps the runtime ensure
  -> Ensure iOS Simulator runtime
  -> wait: [install-xcodegen, install-xcpretty]
  -> Build CtrlProxy iOS IPA
```

**High leverage:** this reusable workflow is called by `nightly.yml`, `release.yml`, and `prepare-release.yml`, so the win lands three times.

## Linked Issue

Closes #4127

## Two constraints that make the ordering load-bearing

1. **xcpretty stays after the cache.** `gem install xcpretty` writes `~/.gem` — exactly what `Cache Ruby gems` restores. It is backgrounded *in place*, never hoisted above the cache. Pinned by a test.
2. **The barrier prevents corruption, not just mis-ordering.** `scripts/ios/ctrl-proxy-create-ipa.sh:76` re-invokes `install-xcodegen.sh`, and `install-xcodegen.sh:74-76` documents the concurrent-prefix race that causes — `"File exists"` and a nested `share/xcodegen/xcodegen/` when two installs run against one prefix. Without the `wait`, the backgrounded install races the build's own invocation. Pinned by a test asserting a **single list barrier** covering both ids before the build.

`ensure-simulator-runtime.sh` touches neither xcodegen nor gems (verified), and stays after `Select Xcode 26.5` because it resolves against the selected toolchain.

## Testing

New `test/scripts/ipaInstallFanOut.test.ts` via the shared `test/helpers/workflowSteps.ts` extractor (parsed YAML, not line matching): both installs backgrounded with ids; XcodeGen before the cache and runtime ensure; **xcpretty after the cache** and before the runtime ensure; one barrier covering both ids before the build; `Select Xcode 26.5` still before the runtime ensure; plus an anti-vacuous guard.

Confirmed **red before** the change (4 failures — exactly the AC assertions; the 2 pre-existing-invariant tests passed as expected).

## Validation — note the gap, and how it was closed

This is a `workflow_call`-only workflow, called solely by nightly/release/prepare-release. **None of them run on `pull_request`, so this PR's own CI cannot exercise the change.** Rather than merge it unexercised, `nightly.yml` was dispatched against this branch so the IPA is actually built from this code — results posted in a follow-up comment.

- [x] `scripts/all_fast_validate_checks.sh` — **17/17 pass**
- [x] `bun test` — 8,237 pass, 0 fail
- [ ] `bun run typecheck` — one pre-existing `PlanSchemaValidator.ts` TS2345 (ajv) unrelated to this diff, which touches no `src/`. Local `node_modules` skew in the shared clone; CI installs with `--frozen-lockfile`.
- [x] Rebased onto latest `main`
