### PR TITLE
fix(performance): never render an empty "Top contributors" diagnostic section

### DIFF
--- a/src/features/memory/MemoryAudit.ts
+++ b/src/features/memory/MemoryAudit.ts
@@ -9,6 +9,7 @@ import { MemoryBaselineManager } from "./MemoryBaselineManager";
 import type { Kysely } from "kysely";
 import { getDatabase } from "../../db/database";
 import { Database, NewMemoryAuditResult } from "../../db/types";
+import { selectTopContributors } from "../../utils/topContributors";
 
 /**
  * Represents a single memory threshold violation
@@ -256,15 +257,10 @@ export class MemoryAudit {
       return "No memory issues detected";
     }
 
-    // Sort violations by contribution weight (highest first)
-    const sortedViolations = [...violations].sort(
-      (a, b) => b.contributionWeight - a.contributionWeight
-    );
-
     let diagnostics = "Memory issues detected:\n\n";
 
-    // Include top contributors (weight > 0.5)
-    const topContributors = sortedViolations.filter(v => v.contributionWeight > 0.5);
+    // Highest-weighted violations first; never empty for a non-empty violation set.
+    const topContributors = selectTopContributors(violations);
 
     diagnostics += "Top contributors:\n";
     for (const violation of topContributors) {

--- a/src/features/performance/PerformanceAudit.ts
+++ b/src/features/performance/PerformanceAudit.ts
@@ -9,6 +9,7 @@ import { TouchLatencyTracker } from "./TouchLatencyTracker";
 import { serverConfig } from "../../utils/ServerConfig";
 import { PerformanceAuditRepository } from "../../db/performanceAuditRepository";
 import { defaultTimer } from "../../utils/SystemTimer";
+import { selectTopContributors } from "../../utils/topContributors";
 
 /**
  * Performance metrics collected during audit
@@ -632,15 +633,10 @@ export class PerformanceAudit {
       return "No performance issues detected";
     }
 
-    // Sort violations by contribution weight (highest first)
-    const sortedViolations = [...violations].sort(
-      (a, b) => b.contributionWeight - a.contributionWeight
-    );
-
     let diagnostics = "Performance issues detected:\n\n";
 
-    // Include top contributors (weight > 0.5)
-    const topContributors = sortedViolations.filter(v => v.contributionWeight > 0.5);
+    // Highest-weighted violations first; never empty for a non-empty violation set.
+    const topContributors = selectTopContributors(violations);
 
     diagnostics += "Top contributors:\n";
     for (const violation of topContributors) {

--- a/src/utils/topContributors.ts
+++ b/src/utils/topContributors.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared selection of the "Top contributors" list rendered by the memory and
+ * performance audit diagnostics.
+ *
+ * Both audits assign every violation a `contributionWeight` in [0, 1] and then
+ * render the highest-weighted ones under a "Top contributors:" heading. The
+ * naive `weight > THRESHOLD` filter used previously could return an empty list
+ * for a non-empty violation set — e.g. a CPU-only performance violation carries
+ * weight exactly 0.5, which `> 0.5` excludes — producing a heading with nothing
+ * under it (issue #4167).
+ */
+
+/** Violations at or above this weight are always reported as top contributors. */
+export const TOP_CONTRIBUTOR_WEIGHT_THRESHOLD = 0.5;
+
+/** Minimal shape needed to rank a violation. */
+export interface WeightedContribution {
+  contributionWeight: number;
+}
+
+/**
+ * Sort violations by contribution weight (highest first) and select the top
+ * contributors.
+ *
+ * The effective cut-off is `min(TOP_CONTRIBUTOR_WEIGHT_THRESHOLD, maxWeight)`
+ * and the comparison is inclusive, which guarantees two properties:
+ *
+ * 1. A non-empty violation set always yields at least one top contributor, so
+ *    the rendered section can never be an empty heading, whatever weights a
+ *    future violation type is given.
+ * 2. Violations weighted below the threshold are still excluded whenever any
+ *    violation meets it, preserving the existing "top" semantics.
+ */
+export function selectTopContributors<T extends WeightedContribution>(violations: T[]): T[] {
+  if (violations.length === 0) {
+    return [];
+  }
+
+  const sorted = [...violations].sort((a, b) => b.contributionWeight - a.contributionWeight);
+  const cutoff = Math.min(TOP_CONTRIBUTOR_WEIGHT_THRESHOLD, sorted[0].contributionWeight);
+
+  return sorted.filter(violation => violation.contributionWeight >= cutoff);
+}

--- a/test/features/memory/MemoryAudit.test.ts
+++ b/test/features/memory/MemoryAudit.test.ts
@@ -365,6 +365,36 @@ describe("MemoryAudit - Unit Tests", function() {
       expect(diagnostics).toContain("Count: 500");
     });
 
+    test("renders a non-empty Top contributors section for anomaly-only violations", function() {
+      // javaHeapAnomaly (0.5) and gcCountAnomaly (0.4) are the weights assigned by
+      // MemoryAudit.validateMetrics for baseline anomalies. Neither cleared the old
+      // `> 0.5` filter, so a baseline-anomaly-only audit rendered an empty section
+      // (same defect class as issue #4167).
+      const metrics: MemoryMetrics = {
+        preSnapshot: { javaHeapMb: 50, nativeHeapMb: 30, totalPssMb: 100, timestamp: Date.now(), raw: "" },
+        postSnapshot: { javaHeapMb: 65, nativeHeapMb: 32, totalPssMb: 115, timestamp: Date.now(), raw: "" },
+        javaHeapGrowthMb: 15,
+        nativeHeapGrowthMb: 2,
+        totalPssGrowthMb: 15,
+        gcEvents: [],
+        gcCount: 3,
+        gcTotalDurationMs: 40,
+      };
+
+      const violations = [
+        { metric: "javaHeapAnomaly", threshold: 40, actual: 65, severity: "warning" as const, contributionWeight: 0.5 },
+        { metric: "gcCountAnomaly", threshold: 2, actual: 3, severity: "warning" as const, contributionWeight: 0.4 },
+      ];
+
+      const diagnostics = (audit as any).generateDiagnostics(metrics, violations);
+
+      const start = diagnostics.indexOf("Top contributors:\n") + "Top contributors:\n".length;
+      const section = diagnostics.slice(start, diagnostics.indexOf("\nMemory snapshots:"));
+      expect(section.split("\n").filter((line: string) => line.length > 0)).toEqual([
+        "- javaHeapAnomaly: 65.00 (threshold: 40.00) [warning]",
+      ]);
+    });
+
     test("should return no issues message when no violations", function() {
       const metrics: MemoryMetrics = {
         preSnapshot: {

--- a/test/features/performance/PerformanceAudit.test.ts
+++ b/test/features/performance/PerformanceAudit.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { PerformanceAudit } from "../../../src/features/performance/PerformanceAudit";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
+
+interface TestViolation {
+  metric: string;
+  threshold: number;
+  actual: number;
+  severity: "warning" | "critical";
+  contributionWeight: number;
+}
+
+/**
+ * Weights assigned by PerformanceAudit.validateMetrics, one row per violation
+ * type. Every one of these must be renderable as a top contributor when it is
+ * the only violation - see issue #4167.
+ */
+const ASSIGNED_WEIGHTS: Array<{ metric: string; weight: number }> = [
+  { metric: "p50", weight: 0.6 },
+  { metric: "p90", weight: 0.7 },
+  { metric: "p95", weight: 0.8 },
+  { metric: "p99", weight: 0.4 },
+  { metric: "jankCount", weight: 0.9 },
+  { metric: "cpuUsage", weight: 0.5 },
+  { metric: "touchLatency", weight: 0.85 },
+  { metric: "anr", weight: 1.0 },
+];
+
+describe("PerformanceAudit.generateDiagnostics - top contributors", function() {
+  let audit: PerformanceAudit;
+
+  beforeEach(function() {
+    audit = new PerformanceAudit(
+      { deviceId: "test-device", name: "test", platform: "android" },
+      new FakeAdbClientFactory()
+    );
+  });
+
+  const baseMetrics = () => ({
+    p50Ms: null,
+    p90Ms: null,
+    p95Ms: null,
+    p99Ms: null,
+    jankCount: null,
+    missedVsyncCount: null,
+    slowUiThreadCount: null,
+    frameDeadlineMissedCount: null,
+    cpuUsagePercent: null,
+    threadCount: null,
+    touchLatencyMs: null,
+    anrDetected: false,
+    anrDetails: null,
+    timeToFirstFrameMs: null,
+    timeToInteractiveMs: null,
+    frameRateFps: null,
+    gfxinfoRaw: null,
+    cpuStatsRaw: null,
+  });
+
+  const generate = (metrics: Record<string, unknown>, violations: TestViolation[]): string =>
+    (audit as unknown as {
+      generateDiagnostics: (m: unknown, v: TestViolation[]) => string;
+    }).generateDiagnostics(metrics, violations);
+
+  /** The lines rendered between "Top contributors:" and the next section. */
+  const contributorLines = (diagnostics: string): string[] => {
+    const start = diagnostics.indexOf("Top contributors:\n");
+    expect(start).toBeGreaterThanOrEqual(0);
+    const rest = diagnostics.slice(start + "Top contributors:\n".length);
+    const end = rest.indexOf("\nDiagnostic details:");
+    expect(end).toBeGreaterThanOrEqual(0);
+    return rest.slice(0, end).split("\n").filter(line => line.length > 0);
+  };
+
+  test("renders a non-empty Top contributors section for a CPU-only violation", function() {
+    const metrics = { ...baseMetrics(), cpuUsagePercent: 92, threadCount: 40, cpuStatsRaw: "raw cpu stats" };
+    const violations: TestViolation[] = [
+      { metric: "cpuUsage", threshold: 80, actual: 92, severity: "warning", contributionWeight: 0.5 },
+    ];
+
+    const diagnostics = generate(metrics, violations);
+
+    expect(contributorLines(diagnostics)).toEqual([
+      "- cpuUsage: 92.00 (threshold: 80.00) [warning]",
+    ]);
+  });
+
+  test("includes the CPU stats dump for a CPU-only violation", function() {
+    const metrics = { ...baseMetrics(), cpuUsagePercent: 92, threadCount: 40, cpuStatsRaw: "raw cpu stats" };
+    const violations: TestViolation[] = [
+      { metric: "cpuUsage", threshold: 80, actual: 92, severity: "warning", contributionWeight: 0.5 },
+    ];
+
+    const diagnostics = generate(metrics, violations);
+
+    expect(diagnostics).toContain("--- CPU STATS ---");
+    expect(diagnostics).toContain("raw cpu stats");
+  });
+
+  test.each(ASSIGNED_WEIGHTS)(
+    "a lone $metric violation at its assigned weight $weight is a top contributor",
+    function({ metric, weight }) {
+      const violations: TestViolation[] = [
+        { metric, threshold: 10, actual: 20, severity: "warning", contributionWeight: weight },
+      ];
+
+      const diagnostics = generate(baseMetrics(), violations);
+
+      expect(contributorLines(diagnostics)).toEqual([
+        `- ${metric}: 20.00 (threshold: 10.00) [warning]`,
+      ]);
+    }
+  );
+
+  test("mixed violations still drop low-weight entries and stay weight-ordered", function() {
+    const violations: TestViolation[] = [
+      { metric: "p99", threshold: 30, actual: 90, severity: "warning", contributionWeight: 0.4 },
+      { metric: "p50", threshold: 15, actual: 40, severity: "warning", contributionWeight: 0.6 },
+      { metric: "jankCount", threshold: 5, actual: 30, severity: "critical", contributionWeight: 0.9 },
+    ];
+
+    const diagnostics = generate(baseMetrics(), violations);
+
+    expect(contributorLines(diagnostics)).toEqual([
+      "- jankCount: 30.00 (threshold: 5.00) [critical]",
+      "- p50: 40.00 (threshold: 15.00) [warning]",
+    ]);
+  });
+
+  test("a mixed set containing the boundary weight includes the boundary entry", function() {
+    const violations: TestViolation[] = [
+      { metric: "cpuUsage", threshold: 80, actual: 92, severity: "warning", contributionWeight: 0.5 },
+      { metric: "p95", threshold: 20, actual: 60, severity: "critical", contributionWeight: 0.8 },
+    ];
+
+    const diagnostics = generate(baseMetrics(), violations);
+
+    expect(contributorLines(diagnostics)).toEqual([
+      "- p95: 60.00 (threshold: 20.00) [critical]",
+      "- cpuUsage: 92.00 (threshold: 80.00) [warning]",
+    ]);
+  });
+
+  test("returns the no-issues message when there are no violations", function() {
+    expect(generate(baseMetrics(), [])).toBe("No performance issues detected");
+  });
+});

--- a/test/utils/topContributors.test.ts
+++ b/test/utils/topContributors.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import {
+  TOP_CONTRIBUTOR_WEIGHT_THRESHOLD,
+  selectTopContributors,
+} from "../../src/utils/topContributors";
+
+describe("selectTopContributors", function() {
+  test("returns an empty list only for an empty violation set", function() {
+    expect(selectTopContributors([])).toEqual([]);
+  });
+
+  test("never returns an empty list for a non-empty violation set", function() {
+    for (const weight of [0, 0.1, 0.4, 0.5, 0.51, 1]) {
+      expect(selectTopContributors([{ metric: "x", contributionWeight: weight }])).toHaveLength(1);
+    }
+  });
+
+  test("includes a violation at exactly the threshold", function() {
+    const at = { metric: "cpuUsage", contributionWeight: TOP_CONTRIBUTOR_WEIGHT_THRESHOLD };
+    const above = { metric: "p95", contributionWeight: 0.8 };
+
+    expect(selectTopContributors([at, above])).toEqual([above, at]);
+  });
+
+  test("drops sub-threshold violations when any violation meets the threshold", function() {
+    const high = { metric: "jankCount", contributionWeight: 0.9 };
+    const low = { metric: "p99", contributionWeight: 0.4 };
+
+    expect(selectTopContributors([low, high])).toEqual([high]);
+  });
+
+  test("keeps the highest-weighted violations when every weight is sub-threshold", function() {
+    const low = { metric: "p99", contributionWeight: 0.4 };
+    const lower = { metric: "noise", contributionWeight: 0.1 };
+
+    expect(selectTopContributors([lower, low])).toEqual([low]);
+  });
+
+  test("sorts by descending weight and does not mutate the input", function() {
+    const input = [
+      { metric: "a", contributionWeight: 0.6 },
+      { metric: "b", contributionWeight: 0.9 },
+      { metric: "c", contributionWeight: 0.7 },
+    ];
+
+    expect(selectTopContributors(input).map(v => v.metric)).toEqual(["b", "c", "a"]);
+    expect(input.map(v => v.metric)).toEqual(["a", "b", "c"]);
+  });
+});


### PR DESCRIPTION
## Summary

The bug is real. `PerformanceAudit.validateMetrics` assigns a CPU-usage violation
`contributionWeight: 0.5`, while `generateDiagnostics` selected top contributors with
`filter(v => v.contributionWeight > 0.5)`. `0.5 > 0.5` is false, so a CPU-only violation
rendered a `Top contributors:` heading with nothing under it — and, because
`hasCpuIssues` is derived from that same list, the `--- CPU STATS ---` dump was silently
dropped as well. The previously-unreachable `topContributors.some(v => v.metric === "cpuUsage")`
check is the evidence that inclusion at 0.5 was the original intent.

**Threshold decision.** The issue offered `>= 0.5` (option 1) or keying the section off
`violations` (option 2). Option 1 alone is insufficient: `p99` is weighted `0.4`, so a
p99-only violation still renders an empty section. Option 2 alone changes the meaning of
"top" and would start listing low-weight noise in mixed sets, contradicting the
"mixed sets unchanged" criterion. This PR takes the combination, expressed as one rule in a
shared helper (`src/utils/topContributors.ts`):

```ts
const cutoff = Math.min(TOP_CONTRIBUTOR_WEIGHT_THRESHOLD, sorted[0].contributionWeight);
return sorted.filter(v => v.contributionWeight >= cutoff);
```

- `>=` at 0.5 restores the author's intent for `cpuUsage`.
- Clamping the cut-off to the highest present weight guarantees a non-empty violation set
  can never yield an empty section, whatever weight a future violation type is given —
  which is the robustness property option 2 was after, without the coupling.
- Sub-threshold violations are still excluded whenever anything meets the threshold, so
  mixed sets keep today's output.

**Empty section reachable by other means — yes, and it is fixed here too.**
`MemoryAudit.generateDiagnostics` has the identical sort+filter, and its baseline-anomaly
violations are weighted `0.5` (`javaHeapAnomaly`) and `0.4` (`gcCountAnomaly`). An audit
whose only findings were baseline anomalies rendered the same empty heading. Both call
sites now go through the shared helper, so the defect cannot be reintroduced in one and
not the other.

## Linked Issue

Closes #4167

## Bug / Regression Context

- **Observed symptom:** `Performance issues detected:` / `Top contributors:` /
  `Diagnostic details:` with no content between the headings; CPU stats dump missing.
- **Repro steps / conditions:** any audit whose only threshold violation is `cpuUsage`
  (weight 0.5) or `p99` (weight 0.4); on the memory side, an audit whose only violations
  are baseline anomalies.

## Changes

- `src/utils/topContributors.ts` (new) — `TOP_CONTRIBUTOR_WEIGHT_THRESHOLD` and a generic
  `selectTopContributors()` that sorts by descending weight and applies the clamped,
  inclusive cut-off.
- `src/features/performance/PerformanceAudit.ts` — use the helper; drop the local
  sort + `> 0.5` filter.
- `src/features/memory/MemoryAudit.ts` — same substitution for the identical defect.

## Validation

- [x] `bun run lint` clean; `bun test` — 8331 pass / 0 fail across 667 files
- [x] `bun run typecheck` reports **no new** errors from this PR. The gate is currently
      red on `src/daemon/telemetryPushSocketServer.ts` on `main`, tracked by #4211 / #4208;
      `scripts/typecheck-baseline.txt` is deliberately untouched to avoid colliding with
      in-flight PRs.
- [x] New tests run in well under 100ms; existing `FakeAdbClientFactory` used, no real
      `getDatabase()` resolution
- [x] New generic code is a small repo helper; no new dependency

### Known-red checks unrelated to this PR

`Node TypeScript Build and Test (ubuntu-latest)` (#4211/#4208),
`BATS Shell Tests (macos-latest)` / `Shell Tests` (#4212), and
`Installer Development (macos-latest)` fail on every PR against current `main`.

## Acceptance criteria

- [x] A CPU-only violation set renders a non-empty "Top contributors" section —
      `renders a non-empty Top contributors section for a CPU-only violation`
- [x] Mixed violation sets are unchanged (no regression) —
      `mixed violations still drop low-weight entries and stay weight-ordered`
      (p99 @ 0.4 still excluded), plus the pre-existing `MemoryAudit` mixed-set test
      (gcCount @ 0.3 still excluded) passes untouched
- [x] A test asserting the **rendered diagnostic content** — the new tests slice the text
      between `Top contributors:` and the following section and assert the exact lines,
      so an empty section fails rather than passing on "returned a non-empty string"
- [x] A boundary row per violation type at exactly its assigned weight — `test.each` over
      all eight `validateMetrics` weights (p50 .6, p90 .7, p95 .8, p99 .4, jankCount .9,
      cpuUsage .5, touchLatency .85, anr 1.0); any future weight/threshold mismatch fails
      immediately
- [x] Regression test red before the fix, green after — 5 of the 13 new
      `PerformanceAudit` tests failed on the pre-fix code (CPU-only section, CPU-stats
      dump, lone cpuUsage @ 0.5, lone p99 @ 0.4, boundary-in-mixed-set); all green after

## Device Verification

N/A — pure string-rendering logic, fully covered by unit tests. No device interaction.
