### PR TITLE
fix(release): hash CtrlProxy xctest executable

### DIFF
--- a/scripts/ci/verify-release-integrity.sh
+++ b/scripts/ci/verify-release-integrity.sh
@@ -5,7 +5,7 @@
 #   1. Version equality — the npm version, every release manifest, the checksum
 #      registry, and the git tag must all name the SAME version. Nothing else
 #      enforces this; bump-versions.sh merely writes them together.
-#   2. iOS runner-binary checksum — registry[0].runnerSha256 must be a real
+#   2. iOS CtrlProxy executable checksum — registry[0].runnerSha256 must be a real
 #      sha256, not the "" default. Empty silently disables runner integrity
 #      verification for the simulator path.
 #
@@ -15,7 +15,7 @@
 #
 # Usage: verify-release-integrity.sh <version> [ipa-path]
 #   <version>  release version / git tag. A leading "v" is stripped.
-#   [ipa-path] optional built control-proxy.ipa. When given, the runner binary is
+#   [ipa-path] optional built control-proxy.ipa. When given, the CtrlProxy xctest executable is
 #              hashed straight out of the IPA and required to match the recorded
 #              registry[0].runnerSha256 — this *binds* the recorded hash to the
 #              artifact that ships. Without it, only the syntactic (64-hex,
@@ -98,7 +98,7 @@ check "android/gradle.properties VERSION_NAME (base)" "${gradle_version%-SNAPSHO
 registry_version="$(bun "$RELEASE_READER" version "$RELEASE_TS")"
 check "src/constants/release.ts registry[0].version" "$registry_version"
 
-# Runner-binary checksum must be populated on the newest registry entry. Empty
+# CtrlProxy executable checksum must be populated on the newest registry entry. Empty
 # means integrity verification is silently skipped — exactly the gap this gate
 # exists to catch. Read via the shared entry-anchored helper (single source of
 # truth with nightly.yml + verify-artifact-sha256.sh).
@@ -113,22 +113,22 @@ sha256_stdin() {
 }
 
 if [ -n "$IPA_PATH" ]; then
-  # Bind the recorded sha to the runner binary inside the shipped IPA (a zip of
-  # Build/Products), so this proves the constant matches what actually ships —
-  # not merely that some 64-hex string was written.
+  # Bind the recorded sha to the CtrlProxy xctest executable inside the shipped
+  # IPA (a zip of Build/Products), so this proves the constant matches the code
+  # that ships — not Xcode's generic XCTRunner stub.
   if [ ! -f "$IPA_PATH" ]; then
     errors+=("runner-sha binding: IPA not found at ${IPA_PATH}")
   else
     runner_entry="$(unzip -Z1 "$IPA_PATH" 2>/dev/null \
-      | grep -E 'CtrlProxyUITests-Runner\.app/CtrlProxyUITests-Runner$' | head -1 || true)"
+      | grep -E 'CtrlProxyUITests-Runner\.app/PlugIns/CtrlProxyUITests\.xctest/CtrlProxyUITests$' | head -1 || true)"
     if [ -z "$runner_entry" ]; then
-      errors+=("runner-sha binding: CtrlProxyUITests-Runner not found inside ${IPA_PATH}")
+      errors+=("runner-sha binding: CtrlProxyUITests not found inside ${IPA_PATH}")
     else
       actual_runner_sha="$(unzip -p "$IPA_PATH" "$runner_entry" | sha256_stdin)"
       if [ "$runner_sha" = "$actual_runner_sha" ]; then
-        echo "  OK  registry[0].runnerSha256 matches the runner inside the IPA"
+        echo "  OK  registry[0].runnerSha256 matches the CtrlProxy executable inside the IPA"
       else
-        errors+=("registry[0].runnerSha256 ('${runner_sha:-empty}') does not match the runner binary shipped in ${IPA_PATH} ('${actual_runner_sha}')")
+        errors+=("registry[0].runnerSha256 ('${runner_sha:-empty}') does not match the CtrlProxy executable shipped in ${IPA_PATH} ('${actual_runner_sha}')")
       fi
     fi
   fi
@@ -146,7 +146,7 @@ if [ "${#errors[@]}" -gt 0 ]; then
   done
   echo ""
   echo "All manifests + the checksum registry + the git tag must name the same"
-  echo "version, and the iOS runner checksum must be populated, before releasing."
+  echo "version, and the iOS CtrlProxy executable checksum must be populated, before releasing."
   exit 1
 fi
 

--- a/scripts/ios/ctrl-proxy-create-ipa.sh
+++ b/scripts/ios/ctrl-proxy-create-ipa.sh
@@ -172,8 +172,10 @@ cd "${PROJECT_ROOT}"
 IPA_SHA256=$(shasum -a 256 "${OUTPUT_PATH}" | cut -d' ' -f1)
 IPA_SIZE=$(stat -f%z "${OUTPUT_PATH}" 2>/dev/null || stat -c%s "${OUTPUT_PATH}" 2>/dev/null)
 
-# Compute SHA256 of runner binary
-RUNNER_BINARY="${SIM_DIR}/CtrlProxyUITests-Runner.app/CtrlProxyUITests-Runner"
+# Compute SHA256 of the CtrlProxy code executable. The outer
+# CtrlProxyUITests-Runner binary is Xcode's generic XCTRunner stub; the xctest
+# bundle is where the shipped CtrlProxy implementation lives.
+RUNNER_BINARY="${SIM_DIR}/CtrlProxyUITests-Runner.app/PlugIns/CtrlProxyUITests.xctest/CtrlProxyUITests"
 RUNNER_SHA256=$(shasum -a 256 "${RUNNER_BINARY}" | cut -d' ' -f1)
 
 echo ""

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -652,15 +652,21 @@ export class IOSCtrlProxyBuilder {
   }
 
   /**
-   * Get the runner binary path for simctl spawn
-   * Returns: <buildPath>/CtrlProxyUITests-Runner.app/CtrlProxyUITests-Runner
+   * Get the CtrlProxy xctest executable path for runner checksum verification.
+   * Returns: <buildPath>/CtrlProxyUITests-Runner.app/PlugIns/CtrlProxyUITests.xctest/CtrlProxyUITests
    */
   public async getRunnerBinaryPath(platform: IOSCtrlProxyPlatform = "simulator"): Promise<string | null> {
     const buildPath = await this.getBuildProductsPath(platform);
     if (!buildPath) {
       return null;
     }
-    const runnerBinaryPath = path.join(buildPath, "CtrlProxyUITests-Runner.app", "CtrlProxyUITests-Runner");
+    const runnerBinaryPath = path.join(
+      buildPath,
+      "CtrlProxyUITests-Runner.app",
+      "PlugIns",
+      "CtrlProxyUITests.xctest",
+      "CtrlProxyUITests"
+    );
     try {
       await fs.access(runnerBinaryPath);
       return runnerBinaryPath;

--- a/test/bats/pinned-tool-install.bats
+++ b/test/bats/pinned-tool-install.bats
@@ -79,7 +79,9 @@ EOF
   chmod +x "$STUB_DIR/swiftlint" "$STUB_DIR/swiftformat" "$STUB_DIR/shfmt"
 
   for script in scripts/swiftlint/apply_swiftlint.sh scripts/swiftlint/validate_swiftlint.sh scripts/swiftformat/apply_swiftformat.sh scripts/swiftformat/validate_swiftformat.sh scripts/shellcheck/apply_shfmt.sh; do
-    run env PATH="$STUB_DIR:$PATH" bash "$REPO_ROOT/$script"
+    # Formatter scripts prepend $HOME/.local/bin to PATH, so isolate HOME to
+    # ensure the deliberately mismatched stub is the executable under test.
+    run env HOME="$STUB_DIR/home" PATH="$STUB_DIR:$PATH" bash "$REPO_ROOT/$script"
     [ "$status" -ne 0 ]
     [[ "$output" == *"version mismatch"* ]]
   done

--- a/test/bats/verify-release-integrity.bats
+++ b/test/bats/verify-release-integrity.bats
@@ -70,6 +70,11 @@ run_gate_ipa() {
   run bash -c "cd '${TEST_ROOT}' && bash '${SCRIPT_ABS}' '$1' '$2'"
 }
 
+@test "IPA producer hashes the CtrlProxy xctest executable" {
+  grep -Fq 'RUNNER_BINARY="${SIM_DIR}/CtrlProxyUITests-Runner.app/PlugIns/CtrlProxyUITests.xctest/CtrlProxyUITests"' \
+    scripts/ios/ctrl-proxy-create-ipa.sh
+}
+
 sha256_of() {
   if command -v sha256sum >/dev/null 2>&1; then
     printf '%s' "$1" | sha256sum | cut -d' ' -f1
@@ -79,18 +84,36 @@ sha256_of() {
 }
 
 # make_ipa <runner-binary-content> <out.ipa> — build a zip mirroring the real
-# IPA layout (a zip of Build/Products) with the runner binary at the expected
-# path, and echo the sha256 of that binary's content.
+# IPA layout (a zip of Build/Products) with the CtrlProxy xctest executable at
+# the expected path, and echo the sha256 of that binary's content.
 make_ipa() {
   local content="$1" out="$2"
-  local stage runner_dir
+  local stage xctest_dir
   stage="$(mktemp -d)"
-  runner_dir="${stage}/Build/Products/Debug-iphonesimulator/CtrlProxyUITests-Runner.app"
-  mkdir -p "$runner_dir"
-  printf '%s' "$content" > "${runner_dir}/CtrlProxyUITests-Runner"
+  xctest_dir="${stage}/Build/Products/Debug-iphonesimulator/CtrlProxyUITests-Runner.app/PlugIns/CtrlProxyUITests.xctest"
+  mkdir -p "$xctest_dir"
+  printf '%s' "$content" > "${xctest_dir}/CtrlProxyUITests"
   ( cd "$stage" && zip -qr "$out" Build/Products/ )
   rm -rf "$stage"
   sha256_of "$content"
+}
+
+# make_ipa_with_stub <stub-content> <xctest-content> <out.ipa> — create the
+# full layout, including Xcode's generic runner stub, and return the hash of
+# the CtrlProxy code executable. The values deliberately differ so a consumer
+# that targets the stub cannot accidentally pass.
+make_ipa_with_stub() {
+  local stub_content="$1" xctest_content="$2" out="$3"
+  local stage runner_dir xctest_dir
+  stage="$(mktemp -d)"
+  runner_dir="${stage}/Build/Products/Debug-iphonesimulator/CtrlProxyUITests-Runner.app"
+  xctest_dir="${runner_dir}/PlugIns/CtrlProxyUITests.xctest"
+  mkdir -p "$xctest_dir"
+  printf '%s' "$stub_content" > "${runner_dir}/CtrlProxyUITests-Runner"
+  printf '%s' "$xctest_content" > "${xctest_dir}/CtrlProxyUITests"
+  ( cd "$stage" && zip -qr "$out" Build/Products/ )
+  rm -rf "$stage"
+  sha256_of "$xctest_content"
 }
 
 @test "passes when all versions align and runner sha is populated" {
@@ -188,23 +211,32 @@ PY
   [[ "$output" == *"registry[0].runnerSha256"* ]]
 }
 
-@test "binds recorded runner sha to the runner inside the IPA (match passes)" {
+@test "binds recorded runner sha to the CtrlProxy executable inside the IPA (match passes)" {
   local ipa="${TEST_ROOT}/control-proxy.ipa" sha
   sha="$(make_ipa "fake-runner-binary-bytes" "$ipa")"
   write_fixtures "$VERSION" "${VERSION}-SNAPSHOT" "$VERSION" "$sha"
   run_gate_ipa "$VERSION" "$ipa"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"matches the runner inside the IPA"* ]]
+  [[ "$output" == *"matches the CtrlProxy executable inside the IPA"* ]]
 }
 
-@test "fails when recorded runner sha does not match the IPA runner (substitution)" {
+@test "binds recorded runner sha to the CtrlProxy xctest executable, not the XCTRunner stub" {
+  local ipa="${TEST_ROOT}/control-proxy.ipa" sha
+  sha="$(make_ipa_with_stub "generic-xctrunner-stub" "ctrl-proxy-code" "$ipa")"
+  write_fixtures "$VERSION" "${VERSION}-SNAPSHOT" "$VERSION" "$sha"
+  run_gate_ipa "$VERSION" "$ipa"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"matches the CtrlProxy executable inside the IPA"* ]]
+}
+
+@test "fails when recorded runner sha does not match the IPA CtrlProxy executable (substitution)" {
   local ipa="${TEST_ROOT}/control-proxy.ipa"
   make_ipa "the-real-shipped-runner" "$ipa" >/dev/null
   # Record a valid-looking but WRONG sha (as if a tampered/stale runner shipped).
   write_fixtures "$VERSION" "${VERSION}-SNAPSHOT" "$VERSION" "$RUNNER_SHA"
   run_gate_ipa "$VERSION" "$ipa"
   [ "$status" -ne 0 ]
-  [[ "$output" == *"does not match the runner binary shipped"* ]]
+  [[ "$output" == *"does not match the CtrlProxy executable shipped"* ]]
 }
 
 @test "fails when the IPA path is given but the file is missing" {
@@ -214,7 +246,7 @@ PY
   [[ "$output" == *"IPA not found"* ]]
 }
 
-@test "fails when the IPA lacks the runner binary" {
+@test "fails when the IPA lacks the CtrlProxy xctest executable" {
   local ipa="${TEST_ROOT}/empty.ipa" stage
   stage="$(mktemp -d)"
   mkdir -p "${stage}/Build/Products/Debug-iphonesimulator"
@@ -224,5 +256,5 @@ PY
   write_fixtures "$VERSION" "${VERSION}-SNAPSHOT" "$VERSION" "$RUNNER_SHA"
   run_gate_ipa "$VERSION" "$ipa"
   [ "$status" -ne 0 ]
-  [[ "$output" == *"CtrlProxyUITests-Runner not found inside"* ]]
+  [[ "$output" == *"CtrlProxyUITests not found inside"* ]]
 }

--- a/test/utils/IOSCtrlProxyBuilder.test.ts
+++ b/test/utils/IOSCtrlProxyBuilder.test.ts
@@ -334,6 +334,21 @@ describe("IOSCtrlProxyBuilder", function() {
     });
   });
 
+  describe("getRunnerBinaryPath", function() {
+    test("returns the CtrlProxy xctest executable rather than the XCTRunner stub", async function() {
+      const buildDir = path.join(tempDir, "Build", "Products", "Debug-iphonesimulator");
+      const runnerDir = path.join(buildDir, "CtrlProxyUITests-Runner.app");
+      const xctestBinary = path.join(runnerDir, "PlugIns", "CtrlProxyUITests.xctest", "CtrlProxyUITests");
+      await fs.mkdir(path.dirname(xctestBinary), { recursive: true });
+      await fs.writeFile(path.join(runnerDir, "CtrlProxyUITests-Runner"), "xctrunner-stub");
+      await fs.writeFile(xctestBinary, "ctrl-proxy-code");
+
+      const builder = IOSCtrlProxyBuilder.getInstance({ derivedDataPath: tempDir });
+
+      expect(await builder.getRunnerBinaryPath()).toBe(xctestBinary);
+    });
+  });
+
   describe("getXctestrunPath", function() {
     test("should return null when xctestrun doesn't exist", async function() {
       const builder = IOSCtrlProxyBuilder.getInstance({


### PR DESCRIPTION
## Summary

Hashes the CtrlProxy xctest executable rather than Xcode's generic XCTRunner stub when producing and verifying iOS release artifacts. Adds an IPA fixture containing both binaries with different bytes so the integrity gate proves it selects the executable that contains CtrlProxy code.

## Linked Issue

Closes #4153

## Bug / Regression Context

- **Prior attempts:** None.
- **Observed symptom:** `runnerSha256` remained unchanged across CtrlProxy Swift changes because it covered the 179 KB XCTRunner stub rather than the xctest bundle executable.
- **Repro steps / conditions:** Build a Control Proxy IPA containing both the stub and `CtrlProxyUITests.xctest/CtrlProxyUITests`; the old integrity gate compares the recorded hash to the stub.

## Validation

- [x] `bats test/bats/verify-release-integrity.bats` passes (18 tests)
- [x] `shellcheck scripts/ios/ctrl-proxy-create-ipa.sh scripts/ci/verify-release-integrity.sh` passes
- [x] `bun run turbo:validate` passes
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] No interfaces, fakes, timers, generic helpers, or dependencies added
- [x] Rebased onto latest `main`, conflicts resolved

## Follow-ups

- [x] No follow-up issue required; the next release/nightly build will regenerate the corrected checksum.
