### PR TITLE
fix(observe): budget the hierarchy fresh wait and re-read the iOS stale fallback

### DIFF
--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -307,9 +307,13 @@ export class CtrlProxyHierarchy {
 
       // Get hierarchy from WebSocket service
       const waitForFresh = !skipWaitForFresh && (cachedHierarchy === null || !cachedHierarchy.fresh);
+      // `timeoutMs` is the caller's overall budget, not a per-step allowance, so
+      // the wait gets what is LEFT of it. Starting from the original value would
+      // let a slow availability check or reconnect be followed by another full
+      // fresh wait, blowing the deadline this parameter exists to protect.
       const freshWaitMs = timeoutMs === undefined
         ? DEFAULT_FRESH_WAIT_MS
-        : Math.max(0, Math.min(DEFAULT_FRESH_WAIT_MS, timeoutMs));
+        : Math.max(0, Math.min(DEFAULT_FRESH_WAIT_MS, timeoutMs - (this.context.timer.now() - startTime)));
       const response = await perf.track("getHierarchy", () =>
         this.getLatestHierarchy(waitForFresh, freshWaitMs, perf, skipWaitForFresh, minTimestamp, signal)
       );

--- a/src/features/observe/ios/CtrlProxyHierarchy.ts
+++ b/src/features/observe/ios/CtrlProxyHierarchy.ts
@@ -149,20 +149,29 @@ export class CtrlProxyHierarchy {
 
     const reconnectStatus = this.context.getReconnectStatus?.() ?? undefined;
 
+    // Re-read the cache: `cachedHierarchy` was captured before the awaited sync,
+    // and an unsolicited hierarchy_update push handled by
+    // IOSCtrlProxyClient.processMessage can have replaced it while that request
+    // was in flight. Serving the pre-await snapshot would hand back the very
+    // entry an invalidation was meant to retire even though newer data arrived.
+    // Note this only re-reads; it must never null the cache, because under
+    // skipWaitForFresh a missing cache yields no hierarchy at all (#4193/#4230).
+    const fallbackHierarchy = this.context.getCachedHierarchy() ?? cachedHierarchy;
+
     // Return cached (stale) data if available
-    if (cachedHierarchy) {
+    if (fallbackHierarchy) {
       // Update tracking from cache — it may have been refreshed by a WebSocket push
-      if (cachedHierarchy.hierarchy.packageName) {
-        if (this.lastKnownPackageName && cachedHierarchy.hierarchy.packageName !== this.lastKnownPackageName) {
-          logger.warn(`[CTRL_PROXY] Stale cache packageName differs: cached=${cachedHierarchy.hierarchy.packageName}, lastKnown=${this.lastKnownPackageName}`);
+      if (fallbackHierarchy.hierarchy.packageName) {
+        if (this.lastKnownPackageName && fallbackHierarchy.hierarchy.packageName !== this.lastKnownPackageName) {
+          logger.warn(`[CTRL_PROXY] Stale cache packageName differs: cached=${fallbackHierarchy.hierarchy.packageName}, lastKnown=${this.lastKnownPackageName}`);
         }
-        this.lastKnownPackageName = cachedHierarchy.hierarchy.packageName;
+        this.lastKnownPackageName = fallbackHierarchy.hierarchy.packageName;
       }
       return {
-        hierarchy: cachedHierarchy.hierarchy,
+        hierarchy: fallbackHierarchy.hierarchy,
         fresh: false,
-        updatedAt: cachedHierarchy.hierarchy.updatedAt,
-        perfTiming: cachedHierarchy.perfTiming,
+        updatedAt: fallbackHierarchy.hierarchy.updatedAt,
+        perfTiming: fallbackHierarchy.perfTiming,
         reconnectStatus,
         reconnectMessage: reconnectStatus
           ? this.buildReconnectMessage(reconnectStatus.retryAfterSeconds)

--- a/test/features/observe/android/ctrlProxyHierarchyBudget.test.ts
+++ b/test/features/observe/android/ctrlProxyHierarchyBudget.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Deadline budgeting for the Android hierarchy delegate (issue #4261).
+ *
+ * `getAccessibilityHierarchy(..., timeoutMs)` documents `timeoutMs` as the
+ * OVERALL budget for the read — it exists so a caller polling against its own
+ * deadline (keyboard-state confirmation) cannot be blocked past it. The sync
+ * fallback already subtracts elapsed time; the WebSocket fresh-data wait did
+ * not, so a slow availability check or reconnect could be followed by another
+ * full `DEFAULT_FRESH_WAIT_MS` wait on top of time already spent.
+ */
+
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { CtrlProxyHierarchy } from "../../../../src/features/observe/android/CtrlProxyHierarchy";
+import type { CachedHierarchy, HierarchyDelegateContext } from "../../../../src/features/observe/android/types";
+import { AndroidCtrlProxyManager } from "../../../../src/utils/CtrlProxyManager";
+import { RequestManager } from "../../../../src/utils/RequestManager";
+import { FakeTimer } from "../../../fakes/FakeTimer";
+
+const DEFAULT_FRESH_WAIT_MS = 1000;
+
+interface Harness {
+  hierarchy: CtrlProxyHierarchy;
+  timer: FakeTimer;
+  /** `freshWaitMs` handed to `getLatestHierarchy`, or null if it was never called. */
+  observedFreshWait: () => number | null;
+  restore: () => void;
+}
+
+/**
+ * @param availabilityCostMs fake milliseconds the availability check burns
+ *   before the fresh wait starts.
+ */
+function createHarness(availabilityCostMs: number): Harness {
+  const timer = new FakeTimer();
+  let cached: CachedHierarchy | null = null;
+  let observedFreshWait: number | null = null;
+
+  const context: HierarchyDelegateContext = {
+    getWebSocket: () => null,
+    requestManager: new RequestManager(timer),
+    timer,
+    ensureConnected: async () => true,
+    cancelScreenshotBackoff: () => {},
+    device: { deviceId: "emulator-5554", platform: "android" } as never,
+    adb: {} as never,
+    getCachedHierarchy: () => cached,
+    setCachedHierarchy: h => { cached = h; },
+    getLastWebSocketTimeout: () => 0,
+    setLastWebSocketTimeout: () => {},
+  };
+
+  const managerSpy = spyOn(AndroidCtrlProxyManager, "getInstance").mockReturnValue({
+    isAvailable: async () => {
+      timer.advanceTime(availabilityCostMs);
+      return true;
+    },
+  } as never);
+
+  const hierarchy = new CtrlProxyHierarchy(context);
+  const latestSpy = spyOn(hierarchy, "getLatestHierarchy").mockImplementation(
+    async (_waitForFresh?: boolean, freshWaitMs?: number) => {
+      observedFreshWait = freshWaitMs ?? null;
+      return { hierarchy: null, fresh: false };
+    }
+  );
+  // The sync fallback is not under test here; keep it from reaching a device.
+  const syncSpy = spyOn(hierarchy, "requestHierarchySync").mockResolvedValue(null);
+
+  return {
+    hierarchy,
+    timer,
+    observedFreshWait: () => observedFreshWait,
+    restore: () => {
+      managerSpy.mockRestore();
+      latestSpy.mockRestore();
+      syncSpy.mockRestore();
+    },
+  };
+}
+
+describe("Android CtrlProxyHierarchy fresh-wait budgeting", () => {
+  let h: Harness | null = null;
+
+  afterEach(() => {
+    h?.restore();
+    h = null;
+  });
+
+  test("the fresh wait is charged against time already spent on the availability check", async () => {
+    h = createHarness(800);
+
+    await h.hierarchy.getAccessibilityHierarchy(undefined, undefined, false, 0, false, undefined, 1000);
+
+    // 1000ms budget, 800ms already burned: at most 200ms is left for the wait.
+    expect(h.observedFreshWait()).toBe(200);
+  });
+
+  test("an availability check that overruns the whole budget leaves no fresh wait", async () => {
+    h = createHarness(1500);
+
+    await h.hierarchy.getAccessibilityHierarchy(undefined, undefined, false, 0, false, undefined, 1000);
+
+    expect(h.observedFreshWait()).toBe(0);
+  });
+
+  test("a fast availability check still gets the full requested wait", async () => {
+    h = createHarness(0);
+
+    await h.hierarchy.getAccessibilityHierarchy(undefined, undefined, false, 0, false, undefined, 500);
+
+    expect(h.observedFreshWait()).toBe(500);
+  });
+
+  test("without a caller budget the default fresh wait is unchanged", async () => {
+    h = createHarness(800);
+
+    await h.hierarchy.getAccessibilityHierarchy(undefined, undefined, false, 0, false, undefined, undefined);
+
+    expect(h.observedFreshWait()).toBe(DEFAULT_FRESH_WAIT_MS);
+  });
+});

--- a/test/features/observe/ios/ctrlProxyHierarchyStaleFallback.test.ts
+++ b/test/features/observe/ios/ctrlProxyHierarchyStaleFallback.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Stale-fallback freshness for the iOS hierarchy delegate (issue #4261).
+ *
+ * `getLatestHierarchy` captures the cache at entry. When an invalidated entry
+ * takes the `skipWaitForFresh` override (issue #4193 / PR #4230) the sync fetch
+ * is awaited — and an unsolicited `hierarchy_update` push handled by
+ * `IOSCtrlProxyClient.processMessage` can replace the cache while that await is
+ * in flight. If the sync then fails, the fallback must hand back the cache as it
+ * stands, not the pre-await snapshot the invalidation was meant to retire.
+ *
+ * Clearing the cache instead is not an option here: under `skipWaitForFresh` a
+ * missing cache yields no hierarchy at all rather than a refetch.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { CtrlProxyHierarchy } from "../../../../src/features/observe/ios/CtrlProxyHierarchy";
+import type {
+  CtrlProxyCachedHierarchy,
+  HierarchyDelegateContext,
+  XCTestHierarchy,
+} from "../../../../src/features/observe/ios/types";
+import { RequestManager } from "../../../../src/utils/RequestManager";
+import { FakeTimer } from "../../../fakes/FakeTimer";
+
+const CACHE_TTL_MS = 500;
+
+function makeHierarchy(updatedAt: number, marker: string): XCTestHierarchy {
+  return {
+    updatedAt,
+    packageName: "com.test.app",
+    hierarchy: { text: marker },
+  } as XCTestHierarchy;
+}
+
+interface Harness {
+  hierarchy: CtrlProxyHierarchy;
+  timer: FakeTimer;
+  getCached: () => CtrlProxyCachedHierarchy | null;
+  setCached: (entry: CtrlProxyCachedHierarchy | null) => void;
+}
+
+/**
+ * @param onSend runs when the sync request hits the socket, standing in for
+ *   whatever the runner does while the caller is parked on the await.
+ */
+function createHarness(onSend: (requestManager: RequestManager, requestId: string) => void): Harness {
+  const timer = new FakeTimer();
+  const requestManager = new RequestManager(timer);
+  let cached: CtrlProxyCachedHierarchy | null = null;
+
+  const context: HierarchyDelegateContext = {
+    getWebSocket: () => ({
+      readyState: 1,
+      send: (data: string) => {
+        const message = JSON.parse(data) as { requestId: string };
+        onSend(requestManager, message.requestId);
+      },
+    } as never),
+    requestManager,
+    timer,
+    ensureConnected: async () => true,
+    cancelScreenshotBackoff: () => {},
+    cacheFreshTtlMs: CACHE_TTL_MS,
+    getCachedHierarchy: () => cached,
+    setCachedHierarchy: h => { cached = h; },
+  };
+
+  return {
+    hierarchy: new CtrlProxyHierarchy(context),
+    timer,
+    getCached: () => cached,
+    setCached: entry => { cached = entry; },
+  };
+}
+
+describe("iOS CtrlProxyHierarchy stale fallback", () => {
+  test("a push that lands during a failing sync wins over the invalidated snapshot", async () => {
+    let harness: Harness | null = null;
+
+    harness = createHarness((requestManager, requestId) => {
+      // An unsolicited hierarchy_update arrives while the sync is outstanding;
+      // processMessage replaces the cache with it.
+      harness!.setCached({
+        hierarchy: makeHierarchy(42, "pushed"),
+        receivedAt: harness!.timer.now(),
+        fresh: true,
+      } as CtrlProxyCachedHierarchy);
+      // The sync itself comes back empty (timed out / failed).
+      requestManager.resolve(requestId, { hierarchy: undefined });
+    });
+
+    harness.setCached({
+      hierarchy: makeHierarchy(1, "invalidated"),
+      receivedAt: harness.timer.now(),
+      fresh: false,
+    } as CtrlProxyCachedHierarchy);
+
+    const result = await harness.hierarchy.getLatestHierarchy(false, 1000, undefined, true);
+
+    expect(result.hierarchy).not.toBeNull();
+    expect((result.hierarchy as XCTestHierarchy).hierarchy.text).toBe("pushed");
+    expect(result.updatedAt).toBe(42);
+  });
+
+  test("with no push during the sync the invalidated entry is still the fallback", async () => {
+    // Guard against 'fixing' this by dropping the stale fallback altogether:
+    // under skipWaitForFresh a missing cache yields no hierarchy at all.
+    const harness = createHarness((requestManager, requestId) => {
+      requestManager.resolve(requestId, { hierarchy: undefined });
+    });
+
+    harness.setCached({
+      hierarchy: makeHierarchy(1, "invalidated"),
+      receivedAt: harness.timer.now(),
+      fresh: false,
+    } as CtrlProxyCachedHierarchy);
+
+    const result = await harness.hierarchy.getLatestHierarchy(false, 1000, undefined, true);
+
+    expect((result.hierarchy as XCTestHierarchy).hierarchy.text).toBe("invalidated");
+    expect(result.fresh).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Two unresolved codex findings on merged PRs, both hierarchy-read budget/staleness bugs in the CtrlProxy delegates.

**Android ([#4239](https://github.com/kaeawc/auto-mobile/pull/4239)) — the fresh wait was not charged against the caller's deadline.** `timeoutMs` is documented as the *overall* budget for the read; it exists so a caller polling against its own deadline (keyboard-state confirmation) cannot be blocked past it. But `freshWaitMs` was derived from the original `timeoutMs`, so a slow availability check or a reconnect could be followed by another full `DEFAULT_FRESH_WAIT_MS` wait on top of the time already spent. Only the sync fallback subtracted elapsed time. The wait now gets what is left of the budget.

**iOS ([#4230](https://github.com/kaeawc/auto-mobile/pull/4230)) — the stale fallback returned a pre-await snapshot.** `cachedHierarchy` is captured at entry. When an invalidated entry takes the `skipWaitForFresh` override and the awaited sync then fails, an unsolicited `hierarchy_update` push that `IOSCtrlProxyClient.processMessage` wrote during the await was discarded: the fallback still served the explicitly-invalidated snapshot. The fallback now re-reads the cache after the await.

The iOS change **re-reads only** — it never nulls the cache. Under `skipWaitForFresh` a missing cache yields no hierarchy at all rather than a refetch, because the delegate does not fetch on a cache miss there. The [#4230](https://github.com/kaeawc/auto-mobile/pull/4230) invalidation semantics are untouched and `ctrlProxyHierarchyCache.test.ts` stays green.

## Linked Issue

Closes #4261

## Bug / Regression Context

- **Prior attempts:** [#4239](https://github.com/kaeawc/auto-mobile/pull/4239) introduced the bounded read; [#4230](https://github.com/kaeawc/auto-mobile/pull/4230) fixed `invalidateCache()` being an observable no-op. Both left unresolved codex feedback, filed as #4261.
- **Observed symptom:** Android — with a 1000ms budget and an availability check costing 800ms, `getLatestHierarchy` was still handed a 1000ms fresh wait. iOS — a push landing during a failing sync was thrown away in favour of the invalidated entry.
- **Repro:** both new test files are red against unmodified `main` (see below).

## Validation

- [x] Red-before / green-after verified per fix, by reverting each source file individually:
  - unmodified source: Android 2 fail / 2 pass, iOS 1 fail / 1 pass
  - Android fix reverted (iOS fix applied): Android suite 2 fail
  - iOS fix reverted (Android fix applied): iOS suite 1 fail
  - both applied: 6 pass / 0 fail
- [x] `bun test` — 8720 pass, 0 fail (681 files)
- [x] `bun run lint`
- [x] `bun run typecheck` — no new errors (baseline untouched)
- [x] New tests use interface + fakes + `FakeTimer`; both files run in single-digit ms
- No device, emulator, or simulator interaction.

## Notes

The Android test drives the elapsed time through a `FakeTimer` advanced inside a stubbed `isAvailable()`, so the budget arithmetic is exercised without any real availability probe. The iOS test resolves the sync request with no hierarchy while replacing the cache in the same `send` — the write lands after the pre-await capture and before the await resumes, which is exactly the race being fixed. A second iOS test pins the no-push case so the fallback cannot be "fixed" by dropping it.
