### PR TITLE
feat(observe): parse the modern dumpsys Task{...} task header

### DIFF
--- a/src/features/observe/GetBackStack.ts
+++ b/src/features/observe/GetBackStack.ts
@@ -7,6 +7,81 @@ import type { BackStack } from "./interfaces/BackStack";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 
 /**
+ * Legacy task header, printed by `TaskRecord.toString()` / the pre-Android-10
+ * `dumpsys` layout: "Task id #123" or "TaskRecord{task123 #123 A=... sz=3}".
+ */
+const LEGACY_TASK_HEADER = /Task\s+id\s+#(\d+)|TaskRecord.*#(\d+)/;
+
+/**
+ * Modern task header (issue #4223). `TaskFragment.dumpInner` prints
+ *
+ *     pw.print(prefix); pw.print("* "); pw.println(toFullString());
+ *
+ * and `Task.toString()` -- which `Task.toFullString()` extends -- opens with
+ * "Task{" + hex identity hash + " #" + mTaskId before any optional field. The
+ * id is therefore the only positionally stable token after the hash: `A=` /
+ * `I=` / `aI=` are mutually exclusive and `rootTaskId=` appears only for
+ * non-root tasks, so everything past the id is matched by key instead.
+ *
+ * The leading "* " is required. `Task{...}` also appears inline elsewhere in
+ * dumpsys output (adjacent-task-fragment references, child lists), and an
+ * unanchored match would invent tasks out of those references. `TaskFragment{`
+ * is a different `toString()` with no "#id" and does not match "Task\{".
+ *
+ * Source: AOSP android15-release,
+ * services/core/java/com/android/server/wm/Task.java (toString, toFullString)
+ * and .../TaskFragment.java (dumpInner).
+ */
+const MODERN_TASK_HEADER = /^\s*\*\s*Task\{\S+\s+#(\d+)\b(.*)$/;
+
+/** "* Hist  #0: ActivityRecord{...}" -- one printed activity. */
+const HIST_LINE = /\bHist\s+#\d+:/;
+
+/** Fields carried by a modern task header line. */
+interface TaskHeaderFields {
+  id: number;
+  /**
+   * `Task.affinity`, verbatim. On Android 11+ this is uid-prefixed
+   * ("10164:com.example") because `ActivityRecord.computeTaskAffinity`
+   * prepends `uid + ":"` (b/35954083). The standalone `affinity=` line, where
+   * it is printed at all, holds the identical string, so no normalization is
+   * applied on either path.
+   */
+  affinity?: string;
+  /** `I=` / `aI=` -- the task's intent component, when it has no affinity. */
+  component?: string;
+}
+
+/**
+ * Parse a task-header line, modern form first, then the legacy forms.
+ * Returns undefined when the line is not a task header.
+ */
+function parseTaskHeader(line: string): TaskHeaderFields | undefined {
+  const modern = line.match(MODERN_TASK_HEADER);
+  if (modern) {
+    const tail = modern[2];
+    // Space-anchored so "aI=" is not read as "I=", and so "visibleRequested="
+    // and friends cannot contribute a stray key match.
+    // The value is bounded to exclude "}" so a field printed last still yields
+    // the bare value rather than one with the closing brace glued on.
+    const affinity = tail.match(/(?:^|\s)A=([^\s}]+)/);
+    const component = tail.match(/(?:^|\s)a?I=([^\s}]+)/);
+    return {
+      id: parseInt(modern[1], 10),
+      affinity: affinity ? affinity[1] : undefined,
+      component: component ? component[1] : undefined
+    };
+  }
+
+  const legacy = line.match(LEGACY_TASK_HEADER);
+  if (legacy) {
+    return { id: parseInt(legacy[1] || legacy[2], 10) };
+  }
+
+  return undefined;
+}
+
+/**
  * Extracts back stack information from Android device using dumpsys activity
  */
 export class GetBackStack implements BackStack {
@@ -33,10 +108,14 @@ export class GetBackStack implements BackStack {
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
 
-      // Match task affinity: "Task id #123" or "TaskRecord{...} #123"
-      const taskIdMatch = line.match(/Task\s+id\s+#(\d+)|TaskRecord.*#(\d+)/);
-      if (taskIdMatch) {
-        currentTaskId = parseInt(taskIdMatch[1] || taskIdMatch[2], 10);
+      // Match the enclosing task header, legacy or modern (see parseTaskHeader).
+      const header = parseTaskHeader(line);
+      if (header) {
+        currentTaskId = header.id;
+        // A modern header carries its affinity inline; a legacy one leaves it
+        // to the standalone "affinity=" line handled just below. Reset either
+        // way so one task's affinity cannot leak onto the next task.
+        currentTaskAffinity = header.affinity;
         logger.debug(`[BACK_STACK] Found task ID: ${currentTaskId}`);
       }
 
@@ -115,25 +194,49 @@ export class GetBackStack implements BackStack {
 
     let currentTaskId = -1;
     let currentTask: Partial<TaskInfo> = {};
+    // Activities printed under the current header. Modern output has no
+    // "numActivities=" line, and the header's "sz=" is getChildCount() -- child
+    // *containers*, which for a non-leaf task counts child tasks rather than
+    // activities. Counting the task's own "Hist #N" lines is correct for both.
+    let histCount = 0;
+
+    const flush = (): void => {
+      if (currentTaskId === -1 || currentTask.id === undefined) {
+        return;
+      }
+      if (currentTask.numActivities === undefined) {
+        currentTask.numActivities = histCount;
+      }
+      tasks.set(currentTaskId, currentTask as TaskInfo);
+    };
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
 
-      // Match task start: "Task id #123" or "TaskRecord{...} #123"
-      const taskIdMatch = line.match(/Task\s+id\s+#(\d+)|TaskRecord.*#(\d+)/);
-      if (taskIdMatch) {
-        // Save previous task if it exists
-        if (currentTaskId !== -1 && currentTask.id !== undefined) {
-          tasks.set(currentTaskId, currentTask as TaskInfo);
-        }
+      // Match task start, legacy or modern (see parseTaskHeader).
+      const header = parseTaskHeader(line);
+      if (header) {
+        flush();
 
-        currentTaskId = parseInt(taskIdMatch[1] || taskIdMatch[2], 10);
+        currentTaskId = header.id;
         currentTask = { id: currentTaskId };
+        histCount = 0;
+        if (header.affinity) {
+          currentTask.affinity = header.affinity;
+        }
+        if (header.component) {
+          currentTask.rootActivity = header.component;
+          currentTask.packageName = header.component.split("/")[0];
+        }
         logger.debug(`[BACK_STACK] Parsing task: ${currentTaskId}`);
       }
 
       if (currentTaskId === -1) {
         continue;
+      }
+
+      if (HIST_LINE.test(line)) {
+        histCount++;
       }
 
       // Match affinity
@@ -163,9 +266,7 @@ export class GetBackStack implements BackStack {
     }
 
     // Save last task
-    if (currentTaskId !== -1 && currentTask.id !== undefined) {
-      tasks.set(currentTaskId, currentTask as TaskInfo);
-    }
+    flush();
 
     return Array.from(tasks.values());
   }

--- a/test/features/observe/GetBackStackTaskHeader.test.ts
+++ b/test/features/observe/GetBackStackTaskHeader.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from "bun:test";
+import { GetBackStack } from "../../../src/features/observe/GetBackStack";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
+import { BackStackInfo, BootedDevice } from "../../../src/models";
+
+/**
+ * The modern task-header line in `dumpsys activity activities` (issue #4223).
+ *
+ * SOURCE. No capture of this line is committed to this repo -- the 13 dumps
+ * under `test/features/observe/windowDumps/` are `dumpsys window` output and
+ * contain no task headers at all (checked: zero hits for `Task{`, `Task id #`
+ * or `TaskRecord` across all of them). The shape below is therefore taken from
+ * AOSP source rather than guessed, and every field asserted here is traceable
+ * to a specific append:
+ *
+ *   frameworks/base/services/core/java/com/android/server/wm/TaskFragment.java
+ *     dumpInner():  pw.print(prefix); pw.print("* "); pw.println(toFullString());
+ *
+ *   frameworks/base/services/core/java/com/android/server/wm/Task.java
+ *     toString():     "Task{" + hexIdentityHash + " #" + mTaskId
+ *                     + " type=" + activityType
+ *                     + (" A=" + affinity | " I=" + component | " aI=" + component)
+ *                     + "}"
+ *     toFullString(): drops the tail "}", then appends
+ *                     " U=" + userId, optional " rootTaskId=" + id,
+ *                     " visible=", " visibleRequested=", " mode=",
+ *                     " translucent=", " sz=" + getChildCount(), "}"
+ *
+ * (android15-release branch; the same two methods exist unchanged back through
+ * the Android 10 rename of `TaskRecord` to `Task`, which is exactly why the old
+ * `/TaskRecord.*#(\d+)/` alternative stopped matching.)
+ *
+ * Two consequences the parser depends on:
+ *
+ *   1. `#<id>` is ALWAYS the second token, emitted by `toString()` immediately
+ *      after the identity hash, before any optional field. Nothing after it is
+ *      positionally stable -- `A=`/`I=`/`aI=` are mutually exclusive and
+ *      `rootTaskId=` only appears for non-root tasks -- so only the `Task{<hash>
+ *      #<id>` prefix is matched positionally; everything else is matched by key.
+ *   2. The header is only ever printed with a leading `* ` by `dumpInner`, so
+ *      the match is anchored on it. `Task{...}` also appears inline elsewhere in
+ *      dumpsys output (e.g. inside `Activities=[...]`), and an unanchored match
+ *      would invent tasks from those references.
+ *
+ * `TaskFragment{...}` must not be mistaken for a task: it is a different
+ * `toString()` with no `#id`, and `Task\{` does not match `TaskFragment{`.
+ *
+ * WHERE THE AFFINITY COMES FROM (issue #4223, last checkbox). On modern output
+ * `A=` inside the header is the ONLY source. The standalone `affinity=` line is
+ * printed by `Task.dump(PrintWriter, String)`, which
+ * `ActivityTaskManagerService.dumpActivitiesLocked` only reaches on the
+ * `dumpsys activity <package> -a` path -- not on `dumpsys activity activities`.
+ * The same goes for `realActivity=` (renamed `mActivityComponent=` there) and
+ * `numActivities=`, which modern AOSP does not print at all; the header's `sz=`
+ * is `getChildCount()`, i.e. child *containers*, which for a non-leaf task is a
+ * count of child tasks and not of activities. So `sz=` is deliberately NOT read
+ * as `numActivities`; the activity count is taken by counting the task's own
+ * `Hist #N` lines, which is true for leaf and non-leaf tasks alike.
+ *
+ * The value of `A=` is uid-prefixed (`10164:com.example`) on Android 11+:
+ * `ActivityRecord.computeTaskAffinity(affinity, uid)` prepends `uid + ":"`
+ * (b/35954083). It is stored verbatim in `Task.affinity`, so the `affinity=`
+ * line -- where it does appear -- carries the identical uid-prefixed string.
+ * The parser therefore does no normalization: both paths yield the same value.
+ */
+
+const device: BootedDevice = { name: "test", platform: "android", deviceId: "test-device" };
+
+async function parse(stdout: string): Promise<BackStackInfo> {
+  const adb = new FakeAdbExecutor();
+  adb.setCommandResponse("dumpsys activity activities", { stdout, stderr: "" });
+  return new GetBackStack(device, new FakeAdbClientFactory(adb)).execute();
+}
+
+// Field order and spelling per Task.toFullString(); see the header comment.
+const MODERN_TWO_TASKS = `
+ACTIVITY MANAGER ACTIVITIES (dumpsys activity activities)
+Display #0 (activities from top to bottom):
+  * Task{d19dee2 #61 type=standard A=10164:com.example U=0 visible=true visibleRequested=true mode=fullscreen translucent=false sz=2}
+    mBounds=Rect(0, 0 - 1080, 2400)
+    isSleeping=false
+    * Hist  #1: ActivityRecord{2b2ce0f u0 com.example/.DetailActivity t61}
+        packageName=com.example processName=com.example
+    * Hist  #0: ActivityRecord{7ff01aa u0 com.example/com.example.MainActivity t61}
+        packageName=com.example processName=com.example
+  * Task{9c31af0 #1 type=home I=com.android.launcher3/.Launcher U=0 visible=false visibleRequested=false mode=fullscreen translucent=true sz=1}
+    isSleeping=false
+    * Hist  #0: ActivityRecord{3177c30 u0 com.android.launcher3/.Launcher t1}
+
+  topResumedActivity=ActivityRecord{2b2ce0f u0 com.example/.DetailActivity t61}
+`;
+
+describe("modern Task{...} header (#4223)", () => {
+  test("parses the task id out of the Task{<hash> #id ...} header", async () => {
+    const result = await parse(MODERN_TWO_TASKS);
+
+    expect(result.tasks.map(t => t.id)).toEqual([61, 1]);
+  });
+
+  test("reads the affinity from the header's A= token", async () => {
+    const result = await parse(MODERN_TWO_TASKS);
+
+    // Verbatim, uid prefix included -- this is exactly what Task.affinity holds.
+    expect(result.tasks[0].affinity).toBe("10164:com.example");
+  });
+
+  test("reads the root component from I= when the task has no affinity", async () => {
+    const result = await parse(MODERN_TWO_TASKS);
+
+    expect(result.tasks[1].affinity).toBeUndefined();
+    expect(result.tasks[1].rootActivity).toBe("com.android.launcher3/.Launcher");
+    expect(result.tasks[1].packageName).toBe("com.android.launcher3");
+  });
+
+  test("counts the task's own Hist entries rather than trusting sz=", async () => {
+    const result = await parse(MODERN_TWO_TASKS);
+
+    expect(result.tasks.map(t => t.numActivities)).toEqual([2, 1]);
+  });
+
+  test("carries the header affinity onto the task's activities", async () => {
+    const result = await parse(MODERN_TWO_TASKS);
+
+    expect(result.activities[0].taskAffinity).toBe("10164:com.example");
+    expect(result.activities[2].taskAffinity).toBeUndefined();
+  });
+
+  test("uses aI= when only an affinity intent is available", async () => {
+    const result = await parse(`
+  * Task{aaa1111 #12 type=standard aI=com.example/.Alias U=0 visible=true mode=fullscreen sz=1}
+    * Hist  #0: ActivityRecord{bbb u0 com.example/.MainActivity t12}
+`);
+
+    expect(result.tasks[0].id).toBe(12);
+    expect(result.tasks[0].rootActivity).toBe("com.example/.Alias");
+  });
+
+  test("ignores a non-root TaskFragment{...} line", async () => {
+    // TaskFragment.toString() carries no "#id"; it must not create a task.
+    const result = await parse(`
+  * Task{aaa1111 #12 type=standard A=10164:com.example U=0 visible=true mode=fullscreen sz=1}
+    * TaskFragment{ccc2222 mode=fullscreen translucent=false sz=1}
+      * Hist  #0: ActivityRecord{bbb u0 com.example/.MainActivity t12}
+`);
+
+    expect(result.tasks.map(t => t.id)).toEqual([12]);
+  });
+
+  test("does not invent tasks from inline Task{...} references", async () => {
+    // Only dumpInner's "* "-prefixed line is a header. An inline mention such as
+    // the one below is a reference to a task dumped elsewhere.
+    const result = await parse(`
+  * Task{aaa1111 #12 type=standard A=10164:com.example U=0 visible=true mode=fullscreen sz=1}
+    mLastPausedActivity: ActivityRecord{ddd u0 com.example/.Other t99}
+    Activities=[ActivityRecord{bbb u0 com.example/.MainActivity t12}]
+    mAdjacentTaskFragment=Task{eee3333 #77 type=standard A=10164:com.other U=0 visible=false mode=fullscreen sz=1}
+      * Hist  #0: ActivityRecord{bbb u0 com.example/.MainActivity t12}
+`);
+
+    expect(result.tasks.map(t => t.id)).toEqual([12]);
+  });
+
+  test("still parses the legacy Task id # and TaskRecord{} headers", async () => {
+    const legacy = await parse(`
+    Task id #7
+    affinity=com.example
+    realActivity=com.example/.MainActivity
+    numActivities=3
+      * Hist #0: ActivityRecord{aaa u0 com.example/.MainActivity t7}
+`);
+    expect(legacy.tasks.map(t => t.id)).toEqual([7]);
+    expect(legacy.tasks[0].affinity).toBe("com.example");
+    // The explicit numActivities= line wins over the Hist count.
+    expect(legacy.tasks[0].numActivities).toBe(3);
+
+    const taskRecord = await parse(`
+    TaskRecord{task123 #123 A=dev.example U=0 StackId=1 sz=3}
+      * Hist #0: ActivityRecord{aaa u0 dev.example/.MainActivity t123}
+`);
+    expect(taskRecord.tasks.map(t => t.id)).toEqual([123]);
+  });
+});
+
+describe("#4222's claim that depth/currentTaskId are independent of the task header", () => {
+  // PR #4222 asserted that depth and currentTaskId derive from activity lines
+  // carrying their own tNN, and are therefore unaffected by parseTasks not
+  // understanding the modern header. These two tests pin that claim so a future
+  // change to the header parser cannot quietly start feeding depth.
+  test("depth and currentTaskId are correct with a header the parser understands", async () => {
+    const result = await parse(MODERN_TWO_TASKS);
+
+    expect(result.currentTaskId).toBe(61);
+    expect(result.depth).toBe(1);
+  });
+
+  test("depth and currentTaskId are identical with the header line removed", async () => {
+    const withoutHeaders = MODERN_TWO_TASKS.split("\n")
+      .filter(line => !/^\s*\*\s*Task\{/.test(line))
+      .join("\n");
+    const result = await parse(withoutHeaders);
+
+    expect(result.tasks).toEqual([]);
+    expect(result.currentTaskId).toBe(61);
+    expect(result.depth).toBe(1);
+    expect(result.activities.map(a => a.taskId)).toEqual([61, 61, 1]);
+  });
+});


### PR DESCRIPTION
## Summary

`GetBackStack.parseTasks` matched only `Task id #N` and `TaskRecord{...} #N`. AOSP renamed
`TaskRecord` to `Task` in Android 10, so on every modern API level the task-header line went
unrecognized: `result.tasks` came back empty and `affinity` / `packageName` / `numActivities` were
never attached. This teaches both `parseTasks` and `parseActivities` the modern header.

### The real header shape, and where it comes from

No capture of this line exists in the repo. The 13 dumps under `test/features/observe/windowDumps/`
are **`dumpsys window` output, not `dumpsys activity activities`** — they contain zero occurrences of
`Task{`, `Task id #` or `TaskRecord`. So the shape is taken from AOSP source and cited in the code,
not guessed:

- `services/core/java/com/android/server/wm/TaskFragment.java` — `dumpInner()`:
  `pw.print(prefix); pw.print("* "); pw.println(toFullString());`
- `services/core/java/com/android/server/wm/Task.java` — `toString()`:
  `"Task{" + hexIdentityHash + " #" + mTaskId + " type=" + type + (" A="|" I="|" aI=") + …`
  and `toFullString()`, which drops the tail `}` and appends
  `" U="`, optional `" rootTaskId="`, `" visible="`, `" visibleRequested="`, `" mode="`,
  `" translucent="`, `" sz=" + getChildCount()`, `}`.

(`android15-release`; both methods are unchanged back through the Android 10 rename.)

Giving:

```
* Task{d19dee2 #61 type=standard A=10164:com.example U=0 visible=true visibleRequested=true mode=fullscreen translucent=false sz=2}
```

Two properties the parser relies on:

1. `#<id>` is **always** the second token — `toString()` emits it immediately after the identity hash,
   before any optional field. Nothing after it is positionally stable (`A=`/`I=`/`aI=` are mutually
   exclusive; `rootTaskId=` appears only for non-root tasks), so everything past the id is matched by
   key rather than by offset.
2. The header is only ever printed with a leading `* ` by `dumpInner`. The match is anchored on it,
   because `Task{...}` also appears inline in dumpsys output (adjacent-task-fragment references, child
   lists) and an unanchored match would invent tasks from those. `TaskFragment{` is a different
   `toString()` with no `#id` and does not match `Task\{`.

### Where the affinity comes from (issue's last checkbox)

**On `dumpsys activity activities`, `A=` inside the header is the only source.** The standalone
`affinity=` line is printed by `Task.dump(PrintWriter, String)`, which
`ActivityTaskManagerService.dumpActivitiesLocked` reaches only on the `dumpsys activity <package> -a`
path. Same for `realActivity=` (renamed `mActivityComponent=` there) and `numActivities=`, which
modern AOSP does not print at all.

The header's `sz=` is **not** read as `numActivities`: it is `getChildCount()`, i.e. child
*containers*, which for a non-leaf task counts child tasks. The activity count is taken by counting
the task's own `Hist #N` lines, which is correct for leaf and non-leaf tasks alike. An explicit
legacy `numActivities=` line still wins.

`A=`'s value is uid-prefixed (`10164:com.example`) on Android 11+ —
`ActivityRecord.computeTaskAffinity` prepends `uid + ":"` (b/35954083) and it is stored verbatim in
`Task.affinity`, so the `affinity=` line carries the identical string. No normalization is applied on
either path.

### #4222's `depth` / `currentTaskId` claim: confirmed

PR #4222 claimed both derive from activity lines carrying their own `tNN` and are therefore unaffected
by the task-header gap. That holds — verified before changing anything: the two tests in
`describe("#4222's claim …")` were **green against the unmodified parser**, and one of them strips the
`* Task{…}` header lines outright and still gets `currentTaskId === 61`, `depth === 1` with
`tasks === []`. Those tests are kept as a regression guard so a future header change cannot quietly
start feeding `depth`. This is why the issue is narrower than its title suggests: the gap was metadata
only, exactly as #4222 said.

One behavior change beyond pure addition: `currentTaskAffinity` in `parseActivities` is now **reset**
at each task header instead of persisting. Previously a task with no affinity inherited the previous
task's — visible as soon as modern headers parse, since a `type=home` task has `I=` and no `A=`.

## Linked Issue

Refs #4223 — **partially addressed; deliberately not `Closes`.** See "Unmet acceptance criteria" below.

## Unmet acceptance criteria (no device access this session)

From the issue's Work list:

- [ ] ~~Capture `dumpsys activity activities` from an emulator **and a physical device**, on two API levels~~ — **NOT DONE.** No device/emulator/adb interaction was possible this session.
- [ ] ~~Commit them as fixtures~~ — **NOT DONE**, follows from the above. The new suite uses fixtures constructed field-by-field from the cited AOSP `toFullString()` appends, which is stronger than the previous hand-written guess but is still not a capture.
- [x] Teach `parseTasks` the `Task{<hash> #id …}` header form — **done**, driven by AOSP source rather than by captures.
- [x] Confirm whether `affinity=` still appears as its own line, or whether `A=` is now the only source — **done**: on the `activities` dump path, `A=` is the only source (details above).

The two capture criteria are the reason this PR references rather than closes #4223. #4223 should stay
open, with its remaining scope reduced to the capture work.

## Bug / Regression Context

- **Prior attempts:** [#4197](https://github.com/kaeawc/auto-mobile/issues/4197) / [PR #4222](https://github.com/kaeawc/auto-mobile/pull/4222) fixed `parseActivities`; the task header was explicitly left out for lack of a confirmed shape.
- **Observed symptom:** `result.tasks === []` on modern API levels; no task affinity, package name or activity count.
- **Repro steps / conditions:** any `observe` on Android 10+. Reproduced here without a device via the new suite, which was red on 8 of 11 tests before the change.

## Validation

- [x] `bun run lint` clean
- [x] `bun test` — **8665 pass, 0 fail**, 11 skip, 28.7s
- [x] `bun run typecheck` — no new errors (224 known baseline errors). The gate reports 10 baseline errors that no longer occur; the baseline is deliberately **not** ratcheted here because [#4248](https://github.com/kaeawc/auto-mobile/issues/4248) owns it.
- [x] `bun run build` succeeds
- [x] New code uses the existing `FakeAdbExecutor` / `FakeAdbClientFactory` seams; the new suite runs in ~5ms
- [x] No new dependencies; pure string parsing, no Swift/shell/schema/DB/runner-protocol surface

## Device Verification

N/A — deliberately not performed. Devices were off-limits this session; see "Unmet acceptance
criteria" above. Nothing in this diff has an on-device code path: it parses a string.

## Follow-ups

- Remaining scope of [#4223](https://github.com/kaeawc/auto-mobile/issues/4223): capture real
  `dumpsys activity activities` from an emulator and a physical device on two API levels, commit them
  as fixtures, and confirm the header shape asserted here against them.
