### PR TITLE
fix(daemon): select session_id in failure backfill projection

### DIFF
--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -7,7 +7,6 @@ src/daemon/manager.ts: error TS18048: 'signal' is possibly 'undefined'.
 src/daemon/performanceStreamSocketServer.ts: error TS2559: Type 'PerformanceStreamSocketRequest' has no properties in common with type 'SocketRequest'.
 src/daemon/socketServer.ts: error TS2322: Type 'unknown' is not assignable to type '{ [x: string]: unknown; } | undefined'.
 src/daemon/socketServer.ts: error TS2554: Expected 1-2 arguments, but got 3.
-src/daemon/telemetryPushSocketServer.ts: error TS2339: Property 'sessionId' does not exist on type '{ timestamp: number; type: "crash" | "anr" | "tool_failure"; title: string; severity: "critical" | "high" | "medium" | "low"; stack_trace_json: string | null; occurrenceId: string; groupId: string; deviceId: string | null; screen: string | null; }'.
 src/daemon/telemetryPushSocketServer.ts: error TS2345: Argument of type '"crash" | "anr" | "nonfatal"' is not assignable to parameter of type 'OperandValueExpressionOrList<Database, "failure_occurrences" | "failure_groups", "failure_groups.type">'.
 src/daemon/testRecordingSocketServer.ts: error TS2322: Type 'string' is not assignable to type 'Platform | undefined'.
 src/daemon/testRecordingSocketServer.ts: error TS2322: Type 'string' is not assignable to type 'Platform | undefined'.
@@ -264,7 +263,6 @@ src/utils/plan/PlanSchemaValidator.ts: error TS1343: The 'import.meta' meta-prop
 # swap-fp: 24,28,49 :: src/features/action/LaunchApp.ts: error TS2339: Property 'getDeviceTimestampMs' does not exist on type 'AdbExecutor'.
 # swap-fp: 25 :: src/daemon/client.ts: error TS2345: Argument of type 'string | NonSharedBuffer' is not assignable to parameter of type 'Buffer<ArrayBufferLike>'.
 # swap-fp: 25,27 :: src/features/action/BaseVisualChange.ts: error TS2339: Property 'getDeviceTimestampMs' does not exist on type 'AdbExecutor'.
-# swap-fp: 26 :: src/daemon/telemetryPushSocketServer.ts: error TS2339: Property 'sessionId' does not exist on type '{ timestamp: number; type: "crash" | "anr" | "tool_failure"; title: string; severity: "critical" | "high" | "medium" | "low"; stack_trace_json: string | null; occurrenceId: string; groupId: string; deviceId: string | null; screen: string | null; }'.
 # swap-fp: 27 :: src/db/migrator.ts: error TS7006: Parameter 'index' implicitly has an 'any' type.
 # swap-fp: 27,45 :: src/db/database.ts: error TS2307: Cannot find module 'bun:sqlite' or its corresponding type declarations.
 # swap-fp: 28 :: src/db/migrations/2026_01_30_000_performance_live_metrics.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'DataTypeExpression'.

--- a/src/daemon/telemetryPushSocketServer.ts
+++ b/src/daemon/telemetryPushSocketServer.ts
@@ -218,6 +218,12 @@ export class TelemetryPushSocketServer extends PushSubscriptionSocketServer<
             "failure_occurrences.group_id as groupId",
             "failure_occurrences.timestamp",
             "failure_occurrences.device_id as deviceId",
+            // Selected so the crash/ANR/tool-failure backfill can report the
+            // originating session like every sibling projection does (#4209).
+            // Without it `r.sessionId` is a type error AND always undefined at
+            // runtime, so these events shipped with `sessionId: null` and were
+            // invisible to session-filtered subscribers.
+            "failure_occurrences.session_id as sessionId",
             "failure_occurrences.screen_at_failure as screen",
             "failure_groups.type",
             "failure_groups.severity",

--- a/test/daemon/telemetryPushSocketServer.test.ts
+++ b/test/daemon/telemetryPushSocketServer.test.ts
@@ -8,6 +8,11 @@ import { boundStructuredField } from "../../src/utils/truncateBodyText";
 import type { TelemetryEvent } from "../../src/features/telemetry/TelemetryRecorder";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeSocket } from "../fakes/FakeNetServer";
+import { withInMemorySingletonDatabase } from "../db/inMemorySingletonDatabase";
+import { getDatabase } from "../../src/db/database";
+import { runMigrations } from "../../src/db/migrator";
+import type { Database } from "../../src/db/types";
+import type { Kysely } from "kysely";
 
 /**
  * Test helper that wraps TelemetryPushSocketServer to allow injecting fake sockets
@@ -469,5 +474,78 @@ describe("TelemetryPushSocketServer", () => {
 
     server.pushTelemetryEvent(event);
     expect(socket.getWrittenMessages()).toHaveLength(1);
+  });
+});
+
+/**
+ * Regression test for issue #4209.
+ *
+ * The crash/ANR/tool-failure branch of `backfillRecentEvents` reads
+ * `r.sessionId`, but its `failure_occurrences` projection did not SELECT
+ * `session_id`. That was simultaneously a `tsc` error (TS2339, which had been
+ * absorbed into the typecheck baseline) and a live runtime bug: the read was
+ * always `undefined`, so every backfilled failure event shipped
+ * `sessionId: null` and was invisible to session-filtered subscribers.
+ *
+ * This pins the projection so the column cannot be dropped from the SELECT
+ * again without a red test.
+ */
+describe("TelemetryPushSocketServer failure backfill (#4209)", () => {
+  it("carries the originating session id on backfilled crash events", async () => {
+    await withInMemorySingletonDatabase(async () => {
+      const db = getDatabase() as unknown as Kysely<Database>;
+      await runMigrations(db as unknown as Kysely<unknown>);
+
+      await db
+        .insertInto("failure_groups")
+        .values({
+          id: "group-1",
+          type: "crash",
+          signature: "sig-1",
+          title: "NullPointerException",
+          message: "boom",
+          severity: "critical",
+          first_occurrence: 1000,
+          last_occurrence: 1000,
+          total_count: 1,
+          unique_sessions: 1,
+          stack_trace_json: null,
+          tool_call_info_json: null,
+        })
+        .execute();
+
+      await db
+        .insertInto("failure_occurrences")
+        .values({
+          id: "occ-1",
+          group_id: "group-1",
+          timestamp: 1000,
+          device_id: "emulator-5554",
+          device_model: "Pixel",
+          os: "34",
+          app_version: "1.0.0",
+          session_id: "session-abc",
+          screen_at_failure: "MainActivity",
+          test_name: null,
+          test_execution_id: null,
+          error_code: null,
+          duration_ms: null,
+          tool_args_json: null,
+        })
+        .execute();
+
+      const server = new TestableTelemetryPushSocketServer(new FakeTimer());
+      const socket = new FakeSocket();
+
+      await (server as any).backfillRecentEvents(
+        { category: "crash", deviceId: "emulator-5554", sessionId: null },
+        socket as unknown as Socket
+      );
+
+      const messages = socket.getWrittenMessages<{ data: TelemetryEvent }>();
+      const crash = messages.find(m => m.data.category === "crash");
+      expect(crash).toBeDefined();
+      expect(crash!.data.sessionId).toBe("session-abc");
+    });
   });
 });


### PR DESCRIPTION
## Summary

`main` was red on the typecheck baseline gate, so `Node TypeScript Build and Test (ubuntu-latest)` failed on every open PR regardless of its contents.

The crash/ANR/tool-failure branch of `backfillRecentEvents` reads `r.sessionId`, but its `failure_occurrences` projection never selected `session_id`. That was two defects at once:

1. **A type error** — `TS2339: Property 'sessionId' does not exist on ...` (the symptom that blocked CI).
2. **A live runtime bug** — the read was always `undefined`, so `sessionId: r.sessionId ?? null` made *every* backfilled crash/ANR/tool-failure event ship `sessionId: null`. Since `matchesFilter` filters on `sessionId`, those events were invisible to any session-filtered subscriber. Every sibling projection (network, log, os, navigation, storage, layout) already carried the session id; this branch silently did not.

The fix adds `failure_occurrences.session_id as sessionId` to the select. `session_id` is a non-null `string` column that already exists on the table (`src/db/types.ts`), so there is no migration and no schema change.

`scripts/typecheck-baseline.txt` was **not** grown. Two now-obsolete lines were *removed* from it (the signature and its `# swap-fp:` companion), which is a ratchet-down.

### Why the baseline was only trimmed by hand, not regenerated

`bun run typecheck:update` on macOS wants to drop 10 further signatures that no longer reproduce locally. Those are stale entries unrelated to this change, and regenerating from a single platform risks deleting entries that *do* still fire on ubuntu CI — which would turn them into NEW errors and put the gate right back to red. So only the two lines this PR provably eliminates were removed. The remaining stale entries are left for a deliberate ratchet pass.

## Linked Issue

Closes #4208

## Bug / Regression Context

- **Prior attempts:** none; `src/daemon/telemetryPushSocketServer.ts` was last touched by #3275, well before the PRs it started blocking.
- **Observed symptom:** `Run Typecheck Gate` fails with one NEW error; `Run Build` and `Run Tests with Coverage` are skipped behind it, so the job never reaches the tests.
- **Repro steps:** `git worktree add /tmp/mainchk origin/main && cd /tmp/mainchk && bun install --frozen-lockfile && bun run typecheck`

## Scope: this PR is the #4208 half only

Three issues were filed for this one red gate. Two are real and **complementary**; they explain different halves, and each needs its own fix:

- **#4208 — this PR.** The TS2339 is a *genuine* type error and a genuine runtime bug. `failure_occurrences.session_id` exists in the schema but was never selected, so `r.sessionId` was always `undefined` and every backfilled failure event shipped `sessionId: null`.
- **#4211 — separate PR.** The gate's signature normalizer is **order-sensitive over union members**, so a reordered union reads as a brand-new error while the identical baselined one reads as fixed. Being fixed independently; a daemon/telemetry behavior change does not belong in a CI-normalizer fix.
- **#4209 — closed as a duplicate** of the two above.

**Verified for whoever tracks #4211:** the delta between the baselined signature and what `tsc` renders now is *exclusively* union member order — every other character is identical. Baseline recorded `severity: "critical" | "high" | "medium" | "low"`; `tsc 6.0.3` now renders `severity: "high" | "medium" | "critical" | "low"`. Canonicalizing union order makes the two strings equal.

**Also verified, per the #4211 question:** fixing #4208 *does* independently remove the baseline entry — the error stops being emitted at all, on every platform, so the signature is genuinely obsolete rather than merely re-rendered. This PR therefore deletes those two baseline lines (the signature and its `# swap-fp:` companion). That is a ratchet-*down*, not growth. The #4211 normalizer fix does not need to touch the baseline file and will not conflict here.

## Cross-runner divergence finding

#4209 asked why the gate reportedly passes on `windows-latest` but fails on `ubuntu-latest` and locally on macOS. **It is not a platform, TS-resolution, case-sensitivity, or lockfile difference — the gate never runs on Windows at all.**

There are two similarly-named jobs in `.github/workflows/pull_request.yml`:

| Job id | Displayed name | Runners | Has `Run Typecheck Gate`? |
| --- | --- | --- | --- |
| `mcp-build-and-test` | `Node TypeScript Build and Test (${{ matrix.os }})` | `macos-latest`, `windows-latest` | **No** |
| `ts-code-coverage` | `Node TypeScript Build and Test (ubuntu-latest)` | `ubuntu-latest` | **Yes** |

`bun run typecheck` appears exactly once in the whole workflow directory, in `ts-code-coverage`. Windows is "green" because it has no such step. This is intentional (the step comment says it runs "on this single ubuntu job with the pinned tsc so the baseline is reproducible"), so no CI change is made here — but the two jobs sharing a name pattern makes the split very easy to misread. Left as an observation rather than a change.

The *genuine* cross-machine instability is the union-ordering issue tracked in #4211, which is machine-dependent rather than OS-dependent.

## Validation

- [x] `bun test` — 8312 pass, 11 skip, **0 fail** across 665 files
- [x] `bun run lint` — clean
- [x] `bun run typecheck` reports no new errors (baseline gate) — `✅ no new type errors (224 known error(s) in baseline)`
- [x] New test verified **red before / green after**: without the fix it fails on `expect(crash.data.sessionId).toBe("session-abc")`; the whole file runs in ~178ms
- [x] New code uses interfaces + fakes + FakeTimer; the new test uses `withInMemorySingletonDatabase` and never resolves the real file-backed `getDatabase()`
- [ ] Android/iOS changes: N/A
- [ ] New dependencies: none

## Testing

Added `TelemetryPushSocketServer failure backfill (#4209)` to `test/daemon/telemetryPushSocketServer.test.ts`. It seeds a `failure_groups` + `failure_occurrences` row in an in-memory singleton DB, drives `backfillRecentEvents` with a `FakeSocket` and `FakeTimer`, and asserts the backfilled crash event carries `sessionId: "session-abc"`. This pins the runtime behaviour, not just the type — the column cannot be dropped from the SELECT again without a red test.
