### PR TITLE
fix(ci): tokenize quoted union members instead of text-splitting

### DIFF
--- a/scripts/typecheck-baseline.sh
+++ b/scripts/typecheck-baseline.sh
@@ -148,6 +148,26 @@ ROOT_SED_PATTERN="$(printf '%s' "$ROOT" | sed 's/[][\.*^$|/]/\\&/g')"
 # identical on every machine.
 canonicalize_unions() {
   awk '
+    # Split a run into its members WITHOUT a plain text split. A string-literal
+    # member may itself contain the separator (the type `"a | b" | "c"`), and a
+    # naive split on " | " cuts inside the quotes -- producing a different result
+    # on each pass, so `--update` would write a baseline that check mode then
+    # rejected as new. Walking front-anchored tokens keeps quoted members intact.
+    # Returns the member count, or 0 if the run does not tokenize cleanly, in
+    # which case the caller leaves it untouched.
+    function split_members(run, arr,   n, rest, tok) {
+      n = 0
+      rest = run
+      while (length(rest) > 0) {
+        if (!match(rest, /^("[^"]*"|[A-Za-z_$][A-Za-z0-9_$]*)/)) { return 0 }
+        arr[++n] = substr(rest, RSTART, RLENGTH)
+        rest = substr(rest, RLENGTH + 1)
+        if (length(rest) == 0) { break }
+        if (substr(rest, 1, 3) != " | ") { return 0 }
+        rest = substr(rest, 4)
+      }
+      return n
+    }
     function canon_unions(line,   out, rest, run, n, arr, i, j, t, joined) {
       out = ""
       rest = line
@@ -155,9 +175,12 @@ canonicalize_unions() {
         out = out substr(rest, 1, RSTART - 1)
         run = substr(rest, RSTART, RLENGTH)
         rest = substr(rest, RSTART + RLENGTH)
-        # split on a literal " | " -- the bracket expression stops awk reading
-        # the pipe as regex alternation.
-        n = split(run, arr, " [|] ")
+        n = split_members(run, arr)
+        if (n < 2) {
+          # Not cleanly tokenizable -- emit verbatim, preserving current behavior.
+          out = out run
+          continue
+        }
         for (i = 1; i <= n; i++)
           for (j = i + 1; j <= n; j++)
             if (arr[i] > arr[j]) { t = arr[i]; arr[i] = arr[j]; arr[j] = t }

--- a/test/bats/typecheck-baseline.bats
+++ b/test/bats/typecheck-baseline.bats
@@ -338,3 +338,35 @@ EOF
   TYPECHECK_TSC_CMD="$orig" run bash "$SCRIPT"
   [ "$status" -eq 0 ]
 }
+
+@test "a string-literal union member containing the separator is not split inside its quotes" {
+  # The type `"a | b" | "c"` has a member whose VALUE contains " | ". A naive
+  # text split cuts inside the quotes and yields a different result on each
+  # pass, so `--update` would write a baseline that check mode instantly
+  # rejected as new. Canonicalization must be idempotent here.
+  q='printf "%s\n" "src/q.ts(1,1): error TS2322: Type is \"a | b\" | \"c\"."'
+  TYPECHECK_TSC_CMD="$q" bash "$SCRIPT" --update
+
+  # Members stay intact and sort as two members, not three.
+  grep -q 'Type is "a | b" | "c"' "$TYPECHECK_BASELINE"
+
+  # The freshly written baseline must validate against the very same output.
+  TYPECHECK_TSC_CMD="$q" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no new type errors"* ]]
+  [[ "$output" != *"no longer occur"* ]]
+}
+
+@test "update then check is idempotent for every union shape in one line" {
+  mixed='printf "%s\n" "src/m.ts(1,1): error TS2322: Bad { a: \"z\" | \"a | b\" | \"c\"; b: string | null; c: { x: 1 } | undefined; }."'
+  TYPECHECK_TSC_CMD="$mixed" bash "$SCRIPT" --update
+  cp "$TYPECHECK_BASELINE" "$TEST_DIR/first.txt"
+
+  # Re-running update must reproduce the file byte-for-byte.
+  TYPECHECK_TSC_CMD="$mixed" bash "$SCRIPT" --update
+  diff -q "$TEST_DIR/first.txt" "$TYPECHECK_BASELINE"
+
+  TYPECHECK_TSC_CMD="$mixed" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no new type errors"* ]]
+}


### PR DESCRIPTION
## Summary

Follow-up to #4224, which merged before this fix could land on it.

#4224 made typecheck baseline signatures union-order-insensitive by byte-sorting the members of each `TOKEN ( " | " TOKEN )+` run. It split each run on a literal `" | "` — but a **string-literal union member can itself contain the separator**. For the type `"a | b" | "c"`, the split cuts inside the quotes and yields three members instead of two.

That makes canonicalization **non-idempotent**, which is the damaging part:

```
input: Type is "a | b" | "c".
pass1: Type is "a | "c" | b".
pass2: Type is ""c" | a | b".
```

`normalize()` canonicalizes on write and `baseline_signatures()` canonicalizes again on read, so `--update` would write a baseline that check mode **immediately rejects as a new error** — the same self-inflicted red that #4211 set out to remove, just with a rarer trigger.

Caught by Codex review on #4224 (P2). I reproduced it before fixing; the mechanism is exactly as described.

## Fix

Replace the text split with a front-anchored token walk (`split_members`), so a quoted member is consumed whole regardless of its contents. A run that does not tokenize cleanly returns `0` and is emitted **verbatim**, so anything unexpected falls back to pre-#4224 behavior rather than being corrupted.

## Linked Issue

Follows up #4211 / #4224. No separate issue filed — this is a defect in code that merged minutes ago, so it belongs to that work rather than to a new tracker.

## Validation

- [x] `bats test/bats/typecheck-baseline.bats` — **26/26**, including the 24 from #4224
- [x] Re-run under the exact `macos-latest` toolchain — **BSD awk 20200816 + bash 3.2.57** — 26/26, since the tokenizer leans on `match()`/`substr()` semantics
- [x] `shellcheck` clean; `validate_shell_portability.sh` clean
- [x] `bun run typecheck` — `✅ no new type errors (225 known error(s) in baseline)`
- [x] `scripts/typecheck-baseline.txt` unchanged

## Testing

Two BATS cases added:

- **`a string-literal union member containing the separator is not split inside its quotes`** — pins the exact `"a | b" | "c"` case: members stay intact, and the freshly written baseline validates against the same output.
- **`update then check is idempotent for every union shape in one line`** — mixes a separator-bearing literal, a plain `string | null`, and an object-literal member on one line, then asserts two consecutive `--update` runs are byte-identical.

## Note

Two BATS cases in `test/bats/boot-simulator.bats` fail on `macos-latest` on this branch. They are #4212 (`boot-simulator.sh: line 34: ci_extra[@]: unbound variable`, bash 3.2 empty-array expansion), pre-existing on `main` and unrelated to this diff — no failures in `typecheck-baseline.bats`.
