### PR TITLE
ci(release): dispatch release.yml explicitly instead of relying on the tag event

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -203,3 +203,21 @@ jobs:
           git push origin "$TAG"
 
           echo "Successfully created and pushed tag: $TAG"
+
+      - name: Start the release
+        shell: bash
+        env:
+          # The default GITHUB_TOKEN cannot dispatch a workflow run from inside a
+          # run; reuse the PAT that pushed the tag.
+          GH_TOKEN: ${{ secrets.AUTO_MOBILE_PR_TOKEN }}
+          TAG: ${{ inputs.version }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Pushing the tag does not start Release on its own: the create event
+          # never fired for the CI-pushed v0.0.42/v0.0.44 tags, so every release
+          # since has been published by hand. Dispatch it explicitly instead.
+          gh workflow run release.yml --repo "$REPO" --ref main --field tag="$TAG"
+
+          echo "Dispatched release.yml for $TAG"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -216,14 +216,37 @@ jobs:
           set -euo pipefail
 
           # Pushing the tag does not start Release on its own: the create event
-          # never fired for the CI-pushed v0.0.42/v0.0.44 tags, so every release
-          # since has been published by hand. Dispatch it explicitly instead.
+          # never fired for the tags CI pushed at 0.0.42 and 0.0.44, so every
+          # release since has been published by hand. Dispatch it explicitly.
+          # (Those two tags were v-prefixed at the time and have since been
+          # deleted, so don't go looking for them in `git tag --list`.)
           #
           # Dispatch on the TAG, not on main. github.ref has to stay a tag ref:
           # action-gh-release derives its tag from it, docker/metadata-action's
           # type=semver is inert without it, and the reusable APK/IPA/jar builders
           # run at the caller's ref -- on main they would build a different tree
           # than the checksums minted just above were computed from.
+          #
+          # Re-dispatching an already-released tag is safe: every non-idempotent
+          # publish step consults scripts/release/already-published.sh first.
+          before=$(gh run list --repo "$REPO" --workflow release.yml \
+            --limit 1 --json databaseId --jq '.[].databaseId // 0')
+
           gh workflow run release.yml --repo "$REPO" --ref "$TAG" -f tag="$TAG"
 
-          echo "Dispatched release.yml for $TAG"
+          # The dispatch API returns 204 before the run exists and gh does not
+          # wait, so `gh workflow run` succeeds even if no run is ever created.
+          # A green step here with nothing queued is the same silent non-release
+          # this change exists to fix, so confirm a new run actually appeared.
+          for _ in $(seq 1 12); do
+            sleep 5
+            after=$(gh run list --repo "$REPO" --workflow release.yml \
+              --limit 1 --json databaseId --jq '.[].databaseId // 0')
+            if [[ "$after" != "$before" ]]; then
+              echo "Dispatched release.yml for $TAG (run ${after})"
+              exit 0
+            fi
+          done
+
+          echo "Dispatched release.yml for $TAG but no run appeared after 60s" >&2
+          exit 1

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -218,6 +218,12 @@ jobs:
           # Pushing the tag does not start Release on its own: the create event
           # never fired for the CI-pushed v0.0.42/v0.0.44 tags, so every release
           # since has been published by hand. Dispatch it explicitly instead.
-          gh workflow run release.yml --repo "$REPO" --ref main --field tag="$TAG"
+          #
+          # Dispatch on the TAG, not on main. github.ref has to stay a tag ref:
+          # action-gh-release derives its tag from it, docker/metadata-action's
+          # type=semver is inert without it, and the reusable APK/IPA/jar builders
+          # run at the caller's ref -- on main they would build a different tree
+          # than the checksums minted just above were computed from.
+          gh workflow run release.yml --repo "$REPO" --ref "$TAG" -f tag="$TAG"
 
           echo "Dispatched release.yml for $TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,10 @@ name: Release
         type: string
 
 # `create:` is retained as a fallback for a hand-pushed tag, so one tag could in
-# principle arrive by both routes. Two concurrent releases would double-publish to
-# npm, Maven and Docker; serialize per tag rather than rely on that never racing.
+# principle arrive by both routes. This serializes them; it does NOT dedupe them
+# -- with cancel-in-progress false the second run queues and then starts once the
+# first finishes. What makes that second run harmless is the already-published.sh
+# guard on each non-idempotent publish step, not this block. Both are required.
 concurrency:
   group: release-${{ inputs.tag || github.event.ref }}
   cancel-in-progress: false
@@ -43,8 +45,23 @@ jobs:
         env:
           TAG: ${{ inputs.tag || github.event.ref }}
           EVENT_NAME: ${{ github.event_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+          # The dispatch must run ON the tag, not merely name it. The Actions UI
+          # ref picker defaults to a branch, and prepare-release is not the only
+          # caller. docker/metadata-action derives its semver tags from
+          # github.ref, so a dispatch from main checks out the right tree and
+          # still pushes an image with no version tag -- green, and wrong.
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]] \
+            && { [[ "$REF_TYPE" != "tag" ]] || [[ "$REF_NAME" != "$TAG" ]]; }; then
+            echo "Release must be dispatched on tag '$TAG', but this run is on" >&2
+            echo "${REF_TYPE} '${REF_NAME}'. Re-run it and pick the tag in the" >&2
+            echo "ref dropdown, or let prepare-release dispatch it." >&2
+            exit 1
+          fi
           if [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+].*)?$ ]]; then
             echo "is_release_tag=true" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,7 +261,22 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          # npm publish is not idempotent: without this, a failure anywhere later
+          # in the job makes the whole release unrerunnable.
+          #
+          # Assign first, then test. Under set -e a failing command substitution
+          # inside an `if` condition does NOT abort, so testing it inline would
+          # turn the guard's fail-closed error into a silent "not published".
+          state=$(scripts/release/already-published.sh npm "$VERSION")
+          if [ "$state" = published ]; then
+            echo "npm already has $VERSION; skipping publish"
+            exit 0
+          fi
+          npm publish --provenance --access public
 
       - name: Publish Homebrew formula
         env:
@@ -278,7 +293,16 @@ jobs:
           curl -L "$URL" | tar xz mcp-publisher
 
       - name: Publish to MCP Registry
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
+          set -euo pipefail
+          # Assign first, then test — see the npm step for why.
+          state=$(scripts/release/already-published.sh mcp "$VERSION")
+          if [ "$state" = published ]; then
+            echo "MCP Registry already has $VERSION; skipping publish"
+            exit 0
+          fi
           ./mcp-publisher login dns --domain jasonpearson.dev \
             --private-key "${{ secrets.MCP_DNS_PRIVATE_KEY }}"
           ./mcp-publisher publish
@@ -304,6 +328,7 @@ jobs:
 
       - name: Publish Android Libraries to Maven Central
         env:
+          VERSION: ${{ steps.version.outputs.version }}
           ORG_GRADLE_PROJECT_mavenCentralUsername:
             ${{ secrets.MAVEN_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword:
@@ -320,6 +345,15 @@ jobs:
           RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
           RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
         run: |
+          set -euo pipefail
+          # A duplicate GAV is rejected, so a rerun would die here. The guard
+          # fails closed on a partial publish rather than choosing for us.
+          # Assign first, then test — see the npm step for why.
+          state=$(scripts/release/already-published.sh maven "$VERSION")
+          if [ "$state" = published ]; then
+            echo "Maven Central already has $VERSION; skipping publish"
+            exit 0
+          fi
           cd android
           # Override VERSION_NAME with release version from git tag
           # (not SNAPSHOT in gradle.properties)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,13 @@ name: Release
         required: true
         type: string
 
+# `create:` is retained as a fallback for a hand-pushed tag, so one tag could in
+# principle arrive by both routes. Two concurrent releases would double-publish to
+# npm, Maven and Docker; serialize per tag rather than rely on that never racing.
+concurrency:
+  group: release-${{ inputs.tag || github.event.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write
@@ -376,6 +383,10 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          # Explicit, not derived from github.ref. The action throws "GitHub
+          # Releases requires a tag" on a non-tag ref, and this step runs after
+          # npm/Homebrew/MCP/Maven/Docker have already published irreversibly.
+          tag_name: ${{ needs.validate-release-tag.outputs.tag }}
           name: AutoMobile v${{ steps.version.outputs.version }}
           body_path: release_notes.txt
           files: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,16 @@ name: Release
 
 "on":
   create:
+  # prepare-release dispatches this explicitly after pushing the tag. The `create`
+  # event above did not fire for CI-pushed tags (see v0.0.42/v0.0.44: the tag push
+  # succeeded and no Release run was ever queued), so the tag event alone cannot be
+  # relied on to start a release.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish, with no leading v (e.g. 0.0.45)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -14,22 +24,34 @@ jobs:
   validate-release-tag:
     name: "Validate Release Tag"
     runs-on: ubuntu-latest
-    if: github.event.ref_type == 'tag'
+    # workflow_dispatch carries no ref_type; only the create path needs the tag gate.
+    if: github.event_name == 'workflow_dispatch' || github.event.ref_type == 'tag'
     outputs:
       is_release_tag: ${{ steps.validate.outputs.is_release_tag }}
+      tag: ${{ steps.validate.outputs.tag }}
     steps:
       - name: "Validate tag format"
         id: validate
         shell: bash
         env:
-          TAG: ${{ github.event.ref }}
+          TAG: ${{ inputs.tag || github.event.ref }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           if [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+].*)?$ ]]; then
             echo "is_release_tag=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "is_release_tag=false" >> "$GITHUB_OUTPUT"
-            echo "Ignoring non-release tag: $TAG"
+            exit 0
           fi
+
+          echo "is_release_tag=false" >> "$GITHUB_OUTPUT"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            # An explicit dispatch names the tag it wants released, so a format
+            # miss is a caller error. Failing beats skipping every publish step
+            # and still reporting the run green.
+            echo "Refusing to release malformed tag: $TAG (expected 0.0.45, no leading v)" >&2
+            exit 1
+          fi
+          echo "Ignoring non-release tag: $TAG"
 
   build-ctrl-proxy-ios-ipa:
     needs: validate-release-tag
@@ -73,7 +95,7 @@ jobs:
         with:
           lfs: false
           fetch-depth: 0
-          ref: refs/tags/${{ github.event.ref }}
+          ref: refs/tags/${{ needs.validate-release-tag.outputs.tag }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -91,7 +113,7 @@ jobs:
       - name: Extract version from tag
         id: version
         env:
-          TAG: ${{ github.event.ref }}
+          TAG: ${{ needs.validate-release-tag.outputs.tag }}
         run: |
           VERSION="$TAG"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"

--- a/scripts/release/already-published.sh
+++ b/scripts/release/already-published.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+#
+# Answer whether a release target already has <version> published.
+#
+# release.yml publishes to six targets in one sequential job, and `npm publish`
+# is not idempotent. A failure late in that sequence leaves the run unrepeatable:
+# the rerun dies on the first already-published target instead of resuming past
+# it. Each guarded step consults this script and skips what is already done.
+#
+# Usage:
+#   already-published.sh <npm|maven|mcp> <version>
+#
+# Prints "published" or "missing" on stdout.
+#
+# Exits non-zero when it cannot determine the answer -- an unreachable registry,
+# an unexpected status, or a partially-published Maven coordinate set. Failing
+# closed is deliberate. A guard that answered "missing" on error would republish
+# over a good release; one that answered "published" on error would silently skip
+# a real publish, which is precisely the fail-green shape this pipeline is being
+# fixed to remove. An unclear answer is a human's problem, not a default's.
+#
+# Homebrew and the GitHub Release are deliberately absent: update-brew-formula.sh
+# already exits early when the rendered formula is unchanged, and
+# action-gh-release updates an existing release rather than failing on one.
+
+set -euo pipefail
+
+NPM_PACKAGE="@kaeawc/auto-mobile"
+MAVEN_GROUP_PATH="dev/jasonpearson/auto-mobile"
+MAVEN_ARTIFACTS=(
+  auto-mobile-protocol
+  auto-mobile-test-plan-validation
+  auto-mobile-junit-runner
+  auto-mobile-sdk
+)
+MCP_SERVER_NAME="dev.jasonpearson/auto-mobile"
+
+# Overridable so the BATS suite can point at a stub instead of the real registry.
+MAVEN_BASE_URL="${MAVEN_BASE_URL:-https://repo1.maven.org/maven2}"
+MCP_REGISTRY_URL="${MCP_REGISTRY_URL:-https://registry.modelcontextprotocol.io}"
+
+usage() {
+  echo "usage: $(basename "$0") <npm|maven|mcp> <version>" >&2
+}
+
+check_npm() {
+  local version="$1" out
+  if out=$(npm view "${NPM_PACKAGE}@${version}" version 2>&1); then
+    # A hit prints the version; an empty body means npm resolved nothing.
+    if [[ -n "$out" ]]; then
+      echo published
+    else
+      echo missing
+    fi
+    return 0
+  fi
+
+  if printf '%s\n' "$out" | grep -q '404'; then
+    echo missing
+    return 0
+  fi
+
+  echo "ERROR: npm view failed for ${NPM_PACKAGE}@${version}: ${out}" >&2
+  return 1
+}
+
+check_maven() {
+  local version="$1" artifact url code
+  local found=0 absent=0
+  local total="${#MAVEN_ARTIFACTS[@]}"
+
+  for artifact in "${MAVEN_ARTIFACTS[@]}"; do
+    url="${MAVEN_BASE_URL}/${MAVEN_GROUP_PATH}/${artifact}/${version}/${artifact}-${version}.pom"
+    # No -f, deliberately. This is a status probe, not a download: the body goes
+    # to /dev/null and a 404 is the meaningful "not published yet" answer. -f
+    # exits non-zero on 404, which would turn that into a fail-closed error and
+    # make every first-time publish look like an unreachable registry.
+    if ! code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 --retry 3 "$url" 2>/dev/null); then # portability-ok
+      echo "ERROR: could not reach Maven Central for ${artifact}" >&2
+      return 1
+    fi
+    case "$code" in
+      200) found=$((found + 1)) ;;
+      404) absent=$((absent + 1)) ;;
+      *)
+        echo "ERROR: unexpected HTTP ${code} for ${url}" >&2
+        return 1
+        ;;
+    esac
+  done
+
+  if [[ "$found" -eq "$total" ]]; then
+    echo published
+    return 0
+  fi
+  if [[ "$absent" -eq "$total" ]]; then
+    echo missing
+    return 0
+  fi
+
+  # All four modules publish in one step, so a split result means that step died
+  # midway. Republishing would 409 on the ones that landed; skipping would leave
+  # the rest missing forever. Neither is safe to pick automatically.
+  echo "ERROR: Maven Central has ${found} of ${total} artifacts at ${version}." >&2
+  echo "       A partial publish needs manual repair before rerunning." >&2
+  return 1
+}
+
+check_mcp() {
+  local version="$1" encoded body matches
+  encoded="${MCP_SERVER_NAME//\//%2F}"
+
+  if ! body=$(curl -sS --max-time 30 --retry 3 --retry-delay 2 \
+    "${MCP_REGISTRY_URL}/v0/servers/${encoded}/versions" 2>/dev/null); then
+    echo "ERROR: could not reach the MCP registry" >&2
+    return 1
+  fi
+
+  if ! matches=$(printf '%s' "$body" \
+    | jq -r --arg v "$version" \
+      '[.servers[]?.server.version // empty | select(. == $v)] | length' 2>/dev/null); then
+    echo "ERROR: unparseable MCP registry response" >&2
+    return 1
+  fi
+
+  if ! [[ "$matches" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: unexpected MCP registry response shape" >&2
+    return 1
+  fi
+
+  if [[ "$matches" -gt 0 ]]; then
+    echo published
+  else
+    echo missing
+  fi
+}
+
+main() {
+  if [[ $# -ne 2 ]]; then
+    usage
+    return 2
+  fi
+
+  local target="$1" version="$2"
+
+  if [[ -z "$version" ]]; then
+    echo "ERROR: version must not be empty" >&2
+    return 2
+  fi
+
+  case "$target" in
+    npm) check_npm "$version" ;;
+    maven) check_maven "$version" ;;
+    mcp) check_mcp "$version" ;;
+    *)
+      echo "ERROR: unknown target: ${target}" >&2
+      usage
+      return 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/release/already-published.sh
+++ b/scripts/release/already-published.sh
@@ -22,6 +22,14 @@
 # Homebrew and the GitHub Release are deliberately absent: update-brew-formula.sh
 # already exits early when the rendered formula is unchanged, and
 # action-gh-release updates an existing release rather than failing on one.
+#
+# Known limit: the maven check probes repo1.maven.org, which is the sync target
+# rather than the Central Portal the publish uploads to. A rerun started inside
+# the sync window sees 404s, answers "missing", and the Gradle step then dies on
+# a duplicate GAV. That is the pre-guard behaviour, so it costs nothing, but it
+# means the maven guard helps a rerun an hour later and not a rerun a minute
+# later. Querying the Portal API with the credentials the step already has would
+# close it.
 
 set -euo pipefail
 
@@ -55,7 +63,10 @@ check_npm() {
     return 0
   fi
 
-  if printf '%s\n' "$out" | grep -q '404'; then
+  # Match npm's own error code, not a bare "404". npm appends a debug-log path
+  # whose millisecond field can itself be 404 (…T10_27_54_404Z-debug-0.log),
+  # which would make any npm failure -- ENOTFOUND, auth, 500 -- read as missing.
+  if printf '%s\n' "$out" | grep -q 'E404'; then
     echo missing
     return 0
   fi
@@ -110,9 +121,23 @@ check_mcp() {
   local version="$1" encoded body matches
   encoded="${MCP_SERVER_NAME//\//%2F}"
 
+  # v0.1 is the documented versions endpoint and the one publish-mcp-registry.sh
+  # verifies against. /v0 currently returns a byte-identical response, but it
+  # reads as a legacy alias and there is no reason to depend on it.
   if ! body=$(curl -sS --max-time 30 --retry 3 --retry-delay 2 \
-    "${MCP_REGISTRY_URL}/v0/servers/${encoded}/versions" 2>/dev/null); then
+    "${MCP_REGISTRY_URL}/v0.1/servers/${encoded}/versions" 2>/dev/null); then
     echo "ERROR: could not reach the MCP registry" >&2
+    return 1
+  fi
+
+  # curl has no -f here, and the registry answers a missing or renamed server
+  # with HTTP 404 and a well-formed JSON error object. `.servers[]?` suppresses
+  # the iterate error on that body, so it would parse to zero versions and read
+  # as "missing" -- the guard silently ceasing to guard. Require the shape.
+  if ! printf '%s' "$body" \
+    | jq -e 'type == "object" and (.servers | type) == "array"' >/dev/null 2>&1; then
+    echo "ERROR: MCP registry did not return a server list for ${MCP_SERVER_NAME}" >&2
+    echo "       response: ${body}" >&2
     return 1
   fi
 
@@ -143,8 +168,10 @@ main() {
 
   local target="$1" version="$2"
 
-  if [[ -z "$version" ]]; then
-    echo "ERROR: version must not be empty" >&2
+  # Same shape validate-release-tag enforces. A -z test alone would let "  "
+  # through, building a URL with spaces that 404s and reads as "missing".
+  if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+].*)?$ ]]; then
+    echo "ERROR: not a release version: '${version}' (expected 0.0.45)" >&2
     return 2
   fi
 

--- a/test/bats/release-already-published.bats
+++ b/test/bats/release-already-published.bats
@@ -14,12 +14,20 @@ setup() {
   export PATH
 }
 
+# Both stubs append their argv to a log. Asserting on that log is the only thing
+# standing between this suite and a guard that queries the wrong thing: a stub
+# that ignores its arguments answers identically whether the script asks for the
+# right version or no version at all, so dropping "@$version" from the npm spec
+# would make the guard report "published" for every release, skip npm publish
+# forever, and keep every test green.
+
 # Writes a `curl` stub. $1 is the status returned for Maven POM requests; any
 # MCP registry request gets $2 as its response body.
 stub_curl() {
   local maven_status="${1:-404}" mcp_body="${2:-\{\"servers\":[]\}}"
   cat > "$STUB_DIR/curl" <<EOF
 #!/usr/bin/env bash
+printf '%s\n' "\$*" >> "${BATS_TEST_TMPDIR}/curl.args"
 url="\${*: -1}"
 if [[ "\$url" == *registry.modelcontextprotocol.io* || "\$url" == *mcp-stub* ]]; then
   printf '%s' '${mcp_body}'
@@ -34,6 +42,7 @@ stub_npm() {
   local exit_code="$1" output="$2"
   cat > "$STUB_DIR/npm" <<EOF
 #!/usr/bin/env bash
+printf '%s\n' "\$*" >> "${BATS_TEST_TMPDIR}/npm.args"
 printf '%s\n' '${output}'
 exit ${exit_code}
 EOF
@@ -45,6 +54,9 @@ EOF
   run "$SCRIPT" npm 0.0.45
   [ "$status" -eq 0 ]
   [ "$output" = "published" ]
+  # Pin the query, not just the answer. Without @0.0.45 in the spec `npm view`
+  # resolves the package itself and every version reports published.
+  grep -Fq 'view @kaeawc/auto-mobile@0.0.45 version' "$BATS_TEST_TMPDIR/npm.args"
 }
 
 @test "npm: a 404 reports missing" {
@@ -67,6 +79,23 @@ EOF
   MAVEN_BASE_URL="http://maven-stub" run "$SCRIPT" maven 0.0.44
   [ "$status" -eq 0 ]
   [ "$output" = "published" ]
+  # The group path, artifact id and version must all reach the URL; a typo in
+  # any of them makes the guard answer "missing" forever.
+  grep -Fq 'http://maven-stub/dev/jasonpearson/auto-mobile/auto-mobile-sdk/0.0.44/auto-mobile-sdk-0.0.44.pom' \
+    "$BATS_TEST_TMPDIR/curl.args"
+}
+
+# A wrong artifact list silently narrows what "published" means. Pin it to the
+# POM_ARTIFACT_ID values the Gradle publish actually uses.
+@test "maven: the probed artifacts match the modules release.yml publishes" {
+  local repo_root="$BATS_TEST_DIRNAME/../.."
+  local module
+  for module in protocol test-plan-validation junit-runner auto-mobile-sdk; do
+    local artifact
+    artifact="$(sed -n 's/^POM_ARTIFACT_ID=//p' "$repo_root/android/$module/gradle.properties")"
+    [ -n "$artifact" ]
+    grep -Fq "  $artifact" "$repo_root/scripts/release/already-published.sh"
+  done
 }
 
 @test "maven: no artifacts present reports missing" {
@@ -106,6 +135,10 @@ EOF
   MCP_REGISTRY_URL="http://mcp-stub" run "$SCRIPT" mcp 0.0.45
   [ "$status" -eq 0 ]
   [ "$output" = "published" ]
+  # The slash in the server name must be percent-encoded; unencoded, the
+  # registry returns an endpoint-not-found envelope that parses to zero versions.
+  # Pin the API version too — a silent endpoint move is the same class of bug.
+  grep -Fq '/v0.1/servers/dev.jasonpearson%2Fauto-mobile/versions' "$BATS_TEST_TMPDIR/curl.args"
 }
 
 @test "mcp: a registry holding only older versions reports missing" {
@@ -133,4 +166,42 @@ EOF
 @test "a missing version argument is rejected" {
   run "$SCRIPT" npm
   [ "$status" -ne 0 ]
+}
+
+# curl without -f exits 0 on an HTTP error, so the "could not reach" branches
+# only fire on a genuine transport failure (exit 6, status 000). Neither stub
+# above ever exits non-zero, so these branches were previously uncovered.
+@test "maven: an unreachable registry fails closed" {
+  printf '#!/usr/bin/env bash\nprintf %%s 000\nexit 6\n' > "$STUB_DIR/curl"
+  chmod +x "$STUB_DIR/curl"
+  MAVEN_BASE_URL="http://maven-stub" run "$SCRIPT" maven 0.0.45
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"could not reach Maven Central"* ]]
+  [[ "$output" != *missing* ]]
+}
+
+@test "mcp: an unreachable registry fails closed" {
+  printf '#!/usr/bin/env bash\nexit 6\n' > "$STUB_DIR/curl"
+  chmod +x "$STUB_DIR/curl"
+  MCP_REGISTRY_URL="http://mcp-stub" run "$SCRIPT" mcp 0.0.45
+  [ "$status" -ne 0 ]
+  [[ "$output" != *missing* ]]
+}
+
+# The registry answers a missing or renamed server with HTTP 404 and a
+# well-formed JSON error object. curl has no -f, so `.servers[]?` swallows it as
+# zero versions and the guard would report "missing" for a server that may well
+# be published under a name the script no longer knows.
+@test "mcp: a 404 error envelope fails closed rather than reading as missing" {
+  stub_curl 404 '{"title":"Not Found","status":404,"detail":"Server not found"}'
+  MCP_REGISTRY_URL="http://mcp-stub" run "$SCRIPT" mcp 0.0.45
+  [ "$status" -ne 0 ]
+  [[ "$output" != *missing* ]]
+  [[ "$output" == *"did not return a server list"* ]]
+}
+
+@test "a whitespace-only version is rejected" {
+  run "$SCRIPT" maven "   "
+  [ "$status" -ne 0 ]
+  [[ "$output" != *missing* ]]
 }

--- a/test/bats/release-already-published.bats
+++ b/test/bats/release-already-published.bats
@@ -1,0 +1,136 @@
+#!/usr/bin/env bats
+#
+# Guards scripts/release/already-published.sh, the idempotency check that makes a
+# failed release rerunnable. The cases that matter most are the failure ones: a
+# guard that answers "published" when it cannot reach a registry would silently
+# skip a real publish, which is the fail-green shape release.yml is being fixed
+# to remove.
+
+setup() {
+  SCRIPT="$BATS_TEST_DIRNAME/../../scripts/release/already-published.sh"
+  STUB_DIR="$BATS_TEST_TMPDIR/bin"
+  mkdir -p "$STUB_DIR"
+  PATH="$STUB_DIR:$PATH"
+  export PATH
+}
+
+# Writes a `curl` stub. $1 is the status returned for Maven POM requests; any
+# MCP registry request gets $2 as its response body.
+stub_curl() {
+  local maven_status="${1:-404}" mcp_body="${2:-\{\"servers\":[]\}}"
+  cat > "$STUB_DIR/curl" <<EOF
+#!/usr/bin/env bash
+url="\${*: -1}"
+if [[ "\$url" == *registry.modelcontextprotocol.io* || "\$url" == *mcp-stub* ]]; then
+  printf '%s' '${mcp_body}'
+  exit 0
+fi
+printf '%s' '${maven_status}'
+EOF
+  chmod +x "$STUB_DIR/curl"
+}
+
+stub_npm() {
+  local exit_code="$1" output="$2"
+  cat > "$STUB_DIR/npm" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' '${output}'
+exit ${exit_code}
+EOF
+  chmod +x "$STUB_DIR/npm"
+}
+
+@test "npm: a resolvable version reports published" {
+  stub_npm 0 "0.0.45"
+  run "$SCRIPT" npm 0.0.45
+  [ "$status" -eq 0 ]
+  [ "$output" = "published" ]
+}
+
+@test "npm: a 404 reports missing" {
+  stub_npm 1 "npm error code E404 - Not found"
+  run "$SCRIPT" npm 99.99.99
+  [ "$status" -eq 0 ]
+  [ "$output" = "missing" ]
+}
+
+@test "npm: a non-404 failure fails closed rather than guessing" {
+  stub_npm 1 "npm error code EAI_AGAIN request to registry failed"
+  run "$SCRIPT" npm 0.0.45
+  [ "$status" -ne 0 ]
+  [[ "$output" != *published* ]]
+  [[ "$output" != *missing* ]]
+}
+
+@test "maven: all four artifacts present reports published" {
+  stub_curl 200
+  MAVEN_BASE_URL="http://maven-stub" run "$SCRIPT" maven 0.0.44
+  [ "$status" -eq 0 ]
+  [ "$output" = "published" ]
+}
+
+@test "maven: no artifacts present reports missing" {
+  stub_curl 404
+  MAVEN_BASE_URL="http://maven-stub" run "$SCRIPT" maven 0.0.45
+  [ "$status" -eq 0 ]
+  [ "$output" = "missing" ]
+}
+
+@test "maven: a partial publish fails closed instead of picking a side" {
+  # 200 for the first artifact, 404 for the rest — the shape left behind when the
+  # publish step dies midway through its four modules.
+  cat > "$STUB_DIR/curl" <<'EOF'
+#!/usr/bin/env bash
+url="${*: -1}"
+case "$url" in
+  *auto-mobile-protocol*) printf '200' ;;
+  *) printf '404' ;;
+esac
+EOF
+  chmod +x "$STUB_DIR/curl"
+  MAVEN_BASE_URL="http://maven-stub" run "$SCRIPT" maven 0.0.45
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"1 of 4"* ]]
+  [[ "$output" == *"manual repair"* ]]
+}
+
+@test "maven: an unexpected status fails closed" {
+  stub_curl 503
+  MAVEN_BASE_URL="http://maven-stub" run "$SCRIPT" maven 0.0.45
+  [ "$status" -ne 0 ]
+  [[ "$output" == *503* ]]
+}
+
+@test "mcp: a matching version reports published" {
+  stub_curl 404 '{"servers":[{"server":{"version":"0.0.13"}},{"server":{"version":"0.0.45"}}]}'
+  MCP_REGISTRY_URL="http://mcp-stub" run "$SCRIPT" mcp 0.0.45
+  [ "$status" -eq 0 ]
+  [ "$output" = "published" ]
+}
+
+@test "mcp: a registry holding only older versions reports missing" {
+  # The live registry is stuck on 0.0.13 while npm is at 0.0.44, so this is the
+  # real-world case, not a hypothetical.
+  stub_curl 404 '{"servers":[{"server":{"version":"0.0.13"}}]}'
+  MCP_REGISTRY_URL="http://mcp-stub" run "$SCRIPT" mcp 0.0.45
+  [ "$status" -eq 0 ]
+  [ "$output" = "missing" ]
+}
+
+@test "mcp: an unparseable response fails closed" {
+  stub_curl 404 'not json at all'
+  MCP_REGISTRY_URL="http://mcp-stub" run "$SCRIPT" mcp 0.0.45
+  [ "$status" -ne 0 ]
+  [[ "$output" != *published* ]]
+}
+
+@test "an unknown target is rejected" {
+  run "$SCRIPT" docker 0.0.45
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unknown target"* ]]
+}
+
+@test "a missing version argument is rejected" {
+  run "$SCRIPT" npm
+  [ "$status" -ne 0 ]
+}

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -158,3 +158,25 @@
 @test "release.yml passes an explicit tag_name to action-gh-release (#4157)" {
   grep -Fq 'tag_name: ${{ needs.validate-release-tag.outputs.tag }}' ".github/workflows/release.yml"
 }
+
+# release.yml publishes to six targets in one job and npm publish is not
+# idempotent, so every target that rejects a duplicate must be guarded or a
+# failure late in the job makes the release unrerunnable. Homebrew and the
+# GitHub Release are intentionally unguarded: update-brew-formula.sh already
+# no-ops on an unchanged formula, and action-gh-release updates in place.
+@test "release.yml guards every non-idempotent publish (#4157)" {
+  local workflow=".github/workflows/release.yml"
+  grep -Fq 'already-published.sh npm "$VERSION"' "$workflow"
+  grep -Fq 'already-published.sh mcp "$VERSION"' "$workflow"
+  grep -Fq 'already-published.sh maven "$VERSION"' "$workflow"
+}
+
+# The guard fails closed, but that only reaches the job if its exit status can
+# propagate. Under set -e a failing command substitution inside an `if`
+# condition does NOT abort, so the inline form would silently downgrade an
+# unreachable-registry error into "not published" and publish anyway.
+@test "release.yml assigns the guard result before testing it (#4157)" {
+  local workflow=".github/workflows/release.yml"
+  grep -Fq 'state=$(scripts/release/already-published.sh' "$workflow"
+  ! grep -Fq 'if [ "$(scripts/release/already-published.sh' "$workflow"
+}

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -138,3 +138,23 @@
     | grep -vE '^[^:]+:[0-9]+:[[:space:]]*#' || true"
   [ -z "$output" ]
 }
+
+# Pushing the tag does not start Release: the `create` event never fired for the
+# CI-pushed v0.0.42/v0.0.44 tags, so ~26 versions were published by hand while CI
+# reported green. prepare-release must dispatch release.yml explicitly, and it must
+# dispatch on the TAG -- action-gh-release and docker/metadata-action's type=semver
+# both read github.ref, so a main ref silently drops the version.
+@test "prepare-release dispatches release.yml on the tag (#4157)" {
+  local workflow=".github/workflows/prepare-release.yml"
+  grep -Fq 'gh workflow run release.yml' "$workflow"
+  # -e is required: a pattern starting with "--" is otherwise parsed as an option.
+  grep -Fq -e '--ref "$TAG"' "$workflow"
+  grep -Fq 'workflow_dispatch:' ".github/workflows/release.yml"
+}
+
+# The release tag must never be derived implicitly from github.ref: that step runs
+# after npm/Homebrew/MCP/Maven/Docker have already published irreversibly, and
+# npm publish is not idempotent, so a throw there is unrecoverable by rerun.
+@test "release.yml passes an explicit tag_name to action-gh-release (#4157)" {
+  grep -Fq 'tag_name: ${{ needs.validate-release-tag.outputs.tag }}' ".github/workflows/release.yml"
+}

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -139,24 +139,62 @@
   [ -z "$output" ]
 }
 
-# Pushing the tag does not start Release: the `create` event never fired for the
-# CI-pushed v0.0.42/v0.0.44 tags, so ~26 versions were published by hand while CI
-# reported green. prepare-release must dispatch release.yml explicitly, and it must
-# dispatch on the TAG -- action-gh-release and docker/metadata-action's type=semver
-# both read github.ref, so a main ref silently drops the version.
-@test "prepare-release dispatches release.yml on the tag (#4157)" {
-  local workflow=".github/workflows/prepare-release.yml"
-  grep -Fq 'gh workflow run release.yml' "$workflow"
-  # -e is required: a pattern starting with "--" is otherwise parsed as an option.
-  grep -Fq -e '--ref "$TAG"' "$workflow"
-  grep -Fq 'workflow_dispatch:' ".github/workflows/release.yml"
+# The assertions below parse the workflow as YAML rather than grepping its text.
+# A raw grep is satisfied by any comment or unrelated step containing the string,
+# so it would keep passing while the step it claims to pin was deleted -- and a
+# wiring link that regresses silently is the exact defect this whole area exists
+# to prevent. `yq` reads the real trigger and step fields instead.
+#
+# Pushing the tag does not start Release on its own: the `create` event never
+# fired for the tags CI pushed at 0.0.42 and 0.0.44, so ~26 versions were
+# published by hand while CI reported green.
+
+# Skipping locally is a convenience; skipping in CI would silently retire every
+# assertion below, which is the same fail-green these guards exist to catch.
+wiring_requires_yq() {
+  command -v yq >/dev/null 2>&1 && return 0
+  if [[ -n "${CI:-}" ]]; then
+    echo "yq is required in CI to verify release workflow wiring" >&2
+    return 1
+  fi
+  skip "yq not installed"
 }
 
-# The release tag must never be derived implicitly from github.ref: that step runs
-# after npm/Homebrew/MCP/Maven/Docker have already published irreversibly, and
-# npm publish is not idempotent, so a throw there is unrecoverable by rerun.
+@test "release.yml accepts a workflow_dispatch carrying a tag input (#4157)" {
+  wiring_requires_yq
+  run yq -r '.on.workflow_dispatch.inputs.tag.required' ".github/workflows/release.yml"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+}
+
+@test "prepare-release dispatches release.yml on the tag, not a branch (#4157)" {
+  wiring_requires_yq
+  # Pull the one step's run script out of the parsed YAML, so comments elsewhere
+  # in the file cannot satisfy these assertions.
+  local script
+  script="$(yq -r '.jobs.prepare.steps[] | select(.name == "Start the release") | .run' \
+    ".github/workflows/prepare-release.yml")"
+  [ -n "$script" ]
+  [ "$script" != "null" ]
+
+  # Strip comment lines before matching, so the command has to really be there.
+  local code
+  code="$(printf '%s\n' "$script" | grep -v '^[[:space:]]*#')"
+  [[ "$code" == *"gh workflow run release.yml"* ]]
+  [[ "$code" == *'--ref "$TAG"'* ]]
+  [[ "$code" != *"--ref main"* ]]
+}
+
+# action-gh-release throws "GitHub Releases requires a tag" when github.ref is not
+# a tag ref, and that step runs after npm/Homebrew/MCP/Maven/Docker have already
+# published irreversibly. The tag must be explicit, never inferred from the ref.
 @test "release.yml passes an explicit tag_name to action-gh-release (#4157)" {
-  grep -Fq 'tag_name: ${{ needs.validate-release-tag.outputs.tag }}' ".github/workflows/release.yml"
+  wiring_requires_yq
+  run yq -r '.jobs."verify-and-release".steps[]
+    | select(.uses != null and (.uses | test("^softprops/action-gh-release")))
+    | .with.tag_name' ".github/workflows/release.yml"
+  [ "$status" -eq 0 ]
+  [ "$output" = '${{ needs.validate-release-tag.outputs.tag }}' ]
 }
 
 # release.yml publishes to six targets in one job and npm publish is not
@@ -165,18 +203,40 @@
 # GitHub Release are intentionally unguarded: update-brew-formula.sh already
 # no-ops on an unchanged formula, and action-gh-release updates in place.
 @test "release.yml guards every non-idempotent publish (#4157)" {
-  local workflow=".github/workflows/release.yml"
-  grep -Fq 'already-published.sh npm "$VERSION"' "$workflow"
-  grep -Fq 'already-published.sh mcp "$VERSION"' "$workflow"
-  grep -Fq 'already-published.sh maven "$VERSION"' "$workflow"
+  wiring_requires_yq
+  local target
+  for target in npm mcp maven; do
+    local script
+    script="$(yq -r ".jobs.\"verify-and-release\".steps[] | select(.run != null) | .run" \
+      ".github/workflows/release.yml" \
+      | grep -v '^[[:space:]]*#' \
+      | grep -F "already-published.sh $target \"\$VERSION\"")"
+    [ -n "$script" ]
+  done
 }
 
 # The guard fails closed, but that only reaches the job if its exit status can
-# propagate. Under set -e a failing command substitution inside an `if`
-# condition does NOT abort, so the inline form would silently downgrade an
+# propagate. Under set -e a failing command substitution inside an `if` condition
+# does NOT abort, so the inline form would silently downgrade an
 # unreachable-registry error into "not published" and publish anyway.
 @test "release.yml assigns the guard result before testing it (#4157)" {
-  local workflow=".github/workflows/release.yml"
-  grep -Fq 'state=$(scripts/release/already-published.sh' "$workflow"
-  ! grep -Fq 'if [ "$(scripts/release/already-published.sh' "$workflow"
+  wiring_requires_yq
+  local runs
+  runs="$(yq -r '.jobs."verify-and-release".steps[] | select(.run != null) | .run' \
+    ".github/workflows/release.yml" | grep -v '^[[:space:]]*#')"
+  [[ "$runs" == *'state=$(scripts/release/already-published.sh'* ]]
+  [[ "$runs" != *'if [ "$(scripts/release/already-published.sh'* ]]
+}
+
+# A dispatch that merely names the tag is not enough: the Actions UI ref picker
+# defaults to a branch, and docker/metadata-action reads github.ref, so a run
+# dispatched from main ships an image with no version tag while reporting green.
+@test "release.yml requires the dispatch to run on the named tag (#4157)" {
+  wiring_requires_yq
+  local script
+  script="$(yq -r '.jobs."validate-release-tag".steps[]
+    | select(.id == "validate") | .run' ".github/workflows/release.yml" \
+    | grep -v '^[[:space:]]*#')"
+  [[ "$script" == *'REF_TYPE'* ]]
+  [[ "$script" == *'REF_NAME'* ]]
 }


### PR DESCRIPTION
## Why

Every npm release has been published by hand. The pipeline that was supposed to do it has never run.

`prepare-release` pushes the release tag with `AUTO_MOBILE_PR_TOKEN` and logs success — the v0.0.44 run shows `Successfully created and pushed tag: v0.0.44` at 02:12:03Z on 2026-07-11. But `release.yml` triggers on `create:`, and it produced **zero** runs for v0.0.40, v0.0.42 and v0.0.44. `gh api .../workflows/release.yml/runs` returns 192 runs in that window, none with a version-like head ref. So the `npm publish` step has never executed — npm confirms it, showing `dist.attestations: NONE` and publisher `kaeawc`, i.e. a local `npm publish`.

A second, independent trap fails the same silent way. #3560 flipped the tag convention to **no leading `v`**, and `validate-release-tag` gates on `^[0-9]+\.[0-9]+\.[0-9]+`. A `v`-prefixed tag sets `is_release_tag=false`, so every publish job is skipped and the run still reports **green**.

Two failure modes that both fail green is why this looked healthy for ~26 versions.

## What changed

Stop depending on the tag event to start a release.

**`prepare-release.yml`** — after pushing the tag, dispatch the release explicitly with `gh workflow run release.yml --ref main --field tag="$TAG"`. Uses the PAT; the default `GITHUB_TOKEN` cannot dispatch a workflow run.

**`release.yml`**
- Adds `workflow_dispatch` with a required `tag` input. The `create:` trigger stays as a fallback.
- `validate-release-tag` reads `inputs.tag || github.event.ref`, and exports the tag as a job output.
- The checkout `ref:` and version extraction read that output — `github.event.ref` is null on a dispatch.
- A malformed tag on the dispatch path now `exit 1`s instead of skipping. An explicit dispatch names the tag it wants, so a format miss is a caller error; the silent green skip is what hid this.

## npm auth needs no code change

`release.yml` is already correctly wired for Trusted Publishing: `id-token: write`, `npm install -g npm@11.5.1`, `npm publish --provenance --access public`.

Deliberately **no** `NODE_AUTH_TOKEN` and **no** `registry-url:` on `setup-node` — either writes an `.npmrc` auth line that can break the OIDC exchange.

## Follow-ups, not in this PR

- **One-time manual step, still required.** npmjs.com → `@kaeawc/auto-mobile` → Settings → Trusted Publisher → GitHub Actions, repo `kaeawc/auto-mobile`, workflow `release.yml`, environment blank. Until saved, publish fails `ENEEDAUTH`.
- **`npm publish` is not idempotent.** A fresh version is fine, but re-running a tag whose version is already on npm hard-fails. Same for the Maven GAV. Worth skip-if-published guards before trusting re-runs.
- `release.yml` is one monolithic job — a flaky Sonatype/Docker step fails the whole release even after npm succeeds.

## Testing

- `scripts/all_fast_validate_checks.sh` — 17/17 pass, including `yaml` and `workflow-assertion-triggers`.
- Regex behavior confirmed locally: `v0.0.44` → false, `0.0.44` → true.
- Separately, the 11 stale `v`-prefixed tags were deleted (9 exact duplicates of their bare twins; `v0.0.14`/`v0.0.15` pointed at orphaned prep commits never on main). 41 bare tags remain and all 36 GitHub Releases still resolve. The next release must be dispatched as bare `0.0.45`.

First run should be supervised — it will be the first time these publish steps have ever executed.
