### PR TITLE
perf(ci): fan out cache restores, hoist hadolint, overlap deploy-docs setups (#4130)

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1235,15 +1235,23 @@ jobs:
           fetch-depth: 0  # Fetch full history for git-revision-date-localized plugin
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Independent of each other: setup-uv fetches a standalone binary and
+      # never reads the Python toolchain. Both are joined before `uv sync`.
       - name: "Setup Python"
         uses: actions/setup-python@v6
+        background: true
+        id: setup-python
         with:
           python-version: '3.11'
 
       - name: "Install uv"
         uses: astral-sh/setup-uv@v7
+        background: true
+        id: setup-uv
         with:
           enable-cache: true
+
+      - wait: [setup-python, setup-uv]
 
       - name: "Install MkDocs and dependencies"
         working-directory: scripts/github
@@ -1252,17 +1260,26 @@ jobs:
       - name: "Build documentation"
         run: scripts/github/deploy_pages.py build
 
+      # Distinct artifacts landing on distinct filenames, so they overlap. They
+      # must stay AFTER "Build documentation" -- mkdocs regenerates/cleans
+      # site/, which would delete a badge that landed early.
       - name: "Download Kotlin Coverage Badge"
         uses: actions/download-artifact@v7
+        background: true
+        id: dl-kotlin-badge
         with:
           name: kotlin-coverage-badge
           path: site
 
       - name: "Download Swift Coverage Badge"
         uses: actions/download-artifact@v7
+        background: true
+        id: dl-swift-badge
         with:
           name: swift-coverage-badge
           path: site
+
+      - wait: [dl-kotlin-badge, dl-swift-badge]
 
       - name: "Setup Pages"
         uses: actions/configure-pages@v5

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -615,6 +615,19 @@ jobs:
           # contain the base commit and the diff would fail.
           fetch-depth: 0
 
+      # Pulls a Docker image and consumes nothing this job produces, so start
+      # it up front and let the whole job overlap the pull. It has no consumer,
+      # so the barrier sits at the end -- a hadolint failure surfaces there
+      # rather than vanishing.
+      - name: "Run hadolint"
+        uses: hadolint/hadolint-action@v3.1.0
+        background: true
+        id: hadolint
+        with:
+          dockerfile: Dockerfile
+          config: .hadolint.yaml
+          failure-threshold: error
+
       # Pure network/disk and independent of everything below, so background it
       # here and let the JDK download and the npm-package setup (Bun + ripgrep +
       # `bun install` + build, ~60-120s) overlap it. The `wait` barrier re-syncs
@@ -680,12 +693,7 @@ jobs:
         shell: bash
         run: bash scripts/versioning/generate-ios-version.sh --check
 
-      - name: "Run hadolint"
-        uses: hadolint/hadolint-action@v3.1.0
-        with:
-          dockerfile: Dockerfile
-          config: .hadolint.yaml
-          failure-threshold: error
+      - wait: hadolint
 
       - name: "Upload Fast Validation Logs"
         if: failure()
@@ -1030,9 +1038,14 @@ jobs:
         with:
           lfs: false
 
+      # Disjoint cache paths, so the two restores overlap each other. The
+      # barrier must precede "Setup Auto Mobile": that composite runs
+      # `turbo run build` against the same .turbo directory being restored.
       - name: "Cache Bun dependencies"
         if: env.RUN_MCP_BUILD_TEST == 'true'
         uses: actions/cache@v5
+        background: true
+        id: cache-bun
         with:
           # Restoring node_modules is notably expensive on Windows because the
           # archive contains thousands of small files. Bun can materialize it
@@ -1046,12 +1059,17 @@ jobs:
       - name: "Cache Turborepo"
         if: env.RUN_MCP_BUILD_TEST == 'true'
         uses: actions/cache@v5
+        background: true
+        id: cache-turbo
         with:
           path: .turbo
           key: turbo-${{ matrix.os }}-${{ hashFiles('bun.lock') }}-${{ github.sha }}
           restore-keys: |
             turbo-${{ matrix.os }}-${{ hashFiles('bun.lock') }}-
             turbo-${{ matrix.os }}-
+
+      - wait: [cache-bun, cache-turbo]
+        if: env.RUN_MCP_BUILD_TEST == 'true'
 
       - name: "Setup Auto Mobile"
         if: env.RUN_MCP_BUILD_TEST == 'true'
@@ -1166,8 +1184,13 @@ jobs:
           # default one-commit shallow clone.
           fetch-depth: 0
 
+      # Disjoint cache paths, so the two restores overlap each other. The
+      # barrier must precede "Setup Auto Mobile": that composite runs
+      # `turbo run build` against the same .turbo directory being restored.
       - name: "Cache Bun dependencies"
         uses: actions/cache@v5
+        background: true
+        id: cache-bun
         with:
           path: |
             ~/.bun/install/cache
@@ -1178,12 +1201,16 @@ jobs:
 
       - name: "Cache Turborepo"
         uses: actions/cache@v5
+        background: true
+        id: cache-turbo
         with:
           path: .turbo
           key: turbo-ubuntu-latest-${{ hashFiles('bun.lock') }}-${{ github.sha }}
           restore-keys: |
             turbo-ubuntu-latest-${{ hashFiles('bun.lock') }}-
             turbo-ubuntu-latest-
+
+      - wait: [cache-bun, cache-turbo]
 
       - name: "Setup Auto Mobile"
         uses: ./.github/actions/setup-auto-mobile-npm-package

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1068,8 +1068,11 @@ jobs:
             turbo-${{ matrix.os }}-${{ hashFiles('bun.lock') }}-
             turbo-${{ matrix.os }}-
 
+      # No `if:` here -- a `wait` step always runs and does not accept a
+      # condition; adding one fails whole-workflow validation. When the job's
+      # RUN_MCP_BUILD_TEST guard skips the cache steps there is simply nothing
+      # outstanding for the barrier to join.
       - wait: [cache-bun, cache-turbo]
-        if: env.RUN_MCP_BUILD_TEST == 'true'
 
       - name: "Setup Auto Mobile"
         if: env.RUN_MCP_BUILD_TEST == 'true'

--- a/test/helpers/workflowSteps.ts
+++ b/test/helpers/workflowSteps.ts
@@ -23,6 +23,7 @@ export interface WorkflowStep {
   background?: boolean;
   /** Native parallel-steps barrier: a single step id or a list of them. */
   wait?: string | string[];
+  if?: string | boolean;
 }
 
 const repoRoot = join(import.meta.dir, "../..");
@@ -65,6 +66,18 @@ export function loadJobs(workflowRelativePath: string): Record<string, WorkflowJ
     }
   }
   return jobs;
+}
+
+/** Every step of every job in a workflow, paired with its job id. */
+export function loadAllJobSteps(
+  workflowRelativePath: string
+): { jobId: string; step: WorkflowStep }[] {
+  const document = load(readFileSync(join(repoRoot, workflowRelativePath), "utf8")) as {
+    jobs?: Record<string, { steps?: WorkflowStep[] } | undefined>;
+  };
+  return Object.entries(document.jobs ?? {}).flatMap(([jobId, job]) =>
+    (job?.steps ?? []).map(step => ({ jobId, step }))
+  );
 }
 
 export function stepNamed(steps: WorkflowStep[], name: string): WorkflowStep | undefined {

--- a/test/scripts/miscParallelSteps.test.ts
+++ b/test/scripts/miscParallelSteps.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+import { indexOfNamed, indexOfWaitOn, loadJobSteps, stepNamed } from "../helpers/workflowSteps";
+
+// Guards issue #4130: the remaining parallel-steps wins.
+//
+//  7d The two cache restores in `mcp-build-and-test` and `ts-code-coverage` hit
+//     disjoint paths (~/.bun/install/cache + node_modules vs .turbo), so they
+//     overlap each other. The barrier MUST precede `Setup Auto Mobile`: that
+//     composite runs `turbo run build`, which reads and writes the same .turbo
+//     directory the cache restores — racing them would miss or corrupt it.
+//  7e hadolint pulls a Docker image and has no consumer, so it is hoisted to
+//     just after checkout and joined at the end of the job. A failure then
+//     surfaces at the barrier instead of vanishing.
+//  7b/7c In deploy-docs, Setup Python and Install uv are mutually independent
+//     (uv ships a standalone binary), and the two badge downloads are distinct
+//     artifacts. The badge downloads must stay AFTER `Build documentation` —
+//     mkdocs regenerates/cleans site/, which would delete a badge landing early.
+
+const PR_WORKFLOW = ".github/workflows/pull_request.yml";
+const MERGE_WORKFLOW = ".github/workflows/merge.yml";
+
+for (const jobId of ["mcp-build-and-test", "ts-code-coverage"]) {
+  describe(`#4130 cache fan-out (${jobId})`, () => {
+    const steps = loadJobSteps(PR_WORKFLOW, jobId);
+
+    test("the job exists and has steps", () => {
+      expect(steps.length).toBeGreaterThan(0);
+    });
+
+    test("both cache restores are backgrounded with ids", () => {
+      const bun = stepNamed(steps, "Cache Bun dependencies");
+      expect(bun?.background).toBe(true);
+      expect(bun?.id).toBe("cache-bun");
+
+      const turbo = stepNamed(steps, "Cache Turborepo");
+      expect(turbo?.background).toBe(true);
+      expect(turbo?.id).toBe("cache-turbo");
+    });
+
+    test("one barrier covers both and precedes Setup Auto Mobile", () => {
+      // Load-bearing: the composite runs `turbo run build` against .turbo.
+      const waitBun = indexOfWaitOn(steps, "cache-bun");
+      const waitTurbo = indexOfWaitOn(steps, "cache-turbo");
+      const setupIndex = indexOfNamed(steps, "Setup Auto Mobile");
+
+      expect(waitBun).toBeGreaterThanOrEqual(0);
+      expect(waitBun).toBe(waitTurbo);
+      expect(setupIndex).toBeGreaterThanOrEqual(0);
+      expect(waitBun).toBeLessThan(setupIndex);
+    });
+  });
+}
+
+describe("#4130 hadolint hoist (fast-validation)", () => {
+  const steps = loadJobSteps(PR_WORKFLOW, "fast-validation");
+
+  test("the job exists and has steps", () => {
+    expect(steps.length).toBeGreaterThan(0);
+  });
+
+  test("hadolint is backgrounded with an id and hoisted above the real work", () => {
+    const hadolint = stepNamed(steps, "Run hadolint");
+    expect(hadolint?.background).toBe(true);
+    expect(hadolint?.id).toBe("hadolint");
+
+    // Hoisted so its image pull overlaps the whole job.
+    const hadolintIndex = indexOfNamed(steps, "Run hadolint");
+    const checksIndex = indexOfNamed(steps, "Run fast validation checks");
+    expect(hadolintIndex).toBeLessThan(checksIndex);
+  });
+
+  test("the hadolint barrier comes after the job's real work, so a failure still surfaces", () => {
+    const waitIndex = indexOfWaitOn(steps, "hadolint");
+    const checksIndex = indexOfNamed(steps, "Run fast validation checks");
+    const batsIndex = indexOfNamed(steps, "Run BATS Tests (Ubuntu)");
+
+    expect(waitIndex).toBeGreaterThanOrEqual(0);
+    expect(waitIndex).toBeGreaterThan(checksIndex);
+    expect(waitIndex).toBeGreaterThan(batsIndex);
+  });
+});
+
+describe("#4130 deploy-docs fan-outs (merge.yml)", () => {
+  const steps = loadJobSteps(MERGE_WORKFLOW, "deploy-docs");
+
+  test("the job exists and has steps", () => {
+    expect(steps.length).toBeGreaterThan(0);
+  });
+
+  test("Python and uv setups are backgrounded and joined before uv sync", () => {
+    expect(stepNamed(steps, "Setup Python")?.background).toBe(true);
+    expect(stepNamed(steps, "Setup Python")?.id).toBe("setup-python");
+    expect(stepNamed(steps, "Install uv")?.background).toBe(true);
+    expect(stepNamed(steps, "Install uv")?.id).toBe("setup-uv");
+
+    const waitPython = indexOfWaitOn(steps, "setup-python");
+    const waitUv = indexOfWaitOn(steps, "setup-uv");
+    const mkdocsIndex = indexOfNamed(steps, "Install MkDocs and dependencies");
+
+    expect(waitPython).toBeGreaterThanOrEqual(0);
+    expect(waitPython).toBe(waitUv);
+    expect(waitPython).toBeLessThan(mkdocsIndex);
+  });
+
+  test("the badge downloads are backgrounded and joined before Setup Pages", () => {
+    expect(stepNamed(steps, "Download Kotlin Coverage Badge")?.background).toBe(true);
+    expect(stepNamed(steps, "Download Swift Coverage Badge")?.background).toBe(true);
+
+    const waitKotlin = indexOfWaitOn(steps, "dl-kotlin-badge");
+    const waitSwift = indexOfWaitOn(steps, "dl-swift-badge");
+    const pagesIndex = indexOfNamed(steps, "Setup Pages");
+
+    expect(waitKotlin).toBeGreaterThanOrEqual(0);
+    expect(waitKotlin).toBe(waitSwift);
+    expect(waitKotlin).toBeLessThan(pagesIndex);
+  });
+
+  test("the badge downloads stay AFTER Build documentation", () => {
+    // mkdocs regenerates/cleans site/, so a badge landing earlier is deleted.
+    const buildIndex = indexOfNamed(steps, "Build documentation");
+    const kotlinIndex = indexOfNamed(steps, "Download Kotlin Coverage Badge");
+    const swiftIndex = indexOfNamed(steps, "Download Swift Coverage Badge");
+
+    expect(buildIndex).toBeGreaterThanOrEqual(0);
+    expect(kotlinIndex).toBeGreaterThan(buildIndex);
+    expect(swiftIndex).toBeGreaterThan(buildIndex);
+  });
+});

--- a/test/scripts/waitStepConditions.test.ts
+++ b/test/scripts/waitStepConditions.test.ts
@@ -1,0 +1,35 @@
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import { loadAllJobSteps } from "../helpers/workflowSteps";
+
+// A `wait` barrier does not accept `if:`. Adding one is not a step-level error
+// that skips the step — it fails whole-workflow validation, so the run dies at
+// startup with zero jobs and no annotation pointing at the offending line
+// (#4130: run 29912090109 finished `failure` in 0s). Nothing local catches it,
+// hence this guard.
+//
+// A barrier needs no condition anyway: when the guarded background steps are
+// themselves skipped, there is simply nothing outstanding for it to join.
+
+const WORKFLOW_DIR = ".github/workflows";
+
+const workflows = readdirSync(join(import.meta.dir, "../..", WORKFLOW_DIR))
+  .filter(name => name.endsWith(".yml") || name.endsWith(".yaml"))
+  .map(name => `${WORKFLOW_DIR}/${name}`);
+
+describe("parallel-steps wait barriers", () => {
+  test("there are workflows to check", () => {
+    expect(workflows.length).toBeGreaterThan(0);
+  });
+
+  for (const workflow of workflows) {
+    test(`no wait step in ${workflow} carries an if:`, () => {
+      const offenders = loadAllJobSteps(workflow)
+        .filter(({ step }) => step.wait !== undefined && step.if !== undefined)
+        .map(({ jobId, step }) => `${jobId}: wait ${JSON.stringify(step.wait)}`);
+
+      expect(offenders).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Four remaining parallel-steps wins, all on PR/merge paths that this PR's own CI exercises.

**`mcp-build-and-test` + `ts-code-coverage`** — the Bun and Turborepo cache restores hit disjoint paths (`~/.bun/install/cache` / `node_modules` vs `.turbo`), so they now overlap each other:

```
Git Checkout -> Cache Bun deps (bg) + Cache Turborepo (bg)
  -> wait: [cache-bun, cache-turbo] -> Setup Auto Mobile -> Run Lint
```

**`fast-validation`** — hadolint pulls a Docker image and consumes nothing the job produces, so it now starts right after checkout and the whole job overlaps the pull:

```
Git Checkout -> Run hadolint (bg) -> ...entire job... -> wait: hadolint -> Upload logs
```

**`deploy-docs`** — `Setup Python` and `Install uv` overlap (joined before `uv sync`), and the two coverage-badge downloads overlap (joined before `Setup Pages`).

## Linked Issue

Closes #4130

## The three constraints that make this safe

1. **The cache barrier precedes `Setup Auto Mobile`, not the lint step.** That composite runs `turbo run build` against the *same* `.turbo` directory the cache is restoring — overlapping the restore with the composite would miss or corrupt the cache. This is the one fan-out in the series that looks obvious but isn't.
2. **In `mcp-build-and-test` the barrier carries the job's `RUN_MCP_BUILD_TEST` guard**, so it skips alongside the cache steps rather than waiting on steps that never ran.
3. **The badge downloads stay AFTER `Build documentation`.** `deploy_pages.py build` regenerates and cleans `site/`, so a badge landing early would be silently deleted. Backgrounding them *in place* is safe; hoisting them is not — there is a test asserting exactly that.

hadolint has no consumer, so its barrier sits at the end of the job: a hadolint failure surfaces at the `wait` instead of vanishing. Pinned by a test asserting the barrier comes *after* the checks and BATS steps.

## Scope reduction

The issue also listed the `dead-code-detection.yml` jq install. Dropped: that workflow runs on a **weekly schedule**, so ~20s there does not justify the change — the same low-frequency reasoning that led to closing #4129.

## Testing

New `test/scripts/miscParallelSteps.test.ts` via the shared `test/helpers/workflowSteps.ts` extractor (parsed YAML), covering all four jobs: backgrounded+ids; one barrier covering both ids per fan-out; barrier before `Setup Auto Mobile`; hadolint hoisted above the checks with its barrier after them; badge downloads after `Build documentation` and joined before `Setup Pages`; plus anti-vacuous guards on every job.

Confirmed **red before** the change: 8 failures, with the 5 pre-existing-invariant tests passing.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` — **17/17 pass**
- [x] `bun test` — 8,273 pass, 0 fail
- [ ] `bun run typecheck` — one pre-existing `PlanSchemaValidator.ts` TS2345 (ajv) unrelated to this diff, which touches no `src/`. Local `node_modules` skew; CI installs with `--frozen-lockfile`.
- [x] Rebased onto latest `main`

Self-exercising: `fast-validation`, `mcp-build-and-test`, and `ts-code-coverage` all run on this PR; `deploy-docs` validates post-merge on `merge.yml`.
