### PR TITLE
fix: update GitPython security dependency

### DIFF
--- a/scripts/utils/get_timestamp.sh
+++ b/scripts/utils/get_timestamp.sh
@@ -5,8 +5,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   if command -v gdate &>/dev/null; then
     gdate +%s%3N
   else
-    echo "On MacOS you need to run 'brew install coreutils' to have gdate in order to capture millisecond timestamps."
-    exit 1
+    python3 -c 'import time; print(int(time.time() * 1000))'
   fi
 else
   date +%s%3N

--- a/test/bats/get-timestamp.bats
+++ b/test/bats/get-timestamp.bats
@@ -1,0 +1,8 @@
+#!/usr/bin/env bats
+
+@test "get_timestamp emits a millisecond epoch when macOS lacks gdate" {
+  run env OSTYPE=darwin /bin/bash scripts/utils/get_timestamp.sh
+
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^[0-9]{13}$ ]]
+}


### PR DESCRIPTION
## Summary

- Update transitive GitPython from 3.1.51 to 3.1.55 in the GitHub docs automation lockfile.
- Resolves the vulnerable version range for [Dependabot alert #60](https://github.com/kaeawc/auto-mobile/security/dependabot/60) (GHSA-rwj8-pgh3-r573).
- Restore macOS fast-validation compatibility when Homebrew `gdate` is unavailable.

## Validation

- `uv lock --locked`
- `uv run --locked python -c 'import git; assert git.__version__ == "3.1.55"; print(git.__version__)'`
- `python3 -m compileall -q auto_mobile_docs deploy_pages.py`
- `bats test/bats/get-timestamp.bats`
- `bash scripts/all_fast_validate_checks.sh --no-parallel`
- `bun run turbo:validate`
- `./gradlew test` (from `android/`)
- `bash scripts/ios/swift-build.sh`
- `git diff --check`
