### PR TITLE
fix: update GitPython security dependency

### DIFF
--- a/scripts/github/uv.lock
+++ b/scripts/github/uv.lock
@@ -178,14 +178,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.51"
+version = "3.1.55"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/30/a8a0c15f9480dc91b5b7f11ebd26105e5f80898d7ff02da197fef35d8395/gitpython-3.1.51.tar.gz", hash = "sha256:22c9c94bb6b0b9f3c7157c684fece45a414cea204586b600beae6cd4570dcd6d", size = 223519, upload-time = "2026-07-12T13:40:07.922Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/ab/ba0d29f2fa2277ed6256b2ac09003494045355f3a10bf32f351761287870/gitpython-3.1.55.tar.gz", hash = "sha256:781e3b1624dad81b24e9524bf0297b69786a0706db2cbceec1e2b05c38e5152f", size = 225071, upload-time = "2026-07-23T02:52:43.246183Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/11/1232bb1ba52a230f20ff08e1b3df7cd9d43a71b61cc0a1c37941064fe4c7/gitpython-3.1.51-py3-none-any.whl", hash = "sha256:d5b29685708f3c80a56db040b665bfd69492c8e150b5848532af8013b686c5a4", size = 215246, upload-time = "2026-07-12T13:40:06.43Z" },
+    { url = "https://files.pythonhosted.org/packages/20/6a/d3b8208d2f8aac66abe8ccc1c23fa2c89464ec42cc71a601e95d05902428/gitpython-3.1.55-py3-none-any.whl", hash = "sha256:7c9ec1e69c158c081632ab35c41471e302c96db2ae42165036a5d2403378812e", size = 216590, upload-time = "2026-07-23T02:52:41.932445Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Update transitive GitPython from 3.1.51 to 3.1.55 in the GitHub docs automation lockfile.
- Resolves the vulnerable version range for [Dependabot alert #60](https://github.com/kaeawc/auto-mobile/security/dependabot/60) (GHSA-rwj8-pgh3-r573).
- Restore macOS fast-validation compatibility when Homebrew `gdate` is unavailable.

## Validation

- `uv lock --locked`
- `uv run --locked python -c 'import git; assert git.__version__ == "3.1.55"; print(git.__version__)'`
- `python3 -m compileall -q auto_mobile_docs deploy_pages.py`
- `bats test/bats/get-timestamp.bats`
- `bash scripts/all_fast_validate_checks.sh --no-parallel`
- `bun run turbo:validate`
- `./gradlew test` (from `android/`)
- `bash scripts/ios/swift-build.sh`
- `git diff --check`
