### PR TITLE
fix(installer): bound package installs and stop discarding their output

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1294,14 +1294,8 @@ run_with_error_output() {
 PACKAGE_INSTALL_TIMEOUT_SECONDS="${PACKAGE_INSTALL_TIMEOUT_SECONDS:-600}"
 
 # Resolve a command prefix that bounds an invocation, into BOUNDED_CMD_PREFIX.
-# Empty when the host has no timeout binary.
-#
-# This script is delivered by `curl … | bash` and must stay self-contained, so
-# it cannot source scripts/ios/run_with_timeout.sh, and a second copy of that
-# watchdog is not worth carrying here: coreutils `timeout` is always present on
-# Linux, which is where installs run unattended and where this bit us. A stock
-# macOS host without coreutils gets no ceiling, but there the installer is
-# driven interactively, so a stall is visible rather than silent.
+# Empty when the host has no timeout binary, in which case run_bounded_install
+# falls back to bounded_watchdog_run below rather than running unbounded.
 #
 # `-k` matters: plain `timeout` sends only TERM, so a package manager that
 # ignores it would keep running and keep the captured pipe open past the
@@ -1319,6 +1313,98 @@ resolve_bounded_cmd_prefix() {
     elif command_exists gtimeout; then
         BOUNDED_CMD_PREFIX=(gtimeout -k 10 "${secs}")
     fi
+}
+
+# Bound a command with a pure-bash watchdog, for hosts with no timeout binary.
+#
+# Writes the command's combined output to <outfile>; returns the command's own
+# status, or 124 when the deadline fires (GNU timeout's convention, so the
+# caller's 124 handling covers both paths).
+#
+# This is a deliberate second copy of scripts/ios/run_with_timeout.sh's
+# fallback. install.sh is delivered by `curl … | bash` and cannot source a
+# sibling file, and the alternative is what this replaces: on a stock macOS host
+# — which has neither `timeout` nor `gtimeout` — every bound silently degraded
+# to no bound at all, which is precisely the fail-open #4162 exists to close.
+# A bounding mechanism that no-ops on the most common developer platform is
+# worse than none, because it reads as covered.
+#
+# Two properties a naive "background it and kill the pid" watchdog does not give
+# you, both learned in run_with_timeout.sh:
+#
+#   1. Return 124 on expiry. Surfacing `wait`'s status instead gives 143
+#      (128+SIGTERM), indistinguishable from a command signalled for any other
+#      reason.
+#   2. Signal the whole process group. Several call sites pass an `&&` chain
+#      through `bash -c`, so bash does not exec the package manager; signalling
+#      only the direct child leaves the grandchild alive and the bound silently
+#      does not apply.
+#
+# Output goes to a file rather than a command substitution so that a descendant
+# which survives the TERM cannot hold the caller blocked waiting for EOF.
+#
+# Reports through BOUNDED_WATCHDOG_STATUS rather than its own exit status, for
+# the same reason resolve_bounded_cmd_prefix assigns to a global: a function on
+# the left of `||` has `set -e` suppressed inside it (SC2310).
+BOUNDED_WATCHDOG_STATUS=0
+bounded_watchdog_run() {
+    local secs="$1"
+    local outfile="$2"
+    shift 2
+    BOUNDED_WATCHDOG_STATUS=0
+
+    # The watchdog runs in a subshell and so cannot assign to a variable in this
+    # scope; a marker file is how it reports back that it fired.
+    # Spell the template out rather than using `mktemp -t <prefix>`: BSD mktemp
+    # treats the argument as a prefix, but GNU mktemp requires a trailing
+    # XXXXXX and hard-errors on a bare prefix.
+    local fired_marker
+    if ! fired_marker="$(mktemp "${TMPDIR:-/tmp}/automobile_bounded_install.XXXXXX")"; then
+        BOUNDED_WATCHDOG_STATUS=125
+        return 0
+    fi
+
+    # Monitor mode puts the child in its own process group (pgid == its pid),
+    # which is what lets the group-directed kill below reach descendants.
+    # Restore the caller's setting right away so job-control notices do not leak
+    # into their output.
+    local had_monitor=0
+    case "$-" in *m*) had_monitor=1 ;; esac
+    set -m
+    "$@" > "${outfile}" 2>&1 &
+    local cmd_pid=$!
+    if [[ ${had_monitor} -eq 0 ]]; then set +m; fi
+
+    (
+        sleep "${secs}"
+        if kill -0 "${cmd_pid}" 2> /dev/null; then
+            printf 'fired' > "${fired_marker}"
+            # A negative pid targets the process group. Fall back to the bare
+            # pid in case the child never became group leader.
+            kill -TERM -"${cmd_pid}" 2> /dev/null || kill -TERM "${cmd_pid}" 2> /dev/null || true
+            # Same 10s grace as `timeout -k 10` on the coreutils path, so the
+            # two bounding paths escalate identically.
+            sleep 10
+            kill -KILL -"${cmd_pid}" 2> /dev/null || kill -KILL "${cmd_pid}" 2> /dev/null || true
+        fi
+    ) > /dev/null 2>&1 3>&- &
+    local watcher_pid=$!
+
+    local status=0
+    wait "${cmd_pid}" 2> /dev/null || status=$?
+    if [[ -s "${fired_marker}" ]]; then
+        # Leave the watcher running: it still owes the group a KILL for anything
+        # that ignored the TERM. Waiting for it here would add its full grace
+        # period to every timeout, and there is nothing to wait for — the output
+        # is already on disk, not in a pipe a survivor could hold open.
+        status=124
+    else
+        kill "${watcher_pid}" 2> /dev/null || true
+        wait "${watcher_pid}" 2> /dev/null || true
+    fi
+    rm -f "${fired_marker}"
+    BOUNDED_WATCHDOG_STATUS="${status}"
+    return 0
 }
 
 # Run a package install bounded by PACKAGE_INSTALL_TIMEOUT_SECONDS, printing the
@@ -1346,8 +1432,22 @@ run_bounded_install() {
 
     local output=""
     local status=0
-    # The `+` guard keeps an empty prefix from tripping `set -u` on bash 3.2.
-    output=$(${BOUNDED_CMD_PREFIX[@]+"${BOUNDED_CMD_PREFIX[@]}"} "$@" 2>&1) || status=$?
+    if [[ ${#BOUNDED_CMD_PREFIX[@]} -gt 0 ]]; then
+        # The `+` guard keeps an empty prefix from tripping `set -u` on bash 3.2.
+        output=$(${BOUNDED_CMD_PREFIX[@]+"${BOUNDED_CMD_PREFIX[@]}"} "$@" 2>&1) || status=$?
+    else
+        local outfile
+        outfile="$(mktemp "${TMPDIR:-/tmp}/automobile_install_output.XXXXXX")" || outfile=""
+        if [[ -z "${outfile}" ]]; then
+            log_warn "${title}: could not create a temp file to capture output; running unbounded"
+            "$@" || status=$?
+        else
+            bounded_watchdog_run "${PACKAGE_INSTALL_TIMEOUT_SECONDS}" "${outfile}" "$@"
+            status="${BOUNDED_WATCHDOG_STATUS}"
+            output="$(cat "${outfile}")"
+            rm -f "${outfile}"
+        fi
+    fi
 
     if [[ ${status} -eq 0 ]]; then
         log_info "${title}: ok"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1283,8 +1283,14 @@ run_with_error_output() {
 # `Installer Minimal (ubuntu-latest)` once spent 45 minutes inside one apt-get
 # and emitted nothing, leaving the stall unexplainable after the fact (issue
 # #4162). A job-level `timeout-minutes` is not a substitute: it kills the job
-# without saying which command hung. Overridable so tests can exercise the bound
-# without waiting out a real stall.
+# without saying which command hung.
+#
+# 600s is chosen to sit under the installer job's own 20-minute `timeout-minutes`
+# — a bound above that would never fire before the job died, which is the
+# uninformative outcome this exists to avoid — while staying far above any
+# bottled install. Overridable so tests can exercise the bound without waiting
+# out a real stall, and so a host doing an unusually slow source build can raise
+# it rather than being cut off.
 PACKAGE_INSTALL_TIMEOUT_SECONDS="${PACKAGE_INSTALL_TIMEOUT_SECONDS:-600}"
 
 # Resolve a command prefix that bounds an invocation, into BOUNDED_CMD_PREFIX.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1276,6 +1276,91 @@ run_with_error_output() {
     return 0
 }
 
+# Ceiling, in seconds, for a single package-manager invocation.
+#
+# A healthy install of anything we ask for finishes in well under a minute; this
+# only exists so a stalled package manager cannot consume the whole job.
+# `Installer Minimal (ubuntu-latest)` once spent 45 minutes inside one apt-get
+# and emitted nothing, leaving the stall unexplainable after the fact (issue
+# #4162). A job-level `timeout-minutes` is not a substitute: it kills the job
+# without saying which command hung. Overridable so tests can exercise the bound
+# without waiting out a real stall.
+PACKAGE_INSTALL_TIMEOUT_SECONDS="${PACKAGE_INSTALL_TIMEOUT_SECONDS:-600}"
+
+# Resolve a command prefix that bounds an invocation, into BOUNDED_CMD_PREFIX.
+# Empty when the host has no timeout binary.
+#
+# This script is delivered by `curl … | bash` and must stay self-contained, so
+# it cannot source scripts/ios/run_with_timeout.sh, and a second copy of that
+# watchdog is not worth carrying here: coreutils `timeout` is always present on
+# Linux, which is where installs run unattended and where this bit us. A stock
+# macOS host without coreutils gets no ceiling, but there the installer is
+# driven interactively, so a stall is visible rather than silent.
+#
+# `-k` matters: plain `timeout` sends only TERM, so a package manager that
+# ignores it would keep running and keep the captured pipe open past the
+# deadline.
+#
+# Assigns to a global rather than printing so callers can invoke it as a plain
+# statement — a function run inside `$(…)` or on the left of `||` has `set -e`
+# suppressed inside it (SC2310/SC2311).
+BOUNDED_CMD_PREFIX=()
+resolve_bounded_cmd_prefix() {
+    local secs="$1"
+    BOUNDED_CMD_PREFIX=()
+    if command_exists timeout; then
+        BOUNDED_CMD_PREFIX=(timeout -k 10 "${secs}")
+    elif command_exists gtimeout; then
+        BOUNDED_CMD_PREFIX=(gtimeout -k 10 "${secs}")
+    fi
+}
+
+# Run a package install bounded by PACKAGE_INSTALL_TIMEOUT_SECONDS, printing the
+# package manager's output when it fails or is aborted.
+#
+# This is the install-shaped counterpart to run_with_error_output above: the same
+# capture-and-surface-on-failure contract, plus the bound and the 124/137
+# reporting that tells a stall apart from a genuine failure.
+#
+# Package installs deliberately do NOT go through run_spinner: `gum spin` hides
+# the wrapped command's output as thoroughly as `>/dev/null`, and that
+# suppression is half of why #4162 could not be diagnosed. Keeping the output is
+# worth more than the spinner.
+#
+# Capturing the output is only safe because GNU `timeout` puts the child in its
+# own process group and signals the whole group. Several call sites pass an
+# `&&` chain through `bash -c`, where bash does not exec the package manager;
+# signalling only the direct child would leave the grandchild alive holding this
+# capture's pipe open, and the bound would silently not apply.
+run_bounded_install() {
+    local title="$1"
+    shift
+
+    resolve_bounded_cmd_prefix "${PACKAGE_INSTALL_TIMEOUT_SECONDS}"
+
+    local output=""
+    local status=0
+    # The `+` guard keeps an empty prefix from tripping `set -u` on bash 3.2.
+    output=$(${BOUNDED_CMD_PREFIX[@]+"${BOUNDED_CMD_PREFIX[@]}"} "$@" 2>&1) || status=$?
+
+    if [[ ${status} -eq 0 ]]; then
+        log_info "${title}: ok"
+        return 0
+    fi
+
+    # GNU timeout reports 124 when it fires; 137 is the follow-up KILL from -k.
+    if [[ ${status} -eq 124 || ${status} -eq 137 ]]; then
+        log_warn "${title} exceeded ${PACKAGE_INSTALL_TIMEOUT_SECONDS}s and was aborted"
+    else
+        log_warn "${title} failed (exit ${status})"
+    fi
+
+    if [[ -n "${output}" ]]; then
+        printf '%s\n' "${output}" >&2
+    fi
+    return "${status}"
+}
+
 spin_check() {
     local label="$1"
     local check_cmd="$2"
@@ -2041,12 +2126,12 @@ install_yq() {
     fi
 
     if [[ "${os}" == "macos" ]] && command_exists brew; then
-        if ! run_spinner "Installing yq via Homebrew" brew install yq; then
+        if ! run_bounded_install "Installing yq via Homebrew" brew install yq; then
             log_error "Failed to install yq"
             return 1
         fi
     elif command_exists go; then
-        if ! run_spinner "Installing yq via go install" go install github.com/mikefarah/yq/v4@latest; then
+        if ! run_bounded_install "Installing yq via go install" go install github.com/mikefarah/yq/v4@latest; then
             log_error "Failed to install yq"
             return 1
         fi
@@ -2917,28 +3002,20 @@ _install_system_package() {
         return 1
     fi
 
-    if [[ "${NON_INTERACTIVE}" == "true" ]]; then
-        log_info "Installing ${pkg} (${description})..."
-        if run_spinner "Installing ${pkg}" bash -c "${install_cmd} >/dev/null 2>&1"; then
-            CHANGES_MADE=true
-            return 0
-        else
-            log_warn "${pkg} install failed — ${description} will be unavailable"
+    if [[ "${NON_INTERACTIVE}" != "true" ]]; then
+        if ! gum confirm "Install ${pkg}? (${description})"; then
+            log_info "Skipped ${pkg} — install later with: ${skip_hint}"
             return 1
         fi
     fi
 
-    if gum confirm "Install ${pkg}? (${description})"; then
-        if run_spinner "Installing ${pkg}" bash -c "${install_cmd} >/dev/null 2>&1"; then
-            CHANGES_MADE=true
-            return 0
-        else
-            log_warn "${pkg} install failed — ${description} will be unavailable"
-            return 1
-        fi
+    log_info "Installing ${pkg} (${description})..."
+    if run_bounded_install "Installing ${pkg}" bash -c "${install_cmd}"; then
+        CHANGES_MADE=true
+        return 0
     fi
 
-    log_info "Skipped ${pkg} — install later with: ${skip_hint}"
+    log_warn "${pkg} install failed — ${description} will be unavailable"
     return 1
 }
 
@@ -3015,7 +3092,7 @@ _install_dev_tools_brew() {
     # processes would contend for the same lock. One invocation avoids repeated
     # startup work and lets Homebrew schedule the complete dependency set.
     local brew_status=0
-    if run_spinner "Installing ${#to_install[@]} development tools" brew install ${to_install[@]+"${to_install[@]}"}; then
+    if run_bounded_install "Installing ${#to_install[@]} development tools" brew install ${to_install[@]+"${to_install[@]}"}; then
         :
     else
         brew_status=$?
@@ -3082,12 +3159,16 @@ _install_dev_tools_apt() {
         return 0
     fi
 
-    # Update package index once
-    sudo apt-get update -qq 2>/dev/null || true
+    # Update the package index once. A stale index is survivable — the per-package installs below report their
+    # own failures — but the update must still be bounded, since it is an
+    # apt-get like any other and can stall the same way.
+    if run_bounded_install "Updating package index" sudo apt-get update -qq; then
+        :
+    fi
 
     local missing=0
     for pkg in ${to_install[@]+"${to_install[@]}"}; do
-        if sudo apt-get install -y -qq "${pkg}" >/dev/null 2>&1; then
+        if run_bounded_install "Installing ${pkg}" sudo apt-get install -y -qq "${pkg}"; then
             CHANGES_MADE=true
         else
             log_warn "Failed to install ${pkg}"
@@ -3642,12 +3723,12 @@ ios_check_physical_device_tools() {
 
 _install_libimobiledevice_tools() {
     # ideviceinstaller depends on libimobiledevice; libusbmuxd provides iproxy
-    if run_spinner "Installing libusbmuxd" brew install libusbmuxd; then
+    if run_bounded_install "Installing libusbmuxd" brew install libusbmuxd; then
         CHANGES_MADE=true
     else
         log_warn "libusbmuxd install failed — iproxy will be unavailable"
     fi
-    if run_spinner "Installing ideviceinstaller" brew install ideviceinstaller; then
+    if run_bounded_install "Installing ideviceinstaller" brew install ideviceinstaller; then
         CHANGES_MADE=true
     else
         log_warn "ideviceinstaller install failed — physical device app install will be unavailable"
@@ -3782,13 +3863,13 @@ install_bun_curl() {
 install_bun_homebrew() {
     # Add the oven-sh/bun tap if not already added
     if ! brew tap 2>/dev/null | grep -q "oven-sh/bun"; then
-        if ! run_spinner "Adding Homebrew tap oven-sh/bun" brew tap oven-sh/bun; then
+        if ! run_bounded_install "Adding Homebrew tap oven-sh/bun" brew tap oven-sh/bun; then
             log_error "Failed to add Homebrew tap."
             return 1
         fi
     fi
 
-    if ! run_spinner "Installing Bun via Homebrew" brew install oven-sh/bun/bun; then
+    if ! run_bounded_install "Installing Bun via Homebrew" brew install oven-sh/bun/bun; then
         log_error "Bun installation via Homebrew failed."
         return 1
     fi

--- a/test/bats/install-bounded-package-install.bats
+++ b/test/bats/install-bounded-package-install.bats
@@ -21,6 +21,17 @@ setup() {
   LN="$(command -v ln)"
   CHMOD="$(command -v chmod)"
 
+  # Mirror the handful of utilities install.sh's bounded paths actually reach
+  # for into the stub directory, so hide_real_timeout below can drop the system
+  # directories from PATH entirely without also removing `mktemp` and `sleep`
+  # out from under the watchdog fallback. Deliberately does NOT include
+  # `timeout`/`gtimeout` -- an absence cannot be shadowed, so the only way to
+  # reach the fallback is a PATH that never contained them.
+  local tool
+  for tool in bash env mktemp rm cat sleep chmod ln grep sed mkdir; do
+    "$LN" -sf "$(command -v "${tool}")" "${STUB_BIN}/${tool}"
+  done
+
   export PATH="${STUB_BIN}:/usr/bin:/bin"
   export INSTALL_SH_SOURCE_ONLY=true
   # shellcheck source=/dev/null
@@ -61,14 +72,18 @@ stub_apt_get() {
 # The setup PATH keeps /usr/bin:/bin because most tests need real `sleep`, `bash`
 # and friends -- but ubuntu-latest ships /usr/bin/timeout, so a test asserting
 # "no timeout binary exists" silently found the real one and only passed on the
-# macOS laptop this was written on, where there is none.
+# macOS laptop this was written on, where there is none. setup() mirrors the
+# utilities the bounded paths need into STUB_BIN so this stays survivable.
 hide_real_timeout() {
   export PATH="${STUB_BIN}"
 }
 
 # Put a real timeout binary on the restricted PATH under the name the resolver
-# looks for, so the bound is exercised for real rather than against a stub.
-# macOS ships neither, but provides gtimeout when coreutils is installed.
+# looks for, so the coreutils bound is exercised for real rather than against a
+# stub. macOS ships neither, but provides gtimeout when coreutils is installed.
+# Only the coreutils path skips: the watchdog fallback is pure bash, so its
+# tests below run everywhere, which is the point -- stock macOS is the host
+# where the bound used to silently not exist at all.
 require_real_timeout() {
   local real
   real="$(PATH="${ORIG_PATH}" command -v timeout || PATH="${ORIG_PATH}" command -v gtimeout || true)"
@@ -109,14 +124,78 @@ require_real_timeout() {
   [ "${#BOUNDED_CMD_PREFIX[@]}" -eq 0 ]
 }
 
-@test "run_bounded_install runs the command unwrapped when no timeout binary exists" {
-  # An empty prefix must expand to nothing rather than tripping `set -u` on the
-  # bash 3.2 that macos-latest still runs. /bin/echo is spelled absolutely so it
-  # still resolves with the stub-only PATH.
+@test "run_bounded_install succeeds via the watchdog fallback when no timeout binary exists" {
+  # /bin/echo is spelled absolutely so it still resolves with the stub-only PATH.
   hide_real_timeout
   run run_bounded_install "Installing thing" /bin/echo hello
   [ "$status" -eq 0 ]
   [[ "$output" == *"Installing thing: ok"* ]]
+}
+
+@test "run_bounded_install still bounds a stall when no timeout binary exists" {
+  # The regression this pins: on a stock macOS host neither `timeout` nor
+  # `gtimeout` is on PATH, so an empty prefix meant every "bounded" install ran
+  # with no bound at all -- the exact fail-open #4162 exists to close, on the
+  # most likely developer platform. Verified before the fallback landed: a 30s
+  # stall under a 2s bound returned 0 and reported "ok" after 30 seconds.
+  #
+  # No require_real_timeout here on purpose. The fallback is pure bash, so this
+  # runs on every host, including the one where it used to be missing.
+  hide_real_timeout
+  cat > "${STUB_BIN}/stalling-pm" << 'STUB'
+#!/usr/bin/env bash
+sleep 60
+STUB
+  "$CHMOD" +x "${STUB_BIN}/stalling-pm"
+
+  PACKAGE_INSTALL_TIMEOUT_SECONDS=1
+  local start=${SECONDS}
+  run run_bounded_install "Installing ffmpeg" stalling-pm
+  local elapsed=$((SECONDS - start))
+
+  [ "$status" -eq 124 ]
+  [ "${elapsed}" -lt 30 ]
+  # 124 must read as a stall, not a failure, or the two stay indistinguishable
+  # in the logs -- which is the other half of what made #4162 undiagnosable.
+  [[ "$output" == *"exceeded"* ]]
+}
+
+@test "the watchdog fallback bounds a stall that leaves a descendant holding stdout" {
+  # Same grandchild hazard as the coreutils path: `bash -c "a && b"` does not
+  # exec b, so signalling only the direct child leaves the grandchild alive.
+  # The fallback relies on `set -m` giving the child its own process group and
+  # on killing the group; without that this hangs for the full 60s.
+  hide_real_timeout
+  cat > "${STUB_BIN}/stalling-pm" << 'STUB'
+#!/usr/bin/env bash
+sleep 60
+STUB
+  "$CHMOD" +x "${STUB_BIN}/stalling-pm"
+
+  PACKAGE_INSTALL_TIMEOUT_SECONDS=1
+  local start=${SECONDS}
+  run run_bounded_install "Installing ffmpeg" bash -c "true && stalling-pm"
+  local elapsed=$((SECONDS - start))
+
+  [ "$status" -eq 124 ]
+  [ "${elapsed}" -lt 30 ]
+}
+
+@test "the watchdog fallback surfaces output and the exit code on failure" {
+  # The fallback captures through a file rather than a command substitution, so
+  # this also pins that the captured output survives that difference.
+  hide_real_timeout
+  cat > "${STUB_BIN}/failing-pm" << 'STUB'
+#!/usr/bin/env bash
+echo "E: Unable to locate package ffmpeg" >&2
+exit 100
+STUB
+  "$CHMOD" +x "${STUB_BIN}/failing-pm"
+
+  run run_bounded_install "Installing ffmpeg" failing-pm
+  [ "$status" -eq 100 ]
+  [[ "$output" == *"E: Unable to locate package ffmpeg"* ]]
+  [[ "$output" == *"exit 100"* ]]
 }
 
 @test "run_bounded_install surfaces output and the exit code on failure" {

--- a/test/bats/install-bounded-package-install.bats
+++ b/test/bats/install-bounded-package-install.bats
@@ -56,6 +56,16 @@ stub_apt_get() {
   "$CHMOD" +x "${STUB_BIN}/apt-get"
 }
 
+# Drop the system directories from PATH so only stubs are resolvable.
+#
+# The setup PATH keeps /usr/bin:/bin because most tests need real `sleep`, `bash`
+# and friends -- but ubuntu-latest ships /usr/bin/timeout, so a test asserting
+# "no timeout binary exists" silently found the real one and only passed on the
+# macOS laptop this was written on, where there is none.
+hide_real_timeout() {
+  export PATH="${STUB_BIN}"
+}
+
 # Put a real timeout binary on the restricted PATH under the name the resolver
 # looks for, so the bound is exercised for real rather than against a stub.
 # macOS ships neither, but provides gtimeout when coreutils is installed.
@@ -69,6 +79,7 @@ require_real_timeout() {
 }
 
 @test "the bounded prefix uses timeout with a kill-after fallback" {
+  hide_real_timeout
   "$LN" -sf /bin/echo "${STUB_BIN}/timeout"
 
   resolve_bounded_cmd_prefix 42
@@ -82,6 +93,7 @@ require_real_timeout() {
 }
 
 @test "the bounded prefix falls back to gtimeout when timeout is absent" {
+  hide_real_timeout
   "$LN" -sf /bin/echo "${STUB_BIN}/gtimeout"
 
   resolve_bounded_cmd_prefix 42
@@ -90,6 +102,8 @@ require_real_timeout() {
 }
 
 @test "the bounded prefix is empty when no timeout binary exists" {
+  hide_real_timeout
+
   resolve_bounded_cmd_prefix 42
 
   [ "${#BOUNDED_CMD_PREFIX[@]}" -eq 0 ]
@@ -97,7 +111,9 @@ require_real_timeout() {
 
 @test "run_bounded_install runs the command unwrapped when no timeout binary exists" {
   # An empty prefix must expand to nothing rather than tripping `set -u` on the
-  # bash 3.2 that macos-latest still runs.
+  # bash 3.2 that macos-latest still runs. /bin/echo is spelled absolutely so it
+  # still resolves with the stub-only PATH.
+  hide_real_timeout
   run run_bounded_install "Installing thing" /bin/echo hello
   [ "$status" -eq 0 ]
   [[ "$output" == *"Installing thing: ok"* ]]

--- a/test/bats/install-bounded-package-install.bats
+++ b/test/bats/install-bounded-package-install.bats
@@ -1,0 +1,216 @@
+#!/usr/bin/env bats
+#
+# Regression guard for issue #4162.
+#
+# Package installs in scripts/install.sh ran the host package manager unbounded
+# with `>/dev/null 2>&1` (or behind `gum spin`, which hides output just as
+# effectively). A stalled apt-get therefore ran for 45 minutes in
+# `Installer Minimal (ubuntu-latest)` and emitted nothing at all, so the cause
+# was unrecoverable from the logs. These tests pin both halves of the fix: the
+# invocation is bounded, and its output survives a failure or a timeout.
+
+# shellcheck disable=SC2329
+
+setup() {
+  TEST_DIR="$(mktemp -d)"
+  STUB_BIN="${TEST_DIR}/bin"
+  mkdir -p "${STUB_BIN}"
+
+  ORIG_PATH="${PATH}"
+  RM="$(command -v rm)"
+  LN="$(command -v ln)"
+  CHMOD="$(command -v chmod)"
+
+  export PATH="${STUB_BIN}:/usr/bin:/bin"
+  export INSTALL_SH_SOURCE_ONLY=true
+  # shellcheck source=/dev/null
+  source scripts/install.sh
+
+  log_info() { printf '[INFO] %s\n' "$1"; }
+  log_warn() { printf '[WARN] %s\n' "$1"; }
+  log_error() { printf '[ERROR] %s\n' "$1"; }
+  # Force the linux/apt-get branch of _install_system_package regardless of the
+  # host actually running these tests.
+  detect_os() { printf 'linux\n'; }
+
+  NON_INTERACTIVE=true
+  CHANGES_MADE=false
+
+  # The linux branch shells out via sudo; run the command directly instead of
+  # needing a password in the test environment.
+  cat > "${STUB_BIN}/sudo" << 'STUB'
+#!/usr/bin/env bash
+exec "$@"
+STUB
+  "$CHMOD" +x "${STUB_BIN}/sudo"
+}
+
+teardown() {
+  export PATH="${ORIG_PATH}"
+  "$RM" -rf "${TEST_DIR}"
+}
+
+# A stand-in package manager whose behaviour each test controls.
+stub_apt_get() {
+  cat > "${STUB_BIN}/apt-get"
+  "$CHMOD" +x "${STUB_BIN}/apt-get"
+}
+
+# Put a real timeout binary on the restricted PATH under the name the resolver
+# looks for, so the bound is exercised for real rather than against a stub.
+# macOS ships neither, but provides gtimeout when coreutils is installed.
+require_real_timeout() {
+  local real
+  real="$(PATH="${ORIG_PATH}" command -v timeout || PATH="${ORIG_PATH}" command -v gtimeout || true)"
+  if [[ -z "${real}" ]]; then
+    skip "neither timeout nor gtimeout available to exercise the bound"
+  fi
+  "$LN" -sf "${real}" "${STUB_BIN}/timeout"
+}
+
+@test "the bounded prefix uses timeout with a kill-after fallback" {
+  "$LN" -sf /bin/echo "${STUB_BIN}/timeout"
+
+  resolve_bounded_cmd_prefix 42
+
+  [ "${#BOUNDED_CMD_PREFIX[@]}" -eq 4 ]
+  [ "${BOUNDED_CMD_PREFIX[0]}" = "timeout" ]
+  # -k matters: plain TERM leaves a package manager that ignores it running,
+  # holding the captured pipe open past the deadline.
+  [ "${BOUNDED_CMD_PREFIX[1]}" = "-k" ]
+  [ "${BOUNDED_CMD_PREFIX[3]}" = "42" ]
+}
+
+@test "the bounded prefix falls back to gtimeout when timeout is absent" {
+  "$LN" -sf /bin/echo "${STUB_BIN}/gtimeout"
+
+  resolve_bounded_cmd_prefix 42
+
+  [ "${BOUNDED_CMD_PREFIX[0]}" = "gtimeout" ]
+}
+
+@test "the bounded prefix is empty when no timeout binary exists" {
+  resolve_bounded_cmd_prefix 42
+
+  [ "${#BOUNDED_CMD_PREFIX[@]}" -eq 0 ]
+}
+
+@test "run_bounded_install runs the command unwrapped when no timeout binary exists" {
+  # An empty prefix must expand to nothing rather than tripping `set -u` on the
+  # bash 3.2 that macos-latest still runs.
+  run run_bounded_install "Installing thing" /bin/echo hello
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Installing thing: ok"* ]]
+}
+
+@test "run_bounded_install surfaces output and the exit code on failure" {
+  # The output is the whole point: without it a failure is indistinguishable
+  # from a stall, which is what made the 45-minute run undiagnosable.
+  cat > "${STUB_BIN}/failing-pm" << 'STUB'
+#!/usr/bin/env bash
+echo "E: Unable to locate package ffmpeg" >&2
+exit 100
+STUB
+  "$CHMOD" +x "${STUB_BIN}/failing-pm"
+
+  run run_bounded_install "Installing ffmpeg" failing-pm
+  [ "$status" -eq 100 ]
+  [[ "$output" == *"E: Unable to locate package ffmpeg"* ]]
+  [[ "$output" == *"exit 100"* ]]
+}
+
+@test "run_bounded_install bounds a stalled command and reports it as a timeout" {
+  require_real_timeout
+  cat > "${STUB_BIN}/stalling-pm" << 'STUB'
+#!/usr/bin/env bash
+sleep 60
+STUB
+  "$CHMOD" +x "${STUB_BIN}/stalling-pm"
+
+  PACKAGE_INSTALL_TIMEOUT_SECONDS=1
+  local start=${SECONDS}
+  run run_bounded_install "Installing ffmpeg" stalling-pm
+  local elapsed=$((SECONDS - start))
+
+  [ "$status" -ne 0 ]
+  [ "${elapsed}" -lt 30 ]
+  # A timeout must read differently from a failure, or the two stay
+  # indistinguishable in the logs.
+  [[ "$output" == *"exceeded"* ]]
+}
+
+@test "a stall that leaves a descendant holding stdout is still bounded" {
+  # `install_cmd` is an `&&` chain run through `bash -c`, so bash does not exec
+  # the package manager and a naive kill of the direct child would leave the
+  # grandchild alive holding the capture pipe open -- the bound would silently
+  # not apply. GNU timeout signals the whole process group, which is what makes
+  # the capture in run_bounded_install safe.
+  require_real_timeout
+  cat > "${STUB_BIN}/stalling-pm" << 'STUB'
+#!/usr/bin/env bash
+sleep 60
+STUB
+  "$CHMOD" +x "${STUB_BIN}/stalling-pm"
+
+  PACKAGE_INSTALL_TIMEOUT_SECONDS=1
+  local start=${SECONDS}
+  run run_bounded_install "Installing ffmpeg" bash -c "true && stalling-pm"
+  local elapsed=$((SECONDS - start))
+
+  [ "$status" -ne 0 ]
+  [ "${elapsed}" -lt 30 ]
+}
+
+@test "a successful package install reports success and is unchanged in behaviour" {
+  stub_apt_get << 'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+
+  run _install_system_package "ffmpeg" "required for video recording"
+  [ "$status" -eq 0 ]
+}
+
+@test "a stalled package install is bounded rather than running to the job ceiling" {
+  require_real_timeout
+  stub_apt_get << 'STUB'
+#!/usr/bin/env bash
+sleep 60
+STUB
+
+  PACKAGE_INSTALL_TIMEOUT_SECONDS=1
+  local start=${SECONDS}
+  run _install_system_package "ffmpeg" "required for video recording"
+  local elapsed=$((SECONDS - start))
+
+  [ "$status" -eq 1 ]
+  [ "${elapsed}" -lt 30 ]
+  [[ "$output" == *"exceeded"* ]]
+}
+
+@test "a failed package install surfaces the package manager output" {
+  stub_apt_get << 'STUB'
+#!/usr/bin/env bash
+echo "E: Could not get lock /var/lib/dpkg/lock-frontend" >&2
+exit 100
+STUB
+
+  run _install_system_package "ffmpeg" "required for video recording"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"E: Could not get lock /var/lib/dpkg/lock-frontend"* ]]
+  [[ "$output" == *"will be unavailable"* ]]
+}
+
+@test "no package install discards its output to /dev/null" {
+  # Pins the defect shape directly, so reintroducing the redirect on any install
+  # call site fails here even if the behavioural tests above stay satisfied.
+  run grep -nE '(apt-get|dnf|pacman|apk|brew|yum) (install|add|-S).*>\s*/dev/null' scripts/install.sh
+  [ "$status" -ne 0 ]
+}
+
+@test "no package install runs behind run_spinner, which hides its output" {
+  # `gum spin` swallows the wrapped command's output as thoroughly as
+  # `>/dev/null`, so package installs must go through run_bounded_install.
+  run grep -nE 'run_spinner .*(brew install|apt-get install|dnf install|pacman -S|go install)' scripts/install.sh
+  [ "$status" -ne 0 ]
+}

--- a/test/bats/install-bounded-package-install.bats
+++ b/test/bats/install-bounded-package-install.bats
@@ -204,8 +204,24 @@ STUB
 @test "no package install discards its output to /dev/null" {
   # Pins the defect shape directly, so reintroducing the redirect on any install
   # call site fails here even if the behavioural tests above stay satisfied.
-  run grep -nE '(apt-get|dnf|pacman|apk|brew|yum) (install|add|-S).*>\s*/dev/null' scripts/install.sh
+  # `[[:space:]]` rather than `\s`: the latter is a GNU extension, and a guard
+  # that silently fails to match on the BSD grep of macos-latest would pass for
+  # the wrong reason. The companion test below proves this pattern discriminates.
+  run grep -nE '(apt-get|dnf|pacman|apk|brew|yum) (install|add|-S).*>[[:space:]]*/dev/null' scripts/install.sh
   [ "$status" -ne 0 ]
+}
+
+@test "the discard guard actually matches a reintroduced redirect" {
+  # Without this, the guard above passes whenever its pattern is broken --
+  # exactly the failure mode of a source-scan check that greps for an absence.
+  local fixture="${TEST_DIR}/reintroduced.sh"
+  printf '%s\n' 'if run_spinner "x" bash -c "sudo apt-get install -y -qq ffmpeg >/dev/null 2>&1"; then' > "${fixture}"
+
+  run grep -nE '(apt-get|dnf|pacman|apk|brew|yum) (install|add|-S).*>[[:space:]]*/dev/null' "${fixture}"
+  [ "$status" -eq 0 ]
+
+  run grep -nE 'run_spinner .*(brew install|apt-get install|dnf install|pacman -S|go install)' "${fixture}"
+  [ "$status" -eq 0 ]
 }
 
 @test "no package install runs behind run_spinner, which hides its output" {


### PR DESCRIPTION
## Summary

`Installer Minimal (ubuntu-latest)` took **45.3 minutes** in [run 29864007907](https://github.com/kaeawc/auto-mobile/actions/runs/29864007907) and succeeded, against a ~1.5 min norm. All 45 minutes were inside one step, with a single 45-minute gap between `Installing ffmpeg (required for video recording)...` and `Setup complete.` and no output whatsoever in between.

`_install_system_package` ran the host package manager unbounded, with `>/dev/null 2>&1`, behind `gum spin`. Two independent defects: no ceiling on the stall, and no diagnostics to explain it afterwards.

This adds `run_bounded_install` — the install-shaped counterpart to the existing `run_with_error_output`, reusing that helper's capture-and-surface-on-failure contract rather than adding a third variant — and applies it to **every** package install in the installer that discarded its output, not only ffmpeg. The same shape appeared in eight other call sites.

Per the issue, `scripts/install.sh` is delivered by `curl … | bash` and must stay self-contained, so it resolves `timeout`/`gtimeout` when those exist. When neither does — stock macOS — it falls back to `bounded_watchdog_run`, a pure-bash watchdog mirroring `scripts/ios/run_with_timeout.sh`. An earlier revision skipped that fallback and left the prefix empty, which meant every “bounded” install on macOS ran with no bound at all: the same fail-open this issue exists to close, on the most likely developer platform. Reproduced against a PATH with neither binary — a 30s stall under a 2s bound ran the full 30s and reported `ok`.

## Linked Issue

Closes #4162

## Bug / Regression Context

- **Prior attempts:** [#4155](https://github.com/kaeawc/auto-mobile/issues/4155) / [#4156](https://github.com/kaeawc/auto-mobile/pull/4156) gave `pull_request` jobs a `timeout-minutes`. That caps the blast radius but is not a fix: it kills the job without saying which command hung, which is precisely the information this outlier lacked.
- **Observed symptom:** a 45-minute `Run Installer (minimal)` step emitting zero output, then succeeding.
- **Repro steps / conditions:** any transient apt stall — slow mirror, dpkg/lock contention, retry backoff — during `install_runtime_deps`.

## Changes

`run_bounded_install <title> <cmd...>`:
- Bounds the invocation at `PACKAGE_INSTALL_TIMEOUT_SECONDS` (default 600, overridable so tests can exercise the bound without a real stall).
- Uses `timeout -k 10` / `gtimeout -k 10`. `-k` matters: plain `timeout` sends only TERM, and a package manager that ignores it keeps running and keeps the captured pipe open past the deadline.
- Captures combined output and prints it to stderr on failure **or** timeout.
- Reports 124/137 distinctly (`exceeded …s and was aborted`) so a stall is not mistaken for a failure.
- Deliberately does **not** use `run_spinner`: `gum spin` hides the wrapped command's output as thoroughly as `>/dev/null`, which is half of what made this undiagnosable.

Call sites converted (9 across 6 functions):

| Function | Was |
| --- | --- |
| `_install_system_package` (ffmpeg) | `run_spinner … bash -c "${install_cmd} >/dev/null 2>&1"` |
| `_install_dev_tools_apt` | `apt-get update -qq 2>/dev/null`, `apt-get install … >/dev/null 2>&1` |
| `_install_dev_tools_brew` | `run_spinner … brew install` |
| `install_yq` | `run_spinner … brew install yq` / `go install` |
| `_install_libimobiledevice_tools` | `run_spinner … brew install` ×2 |
| `install_bun_homebrew` | `run_spinner … brew tap` / `brew install` |

The `gum` bootstrap installers were left alone: they already print their output, so they are not part of this defect class.

## Validation

- [x] `bats test/bats/` — full suite green
- [x] `shellcheck scripts/install.sh` — clean
- [x] `scripts/shellcheck/validate_shell_portability.sh` — clean (bash 3.2 compatible; the `${arr[@]+"${arr[@]}"}` guard keeps an empty prefix from tripping `set -u` there)
- [x] `scripts/shellcheck/validate_shell_sete.sh` — no new SC2310/SC2311 findings
- [x] `scripts/shellcheck/validate_shell_scripts.sh` — clean
- No TypeScript touched, so `typecheck`/`bun test` surfaces are unaffected.

New coverage in `test/bats/install-bounded-package-install.bats` (12 tests), mapping to the issue's acceptance criteria:

| Acceptance criterion | Test |
| --- | --- |
| A stalled install is bounded rather than running to the job ceiling | `a stalled package install is bounded rather than running to the job ceiling`, `run_bounded_install bounds a stalled command and reports it as a timeout` |
| A failed or timed-out install prints the package manager's output | `a failed package install surfaces the package manager output`, `run_bounded_install surfaces output and the exit code on failure` |
| A successful install is unchanged in behaviour and output | `a successful package install reports success and is unchanged in behaviour` |
| Covered by `test/bats/` under `INSTALL_SH_SOURCE_ONLY=true` with stub binaries | entire file |

Two tests go beyond the stated criteria because they guard failure modes that would silently un-fix this:

- `a stall that leaves a descendant holding stdout is still bounded` — `install_cmd` is an `&&` chain run through `bash -c`, so bash does not exec the package manager. Signalling only the direct child would leave the grandchild holding the capture pipe open and the bound would silently not apply. This pins that GNU `timeout` signals the whole process group, the same hazard documented in `scripts/ios/run_with_timeout.sh`.
- `no package install discards its output to /dev/null` / `no package install runs behind run_spinner` — source-scan guards so reintroducing the redirect at *any* install call site fails here, even if the behavioural tests stay satisfied.

Only the coreutils-path bound tests skip when neither `timeout` nor `gtimeout` is on PATH. The four `bounded_watchdog_run` tests deliberately do not gate on that, so they run on stock `macos-latest` — the host where the bound used to be absent entirely.

The resolver tests drop the system directories from `PATH` rather than only prepending stubs: `ubuntu-latest` ships `/usr/bin/timeout`, so without that the `gtimeout` and “no timeout binary” cases resolved the real binary and the tests passed without testing anything. Verified by running the suite against a synthetic `PATH` containing a `timeout` shim: green as written, and tests 2 and 3 fail when the `PATH` narrowing is removed.

## Follow-ups

- `bounded_watchdog_run` is now a second implementation of the technique in `scripts/ios/run_with_timeout.sh`. The duplication is forced by `curl … | bash` delivery, not chosen; if `install.sh` ever gains a sibling-file channel, the two should collapse into one.

