### PR TITLE
fix(installer): let sudo prompt outside the install bound and finish the watchdog kill

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1492,8 +1492,15 @@ bounded_watchdog_run() {
             # straight through. The caller now waits for this subshell, so an
             # unconditional sleep would add the whole grace to every timeout,
             # including the common case where the command dies on TERM at once.
+            # Poll both forms for the same reason the signals above use both:
+            # if the child never became group leader, `-pid` names no group, and
+            # testing only that would break out instantly and collapse the grace
+            # to zero — TERM and KILL in the same instant, with no chance to
+            # clean up.
             while [[ ${waited} -lt ${grace} ]]; do
-                kill -0 -"${cmd_pid}" 2> /dev/null || break
+                if ! kill -0 -"${cmd_pid}" 2> /dev/null && ! kill -0 "${cmd_pid}" 2> /dev/null; then
+                    break
+                fi
                 sleep 1
                 waited=$((waited + 1))
             done

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1304,15 +1304,118 @@ PACKAGE_INSTALL_TIMEOUT_SECONDS="${PACKAGE_INSTALL_TIMEOUT_SECONDS:-600}"
 # Assigns to a global rather than printing so callers can invoke it as a plain
 # statement — a function run inside `$(…)` or on the left of `||` has `set -e`
 # suppressed inside it (SC2310/SC2311).
+#
+# Deliberately NOT `--foreground`. That flag stops `timeout` putting the command
+# in its own process group, and the group is the only reason the
+# `bash -c "a && b"` call sites are bounded at all — bash does not exec the
+# package manager there, so a signal aimed at the direct child never reaches it.
+# `--foreground` looks like the fix for sudo's password prompt (it is what
+# `timeout --help` offers to "allow COMMAND to read from the TTY") but it trades
+# the bound away and does not even solve the prompt, which the output capture
+# swallows either way. The prompt is handled before the bound instead, in
+# ensure_sudo_credentials below.
+
+# How long a command gets between TERM and KILL. Shared with the watchdog
+# fallback so both bounding paths escalate identically, and overridable so tests
+# can exercise the escalation without waiting out the real grace.
+BOUNDED_KILL_GRACE_SECONDS="${BOUNDED_KILL_GRACE_SECONDS:-10}"
+
 BOUNDED_CMD_PREFIX=()
 resolve_bounded_cmd_prefix() {
     local secs="$1"
     BOUNDED_CMD_PREFIX=()
     if command_exists timeout; then
-        BOUNDED_CMD_PREFIX=(timeout -k 10 "${secs}")
+        BOUNDED_CMD_PREFIX=(timeout -k "${BOUNDED_KILL_GRACE_SECONDS}" "${secs}")
     elif command_exists gtimeout; then
-        BOUNDED_CMD_PREFIX=(gtimeout -k 10 "${secs}")
+        BOUNDED_CMD_PREFIX=(gtimeout -k "${BOUNDED_KILL_GRACE_SECONDS}" "${secs}")
     fi
+}
+
+# Whether stdin is a terminal, into STDIN_IS_TERMINAL.
+#
+# Its own function so tests can substitute it: a test harness never has a
+# controlling terminal, but the interactive branch it gates is exactly the
+# behaviour worth pinning. Assigns to a global rather than returning a status
+# for the same reason as resolve_bounded_cmd_prefix — a function used as a
+# condition has `set -e` suppressed inside it (SC2310).
+STDIN_IS_TERMINAL=false
+detect_stdin_terminal() {
+    STDIN_IS_TERMINAL=false
+    if [[ -t 0 ]]; then
+        STDIN_IS_TERMINAL=true
+    fi
+}
+
+# Whether a bounded invocation will shell out through sudo, into
+# BOUNDED_INSTALL_USES_SUDO.
+#
+# Checks every argument rather than just the first: _install_system_package
+# builds `sudo apt-get update && sudo apt-get install …` and hands the whole
+# chain to `bash -c`, so sudo is not argument one there.
+BOUNDED_INSTALL_USES_SUDO=false
+detect_bounded_install_sudo() {
+    local arg
+    BOUNDED_INSTALL_USES_SUDO=false
+    for arg in "$@"; do
+        case " ${arg} " in
+            *" sudo "*)
+                BOUNDED_INSTALL_USES_SUDO=true
+                return 0
+                ;;
+        esac
+    done
+}
+
+# Refresh sudo's cached credential *before* entering the bound and the capture.
+#
+# Both of run_bounded_install's properties are hostile to a password prompt:
+#
+#   - The output is captured, and sudo writes its prompt to stderr, so the
+#     prompt never reaches the terminal while it matters. It surfaces later, if
+#     at all, replayed out of the captured output after the bound has fired.
+#   - The command runs in its own process group (`timeout` calls setpgid, and
+#     the watchdog fallback uses `set -m`), which makes it a *background* group
+#     with respect to the terminal. A background process reading the controlling
+#     terminal gets SIGTTIN and stops, so sudo's read of /dev/tty never
+#     completes — the user's keystrokes go to the parent shell instead.
+#
+# Together those turned an expired credential into a silent hang for the full
+# 600s bound, followed by a spurious "exceeded … and was aborted". Refreshing
+# here — unbounded, uncaptured, in the caller's own process group — means the
+# bounded invocation itself never has to prompt.
+SUDO_CREDENTIALS_READY=false
+ensure_sudo_credentials() {
+    if [[ "${SUDO_CREDENTIALS_READY}" == "true" ]]; then
+        return 0
+    fi
+    # `command -v` rather than the command_exists helper: a function used as a
+    # condition has `set -e` suppressed inside it (SC2310).
+    if ! command -v sudo > /dev/null 2>&1; then
+        return 0
+    fi
+
+    # `-n` never prompts, so this is safe to run before knowing whether a
+    # terminal exists. It also refreshes the timestamp when one is cached.
+    if sudo -n -v 2> /dev/null; then
+        SUDO_CREDENTIALS_READY=true
+        return 0
+    fi
+
+    detect_stdin_terminal
+    if [[ "${NON_INTERACTIVE}" == "true" || "${STDIN_IS_TERMINAL}" != "true" ]]; then
+        # Prompting with no terminal would trade the old 45-minute stall for a
+        # new one. Let the install fail loudly instead.
+        log_warn "sudo has no cached credential and this session is not interactive; package installs may fail"
+        return 0
+    fi
+
+    log_info "Requesting sudo credentials before installing packages"
+    if sudo -v; then
+        SUDO_CREDENTIALS_READY=true
+    else
+        log_warn "Could not refresh sudo credentials; package installs may fail"
+    fi
+    return 0
 }
 
 # Bound a command with a pure-bash watchdog, for hosts with no timeout binary.
@@ -1375,6 +1478,8 @@ bounded_watchdog_run() {
     local cmd_pid=$!
     if [[ ${had_monitor} -eq 0 ]]; then set +m; fi
 
+    local grace="${BOUNDED_KILL_GRACE_SECONDS}"
+    local waited=0
     (
         sleep "${secs}"
         if kill -0 "${cmd_pid}" 2> /dev/null; then
@@ -1382,9 +1487,16 @@ bounded_watchdog_run() {
             # A negative pid targets the process group. Fall back to the bare
             # pid in case the child never became group leader.
             kill -TERM -"${cmd_pid}" 2> /dev/null || kill -TERM "${cmd_pid}" 2> /dev/null || true
-            # Same 10s grace as `timeout -k 10` on the coreutils path, so the
-            # two bounding paths escalate identically.
-            sleep 10
+            # Same grace as `timeout -k` on the coreutils path, so the two
+            # bounding paths escalate identically — but polled rather than slept
+            # straight through. The caller now waits for this subshell, so an
+            # unconditional sleep would add the whole grace to every timeout,
+            # including the common case where the command dies on TERM at once.
+            while [[ ${waited} -lt ${grace} ]]; do
+                kill -0 -"${cmd_pid}" 2> /dev/null || break
+                sleep 1
+                waited=$((waited + 1))
+            done
             kill -KILL -"${cmd_pid}" 2> /dev/null || kill -KILL "${cmd_pid}" 2> /dev/null || true
         fi
     ) > /dev/null 2>&1 3>&- &
@@ -1393,14 +1505,22 @@ bounded_watchdog_run() {
     local status=0
     wait "${cmd_pid}" 2> /dev/null || status=$?
     if [[ -s "${fired_marker}" ]]; then
-        # Leave the watcher running: it still owes the group a KILL for anything
-        # that ignored the TERM. Waiting for it here would add its full grace
-        # period to every timeout, and there is nothing to wait for — the output
-        # is already on disk, not in a pipe a survivor could hold open.
+        # Wait out the watcher's TERM-to-KILL escalation before returning.
+        # `wait` above returns as soon as the *direct child* exits, and the
+        # direct child is frequently a `bash -c` wrapper that dies on TERM while
+        # the package manager it spawned ignores it. Returning here reported the
+        # install aborted while that process was still running — and it outlived
+        # the installer itself. A watchdog that returns before the group is dead
+        # does not bound anything. Same contract as
+        # scripts/ios/run_with_timeout.sh; the poll above keeps the cost near
+        # zero whenever TERM is honoured.
+        wait "${watcher_pid}" 2> /dev/null || true
         status=124
     else
         kill "${watcher_pid}" 2> /dev/null || true
         wait "${watcher_pid}" 2> /dev/null || true
+        # The watcher can fire between the `wait` above and the kill here.
+        if [[ -s "${fired_marker}" ]]; then status=124; fi
     fi
     rm -f "${fired_marker}"
     BOUNDED_WATCHDOG_STATUS="${status}"
@@ -1419,34 +1539,50 @@ bounded_watchdog_run() {
 # suppression is half of why #4162 could not be diagnosed. Keeping the output is
 # worth more than the spinner.
 #
-# Capturing the output is only safe because GNU `timeout` puts the child in its
-# own process group and signals the whole group. Several call sites pass an
-# `&&` chain through `bash -c`, where bash does not exec the package manager;
-# signalling only the direct child would leave the grandchild alive holding this
-# capture's pipe open, and the bound would silently not apply.
+# Both bounding paths route the output to a file rather than a command
+# substitution. A `$(…)` capture keeps the caller blocked on EOF for as long as
+# any descendant retains the write end of the pipe, which is exactly the process
+# the kill escalation is chasing — so the capture would outlive the bound it is
+# supposed to be protected by. Writing to a file removes that coupling entirely:
+# the output is already on disk when the deadline fires, whatever survives.
 run_bounded_install() {
     local title="$1"
     shift
+
+    # Before the bound and before the capture, on purpose. Inside them sudo
+    # cannot prompt: the prompt is swallowed by the capture, and the command runs
+    # in a background process group where reading the terminal raises SIGTTIN.
+    # See ensure_sudo_credentials.
+    detect_bounded_install_sudo "$@"
+    if [[ "${BOUNDED_INSTALL_USES_SUDO}" == "true" ]]; then
+        ensure_sudo_credentials
+    fi
 
     resolve_bounded_cmd_prefix "${PACKAGE_INSTALL_TIMEOUT_SECONDS}"
 
     local output=""
     local status=0
-    if [[ ${#BOUNDED_CMD_PREFIX[@]} -gt 0 ]]; then
+    local outfile
+    outfile="$(mktemp "${TMPDIR:-/tmp}/automobile_install_output.XXXXXX")" || outfile=""
+    if [[ -n "${outfile}" && ${#BOUNDED_CMD_PREFIX[@]} -gt 0 ]]; then
         # The `+` guard keeps an empty prefix from tripping `set -u` on bash 3.2.
-        output=$(${BOUNDED_CMD_PREFIX[@]+"${BOUNDED_CMD_PREFIX[@]}"} "$@" 2>&1) || status=$?
+        ${BOUNDED_CMD_PREFIX[@]+"${BOUNDED_CMD_PREFIX[@]}"} "$@" > "${outfile}" 2>&1 || status=$?
+        output="$(cat "${outfile}")"
+        rm -f "${outfile}"
+    elif [[ -n "${outfile}" ]]; then
+        bounded_watchdog_run "${PACKAGE_INSTALL_TIMEOUT_SECONDS}" "${outfile}" "$@"
+        status="${BOUNDED_WATCHDOG_STATUS}"
+        output="$(cat "${outfile}")"
+        rm -f "${outfile}"
+    elif [[ ${#BOUNDED_CMD_PREFIX[@]} -gt 0 ]]; then
+        # No temp file, but keep the bound: losing the capture is survivable,
+        # losing the ceiling is the fail-open #4162 exists to close. The output
+        # goes straight to the terminal here rather than being replayed.
+        log_warn "${title}: could not create a temp file to capture output; running bounded but uncaptured"
+        ${BOUNDED_CMD_PREFIX[@]+"${BOUNDED_CMD_PREFIX[@]}"} "$@" || status=$?
     else
-        local outfile
-        outfile="$(mktemp "${TMPDIR:-/tmp}/automobile_install_output.XXXXXX")" || outfile=""
-        if [[ -z "${outfile}" ]]; then
-            log_warn "${title}: could not create a temp file to capture output; running unbounded"
-            "$@" || status=$?
-        else
-            bounded_watchdog_run "${PACKAGE_INSTALL_TIMEOUT_SECONDS}" "${outfile}" "$@"
-            status="${BOUNDED_WATCHDOG_STATUS}"
-            output="$(cat "${outfile}")"
-            rm -f "${outfile}"
-        fi
+        log_warn "${title}: could not create a temp file to capture output; running unbounded"
+        "$@" || status=$?
     fi
 
     if [[ ${status} -eq 0 ]]; then

--- a/test/bats/install-bounded-package-install.bats
+++ b/test/bats/install-bounded-package-install.bats
@@ -526,7 +526,8 @@ STUB
   resolve_bounded_cmd_prefix 42
 
   local arg
-  for arg in "${BOUNDED_CMD_PREFIX[@]}"; do
+  # The `+` guard keeps an empty prefix from tripping `set -u` on bash 3.2.
+  for arg in ${BOUNDED_CMD_PREFIX[@]+"${BOUNDED_CMD_PREFIX[@]}"}; do
     [ "${arg}" != "--foreground" ]
     [ "${arg}" != "-f" ]
   done

--- a/test/bats/install-bounded-package-install.bats
+++ b/test/bats/install-bounded-package-install.bats
@@ -57,6 +57,11 @@ STUB
 }
 
 teardown() {
+  # Reap anything a watchdog test deliberately left behind, so a regression in
+  # the kill escalation cannot leak a `sleep` into the rest of the run.
+  if [ -n "${SURVIVOR_PID_FILE:-}" ] && [ -s "${SURVIVOR_PID_FILE}" ]; then
+    kill -KILL "$(cat "${SURVIVOR_PID_FILE}")" 2> /dev/null || true
+  fi
   export PATH="${ORIG_PATH}"
   "$RM" -rf "${TEST_DIR}"
 }
@@ -324,4 +329,221 @@ STUB
   # `>/dev/null`, so package installs must go through run_bounded_install.
   run grep -nE 'run_spinner .*(brew install|apt-get install|dnf install|pacman -S|go install)' scripts/install.sh
   [ "$status" -ne 0 ]
+}
+
+# --- follow-up to #4232: sudo prompts and watchdog kill escalation -----------
+
+# Replace the pass-through sudo stub from setup() with one that models the
+# thing that actually breaks: an expired credential. Real sudo writes its
+# prompt to stderr and reads the password from /dev/tty, and `-n` fails rather
+# than prompting when nothing is cached.
+stub_expired_sudo() {
+  cat > "${STUB_BIN}/sudo" << STUB
+#!/usr/bin/env bash
+if [ "\$1" = "-n" ]; then
+  # Nothing cached yet. Refuse without prompting, exactly as sudo -n does.
+  [ -s "${TEST_DIR}/sudo_cached" ] && exit 0
+  exit 1
+fi
+if [ "\$1" = "-v" ]; then
+  printf 'PROMPT-VISIBLE: [sudo] password for tester: ' >&2
+  printf 'refreshed\n' > "${TEST_DIR}/sudo_cached"
+  printf 'v\n' >> "${TEST_DIR}/sudo_calls"
+  exit 0
+fi
+if [ ! -s "${TEST_DIR}/sudo_cached" ]; then
+  # The bounded invocation must never be the thing that prompts: at this point
+  # it is inside a background process group with its output captured, so the
+  # prompt is invisible and the read cannot reach the terminal.
+  printf 'BOUNDED-PROMPT\n' >&2
+  exit 1
+fi
+printf 'cmd\n' >> "${TEST_DIR}/sudo_calls"
+exec "\$@"
+STUB
+  "$CHMOD" +x "${STUB_BIN}/sudo"
+}
+
+@test "an expired sudo credential is refreshed visibly, outside the capture" {
+  # Reproduced before the fix, in a PTY with a 5s bound and a password typed one
+  # second in: the typed text was echoed by the parent shell, sudo never
+  # received it, and the prompt only surfaced at the end -- replayed out of the
+  # captured output after the bound had already fired.
+  #
+  # A visible prompt on a *successful* install is the assertion that matters:
+  # run_bounded_install prints its capture only on failure, so text that reaches
+  # the caller on the success path can only have escaped the capture.
+  hide_real_timeout
+  stub_expired_sudo
+  cat > "${STUB_BIN}/apt-get" << 'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  "$CHMOD" +x "${STUB_BIN}/apt-get"
+  detect_stdin_terminal() { STDIN_IS_TERMINAL=true; }
+  NON_INTERACTIVE=false
+
+  run run_bounded_install "Installing ffmpeg" sudo apt-get install -y -qq ffmpeg
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PROMPT-VISIBLE"* ]]
+  # ...and the bounded invocation itself must not have been the one prompting.
+  [[ "$output" != *"BOUNDED-PROMPT"* ]]
+}
+
+@test "sudo embedded in a bash -c chain is refreshed too" {
+  # _install_system_package builds `sudo apt-get update && sudo apt-get install`
+  # and hands the whole chain to `bash -c`, so sudo is not argument one.
+  hide_real_timeout
+  stub_expired_sudo
+  cat > "${STUB_BIN}/apt-get" << 'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  "$CHMOD" +x "${STUB_BIN}/apt-get"
+  detect_stdin_terminal() { STDIN_IS_TERMINAL=true; }
+  NON_INTERACTIVE=false
+
+  run run_bounded_install "Installing ffmpeg" bash -c "sudo apt-get update -qq && sudo apt-get install -y -qq ffmpeg"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PROMPT-VISIBLE"* ]]
+}
+
+@test "an already-cached sudo credential is not re-prompted" {
+  hide_real_timeout
+  stub_expired_sudo
+  printf 'already\n' > "${TEST_DIR}/sudo_cached"
+  cat > "${STUB_BIN}/apt-get" << 'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  "$CHMOD" +x "${STUB_BIN}/apt-get"
+  detect_stdin_terminal() { STDIN_IS_TERMINAL=true; }
+  NON_INTERACTIVE=false
+
+  run run_bounded_install "Installing ffmpeg" sudo apt-get install -y -qq ffmpeg
+
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"PROMPT-VISIBLE"* ]]
+}
+
+@test "a non-interactive session does not stop to prompt for sudo" {
+  # CI runs with no terminal on stdin. Blocking there would trade the old
+  # 45-minute stall for a new one.
+  hide_real_timeout
+  stub_expired_sudo
+  cat > "${STUB_BIN}/apt-get" << 'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  "$CHMOD" +x "${STUB_BIN}/apt-get"
+  detect_stdin_terminal() { STDIN_IS_TERMINAL=false; }
+  NON_INTERACTIVE=true
+
+  run run_bounded_install "Installing ffmpeg" sudo apt-get install -y -qq ffmpeg
+
+  [[ "$output" != *"PROMPT-VISIBLE"* ]]
+  [ ! -s "${TEST_DIR}/sudo_cached" ]
+}
+
+@test "a command with no sudo in it never touches sudo" {
+  hide_real_timeout
+  stub_expired_sudo
+  detect_stdin_terminal() { STDIN_IS_TERMINAL=true; }
+  NON_INTERACTIVE=false
+
+  run run_bounded_install "Installing thing" /bin/echo hello
+
+  [ "$status" -eq 0 ]
+  [ ! -s "${TEST_DIR}/sudo_calls" ]
+}
+
+@test "the watchdog fallback does not return while a TERM-ignoring descendant lives" {
+  # A watchdog that returns before the group is dead does not bound anything:
+  # the installer reports the install aborted and moves on -- or exits -- while
+  # the package manager is still running. Reproduced before the fix with a 1s
+  # bound: run_bounded_install returned 124 after 1s and the survivor was still
+  # alive, including after the parent script had exited entirely.
+  #
+  # No require_real_timeout: the fallback is pure bash, so this runs on
+  # macos-latest too, which is the host where the bound used to be absent.
+  hide_real_timeout
+  export SURVIVOR_PID_FILE="${TEST_DIR}/survivor.pid"
+  cat > "${STUB_BIN}/leaky-pm" << 'STUB'
+#!/usr/bin/env bash
+# A descendant that ignores TERM, as a package manager mid-transaction might.
+bash -c 'trap "" TERM; echo $$ > "$SURVIVOR_PID_FILE"; sleep 120' &
+# The direct child, by contrast, exits promptly on TERM -- which is what lets
+# the parent's `wait` return with the group still populated.
+trap 'exit 143' TERM
+sleep 60 &
+wait $!
+STUB
+  "$CHMOD" +x "${STUB_BIN}/leaky-pm"
+
+  PACKAGE_INSTALL_TIMEOUT_SECONDS=1
+  BOUNDED_KILL_GRACE_SECONDS=2
+  run run_bounded_install "Installing ffmpeg" leaky-pm
+
+  [ "$status" -eq 124 ]
+  [ -s "${SURVIVOR_PID_FILE}" ]
+  local survivor
+  survivor="$(cat "${SURVIVOR_PID_FILE}")"
+  run kill -0 "${survivor}"
+  [ "$status" -ne 0 ]
+}
+
+@test "the watchdog does not pay the full kill grace when TERM is honoured" {
+  # Waiting for the watcher must not mean waiting out the grace period on every
+  # timeout -- the common case is a command that dies on TERM immediately.
+  hide_real_timeout
+  cat > "${STUB_BIN}/stalling-pm" << 'STUB'
+#!/usr/bin/env bash
+sleep 60
+STUB
+  "$CHMOD" +x "${STUB_BIN}/stalling-pm"
+
+  PACKAGE_INSTALL_TIMEOUT_SECONDS=1
+  BOUNDED_KILL_GRACE_SECONDS=30
+  local start=${SECONDS}
+  run run_bounded_install "Installing ffmpeg" stalling-pm
+  local elapsed=$((SECONDS - start))
+
+  [ "$status" -eq 124 ]
+  [ "${elapsed}" -lt 20 ]
+}
+
+@test "the bounded prefix does not use --foreground" {
+  # --foreground stops `timeout` putting the child in its own process group,
+  # which is the only reason the `bash -c \"a && b\"` call sites are bounded at
+  # all: without it the signal never reaches the grandchild. It is a tempting
+  # but wrong fix for the sudo-prompt problem -- and it does not even solve it,
+  # since the prompt is swallowed by the output capture either way.
+  hide_real_timeout
+  "$LN" -sf /bin/echo "${STUB_BIN}/timeout"
+
+  resolve_bounded_cmd_prefix 42
+
+  local arg
+  for arg in "${BOUNDED_CMD_PREFIX[@]}"; do
+    [ "${arg}" != "--foreground" ]
+    [ "${arg}" != "-f" ]
+  done
+}
+
+@test "no bounded path captures package manager output through a command substitution" {
+  # Both paths must route output to a file. A `$(...)` capture leaves the caller
+  # blocked on EOF for as long as any descendant retains the write end, which is
+  # precisely the survivor case the kill escalation exists for.
+  run grep -nE 'output=\$\(.*BOUNDED_CMD_PREFIX' scripts/install.sh
+  [ "$status" -ne 0 ]
+}
+
+@test "the command-substitution guard actually matches the shape it forbids" {
+  local fixture="${TEST_DIR}/reintroduced_capture.sh"
+  printf '%s\n' '        output=$(${BOUNDED_CMD_PREFIX[@]+"${BOUNDED_CMD_PREFIX[@]}"} "$@" 2>&1) || status=$?' > "${fixture}"
+
+  run grep -nE 'output=\$\(.*BOUNDED_CMD_PREFIX' "${fixture}"
+  [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Summary

Follow-up to the two unresolved codex P2s on [#4232](https://github.com/kaeawc/auto-mobile/pull/4232). Both were reproduced before being fixed.

An interactive Linux install whose `sudo` credential had expired hung at a password prompt the user could not see. That is a regression [#4232](https://github.com/kaeawc/auto-mobile/pull/4232) introduced, and it is the priority of the two. Separately, on hosts without `timeout`/`gtimeout` the watchdog reported a timeout and returned while the package manager was still running.

## Linked Issue

Closes [#4262](https://github.com/kaeawc/auto-mobile/issues/4262)

## Bug / Regression Context

- **Prior attempts:** [#4232](https://github.com/kaeawc/auto-mobile/pull/4232) bounded package installs and stopped discarding their output, fixing [#4162](https://github.com/kaeawc/auto-mobile/issues/4162). It introduced the sudo regression and left the watchdog's kill unawaited.
- **Observed symptom:** an invisible `sudo` password prompt that swallows the user's keystrokes for the full 600s bound and then reports the install aborted; and a "bounded" install that returns while the package manager is still alive.
- **Repro steps / conditions:** interactive `curl … | bash` on Linux with no cached sudo timestamp; and any package-manager command with a TERM-ignoring descendant on a host with no `timeout` binary.

### Finding 1 — the sudo prompt

Two independent things go wrong once the command is inside `run_bounded_install`:

1. **The command is in a background process group.** `timeout` calls `setpgid` unless given `--foreground`, and the pure-bash fallback uses `set -m` for the same reason. A background process reading the controlling terminal gets `SIGTTIN` and stops, so sudo's read of `/dev/tty` never completes.
2. **The prompt is captured.** sudo writes it to stderr, and `2>&1` routes it into the capture.

Reproduced on stock macOS (no `timeout`, so the watchdog fallback is the live path) by driving a PTY with a fake sudo that prompts on stderr and reads `/dev/tty`, typing a password one second into a 5s bound:

```
hunter2
[WARN] Updating package index exceeded 5s and was aborted
[sudo] password for tester:
--- sudo.log:
(empty - sudo never received a password)
```

The typed password was echoed by the parent shell; the prompt appeared only at the end, replayed out of the captured output after the bound had already fired.

**`--foreground` is not the fix.** Isolating the two halves — child left in the foreground group, output still captured — shows sudo *does* read the terminal, but the prompt is still invisible:

```
=== A: same process group (the --foreground equivalent), output CAPTURED ===
hunter2
captured=[[sudo] password for tester: apt-get ran: update -qq]
```

So `--foreground` addresses only the `SIGTTIN` half and leaves a silent password prompt. It also gives up the property [#4232](https://github.com/kaeawc/auto-mobile/pull/4232) established as load-bearing: several call sites pass an `&&` chain through `bash -c`, so bash does not exec the package manager and only a group-directed signal reaches the grandchild. `--foreground` would make the bound silently not apply there — reintroducing the fail-open this all exists to close.

The fix moves the prompt out of the bounded region entirely: `ensure_sudo_credentials` runs `sudo -n -v` first (never prompts) and, only if that fails and the session is interactive, `sudo -v` unbounded and uncaptured. The bounded invocation then never prompts. A source-scan test pins that `--foreground` stays out of the prefix.

### Finding 2 — the watchdog kill

`bounded_watchdog_run` returned 124 as soon as the *direct child* exited on TERM, leaving the watcher to deliver KILL later. Reproduced with a 1s bound and a stub whose direct child exits on TERM but leaves a TERM-ignoring `sleep 300` behind:

```
[WARN] Installing thing exceeded 1s and was aborted
run_bounded_install returned status=124 after 1s
DEFECT: survivor pid 83230 STILL ALIVE when run_bounded_install returned
```

The survivor was still there after the parent script had exited. A watchdog that returns before the group is dead does not bound anything.

The parent now waits for the watcher on the fired path, as `scripts/ios/run_with_timeout.sh` already does. To keep that from adding the full grace to every timeout, the watcher polls for the group to drain instead of sleeping straight through — so the common case (TERM honoured) costs about a second.

## Changes

- `ensure_sudo_credentials` / `detect_bounded_install_sudo` / `detect_stdin_terminal` in `scripts/install.sh`. Sudo is detected across all arguments, since `_install_system_package` passes `sudo apt-get update && sudo apt-get install …` through `bash -c`.
- Both bounding paths now route output to a **file** rather than a `$(…)` substitution. A command substitution stays blocked on EOF for as long as any descendant holds the write end — exactly the process the kill escalation is chasing — so the capture could outlive the bound protecting it. [#4232](https://github.com/kaeawc/auto-mobile/pull/4232) already did this on the watchdog path; this makes the `timeout` path consistent.
- A failed `mktemp` no longer drops the bound when a `timeout` binary exists; it drops only the capture.
- `BOUNDED_KILL_GRACE_SECONDS` (default 10) now feeds both `timeout -k` and the watchdog, so the two escalate identically and tests can exercise the escalation quickly.
- New helpers assign to globals rather than returning a status, matching the convention already documented in this file and keeping `validate_shell_sete.sh` clean without touching its baseline.

## Validation

Both reproductions rerun green against the fix: the PTY case now prints `Requesting sudo credentials before installing packages`, the prompt is visible, sudo receives the password, and the install succeeds in 1s; the watchdog case reports `OK: survivor already dead`.

- 26/26 in `test/bats/install-bounded-package-install.bats` (10 new). Verified red-before / green-after: tests 17, 18, 22 and 25 fail against `main`.
- Because this host has no coreutils, the run was repeated behind a `timeout` shim reproducing GNU semantics (`-k` parsing, `setpgid`, 124-on-expiry) so the three `require_real_timeout` tests that skip locally were actually exercised — 26/26 there too.
- The four fallback tests from [#4232](https://github.com/kaeawc/auto-mobile/pull/4232) remain ungated by `require_real_timeout`, and the six new behavioural tests are ungated as well, so all of them run on `macos-latest`.
- `shellcheck scripts/install.sh`, `./scripts/shellcheck/validate_shell_portability.sh scripts`, `./scripts/shellcheck/validate_shell_scripts.sh`, `./scripts/shellcheck/validate_shell_sete.sh`, and `bats test/bats/` all clean. Bash 3.2 compatible; no baseline files touched.

Shell-only change: no TypeScript, Kotlin, Swift, or device surface.

- [x] New code reuses existing project helpers and conventions
- [x] Rebased onto latest `main`
