### PR TITLE
fix(ios): issue simctl commands as argv arrays instead of re-split strings

### DIFF
--- a/src/features/action/IosSimulatorPermissions.ts
+++ b/src/features/action/IosSimulatorPermissions.ts
@@ -5,7 +5,6 @@ import { promisify } from "util";
 import type { BootedDevice, ExecResult } from "../../models";
 import { SimCtlClient } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
-import { quoteSimctlArg } from "../../utils/ios-cmdline-tools/iosAppContainer";
 
 export type IosSimulatorPermissionAction = "grant" | "revoke" | "reset";
 
@@ -47,7 +46,7 @@ export interface IosSimulatorPermissionQueryResult {
 }
 
 export interface IosSimulatorPrivacyClient {
-  executeCommand(command: string, timeoutMs?: number): Promise<ExecResult>;
+  executeCommandArgs(args: string[], timeoutMs?: number): Promise<ExecResult>;
 }
 
 interface TccPermissionRow {
@@ -241,14 +240,13 @@ export class IosSimulatorPermissions {
     const results: IosSimulatorPermissionCommandResult[] = await Promise.all(
       normalizedPermissions.map(async permission => {
         try {
-          const command = [
+          const result = await this.simctl.executeCommandArgs([
             "privacy",
-            quoteSimctlArg(this.device.deviceId),
+            this.device.deviceId,
             action,
-            quoteSimctlArg(permission),
-            quoteSimctlArg(normalizedAppId)
-          ].join(" ");
-          const result = await this.simctl.executeCommand(command);
+            permission,
+            normalizedAppId
+          ]);
           return { permission, success: true, stdout: result.stdout, stderr: result.stderr };
         } catch (error) {
           return {

--- a/src/utils/DeepLinkManager.ts
+++ b/src/utils/DeepLinkManager.ts
@@ -16,7 +16,6 @@ import type { ElementGeometry } from "./interfaces/ElementGeometry";
 import { DefaultElementParser } from "../features/utility/ElementParser";
 import { DefaultElementGeometry } from "../features/utility/ElementGeometry";
 import { SimCtlClient } from "./ios-cmdline-tools/SimCtlClient";
-import { quoteSimctlArg } from "./ios-cmdline-tools/iosAppContainer";
 import { isIosSimulatorUdid } from "./ios-cmdline-tools/iosDeviceType";
 
 /**
@@ -244,9 +243,9 @@ export class DeepLinkManager implements DeepLinkManager {
       //    treat that as a clean not-installed result, not a raw thrown error.
       let appPath = "";
       try {
-        const container = await this.simctl.executeCommand(
-          `get_app_container ${quoteSimctlArg(udid)} ${quoteSimctlArg(bundleId)} app`
-        );
+        const container = await this.simctl.executeCommandArgs([
+          "get_app_container", udid, bundleId, "app"
+        ]);
         appPath = container.stdout.trim();
       } catch (error) {
         logger.debug(`[DeepLinkManager] get_app_container failed for ${bundleId}: ${error}`);

--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -298,13 +298,26 @@ function splitCommandArgs(command: string): string[] {
 
   const args: string[] = [];
   let current = "";
+  // A token that was opened with a quote is real even when it is empty — `""`
+  // must survive as an empty argv entry. Dropping it shifts every later
+  // positional argument, which silently rewrites the command (issue #4196).
+  let started = false;
   let quote: '"' | "'" | null = null;
+
+  const flush = (): void => {
+    if (started) {
+      args.push(current);
+      current = "";
+      started = false;
+    }
+  };
 
   for (let i = 0; i < trimmed.length; i++) {
     const char = trimmed[i];
 
     if (char === "\\" && i + 1 < trimmed.length) {
       current += trimmed[i + 1];
+      started = true;
       i++;
       continue;
     }
@@ -320,23 +333,20 @@ function splitCommandArgs(command: string): string[] {
 
     if (char === "'" || char === "\"") {
       quote = char;
+      started = true;
       continue;
     }
 
     if (/\s/.test(char)) {
-      if (current.length > 0) {
-        args.push(current);
-        current = "";
-      }
+      flush();
       continue;
     }
 
     current += char;
+    started = true;
   }
 
-  if (current.length > 0) {
-    args.push(current);
-  }
+  flush();
 
   return args;
 }

--- a/src/utils/ios-cmdline-tools/iosAppContainer.ts
+++ b/src/utils/ios-cmdline-tools/iosAppContainer.ts
@@ -9,10 +9,10 @@ import { logger } from "../logger";
  */
 export const IOS_APP_DATA_FOLDERS = ["Documents", "Library", "tmp"];
 
-/** Quote an arg for an `xcrun simctl` command line. */
-export function quoteSimctlArg(value: string): string {
-  return JSON.stringify(value);
-}
+// NOTE: there is deliberately no `quoteSimctlArg` helper here any more. Building a
+// simctl command line by quoting values into a string and re-splitting it back into
+// argv loses empty values and mangles escapes (issue #4196). Pass an argument array
+// to `executeCommandArgs` instead.
 
 /**
  * Terminate an app on a simulator if it's running. Non-fatal: a not-running app
@@ -36,13 +36,14 @@ export async function terminateAppIfRunning(
  * container can't be resolved (e.g. app not installed).
  */
 export async function getAppDataContainerPath(
-  simctl: Pick<SimCtlClient, "executeCommand">,
+  simctl: Pick<SimCtlClient, "executeCommandArgs">,
   deviceId: string,
   bundleId: string
 ): Promise<string | null> {
   try {
-    const command = `get_app_container ${quoteSimctlArg(deviceId)} ${quoteSimctlArg(bundleId)} data`;
-    const result = await simctl.executeCommand(command);
+    const result = await simctl.executeCommandArgs([
+      "get_app_container", deviceId, bundleId, "data"
+    ]);
     const containerPath = result.stdout.trim();
     if (!containerPath) {
       logger.warn(`[iOS] No data container path for ${bundleId}`);

--- a/src/utils/ios-cmdline-tools/iosSettings.ts
+++ b/src/utils/ios-cmdline-tools/iosSettings.ts
@@ -1,6 +1,12 @@
 import type { SimCtlClient } from "./SimCtlClient";
-import { quoteSimctlArg } from "./iosAppContainer";
 import { logger } from "../logger";
+
+/**
+ * The argv-shaped slice of the simctl client these helpers need. Commands are
+ * always issued as an argument array so values with spaces, quotes, escapes or
+ * no content at all reach `xcrun` verbatim (issue #4196).
+ */
+type SimctlArgvRunner = Pick<SimCtlClient, "executeCommandArgs">;
 
 /**
  * Curated (domain, key) allowlist captured/restored for iOS simulator snapshots.
@@ -29,13 +35,13 @@ export interface IosSettingsSnapshot {
  * prints the current setting; `content_size` is read the same way.
  */
 async function captureUiState(
-  simctl: Pick<SimCtlClient, "executeCommand">,
+  simctl: SimctlArgvRunner,
   deviceId: string
 ): Promise<IosSettingsSnapshot["ui"]> {
   const ui: NonNullable<IosSettingsSnapshot["ui"]> = {};
   try {
     const appearance = (
-      await simctl.executeCommand(`ui ${quoteSimctlArg(deviceId)} appearance`)
+      await simctl.executeCommandArgs(["ui", deviceId, "appearance"])
     ).stdout.trim();
     if (appearance === "light" || appearance === "dark") {
       ui.appearance = appearance;
@@ -45,7 +51,7 @@ async function captureUiState(
   }
   try {
     const contentSize = (
-      await simctl.executeCommand(`ui ${quoteSimctlArg(deviceId)} content_size`)
+      await simctl.executeCommandArgs(["ui", deviceId, "content_size"])
     ).stdout.trim();
     if (contentSize) {
       ui.contentSize = contentSize;
@@ -58,16 +64,15 @@ async function captureUiState(
 
 /** Capture the curated iOS settings allowlist + device-level UI state. */
 export async function captureIosSettings(
-  simctl: Pick<SimCtlClient, "executeCommand">,
+  simctl: SimctlArgvRunner,
   deviceId: string
 ): Promise<IosSettingsSnapshot> {
   const values: Record<string, string> = {};
   for (const { domain, key } of IOS_SETTINGS_KEYS) {
     try {
-      const cmd =
-        `spawn ${quoteSimctlArg(deviceId)} defaults read ` +
-        `${quoteSimctlArg(domain)} ${quoteSimctlArg(key)}`;
-      const result = await simctl.executeCommand(cmd);
+      const result = await simctl.executeCommandArgs([
+        "spawn", deviceId, "defaults", "read", domain, key
+      ]);
       const value = result.stdout.trim();
       if (value) {
         values[`${domain}/${key}`] = value;
@@ -87,7 +92,7 @@ export async function captureIosSettings(
  * are logged and skipped (non-fatal).
  */
 export async function restoreIosSettings(
-  simctl: Pick<SimCtlClient, "executeCommand">,
+  simctl: SimctlArgvRunner,
   deviceId: string,
   settings: IosSettingsSnapshot
 ): Promise<void> {
@@ -99,10 +104,9 @@ export async function restoreIosSettings(
     const domain = compoundKey.slice(0, slash);
     const key = compoundKey.slice(slash + 1);
     try {
-      const cmd =
-        `spawn ${quoteSimctlArg(deviceId)} defaults write ` +
-        `${quoteSimctlArg(domain)} ${quoteSimctlArg(key)} ${quoteSimctlArg(value)}`;
-      await simctl.executeCommand(cmd);
+      await simctl.executeCommandArgs([
+        "spawn", deviceId, "defaults", "write", domain, key, value
+      ]);
     } catch (error) {
       logger.warn(`[iOS] Failed to write ${domain}/${key}: ${error}`);
     }
@@ -110,18 +114,14 @@ export async function restoreIosSettings(
 
   if (settings.ui?.appearance) {
     try {
-      await simctl.executeCommand(
-        `ui ${quoteSimctlArg(deviceId)} appearance ${settings.ui.appearance}`
-      );
+      await simctl.executeCommandArgs(["ui", deviceId, "appearance", settings.ui.appearance]);
     } catch (error) {
       logger.warn(`[iOS] Failed to restore appearance: ${error}`);
     }
   }
   if (settings.ui?.contentSize) {
     try {
-      await simctl.executeCommand(
-        `ui ${quoteSimctlArg(deviceId)} content_size ${quoteSimctlArg(settings.ui.contentSize)}`
-      );
+      await simctl.executeCommandArgs(["ui", deviceId, "content_size", settings.ui.contentSize]);
     } catch (error) {
       logger.warn(`[iOS] Failed to restore content_size: ${error}`);
     }

--- a/test/fakes/FakeSimCtlClient.ts
+++ b/test/fakes/FakeSimCtlClient.ts
@@ -17,6 +17,8 @@ export class FakeSimCtlClient {
   private containerErrors = new Map<string, Error>();
   private commandResults = new Map<string, ExecResult>();
   private commandErrors = new Map<string, Error>();
+  private argvResults = new Map<string, ExecResult>();
+  private argvErrors = new Map<string, Error>();
   private methodCalls = new Map<string, Array<Record<string, unknown>>>();
   private openSimulatorAppError: Error | null = null;
 
@@ -58,6 +60,26 @@ export class FakeSimCtlClient {
     });
   }
 
+  /**
+   * Stub a result keyed by the exact argv array. Unlike {@link setCommandResult},
+   * this survives values containing spaces or empty strings, which a joined
+   * command string cannot distinguish (issue #4196).
+   */
+  setCommandArgsResult(args: string[], stdout: string, stderr: string = ""): void {
+    this.argvResults.set(JSON.stringify(args), {
+      stdout,
+      stderr,
+      toString: () => stdout,
+      trim: () => stdout.trim(),
+      includes: (value: string) => stdout.includes(value),
+    });
+  }
+
+  /** Stub an error keyed by the exact argv array. See {@link setCommandArgsResult}. */
+  setCommandArgsError(args: string[], error: Error): void {
+    this.argvErrors.set(JSON.stringify(args), error);
+  }
+
   getMethodCalls(methodName: string): Array<Record<string, unknown>> {
     return this.methodCalls.get(methodName) ?? [];
   }
@@ -97,6 +119,17 @@ export class FakeSimCtlClient {
 
   async executeCommandArgs(args: string[], timeoutMs?: number): Promise<ExecResult> {
     this.recordCall("executeCommandArgs", { args, timeoutMs });
+
+    const argvKey = JSON.stringify(args);
+    const argvError = this.argvErrors.get(argvKey);
+    if (argvError) {
+      throw argvError;
+    }
+    const argvResult = this.argvResults.get(argvKey);
+    if (argvResult) {
+      return argvResult;
+    }
+
     const command = args.join(" ");
     const commandError = this.commandErrors.get(command);
     if (commandError) {
@@ -106,6 +139,15 @@ export class FakeSimCtlClient {
     const commandResult = this.commandResults.get(command);
     if (commandResult) {
       return commandResult;
+    }
+
+    if (args[0] === "get_app_container" && args[3] === "data") {
+      const bundleId = args[2];
+      const error = this.containerErrors.get(bundleId);
+      if (error) {
+        throw error;
+      }
+      return buildExecResult(this.containerPaths.get(bundleId) ?? "");
     }
 
     return buildExecResult("");

--- a/test/features/action/AppPermissions.test.ts
+++ b/test/features/action/AppPermissions.test.ts
@@ -125,10 +125,10 @@ describe("AppPermissions", () => {
 
     expect(setResult.success).toBe(true);
     expect(setResult.changedCount).toBe(1);
-    expect(simctl.getMethodCalls("executeCommand")).toEqual([
+    expect(simctl.getMethodCalls("executeCommandArgs")).toEqual([
       {
-        command: 'privacy "12345678-1234-1234-1234-123456789ABC" grant "camera" "com.example.app"',
-        timeoutMs: undefined,
+        args: ["privacy", "12345678-1234-1234-1234-123456789ABC", "grant", "camera", "com.example.app"],
+        timeoutMs: undefined
       },
     ]);
     expect(getResult.permissions).toEqual([

--- a/test/features/action/CaptureSnapshotIos.test.ts
+++ b/test/features/action/CaptureSnapshotIos.test.ts
@@ -119,12 +119,12 @@ describe("CaptureSnapshotIos", () => {
   });
 
   it("captures iOS settings (locale + UI) into the manifest when includeSettings", async () => {
-    simctl.setCommandResult(
-      `spawn "${device.deviceId}" defaults read ".GlobalPreferences" "AppleLocale"`,
+    simctl.setCommandArgsResult(
+      ["spawn", device.deviceId, "defaults", "read", ".GlobalPreferences", "AppleLocale"],
       "nl_BE\n"
     );
-    simctl.setCommandResult(`ui "${device.deviceId}" appearance`, "dark\n");
-    simctl.setCommandResult(`ui "${device.deviceId}" content_size`, "large\n");
+    simctl.setCommandArgsResult(["ui", device.deviceId, "appearance"], "dark\n");
+    simctl.setCommandArgsResult(["ui", device.deviceId, "content_size"], "large\n");
 
     const captureSnapshot = new CaptureSnapshotIos(device, simctl as any, store);
     const result = await captureSnapshot.execute({
@@ -156,9 +156,9 @@ describe("CaptureSnapshotIos", () => {
     expect(result.manifest.iosSettings).toBeUndefined();
 
     const settingsCommands = simctl
-      .getMethodCalls("executeCommand")
-      .map(call => String(call.command))
-      .filter(cmd => cmd.includes("defaults") || cmd.startsWith("ui "));
+      .getMethodCalls("executeCommandArgs")
+      .map(call => call.args as string[])
+      .filter(args => args.includes("defaults") || args[0] === "ui");
     expect(settingsCommands).toEqual([]);
   });
 });

--- a/test/features/action/GrantIosSimulatorPermissions.test.ts
+++ b/test/features/action/GrantIosSimulatorPermissions.test.ts
@@ -57,13 +57,13 @@ describe("GrantIosSimulatorPermissions", () => {
     expect(result.success).toBe(true);
     expect(result.grantedCount).toBe(2);
     expect(result.failedCount).toBe(0);
-    expect(simctl.getMethodCalls("executeCommand")).toEqual([
+    expect(simctl.getMethodCalls("executeCommandArgs")).toEqual([
       {
-        command: 'privacy "12345678-1234-1234-1234-123456789ABC" grant "camera" "com.example.app"',
+        args: ["privacy", "12345678-1234-1234-1234-123456789ABC", "grant", "camera", "com.example.app"],
         timeoutMs: undefined
       },
       {
-        command: 'privacy "12345678-1234-1234-1234-123456789ABC" grant "microphone" "com.example.app"',
+        args: ["privacy", "12345678-1234-1234-1234-123456789ABC", "grant", "microphone", "com.example.app"],
         timeoutMs: undefined
       }
     ]);
@@ -71,8 +71,8 @@ describe("GrantIosSimulatorPermissions", () => {
 
   test("returns per-permission failures without aborting the batch", async () => {
     const simctl = new FakeSimCtlClient();
-    simctl.setCommandError(
-      'privacy "12345678-1234-1234-1234-123456789ABC" grant "photos" "com.example.app"',
+    simctl.setCommandArgsError(
+      ["privacy", "12345678-1234-1234-1234-123456789ABC", "grant", "photos", "com.example.app"],
       new Error("unsupported service")
     );
     const action = new GrantIosSimulatorPermissions(simulatorDevice, simctl);
@@ -109,7 +109,7 @@ describe("GrantIosSimulatorPermissions", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toBe("iOS permission changes via simctl privacy are only supported on simulators");
-    expect(simctl.getMethodCalls("executeCommand")).toEqual([]);
+    expect(simctl.getMethodCalls("executeCommandArgs")).toEqual([]);
   });
 
   test("rejects non-iOS devices", async () => {
@@ -124,7 +124,7 @@ describe("GrantIosSimulatorPermissions", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toBe("iOS simulator permissions are only supported on iOS simulators");
-    expect(simctl.getMethodCalls("executeCommand")).toEqual([]);
+    expect(simctl.getMethodCalls("executeCommandArgs")).toEqual([]);
   });
 });
 
@@ -140,13 +140,13 @@ describe("IosSimulatorPermissions", () => {
     expect(revoke.changedCount).toBe(1);
     expect(reset.success).toBe(true);
     expect(reset.changedCount).toBe(1);
-    expect(simctl.getMethodCalls("executeCommand")).toEqual([
+    expect(simctl.getMethodCalls("executeCommandArgs")).toEqual([
       {
-        command: 'privacy "12345678-1234-1234-1234-123456789ABC" revoke "camera" "com.example.app"',
+        args: ["privacy", "12345678-1234-1234-1234-123456789ABC", "revoke", "camera", "com.example.app"],
         timeoutMs: undefined
       },
       {
-        command: 'privacy "12345678-1234-1234-1234-123456789ABC" reset "microphone" "com.example.app"',
+        args: ["privacy", "12345678-1234-1234-1234-123456789ABC", "reset", "microphone", "com.example.app"],
         timeoutMs: undefined
       }
     ]);

--- a/test/features/action/LaunchApp.test.ts
+++ b/test/features/action/LaunchApp.test.ts
@@ -752,6 +752,11 @@ describe("LaunchApp", () => {
           const stdout = command.startsWith("get_app_container") ? containerPath : "";
           return { stdout, stderr: "", trim: () => stdout.trim(), toString: () => stdout, includes: (s: string) => stdout.includes(s) } as any;
         },
+        executeCommandArgs: async (args: string[]) => {
+          calls.push(`exec:${args.join(" ")}`);
+          const stdout = args[0] === "get_app_container" ? containerPath : "";
+          return { stdout, stderr: "", trim: () => stdout.trim(), toString: () => stdout, includes: (s: string) => stdout.includes(s) } as any;
+        },
       };
 
       const iosObserveScreen = new FakeObserveScreen();

--- a/test/features/action/RestoreSnapshotIos.test.ts
+++ b/test/features/action/RestoreSnapshotIos.test.ts
@@ -204,6 +204,7 @@ describe("RestoreSnapshotIos", () => {
     });
 
     expect(simctl.getMethodCalls("executeCommand")).toHaveLength(0);
+    expect(simctl.getMethodCalls("executeCommandArgs")).toHaveLength(0);
     expect(simctl.getMethodCalls("terminateApp")).toHaveLength(0);
   });
 
@@ -227,12 +228,12 @@ describe("RestoreSnapshotIos", () => {
     const restoreSnapshot = new RestoreSnapshotIos(device, simctl as any, store);
     await restoreSnapshot.execute({ snapshotName, manifest, useVmSnapshot: false });
 
-    const commands = simctl.getMethodCalls("executeCommand").map(c => String(c.command));
-    expect(commands).toContain(
-      `spawn "${device.deviceId}" defaults write ".GlobalPreferences" "AppleLocale" "nl_BE"`
+    const argvCommands = simctl.getMethodCalls("executeCommandArgs").map(c => c.args);
+    expect(argvCommands).toContainEqual(
+      ["spawn", device.deviceId, "defaults", "write", ".GlobalPreferences", "AppleLocale", "nl_BE"]
     );
-    expect(commands).toContain(`ui "${device.deviceId}" appearance dark`);
-    expect(commands).toContain(`ui "${device.deviceId}" content_size "large"`);
+    expect(argvCommands).toContainEqual(["ui", device.deviceId, "appearance", "dark"]);
+    expect(argvCommands).toContainEqual(["ui", device.deviceId, "content_size", "large"]);
   });
 
   it("skips settings restore when includeSettings is false", async () => {
@@ -254,14 +255,14 @@ describe("RestoreSnapshotIos", () => {
     const restoreSnapshot = new RestoreSnapshotIos(device, simctl as any, store);
     await restoreSnapshot.execute({ snapshotName, manifest, useVmSnapshot: false });
 
-    const commands = simctl.getMethodCalls("executeCommand").map(c => String(c.command));
-    expect(commands.some(c => c.includes("defaults write"))).toBe(false);
+    const argvCommands = simctl.getMethodCalls("executeCommandArgs").map(c => c.args as string[]);
+    expect(argvCommands.some(args => args.includes("defaults") && args.includes("write"))).toBe(false);
   });
 
   it("continues restoring remaining settings when one key write fails (non-fatal)", async () => {
     const snapshotName = "settings-partial";
-    simctl.setCommandError(
-      `spawn "${device.deviceId}" defaults write ".GlobalPreferences" "AppleLocale" "nl_BE"`,
+    simctl.setCommandArgsError(
+      ["spawn", device.deviceId, "defaults", "write", ".GlobalPreferences", "AppleLocale", "nl_BE"],
       new Error("write failed")
     );
     const manifest: DeviceSnapshotManifest = {
@@ -283,8 +284,8 @@ describe("RestoreSnapshotIos", () => {
     // Should not throw despite the failed key write.
     await restoreSnapshot.execute({ snapshotName, manifest, useVmSnapshot: false });
 
-    const commands = simctl.getMethodCalls("executeCommand").map(c => String(c.command));
+    const argvCommands = simctl.getMethodCalls("executeCommandArgs").map(c => c.args);
     // UI restore still runs after the failed defaults write.
-    expect(commands).toContain(`ui "${device.deviceId}" appearance light`);
+    expect(argvCommands).toContainEqual(["ui", device.deviceId, "appearance", "light"]);
   });
 });

--- a/test/utils/DeepLinkManagerIos.test.ts
+++ b/test/utils/DeepLinkManagerIos.test.ts
@@ -58,8 +58,8 @@ describe("DeepLinkManager iOS", () => {
   test("returns schemes from CFBundleURLTypes for a schemes-only app", async () => {
     const simctl = new FakeSimCtlClient();
     const appPath = "/sim/Containers/Bundle/Application/ABC/MyApp.app";
-    simctl.setCommandResult(
-      `get_app_container "${SIM_UDID}" "com.example.myapp" app`,
+    simctl.setCommandArgsResult(
+      ["get_app_container", SIM_UDID, "com.example.myapp", "app"],
       appPath
     );
 
@@ -88,8 +88,11 @@ describe("DeepLinkManager iOS", () => {
     ]);
 
     // get_app_container routes through simctl (xcrun simctl), not host exec.
-    const simctlCalls = simctl.getMethodCalls("executeCommand");
-    expect(simctlCalls.some(c => String(c.command).includes("get_app_container") && String(c.command).includes(" app"))).toBe(true);
+    const simctlCalls = simctl.getMethodCalls("executeCommandArgs");
+    expect(simctlCalls.some(c => {
+      const args = c.args as string[];
+      return args[0] === "get_app_container" && args[3] === "app";
+    })).toBe(true);
     // plutil/codesign route through host exec, never simctl.
     expect(calls.some(c => c.includes("plutil -convert json"))).toBe(true);
     expect(simctlCalls.every(c => !String(c.command).includes("plutil"))).toBe(true);
@@ -98,8 +101,8 @@ describe("DeepLinkManager iOS", () => {
   test("returns universal-link hosts from associated-domains entitlement", async () => {
     const simctl = new FakeSimCtlClient();
     const appPath = "/sim/MyApp.app";
-    simctl.setCommandResult(
-      `get_app_container "${SIM_UDID}" "com.example.myapp" app`,
+    simctl.setCommandArgsResult(
+      ["get_app_container", SIM_UDID, "com.example.myapp", "app"],
       appPath
     );
 
@@ -135,8 +138,8 @@ describe("DeepLinkManager iOS", () => {
 
   test("unsigned bundle with no entitlements yields empty hosts (not an error)", async () => {
     const simctl = new FakeSimCtlClient();
-    simctl.setCommandResult(
-      `get_app_container "${SIM_UDID}" "com.example.myapp" app`,
+    simctl.setCommandArgsResult(
+      ["get_app_container", SIM_UDID, "com.example.myapp", "app"],
       "/sim/MyApp.app"
     );
     const infoPlist = JSON.stringify({ CFBundleURLTypes: [{ CFBundleURLSchemes: ["myapp"] }] });
@@ -168,8 +171,8 @@ describe("DeepLinkManager iOS", () => {
 
   test("malformed plist JSON returns success:false without throwing", async () => {
     const simctl = new FakeSimCtlClient();
-    simctl.setCommandResult(
-      `get_app_container "${SIM_UDID}" "com.example.myapp" app`,
+    simctl.setCommandArgsResult(
+      ["get_app_container", SIM_UDID, "com.example.myapp", "app"],
       "/sim/MyApp.app"
     );
     const { exec } = fakeHostExec([
@@ -199,7 +202,7 @@ describe("DeepLinkManager iOS", () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain("not yet implemented");
     // No simctl or host exec invoked for physical devices.
-    expect(simctl.getMethodCalls("executeCommand")).toHaveLength(0);
+    expect(simctl.getMethodCalls("executeCommandArgs")).toHaveLength(0);
     expect(calls).toHaveLength(0);
   });
 });

--- a/test/utils/ios-cmdline-tools/iosSettings.test.ts
+++ b/test/utils/ios-cmdline-tools/iosSettings.test.ts
@@ -15,12 +15,12 @@ describe("iosSettings", () => {
 
   test("captureIosSettings reads allowlisted keys + UI state", async () => {
     const simctl = new FakeSimCtlClient();
-    simctl.setCommandResult(
-      `spawn "${UDID}" defaults read ".GlobalPreferences" "AppleLocale"`,
+    simctl.setCommandArgsResult(
+      ["spawn", UDID, "defaults", "read", ".GlobalPreferences", "AppleLocale"],
       "nl_BE\n"
     );
-    simctl.setCommandResult(`ui "${UDID}" appearance`, "dark\n");
-    simctl.setCommandResult(`ui "${UDID}" content_size`, "large\n");
+    simctl.setCommandArgsResult(["ui", UDID, "appearance"], "dark\n");
+    simctl.setCommandArgsResult(["ui", UDID, "content_size"], "large\n");
 
     const snapshot = await captureIosSettings(simctl as any, UDID);
 
@@ -30,8 +30,8 @@ describe("iosSettings", () => {
 
   test("captureIosSettings skips unset keys (defaults read non-zero) without throwing", async () => {
     const simctl = new FakeSimCtlClient();
-    simctl.setCommandError(
-      `spawn "${UDID}" defaults read ".GlobalPreferences" "AppleLocale"`,
+    simctl.setCommandArgsError(
+      ["spawn", UDID, "defaults", "read", ".GlobalPreferences", "AppleLocale"],
       new Error("does not exist")
     );
     // appearance/content_size return "" by default → ui undefined
@@ -48,18 +48,18 @@ describe("iosSettings", () => {
       ui: { appearance: "dark", contentSize: "large" },
     });
 
-    const commands = simctl.getMethodCalls("executeCommand").map(c => String(c.command));
-    expect(commands).toEqual([
-      `spawn "${UDID}" defaults write ".GlobalPreferences" "AppleLocale" "nl_BE"`,
-      `ui "${UDID}" appearance dark`,
-      `ui "${UDID}" content_size "large"`,
+    const argvCommands = simctl.getMethodCalls("executeCommandArgs").map(c => c.args);
+    expect(argvCommands).toEqual([
+      ["spawn", UDID, "defaults", "write", ".GlobalPreferences", "AppleLocale", "nl_BE"],
+      ["ui", UDID, "appearance", "dark"],
+      ["ui", UDID, "content_size", "large"],
     ]);
   });
 
   test("capture -> restore round-trips the locale value", async () => {
     const capSim = new FakeSimCtlClient();
-    capSim.setCommandResult(
-      `spawn "${UDID}" defaults read ".GlobalPreferences" "AppleLocale"`,
+    capSim.setCommandArgsResult(
+      ["spawn", UDID, "defaults", "read", ".GlobalPreferences", "AppleLocale"],
       "en_US"
     );
     const snapshot = await captureIosSettings(capSim as any, UDID);
@@ -67,16 +67,16 @@ describe("iosSettings", () => {
     const restoreSim = new FakeSimCtlClient();
     await restoreIosSettings(restoreSim as any, UDID, snapshot);
 
-    const commands = restoreSim.getMethodCalls("executeCommand").map(c => String(c.command));
-    expect(commands).toContain(
-      `spawn "${UDID}" defaults write ".GlobalPreferences" "AppleLocale" "en_US"`
+    const argvCommands = restoreSim.getMethodCalls("executeCommandArgs").map(c => c.args);
+    expect(argvCommands).toContainEqual(
+      ["spawn", UDID, "defaults", "write", ".GlobalPreferences", "AppleLocale", "en_US"]
     );
   });
 
   test("restoreIosSettings is non-fatal when a single key write fails", async () => {
     const simctl = new FakeSimCtlClient();
-    simctl.setCommandError(
-      `spawn "${UDID}" defaults write ".GlobalPreferences" "AppleLocale" "nl_BE"`,
+    simctl.setCommandArgsError(
+      ["spawn", UDID, "defaults", "write", ".GlobalPreferences", "AppleLocale", "nl_BE"],
       new Error("boom")
     );
 
@@ -85,8 +85,8 @@ describe("iosSettings", () => {
       ui: { appearance: "light" },
     });
 
-    const commands = simctl.getMethodCalls("executeCommand").map(c => String(c.command));
+    const argvCommands = simctl.getMethodCalls("executeCommandArgs").map(c => c.args);
     // UI restore still ran after the failed write.
-    expect(commands).toContain(`ui "${UDID}" appearance light`);
+    expect(argvCommands).toContainEqual(["ui", UDID, "appearance", "light"]);
   });
 });

--- a/test/utils/ios-cmdline-tools/simctlArgvIntegrity.test.ts
+++ b/test/utils/ios-cmdline-tools/simctlArgvIntegrity.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+import { restoreIosSettings } from "../../../src/utils/ios-cmdline-tools/iosSettings";
+import { getAppDataContainerPath } from "../../../src/utils/ios-cmdline-tools/iosAppContainer";
+import { Simctl } from "../../../src/utils/ios-cmdline-tools/SimCtlClient";
+import { FakeSimCtlClient } from "../../fakes/FakeSimCtlClient";
+import { createExecResult } from "../../../src/utils/execResult";
+
+const UDID = "7B3A3792-DB53-4654-BA94-27A1D305C3B7";
+
+/**
+ * Argument shapes that a string-built command line loses or mangles when it is
+ * re-split back into argv. Issue #4196: the empty value is the dangerous one —
+ * dropping it shifts every later positional argument, so a `defaults write`
+ * silently turns into a shorter, different command.
+ */
+const TRICKY_VALUES: ReadonlyArray<{ label: string; value: string }> = [
+  { label: "empty string", value: "" },
+  { label: "newline", value: "line1\nline2" },
+  { label: "tab", value: "col1\tcol2" },
+  { label: "carriage return", value: "a\rb" },
+  { label: "double quote", value: "say \"hi\"" },
+  { label: "single quote", value: "it's" },
+  { label: "backslash", value: "back\\slash" },
+  { label: "literal backslash-n", value: "C:\\new\\tab" },
+  { label: "space", value: "two words" },
+  { label: "leading/trailing space", value: "  padded  " },
+  { label: "shell metacharacters", value: "$HOME `id` ; rm -rf /" },
+  { label: "unicode", value: "café — 日本語 🎉" },
+];
+
+describe("simctl argv integrity (#4196)", () => {
+  describe("restoreIosSettings issues an argv array, preserving every value", () => {
+    for (const { label, value } of TRICKY_VALUES) {
+      test(`defaults write survives ${label}`, async () => {
+        const simctl = new FakeSimCtlClient();
+
+        await restoreIosSettings(simctl as any, UDID, {
+          values: { ".GlobalPreferences/AppleLocale": value },
+        });
+
+        const argvCalls = simctl.getMethodCalls("executeCommandArgs");
+        expect(argvCalls).toHaveLength(1);
+        expect(argvCalls[0].args).toEqual([
+          "spawn",
+          UDID,
+          "defaults",
+          "write",
+          ".GlobalPreferences",
+          "AppleLocale",
+          value,
+        ]);
+      });
+    }
+
+    test("an empty value keeps `write` as the verb and does not shift positions", async () => {
+      const simctl = new FakeSimCtlClient();
+
+      await restoreIosSettings(simctl as any, UDID, {
+        values: { ".GlobalPreferences/AppleLocale": "" },
+      });
+
+      const args = simctl.getMethodCalls("executeCommandArgs")[0].args as string[];
+      expect(args[3]).toBe("write");
+      expect(args).toHaveLength(7);
+    });
+
+    test("no legacy string command path is used for defaults write", async () => {
+      const simctl = new FakeSimCtlClient();
+      await restoreIosSettings(simctl as any, UDID, {
+        values: { ".GlobalPreferences/AppleLocale": "nl_BE" },
+        ui: { appearance: "dark", contentSize: "large" },
+      });
+      expect(simctl.getMethodCalls("executeCommand")).toEqual([]);
+    });
+  });
+
+  describe("getAppDataContainerPath issues an argv array", () => {
+    for (const { label, value } of TRICKY_VALUES) {
+      test(`bundle id survives ${label}`, async () => {
+        const simctl = new FakeSimCtlClient();
+        simctl.setCommandArgsResult(
+          ["get_app_container", UDID, value, "data"],
+          "/tmp/container\n"
+        );
+
+        const result = await getAppDataContainerPath(simctl as any, UDID, value);
+
+        expect(result).toBe("/tmp/container");
+        expect(simctl.getMethodCalls("executeCommandArgs")[0].args).toEqual([
+          "get_app_container",
+          UDID,
+          value,
+          "data",
+        ]);
+      });
+    }
+  });
+
+  describe("legacy string command path no longer drops empty quoted arguments", () => {
+    test("an empty quoted token is preserved as an empty argv entry", async () => {
+      const seen: string[][] = [];
+      const client = new Simctl(null, async (_file, args) => {
+        if (args.join(" ") !== "simctl --version") {
+          seen.push(args);
+        }
+        return createExecResult("", "");
+      });
+
+      await client.executeCommand("spawn udid defaults write domain key \"\"");
+
+      expect(seen[0]).toEqual([
+        "simctl",
+        "spawn",
+        "udid",
+        "defaults",
+        "write",
+        "domain",
+        "key",
+        "",
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`SimCtlClient` had a string round-trip in its command path: callers built an `xcrun simctl`
command line by `JSON.stringify`-quoting values into a string (`quoteSimctlArg`), and
`splitCommandArgs` then re-split that string back into argv. The round trip is lossy.

Two confirmed defects, both reproduced as red tests before the fix:

- **An empty value is dropped entirely.** `splitCommandArgs` only pushed a token when
  `current.length > 0`, so `""` vanished. That shifts every later positional argument, so
  `spawn <udid> defaults write <domain> <key> ""` reached the simulator as
  `defaults write <domain> <key>` — a different command, silently.
- **Escapes are mangled.** `quoteSimctlArg` emits JSON escapes (`\n`, `\t`, `\r`, `\"`,
  `\\`), and `splitCommandArgs` treats `\` as "take the next character literally", so a
  value containing a newline came back as the letter `n`.

The fix removes the round trip rather than patching individual escapes: every data-bearing
simctl call site now passes an **argument array** to the existing `executeCommandArgs`
seam, which hands argv straight to `execFile`. `quoteSimctlArg` had no remaining callers
and is deleted, so the footgun cannot be reintroduced by copy-paste.

`splitCommandArgs` is also fixed to preserve empty quoted tokens, as defense in depth for
the remaining literal (non-data) string commands such as `list devices --json`.

No new helper was added — `executeCommandArgs` / `startCommandArgs` / `createExecResult`
already existed and are reused as-is.

## Linked Issue

Closes #4196

## Bug / Regression Context

- **Observed symptom:** a `defaults write` with an empty value silently executed as a
  shorter, different command and reported success; values containing `\n`/`\t` were
  corrupted before reaching the simulator.
- **Repro steps / conditions:** any `restoreIosSettings` / `get_app_container` /
  `simctl privacy` call whose value contains whitespace, a quote, a backslash, or is empty.

## Changes

- `src/utils/ios-cmdline-tools/iosSettings.ts` — `defaults read` / `defaults write` /
  `simctl ui` now issue argv arrays; the helpers take a narrow
  `Pick<SimCtlClient, "executeCommandArgs">`.
- `src/utils/ios-cmdline-tools/iosAppContainer.ts` — `get_app_container` via argv;
  `quoteSimctlArg` removed.
- `src/utils/DeepLinkManager.ts` — `get_app_container ... app` via argv.
- `src/features/action/IosSimulatorPermissions.ts` — `simctl privacy` via argv; the local
  `IosSimulatorPrivacyClient` interface now declares `executeCommandArgs`.
- `src/utils/ios-cmdline-tools/SimCtlClient.ts` — `splitCommandArgs` preserves empty
  quoted tokens.
- `test/fakes/FakeSimCtlClient.ts` — `setCommandArgsResult` / `setCommandArgsError` key
  stubs by exact argv (a joined command string cannot represent an empty or spaced value),
  plus `get_app_container` handling on the argv path.

## Testing

New table-driven suite `test/utils/ios-cmdline-tools/simctlArgvIntegrity.test.ts` asserts
the **argv actually issued** (not the return value) for 12 argument shapes: empty string,
`\n`, `\t`, `\r`, double quote, single quote, backslash, literal `C:\new\tab`, spaces,
leading/trailing spaces, shell metacharacters (`$HOME`, backtick, `;`), and unicode.
All 27 tests were red at HEAD and are green with the fix. Existing simctl string
assertions were converted to argv assertions.

## Validation

- [x] `bun run lint` passes
- [x] `bun test` — 8338 pass / 0 fail / 11 skip
- [x] `bun run typecheck` reports no new errors (baseline gate green; note it also reports
      10 baseline errors no longer occur — baseline left unmodified deliberately)
- [x] `bun run build` succeeds
- [x] New code reuses the existing `executeCommandArgs` exec seam; no new helper or dependency

## Device Verification

Not run — no simulator was touched (another session is live-testing against the shared
daemon). All coverage is through the `SimCtlClient` fake/seam.

## Follow-ups

- [#4213](https://github.com/kaeawc/auto-mobile/issues/4213) is the **same bug class** in
  `openLink` (`src/features/action/OpenURL.ts:169,201`), where a URL is interpolated into a
  shell string on both Android and iOS. It does **not** share a code path or helper with
  what this PR changed — `OpenURL` never used `quoteSimctlArg`, and the Android half goes
  through `AdbClient`, a different executor — so this PR does not close it. The iOS half is
  now a one-line change to the same `executeCommandArgs` seam this PR standardizes on; left
  out to keep this PR scoped.
