### PR TITLE
fix(action): dispatch the trimmed URL from OpenURL

### DIFF
--- a/src/features/action/OpenURL.ts
+++ b/src/features/action/OpenURL.ts
@@ -138,11 +138,11 @@ export class OpenURL extends BaseVisualChange {
         switch (this.device.platform) {
           case "android":
             return await perf.track("androidOpenURL", () =>
-              this.executeAndroidOpenURL(url)
+              this.executeAndroidOpenURL(trimmedUrl)
             );
           case "ios":
             return await perf.track("iOSOpenURL", () =>
-              this.executeiOSOpenURL(url)
+              this.executeiOSOpenURL(trimmedUrl)
             );
           default:
             perf.end();

--- a/test/features/action/OpenURL.test.ts
+++ b/test/features/action/OpenURL.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test, spyOn } from "bun:test";
 import { OpenURL } from "../../../src/features/action/OpenURL";
+import { BaseVisualChange } from "../../../src/features/action/BaseVisualChange";
 import { LaunchApp } from "../../../src/features/action/LaunchApp";
 import { IOSCtrlProxyManager } from "../../../src/utils/IOSCtrlProxyManager";
 import { BootedDevice } from "../../../src/models";
@@ -223,5 +224,115 @@ describe("OpenURL input validation", () => {
     const result = await openAndroid("package:");
     expect(result.success).toBe(false);
     expect(result.error).toBe("Invalid package URL - no package name specified");
+  });
+});
+
+// Issue #4166: execute() trimmed the URL for validation/logging but dispatched
+// the RAW value, so surrounding whitespace reached `am start -d` / `simctl
+// openurl` while the logs and the returned result showed the clean URL. These
+// tests assert the COMMAND STRING ACTUALLY ISSUED — the return value already
+// looked correct before the fix, which is exactly why this went unnoticed.
+describe("OpenURL trims the dispatched URL (issue #4166)", () => {
+  const restores: Array<() => void> = [];
+  afterEach(() => {
+    while (restores.length) { restores.pop()!(); }
+  });
+
+  // Run execute() without the observe/visual-change machinery: the block is the
+  // platform dispatch we want to observe, and it is the only part under test.
+  const stubObservedInteraction = () => {
+    const spy = spyOn(BaseVisualChange.prototype, "observedInteraction")
+      .mockImplementation(async (block: any) => block({} as any));
+    restores.push(() => spy.mockRestore());
+  };
+
+  const whitespaceCases: Array<[string, string, string]> = [
+    ["no whitespace (control)", "https://example.com/x", "https://example.com/x"],
+    ["leading space", " https://example.com/x", "https://example.com/x"],
+    ["trailing space", "https://example.com/x ", "https://example.com/x"],
+    ["leading and trailing spaces", "  https://example.com/x  ", "https://example.com/x"],
+    ["tab", "\thttps://example.com/x\t", "https://example.com/x"],
+    ["newline", "\nhttps://example.com/x\n", "https://example.com/x"],
+    ["carriage return + newline", "\r\nhttps://example.com/x\r\n", "https://example.com/x"],
+    // Inner whitespace is NOT surrounding whitespace: trim() must leave it alone.
+    ["inner whitespace is preserved", " https://example.com/a b ", "https://example.com/a b"],
+  ];
+
+  test.each(whitespaceCases)(
+    "android dispatch: %s",
+    async (_label, input, expectedUrl) => {
+      stubObservedInteraction();
+      const fakeAdb = new FakeAdbExecutor();
+      const openURL = new OpenURL(
+        { name: "pixel", platform: "android", deviceId: "emulator-5554" },
+        fakeAdb as unknown as any
+      );
+
+      const result = await openURL.execute(input);
+
+      expect(fakeAdb.getExecutedCommands()).toEqual([
+        `shell am start -a android.intent.action.VIEW -d "${expectedUrl}"`,
+      ]);
+      expect(result).toEqual({ success: true, url: expectedUrl });
+    }
+  );
+
+  test.each(whitespaceCases)(
+    "ios simulator dispatch: %s",
+    async (_label, input, expectedUrl) => {
+      stubObservedInteraction();
+      const simctl = new FakeSimCtlClient();
+      const devicectl = new FakeDeviceUrlLauncher();
+      const openURL = new OpenURL(
+        iosDevice(SIMULATOR_UDID),
+        new FakeAdbExecutor() as unknown as any,
+        simctl as any,
+        devicectl as any
+      );
+
+      const result = await openURL.execute(input);
+
+      const calls = simctl.getMethodCalls("executeCommand");
+      expect(calls).toHaveLength(1);
+      expect(calls[0].command).toBe(`openurl ${SIMULATOR_UDID} "${expectedUrl}"`);
+      expect(result).toEqual({ success: true, url: expectedUrl });
+    }
+  );
+
+  test.each(whitespaceCases)(
+    "ios physical dispatch: %s",
+    async (_label, input, expectedUrl) => {
+      stubObservedInteraction();
+      const simctl = new FakeSimCtlClient();
+      const devicectl = new FakeDeviceUrlLauncher();
+      const openURL = new OpenURL(
+        iosDevice(PHYSICAL_UDID),
+        new FakeAdbExecutor() as unknown as any,
+        simctl as any,
+        devicectl as any
+      );
+
+      const result = await openURL.execute(input);
+
+      expect(devicectl.launchCalls).toEqual([
+        { deviceUdid: PHYSICAL_UDID, bundleId: "com.apple.mobilesafari", url: expectedUrl },
+      ]);
+      expect(result).toEqual({ success: true, url: expectedUrl });
+    }
+  );
+
+  test("package: URL with surrounding whitespace still delegates to LaunchApp", async () => {
+    const launchSpy = spyOn(LaunchApp.prototype, "execute").mockResolvedValue({ success: true } as any);
+    restores.push(() => launchSpy.mockRestore());
+
+    const openURL = new OpenURL(
+      { name: "pixel", platform: "android", deviceId: "emulator-5554" },
+      new FakeAdbExecutor() as unknown as any
+    );
+
+    const result = await openURL.execute("  package:com.example.MyApp  ");
+
+    expect(launchSpy.mock.calls[0][0]).toBe("com.example.MyApp");
+    expect(result).toEqual({ success: true, url: "package:com.example.MyApp" });
   });
 });


### PR DESCRIPTION
## Summary

`OpenURL.execute()` computed `trimmedUrl` and used it for validation, the
`package:` branch, the result payload and every log line — but the two platform
dispatch sites still passed the **raw** `url`. The trim was therefore cosmetic:
`openLink(" https://example.com ")` logged and returned the clean URL while
`am start -a android.intent.action.VIEW -d " https://example.com "` (and
`simctl openurl` / `devicectl` on iOS) received the untrimmed value. Because the
logs and the returned result looked correct, the failure was actively misleading
during debugging.

Both dispatch sites now pass `trimmedUrl`.

## Linked Issue

Closes #4166

## Bug / Regression Context

- **Observed symptom:** surrounding whitespace reached the intent/`simctl openurl`
  payload while logs and the `OpenURLResult.url` showed the trimmed URL.
- **Repro steps / conditions:** `openLink(" https://example.com ")` on Android or
  iOS (simulator and physical paths both affected).
- **Root cause:** `src/features/action/OpenURL.ts` — every branch between the
  `const trimmedUrl = url.trim()` line and the platform switch used `trimmedUrl`;
  only `executeAndroidOpenURL(url)` / `executeiOSOpenURL(url)` regressed to the raw
  value.

## Changes

- `src/features/action/OpenURL.ts`: dispatch `trimmedUrl` on both the Android and
  iOS branches.
- `test/features/action/OpenURL.test.ts`: new `describe` block pinning the fix.

## Testing

New regression suite asserts the **command string actually issued**, not the
returned result object (the return value already looked correct before the fix,
which is why this went unnoticed):

- Android: `FakeAdbExecutor.getExecutedCommands()` equals the exact
  `shell am start -a android.intent.action.VIEW -d "<trimmed>"`.
- iOS simulator: `FakeSimCtlClient.getMethodCalls("executeCommand")` equals
  `openurl <udid> "<trimmed>"`.
- iOS physical: `FakeDeviceUrlLauncher.launchCalls` carries the trimmed payload URL.

Each of the three dispatch paths runs a `test.each` table: no-whitespace control,
leading, trailing, both, tab, newline, CRLF, plus an inner-whitespace row that
asserts `trim()` does **not** touch whitespace inside the URL. A `package:` row
confirms the LaunchApp delegation still works with a padded input.

Red before the fix (21 of 39 failing), green after (39/39).

## Validation

- [x] `bun test` — 8336 pass / 0 fail
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — the one reported error
      (`src/daemon/telemetryPushSocketServer.ts` TS2339 `sessionId`) is
      **pre-existing on `main`** and untouched by this diff; follow-up filed below
- [x] New tests use existing fakes; the suite runs in ~0.3s
- [ ] Device verification: N/A — pure string-handling fix, covered by fakes

## CI status — both red checks are pre-existing on `main`

This diff changes two lines of `src/features/action/OpenURL.ts` and one test file. It
touches no shell script, no workflow, and nothing under `src/daemon/` or `src/db/`.

- **`Node TypeScript Build and Test (ubuntu-latest)`** — the typecheck gate rejects
  `src/daemon/telemetryPushSocketServer.ts` TS2339. Reproduced on a clean checkout of
  `origin/main` (`92cd3baa5`) with no PR content at all. The same check is red on
  [#4203](https://github.com/kaeawc/auto-mobile/pull/4203) and [#4205](https://github.com/kaeawc/auto-mobile/pull/4205); [#4200](https://github.com/kaeawc/auto-mobile/pull/4200), which is 8 commits behind, is green.
  Tracked in [#4211](https://github.com/kaeawc/auto-mobile/issues/4211).
- **`BATS Shell Tests (macos-latest)`** (and the `Shell Tests` roll-up that only reports
  its dependency) — two cases in `test/bats/boot-simulator.bats` fail because
  `scripts/ios/boot-simulator.sh:38` expands an empty array under `set -u`, which bash 3.2
  (the `macos-latest` `/bin/bash`) rejects. Both the script and the tests came from
  [#4199](https://github.com/kaeawc/auto-mobile/pull/4199), the current tip of `main`. Tracked in [#4212](https://github.com/kaeawc/auto-mobile/issues/4212).

Neither is papered over here — this PR needs `main` green before it can merge.

## Follow-ups

- [#4211](https://github.com/kaeawc/auto-mobile/issues/4211) — typecheck gate red on clean `main` (union-member reordering defeats the
  baseline signature).
- [#4212](https://github.com/kaeawc/auto-mobile/issues/4212) — `boot-simulator.sh` empty-array expansion breaks under bash 3.2, redding
  the macOS BATS leg.
- [#4213](https://github.com/kaeawc/auto-mobile/issues/4213) — `openLink` interpolates the URL into a shell command string; a URL containing
  `"`/`$`/a backtick is mangled or injects. Same "logs look right, device sees something
  else" class as this bug, deliberately left out to keep this PR to the trim fix.
