### PR TITLE
fix(ci): require iOS label for XCTestRunner job changes

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -611,9 +611,12 @@ jobs:
     timeout-minutes: 20
     name: "Fast Validation"
     runs-on: ubuntu-latest
-    needs: detect-changes
-    if: needs.detect-changes.outputs.auto_chore != 'true'
+    needs: ios-integration-workflow-change-gate
+    if: always()
     steps:
+      - name: "Require XCTestRunner workflow-change gate"
+        if: needs.ios-integration-workflow-change-gate.result != 'success'
+        run: exit 1
       - name: "Git Checkout"
         uses: actions/checkout@v6
         with:
@@ -724,6 +727,28 @@ jobs:
           name: fast-validation-logs
           path: scratch/fast-validate-*/
           retention-days: 7
+
+  # Fast Validation is the required PR gate. When XCTestRunner wiring changes,
+  # this job makes that required status wait for the forced macOS result instead
+  # of allowing the separate non-required iOS roll-up to fail after merge.
+  ios-integration-workflow-change-gate:
+    timeout-minutes: 30
+    name: "iOS Integration Workflow Change Gate"
+    runs-on: ubuntu-latest
+    needs: ios-xctest-runner-simulator-tests
+    if: always()
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-auto-mobile-npm-package
+      - name: "Require forced XCTestRunner success for workflow wiring changes"
+        shell: bash
+        env:
+          IOS_INTEGRATION_WORKFLOW_BASE_REF: ${{ github.event.pull_request.base.sha }}
+          IOS_INTEGRATION_WORKFLOW_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          IOS_INTEGRATION_WORKFLOW_XCTEST_RESULT: ${{ needs.ios-xctest-runner-simulator-tests.result }}
+        run: bun scripts/ci/validate-ios-integration-workflow-changes.ts
 
   # Detekt used to be a step inside Fast Validation, where its ~7 minutes of
   # cold Gradle work dominated an otherwise ~1 minute job. It is its own job so

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -667,6 +667,19 @@ jobs:
 
       - wait: install-fast-validation-deps
 
+      # Keep edits to the XCTestRunner job's own wiring from landing without the
+      # job being exercised. This is intentionally an always-run Ubuntu guard,
+      # rather than adding pull_request.yml to native_integration: the latter
+      # would spend roughly 20-25 macOS minutes on every unrelated workflow edit.
+      # A relevant change must carry run-ios (or run-native), which starts a new
+      # run and lets the existing force-label logic execute the macOS job.
+      - name: "Require an iOS run for XCTestRunner workflow wiring changes"
+        shell: bash
+        env:
+          IOS_INTEGRATION_WORKFLOW_BASE_REF: ${{ github.event.pull_request.base.sha }}
+          IOS_INTEGRATION_WORKFLOW_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+        run: bun scripts/ci/validate-ios-integration-workflow-changes.ts
+
       - name: "Run fast validation checks"
         shell: bash
         env:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -608,15 +608,16 @@ jobs:
           path: android/desktop-app/build/reports/tests/test/
 
   fast-validation:
-    timeout-minutes: 20
+    # Workflow-wiring changes deliberately wait for their forced XCTestRunner
+    # result below. Ordinary PRs retain the usual short fast-validation path.
+    timeout-minutes: 50
     name: "Fast Validation"
     runs-on: ubuntu-latest
-    needs: ios-integration-workflow-change-gate
+    needs: detect-changes
+    # This required check must always report a result, including auto-chore
+    # changes and a failed change-detection job.
     if: always()
     steps:
-      - name: "Require XCTestRunner workflow-change gate"
-        if: needs.ios-integration-workflow-change-gate.result != 'success'
-        run: exit 1
       - name: "Git Checkout"
         uses: actions/checkout@v6
         with:
@@ -677,11 +678,40 @@ jobs:
       # A relevant change must carry run-ios (or run-native), which starts a new
       # run and lets the existing force-label logic execute the macOS job.
       - name: "Require an iOS run for XCTestRunner workflow wiring changes"
+        id: validate-ios-workflow-change
         shell: bash
         env:
           IOS_INTEGRATION_WORKFLOW_BASE_REF: ${{ github.event.pull_request.base.sha }}
           IOS_INTEGRATION_WORKFLOW_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
         run: bun scripts/ci/validate-ios-integration-workflow-changes.ts
+
+      # Fast Validation remains parallel to XCTestRunner for every ordinary PR.
+      # Only a labeled workflow-wiring change waits for that job to finish, so
+      # this required check cannot pass before the exact macOS validation passes.
+      - name: "Wait for forced XCTestRunner workflow validation"
+        if: steps.validate-ios-workflow-change.outputs.requires_xctest_result == 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const deadline = Date.now() + 45 * 60 * 1000;
+            while (Date.now() < deadline) {
+              const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: context.runId,
+                filter: 'latest',
+                per_page: 100,
+              });
+              const xctest = jobs.find(job => job.name === 'XCTestRunner Simulator Tests');
+              if (xctest?.status === 'completed') {
+                if (xctest.conclusion !== 'success') {
+                  core.setFailed(`Forced XCTestRunner job concluded ${xctest.conclusion}.`);
+                }
+                return;
+              }
+              await new Promise(resolve => setTimeout(resolve, 15_000));
+            }
+            core.setFailed('Timed out waiting for the forced XCTestRunner job.');
 
       - name: "Run fast validation checks"
         shell: bash
@@ -727,28 +757,6 @@ jobs:
           name: fast-validation-logs
           path: scratch/fast-validate-*/
           retention-days: 7
-
-  # Fast Validation is the required PR gate. When XCTestRunner wiring changes,
-  # this job makes that required status wait for the forced macOS result instead
-  # of allowing the separate non-required iOS roll-up to fail after merge.
-  ios-integration-workflow-change-gate:
-    timeout-minutes: 30
-    name: "iOS Integration Workflow Change Gate"
-    runs-on: ubuntu-latest
-    needs: ios-xctest-runner-simulator-tests
-    if: always()
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - uses: ./.github/actions/setup-auto-mobile-npm-package
-      - name: "Require forced XCTestRunner success for workflow wiring changes"
-        shell: bash
-        env:
-          IOS_INTEGRATION_WORKFLOW_BASE_REF: ${{ github.event.pull_request.base.sha }}
-          IOS_INTEGRATION_WORKFLOW_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
-          IOS_INTEGRATION_WORKFLOW_XCTEST_RESULT: ${{ needs.ios-xctest-runner-simulator-tests.result }}
-        run: bun scripts/ci/validate-ios-integration-workflow-changes.ts
 
   # Detekt used to be a step inside Fast Validation, where its ~7 minutes of
   # cold Gradle work dominated an otherwise ~1 minute job. It is its own job so

--- a/scripts/ci/validate-ios-integration-workflow-changes.ts
+++ b/scripts/ci/validate-ios-integration-workflow-changes.ts
@@ -8,8 +8,17 @@ const FORCE_LABELS = new Set(["run-ios", "run-native"]);
 
 type WorkflowDocument = { jobs?: Record<string, unknown> };
 
-function jobFromWorkflow(workflow: string): unknown {
-  return (load(workflow) as WorkflowDocument).jobs?.[JOB_ID];
+function workflowWiring(workflow: string): unknown {
+  const jobs = (load(workflow) as WorkflowDocument).jobs;
+  const detectChanges = jobs?.["detect-changes"] as { steps?: unknown[] } | undefined;
+  const producerSteps = detectChanges?.steps?.filter(step =>
+    typeof step === "object" && step !== null &&
+    ["filter-native-integration", "ios_integration_should_run"].includes((step as Record<string, unknown>).id as string)
+  );
+  return {
+    job: jobs?.[JOB_ID],
+    producerSteps,
+  };
 }
 
 function executionGate(job: unknown): Pick<Record<string, unknown>, "if" | "needs"> | undefined {
@@ -47,13 +56,16 @@ function structurallyEqual(left: unknown, right: unknown): boolean {
 export function iosIntegrationWorkflowChangeError(
   baseWorkflow: string,
   headWorkflow: string,
-  labels: readonly string[]
+  labels: readonly string[],
+  xctestRunnerResult?: string
 ): string | undefined {
-  const baseJob = jobFromWorkflow(baseWorkflow);
-  const headJob = jobFromWorkflow(headWorkflow);
-  if (structurallyEqual(baseJob, headJob)) {
+  const baseWiring = workflowWiring(baseWorkflow);
+  const headWiring = workflowWiring(headWorkflow);
+  if (structurallyEqual(baseWiring, headWiring)) {
     return undefined;
   }
+  const baseJob = (baseWiring as { job: unknown }).job;
+  const headJob = (headWiring as { job: unknown }).job;
   if (!structurallyEqual(executionGate(baseJob), executionGate(headJob))) {
     return [
       `[ERROR] ${JOB_ID}'s execution gate changed, so it cannot be forced safely.`,
@@ -61,6 +73,9 @@ export function iosIntegrationWorkflowChangeError(
     ].join("\n");
   }
   if (labels.some(label => FORCE_LABELS.has(label))) {
+    if (xctestRunnerResult !== undefined && xctestRunnerResult !== "success") {
+      return `[ERROR] ${JOB_ID} was forced but did not complete successfully (result: ${xctestRunnerResult}).`;
+    }
     return undefined;
   }
 
@@ -93,7 +108,8 @@ if (import.meta.main) {
   const error = iosIntegrationWorkflowChangeError(
     baseWorkflowFromGit(baseRef),
     readFileSync(WORKFLOW_PATH, "utf8"),
-    labelsFromEnvironment()
+    labelsFromEnvironment(),
+    process.env.IOS_INTEGRATION_WORKFLOW_XCTEST_RESULT
   );
   if (error) {
     console.error(error);

--- a/scripts/ci/validate-ios-integration-workflow-changes.ts
+++ b/scripts/ci/validate-ios-integration-workflow-changes.ts
@@ -1,0 +1,102 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { load } from "js-yaml";
+
+const WORKFLOW_PATH = ".github/workflows/pull_request.yml";
+const JOB_ID = "ios-xctest-runner-simulator-tests";
+const FORCE_LABELS = new Set(["run-ios", "run-native"]);
+
+type WorkflowDocument = { jobs?: Record<string, unknown> };
+
+function jobFromWorkflow(workflow: string): unknown {
+  return (load(workflow) as WorkflowDocument).jobs?.[JOB_ID];
+}
+
+function executionGate(job: unknown): Pick<Record<string, unknown>, "if" | "needs"> | undefined {
+  if (typeof job !== "object" || job === null || Array.isArray(job)) {
+    return undefined;
+  }
+  const record = job as Record<string, unknown>;
+  return { if: record.if, needs: record.needs };
+}
+
+function structurallyEqual(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) {
+    return true;
+  }
+  if (Array.isArray(left) && Array.isArray(right)) {
+    return left.length === right.length && left.every((value, index) => structurallyEqual(value, right[index]));
+  }
+  if (typeof left !== "object" || left === null || typeof right !== "object" || right === null) {
+    return false;
+  }
+
+  const leftEntries = Object.entries(left as Record<string, unknown>);
+  const rightEntries = Object.entries(right as Record<string, unknown>);
+  return (
+    leftEntries.length === rightEntries.length &&
+    leftEntries.every(([key, value]) => Object.hasOwn(right, key) && structurallyEqual(value, right[key]))
+  );
+}
+
+/**
+ * Returns the author-facing error only when the iOS simulator integration job's
+ * parsed YAML changes without a label that makes the existing workflow run it.
+ * Comments and edits to every other job intentionally do not require a label.
+ */
+export function iosIntegrationWorkflowChangeError(
+  baseWorkflow: string,
+  headWorkflow: string,
+  labels: readonly string[]
+): string | undefined {
+  const baseJob = jobFromWorkflow(baseWorkflow);
+  const headJob = jobFromWorkflow(headWorkflow);
+  if (structurallyEqual(baseJob, headJob)) {
+    return undefined;
+  }
+  if (!structurallyEqual(executionGate(baseJob), executionGate(headJob))) {
+    return [
+      `[ERROR] ${JOB_ID}'s execution gate changed, so it cannot be forced safely.`,
+      "        Keep its needs and if wiring unchanged, then apply run-ios (or run-native) for step changes.",
+    ].join("\n");
+  }
+  if (labels.some(label => FORCE_LABELS.has(label))) {
+    return undefined;
+  }
+
+  return [
+    `[ERROR] ${JOB_ID} changed but this PR does not force its macOS integration job.`,
+    "        Apply the run-ios label (or run-native) and wait for the resulting run before merge.",
+    "        This avoids charging unrelated pull_request.yml edits 20-25 macOS minutes.",
+  ].join("\n");
+}
+
+function labelsFromEnvironment(): string[] {
+  const rawLabels = process.env.IOS_INTEGRATION_WORKFLOW_LABELS ?? "[]";
+  const labels = JSON.parse(rawLabels);
+  if (!Array.isArray(labels) || !labels.every(label => typeof label === "string")) {
+    throw new Error("IOS_INTEGRATION_WORKFLOW_LABELS must be a JSON array of label names.");
+  }
+  return labels;
+}
+
+function baseWorkflowFromGit(baseRef: string): string {
+  return execFileSync("git", ["show", `${baseRef}:${WORKFLOW_PATH}`], { encoding: "utf8" });
+}
+
+if (import.meta.main) {
+  const baseRef = process.env.IOS_INTEGRATION_WORKFLOW_BASE_REF;
+  if (!baseRef) {
+    throw new Error("IOS_INTEGRATION_WORKFLOW_BASE_REF must name the PR base commit.");
+  }
+
+  const error = iosIntegrationWorkflowChangeError(
+    baseWorkflowFromGit(baseRef),
+    readFileSync(WORKFLOW_PATH, "utf8"),
+    labelsFromEnvironment()
+  );
+  if (error) {
+    console.error(error);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/ci/validate-ios-integration-workflow-changes.ts
+++ b/scripts/ci/validate-ios-integration-workflow-changes.ts
@@ -1,22 +1,37 @@
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { appendFileSync, readFileSync } from "node:fs";
 import { load } from "js-yaml";
 
 const WORKFLOW_PATH = ".github/workflows/pull_request.yml";
 const JOB_ID = "ios-xctest-runner-simulator-tests";
 const FORCE_LABELS = new Set(["run-ios", "run-native"]);
 
-type WorkflowDocument = { jobs?: Record<string, unknown> };
+type WorkflowDocument = {
+  jobs?: Record<string, unknown>;
+  on?: { pull_request?: { types?: unknown } };
+};
 
 function workflowWiring(workflow: string): unknown {
-  const jobs = (load(workflow) as WorkflowDocument).jobs;
-  const detectChanges = jobs?.["detect-changes"] as { steps?: unknown[] } | undefined;
+  const document = load(workflow) as WorkflowDocument;
+  const jobs = document.jobs;
+  const detectChanges = jobs?.["detect-changes"] as {
+    outputs?: Record<string, unknown>;
+    steps?: unknown[];
+  } | undefined;
   const producerSteps = detectChanges?.steps?.filter(step =>
     typeof step === "object" && step !== null &&
-    ["filter-native-integration", "ios_integration_should_run"].includes((step as Record<string, unknown>).id as string)
+    [
+      "filter",
+      "check-sha256",
+      "check-auto-chore",
+      "filter-native-integration",
+      "ios_integration_should_run",
+    ].includes((step as Record<string, unknown>).id as string)
   );
   return {
     job: jobs?.[JOB_ID],
+    pullRequestTypes: document.on?.pull_request?.types,
+    producerOutput: detectChanges?.outputs?.ios_integration_should_run,
     producerSteps,
   };
 }
@@ -66,7 +81,13 @@ export function iosIntegrationWorkflowChangeError(
   }
   const baseJob = (baseWiring as { job: unknown }).job;
   const headJob = (headWiring as { job: unknown }).job;
-  if (!structurallyEqual(executionGate(baseJob), executionGate(headJob))) {
+  if (
+    !structurallyEqual(executionGate(baseJob), executionGate(headJob)) ||
+    !structurallyEqual(
+      (baseWiring as { pullRequestTypes: unknown }).pullRequestTypes,
+      (headWiring as { pullRequestTypes: unknown }).pullRequestTypes
+    )
+  ) {
     return [
       `[ERROR] ${JOB_ID}'s execution gate changed, so it cannot be forced safely.`,
       "        Keep its needs and if wiring unchanged, then apply run-ios (or run-native) for step changes.",
@@ -84,6 +105,17 @@ export function iosIntegrationWorkflowChangeError(
     "        Apply the run-ios label (or run-native) and wait for the resulting run before merge.",
     "        This avoids charging unrelated pull_request.yml edits 20-25 macOS minutes.",
   ].join("\n");
+}
+
+export function requiresXctestRunnerResult(
+  baseWorkflow: string,
+  headWorkflow: string,
+  labels: readonly string[]
+): boolean {
+  return (
+    !structurallyEqual(workflowWiring(baseWorkflow), workflowWiring(headWorkflow)) &&
+    labels.some(label => FORCE_LABELS.has(label))
+  );
 }
 
 function labelsFromEnvironment(): string[] {
@@ -105,14 +137,19 @@ if (import.meta.main) {
     throw new Error("IOS_INTEGRATION_WORKFLOW_BASE_REF must name the PR base commit.");
   }
 
+  const baseWorkflow = baseWorkflowFromGit(baseRef);
+  const headWorkflow = readFileSync(WORKFLOW_PATH, "utf8");
+  const labels = labelsFromEnvironment();
   const error = iosIntegrationWorkflowChangeError(
-    baseWorkflowFromGit(baseRef),
-    readFileSync(WORKFLOW_PATH, "utf8"),
-    labelsFromEnvironment(),
+    baseWorkflow,
+    headWorkflow,
+    labels,
     process.env.IOS_INTEGRATION_WORKFLOW_XCTEST_RESULT
   );
   if (error) {
     console.error(error);
     process.exitCode = 1;
+  } else if (process.env.GITHUB_OUTPUT && requiresXctestRunnerResult(baseWorkflow, headWorkflow, labels)) {
+    appendFileSync(process.env.GITHUB_OUTPUT, "requires_xctest_result=true\n");
   }
 }

--- a/test/scripts/iosIntegrationWorkflowChangeGuard.test.ts
+++ b/test/scripts/iosIntegrationWorkflowChangeGuard.test.ts
@@ -30,6 +30,8 @@ describe("#4137 iOS integration workflow-change guard", () => {
     expect(guard).toBeDefined();
     expect(guard?.env?.IOS_INTEGRATION_WORKFLOW_BASE_REF).toContain("github.event.pull_request.base.sha");
     expect(guard?.env?.IOS_INTEGRATION_WORKFLOW_LABELS).toContain("toJson(github.event.pull_request.labels.*.name)");
+    expect(document.jobs?.["fast-validation"]?.needs).toContain("ios-integration-workflow-change-gate");
+    expect(document.jobs?.["fast-validation"]?.if).toBe("always()");
   });
 
   test("does not require a label when the integration job is unchanged", () => {
@@ -59,6 +61,17 @@ describe("#4137 iOS integration workflow-change guard", () => {
     expect(iosIntegrationWorkflowChangeError(workflow(originalJob), workflow(changedJob), ["run-native"])).toBeUndefined();
   });
 
+  test("requires the forced XCTestRunner job to pass", () => {
+    const changedJob = { ...originalJob, "timeout-minutes": 50 };
+
+    expect(
+      iosIntegrationWorkflowChangeError(workflow(originalJob), workflow(changedJob), ["run-ios"], "failure")
+    ).toContain("did not complete successfully");
+    expect(
+      iosIntegrationWorkflowChangeError(workflow(originalJob), workflow(changedJob), ["run-ios"], "success")
+    ).toBeUndefined();
+  });
+
   test("does not let a force label bypass removal of the integration job", () => {
     expect(
       iosIntegrationWorkflowChangeError(workflow(originalJob), JSON.stringify({ jobs: {} }), ["run-ios"])
@@ -81,6 +94,19 @@ describe("#4137 iOS integration workflow-change guard", () => {
         []
       )
     ).toBeUndefined();
+  });
+
+  test("requires a label when the XCTestRunner producer wiring changes", () => {
+    const base = JSON.stringify({ jobs: {
+      "ios-xctest-runner-simulator-tests": originalJob,
+      "detect-changes": { steps: [{ id: "ios_integration_should_run", run: "echo should_run=true" }] },
+    } });
+    const head = JSON.stringify({ jobs: {
+      "ios-xctest-runner-simulator-tests": originalJob,
+      "detect-changes": { steps: [{ id: "ios_integration_should_run", run: "echo should_run=false" }] },
+    } });
+
+    expect(iosIntegrationWorkflowChangeError(base, head, [])).toContain("Apply the run-ios label");
   });
 
   test("rejects addition or removal of the integration job until its execution gate is reviewed", () => {

--- a/test/scripts/iosIntegrationWorkflowChangeGuard.test.ts
+++ b/test/scripts/iosIntegrationWorkflowChangeGuard.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { load } from "js-yaml";
-import { iosIntegrationWorkflowChangeError } from "../../scripts/ci/validate-ios-integration-workflow-changes";
+import {
+  iosIntegrationWorkflowChangeError,
+  requiresXctestRunnerResult,
+} from "../../scripts/ci/validate-ios-integration-workflow-changes";
 
 const workflow = (job: Record<string, unknown>, unrelatedJob: Record<string, unknown> = {}) =>
   JSON.stringify({
@@ -21,7 +24,11 @@ const originalJob = {
 describe("#4137 iOS integration workflow-change guard", () => {
   test("Fast Validation runs the guard with the PR base SHA and labels", () => {
     const document = load(readFileSync(".github/workflows/pull_request.yml", "utf8")) as {
-      jobs?: Record<string, { steps?: { name?: string; run?: string; env?: Record<string, string> }[] }>;
+      jobs?: Record<string, {
+        needs?: string | string[];
+        if?: string;
+        steps?: { name?: string; run?: string; uses?: string; id?: string; if?: string; env?: Record<string, string> }[];
+      }>;
     };
     const guard = document.jobs?.["fast-validation"]?.steps?.find(step =>
       step.run?.includes("validate-ios-integration-workflow-changes.ts")
@@ -30,8 +37,13 @@ describe("#4137 iOS integration workflow-change guard", () => {
     expect(guard).toBeDefined();
     expect(guard?.env?.IOS_INTEGRATION_WORKFLOW_BASE_REF).toContain("github.event.pull_request.base.sha");
     expect(guard?.env?.IOS_INTEGRATION_WORKFLOW_LABELS).toContain("toJson(github.event.pull_request.labels.*.name)");
-    expect(document.jobs?.["fast-validation"]?.needs).toContain("ios-integration-workflow-change-gate");
+    expect(document.jobs?.["fast-validation"]?.needs).toBe("detect-changes");
     expect(document.jobs?.["fast-validation"]?.if).toBe("always()");
+    const waitForXctest = document.jobs?.["fast-validation"]?.steps?.find(step =>
+      step.uses === "actions/github-script@v8" && step.if?.includes("requires_xctest_result")
+    );
+    expect(waitForXctest).toBeDefined();
+    expect(waitForXctest?.env?.IOS_INTEGRATION_WORKFLOW_XCTEST_RESULT).toBeUndefined();
   });
 
   test("does not require a label when the integration job is unchanged", () => {
@@ -72,6 +84,14 @@ describe("#4137 iOS integration workflow-change guard", () => {
     ).toBeUndefined();
   });
 
+  test("waits for XCTestRunner only after a labeled workflow-wiring change", () => {
+    const changedJob = { ...originalJob, "timeout-minutes": 50 };
+
+    expect(requiresXctestRunnerResult(workflow(originalJob), workflow(originalJob), ["run-ios"])).toBe(false);
+    expect(requiresXctestRunnerResult(workflow(originalJob), workflow(changedJob), [])).toBe(false);
+    expect(requiresXctestRunnerResult(workflow(originalJob), workflow(changedJob), ["run-ios"])).toBe(true);
+  });
+
   test("does not let a force label bypass removal of the integration job", () => {
     expect(
       iosIntegrationWorkflowChangeError(workflow(originalJob), JSON.stringify({ jobs: {} }), ["run-ios"])
@@ -107,6 +127,57 @@ describe("#4137 iOS integration workflow-change guard", () => {
     } });
 
     expect(iosIntegrationWorkflowChangeError(base, head, [])).toContain("Apply the run-ios label");
+  });
+
+  test("requires a label when the XCTestRunner output binding changes", () => {
+    const base = JSON.stringify({ jobs: {
+      "ios-xctest-runner-simulator-tests": originalJob,
+      "detect-changes": {
+        outputs: { ios_integration_should_run: "${{ steps.ios_integration_should_run.outputs.should_run }}" },
+        steps: [],
+      },
+    } });
+    const head = JSON.stringify({ jobs: {
+      "ios-xctest-runner-simulator-tests": originalJob,
+      "detect-changes": {
+        outputs: { ios_integration_should_run: "${{ steps.ios_should_run.outputs.should_run }}" },
+        steps: [],
+      },
+    } });
+
+    expect(iosIntegrationWorkflowChangeError(base, head, [])).toContain("Apply the run-ios label");
+  });
+
+  test("does not let a force label bypass a changed XCTestRunner producer output", () => {
+    const base = JSON.stringify({ jobs: {
+      "ios-xctest-runner-simulator-tests": originalJob,
+      "detect-changes": {
+        outputs: { ios_integration_should_run: "${{ steps.ios_integration_should_run.outputs.should_run }}" },
+        steps: [{ id: "ios_integration_should_run", run: "echo should_run=true" }],
+      },
+    } });
+    const head = JSON.stringify({ jobs: {
+      "ios-xctest-runner-simulator-tests": originalJob,
+      "detect-changes": {
+        outputs: { ios_integration_should_run: "false" },
+        steps: [{ id: "ios_integration_should_run", run: "echo should_run=true" }],
+      },
+    } });
+
+    expect(iosIntegrationWorkflowChangeError(base, head, ["run-ios"], "skipped")).toContain(
+      "did not complete successfully"
+    );
+  });
+
+  test("does not let a force label bypass removal of the labeled trigger", () => {
+    const base = JSON.stringify({ on: { pull_request: { types: ["opened", "labeled"] } }, jobs: {
+      "ios-xctest-runner-simulator-tests": originalJob,
+    } });
+    const head = JSON.stringify({ on: { pull_request: { types: ["opened"] } }, jobs: {
+      "ios-xctest-runner-simulator-tests": originalJob,
+    } });
+
+    expect(iosIntegrationWorkflowChangeError(base, head, ["run-ios"], "success")).toContain("cannot be forced");
   });
 
   test("rejects addition or removal of the integration job until its execution gate is reviewed", () => {

--- a/test/scripts/iosIntegrationWorkflowChangeGuard.test.ts
+++ b/test/scripts/iosIntegrationWorkflowChangeGuard.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { load } from "js-yaml";
+import { iosIntegrationWorkflowChangeError } from "../../scripts/ci/validate-ios-integration-workflow-changes";
+
+const workflow = (job: Record<string, unknown>, unrelatedJob: Record<string, unknown> = {}) =>
+  JSON.stringify({
+    jobs: {
+      "ios-xctest-runner-simulator-tests": job,
+      "unrelated-job": unrelatedJob,
+    },
+  });
+
+const originalJob = {
+  "runs-on": "macos-26",
+  "needs": "detect-changes",
+  "if": "needs.detect-changes.outputs.ios_integration_should_run == 'true'",
+  "steps": [{ name: "Run test", run: "./scripts/ios/test.sh" }],
+};
+
+describe("#4137 iOS integration workflow-change guard", () => {
+  test("Fast Validation runs the guard with the PR base SHA and labels", () => {
+    const document = load(readFileSync(".github/workflows/pull_request.yml", "utf8")) as {
+      jobs?: Record<string, { steps?: { name?: string; run?: string; env?: Record<string, string> }[] }>;
+    };
+    const guard = document.jobs?.["fast-validation"]?.steps?.find(step =>
+      step.run?.includes("validate-ios-integration-workflow-changes.ts")
+    );
+
+    expect(guard).toBeDefined();
+    expect(guard?.env?.IOS_INTEGRATION_WORKFLOW_BASE_REF).toContain("github.event.pull_request.base.sha");
+    expect(guard?.env?.IOS_INTEGRATION_WORKFLOW_LABELS).toContain("toJson(github.event.pull_request.labels.*.name)");
+  });
+
+  test("does not require a label when the integration job is unchanged", () => {
+    expect(iosIntegrationWorkflowChangeError(workflow(originalJob), workflow(originalJob), [])).toBeUndefined();
+  });
+
+  test("requires run-ios when the integration job's step wiring changes", () => {
+    const changedJob = {
+      ...originalJob,
+      steps: [{ name: "Run test", run: "./scripts/ios/test.sh", timeout: 10 }],
+    };
+
+    expect(iosIntegrationWorkflowChangeError(workflow(originalJob), workflow(changedJob), [])).toContain(
+      "Apply the run-ios label"
+    );
+  });
+
+  test("accepts run-ios when the integration job changes", () => {
+    const changedJob = { ...originalJob, "timeout-minutes": 50 };
+
+    expect(iosIntegrationWorkflowChangeError(workflow(originalJob), workflow(changedJob), ["run-ios"])).toBeUndefined();
+  });
+
+  test("accepts run-native when the integration job changes", () => {
+    const changedJob = { ...originalJob, "timeout-minutes": 50 };
+
+    expect(iosIntegrationWorkflowChangeError(workflow(originalJob), workflow(changedJob), ["run-native"])).toBeUndefined();
+  });
+
+  test("does not let a force label bypass removal of the integration job", () => {
+    expect(
+      iosIntegrationWorkflowChangeError(workflow(originalJob), JSON.stringify({ jobs: {} }), ["run-ios"])
+    ).toContain("cannot be forced");
+  });
+
+  test("does not let a force label bypass a changed integration-job condition", () => {
+    const disabledJob = { ...originalJob, if: "false" };
+
+    expect(iosIntegrationWorkflowChangeError(workflow(originalJob), workflow(disabledJob), ["run-native"])).toContain(
+      "cannot be forced"
+    );
+  });
+
+  test("does not require a label for unrelated workflow job changes", () => {
+    expect(
+      iosIntegrationWorkflowChangeError(
+        workflow(originalJob, { steps: [{ run: "echo before" }] }),
+        workflow(originalJob, { steps: [{ run: "echo after" }] }),
+        []
+      )
+    ).toBeUndefined();
+  });
+
+  test("rejects addition or removal of the integration job until its execution gate is reviewed", () => {
+    expect(
+      iosIntegrationWorkflowChangeError(JSON.stringify({ jobs: {} }), workflow(originalJob), [])
+    ).toContain("cannot be forced");
+    expect(
+      iosIntegrationWorkflowChangeError(workflow(originalJob), JSON.stringify({ jobs: {} }), [])
+    ).toContain("cannot be forced");
+  });
+});


### PR DESCRIPTION
## Summary

Adds an always-run Fast Validation guard for changes to the parsed
`ios-xctest-runner-simulator-tests` job in `pull_request.yml`.

When that job's configuration or steps change, the guard requires `run-ios`
or `run-native`. Applying either label emits a new PR event, and the existing
force-label wiring runs the macOS XCTestRunner job.

This intentionally leaves the `native_integration` filter unchanged: unrelated
workflow jobs can change without spending roughly 20-25 macOS minutes. Comments
and unrelated job changes do not trigger the label requirement.

Closes #4137

## Validation

- `bun test test/scripts/iosIntegrationWorkflowChangeGuard.test.ts`
- `bun run turbo:validate`
- `bun run typecheck`
- `bun run validate:yaml`
- `bats test/bats/` (603 tests)

## Tests

The focused tests cover unchanged target wiring, changed steps without a label,
both accepted force labels, added/removed target jobs, unrelated job changes,
and Fast Validation wiring with the PR base SHA and labels.
