### PR TITLE
fix(ci): resolve the Android emulator SDK before the product boot flow runs

### DIFF
--- a/.github/actions/android-emulator/action.yml
+++ b/.github/actions/android-emulator/action.yml
@@ -156,6 +156,15 @@ runs:
         echo "RELEASE_KEY_ALIAS=${{ inputs.release-key-alias }}" >> $GITHUB_ENV
         echo "RELEASE_KEY_PASSWORD=${{ inputs.release-key-password }}" >> $GITHUB_ENV
 
+    # The AVD-creation step above is the only place the third-party action runs,
+    # and it is skipped on an AVD cache hit -- which is also the only thing that
+    # installs the SDK `emulator` package and puts it on PATH. Every step below
+    # runs outside that action, so the SDK has to be resolved explicitly here or
+    # the product boot flow cannot find the emulator binary (issue #4237).
+    - name: Ensure Android emulator SDK is resolvable
+      shell: ${{ inputs.shell }}
+      run: "${{ github.workspace }}/scripts/android/ensure-emulator-sdk.sh"
+
     # The third-party action above owns SDK/AVD/snapshot preparation only. The
     # product owns every actual emulator launch and readiness probe below.
     - name: Boot and test Emulator (Attempt 1)

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -783,6 +783,31 @@ jobs:
           path: scratch/junit-runner-kotlin-consumer/logs/
           if-no-files-found: ignore
 
+  # The two emulator jobs below stay disabled on merge (runner-heavy, ~15 min
+  # each) and run nightly instead. That left the CI emulator boot path with no
+  # main-push signal at all: #4199 broke it and main stayed green (#4237). This
+  # job is the cheap half of that signal -- it proves the product boot flow can
+  # resolve the emulator binary on a runner where the third-party
+  # emulator-runner action never executed, which is exactly the state an AVD
+  # cache hit produces. It boots nothing and takes ~2 minutes.
+  android-emulator-sdk-preflight:
+    name: "Verify Android Emulator SDK Resolution"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: "Git Checkout"
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+
+      - uses: ./.github/actions/setup-auto-mobile-npm-package
+        with:
+          install-global: "false"
+
+      - name: "Verify the emulator SDK resolves for the product boot flow"
+        shell: "bash"
+        run: scripts/android/verify-emulator-sdk-resolution.sh
+
   # Test isolation issue resolved in #107 and #109
   # Re-enabled in #110
   junit-runner-emulator-tests:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -242,6 +242,11 @@ jobs:
             android:
               - 'android/**'
               - 'scripts/android/**'
+              # The emulator jobs are exactly what this composite action drives,
+              # so an edit to it must exercise them rather than skip them. #4199
+              # rewired this action and only ran the emulator jobs incidentally,
+              # because it also touched scripts/android/** (see #4237).
+              - '.github/actions/android-emulator/**'
               - 'scripts/local-dev/hot-reload.sh'
               - '.github/workflows/android*.yml'
               # This workflow controls Android-job gating, so changes to it

--- a/scripts/android/ensure-emulator-sdk.sh
+++ b/scripts/android/ensure-emulator-sdk.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Make the Android emulator binary resolvable to the AutoMobile product boot flow.
+#
+# `reactivecircus/android-emulator-runner` is the step that installs the SDK
+# `emulator` package and exports ANDROID_HOME/PATH, and it only runs in this
+# repo on an AVD cache MISS. On a cache HIT that step is skipped, so a plain
+# `run:` step that calls scripts/android/boot-emulator.sh sees an SDK with no
+# emulator/ directory and listAvds fails with ENOENT (issue #4237).
+#
+# This script is the precondition for every emulator launch that happens outside
+# the third-party action: it resolves the SDK root, installs the `emulator`
+# package when it is absent, and publishes ANDROID_HOME / ANDROID_SDK_ROOT /
+# PATH to later steps via GITHUB_ENV and GITHUB_PATH.
+set -euo pipefail
+
+sdk_root="${ANDROID_HOME:-${ANDROID_SDK_ROOT:-${ANDROID_SDK_HOME:-}}}"
+if [[ -z "${sdk_root}" ]]; then
+  for candidate in "/usr/local/lib/android/sdk" "${HOME:-}/Library/Android/sdk" "${HOME:-}/Android/Sdk"; do
+    if [[ -n "${candidate}" && -d "${candidate}" ]]; then
+      sdk_root="${candidate}"
+      break
+    fi
+  done
+fi
+
+if [[ -z "${sdk_root}" ]]; then
+  echo "error: could not resolve an Android SDK root." >&2
+  echo "  ANDROID_HOME=${ANDROID_HOME:-<unset>}" >&2
+  echo "  ANDROID_SDK_ROOT=${ANDROID_SDK_ROOT:-<unset>}" >&2
+  echo "  PATH=${PATH}" >&2
+  exit 1
+fi
+
+emulator_bin="${sdk_root}/emulator/emulator"
+
+if [[ ! -x "${emulator_bin}" ]]; then
+  sdkmanager=""
+  for candidate in \
+    "${sdk_root}/cmdline-tools/latest/bin/sdkmanager" \
+    "${sdk_root}/cmdline-tools/bin/sdkmanager" \
+    "${sdk_root}/tools/bin/sdkmanager"; do
+    if [[ -x "${candidate}" ]]; then
+      sdkmanager="${candidate}"
+      break
+    fi
+  done
+
+  if [[ -z "${sdkmanager}" ]]; then
+    echo "error: Android emulator package is missing and no sdkmanager was found to install it." >&2
+    echo "  resolved ANDROID_HOME=${sdk_root}" >&2
+    echo "  expected emulator binary=${emulator_bin}" >&2
+    echo "  PATH=${PATH}" >&2
+    exit 1
+  fi
+
+  echo "Android emulator package missing at ${emulator_bin}; installing via ${sdkmanager}"
+  yes 2>/dev/null | "${sdkmanager}" --install "emulator" >/dev/null || true
+fi
+
+if [[ ! -x "${emulator_bin}" ]]; then
+  echo "error: Android emulator binary still not executable after install attempt." >&2
+  echo "  resolved ANDROID_HOME=${sdk_root}" >&2
+  echo "  expected emulator binary=${emulator_bin}" >&2
+  echo "  PATH=${PATH}" >&2
+  exit 1
+fi
+
+echo "Resolved ANDROID_HOME=${sdk_root}"
+echo "Resolved emulator=${emulator_bin}"
+
+export ANDROID_HOME="${sdk_root}"
+export ANDROID_SDK_ROOT="${sdk_root}"
+
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  {
+    echo "ANDROID_HOME=${sdk_root}"
+    echo "ANDROID_SDK_ROOT=${sdk_root}"
+  } >> "${GITHUB_ENV}"
+fi
+
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+  {
+    echo "${sdk_root}/emulator"
+    echo "${sdk_root}/platform-tools"
+  } >> "${GITHUB_PATH}"
+fi

--- a/scripts/android/verify-emulator-sdk-resolution.sh
+++ b/scripts/android/verify-emulator-sdk-resolution.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Main-push tripwire for the CI emulator SDK precondition (issue #4237).
+#
+# The emulator integration jobs are runner-heavy and only run nightly, so a
+# break in the CI boot path can sit on main for a day looking green. This is the
+# cheap half of that signal: it proves the *product* boot flow can resolve the
+# emulator binary in a CI environment, without booting anything.
+#
+# It deliberately asks for an AVD that does not exist. A healthy environment
+# fails with "no matching device"; a broken one fails with "Android emulator not
+# found", which is the regression this guards.
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/../.." && pwd)"
+
+"${script_dir}/ensure-emulator-sdk.sh"
+
+missing_avd="automobile-sdk-resolution-probe"
+set +e
+output="$(cd "${repo_root}" && bun run src/index.ts --boot-device --platform android \
+  --name "${missing_avd}" --timeout-ms 5000 2>&1)"
+set -e
+
+if printf '%s' "${output}" | grep -q "Android emulator not found"; then
+  echo "error: the product boot flow cannot resolve the Android emulator in CI." >&2
+  printf '%s\n' "${output}" >&2
+  exit 1
+fi
+
+echo "Android emulator SDK is resolvable by the product boot flow."

--- a/scripts/android/verify-emulator-sdk-resolution.sh
+++ b/scripts/android/verify-emulator-sdk-resolution.sh
@@ -18,7 +18,11 @@ repo_root="$(cd -- "${script_dir}/../.." && pwd)"
 
 missing_avd="automobile-sdk-resolution-probe"
 set +e
-output="$(cd "${repo_root}" && bun run src/index.ts --boot-device --platform android \
+# Pin creation off explicitly. This probe deliberately names an AVD that does
+# not exist, so if AUTOMOBILE_ALLOW_DEVICE_CREATE is ever turned on repo-wide it
+# would turn a two-minute resolution check into a full emulator provision.
+output="$(cd "${repo_root}" && AUTOMOBILE_ALLOW_DEVICE_CREATE=0 \
+  bun run src/index.ts --boot-device --platform android \
   --name "${missing_avd}" --timeout-ms 5000 2>&1)"
 set -e
 

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -406,6 +406,25 @@ export class AndroidEmulatorClient implements AndroidEmulator {
     return existsSync(trimmedPath);
   }
 
+  /**
+   * Describe how the emulator binary was resolved, for failure diagnostics.
+   *
+   * The previous guidance ("install via Homebrew") is actively misleading on a
+   * CI runner, where the SDK is present but the emulator package is not. The
+   * resolved path plus the environment it came from is what identifies the
+   * actual gap (issue #4237).
+   */
+  private describeEmulatorResolution(): string {
+    const unset = "<unset>";
+    return [
+      `  resolved emulator path: ${this.emulatorPath || unset}`,
+      `  ANDROID_HOME=${process.env.ANDROID_HOME ?? unset}`,
+      `  ANDROID_SDK_ROOT=${process.env.ANDROID_SDK_ROOT ?? unset}`,
+      `  ANDROID_SDK_HOME=${process.env.ANDROID_SDK_HOME ?? unset}`,
+      `  PATH=${process.env.PATH ?? unset}`,
+    ].join("\n");
+  }
+
   private isLikelyDaemonWorkingDirectoryFailure(errorMsg: string): boolean {
     if (!this.isResolvedEmulatorPathAvailable()) {
       return false;
@@ -661,12 +680,10 @@ export class AndroidEmulatorClient implements AndroidEmulator {
       }
       if (missingEmulator) {
         throw new ActionableError(
-          `Android emulator not found. Please install it using one of these methods:\n` +
-          `1. Via Homebrew: brew install android-emulator\n` +
-          `2. Via Android Studio: Download from https://developer.android.com/studio\n` +
-          `3. Via Android SDK Manager: sdkmanager --install "emulator"\n\n` +
-          `Or set ANDROID_HOME to point to your Android SDK installation:\n` +
-          `export ANDROID_HOME=/path/to/android/sdk`
+          `Android emulator not found.\n${this.describeEmulatorResolution()}\n\n` +
+          `Install the emulator package with: sdkmanager --install "emulator"\n` +
+          `(Android Studio installs it too: https://developer.android.com/studio)\n` +
+          `Or point ANDROID_HOME at an SDK that already has emulator/emulator.`
         );
       }
 

--- a/test/bats/ensure-emulator-sdk.bats
+++ b/test/bats/ensure-emulator-sdk.bats
@@ -1,0 +1,151 @@
+#!/usr/bin/env bats
+
+SCRIPT="scripts/android/ensure-emulator-sdk.sh"
+
+setup() {
+  SCRIPT_PATH="$(pwd)/$SCRIPT"
+  SDK_ROOT="$(mktemp -d)"
+  GITHUB_ENV_FILE="$(mktemp)"
+  GITHUB_PATH_FILE="$(mktemp)"
+}
+
+teardown() {
+  rm -rf "$SDK_ROOT"
+  rm -f "$GITHUB_ENV_FILE" "$GITHUB_PATH_FILE"
+}
+
+make_emulator() {
+  mkdir -p "${SDK_ROOT}/emulator"
+  printf '#!/usr/bin/env bash\n' > "${SDK_ROOT}/emulator/emulator"
+  chmod +x "${SDK_ROOT}/emulator/emulator"
+}
+
+make_sdkmanager() {
+  mkdir -p "${SDK_ROOT}/cmdline-tools/latest/bin"
+  cat > "${SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" <<MOCK
+#!/usr/bin/env bash
+if [[ "\$*" == *"emulator"* ]]; then
+  mkdir -p "${SDK_ROOT}/emulator"
+  printf '#!/usr/bin/env bash\n' > "${SDK_ROOT}/emulator/emulator"
+  chmod +x "${SDK_ROOT}/emulator/emulator"
+fi
+MOCK
+  chmod +x "${SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager"
+}
+
+@test "publishes ANDROID_HOME and the emulator directory to later workflow steps" {
+  make_emulator
+
+  run env ANDROID_HOME="$SDK_ROOT" ANDROID_SDK_ROOT= ANDROID_SDK_HOME= \
+    GITHUB_ENV="$GITHUB_ENV_FILE" GITHUB_PATH="$GITHUB_PATH_FILE" \
+    bash "$SCRIPT_PATH"
+
+  [ "$status" -eq 0 ]
+  [[ "$(<"$GITHUB_ENV_FILE")" == *"ANDROID_HOME=${SDK_ROOT}"* ]]
+  [[ "$(<"$GITHUB_ENV_FILE")" == *"ANDROID_SDK_ROOT=${SDK_ROOT}"* ]]
+  [[ "$(<"$GITHUB_PATH_FILE")" == *"${SDK_ROOT}/emulator"* ]]
+  [[ "$(<"$GITHUB_PATH_FILE")" == *"${SDK_ROOT}/platform-tools"* ]]
+}
+
+@test "installs the emulator package when the AVD cache hit skipped the runner action" {
+  # This is issue #4237: on an AVD cache hit the third-party emulator-runner
+  # step never runs, so the SDK has no emulator/ directory at all.
+  make_sdkmanager
+
+  run env ANDROID_HOME="$SDK_ROOT" ANDROID_SDK_ROOT= ANDROID_SDK_HOME= \
+    GITHUB_ENV="$GITHUB_ENV_FILE" GITHUB_PATH="$GITHUB_PATH_FILE" \
+    bash "$SCRIPT_PATH"
+
+  [ "$status" -eq 0 ]
+  [ -x "${SDK_ROOT}/emulator/emulator" ]
+  [[ "$output" == *"installing via"* ]]
+}
+
+@test "names the resolved ANDROID_HOME and PATH when the emulator cannot be resolved" {
+  run env ANDROID_HOME="$SDK_ROOT" ANDROID_SDK_ROOT= ANDROID_SDK_HOME= \
+    GITHUB_ENV="$GITHUB_ENV_FILE" GITHUB_PATH="$GITHUB_PATH_FILE" \
+    bash "$SCRIPT_PATH"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"resolved ANDROID_HOME=${SDK_ROOT}"* ]]
+  [[ "$output" == *"expected emulator binary=${SDK_ROOT}/emulator/emulator"* ]]
+  [[ "$output" == *"PATH="* ]]
+  [[ "$output" != *"Homebrew"* ]]
+}
+
+# Skipping locally is a convenience; skipping in CI would silently retire the
+# wiring assertions below, which is the fail-green this guard exists to catch.
+wiring_requires_yq() {
+  command -v yq >/dev/null 2>&1 && return 0
+  if [[ -n "${CI:-}" ]]; then
+    echo "yq is required in CI to verify android-emulator action wiring" >&2
+    return 1
+  fi
+  skip "yq not installed"
+}
+
+@test "the android-emulator action resolves the SDK before it boots the emulator (#4237)" {
+  wiring_requires_yq
+  action=".github/actions/android-emulator/action.yml"
+
+  ensure_index="$(yq -r \
+    '[.runs.steps[] | .run // ""] | to_entries | map(select(.value | test("ensure-emulator-sdk.sh"))) | .[0].key' \
+    "$action")"
+  boot_index="$(yq -r \
+    '[.runs.steps[] | .run // ""] | to_entries | map(select(.value | test("boot-emulator.sh"))) | .[0].key' \
+    "$action")"
+
+  [ "$ensure_index" != "null" ]
+  [ "$boot_index" != "null" ]
+  [ "$ensure_index" -lt "$boot_index" ]
+}
+
+@test "reports the resolved environment when no SDK root can be found at all" {
+  run env -u ANDROID_HOME -u ANDROID_SDK_ROOT -u ANDROID_SDK_HOME -u HOME \
+    bash -c 'cd / && exec "$0"' "$SCRIPT_PATH"
+
+  # Either it resolved a real SDK on this machine (status 0) or it failed with a
+  # diagnostic that names what it looked at -- never a bare failure.
+  if [ "$status" -ne 0 ]; then
+    [[ "$output" == *"ANDROID_HOME="* ]]
+    [[ "$output" == *"PATH="* ]]
+  fi
+}
+
+@test "the resolution tripwire fails when the product cannot find the emulator" {
+  make_emulator
+  fake_bin="$(mktemp -d)"
+  cat > "${fake_bin}/bun" <<'MOCK'
+#!/usr/bin/env bash
+echo "error: Android emulator not found."
+exit 1
+MOCK
+  chmod +x "${fake_bin}/bun"
+
+  run env ANDROID_HOME="$SDK_ROOT" ANDROID_SDK_ROOT= ANDROID_SDK_HOME= \
+    PATH="${fake_bin}:${PATH}" \
+    bash "$(pwd)/scripts/android/verify-emulator-sdk-resolution.sh"
+
+  rm -rf "$fake_bin"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"cannot resolve the Android emulator in CI"* ]]
+}
+
+@test "the resolution tripwire passes when the emulator resolves but the AVD is absent" {
+  make_emulator
+  fake_bin="$(mktemp -d)"
+  cat > "${fake_bin}/bun" <<'MOCK'
+#!/usr/bin/env bash
+echo "error: No matching device found for automobile-sdk-resolution-probe"
+exit 1
+MOCK
+  chmod +x "${fake_bin}/bun"
+
+  run env ANDROID_HOME="$SDK_ROOT" ANDROID_SDK_ROOT= ANDROID_SDK_HOME= \
+    PATH="${fake_bin}:${PATH}" \
+    bash "$(pwd)/scripts/android/verify-emulator-sdk-resolution.sh"
+
+  rm -rf "$fake_bin"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"resolvable by the product boot flow"* ]]
+}

--- a/test/bats/ensure-emulator-sdk.bats
+++ b/test/bats/ensure-emulator-sdk.bats
@@ -149,3 +149,25 @@ MOCK
   [ "$status" -eq 0 ]
   [[ "$output" == *"resolvable by the product boot flow"* ]]
 }
+
+@test "the resolution tripwire never provisions a device even if creation is enabled globally" {
+  make_emulator
+  fake_bin="$(mktemp -d)"
+  seen="$(mktemp)"
+  cat > "${fake_bin}/bun" <<MOCK
+#!/usr/bin/env bash
+printf '%s\n' "\${AUTOMOBILE_ALLOW_DEVICE_CREATE:-<unset>}" > "${seen}"
+echo "error: No matching device found"
+exit 1
+MOCK
+  chmod +x "${fake_bin}/bun"
+
+  run env ANDROID_HOME="$SDK_ROOT" ANDROID_SDK_ROOT= ANDROID_SDK_HOME= \
+    AUTOMOBILE_ALLOW_DEVICE_CREATE=1 PATH="${fake_bin}:${PATH}" \
+    bash "$(pwd)/scripts/android/verify-emulator-sdk-resolution.sh"
+
+  [ "$status" -eq 0 ]
+  [ "$(<"$seen")" = "0" ]
+  rm -rf "$fake_bin"
+  rm -f "$seen"
+}

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-listAvds.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-listAvds.test.ts
@@ -151,6 +151,52 @@ describe("AndroidEmulatorClient listAvds", () => {
     }
   });
 
+  test("names the resolved emulator path, ANDROID_HOME and PATH when the emulator is missing", async () => {
+    // Issue #4237: on a GitHub runner the "install via Homebrew" guidance is
+    // useless. What the operator actually needs is the path that was probed and
+    // the environment it was derived from.
+    const originalAndroidHome = process.env.ANDROID_HOME;
+    const originalAndroidSdkRoot = process.env.ANDROID_SDK_ROOT;
+    const originalPath = process.env.PATH;
+
+    try {
+      process.env.ANDROID_HOME = "/usr/local/lib/android/sdk";
+      delete process.env.ANDROID_SDK_ROOT;
+      process.env.PATH = "/usr/bin:/bin";
+
+      const execAsync = async (): Promise<ExecResult> => {
+        throw new Error("spawn /usr/local/lib/android/sdk/emulator/emulator ENOENT");
+      };
+      const client = new AndroidEmulatorClient(execAsync, null, new FakeTimer(), undefined, noAvdConfigReader);
+      (client as any).ensureEmulatorPath = async () => "/usr/local/lib/android/sdk/emulator/emulator";
+
+      let message = "";
+      try {
+        await client.listAvds();
+      } catch (error) {
+        message = error instanceof Error ? error.message : String(error);
+      }
+
+      expect(message).toContain("Android emulator not found");
+      expect(message).toContain("/usr/local/lib/android/sdk/emulator/emulator");
+      expect(message).toContain("ANDROID_HOME=/usr/local/lib/android/sdk");
+      expect(message).toContain("ANDROID_SDK_ROOT=<unset>");
+      expect(message).toContain("PATH=/usr/bin:/bin");
+    } finally {
+      if (originalAndroidHome === undefined) {
+        delete process.env.ANDROID_HOME;
+      } else {
+        process.env.ANDROID_HOME = originalAndroidHome;
+      }
+      if (originalAndroidSdkRoot === undefined) {
+        delete process.env.ANDROID_SDK_ROOT;
+      } else {
+        process.env.ANDROID_SDK_ROOT = originalAndroidSdkRoot;
+      }
+      process.env.PATH = originalPath;
+    }
+  });
+
   test("returns AVDs when emulator command succeeds", async () => {
     const execAsync = async (_command: string): Promise<ExecResult> =>
       createExecResult("Pixel_9\nPixel_Tablet\n");


### PR DESCRIPTION
## Summary

The Android emulator CI jobs run `scripts/android/boot-emulator.sh` from a plain `run:` step, outside `reactivecircus/android-emulator-runner`. That third-party action is the only thing that installs the SDK `emulator` package and puts it on `PATH` — and in this repo it is invoked from a single step that is **skipped on an AVD cache hit**. So on a cache hit the SDK on disk has no `emulator/` directory at all, and the product boot flow (`bootDevice.ts` → `deviceBootService` → `listAvds`) dies with `Android emulator not found`.

This adds an explicit SDK-resolution precondition to the composite action, replaces the misleading failure text, and closes the visibility gap that let the break sit on `main` unnoticed.

## Linked Issue

Closes [#4237](https://github.com/kaeawc/auto-mobile/issues/4237)

## Bug / Regression Context

- **Prior attempts:** [#4199](https://github.com/kaeawc/auto-mobile/pull/4199) moved the emulator boot out of the runner action's `script:` block and into a `run:` step. It is also the source of [#4212](https://github.com/kaeawc/auto-mobile/issues/4212).
- **Observed symptom:** `Run JUnit Runner Emulator Tests` / `Run Playground Automobile Emulator Tests` fail at `AndroidEmulatorClient.ts:663` with `Android emulator not found`.
- **Repro conditions:** the failure is **AVD-cache-state dependent**, which is why it looked intermittent:
  - [#4199](https://github.com/kaeawc/auto-mobile/pull/4199)'s own run logged `Cache not found for input keys: avd-Linux-test-35-...` → the runner action executed → it installed `emulator` → **green**.
  - [#4217](https://github.com/kaeawc/auto-mobile/pull/4217)'s run logged `Cache restored from key: avd-Linux-test-35-x86_64-google_apis` → the `Create AVD and generate snapshot` step was skipped → the `emulator` package was never installed → **red**.
  - Confirmed against the nightly log: `$ANDROID_HOME/emulator` is owned by `runner` and dated to the run itself, not baked into the ubuntu image.

## Changes

**SDK resolution (criterion 1)**
- New `scripts/android/ensure-emulator-sdk.sh`: resolves the SDK root, installs the `emulator` package via `sdkmanager` when it is missing, and publishes `ANDROID_HOME` / `ANDROID_SDK_ROOT` and `$SDK/emulator` + `$SDK/platform-tools` to later steps via `GITHUB_ENV` / `GITHUB_PATH`.
- `.github/actions/android-emulator/action.yml` runs it immediately before the boot/test steps, so the precondition no longer depends on whether the AVD cache hit.

**Diagnostic (criterion 3)**
- `listAvds` no longer suggests Homebrew on a CI runner. It now names the resolved emulator path, `ANDROID_HOME`, `ANDROID_SDK_ROOT`, `ANDROID_SDK_HOME`, and `PATH`, then gives the one instruction that is actually correct in every environment (`sdkmanager --install "emulator"`).

**Visibility (criterion 4)**
- Two real trigger gaps, distinct from the path filter people assume:
  1. The filter is `scripts/android/**`, **not** `scripts/**`. [#4232](https://github.com/kaeawc/auto-mobile/pull/4232) touched `scripts/shellcheck/**` and correctly skipped.
  2. Editing `.github/actions/android-emulator/**` — the action these jobs exist to drive — did **not** trigger them. #4199 ran them only incidentally, because it also touched `scripts/android/**`. That path is now in the `android` filter.
- On `main`: the two emulator jobs are deliberately `if: ${{ false }}` in `merge.yml` (runner-heavy, ~15 min each) and run nightly. Rather than reverse that cost decision, this adds `Verify Android Emulator SDK Resolution` — a ~2 minute merge job that runs `scripts/android/verify-emulator-sdk-resolution.sh`. It asks the daemon-free boot entrypoint for an AVD that does not exist and fails if the answer is `Android emulator not found` rather than "no matching device". It boots nothing, and it reproduces the strictest form of the broken state (a runner where the emulator-runner action never executed at all). It would have gone red on `main` the moment #4199 landed.

## Testing

- `test/bats/ensure-emulator-sdk.bats` (7 tests): env publication, install-on-cache-hit, the diagnostic naming `ANDROID_HOME`/`PATH` and *not* mentioning Homebrew, a `yq`-based wiring guard that the resolve step precedes `boot-emulator.sh` in the composite action, and both tripwire outcomes.
- `AndroidEmulatorClient-listAvds.test.ts`: new case pinning the resolved path + env in the failure message.
- The emulator jobs run on this PR (it touches `scripts/android/**`), which is the criterion-2 check.

## Validation

- [x] `bunx turbo run lint build` passes
- [x] `bun test` — 8655 pass / 0 fail
- [x] `bats test/bats/` — 576 pass
- [x] `bun run typecheck` reports no new errors (baseline untouched; the reported 10-error shrink belongs to [#4248](https://github.com/kaeawc/auto-mobile/issues/4248))
- [x] `shellcheck` clean; `scripts/shellcheck/validate_shell_portability.sh scripts` clean; `scripts/shellcheck/validate_shell_scripts.sh` and `scripts/conventions/validate-stdlib-first.sh` clean

## Follow-ups

None filed. The remaining known weakness is that a single green emulator run is not proof, because behavior differs between AVD cache hit and miss — the new merge-push tripwire is specifically the cache-miss-independent half of that signal.
