### PR TITLE
fix(setUIState): recover the search-budget arming fix that missed #4252's merge

### DIFF
--- a/src/features/action/SetUIState.ts
+++ b/src/features/action/SetUIState.ts
@@ -129,7 +129,10 @@ export class SetUIState extends BaseVisualChange {
     let scrollsWithoutProgress = 0;
     let currentDirection: "up" | "down" = scrollDirection;
     let triedReverse = false;
-    let searchDeadline = this.timer.now() + SEARCH_BUDGET_MS;
+    // Null until a search actually starts. Holding a rolling deadline instead
+    // makes the budget sensitive to how long unrelated work took -- a slow
+    // post-success observe would age it before the next search even began.
+    let searchDeadline: number | null = null;
     let budgetSpent = false;
 
     while (processed.size < options.fields.length) {
@@ -157,10 +160,9 @@ export class SetUIState extends BaseVisualChange {
         fieldResults[fieldIndex] = result;
         processed.add(fieldIndex);
         totalAttempts += result.attempts;
-        // The budget bounds futile searching, not successful work: a form with
-        // many fields legitimately takes longer than one scroll search, and the
-        // next field may already be on screen (#4252 review).
-        searchDeadline = this.timer.now() + SEARCH_BUDGET_MS;
+        // Progress clears the budget: it bounds futile searching, not successful
+        // work. The next search re-arms it from scratch (#4252 review).
+        searchDeadline = null;
 
         // Refresh observation after each success
         if (result.success) {
@@ -182,8 +184,11 @@ export class SetUIState extends BaseVisualChange {
           };
         }
       } else {
-        // No visible matches — scroll to find more
-        if (this.timer.now() >= searchDeadline) {
+        // No visible matches — scroll to find more.
+        // Arm the budget on entering the search; only elapsed *search* time counts.
+        if (searchDeadline === null) {
+          searchDeadline = this.timer.now() + SEARCH_BUDGET_MS;
+        } else if (this.timer.now() >= searchDeadline) {
           budgetSpent = true;
           break;
         }

--- a/test/features/action/SetUIState.test.ts
+++ b/test/features/action/SetUIState.test.ts
@@ -870,3 +870,64 @@ describe("SetUIState budget bounds searching, not successful work (#4252 review)
     expect(result.success).toBe(true);
   });
 });
+
+describe("SetUIState budget is unaffected by slow work before the search (#4252 review 2)", () => {
+  const device: BootedDevice = { name: "test-device", platform: "android", deviceId: "device-1" };
+  let fakeTap: FakeTapOnElement;
+  let fakeInput: FakeInputText;
+  let fakeClear: FakeClearText;
+  let fakeSwipe: FakeSwipeOn;
+  let fakeObserve: FakeObserveScreenForSetUIState;
+  let fakeFieldTypeDetector: FakeFieldTypeDetector;
+  let fakeTimer: FakeTimer;
+
+  beforeEach(() => {
+    fakeTap = new FakeTapOnElement();
+    fakeInput = new FakeInputText();
+    fakeClear = new FakeClearText();
+    fakeSwipe = new FakeSwipeOn();
+    fakeObserve = new FakeObserveScreenForSetUIState();
+    fakeFieldTypeDetector = new FakeFieldTypeDetector();
+    fakeTimer = new FakeTimer();
+  });
+
+  const build = () => new SetUIState(device, null, {
+    tapOnElement: fakeTap, inputText: fakeInput, clearText: fakeClear,
+    swipeOn: fakeSwipe, observeScreen: fakeObserve,
+    fieldTypeDetector: fakeFieldTypeDetector, timer: fakeTimer
+  });
+
+  test("an off-screen field still gets scroll attempts after a slow post-success observe", async () => {
+    // First field is visible and succeeds; the refresh observe that follows is
+    // slow. The second field is off-screen, so the search must still be given its
+    // full budget rather than inheriting time already spent.
+    const onlyFirst = {
+      hierarchy: {
+        node: [{ $: { "bounds": { left: 0, top: 0, right: 100, bottom: 50 }, "resource-id": "first", "class": "android.widget.EditText" } }]
+      }
+    } as unknown as ViewHierarchyResult;
+
+    fakeFieldTypeDetector.setSkipVerification("first", true);
+
+    fakeObserve.setResultFactory(() => {
+      fakeTimer.advanceTime(19_000);
+      return {
+        updatedAt: fakeTimer.now(),
+        screenSize: { width: 1080, height: 1920 },
+        systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+        viewHierarchy: onlyFirst
+      };
+    });
+
+    await build().execute({
+      fields: [
+        { selector: { elementId: "first" }, value: "a" },
+        { selector: { elementId: "offscreen" }, value: "b" }
+      ]
+    });
+
+    // The off-screen field must have been searched for, not skipped because
+    // earlier work had already aged the deadline.
+    expect(fakeSwipe.getCallCount()).toBeGreaterThan(0);
+  });
+});

--- a/test/features/action/SetUIState.test.ts
+++ b/test/features/action/SetUIState.test.ts
@@ -910,7 +910,10 @@ describe("SetUIState budget is unaffected by slow work before the search (#4252 
     fakeFieldTypeDetector.setSkipVerification("first", true);
 
     fakeObserve.setResultFactory(() => {
-      fakeTimer.advanceTime(19_000);
+      // Must EXCEED the 20s budget. At 19s the old rolling deadline — re-armed
+      // to now+20s just before this observe — still had a second left, so a
+      // scroll attempt happened either way and the test could not fail.
+      fakeTimer.advanceTime(25_000);
       return {
         updatedAt: fakeTimer.now(),
         screenSize: { width: 1080, height: 1920 },


### PR DESCRIPTION
## Why this exists

The second codex P2 on [#4252](https://github.com/kaeawc/auto-mobile/pull/4252) was fixed, but the fix **never reached main**. #4252 auto-merged at 20:47:20Z from head `458fd2f10`; the fix commit `9ba9ee249` was pushed after that, which *recreated the deleted branch* rather than updating an open PR. The commit looked pushed and was not on main.

This is the auto-merge-before-second-push race: arming auto-merge before review edits land means a late fix silently misses the merge, and the recreated branch makes it look like it landed.

## What lands here

`9ba9ee249` verbatim, cherry-picked onto current main.

The rolling `searchDeadline` was re-armed on progress, *before* the post-success `observe`. A slow refresh therefore aged the budget before the next search began, and an off-screen field could be reported not-found without a single scroll attempt. The deadline is now `null` until the no-visible-match branch is first entered, and progress clears it rather than re-arming it — so only elapsed **search** time counts against the budget.

## The recovered test did not discriminate — fixed in the second commit

Before opening this I checked the recovered test actually fails without the fix. It did not: **all 24 passed against main's unfixed `SetUIState.ts`.**

`SEARCH_BUDGET_MS` is 20s and the test advanced the fake clock **19s**. Under the old code the deadline was re-armed to `now + 20s` immediately before the slow observe, so a second still remained — a scroll attempt happened either way, and `expect(getCallCount()).toBeGreaterThan(0)` passed regardless.

Advancing **25s** exceeds the budget, so the old code breaks out with zero scroll attempts and the assertion becomes load-bearing.

Verified both directions:

| `src/features/action/SetUIState.ts` | result |
| --- | --- |
| this branch (fixed) | 24 pass, 0 fail |
| reverted to `origin/main` | 23 pass, **1 fail** |

## Scope

Two files, no behavior change beyond the recovered fix. `bun run lint` clean.
