### PR TITLE
fix(ci): make the emulator SDK resolution tripwire fail closed

### DIFF
--- a/scripts/android/verify-emulator-sdk-resolution.sh
+++ b/scripts/android/verify-emulator-sdk-resolution.sh
@@ -19,11 +19,22 @@ repo_root="$(cd -- "${script_dir}/../.." && pwd)"
 missing_avd="automobile-sdk-resolution-probe"
 
 # The one outcome that proves the SDK resolved: the product enumerated the AVDs,
-# found none matching, and refused to create one. This substring is the
-# ActionableError text in src/utils/deviceBootService.ts (provisionAndBoot); a
-# BATS guard pins the two together so a product reword is caught in-repo instead
-# of turning main red.
-expected_diagnostic="device matching criteria found"
+# found none matching, and refused to create one. These substrings come from the
+# ActionableError in src/utils/deviceBootService.ts (provisionAndBoot), which
+# interpolates the platform and the requested name:
+#   `No ${platform} device matching criteria found. ... name=${name} ...`
+# A BATS guard pins them to the product text so a reword is caught in-repo
+# instead of turning main red.
+#
+# Both halves are required, and specifically the ANDROID one. Matching only the
+# platform-agnostic "device matching criteria found" also matches the iOS
+# diagnostic ("No ios device matching criteria found"), so a boot-device CLI that
+# regressed to ignore --platform android, or that routed through the iOS manager,
+# would report a healthy *Android* SDK without exercising Android at all — the
+# same fail-open this tripwire exists to prevent.
+expected_diagnostic="No android device matching criteria found"
+# Pins the failure to *our* probe rather than any incidental no-match message.
+expected_probe_name="name=${missing_avd}"
 # The regression this tripwire exists for (issue #4237).
 resolution_failure="Android emulator not found"
 
@@ -63,6 +74,17 @@ case "${output}" in
   *)
     echo "error: the emulator SDK resolution probe failed for an unexpected reason (exit ${probe_status})." >&2
     echo "Expected the boot flow to fail with \"${expected_diagnostic}\"; it did not, so the SDK precondition is unverified." >&2
+    echo "Note a platform-agnostic no-match message is NOT enough here: the iOS path emits the same wording, and this guard must prove the *Android* SDK resolved." >&2
+    printf '%s\n' "${output}" >&2
+    exit 1
+    ;;
+esac
+
+case "${output}" in
+  *"${expected_probe_name}"*) ;;
+  *)
+    echo "error: the boot flow reported no matching Android device, but not for the AVD this probe asked for (exit ${probe_status})." >&2
+    echo "Expected \"${expected_probe_name}\" in the diagnostic; without it the failure may come from some other lookup, so the SDK precondition is unverified." >&2
     printf '%s\n' "${output}" >&2
     exit 1
     ;;

--- a/scripts/android/verify-emulator-sdk-resolution.sh
+++ b/scripts/android/verify-emulator-sdk-resolution.sh
@@ -37,11 +37,16 @@ output="$(cd "${repo_root}" && AUTOMOBILE_ALLOW_DEVICE_CREATE=0 \
 probe_status=$?
 set -e
 
-if printf '%s\n' "${output}" | grep -q "${resolution_failure}"; then
-  echo "error: the product boot flow cannot resolve the Android emulator in CI." >&2
-  printf '%s\n' "${output}" >&2
-  exit 1
-fi
+# Match with case, not `printf | grep -q`: grep -q exits on the first match, the
+# printf ahead of it can then take SIGPIPE, and `set -o pipefail` would turn a
+# healthy probe with plenty of trailing output into a pipeline failure.
+case "${output}" in
+  *"${resolution_failure}"*)
+    echo "error: the product boot flow cannot resolve the Android emulator in CI." >&2
+    printf '%s\n' "${output}" >&2
+    exit 1
+    ;;
+esac
 
 # Fail closed from here on. Everything below is an outcome this guard does not
 # understand, and a guard that cannot tell "healthy" from "unknown" is the exact
@@ -53,11 +58,14 @@ if [ "${probe_status}" -eq 0 ]; then
   exit 1
 fi
 
-if ! printf '%s\n' "${output}" | grep -q "${expected_diagnostic}"; then
-  echo "error: the emulator SDK resolution probe failed for an unexpected reason (exit ${probe_status})." >&2
-  echo "Expected the boot flow to fail with \"${expected_diagnostic}\"; it did not, so the SDK precondition is unverified." >&2
-  printf '%s\n' "${output}" >&2
-  exit 1
-fi
+case "${output}" in
+  *"${expected_diagnostic}"*) ;;
+  *)
+    echo "error: the emulator SDK resolution probe failed for an unexpected reason (exit ${probe_status})." >&2
+    echo "Expected the boot flow to fail with \"${expected_diagnostic}\"; it did not, so the SDK precondition is unverified." >&2
+    printf '%s\n' "${output}" >&2
+    exit 1
+    ;;
+esac
 
 echo "Android emulator SDK is resolvable by the product boot flow."

--- a/scripts/android/verify-emulator-sdk-resolution.sh
+++ b/scripts/android/verify-emulator-sdk-resolution.sh
@@ -17,6 +17,16 @@ repo_root="$(cd -- "${script_dir}/../.." && pwd)"
 "${script_dir}/ensure-emulator-sdk.sh"
 
 missing_avd="automobile-sdk-resolution-probe"
+
+# The one outcome that proves the SDK resolved: the product enumerated the AVDs,
+# found none matching, and refused to create one. This substring is the
+# ActionableError text in src/utils/deviceBootService.ts (provisionAndBoot); a
+# BATS guard pins the two together so a product reword is caught in-repo instead
+# of turning main red.
+expected_diagnostic="device matching criteria found"
+# The regression this tripwire exists for (issue #4237).
+resolution_failure="Android emulator not found"
+
 set +e
 # Pin creation off explicitly. This probe deliberately names an AVD that does
 # not exist, so if AUTOMOBILE_ALLOW_DEVICE_CREATE is ever turned on repo-wide it
@@ -24,10 +34,28 @@ set +e
 output="$(cd "${repo_root}" && AUTOMOBILE_ALLOW_DEVICE_CREATE=0 \
   bun run src/index.ts --boot-device --platform android \
   --name "${missing_avd}" --timeout-ms 5000 2>&1)"
+probe_status=$?
 set -e
 
-if printf '%s' "${output}" | grep -q "Android emulator not found"; then
+if printf '%s\n' "${output}" | grep -q "${resolution_failure}"; then
   echo "error: the product boot flow cannot resolve the Android emulator in CI." >&2
+  printf '%s\n' "${output}" >&2
+  exit 1
+fi
+
+# Fail closed from here on. Everything below is an outcome this guard does not
+# understand, and a guard that cannot tell "healthy" from "unknown" is the exact
+# blind spot issue #4237 was about.
+if [ "${probe_status}" -eq 0 ]; then
+  echo "error: the emulator SDK resolution probe unexpectedly succeeded." >&2
+  echo "It asks for AVD '${missing_avd}', which must not exist; a success means the probe is no longer testing resolution." >&2
+  printf '%s\n' "${output}" >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "${output}" | grep -q "${expected_diagnostic}"; then
+  echo "error: the emulator SDK resolution probe failed for an unexpected reason (exit ${probe_status})." >&2
+  echo "Expected the boot flow to fail with \"${expected_diagnostic}\"; it did not, so the SDK precondition is unverified." >&2
   printf '%s\n' "${output}" >&2
   exit 1
 fi

--- a/test/bats/ensure-emulator-sdk.bats
+++ b/test/bats/ensure-emulator-sdk.bats
@@ -157,7 +157,7 @@ MOCK
   cat > "${fake_bin}/bun" <<MOCK
 #!/usr/bin/env bash
 printf '%s\n' "\${AUTOMOBILE_ALLOW_DEVICE_CREATE:-<unset>}" > "${seen}"
-echo "error: No android device matching criteria found. Available images: none."
+echo "error: No android device matching criteria found. name=automobile-sdk-resolution-probe Available images: none."
 exit 1
 MOCK
   chmod +x "${fake_bin}/bun"
@@ -240,16 +240,88 @@ MOCK
 }
 
 @test "the tripwire's expected diagnostic still matches the product boot error text" {
-  # The script asserts a substring of DeviceBootService.provisionAndBoot's
+  # The script asserts substrings of DeviceBootService.provisionAndBoot's
   # ActionableError. If the product reworks that message, catch it here rather
   # than by turning main red on the next push.
-  expected="$(grep -o 'expected_diagnostic="[^"]*"' \
-    "$(pwd)/scripts/android/verify-emulator-sdk-resolution.sh" \
-    | head -n 1 | sed 's/^expected_diagnostic="//; s/"$//')"
+  #
+  # The product interpolates `${request.platform}` and `${request.name}`, so the
+  # script's resolved strings can never appear literally in the source. Split
+  # each one into the part the probe chooses and the part the product spells out,
+  # and pin both halves.
+  script="$(pwd)/scripts/android/verify-emulator-sdk-resolution.sh"
+  product="$(pwd)/src/utils/deviceBootService.ts"
 
+  expected="$(grep -o 'expected_diagnostic="[^"]*"' "$script" \
+    | head -n 1 | sed 's/^expected_diagnostic="//; s/"$//')"
   [ -n "$expected" ]
-  run grep -q "$expected" "$(pwd)/src/utils/deviceBootService.ts"
-  [ "$status" -eq 0 ]
+
+  # "No <platform> <invariant tail>"
+  platform="${expected#No }"
+  platform="${platform%% *}"
+  invariant="${expected#No ${platform} }"
+  [ -n "$invariant" ]
+  [ "$invariant" != "$expected" ]
+
+  # The platform baked into the expectation must be the one the probe asks for,
+  # or the guard could pass on a platform it never exercised.
+  [ "$platform" = "android" ]
+  grep -qF -- "--platform ${platform}" "$script"
+
+  # ...and the product must still build exactly "No <platform> <invariant tail>".
+  grep -qF "No \${request.platform} ${invariant}" "$product"
+
+  # The probe-name half: literal in the script (pre-expansion), interpolated in
+  # the product.
+  probe_name="$(grep -o 'expected_probe_name="[^"]*"' "$script" \
+    | head -n 1 | sed 's/^expected_probe_name="//; s/"$//')"
+  [ "$probe_name" = 'name=${missing_avd}' ]
+  grep -qF 'name=${request.name}' "$product"
+}
+
+@test "the resolution tripwire rejects an iOS no-match diagnostic" {
+  # Regression guard: the expectation used to be the platform-agnostic
+  # "device matching criteria found", which the iOS path also emits. A
+  # boot-device CLI that ignored --platform android, or routed through the iOS
+  # manager, would then report a healthy *Android* SDK without touching Android.
+  make_emulator
+  fake_bin="$(mktemp -d)"
+  cat > "${fake_bin}/bun" <<'MOCK'
+#!/usr/bin/env bash
+echo "error: No ios device matching criteria found. name=automobile-sdk-resolution-probe Available images: none."
+exit 1
+MOCK
+  chmod +x "${fake_bin}/bun"
+
+  run env ANDROID_HOME="$SDK_ROOT" ANDROID_SDK_ROOT= ANDROID_SDK_HOME= \
+    PATH="${fake_bin}:${PATH}" \
+    bash "$(pwd)/scripts/android/verify-emulator-sdk-resolution.sh"
+
+  rm -rf "$fake_bin"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"failed for an unexpected reason"* ]]
+  [[ "$output" != *"resolvable by the product boot flow"* ]]
+}
+
+@test "the resolution tripwire rejects an Android no-match for some other device" {
+  # The diagnostic has to be about the AVD this probe asked for; any other
+  # no-match leaves the SDK precondition unverified.
+  make_emulator
+  fake_bin="$(mktemp -d)"
+  cat > "${fake_bin}/bun" <<'MOCK'
+#!/usr/bin/env bash
+echo "error: No android device matching criteria found. name=some-other-avd Available images: none."
+exit 1
+MOCK
+  chmod +x "${fake_bin}/bun"
+
+  run env ANDROID_HOME="$SDK_ROOT" ANDROID_SDK_ROOT= ANDROID_SDK_HOME= \
+    PATH="${fake_bin}:${PATH}" \
+    bash "$(pwd)/scripts/android/verify-emulator-sdk-resolution.sh"
+
+  rm -rf "$fake_bin"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"not for the AVD this probe asked for"* ]]
+  [[ "$output" != *"resolvable by the product boot flow"* ]]
 }
 
 @test "the resolution tripwire survives a healthy probe with lots of trailing output" {
@@ -259,7 +331,7 @@ MOCK
   fake_bin="$(mktemp -d)"
   cat > "${fake_bin}/bun" <<'MOCK'
 #!/usr/bin/env bash
-echo "error: No android device matching criteria found. Available images: none."
+echo "error: No android device matching criteria found. name=automobile-sdk-resolution-probe Available images: none."
 # Trailing diagnostics large enough that the reader can stop before the writer.
 i=0
 while [ "$i" -lt 20000 ]; do

--- a/test/bats/ensure-emulator-sdk.bats
+++ b/test/bats/ensure-emulator-sdk.bats
@@ -251,3 +251,30 @@ MOCK
   run grep -q "$expected" "$(pwd)/src/utils/deviceBootService.ts"
   [ "$status" -eq 0 ]
 }
+
+@test "the resolution tripwire survives a healthy probe with lots of trailing output" {
+  # `printf | grep -q` under `set -o pipefail` can report failure when grep exits
+  # on an early match and printf takes SIGPIPE, failing a healthy probe.
+  make_emulator
+  fake_bin="$(mktemp -d)"
+  cat > "${fake_bin}/bun" <<'MOCK'
+#!/usr/bin/env bash
+echo "error: No android device matching criteria found. Available images: none."
+# Trailing diagnostics large enough that the reader can stop before the writer.
+i=0
+while [ "$i" -lt 20000 ]; do
+  echo "trailing diagnostic line $i padded out to keep the pipe buffer busy"
+  i=$((i + 1))
+done
+exit 1
+MOCK
+  chmod +x "${fake_bin}/bun"
+
+  run env ANDROID_HOME="$SDK_ROOT" ANDROID_SDK_ROOT= ANDROID_SDK_HOME= \
+    PATH="${fake_bin}:${PATH}" \
+    bash "$(pwd)/scripts/android/verify-emulator-sdk-resolution.sh"
+
+  rm -rf "$fake_bin"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"resolvable by the product boot flow"* ]]
+}

--- a/test/bats/ensure-emulator-sdk.bats
+++ b/test/bats/ensure-emulator-sdk.bats
@@ -136,7 +136,7 @@ MOCK
   fake_bin="$(mktemp -d)"
   cat > "${fake_bin}/bun" <<'MOCK'
 #!/usr/bin/env bash
-echo "error: No matching device found for automobile-sdk-resolution-probe"
+echo "error: No android device matching criteria found. name=automobile-sdk-resolution-probe Available images: none."
 exit 1
 MOCK
   chmod +x "${fake_bin}/bun"
@@ -157,7 +157,7 @@ MOCK
   cat > "${fake_bin}/bun" <<MOCK
 #!/usr/bin/env bash
 printf '%s\n' "\${AUTOMOBILE_ALLOW_DEVICE_CREATE:-<unset>}" > "${seen}"
-echo "error: No matching device found"
+echo "error: No android device matching criteria found. Available images: none."
 exit 1
 MOCK
   chmod +x "${fake_bin}/bun"
@@ -170,4 +170,84 @@ MOCK
   [ "$(<"$seen")" = "0" ]
   rm -rf "$fake_bin"
   rm -f "$seen"
+}
+
+# --- fail-closed tripwire semantics (issue #4260) ------------------------------
+#
+# The guard used to key only off the absence of "Android emulator not found", so
+# any other early failure fell through to the success message and reported a
+# green SDK-resolution guard. These pin the closed door.
+
+@test "the resolution tripwire fails when the probe dies for an unexpected reason" {
+  make_emulator
+  fake_bin="$(mktemp -d)"
+  cat > "${fake_bin}/bun" <<'MOCK'
+#!/usr/bin/env bash
+echo "error: Cannot find module './cli/bootDevice'" >&2
+exit 1
+MOCK
+  chmod +x "${fake_bin}/bun"
+
+  run env ANDROID_HOME="$SDK_ROOT" ANDROID_SDK_ROOT= ANDROID_SDK_HOME= \
+    PATH="${fake_bin}:${PATH}" \
+    bash "$(pwd)/scripts/android/verify-emulator-sdk-resolution.sh"
+
+  rm -rf "$fake_bin"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"failed for an unexpected reason"* ]]
+  # The actual probe output has to be surfaced, or the failure is unactionable.
+  [[ "$output" == *"Cannot find module"* ]]
+  [[ "$output" != *"resolvable by the product boot flow"* ]]
+}
+
+@test "the resolution tripwire fails when the probe crashes with no output at all" {
+  make_emulator
+  fake_bin="$(mktemp -d)"
+  cat > "${fake_bin}/bun" <<'MOCK'
+#!/usr/bin/env bash
+exit 137
+MOCK
+  chmod +x "${fake_bin}/bun"
+
+  run env ANDROID_HOME="$SDK_ROOT" ANDROID_SDK_ROOT= ANDROID_SDK_HOME= \
+    PATH="${fake_bin}:${PATH}" \
+    bash "$(pwd)/scripts/android/verify-emulator-sdk-resolution.sh"
+
+  rm -rf "$fake_bin"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"exit 137"* ]]
+  [[ "$output" != *"resolvable by the product boot flow"* ]]
+}
+
+@test "the resolution tripwire fails when the probe unexpectedly succeeds" {
+  make_emulator
+  fake_bin="$(mktemp -d)"
+  cat > "${fake_bin}/bun" <<'MOCK'
+#!/usr/bin/env bash
+echo '{"deviceId":"emulator-5554","platform":"android"}'
+exit 0
+MOCK
+  chmod +x "${fake_bin}/bun"
+
+  run env ANDROID_HOME="$SDK_ROOT" ANDROID_SDK_ROOT= ANDROID_SDK_HOME= \
+    PATH="${fake_bin}:${PATH}" \
+    bash "$(pwd)/scripts/android/verify-emulator-sdk-resolution.sh"
+
+  rm -rf "$fake_bin"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"unexpectedly succeeded"* ]]
+  [[ "$output" != *"resolvable by the product boot flow"* ]]
+}
+
+@test "the tripwire's expected diagnostic still matches the product boot error text" {
+  # The script asserts a substring of DeviceBootService.provisionAndBoot's
+  # ActionableError. If the product reworks that message, catch it here rather
+  # than by turning main red on the next push.
+  expected="$(grep -o 'expected_diagnostic="[^"]*"' \
+    "$(pwd)/scripts/android/verify-emulator-sdk-resolution.sh" \
+    | head -n 1 | sed 's/^expected_diagnostic="//; s/"$//')"
+
+  [ -n "$expected" ]
+  run grep -q "$expected" "$(pwd)/src/utils/deviceBootService.ts"
+  [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Summary

`scripts/android/verify-emulator-sdk-resolution.sh` (the main-push emulator SDK tripwire from [#4254](https://github.com/kaeawc/auto-mobile/pull/4254)) discarded the probe's exit status and keyed only off the absence of the literal `Android emulator not found`. Any other failure — a broken CLI entrypoint, a bad import, a changed diagnostic, a crash before device resolution was even attempted — fell through to the success message and reported a GREEN SDK-resolution guard. That is the same blind spot [#4237](https://github.com/kaeawc/auto-mobile/issues/4237) was about, in the script written to close it.

The guard now fails closed: it captures the exit status, asserts the expected healthy-environment diagnostic explicitly, and treats everything else as a failure with the probe output surfaced on stderr.

## Linked Issue

Closes #4260

## Bug / Regression Context

- **Prior attempts:** [#4254](https://github.com/kaeawc/auto-mobile/pull/4254) added the tripwire; unresolved codex feedback on it flagged the fail-open behaviour.
- **Observed symptom:** with a stub `bun` that exits 1 printing an unrelated error (or exits 137 silently, or exits 0), the script printed "Android emulator SDK is resolvable by the product boot flow" and exited 0.
- **Repro steps / conditions:** `bats test/bats/ensure-emulator-sdk.bats` — the four new tests are red against the pre-change script (three assert exit 1 and get 0; the diagnostic-pin test finds no `expected_diagnostic` at all).

## Changes

- Capture `probe_status` from the probe instead of throwing it away.
- Keep the specific `Android emulator not found` regression message and its dedicated diagnostic.
- Fail on an unexpected success (the probe names an AVD that must not exist — a success means it stopped testing resolution).
- Fail on any non-zero exit whose output does not contain the expected `device matching criteria found` text, printing the exit code and the actual output.

## Validation

- [x] `bats test/bats/ensure-emulator-sdk.bats` — 12/12 green; tests 9–12 verified red against the pre-change script
- [x] `shellcheck scripts/android/verify-emulator-sdk-resolution.sh`
- [x] `./scripts/shellcheck/validate_shell_portability.sh scripts` — no issues (Bash 3.2 compatible)
- [x] `./scripts/shellcheck/validate_shell_sete.sh` — no new findings
- No emulator was booted; every case is driven by a stub `bun` on `PATH`.

## Notes

Two existing stubs in `ensure-emulator-sdk.bats` emitted `No matching device found`, which is not text the product ever produces. They now emit the real `DeviceBootService.provisionAndBoot` wording, and a new test pins the script's `expected_diagnostic` to that source text so a product reword is caught in-repo rather than by turning main red.
