### PR TITLE
fix(cli): thread --embedded-sdk and --network-mockable to the daemon

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,6 +3,7 @@ import { logger } from "../utils/logger";
 import { ActionableError } from "../models";
 import { DaemonClient, DaemonUnavailableError } from "../daemon/client";
 import { DaemonMcpProxy } from "../daemon/daemonMcpProxy";
+import type { DaemonMcpProxyConfig } from "../daemon/daemonMcpProxy";
 import type { DaemonOptions } from "../daemon/types";
 import { resolveDaemonInstallSpecifier } from "../constants/release";
 
@@ -348,12 +349,30 @@ export function parseCliArgs(args: string[]): { toolName: string; sessionUuid?: 
  * call (#2744): a stale different-version/build daemon on the shared socket is
  * restarted to this CLI's build instead of rejecting the request with no self-heal.
  */
+/**
+ * Factory for the daemon proxy, overridable in tests so the CLI's option
+ * threading can be observed without globally mocking the daemonMcpProxy module
+ * (which would replace the real DaemonMcpProxy that daemonMcpProxy.test.ts needs).
+ */
+let daemonProxyFactory: (config: DaemonMcpProxyConfig) => DaemonMcpProxy =
+  config => new DaemonMcpProxy(config);
+
+export function setDaemonProxyFactoryForTesting(
+  factory: (config: DaemonMcpProxyConfig) => DaemonMcpProxy
+): void {
+  daemonProxyFactory = factory;
+}
+
+export function resetDaemonProxyFactoryForTesting(): void {
+  daemonProxyFactory = config => new DaemonMcpProxy(config);
+}
+
 async function runToolViaDaemon(
   toolName: string,
   params: Record<string, any>,
   daemonOptions?: DaemonOptions
 ): Promise<any> {
-  const proxy = new DaemonMcpProxy({ daemonOptions });
+  const proxy = daemonProxyFactory({ daemonOptions });
 
   try {
     const result = await proxy.callTool(toolName, params);

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -207,17 +207,21 @@ export interface ProxiedResourceTemplate {
 
 /**
  * The daemon startup options that change its observable MCP behavior and so must
- * match before a running daemon can be reused: `embeddedSdk`, marker-based
- * eventAll promotion config, plus every output-reduction flag. A same-build MCP
- * client that requests one of these against an already-running daemon started
- * without it (or vice versa) would otherwise silently get the wrong tool-output
- * or inputText behavior until a manual restart (issue #2759 — the
- * `toolResultsNoStructuredContent` case). The output-reduction fields are
- * derived from `OUTPUT_REDUCTION_FLAG_SPECS` (whose `field` names map 1:1 to
- * `DaemonOptions`) so a new flag is covered automatically.
+ * match before a running daemon can be reused: `embeddedSdk`, `networkMockable`,
+ * marker-based eventAll promotion config, plus every output-reduction flag. A
+ * same-build MCP client that requests one of these against an already-running
+ * daemon started without it (or vice versa) would otherwise silently get the
+ * wrong tool-output or inputText behavior until a manual restart (issue #2759 —
+ * the `toolResultsNoStructuredContent` case). `embeddedSdk` and `networkMockable`
+ * additionally gate whole tool families out of the registry, so reusing a daemon
+ * that lacks the requested flag makes those tools unreachable (issue #4247). The
+ * output-reduction fields are derived from `OUTPUT_REDUCTION_FLAG_SPECS` (whose
+ * `field` names map 1:1 to `DaemonOptions`) so a new flag is covered
+ * automatically.
  */
 const REUSE_CRITICAL_OPTION_KEYS: (keyof DaemonOptions)[] = [
   "embeddedSdk",
+  "networkMockable",
   "safeAreaWarnings",
   ...OUTPUT_REDUCTION_FLAG_SPECS.map(spec => spec.field),
 ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -718,7 +718,7 @@ async function main() {
       // Run in CLI mode
       logger.info("Running in CLI mode");
       // logger.enableStdoutLogging();
-      await runCliCommand(cliArgs, { safeAreaWarnings });
+      await runCliCommand(cliArgs, { safeAreaWarnings, embeddedSdk, networkMockable });
       // CRITICAL: Exit explicitly after CLI command completes to prevent process from hanging
       // The event loop may have pending operations (ADB connections, file descriptors) that
       // prevent Node.js from exiting naturally. Force exit with code 0 to ensure clean termination.

--- a/test/cli/daemonOptionsThreading.test.ts
+++ b/test/cli/daemonOptionsThreading.test.ts
@@ -1,5 +1,10 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import type { DaemonOptions } from "../../src/daemon/types";
+import {
+  runCliCommand,
+  setDaemonProxyFactoryForTesting,
+  resetDaemonProxyFactoryForTesting,
+} from "../../src/cli";
 
 /**
  * Regression test for issue #4247: the CLI parses `--embedded-sdk` and
@@ -7,34 +12,31 @@ import type { DaemonOptions } from "../../src/daemon/types";
  * `--cli` starts or reuses, so SDK- and network-gated tools were unreachable.
  *
  * `runCliCommand` routes tool execution through `DaemonMcpProxy`, constructing it
- * with the `daemonOptions` it receives. This test replaces the proxy with a fake
- * that records the options it is constructed with, then asserts both flags are
- * forwarded end to end from `runCliCommand` — no real daemon involved.
+ * with the `daemonOptions` it receives. This test injects a fake proxy via the
+ * `setDaemonProxyFactoryForTesting` seam — deliberately NOT `mock.module`, which
+ * is global in Bun and would replace the real DaemonMcpProxy module for every
+ * other suite in the run (breaking daemonMcpProxy.test.ts's import of the real
+ * error classes). The fake records the options it is constructed with, then the
+ * test asserts both flags are forwarded end to end.
  */
 describe("runCliCommand daemon-option threading (issue #4247)", () => {
   const constructedWith: Array<DaemonOptions | undefined> = [];
 
   afterEach(() => {
     constructedWith.length = 0;
-    mock.restore();
+    resetDaemonProxyFactoryForTesting();
   });
 
   test("forwards embeddedSdk and networkMockable into the DaemonMcpProxy", async () => {
-    mock.module("../../src/daemon/daemonMcpProxy", () => ({
-      DaemonMcpProxy: class {
-        constructor(config: { daemonOptions?: DaemonOptions }) {
-          constructedWith.push(config.daemonOptions);
-        }
-        async callTool(): Promise<any> {
-          return { success: true };
-        }
-        async close(): Promise<void> {
+    setDaemonProxyFactoryForTesting((config): any => {
+      constructedWith.push(config.daemonOptions);
+      return {
+        callTool: async (): Promise<any> => ({ success: true }),
+        close: async (): Promise<void> => {
           // no-op fake
-        }
-      },
-    }));
-
-    const { runCliCommand } = await import("../../src/cli");
+        },
+      };
+    });
 
     await runCliCommand(["listApps", "--platform", "android"], {
       safeAreaWarnings: false,

--- a/test/cli/daemonOptionsThreading.test.ts
+++ b/test/cli/daemonOptionsThreading.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import type { DaemonOptions } from "../../src/daemon/types";
+
+/**
+ * Regression test for issue #4247: the CLI parses `--embedded-sdk` and
+ * `--network-mockable`, but they were dropped before reaching the daemon that
+ * `--cli` starts or reuses, so SDK- and network-gated tools were unreachable.
+ *
+ * `runCliCommand` routes tool execution through `DaemonMcpProxy`, constructing it
+ * with the `daemonOptions` it receives. This test replaces the proxy with a fake
+ * that records the options it is constructed with, then asserts both flags are
+ * forwarded end to end from `runCliCommand` — no real daemon involved.
+ */
+describe("runCliCommand daemon-option threading (issue #4247)", () => {
+  const constructedWith: Array<DaemonOptions | undefined> = [];
+
+  afterEach(() => {
+    constructedWith.length = 0;
+    mock.restore();
+  });
+
+  test("forwards embeddedSdk and networkMockable into the DaemonMcpProxy", async () => {
+    mock.module("../../src/daemon/daemonMcpProxy", () => ({
+      DaemonMcpProxy: class {
+        constructor(config: { daemonOptions?: DaemonOptions }) {
+          constructedWith.push(config.daemonOptions);
+        }
+        async callTool(): Promise<any> {
+          return { success: true };
+        }
+        async close(): Promise<void> {
+          // no-op fake
+        }
+      },
+    }));
+
+    const { runCliCommand } = await import("../../src/cli");
+
+    await runCliCommand(["listApps", "--platform", "android"], {
+      safeAreaWarnings: false,
+      embeddedSdk: true,
+      networkMockable: true,
+    });
+
+    expect(constructedWith).toHaveLength(1);
+    expect(constructedWith[0]?.embeddedSdk).toBe(true);
+    expect(constructedWith[0]?.networkMockable).toBe(true);
+  });
+});

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -432,6 +432,7 @@ describe("DaemonMcpProxy", () => {
     describe("startup option mismatch handling", () => {
       function runningStatus(options: {
         embeddedSdk?: boolean;
+        networkMockable?: boolean;
         safeAreaWarnings?: boolean;
         toolResultsNoStructuredContent?: boolean;
         toolOutputsDir?: string;
@@ -471,6 +472,34 @@ describe("DaemonMcpProxy", () => {
           await proxy.listTools();
           expect(fakeManager.restartCalled).toBe(true);
           expect(fakeManager.restartOptions).toEqual({ embeddedSdk: true });
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
+      test("restarts daemon when network-mockable mode differs (issue #4247)", async () => {
+        const fakeClient = new FakeDaemonClient({
+          daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+        });
+        const fakeManager = new FakeDaemonManager();
+        fakeManager.statusResults = [
+          runningStatus({ networkMockable: false }), // ensureVersionMatches
+          runningStatus({ networkMockable: false }), // ensureBuildMatches
+          runningStatus({ networkMockable: false }), // ensureStartupOptionsMatch (mismatch)
+          runningStatus({ networkMockable: true }), // post-restart verify
+        ];
+        const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+        const proxy = new DaemonMcpProxy({
+          clientFactory: () => fakeClient,
+          daemonManager: fakeManager,
+          daemonOptions: { networkMockable: true },
+        });
+
+        try {
+          await proxy.listTools();
+          expect(fakeManager.restartCalled).toBe(true);
+          expect(fakeManager.restartOptions).toEqual({ networkMockable: true });
         } finally {
           isAvailableSpy.mockRestore();
           await proxy.close();


### PR DESCRIPTION
## Symptom

`--cli` accepts `--embedded-sdk` and `--network-mockable`, but neither reached the daemon it starts or reuses, so any tool gated behind those modes was unreachable from the CLI:

```
$ auto-mobile --embedded-sdk --cli setKeyValue --platform android ...
Error: Tool "setKeyValue" is advertised by this AutoMobile client but the connected
daemon does not provide it, even after restarting and refreshing the tool list.
```

The autostarted daemon lacked embedded-SDK mode, so `ToolRegistry` gated the `embeddedSdkOnly` tools (`setKeyValue`, `removeKeyValue`, `clearKeyValueFile`, preference/database/highlight tools) out of its list. `--network-mockable` gated `mockNetwork` / `clearMockNetwork` the same way.

## Root cause

`src/index.ts:721` threaded only `safeAreaWarnings` into the CLI daemon options:

```ts
await runCliCommand(cliArgs, { safeAreaWarnings });
```

`DaemonOptions` (`src/daemon/types.ts`) declares `embeddedSdk` (:190), `networkMockable` (:188) and `safeAreaWarnings` (:232). The two mode flags are parsed in `src/index.ts` (`embeddedSdk` :184, `networkMockable` :185) and threaded into the daemon/proxy autostart paths, but the `--cli` branch dropped them. This has never worked; it is not a regression (`src/index.ts:721` is byte-identical on `origin/main`).

## Fix

1. **`src/index.ts`** — thread both flags into the CLI call alongside `safeAreaWarnings`:

   ```ts
   await runCliCommand(cliArgs, { safeAreaWarnings, embeddedSdk, networkMockable });
   ```

   Both values come from the same parsed booleans the daemon-autostart path already uses. They flow `runCliCommand` -> `runToolViaDaemon` -> `new DaemonMcpProxy({ daemonOptions })`, and `DaemonMcpProxy` passes them to the daemon it spawns/reconciles.

2. **`src/daemon/daemonMcpProxy.ts`** — add `networkMockable` to `REUSE_CRITICAL_OPTION_KEYS`.

## Warm-daemon reconciliation — handled

`DaemonMcpProxy` already reconciles a warm daemon that lacks a reuse-critical startup flag: `startupOptionDeficits()` compares the connecting client's requested options against the running daemon's reported `status.options`, and restarts the daemon (preserving its existing options and overlaying the client's) when a deficit exists.

- `embeddedSdk` was already in `REUSE_CRITICAL_OPTION_KEYS`, so once threaded, a warm daemon started without it is now restarted with it — the reuse path the issue flagged is covered for embedded SDK with no further change.
- `networkMockable` was **not** in that list, so a warm daemon lacking it would have been silently reused. Since it gates whole tool families identically to `embeddedSdk`, the daemon reports it in `status.options` (`src/daemon/daemon.ts`), and the restart spawn path already emits `--network-mockable` (`src/daemon/manager.ts:739`), adding it to `REUSE_CRITICAL_OPTION_KEYS` makes the warm-daemon path work symmetrically. Reconciliation is one-directional (issue #3846): a client that does not request the flag never forces a restart.

## Tests

- `test/daemon/daemonMcpProxy.test.ts` — new case: a warm daemon reporting `networkMockable: false` is restarted with `networkMockable: true` when the client requests it (mirrors the existing `embeddedSdk` reconciliation test; uses `FakeDaemonManager` / `FakeDaemonClient`, no real daemon).
- `test/cli/daemonOptionsThreading.test.ts` — new file: replaces `DaemonMcpProxy` with a fake that records its constructor `daemonOptions`, then asserts `runCliCommand` forwards both `embeddedSdk` and `networkMockable` end to end. Unit-level, no real daemon.

## Validation

```
$ bun test test/cli/daemonOptionsThreading.test.ts
 1 pass, 0 fail, 3 expect() calls  [292ms]

$ bun test test/daemon/daemonMcpProxy.test.ts
 59 pass, 0 fail, 158 expect() calls  [132ms]

$ bun run build
Build completed successfully!

$ bun run lint
(clean — no violations)

$ bun run typecheck
✅ typecheck gate: no new type errors (214 known error(s) in baseline).
```

Closes #4247
