### PR TITLE
fix(test): inject a Logger into GetDumpsysWindow instead of patching the singleton (#4134)

### DIFF
--- a/src/features/observe/GetDumpsysWindow.ts
+++ b/src/features/observe/GetDumpsysWindow.ts
@@ -7,12 +7,13 @@ import { PerformanceTracker, NoOpPerformanceTracker } from "../../utils/Performa
 import { getTempDir, TEMP_SUBDIRS } from "../../utils/tempDir";
 import type { DumpsysWindow } from "./interfaces/DumpsysWindow";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
-import { logger } from "../../utils/logger";
+import { logger as defaultLogger, type Logger } from "../../utils/logger";
 
 export class GetDumpsysWindow implements DumpsysWindow {
   private adb: AdbExecutor;
   private readonly device: BootedDevice;
   private timer: Timer;
+  private logger: Logger;
   private static memoryCache = new Map<string, { data: ExecResult; timestamp: number }>();
   private static readonly CACHE_TTL_MS = 30000; // 30 seconds
   private readonly cacheDir: string;
@@ -22,13 +23,23 @@ export class GetDumpsysWindow implements DumpsysWindow {
    * Create a GetDumpsysWindow instance
    * @param device - Device to run ADB commands against
    * @param adbFactory - Factory for creating AdbClient instances
+   * @param timer - Injected timer
+   * @param logger - Injected logger. Tests that assert on emitted diagnostics must
+   *   pass a fake: patching the shared `logger` singleton instead makes the
+   *   assertion race every other test that logs concurrently (issue #4134).
    */
-  constructor(device: BootedDevice, adbFactory: AdbClientFactory = defaultAdbClientFactory, timer: Timer = defaultTimer) {
+  constructor(
+    device: BootedDevice,
+    adbFactory: AdbClientFactory = defaultAdbClientFactory,
+    timer: Timer = defaultTimer,
+    logger: Logger = defaultLogger
+  ) {
     this.device = device;
     this.adb = adbFactory.create(device);
     this.cacheDir = getTempDir(TEMP_SUBDIRS.CACHE);
     this.cacheFilePath = path.join(this.cacheDir, `dumpsys-window-${device.deviceId}.json`);
     this.timer = timer;
+    this.logger = logger;
   }
 
   /**
@@ -56,7 +67,7 @@ export class GetDumpsysWindow implements DumpsysWindow {
       }
     } catch (error) {
       // Disk cache is opportunistic; a cache read failure should fall through to ADB refresh.
-      logger.debug(`Failed to load dumpsys window disk cache for device ${this.device.deviceId}: ${error instanceof Error ? error.message : String(error)}`, error);
+      this.logger.debug(`Failed to load dumpsys window disk cache for device ${this.device.deviceId}: ${error instanceof Error ? error.message : String(error)}`, error);
     }
 
     // No valid cache found, refresh and return
@@ -86,7 +97,7 @@ export class GetDumpsysWindow implements DumpsysWindow {
       await perf.track("saveDiskCache", () => this.saveToDiskCache(cacheEntry));
     } catch (error) {
       // Disk cache write failed, but we still return the result
-      logger.warn(`Failed to write disk cache for device ${this.device.deviceId}:`, error);
+      this.logger.warn(`Failed to write disk cache for device ${this.device.deviceId}:`, error);
     }
 
     return result;
@@ -102,7 +113,7 @@ export class GetDumpsysWindow implements DumpsysWindow {
       return JSON.parse(cacheData);
     } catch (error) {
       // Disk cache is opportunistic; callers can refresh from ADB when no cache is available.
-      logger.debug(`Failed to read dumpsys window disk cache for device ${this.device.deviceId}: ${error instanceof Error ? error.message : String(error)}`, error);
+      this.logger.debug(`Failed to read dumpsys window disk cache for device ${this.device.deviceId}: ${error instanceof Error ? error.message : String(error)}`, error);
       return null;
     }
   }

--- a/test/features/observe/GetDumpsysWindow.test.ts
+++ b/test/features/observe/GetDumpsysWindow.test.ts
@@ -1,23 +1,19 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { GetDumpsysWindow } from "../../../src/features/observe/GetDumpsysWindow";
-import { logger, type Logger } from "../../../src/utils/logger";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeLogger } from "../../fakes/FakeLogger";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import type { BootedDevice } from "../../../src/models";
 
 describe("GetDumpsysWindow", () => {
-  const originalDebug = logger.debug;
-
-  afterEach(() => {
-    logger.debug = originalDebug;
-  });
-
   test("logs disk cache read failures before refreshing from adb", async () => {
-    const debugLogs: string[] = [];
-    logger.debug = ((message: string) => {
-      debugLogs.push(message);
-    }) as Logger["debug"];
+    // The logger is injected rather than monkey-patched onto the shared singleton
+    // (issue #4134). The previous version replaced `logger.debug` process-wide and
+    // asserted an exact total, so any other test logging while this one held the
+    // patch appended into its array -- CI once observed 25 entries instead of 1.
+    // A fake instance is unreachable by other tests, so the race cannot occur.
+    const fakeLogger = new FakeLogger();
     const fakeAdb = new FakeAdbExecutor();
     fakeAdb.setCommandResponse("shell dumpsys window", {
       stdout: "mCurrentFocus=Window{test}",
@@ -35,13 +31,22 @@ describe("GetDumpsysWindow", () => {
     const dumpsysWindow = new GetDumpsysWindow(
       device,
       new FakeAdbClientFactory(fakeAdb),
-      new FakeTimer()
+      new FakeTimer(),
+      fakeLogger
     );
 
     const result = await dumpsysWindow.execute();
 
     expect(result.stdout).toBe("mCurrentFocus=Window{test}");
-    expect(debugLogs).toHaveLength(1);
-    expect(debugLogs[0]).toContain("Failed to read dumpsys window disk cache");
+
+    // Assert the specific diagnostic rather than a total count. Even scoped to
+    // this instance, a bare length check would pin every trace the class emits
+    // and break when an unrelated one is added.
+    const cacheReadFailures = fakeLogger.messages.filter(
+      entry => entry.level === "debug"
+        && entry.message.includes("Failed to read dumpsys window disk cache")
+    );
+    expect(cacheReadFailures).toHaveLength(1);
+    expect(cacheReadFailures[0].message).toContain(device.deviceId);
   });
 });


### PR DESCRIPTION
Closes #4134.

## Problem

The test replaced `logger.debug` on the **process-wide singleton** and asserted an exact total:

```ts
logger.debug = ((message: string) => { debugLogs.push(message); }) as Logger["debug"];
...
expect(debugLogs).toHaveLength(1);
```

While it held that patch, any other test exercising a code path that calls `logger.debug` appended into *this* test's array. CI observed **25 entries instead of 1**. It passed in isolation and failed only in the full suite — the assertion was racing whatever the runner happened to be executing alongside it.

## Fix

`GetDumpsysWindow` takes an injected `Logger` defaulting to the shared one — matching `FakeAdbClientFactory` and `FakeTimer`, which this very test already injects, and the precedent in `src/doctor/checks/ios.ts`. `FakeLogger` already existed, so the seam was half-built.

The assertion also now filters for the **specific** diagnostic rather than counting every emitted trace. The class debug-logs a cache *load* failure on this path too, so a bare length check pins unrelated logging and breaks whenever a trace is added — true even scoped to a fake instance.

## Verification

- Non-vacuous: changing the emitted message fails the test.
- 1065 pass across `test/features/observe/`; lint clean; no typecheck errors from these files.

**Honest limit:** I could not reproduce the race locally. I ran the test alongside a neighbour flooding the shared logger, and *both* the old and new versions passed — bun's file scheduling didn't interleave them the way CI did. So the argument here is structural, not empirical: a fake instance is unreachable by other tests, whereas a patched singleton is reachable by definition. The 25-vs-1 CI observation is the evidence that the race is real.

## Not fixed here

Eight other test files patch the logger singleton the same way, several with exact-count assertions — `CtrlProxyClient` (13), `keyedJsonConfigRepository` (9), `toolRegistry.pipeline` (5), `NavigationScreenshotManager` (2), `DeviceServiceUtils` (1). Each needs its own injection seam in the class under test, so widening this PR would turn a one-file fix into a cross-cutting refactor. Filed separately.