### PR TITLE
perf: batch ktfmt validation

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -717,19 +717,9 @@ jobs:
         shell: bash
         env:
           INSTALL_KTFMT_WHEN_MISSING: "true"
-          # Scope the Kotlin format check to files this PR changed. validate_ktfmt.sh
-          # diffs `git diff <base>...HEAD` (three-dot, i.e. relative to the merge
-          # base), so it flags only the PR's own changes, not base-branch commits.
-          # The full tree is already conformant and is re-checked in full
-          # post-merge by the `ktfmt` job in merge.yml -- the backstop for any
-          # tool/style/JDK drift a scoped PR check would miss.
-          ONLY_CHANGED_SINCE_SHA: ${{ github.event.pull_request.base.sha }}
-          # Safety net for the degenerate cases: an empty base SHA, or a
-          # non-empty base SHA that does not resolve (base force-pushed/rebased),
-          # both fall back to a full-tree check. KTFMT_ONLY_TOUCHED_FILES=false
-          # ensures that fallback is the full tree, not the working-tree "touched"
-          # mode -- which sees no changes on a clean CI checkout and would
-          # silently pass without validating anything.
+          # ktfmt validates the complete Kotlin tree in pre-merge Fast Validation.
+          # The batched validator starts one JVM for all files, keeping the
+          # full-tree backstop fast enough to catch formatting drift before merge.
           KTFMT_ONLY_TOUCHED_FILES: "false"
         run: |
           scripts/all_fast_validate_checks.sh \

--- a/scripts/all_fast_validate_checks.sh
+++ b/scripts/all_fast_validate_checks.sh
@@ -30,6 +30,7 @@ add_check() {
   CHECK_DESCRIPTIONS+=("$4")
 }
 
+add_check "ktfmt" "ONLY_TOUCHED_FILES=${KTFMT_ONLY_TOUCHED_FILES:-true} \"$PROJECT_ROOT/scripts/ktfmt/validate_ktfmt.sh\"" "format,kotlin" "Validate Kotlin formatting"
 add_check "yaml" "bun \"$PROJECT_ROOT/scripts/validate-yaml.ts\"" "config,yaml" "Validate test plan YAML files"
 add_check "xml" "\"$PROJECT_ROOT/scripts/xml/validate_xml.sh\"" "config,xml" "Validate XML files"
 add_check "shellcheck" "\"$PROJECT_ROOT/scripts/shellcheck/validate_shell_scripts.sh\"" "lint,shell" "Validate shell scripts with shellcheck"
@@ -37,7 +38,6 @@ add_check "shell-portability" "\"$PROJECT_ROOT/scripts/shellcheck/validate_shell
 add_check "shell-sete" "\"$PROJECT_ROOT/scripts/shellcheck/validate_shell_sete.sh\"" "lint,shell" "Gate new set -e-suppressed shell findings against the baseline"
 add_check "stdlib-first" "\"$PROJECT_ROOT/scripts/conventions/validate-stdlib-first.sh\"" "lint,conventions" "Enforce structured parsing and shared-helper conventions"
 add_check "mkdocs-nav" "\"$PROJECT_ROOT/scripts/validate_mkdocs_nav.sh\"" "docs" "Validate MkDocs navigation"
-add_check "ktfmt" "ONLY_TOUCHED_FILES=${KTFMT_ONLY_TOUCHED_FILES:-true} \"$PROJECT_ROOT/scripts/ktfmt/validate_ktfmt.sh\"" "format,kotlin" "Validate Kotlin formatting"
 add_check "claude-plugin" "\"$PROJECT_ROOT/scripts/claude/validate_plugin.sh\"" "config" "Validate Claude plugin structure"
 add_check "codex-skills" "\"$PROJECT_ROOT/scripts/validate_codex_skills.sh\"" "config,docs" "Validate Codex skills and AGENTS inventory"
 add_check "lychee" "\"$PROJECT_ROOT/scripts/lychee/validate_lychee.sh\"" "docs,links" "Validate documentation links"

--- a/scripts/ktfmt/validate_ktfmt.sh
+++ b/scripts/ktfmt/validate_ktfmt.sh
@@ -68,9 +68,12 @@ echo -e "${YELLOW}Starting ktfmt validation...${NC}"
 
 # Function to find all Kotlin files
 find_all_kotlin_files() {
+    # Scope hidden-file exclusion to the project itself. A generic `*/.*`
+    # pattern also matches hidden parent directories such as
+    # `/Users/jason/.codex/worktrees`, making a valid worktree look empty.
     find "$PROJECT_ROOT" -type f '(' -name "*.kt" -o -name "*.kts" ')' \
         -not -path "*/build/*" \
-        -not -path "*/.*" \
+        -not -path "$PROJECT_ROOT/.*" \
         -not -path "*/node_modules/*" \
         -not -path "*/target/*" \
         -not -path "*/out/*" \
@@ -140,6 +143,21 @@ if [[ -n "$ONLY_CHANGED_SINCE_SHA" ]] \
     && ! git rev-parse --verify -q "${ONLY_CHANGED_SINCE_SHA}^{commit}" >/dev/null 2>&1; then
     echo -e "${YELLOW}Base SHA '${ONLY_CHANGED_SINCE_SHA}' does not resolve; falling back to a full-tree ktfmt check.${NC}"
     ONLY_CHANGED_SINCE_SHA=""
+    ONLY_TOUCHED_FILES=false
+fi
+
+# A changed formatter, its file-selection helper, or its CI runtime can change
+# the result for files outside a PR's Kotlin diff. Run the full tree for those
+# changes rather than relying on the post-merge backstop to discover drift.
+if [[ -n "$ONLY_CHANGED_SINCE_SHA" ]] \
+    && ! git diff --quiet "$ONLY_CHANGED_SINCE_SHA"...HEAD -- \
+        scripts/ktfmt \
+        scripts/lib/file-selection.sh \
+        .github/workflows/pull_request.yml \
+        .github/workflows/merge.yml; then
+    echo -e "${YELLOW}Ktfmt inputs changed since the base SHA; running a full-tree ktfmt check.${NC}"
+    ONLY_CHANGED_SINCE_SHA=""
+    ONLY_TOUCHED_FILES=false
 fi
 
 if [[ -n "$ONLY_CHANGED_SINCE_SHA" ]]; then
@@ -170,46 +188,35 @@ fi
 
 echo -e "${YELLOW}Found ${#files_to_process[@]} Kotlin file(s) to process${NC}"
 
-# Create temporary file for storing file list
-temp_file=$(mktemp)
-trap 'rm -f "$temp_file"' EXIT
+# ktfmt writes formatted content back to its input files. Mirror the selected
+# files under one temporary root so validation stays read-only, then format all
+# copies in one JVM. The old one-file-at-a-time loop started a JVM per source
+# file; on main that turned 680 files into a ten-minute job.
+temp_dir=$(mktemp -d)
+ktfmt_log=$(mktemp)
+trap 'rm -rf "$temp_dir"; rm -f "$ktfmt_log"' EXIT
 
-# Write files to temporary file for xargs processing
-printf '%s\n' "${files_to_process[@]}" > "$temp_file"
+declare -a formatted_files
+for file in "${files_to_process[@]}"; do
+    relative_file="${file#"$PROJECT_ROOT"/}"
+    formatted_file="$temp_dir/$relative_file"
+    mkdir -p "$(dirname "$formatted_file")"
+    cp "$file" "$formatted_file"
+    formatted_files+=("$formatted_file")
+done
 
-# Run ktfmt with xargs and capture output
+# Passing all files in one invocation is safe for the current tree (680 paths)
+# and removes almost all JVM startup cost; no parallel workers are needed.
 echo -e "${YELLOW}Running ktfmt...${NC}"
-
-if [[ -s "$temp_file" ]]; then
-    temp_dir=$(mktemp -d)
-    trap 'rm -rf "$temp_dir"' EXIT
-
-    while IFS= read -r file; do
-        if [[ -f "$file" ]]; then
-            # Preserve the file name for actionable output while formatting an
-            # isolated copy so validation never mutates the working tree.
-            temp_file_path="$temp_dir/$(basename "$file")"
-            cp "$file" "$temp_file_path"
-
-            # Format the temp file with --google-style (2-space block and
-            # 2-space continuation indent — the style the tree is formatted
-            # with). Treat a non-zero ktfmt exit as a failure rather than
-            # silently diffing an unformatted copy (which would falsely report
-            # the file as clean).
-            if ! ktfmt --google-style "$temp_file_path" >/dev/null 2>&1; then
-                errors="${errors}${file}: ktfmt failed to run (non-zero exit)\n"
-                continue
-            fi
-
-            # Compare original and formatted versions.
-            if ! diff -q "$file" "$temp_file_path" >/dev/null 2>&1; then
-                errors="${errors}${file}: File needs formatting\n"
-            fi
-        fi
-    done < "$temp_file"
-else
-    echo -e "${GREEN}No files to process${NC}"
+if ! ktfmt --google-style "${formatted_files[@]}" > "$ktfmt_log" 2>&1; then
+    errors="ktfmt failed to run (non-zero exit):\n$(<"$ktfmt_log")\n"
 fi
+
+for index in "${!files_to_process[@]}"; do
+    if ! diff -q "${files_to_process[$index]}" "${formatted_files[$index]}" >/dev/null 2>&1; then
+        errors="${errors}${files_to_process[$index]}: File needs formatting\n"
+    fi
+done
 
 # Calculate total elapsed time
 if [[ -f "$PROJECT_ROOT/scripts/utils/get_timestamp.sh" ]]; then

--- a/test/bats/validate-ktfmt.bats
+++ b/test/bats/validate-ktfmt.bats
@@ -21,9 +21,10 @@ setup() {
   #    pin). Tests override KTFMT_STUB_VERSION to simulate formatter-version drift,
   #    or set KTFMT_STUB_VERSION="" to simulate an unparseable/failing --version.
   #  * exits 0 for the stdin probe (`--google-style -`) and dry-run.
-  #  * for an in-place `--google-style <file>` it "reformats" (mutating the copy
-  #    the script made) only when the file contains the marker FORMAT_ME, letting
-  #    a test simulate a misformatted file deterministically.
+  #  * for an in-place `--google-style <files...>` it "reformats" (mutating the
+  #    copies the script made) only when a file contains FORMAT_ME, letting a test
+  #    simulate a misformatted file deterministically. It also records each
+  #    formatting invocation when KTFMT_STUB_LOG is set.
   STUB_BIN="$TEST_DIR/bin"
   mkdir -p "$STUB_BIN"
   cat > "$STUB_BIN/ktfmt" <<'STUB'
@@ -51,21 +52,27 @@ if [[ "$last" == "-" || " $* " == *" --dry-run "* ]]; then
   cat >/dev/null 2>&1 || true
   exit 0
 fi
-if [[ -f "$last" ]]; then
-  if grep -q 'FORMAT_ME' "$last"; then
-    sed -i.bak 's/FORMAT_ME//g' "$last" && rm -f "$last.bak"
-  fi
-  exit 0
+if [[ -n "${KTFMT_STUB_LOG:-}" ]]; then
+  printf '%s\n' "$#" >> "$KTFMT_STUB_LOG"
+  printf '%s\n' "$@" >> "$KTFMT_STUB_LOG"
 fi
+for file in "$@"; do
+  [[ "$file" == "--google-style" ]] && continue
+  if [[ -f "$file" ]] && grep -q 'FORMAT_ME' "$file"; then
+    sed -i.bak 's/FORMAT_ME//g' "$file" && rm -f "$file.bak"
+  fi
+done
 exit 0
 STUB
   chmod +x "$STUB_BIN/ktfmt"
   export PATH="$STUB_BIN:$PATH"
 
   # A throwaway git repo that becomes PROJECT_ROOT (script uses `pwd`).
-  REPO="$TEST_DIR/repo"
+  # Mirror the standard Codex worktree layout. The validator must not exclude
+  # Kotlin files merely because a parent directory is hidden (`.codex`).
+  REPO="$TEST_DIR/.codex/worktrees/ktfmt"
   mkdir -p "$REPO/app/src"
-  cd "$REPO"
+  cd "$REPO" || return 1
   git init -q
   git config user.email t@t.t
   git config user.name t
@@ -77,7 +84,7 @@ teardown() {
 }
 
 # Helper: write a clean (already-formatted) Kotlin file.
-clean_kt() { printf 'fun a() {}\n' > "$1"; }
+clean_kt() { mkdir -p "$(dirname "$1")" && printf 'fun a() {}\n' > "$1"; }
 
 @test "validator runs under strict bash mode" {
   grep -qx 'set -euo pipefail' "$SCRIPT"
@@ -124,7 +131,7 @@ clean_kt() { printf 'fun a() {}\n' > "$1"; }
   git add -A && git commit -qm base
 
   run env ONLY_CHANGED_SINCE_SHA="deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" \
-    ONLY_TOUCHED_FILES=false bash "$SCRIPT"
+    ONLY_TOUCHED_FILES=true bash "$SCRIPT"
   [ "$status" -eq 0 ]
   [[ "$output" == *"does not resolve; falling back to a full-tree ktfmt check"* ]]
   # It must actually validate the tree, not report "No Kotlin files".
@@ -183,6 +190,39 @@ STUB
   [ "$status" -ne 0 ]
   [[ "$output" == *"Formatting issues found"* ]]
   [[ "$output" == *"Bad.kt"* ]]
+}
+
+@test "formats isolated copies in one invocation and preserves duplicate basenames" {
+  clean_kt app/one/Same.kt
+  clean_kt app/two/Same.kt
+  local ktfmt_log="$TEST_DIR/ktfmt.log"
+
+  run env KTFMT_STUB_LOG="$ktfmt_log" ONLY_CHANGED_SINCE_SHA="" \
+    ONLY_TOUCHED_FILES=false bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+
+  # One formatter process handles both copies, and their relative paths remain
+  # distinct so a Same.kt in one directory cannot overwrite the other copy.
+  [ "$(wc -l < "$ktfmt_log")" -eq 4 ]
+  [[ "$(sed -n '1p' "$ktfmt_log")" == "3" ]]
+  [[ "$(sed -n '2p' "$ktfmt_log")" == "--google-style" ]]
+  [[ "$(sed -n '3p' "$ktfmt_log")" == */app/one/Same.kt ]]
+  [[ "$(sed -n '4p' "$ktfmt_log")" == */app/two/Same.kt ]]
+}
+
+@test "formatter input changes force a full-tree check" {
+  clean_kt app/src/Base.kt
+  git add -A && git commit -qm base
+  local base; base="$(git rev-parse HEAD)"
+  clean_kt app/src/Feature.kt
+  mkdir -p scripts/ktfmt
+  printf 'changed formatter input\n' > scripts/ktfmt/config
+  git add -A && git commit -qm formatter-change
+
+  run env ONLY_CHANGED_SINCE_SHA="$base" ONLY_TOUCHED_FILES=true bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Ktfmt inputs changed since the base SHA; running a full-tree ktfmt check"* ]]
+  [[ "$output" == *"Found 2 Kotlin file(s) to process"* ]]
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- format selected Kotlin files in one ktfmt JVM invocation on isolated temporary copies
- preserve changed-file PR validation and force a full-tree check when formatter inputs change
- scope hidden-directory exclusion to the project root so `.codex` worktrees are validated
- validate the complete Kotlin tree in pre-merge Fast Validation
- add regression coverage for batching, duplicate basenames, and the full-tree fallback

## Why

The main ktfmt job started one JVM per Kotlin file. On the 680-file tree, that ran for more than ten minutes before cancellation; a single invocation completed the same formatting work in about two seconds locally. The old hidden-path exclusion also incorrectly skipped every source file when the project lived below `.codex/worktrees`.

## Validation

- `bats test/bats/validate-ktfmt.bats`
- `shellcheck scripts/ktfmt/validate_ktfmt.sh test/bats/validate-ktfmt.bats`
- `git diff --check`
