### PR TITLE
perf(ci): overlap Reminders XCTest prebuild warm-up

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1667,6 +1667,17 @@ jobs:
         timeout-minutes: 10
         run: ./scripts/ios/video-recording-start-stop-integration.sh
 
+      # The Xcode toolchain was selected by the bring-up above. XCTest compilation
+      # is CPU-bound, while the daemon and CtrlProxy warm-ups are mostly wait-bound,
+      # so overlap them (#4131). The barrier before the target-app warm-up keeps
+      # `swift test` from compiling after the final warm-up and re-cooling the sim.
+      - name: "Pre-build Reminders XCTest bundle (Xcode 26.5)"
+        if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
+        timeout-minutes: 15
+        background: true
+        id: prebuild-xctest
+        run: ./scripts/ci/prebuild-reminders-xctest-bundle.sh
+
       # This is a freshly-booted sim, so bring the daemon to ready and warm
       # CtrlProxy before the Reminders run. Pre-starting the daemon and waiting
       # for readiness makes a startup failure surface loudly here instead of
@@ -1686,15 +1697,9 @@ jobs:
         timeout-minutes: 12
         run: ./scripts/ci/ensure-ctrl-proxy-ready.sh
 
-      # Compile the XCTest bundle BEFORE the target-app warm-up. Otherwise `swift test`
-      # in the timed Reminders step spends tens of seconds compiling first, letting the
-      # freshly-warmed simulator/app go cold again and reintroducing the cold observe
-      # timeout (#3851 direction 4). Runs after the leg's Xcode is selected so the build
-      # cache matches the `swift test` that follows.
-      - name: "Pre-build Reminders XCTest bundle (Xcode 26.5)"
-        if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
-        timeout-minutes: 15
-        run: ./scripts/ci/prebuild-reminders-xctest-bundle.sh
+      # A background failure surfaces at this barrier. Do not start the target-app
+      # warm-up until the test bundle is complete, or `swift test` can re-cool it.
+      - wait: prebuild-xctest
 
       # Keep target-app cold bring-up outside the timed Reminders plan. CtrlProxy
       # is already warm above; this leaves Reminders foregrounded so the plan's

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RemindersPlanContentTests.swift
@@ -257,16 +257,15 @@ final class RemindersPlanContentTests: XCTestCase {
 
     /// The XCTest bundle must be compiled before the target-app warm-up (#3851 direction 4):
     /// otherwise `swift test` in the timed Reminders step compiles first, re-cooling the
-    /// freshly-warmed simulator/app and reintroducing the cold observe timeout. The pre-build
-    /// must also follow the leg's CtrlProxy warm-up (which runs after the leg's Xcode is
-    /// selected) so the build cache matches the `swift test` that follows.
+    /// freshly-warmed simulator/app and reintroducing the cold observe timeout. The Xcode
+    /// toolchain is selected by the earlier simulator bring-up, so this pre-build may overlap
+    /// daemon and CtrlProxy warm-up, but it must finish before target-app warm-up.
     func testPullRequestWorkflowPreBuildsXCTestBundleBeforeWarmUp() throws {
         let workflow = try loadRepositoryFile(".github/workflows/pull_request.yml")
 
         assertWorkflowPreBuildsXCTestBundleBeforeWarmUp(
             workflow,
             preBuildStepName: "Pre-build Reminders XCTest bundle (Xcode 26.5)",
-            afterCtrlProxyStepName: "Warm up iOS CtrlProxy (Xcode 26.5)",
             warmupStepName: "Warm up Reminders target app (Xcode 26.5)"
         )
     }
@@ -893,14 +892,28 @@ private func assertWorkflowWarmsTargetAppBeforeRemindersRun(
 private func assertWorkflowPreBuildsXCTestBundleBeforeWarmUp(
     _ workflow: String,
     preBuildStepName: String,
-    afterCtrlProxyStepName: String,
+    afterCtrlProxyStepName: String? = nil,
     warmupStepName: String,
     file: StaticString = #filePath,
     line: UInt = #line
 ) {
-    guard let ctrlProxyRange = workflow.range(of: #"name: "\#(afterCtrlProxyStepName)""#) else {
-        XCTFail("Workflow is missing step named \(afterCtrlProxyStepName)", file: file, line: line)
-        return
+    if let afterCtrlProxyStepName {
+        guard let ctrlProxyRange = workflow.range(of: #"name: "\#(afterCtrlProxyStepName)""#) else {
+            XCTFail("Workflow is missing step named \(afterCtrlProxyStepName)", file: file, line: line)
+            return
+        }
+        guard let preBuildRange = workflow.range(of: #"name: "\#(preBuildStepName)""#) else {
+            XCTFail("Workflow is missing step named \(preBuildStepName)", file: file, line: line)
+            return
+        }
+        XCTAssertLessThan(
+            ctrlProxyRange.lowerBound,
+            preBuildRange.lowerBound,
+            "\(preBuildStepName) must run after \(afterCtrlProxyStepName) so the leg's Xcode toolchain "
+                + "is already selected and the pre-build cache matches the swift test that follows",
+            file: file,
+            line: line
+        )
     }
     guard let preBuildRange = workflow.range(of: #"name: "\#(preBuildStepName)""#) else {
         XCTFail("Workflow is missing step named \(preBuildStepName)", file: file, line: line)
@@ -911,14 +924,6 @@ private func assertWorkflowPreBuildsXCTestBundleBeforeWarmUp(
         return
     }
 
-    XCTAssertLessThan(
-        ctrlProxyRange.lowerBound,
-        preBuildRange.lowerBound,
-        "\(preBuildStepName) must run after \(afterCtrlProxyStepName) so the leg's Xcode toolchain "
-            + "is already selected and the pre-build cache matches the swift test that follows",
-        file: file,
-        line: line
-    )
     XCTAssertLessThan(
         preBuildRange.lowerBound,
         warmupRange.lowerBound,

--- a/test/scripts/remindersXctestPrebuildOverlap.test.ts
+++ b/test/scripts/remindersXctestPrebuildOverlap.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { indexOfNamed, indexOfWaitOn, loadJobSteps, stepNamed } from "../helpers/workflowSteps";
+
+// Guards #4131: compiling XCTestRunner tests is CPU-bound, while daemon and
+// CtrlProxy readiness are mostly wait-bound. Start the prebuild before those
+// warm-ups, then join it immediately before warming the Reminders target app:
+// `swift test` must never recompile after that final warm-up.
+const WORKFLOW = ".github/workflows/pull_request.yml";
+const JOB_ID = "ios-xctest-runner-simulator-tests";
+const PREBUILD_STEP = "Pre-build Reminders XCTest bundle (Xcode 26.5)";
+const DAEMON_STEP = "Ensure AutoMobile daemon ready (Xcode 26.5)";
+const CTRL_PROXY_STEP = "Warm up iOS CtrlProxy (Xcode 26.5)";
+const REMINDERS_WARMUP_STEP = "Warm up Reminders target app (Xcode 26.5)";
+const PREBUILD_ID = "prebuild-xctest";
+
+const steps = loadJobSteps(WORKFLOW, JOB_ID);
+
+describe("#4131 Reminders XCTest prebuild overlap", () => {
+  test("the XCTestRunner job exists and has steps", () => {
+    expect(steps.length).toBeGreaterThan(0);
+  });
+
+  test("the prebuild is backgrounded with a stable id", () => {
+    const prebuild = stepNamed(steps, PREBUILD_STEP);
+
+    expect(prebuild).toBeDefined();
+    expect(prebuild?.background).toBe(true);
+    expect(prebuild?.id).toBe(PREBUILD_ID);
+  });
+
+  test("the prebuild overlaps daemon and CtrlProxy warm-up", () => {
+    const prebuildIndex = indexOfNamed(steps, PREBUILD_STEP);
+    const daemonIndex = indexOfNamed(steps, DAEMON_STEP);
+    const ctrlProxyIndex = indexOfNamed(steps, CTRL_PROXY_STEP);
+
+    expect(prebuildIndex).toBeGreaterThanOrEqual(0);
+    expect(daemonIndex).toBeGreaterThanOrEqual(0);
+    expect(ctrlProxyIndex).toBeGreaterThanOrEqual(0);
+    expect(prebuildIndex).toBeLessThan(daemonIndex);
+    expect(daemonIndex).toBeLessThan(ctrlProxyIndex);
+  });
+
+  test("the prebuild barrier immediately precedes Reminders warm-up", () => {
+    const ctrlProxyIndex = indexOfNamed(steps, CTRL_PROXY_STEP);
+    const waitIndex = indexOfWaitOn(steps, PREBUILD_ID);
+    const warmupIndex = indexOfNamed(steps, REMINDERS_WARMUP_STEP);
+
+    expect(ctrlProxyIndex).toBeGreaterThanOrEqual(0);
+    expect(waitIndex).toBeGreaterThan(ctrlProxyIndex);
+    expect(warmupIndex).toBeGreaterThanOrEqual(0);
+    expect(waitIndex).toBe(warmupIndex - 1);
+  });
+});


### PR DESCRIPTION
## Summary

Starts the Reminders XCTest bundle prebuild in the background before daemon and CtrlProxy warm-up, then joins it immediately before the target-app warm-up. This overlaps CPU-bound compilation with mostly wait-bound readiness while preserving the final warmed state for `swift test`.

## Linked Issue

Closes #4131

## Validation

- [x] `bun test test/scripts/remindersXctestPrebuildOverlap.test.ts`
- [x] `swift test --filter RemindersPlanContentTests`
- [x] `bats test/bats/xctest-shared-prereq-gate.bats`
- [x] `bats test/bats/prebuild-reminders-xctest-bundle.bats`
- [x] `scripts/all_fast_validate_checks.sh --only yaml --max-parallel 1`
- [x] `bun run typecheck` reports no new errors
- [x] `bun run turbo:validate`

## CI experiment measurement

The forced `XCTestRunner Simulator Tests` job passed in 18m39s. The three immediately preceding successful runs took 14m30s, 12m44s, and 11m29s (mean 12m54s), so this run was 5m45s (45%) slower than that mean.

The changed sequence behaved correctly, but the measured target steps regressed: CtrlProxy warm-up took 2m15s, Reminders target-app warm-up took 1m03s, and the Reminders integration tests took 1m25s. The corresponding three-run means were 1m26s, 0m37s, and 0m51s. Per [#4131](https://github.com/kaeawc/auto-mobile/issues/4131), this experiment will be closed without merging.
