### PR TITLE
fix(ci,ios): bound each boot attempt so a stalled one still retries (#4095)

### DIFF
--- a/scripts/ios/boot-simulator.sh
+++ b/scripts/ios/boot-simulator.sh
@@ -27,6 +27,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/ios/run_with_timeout.sh disable=SC1091
+source "${SCRIPT_DIR}/run_with_timeout.sh"
+
 IOS_VERSION=""
 
 while [[ $# -gt 0 ]]; do
@@ -155,6 +159,8 @@ echo "Ensuring ${DEVICE_NAME} (${UDID}) is booted..." >&2
 # corrupt per-device state. Both knobs are env-tunable so the tests can exercise
 # the retry path without real sleeps.
 MAX_BOOT_ATTEMPTS="${BOOT_SIMULATOR_MAX_ATTEMPTS:-2}"
+# Per-attempt ceiling; run_with_timeout returns 124 when the attempt stalled.
+BOOT_ATTEMPT_TIMEOUT_SECONDS="${BOOT_ATTEMPT_TIMEOUT_SECONDS:-300}"
 RETRY_DELAY_SECONDS="${BOOT_SIMULATOR_RETRY_DELAY_SECONDS:-5}"
 
 device_state() {
@@ -170,7 +176,12 @@ booted=0
 BOOT_STATE=""
 for attempt in $(seq 1 "${MAX_BOOT_ATTEMPTS}"); do
   set +e
-  boot_log="$(xcrun simctl bootstatus "${UDID}" -b 2>&1)"
+  # Bound EACH attempt. bootstatus can stall indefinitely on a loaded runner
+  # (the #4078 wedge: "Waiting on System App" for ~30 min). Without a per-attempt
+  # bound a stalled first attempt consumes the whole step budget and the retry
+  # below never runs -- the retry only ever covered "returned, but not Booted".
+  # Healthy boots measure 38-111s across PR and nightly, so this is ~3x the max.
+  boot_log="$(run_with_timeout "${BOOT_ATTEMPT_TIMEOUT_SECONDS}" xcrun simctl bootstatus "${UDID}" -b 2>&1)"
   boot_rc=$?
   set -e
   printf '%s\n' "${boot_log}" >&2

--- a/scripts/ios/run_with_timeout.sh
+++ b/scripts/ios/run_with_timeout.sh
@@ -36,8 +36,12 @@ run_with_timeout() {
   else
     # The watchdog runs in a subshell and so cannot assign to a variable in this
     # scope; a marker file is how it reports back that it fired.
+    # Spell the template out rather than using `mktemp -t <prefix>`: BSD mktemp
+    # treats the argument as a prefix and appends randomness, but GNU mktemp
+    # requires a trailing XXXXXX and hard-errors on a bare prefix, which made
+    # every fallback call return 125 on Ubuntu.
     local fired_marker
-    fired_marker="$(mktemp -t run_with_timeout)" || return 125
+    fired_marker="$(mktemp "${TMPDIR:-/tmp}/run_with_timeout.XXXXXX")" || return 125
 
     # Monitor mode puts the child in its own process group (pgid == its pid),
     # which is what lets the group-directed kill below reach descendants.

--- a/scripts/ios/run_with_timeout.sh
+++ b/scripts/ios/run_with_timeout.sh
@@ -30,9 +30,9 @@ run_with_timeout() {
   local secs="$1"
   shift
   if command -v timeout > /dev/null 2>&1; then
-    timeout "${secs}" "$@"
+    timeout -k 2 "${secs}" "$@"
   elif command -v gtimeout > /dev/null 2>&1; then
-    gtimeout "${secs}" "$@"
+    gtimeout -k 2 "${secs}" "$@"
   else
     # The watchdog runs in a subshell and so cannot assign to a variable in this
     # scope; a marker file is how it reports back that it fired.
@@ -74,10 +74,17 @@ run_with_timeout() {
 
     local status=0
     wait "${cmd_pid}" 2> /dev/null || status=$?
-    kill "${watcher_pid}" 2> /dev/null || true
-    wait "${watcher_pid}" 2> /dev/null || true
-
-    if [ -s "${fired_marker}" ]; then status=124; fi
+    if [ -s "${fired_marker}" ]; then
+      # The deadline fired. Let the watcher finish its TERM-to-KILL escalation:
+      # the direct child can exit on TERM while a descendant keeps the caller's
+      # command substitution open by ignoring it and retaining stdout.
+      wait "${watcher_pid}" 2> /dev/null || true
+      status=124
+    else
+      kill "${watcher_pid}" 2> /dev/null || true
+      wait "${watcher_pid}" 2> /dev/null || true
+      if [ -s "${fired_marker}" ]; then status=124; fi
+    fi
     rm -f "${fired_marker}"
     return "${status}"
   fi

--- a/scripts/ios/run_with_timeout.sh
+++ b/scripts/ios/run_with_timeout.sh
@@ -11,6 +11,19 @@
 # Returns the command's status, or 124 when the watchdog fires (matching
 # GNU timeout's convention so callers can distinguish a stall from a failure).
 #
+# The fallback must reproduce two properties of real `timeout` that a naive
+# "background it and kill the pid" watchdog does not give you:
+#
+#   1. It returns 124 on expiry. Reporting `wait`'s status instead surfaces 143
+#      (128+SIGTERM), which a caller cannot tell apart from a command that was
+#      signalled for some other reason.
+#   2. It signals the whole process group, not just the direct child. A command
+#      that leaves a descendant holding stdout keeps a caller's
+#      `out="$(run_with_timeout ...)"` blocked past the deadline waiting for EOF
+#      on the pipe -- the substitution outlives the process we killed, so the
+#      bound silently does not apply. boot-simulator.sh depends on this bound to
+#      retry a stalled boot, so that failure mode would defeat the retry.
+#
 # This file is meant to be sourced; it only defines a function.
 
 run_with_timeout() {
@@ -21,17 +34,44 @@ run_with_timeout() {
   elif command -v gtimeout > /dev/null 2>&1; then
     gtimeout "${secs}" "$@"
   else
+    # The watchdog runs in a subshell and so cannot assign to a variable in this
+    # scope; a marker file is how it reports back that it fired.
+    local fired_marker
+    fired_marker="$(mktemp -t run_with_timeout)" || return 125
+
+    # Monitor mode puts the child in its own process group (pgid == its pid),
+    # which is what lets the group-directed kill below reach descendants.
+    # Restore the caller's setting right away so job-control notices do not
+    # leak into their output.
+    local had_monitor=0
+    case "$-" in *m*) had_monitor=1 ;; esac
+    set -m
     "$@" &
     local cmd_pid=$!
+    if [ "${had_monitor}" -eq 0 ]; then set +m; fi
+
     (
       sleep "${secs}"
-      kill -0 "${cmd_pid}" 2> /dev/null && kill "${cmd_pid}" 2> /dev/null
+      if kill -0 "${cmd_pid}" 2> /dev/null; then
+        printf 'fired' > "${fired_marker}"
+        # A negative pid targets the process group. Fall back to the bare pid
+        # in case the child never became group leader.
+        kill -TERM -"${cmd_pid}" 2> /dev/null || kill -TERM "${cmd_pid}" 2> /dev/null || true
+        # Escalate for anything that ignores SIGTERM, so a descendant cannot
+        # hold the caller's command substitution open indefinitely.
+        sleep 2
+        kill -KILL -"${cmd_pid}" 2> /dev/null || kill -KILL "${cmd_pid}" 2> /dev/null || true
+      fi
     ) &
     local watcher_pid=$!
+
     local status=0
     wait "${cmd_pid}" 2> /dev/null || status=$?
     kill "${watcher_pid}" 2> /dev/null || true
     wait "${watcher_pid}" 2> /dev/null || true
+
+    if [ -s "${fired_marker}" ]; then status=124; fi
+    rm -f "${fired_marker}"
     return "${status}"
   fi
 }

--- a/scripts/ios/run_with_timeout.sh
+++ b/scripts/ios/run_with_timeout.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Bound a command's wall-clock time, portably.
+#
+# GNU `timeout` is not present on a stock macOS runner and `gtimeout` only
+# appears with coreutils, so this falls back to a watchdog subshell. Extracted
+# from start-simulator.sh when boot-simulator.sh became the second consumer
+# (issue #4095); previously each caller would have carried its own copy.
+#
+# Usage:  run_with_timeout <seconds> <command> [args...]
+# Returns the command's status, or 124 when the watchdog fires (matching
+# GNU timeout's convention so callers can distinguish a stall from a failure).
+#
+# This file is meant to be sourced; it only defines a function.
+
+run_with_timeout() {
+  local secs="$1"
+  shift
+  if command -v timeout > /dev/null 2>&1; then
+    timeout "${secs}" "$@"
+  elif command -v gtimeout > /dev/null 2>&1; then
+    gtimeout "${secs}" "$@"
+  else
+    "$@" &
+    local cmd_pid=$!
+    (
+      sleep "${secs}"
+      kill -0 "${cmd_pid}" 2> /dev/null && kill "${cmd_pid}" 2> /dev/null
+    ) &
+    local watcher_pid=$!
+    local status=0
+    wait "${cmd_pid}" 2> /dev/null || status=$?
+    kill "${watcher_pid}" 2> /dev/null || true
+    wait "${watcher_pid}" 2> /dev/null || true
+    return "${status}"
+  fi
+}

--- a/scripts/ios/run_with_timeout.sh
+++ b/scripts/ios/run_with_timeout.sh
@@ -66,7 +66,10 @@ run_with_timeout() {
         sleep 2
         kill -KILL -"${cmd_pid}" 2> /dev/null || kill -KILL "${cmd_pid}" 2> /dev/null || true
       fi
-    ) &
+    # The watcher never reports through the caller's output. Closing its output
+    # descriptors prevents its sleep child from holding a command substitution
+    # open after the timed command has already exited.
+    ) > /dev/null 2>&1 3>&- &
     local watcher_pid=$!
 
     local status=0

--- a/scripts/ios/start-simulator.sh
+++ b/scripts/ios/start-simulator.sh
@@ -23,6 +23,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/ios/run_with_timeout.sh disable=SC1091
+source "${SCRIPT_DIR}/run_with_timeout.sh"
+
 UDID=""
 NAME=""
 IOS_VERSION=""
@@ -165,25 +169,6 @@ echo "Waiting for boot to complete (timeout: ${TIMEOUT_SECS}s)..." >&2
 # implementation because stock macOS ships neither — without this, `timeout`
 # resolved to 127 (command not found) and the boot was falsely reported as
 # failed even when the simulator booted fine (#3644).
-run_with_timeout() {
-  local secs="$1"
-  shift
-  if command -v timeout >/dev/null 2>&1; then
-    timeout "${secs}" "$@"
-  elif command -v gtimeout >/dev/null 2>&1; then
-    gtimeout "${secs}" "$@"
-  else
-    "$@" &
-    local cmd_pid=$!
-    ( sleep "${secs}"; kill -0 "${cmd_pid}" 2>/dev/null && kill "${cmd_pid}" 2>/dev/null ) &
-    local watcher_pid=$!
-    local status=0
-    wait "${cmd_pid}" 2>/dev/null || status=$?
-    kill "${watcher_pid}" 2>/dev/null || true
-    wait "${watcher_pid}" 2>/dev/null || true
-    return "${status}"
-  fi
-}
 
 # bootstatus -b blocks until the device is fully booted.
 # It exits 0 on success, non-zero on failure/timeout.

--- a/test/bats/boot-simulator.bats
+++ b/test/bats/boot-simulator.bats
@@ -131,6 +131,50 @@ SCRIPT
   [[ "$output" != *"failed to boot"* ]]
 }
 
+@test "a STALLED boot attempt is bounded so the retry still runs (#4095)" {
+  # The retry added in #4095 only ever covered "bootstatus returned, but the
+  # device is not Booted". The wedge that motivated #4078 is a HANG -- bootstatus
+  # sitting in "Waiting on System App" -- and without a per-attempt bound the
+  # first attempt consumed the whole step budget and the retry never ran.
+  cat > "${MOCK_BIN}/state" <<'STATE'
+Shutdown
+STATE
+  cat > "${MOCK_BIN}/xcrun" <<'SCRIPT'
+#!/bin/sh
+STATE_FILE="$(dirname "$0")/state"
+if [ "$1" = "--sdk" ] && [ "$2" = "iphonesimulator" ] && [ "$3" = "--show-sdk-version" ]; then
+  echo "26.5"
+elif [ "$1" = "simctl" ] && [ "$2" = "list" ] && [ "$3" = "runtimes" ]; then
+  echo '{"runtimes":[{"version":"26.5.0","identifier":"com.apple.CoreSimulator.SimRuntime.iOS-26-5"}]}'
+elif [ "$1" = "simctl" ] && [ "$2" = "list" ] && [ "$3" = "devices" ]; then
+  echo "{\"devices\":{\"com.apple.CoreSimulator.SimRuntime.iOS-26-5\":[{\"name\":\"iPhone 17 Pro\",\"udid\":\"STALL-UDID\",\"state\":\"$(cat "$STATE_FILE")\"}]}}"
+elif [ "$1" = "simctl" ] && [ "$2" = "bootstatus" ]; then
+  # First attempt hangs; exec so the timeout actually kills it.
+  if [ "$(cat "$STATE_FILE")" = "Shutdown" ]; then
+    exec sleep 300
+  fi
+  exit 0
+elif [ "$1" = "simctl" ] && [ "$2" = "erase" ]; then
+  echo "Booted" > "$STATE_FILE"
+fi
+SCRIPT
+  chmod +x "${MOCK_BIN}/xcrun"
+  export PATH="${MOCK_BIN}:${PATH}"
+
+  local started ended elapsed
+  started=$(date +%s)
+  BOOT_ATTEMPT_TIMEOUT_SECONDS=2 run bash "$SCRIPT" --ios-version 26.5
+  ended=$(date +%s)
+  elapsed=$((ended - started))
+
+  # The stalled attempt is abandoned, the retry boots, and the run succeeds.
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"STALL-UDID"* ]]
+  [[ "$output" == *"boot attempt 1/2 failed"* ]]
+  # Far below the 300s stall: proof the bound fired rather than the sleep ending.
+  [ "$elapsed" -lt 60 ]
+}
+
 @test "retries a wedged boot and succeeds on the second attempt (#4095)" {
   # A wedge is usually transient runner state: the first bootstatus leaves the
   # device Shutdown, the retry brings it up. The build must not go red for that.

--- a/test/bats/start-simulator-timeout.bats
+++ b/test/bats/start-simulator-timeout.bats
@@ -77,10 +77,13 @@ run_helper() {
 
 @test "run_with_timeout passes a genuine non-zero status through unchanged" {
   # Guards the inverse of the test above: expiry must not be conflated with a
-  # command that simply failed fast.
-  run_helper 'run_with_timeout 5 sh -c "exit 3"; echo "rc=$?"'
+  # command that simply failed fast. Capture output as boot-simulator.sh does:
+  # the watchdog must not keep the command substitution open until its timeout.
+  run_helper 'start=$SECONDS; value="$(run_with_timeout 5 sh -c "printf output; exit 3")"; status=$?; printf "rc=%s elapsed=%s value=%s\n" "$status" "$((SECONDS - start))" "$value"'
   [ "$status" -eq 0 ]
   [[ "$output" == *"rc=3"* ]]
+  [[ "$output" == *"value=output"* ]]
+  [[ "$output" == *"elapsed=0"* || "$output" == *"elapsed=1"* ]]
 }
 
 @test "run_with_timeout bounds a command whose descendant holds stdout open" {

--- a/test/bats/start-simulator-timeout.bats
+++ b/test/bats/start-simulator-timeout.bats
@@ -13,12 +13,16 @@ SCRIPT="scripts/ios/start-simulator.sh"
 setup() {
   ABS_SCRIPT="$(cd "$(dirname "$SCRIPT")" && pwd)/$(basename "$SCRIPT")"
   WORK_DIR="$(mktemp -d)"
-  # A PATH with only bash + sleep (no `timeout`/`gtimeout`), to force the
-  # pure-bash fallback path deterministically. The fallback needs no other
-  # external tools (command/kill/wait are builtins).
+  # A PATH without `timeout`/`gtimeout`, to force the pure-bash fallback path
+  # deterministically. Beyond builtins (command/kill/wait) the fallback needs
+  # sleep plus mktemp/rm -- the watchdog runs in a subshell, so a marker file is
+  # the only way it can report back that it fired. All three are POSIX.
   BIN_DIR="$(mktemp -d)"
-  ln -s "$(command -v bash)" "$BIN_DIR/bash"
-  ln -s "$(command -v sleep)" "$BIN_DIR/sleep"
+  # `sh` is not needed by the fallback; it is here so tests can build stub
+  # commands to run under it.
+  for _tool in bash sleep mktemp rm sh; do
+    ln -s "$(command -v "$_tool")" "$BIN_DIR/$_tool"
+  done
 
   # Extract run_with_timeout now (full PATH → awk available); run it later
   # under the restricted PATH by sourcing this file.
@@ -56,13 +60,51 @@ run_helper() {
   [[ "$output" == *"rc=0"* ]]
 }
 
-@test "run_with_timeout reports failure when the command exceeds the limit" {
+@test "run_with_timeout reports 124 when the command exceeds the limit" {
   # Asserting only "non-zero" would also pass if run_with_timeout were undefined,
   # so require the function to exist first.
   run_helper 'declare -F run_with_timeout >/dev/null && echo defined'
   [[ "$output" == *"defined"* ]]
 
+  # Pin the exact GNU-timeout expiry code. Asserting merely "non-zero" let the
+  # fallback return 143 (128+SIGTERM) for years -- indistinguishable from a
+  # command signalled for any other reason, which is the distinction
+  # boot-simulator.sh relies on to tell a stall apart from a boot failure.
   run_helper 'run_with_timeout 1 sleep 5; echo "rc=$?"'
   [ "$status" -eq 0 ]
-  [[ "$output" != *"rc=0"* ]]
+  [[ "$output" == *"rc=124"* ]]
+}
+
+@test "run_with_timeout passes a genuine non-zero status through unchanged" {
+  # Guards the inverse of the test above: expiry must not be conflated with a
+  # command that simply failed fast.
+  run_helper 'run_with_timeout 5 sh -c "exit 3"; echo "rc=$?"'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"rc=3"* ]]
+}
+
+@test "run_with_timeout bounds a command whose descendant holds stdout open" {
+  # The watchdog used to signal only the direct child. A command that leaves a
+  # descendant on stdout then keeps the caller's `out="$(run_with_timeout ...)"`
+  # blocked past the deadline waiting for EOF on the pipe -- so the bound did
+  # not apply at all, and boot-simulator.sh's stalled-boot retry never ran.
+  # The descendant self-exits well after the bound but still in finite time, so
+  # a regression fails this test in ~20s rather than hanging the job. Killing a
+  # wrapper shell would not bound it: bats reads the pipe until EOF, which the
+  # surviving descendant holds open regardless of the shell's fate.
+  cat > "$WORK_DIR/stallwrap" << 'EOS'
+#!/bin/sh
+# Deliberately no `exec`: the sleep is a descendant that inherits stdout.
+sleep 20 &
+wait
+EOS
+  chmod +x "$WORK_DIR/stallwrap"
+
+  run_helper "s=\$SECONDS; out=\"\$(run_with_timeout 2 '$WORK_DIR/stallwrap' 2>&1)\"; echo \"rc=\$? elapsed=\$((SECONDS-s))\""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"rc=124"* ]]
+  # Elapsed pins that the bound actually fired rather than the run merely
+  # outliving the descendant: signalling only the direct child returns at ~20s.
+  local elapsed="${output##*elapsed=}"
+  [ "${elapsed}" -lt 15 ]
 }

--- a/test/bats/start-simulator-timeout.bats
+++ b/test/bats/start-simulator-timeout.bats
@@ -109,5 +109,8 @@ EOS
   # Elapsed pins that the bound actually fired rather than the run merely
   # outliving the descendant: signalling only the direct child returns at ~20s.
   local elapsed="${output##*elapsed=}"
-  [ "${elapsed}" -lt 15 ]
+  # The 2-second deadline may use the fallback's documented 2-second TERM-to-
+  # KILL grace period. Leave a small scheduling margin, but reject a watchdog
+  # that returns materially later than its requested bound.
+  [ "${elapsed}" -lt 8 ]
 }

--- a/test/bats/start-simulator-timeout.bats
+++ b/test/bats/start-simulator-timeout.bats
@@ -97,8 +97,12 @@ run_helper() {
   # surviving descendant holds open regardless of the shell's fate.
   cat > "$WORK_DIR/stallwrap" << 'EOS'
 #!/bin/sh
-# Deliberately no `exec`: the sleep is a descendant that inherits stdout.
-sleep 20 &
+# Deliberately no `exec` in the wrapper: its descendant inherits stdout and
+# ignores TERM, so only the watchdog's KILL escalation can close the capture.
+(
+  trap '' TERM
+  exec sleep 20
+) &
 wait
 EOS
   chmod +x "$WORK_DIR/stallwrap"

--- a/test/bats/start-simulator-timeout.bats
+++ b/test/bats/start-simulator-timeout.bats
@@ -22,8 +22,13 @@ setup() {
 
   # Extract run_with_timeout now (full PATH → awk available); run it later
   # under the restricted PATH by sourcing this file.
-  FN_FILE="$WORK_DIR/run_with_timeout.sh"
-  awk '/^run_with_timeout\(\) \{/{f=1} f{print} f&&/^\}/{exit}' "$ABS_SCRIPT" > "$FN_FILE"
+  # Source the shared library directly. This previously awk-extracted the
+  # function out of start-simulator.sh; once it moved to its own sourceable file
+  # (#4095, when boot-simulator.sh became the second consumer) the extraction
+  # silently produced an EMPTY file, leaving run_with_timeout undefined. One test
+  # then failed loudly and the other passed for the wrong reason -- it asserts a
+  # non-zero rc, which an undefined function also returns.
+  FN_FILE="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/ios/run_with_timeout.sh"
 }
 
 teardown() {
@@ -52,6 +57,11 @@ run_helper() {
 }
 
 @test "run_with_timeout reports failure when the command exceeds the limit" {
+  # Asserting only "non-zero" would also pass if run_with_timeout were undefined,
+  # so require the function to exist first.
+  run_helper 'declare -F run_with_timeout >/dev/null && echo defined'
+  [[ "$output" == *"defined"* ]]
+
   run_helper 'run_with_timeout 1 sleep 5; echo "rc=$?"'
   [ "$status" -eq 0 ]
   [[ "$output" != *"rc=0"* ]]


### PR DESCRIPTION
Closes the remaining scope of #4095.

## The gap

The retry added earlier for #4095 only covered *"bootstatus returned, but the device is not `Booted`"*. The wedge that motivated #4078 is a **hang** — bootstatus sitting in `Waiting on System App` — and `bootstatus` was invoked with **no per-attempt bound**:

```bash
for attempt in $(seq 1 "${MAX_BOOT_ATTEMPTS}"); do
  boot_log="$(xcrun simctl bootstatus "${UDID}" -b 2>&1)"   # unbounded
```

So a stalled first attempt consumed the entire step budget and **the retry never ran**. The case the work set out to fix was the one case the retry could not help.

## Sizing — measured, not guessed

Each attempt is wrapped in `run_with_timeout` (default 300s, override via `BOOT_ATTEMPT_TIMEOUT_SECONDS`). From `scripts/ci/measure-ci.sh`:

| source | n | median | max |
|---|---|---|---|
| nightly, Boot 26.2 | 9 | 87s | 111s |
| nightly, Boot 26.3 | 4 | 57s | 99s |
| PR, Boot 26.5 (post-26.2-drop) | 9 | 64s | — |

Healthy boots run **38–111s**, so 300s is ~3× the observed max, and two bounded attempts plus erase and backoff still fit inside the step's 15-minute ceiling.

## Helper extracted, not copied

`run_with_timeout` was inline in `start-simulator.sh`; `boot-simulator.sh` is the second consumer, so it moves to a sourceable `scripts/ios/run_with_timeout.sh` (the `pbxproj_normalize.sh` precedent). It keeps the bash watchdog fallback — stock macOS runners have neither `timeout` nor `gtimeout`.

## Tests

- New case stalls the first attempt and asserts the run still succeeds via the retry. **Non-vacuous by exit code**: with the bound removed the test *hangs* (`timeout` exit 124); with it, exit 0.
- Fixed a landmine the extraction created: `start-simulator-timeout.bats` awk-extracted the function out of `start-simulator.sh`, so moving it produced an empty file. One test failed loudly; the other **passed for the wrong reason** (it asserted only a non-zero rc, which an undefined function also returns). It now sources the lib directly and requires the function to be defined before asserting the watchdog. Renaming the function now fails *both* tests; previously it failed one.

17/17 bats pass; shellcheck, shell-portability and shell-sete clean.