### PR TITLE
refactor(adb): remove unused killServer() literal-adb bypass (#4048)

### DIFF
--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -1016,21 +1016,4 @@ export class AdbClient implements AdbExecutor {
       return null;
     }
   }
-
-  /**
-   * Kill the ADB server daemon.
-   * Useful for cleanup after tests to prevent orphan processes.
-   */
-  static async killServer(): Promise<void> {
-    try {
-      const { execFile } = await import("child_process");
-      const { promisify } = await import("util");
-      const execFileAsync = promisify(execFile);
-      await execFileAsync("adb", ["kill-server"]);
-      logger.debug("[ADB] Server killed successfully");
-    } catch {
-      // Ignore errors - server may not be running
-      logger.debug("[ADB] Server kill failed or server not running");
-    }
-  }
 }


### PR DESCRIPTION
## Summary

Removes `AdbClient.killServer()`, the last bypass named in #4048.

[PR #4070](https://github.com/kaeawc/auto-mobile/pull/4070) migrated every other call site in that
issue to the argv-first `AdbExecutor` seam, but its body was written with literal `\n` escapes, so
the `Closes #4048` link never fired and the issue stayed open with one bullet outstanding:

> `AdbClient.killServer()` uses literal `adb`, bypassing its path-resolution seam.

It did — `execFileAsync("adb", ["kill-server"])`, ignoring the resolved `adbPath`. Rather than
route it through the seam, this deletes it: the method has **zero callers** in `src/`, `test/`, or
`scripts/`. Its docstring claimed it was "useful for cleanup after tests," but no test ever used
it. Deleting removes the bypass outright instead of relocating it.

## Changes

- Delete `AdbClient.killServer()` (17 lines, `src/utils/android-cmdline-tools/AdbClient.ts`)

## Testing

- `bun test` — 8231 pass, 11 skip, 0 fail
- `bun run typecheck` — no new errors (225 known in baseline)
- `bun run lint` — clean, including the `check-no-new-direct-simctl.sh` ratchet
- `bun run build` — succeeds
- `grep -rn killServer src test scripts` — no remaining references

## Acceptance criteria

- [x] No production ADB execution resolves the executable outside `AdbClient`'s path-resolution seam

## Notes

The typecheck gate reports 6 baseline errors that no longer occur. They are `TS2339` entries
unrelated to this deletion (pre-existing drift from other merges), so the baseline ratchet is left
to whoever fixed them rather than folded into this diff.

`simctl` centralization (#4049) needs no code change — verified separately and closed; the
`xcrun devicectl` call sites that remain belong to #4053 and #4063.

Closes #4048
