### PR TITLE
test: isolate logger captures in flaky tests

### DIFF
--- a/src/db/keyedJsonConfigRepository.ts
+++ b/src/db/keyedJsonConfigRepository.ts
@@ -4,7 +4,7 @@ import type {
   DeviceSnapshotConfig,
   VideoRecordingConfig,
 } from "../models";
-import { logger } from "../utils/logger";
+import { logger, type Logger } from "../utils/logger";
 import { ensureMigrations, getDatabase } from "./database";
 import type { Database } from "./types";
 
@@ -19,6 +19,7 @@ export interface KeyedJsonConfigRepositoryOptions {
   tableName: KeyedJsonConfigTableName;
   loggerTag?: string;
   db?: Kysely<Database>;
+  logger?: Logger;
 }
 
 const KEYED_JSON_CONFIG_TABLES = {
@@ -49,11 +50,13 @@ export class KeyedJsonConfigRepository<TConfig> implements ConfigRepository<TCon
   private readonly tableName: KeyedJsonConfigTableName;
   private readonly loggerTag: string;
   private readonly db: Kysely<Database> | null;
+  private readonly logger: Logger;
 
   constructor(options: KeyedJsonConfigRepositoryOptions) {
     this.tableName = options.tableName;
     this.loggerTag = options.loggerTag ?? "KeyedJsonConfigRepository";
     this.db = options.db ?? null;
+    this.logger = options.logger ?? logger;
   }
 
   private async getDb(): Promise<Kysely<Database>> {
@@ -79,7 +82,7 @@ export class KeyedJsonConfigRepository<TConfig> implements ConfigRepository<TCon
     try {
       return JSON.parse(row.config_json) as TConfig;
     } catch (error) {
-      logger.warn(`[${this.loggerTag}] Failed to parse config JSON: ${error}`);
+      this.logger.warn(`[${this.loggerTag}] Failed to parse config JSON: ${error}`);
       return null;
     }
   }

--- a/src/doctor/checks/automobile.ts
+++ b/src/doctor/checks/automobile.ts
@@ -33,6 +33,7 @@ import { AndroidCtrlProxyManager } from "../../utils/CtrlProxyManager";
 import { loadSharp, type SharpFactory } from "../../utils/image/loadSharp";
 import { WebpBinaryResolver, type ResolvedWebpBinaries } from "../../utils/image/webp/WebpBinaryResolver";
 import { logger } from "../../utils/logger";
+import type { Logger } from "../../utils/logger";
 import { ActionableError } from "../../models/ActionableError";
 
 const RELEASES_URL = "https://github.com/kaeawc/auto-mobile/releases";
@@ -49,6 +50,10 @@ export interface DaemonStatusDependencies {
 export interface DaemonBuildIdentityDependencies {
   daemonManager?: DaemonStatusManager;
   getClientBuildIdentity?: () => BuildIdentity;
+}
+
+export interface CtrlProxyDoctorDependencies {
+  logger?: Logger;
 }
 
 export interface AutoMobileCheckDependencies {
@@ -324,8 +329,10 @@ export async function checkDaemonBuildIdentity(
  * Check CtrlProxy status on connected devices
  */
 export async function checkCtrlProxy(
-  adbFactory: AdbClientFactory = defaultAdbClientFactory
+  adbFactory: AdbClientFactory = defaultAdbClientFactory,
+  dependencies: CtrlProxyDoctorDependencies = {}
 ): Promise<CheckResult> {
+  const log = dependencies.logger ?? logger;
   try {
     const adb = adbFactory.create();
     // Validate hermetic asset configuration before device-dependent shortcuts so
@@ -468,14 +475,14 @@ export async function checkCtrlProxy(
     };
   } catch (error) {
     if (error instanceof ActionableError) {
-      logger.warn(`CtrlProxy check failed: ${error.message}`, error);
+      log.warn(`CtrlProxy check failed: ${error.message}`, error);
       return {
         name: "CtrlProxy",
         status: "fail",
         message: error.message,
       };
     }
-    logger.warn(`CtrlProxy check failed: ${error instanceof Error ? error.message : String(error)}`, error);
+    log.warn(`CtrlProxy check failed: ${error instanceof Error ? error.message : String(error)}`, error);
     return {
       name: "CtrlProxy",
       status: "skip",

--- a/src/features/navigation/NavigationScreenshotManager.ts
+++ b/src/features/navigation/NavigationScreenshotManager.ts
@@ -1,6 +1,6 @@
 import path from "path";
 import crypto from "crypto";
-import { logger } from "../../utils/logger";
+import { logger, type Logger } from "../../utils/logger";
 import { Image } from "../../utils/image-utils";
 import { TakeScreenshot } from "../observe/TakeScreenshot";
 import { BootedDevice } from "../../models";
@@ -24,6 +24,7 @@ interface NavigationScreenshotManagerOptions {
   webpQuality?: number;
   fileSystem?: FileSystem;
   timer?: Timer;
+  logger?: Logger;
 }
 
 /**
@@ -41,6 +42,7 @@ export class NavigationScreenshotManager {
   private readonly webpQuality: number;
   private readonly fs: FileSystem;
   private readonly timer: Timer;
+  private readonly logger: Logger;
 
   // Track pending captures to avoid duplicate work
   private pendingCaptures: Map<string, Promise<string | null>> = new Map();
@@ -53,10 +55,11 @@ export class NavigationScreenshotManager {
     this.webpQuality = options.webpQuality ?? 65;
     this.fs = options.fileSystem ?? new CanonicalDefaultFileSystem();
     this.timer = options.timer ?? defaultTimer;
+    this.logger = options.logger ?? logger;
 
     // Ensure directory exists
     this.fs.ensureDir(this.screenshotDir).catch(err => {
-      logger.warn(`[NAV_SCREENSHOT] Failed to create screenshot directory: ${err}`);
+      this.logger.warn(`[NAV_SCREENSHOT] Failed to create screenshot directory: ${err}`);
     });
   }
 
@@ -133,7 +136,7 @@ export class NavigationScreenshotManager {
       return path.join(this.screenshotDir, matching[0]);
     } catch (error) {
       // Screenshot lookup is best-effort; callers can capture a fresh image when lookup fails.
-      logger.debug(`[NAV_SCREENSHOT] Failed to find existing screenshot: ${error instanceof Error ? error.message : String(error)}`, error);
+      this.logger.debug(`[NAV_SCREENSHOT] Failed to find existing screenshot: ${error instanceof Error ? error.message : String(error)}`, error);
       return null;
     }
   }
@@ -376,7 +379,7 @@ export class NavigationScreenshotManager {
       return await this.fs.readFileBuffer(screenshotPath);
     } catch (error) {
       // Screenshot reads are best-effort; callers treat null as an unavailable image.
-      logger.debug(`[NAV_SCREENSHOT] Failed to read screenshot: ${error instanceof Error ? error.message : String(error)}`, error);
+      this.logger.debug(`[NAV_SCREENSHOT] Failed to read screenshot: ${error instanceof Error ? error.message : String(error)}`, error);
       return null;
     }
   }

--- a/src/features/observe/DeviceServiceUtils.ts
+++ b/src/features/observe/DeviceServiceUtils.ts
@@ -7,7 +7,7 @@
 
 import type { Timer } from "../../utils/SystemTimer";
 import type { PerformanceTracker } from "../../utils/PerformanceTracker";
-import { logger } from "../../utils/logger";
+import { logger, type Logger } from "../../utils/logger";
 import type { GestureResult, TextResult, ScreenshotResult } from "./DeviceService";
 import type { BaseResult, GestureTimingResult, ActionTimingResult, DelegateContext } from "./shared/types";
 
@@ -171,13 +171,13 @@ export function createCacheEntry<T>(
 /**
  * Safely parse a JSON message.
  */
-export function parseMessage<T>(data: string | Buffer): T | null {
+export function parseMessage<T>(data: string | Buffer, log: Logger = logger): T | null {
   try {
     const text = typeof data === "string" ? data : data.toString();
     return JSON.parse(text) as T;
   } catch (error) {
     // Malformed delegate messages are non-fatal; callers treat null as an unparseable message.
-    logger.debug(`Failed to parse device service message: ${error instanceof Error ? error.message : String(error)}`, error);
+    log.debug(`Failed to parse device service message: ${error instanceof Error ? error.message : String(error)}`, error);
     return null;
   }
 }

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -18,7 +18,7 @@ import WebSocket from "ws";
 import { AdbClientFactory, defaultAdbClientFactory } from "../../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "../../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import type { AdbClient } from "../../../utils/android-cmdline-tools/AdbClient";
-import { logger } from "../../../utils/logger";
+import { logger, type Logger } from "../../../utils/logger";
 import { rewriteUnknownCommandError } from "../shared/rewriteUnknownCommandError";
 import {
   BootedDevice,
@@ -933,6 +933,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
    * injectable for tests.
    */
   private sdkEventIngestorInstance: AndroidSdkEventIngestor | null = null;
+  private readonly loggerInstance: Logger;
 
   // Logging tag for base class
   protected readonly logTag = "ACCESSIBILITY_SERVICE";
@@ -949,10 +950,12 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     retryExecutor?: RetryExecutor,
     crashEventSink?: CrashEventSink,
     deviceConnectionLostNotifier?: DeviceConnectionLostNotifier,
-    sdkEventIngestor?: AndroidSdkEventIngestor
+    sdkEventIngestor?: AndroidSdkEventIngestor,
+    loggerInstance: Logger = logger
   ) {
     super(timer ?? defaultTimer, webSocketFactory ?? defaultWebSocketFactory, {}, retryExecutor ?? defaultRetryExecutor);
     this.sdkEventIngestorInstance = sdkEventIngestor ?? null;
+    this.loggerInstance = loggerInstance;
     this.device = device;
     this.adb = adb;
     this.installedAppsRepository = installedAppsRepository ?? null;
@@ -1072,7 +1075,8 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     retryExecutor?: RetryExecutor,
     crashEventSink?: CrashEventSink,
     deviceConnectionLostNotifier?: DeviceConnectionLostNotifier,
-    sdkEventIngestor?: AndroidSdkEventIngestor
+    sdkEventIngestor?: AndroidSdkEventIngestor,
+    loggerInstance?: Logger
   ): AndroidCtrlProxyClient {
     return new AndroidCtrlProxyClient(
       device,
@@ -1083,7 +1087,8 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       retryExecutor,
       crashEventSink,
       deviceConnectionLostNotifier,
-      sdkEventIngestor
+      sdkEventIngestor,
+      loggerInstance
     );
   }
 
@@ -1996,7 +2001,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       const attemptsSummary = shortCircuited
         ? `${result.attempts}/${maxAttempts} verification attempts (short-circuited: identical runner error on ${VERIFY_READY_IDENTICAL_RUNNER_ERROR_LIMIT} consecutive attempts)`
         : `${maxAttempts} verification attempts`;
-      logger.warn(`[CTRL_PROXY] Service not ready after ${attemptsSummary}${runnerErrorSuffix}`);
+      this.loggerInstance.warn(`[CTRL_PROXY] Service not ready after ${attemptsSummary}${runnerErrorSuffix}`);
       return false;
     }
 

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -12,7 +12,7 @@ import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClien
 import { AndroidCtrlProxyClient } from "../features/observe/android";
 import { IOSCtrlProxyClient } from "../features/observe/ios";
 import { createGlobalPerformanceTracker } from "../utils/PerformanceTracker";
-import { logger } from "../utils/logger";
+import { logger, type Logger } from "../utils/logger";
 import { DaemonState } from "../daemon/daemonState";
 import { createToolExecutionContext } from "./ToolExecutionContext";
 import { AppCleanupService, DefaultAppCleanupService } from "./AppCleanupService";
@@ -222,6 +222,7 @@ interface ToolRegistryPipelineOverrides {
 }
 
 class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
+  constructor(private readonly logger: Logger = logger) {}
   async resolveExecutionTarget(input: ExecutionTargetInput): Promise<ExecutionTargetContext> {
     const { name, args, options, deviceSessionManager } = input;
     const shouldResolveDevice = options.shouldEnsureDevice
@@ -354,7 +355,7 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
           IOSCtrlProxyClient.getInstance(device).bindSession(sessionUuid);
         }
       } catch (error) {
-        logger.debug(`[ToolRegistry] Best-effort CtrlProxy session bind skipped for ${name}: ${error}`);
+        this.logger.debug(`[ToolRegistry] Best-effort CtrlProxy session bind skipped for ${name}: ${error}`);
       }
     }
 
@@ -474,6 +475,7 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
 // the ToolRegistry constructor; tests instantiate it directly to exercise the
 // memory-audit wrapping decision and foreground-package lookup without a device.
 export class DefaultAuditRunner implements AuditRunner {
+  constructor(private readonly log: Logger = logger) {}
   async run(input: AuditRunnerInput): Promise<any> {
     const { name, args, device, handler, progress, signal } = input;
     if (!serverConfig.isMemPerfAuditEnabled() || device.platform !== "android") {
@@ -482,7 +484,7 @@ export class DefaultAuditRunner implements AuditRunner {
 
     const packageName = await this.getForegroundPackageName(device);
     if (!packageName) {
-      logger.warn(`[ToolRegistry] Could not determine foreground app, skipping memory audit for ${name}`);
+      this.log.warn(`[ToolRegistry] Could not determine foreground app, skipping memory audit for ${name}`);
       return handler(device, args, progress, signal);
     }
 
@@ -521,7 +523,7 @@ export class DefaultAuditRunner implements AuditRunner {
       const match = stdout.match(/\s+(\S+)\/\S+\}/);
       return match ? match[1] : null;
     } catch (error) {
-      logger.warn(`[ToolRegistry] Failed to get foreground package name: ${error}`);
+      this.log.warn(`[ToolRegistry] Failed to get foreground package name: ${error}`);
       return null;
     }
   }
@@ -722,7 +724,7 @@ export class DefaultPlanLifecycleManager implements PlanLifecycleManager {
 }
 
 // The registry that holds all tools
-class ToolRegistryClass {
+export class ToolRegistryClass {
   private tools: Map<string, RegisteredTool> = new Map();
   // Every live MCP server this registry has been registered with. In daemon
   // mode `registerWithServer` runs once per HTTP session, so notifications must
@@ -741,13 +743,13 @@ class ToolRegistryClass {
   private planLifecycleManager: PlanLifecycleManager;
   private toolDefinitionSchemaCache: Map<string, CachedToolDefinitionSchemas> = new Map();
 
-  constructor(timer: Timer = defaultTimer) {
+  constructor(timer: Timer = defaultTimer, loggerInstance: Logger = logger) {
     this.deviceSessionManager = DeviceSessionManager.getInstance();
     this.cleanupService = new DefaultAppCleanupService();
     this.toolCallRepository = new ToolCallRepository();
     this.timer = timer;
-    this.executionTargetResolver = new DefaultExecutionTargetResolver();
-    this.auditRunner = new DefaultAuditRunner();
+    this.executionTargetResolver = new DefaultExecutionTargetResolver(loggerInstance);
+    this.auditRunner = new DefaultAuditRunner(loggerInstance);
     this.navigationToolCallRecorder = new DefaultNavigationToolCallRecorder();
     this.afterToolCall = new DefaultAfterToolCallHandler();
     this.planLifecycleManager = new DefaultPlanLifecycleManager();

--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -7,7 +7,7 @@ import {
   AbortStrategy,
   DEFAULT_ABORT_STRATEGY,
 } from "../../models/Plan";
-import { logger } from "../logger";
+import { logger, type Logger } from "../logger";
 import { ToolRegistry, type RegisteredTool } from "../../server/toolRegistry";
 import { ActionableError } from "../../models";
 import { isDebugModeEnabled } from "../debug";
@@ -82,9 +82,11 @@ export interface PlanExecutor {
  */
 export class DefaultPlanExecutor implements PlanExecutor {
   private timer: Timer;
+  private logger: Logger;
 
-  constructor(timer: Timer = defaultTimer) {
+  constructor(timer: Timer = defaultTimer, loggerInstance: Logger = logger) {
     this.timer = timer;
+    this.logger = loggerInstance;
   }
 
   /**
@@ -496,7 +498,7 @@ export class DefaultPlanExecutor implements PlanExecutor {
     } catch (error) {
       const errorMessage = `${error}`;
       if (step.optional && !context.signal?.aborted && !(error instanceof ZodError)) {
-        logger.warn(`${context.logPrefix} optional step ${step.tool} threw; returning skipped status`, error);
+        this.logger.warn(`${context.logPrefix} optional step ${step.tool} threw; returning skipped status`, error);
         return {
           status: "skipped",
           error: errorMessage,
@@ -517,7 +519,7 @@ export class DefaultPlanExecutor implements PlanExecutor {
           context.deviceId,
           context.sessionUuid,
         );
-      logger.warn(`${context.logPrefix} step ${step.tool} threw; returning failed status`, error);
+      this.logger.warn(`${context.logPrefix} step ${step.tool} threw; returning failed status`, error);
       return {
         status: "failed",
         error: errorMessage,

--- a/test/db/keyedJsonConfigRepository.test.ts
+++ b/test/db/keyedJsonConfigRepository.test.ts
@@ -9,8 +9,8 @@ import {
   createVideoRecordingConfigRepository,
 } from "../../src/db/keyedJsonConfigRepository";
 import type { Database } from "../../src/db/types";
-import { logger } from "../../src/utils/logger";
 import { createTestDatabase } from "./testDbHelper";
+import { FakeLogger } from "../fakes/FakeLogger";
 
 describe("KeyedJsonConfigRepository", () => {
   let db: Kysely<Database>;
@@ -149,33 +149,26 @@ describe("KeyedJsonConfigRepository", () => {
   });
 
   test("returns null and logs a warning for malformed config JSON", async () => {
-    const warnings: string[] = [];
-    const originalWarn = logger.warn;
-    logger.warn = (message: string) => {
-      warnings.push(message);
-    };
+    const log = new FakeLogger();
+    const repo = new KeyedJsonConfigRepository<{ autoCapture: boolean }>({
+      tableName: "device_snapshot_configs",
+      loggerTag: "DeviceSnapshotConfigRepository",
+      db,
+      logger: log,
+    });
+    await db
+      .insertInto("device_snapshot_configs")
+      .values({
+        key: "global",
+        config_json: "{not-json",
+        updated_at: new Date().toISOString(),
+      })
+      .execute();
 
-    try {
-      const repo = new KeyedJsonConfigRepository<{ autoCapture: boolean }>({
-        tableName: "device_snapshot_configs",
-        loggerTag: "DeviceSnapshotConfigRepository",
-        db,
-      });
-      await db
-        .insertInto("device_snapshot_configs")
-        .values({
-          key: "global",
-          config_json: "{not-json",
-          updated_at: new Date().toISOString(),
-        })
-        .execute();
-
-      expect(await repo.getConfig()).toBeNull();
-      expect(warnings).toHaveLength(1);
-      expect(warnings[0]).toContain("[DeviceSnapshotConfigRepository] Failed to parse config JSON:");
-    } finally {
-      logger.warn = originalWarn;
-    }
+    expect(await repo.getConfig()).toBeNull();
+    expect(log.at("warn")).toContainEqual(expect.objectContaining({
+      message: expect.stringContaining("[DeviceSnapshotConfigRepository] Failed to parse config JSON:"),
+    }));
   });
 
   test("removes the per-table wrapper modules", () => {

--- a/test/doctor/automobile.test.ts
+++ b/test/doctor/automobile.test.ts
@@ -23,7 +23,7 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import AdmZip from "adm-zip";
 import crypto from "crypto";
-import { logger, type Logger } from "../../src/utils/logger";
+import { FakeLogger } from "../fakes/FakeLogger";
 
 describe("checkDaemonVersion", () => {
   test("returns pass status", () => {
@@ -358,25 +358,19 @@ describe("checkCtrlProxy", () => {
   });
 
   test("logs unexpected failures at warn before returning typed skip", async () => {
-    const warnings: string[] = [];
-    const originalWarn = logger.warn;
-    logger.warn = ((message: string) => {
-      warnings.push(message);
-    }) as Logger["warn"];
-    try {
-      const result = await checkCtrlProxy({
-        create: () => {
-          throw new Error("adb unavailable");
-        },
-      });
+    const log = new FakeLogger();
+    const result = await checkCtrlProxy({
+      create: () => {
+        throw new Error("adb unavailable");
+      },
+    }, { logger: log });
 
-      expect(result.name).toBe("CtrlProxy");
-      expect(result.status).toBe("skip");
-      expect(result.message).toBe("Could not check: adb unavailable");
-      expect(warnings).toEqual(["CtrlProxy check failed: adb unavailable"]);
-    } finally {
-      logger.warn = originalWarn;
-    }
+    expect(result.name).toBe("CtrlProxy");
+    expect(result.status).toBe("skip");
+    expect(result.message).toBe("Could not check: adb unavailable");
+    expect(log.at("warn")).toContainEqual(expect.objectContaining({
+      message: "CtrlProxy check failed: adb unavailable",
+    }));
   });
 
   test("fails malformed mirror configuration even when no devices are connected (#2815)", async () => {

--- a/test/features/navigation/NavigationScreenshotManager.test.ts
+++ b/test/features/navigation/NavigationScreenshotManager.test.ts
@@ -4,22 +4,7 @@ import {
 } from "../../../src/features/navigation/NavigationScreenshotManager";
 import { FileSystem } from "../../../src/utils/filesystem/DefaultFileSystem";
 import { FakeTimer } from "../../fakes/FakeTimer";
-import { logger, type Logger } from "../../../src/utils/logger";
-
-function captureDebugLogs(): { messages: string[]; restore(): void } {
-  const messages: string[] = [];
-  const originalDebug = logger.debug;
-  logger.debug = ((message: string) => {
-    messages.push(message);
-  }) as Logger["debug"];
-
-  return {
-    messages,
-    restore: () => {
-      logger.debug = originalDebug;
-    },
-  };
-}
+import { FakeLogger } from "../../fakes/FakeLogger";
 
 /**
  * Normalize a path to use forward slashes for consistent comparison.
@@ -172,18 +157,21 @@ describe("NavigationScreenshotManager", () => {
   let manager: NavigationScreenshotManager;
   let fakeFs: FakeFileSystem;
   let fakeTimer: FakeTimer;
+  let fakeLogger: FakeLogger;
   const screenshotDir = "/tmp/test-screenshots";
 
   beforeEach(() => {
     NavigationScreenshotManager.resetInstance();
     fakeFs = new FakeFileSystem();
     fakeTimer = new FakeTimer();
+    fakeLogger = new FakeLogger();
 
     manager = NavigationScreenshotManager.createForTesting({
       screenshotDir,
       maxCacheSizeBytes: 1024 * 1024, // 1MB for testing
       fileSystem: fakeFs,
       timer: fakeTimer,
+      logger: fakeLogger,
     });
   });
 
@@ -273,17 +261,13 @@ describe("NavigationScreenshotManager", () => {
     });
 
     test("logs directory read failures before returning null", async () => {
-      const debugLogs = captureDebugLogs();
       fakeFs.failReaddir(new Error("directory unavailable"));
-      try {
-        const result = await manager.findExistingScreenshot("com.test.app", "HomeScreen");
+      const result = await manager.findExistingScreenshot("com.test.app", "HomeScreen");
 
-        expect(result).toBeNull();
-        expect(debugLogs.messages).toHaveLength(1);
-        expect(debugLogs.messages[0]).toContain("[NAV_SCREENSHOT] Failed to find existing screenshot");
-      } finally {
-        debugLogs.restore();
-      }
+      expect(result).toBeNull();
+      expect(fakeLogger.at("debug")).toContainEqual(expect.objectContaining({
+        message: expect.stringContaining("[NAV_SCREENSHOT] Failed to find existing screenshot"),
+      }));
     });
   });
 
@@ -303,19 +287,15 @@ describe("NavigationScreenshotManager", () => {
     });
 
     test("logs read failures before returning null", async () => {
-      const debugLogs = captureDebugLogs();
       const path = `${screenshotDir}/test.webp`;
       fakeFs.setFile(path, Buffer.from("test image data"));
       fakeFs.failReadFileBuffer(new Error("read failed"));
-      try {
-        const result = await manager.readScreenshot(path);
+      const result = await manager.readScreenshot(path);
 
-        expect(result).toBeNull();
-        expect(debugLogs.messages).toHaveLength(1);
-        expect(debugLogs.messages[0]).toContain("[NAV_SCREENSHOT] Failed to read screenshot");
-      } finally {
-        debugLogs.restore();
-      }
+      expect(result).toBeNull();
+      expect(fakeLogger.at("debug")).toContainEqual(expect.objectContaining({
+        message: expect.stringContaining("[NAV_SCREENSHOT] Failed to read screenshot"),
+      }));
     });
   });
 

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -20,7 +20,7 @@ import { PortManager } from "../../../src/utils/PortManager";
 import { installInMemoryNavManager } from "../../helpers/navigationTestHarness";
 import type { HierarchySyncDiagnostics } from "../../../src/features/observe/android/types";
 import { DefaultRetryExecutor } from "../../../src/utils/retry/RetryExecutor";
-import { logger } from "../../../src/utils/logger";
+import { FakeLogger } from "../../fakes/FakeLogger";
 import {
   startDeviceDataStreamSocketServer,
   stopDeviceDataStreamSocketServer,
@@ -1597,7 +1597,6 @@ describe("AndroidCtrlProxyClient", function() {
       // failures (issue #2985). Without a consumer branch the awaiter would hang to timeout; this
       // asserts the pending request resolves immediately with a failed result carrying the message.
       const errorTimer = new FakeTimer();
-
       const { factory, getSocket } = createCapturingWebSocketFactory(errorTimer);
       const testClient = AndroidCtrlProxyClient.createForTesting(
         testDevice,
@@ -2274,19 +2273,20 @@ describe("AndroidCtrlProxyClient", function() {
       // log line (not just the dropped per-attempt debug), attributing the deterministic handler
       // failure instead of an anonymous "no hierarchy". Spy on the module logger's warn.
       const errorTimer = new FakeTimer();
+      const log = new FakeLogger();
       const { factory, getSocket } = createCapturingWebSocketFactory(errorTimer);
       const testClient = AndroidCtrlProxyClient.createForTesting(
         testDevice,
         fakeAdb,
         factory,
-        errorTimer
+        errorTimer,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        log
       );
-
-      const warnMessages: string[] = [];
-      const originalWarn = logger.warn;
-      logger.warn = (message: string) => {
-        warnMessages.push(message);
-      };
 
       try {
         testClient.invalidateCache();
@@ -2313,11 +2313,9 @@ describe("AndroidCtrlProxyClient", function() {
         const ready = await errorTimer.resolvePromise(verifyPromise);
 
         expect(ready).toBe(false);
-        const terminalWarn = warnMessages.find(m => m.includes("Service not ready"));
-        expect(terminalWarn).toBeDefined();
-        expect(terminalWarn).toContain(runnerText);
+        const terminalWarn = log.at("warn").find(({ message }) => message.includes("Service not ready"));
+        expect(terminalWarn?.message).toContain(runnerText);
       } finally {
-        logger.warn = originalWarn;
         await testClient.close();
       }
     });
@@ -2376,8 +2374,10 @@ describe("AndroidCtrlProxyClient", function() {
       testClient: AndroidCtrlProxyClient;
       getSocket: () => CapturingWebSocket | null;
       timer: FakeTimer;
+      log: FakeLogger;
     } => {
       const timer = new FakeTimer();
+      const log = new FakeLogger();
       const { factory, getSocket } = createCapturingWebSocketFactory(timer);
       const testClient = AndroidCtrlProxyClient.createForTesting(
         testDevice,
@@ -2386,23 +2386,17 @@ describe("AndroidCtrlProxyClient", function() {
         timer,
         undefined,
         // Retry delays must run on the SAME fake timer so the test controls them.
-        new DefaultRetryExecutor(timer)
+        new DefaultRetryExecutor(timer),
+        undefined,
+        undefined,
+        undefined,
+        log
       );
-      return { testClient, getSocket, timer };
-    };
-
-    const captureWarns = (): { warnMessages: string[]; restore: () => void } => {
-      const warnMessages: string[] = [];
-      const originalWarn = logger.warn;
-      logger.warn = (message: string) => {
-        warnMessages.push(message);
-      };
-      return { warnMessages, restore: () => { logger.warn = originalWarn; } };
+      return { testClient, getSocket, timer, log };
     };
 
     test("identical runner error on 2 consecutive attempts short-circuits the remaining retries", async function() {
-      const { testClient, getSocket, timer } = createShortCircuitTestClient();
-      const { warnMessages, restore } = captureWarns();
+      const { testClient, getSocket, timer, log } = createShortCircuitTestClient();
 
       try {
         testClient.invalidateCache();
@@ -2430,13 +2424,11 @@ describe("AndroidCtrlProxyClient", function() {
         expect(ready).toBe(false);
         // Short-circuited after 2 attempts: attempts 3-5 never sent a request.
         expect(sentHierarchyRequests(socket).length).toBe(2);
-        const terminalWarn = warnMessages.find(m => m.includes("Service not ready"));
-        expect(terminalWarn).toBeDefined();
-        expect(terminalWarn).toContain("short-circuited");
-        expect(terminalWarn).toContain("2/5 verification attempts");
-        expect(terminalWarn).toContain(runnerText);
+        const terminalWarn = log.at("warn").find(({ message }) => message.includes("Service not ready"));
+        expect(terminalWarn?.message).toContain("short-circuited");
+        expect(terminalWarn?.message).toContain("2/5 verification attempts");
+        expect(terminalWarn?.message).toContain(runnerText);
       } finally {
-        restore();
         await testClient.close();
       }
     });
@@ -2445,8 +2437,7 @@ describe("AndroidCtrlProxyClient", function() {
       // The regression guard for the startup path this method exists to verify: ONE handler
       // error during bring-up must not conclude "deterministic" — the retry still runs and a
       // successful push flips the verification to ready.
-      const { testClient, getSocket, timer } = createShortCircuitTestClient();
-      const { warnMessages, restore } = captureWarns();
+      const { testClient, getSocket, timer, log } = createShortCircuitTestClient();
 
       try {
         testClient.invalidateCache();
@@ -2478,16 +2469,14 @@ describe("AndroidCtrlProxyClient", function() {
         const ready = await timer.resolvePromise(verifyPromise);
 
         expect(ready).toBe(true);
-        expect(warnMessages.find(m => m.includes("Service not ready"))).toBeUndefined();
+        expect(log.at("warn").find(({ message }) => message.includes("Service not ready"))).toBeUndefined();
       } finally {
-        restore();
         await testClient.close();
       }
     });
 
     test("differing runner error texts never short-circuit (full retry budget)", async function() {
-      const { testClient, getSocket, timer } = createShortCircuitTestClient();
-      const { warnMessages, restore } = captureWarns();
+      const { testClient, getSocket, timer, log } = createShortCircuitTestClient();
 
       try {
         testClient.invalidateCache();
@@ -2509,13 +2498,11 @@ describe("AndroidCtrlProxyClient", function() {
         expect(ready).toBe(false);
         // All 3 attempts ran: varying error text is not treated as deterministic.
         expect(sentHierarchyRequests(socket).length).toBe(3);
-        const terminalWarn = warnMessages.find(m => m.includes("Service not ready"));
-        expect(terminalWarn).toBeDefined();
-        expect(terminalWarn).not.toContain("short-circuited");
-        expect(terminalWarn).toContain("after 3 verification attempts");
-        expect(terminalWarn).toContain("distinct cause 3");
+        const terminalWarn = log.at("warn").find(({ message }) => message.includes("Service not ready"));
+        expect(terminalWarn?.message).not.toContain("short-circuited");
+        expect(terminalWarn?.message).toContain("after 3 verification attempts");
+        expect(terminalWarn?.message).toContain("distinct cause 3");
       } finally {
-        restore();
         await testClient.close();
       }
     });
@@ -2524,8 +2511,7 @@ describe("AndroidCtrlProxyClient", function() {
       // error X -> timeout -> error X -> error X with maxAttempts=5: the timeout on attempt 2
       // breaks the streak, so the short-circuit lands after attempt 4 (streak rebuilt on 3+4),
       // not after attempt 3 (which a no-reset implementation would produce).
-      const { testClient, getSocket, timer } = createShortCircuitTestClient();
-      const { warnMessages, restore } = captureWarns();
+      const { testClient, getSocket, timer, log } = createShortCircuitTestClient();
 
       try {
         testClient.invalidateCache();
@@ -2561,12 +2547,10 @@ describe("AndroidCtrlProxyClient", function() {
         expect(ready).toBe(false);
         // 4 attempts, not 3 (timeout reset the streak) and not 5 (short-circuit stopped attempt 5).
         expect(sentHierarchyRequests(socket).length).toBe(4);
-        const terminalWarn = warnMessages.find(m => m.includes("Service not ready"));
-        expect(terminalWarn).toBeDefined();
-        expect(terminalWarn).toContain("short-circuited");
-        expect(terminalWarn).toContain("4/5 verification attempts");
+        const terminalWarn = log.at("warn").find(({ message }) => message.includes("Service not ready"));
+        expect(terminalWarn?.message).toContain("short-circuited");
+        expect(terminalWarn?.message).toContain("4/5 verification attempts");
       } finally {
-        restore();
         await testClient.close();
       }
     });

--- a/test/features/observe/DeviceServiceUtils.test.ts
+++ b/test/features/observe/DeviceServiceUtils.test.ts
@@ -22,22 +22,7 @@ import {
   type CachedHierarchy,
 } from "../../../src/features/observe/DeviceServiceUtils";
 import { FakeTimer } from "../../fakes/FakeTimer";
-import { logger, type Logger } from "../../../src/utils/logger";
-
-function captureDebugLogs(): { messages: string[]; restore(): void } {
-  const messages: string[] = [];
-  const originalDebug = logger.debug;
-  logger.debug = ((message: string) => {
-    messages.push(message);
-  }) as Logger["debug"];
-
-  return {
-    messages,
-    restore: () => {
-      logger.debug = originalDebug;
-    },
-  };
-}
+import { FakeLogger } from "../../fakes/FakeLogger";
 
 describe("DeviceServiceUtils", () => {
   // ===========================================================================
@@ -476,16 +461,13 @@ describe("DeviceServiceUtils", () => {
     });
 
     test("logs invalid JSON before returning null", () => {
-      const debugLogs = captureDebugLogs();
-      try {
-        const result = parseMessage("not valid json");
+      const log = new FakeLogger();
+      const result = parseMessage("not valid json", log);
 
-        expect(result).toBeNull();
-        expect(debugLogs.messages).toHaveLength(1);
-        expect(debugLogs.messages[0]).toContain("Failed to parse device service message");
-      } finally {
-        debugLogs.restore();
-      }
+      expect(result).toBeNull();
+      expect(log.at("debug")).toContainEqual(expect.objectContaining({
+        message: expect.stringContaining("Failed to parse device service message"),
+      }));
     });
 
     test("returns null for empty string", () => {

--- a/test/server/toolRegistry.collaborators.test.ts
+++ b/test/server/toolRegistry.collaborators.test.ts
@@ -10,7 +10,7 @@ import type { BootedDevice } from "../../src/models";
 import { serverConfig } from "../../src/utils/ServerConfig";
 import { defaultAdbClientFactory } from "../../src/utils/android-cmdline-tools/AdbClientFactory";
 import { DaemonState } from "../../src/daemon/daemonState";
-import { logger } from "../../src/utils/logger";
+import { FakeLogger } from "../fakes/FakeLogger";
 
 // Direct, fast unit coverage for the two ToolRegistry pipeline collaborators
 // called out in issue #3208. Both reach module-level singletons, so each test
@@ -106,30 +106,23 @@ describe("DefaultAuditRunner", () => {
       } as unknown as ReturnType<typeof originalCreate>;
     }) as typeof originalCreate;
 
-    const warnMessages: string[] = [];
-    const originalWarn = logger.warn;
-    logger.warn = ((message: string) => {
-      warnMessages.push(message);
-    }) as typeof logger.warn;
+    const log = new FakeLogger();
+    let handlerCalled = false;
+    const runner = new DefaultAuditRunner(log);
+    const result = await runner.run(
+      makeInput(androidDevice, async () => {
+        handlerCalled = true;
+        return { success: true, sentinel: "no-package" };
+      })
+    );
 
-    try {
-      let handlerCalled = false;
-      const runner = new DefaultAuditRunner();
-      const result = await runner.run(
-        makeInput(androidDevice, async () => {
-          handlerCalled = true;
-          return { success: true, sentinel: "no-package" };
-        })
-      );
-
-      expect(receivedCommand).toContain("dumpsys window");
-      expect(receivedCommand).toContain("mCurrentFocus");
-      expect(handlerCalled).toBe(true);
-      expect(result).toEqual({ success: true, sentinel: "no-package" });
-      expect(warnMessages.some(m => m.includes("skipping memory audit"))).toBe(true);
-    } finally {
-      logger.warn = originalWarn;
-    }
+    expect(receivedCommand).toContain("dumpsys window");
+    expect(receivedCommand).toContain("mCurrentFocus");
+    expect(handlerCalled).toBe(true);
+    expect(result).toEqual({ success: true, sentinel: "no-package" });
+    expect(log.at("warn")).toContainEqual(expect.objectContaining({
+      message: expect.stringContaining("skipping memory audit"),
+    }));
   });
 
   test("swallows adb failures during foreground lookup and still runs the handler", async () => {
@@ -140,23 +133,16 @@ describe("DefaultAuditRunner", () => {
       },
     })) as unknown as typeof originalCreate;
 
-    const warnMessages: string[] = [];
-    const originalWarn = logger.warn;
-    logger.warn = ((message: string) => {
-      warnMessages.push(message);
-    }) as typeof logger.warn;
+    const log = new FakeLogger();
+    const runner = new DefaultAuditRunner(log);
+    const result = await runner.run(
+      makeInput(androidDevice, async () => ({ success: true, sentinel: "adb-error" }))
+    );
 
-    try {
-      const runner = new DefaultAuditRunner();
-      const result = await runner.run(
-        makeInput(androidDevice, async () => ({ success: true, sentinel: "adb-error" }))
-      );
-
-      expect(result).toEqual({ success: true, sentinel: "adb-error" });
-      expect(warnMessages.some(m => m.includes("Failed to get foreground package name"))).toBe(true);
-    } finally {
-      logger.warn = originalWarn;
-    }
+    expect(result).toEqual({ success: true, sentinel: "adb-error" });
+    expect(log.at("warn")).toContainEqual(expect.objectContaining({
+      message: expect.stringContaining("Failed to get foreground package name"),
+    }));
   });
 });
 

--- a/test/server/toolRegistry.pipeline.test.ts
+++ b/test/server/toolRegistry.pipeline.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { z } from "zod";
-import { DefaultAfterToolCallHandler, ToolRegistry } from "../../src/server/toolRegistry";
+import { DefaultAfterToolCallHandler, ToolRegistry, ToolRegistryClass } from "../../src/server/toolRegistry";
 import type { BootedDevice } from "../../src/models";
 import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
-import { logger } from "../../src/utils/logger";
+import { FakeLogger } from "../fakes/FakeLogger";
 import { FakeDeviceSessionManager } from "../fakes/FakeDeviceSessionManager";
 import type { ObservationArtifactPayload, ObservationArtifactWriter } from "../../src/server/finalizeToolResponse";
 import { createStructuredToolResponse, stringifyToolResponse } from "../../src/utils/toolUtils";
@@ -156,13 +156,12 @@ describe("ToolRegistry device-aware pipeline", () => {
   test("logs and continues when best-effort CtrlProxy session bind fails", async () => {
     const fakeDeviceSessionManager = new FakeDeviceSessionManager();
     fakeDeviceSessionManager.setConnectedDevices([device]);
-    const originalDeviceSessionManager = (ToolRegistry as any).deviceSessionManager;
     const originalGetInstance = (AndroidCtrlProxyClient as any).getInstance;
-    const originalDebug = logger.debug;
-    const debugMessages: string[] = [];
+    const log = new FakeLogger();
+    const registry = new ToolRegistryClass(undefined, log);
 
-    (ToolRegistry as any).deviceSessionManager = fakeDeviceSessionManager;
-    (ToolRegistry as any).toolCallRepository = {
+    (registry as any).deviceSessionManager = fakeDeviceSessionManager;
+    (registry as any).toolCallRepository = {
       async recordToolCall(): Promise<void> {},
     };
     (AndroidCtrlProxyClient as any).getInstance = () => ({
@@ -170,27 +169,21 @@ describe("ToolRegistry device-aware pipeline", () => {
         throw new Error("bind unavailable");
       },
     });
-    logger.debug = (message: string) => {
-      debugMessages.push(message);
-    };
-
     try {
-      ToolRegistry.registerDeviceAware(
+      registry.registerDeviceAware(
         "bindFailureProbe",
         "Bind failure probe",
         z.object({}),
         async () => ({ success: true })
       );
 
-      const tool = ToolRegistry.getTool("bindFailureProbe")!;
+      const tool = registry.getTool("bindFailureProbe")!;
       await expect(tool.handler({ platform: "android", sessionUuid: "session-1" })).resolves.toEqual({ success: true });
-      expect(debugMessages).toEqual([
-        expect.stringContaining("[ToolRegistry] Best-effort CtrlProxy session bind skipped for bindFailureProbe: Error: bind unavailable"),
-      ]);
+      expect(log.at("debug")).toContainEqual(expect.objectContaining({
+        message: expect.stringContaining("[ToolRegistry] Best-effort CtrlProxy session bind skipped for bindFailureProbe: Error: bind unavailable"),
+      }));
     } finally {
-      (ToolRegistry as any).deviceSessionManager = originalDeviceSessionManager;
       (AndroidCtrlProxyClient as any).getInstance = originalGetInstance;
-      logger.debug = originalDebug;
     }
   });
 });

--- a/test/utils/planExecutorCatchLogging.test.ts
+++ b/test/utils/planExecutorCatchLogging.test.ts
@@ -3,14 +3,7 @@ import { z } from "zod";
 import { Plan } from "../../src/models/Plan";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import { DefaultPlanExecutor } from "../../src/utils/plan/PlanExecutor";
-import { logger } from "../../src/utils/logger";
-
-const originalWarn = logger.warn;
-
-interface WarnCall {
-  message: string;
-  args: unknown[];
-}
+import { FakeLogger } from "../fakes/FakeLogger";
 
 function registerThrowingTool(name: string): void {
   ToolRegistry.register(
@@ -24,18 +17,14 @@ function registerThrowingTool(name: string): void {
 }
 
 afterEach(() => {
-  logger.warn = originalWarn;
   ToolRegistry.clearTools();
 });
 
 describe("PlanExecutor catch logging", () => {
   test("warns before returning a skipped status from an optional thrown step", async () => {
-    const warnCalls: WarnCall[] = [];
-    logger.warn = (message: string, ...args: unknown[]) => {
-      warnCalls.push({ message, args });
-    };
+    const log = new FakeLogger();
     registerThrowingTool("optionalThrowingTool");
-    const executor = new DefaultPlanExecutor();
+    const executor = new DefaultPlanExecutor(undefined, log);
     const plan: Plan = {
       name: "optional catch logging",
       steps: [{ tool: "optionalThrowingTool", params: {}, optional: true }],
@@ -44,19 +33,16 @@ describe("PlanExecutor catch logging", () => {
     const result = await executor.executePlan(plan, 0);
 
     expect(result.success).toBe(true);
-    expect(warnCalls).toContainEqual({
+    expect(log.at("warn")).toContainEqual(expect.objectContaining({
       message: "[PLAN_STEP_1] optional step optionalThrowingTool threw; returning skipped status",
       args: [expect.objectContaining({ message: "optionalThrowingTool boom" })],
-    });
+    }));
   });
 
   test("warns before returning a failed status from a thrown step", async () => {
-    const warnCalls: WarnCall[] = [];
-    logger.warn = (message: string, ...args: unknown[]) => {
-      warnCalls.push({ message, args });
-    };
+    const log = new FakeLogger();
     registerThrowingTool("requiredThrowingTool");
-    const executor = new DefaultPlanExecutor();
+    const executor = new DefaultPlanExecutor(undefined, log);
     const plan: Plan = {
       name: "required catch logging",
       steps: [{ tool: "requiredThrowingTool", params: {} }],
@@ -65,9 +51,9 @@ describe("PlanExecutor catch logging", () => {
     const result = await executor.executePlan(plan, 0);
 
     expect(result.success).toBe(false);
-    expect(warnCalls).toContainEqual({
+    expect(log.at("warn")).toContainEqual(expect.objectContaining({
       message: "[PLAN_STEP_1] step requiredThrowingTool threw; returning failed status",
       args: [expect.objectContaining({ message: "requiredThrowingTool boom" })],
-    });
+    }));
   });
 });


### PR DESCRIPTION
## Summary

- inject defaulted loggers at the eight affected test seams
- replace shared-singleton monkey patches with `FakeLogger` assertions
- remove exact aggregate log-count assertions so unrelated diagnostics cannot flake the tests

## Root cause

The affected tests replaced methods on the process-wide logger singleton. Concurrent tests could write into those captures, causing CI-only failures.

## Validation

- `bun test test/features/observe/CtrlProxyClient.test.ts test/db/keyedJsonConfigRepository.test.ts test/server/toolRegistry.pipeline.test.ts test/features/navigation/NavigationScreenshotManager.test.ts test/features/observe/DeviceServiceUtils.test.ts test/doctor/automobile.test.ts test/server/toolRegistry.collaborators.test.ts test/utils/planExecutorCatchLogging.test.ts`
- `bun run turbo:validate`
- `bun run typecheck`

Closes #4149