### PR TITLE
docs(ios): correct AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH guidance (#4221)

### DIFF
--- a/docs/using/environment-variables.md
+++ b/docs/using/environment-variables.md
@@ -70,7 +70,7 @@ here for discoverability; most are diagnostic or for advanced testing.
 | `AUTOMOBILE_DEBUG_PERF` | Enables performance/timing debug output. |
 | `AUTOMOBILE_CTRL_PROXY_APK_PATH` | Overrides the path to the Android CtrlProxy APK (for testing a locally-built runner). |
 | `AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH` | Overrides the iOS CtrlProxy bundle with a packaged `.ipa` **file** (alias of `AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH`). This is **not** the way to use a local `xcodebuild` output — a directory is rejected and the daemon falls back to the cached runner. Use `AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA` for locally-built runners. |
-| `AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA` | Derived-data **root** for a locally-built iOS runner (`Build/Products` is appended internally). Only needed when building to a non-default location. Defaults to `/tmp/automobile-ctrl-proxy`, which is where `scripts/ios/ctrl-proxy-build-for-testing.sh` writes. |
+| `AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA` | Derived-data **root** for a locally-built iOS runner (`Build/Products` is appended internally). Only needed when building to a non-default location. Defaults to `/tmp/automobile-ctrl-proxy`, which is where `scripts/ios/ctrl-proxy-build-for-testing.sh` writes. Pair it with `AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD=true`: on a host whose cached bundle metadata is missing or does not match the current version, the daemon downloads the released bundle and extracts it over this directory, replacing the local build. |
 | `AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD` | Skips Android and iOS CtrlProxy downloads/prefetches when set to `1` or `true`. |
 | `AUTOMOBILE_SKIP_ACCESSIBILITY_DOWNLOAD_IF_INSTALLED` | Skips the accessibility service download when it is already installed. |
 

--- a/docs/using/environment-variables.md
+++ b/docs/using/environment-variables.md
@@ -69,7 +69,8 @@ here for discoverability; most are diagnostic or for advanced testing.
 | `AUTOMOBILE_DEBUG` | Enables verbose debug logging. |
 | `AUTOMOBILE_DEBUG_PERF` | Enables performance/timing debug output. |
 | `AUTOMOBILE_CTRL_PROXY_APK_PATH` | Overrides the path to the Android CtrlProxy APK (for testing a locally-built runner). |
-| `AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH` | Overrides the path to the iOS CtrlProxy bundle (for testing a locally-built runner). |
+| `AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH` | Overrides the iOS CtrlProxy bundle with a packaged `.ipa` **file** (alias of `AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH`). This is **not** the way to use a local `xcodebuild` output — a directory is rejected and the daemon falls back to the cached runner. Use `AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA` for locally-built runners. |
+| `AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA` | Derived-data **root** for a locally-built iOS runner (`Build/Products` is appended internally). Only needed when building to a non-default location. Defaults to `/tmp/automobile-ctrl-proxy`, which is where `scripts/ios/ctrl-proxy-build-for-testing.sh` writes. |
 | `AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD` | Skips Android and iOS CtrlProxy downloads/prefetches when set to `1` or `true`. |
 | `AUTOMOBILE_SKIP_ACCESSIBILITY_DOWNLOAD_IF_INSTALLED` | Skips the accessibility service download when it is already installed. |
 

--- a/skills/manual-test/SKILL.md
+++ b/skills/manual-test/SKILL.md
@@ -85,11 +85,37 @@ at a time to conserve context; never let two actors drive devices at once.
      the daemon falls back to the **cached** runner with no diagnostic, so you
      attribute results to a local build that never ran (ref
      [#4221](https://github.com/kaeawc/auto-mobile/issues/4221)). The build script
-     writes to the **default** derived-data path, so a fresh local iOS runner needs
-     **no env var at all**. Only for a non-default location set
+     writes to the **default** derived-data path (`/tmp/automobile-ctrl-proxy`), so
+     no path env var is needed; only for a non-default location set
      `AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA=<derived-data-root>` (the root — the
-     code appends `Build/Products` itself). Verify which runner actually served a
-     call with `grep xctestrun <daemon-log>`.
+     code appends `Build/Products` itself).
+   - **Set `AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD=true` (or pass
+     `--skip-ctrl-proxy-download`) when testing a locally built iOS runner.**
+     Landing the build in the default derived-data path is **not** sufficient on
+     its own: `needsRebuild()` also consults release metadata cached **separately**
+     in `~/.automobile/ctrl-proxy-ios/ctrl-proxy-ios-bundle.json`, which the build
+     script never writes (`src/utils/IOSCtrlProxyBuilder.ts:398-433`). Three common
+     states download the **released** runner and extract it straight over
+     `/tmp/automobile-ctrl-proxy`, destroying your local build without a warning:
+     - **fresh host / cleared cache** — metadata missing ⇒ "metadata missing, need
+       download";
+     - **changed `AUTOMOBILE_VERSION`** — expected checksum no longer matches the
+       cached metadata ⇒ "checksum mismatch, need download" (and if the pinned
+       version is not in the checksum registry, setup fails closed instead);
+     - **physical-device target** — the baked device app hash never matches a local
+       build ⇒ "app hash mismatch, need download". (Simulator targets have no
+       expected app hash, so this one does not fire there.)
+
+     Only when metadata is already present **and** matches the current version does
+     the "no env var" path reuse your local build. The skip flag short-circuits
+     `needsRebuild()` before any of those checks, so it is the reliable switch.
+     **Caveat — it is process-wide, not iOS-only:** it also suppresses the Android
+     CtrlProxy download/install, so install the freshly built APK on the emulator
+     yourself (`adb install -r <fresh apk>`) before starting the daemon, or run the
+     Android leg in a separate daemon without the flag.
+   - **Verify which runner actually served the call** — `grep xctestrun <daemon-log>`
+     for the path, and `grep 'need download\|Downloading CtrlProxy bundle' <daemon-log>`
+     to confirm the released bundle did *not* replace your build.
    - `--embedded-sdk` — required for `sqlQuery`, `setPreference`/`getPreference`,
      in-app `highlight` (registration is **daemon-side**; the CLI must pass the same
      flag so the reuse check matches, else it restarts the daemon).

--- a/skills/manual-test/SKILL.md
+++ b/skills/manual-test/SKILL.md
@@ -79,8 +79,17 @@ at a time to conserve context; never let two actors drive devices at once.
      runner (also uninstall+reinstall the APK on the emulator first for a runner fix);
      otherwise `AUTOMOBILE_SKIP_ACCESSIBILITY_DOWNLOAD_IF_INSTALLED=true` to keep the
      installed one and avoid the ~30s blocking download (#2590).
-   - `AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH=/tmp/automobile-ctrl-proxy/Build/Products`
-     for the fresh iOS runner.
+   - **Do NOT set `AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH`.** It wants an `.ipa`
+     **file**, and `scripts/ios/ctrl-proxy-build-for-testing.sh` produces no `.ipa`
+     — only a derived-data tree. Pointing it at a directory is silently ignored:
+     the daemon falls back to the **cached** runner with no diagnostic, so you
+     attribute results to a local build that never ran (ref
+     [#4221](https://github.com/kaeawc/auto-mobile/issues/4221)). The build script
+     writes to the **default** derived-data path, so a fresh local iOS runner needs
+     **no env var at all**. Only for a non-default location set
+     `AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA=<derived-data-root>` (the root — the
+     code appends `Build/Products` itself). Verify which runner actually served a
+     call with `grep xctestrun <daemon-log>`.
    - `--embedded-sdk` — required for `sqlQuery`, `setPreference`/`getPreference`,
      in-app `highlight` (registration is **daemon-side**; the CLI must pass the same
      flag so the reuse check matches, else it restarts the daemon).

--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -29,9 +29,11 @@ const MIN_XCODE_VERSION = "15.0";
 
 const IOS_RUNNER_REBUILD_RECOMMENDATION =
   "Rebuild and redeploy the iOS CtrlProxy runner: run scripts/ios/ctrl-proxy-build-for-testing.sh " +
-  "— its output is picked up automatically from the default derived-data path, so no env var is " +
-  "needed (set AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA to the derived-data root only when building " +
-  "to a non-default location). Alternatively, run the iOS hot-reload watcher with --manage-ios-runner.";
+  "— its output lands in the default derived-data path (set AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA " +
+  "to the derived-data root only when building to a non-default location). Start the daemon with " +
+  "AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD=true so a missing/mismatched cached bundle metadata does not " +
+  "download the released runner over your build. Alternatively, run the iOS hot-reload watcher with " +
+  "--manage-ios-runner.";
 
 /** Per-simulator runner identity gathered by the inspector. */
 export interface IosRunnerInspection {

--- a/src/doctor/checks/ios.ts
+++ b/src/doctor/checks/ios.ts
@@ -29,8 +29,9 @@ const MIN_XCODE_VERSION = "15.0";
 
 const IOS_RUNNER_REBUILD_RECOMMENDATION =
   "Rebuild and redeploy the iOS CtrlProxy runner: run scripts/ios/ctrl-proxy-build-for-testing.sh " +
-  "and point AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH at the rebuilt bundle, or run the iOS hot-reload " +
-  "watcher with --manage-ios-runner.";
+  "— its output is picked up automatically from the default derived-data path, so no env var is " +
+  "needed (set AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA to the derived-data root only when building " +
+  "to a non-default location). Alternatively, run the iOS hot-reload watcher with --manage-ios-runner.";
 
 /** Per-simulator runner identity gathered by the inspector. */
 export interface IosRunnerInspection {

--- a/test/doctor/ios.test.ts
+++ b/test/doctor/ios.test.ts
@@ -650,7 +650,10 @@ describe("checkIosCtrlProxyRunner", () => {
     expect(result.message).toContain("versionStatus=stale");
     expect(result.message).toContain("request_shake");
     expect(result.recommendation).toContain("ctrl-proxy-build-for-testing.sh");
-    expect(result.recommendation).toContain("AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH");
+    // BUNDLE_PATH takes an .ipa file and cannot consume the build script's
+    // derived-data output; DERIVED_DATA is the followable override (#4221).
+    expect(result.recommendation).toContain("AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA");
+    expect(result.recommendation).not.toContain("AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH");
   });
 
   test("reports unknown when the runner is installed but not running", async () => {


### PR DESCRIPTION
## What was wrong

`AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH` was documented and recommended as the way to
point AutoMobile at a locally-built iOS runner. It cannot do that: it takes a packaged
`.ipa` **file**, and the local build script emits no `.ipa`. Following the docs produces
a silent no-op — the daemon falls back to the cached runner with no diagnostic, so manual
testing attributes results to a local build that never ran.

## Facts (verified on device)

1. `AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH` is an alias of
   `AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH` (`src/utils/IOSCtrlProxyBuilder.ts:687`) and the
   override path is `stat`-ed and rejected unless `isFile()`, then `copyFile`d
   (`src/utils/IOSCtrlProxyBuilder.ts:737`) — it must be a file, not a directory.
2. `scripts/ios/ctrl-proxy-build-for-testing.sh` produces **no** `.ipa` — only a
   derived-data tree (`Build/Products` + `.xctestrun`).
3. `DEFAULT_DERIVED_DATA_PATH` (`src/utils/IOSCtrlProxyBuilder.ts:83`) is
   `/tmp/automobile-ctrl-proxy`, exactly where that build script writes — so a locally
   built runner is picked up with **no env var at all**.
   `AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA` (`:126`) is the correct override for a
   non-default location, and takes the derived-data **root** (the code appends
   `Build/Products` itself at `:230`/`:338`). Confirmed by pointing it at an alternate
   directory and verifying the daemon loaded the `.xctestrun` from there.

## Changes (docs / user-facing strings only)

- `skills/manual-test/SKILL.md` — Phase 2 no longer instructs setting `BUNDLE_PATH` to a
  directory; explains the silent-fallback trap, that no env var is needed for the default
  path, and how to verify which runner served a call (`grep xctestrun <daemon-log>`).
- `src/doctor/checks/ios.ts` — `IOS_RUNNER_REBUILD_RECOMMENDATION` reworded so it is
  actually followable. String constant only; no control flow touched.
- `docs/using/environment-variables.md` — `BUNDLE_PATH` row corrected to state it needs an
  `.ipa` file; added a row for `AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA`.
- `test/doctor/ios.test.ts` — the stale-runner test pinned the old (impossible)
  recommendation text; updated to assert the new variable and that `BUNDLE_PATH` is no
  longer recommended.

## Scope

Docs-only — no runtime behavior changes. The substantive code fixes remain **open** in
[#4221](https://github.com/kaeawc/auto-mobile/issues/4221): failing closed on an unusable
override instead of silently falling back, and validating the guard in `networkTools.ts`.
This PR only stops the documentation from instructing users into the trap.

Refs [#4221](https://github.com/kaeawc/auto-mobile/issues/4221)
