### PR TITLE
fix(daemon): register video-stream.sock in both socket registries

### DIFF
--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -17,7 +17,7 @@ import { McpTimeoutError } from "./McpTimeoutError";
 import { type Timer, defaultTimer } from "../utils/SystemTimer";
 import {
   cleanupStaleDaemonFilesForDeadPidSync,
-  getDaemonSocketPaths,
+  getDaemonSocketPathList,
   type StaleDaemonFileCleanupOptions,
 } from "./daemonFiles";
 
@@ -298,7 +298,7 @@ export class DaemonClient {
     recoveryOptions: DaemonClientRecoveryOptions
   ): boolean {
     const socketPaths = recoveryOptions.socketPaths ?? (
-      socketPath === SOCKET_PATH ? getDaemonSocketPaths() : [socketPath]
+      socketPath === SOCKET_PATH ? getDaemonSocketPathList() : [socketPath]
     );
 
     return cleanupStaleDaemonFilesForDeadPidSync({

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -47,7 +47,7 @@ import { startFailuresPushSocketServer, stopFailuresPushSocketServer } from "./f
 import { startTelemetryPushSocketServer, stopTelemetryPushSocketServer } from "./telemetryPushSocketServer";
 import { startWebRtcStreamSocketServer, stopWebRtcStreamSocketServer } from "./webrtcStreamSocketServer";
 import { startVideoStreamSocketServer, stopVideoStreamSocketServer } from "./videoStreamSocketServer";
-import { getDaemonSocketPaths } from "./socketPaths";
+import { getDaemonSocketPathsByName } from "./socketPaths";
 import { AndroidCtrlProxyClient } from "../features/observe/android";
 import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
 import { IOSCtrlProxyClient } from "../features/observe/ios";
@@ -769,7 +769,7 @@ export class Daemon {
     const pidData: PidFileData = {
       pid: process.pid,
       socketPath: SOCKET_PATH,
-      sockets: getDaemonSocketPaths(),
+      sockets: getDaemonSocketPathsByName(),
       port: this.port,
       dbPath: getDatabasePath(),
       startedAt: this.timer.now(),

--- a/src/daemon/daemonFiles.ts
+++ b/src/daemon/daemonFiles.ts
@@ -4,7 +4,7 @@ import { existsSync, readFileSync, unlinkSync } from "node:fs";
 import { unlink } from "node:fs/promises";
 import { PID_FILE_PATH, SOCKET_PATH } from "./constants";
 import { getSocketPath, type SocketServerConfig } from "./socketServer/index";
-import type { PidFileData } from "./types";
+import type { AuxiliaryDaemonSocketName, PidFileData } from "./types";
 import { logger } from "../utils/logger";
 
 export const VIDEO_RECORDING_SOCKET_CONFIG: SocketServerConfig = {
@@ -55,19 +55,27 @@ export const WEBRTC_STREAM_SOCKET_CONFIG: SocketServerConfig = {
   defaultPath: path.join(os.homedir(), ".auto-mobile", "webrtc-stream.sock"),
 };
 
-const AUXILIARY_SOCKET_CONFIGS: SocketServerConfig[] = [
-  VIDEO_RECORDING_SOCKET_CONFIG,
-  TEST_RECORDING_SOCKET_CONFIG,
-  DEVICE_SNAPSHOT_SOCKET_CONFIG,
-  APPEARANCE_SOCKET_CONFIG,
-  PERFORMANCE_STREAM_SOCKET_CONFIG,
-  PERFORMANCE_PUSH_SOCKET_CONFIG,
-  DEVICE_DATA_STREAM_SOCKET_CONFIG,
-  FAILURES_STREAM_SOCKET_CONFIG,
-  FAILURES_PUSH_SOCKET_CONFIG,
-  TELEMETRY_PUSH_SOCKET_CONFIG,
-  WEBRTC_STREAM_SOCKET_CONFIG,
-];
+/**
+ * Canonical registry of every auxiliary daemon socket, keyed by its published
+ * name. This is the single source of truth: `getDaemonSocketPathList()` (cleanup)
+ * and `getDaemonSocketPathsByName()` (publication, `socketPaths.ts`) both derive
+ * from it, and the exhaustive `Record` type means adding a member to
+ * `AuxiliaryDaemonSocketName` without registering it here is a compile error.
+ */
+export const AUXILIARY_SOCKET_CONFIGS_BY_NAME: Record<AuxiliaryDaemonSocketName, SocketServerConfig> = {
+  "appearance": APPEARANCE_SOCKET_CONFIG,
+  "device-snapshot": DEVICE_SNAPSHOT_SOCKET_CONFIG,
+  "failures-push": FAILURES_PUSH_SOCKET_CONFIG,
+  "failures-stream": FAILURES_STREAM_SOCKET_CONFIG,
+  "observation-stream": DEVICE_DATA_STREAM_SOCKET_CONFIG,
+  "performance-push": PERFORMANCE_PUSH_SOCKET_CONFIG,
+  "performance-stream": PERFORMANCE_STREAM_SOCKET_CONFIG,
+  "telemetry-push": TELEMETRY_PUSH_SOCKET_CONFIG,
+  "test-recording": TEST_RECORDING_SOCKET_CONFIG,
+  "video-recording": VIDEO_RECORDING_SOCKET_CONFIG,
+  "video-stream": VIDEO_STREAM_SOCKET_CONFIG,
+  "webrtc-stream": WEBRTC_STREAM_SOCKET_CONFIG,
+};
 
 export interface DaemonFileCleanupOptions {
   pidFilePath?: string;
@@ -79,16 +87,24 @@ export interface StaleDaemonFileCleanupOptions extends DaemonFileCleanupOptions 
   isProcessRunning?: (pid: number) => boolean;
 }
 
-export function getDaemonSocketPaths(): string[] {
+/**
+ * Default on-disk paths of every daemon socket, for unlink-on-cleanup.
+ *
+ * Named apart from `getDaemonSocketPathsByName()` in `socketPaths.ts` (which
+ * returns the keyed map of live paths for publication) so the two cannot be
+ * confused at an import site — the shared-name/divergent-shape pair is what let
+ * `video-stream.sock` escape both registries (issue #4195).
+ */
+export function getDaemonSocketPathList(): string[] {
   return [
     SOCKET_PATH,
-    ...AUXILIARY_SOCKET_CONFIGS.map(config => getSocketPath(config)),
+    ...Object.values(AUXILIARY_SOCKET_CONFIGS_BY_NAME).map(config => getSocketPath(config)),
   ];
 }
 
 export async function cleanupDaemonFiles(options: DaemonFileCleanupOptions = {}): Promise<boolean> {
   const pidFilePath = options.pidFilePath ?? PID_FILE_PATH;
-  const socketPaths = options.socketPaths ?? getDaemonSocketPaths();
+  const socketPaths = options.socketPaths ?? getDaemonSocketPathList();
 
   if (!shouldCleanupForExpectedPid(pidFilePath, options.expectedPid)) {
     return false;
@@ -117,7 +133,7 @@ export async function cleanupDaemonFiles(options: DaemonFileCleanupOptions = {})
 
 export function cleanupDaemonFilesSync(options: DaemonFileCleanupOptions = {}): boolean {
   const pidFilePath = options.pidFilePath ?? PID_FILE_PATH;
-  const socketPaths = options.socketPaths ?? getDaemonSocketPaths();
+  const socketPaths = options.socketPaths ?? getDaemonSocketPathList();
 
   if (!shouldCleanupForExpectedPid(pidFilePath, options.expectedPid)) {
     return false;

--- a/src/daemon/socketPaths.ts
+++ b/src/daemon/socketPaths.ts
@@ -9,10 +9,19 @@ import { getPerformanceStreamSocketPath } from "./performanceStreamSocketServer"
 import { getTelemetryPushSocketPath } from "./telemetryPushSocketServer";
 import { getTestRecordingSocketPath } from "./testRecordingSocketServer";
 import { getVideoRecordingSocketPath } from "./videoRecordingSocketServer";
+import { getVideoStreamSocketPath } from "./videoStreamSocketServer";
 import { getWebRtcStreamSocketPath } from "./webrtcStreamSocketServer";
 import type { DaemonSocketPaths } from "./types";
 
-export function getDaemonSocketPaths(): DaemonSocketPaths {
+/**
+ * Live paths of every daemon socket, keyed by published name, for the daemon
+ * status/pidfile payload.
+ *
+ * Distinct from `getDaemonSocketPathList()` in `daemonFiles.ts`, which returns
+ * the default paths as a flat array for unlink-on-cleanup. Both are anchored to
+ * `AuxiliaryDaemonSocketName`, so a new socket must appear in both (issue #4195).
+ */
+export function getDaemonSocketPathsByName(): DaemonSocketPaths {
   return {
     "control": SOCKET_PATH,
     "appearance": getAppearanceSocketPath(),
@@ -25,6 +34,7 @@ export function getDaemonSocketPaths(): DaemonSocketPaths {
     "telemetry-push": getTelemetryPushSocketPath(),
     "test-recording": getTestRecordingSocketPath(),
     "video-recording": getVideoRecordingSocketPath(),
+    "video-stream": getVideoStreamSocketPath(),
     "webrtc-stream": getWebRtcStreamSocketPath(),
   };
 }

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -81,7 +81,16 @@ export type DaemonSocketName =
   | "telemetry-push"
   | "test-recording"
   | "video-recording"
+  | "video-stream"
   | "webrtc-stream";
+
+/**
+ * Every daemon socket except the control socket. Auxiliary sockets are declared
+ * once in `daemonFiles.ts` as an exhaustive `Record` keyed by this type, so a
+ * newly-added socket cannot be started without also being registered for
+ * publication and cleanup (issue #4195).
+ */
+export type AuxiliaryDaemonSocketName = Exclude<DaemonSocketName, "control">;
 
 export type DaemonSocketPaths = Record<DaemonSocketName, string>;
 

--- a/test/daemon/socketPaths.test.ts
+++ b/test/daemon/socketPaths.test.ts
@@ -2,11 +2,16 @@ import { describe, expect, test } from "bun:test";
 import os from "node:os";
 import path from "node:path";
 import { SOCKET_PATH } from "../../src/daemon/constants";
-import { getDaemonSocketPaths } from "../../src/daemon/socketPaths";
+import { getDaemonSocketPathsByName } from "../../src/daemon/socketPaths";
+import {
+  AUXILIARY_SOCKET_CONFIGS_BY_NAME,
+  getDaemonSocketPathList,
+} from "../../src/daemon/daemonFiles";
+import { getSocketPath } from "../../src/daemon/socketServer/index";
 
 describe("daemon socket paths", () => {
   test("publishes all default socket paths", () => {
-    expect(getDaemonSocketPaths()).toEqual({
+    expect(getDaemonSocketPathsByName()).toEqual({
       "control": SOCKET_PATH,
       "appearance": path.join(os.homedir(), ".auto-mobile", "appearance.sock"),
       "device-snapshot": path.join(os.homedir(), ".auto-mobile", "device-snapshot.sock"),
@@ -18,7 +23,31 @@ describe("daemon socket paths", () => {
       "telemetry-push": path.join(os.homedir(), ".auto-mobile", "telemetry-push.sock"),
       "test-recording": path.join(os.homedir(), ".auto-mobile", "test-recording.sock"),
       "video-recording": path.join(os.homedir(), ".auto-mobile", "video-recording.sock"),
+      // Issue #4195: started by the daemon but previously absent from both registries.
+      "video-stream": path.join(os.homedir(), ".auto-mobile", "video-stream.sock"),
       "webrtc-stream": path.join(os.homedir(), ".auto-mobile", "webrtc-stream.sock"),
     });
+  });
+
+  test("cleanup path list unlinks every published socket", () => {
+    const published = Object.values(getDaemonSocketPathsByName());
+    const cleanupPaths = getDaemonSocketPathList();
+
+    for (const socketPath of published) {
+      expect(cleanupPaths).toContain(socketPath);
+    }
+    expect(cleanupPaths.length).toBe(published.length);
+  });
+
+  test("cleanup list and keyed map are anchored to the same registry", () => {
+    const published = getDaemonSocketPathsByName();
+    const auxiliaryNames = Object.keys(AUXILIARY_SOCKET_CONFIGS_BY_NAME).sort();
+
+    expect(Object.keys(published).filter(name => name !== "control").sort())
+      .toEqual(auxiliaryNames);
+
+    for (const [name, config] of Object.entries(AUXILIARY_SOCKET_CONFIGS_BY_NAME)) {
+      expect(path.basename(getSocketPath(config))).toBe(`${name}.sock`);
+    }
   });
 });

--- a/test/daemon/socketRegistryCoverage.test.ts
+++ b/test/daemon/socketRegistryCoverage.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import * as daemonFiles from "../../src/daemon/daemonFiles";
+import type { SocketServerConfig } from "../../src/daemon/socketServer/index";
+
+/**
+ * Guard for issue #4195.
+ *
+ * `video-stream.sock` was started by the daemon while being absent from both
+ * socket registries, so it was never published and never unlinked. The registry
+ * is now a single exhaustive `Record` keyed by `AuxiliaryDaemonSocketName`, which
+ * makes the *type* side unforgeable; this test closes the other direction — a
+ * socket config declared in `daemonFiles.ts` but never wired into the registry.
+ */
+describe("daemon socket registry coverage", () => {
+  const declaredConfigs = Object.entries(daemonFiles)
+    .filter((entry): entry is [string, SocketServerConfig] =>
+      entry[0].endsWith("_SOCKET_CONFIG")
+    );
+
+  test("every declared socket config is reachable from daemonFiles exports", () => {
+    expect(declaredConfigs.length).toBeGreaterThan(0);
+  });
+
+  test("every declared socket config is registered for publication and cleanup", () => {
+    const registered = new Set<SocketServerConfig>(
+      Object.values(daemonFiles.AUXILIARY_SOCKET_CONFIGS_BY_NAME)
+    );
+
+    const unregistered = declaredConfigs
+      .filter(([, config]) => !registered.has(config))
+      .map(([exportName]) => exportName);
+
+    expect(unregistered).toEqual([]);
+  });
+
+  test("registry has no duplicate config entries", () => {
+    const configs = Object.values(daemonFiles.AUXILIARY_SOCKET_CONFIGS_BY_NAME);
+    expect(new Set(configs).size).toBe(configs.length);
+  });
+});


### PR DESCRIPTION
## Summary

`video-stream.sock` was started at `src/daemon/daemon.ts:356` and stopped at `:1491`, but it was
absent from **both** daemon socket registries. It was therefore never published in the daemon
status/pidfile payload, and `cleanupDaemonFiles` never unlinked it — a stale socket file survived
shutdown and could wedge the next start.

The socket was the symptom. The defect was two same-named `getDaemonSocketPaths()` exports in
`src/daemon/`, with divergent shapes (a flat `string[]` for cleanup, a keyed `DaemonSocketPaths`
map for publication) and no shared source of truth, so a new socket had to be remembered in two
unrelated hand-maintained lists.

This PR makes the registry singular and typed:

- `AUXILIARY_SOCKET_CONFIGS_BY_NAME` in `daemonFiles.ts` is now the canonical registry — an
  exhaustive `Record<AuxiliaryDaemonSocketName, SocketServerConfig>`. Adding a name to
  `DaemonSocketName` without registering the config is a **compile error**.
- The duplicate names are resolved: `daemonFiles.getDaemonSocketPathList()` (array, cleanup) and
  `socketPaths.getDaemonSocketPathsByName()` (keyed map, publication). They can no longer be
  confused at an import site.
- `video-stream` is registered in both, and is unlinked on cleanup.

**Audit of the other sockets:** the daemon starts 12 auxiliary socket servers
(`daemon.ts:345-356`). `video-stream` was the *only* one missing — the other 11 were present in
both registries. Both registries now hold all 12.

## Linked Issue

Closes #4195

## Bug / Regression Context

- **Observed symptom:** `~/.auto-mobile/video-stream.sock` is left behind after daemon shutdown;
  daemon status never reports the video-stream socket path.
- **Repro steps / conditions:** start the daemon (creates `video-stream.sock`), stop it —
  `cleanupDaemonFiles` iterates `getDaemonSocketPaths()`, which never listed that path.
- **Verified red before the fix:** a scratch test asserting `video-stream.sock` appears in the
  cleanup array and the keyed map failed on both assertions against `origin/main`, and passes now.

## Validation

- [x] `bun run lint` passes
- [x] `bun test` passes — 8316 pass / 0 fail across 666 files
- [x] `bun run typecheck` — the one reported error is the **pre-existing** baseline drift in
      `src/daemon/telemetryPushSocketServer.ts` (`TS2339 sessionId`), tracked by #4211 / #4208 and
      untouched by this PR. `scripts/typecheck-baseline.txt` is deliberately **not** modified, to
      avoid colliding with in-flight PRs.
- [x] New code uses no new dependencies or helpers; unit tests are pure path computation and run in
      well under 100ms
- [x] Imports come from `src/daemon/socketServer/index` (the directory, not the shadowing
      `socketServer.ts`)
- [x] Rebased onto latest `main`

Note: `main` is currently red on three checks unrelated to this change — the typecheck baseline
drift above (#4211/#4208), bash 3.2 breakage in `scripts/ios/boot-simulator.sh` (#4212), and an
`actions/checkout@v6` load error in Installer Development. Expect those on this PR.

**No daemon was started, stopped, or connected to, and no real socket file was unlinked, while
developing this change.** The tests only compute paths.

## Tests

`test/daemon/socketPaths.test.ts` — updated deliberately, with the new `video-stream` key asserted
in the `toEqual` literal, plus two new invariants: every published socket appears in the cleanup
list (and the two are the same size), and the keyed map's names match the registry exactly with
each config's basename equal to `<name>.sock`.

`test/daemon/socketRegistryCoverage.test.ts` — new guard closing the direction the type system
cannot: any `*_SOCKET_CONFIG` declared in `daemonFiles.ts` but not wired into the registry fails the
test, naming the offending export. Confirmed it catches the original bug — removing the
`video-stream` entry makes it fail with `+ "VIDEO_STREAM_SOCKET_CONFIG"`.

## Follow-ups

None. The audit found no other unregistered socket.
