### PR TITLE
fix(daemon): reject unsupported enter button

### DIFF
--- a/docs/design-docs/mcp/daemon/unix-socket-api.md
+++ b/docs/design-docs/mcp/daemon/unix-socket-api.md
@@ -485,7 +485,7 @@ Presses a device or navigation button.
 |---|---|---|---|
 | `platform` | `"android" \| "ios"` | Yes | Target platform. |
 | `deviceId` | `string` | No | Target device; see [Common input fields](#common-input-fields). |
-| `button` | `"back" \| "home" \| "app_switch" \| "volume_up" \| "volume_down" \| "power" \| "enter"` plus MCP aliases `"menu"` and `"recent"` | Yes | Button to press. Unsupported buttons fail with `success: false`. |
+| `button` | `"back" \| "home" \| "app_switch" \| "volume_up" \| "volume_down" \| "power"` plus MCP aliases `"menu"` and `"recent"` | Yes | Button to press. Unsupported buttons fail with `success: false`. |
 
 **Request**
 
@@ -529,10 +529,8 @@ Examples for supported Android navigation and hardware actions:
 `app_switch` is the socket API name for the app switcher and maps to the MCP
 `recent` button implementation. The daemon also accepts the MCP alias `recent`.
 
-`enter` is reserved by the socket contract but is not implemented by
-`input/pressButton`; callers should use `input/key` for a discrete Enter press
-or `input/typeText` for committed text. `enter` currently returns a clear
-unsupported error instead of being treated as an unknown field value.
+`enter` is not a supported `input/pressButton` value. Callers should use
+`input/key` for a discrete Enter press or `input/typeText` for committed text.
 
 iOS supports `home`, `back`, and `app_switch` through CtrlProxy navigation. On
 physical iOS devices, `power`, `volume_up`, and `volume_down` route to the

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1293,7 +1293,7 @@ export class UnixSocketServer {
     if (typeof args.button !== "string") {
       throw new Error("input/pressButton requires button");
     }
-    const supportedButtons = ["home", "back", "menu", "power", "volume_up", "volume_down", "recent", "app_switch", "enter"];
+    const supportedButtons = ["home", "back", "menu", "power", "volume_up", "volume_down", "recent", "app_switch"];
     if (!supportedButtons.includes(args.button)) {
       throw new Error(`input/pressButton button must be one of: ${supportedButtons.join(", ")}`);
     }

--- a/test/daemon/socketServerInputPressButton.test.ts
+++ b/test/daemon/socketServerInputPressButton.test.ts
@@ -375,7 +375,7 @@ describe("UnixSocketServer input/pressButton", () => {
     expect(press).toHaveBeenCalledWith("menu", expect.any(Number));
   });
 
-  test("accepts enter as a socket contract button and reports the current platform unsupported result", async () => {
+  test("rejects enter before calling the platform button handler", async () => {
     const press = mock(async (button: string): Promise<PressButtonResult> => ({
       success: false,
       button,
@@ -394,8 +394,10 @@ describe("UnixSocketServer input/pressButton", () => {
     });
 
     expect(response.success).toBe(false);
-    expect(response.error).toBe("Unsupported button: enter");
-    expect(press).toHaveBeenCalledWith("enter", expect.any(Number));
+    expect(response.error).toBe(
+      "input/pressButton button must be one of: home, back, menu, power, volume_up, volume_down, recent, app_switch"
+    );
+    expect(press).not.toHaveBeenCalled();
   });
 
   test("rejects missing, non-string, and unsupported button values with actionable errors", async () => {
@@ -421,7 +423,7 @@ describe("UnixSocketServer input/pressButton", () => {
     expect(nonString.error).toBe("input/pressButton requires button");
     expect(unsupported.success).toBe(false);
     expect(unsupported.error).toBe(
-      "input/pressButton button must be one of: home, back, menu, power, volume_up, volume_down, recent, app_switch, enter"
+      "input/pressButton button must be one of: home, back, menu, power, volume_up, volume_down, recent, app_switch"
     );
   });
 });

--- a/test/docs/daemonInputApiExamples.test.ts
+++ b/test/docs/daemonInputApiExamples.test.ts
@@ -183,6 +183,15 @@ describe("daemon input API consumer docs", () => {
     expect(unixSocketApi).toContain("iOS simulators return clear unsupported errors for");
   });
 
+  test("documents pressButton values that the socket actually accepts", async () => {
+    const unixSocketApi = await readRepoFile("docs/design-docs/mcp/daemon/unix-socket-api.md");
+
+    expect(unixSocketApi).toContain('"back" \\| "home" \\| "app_switch" \\| "volume_up" \\| "volume_down" \\| "power"');
+    expect(unixSocketApi).toContain("`input/key` for a discrete Enter press");
+    expect(unixSocketApi).not.toContain('"power" \\| "enter"');
+    expect(unixSocketApi).not.toContain("`enter` is reserved by the socket contract");
+  });
+
   test("links future IDE screen control docs to the daemon input API", async () => {
     const unixSocketApi = await readRepoFile("docs/design-docs/mcp/daemon/unix-socket-api.md");
     const screenStreaming = await readRepoFile("docs/design-docs/mcp/observe/screen-streaming.md");


### PR DESCRIPTION
## Summary

Remove the unsupported `enter` value from the daemon socket `input/pressButton` contract. The socket now rejects it before dispatching to a platform-specific button handler, matching the MCP tool's advertised buttons.

## Linked Issue

Closes #4214

## Bug / Regression Context

- **Prior attempts:** None; this is a pre-existing socket contract gap.
- **Observed symptom:** `button: "enter"` passed daemon validation but then failed downstream as unsupported on every platform.
- **Repro steps / conditions:** Send `input/pressButton` with `platform: "android"` and `button: "enter"`.

## Validation

- [x] Focused daemon socket regression test: `bun test test/daemon/socketServerInputPressButton.test.ts`
- [x] `bun run turbo:validate` passes
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] No Android/iOS changes
- [x] No new generic code or dependencies
- [x] Rebased onto the latest `origin/main` before implementation

## Follow-ups

- [x] No follow-up issues needed; the socket contract now matches the supported MCP button set.
