### PR TITLE
fix(ci): complete owned simulator recovery

### DIFF
--- a/src/utils/deviceBootRecovery.ts
+++ b/src/utils/deviceBootRecovery.ts
@@ -84,9 +84,9 @@ export function shouldUseCiIosBootRecovery(request: DeviceBootRequest, environme
   return request.platform === "ios" && !request.name && !request.deviceId && isGitHubActionsCi(environment);
 }
 
-/** Match the runtime-qualified CI-owned name rather than re-applying SDK bounds after fallback. */
+/** Match the runtime-qualified CI-owned name across fallback without changing provisioning bounds. */
 export function normalizeCiIosBootRequest(request: DeviceBootRequest, ownedSimulatorName: string): DeviceBootRequest {
-  return { ...request, name: ownedSimulatorName, minOsVersion: undefined, maxOsVersion: undefined };
+  return { ...request, name: ownedSimulatorName, matchNamedDeviceIgnoringOsVersion: true };
 }
 
 /**

--- a/src/utils/deviceBootService.ts
+++ b/src/utils/deviceBootService.ts
@@ -19,6 +19,8 @@ export interface DeviceBootRequest {
   preferRunning?: boolean;
   timeoutMs?: number;
   createIfMissing?: boolean;
+  /** Internal CI policy: preserve OS bounds for provisioning while matching its exact owned name across runtime fallback. */
+  matchNamedDeviceIgnoringOsVersion?: boolean;
 }
 
 export interface DeviceBootProgress {
@@ -68,7 +70,7 @@ export class DeviceBootService {
     const booted = await deviceManager.getBootedDevices(request.platform);
     const running = booted.find(device => device.deviceId === request.deviceId);
     if (running) {
-      return { device: await this.waitForRunningDevice(running, timeoutMs), source: "booted", provisioned: false };
+      return this.waitForRunningDevice(running, timeoutMs, progress);
     }
     const images = await deviceManager.listDeviceImages(request.platform);
     const image = images.find(device => device.deviceId === request.deviceId || device.name === request.deviceId);
@@ -83,7 +85,7 @@ export class DeviceBootService {
 
   private async bootMatchingDevice(request: DeviceBootRequest, timeoutMs: number, progress?: DeviceBootProgress): Promise<DeviceBootResult> {
     const { deviceManager, deviceMatcher, matchingStrategy } = this.dependencies;
-    const criteria: DeviceMatchCriteria = {
+    const provisionCriteria: DeviceMatchCriteria = {
       platform: request.platform,
       minOsVersion: request.minOsVersion,
       maxOsVersion: request.maxOsVersion,
@@ -91,6 +93,9 @@ export class DeviceBootService {
       formFactor: request.formFactor,
       screenSize: request.screenSize,
     };
+    const criteria = request.matchNamedDeviceIgnoringOsVersion
+      ? { ...provisionCriteria, minOsVersion: undefined, maxOsVersion: undefined }
+      : provisionCriteria;
     const images = await deviceManager.listDeviceImages(request.platform);
     const running = await this.findRunningMatch(request, criteria, images, timeoutMs, progress);
     if (running) {
@@ -100,7 +105,7 @@ export class DeviceBootService {
     if (image) {
       return this.bootMatchedImage(image, timeoutMs, progress);
     }
-    return this.provisionAndBoot(request, criteria, images, timeoutMs, progress);
+    return this.provisionAndBoot(request, provisionCriteria, images, timeoutMs, progress);
   }
 
   private async findRunningMatch(request: DeviceBootRequest, criteria: DeviceMatchCriteria, images: DeviceInfo[], timeoutMs: number, progress?: DeviceBootProgress): Promise<DeviceBootResult | undefined> {
@@ -109,7 +114,7 @@ export class DeviceBootService {
     const match = this.dependencies.deviceMatcher.matchBootedDevice(criteria, enrichBootedDevicesFromImages(booted, images), this.dependencies.matchingStrategy);
     if (!match) { return undefined; }
     await progress?.report(100, 100, "Found matching running device");
-    return { device: await this.waitForRunningDevice(match, timeoutMs), source: "booted", provisioned: false };
+    return this.waitForRunningDevice(match, timeoutMs, progress);
   }
 
   private async bootMatchedImage(image: DeviceInfo, timeoutMs: number, progress?: DeviceBootProgress): Promise<DeviceBootResult> {
@@ -117,8 +122,8 @@ export class DeviceBootService {
     const booted = await this.dependencies.deviceManager.getBootedDevices(image.platform);
     const running = booted.find(device => device.deviceId === image.deviceId || device.name === image.name);
     if (!running) { return this.bootImage(image, timeoutMs, progress, false); }
-    const device = await this.waitForRunningDevice(running, timeoutMs);
-    return { device: enrichBootedDevice(device, image), source: "booted", provisioned: false };
+    const result = await this.waitForRunningDevice(running, timeoutMs, progress);
+    return { ...result, device: enrichBootedDevice(result.device, image) };
   }
 
   private async provisionAndBoot(request: DeviceBootRequest, criteria: DeviceMatchCriteria, images: DeviceInfo[], timeoutMs: number, progress?: DeviceBootProgress): Promise<DeviceBootResult> {
@@ -142,11 +147,16 @@ export class DeviceBootService {
     return this.bootImage(createdImage, timeoutMs, progress, true);
   }
 
-  private async waitForRunningDevice(device: BootedDevice, timeoutMs: number): Promise<BootedDevice> {
+  private async waitForRunningDevice(device: BootedDevice, timeoutMs: number, progress?: DeviceBootProgress): Promise<DeviceBootResult> {
     const recoveryTarget: DeviceInfo = { ...device, isRunning: true };
+    let attempts = 0;
     return this.bootRecovery.run(recoveryTarget, async () => {
+      attempts++;
+      if (attempts > 1) {
+        return this.bootImageOnce(recoveryTarget, timeoutMs, progress, false);
+      }
       const ready = await this.dependencies.deviceManager.waitForDeviceReady({ ...device, isRunning: true }, timeoutMs);
-      return { ...device, ...ready };
+      return { device: { ...device, ...ready }, source: "booted", provisioned: false };
     });
   }
 

--- a/test/utils/ciIosBootRecovery.test.ts
+++ b/test/utils/ciIosBootRecovery.test.ts
@@ -22,7 +22,7 @@ describe("CI iOS boot recovery", () => {
     expect(shouldUseCiIosBootRecovery({ platform: "ios", deviceId: "personal-udid" }, environment)).toBe(false);
   });
 
-  it("matches the resolved CI-owned runtime name without stale SDK bounds", () => {
+  it("matches the resolved CI-owned runtime name without changing provisioning SDK bounds", () => {
     expect(normalizeCiIosBootRequest({
       platform: "ios",
       minOsVersion: "26.3",
@@ -30,8 +30,9 @@ describe("CI iOS boot recovery", () => {
     }, owned.name)).toEqual({
       platform: "ios",
       name: owned.name,
-      minOsVersion: undefined,
-      maxOsVersion: undefined,
+      minOsVersion: "26.3",
+      maxOsVersion: "26.3",
+      matchNamedDeviceIgnoringOsVersion: true,
     });
   });
 

--- a/test/utils/deviceBootService.test.ts
+++ b/test/utils/deviceBootService.test.ts
@@ -3,6 +3,7 @@ import { DeviceBootService } from "../../src/utils/deviceBootService";
 import { FakeDeviceMatcher } from "../fakes/FakeDeviceMatcher";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import type { DeviceInfo } from "../../src/models";
+import type { DeviceMatchCriteria } from "../../src/models/DeviceMatchCriteria";
 import type { DeviceBootRecovery } from "../../src/utils/deviceBootRecovery";
 
 const image: DeviceInfo = {
@@ -106,5 +107,60 @@ describe("DeviceBootService", () => {
     await service(devices, matcher, bootRecovery).boot({ platform: "android" });
 
     expect(recovered).toEqual(["emulator-5554"]);
+  });
+
+  it("cold-boots an adopted device after recovery erases its failed readiness state", async () => {
+    const devices = new FakeDeviceUtils();
+    const matcher = new FakeDeviceMatcher();
+    const running = { name: image.name, platform: "android" as const, deviceId: "emulator-5554" };
+    devices.setDeviceImages("android", [image]);
+    devices.setBootedDevices("android", [running]);
+    matcher.setBootedResult(running);
+    let attempts = 0;
+    const originalWaitForDeviceReady = devices.waitForDeviceReady.bind(devices);
+    devices.waitForDeviceReady = async (...args) => {
+      attempts++;
+      if (attempts === 1) { throw new Error("not ready"); }
+      return originalWaitForDeviceReady(...args);
+    };
+    const bootRecovery: DeviceBootRecovery = {
+      run: async (_target, boot) => {
+        try { return await boot(); } catch { return boot(); }
+      },
+    };
+
+    const result = await service(devices, matcher, bootRecovery).boot({ platform: "android", timeoutMs: 12_345 });
+
+    expect(result.source).toBe("cold-boot");
+    expect(devices.getExecutedOperations()).toContain("startDevice:Pixel_9_API_35:12345");
+  });
+
+  it("preserves named CI runtime bounds when provisioning after a relaxed named match", async () => {
+    const devices = new FakeDeviceUtils();
+    const matcher = new FakeDeviceMatcher();
+    let provisionCriteria: DeviceMatchCriteria | undefined;
+    const bootService = new DeviceBootService({
+      deviceManager: devices,
+      deviceMatcher: matcher,
+      deviceCreationGate: { isCreationAllowed: () => true, describeSource: () => "test" },
+      deviceProvisioner: {
+        provision: async criteria => {
+          provisionCriteria = criteria;
+          return { platform: "ios", name: "AutoMobile CI iPhone", deviceId: "CI-UDID", deviceType: "iPhone", runtime: "iOS-26-3" };
+        },
+      },
+      matchingStrategy: "LATEST",
+    });
+
+    await bootService.boot({
+      platform: "ios",
+      name: "AutoMobile CI iPhone (com.apple.CoreSimulator.SimRuntime.iOS-26-3)",
+      minOsVersion: "26.3",
+      maxOsVersion: "26.3",
+      matchNamedDeviceIgnoringOsVersion: true,
+      createIfMissing: true,
+    });
+
+    expect(provisionCriteria).toMatchObject({ minOsVersion: "26.3", maxOsVersion: "26.3" });
   });
 });


### PR DESCRIPTION
## Summary

- cold-boot the CI-owned simulator after erase recovery when it was initially adopted as already running
- retain requested iOS SDK bounds for provisioning while relaxing only the exact CI-owned-name match

## Validation

- `bun test test/utils/deviceBootService.test.ts test/utils/ciIosBootRecovery.test.ts`
- `bun test`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
