### PR TITLE
fix(observe): parse dumpsys ActivityRecord component from inside the braces

### DIFF
--- a/src/features/observe/GetBackStack.ts
+++ b/src/features/observe/GetBackStack.ts
@@ -52,8 +52,14 @@ export class GetBackStack implements BackStack {
       //   "* Hist  #0: ActivityRecord{2b2ce0f u0 com.example/.MainActivity t61}"
       // The "Hist #N" index counts up from the task root, so #0 is the task
       // root and the highest index is the topmost (visible) activity.
+      //
+      // Trailing tokens before the closing brace are tolerated deliberately: a
+      // finishing activity prints " f}" and an activity with no task prints
+      // "t??". Requiring the task id to be the last token is what made the
+      // previous regex drop every line, so anything unrecognized is skipped
+      // rather than allowed to reject the whole activity.
       const activityMatch = line.match(
-        /Hist\s+#(\d+):\s+ActivityRecord\{\S+\s+u\d+\s+(\S+)(?:\s+t(\d+))?\}/
+        /Hist\s+#(\d+):\s+ActivityRecord\{\S+\s+u\d+\s+(\S+?)(?:\s+t(\d+))?(?:\s+[^}]*)?\}/
       );
       if (activityMatch) {
         const histIndex = parseInt(activityMatch[1], 10);

--- a/src/features/observe/GetBackStack.ts
+++ b/src/features/observe/GetBackStack.ts
@@ -47,24 +47,37 @@ export class GetBackStack implements BackStack {
         logger.debug(`[BACK_STACK] Found task affinity: ${currentTaskAffinity}`);
       }
 
-      // Match activity. AOSP's ActivityRecord.toString() puts the user id, the
-      // component and the task id INSIDE the braces, e.g.
-      //   "* Hist  #0: ActivityRecord{2b2ce0f u0 com.example/.MainActivity t61}"
-      // The "Hist #N" index counts up from the task root, so #0 is the task
-      // root and the highest index is the topmost (visible) activity.
+      // Match activity. AOSP's ActivityRecord.toString() always puts the user id
+      // and the component INSIDE the braces, but it does NOT agree across
+      // versions on where the task id goes. Both shapes are present in this
+      // repo's committed captures under test/features/observe/windowDumps:
       //
-      // Trailing tokens before the closing brace are tolerated deliberately: a
-      // finishing activity prints " f}" and an activity with no task prints
-      // "t??". Requiring the task id to be the last token is what made the
-      // previous regex drop every line, so anything unrecognized is skipped
-      // rather than allowed to reject the whole activity.
+      //   API 30-32, 34-36: ActivityRecord{2b2ce0f u0 com.example/.Main t61}
+      //   API 33:           ActivityRecord{a9cf40f u0 com.example/.Main} t8}
+      //
+      // On API 33 the component is closed off by its own brace and the task id
+      // trails outside it. So the component group is bounded to exclude "}"
+      // (otherwise the API 33 shape yields a name ending in "}"), and the task
+      // id is scanned for anywhere in the tail rather than assumed to sit at a
+      // fixed offset. The "Hist #N" index counts up from the task root, so #0
+      // is the task root and the highest index is the topmost activity.
+      //
+      // Other trailing tokens are tolerated deliberately: a finishing activity
+      // prints " f" and an activity with no task prints "t??". Requiring the
+      // task id to be the last token is what made the original regex drop every
+      // line, so an unrecognized tail leaves the task id to fall back to the
+      // enclosing task header rather than rejecting the whole activity.
       const activityMatch = line.match(
-        /Hist\s+#(\d+):\s+ActivityRecord\{\S+\s+u\d+\s+(\S+?)(?:\s+t(\d+))?(?:\s+[^}]*)?\}/
+        /Hist\s+#(\d+):\s+ActivityRecord\{\S+\s+u\d+\s+([^\s}]+)([^\n]*\})/
       );
       if (activityMatch) {
         const histIndex = parseInt(activityMatch[1], 10);
         const fullName = activityMatch[2];
-        const taskIdFromActivity = activityMatch[3] ? parseInt(activityMatch[3], 10) : currentTaskId;
+        // Standalone "tNN" token in the tail, on either side of a closing brace.
+        const taskIdMatchFromActivity = activityMatch[3].match(/(?:^|[\s}])t(\d+)(?=[\s}]|$)/);
+        const taskIdFromActivity = taskIdMatchFromActivity
+          ? parseInt(taskIdMatchFromActivity[1], 10)
+          : currentTaskId;
 
         // Parse package/activity name (format: "com.example/.MainActivity" or "com.example/com.example.MainActivity")
         const parts = fullName.split("/");

--- a/src/features/observe/GetBackStack.ts
+++ b/src/features/observe/GetBackStack.ts
@@ -47,12 +47,18 @@ export class GetBackStack implements BackStack {
         logger.debug(`[BACK_STACK] Found task affinity: ${currentTaskAffinity}`);
       }
 
-      // Match activity: "Hist #0: ActivityRecord{...} u0 com.example/.MainActivity"
-      // or "* Hist #0: ActivityRecord{...} u0 com.example/.MainActivity t123"
-      const activityMatch = line.match(/\*?\s*Hist\s+#\d+:\s+ActivityRecord\{[^\}]+\}\s+u\d+\s+([^\s]+)(?:\s+t(\d+))?/);
+      // Match activity. AOSP's ActivityRecord.toString() puts the user id, the
+      // component and the task id INSIDE the braces, e.g.
+      //   "* Hist  #0: ActivityRecord{2b2ce0f u0 com.example/.MainActivity t61}"
+      // The "Hist #N" index counts up from the task root, so #0 is the task
+      // root and the highest index is the topmost (visible) activity.
+      const activityMatch = line.match(
+        /Hist\s+#(\d+):\s+ActivityRecord\{\S+\s+u\d+\s+(\S+)(?:\s+t(\d+))?\}/
+      );
       if (activityMatch) {
-        const fullName = activityMatch[1];
-        const taskIdFromActivity = activityMatch[2] ? parseInt(activityMatch[2], 10) : currentTaskId;
+        const histIndex = parseInt(activityMatch[1], 10);
+        const fullName = activityMatch[2];
+        const taskIdFromActivity = activityMatch[3] ? parseInt(activityMatch[3], 10) : currentTaskId;
 
         // Parse package/activity name (format: "com.example/.MainActivity" or "com.example/com.example.MainActivity")
         const parts = fullName.split("/");
@@ -67,7 +73,8 @@ export class GetBackStack implements BackStack {
         const activity: ActivityInfo = {
           name: activityName,
           taskId: taskIdFromActivity,
-          taskAffinity: currentTaskAffinity
+          taskAffinity: currentTaskAffinity,
+          isTaskRoot: histIndex === 0
         };
 
         activities.push(activity);
@@ -209,15 +216,13 @@ export class GetBackStack implements BackStack {
         ])
       );
 
-      // Calculate depth: number of activities in current task minus 1 (the current activity)
+      // Calculate depth: number of activities in current task minus 1 (the current activity).
+      // This is the number of entries that can still be popped from the current task.
+      // isTaskRoot is set during parsing from the activity's own "Hist #N" index -- the
+      // root is the #0 entry, which dumpsys prints LAST because it lists top-to-bottom.
       const currentTaskId = currentActivity?.taskId || -1;
       const activitiesInCurrentTask = activities.filter(a => a.taskId === currentTaskId);
       const depth = Math.max(0, activitiesInCurrentTask.length - 1);
-
-      // Mark the root activity
-      if (activitiesInCurrentTask.length > 0) {
-        activitiesInCurrentTask[0].isTaskRoot = true;
-      }
 
       const backStackInfo: BackStackInfo = {
         depth,

--- a/src/models/BackStack.ts
+++ b/src/models/BackStack.ts
@@ -50,7 +50,11 @@ export interface TaskInfo {
 export interface BackStackInfo {
   /** Total depth of the back stack (number of entries that can be popped) */
   depth: number;
-  /** Activities in the back stack, ordered from bottom to top */
+  /**
+   * Activities in the back stack, in the order dumpsys reports them: top of
+   * stack first, task root last. The root entry of each task is flagged with
+   * `isTaskRoot`.
+   */
   activities: ActivityInfo[];
   /** Tasks in the back stack */
   tasks: TaskInfo[];

--- a/test/features/observe/GetBackStack.test.ts
+++ b/test/features/observe/GetBackStack.test.ts
@@ -32,7 +32,7 @@ describe("GetBackStack", function() {
 
     expect(result).toBeDefined();
     expect(result.activities).toBeDefined();
-    expect(result.activities.length).toBeGreaterThanOrEqual(0); // May be 0 if regex doesn't match
+    expect(result.activities.length).toBe(4);
     expect(result.source).toBe("adb");
   });
 

--- a/test/features/observe/GetBackStackParsing.test.ts
+++ b/test/features/observe/GetBackStackParsing.test.ts
@@ -8,17 +8,25 @@ import { BackStackInfo, BootedDevice } from "../../../src/models";
  * Back-stack semantics pinned by this suite (issue #4197).
  *
  * Wire format. `dumpsys activity activities` prints activities using AOSP's
- * `ActivityRecord.toString()`, which puts the user id, the component and the
- * task id INSIDE the braces:
+ * `ActivityRecord.toString()`, which puts the user id and the component INSIDE
+ * the braces:
  *
  *     * Hist  #0: ActivityRecord{2b2ce0f u0 com.example/.MainActivity t61}
  *
- * Every real capture committed to this repo agrees on that shape — see
- * `test/features/observe/Window.test.ts` and the documented samples in
- * `src/utils/android-cmdline-tools/AdbClient.ts`. The shape the parser used to
- * expect (`ActivityRecord{...} u0 com.example/.MainActivity`, component after
- * the closing brace) is not emitted by any Android version, which is why
- * `parseActivities` returned an empty array against real output.
+ * The shape the parser used to expect (`ActivityRecord{...} u0
+ * com.example/.MainActivity`, component after the closing brace) is not emitted
+ * by any Android version, which is why `parseActivities` returned an empty
+ * array against real output.
+ *
+ * Where the TASK ID goes, however, is version-dependent. The captures committed
+ * under `test/features/observe/windowDumps/` disagree:
+ *
+ *     API 30-32, 34-36  ActivityRecord{6f2ed08 u0 com.android.settings/.Settings t6}
+ *     API 33            ActivityRecord{a9cf40f u0 com.android.settings/.Settings} t8}
+ *
+ * API 33 closes the component with its own brace and trails the task id after
+ * it. Both shapes are pinned below; the component must never come back with a
+ * "}" glued to it.
  *
  * Ordering and the task root. Activities are printed top-of-stack first, and
  * the `Hist #N` index is the position within the task counting UP from the
@@ -195,6 +203,30 @@ describe("GetBackStack real-output parsing (#4197)", () => {
         "com.example.MainActivity"
       ]);
       expect(result.activities.map(a => a.taskId)).toEqual([5, 5]);
+    });
+
+    test("API 33 shape ('...}' then ' tNN}') parses the component and its own task id", async () => {
+      // The two ActivityRecord strings below are copied verbatim from the
+      // committed API 33 capture, test/features/observe/windowDumps/
+      // api33-settings-window-dump.log:289 and :318. Unlike every other API
+      // level captured in that directory, API 33 closes the component with a
+      // brace and prints the task id after it. The enclosing task header is
+      // deliberately a task id the activities do NOT belong to, so a component
+      // ending in "}" or a task id silently falling back to the header both
+      // fail here.
+      const result = await parse(`
+    Task id #99
+    affinity=com.android.settings
+      * Hist  #1: ActivityRecord{a9cf40f u0 com.android.settings/.Settings} t8}
+      * Hist  #0: ActivityRecord{3177c30 u0 com.google.android.apps.nexuslauncher/.NexusLauncherActivity} t7}
+`);
+
+      expect(result.activities.map(a => a.name)).toEqual([
+        "com.android.settings.Settings",
+        "com.google.android.apps.nexuslauncher.NexusLauncherActivity"
+      ]);
+      expect(result.activities.map(a => a.taskId)).toEqual([8, 7]);
+      expect(result.activities.map(a => a.isTaskRoot)).toEqual([false, true]);
     });
 
     test("an activity with no task ('t??') falls back to the enclosing task", async () => {

--- a/test/features/observe/GetBackStackParsing.test.ts
+++ b/test/features/observe/GetBackStackParsing.test.ts
@@ -182,6 +182,32 @@ describe("GetBackStack real-output parsing (#4197)", () => {
       expect(result.depth).toBe(1);
     });
 
+    test("a finishing activity (' f}') is still parsed", async () => {
+      const result = await parse(`
+    Task id #5
+    affinity=com.example
+      * Hist #1: ActivityRecord{aaa u0 com.example/.TopActivity t5 f}
+      * Hist #0: ActivityRecord{bbb u0 com.example/.MainActivity t5}
+`);
+
+      expect(result.activities.map(a => a.name)).toEqual([
+        "com.example.TopActivity",
+        "com.example.MainActivity"
+      ]);
+      expect(result.activities.map(a => a.taskId)).toEqual([5, 5]);
+    });
+
+    test("an activity with no task ('t??') falls back to the enclosing task", async () => {
+      const result = await parse(`
+    Task id #5
+    affinity=com.example
+      * Hist #0: ActivityRecord{aaa u0 com.example/.MainActivity t??}
+`);
+
+      expect(result.activities).toHaveLength(1);
+      expect(result.activities[0].taskId).toBe(5);
+    });
+
     test("an activity line without a tNN suffix falls back to the enclosing task", async () => {
       const result = await parse(`
     Task id #5

--- a/test/features/observe/GetBackStackParsing.test.ts
+++ b/test/features/observe/GetBackStackParsing.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from "bun:test";
+import { GetBackStack } from "../../../src/features/observe/GetBackStack";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
+import { BackStackInfo, BootedDevice } from "../../../src/models";
+
+/**
+ * Back-stack semantics pinned by this suite (issue #4197).
+ *
+ * Wire format. `dumpsys activity activities` prints activities using AOSP's
+ * `ActivityRecord.toString()`, which puts the user id, the component and the
+ * task id INSIDE the braces:
+ *
+ *     * Hist  #0: ActivityRecord{2b2ce0f u0 com.example/.MainActivity t61}
+ *
+ * Every real capture committed to this repo agrees on that shape — see
+ * `test/features/observe/Window.test.ts` and the documented samples in
+ * `src/utils/android-cmdline-tools/AdbClient.ts`. The shape the parser used to
+ * expect (`ActivityRecord{...} u0 com.example/.MainActivity`, component after
+ * the closing brace) is not emitted by any Android version, which is why
+ * `parseActivities` returned an empty array against real output.
+ *
+ * Ordering and the task root. Activities are printed top-of-stack first, and
+ * the `Hist #N` index is the position within the task counting UP from the
+ * root: `Hist #0` is the task root, the highest `Hist #N` is the currently
+ * visible activity. The root is therefore the LAST entry in printed order, not
+ * the first. `isTaskRoot` is derived from the `Hist` index rather than from an
+ * array position so it stays correct regardless of how the list is ordered.
+ *
+ * Depth. `depth` counts how many entries can be popped from the current task,
+ * i.e. (activities in the current task) - 1. A single-activity task has depth 0.
+ *
+ * Task id. Each activity line carries its own `tNN`, so the activity's task id
+ * is read from the activity itself and only falls back to the enclosing task
+ * header when the line omits it. That keeps activity parsing correct even when
+ * the task-header line is printed in a format the task parser does not know.
+ */
+
+const device: BootedDevice = { name: "test", platform: "android", deviceId: "test-device" };
+
+async function parse(stdout: string): Promise<BackStackInfo> {
+  const adb = new FakeAdbExecutor();
+  adb.setCommandResponse("dumpsys activity activities", { stdout, stderr: "" });
+  return new GetBackStack(device, new FakeAdbClientFactory(adb)).execute();
+}
+
+// Legacy-style block: "Task id #N" headers, single-space "Hist #N:".
+const LEGACY_MULTI_TASK = `
+ACTIVITY MANAGER ACTIVITIES (dumpsys activity activities)
+Display #0 (activities from top to bottom):
+
+  Stack #0: type=home mode=fullscreen
+    Task id #1
+    affinity=com.android.launcher3
+    realActivity=com.android.launcher3/.Launcher
+    numActivities=1
+      * Hist #0: ActivityRecord{abc123 u0 com.android.launcher3/.Launcher t1}
+
+  Stack #1: type=standard mode=fullscreen
+    Task id #123
+    affinity=dev.jasonpearson.automobile.playground
+    realActivity=dev.jasonpearson.automobile.playground/.MainActivity
+    numActivities=3
+      * Hist #2: ActivityRecord{def456 u0 dev.jasonpearson.automobile.playground/.DetailActivity t123}
+      * Hist #1: ActivityRecord{ghi789 u0 dev.jasonpearson.automobile.playground/.ListActivity t123}
+      * Hist #0: ActivityRecord{jkl012 u0 dev.jasonpearson.automobile.playground/.MainActivity t123}
+
+  mResumedActivity: ActivityRecord{def456 u0 dev.jasonpearson.automobile.playground/.DetailActivity t123}
+`;
+
+// Modern-style block: two spaces after "Hist", task header printed as
+// "Task{<hash> #id ...}". Only activity-derived facts are asserted for this
+// fixture; the task-header form is tracked separately.
+const MODERN_SINGLE_TASK = `
+ACTIVITY MANAGER ACTIVITIES (dumpsys activity activities)
+Display #0 (activities from top to bottom):
+  * Task{d19dee2 #61 type=standard A=10164:com.example U=0 visible=true mode=fullscreen sz=2}
+    mBounds=Rect(0, 0 - 1080, 2400)
+    isSleeping=false
+    * Hist  #1: ActivityRecord{2b2ce0f u0 com.example/.DetailActivity t61}
+        packageName=com.example processName=com.example
+    * Hist  #0: ActivityRecord{7ff01aa u0 com.example/com.example.MainActivity t61}
+        packageName=com.example processName=com.example
+
+  topResumedActivity=ActivityRecord{2b2ce0f u0 com.example/.DetailActivity t61}
+`;
+
+describe("GetBackStack real-output parsing (#4197)", () => {
+  test("parses every activity out of a real-format multi-task dump", async () => {
+    const result = await parse(LEGACY_MULTI_TASK);
+
+    expect(result.activities.map(a => a.name)).toEqual([
+      "com.android.launcher3.Launcher",
+      "dev.jasonpearson.automobile.playground.DetailActivity",
+      "dev.jasonpearson.automobile.playground.ListActivity",
+      "dev.jasonpearson.automobile.playground.MainActivity"
+    ]);
+  });
+
+  test("reads each activity's task id from its own tNN suffix", async () => {
+    const result = await parse(LEGACY_MULTI_TASK);
+
+    expect(result.activities.map(a => a.taskId)).toEqual([1, 123, 123, 123]);
+  });
+
+  test("marks Hist #0 as the task root, not the topmost activity", async () => {
+    const result = await parse(LEGACY_MULTI_TASK);
+
+    const roots = result.activities.filter(a => a.isTaskRoot).map(a => a.name);
+    expect(roots).toEqual([
+      "com.android.launcher3.Launcher",
+      "dev.jasonpearson.automobile.playground.MainActivity"
+    ]);
+    // The topmost (resumed) activity is explicitly NOT the root.
+    expect(result.activities.find(a => a.name.endsWith(".DetailActivity"))?.isTaskRoot).toBe(false);
+  });
+
+  test("computes depth as poppable entries in the current task", async () => {
+    const result = await parse(LEGACY_MULTI_TASK);
+
+    expect(result.currentTaskId).toBe(123);
+    expect(result.depth).toBe(2);
+  });
+
+  test("parses the modern two-space Hist form and its task id", async () => {
+    const result = await parse(MODERN_SINGLE_TASK);
+
+    expect(result.activities.map(a => a.name)).toEqual([
+      "com.example.DetailActivity",
+      "com.example.MainActivity"
+    ]);
+    expect(result.activities.map(a => a.taskId)).toEqual([61, 61]);
+    expect(result.activities.map(a => a.isTaskRoot)).toEqual([false, true]);
+    expect(result.depth).toBe(1);
+  });
+
+  test("carries the enclosing task affinity onto its activities", async () => {
+    const result = await parse(LEGACY_MULTI_TASK);
+
+    expect(result.activities[0].taskAffinity).toBe("com.android.launcher3");
+    expect(result.activities[3].taskAffinity).toBe("dev.jasonpearson.automobile.playground");
+  });
+
+  describe("degenerate input", () => {
+    test("no tasks at all", async () => {
+      const result = await parse("ACTIVITY MANAGER ACTIVITIES (dumpsys activity activities)\n");
+
+      expect(result.activities).toEqual([]);
+      expect(result.tasks).toEqual([]);
+      expect(result.depth).toBe(0);
+    });
+
+    test("a task with no activities", async () => {
+      const result = await parse(`
+    Task id #7
+    affinity=com.example
+    realActivity=com.example/.MainActivity
+    numActivities=0
+`);
+
+      expect(result.activities).toEqual([]);
+      expect(result.tasks).toHaveLength(1);
+      expect(result.tasks[0].id).toBe(7);
+      expect(result.depth).toBe(0);
+    });
+
+    test("a malformed activity line mid-block does not drop its neighbours", async () => {
+      const result = await parse(`
+    Task id #9
+    affinity=com.example
+      * Hist #2: ActivityRecord{aaa u0 com.example/.TopActivity t9}
+      * Hist #1: ActivityRecord{bbb u0 com.example
+      * Hist #0: ActivityRecord{ccc u0 com.example/.MainActivity t9}
+
+  mResumedActivity: ActivityRecord{aaa u0 com.example/.TopActivity t9}
+`);
+
+      expect(result.activities.map(a => a.name)).toEqual([
+        "com.example.TopActivity",
+        "com.example.MainActivity"
+      ]);
+      expect(result.depth).toBe(1);
+    });
+
+    test("an activity line without a tNN suffix falls back to the enclosing task", async () => {
+      const result = await parse(`
+    Task id #5
+    affinity=com.example
+      * Hist #0: ActivityRecord{aaa u0 com.example/.MainActivity}
+`);
+
+      expect(result.activities).toHaveLength(1);
+      expect(result.activities[0].taskId).toBe(5);
+      expect(result.activities[0].isTaskRoot).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The `dumpsys activity activities` activity regex in `GetBackStack.parseActivities` expected the
user id and component to appear **after** the closing brace of `ActivityRecord{...}`:

```
ActivityRecord{abc123} u0 com.example/.MainActivity t123     <-- what the regex wanted
```

AOSP's `ActivityRecord.toString()` puts them **inside** the braces:

```
* Hist  #0: ActivityRecord{2b2ce0f u0 com.example/.MainActivity t61}     <-- what dumpsys emits
```

No Android version emits the first shape, so `parseActivities` returned `[]` against every real
capture and `depth` was consequently always `0` — matching the report in #4197.

While fixing it, `isTaskRoot` turned out to be inverted. It was assigned to
`activitiesInCurrentTask[0]`, but dumpsys prints activities top-of-stack first, so index 0 is the
**topmost** activity, not the root. It is now derived from the activity's own `Hist #N` index —
`#0` is the task root — which is authoritative regardless of list ordering. This is the "pins
backwards semantics" concern the audit's critic raised in the issue; the semantics are now written
down as prose at the top of the new test file.

Each activity's task id is also now read from its own `tNN` suffix, falling back to the enclosing
task header only when the line omits it. That keeps activity parsing correct even when the
task-header line uses a format the task parser does not recognize.

### Correction: the task id's position is version-dependent

An earlier revision of this PR framed "user id, component **and task id** inside the braces" as
universal. Review pushed back, and the repo's own committed captures settle it. Surveying every
`ActivityRecord` string under `test/features/observe/windowDumps/`:

| API level | shape |
| --- | --- |
| 26–29 | `ActivityRecord{9987e1b u0 com.example/.Main t5}` (plus enclosing window-token braces) |
| 30, 31, 32, 34, 35, 36 | `ActivityRecord{6f2ed08 u0 com.android.settings/.Settings t6}` |
| **33** | `ActivityRecord{a9cf40f u0 com.android.settings/.Settings} t8}` |

The component is inside the braces on every level — that part of the thesis holds, and it is the
actual bug in #4197. But **API 33 alone** closes the component with its own brace and trails the
task id outside it. The regex only recognized the task id in the inside position, so on API 33 it
came back `undefined` and every activity fell back to the enclosing task header — the same header
whose modern `Task{...}` form the task parser does not recognize (#4223).

The task id is now scanned for as a standalone `tNN` token anywhere in the tail, on either side of a
closing brace, and the component group is bounded to exclude `}`. This also firms up the honest
caveat below: the `f}` / `t??` shapes were read out of `ActivityRecord.toString()` rather than
captured, but the API 33 shape is now grounded in a committed capture.

## Linked Issue

Closes #4197

## Bug / Regression Context

- **Prior attempts:** `a3a5042a1 Harden dumpsys parsing for Android observe` touched this parser but
  kept the after-the-brace shape.
- **Observed symptom:** `{ depth: 0, activities: [], tasks: [{ id: 123 }] }` — tasks parse, activities
  never do, so `backStackDepth` recorded into the navigation graph is always 0 and
  `DefaultPathOptimizer`'s depth comparison can never fire.
- **Repro steps / conditions:** any `observe` on Android. Reproduced here **without a device**: every
  `ActivityRecord` sample committed in this repo — `test/features/observe/Window.test.ts:248` (a real
  `dumpsys window` capture), the documented format at
  `src/utils/android-cmdline-tools/AdbClient.ts:1000-1002`, and this file's own pre-existing mock —
  uses the inside-the-braces shape, and the old regex rejects all of them. Confirming evidence in the
  same test file: the sibling `topResumedActivity` regex is written with `.*?` instead of requiring
  `\}`, which is the only reason `currentActivity` kept working while `activities` did not.

## Validation

- [x] Rebased onto `origin/main` after #4217, #4224 and #4229 landed.
- [x] `bun run lint` clean; `bun test` — **8376 pass, 0 fail**, 11 skip, 28.9s. The
      `InputText.test.ts` flake noted on the previous revision did not reproduce post-rebase.
- [x] `bun run typecheck` reports no NEW errors from this diff (225 known baseline errors). The
      `telemetryPushSocketServer.ts` drift previously seen here is gone — the rebase picked up its
      fix. The gate now reports 10 baseline errors that no longer occur; the baseline is
      deliberately **not** ratcheted down in this PR to avoid colliding with in-flight PRs.
- [x] New code uses interfaces + fakes; the new suite runs in ~5ms
- [x] Reuses the existing `FakeAdbExecutor` / `FakeAdbClientFactory` seams; no new dependencies

Note: some `main` breakage is unrelated to this diff (#4212 BATS bash 3.2, and iOS/XCTestRunner
simulator legs). Those are expected here too and are not caused by this change, which is pure string
parsing with no Swift, shell or device surface.

## Device Verification

- [ ] N/A — pure string-parsing change, and devices were off-limits for this session (another agent
      holds the daemon). No `adb`/`dumpsys` was run. Verification is instead grounded in the
      **committed** captures under `test/features/observe/windowDumps/`, which cover API 25–36 and
      are what surfaced the API 33 divergence above. The issue asked for fresh captures from two API
      levels; see Follow-ups.

## Testing

New `test/features/observe/GetBackStackParsing.test.ts` is table-driven over two fixtures plus the
degenerate rows the issue asked for. It opens with a prose statement of the wire format, the
ordering/task-root semantics, and what `depth` counts.

- multi-task legacy-style block (`Task id #N`, single-space `Hist #N:`): all 4 activities parsed,
  per-activity task ids, `isTaskRoot` on the `Hist #0` entries only and explicitly **not** on the
  resumed activity, `depth === 2`, task affinity carried onto activities
- modern-style block (two-space `Hist  #0:`, `Task{<hash> #61 ...}` header): activities and their
  task ids parse from the activity lines alone
- **API 33 shape**: the two `ActivityRecord` strings copied verbatim out of
  `test/features/observe/windowDumps/api33-settings-window-dump.log:289` and `:318`, under a task
  header carrying a task id the activities deliberately do NOT belong to — so both a component
  ending in `}` and a task id silently falling back to the header fail the test
- degenerate: no tasks; a task with no activities; a malformed activity line mid-block (neighbours
  survive); an activity line with no `tNN` suffix (falls back to the enclosing task)

All 10 were red before the fix (`activities` was `[]`) and green after. The pre-existing suite still
passes, with its vacuous `toBeGreaterThanOrEqual(0) // May be 0 if regex doesn't match` assertion
tightened to the real count.

## Follow-ups

- [ ] #4223 — task-header parsing does not recognize the modern `* Task{<hash> #61 ...}` line, and
      capture real fixtures from an emulator + physical device on two API levels

