### PR TITLE
refactor(ci): extract PR review-thread collection

### DIFF
--- a/scripts/ci/pr-review-threads.sh
+++ b/scripts/ci/pr-review-threads.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Emit a complete JSON array of review threads for a pull request.
+#
+# Usage: scripts/ci/pr-review-threads.sh [PR_NUMBER] [--unresolved-only]
+#
+# GraphQL --paginate emits one JSON document per page. --slurp retains every
+# document so jq can flatten them before anything is written to stdout.
+set -uo pipefail
+
+REPO=kaeawc/auto-mobile
+PR_NUMBER=""
+UNRESOLVED_ONLY=false
+
+for argument in "$@"; do
+  case "$argument" in
+    --unresolved-only)
+      if [ "$UNRESOLVED_ONLY" = true ]; then
+        echo "--unresolved-only was provided more than once." >&2
+        exit 2
+      fi
+      UNRESOLVED_ONLY=true
+      ;;
+    --*)
+      echo "Unknown option: ${argument}" >&2
+      exit 2
+      ;;
+    *)
+      if [ -n "$PR_NUMBER" ]; then
+        echo "Only one pull request number may be provided." >&2
+        exit 2
+      fi
+      PR_NUMBER="$argument"
+      ;;
+  esac
+done
+
+if [ -z "$PR_NUMBER" ]; then
+  PR_NUMBER=$(gh pr view --json number -q .number 2>/dev/null) || {
+    echo "No PR found for the current branch. Usage: $0 [PR_NUMBER] [--unresolved-only]" >&2
+    exit 1
+  }
+fi
+
+if [ -z "$PR_NUMBER" ]; then
+  echo "No PR found for the current branch. Usage: $0 [PR_NUMBER] [--unresolved-only]" >&2
+  exit 1
+fi
+
+TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/pr-review-threads.XXXXXX") || exit 1
+trap 'rm -rf "$TEMP_DIR"' EXIT
+PAGES_FILE="${TEMP_DIR}/pages.json"
+THREADS_FILE="${TEMP_DIR}/threads.json"
+
+# shellcheck disable=SC2016 # GraphQL variables must reach gh literally.
+if ! gh api graphql --paginate --slurp -f query='
+query($owner:String!,$repo:String!,$pr:Int!,$endCursor:String){
+  repository(owner:$owner,name:$repo){
+    pullRequest(number:$pr){
+      reviewThreads(first:100, after:$endCursor){
+        pageInfo{ hasNextPage endCursor }
+        nodes{ id isResolved isOutdated path line originalLine diffSide
+          comments(first:20){ nodes{ author{login} body url createdAt } } } } } } }' \
+  -F owner="${REPO%%/*}" -F repo="${REPO##*/}" -F pr="$PR_NUMBER" >"$PAGES_FILE"; then
+  echo "Could not collect review threads for PR #${PR_NUMBER}." >&2
+  exit 1
+fi
+
+# Validate the complete response before emitting anything. A malformed or partial
+# GraphQL payload must fail closed rather than look like an empty feedback ledger.
+if ! jq -e '
+  if type != "array" or length == 0 then
+    error("expected GraphQL pages array")
+  elif .[-1].data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage != false then
+    error("final GraphQL page indicates more review threads")
+  elif all(.[]; (.data.repository.pullRequest.reviewThreads.nodes | type) == "array"
+                   and (.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage | type) == "boolean")
+    and all(.[] | .data.repository.pullRequest.reviewThreads.nodes[]; (.comments.nodes | type) == "array") then
+    [.[] | .data.repository.pullRequest.reviewThreads.nodes[] | .comments = .comments.nodes]
+  else
+    error("reviewThreads nodes missing from GraphQL response")
+  end
+' "$PAGES_FILE" >"$THREADS_FILE"; then
+  echo "Could not validate review threads for PR #${PR_NUMBER}; no partial result was emitted." >&2
+  exit 1
+fi
+
+if [ "$UNRESOLVED_ONLY" = true ]; then
+  jq '[.[] | select(.isResolved | not)]' "$THREADS_FILE"
+else
+  cat "$THREADS_FILE"
+fi

--- a/skills/github-cli/SKILL.md
+++ b/skills/github-cli/SKILL.md
@@ -43,39 +43,15 @@ This is just the mechanics.
 ## Review threads: resolution state
 
 `GET /pulls/{n}/comments` and `gh pr view --json comments` return bodies but **not** whether a
-thread is resolved; that lives only in GraphQL. Note `first: 100` is not pagination — a PR with
-more than 100 threads truncates silently, with no error — so page properly:
+thread is resolved; that lives only in GraphQL. Collect threads through the tested helper:
 
 ```bash
-gh api graphql --paginate -f query='
-query($owner:String!,$repo:String!,$pr:Int!,$endCursor:String){
-  repository(owner:$owner,name:$repo){
-    pullRequest(number:$pr){
-      reviewThreads(first:100, after:$endCursor){
-        pageInfo{ hasNextPage endCursor }
-        nodes{ id isResolved isOutdated path line originalLine diffSide
-          comments(first:20){ nodes{ author{login} body url createdAt } } } } } } }' \
-  -F owner=kaeawc -F repo=auto-mobile -F pr=<PR> \
-  --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved|not)
-        | "\(.id)\t\(.path):\(.line)\t\(.comments.nodes[0].author.login)"'
+scripts/ci/pr-review-threads.sh <PR> --unresolved-only
 ```
 
-**GraphQL `--paginate` does not merge.** Unlike the REST array endpoints above, it emits one
-complete JSON *document per page*, concatenated. The `--jq` form above is safe because jq
-streams every document — but redirecting the same query to a file and parsing it afterwards
-reads **only the first page**, silently, with no error. Verified on PR [#4098](https://github.com/kaeawc/auto-mobile/pull/4098) with `first: 2`
-against 4 threads: the saved file yields `nodes | length` = 2, and `pageInfo` appears twice.
-
-So when you need the whole result as a file, add `--slurp` (which cannot be combined with
-`--jq`) and index through the page array:
-
-```bash
-gh api graphql --paginate --slurp -f query='…' -F pr=<PR> > scratch/threads.json
-jq '[.[].data.repository.pullRequest.reviewThreads.nodes[]]' scratch/threads.json
-```
-
-Otherwise keep `--jq` and consume the stream directly. Never save a non-slurped GraphQL
-`--paginate` result and parse it as one document.
+It paginates review threads, emits one clean JSON array, and fails closed rather than returning a
+partial feedback ledger. Do not replace it with a saved `gh api graphql --paginate` response:
+GraphQL emits one JSON document per page, unlike the REST array endpoints above.
 
 `--paginate` advances the **outer** `reviewThreads` connection only. The nested
 `comments(first:20)` is a separate connection: a thread with more replies than that silently

--- a/skills/github-pr-feedback/SKILL.md
+++ b/skills/github-pr-feedback/SKILL.md
@@ -27,18 +27,17 @@ needs a deliberate disposition. See `github-cli` for the underlying command mech
    - conversation: `gh api --paginate "repos/<owner>/<repo>/issues/<pr>/comments?per_page=100"`
    - review verdicts: `gh api --paginate "repos/<owner>/<repo>/pulls/<pr>/reviews?per_page=100"`
    - inline: `gh api --paginate "repos/<owner>/<repo>/pulls/<pr>/comments?per_page=100"`
-   - GraphQL review threads, paginated with `first: 100`, `$endCursor`, and `pageInfo`,
-     requesting `id`, `isResolved`, `isOutdated`, `path`, `line`, `originalLine`, `diffSide`,
-     and every comment's author, body, URL, and timestamp.
+   - GraphQL review threads: `scripts/ci/pr-review-threads.sh <pr>`, which returns a complete
+     JSON array containing `id`, `isResolved`, `isOutdated`, `path`, `line`, `originalLine`,
+     `diffSide`, and each requested comment's author, body, URL, and timestamp. Add
+     `--unresolved-only` only when the full resolved-thread history is not needed.
 
    Query thread state even when the flat inline list is empty.
 
    The three REST endpoints return top-level arrays and `--paginate` merges them, so saving
    and parsing those is safe — do not add `--slurp`, which would yield an array *of pages* and
-   is rejected alongside `--jq`. **GraphQL is the opposite**: `--paginate` emits one document
-   per page, so a saved-then-parsed result silently contains only page one. Either consume it
-   through `--jq`, or add `--slurp` and index `[.[].data…nodes[]]`. A ledger built from page
-   one looks complete and is not.
+   is rejected alongside `--jq`. GraphQL is the opposite, which is why review threads must use
+   `pr-review-threads.sh`; a ledger built from only its first page looks complete and is not.
 4. Build the ledger — one row per unresolved thread, review request, inline comment, and
    conversation comment: source URL, head SHA, requested behavior, file/line, disposition
    (`fix`, `wrong reason, right change`, `already addressed`, `not actionable`, `duplicate`,

--- a/test/bats/pr-review-threads.bats
+++ b/test/bats/pr-review-threads.bats
@@ -1,0 +1,121 @@
+#!/usr/bin/env bats
+# Tests for scripts/ci/pr-review-threads.sh (issue #4120).
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/ci/pr-review-threads.sh"
+
+setup() {
+  TEST_ROOT="$(mktemp -d)"
+  STUB_DIR="${TEST_ROOT}/bin"
+  mkdir -p "$STUB_DIR"
+
+  cat >"${STUB_DIR}/gh" <<'SHIM'
+#!/usr/bin/env bash
+set -u
+
+printf '%s\n' "$*" >> "${GH_CALLS:?}"
+
+case "$*" in
+  "api graphql "*)
+    case "${GH_SCENARIO:?}" in
+      two-pages)
+        jq -s '.' <<'JSON'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"thread-one","isResolved":false,"isOutdated":false,"path":"one.ts","line":1,"originalLine":1,"diffSide":"RIGHT","comments":{"nodes":[{"author":{"login":"first"},"body":"first body","url":"https://example.test/one","createdAt":"2026-01-01T00:00:00Z"}]}}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-one"}}}}}}
+{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"thread-two","isResolved":true,"isOutdated":false,"path":"two.ts","line":2,"originalLine":2,"diffSide":"RIGHT","comments":{"nodes":[]}},{"id":"thread-three","isResolved":false,"isOutdated":true,"path":"three.ts","line":3,"originalLine":3,"diffSide":"RIGHT","comments":{"nodes":[]}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}
+JSON
+        ;;
+      empty)
+        printf '%s\n' '[{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}]'
+        ;;
+      incomplete)
+        printf '%s\n' '[{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"id":"thread-one","isResolved":false,"isOutdated":false,"path":"one.ts","line":1,"originalLine":1,"diffSide":"RIGHT","comments":{"nodes":[]}}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-one"}}}}}}]'
+        ;;
+      api-error)
+        printf '%s\n' 'simulated GitHub API failure' >&2
+        exit 1
+        ;;
+      *)
+        echo "unknown scenario: ${GH_SCENARIO}" >&2
+        exit 99
+        ;;
+    esac
+    ;;
+  "pr view "*)
+    printf '%s\n' '42'
+    ;;
+  *)
+    echo "unexpected gh call: $*" >&2
+    exit 99
+    ;;
+esac
+SHIM
+  chmod +x "${STUB_DIR}/gh"
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT"
+}
+
+run_script() {
+  if [ -n "${2:-}" ]; then
+    run env \
+      PATH="${STUB_DIR}:/opt/homebrew/bin:/usr/bin:/bin" \
+      GH_CALLS="${TEST_ROOT}/gh-calls" \
+      GH_SCENARIO="$1" \
+      bash "$SCRIPT" 42 "$2"
+  else
+    run env \
+      PATH="${STUB_DIR}:/opt/homebrew/bin:/usr/bin:/bin" \
+      GH_CALLS="${TEST_ROOT}/gh-calls" \
+      GH_SCENARIO="$1" \
+      bash "$SCRIPT" 42
+  fi
+}
+
+@test "flattens every GraphQL page into one JSON array" {
+  run_script two-pages
+
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s' "$output" | jq -e 'type == "array" and length == 3')" = "true" ]
+  [ "$(printf '%s' "$output" | jq -r '.[].id' | tr '\n' ' ')" = "thread-one thread-two thread-three " ]
+  [ "$(printf '%s' "$output" | jq -e '.[0].comments | type == "array" and .[0].author.login == "first"')" = "true" ]
+  grep -q -- '--paginate --slurp' "${TEST_ROOT}/gh-calls"
+}
+
+@test "unresolved-only filters by isResolved without dropping outdated threads" {
+  run_script two-pages --unresolved-only
+
+  [ "$status" -eq 0 ]
+  [ "$(printf '%s' "$output" | jq -e 'length == 2 and all(.[]; .isResolved | not)')" = "true" ]
+  [ "$(printf '%s' "$output" | jq -r '.[].id' | tr '\n' ' ')" = "thread-one thread-three " ]
+}
+
+@test "an empty review-thread response emits an empty JSON array" {
+  run_script empty
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "[]" ]
+}
+
+@test "an API failure exits non-zero without writing a partial array to stdout" {
+  stdout_file="${TEST_ROOT}/stdout"
+  stderr_file="${TEST_ROOT}/stderr"
+
+  run bash -c 'env PATH="$1:/opt/homebrew/bin:/usr/bin:/bin" GH_CALLS="$2" GH_SCENARIO=api-error bash "$3" 42 >"$4" 2>"$5"' \
+    _ "$STUB_DIR" "${TEST_ROOT}/gh-calls" "$SCRIPT" "$stdout_file" "$stderr_file"
+
+  [ "$status" -ne 0 ]
+  [ ! -s "$stdout_file" ]
+  grep -q 'simulated GitHub API failure' "$stderr_file"
+}
+
+@test "a response whose final page has more pages fails without emitting a partial array" {
+  stdout_file="${TEST_ROOT}/stdout"
+  stderr_file="${TEST_ROOT}/stderr"
+
+  run bash -c 'env PATH="$1:/opt/homebrew/bin:/usr/bin:/bin" GH_CALLS="$2" GH_SCENARIO=incomplete bash "$3" 42 >"$4" 2>"$5"' \
+    _ "$STUB_DIR" "${TEST_ROOT}/gh-calls" "$SCRIPT" "$stdout_file" "$stderr_file"
+
+  [ "$status" -ne 0 ]
+  [ ! -s "$stdout_file" ]
+  grep -q 'final GraphQL page indicates more review threads' "$stderr_file"
+}


### PR DESCRIPTION
## Summary

Extracts pull-request review-thread collection into a tested CI script. The helper flattens every
GraphQL page into one JSON array and fails without emitting partial output when collection or
response validation fails. The feedback skills now call that helper instead of embedding the
pagination details.

## Linked Issue

Closes #4120

## Validation

- [x] `bats test/bats/pr-review-threads.bats`
- [x] ShellCheck, shell portability, and `set -e` gates
- [x] `bash scripts/validate_codex_skills.sh`
- [x] `bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Rebased onto latest `main`, conflicts resolved

## Follow-ups

- [x] No follow-up issues needed; nested review-comment pagination remains explicitly documented
  as a separate GraphQL connection.
