### PR TITLE
fix(typecheck): parse union members instead of regex-splitting them

### DIFF
--- a/scripts/typecheck-baseline.sh
+++ b/scripts/typecheck-baseline.sh
@@ -132,11 +132,28 @@ ROOT_SED_PATTERN="$(printf '%s' "$ROOT" | sed 's/[][\.*^$|/]/\\&/g')"
 #
 # Each maximal run of `TOKEN ( " | " TOKEN )+` is byte-sorted in place. TOKEN is
 # deliberately narrow -- a double-quoted string literal or a bare identifier --
-# so a run whose members are complex (object literals, generics) is left ALONE
-# rather than mis-parsed; leaving it alone is exactly today's behavior, so the
-# conservative match can only preserve the status quo, never corrupt a signature.
-# Runs are matched independently, so adjacent unions separated by `;` are sorted
-# separately and never bleed into one another.
+# so a run whose members are complex (object literals, generics, template-literal
+# types, numeric literals) is left ALONE rather than mis-parsed; leaving it alone
+# is exactly today's behavior, so the conservative match can only preserve the
+# status quo, never corrupt a signature. Runs are found independently, so
+# adjacent unions separated by `;` are sorted separately and never bleed into
+# one another.
+#
+# Runs are found by SCANNING, not by matching a run-shaped regex and re-splitting
+# the match (issue #4257). Two things a regex split gets wrong, and both have
+# turned `main` red before:
+#   * a string-literal member may contain the separator (`"a | b" | "c"`), so a
+#     text split on " | " cuts inside the quotes (issue #4229); and
+#   * a member's VALUE may contain an ESCAPED quote (`"z" | "a\" | b" | "c"`), so
+#     a `"[^"]*"` token stops at the `\"` and the literal's tail is re-read as
+#     extra members -- writing the corrupted signature `"a\" | "z" | b" | "c"`.
+#     That corruption is self-consistent, so a round trip passes; it only shows
+#     up when the same union is re-rendered in a different order, i.e. exactly
+#     the case union canonicalization exists to tolerate (issue #4257).
+# The scanner therefore reads a string literal the way TypeScript renders one:
+# quote, then a body of escape pairs (`\"`, `\\`, `\n`, ...) or plain non-quote
+# non-backslash characters, then the closing quote. Anything that is not a
+# complete literal or a bare identifier ends the run and is emitted verbatim.
 #
 # This is order-INSENSITIVE, not laxer: sorting is a canonical form, so two
 # errors collide only when their union members are the same multiset -- i.e.
@@ -148,47 +165,63 @@ ROOT_SED_PATTERN="$(printf '%s' "$ROOT" | sed 's/[][\.*^$|/]/\\&/g')"
 # identical on every machine.
 canonicalize_unions() {
   awk '
-    # Split a run into its members WITHOUT a plain text split. A string-literal
-    # member may itself contain the separator (the type `"a | b" | "c"`), and a
-    # naive split on " | " cuts inside the quotes -- producing a different result
-    # on each pass, so `--update` would write a baseline that check mode then
-    # rejected as new. Walking front-anchored tokens keeps quoted members intact.
-    # Returns the member count, or 0 if the run does not tokenize cleanly, in
-    # which case the caller leaves it untouched.
-    function split_members(run, arr,   n, rest, tok) {
-      n = 0
-      rest = run
-      while (length(rest) > 0) {
-        if (!match(rest, /^("[^"]*"|[A-Za-z_$][A-Za-z0-9_$]*)/)) { return 0 }
-        arr[++n] = substr(rest, RSTART, RLENGTH)
-        rest = substr(rest, RLENGTH + 1)
-        if (length(rest) == 0) { break }
-        if (substr(rest, 1, 3) != " | ") { return 0 }
-        rest = substr(rest, 4)
-      }
-      return n
+    # Read ONE member anchored at the front of `rest`: either a complete
+    # double-quoted string literal whose body understands backslash escapes
+    # (so `\"` and `\\` stay inside the literal), or a bare identifier.
+    # Returns its length in characters, or 0 when `rest` does not start with a
+    # complete member -- which is how an unterminated quote, a template literal,
+    # a numeric literal or an object type ends the run instead of being
+    # mis-parsed.
+    function member_len(rest) {
+      if (match(rest, /^("(\\.|[^"\\])*"|[A-Za-z_$][A-Za-z0-9_$]*)/)) { return RLENGTH }
+      return 0
     }
-    function canon_unions(line,   out, rest, run, n, arr, i, j, t, joined) {
+    function canon_unions(line,   out, pos, len, c, n, arr, i, j, t, joined, p, end, w) {
       out = ""
-      rest = line
-      while (match(rest, /("[^"]*"|[A-Za-z_$][A-Za-z0-9_$]*)( [|] ("[^"]*"|[A-Za-z_$][A-Za-z0-9_$]*))+/)) {
-        out = out substr(rest, 1, RSTART - 1)
-        run = substr(rest, RSTART, RLENGTH)
-        rest = substr(rest, RSTART + RLENGTH)
-        n = split_members(run, arr)
-        if (n < 2) {
-          # Not cleanly tokenizable -- emit verbatim, preserving current behavior.
-          out = out run
+      pos = 1
+      len = length(line)
+      while (pos <= len) {
+        c = substr(line, pos, 1)
+        # Only a quote or an identifier-start character can begin a member;
+        # everything else is copied through untouched.
+        if (c != "\"" && c !~ /^[A-Za-z_$]$/) {
+          out = out c
+          pos++
           continue
         }
-        for (i = 1; i <= n; i++)
-          for (j = i + 1; j <= n; j++)
-            if (arr[i] > arr[j]) { t = arr[i]; arr[i] = arr[j]; arr[j] = t }
-        joined = arr[1]
-        for (i = 2; i <= n; i++) joined = joined " | " arr[i]
-        out = out joined
+        # Walk `member ( " | " member )*` from here, remembering where the last
+        # COMPLETE member ended so a dangling separator is never consumed.
+        n = 0
+        p = pos
+        end = pos
+        while (1) {
+          w = member_len(substr(line, p))
+          if (w == 0) { break }
+          arr[++n] = substr(line, p, w)
+          p += w
+          end = p
+          if (substr(line, p, 3) != " | ") { break }
+          p += 3
+        }
+        if (n == 0) {
+          # A quote that opens no complete literal: emit it and move on.
+          out = out c
+          pos++
+          continue
+        }
+        if (n == 1) {
+          out = out arr[1]
+        } else {
+          for (i = 1; i <= n; i++)
+            for (j = i + 1; j <= n; j++)
+              if (arr[i] > arr[j]) { t = arr[i]; arr[i] = arr[j]; arr[j] = t }
+          joined = arr[1]
+          for (i = 2; i <= n; i++) joined = joined " | " arr[i]
+          out = out joined
+        }
+        pos = end
       }
-      return out rest
+      return out
     }
     { print canon_unions($0) }
   '

--- a/test/bats/typecheck-baseline.bats
+++ b/test/bats/typecheck-baseline.bats
@@ -370,3 +370,88 @@ EOF
   [ "$status" -eq 0 ]
   [[ "$output" == *"no new type errors"* ]]
 }
+
+# --- Escaped quotes inside string-literal members (issue #4257) --------------
+#
+# The tokenizer keyed on `"[^"]*"`, which cannot represent a literal whose VALUE
+# contains an escaped quote. `"z" | "a\" | b" | "c"` tokenized as `"z"`, `"a\"`
+# and a bare `b`, so `--update` wrote the corrupted signature
+# `"a\" | "z" | b" | "c"`. It is self-consistent (check mode against the same
+# render passed) but NOT order-insensitive, so the same baselined error rendered
+# in a different order read as NEW -- the exact failure issue #4224 exists to
+# prevent.
+
+@test "a member whose value contains an escaped quote is not split at that quote" {
+  esc='printf "%s\n" "src/e.ts(1,1): error TS2322: Type is \"z\" | \"a\\\" | b\" | \"c\"."'
+  TYPECHECK_TSC_CMD="$esc" bash "$SCRIPT" --update
+
+  # Three members, byte-sorted; the escaped quote and the separator inside the
+  # literal both stay within their member.
+  grep -qF 'Type is "a\" | b" | "c" | "z".' "$TYPECHECK_BASELINE"
+  # The pre-fix corruption must not reappear.
+  run grep -cF 'Type is "a\" | "z" | b" | "c".' "$TYPECHECK_BASELINE"
+  [ "$output" -eq 0 ]
+
+  # Round trip: the freshly written baseline validates against the same output.
+  TYPECHECK_TSC_CMD="$esc" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no new type errors"* ]]
+  [[ "$output" != *"no longer occur"* ]]
+}
+
+@test "a union containing an escaped quote is order-insensitive" {
+  esc='printf "%s\n" "src/e.ts(1,1): error TS2322: Type is \"z\" | \"a\\\" | b\" | \"c\"."'
+  TYPECHECK_TSC_CMD="$esc" bash "$SCRIPT" --update
+
+  # Same three members, different render order -- must not read as new.
+  reordered='printf "%s\n" "src/e.ts(1,1): error TS2322: Type is \"a\\\" | b\" | \"c\" | \"z\"."'
+  TYPECHECK_TSC_CMD="$reordered" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no new type errors"* ]]
+  [[ "$output" != *"no longer occur"* ]]
+}
+
+@test "escaped backslashes and escaped quotes tokenize together" {
+  # `"b\\"` ends in an escaped BACKSLASH (value `b\`) -- the closing quote is
+  # real -- while `"a\" | x"` embeds an escaped QUOTE and the separator. Getting
+  # only one of the two escapes right still mis-tokenizes this run.
+  esc='printf "%s\n" "src/bs.ts(1,1): error TS2322: Type is \"b\\\\\" | \"a\\\" | x\" | \"c\"."'
+  TYPECHECK_TSC_CMD="$esc" bash "$SCRIPT" --update
+
+  grep -qF 'Type is "a\" | x" | "b\\" | "c".' "$TYPECHECK_BASELINE"
+
+  TYPECHECK_TSC_CMD="$esc" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no new type errors"* ]]
+  [[ "$output" != *"no longer occur"* ]]
+}
+
+@test "an escaped-quote union does not absorb a genuinely different error" {
+  esc='printf "%s\n" "src/e.ts(1,1): error TS2322: Type is \"z\" | \"a\\\" | b\" | \"c\"."'
+  TYPECHECK_TSC_CMD="$esc" bash "$SCRIPT" --update
+
+  # The baselined union reorders (benign) and a DISTINCT error appears whose
+  # escaped-quote member has a different value. Only the latter is new, and the
+  # baselined signature must not swallow it.
+  both='printf "%s\n" \
+    "src/e.ts(1,1): error TS2322: Type is \"c\" | \"z\" | \"a\\\" | b\"." \
+    "src/e.ts(4,4): error TS2322: Type is \"z\" | \"a\\\" | q\" | \"c\"."'
+  TYPECHECK_TSC_CMD="$both" run bash "$SCRIPT"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"1 NEW TypeScript error"* ]]
+  [[ "$output" == *'| q"'* ]]
+}
+
+@test "a template-literal member leaves its run untouched instead of mis-parsing" {
+  # Template literal types can contain both quotes and pipes and are not part of
+  # the token grammar, so the conservative fallback must leave the run alone
+  # rather than reorder across it.
+  tl='printf "%s\n" "src/t.ts(1,1): error TS2322: Type is \"z\" | \`p|q\` | \"a\"."'
+  TYPECHECK_TSC_CMD="$tl" bash "$SCRIPT" --update
+
+  grep -qF 'Type is "z" | `p|q` | "a".' "$TYPECHECK_BASELINE"
+
+  TYPECHECK_TSC_CMD="$tl" run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no new type errors"* ]]
+}


### PR DESCRIPTION
## Summary

`canonicalize_unions()` in `scripts/typecheck-baseline.sh` tokenized string-literal union members with `"[^"]*"`. That pattern cannot represent a literal whose **value contains an escaped quote**, so the token stopped at the `\"` and the rest of the literal was re-read as extra members — writing a corrupted signature into the baseline.

This replaces the "match a run-shaped regex, then re-split the match" approach with a single left-to-right **scanner**. It reads a string literal the way TypeScript renders one — quote, a body of escape pairs (`\"`, `\\`, ...) or plain characters, closing quote — or a bare identifier, and ends the run at anything that is not a complete member (template-literal types, numeric literals, object types), leaving such runs untouched exactly as before.

Reported by codex review on merged PR [#4229](https://github.com/kaeawc/auto-mobile/pull/4229).

## Linked Issue

Closes [#4257](https://github.com/kaeawc/auto-mobile/issues/4257)

## Bug / Regression Context

- **Prior attempts:** [#4224](https://github.com/kaeawc/auto-mobile/issues/4224) made baseline signatures union-order-insensitive; [#4229](https://github.com/kaeawc/auto-mobile/pull/4229) fixed a non-idempotence bug in the same tokenizer. This is the third defect in the one function, and all three had the same consequence — a red typecheck gate on clean `main`, blocking every open PR.
- **Observed symptom:** a pre-existing, already-baselined error reads as NEW.
- **Repro:** for the type `"z" | "a\" | b" | "c"` (three members; the second one's value is `a" | b`), `--update` wrote

  ```
  src/e.ts: error TS2322: Type is "a\" | "z" | b" | "c".
  ```

  `b` was split out as a bare member and sorted away from the literal it belongs to. The corruption is self-consistent, so a round trip against the same render passes — it only surfaces when the union re-renders in a different order:

  ```
  ❌ typecheck gate: 1 NEW TypeScript error(s) not in the baseline:
  src/e.ts: error TS2322: Type is "a\" | b" | "c" | "z".
  ```

  With the fix both renders canonicalize to `Type is "a\" | b" | "c" | "z".` and the gate stays green.

## Changes

- `scripts/typecheck-baseline.sh`: `canonicalize_unions()` now scans left-to-right with a `member_len()` helper that parses one complete member (escape-aware string literal, or identifier). The run stops at the last **complete** member, so a dangling ` | ` separator is never consumed. Behavior for non-tokenizable runs is unchanged (emit verbatim).
- `test/bats/typecheck-baseline.bats`: five new cases.

## Testing

- `bats test/bats/typecheck-baseline.bats` — 31/31 pass. New cases:
  - the reviewer's exact input is not split at the escaped quote (**round trip**: `--update` then check mode is green, and not reported as fixed either);
  - a union containing an escaped quote is **order-insensitive** — the reordered render is not new;
  - escaped backslashes and escaped quotes tokenize together (`"b\\" | "a\" | x" | "c"`);
  - **the baseline is not weakened**: alongside a benign reorder of the baselined escaped-quote union, a genuinely distinct error whose member value differs is still reported as `1 NEW`;
  - a template-literal member (which can carry both quotes and pipes) leaves its run untouched rather than reordering across it.
- Red-before / green-after confirmed by running the pre-fix script from `HEAD` against the same fixtures: e.g. `"b\\" | "a\" | x" | "c"` produced `"a\" | "b\\" | x" | "c"` before and `"a\" | x" | "b\\" | "c"` after.
- The committed baseline contains no escaped quotes today, so canonical output over real data is unchanged; both sides of the diff are canonicalized on read, so no baseline regeneration is needed (and none is included — [#4251](https://github.com/kaeawc/auto-mobile/pull/4251) just ratcheted it).

## Validation

- [x] `bun test` — 8714 pass, 0 fail
- [x] `bunx turbo run lint`
- [x] `bun run typecheck` — no new errors (214 known)
- [x] `shellcheck scripts/typecheck-baseline.sh`, `validate_shell_portability.sh`, `validate_shell_sete.sh`
- [x] `bats test/bats/typecheck-baseline.bats`
