### PR TITLE
fix(observe): drop root children that are all filtered out

### DIFF
--- a/src/features/observe/ViewHierarchy.ts
+++ b/src/features/observe/ViewHierarchy.ts
@@ -248,11 +248,10 @@ export class ViewHierarchy implements ViewHierarchyInterface {
       const rootCopy = structuredClone(node);
 
       if (node.node) {
+        // Always overwrite: when every child is filtered out the root must report an
+        // empty child list rather than falling back to the raw cloned children.
         const processedChildren = this.processNodeChildren(node, child => this.filterSingleNode(child));
-
-        if (processedChildren.length > 0) {
-          rootCopy.node = this.normalizeNodeStructure(processedChildren);
-        }
+        rootCopy.node = this.normalizeNodeStructure(processedChildren);
       }
 
       return rootCopy;

--- a/test/features/observe/ViewHierarchy.filter.test.ts
+++ b/test/features/observe/ViewHierarchy.filter.test.ts
@@ -99,4 +99,39 @@ describe("ViewHierarchy filtering", () => {
     expect(source.hierarchy.node.node).toBe(originalChildren);
     expect(source.hierarchy.node.node).toHaveLength(2);
   });
+
+  test("drops all root children when none meet the filter criteria", () => {
+    const viewHierarchy = new ViewHierarchy(device, new FakeAdbClientFactory());
+    const child = { class: "android.widget.FrameLayout", enabled: "true" };
+    const root = { node: [child] };
+
+    expect(viewHierarchy.meetsFilterCriteria(child)).toBe(false);
+
+    const result = viewHierarchy.filterSingleNode(root, true);
+
+    expect(result.node).toEqual([]);
+  });
+
+  test("keeps only surviving root children when some meet the filter criteria", () => {
+    const viewHierarchy = new ViewHierarchy(device, new FakeAdbClientFactory());
+    const root = {
+      node: [
+        { class: "android.widget.FrameLayout", enabled: "true" },
+        { text: "Keep me" },
+      ],
+    };
+
+    const result = viewHierarchy.filterSingleNode(root, true);
+
+    expect(result.node).toEqual({ text: "Keep me" });
+  });
+
+  test("leaves a root node without children unchanged", () => {
+    const viewHierarchy = new ViewHierarchy(device, new FakeAdbClientFactory());
+    const root = { class: "android.widget.FrameLayout", enabled: "true" };
+
+    const result = viewHierarchy.filterSingleNode(root, true);
+
+    expect(result).toEqual({ class: "android.widget.FrameLayout", enabled: "true" });
+  });
 });


### PR DESCRIPTION
## Summary

`ViewHierarchy.filterSingleNode` failed **open** at the root: `rootCopy` started as a
`structuredClone` of the raw node (children included), and the filtered children were only
written back when at least one child survived. When *every* root child was filtered out the
guard left the raw, unfiltered children in place, so `observe` returned exactly the noise the
filter existed to remove — silently, with no way for the caller to tell "nothing was filtered"
from "everything was filtered".

The fix drops the `length > 0` guard so the filtered child list is always assigned whenever the
root has a `node` property. `normalizeNodeStructure([])` already returns `[]`, so the
all-filtered case now yields an empty child list.

## Linked Issue

Closes #4164

## Bug / Regression Context

- **Observed symptom:** root node with all children failing `meetsFilterCriteria` returned the
  original unfiltered children instead of `[]`.
- **Repro steps / conditions:** `filterSingleNode({ node: [{ class: "android.widget.FrameLayout",
  enabled: "true" }] }, true)` — the child does not meet the filter criteria yet survives.

## Changes

- `src/features/observe/ViewHierarchy.ts` — unconditionally assign the processed children on the
  root copy.
- `test/features/observe/ViewHierarchy.filter.test.ts` — three regression tests covering the
  issue's acceptance criteria.

## Acceptance criteria

- [x] Root node with all children filtered out returns an empty child list.
- [x] Root node with a mix returns only the surviving children (no regression).
- [x] Root node with no `node` property is unchanged.
- [x] Regression test is red before the fix and green after — verified: the all-filtered test
      failed with the raw child array before the source change.

## Validation

- [x] `bun test` — 8314 pass / 0 fail (665 files)
- [x] `bun run lint` — exit 0
- [x] `bun run build` — exit 0
- [x] `bun run typecheck` — reports only the known pre-existing
      `src/daemon/telemetryPushSocketServer.ts` baseline drift that is currently red on `main`
      (tracked by #4211 / #4208); no new errors from this change. Baseline file deliberately
      untouched to avoid colliding with in-flight PRs.

## Device Verification

N/A — pure in-memory hierarchy filtering, covered by unit tests.

## Follow-ups

None. Scope kept to the root-node fail-open path; the non-root branch's separate
`relevantChildren.length > 0` guard is intentionally left alone (there, omitting an empty `node`
key is the desired shape).
