### PR TITLE
fix(devices): print device identifiers instead of [object Object] in not-found errors

### DIFF
--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -24,6 +24,27 @@ import { applyAppearanceOnConnect } from "./appearance/applyAppearanceOnConnect"
 import { disableStylusHandwriting } from "./disableStylusHandwriting";
 
 /**
+ * Render a device list for a "not found" error.
+ *
+ * These messages exist to tell the caller which identifier to use instead, so
+ * they must print the identifiers rather than the objects: `BootedDevice[].join()`
+ * stringifies each element to "[object Object]" and destroys the only actionable
+ * part of the message (#4227).
+ *
+ * Both identifiers are shown because callers reason in either — a user reads
+ * "Pixel_9_Pro" in a device picker but must pass the id. Android currently sets
+ * `name === deviceId` (AdbClient.getBootedAndroidDevices), so the redundant
+ * "x (x)" form is collapsed to a single value.
+ */
+function describeDevices(devices: BootedDevice[]): string {
+  return devices
+    .map(device => (device.name && device.name !== device.deviceId
+      ? `${device.name} (${device.deviceId})`
+      : device.deviceId))
+    .join(", ") || "none";
+}
+
+/**
  * Provider interface for device clients - enables dependency injection for testing
  */
 export interface DeviceClientProvider {
@@ -382,7 +403,7 @@ export class DeviceSessionManager implements DeviceSessionManager {
       if (!providedDevice) {
         throw new ActionableError(
           `Device ${providedDeviceId} not found on ${platform} platform. ` +
-          `Available ${platform} devices: ${platformDevices.join(", ") || "none"}`
+          `Available ${platform} devices: ${describeDevices(platformDevices)}`
         );
       }
       selectedDevice = providedDevice;
@@ -459,7 +480,7 @@ export class DeviceSessionManager implements DeviceSessionManager {
 
     if (!device) {
       throw new ActionableError(
-        `Android device ${deviceId} is not connected. Available devices: ${allDevices.join(", ") || "none"}`
+        `Android device ${deviceId} is not connected. Available devices: ${describeDevices(allDevices)}`
       );
     }
 

--- a/test/utils/DeviceSessionManager.test.ts
+++ b/test/utils/DeviceSessionManager.test.ts
@@ -694,3 +694,88 @@ describe("DeviceSessionManager dual-platform resolution", () => {
     expect(fakeDeviceUtils.getWaitForDeviceReadyChildProcess()).toBe(childProcess);
   });
 });
+
+describe("DeviceSessionManager device-list error formatting (#4227)", () => {
+  // These messages exist to tell the caller which identifier to use instead.
+  // Joining BootedDevice objects renders "[object Object]", destroying the only
+  // actionable part of the error.
+
+  function makeProvider(devices: BootedDevice[]): FakeDeviceClientProvider {
+    const adb = new FakeAdbExecutor();
+    adb.setDevices(devices);
+    return new FakeDeviceClientProvider(adb, new FakeDeviceUtils(), undefined, {
+      window: makeReadyWindow(),
+      ctrlProxyManager: new FakeCtrlProxyManager(),
+      ctrlProxyClient: stubAndroidCtrlProxy({ isConnected: () => true }),
+    });
+  }
+
+  const androidDevice: BootedDevice = {
+    name: "Pixel_9_Pro",
+    platform: "android",
+    deviceId: "emulator-5554",
+  };
+
+  test("ensureDeviceReady names the available devices instead of [object Object]", async () => {
+    const manager = DeviceSessionManager.createInstance(makeProvider([androidDevice]));
+
+    await expect(
+      manager.ensureDeviceReady("android", "no-such-device", { skipCtrlProxyDownload: true })
+    ).rejects.toThrow(/emulator-5554/);
+  });
+
+  test("ensureDeviceReady never renders [object Object]", async () => {
+    const manager = DeviceSessionManager.createInstance(makeProvider([androidDevice]));
+
+    let message = "";
+    try {
+      await manager.ensureDeviceReady("android", "no-such-device", { skipCtrlProxyDownload: true });
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(message).not.toContain("[object Object]");
+  });
+
+  test("ensureDeviceReady still reports 'none' when no devices are present", async () => {
+    const manager = DeviceSessionManager.createInstance(makeProvider([]));
+
+    let message = "";
+    try {
+      await manager.ensureDeviceReady("android", "no-such-device", { skipCtrlProxyDownload: true });
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(message).not.toContain("[object Object]");
+    expect(message).toContain("none");
+  });
+
+  test("verifyAndroidDevice names the available devices instead of [object Object]", async () => {
+    const manager = DeviceSessionManager.createInstance(makeProvider([androidDevice]));
+
+    let message = "";
+    try {
+      await manager.verifyAndroidDevice("no-such-device");
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(message).not.toContain("[object Object]");
+    expect(message).toContain("Pixel_9_Pro");
+  });
+
+  test("verifyAndroidDevice still reports 'none' when no devices are present", async () => {
+    const manager = DeviceSessionManager.createInstance(makeProvider([]));
+
+    let message = "";
+    try {
+      await manager.verifyAndroidDevice("no-such-device");
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+
+    expect(message).toContain("none");
+    expect(message).not.toContain("[object Object]");
+  });
+});


### PR DESCRIPTION
## Summary

Both device "not found" errors in `DeviceSessionManager` joined `BootedDevice[]` directly, so `Array.prototype.join` stringified each element and the message rendered as `[object Object]` — destroying the only actionable part of the error, which exists to tell the caller which identifier to use instead.

## Linked Issue

Closes #4227

## Bug / Regression Context

- **Observed symptom:**
  ```
  Error: Device nope-android not found on android platform. Available android devices: [object Object]
  Error: Device nope-ios not found on ios platform. Available ios devices: [object Object]
  ```
- **Repro steps / conditions:** call `setActiveDevice` with an id that does not match, with at least one device connected. Found during a manual-test iteration over `0.0.44..main`.
- **Prior attempts:** none — the formatting dates to `55d35a6dc` (2025-12-29) and is not a regression from the recent device-tooling refactors (#4121, #4199).

## Changes

- New `describeDevices()` helper in `src/utils/DeviceSessionManager.ts`, used by both call sites.
- `ensureDeviceReady` (`:385`) — the path `setActiveDevice` takes.
- `verifyAndroidDevice` (`:462`) — **the same bug**, found by the sweep the issue asked for. Not in the issue's proposed diff.

The helper prints `name (deviceId)` when the two differ and collapses to a single value when equal — which is the case for booted Android devices today, since `AdbClient.getBootedAndroidDevices` sets `name === deviceId` (`AdbClient.ts:792`). Without that collapse the message would read `emulator-5554 (emulator-5554)`.

`|| "none"` for an empty list is preserved: `join` returns `""` there, so the fallback still fires.

Worth noting the `find()` immediately above each message already reached through to the correct field — only the formatting was wrong.

## Not in scope

- **`LaunchApp.ts:576/580`** also joins in a log line, but `installedApps` is `Promise<string[]>` (`InstalledAppsProvider:31`), so joining is correct. No change.
- **`setActiveDevice`'s schema.** `deviceId` stays required and unchanged.
- **`verifyAndroidDevice` matching `device.name` against a parameter named `deviceId`** — a latent trap that works today only because Android sets the two fields equal. Filed separately as #4244; this PR only fixes its message.

## Validation

- [x] `bun test` — **8604 pass, 11 skip, 0 fail** (673 files)
- [x] `bun run build` — pass
- [x] `bun run lint` — pass
- [x] `bun run typecheck` — pass
- [x] 5 new tests in `test/utils/DeviceSessionManager.test.ts`

## Acceptance criteria

| # | Criterion | Pinned by |
|---|---|---|
| AC1 | Not-found error lists real identifiers, never `[object Object]` | `ensureDeviceReady names the available devices…`, `…never renders [object Object]` |
| AC2 | Empty list still renders `none` | `ensureDeviceReady still reports 'none'…`, `verifyAndroidDevice still reports 'none'…` |
| AC3 | Same bug at `verifyAndroidDevice` fixed | `verifyAndroidDevice names the available devices…` |

The three `[object Object]` tests were confirmed **red first**, failing with the literal `Available devices: [object Object]`. The two `none` tests pass pre-change by design — they are regression guards for the empty-list fallback, not red tests.
