### PR TITLE
fix(android): invalidate accessibility detector cache at a single choke point

### DIFF
--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -1025,9 +1025,6 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       perf.endOperation("writeServiceEnabled");
       logger.info("Accessibility Service enabled successfully via settings");
 
-      // Clear cache after enabling; clearAvailabilityCache also invalidates the
-      // accessibility detector cache so observe reports correct state (#4192).
-      this.clearAvailabilityCache();
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
       const errorLower = errorMsg.toLowerCase();
@@ -1042,6 +1039,12 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       } else {
         throw new Error(`Failed to enable Accessibility Service via settings. This may indicate an ADB communication issue or device state problem. Original error: ${errorMsg}`);
       }
+    } finally {
+      // Issue #4192: clear in `finally` so success, early return, and a partial
+      // failure all reconcile our cached view. clearAvailabilityCache also
+      // invalidates the accessibility detector cache, so observe cannot keep
+      // reporting the pre-mutation state.
+      this.clearAvailabilityCache();
     }
   }
 
@@ -1067,9 +1070,6 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       // Handle null or empty values
       if (currentServices === "null" || currentServices === "") {
         logger.info("No accessibility services enabled");
-        // Issue #4192: nothing to write, but our cached view may still claim the
-        // service is available - reconcile it with the device before returning.
-        this.clearAvailabilityCache();
         return;
       }
 
@@ -1098,9 +1098,6 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       }
 
       logger.info("Accessibility Service disabled successfully via settings");
-
-      // Clear cache after disabling
-      this.clearAvailabilityCache();
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
       const errorLower = errorMsg.toLowerCase();
@@ -1115,6 +1112,12 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       } else {
         throw new Error(`Failed to disable Accessibility Service via settings. This may indicate an ADB communication issue or device state problem. Original error: ${errorMsg}`);
       }
+    } finally {
+      // Issue #4192: the disable path previously invalidated nothing, so observe
+      // kept reporting accessibility as available after the service was torn down.
+      // `finally` covers the early return (no services enabled) and a partial
+      // failure as well as the success path.
+      this.clearAvailabilityCache();
     }
   }
 
@@ -1171,9 +1174,6 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       await this.adb.executeCommand(`shell settings --user ${userId} put secure accessibility_enabled 1`);
       logger.info(`[CTRL_PROXY] Accessibility Service enabled successfully via settings for user ${userId}`);
 
-      // Clear cache after enabling (main user cache - per-user caching not implemented);
-      // this also invalidates the accessibility detector cache (#4192).
-      this.clearAvailabilityCache();
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
       const errorLower = errorMsg.toLowerCase();
@@ -1188,6 +1188,10 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       } else {
         throw new Error(`Failed to enable Accessibility Service via settings for user ${userId}. This may indicate an ADB communication issue or device state problem. Original error: ${errorMsg}`);
       }
+    } finally {
+      // Issue #4192: main-user cache only (per-user caching not implemented);
+      // `finally` also covers the partial-failure path.
+      this.clearAvailabilityCache();
     }
   }
 

--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -399,12 +399,16 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
   }
 
   /**
-   * Clear the cached availability status
+   * Clear the cached availability status.
+   *
+   * Issue #4192: this is the single choke point for "our cached view of the
+   * accessibility service is stale". It also invalidates the AccessibilityDetector
+   * cache, so `observe` cannot keep reporting the pre-mutation state. Every
+   * mutation path (enable/disable/enableForUser, install/upgrade, setup reset)
+   * routes through here — do not re-add per-call-site invalidation.
    */
   public clearAvailabilityCache(): void {
-    this.cachedAvailability = null;
-    this.cachedInstallation = null;
-    this.cachedEnabled = null;
+    this.clearServiceAvailabilityCache();
     this.cachedToggleCapabilities = null;
     this.cachedVersionCheck = null;
     logger.info("[CTRL_PROXY] Cleared all availability caches");
@@ -1021,10 +1025,9 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       perf.endOperation("writeServiceEnabled");
       logger.info("Accessibility Service enabled successfully via settings");
 
-      // Clear cache after enabling
+      // Clear cache after enabling; clearAvailabilityCache also invalidates the
+      // accessibility detector cache so observe reports correct state (#4192).
       this.clearAvailabilityCache();
-      // Also invalidate the accessibility detector cache so observe reports correct state
-      this.getAccessibilityDetector().invalidateCache(this.device.deviceId);
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
       const errorLower = errorMsg.toLowerCase();
@@ -1064,6 +1067,9 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       // Handle null or empty values
       if (currentServices === "null" || currentServices === "") {
         logger.info("No accessibility services enabled");
+        // Issue #4192: nothing to write, but our cached view may still claim the
+        // service is available - reconcile it with the device before returning.
+        this.clearAvailabilityCache();
         return;
       }
 
@@ -1165,10 +1171,9 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       await this.adb.executeCommand(`shell settings --user ${userId} put secure accessibility_enabled 1`);
       logger.info(`[CTRL_PROXY] Accessibility Service enabled successfully via settings for user ${userId}`);
 
-      // Clear cache after enabling (main user cache - per-user caching not implemented)
+      // Clear cache after enabling (main user cache - per-user caching not implemented);
+      // this also invalidates the accessibility detector cache (#4192).
       this.clearAvailabilityCache();
-      // Also invalidate the accessibility detector cache so observe reports correct state
-      this.getAccessibilityDetector().invalidateCache(this.device.deviceId);
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
       const errorLower = errorMsg.toLowerCase();
@@ -1586,6 +1591,10 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
     this.cachedAvailability = null;
     this.cachedInstallation = null;
     this.cachedEnabled = null;
+    // Issue #4192: the detector answers "is accessibility available on this device"
+    // from its own cache, so it goes stale for exactly the same reasons these fields
+    // do. Invalidating here keeps the two views from diverging silently.
+    this.getAccessibilityDetector().invalidateCache(this.device.deviceId);
   }
 
   private queueBackgroundApkRefresh(): void {

--- a/test/utils/CtrlProxyManager.test.ts
+++ b/test/utils/CtrlProxyManager.test.ts
@@ -2018,4 +2018,113 @@ describe("CtrlProxyManager", function() {
       expect(fakeAdb.wasCommandExecuted("shell settings put secure accessibility_enabled 0")).toBe(true);
     });
   });
+
+  // Issue #4192: every path that mutates accessibility state must also invalidate the
+  // AccessibilityDetector cache, otherwise `observe` keeps reporting the pre-mutation
+  // state. The invariant is enforced at a single choke point (clearAvailabilityCache),
+  // so a future fourth mutation method inherits it instead of having to remember.
+  describe("accessibility detector cache invalidation", function() {
+    const serviceComponent = `${AndroidCtrlProxyManager.PACKAGE}/${AndroidCtrlProxyManager.PACKAGE}.CtrlProxy`;
+    let fakeDetector: FakeAccessibilityDetector;
+
+    function stubSettingsToggleSupported(): void {
+      // Emulator + API 29 => settings-based toggle is supported.
+      fakeAdb.setCommandResponse("shell getprop ro.kernel.qemu", { stdout: "1", stderr: "" });
+      fakeAdb.setCommandResponse("shell getprop ro.build.version.sdk", { stdout: "29", stderr: "" });
+    }
+
+    beforeEach(function() {
+      fakeDetector = new FakeAccessibilityDetector();
+      AndroidCtrlProxyManager.setAccessibilityDetectorForTesting(fakeDetector);
+      stubSettingsToggleSupported();
+    });
+
+    test("clearAvailabilityCache invalidates the detector cache (the shared choke point)", function() {
+      expect(fakeDetector.getInvalidatedDevices()).toEqual([]);
+
+      accessibilityServiceClient.clearAvailabilityCache();
+
+      expect(fakeDetector.getInvalidatedDevices()).toEqual([testDevice.deviceId]);
+    });
+
+    test("disableViaSettings invalidates the detector cache", async function() {
+      fakeAdb.setCommandResponse("shell settings get secure enabled_accessibility_services", {
+        stdout: serviceComponent,
+        stderr: ""
+      });
+      fakeAdb.setCommandResponse('shell settings put secure enabled_accessibility_services ""', {
+        stdout: "",
+        stderr: ""
+      });
+      fakeAdb.setCommandResponse("shell settings put secure accessibility_enabled 0", {
+        stdout: "",
+        stderr: ""
+      });
+
+      expect(fakeDetector.getInvalidatedDevices()).toEqual([]);
+
+      await accessibilityServiceClient.disableViaSettings();
+
+      expect(fakeDetector.getInvalidatedDevices()).toContain(testDevice.deviceId);
+    });
+
+    test("disableViaSettings invalidates the detector cache when no services are enabled", async function() {
+      // Early-return path: the device reports no enabled services, so nothing is written.
+      // A detector cache still claiming "available" is exactly the divergence in #4192.
+      fakeAdb.setCommandResponse("shell settings get secure enabled_accessibility_services", {
+        stdout: "null",
+        stderr: ""
+      });
+
+      await accessibilityServiceClient.disableViaSettings();
+
+      expect(fakeAdb.wasCommandExecuted("shell settings put secure")).toBe(false);
+      expect(fakeDetector.getInvalidatedDevices()).toContain(testDevice.deviceId);
+    });
+
+    describe("symmetry across every accessibility mutation method", function() {
+      const mutations: Array<{ name: string; run: () => Promise<void> }> = [
+        {
+          name: "enableViaSettings",
+          run: () => accessibilityServiceClient.enableViaSettings()
+        },
+        {
+          name: "disableViaSettings",
+          run: () => accessibilityServiceClient.disableViaSettings()
+        },
+        {
+          name: "enableForUser",
+          run: () => accessibilityServiceClient.enableForUser(10)
+        }
+      ];
+
+      for (const mutation of mutations) {
+        test(`${mutation.name} invalidates the detector cache for the target device`, async function() {
+          // Respond to both the default-user and --user forms so one table drives all three.
+          for (const prefix of ["shell settings", "shell settings --user 10"]) {
+            fakeAdb.setCommandResponse(`${prefix} get secure enabled_accessibility_services`, {
+              stdout: serviceComponent,
+              stderr: ""
+            });
+            fakeAdb.setCommandResponse(`${prefix} put secure enabled_accessibility_services "${serviceComponent}"`, {
+              stdout: "",
+              stderr: ""
+            });
+            fakeAdb.setCommandResponse(`${prefix} put secure enabled_accessibility_services ""`, {
+              stdout: "",
+              stderr: ""
+            });
+            fakeAdb.setCommandResponse(`${prefix} put secure accessibility_enabled 1`, { stdout: "", stderr: "" });
+            fakeAdb.setCommandResponse(`${prefix} put secure accessibility_enabled 0`, { stdout: "", stderr: "" });
+          }
+
+          expect(fakeDetector.getInvalidatedDevices()).toEqual([]);
+
+          await mutation.run();
+
+          expect(fakeDetector.getInvalidatedDevices()).toContain(testDevice.deviceId);
+        });
+      }
+    });
+  });
 });

--- a/test/utils/CtrlProxyManager.test.ts
+++ b/test/utils/CtrlProxyManager.test.ts
@@ -2082,6 +2082,23 @@ describe("CtrlProxyManager", function() {
       expect(fakeDetector.getInvalidatedDevices()).toContain(testDevice.deviceId);
     });
 
+    test("disableViaSettings invalidates the detector cache when the write fails", async function() {
+      // A partial failure leaves the device state uncertain, so a cached
+      // "available" answer is exactly as wrong as it is after a clean disable.
+      fakeAdb.setCommandResponse("shell settings get secure enabled_accessibility_services", {
+        stdout: serviceComponent,
+        stderr: ""
+      });
+      fakeAdb.setCommandError(
+        'shell settings put secure enabled_accessibility_services ""',
+        new Error("device offline")
+      );
+
+      await expect(accessibilityServiceClient.disableViaSettings()).rejects.toThrow();
+
+      expect(fakeDetector.getInvalidatedDevices()).toContain(testDevice.deviceId);
+    });
+
     describe("symmetry across every accessibility mutation method", function() {
       const mutations: Array<{ name: string; run: () => Promise<void> }> = [
         {


### PR DESCRIPTION
## Summary

`disableViaSettings` cleared the CtrlProxyManager availability caches but never invalidated
the `AccessibilityDetector` cache, so after the accessibility service was torn down `observe`
kept reporting a11y as available until something else happened to invalidate it. The device
state and the reported state diverged silently.

Rather than adding a third copy of `getAccessibilityDetector().invalidateCache(deviceId)` to
the disable path, the invalidation moves **down to a single choke point**:
`clearServiceAvailabilityCache()`, which every caller of the public `clearAvailabilityCache()`
now routes through. The detector answers "is accessibility available on this device" from its
own cache, so it goes stale for exactly the same reasons `cachedAvailability` /
`cachedInstallation` / `cachedEnabled` do — one place, one rule. A future fourth mutation
method inherits the behaviour instead of having to remember it.

The duplicated per-call-site invalidations in `enableViaSettings` and `enableForUser` are
removed. All three mutation methods now clear in a `finally` block rather than at one point
inside `try`, which makes the reconciliation structural instead of positional and covers two
paths that previously escaped it: the `disableViaSettings` early return (device reports no
enabled services, so nothing is written) and a mid-mutation adb failure, where the device is
left in an uncertain state but the stale "available" cache survived the throw.

### Audit of the other mutation paths

Per the review request, all mutation paths were checked, not just the reported one:

| Path | Before | After |
|---|---|---|
| `enableViaSettings` | invalidated (explicitly) | invalidated (via choke point) |
| `enableForUser` | invalidated (explicitly) | invalidated (via choke point) |
| `disableViaSettings` | **not invalidated** | invalidated |
| `disableViaSettings` early return (no services enabled) | **no cache clear at all** | invalidated |
| any mutation method throwing mid-write | **no cache clear at all** | invalidated (`finally`) |
| `installDownloadedApk` upgrade / reinstall / failure | availability cleared, detector **not** invalidated | invalidated |
| `resetSetupState` | availability cleared, detector **not** invalidated | invalidated |

So the reported disable path was not the only offender — the APK install/upgrade/failure paths
and `resetSetupState` had the same gap. All are fixed by the single choke point.

Outside `CtrlProxyManager`, `TalkBackToggle`, `VoiceOverToggle` and `accessibilityTools` already
invalidate the detector around their mutations; no gap found there.

## Linked Issue

Closes #4192

## Bug / Regression Context

- **Prior attempts:** none; the enable paths were given explicit invalidation and the disable
  path was missed.
- **Observed symptom:** after `disableViaSettings`, `observe` continues to report accessibility
  as available.
- **Repro steps / conditions:** enable a11y (detector caches "available"), call
  `disableViaSettings`, then detect again — the stale cached answer is returned. Pinned by the
  new unit tests, which are red before the source change and green after.

## Validation

- [x] `bun run lint` + `bun test` pass (8318 pass / 0 fail, full suite)
- [x] `bun run typecheck` reports no new errors (baseline gate; baseline untouched)
- [x] `bun run build` succeeds
- [x] New code uses interfaces + fakes (`FakeAccessibilityDetector`, `FakeAdbExecutor`); the new
      tests run in ~1 ms each
- [x] No new dependencies or helpers — reuses the existing detector interface and fakes
- [x] Branched off latest `origin/main` (`170c7d58a`)

### Acceptance criteria

- [x] `disableViaSettings` invalidates the detector cache; a subsequent detection reflects the
      disabled state — `disableViaSettings invalidates the detector cache`.
- [x] Symmetry test across all three methods so a future fourth method cannot regress the same
      way, asserting the invariant rather than the individual call — the table-driven
      `symmetry across every accessibility mutation method` block plus
      `clearAvailabilityCache invalidates the detector cache (the shared choke point)`, which
      pins the invariant itself.
- [x] Red before the fix, green after — 4 of the 6 new tests failed before the source change
      (the two enable cases already passed), all 7 pass after.

## Device Verification

N/A — pure cache-lifecycle logic on the TypeScript side, fully covered by fakes. No device
interaction was performed (a live daemon was in use elsewhere).
