### PR TITLE
fix: harden WebRTC streaming lifecycle

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -244,6 +244,9 @@ jobs:
               - 'scripts/android/**'
               - 'scripts/local-dev/hot-reload.sh'
               - '.github/workflows/android*.yml'
+              # This workflow controls Android-job gating, so changes to it
+              # must exercise the gate rather than being silently skipped.
+              - '.github/workflows/pull_request.yml'
 
       # Narrower than `android` above: detekt analyzes Kotlin only, so an XML
       # resource or a doc under android/ has nothing for it to look at. The

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1277,7 +1277,7 @@ jobs:
 
       - uses: ./.github/actions/gradle-task-run
         with:
-          gradle-tasks: ":junit-runner:test :junit-runner:jacocoTestReport :control-proxy:testDebugUnitTest :control-proxy:createDebugUnitTestCoverageReport :auto-mobile-sdk:testDebugUnitTest :auto-mobile-sdk:createDebugUnitTestCoverageReport :test-plan-validation:test :test-plan-validation:jacocoTestReport :protocol:test :protocol:jacocoTestReport :video-server:test"
+          gradle-tasks: ":junit-runner:test :junit-runner:jacocoTestReport :control-proxy:testDebugUnitTest :control-proxy:createDebugUnitTestCoverageReport :auto-mobile-sdk:testDebugUnitTest :auto-mobile-sdk:createDebugUnitTestCoverageReport :test-plan-validation:test :test-plan-validation:jacocoTestReport :protocol:test :protocol:jacocoTestReport :video-server:test :video-server:d8Dex"
           gradle-project-directory: "android"
           gradle-home-directory: "~/.gradle/${{ github.job }}"
           reuse-configuration-cache: true

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/AudioCapture.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/AudioCapture.kt
@@ -53,8 +53,14 @@ class AudioCapture(
       throw IllegalStateException("AudioRecord REMOTE_SUBMIX failed to initialize")
     }
 
-    recorder.startRecording()
-    record = recorder
+    try {
+      recorder.startRecording()
+      record = recorder
+    } catch (e: RuntimeException) {
+      running.set(false)
+      recorder.release()
+      throw e
+    }
     thread =
       Thread(
           {

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoEncoder.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoEncoder.kt
@@ -21,11 +21,6 @@ class VideoEncoder(
   private val bitrate: Int,
   private val fps: Int,
 ) {
-  companion object {
-    /** H.264 Level 4.2 is the capability advertised by the WebRTC publisher. */
-    internal const val WEBRTC_H264_LEVEL = MediaCodecInfo.CodecProfileLevel.AVCLevel42
-  }
-
   private var codec: MediaCodec? = null
 
   /** Input surface for the VirtualDisplay to render to. Available after [start]. */
@@ -58,14 +53,14 @@ class VideoEncoder(
         // Repeat frame after 100ms of no changes (reduces idle bandwidth)
         setLong(MediaFormat.KEY_REPEAT_PREVIOUS_FRAME_AFTER, 100_000)
 
-        // Match the constrained-baseline Level 4.2 advertised by the WebRTC
-        // publisher. The configured presets and validated size overrides fit
-        // this level; leaving it unconstrained can emit an incompatible SPS.
+        // Request baseline profile but let MediaCodec choose a supported level
+        // for this device and capture size. The publisher validates the emitted
+        // SPS before forwarding it, so an unsupported encoder level reconnects
+        // safely instead of making MediaCodec.configure() fail up front.
         setInteger(
           MediaFormat.KEY_PROFILE,
           MediaCodecInfo.CodecProfileLevel.AVCProfileBaseline,
         )
-        setInteger(MediaFormat.KEY_LEVEL, WEBRTC_H264_LEVEL)
 
         // CBR for consistent bitrate
         setInteger(

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoEncoder.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoEncoder.kt
@@ -21,6 +21,11 @@ class VideoEncoder(
   private val bitrate: Int,
   private val fps: Int,
 ) {
+  companion object {
+    /** H.264 Level 4.2 is the capability advertised by the WebRTC publisher. */
+    internal const val WEBRTC_H264_LEVEL = MediaCodecInfo.CodecProfileLevel.AVCLevel42
+  }
+
   private var codec: MediaCodec? = null
 
   /** Input surface for the VirtualDisplay to render to. Available after [start]. */
@@ -53,13 +58,14 @@ class VideoEncoder(
         // Repeat frame after 100ms of no changes (reduces idle bandwidth)
         setLong(MediaFormat.KEY_REPEAT_PREVIOUS_FRAME_AFTER, 100_000)
 
-        // H.264 Baseline profile for maximum compatibility
-        // Note: We don't set KEY_LEVEL - let the codec choose the appropriate level
-        // based on resolution/fps. Level 3.1 can't handle 720p@60fps or 1080p@60fps.
+        // Match the constrained-baseline Level 4.2 advertised by the WebRTC
+        // publisher. The configured presets and validated size overrides fit
+        // this level; leaving it unconstrained can emit an incompatible SPS.
         setInteger(
           MediaFormat.KEY_PROFILE,
           MediaCodecInfo.CodecProfileLevel.AVCProfileBaseline,
         )
+        setInteger(MediaFormat.KEY_LEVEL, WEBRTC_H264_LEVEL)
 
         // CBR for consistent bitrate
         setInteger(

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
@@ -134,8 +134,11 @@ object VideoServer {
     }
     val width = parts[0].toIntOrNull()?.takeIf { it > 0 } ?: return null
     val height = parts[1].toIntOrNull()?.takeIf { it > 0 } ?: return null
-    // MediaCodec requires even dimensions.
-    return (width and 0xFFFE) to (height and 0xFFFE)
+    // MediaCodec requires even, non-zero dimensions. Silently rounding 1x1 to 0x0
+    // defers a bad command-line value into an opaque encoder failure.
+    val evenWidth = width and 0xFFFE
+    val evenHeight = height and 0xFFFE
+    return if (evenWidth > 0 && evenHeight > 0) evenWidth to evenHeight else null
   }
 
   private fun printUsage() {
@@ -173,7 +176,7 @@ object VideoServer {
     if (isPortrait) {
       // Scale based on height
       if (displayHeight <= quality.maxHeight) {
-        return displayWidth to displayHeight
+        return evenDimensions(displayWidth, displayHeight)
       }
       val scale = quality.maxHeight.toFloat() / displayHeight.toFloat()
       val scaledWidth = (displayWidth * scale).toInt() and 0xFFFE // Round to even
@@ -181,13 +184,16 @@ object VideoServer {
     } else {
       // Scale based on width (landscape)
       if (displayWidth <= quality.maxHeight) {
-        return displayWidth to displayHeight
+        return evenDimensions(displayWidth, displayHeight)
       }
       val scale = quality.maxHeight.toFloat() / displayWidth.toFloat()
       val scaledHeight = (displayHeight * scale).toInt() and 0xFFFE // Round to even
       return quality.maxHeight to scaledHeight
     }
   }
+
+  private fun evenDimensions(width: Int, height: Int): Pair<Int, Int> =
+    (width and 0xFFFE) to (height and 0xFFFE)
 
   private fun run(
     width: Int,

--- a/docs/design-docs/mcp/observe/ios-webrtc-streaming.md
+++ b/docs/design-docs/mcp/observe/ios-webrtc-streaming.md
@@ -9,6 +9,10 @@
 > raw `simctl` streaming and the remaining iOS delivery constraints. See the
 > [Status Glossary](../../status-glossary.md) for chip definitions.
 
+The WebRTC, RTP, and WHIP behavior shared with Android is mapped to its public
+standards in the [WebRTC standards map](./webrtc-standards-map.md). This document
+only covers the iOS capture and encoding boundary.
+
 Follow-up to #3751; addresses #3777.
 
 ## Goal

--- a/docs/design-docs/mcp/observe/webrtc-standards-map.md
+++ b/docs/design-docs/mcp/observe/webrtc-standards-map.md
@@ -1,0 +1,60 @@
+# WebRTC standards map
+
+This page connects AutoMobile's WebRTC implementation choices to the public
+standards that define the interoperable wire protocol. It is intended as a
+reading guide, not as a replacement for the specifications.
+
+## Scope and reading order
+
+The standards below govern the WebRTC session, signalling, secure media, and
+RTP payloads. Android capture (`video-server` / `screenrecord`), iOS capture
+(ScreenCaptureKit helper / FFmpeg), the local Unix-socket control protocol, and
+request-size or timeout limits are AutoMobile or platform implementation
+choices; they are not WebRTC standards.
+
+For a first pass, read the [W3C WebRTC API](https://www.w3.org/TR/webrtc/),
+[JSEP (RFC 9429)](https://www.rfc-editor.org/rfc/rfc9429.html),
+[WHIP (RFC 9725)](https://www.rfc-editor.org/rfc/rfc9725.html), and
+[ICE (RFC 8445)](https://www.rfc-editor.org/rfc/rfc8445.html). Then use the
+row for the feature being investigated.
+
+## Implementation-to-spec map
+
+| AutoMobile functionality | Implementation choice and boundary | Standards basis |
+| --- | --- | --- |
+| Peer connection and media directions | `WebRtcPublisher` creates a WebRTC peer connection with sendonly H.264 video and optional sendonly PCMU audio. The peer-connection state is the lifecycle signal; AutoMobile does not invent a separate media-session protocol. | [W3C WebRTC: `RTCPeerConnection` and transceivers](https://www.w3.org/TR/webrtc/#rtcpeerconnection-interface), [JSEP (RFC 9429)](https://www.rfc-editor.org/rfc/rfc9429.html), and [SDP offer/answer (RFC 3264)](https://www.rfc-editor.org/rfc/rfc3264.html). |
+| Offer/answer validation | Before accepting an answer, AutoMobile checks the expected media sections, negotiated codecs, and directions. A malformed or partially compatible answer fails the session rather than being treated as a working stream. | [SDP (RFC 8866)](https://www.rfc-editor.org/rfc/rfc8866.html) defines SDP syntax; [RFC 3264](https://www.rfc-editor.org/rfc/rfc3264.html) defines matching media sections and format intersection; [WHIP section 4.4](https://www.rfc-editor.org/rfc/rfc9725.html#section-4.4) adds WHIP-specific media constraints. |
+| WHIP ingest and teardown | `WhipClient` POSTs an `application/sdp` offer, accepts the server SDP answer and `Location` resource URL, and DELETEs that URL on stop or failed startup. Retaining and deleting the resource avoids leaking server-side sessions. | [WHIP sections 4.2 and 4.6 (RFC 9725)](https://www.rfc-editor.org/rfc/rfc9725.html#section-4.2). |
+| WHIP bearer token | When configured, `whipToken` is sent as an HTTP `Authorization: Bearer` credential on WHIP requests. Supplying the token and protecting it are deployment responsibilities; AutoMobile only applies the configured request authentication. | [WHIP authentication and bearer-token rules (RFC 9725 section 4.7)](https://www.rfc-editor.org/rfc/rfc9725.html#section-4.7) and [OAuth 2.0 bearer-token usage (RFC 6750)](https://www.rfc-editor.org/rfc/rfc6750.html). |
+| WHEP viewing | The bundled coordination server accepts a viewer's offer and returns an answer, then forwards the publisher's RTP to that viewer. WHEP is still an Internet-Draft, so its behavior is an interoperability target rather than an RFC guarantee. | [WebRTC-HTTP Egress Protocol (WHEP) Internet-Draft](https://datatracker.ietf.org/doc/html/draft-ietf-wish-whep). |
+| ICE candidate gathering and STUN/TURN | By default AutoMobile waits for ICE gathering before its WHIP POST. `iceServers` can supply STUN or TURN servers. This conservative non-trickle default favors simple WHIP interoperability; it is not a different ICE protocol. | [ICE (RFC 8445)](https://www.rfc-editor.org/rfc/rfc8445.html), [STUN (RFC 8489)](https://www.rfc-editor.org/rfc/rfc8489.html), and [TURN (RFC 8656)](https://www.rfc-editor.org/rfc/rfc8656.html). |
+| Opt-in trickle ICE | With `trickleIce: true`, AutoMobile sends the initial offer and PATCHes later candidates as `application/trickle-ice-sdpfrag`. The ingest server must advertise/support this extension. | [Trickle ICE (RFC 8838)](https://www.rfc-editor.org/rfc/rfc8838.html), [SDP fragments (RFC 8840)](https://www.rfc-editor.org/rfc/rfc8840.html), and [WHIP section 4.3 (RFC 9725)](https://www.rfc-editor.org/rfc/rfc9725.html#section-4.3). |
+| Secure media readiness | Capture packets are only sent after the peer connection reaches a connected state. That is AutoMobile's lifecycle guard around the standard ICE + DTLS-SRTP establishment performed by werift; it prevents an old source from sending into a failed session. | [W3C connection state](https://www.w3.org/TR/webrtc/#dom-rtcpeerconnectionstate), [ICE (RFC 8445)](https://www.rfc-editor.org/rfc/rfc8445.html), and [DTLS-SRTP (RFC 5764)](https://www.rfc-editor.org/rfc/rfc5764.html). |
+| H.264 Annex-B to RTP packetization | `VideoServerStreamParser` accepts arbitrary input chunks, reconstructs Annex-B NAL units/access units, and packetizes them as single-NAL or FU-A RTP payloads. The RTP marker marks the final packet of an access unit. Chunk tolerance is an AutoMobile transport boundary; the payload layout is standards-defined. | [RTP (RFC 3550)](https://www.rfc-editor.org/rfc/rfc3550.html) and [H.264 RTP payload format, especially sections 5.1, 5.2, 5.6, and 5.8 (RFC 6184)](https://www.rfc-editor.org/rfc/rfc6184.html#section-5.2). |
+| Late WHEP viewers and decoder configuration | The coordination server caches the most recent SPS/PPS and a complete IDR access unit, then replays them after a viewer's peer connection is ready. This is an implementation policy so a new decoder has configuration and a decodable refresh point; it does not substitute for a generic RTCP keyframe-request implementation. | [RFC 6184 parameter sets and payload parameters](https://www.rfc-editor.org/rfc/rfc6184.html#section-8) and the public [ITU-T H.264 recommendation](https://www.itu.int/rec/T-REC-H.264). |
+| RTP forwarding to several viewers | RTP packets are copied before each WHEP subscriber receives them, so a writable packet buffer owned by one peer cannot corrupt another peer's media. Per-subscriber copying is an AutoMobile memory-ownership safeguard; RTP sequence/timestamp/SSRC semantics remain the standards contract. | [RTP header and source semantics (RFC 3550)](https://www.rfc-editor.org/rfc/rfc3550.html#section-5). |
+| Optional PCMU audio | AutoMobile encodes 8 kHz mono PCM16 as G.711 mu-law (PCMU) and offers it as RTP payload type 0. Audio capture availability is platform-specific; the codec clock rate and payload mapping are interoperable RTP choices. | [RTP A/V Profile: PCMU and static payload type 0 (RFC 3551)](https://www.rfc-editor.org/rfc/rfc3551.html#section-6). |
+| Reconnect, stop, and consent loss | On connection failure, AutoMobile tears down the old WHIP resource, backs off, and starts a fresh capture/session so a new keyframe follows. The retry schedule and source restart are implementation policy; deleting a WHIP resource and ceasing media when peer consent is lost are protocol-aligned. | [WHIP session termination (RFC 9725 section 4.6)](https://www.rfc-editor.org/rfc/rfc9725.html#section-4.6) and [ICE consent freshness (RFC 7675)](https://www.rfc-editor.org/rfc/rfc7675.html). |
+| BUNDLE and RTCP multiplexing | AutoMobile delegates SDP generation and transport details to werift. It does not add custom BUNDLE or RTCP-mux rules; those are negotiated as part of the WebRTC/WHIP session. | [WHIP section 4.4 (RFC 9725)](https://www.rfc-editor.org/rfc/rfc9725.html#section-4.4), [JSEP (RFC 9429)](https://www.rfc-editor.org/rfc/rfc9429.html), and [W3C WebRTC](https://www.w3.org/TR/webrtc/). |
+
+## Deliberately non-standardized choices
+
+- **Capture source selection and encoder lifecycle:** selecting Android
+  `video-server` versus `screenrecord`, or iOS ScreenCaptureKit plus FFmpeg,
+  is a platform integration choice. Their output contract is H.264 Annex-B,
+  which is consumed at the RFC 6184 boundary.
+- **Stream IDs and the Unix socket:** reserving IDs before asynchronous start,
+  cancellation during source resolution, and bounded local framing prevent
+  daemon races and denial-of-service conditions. They do not appear on the
+  WebRTC wire.
+- **Safety limits and retries:** HTTP body limits, timeouts, packet copies, and
+  reconnect backoff make the reference server predictable. They must preserve
+  the negotiated WebRTC session semantics but are not required parameter values
+  in a WebRTC specification.
+- **Keyframe replay policy:** replaying cached SPS/PPS plus a complete IDR is
+  chosen for fast late-viewer startup. Future RTCP feedback support should be
+  documented against its own specification when it is implemented.
+
+For the architecture and operational configuration, see
+[WebRTC Screen Streaming](./webrtc-streaming.md). For a CI-worker walkthrough,
+see [Streaming a device's screen from a CI worker](../../../webrtc-streaming-ci-worker.md).

--- a/docs/design-docs/mcp/observe/webrtc-streaming.md
+++ b/docs/design-docs/mcp/observe/webrtc-streaming.md
@@ -141,7 +141,7 @@ Newline-delimited JSON request/response.
 | `AUTOMOBILE_WEBRTC_ICE_SERVERS` | Comma-separated STUN/TURN URLs, or a JSON array of `{urls,username,credential}` |
 | `AUTOMOBILE_WEBRTC_BITRATE_KBPS` | Target encoder bitrate |
 | `AUTOMOBILE_WEBRTC_MAX_SIZE` | Capture downscale, `WIDTHxHEIGHT` |
-| `AUTOMOBILE_WEBRTC_AUDIO` | Enable optional Android audio (`audio: true` per request). Requires the persistent `video-server` jar. |
+| `AUTOMOBILE_WEBRTC_AUDIO` | Enable optional audio (`audio: true` per request). Android requires the persistent `video-server` jar; iOS supports Simulator-window audio only. |
 
 Per-request fields override the environment defaults.
 

--- a/docs/design-docs/mcp/observe/webrtc-streaming.md
+++ b/docs/design-docs/mcp/observe/webrtc-streaming.md
@@ -216,13 +216,14 @@ flag reference.
 
 ## Optional audio
 
-Audio is opt-in (`AUTOMOBILE_WEBRTC_AUDIO=1` or `"audio": true`) and currently
-Android-only. The publisher adds a sendonly PCMU audio track and the Android
-`video-server` captures 8 kHz mono PCM16 from `REMOTE_SUBMIX`; the TypeScript
-publisher converts that PCM to PCMU RTP. Because `screenrecord` is video-only,
-audio-enabled streams require the persistent `automobile-video.jar` path. If the
-jar is unavailable or `REMOTE_SUBMIX` cannot initialize on the device build, the
-stream start fails instead of silently publishing video-only audio.
+Audio is opt-in (`AUTOMOBILE_WEBRTC_AUDIO=1` or `"audio": true`). The publisher
+adds a sendonly PCMU audio track. Android `video-server` captures 8 kHz mono PCM16
+from `REMOTE_SUBMIX`, while iOS Simulator-window capture uses ScreenCaptureKit;
+the TypeScript publisher converts the PCM to PCMU RTP. Because `screenrecord` is
+video-only, Android audio-enabled streams require the persistent
+`automobile-video.jar` path. If its jar is unavailable or `REMOTE_SUBMIX` cannot
+initialize on the device build, stream start fails instead of silently publishing
+video-only audio. Physical iOS playback capture is unavailable through public APIs.
 
 Android playback capture is policy-limited: some apps/usages cannot be captured,
 and `REMOTE_SUBMIX` is privileged. The reference coordination server forwards
@@ -240,9 +241,9 @@ both the H.264 and PCMU tracks to WHEP subscribers and exposes `audio` plus
   demand, so production installs use the persistent encoder by default. See
   [Persistent-encoder delivery](#persistent-encoder-delivery-automobile-videojar)
   above.
-- **Audio is Android-only and opt-in.** iOS WebRTC capture remains video-only,
-  and Android audio depends on `REMOTE_SUBMIX` availability for the shell-owned
-  `video-server` process.
+- **Audio is opt-in and platform-constrained.** iOS audio requires Simulator-window
+  capture; physical devices remain video-only. Android audio depends on
+  `REMOTE_SUBMIX` availability for the shell-owned `video-server` process.
 - **Reference server is single-process/in-memory.** Use a hardened WHIP/WHEP SFU
   (MediaMTX, LiveKit, Janus, Cloudflare) in production; the publisher is unchanged.
 - **Trickle ICE is opt-in.** By default the publisher gathers candidates before

--- a/docs/design-docs/mcp/observe/webrtc-streaming.md
+++ b/docs/design-docs/mcp/observe/webrtc-streaming.md
@@ -9,6 +9,9 @@
 > socket. A reference coordination server + browser viewer ships under
 > [`examples/webrtc-coordination-server/`](../../../../examples/webrtc-coordination-server/).
 >
+> For the WebRTC protocol choices behind this implementation, see the
+> [WebRTC standards map](./webrtc-standards-map.md).
+>
 > Live Android capture depends on `adb screenrecord` or the persistent
 > `video-server` jar on a real device/emulator; iOS capture depends on the
 > CtrlProxy screen streaming helper plus local `ffmpeg` H.264 encoding. Everything
@@ -257,9 +260,9 @@ both the H.264 and PCMU tracks to WHEP subscribers and exposes `audio` plus
 
 ## References
 
-- [WHIP — draft-ietf-wish-whip](https://datatracker.ietf.org/doc/draft-ietf-wish-whip/)
-- [WHEP — draft-ietf-wish-whep](https://datatracker.ietf.org/doc/draft-ietf-wish-whep/)
-- [RFC 6184 — RTP Payload Format for H.264 Video](https://datatracker.ietf.org/doc/html/rfc6184)
+- [WebRTC standards map](./webrtc-standards-map.md) — W3C, IETF, and ITU references mapped to AutoMobile behavior
+- [WHIP — RFC 9725](https://www.rfc-editor.org/rfc/rfc9725.html)
+- [WHEP — Internet-Draft](https://datatracker.ietf.org/doc/html/draft-ietf-wish-whep)
 - [werift-webrtc](https://github.com/shinyoshiaki/werift-webrtc)
 - [CI worker setup guide](../../../webrtc-streaming-ci-worker.md)
 - [Reference coordination server](../../../../examples/webrtc-coordination-server/README.md)

--- a/docs/webrtc-streaming-ci-worker.md
+++ b/docs/webrtc-streaming-ci-worker.md
@@ -69,8 +69,9 @@ Response:
 If multiple devices are attached, pass `"deviceId":"emulator-5554"` or the iOS
 simulator UDID. You can also override any config per call, e.g.
 `{"action":"start","whipEndpoint":"https://other/whip","bitrateKbps":2000}`.
-For audio, pass `"audio":true`; it is Android-only and requires the persistent
-`video-server` jar because `screenrecord` is video-only.
+For audio, pass `"audio":true`. Android requires the persistent `video-server`
+jar because `screenrecord` is video-only. iOS supports audio for Simulator-window
+capture through ScreenCaptureKit; physical iOS playback capture is unavailable.
 
 ### From Node / Bun
 
@@ -118,7 +119,7 @@ echo '{"action":"stop","streamId":"'"$CI_JOB_ID"'"}'  | nc -U ~/.auto-mobile/web
 
 The publisher reconnects automatically if the network blips; the browser viewer
 reconnects via the coordination server's reconnect API. Video streaming supports
-Android and iOS; optional audio is Android-only today.
+Android and iOS; optional audio works on Android and iOS Simulator windows.
 
 ## Troubleshooting
 

--- a/docs/webrtc-streaming-ci-worker.md
+++ b/docs/webrtc-streaming-ci-worker.md
@@ -34,7 +34,7 @@ export AUTOMOBILE_WEBRTC_ICE_SERVERS="stun:stun.l.google.com:19302"
 # Optional tuning:
 export AUTOMOBILE_WEBRTC_BITRATE_KBPS="4000"
 export AUTOMOBILE_WEBRTC_MAX_SIZE="720x1280"
-# Optional Android audio (requires AUTOMOBILE_VIDEO_SERVER_JAR / built video-server):
+# Optional audio: Android requires a video-server jar; iOS requires Simulator-window capture.
 export AUTOMOBILE_WEBRTC_AUDIO="1"
 ```
 

--- a/docs/webrtc-streaming-ci-worker.md
+++ b/docs/webrtc-streaming-ci-worker.md
@@ -5,7 +5,9 @@ the screen of the Android or iOS device it is driving to a coordination server
 over WebRTC, so the stream can be watched live in a browser.
 
 For the full design, see
-[WebRTC Screen Streaming](./design-docs/mcp/observe/webrtc-streaming.md).
+[WebRTC Screen Streaming](./design-docs/mcp/observe/webrtc-streaming.md), and
+for the protocol rationale, see the
+[WebRTC standards map](./design-docs/mcp/observe/webrtc-standards-map.md).
 
 ```
 CI worker (AutoMobile daemon) ──WHIP──▶ coordination server ──WHEP──▶ browser

--- a/examples/webrtc-coordination-server/README.md
+++ b/examples/webrtc-coordination-server/README.md
@@ -66,7 +66,8 @@ echo '{"action":"start","deviceId":"emulator-5554","streamId":"ci-run-42"}' \
 
 | Method & path | Purpose |
 |---------------|---------|
-| `POST /whip[?streamId=]` | WHIP ingest — body is the publisher SDP offer; returns `201` + SDP answer + `Location: /whip/{streamId}` |
+| `POST /whip[?streamId=]` | WHIP ingest — `Content-Type: application/sdp`; returns `201` + SDP answer + `Location: /whip/{streamId}` + `ETag` |
+| `PATCH /whip/{streamId}` | WHIP Trickle ICE — `Content-Type: application/trickle-ice-sdpfrag` and `If-Match: <ETag>`; returns `204` for candidates or `422` for unsupported ICE restart |
 | `DELETE /whip/{streamId}` | Terminate an ingest session |
 | `POST /whep/{streamId}` | WHEP subscribe — body is the viewer SDP offer; returns `201` + SDP answer + `Location: /whep/{streamId}/{subscriberId}` |
 | `DELETE /whep/{streamId}/{subscriberId}` | Terminate a subscriber |

--- a/examples/webrtc-coordination-server/README.md
+++ b/examples/webrtc-coordination-server/README.md
@@ -66,9 +66,9 @@ echo '{"action":"start","deviceId":"emulator-5554","streamId":"ci-run-42"}' \
 
 | Method & path | Purpose |
 |---------------|---------|
-| `POST /whip[?streamId=]` | WHIP ingest — `Content-Type: application/sdp`; returns `201` + SDP answer + `Location: /whip/{streamId}` + `ETag` |
-| `PATCH /whip/{streamId}` | WHIP Trickle ICE — `Content-Type: application/trickle-ice-sdpfrag` and `If-Match: <ETag>`; returns `204` for candidates or `422` for unsupported ICE restart |
-| `DELETE /whip/{streamId}` | Terminate an ingest session |
+| `POST /whip[?streamId=]` | WHIP ingest — `Content-Type: application/sdp`; returns `201` + SDP answer + opaque `Location: /whip/{sessionId}` + `ETag` |
+| `PATCH /whip/{sessionId}` | WHIP Trickle ICE — `Content-Type: application/trickle-ice-sdpfrag` and `If-Match: <ETag>`; returns `204` for candidates or `422` for unsupported ICE restart |
+| `DELETE /whip/{sessionId}` | Terminate that ingest session |
 | `POST /whep/{streamId}` | WHEP subscribe — body is the viewer SDP offer; returns `201` + SDP answer + `Location: /whep/{streamId}/{subscriberId}` |
 | `DELETE /whep/{streamId}/{subscriberId}` | Terminate a subscriber |
 | `GET /api/streams` | **Reconnect API** — `{ streams: StreamDescriptor[] }` |

--- a/examples/webrtc-coordination-server/coordinationServer.ts
+++ b/examples/webrtc-coordination-server/coordinationServer.ts
@@ -70,6 +70,8 @@ interface StreamEntry {
   videoConfig: RtpPacket[];
   videoKeyFrame: RtpPacket[];
   collectingKeyFrame: RtpPacket[] | null;
+  iceEtag: string;
+  iceCredentials: { ufrag: string; pwd: string };
 }
 
 export interface RtpOutboundTrack {
@@ -119,7 +121,7 @@ export class CoordinationServer {
   async ingest(
     offerSdp: string,
     requestedStreamId?: string
-  ): Promise<{ streamId: string; answerSdp: string }> {
+  ): Promise<{ streamId: string; answerSdp: string; etag: string }> {
     const streamId = requestedStreamId?.trim() || `stream-${randomUUID().slice(0, 8)}`;
 
     const pc = new RTCPeerConnection({ codecs: { video: [useH264()], audio: [usePCMU()] } });
@@ -134,6 +136,8 @@ export class CoordinationServer {
       videoConfig: [],
       videoKeyFrame: [],
       collectingKeyFrame: null,
+      iceEtag: randomUUID(),
+      iceCredentials: parseIceCredentials(offerSdp),
     };
     pc.onTrack.subscribe(track => {
       if (track.kind !== "audio" && track.kind !== "video") {
@@ -182,7 +186,7 @@ export class CoordinationServer {
       await this.stopIngest(streamId);
     }
     this.streams.set(streamId, entry);
-    return { streamId, answerSdp: pc.localDescription?.sdp ?? "" };
+    return { streamId, answerSdp: pc.localDescription?.sdp ?? "", etag: entry.iceEtag };
   }
 
   /**
@@ -286,25 +290,30 @@ export class CoordinationServer {
    * stream id is unknown so the HTTP layer can answer 404. Parses leniently: the
    * `a=mid:` line (if any) applies to the following `a=candidate:` lines.
    */
-  async addIngestCandidates(streamId: string, fragment: string): Promise<boolean> {
+  getIceEtag(streamId: string): string | null {
+    return this.streams.get(streamId)?.iceEtag ?? null;
+  }
+
+  async addIngestCandidates(streamId: string, fragment: string): Promise<"unknown" | "applied" | "invalid" | "restart"> {
     const entry = this.streams.get(streamId);
     if (!entry) {
-      return false;
+      return "unknown";
     }
-    let sdpMid: string | undefined;
-    for (const rawLine of fragment.split(/\r?\n/)) {
-      const line = rawLine.trim();
-      if (line.startsWith("a=mid:")) {
-        sdpMid = line.slice("a=mid:".length).trim() || undefined;
-      } else if (line.startsWith("a=candidate:")) {
+    const parsed = parseCandidateFragment(fragment);
+    if (!parsed) {
+      return "invalid";
+    }
+    if (parsed.ice.ufrag !== entry.iceCredentials.ufrag || parsed.ice.pwd !== entry.iceCredentials.pwd) {
+      return "restart";
+    }
+    for (const candidate of parsed.candidates) {
         await entry.ingestPc
-          .addIceCandidate({ candidate: line.slice("a=".length), sdpMid })
+          .addIceCandidate({ candidate, sdpMid: parsed.mid })
           .catch(() => {
             // A malformed or duplicate candidate is non-fatal; keep the stream up.
           });
-      }
     }
-    return true;
+    return "applied";
   }
 
   async stopSubscriber(streamId: string, subscriberId: string): Promise<void> {
@@ -371,11 +380,11 @@ function cacheVideoForLateSubscriber(entry: StreamEntry, rtp: RtpPacket): void {
   // §8 documents parameter-set transport; caching/replay is our late-viewer
   // policy, not a replacement for RTCP feedback.
   // https://www.rfc-editor.org/rfc/rfc6184.html#section-8
-  if (nalType === 7 || nalType === 8) {
+  if (nalType === 7 || nalType === 8 || containsStapANalType(payload, 7) || containsStapANalType(payload, 8)) {
     entry.videoConfig = [...entry.videoConfig.filter(packet => (packet.payload[0] & 0x1f) !== nalType), rtp.clone()];
   }
 
-  const isIdrStart = nalType === 5 || (nalType === 28 && (payload[1] & 0x80) !== 0 && (payload[1] & 0x1f) === 5);
+  const isIdrStart = nalType === 5 || (nalType === 28 && (payload[1] & 0x80) !== 0 && (payload[1] & 0x1f) === 5) || containsStapANalType(payload, 5);
   // An IDR access unit may contain several type-5 NALs (or fragmented FU-As).
   // Keep collecting until its RTP marker rather than discarding earlier slices.
   if (isIdrStart && !entry.collectingKeyFrame) {entry.collectingKeyFrame = [];}
@@ -386,6 +395,37 @@ function cacheVideoForLateSubscriber(entry: StreamEntry, rtp: RtpPacket): void {
       entry.collectingKeyFrame = null;
     }
   }
+}
+
+function containsStapANalType(payload: Buffer, expectedType: number): boolean {
+  if ((payload[0] & 0x1f) !== 24) return false;
+  let offset = 1;
+  while (offset + 2 <= payload.length) {
+    const size = payload.readUInt16BE(offset);
+    offset += 2;
+    if (size === 0 || offset + size > payload.length) return false;
+    if ((payload[offset] & 0x1f) === expectedType) return true;
+    offset += size;
+  }
+  return false;
+}
+
+function parseIceCredentials(sdp: string): { ufrag: string; pwd: string } {
+  const ufrag = sdp.match(/^a=ice-ufrag:(.+)$/m)?.[1]?.trim();
+  const pwd = sdp.match(/^a=ice-pwd:(.+)$/m)?.[1]?.trim();
+  if (!ufrag || !pwd) throw new Error("Offer omitted ICE credentials.");
+  return { ufrag, pwd };
+}
+
+function parseCandidateFragment(fragment: string): { mid: string; ice: { ufrag: string; pwd: string }; candidates: string[] } | null {
+  const lines = fragment.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+  const mLine = lines.find(line => line.startsWith("m="));
+  const mid = lines.find(line => line.startsWith("a=mid:"))?.slice(6).trim();
+  const ufrag = lines.find(line => line.startsWith("a=ice-ufrag:"))?.slice(12).trim();
+  const pwd = lines.find(line => line.startsWith("a=ice-pwd:"))?.slice(10).trim();
+  const candidates = lines.filter(line => line.startsWith("a=candidate:")).map(line => line.slice(2));
+  if (!mLine || !mid || !ufrag || !pwd || (candidates.length === 0 && !lines.includes("a=end-of-candidates"))) return null;
+  return { mid, ice: { ufrag, pwd }, candidates };
 }
 
 function replayCachedVideo(entry: StreamEntry, track: MediaStreamTrack): void {

--- a/examples/webrtc-coordination-server/coordinationServer.ts
+++ b/examples/webrtc-coordination-server/coordinationServer.ts
@@ -58,6 +58,10 @@ interface StreamEntry {
   createdAt: string;
   framesForwarded: number;
   audioPacketsForwarded: number;
+  /** Last codec config plus a complete IDR access unit for late WHEP viewers. */
+  videoConfig: RtpPacket[];
+  videoKeyFrame: RtpPacket[];
+  collectingKeyFrame: RtpPacket[] | null;
 }
 
 export interface RtpOutboundTrack {
@@ -117,6 +121,9 @@ export class CoordinationServer {
       createdAt: new Date().toISOString(),
       framesForwarded: 0,
       audioPacketsForwarded: 0,
+      videoConfig: [],
+      videoKeyFrame: [],
+      collectingKeyFrame: null,
     };
     pc.onTrack.subscribe(track => {
       if (track.kind !== "audio" && track.kind !== "video") {
@@ -126,6 +133,7 @@ export class CoordinationServer {
       track.onReceiveRtp.subscribe((rtp: RtpPacket) => {
         if (track.kind === "video") {
           entry.framesForwarded += rtp.header.marker ? 1 : 0;
+          cacheVideoForLateSubscriber(entry, rtp);
         } else {
           entry.audioPacketsForwarded++;
         }
@@ -223,6 +231,7 @@ export class CoordinationServer {
     }
 
     entry.subscribers.set(subscriberId, { id: subscriberId, pc, tracks });
+    replayCachedVideo(entry, videoTrack);
     return { subscriberId, answerSdp: pc.localDescription?.sdp ?? "" };
   }
 
@@ -317,6 +326,36 @@ export class CoordinationServer {
       );
     } catch {
       // Proceed with whatever candidates were gathered.
+    }
+  }
+}
+
+function cacheVideoForLateSubscriber(entry: StreamEntry, rtp: RtpPacket): void {
+  const payload = rtp.payload;
+  const nalType = payload[0] & 0x1f;
+  // SPS/PPS are normally single RTP packets. Preserve the most recent pair so a
+  // new decoder can configure itself before its first IDR access unit.
+  if (nalType === 7 || nalType === 8) {
+    entry.videoConfig = [...entry.videoConfig.filter(packet => (packet.payload[0] & 0x1f) !== nalType), rtp.clone()];
+  }
+
+  const isIdrStart = nalType === 5 || (nalType === 28 && (payload[1] & 0x80) !== 0 && (payload[1] & 0x1f) === 5);
+  if (isIdrStart) {entry.collectingKeyFrame = [];}
+  if (entry.collectingKeyFrame) {
+    entry.collectingKeyFrame.push(rtp.clone());
+    if (rtp.header.marker) {
+      entry.videoKeyFrame = entry.collectingKeyFrame;
+      entry.collectingKeyFrame = null;
+    }
+  }
+}
+
+function replayCachedVideo(entry: StreamEntry, track: MediaStreamTrack): void {
+  for (const packet of [...entry.videoConfig, ...entry.videoKeyFrame]) {
+    try {
+      track.writeRtp(packet.clone());
+    } catch {
+      return;
     }
   }
 }

--- a/examples/webrtc-coordination-server/coordinationServer.ts
+++ b/examples/webrtc-coordination-server/coordinationServer.ts
@@ -61,6 +61,8 @@ interface Subscriber {
 
 interface StreamEntry {
   streamId: string;
+  /** Opaque WHIP resource id; distinct from the user-visible stream id. */
+  ingestSessionId: string;
   ingestPc: RTCPeerConnection;
   inboundTracks: Map<"audio" | "video", MediaStreamTrack>;
   subscribers: Map<string, Subscriber>;
@@ -105,6 +107,7 @@ const DEFAULT_ICE_SERVERS: RTCIceServer[] = [{ urls: "stun:stun.l.google.com:193
 
 export class CoordinationServer {
   private readonly streams = new Map<string, StreamEntry>();
+  private readonly ingestSessions = new Map<string, StreamEntry>();
   private readonly iceServers: RTCIceServer[];
   private readonly iceGatheringTimeoutMs: number;
   private readonly timer: Timer;
@@ -122,7 +125,7 @@ export class CoordinationServer {
   async ingest(
     offerSdp: string,
     requestedStreamId?: string
-  ): Promise<{ streamId: string; answerSdp: string; etag: string }> {
+  ): Promise<{ streamId: string; sessionId: string; answerSdp: string; etag: string }> {
     const streamId = requestedStreamId?.trim() || `stream-${randomUUID().slice(0, 8)}`;
     // Validate before allocating a peer connection. A malformed WHIP offer must
     // fail with 4xx without leaking a native transport.
@@ -134,6 +137,7 @@ export class CoordinationServer {
     });
     const entry: StreamEntry = {
       streamId,
+      ingestSessionId: randomUUID(),
       ingestPc: pc,
       inboundTracks: new Map(),
       subscribers: new Map(),
@@ -193,8 +197,10 @@ export class CoordinationServer {
       await this.stopIngest(streamId);
     }
     this.streams.set(streamId, entry);
+    this.ingestSessions.set(entry.ingestSessionId, entry);
     return {
       streamId,
+      sessionId: entry.ingestSessionId,
       // Werift serializes rtcp-mux but not RFC 9725 / WHEP's required
       // rtcp-mux-only SDP attribute. This changes signalling only; the peer
       // connection remains RTCP-multiplexed.
@@ -294,7 +300,22 @@ export class CoordinationServer {
     if (!entry) {
       return;
     }
-    this.streams.delete(streamId);
+    await this.stopIngestEntry(entry);
+  }
+
+  /** Stop the exact WHIP resource identified by its opaque session id. */
+  async stopIngestSession(sessionId: string): Promise<void> {
+    const entry = this.ingestSessions.get(sessionId);
+    if (entry) {
+      await this.stopIngestEntry(entry);
+    }
+  }
+
+  private async stopIngestEntry(entry: StreamEntry): Promise<void> {
+    if (this.streams.get(entry.streamId) === entry) {
+      this.streams.delete(entry.streamId);
+    }
+    this.ingestSessions.delete(entry.ingestSessionId);
     for (const subscriber of entry.subscribers.values()) {
       await subscriber.pc.close().catch(() => {});
     }
@@ -307,12 +328,12 @@ export class CoordinationServer {
    * stream id is unknown so the HTTP layer can answer 404. Parses leniently: the
    * `a=mid:` line (if any) applies to the following `a=candidate:` lines.
    */
-  getIceEtag(streamId: string): string | null {
-    return this.streams.get(streamId)?.iceEtag ?? null;
+  getIceEtag(sessionId: string): string | null {
+    return this.ingestSessions.get(sessionId)?.iceEtag ?? null;
   }
 
-  async addIngestCandidates(streamId: string, fragment: string): Promise<"unknown" | "applied" | "invalid" | "restart"> {
-    const entry = this.streams.get(streamId);
+  async addIngestCandidates(sessionId: string, fragment: string): Promise<"unknown" | "applied" | "invalid" | "restart"> {
+    const entry = this.ingestSessions.get(sessionId);
     if (!entry) {
       return "unknown";
     }

--- a/examples/webrtc-coordination-server/coordinationServer.ts
+++ b/examples/webrtc-coordination-server/coordinationServer.ts
@@ -17,6 +17,11 @@ import { defaultTimer, type Timer } from "../../src/utils/SystemTimer";
  * subscriber of that stream. `listStreams()` / `getStream()` back the reconnect
  * API a frontend uses to discover streams and (re)connect.
  *
+ * WHEP reference: https://datatracker.ietf.org/doc/html/draft-ietf-wish-whep
+ * RTP forwarding and H.264 packet semantics: RFC 3550 and RFC 6184
+ * (https://www.rfc-editor.org/rfc/rfc3550.html and
+ * https://www.rfc-editor.org/rfc/rfc6184.html).
+ *
  * This is intentionally minimal (single-server, in-memory) — for production use
  * a hardened SFU such as MediaMTX, LiveKit, or Janus that also speaks WHIP/WHEP.
  */
@@ -362,7 +367,10 @@ function cacheVideoForLateSubscriber(entry: StreamEntry, rtp: RtpPacket): void {
   const payload = rtp.payload;
   const nalType = payload[0] & 0x1f;
   // SPS/PPS are normally single RTP packets. Preserve the most recent pair so a
-  // new decoder can configure itself before its first IDR access unit.
+  // new decoder can configure itself before its first IDR access unit. RFC 6184
+  // §8 documents parameter-set transport; caching/replay is our late-viewer
+  // policy, not a replacement for RTCP feedback.
+  // https://www.rfc-editor.org/rfc/rfc6184.html#section-8
   if (nalType === 7 || nalType === 8) {
     entry.videoConfig = [...entry.videoConfig.filter(packet => (packet.payload[0] & 0x1f) !== nalType), rtp.clone()];
   }

--- a/examples/webrtc-coordination-server/coordinationServer.ts
+++ b/examples/webrtc-coordination-server/coordinationServer.ts
@@ -7,6 +7,7 @@ import {
   usePCMU,
   type RTCIceServer,
 } from "werift";
+import { defaultTimer, type Timer } from "../../src/utils/SystemTimer";
 
 /**
  * Reference WebRTC coordination server (a tiny SFU).
@@ -25,6 +26,8 @@ export interface CoordinationServerOptions {
   iceServers?: RTCIceServer[];
   /** How long to wait for ICE gathering (ms) before returning an SDP answer. */
   iceGatheringTimeoutMs?: number;
+  /** Injected so delayed replay remains deterministic in tests. */
+  timer?: Timer;
 }
 
 export interface StreamDescriptor {
@@ -96,10 +99,12 @@ export class CoordinationServer {
   private readonly streams = new Map<string, StreamEntry>();
   private readonly iceServers: RTCIceServer[];
   private readonly iceGatheringTimeoutMs: number;
+  private readonly timer: Timer;
 
   constructor(options: CoordinationServerOptions = {}) {
     this.iceServers = options.iceServers ?? DEFAULT_ICE_SERVERS;
     this.iceGatheringTimeoutMs = options.iceGatheringTimeoutMs ?? 5000;
+    this.timer = options.timer ?? defaultTimer;
   }
 
   /**
@@ -200,8 +205,26 @@ export class CoordinationServer {
     }
 
     const subscriberId = randomUUID();
+    let replayedCachedVideo = false;
+    const replayWhenConnected = (): void => {
+      if (replayedCachedVideo || entry.subscribers.get(subscriberId)?.pc !== pc) {
+        return;
+      }
+      replayedCachedVideo = true;
+      replayCachedVideo(entry, videoTrack);
+    };
+    const scheduleReplayWhenConnected = (): void => {
+      // werift exposes `connected` before the remote WHEP peer has necessarily
+      // installed the returned answer. Give the paired transport a short turn
+      // to finish its sender/receiver bookkeeping before replaying cached RTP.
+      this.timer.setTimeout(replayWhenConnected, 100);
+    };
 
     pc.connectionStateChange.subscribe(state => {
+      if (state === "connected") {
+        scheduleReplayWhenConnected();
+        return;
+      }
       if (state === "failed" || state === "closed" || state === "disconnected") {
         entry.subscribers.delete(subscriberId);
         void pc.close().catch(() => {});
@@ -231,7 +254,12 @@ export class CoordinationServer {
     }
 
     entry.subscribers.set(subscriberId, { id: subscriberId, pc, tracks });
-    replayCachedVideo(entry, videoTrack);
+    // WHEP returns the answer before the browser can complete DTLS. Writing
+    // before this connection is live is dropped by werift, so replay after the
+    // connected transition (or immediately if it raced before registration).
+    if (pc.connectionState === "connected") {
+      scheduleReplayWhenConnected();
+    }
     return { subscriberId, answerSdp: pc.localDescription?.sdp ?? "" };
   }
 
@@ -340,7 +368,9 @@ function cacheVideoForLateSubscriber(entry: StreamEntry, rtp: RtpPacket): void {
   }
 
   const isIdrStart = nalType === 5 || (nalType === 28 && (payload[1] & 0x80) !== 0 && (payload[1] & 0x1f) === 5);
-  if (isIdrStart) {entry.collectingKeyFrame = [];}
+  // An IDR access unit may contain several type-5 NALs (or fragmented FU-As).
+  // Keep collecting until its RTP marker rather than discarding earlier slices.
+  if (isIdrStart && !entry.collectingKeyFrame) {entry.collectingKeyFrame = [];}
   if (entry.collectingKeyFrame) {
     entry.collectingKeyFrame.push(rtp.clone());
     if (rtp.header.marker) {

--- a/examples/webrtc-coordination-server/coordinationServer.ts
+++ b/examples/webrtc-coordination-server/coordinationServer.ts
@@ -7,6 +7,7 @@ import {
   usePCMU,
   type RTCIceServer,
 } from "werift";
+import { WEBRTC_H264_PROFILE_LEVEL_ID } from "../../src/features/webrtc/h264Level";
 import { defaultTimer, type Timer } from "../../src/utils/SystemTimer";
 
 /**
@@ -129,7 +130,7 @@ export class CoordinationServer {
 
     const pc = new RTCPeerConnection({
       bundlePolicy: "max-bundle",
-      codecs: { video: [useH264()], audio: [usePCMU()] },
+      codecs: { video: [useH264({ parameters: `profile-level-id=${WEBRTC_H264_PROFILE_LEVEL_ID};packetization-mode=1;level-asymmetry-allowed=1` })], audio: [usePCMU()] },
     });
     const entry: StreamEntry = {
       streamId,
@@ -217,7 +218,7 @@ export class CoordinationServer {
 
     const pc = new RTCPeerConnection({
       bundlePolicy: "max-bundle",
-      codecs: { video: [useH264()], audio: [usePCMU()] },
+      codecs: { video: [useH264({ parameters: `profile-level-id=${WEBRTC_H264_PROFILE_LEVEL_ID};packetization-mode=1;level-asymmetry-allowed=1` })], audio: [usePCMU()] },
     });
     const tracks = new Map<"audio" | "video", MediaStreamTrack>();
     const videoTrack = new MediaStreamTrack({ kind: "video" });

--- a/examples/webrtc-coordination-server/coordinationServer.ts
+++ b/examples/webrtc-coordination-server/coordinationServer.ts
@@ -123,8 +123,14 @@ export class CoordinationServer {
     requestedStreamId?: string
   ): Promise<{ streamId: string; answerSdp: string; etag: string }> {
     const streamId = requestedStreamId?.trim() || `stream-${randomUUID().slice(0, 8)}`;
+    // Validate before allocating a peer connection. A malformed WHIP offer must
+    // fail with 4xx without leaking a native transport.
+    const iceCredentials = parseIceCredentials(offerSdp);
 
-    const pc = new RTCPeerConnection({ codecs: { video: [useH264()], audio: [usePCMU()] } });
+    const pc = new RTCPeerConnection({
+      bundlePolicy: "max-bundle",
+      codecs: { video: [useH264()], audio: [usePCMU()] },
+    });
     const entry: StreamEntry = {
       streamId,
       ingestPc: pc,
@@ -137,7 +143,7 @@ export class CoordinationServer {
       videoKeyFrame: [],
       collectingKeyFrame: null,
       iceEtag: randomUUID(),
-      iceCredentials: parseIceCredentials(offerSdp),
+      iceCredentials,
     };
     pc.onTrack.subscribe(track => {
       if (track.kind !== "audio" && track.kind !== "video") {
@@ -186,7 +192,14 @@ export class CoordinationServer {
       await this.stopIngest(streamId);
     }
     this.streams.set(streamId, entry);
-    return { streamId, answerSdp: pc.localDescription?.sdp ?? "", etag: entry.iceEtag };
+    return {
+      streamId,
+      // Werift serializes rtcp-mux but not RFC 9725 / WHEP's required
+      // rtcp-mux-only SDP attribute. This changes signalling only; the peer
+      // connection remains RTCP-multiplexed.
+      answerSdp: addRtcpMuxOnly(pc.localDescription?.sdp ?? ""),
+      etag: entry.iceEtag,
+    };
   }
 
   /**
@@ -202,7 +215,10 @@ export class CoordinationServer {
       throw new Error(`No such stream: ${streamId}`);
     }
 
-    const pc = new RTCPeerConnection({ codecs: { video: [useH264()], audio: [usePCMU()] } });
+    const pc = new RTCPeerConnection({
+      bundlePolicy: "max-bundle",
+      codecs: { video: [useH264()], audio: [usePCMU()] },
+    });
     const tracks = new Map<"audio" | "video", MediaStreamTrack>();
     const videoTrack = new MediaStreamTrack({ kind: "video" });
     tracks.set("video", videoTrack);
@@ -269,7 +285,7 @@ export class CoordinationServer {
     if (pc.connectionState === "connected") {
       scheduleReplayWhenConnected();
     }
-    return { subscriberId, answerSdp: pc.localDescription?.sdp ?? "" };
+    return { subscriberId, answerSdp: addRtcpMuxOnly(pc.localDescription?.sdp ?? "") };
   }
 
   async stopIngest(streamId: string): Promise<void> {
@@ -307,11 +323,11 @@ export class CoordinationServer {
       return "restart";
     }
     for (const candidate of parsed.candidates) {
-        await entry.ingestPc
-          .addIceCandidate({ candidate, sdpMid: parsed.mid })
-          .catch(() => {
-            // A malformed or duplicate candidate is non-fatal; keep the stream up.
-          });
+      await entry.ingestPc
+        .addIceCandidate({ candidate, sdpMid: parsed.mid })
+        .catch(() => {
+          // A malformed or duplicate candidate is non-fatal; keep the stream up.
+        });
     }
     return "applied";
   }
@@ -372,6 +388,10 @@ export class CoordinationServer {
   }
 }
 
+function addRtcpMuxOnly(sdp: string): string {
+  return sdp.replace(/a=rtcp-mux\r?\n/g, match => `${match}a=rtcp-mux-only\r\n`);
+}
+
 function cacheVideoForLateSubscriber(entry: StreamEntry, rtp: RtpPacket): void {
   const payload = rtp.payload;
   const nalType = payload[0] & 0x1f;
@@ -398,13 +418,13 @@ function cacheVideoForLateSubscriber(entry: StreamEntry, rtp: RtpPacket): void {
 }
 
 function containsStapANalType(payload: Buffer, expectedType: number): boolean {
-  if ((payload[0] & 0x1f) !== 24) return false;
+  if ((payload[0] & 0x1f) !== 24) {return false;}
   let offset = 1;
   while (offset + 2 <= payload.length) {
     const size = payload.readUInt16BE(offset);
     offset += 2;
-    if (size === 0 || offset + size > payload.length) return false;
-    if ((payload[offset] & 0x1f) === expectedType) return true;
+    if (size === 0 || offset + size > payload.length) {return false;}
+    if ((payload[offset] & 0x1f) === expectedType) {return true;}
     offset += size;
   }
   return false;
@@ -413,7 +433,7 @@ function containsStapANalType(payload: Buffer, expectedType: number): boolean {
 function parseIceCredentials(sdp: string): { ufrag: string; pwd: string } {
   const ufrag = sdp.match(/^a=ice-ufrag:(.+)$/m)?.[1]?.trim();
   const pwd = sdp.match(/^a=ice-pwd:(.+)$/m)?.[1]?.trim();
-  if (!ufrag || !pwd) throw new Error("Offer omitted ICE credentials.");
+  if (!ufrag || !pwd) {throw new Error("Offer omitted ICE credentials.");}
   return { ufrag, pwd };
 }
 
@@ -424,7 +444,7 @@ function parseCandidateFragment(fragment: string): { mid: string; ice: { ufrag: 
   const ufrag = lines.find(line => line.startsWith("a=ice-ufrag:"))?.slice(12).trim();
   const pwd = lines.find(line => line.startsWith("a=ice-pwd:"))?.slice(10).trim();
   const candidates = lines.filter(line => line.startsWith("a=candidate:")).map(line => line.slice(2));
-  if (!mLine || !mid || !ufrag || !pwd || (candidates.length === 0 && !lines.includes("a=end-of-candidates"))) return null;
+  if (!mLine || !mid || !ufrag || !pwd || (candidates.length === 0 && !lines.includes("a=end-of-candidates"))) {return null;}
   return { mid, ice: { ufrag, pwd }, candidates };
 }
 

--- a/examples/webrtc-coordination-server/coordinationServer.ts
+++ b/examples/webrtc-coordination-server/coordinationServer.ts
@@ -57,6 +57,7 @@ interface Subscriber {
   id: string;
   pc: RTCPeerConnection;
   tracks: Map<"audio" | "video", MediaStreamTrack>;
+  ready: boolean;
 }
 
 interface StreamEntry {
@@ -73,6 +74,7 @@ interface StreamEntry {
   videoConfig: RtpPacket[];
   videoKeyFrame: RtpPacket[];
   collectingKeyFrame: RtpPacket[] | null;
+  collectingKeyFrameTimestamp: number | null;
   iceEtag: string;
   iceCredentials: { ufrag: string; pwd: string };
 }
@@ -96,6 +98,9 @@ function* outboundTracksFor(
   kind: "audio" | "video"
 ): Iterable<RtpOutboundTrack> {
   for (const subscriber of subscribers) {
+    if (kind === "video" && !subscriber.ready) {
+      continue;
+    }
     const outbound = subscriber.tracks.get(kind);
     if (outbound) {
       yield outbound;
@@ -147,6 +152,7 @@ export class CoordinationServer {
       videoConfig: [],
       videoKeyFrame: [],
       collectingKeyFrame: null,
+      collectingKeyFrameTimestamp: null,
       iceEtag: randomUUID(),
       iceCredentials,
     };
@@ -239,11 +245,15 @@ export class CoordinationServer {
     const subscriberId = randomUUID();
     let replayedCachedVideo = false;
     const replayWhenConnected = (): void => {
-      if (replayedCachedVideo || entry.subscribers.get(subscriberId)?.pc !== pc) {
+      const subscriber = entry.subscribers.get(subscriberId);
+      if (replayedCachedVideo || subscriber?.pc !== pc) {
         return;
       }
       replayedCachedVideo = true;
       replayCachedVideo(entry, videoTrack);
+      // Do not forward newer live RTP before the cached SPS/PPS + IDR has been
+      // written, otherwise its older sequence numbers can be discarded.
+      subscriber.ready = true;
     };
     const scheduleReplayWhenConnected = (): void => {
       // werift exposes `connected` before the remote WHEP peer has necessarily
@@ -285,7 +295,7 @@ export class CoordinationServer {
       throw new Error(`Stream ${streamId} is no longer available`);
     }
 
-    entry.subscribers.set(subscriberId, { id: subscriberId, pc, tracks });
+    entry.subscribers.set(subscriberId, { id: subscriberId, pc, tracks, ready: false });
     // WHEP returns the answer before the browser can complete DTLS. Writing
     // before this connection is live is dropped by werift, so replay after the
     // connected transition (or immediately if it raced before registration).
@@ -429,12 +439,16 @@ function cacheVideoForLateSubscriber(entry: StreamEntry, rtp: RtpPacket): void {
   const isIdrStart = nalType === 5 || (nalType === 28 && (payload[1] & 0x80) !== 0 && (payload[1] & 0x1f) === 5) || containsStapANalType(payload, 5);
   // An IDR access unit may contain several type-5 NALs (or fragmented FU-As).
   // Keep collecting until its RTP marker rather than discarding earlier slices.
-  if (isIdrStart && !entry.collectingKeyFrame) {entry.collectingKeyFrame = [];}
+  if (isIdrStart && (!entry.collectingKeyFrame || entry.collectingKeyFrameTimestamp !== rtp.header.timestamp)) {
+    entry.collectingKeyFrame = [];
+    entry.collectingKeyFrameTimestamp = rtp.header.timestamp;
+  }
   if (entry.collectingKeyFrame) {
     entry.collectingKeyFrame.push(rtp.clone());
     if (rtp.header.marker) {
       entry.videoKeyFrame = entry.collectingKeyFrame;
       entry.collectingKeyFrame = null;
+      entry.collectingKeyFrameTimestamp = null;
     }
   }
 }

--- a/examples/webrtc-coordination-server/httpServer.ts
+++ b/examples/webrtc-coordination-server/httpServer.ts
@@ -24,6 +24,7 @@ class InvalidSdpError extends Error {}
  *
  * Routes:
  *   POST   /whip[?streamId=]         WHIP ingest (from AutoMobile)   -> 201 + Location
+ *   PATCH  /whip/:streamId           conditional Trickle-ICE candidate update
  *   DELETE /whip/:streamId           terminate ingest
  *   POST   /whep/:streamId           WHEP subscribe (from browser)   -> 201 + Location
  *   DELETE /whep/:streamId/:subId    terminate subscriber
@@ -80,7 +81,7 @@ export class HttpCoordinationServer {
     this.applyCors(res);
 
     if (method === "OPTIONS") {
-      res.writeHead(204).end();
+      res.writeHead(200, { "Accept-Post": "application/sdp" }).end();
       return;
     }
 
@@ -230,7 +231,10 @@ export class HttpCoordinationServer {
   private applyCors(res: ServerResponse): void {
     res.setHeader("Access-Control-Allow-Origin", "*");
     res.setHeader("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS");
-    res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+    res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization, If-Match");
+    // Browsers otherwise hide the WHIP session URL and entity-tag needed for
+    // conditional Trickle-ICE PATCH requests.
+    res.setHeader("Access-Control-Expose-Headers", "Location, ETag");
   }
 
   private sendJson(res: ServerResponse, status: number, body: unknown): void {

--- a/examples/webrtc-coordination-server/httpServer.ts
+++ b/examples/webrtc-coordination-server/httpServer.ts
@@ -24,8 +24,8 @@ class InvalidSdpError extends Error {}
  *
  * Routes:
  *   POST   /whip[?streamId=]         WHIP ingest (from AutoMobile)   -> 201 + Location
- *   PATCH  /whip/:streamId           conditional Trickle-ICE candidate update
- *   DELETE /whip/:streamId           terminate ingest
+ *   PATCH  /whip/:sessionId          conditional Trickle-ICE candidate update
+ *   DELETE /whip/:sessionId          terminate ingest
  *   POST   /whep/:streamId           WHEP subscribe (from browser)   -> 201 + Location
  *   DELETE /whep/:streamId/:subId    terminate subscriber
  *   GET    /api/streams              reconnect API: list streams
@@ -118,7 +118,7 @@ export class HttpCoordinationServer {
       }
       assertContentType(req, "application/sdp");
       const offer = await readBody(req);
-      let ingest: { streamId: string; answerSdp: string; etag: string };
+      let ingest: { streamId: string; sessionId: string; answerSdp: string; etag: string };
       try {
         ingest = await this.coordinator.ingest(offer, url.searchParams.get("streamId") ?? undefined);
       } catch {
@@ -126,7 +126,7 @@ export class HttpCoordinationServer {
       }
       res.writeHead(201, {
         "Content-Type": "application/sdp",
-        "Location": `/whip/${encodeURIComponent(ingest.streamId)}`,
+        "Location": `/whip/${encodeURIComponent(ingest.sessionId)}`,
         "ETag": `\"${ingest.etag}\"`,
       });
       res.end(ingest.answerSdp);
@@ -142,8 +142,8 @@ export class HttpCoordinationServer {
       assertContentType(req, "application/trickle-ice-sdpfrag");
       const ifMatch = req.headers["if-match"];
       if (typeof ifMatch !== "string") { res.writeHead(428).end(); return; }
-      const streamId = decodeURIComponent(whipPatchMatch[1]);
-      const etag = this.coordinator.getIceEtag(streamId);
+      const sessionId = decodeURIComponent(whipPatchMatch[1]);
+      const etag = this.coordinator.getIceEtag(sessionId);
       if (!etag) { res.writeHead(404).end(); return; }
       // RFC 9725 §4.3.3 requires `If-Match: *` for an ICE restart. Let that
       // reach the fragment parser so this Trickle-only server can return its
@@ -151,7 +151,7 @@ export class HttpCoordinationServer {
       if (ifMatch !== "*" && ifMatch !== `\"${etag}\"`) { res.writeHead(412).end(); return; }
       const fragment = await readBody(req);
       const applied = await this.coordinator.addIngestCandidates(
-        streamId,
+        sessionId,
         fragment
       );
       res.writeHead(applied === "applied" ? 204 : applied === "restart" ? 422 : applied === "invalid" ? 400 : 404).end();
@@ -165,7 +165,7 @@ export class HttpCoordinationServer {
         res.writeHead(401).end("Unauthorized");
         return;
       }
-      await this.coordinator.stopIngest(decodeURIComponent(whipDeleteMatch[1]));
+      await this.coordinator.stopIngestSession(decodeURIComponent(whipDeleteMatch[1]));
       res.writeHead(200).end();
       return;
     }

--- a/examples/webrtc-coordination-server/httpServer.ts
+++ b/examples/webrtc-coordination-server/httpServer.ts
@@ -9,6 +9,9 @@ export interface HttpCoordinationServerOptions extends CoordinationServerOptions
 }
 
 const VIEWER_HTML_PATH = join(import.meta.dir ?? __dirname, "viewer.html");
+const MAX_SDP_BODY_BYTES = 1_000_000;
+
+class RequestBodyTooLargeError extends Error {}
 
 /**
  * HTTP/WHIP/WHEP front end for {@link CoordinationServer}.
@@ -32,6 +35,10 @@ export class HttpCoordinationServer {
     this.ingestToken = options.ingestToken;
     this.server = createServer((req, res) => {
       this.handle(req, res).catch(error => {
+        if (error instanceof RequestBodyTooLargeError) {
+          res.writeHead(413).end("request body too large");
+          return;
+        }
         // Log the detail server-side; never expose error/stack text to the client.
         console.error("[coordination-server] request error:", error);
         this.sendJson(res, 500, { error: "internal server error" });
@@ -40,8 +47,10 @@ export class HttpCoordinationServer {
   }
 
   listen(port: number, host = "0.0.0.0"): Promise<number> {
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
+      this.server.once("error", reject);
       this.server.listen(port, host, () => {
+        this.server.off("error", reject);
         const address = this.server.address();
         const boundPort = typeof address === "object" && address ? address.port : port;
         resolve(boundPort);
@@ -199,11 +208,20 @@ export class HttpCoordinationServer {
 
 function readBody(req: IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
-    let data = "";
+    const chunks: Buffer[] = [];
+    let size = 0;
     req.on("data", chunk => {
-      data += chunk;
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      size += buffer.length;
+      if (size > MAX_SDP_BODY_BYTES) {
+        reject(new RequestBodyTooLargeError());
+        req.removeAllListeners("data");
+        req.resume();
+        return;
+      }
+      chunks.push(buffer);
     });
-    req.on("end", () => resolve(data));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
     req.on("error", reject);
   });
 }

--- a/examples/webrtc-coordination-server/httpServer.ts
+++ b/examples/webrtc-coordination-server/httpServer.ts
@@ -145,7 +145,10 @@ export class HttpCoordinationServer {
       const streamId = decodeURIComponent(whipPatchMatch[1]);
       const etag = this.coordinator.getIceEtag(streamId);
       if (!etag) { res.writeHead(404).end(); return; }
-      if (ifMatch !== `\"${etag}\"`) { res.writeHead(412).end(); return; }
+      // RFC 9725 §4.3.3 requires `If-Match: *` for an ICE restart. Let that
+      // reach the fragment parser so this Trickle-only server can return its
+      // required 422 response for unsupported restarts instead of 412.
+      if (ifMatch !== "*" && ifMatch !== `\"${etag}\"`) { res.writeHead(412).end(); return; }
       const fragment = await readBody(req);
       const applied = await this.coordinator.addIngestCandidates(
         streamId,

--- a/examples/webrtc-coordination-server/httpServer.ts
+++ b/examples/webrtc-coordination-server/httpServer.ts
@@ -12,6 +12,7 @@ const VIEWER_HTML_PATH = join(import.meta.dir ?? __dirname, "viewer.html");
 const MAX_SDP_BODY_BYTES = 1_000_000;
 
 class RequestBodyTooLargeError extends Error {}
+class InvalidSdpError extends Error {}
 
 /**
  * HTTP/WHIP/WHEP front end for {@link CoordinationServer}.
@@ -42,6 +43,10 @@ export class HttpCoordinationServer {
       this.handle(req, res).catch(error => {
         if (error instanceof RequestBodyTooLargeError) {
           res.writeHead(413).end("request body too large");
+          return;
+        }
+        if (error instanceof InvalidSdpError) {
+          res.writeHead(400).end("invalid SDP");
           return;
         }
         // Log the detail server-side; never expose error/stack text to the client.
@@ -79,6 +84,15 @@ export class HttpCoordinationServer {
       return;
     }
 
+    if (method === "GET" && (path === "/whip" || path === "/whep" || /^\/(whip|whep)\/[^/]+$/.test(path) || /^\/whep\/[^/]+\/[^/]+$/.test(path))) {
+      res.writeHead(204).end();
+      return;
+    }
+    if (method === "HEAD" && /^\/whep\/[^/]+$/.test(path)) {
+      res.writeHead(200, { "Content-Type": "application/sdp" }).end();
+      return;
+    }
+
     // Reconnect API ---------------------------------------------------------
     if (method === "GET" && path === "/api/streams") {
       this.sendJson(res, 200, { streams: this.coordinator.listStreams() });
@@ -101,16 +115,20 @@ export class HttpCoordinationServer {
         res.writeHead(401).end("Unauthorized");
         return;
       }
+      assertContentType(req, "application/sdp");
       const offer = await readBody(req);
-      const { streamId, answerSdp } = await this.coordinator.ingest(
-        offer,
-        url.searchParams.get("streamId") ?? undefined
-      );
+      let ingest: { streamId: string; answerSdp: string; etag: string };
+      try {
+        ingest = await this.coordinator.ingest(offer, url.searchParams.get("streamId") ?? undefined);
+      } catch {
+        throw new InvalidSdpError();
+      }
       res.writeHead(201, {
         "Content-Type": "application/sdp",
-        "Location": `/whip/${encodeURIComponent(streamId)}`,
+        "Location": `/whip/${encodeURIComponent(ingest.streamId)}`,
+        "ETag": `\"${ingest.etag}\"`,
       });
-      res.end(answerSdp);
+      res.end(ingest.answerSdp);
       return;
     }
     // WHIP trickle ICE: incremental candidates from the publisher --------------
@@ -120,13 +138,19 @@ export class HttpCoordinationServer {
         res.writeHead(401).end("Unauthorized");
         return;
       }
+      assertContentType(req, "application/trickle-ice-sdpfrag");
+      const ifMatch = req.headers["if-match"];
+      if (typeof ifMatch !== "string") { res.writeHead(428).end(); return; }
+      const streamId = decodeURIComponent(whipPatchMatch[1]);
+      const etag = this.coordinator.getIceEtag(streamId);
+      if (!etag) { res.writeHead(404).end(); return; }
+      if (ifMatch !== `\"${etag}\"`) { res.writeHead(412).end(); return; }
       const fragment = await readBody(req);
       const applied = await this.coordinator.addIngestCandidates(
-        decodeURIComponent(whipPatchMatch[1]),
+        streamId,
         fragment
       );
-      // 204 on success; 404 if the stream id is unknown (stale resource).
-      res.writeHead(applied ? 204 : 404).end();
+      res.writeHead(applied === "applied" ? 204 : applied === "restart" ? 422 : applied === "invalid" ? 400 : 404).end();
       return;
     }
     const whipDeleteMatch = /^\/whip\/([^/]+)$/.exec(path);
@@ -146,6 +170,10 @@ export class HttpCoordinationServer {
     const whepMatch = /^\/whep\/([^/]+)$/.exec(path);
     if (method === "POST" && whepMatch) {
       const streamId = decodeURIComponent(whepMatch[1]);
+      if (!hasContentType(req, "application/sdp")) {
+        res.writeHead(415).end("unsupported SDP media type");
+        return;
+      }
       const offer = await readBody(req);
       try {
         const { subscriberId, answerSdp } = await this.coordinator.subscribe(streamId, offer);
@@ -209,6 +237,16 @@ export class HttpCoordinationServer {
     res.writeHead(status, { "Content-Type": "application/json" });
     res.end(JSON.stringify(body));
   }
+}
+
+function assertContentType(req: IncomingMessage, expected: string): void {
+  if (!hasContentType(req, expected)) {
+    throw new InvalidSdpError();
+  }
+}
+
+function hasContentType(req: IncomingMessage, expected: string): boolean {
+  return req.headers["content-type"]?.split(";", 1)[0]?.trim().toLowerCase() === expected;
 }
 
 function readBody(req: IncomingMessage): Promise<string> {

--- a/examples/webrtc-coordination-server/httpServer.ts
+++ b/examples/webrtc-coordination-server/httpServer.ts
@@ -16,6 +16,11 @@ class RequestBodyTooLargeError extends Error {}
 /**
  * HTTP/WHIP/WHEP front end for {@link CoordinationServer}.
  *
+ * WHIP setup, resource `Location`, DELETE, trickle PATCH, and bearer auth are
+ * implemented from RFC 9725: https://www.rfc-editor.org/rfc/rfc9725.html.
+ * WHEP remains an Internet-Draft:
+ * https://datatracker.ietf.org/doc/html/draft-ietf-wish-whep
+ *
  * Routes:
  *   POST   /whip[?streamId=]         WHIP ingest (from AutoMobile)   -> 201 + Location
  *   DELETE /whip/:streamId           terminate ingest

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/DeviceCaptureSession.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/DeviceCaptureSession.swift
@@ -9,33 +9,102 @@ final class DeviceCaptureSession: NSObject, AVCaptureVideoDataOutputSampleBuffer
     private let session = AVCaptureSession()
     private let output = AVCaptureVideoDataOutput()
     private let writer: FrameWriter
+    private let onFatalError: (Error) -> Void
     private let queue = DispatchQueue(label: "automobile.screen-capture.frames")
+    private var observers: [NSObjectProtocol] = []
+    private var stopping = false
 
-    init(writer: FrameWriter) {
+    init(writer: FrameWriter, onFatalError: @escaping (Error) -> Void) {
         self.writer = writer
+        self.onFatalError = onFatalError
+    }
+
+    deinit {
+        removeObservers()
     }
 
     func start(device: AVCaptureDevice) throws {
         let input = try AVCaptureDeviceInput(device: device)
 
         session.beginConfiguration()
-        if session.canAddInput(input) {
-            session.addInput(input)
+        guard session.canAddInput(input) else {
+            session.commitConfiguration()
+            throw CaptureError.couldNotAddInput
         }
+        session.addInput(input)
         output.alwaysDiscardsLateVideoFrames = true
         output.videoSettings = [
             kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA
         ]
         output.setSampleBufferDelegate(self, queue: queue)
-        if session.canAddOutput(output) {
-            session.addOutput(output)
+        guard session.canAddOutput(output) else {
+            session.commitConfiguration()
+            throw CaptureError.couldNotAddOutput
         }
+        session.addOutput(output)
         session.commitConfiguration()
+        installObservers()
         session.startRunning()
+        guard session.isRunning else {
+            throw CaptureError.didNotStart
+        }
     }
 
     func stop() {
+        stopping = true
+        removeObservers()
         session.stopRunning()
+    }
+
+    private func installObservers() {
+        let center = NotificationCenter.default
+        observers = [
+            center.addObserver(
+                forName: AVCaptureSession.runtimeErrorNotification,
+                object: session,
+                queue: .main
+            ) { [weak self] notification in
+                let error = notification.userInfo?[AVCaptureSessionErrorKey] as? Error
+                    ?? CaptureError.runtimeFailure
+                self?.reportFatal(error)
+            },
+            center.addObserver(
+                forName: AVCaptureSession.wasInterruptedNotification,
+                object: session,
+                queue: .main
+            ) { [weak self] _ in
+                self?.reportFatal(CaptureError.interrupted)
+            },
+        ]
+    }
+
+    private func removeObservers() {
+        let center = NotificationCenter.default
+        observers.forEach(center.removeObserver)
+        observers = []
+    }
+
+    private func reportFatal(_ error: Error) {
+        guard !stopping else { return }
+        onFatalError(error)
+    }
+
+    private enum CaptureError: LocalizedError {
+        case couldNotAddInput
+        case couldNotAddOutput
+        case didNotStart
+        case runtimeFailure
+        case interrupted
+
+        var errorDescription: String? {
+            switch self {
+            case .couldNotAddInput: return "Unable to add the iOS capture input."
+            case .couldNotAddOutput: return "Unable to add the iOS capture output."
+            case .didNotStart: return "The iOS capture session did not start."
+            case .runtimeFailure: return "The iOS capture session reported a runtime failure."
+            case .interrupted: return "The iOS capture session was interrupted."
+            }
+        }
     }
 
     func captureOutput(

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
@@ -10,6 +10,7 @@ import ScreenCaptureCore
 /// reconfiguration so frames don't get cropped.
 final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate {
     private let writer: FrameWriter
+    private let onFatalError: (Error) -> Void
     private let queue = DispatchQueue(label: "automobile.simulator-capture.frames")
     private var stream: SCStream?
     private var configuredPixelWidth: Int = 0
@@ -18,8 +19,9 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
     private var fps: Int = CommandLineOptions.defaultSimulatorFPS
     private var audioEnabled = false
 
-    init(writer: FrameWriter) {
+    init(writer: FrameWriter, onFatalError: @escaping (Error) -> Void) {
         self.writer = writer
+        self.onFatalError = onFatalError
     }
 
     func start(window: SCWindow, fps: Int, audio: Bool) async throws {
@@ -90,9 +92,7 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
     // MARK: - SCStreamDelegate
 
     func stream(_ stream: SCStream, didStopWithError error: Error) {
-        FileHandle.standardError.write(
-            Data("error: ScreenCaptureKit stream stopped: \(error)\n".utf8)
-        )
+        onFatalError(error)
     }
 
     // MARK: - Internals

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
@@ -106,7 +106,9 @@ case .captureSimulator(let windowID, let fps, let audio):
 
     let sink = FileHandleFrameSink(handle: .standardOutput)
     let writer = FrameWriter(sink: sink)
-    let simSession = SimulatorCaptureSession(writer: writer)
+    let simSession = SimulatorCaptureSession(writer: writer) { error in
+        logError("error: ScreenCaptureKit stream stopped: \(error)")
+    }
 
     if case .failure(let error) = runBlocking({
         try await simSession.start(window: window, fps: fps, audio: audio)
@@ -157,7 +159,9 @@ case .capture(let deviceID):
 
     let sink = FileHandleFrameSink(handle: .standardOutput)
     let writer = FrameWriter(sink: sink)
-    let captureSession = DeviceCaptureSession(writer: writer)
+    let captureSession = DeviceCaptureSession(writer: writer) { error in
+        logError("error: iOS device capture failed: \(error)")
+    }
 
     do {
         try captureSession.start(device: device)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
              - 'Appearance Sync': design-docs/mcp/observe/appearance.md
              - 'Screen Streaming': design-docs/mcp/observe/screen-streaming.md
              - 'WebRTC Streaming (WHIP)': design-docs/mcp/observe/webrtc-streaming.md
+             - 'WebRTC Standards Map': design-docs/mcp/observe/webrtc-standards-map.md
              - 'iOS WebRTC Streaming': design-docs/mcp/observe/ios-webrtc-streaming.md
              - 'Video Recording': design-docs/mcp/observe/video-recording.md
              - 'Vision Fallback': design-docs/mcp/observe/vision-fallback.md

--- a/src/daemon/videoStreamSocketServer.ts
+++ b/src/daemon/videoStreamSocketServer.ts
@@ -8,14 +8,13 @@ import { resolveVideoServerJar } from "../features/webrtc/videoServerJar";
 import type { BootedDevice } from "../models";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
 import type { H264CaptureSource } from "../features/webrtc/H264CaptureSource";
+import { H264AnnexBParser, nalUnitType, NAL_TYPE_IDR, NAL_TYPE_PPS, NAL_TYPE_SPS } from "../features/webrtc/h264";
 import { VIDEO_STREAM_SOCKET_CONFIG } from "./daemonFiles";
 import { BaseSocketServer, getSocketPath } from "./socketServer/index";
 import {
   encodePacket,
   encodePtsAndFlags,
   encodeStreamHeader,
-  isKeyFrameChunk,
-  isParameterSetChunk,
 } from "./videoStreamFraming";
 import type { VideoStreamSocketRequest, VideoStreamSocketResponse } from "./videoStreamSocketTypes";
 
@@ -39,12 +38,19 @@ export interface VideoStreamSocketServerDependencies {
 interface DeviceCapture {
   source: H264CaptureSource | null;
   subscribers: Set<Socket>;
+  backpressuredSubscribers: Set<Socket>;
+  waitingForKeyFrame: Set<Socket>;
   /**
    * Most recent parameter sets (SPS/PPS). A client that joins mid-stream cannot decode until it
    * sees these, and the encoder only re-emits them on key frames.
    */
-  parameterSets: Buffer | null;
+  sps: Buffer | null;
+  pps: Buffer | null;
+  parser: H264AnnexBParser;
+  size?: { width: number; height: number };
 }
+
+const ANNEX_B_START_CODE = Buffer.from([0, 0, 0, 1]);
 
 /**
  * Relays a device's live H.264 stream to local clients over `~/.auto-mobile/video-stream.sock`.
@@ -137,18 +143,11 @@ export class VideoStreamSocketServer extends BaseSocketServer {
         framing: "h264",
       } satisfies VideoStreamSocketResponse);
 
-      socket.write(encodeStreamHeader(request.size?.width ?? 0, request.size?.height ?? 0));
+      socket.write(encodeStreamHeader(capture.size?.width ?? 0, capture.size?.height ?? 0));
 
       // Replay the parameter sets so a late joiner can decode immediately instead of waiting for
       // the encoder's next key frame.
-      if (capture.parameterSets) {
-        socket.write(
-          encodePacket(
-            encodePtsAndFlags(this.deps.nowUs(), { isConfig: true }),
-            capture.parameterSets
-          )
-        );
-      }
+      this.replayParameterSets(capture, socket);
     } catch (error) {
       logger.warn(`[VideoStream] subscribe failed: ${error}`);
       this.sendJson(socket, {
@@ -178,6 +177,8 @@ export class VideoStreamSocketServer extends BaseSocketServer {
     const existing = this.captures.get(deviceId);
     if (existing) {
       existing.subscribers.add(socket);
+      // A client that joins part way through a GOP must not consume inter frames before an IDR.
+      existing.waitingForKeyFrame.add(socket);
       this.socketDeviceIds.set(socket, deviceId);
       return existing;
     }
@@ -185,7 +186,12 @@ export class VideoStreamSocketServer extends BaseSocketServer {
     const capture: DeviceCapture = {
       source: null,
       subscribers: new Set([socket]),
-      parameterSets: null,
+      backpressuredSubscribers: new Set(),
+      waitingForKeyFrame: new Set(),
+      sps: null,
+      pps: null,
+      parser: new H264AnnexBParser(),
+      size: request.size,
     };
     // Registered before start() so a chunk arriving during startup still finds its subscribers.
     this.captures.set(deviceId, capture);
@@ -218,28 +224,52 @@ export class VideoStreamSocketServer extends BaseSocketServer {
       return;
     }
 
-    const isConfig = isParameterSetChunk(chunk);
-    if (isConfig) {
-      capture.parameterSets = Buffer.from(chunk);
+    // Source chunks are arbitrary byte boundaries. Split incrementally so a start code or NAL
+    // spanning two reads cannot be mistaken for a complete frame.
+    for (const nal of capture.parser.push(chunk)) {
+      this.broadcastNal(deviceId, capture, nal);
     }
+  }
 
+  private broadcastNal(deviceId: string, capture: DeviceCapture, nal: Buffer): void {
+    const type = nalUnitType(nal);
+    const isConfig = type === NAL_TYPE_SPS || type === NAL_TYPE_PPS;
+    if (type === NAL_TYPE_SPS) {capture.sps = Buffer.from(nal);}
+    if (type === NAL_TYPE_PPS) {capture.pps = Buffer.from(nal);}
+
+    const isKeyFrame = type === NAL_TYPE_IDR;
     const packet = encodePacket(
-      encodePtsAndFlags(this.deps.nowUs(), { isConfig, isKeyFrame: isKeyFrameChunk(chunk) }),
-      chunk
+      encodePtsAndFlags(this.deps.nowUs(), { isConfig, isKeyFrame }),
+      Buffer.concat([ANNEX_B_START_CODE, nal])
     );
 
     for (const subscriber of capture.subscribers) {
       if (subscriber.destroyed) {
-        capture.subscribers.delete(subscriber);
+        this.detach(subscriber);
         continue;
       }
-      // A slow viewer must not stall the encoder or the other viewers. write() returning false
-      // only means the kernel buffer is full and Node is queueing; for live video a backlog is
-      // worth a trace, not a disconnect.
+      if (capture.backpressuredSubscribers.has(subscriber)) {continue;}
+      if (capture.waitingForKeyFrame.has(subscriber)) {
+        if (!isKeyFrame) {continue;}
+        capture.waitingForKeyFrame.delete(subscriber);
+      }
       if (!subscriber.write(packet)) {
-        logger.debug(`[VideoStream] subscriber is behind on ${deviceId}`);
+        logger.debug(`[VideoStream] subscriber is behind on ${deviceId}; dropping to next key frame`);
+        capture.backpressuredSubscribers.add(subscriber);
+        capture.waitingForKeyFrame.add(subscriber);
+        subscriber.once("drain", () => {
+          const current = this.captures.get(deviceId);
+          current?.backpressuredSubscribers.delete(subscriber);
+        });
       }
     }
+  }
+
+  private replayParameterSets(capture: DeviceCapture, socket: Socket): void {
+    const parameterSets = [capture.sps, capture.pps].filter((nal): nal is Buffer => nal !== null);
+    if (parameterSets.length === 0) {return;}
+    const payload = Buffer.concat(parameterSets.flatMap(nal => [ANNEX_B_START_CODE, nal]));
+    socket.write(encodePacket(encodePtsAndFlags(this.deps.nowUs(), { isConfig: true }), payload));
   }
 
   private detach(socket: Socket): void {
@@ -254,6 +284,8 @@ export class VideoStreamSocketServer extends BaseSocketServer {
       return;
     }
     capture.subscribers.delete(socket);
+    capture.backpressuredSubscribers.delete(socket);
+    capture.waitingForKeyFrame.delete(socket);
     if (capture.subscribers.size === 0) {
       void this.stopCapture(deviceId);
     }
@@ -271,6 +303,8 @@ export class VideoStreamSocketServer extends BaseSocketServer {
       subscriber.end();
     }
     capture.subscribers.clear();
+    capture.backpressuredSubscribers.clear();
+    capture.waitingForKeyFrame.clear();
 
     try {
       await capture.source?.stop();

--- a/src/daemon/videoStreamSocketServer.ts
+++ b/src/daemon/videoStreamSocketServer.ts
@@ -198,7 +198,7 @@ export class VideoStreamSocketServer extends BaseSocketServer {
     this.socketDeviceIds.set(socket, deviceId);
 
     try {
-      capture.source = await this.deps.createCaptureSource({
+      const source = await this.deps.createCaptureSource({
         device,
         onData: chunk => this.broadcast(deviceId, chunk),
         onError: error => {
@@ -208,7 +208,19 @@ export class VideoStreamSocketServer extends BaseSocketServer {
         bitrateBps: request.bitrateKbps ? request.bitrateKbps * 1000 : undefined,
         size: request.size,
       });
-      await capture.source.start();
+      // The final subscriber may disconnect while source construction is in
+      // flight. Do not attach an unreachable capture process to a removed entry.
+      if (this.captures.get(deviceId) !== capture || capture.subscribers.size === 0) {
+        await source.stop().catch(() => {});
+        throw new ActionableError(`Video capture for ${deviceId} was stopped during startup.`);
+      }
+      capture.source = source;
+      await source.start();
+      if (this.captures.get(deviceId) !== capture || capture.subscribers.size === 0) {
+        capture.source = null;
+        await source.stop().catch(() => {});
+        throw new ActionableError(`Video capture for ${deviceId} was stopped during startup.`);
+      }
     } catch (error) {
       this.captures.delete(deviceId);
       this.socketDeviceIds.delete(socket);
@@ -250,8 +262,13 @@ export class VideoStreamSocketServer extends BaseSocketServer {
       }
       if (capture.backpressuredSubscribers.has(subscriber)) {continue;}
       if (capture.waitingForKeyFrame.has(subscriber)) {
-        if (!isKeyFrame) {continue;}
-        capture.waitingForKeyFrame.delete(subscriber);
+        // Keep codec configuration flowing while waiting for an IDR. A late
+        // join can occur after SPS but before PPS, and suppressing PPS leaves
+        // the otherwise complete IDR undecodable.
+        if (!isKeyFrame && !isConfig) {continue;}
+        if (isKeyFrame) {
+          capture.waitingForKeyFrame.delete(subscriber);
+        }
       }
       if (!subscriber.write(packet)) {
         logger.debug(`[VideoStream] subscriber is behind on ${deviceId}; dropping to next key frame`);

--- a/src/daemon/videoStreamSocketServer.ts
+++ b/src/daemon/videoStreamSocketServer.ts
@@ -222,7 +222,11 @@ export class VideoStreamSocketServer extends BaseSocketServer {
         throw new ActionableError(`Video capture for ${deviceId} was stopped during startup.`);
       }
     } catch (error) {
-      this.captures.delete(deviceId);
+      // A replacement subscriber may have installed a new capture while this
+      // asynchronous start was unwinding. Never remove that newer capture.
+      if (this.captures.get(deviceId) === capture) {
+        this.captures.delete(deviceId);
+      }
       this.socketDeviceIds.delete(socket);
       throw toActionableError(error, `Failed to start video capture for ${deviceId}`);
     }

--- a/src/features/webrtc/AndroidH264Source.ts
+++ b/src/features/webrtc/AndroidH264Source.ts
@@ -7,6 +7,7 @@ import {
 } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbProcess } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { ANDROID_SCREENRECORD_MAX_SECONDS } from "../video/androidScreenrecord";
+import { h264MacroblocksPerFrame, WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME } from "./h264Level";
 import type { H264CaptureSource, H264CaptureSourceOptions } from "./H264CaptureSource";
 
 export type { ProcessSpawner, SpawnedProcess } from "./processSpawner";
@@ -17,6 +18,7 @@ export type { ProcessSpawner, SpawnedProcess } from "./processSpawner";
  * boundary. A fresh segment re-emits SPS/PPS + an IDR, which decoders handle.
  */
 export const ANDROID_STREAM_SEGMENT_ROTATE_MS = (ANDROID_SCREENRECORD_MAX_SECONDS - 5) * 1000;
+const DEFAULT_SCREENRECORD_SIZE = { width: 1280, height: 720 };
 
 export interface AndroidH264SourceOptions extends H264CaptureSourceOptions {
   adbFactory?: AdbClientFactory;
@@ -46,6 +48,7 @@ export class AndroidH264Source implements H264CaptureSource {
   private rotateHandle: NodeJS.Timeout | null = null;
   private running = false;
   private segmentCount = 0;
+  private resolvedSize: { width: number; height: number } | null = null;
 
   constructor(options: AndroidH264SourceOptions) {
     this.options = options;
@@ -105,6 +108,10 @@ export class AndroidH264Source implements H264CaptureSource {
     if (!this.running) {
       return;
     }
+    const size = await this.captureSize(adb);
+    if (!this.running) {
+      return;
+    }
     const args = [
       "exec-out",
       "screenrecord",
@@ -115,9 +122,7 @@ export class AndroidH264Source implements H264CaptureSource {
     if (this.options.bitrateBps && this.options.bitrateBps > 0) {
       args.push("--bit-rate", String(Math.round(this.options.bitrateBps)));
     }
-    if (this.options.size) {
-      args.push("--size", `${this.options.size.width}x${this.options.size.height}`);
-    }
+    args.push("--size", `${size.width}x${size.height}`);
     args.push("-");
 
     logger.info(
@@ -223,4 +228,42 @@ export class AndroidH264Source implements H264CaptureSource {
       this.rotateHandle = null;
     }
   }
+
+  private async captureSize(adb: ReturnType<AdbClientFactory["create"]>): Promise<{ width: number; height: number }> {
+    if (this.options.size) {
+      return this.options.size;
+    }
+    if (this.resolvedSize) {
+      return this.resolvedSize;
+    }
+    try {
+      const { stdout } = await adb.executeCommand("shell wm size");
+      const match = /Physical size:\s*(\d+)x(\d+)/.exec(stdout);
+      if (match) {
+        this.resolvedSize = capToLevel42({ width: Number(match[1]), height: Number(match[2]) });
+        return this.resolvedSize;
+      }
+    } catch (error) {
+      logger.debug(`[AndroidH264Source] could not query display size: ${error}`);
+    }
+    // `wm size` is unavailable on a few older/restricted devices. Keep that
+    // fallback within the Level 4.2 SDP capability instead of emitting native
+    // display resolution with an unbounded SPS level.
+    this.resolvedSize = DEFAULT_SCREENRECORD_SIZE;
+    return this.resolvedSize;
+  }
+}
+
+function capToLevel42(size: { width: number; height: number }): { width: number; height: number } {
+  const scale = Math.min(1, Math.sqrt((WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME * 256) / (size.width * size.height)));
+  let width = Math.max(2, Math.floor((size.width * scale) / 2) * 2);
+  let height = Math.max(2, Math.floor((size.height * scale) / 2) * 2);
+  while (h264MacroblocksPerFrame(width, height) > WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME) {
+    if (width >= height) {
+      width -= 2;
+    } else {
+      height -= 2;
+    }
+  }
+  return { width, height };
 }

--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -429,6 +429,11 @@ export class IosH264Source implements H264CaptureSource {
     ];
     if (this.options.size) {
       args.push("-vf", `scale=${this.options.size.width}:${this.options.size.height}`);
+    } else {
+      // Keep an unconstrained macOS capture inside the Level 4.2 capability
+      // advertised in the WHIP SDP. Explicit sizes are validated before source
+      // creation by webrtcStreamingConfig.
+      args.push("-vf", "scale=1920:1080:force_original_aspect_ratio=decrease:force_divisible_by=2");
     }
     args.push(
       "-an",
@@ -436,6 +441,8 @@ export class IosH264Source implements H264CaptureSource {
       "h264_videotoolbox",
       "-profile:v",
       "baseline",
+      "-level:v",
+      "4.2",
       "-bf",
       "0"
     );

--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -250,6 +250,8 @@ export class IosH264Source implements H264CaptureSource {
         }
         if (isNoFramesPermissionWarning(line)) {
           finish(() => reject(makeNoFramesError(target)));
+        } else if (isHelperError(line)) {
+          finish(() => reject(new Error(`screen-capture-helper reported an error: ${line}`)));
         }
       });
       helper.on("error", error => {
@@ -331,6 +333,12 @@ export class IosH264Source implements H264CaptureSource {
     helper.on("stderr", line => {
       if (line.length > 0) {
         logger.debug(`[IosH264Source] screen-capture-helper stderr: ${line}`);
+      }
+      if (isHelperError(line)) {
+        this.failIfCurrentHelper(
+          helper,
+          new Error(`screen-capture-helper reported an error: ${line}`)
+        );
       }
     });
   }
@@ -496,6 +504,10 @@ function makeNoFramesError(target: CaptureTarget): ActionableError {
 
 function isNoFramesPermissionWarning(line: string): boolean {
   return line.toLowerCase().includes(NO_FRAMES_PERMISSION_WARNING);
+}
+
+function isHelperError(line: string): boolean {
+  return line.trimStart().toLowerCase().startsWith("error:");
 }
 
 function tightlyPackBgraFrame(frame: DecodedFrame): Buffer {

--- a/src/features/webrtc/PersistentEncoderH264Source.ts
+++ b/src/features/webrtc/PersistentEncoderH264Source.ts
@@ -90,6 +90,7 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
   private socket: StreamSocket | null = null;
   private forwardedPort: number | null = null;
   private running = false;
+  private teardownPromise: Promise<void> | null = null;
   private resolveStartupAudioHeader: ((header: VideoServerStreamHeader) => void) | undefined;
   private resolveStartupAudioPacket: ((packet: VideoServerPacket) => void) | undefined;
 
@@ -116,17 +117,18 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
       // Startup failed before we produced anything: tear down and rethrow so the
       // caller (source factory) can fall back to screenrecord.
       this.running = false;
-      await this.teardown();
+      await this.beginTeardown();
       throw error;
     }
   }
 
   async stop(): Promise<void> {
     if (!this.running) {
+      await this.teardownPromise;
       return;
     }
     this.running = false;
-    await this.teardown();
+    await this.beginTeardown();
   }
 
   private async launch(): Promise<void> {
@@ -137,9 +139,16 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
 
     // Push the DEX jar (idempotent; overwrites any prior copy).
     await adb.executeCommand(`push "${this.options.jarPath}" ${VIDEO_SERVER_REMOTE_JAR_PATH}`);
+    if (!this.running) {
+      return;
+    }
 
     // Launch the persistent server as a long-lived process.
     const server = await adb.spawn(this.buildServerArgs());
+    if (!this.running) {
+      server.kill("SIGINT");
+      return;
+    }
     this.server = server;
     server.stderr.on("data", (chunk: Buffer) => {
       const text = chunk.toString().trim();
@@ -398,9 +407,15 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
       return;
     }
     this.running = false;
-    this.socket = null;
-    void this.teardown();
+    void this.beginTeardown();
     this.options.onError?.(error);
+  }
+
+  private beginTeardown(): Promise<void> {
+    this.teardownPromise ??= this.teardown().finally(() => {
+      this.teardownPromise = null;
+    });
+    return this.teardownPromise;
   }
 
   private async teardown(): Promise<void> {

--- a/src/features/webrtc/ReconnectController.ts
+++ b/src/features/webrtc/ReconnectController.ts
@@ -68,10 +68,18 @@ export class ReconnectController {
       await this.attempt();
     } catch (error) {
       this.cycleActive = false;
+      // stop() may win while an in-flight initial attempt is unwinding. Preserve
+      // its terminal state rather than reporting a cancelled start as failed.
+      if (this.stopped) {
+        return;
+      }
       this.setState("failed");
       throw error;
     }
     this.cycleActive = false;
+    if (this.stopped) {
+      return;
+    }
     this.setState("connected");
     this.drainPendingReconnect();
   }

--- a/src/features/webrtc/ReconnectController.ts
+++ b/src/features/webrtc/ReconnectController.ts
@@ -134,6 +134,11 @@ export class ReconnectController {
     try {
       await this.attempt();
       this.cycleActive = false;
+      // stop() may win while a reconnect is establishing. Do not resurrect the
+      // terminal state after its transport has already been torn down.
+      if (this.stopped) {
+        return;
+      }
       this.setState("connected");
       this.drainPendingReconnect();
     } catch (error) {

--- a/src/features/webrtc/RtpH264TrackWriter.ts
+++ b/src/features/webrtc/RtpH264TrackWriter.ts
@@ -65,6 +65,9 @@ export class RtpH264TrackWriter {
     this.ssrc = options.ssrc >>> 0;
     this.payloadType = options.payloadType ?? 102;
     this.mtu = options.mtu ?? DEFAULT_RTP_MTU;
+    if (!Number.isSafeInteger(this.mtu) || this.mtu < 3) {
+      throw new Error("H.264 RTP MTU must be an integer of at least 3 bytes.");
+    }
     this.timer = options.timer ?? defaultTimer;
     this.sequenceNumber = (options.initialSequenceNumber ?? 0) & 0xffff;
   }

--- a/src/features/webrtc/RtpH264TrackWriter.ts
+++ b/src/features/webrtc/RtpH264TrackWriter.ts
@@ -34,6 +34,8 @@ export interface RtpH264TrackWriterOptions {
   timer?: Timer;
   /** Initial 16-bit sequence number (defaults to 0). */
   initialSequenceNumber?: number;
+  /** Observes each complete SPS before it can be sent to the negotiated peer. */
+  onSps?: (nal: Buffer) => void;
 }
 
 /**
@@ -50,6 +52,7 @@ export class RtpH264TrackWriter {
   private readonly payloadType: number;
   private readonly mtu: number;
   private readonly timer: Timer;
+  private readonly onSps?: (nal: Buffer) => void;
   private readonly parser = new H264AnnexBParser();
   private readonly assembler = new H264AccessUnitAssembler();
 
@@ -69,6 +72,7 @@ export class RtpH264TrackWriter {
       throw new Error("H.264 RTP MTU must be an integer of at least 3 bytes.");
     }
     this.timer = options.timer ?? defaultTimer;
+    this.onSps = options.onSps;
     this.sequenceNumber = (options.initialSequenceNumber ?? 0) & 0xffff;
   }
 
@@ -99,6 +103,9 @@ export class RtpH264TrackWriter {
   }
 
   private consumeNal(nal: Buffer): void {
+    if ((nal[0] & 0x1f) === 7) {
+      this.onSps?.(nal);
+    }
     if (isKeyFrameNal(nal)) {
       this.sawKeyFrame = true;
     }

--- a/src/features/webrtc/RtpH264TrackWriter.ts
+++ b/src/features/webrtc/RtpH264TrackWriter.ts
@@ -8,7 +8,10 @@ import {
   packetizeAccessUnit,
 } from "./h264";
 
-/** H.264 RTP clock rate (fixed by RFC 6184). */
+/**
+ * H.264 RTP clock rate (90 kHz, fixed by RFC 6184 §6).
+ * https://www.rfc-editor.org/rfc/rfc6184.html#section-6
+ */
 export const H264_CLOCK_RATE = 90_000;
 
 /**
@@ -37,7 +40,9 @@ export interface RtpH264TrackWriterOptions {
  * Consumes an Annex-B H.264 elementary stream and writes RFC 6184 RTP packets
  * to a sink. Access units are timestamped from a wall clock (90 kHz), so RTP
  * pacing tracks real capture time regardless of the encoder's nominal frame
- * rate. The marker bit is set on the last packet of each frame.
+ * rate. The marker bit is set on the last packet of each frame, as required
+ * for an H.264 access unit by RFC 6184 §5.1:
+ * https://www.rfc-editor.org/rfc/rfc6184.html#section-5.1
  */
 export class RtpH264TrackWriter {
   private readonly sink: RtpPacketSink;

--- a/src/features/webrtc/RtpPcmuTrackWriter.ts
+++ b/src/features/webrtc/RtpPcmuTrackWriter.ts
@@ -1,7 +1,10 @@
 import { RtpHeader, RtpPacket } from "werift";
 import type { RtpPacketSink } from "./RtpH264TrackWriter";
 
-/** PCMU/G.711 RTP clock rate. */
+/**
+ * PCMU/G.711 RTP clock rate and static payload type 0.
+ * RFC 3551 §6: https://www.rfc-editor.org/rfc/rfc3551.html#section-6
+ */
 export const PCMU_CLOCK_RATE = 8_000;
 export const PCMU_PAYLOAD_TYPE = 0;
 const DEFAULT_AUDIO_MTU = 1200;

--- a/src/features/webrtc/RtpPcmuTrackWriter.ts
+++ b/src/features/webrtc/RtpPcmuTrackWriter.ts
@@ -31,6 +31,7 @@ export class RtpPcmuTrackWriter {
   private timestamp = 0;
   private packetsWritten = 0;
   private samplesWritten = 0;
+  private remainder: Buffer | null = null;
 
   constructor(options: RtpPcmuTrackWriterOptions) {
     this.sink = options.sink;
@@ -41,14 +42,16 @@ export class RtpPcmuTrackWriter {
   }
 
   writePcm16Chunk(chunk: Buffer): void {
-    const sampleCount = Math.floor(chunk.length / 2);
+    const input = this.remainder ? Buffer.concat([this.remainder, chunk]) : chunk;
+    const sampleCount = Math.floor(input.length / 2);
+    this.remainder = input.length % 2 === 0 ? null : Buffer.from(input.subarray(-1));
     if (sampleCount === 0) {
       return;
     }
 
     const payload = Buffer.alloc(sampleCount);
     for (let i = 0; i < sampleCount; i++) {
-      payload[i] = linear16ToMuLaw(chunk.readInt16LE(i * 2));
+      payload[i] = linear16ToMuLaw(input.readInt16LE(i * 2));
     }
 
     for (let offset = 0; offset < payload.length; offset += this.mtu) {

--- a/src/features/webrtc/WebRtcPublisher.ts
+++ b/src/features/webrtc/WebRtcPublisher.ts
@@ -12,7 +12,7 @@ import { DEFAULT_RTP_MTU } from "./h264";
 import { ReconnectController, type ReconnectState } from "./ReconnectController";
 import { RtpH264TrackWriter } from "./RtpH264TrackWriter";
 import { RtpPcmuTrackWriter } from "./RtpPcmuTrackWriter";
-import { TrickleIceForwarder } from "./trickleIce";
+import { parseTrickleIceMediaContexts, TrickleIceForwarder } from "./trickleIce";
 import { WhipClient, type WhipClientOptions } from "./WhipClient";
 
 /**
@@ -109,6 +109,7 @@ export class WebRtcPublisher {
   private writer: RtpH264TrackWriter | null = null;
   private audioWriter: RtpPcmuTrackWriter | null = null;
   private resourceUrl: string | null = null;
+  private activeWhipEtag: string | null = null;
   private state: ReconnectState = "idle";
   private closed = false;
   private establishing = false;
@@ -227,7 +228,8 @@ export class WebRtcPublisher {
     this.pc = pc;
 
     try {
-      const track = new MediaStreamTrack({ kind: "video" });
+      // WHIP permits exactly one MediaStream; both media tracks share its id.
+      const track = new MediaStreamTrack({ kind: "video", streamId: this.config.streamId });
       const transceiver = pc.addTransceiver(track, { direction: "sendonly" });
       this.writer = new RtpH264TrackWriter({
         sink: track,
@@ -236,7 +238,7 @@ export class WebRtcPublisher {
         timer: this.timer,
       });
       if (this.audioEnabled) {
-        const audioTrack = new MediaStreamTrack({ kind: "audio" });
+        const audioTrack = new MediaStreamTrack({ kind: "audio", streamId: this.config.streamId });
         const audioTransceiver = pc.addTransceiver(audioTrack, { direction: "sendonly" });
         this.audioWriter = new RtpPcmuTrackWriter({
           sink: audioTrack,
@@ -261,7 +263,10 @@ export class WebRtcPublisher {
         throw new Error("Failed to produce a local SDP offer.");
       }
 
-      const session = await this.whip.publish(localSdp);
+      // werift implements rtcp-mux but does not serialize the WHIP-required
+      // rtcp-mux-only attribute. It is an SDP signalling constraint; werift's
+      // transport remains multiplexed after local description is installed.
+      const session = await this.whip.publish(addWhipRtcpMuxOnly(localSdp));
 
       // stop() may have run while we were awaiting ICE/WHIP. The WHIP session now
       // exists on the server but teardown already happened (before resourceUrl was
@@ -276,6 +281,10 @@ export class WebRtcPublisher {
       }
 
       this.resourceUrl = session.resourceUrl;
+      this.activeWhipEtag = session.etag;
+      if (this.trickleIce && !session.etag) {
+        throw new Error("WHIP server did not return the ETag required for Trickle ICE.");
+      }
       // Flush candidates gathered during the WHIP round-trip and stream the rest.
       this.trickle?.setResource(session.resourceUrl);
       await pc.setRemoteDescription({ type: "answer", sdp: session.answerSdp });
@@ -306,6 +315,7 @@ export class WebRtcPublisher {
       if (this.pc === pc) {
         const resourceUrl = this.resourceUrl;
         this.resourceUrl = null;
+        this.activeWhipEtag = null;
         this.pc = null;
         this.writer = null;
         this.audioWriter = null;
@@ -367,21 +377,29 @@ export class WebRtcPublisher {
    * after publish), then PATCHed as `application/trickle-ice-sdpfrag`.
    */
   private startTrickle(pc: RTCPeerConnection): void {
+    const contexts = parseTrickleIceMediaContexts(pc.localDescription?.sdp ?? "");
     const forwarder = new TrickleIceForwarder((resourceUrl, fragment) => {
-      void this.whip.patchCandidate(resourceUrl, fragment).catch(error => {
+      const etag = this.activeWhipEtag;
+      if (!etag) {
+        return;
+      }
+      void this.whip.patchCandidate(resourceUrl, etag, fragment).catch(error => {
         logger.debug(`[WebRTC] trickle candidate PATCH failed: ${error}`);
       });
-    });
+    }, contexts);
     this.trickle = forwarder;
     this.candidateSub = pc.onIceCandidate.subscribe(candidate => {
-      // Ignore the end-of-candidates signal (undefined) and any candidate from a
-      // peer connection a concurrent teardown/establish already replaced.
-      if (candidate && this.pc === pc) {
+      if (this.pc !== pc) {
+        return;
+      }
+      if (candidate) {
         forwarder.addCandidate({
           candidate: candidate.candidate,
           sdpMid: candidate.sdpMid,
           sdpMLineIndex: candidate.sdpMLineIndex,
         });
+      } else {
+        forwarder.completeGathering();
       }
     });
   }
@@ -409,6 +427,7 @@ export class WebRtcPublisher {
     this.writer = null;
     this.audioWriter = null;
     this.resourceUrl = null;
+    this.activeWhipEtag = null;
 
     // Stop forwarding candidates and detach the listener before the pc closes.
     this.trickle?.stop();
@@ -443,7 +462,7 @@ function assertWhipAnswerAcceptsMedia(
     throw new Error(`WHIP answer did not include a ${kind} m-line.`);
   }
 
-  const [mediaLine, ...attributeLines] = section;
+  const { mediaLine, attributeLines, sessionDirection } = section;
   const mediaParts = mediaLine.split(/\s+/);
   const port = Number(mediaParts[1]);
   const formats = new Set(mediaParts.slice(3));
@@ -455,7 +474,7 @@ function assertWhipAnswerAcceptsMedia(
     attributeLines
       .map(line => line.match(/^a=(sendrecv|sendonly|recvonly|inactive)$/)?.[1])
       .find((value): value is "sendrecv" | "sendonly" | "recvonly" | "inactive" => value !== undefined) ??
-    "sendrecv";
+    sessionDirection ?? "sendrecv";
   if (direction !== "recvonly" && direction !== "sendrecv") {
     throw new Error(`WHIP answer did not accept receiving ${kind} (direction=${direction}).`);
   }
@@ -463,33 +482,56 @@ function assertWhipAnswerAcceptsMedia(
   const staticPayloadType = codec === "pcmu" ? "0" : undefined;
   const accepted =
     (staticPayloadType !== undefined && formats.has(staticPayloadType)) ||
-    attributeLines.some(line => isAcceptedCodecRtpMap(line, formats, codec));
+    attributeLines.some(line => isAcceptedCodecRtpMap(line, formats, codec, attributeLines));
   if (!accepted) {
     throw new Error(`WHIP answer did not accept ${codec.toUpperCase()} ${kind}.`);
   }
 }
 
-function findSdpMediaSection(sdp: string, kind: "audio" | "video"): string[] | null {
+function findSdpMediaSection(sdp: string, kind: "audio" | "video"): {
+  mediaLine: string;
+  attributeLines: string[];
+  sessionDirection?: "sendrecv" | "sendonly" | "recvonly" | "inactive";
+} | null {
   const lines = sdp.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+  const firstMedia = lines.findIndex(line => line.startsWith("m="));
+  const sessionDirection = lines
+    .slice(0, firstMedia < 0 ? lines.length : firstMedia)
+    .map(line => line.match(/^a=(sendrecv|sendonly|recvonly|inactive)$/)?.[1])
+    .find((value): value is "sendrecv" | "sendonly" | "recvonly" | "inactive" => value !== undefined);
   for (let index = 0; index < lines.length; index++) {
     if (!lines[index].startsWith(`m=${kind} `)) {
       continue;
     }
-    const section = [lines[index]];
+    const attributeLines: string[] = [];
     for (let sectionIndex = index + 1; sectionIndex < lines.length; sectionIndex++) {
       if (lines[sectionIndex].startsWith("m=")) {
         break;
       }
-      section.push(lines[sectionIndex]);
+      attributeLines.push(lines[sectionIndex]);
     }
-    return section;
+    return { mediaLine: lines[index], attributeLines, sessionDirection };
   }
   return null;
 }
 
-function isAcceptedCodecRtpMap(line: string, formats: Set<string>, codec: string): boolean {
+function isAcceptedCodecRtpMap(
+  line: string,
+  formats: Set<string>,
+  codec: string,
+  attributeLines: string[]
+): boolean {
   const match = line.match(/^a=rtpmap:(\S+)\s+([^/\s]+)/i);
-  return Boolean(match && formats.has(match[1]) && match[2].toLowerCase() === codec);
+  if (!match || !formats.has(match[1]) || match[2].toLowerCase() !== codec) {
+    return false;
+  }
+  return codec !== "h264" || attributeLines.some(fmtp =>
+    fmtp.startsWith(`a=fmtp:${match[1]} `) && /(?:^|;)\s*packetization-mode\s*=\s*1(?:;|$)/i.test(fmtp.slice(fmtp.indexOf(" ") + 1))
+  );
+}
+
+function addWhipRtcpMuxOnly(sdp: string): string {
+  return sdp.replace(/a=rtcp-mux\r?\n/g, match => `${match}a=rtcp-mux-only\r\n`);
 }
 
 /**

--- a/src/features/webrtc/WebRtcPublisher.ts
+++ b/src/features/webrtc/WebRtcPublisher.ts
@@ -15,7 +15,13 @@ import { RtpPcmuTrackWriter } from "./RtpPcmuTrackWriter";
 import { TrickleIceForwarder } from "./trickleIce";
 import { WhipClient, type WhipClientOptions } from "./WhipClient";
 
-/** How long to wait for ICE gathering before publishing the offer. */
+/**
+ * How long to wait for ICE gathering before publishing the offer.
+ *
+ * Protocol background: [ICE (RFC 8445)](https://www.rfc-editor.org/rfc/rfc8445.html).
+ * AutoMobile's bounded non-trickle wait is an implementation choice; enable
+ * `trickleIce` for the WHIP extension described in `trickleIce.ts`.
+ */
 export const ICE_GATHERING_TIMEOUT_MS = 5000;
 
 export interface WebRtcPublisherConfig {
@@ -79,6 +85,13 @@ export interface WebRtcStreamDescriptor {
  * publisher packetizes it to RTP and sends it over a sendonly WebRTC track.
  * Connection loss triggers automatic reconnection (fresh WHIP publish) with
  * backoff via {@link ReconnectController}.
+ *
+ * Standards: [W3C WebRTC](https://www.w3.org/TR/webrtc/),
+ * [JSEP (RFC 9429)](https://www.rfc-editor.org/rfc/rfc9429.html),
+ * [WHIP (RFC 9725)](https://www.rfc-editor.org/rfc/rfc9725.html), and
+ * [H.264 over RTP (RFC 6184)](https://www.rfc-editor.org/rfc/rfc6184.html).
+ * See `docs/design-docs/mcp/observe/webrtc-standards-map.md` for the full
+ * implementation-to-spec mapping.
  */
 export class WebRtcPublisher {
   private readonly config: WebRtcPublisherConfig;
@@ -266,6 +279,9 @@ export class WebRtcPublisher {
       // Flush candidates gathered during the WHIP round-trip and stream the rest.
       this.trickle?.setResource(session.resourceUrl);
       await pc.setRemoteDescription({ type: "answer", sdp: session.answerSdp });
+      // WHIP forbids a misleading partially successful ingest session: reject
+      // an answer that did not accept each requested media section.
+      // RFC 9725 §4.4.3: https://www.rfc-editor.org/rfc/rfc9725.html#section-4.4.3
       assertWhipAnswerAcceptsMedia(session.answerSdp, "video", "h264");
       if (this.audioEnabled) {
         assertWhipAnswerAcceptsMedia(session.answerSdp, "audio", "pcmu");

--- a/src/features/webrtc/WebRtcPublisher.ts
+++ b/src/features/webrtc/WebRtcPublisher.ts
@@ -266,6 +266,10 @@ export class WebRtcPublisher {
       // Flush candidates gathered during the WHIP round-trip and stream the rest.
       this.trickle?.setResource(session.resourceUrl);
       await pc.setRemoteDescription({ type: "answer", sdp: session.answerSdp });
+      assertWhipAnswerAcceptsMedia(session.answerSdp, "video", "h264");
+      if (this.audioEnabled) {
+        assertWhipAnswerAcceptsMedia(session.answerSdp, "audio", "pcmu");
+      }
 
       this.establishing = false;
       this.watchConnectionState(pc);
@@ -284,6 +288,8 @@ export class WebRtcPublisher {
       // reconnect attempt to tear it down, so close it here. Guard on identity so
       // we never close a pc a concurrent teardown/establish already replaced.
       if (this.pc === pc) {
+        const resourceUrl = this.resourceUrl;
+        this.resourceUrl = null;
         this.pc = null;
         this.writer = null;
         this.audioWriter = null;
@@ -291,6 +297,9 @@ export class WebRtcPublisher {
         this.trickle = null;
         this.candidateSub?.unSubscribe();
         this.candidateSub = null;
+        if (resourceUrl) {
+          await this.whip.delete(resourceUrl).catch(() => {});
+        }
         await pc.close().catch(() => {});
       }
       throw error;
@@ -314,6 +323,11 @@ export class WebRtcPublisher {
         this.controller.notifyConnectionLost();
       }
     });
+    // An ICE/DTLS failure can arrive before the subscription above is installed.
+    // werift does not replay prior state changes, so inspect the current state too.
+    if (pc.connectionState === "failed" || pc.connectionState === "disconnected") {
+      this.controller.notifyConnectionLost();
+    }
   }
 
   /** Start capture (once per session) now that media can actually flow. */
@@ -401,6 +415,65 @@ export class WebRtcPublisher {
       }
     }
   }
+}
+
+function assertWhipAnswerAcceptsMedia(
+  answerSdp: string,
+  kind: "audio" | "video",
+  codec: "h264" | "pcmu"
+): void {
+  const section = findSdpMediaSection(answerSdp, kind);
+  if (!section) {
+    throw new Error(`WHIP answer did not include a ${kind} m-line.`);
+  }
+
+  const [mediaLine, ...attributeLines] = section;
+  const mediaParts = mediaLine.split(/\s+/);
+  const port = Number(mediaParts[1]);
+  const formats = new Set(mediaParts.slice(3));
+  if (!Number.isFinite(port) || port === 0) {
+    throw new Error(`WHIP answer rejected the requested ${kind} m-line.`);
+  }
+
+  const direction =
+    attributeLines
+      .map(line => line.match(/^a=(sendrecv|sendonly|recvonly|inactive)$/)?.[1])
+      .find((value): value is "sendrecv" | "sendonly" | "recvonly" | "inactive" => value !== undefined) ??
+    "sendrecv";
+  if (direction !== "recvonly" && direction !== "sendrecv") {
+    throw new Error(`WHIP answer did not accept receiving ${kind} (direction=${direction}).`);
+  }
+
+  const staticPayloadType = codec === "pcmu" ? "0" : undefined;
+  const accepted =
+    (staticPayloadType !== undefined && formats.has(staticPayloadType)) ||
+    attributeLines.some(line => isAcceptedCodecRtpMap(line, formats, codec));
+  if (!accepted) {
+    throw new Error(`WHIP answer did not accept ${codec.toUpperCase()} ${kind}.`);
+  }
+}
+
+function findSdpMediaSection(sdp: string, kind: "audio" | "video"): string[] | null {
+  const lines = sdp.split(/\r?\n/).map(line => line.trim()).filter(Boolean);
+  for (let index = 0; index < lines.length; index++) {
+    if (!lines[index].startsWith(`m=${kind} `)) {
+      continue;
+    }
+    const section = [lines[index]];
+    for (let sectionIndex = index + 1; sectionIndex < lines.length; sectionIndex++) {
+      if (lines[sectionIndex].startsWith("m=")) {
+        break;
+      }
+      section.push(lines[sectionIndex]);
+    }
+    return section;
+  }
+  return null;
+}
+
+function isAcceptedCodecRtpMap(line: string, formats: Set<string>, codec: string): boolean {
+  const match = line.match(/^a=rtpmap:(\S+)\s+([^/\s]+)/i);
+  return Boolean(match && formats.has(match[1]) && match[2].toLowerCase() === codec);
 }
 
 /**

--- a/src/features/webrtc/WebRtcPublisher.ts
+++ b/src/features/webrtc/WebRtcPublisher.ts
@@ -12,6 +12,11 @@ import { DEFAULT_RTP_MTU } from "./h264";
 import { ReconnectController, type ReconnectState } from "./ReconnectController";
 import { RtpH264TrackWriter } from "./RtpH264TrackWriter";
 import { RtpPcmuTrackWriter } from "./RtpPcmuTrackWriter";
+import {
+  h264SpsLevelIdc,
+  WEBRTC_H264_LEVEL_IDC,
+  WEBRTC_H264_PROFILE_LEVEL_ID,
+} from "./h264Level";
 import { parseTrickleIceMediaContexts, TrickleIceForwarder } from "./trickleIce";
 import { WhipClient, type WhipClientOptions } from "./WhipClient";
 
@@ -134,8 +139,8 @@ export class WebRtcPublisher {
           // gathers/trickles ICE candidates (RFC 9725 §4.3.2).
           bundlePolicy: "max-bundle",
           codecs: this.audioEnabled
-            ? { video: [useH264()], audio: [usePCMU()] }
-            : { video: [useH264()] },
+            ? { video: [useH264({ parameters: h264CodecParameters() })], audio: [usePCMU()] }
+            : { video: [useH264({ parameters: h264CodecParameters() })] },
         }));
     const createWhip = deps.createWhipClient ?? (options => new WhipClient(options));
     this.whip = createWhip({
@@ -167,7 +172,14 @@ export class WebRtcPublisher {
 
   /** Feed a chunk of the raw H.264 (Annex-B) elementary stream. */
   writeH264Chunk(chunk: Buffer): void {
-    this.writer?.writeChunk(chunk);
+    try {
+      this.writer?.writeChunk(chunk);
+    } catch (error) {
+      logger.warn(
+        `[WebRTC] stream ${this.config.streamId} emitted an H.264 stream outside its negotiated capability: ${error instanceof Error ? error.message : String(error)}`
+      );
+      this.notifySourceFailed();
+    }
   }
 
   /** Feed 8 kHz mono PCM16LE audio; ignored when audio is not enabled. */
@@ -227,6 +239,12 @@ export class WebRtcPublisher {
     await this.teardownActiveSession();
 
     await this.onBeforeEstablish?.();
+    // stop() can race an asynchronous pre-establish hook (for example, source
+    // setup). Do not allocate a peer connection or POST a WHIP offer after the
+    // caller has explicitly stopped this publisher.
+    if (this.closed) {
+      throw new Error("Publisher closed during pre-establish.");
+    }
 
     const pc = this.createPeerConnection(this.config.iceServers ?? []);
     this.pc = pc;
@@ -240,6 +258,14 @@ export class WebRtcPublisher {
         ssrc: transceiver.sender.ssrc,
         mtu: this.config.mtu ?? DEFAULT_RTP_MTU,
         timer: this.timer,
+        onSps: sps => {
+          const levelIdc = h264SpsLevelIdc(sps);
+          if (levelIdc !== undefined && levelIdc > WEBRTC_H264_LEVEL_IDC) {
+            throw new Error(
+              `H.264 SPS level ${levelIdc} exceeds negotiated level ${WEBRTC_H264_LEVEL_IDC}.`
+            );
+          }
+        },
       });
       if (this.audioEnabled) {
         const audioTrack = new MediaStreamTrack({ kind: "audio", streamId: this.config.streamId });
@@ -366,7 +392,7 @@ export class WebRtcPublisher {
       return;
     }
     this.connectedFired = true;
-    void Promise.resolve(this.onConnected?.()).catch(error => {
+    void Promise.resolve().then(() => this.onConnected?.()).catch(error => {
       // Capture failed to start (e.g. adb/screenrecord spawn failed) even though
       // the peer connected. Without this the stream would report connected with
       // no media and never recover — route it through the reconnect path.
@@ -479,7 +505,10 @@ function assertWhipAnswerAcceptsMedia(
       .map(line => line.match(/^a=(sendrecv|sendonly|recvonly|inactive)$/)?.[1])
       .find((value): value is "sendrecv" | "sendonly" | "recvonly" | "inactive" => value !== undefined) ??
     sessionDirection ?? "sendrecv";
-  if (direction !== "recvonly" && direction !== "sendrecv") {
+  // WHIP is unidirectional ingest: an accepting endpoint MUST answer recvonly
+  // (RFC 9725 §4.2). Accepting sendrecv would make AutoMobile interoperate with
+  // a non-conforming endpoint and hide an invalid session contract.
+  if (direction !== "recvonly") {
     throw new Error(`WHIP answer did not accept receiving ${kind} (direction=${direction}).`);
   }
 
@@ -541,9 +570,39 @@ function isAcceptedCodecRtpMap(
     }
     const parameters = fmtp.slice(fmtp.indexOf(" ") + 1);
     const packetizationMode = /(?:^|;)\s*packetization-mode\s*=\s*1(?:;|$)/i.test(parameters);
-    const profile = /(?:^|;)\s*profile-level-id\s*=\s*(42e0[0-9a-f]{2})(?:;|$)/i.test(parameters);
-    return packetizationMode && profile;
+    const profileLevelId = /(?:^|;)\s*profile-level-id\s*=\s*([0-9a-f]{6})(?:;|$)/i.exec(parameters)?.[1];
+    return packetizationMode && profileLevelId !== undefined && acceptsLocalH264Send(parameters, profileLevelId);
   });
+}
+
+function hasCompatibleH264Profile(profileLevelId: string): boolean {
+  // RFC 6184 §8.2.2 treats constraint_set3_flag (bit 4 of profile-iop) as
+  // part of the level for Baseline/Main/Extended profiles, so it may differ in
+  // a conforming answer. The profile_idc and remaining profile-iop bits must
+  // stay symmetric with AutoMobile's 42e0xx constrained-baseline offer.
+  const profileIdc = Number.parseInt(profileLevelId.slice(0, 2), 16);
+  const profileIop = Number.parseInt(profileLevelId.slice(2, 4), 16);
+  return profileIdc === 0x42 && (profileIop & 0xef) === 0xe0;
+}
+
+function h264CodecParameters(): string {
+  return `profile-level-id=${WEBRTC_H264_PROFILE_LEVEL_ID};packetization-mode=1;level-asymmetry-allowed=1`;
+}
+
+function acceptsLocalH264Send(parameters: string, profileLevelId: string): boolean {
+  if (!hasCompatibleH264Profile(profileLevelId)) {
+    return false;
+  }
+  const answerLevelIdc = Number.parseInt(profileLevelId.slice(4, 6), 16);
+  if (answerLevelIdc >= WEBRTC_H264_LEVEL_IDC) {
+    return true;
+  }
+  // With level asymmetry, the answer's profile-level-id describes its sending
+  // level; max-recv-level is its separately advertised receive ceiling (RFC
+  // 6184 §8.2.2). Do not send a Level 4.2 stream unless that ceiling permits it.
+  const asymmetric = /(?:^|;)\s*level-asymmetry-allowed\s*=\s*1(?:;|$)/i.test(parameters);
+  const maxReceiveLevel = /(?:^|;)\s*max-recv-level\s*=\s*(\d+)(?:;|$)/i.exec(parameters)?.[1];
+  return asymmetric && Number(maxReceiveLevel) >= WEBRTC_H264_LEVEL_IDC;
 }
 
 function addWhipRtcpMuxOnly(sdp: string): string {

--- a/src/features/webrtc/WebRtcPublisher.ts
+++ b/src/features/webrtc/WebRtcPublisher.ts
@@ -13,7 +13,9 @@ import { ReconnectController, type ReconnectState } from "./ReconnectController"
 import { RtpH264TrackWriter } from "./RtpH264TrackWriter";
 import { RtpPcmuTrackWriter } from "./RtpPcmuTrackWriter";
 import {
+  h264SpsProfileLevelId,
   h264SpsLevelIdc,
+  isCompatibleConstrainedBaselineProfile,
   WEBRTC_H264_LEVEL_IDC,
   WEBRTC_H264_PROFILE_LEVEL_ID,
 } from "./h264Level";
@@ -259,6 +261,12 @@ export class WebRtcPublisher {
         mtu: this.config.mtu ?? DEFAULT_RTP_MTU,
         timer: this.timer,
         onSps: sps => {
+          const profileLevelId = h264SpsProfileLevelId(sps);
+          if (profileLevelId && !isCompatibleConstrainedBaselineProfile(profileLevelId)) {
+            throw new Error(
+              `H.264 SPS profile ${profileLevelId.slice(0, 4)} is incompatible with negotiated constrained baseline.`
+            );
+          }
           const levelIdc = h264SpsLevelIdc(sps);
           if (levelIdc !== undefined && levelIdc > WEBRTC_H264_LEVEL_IDC) {
             throw new Error(
@@ -575,22 +583,12 @@ function isAcceptedCodecRtpMap(
   });
 }
 
-function hasCompatibleH264Profile(profileLevelId: string): boolean {
-  // RFC 6184 §8.2.2 treats constraint_set3_flag (bit 4 of profile-iop) as
-  // part of the level for Baseline/Main/Extended profiles, so it may differ in
-  // a conforming answer. The profile_idc and remaining profile-iop bits must
-  // stay symmetric with AutoMobile's 42e0xx constrained-baseline offer.
-  const profileIdc = Number.parseInt(profileLevelId.slice(0, 2), 16);
-  const profileIop = Number.parseInt(profileLevelId.slice(2, 4), 16);
-  return profileIdc === 0x42 && (profileIop & 0xef) === 0xe0;
-}
-
 function h264CodecParameters(): string {
   return `profile-level-id=${WEBRTC_H264_PROFILE_LEVEL_ID};packetization-mode=1;level-asymmetry-allowed=1`;
 }
 
 function acceptsLocalH264Send(parameters: string, profileLevelId: string): boolean {
-  if (!hasCompatibleH264Profile(profileLevelId)) {
+  if (!isCompatibleConstrainedBaselineProfile(profileLevelId)) {
     return false;
   }
   const answerLevelIdc = Number.parseInt(profileLevelId.slice(4, 6), 16);
@@ -601,8 +599,14 @@ function acceptsLocalH264Send(parameters: string, profileLevelId: string): boole
   // level; max-recv-level is its separately advertised receive ceiling (RFC
   // 6184 §8.2.2). Do not send a Level 4.2 stream unless that ceiling permits it.
   const asymmetric = /(?:^|;)\s*level-asymmetry-allowed\s*=\s*1(?:;|$)/i.test(parameters);
-  const maxReceiveLevel = /(?:^|;)\s*max-recv-level\s*=\s*(\d+)(?:;|$)/i.exec(parameters)?.[1];
-  return asymmetric && Number(maxReceiveLevel) >= WEBRTC_H264_LEVEL_IDC;
+  const maxReceiveLevel = /(?:^|;)\s*max-recv-level\s*=\s*([0-9a-f]{4})(?:;|$)/i.exec(parameters)?.[1];
+  // RFC 6184 §8.2.2 encodes max-recv-level as the two hexadecimal bytes after
+  // profile_idc in an SPS: profile-iop followed by level_idc (for example,
+  // e02a for constrained-baseline Level 4.2). It is not a decimal level number.
+  const maxReceiveLevelIdc = maxReceiveLevel
+    ? Number.parseInt(maxReceiveLevel.slice(2), 16)
+    : Number.NaN;
+  return asymmetric && maxReceiveLevelIdc >= WEBRTC_H264_LEVEL_IDC;
 }
 
 function addWhipRtcpMuxOnly(sdp: string): string {

--- a/src/features/webrtc/WebRtcPublisher.ts
+++ b/src/features/webrtc/WebRtcPublisher.ts
@@ -129,6 +129,10 @@ export class WebRtcPublisher {
       (iceServers =>
         new RTCPeerConnection({
           iceServers,
+          // RFC 9725 §4.4.1 requires the WHIP client to use max-bundle. Besides
+          // sharing one transport, this ensures only the offerer-tagged m-line
+          // gathers/trickles ICE candidates (RFC 9725 §4.3.2).
+          bundlePolicy: "max-bundle",
           codecs: this.audioEnabled
             ? { video: [useH264()], audio: [usePCMU()] }
             : { video: [useH264()] },
@@ -521,13 +525,25 @@ function isAcceptedCodecRtpMap(
   codec: string,
   attributeLines: string[]
 ): boolean {
-  const match = line.match(/^a=rtpmap:(\S+)\s+([^/\s]+)/i);
+  const match = line.match(/^a=rtpmap:(\S+)\s+([^/\s]+)\/(\d+)/i);
   if (!match || !formats.has(match[1]) || match[2].toLowerCase() !== codec) {
     return false;
   }
-  return codec !== "h264" || attributeLines.some(fmtp =>
-    fmtp.startsWith(`a=fmtp:${match[1]} `) && /(?:^|;)\s*packetization-mode\s*=\s*1(?:;|$)/i.test(fmtp.slice(fmtp.indexOf(" ") + 1))
-  );
+  if (codec !== "h264") {
+    return true;
+  }
+  // AutoMobile packetizes H.264 at the RFC 6184 fixed 90 kHz clock rate and
+  // uses FU-A, which requires packetization-mode=1. The local werift codec is
+  // constrained-baseline 42e0xx; level may differ when asymmetry is negotiated.
+  return match[3] === "90000" && attributeLines.some(fmtp => {
+    if (!fmtp.startsWith(`a=fmtp:${match[1]} `)) {
+      return false;
+    }
+    const parameters = fmtp.slice(fmtp.indexOf(" ") + 1);
+    const packetizationMode = /(?:^|;)\s*packetization-mode\s*=\s*1(?:;|$)/i.test(parameters);
+    const profile = /(?:^|;)\s*profile-level-id\s*=\s*(42e0[0-9a-f]{2})(?:;|$)/i.test(parameters);
+    return packetizationMode && profile;
+  });
 }
 
 function addWhipRtcpMuxOnly(sdp: string): string {

--- a/src/features/webrtc/WhipClient.ts
+++ b/src/features/webrtc/WhipClient.ts
@@ -99,7 +99,7 @@ export class WhipClient {
       );
     }
 
-    const answerSdp = await response.text();
+    const answerSdp = await this.readTextWithTimeout(response, "POST");
     if (!answerSdp.trim()) {
       throw new ActionableError("WHIP ingest returned an empty SDP answer.");
     }
@@ -198,10 +198,30 @@ export class WhipClient {
 
   private async safeText(response: { text(): Promise<string> }): Promise<string> {
     try {
-      return (await response.text()).slice(0, 300);
+      return (await this.readTextWithTimeout(response, "response")).slice(0, 300);
     } catch (error) {
       logger.debug(`[WHIP] failed to read error response body: ${error}`);
       return "";
+    }
+  }
+
+  /** Keep the request deadline in force when a peer stalls after HTTP headers. */
+  private async readTextWithTimeout(response: { text(): Promise<string> }, method: string): Promise<string> {
+    let timeout: NodeJS.Timeout | undefined;
+    try {
+      return await Promise.race([
+        response.text(),
+        new Promise<never>((_, reject) => {
+          timeout = this.timer.setTimeout(
+            () => reject(new ActionableError(`WHIP ${method} response body timed out after ${this.requestTimeoutMs}ms.`)),
+            this.requestTimeoutMs
+          );
+        }),
+      ]);
+    } finally {
+      if (timeout) {
+        this.timer.clearTimeout(timeout);
+      }
     }
   }
 }

--- a/src/features/webrtc/WhipClient.ts
+++ b/src/features/webrtc/WhipClient.ts
@@ -45,10 +45,16 @@ export interface WhipSession {
 }
 
 /**
- * Client for the WebRTC-HTTP Ingestion Protocol (WHIP, draft-ietf-wish-whip).
+ * Client for the WebRTC-HTTP Ingestion Protocol (WHIP, RFC 9725).
  * The publisher POSTs an SDP offer and receives an SDP answer plus a resource
  * URL; DELETE on that URL tears the session down. Reconnection is a fresh
  * `publish()` (optionally after DELETEing the stale resource).
+ *
+ * Specification: https://www.rfc-editor.org/rfc/rfc9725.html
+ * - setup and `201 Created` / `Location`: §4.2
+ * - trickle-ICE PATCH: §4.3
+ * - DELETE session termination: §4.2
+ * - bearer authentication: §4.7
  */
 export class WhipClient {
   private readonly endpoint: string;

--- a/src/features/webrtc/WhipClient.ts
+++ b/src/features/webrtc/WhipClient.ts
@@ -1,5 +1,8 @@
 import { ActionableError } from "../../models";
 import { logger } from "../../utils/logger";
+import { defaultTimer, type Timer } from "../../utils/SystemTimer";
+
+export const DEFAULT_WHIP_REQUEST_TIMEOUT_MS = 15_000;
 
 /**
  * Minimal `fetch` surface used by the WHIP client, so tests can inject a fake
@@ -26,6 +29,9 @@ export interface WhipClientOptions {
   /** Optional bearer token sent as `Authorization: Bearer <token>`. */
   bearerToken?: string;
   fetchImpl?: FetchLike;
+  /** Bound a stalled WHIP endpoint so start/stop/reconnect cannot hang forever. */
+  requestTimeoutMs?: number;
+  timer?: Timer;
 }
 
 export interface WhipSession {
@@ -48,6 +54,8 @@ export class WhipClient {
   private readonly endpoint: string;
   private readonly bearerToken?: string;
   private readonly fetchImpl: FetchLike;
+  private readonly requestTimeoutMs: number;
+  private readonly timer: Timer;
 
   constructor(options: WhipClientOptions) {
     if (!options.endpoint) {
@@ -60,11 +68,16 @@ export class WhipClient {
     if (!this.fetchImpl) {
       throw new ActionableError("No fetch implementation available for WHIP client.");
     }
+    this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_WHIP_REQUEST_TIMEOUT_MS;
+    if (!Number.isFinite(this.requestTimeoutMs) || this.requestTimeoutMs <= 0) {
+      throw new ActionableError("WHIP request timeout must be a positive number of milliseconds.");
+    }
+    this.timer = options.timer ?? defaultTimer;
   }
 
   /** POST the SDP offer to the ingest endpoint; returns the answer + resource URL. */
   async publish(offerSdp: string, signal?: AbortSignal): Promise<WhipSession> {
-    const response = await this.fetchImpl(this.endpoint, {
+    const response = await this.fetchWithTimeout(this.endpoint, {
       method: "POST",
       headers: this.headers({ "Content-Type": "application/sdp" }),
       body: offerSdp,
@@ -84,10 +97,10 @@ export class WhipClient {
     }
 
     const location = response.headers.get("location");
-    const resourceUrl = location ? this.resolveLocation(location) : null;
-    if (!resourceUrl) {
-      logger.warn("[WHIP] Ingest response omitted a Location header; reconnect/teardown will re-POST.");
+    if (!location) {
+      throw new ActionableError("WHIP ingest response omitted the required Location header.");
     }
+    const resourceUrl = this.resolveLocation(location);
 
     return { answerSdp, resourceUrl };
   }
@@ -103,7 +116,7 @@ export class WhipClient {
     sdpFragment: string,
     signal?: AbortSignal
   ): Promise<void> {
-    const response = await this.fetchImpl(resourceUrl, {
+    const response = await this.fetchWithTimeout(resourceUrl, {
       method: "PATCH",
       headers: this.headers({ "Content-Type": "application/trickle-ice-sdpfrag" }),
       body: sdpFragment,
@@ -118,7 +131,7 @@ export class WhipClient {
 
   /** DELETE the ingest resource to terminate the session (best-effort). */
   async delete(resourceUrl: string, signal?: AbortSignal): Promise<void> {
-    const response = await this.fetchImpl(resourceUrl, {
+    const response = await this.fetchWithTimeout(resourceUrl, {
       method: "DELETE",
       headers: this.headers(),
       signal,
@@ -134,6 +147,27 @@ export class WhipClient {
       headers["Authorization"] = `Bearer ${this.bearerToken}`;
     }
     return headers;
+  }
+
+  private async fetchWithTimeout(
+    url: string,
+    init: { method: string; headers: Record<string, string>; body?: string; signal?: AbortSignal }
+  ): Promise<Awaited<ReturnType<FetchLike>>> {
+    const controller = new AbortController();
+    const onAbort = (): void => controller.abort();
+    init.signal?.addEventListener("abort", onAbort, { once: true });
+    const timeout = this.timer.setTimeout(() => controller.abort(), this.requestTimeoutMs);
+    try {
+      return await this.fetchImpl(url, { ...init, signal: controller.signal });
+    } catch (error) {
+      if (controller.signal.aborted && !init.signal?.aborted) {
+        throw new ActionableError(`WHIP ${init.method} request timed out after ${this.requestTimeoutMs}ms.`);
+      }
+      throw error;
+    } finally {
+      this.timer.clearTimeout(timeout);
+      init.signal?.removeEventListener("abort", onAbort);
+    }
   }
 
   private resolveLocation(location: string): string {

--- a/src/features/webrtc/WhipClient.ts
+++ b/src/features/webrtc/WhipClient.ts
@@ -155,7 +155,11 @@ export class WhipClient {
   ): Promise<Awaited<ReturnType<FetchLike>>> {
     const controller = new AbortController();
     const onAbort = (): void => controller.abort();
-    init.signal?.addEventListener("abort", onAbort, { once: true });
+    if (init.signal?.aborted) {
+      controller.abort();
+    } else {
+      init.signal?.addEventListener("abort", onAbort, { once: true });
+    }
     const timeout = this.timer.setTimeout(() => controller.abort(), this.requestTimeoutMs);
     try {
       return await this.fetchImpl(url, { ...init, signal: controller.signal });

--- a/src/features/webrtc/WhipClient.ts
+++ b/src/features/webrtc/WhipClient.ts
@@ -42,6 +42,8 @@ export interface WhipSession {
    * used to terminate — and, by extension, reconnect (re-publish) — the stream.
    */
   resourceUrl: string | null;
+  /** Strong entity tag for conditional Trickle-ICE PATCH requests. */
+  etag: string | null;
 }
 
 /**
@@ -107,8 +109,9 @@ export class WhipClient {
       throw new ActionableError("WHIP ingest response omitted the required Location header.");
     }
     const resourceUrl = this.resolveLocation(location);
+    const etag = response.headers.get("etag");
 
-    return { answerSdp, resourceUrl };
+    return { answerSdp, resourceUrl, etag };
   }
 
   /**
@@ -119,12 +122,16 @@ export class WhipClient {
    */
   async patchCandidate(
     resourceUrl: string,
+    etag: string,
     sdpFragment: string,
     signal?: AbortSignal
   ): Promise<void> {
     const response = await this.fetchWithTimeout(resourceUrl, {
       method: "PATCH",
-      headers: this.headers({ "Content-Type": "application/trickle-ice-sdpfrag" }),
+      headers: this.headers({
+        "Content-Type": "application/trickle-ice-sdpfrag",
+        "If-Match": etag,
+      }),
       body: sdpFragment,
       signal,
     });

--- a/src/features/webrtc/androidH264CaptureSourceFactory.ts
+++ b/src/features/webrtc/androidH264CaptureSourceFactory.ts
@@ -29,6 +29,7 @@ const defaultDeps: AndroidH264CaptureSourceDeps = {
  */
 class FallbackH264CaptureSource implements H264CaptureSource {
   private active: H264CaptureSource | null = null;
+  private stopped = false;
 
   constructor(
     private readonly persistent: H264CaptureSource,
@@ -36,24 +37,30 @@ class FallbackH264CaptureSource implements H264CaptureSource {
   ) {}
 
   async start(): Promise<void> {
+    this.stopped = false;
+    this.active = this.persistent;
     try {
       await this.persistent.start();
-      this.active = this.persistent;
     } catch (error) {
+      if (this.stopped || this.active !== this.persistent) {
+        return;
+      }
       logger.warn(
         `[webrtc] persistent encoder unavailable, falling back to screenrecord: ${
           error instanceof Error ? error.message : String(error)
         }`
       );
       const screenrecord = this.buildScreenrecord();
-      await screenrecord.start();
       this.active = screenrecord;
+      await screenrecord.start();
     }
   }
 
   async stop(): Promise<void> {
-    await this.active?.stop();
+    this.stopped = true;
+    const active = this.active;
     this.active = null;
+    await active?.stop();
   }
 }
 

--- a/src/features/webrtc/h264.ts
+++ b/src/features/webrtc/h264.ts
@@ -8,6 +8,10 @@
  * (one displayed frame) so every fragment of a frame shares an RTP timestamp,
  * and (3) packetize each NAL unit into RTP payloads per RFC 6184.
  *
+ * Specification: https://www.rfc-editor.org/rfc/rfc6184.html
+ * - single-NAL and FU-A payload structures: §§5.2, 5.6, and 5.8
+ * - RTP marker use for an access unit: §5.1
+ *
  * All functions here are pure / library-agnostic so they can be unit-tested
  * without werift or a device. The publisher (`WebRtcPublisher`) owns RTP header
  * assignment (sequence numbers, timestamps, SSRC, marker bit).
@@ -29,6 +33,7 @@ export const FU_A_TYPE = 28;
 /**
  * Default RTP payload MTU. 1200 bytes leaves headroom under a 1500-byte
  * Ethernet MTU for IP/UDP/RTP/SRTP/DTLS overhead, matching common WebRTC stacks.
+ * This value is an AutoMobile operational choice, not an RFC 6184 requirement.
  */
 export const DEFAULT_RTP_MTU = 1200;
 

--- a/src/features/webrtc/h264Level.ts
+++ b/src/features/webrtc/h264Level.ts
@@ -1,0 +1,23 @@
+/**
+ * The constrained-baseline level advertised by AutoMobile's WebRTC sender.
+ *
+ * Level 4.2 supports 8,192 macroblocks per picture and 522,240 macroblocks
+ * per second (RFC 6184 §8.2.2 and ITU-T H.264 Annex A). That covers AutoMobile's
+ * 1080p/60 Android preset while keeping the SDP offer truthful.
+ * https://www.rfc-editor.org/rfc/rfc6184.html#section-8.2.2
+ */
+export const WEBRTC_H264_PROFILE_LEVEL_ID = "42e02a";
+export const WEBRTC_H264_LEVEL_IDC = 0x2a;
+export const WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME = 8_192;
+
+/** Return the number of 16x16 H.264 macroblocks needed for a frame. */
+export function h264MacroblocksPerFrame(width: number, height: number): number {
+  return Math.ceil(width / 16) * Math.ceil(height / 16);
+}
+
+/** Read `level_idc` from an SPS NAL unit, if it contains the fixed SPS prefix. */
+export function h264SpsLevelIdc(nal: Buffer): number | undefined {
+  // nal[0] is the NAL header; profile_idc, constraint flags, and level_idc
+  // immediately follow it in an SPS RBSP (H.264 §7.3.2.1.1).
+  return nal.length >= 4 && (nal[0] & 0x1f) === 7 ? nal[3] : undefined;
+}

--- a/src/features/webrtc/h264Level.ts
+++ b/src/features/webrtc/h264Level.ts
@@ -32,10 +32,11 @@ export function h264SpsLevelIdc(nal: Buffer): number | undefined {
 
 /** Whether a profile-level-id is compatible with AutoMobile constrained baseline. */
 export function isCompatibleConstrainedBaselineProfile(profileLevelId: string): boolean {
-  // RFC 6184 §8.2.2 permits constraint_set3_flag (bit 4) to vary with the
-  // level for Baseline/Main/Extended profiles; the remaining profile fields
-  // must be symmetric.
+  // RFC 6184 Table 5 defines constrained baseline as profile_idc 66 with
+  // constraint_set1_flag set and the lower four constraint bits clear. The
+  // other constraint flags may vary, so accept every valid representation.
+  // https://www.rfc-editor.org/rfc/rfc6184.html#section-8.2.2
   const profileIdc = Number.parseInt(profileLevelId.slice(0, 2), 16);
   const profileIop = Number.parseInt(profileLevelId.slice(2, 4), 16);
-  return profileIdc === 0x42 && (profileIop & 0xef) === 0xe0;
+  return profileIdc === 0x42 && (profileIop & 0x4f) === 0x40;
 }

--- a/src/features/webrtc/h264Level.ts
+++ b/src/features/webrtc/h264Level.ts
@@ -16,8 +16,26 @@ export function h264MacroblocksPerFrame(width: number, height: number): number {
 }
 
 /** Read `level_idc` from an SPS NAL unit, if it contains the fixed SPS prefix. */
-export function h264SpsLevelIdc(nal: Buffer): number | undefined {
+export function h264SpsProfileLevelId(nal: Buffer): string | undefined {
   // nal[0] is the NAL header; profile_idc, constraint flags, and level_idc
   // immediately follow it in an SPS RBSP (H.264 §7.3.2.1.1).
-  return nal.length >= 4 && (nal[0] & 0x1f) === 7 ? nal[3] : undefined;
+  return nal.length >= 4 && (nal[0] & 0x1f) === 7
+    ? nal.subarray(1, 4).toString("hex")
+    : undefined;
+}
+
+/** Return the level_idc byte from an SPS NAL unit. */
+export function h264SpsLevelIdc(nal: Buffer): number | undefined {
+  const profileLevelId = h264SpsProfileLevelId(nal);
+  return profileLevelId ? Number.parseInt(profileLevelId.slice(4, 6), 16) : undefined;
+}
+
+/** Whether a profile-level-id is compatible with AutoMobile constrained baseline. */
+export function isCompatibleConstrainedBaselineProfile(profileLevelId: string): boolean {
+  // RFC 6184 §8.2.2 permits constraint_set3_flag (bit 4) to vary with the
+  // level for Baseline/Main/Extended profiles; the remaining profile fields
+  // must be symmetric.
+  const profileIdc = Number.parseInt(profileLevelId.slice(0, 2), 16);
+  const profileIop = Number.parseInt(profileLevelId.slice(2, 4), 16);
+  return profileIdc === 0x42 && (profileIop & 0xef) === 0xe0;
 }

--- a/src/features/webrtc/trickleIce.ts
+++ b/src/features/webrtc/trickleIce.ts
@@ -2,10 +2,14 @@
  * Trickle-ICE helpers for the WHIP publisher.
  *
  * WHIP's trickle extension exchanges ICE candidates incrementally as
- * `application/trickle-ice-sdpfrag` bodies (RFC 8840) via HTTP PATCH to the
- * session resource, instead of blocking on ICE gathering before the offer is
- * POSTed. These functions are pure/serialization-only so they can be unit-tested
- * without a peer connection or HTTP.
+ * `application/trickle-ice-sdpfrag` bodies via HTTP PATCH to the session
+ * resource, instead of blocking on ICE gathering before the offer is POSTed.
+ *
+ * Standards: [Trickle ICE (RFC 8838)](https://www.rfc-editor.org/rfc/rfc8838.html),
+ * [SDP fragments (RFC 8840)](https://www.rfc-editor.org/rfc/rfc8840.html), and
+ * [WHIP §4.3 (RFC 9725)](https://www.rfc-editor.org/rfc/rfc9725.html#section-4.3).
+ * These functions are pure/serialization-only so they can be unit-tested without
+ * a peer connection or HTTP.
  */
 
 /** Minimal candidate shape (matches the fields werift's RTCIceCandidate exposes). */

--- a/src/features/webrtc/trickleIce.ts
+++ b/src/features/webrtc/trickleIce.ts
@@ -25,6 +25,13 @@ export interface IceCredentials {
   pwd?: string;
 }
 
+/** SDP context required by RFC 8840 for a media-level candidate fragment. */
+export interface TrickleIceMediaContext {
+  mLine: string;
+  mid: string;
+  ice: Required<IceCredentials>;
+}
+
 /** Ensure the candidate value carries the `candidate:` prefix exactly once. */
 function normalizeCandidateLine(candidate: string): string {
   const trimmed = candidate.trim();
@@ -38,20 +45,28 @@ function normalizeCandidateLine(candidate: string): string {
  */
 export function serializeTrickleFragment(
   candidate: TrickleCandidate,
-  ice: IceCredentials = {}
+  context: TrickleIceMediaContext
 ): string {
-  const lines: string[] = [];
-  if (ice.ufrag) {
-    lines.push(`a=ice-ufrag:${ice.ufrag}`);
-  }
-  if (ice.pwd) {
-    lines.push(`a=ice-pwd:${ice.pwd}`);
-  }
-  if (candidate.sdpMid !== undefined && candidate.sdpMid !== null) {
-    lines.push(`a=mid:${candidate.sdpMid}`);
-  }
+  const lines = [
+    context.mLine,
+    `a=mid:${candidate.sdpMid ?? context.mid}`,
+    `a=ice-ufrag:${context.ice.ufrag}`,
+    `a=ice-pwd:${context.ice.pwd}`,
+  ];
   lines.push(`a=${normalizeCandidateLine(candidate.candidate)}`);
   return `${lines.join("\r\n")}\r\n`;
+}
+
+/** Serialize the terminal marker for one Trickle-ICE media section. */
+export function serializeEndOfCandidates(context: TrickleIceMediaContext): string {
+  return [
+    context.mLine,
+    `a=mid:${context.mid}`,
+    `a=ice-ufrag:${context.ice.ufrag}`,
+    `a=ice-pwd:${context.ice.pwd}`,
+    "a=end-of-candidates",
+    "",
+  ].join("\r\n");
 }
 
 /**
@@ -86,14 +101,35 @@ export class TrickleIceForwarder {
 
   constructor(
     private readonly send: (resourceUrl: string, fragment: string) => void,
-    private readonly ice: IceCredentials = {}
+    private readonly contexts: Map<string, TrickleIceMediaContext>
   ) {}
 
   addCandidate(candidate: TrickleCandidate): void {
     if (this.stopped) {
       return;
     }
-    const fragment = serializeTrickleFragment(candidate, this.ice);
+    const context = this.contextFor(candidate.sdpMid);
+    if (!context) {
+      return;
+    }
+    const fragment = serializeTrickleFragment(candidate, context);
+    if (this.resourceUrl === null) {
+      this.buffered.push(fragment);
+    } else {
+      this.send(this.resourceUrl, fragment);
+    }
+  }
+
+  /** Forward the RFC 8838 end-of-candidates marker once gathering completes. */
+  completeGathering(mid?: string): void {
+    if (this.stopped) {
+      return;
+    }
+    const context = this.contextFor(mid);
+    if (!context) {
+      return;
+    }
+    const fragment = serializeEndOfCandidates(context);
     if (this.resourceUrl === null) {
       this.buffered.push(fragment);
     } else {
@@ -121,4 +157,30 @@ export class TrickleIceForwarder {
     this.stopped = true;
     this.buffered = [];
   }
+
+  private contextFor(mid: string | undefined): TrickleIceMediaContext | undefined {
+    return (mid === undefined ? this.contexts.values().next().value : this.contexts.get(mid));
+  }
+}
+
+/** Extract media-level pseudo-section context from a locally generated SDP offer. */
+export function parseTrickleIceMediaContexts(sdp: string): Map<string, TrickleIceMediaContext> {
+  const sessionIce = extractIceCredentials(sdp.split(/\r?\n(?=m=)/)[0]);
+  const contexts = new Map<string, TrickleIceMediaContext>();
+  for (const section of sdp.split(/\r?\n(?=m=)/).slice(1)) {
+    const lines = section.split(/\r?\n/).filter(Boolean);
+    const mLine = lines[0];
+    const mid = lines.find(line => line.startsWith("a=mid:"))?.slice("a=mid:".length);
+    const ice = { ...sessionIce, ...extractIceCredentials(section) };
+    if (mLine && mid && ice.ufrag && ice.pwd) {
+      contexts.set(mid, { mLine, mid, ice: { ufrag: ice.ufrag, pwd: ice.pwd } });
+    }
+  }
+  return contexts;
+}
+
+function extractIceCredentials(sdp: string): IceCredentials {
+  const ufrag = sdp.match(/^a=ice-ufrag:(.+)$/m)?.[1]?.trim();
+  const pwd = sdp.match(/^a=ice-pwd:(.+)$/m)?.[1]?.trim();
+  return { ufrag, pwd };
 }

--- a/src/features/webrtc/webrtcStreamingConfig.ts
+++ b/src/features/webrtc/webrtcStreamingConfig.ts
@@ -107,7 +107,7 @@ export function parseSize(raw: string | undefined): { width: number; height: num
   if (!match) {
     throw new ActionableError(`Invalid size "${raw}"; expected WIDTHxHEIGHT (e.g. 1280x720).`);
   }
-  return { width: Number(match[1]), height: Number(match[2]) };
+  return validateSize({ width: Number(match[1]), height: Number(match[2]) });
 }
 
 /** Parse a boolean env flag (`1/true/yes/on`, case-insensitive). */
@@ -147,13 +147,17 @@ export function resolveWebRtcStreamingConfig(
 
   const iceServers =
     overrides.iceServers ?? parseIceServers(env[WEBRTC_ENV.ICE_SERVERS]) ?? DEFAULT_ICE_SERVERS;
-  const bitrateKbps = overrides.bitrateKbps ?? parseBitrate(env[WEBRTC_ENV.BITRATE_KBPS]);
-  const size = overrides.size ?? parseSize(env[WEBRTC_ENV.MAX_SIZE]);
+  const bitrateKbps = overrides.bitrateKbps === undefined
+    ? parseBitrate(env[WEBRTC_ENV.BITRATE_KBPS])
+    : validateBitrate(overrides.bitrateKbps);
+  const size = overrides.size === undefined
+    ? parseSize(env[WEBRTC_ENV.MAX_SIZE])
+    : validateSize(overrides.size);
   const trickleIce = overrides.trickleIce ?? parseBooleanFlag(env[WEBRTC_ENV.TRICKLE_ICE]);
   const audioEnabled = overrides.audioEnabled ?? parseBooleanFlag(env[WEBRTC_ENV.AUDIO]);
 
   return {
-    whipEndpoint: whipEndpoint.trim(),
+    whipEndpoint: validateWhipEndpoint(whipEndpoint),
     bearerToken: overrides.bearerToken ?? env[WEBRTC_ENV.WHIP_TOKEN] ?? undefined,
     iceServers,
     bitrateKbps,
@@ -161,4 +165,41 @@ export function resolveWebRtcStreamingConfig(
     trickleIce,
     audioEnabled,
   };
+}
+
+function validateBitrate(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new ActionableError(`Invalid bitrate "${value}"; expected a positive number of kbps.`);
+  }
+  return Math.round(value);
+}
+
+function validateSize(size: { width: number; height: number }): { width: number; height: number } {
+  const { width, height } = size;
+  if (
+    !Number.isSafeInteger(width) ||
+    !Number.isSafeInteger(height) ||
+    width <= 0 ||
+    height <= 0 ||
+    width % 2 !== 0 ||
+    height % 2 !== 0
+  ) {
+    throw new ActionableError(
+      `Invalid size "${width}x${height}"; width and height must be positive even integers.`
+    );
+  }
+  return { width, height };
+}
+
+function validateWhipEndpoint(endpoint: string): string {
+  const trimmed = endpoint.trim();
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      throw new Error("unsupported protocol");
+    }
+  } catch {
+    throw new ActionableError(`Invalid WHIP endpoint "${trimmed}"; expected an absolute http(s) URL.`);
+  }
+  return trimmed;
 }

--- a/src/features/webrtc/webrtcStreamingConfig.ts
+++ b/src/features/webrtc/webrtcStreamingConfig.ts
@@ -1,5 +1,6 @@
 import { ActionableError } from "../../models";
 import type { RTCIceServer } from "werift";
+import { h264MacroblocksPerFrame, WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME } from "./h264Level";
 
 /**
  * WebRTC streaming configuration. On a CI worker this is typically supplied
@@ -182,10 +183,11 @@ function validateSize(size: { width: number; height: number }): { width: number;
     width <= 0 ||
     height <= 0 ||
     width % 2 !== 0 ||
-    height % 2 !== 0
+    height % 2 !== 0 ||
+    h264MacroblocksPerFrame(width, height) > WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME
   ) {
     throw new ActionableError(
-      `Invalid size "${width}x${height}"; width and height must be positive even integers.`
+      `Invalid size "${width}x${height}"; width and height must be positive even integers within the H.264 Level 4.2 frame limit.`
     );
   }
   return { width, height };

--- a/src/server/webrtcStreamManager.ts
+++ b/src/server/webrtcStreamManager.ts
@@ -211,6 +211,47 @@ function stoppedPendingDescriptor(pending: PendingWebRtcStart): WebRtcStreamDesc
   };
 }
 
+/** Cancel a pending-only start, or return undefined when an active record must stop. */
+function stopPendingStart(streamId?: string): WebRtcStreamDescriptor | undefined {
+  if (!streamId && streams.size > 0 && startingStreamIds.size > 0) {
+    throw new ActionableError("Multiple WebRTC streams are active or starting; specify streamId to stop one.");
+  }
+  const pending = streamId
+    ? startingStreamIds.get(streamId)
+    : startingStreamIds.size === 1
+      ? startingStreamIds.values().next().value
+      : undefined;
+  if (!pending || streams.has(pending.streamId)) {
+    return undefined;
+  }
+  pending.cancelled = true;
+  startingDeviceIds.delete(pending.device.deviceId);
+  startingStreamIds.delete(pending.streamId);
+  return stoppedPendingDescriptor(pending);
+}
+
+/** Remove the matching reservation without affecting a replacement stream start. */
+function cancelRecordStart(record: WebRtcStreamRecord): void {
+  const pending = startingStreamIds.get(record.streamId);
+  if (pending?.token === record.startToken) {
+    pending.cancelled = true;
+    startingStreamIds.delete(record.streamId);
+  }
+  if (startingDeviceIds.get(record.device.deviceId)?.token === record.startToken) {
+    startingDeviceIds.delete(record.device.deviceId);
+  }
+}
+
+/** Stop live media components while retaining best-effort cleanup semantics. */
+async function stopActiveRecord(record: WebRtcStreamRecord): Promise<void> {
+  await record.source?.stop().catch(error => {
+    logger.debug(`[WebRtcStream] source stop failed: ${error}`);
+  });
+  await record.publisher.stop().catch(error => {
+    logger.debug(`[WebRtcStream] publisher stop failed: ${error}`);
+  });
+}
+
 /**
  * Start publishing a device's screen to the configured coordination server over
  * WHIP. Android capture prefers the persistent on-device encoder and falls back
@@ -358,41 +399,15 @@ export async function startWebRtcStream(
 
 /** Stop a stream by id, or the sole active stream when id is omitted. */
 export async function stopWebRtcStream(streamId?: string): Promise<WebRtcStreamDescriptor> {
-  if (!streamId && streams.size > 0 && startingStreamIds.size > 0) {
-    throw new ActionableError("Multiple WebRTC streams are active or starting; specify streamId to stop one.");
-  }
-  const pending = streamId
-    ? startingStreamIds.get(streamId)
-    : startingStreamIds.size === 1
-      ? startingStreamIds.values().next().value
-      : undefined;
-  if (pending && !streams.has(pending.streamId)) {
-    pending.cancelled = true;
-    startingDeviceIds.delete(pending.device.deviceId);
-    startingStreamIds.delete(pending.streamId);
-    return stoppedPendingDescriptor(pending);
+  const stoppedPending = stopPendingStart(streamId);
+  if (stoppedPending) {
+    return stoppedPending;
   }
   const record = resolveStreamRecord(streamId);
   streams.delete(record.streamId);
-  const recordPending = startingStreamIds.get(record.streamId);
-  if (recordPending?.token === record.startToken) {
-    recordPending.cancelled = true;
-  }
-  if (startingDeviceIds.get(record.device.deviceId)?.token === record.startToken) {
-    startingDeviceIds.delete(record.device.deviceId);
-  }
-  if (startingStreamIds.get(record.streamId)?.token === record.startToken) {
-    startingStreamIds.delete(record.streamId);
-  }
+  cancelRecordStart(record);
   const descriptor = record.publisher.getDescriptor();
-
-  await record.source?.stop().catch(error => {
-    logger.debug(`[WebRtcStream] source stop failed: ${error}`);
-  });
-  await record.publisher.stop().catch(error => {
-    logger.debug(`[WebRtcStream] publisher stop failed: ${error}`);
-  });
-
+  await stopActiveRecord(record);
   return { ...descriptor, state: "stopped" };
 }
 

--- a/src/server/webrtcStreamManager.ts
+++ b/src/server/webrtcStreamManager.ts
@@ -36,6 +36,14 @@ interface WebRtcStreamRecord {
   startToken: symbol;
 }
 
+interface PendingWebRtcStart {
+  streamId: string;
+  device: BootedDevice;
+  config: ReturnType<typeof resolveWebRtcStreamingConfig>;
+  token: symbol;
+  cancelled: boolean;
+}
+
 export interface WebRtcStreamManagerDependencies {
   idGenerator: IdGenerator;
   createPublisher: (config: WebRtcPublisherConfig, deps: WebRtcPublisherDeps) => WebRtcPublisher;
@@ -61,8 +69,8 @@ const defaultDependencies: WebRtcStreamManagerDependencies = {
 
 let dependencies: WebRtcStreamManagerDependencies = { ...defaultDependencies };
 const streams = new Map<string, WebRtcStreamRecord>();
-const startingDeviceIds = new Map<string, symbol>();
-const startingStreamIds = new Map<string, symbol>();
+const startingDeviceIds = new Map<string, PendingWebRtcStart>();
+const startingStreamIds = new Map<string, PendingWebRtcStart>();
 const INITIAL_AUDIO_SOURCE_START_TIMEOUT_MS = 30_000;
 
 /** Override manager dependencies (tests). */
@@ -189,6 +197,20 @@ function assertStreamStartAvailable(deviceId: string, streamId: string): void {
   }
 }
 
+function stoppedPendingDescriptor(pending: PendingWebRtcStart): WebRtcStreamDescriptor {
+  return {
+    streamId: pending.streamId,
+    state: "stopped",
+    whipEndpoint: pending.config.whipEndpoint,
+    resourceUrl: null,
+    iceServers: pending.config.iceServers,
+    framesSent: 0,
+    packetsSent: 0,
+    audioPacketsSent: 0,
+    audioSamplesSent: 0,
+  };
+}
+
 /**
  * Start publishing a device's screen to the configured coordination server over
  * WHIP. Android capture prefers the persistent on-device encoder and falls back
@@ -206,8 +228,15 @@ export async function startWebRtcStream(
   assertStreamStartAvailable(request.device.deviceId, streamId);
 
   const startToken = Symbol(streamId);
-  startingDeviceIds.set(request.device.deviceId, startToken);
-  startingStreamIds.set(streamId, startToken);
+  const pending: PendingWebRtcStart = {
+    streamId,
+    device: request.device,
+    config,
+    token: startToken,
+    cancelled: false,
+  };
+  startingDeviceIds.set(request.device.deviceId, pending);
+  startingStreamIds.set(streamId, pending);
   try {
     const bitrateBps = config.bitrateKbps ? config.bitrateKbps * 1000 : undefined;
 
@@ -218,6 +247,9 @@ export async function startWebRtcStream(
     // startSource() only constructs the (synchronous) capture source. A degrade
     // returns null → screenrecord.
     const jarPath = await dependencies.resolveVideoJar(request.device);
+    if (pending.cancelled) {
+      throw new ActionableError(`WebRTC stream ${streamId} was stopped before startup completed.`);
+    }
 
     let settleInitialAudioSourceStart:
     | ((result: { ok: true } | { ok: false; error: unknown }) => void)
@@ -315,10 +347,10 @@ export async function startWebRtcStream(
 
     return publisher.getDescriptor();
   } finally {
-    if (startingDeviceIds.get(request.device.deviceId) === startToken) {
+    if (startingDeviceIds.get(request.device.deviceId) === pending) {
       startingDeviceIds.delete(request.device.deviceId);
     }
-    if (startingStreamIds.get(streamId) === startToken) {
+    if (startingStreamIds.get(streamId) === pending) {
       startingStreamIds.delete(streamId);
     }
   }
@@ -326,12 +358,27 @@ export async function startWebRtcStream(
 
 /** Stop a stream by id, or the sole active stream when id is omitted. */
 export async function stopWebRtcStream(streamId?: string): Promise<WebRtcStreamDescriptor> {
+  const pending = streamId
+    ? startingStreamIds.get(streamId)
+    : startingStreamIds.size === 1
+      ? startingStreamIds.values().next().value
+      : undefined;
+  if (pending && !streams.has(pending.streamId)) {
+    pending.cancelled = true;
+    startingDeviceIds.delete(pending.device.deviceId);
+    startingStreamIds.delete(pending.streamId);
+    return stoppedPendingDescriptor(pending);
+  }
   const record = resolveStreamRecord(streamId);
   streams.delete(record.streamId);
-  if (startingDeviceIds.get(record.device.deviceId) === record.startToken) {
+  const recordPending = startingStreamIds.get(record.streamId);
+  if (recordPending?.token === record.startToken) {
+    recordPending.cancelled = true;
+  }
+  if (startingDeviceIds.get(record.device.deviceId)?.token === record.startToken) {
     startingDeviceIds.delete(record.device.deviceId);
   }
-  if (startingStreamIds.get(record.streamId) === record.startToken) {
+  if (startingStreamIds.get(record.streamId)?.token === record.startToken) {
     startingStreamIds.delete(record.streamId);
   }
   const descriptor = record.publisher.getDescriptor();

--- a/src/server/webrtcStreamManager.ts
+++ b/src/server/webrtcStreamManager.ts
@@ -42,6 +42,8 @@ interface PendingWebRtcStart {
   config: ReturnType<typeof resolveWebRtcStreamingConfig>;
   token: symbol;
   cancelled: boolean;
+  /** Reject an audio startup waiter when this exact reservation is stopped. */
+  onCancelled?: () => void;
 }
 
 export interface WebRtcStreamManagerDependencies {
@@ -225,6 +227,7 @@ function stopPendingStart(streamId?: string): WebRtcStreamDescriptor | undefined
     return undefined;
   }
   pending.cancelled = true;
+  pending.onCancelled?.();
   startingDeviceIds.delete(pending.device.deviceId);
   startingStreamIds.delete(pending.streamId);
   return stoppedPendingDescriptor(pending);
@@ -235,6 +238,7 @@ function cancelRecordStart(record: WebRtcStreamRecord): void {
   const pending = startingStreamIds.get(record.streamId);
   if (pending?.token === record.startToken) {
     pending.cancelled = true;
+    pending.onCancelled?.();
     startingStreamIds.delete(record.streamId);
   }
   if (startingDeviceIds.get(record.device.deviceId)?.token === record.startToken) {
@@ -296,6 +300,7 @@ export async function startWebRtcStream(
     | ((result: { ok: true } | { ok: false; error: unknown }) => void)
     | undefined;
     let initialAudioSourceStartSettled = false;
+    let initialAudioSourceStartStarted = false;
     const initialAudioSourceStart = config.audioEnabled
       ? new Promise<void>((resolve, reject) => {
         settleInitialAudioSourceStart = result => {
@@ -316,6 +321,14 @@ export async function startWebRtcStream(
         return;
       }
       settleInitialAudioSourceStart?.(error ? { ok: false, error } : { ok: true });
+    };
+    pending.onCancelled = () => {
+      // Once onConnected has begun starting the source, let that operation
+      // report its own result. This preserves a real source-start failure when
+      // a replacement stream is started with the same id.
+      if (!initialAudioSourceStartStarted) {
+        settleInitialAudioStart(new Error(`WebRTC stream ${streamId} was stopped before capture source started.`));
+      }
     };
 
     const publisherRef: { current?: WebRtcPublisher } = {};
@@ -338,6 +351,7 @@ export async function startWebRtcStream(
             return;
           }
           try {
+            initialAudioSourceStartStarted = true;
             const started = await startSource(currentRecord);
             if (!started) {
               const error = new Error(`WebRTC stream ${streamId} stopped before capture source started.`);

--- a/src/server/webrtcStreamManager.ts
+++ b/src/server/webrtcStreamManager.ts
@@ -32,6 +32,8 @@ interface WebRtcStreamRecord {
   size?: { width: number; height: number };
   audioEnabled: boolean;
   startedAt: string;
+  /** Reservation token for a start that has not returned to its caller yet. */
+  startToken: symbol;
 }
 
 export interface WebRtcStreamManagerDependencies {
@@ -59,6 +61,8 @@ const defaultDependencies: WebRtcStreamManagerDependencies = {
 
 let dependencies: WebRtcStreamManagerDependencies = { ...defaultDependencies };
 const streams = new Map<string, WebRtcStreamRecord>();
+const startingDeviceIds = new Map<string, symbol>();
+const startingStreamIds = new Map<string, symbol>();
 const INITIAL_AUDIO_SOURCE_START_TIMEOUT_MS = 30_000;
 
 /** Override manager dependencies (tests). */
@@ -71,6 +75,8 @@ export function setWebRtcStreamManagerDependencies(
 /** Reset manager state and dependencies (tests). */
 export function resetWebRtcStreamManager(): void {
   streams.clear();
+  startingDeviceIds.clear();
+  startingStreamIds.clear();
   dependencies = { ...defaultDependencies };
 }
 
@@ -171,6 +177,18 @@ async function cleanupFailedStart(
   await publisher.stop().catch(() => {});
 }
 
+function assertStreamStartAvailable(deviceId: string, streamId: string): void {
+  const existing = activeStreamForDevice(deviceId);
+  if (existing || startingDeviceIds.has(deviceId)) {
+    throw new ActionableError(
+      `WebRTC stream already active or starting for device ${deviceId} (streamId ${existing?.streamId ?? "pending"}). Stop it first.`
+    );
+  }
+  if (streams.has(streamId) || startingStreamIds.has(streamId)) {
+    throw new ActionableError(`WebRTC stream ${streamId} already active. Stop it first.`);
+  }
+}
+
 /**
  * Start publishing a device's screen to the configured coordination server over
  * WHIP. Android capture prefers the persistent on-device encoder and falls back
@@ -181,133 +199,141 @@ async function cleanupFailedStart(
 export async function startWebRtcStream(
   request: StartWebRtcStreamRequest
 ): Promise<WebRtcStreamDescriptor> {
-  const existing = activeStreamForDevice(request.device.deviceId);
-  if (existing) {
-    throw new ActionableError(
-      `WebRTC stream already active for device ${request.device.deviceId} (streamId ${existing.streamId}). Stop it first.`
-    );
-  }
-
   const config = resolveWebRtcStreamingConfig(request.overrides);
   const streamId = request.streamId ?? `webrtc_${dependencies.idGenerator.next()}`;
-
   // An explicit id reused across devices would otherwise overwrite the existing
-  // record here, orphaning the first stream's publisher/source (leaking the
-  // screenrecord/WHIP session and hiding it from list/stop).
-  if (streams.has(streamId)) {
-    throw new ActionableError(`WebRTC stream ${streamId} already active. Stop it first.`);
-  }
+  // record, orphaning the first stream's publisher/source.
+  assertStreamStartAvailable(request.device.deviceId, streamId);
 
-  const bitrateBps = config.bitrateKbps ? config.bitrateKbps * 1000 : undefined;
+  const startToken = Symbol(streamId);
+  startingDeviceIds.set(request.device.deviceId, startToken);
+  startingStreamIds.set(streamId, startToken);
+  try {
+    const bitrateBps = config.bitrateKbps ? config.bitrateKbps * 1000 : undefined;
 
-  // Resolve the persistent-encoder jar ONCE, before establishing the WHIP
-  // session — a fatal fail-mode (checksum mismatch, or REQUIRE with nothing
-  // available) must abort the stream start with its ActionableError rather than
-  // surfacing mid-capture. The download resolves here, off the per-frame path;
-  // startSource() only constructs the (synchronous) capture source. A degrade
-  // returns null → screenrecord.
-  const jarPath = await dependencies.resolveVideoJar(request.device);
+    // Resolve the persistent-encoder jar ONCE, before establishing the WHIP
+    // session — a fatal fail-mode (checksum mismatch, or REQUIRE with nothing
+    // available) must abort the stream start with its ActionableError rather than
+    // surfacing mid-capture. The download resolves here, off the per-frame path;
+    // startSource() only constructs the (synchronous) capture source. A degrade
+    // returns null → screenrecord.
+    const jarPath = await dependencies.resolveVideoJar(request.device);
 
-  let settleInitialAudioSourceStart:
+    let settleInitialAudioSourceStart:
     | ((result: { ok: true } | { ok: false; error: unknown }) => void)
     | undefined;
-  let initialAudioSourceStartSettled = false;
-  const initialAudioSourceStart = config.audioEnabled
-    ? new Promise<void>((resolve, reject) => {
-      settleInitialAudioSourceStart = result => {
-        if (initialAudioSourceStartSettled) {
-          return;
-        }
-        initialAudioSourceStartSettled = true;
-        if (result.ok) {
-          resolve();
-        } else {
-          reject(result.error);
-        }
-      };
-    })
-    : null;
-  const settleInitialAudioStart = (error?: unknown): void => {
-    if (!config.audioEnabled) {
-      return;
-    }
-    settleInitialAudioSourceStart?.(error ? { ok: false, error } : { ok: true });
-  };
-
-  const publisherRef: { current?: WebRtcPublisher } = {};
-  const publisher = dependencies.createPublisher(
-    {
-      streamId,
-      whipEndpoint: config.whipEndpoint,
-      bearerToken: config.bearerToken,
-      iceServers: config.iceServers,
-      bitrateBps,
-      trickleIce: config.trickleIce,
-      audioEnabled: config.audioEnabled,
-    },
-    {
-      onBeforeEstablish: () => withRecord(streamId, stopSource),
-      onConnected: async () => {
-        const currentRecord = streams.get(streamId);
-        if (!currentRecord || currentRecord.publisher !== publisherRef.current) {
-          settleInitialAudioStart(new Error(`WebRTC stream ${streamId} stopped before capture source started.`));
-          return;
-        }
-        try {
-          const started = await startSource(currentRecord);
-          if (!started) {
-            const error = new Error(`WebRTC stream ${streamId} stopped before capture source started.`);
-            settleInitialAudioStart(error);
-            if (config.audioEnabled) {
-              throw error;
-            }
+    let initialAudioSourceStartSettled = false;
+    const initialAudioSourceStart = config.audioEnabled
+      ? new Promise<void>((resolve, reject) => {
+        settleInitialAudioSourceStart = result => {
+          if (initialAudioSourceStartSettled) {
             return;
           }
-          settleInitialAudioStart();
-        } catch (error) {
-          settleInitialAudioStart(error);
-          throw error;
-        }
-      },
-    }
-  );
-  publisherRef.current = publisher;
-  const record: WebRtcStreamRecord = {
-    streamId,
-    device: request.device,
-    publisher,
-    source: null,
-    jarPath,
-    bitrateBps,
-    size: config.size,
-    audioEnabled: config.audioEnabled,
-    startedAt: dependencies.now().toISOString(),
-  };
-  streams.set(streamId, record);
+          initialAudioSourceStartSettled = true;
+          if (result.ok) {
+            resolve();
+          } else {
+            reject(result.error);
+          }
+        };
+      })
+      : null;
+    const settleInitialAudioStart = (error?: unknown): void => {
+      if (!config.audioEnabled) {
+        return;
+      }
+      settleInitialAudioSourceStart?.(error ? { ok: false, error } : { ok: true });
+    };
 
-  try {
-    await publisher.start();
-    if (initialAudioSourceStart) {
-      await withTimeout(
-        initialAudioSourceStart,
-        INITIAL_AUDIO_SOURCE_START_TIMEOUT_MS,
-        "Timed out waiting for WebRTC audio capture source to start."
+    const publisherRef: { current?: WebRtcPublisher } = {};
+    const publisher = dependencies.createPublisher(
+      {
+        streamId,
+        whipEndpoint: config.whipEndpoint,
+        bearerToken: config.bearerToken,
+        iceServers: config.iceServers,
+        bitrateBps,
+        trickleIce: config.trickleIce,
+        audioEnabled: config.audioEnabled,
+      },
+      {
+        onBeforeEstablish: () => withRecord(streamId, stopSource),
+        onConnected: async () => {
+          const currentRecord = streams.get(streamId);
+          if (!currentRecord || currentRecord.publisher !== publisherRef.current) {
+            settleInitialAudioStart(new Error(`WebRTC stream ${streamId} stopped before capture source started.`));
+            return;
+          }
+          try {
+            const started = await startSource(currentRecord);
+            if (!started) {
+              const error = new Error(`WebRTC stream ${streamId} stopped before capture source started.`);
+              settleInitialAudioStart(error);
+              if (config.audioEnabled) {
+                throw error;
+              }
+              return;
+            }
+            settleInitialAudioStart();
+          } catch (error) {
+            settleInitialAudioStart(error);
+            throw error;
+          }
+        },
+      }
+    );
+    publisherRef.current = publisher;
+    const record: WebRtcStreamRecord = {
+      streamId,
+      device: request.device,
+      publisher,
+      source: null,
+      jarPath,
+      bitrateBps,
+      size: config.size,
+      audioEnabled: config.audioEnabled,
+      startedAt: dependencies.now().toISOString(),
+      startToken,
+    };
+    streams.set(streamId, record);
+
+    try {
+      await publisher.start();
+      if (initialAudioSourceStart) {
+        await withTimeout(
+          initialAudioSourceStart,
+          INITIAL_AUDIO_SOURCE_START_TIMEOUT_MS,
+          "Timed out waiting for WebRTC audio capture source to start."
+        );
+      }
+    } catch (error) {
+      await cleanupFailedStart(streamId, record, publisher);
+      throw new ActionableError(
+        `Failed to start WebRTC stream: ${error instanceof Error ? error.message : String(error)}`
       );
     }
-  } catch (error) {
-    await cleanupFailedStart(streamId, record, publisher);
-    throw new ActionableError(
-      `Failed to start WebRTC stream: ${error instanceof Error ? error.message : String(error)}`
-    );
-  }
 
-  return publisher.getDescriptor();
+    return publisher.getDescriptor();
+  } finally {
+    if (startingDeviceIds.get(request.device.deviceId) === startToken) {
+      startingDeviceIds.delete(request.device.deviceId);
+    }
+    if (startingStreamIds.get(streamId) === startToken) {
+      startingStreamIds.delete(streamId);
+    }
+  }
 }
 
 /** Stop a stream by id, or the sole active stream when id is omitted. */
 export async function stopWebRtcStream(streamId?: string): Promise<WebRtcStreamDescriptor> {
   const record = resolveStreamRecord(streamId);
   streams.delete(record.streamId);
+  if (startingDeviceIds.get(record.device.deviceId) === record.startToken) {
+    startingDeviceIds.delete(record.device.deviceId);
+  }
+  if (startingStreamIds.get(record.streamId) === record.startToken) {
+    startingStreamIds.delete(record.streamId);
+  }
   const descriptor = record.publisher.getDescriptor();
 
   await record.source?.stop().catch(error => {

--- a/src/server/webrtcStreamManager.ts
+++ b/src/server/webrtcStreamManager.ts
@@ -358,6 +358,9 @@ export async function startWebRtcStream(
 
 /** Stop a stream by id, or the sole active stream when id is omitted. */
 export async function stopWebRtcStream(streamId?: string): Promise<WebRtcStreamDescriptor> {
+  if (!streamId && streams.size > 0 && startingStreamIds.size > 0) {
+    throw new ActionableError("Multiple WebRTC streams are active or starting; specify streamId to stop one.");
+  }
   const pending = streamId
     ? startingStreamIds.get(streamId)
     : startingStreamIds.size === 1

--- a/test/daemon/videoStreamSocketServer.test.ts
+++ b/test/daemon/videoStreamSocketServer.test.ts
@@ -253,6 +253,56 @@ describe("VideoStreamSocketServer", () => {
     expect(source.started).toBe(false);
   });
 
+  test("keeps a replacement capture when an abandoned startup later fails", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "amvs-replacement-capture-"));
+    const socketPath = path.join(dir, "video-stream.sock");
+    const abandonedSource = new FakeCaptureSource();
+    const replacementSource = new FakeCaptureSource();
+    let resolveAbandonedSource: ((source: H264CaptureSource) => void) | undefined;
+    let sourceCalls = 0;
+    const server = new VideoStreamSocketServer(
+      {
+        resolveDevice: async () => DEVICE,
+        createCaptureSource: async () => {
+          sourceCalls++;
+          if (sourceCalls === 1) {
+            return await new Promise<H264CaptureSource>(resolve => { resolveAbandonedSource = resolve; });
+          }
+          return replacementSource;
+        },
+        nowUs: () => 1_000n,
+      },
+      socketPath
+    );
+    await server.start();
+    harnesses.push({
+      server,
+      socketPath,
+      sources: [abandonedSource, replacementSource],
+      emit: () => {},
+      cleanup: async () => {
+        await server.close();
+        rmSync(dir, { recursive: true, force: true });
+      },
+    });
+
+    const abandonedSocket = net.createConnection(socketPath);
+    await new Promise<void>(resolve => abandonedSocket.once("connect", resolve));
+    abandonedSocket.write(`${JSON.stringify({ action: "subscribe", deviceId: DEVICE.deviceId })}\n`);
+    await waitFor(() => resolveAbandonedSource !== undefined);
+    abandonedSocket.destroy();
+    await waitFor(() => server.activeDeviceIds().length === 0);
+
+    const replacement = await subscribe(socketPath);
+    expect(replacement.ack.success).toBe(true);
+    expect(server.activeDeviceIds()).toEqual([DEVICE.deviceId]);
+
+    resolveAbandonedSource?.(abandonedSource);
+    await waitFor(() => abandonedSource.stopped);
+    expect(server.activeDeviceIds()).toEqual([DEVICE.deviceId]);
+    expect(server.subscriberCount(DEVICE.deviceId)).toBe(1);
+  });
+
   test("uses the shared capture dimensions for every viewer", async () => {
     const h = await startHarness();
     await subscribe(h.socketPath, {

--- a/test/daemon/videoStreamSocketServer.test.ts
+++ b/test/daemon/videoStreamSocketServer.test.ts
@@ -171,7 +171,7 @@ describe("VideoStreamSocketServer", () => {
     const { binary } = await subscribe(h.socketPath);
     await waitFor(() => binary().length >= 12);
 
-    h.emit(Buffer.from([0x00, 0x00, 0x00, 0x01, 0x01, 0xaa, 0xbb]));
+    h.emit(Buffer.from([0x00, 0x00, 0x00, 0x01, 0x01, 0xaa, 0xbb, 0x00, 0x00, 0x00, 0x01, 0x01]));
     await waitFor(() => binary().length > 12);
 
     expect(h.sources).toHaveLength(1);
@@ -180,6 +180,21 @@ describe("VideoStreamSocketServer", () => {
     const packet = binary().subarray(12);
     expect(packet.readInt32BE(8)).toBe(7); // payload length
     expect(packet.subarray(12, 19)).toEqual(Buffer.from([0x00, 0x00, 0x00, 0x01, 0x01, 0xaa, 0xbb]));
+  });
+
+  test("does not mistake arbitrary source chunks for complete H.264 NAL units", async () => {
+    const h = await startHarness();
+    const { binary } = await subscribe(h.socketPath);
+    await waitFor(() => binary().length >= 12);
+
+    h.emit(Buffer.from([0x00, 0x00]));
+    h.emit(Buffer.from([0x00, 0x01, 0x05, 0xaa, 0xbb, 0x00, 0x00, 0x00, 0x01, 0x01]));
+    await waitFor(() => binary().length > 12);
+
+    const packet = binary().subarray(12);
+    expect(packet.readInt32BE(8)).toBe(7);
+    expect(packet.subarray(12, 19)).toEqual(Buffer.from([0x00, 0x00, 0x00, 0x01, 0x05, 0xaa, 0xbb]));
+    expect(packet.readBigInt64BE(0) & (1n << 62n)).toBe(1n << 62n); // IDR sets key-frame.
   });
 
   test("a second viewer of the same device shares the capture", async () => {
@@ -193,13 +208,31 @@ describe("VideoStreamSocketServer", () => {
     expect(h.sources).toHaveLength(1);
   });
 
+  test("uses the shared capture dimensions for every viewer", async () => {
+    const h = await startHarness();
+    await subscribe(h.socketPath, {
+      action: "subscribe",
+      deviceId: DEVICE.deviceId,
+      size: { width: 640, height: 360 },
+    });
+    const later = await subscribe(h.socketPath, {
+      action: "subscribe",
+      deviceId: DEVICE.deviceId,
+      size: { width: 1920, height: 1080 },
+    });
+    await waitFor(() => later.binary().length >= 12);
+
+    expect(later.binary().readInt32BE(4)).toBe(640);
+    expect(later.binary().readInt32BE(8)).toBe(360);
+  });
+
   test("both viewers receive the same packet", async () => {
     const h = await startHarness();
     const first = await subscribe(h.socketPath);
     const second = await subscribe(h.socketPath);
     await waitFor(() => first.binary().length >= 12 && second.binary().length >= 12);
 
-    h.emit(Buffer.from([0x00, 0x00, 0x00, 0x01, 0x01, 0x42]));
+    h.emit(Buffer.from([0x00, 0x00, 0x00, 0x01, 0x05, 0x42, 0x00, 0x00, 0x00, 0x01, 0x01]));
     await waitFor(() => first.binary().length > 12 && second.binary().length > 12);
 
     expect(first.binary().subarray(12)).toEqual(second.binary().subarray(12));
@@ -227,7 +260,7 @@ describe("VideoStreamSocketServer", () => {
 
     // SPS arrives before the second viewer connects.
     const sps = Buffer.from([0x00, 0x00, 0x00, 0x01, 0x07, 0x64, 0x00]);
-    h.emit(sps);
+    h.emit(Buffer.concat([sps, Buffer.from([0x00, 0x00, 0x00, 0x01, 0x08])]));
 
     const late = await subscribe(h.socketPath);
     await waitFor(() => late.binary().length > 12);

--- a/test/daemon/videoStreamSocketServer.test.ts
+++ b/test/daemon/videoStreamSocketServer.test.ts
@@ -208,6 +208,51 @@ describe("VideoStreamSocketServer", () => {
     expect(h.sources).toHaveLength(1);
   });
 
+  test("stops a capture source that resolves after its only subscriber disconnects", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "amvs-late-source-"));
+    const socketPath = path.join(dir, "video-stream.sock");
+    const source = new FakeCaptureSource();
+    let resolveSource: ((source: H264CaptureSource) => void) | undefined;
+    const sourceCreated = new Promise<void>(resolve => {
+      const server = new VideoStreamSocketServer(
+        {
+          resolveDevice: async () => DEVICE,
+          createCaptureSource: async () => {
+            resolve();
+            return await new Promise<H264CaptureSource>(sourceResolve => { resolveSource = sourceResolve; });
+          },
+          nowUs: () => 1_000n,
+        },
+        socketPath
+      );
+      void server.start().then(() => {
+        harnesses.push({
+          server,
+          socketPath,
+          sources: [source],
+          emit: () => {},
+          cleanup: async () => {
+            await server.close();
+            rmSync(dir, { recursive: true, force: true });
+          },
+        });
+      });
+    });
+
+    await waitFor(() => harnesses.some(h => h.socketPath === socketPath));
+    const harness = harnesses.find(h => h.socketPath === socketPath)!;
+    const socket = net.createConnection(socketPath);
+    await new Promise<void>(resolve => socket.once("connect", resolve));
+    socket.write(`${JSON.stringify({ action: "subscribe", deviceId: DEVICE.deviceId })}\n`);
+    await sourceCreated;
+    socket.destroy();
+    await waitFor(() => harness.server.activeDeviceIds().length === 0);
+    resolveSource?.(source);
+
+    await waitFor(() => source.stopped);
+    expect(source.started).toBe(false);
+  });
+
   test("uses the shared capture dimensions for every viewer", async () => {
     const h = await startHarness();
     await subscribe(h.socketPath, {
@@ -270,6 +315,22 @@ describe("VideoStreamSocketServer", () => {
     expect(packet.readInt32BE(8)).toBe(sps.length);
     expect(packet.subarray(12, 12 + sps.length)).toEqual(sps);
     expect(packet.readBigInt64BE(0)).toBeLessThan(0n); // CONFIG flag is bit 63
+  });
+
+  test("forwards a PPS that arrives after a late viewer's replayed SPS", async () => {
+    const h = await startHarness();
+    await subscribe(h.socketPath);
+    const sps = Buffer.from([0x00, 0x00, 0x00, 0x01, 0x07, 0x64]);
+    const pps = Buffer.from([0x00, 0x00, 0x00, 0x01, 0x08, 0xee]);
+    const idr = Buffer.from([0x00, 0x00, 0x00, 0x01, 0x05, 0xaa]);
+    h.emit(Buffer.concat([sps, pps]));
+
+    const late = await subscribe(h.socketPath);
+    h.emit(Buffer.concat([idr, Buffer.from([0x00, 0x00, 0x00, 0x01, 0x01])]));
+    await waitFor(() => late.binary().includes(pps) && late.binary().includes(idr));
+
+    expect(late.binary().includes(pps)).toBe(true);
+    expect(late.binary().includes(idr)).toBe(true);
   });
 
   test("a failed capture start is reported and starts nothing", async () => {

--- a/test/features/webrtc/AndroidH264Source.test.ts
+++ b/test/features/webrtc/AndroidH264Source.test.ts
@@ -27,7 +27,8 @@ class FakeProcess extends EventEmitter implements SpawnedProcess {
 function fakeAdbFactory(
   commands: string[] = [],
   spawnArgs: string[][] = [],
-  processes: FakeProcess[] = []
+  processes: FakeProcess[] = [],
+  wmSizeOutput = ""
 ): AdbClientFactory {
   return {
     create() {
@@ -35,7 +36,7 @@ function fakeAdbFactory(
         getAdbPathOnly: async () => "adb",
         executeCommand: async (command: string) => {
           commands.push(command);
-          return { stdout: "", stderr: "", exitCode: 0 };
+          return { stdout: wmSizeOutput, stderr: "", exitCode: 0 };
         },
         spawn: async (args: string[]) => {
           spawnArgs.push(args);
@@ -48,7 +49,10 @@ function fakeAdbFactory(
   };
 }
 
-function makeSource(overrides: Partial<Parameters<typeof AndroidH264Source.prototype.constructor>[0]> = {}) {
+function makeSource(
+  overrides: Partial<Parameters<typeof AndroidH264Source.prototype.constructor>[0]> = {},
+  wmSizeOutput = ""
+) {
   const chunks: Buffer[] = [];
   const processes: FakeProcess[] = [];
   const commands: string[] = [];
@@ -58,7 +62,7 @@ function makeSource(overrides: Partial<Parameters<typeof AndroidH264Source.proto
   const source = new AndroidH264Source({
     device: DEVICE,
     onData: chunk => chunks.push(chunk),
-    adbFactory: fakeAdbFactory(commands, spawnArgs, processes),
+    adbFactory: fakeAdbFactory(commands, spawnArgs, processes, wmSizeOutput),
     timer,
     segmentRotateMs: 1000,
     ...overrides,
@@ -75,6 +79,7 @@ describe("AndroidH264Source", () => {
     expect(processes).toHaveLength(1);
     const args = spawnArgs[0].join(" ");
     expect(args).toContain("exec-out screenrecord --output-format=h264");
+    expect(args).toContain("--size 1280x720");
     expect(args).not.toContain("-s emulator-5554");
     expect(args.endsWith(" -")).toBe(true);
 
@@ -82,6 +87,15 @@ describe("AndroidH264Source", () => {
     expect(chunks).toHaveLength(1);
     expect(chunks[0]).toEqual(Buffer.from([0, 0, 0, 1, 0x67]));
 
+    await source.stop();
+  });
+
+  test("caps an unconfigured high-resolution display to the advertised H.264 level", async () => {
+    const { source, spawnArgs } = makeSource({}, "Physical size: 1440x3200\n");
+    await source.start();
+    const size = spawnArgs[0][spawnArgs[0].indexOf("--size") + 1];
+    const [width, height] = size.split("x").map(Number);
+    expect(Math.ceil(width / 16) * Math.ceil(height / 16)).toBeLessThanOrEqual(8192);
     await source.stop();
   });
 
@@ -191,6 +205,8 @@ describe("AndroidH264Source", () => {
 
     const { source, processes } = makeSource({ adbFactory });
     const startPromise = source.start(); // suspends on adb.spawn
+    await Promise.resolve(); // let the display-size query settle before spawn
+    await Promise.resolve();
     await source.stop(); // running=false while current is still null
     resolveAdb!(); // startSegment resumes after setup
     await startPromise;

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -368,6 +368,17 @@ describe("IosH264Source", () => {
     expect(errors[0].message).toContain("ffmpeg exited");
   });
 
+  test("reports a fatal capture-helper diagnostic after startup", async () => {
+    const { source, helper, errors } = createHarness();
+
+    await startWithFrame(source, helper, frame(1, 1, 0x11));
+    helper.emitStderr("Error: AVCaptureSession runtime error: media services were reset");
+    await flush();
+
+    expect(errors[0].message).toContain("media services were reset");
+    expect(helper.stopped).toBe(true);
+  });
+
   test("awaits in-flight teardown after post-start encoder failure", async () => {
     const helper = new DelayedStopFrameCaptureHelper();
     const encoder = new FakeChildProcess();

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -203,6 +203,9 @@ describe("IosH264Source", () => {
     expect(helperTargets).toEqual([{ kind: "device", deviceId: IOS_DEVICE.deviceId }]);
     expect(encoderSpawns[0].command).toBe("ffmpeg");
     expect(encoderSpawns[0].args).toContain("2x1");
+    expect(encoderSpawns[0].args).toContain("-level:v");
+    expect(encoderSpawns[0].args).toContain("4.2");
+    expect(encoderSpawns[0].args).toContain("scale=1920:1080:force_original_aspect_ratio=decrease:force_divisible_by=2");
     expect(encoder.getStdinData()).toEqual(Buffer.alloc(8, 0x44));
     expect(chunks).toEqual([Buffer.from([0, 0, 0, 1, 0x65])]);
   });

--- a/test/features/webrtc/ReconnectController.test.ts
+++ b/test/features/webrtc/ReconnectController.test.ts
@@ -172,6 +172,30 @@ describe("ReconnectController", () => {
     expect(attempts).toBe(2);
     expect(controller.getState()).toBe("stopped");
   });
+
+  test("stop during an in-flight reconnect remains stopped when that attempt succeeds", async () => {
+    const timer = new FakeTimer();
+    let resolveReconnect: (() => void) | undefined;
+    let attempts = 0;
+    const controller = new ReconnectController({
+      attempt: async () => {
+        attempts++;
+        if (attempts === 2) {
+          await new Promise<void>(resolve => { resolveReconnect = resolve; });
+        }
+      },
+      timer,
+    });
+
+    await controller.start();
+    controller.notifyConnectionLost();
+    await drain();
+    controller.stop();
+    resolveReconnect?.();
+    await drain();
+
+    expect(controller.getState()).toBe("stopped");
+  });
 });
 
 /** Let queued microtasks (async attempt bodies) settle after advancing time. */

--- a/test/features/webrtc/RtpH264TrackWriter.test.ts
+++ b/test/features/webrtc/RtpH264TrackWriter.test.ts
@@ -107,4 +107,20 @@ describe("RtpH264TrackWriter", () => {
     expect(sink.packets[0].header.sequenceNumber).toBe(0xffff);
     expect(sink.packets[1].header.sequenceNumber).toBe(0);
   });
+
+  test("observes an SPS before packetizing its access unit", () => {
+    const sink = new RecordingSink();
+    const observed: Buffer[] = [];
+    const writer = new RtpH264TrackWriter({
+      sink,
+      ssrc: 1,
+      onSps: sps => observed.push(Buffer.from(sps)),
+    });
+    const sps = Buffer.from([0x67, 0x42, 0xe0, 0x2a]);
+
+    writer.writeChunk(annexB(sps, makeNal(5, 8)));
+    writer.flush();
+
+    expect(observed).toEqual([sps]);
+  });
 });

--- a/test/features/webrtc/RtpPcmuTrackWriter.test.ts
+++ b/test/features/webrtc/RtpPcmuTrackWriter.test.ts
@@ -36,4 +36,17 @@ describe("RtpPcmuTrackWriter", () => {
     expect(packets.map(packet => packet.header.timestamp)).toEqual([0, 2, 4]);
     expect(writer.stats).toEqual({ packetsWritten: 3, samplesWritten: 5 });
   });
+
+  test("preserves a PCM16 sample split across arbitrary chunk boundaries", () => {
+    const packets: RtpPacket[] = [];
+    const writer = new RtpPcmuTrackWriter({ sink: { writeRtp: packet => packets.push(packet) }, ssrc: 1 });
+
+    writer.writePcm16Chunk(Buffer.from([0x00]));
+    expect(packets).toHaveLength(0);
+    writer.writePcm16Chunk(Buffer.from([0x00]));
+
+    expect(packets).toHaveLength(1);
+    expect(packets[0].payload).toEqual(Buffer.from([0xff]));
+    expect(writer.stats).toEqual({ packetsWritten: 1, samplesWritten: 1 });
+  });
 });

--- a/test/features/webrtc/WebRtcPublisher.loopback.test.ts
+++ b/test/features/webrtc/WebRtcPublisher.loopback.test.ts
@@ -32,7 +32,8 @@ function nal(type: number, size: number, fill: number): Buffer {
 /** A keyframe access unit (SPS + PPS + large IDR) followed by the next start code. */
 function keyframeStream(): Buffer {
   return Buffer.concat([
-    START, nal(7, 8, 0x11), // SPS
+    // Constrained-baseline Level 4.2, matching the publisher's SDP contract.
+    START, Buffer.from([0x67, 0x42, 0xe0, 0x2a, 0x11, 0x11, 0x11, 0x11]),
     START, nal(8, 6, 0x22), // PPS
     START, nal(5, 4000, 0x33), // IDR large enough to force FU-A fragmentation
     START, // trailing start code so the IDR NAL is emitted immediately

--- a/test/features/webrtc/WebRtcPublisher.test.ts
+++ b/test/features/webrtc/WebRtcPublisher.test.ts
@@ -184,7 +184,7 @@ describe("WebRtcPublisher WHIP answer validation", () => {
           publish: async () => ({
             answerSdp: ACCEPTED_VIDEO_ANSWER.replace(
               "profile-level-id=42e02a",
-              "profile-level-id=42f00b;level-asymmetry-allowed=1;max-recv-level=42"
+              "profile-level-id=42f00b;level-asymmetry-allowed=1;max-recv-level=f02a"
             ),
             resourceUrl: "https://coord/whip/s",
           }),
@@ -214,7 +214,7 @@ describe("WebRtcPublisher WHIP answer validation", () => {
               resourceUrl: "https://coord/resource",
               answerSdp: ACCEPTED_VIDEO_ANSWER.replace(
                 "profile-level-id=42e02a",
-                "profile-level-id=42e01f;level-asymmetry-allowed=1;max-recv-level=42"
+                "profile-level-id=42e01f;level-asymmetry-allowed=1;max-recv-level=e02a"
               ),
             }),
             delete: async () => {},
@@ -224,6 +224,15 @@ describe("WebRtcPublisher WHIP answer validation", () => {
 
     await publisher.start();
     expect(publisher.getDescriptor().resourceUrl).toBe("https://coord/resource");
+  });
+
+  test("rejects a decimal max-recv-level because RFC 6184 requires hexadecimal SPS bytes", async () => {
+    await expectRejectedAnswer(
+      ACCEPTED_VIDEO_ANSWER.replace(
+        "profile-level-id=42e02a",
+        "profile-level-id=42e01f;level-asymmetry-allowed=1;max-recv-level=42"
+      )
+    );
   });
 });
 
@@ -260,6 +269,31 @@ describe("WebRtcPublisher.notifySourceFailed", () => {
     expect(() => internals.fireConnected(pc as unknown as RTCPeerConnection)).not.toThrow();
     await Promise.resolve();
     await Promise.resolve();
+    expect(recoveries).toBe(1);
+  });
+
+  test("recovers instead of forwarding an SPS incompatible with the advertised H.264 profile", async () => {
+    const pc = new FakePeerConnection();
+    const publisher = new WebRtcPublisher(
+      { streamId: "s", whipEndpoint: "https://coord/whip" },
+      {
+        createPeerConnection: () => pc as unknown as RTCPeerConnection,
+        createWhipClient: () =>
+          ({
+            publish: async () => ({ answerSdp: ACCEPTED_VIDEO_ANSWER, resourceUrl: "https://coord/whip/s" }),
+            delete: async () => {},
+          }) as unknown as WhipClient,
+      }
+    );
+    await publisher.start();
+    const internals = publisher as unknown as { notifySourceFailed: () => void };
+    let recoveries = 0;
+    internals.notifySourceFailed = () => { recoveries++; };
+
+    // A High-profile SPS must not be forwarded under the constrained-baseline
+    // profile-level-id advertised in the negotiated SDP.
+    publisher.writeH264Chunk(Buffer.from([0, 0, 0, 1, 0x67, 0x64, 0x00, 0x1f, 0, 0, 0, 1]));
+
     expect(recoveries).toBe(1);
   });
 });

--- a/test/features/webrtc/WebRtcPublisher.test.ts
+++ b/test/features/webrtc/WebRtcPublisher.test.ts
@@ -3,6 +3,18 @@ import type { RTCPeerConnection } from "werift";
 import { WebRtcPublisher } from "../../../src/features/webrtc/WebRtcPublisher";
 import type { WhipClient, WhipClientOptions } from "../../../src/features/webrtc/WhipClient";
 
+const ACCEPTED_VIDEO_ANSWER = [
+  "v=0",
+  "m=video 9 UDP/TLS/RTP/SAVPF 102",
+  "a=recvonly",
+  "a=rtpmap:102 H264/90000",
+].join("\r\n");
+const ACCEPTED_VIDEO_AND_AUDIO_ANSWER = [
+  ACCEPTED_VIDEO_ANSWER,
+  "m=audio 9 UDP/TLS/RTP/SAVPF 0",
+  "a=recvonly",
+].join("\r\n");
+
 /** Minimal fake peer connection whose media/offer path succeeds up to publish. */
 class FakePeerConnection {
   closed = false;
@@ -116,7 +128,7 @@ describe("WebRtcPublisher audio", () => {
         createPeerConnection: () => pc as unknown as RTCPeerConnection,
         createWhipClient: () =>
           ({
-            publish: async () => ({ answerSdp: "v=0", resourceUrl: "https://coord/whip/s" }),
+            publish: async () => ({ answerSdp: ACCEPTED_VIDEO_AND_AUDIO_ANSWER, resourceUrl: "https://coord/whip/s" }),
             delete: async () => {},
           }) as unknown as WhipClient,
       }
@@ -139,7 +151,7 @@ describe("WebRtcPublisher audio", () => {
         createPeerConnection: () => pc as unknown as RTCPeerConnection,
         createWhipClient: () =>
           ({
-            publish: async () => ({ answerSdp: "v=0", resourceUrl: "https://coord/whip/s" }),
+            publish: async () => ({ answerSdp: ACCEPTED_VIDEO_ANSWER, resourceUrl: "https://coord/whip/s" }),
             delete: async () => {},
           }) as unknown as WhipClient,
       }
@@ -152,5 +164,28 @@ describe("WebRtcPublisher audio", () => {
     expect(publisher.getDescriptor().audioPacketsSent).toBe(0);
 
     await publisher.stop();
+  });
+
+  test("rejects a WHIP answer that drops requested audio and deletes the session", async () => {
+    const pc = new RecordingPeerConnection();
+    const deleted: string[] = [];
+    const publisher = new WebRtcPublisher(
+      { streamId: "s", whipEndpoint: "https://coord/whip", audioEnabled: true },
+      {
+        createPeerConnection: () => pc as unknown as RTCPeerConnection,
+        createWhipClient: () =>
+          ({
+            publish: async () => ({
+              answerSdp: `${ACCEPTED_VIDEO_ANSWER}\r\nm=audio 0 UDP/TLS/RTP/SAVPF 0`,
+              resourceUrl: "https://coord/whip/s",
+            }),
+            delete: async (url: string) => { deleted.push(url); },
+          }) as unknown as WhipClient,
+      }
+    );
+
+    await expect(publisher.start()).rejects.toThrow(/rejected the requested audio/);
+    expect(deleted).toEqual(["https://coord/whip/s"]);
+    expect(pc.closed).toBe(true);
   });
 });

--- a/test/features/webrtc/WebRtcPublisher.test.ts
+++ b/test/features/webrtc/WebRtcPublisher.test.ts
@@ -8,6 +8,7 @@ const ACCEPTED_VIDEO_ANSWER = [
   "m=video 9 UDP/TLS/RTP/SAVPF 102",
   "a=recvonly",
   "a=rtpmap:102 H264/90000",
+  "a=fmtp:102 packetization-mode=1;profile-level-id=42e01f",
 ].join("\r\n");
 const ACCEPTED_VIDEO_AND_AUDIO_ANSWER = [
   ACCEPTED_VIDEO_ANSWER,

--- a/test/features/webrtc/WebRtcPublisher.test.ts
+++ b/test/features/webrtc/WebRtcPublisher.test.ts
@@ -109,6 +109,32 @@ describe("WebRtcPublisher establish failure", () => {
   });
 });
 
+describe("WebRtcPublisher WHIP answer validation", () => {
+  async function expectRejectedAnswer(answerSdp: string): Promise<void> {
+    const pc = new FakePeerConnection();
+    const publisher = new WebRtcPublisher(
+      { streamId: "s", whipEndpoint: "https://coord/whip", maxReconnectAttempts: 1 },
+      {
+        createPeerConnection: () => pc as unknown as RTCPeerConnection,
+        createWhipClient: () => ({
+          publish: async () => ({ answerSdp, resourceUrl: "https://coord/whip/s" }),
+          delete: async () => {},
+        }) as unknown as WhipClient,
+      }
+    );
+    await expect(publisher.start()).rejects.toThrow(/did not accept H264 video/);
+    expect(pc.closed).toBe(true);
+  }
+
+  test("rejects H.264 at a non-RFC-6184 clock rate", async () => {
+    await expectRejectedAnswer(ACCEPTED_VIDEO_ANSWER.replace("H264/90000", "H264/8000"));
+  });
+
+  test("rejects an H.264 profile incompatible with the constrained-baseline sender", async () => {
+    await expectRejectedAnswer(ACCEPTED_VIDEO_ANSWER.replace("42e01f", "64001f"));
+  });
+});
+
 describe("WebRtcPublisher.notifySourceFailed", () => {
   test("is a no-op after close (does not throw)", async () => {
     const publisher = new WebRtcPublisher(

--- a/test/features/webrtc/WebRtcPublisher.test.ts
+++ b/test/features/webrtc/WebRtcPublisher.test.ts
@@ -8,7 +8,7 @@ const ACCEPTED_VIDEO_ANSWER = [
   "m=video 9 UDP/TLS/RTP/SAVPF 102",
   "a=recvonly",
   "a=rtpmap:102 H264/90000",
-  "a=fmtp:102 packetization-mode=1;profile-level-id=42e01f",
+  "a=fmtp:102 packetization-mode=1;profile-level-id=42e02a",
 ].join("\r\n");
 const ACCEPTED_VIDEO_AND_AUDIO_ANSWER = [
   ACCEPTED_VIDEO_ANSWER,
@@ -43,6 +43,12 @@ class RecordingPeerConnection extends FakePeerConnection {
     this.transceiverKinds.push(track.kind);
     return { sender: { ssrc: this.transceiverKinds.length } };
   }
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>(done => { resolve = done; });
+  return { promise, resolve };
 }
 
 /**
@@ -107,6 +113,36 @@ describe("WebRtcPublisher establish failure", () => {
     expect(pc.closed).toBe(true);
     expect(publisher.getDescriptor().resourceUrl).toBeNull();
   });
+
+  test("stop during pre-establish does not create a WHIP session or overwrite stopped", async () => {
+    const gate = deferred();
+    let peerConnections = 0;
+    let publishes = 0;
+    const publisher = new WebRtcPublisher(
+      { streamId: "s", whipEndpoint: "https://coord/whip" },
+      {
+        onBeforeEstablish: () => gate.promise,
+        createPeerConnection: () => {
+          peerConnections++;
+          return new FakePeerConnection() as unknown as RTCPeerConnection;
+        },
+        createWhipClient: () => ({
+          publish: async () => { publishes++; return { answerSdp: ACCEPTED_VIDEO_ANSWER, resourceUrl: "https://coord/whip/s" }; },
+          delete: async () => {},
+        }) as unknown as WhipClient,
+      }
+    );
+
+    const start = publisher.start();
+    await Promise.resolve();
+    await publisher.stop();
+    gate.resolve();
+    await start;
+
+    expect(peerConnections).toBe(0);
+    expect(publishes).toBe(0);
+    expect(publisher.getState()).toBe("stopped");
+  });
 });
 
 describe("WebRtcPublisher WHIP answer validation", () => {
@@ -122,7 +158,7 @@ describe("WebRtcPublisher WHIP answer validation", () => {
         }) as unknown as WhipClient,
       }
     );
-    await expect(publisher.start()).rejects.toThrow(/did not accept H264 video/);
+    await expect(publisher.start()).rejects.toThrow(/WHIP answer did not accept/);
     expect(pc.closed).toBe(true);
   }
 
@@ -130,8 +166,64 @@ describe("WebRtcPublisher WHIP answer validation", () => {
     await expectRejectedAnswer(ACCEPTED_VIDEO_ANSWER.replace("H264/90000", "H264/8000"));
   });
 
+  test("rejects a WHIP answer that is not recvonly", async () => {
+    await expectRejectedAnswer(ACCEPTED_VIDEO_ANSWER.replace("a=recvonly", "a=sendrecv"));
+  });
+
   test("rejects an H.264 profile incompatible with the constrained-baseline sender", async () => {
-    await expectRejectedAnswer(ACCEPTED_VIDEO_ANSWER.replace("42e01f", "64001f"));
+    await expectRejectedAnswer(ACCEPTED_VIDEO_ANSWER.replace("42e02a", "64001f"));
+  });
+
+  test("accepts a conforming Baseline level-1b profile variation with a sufficient receive ceiling", async () => {
+    const pc = new FakePeerConnection();
+    const publisher = new WebRtcPublisher(
+      { streamId: "s", whipEndpoint: "https://coord/whip" },
+      {
+        createPeerConnection: () => pc as unknown as RTCPeerConnection,
+        createWhipClient: () => ({
+          publish: async () => ({
+            answerSdp: ACCEPTED_VIDEO_ANSWER.replace(
+              "profile-level-id=42e02a",
+              "profile-level-id=42f00b;level-asymmetry-allowed=1;max-recv-level=42"
+            ),
+            resourceUrl: "https://coord/whip/s",
+          }),
+          delete: async () => {},
+        }) as unknown as WhipClient,
+      }
+    );
+
+    await publisher.start();
+    expect(publisher.getState()).toBe("connected");
+    await publisher.stop();
+  });
+
+  test("rejects an answer whose receive level is below AutoMobile's source capability", async () => {
+    await expectRejectedAnswer(ACCEPTED_VIDEO_ANSWER.replace("42e02a", "42e01f"));
+  });
+
+  test("accepts an asymmetric answer that explicitly supports the source level", async () => {
+    const pc = new FakePeerConnection();
+    const publisher = new WebRtcPublisher(
+      { streamId: "s", whipEndpoint: "https://coord/whip" },
+      {
+        createPeerConnection: () => pc as unknown as RTCPeerConnection,
+        createWhipClient: () =>
+          ({
+            publish: async () => ({
+              resourceUrl: "https://coord/resource",
+              answerSdp: ACCEPTED_VIDEO_ANSWER.replace(
+                "profile-level-id=42e02a",
+                "profile-level-id=42e01f;level-asymmetry-allowed=1;max-recv-level=42"
+              ),
+            }),
+            delete: async () => {},
+          }) as unknown as WhipClient,
+      }
+    );
+
+    await publisher.start();
+    expect(publisher.getDescriptor().resourceUrl).toBe("https://coord/resource");
   });
 });
 
@@ -143,6 +235,32 @@ describe("WebRtcPublisher.notifySourceFailed", () => {
     );
     await publisher.stop();
     expect(() => publisher.notifySourceFailed()).not.toThrow();
+  });
+
+  test("routes a synchronously throwing connected hook through recovery", async () => {
+    const pc = new FakePeerConnection();
+    const publisher = new WebRtcPublisher(
+      { streamId: "s", whipEndpoint: "https://coord/whip" },
+      {
+        onConnected: () => { throw new Error("capture start failed"); },
+        createWhipClient: () => ({}) as unknown as WhipClient,
+      }
+    );
+    const internals = publisher as unknown as {
+      pc: RTCPeerConnection | null;
+      fireConnected(connection: RTCPeerConnection): void;
+      notifySourceFailed: () => void;
+    };
+    let recoveries = 0;
+    internals.pc = pc as unknown as RTCPeerConnection;
+    internals.notifySourceFailed = () => { recoveries++; };
+
+    // A synchronous hook failure used to escape `Promise.resolve(hook())` and
+    // reject start. The asynchronous boundary now routes it to recovery.
+    expect(() => internals.fireConnected(pc as unknown as RTCPeerConnection)).not.toThrow();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(recoveries).toBe(1);
   });
 });
 

--- a/test/features/webrtc/WebRtcPublisher.test.ts
+++ b/test/features/webrtc/WebRtcPublisher.test.ts
@@ -174,6 +174,27 @@ describe("WebRtcPublisher WHIP answer validation", () => {
     await expectRejectedAnswer(ACCEPTED_VIDEO_ANSWER.replace("42e02a", "64001f"));
   });
 
+  test("accepts every RFC 6184 constrained-baseline profile representation", async () => {
+    const pc = new FakePeerConnection();
+    const publisher = new WebRtcPublisher(
+      { streamId: "s", whipEndpoint: "https://coord/whip" },
+      {
+        createPeerConnection: () => pc as unknown as RTCPeerConnection,
+        createWhipClient: () => ({
+          publish: async () => ({
+            answerSdp: ACCEPTED_VIDEO_ANSWER.replace("42e02a", "42c02a"),
+            resourceUrl: "https://coord/whip/s",
+          }),
+          delete: async () => {},
+        }) as unknown as WhipClient,
+      }
+    );
+
+    await publisher.start();
+    expect(publisher.getState()).toBe("connected");
+    await publisher.stop();
+  });
+
   test("accepts a conforming Baseline level-1b profile variation with a sufficient receive ceiling", async () => {
     const pc = new FakePeerConnection();
     const publisher = new WebRtcPublisher(

--- a/test/features/webrtc/WebRtcPublisher.trickle.test.ts
+++ b/test/features/webrtc/WebRtcPublisher.trickle.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { RTCPeerConnection } from "werift";
 import { WebRtcPublisher } from "../../../src/features/webrtc/WebRtcPublisher";
 import type { WhipClient } from "../../../src/features/webrtc/WhipClient";
+import { VIDEO_ONLY_WHIP_ANSWER } from "../../helpers/webrtcFakes";
 
 /**
  * Fake peer connection whose ICE gathering NEVER completes, so a publisher that
@@ -47,7 +48,7 @@ function makePublisher(pc: FakeTricklePc, trickleIce: boolean) {
       createPeerConnection: () => pc as unknown as RTCPeerConnection,
       createWhipClient: () =>
         ({
-          publish: async () => ({ answerSdp: "v=0", resourceUrl: "https://coord/whip/s" }),
+          publish: async () => ({ answerSdp: VIDEO_ONLY_WHIP_ANSWER, resourceUrl: "https://coord/whip/s" }),
           patchCandidate: async (url: string, fragment: string) => {
             patched.push({ url, fragment });
           },

--- a/test/features/webrtc/WebRtcPublisher.trickle.test.ts
+++ b/test/features/webrtc/WebRtcPublisher.trickle.test.ts
@@ -23,7 +23,7 @@ class FakeTricklePc {
       return { unSubscribe: () => {} };
     },
   };
-  localDescription = { sdp: "v=0" };
+  localDescription = { sdp: ["v=0", "m=video 9 UDP/TLS/RTP/SAVPF 102", "a=mid:0", "a=ice-ufrag:u", "a=ice-pwd:p"].join("\r\n") };
   addTransceiver() {
     return { sender: { ssrc: 1 } };
   }
@@ -48,8 +48,8 @@ function makePublisher(pc: FakeTricklePc, trickleIce: boolean) {
       createPeerConnection: () => pc as unknown as RTCPeerConnection,
       createWhipClient: () =>
         ({
-          publish: async () => ({ answerSdp: VIDEO_ONLY_WHIP_ANSWER, resourceUrl: "https://coord/whip/s" }),
-          patchCandidate: async (url: string, fragment: string) => {
+          publish: async () => ({ answerSdp: VIDEO_ONLY_WHIP_ANSWER, resourceUrl: "https://coord/whip/s", etag: "\"etag\"" }),
+          patchCandidate: async (url: string, _etag: string, fragment: string) => {
             patched.push({ url, fragment });
           },
           delete: async () => {},

--- a/test/features/webrtc/WhipClient.test.ts
+++ b/test/features/webrtc/WhipClient.test.ts
@@ -110,6 +110,20 @@ describe("WhipClient.publish", () => {
     await expect(publishing).rejects.toThrow(/timed out/);
     expect(aborted).toBe(true);
   });
+
+  test("preserves an already-aborted caller signal", async () => {
+    let receivedAbortedSignal = false;
+    const client = new WhipClient({
+      endpoint: "https://coord.example.com/whip",
+      fetchImpl: async (_url, init) => {
+        receivedAbortedSignal = init.signal?.aborted ?? false;
+        throw new Error("aborted by caller");
+      },
+    });
+
+    await expect(client.publish("offer", AbortSignal.abort())).rejects.toThrow("aborted by caller");
+    expect(receivedAbortedSignal).toBe(true);
+  });
 });
 
 describe("WhipClient.delete", () => {

--- a/test/features/webrtc/WhipClient.test.ts
+++ b/test/features/webrtc/WhipClient.test.ts
@@ -113,6 +113,14 @@ describe("WhipClient.publish", () => {
 
   test("times out when a successful response stalls while reading its SDP body", async () => {
     const timer = new FakeTimer();
+    let resolveBodyReadStarted!: () => void;
+    let resolveStalledBody!: (body: string) => void;
+    const bodyReadStarted = new Promise<void>(resolve => {
+      resolveBodyReadStarted = resolve;
+    });
+    const stalledBody = new Promise<string>(resolve => {
+      resolveStalledBody = resolve;
+    });
     const client = new WhipClient({
       endpoint: "https://coord.example.com/whip",
       timer,
@@ -121,15 +129,22 @@ describe("WhipClient.publish", () => {
         status: 201,
         ok: true,
         headers: { get: name => (name.toLowerCase() === "location" ? "/r/1" : null) },
-        text: async () => await new Promise<string>(() => {}),
+        text: async () => {
+          resolveBodyReadStarted();
+          return await stalledBody;
+        },
       }),
     });
 
     const publishing = client.publish("offer");
-    await Promise.resolve();
+    await bodyReadStarted;
     timer.advanceTime(10);
 
     await expect(publishing).rejects.toThrow(/response body timed out/);
+    // Let the losing branch of Promise.race settle too. Bun tracks a pending
+    // test promise even after the timeout branch rejects.
+    resolveStalledBody("");
+    await Promise.resolve();
   });
 
   test("preserves an already-aborted caller signal", async () => {

--- a/test/features/webrtc/WhipClient.test.ts
+++ b/test/features/webrtc/WhipClient.test.ts
@@ -111,6 +111,27 @@ describe("WhipClient.publish", () => {
     expect(aborted).toBe(true);
   });
 
+  test("times out when a successful response stalls while reading its SDP body", async () => {
+    const timer = new FakeTimer();
+    const client = new WhipClient({
+      endpoint: "https://coord.example.com/whip",
+      timer,
+      requestTimeoutMs: 10,
+      fetchImpl: async () => ({
+        status: 201,
+        ok: true,
+        headers: { get: name => (name.toLowerCase() === "location" ? "/r/1" : null) },
+        text: async () => await new Promise<string>(() => {}),
+      }),
+    });
+
+    const publishing = client.publish("offer");
+    await Promise.resolve();
+    timer.advanceTime(10);
+
+    await expect(publishing).rejects.toThrow(/response body timed out/);
+  });
+
   test("preserves an already-aborted caller signal", async () => {
     let receivedAbortedSignal = false;
     const client = new WhipClient({

--- a/test/features/webrtc/WhipClient.test.ts
+++ b/test/features/webrtc/WhipClient.test.ts
@@ -155,11 +155,12 @@ describe("WhipClient.patchCandidate", () => {
       bearerToken: "tok",
       fetchImpl,
     });
-    await client.patchCandidate("https://coord.example.com/whip/s", "a=candidate:1 1 udp ...\r\n");
+    await client.patchCandidate("https://coord.example.com/whip/s", "\"etag\"", "a=candidate:1 1 udp ...\r\n");
     expect(calls[0].method).toBe("PATCH");
     expect(calls[0].url).toBe("https://coord.example.com/whip/s");
     expect(calls[0].headers["Content-Type"]).toBe("application/trickle-ice-sdpfrag");
     expect(calls[0].headers["Authorization"]).toBe("Bearer tok");
+    expect(calls[0].headers["If-Match"]).toBe("\"etag\"");
     expect(calls[0].body).toContain("a=candidate:1 1 udp");
   });
 
@@ -167,7 +168,7 @@ describe("WhipClient.patchCandidate", () => {
     const { fetchImpl } = fakeFetch(() => ({ status: 405 }));
     const client = new WhipClient({ endpoint: "https://coord.example.com/whip", fetchImpl });
     await expect(
-      client.patchCandidate("https://coord.example.com/whip/s", "a=candidate:...")
+      client.patchCandidate("https://coord.example.com/whip/s", "\"etag\"", "a=candidate:...")
     ).resolves.toBeUndefined();
   });
 });

--- a/test/features/webrtc/WhipClient.test.ts
+++ b/test/features/webrtc/WhipClient.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { WhipClient, type FetchLike } from "../../../src/features/webrtc/WhipClient";
+import { FakeTimer } from "../../fakes/FakeTimer";
 
 interface Recorded {
   url: string;
@@ -80,11 +81,34 @@ describe("WhipClient.publish", () => {
     await expect(client.publish("offer")).rejects.toThrow(/empty SDP/);
   });
 
-  test("tolerates a missing Location header", async () => {
+  test("rejects a missing Location header because the session could not be cleaned up", async () => {
     const { fetchImpl } = fakeFetch(() => ({ status: 201, body: "answer", location: null }));
     const client = new WhipClient({ endpoint: "https://coord.example.com/whip", fetchImpl });
-    const session = await client.publish("offer");
-    expect(session.resourceUrl).toBeNull();
+    await expect(client.publish("offer")).rejects.toThrow(/required Location/);
+  });
+
+  test("aborts a stalled request at the configured timeout", async () => {
+    const timer = new FakeTimer();
+    let aborted = false;
+    const fetchImpl: FetchLike = async (_url, init) =>
+      new Promise((_resolve, reject) => {
+        init.signal?.addEventListener("abort", () => {
+          aborted = true;
+          reject(new Error("aborted"));
+        });
+      });
+    const client = new WhipClient({
+      endpoint: "https://coord.example.com/whip",
+      fetchImpl,
+      timer,
+      requestTimeoutMs: 10,
+    });
+
+    const publishing = client.publish("offer");
+    timer.advanceTime(10);
+
+    await expect(publishing).rejects.toThrow(/timed out/);
+    expect(aborted).toBe(true);
   });
 });
 

--- a/test/features/webrtc/androidH264CaptureSourceFactory.test.ts
+++ b/test/features/webrtc/androidH264CaptureSourceFactory.test.ts
@@ -83,6 +83,26 @@ describe("createAndroidH264CaptureSource", () => {
     expect(persistent.stopped).toBe(0);
   });
 
+  test("stops the selected source when stop races its startup", async () => {
+    let releaseStart: (() => void) | undefined;
+    const persistent = new FakeSource(
+      () => new Promise<void>(resolve => { releaseStart = resolve; })
+    );
+    const deps: AndroidH264CaptureSourceDeps = {
+      createPersistent: () => persistent,
+      createScreenrecord: () => new FakeSource(),
+    };
+    const source = createAndroidH264CaptureSource(baseOptions(), "/tmp/automobile-video.jar", deps);
+
+    const starting = source.start();
+    await Promise.resolve();
+    await source.stop();
+    releaseStart?.();
+    await starting;
+
+    expect(persistent.stopped).toBe(1);
+  });
+
   test("passes the provided jar path to the persistent source", () => {
     let capturedJar: string | undefined;
     const deps: AndroidH264CaptureSourceDeps = {

--- a/test/features/webrtc/h264Level.test.ts
+++ b/test/features/webrtc/h264Level.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import {
+  h264SpsLevelIdc,
+  h264SpsProfileLevelId,
+  isCompatibleConstrainedBaselineProfile,
+} from "../../../src/features/webrtc/h264Level";
+
+describe("H.264 SDP and SPS capability helpers", () => {
+  test("reads the profile and level fields from an SPS", () => {
+    const sps = Buffer.from([0x67, 0x42, 0xe0, 0x2a]);
+    expect(h264SpsProfileLevelId(sps)).toBe("42e02a");
+    expect(h264SpsLevelIdc(sps)).toBe(0x2a);
+  });
+
+  test("accepts constrained-baseline profile variants but rejects a different profile", () => {
+    expect(isCompatibleConstrainedBaselineProfile("42e02a")).toBe(true);
+    expect(isCompatibleConstrainedBaselineProfile("42f00b")).toBe(true);
+    expect(isCompatibleConstrainedBaselineProfile("64001f")).toBe(false);
+  });
+});

--- a/test/features/webrtc/h264Level.test.ts
+++ b/test/features/webrtc/h264Level.test.ts
@@ -15,6 +15,7 @@ describe("H.264 SDP and SPS capability helpers", () => {
   test("accepts constrained-baseline profile variants but rejects a different profile", () => {
     expect(isCompatibleConstrainedBaselineProfile("42e02a")).toBe(true);
     expect(isCompatibleConstrainedBaselineProfile("42f00b")).toBe(true);
+    expect(isCompatibleConstrainedBaselineProfile("42c02a")).toBe(true);
     expect(isCompatibleConstrainedBaselineProfile("64001f")).toBe(false);
   });
 });

--- a/test/features/webrtc/trickleIce.test.ts
+++ b/test/features/webrtc/trickleIce.test.ts
@@ -5,11 +5,18 @@ import {
   serializeTrickleFragment,
 } from "../../../src/features/webrtc/trickleIce";
 
+const context = {
+  mLine: "m=video 9 UDP/TLS/RTP/SAVPF 102",
+  mid: "0",
+  ice: { ufrag: "abc", pwd: "def" },
+};
+const contexts = new Map([[context.mid, context]]);
+
 describe("serializeTrickleFragment / parseTrickleFragment", () => {
   test("round-trips a candidate with mid and ICE credentials", () => {
     const fragment = serializeTrickleFragment(
       { candidate: "candidate:1 1 udp 2113 1.2.3.4 5000 typ host", sdpMid: "0", sdpMLineIndex: 0 },
-      { ufrag: "abc", pwd: "def" }
+      context
     );
     expect(fragment).toContain("a=ice-ufrag:abc");
     expect(fragment).toContain("a=ice-pwd:def");
@@ -23,7 +30,7 @@ describe("serializeTrickleFragment / parseTrickleFragment", () => {
   });
 
   test("adds the candidate: prefix when missing", () => {
-    const fragment = serializeTrickleFragment({ candidate: "1 1 udp 2113 1.2.3.4 5000 typ host" });
+    const fragment = serializeTrickleFragment({ candidate: "1 1 udp 2113 1.2.3.4 5000 typ host" }, context);
     expect(fragment).toContain("a=candidate:1 1 udp");
   });
 
@@ -40,7 +47,7 @@ describe("serializeTrickleFragment / parseTrickleFragment", () => {
 describe("TrickleIceForwarder", () => {
   test("buffers candidates until the resource URL is known, then flushes in order", () => {
     const sent: Array<{ url: string; fragment: string }> = [];
-    const forwarder = new TrickleIceForwarder((url, fragment) => sent.push({ url, fragment }));
+    const forwarder = new TrickleIceForwarder((url, fragment) => sent.push({ url, fragment }), contexts);
 
     forwarder.addCandidate({ candidate: "candidate:a 1 udp 1 h 1 typ host" });
     forwarder.addCandidate({ candidate: "candidate:b 1 udp 1 h 2 typ host" });
@@ -55,7 +62,7 @@ describe("TrickleIceForwarder", () => {
 
   test("sends immediately once the resource URL is set", () => {
     const sent: string[] = [];
-    const forwarder = new TrickleIceForwarder((_url, fragment) => sent.push(fragment));
+    const forwarder = new TrickleIceForwarder((_url, fragment) => sent.push(fragment), contexts);
     forwarder.setResource("https://coord/whip/s");
     forwarder.addCandidate({ candidate: "candidate:c 1 udp 1 h 3 typ host" });
     expect(sent).toHaveLength(1);
@@ -64,7 +71,7 @@ describe("TrickleIceForwarder", () => {
 
   test("stop() drops buffered candidates and ignores further ones", () => {
     const sent: string[] = [];
-    const forwarder = new TrickleIceForwarder((_url, fragment) => sent.push(fragment));
+    const forwarder = new TrickleIceForwarder((_url, fragment) => sent.push(fragment), contexts);
     forwarder.addCandidate({ candidate: "candidate:a 1 udp 1 h 1 typ host" });
     forwarder.stop();
     forwarder.setResource("https://coord/whip/s");
@@ -74,7 +81,7 @@ describe("TrickleIceForwarder", () => {
 
   test("null resource (no Location header) keeps candidates unsent without error", () => {
     const sent: string[] = [];
-    const forwarder = new TrickleIceForwarder((_url, fragment) => sent.push(fragment));
+    const forwarder = new TrickleIceForwarder((_url, fragment) => sent.push(fragment), contexts);
     forwarder.addCandidate({ candidate: "candidate:a 1 udp 1 h 1 typ host" });
     expect(() => forwarder.setResource(null)).not.toThrow();
     expect(sent).toHaveLength(0);

--- a/test/features/webrtc/webrtcStreamingConfig.test.ts
+++ b/test/features/webrtc/webrtcStreamingConfig.test.ts
@@ -48,6 +48,11 @@ describe("parseSize", () => {
   test("throws on bad format", () => {
     expect(() => parseSize("720p")).toThrow(/WIDTHxHEIGHT/);
   });
+
+  test("rejects zero and odd dimensions before device startup", () => {
+    expect(() => parseSize("0x720")).toThrow(/positive even integers/);
+    expect(() => parseSize("721x1280")).toThrow(/positive even integers/);
+  });
 });
 
 describe("resolveWebRtcStreamingConfig", () => {
@@ -110,6 +115,16 @@ describe("resolveWebRtcStreamingConfig", () => {
     );
     expect(config.whipEndpoint).toBe("https://override/whip");
     expect(config.bitrateKbps).toBe(8000);
+  });
+
+  test("rejects invalid per-request size, bitrate, and WHIP endpoint", () => {
+    expect(() =>
+      resolveWebRtcStreamingConfig({ whipEndpoint: "https://coord/whip", size: { width: 1, height: 2 } })
+    ).toThrow(/positive even integers/);
+    expect(() =>
+      resolveWebRtcStreamingConfig({ whipEndpoint: "https://coord/whip", bitrateKbps: 0 })
+    ).toThrow(/positive number/);
+    expect(() => resolveWebRtcStreamingConfig({ whipEndpoint: "not a URL" })).toThrow(/absolute http/);
   });
 
   test("falls back to a default STUN server", () => {

--- a/test/features/webrtc/webrtcStreamingConfig.test.ts
+++ b/test/features/webrtc/webrtcStreamingConfig.test.ts
@@ -53,6 +53,10 @@ describe("parseSize", () => {
     expect(() => parseSize("0x720")).toThrow(/positive even integers/);
     expect(() => parseSize("721x1280")).toThrow(/positive even integers/);
   });
+
+  test("rejects a frame that exceeds the advertised H.264 Level 4.2 capability", () => {
+    expect(() => parseSize("2048x1080")).toThrow(/Level 4.2/);
+  });
 });
 
 describe("resolveWebRtcStreamingConfig", () => {

--- a/test/helpers/webrtcFakes.ts
+++ b/test/helpers/webrtcFakes.ts
@@ -5,6 +5,7 @@ export const VIDEO_ONLY_WHIP_ANSWER = [
   "m=video 9 UDP/TLS/RTP/SAVPF 96",
   "a=recvonly",
   "a=rtpmap:96 H264/90000",
+  "a=fmtp:96 packetization-mode=1;profile-level-id=42e01f",
   "",
 ].join("\r\n");
 

--- a/test/helpers/webrtcFakes.ts
+++ b/test/helpers/webrtcFakes.ts
@@ -5,7 +5,7 @@ export const VIDEO_ONLY_WHIP_ANSWER = [
   "m=video 9 UDP/TLS/RTP/SAVPF 96",
   "a=recvonly",
   "a=rtpmap:96 H264/90000",
-  "a=fmtp:96 packetization-mode=1;profile-level-id=42e01f",
+  "a=fmtp:96 packetization-mode=1;profile-level-id=42e02a",
   "",
 ].join("\r\n");
 

--- a/test/helpers/webrtcFakes.ts
+++ b/test/helpers/webrtcFakes.ts
@@ -1,5 +1,13 @@
 import type { FetchLike } from "../../src/features/webrtc/WhipClient";
 
+export const VIDEO_ONLY_WHIP_ANSWER = [
+  "v=0",
+  "m=video 9 UDP/TLS/RTP/SAVPF 96",
+  "a=recvonly",
+  "a=rtpmap:96 H264/90000",
+  "",
+].join("\r\n");
+
 export interface RecordedWhipRequest {
   url: string;
   method: string;
@@ -53,7 +61,7 @@ export function createSuccessfulWhipFetch(
       status: 201,
       ok: true,
       headers: { get: name => (name.toLowerCase() === "location" ? location : null) },
-      text: async () => "v=0",
+      text: async () => VIDEO_ONLY_WHIP_ANSWER,
     };
   };
 }

--- a/test/integration/webrtcCoordinationServer.e2e.test.ts
+++ b/test/integration/webrtcCoordinationServer.e2e.test.ts
@@ -32,7 +32,8 @@ function nal(type: number, size: number, fill: number): Buffer {
 
 function keyframe(): Buffer {
   return Buffer.concat([
-    START, nal(7, 8, 0x11),
+    // Constrained-baseline Level 4.2 SPS, matching the publisher's SDP.
+    START, Buffer.from([0x67, 0x42, 0xe0, 0x2a, 0x11, 0x11, 0x11, 0x11]),
     START, nal(8, 6, 0x22),
     START, nal(5, 3000, 0x33),
     START,
@@ -150,7 +151,7 @@ describe("WebRTC coordination server e2e", () => {
       const publisher = new WebRtcPublisher({ streamId: "restart", whipEndpoint: `${base}/whip?streamId=restart` });
       try {
         await publisher.start();
-        const response = await fetch(`${base}/whip/restart`, {
+        const response = await fetch(publisher.getDescriptor().resourceUrl!, {
           method: "PATCH",
           headers: {
             "Content-Type": "application/trickle-ice-sdpfrag",
@@ -170,6 +171,30 @@ describe("WebRTC coordination server e2e", () => {
         expect((await fetch(`${base}/api/streams/restart`)).status).toBe(200);
       } finally {
         await publisher.stop();
+        await http.close();
+      }
+    },
+    15000
+  );
+
+  test(
+    "does not let a stale WHIP session delete a replacement with the same stream id",
+    async () => {
+      const http = new HttpCoordinationServer({ iceServers: [] });
+      const port = await http.listen(0, "127.0.0.1");
+      const endpoint = `http://127.0.0.1:${port}/whip?streamId=replaced`;
+      const first = new WebRtcPublisher({ streamId: "replaced", whipEndpoint: endpoint });
+      const replacement = new WebRtcPublisher({ streamId: "replaced", whipEndpoint: endpoint });
+      try {
+        await first.start();
+        const staleResourceUrl = first.getDescriptor().resourceUrl!;
+        await replacement.start();
+
+        expect((await fetch(staleResourceUrl, { method: "DELETE" })).status).toBe(200);
+        expect((await fetch(`http://127.0.0.1:${port}/api/streams/replaced`)).status).toBe(200);
+      } finally {
+        await first.stop();
+        await replacement.stop();
         await http.close();
       }
     },
@@ -294,7 +319,7 @@ describe("WebRTC coordination server e2e", () => {
         const secondIdrSlice = nal(5, 1200, 0x44);
         secondIdrSlice[1] = 0x40; // first_mb_in_slice > 0: same access unit as the first IDR.
         publisher.writeH264Chunk(Buffer.concat([
-          START, nal(7, 8, 0x11),
+          START, Buffer.from([0x67, 0x42, 0xe0, 0x2a, 0x11, 0x11, 0x11, 0x11]),
           START, nal(8, 6, 0x22),
           START, nal(5, 1200, 0x33),
           START, secondIdrSlice,

--- a/test/integration/webrtcCoordinationServer.e2e.test.ts
+++ b/test/integration/webrtcCoordinationServer.e2e.test.ts
@@ -108,6 +108,23 @@ describe("WebRTC coordination server e2e", () => {
     expect(packet.header.ssrc).toBe(0x05060708);
   });
 
+  test("rejects an oversized SDP request without taking down the HTTP server", async () => {
+    const http = new HttpCoordinationServer({ iceServers: [] });
+    const port = await http.listen(0, "127.0.0.1");
+    const base = `http://127.0.0.1:${port}`;
+    try {
+      const response = await fetch(`${base}/whip`, {
+        method: "POST",
+        headers: { "Content-Type": "application/sdp" },
+        body: "v=0\r\n" + "x".repeat(1_000_000),
+      });
+      expect(response.status).toBe(413);
+      expect((await fetch(`${base}/api/streams`)).status).toBe(200);
+    } finally {
+      await http.close();
+    }
+  });
+
   test(
     "publisher -> WHIP ingest -> WHEP subscriber forwards frames, reconnect API lists the stream",
     async () => {
@@ -181,6 +198,81 @@ describe("WebRTC coordination server e2e", () => {
         expect(descriptor.subscriberCount).toBeGreaterThanOrEqual(1);
       } finally {
         await publisher.stop();
+        await viewer.close();
+        await http.close();
+      }
+    },
+    30000
+  );
+
+  test(
+    "replays cached SPS/PPS and a complete multi-slice IDR to a late WHEP viewer",
+    async () => {
+      const http = new HttpCoordinationServer({ iceServers: [] });
+      const port = await http.listen(0, "127.0.0.1");
+      const base = `http://127.0.0.1:${port}`;
+      const publisher = new WebRtcPublisher({
+        streamId: "late-viewer",
+        whipEndpoint: `${base}/whip?streamId=late-viewer`,
+      });
+      const primingViewer = new RTCPeerConnection({ codecs: { video: [useH264()] } });
+      const viewer = new RTCPeerConnection({ codecs: { video: [useH264()] } });
+      const received: RtpPacket[] = [];
+      viewer.onTrack.subscribe((track: MediaStreamTrack) => {
+        track.onReceiveRtp.subscribe((rtp: RtpPacket) => received.push(rtp));
+      });
+
+      try {
+        await publisher.start();
+        await waitFor(() => publisher.getState() === "connected", 8000);
+        primingViewer.addTransceiver("video", { direction: "recvonly" });
+        await primingViewer.setLocalDescription(await primingViewer.createOffer());
+        await waitForIce(primingViewer);
+        const primingResponse = await fetch(`${base}/whep/late-viewer`, {
+          method: "POST",
+          headers: { "Content-Type": "application/sdp" },
+          body: primingViewer.localDescription?.sdp ?? "",
+        });
+        await primingViewer.setRemoteDescription({ type: "answer", sdp: await primingResponse.text() });
+        await waitFor(() => primingViewer.connectionState === "connected", 8000);
+        // Two IDR slices prove the cache retains the complete marked access unit.
+        const secondIdrSlice = nal(5, 1200, 0x44);
+        secondIdrSlice[1] = 0x40; // first_mb_in_slice > 0: same access unit as the first IDR.
+        publisher.writeH264Chunk(Buffer.concat([
+          START, nal(7, 8, 0x11),
+          START, nal(8, 6, 0x22),
+          START, nal(5, 1200, 0x33),
+          START, secondIdrSlice,
+          START,
+        ]));
+        publisher.writeH264Chunk(pFrame(0x55)); // Terminates and sends the cached IDR access unit.
+        publisher.writeH264Chunk(pFrame(0x56)); // Terminates the first P-frame parser buffer.
+        await sleep(200);
+        const cachedStream = (await (await fetch(`${base}/api/streams/late-viewer`)).json()) as {
+          framesForwarded: number;
+        };
+        expect(cachedStream.framesForwarded).toBeGreaterThan(0);
+        await primingViewer.close();
+
+        viewer.addTransceiver("video", { direction: "recvonly" });
+        await viewer.setLocalDescription(await viewer.createOffer());
+        await waitForIce(viewer);
+        const response = await fetch(`${base}/whep/late-viewer`, {
+          method: "POST",
+          headers: { "Content-Type": "application/sdp" },
+          body: viewer.localDescription?.sdp ?? "",
+        });
+        expect(response.status).toBe(201);
+        await viewer.setRemoteDescription({ type: "answer", sdp: await response.text() });
+        await waitFor(() => viewer.connectionState === "connected", 8000);
+        await waitFor(() => received.some(rtp => rtp.header.marker), 5000);
+
+        expect(received.some(rtp => (rtp.payload[0] & 0x1f) === 7)).toBe(true);
+        expect(received.some(rtp => (rtp.payload[0] & 0x1f) === 8)).toBe(true);
+        expect(received.filter(rtp => (rtp.payload[0] & 0x1f) === 5).length).toBeGreaterThanOrEqual(2);
+      } finally {
+        await publisher.stop();
+        await primingViewer.close();
         await viewer.close();
         await http.close();
       }

--- a/test/integration/webrtcCoordinationServer.e2e.test.ts
+++ b/test/integration/webrtcCoordinationServer.e2e.test.ts
@@ -125,6 +125,22 @@ describe("WebRTC coordination server e2e", () => {
     }
   });
 
+  test("advertises the CORS and SDP contract required by browser WHIP clients", async () => {
+    const http = new HttpCoordinationServer({ iceServers: [] });
+    const port = await http.listen(0, "127.0.0.1");
+    const base = `http://127.0.0.1:${port}`;
+    try {
+      const response = await fetch(`${base}/whip`, { method: "OPTIONS" });
+      expect(response.status).toBe(200);
+      expect(response.headers.get("accept-post")).toBe("application/sdp");
+      expect(response.headers.get("access-control-allow-headers")).toContain("If-Match");
+      expect(response.headers.get("access-control-expose-headers")).toContain("Location");
+      expect(response.headers.get("access-control-expose-headers")).toContain("ETag");
+    } finally {
+      await http.close();
+    }
+  });
+
   test(
     "publisher -> WHIP ingest -> WHEP subscriber forwards frames, reconnect API lists the stream",
     async () => {
@@ -173,7 +189,11 @@ describe("WebRTC coordination server e2e", () => {
         });
         expect(whepRes.status).toBe(201);
         expect(whepRes.headers.get("location")).toContain("/whep/e2e/");
-        await viewer.setRemoteDescription({ type: "answer", sdp: await whepRes.text() });
+        const whepAnswer = await whepRes.text();
+        // RFC 9725 / WHEP require rtcp-mux-only on each bundled m-section;
+        // werift needs this signalled explicitly by the reference server.
+        expect(whepAnswer).toContain("a=rtcp-mux\r\na=rtcp-mux-only\r\n");
+        await viewer.setRemoteDescription({ type: "answer", sdp: whepAnswer });
 
         await waitFor(() => viewer.connectionState === "connected", 8000);
 

--- a/test/integration/webrtcCoordinationServer.e2e.test.ts
+++ b/test/integration/webrtcCoordinationServer.e2e.test.ts
@@ -142,6 +142,41 @@ describe("WebRTC coordination server e2e", () => {
   });
 
   test(
+    "returns 422 for a compliant but unsupported WHIP ICE restart",
+    async () => {
+      const http = new HttpCoordinationServer({ iceServers: [] });
+      const port = await http.listen(0, "127.0.0.1");
+      const base = `http://127.0.0.1:${port}`;
+      const publisher = new WebRtcPublisher({ streamId: "restart", whipEndpoint: `${base}/whip?streamId=restart` });
+      try {
+        await publisher.start();
+        const response = await fetch(`${base}/whip/restart`, {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/trickle-ice-sdpfrag",
+            "If-Match": "*",
+          },
+          body: [
+            "m=video 9 UDP/TLS/RTP/SAVPF 96",
+            "a=mid:0",
+            "a=ice-ufrag:replacement",
+            "a=ice-pwd:replacement",
+            "a=end-of-candidates",
+            "",
+          ].join("\r\n"),
+        });
+
+        expect(response.status).toBe(422);
+        expect((await fetch(`${base}/api/streams/restart`)).status).toBe(200);
+      } finally {
+        await publisher.stop();
+        await http.close();
+      }
+    },
+    15000
+  );
+
+  test(
     "publisher -> WHIP ingest -> WHEP subscriber forwards frames, reconnect API lists the stream",
     async () => {
       const http = new HttpCoordinationServer({ iceServers: [] });

--- a/test/package/webrtcRuntimeMetadata.test.ts
+++ b/test/package/webrtcRuntimeMetadata.test.ts
@@ -72,7 +72,7 @@ const publisher = new WebRtcPublisher(
             status: 201,
             ok: true,
             headers: { get: name => (name.toLowerCase() === "location" ? "/whip/resource/debug-1" : null) },
-            text: async () => ["v=0", "m=video 9 UDP/TLS/RTP/SAVPF 96", "a=recvonly", "a=rtpmap:96 H264/90000", "a=fmtp:96 packetization-mode=1;profile-level-id=42e01f", ""].join("\\r\\n"),
+            text: async () => ["v=0", "m=video 9 UDP/TLS/RTP/SAVPF 96", "a=recvonly", "a=rtpmap:96 H264/90000", "a=fmtp:96 packetization-mode=1;profile-level-id=42e02a", ""].join("\\r\\n"),
           };
         },
       }),

--- a/test/package/webrtcRuntimeMetadata.test.ts
+++ b/test/package/webrtcRuntimeMetadata.test.ts
@@ -72,7 +72,7 @@ const publisher = new WebRtcPublisher(
             status: 201,
             ok: true,
             headers: { get: name => (name.toLowerCase() === "location" ? "/whip/resource/debug-1" : null) },
-            text: async () => ["v=0", "m=video 9 UDP/TLS/RTP/SAVPF 96", "a=recvonly", "a=rtpmap:96 H264/90000", ""].join("\\r\\n"),
+            text: async () => ["v=0", "m=video 9 UDP/TLS/RTP/SAVPF 96", "a=recvonly", "a=rtpmap:96 H264/90000", "a=fmtp:96 packetization-mode=1;profile-level-id=42e01f", ""].join("\\r\\n"),
           };
         },
       }),

--- a/test/package/webrtcRuntimeMetadata.test.ts
+++ b/test/package/webrtcRuntimeMetadata.test.ts
@@ -72,7 +72,7 @@ const publisher = new WebRtcPublisher(
             status: 201,
             ok: true,
             headers: { get: name => (name.toLowerCase() === "location" ? "/whip/resource/debug-1" : null) },
-            text: async () => "v=0",
+            text: async () => ["v=0", "m=video 9 UDP/TLS/RTP/SAVPF 96", "a=recvonly", "a=rtpmap:96 H264/90000", ""].join("\\r\\n"),
           };
         },
       }),

--- a/test/server/webrtcStreamManager.test.ts
+++ b/test/server/webrtcStreamManager.test.ts
@@ -241,6 +241,20 @@ describe("webrtcStreamManager", () => {
     expect(stopped.state).toBe("stopped");
   });
 
+  test("stop without id rejects an active stream plus a different pending start as ambiguous", async () => {
+    let releaseJar: ((path: string | null) => void) | undefined;
+    installFakes();
+    await startWebRtcStream({ device: ANDROID, overrides: { whipEndpoint: ENDPOINT } });
+    setWebRtcStreamManagerDependencies({
+      resolveVideoJar: () => new Promise(resolve => { releaseJar = resolve; }),
+    });
+    const pending = startWebRtcStream({ device: IOS, overrides: { whipEndpoint: ENDPOINT } });
+
+    await expect(stopWebRtcStream()).rejects.toThrow(/specify streamId/);
+    releaseJar?.(null);
+    await pending;
+  });
+
   test("does not leave an orphaned source when the stream is stopped mid-start", async () => {
     // A source whose start() stops the stream (simulating stopWebRtcStream racing
     // the async onConnected startup path). The manager must re-check ownership

--- a/test/server/webrtcStreamManager.test.ts
+++ b/test/server/webrtcStreamManager.test.ts
@@ -144,6 +144,25 @@ describe("webrtcStreamManager", () => {
     ).rejects.toThrow(/already active/);
   });
 
+  test("reserves a device before asynchronous jar resolution completes", async () => {
+    let releaseJar: ((path: string | null) => void) | undefined;
+    setWebRtcStreamManagerDependencies({
+      idGenerator: new CountingIdGenerator("id"),
+      createPublisher: (config, deps) => new FakePublisher(config, deps) as unknown as WebRtcPublisher,
+      createSource: () => new FakeSource() as unknown as AndroidH264Source,
+      resolveVideoJar: () => new Promise(resolve => { releaseJar = resolve; }),
+      now: () => new Date("2026-07-11T00:00:00.000Z"),
+    });
+
+    const first = startWebRtcStream({ device: ANDROID, overrides: { whipEndpoint: ENDPOINT } });
+    await expect(
+      startWebRtcStream({ device: ANDROID, overrides: { whipEndpoint: ENDPOINT } })
+    ).rejects.toThrow(/already active or starting/);
+
+    releaseJar?.(null);
+    await first;
+  });
+
   test("rejects a duplicate explicit streamId (even on a different device)", async () => {
     installFakes();
     const other: BootedDevice = { deviceId: "emulator-5556", platform: "android", name: "b" } as BootedDevice;

--- a/test/server/webrtcStreamManager.test.ts
+++ b/test/server/webrtcStreamManager.test.ts
@@ -163,6 +163,34 @@ describe("webrtcStreamManager", () => {
     await first;
   });
 
+  test("cancels an explicit stream while jar resolution is pending", async () => {
+    let releaseJar: ((path: string | null) => void) | undefined;
+    let publishersCreated = 0;
+    setWebRtcStreamManagerDependencies({
+      idGenerator: new CountingIdGenerator("id"),
+      createPublisher: (config, deps) => {
+        publishersCreated++;
+        return new FakePublisher(config, deps) as unknown as WebRtcPublisher;
+      },
+      createSource: () => new FakeSource() as unknown as AndroidH264Source,
+      resolveVideoJar: () => new Promise(resolve => { releaseJar = resolve; }),
+      now: () => new Date("2026-07-11T00:00:00.000Z"),
+    });
+
+    const starting = startWebRtcStream({
+      device: ANDROID,
+      streamId: "pending-stop",
+      overrides: { whipEndpoint: ENDPOINT },
+    });
+    const stopped = await stopWebRtcStream("pending-stop");
+    releaseJar?.(null);
+
+    await expect(starting).rejects.toThrow(/stopped before startup/);
+    expect(stopped.state).toBe("stopped");
+    expect(publishersCreated).toBe(0);
+    expect(listWebRtcStreams()).toEqual([]);
+  });
+
   test("rejects a duplicate explicit streamId (even on a different device)", async () => {
     installFakes();
     const other: BootedDevice = { deviceId: "emulator-5556", platform: "android", name: "b" } as BootedDevice;

--- a/test/server/webrtcStreamManager.test.ts
+++ b/test/server/webrtcStreamManager.test.ts
@@ -255,6 +255,39 @@ describe("webrtcStreamManager", () => {
     await pending;
   });
 
+  test("rejects audio startup promptly when stopped before the publisher connects", async () => {
+    let releaseStart: (() => void) | undefined;
+    let enteredStart: (() => void) | undefined;
+    const startEntered = new Promise<void>(resolve => { enteredStart = resolve; });
+    const allowStartToReturn = new Promise<void>(resolve => { releaseStart = resolve; });
+    setWebRtcStreamManagerDependencies({
+      idGenerator: new CountingIdGenerator("id"),
+      createPublisher: (config, deps) => {
+        const publisher = new FakePublisher(config, deps);
+        publisher.start = async () => {
+          await publisher.onBeforeEstablish?.();
+          enteredStart?.();
+          await allowStartToReturn;
+        };
+        return publisher as unknown as WebRtcPublisher;
+      },
+      createSource: () => new FakeSource() as unknown as AndroidH264Source,
+      resolveVideoJar: async () => null,
+      now: () => new Date("2026-07-11T00:00:00.000Z"),
+    });
+
+    const starting = startWebRtcStream({
+      device: ANDROID,
+      streamId: "audio-stop-before-connect",
+      overrides: { whipEndpoint: ENDPOINT, audioEnabled: true },
+    });
+    await startEntered;
+    await stopWebRtcStream("audio-stop-before-connect");
+    releaseStart?.();
+
+    await expect(starting).rejects.toThrow(/stopped before capture source started/);
+  });
+
   test("does not leave an orphaned source when the stream is stopped mid-start", async () => {
     // A source whose start() stops the stream (simulating stopWebRtcStream racing
     // the async onConnected startup path). The manager must re-check ownership


### PR DESCRIPTION
## Summary

- Harden WHIP/WebRTC lifecycle, negotiation validation, timeouts, and failed-session cleanup.
- Make Android and iOS capture failures, startup/stop races, and invalid stream configuration fail safely and recoverably.
- Make local and reference video relays safe for arbitrary H.264 chunking, late viewers, slow consumers, and oversized HTTP requests.

## Root cause

Several streaming boundaries assumed happy-path timing and complete transport chunks. That allowed duplicate starts, stale capture processes, frozen iOS streams, invalid WHIP answers, undecodable late viewers, and unbounded buffering behind slow local subscribers.

## Impact

WebRTC streaming now rejects invalid or incomplete negotiation up front, tears down resources deterministically, and delivers a decodable stream to late viewers without allowing a slow viewer to consume unbounded memory. iOS and Android capture failures now reach reconnect/error handling instead of leaving a silent frozen stream.

## Validation

- `bun run build`
- `bun test` (8,240 passed, 11 environment-gated tests skipped)
- `bun run typecheck`
- `(cd android && ./gradlew :video-server:test)`
- `(cd ios/screen-capture && swift test)`
