### PR TITLE
fix(screen-stream): resynchronize the frame decoder after a corrupt header

### DIFF
--- a/src/features/screen-stream/frameProtocol.ts
+++ b/src/features/screen-stream/frameProtocol.ts
@@ -31,7 +31,7 @@ export const FRAME_HEADER_SIZE = 16;
  * re-lock onto garbage almost immediately.
  */
 /** Largest plausible display dimension, in pixels. */
-export const MAX_FRAME_DIMENSION = 16_384;
+const MAX_FRAME_DIMENSION = 16_384;
 /**
  * Largest row padding accepted beyond the visible `width * 4` BGRA bytes.
  * `CVPixelBufferGetBytesPerRow` aligns rows to a small boundary (real captures
@@ -40,11 +40,11 @@ export const MAX_FRAME_DIMENSION = 16_384;
  * ties two of the four header words together, which arbitrary payload bytes
  * almost never satisfy.
  */
-export const MAX_ROW_PADDING_BYTES = 4096;
+const MAX_ROW_PADDING_BYTES = 4096;
 /** Largest plausible single-frame pixel payload (256 MiB). */
-export const MAX_FRAME_PAYLOAD_BYTES = 256 * 1024 * 1024;
+const MAX_FRAME_PAYLOAD_BYTES = 256 * 1024 * 1024;
 /** Largest plausible audio record (16 MiB ≈ 17 minutes of 8 kHz PCM16LE). */
-export const MAX_AUDIO_PAYLOAD_BYTES = 16 * 1024 * 1024;
+const MAX_AUDIO_PAYLOAD_BYTES = 16 * 1024 * 1024;
 
 export interface FrameHeader {
   width: number;
@@ -62,7 +62,7 @@ export interface DecodedAudio {
   pcm16le: Buffer;
 }
 
-export type MalformedFrameReason =
+type MalformedFrameReason =
   | "header_width_zero"
   | "header_height_zero"
   | "header_bytes_per_row_too_small"
@@ -110,19 +110,21 @@ export class FrameDecoder {
         const outcome = this.takeHeader(onMalformed);
         if (outcome === "starved") {break;}
         if (outcome === "malformed") {continue;}
+        this.pendingHeader = outcome;
       }
 
-      const expected = payloadSize(this.pendingHeader);
+      const pending = this.pendingHeader;
+      const expected = payloadSize(pending);
       if (this.buffer.length < expected) {break;}
 
       // Copy pixels to release the underlying chunk allocation; otherwise
       // every emitted frame pins the entire upstream buffer in memory.
       const payload = Buffer.from(this.buffer.subarray(0, expected));
       this.buffer = this.buffer.subarray(expected);
-      if (isAudioHeader(this.pendingHeader)) {
+      if (isAudioHeader(pending)) {
         onAudio?.({ pcm16le: payload });
       } else {
-        frames.push({ header: this.pendingHeader, pixels: payload });
+        frames.push({ header: pending, pixels: payload });
       }
       this.pendingHeader = null;
     }
@@ -138,7 +140,7 @@ export class FrameDecoder {
    */
   private takeHeader(
     onMalformed?: (error: MalformedFrameError) => void
-  ): "ok" | "starved" | "malformed" {
+  ): FrameHeader | "starved" | "malformed" {
     if (this.buffer.length < FRAME_HEADER_SIZE) {return "starved";}
     const header = parseHeader(this.buffer, 0);
     const malformed = headerError(header);
@@ -148,8 +150,7 @@ export class FrameDecoder {
       return "malformed";
     }
     this.buffer = this.buffer.subarray(FRAME_HEADER_SIZE);
-    this.pendingHeader = header;
-    return "ok";
+    return header;
   }
 
   /**
@@ -180,14 +181,23 @@ export class FrameDecoder {
       if (verdict === "unsettled" && firstUnsettled < 0) {firstUnsettled = offset;}
     }
 
-    // Keep the earliest candidate that more bytes could still confirm;
-    // otherwise keep only what could be a header straddling the chunk
-    // boundary. Copy so the discarded chunk allocation can be freed.
+    // A corroborated candidate outranks an earlier unproven one — payload
+    // bytes one byte before a real boundary can spell a valid header, and only
+    // corroboration tells the two apart. So the scan runs to the end before
+    // falling back to the earliest candidate more bytes could still confirm;
+    // failing that, keep only what could be a header straddling the chunk
+    // boundary. The retained region is rescanned when the next chunk arrives,
+    // which is bounded in practice: post-validation a random offset is a
+    // plausible header with probability ~2^-38, so the fallback is virtually
+    // always the genuine next frame, settled as soon as its payload lands.
     const keepFrom =
       firstUnsettled >= 0
         ? firstUnsettled
         : Math.max(0, this.buffer.length - (FRAME_HEADER_SIZE - 1));
-    this.buffer = Buffer.from(this.buffer.subarray(keepFrom));
+    if (keepFrom > 0) {
+      // Copy so the discarded chunk allocation can be freed.
+      this.buffer = Buffer.from(this.buffer.subarray(keepFrom));
+    }
     return false;
   }
 

--- a/src/features/screen-stream/frameProtocol.ts
+++ b/src/features/screen-stream/frameProtocol.ts
@@ -85,6 +85,21 @@ export class FrameDecoder {
    * one corrupt frame produces one report, not one per 16 discarded bytes.
    */
   private resynchronizing: boolean = false;
+  /**
+   * Offsets into `buffer`, ascending, whose corroboration is still pending
+   * because the bytes that would settle them have not arrived. These are the
+   * only already-examined offsets a later chunk can change the verdict of.
+   */
+  private unsettled: number[] = [];
+  /**
+   * How many leading bytes of `buffer` the forward scan has already examined.
+   * Offsets below this are settled for good: a 16-byte window is immutable once
+   * buffered, so an implausible header stays implausible, and a candidate
+   * rejected by its successor stays rejected. Carrying this cursor across
+   * pushes is what keeps resynchronization linear in the bytes received rather
+   * than re-parsing the whole retained buffer on every chunk.
+   */
+  private scanned: number = 0;
 
   /**
    * Append bytes from the helper's stdout stream and return any frames that
@@ -146,6 +161,7 @@ export class FrameDecoder {
     const malformed = headerError(header);
     if (malformed) {
       this.resynchronizing = true;
+      this.resetScan();
       onMalformed?.({ reason: malformed, header });
       return "malformed";
     }
@@ -164,21 +180,28 @@ export class FrameDecoder {
    * one can spell a perfectly plausible header. Each candidate is corroborated
    * by checking that whatever follows its payload is itself a valid header (or
    * that the payload runs exactly to the end of what has arrived).
+   *
+   * Each byte offset is examined exactly once across the whole resynchronization,
+   * not once per chunk. Only offsets still awaiting corroboration are re-asked,
+   * and there are almost never more than one of those: post-validation a random
+   * offset is a plausible header with probability ~2^-38.
    */
   private resynchronize(): boolean {
-    const lastOffset = this.buffer.length - FRAME_HEADER_SIZE;
-    let firstUnsettled = -1;
+    const pending: number[] = [];
+    // Ascending offset order overall — every retained candidate sits below the
+    // scan cursor, every newly examinable offset at or above it — so this still
+    // accepts the lowest-offset candidate that corroborates, as a single
+    // whole-buffer pass did.
+    let accepted = this.scan(this.unsettled, pending);
+    if (accepted < 0) {
+      accepted = this.scan(range(this.scanned, this.buffer.length - FRAME_HEADER_SIZE), pending);
+    }
 
-    for (let offset = 0; offset <= lastOffset; offset++) {
-      const header = parseHeader(this.buffer, offset);
-      if (headerError(header) !== null) {continue;}
-      const verdict = this.corroborate(offset, header);
-      if (verdict === "accept") {
-        this.buffer = this.buffer.subarray(offset);
-        this.resynchronizing = false;
-        return true;
-      }
-      if (verdict === "unsettled" && firstUnsettled < 0) {firstUnsettled = offset;}
+    if (accepted >= 0) {
+      this.buffer = this.buffer.subarray(accepted);
+      this.resetScan();
+      this.resynchronizing = false;
+      return true;
     }
 
     // A corroborated candidate outranks an earlier unproven one — payload
@@ -186,19 +209,48 @@ export class FrameDecoder {
     // corroboration tells the two apart. So the scan runs to the end before
     // falling back to the earliest candidate more bytes could still confirm;
     // failing that, keep only what could be a header straddling the chunk
-    // boundary. The retained region is rescanned when the next chunk arrives,
-    // which is bounded in practice: post-validation a random offset is a
-    // plausible header with probability ~2^-38, so the fallback is virtually
-    // always the genuine next frame, settled as soon as its payload lands.
-    const keepFrom =
-      firstUnsettled >= 0
-        ? firstUnsettled
-        : Math.max(0, this.buffer.length - (FRAME_HEADER_SIZE - 1));
-    if (keepFrom > 0) {
-      // Copy so the discarded chunk allocation can be freed.
-      this.buffer = Buffer.from(this.buffer.subarray(keepFrom));
-    }
+    // boundary.
+    this.scanned = Math.max(this.scanned, this.buffer.length - FRAME_HEADER_SIZE + 1, 0);
+    this.unsettled = pending;
+    this.discardSettledPrefix();
     return false;
+  }
+
+  /**
+   * Examine `offsets` in order, returning the first that corroborates, or -1.
+   * Offsets whose verdict more bytes could still change are appended to
+   * `pending`; settled ones are dropped and never looked at again.
+   */
+  private scan(offsets: Iterable<number>, pending: number[]): number {
+    for (const offset of offsets) {
+      const header = parseHeader(this.buffer, offset);
+      if (headerError(header) !== null) {continue;}
+      const verdict = this.corroborate(offset, header);
+      if (verdict === "accept") {return offset;}
+      if (verdict === "unsettled") {pending.push(offset);}
+    }
+    return -1;
+  }
+
+  /**
+   * Drop the leading bytes that can no longer begin a frame, rebasing the scan
+   * cursor and the retained candidates onto the shortened buffer.
+   */
+  private discardSettledPrefix(): void {
+    const keepFrom =
+      this.unsettled.length > 0
+        ? this.unsettled[0]
+        : Math.max(0, this.buffer.length - (FRAME_HEADER_SIZE - 1));
+    if (keepFrom === 0) {return;}
+    // Copy so the discarded chunk allocation can be freed.
+    this.buffer = Buffer.from(this.buffer.subarray(keepFrom));
+    this.unsettled = this.unsettled.map(offset => offset - keepFrom);
+    this.scanned = Math.max(0, this.scanned - keepFrom);
+  }
+
+  private resetScan(): void {
+    this.unsettled = [];
+    this.scanned = 0;
   }
 
   /**
@@ -229,6 +281,11 @@ export class FrameDecoder {
     if (this.buffer.length - end < FRAME_HEADER_SIZE) {return "unsettled";}
     return headerError(parseHeader(this.buffer, end)) === null ? "accept" : "reject";
   }
+}
+
+/** Lazily yields `from..toInclusive`, so a scan never materializes the range. */
+function* range(from: number, toInclusive: number): Generator<number> {
+  for (let value = from; value <= toInclusive; value++) {yield value;}
 }
 
 function isAudioHeader(header: FrameHeader): boolean {

--- a/src/features/screen-stream/frameProtocol.ts
+++ b/src/features/screen-stream/frameProtocol.ts
@@ -203,16 +203,30 @@ export class FrameDecoder {
 
   /**
    * Decide whether a candidate header at `offset` really is a frame boundary.
-   * "unsettled" means the buffered bytes cannot answer yet — the caller keeps
+   * The only evidence accepted is a valid header sitting exactly where this
+   * candidate's payload ends.
+   *
+   * Deliberately *not* evidence: the payload ending at the end of the buffer.
+   * stdout splits wherever the pipe happens to flush, so a chunk boundary says
+   * nothing about frame boundaries — trusting it lets payload bytes that spell
+   * a plausible header be emitted as a fabricated frame, which would feed
+   * garbage dimensions to the encoder downstream. Waiting costs one chunk of
+   * latency, once, on a path that is already degraded.
+   *
+   * The converse case is a real trade-off: when a recovered frame is followed
+   * immediately by a *second* corrupt header, that frame is rejected and
+   * dropped even though it was genuine. Accepting it would mean accepting any
+   * candidate whose successor is invalid — the exact rule that fabricates
+   * frames out of payload bytes. One dropped frame during back-to-back
+   * corruption is the cheaper error.
+   *
+   * "unsettled" means the buffered bytes cannot answer yet; the caller keeps
    * the candidate and re-asks once more data arrives. Retention is bounded by
    * the same payload ceiling that bounds normal decoding.
    */
   private corroborate(offset: number, header: FrameHeader): "accept" | "unsettled" | "reject" {
     const end = offset + FRAME_HEADER_SIZE + payloadSize(header);
-    const trailing = this.buffer.length - end;
-    if (trailing < 0) {return "unsettled";}
-    if (trailing === 0) {return "accept";}
-    if (trailing < FRAME_HEADER_SIZE) {return "unsettled";}
+    if (this.buffer.length - end < FRAME_HEADER_SIZE) {return "unsettled";}
     return headerError(parseHeader(this.buffer, end)) === null ? "accept" : "reject";
   }
 }

--- a/src/features/screen-stream/frameProtocol.ts
+++ b/src/features/screen-stream/frameProtocol.ts
@@ -11,9 +11,40 @@
  * The decoder buffers incoming chunks and emits complete frames as soon as
  * enough bytes have arrived. It tolerates arbitrary chunking from the helper's
  * stdout pipe.
+ *
+ * Corrupt headers are the interesting case. A corrupt header carries no usable
+ * payload length, so the decoder cannot know where the damaged frame ends.
+ * Skipping only the 16 header bytes would walk the payload as if it were a
+ * sequence of headers, amplifying one bad frame on the wire into thousands of
+ * downstream callbacks. Instead the decoder enters a resynchronizing state:
+ * it reports the corruption exactly once, then scans forward byte by byte for
+ * the next structurally plausible header and resumes there.
  */
 
 export const FRAME_HEADER_SIZE = 16;
+
+/**
+ * Structural bounds used to decide whether 16 bytes are a plausible header.
+ * These are not protocol limits — they are the sanity envelope that makes
+ * resynchronization reliable. Without them roughly one in eight arbitrary
+ * offsets in a payload satisfies the header rules, so a forward scan would
+ * re-lock onto garbage almost immediately.
+ */
+/** Largest plausible display dimension, in pixels. */
+export const MAX_FRAME_DIMENSION = 16_384;
+/**
+ * Largest row padding accepted beyond the visible `width * 4` BGRA bytes.
+ * `CVPixelBufferGetBytesPerRow` aligns rows to a small boundary (real captures
+ * observed at exactly `width * 4`), so a full page of slack is generous. This
+ * is the constraint that does most of the work during resynchronization: it
+ * ties two of the four header words together, which arbitrary payload bytes
+ * almost never satisfy.
+ */
+export const MAX_ROW_PADDING_BYTES = 4096;
+/** Largest plausible single-frame pixel payload (256 MiB). */
+export const MAX_FRAME_PAYLOAD_BYTES = 256 * 1024 * 1024;
+/** Largest plausible audio record (16 MiB ≈ 17 minutes of 8 kHz PCM16LE). */
+export const MAX_AUDIO_PAYLOAD_BYTES = 16 * 1024 * 1024;
 
 export interface FrameHeader {
   width: number;
@@ -31,19 +62,35 @@ export interface DecodedAudio {
   pcm16le: Buffer;
 }
 
+export type MalformedFrameReason =
+  | "header_width_zero"
+  | "header_height_zero"
+  | "header_bytes_per_row_too_small"
+  | "header_bytes_per_row_too_large"
+  | "header_dimensions_out_of_range"
+  | "header_payload_too_large"
+  | "audio_payload_too_large";
+
 export interface MalformedFrameError {
-  reason: "header_width_zero" | "header_height_zero" | "header_bytes_per_row_too_small";
+  reason: MalformedFrameReason;
   header: FrameHeader;
 }
 
 export class FrameDecoder {
   private buffer: Buffer = Buffer.alloc(0);
   private pendingHeader: FrameHeader | null = null;
+  /**
+   * True while the decoder has lost frame alignment and is scanning for the
+   * next plausible header. Malformed callbacks are suppressed in this state so
+   * one corrupt frame produces one report, not one per 16 discarded bytes.
+   */
+  private resynchronizing: boolean = false;
 
   /**
    * Append bytes from the helper's stdout stream and return any frames that
-   * have completed. Malformed headers are surfaced via `onMalformed`; the
-   * decoder discards the offending bytes and continues parsing.
+   * have completed. A malformed header is surfaced via `onMalformed` exactly
+   * once; the decoder then discards bytes until it finds the next plausible
+   * header and resumes decoding there.
    */
   push(
     chunk: Buffer,
@@ -57,20 +104,12 @@ export class FrameDecoder {
     const frames: DecodedFrame[] = [];
 
     while (true) {
+      if (this.resynchronizing && !this.resynchronize()) {break;}
+
       if (this.pendingHeader === null) {
-        if (this.buffer.length < FRAME_HEADER_SIZE) {break;}
-        const header = parseHeader(this.buffer);
-        this.buffer = this.buffer.subarray(FRAME_HEADER_SIZE);
-        if (isAudioHeader(header)) {
-          this.pendingHeader = header;
-          continue;
-        }
-        const malformed = validateHeader(header);
-        if (malformed) {
-          onMalformed?.({ reason: malformed, header });
-          continue;
-        }
-        this.pendingHeader = header;
+        const outcome = this.takeHeader(onMalformed);
+        if (outcome === "starved") {break;}
+        if (outcome === "malformed") {continue;}
       }
 
       const expected = payloadSize(this.pendingHeader);
@@ -90,6 +129,82 @@ export class FrameDecoder {
 
     return frames;
   }
+
+  /**
+   * Consume the next header from the front of the buffer. On a malformed
+   * header the bytes are deliberately left in place — the decoder switches to
+   * resynchronizing and the forward scan steps past them itself — and the
+   * corruption is reported once.
+   */
+  private takeHeader(
+    onMalformed?: (error: MalformedFrameError) => void
+  ): "ok" | "starved" | "malformed" {
+    if (this.buffer.length < FRAME_HEADER_SIZE) {return "starved";}
+    const header = parseHeader(this.buffer, 0);
+    const malformed = headerError(header);
+    if (malformed) {
+      this.resynchronizing = true;
+      onMalformed?.({ reason: malformed, header });
+      return "malformed";
+    }
+    this.buffer = this.buffer.subarray(FRAME_HEADER_SIZE);
+    this.pendingHeader = header;
+    return "ok";
+  }
+
+  /**
+   * Scan forward for the next frame boundary. Returns true when alignment is
+   * recovered (the buffer now starts at that header), false when the buffered
+   * bytes do not yet settle the question — in which case bytes that can no
+   * longer contain a boundary are discarded and the scan resumes on the next
+   * chunk.
+   *
+   * A structurally valid header alone is not enough: payload bytes shifted by
+   * one can spell a perfectly plausible header. Each candidate is corroborated
+   * by checking that whatever follows its payload is itself a valid header (or
+   * that the payload runs exactly to the end of what has arrived).
+   */
+  private resynchronize(): boolean {
+    const lastOffset = this.buffer.length - FRAME_HEADER_SIZE;
+    let firstUnsettled = -1;
+
+    for (let offset = 0; offset <= lastOffset; offset++) {
+      const header = parseHeader(this.buffer, offset);
+      if (headerError(header) !== null) {continue;}
+      const verdict = this.corroborate(offset, header);
+      if (verdict === "accept") {
+        this.buffer = this.buffer.subarray(offset);
+        this.resynchronizing = false;
+        return true;
+      }
+      if (verdict === "unsettled" && firstUnsettled < 0) {firstUnsettled = offset;}
+    }
+
+    // Keep the earliest candidate that more bytes could still confirm;
+    // otherwise keep only what could be a header straddling the chunk
+    // boundary. Copy so the discarded chunk allocation can be freed.
+    const keepFrom =
+      firstUnsettled >= 0
+        ? firstUnsettled
+        : Math.max(0, this.buffer.length - (FRAME_HEADER_SIZE - 1));
+    this.buffer = Buffer.from(this.buffer.subarray(keepFrom));
+    return false;
+  }
+
+  /**
+   * Decide whether a candidate header at `offset` really is a frame boundary.
+   * "unsettled" means the buffered bytes cannot answer yet — the caller keeps
+   * the candidate and re-asks once more data arrives. Retention is bounded by
+   * the same payload ceiling that bounds normal decoding.
+   */
+  private corroborate(offset: number, header: FrameHeader): "accept" | "unsettled" | "reject" {
+    const end = offset + FRAME_HEADER_SIZE + payloadSize(header);
+    const trailing = this.buffer.length - end;
+    if (trailing < 0) {return "unsettled";}
+    if (trailing === 0) {return "accept";}
+    if (trailing < FRAME_HEADER_SIZE) {return "unsettled";}
+    return headerError(parseHeader(this.buffer, end)) === null ? "accept" : "reject";
+  }
 }
 
 function isAudioHeader(header: FrameHeader): boolean {
@@ -102,20 +217,33 @@ function payloadSize(header: FrameHeader): number {
     : header.height * header.bytesPerRow;
 }
 
-function parseHeader(buffer: Buffer): FrameHeader {
+function parseHeader(buffer: Buffer, offset: number): FrameHeader {
   return {
-    width: buffer.readUInt32LE(0),
-    height: buffer.readUInt32LE(4),
-    bytesPerRow: buffer.readUInt32LE(8),
-    timestampMs: buffer.readUInt32LE(12),
+    width: buffer.readUInt32LE(offset),
+    height: buffer.readUInt32LE(offset + 4),
+    bytesPerRow: buffer.readUInt32LE(offset + 8),
+    timestampMs: buffer.readUInt32LE(offset + 12),
   };
 }
 
-function validateHeader(header: FrameHeader): MalformedFrameError["reason"] | null {
+/** Returns the reason these 16 bytes are not a usable header, or null. */
+function headerError(header: FrameHeader): MalformedFrameReason | null {
+  if (isAudioHeader(header)) {
+    return header.timestampMs > MAX_AUDIO_PAYLOAD_BYTES ? "audio_payload_too_large" : null;
+  }
   if (header.width === 0) {return "header_width_zero";}
   if (header.height === 0) {return "header_height_zero";}
   // BGRA is 4 bytes per pixel; bytesPerRow may include padding but must fit
   // at least the visible pixels.
   if (header.bytesPerRow < header.width * 4) {return "header_bytes_per_row_too_small";}
+  if (header.width > MAX_FRAME_DIMENSION || header.height > MAX_FRAME_DIMENSION) {
+    return "header_dimensions_out_of_range";
+  }
+  if (header.bytesPerRow > header.width * 4 + MAX_ROW_PADDING_BYTES) {
+    return "header_bytes_per_row_too_large";
+  }
+  if (header.height * header.bytesPerRow > MAX_FRAME_PAYLOAD_BYTES) {
+    return "header_payload_too_large";
+  }
   return null;
 }

--- a/test/features/screen-stream/frameProtocol.test.ts
+++ b/test/features/screen-stream/frameProtocol.test.ts
@@ -173,6 +173,27 @@ describe("FrameDecoder corrupt-header resynchronization", () => {
     expect(out.map(f => f.header.timestampMs)).toEqual([88]);
   });
 
+  test("a sustained garbage stream stays quiet instead of amplifying", () => {
+    const decoder = new FrameDecoder();
+    const errors: MalformedFrameError[] = [];
+    // 1 MiB of noise arriving in realistic chunks, then a real frame. The old
+    // decoder failed this two ways depending on the bytes: a callback per 16
+    // discarded bytes, or a silent stall once it locked onto a bogus header
+    // claiming a huge payload. Quiet is only half the requirement — the stream
+    // has to come back.
+    const noise = pseudoRandomPayload(1024 * 1024);
+    const frames: number[] = [];
+    const stream = Buffer.concat([noise, makeFrameBytes(4, 4, 16, 909, 0x0f)]);
+    for (let offset = 0; offset < stream.length; offset += 65_536) {
+      const out = decoder.push(stream.subarray(offset, offset + 65_536), err =>
+        errors.push(err)
+      );
+      frames.push(...out.map(f => f.header.timestampMs));
+    }
+    expect(errors.length).toBeLessThanOrEqual(4);
+    expect(frames).toEqual([909]);
+  });
+
   test("implausible dimensions are rejected so payload bytes rarely look like headers", () => {
     const decoder = new FrameDecoder();
     const errors: MalformedFrameError[] = [];

--- a/test/features/screen-stream/frameProtocol.test.ts
+++ b/test/features/screen-stream/frameProtocol.test.ts
@@ -350,7 +350,50 @@ describe("FrameDecoder corrupt-header resynchronization", () => {
     expect(audio[0].length).toBe(32);
     expect(out.map(f => f.header.timestampMs)).toEqual([CONFIRM_TS]);
   });
+
+  test("an unsettled candidate does not make later chunks rescan the retained bytes", () => {
+    // The adversarial shape: a corrupt header whose payload begins with a
+    // plausible header declaring a 256 MiB payload. That candidate cannot be
+    // corroborated until 256 MiB have arrived, so it is retained across every
+    // subsequent chunk. Scanning must resume where it left off — restarting at
+    // offset 0 each push makes one corrupt frame cost quadratic CPU, which is
+    // the disproportionate-work shape this whole change exists to remove.
+    const decoder = new FrameDecoder();
+    const decoy = encodeHeader(8_192, 8_192, 32_768, 0);
+    decoder.push(Buffer.concat([encodeHeader(0, 0, 0, 0), decoy]), () => {});
+
+    const chunks = 12;
+    const chunk = Buffer.alloc(8 * 1024, 0);
+    const parses = countHeaderParses(() => {
+      for (let i = 0; i < chunks; i++) {decoder.push(chunk);}
+    });
+
+    // Linear: each byte offset is examined once overall, plus the retained
+    // candidate re-asked once per chunk. Rescanning from zero would cost
+    // ~chunks/2 times this.
+    expect(parses).toBeLessThan(chunks * chunk.length * 1.1);
+  });
 });
+
+/**
+ * Count `parseHeader` calls inside `body`, via the four header-word reads each
+ * one makes. Measures scan work directly instead of timing it, so the bound is
+ * deterministic under load.
+ */
+function countHeaderParses(body: () => void): number {
+  let reads = 0;
+  const original = Buffer.prototype.readUInt32LE;
+  Buffer.prototype.readUInt32LE = function(this: Buffer, offset?: number): number {
+    reads++;
+    return original.call(this, offset as number);
+  };
+  try {
+    body();
+  } finally {
+    Buffer.prototype.readUInt32LE = original;
+  }
+  return reads / 4;
+}
 
 /** Timestamp of the frame whose header confirms a recovery point. */
 const CONFIRM_TS = 1000;

--- a/test/features/screen-stream/frameProtocol.test.ts
+++ b/test/features/screen-stream/frameProtocol.test.ts
@@ -93,10 +93,15 @@ describe("FrameDecoder", () => {
     const bad = encodeHeader(0, 1, 4, 0);
     const good = makeFrameBytes(1, 1, 4, 99, 0xcd);
     const errors: MalformedFrameError[] = [];
-    const out = decoder.push(Buffer.concat([bad, good]), err => errors.push(err));
+    // Recovery is confirmed by the header that follows the recovered frame, so
+    // the stream carries one more frame after it.
+    const out = decoder.push(
+      Buffer.concat([bad, good, confirmingFrame()]),
+      err => errors.push(err)
+    );
     expect(errors).toHaveLength(1);
-    expect(out).toHaveLength(1);
-    expect(out[0].header.timestampMs).toBe(99);
+    expect(out.map(f => f.header.timestampMs)).toEqual([99, CONFIRM_TS]);
+    expect(out[0].pixels[0]).toBe(0xcd);
   });
 
   test("handles empty chunks without emitting frames", () => {
@@ -107,8 +112,12 @@ describe("FrameDecoder", () => {
 
 describe("FrameDecoder corrupt-header resynchronization", () => {
   // A corrupt header carries no usable payload length, so the decoder cannot
-  // know where the frame ends. It must scan forward for the next plausible
-  // header rather than re-walking the payload as if it were headers.
+  // know where the damaged frame ends. It must scan forward for the next frame
+  // boundary rather than re-walking the payload as if it were headers.
+  //
+  // A recovery point is only accepted once the header that follows it confirms
+  // it, so each case below carries one extra frame on the wire; `CONFIRM_TS`
+  // marks it.
 
   test("a corrupt header at stream start discards the frame, not just its 16 header bytes", () => {
     const decoder = new FrameDecoder();
@@ -118,12 +127,14 @@ describe("FrameDecoder corrupt-header resynchronization", () => {
     const good = makeFrameBytes(2, 2, 8, 777, 0x5a);
 
     const errors: MalformedFrameError[] = [];
-    const out = decoder.push(Buffer.concat([corrupt, good]), err => errors.push(err));
+    const out = decoder.push(
+      Buffer.concat([corrupt, good, confirmingFrame()]),
+      err => errors.push(err)
+    );
 
     expect(errors).toHaveLength(1);
     expect(errors[0].reason).toBe("header_width_zero");
-    expect(out).toHaveLength(1);
-    expect(out[0].header.timestampMs).toBe(777);
+    expect(out.map(f => f.header.timestampMs)).toEqual([777, CONFIRM_TS]);
     expect(out[0].pixels[0]).toBe(0x5a);
   });
 
@@ -134,14 +145,17 @@ describe("FrameDecoder corrupt-header resynchronization", () => {
     const after = makeFrameBytes(1, 1, 4, 22, 0x22);
 
     const errors: MalformedFrameError[] = [];
-    const out = decoder.push(Buffer.concat([before, corrupt, after]), err => errors.push(err));
+    const out = decoder.push(
+      Buffer.concat([before, corrupt, after, confirmingFrame()]),
+      err => errors.push(err)
+    );
 
     expect(errors).toHaveLength(1);
     expect(errors[0].reason).toBe("header_height_zero");
-    expect(out.map(f => f.header.timestampMs)).toEqual([11, 22]);
+    expect(out.map(f => f.header.timestampMs)).toEqual([11, 22, CONFIRM_TS]);
   });
 
-  test("a corrupt header at the tail emits one callback and resyncs on the next push", () => {
+  test("a corrupt header at the tail emits one callback and resyncs on a later push", () => {
     const decoder = new FrameDecoder();
     const errors: MalformedFrameError[] = [];
 
@@ -149,11 +163,13 @@ describe("FrameDecoder corrupt-header resynchronization", () => {
     expect(decoder.push(tail, err => errors.push(err))).toHaveLength(0);
     expect(errors).toHaveLength(1);
 
-    // The stream resumes with a valid frame in a later chunk.
-    const out = decoder.push(makeFrameBytes(1, 1, 4, 33, 0x33), err => errors.push(err));
+    // The stream resumes with valid frames in a later chunk.
+    const out = decoder.push(
+      Buffer.concat([makeFrameBytes(1, 1, 4, 33, 0x33), confirmingFrame()]),
+      err => errors.push(err)
+    );
     expect(errors).toHaveLength(1);
-    expect(out).toHaveLength(1);
-    expect(out[0].header.timestampMs).toBe(33);
+    expect(out.map(f => f.header.timestampMs)).toEqual([33, CONFIRM_TS]);
   });
 
   test("a large corrupt frame does not amplify into a flood of callbacks", () => {
@@ -165,25 +181,29 @@ describe("FrameDecoder corrupt-header resynchronization", () => {
         encodeHeader(0, 1080, 7680, 0),
         pseudoRandomPayload(16_000),
         makeFrameBytes(1, 1, 4, 88, 0x88),
+        confirmingFrame(),
       ]),
       err => errors.push(err)
     );
     expect(errors).toHaveLength(1);
     // Not just quiet — actually back in sync.
-    expect(out.map(f => f.header.timestampMs)).toEqual([88]);
+    expect(out.map(f => f.header.timestampMs)).toEqual([88, CONFIRM_TS]);
   });
 
   test("a sustained garbage stream stays quiet instead of amplifying", () => {
     const decoder = new FrameDecoder();
     const errors: MalformedFrameError[] = [];
-    // 1 MiB of noise arriving in realistic chunks, then a real frame. The old
+    // 1 MiB of noise arriving in realistic chunks, then real frames. The old
     // decoder failed this two ways depending on the bytes: a callback per 16
     // discarded bytes, or a silent stall once it locked onto a bogus header
     // claiming a huge payload. Quiet is only half the requirement — the stream
     // has to come back.
-    const noise = pseudoRandomPayload(1024 * 1024);
     const frames: number[] = [];
-    const stream = Buffer.concat([noise, makeFrameBytes(4, 4, 16, 909, 0x0f)]);
+    const stream = Buffer.concat([
+      pseudoRandomPayload(1024 * 1024),
+      makeFrameBytes(4, 4, 16, 909, 0x0f),
+      confirmingFrame(),
+    ]);
     for (let offset = 0; offset < stream.length; offset += 65_536) {
       const out = decoder.push(stream.subarray(offset, offset + 65_536), err =>
         errors.push(err)
@@ -191,7 +211,7 @@ describe("FrameDecoder corrupt-header resynchronization", () => {
       frames.push(...out.map(f => f.header.timestampMs));
     }
     expect(errors.length).toBeLessThanOrEqual(4);
-    expect(frames).toEqual([909]);
+    expect(frames).toEqual([909, CONFIRM_TS]);
   });
 
   test("implausible dimensions are rejected so payload bytes rarely look like headers", () => {
@@ -203,11 +223,10 @@ describe("FrameDecoder corrupt-header resynchronization", () => {
     expect(errors[0].reason).toBe("header_dimensions_out_of_range");
   });
 
-  test("payload bytes that form a plausible header resync deterministically", () => {
+  test("payload bytes that form a plausible header do not become a frame", () => {
     const decoder = new FrameDecoder();
-    // Payload containing an embedded, structurally valid header. This is
-    // genuinely ambiguous on the wire; what matters is that the decoder is
-    // deterministic, bounded, and still lands on the real trailing frame.
+    // Payload containing an embedded, structurally valid header. Nothing
+    // corroborates it, so the scan rejects it and lands on the real frame.
     const embedded = Buffer.concat([encodeHeader(1, 1, 4, 555), Buffer.alloc(4, 0x77)]);
     const corrupt = Buffer.concat([
       encodeHeader(0, 1, 4, 0),
@@ -218,12 +237,58 @@ describe("FrameDecoder corrupt-header resynchronization", () => {
     const good = makeFrameBytes(1, 1, 4, 444, 0x44);
 
     const errors: MalformedFrameError[] = [];
-    const out = decoder.push(Buffer.concat([corrupt, good]), err => errors.push(err));
+    const out = decoder.push(
+      Buffer.concat([corrupt, good, confirmingFrame()]),
+      err => errors.push(err)
+    );
 
-    // The embedded header is not corroborated by what follows its payload, so
-    // the scan rejects it and lands on the real frame. One report, no flood.
     expect(errors).toHaveLength(1);
-    expect(out.map(f => f.header.timestampMs)).toEqual([444]);
+    expect(out.map(f => f.header.timestampMs)).toEqual([444, CONFIRM_TS]);
+  });
+
+  test("a chunk boundary is not treated as proof of a frame boundary", () => {
+    const decoder = new FrameDecoder();
+    // The corrupt payload ends with bytes that spell a valid 1x1 header whose
+    // payload runs exactly to the end of the chunk. stdout splits wherever the
+    // pipe flushes, so that alignment is a coincidence, not corroboration —
+    // emitting it would fabricate a frame out of payload bytes.
+    const errors: MalformedFrameError[] = [];
+    const out = decoder.push(
+      Buffer.concat([
+        encodeHeader(0, 1, 4, 0),
+        Buffer.alloc(40, 0x00),
+        encodeHeader(1, 1, 4, 4242),
+        Buffer.alloc(4, 0xaa),
+      ]),
+      err => errors.push(err)
+    );
+
+    expect(errors).toHaveLength(1);
+    expect(out).toHaveLength(0);
+  });
+
+  test("drops a recovered frame when a second corrupt header follows it", () => {
+    const decoder = new FrameDecoder();
+    // Deliberate trade-off, pinned so it stays deliberate: accepting a
+    // candidate whose successor is not a valid header is the same rule that
+    // fabricates frames out of payload bytes (see the test above). One dropped
+    // frame during back-to-back corruption is the cheaper error.
+    const errors: MalformedFrameError[] = [];
+    const out = decoder.push(
+      Buffer.concat([
+        encodeHeader(0, 1, 4, 0),
+        Buffer.alloc(200, 0x31),
+        makeFrameBytes(1, 1, 4, 777, 0xbb),
+        encodeHeader(0, 1, 4, 0),
+        Buffer.alloc(200, 0x31),
+        makeFrameBytes(1, 1, 4, 888, 0xcc),
+        confirmingFrame(),
+      ]),
+      err => errors.push(err)
+    );
+
+    expect(out.map(f => f.header.timestampMs)).toEqual([888, CONFIRM_TS]);
+    expect(out.map(f => f.header.timestampMs)).not.toContain(777);
   });
 
   test("resynchronizes across a chunk boundary that splits the recovery header", () => {
@@ -231,15 +296,14 @@ describe("FrameDecoder corrupt-header resynchronization", () => {
     const errors: MalformedFrameError[] = [];
     const corrupt = Buffer.concat([encodeHeader(0, 1, 4, 0), pseudoRandomPayload(1_000)]);
     const good = makeFrameBytes(1, 1, 4, 66, 0x66);
-    const all = Buffer.concat([corrupt, good]);
+    const all = Buffer.concat([corrupt, good, confirmingFrame()]);
     const split = corrupt.length + 7;
 
     expect(decoder.push(all.subarray(0, split), err => errors.push(err))).toHaveLength(0);
     const out = decoder.push(all.subarray(split), err => errors.push(err));
 
     expect(errors).toHaveLength(1);
-    expect(out).toHaveLength(1);
-    expect(out[0].header.timestampMs).toBe(66);
+    expect(out.map(f => f.header.timestampMs)).toEqual([66, CONFIRM_TS]);
   });
 
   test("waits for more bytes rather than locking onto an unconfirmed candidate", () => {
@@ -249,15 +313,14 @@ describe("FrameDecoder corrupt-header resynchronization", () => {
     // the rest of it arrives. The decoder must not lock onto earlier garbage.
     const corrupt = Buffer.concat([encodeHeader(0, 1, 4, 0), pseudoRandomPayload(3_000)]);
     const good = makeFrameBytes(64, 64, 256, 121, 0xee);
-    const all = Buffer.concat([corrupt, good]);
+    const all = Buffer.concat([corrupt, good, confirmingFrame()]);
     const half = corrupt.length + 1_000;
 
     expect(decoder.push(all.subarray(0, half), err => errors.push(err))).toHaveLength(0);
     const out = decoder.push(all.subarray(half), err => errors.push(err));
 
     expect(errors).toHaveLength(1);
-    expect(out).toHaveLength(1);
-    expect(out[0].header.timestampMs).toBe(121);
+    expect(out.map(f => f.header.timestampMs)).toEqual([121, CONFIRM_TS]);
     expect(out[0].pixels.length).toBe(64 * 256);
   });
 
@@ -276,8 +339,8 @@ describe("FrameDecoder corrupt-header resynchronization", () => {
     const corrupt = Buffer.concat([encodeHeader(0, 1, 4, 0), pseudoRandomPayload(512)]);
     const record = Buffer.concat([encodeHeader(0, 8_000, 1, 32), Buffer.alloc(32, 0x09)]);
 
-    decoder.push(
-      Buffer.concat([corrupt, record]),
+    const out = decoder.push(
+      Buffer.concat([corrupt, record, confirmingFrame()]),
       err => errors.push(err),
       a => audio.push(a.pcm16le)
     );
@@ -285,9 +348,17 @@ describe("FrameDecoder corrupt-header resynchronization", () => {
     expect(errors).toHaveLength(1);
     expect(audio).toHaveLength(1);
     expect(audio[0].length).toBe(32);
+    expect(out.map(f => f.header.timestampMs)).toEqual([CONFIRM_TS]);
   });
 });
 
+/** Timestamp of the frame whose header confirms a recovery point. */
+const CONFIRM_TS = 1000;
+
+/** The frame that corroborates the recovered one preceding it. */
+function confirmingFrame(): Buffer {
+  return makeFrameBytes(1, 1, 4, CONFIRM_TS, 0x01);
+}
 /** Deterministic pseudo-random filler — reproducible across runs. */
 function pseudoRandomPayload(length: number): Buffer {
   const buf = Buffer.alloc(length);

--- a/test/features/screen-stream/frameProtocol.test.ts
+++ b/test/features/screen-stream/frameProtocol.test.ts
@@ -104,3 +104,176 @@ describe("FrameDecoder", () => {
     expect(decoder.push(Buffer.alloc(0))).toHaveLength(0);
   });
 });
+
+describe("FrameDecoder corrupt-header resynchronization", () => {
+  // A corrupt header carries no usable payload length, so the decoder cannot
+  // know where the frame ends. It must scan forward for the next plausible
+  // header rather than re-walking the payload as if it were headers.
+
+  test("a corrupt header at stream start discards the frame, not just its 16 header bytes", () => {
+    const decoder = new FrameDecoder();
+    // Corrupt header claiming zero width, followed by a payload of pseudo-random
+    // bytes and then a genuinely valid frame.
+    const corrupt = Buffer.concat([encodeHeader(0, 1, 4, 0), pseudoRandomPayload(4_000)]);
+    const good = makeFrameBytes(2, 2, 8, 777, 0x5a);
+
+    const errors: MalformedFrameError[] = [];
+    const out = decoder.push(Buffer.concat([corrupt, good]), err => errors.push(err));
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].reason).toBe("header_width_zero");
+    expect(out).toHaveLength(1);
+    expect(out[0].header.timestampMs).toBe(777);
+    expect(out[0].pixels[0]).toBe(0x5a);
+  });
+
+  test("a corrupt header mid-stream costs one callback and both good frames survive", () => {
+    const decoder = new FrameDecoder();
+    const before = makeFrameBytes(1, 1, 4, 11, 0x11);
+    const corrupt = Buffer.concat([encodeHeader(1, 0, 4, 0), pseudoRandomPayload(8_000)]);
+    const after = makeFrameBytes(1, 1, 4, 22, 0x22);
+
+    const errors: MalformedFrameError[] = [];
+    const out = decoder.push(Buffer.concat([before, corrupt, after]), err => errors.push(err));
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].reason).toBe("header_height_zero");
+    expect(out.map(f => f.header.timestampMs)).toEqual([11, 22]);
+  });
+
+  test("a corrupt header at the tail emits one callback and resyncs on the next push", () => {
+    const decoder = new FrameDecoder();
+    const errors: MalformedFrameError[] = [];
+
+    const tail = Buffer.concat([encodeHeader(0, 0, 0, 0), pseudoRandomPayload(2_048)]);
+    expect(decoder.push(tail, err => errors.push(err))).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+
+    // The stream resumes with a valid frame in a later chunk.
+    const out = decoder.push(makeFrameBytes(1, 1, 4, 33, 0x33), err => errors.push(err));
+    expect(errors).toHaveLength(1);
+    expect(out).toHaveLength(1);
+    expect(out[0].header.timestampMs).toBe(33);
+  });
+
+  test("a large corrupt frame does not amplify into a flood of callbacks", () => {
+    const decoder = new FrameDecoder();
+    const errors: MalformedFrameError[] = [];
+    // The audit's shape: one corrupt header followed by a full-size payload.
+    const out = decoder.push(
+      Buffer.concat([
+        encodeHeader(0, 1080, 7680, 0),
+        pseudoRandomPayload(16_000),
+        makeFrameBytes(1, 1, 4, 88, 0x88),
+      ]),
+      err => errors.push(err)
+    );
+    expect(errors).toHaveLength(1);
+    // Not just quiet — actually back in sync.
+    expect(out.map(f => f.header.timestampMs)).toEqual([88]);
+  });
+
+  test("implausible dimensions are rejected so payload bytes rarely look like headers", () => {
+    const decoder = new FrameDecoder();
+    const errors: MalformedFrameError[] = [];
+    // width*4 <= bytesPerRow, but both are absurd for a real display.
+    decoder.push(encodeHeader(1_000_000, 1_000_000, 8_000_000, 0), err => errors.push(err));
+    expect(errors).toHaveLength(1);
+    expect(errors[0].reason).toBe("header_dimensions_out_of_range");
+  });
+
+  test("payload bytes that form a plausible header resync deterministically", () => {
+    const decoder = new FrameDecoder();
+    // Payload containing an embedded, structurally valid header. This is
+    // genuinely ambiguous on the wire; what matters is that the decoder is
+    // deterministic, bounded, and still lands on the real trailing frame.
+    const embedded = Buffer.concat([encodeHeader(1, 1, 4, 555), Buffer.alloc(4, 0x77)]);
+    const corrupt = Buffer.concat([
+      encodeHeader(0, 1, 4, 0),
+      Buffer.alloc(64, 0x00),
+      embedded,
+      Buffer.alloc(64, 0x00),
+    ]);
+    const good = makeFrameBytes(1, 1, 4, 444, 0x44);
+
+    const errors: MalformedFrameError[] = [];
+    const out = decoder.push(Buffer.concat([corrupt, good]), err => errors.push(err));
+
+    // The embedded header is not corroborated by what follows its payload, so
+    // the scan rejects it and lands on the real frame. One report, no flood.
+    expect(errors).toHaveLength(1);
+    expect(out.map(f => f.header.timestampMs)).toEqual([444]);
+  });
+
+  test("resynchronizes across a chunk boundary that splits the recovery header", () => {
+    const decoder = new FrameDecoder();
+    const errors: MalformedFrameError[] = [];
+    const corrupt = Buffer.concat([encodeHeader(0, 1, 4, 0), pseudoRandomPayload(1_000)]);
+    const good = makeFrameBytes(1, 1, 4, 66, 0x66);
+    const all = Buffer.concat([corrupt, good]);
+    const split = corrupt.length + 7;
+
+    expect(decoder.push(all.subarray(0, split), err => errors.push(err))).toHaveLength(0);
+    const out = decoder.push(all.subarray(split), err => errors.push(err));
+
+    expect(errors).toHaveLength(1);
+    expect(out).toHaveLength(1);
+    expect(out[0].header.timestampMs).toBe(66);
+  });
+
+  test("waits for more bytes rather than locking onto an unconfirmed candidate", () => {
+    const decoder = new FrameDecoder();
+    const errors: MalformedFrameError[] = [];
+    // The recovery frame is large, so its payload cannot be corroborated until
+    // the rest of it arrives. The decoder must not lock onto earlier garbage.
+    const corrupt = Buffer.concat([encodeHeader(0, 1, 4, 0), pseudoRandomPayload(3_000)]);
+    const good = makeFrameBytes(64, 64, 256, 121, 0xee);
+    const all = Buffer.concat([corrupt, good]);
+    const half = corrupt.length + 1_000;
+
+    expect(decoder.push(all.subarray(0, half), err => errors.push(err))).toHaveLength(0);
+    const out = decoder.push(all.subarray(half), err => errors.push(err));
+
+    expect(errors).toHaveLength(1);
+    expect(out).toHaveLength(1);
+    expect(out[0].header.timestampMs).toBe(121);
+    expect(out[0].pixels.length).toBe(64 * 256);
+  });
+
+  test("audio records with an implausible payload length are rejected", () => {
+    const decoder = new FrameDecoder();
+    const errors: MalformedFrameError[] = [];
+    decoder.push(encodeHeader(0, 8_000, 1, 0xffffffff), err => errors.push(err));
+    expect(errors).toHaveLength(1);
+    expect(errors[0].reason).toBe("audio_payload_too_large");
+  });
+
+  test("valid audio records still decode after a corrupt frame", () => {
+    const decoder = new FrameDecoder();
+    const errors: MalformedFrameError[] = [];
+    const audio: Buffer[] = [];
+    const corrupt = Buffer.concat([encodeHeader(0, 1, 4, 0), pseudoRandomPayload(512)]);
+    const record = Buffer.concat([encodeHeader(0, 8_000, 1, 32), Buffer.alloc(32, 0x09)]);
+
+    decoder.push(
+      Buffer.concat([corrupt, record]),
+      err => errors.push(err),
+      a => audio.push(a.pcm16le)
+    );
+
+    expect(errors).toHaveLength(1);
+    expect(audio).toHaveLength(1);
+    expect(audio[0].length).toBe(32);
+  });
+});
+
+/** Deterministic pseudo-random filler — reproducible across runs. */
+function pseudoRandomPayload(length: number): Buffer {
+  const buf = Buffer.alloc(length);
+  let state = 0x12345678;
+  for (let i = 0; i < length; i++) {
+    state = (state * 1103515245 + 12345) & 0x7fffffff;
+    buf[i] = (state >>> 16) & 0xff;
+  }
+  return buf;
+}


### PR DESCRIPTION
## Summary

A single corrupt frame header on the screen-stream wire re-parsed the frame's
payload as a sequence of headers. Because only the 16 header bytes were
discarded, an 8 KB payload turned into ~1000 `malformed` callbacks — one per 16
bytes — and the decoder stayed desynchronized afterwards. The input is remote,
so the amplification factor is a denial-of-service shape, not just noise.

The fix does not cap the callback count (a cap hides the symptom and leaves the
stream desynchronized). Instead the decoder recovers alignment:

1. **Report once, then resynchronize.** A malformed header flips the decoder
   into a `resynchronizing` state. Further malformed reports are suppressed
   while in that state, so one corrupt frame produces exactly one callback.
2. **Scan forward for the next frame boundary.** Rather than assuming the frame
   is 16 bytes long, the decoder scans byte by byte for the next plausible
   header and resumes there — so the corrupt *frame* is discarded, not just its
   header, and a valid frame following a corrupt one decodes correctly.
3. **Corroborate the candidate.** A structurally valid header alone is not
   enough: payload bytes shifted by one byte can spell a perfectly plausible
   header (this actually happened while developing the fix). A candidate is
   accepted only when a valid header sits exactly where its payload ends. When
   the buffered bytes cannot answer yet, the decoder keeps the candidate and
   re-asks on the next chunk instead of locking onto garbage.

   A chunk boundary is explicitly *not* corroboration. stdout splits wherever
   the pipe flushes, so a payload that happens to end at the end of the buffer
   proves nothing — trusting it let payload bytes be emitted as a fabricated
   frame with attacker-chosen dimensions. The cost of waiting is one chunk of
   latency, once, on an already-degraded path; normal synchronized decoding
   never goes through corroboration at all.

   The converse case is a deliberate trade, pinned by a test so it stays
   deliberate: when a recovered frame is immediately followed by a *second*
   corrupt header, that frame is dropped. Accepting it would mean accepting any
   candidate whose successor is invalid — the very rule that fabricates frames
   out of payload bytes. One dropped frame during back-to-back corruption is
   the cheaper error.
4. **Tighten the plausibility envelope.** Header validation now bounds
   dimensions, total payload size, audio-record length, and — the constraint
   that does most of the work — row padding (`bytesPerRow` must be within one
   page of `width * 4`). Under the previous rules roughly one in eight arbitrary
   offsets in a payload satisfied the header checks; tying two header words
   together makes false locks vanishingly rare.

Wire format is unchanged. This is decoder-side validation only.

## Linked Issue

Closes #4194

## Bug / Regression Context

- **Observed symptom:** 1,001 malformed callbacks from a single corrupt frame
  (500 for a 7,999-byte variant). Re-measured against `origin/main`: a corrupt
  header plus a 16,000-byte payload produces exactly **1,001** callbacks,
  matching the audit. Each one becomes a `malformed` emit in
  `IOSScreenCaptureHelper`, which `IosH264Source.wireHelperFrames`
  (`src/features/webrtc/IosH264Source.ts:330`) turns into a `logger.warn` — so
  the amplification lands in the log, once per 16 bytes of payload.

  The second, quieter failure mode matters as much: with payload bytes that
  happen to satisfy the old loose header rules, the decoder instead locks onto
  a bogus header claiming a huge payload and **stalls silently**. 1 MiB of
  noise followed by a real frame decodes *zero* frames on `main` and emits no
  callbacks at all. A callback cap would have done nothing about this half.
- **Repro steps / conditions:** any corrupt 16-byte header on the helper's
  stdout stream — reproduced in unit tests, which were red at HEAD.

## Changes

- `src/features/screen-stream/frameProtocol.ts` — resynchronization state
  machine (`takeHeader` / `resynchronize` / `corroborate`), plausibility bounds
  (`MAX_FRAME_DIMENSION`, `MAX_ROW_PADDING_BYTES`, `MAX_FRAME_PAYLOAD_BYTES`,
  `MAX_AUDIO_PAYLOAD_BYTES`), and three new `MalformedFrameReason` values.
- `test/features/screen-stream/frameProtocol.test.ts` — new
  `FrameDecoder corrupt-header resynchronization` suite.

## Acceptance criteria

- [x] A corrupt header discards the **frame**, not just its 16 header bytes.
- [x] Exactly one error callback per corrupt frame.
- [x] The stream **resynchronizes** — a valid frame following a corrupt one is
      parsed correctly (pinned at stream start, mid-stream, at the tail, and
      across a chunk boundary that splits the recovery header).
- [x] Boundary rows: corrupt header at stream start, mid-stream, at the tail,
      and a payload whose bytes happen to form a plausible header.
- [x] Red before the fix, green after — the resynchronization suite fails at
      `main` for the right reasons (callback floods, silent stalls,
      non-recovery, and a fabricated frame); two of its cases cover the new
      plausibility bounds.

## Validation

- [x] `bun run lint` passes
- [x] `bun test` passes — 8324 pass / 0 fail across 665 files
- [x] `bun run build` passes
- [x] `bun run typecheck` reports no new errors from this change
- [x] New tests run in <100ms; no fakes/timers needed (pure decoder)

## Note on CI

`main` is currently red for reasons unrelated to this PR: the typecheck baseline
drift on `src/daemon/telemetryPushSocketServer.ts` ([#4211](https://github.com/kaeawc/auto-mobile/issues/4211) /
[#4208](https://github.com/kaeawc/auto-mobile/issues/4208)), the bash 3.2 BATS breakage
([#4212](https://github.com/kaeawc/auto-mobile/issues/4212)), and the installer `actions/checkout` load error.
`scripts/typecheck-baseline.txt` is deliberately untouched here to avoid
colliding with in-flight fixes.
