### PR TITLE
fix(devices): verify Android devices by ID

### DIFF
--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -477,7 +477,7 @@ export class DeviceSessionManager implements DeviceSessionManager {
    */
   public async verifyAndroidDevice(deviceId: string, options?: DeviceReadyOptions): Promise<void> {
     const allDevices = await this.adb.getBootedAndroidDevices();
-    const device = allDevices.find(device => device.name === deviceId);
+    const device = allDevices.find(device => device.deviceId === deviceId);
 
     if (!device) {
       throw new ActionableError(

--- a/test/utils/DeviceSessionManager.test.ts
+++ b/test/utils/DeviceSessionManager.test.ts
@@ -765,6 +765,14 @@ describe("DeviceSessionManager device-list error formatting (#4227)", () => {
     deviceId: "emulator-5554",
   };
 
+  test("verifyAndroidDevice matches the device id when the Android name differs", async () => {
+    const manager = DeviceSessionManager.createInstance(makeProvider([androidDevice]));
+
+    await expect(
+      manager.verifyAndroidDevice(androidDevice.deviceId, { skipCtrlProxyDownload: true })
+    ).resolves.toBeUndefined();
+  });
+
   test("ensureDeviceReady names the available devices instead of [object Object]", async () => {
     const manager = DeviceSessionManager.createInstance(makeProvider([androidDevice]));
 


### PR DESCRIPTION
## Summary

Match Android booted devices by their `deviceId` in `verifyAndroidDevice`.
This keeps the method aligned with its callers and avoids a latent failure when
an Android device's display name differs from its ADB serial.

## Linked Issue

Closes #4244

## Bug / Regression Context

- **Prior attempts:** [#4245](https://github.com/kaeawc/auto-mobile/pull/4245) fixed the related error-message formatting only.
- **Observed symptom:** Device verification compared the `deviceId` parameter against `BootedDevice.name`.
- **Repro steps / conditions:** Use a booted Android device with a human-readable name distinct from its ADB serial.

## Validation

- [x] `bun test test/utils/DeviceSessionManager.test.ts` passes (34 tests).
- [x] `bun run turbo:validate` passes (lint, build, tests, Android emulator boundary check).
- [x] `bun run typecheck` reports no new errors (baseline gate).
- [x] New behavior is covered with existing fakes; no new dependency or generic helper was added.
- [x] Rebased onto the latest `origin/main` before implementation.
