### PR TITLE
fix(setUIState): bound the scroll search so its own error surfaces before the request timeout

### DIFF
--- a/src/features/action/SetUIState.ts
+++ b/src/features/action/SetUIState.ts
@@ -129,14 +129,10 @@ export class SetUIState extends BaseVisualChange {
     let scrollsWithoutProgress = 0;
     let currentDirection: "up" | "down" = scrollDirection;
     let triedReverse = false;
-    const searchDeadline = this.timer.now() + SEARCH_BUDGET_MS;
+    let searchDeadline = this.timer.now() + SEARCH_BUDGET_MS;
     let budgetSpent = false;
 
     while (processed.size < options.fields.length) {
-      if (this.timer.now() >= searchDeadline) {
-        budgetSpent = true;
-        break;
-      }
       // Find all unprocessed fields visible in the current hierarchy, sorted by bounds.top
       const visibleFields = this.findVisibleFieldsInScreenOrder(
         options.fields,
@@ -161,6 +157,10 @@ export class SetUIState extends BaseVisualChange {
         fieldResults[fieldIndex] = result;
         processed.add(fieldIndex);
         totalAttempts += result.attempts;
+        // The budget bounds futile searching, not successful work: a form with
+        // many fields legitimately takes longer than one scroll search, and the
+        // next field may already be on screen (#4252 review).
+        searchDeadline = this.timer.now() + SEARCH_BUDGET_MS;
 
         // Refresh observation after each success
         if (result.success) {
@@ -183,6 +183,11 @@ export class SetUIState extends BaseVisualChange {
         }
       } else {
         // No visible matches — scroll to find more
+        if (this.timer.now() >= searchDeadline) {
+          budgetSpent = true;
+          break;
+        }
+
         scrollsWithoutProgress++;
 
         if (scrollsWithoutProgress > MAX_FUTILE_SCROLLS) {

--- a/src/features/action/SetUIState.ts
+++ b/src/features/action/SetUIState.ts
@@ -66,6 +66,17 @@ interface SetUIStateDependencies {
 const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_SCROLL_DIRECTION = "down";
 const MAX_FUTILE_SCROLLS = 3;
+/**
+ * Wall-clock ceiling for the scroll search.
+ *
+ * Each futile scroll costs a swipe plus an observe against the device, and the
+ * loop tries MAX_FUTILE_SCROLLS in each direction — roughly eight round trips,
+ * which lands at about the caller's request timeout. The caller then sees a
+ * transport timeout instead of this tool's own "Fields not found" error, which
+ * points at the wrong thing (#4242). Stopping short of that keeps the actionable
+ * error reachable.
+ */
+const SEARCH_BUDGET_MS = 20_000;
 
 /**
  * SetUIState - Declarative form field population tool
@@ -118,8 +129,14 @@ export class SetUIState extends BaseVisualChange {
     let scrollsWithoutProgress = 0;
     let currentDirection: "up" | "down" = scrollDirection;
     let triedReverse = false;
+    const searchDeadline = this.timer.now() + SEARCH_BUDGET_MS;
+    let budgetSpent = false;
 
     while (processed.size < options.fields.length) {
+      if (this.timer.now() >= searchDeadline) {
+        budgetSpent = true;
+        break;
+      }
       // Find all unprocessed fields visible in the current hierarchy, sorted by bounds.top
       const visibleFields = this.findVisibleFieldsInScreenOrder(
         options.fields,
@@ -207,7 +224,9 @@ export class SetUIState extends BaseVisualChange {
         fields: this.collectResults(fieldResults, options.fields, processed),
         totalAttempts,
         observation: lastObservation,
-        error: `Fields not found after scrolling: ${missing.join(", ")}`
+        error: budgetSpent
+          ? `Fields not found within the ${Math.round(SEARCH_BUDGET_MS / 1000)}s search budget: ${missing.join(", ")}`
+          : `Fields not found after scrolling: ${missing.join(", ")}`
       };
     }
 
@@ -324,6 +343,14 @@ export class SetUIState extends BaseVisualChange {
           signal
         );
 
+        // Retrying cannot reclassify an element that is not an editable field --
+        // the type comes from the element itself, so the remaining attempts would
+        // fail identically and only cost round trips (#4242).
+        if (!applyResult.success && applyResult.unclassifiable) {
+          lastError = applyResult.error;
+          break;
+        }
+
         if (!applyResult.success) {
           lastError = applyResult.error;
           continue;
@@ -430,7 +457,7 @@ export class SetUIState extends BaseVisualChange {
     fieldType: FieldType,
     progress?: ProgressCallback,
     signal?: AbortSignal
-  ): Promise<{ success: boolean; error?: string }> {
+  ): Promise<{ success: boolean; error?: string; unclassifiable?: boolean }> {
     const tapOnElement = this.getTapOnElement();
     const inputText = this.getInputText();
     const clearText = this.getClearText();
@@ -538,7 +565,15 @@ export class SetUIState extends BaseVisualChange {
         }
 
         default:
-          return { success: false, error: `Unknown field type: ${fieldType}` };
+          // Name what was actually matched: this is normally a label rather than
+          // the input itself, and "Unknown field type: unknown" describes an
+          // internal state the caller cannot act on (#4242).
+          return {
+            success: false,
+            unclassifiable: true,
+            error: `Cannot set ${this.describeSelector(fieldSpec.selector)}: matched an element that is not `
+              + `an editable field (detected type "${fieldType}"). Select the input rather than its label.`
+          };
       }
     } catch (error) {
       return {

--- a/test/features/action/SetUIState.test.ts
+++ b/test/features/action/SetUIState.test.ts
@@ -676,3 +676,131 @@ describe("SetUIState", () => {
     });
   });
 });
+
+describe("SetUIState search budget and unclassifiable fields (#4242)", () => {
+  const device: BootedDevice = { name: "test-device", platform: "android", deviceId: "device-1" };
+
+  let fakeTap: FakeTapOnElement;
+  let fakeInput: FakeInputText;
+  let fakeClear: FakeClearText;
+  let fakeSwipe: FakeSwipeOn;
+  let fakeObserve: FakeObserveScreenForSetUIState;
+  let fakeFieldTypeDetector: FakeFieldTypeDetector;
+  let fakeTimer: FakeTimer;
+
+  beforeEach(() => {
+    fakeTap = new FakeTapOnElement();
+    fakeInput = new FakeInputText();
+    fakeClear = new FakeClearText();
+    fakeSwipe = new FakeSwipeOn();
+    fakeObserve = new FakeObserveScreenForSetUIState();
+    fakeFieldTypeDetector = new FakeFieldTypeDetector();
+    fakeTimer = new FakeTimer();
+  });
+
+  const build = () => new SetUIState(device, null, {
+    tapOnElement: fakeTap,
+    inputText: fakeInput,
+    clearText: fakeClear,
+    swipeOn: fakeSwipe,
+    observeScreen: fakeObserve,
+    fieldTypeDetector: fakeFieldTypeDetector,
+    timer: fakeTimer
+  });
+
+  test("an unmatched selector returns the tool's own error rather than searching forever", async () => {
+    // The screen never contains the field, so the scroll search exhausts both
+    // directions. The caller must get "Fields not found", not a transport timeout.
+    const result = await build().execute({
+      fields: [{ selector: { text: "NeverPresent" }, value: "x" }]
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not found");
+    expect(result.error).toContain("NeverPresent");
+  });
+
+  test("the search is bounded — it does not scroll indefinitely", async () => {
+    await build().execute({
+      fields: [{ selector: { text: "NeverPresent" }, value: "x" }]
+    });
+
+    // Both directions tried, then it stops. Without a bound this would not settle.
+    expect(fakeSwipe.getCallCount()).toBeGreaterThan(0);
+    expect(fakeSwipe.getCallCount()).toBeLessThanOrEqual(10);
+  });
+
+  test("the search stops once its time budget is spent, before the request times out", async () => {
+    // Each observe costs real wall-clock on a device (~3s of swipe + observe per
+    // futile scroll). Fakes are instant, so the cost is simulated here: without a
+    // deadline the loop only stops after exhausting both directions, which is
+    // what pushed a real call past the caller's request timeout (#4242).
+    let observeCalls = 0;
+    fakeObserve.setResultFactory(() => {
+      observeCalls++;
+      fakeTimer.advanceTime(5_000);
+      return {
+        updatedAt: fakeTimer.now(),
+        screenSize: { width: 1080, height: 1920 },
+        systemInsets: { top: 0, right: 0, bottom: 0, left: 0 }
+      };
+    });
+
+    const result = await build().execute({
+      fields: [{ selector: { text: "NeverPresent" }, value: "x" }]
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not found");
+    // The budget must cut the search short rather than running every futile scroll.
+    expect(observeCalls).toBeLessThan(8);
+  });
+
+  test("a matched but unclassifiable node reports what it matched, not 'unknown'", async () => {
+    const hierarchy: ViewHierarchyResult = {
+      hierarchy: {
+        node: [{
+          $: { bounds: { left: 0, top: 0, right: 100, bottom: 50 }, text: "Email" }
+        }]
+      }
+    } as ViewHierarchyResult;
+    fakeObserve.setResult({
+      updatedAt: Date.now(),
+      screenSize: { width: 1080, height: 1920 },
+      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+      viewHierarchy: hierarchy
+    });
+    fakeFieldTypeDetector.setFieldType("Email", "unknown" as any);
+
+    const result = await build().execute({
+      fields: [{ selector: { text: "Email" }, value: "a@b.c" }]
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).not.toBe("Unknown field type: unknown");
+    expect(result.error).toContain("Email");
+  });
+
+  test("an unclassifiable node is not retried", async () => {
+    const hierarchy: ViewHierarchyResult = {
+      hierarchy: {
+        node: [{
+          $: { bounds: { left: 0, top: 0, right: 100, bottom: 50 }, text: "Email" }
+        }]
+      }
+    } as ViewHierarchyResult;
+    fakeObserve.setResult({
+      updatedAt: Date.now(),
+      screenSize: { width: 1080, height: 1920 },
+      systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+      viewHierarchy: hierarchy
+    });
+    fakeFieldTypeDetector.setFieldType("Email", "unknown" as any);
+
+    const result = await build().execute({
+      fields: [{ selector: { text: "Email" }, value: "a@b.c" }]
+    });
+
+    expect(result.totalAttempts).toBeLessThanOrEqual(1);
+  });
+});

--- a/test/features/action/SetUIState.test.ts
+++ b/test/features/action/SetUIState.test.ts
@@ -804,3 +804,69 @@ describe("SetUIState search budget and unclassifiable fields (#4242)", () => {
     expect(result.totalAttempts).toBeLessThanOrEqual(1);
   });
 });
+
+describe("SetUIState budget bounds searching, not successful work (#4252 review)", () => {
+  const device: BootedDevice = { name: "test-device", platform: "android", deviceId: "device-1" };
+
+  let fakeTap: FakeTapOnElement;
+  let fakeInput: FakeInputText;
+  let fakeClear: FakeClearText;
+  let fakeSwipe: FakeSwipeOn;
+  let fakeObserve: FakeObserveScreenForSetUIState;
+  let fakeFieldTypeDetector: FakeFieldTypeDetector;
+  let fakeTimer: FakeTimer;
+
+  beforeEach(() => {
+    fakeTap = new FakeTapOnElement();
+    fakeInput = new FakeInputText();
+    fakeClear = new FakeClearText();
+    fakeSwipe = new FakeSwipeOn();
+    fakeObserve = new FakeObserveScreenForSetUIState();
+    fakeFieldTypeDetector = new FakeFieldTypeDetector();
+    fakeTimer = new FakeTimer();
+  });
+
+  const build = () => new SetUIState(device, null, {
+    tapOnElement: fakeTap, inputText: fakeInput, clearText: fakeClear,
+    swipeOn: fakeSwipe, observeScreen: fakeObserve,
+    fieldTypeDetector: fakeFieldTypeDetector, timer: fakeTimer
+  });
+
+  test("a visible field is still set even after earlier fields consumed the budget", async () => {
+    // Both fields are on screen the whole time. Setting the first is slow, which
+    // must not make the second -- still visible -- be reported as not found.
+    const twoFields = {
+      hierarchy: {
+        node: [
+          { $: { "bounds": { left: 0, top: 0, right: 100, bottom: 50 }, "resource-id": "first", "class": "android.widget.EditText" } },
+          { $: { "bounds": { left: 0, top: 60, right: 100, bottom: 110 }, "resource-id": "second", "class": "android.widget.EditText" } }
+        ]
+      }
+    } as unknown as ViewHierarchyResult;
+
+    // Verification would need the fake hierarchy to echo the typed value; that is
+    // orthogonal to what this test pins, so skip it for both fields.
+    fakeFieldTypeDetector.setSkipVerification("first", true);
+    fakeFieldTypeDetector.setSkipVerification("second", true);
+
+    fakeObserve.setResultFactory(() => {
+      fakeTimer.advanceTime(9_000);
+      return {
+        updatedAt: fakeTimer.now(),
+        screenSize: { width: 1080, height: 1920 },
+        systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+        viewHierarchy: twoFields
+      };
+    });
+
+    const result = await build().execute({
+      fields: [
+        { selector: { elementId: "first" }, value: "a" },
+        { selector: { elementId: "second" }, value: "b" }
+      ]
+    });
+
+    expect(result.error ?? "").not.toContain("not found");
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`setUIState` was not hanging — it was **scroll-searching**. When no field matches it swipes, re-observes and repeats, `MAX_FUTILE_SCROLLS` in each direction before reversing: roughly **eight device round trips**. That lands at about the caller's request timeout, so the caller saw a transport timeout instead of the tool's own error.

The tool already produced the right message (`Fields not found after scrolling: …`, `SetUIState.ts:210`) — it just finished at the same moment the request budget expired, so it never reached the caller.

## Linked Issue

Closes #4242

## Bug / Regression Context

- **Observed symptom:** `setUIState` with a selector that matches nothing → `exit 1 after 30s: MCP error -32001: Request timed out` (reproduced twice). `tapOn` with an equally bogus selector fails in ~2s.
- **Repro:** `setUIState --fields '[{"selector":{"text":"Email"},"value":"x"}]'` on a screen with no `Email`.
- **Correction to the issue:** #4242 said this should "fail fast like `tapOn`". That is wrong — `tapOn` does not scroll-search, and making `setUIState` fail fast would remove its ability to reach **off-screen** fields. The fix is to bound the search so its own error surfaces, not to delete the search.

## Changes

- **`SEARCH_BUDGET_MS = 20_000`** — the scroll loop checks a deadline each iteration and stops, reporting `Fields not found within the 20s search budget: …`. Time comes from the injected `Timer`, so it is testable without real waiting.
- **`Unknown field type: unknown` replaced.** That string describes an internal state; the message now names what was matched and says to select the input rather than its label, which is the usual cause (a selector matching a field's *label* — no class, no editable attributes).
- **No retries on an unclassifiable node.** The type comes from the element itself, so the remaining two attempts would fail identically and only cost round trips.

## Testing

- `bun test` — **8630 pass, 11 skip, 0 fail** (675 files)
- `bun run build` / `bun run lint` / `bun run typecheck` — all pass
- 5 new tests in `test/features/action/SetUIState.test.ts`

The budget test simulates real round-trip cost by advancing `FakeTimer` inside the observe fake — fakes are instant, so without that the unit layer cannot reproduce a wall-clock timeout at all. That is precisely why this escaped existing coverage.

## Acceptance criteria

| # | Criterion | Pinned by |
|---|---|---|
| AC1 | An unmatched selector returns the tool's own error | `an unmatched selector returns the tool's own error…` |
| AC2 | The search is bounded in time | `the search stops once its time budget is spent…` |
| AC3 | The search is bounded in scrolls | `the search is bounded — it does not scroll indefinitely` |
| AC4 | A non-editable match says what it matched | `a matched but unclassifiable node reports what it matched…` |
| AC5 | No retry on an unclassifiable node | `an unclassifiable node is not retried` |

## Follow-up

Whether `MAX_FUTILE_SCROLLS = 3` in **both** directions is the right search shape is a separate question — this PR only stops it from outliving the request.

## Note on the budget

20s is chosen to sit inside the ~30s request timeout with room for the initial observe and the per-field work that follows a successful find. A field that today would be found on a very late scroll under a slow device could now be missed; the error names the budget so that case is diagnosable rather than mysterious.
