### PR TITLE
fix(cli): coerce --cli values by declared schema type instead of JSON.parse

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -146,7 +146,7 @@ function getDeclaredParamTypes(toolName: string): Record<string, string> | null 
   for (const shape of shapes) {
     for (const [key, value] of Object.entries(shape)) {
       const types = byParam.get(key) ?? new Set<string>();
-      types.add(getCliHelpParameterInfo(value).typeName);
+      types.add(resolveDeclaredType(value));
       byParam.set(key, types);
     }
   }
@@ -156,6 +156,52 @@ function getDeclaredParamTypes(toolName: string): Record<string, string> | null 
       .filter(([, types]) => types.size === 1)
       .map(([key, types]) => [key, [...types][0]])
   );
+}
+
+/**
+ * The effective declared type of a parameter, seeing through wrappers.
+ *
+ * `getCliHelpParameterInfo` unwraps `optional` only, so a wrapped param reports
+ * the wrapper (`nullable`, `default`) instead of the type underneath and falls
+ * back to JSON coercion — `setKeyValue --value 12345` sends the number `12345`
+ * even though `storageTools.ts` declares `z.string().nullable()`. Wrappers are
+ * peeled here so the inner type decides the coercion.
+ *
+ * A `literal` resolves to the runtime type of its value, so `z.literal("copy")`
+ * coerces as a string rather than falling through.
+ */
+const SCHEMA_WRAPPER_TYPES = new Set([
+  "optional", "nullable", "default", "readonly", "catch", "branded", "lazy"
+]);
+
+/** The zod type name of a schema, normalized ("ZodString" -> "string"). */
+function schemaTypeName(schema: any): string {
+  const raw = schema?._def?.typeName ?? schema?._def?.type ?? "unknown";
+  return String(raw).replace(/^Zod/, "").toLowerCase();
+}
+
+/** The schema a wrapper wraps; the key varies across zod versions. */
+function unwrapSchema(schema: any): any {
+  const definition = schema?._def;
+  return definition?.innerType ?? definition?.type ?? definition?.schema ?? null;
+}
+
+function resolveDeclaredType(schema: any): string {
+  let current = schema;
+
+  for (let depth = 0; depth < 10 && current; depth++) {
+    const name = schemaTypeName(current);
+
+    if (name === "literal") {
+      return typeof (current._def?.value ?? current._def?.values?.[0]);
+    }
+    if (!SCHEMA_WRAPPER_TYPES.has(name)) {
+      return name;
+    }
+    current = unwrapSchema(current);
+  }
+
+  return "unknown";
 }
 
 /**

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -104,8 +104,17 @@ function tryParseJsonToken(raw: string): { parsed: boolean; value: unknown } {
   }
 }
 
-function coerceCliValue(raw: string, typeName: string | undefined): unknown {
+function coerceCliValue(raw: string, declared: DeclaredType | undefined): unknown {
   const bestEffort = (): unknown => tryParseJsonToken(raw).value;
+
+  // A nullable param must still be able to receive an explicit JSON null --
+  // storageTools removes a key only when `value === null`, so turning the token
+  // into the string "null" would overwrite it instead of clearing it.
+  if (declared?.nullable && raw === "null") {
+    return null;
+  }
+
+  const typeName = declared?.type;
 
   switch (typeName) {
     // Enums are string-valued here (e.g. --action start); treating them as
@@ -160,7 +169,7 @@ function asDeclaredNumber(raw: string): unknown {
  * the old JSON coercion. Registration is idempotent (the registry is a Map keyed
  * by tool name), so calling it per invocation is safe.
  */
-function getDeclaredParamTypes(toolName: string): Record<string, string> | null {
+function getDeclaredParamTypes(toolName: string): Record<string, DeclaredType> | null {
   initializeCliTools();
   const tool = ToolRegistry.getTool(toolName);
   if (!tool) {
@@ -175,19 +184,22 @@ function getDeclaredParamTypes(toolName: string): Record<string, string> | null 
   // A param declared with different types across union branches cannot be
   // coerced unambiguously from the token alone, so it is omitted and falls back
   // to best-effort parsing rather than being coerced to the wrong branch's type.
-  const byParam = new Map<string, Set<string>>();
+  // Nullability is unioned: if any branch accepts null, a JSON null must survive.
+  const byParam = new Map<string, { types: Set<string>; nullable: boolean }>();
   for (const shape of shapes) {
     for (const [key, value] of Object.entries(shape)) {
-      const types = byParam.get(key) ?? new Set<string>();
-      types.add(resolveDeclaredType(value));
-      byParam.set(key, types);
+      const declared = resolveDeclaredType(value);
+      const entry = byParam.get(key) ?? { types: new Set<string>(), nullable: false };
+      entry.types.add(declared.type);
+      entry.nullable = entry.nullable || declared.nullable;
+      byParam.set(key, entry);
     }
   }
 
   return Object.fromEntries(
     [...byParam.entries()]
-      .filter(([, types]) => types.size === 1)
-      .map(([key, types]) => [key, [...types][0]])
+      .filter(([, entry]) => entry.types.size === 1)
+      .map(([key, entry]) => [key, { type: [...entry.types][0], nullable: entry.nullable }])
   );
 }
 
@@ -219,22 +231,32 @@ function unwrapSchema(schema: any): any {
   return definition?.innerType ?? definition?.type ?? definition?.schema ?? null;
 }
 
-function resolveDeclaredType(schema: any): string {
+interface DeclaredType {
+  type: string;
+  /** True when a JSON `null` is a legal value and must survive coercion. */
+  nullable: boolean;
+}
+
+function resolveDeclaredType(schema: any): DeclaredType {
   let current = schema;
+  let nullable = false;
 
   for (let depth = 0; depth < 10 && current; depth++) {
     const name = schemaTypeName(current);
 
+    if (name === "nullable") {
+      nullable = true;
+    }
     if (name === "literal") {
-      return typeof (current._def?.value ?? current._def?.values?.[0]);
+      return { type: typeof (current._def?.value ?? current._def?.values?.[0]), nullable };
     }
     if (!SCHEMA_WRAPPER_TYPES.has(name)) {
-      return name;
+      return { type: name, nullable };
     }
     current = unwrapSchema(current);
   }
 
-  return "unknown";
+  return { type: "unknown", nullable };
 }
 
 /**

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -133,13 +133,60 @@ function getDeclaredParamTypes(toolName: string): Record<string, string> | null 
   if (!tool) {
     return null;
   }
-  const shape = getCliHelpSchemaShape(tool.schema);
-  if (!shape) {
+
+  const shapes = collectSchemaShapes(tool.schema);
+  if (shapes.length === 0) {
     return null;
   }
+
+  // A param declared with different types across union branches cannot be
+  // coerced unambiguously from the token alone, so it is omitted and falls back
+  // to best-effort parsing rather than being coerced to the wrong branch's type.
+  const byParam = new Map<string, Set<string>>();
+  for (const shape of shapes) {
+    for (const [key, value] of Object.entries(shape)) {
+      const types = byParam.get(key) ?? new Set<string>();
+      types.add(getCliHelpParameterInfo(value).typeName);
+      byParam.set(key, types);
+    }
+  }
+
   return Object.fromEntries(
-    Object.entries(shape).map(([key, value]) => [key, getCliHelpParameterInfo(value).typeName])
+    [...byParam.entries()]
+      .filter(([, types]) => types.size === 1)
+      .map(([key, types]) => [key, [...types][0]])
   );
+}
+
+/**
+ * Every object shape a tool's schema can present.
+ *
+ * Union-rooted tools (`clipboard`, `deviceSnapshot`, and `postNotification` via a
+ * pipe into a union) have no single shape, so a lookup that only understands a
+ * flat object returns nothing and their params silently keep the old JSON
+ * coercion — `clipboard --action copy --text 12345` would still send a number.
+ * Branches are collected so those tools are typed too.
+ */
+function collectSchemaShapes(schema: any): Record<string, any>[] {
+  const definition = schema?._def;
+  if (!definition) {
+    return [];
+  }
+
+  if (definition.shape) {
+    return [definition.shape];
+  }
+
+  const options = definition.options ?? definition.out?._def?.options;
+  if (Array.isArray(options)) {
+    return options.flatMap((option: any) => collectSchemaShapes(option));
+  }
+
+  if (definition.out) {
+    return collectSchemaShapes(definition.out);
+  }
+
+  return [];
 }
 
 export function parseCliArgs(args: string[]): { toolName: string; sessionUuid?: string; params: Record<string, any> } {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -88,26 +88,34 @@ function initializeCliTools(): void {
  * best-effort JSON behaviour so unknown tools and undeclared params are
  * unaffected.
  */
+/**
+ * Parse a CLI token as JSON, reporting whether it was JSON at all.
+ *
+ * A token that is not JSON is the common case, not an error — `--text plain` and
+ * `--action tap` are ordinary input — so the failure is logged at debug and the
+ * caller decides what the raw token means.
+ */
+function tryParseJsonToken(raw: string): { parsed: boolean; value: unknown } {
+  try {
+    return { parsed: true, value: JSON.parse(raw) };
+  } catch (error) {
+    logger.debug(`[cli] value is not JSON, treating as a raw token: ${raw} (${error})`);
+    return { parsed: false, value: raw };
+  }
+}
+
 function coerceCliValue(raw: string, typeName: string | undefined): unknown {
-  const bestEffort = (): unknown => {
-    try {
-      return JSON.parse(raw);
-    } catch {
-      return raw;
-    }
-  };
+  const bestEffort = (): unknown => tryParseJsonToken(raw).value;
 
   switch (typeName) {
     // Enums are string-valued here (e.g. --action start); treating them as
     // strings avoids a member that happens to look numeric being coerced.
     case "string":
     case "enum":
-      return raw;
+      return asDeclaredString(raw);
     case "number":
-    case "bigint": {
-      const parsed = Number(raw);
-      return Number.isNaN(parsed) ? bestEffort() : parsed;
-    }
+    case "bigint":
+      return asDeclaredNumber(raw);
     case "boolean":
       if (raw === "true") { return true; }
       if (raw === "false") { return false; }
@@ -115,6 +123,31 @@ function coerceCliValue(raw: string, typeName: string | undefined): unknown {
     default:
       return bestEffort();
   }
+}
+
+/**
+ * A string param's value.
+ *
+ * The bare token is the answer, except when the caller JSON-encoded it —
+ * `--text '"12345"'` must still yield `12345`, not a token with literal quote
+ * characters, since generated wrappers legitimately encode scalars that way.
+ */
+function asDeclaredString(raw: string): string {
+  const { parsed, value } = tryParseJsonToken(raw);
+  return parsed && typeof value === "string" ? value : raw;
+}
+
+/**
+ * A number param's value, or the raw token when it is not a JSON number.
+ *
+ * `Number()` accepts things JSON does not — `""` and `" "` become `0`, `"0x10"`
+ * becomes `16` — which would silently pass a wrong value to the daemon instead of
+ * letting schema validation reject a bad argument. Returning the raw token keeps
+ * the rejection.
+ */
+function asDeclaredNumber(raw: string): unknown {
+  const { parsed, value } = tryParseJsonToken(raw);
+  return parsed && typeof value === "number" && Number.isFinite(value) ? value : raw;
 }
 
 /**

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,6 +16,23 @@ import { registerPlanTools } from "../server/planTools";
 import { registerDoctorTools } from "../server/doctorTools";
 import { registerVideoRecordingTools } from "../server/videoRecordingTools";
 import { registerNotificationTools } from "../server/notificationTools";
+import { registerAccessibilityFocusTools } from "../server/accessibilityFocusTools";
+import { registerAccessibilityTools } from "../server/accessibilityTools";
+import { registerAppFileTools } from "../server/appFileTools";
+import { registerBarrierTools } from "../server/barrierTools";
+import { registerBiometricTools } from "../server/biometricTools";
+import { registerCriticalSectionTools } from "../server/criticalSectionTools";
+import { registerDatabaseTools } from "../server/databaseTools";
+import { registerDebugTools } from "../server/debugTools";
+import { registerDeepLinkTools } from "../server/deepLinkTools";
+import { registerFormTools } from "../server/formTools";
+import { registerHighlightTools } from "../server/highlightTools";
+import { registerNavigationTools } from "../server/navigationTools";
+import { registerNetworkTools } from "../server/networkTools";
+import { registerPreferenceTools } from "../server/preferenceTools";
+import { registerSnapshotTools } from "../server/snapshotTools";
+import { registerStorageTools } from "../server/storageTools";
+import { registerTelephonyTools } from "../server/telephonyTools";
 
 type CliHelpSchemaShape = Record<string, any> | undefined;
 interface CliHelpParameterInfo {
@@ -37,10 +54,95 @@ function initializeCliTools(): void {
   registerDoctorTools();
   registerVideoRecordingTools();
   registerNotificationTools();
+  registerAccessibilityFocusTools();
+  registerAccessibilityTools();
+  registerAppFileTools();
+  registerBarrierTools();
+  registerBiometricTools();
+  registerCriticalSectionTools();
+  registerDatabaseTools();
+  registerDebugTools();
+  registerDeepLinkTools();
+  registerFormTools();
+  registerHighlightTools();
+  registerNavigationTools();
+  registerNetworkTools();
+  registerPreferenceTools();
+  registerSnapshotTools();
+  registerStorageTools();
+  registerTelephonyTools();
 }
 
 // Parse CLI arguments into tool name, session UUID, and parameters
-function parseCliArgs(args: string[]): { toolName: string; sessionUuid?: string; params: Record<string, any> } {
+/**
+ * Coerce a raw CLI token using the tool's declared zod type.
+ *
+ * Running every value through `JSON.parse` made numeric-looking strings
+ * unpassable: `JSON.parse("12345")` yields a number, so `inputText --text 12345`
+ * and `sendSms --phoneNumber 5551234567` were rejected as
+ * "expected string, received number" (#4241). A phone number, PIN, OTP or zip
+ * code is a string whose natural value is digits, and the token alone cannot say
+ * which the caller meant — only the schema can.
+ *
+ * The declared type wins where we know it; otherwise we keep the previous
+ * best-effort JSON behaviour so unknown tools and undeclared params are
+ * unaffected.
+ */
+function coerceCliValue(raw: string, typeName: string | undefined): unknown {
+  const bestEffort = (): unknown => {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return raw;
+    }
+  };
+
+  switch (typeName) {
+    // Enums are string-valued here (e.g. --action start); treating them as
+    // strings avoids a member that happens to look numeric being coerced.
+    case "string":
+    case "enum":
+      return raw;
+    case "number":
+    case "bigint": {
+      const parsed = Number(raw);
+      return Number.isNaN(parsed) ? bestEffort() : parsed;
+    }
+    case "boolean":
+      if (raw === "true") { return true; }
+      if (raw === "false") { return false; }
+      return bestEffort();
+    default:
+      return bestEffort();
+  }
+}
+
+/**
+ * Declared parameter types for a tool, or null when the tool is unknown.
+ *
+ * Registers the tool categories first: `runCliCommand` only calls
+ * `initializeCliTools()` on the no-args and `help` branches, not on the
+ * tool-execution path, so without this the registry is empty exactly when a real
+ * `--cli <tool>` invocation needs it and every value would silently fall back to
+ * the old JSON coercion. Registration is idempotent (the registry is a Map keyed
+ * by tool name), so calling it per invocation is safe.
+ */
+function getDeclaredParamTypes(toolName: string): Record<string, string> | null {
+  initializeCliTools();
+  const tool = ToolRegistry.getTool(toolName);
+  if (!tool) {
+    return null;
+  }
+  const shape = getCliHelpSchemaShape(tool.schema);
+  if (!shape) {
+    return null;
+  }
+  return Object.fromEntries(
+    Object.entries(shape).map(([key, value]) => [key, getCliHelpParameterInfo(value).typeName])
+  );
+}
+
+export function parseCliArgs(args: string[]): { toolName: string; sessionUuid?: string; params: Record<string, any> } {
   if (args.length === 0) {
     throw new ActionableError("No tool name provided. Usage: --cli [--session-uuid <uuid>] <tool-name> [--param value ...]");
   }
@@ -59,6 +161,7 @@ function parseCliArgs(args: string[]): { toolName: string; sessionUuid?: string;
 
   const toolName = args[toolNameIndex];
   const params: Record<string, any> = {};
+  const declaredTypes = getDeclaredParamTypes(toolName);
 
   // Parse remaining arguments as key-value pairs or boolean flags
   for (let i = toolNameIndex + 1; i < args.length; i++) {
@@ -82,13 +185,7 @@ function parseCliArgs(args: string[]): { toolName: string; sessionUuid?: string;
       // Key-value pair
       i++; // Skip the value in the next iteration
 
-      // Try to parse as JSON, fallback to string
-      try {
-        params[paramName] = JSON.parse(nextArg);
-      } catch {
-        // If not valid JSON, treat as string
-        params[paramName] = nextArg;
-      }
+      params[paramName] = coerceCliValue(nextArg, declaredTypes?.[paramName]);
     }
   }
 
@@ -364,10 +461,12 @@ Options:
 
 Parameters:
   Parameters are passed as --key value pairs
-  Values are parsed as JSON if possible, otherwise as strings
+  Values are converted using the tool's declared parameter type
+  Strings: --text 12345 stays the string "12345"
   Boolean values: --flag true or --flag false
   Numbers: --count 5
   Objects: --options '{"key": "value"}'
+  Unknown tools or parameters fall back to JSON-if-possible, otherwise string
 
 Session-based Execution:
   When using --session-uuid, the tool will be executed on the device assigned to that session.

--- a/test/cli/parseCliArgsCoercion.test.ts
+++ b/test/cli/parseCliArgsCoercion.test.ts
@@ -105,3 +105,45 @@ describe("parseCliArgs coercion for union-rooted schemas (#4241 review)", () => 
     expect(typeof params.title).toBe("string");
   });
 });
+
+describe("parseCliArgs coercion sees through schema wrappers (#4241 review)", () => {
+  // getCliHelpParameterInfo unwraps `optional` only, so a param wrapped in
+  // nullable/default reported the wrapper and fell back to JSON coercion.
+
+  test("a default-wrapped enum still coerces as a string", () => {
+    const { params } = parseCliArgs([
+      "tapOn", "--platform", "android", "--selector", '{"text":"x"}', "--action", "tap"
+    ]);
+
+    expect(params.action).toBe("tap");
+    expect(typeof params.action).toBe("string");
+  });
+
+  test("a default-wrapped number still coerces as a number", () => {
+    const { params } = parseCliArgs([
+      "executePlan", "--platform", "android", "--planContent", "x", "--startStep", "3"
+    ]);
+
+    expect(params.startStep).toBe(3);
+    expect(typeof params.startStep).toBe("number");
+  });
+
+  test("a nullable string keeps a numeric-looking value as a string", async () => {
+    // setKeyValue is embeddedSdkOnly, so it is only visible to the registry --
+    // and only callable at all -- in embedded-SDK mode.
+    const { serverConfig } = await import("../../src/utils/ServerConfig");
+    const previous = serverConfig.isEmbeddedSdkEnabled();
+    serverConfig.setEmbeddedSdkEnabled(true);
+    try {
+      const { params } = parseCliArgs([
+        "setKeyValue", "--platform", "android", "--appId", "com.example",
+        "--name", "prefs", "--key", "pin", "--type", "STRING", "--value", "12345"
+      ]);
+
+      expect(params.value).toBe("12345");
+      expect(typeof params.value).toBe("string");
+    } finally {
+      serverConfig.setEmbeddedSdkEnabled(previous);
+    }
+  });
+});

--- a/test/cli/parseCliArgsCoercion.test.ts
+++ b/test/cli/parseCliArgsCoercion.test.ts
@@ -147,3 +147,45 @@ describe("parseCliArgs coercion sees through schema wrappers (#4241 review)", ()
     }
   });
 });
+
+describe("parseCliArgs preserves JSON-encoded scalars and rejects bad numbers (#4241 review)", () => {
+  test("a JSON-encoded string for a string param unwraps to the inner string", () => {
+    const { params } = parseCliArgs(["inputText", "--platform", "android", "--text", '"12345"']);
+
+    expect(params.text).toBe("12345");
+  });
+
+  test("a JSON-encoded string containing spaces unwraps", () => {
+    const { params } = parseCliArgs(["inputText", "--platform", "android", "--text", '"a b"']);
+
+    expect(params.text).toBe("a b");
+  });
+
+  test("a bare token for a string param is unchanged", () => {
+    const { params } = parseCliArgs(["inputText", "--platform", "android", "--text", "plain"]);
+
+    expect(params.text).toBe("plain");
+  });
+
+  test.each([
+    ["", "empty"],
+    [" ", "whitespace"],
+    ["0x10", "hex"],
+    ["[]", "array"],
+  ])("a non-JSON number token (%p, %s) is left for schema validation to reject", raw => {
+    const { params } = parseCliArgs(["startDevice", "--platform", "ios", "--timeout-ms", raw]);
+
+    expect(typeof params.timeoutMs).toBe("string");
+    expect(params.timeoutMs).toBe(raw);
+  });
+
+  test.each([
+    ["12", 12],
+    ["1e3", 1000],
+    ["-5", -5],
+  ])("a valid JSON number token (%p) still coerces to %p", (raw, expected) => {
+    const { params } = parseCliArgs(["startDevice", "--platform", "ios", "--timeout-ms", raw]);
+
+    expect(params.timeoutMs).toBe(expected);
+  });
+});

--- a/test/cli/parseCliArgsCoercion.test.ts
+++ b/test/cli/parseCliArgsCoercion.test.ts
@@ -72,3 +72,36 @@ describe("parseCliArgs schema-aware coercion (#4241)", () => {
     expect(params.raw).toBe(true);
   });
 });
+
+describe("parseCliArgs coercion for union-rooted schemas (#4241 review)", () => {
+  // clipboard / deviceSnapshot are z.union at the root, and postNotification is a
+  // pipe into a union, so a shape lookup that only understands a flat object
+  // returns nothing and these tools kept the old JSON coercion.
+
+  test("clipboard --text keeps a numeric-looking value as a string", () => {
+    const { params } = parseCliArgs([
+      "clipboard", "--platform", "android", "--action", "copy", "--text", "12345"
+    ]);
+
+    expect(params.text).toBe("12345");
+    expect(typeof params.text).toBe("string");
+  });
+
+  test("deviceSnapshot --snapshotName keeps a numeric-looking value as a string", () => {
+    const { params } = parseCliArgs([
+      "deviceSnapshot", "--platform", "android", "--action", "capture", "--snapshotName", "20260722"
+    ]);
+
+    expect(params.snapshotName).toBe("20260722");
+    expect(typeof params.snapshotName).toBe("string");
+  });
+
+  test("postNotification --title keeps a numeric-looking value as a string", () => {
+    const { params } = parseCliArgs([
+      "postNotification", "--platform", "android", "--title", "911", "--body", "test"
+    ]);
+
+    expect(params.title).toBe("911");
+    expect(typeof params.title).toBe("string");
+  });
+});

--- a/test/cli/parseCliArgsCoercion.test.ts
+++ b/test/cli/parseCliArgsCoercion.test.ts
@@ -189,3 +189,47 @@ describe("parseCliArgs preserves JSON-encoded scalars and rejects bad numbers (#
     expect(params.timeoutMs).toBe(expected);
   });
 });
+
+describe("parseCliArgs preserves JSON null for nullable params (#4241 review)", () => {
+  async function withEmbeddedSdk<T>(run: () => T): Promise<T> {
+    const { serverConfig } = await import("../../src/utils/ServerConfig");
+    const previous = serverConfig.isEmbeddedSdkEnabled();
+    serverConfig.setEmbeddedSdkEnabled(true);
+    try {
+      return run();
+    } finally {
+      serverConfig.setEmbeddedSdkEnabled(previous);
+    }
+  }
+
+  const setKeyValue = (value: string) => [
+    "setKeyValue", "--platform", "android", "--appId", "com.example",
+    "--name", "prefs", "--key", "k", "--type", "STRING", "--value", value
+  ];
+
+  test("an explicit null reaches a nullable param as null", async () => {
+    // storageTools removes the key only when value === null; the literal string
+    // "null" would overwrite it instead.
+    const params = await withEmbeddedSdk(() => parseCliArgs(setKeyValue("null")).params);
+
+    expect(params.value).toBeNull();
+  });
+
+  test("a nullable param still keeps other numeric-looking strings as strings", async () => {
+    const params = await withEmbeddedSdk(() => parseCliArgs(setKeyValue("12345")).params);
+
+    expect(params.value).toBe("12345");
+  });
+
+  test("a value merely containing 'null' is untouched", async () => {
+    const params = await withEmbeddedSdk(() => parseCliArgs(setKeyValue("null-ish")).params);
+
+    expect(params.value).toBe("null-ish");
+  });
+
+  test("a non-nullable string param keeps the literal token 'null'", () => {
+    const { params } = parseCliArgs(["inputText", "--platform", "android", "--text", "null"]);
+
+    expect(params.text).toBe("null");
+  });
+});

--- a/test/cli/parseCliArgsCoercion.test.ts
+++ b/test/cli/parseCliArgsCoercion.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { parseCliArgs } from "../../src/cli";
+
+// The CLI ran every value through JSON.parse, so a numeric-looking string
+// argument arrived as a number and string-typed params rejected it (#4241).
+// Coercion must follow the tool's declared zod type, not the token's shape.
+
+describe("parseCliArgs schema-aware coercion (#4241)", () => {
+  test("keeps a numeric-looking value as a string for a string-typed param", () => {
+    const { params } = parseCliArgs(["inputText", "--platform", "android", "--text", "12345"]);
+
+    expect(params.text).toBe("12345");
+    expect(typeof params.text).toBe("string");
+  });
+
+  test("keeps an all-digit phone number as a string", () => {
+    const { params } = parseCliArgs([
+      "sendSms", "--platform", "android", "--phoneNumber", "5551234567", "--message", "hi"
+    ]);
+
+    expect(params.phoneNumber).toBe("5551234567");
+    expect(typeof params.phoneNumber).toBe("string");
+  });
+
+  test("still coerces a number-typed param to a number", () => {
+    const { params } = parseCliArgs([
+      "videoRecording", "--platform", "android", "--action", "start", "--maxDuration", "240"
+    ]);
+
+    expect(params.maxDuration).toBe(240);
+    expect(typeof params.maxDuration).toBe("number");
+  });
+
+  test("still coerces a boolean-typed param to a boolean", () => {
+    const { params } = parseCliArgs(["observe", "--platform", "android", "--raw", "true"]);
+
+    expect(params.raw).toBe(true);
+    expect(typeof params.raw).toBe("boolean");
+  });
+
+  test("still parses an object-typed param as JSON", () => {
+    const { params } = parseCliArgs([
+      "tapOn", "--platform", "android", "--selector", '{"text":"Settings"}'
+    ]);
+
+    expect(params.selector).toEqual({ text: "Settings" });
+  });
+
+  test("a nested string value inside an object param stays a string", () => {
+    const { params } = parseCliArgs([
+      "tapOn", "--platform", "android", "--selector", '{"text":"12345"}'
+    ]);
+
+    expect(params.selector).toEqual({ text: "12345" });
+  });
+
+  test("falls back to best-effort parsing for an unknown tool", () => {
+    const { params } = parseCliArgs(["noSuchTool", "--count", "5"]);
+
+    expect(params.count).toBe(5);
+  });
+
+  test("falls back to best-effort parsing for an undeclared param", () => {
+    const { params } = parseCliArgs(["observe", "--platform", "android", "--notARealParam", "5"]);
+
+    expect(params.notARealParam).toBe(5);
+  });
+
+  test("bare flags with no value remain true", () => {
+    const { params } = parseCliArgs(["observe", "--platform", "android", "--raw"]);
+
+    expect(params.raw).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Every `--cli` value went through `JSON.parse`, so a numeric-looking string arrived as a **number** and string-typed params rejected it. The two examples from the issue both failed:

```
--cli inputText  --text 12345               -> text expected string, received number
--cli sendSms    --phoneNumber 5551234567   -> phoneNumber expected string, received number
```

A phone number, PIN, OTP or zip code is a string whose natural value is digits. The token alone cannot say which the caller meant — only the schema can.

## Linked Issue

Closes #4241

## Bug / Regression Context

- **Observed symptom:** the above. `--phoneNumber +15551234567` worked only because a leading `+` is not valid JSON, and `"007"` survived as a string while `"12345"` did not — behaviour that is hard to predict from outside.
- **Repro:** `--cli inputText --platform android --text 12345`. Quoting does not help; the shell strips quotes and the parser re-interprets the bare token.
- **Prior attempts:** none. `cli/index.ts:87` is long-standing.

## Changes

`parseCliArgs` looks the tool up in `ToolRegistry` and coerces each value by its declared zod type — `string`/`enum` keep the raw token, `number`/`boolean` convert, `object`/`array` parse as JSON, anything unknown falls back to the previous JSON-if-possible behaviour. Enums are treated as strings so a member that happens to look numeric is not coerced.

Two things were needed to make that actually reachable, and both are worth calling out because without them the change is a silent no-op:

1. **`runCliCommand` never registered tools on the execution path.** `initializeCliTools()` was called only on the no-args and `help` branches (`:340`, `:347`), so the registry was empty exactly when a real `--cli <tool>` invocation needed it — every value would have fallen back to the old behaviour and the fix would have done nothing. `getDeclaredParamTypes` now registers first; registration is idempotent (the registry is a `Map` keyed by tool name, verified: 43 tools after one call, 43 after two).

2. **The CLI registered 9 of the 26 categories the server registers.** `sendSms` lives in `telephonyTools`, which was not among them, so the issue's own headline example had no schema to consult. All 26 are now registered.

That second point also fixes `--cli help` under-reporting: it listed **43** tools, now **61**. Execution still routes through the daemon (`runToolViaDaemon` → `proxy.callTool`), so this does not change which tools can actually run — only which the CLI can describe and type. Gated tools such as `barrier`/`criticalSection` remain absent from the daemon's `tools/list` and are still not executable.

Help text updated, since "Values are parsed as JSON if possible" stopped being true.

## Testing

End-to-end against a live daemon and Android emulator — both headline examples now work:

```
--cli sendSms --platform android --phoneNumber 5551234567 --message hi
  -> {"message":"Delivered simulated SMS from 5551234567 (2 chars)","success":true,
      "phoneNumber":"5551234567", ...}          # string, not number

--cli inputText --platform android --text 12345
  -> {"message":"Input text", ...}              # succeeds
```

- `bun test` — **8629 pass, 11 skip, 0 fail** (676 files)
- `bun run build` / `bun run lint` / `bun run typecheck` — all pass
- 9 new tests in `test/cli/parseCliArgsCoercion.test.ts`

## Acceptance criteria

| # | Criterion | Pinned by |
|---|---|---|
| AC1 | `--text 12345` sends the string `"12345"` | `keeps a numeric-looking value as a string…` |
| AC2 | `--phoneNumber 5551234567` succeeds | `keeps an all-digit phone number as a string` |
| AC3 | `--count 5` still yields a number | `still coerces a number-typed param…` |
| AC4 | `--raw true` still yields a boolean | `still coerces a boolean-typed param…` |
| AC5 | `--selector '{"text":"x"}'` still yields an object | `still parses an object-typed param as JSON` |
| AC6 | Unknown tool / undeclared param falls back | `falls back to best-effort parsing…` (×2) |

A nested string inside an object param stays a string, and bare flags with no value still become `true` — both pinned.

## Behaviour change worth noting

`"007"` previously survived as a string only because it is not valid JSON; `"12345"` did not. Both now follow the declared type. Anyone relying on the old accident sees a change — strictly more predictable, but not invisible.

## Follow-up

`--session-uuid` and the daemon flags are parsed elsewhere and keep their own handling; I checked but did not restructure them.
