### PR TITLE
fix(installer): reap timed-out runtime probe tree

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3431,6 +3431,18 @@ finish_ios_runtime_probe() {
             while kill -0 "${IOS_RUNTIME_PROBE_PID}" 2>/dev/null; do
                 if ((reap_waited >= 10)); then
                     terminate_process_tree_for_reaping "${IOS_RUNTIME_PROBE_PID}"
+                    # The resumed wrapper gets a bounded chance to reap its
+                    # killed children. Do not join it unboundedly: a wrapper
+                    # can resume from `wait` and continue into another stall.
+                    local fallback_waited=0
+                    while kill -0 "${IOS_RUNTIME_PROBE_PID}" 2>/dev/null; do
+                        if ((fallback_waited >= 10)); then
+                            terminate_process_tree "${IOS_RUNTIME_PROBE_PID}"
+                            break
+                        fi
+                        sleep 0.1
+                        fallback_waited=$((fallback_waited + 1))
+                    done
                     break
                 fi
                 sleep 0.1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -155,6 +155,39 @@ request_process_tree_shutdown() {
     done
 }
 
+# Force-stop a tree from its leaves while resuming each parent. A parent that
+# was blocked in `wait` gets to reap its killed child before it exits. This is
+# intentionally distinct from `terminate_process_tree`, whose cancellation
+# callers must stop every process immediately.
+terminate_process_tree_for_reaping() {
+    local pid="$1"
+    kill -0 "${pid}" 2>/dev/null || return 0
+
+    kill -STOP "${pid}" 2>/dev/null || true
+
+    local children=()
+    local child
+    local has_children=false
+    if command_exists pgrep; then
+        while IFS= read -r child; do
+            if [[ -n "${child}" ]]; then
+                children+=("${child}")
+                has_children=true
+            fi
+        done < <(pgrep -P "${pid}" . 2>/dev/null || true)
+    fi
+
+    if [[ "${has_children}" == "false" ]]; then
+        kill -KILL "${pid}" 2>/dev/null || true
+        return 0
+    fi
+
+    for child in "${children[@]:-}"; do
+        terminate_process_tree_for_reaping "${child}"
+    done
+    kill -CONT "${pid}" 2>/dev/null || true
+}
+
 # Reap installer background work and remove its temporary files. The runtime
 # probe and post-Bun setup are always awaited during a normal install; this is
 # only the cancellation/error path that prevents an orphaned child process.
@@ -3397,7 +3430,7 @@ finish_ios_runtime_probe() {
             local reap_waited=0
             while kill -0 "${IOS_RUNTIME_PROBE_PID}" 2>/dev/null; do
                 if ((reap_waited >= 10)); then
-                    terminate_process_tree "${IOS_RUNTIME_PROBE_PID}"
+                    terminate_process_tree_for_reaping "${IOS_RUNTIME_PROBE_PID}"
                     break
                 fi
                 sleep 0.1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3361,7 +3361,7 @@ finish_ios_runtime_probe() {
     local probe_status=0 waited=0
     while kill -0 "${IOS_RUNTIME_PROBE_PID}" 2>/dev/null; do
         if ((waited >= IOS_RUNTIME_PROBE_TIMEOUT_SECONDS)); then
-            kill "${IOS_RUNTIME_PROBE_PID}" 2>/dev/null || true
+            terminate_process_tree "${IOS_RUNTIME_PROBE_PID}"
             wait "${IOS_RUNTIME_PROBE_PID}" 2>/dev/null || true
             IOS_RUNTIME_PROBE_PID=""
             rm -f "${IOS_RUNTIME_PROBE_FILE}"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -126,6 +126,35 @@ terminate_process_tree() {
     kill -KILL "${pid}" 2>/dev/null || true
 }
 
+# Ask leaf processes in a tree to stop without killing their parents. A wrapper
+# blocked in `wait` can then reap the child and exit normally; callers retain a
+# bounded hard-kill fallback for helpers that ignore SIGTERM.
+request_process_tree_shutdown() {
+    local pid="$1"
+    kill -0 "${pid}" 2>/dev/null || return 0
+
+    local children=()
+    local child
+    local has_children=false
+    if command_exists pgrep; then
+        while IFS= read -r child; do
+            if [[ -n "${child}" ]]; then
+                children+=("${child}")
+                has_children=true
+            fi
+        done < <(pgrep -P "${pid}" . 2>/dev/null || true)
+    fi
+
+    if [[ "${has_children}" == "false" ]]; then
+        kill -TERM "${pid}" 2>/dev/null || true
+        return 0
+    fi
+
+    for child in "${children[@]:-}"; do
+        request_process_tree_shutdown "${child}"
+    done
+}
+
 # Reap installer background work and remove its temporary files. The runtime
 # probe and post-Bun setup are always awaited during a normal install; this is
 # only the cancellation/error path that prevents an orphaned child process.
@@ -3361,7 +3390,19 @@ finish_ios_runtime_probe() {
     local probe_status=0 waited=0
     while kill -0 "${IOS_RUNTIME_PROBE_PID}" 2>/dev/null; do
         if ((waited >= IOS_RUNTIME_PROBE_TIMEOUT_SECONDS)); then
-            terminate_process_tree "${IOS_RUNTIME_PROBE_PID}"
+            # Stop the helper first so an xcrun wrapper blocked in `wait` can
+            # reap it. Fall back to the hard tree kill after a one-second
+            # grace period so a stubborn helper cannot reintroduce the hang.
+            request_process_tree_shutdown "${IOS_RUNTIME_PROBE_PID}"
+            local reap_waited=0
+            while kill -0 "${IOS_RUNTIME_PROBE_PID}" 2>/dev/null; do
+                if ((reap_waited >= 10)); then
+                    terminate_process_tree "${IOS_RUNTIME_PROBE_PID}"
+                    break
+                fi
+                sleep 0.1
+                reap_waited=$((reap_waited + 1))
+            done
             wait "${IOS_RUNTIME_PROBE_PID}" 2>/dev/null || true
             IOS_RUNTIME_PROBE_PID=""
             rm -f "${IOS_RUNTIME_PROBE_FILE}"

--- a/test/bats/install-background-work.bats
+++ b/test/bats/install-background-work.bats
@@ -76,7 +76,7 @@ STUB
 @test "a SIGTERM-ignoring runtime helper is reaped after the hard fallback" {
   cat > "${STUB_BIN}/xcrun" <<'STUB'
 #!/usr/bin/env bash
-bash -c 'trap "" TERM; sleep 300' &
+bash -c 'trap "" TERM; while :; do :; done' &
 wait
 STUB
   chmod +x "${STUB_BIN}/xcrun"
@@ -86,25 +86,41 @@ STUB
 
   start_ios_runtime_probe
   local worker_pid="${IOS_RUNTIME_PROBE_PID}"
-  local helper_pid child_pid
+  local helper_pid
   for _ in {1..10}; do
-    helper_pid=$("${PGREP}" -P "${worker_pid}" bash 2>/dev/null || true)
+    helper_pid=$("${PGREP}" -P "${worker_pid}" . 2>/dev/null || true)
     [[ -n "${helper_pid}" ]] && break
     sleep 0.1
   done
   [ -n "${helper_pid}" ]
-  for _ in {1..10}; do
-    child_pid=$("${PGREP}" -P "${helper_pid}" sleep 2>/dev/null || true)
-    [[ -n "${child_pid}" ]] && break
-    sleep 0.1
-  done
-  [ -n "${child_pid}" ]
-
   finish_ios_runtime_probe >/dev/null 2>&1
 
   assert_process_is_reaped "${worker_pid}"
   assert_process_is_reaped "${helper_pid}"
-  assert_process_is_reaped "${child_pid}"
+}
+
+@test "the hard runtime-probe fallback remains bounded after a wrapper resumes into another stall" {
+  cat > "${STUB_BIN}/xcrun" <<'STUB'
+#!/usr/bin/env bash
+bash -c 'trap "" TERM; while :; do :; done' &
+wait || true
+while :; do :; done
+STUB
+  chmod +x "${STUB_BIN}/xcrun"
+
+  detect_os() { printf 'macos\n'; }
+  IOS_RUNTIME_PROBE_TIMEOUT_SECONDS=1
+
+  start_ios_runtime_probe
+  local worker_pid="${IOS_RUNTIME_PROBE_PID}"
+  local started ended elapsed
+  started=$(date +%s)
+  finish_ios_runtime_probe >/dev/null 2>&1
+  ended=$(date +%s)
+  elapsed=$((ended - started))
+
+  [ "${elapsed}" -lt 30 ]
+  assert_process_is_reaped "${worker_pid}"
 }
 
 @test "iOS runtime probe runs in the background and reports its completed result" {

--- a/test/bats/install-background-work.bats
+++ b/test/bats/install-background-work.bats
@@ -73,6 +73,40 @@ STUB
   assert_process_is_reaped "${child_pid}"
 }
 
+@test "a SIGTERM-ignoring runtime helper is reaped after the hard fallback" {
+  cat > "${STUB_BIN}/xcrun" <<'STUB'
+#!/usr/bin/env bash
+bash -c 'trap "" TERM; sleep 300' &
+wait
+STUB
+  chmod +x "${STUB_BIN}/xcrun"
+
+  detect_os() { printf 'macos\n'; }
+  IOS_RUNTIME_PROBE_TIMEOUT_SECONDS=1
+
+  start_ios_runtime_probe
+  local worker_pid="${IOS_RUNTIME_PROBE_PID}"
+  local helper_pid child_pid
+  for _ in {1..10}; do
+    helper_pid=$("${PGREP}" -P "${worker_pid}" bash 2>/dev/null || true)
+    [[ -n "${helper_pid}" ]] && break
+    sleep 0.1
+  done
+  [ -n "${helper_pid}" ]
+  for _ in {1..10}; do
+    child_pid=$("${PGREP}" -P "${helper_pid}" sleep 2>/dev/null || true)
+    [[ -n "${child_pid}" ]] && break
+    sleep 0.1
+  done
+  [ -n "${child_pid}" ]
+
+  finish_ios_runtime_probe >/dev/null 2>&1
+
+  assert_process_is_reaped "${worker_pid}"
+  assert_process_is_reaped "${helper_pid}"
+  assert_process_is_reaped "${child_pid}"
+}
+
 @test "iOS runtime probe runs in the background and reports its completed result" {
   cat > "${STUB_BIN}/xcrun" <<'STUB'
 #!/usr/bin/env bash

--- a/test/bats/install-background-work.bats
+++ b/test/bats/install-background-work.bats
@@ -21,6 +21,12 @@ assert_process_is_not_active() {
   [[ -z "${state}" || "${state}" == *Z* ]]
 }
 
+assert_process_is_reaped() {
+  local state
+  state=$(ps -o stat= -p "$1" 2>/dev/null || true)
+  [[ -z "${state}" ]]
+}
+
 teardown() {
   export PATH="${ORIG_PATH}"
   rm -rf "${TEST_DIR}"
@@ -32,8 +38,8 @@ teardown() {
   # for 6 hours until the runner cancelled it. A stall must be abandoned.
   cat > "${STUB_BIN}/xcrun" <<'STUB'
 #!/usr/bin/env bash
-# Keep a child alive under the xcrun wrapper. The timeout must remove both
-# processes, not merely the wrapper that launched the stalled helper.
+  # Keep a child alive under the xcrun wrapper. The timeout must let the
+  # wrapper reap the helper rather than leaving it as a zombie.
 sleep 300 &
 wait
 STUB
@@ -63,8 +69,8 @@ STUB
   [ "$status" -eq 0 ]
   [ "$elapsed" -lt 30 ]
   [ -z "${IOS_RUNTIME_PROBE_PID}" ]
-  assert_process_is_not_active "${worker_pid}"
-  assert_process_is_not_active "${child_pid}"
+  assert_process_is_reaped "${worker_pid}"
+  assert_process_is_reaped "${child_pid}"
 }
 
 @test "iOS runtime probe runs in the background and reports its completed result" {

--- a/test/bats/install-background-work.bats
+++ b/test/bats/install-background-work.bats
@@ -32,9 +32,10 @@ teardown() {
   # for 6 hours until the runner cancelled it. A stall must be abandoned.
   cat > "${STUB_BIN}/xcrun" <<'STUB'
 #!/usr/bin/env bash
-# exec so the stub IS the stalled process: killing the probe PID must actually
-# stop it, not orphan a child that keeps the inherited fd open.
-exec sleep 300
+# Keep a child alive under the xcrun wrapper. The timeout must remove both
+# processes, not merely the wrapper that launched the stalled helper.
+sleep 300 &
+wait
 STUB
   chmod +x "${STUB_BIN}/xcrun"
 
@@ -42,7 +43,15 @@ STUB
   IOS_RUNTIME_PROBE_TIMEOUT_SECONDS=1
 
   start_ios_runtime_probe
-  [ -n "${IOS_RUNTIME_PROBE_PID}" ]
+  local worker_pid="${IOS_RUNTIME_PROBE_PID}"
+  [ -n "${worker_pid}" ]
+  local child_pid
+  for _ in {1..10}; do
+    child_pid=$("${PGREP}" -P "${worker_pid}" sleep 2>/dev/null || true)
+    [[ -n "${child_pid}" ]] && break
+    sleep 0.1
+  done
+  [ -n "${child_pid}" ]
 
   local started ended elapsed status=0
   started=$(date +%s)
@@ -54,6 +63,8 @@ STUB
   [ "$status" -eq 0 ]
   [ "$elapsed" -lt 30 ]
   [ -z "${IOS_RUNTIME_PROBE_PID}" ]
+  assert_process_is_not_active "${worker_pid}"
+  assert_process_is_not_active "${child_pid}"
 }
 
 @test "iOS runtime probe runs in the background and reports its completed result" {


### PR DESCRIPTION
## Summary

- terminate the complete iOS runtime probe process tree when its bounded join times out
- cover an `xcrun` wrapper that leaves a stalled child process running

## Validation

- `bats test/bats/install-background-work.bats`
- `shellcheck scripts/install.sh`
- `scripts/shellcheck/validate_shell_sete.sh`
