### PR TITLE
fix(ios): classify physical iOS device UDIDs as iOS, not Android

### DIFF
--- a/src/utils/DeviceDetection.ts
+++ b/src/utils/DeviceDetection.ts
@@ -1,3 +1,4 @@
+import { isIosUdid } from "./ios-cmdline-tools/iosDeviceType";
 import { logger } from "./logger";
 
 /**
@@ -43,18 +44,15 @@ export class DeviceDetection implements DeviceDetection {
       return "android";
     }
 
-    // iOS device patterns (UUIDs from the iOS Simulator)
-    // iOS devices typically use UUIDs like: 569C0F94-5D53-40D2-AF8F-F4AA5BAA7D5E
-    // iOS simulators also use similar UUID patterns
-    const iosPattern = /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
-
     // Android device patterns
     // Emulators: emulator-5554, emulator-5556, etc.
     // Physical devices: various patterns like serial numbers
     const androidEmulatorPattern = /^emulator-\d+$/;
 
-    // Check for iOS UUID pattern first
-    if (iosPattern.test(deviceId)) {
+    // iOS covers three UDID shapes: the simulator's 8-4-4-4-12 UUID plus the two
+    // physical-device forms. Reuse the canonical predicate rather than a second
+    // classifier so this stays in step with the simctl/devicectl routing.
+    if (isIosUdid(deviceId)) {
       logger.info(`[DeviceDetection] Detected iOS device: ${deviceId}`);
       return "ios";
     }

--- a/src/utils/ios-cmdline-tools/iosDeviceType.ts
+++ b/src/utils/ios-cmdline-tools/iosDeviceType.ts
@@ -1,6 +1,6 @@
 /**
  * iOS simulator UDIDs are standard 8-4-4-4-12 hex UUIDs, whereas physical
- * device UDIDs are 40-char hex or the newer `00008XXX-XXXXXXXXXXXXXXXX` form.
+ * device UDIDs are 40-char hex or the newer 8-hex + `-` + 16-hex form.
  * This pattern is the runtime signal used across the iOS tooling to choose
  * between `simctl` (simulator) and `devicectl` (physical device).
  */
@@ -10,14 +10,33 @@ export const IOS_SIMULATOR_UUID_PATTERN =
 /**
  * Physical iOS devices with an A12 or newer SoC (iOS 12+) report a UDID of
  * 8 hex digits, a hyphen, then 16 hex digits — e.g. `00008030-001C2D3E1234567A`.
+ *
+ * The leading group is the zero-padded chip id, so shipped devices all start
+ * `00008` today (8020 = A12, 8030 = A13, 8101 = A14, 8110 = A15, 8120 = A16,
+ * 8130 = A17 Pro, …). The pattern deliberately does NOT hardcode that prefix:
+ * every new SoC introduces a new chip id, and pinning `00008` would silently
+ * reclassify the next generation of iPhones as Android — which is exactly the
+ * bug this module exists to fix (#4165), just deferred to the next chip.
+ *
+ * Matching structure instead of vendor prefix is safe because the shape cannot
+ * collide with an Android device id:
+ *   - Android's CDD (3.2.2 Build Parameters) requires `Build.SERIAL` /
+ *     `ro.serialno` to match `^([a-zA-Z0-9]{0,20})$` — alphanumeric only, so a
+ *     serial can contain neither the hyphen this pattern requires nor the 25
+ *     characters it is long.
+ *   - The other adb device-id shapes (`emulator-NNNN`, `host:port`,
+ *     `adb-<serial>-XXXXXX._adb-tls-connect._tcp`) all carry characters outside
+ *     the hex alphabet in the positions this pattern constrains.
+ * `iosDeviceType.test.ts` pins that disjointness over the whole CDD serial
+ * grammar plus real-world serials, so a regression here fails loudly.
  */
 const IOS_PHYSICAL_UDID_MODERN_PATTERN = /^[0-9A-F]{8}-[0-9A-F]{16}$/i;
 
 /**
  * Pre-A12 physical iOS devices report a bare 40-character hex UDID with no
- * separators. Deliberately anchored and length-exact: Android serials are
- * shorter and/or contain characters outside the hex alphabet, so this stays
- * disjoint from them.
+ * separators. Deliberately anchored and length-exact, which keeps it disjoint
+ * from Android serials for the same reason as above: 40 characters is twice the
+ * 20-character ceiling the CDD puts on `Build.SERIAL`.
  */
 const IOS_PHYSICAL_UDID_LEGACY_PATTERN = /^[0-9A-F]{40}$/i;
 

--- a/src/utils/ios-cmdline-tools/iosDeviceType.ts
+++ b/src/utils/ios-cmdline-tools/iosDeviceType.ts
@@ -11,7 +11,7 @@ export const IOS_SIMULATOR_UUID_PATTERN =
  * Physical iOS devices with an A12 or newer SoC (iOS 12+) report a UDID of
  * 8 hex digits, a hyphen, then 16 hex digits — e.g. `00008030-001C2D3E1234567A`.
  */
-export const IOS_PHYSICAL_UDID_MODERN_PATTERN = /^[0-9A-F]{8}-[0-9A-F]{16}$/i;
+const IOS_PHYSICAL_UDID_MODERN_PATTERN = /^[0-9A-F]{8}-[0-9A-F]{16}$/i;
 
 /**
  * Pre-A12 physical iOS devices report a bare 40-character hex UDID with no
@@ -19,7 +19,7 @@ export const IOS_PHYSICAL_UDID_MODERN_PATTERN = /^[0-9A-F]{8}-[0-9A-F]{16}$/i;
  * shorter and/or contain characters outside the hex alphabet, so this stays
  * disjoint from them.
  */
-export const IOS_PHYSICAL_UDID_LEGACY_PATTERN = /^[0-9A-F]{40}$/i;
+const IOS_PHYSICAL_UDID_LEGACY_PATTERN = /^[0-9A-F]{40}$/i;
 
 /** True when the deviceId looks like an iOS simulator UDID (not a physical device). */
 export function isIosSimulatorUdid(deviceId: string): boolean {

--- a/src/utils/ios-cmdline-tools/iosDeviceType.ts
+++ b/src/utils/ios-cmdline-tools/iosDeviceType.ts
@@ -7,7 +7,37 @@
 export const IOS_SIMULATOR_UUID_PATTERN =
   /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i;
 
+/**
+ * Physical iOS devices with an A12 or newer SoC (iOS 12+) report a UDID of
+ * 8 hex digits, a hyphen, then 16 hex digits — e.g. `00008030-001C2D3E1234567A`.
+ */
+export const IOS_PHYSICAL_UDID_MODERN_PATTERN = /^[0-9A-F]{8}-[0-9A-F]{16}$/i;
+
+/**
+ * Pre-A12 physical iOS devices report a bare 40-character hex UDID with no
+ * separators. Deliberately anchored and length-exact: Android serials are
+ * shorter and/or contain characters outside the hex alphabet, so this stays
+ * disjoint from them.
+ */
+export const IOS_PHYSICAL_UDID_LEGACY_PATTERN = /^[0-9A-F]{40}$/i;
+
 /** True when the deviceId looks like an iOS simulator UDID (not a physical device). */
 export function isIosSimulatorUdid(deviceId: string): boolean {
   return IOS_SIMULATOR_UUID_PATTERN.test(deviceId);
+}
+
+/** True when the deviceId looks like a physical iOS device UDID (either generation). */
+export function isIosPhysicalUdid(deviceId: string): boolean {
+  return (
+    IOS_PHYSICAL_UDID_MODERN_PATTERN.test(deviceId) || IOS_PHYSICAL_UDID_LEGACY_PATTERN.test(deviceId)
+  );
+}
+
+/**
+ * True when the deviceId looks like any iOS UDID — simulator or physical.
+ * Callers that need to know *which* transport to use should keep branching on
+ * {@link isIosSimulatorUdid}; this predicate only answers "is this iOS at all".
+ */
+export function isIosUdid(deviceId: string): boolean {
+  return isIosSimulatorUdid(deviceId) || isIosPhysicalUdid(deviceId);
 }

--- a/test/utils/DeviceDetection.test.ts
+++ b/test/utils/DeviceDetection.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { DeviceDetection, DevicePlatform } from "../../src/utils/DeviceDetection";
+import { isIosSimulatorUdid } from "../../src/utils/ios-cmdline-tools/iosDeviceType";
+
+/**
+ * `detectPlatform` silently misroutes when it is wrong — the caller gets a
+ * confident answer, not an error — so the boundary rows below are the
+ * specification for what counts as an iOS UDID.
+ *
+ * Three real-world iOS UDID shapes exist:
+ *   - simulator:        8-4-4-4-12 hex UUID   (569C0F94-5D53-40D2-AF8F-F4AA5BAA7D5E)
+ *   - physical, A12+:   8 hex + "-" + 16 hex  (00008030-001C2D3E1234567A)
+ *   - physical, legacy: 40 hex, no dashes
+ */
+describe("DeviceDetection.detectPlatform", () => {
+  const detection = new DeviceDetection();
+
+  const cases: [label: string, deviceId: string, expected: DevicePlatform][] = [
+    // --- iOS: simulator UUIDs -------------------------------------------------
+    ["simulator UUID (upper case)", "569C0F94-5D53-40D2-AF8F-F4AA5BAA7D5E", "ios"],
+    ["simulator UUID (lower case)", "569c0f94-5d53-40d2-af8f-f4aa5baa7d5e", "ios"],
+
+    // --- iOS: physical devices, A12 and newer ---------------------------------
+    ["physical A12+ UDID", "00008030-001C2D3E1234567A", "ios"],
+    ["physical A12+ UDID (lower case)", "00008110-000a4d3c1234801e", "ios"],
+
+    // --- iOS: physical devices, legacy 40-hex ---------------------------------
+    ["legacy 40-hex UDID", "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678", "ios"],
+    ["legacy 40-hex UDID (upper case)", "A1B2C3D4E5F60718293A4B5C6D7E8F9012345678", "ios"],
+
+    // --- Android: emulators ---------------------------------------------------
+    ["android emulator", "emulator-5554", "android"],
+    ["android emulator, high port", "emulator-5584", "android"],
+
+    // --- Android: physical serials (must NOT be captured by the iOS widening) --
+    ["android serial with letters beyond hex", "R58M12ABCDE", "android"],
+    ["android serial, short hex-only", "0123456789ABCDEF", "android"],
+    ["android serial, 40 chars but non-hex", `R58M${"Z".repeat(36)}`, "android"],
+    ["android transport id style", "192.168.1.24:5555", "android"],
+
+    // --- Degenerate / boundary input ------------------------------------------
+    ["empty string", "", "android"],
+    ["whitespace only", "   ", "android"],
+    ["simulator UUID with surrounding whitespace", " 569C0F94-5D53-40D2-AF8F-F4AA5BAA7D5E ", "android"],
+    ["39 hex chars (one short of legacy)", "a".repeat(39), "android"],
+    ["41 hex chars (one over legacy)", "a".repeat(41), "android"],
+    ["A12+ form, 15 hex tail (one short)", "00008030-001C2D3E123456", "android"],
+    ["A12+ form, 17 hex tail (one over)", "00008030-001C2D3E1234567AB", "android"],
+    ["A12+ form, 7 hex head (one short)", "0000803-001C2D3E1234567A", "android"],
+    ["A12+ form with non-hex char", "00008030-001C2D3E1234567G", "android"],
+    ["legacy form with non-hex char", `${"a".repeat(39)}g`, "android"],
+    ["not a udid at all", "not-a-uuid", "android"],
+  ];
+
+  test.each(cases)("classifies %s as the expected platform", (_label, deviceId, expected) => {
+    expect(detection.detectPlatform(deviceId)).toBe(expected);
+  });
+
+  test.each(cases)("isiOSDevice/isAndroidDevice agree with detectPlatform for %s", (_l, deviceId, expected) => {
+    expect(detection.isiOSDevice(deviceId)).toBe(expected === "ios");
+    expect(detection.isAndroidDevice(deviceId)).toBe(expected === "android");
+  });
+
+  test("static convenience methods match the instance methods", () => {
+    expect(DeviceDetection.detectPlatform("00008030-001C2D3E1234567A")).toBe("ios");
+    expect(DeviceDetection.isiOSDevice("a".repeat(40))).toBe(true);
+    expect(DeviceDetection.isAndroidDevice("emulator-5554")).toBe(true);
+  });
+
+  /**
+   * Simulator-vs-physical branching across the iOS action layer keys off
+   * `isIosSimulatorUdid`. Both classifiers must agree that these are iOS; they
+   * differ only on which transport (simctl vs devicectl) to use.
+   */
+  test("stays consistent with isIosSimulatorUdid, the sim-vs-physical router", () => {
+    const simulator = "569C0F94-5D53-40D2-AF8F-F4AA5BAA7D5E";
+    const physicalNew = "00008030-001C2D3E1234567A";
+    const physicalLegacy = "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678";
+
+    for (const udid of [simulator, physicalNew, physicalLegacy]) {
+      expect(detection.detectPlatform(udid)).toBe("ios");
+    }
+
+    expect(isIosSimulatorUdid(simulator)).toBe(true);
+    expect(isIosSimulatorUdid(physicalNew)).toBe(false);
+    expect(isIosSimulatorUdid(physicalLegacy)).toBe(false);
+  });
+});

--- a/test/utils/ios-cmdline-tools/iosDeviceType.test.ts
+++ b/test/utils/ios-cmdline-tools/iosDeviceType.test.ts
@@ -68,6 +68,68 @@ describe("isIosPhysicalUdid", () => {
   });
 });
 
+/**
+ * The modern physical pattern matches structure (8 hex + "-" + 16 hex) rather
+ * than the `00008` chip-id prefix on purpose — see the note on
+ * IOS_PHYSICAL_UDID_MODERN_PATTERN. These rows are the proof that the breadth
+ * cannot swallow an Android device id, which is the failure mode issue #4165
+ * describes in the other direction.
+ *
+ * Android's CDD (3.2.2 Build Parameters) constrains `Build.SERIAL` /
+ * `ro.serialno` to `^([a-zA-Z0-9]{0,20})$`: alphanumeric only, at most 20
+ * characters. Both iOS physical forms fall outside that grammar — one needs a
+ * hyphen and 25 characters, the other needs 40.
+ */
+describe("physical-UDID patterns stay disjoint from Android device ids", () => {
+  const CDD_SERIAL_ALPHABET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  const CDD_SERIAL_MAX_LENGTH = 20;
+
+  test("no string in the CDD serial grammar is classified as an iOS UDID", () => {
+    const misclassified: string[] = [];
+
+    for (let length = 1; length <= CDD_SERIAL_MAX_LENGTH; length++) {
+      for (const char of CDD_SERIAL_ALPHABET) {
+        // Homogeneous run plus a mixed run, so hex-only serials (the closest
+        // any compliant serial can get to a UDID) are covered at every length.
+        const homogeneous = char.repeat(length);
+        const mixed = Array.from({ length }, (_, i) =>
+          i % 2 === 0 ? char : CDD_SERIAL_ALPHABET[(i * 7 + length) % CDD_SERIAL_ALPHABET.length]
+        ).join("");
+
+        for (const serial of [homogeneous, mixed]) {
+          if (isIosUdid(serial)) {
+            misclassified.push(serial);
+          }
+        }
+      }
+    }
+
+    expect(misclassified).toEqual([]);
+  });
+
+  test.each([
+    ["Pixel", "1A241FDEE0071P"],
+    ["Pixel, hex-only characters", "8ADX0123456"],
+    ["Samsung", "R58M12ABCDE"],
+    ["Samsung, second form", "RF8N20XXXXY"],
+    ["OnePlus / MTK style, 16 hex chars", "0123456789ABCDEF"],
+    ["8 hex chars only", "00008030"],
+    ["16 hex chars only", "001C2D3E1234567A"],
+    ["20 hex chars (CDD length ceiling)", "00008030001C2D3E1234"],
+    ["emulator", "emulator-5554"],
+    ["adb over TCP/IP", "192.168.1.24:5555"],
+    ["adb wireless-debugging mDNS id", "adb-R58M12ABCDE-vWL3xY._adb-tls-connect._tcp"],
+  ])("classifies the %s device id as non-iOS", (_label, serial) => {
+    expect(isIosUdid(serial)).toBe(false);
+  });
+
+  test("hyphenated hex that is not the 8-16 shape is still rejected", () => {
+    expect(isIosPhysicalUdid("0000803-0001C2D3E1234567A")).toBe(false);
+    expect(isIosPhysicalUdid("000080300-01C2D3E1234567A")).toBe(false);
+    expect(isIosPhysicalUdid("00008030-001C2D3E1234567A-0000")).toBe(false);
+  });
+});
+
 describe("isIosUdid", () => {
   test("is the union of the simulator and physical predicates", () => {
     const iosUdids = [

--- a/test/utils/ios-cmdline-tools/iosDeviceType.test.ts
+++ b/test/utils/ios-cmdline-tools/iosDeviceType.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { isIosSimulatorUdid } from "../../../src/utils/ios-cmdline-tools/iosDeviceType";
+import {
+  isIosPhysicalUdid,
+  isIosSimulatorUdid,
+  isIosUdid,
+} from "../../../src/utils/ios-cmdline-tools/iosDeviceType";
 
 /**
  * `isIosSimulatorUdid` is the routing predicate that decides simctl (simulator)
@@ -31,5 +35,55 @@ describe("isIosSimulatorUdid", () => {
 
   test("rejects a UUID with surrounding whitespace (anchored match)", () => {
     expect(isIosSimulatorUdid(" A1B2C3D4-E5F6-7890-ABCD-EF1234567890 ")).toBe(false);
+  });
+});
+
+/**
+ * The physical-device forms are what `isIosSimulatorUdid` deliberately rejects.
+ * They still have to be recognised as iOS by platform-level classification
+ * (issue #4165), so pin both generations and the negative boundaries.
+ */
+describe("isIosPhysicalUdid", () => {
+  test("accepts the A12+ form (8 hex + '-' + 16 hex, either case)", () => {
+    expect(isIosPhysicalUdid("00008030-001C2D3E1234567A")).toBe(true);
+    expect(isIosPhysicalUdid("00008110-000a4d3c1234801e")).toBe(true);
+  });
+
+  test("accepts the legacy 40-hex form (either case)", () => {
+    expect(isIosPhysicalUdid("a1b2c3d4e5f60718293a4b5c6d7e8f9012345678")).toBe(true);
+    expect(isIosPhysicalUdid("A1B2C3D4E5F60718293A4B5C6D7E8F9012345678")).toBe(true);
+  });
+
+  test("rejects simulator UUIDs, Android serials and off-by-one lengths", () => {
+    expect(isIosPhysicalUdid("569C0F94-5D53-40D2-AF8F-F4AA5BAA7D5E")).toBe(false);
+    expect(isIosPhysicalUdid("emulator-5554")).toBe(false);
+    expect(isIosPhysicalUdid("R58M12ABCDE")).toBe(false);
+    expect(isIosPhysicalUdid("a".repeat(39))).toBe(false);
+    expect(isIosPhysicalUdid("a".repeat(41))).toBe(false);
+    expect(isIosPhysicalUdid("00008030-001C2D3E123456")).toBe(false);
+    expect(isIosPhysicalUdid("00008030-001C2D3E1234567AB")).toBe(false);
+    expect(isIosPhysicalUdid("00008030-001C2D3E1234567G")).toBe(false);
+    expect(isIosPhysicalUdid("")).toBe(false);
+    expect(isIosPhysicalUdid(" 00008030-001C2D3E1234567A ")).toBe(false);
+  });
+});
+
+describe("isIosUdid", () => {
+  test("is the union of the simulator and physical predicates", () => {
+    const iosUdids = [
+      "569C0F94-5D53-40D2-AF8F-F4AA5BAA7D5E",
+      "00008030-001C2D3E1234567A",
+      "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678",
+    ];
+    for (const udid of iosUdids) {
+      expect(isIosUdid(udid)).toBe(true);
+      expect(isIosSimulatorUdid(udid) || isIosPhysicalUdid(udid)).toBe(true);
+    }
+  });
+
+  test("rejects Android serials and degenerate input", () => {
+    for (const serial of ["emulator-5554", "R58M12ABCDE", "192.168.1.24:5555", "", "   ", "not-a-uuid"]) {
+      expect(isIosUdid(serial)).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
## Summary

`DeviceDetection.detectPlatform` only recognised the iOS Simulator's 8-4-4-4-12 UUID, so
every **physical** iOS device UDID fell through to the Android default — a silent misroute
(confident wrong answer, not an error).

Rather than widen the inline regex in `DeviceDetection`, the two physical-device shapes are
added to the canonical iOS classifier module, `src/utils/ios-cmdline-tools/iosDeviceType.ts`,
which already owns `isIosSimulatorUdid` — the predicate the whole iOS action layer uses to
branch simctl vs devicectl. `DeviceDetection` now consumes the new `isIosUdid` union instead
of carrying a second, divergent classifier.

| Form | Example | Devices |
|---|---|---|
| 8-4-4-4-12 UUID | `569C0F94-5D53-40D2-AF8F-F4AA5BAA7D5E` | Simulator |
| 8 hex + `-` + 16 hex | `00008030-001C2D3E1234567A` | A12 and newer |
| 40 hex, no dashes | `a1b2…5678` | pre-A12 legacy |

The new patterns are anchored and length-exact, so Android serials stay disjoint: they are
either shorter, contain characters outside the hex alphabet, or use the `emulator-NNNN` /
`host:port` shapes. `isIosSimulatorUdid` itself is unchanged, so sim-vs-physical routing
behaviour is identical.

## Changes

- `src/utils/ios-cmdline-tools/iosDeviceType.ts`: add `IOS_PHYSICAL_UDID_MODERN_PATTERN`,
  `IOS_PHYSICAL_UDID_LEGACY_PATTERN`, `isIosPhysicalUdid`, and the `isIosUdid` union.
- `src/utils/DeviceDetection.ts`: drop the duplicated simulator-only regex; delegate to
  `isIosUdid`.
- `test/utils/DeviceDetection.test.ts` (new): `test.each` boundary table over all three iOS
  forms, Android emulator/serial rows, and degenerate input; plus a consistency test tying
  `detectPlatform` to `isIosSimulatorUdid`.
- `test/utils/ios-cmdline-tools/iosDeviceType.test.ts`: coverage for the new predicates.

## Linked Issue

Closes #4165

## Bug / Regression Context

- **Observed symptom:** `detectPlatform("00008030-001C2D3E1234567A")` and
  `detectPlatform("a1b2c3d4e5f60718293a4b5c6d7e8f9012345678")` both returned `"android"`.
- **Repro steps / conditions:** any call routing on `detectPlatform` with a physical iOS
  device attached.
- **Red before, green after:** the new table failed 10 rows against the pre-fix regex
  (every physical-UDID row) and passes after.

## Validation

- [x] `bun run lint` + `bun test` pass (8364 pass / 0 fail, full suite)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New code reuses the existing `iosDeviceType` helper rather than adding a second classifier
- [x] Unit tests run well under 100ms (58 tests across the two files in ~130ms)
- [x] Branched off latest `main`

## Device Verification

N/A — pure string classification, verified with fixtures.

## Follow-ups

None. Behaviour of `isIosSimulatorUdid` and its call sites is unchanged.
