### PR TITLE
docs: scope the clickable-reference rule to prose surfaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,11 @@ Bun TypeScript MCP server providing Android & iOS device automation capabilities
 ## Key Rules
 - TypeScript only (no JavaScript)
 - Always write GitHub issue and pull request references as clickable Markdown links.
+  This governs prose surfaces — issue and PR bodies, review comments, commit
+  messages, and Markdown docs. It does NOT apply to references inside source
+  code comments, where the bare `#NNNN` form is the established convention
+  (625 bare references in `src/`, zero linked). Linking there renders as noise
+  in an editor and would make the touched file the only inconsistent one.
 - After implementation changes, run relevant validation commands
 - Write terminal output to `scratch/` when not visible
 - Local validation scripts live under `scripts/` and should almost always be written in bash with shellcheck validation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,11 @@ Node TypeScript MCP server providing Android Debug Bridge (ADB) capabilities thr
 ## Key Rules
 - TypeScript only (no JavaScript)
 - Always write GitHub issue and pull request references as clickable Markdown links.
+  This governs prose surfaces — issue and PR bodies, review comments, commit
+  messages, and Markdown docs. It does NOT apply to references inside source
+  code comments, where the bare `#NNNN` form is the established convention
+  (625 bare references in `src/`, zero linked). Linking there renders as noise
+  in an editor and would make the touched file the only inconsistent one.
 - After implementation changes, run relevant validation commands
 - Write terminal output to `scratch/` when not visible
 - Local validation scripts live under `scripts/` and should almost always be written in bash with shellcheck validation


### PR DESCRIPTION
## Why

This nit has been raised on six separate PRs in the current batch, asking that a bare `#NNNN` in a **source code comment** be rewritten as a clickable Markdown link. Every agent that investigated rejected it, independently, for the same reason. When a rule gets rejected six times for one reason, the rule text is what needs fixing.

## Evidence

```
bare '#NNNN' refs in src/:  625
markdown-linked refs in src/: 0
```

The convention in code has never been Markdown links, and following the rule literally would make whichever file a PR happens to touch the only inconsistent one in the tree.

## What changes

Only the rule's wording, in `AGENTS.md` and `CLAUDE.md`. It now states explicitly that it governs prose surfaces — issue and PR bodies, review comments, commit messages, and Markdown docs — and not references inside source comments.

The rule itself is a good one and is unchanged for prose; several PRs in this batch were caught writing `Closes #NNNN` without a link, which is exactly what it exists to prevent. This only stops it being re-litigated on every PR that adds a code comment.

No code changes.
