### PR TITLE
fix(ios): preserve legacy runner checksum verification

### DIFF
--- a/.github/workflows/build-ctrl-proxy-ios-ipa.yml
+++ b/.github/workflows/build-ctrl-proxy-ios-ipa.yml
@@ -7,7 +7,7 @@ on:
         description: "SHA256 checksum of the built IPA"
         value: ${{ jobs.build.outputs.sha256 }}
       runner_sha256:
-        description: "SHA256 checksum of the CtrlProxyUITests-Runner binary"
+        description: "SHA256 checksum of the CtrlProxyUITests xctest executable"
         value: ${{ jobs.build.outputs.runner_sha256 }}
 
 jobs:

--- a/scripts/ci/verify-release-integrity.sh
+++ b/scripts/ci/verify-release-integrity.sh
@@ -103,6 +103,11 @@ check "src/constants/release.ts registry[0].version" "$registry_version"
 # exists to catch. Read via the shared entry-anchored helper (single source of
 # truth with nightly.yml + verify-artifact-sha256.sh).
 runner_sha="$(bun "$RELEASE_READER" runnerSha256 "$RELEASE_TS")"
+runner_sha_target="$(bun "$RELEASE_READER" runnerSha256Target "$RELEASE_TS")"
+
+if [ "$runner_sha_target" != "xctest" ]; then
+  errors+=("registry[0].runnerSha256Target must be 'xctest', got '${runner_sha_target:-missing}'")
+fi
 
 sha256_stdin() {
   if command -v sha256sum >/dev/null 2>&1; then

--- a/scripts/generate-release-constants.sh
+++ b/scripts/generate-release-constants.sh
@@ -167,6 +167,7 @@ if [ -n "$release_version" ]; then
     apkSha256: \"${apk_checksum}\",
     ipaSha256: \"${ios_checksum}\",
     runnerSha256: \"${ios_runner_sha256}\",
+    runnerSha256Target: \"xctest\",
     videoJarSha256: \"${video_jar_checksum}\",
   },"
 
@@ -222,6 +223,7 @@ else
 
   if [ -n "$ios_runner_sha256" ]; then
     update_registry_field "$tmp_file" "nightly" "runnerSha256" "$ios_runner_sha256"
+    update_registry_field "$tmp_file" "nightly" "runnerSha256Target" "xctest"
   fi
 
   if [ -n "$video_jar_checksum" ]; then
@@ -249,6 +251,7 @@ fi
 if [ -n "$ios_runner_sha256" ]; then
   if [ -n "$release_version" ]; then
     update_registry_field "$tmp_file" "$release_version" "runnerSha256" "$ios_runner_sha256"
+    update_registry_field "$tmp_file" "$release_version" "runnerSha256Target" "xctest"
   fi
   echo "   iOS runner SHA256: ${ios_runner_sha256}"
 fi

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -29,11 +29,19 @@ import { ActionableError } from "../models/ActionableError";
 
 export const LATEST_RELEASE_VERSION = "latest";
 
+/** Executable whose SHA-256 is recorded in a release entry. */
+export type RunnerSha256Target = "runner" | "xctest";
+
 export interface ReleaseChecksumEntry {
   version: string;
   apkSha256: string;
   ipaSha256: string;
   runnerSha256: string;
+  /**
+   * The executable represented by runnerSha256. Missing fields predate the
+   * xctest migration and deliberately retain the legacy XCTRunner-stub target.
+   */
+  runnerSha256Target?: RunnerSha256Target;
   /**
    * SHA-256 of the persistent on-device H.264 encoder jar
    * (`automobile-video.jar`, #3776/#3830). Optional so registry entries that
@@ -250,6 +258,25 @@ export function resolveRunnerChecksum(
     ? registry[0]
     : registry.find(e => e.version === pinned);
   return entry?.runnerSha256 ?? "";
+}
+
+/**
+ * Resolve the executable represented by the selected runner checksum.
+ * Existing entries omit this field because their hashes were taken from the
+ * outer XCTRunner stub before CtrlProxy's code executable was adopted.
+ */
+export function resolveRunnerChecksumTarget(
+  env: EnvLike = process.env,
+  registry: ReleaseChecksumEntry[] = RELEASE_CHECKSUM_REGISTRY
+): RunnerSha256Target {
+  if (registry.length === 0) {
+    return "runner";
+  }
+  const pinned = resolvePinnedVersion(env);
+  const entry = pinned === LATEST_RELEASE_VERSION
+    ? registry[0]
+    : registry.find(e => e.version === pinned);
+  return entry?.runnerSha256Target ?? "runner";
 }
 
 /**
@@ -474,7 +501,7 @@ export const IOS_CTRL_PROXY_RELEASE_VERSION: string = RELEASE_VERSION;
 export const IOS_CTRL_PROXY_IPA_URL: string = resolveIpaUrl({});
 export const IOS_CTRL_PROXY_SHA256_CHECKSUM: string = resolveIpaChecksum({});
 export const IOS_CTRL_PROXY_APP_HASH: string = ""; // Hash of CtrlProxyApp.app (device build), empty = skip verification
-// SHA256 of the simulator runner binary (CtrlProxyUITests-Runner), empty = skip
-// verification. Resolved through RELEASE_CHECKSUM_REGISTRY so pinned iOS
-// downloads verify against the runner hash recorded for the same release entry.
+// SHA256 of the simulator runner executable, empty = skip verification. The
+// per-release target records whether that is the legacy XCTRunner stub or the
+// CtrlProxy xctest executable.
 export const IOS_CTRL_PROXY_RUNNER_SHA256_CHECKSUM: string = resolveRunnerChecksum({});

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -13,7 +13,9 @@ import {
   resolveIpaChecksum,
   resolveIpaUrl,
   resolvePinnedVersion,
-  resolveRunnerChecksum
+  resolveRunnerChecksum,
+  resolveRunnerChecksumTarget,
+  type RunnerSha256Target
 } from "../constants/release";
 import {
   DefaultIOSCtrlProxyBundleDownloader,
@@ -94,6 +96,7 @@ export class IOSCtrlProxyBuilder {
   private static prefetchError: Error | null = null;
   private static expectedChecksumOverride: string | null = null;
   private static expectedRunnerChecksumOverride: string | null = null;
+  private static expectedRunnerChecksumTargetOverride: RunnerSha256Target | null = null;
   private static timer: Timer = defaultTimer;
 
   // Singleton instances per configuration
@@ -158,6 +161,7 @@ export class IOSCtrlProxyBuilder {
     IOSCtrlProxyBuilder.prefetchError = null;
     IOSCtrlProxyBuilder.expectedChecksumOverride = null;
     IOSCtrlProxyBuilder.expectedRunnerChecksumOverride = null;
+    IOSCtrlProxyBuilder.expectedRunnerChecksumTargetOverride = null;
     IOSCtrlProxyBuilder.timer = defaultTimer;
   }
 
@@ -175,8 +179,12 @@ export class IOSCtrlProxyBuilder {
     IOSCtrlProxyBuilder.expectedChecksumOverride = checksum;
   }
 
-  public static setExpectedRunnerChecksumForTesting(checksum: string | null): void {
+  public static setExpectedRunnerChecksumForTesting(
+    checksum: string | null,
+    target: RunnerSha256Target | null = null
+  ): void {
     IOSCtrlProxyBuilder.expectedRunnerChecksumOverride = checksum;
+    IOSCtrlProxyBuilder.expectedRunnerChecksumTargetOverride = target;
   }
 
   /**
@@ -651,22 +659,19 @@ export class IOSCtrlProxyBuilder {
     }
   }
 
-  /**
-   * Get the CtrlProxy xctest executable path for runner checksum verification.
-   * Returns: <buildPath>/CtrlProxyUITests-Runner.app/PlugIns/CtrlProxyUITests.xctest/CtrlProxyUITests
-   */
-  public async getRunnerBinaryPath(platform: IOSCtrlProxyPlatform = "simulator"): Promise<string | null> {
+  /** Get the executable represented by the selected release's runner checksum. */
+  public async getRunnerBinaryPath(
+    platform: IOSCtrlProxyPlatform = "simulator",
+    target: RunnerSha256Target = this.getExpectedRunnerChecksumTarget()
+  ): Promise<string | null> {
     const buildPath = await this.getBuildProductsPath(platform);
     if (!buildPath) {
       return null;
     }
-    const runnerBinaryPath = path.join(
-      buildPath,
-      "CtrlProxyUITests-Runner.app",
-      "PlugIns",
-      "CtrlProxyUITests.xctest",
-      "CtrlProxyUITests"
-    );
+    const runnerAppPath = path.join(buildPath, "CtrlProxyUITests-Runner.app");
+    const runnerBinaryPath = target === "xctest"
+      ? path.join(runnerAppPath, "PlugIns", "CtrlProxyUITests.xctest", "CtrlProxyUITests")
+      : path.join(runnerAppPath, "CtrlProxyUITests-Runner");
     try {
       await fs.access(runnerBinaryPath);
       return runnerBinaryPath;
@@ -712,6 +717,14 @@ export class IOSCtrlProxyBuilder {
       return override;
     }
     return resolveRunnerChecksum();
+  }
+
+  private getExpectedRunnerChecksumTarget(): RunnerSha256Target {
+    const override = IOSCtrlProxyBuilder.expectedRunnerChecksumTargetOverride;
+    if (override !== null) {
+      return override;
+    }
+    return resolveRunnerChecksumTarget();
   }
 
   public getExpectedAppHash(platform: IOSCtrlProxyPlatform): string {
@@ -966,11 +979,12 @@ export class IOSCtrlProxyBuilder {
       logger.warn(`[IOSCtrlProxyBuilder] App bundle hash verification skipped for ${platform} (no hash provided)`);
     }
 
-    // Verify runner binary SHA256 for simulator (used by simctl spawn)
+    // Verify the release-selected runner executable SHA256 for simulator.
     if (platform === "simulator") {
       const expectedRunnerSha256 = this.getExpectedRunnerChecksum();
       if (expectedRunnerSha256 && expectedRunnerSha256.length > 0) {
-        const runnerBinaryPath = await this.getRunnerBinaryPath(platform);
+        const runnerChecksumTarget = this.getExpectedRunnerChecksumTarget();
+        const runnerBinaryPath = await this.getRunnerBinaryPath(platform, runnerChecksumTarget);
         if (!runnerBinaryPath) {
           throw new Error(`CtrlProxy runner binary missing for ${platform}`);
         }

--- a/test/bats/generate-release-constants.bats
+++ b/test/bats/generate-release-constants.bats
@@ -36,6 +36,7 @@ teardown() {
   grep -q "apkSha256: \"${APK_SHA}\"" "${TEST_ROOT}/src/constants/release.ts"
   grep -q "ipaSha256: \"${IPA_SHA}\"" "${TEST_ROOT}/src/constants/release.ts"
   grep -q "runnerSha256: \"${RUNNER_SHA}\"" "${TEST_ROOT}/src/constants/release.ts"
+  grep -q 'runnerSha256Target: "xctest"' "${TEST_ROOT}/src/constants/release.ts"
 }
 
 @test "writes runnerSha256 in release mode" {
@@ -48,6 +49,7 @@ teardown() {
 
   [ "$status" -eq 0 ]
   grep -q "runnerSha256: \"${RUNNER_SHA}\"" "${TEST_ROOT}/src/constants/release.ts"
+  grep -q 'runnerSha256Target: "xctest"' "${TEST_ROOT}/src/constants/release.ts"
 }
 
 # Read a field from the block anchored on `version: "$1"` (either a registry
@@ -79,6 +81,8 @@ read_field_for_version() {
   # The nightly slot moved.
   nightly_runner="$(read_field_for_version nightly runnerSha256 "${TEST_ROOT}/src/constants/release.ts")"
   [ "$nightly_runner" = "$RUNNER_SHA" ]
+  nightly_target="$(read_field_for_version nightly runnerSha256Target "${TEST_ROOT}/src/constants/release.ts")"
+  [ "$nightly_target" = "xctest" ]
   # The tagged release entry (registry[0], 0.0.44) is untouched.
   release_runner_after="$(read_field_for_version 0.0.44 runnerSha256 "${TEST_ROOT}/src/constants/release.ts")"
   [ "$release_runner_after" = "$release_runner_before" ]

--- a/test/bats/verify-release-integrity.bats
+++ b/test/bats/verify-release-integrity.bats
@@ -56,6 +56,7 @@ export const RELEASE_CHECKSUM_REGISTRY: ReleaseChecksumEntry[] = [
     apkSha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     ipaSha256: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
     runnerSha256: "${runner}",
+    runnerSha256Target: "${runner_target:-xctest}",
   },
 ];
 export const IOS_CTRL_PROXY_APP_HASH: string = "";
@@ -209,6 +210,16 @@ PY
   run_gate "$VERSION"
   [ "$status" -ne 0 ]
   [[ "$output" == *"registry[0].runnerSha256"* ]]
+}
+
+@test "fails when runner sha256 target is not the CtrlProxy xctest executable" {
+  runner_target="runner"
+  write_fixtures "0.0.40" "0.0.40-SNAPSHOT" "0.0.40" "$RUNNER_SHA"
+
+  run_gate "0.0.40"
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"runnerSha256Target must be 'xctest'"* ]]
 }
 
 @test "binds recorded runner sha to the CtrlProxy executable inside the IPA (match passes)" {

--- a/test/constants/release.test.ts
+++ b/test/constants/release.test.ts
@@ -24,6 +24,7 @@ import {
   resolveLatestVersion,
   resolvePinnedVersion,
   resolveRunnerChecksum,
+  resolveRunnerChecksumTarget,
   resolveVideoJarChecksum,
   resolveVideoJarUrl,
   VIDEO_SERVER_JAR_FILENAME,
@@ -292,6 +293,24 @@ describe("resolveRunnerChecksum", function() {
 
   test("unknown pinned version yields an empty checksum", function() {
     expect(resolveRunnerChecksum({ AUTOMOBILE_VERSION: "99.99.99" })).toBe("");
+  });
+});
+
+describe("resolveRunnerChecksumTarget", function() {
+  test("legacy entries without a target retain the outer XCTRunner checksum target", function() {
+    expect(resolveRunnerChecksumTarget({ AUTOMOBILE_VERSION: "0.0.44" })).toBe("runner");
+  });
+
+  test("uses the target recorded by a newer release entry", function() {
+    const registry: ReleaseChecksumEntry[] = [{
+      version: "0.0.45",
+      apkSha256: "apk45",
+      ipaSha256: "ipa45",
+      runnerSha256: "runner45",
+      runnerSha256Target: "xctest",
+    }];
+
+    expect(resolveRunnerChecksumTarget({}, registry)).toBe("xctest");
   });
 });
 

--- a/test/fakes/FakeIOSCtrlProxyBundleDownloader.ts
+++ b/test/fakes/FakeIOSCtrlProxyBundleDownloader.ts
@@ -8,6 +8,8 @@ export class FakeIOSCtrlProxyBundleDownloader implements CtrlProxyIosBundleDownl
   public extractedPaths: string[] = [];
   public checksum: string = "fake-checksum";
   public runnerChecksum: string = resolveRunnerChecksum();
+  public legacyRunnerChecksum: string = resolveRunnerChecksum();
+  public checksummedFilePaths: string[] = [];
   public checksumSource: Sha256Source = "node";
   public extractedSubdir: string = "";
 
@@ -19,8 +21,12 @@ export class FakeIOSCtrlProxyBundleDownloader implements CtrlProxyIosBundleDownl
   }
 
   public async computeFileSha256(filePath: string): Promise<{ checksum: string; source: Sha256Source }> {
-    if (path.basename(filePath) === "CtrlProxyUITests-Runner") {
+    this.checksummedFilePaths.push(filePath);
+    if (path.basename(filePath) === "CtrlProxyUITests") {
       return { checksum: this.runnerChecksum, source: this.checksumSource };
+    }
+    if (path.basename(filePath) === "CtrlProxyUITests-Runner") {
+      return { checksum: this.legacyRunnerChecksum, source: this.checksumSource };
     }
     return { checksum: this.checksum, source: this.checksumSource };
   }
@@ -38,6 +44,9 @@ export class FakeIOSCtrlProxyBundleDownloader implements CtrlProxyIosBundleDownl
     const runnerDir = path.join(productsDir, "CtrlProxyUITests-Runner.app");
     await fs.mkdir(runnerDir, { recursive: true });
     await fs.writeFile(path.join(runnerDir, "CtrlProxyUITests-Runner"), "fake runner");
+    const xctestBinary = path.join(runnerDir, "PlugIns", "CtrlProxyUITests.xctest", "CtrlProxyUITests");
+    await fs.mkdir(path.dirname(xctestBinary), { recursive: true });
+    await fs.writeFile(xctestBinary, "fake CtrlProxy code");
     await fs.mkdir(path.join(productsDir, "CtrlProxyTests.xctest"), { recursive: true });
   }
 }

--- a/test/utils/IOSCtrlProxyBuilder.test.ts
+++ b/test/utils/IOSCtrlProxyBuilder.test.ts
@@ -345,7 +345,10 @@ describe("IOSCtrlProxyBuilder", function() {
 
       const builder = IOSCtrlProxyBuilder.getInstance({ derivedDataPath: tempDir });
 
-      expect(await builder.getRunnerBinaryPath()).toBe(xctestBinary);
+      expect(await builder.getRunnerBinaryPath("simulator", "xctest")).toBe(xctestBinary);
+      expect(await builder.getRunnerBinaryPath("simulator", "runner")).toBe(
+        path.join(runnerDir, "CtrlProxyUITests-Runner")
+      );
     });
   });
 
@@ -632,6 +635,49 @@ describe("IOSCtrlProxyBuilder", function() {
 
       expect(result.success).toBe(true);
       expect(buildProducts).toBe(path.join(derivedDataPath, "Build", "Products", "Debug-iphonesimulator"));
+    });
+
+    test("verifies the xctest executable for releases that record an xctest checksum", async function() {
+      const derivedDataPath = path.join(tempDir, "DerivedData");
+      const cacheDir = path.join(tempDir, "cache");
+      const downloader = new FakeIOSCtrlProxyBundleDownloader();
+      downloader.checksum = "expected-checksum";
+      downloader.runnerChecksum = "xctest-checksum";
+      downloader.legacyRunnerChecksum = "xctrunner-stub-checksum";
+
+      IOSCtrlProxyBuilder.setExpectedChecksumForTesting("expected-checksum");
+      IOSCtrlProxyBuilder.setExpectedRunnerChecksumForTesting("xctest-checksum", "xctest");
+      const builder = IOSCtrlProxyBuilder.getInstance(
+        { derivedDataPath, bundleCacheDir: cacheDir },
+        { downloader }
+      );
+
+      const result = await builder.build("simulator");
+
+      expect(result.success).toBe(true);
+      expect(downloader.checksummedFilePaths).toContain(
+        path.join(derivedDataPath, "Build", "Products", "Debug-iphonesimulator", "CtrlProxyUITests-Runner.app", "PlugIns", "CtrlProxyUITests.xctest", "CtrlProxyUITests")
+      );
+    });
+
+    test("fails when the xctest executable checksum differs", async function() {
+      const derivedDataPath = path.join(tempDir, "DerivedData");
+      const cacheDir = path.join(tempDir, "cache");
+      const downloader = new FakeIOSCtrlProxyBundleDownloader();
+      downloader.checksum = "expected-checksum";
+      downloader.runnerChecksum = "wrong-xctest-checksum";
+
+      IOSCtrlProxyBuilder.setExpectedChecksumForTesting("expected-checksum");
+      IOSCtrlProxyBuilder.setExpectedRunnerChecksumForTesting("expected-xctest-checksum", "xctest");
+      const builder = IOSCtrlProxyBuilder.getInstance(
+        { derivedDataPath, bundleCacheDir: cacheDir },
+        { downloader }
+      );
+
+      const result = await builder.build("simulator");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("runner binary SHA256 mismatch");
     });
 
     test("fails closed when AUTOMOBILE_VERSION is pinned to an unknown version (#2746)", async function() {


### PR DESCRIPTION
## Summary

- preserve verification of the outer XCTRunner stub for already-published iOS releases
- record `runnerSha256Target: "xctest"` for future releases, whose checksums cover the CtrlProxy xctest executable
- enforce that release generation and release-integrity verification agree on the xctest target

## Root cause

[#4287](https://github.com/kaeawc/auto-mobile/pull/4287) correctly changed future IPA checksum production to the CtrlProxy xctest executable. Existing release registry entries, however, contain hashes of the legacy outer XCTRunner stub. Updated clients would otherwise compare an old hash to the new executable and reject those published IPAs at startup.

## Validation

- `bun run turbo:validate` (8,806 passing, 0 failures)
- `bats test/bats/generate-release-constants.bats`
- `bats test/bats/verify-release-integrity.bats -f 'runner sha256 target'`
- `shellcheck scripts/generate-release-constants.sh scripts/ci/verify-release-integrity.sh scripts/ios/ctrl-proxy-create-ipa.sh`
- `git diff --check origin/main...HEAD`
