### PR TITLE
fix(observe): anchor legacy task headers and source task root from Hist #0

### DIFF
--- a/src/features/observe/GetBackStack.ts
+++ b/src/features/observe/GetBackStack.ts
@@ -7,10 +7,91 @@ import type { BackStack } from "./interfaces/BackStack";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 
 /**
- * Legacy task header, printed by `TaskRecord.toString()` / the pre-Android-10
- * `dumpsys` layout: "Task id #123" or "TaskRecord{task123 #123 A=... sz=3}".
+ * Legacy task header, printed by the pre-Android-10 `dumpsys` layout as either
+ * "Task id #123" or `ActivityStack.dumpActivitiesLocked`'s `"    * " + task`,
+ * i.e. "* TaskRecord{1d3813b #14418 A=com.example U=0 StackId=436 sz=2}".
+ *
+ * Anchored to the start of the line (issue #4263). `TaskRecord{...}` is printed
+ * verbatim in at least two NON-header positions in real legacy output:
+ *
+ *     * Hist #1: ActivityRecord{...}
+ *         frontOfTask=false task=TaskRecord{1d3813b #14418 A=... sz=2}
+ *
+ *     Running activities (most recent first):
+ *       TaskRecord{1d3813b #14418 A=... sz=2}
+ *
+ * The first sits BETWEEN two `Hist` rows, so read as a header it splits one
+ * task's activities across two headers and (before #4263) blanked the affinity
+ * of every activity below it. Line-anchoring rejects it: it is always preceded
+ * by `frontOfTask=<bool> task=`.
+ *
+ * The second IS at the start of its line, only without the bullet, so anchoring
+ * alone cannot tell it apart from a real header -- and the bullet-less form is
+ * itself pinned as a header by the #4223 suite. It is instead defused in
+ * `parseTasks`, which resumes an already-seen task id rather than restarting
+ * it, so a repeat cannot discard what was already parsed.
+ *
+ * The id is taken from the token right after the identity hash rather than by
+ * the previous greedy scan, which captured the last "#number" on the line.
  */
-const LEGACY_TASK_HEADER = /Task\s+id\s+#(\d+)|TaskRecord.*#(\d+)/;
+const LEGACY_TASK_HEADER = /^\s*(?:Task\s+id\s+#(\d+)\b|\*?\s*TaskRecord\{\S+\s+#(\d+)\b(.*))$/;
+
+/**
+ * `A=` / `I=` / `aI=` out of a task-header tail. Space-anchored so "aI=" is not
+ * read as "I=" and so "visibleRequested=" and friends cannot contribute a stray
+ * key match; the value excludes "}" so a field printed last yields the bare
+ * value rather than one with the closing brace glued on.
+ */
+const HEADER_AFFINITY = /(?:^|\s)A=([^\s}]+)/;
+const HEADER_COMPONENT = /(?:^|\s)a?I=([^\s}]+)/;
+
+/**
+ * One printed activity: "* Hist  #0: ActivityRecord{2b2ce0f u0 pkg/.Cls t61}".
+ *
+ * AOSP's `ActivityRecord.toString()` always puts the user id and the component
+ * INSIDE the braces, but it does NOT agree across versions on where the task id
+ * goes. Both shapes are present in this repo's committed captures under
+ * test/features/observe/windowDumps:
+ *
+ *   API 30-32, 34-36: ActivityRecord{2b2ce0f u0 com.example/.Main t61}
+ *   API 33:           ActivityRecord{a9cf40f u0 com.example/.Main} t8}
+ *
+ * On API 33 the component is closed off by its own brace and the task id trails
+ * outside it. So the component group is bounded to exclude "}" (otherwise the
+ * API 33 shape yields a name ending in "}"), and the task id is scanned for
+ * anywhere in the tail rather than assumed to sit at a fixed offset.
+ *
+ * Other trailing tokens are tolerated deliberately: a finishing activity prints
+ * " f" and an activity with no task prints "t??". Requiring the task id to be
+ * the last token is what made the original regex drop every line, so an
+ * unrecognized tail leaves the task id to fall back to the enclosing header
+ * rather than rejecting the whole activity.
+ */
+const ACTIVITY_LINE = /Hist\s+#(\d+):\s+ActivityRecord\{\S+\s+u\d+\s+([^\s}]+)([^\n]*\})/;
+
+/** A parsed "Hist #N" row: its index within the task and its component. */
+interface HistRow {
+  /** Counts UP from the task root, so #0 is the root, not the top. */
+  histIndex: number;
+  /** Verbatim "pkg/.Cls" -- the same shape legacy `realActivity=` prints. */
+  component: string;
+  /** The row's own "tNN" token, when it carries one. */
+  taskId?: number;
+}
+
+function parseHistRow(line: string): HistRow | undefined {
+  const match = line.match(ACTIVITY_LINE);
+  if (!match) {
+    return undefined;
+  }
+  // Standalone "tNN" token in the tail, on either side of a closing brace.
+  const taskId = match[3].match(/(?:^|[\s}])t(\d+)(?=[\s}]|$)/);
+  return {
+    histIndex: parseInt(match[1], 10),
+    component: match[2],
+    taskId: taskId ? parseInt(taskId[1], 10) : undefined
+  };
+}
 
 /**
  * Modern task header (issue #4223). `TaskFragment.dumpInner` prints
@@ -59,26 +140,29 @@ interface TaskHeaderFields {
 function parseTaskHeader(line: string): TaskHeaderFields | undefined {
   const modern = line.match(MODERN_TASK_HEADER);
   if (modern) {
-    const tail = modern[2];
-    // Space-anchored so "aI=" is not read as "I=", and so "visibleRequested="
-    // and friends cannot contribute a stray key match.
-    // The value is bounded to exclude "}" so a field printed last still yields
-    // the bare value rather than one with the closing brace glued on.
-    const affinity = tail.match(/(?:^|\s)A=([^\s}]+)/);
-    const component = tail.match(/(?:^|\s)a?I=([^\s}]+)/);
-    return {
-      id: parseInt(modern[1], 10),
-      affinity: affinity ? affinity[1] : undefined,
-      component: component ? component[1] : undefined
-    };
+    return fieldsFromTail(parseInt(modern[1], 10), modern[2]);
   }
 
   const legacy = line.match(LEGACY_TASK_HEADER);
   if (legacy) {
-    return { id: parseInt(legacy[1] || legacy[2], 10) };
+    // "Task id #N" carries no fields; the "* TaskRecord{...}" form carries the
+    // same A=/I=/aI= tokens as the modern header and is read the same way.
+    return legacy[1] !== undefined
+      ? { id: parseInt(legacy[1], 10) }
+      : fieldsFromTail(parseInt(legacy[2], 10), legacy[3]);
   }
 
   return undefined;
+}
+
+function fieldsFromTail(id: number, tail: string): TaskHeaderFields {
+  const affinity = tail.match(HEADER_AFFINITY);
+  const component = tail.match(HEADER_COMPONENT);
+  return {
+    id,
+    affinity: affinity ? affinity[1] : undefined,
+    component: component ? component[1] : undefined
+  };
 }
 
 /**
@@ -126,37 +210,12 @@ export class GetBackStack implements BackStack {
         logger.debug(`[BACK_STACK] Found task affinity: ${currentTaskAffinity}`);
       }
 
-      // Match activity. AOSP's ActivityRecord.toString() always puts the user id
-      // and the component INSIDE the braces, but it does NOT agree across
-      // versions on where the task id goes. Both shapes are present in this
-      // repo's committed captures under test/features/observe/windowDumps:
-      //
-      //   API 30-32, 34-36: ActivityRecord{2b2ce0f u0 com.example/.Main t61}
-      //   API 33:           ActivityRecord{a9cf40f u0 com.example/.Main} t8}
-      //
-      // On API 33 the component is closed off by its own brace and the task id
-      // trails outside it. So the component group is bounded to exclude "}"
-      // (otherwise the API 33 shape yields a name ending in "}"), and the task
-      // id is scanned for anywhere in the tail rather than assumed to sit at a
-      // fixed offset. The "Hist #N" index counts up from the task root, so #0
-      // is the task root and the highest index is the topmost activity.
-      //
-      // Other trailing tokens are tolerated deliberately: a finishing activity
-      // prints " f" and an activity with no task prints "t??". Requiring the
-      // task id to be the last token is what made the original regex drop every
-      // line, so an unrecognized tail leaves the task id to fall back to the
-      // enclosing task header rather than rejecting the whole activity.
-      const activityMatch = line.match(
-        /Hist\s+#(\d+):\s+ActivityRecord\{\S+\s+u\d+\s+([^\s}]+)([^\n]*\})/
-      );
-      if (activityMatch) {
-        const histIndex = parseInt(activityMatch[1], 10);
-        const fullName = activityMatch[2];
-        // Standalone "tNN" token in the tail, on either side of a closing brace.
-        const taskIdMatchFromActivity = activityMatch[3].match(/(?:^|[\s}])t(\d+)(?=[\s}]|$)/);
-        const taskIdFromActivity = taskIdMatchFromActivity
-          ? parseInt(taskIdMatchFromActivity[1], 10)
-          : currentTaskId;
+      // Match activity (see ACTIVITY_LINE / parseHistRow).
+      const hist = parseHistRow(line);
+      if (hist) {
+        const histIndex = hist.histIndex;
+        const fullName = hist.component;
+        const taskIdFromActivity = hist.taskId ?? currentTaskId;
 
         // Parse package/activity name (format: "com.example/.MainActivity" or "com.example/com.example.MainActivity")
         const parts = fullName.split("/");
@@ -198,15 +257,26 @@ export class GetBackStack implements BackStack {
     // "numActivities=" line, and the header's "sz=" is getChildCount() -- child
     // *containers*, which for a non-leaf task counts child tasks rather than
     // activities. Counting the task's own "Hist #N" lines is correct for both.
-    let histCount = 0;
+    // Kept per task id, not per header line: legacy output prints two headers
+    // for the same task ("Task id #N" then "* TaskRecord{... #N ...}"), so the
+    // second must resume the first's count rather than restart it.
+    const histCounts: Map<number, number> = new Map();
+    // The component of each task's "Hist #0" row. `Hist #0` is the task root
+    // (see #4197), and its "pkg/.Cls" is the same shape legacy `realActivity=`
+    // prints. This is the ONLY package source on the modern path (issue #4263):
+    // a modern header's `A=` is `Task.affinity`, which is uid-prefixed on
+    // Android 11+, is an app-declarable string that need not name a package,
+    // and is empty for `android:taskAffinity=""`. It is applied at flush time,
+    // and only as a fallback, so `I=`/`aI=` and `realActivity=` still win.
+    const histRoots: Map<number, string> = new Map();
 
     const flush = (): void => {
       if (currentTaskId === -1 || currentTask.id === undefined) {
         return;
       }
-      if (currentTask.numActivities === undefined) {
-        currentTask.numActivities = histCount;
-      }
+      // Hist-derived fields are filled in one pass after the loop, not here: a
+      // task can be flushed and then resumed by a later header for the same id,
+      // and a value written here would be mistaken for an explicit one.
       tasks.set(currentTaskId, currentTask as TaskInfo);
     };
 
@@ -219,8 +289,12 @@ export class GetBackStack implements BackStack {
         flush();
 
         currentTaskId = header.id;
-        currentTask = { id: currentTaskId };
-        histCount = 0;
+        // Resume a task we have already seen a header for rather than starting
+        // it over. Legacy output prints "Task id #N" and "* TaskRecord{... #N}"
+        // back to back for one task, and repeats the TaskRecord line under
+        // "Running activities"; restarting there discarded everything already
+        // parsed for that task (issue #4263).
+        currentTask = tasks.get(currentTaskId) ?? { id: currentTaskId };
         if (header.affinity) {
           currentTask.affinity = header.affinity;
         }
@@ -235,8 +309,18 @@ export class GetBackStack implements BackStack {
         continue;
       }
 
-      if (HIST_LINE.test(line)) {
-        histCount++;
+      const hist = parseHistRow(line);
+      if (hist) {
+        // A row carrying its own tNN belongs to that task even when it is
+        // printed under another header.
+        const owner = hist.taskId ?? currentTaskId;
+        histCounts.set(owner, (histCounts.get(owner) ?? 0) + 1);
+        if (hist.histIndex === 0 && !histRoots.has(owner)) {
+          histRoots.set(owner, hist.component);
+        }
+      } else if (HIST_LINE.test(line)) {
+        // A Hist row in a shape parseHistRow does not recognize still counts.
+        histCounts.set(currentTaskId, (histCounts.get(currentTaskId) ?? 0) + 1);
       }
 
       // Match affinity
@@ -267,6 +351,25 @@ export class GetBackStack implements BackStack {
 
     // Save last task
     flush();
+
+    for (const task of tasks.values()) {
+      if (task.numActivities === undefined) {
+        task.numActivities = histCounts.get(task.id) ?? 0;
+      }
+      const histRoot = histRoots.get(task.id);
+      // No Hist #0 row and no I=/aI=/realActivity= means nothing in this dump
+      // identifies the task's package. Leaving both undefined is the honest
+      // answer; the affinity is not a package name and is not guessed from.
+      if (histRoot === undefined) {
+        continue;
+      }
+      if (task.rootActivity === undefined) {
+        task.rootActivity = histRoot;
+      }
+      if (task.packageName === undefined) {
+        task.packageName = histRoot.split("/")[0];
+      }
+    }
 
     return Array.from(tasks.values());
   }

--- a/test/features/observe/GetBackStackTaskAnchoring.test.ts
+++ b/test/features/observe/GetBackStackTaskAnchoring.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from "bun:test";
+import { GetBackStack } from "../../../src/features/observe/GetBackStack";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
+import { BackStackInfo, BootedDevice } from "../../../src/models";
+
+/**
+ * Task-header anchoring and root-component derivation (issue #4263,
+ * follow-up to the two P2 review findings on PR #4253).
+ *
+ * PROVENANCE. The 13 captures committed under
+ * `test/features/observe/windowDumps/` are `dumpsys window windows` output.
+ * They contain no `Task{`, no `TaskRecord`, no `Task id #`, no `Hist #N` and no
+ * `A=`/`I=`/`aI=`/`realActivity=` tokens, so they cannot exercise any of this.
+ *
+ * LEGACY_REAL_CAPTURE below is trimmed verbatim from a real
+ * `dumpsys activity activities` capture of an Android 9-era device -- the one
+ * linked from the PR #4253 review comment
+ * (gist.github.com/ganadist/0102b683fb8a873feee7f0568b9a0382). Two of its lines
+ * match the old unanchored `/TaskRecord.*#(\d+)/` without being task headers:
+ *
+ *   1. `frontOfTask=false task=TaskRecord{...}`, printed by the ACTIVITY dump
+ *      between two `Hist #N` rows.
+ *   2. the `TaskRecord{...}` line repeated under
+ *      `Running activities (most recent first):`.
+ *
+ * The genuine legacy headers are line-anchored: `Task id #N`, and the
+ * `"    * " + task` line printed by `ActivityStack.dumpActivitiesLocked`.
+ *
+ * The MODERN fixtures remain AOSP-shaped and UNVERIFIED against a real
+ * capture -- unchanged from #4253. What they pin here is only that the root
+ * component falls back to the task's own `Hist #0` row, since `A=` carries
+ * `Task.affinity` (uid-prefixed on Android 11+, app-declarable, possibly empty)
+ * and is not a package name.
+ */
+
+const device: BootedDevice = { name: "test", platform: "android", deviceId: "test-device" };
+
+async function parse(stdout: string): Promise<BackStackInfo> {
+  const adb = new FakeAdbExecutor();
+  adb.setCommandResponse("dumpsys activity activities", { stdout, stderr: "" });
+  return new GetBackStack(device, new FakeAdbClientFactory(adb)).execute();
+}
+
+// Verbatim excerpt: one two-activity task, both hazard lines present.
+const LEGACY_REAL_CAPTURE = `
+ACTIVITY MANAGER ACTIVITIES (dumpsys activity activities)
+Display #0 (activities from top to bottom):
+
+  Stack #436: type=standard mode=fullscreen
+    Task id #14418
+    mBounds=Rect(0, 0 - 0, 0)
+    * TaskRecord{1d3813b #14418 A=com.facebook.katana U=0 StackId=436 sz=2}
+      userId=0 effectiveUid=u0a161 mCallingUid=u0a161
+      affinity=com.facebook.katana
+      realActivity=com.facebook.katana/.activity.ImmersiveActivity
+      numActivities=2
+      * Hist #1: ActivityRecord{7c63edf u0 com.facebook.katana/.activity.FbMainTabActivity t14418}
+          packageName=com.facebook.katana processName=com.facebook.katana
+          frontOfTask=false task=TaskRecord{1d3813b #14418 A=com.facebook.katana U=0 StackId=436 sz=2}
+          taskAffinity=com.facebook.katana
+      * Hist #0: ActivityRecord{7f67c32 u0 com.facebook.katana/.activity.FbMainTabActivity t14418}
+          packageName=com.facebook.katana processName=com.facebook.katana
+          frontOfTask=true task=TaskRecord{1d3813b #14418 A=com.facebook.katana U=0 StackId=436 sz=2}
+          taskAffinity=com.facebook.katana
+
+    Running activities (most recent first):
+      TaskRecord{1d3813b #14418 A=com.facebook.katana U=0 StackId=436 sz=2}
+        Run #0: ActivityRecord{7c63edf u0 com.facebook.katana/.activity.FbMainTabActivity t14418}
+
+    mResumedActivity: ActivityRecord{7c63edf u0 com.facebook.katana/.activity.FbMainTabActivity t14418}
+`;
+
+describe("legacy inline TaskRecord{...} references are not task headers (#4263)", () => {
+  test("produces exactly one task, not one per inline reference", async () => {
+    const result = await parse(LEGACY_REAL_CAPTURE);
+
+    expect(result.tasks.map(t => t.id)).toEqual([14418]);
+  });
+
+  test("keeps taskAffinity on every activity in the task", async () => {
+    // The inline `task=TaskRecord{...}` sits between Hist #1 and Hist #0. Read
+    // as a header it reset the affinity to undefined, so Hist #0 lost it.
+    const result = await parse(LEGACY_REAL_CAPTURE);
+
+    expect(result.activities.map(a => a.taskAffinity)).toEqual([
+      "com.facebook.katana",
+      "com.facebook.katana"
+    ]);
+  });
+
+  test("the Running activities repeat does not blank the parsed task", async () => {
+    const result = await parse(LEGACY_REAL_CAPTURE);
+
+    expect(result.tasks[0]).toMatchObject({
+      id: 14418,
+      affinity: "com.facebook.katana",
+      packageName: "com.facebook.katana",
+      rootActivity: "com.facebook.katana/.activity.ImmersiveActivity",
+      numActivities: 2
+    });
+  });
+
+  test("counts the task's Hist rows once, not once per spurious header", async () => {
+    const result = await parse(LEGACY_REAL_CAPTURE);
+
+    expect(result.activities).toHaveLength(2);
+    expect(result.depth).toBe(1);
+  });
+
+  test("reads the id after the identity hash, not the last #number on the line", async () => {
+    // `TaskRecord.*#(\\d+)` was greedy, so a later "#N" token won the capture.
+    const result = await parse(`
+    * TaskRecord{1d3813b #14418 A=com.example U=0 StackId=436 sz=2} mLastFrame=#99
+      * Hist #0: ActivityRecord{aaa u0 com.example/.MainActivity t14418}
+`);
+
+    expect(result.tasks.map(t => t.id)).toEqual([14418]);
+  });
+
+  test("a legacy TaskRecord header carries its own A= affinity", async () => {
+    // No standalone `affinity=` line: the header token is the only source.
+    const result = await parse(`
+    * TaskRecord{1d3813b #14418 A=com.facebook.katana U=0 StackId=436 sz=2}
+      * Hist #0: ActivityRecord{aaa u0 com.facebook.katana/.Main t14418}
+`);
+
+    expect(result.tasks[0].affinity).toBe("com.facebook.katana");
+    expect(result.activities[0].taskAffinity).toBe("com.facebook.katana");
+  });
+
+  test("a legacy TaskRecord header carries its own I= component", async () => {
+    const result = await parse(`
+    * TaskRecord{a2dcbca #14243 I=com.google.android.apps.nexuslauncher/.NexusLauncherActivity U=0 StackId=0 sz=1}
+      * Hist #0: ActivityRecord{8f236c u0 com.google.android.apps.nexuslauncher/.NexusLauncherActivity t14243}
+`);
+
+    expect(result.tasks[0].rootActivity).toBe(
+      "com.google.android.apps.nexuslauncher/.NexusLauncherActivity"
+    );
+    expect(result.tasks[0].packageName).toBe("com.google.android.apps.nexuslauncher");
+  });
+});
+
+describe("modern A= tasks source their root component from Hist #0 (#4263)", () => {
+  const MODERN_AFFINITY_TASK = `
+ACTIVITY MANAGER ACTIVITIES (dumpsys activity activities)
+Display #0 (activities from top to bottom):
+  * Task{d19dee2 #61 type=standard A=10164:com.example U=0 visible=true mode=fullscreen sz=2}
+    * Hist  #1: ActivityRecord{2b2ce0f u0 com.example/.DetailActivity t61}
+        packageName=com.example processName=com.example
+    * Hist  #0: ActivityRecord{7ff01aa u0 com.example/com.example.MainActivity t61}
+        packageName=com.example processName=com.example
+`;
+
+  test("packageName and rootActivity come from the Hist #0 row", async () => {
+    const result = await parse(MODERN_AFFINITY_TASK);
+
+    expect(result.tasks[0].packageName).toBe("com.example");
+    expect(result.tasks[0].rootActivity).toBe("com.example/com.example.MainActivity");
+  });
+
+  test("affinity is still the verbatim, uid-prefixed A= value", async () => {
+    // A= is Task.affinity, NOT a package name: it keeps the uid prefix, and an
+    // app can declare any string. It is never used to derive packageName.
+    const result = await parse(MODERN_AFFINITY_TASK);
+
+    expect(result.tasks[0].affinity).toBe("10164:com.example");
+  });
+
+  test("Hist #0 does not override an I= header component", async () => {
+    // I= is the task's own intent component and outranks the printed root
+    // activity, which may be an origActivity/alias target.
+    const result = await parse(`
+  * Task{9c31af0 #1 type=home I=com.android.launcher3/.Launcher U=0 mode=fullscreen sz=1}
+    * Hist  #0: ActivityRecord{3177c30 u0 com.android.launcher3/.OtherEntry t1}
+`);
+
+    expect(result.tasks[0].rootActivity).toBe("com.android.launcher3/.Launcher");
+    expect(result.tasks[0].packageName).toBe("com.android.launcher3");
+  });
+
+  test("Hist #0 does not override a legacy realActivity= line", async () => {
+    // The real capture's task 14414 has origActivity=InitActivity as Hist #0
+    // while realActivity= is MainActivity; realActivity is the correct root.
+    const result = await parse(`
+    Task id #14414
+    * TaskRecord{b957b35 #14414 A=com.google.android.apps.inbox U=0 StackId=432 sz=1}
+      realActivity=com.google.android.apps.inbox/com.google.android.apps.bigtop.activities.MainActivity
+      * Hist #0: ActivityRecord{9f42109 u0 com.google.android.apps.inbox/com.google.android.apps.bigtop.activities.InitActivity t14414}
+`);
+
+    expect(result.tasks[0].rootActivity).toBe(
+      "com.google.android.apps.inbox/com.google.android.apps.bigtop.activities.MainActivity"
+    );
+  });
+
+  test("a task with no printed Hist #0 leaves packageName/rootActivity undefined", async () => {
+    // Nothing on the modern path identifies the package otherwise: A= is an
+    // affinity string, not a package. Undefined is the honest answer.
+    const result = await parse(`
+  * Task{d19dee2 #61 type=standard A=10164:com.example U=0 mode=fullscreen sz=1}
+    * Hist  #3: ActivityRecord{2b2ce0f u0 com.example/.DetailActivity t61}
+`);
+
+    expect(result.tasks[0].id).toBe(61);
+    expect(result.tasks[0].packageName).toBeUndefined();
+    expect(result.tasks[0].rootActivity).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes [#4263](https://github.com/kaeawc/auto-mobile/issues/4263).

Follow-up to [PR #4253](https://github.com/kaeawc/auto-mobile/pull/4253), addressing the two P2 review findings left unresolved there. Both are in `src/features/observe/GetBackStack.ts`.

## Provenance, stated up front

This parser has been wrong three times, each time by being too tight or too loose about brace/token shapes, so it is worth being explicit about what is evidence and what is not.

The 13 committed captures under `test/features/observe/windowDumps/` are `dumpsys window windows` output. Grep says they contain zero `Task{`, zero `TaskRecord`, zero `Task id #`, zero `Hist #N` and zero `A=`/`I=`/`aI=`/`realActivity=` tokens. They cannot exercise task-header parsing at all. They remain the ground truth for the `ActivityRecord{...}` shapes (including the API 33 early-brace form), and that regex is unchanged here.

The legacy shapes fixed below come from a real `dumpsys activity activities` capture of an Android 9-era device - the one linked from the review comment (`gist.github.com/ganadist/0102b683fb8a873feee7f0568b9a0382`). The relevant excerpt is committed verbatim as `LEGACY_REAL_CAPTURE` in the new test file.

The modern `Task{...}` shapes are still AOSP-sourced and **unverified against any real capture**. That is unchanged from #4253 and this PR does not fix it.

## Finding 1 - inline `TaskRecord{...}` refs read as task headers

`LEGACY_TASK_HEADER` was `/Task\s+id\s+#(\d+)|TaskRecord.*#(\d+)/`, unanchored. Two non-header lines in the real capture match it:

```
      * Hist #1: ActivityRecord{7c63edf u0 com.facebook.katana/.activity.FbMainTabActivity t14418}
          frontOfTask=false task=TaskRecord{1d3813b #14418 A=com.facebook.katana U=0 StackId=436 sz=2}
      * Hist #0: ActivityRecord{7f67c32 u0 com.facebook.katana/.activity.FbMainTabActivity t14418}

    Running activities (most recent first):
      TaskRecord{1d3813b #14418 A=com.facebook.katana U=0 StackId=436 sz=2}
```

Observed against unfixed code:

- `parseActivities` - the `frontOfTask=` line sits between `Hist #1` and `Hist #0`, and #4253's `currentTaskAffinity = header.affinity` reset assigns `undefined` because legacy headers carry no affinity. `Hist #1` keeps `taskAffinity`, `Hist #0` comes back `undefined`.
- `parseTasks` - the `Running activities` repeat calls `flush()` and then replaces `currentTask` with a bare `{ id }`, so the finished task is **overwritten by an empty one**, losing `affinity`, `packageName`, `rootActivity` and `numActivities`.
- `TaskRecord.*#(\d+)` is greedy, so it captured the last `#`-number on the line rather than the task id.

Fixes:

- The regex is line-anchored and reads the id from the token right after the identity hash. That alone rejects the `frontOfTask=... task=` ref, which is never at line start.
- The `Running activities` repeat **is** at line start, differing only by the missing `* ` bullet - and the bullet-less form is itself pinned as a valid header by the committed #4223 suite (`GetBackStackTaskHeader.test.ts:178`). So the bullet stays optional and the repeat is defused differently: `parseTasks` now *resumes* an already-seen task id instead of restarting it. That also fixes the legacy `Task id #N` / `* TaskRecord{... #N}` pair, which prints two headers for one task.
- Because a task can now be flushed and resumed, `numActivities` and the hist-derived root are filled in a single pass after the loop rather than at flush time, so a resumed task is not mistaken for one with explicit values.
- A legacy `TaskRecord{...}` header now reads its own `A=`/`I=`/`aI=` tokens through the same helper as the modern header - the real capture carries them, and this is the second half of the reviewer's suggestion.

## Finding 2 - modern `A=` tasks had no `packageName`/`rootActivity`

**`packageName` is not derivable from `A=`.** `A=` is `Task.affinity`, which is uid-prefixed on Android 11+ (`10164:com.example`, per `ActivityRecord.computeTaskAffinity`), is an app-declarable `android:taskAffinity` string that need not name a package, and is empty for `android:taskAffinity=""`. Stripping a `uid:` prefix off it would be a guess dressed up as a derivation, so this PR does not do that. `affinity` keeps the verbatim value, uid prefix included.

The honest source is the task's own activity rows, which the modern path does print, and which the reviewer pointed at:

```
    * Hist  #0: ActivityRecord{7ff01aa u0 com.example/com.example.MainActivity t61}
```

`Hist #0` is the task root (pinned by #4197) and its component has the same `pkg/.Cls` shape legacy `realActivity=` prints. It is applied as a **fallback only**, so `I=`/`aI=` and a legacy `realActivity=` line still win - which matters, because the real capture's task 14414 prints `origActivity=InitActivity` as `Hist #0` while `realActivity=` is `MainActivity`.

A task with no printed `Hist #0` row keeps `packageName`/`rootActivity` undefined. Nothing else in this dump identifies its package; that is documented in code rather than guessed at, and is pinned by a test.

The `Hist` row regex was extracted to a shared `parseHistRow` so `parseActivities` and `parseTasks` cannot drift apart on the shape - it is the exact regex from #4253, unchanged.

## Testing

New `test/features/observe/GetBackStackTaskAnchoring.test.ts`, 12 tests.

Red-before / green-after, verified by checking out `origin/main`'s `GetBackStack.ts` under the new tests:

- red: 6 pass / 6 fail. The Finding 1 failure is exactly the reviewer's prediction - `["com.facebook.katana", undefined]` where both should be `com.facebook.katana`. The Finding 2 failure is `packageName` / `rootActivity` undefined for the modern `A=` task.
- green with the fix: 44 pass / 0 fail across all four `GetBackStack*` suites, i.e. every #4197 / #4222 / #4223 behaviour still holds.

Full local gates: `bun test` 8726 pass / 0 fail, `bun run typecheck` clean (214 baseline errors, none new), `bun run lint` clean. No baselines touched. No device interaction - committed fixtures only.

## Acceptance criteria

All seven from #4263 are satisfied and each has a test.
