### PR TITLE
fix(ci): make typecheck baseline signatures union-order-insensitive

### DIFF
--- a/scripts/typecheck-baseline.sh
+++ b/scripts/typecheck-baseline.sh
@@ -116,17 +116,75 @@ detect_tsc_version() {
 # machine.
 ROOT_SED_PATTERN="$(printf '%s' "$ROOT" | sed 's/[][\.*^$|/]/\\&/g')"
 
+# Union-order canonicalization (issue #4211).
+#
+# `tsc` renders a union's members in the order their literal types were first
+# instantiated across the program, NOT in declaration order. That instantiation
+# order shifts when the module graph changes, so the SAME error under the SAME
+# pinned tsc can render as
+#     severity: "critical" | "high" | "medium" | "low"     (when baselined)
+#     severity: "high" | "medium" | "critical" | "low"     (later)
+# Because the signature embeds the rendered type text verbatim, a reordering made
+# the baselined error read as NEW while the identical baselined one read as
+# FIXED -- turning `main` red with no code change (issue #4211, and the reason
+# issue #4209 was filed). The gate is meant to key on the ERROR, and `A | B` and
+# `B | A` are the same type, so member order must not be part of the key.
+#
+# Each maximal run of `TOKEN ( " | " TOKEN )+` is byte-sorted in place. TOKEN is
+# deliberately narrow -- a double-quoted string literal or a bare identifier --
+# so a run whose members are complex (object literals, generics) is left ALONE
+# rather than mis-parsed; leaving it alone is exactly today's behavior, so the
+# conservative match can only preserve the status quo, never corrupt a signature.
+# Runs are matched independently, so adjacent unions separated by `;` are sorted
+# separately and never bleed into one another.
+#
+# This is order-INSENSITIVE, not laxer: sorting is a canonical form, so two
+# errors collide only when their union members are the same multiset -- i.e.
+# when they are genuinely the same type. A union with a DIFFERENT member still
+# produces a different signature and is still caught as new (pinned by the
+# "different union members" BATS case).
+#
+# LC_ALL=C is exported at the top of this script, so the sort is byte-wise and
+# identical on every machine.
+canonicalize_unions() {
+  awk '
+    function canon_unions(line,   out, rest, run, n, arr, i, j, t, joined) {
+      out = ""
+      rest = line
+      while (match(rest, /("[^"]*"|[A-Za-z_$][A-Za-z0-9_$]*)( [|] ("[^"]*"|[A-Za-z_$][A-Za-z0-9_$]*))+/)) {
+        out = out substr(rest, 1, RSTART - 1)
+        run = substr(rest, RSTART, RLENGTH)
+        rest = substr(rest, RSTART + RLENGTH)
+        # split on a literal " | " -- the bracket expression stops awk reading
+        # the pipe as regex alternation.
+        n = split(run, arr, " [|] ")
+        for (i = 1; i <= n; i++)
+          for (j = i + 1; j <= n; j++)
+            if (arr[i] > arr[j]) { t = arr[i]; arr[i] = arr[j]; arr[j] = t }
+        joined = arr[1]
+        for (i = 2; i <= n; i++) joined = joined " | " arr[i]
+        out = out joined
+      }
+      return out rest
+    }
+    { print canon_unions($0) }
+  '
+}
+
 # Reduce raw tsc output to a sorted multiset of stable error signatures.
 # 1. keep only top-level error lines (indented detail lines are dropped);
 # 2. strip the "(line,col)" file location (first "(n,n)" only, via no /g flag),
 #    so line shifts don't churn the baseline and message-embedded numbers survive;
-# 3. strip the absolute repo-root prefix from message-embedded paths.
+# 3. strip the absolute repo-root prefix from message-embedded paths;
+# 4. canonicalize union member order (issue #4211) so a re-rendered union does
+#    not read as a new error.
 # The `grep` is guarded with `|| true` so a clean tree (zero matching lines) does
 # not abort the script under `set -o pipefail`.
 normalize() {
   { grep -E '^[^[:space:]].*: error TS[0-9]+' || true; } \
     | sed -E 's/\(([0-9]+),([0-9]+)\)//' \
     | sed "s|${ROOT_SED_PATTERN}/||g" \
+    | canonicalize_unions \
     | sort
 }
 
@@ -175,12 +233,20 @@ swap_fingerprints() {
             if (joined != "") print "# swap-fp: " joined " :: " sig
           }
         }' \
+    | canonicalize_unions \
     | sort
 }
 
 # Baseline signatures only, i.e. the committed file minus its `#` header lines.
+#
+# The stored signatures are canonicalized on READ as well as on write (issue
+# #4211). `normalize()` now emits union members byte-sorted, so a baseline
+# committed BEFORE that change still holds unsorted unions; canonicalizing here
+# means such a baseline keeps matching instead of every union-bearing signature
+# reading as simultaneously new and fixed. It is idempotent for a freshly
+# written baseline, so the two paths cannot drift.
 baseline_signatures() {
-  grep -v '^#' "$BASELINE" || true
+  { grep -v '^#' "$BASELINE" || true; } | canonicalize_unions
 }
 
 # tsc exits 0 on a clean check and non-zero (2) when it reports diagnostics --
@@ -271,7 +337,13 @@ fi
 # against the current ones; a signature whose count is unchanged but whose column
 # multiset moved is a likely swap. Advisory ONLY -- never changes the exit code,
 # and silently no-ops for baselines generated before this field existed.
-baseline_swap_fp="$(grep -E '^# swap-fp: ' "$BASELINE" || true)"
+# Canonicalized on read for the same reason as `baseline_signatures()` (issue
+# #4211): the signature half of a `# swap-fp:` line stored before canonicalization
+# holds unsorted unions. Without this, every union-bearing fingerprint would look
+# "moved" against the now-canonical current set and the advisory would fire on
+# dozens of signatures at once -- noise that trains readers to ignore a guard
+# whose whole value is being rare.
+baseline_swap_fp="$({ grep -E '^# swap-fp: ' "$BASELINE" || true; } | canonicalize_unions)"
 if [[ -n "$baseline_swap_fp" ]]; then
   current_swap_fp="$(printf '%s\n' "$raw_tsc" | swap_fingerprints)"
   swap_moved="$(comm -13 \

--- a/test/bats/typecheck-baseline.bats
+++ b/test/bats/typecheck-baseline.bats
@@ -254,3 +254,87 @@ teardown() {
   [[ "$output" != *"swap-guard"* ]]
   [[ "$output" == *"no new type errors"* ]]
 }
+
+# --- Union member order canonicalization (issue #4211) -----------------------
+#
+# `tsc` renders union members in type-instantiation order, which shifts when the
+# module graph changes. A reordered union used to read as a NEW error while the
+# identical baselined one read as FIXED, turning `main` red with no code change.
+
+@test "check mode PASSES when a baselined union is re-rendered in a different order" {
+  orig='printf "%s\n" "src/u.ts(1,1): error TS2339: Property (s) does not exist on type { severity: \"critical\" | \"high\" | \"medium\" | \"low\"; }."'
+  TYPECHECK_TSC_CMD="$orig" bash "$SCRIPT" --update
+
+  # Same error, same members, different render order -- must not be "new".
+  reordered='printf "%s\n" "src/u.ts(1,1): error TS2339: Property (s) does not exist on type { severity: \"high\" | \"medium\" | \"critical\" | \"low\"; }."'
+  TYPECHECK_TSC_CMD="$reordered" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no new type errors"* ]]
+  # It must not be reported as fixed either -- that would mean the two signatures
+  # still differ and merely cancelled out in the counts.
+  [[ "$output" != *"no longer occur"* ]]
+}
+
+@test "canonicalization is order-insensitive, NOT laxer: different union members still fail" {
+  orig='printf "%s\n" "src/u.ts(1,1): error TS2339: Property (s) does not exist on type { severity: \"critical\" | \"high\" | \"medium\" | \"low\"; }."'
+  TYPECHECK_TSC_CMD="$orig" bash "$SCRIPT" --update
+
+  # One member genuinely changed ("low" -> "trivial"): a different type, so a
+  # different error, so the gate must still fail closed.
+  changed='printf "%s\n" "src/u.ts(1,1): error TS2339: Property (s) does not exist on type { severity: \"critical\" | \"high\" | \"medium\" | \"trivial\"; }."'
+  TYPECHECK_TSC_CMD="$changed" run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"1 NEW TypeScript error"* ]]
+}
+
+@test "a genuinely new error is still caught alongside a reordered union" {
+  orig='printf "%s\n" "src/u.ts(1,1): error TS2339: Property (s) does not exist on type { severity: \"critical\" | \"high\"; }."'
+  TYPECHECK_TSC_CMD="$orig" bash "$SCRIPT" --update
+
+  # The union reorders AND an unrelated error appears; only the latter is new.
+  both='printf "%s\n" \
+    "src/u.ts(1,1): error TS2339: Property (s) does not exist on type { severity: \"high\" | \"critical\"; }." \
+    "src/new.ts(2,2): error TS2551: Property (q) does not exist."'
+  TYPECHECK_TSC_CMD="$both" run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"1 NEW TypeScript error"* ]]
+  [[ "$output" == *"src/new.ts"* ]]
+  [[ "$output" != *"src/u.ts"* ]]
+}
+
+@test "a legacy baseline with unsorted unions still matches after the change" {
+  # Simulate a baseline committed BEFORE canonicalization existed: written by
+  # hand with members in non-sorted order, exactly as the real committed
+  # baseline holds them.
+  cat > "$TYPECHECK_BASELINE" <<EOF
+# AutoMobile typecheck baseline (issue #3001) -- see scripts/typecheck-baseline.sh
+# generated-with: tsc 6.0.3
+src/legacy.ts: error TS2339: Property (s) does not exist on type { k: "zebra" | "apple" | "mango"; }.
+EOF
+
+  same='printf "%s\n" "src/legacy.ts(9,9): error TS2339: Property (s) does not exist on type { k: \"zebra\" | \"apple\" | \"mango\"; }."'
+  TYPECHECK_TSC_VERSION="6.0.3" TYPECHECK_TSC_CMD="$same" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no new type errors"* ]]
+  [[ "$output" != *"no longer occur"* ]]
+}
+
+@test "adjacent unions separated by a semicolon are sorted independently" {
+  orig='printf "%s\n" "src/two.ts(1,1): error TS2339: Bad type { a: \"y\" | \"x\"; b: string | null; }."'
+  TYPECHECK_TSC_CMD="$orig" bash "$SCRIPT" --update
+
+  # Each run canonicalizes on its own; members must not migrate across the ";".
+  grep -q 'a: "x" | "y"; b: null | string;' "$TYPECHECK_BASELINE"
+}
+
+@test "a union with complex members is left untouched rather than mis-parsed" {
+  orig='printf "%s\n" "src/c.ts(1,1): error TS2345: Type { a: number } | null is not assignable."'
+  TYPECHECK_TSC_CMD="$orig" bash "$SCRIPT" --update
+
+  # The object-literal member is not a bare token, so the conservative matcher
+  # leaves the run alone -- preserving today'"'"'s behavior instead of corrupting it.
+  grep -q 'Type { a: number } | null is not assignable' "$TYPECHECK_BASELINE"
+
+  TYPECHECK_TSC_CMD="$orig" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

`main` was red on the typecheck baseline gate, so every TS-touching PR failed `Node TypeScript Build and Test (ubuntu-latest)` regardless of its contents.

**The reported error was already in the baseline.** `scripts/typecheck-baseline.txt:10` recorded the exact `TS2339`, but with the `severity` union in a different member order. Comparing the two strings character by character, the *sole* difference is:

```
baseline: critical" | "high" | "medium
current:  high" | "medium" | "critical
```

Every other character is identical, and the same pinned `tsc 6.0.3` produced both — so this is not the version drift the baseline header warns about.

`tsc` renders a union's members in the order their literal types were first *instantiated* across the program, not in declaration order. That instantiation order shifts when the module graph changes. Since the signature embeds the rendered type text verbatim, a reordering makes the baselined error read as **new** while the identical baselined one reads as **fixed** — the gate fails and simultaneously reports the same error as resolved. `# swap-fp:` lines existed for this very signature and did not absorb it, because that mechanism compares columns, not type text.

## Fix

`canonicalize_unions()` byte-sorts the members of each maximal `TOKEN ( " | " TOKEN )+` run. It is applied in three places:

- `normalize()` — so newly written baselines are canonical;
- `baseline_signatures()` — so the **already-committed** baseline keeps matching without regeneration;
- the `# swap-fp:` read — so legacy fingerprints don't all read as "moved" and drown the swap advisory in noise.

`TOKEN` is deliberately narrow (a double-quoted string literal or a bare identifier). A run with complex members — object literals, generics — is left **alone** rather than mis-parsed, so the conservative matcher can only preserve today's behavior, never corrupt a signature. Runs are matched independently, so adjacent unions separated by `;` never bleed into one another.

`LC_ALL=C` is already exported at the top of the script, so the sort is byte-wise and identical on every machine.

### This is order-insensitive, not laxer

The explicit concern was that canonicalizing must not let a genuinely new error slip through by colliding with a baselined signature. Sorting is a *canonical form*, so two signatures collide only when their union members are the same multiset — i.e. when they denote the same type, since `A | B` and `B | A` *are* the same type in TypeScript. A union with a genuinely different member still produces a different signature and still fails the gate.

Three of the new tests pin exactly this: `different union members still fail`, `a genuinely new error is still caught alongside a reordered union`, and `a union with complex members is left untouched`.

## Linked Issue

Closes #4211

## Relationship to #4208 / #4209

Three issues were filed for this one red gate.

- **#4211 (this PR)** — the gate mechanism. Verified: the delta really is *only* union member ordering.
- **#4208 (separate PR #4215)** — the underlying product bug. The `TS2339` is *also* genuine: `failure_occurrences.session_id` is never selected, so `r.sessionId` is always `undefined` and backfilled crash/ANR events ship `sessionId: null`, invisible to session-filtered subscribers. Kept separate deliberately — a daemon/telemetry behavior change does not belong in a CI-normalizer fix.
- **#4209** — closed as a duplicate of the two above.

**Either PR independently turns the gate green**, by different mechanisms: this one makes the signature match again; #4215 removes the error entirely. They do not conflict — this PR does not touch `scripts/typecheck-baseline.txt`, and #4215 only deletes the two now-obsolete lines for that one signature. Merge order does not matter.

This fix remains necessary even after #4215, because the order-sensitivity applies to the ~224 *other* baselined signatures, many of which contain unions.

## Validation

- [x] **The decisive check** — on a pristine `origin/main` worktree with *only* this script change and no `src/` edits, `bun run typecheck` goes from red to `✅ no new type errors (225 known error(s) in baseline)`. The TS2339 is reported neither as new nor as fixed, i.e. it genuinely matched.
- [x] `bats test/bats/typecheck-baseline.bats` — 24/24, all 18 pre-existing tests still green
- [x] `shellcheck scripts/typecheck-baseline.sh` — clean
- [x] `scripts/shellcheck/validate_shell_portability.sh`, `validate_shell_sete.sh`, `validate_shell_scripts.sh` — all clean
- [x] `--update` is **idempotent** — running it twice produces a byte-identical file, so canonical-write and canonical-read cannot drift
- [x] `scripts/typecheck-baseline.txt` deliberately **unchanged** — no regeneration needed, and regenerating from one platform risks dropping entries that still fire on another

## Testing

Six BATS cases added to `test/bats/typecheck-baseline.bats`:

| Test | Pins |
| --- | --- |
| reordered union passes | the actual #4211 regression |
| different union members still fail | not laxer |
| new error caught alongside a reordered union | discrimination |
| legacy unsorted baseline still matches | no regeneration required |
| adjacent unions sorted independently | members don't cross `;` |
| complex members left untouched | conservative matcher preserves status quo |

## Follow-ups

Not filed as issues, but noted for whoever does a deliberate ratchet pass: `bun run typecheck:update` currently wants to drop **10** further stale signatures, and `validate_shell_sete.sh` reports **11** baselined findings already fixed. Both baselines have drifted larger than reality. I left them alone rather than regenerate from a single platform, since an entry that no longer reproduces on macOS may still fire on ubuntu, and deleting it would turn it into a NEW error there — putting the gate straight back to red.
