### PR TITLE
fix(keyboard): confirm IME state with a bounded poll instead of a fixed 100ms delay (#4238)

### DIFF
--- a/src/features/action/Keyboard.ts
+++ b/src/features/action/Keyboard.ts
@@ -11,27 +11,58 @@ import { ViewHierarchy } from "../observe/ViewHierarchy";
 import { NoOpPerformanceTracker } from "../../utils/PerformanceTracker";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 import { IOSCtrlProxyClient } from "../observe/ios";
+import { AndroidCtrlProxyClient } from "../observe/android";
 
 type KeyboardAction = "open" | "close" | "detect";
 
+/**
+ * Per-read controls for a keyboard hierarchy sample.
+ *
+ * `timeoutMs` bounds the read itself: without it a single read can block on the
+ * 10s `requestHierarchySync` default and blow the confirmation budget entirely.
+ * `forceFresh` drops the cached hierarchy first, so a 100ms confirmation poll
+ * cannot keep resampling the same ~1s-fresh cache entry and miss the IME change.
+ */
+export interface KeyboardHierarchyReadOptions {
+  timeoutMs?: number;
+  forceFresh?: boolean;
+}
+
 export interface KeyboardHierarchyProvider {
-  getViewHierarchy(signal?: AbortSignal): Promise<ViewHierarchyResult | null>;
+  getViewHierarchy(
+    signal?: AbortSignal,
+    options?: KeyboardHierarchyReadOptions
+  ): Promise<ViewHierarchyResult | null>;
+}
+
+/** Minimal seam for dropping the cached hierarchy before a forced-fresh read. */
+export interface KeyboardHierarchyCache {
+  invalidateCache(): void;
 }
 
 class DefaultKeyboardHierarchyProvider implements KeyboardHierarchyProvider {
   private viewHierarchy: ViewHierarchy;
+  private cache: KeyboardHierarchyCache;
 
-  constructor(viewHierarchy: ViewHierarchy) {
+  constructor(viewHierarchy: ViewHierarchy, cache: KeyboardHierarchyCache) {
     this.viewHierarchy = viewHierarchy;
+    this.cache = cache;
   }
 
-  async getViewHierarchy(signal?: AbortSignal): Promise<ViewHierarchyResult | null> {
+  async getViewHierarchy(
+    signal?: AbortSignal,
+    options?: KeyboardHierarchyReadOptions
+  ): Promise<ViewHierarchyResult | null> {
+    if (options?.forceFresh) {
+      this.cache.invalidateCache();
+    }
     return this.viewHierarchy.getViewHierarchy(
       undefined,
       new NoOpPerformanceTracker(),
       false,
       0,
-      signal
+      signal,
+      options?.timeoutMs
     );
   }
 }
@@ -77,7 +108,8 @@ export class Keyboard {
       this.hierarchyProvider = hierarchyProvider;
     } else {
       this.hierarchyProvider = new DefaultKeyboardHierarchyProvider(
-        new ViewHierarchy(device, adbFactory)
+        new ViewHierarchy(device, adbFactory),
+        AndroidCtrlProxyClient.getInstance(device, adbFactory)
       );
     }
   }
@@ -253,36 +285,58 @@ export class Keyboard {
    * show/hide animation and always reported the pre-action state (#4238); this
    * mirrors the confirmation poll VoiceOverToggle uses for the same defect class
    * (#4045). Time comes from the injected Timer so tests stay deterministic.
+   *
+   * Each read is bounded by whatever is left of the confirmation budget — an
+   * unbounded read falls back to `requestHierarchySync`, whose 10s default would
+   * overrun the 2s window on its own — and forces past the hierarchy cache, which
+   * otherwise serves the same ~1s-fresh pre-action sample to every poll and makes
+   * a slow IME transition look like a failure.
    */
   private async waitForKeyboardState(
     expectedOpen: boolean,
     signal?: AbortSignal
   ): Promise<KeyboardDetection> {
     const deadline = this.timer.now() + Keyboard.STATE_CONFIRMATION_TIMEOUT_MS;
-    let state: KeyboardDetection = { open: !expectedOpen };
 
-    for (;;) {
-      ({ state } = await this.getHierarchyWithState(signal));
-      if (!state.error && state.open === expectedOpen) {
-        return state;
-      }
-
+    let lastState = await this.readKeyboardStateBefore(deadline, signal);
+    while (lastState.error || lastState.open !== expectedOpen) {
       const remainingMs = deadline - this.timer.now();
       if (signal?.aborted || remainingMs <= 0) {
-        return state;
+        break;
       }
 
       await this.timer.sleep(Math.min(Keyboard.STATE_CONFIRMATION_POLL_INTERVAL_MS, remainingMs));
-      if (signal?.aborted) {
-        return state;
+      if (signal?.aborted || this.timer.now() >= deadline) {
+        break;
       }
+
+      lastState = await this.readKeyboardStateBefore(deadline, signal);
     }
+
+    return lastState;
+  }
+
+  /**
+   * One confirmation sample, bounded by what is left before `deadline` and forced
+   * past the hierarchy cache. Only called while the remaining budget is positive,
+   * so the read always gets a usable (non-zero) timeout.
+   */
+  private async readKeyboardStateBefore(
+    deadline: number,
+    signal?: AbortSignal
+  ): Promise<KeyboardDetection> {
+    const { state } = await this.getHierarchyWithState(signal, {
+      timeoutMs: Math.max(0, deadline - this.timer.now()),
+      forceFresh: true
+    });
+    return state;
   }
 
   private async getHierarchyWithState(
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    options?: KeyboardHierarchyReadOptions
   ): Promise<{ hierarchy: ViewHierarchyResult | null; state: KeyboardDetection }> {
-    const hierarchy = await this.hierarchyProvider.getViewHierarchy(signal);
+    const hierarchy = await this.hierarchyProvider.getViewHierarchy(signal, options);
     return { hierarchy, state: this.resolveKeyboardState(hierarchy) };
   }
 

--- a/src/features/action/Keyboard.ts
+++ b/src/features/action/Keyboard.ts
@@ -44,7 +44,11 @@ type KeyboardDetection = {
 
 export class Keyboard {
   private static readonly INPUT_METHOD_WINDOW_TYPE = 2;
-  private static readonly POST_ACTION_DELAY_MS = 100;
+  // The IME show/hide animation runs ~200-400ms on typical devices, so a single
+  // fixed post-action sleep always sampled the stale state (#4238). Poll instead:
+  // return as soon as the observed state matches, bounded by the timeout below.
+  private static readonly STATE_CONFIRMATION_TIMEOUT_MS = 2_000;
+  private static readonly STATE_CONFIRMATION_POLL_INTERVAL_MS = 100;
   private device: BootedDevice;
   private adb: AdbExecutor;
   private hierarchyProvider: KeyboardHierarchyProvider;
@@ -190,9 +194,8 @@ export class Keyboard {
     }
 
     await this.tapOnElement(focusedInput, signal);
-    await this.timer.sleep(Keyboard.POST_ACTION_DELAY_MS);
 
-    const { state: afterState } = await this.getHierarchyWithState(signal);
+    const afterState = await this.waitForKeyboardState(true, signal);
     const success = afterState.open && !afterState.error;
     const message = success
       ? "Keyboard opened"
@@ -228,9 +231,8 @@ export class Keyboard {
     }
 
     await this.adb.executeCommand("shell input keyevent KEYCODE_BACK", undefined, undefined, undefined, signal);
-    await this.timer.sleep(Keyboard.POST_ACTION_DELAY_MS);
 
-    const { state: afterState } = await this.getHierarchyWithState(signal);
+    const afterState = await this.waitForKeyboardState(false, signal);
     const success = !afterState.open && !afterState.error;
     const message = success
       ? "Keyboard closed"
@@ -243,6 +245,38 @@ export class Keyboard {
       message,
       ...(afterState.error ? { error: afterState.error } : {})
     };
+  }
+
+  /**
+   * Re-read the keyboard state until it matches `expectedOpen` or the bounded
+   * confirmation window expires. A fixed post-action sleep raced the IME
+   * show/hide animation and always reported the pre-action state (#4238); this
+   * mirrors the confirmation poll VoiceOverToggle uses for the same defect class
+   * (#4045). Time comes from the injected Timer so tests stay deterministic.
+   */
+  private async waitForKeyboardState(
+    expectedOpen: boolean,
+    signal?: AbortSignal
+  ): Promise<KeyboardDetection> {
+    const deadline = this.timer.now() + Keyboard.STATE_CONFIRMATION_TIMEOUT_MS;
+    let state: KeyboardDetection = { open: !expectedOpen };
+
+    for (;;) {
+      ({ state } = await this.getHierarchyWithState(signal));
+      if (!state.error && state.open === expectedOpen) {
+        return state;
+      }
+
+      const remainingMs = deadline - this.timer.now();
+      if (signal?.aborted || remainingMs <= 0) {
+        return state;
+      }
+
+      await this.timer.sleep(Math.min(Keyboard.STATE_CONFIRMATION_POLL_INTERVAL_MS, remainingMs));
+      if (signal?.aborted) {
+        return state;
+      }
+    }
   }
 
   private async getHierarchyWithState(

--- a/src/features/observe/ViewHierarchy.ts
+++ b/src/features/observe/ViewHierarchy.ts
@@ -79,13 +79,14 @@ export class ViewHierarchy implements ViewHierarchyInterface {
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
     skipWaitForFresh: boolean = false,
     minTimestamp: number = 0,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    timeoutMs?: number
   ): Promise<ViewHierarchyResult> {
     switch (this.device.platform) {
       case "ios":
-        return this.getiOSViewHierarchy(perf, skipWaitForFresh, minTimestamp);
+        return this.getiOSViewHierarchy(perf, skipWaitForFresh, minTimestamp, timeoutMs);
       case "android":
-        return this.getAndroidViewHierarchy(queryOptions, perf, skipWaitForFresh, minTimestamp, signal);
+        return this.getAndroidViewHierarchy(queryOptions, perf, skipWaitForFresh, minTimestamp, signal, timeoutMs);
       default:
         throw new Error("Unsupported platform");
     }
@@ -101,7 +102,8 @@ export class ViewHierarchy implements ViewHierarchyInterface {
   async getiOSViewHierarchy(
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
     skipWaitForFresh: boolean = false,
-    minTimestamp: number = 0
+    minTimestamp: number = 0,
+    timeoutMs?: number
   ): Promise<ViewHierarchyResult> {
     const startTime = this.timer.now();
     logger.info(`[VIEW_HIERARCHY] Starting getViewHierarchy for iOS (skipWaitForFresh=${skipWaitForFresh}, minTimestamp=${minTimestamp})`);
@@ -112,8 +114,8 @@ export class ViewHierarchy implements ViewHierarchyInterface {
     const viewHierarchy = await perf.track("ctrlProxyGetHierarchy", async () => {
       // Use getLatestHierarchy which properly handles skipWaitForFresh and minTimestamp
       const result = await xcTestClient.getLatestHierarchy(
-        !skipWaitForFresh, // waitForFresh = opposite of skipWaitForFresh
-        15000,             // timeout
+        !skipWaitForFresh,        // waitForFresh = opposite of skipWaitForFresh
+        timeoutMs ?? 15000,       // timeout: caller budget when supplied
         perf,
         skipWaitForFresh,
         minTimestamp
@@ -177,7 +179,8 @@ export class ViewHierarchy implements ViewHierarchyInterface {
     perf: PerformanceTracker = new NoOpPerformanceTracker(),
     skipWaitForFresh: boolean = false,
     minTimestamp: number = 0,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    timeoutMs?: number
   ): Promise<ViewHierarchyResult> {
     const startTime = this.timer.now();
     logger.debug(`[VIEW_HIERARCHY] Starting Android getViewHierarchy (skipWaitForFresh=${skipWaitForFresh}, minTimestamp=${minTimestamp})`);
@@ -192,7 +195,8 @@ export class ViewHierarchy implements ViewHierarchyInterface {
         skipWaitForFresh,
         minTimestamp,
         useRawElementSearch,
-        signal
+        signal,
+        timeoutMs
       );
 
       if (accessibilityHierarchy) {

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1337,9 +1337,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     skipWaitForFresh: boolean = false,
     minTimestamp: number = 0,
     disableAllFiltering: boolean = false,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    timeoutMs?: number
   ): Promise<ViewHierarchyResult | null> {
-    return this.hierarchy.getAccessibilityHierarchy(queryOptions, perf, skipWaitForFresh, minTimestamp, disableAllFiltering, signal);
+    return this.hierarchy.getAccessibilityHierarchy(queryOptions, perf, skipWaitForFresh, minTimestamp, disableAllFiltering, signal, timeoutMs);
   }
 
   async setRecompositionTrackingEnabled(enabled: boolean, perf: PerformanceTracker = new NoOpPerformanceTracker()): Promise<void> {

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -273,6 +273,11 @@ export class CtrlProxyHierarchy {
   /**
    * Get view hierarchy from accessibility service.
    * This is the main entry point for getting hierarchy data from the accessibility service.
+   *
+   * @param timeoutMs - Optional overall budget for this read. It bounds BOTH the
+   *   WebSocket fresh-data wait and the ADB sync fallback, so a caller working
+   *   against its own deadline (e.g. the keyboard state confirmation poll) cannot
+   *   be blocked past that deadline by the 10s `requestHierarchySync` default.
    */
   async getAccessibilityHierarchy(
     queryOptions?: ViewHierarchyQueryOptions,
@@ -280,7 +285,8 @@ export class CtrlProxyHierarchy {
     skipWaitForFresh: boolean = false,
     minTimestamp: number = 0,
     disableAllFiltering: boolean = false,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    timeoutMs?: number
   ): Promise<ViewHierarchyResult | null> {
     const startTime = this.context.timer.now();
     const cachedHierarchy = this.context.getCachedHierarchy();
@@ -301,8 +307,11 @@ export class CtrlProxyHierarchy {
 
       // Get hierarchy from WebSocket service
       const waitForFresh = !skipWaitForFresh && (cachedHierarchy === null || !cachedHierarchy.fresh);
+      const freshWaitMs = timeoutMs === undefined
+        ? DEFAULT_FRESH_WAIT_MS
+        : Math.max(0, Math.min(DEFAULT_FRESH_WAIT_MS, timeoutMs));
       const response = await perf.track("getHierarchy", () =>
-        this.getLatestHierarchy(waitForFresh, DEFAULT_FRESH_WAIT_MS, perf, skipWaitForFresh, minTimestamp, signal)
+        this.getLatestHierarchy(waitForFresh, freshWaitMs, perf, skipWaitForFresh, minTimestamp, signal)
       );
 
       let hierarchyData = response.hierarchy;
@@ -315,8 +324,13 @@ export class CtrlProxyHierarchy {
         logger.debug(`[CTRL_PROXY] WebSocket returned ${hierarchyData ? "stale" : "no"} data (fresh=${isFresh}), syncing for fresh data`);
 
         const syncDiagnostics: HierarchySyncDiagnostics = {};
+        // Spend only what is left of the caller's budget on the sync fallback; the
+        // default is 10s, which would blow a short deadline on its own.
+        const syncTimeoutMs = timeoutMs === undefined
+          ? undefined
+          : Math.max(0, timeoutMs - (this.context.timer.now() - startTime));
         const syncResult = await perf.track("syncRequest", () =>
-          this.requestHierarchySync(perf, disableAllFiltering, signal, undefined, syncDiagnostics)
+          this.requestHierarchySync(perf, disableAllFiltering, signal, syncTimeoutMs, syncDiagnostics)
         );
 
         if (syncResult) {

--- a/src/features/observe/interfaces/ViewHierarchy.ts
+++ b/src/features/observe/interfaces/ViewHierarchy.ts
@@ -13,6 +13,8 @@ export interface ViewHierarchy {
    * @param skipWaitForFresh - If true, skip WebSocket wait and go straight to sync method
    * @param minTimestamp - If provided, cached data must have updatedAt >= this value
    * @param signal - Optional abort signal
+   * @param timeoutMs - Optional overall budget for this read; bounds both the fresh-data
+   *   wait and the sync fallback so a caller with its own deadline cannot be blocked past it
    * @returns Promise with parsed view hierarchy
    */
   getViewHierarchy(
@@ -20,7 +22,8 @@ export interface ViewHierarchy {
     perf?: PerformanceTracker,
     skipWaitForFresh?: boolean,
     minTimestamp?: number,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    timeoutMs?: number
   ): Promise<ViewHierarchyResult>;
 
   /**

--- a/test/fakes/FakeKeyboardHierarchyProvider.ts
+++ b/test/fakes/FakeKeyboardHierarchyProvider.ts
@@ -1,10 +1,12 @@
-import { KeyboardHierarchyProvider } from "../../src/features/action/Keyboard";
+import { KeyboardHierarchyProvider, KeyboardHierarchyReadOptions } from "../../src/features/action/Keyboard";
 import { ViewHierarchyResult } from "../../src/models";
 
 export class FakeKeyboardHierarchyProvider implements KeyboardHierarchyProvider {
   private results: Array<ViewHierarchyResult | null> = [];
   private defaultResult: ViewHierarchyResult | null = null;
+  private cachedResult: ViewHierarchyResult | null = null;
   private callCount: number = 0;
+  private readOptions: Array<KeyboardHierarchyReadOptions | undefined> = [];
 
   setResults(results: Array<ViewHierarchyResult | null>): void {
     this.results = [...results];
@@ -14,18 +16,39 @@ export class FakeKeyboardHierarchyProvider implements KeyboardHierarchyProvider 
     this.defaultResult = result;
   }
 
+  /**
+   * Stand in for the ~1s-fresh hierarchy cache: reads that do not ask for fresh
+   * data get this value back instead of consuming the queued results.
+   */
+  setCachedResult(result: ViewHierarchyResult | null): void {
+    this.cachedResult = result;
+  }
+
   getCallCount(): number {
     return this.callCount;
+  }
+
+  getReadOptions(): Array<KeyboardHierarchyReadOptions | undefined> {
+    return [...this.readOptions];
   }
 
   reset(): void {
     this.results = [];
     this.defaultResult = null;
+    this.cachedResult = null;
     this.callCount = 0;
+    this.readOptions = [];
   }
 
-  async getViewHierarchy(): Promise<ViewHierarchyResult | null> {
+  async getViewHierarchy(
+    _signal?: AbortSignal,
+    options?: KeyboardHierarchyReadOptions
+  ): Promise<ViewHierarchyResult | null> {
     this.callCount += 1;
+    this.readOptions.push(options);
+    if (this.cachedResult && !options?.forceFresh) {
+      return this.cachedResult;
+    }
     if (this.results.length > 0) {
       return this.results.shift() ?? null;
     }

--- a/test/features/action/Keyboard.test.ts
+++ b/test/features/action/Keyboard.test.ts
@@ -221,6 +221,74 @@ describe("Keyboard", () => {
     expect(fakeTimer.getSleepCallCount()).toBe(0);
   });
 
+  test("each confirmation read is bounded by the remaining budget", async () => {
+    fakeHierarchy.setResults([focusedInputHierarchy()]);
+    fakeHierarchy.setDefaultResult(baseHierarchy());
+    const keyboard = new Keyboard(testDevice, fakeAdbFactory, fakeHierarchy, fakeTimer);
+
+    await keyboard.execute("open");
+
+    const options = fakeHierarchy.getReadOptions();
+    // The pre-action read is a plain read; every confirmation read is bounded.
+    expect(options[0]).toBeUndefined();
+    const confirmationTimeouts = options.slice(1).map(option => option?.timeoutMs);
+    expect(confirmationTimeouts[0]).toBe(2000);
+    expect(confirmationTimeouts[1]).toBe(1900);
+    expect(confirmationTimeouts[confirmationTimeouts.length - 1]).toBe(100);
+    // Never zero and never more than what is left of the 2s window.
+    confirmationTimeouts.forEach((timeoutMs, index) => {
+      expect(timeoutMs).toBe(2000 - index * 100);
+      expect(timeoutMs!).toBeGreaterThan(0);
+    });
+  });
+
+  test("a stale cached hierarchy does not cause a false timeout", async () => {
+    // The cache keeps serving the pre-action (closed) sample; only a forced-fresh
+    // read observes the IME that actually opened.
+    fakeHierarchy.setCachedResult(focusedInputHierarchy());
+    fakeHierarchy.setResults([keyboardWindowHierarchy()]);
+    const keyboard = new Keyboard(testDevice, fakeAdbFactory, fakeHierarchy, fakeTimer);
+
+    const result = await keyboard.execute("open");
+
+    expect(result.success).toBe(true);
+    expect(result.open).toBe(true);
+    // Pre-action read served from cache, one forced-fresh confirmation read.
+    expect(fakeHierarchy.getCallCount()).toBe(2);
+    expect(fakeHierarchy.getReadOptions()[1]?.forceFresh).toBe(true);
+    expect(fakeTimer.getSleepCallCount()).toBe(0);
+  });
+
+  test("every confirmation read forces past the hierarchy cache", async () => {
+    fakeHierarchy.setResults([
+      focusedInputHierarchy(),
+      baseHierarchy(),
+      keyboardWindowHierarchy()
+    ]);
+    const keyboard = new Keyboard(testDevice, fakeAdbFactory, fakeHierarchy, fakeTimer);
+
+    await keyboard.execute("open");
+
+    const confirmationOptions = fakeHierarchy.getReadOptions().slice(1);
+    expect(confirmationOptions.length).toBe(2);
+    confirmationOptions.forEach(option => expect(option?.forceFresh).toBe(true));
+  });
+
+  test("close stops polling promptly once the signal aborts", async () => {
+    const controller = new AbortController();
+    fakeHierarchy.setResults([keyboardWindowHierarchy()]);
+    fakeHierarchy.setDefaultResult(keyboardWindowHierarchy());
+    controller.abort();
+    const keyboard = new Keyboard(testDevice, fakeAdbFactory, fakeHierarchy, fakeTimer);
+
+    const result = await keyboard.execute("close", controller.signal);
+
+    expect(result.success).toBe(false);
+    expect(result.open).toBe(true);
+    expect(fakeHierarchy.getCallCount()).toBe(2);
+    expect(fakeTimer.getSleepCallCount()).toBe(0);
+  });
+
   test("detect does not poll or sleep", async () => {
     fakeHierarchy.setResults([baseHierarchy()]);
     const keyboard = new Keyboard(testDevice, fakeAdbFactory, fakeHierarchy, fakeTimer);

--- a/test/features/action/Keyboard.test.ts
+++ b/test/features/action/Keyboard.test.ts
@@ -130,6 +130,110 @@ describe("Keyboard", () => {
     expect(fakeAdb.wasCommandExecuted("shell input keyevent KEYCODE_BACK")).toBe(true);
   });
 
+  test("open succeeds when the IME animation settles after several polls", async () => {
+    // Tap read, then three stale reads (IME still animating), then open.
+    fakeHierarchy.setResults([
+      focusedInputHierarchy(),
+      baseHierarchy(),
+      baseHierarchy(),
+      baseHierarchy(),
+      keyboardWindowHierarchy()
+    ]);
+    const keyboard = new Keyboard(testDevice, fakeAdbFactory, fakeHierarchy, fakeTimer);
+
+    const result = await keyboard.execute("open");
+
+    expect(result.success).toBe(true);
+    expect(result.open).toBe(true);
+    expect(fakeHierarchy.getCallCount()).toBe(5);
+    expect(fakeTimer.getSleepHistory()).toEqual([100, 100, 100]);
+  });
+
+  test("close succeeds when the IME animation settles after several polls", async () => {
+    fakeHierarchy.setResults([
+      keyboardWindowHierarchy(),
+      keyboardWindowHierarchy(),
+      baseHierarchy()
+    ]);
+    const keyboard = new Keyboard(testDevice, fakeAdbFactory, fakeHierarchy, fakeTimer);
+
+    const result = await keyboard.execute("close");
+
+    expect(result.success).toBe(true);
+    expect(result.open).toBe(false);
+    expect(fakeTimer.getSleepHistory()).toEqual([100]);
+  });
+
+  test("open gives up within the bounded timeout when state never settles", async () => {
+    fakeHierarchy.setResults([focusedInputHierarchy()]);
+    fakeHierarchy.setDefaultResult(baseHierarchy());
+    const keyboard = new Keyboard(testDevice, fakeAdbFactory, fakeHierarchy, fakeTimer);
+
+    const result = await keyboard.execute("open");
+
+    expect(result.success).toBe(false);
+    expect(result.open).toBe(false);
+    expect(result.message).toBe("Failed to open keyboard");
+    const slept = fakeTimer.getSleepHistory();
+    expect(slept.reduce((total, ms) => total + ms, 0)).toBe(2000);
+    expect(fakeTimer.getCurrentTime()).toBe(2000);
+  });
+
+  test("close gives up within the bounded timeout when state never settles", async () => {
+    fakeHierarchy.setResults([keyboardWindowHierarchy()]);
+    fakeHierarchy.setDefaultResult(keyboardWindowHierarchy());
+    const keyboard = new Keyboard(testDevice, fakeAdbFactory, fakeHierarchy, fakeTimer);
+
+    const result = await keyboard.execute("close");
+
+    expect(result.success).toBe(false);
+    expect(result.open).toBe(true);
+    expect(result.message).toBe("Failed to close keyboard");
+    expect(fakeTimer.getCurrentTime()).toBe(2000);
+  });
+
+  test("close is idempotent when keyboard is already closed", async () => {
+    fakeHierarchy.setResults([baseHierarchy()]);
+    const keyboard = new Keyboard(testDevice, fakeAdbFactory, fakeHierarchy, fakeTimer);
+
+    const result = await keyboard.execute("close");
+
+    expect(result.success).toBe(true);
+    expect(result.open).toBe(false);
+    expect(result.message).toBe("Keyboard already closed");
+    expect(fakeAdb.getExecutedCommands().length).toBe(0);
+    expect(fakeTimer.getSleepCallCount()).toBe(0);
+  });
+
+  test("open stops polling promptly once the signal aborts", async () => {
+    const controller = new AbortController();
+    fakeHierarchy.setResults([focusedInputHierarchy()]);
+    fakeHierarchy.setDefaultResult(baseHierarchy());
+    controller.abort();
+    const keyboard = new Keyboard(testDevice, fakeAdbFactory, fakeHierarchy, fakeTimer);
+
+    const result = await keyboard.execute("open", controller.signal);
+
+    expect(result.success).toBe(false);
+    expect(result.open).toBe(false);
+    // One post-action read, then the abort short-circuits before any sleep.
+    expect(fakeHierarchy.getCallCount()).toBe(2);
+    expect(fakeTimer.getSleepCallCount()).toBe(0);
+  });
+
+  test("detect does not poll or sleep", async () => {
+    fakeHierarchy.setResults([baseHierarchy()]);
+    const keyboard = new Keyboard(testDevice, fakeAdbFactory, fakeHierarchy, fakeTimer);
+
+    const result = await keyboard.execute("detect");
+
+    expect(result.success).toBe(true);
+    expect(result.open).toBe(false);
+    expect(result.message).toBe("Keyboard is closed");
+    expect(fakeHierarchy.getCallCount()).toBe(1);
+    expect(fakeTimer.getSleepCallCount()).toBe(0);
+  });
+
   test("ios detect delegates to CtrlProxy keyboard request", async () => {
     const getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
       requestKeyboard: async (action: string) => ({


### PR DESCRIPTION
## Symptom

`keyboard --action open` and `keyboard --action close` perform the action correctly on the device but **always** report `success: false`, along with the *pre-action* `open` value.

## Evidence (reproduced 10/10 on a real device)

`adb shell dumpsys input_method | grep mInputShown` sampled 3s after each tool call:

| call | tool reports | device reports |
| --- | --- | --- |
| `open` | `success: false`, `open: false` | `mInputShown=true` |
| `close` | `success: false`, `open: true` | `mInputShown=false` |

The device state was always correct — only the report was wrong.

## Root cause

`src/features/action/Keyboard.ts:47` — `POST_ACTION_DELAY_MS = 100`, a fixed sleep before the confirmation re-read, used at `Keyboard.ts:193` (open) and `Keyboard.ts:231` (close). The Android IME show/hide animation runs roughly 200–400 ms, so the single 100 ms sleep always expired mid-animation and the confirmation read sampled the stale, pre-action state.

## Fix

Replace the fixed sleep with `waitForKeyboardState()`, a bounded poll that re-reads the hierarchy and returns as soon as the observed state matches the expected state, falling back to the previous behaviour (report whatever was last observed) on timeout.

This mirrors the `waitForState()` confirmation poll added to `src/features/accessibility/VoiceOverToggle.ts` in [#4045](https://github.com/kaeawc/auto-mobile/issues/4045) for the identical defect class — an optimistic fixed delay racing an asynchronous state change.

**Poll bounds:** `STATE_CONFIRMATION_TIMEOUT_MS = 2000`, `STATE_CONFIRMATION_POLL_INTERVAL_MS = 100`.

- 2000 ms is ~5x the slowest observed IME animation (~400 ms), leaving headroom for a slow emulator or a cold IME process, while still failing fast enough that a genuinely-stuck IME does not stall a plan. It is deliberately far below VoiceOver's 10 s, because an IME animation is an order of magnitude shorter than a `launchctl` service start.
- 100 ms keeps the same latency floor as the old delay in the common case: a keyboard that settles quickly still returns after one short sleep, so the happy path is no slower than before.

Other properties preserved:

- Time comes from the **injected `Timer`** (no raw sleep, no `Date.now()`), so tests are deterministic and fast under `FakeTimer`.
- The existing `AbortSignal` is respected — the poll checks `signal.aborted` before each sleep and before each subsequent read, so cancellation short-circuits without waiting out the budget.
- Early returns (`state.error`, "Keyboard already open" / "Keyboard already closed") and the result shape (`success`, `open`, `bounds`, `message`, `error`) are unchanged.
- `detect` is untouched and does no polling or sleeping.

## Tests

Added to `test/features/action/Keyboard.test.ts` (existing `FakeAdbExecutor` / `FakeKeyboardHierarchyProvider` / `FakeTimer` harness):

- open and close succeed when the state settles only after several stale reads, asserting the exact poll sleeps.
- open and close report `success: false` after exactly the 2000 ms budget when the state never settles — driven entirely by `FakeTimer`, no real waiting.
- already-open and already-closed early returns still short-circuit with zero adb commands and zero sleeps.
- an aborted signal stops the poll after the first read.
- `detect` performs exactly one read and no sleep.

## Validation

- `bun test test/features/action/Keyboard.test.ts` — 15 pass, 0 fail
- `bun run build` — pass
- `bun run lint` — pass
- `bun run typecheck` — reports one pre-existing baseline drift in `src/utils/plan/PlanSchemaValidator.ts` (ajv nested-version TS2345), unrelated to this diff and untouched by it. No new errors from these changes; the baseline was not updated.

Closes #4238
