### PR TITLE
fix(observe): name a locked keyguard as the cause of a hierarchy failure (#4281)

### DIFF
--- a/src/features/observe/ViewHierarchy.ts
+++ b/src/features/observe/ViewHierarchy.ts
@@ -213,7 +213,7 @@ export class ViewHierarchy implements ViewHierarchyInterface {
       logger.warn("[VIEW_HIERARCHY] Accessibility service returned null hierarchy");
       return {
         hierarchy: {
-          error: await this.describeHierarchyFailure("Failed to retrieve view hierarchy from accessibility service", signal)
+          error: await this.describeHierarchyFailure("Failed to retrieve view hierarchy from accessibility service", signal, timeoutMs)
         },
         updatedAt: this.timer.now()
       };
@@ -223,7 +223,7 @@ export class ViewHierarchy implements ViewHierarchyInterface {
       logger.warn(`[VIEW_HIERARCHY] Failed to get hierarchy from accessibility service after ${duration}ms:`, err);
       return {
         hierarchy: {
-          error: await this.describeHierarchyFailure("Failed to retrieve view hierarchy", signal)
+          error: await this.describeHierarchyFailure("Failed to retrieve view hierarchy", signal, timeoutMs)
         },
         updatedAt: this.timer.now()
       };
@@ -244,16 +244,24 @@ export class ViewHierarchy implements ViewHierarchyInterface {
    * falls back to `fallback`, so this never turns a real transport error into a
    * misleading "device is locked".
    */
-  private async describeHierarchyFailure(fallback: string, signal?: AbortSignal): Promise<string> {
+  private async describeHierarchyFailure(
+    fallback: string,
+    signal?: AbortSignal,
+    timeoutMs?: number
+  ): Promise<string> {
     if (this.device.platform !== "android") {
       return fallback;
     }
-    // Never spend time improving the error wording past the caller's deadline: a
-    // short-budget caller (e.g. the keyboard confirmation loop) may already have
-    // consumed its per-read budget in getAccessibilityHierarchy, so skip the probe
-    // when the signal is aborted, and thread it in so an in-flight dumpsys aborts
-    // with the request rather than blocking on its own (#4281 review).
-    if (signal?.aborted) {
+    // Only reword the error for an unbudgeted (interactive) observe. A caller that
+    // bounds each read -- an aborted signal, or a per-read `timeoutMs` like the
+    // keyboard confirmation poll -- is latency-sensitive, and getDeviceLock's
+    // `dumpsys window policy` is not itself bounded when no signal aborts it (the
+    // keyboard path relies on `timeoutMs`, not a signal). So skip the probe rather
+    // than risk blocking past the caller's deadline just to improve wording; the
+    // main observe path (HierarchyCollector) passes no timeoutMs and still gets the
+    // lock-specific message (#4281 review). The signal is still threaded through so
+    // an in-flight dumpsys aborts with the request when one is present.
+    if (signal?.aborted || timeoutMs !== undefined) {
       return fallback;
     }
     try {

--- a/src/features/observe/ViewHierarchy.ts
+++ b/src/features/observe/ViewHierarchy.ts
@@ -232,7 +232,7 @@ export class ViewHierarchy implements ViewHierarchyInterface {
 
   /**
    * Turn a generic Android hierarchy failure into a lock-specific message when
-   * the keyguard is showing (#4281).
+   * the keyguard is actually blocking the app (#4281).
    *
    * A locked device — most commonly a fresh boot before the keyguard is first
    * dismissed — blocks Android from binding non-encryption-aware accessibility
@@ -266,7 +266,7 @@ export class ViewHierarchy implements ViewHierarchyInterface {
     }
     try {
       const lock = await this.adbFactory.create(this.device).getDeviceLock(signal);
-      if (!lock?.keyguardShowing) {
+      if (!lock?.locked) {
         return fallback;
       }
       const preamble =

--- a/src/features/observe/ViewHierarchy.ts
+++ b/src/features/observe/ViewHierarchy.ts
@@ -213,7 +213,7 @@ export class ViewHierarchy implements ViewHierarchyInterface {
       logger.warn("[VIEW_HIERARCHY] Accessibility service returned null hierarchy");
       return {
         hierarchy: {
-          error: await this.describeHierarchyFailure("Failed to retrieve view hierarchy from accessibility service")
+          error: await this.describeHierarchyFailure("Failed to retrieve view hierarchy from accessibility service", signal)
         },
         updatedAt: this.timer.now()
       };
@@ -223,7 +223,7 @@ export class ViewHierarchy implements ViewHierarchyInterface {
       logger.warn(`[VIEW_HIERARCHY] Failed to get hierarchy from accessibility service after ${duration}ms:`, err);
       return {
         hierarchy: {
-          error: await this.describeHierarchyFailure("Failed to retrieve view hierarchy")
+          error: await this.describeHierarchyFailure("Failed to retrieve view hierarchy", signal)
         },
         updatedAt: this.timer.now()
       };
@@ -244,12 +244,20 @@ export class ViewHierarchy implements ViewHierarchyInterface {
    * falls back to `fallback`, so this never turns a real transport error into a
    * misleading "device is locked".
    */
-  private async describeHierarchyFailure(fallback: string): Promise<string> {
+  private async describeHierarchyFailure(fallback: string, signal?: AbortSignal): Promise<string> {
     if (this.device.platform !== "android") {
       return fallback;
     }
+    // Never spend time improving the error wording past the caller's deadline: a
+    // short-budget caller (e.g. the keyboard confirmation loop) may already have
+    // consumed its per-read budget in getAccessibilityHierarchy, so skip the probe
+    // when the signal is aborted, and thread it in so an in-flight dumpsys aborts
+    // with the request rather than blocking on its own (#4281 review).
+    if (signal?.aborted) {
+      return fallback;
+    }
     try {
-      const lock = await this.adbFactory.create(this.device).getDeviceLock();
+      const lock = await this.adbFactory.create(this.device).getDeviceLock(signal);
       if (!lock?.keyguardShowing) {
         return fallback;
       }

--- a/src/features/observe/ViewHierarchy.ts
+++ b/src/features/observe/ViewHierarchy.ts
@@ -33,6 +33,7 @@ export class ViewHierarchy implements ViewHierarchyInterface {
   private parser: ElementParser;
   private geometry: ElementGeometry;
   private accessibilityServiceClient: AndroidCtrlProxyClient;
+  private adbFactory: AdbClientFactory;
   private timer: Timer;
 
   /**
@@ -52,6 +53,7 @@ export class ViewHierarchy implements ViewHierarchyInterface {
     this.geometry = new DefaultElementGeometry();
 
     this.accessibilityServiceClient = accessibilityServiceClient || AndroidCtrlProxyClient.getInstance(device, adbFactory);
+    this.adbFactory = adbFactory;
     this.timer = timer;
   }
 
@@ -211,7 +213,7 @@ export class ViewHierarchy implements ViewHierarchyInterface {
       logger.warn("[VIEW_HIERARCHY] Accessibility service returned null hierarchy");
       return {
         hierarchy: {
-          error: "Failed to retrieve view hierarchy from accessibility service"
+          error: await this.describeHierarchyFailure("Failed to retrieve view hierarchy from accessibility service")
         },
         updatedAt: this.timer.now()
       };
@@ -221,10 +223,51 @@ export class ViewHierarchy implements ViewHierarchyInterface {
       logger.warn(`[VIEW_HIERARCHY] Failed to get hierarchy from accessibility service after ${duration}ms:`, err);
       return {
         hierarchy: {
-          error: "Failed to retrieve view hierarchy"
+          error: await this.describeHierarchyFailure("Failed to retrieve view hierarchy")
         },
         updatedAt: this.timer.now()
       };
+    }
+  }
+
+  /**
+   * Turn a generic Android hierarchy failure into a lock-specific message when
+   * the keyguard is showing (#4281).
+   *
+   * A locked device — most commonly a fresh boot before the keyguard is first
+   * dismissed — blocks Android from binding non-encryption-aware accessibility
+   * services, so the hierarchy read fails with a message that points at the
+   * service even though it is healthy. That is indistinguishable from the #4039
+   * transport failure, which emits the identical string. Reading the lock state
+   * over adb (a `dumpsys` path that works even while the service is unbound) lets
+   * us name the real cause. Best-effort: any failure to read the lock state
+   * falls back to `fallback`, so this never turns a real transport error into a
+   * misleading "device is locked".
+   */
+  private async describeHierarchyFailure(fallback: string): Promise<string> {
+    if (this.device.platform !== "android") {
+      return fallback;
+    }
+    try {
+      const lock = await this.adbFactory.create(this.device).getDeviceLock();
+      if (!lock?.keyguardShowing) {
+        return fallback;
+      }
+      const preamble =
+        "Device is locked; a locked device blocks the accessibility service from binding, "
+        + "so no view hierarchy is available.";
+      if (lock.secure === true) {
+        return `${preamble} Unlock the device (PIN/pattern/password) — you may need to ask the user — before observing.`;
+      }
+      if (lock.secure === false) {
+        return `${preamble} Dismiss the keyguard (e.g. swipe up) before observing.`;
+      }
+      return `${preamble} Unlock or dismiss the keyguard before observing.`;
+    } catch (error) {
+      // Never let a lock-read failure mask a genuine transport error (#4039); a
+      // debug trace is enough since the caller still returns an actionable error.
+      logger.debug(`[VIEW_HIERARCHY] Could not read lock state for failure message: ${error}`);
+      return fallback;
     }
   }
 

--- a/test/features/observe/ViewHierarchy.test.ts
+++ b/test/features/observe/ViewHierarchy.test.ts
@@ -257,7 +257,7 @@ describe("ViewHierarchy", function() {
       expect(String((result.hierarchy as any).error)).toContain("Failed to retrieve view hierarchy");
     });
 
-    test("skips the lock probe when the caller's budget is already spent (#4281 review)", async function() {
+    test("skips the lock probe when the caller's signal is already aborted (#4281 review)", async function() {
       // Locked device, but the caller's deadline has already fired: the diagnostic
       // must not start an unbounded dumpsys just to reword the error.
       fakeAdb.setDeviceLock({ locked: true, keyguardShowing: true, secure: true });
@@ -271,6 +271,24 @@ describe("ViewHierarchy", function() {
       controller.abort();
 
       const result = await viewHierarchy.getAndroidViewHierarchy(undefined, undefined, false, 0, controller.signal);
+
+      expect(probed).toBe(false);
+      expect(String((result.hierarchy as any).error)).toContain("Failed to retrieve view hierarchy");
+    });
+
+    test("skips the lock probe when a per-read timeoutMs budget is supplied (#4281 review)", async function() {
+      // The keyboard confirmation poll bounds each read with timeoutMs and passes
+      // no signal; the unbounded dumpsys probe must not run for such a caller.
+      fakeAdb.setDeviceLock({ locked: true, keyguardShowing: true, secure: true });
+      let probed = false;
+      const originalGetDeviceLock = fakeAdb.getDeviceLock.bind(fakeAdb);
+      (fakeAdb as any).getDeviceLock = async (signal?: AbortSignal) => {
+        probed = true;
+        return originalGetDeviceLock(signal);
+      };
+
+      // timeoutMs supplied (5th arg signal omitted, 6th arg timeoutMs=500).
+      const result = await viewHierarchy.getAndroidViewHierarchy(undefined, undefined, false, 0, undefined, 500);
 
       expect(probed).toBe(false);
       expect(String((result.hierarchy as any).error)).toContain("Failed to retrieve view hierarchy");

--- a/test/features/observe/ViewHierarchy.test.ts
+++ b/test/features/observe/ViewHierarchy.test.ts
@@ -257,6 +257,25 @@ describe("ViewHierarchy", function() {
       expect(String((result.hierarchy as any).error)).toContain("Failed to retrieve view hierarchy");
     });
 
+    test("skips the lock probe when the caller's budget is already spent (#4281 review)", async function() {
+      // Locked device, but the caller's deadline has already fired: the diagnostic
+      // must not start an unbounded dumpsys just to reword the error.
+      fakeAdb.setDeviceLock({ locked: true, keyguardShowing: true, secure: true });
+      let probed = false;
+      const originalGetDeviceLock = fakeAdb.getDeviceLock.bind(fakeAdb);
+      (fakeAdb as any).getDeviceLock = async (signal?: AbortSignal) => {
+        probed = true;
+        return originalGetDeviceLock(signal);
+      };
+      const controller = new AbortController();
+      controller.abort();
+
+      const result = await viewHierarchy.getAndroidViewHierarchy(undefined, undefined, false, 0, controller.signal);
+
+      expect(probed).toBe(false);
+      expect(String((result.hierarchy as any).error)).toContain("Failed to retrieve view hierarchy");
+    });
+
     test("surfaces iOS CtrlProxy reconnect cooldown as retry metadata", async function() {
       const iosDevice: BootedDevice = {
         deviceId: "test-ios-device",

--- a/test/features/observe/ViewHierarchy.test.ts
+++ b/test/features/observe/ViewHierarchy.test.ts
@@ -251,6 +251,16 @@ describe("ViewHierarchy", function() {
       expect(error.toLowerCase()).not.toContain("keyguard");
     });
 
+    test("keeps the generic message when a keyguard is showing but occluded (#4281)", async function() {
+      // `locked` is false when a show-when-locked activity occludes the keyguard;
+      // that state cannot explain an accessibility-service binding failure.
+      fakeAdb.setDeviceLock({ locked: false, keyguardShowing: true, secure: true });
+      const result = await viewHierarchy.getAndroidViewHierarchy();
+      const error = String((result.hierarchy as any).error);
+      expect(error).toContain("Failed to retrieve view hierarchy");
+      expect(error.toLowerCase()).not.toContain("device is locked");
+    });
+
     test("falls back to the generic message when the lock read fails (#4281)", async function() {
       (fakeAdb as any).getDeviceLock = async () => { throw new Error("dumpsys boom"); };
       const result = await viewHierarchy.getAndroidViewHierarchy();

--- a/test/features/observe/ViewHierarchy.test.ts
+++ b/test/features/observe/ViewHierarchy.test.ts
@@ -216,6 +216,47 @@ describe("ViewHierarchy", function() {
       expect(result.hierarchy).toHaveProperty("error");
     });
 
+    // #4281: a fresh-boot / locked device blocks the accessibility service from
+    // binding, producing the same generic hierarchy error as the #4039 transport
+    // failure. When the keyguard is showing, name the real cause instead.
+    test("names a secure keyguard as the cause of a null hierarchy (#4281)", async function() {
+      fakeAdb.setDeviceLock({ locked: true, keyguardShowing: true, secure: true });
+      const result = await viewHierarchy.getAndroidViewHierarchy();
+      const error = String((result.hierarchy as any).error).toLowerCase();
+      expect(error).toContain("locked");
+      expect(error).toContain("unlock");
+    });
+
+    test("names a swipe keyguard as the cause of a hierarchy error (#4281)", async function() {
+      fakeAdb.setDeviceLock({ locked: true, keyguardShowing: true, secure: false });
+      const throwingClient = {
+        getLatestHierarchy: async () => null,
+        convertToViewHierarchyResult: () => ({ hierarchy: {} }),
+        convertAccessibilityNode: () => ({}),
+        getAccessibilityHierarchy: async () => { throw new Error("Accessibility service error"); }
+      } as unknown as AndroidCtrlProxyClient;
+      const vh = new ViewHierarchy(mockDevice, new FakeAdbClientFactory(fakeAdb), throwingClient);
+
+      const result = await vh.getAndroidViewHierarchy();
+      const error = String((result.hierarchy as any).error).toLowerCase();
+      expect(error).toContain("locked");
+      expect(error).toContain("dismiss");
+    });
+
+    test("keeps the generic message when the device is not locked (#4281/#4039)", async function() {
+      fakeAdb.setDeviceLock({ locked: false, keyguardShowing: false, secure: false });
+      const result = await viewHierarchy.getAndroidViewHierarchy();
+      const error = String((result.hierarchy as any).error);
+      expect(error).toContain("Failed to retrieve view hierarchy");
+      expect(error.toLowerCase()).not.toContain("keyguard");
+    });
+
+    test("falls back to the generic message when the lock read fails (#4281)", async function() {
+      (fakeAdb as any).getDeviceLock = async () => { throw new Error("dumpsys boom"); };
+      const result = await viewHierarchy.getAndroidViewHierarchy();
+      expect(String((result.hierarchy as any).error)).toContain("Failed to retrieve view hierarchy");
+    });
+
     test("surfaces iOS CtrlProxy reconnect cooldown as retry metadata", async function() {
       const iosDevice: BootedDevice = {
         deviceId: "test-ios-device",


### PR DESCRIPTION
## Summary

Closes #4281. A locked Android device — most often a fresh boot before the keyguard is first dismissed — blocks Android from binding non-encryption-aware accessibility services, so the view-hierarchy read fails with a message pointing at the service even though it is installed, enabled, and healthy. That string is **identical** to the #4039 transport failure, so the two were indistinguishable and cost real debugging time (hit twice during the 0.0.44 manual-test campaign).

Part of the #4235 device-lock series, after #4279 (observability) and #4280 (action warning).

## Changes

- `ViewHierarchy.getAndroidViewHierarchy` — both failure paths (accessibility service returns null; and the catch path) now build the error via a new `describeHierarchyFailure(fallback)` helper.
- The helper reads the lock state over adb (`getDeviceLock`, a `dumpsys window policy` path that works even while the accessibility service is unbound). When the keyguard is showing it returns a lock-specific message — secure → "unlock (PIN/pattern/password), ask the user"; swipe → "dismiss the keyguard" — instead of the generic string.
- **Best-effort:** platform-guarded to Android, and any failure to read the lock state (or an unlocked device) falls back to the generic message, so a genuine #4039 transport error is never masked as "device is locked".

## Testing

- `ViewHierarchy.test.ts` — secure keyguard → null-path message names the lock + "unlock"; swipe keyguard → catch-path message says "dismiss"; unlocked device → unchanged generic string (no "keyguard"), preserving #4039; lock read throws → generic fallback. Verified red before the change.
- Full suite green (8816 pass, 0 fail); lint + typecheck clean. `getDeviceLock` itself was verified on a live emulator in #4279.

## Acceptance criteria

- ✅ Android hierarchy failure + keyguard showing → lock-specific, actionable message.
- ✅ Distinguishable from #4039 (unlocked failure keeps the generic string).
- ✅ Lock read is best-effort; a read failure falls back to the generic message, never a false "locked".

## Follow-ups

Last of the series is #4282 (secure-keyguard recovery, prompt-only). With #4279 (`observe.deviceLock.secure`) + #4280 (action warning that says "ask the user to unlock") already shipping the prompt-only intent, I'll assess whether #4282 has any distinct remaining work or should close as satisfied.
