### PR TITLE
fix(ios): fail closed on an unusable CtrlProxy runner override

### DIFF
--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -10,6 +10,7 @@ import { DEVICE_IMAGE_RESOURCE_URIS, notifyDeviceImageResourcesUpdated } from ".
 import { syncInstalledAppResources } from "./appResources";
 import { listActiveVideoRecordings, stopVideoRecording } from "./videoRecordingManager";
 import { IOSCtrlProxyManager } from "../utils/IOSCtrlProxyManager";
+import { checkIosCtrlProxyOverride } from "../utils/iosCtrlProxyOverride";
 import { IOSCtrlProxyClient } from "../features/observe/ios";
 import { logger } from "../utils/logger";
 import { createPerformanceTracker } from "../utils/PerformanceTracker";
@@ -238,6 +239,19 @@ export function registerDeviceTools() {
   ) {
     if (device.platform !== "ios") {
       return;
+    }
+
+    // Fail closed on an unusable runner override before any warm-path return.
+    // startDevice has its own enforcement here, and it returns early when the
+    // CtrlProxy client is already connected -- skipping the builder that would
+    // validate the override -- so a directory- or typo-valued
+    // AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH would otherwise silently reuse the
+    // cached released runner (#4221).
+    const iosOverride = await checkIosCtrlProxyOverride();
+    if (iosOverride.present && !iosOverride.usable) {
+      throw new ActionableError(
+        `AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH / _IPA_PATH is set but unusable: ${iosOverride.reason}`
+      );
     }
 
     perf.startOperation("ensureCtrlProxy");

--- a/src/server/networkTools.ts
+++ b/src/server/networkTools.ts
@@ -7,6 +7,7 @@ import { buildNetworkMockRules } from "./networkMockRules";
 import { getNetworkEvents } from "../db/networkEventRepository";
 import { buildNetworkGraph } from "./networkGraph";
 import { serverConfig } from "../utils/ServerConfig";
+import { isIosCtrlProxyOverrideUsableSync } from "../utils/iosCtrlProxyOverride";
 import { ActionableError } from "../models";
 import { defaultTimer } from "../utils/SystemTimer";
 import { AndroidCtrlProxyClient } from "../features/observe/android";
@@ -142,12 +143,11 @@ function compareDottedVersion(a: string, b: string): number {
 }
 
 function hasIosCtrlProxyRunnerOverride(env: NodeJS.ProcessEnv = process.env): boolean {
-  const ipaPath = env.AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH?.trim();
-  const bundlePath = env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH?.trim();
-  return (
-    (ipaPath !== undefined && ipaPath.length > 0) ||
-    (bundlePath !== undefined && bundlePath.length > 0)
-  );
+  // A non-empty string is not enough: a directory or a missing path resolves to
+  // no runnable artifact, so treating it as "capability present" made mockNetwork
+  // bypass its min-release gate on the strength of a value that never loads
+  // (#4221). Require the override to resolve to a real .ipa file.
+  return isIosCtrlProxyOverrideUsableSync(env);
 }
 
 export function isIosNetworkErrorSimulationAvailable(

--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -22,6 +22,7 @@ import { createPerformanceTracker, createGlobalPerformanceTracker } from "./Perf
 import { storeSetupTiming } from "../server/ToolExecutionContext";
 import { applyAppearanceOnConnect } from "./appearance/applyAppearanceOnConnect";
 import { disableStylusHandwriting } from "./disableStylusHandwriting";
+import { checkIosCtrlProxyOverride } from "./iosCtrlProxyOverride";
 
 /**
  * Render a device list for a "not found" error.
@@ -654,6 +655,20 @@ export class DeviceSessionManager implements DeviceSessionManager {
    * Verify an iOS device is connected and ready
    */
   public async verifyIosDevice(deviceId: string, options?: DeviceReadyOptions): Promise<void> {
+    // An explicit runner override that cannot be used must fail closed before any
+    // other path, whatever the simulator/runner state. Every downstream branch
+    // (already-connected, already-running, cached-start) skips the builder that
+    // would validate it, so otherwise a directory- or typo-valued
+    // AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH would silently run the cached released
+    // runner and the caller would attribute results to a local build that never
+    // loaded (#4221).
+    const iosOverride = await checkIosCtrlProxyOverride();
+    if (iosOverride.present && !iosOverride.usable) {
+      throw new ActionableError(
+        `AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH / _IPA_PATH is set but unusable: ${iosOverride.reason}`
+      );
+    }
+
     if (!this.simctl) {
       throw new ActionableError("iOS simulator tools not available");
     }

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -4,6 +4,8 @@ import { requireBootedDevice } from "./requireBootedDevice";
 import { NoOpPerformanceTracker, createGlobalPerformanceTracker, type PerformanceTracker } from "./PerformanceTracker";
 import { Timer, defaultTimer } from "./SystemTimer";
 import { IOSCtrlProxyBuilder, type CtrlProxyIosBuildResult } from "./IOSCtrlProxyBuilder";
+import { checkIosCtrlProxyOverride } from "./iosCtrlProxyOverride";
+import { ActionableError } from "../models/ActionableError";
 import { resolvePinnedVersion } from "../constants/release";
 import { type ChildProcess } from "child_process";
 import { IOS_CTRL_PROXY_RESERVED_PORTS, PortManager } from "./PortManager";
@@ -599,6 +601,18 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    * Internal start implementation (called within mutex)
    */
   private async startInternal(): Promise<void> {
+    // Authoritative fail-closed gate (#4221): this is the single chokepoint every
+    // launch path funnels through (startDevice, session-reuse in toolRegistry, and
+    // discovery-pooled devices that never hit verifyIosDevice/ensureCtrlProxyReady).
+    // If a local runner override is set but unusable, refuse to start rather than
+    // silently launching the released runner and driving the device with it.
+    const iosOverride = await checkIosCtrlProxyOverride();
+    if (iosOverride.present && !iosOverride.usable) {
+      throw new ActionableError(
+        `AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH / _IPA_PATH is set but unusable: ${iosOverride.reason}`
+      );
+    }
+
     logger.info("[IOSCtrlProxy] Starting CtrlProxy");
     this.isStopping = false;
     const perf = createGlobalPerformanceTracker();

--- a/src/utils/iosCtrlProxyOverride.ts
+++ b/src/utils/iosCtrlProxyOverride.ts
@@ -1,4 +1,4 @@
-import { promises as fs, statSync } from "fs";
+import { promises as fs, statSync, openSync, readSync, closeSync } from "fs";
 import { resolvePathFromDaemonLaunchWorkingDirectory } from "./workingDirectory";
 import { logger } from "./logger";
 
@@ -32,6 +32,44 @@ export function getIosCtrlProxyOverridePath(env: NodeJS.ProcessEnv = process.env
   return raw === null ? null : resolvePathFromDaemonLaunchWorkingDirectory(raw);
 }
 
+/**
+ * An IPA is a zip archive, and a real CtrlProxy bundle is well over this size.
+ * Requiring both rejects a path that exists but cannot be a runner bundle -- a
+ * text file like /etc/hosts, a stale .xctestrun, or a tiny fixture -- which
+ * otherwise reported `usable: true` and let the capability guard open on a value
+ * that never loads (#4221 review). Mirrors IOSCtrlProxyBuilder's own
+ * MIN_BUNDLE_SIZE_BYTES / verifyBundle checks.
+ */
+const MIN_BUNDLE_SIZE_BYTES = 10_000;
+const ZIP_MAGIC = Buffer.from([0x50, 0x4b]); // "PK", the start of every zip/ipa
+
+function hasZipMagic(path: string): boolean {
+  let fd: number | undefined;
+  try {
+    fd = openSync(path, "r");
+    const head = Buffer.alloc(2);
+    const bytes = readSync(fd, head, 0, 2, 0);
+    return bytes === 2 && head.equals(ZIP_MAGIC);
+  } catch (error) {
+    // Unreadable file is simply not a usable bundle; a debug trace suffices.
+    logger.debug(`[iosCtrlProxyOverride] could not read magic bytes of ${path}: ${error}`);
+    return false;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch (closeError) {
+        logger.debug(`[iosCtrlProxyOverride] fd close failed for ${path}: ${closeError}`);
+      }
+    }
+  }
+}
+
+/** True when the file at `path` looks like a runnable .ipa (zip, non-trivial). */
+function looksLikeRunnerBundle(path: string, sizeBytes: number): boolean {
+  return sizeBytes >= MIN_BUNDLE_SIZE_BYTES && hasZipMagic(path);
+}
+
 export interface IosCtrlProxyOverrideCheck {
   /** True when an override env var is set at all. */
   present: boolean;
@@ -61,16 +99,26 @@ export async function checkIosCtrlProxyOverride(
 
   try {
     const stats = await fs.stat(path);
-    if (stats.isFile()) {
-      return { present: true, usable: true, path };
+    if (!stats.isFile()) {
+      return {
+        present: true,
+        usable: false,
+        path,
+        reason: `expected an .ipa file but ${path} is a directory. For a local xcodebuild `
+          + `output, set AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA to the derived-data root instead.`
+      };
     }
-    return {
-      present: true,
-      usable: false,
-      path,
-      reason: `expected an .ipa file but ${path} is a directory. For a local xcodebuild `
-        + `output, set AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA to the derived-data root instead.`
-    };
+    if (!looksLikeRunnerBundle(path, stats.size)) {
+      return {
+        present: true,
+        usable: false,
+        path,
+        reason: `${path} is not a runnable .ipa bundle (a packaged CtrlProxy runner is a `
+          + `zip archive over ${MIN_BUNDLE_SIZE_BYTES} bytes). For a local xcodebuild output, `
+          + `set AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA to the derived-data root instead.`
+      };
+    }
+    return { present: true, usable: true, path };
   } catch (error) {
     // A missing path is the expected "override set but unusable" case, not a
     // failure of this check; log at debug so there is a trace without noise.
@@ -95,7 +143,8 @@ export function isIosCtrlProxyOverrideUsableSync(env: NodeJS.ProcessEnv = proces
     return false;
   }
   try {
-    return statSync(path).isFile();
+    const stats = statSync(path);
+    return stats.isFile() && looksLikeRunnerBundle(path, stats.size);
   } catch (error) {
     // Missing/unstatable path is simply "not usable"; a debug trace suffices.
     logger.debug(`[iosCtrlProxyOverride] override path not statable (sync): ${path} (${error})`);

--- a/src/utils/iosCtrlProxyOverride.ts
+++ b/src/utils/iosCtrlProxyOverride.ts
@@ -1,0 +1,104 @@
+import { promises as fs, statSync } from "fs";
+import { resolvePathFromDaemonLaunchWorkingDirectory } from "./workingDirectory";
+import { logger } from "./logger";
+
+/**
+ * Reader for the local iOS CtrlProxy runner override
+ * (AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH / AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH).
+ *
+ * Both are aliases for a packaged `.ipa` file; IPA_PATH wins when both are set.
+ * Centralised here because three call sites read these vars with subtly
+ * different logic, and #4221 needs one consistent answer to "is this override
+ * present, and is it actually usable?".
+ */
+
+/** The raw override string as set, IPA_PATH preferred, trimmed; null if unset. */
+export function getIosCtrlProxyOverrideRaw(env: NodeJS.ProcessEnv = process.env): string | null {
+  const ipaPath = env.AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH?.trim();
+  const bundlePath = env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH?.trim();
+  const value = (ipaPath && ipaPath.length > 0 ? ipaPath : undefined)
+    ?? (bundlePath && bundlePath.length > 0 ? bundlePath : undefined);
+  return value ?? null;
+}
+
+/** True when either override env var is set to a non-empty value. */
+export function hasIosCtrlProxyOverride(env: NodeJS.ProcessEnv = process.env): boolean {
+  return getIosCtrlProxyOverrideRaw(env) !== null;
+}
+
+/** The override resolved against the daemon launch cwd; null if unset. */
+export function getIosCtrlProxyOverridePath(env: NodeJS.ProcessEnv = process.env): string | null {
+  const raw = getIosCtrlProxyOverrideRaw(env);
+  return raw === null ? null : resolvePathFromDaemonLaunchWorkingDirectory(raw);
+}
+
+export interface IosCtrlProxyOverrideCheck {
+  /** True when an override env var is set at all. */
+  present: boolean;
+  /** True when it resolves to a real file (the packaged .ipa the loader needs). */
+  usable: boolean;
+  /** The resolved path, or null when no override is set. */
+  path: string | null;
+  /** A human-readable reason when present but not usable. */
+  reason?: string;
+}
+
+/**
+ * Resolve and validate the override.
+ *
+ * `usable` is true only when the override points at a real file. A directory
+ * (the common mistake -- pointing at a local `Build/Products` derived-data tree)
+ * is `present: true, usable: false`, so callers can fail closed with an
+ * actionable message instead of silently running the released runner (#4221).
+ */
+export async function checkIosCtrlProxyOverride(
+  env: NodeJS.ProcessEnv = process.env
+): Promise<IosCtrlProxyOverrideCheck> {
+  const path = getIosCtrlProxyOverridePath(env);
+  if (path === null) {
+    return { present: false, usable: false, path: null };
+  }
+
+  try {
+    const stats = await fs.stat(path);
+    if (stats.isFile()) {
+      return { present: true, usable: true, path };
+    }
+    return {
+      present: true,
+      usable: false,
+      path,
+      reason: `expected an .ipa file but ${path} is a directory. For a local xcodebuild `
+        + `output, set AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA to the derived-data root instead.`
+    };
+  } catch (error) {
+    // A missing path is the expected "override set but unusable" case, not a
+    // failure of this check; log at debug so there is a trace without noise.
+    logger.debug(`[iosCtrlProxyOverride] override path not statable: ${path} (${error})`);
+    return {
+      present: true,
+      usable: false,
+      path,
+      reason: `path does not exist: ${path}`
+    };
+  }
+}
+
+/**
+ * Synchronous "is the override usable?" for callers on a sync path (the network
+ * error-simulation capability guard). Same file-vs-directory rule as
+ * {@link checkIosCtrlProxyOverride}.
+ */
+export function isIosCtrlProxyOverrideUsableSync(env: NodeJS.ProcessEnv = process.env): boolean {
+  const path = getIosCtrlProxyOverridePath(env);
+  if (path === null) {
+    return false;
+  }
+  try {
+    return statSync(path).isFile();
+  } catch (error) {
+    // Missing/unstatable path is simply "not usable"; a debug trace suffices.
+    logger.debug(`[iosCtrlProxyOverride] override path not statable (sync): ${path} (${error})`);
+    return false;
+  }
+}

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -9,6 +9,7 @@ import { SessionManager } from "../../src/daemon/sessionManager";
 import { DevicePool } from "../../src/daemon/devicePool";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { DEFAULT_DEVICE_READY_TIMEOUT_MS } from "../../src/utils/deviceUtils";
+import * as os from "os";
 
 const AUTOLOCK_ENV_KEYS = [
   "AUTOMOBILE_DEVICE_POOL_AUTOLOCK",
@@ -98,6 +99,36 @@ describe("startDevice handler", () => {
     expect(result.osVersion).toBe("14");
     expect(result.sessionId).toBeDefined();
     expect(typeof result.sessionId).toBe("string");
+  });
+
+  it("fails closed on an unusable iOS runner override, before touching the cached runner (#4221)", async () => {
+    // Use the DEFAULT ensureCtrlProxyReady (not the beforeEach stub) so the real
+    // fail-closed check runs. It sits at the top of that function, before any
+    // manager access, so a directory-valued override rejects without booting a
+    // real CtrlProxy.
+    resetDeviceToolsDependencies();
+    setDeviceToolsDependencies({
+      deviceManagerFactory: () => fakeDeviceUtils,
+      deviceMatcherFactory: () => fakeMatcher,
+      notifyResourcesChanged: async () => {},
+      // deliberately no ensureCtrlProxyReady -> default closure with the check
+    });
+    registerDeviceTools();
+
+    fakeDeviceUtils.setBootedDevices("ios", [iosDevice]);
+    fakeMatcher.setBootedResult(iosDevice);
+
+    const original = process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH;
+    process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH = os.tmpdir(); // a directory
+    try {
+      await expect(callStartDevice({ platform: "ios" })).rejects.toThrow(/BUNDLE_PATH.*unusable|directory|runnable .ipa/);
+    } finally {
+      if (original === undefined) {
+        delete process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH;
+      } else {
+        process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH = original;
+      }
+    }
   });
 
   it("waits for readiness before returning a matched booted device", async () => {

--- a/test/server/networkTools.test.ts
+++ b/test/server/networkTools.test.ts
@@ -9,6 +9,9 @@ import {
 } from "../../src/server/networkTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import { serverConfig } from "../../src/utils/ServerConfig";
+import { promises as fs } from "fs";
+import * as path from "path";
+import * as os from "os";
 
 function parseToolJson(response: any): any {
   return JSON.parse(response.content[0].text);
@@ -69,13 +72,17 @@ describe("network tool schema", () => {
     registerNetworkTools();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     ToolRegistry.clearTools();
     NetworkState.resetInstance();
     serverConfig.setEmbeddedSdkEnabled(false);
     serverConfig.setNetworkMockableEnabled(false);
     iosGetInstanceSpy.mockRestore();
     androidGetInstanceSpy.mockRestore();
+    if (localRunnerIpa) {
+      await fs.rm(path.dirname(localRunnerIpa), { recursive: true, force: true }).catch(() => undefined);
+      localRunnerIpa = undefined;
+    }
     restoreEnv("AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH", originalIosBundlePath);
     restoreEnv("AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH", originalIosIpaPath);
     restoreEnv("AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD", originalSkipDownload);
@@ -89,8 +96,16 @@ describe("network tool schema", () => {
     process.env[key] = value;
   }
 
-  function allowLocalIosRunner(): void {
-    process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH = "/tmp/CtrlProxyUITests-Runner.app";
+  let localRunnerIpa: string | undefined;
+
+  // Point the override at a REAL .ipa file. hasIosCtrlProxyRunnerOverride now
+  // validates that the override resolves to a file (#4221), so a bare
+  // non-existent path no longer counts as an available local runner.
+  async function allowLocalIosRunner(): Promise<void> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "nettools-local-runner-"));
+    localRunnerIpa = path.join(dir, "CtrlProxyUITests-Runner.ipa");
+    await fs.writeFile(localRunnerIpa, "x");
+    process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH = localRunnerIpa;
   }
 
   test("requires durationSeconds when starting error simulation", () => {
@@ -120,7 +135,7 @@ describe("network tool schema", () => {
   });
 
   test("network simulateErrors syncs iOS error simulation through IOSCtrlProxyClient", async () => {
-    allowLocalIosRunner();
+    await allowLocalIosRunner();
     const tool = ToolRegistry.getTool("network");
 
     const response = await tool!.deviceAwareHandler!(iosDevice, {
@@ -148,7 +163,7 @@ describe("network tool schema", () => {
   });
 
   test("network simulateErrors rounds fractional iOS expiry before syncing", async () => {
-    allowLocalIosRunner();
+    await allowLocalIosRunner();
     const state = NetworkState.getInstance();
     const nowSpy = spyOn(state.timer, "now").mockReturnValue(1_000);
     const tool = ToolRegistry.getTool("network");
@@ -179,7 +194,7 @@ describe("network tool schema", () => {
   });
 
   test("network simulateErrors on iOS reuses device expiry for local state", async () => {
-    allowLocalIosRunner();
+    await allowLocalIosRunner();
     let nowMs = 1_000;
     const state = NetworkState.getInstance();
     const nowSpy = spyOn(state.timer, "now").mockImplementation(() => nowMs);
@@ -211,7 +226,7 @@ describe("network tool schema", () => {
   });
 
   test("network simulateErrors cancel clears iOS error simulation on device", async () => {
-    allowLocalIosRunner();
+    await allowLocalIosRunner();
     const tool = ToolRegistry.getTool("network");
 
     await tool!.deviceAwareHandler!(iosDevice, {
@@ -239,7 +254,7 @@ describe("network tool schema", () => {
   });
 
   test("network simulateErrors cancel clears local iOS state when device sync fails", async () => {
-    allowLocalIosRunner();
+    await allowLocalIosRunner();
     const tool = ToolRegistry.getTool("network");
 
     await tool!.deviceAwareHandler!(iosDevice, {
@@ -272,7 +287,7 @@ describe("network tool schema", () => {
   });
 
   test("network simulateErrors on iOS fails closed when CtrlProxy rejects the command", async () => {
-    allowLocalIosRunner();
+    await allowLocalIosRunner();
     iosGetInstanceSpy.mockRestore();
     iosGetInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
       setNetworkErrorSimulation: async () => ({
@@ -371,6 +386,32 @@ describe("network tool schema", () => {
       ipaSha256: "ipa",
       runnerSha256: "runner",
     }])).toBe(true);
+  });
+
+  test("an unusable override does not open the gate when the released runner is too old (#4221)", () => {
+    // Below-min registry forces the version gate closed, so only a usable
+    // override could open it. A directory or missing path must not.
+    const oldRegistry = [{ version: "0.0.40", apkSha256: "a", ipaSha256: "i", runnerSha256: "r" }];
+
+    expect(isIosNetworkErrorSimulationAvailable(
+      { AUTOMOBILE_VERSION: "0.0.40", AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH: "/no/such/runner.ipa" },
+      oldRegistry
+    )).toBe(false);
+  });
+
+  test("a usable .ipa override opens the gate even when the released runner is too old (#4221)", async () => {
+    const overrideDir = await fs.mkdtemp(path.join(os.tmpdir(), "nettools-override-"));
+    const ipa = path.join(overrideDir, "runner.ipa");
+    await fs.writeFile(ipa, "x");
+    try {
+      const oldRegistry = [{ version: "0.0.40", apkSha256: "a", ipaSha256: "i", runnerSha256: "r" }];
+      expect(isIosNetworkErrorSimulationAvailable(
+        { AUTOMOBILE_VERSION: "0.0.40", AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH: ipa },
+        oldRegistry
+      )).toBe(true);
+    } finally {
+      await fs.rm(overrideDir, { recursive: true, force: true });
+    }
   });
 
   test("network simulateErrors still syncs Android through AndroidCtrlProxyClient", async () => {

--- a/test/server/networkTools.test.ts
+++ b/test/server/networkTools.test.ts
@@ -13,6 +13,12 @@ import { promises as fs } from "fs";
 import * as path from "path";
 import * as os from "os";
 
+function ipaBytes(): Buffer {
+  // A real CtrlProxy .ipa is a zip over 10KB; the override guard validates
+  // magic + size (#4221 review), so fixtures cannot be one byte.
+  return Buffer.concat([Buffer.from([0x50, 0x4b, 0x03, 0x04]), Buffer.alloc(11_000)]);
+}
+
 function parseToolJson(response: any): any {
   return JSON.parse(response.content[0].text);
 }
@@ -104,7 +110,7 @@ describe("network tool schema", () => {
   async function allowLocalIosRunner(): Promise<void> {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "nettools-local-runner-"));
     localRunnerIpa = path.join(dir, "CtrlProxyUITests-Runner.ipa");
-    await fs.writeFile(localRunnerIpa, "x");
+    await fs.writeFile(localRunnerIpa, ipaBytes());
     process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH = localRunnerIpa;
   }
 
@@ -402,7 +408,7 @@ describe("network tool schema", () => {
   test("a usable .ipa override opens the gate even when the released runner is too old (#4221)", async () => {
     const overrideDir = await fs.mkdtemp(path.join(os.tmpdir(), "nettools-override-"));
     const ipa = path.join(overrideDir, "runner.ipa");
-    await fs.writeFile(ipa, "x");
+    await fs.writeFile(ipa, ipaBytes());
     try {
       const oldRegistry = [{ version: "0.0.40", apkSha256: "a", ipaSha256: "i", runnerSha256: "r" }];
       expect(isIosNetworkErrorSimulationAvailable(

--- a/test/utils/DeviceSessionManager.test.ts
+++ b/test/utils/DeviceSessionManager.test.ts
@@ -24,6 +24,12 @@ import * as os from "os";
 // exercises — the Android fake lacks per-call `waitForConnection` /
 // `verifyServiceReady` toggles needed to cover the cache-stale and
 // "connected but not responsive" branches independently.
+function ipaBytes(): Buffer {
+  // A real CtrlProxy .ipa is a zip over 10KB; the override guard validates
+  // magic + size (#4221 review), so a usable-override fixture must be genuine.
+  return Buffer.concat([Buffer.from([0x50, 0x4b, 0x03, 0x04]), Buffer.alloc(11_000)]);
+}
+
 function stubAndroidCtrlProxy(overrides: Partial<AndroidCtrlProxy>): AndroidCtrlProxy {
   return overrides as unknown as AndroidCtrlProxy;
 }
@@ -614,7 +620,7 @@ describe("DeviceSessionManager dual-platform resolution", () => {
     const original = process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH;
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "dsm-override-"));
     const ipa = path.join(dir, "runner.ipa");
-    await fs.writeFile(ipa, "x");
+    await fs.writeFile(ipa, ipaBytes());
     process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH = ipa;
     try {
       const manager = DeviceSessionManager.createInstance(buildProvider(), fakeAdbFactory);

--- a/test/utils/DeviceSessionManager.test.ts
+++ b/test/utils/DeviceSessionManager.test.ts
@@ -16,6 +16,9 @@ import { serverConfig } from "../../src/utils/ServerConfig";
 import type { AdbClientFactory } from "../../src/utils/android-cmdline-tools/AdbClientFactory";
 import type { AndroidCtrlProxy } from "../../src/features/observe/android/AndroidCtrlProxyClient";
 import type { IOSCtrlProxy } from "../../src/features/observe/ios/IOSCtrlProxyClient";
+import { promises as fs } from "fs";
+import * as path from "path";
+import * as os from "os";
 
 // Inline minimal AndroidCtrlProxy where each test sets only the methods it
 // exercises — the Android fake lacks per-call `waitForConnection` /
@@ -585,6 +588,46 @@ describe("DeviceSessionManager dual-platform resolution", () => {
     await expect(
       manager.ensureDeviceReady("either")
     ).rejects.toThrow("Both Android and iOS devices are connected");
+  });
+
+  test("fails closed when an unusable iOS runner override is set (#4221)", async () => {
+    // A directory-valued AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH cannot load, and
+    // the cached-start path skips the builder that would validate it. The
+    // override must fail closed rather than silently run the cached runner.
+    const original = process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH;
+    process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH = os.tmpdir(); // a directory
+    try {
+      const manager = DeviceSessionManager.createInstance(buildProvider(), fakeAdbFactory);
+      await expect(
+        manager.verifyIosDevice(iosDevice.deviceId, { skipCtrlProxyDownload: true })
+      ).rejects.toThrow(/BUNDLE_PATH.*unusable|directory/);
+    } finally {
+      if (original === undefined) {
+        delete process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH;
+      } else {
+        process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH = original;
+      }
+    }
+  });
+
+  test("does not fail closed when a usable .ipa override is set (#4221)", async () => {
+    const original = process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH;
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "dsm-override-"));
+    const ipa = path.join(dir, "runner.ipa");
+    await fs.writeFile(ipa, "x");
+    process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH = ipa;
+    try {
+      const manager = DeviceSessionManager.createInstance(buildProvider(), fakeAdbFactory);
+      const result = await manager.ensureDeviceReady("ios", iosDevice.deviceId, { skipCtrlProxyDownload: true });
+      expect(result.platform).toBe("ios");
+    } finally {
+      if (original === undefined) {
+        delete process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH;
+      } else {
+        process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH = original;
+      }
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
   });
 
   test("should resolve to ios when setActiveDevice was called with ios", async () => {

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -218,6 +218,28 @@ describe("IOSCtrlProxyManager", function() {
     });
   });
 
+  describe("start fail-closed on unusable runner override (#4221)", function() {
+    test("start() rejects before any launch work when the override is a directory", async function() {
+      // A directory is the canonical unusable override (pointing at a derived-data
+      // tree instead of the packaged .ipa). This must fail closed on EVERY launch
+      // path, including a device pooled by discovery that never went through
+      // verifyIosDevice/ensureCtrlProxyReady -- start()/startInternal() is that
+      // single chokepoint, so the check lives there.
+      const prev = process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH;
+      process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH = os.tmpdir();
+      try {
+        const manager = IOSCtrlProxyManager.getInstance(testDevice);
+        await expect(manager.start()).rejects.toThrow(/set but unusable/);
+      } finally {
+        if (prev === undefined) {
+          delete process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH;
+        } else {
+          process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH = prev;
+        }
+      }
+    });
+  });
+
   describe("getInstance", function() {
     test("should return same instance for same device", function() {
       const instance1 = IOSCtrlProxyManager.getInstance(testDevice);

--- a/test/utils/iosCtrlProxyOverride.test.ts
+++ b/test/utils/iosCtrlProxyOverride.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { promises as fs } from "fs";
+import * as path from "path";
+import * as os from "os";
+import {
+  getIosCtrlProxyOverrideRaw,
+  hasIosCtrlProxyOverride,
+  checkIosCtrlProxyOverride
+} from "../../src/utils/iosCtrlProxyOverride";
+
+describe("iosCtrlProxyOverride (#4221)", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), "ios-override-test-"));
+  });
+  afterEach(async () => {
+    try { await fs.rm(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  const env = (o: Record<string, string | undefined>): NodeJS.ProcessEnv => o as NodeJS.ProcessEnv;
+
+  test("reports no override when neither var is set", () => {
+    expect(getIosCtrlProxyOverrideRaw(env({}))).toBeNull();
+    expect(hasIosCtrlProxyOverride(env({}))).toBe(false);
+  });
+
+  test("IPA_PATH wins over BUNDLE_PATH", () => {
+    expect(getIosCtrlProxyOverrideRaw(env({
+      AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH: "/a.ipa",
+      AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH: "/b"
+    }))).toBe("/a.ipa");
+  });
+
+  test("a real .ipa file is usable", async () => {
+    const ipa = path.join(dir, "runner.ipa");
+    await fs.writeFile(ipa, "x");
+    const result = await checkIosCtrlProxyOverride(env({ AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH: ipa }));
+    expect(result).toMatchObject({ present: true, usable: true, path: ipa });
+  });
+
+  test("a directory is present but not usable, and says why", async () => {
+    const result = await checkIosCtrlProxyOverride(env({ AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH: dir }));
+    expect(result.present).toBe(true);
+    expect(result.usable).toBe(false);
+    expect(result.reason).toContain("directory");
+    expect(result.reason).toContain("AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA");
+  });
+
+  test("a non-existent path is present but not usable", async () => {
+    const result = await checkIosCtrlProxyOverride(env({
+      AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH: path.join(dir, "nope.ipa")
+    }));
+    expect(result.present).toBe(true);
+    expect(result.usable).toBe(false);
+    expect(result.reason).toContain("does not exist");
+  });
+
+  test("no override resolves to present:false", async () => {
+    const result = await checkIosCtrlProxyOverride(env({}));
+    expect(result).toMatchObject({ present: false, usable: false, path: null });
+  });
+});

--- a/test/utils/iosCtrlProxyOverride.test.ts
+++ b/test/utils/iosCtrlProxyOverride.test.ts
@@ -20,6 +20,14 @@ describe("iosCtrlProxyOverride (#4221)", () => {
 
   const env = (o: Record<string, string | undefined>): NodeJS.ProcessEnv => o as NodeJS.ProcessEnv;
 
+  // A real CtrlProxy .ipa is a zip over 10KB. The helper validates zip magic +
+  // size (#4221 review), so fixtures must be genuine, not one byte.
+  function ipaBytes(): Buffer {
+    const head = Buffer.from([0x50, 0x4b, 0x03, 0x04]); // "PK\x03\x04"
+    return Buffer.concat([head, Buffer.alloc(11_000)]);
+  }
+
+
   test("reports no override when neither var is set", () => {
     expect(getIosCtrlProxyOverrideRaw(env({}))).toBeNull();
     expect(hasIosCtrlProxyOverride(env({}))).toBe(false);
@@ -34,7 +42,7 @@ describe("iosCtrlProxyOverride (#4221)", () => {
 
   test("a real .ipa file is usable", async () => {
     const ipa = path.join(dir, "runner.ipa");
-    await fs.writeFile(ipa, "x");
+    await fs.writeFile(ipa, ipaBytes());
     const result = await checkIosCtrlProxyOverride(env({ AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH: ipa }));
     expect(result).toMatchObject({ present: true, usable: true, path: ipa });
   });
@@ -59,5 +67,21 @@ describe("iosCtrlProxyOverride (#4221)", () => {
   test("no override resolves to present:false", async () => {
     const result = await checkIosCtrlProxyOverride(env({}));
     expect(result).toMatchObject({ present: false, usable: false, path: null });
+  });
+
+  test("an existing file that is not a zip/ipa is present but not usable (#4221 review)", async () => {
+    const notABundle = path.join(dir, "hosts");
+    await fs.writeFile(notABundle, "127.0.0.1 localhost\n");
+    const result = await checkIosCtrlProxyOverride(env({ AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH: notABundle }));
+    expect(result.present).toBe(true);
+    expect(result.usable).toBe(false);
+    expect(result.reason).toContain("not a runnable .ipa bundle");
+  });
+
+  test("a zip that is too small is not usable (#4221 review)", async () => {
+    const tiny = path.join(dir, "tiny.ipa");
+    await fs.writeFile(tiny, Buffer.from([0x50, 0x4b, 0x03, 0x04])); // valid magic, 4 bytes
+    const result = await checkIosCtrlProxyOverride(env({ AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH: tiny }));
+    expect(result.usable).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

The two **runtime** halves of #4221. The docs half already landed (#4243 / #4226), which corrected the guidance to use `AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA` for a local runner.

`AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH` (and its `_IPA_PATH` alias) points at a packaged `.ipa` file. Two things treated an *unusable* override — a directory, or a typo'd path — as valid:

1. The daemon's iOS setup silently ran the cached released runner, so results were attributed to a local build that never loaded.
2. `mockNetwork`'s capability guard counted any non-empty string as "a local runner is present" and bypassed its min-release gate.

## Linked Issue

Closes #4221

## Changes

**New canonical helper** `src/utils/iosCtrlProxyOverride.ts`. Three call sites read these env vars with subtly different logic; this centralises "is the override present, and does it resolve to a real `.ipa` file?". A directory is `present: true, usable: false`, with an actionable `reason` naming `AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA` as the right variable for a local xcodebuild output.

**Fix 1 — fail closed** (`DeviceSessionManager.verifyIosDevice`). An unusable override now throws `ActionableError` **before any other path**. This matters because every downstream branch — already-connected, already-running, and the cached-start path — skips the builder that would otherwise validate the override (`IOSCtrlProxyBuilder.ensureBundleDownloaded`, which does throw for a non-file). So the check has to sit at the top of the method, not just before the cached start.

**Fix 3 — validate the guard** (`networkTools.hasIosCtrlProxyRunnerOverride`). It now requires the override to resolve to a real file rather than merely being a non-empty string. The test helper `allowLocalIosRunner` accordingly creates a real `.ipa` instead of a bare non-existent path — otherwise it was asserting availability on a value that, under the stricter guard, no longer counts.

## Not in scope (follow-up)

**Fix 2** — making `BUNDLE_PATH` *accept* a directory, or emit a runtime error naming the right variable. The docs already steer users to `DERIVED_DATA`, and it touches convenience rather than correctness, so it is a cleaner separate change than folding it into a runner-lifecycle PR.

## Testing

- New `test/utils/iosCtrlProxyOverride.test.ts` — 6 tests: precedence, a real `.ipa` is usable, a directory / missing path is present-but-unusable with the right reason.
- `test/utils/DeviceSessionManager.test.ts` — fail-closed on an unusable override via `verifyIosDevice`, and no-fail on a usable `.ipa`.
- `test/server/networkTools.test.ts` — with the version gate forced closed (below-min registry), an unusable override does **not** open it and a usable `.ipa` does.
- `bun run build` / `bun run lint` / `bun run typecheck` — all pass. 58/58 across the three touched suites.

## A note on verification and one honest limitation

These are the daemon's iOS runner-setup paths, which cannot be exercised on this host without a real iOS runner to drive, so verification here is unit tests plus review rather than device. The check is placed to fail closed regardless of runner state, and the fail-closed / usable-override branches are both pinned.

Pre-existing unrelated flake seen in the full suite: `DetectIntentChooser` / `HandleIntentChooser` time out at 5000ms on this host and fail identically on unmodified `origin/main`; they touch none of these files.
