### PR TITLE
fix(vision): give the result cache a lifetime that outlives one tool call

### DIFF
--- a/src/vision/VisionFallback.ts
+++ b/src/vision/VisionFallback.ts
@@ -8,6 +8,7 @@ import type {
   VisionFallbackConfig,
   VisionFallbackResult,
   ElementSearchCriteria,
+  VisionClient,
 } from "./VisionTypes";
 import type { ViewHierarchyNode } from "../models/ViewHierarchyResult";
 import type { Timer } from "../utils/SystemTimer";
@@ -15,19 +16,29 @@ import { defaultTimer } from "../utils/SystemTimer";
 import { logger } from "../utils/logger";
 import { stableStringify } from "../utils/stableStringify";
 
+/**
+ * Upper bound on live cache entries. The cache now outlives a single tool call
+ * (see VisionFallbackRegistry), so without a cap a long-running daemon would
+ * retain one entry per (screenshot, criteria) pair for its whole lifetime.
+ * Eviction is oldest-write-first once the cap is reached.
+ */
+export const MAX_VISION_CACHE_ENTRIES = 64;
+
 export class VisionFallback {
   private config: VisionFallbackConfig;
-  private claudeClient: ClaudeVisionClient | null = null;
+  private claudeClient: VisionClient | null = null;
   private resultCache: Map<string, { result: VisionFallbackResult; timestamp: number }>;
   private timer: Timer;
 
-  constructor(config: VisionFallbackConfig, timer: Timer = defaultTimer) {
+  constructor(config: VisionFallbackConfig, timer: Timer = defaultTimer, client?: VisionClient) {
     this.config = config;
     this.timer = timer;
     this.resultCache = new Map();
 
     // Initialize Claude client if provider is 'claude'
-    if (config.provider === "claude") {
+    if (client) {
+      this.claudeClient = client;
+    } else if (config.provider === "claude") {
       this.claudeClient = new ClaudeVisionClient();
     }
   }
@@ -110,10 +121,38 @@ export class VisionFallback {
     result: VisionFallbackResult
   ): void {
     const cacheKey = this.generateCacheKey(screenshotPath, searchCriteria);
+    this.evictExpired();
     this.resultCache.set(cacheKey, {
       result,
       timestamp: this.timer.now(),
     });
+    this.evictOverflow();
+  }
+
+  /**
+   * Drop entries past their TTL. getCachedResult only evicts the key it was
+   * asked for, so a key that is never queried again would otherwise be
+   * retained forever now that the cache is long-lived.
+   */
+  private evictExpired(): void {
+    const now = this.timer.now();
+    for (const [key, entry] of this.resultCache) {
+      const ageMinutes = (now - entry.timestamp) / (1000 * 60);
+      if (ageMinutes > this.config.cacheTtlMinutes) {
+        this.resultCache.delete(key);
+      }
+    }
+  }
+
+  /** Map iteration order is insertion order, so this evicts oldest-write-first. */
+  private evictOverflow(): void {
+    while (this.resultCache.size > MAX_VISION_CACHE_ENTRIES) {
+      const oldest = this.resultCache.keys().next();
+      if (oldest.done) {
+        return;
+      }
+      this.resultCache.delete(oldest.value);
+    }
   }
 
   private generateCacheKey(

--- a/src/vision/VisionFallback.ts
+++ b/src/vision/VisionFallback.ts
@@ -15,6 +15,8 @@ import type { Timer } from "../utils/SystemTimer";
 import { defaultTimer } from "../utils/SystemTimer";
 import { logger } from "../utils/logger";
 import { stableStringify } from "../utils/stableStringify";
+import type { ChecksumCalculator } from "../utils/ChecksumCalculator";
+import { DefaultChecksumCalculator } from "../utils/ChecksumCalculator";
 
 /**
  * Upper bound on live cache entries. The cache now outlives a single tool call
@@ -29,10 +31,17 @@ export class VisionFallback {
   private claudeClient: VisionClient | null = null;
   private resultCache: Map<string, { result: VisionFallbackResult; timestamp: number }>;
   private timer: Timer;
+  private checksums: ChecksumCalculator;
 
-  constructor(config: VisionFallbackConfig, timer: Timer = defaultTimer, client?: VisionClient) {
+  constructor(
+    config: VisionFallbackConfig,
+    timer: Timer = defaultTimer,
+    client?: VisionClient,
+    checksums: ChecksumCalculator = new DefaultChecksumCalculator()
+  ) {
     this.config = config;
     this.timer = timer;
+    this.checksums = checksums;
     this.resultCache = new Map();
 
     // Initialize Claude client if provider is 'claude'
@@ -52,9 +61,15 @@ export class VisionFallback {
       throw new Error("Vision fallback is not enabled");
     }
 
+    // Every capture writes screenshot_<timestamp>.png, so the key must be
+    // derived once here from the file's *contents*; see generateCacheKey.
+    const cacheKey = this.config.cacheResults
+      ? await this.generateCacheKey(screenshotPath, searchCriteria)
+      : null;
+
     // Check cache first
-    if (this.config.cacheResults) {
-      const cached = this.getCachedResult(screenshotPath, searchCriteria);
+    if (cacheKey) {
+      const cached = this.getCachedResult(cacheKey);
       if (cached) {
         logger.debug("Vision fallback: using cached result");
         return cached;
@@ -82,8 +97,8 @@ export class VisionFallback {
       logger.debug(`Vision fallback complete: confidence=${result.confidence}, cost=$${result.costUsd.toFixed(4)}, time=${result.durationMs}ms`);
 
       // Cache result
-      if (this.config.cacheResults) {
-        this.cacheResult(screenshotPath, searchCriteria, result);
+      if (cacheKey) {
+        this.cacheResult(cacheKey, result);
       }
 
       return result;
@@ -92,11 +107,7 @@ export class VisionFallback {
     throw new Error(`Unsupported vision provider: ${this.config.provider}`);
   }
 
-  private getCachedResult(
-    screenshotPath: string,
-    searchCriteria: ElementSearchCriteria
-  ): VisionFallbackResult | null {
-    const cacheKey = this.generateCacheKey(screenshotPath, searchCriteria);
+  private getCachedResult(cacheKey: string): VisionFallbackResult | null {
     const cached = this.resultCache.get(cacheKey);
 
     if (!cached) {
@@ -115,12 +126,7 @@ export class VisionFallback {
     return cached.result;
   }
 
-  private cacheResult(
-    screenshotPath: string,
-    searchCriteria: ElementSearchCriteria,
-    result: VisionFallbackResult
-  ): void {
-    const cacheKey = this.generateCacheKey(screenshotPath, searchCriteria);
+  private cacheResult(cacheKey: string, result: VisionFallbackResult): void {
     this.evictExpired();
     this.resultCache.set(cacheKey, {
       result,
@@ -155,14 +161,33 @@ export class VisionFallback {
     }
   }
 
-  private generateCacheKey(
+  private async generateCacheKey(
     screenshotPath: string,
     searchCriteria: ElementSearchCriteria
-  ): string {
+  ): Promise<string> {
     // Sorted-key serialization: criteria written with their keys in a different
     // order are the same search, and must not cost a second paid analyzer call.
     const criteriaStr = stableStringify(searchCriteria);
-    return `${screenshotPath}:${criteriaStr}`;
+    return `${await this.fingerprintScreenshot(screenshotPath)}:${criteriaStr}`;
+  }
+
+  /**
+   * Identify a screenshot by its contents, not its path. TakeScreenshot writes
+   * screenshot_<timestamp>.png, so a path-keyed cache gets a fresh key on every
+   * capture and can never hit — two tool calls against an unchanged screen must
+   * produce the same key or the cache is decorative.
+   */
+  private async fingerprintScreenshot(screenshotPath: string): Promise<string> {
+    try {
+      const { checksum } = await this.checksums.computeFileSha256(screenshotPath);
+      return checksum;
+    } catch (error) {
+      // Unreadable screenshot: fall back to the path, which is unique per
+      // capture. That only costs a cache miss — the paid call still happens
+      // and the caller still gets a result, so this must not throw.
+      logger.debug(`Vision fallback: could not fingerprint ${screenshotPath}, using path as key: ${error}`);
+      return screenshotPath;
+    }
   }
 
   /**

--- a/src/vision/VisionFallbackRegistry.ts
+++ b/src/vision/VisionFallbackRegistry.ts
@@ -1,0 +1,91 @@
+/**
+ * Keeps `VisionFallback` orchestrators alive across tool calls.
+ *
+ * `VisionFallback` owns its result cache as an instance field. Every production
+ * consumer of vision fallback (TapOnElement, SwipeOn, DragAndDrop, PinchOn) is
+ * constructed per tool call and reaches vision through `getVisionEnrichedError`,
+ * so constructing the orchestrator there threw the cache away before it could
+ * ever be read a second time — `cacheResults` and `cacheTtlMinutes` were dead
+ * configuration and every fallback was a fresh paid analyzer call.
+ *
+ * The orchestrator is therefore memoized here, keyed by its configuration, so
+ * the cache lifetime is the process rather than the call. Keying by config
+ * means a changed provider or TTL gets its own cache instead of silently
+ * reusing entries produced under different settings.
+ */
+
+import { VisionFallback } from "./VisionFallback";
+import type { VisionFallbackConfig } from "./VisionTypes";
+import { stableStringify } from "../utils/stableStringify";
+
+export type VisionFallbackFactory = (config: VisionFallbackConfig) => VisionFallback;
+
+const defaultFactory: VisionFallbackFactory = config => new VisionFallback(config);
+
+/**
+ * Distinct configs in a single process are few (config is effectively static
+ * per install), so this only guards against an unbounded map if a caller ever
+ * synthesizes configs per call.
+ */
+export const MAX_VISION_FALLBACK_INSTANCES = 8;
+
+export class VisionFallbackRegistry {
+  private instances = new Map<string, VisionFallback>();
+  private createFallback: VisionFallbackFactory;
+
+  constructor(createFallback: VisionFallbackFactory = defaultFactory) {
+    this.createFallback = createFallback;
+  }
+
+  /**
+   * Returns the orchestrator for this config, constructing it on first use.
+   * Repeat calls with an equivalent config get the same instance — and so the
+   * same result cache.
+   */
+  get(config: VisionFallbackConfig): VisionFallback {
+    const key = stableStringify(config);
+    const existing = this.instances.get(key);
+    if (existing) {
+      return existing;
+    }
+
+    const created = this.createFallback(config);
+    this.instances.set(key, created);
+
+    // Map iteration order is insertion order: evict oldest-created first.
+    while (this.instances.size > MAX_VISION_FALLBACK_INSTANCES) {
+      const oldest = this.instances.keys().next();
+      if (oldest.done) {
+        break;
+      }
+      this.instances.delete(oldest.value);
+    }
+
+    return created;
+  }
+
+  clear(): void {
+    this.instances.clear();
+  }
+
+  get size(): number {
+    return this.instances.size;
+  }
+}
+
+let sharedRegistry = new VisionFallbackRegistry();
+
+/** The process-wide registry used by `getVisionEnrichedError`. */
+export function getSharedVisionFallback(config: VisionFallbackConfig): VisionFallback {
+  return sharedRegistry.get(config);
+}
+
+/**
+ * Swap the process-wide registry. Tests use this to supply a registry whose
+ * factory builds a real `VisionFallback` around a counting stub client, so the
+ * caching path is exercised for real without a paid call. Passing null restores
+ * the default registry.
+ */
+export function setSharedVisionFallbackRegistry(registry: VisionFallbackRegistry | null): void {
+  sharedRegistry = registry ?? new VisionFallbackRegistry();
+}

--- a/src/vision/VisionTypes.ts
+++ b/src/vision/VisionTypes.ts
@@ -54,6 +54,19 @@ export interface VisionFallbackConfig {
   cacheTtlMinutes: number;
 }
 
+/**
+ * The paid, provider-facing call. `VisionFallback` orchestrates caching and
+ * cost accounting around this; tests substitute a counting stub so the cache
+ * behaviour can be exercised without spending money.
+ */
+export interface VisionClient {
+  analyzeUIElement(
+    screenshotPath: string,
+    searchCriteria: ElementSearchCriteria,
+    viewHierarchy?: any
+  ): Promise<VisionFallbackResult>;
+}
+
 export interface VisionAnalyzer {
   analyzeAndSuggest(
     screenshotPath: string,

--- a/src/vision/applyVisionFallback.ts
+++ b/src/vision/applyVisionFallback.ts
@@ -2,7 +2,7 @@
  * Shared utility for applying vision fallback error enrichment across tools.
  */
 
-import { VisionFallback } from "./VisionFallback";
+import { getSharedVisionFallback } from "./VisionFallbackRegistry";
 import type { VisionFallbackConfig, ElementSearchCriteria, VisionAnalyzer } from "./VisionTypes";
 import type { ScreenshotCapturer } from "../features/navigation/SelectionStateTracker";
 import { logger } from "../utils/logger";
@@ -31,7 +31,10 @@ export async function getVisionEnrichedError(
       return baseError;
     }
 
-    const analyzer: VisionAnalyzer = visionAnalyzer ?? new VisionFallback(visionConfig);
+    // Must be the shared, config-keyed orchestrator: constructing one here
+    // would discard its result cache after a single call, making every vision
+    // fallback a fresh paid analyzer invocation.
+    const analyzer: VisionAnalyzer = visionAnalyzer ?? getSharedVisionFallback(visionConfig);
     const visionResult = await analyzer.analyzeAndSuggest(
       screenshotPath,
       viewHierarchy,

--- a/src/vision/index.ts
+++ b/src/vision/index.ts
@@ -5,6 +5,11 @@
 export { VisionFallback, DEFAULT_VISION_CONFIG } from "./VisionFallback";
 export { ClaudeVisionClient } from "./ClaudeVisionClient";
 export { getVisionEnrichedError } from "./applyVisionFallback";
+export {
+  VisionFallbackRegistry,
+  getSharedVisionFallback,
+  setSharedVisionFallbackRegistry,
+} from "./VisionFallbackRegistry";
 export type {
   VisionFallbackConfig,
   VisionFallbackResult,
@@ -13,4 +18,5 @@ export type {
   AlternativeSelector,
   ClaudeVisionAnalysis,
   VisionAnalyzer,
+  VisionClient,
 } from "./VisionTypes";

--- a/test/fakes/FakeChecksumCalculator.ts
+++ b/test/fakes/FakeChecksumCalculator.ts
@@ -5,12 +5,37 @@ export class FakeChecksumCalculator implements ChecksumCalculator {
   public checksumSource: Sha256Source = "node";
   public computedFiles: string[] = [];
   public shouldThrow: Error | null = null;
+  private perFile = new Map<string, string>();
+  private unreadable = new Set<string>();
+  /**
+   * When true, an unregistered path digests to something derived from the path
+   * instead of the shared `checksum`, so distinct fixtures are distinct files.
+   * Off by default to preserve the single-value behaviour existing suites rely on.
+   */
+  public distinctPerFile: boolean = false;
+
+  /**
+   * Give one path its own digest, for tests that need two files to compare
+   * equal or unequal by content. Paths left unset keep returning `checksum`.
+   */
+  public setFileChecksum(filePath: string, checksum: string): void {
+    this.perFile.set(filePath, checksum);
+  }
+
+  /** Make a single path fail, as an unlinked or truncated file would. */
+  public setUnreadable(filePath: string): void {
+    this.unreadable.add(filePath);
+  }
 
   public async computeFileSha256(filePath: string): Promise<{ checksum: string; source: Sha256Source }> {
     if (this.shouldThrow) {
       throw this.shouldThrow;
     }
+    if (this.unreadable.has(filePath)) {
+      throw new Error(`ENOENT: no such file or directory, open '${filePath}'`);
+    }
     this.computedFiles.push(filePath);
-    return { checksum: this.checksum, source: this.checksumSource };
+    const fallback = this.distinctPerFile ? `sha256(${filePath})` : this.checksum;
+    return { checksum: this.perFile.get(filePath) ?? fallback, source: this.checksumSource };
   }
 }

--- a/test/vision/VisionFallback.test.ts
+++ b/test/vision/VisionFallback.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { VisionFallback } from "../../src/vision/VisionFallback";
+import { VisionFallback, MAX_VISION_CACHE_ENTRIES } from "../../src/vision/VisionFallback";
 import type {
   VisionFallbackConfig,
   VisionFallbackResult,
@@ -169,5 +169,38 @@ describe("VisionFallback orchestrator", () => {
     const res = await fb.analyzeAndSuggest("/s.png", HIERARCHY, criteria("Login"));
     expect(res.found).toBe(true);
     expect(res.costUsd).toBe(5.0);
+  });
+
+  // The cache now outlives a single tool call (issue #4207), so it has to be
+  // bounded or a long-running daemon retains every query it ever made.
+  test("caps retained entries at MAX_VISION_CACHE_ENTRIES", async () => {
+    const fb = new VisionFallback(config(), timer);
+    stubAnalyzer(fb, result());
+
+    for (let i = 0; i < MAX_VISION_CACHE_ENTRIES + 10; i++) {
+      await fb.analyzeAndSuggest(`/s-${i}.png`, HIERARCHY, criteria("Login"));
+    }
+
+    expect(fb.getCacheStats().size).toBe(MAX_VISION_CACHE_ENTRIES);
+    // Oldest-write-first eviction: the earliest screenshots are gone.
+    expect(fb.getCacheStats().keys.some(k => k.startsWith("/s-0.png:"))).toBe(false);
+    expect(fb.getCacheStats().keys.some(k => k.startsWith("/s-73.png:"))).toBe(true);
+  });
+
+  test("sweeps entries past their TTL on write, not only on read", async () => {
+    const fb = new VisionFallback(config({ cacheTtlMinutes: 10 }), timer);
+    stubAnalyzer(fb, result());
+
+    await fb.analyzeAndSuggest("/stale.png", HIERARCHY, criteria("Login"));
+    expect(fb.getCacheStats().size).toBe(1);
+
+    timer.advanceTime(11 * 60 * 1000);
+    // A write for a *different* key must still retire the expired entry.
+    await fb.analyzeAndSuggest("/fresh.png", HIERARCHY, criteria("Login"));
+
+    expect(fb.getCacheStats().keys).toEqual(expect.arrayContaining([
+      expect.stringContaining("/fresh.png"),
+    ]));
+    expect(fb.getCacheStats().size).toBe(1);
   });
 });

--- a/test/vision/VisionFallback.test.ts
+++ b/test/vision/VisionFallback.test.ts
@@ -6,6 +6,7 @@ import type {
   ElementSearchCriteria,
 } from "../../src/vision/VisionTypes";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeChecksumCalculator } from "../fakes/FakeChecksumCalculator";
 
 // VisionFallback constructs a ClaudeVisionClient internally (provider "claude"),
 // whose Anthropic client needs *some* key at construction. A dummy is fine — we
@@ -54,20 +55,26 @@ function stubAnalyzer(fallback: VisionFallback, canned: VisionFallbackResult): (
 
 describe("VisionFallback orchestrator", () => {
   let timer: FakeTimer;
+  let checksums: FakeChecksumCalculator;
 
   beforeEach(() => {
     timer = new FakeTimer();
+    // Screenshots are keyed by content; give each path its own digest so the
+    // fixtures behave like distinct screens without touching the disk.
+    checksums = new FakeChecksumCalculator();
+    // Each fixture path stands for a different screen.
+    checksums.distinctPerFile = true;
   });
 
   test("throws when vision fallback is disabled", async () => {
-    const fb = new VisionFallback(config({ enabled: false }), timer);
+    const fb = new VisionFallback(config({ enabled: false }), timer, undefined, checksums);
     await expect(
       fb.analyzeAndSuggest("/s.png", HIERARCHY, criteria("Login"))
     ).rejects.toThrow(/not enabled/);
   });
 
   test("caches a result: an identical query hits the analyzer only once", async () => {
-    const fb = new VisionFallback(config(), timer);
+    const fb = new VisionFallback(config(), timer, undefined, checksums);
     const count = stubAnalyzer(fb, result());
 
     const first = await fb.analyzeAndSuggest("/s.png", HIERARCHY, criteria("Login"));
@@ -79,7 +86,7 @@ describe("VisionFallback orchestrator", () => {
   });
 
   test("re-analyzes after the cache entry passes cacheTtlMinutes", async () => {
-    const fb = new VisionFallback(config({ cacheTtlMinutes: 60 }), timer);
+    const fb = new VisionFallback(config({ cacheTtlMinutes: 60 }), timer, undefined, checksums);
     const count = stubAnalyzer(fb, result());
 
     await fb.analyzeAndSuggest("/s.png", HIERARCHY, criteria("Login"));
@@ -95,7 +102,7 @@ describe("VisionFallback orchestrator", () => {
   });
 
   test("caches distinct search criteria separately", async () => {
-    const fb = new VisionFallback(config(), timer);
+    const fb = new VisionFallback(config(), timer, undefined, checksums);
     const count = stubAnalyzer(fb, result());
 
     await fb.analyzeAndSuggest("/s.png", HIERARCHY, criteria("Login"));
@@ -109,7 +116,7 @@ describe("VisionFallback orchestrator", () => {
   });
 
   test("criteria written with keys in a different order hit the cache: the paid analyzer runs once", async () => {
-    const fb = new VisionFallback(config(), timer);
+    const fb = new VisionFallback(config(), timer, undefined, checksums);
     const count = stubAnalyzer(fb, result());
 
     // Semantically identical searches, keys typed in a different order.
@@ -121,7 +128,7 @@ describe("VisionFallback orchestrator", () => {
   });
 
   test("control: criteria with the same keys but different values are still analyzed separately", async () => {
-    const fb = new VisionFallback(config(), timer);
+    const fb = new VisionFallback(config(), timer, undefined, checksums);
     const count = stubAnalyzer(fb, result());
 
     await fb.analyzeAndSuggest("/s.png", HIERARCHY, { text: "Login", resourceId: "btn" });
@@ -132,7 +139,7 @@ describe("VisionFallback orchestrator", () => {
   });
 
   test("control: the same criteria against a different screenshot is not a cache hit", async () => {
-    const fb = new VisionFallback(config(), timer);
+    const fb = new VisionFallback(config(), timer, undefined, checksums);
     const count = stubAnalyzer(fb, result());
 
     await fb.analyzeAndSuggest("/a.png", HIERARCHY, criteria("Login"));
@@ -142,7 +149,7 @@ describe("VisionFallback orchestrator", () => {
   });
 
   test("clearCache forces re-analysis", async () => {
-    const fb = new VisionFallback(config(), timer);
+    const fb = new VisionFallback(config(), timer, undefined, checksums);
     const count = stubAnalyzer(fb, result());
 
     await fb.analyzeAndSuggest("/s.png", HIERARCHY, criteria("Login"));
@@ -153,7 +160,7 @@ describe("VisionFallback orchestrator", () => {
   });
 
   test("does not cache when cacheResults is false", async () => {
-    const fb = new VisionFallback(config({ cacheResults: false }), timer);
+    const fb = new VisionFallback(config({ cacheResults: false }), timer, undefined, checksums);
     const count = stubAnalyzer(fb, result());
 
     await fb.analyzeAndSuggest("/s.png", HIERARCHY, criteria("Login"));
@@ -163,7 +170,7 @@ describe("VisionFallback orchestrator", () => {
   });
 
   test("a cost above maxCostUsd is a warning, not a failure — the result is still returned", async () => {
-    const fb = new VisionFallback(config({ maxCostUsd: 0.01 }), timer);
+    const fb = new VisionFallback(config({ maxCostUsd: 0.01 }), timer, undefined, checksums);
     stubAnalyzer(fb, result({ costUsd: 5.0 }));
 
     const res = await fb.analyzeAndSuggest("/s.png", HIERARCHY, criteria("Login"));
@@ -174,7 +181,7 @@ describe("VisionFallback orchestrator", () => {
   // The cache now outlives a single tool call (issue #4207), so it has to be
   // bounded or a long-running daemon retains every query it ever made.
   test("caps retained entries at MAX_VISION_CACHE_ENTRIES", async () => {
-    const fb = new VisionFallback(config(), timer);
+    const fb = new VisionFallback(config(), timer, undefined, checksums);
     stubAnalyzer(fb, result());
 
     for (let i = 0; i < MAX_VISION_CACHE_ENTRIES + 10; i++) {
@@ -183,12 +190,12 @@ describe("VisionFallback orchestrator", () => {
 
     expect(fb.getCacheStats().size).toBe(MAX_VISION_CACHE_ENTRIES);
     // Oldest-write-first eviction: the earliest screenshots are gone.
-    expect(fb.getCacheStats().keys.some(k => k.startsWith("/s-0.png:"))).toBe(false);
-    expect(fb.getCacheStats().keys.some(k => k.startsWith("/s-73.png:"))).toBe(true);
+    expect(fb.getCacheStats().keys.some(k => k.startsWith("sha256(/s-0.png):"))).toBe(false);
+    expect(fb.getCacheStats().keys.some(k => k.startsWith("sha256(/s-73.png):"))).toBe(true);
   });
 
   test("sweeps entries past their TTL on write, not only on read", async () => {
-    const fb = new VisionFallback(config({ cacheTtlMinutes: 10 }), timer);
+    const fb = new VisionFallback(config({ cacheTtlMinutes: 10 }), timer, undefined, checksums);
     stubAnalyzer(fb, result());
 
     await fb.analyzeAndSuggest("/stale.png", HIERARCHY, criteria("Login"));
@@ -199,7 +206,7 @@ describe("VisionFallback orchestrator", () => {
     await fb.analyzeAndSuggest("/fresh.png", HIERARCHY, criteria("Login"));
 
     expect(fb.getCacheStats().keys).toEqual(expect.arrayContaining([
-      expect.stringContaining("/fresh.png"),
+      expect.stringContaining("sha256(/fresh.png)"),
     ]));
     expect(fb.getCacheStats().size).toBe(1);
   });

--- a/test/vision/visionFallbackLifetime.test.ts
+++ b/test/vision/visionFallbackLifetime.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Pins the *lifetime* of the vision result cache (issue #4207).
+ *
+ * These tests deliberately do NOT inject `visionAnalyzer` into
+ * `getVisionEnrichedError`, because that seam is the thing that hid the bug:
+ * holding one `VisionFallback` across calls is exactly the lifetime production
+ * did not have. The only substitution is the paid provider client, so the real
+ * orchestrator, the real cache key and the real TTL logic all run.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { getVisionEnrichedError } from "../../src/vision/applyVisionFallback";
+import { VisionFallback } from "../../src/vision/VisionFallback";
+import {
+  VisionFallbackRegistry,
+  setSharedVisionFallbackRegistry,
+} from "../../src/vision/VisionFallbackRegistry";
+import type {
+  VisionClient,
+  VisionFallbackConfig,
+  VisionFallbackResult,
+} from "../../src/vision/VisionTypes";
+import { FakeScreenshotCapturer } from "../fakes/FakeScreenshotCapturer";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+const config = (overrides: Partial<VisionFallbackConfig> = {}): VisionFallbackConfig => ({
+  enabled: true,
+  provider: "claude",
+  confidenceThreshold: "high",
+  maxCostUsd: 1.0,
+  cacheResults: true,
+  cacheTtlMinutes: 60,
+  ...overrides,
+});
+
+const CANNED: VisionFallbackResult = {
+  found: false,
+  confidence: "low",
+  reason: "Element appears to be off-screen",
+  costUsd: 0.02,
+  durationMs: 10,
+  screenshotPath: "/s.png",
+  provider: "claude",
+};
+
+/** Counts the paid provider calls that a real VisionFallback would make. */
+class CountingVisionClient implements VisionClient {
+  calls = 0;
+  async analyzeUIElement(): Promise<VisionFallbackResult> {
+    this.calls += 1;
+    return CANNED;
+  }
+}
+
+describe("vision result cache lifetime across tool calls", () => {
+  let timer: FakeTimer;
+  let client: CountingVisionClient;
+
+  beforeEach(() => {
+    timer = new FakeTimer();
+    client = new CountingVisionClient();
+    // Real VisionFallback, real cache, real TTL — only the paid client is faked.
+    setSharedVisionFallbackRegistry(
+      new VisionFallbackRegistry(cfg => new VisionFallback(cfg, timer, client))
+    );
+  });
+
+  afterEach(() => {
+    setSharedVisionFallbackRegistry(null);
+  });
+
+  const enrich = async (
+    capturer: FakeScreenshotCapturer,
+    cfg: VisionFallbackConfig
+  ): Promise<string> =>
+    getVisionEnrichedError(capturer, null, { text: "Login" }, cfg, "Element not found");
+
+  const capturerFor = (paths: string[]): FakeScreenshotCapturer => {
+    const capturer = new FakeScreenshotCapturer();
+    capturer.setPaths(paths);
+    return capturer;
+  };
+
+  test("two separate tool calls with the same screenshot and criteria pay once", async () => {
+    // Two independent capturers stand in for two independent tool calls: no
+    // object is shared between them except the process-wide registry.
+    const first = await enrich(capturerFor(["/s.png"]), config());
+    const second = await enrich(capturerFor(["/s.png"]), config());
+
+    expect(client.calls).toBe(1);
+    expect(second).toBe(first);
+  });
+
+  test("cacheResults: false still bypasses the cache", async () => {
+    await enrich(capturerFor(["/s.png"]), config({ cacheResults: false }));
+    await enrich(capturerFor(["/s.png"]), config({ cacheResults: false }));
+
+    expect(client.calls).toBe(2);
+  });
+
+  test("cacheTtlMinutes still evicts across tool calls", async () => {
+    await enrich(capturerFor(["/s.png"]), config({ cacheTtlMinutes: 10 }));
+    expect(client.calls).toBe(1);
+
+    timer.advanceTime(11 * 60 * 1000);
+
+    await enrich(capturerFor(["/s.png"]), config({ cacheTtlMinutes: 10 }));
+    expect(client.calls).toBe(2);
+  });
+
+  test("an entry within the TTL is still served after time advances", async () => {
+    await enrich(capturerFor(["/s.png"]), config({ cacheTtlMinutes: 10 }));
+    timer.advanceTime(9 * 60 * 1000);
+    await enrich(capturerFor(["/s.png"]), config({ cacheTtlMinutes: 10 }));
+
+    expect(client.calls).toBe(1);
+  });
+
+  test("entries are not shared across differing configs", async () => {
+    await enrich(capturerFor(["/s.png"]), config({ cacheTtlMinutes: 10 }));
+    await enrich(capturerFor(["/s.png"]), config({ cacheTtlMinutes: 30 }));
+
+    expect(client.calls).toBe(2);
+  });
+
+  test("config key is order-insensitive, so equivalent configs share a cache", async () => {
+    const a: VisionFallbackConfig = {
+      enabled: true,
+      provider: "claude",
+      confidenceThreshold: "high",
+      maxCostUsd: 1.0,
+      cacheResults: true,
+      cacheTtlMinutes: 60,
+    };
+    const b: VisionFallbackConfig = {
+      cacheTtlMinutes: 60,
+      cacheResults: true,
+      maxCostUsd: 1.0,
+      confidenceThreshold: "high",
+      provider: "claude",
+      enabled: true,
+    };
+
+    await enrich(capturerFor(["/s.png"]), a);
+    await enrich(capturerFor(["/s.png"]), b);
+
+    expect(client.calls).toBe(1);
+  });
+
+  test("different screenshots do not share an entry", async () => {
+    await enrich(capturerFor(["/a.png"]), config());
+    await enrich(capturerFor(["/b.png"]), config());
+
+    expect(client.calls).toBe(2);
+  });
+});
+
+describe("VisionFallbackRegistry", () => {
+  afterEach(() => {
+    setSharedVisionFallbackRegistry(null);
+  });
+
+  test("returns the same instance for an equivalent config", () => {
+    const registry = new VisionFallbackRegistry(cfg => new VisionFallback(cfg, new FakeTimer(), new CountingVisionClient()));
+
+    expect(registry.get(config())).toBe(registry.get(config()));
+    expect(registry.size).toBe(1);
+  });
+
+  test("bounds how many instances it retains", () => {
+    const registry = new VisionFallbackRegistry(cfg => new VisionFallback(cfg, new FakeTimer(), new CountingVisionClient()));
+
+    for (let i = 0; i < 20; i++) {
+      registry.get(config({ cacheTtlMinutes: i }));
+    }
+
+    expect(registry.size).toBe(8);
+  });
+});

--- a/test/vision/visionFallbackLifetime.test.ts
+++ b/test/vision/visionFallbackLifetime.test.ts
@@ -21,6 +21,7 @@ import type {
   VisionFallbackResult,
 } from "../../src/vision/VisionTypes";
 import { FakeScreenshotCapturer } from "../fakes/FakeScreenshotCapturer";
+import { FakeChecksumCalculator } from "../fakes/FakeChecksumCalculator";
 import { FakeTimer } from "../fakes/FakeTimer";
 
 const config = (overrides: Partial<VisionFallbackConfig> = {}): VisionFallbackConfig => ({
@@ -52,16 +53,28 @@ class CountingVisionClient implements VisionClient {
   }
 }
 
+/**
+ * TakeScreenshot writes screenshot_<timestamp>.png, so two tool calls never see
+ * the same path even when the screen is identical. These tests reproduce that:
+ * every capture gets a distinct path, and sameness lives in the contents.
+ */
+const UNCHANGED_SCREEN = "pixels-of-an-unchanged-screen";
+
 describe("vision result cache lifetime across tool calls", () => {
   let timer: FakeTimer;
   let client: CountingVisionClient;
+  let checksums: FakeChecksumCalculator;
+  let captureCount: number;
 
   beforeEach(() => {
     timer = new FakeTimer();
     client = new CountingVisionClient();
-    // Real VisionFallback, real cache, real TTL — only the paid client is faked.
+    checksums = new FakeChecksumCalculator();
+    captureCount = 0;
+    // Real VisionFallback, real cache, real TTL — only the paid client and the
+    // filesystem read behind the content fingerprint are faked.
     setSharedVisionFallbackRegistry(
-      new VisionFallbackRegistry(cfg => new VisionFallback(cfg, timer, client))
+      new VisionFallbackRegistry(cfg => new VisionFallback(cfg, timer, client, checksums))
     );
   });
 
@@ -75,50 +88,57 @@ describe("vision result cache lifetime across tool calls", () => {
   ): Promise<string> =>
     getVisionEnrichedError(capturer, null, { text: "Login" }, cfg, "Element not found");
 
-  const capturerFor = (paths: string[]): FakeScreenshotCapturer => {
+  /**
+   * Stands in for one tool call: a fresh capturer writing to a never-before-seen
+   * timestamped path, whose contents are `content`.
+   */
+  const capture = (content: string): FakeScreenshotCapturer => {
+    captureCount += 1;
+    const path = `/cache/screenshot_${1000 + captureCount}.png`;
+    checksums.setFileChecksum(path, `sha256(${content})`);
     const capturer = new FakeScreenshotCapturer();
-    capturer.setPaths(paths);
+    capturer.setPaths([path]);
     return capturer;
   };
 
   test("two separate tool calls with the same screenshot and criteria pay once", async () => {
     // Two independent capturers stand in for two independent tool calls: no
     // object is shared between them except the process-wide registry.
-    const first = await enrich(capturerFor(["/s.png"]), config());
-    const second = await enrich(capturerFor(["/s.png"]), config());
+    const first = await enrich(capture(UNCHANGED_SCREEN), config());
+    const second = await enrich(capture(UNCHANGED_SCREEN), config());
 
     expect(client.calls).toBe(1);
     expect(second).toBe(first);
   });
 
   test("cacheResults: false still bypasses the cache", async () => {
-    await enrich(capturerFor(["/s.png"]), config({ cacheResults: false }));
-    await enrich(capturerFor(["/s.png"]), config({ cacheResults: false }));
+    await enrich(capture(UNCHANGED_SCREEN), config({ cacheResults: false }));
+    await enrich(capture(UNCHANGED_SCREEN), config({ cacheResults: false }));
 
     expect(client.calls).toBe(2);
   });
 
   test("cacheTtlMinutes still evicts across tool calls", async () => {
-    await enrich(capturerFor(["/s.png"]), config({ cacheTtlMinutes: 10 }));
+    await enrich(capture(UNCHANGED_SCREEN), config({ cacheTtlMinutes: 10 }));
     expect(client.calls).toBe(1);
 
     timer.advanceTime(11 * 60 * 1000);
 
-    await enrich(capturerFor(["/s.png"]), config({ cacheTtlMinutes: 10 }));
+    await enrich(capture(UNCHANGED_SCREEN), config({ cacheTtlMinutes: 10 }));
     expect(client.calls).toBe(2);
   });
 
   test("an entry within the TTL is still served after time advances", async () => {
-    await enrich(capturerFor(["/s.png"]), config({ cacheTtlMinutes: 10 }));
+    await enrich(capture(UNCHANGED_SCREEN), config({ cacheTtlMinutes: 10 }));
     timer.advanceTime(9 * 60 * 1000);
-    await enrich(capturerFor(["/s.png"]), config({ cacheTtlMinutes: 10 }));
+    await enrich(capture(UNCHANGED_SCREEN), config({ cacheTtlMinutes: 10 }));
 
     expect(client.calls).toBe(1);
   });
 
   test("entries are not shared across differing configs", async () => {
-    await enrich(capturerFor(["/s.png"]), config({ cacheTtlMinutes: 10 }));
-    await enrich(capturerFor(["/s.png"]), config({ cacheTtlMinutes: 30 }));
+    await enrich(capture(UNCHANGED_SCREEN), config({ cacheTtlMinutes: 10 }));
+    await enrich(capture(UNCHANGED_SCREEN), config({ cacheTtlMinutes: 30 }));
 
     expect(client.calls).toBe(2);
   });
@@ -141,17 +161,42 @@ describe("vision result cache lifetime across tool calls", () => {
       enabled: true,
     };
 
-    await enrich(capturerFor(["/s.png"]), a);
-    await enrich(capturerFor(["/s.png"]), b);
+    await enrich(capture(UNCHANGED_SCREEN), a);
+    await enrich(capture(UNCHANGED_SCREEN), b);
 
     expect(client.calls).toBe(1);
   });
 
   test("different screenshots do not share an entry", async () => {
-    await enrich(capturerFor(["/a.png"]), config());
-    await enrich(capturerFor(["/b.png"]), config());
+    await enrich(capture("screen-a"), config());
+    await enrich(capture("screen-b"), config());
 
     expect(client.calls).toBe(2);
+  });
+
+  test("differing criteria against one screenshot do not share an entry", async () => {
+    const capturer = capture(UNCHANGED_SCREEN);
+    const cfg = config();
+    await getVisionEnrichedError(capturer, null, { text: "Login" }, cfg, "e");
+
+    const second = capture(UNCHANGED_SCREEN);
+    await getVisionEnrichedError(second, null, { text: "Logout" }, cfg, "e");
+
+    expect(client.calls).toBe(2);
+  });
+
+  test("an unreadable screenshot degrades to a miss rather than failing the call", async () => {
+    captureCount += 1;
+    const path = `/cache/screenshot_${1000 + captureCount}.png`;
+    checksums.setUnreadable(path);
+    const capturer = new FakeScreenshotCapturer();
+    capturer.setPaths([path]);
+
+    const message = await enrich(capturer, config());
+
+    // The caller still gets an enriched message; only the caching is lost.
+    expect(message).toContain("Element appears to be off-screen");
+    expect(client.calls).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Summary

`VisionFallback` owns its `resultCache` as an instance field, but
`getVisionEnrichedError` constructed a fresh `VisionFallback` on **every** call,
and no production site ever injects the `visionAnalyzer` seam — it is test-only
on all four consumers. So the cache was garbage before it could be read a second
time: `cacheResults` and `cacheTtlMinutes` were dead configuration and every
vision fallback was a fresh paid analyzer call.

This memoizes the orchestrator in a process-wide `VisionFallbackRegistry` keyed
by `stableStringify` of its config, so the cache lifetime is the process rather
than a single tool call.

**Why a module-level registry** over the alternatives:

- The four consumers (`TapOnElement`, `SwipeOn`, `DragAndDrop`, `PinchOn`) are
  constructed per tool call and reach vision through a free function. Neither a
  caller-owned nor a session-scoped cache has anything to hang on to without
  threading a new dependency through four call sites and their tool wiring.
- Cached results are a pure function of (screenshot contents, criteria), so a
  process-wide cache has no cross-session correctness hazard: a shared entry
  means the screens were byte-identical.
- Keying the registry by config satisfies "entries are not shared across
  differing `VisionFallbackConfig` values" directly, and reuses the
  `stableStringify` helper landed by #4205 rather than duplicating it.

Because the cache is now long-lived, it is also bounded: expired entries are
swept on write (read-time eviction only ever touched the key being queried, so a
key never queried again was retained forever), and retained entries are capped
at `MAX_VISION_CACHE_ENTRIES`, evicting oldest-write-first.

### Second defect, found reviewing this PR

The lifetime fix alone still hits **0%** in production. `TakeScreenshot.generateScreenshotPath`
(`src/features/observe/TakeScreenshot.ts:128`) writes `screenshot_${timestamp}.png` from a fresh
`Date.now()` per capture, and the cache key was `${screenshotPath}:${criteria}` — so a
long-lived cache still gets a brand-new key on every call. Keeping the orchestrator alive
without fixing the key would have shipped the same "cache that never hits" defect the issue is
about.

The key is now the screenshot's **content** digest, via the existing streaming
`ChecksumCalculator` seam (`src/utils/ChecksumCalculator.ts`) rather than a new hasher. An
unreadable screenshot degrades to the path — a cache miss, not a failed call.

Both halves are independently load-bearing; each was verified red on its own (below).

## Linked Issue

Closes #4207

## Bug / Regression Context

- **Prior attempts:** [#4205](https://github.com/kaeawc/auto-mobile/pull/4205) fixed the cache *key* (order-sensitive criteria) for [#4189](https://github.com/kaeawc/auto-mobile/issues/4189). It did not touch the *lifetime*, which is the strictly larger miss.
- **Observed symptom:** every vision fallback is a paid analyzer invocation, even for a byte-identical repeat query against the same screenshot.
- **Repro steps / conditions:** any two tool calls that both fall back to vision with the same screenshot and criteria. Reproduced under test — see below.

## Testing

New `test/vision/visionFallbackLifetime.test.ts` drives the production entry
point `getVisionEnrichedError` **without** injecting `visionAnalyzer`, so the
real orchestrator, real cache key and real TTL logic all run. The only
substitution is the paid provider client, which counts its invocations —
assertions are on **call count**, not key equality.

The red state was verified by reverting `VisionFallbackRegistry.get` to
construct a new orchestrator per call (production's behaviour before this PR).
Exactly the cross-call tests fail, and the bypass/eviction tests stay green as
they should:

```
(fail) two separate tool calls with the same screenshot and criteria pay once
(fail) an entry within the TTL is still served after time advances
(fail) config key is order-insensitive, so equivalent configs share a cache
(fail) VisionFallbackRegistry > returns the same instance for an equivalent config
```

Independently, reverting only the content key back to `${screenshotPath}:${criteria}` — with the
registry left in place — reddens the cross-call tests again, so the second half is load-bearing
too:

```
(fail) two separate tool calls with the same screenshot and criteria pay once
(fail) an entry within the TTL is still served after time advances
(fail) config key is order-insensitive, so equivalent configs share a cache
```

Note the tests give every capture a **distinct** timestamped path, matching production, so
sameness lives only in the contents.

With the fix: `bun test test/vision/` → 37 pass, 0 fail. Full suite: 8667 pass,
11 skip, 0 fail.

No real vision analyzer was called at any point; the provider client is stubbed.

### Acceptance criteria

- [x] Two vision fallbacks triggered by two separate tool calls, same screenshot and criteria, invoke the paid analyzer **once** — `two separate tool calls with the same screenshot and criteria pay once`
- [x] The test drives `getVisionEnrichedError` without injecting `visionAnalyzer` — the seam moved down to the provider client, so construction is the real path
- [x] `cacheResults: false` still bypasses the cache, and `cacheTtlMinutes` still evicts — `cacheResults: false still bypasses the cache`, `cacheTtlMinutes still evicts across tool calls`, `an entry within the TTL is still served after time advances`
- [x] Entries are not shared across differing `VisionFallbackConfig` values — `entries are not shared across differing configs`

## Validation

- [x] `bun run lint` + `bun test` pass
- [x] `bun run typecheck` reports no new errors (baseline gate: 224 known)
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] New generic code reuses an existing project helper (`stableStringify` from #4205); no new dependency
- [x] Rebased onto latest `main`

## Follow-ups

- Two *concurrent* identical vision fallbacks both miss and both pay, since there is no
  single-flight around the analyzer call. Narrow (concurrent identical fallbacks are rare) and
  outside this issue's criteria — noted here rather than filed.
- The cache is process-wide rather than per-device. Entries are keyed by screenshot content, so
  two devices sharing an entry means they rendered byte-identical screens and the suggestion is
  equally valid for both.

## Notes

The typecheck gate reports 10 baseline errors that no longer occur. Not ratcheted
here — [#4248](https://github.com/kaeawc/auto-mobile/issues/4248) owns
`scripts/typecheck-baseline.txt`.
