### PR TITLE
fix: reap bounded install watchdog

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -806,7 +806,7 @@ jobs:
           retention-days: 7
 
   bats-tests:
-    timeout-minutes: 30
+    timeout-minutes: 5
     name: "BATS Shell Tests (${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
     needs: detect-changes

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1480,6 +1480,12 @@ bounded_watchdog_run() {
 
     local grace="${BOUNDED_KILL_GRACE_SECONDS}"
     local waited=0
+    # The watcher also starts a child (`sleep`). Give it a separate process
+    # group so cancelling a successful install cannot leave that sleep alive
+    # until PACKAGE_INSTALL_TIMEOUT_SECONDS expires on macOS bash.
+    local watcher_had_monitor=0
+    case "$-" in *m*) watcher_had_monitor=1 ;; esac
+    set -m
     (
         sleep "${secs}"
         if kill -0 "${cmd_pid}" 2> /dev/null; then
@@ -1508,6 +1514,7 @@ bounded_watchdog_run() {
         fi
     ) > /dev/null 2>&1 3>&- &
     local watcher_pid=$!
+    if [[ ${watcher_had_monitor} -eq 0 ]]; then set +m; fi
 
     local status=0
     wait "${cmd_pid}" 2> /dev/null || status=$?
@@ -1524,7 +1531,10 @@ bounded_watchdog_run() {
         wait "${watcher_pid}" 2> /dev/null || true
         status=124
     else
-        kill "${watcher_pid}" 2> /dev/null || true
+        # The watcher may have forked its `sleep` rather than exec'd it. Kill
+        # its process group too, otherwise that child can keep a BATS run alive
+        # for the full default 600-second package-install budget.
+        kill -TERM -"${watcher_pid}" 2> /dev/null || kill "${watcher_pid}" 2> /dev/null || true
         wait "${watcher_pid}" 2> /dev/null || true
         # The watcher can fire between the `wait` above and the kill here.
         if [[ -s "${fired_marker}" ]]; then status=124; fi

--- a/test/bats/install-bounded-package-install.bats
+++ b/test/bats/install-bounded-package-install.bats
@@ -62,6 +62,9 @@ teardown() {
   if [ -n "${SURVIVOR_PID_FILE:-}" ] && [ -s "${SURVIVOR_PID_FILE}" ]; then
     kill -KILL "$(cat "${SURVIVOR_PID_FILE}")" 2> /dev/null || true
   fi
+  if [ -n "${WATCHDOG_SLEEP_PID_FILE:-}" ] && [ -s "${WATCHDOG_SLEEP_PID_FILE}" ]; then
+    kill -KILL "$(cat "${WATCHDOG_SLEEP_PID_FILE}")" 2> /dev/null || true
+  fi
   export PATH="${ORIG_PATH}"
   "$RM" -rf "${TEST_DIR}"
 }
@@ -135,6 +138,39 @@ require_real_timeout() {
   run run_bounded_install "Installing thing" /bin/echo hello
   [ "$status" -eq 0 ]
   [[ "$output" == *"Installing thing: ok"* ]]
+}
+
+@test "a successful watchdog fallback reaps its pending sleep" {
+  # macOS bash can leave the watcher's `sleep` alive when only the watcher PID
+  # is signalled. That made otherwise-complete BATS runs wait the full default
+  # 600-second package-install timeout after printing their final assertion.
+  hide_real_timeout
+  export WATCHDOG_SLEEP_PID_FILE="${TEST_DIR}/watchdog-sleep.pid"
+  "$RM" -f "${STUB_BIN}/sleep"
+  cat > "${STUB_BIN}/sleep" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$1" == "30" ]]; then
+  printf '%s\n' "$$" > "${WATCHDOG_SLEEP_PID_FILE}"
+fi
+exec /bin/sleep "$@"
+STUB
+  cat > "${STUB_BIN}/wait-for-watchdog" <<'STUB'
+#!/usr/bin/env bash
+for _ in {1..100}; do
+  [[ -s "${WATCHDOG_SLEEP_PID_FILE}" ]] && exit 0
+  sleep 0.01
+done
+exit 1
+STUB
+  "$CHMOD" +x "${STUB_BIN}/sleep" "${STUB_BIN}/wait-for-watchdog"
+
+  PACKAGE_INSTALL_TIMEOUT_SECONDS=30
+  run run_bounded_install "Installing thing" wait-for-watchdog
+
+  [ "$status" -eq 0 ]
+  [ -s "${WATCHDOG_SLEEP_PID_FILE}" ]
+  run kill -0 "$(cat "${WATCHDOG_SLEEP_PID_FILE}")"
+  [ "$status" -ne 0 ]
 }
 
 @test "run_bounded_install still bounds a stall when no timeout binary exists" {


### PR DESCRIPTION
## Summary

- put the fallback package-install watchdog in its own process group
- terminate that group after a successful install so its pending sleep cannot hold macOS BATS jobs open
- add a regression test that records and verifies cleanup of the watchdog sleep process
- cap the PR BATS job at five minutes as a backstop

## Root cause

The success path cancelled only the watchdog shell PID. On macOS, its child `sleep` could remain alive for the default 600-second install timeout after every BATS assertion had completed.

## Validation

- `bats test/bats/`
- `shellcheck scripts/install.sh`
- `git diff --check`
