### PR TITLE
fix(action): issue openLink URLs as argv instead of interpolating into a shell string

### DIFF
--- a/src/features/action/OpenURL.ts
+++ b/src/features/action/OpenURL.ts
@@ -7,6 +7,7 @@ import { DeviceAppManager, DeviceUrlLauncher } from "../../utils/ios-cmdline-too
 import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
 import { IOSCtrlProxyManager } from "../../utils/IOSCtrlProxyManager";
 import { logger } from "../../utils/logger";
+import { shellQuote } from "../../utils/shellQuote";
 import { LaunchApp } from "./LaunchApp";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 
@@ -163,10 +164,18 @@ export class OpenURL extends BaseVisualChange {
    * @returns Result of the URL opening operation
    */
   private async executeAndroidOpenURL(url: string): Promise<OpenURLResult> {
-    // Pass URL through as-is to am start without any reformatting
+    // Pass URL through as-is to am start without any reformatting.
     // Android's Intent system handles both hierarchical (scheme://authority/path)
-    // and opaque (scheme:scheme-specific-part) URIs correctly
-    await this.adb.executeCommand(`shell am start -a android.intent.action.VIEW -d "${url}"`);
+    // and opaque (scheme:scheme-specific-part) URIs correctly.
+    //
+    // The `am start …` line is issued as ONE argv element, so no host shell ever
+    // sees it; adb hands that element to the device's `sh`, which does parse it,
+    // so the URL is single-quoted for that shell (issue #4213). Double quotes
+    // would leave `"`, `$`, backticks and `\` live.
+    await this.adb.execute([
+      "shell",
+      `am start -a android.intent.action.VIEW -d ${shellQuote(url)}`,
+    ]);
 
     return {
       success: true,
@@ -197,8 +206,10 @@ export class OpenURL extends BaseVisualChange {
   private async executeiOSSimulatorOpenURL(url: string): Promise<OpenURLResult> {
     try {
       const simctl = this.simctl ?? new SimCtlClient();
-      // Use simctl openurl command: xcrun simctl openurl <device> <url>
-      await simctl.executeCommand(`openurl ${this.device.deviceId} "${url}"`);
+      // xcrun simctl openurl <device> <url>, issued as argv so the URL reaches
+      // execFile byte-for-byte. The string path re-splits its command, which
+      // mangles quotes and backslashes (issue #4213 / #4196).
+      await simctl.executeCommandArgs(["openurl", this.device.deviceId, url]);
 
       return {
         success: true,

--- a/src/utils/shellQuote.ts
+++ b/src/utils/shellQuote.ts
@@ -1,0 +1,24 @@
+/**
+ * POSIX shell quoting for values that must survive a shell that is NOT ours.
+ *
+ * Host-side execution in this repo goes through `execFile`/`spawn` with an argv
+ * array, so no host shell is involved. But `adb shell <cmd>` is different: adb
+ * concatenates its remaining arguments with spaces and hands the result to
+ * `/system/bin/sh` ON THE DEVICE, which then does full word splitting and
+ * expansion. Any caller-supplied value embedded in such a command must therefore
+ * be quoted for that device shell.
+ *
+ * Double quotes are not enough — `$`, backticks and `\` stay live inside them.
+ * Single quotes are the only POSIX construct that suppresses every expansion.
+ */
+
+/**
+ * Wrap `value` in single quotes so a POSIX shell sees it as exactly one literal
+ * word. A single quote cannot appear inside a single-quoted string, so each one
+ * is emitted as `'\''` — close, escaped literal quote, reopen.
+ * @param value - Raw value to quote
+ * @returns The value as a single, fully literal shell word
+ */
+export function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}

--- a/test/fakes/FakeAdbExecutor.ts
+++ b/test/fakes/FakeAdbExecutor.ts
@@ -1,4 +1,4 @@
-import { AdbExecutor } from "../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
+import { AdbExecutor, type AdbExecuteOptions } from "../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { BootedDevice, ExecResult, AndroidUser } from "../../src/models";
 
 /**
@@ -12,6 +12,7 @@ export class FakeAdbExecutor implements AdbExecutor {
   private defaultResponse: ExecResult = this.createExecResult("", "");
   private defaultError: Error | null = null;
   private executedCommands: string[] = [];
+  private executedArgv: string[][] = [];
   private commandCalls: Array<{
     command: string;
     timeoutMs?: number;
@@ -146,6 +147,16 @@ export class FakeAdbExecutor implements AdbExecutor {
     return [...this.executedCommands];
   }
 
+  /**
+   * Get the history of argv arrays passed to `execute()` (for test assertions).
+   * Unlike {@link getExecutedCommands}, this preserves argument boundaries, so a
+   * test can prove which characters landed inside a single argument.
+   * @returns Array of argv arrays, in call order
+   */
+  getExecutedArgv(): string[][] {
+    return this.executedArgv.map(args => [...args]);
+  }
+
   getCommandCalls(): Array<{
     command: string;
     timeoutMs?: number;
@@ -170,6 +181,7 @@ export class FakeAdbExecutor implements AdbExecutor {
    */
   clearHistory(): void {
     this.executedCommands = [];
+    this.executedArgv = [];
     this.commandCalls = [];
   }
 
@@ -199,6 +211,22 @@ export class FakeAdbExecutor implements AdbExecutor {
   }
 
   // Implementation of AdbExecutor interface
+
+  /**
+   * Execute argv directly. The argv array is recorded verbatim for boundary
+   * assertions, and its space-joined form is also appended to the string
+   * command history so existing pattern-based stubs keep matching.
+   */
+  async execute(args: string[], options: AdbExecuteOptions = {}): Promise<ExecResult> {
+    this.executedArgv.push([...args]);
+    return this.executeCommand(
+      args.join(" "),
+      options.timeoutMs,
+      options.maxBuffer,
+      options.noRetry,
+      options.signal
+    );
+  }
 
   async executeCommand(
     command: string,

--- a/test/features/action/OpenURL.test.ts
+++ b/test/features/action/OpenURL.test.ts
@@ -42,9 +42,9 @@ describe("OpenURL iOS routing", () => {
     const result = await openIos(iosDevice(SIMULATOR_UDID), simctl, devicectl, "https://example.com/x");
 
     expect(result).toEqual({ success: true, url: "https://example.com/x" });
-    const calls = simctl.getMethodCalls("executeCommand");
+    const calls = simctl.getMethodCalls("executeCommandArgs");
     expect(calls).toHaveLength(1);
-    expect(calls[0].command).toBe(`openurl ${SIMULATOR_UDID} "https://example.com/x"`);
+    expect(calls[0].args).toEqual(["openurl", SIMULATOR_UDID, "https://example.com/x"]);
     expect(devicectl.launchCalls).toHaveLength(0);
   });
 
@@ -58,7 +58,7 @@ describe("OpenURL iOS routing", () => {
     expect(devicectl.launchCalls).toEqual([
       { deviceUdid: PHYSICAL_UDID, bundleId: "com.apple.mobilesafari", url: "https://example.com/order/123" },
     ]);
-    expect(simctl.getMethodCalls("executeCommand")).toHaveLength(0);
+    expect(simctl.getMethodCalls("executeCommandArgs")).toHaveLength(0);
   });
 
   test("(c) physical UDID + custom scheme launches the resolved target bundle id", async () => {
@@ -130,7 +130,7 @@ describe("OpenURL iOS routing", () => {
     expect(result.success).toBe(false);
     expect(result.error).toMatch(/Xcode 15\+ and iOS 17\+/);
     expect(devicectl.launchCalls).toHaveLength(0);
-    expect(simctl.getMethodCalls("executeCommand")).toHaveLength(0);
+    expect(simctl.getMethodCalls("executeCommandArgs")).toHaveLength(0);
   });
 
   test("(e) devicectl launch failure returns { success:false, error }", async () => {
@@ -146,7 +146,7 @@ describe("OpenURL iOS routing", () => {
 
   test("(a-neg) simulator simctl failure returns { success:false, error }", async () => {
     const simctl = new FakeSimCtlClient();
-    simctl.setCommandError(`openurl ${SIMULATOR_UDID} "https://example.com"`, new Error("Invalid device"));
+    simctl.setCommandError(`openurl ${SIMULATOR_UDID} https://example.com`, new Error("Invalid device"));
     const devicectl = new FakeDeviceUrlLauncher();
 
     const result = await openIos(iosDevice(SIMULATOR_UDID), simctl, devicectl, "https://example.com");
@@ -181,7 +181,7 @@ describe("OpenURL package: delegation is unchanged", () => {
     expect(launchSpy).toHaveBeenCalledTimes(1);
     expect(launchSpy.mock.calls[0][0]).toBe("com.example.MyApp");
     expect(devicectl.launchCalls).toHaveLength(0);
-    expect(simctl.getMethodCalls("executeCommand")).toHaveLength(0);
+    expect(simctl.getMethodCalls("executeCommandArgs")).toHaveLength(0);
   });
 });
 
@@ -196,9 +196,9 @@ describe("OpenURL Android parity (regression guard)", () => {
     const result = await (openURL as any).executeAndroidOpenURL("https://example.com/x") as { success: boolean; url: string };
 
     expect(result).toEqual({ success: true, url: "https://example.com/x" });
-    expect(fakeAdb.getExecutedCommands()).toContain(
-      'shell am start -a android.intent.action.VIEW -d "https://example.com/x"'
-    );
+    expect(fakeAdb.getExecutedArgv()).toEqual([
+      ["shell", "am start -a android.intent.action.VIEW -d 'https://example.com/x'"],
+    ]);
   });
 });
 
@@ -270,8 +270,8 @@ describe("OpenURL trims the dispatched URL (issue #4166)", () => {
 
       const result = await openURL.execute(input);
 
-      expect(fakeAdb.getExecutedCommands()).toEqual([
-        `shell am start -a android.intent.action.VIEW -d "${expectedUrl}"`,
+      expect(fakeAdb.getExecutedArgv()).toEqual([
+        ["shell", `am start -a android.intent.action.VIEW -d '${expectedUrl}'`],
       ]);
       expect(result).toEqual({ success: true, url: expectedUrl });
     }
@@ -292,9 +292,9 @@ describe("OpenURL trims the dispatched URL (issue #4166)", () => {
 
       const result = await openURL.execute(input);
 
-      const calls = simctl.getMethodCalls("executeCommand");
+      const calls = simctl.getMethodCalls("executeCommandArgs");
       expect(calls).toHaveLength(1);
-      expect(calls[0].command).toBe(`openurl ${SIMULATOR_UDID} "${expectedUrl}"`);
+      expect(calls[0].args).toEqual(["openurl", SIMULATOR_UDID, expectedUrl]);
       expect(result).toEqual({ success: true, url: expectedUrl });
     }
   );

--- a/test/features/action/openUrlShellInjection.test.ts
+++ b/test/features/action/openUrlShellInjection.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { OpenURL } from "../../../src/features/action/OpenURL";
+import { BaseVisualChange } from "../../../src/features/action/BaseVisualChange";
+import { BootedDevice } from "../../../src/models";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeSimCtlClient } from "../../fakes/FakeSimCtlClient";
+import { FakeDeviceUrlLauncher } from "../../fakes/FakeDeviceUrlLauncher";
+
+/**
+ * Issue #4213: `openLink` interpolated the caller-supplied URL into a command
+ * STRING on both platforms, wrapped in nothing but a pair of double quotes.
+ *
+ * On Android that string is handed to `adb shell`, where a real shell ON THE
+ * DEVICE parses it — so a URL containing `"` closes the quote and everything
+ * after it is parsed as further shell words. `$`, backticks and `\` stay live
+ * inside double quotes too. On iOS the simulator path ends at
+ * `execFile("xcrun", argv)` with no shell, so the same interpolation is a
+ * correctness/mangling defect rather than an injection one.
+ *
+ * These tests assert the ARGV / COMMAND ACTUALLY ISSUED, not the log line or
+ * the returned result — both of those looked correct before the fix, which is
+ * exactly why this went unnoticed.
+ */
+
+const SIMULATOR_UDID = "ABCDEF01-1234-1234-1234-1234567890AB";
+const ANDROID_DEVICE: BootedDevice = { name: "pixel", platform: "android", deviceId: "emulator-5554" };
+const iosSimulator: BootedDevice = { name: "iPhone", platform: "ios", deviceId: SIMULATOR_UDID };
+
+/**
+ * Hostile-but-legal URLs, each paired with the exact POSIX single-quoted form
+ * the device shell must receive. The expected column is written out literally
+ * rather than computed, so it cannot drift with the implementation.
+ */
+const hostileUrls: Array<[label: string, url: string, deviceShellQuoted: string]> = [
+  // Control row: an ordinary URL must still be passed through unchanged.
+  ["control (plain URL)", "https://example.com/x", "'https://example.com/x'"],
+  ["embedded double quote", 'https://example.com/a"b', `'https://example.com/a"b'`],
+  ["quote-break command injection", 'https://x/" ; id ; echo "', `'https://x/" ; id ; echo "'`],
+  ["command substitution $()", "https://example.com/?q=$(id)", "'https://example.com/?q=$(id)'"],
+  ["backtick substitution", "https://example.com/?q=`id`", "'https://example.com/?q=`id`'"],
+  ["bare variable expansion", "https://example.com/?q=$HOME", "'https://example.com/?q=$HOME'"],
+  ["semicolon", "https://example.com/a;id", "'https://example.com/a;id'"],
+  ["logical and", "https://example.com/a&&id", "'https://example.com/a&&id'"],
+  ["pipe and redirect", "https://example.com/a|id>/data/local/tmp/x", "'https://example.com/a|id>/data/local/tmp/x'"],
+  ["backslash", "https://example.com/a\\b", "'https://example.com/a\\b'"],
+  ["inner space", "https://example.com/a b", "'https://example.com/a b'"],
+  // A single quote is the one character single-quoting cannot contain, so it
+  // must be closed, escaped, and reopened: ' -> '\''
+  ["single quote", "https://example.com/it's", "'https://example.com/it'\\''s'"],
+  ["unicode", "https://example.com/café/日本", "'https://example.com/café/日本'"],
+  ["percent-encoding is preserved verbatim", "https://example.com/a%20b%22c", "'https://example.com/a%20b%22c'"],
+];
+
+describe("openLink does not let a URL escape the Android device shell (issue #4213)", () => {
+  const restores: Array<() => void> = [];
+  afterEach(() => {
+    while (restores.length) { restores.pop()!(); }
+  });
+
+  // Run execute() without the observe/visual-change machinery: the platform
+  // dispatch is the only part under test here.
+  const stubObservedInteraction = () => {
+    const spy = spyOn(BaseVisualChange.prototype, "observedInteraction")
+      .mockImplementation(async (block: any) => block({} as any));
+    restores.push(() => spy.mockRestore());
+  };
+
+  test.each(hostileUrls)(
+    "android argv: %s",
+    async (_label, url, quoted) => {
+      stubObservedInteraction();
+      const fakeAdb = new FakeAdbExecutor();
+      const openURL = new OpenURL(ANDROID_DEVICE, fakeAdb as unknown as any);
+
+      const result = await openURL.execute(url);
+
+      // The whole `am start …` line is ONE adb argument, and the URL inside it
+      // is one shell word: nothing the caller supplied can become a new word.
+      expect(fakeAdb.getExecutedArgv()).toEqual([
+        ["shell", `am start -a android.intent.action.VIEW -d ${quoted}`],
+      ]);
+      expect(result).toEqual({ success: true, url });
+    }
+  );
+
+  test("the reproduced injection payload cannot terminate the -d argument", async () => {
+    stubObservedInteraction();
+    const fakeAdb = new FakeAdbExecutor();
+    // Before the fix this produced:
+    //   am start -a android.intent.action.VIEW -d "https://x/" ; id ; echo ""
+    // i.e. a second shell command (`id`) executed on the device.
+    const payload = 'https://x/" ; id ; echo "';
+
+    await new OpenURL(ANDROID_DEVICE, fakeAdb as unknown as any).execute(payload);
+
+    const [argv] = fakeAdb.getExecutedArgv();
+    const shellCommand = argv[1];
+    // No unquoted metacharacter survives: the URL is wholly inside one
+    // single-quoted word that starts right after `-d `.
+    expect(shellCommand).toBe(
+      `am start -a android.intent.action.VIEW -d 'https://x/" ; id ; echo "'`
+    );
+    expect(shellCommand.startsWith("am start -a android.intent.action.VIEW -d '")).toBe(true);
+    expect(shellCommand.endsWith("'")).toBe(true);
+    // Exactly two single quotes -> exactly one quoted word, nothing after it.
+    expect(shellCommand.split("'")).toHaveLength(3);
+  });
+});
+
+describe("openLink passes the URL to simctl as its own argv element (issue #4213)", () => {
+  const restores: Array<() => void> = [];
+  afterEach(() => {
+    while (restores.length) { restores.pop()!(); }
+  });
+
+  const stubObservedInteraction = () => {
+    const spy = spyOn(BaseVisualChange.prototype, "observedInteraction")
+      .mockImplementation(async (block: any) => block({} as any));
+    restores.push(() => spy.mockRestore());
+  };
+
+  test.each(hostileUrls)(
+    "ios simulator argv: %s",
+    async (_label, url) => {
+      stubObservedInteraction();
+      const simctl = new FakeSimCtlClient();
+      const openURL = new OpenURL(
+        iosSimulator,
+        new FakeAdbExecutor() as unknown as any,
+        simctl as any,
+        new FakeDeviceUrlLauncher() as any
+      );
+
+      const result = await openURL.execute(url);
+
+      // `executeCommand` re-splits its string back into argv; `executeCommandArgs`
+      // hands argv straight to execFile, so the URL arrives byte-for-byte.
+      expect(simctl.getMethodCalls("executeCommand")).toHaveLength(0);
+      const calls = simctl.getMethodCalls("executeCommandArgs");
+      expect(calls).toHaveLength(1);
+      expect(calls[0].args).toEqual(["openurl", SIMULATOR_UDID, url]);
+      expect(result).toEqual({ success: true, url });
+    }
+  );
+});


### PR DESCRIPTION
## Summary

`openLink` interpolated the caller-supplied URL into a command **string** on both
platforms, wrapped in nothing but a pair of double quotes. Both call sites now issue
**argv arrays**, and the Android one quotes the URL for the shell that actually parses
it.

The two halves are not equally severe, and the fix differs accordingly:

- **Android — real command injection.** The `am start …` string goes to `adb shell`.
  Host-side there is no shell (`execFile`), but adb concatenates its arguments and hands
  the result to `/system/bin/sh` **on the device**, which does full word splitting and
  expansion. Double quotes leave `"`, `$`, backticks and `\` live. Reproduced as a red
  test: `openLink('https://x/" ; id ; echo "')` issued
  `am start … -d "https://x/" ; id ; echo ""` — the device shell parsed `; id ;` as a
  second command and ran it. The URL is now wrapped with `shellQuote()` (POSIX
  single-quoting, `'` → `'\''`), so the whole value is one literal shell word.
- **iOS simulator — mangling, not injection.** `SimCtlClient.executeCommand` ends at
  `execFile("xcrun", argv)` with no shell anywhere, so nothing can be injected. What it
  does do is re-split the string it was handed (`splitCommandArgs`), so a URL containing
  a quote, a space or a backslash reaches the simulator different from what the caller
  passed. Fixed by calling the existing argv seam `executeCommandArgs`, exactly as
  #4233 did for the other simctl call sites.

## Reuse check

No new exec primitive was invented. `AdbClient.execute(args)` and
`SimCtlClient.executeCommandArgs(args)` (standardized in #4233, built on
`createExecResult`) already existed and are reused as-is — `AdbClient` needed **no** new
argv path. The one new file is `src/utils/shellQuote.ts`: device-shell quoting is a
distinct concern from argv construction and the repo had **five** private copies of the
same one-liner (`AppPreferences.ts`, `appFileService.ts`, `DeviceAppManager.ts`,
`AndroidSystemConfigurationAdapter.ts`, `WebpBinaryResolver.ts`) and no shared module.
Rather than add a sixth copy, this promotes one canonical `shellQuote` and uses it here;
migrating the five existing copies is deliberately left to a follow-up so this PR stays
reviewable.

## Linked Issue

Closes #4213

## Bug / Regression Context

- **Observed symptom:** a URL containing `"` was silently mangled before reaching the
  intent (same "logs look right, device sees something else" class as #4166); a URL
  containing `"` plus `;` executed arbitrary commands on the device as the shell user.
- **Repro steps / conditions:** any `openLink` call whose URL contains `"`, `$`,
  a backtick, `;`, `&&`, `|` or a space. `openLink` takes the URL straight from the MCP
  tool argument, so the value is arbitrary and often comes from a page, a deep-link
  table, or a model-generated string.

## Changes

- `src/features/action/OpenURL.ts` — Android dispatch goes through
  `adb.execute(["shell", …])` with the URL `shellQuote`d for the device shell; iOS
  simulator dispatch goes through `simctl.executeCommandArgs(["openurl", udid, url])`.
- `src/utils/shellQuote.ts` — new canonical POSIX single-quote helper, documented with
  *why* `adb shell` needs it when host-side argv does not.
- `test/fakes/FakeAdbExecutor.ts` — implements the `AdbExecutor.execute(args)` member it
  was missing, recording argv verbatim and exposing `getExecutedArgv()` so tests can
  assert argument boundaries rather than a re-joined string. The joined form is still
  appended to the existing command history, so every existing pattern-based stub keeps
  matching.

## Testing

New `test/features/action/openUrlShellInjection.test.ts` — a 14-row table of
hostile-but-legal URLs (control row, embedded `"`, the quote-break `" ; id ; echo "`
payload, `$(…)`, backtick, `$HOME`, `;`, `&&`, `|`/`>`, backslash, inner space, single
quote, unicode, percent-encoding) run against both the Android and the iOS-simulator
dispatch. Assertions are on the **argv actually issued** via
`FakeAdbExecutor.getExecutedArgv()` / `FakeSimCtlClient.getMethodCalls("executeCommandArgs")`,
never the log line or the returned result — both of those looked correct before the fix,
which is why this went unnoticed. Expected quoted forms are written out literally so they
cannot drift with the implementation. One dedicated test pins that the injection payload
yields exactly one single-quoted word (`split("'")` has length 3), so nothing the caller
supplied can become a new shell word.

**Red before, green after:** all 29 new tests failed against `main` (Android: no argv
issued at all; iOS: still on the string path), all 29 pass after.

The existing #4166 whitespace-table assertions in `test/features/action/OpenURL.test.ts`
were updated to the new argv shape — same cases, same coverage, now boundary-aware.

## Validation

- [x] `bun run lint` passes
- [x] `bun test` — 8683 pass / 0 fail
- [x] `bun run typecheck` reports no new errors (baseline gate). It also reports 10
      baseline errors no longer occur — those are the `FakeAdbExecutor` missing-member
      errors this PR fixes. `scripts/typecheck-baseline.txt` is deliberately **not**
      ratcheted here; #4248 owns that file.
- [x] New code uses interfaces + fakes; the new suite runs in ~160ms
- [x] New generic code reuses existing project helpers (see Reuse check)

## Device Verification

Not applicable — this PR is verified entirely with fakes, and deliberately so: the whole
point is asserting the exact bytes handed to the exec seam, which a real device cannot
show you.

## Follow-ups

- Not addressed here, tracked separately: #4234 (the remaining string-built commands
  *inside* `SimCtlClient` — `create`/`install`/`push` and the fixed-shape ones). Those
  are the correctness half only, share no helper with `openLink`, and are explicitly
  scoped to their own issue.
- Consolidating the five private `shellQuote`/`quoteShellArg` copies onto
  `src/utils/shellQuote.ts` — filed as #4255.
