### PR TITLE
fix(vision): order-insensitive cache key so identical searches cost one analyzer call

### DIFF
--- a/src/utils/predictionUtils.ts
+++ b/src/utils/predictionUtils.ts
@@ -1,6 +1,4 @@
-function stableStringify(value: unknown): string {
-  return JSON.stringify(sortValue(value));
-}
+import { stableStringify } from "./stableStringify";
 
 export function normalizeToolArgs(args?: Record<string, any> | null): string {
   if (!args || Object.keys(args).length === 0) {
@@ -12,21 +10,6 @@ export function normalizeToolArgs(args?: Record<string, any> | null): string {
 export function normalizeIdentifier(value?: string): string | undefined {
   const trimmed = value?.trim();
   return trimmed ? trimmed.toLowerCase() : undefined;
-}
-
-function sortValue(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map(sortValue);
-  }
-  if (value && typeof value === "object") {
-    const record = value as Record<string, unknown>;
-    return Object.fromEntries(
-      Object.keys(record)
-        .sort()
-        .map(key => [key, sortValue(record[key])])
-    );
-  }
-  return value;
 }
 
 function stripToolArgs(args: Record<string, any>): Record<string, any> {

--- a/src/utils/stableStringify.ts
+++ b/src/utils/stableStringify.ts
@@ -1,0 +1,28 @@
+/**
+ * Order-insensitive JSON serialization.
+ *
+ * `JSON.stringify` preserves key *insertion* order, so two semantically
+ * identical objects written with their keys in a different order serialize
+ * differently. Anything that uses a serialized object as a cache key or an
+ * identity signature must sort keys first, or it silently misses.
+ *
+ * Array element order is meaningful and is preserved.
+ */
+export function stableStringify(value: unknown): string {
+  return JSON.stringify(sortValue(value));
+}
+
+function sortValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortValue);
+  }
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.keys(record)
+        .sort()
+        .map(key => [key, sortValue(record[key])])
+    );
+  }
+  return value;
+}

--- a/src/vision/VisionFallback.ts
+++ b/src/vision/VisionFallback.ts
@@ -13,6 +13,7 @@ import type { ViewHierarchyNode } from "../models/ViewHierarchyResult";
 import type { Timer } from "../utils/SystemTimer";
 import { defaultTimer } from "../utils/SystemTimer";
 import { logger } from "../utils/logger";
+import { stableStringify } from "../utils/stableStringify";
 
 export class VisionFallback {
   private config: VisionFallbackConfig;
@@ -119,7 +120,9 @@ export class VisionFallback {
     screenshotPath: string,
     searchCriteria: ElementSearchCriteria
   ): string {
-    const criteriaStr = JSON.stringify(searchCriteria);
+    // Sorted-key serialization: criteria written with their keys in a different
+    // order are the same search, and must not cost a second paid analyzer call.
+    const criteriaStr = stableStringify(searchCriteria);
     return `${screenshotPath}:${criteriaStr}`;
   }
 

--- a/test/utils/stableStringify.test.ts
+++ b/test/utils/stableStringify.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { stableStringify } from "../../src/utils/stableStringify";
+
+describe("stableStringify", () => {
+  test("key order does not change the output", () => {
+    expect(stableStringify({ a: 1, b: 2 })).toBe(stableStringify({ b: 2, a: 1 }));
+  });
+
+  test("different content still produces different output", () => {
+    expect(stableStringify({ a: 1, b: 2 })).not.toBe(stableStringify({ a: 1, b: 3 }));
+    expect(stableStringify({ a: 1 })).not.toBe(stableStringify({ a: 1, b: 2 }));
+  });
+
+  test("nested objects are sorted at every level", () => {
+    const left = { outer: { z: 1, a: { y: 2, b: 3 } } };
+    const right = { outer: { a: { b: 3, y: 2 }, z: 1 } };
+    expect(stableStringify(left)).toBe(stableStringify(right));
+  });
+
+  test("array element order is preserved (it is meaningful)", () => {
+    expect(stableStringify({ v: [1, 2] })).not.toBe(stableStringify({ v: [2, 1] }));
+  });
+
+  test("objects nested inside arrays are sorted", () => {
+    expect(stableStringify({ v: [{ a: 1, b: 2 }] })).toBe(
+      stableStringify({ v: [{ b: 2, a: 1 }] })
+    );
+  });
+
+  test("primitives and null round-trip like JSON.stringify", () => {
+    expect(stableStringify("x")).toBe("\"x\"");
+    expect(stableStringify(3)).toBe("3");
+    expect(stableStringify(null)).toBe("null");
+    expect(stableStringify({ a: undefined, b: 1 })).toBe(stableStringify({ b: 1 }));
+  });
+});

--- a/test/vision/VisionFallback.test.ts
+++ b/test/vision/VisionFallback.test.ts
@@ -108,6 +108,39 @@ describe("VisionFallback orchestrator", () => {
     expect(count()).toBe(2);
   });
 
+  test("criteria written with keys in a different order hit the cache: the paid analyzer runs once", async () => {
+    const fb = new VisionFallback(config(), timer);
+    const count = stubAnalyzer(fb, result());
+
+    // Semantically identical searches, keys typed in a different order.
+    await fb.analyzeAndSuggest("/s.png", HIERARCHY, { text: "Login", resourceId: "btn" });
+    await fb.analyzeAndSuggest("/s.png", HIERARCHY, { resourceId: "btn", text: "Login" });
+
+    expect(count()).toBe(1);
+    expect(fb.getCacheStats().size).toBe(1);
+  });
+
+  test("control: criteria with the same keys but different values are still analyzed separately", async () => {
+    const fb = new VisionFallback(config(), timer);
+    const count = stubAnalyzer(fb, result());
+
+    await fb.analyzeAndSuggest("/s.png", HIERARCHY, { text: "Login", resourceId: "btn" });
+    await fb.analyzeAndSuggest("/s.png", HIERARCHY, { resourceId: "btn2", text: "Login" });
+
+    expect(count()).toBe(2);
+    expect(fb.getCacheStats().size).toBe(2);
+  });
+
+  test("control: the same criteria against a different screenshot is not a cache hit", async () => {
+    const fb = new VisionFallback(config(), timer);
+    const count = stubAnalyzer(fb, result());
+
+    await fb.analyzeAndSuggest("/a.png", HIERARCHY, criteria("Login"));
+    await fb.analyzeAndSuggest("/b.png", HIERARCHY, criteria("Login"));
+
+    expect(count()).toBe(2);
+  });
+
   test("clearCache forces re-analysis", async () => {
     const fb = new VisionFallback(config(), timer);
     const count = stubAnalyzer(fb, result());


### PR DESCRIPTION
## Summary

`VisionFallback.generateCacheKey` built its key from a bare `JSON.stringify(searchCriteria)`. `JSON.stringify` preserves key *insertion* order, so two semantically identical searches whose criteria keys were written in a different order produced different cache keys, missed the cache, and paid for a second vision-analyzer call. Silent failure mode: correct results, doubled cost.

The fix serializes the criteria with sorted keys. Rather than inline a new sorter, this promotes the recursive `stableStringify` that already existed (unexported) in `src/utils/predictionUtils.ts` into a shared `src/utils/stableStringify.ts`, and uses it from both call sites — one canonical primitive for order-insensitive serialization.

## Linked Issue

Closes #4189

## Bug / Regression Context

- **Observed symptom:** two identical vision queries with reordered criteria keys invoked the paid analyzer twice (`Expected 1, Received 2`).
- **Repro steps / conditions:** `analyzeAndSuggest(path, h, { text: "Login", resourceId: "btn" })` followed by `analyzeAndSuggest(path, h, { resourceId: "btn", text: "Login" })` with `cacheResults: true`.
- **Root cause:** `src/vision/VisionFallback.ts:122` — order-sensitive `JSON.stringify` in the cache key.

## Changes

- Added `src/utils/stableStringify.ts` — recursive, key-sorted JSON serialization; array element order preserved because it is meaningful.
- `src/utils/predictionUtils.ts` now imports the shared helper instead of carrying its own private copy (behavior unchanged).
- `src/vision/VisionFallback.ts` uses `stableStringify` for the criteria portion of the cache key.

## Acceptance criteria

- [x] Two criteria objects with identical content and different key order produce the same key — `VisionFallback.test.ts`, "criteria written with keys in a different order hit the cache".
- [x] Genuinely different criteria still produce different keys — two control tests: differing criteria values, and same criteria against a different screenshot.
- [x] Nested-object and array-valued criteria covered — `test/utils/stableStringify.test.ts` covers nesting at every level, objects inside arrays, and array-order significance.
- [x] Test asserts the **analyzer was invoked once**, not merely that key strings match — the assertions are on the stubbed analyzer's call count, not on the key.
- [x] Red before the fix, green after — the new test failed with exactly `Expected: 1 / Received: 2` before the change.

## Validation

- [x] `bun test` — 8320 pass, 0 fail (full suite)
- [x] `bun run lint` clean
- [x] `bun run typecheck` — the one reported error (`src/daemon/telemetryPushSocketServer.ts` TS2339) reproduces on pristine `origin/main` with this branch's changes absent; it is pre-existing baseline drift, not from this PR. Verified in a detached worktree at `origin/main`.
- [x] New code reuses an existing project helper rather than adding a dependency
- [x] No device interaction required; no real analyzer call is made by any test

## Follow-ups

Filed separately to keep this PR scoped to the cache key:

- [#4207](https://github.com/kaeawc/auto-mobile/issues/4207) — the vision result cache is constructed per call in production (`applyVisionFallback.ts:33` builds a fresh `VisionFallback` each time, and no production site injects `visionAnalyzer`), so the cache never survives to be read. Strictly larger than this fix: #4189 doubled the cost for reordered keys, that one misses every repeat.
- [#4209](https://github.com/kaeawc/auto-mobile/issues/4209) — `main` is red on the typecheck gate (`telemetryPushSocketServer.ts` TS2339), which fails `Node TypeScript Build and Test (ubuntu-latest)` on this PR and on unrelated PRs #4203/#4204. **This PR cannot merge until that is fixed**; the failure is not caused by these changes.

Noted but out of scope: `ElementSearchCriteria` is currently flat, so the recursive sorting is defensive against future nesting rather than exercised by the production type today.
