### PR TITLE
fix(server): stop prototype-inherited keys corrupting lookup maps

### DIFF
--- a/src/features/action/AppPermissions.ts
+++ b/src/features/action/AppPermissions.ts
@@ -19,6 +19,36 @@ import {
 } from "./IosPhysicalPermissions";
 import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
 
+/**
+ * Map requested permission names onto the runner-reported grant map.
+ *
+ * `granted` is decoded from the wire and `permissionNames` is caller-supplied, so the
+ * membership test must be an own-property check: `permission in granted` also matches
+ * inherited `Object.prototype` members, which would report a bogus permission such as
+ * `toString` as "granted" (its inherited value is a truthy function) instead of
+ * "unknown" (issue #4187).
+ */
+export function mapAndroidPermissionStates(
+  permissionNames: string[],
+  granted: Record<string, boolean>
+): AppPermissionStateResult[] {
+  return permissionNames.map(permission => {
+    if (Object.hasOwn(granted, permission)) {
+      return {
+        permission,
+        state: granted[permission] ? "granted" : "denied",
+        source: "androidRuntime" as const,
+        raw: { granted: granted[permission] },
+      };
+    }
+    return {
+      permission,
+      state: "unknown" as const,
+      source: "androidRuntime" as const,
+    };
+  });
+}
+
 export type AppPermissionAction = IosSimulatorPermissionAction;
 
 export interface SetAppPermissionsInput {
@@ -378,21 +408,7 @@ export class AppPermissions {
           appId: normalizedAppId,
           deviceId: this.device.deviceId,
           platform: "android",
-          permissions: permissionNames.map(permission => {
-            if (permission in granted) {
-              return {
-                permission,
-                state: granted[permission] ? "granted" : "denied",
-                source: "androidRuntime" as const,
-                raw: { granted: granted[permission] },
-              };
-            }
-            return {
-              permission,
-              state: "unknown" as const,
-              source: "androidRuntime" as const,
-            };
-          }),
+          permissions: mapAndroidPermissionStates(permissionNames, granted),
         };
       }
     } catch {

--- a/src/features/action/PressButton.ts
+++ b/src/features/action/PressButton.ts
@@ -6,7 +6,7 @@ import { IOSCtrlProxyClient } from "../observe/ios";
 import { AndroidCtrlProxyClient } from "../observe/android";
 import { logger } from "../../utils/logger";
 import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
-import { isNavigationPressButton } from "./pressButtonPolicy";
+import { isNavigationPressButton, resolveAndroidKeyCode } from "./pressButtonPolicy";
 
 export class PressButton extends BaseVisualChange {
   constructor(device: BootedDevice, adb: AdbClient | null = null) {
@@ -85,19 +85,9 @@ export class PressButton extends BaseVisualChange {
   private static readonly GLOBAL_ACTION_TIMEOUT_MS = 3000;
 
   private async executeAndroidButtonPress(button: string, timeoutMs?: number): Promise<PressButtonResult> {
-    const keyCodeMap: Record<string, number> = {
-      "home": 3,
-      "back": 4,
-      "menu": 82,
-      "power": 26,
-      "volume_up": 24,
-      "volume_down": 25,
-      "recent": 187,
-    };
-
     const normalized = button.toLowerCase();
-    const keyCode = keyCodeMap[normalized];
-    if (!keyCode) {
+    const keyCode = resolveAndroidKeyCode(normalized);
+    if (keyCode === undefined) {
       return {
         success: false,
         button,

--- a/src/features/action/pressButtonPolicy.ts
+++ b/src/features/action/pressButtonPolicy.ts
@@ -8,3 +8,29 @@ export function isNavigationPressButton(button: unknown): boolean {
 export function isInPlacePressButton(button: unknown): boolean {
   return typeof button === "string" && IN_PLACE_PRESS_BUTTONS.has(button.toLowerCase());
 }
+
+/**
+ * Android keyevent codes for the supported hardware/navigation buttons.
+ *
+ * Null-prototype map: a `{}` map inherits `Object.prototype`, so a button named
+ * `constructor`/`toString`/`__proto__`/... would read back as the inherited member
+ * (truthy) and slip past the "unsupported button" guard straight into
+ * `shell input keyevent <function Object() { [native code] }>` (issue #4187).
+ */
+const ANDROID_KEY_CODES: Record<string, number> = Object.assign(Object.create(null), {
+  "home": 3,
+  "back": 4,
+  "menu": 82,
+  "power": 26,
+  "volume_up": 24,
+  "volume_down": 25,
+  "recent": 187,
+});
+
+/**
+ * Resolve an Android keyevent code for a button name, or `undefined` when the
+ * button is not supported.
+ */
+export function resolveAndroidKeyCode(button: string): number | undefined {
+  return ANDROID_KEY_CODES[button.toLowerCase()];
+}

--- a/src/server/TopLevelUnionFlattener.ts
+++ b/src/server/TopLevelUnionFlattener.ts
@@ -28,7 +28,11 @@ export function flattenTopLevelUnion(schema: Record<string, unknown>): Record<st
     return schema;
   }
 
-  const mergedProperties: Record<string, unknown> = {};
+  // Null-prototype map: a `{}` here inherits `Object.prototype`, so the
+  // `!mergedProperties[key]` guard below would read the inherited member for a
+  // property named `constructor`/`toString`/`__proto__`/... and merge the real
+  // branch schema into it, silently corrupting the emitted schema (issue #4187).
+  const mergedProperties: Record<string, unknown> = Object.create(null);
   const seenAdditionalProperties = new Set<boolean | undefined>();
   const requiredSets: Set<string>[] = [];
 

--- a/src/server/networkGraph.ts
+++ b/src/server/networkGraph.ts
@@ -126,7 +126,7 @@ export function buildNetworkGraph(
   const result: GraphHost[] = [];
 
   for (const [, { scheme, host, pathGroups }] of hostMap) {
-    const root: Record<string, GraphNode> = {};
+    const root: Record<string, GraphNode> = createPathNode();
 
     for (const [groupKey, groups] of pathGroups) {
       const [path] = groupKey.split("::");
@@ -187,6 +187,17 @@ function stripDurations(node: Record<string, GraphNode>): void {
   }
 }
 
+/**
+ * Path-tree nodes are keyed by URL path segments, which are attacker/app controlled.
+ * A `{}` map inherits `Object.prototype`, so a segment named `constructor`,
+ * `toString`, `__proto__`, ... reads back as the inherited member and the
+ * `!node[key]` guard below never creates the branch — writing `paths` onto the
+ * global `Object` constructor / `Object.prototype` instead (issue #4187).
+ */
+function createPathNode(): Record<string, GraphNode> {
+  return Object.create(null) as Record<string, GraphNode>;
+}
+
 function insertIntoTree(
   node: Record<string, GraphNode>,
   segments: string[],
@@ -230,14 +241,14 @@ function insertIntoTree(
   } else {
     // Branch position
     if (!node[key]) {
-      node[key] = { paths: {} } as GraphBranch;
+      node[key] = { paths: createPathNode() } as GraphBranch;
       if (isParam) {
         (node[key] as GraphBranch).parameterized = true;
       }
     }
     const branch = node[key] as GraphBranch;
     if (!branch.paths) {
-      branch.paths = {};
+      branch.paths = createPathNode();
     }
     insertIntoTree(branch.paths, segments, index + 1, leaf);
   }

--- a/src/server/networkResources.ts
+++ b/src/server/networkResources.ts
@@ -178,6 +178,49 @@ export function bucketEvents(events: NetworkEventWithId[], bucketSeconds: number
   return result.sort((a, b) => a.bucketStart - b.bucketStart);
 }
 
+export interface HostStats {
+  requests: number;
+  errors: number;
+  p50: number;
+  p95: number;
+}
+
+/**
+ * Aggregate per-host request/error counts and latency percentiles.
+ *
+ * The accumulator is a null-prototype map: hosts come off the wire, and a `{}` map
+ * inherits `Object.prototype`, so a host named `constructor`/`toString`/`__proto__`/...
+ * would make the `!byHost[host]` guard read the inherited member (truthy), skip
+ * initialization, and drop that host from the emitted stats (issue #4187).
+ */
+export function aggregateStatsByHost(events: NetworkEventWithId[]): Record<string, HostStats> {
+  const byHost: Record<string, HostStats> = Object.create(null);
+  const durationsByHost: Record<string, number[]> = Object.create(null);
+
+  for (const event of events) {
+    const host = event.host ?? "unknown";
+    if (!byHost[host]) {
+      byHost[host] = { requests: 0, errors: 0, p50: 0, p95: 0 };
+      durationsByHost[host] = [];
+    }
+    byHost[host].requests++;
+    if (event.statusCode >= 400) {
+      byHost[host].errors++;
+    }
+    if (event.durationMs > 0) {
+      durationsByHost[host].push(event.durationMs);
+    }
+  }
+
+  for (const host of Object.keys(byHost)) {
+    const sorted = durationsByHost[host].sort((a, b) => a - b);
+    byHost[host].p50 = Math.round(computePercentile(sorted, 50));
+    byHost[host].p95 = Math.round(computePercentile(sorted, 95));
+  }
+
+  return byHost;
+}
+
 async function handleTrafficQuery(
   params: Record<string, string>
 ): Promise<ResourceContent> {
@@ -339,27 +382,7 @@ export function registerNetworkResources(): void {
       const p50 = Math.round(computePercentile(durations, 50));
       const p95 = Math.round(computePercentile(durations, 95));
 
-      const byHost: Record<string, { requests: number; errors: number; p50: number; p95: number }> = {};
-      const durationsByHost: Record<string, number[]> = {};
-      for (const event of events) {
-        const host = event.host ?? "unknown";
-        if (!byHost[host]) {
-          byHost[host] = { requests: 0, errors: 0, p50: 0, p95: 0 };
-          durationsByHost[host] = [];
-        }
-        byHost[host].requests++;
-        if (event.statusCode >= 400) {
-          byHost[host].errors++;
-        }
-        if (event.durationMs > 0) {
-          durationsByHost[host].push(event.durationMs);
-        }
-      }
-      for (const host of Object.keys(byHost)) {
-        const sorted = durationsByHost[host].sort((a, b) => a - b);
-        byHost[host].p50 = Math.round(computePercentile(sorted, 50));
-        byHost[host].p95 = Math.round(computePercentile(sorted, 95));
-      }
+      const byHost = aggregateStatsByHost(events);
 
       return {
         uri: NETWORK_RESOURCE_URIS.STATS,

--- a/src/server/queryParamValidation.ts
+++ b/src/server/queryParamValidation.ts
@@ -57,7 +57,10 @@ export function optionalBoolean(value: string | undefined, label: string): boole
 
 export function queryParamsToRecord(query: string): Record<string, string> {
   const params = new URLSearchParams(query);
-  const entries: Record<string, string> = {};
+  // Null-prototype map: a `{}` here inherits `Object.prototype`, so a parameter named
+  // `constructor`/`toString`/`__proto__`/... would hit an inherited member and be
+  // rejected as a duplicate on its first occurrence (issue #4187).
+  const entries: Record<string, string> = Object.create(null);
   for (const [key, value] of params.entries()) {
     if (key in entries) {
       throw new Error(`Duplicate query parameter: ${key}`);

--- a/test/features/action/mapAndroidPermissionStates.test.ts
+++ b/test/features/action/mapAndroidPermissionStates.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { mapAndroidPermissionStates } from "../../../src/features/action/AppPermissions";
+
+describe("mapAndroidPermissionStates", () => {
+  test("reports granted and denied runtime permissions", () => {
+    const result = mapAndroidPermissionStates(
+      ["android.permission.CAMERA", "android.permission.RECORD_AUDIO"],
+      { "android.permission.CAMERA": true, "android.permission.RECORD_AUDIO": false }
+    );
+
+    expect(result).toEqual([
+      {
+        permission: "android.permission.CAMERA",
+        state: "granted",
+        source: "androidRuntime",
+        raw: { granted: true },
+      },
+      {
+        permission: "android.permission.RECORD_AUDIO",
+        state: "denied",
+        source: "androidRuntime",
+        raw: { granted: false },
+      },
+    ]);
+  });
+
+  // Issue #4187: `permission in granted` also matches inherited Object.prototype
+  // members, so a bogus permission name reported "granted" (the inherited value is a
+  // truthy function) instead of "unknown".
+  test.each([
+    ["constructor"],
+    ["toString"],
+    ["valueOf"],
+    ["hasOwnProperty"],
+    ["__proto__"],
+    // Control row: an ordinary absent permission must behave identically.
+    ["android.permission.NOT_REPORTED"],
+  ])("reports the absent permission %s as unknown", permission => {
+    expect(mapAndroidPermissionStates([permission], { "android.permission.CAMERA": true }))
+      .toEqual([{ permission, state: "unknown", source: "androidRuntime" }]);
+  });
+});

--- a/test/features/action/pressButtonPolicy.test.ts
+++ b/test/features/action/pressButtonPolicy.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isInPlacePressButton,
+  isNavigationPressButton,
+  resolveAndroidKeyCode
+} from "../../../src/features/action/pressButtonPolicy";
+
+describe("pressButtonPolicy", () => {
+  test("classifies navigation and in-place buttons", () => {
+    expect(isNavigationPressButton("BACK")).toBe(true);
+    expect(isNavigationPressButton("volume_up")).toBe(false);
+    expect(isInPlacePressButton("Menu")).toBe(true);
+    expect(isInPlacePressButton("home")).toBe(false);
+  });
+
+  test.each([
+    ["home", 3],
+    ["back", 4],
+    ["menu", 82],
+    ["power", 26],
+    ["volume_up", 24],
+    ["volume_down", 25],
+    ["recent", 187],
+  ])("resolves %s to keycode %i", (button, expected) => {
+    expect(resolveAndroidKeyCode(button)).toBe(expected);
+    expect(resolveAndroidKeyCode(button.toUpperCase())).toBe(expected);
+  });
+
+  // Issue #4187: the keycode map was a `{}` guarded by `!keyCode`, so a button named
+  // after an `Object.prototype` member resolved to the truthy inherited member and
+  // flowed into `shell input keyevent <function Object() { [native code] }>`.
+  test.each([
+    ["constructor"],
+    ["toString"],
+    ["valueOf"],
+    ["hasOwnProperty"],
+    ["__proto__"],
+    // Control row: an ordinary unsupported button must behave identically.
+    ["definitely_not_a_button"],
+  ])("rejects the prototype-named button %s", button => {
+    expect(resolveAndroidKeyCode(button)).toBeUndefined();
+  });
+});

--- a/test/server/TopLevelUnionFlattener.test.ts
+++ b/test/server/TopLevelUnionFlattener.test.ts
@@ -41,4 +41,43 @@ describe("TopLevelUnionFlattener module", () => {
     // Second branch's requirement is chained via else.
     expect((result.else as any).then).toEqual({ required: ["bOnly"] });
   });
+
+  // Issue #4187: `mergedProperties` was a `{}` map guarded by `!mergedProperties[key]`,
+  // so a union property named after an `Object.prototype` member read back as the
+  // inherited member (truthy) and the real schema was merged into it instead.
+  describe("prototype-named union properties (issue #4187)", () => {
+    test.each([
+      ["constructor"],
+      ["toString"],
+      ["valueOf"],
+      ["hasOwnProperty"],
+      ["__proto__"],
+      // Control row: a normal property name must behave identically.
+      ["normalProp"],
+    ])("flattens a %s property to its real schema", key => {
+      const result = flattenTopLevelUnion({
+        anyOf: [
+          { type: "object", properties: { [key]: { type: "string" } } },
+          { type: "object", properties: { other: { type: "number" } } },
+        ],
+      });
+
+      const properties = result.properties as Record<string, unknown>;
+      expect(Object.prototype.hasOwnProperty.call(properties, key)).toBe(true);
+      expect(properties[key]).toEqual({ type: "string" });
+      expect(properties.other).toEqual({ type: "number" });
+    });
+
+    test("still merges const values of a prototype-named property across branches", () => {
+      const result = flattenTopLevelUnion({
+        anyOf: [
+          { type: "object", properties: { constructor: { const: "a" } } },
+          { type: "object", properties: { constructor: { const: "b" } } },
+        ],
+      });
+
+      const properties = result.properties as Record<string, unknown>;
+      expect(properties.constructor).toEqual({ enum: ["a", "b"] });
+    });
+  });
 });

--- a/test/server/networkGraph.test.ts
+++ b/test/server/networkGraph.test.ts
@@ -176,3 +176,42 @@ describe("buildNetworkGraph", () => {
     expect(postLeaf.p50).toBe(150);
   });
 });
+
+// Issue #4187: the tree used `{}` nodes guarded by `!node[key]`, so a path segment
+// named after an `Object.prototype` member read back as the inherited member
+// (truthy), the branch was never created, and `branch.paths = {}` was written onto
+// the global `Object` constructor instead.
+describe("buildNetworkGraph prototype-named path segments (issue #4187)", () => {
+  const PROTOTYPE_SEGMENTS = ["constructor", "toString", "valueOf", "hasOwnProperty", "__proto__"];
+
+  it.each([...PROTOTYPE_SEGMENTS, "normalSegment"])(
+    "builds a branch for the %s segment without touching Object",
+    segment => {
+      const events = [
+        makeEvent({ url: `https://api.example.com/${segment}/items`, path: `/${segment}/items` }),
+      ];
+
+      const result = buildNetworkGraph(events);
+
+      expect(result.graph).toHaveLength(1);
+      const root = result.graph[0].paths;
+      expect(Object.prototype.hasOwnProperty.call(root, segment)).toBe(true);
+      const branch = root[segment] as GraphBranch;
+      expect(Object.keys(branch.paths)).toEqual(["items[GET]"]);
+      expect((branch.paths["items[GET]"] as GraphLeaf).success).toBe(1);
+      expect((Object as unknown as { paths?: unknown }).paths).toBeUndefined();
+    }
+  );
+
+  it.each([...PROTOTYPE_SEGMENTS, "normalSegment"])(
+    "records a leaf named %s",
+    segment => {
+      const events = [makeEvent({ url: `https://api.example.com/${segment}`, path: `/${segment}` })];
+
+      const result = buildNetworkGraph(events);
+      const root = result.graph[0].paths;
+      expect(Object.prototype.hasOwnProperty.call(root, `${segment}[GET]`)).toBe(true);
+      expect((root[`${segment}[GET]`] as GraphLeaf).success).toBe(1);
+    }
+  );
+});

--- a/test/server/networkResources.test.ts
+++ b/test/server/networkResources.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { bucketEvents } from "../../src/server/networkResources";
+import { aggregateStatsByHost, bucketEvents } from "../../src/server/networkResources";
 import type { NetworkEventWithId } from "../../src/db/networkEventRepository";
 
 function makeEvent(overrides: Partial<NetworkEventWithId> = {}): NetworkEventWithId {
@@ -128,5 +128,33 @@ describe("bucketEvents", () => {
     expect(buckets.length).toBeLessThanOrEqual(1000);
     // The later event should still land in a bucket
     expect(buckets[buckets.length - 1].requests).toBe(1);
+  });
+});
+
+// Issue #4187: `byHost` was a `{}` map guarded by `!byHost[host]`, so a host named
+// after an `Object.prototype` member read back as the inherited member (truthy),
+// initialization was skipped, and the host vanished from the emitted stats.
+describe("aggregateStatsByHost", () => {
+  const PROTOTYPE_HOSTS = ["constructor", "toString", "valueOf", "hasOwnProperty", "__proto__"];
+
+  it.each([...PROTOTYPE_HOSTS, "api.example.com"])("aggregates the %s host", host => {
+    const stats = aggregateStatsByHost([
+      makeEvent({ host, durationMs: 100, statusCode: 200 }),
+      makeEvent({ host, durationMs: 300, statusCode: 500 }),
+    ]);
+
+    expect(Object.prototype.hasOwnProperty.call(stats, host)).toBe(true);
+    expect(stats[host]).toEqual({ requests: 2, errors: 1, p50: 200, p95: 290 });
+  });
+
+  it("keeps separate hosts separate", () => {
+    const stats = aggregateStatsByHost([
+      makeEvent({ host: "constructor", statusCode: 200 }),
+      makeEvent({ host: "api.example.com", statusCode: 404 }),
+    ]);
+
+    expect(Object.keys(stats).sort()).toEqual(["api.example.com", "constructor"]);
+    expect(stats["constructor"].errors).toBe(0);
+    expect(stats["api.example.com"].errors).toBe(1);
   });
 });

--- a/test/server/queryParamValidation.test.ts
+++ b/test/server/queryParamValidation.test.ts
@@ -20,4 +20,32 @@ describe("queryParamValidation", () => {
     expect(() => queryParamsToRecord("limit=1&limit=2")).toThrow("Duplicate query parameter: limit");
     expect(queryParamsToRecord("limit=1&testClass=A")).toEqual({ limit: "1", testClass: "A" });
   });
+
+  // Issue #4187: the duplicate guard used `key in entries` against a `{}` map, so any
+  // key that names an `Object.prototype` member was rejected as a duplicate on its
+  // first (and only) occurrence.
+  describe("prototype-named query parameters", () => {
+    const PROTOTYPE_KEYS = ["constructor", "toString", "valueOf", "hasOwnProperty", "__proto__"];
+
+    test.each([
+      ...PROTOTYPE_KEYS.map(key => [key, `${key}=x`, { [key]: "x" }] as const),
+      // Control row: a normal key must still round-trip.
+      ["normal control key", "limit=1", { limit: "1" }] as const,
+    ])("accepts a single %s parameter", (_label, query, expected) => {
+      const record = queryParamsToRecord(query);
+      expect({ ...record }).toEqual(expected as Record<string, string>);
+    });
+
+    test.each([
+      ...PROTOTYPE_KEYS.map(key => [key, `${key}=x&${key}=y`] as const),
+      // Control row: the duplicate check itself must not have been disabled.
+      ["limit", "limit=1&limit=2"] as const,
+    ])("still rejects a genuine duplicate %s", (key, query) => {
+      expect(() => queryParamsToRecord(query)).toThrow(`Duplicate query parameter: ${key}`);
+    });
+
+    test("returned record does not inherit from Object.prototype", () => {
+      expect(Object.getPrototypeOf(queryParamsToRecord("limit=1"))).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Five lookup maps in `src/` were plain `{}` objects whose membership was tested with
`key in map` or with truthiness of `map[key]`. A `{}` inherits `Object.prototype`, so a
key naming an inherited member — `constructor`, `toString`, `valueOf`, `hasOwnProperty`,
`__proto__` — resolved to that inherited member and the guard took the wrong branch.

Each map is now either null-prototype (`Object.create(null)`) or guarded with an
own-property check. `Object.create(null)` is preferred where the map is a pure
accumulator: it removes the whole class of bug rather than one call site, and none of
these maps has any reason to inherit from `Object.prototype`.

| Site | Before | After |
|---|---|---|
| `src/server/queryParamValidation.ts` — `queryParamsToRecord` | `?constructor=x` threw `Duplicate query parameter: constructor` on its **only** occurrence | null-prototype accumulator; single occurrence accepted, genuine repeats still throw |
| `src/server/TopLevelUnionFlattener.ts` — `flattenTopLevelUnion` | a union property named `constructor` emitted `[class Object]` instead of its schema, silently | null-prototype `mergedProperties` |
| `src/features/action/PressButton.ts` — Android keycode lookup | the `!keyCode` guard did not fire for `"constructor"` (see reachability note below) | keycode map hoisted to `pressButtonPolicy.resolveAndroidKeyCode()` (null-prototype), guard is now `keyCode === undefined` |
| `src/server/networkGraph.ts` — `insertIntoTree` | a URL path segment named `__proto__` wrote `paths` onto `Object.prototype`, after which `stripDurations` recursed until `RangeError: Maximum call stack size exceeded` | all path-tree nodes built via `createPathNode()` (null-prototype) |
| `src/server/networkResources.ts` — per-host stats | a host named `constructor` skipped initialization and vanished from the emitted stats | aggregation extracted to exported `aggregateStatsByHost()` with null-prototype accumulators |
| `src/features/action/AppPermissions.ts` — Android grant map | a caller-supplied permission named `toString` reported `granted` (inherited function is truthy) instead of `unknown` | mapping extracted to exported `mapAndroidPermissionStates()` using `Object.hasOwn` |

### Reachability note on Site 3 (`PressButton`)

The issue describes the prototype-named button reaching `shell input keyevent`. Confirmed
the *mechanism* — `keyCodeMap["constructor"]` is the truthy `Object` constructor and
`!keyCode` does not fire — but **both public entry points already reject it upstream**, so
this one is defense-in-depth rather than a live escape:

- MCP tool: `pressButtonSchema` in `src/server/interactionTools.ts:260` is
  `z.enum(["home","back","menu","power","volume_up","volume_down","recent"])`.
- Daemon socket: `parseInputPressButtonParams` in `src/daemon/socketServer.ts:1296` checks
  an explicit `supportedButtons` allow-list.

Fixing it anyway: the map is the last line of defense before shell argv, and the two
validators are a long way from the lookup. Calling this out so the guard is not mistaken
for a fix to a reachable exploit.

### Sweep-site dispositions

The issue asked that each sweep site be confirmed or dismissed with a test rather than
assumed. All three were **confirmed reachable and fixed**, none dismissed:

- `networkResources.ts:346` — `host` is wire-derived; confirmed the host disappears from
  the stats payload. Fixed.
- `networkGraph.ts:232` — confirmed, and worse than filed: the `__proto__` segment
  pollutes `Object.prototype` globally and hangs the next unrelated call. Fixed.
- `AppPermissions.ts:382` — the issue guessed this was unreachable because Android
  permission strings are dotted. That is true of the *runner-supplied* names, but
  `permissionNames` falls back to `input.permissions`, which is caller-supplied through
  the `getAppPermissions` MCP tool and is not constrained to dotted strings. Confirmed
  reachable and fixed rather than dismissed.

Two of the six fixes required extracting a pure function (`aggregateStatsByHost`,
`mapAndroidPermissionStates`) because the buggy code was inline in a resource callback /
long method and could not otherwise be pinned by a fast unit test. Both extractions are
behaviour-preserving moves.

## Linked Issue

Closes #4187

## Bug / Regression Context

- **Observed symptom:** legitimate single-valued query params rejected as duplicates;
  union schemas emitted with a property replaced by the `Object` constructor; an
  unsupported button name reaching the ADB shell; a host silently dropped from network
  stats; `Object.prototype` polluted by a URL path segment.
- **Repro steps / conditions:** any of these keys named after an `Object.prototype`
  member: `constructor`, `toString`, `valueOf`, `hasOwnProperty`, `__proto__`. Repros
  from the issue body reproduce verbatim on `main`.

## Validation

- [x] `bun run lint` passes
- [x] `bun test` — 8371 pass / 11 skip / 0 fail across 667 files
- [x] New tests verified **red before the fix, green after**. For the three in-place fixes
      (`queryParamValidation`, `TopLevelUnionFlattener`, `networkGraph`) the new
      assertions were run against unmodified source: 24 failures, including the
      `RangeError: Maximum call stack size exceeded` that the `__proto__` path segment
      induces in `stripDurations` — and which then breaks the *next, unrelated* call. For
      the three extracted sites the pre-fix logic was copied verbatim from `92cd3baa5` and
      re-run, confirming: `keyCodeMap["constructor"]` → `function Object() {...}` with the
      `!keyCode` guard not firing; `"toString" in granted` → `granted`; and the
      `constructor` host absent from the emitted `Object.keys(byHost)`
- [x] Every `test.each` table carries a **control row** (a normal key / a normal
      unsupported button / an ordinary absent permission) plus, for the query-param
      site, a genuine-duplicate row — these prove the fix did not simply disable the
      duplicate check
- [x] New code reuses the standard library (`Object.create(null)`, `Object.hasOwn`); no
      new dependency
- [ ] `bun run typecheck` — see below

### Two red checks, both pre-existing on `main`, neither from this PR

This PR touches only `src/server/*.ts`, `src/features/action/*.ts` and their tests — no shell
script, no workflow, no `.bats` file, no iOS/Android runner source.

**`BATS Shell Tests (macos-latest)`** — `test/bats/boot-simulator.bats:73`, "fails when the
product command does not return a deviceId". Tracked by
[#4212](https://github.com/kaeawc/auto-mobile/issues/4212) (`boot-simulator.sh` empty-array
expansion under bash 3.2). The identical test fails on
[#4203](https://github.com/kaeawc/auto-mobile/pull/4203).

**`Node TypeScript Build and Test (ubuntu-latest)`** — the typecheck gate:

`bun run typecheck` fails on `main` and on this branch with the **same single error**, in
a file this PR does not touch:

```
src/daemon/telemetryPushSocketServer.ts: error TS2339: Property 'sessionId' does not
exist on type '{ timestamp: number; type: "crash" | "anr" | "tool_failure"; ... }'
```

It is red on every open PR regardless of contents, and is already tracked by
[#4211](https://github.com/kaeawc/auto-mobile/issues/4211) (root cause: the error *is* in
`scripts/typecheck-baseline.txt:10`, but the `severity` union members render in a different
order than the baseline recorded, so the signature multiset reads it as new),
[#4209](https://github.com/kaeawc/auto-mobile/issues/4209) and
[#4208](https://github.com/kaeawc/auto-mobile/issues/4208). Also red for the same reason on
[#4203](https://github.com/kaeawc/auto-mobile/pull/4203),
[#4204](https://github.com/kaeawc/auto-mobile/pull/4204) and
[#4205](https://github.com/kaeawc/auto-mobile/pull/4205), none of which touch that file
either.

This PR deliberately does **not** paper over it by growing the baseline. It merges once
`main` is green.

### Verified not to change any emitted output

`Object.create(null)` changes the prototype of values that cross serialization
boundaries, so the propagation was swept rather than assumed:

- Regenerating `schemas/tool-definitions.json` produces a **byte-identical** artifact — the
  null-prototype `mergedProperties` serializes the same as before.
- No consumer of any of the five maps calls a prototype method on it: `grep -rn
  "\.hasOwnProperty(" src/` and `grep -rn "instanceof Object" src/` are both empty, and no
  `structuredClone` runs over these values. Downstream use is `Object.keys`, direct property
  reads, and `JSON.stringify`, all of which behave identically on a null-prototype object.

## Device Verification

N/A — pure TypeScript logic, no on-device behaviour change. The `PressButton` change only
tightens which button names are rejected before any ADB command is issued.

## Follow-ups

- [#4214](https://github.com/kaeawc/auto-mobile/issues/4214) — `input/pressButton` accepts
  `"enter"` in its `supportedButtons` allow-list, but neither the Android keycode map nor the
  iOS button sets handle it, so the call always fails after passing validation. Pre-existing
  and unchanged by this PR (the guard moved from `!keyCode` to `keyCode === undefined`, which
  leaves `enter` behaving identically); filed rather than fixed here to keep this PR scoped.
