### PR TITLE
fix(database): stop truncating SQLite error type and message at whitespace/comma

### DIFF
--- a/src/features/database/DatabaseInspector.ts
+++ b/src/features/database/DatabaseInspector.ts
@@ -67,6 +67,13 @@ export interface SQLResult {
  * `adb shell content call` commands.
  */
 export class DatabaseInspector {
+  /**
+   * Keys the DatabaseInspectorProvider puts into the Bundle it returns from `call`
+   * (android/auto-mobile-sdk/src/debug/kotlin/.../database/DatabaseInspectorProvider.kt).
+   * Used to find entry boundaries when splitting the printed Bundle.
+   */
+  private static readonly BUNDLE_KEYS = ["success", "errorType", "error", "result"];
+
   constructor(
     private device: BootedDevice,
     private adb: AdbExecutor
@@ -177,13 +184,11 @@ export class DatabaseInspector {
    */
   private parseContentCallResult<T>(output: string): T {
     // Check for success
-    const successMatch = output.match(/success=(\w+)/);
-    const success = successMatch?.[1] === "true";
+    const success = this.extractBundleValue(output, "success") === "true";
 
     if (!success) {
-      const errorType = output.match(/errorType=(\w+)/)?.[1] || "UNKNOWN";
-      const errorMatch = output.match(/error=([^,}]+)/);
-      const error = errorMatch?.[1]?.trim() || "Unknown error";
+      const errorType = this.extractBundleValue(output, "errorType") || "UNKNOWN";
+      const error = this.extractBundleValue(output, "error") || "Unknown error";
       throw new ActionableError(`Database error (${errorType}): ${error}`);
     }
 
@@ -198,6 +203,44 @@ export class DatabaseInspector {
     } catch {
       throw new ActionableError(`Failed to parse ContentProvider response: invalid JSON`);
     }
+  }
+
+  /**
+   * Extract a single Bundle entry value from `content call` output.
+   *
+   * `adb shell content call` prints the returned Bundle with Bundle.toString(), i.e.
+   * `Bundle[{key=value, key=value}]`: entries are joined by ", " and the map is closed by a
+   * single trailing "}]". Values are raw, unescaped strings — a SQLite message routinely
+   * contains spaces, commas and braces — so a value can only be terminated by the next
+   * `, <knownKey>=` boundary or by the bundle's trailing "}]". Matching a value with a
+   * character class such as `[^,}]+` silently truncates it at the first comma or brace.
+   */
+  private extractBundleValue(output: string, key: string): string | null {
+    // A key always starts the bundle ("Bundle[{key=") or follows an entry separator.
+    const keyPattern = new RegExp(`(?:^|[[{,]\\s*)${key}=`);
+    const keyMatch = keyPattern.exec(output);
+    if (!keyMatch) {
+      return null;
+    }
+
+    const valueStart = keyMatch.index + keyMatch[0].length;
+    const rest = output.slice(valueStart);
+
+    // The value ends at the next known key boundary...
+    const nextKeyPattern = new RegExp(`,\\s*(?:${DatabaseInspector.BUNDLE_KEYS.join("|")})=`);
+    const nextKeyMatch = nextKeyPattern.exec(rest);
+    let end = nextKeyMatch ? nextKeyMatch.index : rest.length;
+
+    // ...or, when it is the last entry, at the bundle's trailing "}]".
+    if (!nextKeyMatch) {
+      const terminator = rest.lastIndexOf("}]");
+      if (terminator !== -1) {
+        end = terminator;
+      }
+    }
+
+    const value = rest.slice(0, end).trim();
+    return value.length > 0 ? value : null;
   }
 
   /**

--- a/src/features/database/DatabaseInspector.ts
+++ b/src/features/database/DatabaseInspector.ts
@@ -214,6 +214,11 @@ export class DatabaseInspector {
    * contains spaces, commas and braces — so a value can only be terminated by the next
    * `, <knownKey>=` boundary or by the bundle's trailing "}]". Matching a value with a
    * character class such as `[^,}]+` silently truncates it at the first comma or brace.
+   *
+   * Bundle.toString() does not escape its values, so a value that itself contains a literal
+   * `, <knownKey>=` sequence is indistinguishable from a real entry boundary and would still be
+   * cut short. That ambiguity is in the wire format, not in this parser, and no SQLite message
+   * produces it in practice.
    */
   private extractBundleValue(output: string, key: string): string | null {
     // A key always starts the bundle ("Bundle[{key=") or follows an entry separator.

--- a/test/features/database/DatabaseInspector.test.ts
+++ b/test/features/database/DatabaseInspector.test.ts
@@ -210,6 +210,76 @@ describe("DatabaseInspector", () => {
     });
   });
 
+  describe("error envelope parsing", () => {
+    // Wire contract, established from the producer
+    // (android/auto-mobile-sdk/src/debug/kotlin/.../DatabaseInspectorProvider.kt): the
+    // provider fills a Bundle with the string keys `success`, `errorType`, `error` (and
+    // `result` on success). `adb shell content call` prints it with Bundle.toString(),
+    // i.e. `Bundle[{key=value, key=value}]` — entries joined by ", " and the whole map
+    // closed by a single trailing "}]". Values are raw, unescaped strings, so an entry's
+    // value may itself contain spaces, commas and closing braces. The only reliable
+    // terminators for a value are the next `, <knownKey>=` boundary or the bundle's
+    // trailing "}]".
+    const errorFor = async (response: string): Promise<string> => {
+      fakeAdb.setCommandResult(
+        `shell content call --uri content://${appId}.automobile.database --method listDatabases`,
+        response
+      );
+      try {
+        await inspector.listDatabases(appId);
+      } catch (error) {
+        return (error as Error).message;
+      }
+      throw new Error("expected listDatabases to reject");
+    };
+
+    test("preserves a multi-word errorType", async () => {
+      const message = await errorFor(
+        `Bundle[{success=false, errorType=SQL Error, error=Database inspection is disabled}]`
+      );
+
+      expect(message).toBe("Database error (SQL Error): Database inspection is disabled");
+    });
+
+    test("preserves error text containing commas", async () => {
+      const message = await errorFor(
+        `Bundle[{success=false, errorType=SQLiteException, error=no such column: foo, bar}]`
+      );
+
+      expect(message).toBe("Database error (SQLiteException): no such column: foo, bar");
+    });
+
+    test("preserves error text containing a closing brace", async () => {
+      const message = await errorFor(
+        `Bundle[{success=false, errorType=SQLiteException, error=near "}": syntax error (code 1)}]`
+      );
+
+      expect(message).toBe(`Database error (SQLiteException): near "}": syntax error (code 1)`);
+    });
+
+    test("preserves error text when errorType follows error in the bundle", async () => {
+      const message = await errorFor(
+        `Bundle[{success=false, error=no such table: users, orders, errorType=SQLiteException}]`
+      );
+
+      expect(message).toBe("Database error (SQLiteException): no such table: users, orders");
+    });
+
+    test("single-word errorType and comma-free error text are unchanged", async () => {
+      const message = await errorFor(
+        `Bundle[{success=false, errorType=DISABLED, error=Database inspection is disabled}]`
+      );
+
+      expect(message).toBe("Database error (DISABLED): Database inspection is disabled");
+    });
+
+    test("falls back to UNKNOWN and Unknown error when the keys are absent", async () => {
+      const message = await errorFor(`Bundle[{success=false}]`);
+
+      expect(message).toBe("Database error (UNKNOWN): Unknown error");
+    });
+  });
+
   describe("error handling", () => {
     test("throws ActionableError when ContentProvider not found", async () => {
       // Simulate when the app doesn't have the SDK or provider


### PR DESCRIPTION
## Summary

`DatabaseInspector.parseContentCallResult` matched the failure envelope with two regexes that
silently truncate the diagnostic they are supposed to surface: `errorType=(\w+)` stops at the
first non-word character, and `error=([^,}]+)` stops at the first comma or brace. SQLite
messages routinely contain both (`no such table: users, orders`, `near "}": syntax error`), so
the user was shown a truncated message that still *looked* complete — the worst failure mode
for an error path.

This replaces both regexes with a boundary-aware `extractBundleValue(output, key)` helper that
parses the printed Bundle the way the producer actually writes it.

**Wire contract (established from the producer, not guessed):**
`android/auto-mobile-sdk/src/debug/kotlin/.../database/DatabaseInspectorProvider.kt` fills a
`Bundle` with the string keys `success`, `errorType`, `error` and (on success) `result`.
`adb shell content call` prints it via `Bundle.toString()` as `Bundle[{key=value, key=value}]` —
entries joined by `", "`, the whole map closed by one trailing `"}]"`. Values are raw and
unescaped, so a value may itself contain spaces, commas and closing braces. The only reliable
terminators for a value are therefore the next `, <knownKey>=` boundary or the bundle's trailing
`}]`. The helper scans for exactly those, so entry order in the Bundle does not matter either
(`ArrayMap` ordering is hash-based, not insertion-ordered).

`success=` now goes through the same helper, and the existing balanced-brace `result=` extractor
is untouched.

## Linked Issue

Closes #4191

## Bug / Regression Context

- **Observed symptom:** `Database error (SQL): ...` for an `errorType` of `SQL Error`, and
  `no such column: foo` for an error of `no such column: foo, bar`.
- **Repro steps / conditions:** any `executeSQL` / `listTables` / `getTableData` failure whose
  SQLite message contains a comma or a brace, which is the common case for syntax errors.
- **Prior attempts:** none.

## Validation

- [x] `bun test` — 8317 pass / 0 fail (full suite)
- [x] `bun run lint` — clean (exit 0)
- [ ] `bun run typecheck` — fails on a **pre-existing** main breakage unrelated to this diff:
      a baselined `TS2339` line for `src/daemon/telemetryPushSocketServer.ts` drifted because the
      printed `severity` union member order changed (`"critical" | "high" | "medium" | "low"` in
      `scripts/typecheck-baseline.txt` vs `"high" | "medium" | "critical" | "low"` now). The same
      failure reproduces on other in-flight PRs (#4203, #4204, #4205), so it is not caused here
      and is deliberately not fixed here to avoid four PRs editing the same baseline line.
- [x] New code reuses the existing helper style in this file; no new dependency

## Acceptance criteria

| Criterion | Test |
| --- | --- |
| Multi-word `errorType` preserved intact | `preserves a multi-word errorType` |
| Error text containing commas preserved intact | `preserves error text containing commas` |
| Error text containing `}` handled per the real delimiter contract | `preserves error text containing a closing brace` (contract documented in the test) |
| Single-word / no-comma cases unchanged (control rows) | `single-word errorType and comma-free error text are unchanged`, plus the pre-existing `DISABLED` / `NotFound` / `SqlError` tests |
| Missing keys still fall back | `falls back to UNKNOWN and Unknown error when the keys are absent` |
| Entry order independence | `preserves error text when errorType follows error in the bundle` |

All four new criterion tests were confirmed **red** at HEAD before the fix (truncating to `SQL`,
`no such column: foo`, `near "`, `no such table: users` respectively) and are green after.

## Device Verification

N/A — pure parsing change, covered by unit tests against captured wire text.
