### PR TITLE
fix(screen-stream): anchor resync to the stream's own geometry

### DIFF
--- a/src/features/screen-stream/frameProtocol.ts
+++ b/src/features/screen-stream/frameProtocol.ts
@@ -92,11 +92,21 @@ export interface MalformedFrameError {
   header: FrameHeader;
 }
 
-/** Result of walking past a run of audio records to the next video boundary. */
+/**
+ * Result of walking past a run of audio records to the next video boundary.
+ * `unsettled` carries `at`, the furthest offset the walk reached before running
+ * out of bytes, so the next chunk resumes from there instead of restarting.
+ */
 type AudioSkip =
   | { kind: "video"; header: FrameHeader }
-  | { kind: "unsettled" }
+  | { kind: "unsettled"; at: number }
   | { kind: "reject" };
+
+/** A resync candidate awaiting corroboration, with its audio-skip resume point. */
+interface Candidate {
+  offset: number;
+  resumeAt: number;
+}
 
 export class FrameDecoder {
   private buffer: Buffer = Buffer.alloc(0);
@@ -108,11 +118,16 @@ export class FrameDecoder {
    */
   private resynchronizing: boolean = false;
   /**
-   * Offsets into `buffer`, ascending, whose corroboration is still pending
-   * because the bytes that would settle them have not arrived. These are the
-   * only already-examined offsets a later chunk can change the verdict of.
+   * Candidates into `buffer`, ascending by `offset`, whose corroboration is
+   * still pending because the bytes that would settle them have not arrived.
+   * These are the only already-examined offsets a later chunk can change the
+   * verdict of. `resumeAt` carries how far the audio-skip walk to this
+   * candidate's successor has already progressed, so re-asking it after each
+   * chunk parses only the newly arrived records rather than re-walking a
+   * growing audio run from the start — the difference between linear and
+   * quadratic when a recovered frame is followed by a long audio-only gap.
    */
-  private unsettled: number[] = [];
+  private unsettled: Candidate[] = [];
   /**
    * How many leading bytes of `buffer` the forward scan has already examined.
    * Offsets below this are settled for good: a 16-byte window is immutable once
@@ -137,17 +152,6 @@ export class FrameDecoder {
    * eventually. Only a wire-format marker closes that — see #4270.
    */
   private anchor: FrameHeader | null = null;
-  /**
-   * Memoizes the audio-skip walk within a single `resynchronize()` pass, keyed
-   * by the offset the walk starts at. Audio records are self-describing and
-   * chain end-to-end, so every candidate whose payload lands in the same audio
-   * run walks to the same terminal video header; without memoization each of
-   * the N audio offsets re-walks the O(N) tail, and one audio-interleaved
-   * corruption window costs O(N²) parses — the disproportionate-work shape this
-   * decoder exists to avoid. Reset each pass because the buffer (and therefore
-   * the absolute offsets) changes between passes.
-   */
-  private audioSkip: Map<number, AudioSkip> = new Map();
 
   /**
    * Append bytes from the helper's stdout stream and return any frames that
@@ -236,17 +240,26 @@ export class FrameDecoder {
    * offset is a plausible header with probability ~2^-38.
    */
   private resynchronize(): boolean {
-    // Offsets are absolute into the current buffer, which is stable for the
-    // duration of this pass and changes before the next one.
-    this.audioSkip.clear();
-    const pending: number[] = [];
+    const pending: Candidate[] = [];
     // Ascending offset order overall — every retained candidate sits below the
     // scan cursor, every newly examinable offset at or above it — so this still
     // accepts the lowest-offset candidate that corroborates, as a single
-    // whole-buffer pass did.
-    let accepted = this.scan(this.unsettled, pending);
+    // whole-buffer pass did. Retained candidates resume their audio-skip walk
+    // where it stopped; fresh offsets start it at their payload's end.
+    let accepted = this.rescan(this.unsettled, pending);
     if (accepted < 0) {
-      accepted = this.scan(range(this.scanned, this.buffer.length - FRAME_HEADER_SIZE), pending);
+      // Every retained candidate has already confirmed contiguous audio out to
+      // its `resumeAt`; a fresh audio offset below that high-water mark is in
+      // the same run and settles identically, so it need not be retained as its
+      // own candidate. Without this, a run of N audio records arriving one per
+      // chunk retains N equivalent candidates and re-walks them, O(N²) — the
+      // exact shape resync exists to avoid.
+      const coveredTo = pending.reduce((max, c) => Math.max(max, c.resumeAt), 0);
+      accepted = this.scanFresh(
+        range(this.scanned, this.buffer.length - FRAME_HEADER_SIZE),
+        pending,
+        coveredTo
+      );
     }
 
     if (accepted >= 0) {
@@ -269,18 +282,47 @@ export class FrameDecoder {
   }
 
   /**
-   * Examine `offsets` in order, returning the first that corroborates, or -1.
-   * Offsets whose verdict more bytes could still change are appended to
+   * Re-examine already-retained candidates, resuming each one's audio-skip walk
+   * from where it stopped so a growing audio run is never re-walked from the
+   * start. Returns the first offset that corroborates, or -1; survivors are
+   * appended to `pending` with their advanced resume point.
+   */
+  private rescan(candidates: Candidate[], pending: Candidate[]): number {
+    for (const candidate of candidates) {
+      const header = parseHeader(this.buffer, candidate.offset);
+      const verdict = this.corroborate(header, candidate.resumeAt);
+      if (verdict.kind === "accept") {return candidate.offset;}
+      if (verdict.kind === "unsettled") {
+        candidate.resumeAt = verdict.resumeAt;
+        pending.push(candidate);
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Examine fresh byte offsets in order, returning the first that corroborates,
+   * or -1. Offsets whose verdict more bytes could still change are appended to
    * `pending`; settled ones are dropped and never looked at again.
    */
-  private scan(offsets: Iterable<number>, pending: number[]): number {
+  private scanFresh(offsets: Iterable<number>, pending: Candidate[], coveredTo: number): number {
     for (const offset of offsets) {
       const header = parseHeader(this.buffer, offset);
       if (headerError(header) !== null) {continue;}
       if (!this.admissible(header)) {continue;}
-      const verdict = this.corroborate(offset, header);
-      if (verdict === "accept") {return offset;}
-      if (verdict === "unsettled") {pending.push(offset);}
+      // Subsumed by an already-retained candidate's confirmed audio run: it
+      // skips to the same handoff and would settle identically, so retaining it
+      // separately only multiplies the re-walk. Video candidates are never
+      // skipped this way — a differently-anchored video inside the run is a
+      // reject the retained candidate already accounts for.
+      if (isAudioHeader(header) && offset < coveredTo) {continue;}
+      const from = offset + FRAME_HEADER_SIZE + payloadSize(header);
+      const verdict = this.corroborate(header, from);
+      if (verdict.kind === "accept") {return offset;}
+      if (verdict.kind === "unsettled") {
+        pending.push({ offset, resumeAt: verdict.resumeAt });
+        coveredTo = Math.max(coveredTo, verdict.resumeAt);
+      }
     }
     return -1;
   }
@@ -292,12 +334,15 @@ export class FrameDecoder {
   private discardSettledPrefix(): void {
     const keepFrom =
       this.unsettled.length > 0
-        ? this.unsettled[0]
+        ? this.unsettled[0].offset
         : Math.max(0, this.buffer.length - (FRAME_HEADER_SIZE - 1));
     if (keepFrom === 0) {return;}
     // Copy so the discarded chunk allocation can be freed.
     this.buffer = Buffer.from(this.buffer.subarray(keepFrom));
-    this.unsettled = this.unsettled.map(offset => offset - keepFrom);
+    this.unsettled = this.unsettled.map(candidate => ({
+      offset: candidate.offset - keepFrom,
+      resumeAt: candidate.resumeAt - keepFrom,
+    }));
     this.scanned = Math.max(0, this.scanned - keepFrom);
   }
 
@@ -329,53 +374,52 @@ export class FrameDecoder {
    * the candidate and re-asks once more data arrives. Retention is bounded by
    * the same payload ceiling that bounds normal decoding.
    */
-  private corroborate(offset: number, header: FrameHeader): "accept" | "unsettled" | "reject" {
-    // Walk from the end of the candidate's payload to the first *video* header,
-    // stepping over self-describing audio records on the way. That video header
-    // is where resync hands control back to the synchronized path, which emits
-    // video frames without consulting the anchor — so it is the boundary that
-    // must match, not merely whatever record sits physically next to the
-    // candidate. `SimulatorCaptureSession` writes screen and audio to one queue,
-    // so an audio record routinely lands between two video frames; stopping at
-    // that audio would either stall recovery on every real stream, or — worse —
-    // accept the candidate and hand the unchecked video *after* the audio, of
-    // any geometry, straight to the encoder.
-    const handoff = this.skipAudio(offset + FRAME_HEADER_SIZE + payloadSize(header));
-    if (handoff.kind !== "video") {return handoff.kind;}
+  private corroborate(
+    header: FrameHeader,
+    from: number
+  ): { kind: "accept" | "reject" } | { kind: "unsettled"; resumeAt: number } {
+    // Walk from `from` (a candidate's payload end, or where its earlier walk
+    // stopped) to the first *video* header, stepping over self-describing audio
+    // records on the way. That video header is where resync hands control back
+    // to the synchronized path, which emits video frames without consulting the
+    // anchor — so it is the boundary that must match, not merely whatever record
+    // sits physically next to the candidate. `SimulatorCaptureSession` writes
+    // screen and audio to one queue, so an audio record routinely lands between
+    // two video frames; stopping at that audio would either stall recovery on
+    // every real stream, or — worse — accept the candidate and hand the
+    // unchecked video *after* the audio, of any geometry, straight to the
+    // encoder.
+    const handoff = this.skipAudio(from);
+    if (handoff.kind === "reject") {return { kind: "reject" };}
+    if (handoff.kind === "unsettled") {return { kind: "unsettled", resumeAt: handoff.at };}
     // `handoff.header` is the video header resync would hand back at. It must
     // belong to the same stream — before the first frame decodes there is no
     // anchor and whatever arrives first defines the geometry (admissible()
     // allows it), so the candidate and this successor must simply agree.
-    if (!this.admissible(handoff.header)) {return "reject";}
-    // An audio candidate carries no geometry of its own; a corroborating video
-    // handoff is all it needs.
-    if (isAudioHeader(header)) {return "accept";}
-    return sameGeometry(header, handoff.header) ? "accept" : "reject";
+    if (!this.admissible(handoff.header)) {return { kind: "reject" };}
+    // An audio candidate carries no geometry of its own, so a corroborating
+    // video handoff is all it needs — that keeps a valid audio record that
+    // lands right after a corrupt frame decodable, rather than dropped.
+    if (isAudioHeader(header)) {return { kind: "accept" };}
+    return { kind: sameGeometry(header, handoff.header) ? "accept" : "reject" };
   }
 
   /**
    * Follow the chain of audio records starting at `cursor` to the first video
-   * header, memoized so a run of N audio records costs O(N) parses across the
-   * whole pass rather than O(N) per candidate. Returns the terminal video
-   * header, `unsettled` if the run reaches the end of the buffer without one,
-   * or `reject` if a malformed header interrupts it. Iterative rather than
-   * recursive so a long audio run cannot overflow the stack.
+   * header. Returns that terminal video header; `unsettled` with the furthest
+   * offset reached if the run runs off the end of the buffer before a video
+   * (so the caller resumes there next chunk rather than restarting); or
+   * `reject` if a malformed header interrupts the run. Iterative so a long
+   * audio run cannot overflow the stack.
    */
   private skipAudio(cursor: number): AudioSkip {
-    const chain: number[] = [];
-    let result: AudioSkip;
     for (;;) {
-      const memo = this.audioSkip.get(cursor);
-      if (memo !== undefined) {result = memo; break;}
-      if (this.buffer.length - cursor < FRAME_HEADER_SIZE) {result = { kind: "unsettled" }; break;}
+      if (this.buffer.length - cursor < FRAME_HEADER_SIZE) {return { kind: "unsettled", at: cursor };}
       const header = parseHeader(this.buffer, cursor);
-      if (headerError(header) !== null) {result = { kind: "reject" }; break;}
-      if (!isAudioHeader(header)) {result = { kind: "video", header }; break;}
-      chain.push(cursor);
+      if (headerError(header) !== null) {return { kind: "reject" };}
+      if (!isAudioHeader(header)) {return { kind: "video", header };}
       cursor += FRAME_HEADER_SIZE + payloadSize(header);
     }
-    for (const start of chain) {this.audioSkip.set(start, result);}
-    return result;
   }
 
   /**

--- a/src/features/screen-stream/frameProtocol.ts
+++ b/src/features/screen-stream/frameProtocol.ts
@@ -324,6 +324,17 @@ export class FrameDecoder {
    * geometry the stream is already using; before the first frame decodes there
    * is nothing to match, and nothing downstream to poison either — whatever
    * geometry arrives first *is* the stream's geometry, corrupt or not.
+   *
+   * The trade, pinned by a test so it stays deliberate: the helper does change
+   * geometry mid-stream (`SimulatorCaptureSession` reconfigures `SCStream` when
+   * the simulator window resizes), and if that change lands inside a corruption
+   * window the decoder will not resynchronize — the stream needs a restart.
+   * There is no way to allow it safely: a genuine reconfigure and a crafted run
+   * of frames at a new size are byte-identical on a wire with no sync marker,
+   * so any rule permitting the first permits the second. Preferring the
+   * observable failure (no frames, corruption already reported) over silent
+   * injection into the encoder is the same trade this decoder already makes
+   * when it drops an uncorroborated recovered frame.
    */
   private admissible(header: FrameHeader): boolean {
     if (isAudioHeader(header) || this.anchor === null) {return true;}

--- a/src/features/screen-stream/frameProtocol.ts
+++ b/src/features/screen-stream/frameProtocol.ts
@@ -19,6 +19,22 @@
  * downstream callbacks. Instead the decoder enters a resynchronizing state:
  * it reports the corruption exactly once, then scans forward byte by byte for
  * the next structurally plausible header and resumes there.
+ *
+ * Structural plausibility is not enough on its own. The payload is BGRA pixel
+ * data, so its bytes reflect what is on the captured screen — a byte sequence
+ * someone can influence. Probability bounds ("a random offset parses as a
+ * header only once in 2^38") say nothing about chosen bytes: a payload can
+ * simply contain two header-shaped ranges spaced by the first one's declared
+ * payload length, and structural corroboration accepts it. So resync is also
+ * bounded by the stream's own geometry, which the decoder cannot be talked out
+ * of: see `admissible()`.
+ *
+ * What that does *not* close: chosen pixels at the geometry the stream is
+ * already using. Nothing in the wire format distinguishes a crafted byte
+ * sequence from a genuine one — there is no sync marker and no checksum — so
+ * only a format change could. It is a much smaller residual: the dimensions
+ * the encoder configures on can no longer be influenced, and whoever can choose
+ * payload pixels is already drawing on the screen being captured.
  */
 
 export const FRAME_HEADER_SIZE = 16;
@@ -100,6 +116,16 @@ export class FrameDecoder {
    * than re-parsing the whole retained buffer on every chunk.
    */
   private scanned: number = 0;
+  /**
+   * Geometry of the most recently decoded frame — the geometry this stream is
+   * using. A capture session emits one frame size for its lifetime, so once
+   * this is known, resync is locked to it and cannot introduce a size the
+   * stream was not already producing. That is what makes fabricating a frame
+   * with chosen dimensions impossible rather than merely improbable: no matter
+   * how many header-shaped ranges a damaged payload contains, the set of
+   * accepted geometries has exactly one element.
+   */
+  private anchor: FrameHeader | null = null;
 
   /**
    * Append bytes from the helper's stdout stream and return any frames that
@@ -140,6 +166,7 @@ export class FrameDecoder {
         onAudio?.({ pcm16le: payload });
       } else {
         frames.push({ header: pending, pixels: payload });
+        this.anchor = pending;
       }
       this.pendingHeader = null;
     }
@@ -225,6 +252,7 @@ export class FrameDecoder {
     for (const offset of offsets) {
       const header = parseHeader(this.buffer, offset);
       if (headerError(header) !== null) {continue;}
+      if (!this.admissible(header)) {continue;}
       const verdict = this.corroborate(offset, header);
       if (verdict === "accept") {return offset;}
       if (verdict === "unsettled") {pending.push(offset);}
@@ -279,8 +307,32 @@ export class FrameDecoder {
   private corroborate(offset: number, header: FrameHeader): "accept" | "unsettled" | "reject" {
     const end = offset + FRAME_HEADER_SIZE + payloadSize(header);
     if (this.buffer.length - end < FRAME_HEADER_SIZE) {return "unsettled";}
-    return headerError(parseHeader(this.buffer, end)) === null ? "accept" : "reject";
+    const successor = parseHeader(this.buffer, end);
+    if (headerError(successor) !== null) {return "reject";}
+    // The successor must belong to the same stream, not merely be well-formed.
+    // Consecutive frames in a capture session share a geometry, so a successor
+    // of a different size is evidence of coincidence, not of a boundary. This
+    // is what covers the window before any frame has decoded, when there is no
+    // anchor to check against.
+    if (isAudioHeader(header) || isAudioHeader(successor)) {return "accept";}
+    return sameGeometry(header, successor) ? "accept" : "reject";
   }
+
+  /**
+   * Whether a resync candidate may be considered at all. Audio records are
+   * self-describing and carry no geometry. A video candidate must match the
+   * geometry the stream is already using; before the first frame decodes there
+   * is nothing to match, and nothing downstream to poison either — whatever
+   * geometry arrives first *is* the stream's geometry, corrupt or not.
+   */
+  private admissible(header: FrameHeader): boolean {
+    if (isAudioHeader(header) || this.anchor === null) {return true;}
+    return sameGeometry(header, this.anchor);
+  }
+}
+
+function sameGeometry(a: FrameHeader, b: FrameHeader): boolean {
+  return a.width === b.width && a.height === b.height && a.bytesPerRow === b.bytesPerRow;
 }
 
 /** Lazily yields `from..toInclusive`, so a scan never materializes the range. */

--- a/src/features/screen-stream/frameProtocol.ts
+++ b/src/features/screen-stream/frameProtocol.ts
@@ -92,6 +92,12 @@ export interface MalformedFrameError {
   header: FrameHeader;
 }
 
+/** Result of walking past a run of audio records to the next video boundary. */
+type AudioSkip =
+  | { kind: "video"; header: FrameHeader }
+  | { kind: "unsettled" }
+  | { kind: "reject" };
+
 export class FrameDecoder {
   private buffer: Buffer = Buffer.alloc(0);
   private pendingHeader: FrameHeader | null = null;
@@ -131,6 +137,17 @@ export class FrameDecoder {
    * eventually. Only a wire-format marker closes that — see #4270.
    */
   private anchor: FrameHeader | null = null;
+  /**
+   * Memoizes the audio-skip walk within a single `resynchronize()` pass, keyed
+   * by the offset the walk starts at. Audio records are self-describing and
+   * chain end-to-end, so every candidate whose payload lands in the same audio
+   * run walks to the same terminal video header; without memoization each of
+   * the N audio offsets re-walks the O(N) tail, and one audio-interleaved
+   * corruption window costs O(N²) parses — the disproportionate-work shape this
+   * decoder exists to avoid. Reset each pass because the buffer (and therefore
+   * the absolute offsets) changes between passes.
+   */
+  private audioSkip: Map<number, AudioSkip> = new Map();
 
   /**
    * Append bytes from the helper's stdout stream and return any frames that
@@ -219,6 +236,9 @@ export class FrameDecoder {
    * offset is a plausible header with probability ~2^-38.
    */
   private resynchronize(): boolean {
+    // Offsets are absolute into the current buffer, which is stable for the
+    // duration of this pass and changes before the next one.
+    this.audioSkip.clear();
     const pending: number[] = [];
     // Ascending offset order overall — every retained candidate sits below the
     // scan cursor, every newly examinable offset at or above it — so this still
@@ -320,28 +340,42 @@ export class FrameDecoder {
     // that audio would either stall recovery on every real stream, or — worse —
     // accept the candidate and hand the unchecked video *after* the audio, of
     // any geometry, straight to the encoder.
-    let cursor = offset + FRAME_HEADER_SIZE + payloadSize(header);
+    const handoff = this.skipAudio(offset + FRAME_HEADER_SIZE + payloadSize(header));
+    if (handoff.kind !== "video") {return handoff.kind;}
+    // `handoff.header` is the video header resync would hand back at. It must
+    // belong to the same stream — before the first frame decodes there is no
+    // anchor and whatever arrives first defines the geometry (admissible()
+    // allows it), so the candidate and this successor must simply agree.
+    if (!this.admissible(handoff.header)) {return "reject";}
+    // An audio candidate carries no geometry of its own; a corroborating video
+    // handoff is all it needs.
+    if (isAudioHeader(header)) {return "accept";}
+    return sameGeometry(header, handoff.header) ? "accept" : "reject";
+  }
+
+  /**
+   * Follow the chain of audio records starting at `cursor` to the first video
+   * header, memoized so a run of N audio records costs O(N) parses across the
+   * whole pass rather than O(N) per candidate. Returns the terminal video
+   * header, `unsettled` if the run reaches the end of the buffer without one,
+   * or `reject` if a malformed header interrupts it. Iterative rather than
+   * recursive so a long audio run cannot overflow the stack.
+   */
+  private skipAudio(cursor: number): AudioSkip {
+    const chain: number[] = [];
+    let result: AudioSkip;
     for (;;) {
-      if (this.buffer.length - cursor < FRAME_HEADER_SIZE) {return "unsettled";}
-      const successor = parseHeader(this.buffer, cursor);
-      if (headerError(successor) !== null) {return "reject";}
-      if (isAudioHeader(successor)) {
-        // Audio carries no geometry and is emitted harmlessly, so it cannot be
-        // the boundary that poisons the encoder. Step over it and keep looking
-        // for the video header that actually needs vetting.
-        cursor += FRAME_HEADER_SIZE + payloadSize(successor);
-        continue;
-      }
-      // `successor` is the video header resync would hand back at. It must
-      // belong to the same stream — before the first frame decodes there is no
-      // anchor and whatever arrives first defines the geometry (admissible()
-      // allows it), so the candidate and this successor must simply agree.
-      if (!this.admissible(successor)) {return "reject";}
-      // An audio candidate carries no geometry of its own; a corroborating
-      // video handoff is all it needs.
-      if (isAudioHeader(header)) {return "accept";}
-      return sameGeometry(header, successor) ? "accept" : "reject";
+      const memo = this.audioSkip.get(cursor);
+      if (memo !== undefined) {result = memo; break;}
+      if (this.buffer.length - cursor < FRAME_HEADER_SIZE) {result = { kind: "unsettled" }; break;}
+      const header = parseHeader(this.buffer, cursor);
+      if (headerError(header) !== null) {result = { kind: "reject" }; break;}
+      if (!isAudioHeader(header)) {result = { kind: "video", header }; break;}
+      chain.push(cursor);
+      cursor += FRAME_HEADER_SIZE + payloadSize(header);
     }
+    for (const start of chain) {this.audioSkip.set(start, result);}
+    return result;
   }
 
   /**

--- a/src/features/screen-stream/frameProtocol.ts
+++ b/src/features/screen-stream/frameProtocol.ts
@@ -314,17 +314,21 @@ export class FrameDecoder {
     if (this.buffer.length - end < FRAME_HEADER_SIZE) {return "unsettled";}
     const successor = parseHeader(this.buffer, end);
     if (headerError(successor) !== null) {return "reject";}
-    // The successor is where resync hands control back to synchronized
-    // decoding, and the synchronized path does not consult the anchor — so the
-    // handoff point has to. Without this an audio-shaped record inside the
-    // damaged bytes is admissible on its own, resync ends at it, and whatever
-    // video header follows is decoded unchecked.
+    // The successor is held to the same admissibility rule as the candidate.
+    // An audio record is self-describing and carries no geometry, so on an
+    // anchored stream it cannot corroborate anything: accepting it would let a
+    // single crafted anchor-geometry frame followed by a 16-byte audio header
+    // end resync, one crafted frame cheaper than the two an anchored stream
+    // should cost. Audio interleaving during recovery therefore costs the
+    // frame it follows — the scan resumes at the next video pair — which is
+    // the same trade this decoder already makes for an uncorroborated frame.
     if (!this.admissible(successor)) {return "reject";}
     // The successor must belong to the same stream, not merely be well-formed.
     // Consecutive frames in a capture session share a geometry, so a successor
     // of a different size is evidence of coincidence, not of a boundary. This
     // is what covers the window before any frame has decoded, when there is no
-    // anchor to check against.
+    // anchor to check against: pre-anchor `admissible()` admits everything, so
+    // an audio record on either side is still accepted there.
     if (isAudioHeader(header) || isAudioHeader(successor)) {return "accept";}
     return sameGeometry(header, successor) ? "accept" : "reject";
   }
@@ -348,8 +352,13 @@ export class FrameDecoder {
    * when it drops an uncorroborated recovered frame.
    */
   private admissible(header: FrameHeader): boolean {
-    if (isAudioHeader(header) || this.anchor === null) {return true;}
-    return sameGeometry(header, this.anchor);
+    if (this.anchor === null) {return true;}
+    // Audio records carry no geometry, so they can never establish that the
+    // decoder is back on real frame boundaries — and resync ending at one hands
+    // the synchronized path a position nothing checked. An anchored stream
+    // stays in resync until it reaches a *video* boundary at its own geometry;
+    // audio arriving during that window is discarded with the rest.
+    return !isAudioHeader(header) && sameGeometry(header, this.anchor);
   }
 }
 

--- a/src/features/screen-stream/frameProtocol.ts
+++ b/src/features/screen-stream/frameProtocol.ts
@@ -314,21 +314,17 @@ export class FrameDecoder {
     if (this.buffer.length - end < FRAME_HEADER_SIZE) {return "unsettled";}
     const successor = parseHeader(this.buffer, end);
     if (headerError(successor) !== null) {return "reject";}
-    // The successor is held to the same admissibility rule as the candidate.
-    // An audio record is self-describing and carries no geometry, so on an
-    // anchored stream it cannot corroborate anything: accepting it would let a
-    // single crafted anchor-geometry frame followed by a 16-byte audio header
-    // end resync, one crafted frame cheaper than the two an anchored stream
-    // should cost. Audio interleaving during recovery therefore costs the
-    // frame it follows — the scan resumes at the next video pair — which is
-    // the same trade this decoder already makes for an uncorroborated frame.
+    // The successor is where resync hands control back to synchronized
+    // decoding, and the synchronized path does not consult the anchor — so the
+    // handoff point has to. Without this an audio-shaped record inside the
+    // damaged bytes is admissible on its own, resync ends at it, and whatever
+    // video header follows is decoded unchecked.
     if (!this.admissible(successor)) {return "reject";}
     // The successor must belong to the same stream, not merely be well-formed.
     // Consecutive frames in a capture session share a geometry, so a successor
     // of a different size is evidence of coincidence, not of a boundary. This
     // is what covers the window before any frame has decoded, when there is no
-    // anchor to check against: pre-anchor `admissible()` admits everything, so
-    // an audio record on either side is still accepted there.
+    // anchor to check against.
     if (isAudioHeader(header) || isAudioHeader(successor)) {return "accept";}
     return sameGeometry(header, successor) ? "accept" : "reject";
   }
@@ -352,13 +348,8 @@ export class FrameDecoder {
    * when it drops an uncorroborated recovered frame.
    */
   private admissible(header: FrameHeader): boolean {
-    if (this.anchor === null) {return true;}
-    // Audio records carry no geometry, so they can never establish that the
-    // decoder is back on real frame boundaries — and resync ending at one hands
-    // the synchronized path a position nothing checked. An anchored stream
-    // stays in resync until it reaches a *video* boundary at its own geometry;
-    // audio arriving during that window is discarded with the rest.
-    return !isAudioHeader(header) && sameGeometry(header, this.anchor);
+    if (isAudioHeader(header) || this.anchor === null) {return true;}
+    return sameGeometry(header, this.anchor);
   }
 }
 

--- a/src/features/screen-stream/frameProtocol.ts
+++ b/src/features/screen-stream/frameProtocol.ts
@@ -310,23 +310,38 @@ export class FrameDecoder {
    * the same payload ceiling that bounds normal decoding.
    */
   private corroborate(offset: number, header: FrameHeader): "accept" | "unsettled" | "reject" {
-    const end = offset + FRAME_HEADER_SIZE + payloadSize(header);
-    if (this.buffer.length - end < FRAME_HEADER_SIZE) {return "unsettled";}
-    const successor = parseHeader(this.buffer, end);
-    if (headerError(successor) !== null) {return "reject";}
-    // The successor is where resync hands control back to synchronized
-    // decoding, and the synchronized path does not consult the anchor — so the
-    // handoff point has to. Without this an audio-shaped record inside the
-    // damaged bytes is admissible on its own, resync ends at it, and whatever
-    // video header follows is decoded unchecked.
-    if (!this.admissible(successor)) {return "reject";}
-    // The successor must belong to the same stream, not merely be well-formed.
-    // Consecutive frames in a capture session share a geometry, so a successor
-    // of a different size is evidence of coincidence, not of a boundary. This
-    // is what covers the window before any frame has decoded, when there is no
-    // anchor to check against.
-    if (isAudioHeader(header) || isAudioHeader(successor)) {return "accept";}
-    return sameGeometry(header, successor) ? "accept" : "reject";
+    // Walk from the end of the candidate's payload to the first *video* header,
+    // stepping over self-describing audio records on the way. That video header
+    // is where resync hands control back to the synchronized path, which emits
+    // video frames without consulting the anchor — so it is the boundary that
+    // must match, not merely whatever record sits physically next to the
+    // candidate. `SimulatorCaptureSession` writes screen and audio to one queue,
+    // so an audio record routinely lands between two video frames; stopping at
+    // that audio would either stall recovery on every real stream, or — worse —
+    // accept the candidate and hand the unchecked video *after* the audio, of
+    // any geometry, straight to the encoder.
+    let cursor = offset + FRAME_HEADER_SIZE + payloadSize(header);
+    for (;;) {
+      if (this.buffer.length - cursor < FRAME_HEADER_SIZE) {return "unsettled";}
+      const successor = parseHeader(this.buffer, cursor);
+      if (headerError(successor) !== null) {return "reject";}
+      if (isAudioHeader(successor)) {
+        // Audio carries no geometry and is emitted harmlessly, so it cannot be
+        // the boundary that poisons the encoder. Step over it and keep looking
+        // for the video header that actually needs vetting.
+        cursor += FRAME_HEADER_SIZE + payloadSize(successor);
+        continue;
+      }
+      // `successor` is the video header resync would hand back at. It must
+      // belong to the same stream — before the first frame decodes there is no
+      // anchor and whatever arrives first defines the geometry (admissible()
+      // allows it), so the candidate and this successor must simply agree.
+      if (!this.admissible(successor)) {return "reject";}
+      // An audio candidate carries no geometry of its own; a corroborating
+      // video handoff is all it needs.
+      if (isAudioHeader(header)) {return "accept";}
+      return sameGeometry(header, successor) ? "accept" : "reject";
+    }
   }
 
   /**

--- a/src/features/screen-stream/frameProtocol.ts
+++ b/src/features/screen-stream/frameProtocol.ts
@@ -118,12 +118,17 @@ export class FrameDecoder {
   private scanned: number = 0;
   /**
    * Geometry of the most recently decoded frame — the geometry this stream is
-   * using. A capture session emits one frame size for its lifetime, so once
-   * this is known, resync is locked to it and cannot introduce a size the
-   * stream was not already producing. That is what makes fabricating a frame
-   * with chosen dimensions impossible rather than merely improbable: no matter
-   * how many header-shaped ranges a damaged payload contains, the set of
-   * accepted geometries has exactly one element.
+   * using. Resync is locked to it, so the point where the decoder re-enters
+   * synchronized decoding can never be a frame of a size the stream was not
+   * already producing, however many header-shaped ranges a damaged payload
+   * contains.
+   *
+   * That bounds the resync *boundary*, which is what the fabrication cases
+   * exploited; it is not a guarantee that no chosen-size frame can ever be
+   * emitted. The synchronized path deliberately does not consult the anchor,
+   * because a genuine mid-stream reconfigure has to be honored, so an attacker
+   * who can supply a long enough run of chosen bytes still gets there
+   * eventually. Only a wire-format marker closes that — see #4270.
    */
   private anchor: FrameHeader | null = null;
 
@@ -309,6 +314,12 @@ export class FrameDecoder {
     if (this.buffer.length - end < FRAME_HEADER_SIZE) {return "unsettled";}
     const successor = parseHeader(this.buffer, end);
     if (headerError(successor) !== null) {return "reject";}
+    // The successor is where resync hands control back to synchronized
+    // decoding, and the synchronized path does not consult the anchor — so the
+    // handoff point has to. Without this an audio-shaped record inside the
+    // damaged bytes is admissible on its own, resync ends at it, and whatever
+    // video header follows is decoded unchecked.
+    if (!this.admissible(successor)) {return "reject";}
     // The successor must belong to the same stream, not merely be well-formed.
     // Consecutive frames in a capture session share a geometry, so a successor
     // of a different size is evidence of coincidence, not of a boundary. This

--- a/test/features/screen-stream/frameProtocol.test.ts
+++ b/test/features/screen-stream/frameProtocol.test.ts
@@ -439,6 +439,38 @@ describe("FrameDecoder corrupt-header resynchronization", () => {
     expect(out).toHaveLength(0);
   });
 
+  test("resync stays linear across a long audio-only gap", () => {
+    // Walking past audio to the video handoff must be memoized: every audio
+    // record is itself an admissible candidate, so without memoization each of
+    // N audio offsets re-walks the O(N) tail — one audio-interleaved corruption
+    // window costs O(N²) parses, the disproportionate-work shape this whole
+    // change exists to remove. `SimulatorCaptureSession` writes audio
+    // independently of screen frames, so a long audio-only gap after a corrupt
+    // frame is a real stream shape, not a contrived one.
+    const decoder = new FrameDecoder();
+    expect(decoder.push(makeFrameBytes(4, 4, 16, 1, 0x01))).toHaveLength(1);
+
+    const audioRecord = (fill: number): Buffer =>
+      Buffer.concat([encodeHeader(0, 8_000, 1, 8), Buffer.alloc(8, fill)]);
+    const audioRun = Buffer.concat(
+      Array.from({ length: 500 }, (_unused, i) => audioRecord(i & 0xff))
+    );
+
+    let out: DecodedFrame[] = [];
+    const parses = countHeaderParses(() => {
+      out = decoder.push(
+        Buffer.concat([encodeHeader(0, 1, 4, 0), audioRun]),
+        () => {}
+      );
+    });
+
+    // No video after the audio yet, so resync correctly emits nothing and holds
+    // the bytes — but the work to reach that verdict must be linear in the gap,
+    // not quadratic. The pre-memoization walk cost ~140k parses here.
+    expect(out).toHaveLength(0);
+    expect(parses).toBeLessThan(audioRun.length * 1.2);
+  });
+
   test("does not resynchronize when the capture geometry changes inside the corruption", () => {
     const decoder = new FrameDecoder();
     // Deliberate trade, pinned so it stays deliberate. The helper does change

--- a/test/features/screen-stream/frameProtocol.test.ts
+++ b/test/features/screen-stream/frameProtocol.test.ts
@@ -405,6 +405,40 @@ describe("FrameDecoder corrupt-header resynchronization", () => {
     expect(audio).toHaveLength(2);
   });
 
+  test("an audio successor does not let a different-size video through resync", () => {
+    const decoder = new FrameDecoder();
+    // The fabrication path an audio successor must not open: an anchor-geometry
+    // candidate whose successor is audio cannot be accepted on the audio alone,
+    // because the video frame *after* the audio is where synchronized decoding
+    // resumes and it is emitted unchecked. If that video is a different size,
+    // accepting the candidate hands a fabricated-geometry frame to the encoder
+    // from one damaged frame. Corroboration must scan through the audio and hold
+    // the next video boundary to the anchor.
+    const errors: MalformedFrameError[] = [];
+    const audio: Buffer[] = [];
+    expect(decoder.push(makeFrameBytes(4, 4, 16, 1, 0x01))).toHaveLength(1);
+
+    const audioRecord = (fill: number): Buffer =>
+      Buffer.concat([encodeHeader(0, 8_000, 1, 16), Buffer.alloc(16, fill)]);
+
+    const out = decoder.push(
+      Buffer.concat([
+        encodeHeader(0, 1, 4, 0), // corruption
+        makeFrameBytes(4, 4, 16, 2, 0x02), // V — anchor-geometry candidate
+        audioRecord(0xa1), // A — must not corroborate the candidate by itself
+        makeFrameBytes(32, 32, 128, 3, 0x03), // V — different size, would-be fabrication
+      ]),
+      err => errors.push(err),
+      rec => audio.push(rec.pcm16le)
+    );
+
+    // The 32x32 frame must never surface, and the anchor-mismatched candidate is
+    // not corroborated, so resync stalls rather than emitting anything.
+    expect(errors).toHaveLength(1);
+    expect(out.map(f => `${f.header.width}x${f.header.height}`)).not.toContain("32x32");
+    expect(out).toHaveLength(0);
+  });
+
   test("does not resynchronize when the capture geometry changes inside the corruption", () => {
     const decoder = new FrameDecoder();
     // Deliberate trade, pinned so it stays deliberate. The helper does change

--- a/test/features/screen-stream/frameProtocol.test.ts
+++ b/test/features/screen-stream/frameProtocol.test.ts
@@ -370,62 +370,39 @@ describe("FrameDecoder corrupt-header resynchronization", () => {
     expect(audio).toHaveLength(0);
   });
 
-  test("an audio successor does not corroborate a resync point on an anchored stream", () => {
+  test("resynchronizes through interleaved audio on an anchored stream", () => {
     const decoder = new FrameDecoder();
-    // The candidate side of the handoff is anchor-locked, but the successor was
-    // not: an audio header was accepted as corroboration outright. That let one
-    // crafted frame at the anchor geometry plus a bare 16-byte audio header end
-    // resync, handing the synchronized path — which does not consult the anchor
-    // — the chosen-geometry frame behind it. An anchored stream costs two
-    // crafted frames (see #4270); this made it one.
+    // The real helper (`SimulatorCaptureSession`) writes screen and audio to one
+    // queue, so a recovered video frame's immediate successor is routinely an
+    // audio header, not another video header. An audio record is a valid
+    // corroborator — it proves the candidate's payload ran to a real boundary —
+    // and audio does not disturb the anchor-locked recovery point. Holding the
+    // successor to video-only geometry instead would leave this common stream
+    // unable to resync at all: no video frame is ever immediately followed by a
+    // video header, so nothing would corroborate and the stream would stall.
     const errors: MalformedFrameError[] = [];
     const audio: Buffer[] = [];
     expect(decoder.push(makeFrameBytes(4, 4, 16, 1, 0x01))).toHaveLength(1);
 
+    const audioRecord = (fill: number): Buffer =>
+      Buffer.concat([encodeHeader(0, 8_000, 1, 16), Buffer.alloc(16, fill)]);
+
     const out = decoder.push(
       Buffer.concat([
-        encodeHeader(0, 1, 4, 0),
-        makeFrameBytes(4, 4, 16, 7, 0x33), // one crafted frame at the anchor geometry
-        encodeHeader(0, 8_000, 1, 8), // ...corroborated only by an audio header
-        Buffer.alloc(8, 0x07),
-        makeFrameBytes(32, 32, 128, 4242, 0xa5), // the payoff the handoff would reach
-        encodeHeader(32, 32, 128, 4243),
+        encodeHeader(0, 1, 4, 0), // corruption
+        makeFrameBytes(4, 4, 16, 2, 0x02), // V — recovery point, anchor geometry
+        audioRecord(0xa1), // A — the successor that corroborates it
+        makeFrameBytes(4, 4, 16, 3, 0x03), // V
+        audioRecord(0xa2), // A
+        makeFrameBytes(4, 4, 16, 4, 0x04), // V
       ]),
       err => errors.push(err),
       rec => audio.push(rec.pcm16le)
     );
 
     expect(errors).toHaveLength(1);
-    expect(out).toHaveLength(0);
-    expect(audio).toHaveLength(0);
-  });
-
-  test("an audio record still corroborates a resync point before any frame anchors", () => {
-    const decoder = new FrameDecoder();
-    // The mirror of the case above: pre-anchor there is no geometry to match,
-    // `admissible()` admits everything, and audio on either side of the handoff
-    // stays valid corroboration. Tightening the anchored path must not quietly
-    // take this with it.
-    const errors: MalformedFrameError[] = [];
-    const audio: Buffer[] = [];
-
-    const out = decoder.push(
-      Buffer.concat([
-        encodeHeader(0, 1, 4, 0),
-        Buffer.alloc(32, 0x00),
-        makeFrameBytes(8, 8, 32, 11, 0x22),
-        encodeHeader(0, 8_000, 1, 8),
-        Buffer.alloc(8, 0x07),
-        encodeHeader(8, 8, 32, 12),
-      ]),
-      err => errors.push(err),
-      rec => audio.push(rec.pcm16le)
-    );
-
-    expect(errors).toHaveLength(1);
-    expect(out).toHaveLength(1);
-    expect(out[0].header.width).toBe(8);
-    expect(audio).toHaveLength(1);
+    expect(out.map(f => f.header.timestampMs)).toEqual([2, 3, 4]);
+    expect(audio).toHaveLength(2);
   });
 
   test("does not resynchronize when the capture geometry changes inside the corruption", () => {

--- a/test/features/screen-stream/frameProtocol.test.ts
+++ b/test/features/screen-stream/frameProtocol.test.ts
@@ -341,6 +341,33 @@ describe("FrameDecoder corrupt-header resynchronization", () => {
     expect(out).toHaveLength(0);
   });
 
+  test("does not resynchronize when the capture geometry changes inside the corruption", () => {
+    const decoder = new FrameDecoder();
+    // Deliberate trade, pinned so it stays deliberate. The helper does change
+    // geometry mid-stream — SimulatorCaptureSession reconfigures SCStream when
+    // the simulator window resizes — and a change landing inside a corruption
+    // window leaves the decoder unable to resync, so the stream needs a
+    // restart. There is no safe way to allow it: on a wire with no sync marker
+    // a genuine reconfigure and a crafted run of frames at a new size are the
+    // same bytes, so any rule that readmits the first readmits the second.
+    const errors: MalformedFrameError[] = [];
+    expect(decoder.push(makeFrameBytes(4, 4, 16, 1, 0x01))).toHaveLength(1);
+    decoder.push(Buffer.concat([encodeHeader(0, 1, 4, 0), Buffer.alloc(50, 0x00)]), err =>
+      errors.push(err)
+    );
+
+    let recovered = 0;
+    for (let i = 0; i < 20; i++) {
+      recovered += decoder.push(makeFrameBytes(8, 8, 32, 10 + i, 0x02), err =>
+        errors.push(err)
+      ).length;
+    }
+
+    // Corruption reported once, then silence — not a fabricated 8x8 frame.
+    expect(errors).toHaveLength(1);
+    expect(recovered).toBe(0);
+  });
+
   test("resynchronizes across a chunk boundary that splits the recovery header", () => {
     const decoder = new FrameDecoder();
     const errors: MalformedFrameError[] = [];

--- a/test/features/screen-stream/frameProtocol.test.ts
+++ b/test/features/screen-stream/frameProtocol.test.ts
@@ -128,7 +128,7 @@ describe("FrameDecoder corrupt-header resynchronization", () => {
 
     const errors: MalformedFrameError[] = [];
     const out = decoder.push(
-      Buffer.concat([corrupt, good, confirmingFrame()]),
+      Buffer.concat([corrupt, good, confirmingFrameLike(2, 2, 8)]),
       err => errors.push(err)
     );
 
@@ -202,7 +202,7 @@ describe("FrameDecoder corrupt-header resynchronization", () => {
     const stream = Buffer.concat([
       pseudoRandomPayload(1024 * 1024),
       makeFrameBytes(4, 4, 16, 909, 0x0f),
-      confirmingFrame(),
+      confirmingFrameLike(4, 4, 16),
     ]);
     for (let offset = 0; offset < stream.length; offset += 65_536) {
       const out = decoder.push(stream.subarray(offset, offset + 65_536), err =>
@@ -291,6 +291,56 @@ describe("FrameDecoder corrupt-header resynchronization", () => {
     expect(out.map(f => f.header.timestampMs)).not.toContain(777);
   });
 
+  test("two coordinated header-shaped ranges in a payload do not fabricate a frame", () => {
+    const decoder = new FrameDecoder();
+    // The payload of the damaged frame carries two header-shaped byte ranges,
+    // spaced by exactly the first one's declared payload length, so the second
+    // corroborates the first. Structural corroboration alone therefore accepts
+    // it and emits payload bytes as a 32x32 frame — dimensions of the attacker's
+    // choosing, fed straight to the encoder. The payload is BGRA pixel data, so
+    // its bytes reflect what is on the captured screen; probability bounds do
+    // not apply to a byte sequence someone can choose.
+    const errors: MalformedFrameError[] = [];
+    const out = decoder.push(
+      Buffer.concat([
+        encodeHeader(0, 1, 4, 0),
+        encodeHeader(32, 32, 128, 4242),
+        Buffer.alloc(32 * 128, 0xa5),
+        encodeHeader(1, 1, 4, 7),
+      ]),
+      err => errors.push(err)
+    );
+
+    expect(errors).toHaveLength(1);
+    expect(out).toHaveLength(0);
+  });
+
+  test("resync cannot introduce a geometry the stream was not already using", () => {
+    const decoder = new FrameDecoder();
+    // Once a frame has decoded on the synchronized path its geometry is the
+    // stream's geometry, and resync is locked to it. A crafted pair of matching
+    // header-shaped ranges therefore cannot poison the encoder's frame size,
+    // however self-consistent the pair is.
+    const errors: MalformedFrameError[] = [];
+    const established = decoder.push(makeFrameBytes(4, 4, 16, 1, 0x01));
+    expect(established.map(f => f.header.width)).toEqual([4]);
+
+    const out = decoder.push(
+      Buffer.concat([
+        encodeHeader(0, 1, 4, 0),
+        encodeHeader(32, 32, 128, 4242),
+        Buffer.alloc(32 * 128, 0xa5),
+        encodeHeader(32, 32, 128, 4243),
+        Buffer.alloc(32 * 128, 0xa5),
+        encodeHeader(32, 32, 128, 4244),
+      ]),
+      err => errors.push(err)
+    );
+
+    expect(errors).toHaveLength(1);
+    expect(out).toHaveLength(0);
+  });
+
   test("resynchronizes across a chunk boundary that splits the recovery header", () => {
     const decoder = new FrameDecoder();
     const errors: MalformedFrameError[] = [];
@@ -313,7 +363,7 @@ describe("FrameDecoder corrupt-header resynchronization", () => {
     // the rest of it arrives. The decoder must not lock onto earlier garbage.
     const corrupt = Buffer.concat([encodeHeader(0, 1, 4, 0), pseudoRandomPayload(3_000)]);
     const good = makeFrameBytes(64, 64, 256, 121, 0xee);
-    const all = Buffer.concat([corrupt, good, confirmingFrame()]);
+    const all = Buffer.concat([corrupt, good, confirmingFrameLike(64, 64, 256)]);
     const half = corrupt.length + 1_000;
 
     expect(decoder.push(all.subarray(0, half), err => errors.push(err))).toHaveLength(0);
@@ -400,7 +450,16 @@ const CONFIRM_TS = 1000;
 
 /** The frame that corroborates the recovered one preceding it. */
 function confirmingFrame(): Buffer {
-  return makeFrameBytes(1, 1, 4, CONFIRM_TS, 0x01);
+  return confirmingFrameLike(1, 1, 4);
+}
+/**
+ * The confirming frame for a recovery frame of a given geometry. A capture
+ * session emits one frame size for its lifetime, and resync now requires the
+ * corroborating successor to agree, so a confirming frame has to match the
+ * frame it confirms.
+ */
+function confirmingFrameLike(width: number, height: number, bytesPerRow: number): Buffer {
+  return makeFrameBytes(width, height, bytesPerRow, CONFIRM_TS, 0x01);
 }
 /** Deterministic pseudo-random filler — reproducible across runs. */
 function pseudoRandomPayload(length: number): Buffer {

--- a/test/features/screen-stream/frameProtocol.test.ts
+++ b/test/features/screen-stream/frameProtocol.test.ts
@@ -341,6 +341,35 @@ describe("FrameDecoder corrupt-header resynchronization", () => {
     expect(out).toHaveLength(0);
   });
 
+  test("an audio-shaped record in the damaged bytes is not a way around the anchor", () => {
+    const decoder = new FrameDecoder();
+    // Audio records carry no geometry, so they are admissible on their own.
+    // That made them a handoff point: resync could end at the audio record and
+    // let the synchronized path — which does not consult the anchor — decode
+    // whatever video header followed. The successor is checked for exactly
+    // this reason.
+    const errors: MalformedFrameError[] = [];
+    const audio: Buffer[] = [];
+    expect(decoder.push(makeFrameBytes(4, 4, 16, 1, 0x01))).toHaveLength(1);
+
+    const out = decoder.push(
+      Buffer.concat([
+        encodeHeader(0, 1, 4, 0),
+        Buffer.alloc(32, 0x00),
+        encodeHeader(0, 8_000, 1, 8),
+        Buffer.alloc(8, 0x07),
+        makeFrameBytes(32, 32, 128, 4242, 0xa5),
+        encodeHeader(32, 32, 128, 4243),
+      ]),
+      err => errors.push(err),
+      rec => audio.push(rec.pcm16le)
+    );
+
+    expect(errors).toHaveLength(1);
+    expect(out).toHaveLength(0);
+    expect(audio).toHaveLength(0);
+  });
+
   test("does not resynchronize when the capture geometry changes inside the corruption", () => {
     const decoder = new FrameDecoder();
     // Deliberate trade, pinned so it stays deliberate. The helper does change

--- a/test/features/screen-stream/frameProtocol.test.ts
+++ b/test/features/screen-stream/frameProtocol.test.ts
@@ -471,6 +471,35 @@ describe("FrameDecoder corrupt-header resynchronization", () => {
     expect(parses).toBeLessThan(audioRun.length * 1.2);
   });
 
+  test("resync stays linear when audio arrives one record per chunk after a recovery frame", () => {
+    // The cross-chunk shape: a recovered video frame followed by audio that
+    // arrives one record per `push()` before the next video. Each retained
+    // candidate must resume its audio-skip walk where it stopped and audio
+    // offsets already inside a retained run must not be re-retained, or every
+    // chunk re-walks the whole buffered gap — 12k / 45k / 170k parses for
+    // N=100 / 200 / 400 in the report. `SimulatorCaptureSession` writes audio
+    // independently and can delay screen samples, so this is a real shape.
+    const audioRecord = (fill: number): Buffer =>
+      Buffer.concat([encodeHeader(0, 8_000, 1, 8), Buffer.alloc(8, fill)]);
+
+    const parsesFor = (n: number): number => {
+      const decoder = new FrameDecoder();
+      decoder.push(makeFrameBytes(4, 4, 16, 1, 0x01));
+      // Corruption then a 4x4 recovery frame, so a video candidate is retained
+      // across the whole audio gap — the case that re-walks without a resume
+      // cursor.
+      decoder.push(Buffer.concat([encodeHeader(0, 1, 4, 0), makeFrameBytes(4, 4, 16, 2, 0x02)]));
+      return countHeaderParses(() => {
+        for (let i = 0; i < n; i++) {decoder.push(audioRecord(i & 0xff));}
+      });
+    };
+
+    // Linear, not quadratic: doubling the gap must roughly double the work, and
+    // stay far below the quadratic curve the report measured.
+    expect(parsesFor(200)).toBeLessThan(parsesFor(100) * 2.5);
+    expect(parsesFor(400)).toBeLessThan(400 * 40);
+  });
+
   test("does not resynchronize when the capture geometry changes inside the corruption", () => {
     const decoder = new FrameDecoder();
     // Deliberate trade, pinned so it stays deliberate. The helper does change

--- a/test/features/screen-stream/frameProtocol.test.ts
+++ b/test/features/screen-stream/frameProtocol.test.ts
@@ -370,6 +370,64 @@ describe("FrameDecoder corrupt-header resynchronization", () => {
     expect(audio).toHaveLength(0);
   });
 
+  test("an audio successor does not corroborate a resync point on an anchored stream", () => {
+    const decoder = new FrameDecoder();
+    // The candidate side of the handoff is anchor-locked, but the successor was
+    // not: an audio header was accepted as corroboration outright. That let one
+    // crafted frame at the anchor geometry plus a bare 16-byte audio header end
+    // resync, handing the synchronized path — which does not consult the anchor
+    // — the chosen-geometry frame behind it. An anchored stream costs two
+    // crafted frames (see #4270); this made it one.
+    const errors: MalformedFrameError[] = [];
+    const audio: Buffer[] = [];
+    expect(decoder.push(makeFrameBytes(4, 4, 16, 1, 0x01))).toHaveLength(1);
+
+    const out = decoder.push(
+      Buffer.concat([
+        encodeHeader(0, 1, 4, 0),
+        makeFrameBytes(4, 4, 16, 7, 0x33), // one crafted frame at the anchor geometry
+        encodeHeader(0, 8_000, 1, 8), // ...corroborated only by an audio header
+        Buffer.alloc(8, 0x07),
+        makeFrameBytes(32, 32, 128, 4242, 0xa5), // the payoff the handoff would reach
+        encodeHeader(32, 32, 128, 4243),
+      ]),
+      err => errors.push(err),
+      rec => audio.push(rec.pcm16le)
+    );
+
+    expect(errors).toHaveLength(1);
+    expect(out).toHaveLength(0);
+    expect(audio).toHaveLength(0);
+  });
+
+  test("an audio record still corroborates a resync point before any frame anchors", () => {
+    const decoder = new FrameDecoder();
+    // The mirror of the case above: pre-anchor there is no geometry to match,
+    // `admissible()` admits everything, and audio on either side of the handoff
+    // stays valid corroboration. Tightening the anchored path must not quietly
+    // take this with it.
+    const errors: MalformedFrameError[] = [];
+    const audio: Buffer[] = [];
+
+    const out = decoder.push(
+      Buffer.concat([
+        encodeHeader(0, 1, 4, 0),
+        Buffer.alloc(32, 0x00),
+        makeFrameBytes(8, 8, 32, 11, 0x22),
+        encodeHeader(0, 8_000, 1, 8),
+        Buffer.alloc(8, 0x07),
+        encodeHeader(8, 8, 32, 12),
+      ]),
+      err => errors.push(err),
+      rec => audio.push(rec.pcm16le)
+    );
+
+    expect(errors).toHaveLength(1);
+    expect(out).toHaveLength(1);
+    expect(out[0].header.width).toBe(8);
+    expect(audio).toHaveLength(1);
+  });
+
   test("does not resynchronize when the capture geometry changes inside the corruption", () => {
     const decoder = new FrameDecoder();
     // Deliberate trade, pinned so it stays deliberate. The helper does change


### PR DESCRIPTION
## Summary

Follow-up to the unresolved codex P2 on
[#4225](https://github.com/kaeawc/auto-mobile/pull/4225). The reviewer's case
reproduces exactly as described: a damaged frame whose payload contains **two**
header-shaped byte ranges spaced by the first one's declared payload length
passes the corroboration check, and `push()` emits payload bytes as a genuine
frame with dimensions of the attacker's choosing.

```
errors [ "header_width_zero" ]
frames [ { width: 32, height: 32, bytesPerRow: 128, timestampMs: 4242 } ]
```

### Why the existing defenses did not cover it

#4225 tied `bytesPerRow` to `width * 4`, taking a random offset's odds of
parsing as a plausible header to roughly 2^-38, and required one corroborating
successor. Both are **probability** arguments, and probability is the wrong
tool here. The payload is BGRA pixel data — its bytes reflect what is on the
captured screen, which is influenceable. Against *chosen* bytes, "one in 2^38"
buys nothing: each structural predicate is satisfied by construction. Requiring
more corroborating successors repeats the mistake at greater depth, since N
links cost an attacker N crafted headers — linear work, not exponential. So this
change does not raise the bar again.

### What this changes

Remove the degree of freedom instead of making its use improbable.

1. **Geometry anchoring.** The decoder records the geometry
   (`width`/`height`/`bytesPerRow`) of the last frame decoded on the
   synchronized path. During resync a video candidate is admissible only if its
   geometry equals that anchor, and so is the corroborating successor — the
   successor is where resync hands control back to synchronized decoding, which
   does not consult the anchor, so the handoff point is what has to be checked.
   The resync **boundary** can therefore never be a frame of a size the stream
   was not already producing, however many header-shaped ranges a payload
   contains.
2. **Successor agreement.** The corroborating successor must be a frame of the
   same geometry as the candidate, or an audio record. This covers the window
   before any frame has decoded, where there is no anchor yet, and is what
   rejects the reviewer's 32x32-then-1x1 construction.

Effect on the odds: for random bytes, acceptance now additionally requires 96
bits of geometry to match a fixed value, moving per-offset false-lock odds from
~2^-38 to beyond 2^-96. But the load-bearing claim is not probabilistic — it is
that the admissible set at the resync boundary is a singleton, so the
chosen-dimension attack has no target *there*.

**Scope of that claim, stated precisely** (an earlier revision of this PR
overclaimed it, and codex was right to push). Anchoring bounds the resync
boundary. It is not a guarantee that no chosen-size frame is ever emitted: the
synchronized path deliberately does not consult the anchor, because a genuine
mid-stream reconfigure has to be honored. An attacker who can supply a run of
chosen bytes — roughly two crafted frames at the anchor geometry, to get resync
to hand off — reaches the synchronized path, after which a chosen size follows.
Pre-anchor, two forged same-geometry pairs are likewise accepted, since there is
no established geometry to check against. Both are
[#4270](https://github.com/kaeawc/auto-mobile/issues/4270). What this PR closes
is the single-damaged-frame case, which is what was reported and what actually
happens without an adversary.

### Residual risk, stated rather than implied

An attacker who controls payload bytes can still cause chosen **pixels** to be
emitted at the geometry the stream is already using. That cannot be closed in
the decoder: the wire format carries no sync marker and no checksum, so a
crafted byte sequence is indistinguishable from a genuine one by construction.
Filed as [#4270](https://github.com/kaeawc/auto-mobile/issues/4270) rather than
smuggled in here, since it is a two-sided format change. The residual is
materially smaller than what it replaces — the dimensions the encoder configures
on can no longer be influenced, and whoever can choose payload pixels is by
definition already drawing on the screen being captured.

### A cost this introduces, found while reviewing it

`SimulatorCaptureSession.swift:83-85` reconfigures `SCStream` when the simulator
window resizes, so geometry **does** change mid-stream. Anchoring means a
reconfigure landing inside a corruption window leaves the decoder unable to
resynchronize — the stream needs a restart. I could not find a safe way to
readmit it: a genuine reconfigure and a crafted run of frames at a new size are
byte-identical, so every rule I tried that lets the first back in lets the
second in too (including "consume the transition frame without emitting it",
which just moves the anchor for the attacker and then eats real frames as
payload). Preferring the observable failure — no frames, corruption already
reported once — over silent injection into the encoder is the same trade this
decoder already makes when it drops an uncorroborated recovered frame, so it is
pinned by `does not resynchronize when the capture geometry changes inside the
corruption` and tracked in [#4270](https://github.com/kaeawc/auto-mobile/issues/4270),
which fixes both halves at the format level.

## Linked Issue

Closes #4264

## Changes

- `src/features/screen-stream/frameProtocol.ts` — `anchor` geometry recorded on
  every decoded frame, `admissible()` gate in the resync scan, and
  successor-geometry agreement in `corroborate()`.
- `test/features/screen-stream/frameProtocol.test.ts` — four new cases, plus
  `confirmingFrameLike()` so the existing recovery cases carry a confirming
  frame that matches the frame it confirms (they previously mixed geometries,
  which no real session does).

## What was deliberately left alone

Both behaviors #4225 pinned on purpose survive, with their tests untouched and
green:

- `drops a recovered frame when a second corrupt header follows it` — accepting
  a candidate whose successor is invalid is the fabrication rule itself.
- `an unsettled candidate does not make later chunks rescan the retained bytes`
  — the scan cursor is untouched; resync stays linear in bytes received. The
  new gate is a per-candidate predicate on offsets the cursor already visits, so
  it adds no parses.

## Acceptance criteria

- [x] The reviewer's exact construction emits no frame — red before, green after
      (`two coordinated header-shaped ranges in a payload do not fabricate a frame`).
- [x] After a frame has decoded, resync cannot emit a frame of any other
      geometry, even when the crafted pair is self-consistent
      (`resync cannot introduce a geometry the stream was not already using`).
- [x] The two deliberate #4225 behaviors stay green.
- [x] Residual risk stated in the PR and in the module doc comment.
- [x] The availability cost this change introduces is pinned by its own test and
      tracked, not left latent.

## Validation

- [x] `bun run lint` passes
- [x] `bun run typecheck` — no new type errors (214 known in baseline; baseline untouched)
- [x] `bun test` — 8718 pass / 0 fail across 679 files
- [x] New tests run in well under 100ms (pure decoder, no fakes or timers needed)
