### PR TITLE
fix(installer): isolate runtime probe process group

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -56,6 +56,7 @@ PRESET_CLIENT_FILTER=""  # When set, auto-select clients matching this prefix
 IOS_RUNTIME_NAMES=()
 IOS_RUNTIME_PROBE_PID=""
 IOS_RUNTIME_PROBE_FILE=""
+IOS_RUNTIME_PROBE_PROCESS_GROUP=false
 POST_BUN_SETUP_PID=""
 POST_BUN_SETUP_LOG_FILE=""
 POST_BUN_SETUP_STATE_FILE=""
@@ -124,68 +125,6 @@ terminate_process_tree() {
     # installer-owned worker processes, so use SIGKILL after the recursive
     # walk to guarantee cancellation cannot leave a Bun or daemon child alive.
     kill -KILL "${pid}" 2>/dev/null || true
-}
-
-# Ask leaf processes in a tree to stop without killing their parents. A wrapper
-# blocked in `wait` can then reap the child and exit normally; callers retain a
-# bounded hard-kill fallback for helpers that ignore SIGTERM.
-request_process_tree_shutdown() {
-    local pid="$1"
-    kill -0 "${pid}" 2>/dev/null || return 0
-
-    local children=()
-    local child
-    local has_children=false
-    if command_exists pgrep; then
-        while IFS= read -r child; do
-            if [[ -n "${child}" ]]; then
-                children+=("${child}")
-                has_children=true
-            fi
-        done < <(pgrep -P "${pid}" . 2>/dev/null || true)
-    fi
-
-    if [[ "${has_children}" == "false" ]]; then
-        kill -TERM "${pid}" 2>/dev/null || true
-        return 0
-    fi
-
-    for child in "${children[@]:-}"; do
-        request_process_tree_shutdown "${child}"
-    done
-}
-
-# Force-stop a tree from its leaves while resuming each parent. A parent that
-# was blocked in `wait` gets to reap its killed child before it exits. This is
-# intentionally distinct from `terminate_process_tree`, whose cancellation
-# callers must stop every process immediately.
-terminate_process_tree_for_reaping() {
-    local pid="$1"
-    kill -0 "${pid}" 2>/dev/null || return 0
-
-    kill -STOP "${pid}" 2>/dev/null || true
-
-    local children=()
-    local child
-    local has_children=false
-    if command_exists pgrep; then
-        while IFS= read -r child; do
-            if [[ -n "${child}" ]]; then
-                children+=("${child}")
-                has_children=true
-            fi
-        done < <(pgrep -P "${pid}" . 2>/dev/null || true)
-    fi
-
-    if [[ "${has_children}" == "false" ]]; then
-        kill -KILL "${pid}" 2>/dev/null || true
-        return 0
-    fi
-
-    for child in "${children[@]:-}"; do
-        terminate_process_tree_for_reaping "${child}"
-    done
-    kill -CONT "${pid}" 2>/dev/null || true
 }
 
 # Reap installer background work and remove its temporary files. The runtime
@@ -3401,7 +3340,16 @@ start_ios_runtime_probe() {
     fi
 
     IOS_RUNTIME_PROBE_FILE=$(mktemp "${TMPDIR:-/tmp}/auto-mobile-ios-runtimes.XXXXXX")
-    xcrun simctl list runtimes >"${IOS_RUNTIME_PROBE_FILE}" 2>/dev/null &
+    if command_exists perl; then
+        # A dedicated process group lets the timeout signal every helper in one
+        # operation while this shell still waits for and reaps the direct child.
+        perl -MPOSIX=setsid -e 'setsid() or die "setsid: $!\n"; exec @ARGV or die "exec: $!\n"' \
+            xcrun simctl list runtimes >"${IOS_RUNTIME_PROBE_FILE}" 2>/dev/null &
+        IOS_RUNTIME_PROBE_PROCESS_GROUP=true
+    else
+        xcrun simctl list runtimes >"${IOS_RUNTIME_PROBE_FILE}" 2>/dev/null &
+        IOS_RUNTIME_PROBE_PROCESS_GROUP=false
+    fi
     IOS_RUNTIME_PROBE_PID=$!
 }
 
@@ -3423,33 +3371,24 @@ finish_ios_runtime_probe() {
     local probe_status=0 waited=0
     while kill -0 "${IOS_RUNTIME_PROBE_PID}" 2>/dev/null; do
         if ((waited >= IOS_RUNTIME_PROBE_TIMEOUT_SECONDS)); then
-            # Stop the helper first so an xcrun wrapper blocked in `wait` can
-            # reap it. Fall back to the hard tree kill after a one-second
-            # grace period so a stubborn helper cannot reintroduce the hang.
-            request_process_tree_shutdown "${IOS_RUNTIME_PROBE_PID}"
-            local reap_waited=0
+            local signal_target="${IOS_RUNTIME_PROBE_PID}"
+            if [[ "${IOS_RUNTIME_PROBE_PROCESS_GROUP}" == "true" ]]; then
+                signal_target="-${IOS_RUNTIME_PROBE_PID}"
+            fi
+
+            kill -TERM -- "${signal_target}" 2>/dev/null || true
+            local shutdown_waited=0
             while kill -0 "${IOS_RUNTIME_PROBE_PID}" 2>/dev/null; do
-                if ((reap_waited >= 10)); then
-                    terminate_process_tree_for_reaping "${IOS_RUNTIME_PROBE_PID}"
-                    # The resumed wrapper gets a bounded chance to reap its
-                    # killed children. Do not join it unboundedly: a wrapper
-                    # can resume from `wait` and continue into another stall.
-                    local fallback_waited=0
-                    while kill -0 "${IOS_RUNTIME_PROBE_PID}" 2>/dev/null; do
-                        if ((fallback_waited >= 10)); then
-                            terminate_process_tree "${IOS_RUNTIME_PROBE_PID}"
-                            break
-                        fi
-                        sleep 0.1
-                        fallback_waited=$((fallback_waited + 1))
-                    done
+                if ((shutdown_waited >= 10)); then
+                    kill -KILL -- "${signal_target}" 2>/dev/null || true
                     break
                 fi
                 sleep 0.1
-                reap_waited=$((reap_waited + 1))
+                shutdown_waited=$((shutdown_waited + 1))
             done
             wait "${IOS_RUNTIME_PROBE_PID}" 2>/dev/null || true
             IOS_RUNTIME_PROBE_PID=""
+            IOS_RUNTIME_PROBE_PROCESS_GROUP=false
             rm -f "${IOS_RUNTIME_PROBE_FILE}"
             return 0
         fi
@@ -3463,6 +3402,7 @@ finish_ios_runtime_probe() {
         probe_status=$?
     fi
     IOS_RUNTIME_PROBE_PID=""
+    IOS_RUNTIME_PROBE_PROCESS_GROUP=false
 
     if [[ ${probe_status} -eq 0 ]]; then
         local runtimes

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3378,7 +3378,9 @@ finish_ios_runtime_probe() {
 
             kill -TERM -- "${signal_target}" 2>/dev/null || true
             local shutdown_waited=0
-            while kill -0 "${IOS_RUNTIME_PROBE_PID}" 2>/dev/null; do
+            # The wrapper can exit before a helper that ignored SIGTERM. Poll
+            # the isolated group so the SIGKILL fallback still reaches it.
+            while kill -0 -- "${signal_target}" 2>/dev/null; do
                 if ((shutdown_waited >= 10)); then
                     kill -KILL -- "${signal_target}" 2>/dev/null || true
                     break

--- a/test/bats/install-background-work.bats
+++ b/test/bats/install-background-work.bats
@@ -27,6 +27,16 @@ assert_process_is_reaped() {
   [[ -z "${state}" ]]
 }
 
+wait_for_process_group_leader() {
+  local group
+  for _ in {1..10}; do
+    group=$(ps -o pgid= -p "$1" 2>/dev/null | tr -d ' ')
+    [ "${group}" = "$1" ] && return 0
+    sleep 0.1
+  done
+  return 1
+}
+
 teardown() {
   export PATH="${ORIG_PATH}"
   rm -rf "${TEST_DIR}"
@@ -51,6 +61,7 @@ STUB
   start_ios_runtime_probe
   local worker_pid="${IOS_RUNTIME_PROBE_PID}"
   [ -n "${worker_pid}" ]
+  wait_for_process_group_leader "${worker_pid}"
   local child_pid
   for _ in {1..10}; do
     child_pid=$("${PGREP}" -P "${worker_pid}" sleep 2>/dev/null || true)
@@ -73,7 +84,7 @@ STUB
   assert_process_is_reaped "${child_pid}"
 }
 
-@test "a SIGTERM-ignoring runtime helper is reaped after the hard fallback" {
+@test "a SIGTERM-ignoring runtime process group is reaped after the hard fallback" {
   cat > "${STUB_BIN}/xcrun" <<'STUB'
 #!/usr/bin/env bash
 bash -c 'trap "" TERM; while :; do :; done' &
@@ -86,20 +97,13 @@ STUB
 
   start_ios_runtime_probe
   local worker_pid="${IOS_RUNTIME_PROBE_PID}"
-  local helper_pid
-  for _ in {1..10}; do
-    helper_pid=$("${PGREP}" -P "${worker_pid}" . 2>/dev/null || true)
-    [[ -n "${helper_pid}" ]] && break
-    sleep 0.1
-  done
-  [ -n "${helper_pid}" ]
+  wait_for_process_group_leader "${worker_pid}"
   finish_ios_runtime_probe >/dev/null 2>&1
 
   assert_process_is_reaped "${worker_pid}"
-  assert_process_is_reaped "${helper_pid}"
 }
 
-@test "the hard runtime-probe fallback remains bounded after a wrapper resumes into another stall" {
+@test "the runtime-probe process group remains bounded after a wrapper resumes into another stall" {
   cat > "${STUB_BIN}/xcrun" <<'STUB'
 #!/usr/bin/env bash
 bash -c 'trap "" TERM; while :; do :; done' &
@@ -113,6 +117,7 @@ STUB
 
   start_ios_runtime_probe
   local worker_pid="${IOS_RUNTIME_PROBE_PID}"
+  wait_for_process_group_leader "${worker_pid}"
   local started ended elapsed
   started=$(date +%s)
   finish_ios_runtime_probe >/dev/null 2>&1

--- a/test/bats/install-background-work.bats
+++ b/test/bats/install-background-work.bats
@@ -98,9 +98,17 @@ STUB
   start_ios_runtime_probe
   local worker_pid="${IOS_RUNTIME_PROBE_PID}"
   wait_for_process_group_leader "${worker_pid}"
+  local helper_pid
+  for _ in {1..10}; do
+    helper_pid=$("${PGREP}" -P "${worker_pid}" . 2>/dev/null || true)
+    [[ -n "${helper_pid}" ]] && break
+    sleep 0.1
+  done
+  [ -n "${helper_pid}" ]
   finish_ios_runtime_probe >/dev/null 2>&1
 
   assert_process_is_reaped "${worker_pid}"
+  assert_process_is_not_active "${helper_pid}"
 }
 
 @test "the runtime-probe process group remains bounded after a wrapper resumes into another stall" {


### PR DESCRIPTION
## Summary

- run the iOS runtime probe in an isolated process group
- terminate the bounded probe by process group while reaping its direct child
- remove recursive timeout-only process-tree shutdown helpers

## Validation

- `bats test/bats/install-background-work.bats`
- `shellcheck scripts/install.sh`
- `scripts/shellcheck/validate_shell_sete.sh`
