### PR TITLE
fix(ios): honour the fresh flag so CtrlProxyHierarchy.invalidateCache() actually invalidates

### DIFF
--- a/src/features/action/LaunchApp.ts
+++ b/src/features/action/LaunchApp.ts
@@ -349,8 +349,10 @@ export class LaunchApp extends BaseVisualChange {
           // re-targeted above (setTargetBundleId); after a data wipe the app gets
           // a brand-new process, so drop the cached hierarchy too — otherwise
           // waitForIosHierarchyReady returns stale pre-terminate data via the
-          // cache fast path. clearCache() nulls the cache entirely; invalidateCache()
-          // only marks it not-fresh but the time-based freshness check still matches.
+          // cache fast path. clearCache() nulls the cache entirely, which is what we
+          // need here: invalidateCache() (fixed in #4193) forces a refetch, but the
+          // invalidated entry is still served as a stale fallback if that refetch
+          // fails — and pre-terminate data for a wiped app must never be served.
           IOSCtrlProxyClient.getInstance(this.device).clearCache();
           launchResult = await perf.track("launch", () =>
             simulator

--- a/src/features/observe/ios/CtrlProxyHierarchy.ts
+++ b/src/features/observe/ios/CtrlProxyHierarchy.ts
@@ -121,8 +121,17 @@ export class CtrlProxyHierarchy {
       }
     }
 
-    // Need fresh data
-    if (!skipWaitForFresh) {
+    // Need fresh data.
+    //
+    // An explicitly invalidated entry forces the sync fetch even when the caller
+    // passed skipWaitForFresh. Observe's default path is skipWaitForFresh=true, so
+    // without this the stale fallback below would hand back the very entry the
+    // invalidation was meant to retire — e.g. the unfiltered snapshot that
+    // HierarchyCollector.collectRaw caches and then invalidates (issue #4193).
+    // Nulling the cache instead is not an option here: under skipWaitForFresh a
+    // missing cache yields no hierarchy at all rather than a refetch.
+    const cacheInvalidated = cachedHierarchy !== null && !cachedHierarchy.fresh;
+    if (!skipWaitForFresh || cacheInvalidated) {
       const result = await this.requestHierarchySync(perf, false, undefined, timeout);
       if (result) {
         if (result.hierarchy.packageName) {

--- a/src/features/observe/ios/CtrlProxyHierarchy.ts
+++ b/src/features/observe/ios/CtrlProxyHierarchy.ts
@@ -50,11 +50,17 @@ export class CtrlProxyHierarchy {
 
   /**
    * Invalidate the cache (mark as not fresh).
+   *
+   * The entry is deliberately kept rather than nulled: `getLatestHierarchy` still
+   * returns it as an explicitly-stale fallback when a fresh fetch is impossible
+   * (disconnected/reconnecting runner). Use `IOSCtrlProxyClient.clearCache()` when
+   * the cached data must not be served at all — e.g. after an app data wipe.
    */
   invalidateCache(): void {
     const cached = this.context.getCachedHierarchy();
     if (cached) {
-      cached.fresh = false;
+      logger.debug("[CTRL_PROXY] Invalidating cached hierarchy");
+      this.context.setCachedHierarchy({ ...cached, fresh: false });
     }
   }
 
@@ -97,7 +103,9 @@ export class CtrlProxyHierarchy {
     const cachedHierarchy = this.context.getCachedHierarchy();
     if (cachedHierarchy) {
       const cacheAge = this.context.timer.now() - cachedHierarchy.receivedAt;
-      const isFresh = cacheAge < this.context.cacheFreshTtlMs;
+      // `fresh` is honoured as well as elapsed time: without it, invalidateCache()
+      // would be an observable no-op inside the TTL (issue #4193).
+      const isFresh = cachedHierarchy.fresh && cacheAge < this.context.cacheFreshTtlMs;
       const meetsMinTimestamp = minTimestamp === 0 || cachedHierarchy.hierarchy.updatedAt >= minTimestamp;
 
       if (isFresh && meetsMinTimestamp) {

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -1720,7 +1720,9 @@ describe("IOSCtrlProxyClient", function() {
         // Invalidate cache
         testClient.invalidateCache();
 
-        // Cache still exists but is marked as stale
+        // Cache still exists but is marked as stale (kept for the stale fallback
+        // path). See ctrlProxyHierarchyCache.test.ts for the refetch semantics
+        // this flag drives (issue #4193).
         expect(testClient.hasCachedHierarchy()).toBe(true);
       } finally {
         await testClient.close();

--- a/test/features/observe/ios/ctrlProxyHierarchyCache.test.ts
+++ b/test/features/observe/ios/ctrlProxyHierarchyCache.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Cache-invalidation semantics for the iOS hierarchy delegate (issue #4193).
+ *
+ * `CtrlProxyHierarchy.invalidateCache()` marks the cached entry `fresh = false`.
+ * Before #4193, `getLatestHierarchy()` derived freshness from elapsed time alone
+ * and never read that flag, so invalidation was an observable no-op: the next
+ * call still served the stale cache for the remainder of the TTL.
+ *
+ * These tests drive the TTL boundary with `FakeTimer` and count wire fetches, so
+ * they pin both the invalidation path and the caching controls that prove the fix
+ * did not simply disable the cache.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import { CtrlProxyHierarchy } from "../../../../src/features/observe/ios/CtrlProxyHierarchy";
+import type {
+  CtrlProxyCachedHierarchy,
+  HierarchyDelegateContext,
+  XCTestHierarchy,
+} from "../../../../src/features/observe/ios/types";
+import { RequestManager } from "../../../../src/utils/RequestManager";
+import { FakeTimer } from "../../../fakes/FakeTimer";
+
+const CACHE_TTL_MS = 500;
+
+interface Harness {
+  hierarchy: CtrlProxyHierarchy;
+  timer: FakeTimer;
+  /** Number of `request_hierarchy*` messages that reached the socket. */
+  fetchCount: () => number;
+  getCached: () => CtrlProxyCachedHierarchy | null;
+}
+
+function makeHierarchy(updatedAt: number, marker: string): XCTestHierarchy {
+  return {
+    updatedAt,
+    packageName: "com.test.app",
+    hierarchy: { text: marker },
+  } as XCTestHierarchy;
+}
+
+function createHarness(): Harness {
+  const timer = new FakeTimer();
+  const requestManager = new RequestManager(timer);
+  let cached: CtrlProxyCachedHierarchy | null = null;
+  let fetches = 0;
+
+  const context: HierarchyDelegateContext = {
+    getWebSocket: () => ({
+      readyState: 1,
+      send: (data: string) => {
+        const message = JSON.parse(data) as { requestId: string };
+        fetches += 1;
+        // Respond immediately with a hierarchy stamped at the current fake time,
+        // so each fetch is distinguishable from the previously cached one.
+        requestManager.resolve(message.requestId, {
+          hierarchy: makeHierarchy(timer.now(), `fetch-${fetches}`),
+        });
+      },
+    } as never),
+    requestManager,
+    timer,
+    ensureConnected: async () => true,
+    cancelScreenshotBackoff: () => {},
+    cacheFreshTtlMs: CACHE_TTL_MS,
+    getCachedHierarchy: () => cached,
+    setCachedHierarchy: h => { cached = h; },
+  };
+
+  return {
+    hierarchy: new CtrlProxyHierarchy(context),
+    timer,
+    fetchCount: () => fetches,
+    getCached: () => cached,
+  };
+}
+
+describe("CtrlProxyHierarchy cache invalidation (iOS)", () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    h = createHarness();
+  });
+
+  async function primeCache(): Promise<void> {
+    await h.hierarchy.getLatestHierarchy(true, 1000);
+    expect(h.fetchCount()).toBe(1);
+    expect(h.getCached()).not.toBeNull();
+  }
+
+  test("invalidateCache forces a refetch well inside the TTL", async () => {
+    await primeCache();
+
+    h.timer.advanceTime(CACHE_TTL_MS / 2);
+    h.hierarchy.invalidateCache();
+
+    const result = await h.hierarchy.getLatestHierarchy(true, 1000);
+
+    expect(h.fetchCount()).toBe(2);
+    expect(result.fresh).toBe(true);
+    expect(result.updatedAt).toBe(CACHE_TTL_MS / 2);
+  });
+
+  test("invalidateCache at the TTL boundary still refetches", async () => {
+    await primeCache();
+
+    h.timer.advanceTime(CACHE_TTL_MS - 1);
+    h.hierarchy.invalidateCache();
+    await h.hierarchy.getLatestHierarchy(true, 1000);
+
+    expect(h.fetchCount()).toBe(2);
+  });
+
+  test("a refetch after invalidation restores caching", async () => {
+    await primeCache();
+
+    h.hierarchy.invalidateCache();
+    await h.hierarchy.getLatestHierarchy(true, 1000);
+    expect(h.fetchCount()).toBe(2);
+
+    // The replacement entry is fresh again, so the next in-TTL call is a cache hit.
+    await h.hierarchy.getLatestHierarchy(true, 1000);
+    expect(h.fetchCount()).toBe(2);
+  });
+
+  // --- Controls: these fail if the fix simply disabled caching. ---
+
+  test("without invalidation the cache serves inside the TTL", async () => {
+    await primeCache();
+
+    h.timer.advanceTime(CACHE_TTL_MS - 1);
+    const result = await h.hierarchy.getLatestHierarchy(true, 1000);
+
+    expect(h.fetchCount()).toBe(1);
+    expect(result.fresh).toBe(true);
+    expect(result.updatedAt).toBe(0);
+  });
+
+  test("without invalidation the cache refetches at and past the TTL", async () => {
+    await primeCache();
+
+    // Boundary: cacheAge === TTL is NOT fresh (strict `<`).
+    h.timer.advanceTime(CACHE_TTL_MS);
+    await h.hierarchy.getLatestHierarchy(true, 1000);
+    expect(h.fetchCount()).toBe(2);
+
+    h.timer.advanceTime(CACHE_TTL_MS + 1);
+    await h.hierarchy.getLatestHierarchy(true, 1000);
+    expect(h.fetchCount()).toBe(3);
+  });
+
+  test("invalidated cache is still returned as stale fallback when no fetch is possible", async () => {
+    await primeCache();
+    h.hierarchy.invalidateCache();
+
+    // skipWaitForFresh suppresses the sync fetch; the invalidated entry must still
+    // be available as a stale fallback rather than disappearing.
+    const result = await h.hierarchy.getLatestHierarchy(false, 1000, undefined, true);
+
+    expect(h.fetchCount()).toBe(1);
+    expect(result.fresh).toBe(false);
+    expect(result.hierarchy).not.toBeNull();
+  });
+});

--- a/test/features/observe/ios/ctrlProxyHierarchyCache.test.ts
+++ b/test/features/observe/ios/ctrlProxyHierarchyCache.test.ts
@@ -123,6 +123,24 @@ describe("CtrlProxyHierarchy cache invalidation (iOS)", () => {
     expect(h.fetchCount()).toBe(2);
   });
 
+  test("the raw-observe invalidate keeps the unfiltered snapshot out of the next read", async () => {
+    // Mirrors HierarchyCollector.collectRaw: a raw (disableAllFiltering) fetch
+    // caches the *unfiltered* snapshot, then invalidates so it does not bleed into
+    // the next normal observe. That caller is the one the no-op was defeating —
+    // it never depended on invalidateCache() doing nothing.
+    const rawResult = await h.hierarchy.requestHierarchySync(undefined, true, undefined, 1000);
+    expect(h.fetchCount()).toBe(1);
+    expect(rawResult).not.toBeNull();
+    // The unfiltered snapshot really is in the shared cache at this point.
+    expect(h.getCached()?.hierarchy).toBe(rawResult!.hierarchy);
+
+    h.hierarchy.invalidateCache();
+
+    const next = await h.hierarchy.getLatestHierarchy(true, 1000);
+    expect(h.fetchCount()).toBe(2);
+    expect(next.hierarchy).not.toBe(rawResult!.hierarchy);
+  });
+
   // --- Controls: these fail if the fix simply disabled caching. ---
 
   test("without invalidation the cache serves inside the TTL", async () => {

--- a/test/features/observe/ios/ctrlProxyHierarchyCache.test.ts
+++ b/test/features/observe/ios/ctrlProxyHierarchyCache.test.ts
@@ -29,6 +29,8 @@ interface Harness {
   /** Number of `request_hierarchy*` messages that reached the socket. */
   fetchCount: () => number;
   getCached: () => CtrlProxyCachedHierarchy | null;
+  /** Simulate a disconnected/reconnecting runner, so no fetch can succeed. */
+  setConnected: (connected: boolean) => void;
 }
 
 function makeHierarchy(updatedAt: number, marker: string): XCTestHierarchy {
@@ -44,6 +46,7 @@ function createHarness(): Harness {
   const requestManager = new RequestManager(timer);
   let cached: CtrlProxyCachedHierarchy | null = null;
   let fetches = 0;
+  let connected = true;
 
   const context: HierarchyDelegateContext = {
     getWebSocket: () => ({
@@ -60,7 +63,7 @@ function createHarness(): Harness {
     } as never),
     requestManager,
     timer,
-    ensureConnected: async () => true,
+    ensureConnected: async () => connected,
     cancelScreenshotBackoff: () => {},
     cacheFreshTtlMs: CACHE_TTL_MS,
     getCachedHierarchy: () => cached,
@@ -72,6 +75,7 @@ function createHarness(): Harness {
     timer,
     fetchCount: () => fetches,
     getCached: () => cached,
+    setConnected: value => { connected = value; },
   };
 }
 
@@ -141,6 +145,30 @@ describe("CtrlProxyHierarchy cache invalidation (iOS)", () => {
     expect(next.hierarchy).not.toBe(rawResult!.hierarchy);
   });
 
+  test("an invalidated entry forces a refetch even on the skipWaitForFresh observe path", async () => {
+    // ObserveScreen defaults to skipWaitForFresh=true, which normally suppresses the
+    // sync fetch entirely. An invalidated entry must override that, or the stale
+    // fallback hands back exactly the snapshot the invalidation was retiring.
+    const rawResult = await h.hierarchy.requestHierarchySync(undefined, true, undefined, 1000);
+    h.hierarchy.invalidateCache();
+
+    const next = await h.hierarchy.getLatestHierarchy(false, 15000, undefined, true, 0);
+
+    expect(h.fetchCount()).toBe(2);
+    expect(next.fresh).toBe(true);
+    expect(next.hierarchy).not.toBe(rawResult!.hierarchy);
+  });
+
+  test("skipWaitForFresh still skips the fetch when the cache was not invalidated", async () => {
+    await primeCache();
+    h.timer.advanceTime(CACHE_TTL_MS * 4); // past the TTL, but not invalidated
+
+    const result = await h.hierarchy.getLatestHierarchy(false, 15000, undefined, true, 0);
+
+    expect(h.fetchCount()).toBe(1);
+    expect(result.fresh).toBe(false);
+  });
+
   // --- Controls: these fail if the fix simply disabled caching. ---
 
   test("without invalidation the cache serves inside the TTL", async () => {
@@ -167,16 +195,20 @@ describe("CtrlProxyHierarchy cache invalidation (iOS)", () => {
     expect(h.fetchCount()).toBe(3);
   });
 
-  test("invalidated cache is still returned as stale fallback when no fetch is possible", async () => {
+  test("invalidated cache is still returned as stale fallback when the refetch fails", async () => {
     await primeCache();
+    const stale = h.getCached()!.hierarchy;
     h.hierarchy.invalidateCache();
 
-    // skipWaitForFresh suppresses the sync fetch; the invalidated entry must still
-    // be available as a stale fallback rather than disappearing.
+    // Disconnected/reconnecting runner: the forced refetch cannot succeed, so the
+    // invalidated entry must still be available as an explicitly-stale fallback
+    // rather than disappearing. This is why invalidateCache() keeps the entry
+    // instead of nulling it the way the Android delegate does.
+    h.setConnected(false);
     const result = await h.hierarchy.getLatestHierarchy(false, 1000, undefined, true);
 
-    expect(h.fetchCount()).toBe(1);
+    expect(h.fetchCount()).toBe(1); // ensureConnected failed before any send
     expect(result.fresh).toBe(false);
-    expect(result.hierarchy).not.toBeNull();
+    expect(result.hierarchy).toBe(stale);
   });
 });


### PR DESCRIPTION
> ## ⚠️ No iOS runner re-cut required
>
> **This is a TypeScript-only fix.** Nothing under `ios/control-proxy/` changes, no Swift
> source is touched, and no runner checksum moves — `git diff origin/main...HEAD` touches
> only `src/features/**` and `test/features/**`. The fix reaches users with the next npm
> publish; **no release cut of the iOS runner is needed.**

## Summary

`CtrlProxyHierarchy.invalidateCache()` on iOS was an observable no-op. It set
`cached.fresh = false`, but `getLatestHierarchy()` derived freshness from elapsed time
alone (`cacheAge < cacheFreshTtlMs`) and never read the flag — so after an invalidation
the next call still served the stale cache for the rest of the 500 ms TTL.

Two changes make invalidation actually take effect:

1. The fast-path freshness check now honours the flag as well as the age.
2. An invalidated entry **forces the sync refetch even when the caller passed
   `skipWaitForFresh`**. `ObserveScreen` defaults to `skipWaitForFresh = true`, and on
   that path the delegate never issues a wire fetch — so fixing only (1) still handed the
   invalidated entry back through the stale-fallback branch. Caught in review; see the
   caller analysis below.

The entry is deliberately still *kept* (not nulled, unlike the Android delegate) because
`getLatestHierarchy` returns it as an explicitly-stale fallback when a fresh fetch is
genuinely impossible (disconnected/reconnecting runner). Nulling would be wrong on iOS
specifically: under `skipWaitForFresh` a missing cache produces *no hierarchy at all*
rather than a refetch, because Android's delegate fetches on a cache miss and iOS's does
not. `IOSCtrlProxyClient.clearCache()` remains the "must not be served at all" hammer.

## Linked Issue

Closes #4193

## Caller analysis — did anything depend on the no-op?

Every caller of the iOS `invalidateCache()` was traced. `src/features/observe/interfaces/CtrlProxyClient.ts`
declares it, `IOSCtrlProxyClient.invalidateCache()` (line 1222) is the only forwarder, and
it has exactly **one** production caller:

- `HierarchyCollector.collectRaw()` (`src/features/observe/collectors/HierarchyCollector.ts:155`) —
  fetches the raw unfiltered hierarchy, which `requestHierarchySync` caches, then invalidates
  so that snapshot does not bleed into the next normal observe.

That caller was **not** relying on the no-op — it was the bug's victim. Its stated contract
("so that the unfiltered snapshot does not bleed into subsequent normal observe calls") was
silently unmet, on both the fast path *and* the `skipWaitForFresh` path. Both are now pinned
by tests.

Other `invalidateCache` hits in the tree are unrelated types with their own caches
(`AccessibilityDetector`, `IosVoiceOverDetector`, `daemonMcpProxy`, the Android delegate),
none of which routes through this code.

No writer ever stores `fresh: false`: both cache-population sites
(`CtrlProxyHierarchy.requestHierarchySync` and the `hierarchy_update` push handler in
`IOSCtrlProxyClient.ts:1051`) set `fresh: true`. So `fresh === false` is reachable *only*
via `invalidateCache()`, and honouring the flag cannot retire any pre-existing entry that
used to be served.

## Changes

- `src/features/observe/ios/CtrlProxyHierarchy.ts` — `isFresh` now requires
  `cachedHierarchy.fresh`; an invalidated entry forces the sync fetch even under
  `skipWaitForFresh`; `invalidateCache()` writes the flag back through `setCachedHierarchy`
  (so it is not a mutation of a possibly-shared object) and logs at debug, matching the
  Android delegate's shape.
- `src/features/action/LaunchApp.ts` — **workaround kept**, comment corrected. The
  `clearCache()` call there is still the right primitive: after an app-data wipe, the
  pre-terminate hierarchy must never be served, not even as a stale fallback. Only the
  now-inaccurate "invalidateCache only marks it not-fresh but the freshness check still
  matches" sentence changed.
- `test/features/observe/ios/ctrlProxyHierarchyCache.test.ts` — new focused suite.
- `test/features/observe/ios/IOSCtrlProxyClient.test.ts` — comment pointing the existing
  weak assertion at the new suite.

## Acceptance criteria

- [x] After `invalidateCache()`, the next `getLatestHierarchy` refetches even well inside
      the TTL — `invalidateCache forces a refetch well inside the TTL`.
- [x] The `collectRaw` sequence (raw fetch → invalidate → read) no longer returns the raw
      snapshot — `the raw-observe invalidate keeps the unfiltered snapshot out of the next read`.
- [x] Same, on observe's default `skipWaitForFresh = true` path — `an invalidated entry
      forces a refetch even on the skipWaitForFresh observe path`.
- [x] Controls proving caching is not simply disabled — `without invalidation the cache
      serves inside the TTL`, `... refetches at and past the TTL`, `skipWaitForFresh still
      skips the fetch when the cache was not invalidated`, and `a refetch after invalidation
      restores caching`.
- [x] Stale fallback preserved for a disconnected runner — `invalidated cache is still
      returned as stale fallback when the refetch fails`.
- [x] `FakeTimer` drives the TTL boundary; asserted at `TTL-1`, `TTL`, and `TTL+1`.
- [x] `LaunchApp.ts` workaround considered — kept, with the reason stated above and in
      the code comment.
- [x] Red before the fix, green after (verified by temporarily reverting each guard).

## Validation

- [x] `bun test` — 8372 pass / 0 fail
- [x] `bun run lint`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New code uses interfaces + fakes + FakeTimer; the new suite runs in ~130 ms
- [x] Rebased onto `origin/main` at `9cb523bc6` (picks up #4224, #4229, #4217)

## Device Verification

Not run — pure cache-bookkeeping change with no wire-protocol surface, and a live device
session is in progress on this machine.

## Notes

`bun run typecheck` reports 10 baseline entries that no longer occur (pre-existing drift,
unrelated to this diff). `scripts/typecheck-baseline.txt` intentionally left untouched here.
