### PR TITLE
docs: write the GetDumpsysWindow issue references as clickable links

### DIFF
--- a/src/features/observe/GetDumpsysWindow.ts
+++ b/src/features/observe/GetDumpsysWindow.ts
@@ -26,7 +26,8 @@ export class GetDumpsysWindow implements DumpsysWindow {
    * @param timer - Injected timer
    * @param logger - Injected logger. Tests that assert on emitted diagnostics must
    *   pass a fake: patching the shared `logger` singleton instead makes the
-   *   assertion race every other test that logs concurrently (issue #4134).
+   *   assertion race every other test that logs concurrently
+   *   ([issue #4134](https://github.com/kaeawc/auto-mobile/issues/4134)).
    */
   constructor(
     device: BootedDevice,

--- a/test/features/observe/GetDumpsysWindow.test.ts
+++ b/test/features/observe/GetDumpsysWindow.test.ts
@@ -8,11 +8,13 @@ import type { BootedDevice } from "../../../src/models";
 
 describe("GetDumpsysWindow", () => {
   test("logs disk cache read failures before refreshing from adb", async () => {
-    // The logger is injected rather than monkey-patched onto the shared singleton
-    // (issue #4134). The previous version replaced `logger.debug` process-wide and
-    // asserted an exact total, so any other test logging while this one held the
-    // patch appended into its array -- CI once observed 25 entries instead of 1.
-    // A fake instance is unreachable by other tests, so the race cannot occur.
+    // The logger is injected rather than monkey-patched onto the shared
+    // singleton -- see
+    // [issue #4134](https://github.com/kaeawc/auto-mobile/issues/4134).
+    // The previous version replaced `logger.debug` process-wide and asserted an
+    // exact total, so any other test logging while this one held the patch
+    // appended into its array; CI once observed 25 entries instead of 1. A fake
+    // instance is unreachable by other tests, so the race cannot occur.
     const fakeLogger = new FakeLogger();
     const fakeAdb = new FakeAdbExecutor();
     fakeAdb.setCommandResponse("shell dumpsys window", {


### PR DESCRIPTION
Follow-up to #4148, which merged before this review comment could be applied.

AGENTS.md:7 — *"Always write GitHub issue and pull request references as clickable Markdown links."* The two references #4148 added were bare `issue #4134`.

Both are now `[issue #4134](https://github.com/kaeawc/auto-mobile/issues/4134)`, with the surrounding comments rewrapped so the link doesn't break mid-sentence.

Verified: 1 pass, lint clean.

## Worth flagging separately

`src/` currently contains **297 bare `issue #NNNN` references and zero clickable ones**. So this convention is stated in AGENTS.md but has no compliant example in the codebase — my original comments matched the prevailing style rather than the written rule.

I've complied here because it costs nothing and the rule is explicit, but a rule with 297 violations and no enforcement will keep being missed by anyone reading surrounding code for guidance. If it's meant to hold, it likely wants a source-scan guard (the repo has several already, e.g. `check-android-emulator-boundary.ts`) plus a sweep; if it isn't, the AGENTS.md line is misleading. Happy to file either way — I didn't want to unilaterally rewrite 297 comments or silently ignore the discrepancy.