### PR TITLE
perf(ci): parallelize nightly iOS installs, drop redundant Bun setup (#4128)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -325,14 +325,25 @@ jobs:
         with:
           xcode-version: ${{ matrix.config.xcode }}
 
+      # Network I/O, and the simulator-runtime ensure below never touches
+      # xcodegen, so background the install and let the ensure overlap it. The
+      # barrier must precede `Generate Xcode Projects`, not merely the build:
+      # xcodegen-generate.sh AND xcode-build.sh each re-invoke
+      # install-xcodegen.sh, and concurrent installs against one prefix are a
+      # documented corruption race ("File exists", nested
+      # share/xcodegen/xcodegen/). Mechanism per #3779.
       - name: "Install XcodeGen"
         run: ./scripts/ios/install-xcodegen.sh
-
-      - name: "Generate Xcode Projects"
-        run: ./scripts/ios/xcodegen-generate.sh
+        background: true
+        id: install-xcodegen
 
       - name: "Ensure iOS Simulator runtime"
         uses: ./.github/actions/ensure-ios-simulator-runtime
+
+      - wait: install-xcodegen
+
+      - name: "Generate Xcode Projects"
+        run: ./scripts/ios/xcodegen-generate.sh
 
       - name: "Build Xcode Projects"
         run: ./scripts/ios/xcode-build.sh
@@ -494,21 +505,26 @@ jobs:
         with:
           xcode-version: "26.5"
 
+      # Network I/O whose only consumer is ctrl-proxy-build-for-testing.sh
+      # (which pipes to xcpretty), so background it and let the runtime ensure
+      # and the npm-package setup overlap it. Mechanism per #3779.
+      - name: "Install xcpretty"
+        run: gem install xcpretty
+        background: true
+        id: install-xcpretty
+
       - name: "Ensure iOS Simulator runtime"
         uses: ./.github/actions/ensure-ios-simulator-runtime
 
-      - name: "Install xcpretty"
-        run: gem install xcpretty
+      # Hoisted above the build so its ~1-2 minutes overlap the backgrounded
+      # install. No standalone "Setup Bun" step is needed -- this composite
+      # already runs oven-sh/setup-bun@v2 at the same pinned 1.3.9.
+      - uses: ./.github/actions/setup-auto-mobile-npm-package
+
+      - wait: install-xcpretty
 
       - name: "Build CtrlProxy iOS for Testing"
         run: ./scripts/ios/ctrl-proxy-build-for-testing.sh
-
-      - name: "Setup Bun"
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.9
-
-      - uses: ./.github/actions/setup-auto-mobile-npm-package
 
       - name: "Verify CtrlProxy iOS Artifacts"
         run: |

--- a/test/scripts/nightlyParallelSteps.test.ts
+++ b/test/scripts/nightlyParallelSteps.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import {
+  indexOfNamed,
+  indexOfUses,
+  indexOfWaitOn,
+  loadJobSteps,
+  stepNamed,
+} from "../helpers/workflowSteps";
+
+// Guards issue #4128: three independent wins in nightly.yml.
+//
+//  5a `ios-xctest-runner-simulator-tests` — `gem install xcpretty` is network
+//     I/O and its only consumer is ctrl-proxy-build-for-testing.sh (which pipes
+//     to xcpretty). Background it and hoist the npm-package setup above the
+//     build so both overlap it, then re-sync before the build.
+//  5b `ios-xcode-build-sweep` — the XcodeGen install is network I/O and the
+//     simulator-runtime ensure never touches xcodegen, so they overlap. The
+//     barrier MUST precede `Generate Xcode Projects`: both
+//     xcodegen-generate.sh and xcode-build.sh re-invoke install-xcodegen.sh,
+//     and concurrent installs against one prefix are a documented corruption
+//     race ("File exists", nested share/xcodegen/xcodegen/).
+//  5c the standalone `Setup Bun` step was redundant —
+//     setup-auto-mobile-npm-package already runs oven-sh/setup-bun@v2 at the
+//     same pinned 1.3.9.
+
+const WORKFLOW = ".github/workflows/nightly.yml";
+const NPM_PACKAGE_ACTION = "./.github/actions/setup-auto-mobile-npm-package";
+
+describe("#4128 nightly — xcpretty overlap in ios-xctest-runner-simulator-tests", () => {
+  const steps = loadJobSteps(WORKFLOW, "ios-xctest-runner-simulator-tests");
+
+  test("the job exists and has steps", () => {
+    expect(steps.length).toBeGreaterThan(0);
+  });
+
+  test("the xcpretty install is backgrounded and carries its id", () => {
+    const install = stepNamed(steps, "Install xcpretty");
+    expect(install).toBeDefined();
+    expect(install?.background).toBe(true);
+    expect(install?.id).toBe("install-xcpretty");
+  });
+
+  test("the npm-package setup is hoisted above the build so it overlaps the install", () => {
+    const installIndex = indexOfNamed(steps, "Install xcpretty");
+    const npmIndex = indexOfUses(steps, NPM_PACKAGE_ACTION);
+    const buildIndex = indexOfNamed(steps, "Build CtrlProxy iOS for Testing");
+
+    expect(installIndex).toBeGreaterThanOrEqual(0);
+    expect(npmIndex).toBeGreaterThanOrEqual(0);
+    expect(buildIndex).toBeGreaterThanOrEqual(0);
+
+    expect(installIndex).toBeLessThan(npmIndex);
+    expect(npmIndex).toBeLessThan(buildIndex);
+  });
+
+  test("the wait barrier precedes the CtrlProxy build, xcpretty's only consumer", () => {
+    const waitIndex = indexOfWaitOn(steps, "install-xcpretty");
+    const buildIndex = indexOfNamed(steps, "Build CtrlProxy iOS for Testing");
+
+    expect(waitIndex).toBeGreaterThanOrEqual(0);
+    expect(waitIndex).toBeLessThan(buildIndex);
+  });
+
+  test("the artifact verification still follows the build that produces them", () => {
+    const buildIndex = indexOfNamed(steps, "Build CtrlProxy iOS for Testing");
+    const verifyIndex = indexOfNamed(steps, "Verify CtrlProxy iOS Artifacts");
+
+    expect(verifyIndex).toBeGreaterThanOrEqual(0);
+    expect(buildIndex).toBeLessThan(verifyIndex);
+  });
+
+  test("the redundant standalone Setup Bun step is gone", () => {
+    // 5c: setup-auto-mobile-npm-package already runs setup-bun at the same
+    // pinned version, so a second standalone step is pure duplication.
+    expect(stepNamed(steps, "Setup Bun")).toBeUndefined();
+    // ...but Bun must still be provisioned, via the composite.
+    expect(indexOfUses(steps, NPM_PACKAGE_ACTION)).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("#4128 nightly — XcodeGen overlap in ios-xcode-build-sweep", () => {
+  const steps = loadJobSteps(WORKFLOW, "ios-xcode-build-sweep");
+
+  test("the job exists and has steps", () => {
+    expect(steps.length).toBeGreaterThan(0);
+  });
+
+  test("the XcodeGen install is backgrounded and carries its id", () => {
+    const install = stepNamed(steps, "Install XcodeGen");
+    expect(install).toBeDefined();
+    expect(install?.background).toBe(true);
+    expect(install?.id).toBe("install-xcodegen");
+  });
+
+  test("the simulator runtime ensure is hoisted up to overlap the install", () => {
+    const installIndex = indexOfNamed(steps, "Install XcodeGen");
+    const runtimeIndex = indexOfNamed(steps, "Ensure iOS Simulator runtime");
+    const generateIndex = indexOfNamed(steps, "Generate Xcode Projects");
+
+    expect(installIndex).toBeGreaterThanOrEqual(0);
+    expect(runtimeIndex).toBeGreaterThanOrEqual(0);
+    expect(generateIndex).toBeGreaterThanOrEqual(0);
+
+    expect(installIndex).toBeLessThan(runtimeIndex);
+    expect(runtimeIndex).toBeLessThan(generateIndex);
+  });
+
+  test("the barrier precedes Generate Xcode Projects, not just the build", () => {
+    // Load-bearing: xcodegen-generate.sh AND xcode-build.sh each re-invoke
+    // install-xcodegen.sh. Waiting only before `Build Xcode Projects` would
+    // still let the generate step race the backgrounded install.
+    const waitIndex = indexOfWaitOn(steps, "install-xcodegen");
+    const generateIndex = indexOfNamed(steps, "Generate Xcode Projects");
+    const buildIndex = indexOfNamed(steps, "Build Xcode Projects");
+
+    expect(waitIndex).toBeGreaterThanOrEqual(0);
+    expect(waitIndex).toBeLessThan(generateIndex);
+    expect(generateIndex).toBeLessThan(buildIndex);
+  });
+});

--- a/turbo.json
+++ b/turbo.json
@@ -45,7 +45,8 @@
         "schemas/**",
         "scripts/**",
         "package.json",
-        "bunfig.toml"
+        "bunfig.toml",
+        ".github/workflows/**"
       ],
       "outputs": [],
       "outputLogs": "new-only",


### PR DESCRIPTION
## Summary

Three independent wins in `nightly.yml`.

**`ios-xctest-runner-simulator-tests`** — `gem install xcpretty` is network I/O whose only consumer is `ctrl-proxy-build-for-testing.sh` (which pipes to xcpretty). Background it, and hoist `setup-auto-mobile-npm-package` above the build so its ~1-2 minutes overlap the install:

```
Select Xcode 26.5 -> Install xcpretty (background) -> Ensure iOS Simulator runtime
  -> setup-auto-mobile-npm-package -> wait: install-xcpretty
  -> Build CtrlProxy iOS for Testing -> Verify CtrlProxy iOS Artifacts
```

**`ios-xcode-build-sweep`** — the XcodeGen install is network I/O and the simulator-runtime ensure never touches xcodegen, so the ensure now overlaps it:

```
Select Xcode -> Install XcodeGen (background) -> Ensure iOS Simulator runtime
  -> wait: install-xcodegen -> Generate Xcode Projects -> Build Xcode Projects
```

**Redundant `Setup Bun` removed** — `setup-auto-mobile-npm-package` already runs `oven-sh/setup-bun@v2` at the same pinned `1.3.9` (verified in the action).

## Linked Issue

Closes #4128

## The one subtle bit

In the sweep, the barrier precedes **`Generate Xcode Projects`**, not merely the build. Both `xcodegen-generate.sh:55` **and** `xcode-build.sh:121` re-invoke `install-xcodegen.sh`, and `install-xcodegen.sh` documents the corruption race two concurrent installs cause against one prefix (`"File exists"`, nested `share/xcodegen/xcodegen/`). Waiting only before `Build Xcode Projects` would still let the generate step race the backgrounded install — so there is a test asserting the barrier sits before `Generate Xcode Projects` specifically.

## Testing

New `test/scripts/nightlyParallelSteps.test.ts` via the shared `test/helpers/workflowSteps.ts` extractor (parsed YAML, not line matching), covering both jobs: backgrounded+id; npm-package hoisted above the build; barrier before the CtrlProxy build; barrier before `Generate Xcode Projects`; artifact verification still after the build; exactly one Bun provisioning path remains (no standalone step, composite still present); plus anti-vacuous guards.

Confirmed **red before** the change: 7 failures — exactly the AC assertions — with the 3 pre-existing-invariant tests passing.

## Validation — and the gap

`nightly.yml` runs only on schedule/`workflow_dispatch`, so this PR's own CI cannot exercise it. As with #4127, nightly was dispatched against this branch so both affected jobs actually run from this code; results in a follow-up comment.

- [x] `scripts/all_fast_validate_checks.sh` — **17/17 pass**
- [x] `bun test` — 8,247 pass, 0 fail
- [ ] `bun run typecheck` — one pre-existing `PlanSchemaValidator.ts` TS2345 (ajv) unrelated to this diff, which touches no `src/`. Local `node_modules` skew; CI installs with `--frozen-lockfile`.
- [x] Rebased onto latest `main`
