### PR TITLE
test(webrtc): add MediaMTX publisher WHEP integration

### DIFF
--- a/examples/mediamtx/README.md
+++ b/examples/mediamtx/README.md
@@ -1,0 +1,30 @@
+# MediaMTX integration test
+
+The checked-in `mediamtx.yml` is exercised by an opt-in integration test. It
+uses the actual AutoMobile `WebRtcPublisher` to ingest a synthetic, valid H.264
+stream over WHIP, then opens MediaMTX's built-in WHEP reader in headless Chrome
+and requires decoded video frames.
+
+Run it from the repository root:
+
+```bash
+bun run test:integration:webrtc-mediamtx
+```
+
+The runner downloads the pinned official MediaMTX v1.19.2 binary into
+`scratch/mediamtx`, verifies the release SHA-256 before extraction, and starts
+it with this configuration. The download is cached. It requires `curl`, `tar`,
+`ffmpeg` with `libx264`, and Google Chrome. On Linux, set
+`AUTOMOBILE_CHROME_BINARY` if Chrome is not installed at a standard path.
+
+To use a pre-downloaded binary instead, point the runner at it:
+
+```bash
+AUTOMOBILE_MEDIAMTX_BINARY=/path/to/mediamtx \
+  bun run test:integration:webrtc-mediamtx
+```
+
+The test uses localhost-only MediaMTX authentication from `mediamtx.yml` and
+temporarily binds the WebRTC HTTP listener to port 8889. Stop a conflicting
+local MediaMTX process before running it. The normal `bun test` suite leaves
+this test skipped; it does not require MediaMTX, FFmpeg, or Chrome.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test:image:bun": "bun scripts/ci/image-runtime-smoke.ts",
     "test:image:sharp-bun-repro": "bash scripts/validate-sharp-bun-repro.sh",
     "test:memory-leaks": "bun --expose-gc scripts/detect-memory-leaks.ts",
+    "test:integration:webrtc-mediamtx": "bash scripts/webrtc/run-mediamtx-publisher-integration.sh",
     "lint": "eslint . --fix --pass-on-unpruned-suppressions && bash scripts/check-no-new-direct-simctl.sh",
     "lint:prune": "eslint . --prune-suppressions",
     "lint:baseline": "eslint . --suppress-rule max-depth --suppress-rule complexity --suppress-rule max-nested-callbacks --suppress-rule auto-mobile/no-accumulator-foreach",

--- a/scripts/webrtc/run-mediamtx-publisher-integration.sh
+++ b/scripts/webrtc/run-mediamtx-publisher-integration.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Run the opt-in MediaMTX-backed WebRTC publisher integration test.
+#
+# The fast test suite discovers the test but skips it. This runner downloads the
+# pinned MediaMTX release when AUTOMOBILE_MEDIAMTX_BINARY is not supplied, then
+# enables the real SFU + FFmpeg + browser-decoder path explicitly.
+
+set -euo pipefail
+
+readonly MEDIAMTX_VERSION="1.19.2"
+readonly TEST_FILE="test/integration/mediamtxWebRtcPublisher.integration.test.ts"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cache_dir="${AUTOMOBILE_MEDIAMTX_CACHE_DIR:-${repo_root}/scratch/mediamtx}"
+
+fail() {
+  printf 'MediaMTX WebRTC integration: %s\n' "$*" >&2
+  exit 1
+}
+
+sha256_of() {
+  local file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${file}" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "${file}" | awk '{print $1}'
+  elif command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 "${file}" | awk '{print $2}'
+  else
+    fail "need sha256sum, shasum, or openssl to verify MediaMTX"
+  fi
+}
+
+resolve_release() {
+  local os arch
+  os="$(uname -s)"
+  arch="$(uname -m)"
+  case "${os}:${arch}" in
+    Darwin:arm64)
+      mediamtx_asset="mediamtx_v${MEDIAMTX_VERSION}_darwin_arm64.tar.gz"
+      mediamtx_sha256="c225e46ab65295f95ee9fcda75703129c07add8852483abda09299a78524391f"
+      ;;
+    Darwin:x86_64)
+      mediamtx_asset="mediamtx_v${MEDIAMTX_VERSION}_darwin_amd64.tar.gz"
+      mediamtx_sha256="b8851bf53d1e0d6d078240d54e78517a3a239b40040b22cddddf5a0ef2712c17"
+      ;;
+    Linux:aarch64 | Linux:arm64)
+      mediamtx_asset="mediamtx_v${MEDIAMTX_VERSION}_linux_arm64.tar.gz"
+      mediamtx_sha256="562f419912a8668c18216a9e8c95359ec82fbb754e4a44e2953ef62b98eec688"
+      ;;
+    Linux:x86_64 | Linux:amd64)
+      mediamtx_asset="mediamtx_v${MEDIAMTX_VERSION}_linux_amd64.tar.gz"
+      mediamtx_sha256="f9c601cc303ceca8fad2883917b022882672c5bc56311e92dbceb16e5f20c60c"
+      ;;
+    *)
+      fail "no pinned MediaMTX ${MEDIAMTX_VERSION} binary for ${os}/${arch}; set AUTOMOBILE_MEDIAMTX_BINARY"
+      ;;
+  esac
+}
+
+download_mediamtx() {
+  resolve_release
+  local install_dir archive actual_sha
+  install_dir="${cache_dir}/v${MEDIAMTX_VERSION}/${mediamtx_asset%.tar.gz}"
+  mediamtx_binary="${install_dir}/mediamtx"
+  if [[ -x "${mediamtx_binary}" ]]; then
+    return
+  fi
+
+  command -v curl >/dev/null 2>&1 || fail "curl is required to download MediaMTX; set AUTOMOBILE_MEDIAMTX_BINARY instead"
+  command -v tar >/dev/null 2>&1 || fail "tar is required to extract MediaMTX; set AUTOMOBILE_MEDIAMTX_BINARY instead"
+  mkdir -p "${install_dir}"
+  archive="$(mktemp "${cache_dir}/.${mediamtx_asset}.XXXXXX")"
+  trap 'rm -f "${archive}"' RETURN
+  curl --fail --location --retry 3 --output "${archive}" \
+    "https://github.com/bluenviron/mediamtx/releases/download/v${MEDIAMTX_VERSION}/${mediamtx_asset}"
+  actual_sha="$(sha256_of "${archive}")"
+  [[ "${actual_sha}" == "${mediamtx_sha256}" ]] || fail "downloaded MediaMTX checksum mismatch (wanted ${mediamtx_sha256}, got ${actual_sha})"
+  tar -xzf "${archive}" -C "${install_dir}"
+  [[ -x "${mediamtx_binary}" ]] || fail "MediaMTX archive did not contain an executable at ${mediamtx_binary}"
+}
+
+if [[ -n "${AUTOMOBILE_MEDIAMTX_BINARY:-}" ]]; then
+  mediamtx_binary="${AUTOMOBILE_MEDIAMTX_BINARY}"
+  [[ -x "${mediamtx_binary}" ]] || fail "AUTOMOBILE_MEDIAMTX_BINARY is not executable: ${mediamtx_binary}"
+else
+  download_mediamtx
+fi
+
+cd "${repo_root}"
+AUTOMOBILE_MEDIAMTX_WEBRTC_INTEGRATION=1 \
+AUTOMOBILE_MEDIAMTX_BINARY="${mediamtx_binary}" \
+  exec bun test "${TEST_FILE}"

--- a/test/bats/mediamtx-webrtc-integration.bats
+++ b/test/bats/mediamtx-webrtc-integration.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+#
+# Contract tests for the opt-in MediaMTX publisher -> WHEP decoder integration
+# runner. The real media path is intentionally outside the fast BATS suite.
+
+SCRIPT="scripts/webrtc/run-mediamtx-publisher-integration.sh"
+TEST_FILE="test/integration/mediamtxWebRtcPublisher.integration.test.ts"
+
+setup() {
+  TEST_DIR="$(mktemp -d)"
+  MOCK_BIN="${TEST_DIR}/bin"
+  INVOCATIONS_FILE="${TEST_DIR}/invocations"
+  mkdir -p "${MOCK_BIN}"
+  ORIG_PATH="${PATH}"
+}
+
+teardown() {
+  rm -rf "${TEST_DIR}"
+  export PATH="${ORIG_PATH}"
+}
+
+make_bun_stub() {
+  cat > "${MOCK_BIN}/bun" <<'SCRIPT'
+#!/usr/bin/env bash
+printf 'gate=%s binary=%s args=%s\n' \
+  "${AUTOMOBILE_MEDIAMTX_WEBRTC_INTEGRATION:-}" \
+  "${AUTOMOBILE_MEDIAMTX_BINARY:-}" \
+  "$*" >> "${INVOCATIONS_FILE}"
+SCRIPT
+  chmod +x "${MOCK_BIN}/bun"
+}
+
+@test "runner is executable and package.json exposes it" {
+  [ -x "${SCRIPT}" ]
+  run bun -e 'const pkg = require("./package.json"); process.exit(pkg.scripts["test:integration:webrtc-mediamtx"] ? 0 : 1);'
+  [ "${status}" -eq 0 ]
+}
+
+@test "injected MediaMTX binary is forwarded to the opt-in test without downloading" {
+  make_bun_stub
+  local binary="${TEST_DIR}/mediamtx"
+  cat > "${binary}" <<'SCRIPT'
+#!/usr/bin/env bash
+exit 0
+SCRIPT
+  chmod +x "${binary}"
+
+  run env \
+    PATH="${MOCK_BIN}:${PATH}" \
+    AUTOMOBILE_MEDIAMTX_BINARY="${binary}" \
+    INVOCATIONS_FILE="${INVOCATIONS_FILE}" \
+    bash "${SCRIPT}"
+
+  [ "${status}" -eq 0 ]
+  [ "$(cat "${INVOCATIONS_FILE}")" = "gate=1 binary=${binary} args=test ${TEST_FILE}" ]
+}
+
+@test "download path rejects a MediaMTX archive whose pinned checksum does not match" {
+  make_bun_stub
+  cat > "${MOCK_BIN}/uname" <<'SCRIPT'
+#!/usr/bin/env bash
+if [[ "$1" == "-s" ]]; then
+  printf '%s\n' Darwin
+else
+  printf '%s\n' arm64
+fi
+SCRIPT
+  cat > "${MOCK_BIN}/curl" <<'SCRIPT'
+#!/usr/bin/env bash
+for ((index = 1; index <= $#; index++)); do
+  if [[ "${!index}" == "--output" ]]; then
+    next=$((index + 1))
+    printf 'untrusted archive' > "${!next}"
+    exit 0
+  fi
+done
+exit 1
+SCRIPT
+  cat > "${MOCK_BIN}/sha256sum" <<'SCRIPT'
+#!/usr/bin/env bash
+printf '%064d  %s\n' 0 "$1"
+SCRIPT
+  chmod +x "${MOCK_BIN}/uname" "${MOCK_BIN}/curl" "${MOCK_BIN}/sha256sum"
+
+  run env \
+    PATH="${MOCK_BIN}:${PATH}" \
+    AUTOMOBILE_MEDIAMTX_CACHE_DIR="${TEST_DIR}/cache" \
+    INVOCATIONS_FILE="${INVOCATIONS_FILE}" \
+    bash "${SCRIPT}"
+
+  [ "${status}" -eq 1 ]
+  [[ "${output}" == *"checksum mismatch"* ]]
+  [ ! -e "${INVOCATIONS_FILE}" ]
+}

--- a/test/integration/mediamtxWebRtcPublisher.integration.test.ts
+++ b/test/integration/mediamtxWebRtcPublisher.integration.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, test } from "bun:test";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { once } from "node:events";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import WebSocket from "ws";
+import { WebRtcPublisher } from "../../src/features/webrtc/WebRtcPublisher";
+
+/**
+ * Real SFU + decoder coverage for #4290. This is deliberately opt-in: it
+ * spawns MediaMTX, FFmpeg, and a local Chrome instance, so it cannot be part of
+ * the pure-logic test suite. Run `bun run test:integration:webrtc-mediamtx`.
+ */
+const RUN_INTEGRATION = process.env.AUTOMOBILE_MEDIAMTX_WEBRTC_INTEGRATION === "1";
+const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
+const STREAM_NAME = "automobile-integration";
+const WEBRTC_PORT = 8889;
+const MAX_LOG_CHARS = 8_000;
+
+interface ChromeTarget {
+  type: string;
+  webSocketDebuggerUrl?: string;
+}
+
+interface CdpResponse {
+  id?: number;
+  result?: { result?: { value?: unknown } };
+  error?: { message?: string };
+}
+
+interface DecodedVideo {
+  width: number;
+  height: number;
+  decodedFrames: number;
+}
+
+class CdpClient {
+  private readonly socket: WebSocket;
+  private nextId = 1;
+  private readonly pending = new Map<number, { resolve: (value: CdpResponse) => void; reject: (error: Error) => void }>();
+
+  private constructor(socket: WebSocket) {
+    this.socket = socket;
+    socket.on("message", raw => {
+      const message = JSON.parse(raw.toString()) as CdpResponse;
+      if (message.id === undefined) {
+        return;
+      }
+      const request = this.pending.get(message.id);
+      if (!request) {
+        return;
+      }
+      this.pending.delete(message.id);
+      if (message.error) {
+        request.reject(new Error(`Chrome DevTools error: ${message.error.message}`));
+      } else {
+        request.resolve(message);
+      }
+    });
+    socket.on("close", () => {
+      for (const request of this.pending.values()) {
+        request.reject(new Error("Chrome DevTools connection closed"));
+      }
+      this.pending.clear();
+    });
+  }
+
+  static async connect(url: string): Promise<CdpClient> {
+    const socket = new WebSocket(url);
+    await once(socket, "open");
+    return new CdpClient(socket);
+  }
+
+  async command(method: string, params: Record<string, unknown> = {}): Promise<CdpResponse> {
+    const id = this.nextId++;
+    const response = new Promise<CdpResponse>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+    });
+    this.socket.send(JSON.stringify({ id, method, params }));
+    return response;
+  }
+
+  close(): void {
+    this.socket.close();
+  }
+}
+
+function appendLog(current: string, chunk: Buffer): string {
+  return `${current}${chunk.toString()}`.slice(-MAX_LOG_CHARS);
+}
+
+function startProcess(command: string, args: string[], cwd: string): { process: ChildProcessWithoutNullStreams; logs: () => string } {
+  const process = spawn(command, args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+  let output = "";
+  process.stdout.on("data", chunk => {
+    output = appendLog(output, chunk);
+  });
+  process.stderr.on("data", chunk => {
+    output = appendLog(output, chunk);
+  });
+  return { process, logs: () => output };
+}
+
+async function waitFor(predicate: () => boolean | Promise<boolean>, message: string, timeoutMs: number = 15_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) {
+      return;
+    }
+    await Bun.sleep(100);
+  }
+  if (!(await predicate())) {
+    throw new Error(message);
+  }
+}
+
+async function stopProcess(process: ChildProcessWithoutNullStreams | undefined): Promise<void> {
+  if (!process || process.exitCode !== null || process.killed) {
+    return;
+  }
+  process.kill("SIGTERM");
+  await Promise.race([
+    once(process, "exit"),
+    Bun.sleep(3_000),
+  ]);
+  if (process.exitCode === null && !process.killed) {
+    process.kill("SIGKILL");
+    await once(process, "exit");
+  }
+}
+
+function resolveChromeBinary(): string {
+  const configured = process.env.AUTOMOBILE_CHROME_BINARY;
+  if (configured) {
+    return configured;
+  }
+  const candidates = process.platform === "darwin"
+    ? ["/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"]
+    : ["/usr/bin/google-chrome", "/usr/bin/chromium", "/usr/bin/chromium-browser"];
+  const binary = candidates.find(existsSync);
+  if (!binary) {
+    throw new Error("Chrome is required; install it or set AUTOMOBILE_CHROME_BINARY");
+  }
+  return binary;
+}
+
+async function waitForChromeTarget(port: string): Promise<ChromeTarget> {
+  let targets: ChromeTarget[] = [];
+  await waitFor(async () => {
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/json/list`);
+      targets = await response.json() as ChromeTarget[];
+      return targets.some(target => target.type === "page" && target.webSocketDebuggerUrl);
+    } catch {
+      return false;
+    }
+  }, "Chrome DevTools did not expose a page target");
+  const target = targets.find(candidate => candidate.type === "page" && candidate.webSocketDebuggerUrl);
+  if (!target?.webSocketDebuggerUrl) {
+    throw new Error("Chrome DevTools returned no debuggable page");
+  }
+  return target;
+}
+
+async function openReader(chrome: ChildProcessWithoutNullStreams, profileDir: string): Promise<CdpClient> {
+  await waitFor(() => existsSync(join(profileDir, "DevToolsActivePort")), "Chrome did not create DevToolsActivePort");
+  if (chrome.exitCode !== null) {
+    throw new Error(`Chrome exited before DevTools started (${chrome.exitCode})`);
+  }
+  const [port] = (await readFile(join(profileDir, "DevToolsActivePort"), "utf8")).split("\n");
+  const target = await waitForChromeTarget(port);
+  const cdp = await CdpClient.connect(target.webSocketDebuggerUrl!);
+  await cdp.command("Page.enable");
+  await cdp.command("Runtime.enable");
+  await cdp.command("Page.navigate", { url: `http://127.0.0.1:${WEBRTC_PORT}/${STREAM_NAME}` });
+  return cdp;
+}
+
+async function readDecodedVideo(cdp: CdpClient): Promise<DecodedVideo> {
+  const expression = `
+    (async () => {
+      const deadline = Date.now() + 20000;
+      while (Date.now() < deadline) {
+        const video = document.querySelector("video");
+        const quality = video?.getVideoPlaybackQuality?.();
+        if (video && video.videoWidth > 0 && video.videoHeight > 0 && (quality?.totalVideoFrames ?? 0) > 0) {
+          return { width: video.videoWidth, height: video.videoHeight, decodedFrames: quality.totalVideoFrames };
+        }
+        await new Promise(resolve => setTimeout(resolve, 100));
+      }
+      const video = document.querySelector("video");
+      const quality = video?.getVideoPlaybackQuality?.();
+      return { width: video?.videoWidth ?? 0, height: video?.videoHeight ?? 0, decodedFrames: quality?.totalVideoFrames ?? 0 };
+    })()
+  `;
+  const response = await cdp.command("Runtime.evaluate", { expression, awaitPromise: true, returnByValue: true });
+  const value = response.result?.result?.value as DecodedVideo | undefined;
+  if (!value) {
+    throw new Error("Chrome did not return video playback quality");
+  }
+  return value;
+}
+
+describeIntegration("MediaMTX WebRTC publisher integration (#4290)", () => {
+  test("publishes real H.264 through WHIP and Chrome decodes the MediaMTX WHEP reader", async () => {
+    const mediamtxBinary = process.env.AUTOMOBILE_MEDIAMTX_BINARY;
+    if (!mediamtxBinary) {
+      throw new Error("AUTOMOBILE_MEDIAMTX_BINARY is required; use bun run test:integration:webrtc-mediamtx");
+    }
+    const repoRoot = resolve(import.meta.dir, "../..");
+    const tempDir = await mkdtemp(join(tmpdir(), "automobile-mediamtx-"));
+    const mediaMtx = startProcess(mediamtxBinary, [join(repoRoot, "examples/mediamtx/mediamtx.yml")], tempDir);
+    let ffmpeg: ChildProcessWithoutNullStreams | undefined;
+    let chrome: ChildProcessWithoutNullStreams | undefined;
+    let cdp: CdpClient | undefined;
+    const publisher = new WebRtcPublisher({
+      streamId: STREAM_NAME,
+      whipEndpoint: `http://127.0.0.1:${WEBRTC_PORT}/${STREAM_NAME}/whip`,
+      maxReconnectAttempts: 1,
+    });
+
+    try {
+      await waitFor(async () => {
+        try {
+          return (await fetch(`http://127.0.0.1:${WEBRTC_PORT}/`)).status < 500;
+        } catch {
+          return false;
+        }
+      }, `MediaMTX did not start:\n${mediaMtx.logs()}`);
+
+      await publisher.start();
+      ffmpeg = spawn("ffmpeg", [
+        "-hide_banner", "-loglevel", "error", "-re",
+        "-f", "lavfi", "-i", "testsrc2=size=320x240:rate=10",
+        "-an", "-c:v", "libx264", "-profile:v", "baseline", "-level:v", "3.1",
+        "-preset", "ultrafast", "-tune", "zerolatency", "-g", "10", "-keyint_min", "10",
+        "-f", "h264", "pipe:1",
+      ], { stdio: ["ignore", "pipe", "pipe"] });
+      let ffmpegErrors = "";
+      ffmpeg.stderr.on("data", chunk => {
+        ffmpegErrors = appendLog(ffmpegErrors, chunk);
+      });
+      ffmpeg.stdout.on("data", chunk => publisher.writeH264Chunk(chunk));
+
+      await waitFor(() => publisher.getDescriptor().framesSent >= 10, "publisher did not send synthetic H.264 frames");
+      const profileDir = join(tempDir, "chrome-profile");
+      chrome = startProcess(resolveChromeBinary(), [
+        "--headless=new", "--no-first-run", "--no-default-browser-check",
+        "--autoplay-policy=no-user-gesture-required", "--remote-debugging-port=0",
+        `--user-data-dir=${profileDir}`, "about:blank",
+      ], tempDir).process;
+      cdp = await openReader(chrome, profileDir);
+      const decoded = await readDecodedVideo(cdp);
+
+      expect(publisher.getDescriptor().framesSent).toBeGreaterThanOrEqual(10);
+      expect(publisher.getDescriptor().packetsSent).toBeGreaterThan(0);
+      expect(decoded.width).toBe(320);
+      expect(decoded.height).toBe(240);
+      expect(decoded.decodedFrames).toBeGreaterThan(0);
+      expect(ffmpegErrors).toBe("");
+    } finally {
+      cdp?.close();
+      await stopProcess(ffmpeg);
+      await publisher.stop();
+      await stopProcess(chrome);
+      await stopProcess(mediaMtx.process);
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  }, 90_000);
+});

--- a/test/integration/mediamtxWebRtcPublisher.integration.test.ts
+++ b/test/integration/mediamtxWebRtcPublisher.integration.test.ts
@@ -117,6 +117,47 @@ async function waitFor(predicate: () => boolean | Promise<boolean>, message: str
   }
 }
 
+function exitedProcessDescription(process: ChildProcessWithoutNullStreams): string | undefined {
+  if (process.exitCode !== null) {
+    return `exit code ${process.exitCode}`;
+  }
+  if (process.signalCode !== null) {
+    return `signal ${process.signalCode}`;
+  }
+  return undefined;
+}
+
+async function waitForHttpServer(
+  process: ChildProcessWithoutNullStreams,
+  logs: () => string,
+  url: string,
+  name: string,
+): Promise<void> {
+  await waitFor(async () => {
+    const exited = exitedProcessDescription(process);
+    if (exited) {
+      throw new Error(`${name} exited before readiness (${exited}):\n${logs()}`);
+    }
+    try {
+      const response = await fetch(url);
+      if (response.status >= 500) {
+        return false;
+      }
+      await Bun.sleep(100);
+      const exitedAfterProbe = exitedProcessDescription(process);
+      if (exitedAfterProbe) {
+        throw new Error(`${name} exited before readiness (${exitedAfterProbe}):\n${logs()}`);
+      }
+      return true;
+    } catch (error) {
+      if (error instanceof Error && error.message.startsWith(`${name} exited before readiness`)) {
+        throw error;
+      }
+      return false;
+    }
+  }, `${name} did not start:\n${logs()}`);
+}
+
 async function stopProcess(process: ChildProcessWithoutNullStreams | undefined, graceMs: number = 3_000): Promise<void> {
   if (!process || process.exitCode !== null || process.signalCode !== null) {
     return;
@@ -229,6 +270,16 @@ test.skipIf(process.platform === "win32")("force-kills a child that ignores SIGT
   expect(child.signalCode).toBe("SIGKILL");
 });
 
+test.skipIf(process.platform === "win32")("rejects a stale listener when the server child has already exited", async () => {
+  const child = spawn("/bin/sh", ["-c", "exit 7"], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  await once(child, "exit");
+
+  await expect(waitForHttpServer(child, () => "address already in use", "http://127.0.0.1:8889/", "MediaMTX"))
+    .rejects.toThrow("MediaMTX exited before readiness (exit code 7):\naddress already in use");
+});
+
 describeIntegration("MediaMTX WebRTC publisher integration (#4290)", () => {
   test("publishes real H.264 through WHIP and Chrome decodes the MediaMTX WHEP reader", async () => {
     const mediamtxBinary = process.env.AUTOMOBILE_MEDIAMTX_BINARY;
@@ -248,13 +299,12 @@ describeIntegration("MediaMTX WebRTC publisher integration (#4290)", () => {
     });
 
     try {
-      await waitFor(async () => {
-        try {
-          return (await fetch(`http://127.0.0.1:${WEBRTC_PORT}/`)).status < 500;
-        } catch {
-          return false;
-        }
-      }, `MediaMTX did not start:\n${mediaMtx.logs()}`);
+      await waitForHttpServer(
+        mediaMtx.process,
+        mediaMtx.logs,
+        `http://127.0.0.1:${WEBRTC_PORT}/`,
+        "MediaMTX",
+      );
 
       await publisher.start();
       ffmpeg = spawn("ffmpeg", [

--- a/test/integration/mediamtxWebRtcPublisher.integration.test.ts
+++ b/test/integration/mediamtxWebRtcPublisher.integration.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from "bun:test";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { once } from "node:events";
 import { existsSync } from "node:fs";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import WebSocket from "ws";
@@ -164,13 +165,26 @@ async function waitForChromeTarget(port: string): Promise<ChromeTarget> {
   return target;
 }
 
-async function openReader(chrome: ChildProcessWithoutNullStreams, profileDir: string): Promise<CdpClient> {
-  await waitFor(() => existsSync(join(profileDir, "DevToolsActivePort")), "Chrome did not create DevToolsActivePort");
+async function reserveLoopbackPort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("Could not reserve a loopback port for Chrome DevTools");
+  }
+  await new Promise<void>((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+  return address.port;
+}
+
+async function openReader(chrome: ChildProcessWithoutNullStreams, debugPort: number): Promise<CdpClient> {
   if (chrome.exitCode !== null) {
     throw new Error(`Chrome exited before DevTools started (${chrome.exitCode})`);
   }
-  const [port] = (await readFile(join(profileDir, "DevToolsActivePort"), "utf8")).split("\n");
-  const target = await waitForChromeTarget(port);
+  const target = await waitForChromeTarget(String(debugPort));
   const cdp = await CdpClient.connect(target.webSocketDebuggerUrl!);
   await cdp.command("Page.enable");
   await cdp.command("Runtime.enable");
@@ -258,12 +272,13 @@ describeIntegration("MediaMTX WebRTC publisher integration (#4290)", () => {
 
       await waitFor(() => publisher.getDescriptor().framesSent >= 10, "publisher did not send synthetic H.264 frames");
       const profileDir = join(tempDir, "chrome-profile");
+      const debugPort = await reserveLoopbackPort();
       chrome = startProcess(resolveChromeBinary(), [
         "--headless=new", "--no-first-run", "--no-default-browser-check",
-        "--autoplay-policy=no-user-gesture-required", "--remote-debugging-port=0",
+        "--autoplay-policy=no-user-gesture-required", `--remote-debugging-port=${debugPort}`,
         `--user-data-dir=${profileDir}`, "about:blank",
       ], tempDir).process;
-      cdp = await openReader(chrome, profileDir);
+      cdp = await openReader(chrome, debugPort);
       const decoded = await readDecodedVideo(cdp);
 
       expect(publisher.getDescriptor().framesSent).toBeGreaterThanOrEqual(10);

--- a/test/integration/mediamtxWebRtcPublisher.integration.test.ts
+++ b/test/integration/mediamtxWebRtcPublisher.integration.test.ts
@@ -116,16 +116,16 @@ async function waitFor(predicate: () => boolean | Promise<boolean>, message: str
   }
 }
 
-async function stopProcess(process: ChildProcessWithoutNullStreams | undefined): Promise<void> {
-  if (!process || process.exitCode !== null || process.killed) {
+async function stopProcess(process: ChildProcessWithoutNullStreams | undefined, graceMs: number = 3_000): Promise<void> {
+  if (!process || process.exitCode !== null || process.signalCode !== null) {
     return;
   }
   process.kill("SIGTERM");
   await Promise.race([
     once(process, "exit"),
-    Bun.sleep(3_000),
+    Bun.sleep(graceMs),
   ]);
-  if (process.exitCode === null && !process.killed) {
+  if (process.exitCode === null && process.signalCode === null) {
     process.kill("SIGKILL");
     await once(process, "exit");
   }
@@ -202,6 +202,18 @@ async function readDecodedVideo(cdp: CdpClient): Promise<DecodedVideo> {
   }
   return value;
 }
+
+test.skipIf(process.platform === "win32")("force-kills a child that ignores SIGTERM", async () => {
+  const child = spawn("/bin/sh", ["-c", 'trap "" TERM; printf ready; while :; do sleep 1; done'], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  await once(child.stdout, "data");
+
+  await stopProcess(child, 10);
+
+  expect(child.exitCode).toBeNull();
+  expect(child.signalCode).toBe("SIGKILL");
+});
 
 describeIntegration("MediaMTX WebRTC publisher integration (#4290)", () => {
   test("publishes real H.264 through WHIP and Chrome decodes the MediaMTX WHEP reader", async () => {


### PR DESCRIPTION
## Summary

- add an opt-in MediaMTX integration test that feeds real FFmpeg-generated H.264 through `WebRtcPublisher` over WHIP and requires decoded frames from MediaMTX's WHEP reader in headless Chrome
- add a checksum-verified, pinned MediaMTX v1.19.2 runner plus BATS coverage for binary forwarding and failed checksum handling
- document local prerequisites, cached download behavior, and the pre-downloaded binary override

## Why opt-in

This test intentionally stays out of the pure-logic suite: it starts a real SFU, FFmpeg encoder, local browser decoder, and UDP/WebRTC transport. It is available through `bun run test:integration:webrtc-mediamtx`; ordinary `bun test` discovers it as a skip.

Closes #4290

## Validation

- [x] `bun run test:integration:webrtc-mediamtx` — real MediaMTX WHIP → WHEP → Chrome decode
- [x] `bats test/bats/`
- [x] `shellcheck scripts/webrtc/run-mediamtx-publisher-integration.sh`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run turbo:validate`
