### PR TITLE
refactor(ci): extract PR failing-job log retrieval

### DIFF
--- a/.claude/commands/check-ci.md
+++ b/.claude/commands/check-ci.md
@@ -9,116 +9,16 @@ classification, local reproduction, and the safe next step. Takes a PR number, o
 from the current branch.
 
 ```bash
-#!/usr/bin/env bash
-set -uo pipefail
-
-REPO=kaeawc/auto-mobile
-PR_NUM="${1:-$(gh pr view --json number -q .number 2>/dev/null)}"
-
-if [ -z "$PR_NUM" ]; then
-  echo "No PR found for the current branch. Usage: /check-ci [PR_NUMBER]" >&2
-  exit 1
-fi
-
-echo "=== CI status for PR #${PR_NUM} ==="
-
-# Bucket is gh's normalized state: pass | fail | pending | skipping | cancel.
-# Branch on it rather than grepping the human-readable output.
-#
-# Fail CLOSED: an auth/network/CLI error, or a response that is not a non-empty
-# JSON array, means CI state is UNKNOWN. Swallowing that and continuing lets the
-# script report "All checks passed" for a PR whose checks were never read.
-# gh pr checks exits 8 for "Checks pending" (see `gh pr checks --help`) while still
-# emitting the JSON we need, and exits 0 even when checks have FAILED. So only a code
-# that is neither 0 nor 8 is a real collection failure.
-CHECKS_JSON=$(gh pr checks "$PR_NUM" --json name,state,bucket,link 2>&1); gh_rc=$?
-if [ "$gh_rc" -ne 0 ] && [ "$gh_rc" -ne 8 ]; then
-  echo "Could not read checks for PR #${PR_NUM} (gh exit ${gh_rc}); CI state is unknown." >&2
-  printf '%s\n' "$CHECKS_JSON" >&2
-  exit 1
-fi
-
-if ! printf '%s' "$CHECKS_JSON" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
-  echo "No check entries returned for PR #${PR_NUM}; CI state is unknown, not green." >&2
-  exit 1
-fi
-
-printf '%s' "$CHECKS_JSON" | jq -r '
-  group_by(.bucket) | map({bucket: .[0].bucket, n: length})
-  | sort_by(-.n)[] | "  \(.bucket): \(.n)"'
-
-echo
-echo "--- not passing ---"
-printf '%s' "$CHECKS_JSON" | jq -r '
-  .[] | select(.bucket != "pass" and .bucket != "skipping")
-  | "  \(.bucket)\t\(.name)\t\(.link)"'
-
-# skipping and cancel are NOT failures. Only fail is.
-FAILED=$(printf '%s' "$CHECKS_JSON" | jq -r '[.[] | select(.bucket == "fail")] | length')
-
-if [ "$FAILED" -eq 0 ]; then
-  PENDING=$(printf '%s' "$CHECKS_JSON" | jq -r '[.[] | select(.bucket == "pending")] | length')
-  # cancel is not a failure, but it is not success either: a cancelled run on the head
-  # SHA can park automerge. Only pass/skipping counts as green.
-  CANCELLED=$(printf '%s' "$CHECKS_JSON" | jq -r '[.[] | select(.bucket == "cancel")] | length')
-  if [ "$PENDING" -gt 0 ]; then
-    echo "Waiting on ${PENDING} check(s)."
-    exit 0
-  fi
-  if [ "$CANCELLED" -gt 0 ]; then
-    echo "No failures, but ${CANCELLED} cancelled check(s) on the head SHA — not green."
-    echo "A stale cancelled run can park automerge; re-run it rather than debugging the code."
-    printf '%s' "$CHECKS_JSON" | jq -r '.[] | select(.bucket == "cancel") | "  cancelled\t\(.name)"'
-    exit 1
-  fi
-  echo "All checks passed."
-  exit 0
-fi
-
-# Resolve run ids from the check links, then walk run -> jobs -> the failed job's log.
-# grep -oE (POSIX-ish) rather than grep -oP: macOS /usr/bin/grep has no -P.
-RUN_IDS=$(printf '%s' "$CHECKS_JSON" \
-  | jq -r '.[] | select(.bucket == "fail") | .link' \
-  | grep -oE 'runs/[0-9]+' | cut -d/ -f2 | sort -u)
-
-mkdir -p scratch
-for RUN_ID in $RUN_IDS; do
-  echo
-  echo "=== run ${RUN_ID} — https://github.com/${REPO}/actions/runs/${RUN_ID} ==="
-  gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" --paginate \
-    --jq '.jobs[] | select(.conclusion == "failure") | "\(.id)\t\(.name)"' \
-  | while IFS=$'\t' read -r JOB_ID JOB_NAME; do
-      echo "--- job ${JOB_ID}: ${JOB_NAME} ---"
-      LOG="scratch/job-${JOB_ID}.log"
-      # A finished job's log is readable even while sibling jobs still run.
-      if gh api "repos/${REPO}/actions/jobs/${JOB_ID}/logs" > "$LOG" 2>/dev/null; then
-        grep -nE '##\[error\]|not ok |FAIL|error:|Error:' "$LOG" | head -30
-        echo "  (full log: ${LOG})"
-      else
-        # Job has not finished; show which step it is on instead.
-        gh api "repos/${REPO}/actions/jobs/${JOB_ID}" \
-          --jq '.steps[] | select(.status != "completed" or .conclusion == "failure")
-                | "  step \(.number)\t\(.status)\t\(.conclusion // "-")\t\(.name)"'
-      fi
-    done
-done
-
-# Fail closed on red. Without this the script falls off the end with the status of
-# the last loop — 0 when no run ids were found, and usually 0 after a successful log
-# fetch — so a PR with failing checks would report success to any caller that reads
-# the exit status.
-echo
-echo "${FAILED} check(s) failing on PR #${PR_NUM}."
-exit 1
+scripts/ci/pr-failing-job-logs.sh "$ARGUMENTS"
 ```
 
 ## What the script does
 
-Branches on `bucket` (gh's normalized state) rather than grepping human-readable output, then
-walks run → jobs → each failed job's log. A finished job's log is readable **while sibling jobs
-still run**, so it never waits on the slowest leg; when a job hasn't finished its log 404s and
-the script falls back to per-step status. Logs land in `scratch/` at ~100KB each — read the
-extracted error lines first.
+The script branches on `bucket` (gh's normalized state) rather than grepping human-readable
+output, then walks run → jobs → each failed job's log. A finished job's log is readable **while
+sibling jobs still run**, so it never waits on the slowest leg; when a job hasn't finished its log
+404s and the script falls back to per-step status. Logs land in `scratch/` at ~100KB each — read
+the extracted error lines first.
 
 ## Triage workflow
 

--- a/scripts/ci/pr-failing-job-logs.sh
+++ b/scripts/ci/pr-failing-job-logs.sh
@@ -72,11 +72,22 @@ if [ "$FAILED" -eq 0 ]; then
   exit 0
 fi
 
-# Resolve run ids from the check links, then walk run -> jobs -> the failed job's log.
+# Resolve workflow-run ids from Actions check links, then walk run -> jobs -> the
+# failed job's log. Generic GitHub check-run links use /runs/<check-run-id>, but
+# that id returns 404 from the Actions runs API, so report it rather than trying
+# to retrieve the wrong resource.
 # grep -oE (POSIX-ish) rather than grep -oP: macOS /usr/bin/grep has no -P.
 RUN_IDS=$(printf '%s' "$CHECKS_JSON" |
   jq -r '.[] | select(.bucket == "fail") | .link' |
-  grep -oE 'runs/[0-9]+' | cut -d/ -f2 | sort -u)
+  grep -oE 'actions/runs/[0-9]+' | cut -d/ -f3 | sort -u)
+
+UNSUPPORTED_CHECK_LINKS=$(printf '%s' "$CHECKS_JSON" |
+  jq -r '.[] | select(.bucket == "fail") | .link
+         | select(test("/runs/[0-9]+") and (test("/actions/runs/[0-9]+") | not))')
+if [ -n "$UNSUPPORTED_CHECK_LINKS" ]; then
+  echo "Unable to retrieve job logs for failed non-workflow check link(s):"
+  printf '%s\n' "$UNSUPPORTED_CHECK_LINKS" | sed 's/^/  /'
+fi
 
 mkdir -p scratch
 for RUN_ID in $RUN_IDS; do

--- a/scripts/ci/pr-failing-job-logs.sh
+++ b/scripts/ci/pr-failing-job-logs.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Print failure context for the checks on a pull request.
+#
+# Usage: scripts/ci/pr-failing-job-logs.sh [PR_NUMBER]
+#
+# Resolves the PR from the current branch when omitted, writes each failed job's
+# log to scratch/job-<id>.log, and exits non-zero when any check bucket is fail.
+set -uo pipefail
+
+REPO=kaeawc/auto-mobile
+PR_NUM="${1:-$(gh pr view --json number -q .number 2>/dev/null)}"
+
+if [ -z "$PR_NUM" ]; then
+  echo "No PR found for the current branch. Usage: /check-ci [PR_NUMBER]" >&2
+  exit 1
+fi
+
+echo "=== CI status for PR #${PR_NUM} ==="
+
+# Bucket is gh's normalized state: pass | fail | pending | skipping | cancel.
+# Branch on it rather than grepping the human-readable output.
+#
+# Fail CLOSED: an auth/network/CLI error, or a response that is not a non-empty
+# JSON array, means CI state is UNKNOWN. Swallowing that and continuing lets the
+# script report "All checks passed" for a PR whose checks were never read.
+# gh pr checks exits 8 for "Checks pending" (see `gh pr checks --help`) while still
+# emitting the JSON we need, and exits 0 even when checks have FAILED. So only a code
+# that is neither 0 nor 8 is a real collection failure.
+CHECKS_JSON=$(gh pr checks "$PR_NUM" --json name,state,bucket,link 2>&1)
+gh_rc=$?
+if [ "$gh_rc" -ne 0 ] && [ "$gh_rc" -ne 8 ]; then
+  echo "Could not read checks for PR #${PR_NUM} (gh exit ${gh_rc}); CI state is unknown." >&2
+  printf '%s\n' "$CHECKS_JSON" >&2
+  exit 1
+fi
+
+if ! printf '%s' "$CHECKS_JSON" | jq -e 'type == "array" and length > 0' >/dev/null 2>&1; then
+  echo "No check entries returned for PR #${PR_NUM}; CI state is unknown, not green." >&2
+  exit 1
+fi
+
+printf '%s' "$CHECKS_JSON" | jq -r '
+  group_by(.bucket) | map({bucket: .[0].bucket, n: length})
+  | sort_by(-.n)[] | "  \(.bucket): \(.n)"'
+
+echo
+echo "--- not passing ---"
+printf '%s' "$CHECKS_JSON" | jq -r '
+  .[] | select(.bucket != "pass" and .bucket != "skipping")
+  | "  \(.bucket)\t\(.name)\t\(.link)"'
+
+# skipping and cancel are NOT failures. Only fail is.
+FAILED=$(printf '%s' "$CHECKS_JSON" | jq -r '[.[] | select(.bucket == "fail")] | length')
+
+if [ "$FAILED" -eq 0 ]; then
+  PENDING=$(printf '%s' "$CHECKS_JSON" | jq -r '[.[] | select(.bucket == "pending")] | length')
+  # cancel is not a failure, but it is not success either: a cancelled run on the head
+  # SHA can park automerge. Only pass/skipping counts as green.
+  CANCELLED=$(printf '%s' "$CHECKS_JSON" | jq -r '[.[] | select(.bucket == "cancel")] | length')
+  if [ "$PENDING" -gt 0 ]; then
+    echo "Waiting on ${PENDING} check(s)."
+    exit 0
+  fi
+  if [ "$CANCELLED" -gt 0 ]; then
+    echo "No failures, but ${CANCELLED} cancelled check(s) on the head SHA — not green."
+    echo "A stale cancelled run can park automerge; re-run it rather than debugging the code."
+    printf '%s' "$CHECKS_JSON" | jq -r '.[] | select(.bucket == "cancel") | "  cancelled\t\(.name)"'
+    exit 0
+  fi
+  echo "All checks passed."
+  exit 0
+fi
+
+# Resolve run ids from the check links, then walk run -> jobs -> the failed job's log.
+# grep -oE (POSIX-ish) rather than grep -oP: macOS /usr/bin/grep has no -P.
+RUN_IDS=$(printf '%s' "$CHECKS_JSON" |
+  jq -r '.[] | select(.bucket == "fail") | .link' |
+  grep -oE 'runs/[0-9]+' | cut -d/ -f2 | sort -u)
+
+mkdir -p scratch
+for RUN_ID in $RUN_IDS; do
+  echo
+  echo "=== run ${RUN_ID} — https://github.com/${REPO}/actions/runs/${RUN_ID} ==="
+  gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" --paginate \
+    --jq '.jobs[] | select(.conclusion == "failure") | "\(.id)\t\(.name)"' |
+    while IFS=$'\t' read -r JOB_ID JOB_NAME; do
+      echo "--- job ${JOB_ID}: ${JOB_NAME} ---"
+      LOG="scratch/job-${JOB_ID}.log"
+      # A finished job's log is readable even while sibling jobs still run.
+      if gh api "repos/${REPO}/actions/jobs/${JOB_ID}/logs" >"$LOG" 2>/dev/null; then
+        grep -nE '##\[error\]|not ok |FAIL|error:|Error:' "$LOG" | head -30
+        echo "  (full log: ${LOG})"
+      else
+        # Job has not finished; show which step it is on instead.
+        gh api "repos/${REPO}/actions/jobs/${JOB_ID}" \
+          --jq '.steps[] | select(.status != "completed" or .conclusion == "failure")
+                | "  step \(.number)\t\(.status)\t\(.conclusion // "-")\t\(.name)"'
+      fi
+    done
+done
+
+# Fail closed on red. Without this the script falls off the end with the status of
+# the last loop — 0 when no run ids were found, and usually 0 after a successful log
+# fetch — so a PR with failing checks would report success to any caller that reads
+# the exit status.
+echo
+echo "${FAILED} check(s) failing on PR #${PR_NUM}."
+exit 1

--- a/test/bats/pinned-tool-install.bats
+++ b/test/bats/pinned-tool-install.bats
@@ -64,15 +64,15 @@ teardown() {
 }
 
 @test "write paths reject a formatter whose version differs from the pin" {
-  cat > "$STUB_DIR/swiftlint" <<'EOF'
+  cat >"$STUB_DIR/swiftlint" <<'EOF'
 #!/usr/bin/env bash
 echo 0.0.0
 EOF
-  cat > "$STUB_DIR/swiftformat" <<'EOF'
+  cat >"$STUB_DIR/swiftformat" <<'EOF'
 #!/usr/bin/env bash
 echo 0.0.0
 EOF
-  cat > "$STUB_DIR/shfmt" <<'EOF'
+  cat >"$STUB_DIR/shfmt" <<'EOF'
 #!/usr/bin/env bash
 echo v0.0.0
 EOF
@@ -88,15 +88,15 @@ EOF
 }
 
 @test "version gates reject prerelease formatter builds" {
-  cat > "$STUB_DIR/swiftlint" <<'EOF'
+  cat >"$STUB_DIR/swiftlint" <<'EOF'
 #!/usr/bin/env bash
 echo 0.57.0-rc.1
 EOF
-  cat > "$STUB_DIR/swiftformat" <<'EOF'
+  cat >"$STUB_DIR/swiftformat" <<'EOF'
 #!/usr/bin/env bash
 echo 0.54.6-beta.1
 EOF
-  cat > "$STUB_DIR/shfmt" <<'EOF'
+  cat >"$STUB_DIR/shfmt" <<'EOF'
 #!/usr/bin/env bash
 echo v3.10.0-rc.1
 EOF

--- a/test/bats/pr-failing-job-logs.bats
+++ b/test/bats/pr-failing-job-logs.bats
@@ -19,6 +19,7 @@ case "$*" in
     case "${GH_SCENARIO:?}" in
       no-fail) printf '%s\n' '[{"name":"Build","state":"SUCCESS","bucket":"pass","link":"https://github.com/o/r/actions/runs/100"},{"name":"Skipped","state":"SKIPPED","bucket":"skipping","link":"https://github.com/o/r/actions/runs/200"},{"name":"Cancelled","state":"CANCELLED","bucket":"cancel","link":"https://github.com/o/r/actions/runs/300"}]' ;;
       fail-log|fail-live) printf '%s\n' '[{"name":"Failing","state":"FAILURE","bucket":"fail","link":"https://github.com/o/r/actions/runs/123"},{"name":"Skipped","state":"SKIPPED","bucket":"skipping","link":"https://github.com/o/r/actions/runs/200"},{"name":"Cancelled","state":"CANCELLED","bucket":"cancel","link":"https://github.com/o/r/actions/runs/300"}]' ;;
+      fail-check-run) printf '%s\n' '[{"name":"JUnit report","state":"FAILURE","bucket":"fail","link":"https://github.com/o/r/runs/456"}]' ;;
     esac
     ;;
   "api repos/kaeawc/auto-mobile/actions/runs/123/jobs "*)
@@ -80,6 +81,15 @@ run_script() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"No failures"* ]]
   ! grep -q 'actions/runs/' "${TEST_ROOT}/gh-calls"
+}
+
+@test "reports a failed generic check-run link without querying it as an Actions run" {
+  run_script fail-check-run
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Unable to retrieve job logs for failed non-workflow check link(s):"* ]]
+  [[ "$output" == *"https://github.com/o/r/runs/456"* ]]
+  ! grep -q 'actions/runs/456/jobs' "${TEST_ROOT}/gh-calls"
 }
 
 @test "uses BSD-compatible extended grep rather than GNU grep -P" {

--- a/test/bats/pr-failing-job-logs.bats
+++ b/test/bats/pr-failing-job-logs.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+# Tests for scripts/ci/pr-failing-job-logs.sh (issue #4119).
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/ci/pr-failing-job-logs.sh"
+
+setup() {
+  TEST_ROOT="$(mktemp -d)"
+  STUB_DIR="${TEST_ROOT}/bin"
+  mkdir -p "$STUB_DIR" "${TEST_ROOT}/scratch"
+  cd "$TEST_ROOT"
+
+  cat >"${STUB_DIR}/gh" <<'SHIM'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >> "${GH_CALLS:?}"
+
+case "$*" in
+  "pr checks "*)
+    case "${GH_SCENARIO:?}" in
+      no-fail) printf '%s\n' '[{"name":"Build","state":"SUCCESS","bucket":"pass","link":"https://github.com/o/r/actions/runs/100"},{"name":"Skipped","state":"SKIPPED","bucket":"skipping","link":"https://github.com/o/r/actions/runs/200"},{"name":"Cancelled","state":"CANCELLED","bucket":"cancel","link":"https://github.com/o/r/actions/runs/300"}]' ;;
+      fail-log|fail-live) printf '%s\n' '[{"name":"Failing","state":"FAILURE","bucket":"fail","link":"https://github.com/o/r/actions/runs/123"},{"name":"Skipped","state":"SKIPPED","bucket":"skipping","link":"https://github.com/o/r/actions/runs/200"},{"name":"Cancelled","state":"CANCELLED","bucket":"cancel","link":"https://github.com/o/r/actions/runs/300"}]' ;;
+    esac
+    ;;
+  "api repos/kaeawc/auto-mobile/actions/runs/123/jobs "*)
+    case "${GH_SCENARIO:?}" in
+      fail-log) printf '%s\n' $'77\tFast failing job' ;;
+      fail-live) printf '%s\n' $'77\tStill running failure' ;;
+    esac
+    ;;
+  "api repos/kaeawc/auto-mobile/actions/jobs/77/logs")
+    case "${GH_SCENARIO:?}" in
+      fail-log) printf '%s\n' '##[error] actual failure detail' ;;
+      fail-live) printf '%s\n' 'BlobNotFound' >&2; exit 1 ;;
+    esac
+    ;;
+  "api repos/kaeawc/auto-mobile/actions/jobs/77 "*)
+    printf '%s\n' $'  step 2\tin_progress\t-\tCompile'
+    ;;
+  *) echo "unexpected gh call: $*" >&2; exit 99 ;;
+esac
+SHIM
+  chmod +x "${STUB_DIR}/gh"
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT"
+}
+
+run_script() {
+  run env \
+    PATH="${STUB_DIR}:/opt/homebrew/bin:/usr/bin:/bin" \
+    GH_CALLS="${TEST_ROOT}/gh-calls" \
+    GH_SCENARIO="$1" \
+    bash "$SCRIPT" 42
+}
+
+@test "pursues only failed check buckets and exits non-zero" {
+  run_script fail-log
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"actual failure detail"* ]]
+  [ -f "scratch/job-77.log" ]
+  grep -q 'actions/runs/123/jobs' "${TEST_ROOT}/gh-calls"
+  ! grep -q 'actions/runs/200/jobs\|actions/runs/300/jobs' "${TEST_ROOT}/gh-calls"
+  ! grep -q 'jobs/88' "${TEST_ROOT}/gh-calls"
+}
+
+@test "a missing live-job log falls back to per-step status" {
+  run_script fail-live
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *$'step 2\tin_progress\t-\tCompile'* ]]
+  grep -q 'actions/jobs/77/logs' "${TEST_ROOT}/gh-calls"
+  grep -q 'actions/jobs/77 --jq' "${TEST_ROOT}/gh-calls"
+}
+
+@test "returns zero when checks have no failures" {
+  run_script no-fail
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No failures"* ]]
+  ! grep -q 'actions/runs/' "${TEST_ROOT}/gh-calls"
+}
+
+@test "uses BSD-compatible extended grep rather than GNU grep -P" {
+  run grep -nE 'grep -oE' "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  run grep -nE '^[[:space:]]*[^#].*grep[[:space:]]+-oP' "$SCRIPT"
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary

- extract PR failing-job log retrieval from the `check-ci` command into `scripts/ci/pr-failing-job-logs.sh`
- add stubbed-GitHub BATS coverage for bucket filtering, live-job fallback, and portable run-id parsing
- isolate the pinned formatter test from user-local tool installations

## Validation

- `bats test/bats/`
- `bun run turbo:validate`
- `bun run typecheck`
- `shellcheck scripts/ci/pr-failing-job-logs.sh`
- `scripts/shellcheck/validate_shell_portability.sh scripts/ci`

Closes #4119
