### PR TITLE
fix(ci): close two more empty-array lint fail-opens (#4217 review)

### DIFF
--- a/scripts/shellcheck/validate_shell_portability.sh
+++ b/scripts/shellcheck/validate_shell_portability.sh
@@ -128,12 +128,15 @@ EMPTY_ARRAY_AWK='
 # `local arr=()`, `local -a arr=()`, `declare -A arr=()`, `typeset -a arr=()`.
 # A trailing comment (`items=() # optional args`) is a normal initializer and
 # must still register the array.
-match($0, /^[ \t]*((local|declare|typeset)[ \t]+(-[aAgilnrtux]+[ \t]+)*)?[A-Za-z_][A-Za-z0-9_]*=\(\)[ \t]*(#.*)?$/) {
+# `items=(); printf ...` and `items=();` are ordinary initializers. Anchoring to
+# end-of-line missed them entirely, so the array was never recorded and every
+# later expansion of it went unchecked.
+match($0, /^[ \t]*((local|declare|typeset)[ \t]+(-[aAgilnrtux]+[ \t]+)*)?[A-Za-z_][A-Za-z0-9_]*=\(\)[ \t]*(;|#|$)/) {
   decl = $0
   sub(/^[ \t]*/, "", decl)
   sub(/^(local|declare|typeset)[ \t]+/, "", decl)
   while (decl ~ /^-[aAgilnrtux]+[ \t]+/) { sub(/^-[aAgilnrtux]+[ \t]+/, "", decl) }
-  sub(/=\(\)[ \t]*(#.*)?$/, "", decl)
+  sub(/=\(\).*$/, "", decl)
   arrays[decl] = 1
 }
 
@@ -195,10 +198,10 @@ function is_empty_early_out(lines, nlines, k, name,   j, seg, cut) {
     # NON-empty case. Truncate and make this the last segment considered.
     if (match(seg, /(^|[ \t;])(else|elif)([ \t;]|$)/)) {
       seg = substr(seg, 1, RSTART - 1)
-      if (seg ~ /(^|[ \t;])(return|exit|continue|break)([ \t;]|$)/) { return 1 }
+      if (seg ~ /(^|[ \t;])(return|exit)([ \t;]|$)/) { return 1 }
       return 0
     }
-    if (seg ~ /(^|[ \t;])(return|exit|continue|break)([ \t;]|$)/) { return 1 }
+    if (seg ~ /(^|[ \t;])(return|exit)([ \t;]|$)/) { return 1 }
     # `fi` closes the construct without an exit — not an early-out.
     if (seg ~ /(^|[ \t;])fi([ \t;]|$)/) { return 0 }
   }

--- a/test/bats/validate-shell-portability.bats
+++ b/test/bats/validate-shell-portability.bats
@@ -380,3 +380,61 @@ FIXTURE
   run bash "$ABS" "$FIX"
   [ "$status" -eq 0 ]
 }
+
+# --- Holes 4 and 5, found in review of #4217 after it merged. ---
+# Both are the same failure mode as holes 1-3: the gate reported success while
+# the bash 3.2 crash it exists to catch went undetected.
+
+@test "a loop continue is not a function-wide empty-array early-out" {
+  write_lines bad <<'FIXTURE'
+#!/usr/bin/env bash
+set -euo pipefail
+items=()
+for attempt in 1 2 3; do
+  if [[ ${#items[@]} -eq 0 ]]; then continue; fi
+  echo "$attempt"
+done
+printf '%s\n' "${items[@]}"
+FIXTURE
+  run bash "$ABS" "$FIX"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"empty-array-set-u"* ]]
+}
+
+@test "a loop break is not a function-wide empty-array early-out" {
+  write_lines bad <<'FIXTURE'
+#!/usr/bin/env bash
+set -euo pipefail
+items=()
+while true; do
+  if [[ ${#items[@]} -eq 0 ]]; then break; fi
+done
+printf '%s\n' "${items[@]}"
+FIXTURE
+  run bash "$ABS" "$FIX"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"empty-array-set-u"* ]]
+}
+
+@test "records a semicolon-terminated empty-array declaration" {
+  write_lines bad <<'FIXTURE'
+#!/usr/bin/env bash
+set -euo pipefail
+items=(); printf '%s\n' "${items[@]}"
+FIXTURE
+  run bash "$ABS" "$FIX"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"empty-array-set-u"* ]]
+}
+
+@test "records a bare semicolon empty-array declaration" {
+  write_lines bad <<'FIXTURE'
+#!/usr/bin/env bash
+set -euo pipefail
+items=();
+printf '%s\n' "${items[@]}"
+FIXTURE
+  run bash "$ABS" "$FIX"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"empty-array-set-u"* ]]
+}


### PR DESCRIPTION
Follow-up to [#4217](https://github.com/kaeawc/auto-mobile/pull/4217), which merged with two codex P2s unresolved. Both reproduce, and both are the same failure mode as the first three holes in this rule: **the gate reports success while the bash 3.2 crash it exists to catch goes undetected.**

## Hole 4 — a loop `continue`/`break` credited as a function-wide early-out

```bash
set -euo pipefail
items=()
for attempt in 1 2 3; do
  if [[ ${#items[@]} -eq 0 ]]; then continue; fi
  echo "$attempt"
done
printf '%s\n' "${items[@]}"     # <-- crashes on bash 3.2; gate exited 0
```

`continue` and `break` only leave the iteration or block; code after the loop still reaches the bare expansion. Only `return` and `exit` actually leave the scope, so only those count as early-outs now.

## Hole 5 — semicolon-terminated declarations never recorded

```bash
set -euo pipefail
items=(); printf '%s\n' "${items[@]}"   # <-- gate exited 0
```

`items=();` and `items=(); cmd` are ordinary initializers, but the matcher anchored `arr=()` to end-of-line, so the array never entered `arrays` and *every* later expansion of it went unchecked.

## Why I did not switch to mandating the safe form

In the #4217 thread I said that if a fourth hole appeared I would rather require `${arr[@]+"${arr[@]}"}` outright than keep patching flow analysis — that eliminates the hole class instead of narrowing it. I measured it before deciding:

**30 expansions across 14 files** in `scripts/` would be flagged, nearly all legitimately guarded today (`all_fast_validate_checks.sh`, `install.sh`, `clean-env-uninstall.sh`, `uninstall.sh` and others). That is too much mechanical rewriting to carry in a follow-up, and hand-rewriting guarded call sites risks introducing the very bugs the rule prevents.

The narrower read is better supported by the evidence: **all five holes have been in the early-out sweep**, never in the local `${#arr[@]}` length-check guard. So the sweep is what needed tightening. If a sixth hole appears in the sweep, the mandate is the right answer and the measurement above is what it costs.

Both changes are **conservative** — they under-credit guards, so the failure mode is a false positive asking for the explicit form, never a missed crash.

## Verification

- Both fixtures flagged; **zero new violations** across `scripts/` after the change, so no churn.
- 36 BATS cases pass, including the four new ones and all pre-existing no-false-positive tests.
- `shellcheck` clean; verified under real bash 3.2.57 (`/bin/bash` on macOS).
