### PR TITLE
fix(ci): make empty-array expansions bash 3.2 safe under set -u

### DIFF
--- a/scripts/all_fast_validate_checks.sh
+++ b/scripts/all_fast_validate_checks.sh
@@ -79,7 +79,7 @@ split_csv() {
   if [[ -n "$value" ]]; then
     IFS=',' read -r -a items <<< "$value"
   fi
-  echo "${items[@]}"
+  echo ${items[@]+"${items[@]}"}
 }
 
 contains_item() {
@@ -103,7 +103,7 @@ groups_intersect() {
     IFS=',' read -r -a check_group_list <<< "$check_groups"
   fi
   local group
-  for group in "${check_group_list[@]}"; do
+  for group in ${check_group_list[@]+"${check_group_list[@]}"}; do
     if contains_item "$group" "${selected_groups[@]}"; then
       return 0
     fi
@@ -220,7 +220,7 @@ for idx in "${!CHECK_NAMES[@]}"; do
     fi
   elif [[ -n "${group_list[*]-}" ]]; then
     include=0
-    if groups_intersect "$groups" "${group_list[@]}"; then
+    if groups_intersect "$groups" ${group_list[@]+"${group_list[@]}"}; then
       include=1
     fi
   fi

--- a/scripts/all_fast_validate_checks.sh
+++ b/scripts/all_fast_validate_checks.sh
@@ -191,7 +191,7 @@ fi
 
 if [[ -n "${only_list[*]-}" ]]; then
   for requested in "${only_list[@]}"; do
-    if ! contains_item "$requested" "${CHECK_NAMES[@]}"; then
+    if ! contains_item "$requested" ${CHECK_NAMES[@]+"${CHECK_NAMES[@]}"}; then
       echo "Unknown check in --only: $requested" >&2
       exit 1
     fi
@@ -200,7 +200,7 @@ fi
 
 if [[ -n "${skip_list[*]-}" ]]; then
   for requested in "${skip_list[@]}"; do
-    if ! contains_item "$requested" "${CHECK_NAMES[@]}"; then
+    if ! contains_item "$requested" ${CHECK_NAMES[@]+"${CHECK_NAMES[@]}"}; then
       echo "Unknown check in --skip: $requested" >&2
       exit 1
     fi
@@ -320,7 +320,7 @@ prune_finished_jobs() {
   # in-flight jobs drain (#3650).
   if [[ ${#new_pids[@]} -gt 0 ]]; then
     pids=("${new_pids[@]}")
-    pid_names=("${new_names[@]}")
+    pid_names=(${new_names[@]+"${new_names[@]}"})
   else
     pids=()
     pid_names=()
@@ -337,12 +337,12 @@ wait_for_slot() {
   done
 }
 
-for idx in "${selected_indices[@]}"; do
+for idx in ${selected_indices[@]+"${selected_indices[@]}"}; do
   wait_for_slot "$max_parallel"
   start_check "$idx"
 done
 
-for pid in "${pids[@]}"; do
+for pid in ${pids[@]+"${pids[@]}"}; do
   wait "$pid" || true
 done
 
@@ -353,7 +353,7 @@ echo "======================="
 passed=0
 failed=0
 
-for idx in "${selected_indices[@]}"; do
+for idx in ${selected_indices[@]+"${selected_indices[@]}"}; do
   name="${CHECK_NAMES[$idx]}"
   status_file="$run_dir/${name}.status"
   start_file="$run_dir/${name}.start"

--- a/scripts/avd_experiments.sh
+++ b/scripts/avd_experiments.sh
@@ -44,7 +44,7 @@ done < <(rg -o "system-images;android-[0-9]+;${tag};${abi}" "$list_log" | sort -
 declare -a requested_packages=()
 for api in $(seq "$start_api" "$end_api"); do
   pkg="system-images;android-${api};${tag};${abi}"
-  if printf '%s\n' "${available_packages[@]}" | rg -q "^${pkg}$"; then
+  if printf '%s\n' ${available_packages[@]+"${available_packages[@]}"} | rg -q "^${pkg}$"; then
     requested_packages+=("$pkg")
   fi
 done

--- a/scripts/ci/measure-ci.sh
+++ b/scripts/ci/measure-ci.sh
@@ -366,7 +366,7 @@ fetch_bundle() {
   [ -n "$BRANCH" ] && run_args+=(--branch "$BRANCH")
 
   echo "Fetching up to ${LIMIT} \"${WORKFLOW}\" runs..." >&2
-  gh run list "${run_args[@]}" \
+  gh run list ${run_args[@]+"${run_args[@]}"} \
     --json databaseId,number,headSha,headBranch,event,status,conclusion,attempt,createdAt,updatedAt \
     | jq -c '[ .[] | {
         id: .databaseId,

--- a/scripts/ci/validate-ios-swift.sh
+++ b/scripts/ci/validate-ios-swift.sh
@@ -83,7 +83,7 @@ echo "Validation Summary"
 echo "========================================="
 echo ""
 echo "Passed: ${#PASSED_COMPONENTS[@]}"
-for component in "${PASSED_COMPONENTS[@]}"; do
+for component in ${PASSED_COMPONENTS[@]+"${PASSED_COMPONENTS[@]}"}; do
   echo "  ✓ ${component}"
 done
 echo ""

--- a/scripts/ci/validate_workflow_assertion_triggers.sh
+++ b/scripts/ci/validate_workflow_assertion_triggers.sh
@@ -96,7 +96,7 @@ filter_entries="$(
 # glob and the path sits directly under that dir. Inlined (rather than a helper
 # invoked in an `if`) so `set -e` stays armed and no SC2310 suppression is added.
 missing=()
-for path in "${asserted_paths[@]}"; do
+for path in ${asserted_paths[@]+"${asserted_paths[@]}"}; do
   covered=0
   while IFS= read -r entry; do
     [[ -z "$entry" ]] && continue

--- a/scripts/clean-env-uninstall.sh
+++ b/scripts/clean-env-uninstall.sh
@@ -330,7 +330,7 @@ remove_homebrew_packages() {
         return 0
     fi
 
-    for pkg in "${installed[@]}"; do
+    for pkg in ${installed[@]+"${installed[@]}"}; do
         run_cmd brew uninstall --ignore-dependencies "${pkg}" || true
     done
 

--- a/scripts/ide-plugin/install_from_source.sh
+++ b/scripts/ide-plugin/install_from_source.sh
@@ -103,7 +103,7 @@ restart_ide_macos() {
     if [[ "${#matches[@]}" -eq 1 ]]; then
       app_name="${matches[0]}"
     elif [[ "${#matches[@]}" -gt 1 ]]; then
-      app_name="$(select_from_list "Multiple IDEs are running. Which should be restarted?" "${matches[@]}")"
+      app_name="$(select_from_list "Multiple IDEs are running. Which should be restarted?" ${matches[@]+"${matches[@]}"})"
     fi
   fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1206,41 +1206,41 @@ install_gum_linux() {
 
     if command_exists apt-get; then
         plain_info "Installing gum with apt-get..."
-        if ! "${sudo_cmd[@]}" apt-get update; then
+        if ! ${sudo_cmd[@]+"${sudo_cmd[@]}"} apt-get update; then
             plain_warn "apt-get update failed; falling back to manual gum install."
             return 1
         fi
-        if "${sudo_cmd[@]}" apt-get install -y gum; then
+        if ${sudo_cmd[@]+"${sudo_cmd[@]}"} apt-get install -y gum; then
             return 0
         fi
         plain_warn "apt-get install failed; falling back to manual gum install."
     elif command_exists dnf; then
         plain_info "Installing gum with dnf..."
-        if "${sudo_cmd[@]}" dnf install -y gum; then
+        if ${sudo_cmd[@]+"${sudo_cmd[@]}"} dnf install -y gum; then
             return 0
         fi
         plain_warn "dnf install failed; falling back to manual gum install."
     elif command_exists yum; then
         plain_info "Installing gum with yum..."
-        if "${sudo_cmd[@]}" yum install -y gum; then
+        if ${sudo_cmd[@]+"${sudo_cmd[@]}"} yum install -y gum; then
             return 0
         fi
         plain_warn "yum install failed; falling back to manual gum install."
     elif command_exists pacman; then
         plain_info "Installing gum with pacman..."
-        if "${sudo_cmd[@]}" pacman -S --noconfirm gum; then
+        if ${sudo_cmd[@]+"${sudo_cmd[@]}"} pacman -S --noconfirm gum; then
             return 0
         fi
         plain_warn "pacman install failed; falling back to manual gum install."
     elif command_exists zypper; then
         plain_info "Installing gum with zypper..."
-        if "${sudo_cmd[@]}" zypper --non-interactive install gum; then
+        if ${sudo_cmd[@]+"${sudo_cmd[@]}"} zypper --non-interactive install gum; then
             return 0
         fi
         plain_warn "zypper install failed; falling back to manual gum install."
     elif command_exists apk; then
         plain_info "Installing gum with apk..."
-        if "${sudo_cmd[@]}" apk add --no-cache gum; then
+        if ${sudo_cmd[@]+"${sudo_cmd[@]}"} apk add --no-cache gum; then
             return 0
         fi
         plain_warn "apk install failed; falling back to manual gum install."
@@ -3816,7 +3816,7 @@ install_bun() {
             # Multiple options - show choose menu with Skip option
             options+=("Skip")
             local choice
-            choice=$(printf '%s\n' "${options[@]}" | gum choose --header "How would you like to install Bun?")
+            choice=$(printf '%s\n' ${options[@]+"${options[@]}"} | gum choose --header "How would you like to install Bun?")
 
             if [[ -z "${choice}" || "${choice}" == "Skip" ]]; then
                 log_info "Skipped Bun installation"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -220,7 +220,7 @@ show_installation_progress() {
 
     local index=1
     local step
-    for step in "${INSTALL_STEPS[@]}"; do
+    for step in ${INSTALL_STEPS[@]+"${INSTALL_STEPS[@]}"}; do
         if [[ "${index}" -eq "${CURRENT_INSTALL_STEP}" ]]; then
             gum style --bold --foreground 212 "  ${index}. → ${step}"
         else
@@ -671,7 +671,7 @@ print_dry_run_summary() {
     echo ""
 
     local i=1
-    for action in "${DRY_RUN_LOG[@]}"; do
+    for action in ${DRY_RUN_LOG[@]+"${DRY_RUN_LOG[@]}"}; do
         # Strip [DRY-RUN] prefix for cleaner output
         local clean_action="${action#\[DRY-RUN\] }"
         printf '  %d. %s\n' "${i}" "${clean_action}"
@@ -877,7 +877,7 @@ offer_android_home_shell_setup() {
     options+=("Skip (I'll set it manually)")
 
     local choice
-    choice=$(printf '%s\n' "${options[@]}" | gum choose --header "Add ANDROID_HOME to shell profile?")
+    choice=$(printf '%s\n' ${options[@]+"${options[@]}"} | gum choose --header "Add ANDROID_HOME to shell profile?")
 
     if [[ -z "${choice}" || "${choice}" == "Skip (I'll set it manually)" ]]; then
         log_info "Skipped ANDROID_HOME shell setup"
@@ -1556,7 +1556,7 @@ detect_mcp_clients() {
 
 # Get list of detected client names for display
 get_detected_client_names() {
-    for entry in "${MCP_CLIENT_LIST[@]}"; do
+    for entry in ${MCP_CLIENT_LIST[@]+"${MCP_CLIENT_LIST[@]}"}; do
         echo "${entry}" | cut -d'|' -f1
     done | sort
 }
@@ -1571,7 +1571,7 @@ find_client_entry() {
         return 1
     fi
 
-    for entry in "${MCP_CLIENT_LIST[@]}"; do
+    for entry in ${MCP_CLIENT_LIST[@]+"${MCP_CLIENT_LIST[@]}"}; do
         local entry_name
         entry_name=$(echo "${entry}" | cut -d'|' -f1)
         if [[ "${entry_name}" == "${name}" ]]; then
@@ -1694,7 +1694,7 @@ select_mcp_clients() {
                 ;;
             "Update existing configurations to use @latest")
                 # Select all clients that have auto-mobile for update
-                SELECTED_MCP_CLIENTS=("${clients_with_auto_mobile[@]}")
+                SELECTED_MCP_CLIENTS=(${clients_with_auto_mobile[@]+"${clients_with_auto_mobile[@]}"})
                 log_info "Will update ${#SELECTED_MCP_CLIENTS[@]} existing configuration(s)"
                 return 0
                 ;;
@@ -2308,7 +2308,7 @@ configure_selected_mcp_clients() {
     gum style --bold "Configuring AutoMobile with the ${config_preset} setup"
     echo ""
 
-    for client in "${SELECTED_MCP_CLIENTS[@]}"; do
+    for client in ${SELECTED_MCP_CLIENTS[@]+"${SELECTED_MCP_CLIENTS[@]}"}; do
         local config_path
         config_path=$(get_client_config_path "${client}")
         local format
@@ -2430,7 +2430,7 @@ run_auto_mobile_cli() {
         return 1
     fi
 
-    "${AUTO_MOBILE_CMD[@]}" --cli "$@"
+    ${AUTO_MOBILE_CMD[@]+"${AUTO_MOBILE_CMD[@]}"} --cli "$@"
 }
 
 extract_device_ids() {
@@ -2774,7 +2774,7 @@ migrate_stale_daemon() {
 
     local restart_output
     local restart_status=0
-    restart_output=$("${AUTO_MOBILE_CMD[@]}" --daemon restart 2>&1) || restart_status=$?
+    restart_output=$(${AUTO_MOBILE_CMD[@]+"${AUTO_MOBILE_CMD[@]}"} --daemon restart 2>&1) || restart_status=$?
 
     if [[ ${restart_status} -ne 0 ]]; then
         log_warn "Daemon restart failed. You may need to restart manually:"
@@ -2804,7 +2804,7 @@ start_mcp_daemon() {
 
     local daemon_output
     local daemon_status=0
-    daemon_output=$("${AUTO_MOBILE_CMD[@]}" --daemon start 2>&1) || daemon_status=$?
+    daemon_output=$(${AUTO_MOBILE_CMD[@]+"${AUTO_MOBILE_CMD[@]}"} --daemon start 2>&1) || daemon_status=$?
 
     if [[ ${daemon_status} -ne 0 ]]; then
         # Check for corrupted migrations error
@@ -2843,7 +2843,7 @@ start_mcp_daemon() {
 
                     # Retry daemon start (reset status first)
                     daemon_status=0
-                    daemon_output=$("${AUTO_MOBILE_CMD[@]}" --daemon start 2>&1) || daemon_status=$?
+                    daemon_output=$(${AUTO_MOBILE_CMD[@]+"${AUTO_MOBILE_CMD[@]}"} --daemon start 2>&1) || daemon_status=$?
                     if [[ ${daemon_status} -ne 0 ]]; then
                         log_error "Failed to start MCP daemon after database reset:"
                         echo "${daemon_output}"
@@ -2864,7 +2864,7 @@ start_mcp_daemon() {
 
     local health_output
     local health_status=0
-    health_output=$("${AUTO_MOBILE_CMD[@]}" --daemon health 2>&1) || health_status=$?
+    health_output=$(${AUTO_MOBILE_CMD[@]+"${AUTO_MOBILE_CMD[@]}"} --daemon health 2>&1) || health_status=$?
 
     if [[ ${health_status} -ne 0 ]]; then
         log_error "Daemon health check failed:"
@@ -3015,7 +3015,7 @@ _install_dev_tools_brew() {
     # processes would contend for the same lock. One invocation avoids repeated
     # startup work and lets Homebrew schedule the complete dependency set.
     local brew_status=0
-    if run_spinner "Installing ${#to_install[@]} development tools" brew install "${to_install[@]}"; then
+    if run_spinner "Installing ${#to_install[@]} development tools" brew install ${to_install[@]+"${to_install[@]}"}; then
         :
     else
         brew_status=$?
@@ -3086,7 +3086,7 @@ _install_dev_tools_apt() {
     sudo apt-get update -qq 2>/dev/null || true
 
     local missing=0
-    for pkg in "${to_install[@]}"; do
+    for pkg in ${to_install[@]+"${to_install[@]}"}; do
         if sudo apt-get install -y -qq "${pkg}" >/dev/null 2>&1; then
             CHANGES_MADE=true
         else
@@ -3941,7 +3941,7 @@ apply_preset() {
 client_base_has_config() {
     local base_name="$1"
     detect_mcp_clients
-    for entry in "${MCP_CLIENT_LIST[@]}"; do
+    for entry in ${MCP_CLIENT_LIST[@]+"${MCP_CLIENT_LIST[@]}"}; do
         local entry_name
         entry_name=$(echo "${entry}" | cut -d'|' -f1)
         if [[ "${entry_name}" == "${base_name}"* ]]; then
@@ -4017,7 +4017,7 @@ select_preset() {
             choice=$(printf '%s\n' "${available_clients}" | head -1)
         fi
     else
-        choice=$(printf '%s\n' "${options[@]}" | gum filter --header "Select installation preset:" --placeholder "Type to filter...") || true
+        choice=$(printf '%s\n' ${options[@]+"${options[@]}"} | gum filter --header "Select installation preset:" --placeholder "Type to filter...") || true
     fi
 
     # Handle Ctrl+C or empty selection - exit script
@@ -4388,7 +4388,7 @@ main() {
         fi
 
         if [[ "${need_platform_choice}" == "true" ]]; then
-            platform_choice=$(printf '%s\n' "${platform_options[@]}" | gum choose --header "Platform setup:")
+            platform_choice=$(printf '%s\n' ${platform_options[@]+"${platform_options[@]}"} | gum choose --header "Platform setup:")
             # Normalize skip choices
             if [[ "${platform_choice}" == Skip* ]]; then
                 platform_choice="Skip platform setup"
@@ -4429,7 +4429,7 @@ main() {
             # User selected a specific AI agent - auto-configure matching clients
             detect_mcp_clients
             local matching_clients=()
-            for entry in "${MCP_CLIENT_LIST[@]}"; do
+            for entry in ${MCP_CLIENT_LIST[@]+"${MCP_CLIENT_LIST[@]}"}; do
                 local entry_name
                 entry_name=$(echo "${entry}" | cut -d'|' -f1)
                 # Match clients that start with the filter (e.g., "Cursor" matches "Cursor (Global)")

--- a/scripts/ios/boot-simulator.sh
+++ b/scripts/ios/boot-simulator.sh
@@ -31,7 +31,10 @@ if [[ "${GITHUB_ACTIONS:-}" == "true" && "${CI:-}" == "true" ]]; then
   if [[ -n "${ios_version}" ]]; then
     ci_args+=(--ios-version "${ios_version}")
   fi
-  ci_args+=("${ci_extra[@]}")
+  # `${arr[@]+"${arr[@]}"}` keeps an empty ci_extra expanding to nothing under
+  # `set -u` on bash 3.2 (the macos-latest runner's /bin/bash), where a bare
+  # "${ci_extra[@]}" aborts with "unbound variable" (#4212).
+  ci_args+=(${ci_extra[@]+"${ci_extra[@]}"})
   result="$(cd "${repo_root}" && bun run src/ci/bootIosSimulatorCli.ts "${ci_args[@]}")"
 else
   if [[ -z "${ios_version}" ]]; then

--- a/scripts/ios/sign-macos-products.sh
+++ b/scripts/ios/sign-macos-products.sh
@@ -78,7 +78,7 @@ sign_package() {
 sign_package "XcodeCompanion" "AutoMobileCompanion" "true"
 sign_package "XcodeExtension" "" "false"
 
-for artifact in "${sign_paths[@]}"; do
+for artifact in ${sign_paths[@]+"${sign_paths[@]}"}; do
   echo "Signing ${artifact}"
   codesign "${CODESIGN_ARGS[@]}" "${artifact}"
   codesign --verify --strict --verbose=2 "${artifact}"

--- a/scripts/ios/xcodegen-drift-check.sh
+++ b/scripts/ios/xcodegen-drift-check.sh
@@ -112,6 +112,6 @@ if [ "${SCOPE}" = "--ctrl-proxy" ]; then
 else
     echo "Run scripts/ios/xcodegen-generate.sh and commit the regenerated project files." >&2
 fi
-git status --short -- "${REAL_DRIFT_PATHS[@]}" >&2
-git diff -- "${REAL_DRIFT_PATHS[@]}" >&2
+git status --short -- ${REAL_DRIFT_PATHS[@]+"${REAL_DRIFT_PATHS[@]}"} >&2
+git diff -- ${REAL_DRIFT_PATHS[@]+"${REAL_DRIFT_PATHS[@]}"} >&2
 exit 1

--- a/scripts/launch_app_perf_test.sh
+++ b/scripts/launch_app_perf_test.sh
@@ -419,7 +419,7 @@ main() {
     local max_time=${all_durations[0]}
     local sum_time=0
 
-    for duration in "${all_durations[@]}"; do
+    for duration in ${all_durations[@]+"${all_durations[@]}"}; do
         [[ $duration -lt $min_time ]] && min_time=$duration
         [[ $duration -gt $max_time ]] && max_time=$duration
         sum_time=$((sum_time + duration))

--- a/scripts/local-dev/hot-reload.sh
+++ b/scripts/local-dev/hot-reload.sh
@@ -166,14 +166,14 @@ kill_ctrl_proxy_ios_xcodebuild_processes() {
     log_info "Killing CtrlProxy iOS xcodebuild processes: ${pids[*]}"
   fi
 
-  for pid in "${pids[@]}"; do
+  for pid in ${pids[@]+"${pids[@]}"}; do
     kill "${pid}" 2>/dev/null || true
   done
 
   sleep 2
 
   local still_running=()
-  for pid in "${pids[@]}"; do
+  for pid in ${pids[@]+"${pids[@]}"}; do
     if kill -0 "${pid}" 2>/dev/null; then
       still_running+=("${pid}")
     fi
@@ -253,10 +253,10 @@ reload_mcp_daemon() {
     # Run daemon restart in background with timeout to prevent hanging
     local daemon_log="${PROJECT_ROOT}/scratch/daemon-restart.log"
     if [[ "${should_skip_ios_build}" == "true" ]]; then
-      env AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD=true "${daemon_env[@]}" \
+      env AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD=true ${daemon_env[@]+"${daemon_env[@]}"} \
         auto-mobile --daemon restart --debug --debug-perf > "${daemon_log}" 2>&1 &
     else
-      env "${daemon_env[@]}" \
+      env ${daemon_env[@]+"${daemon_env[@]}"} \
         auto-mobile --daemon restart --debug --debug-perf > "${daemon_log}" 2>&1 &
     fi
     local daemon_pid=$!

--- a/scripts/local-dev/probe-android-locale.sh
+++ b/scripts/local-dev/probe-android-locale.sh
@@ -191,7 +191,7 @@ if [[ -z "${ADB_SERIAL}" ]]; then
       [[ -n "${arg}" ]] || continue
       extra_emulator_args+=("${arg}")
     done <<< "${EMULATOR_ARGS}"
-    emulator_args_array+=("${extra_emulator_args[@]}")
+    emulator_args_array+=(${extra_emulator_args[@]+"${extra_emulator_args[@]}"})
   fi
   "${EMULATOR_BIN}" -avd "${AVD_NAME}" -port "${EMULATOR_PORT}" "${emulator_args_array[@]}" >/tmp/auto-mobile-locale-probe-emulator.log 2>&1 &
   EMULATOR_PID="$!"

--- a/scripts/local-dev/probe-biometric-enrollment.sh
+++ b/scripts/local-dev/probe-biometric-enrollment.sh
@@ -240,7 +240,7 @@ if [[ -z "${ADB_SERIAL}" ]]; then
       [[ -n "${arg}" ]] || continue
       extra_emulator_args+=("${arg}")
     done <<< "${EMULATOR_ARGS}"
-    emulator_args_array+=("${extra_emulator_args[@]}")
+    emulator_args_array+=(${extra_emulator_args[@]+"${extra_emulator_args[@]}"})
   fi
   "${EMULATOR_BIN}" -avd "${AVD_NAME}" -port "${EMULATOR_PORT}" "${emulator_args_array[@]}" \
     > /tmp/auto-mobile-biometric-probe-emulator.log 2>&1 &

--- a/scripts/local/validate-ios.sh
+++ b/scripts/local/validate-ios.sh
@@ -186,7 +186,7 @@ echo ""
 
 echo "Build Results:"
 echo "  Passed: ${#PASSED_BUILDS[@]}"
-for component in "${PASSED_BUILDS[@]}"; do
+for component in ${PASSED_BUILDS[@]+"${PASSED_BUILDS[@]}"}; do
   echo "    ✓ ${component}"
 done
 echo ""

--- a/scripts/shellcheck/validate_shell_portability.sh
+++ b/scripts/shellcheck/validate_shell_portability.sh
@@ -97,15 +97,27 @@ scan "bare-python" \
 # cannot reuse the line-oriented `scan` helper above.
 # shellcheck disable=SC2016 # awk program: $0/$NR are awk fields, not shell.
 EMPTY_ARRAY_AWK='
-{ lines[NR] = $0 }
-# `set -u` has several spellings, and every one of them arms nounset:
-#   compact/split flag groups — `set -u`, `set -eu`, `set -euo pipefail`,
-#   `set -e -u -o pipefail`; and the long form `set -o nounset`.
-# Matching only /set -[a-z]*u/ missed the last two, leaving those files
-# unscanned entirely (they reported zero violations rather than being skipped
-# loudly, which is why the gap was invisible).
-/(^|[ \t;])set[ \t]+[^#]*-o[ \t]+nounset([ \t]|;|$)/ { setu = 1 }
-/(^|[ \t;])set[ \t]+([^#]*[ \t])?-[a-zA-Z]*u[a-zA-Z]*([ \t]|;|$)/ { setu = 1 }
+{
+  lines[NR] = $0
+  # `set -u` has several spellings, and every one of them arms nounset:
+  #   compact/split flag groups — `set -u`, `set -eu`, `set -euo pipefail`,
+  #   `set -e -u -o pipefail`; and the long form `set -o nounset`.
+  # Matching only /set -[a-z]*u/ missed the last two, leaving those files
+  # unscanned entirely (they reported zero violations rather than being
+  # skipped loudly, which is why the gap was invisible).
+  #
+  # Match against the CODE only. Prose mentioning `set -u` — including the
+  # rule documentation in this very file — must not arm the scan, or the rule
+  # flags valid expansions in scripts bash would run happily.
+  codeline = $0
+  if (codeline ~ /^[ \t]*#/) {
+    codeline = ""
+  } else {
+    sub(/[ \t]+#.*$/, "", codeline)
+  }
+  if (codeline ~ /(^|[ \t;])set[ \t]+[^#]*-o[ \t]+nounset([ \t]|;|$)/) { setu = 1 }
+  if (codeline ~ /(^|[ \t;])set[ \t]+([^#]*[ \t])?-[a-zA-Z]*u[a-zA-Z]*([ \t]|;|$)/) { setu = 1 }
+}
 # Function-definition boundaries. An early-out in one function says nothing
 # about an expansion in another, so guards may not cross one of these lines.
 # Deliberately NOT anchored to end-of-line: a whole single-line definition
@@ -154,13 +166,41 @@ function is_positive_length_guard(line, name) {
 
 # `if [ ${#arr[@]} -eq 0 ]; then return; fi` is an early-out: everything after
 # it is reached only when the array is non-empty. Returns 1 when line k opens
-# such a block and it leaves the scope within the next few lines.
-function is_empty_early_out(lines, nlines, k, name,   j) {
+# such a block AND the branch taken when the array is empty is the one that
+# leaves scope.
+#
+# The exit must live in the THEN branch. Accepting any `return`/`exit` within
+# the next few lines credited this:
+#   if [[ ${#items[@]} -eq 0 ]]; then echo none; else return 0; fi
+# where the empty case falls through to the unsafe expansion and crashes on
+# bash 3.2. So the scan stops dead at `else`/`elif`/`fi`.
+function is_empty_early_out(lines, nlines, k, name,   j, seg, cut) {
   if (!index(lines[k], "${#" name "[@]}")) { return 0 }
   if (lines[k] !~ /-eq[ \t]+0/ && lines[k] !~ /-lt[ \t]+1/ && lines[k] !~ /==[ \t]*0/) { return 0 }
   if (lines[k] !~ /(^|[ \t;])(if|elif)[ \t]/ && lines[k] !~ /&&/) { return 0 }
   for (j = k; j <= k + 3 && j <= nlines; j++) {
-    if (lines[j] ~ /(^|[ \t;])(return|exit|continue|break)([ \t;]|$)/) { return 1 }
+    seg = lines[j]
+    # On the opening line, only what follows `then` is inside the then-branch;
+    # the test itself may legitimately contain the word `exit` in a message.
+    if (j == k) {
+      cut = index(seg, "; then")
+      if (cut > 0) {
+        seg = substr(seg, cut + 6)
+      } else {
+        cut = index(seg, " then ")
+        if (cut > 0) { seg = substr(seg, cut + 5) } else { seg = "" }
+      }
+    }
+    # `else`/`elif` ends the then-branch: anything past it runs in the
+    # NON-empty case. Truncate and make this the last segment considered.
+    if (match(seg, /(^|[ \t;])(else|elif)([ \t;]|$)/)) {
+      seg = substr(seg, 1, RSTART - 1)
+      if (seg ~ /(^|[ \t;])(return|exit|continue|break)([ \t;]|$)/) { return 1 }
+      return 0
+    }
+    if (seg ~ /(^|[ \t;])(return|exit|continue|break)([ \t;]|$)/) { return 1 }
+    # `fi` closes the construct without an exit — not an early-out.
+    if (seg ~ /(^|[ \t;])fi([ \t;]|$)/) { return 0 }
   }
   return 0
 }

--- a/scripts/shellcheck/validate_shell_portability.sh
+++ b/scripts/shellcheck/validate_shell_portability.sh
@@ -99,12 +99,46 @@ scan "bare-python" \
 EMPTY_ARRAY_AWK='
 { lines[NR] = $0 }
 /set -[a-z]*u/ { setu = 1 }
-match($0, /^[ \t]*(local[ \t]+)?[A-Za-z_][A-Za-z0-9_]*=\(\)[ \t]*$/) {
+# Empty-array declarations, including the typed forms: `arr=()`,
+# `local arr=()`, `local -a arr=()`, `declare -A arr=()`, `typeset -a arr=()`.
+match($0, /^[ \t]*((local|declare|typeset)[ \t]+(-[aAgilnrtux]+[ \t]+)*)?[A-Za-z_][A-Za-z0-9_]*=\(\)[ \t]*$/) {
   decl = $0
   sub(/^[ \t]*/, "", decl)
-  sub(/^local[ \t]+/, "", decl)
+  sub(/^(local|declare|typeset)[ \t]+/, "", decl)
+  while (decl ~ /^-[aAgilnrtux]+[ \t]+/) { sub(/^-[aAgilnrtux]+[ \t]+/, "", decl) }
   sub(/=\(\)[ \t]*$/, "", decl)
   arrays[decl] = 1
+}
+
+# A `${#arr[@]}` mention only counts as a guard when it is a positive-sense
+# length test that opens a block — an `-eq 0` early-out or a bare count in a
+# message guards nothing.
+function is_positive_length_guard(line, name) {
+  if (index(line, "${#" name "[@]}")) {
+    if (line ~ /-eq[ \t]+0/ || line ~ /-lt[ \t]+1/ || line ~ /==[ \t]*0/) { return 0 }
+    if (line !~ /(^|[ \t;])(if|elif|while|until)[ \t]/ && line !~ /&&/) { return 0 }
+    if (line ~ /-gt[ \t]+0/ || line ~ /-ge[ \t]+1/ || line ~ /-ne[ \t]+0/) { return 1 }
+    if (line ~ /\(\([^)]*\$\{#/) { return 1 }
+    return 0
+  }
+  # `[[ -n "${arr[*]-}" ]]` is the other non-empty test used in this repo.
+  if (line ~ /-n[ \t]+"?\$\{/ && (index(line, "${" name "[*]-}") || index(line, "${" name "[@]-}"))) {
+    return 1
+  }
+  return 0
+}
+
+# `if [ ${#arr[@]} -eq 0 ]; then return; fi` is an early-out: everything after
+# it is reached only when the array is non-empty. Returns 1 when line k opens
+# such a block and it leaves the scope within the next few lines.
+function is_empty_early_out(lines, nlines, k, name,   j) {
+  if (!index(lines[k], "${#" name "[@]}")) { return 0 }
+  if (lines[k] !~ /-eq[ \t]+0/ && lines[k] !~ /-lt[ \t]+1/ && lines[k] !~ /==[ \t]*0/) { return 0 }
+  if (lines[k] !~ /(^|[ \t;])(if|elif)[ \t]/ && lines[k] !~ /&&/) { return 0 }
+  for (j = k; j <= k + 3 && j <= nlines; j++) {
+    if (lines[j] ~ /(^|[ \t;])(return|exit|continue|break)([ \t;]|$)/) { return 1 }
+  }
+  return 0
 }
 END {
   if (!setu) { exit }
@@ -118,7 +152,15 @@ END {
       if (index(line, "${" name "[@]+")) { continue }
       guarded = 0
       for (k = n - 9; k < n; k++) {
-        if (k >= 1 && index(lines[k], "${#" name "[@]}")) { guarded = 1 }
+        if (k < 1) { continue }
+        # A block terminator between the guard and the expansion means the
+        # guard has already closed and no longer covers this line.
+        if (lines[k] ~ /^[ \t]*(fi|else|elif|done|esac|\})([ \t]|;|$)/) { guarded = 0; continue }
+        if (is_positive_length_guard(lines[k], name)) { guarded = 1 }
+      }
+      # An empty-array early-out anywhere above in the same scope also covers it.
+      for (k = 1; k < n && !guarded; k++) {
+        if (is_empty_early_out(lines, NR, k, name)) { guarded = 1 }
       }
       if (guarded) { continue }
       text = line

--- a/scripts/shellcheck/validate_shell_portability.sh
+++ b/scripts/shellcheck/validate_shell_portability.sh
@@ -98,16 +98,40 @@ scan "bare-python" \
 # shellcheck disable=SC2016 # awk program: $0/$NR are awk fields, not shell.
 EMPTY_ARRAY_AWK='
 { lines[NR] = $0 }
-/set -[a-z]*u/ { setu = 1 }
+# `set -u` has several spellings, and every one of them arms nounset:
+#   compact/split flag groups — `set -u`, `set -eu`, `set -euo pipefail`,
+#   `set -e -u -o pipefail`; and the long form `set -o nounset`.
+# Matching only /set -[a-z]*u/ missed the last two, leaving those files
+# unscanned entirely (they reported zero violations rather than being skipped
+# loudly, which is why the gap was invisible).
+/(^|[ \t;])set[ \t]+[^#]*-o[ \t]+nounset([ \t]|;|$)/ { setu = 1 }
+/(^|[ \t;])set[ \t]+([^#]*[ \t])?-[a-zA-Z]*u[a-zA-Z]*([ \t]|;|$)/ { setu = 1 }
+# Function-definition boundaries. An early-out in one function says nothing
+# about an expansion in another, so guards may not cross one of these lines.
+# Deliberately NOT anchored to end-of-line: a whole single-line definition
+# (`use() { printf "%s\n" "${items[@]}"; }`) is still a boundary.
+/^[ \t]*(function[ \t]+)?[A-Za-z_][A-Za-z0-9_:.-]*[ \t]*\(\)[ \t]*(\{|$)/ { fnstart[NR] = 1 }
+/^[ \t]*function[ \t]+[A-Za-z_][A-Za-z0-9_:.-]*[ \t]*\{/ { fnstart[NR] = 1 }
 # Empty-array declarations, including the typed forms: `arr=()`,
 # `local arr=()`, `local -a arr=()`, `declare -A arr=()`, `typeset -a arr=()`.
-match($0, /^[ \t]*((local|declare|typeset)[ \t]+(-[aAgilnrtux]+[ \t]+)*)?[A-Za-z_][A-Za-z0-9_]*=\(\)[ \t]*$/) {
+# A trailing comment (`items=() # optional args`) is a normal initializer and
+# must still register the array.
+match($0, /^[ \t]*((local|declare|typeset)[ \t]+(-[aAgilnrtux]+[ \t]+)*)?[A-Za-z_][A-Za-z0-9_]*=\(\)[ \t]*(#.*)?$/) {
   decl = $0
   sub(/^[ \t]*/, "", decl)
   sub(/^(local|declare|typeset)[ \t]+/, "", decl)
   while (decl ~ /^-[aAgilnrtux]+[ \t]+/) { sub(/^-[aAgilnrtux]+[ \t]+/, "", decl) }
-  sub(/=\(\)[ \t]*$/, "", decl)
+  sub(/=\(\)[ \t]*(#.*)?$/, "", decl)
   arrays[decl] = 1
+}
+
+# True when a function definition starts strictly between lines a and b, i.e.
+# the two lines cannot be proven to sit on the same lexical path.
+function crosses_function(a, b,   j) {
+  for (j = a + 1; j <= b; j++) {
+    if (fnstart[j]) { return 1 }
+  }
+  return 0
 }
 
 # A `${#arr[@]}` mention only counts as a guard when it is a positive-sense
@@ -156,10 +180,15 @@ END {
         # A block terminator between the guard and the expansion means the
         # guard has already closed and no longer covers this line.
         if (lines[k] ~ /^[ \t]*(fi|else|elif|done|esac|\})([ \t]|;|$)/) { guarded = 0; continue }
+        if (crosses_function(k, n)) { continue }
         if (is_positive_length_guard(lines[k], name)) { guarded = 1 }
       }
-      # An empty-array early-out anywhere above in the same scope also covers it.
+      # An empty-array early-out above also covers this expansion, but ONLY on
+      # the same lexical path. Scanning the whole file let a `return` inside one
+      # function excuse an unguarded expansion inside another, which is exactly
+      # the bash 3.2 crash this rule exists to catch.
       for (k = 1; k < n && !guarded; k++) {
+        if (crosses_function(k, n)) { continue }
         if (is_empty_early_out(lines, NR, k, name)) { guarded = 1 }
       }
       if (guarded) { continue }
@@ -171,16 +200,38 @@ END {
 }
 '
 
+scanner_errors=0
+
 while IFS= read -r file; do
+  # Fail CLOSED: `awk ... || true` turned a scanner crash into "no matches",
+  # so a broken or missing awk left this gate reporting success while it had
+  # scanned nothing at all. Capture the status and surface the diagnostic
+  # instead of discarding it down /dev/null.
+  awk_out=$(awk "$EMPTY_ARRAY_AWK" "$file" 2>&1)
+  awk_status=$?
+  if [ "$awk_status" -ne 0 ]; then
+    printf '%s[scanner-error]%s %s\n    awk exited %s while scanning this file\n    %s%s%s\n' \
+      "$RED" "$NC" "$file" "$awk_status" "$YELLOW" "$awk_out" "$NC" >&2
+    scanner_errors=$((scanner_errors + 1))
+    continue
+  fi
+  [ -z "$awk_out" ] && continue
   while IFS=: read -r lineno text; do
     [ -z "$lineno" ] && continue
     # shellcheck disable=SC2016 # literal hint text, not a shell expansion.
     report "empty-array-set-u" "$file" "$lineno" "$text" \
       'Bash 3.2 aborts on an empty "${arr[@]}" under set -u — use ${arr[@]+"${arr[@]}"}.'
-  done < <(awk "$EMPTY_ARRAY_AWK" "$file" 2>/dev/null || true)
+  done <<EOF
+$awk_out
+EOF
 done < <(find "${ROOTS[@]}" -name '*.sh' -type f ! -name 'validate_shell_portability.sh' 2>/dev/null | sort)
 
 echo ""
+if [ "$scanner_errors" -gt 0 ]; then
+  echo "${RED}The empty-array scanner failed on ${scanner_errors} file(s); results are incomplete.${NC}" >&2
+  echo "This is a gate failure, not a clean scan — fix the scanner before trusting a green run." >&2
+  exit 2
+fi
 if [ "$violations" -gt 0 ]; then
   echo "${RED}Found ${violations} shell-portability issue(s).${NC}" >&2
   echo "Fix them, or add '# portability-ok' on the line if it is a genuine exception." >&2

--- a/scripts/shellcheck/validate_shell_portability.sh
+++ b/scripts/shellcheck/validate_shell_portability.sh
@@ -20,6 +20,12 @@
 #                      the last redirect wins. (#3648)
 #   bare-python        A bare `python` invocation (not python3) — absent on
 #                      ubuntu-latest / modern macOS. (#3657)
+#   empty-array-set-u  `"${arr[@]}"` for an array that can be empty, under
+#                      `set -u`. Bash 3.2 (/bin/bash on macos-latest) aborts
+#                      with "unbound variable"; 4.4+ special-cases it, so the
+#                      bug is invisible on Linux and locally. Use
+#                      `${arr[@]+"${arr[@]}"}` or an explicit
+#                      `[ ${#arr[@]} -gt 0 ]` guard. (#3651, #4212)
 #
 # Usage: scripts/shellcheck/validate_shell_portability.sh [dir ...]
 set -uo pipefail
@@ -85,6 +91,52 @@ scan "append-then-stderr" \
 scan "bare-python" \
   '(^|[;&|(]|\$\()[[:space:]]*python([[:space:]]|$)' \
   'Use python3 — bare python is absent on ubuntu-latest / modern macOS.'
+
+# The empty-array rule needs whole-file context (which arrays are initialized
+# empty, and whether a nearby `${#arr[@]}` guard covers the expansion), so it
+# cannot reuse the line-oriented `scan` helper above.
+# shellcheck disable=SC2016 # awk program: $0/$NR are awk fields, not shell.
+EMPTY_ARRAY_AWK='
+{ lines[NR] = $0 }
+/set -[a-z]*u/ { setu = 1 }
+match($0, /^[ \t]*(local[ \t]+)?[A-Za-z_][A-Za-z0-9_]*=\(\)[ \t]*$/) {
+  decl = $0
+  sub(/^[ \t]*/, "", decl)
+  sub(/^local[ \t]+/, "", decl)
+  sub(/=\(\)[ \t]*$/, "", decl)
+  arrays[decl] = 1
+}
+END {
+  if (!setu) { exit }
+  for (n = 1; n <= NR; n++) {
+    line = lines[n]
+    if (line ~ /^[ \t]*#/) { continue }
+    if (index(line, "portability-ok")) { continue }
+    for (name in arrays) {
+      unsafe = "${" name "[@]}"
+      if (!index(line, unsafe)) { continue }
+      if (index(line, "${" name "[@]+")) { continue }
+      guarded = 0
+      for (k = n - 9; k < n; k++) {
+        if (k >= 1 && index(lines[k], "${#" name "[@]}")) { guarded = 1 }
+      }
+      if (guarded) { continue }
+      text = line
+      sub(/^[ \t]*/, "", text)
+      printf "%d:%s\n", n, text
+    }
+  }
+}
+'
+
+while IFS= read -r file; do
+  while IFS=: read -r lineno text; do
+    [ -z "$lineno" ] && continue
+    # shellcheck disable=SC2016 # literal hint text, not a shell expansion.
+    report "empty-array-set-u" "$file" "$lineno" "$text" \
+      'Bash 3.2 aborts on an empty "${arr[@]}" under set -u — use ${arr[@]+"${arr[@]}"}.'
+  done < <(awk "$EMPTY_ARRAY_AWK" "$file" 2>/dev/null || true)
+done < <(find "${ROOTS[@]}" -name '*.sh' -type f ! -name 'validate_shell_portability.sh' 2>/dev/null | sort)
 
 echo ""
 if [ "$violations" -gt 0 ]; then

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -208,7 +208,7 @@ detect_mcp_configs() {
     configs+=("Goose|${HOME}/.config/goose/config.yaml|yaml")
 
     # Check each config for auto-mobile entries
-    for entry in "${configs[@]}"; do
+    for entry in ${configs[@]+"${configs[@]}"}; do
         local name path format
         name=$(echo "${entry}" | cut -d'|' -f1)
         path=$(echo "${entry}" | cut -d'|' -f2)
@@ -597,7 +597,7 @@ select_components() {
     echo ""
 
     local selected
-    selected=$(printf '%s\n' "${options[@]}" | gum filter --no-limit --placeholder "Type to filter, SPACE to select...") || true
+    selected=$(printf '%s\n' ${options[@]+"${options[@]}"} | gum filter --no-limit --placeholder "Type to filter, SPACE to select...") || true
 
     if [[ -z "${selected}" ]]; then
         log_info "No components selected"
@@ -650,7 +650,7 @@ confirm_uninstall() {
     echo ""
 
     if [[ "${UNINSTALL_MCP_CONFIGS}" == "true" ]]; then
-        for entry in "${MCP_CONFIGS_FOUND[@]}"; do
+        for entry in ${MCP_CONFIGS_FOUND[@]+"${MCP_CONFIGS_FOUND[@]}"}; do
             local name path
             name=$(echo "${entry}" | cut -d'|' -f1)
             path=$(echo "${entry}" | cut -d'|' -f2)

--- a/test/bats/boot-simulator.bats
+++ b/test/bats/boot-simulator.bats
@@ -62,13 +62,55 @@ MOCK
   rm -f "$args_file"
 }
 
-@test "fails when the product command does not return a deviceId" {
+@test "fails when the CI product command does not return a deviceId" {
   cat > "${MOCK_BIN}/bun" <<'MOCK'
 #!/usr/bin/env bash
 printf '%s\n' '{}'
 MOCK
   chmod +x "${MOCK_BIN}/bun"
-  run bash "$SCRIPT"
+  # Pin CI/GITHUB_ACTIONS instead of inheriting the runner's: under real GitHub
+  # Actions an unpinned case silently exercises whichever branch the runner's
+  # environment selects (#4212).
+  run env CI=true GITHUB_ACTIONS=true bash "$SCRIPT"
   [ "$status" -eq 1 ]
   [[ "$output" == *"returned no deviceId"* ]]
+}
+
+@test "fails when the local product command does not return a deviceId" {
+  cat > "${MOCK_BIN}/bun" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' '{}'
+MOCK
+  cat > "${MOCK_BIN}/xcrun" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' '26.5'
+MOCK
+  chmod +x "${MOCK_BIN}/bun"
+  chmod +x "${MOCK_BIN}/xcrun"
+  run env CI= GITHUB_ACTIONS= bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"returned no deviceId"* ]]
+}
+
+@test "CI branch survives an empty optional-arg array on bash 3.2" {
+  # /bin/bash is 3.2 on macOS (and on the macos-latest runner), where an empty
+  # "${arr[@]}" under set -u aborts with "unbound variable". Bash 4.4+
+  # special-cases it, so this regression is invisible on the ubuntu legs.
+  if ! /bin/bash -c 'set -u; a=(); b=(x "${a[@]}")' 2>/dev/null; then
+    :
+  else
+    skip "/bin/bash already special-cases empty array expansion (bash >= 4.4)"
+  fi
+  cat > "${MOCK_BIN}/bun" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$BUN_ARGS_FILE"
+printf '%s\n' '{"deviceId":"CI-UDID"}'
+MOCK
+  chmod +x "${MOCK_BIN}/bun"
+  args_file="$(mktemp)"
+  run env CI=true GITHUB_ACTIONS=true BUN_ARGS_FILE="$args_file" /bin/bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$output" = "CI-UDID" ]
+  [[ "$(<"$args_file")" == *"src/ci/bootIosSimulatorCli.ts"* ]]
+  rm -f "$args_file"
 }

--- a/test/bats/validate-shell-portability.bats
+++ b/test/bats/validate-shell-portability.bats
@@ -253,3 +253,91 @@ FIXTURE
   run bash "$ABS" "$FIX"
   [ "$status" -eq 0 ]
 }
+
+# --- Regression coverage for four fail-open gaps found in review of #4212. ---
+# Every one of these made the validator report success while the bash 3.2
+# crash it exists to catch went undetected. A gate that fails open is worse
+# than no gate, so each gap gets a test that fails if the hole reopens.
+
+@test "detects nounset armed via 'set -o nounset'" {
+  write_lines bad <<'FIXTURE'
+#!/usr/bin/env bash
+set -o nounset
+items=()
+printf '%s\n' "${items[@]}"
+FIXTURE
+  run bash "$ABS" "$FIX"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"empty-array-set-u"* ]]
+}
+
+@test "detects nounset armed via split flags 'set -e -u -o pipefail'" {
+  write_lines bad <<'FIXTURE'
+#!/usr/bin/env bash
+set -e -u -o pipefail
+items=()
+printf '%s\n' "${items[@]}"
+FIXTURE
+  run bash "$ABS" "$FIX"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"empty-array-set-u"* ]]
+}
+
+@test "an early-out in one function does not excuse an expansion in another" {
+  write_lines bad <<'FIXTURE'
+#!/usr/bin/env bash
+set -euo pipefail
+items=()
+guard() { if [[ ${#items[@]} -eq 0 ]]; then return 0; fi; }
+use() { printf '%s\n' "${items[@]}"; }
+FIXTURE
+  run bash "$ABS" "$FIX"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"empty-array-set-u"* ]]
+}
+
+@test "records an empty-array declaration carrying a trailing comment" {
+  write_lines bad <<'FIXTURE'
+#!/usr/bin/env bash
+set -euo pipefail
+items=() # optional args
+printf '%s\n' "${items[@]}"
+FIXTURE
+  run bash "$ABS" "$FIX"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"empty-array-set-u"* ]]
+}
+
+@test "fails closed when the awk scanner itself errors" {
+  write_lines bad <<'FIXTURE'
+#!/usr/bin/env bash
+set -euo pipefail
+extra=()
+printf '%s\n' "${extra[@]}"
+FIXTURE
+  FAKEBIN="$(mktemp -d)"
+  printf '#!/bin/sh\nexit 2\n' > "$FAKEBIN/awk"
+  chmod +x "$FAKEBIN/awk"
+  PATH="$FAKEBIN:$PATH" run bash "$ABS" "$FIX"
+  rm -rf "$FAKEBIN"
+  # Must NOT be 0. A scanner crash is a gate failure, not a clean scan.
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"scanner-error"* ]]
+}
+
+@test "still does NOT flag a same-function early-out (no false positive)" {
+  write_lines ok <<'FIXTURE'
+#!/usr/bin/env bash
+set -euo pipefail
+f() {
+  local found=()
+  if [[ ${#found[@]} -eq 0 ]]; then
+    return 0
+  fi
+  printf '%s\n' "${found[@]}"
+}
+f
+FIXTURE
+  run bash "$ABS" "$FIX"
+  [ "$status" -eq 0 ]
+}

--- a/test/bats/validate-shell-portability.bats
+++ b/test/bats/validate-shell-portability.bats
@@ -86,3 +86,83 @@ write() { printf '%s\n' "$2" > "$FIX/$1.sh"; }
   run bash "$ABS" "$FIX"
   [ "$status" -eq 0 ]
 }
+
+# --- empty-array-set-u (#4212) --------------------------------------------
+# These fixtures need more than one line (a `set -u`, an empty array init and
+# an expansion), so they use a stdin heredoc rather than the `write` helper.
+write_lines() { cat > "$FIX/$1.sh"; }
+
+@test "flags a bare empty-array expansion under set -u" {
+  write_lines bad <<'FIXTURE'
+#!/usr/bin/env bash
+set -euo pipefail
+extra=()
+cmd=(run)
+cmd+=("${extra[@]}")
+FIXTURE
+  run bash "$ABS" "$FIX"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"empty-array-set-u"* ]]
+}
+
+@test "flags an empty-array expansion in a for loop under set -u" {
+  write_lines bad <<'FIXTURE'
+#!/usr/bin/env bash
+set -euo pipefail
+items=()
+for i in "${items[@]}"; do echo "$i"; done
+FIXTURE
+  run bash "$ABS" "$FIX"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"empty-array-set-u"* ]]
+}
+
+@test "does NOT flag the \${arr[@]+\"\${arr[@]}\"} bash 3.2 safe form" {
+  write_lines ok <<'FIXTURE'
+#!/usr/bin/env bash
+set -euo pipefail
+extra=()
+cmd=(run)
+cmd+=(${extra[@]+"${extra[@]}"})
+FIXTURE
+  run bash "$ABS" "$FIX"
+  [ "$status" -eq 0 ]
+}
+
+@test "does NOT flag an expansion guarded by a nearby \${#arr[@]} check" {
+  write_lines ok <<'FIXTURE'
+#!/usr/bin/env bash
+set -euo pipefail
+extra=()
+cmd=(run)
+if [ "${#extra[@]}" -gt 0 ]; then
+  cmd+=("${extra[@]}")
+fi
+FIXTURE
+  run bash "$ABS" "$FIX"
+  [ "$status" -eq 0 ]
+}
+
+@test "does NOT flag an empty-array expansion when set -u is not enabled" {
+  write_lines ok <<'FIXTURE'
+#!/usr/bin/env bash
+set -eo pipefail
+extra=()
+cmd=(run)
+cmd+=("${extra[@]}")
+FIXTURE
+  run bash "$ABS" "$FIX"
+  [ "$status" -eq 0 ]
+}
+
+@test "respects a # portability-ok suppression on an empty-array expansion" {
+  write_lines ok <<'FIXTURE'
+#!/usr/bin/env bash
+set -euo pipefail
+extra=()
+cmd=(run)
+cmd+=("${extra[@]}") # portability-ok
+FIXTURE
+  run bash "$ABS" "$FIX"
+  [ "$status" -eq 0 ]
+}

--- a/test/bats/validate-shell-portability.bats
+++ b/test/bats/validate-shell-portability.bats
@@ -341,3 +341,42 @@ FIXTURE
   run bash "$ABS" "$FIX"
   [ "$status" -eq 0 ]
 }
+
+@test "an else-branch exit is not an empty-array early-out" {
+  write_lines bad <<'FIXTURE'
+#!/usr/bin/env bash
+set -euo pipefail
+items=()
+if [[ ${#items[@]} -eq 0 ]]; then echo none; else return 0; fi
+printf '%s\n' "${items[@]}"
+FIXTURE
+  run bash "$ABS" "$FIX"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"empty-array-set-u"* ]]
+}
+
+@test "does NOT arm the rule when set -u appears only in a comment" {
+  write_lines ok <<'FIXTURE'
+#!/usr/bin/env bash
+# mentions set -u only
+items=()
+printf '%s\n' "${items[@]}"
+FIXTURE
+  run bash "$ABS" "$FIX"
+  [ "$status" -eq 0 ]
+}
+
+@test "still credits a single-line then-branch early-out (no false positive)" {
+  write_lines ok <<'FIXTURE'
+#!/usr/bin/env bash
+set -euo pipefail
+g() {
+  local xs=()
+  if [[ ${#xs[@]} -eq 0 ]]; then return 0; fi
+  printf '%s\n' "${xs[@]}"
+}
+g
+FIXTURE
+  run bash "$ABS" "$FIX"
+  [ "$status" -eq 0 ]
+}

--- a/test/bats/validate-shell-portability.bats
+++ b/test/bats/validate-shell-portability.bats
@@ -166,3 +166,90 @@ FIXTURE
   run bash "$ABS" "$FIX"
   [ "$status" -eq 0 ]
 }
+
+@test "flags a typed 'declare -a' empty-array declaration" {
+  write_lines bad <<'FIXTURE'
+#!/usr/bin/env bash
+set -euo pipefail
+declare -a extra=()
+cmd=(run "${extra[@]}")
+FIXTURE
+  run bash "$ABS" "$FIX"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"empty-array-set-u"* ]]
+}
+
+@test "flags a typed 'local -a' empty-array declaration" {
+  write_lines bad <<'FIXTURE'
+#!/usr/bin/env bash
+set -euo pipefail
+f() {
+  local -a extra=()
+  printf '%s\n' "${extra[@]}"
+}
+f
+FIXTURE
+  run bash "$ABS" "$FIX"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"empty-array-set-u"* ]]
+}
+
+@test "flags an expansion after an inverse \${#arr[@]} check that guards nothing" {
+  write_lines bad <<'FIXTURE'
+#!/usr/bin/env bash
+set -euo pipefail
+extra=()
+if [[ "${#extra[@]}" -eq 0 ]]; then
+  echo none
+fi
+cmd=(run "${extra[@]}")
+FIXTURE
+  run bash "$ABS" "$FIX"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"empty-array-set-u"* ]]
+}
+
+@test "flags an expansion after a positive guard block has already closed" {
+  write_lines bad <<'FIXTURE'
+#!/usr/bin/env bash
+set -euo pipefail
+extra=()
+if [[ "${#extra[@]}" -gt 0 ]]; then
+  echo some
+fi
+cmd=(run "${extra[@]}")
+FIXTURE
+  run bash "$ABS" "$FIX"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"empty-array-set-u"* ]]
+}
+
+@test "does NOT flag an expansion after an empty-array early return" {
+  write_lines ok <<'FIXTURE'
+#!/usr/bin/env bash
+set -euo pipefail
+f() {
+  local found=()
+  if [[ ${#found[@]} -eq 0 ]]; then
+    return 0
+  fi
+  printf '%s\n' "${found[@]}"
+}
+f
+FIXTURE
+  run bash "$ABS" "$FIX"
+  [ "$status" -eq 0 ]
+}
+
+@test "does NOT flag an expansion guarded by a -n \${arr[*]-} test" {
+  write_lines ok <<'FIXTURE'
+#!/usr/bin/env bash
+set -euo pipefail
+only_list=()
+if [[ -n "${only_list[*]-}" ]]; then
+  for requested in "${only_list[@]}"; do echo "$requested"; done
+fi
+FIXTURE
+  run bash "$ABS" "$FIX"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

`scripts/ios/boot-simulator.sh` expanded a possibly-empty array (`ci_extra`) under
`set -u`. Bash 3.2 — which is `/bin/bash` on the `macos-latest` runner — treats
`"${empty[@]}"` under `set -u` as an unbound variable and aborts; bash 4.4+
special-cases it, so the bug is invisible on the ubuntu legs and on any modern
local bash. That redded `BATS Shell Tests (macos-latest)` and the `Shell Tests`
roll-up on `main`, blocking PRs with no shell changes at all.

Rather than patching only line 38, this sweeps `scripts/` for the same class and
adds a lint rule so it cannot come back:

- **Fix:** 42 unsafe expansions across 15 scripts now use the repo's existing
  bash-3.2-safe idiom `${arr[@]+"${arr[@]}"}` (already used in
  `scripts/android/start-emulator-wtf-session.sh` and
  `scripts/validate_codex_skills.sh` after the same bug class in #3651). The form
  is a no-op on bash >= 4.4, so behaviour is unchanged everywhere it already
  worked. Notably this also affected `scripts/install.sh` and
  `scripts/uninstall.sh`, which run under a stock macOS `/bin/bash` 3.2 for users
  without Homebrew bash.
- **Guard:** new `empty-array-set-u` rule in
  `scripts/shellcheck/validate_shell_portability.sh` (the existing portability
  footgun lint, already wired into Fast Validation via
  `scripts/all_fast_validate_checks.sh`). It flags any expansion of an
  empty-initialized array in a `set -u` file that is neither written in the safe
  form, nor covered by a nearby `${#arr[@]}` guard, nor suppressed with
  `# portability-ok`. The rule needs whole-file context, so it is an `awk` pass
  rather than the line-oriented `scan` helper.
- **Test env pinning:** `test/bats/boot-simulator.bats` had a case that did not
  clear `CI`/`GITHUB_ACTIONS`, so under real GitHub Actions it silently took the
  CI branch instead of the local one it was written for. It is now split into two
  cases that pin their own environment and cover both branches deterministically.

## Linked Issue

Closes #4212

## Bug / Regression Context

- **Prior attempts:** #3651 fixed two instances of this class by hand; no lint
  rule was added, so #4199 reintroduced it in a new script.
- **Observed symptom:** `BATS Shell Tests (macos-latest)` red on `main`;
  `boot-simulator.sh` exits non-zero with `ci_extra[@]: unbound variable`.
- **Repro steps / conditions:**
  ```sh
  /bin/bash -c 'set -euo pipefail; a=(); b=(x "${a[@]}")'
  # /bin/bash: a[@]: unbound variable
  ```

## Validation

- [x] `shellcheck` clean on every changed script (`validate_shell_scripts.sh`:
      "All shell scripts are valid")
- [x] `scripts/shellcheck/validate_shell_portability.sh scripts` — clean, and
      run via `all_fast_validate_checks.sh --only shell-portability`
- [x] `scripts/shellcheck/validate_shell_sete.sh` — no new findings (the
      "11 baselined findings now fixed" note reproduces on unmodified `main`; it
      is pre-existing baseline drift, not from this PR)
- [x] `bats test/bats/boot-simulator.bats` — 6/6, and the new bash-3.2 case fails
      as expected when the fix is reverted
- [x] `bats test/bats/validate-shell-portability.bats` — 17/17, including 6 new
      cases for the rule (flag bare expansion, flag in `for`, allow safe form,
      allow `${#arr[@]}` guard, allow files without `set -u`, honour
      `# portability-ok`)
- [x] No TypeScript touched, so `turbo run build test` / `bun run typecheck` are
      unaffected by this diff. (`main` is separately red on the typecheck gate —
      #4209/#4211.)

## Follow-ups

None required. `scripts/shellcheck/sete-baseline.txt` has 11 stale entries on
`main` that a `--update` would prune; left alone here to keep this PR to one
concern.
