### PR TITLE
docs(webrtc): adopt MediaMTX as the supported WHIP/WHEP fanout

### DIFF
--- a/docs/design-docs/mcp/observe/webrtc-streaming.md
+++ b/docs/design-docs/mcp/observe/webrtc-streaming.md
@@ -106,14 +106,15 @@ mediamtx ./examples/mediamtx/mediamtx.yml   # serves WHIP + WHEP on :8889
 
 Then point the worker at a **per-stream** WHIP URL — MediaMTX takes the stream
 name from the URL path (`/<stream>/whip`); the publisher additionally appends a
-harmless `?streamId=` query that MediaMTX ignores:
+harmless `?streamId=` query that MediaMTX ignores. The stock config serves plain
+HTTP on `:8889` (enable `webrtcEncryption` for `https://`):
 
 ```bash
-export AUTOMOBILE_WEBRTC_WHIP_ENDPOINT="https://mediamtx-host:8889/ci-run-42/whip"
+export AUTOMOBILE_WEBRTC_WHIP_ENDPOINT="http://mediamtx-host:8889/ci-run-42/whip"
 ```
 
-Browsers subscribe at the matching WHEP URL `https://mediamtx-host:8889/ci-run-42/whep`
-(MediaMTX also serves a built-in reader page at `https://mediamtx-host:8889/ci-run-42`).
+Browsers subscribe at the matching WHEP URL `http://mediamtx-host:8889/ci-run-42/whep`
+(MediaMTX also serves a built-in reader page at `http://mediamtx-host:8889/ci-run-42`).
 Any WHIP/WHEP-compatible SFU (LiveKit, Janus, Cloudflare) works the same way.
 
 The bundled reference coordination server

--- a/docs/design-docs/mcp/observe/webrtc-streaming.md
+++ b/docs/design-docs/mcp/observe/webrtc-streaming.md
@@ -98,7 +98,7 @@ ingests the WHIP stream and fans it out to browsers over WHEP. It owns the
 per-subscriber RTP forwarding, keyframe recovery, and reconnect/migration that a
 multi-viewer stream needs — so AutoMobile stays out of the SFU business.
 
-Run it with the checked-in [example config](../../../../examples/mediamtx/mediamtx.yml):
+Run it with the checked-in [example config](https://github.com/kaeawc/auto-mobile/blob/main/examples/mediamtx/mediamtx.yml):
 
 ```bash
 mediamtx ./examples/mediamtx/mediamtx.yml   # serves WHIP + WHEP on :8889
@@ -137,8 +137,8 @@ webrtcServerCert: server.crt
 
 then use `https://` for both `AUTOMOBILE_WEBRTC_WHIP_ENDPOINT` and the WHEP URL
 (`https://mediamtx-host:8889/ci-run-42/whip` · `…/whep`). The
-[example config](../../../../examples/mediamtx/mediamtx.yml) carries these keys
-commented out.
+[example config](https://github.com/kaeawc/auto-mobile/blob/main/examples/mediamtx/mediamtx.yml)
+carries these keys commented out.
 
 The bundled reference coordination server
 ([`examples/webrtc-coordination-server/`](../../../../examples/webrtc-coordination-server/README.md))

--- a/docs/design-docs/mcp/observe/webrtc-streaming.md
+++ b/docs/design-docs/mcp/observe/webrtc-streaming.md
@@ -117,6 +117,25 @@ Browsers subscribe at the matching WHEP URL `http://mediamtx-host:8889/ci-run-42
 (MediaMTX also serves a built-in reader page at `http://mediamtx-host:8889/ci-run-42`).
 Any WHIP/WHEP-compatible SFU (LiveKit, Janus, Cloudflare) works the same way.
 
+**HTTPS.** The stock config is plain HTTP. For a reachable deployment, terminate
+TLS on the WebRTC listener: generate a certificate and enable it in the config —
+
+```bash
+openssl genrsa -out server.key 2048
+openssl req -new -x509 -sha256 -key server.key -out server.crt -days 3650
+```
+
+```yaml
+webrtcEncryption: yes
+webrtcServerKey: server.key
+webrtcServerCert: server.crt
+```
+
+then use `https://` for both `AUTOMOBILE_WEBRTC_WHIP_ENDPOINT` and the WHEP URL
+(`https://mediamtx-host:8889/ci-run-42/whip` · `…/whep`). The
+[example config](../../../../examples/mediamtx/mediamtx.yml) carries these keys
+commented out.
+
 The bundled reference coordination server
 ([`examples/webrtc-coordination-server/`](../../../../examples/webrtc-coordination-server/README.md))
 remains as a zero-dependency way to try the path locally, and is described below.

--- a/docs/design-docs/mcp/observe/webrtc-streaming.md
+++ b/docs/design-docs/mcp/observe/webrtc-streaming.md
@@ -113,6 +113,14 @@ HTTP on `:8889` (enable `webrtcEncryption` for `https://`):
 export AUTOMOBILE_WEBRTC_WHIP_ENDPOINT="http://mediamtx-host:8889/ci-run-42/whip"
 ```
 
+> **Reachable/containerized hosts** need more than `:8889` (which is only
+> signaling): expose the ICE media port `webrtcLocalUDPAddress: :8189/udp` (add
+> `webrtcAdditionalHosts` behind NAT, or use TURN), and enable auth — the stock
+> config is localhost-only, so a cross-host worker `401`s until the tokened
+> `authInternalUsers` block is enabled and `AUTOMOBILE_WEBRTC_WHIP_TOKEN` is set to
+> `<user>:<pass>`. See the CI guide's
+> [Prerequisites](../../../webrtc-streaming-ci-worker.md#prerequisites) for both.
+
 Browsers subscribe at the matching WHEP URL `http://mediamtx-host:8889/ci-run-42/whep`
 (MediaMTX also serves a built-in reader page at `http://mediamtx-host:8889/ci-run-42`).
 Any WHIP/WHEP-compatible SFU (LiveKit, Janus, Cloudflare) works the same way.

--- a/docs/design-docs/mcp/observe/webrtc-streaming.md
+++ b/docs/design-docs/mcp/observe/webrtc-streaming.md
@@ -118,9 +118,13 @@ Browsers subscribe at the matching WHEP URL `http://mediamtx-host:8889/ci-run-42
 Any WHIP/WHEP-compatible SFU (LiveKit, Janus, Cloudflare) works the same way.
 
 **HTTPS.** The stock config is plain HTTP. For a reachable deployment, terminate
-TLS on the WebRTC listener: generate a certificate and enable it in the config —
+TLS on the WebRTC listener with a **publicly-trusted** certificate (e.g. Let's
+Encrypt) — AutoMobile's WHIP client (Bun's `fetch`) and browser WHEP clients both
+reject an untrusted cert, so a self-signed cert works only if its CA is trusted on
+every publisher and viewer host. Enable it in the config —
 
 ```bash
+# publicly-trusted cert preferred; self-signed shown for a CA-trusted intranet:
 openssl genrsa -out server.key 2048
 openssl req -new -x509 -sha256 -key server.key -out server.crt -days 3650
 ```

--- a/docs/design-docs/mcp/observe/webrtc-streaming.md
+++ b/docs/design-docs/mcp/observe/webrtc-streaming.md
@@ -54,12 +54,17 @@ by common media servers (MediaMTX, LiveKit, Janus, Cloudflare).
                                            │  Location: resource URL
                                            ▼
                                  ┌───────────────────────┐   WHEP    ┌─────────┐
-                                 │ Coordination server   │◀─────────▶│ Browser │
-                                 │ (WHIP ingest → forward │  offer/   │ <video> │
-                                 │  RTP → WHEP egress)   │  answer   └─────────┘
-                                 │  GET /api/streams  ◀──┼── reconnect API
+                                 │ MediaMTX (SFU)        │◀─────────▶│ Browser │
+                                 │ WHIP ingest → forward  │  offer/   │ <video> │
+                                 │ RTP → WHEP egress     │  answer   └─────────┘
+                                 │ /<stream>/whip · /whep │
                                  └───────────────────────┘
 ```
+
+> The supported production fanout is **MediaMTX**; the AutoMobile publisher is
+> unchanged (a standard WHIP client). See
+> [Production fanout: MediaMTX](#production-fanout-mediamtx) below. The bundled
+> reference coordination server remains for zero-dependency local try-out.
 
 ### Components (in `src/features/webrtc/`)
 
@@ -83,6 +88,37 @@ Control plane:
 | `src/server/webrtcStreamManager.ts` | Per-device stream lifecycle; wires source ⇄ publisher; restarts the source on reconnect so a fresh keyframe follows |
 | `src/daemon/webrtcStreamSocketServer.ts` | `webrtc-stream.sock` request/response control (`start`/`stop`/`status`/`list`) |
 | `src/daemon/webrtcStreamClient.ts` | Minimal client for scripts/tooling |
+
+## Production fanout: MediaMTX
+
+The publisher only needs a **WHIP ingest endpoint**; it does not care what
+serves it. The supported production fanout is
+[MediaMTX](https://github.com/bluenviron/mediamtx), a single-binary SFU that
+ingests the WHIP stream and fans it out to browsers over WHEP. It owns the
+per-subscriber RTP forwarding, keyframe recovery, and reconnect/migration that a
+multi-viewer stream needs — so AutoMobile stays out of the SFU business.
+
+Run it with the checked-in [example config](../../../../examples/mediamtx/mediamtx.yml):
+
+```bash
+mediamtx ./examples/mediamtx/mediamtx.yml   # serves WHIP + WHEP on :8889
+```
+
+Then point the worker at a **per-stream** WHIP URL — MediaMTX takes the stream
+name from the URL path (`/<stream>/whip`); the publisher additionally appends a
+harmless `?streamId=` query that MediaMTX ignores:
+
+```bash
+export AUTOMOBILE_WEBRTC_WHIP_ENDPOINT="https://mediamtx-host:8889/ci-run-42/whip"
+```
+
+Browsers subscribe at the matching WHEP URL `https://mediamtx-host:8889/ci-run-42/whep`
+(MediaMTX also serves a built-in reader page at `https://mediamtx-host:8889/ci-run-42`).
+Any WHIP/WHEP-compatible SFU (LiveKit, Janus, Cloudflare) works the same way.
+
+The bundled reference coordination server
+([`examples/webrtc-coordination-server/`](../../../../examples/webrtc-coordination-server/README.md))
+remains as a zero-dependency way to try the path locally, and is described below.
 
 ## Why the daemon socket (not an MCP tool)
 
@@ -247,8 +283,10 @@ both the H.264 and PCMU tracks to WHEP subscribers and exposes `audio` plus
 - **Audio is opt-in and platform-constrained.** iOS audio requires Simulator-window
   capture; physical devices remain video-only. Android audio depends on
   `REMOTE_SUBMIX` availability for the shell-owned `video-server` process.
-- **Reference server is single-process/in-memory.** Use a hardened WHIP/WHEP SFU
-  (MediaMTX, LiveKit, Janus, Cloudflare) in production; the publisher is unchanged.
+- **Reference server is single-process/in-memory.** It exists for local
+  try-out only. Use the supported [MediaMTX](#production-fanout-mediamtx) fanout
+  (or another hardened WHIP/WHEP SFU — LiveKit, Janus, Cloudflare) in production;
+  the publisher is unchanged.
 - **Trickle ICE is opt-in.** By default the publisher gathers candidates before
   POSTing the WHIP offer (non-trickle), which is simplest and widely compatible.
   Set `AUTOMOBILE_WEBRTC_TRICKLE_ICE=1` (or `trickleIce: true`) to publish the

--- a/docs/using/environment-variables.md
+++ b/docs/using/environment-variables.md
@@ -109,7 +109,7 @@ overridden per request on the `webrtc-stream.sock` control socket.
 
 | Variable | Purpose | Default |
 |----------|---------|---------|
-| `AUTOMOBILE_WEBRTC_WHIP_ENDPOINT` | WHIP ingest URL. For MediaMTX use a per-stream path, e.g. `https://host:8889/<stream>/whip`. Required to start a stream unless passed per request. | unset |
+| `AUTOMOBILE_WEBRTC_WHIP_ENDPOINT` | WHIP ingest URL. For MediaMTX use a per-stream path, e.g. `http://host:8889/<stream>/whip` (the stock config is plain HTTP; enable `webrtcEncryption` for `https://`). Required to start a stream unless passed per request. | unset |
 | `AUTOMOBILE_WEBRTC_WHIP_TOKEN` | Bearer token sent as `Authorization: Bearer <token>` on WHIP ingest. | unset |
 | `AUTOMOBILE_WEBRTC_ICE_SERVERS` | Comma-separated STUN/TURN URLs, or a JSON array of `{urls,username,credential}`. | `stun:stun.l.google.com:19302` |
 | `AUTOMOBILE_WEBRTC_BITRATE_KBPS` | Target encoder bitrate (kbps). | encoder default |

--- a/docs/using/environment-variables.md
+++ b/docs/using/environment-variables.md
@@ -101,14 +101,15 @@ the resolved device type and runtime are logged at creation time.
 
 ## WebRTC screen streaming (`AUTOMOBILE_WEBRTC_*`)
 
-Defaults for pushing a device's screen to a coordination server over WebRTC/WHIP.
+Defaults for pushing a device's screen to a WHIP ingest server (the supported
+fanout is [MediaMTX](https://github.com/bluenviron/mediamtx)) over WebRTC/WHIP.
 See the [CI worker guide](../webrtc-streaming-ci-worker.md) and the
 [design doc](../design-docs/mcp/observe/webrtc-streaming.md). Any value can be
 overridden per request on the `webrtc-stream.sock` control socket.
 
 | Variable | Purpose | Default |
 |----------|---------|---------|
-| `AUTOMOBILE_WEBRTC_WHIP_ENDPOINT` | WHIP ingest URL of the coordination server. Required to start a stream unless passed per request. | unset |
+| `AUTOMOBILE_WEBRTC_WHIP_ENDPOINT` | WHIP ingest URL. For MediaMTX use a per-stream path, e.g. `https://host:8889/<stream>/whip`. Required to start a stream unless passed per request. | unset |
 | `AUTOMOBILE_WEBRTC_WHIP_TOKEN` | Bearer token sent as `Authorization: Bearer <token>` on WHIP ingest. | unset |
 | `AUTOMOBILE_WEBRTC_ICE_SERVERS` | Comma-separated STUN/TURN URLs, or a JSON array of `{urls,username,credential}`. | `stun:stun.l.google.com:19302` |
 | `AUTOMOBILE_WEBRTC_BITRATE_KBPS` | Target encoder bitrate (kbps). | encoder default |

--- a/docs/webrtc-streaming-ci-worker.md
+++ b/docs/webrtc-streaming-ci-worker.md
@@ -30,6 +30,11 @@ CI worker (AutoMobile daemon) ──WHIP──▶ MediaMTX (SFU) ──WHEP─�
   [reference server](../examples/webrtc-coordination-server/README.md) still
   exists for a zero-dependency local try-out, but MediaMTX is the supported
   production fanout.
+  - **Ports:** `8889` is only the WHIP/WHEP signaling listener. The media itself
+    flows over MediaMTX's ICE **UDP** listener `webrtcLocalUDPAddress: :8189` — a
+    containerized or firewalled deployment that exposes only `8889` gets WHIP/WHEP
+    setup failures or black video. Map/open `8189/udp` too, or configure a
+    TURN/TCP-only path.
 
 ## 1. Point the worker at your WHIP server
 
@@ -39,7 +44,10 @@ that MediaMTX ignores). The stock config serves plain **HTTP** on `:8889`, so us
 `http://`. For a reachable deployment, enable TLS and switch to `https://` — see
 [HTTPS](./design-docs/mcp/observe/webrtc-streaming.md#production-fanout-mediamtx)
 in the design doc for the certificate + `webrtcEncryption` steps. Set these
-before (or when) starting the daemon:
+before (or when) starting the daemon. Because MediaMTX keys the stream from the
+path, a **per-job** stream must carry its id in the endpoint path — the `start`
+request's `streamId` alone only sets the ignored query (see [Typical CI
+shape](#typical-ci-shape) for deriving both from `$CI_JOB_ID`):
 
 ```bash
 export AUTOMOBILE_WEBRTC_WHIP_ENDPOINT="http://mediamtx.example.com:8889/ci-run-42/whip"
@@ -126,8 +134,11 @@ echo '{"action":"status","streamId":"ci-run-42"}' | nc -U ~/.auto-mobile/webrtc-
 
 ```bash
 # 1. boot emulator/simulator + start daemon (project-specific)
-# 2. begin streaming so humans can watch the run live
-echo '{"action":"start","streamId":"'"$CI_JOB_ID"'"}' | nc -U ~/.auto-mobile/webrtc-stream.sock
+# 2. begin streaming so humans can watch the run live.
+#    Put $CI_JOB_ID in the WHIP *path* so each job is its own MediaMTX stream —
+#    passing only streamId would leave every job publishing to the same path.
+WHIP="http://mediamtx.example.com:8889/$CI_JOB_ID/whip"
+echo '{"action":"start","streamId":"'"$CI_JOB_ID"'","whipEndpoint":"'"$WHIP"'"}' | nc -U ~/.auto-mobile/webrtc-stream.sock
 # 3. run your AutoMobile test plan ...
 # 4. stop streaming on teardown (best-effort)
 echo '{"action":"stop","streamId":"'"$CI_JOB_ID"'"}'  | nc -U ~/.auto-mobile/webrtc-stream.sock || true

--- a/docs/webrtc-streaming-ci-worker.md
+++ b/docs/webrtc-streaming-ci-worker.md
@@ -1,8 +1,10 @@
 # Streaming a device's screen from a CI worker (WebRTC / WHIP)
 
 This guide shows how to make an AutoMobile daemon running on a CI worker **push**
-the screen of the Android or iOS device it is driving to a coordination server
-over WebRTC, so the stream can be watched live in a browser.
+the screen of the Android or iOS device it is driving to a WHIP ingest server
+over WebRTC, so the stream can be watched live in a browser. The supported
+server is [MediaMTX](https://github.com/bluenviron/mediamtx) — a single-binary
+SFU that accepts the WHIP stream and fans it out to browsers over WHEP.
 
 For the full design, see
 [WebRTC Screen Streaming](./design-docs/mcp/observe/webrtc-streaming.md), and
@@ -10,7 +12,7 @@ for the protocol rationale, see the
 [WebRTC standards map](./design-docs/mcp/observe/webrtc-standards-map.md).
 
 ```
-CI worker (AutoMobile daemon) ──WHIP──▶ coordination server ──WHEP──▶ browser
+CI worker (AutoMobile daemon) ──WHIP──▶ MediaMTX (SFU) ──WHEP──▶ browser
 ```
 
 ## Prerequisites
@@ -20,16 +22,23 @@ CI worker (AutoMobile daemon) ──WHIP──▶ coordination server ──WHEP
 - A connected/booted **Android** emulator or device (`adb devices` lists it), or
   a booted **iOS** simulator with the CtrlProxy screen streaming helper and
   local `ffmpeg` available.
-- A reachable **coordination server** that accepts WHIP ingest. Use the bundled
-  [reference server](../examples/webrtc-coordination-server/README.md) to try it
-  out, or a production SFU such as MediaMTX / LiveKit / Janus / Cloudflare.
+- A reachable **WHIP ingest server**. Run MediaMTX with the
+  [example config](../examples/mediamtx/mediamtx.yml) — `mediamtx ./examples/mediamtx/mediamtx.yml`
+  (or the official container) — which serves WHIP at `/<stream>/whip` and WHEP at
+  `/<stream>/whep` on port `8889`. Any WHIP-compatible SFU (LiveKit, Janus,
+  Cloudflare) works too. The bundled
+  [reference server](../examples/webrtc-coordination-server/README.md) still
+  exists for a zero-dependency local try-out, but MediaMTX is the supported
+  production fanout.
 
-## 1. Point the worker at your coordination server
+## 1. Point the worker at your WHIP server
 
-Set these before (or when) starting the daemon:
+MediaMTX derives the stream name from the URL **path**, so set the endpoint to a
+per-stream WHIP URL (the publisher also appends a harmless `?streamId=` query
+that MediaMTX ignores). Set these before (or when) starting the daemon:
 
 ```bash
-export AUTOMOBILE_WEBRTC_WHIP_ENDPOINT="https://coord.example.com/whip"
+export AUTOMOBILE_WEBRTC_WHIP_ENDPOINT="https://mediamtx.example.com:8889/ci-run-42/whip"
 # Optional:
 export AUTOMOBILE_WEBRTC_WHIP_TOKEN="<bearer token, if the server requires one>"
 export AUTOMOBILE_WEBRTC_ICE_SERVERS="stun:stun.l.google.com:19302"
@@ -65,7 +74,7 @@ Response:
 ```json
 {"success":true,"type":"webrtc_stream_response","action":"start",
  "stream":{"streamId":"ci-run-42","state":"connected",
-           "resourceUrl":"https://coord.example.com/whip/ci-run-42", ...}}
+           "resourceUrl":"https://mediamtx.example.com:8889/ci-run-42/whip/<session>", ...}}
 ```
 
 If multiple devices are attached, pass `"deviceId":"emulator-5554"` or the iOS
@@ -87,9 +96,10 @@ console.log(res.stream?.resourceUrl);
 
 ## 3. Watch it
 
-Open the coordination server's viewer (the reference server serves one at `/`)
-and pick `ci-run-42` from the stream list. The viewer discovers streams through
-the reconnect API (`GET /api/streams`) and connects over WHEP.
+Point a browser WHEP viewer at the matching WHEP URL — for the stream above,
+`https://mediamtx.example.com:8889/ci-run-42/whep`. MediaMTX serves a built-in
+reader page at `https://mediamtx.example.com:8889/ci-run-42`; any WHEP-capable
+`<video>` client works too.
 
 ## 4. Stop the stream
 
@@ -119,9 +129,10 @@ echo '{"action":"start","streamId":"'"$CI_JOB_ID"'"}' | nc -U ~/.auto-mobile/web
 echo '{"action":"stop","streamId":"'"$CI_JOB_ID"'"}'  | nc -U ~/.auto-mobile/webrtc-stream.sock || true
 ```
 
-The publisher reconnects automatically if the network blips; the browser viewer
-reconnects via the coordination server's reconnect API. Video streaming supports
-Android and iOS; optional audio works on Android and iOS Simulator windows.
+The publisher reconnects automatically if the network blips; MediaMTX keeps the
+WHEP path stable so the browser viewer reconnects to the same URL. Video
+streaming supports Android and iOS; optional audio works on Android and iOS
+Simulator windows.
 
 ## Troubleshooting
 
@@ -129,7 +140,7 @@ Android and iOS; optional audio works on Android and iOS Simulator windows.
 |---------|--------------------|
 | `No WHIP endpoint configured` | Set `AUTOMOBILE_WEBRTC_WHIP_ENDPOINT` or pass `whipEndpoint`. |
 | `No connected android devices found` | Emulator/device not booted, or pass the right `deviceId`. |
-| `WHIP ingest failed: … 401` | Coordination server requires a token — set `AUTOMOBILE_WEBRTC_WHIP_TOKEN`. |
+| `WHIP ingest failed: … 401` | The WHIP server requires a token — set `AUTOMOBILE_WEBRTC_WHIP_TOKEN` (for MediaMTX, matching the `authInternalUsers` publish password). |
 | Stream shows `connected` but the browser video is black | ICE could not traverse NAT — add a TURN server. |
 | Brief hitch every ~3 minutes | Expected `screenrecord` segment rotation (180 s cap). Build/provide `automobile-video.jar` to use the persistent encoder. |
 | Audio-enabled stream fails to start | The persistent `video-server` jar is missing, or the device build does not allow shell `REMOTE_SUBMIX` capture. Disable audio or use a compatible Android image. |

--- a/docs/webrtc-streaming-ci-worker.md
+++ b/docs/webrtc-streaming-ci-worker.md
@@ -35,6 +35,11 @@ CI worker (AutoMobile daemon) ──WHIP──▶ MediaMTX (SFU) ──WHEP─�
     containerized or firewalled deployment that exposes only `8889` gets WHIP/WHEP
     setup failures or black video. Map/open `8189/udp` too, or configure a
     TURN/TCP-only path.
+  - **Auth:** the stock config is **localhost-only** — its active `authInternalUsers`
+    entry admits `127.0.0.1`/`::1`, so a CI worker publishing from *another host*
+    gets `401` until you enable the config's commented tokened `authInternalUsers`
+    block. Then set `AUTOMOBILE_WEBRTC_WHIP_TOKEN` to that user's `<user>:<pass>`
+    (MediaMTX reads internal credentials from `Authorization: Bearer <user>:<pass>`).
 
 ## 1. Point the worker at your WHIP server
 
@@ -52,7 +57,7 @@ shape](#typical-ci-shape) for deriving both from `$CI_JOB_ID`):
 ```bash
 export AUTOMOBILE_WEBRTC_WHIP_ENDPOINT="http://mediamtx.example.com:8889/ci-run-42/whip"
 # Optional:
-export AUTOMOBILE_WEBRTC_WHIP_TOKEN="<bearer token, if the server requires one>"
+export AUTOMOBILE_WEBRTC_WHIP_TOKEN="<user>:<pass>"  # for cross-host MediaMTX; matches the tokened authInternalUsers block
 export AUTOMOBILE_WEBRTC_ICE_SERVERS="stun:stun.l.google.com:19302"
 # Optional tuning:
 export AUTOMOBILE_WEBRTC_BITRATE_KBPS="4000"
@@ -155,7 +160,7 @@ Simulator windows.
 |---------|--------------------|
 | `No WHIP endpoint configured` | Set `AUTOMOBILE_WEBRTC_WHIP_ENDPOINT` or pass `whipEndpoint`. |
 | `No connected android devices found` | Emulator/device not booted, or pass the right `deviceId`. |
-| `WHIP ingest failed: … 401` | The WHIP server requires a token — set `AUTOMOBILE_WEBRTC_WHIP_TOKEN` (for MediaMTX, matching the `authInternalUsers` publish password). |
+| `WHIP ingest failed: … 401` | The WHIP server requires auth, or you're publishing cross-host against the localhost-only stock config. Enable the tokened `authInternalUsers` block and set `AUTOMOBILE_WEBRTC_WHIP_TOKEN` to that user's `<user>:<pass>`. |
 | Stream shows `connected` but the browser video is black | ICE could not traverse NAT — add a TURN server. |
 | Brief hitch every ~3 minutes | Expected `screenrecord` segment rotation (180 s cap). Build/provide `automobile-video.jar` to use the persistent encoder. |
 | Audio-enabled stream fails to start | The persistent `video-server` jar is missing, or the device build does not allow shell `REMOTE_SUBMIX` capture. Disable audio or use a compatible Android image. |

--- a/docs/webrtc-streaming-ci-worker.md
+++ b/docs/webrtc-streaming-ci-worker.md
@@ -35,10 +35,13 @@ CI worker (AutoMobile daemon) ──WHIP──▶ MediaMTX (SFU) ──WHEP─�
 
 MediaMTX derives the stream name from the URL **path**, so set the endpoint to a
 per-stream WHIP URL (the publisher also appends a harmless `?streamId=` query
-that MediaMTX ignores). Set these before (or when) starting the daemon:
+that MediaMTX ignores). The stock config serves plain **HTTP** on `:8889`, so use
+`http://` — enable TLS (`webrtcEncryption` + cert/key in the config) and switch
+to `https://` for any reachable deployment. Set these before (or when) starting
+the daemon:
 
 ```bash
-export AUTOMOBILE_WEBRTC_WHIP_ENDPOINT="https://mediamtx.example.com:8889/ci-run-42/whip"
+export AUTOMOBILE_WEBRTC_WHIP_ENDPOINT="http://mediamtx.example.com:8889/ci-run-42/whip"
 # Optional:
 export AUTOMOBILE_WEBRTC_WHIP_TOKEN="<bearer token, if the server requires one>"
 export AUTOMOBILE_WEBRTC_ICE_SERVERS="stun:stun.l.google.com:19302"
@@ -74,7 +77,7 @@ Response:
 ```json
 {"success":true,"type":"webrtc_stream_response","action":"start",
  "stream":{"streamId":"ci-run-42","state":"connected",
-           "resourceUrl":"https://mediamtx.example.com:8889/ci-run-42/whip/<session>", ...}}
+           "resourceUrl":"http://mediamtx.example.com:8889/ci-run-42/whip/<session>", ...}}
 ```
 
 If multiple devices are attached, pass `"deviceId":"emulator-5554"` or the iOS
@@ -97,8 +100,8 @@ console.log(res.stream?.resourceUrl);
 ## 3. Watch it
 
 Point a browser WHEP viewer at the matching WHEP URL — for the stream above,
-`https://mediamtx.example.com:8889/ci-run-42/whep`. MediaMTX serves a built-in
-reader page at `https://mediamtx.example.com:8889/ci-run-42`; any WHEP-capable
+`http://mediamtx.example.com:8889/ci-run-42/whep`. MediaMTX serves a built-in
+reader page at `http://mediamtx.example.com:8889/ci-run-42`; any WHEP-capable
 `<video>` client works too.
 
 ## 4. Stop the stream

--- a/docs/webrtc-streaming-ci-worker.md
+++ b/docs/webrtc-streaming-ci-worker.md
@@ -23,7 +23,7 @@ CI worker (AutoMobile daemon) ──WHIP──▶ MediaMTX (SFU) ──WHEP─�
   a booted **iOS** simulator with the CtrlProxy screen streaming helper and
   local `ffmpeg` available.
 - A reachable **WHIP ingest server**. Run MediaMTX with the
-  [example config](../examples/mediamtx/mediamtx.yml) — `mediamtx ./examples/mediamtx/mediamtx.yml`
+  [example config](https://github.com/kaeawc/auto-mobile/blob/main/examples/mediamtx/mediamtx.yml) — `mediamtx ./examples/mediamtx/mediamtx.yml`
   (or the official container) — which serves WHIP at `/<stream>/whip` and WHEP at
   `/<stream>/whep` on port `8889`. Any WHIP-compatible SFU (LiveKit, Janus,
   Cloudflare) works too. The bundled
@@ -34,7 +34,10 @@ CI worker (AutoMobile daemon) ──WHIP──▶ MediaMTX (SFU) ──WHEP─�
     flows over MediaMTX's ICE **UDP** listener `webrtcLocalUDPAddress: :8189` — a
     containerized or firewalled deployment that exposes only `8889` gets WHIP/WHEP
     setup failures or black video. Map/open `8189/udp` too, or configure a
-    TURN/TCP-only path.
+    TURN/TCP-only path. Behind Docker/NAT, mapping the port is not enough if
+    MediaMTX advertises its private/container interface — set
+    `webrtcAdditionalHosts: [<public-ip-or-dns>]` so it hands out reachable ICE
+    candidates, otherwise signaling completes but ICE times out to black video.
   - **Auth:** the stock config is **localhost-only** — its active `authInternalUsers`
     entry admits `127.0.0.1`/`::1`, so a CI worker publishing from *another host*
     gets `401` until you enable the config's commented tokened `authInternalUsers`

--- a/docs/webrtc-streaming-ci-worker.md
+++ b/docs/webrtc-streaming-ci-worker.md
@@ -152,10 +152,10 @@ echo '{"action":"start","streamId":"'"$CI_JOB_ID"'","whipEndpoint":"'"$WHIP"'"}'
 echo '{"action":"stop","streamId":"'"$CI_JOB_ID"'"}'  | nc -U ~/.auto-mobile/webrtc-stream.sock || true
 ```
 
-The publisher reconnects automatically if the network blips; MediaMTX keeps the
-WHEP path stable so the browser viewer reconnects to the same URL. Video
-streaming supports Android and iOS; optional audio works on Android and iOS
-Simulator windows.
+The publisher reconnects automatically if the network blips. MediaMTX keeps the
+WHEP path stable, but a browser WHEP client must retry or recreate its peer
+connection after the publisher reconnects. Video streaming supports Android and
+iOS; optional audio works on Android and iOS Simulator windows.
 
 ## Troubleshooting
 

--- a/docs/webrtc-streaming-ci-worker.md
+++ b/docs/webrtc-streaming-ci-worker.md
@@ -36,9 +36,10 @@ CI worker (AutoMobile daemon) ──WHIP──▶ MediaMTX (SFU) ──WHEP─�
 MediaMTX derives the stream name from the URL **path**, so set the endpoint to a
 per-stream WHIP URL (the publisher also appends a harmless `?streamId=` query
 that MediaMTX ignores). The stock config serves plain **HTTP** on `:8889`, so use
-`http://` — enable TLS (`webrtcEncryption` + cert/key in the config) and switch
-to `https://` for any reachable deployment. Set these before (or when) starting
-the daemon:
+`http://`. For a reachable deployment, enable TLS and switch to `https://` — see
+[HTTPS](./design-docs/mcp/observe/webrtc-streaming.md#production-fanout-mediamtx)
+in the design doc for the certificate + `webrtcEncryption` steps. Set these
+before (or when) starting the daemon:
 
 ```bash
 export AUTOMOBILE_WEBRTC_WHIP_ENDPOINT="http://mediamtx.example.com:8889/ci-run-42/whip"

--- a/docs/webrtc-streaming-ci-worker.md
+++ b/docs/webrtc-streaming-ci-worker.md
@@ -71,7 +71,7 @@ export AUTOMOBILE_WEBRTC_AUDIO="1"
 
 > **NAT/firewall:** CI workers are usually behind NAT. Add a **TURN** server to
 > `AUTOMOBILE_WEBRTC_ICE_SERVERS` (JSON form) if a plain STUN server cannot
-> establish connectivity to your coordination server:
+> establish connectivity to your WHIP server:
 >
 > ```bash
 > export AUTOMOBILE_WEBRTC_ICE_SERVERS='[{"urls":"turn:turn.example.com:3478","username":"u","credential":"p"}]'

--- a/examples/mediamtx/mediamtx.yml
+++ b/examples/mediamtx/mediamtx.yml
@@ -1,0 +1,90 @@
+# MediaMTX configuration for AutoMobile WebRTC screen streaming.
+#
+# MediaMTX (https://github.com/bluenviron/mediamtx) is a single-binary media
+# server that ingests a WebRTC stream over WHIP and fans it out to browsers over
+# WHEP. It replaces the hand-rolled reference coordination server as the
+# supported production fanout: it owns per-subscriber RTP forwarding, keyframe
+# recovery, and reconnect/migration — so AutoMobile only has to publish.
+#
+# The AutoMobile publisher is unchanged: it is a standard RFC 9725 WHIP client.
+# Point AUTOMOBILE_WEBRTC_WHIP_ENDPOINT at a per-stream WHIP URL served here
+# (see the note on stream naming at the bottom of this file).
+#
+# This config targets MediaMTX v1.x. Keys occasionally change across releases;
+# the authoritative reference is the bundled mediamtx.yml in the MediaMTX repo.
+# Its functional correctness against a live server is exercised by the
+# publisher -> MediaMTX -> WHEP integration test (see issue #4290).
+
+###############################################################################
+# WebRTC (WHIP ingest + WHEP egress)
+###############################################################################
+
+# Enable the WebRTC server. It serves WHIP at /<name>/whip and WHEP at
+# /<name>/whep on webrtcAddress.
+webrtc: yes
+webrtcAddress: :8889
+
+# STUN/TURN for NAT traversal. Mirror whatever you pass to the publisher via
+# AUTOMOBILE_WEBRTC_ICE_SERVERS so both peers agree on how to connect.
+webrtcICEServers2:
+  - url: stun:stun.l.google.com:19302
+  # TURN example — uncomment and fill in for CI workers behind NAT that a plain
+  # STUN server cannot traverse:
+  # - url: turn:turn.example.com:3478
+  #   username: user
+  #   password: pass
+
+###############################################################################
+# Trim the surface: AutoMobile only uses WebRTC. Disable the other ingress and
+# egress protocols so nothing else is listening.
+###############################################################################
+rtsp: no
+rtmp: no
+hls: no
+srt: no
+
+###############################################################################
+# Authentication
+###############################################################################
+# By default MediaMTX permits anonymous publish/read only from localhost. For a
+# reachable deployment, require the bearer token AutoMobile sends as
+# `Authorization: Bearer <token>` (AUTOMOBILE_WEBRTC_WHIP_TOKEN). Configure an
+# internal user or JWT auth — see
+# https://github.com/bluenviron/mediamtx#authentication. Example (publish
+# requires a token; anyone may read):
+#
+# authInternalUsers:
+#   - user: publisher
+#     pass: <the same value as AUTOMOBILE_WEBRTC_WHIP_TOKEN>
+#     permissions:
+#       - action: publish
+#   - user: any
+#     permissions:
+#       - action: read
+
+###############################################################################
+# Paths (streams)
+###############################################################################
+# One path per stream, created on demand. AutoMobile publishes to
+# /<streamId>/whip and browsers subscribe at /<streamId>/whep. `all_others`
+# accepts any stream name without pre-declaring it.
+paths:
+  all_others:
+
+###############################################################################
+# Stream naming — how to set AUTOMOBILE_WEBRTC_WHIP_ENDPOINT
+###############################################################################
+# MediaMTX derives the stream name from the URL *path* (/<name>/whip), whereas
+# the AutoMobile publisher additionally appends a harmless `?streamId=<id>`
+# query parameter (a coordination-server convention MediaMTX ignores). So put
+# the stream name in the path:
+#
+#   export AUTOMOBILE_WEBRTC_WHIP_ENDPOINT="http://mediamtx-host:8889/ci-run-42/whip"
+#
+# or override per request over the control socket so the path carries the job id:
+#
+#   {"action":"start","whipEndpoint":"http://mediamtx-host:8889/$CI_JOB_ID/whip"}
+#
+# Watch it in a browser at the matching WHEP URL:
+#
+#   http://mediamtx-host:8889/ci-run-42/whep

--- a/examples/mediamtx/mediamtx.yml
+++ b/examples/mediamtx/mediamtx.yml
@@ -20,12 +20,23 @@
 ###############################################################################
 
 # Enable the WebRTC server. It serves WHIP at /<name>/whip and WHEP at
-# /<name>/whep on webrtcAddress. This listener is plain HTTP by default
-# (webrtcEncryption is off), so its URLs are http://…:8889/… — use those for the
-# local try-out. For a reachable deployment, set `webrtcEncryption: yes` with
-# `webrtcServerCert`/`webrtcServerKey` and switch the URLs to https://.
+# /<name>/whep on webrtcAddress.
 webrtc: yes
 webrtcAddress: :8889
+
+# --- TLS / HTTPS ---
+# This listener is plain HTTP by default (webrtcEncryption: no), so its URLs are
+# http://…:8889/… — use those for the local try-out. For a reachable deployment,
+# terminate TLS here and switch the URLs (and AUTOMOBILE_WEBRTC_WHIP_ENDPOINT) to
+# https://. MediaMTX does not ship a certificate; generate one, e.g.:
+#
+#   openssl genrsa -out server.key 2048
+#   openssl req -new -x509 -sha256 -key server.key -out server.crt -days 3650
+#
+# then uncomment (paths are relative to MediaMTX's working directory):
+# webrtcEncryption: yes
+# webrtcServerKey: server.key
+# webrtcServerCert: server.crt
 
 # STUN/TURN for NAT traversal. Mirror whatever you pass to the publisher via
 # AUTOMOBILE_WEBRTC_ICE_SERVERS so both peers agree on how to connect.

--- a/examples/mediamtx/mediamtx.yml
+++ b/examples/mediamtx/mediamtx.yml
@@ -20,7 +20,10 @@
 ###############################################################################
 
 # Enable the WebRTC server. It serves WHIP at /<name>/whip and WHEP at
-# /<name>/whep on webrtcAddress.
+# /<name>/whep on webrtcAddress. This listener is plain HTTP by default
+# (webrtcEncryption is off), so its URLs are http://…:8889/… — use those for the
+# local try-out. For a reachable deployment, set `webrtcEncryption: yes` with
+# `webrtcServerCert`/`webrtcServerKey` and switch the URLs to https://.
 webrtc: yes
 webrtcAddress: :8889
 
@@ -46,19 +49,29 @@ srt: no
 ###############################################################################
 # Authentication
 ###############################################################################
-# By default MediaMTX permits anonymous publish/read only from localhost. For a
-# reachable deployment, require the bearer token AutoMobile sends as
-# `Authorization: Bearer <token>` (AUTOMOBILE_WEBRTC_WHIP_TOKEN). Configure an
-# internal user or JWT auth — see
-# https://github.com/bluenviron/mediamtx#authentication. Example (publish
-# requires a token; anyone may read):
+# IMPORTANT: out of the box MediaMTX allows anonymous publish AND read from ANY
+# IP (its built-in `any` user has an empty `ips` list). On a reachable host that
+# is an open WHIP/WHEP endpoint. This example overrides that default to restrict
+# anonymous access to localhost, so copying it verbatim does not expose an open
+# ingest — the local try-out still works with no credentials.
+authInternalUsers:
+  - user: any
+    ips: ["127.0.0.1", "::1"]
+    permissions:
+      - action: publish
+      - action: read
+
+# Reachable deployment (the CI-worker use case): require the token AutoMobile
+# sends. Under internal auth MediaMTX reads credentials from an
+# `Authorization: Bearer <user>:<pass>` header, so set
+# AUTOMOBILE_WEBRTC_WHIP_TOKEN to "<user>:<pass>". Replace the block above with:
 #
 # authInternalUsers:
-#   - user: publisher
-#     pass: <the same value as AUTOMOBILE_WEBRTC_WHIP_TOKEN>
+#   - user: automobile
+#     pass: <choose-a-strong-secret>   # AUTOMOBILE_WEBRTC_WHIP_TOKEN="automobile:<choose-a-strong-secret>"
 #     permissions:
 #       - action: publish
-#   - user: any
+#   - user: any                        # readers open; tokenize the same way to lock down
 #     permissions:
 #       - action: read
 

--- a/examples/mediamtx/mediamtx.yml
+++ b/examples/mediamtx/mediamtx.yml
@@ -52,6 +52,11 @@ webrtcICEServers2:
   #   username: user
   #   password: pass
 
+# Behind Docker/NAT, MediaMTX otherwise advertises its private/container
+# interface as the ICE host, so signaling succeeds but media never connects.
+# List the public IP(s)/DNS name(s) clients use to reach the server:
+# webrtcAdditionalHosts: [1.2.3.4, mediamtx.example.com]
+
 ###############################################################################
 # Trim the surface: AutoMobile only uses WebRTC. Disable the other ingress and
 # egress protocols so nothing else is listening.

--- a/examples/mediamtx/mediamtx.yml
+++ b/examples/mediamtx/mediamtx.yml
@@ -12,8 +12,8 @@
 #
 # This config targets MediaMTX v1.x. Keys occasionally change across releases;
 # the authoritative reference is the bundled mediamtx.yml in the MediaMTX repo.
-# Its functional correctness against a live server is exercised by the
-# publisher -> MediaMTX -> WHEP integration test (see issue #4290).
+# Its functional correctness against a live server is exercised by a dedicated
+# publisher -> MediaMTX -> WHEP integration test.
 
 ###############################################################################
 # WebRTC (WHIP ingest + WHEP egress)
@@ -28,7 +28,11 @@ webrtcAddress: :8889
 # This listener is plain HTTP by default (webrtcEncryption: no), so its URLs are
 # http://…:8889/… — use those for the local try-out. For a reachable deployment,
 # terminate TLS here and switch the URLs (and AUTOMOBILE_WEBRTC_WHIP_ENDPOINT) to
-# https://. MediaMTX does not ship a certificate; generate one, e.g.:
+# https://. MediaMTX does not ship a certificate. Use a publicly-trusted
+# certificate (e.g. Let's Encrypt): AutoMobile's WHIP client is Bun's `fetch` and
+# browser WHEP clients both reject an untrusted cert, so a self-signed cert only
+# works if its CA is installed/trusted on every publisher and viewer host. A
+# self-signed cert can be generated for such a setup with:
 #
 #   openssl genrsa -out server.key 2048
 #   openssl req -new -x509 -sha256 -key server.key -out server.crt -days 3650
@@ -56,6 +60,7 @@ rtsp: no
 rtmp: no
 hls: no
 srt: no
+moq: no
 
 ###############################################################################
 # Authentication

--- a/examples/mediamtx/mediamtx.yml
+++ b/examples/mediamtx/mediamtx.yml
@@ -10,10 +10,11 @@
 # Point AUTOMOBILE_WEBRTC_WHIP_ENDPOINT at a per-stream WHIP URL served here
 # (see the note on stream naming at the bottom of this file).
 #
-# This config targets MediaMTX v1.x. Keys occasionally change across releases;
-# the authoritative reference is the bundled mediamtx.yml in the MediaMTX repo.
-# Its functional correctness against a live server is exercised by a dedicated
-# publisher -> MediaMTX -> WHEP integration test.
+# This config requires MediaMTX v1.19.2 or newer. Keys occasionally change
+# across releases; the authoritative reference is the bundled mediamtx.yml in
+# the MediaMTX repo.
+# Validate this configuration against the MediaMTX release you deploy before
+# exposing it outside a local try-out.
 
 ###############################################################################
 # WebRTC (WHIP ingest + WHEP egress)


### PR DESCRIPTION
## Summary

Makes **MediaMTX** the documented, supported WHIP/WHEP fanout for WebRTC screen
streaming. This is the first of a three-item sequence that retires the hand-rolled
reference coordination server in favor of a hardened SFU, while keeping
[werift](https://github.com/shinyoshiaki/werift-webrtc) as the publisher engine
and the native platform capture unchanged.

**Additive only** — a new example config plus doc prose. No `src/` changes, no
deletions. The publisher is already SFU-agnostic (`WhipClient` is a standard
RFC 9725 client; the endpoint comes from `AUTOMOBILE_WEBRTC_WHIP_ENDPOINT`), so
adopting MediaMTX needs zero code changes — only pointing that env var at a
per-stream WHIP URL.

Changes:
- **New `examples/mediamtx/mediamtx.yml`** — WHIP ingest + WHEP egress on `:8889`,
  with commented STUN/TURN and bearer-token (`authInternalUsers`) hooks that mirror
  the publisher's knobs, other protocols disabled, and a note on stream naming.
- **`docs/design-docs/mcp/observe/webrtc-streaming.md`** — architecture diagram now
  shows MediaMTX; a new *Production fanout: MediaMTX* section covers running it and
  pointing the worker at it; the reference server is reframed as local try-out only.
- **`docs/webrtc-streaming-ci-worker.md`** — MediaMTX is the primary path (bring-up,
  per-stream endpoint, WHEP viewing); reference server kept as a zero-dependency note.
- **`docs/using/environment-variables.md`** — `AUTOMOBILE_WEBRTC_WHIP_ENDPOINT`
  wording no longer says "of the coordination server" and shows the MediaMTX
  per-stream path form.

One accuracy detail captured in the docs and config: MediaMTX takes the stream
name from the URL **path** (`/<stream>/whip`), whereas the publisher appends a
harmless `?streamId=` **query** that MediaMTX ignores — so the endpoint must carry
the stream name in the path.

## Linked Issue

Closes #4289

## Validation

- [x] Diff scoped to `docs/**` + `examples/mediamtx/**` only; no `src/`/test changes
- [x] `mediamtx.yml` is valid YAML
- [x] `lychee` link check on the changed docs: 22 OK, 0 errors (new
      `#production-fanout-mediamtx` anchor and relative config links resolve)
- [x] `bun run lint` + `build` green (no code changed, so the test suite is
      unaffected relative to `main`)
- [x] Rebased onto latest `main` (includes #4278)

Note: `mkdocs build --strict` could not run in this environment (the `mermaid2`
plugin is not installed here) — link/anchor validation was done via `lychee`, the
CI docs gate.

## Follow-ups

Part of the sequence #4289 → #4290 (MediaMTX-backed integration test) → #4291
(retire the coordination server). The config's functional correctness against a
live server is pinned by #4290, which reuses this `mediamtx.yml`.
