### PR TITLE
test(action): make device action failures assertive

### DIFF
--- a/test/features/action/HomeScreen.test.ts
+++ b/test/features/action/HomeScreen.test.ts
@@ -72,13 +72,15 @@ describe("HomeScreen", () => {
     test("should work with progress callback", async () => {
       fakeAdb.setCommandResponse("shell input keyevent 3", { stdout: "", stderr: "" });
 
+      let callbackCalled = false;
       const progressCallback = async () => {
-        // callback for progress tracking
+        callbackCalled = true;
       };
       const result = await homeScreen.execute(progressCallback);
 
       expect(result.success).toBe(true);
       expect(result.navigationMethod).toBe("hardware");
+      expect(callbackCalled).toBe(true);
     });
 
     test("should include observation in result", async () => {
@@ -119,14 +121,9 @@ describe("HomeScreen", () => {
 
   describe("error handling", () => {
     test("should propagate errors when hardware navigation fails", async () => {
-      fakeAdb.setCommandResponse("shell input keyevent 3", { stdout: "", stderr: "Hardware failed" });
+      fakeAdb.setCommandError("shell input keyevent 3", new Error("hardware home failed"));
 
-      try {
-        await homeScreen.execute();
-        throw new Error("Should have thrown an error");
-      } catch (error) {
-        expect(error).toBeDefined();
-      }
+      await expect(homeScreen.execute()).rejects.toThrow("hardware home failed");
     });
   });
 

--- a/test/features/action/ImeAction.test.ts
+++ b/test/features/action/ImeAction.test.ts
@@ -297,19 +297,6 @@ describe("ImeAction", () => {
     });
   });
 
-  describe("constructor", () => {
-    test("should work with device object", () => {
-      const imeActionInstance = new ImeAction(testDevice);
-      expect(imeActionInstance).toBeDefined();
-    });
-
-    test("should work with custom FakeAdbExecutor", () => {
-      const customAdb = new FakeAdbExecutor();
-      const imeActionInstance = new ImeAction(testDevice, customAdb);
-      expect(imeActionInstance).toBeDefined();
-    });
-  });
-
   describe("timing", () => {
     test("should complete quickly via accessibility service", async () => {
       fakeA11yService.setHierarchyData({
@@ -345,12 +332,7 @@ describe("ImeAction", () => {
       fakeObserveScreen.setFailureMode("getMostRecentCachedObserveResult", new Error("Cannot perform action without view hierarchy"));
       fakeObserveScreen.setFailureMode("execute", new Error("Cannot perform action without view hierarchy"));
 
-      try {
-        await imeAction.execute("done");
-        throw new Error("Expected an error to be thrown");
-      } catch (caughtError) {
-        expect((caughtError as Error).message).toContain("Cannot perform action without view hierarchy");
-      }
+      await expect(imeAction.execute("done")).rejects.toThrow("Cannot perform action without view hierarchy");
     });
 
     test("should handle observation failure", async () => {
@@ -364,14 +346,7 @@ describe("ImeAction", () => {
       const observationError = new Error("Failed to observe screen");
       fakeObserveScreen.setFailureMode("execute", observationError);
 
-      try {
-        const result = await imeAction.execute("done");
-        // If we get here, BaseVisualChange handled the observation error
-        expect(result.action).toBe("done");
-      } catch (caughtError) {
-        // If the error bubbled up, that's also valid behavior
-        expect((caughtError as Error).message).toContain("Failed to observe screen");
-      }
+      await expect(imeAction.execute("done")).rejects.toThrow("Failed to observe screen");
     });
 
     test("should handle null action gracefully", async () => {

--- a/test/features/action/RecentApps.test.ts
+++ b/test/features/action/RecentApps.test.ts
@@ -197,7 +197,7 @@ describe("RecentApps", () => {
       const result = await recentApps.execute(progressCallback);
 
       expect(result.success).toBe(true);
-      expect(callbackCalled || fakeObserveScreen.wasMethodCalled("execute")).toBe(true);
+      expect(callbackCalled).toBe(true);
     });
 
     test("should handle missing view hierarchy gracefully", async () => {
@@ -208,14 +208,10 @@ describe("RecentApps", () => {
         return result;
       });
 
-      try {
-        const result = await recentApps.execute();
-        // BaseVisualChange catches the error and returns success: false
-        // We're testing the graceful handling, so just ensure result is not successful
-        expect(result.success).toBe(false);
-      } catch (caughtError) {
-        expect((caughtError as Error).message).toContain("Cannot perform action without view hierarchy");
-      }
+      const result = await recentApps.execute();
+
+      expect(result.success).toBe(false);
+      expect(result.method).toBe("unknown");
     });
 
     test("should handle missing screen size gracefully", async () => {
@@ -226,12 +222,7 @@ describe("RecentApps", () => {
         return result;
       });
 
-      try {
-        await recentApps.execute();
-        throw new Error("Expected an error to be thrown");
-      } catch (caughtError) {
-        expect((caughtError as Error).message).toContain("Screen size or system insets not available");
-      }
+      await expect(recentApps.execute()).rejects.toThrow("Screen size or system insets not available");
     });
   });
 
@@ -274,42 +265,25 @@ describe("RecentApps", () => {
     test("should handle gesture navigation ADB command failure", async () => {
       const mockCachedObservation = createObserveResult(createGestureNavigationHierarchy());
       fakeObserveScreen.setObserveResult(mockCachedObservation);
-      fakeAdb.setDefaultResponse({ stdout: "", stderr: "error" });
+      fakeAdb.setDefaultError(new Error("gesture command failed"));
 
-      try {
-        await recentApps.execute();
-        throw new Error("Expected an error to be thrown");
-      } catch (caughtError) {
-        expect(caughtError).toBeDefined();
-      }
+      await expect(recentApps.execute()).rejects.toThrow("gesture command failed");
     });
 
     test("should handle legacy navigation ADB command failure", async () => {
       const mockCachedObservation = createObserveResult(createLegacyNavigationHierarchy());
       fakeObserveScreen.setObserveResult(mockCachedObservation);
-      // Set default response with error to simulate ADB failure
-      fakeAdb.setDefaultResponse({ stdout: "", stderr: "error" });
+      fakeAdb.setDefaultError(new Error("legacy command failed"));
 
-      try {
-        await recentApps.execute();
-        throw new Error("Expected an error to be thrown");
-      } catch (caughtError) {
-        // Error should be thrown when ADB command fails
-        expect(caughtError).toBeDefined();
-      }
+      await expect(recentApps.execute()).rejects.toThrow("legacy command failed");
     });
 
     test("should handle hardware navigation ADB command failure", async () => {
       const mockCachedObservation = createObserveResult(createEmptyHierarchy());
       fakeObserveScreen.setObserveResult(mockCachedObservation);
-      fakeAdb.setCommandResponse("shell input keyevent 187", { stdout: "", stderr: "error" });
+      fakeAdb.setCommandError("shell input keyevent 187", new Error("hardware command failed"));
 
-      try {
-        await recentApps.execute();
-        throw new Error("Expected an error to be thrown");
-      } catch (caughtError) {
-        expect(caughtError).toBeDefined();
-      }
+      await expect(recentApps.execute()).rejects.toThrow("hardware command failed");
     });
 
     test("should handle missing system insets for gesture navigation", async () => {
@@ -317,12 +291,7 @@ describe("RecentApps", () => {
       (mockCachedObservation.systemInsets as any) = null;
       fakeObserveScreen.setObserveResult(mockCachedObservation);
 
-      try {
-        await recentApps.execute();
-        throw new Error("Expected an error to be thrown");
-      } catch (caughtError) {
-        expect((caughtError as Error).message).toContain("Screen size or system insets not available");
-      }
+      await expect(recentApps.execute()).rejects.toThrow("Screen size or system insets not available");
     });
 
     test("should handle missing recent apps button in legacy navigation", async () => {
@@ -337,27 +306,11 @@ describe("RecentApps", () => {
       (recentApps as any).detectNavigationStyle = () => "legacy";
 
       try {
-        await recentApps.execute();
-        throw new Error("Expected an error to be thrown");
-      } catch (caughtError) {
-        expect((caughtError as Error).message).toContain("Recent apps button not found");
+        await expect(recentApps.execute()).rejects.toThrow("Recent apps button not found");
       } finally {
         // Restore the original method
         (recentApps as any).detectNavigationStyle = originalDetectNavigationStyle;
       }
-    });
-  });
-
-  describe("constructor", () => {
-    test("should work with null deviceId", () => {
-      const recentAppsInstance = new RecentApps(testDevice, fakeAdb, fakeTimer);
-      expect(recentAppsInstance).toBeDefined();
-    });
-
-    test("should work with custom AdbClient", () => {
-      const customAdb = new FakeAdbExecutor();
-      const recentAppsInstance = new RecentApps(testDevice, customAdb, fakeTimer);
-      expect(recentAppsInstance).toBeDefined();
     });
   });
 
@@ -403,12 +356,7 @@ describe("RecentApps", () => {
     test("should throw when CtrlProxy recentApps fails on iOS", async () => {
       fakeIOSCtrlProxy.setFailureMode("recentApps", new Error("Connection lost"));
 
-      try {
-        await iosRecentApps.execute();
-        throw new Error("Expected an error to be thrown");
-      } catch (error) {
-        expect((error as Error).message).toContain("Connection lost");
-      }
+      await expect(iosRecentApps.execute()).rejects.toThrow("Connection lost");
     });
 
     test("should return explicit failure when CtrlProxy cannot verify App Switcher on iOS", async () => {

--- a/test/features/action/Rotate.test.ts
+++ b/test/features/action/Rotate.test.ts
@@ -222,31 +222,6 @@ describe("Rotate", () => {
     });
   });
 
-  describe("constructor", () => {
-    test("should work with non-null deviceId", () => {
-      const device: BootedDevice = {
-        name: "Test Device",
-        platform: "android",
-        deviceId: "test-device",
-        source: "local"
-      };
-      const rotateInstance = new Rotate(device, null, fakeTimer);
-      expect(rotateInstance).toBeDefined();
-    });
-
-    test("should work with custom ADB executor", () => {
-      const device: BootedDevice = {
-        name: "Test Device",
-        platform: "android",
-        deviceId: "test-device",
-        source: "local"
-      };
-      const customAdb = new FakeAdbExecutor();
-      const rotateInstance = new Rotate(device, customAdb, fakeTimer);
-      expect(rotateInstance).toBeDefined();
-    });
-  });
-
   describe("edge cases", () => {
     test("should handle whitespace in ADB output", async () => {
       fakeAdb.setCommandResponse("shell settings get system user_rotation", createExecResult("  1  \n"));

--- a/test/features/action/Shake.test.ts
+++ b/test/features/action/Shake.test.ts
@@ -1,6 +1,6 @@
 import { expect, describe, test, beforeEach, spyOn } from "bun:test";
 import { Shake } from "../../../src/features/action/Shake";
-import { BootedDevice, ObserveResult } from "../../../src/models";
+import { BootedDevice, ObserveResult, ShakeOptions } from "../../../src/models";
 
 const testDevice: BootedDevice = { name: "test-device", platform: "android", deviceId: "emulator-5554" };
 import { IOSCtrlProxyClient } from "../../../src/features/observe/ios";
@@ -51,118 +51,24 @@ describe("Shake", () => {
   });
 
   describe("execute", () => {
-    test("should execute shake with default parameters", async () => {
-      // Mock successful ADB commands
-      fakeAdb.setCommandResponse("emu sensor set acceleration 100:100:100", { stdout: "", stderr: "" });
-      fakeAdb.setCommandResponse("emu sensor set acceleration 0:0:0", { stdout: "", stderr: "" });
-
-      // Mock observation (BaseVisualChange calls observeScreen.execute at the end)
-      const mockObservation = createObserveResult();
-      fakeObserveScreen.setObserveResult(mockObservation);
-
-      // Start the execution
-      const resultPromise = shake.execute();
-      const result = await resultPromise;
+    test.each([
+      { name: "defaults", options: undefined, duration: 1000, intensity: 100 },
+      { name: "a custom duration", options: { duration: 100 }, duration: 100, intensity: 100 },
+      { name: "a custom intensity", options: { duration: 100, intensity: 200 }, duration: 100, intensity: 200 },
+      { name: "custom duration and intensity", options: { duration: 100, intensity: 150 }, duration: 100, intensity: 150 },
+      { name: "an empty options object", options: {}, duration: 1000, intensity: 100 },
+      { name: "a zero duration", options: { duration: 0 }, duration: 0, intensity: 100 },
+      { name: "a zero intensity", options: { duration: 100, intensity: 0 }, duration: 100, intensity: 0 }
+    ] satisfies Array<{ name: string; options: ShakeOptions | undefined; duration: number; intensity: number }>)("executes shake with $name", async ({ options, duration, intensity }) => {
+      const result = await shake.execute(options);
 
       expect(result.success).toBe(true);
-      expect(result.duration).toBe(1000);
-      expect(result.intensity).toBe(100);
+      expect(result.duration).toBe(duration);
+      expect(result.intensity).toBe(intensity);
       expect(result.observation).toBeDefined();
-
-      // Verify timer was called with correct duration
-      expect(fakeTimer.wasSleepCalled(1000)).toBe(true);
-
-      // Verify ADB commands were executed
-      const executedCommands = fakeAdb.getExecutedCommands();
-      expect(executedCommands.some(cmd => cmd.includes("emu sensor set acceleration 100:100:100"))).toBe(true);
-      expect(executedCommands.some(cmd => cmd.includes("emu sensor set acceleration 0:0:0"))).toBe(true);
-    });
-
-    test("should execute shake with custom duration", async () => {
-      fakeAdb.setCommandResponse("emu sensor set acceleration 100:100:100", { stdout: "", stderr: "" });
-      fakeAdb.setCommandResponse("emu sensor set acceleration 0:0:0", { stdout: "", stderr: "" });
-      const mockObservation = createObserveResult();
-      fakeObserveScreen.setObserveResult(mockObservation);
-
-      const resultPromise = shake.execute({ duration: 100 }); // Reduced for faster test
-      const result = await resultPromise;
-
-      expect(result.success).toBe(true);
-      expect(result.duration).toBe(100);
-      expect(result.intensity).toBe(100);
-      expect(fakeTimer.wasSleepCalled(100)).toBe(true);
-    });
-
-    test("should execute shake with custom intensity", async () => {
-      fakeAdb.setCommandResponse("emu sensor set acceleration 200:200:200", { stdout: "", stderr: "" });
-      fakeAdb.setCommandResponse("emu sensor set acceleration 0:0:0", { stdout: "", stderr: "" });
-      const mockObservation = createObserveResult();
-      fakeObserveScreen.setObserveResult(mockObservation);
-
-      const resultPromise = shake.execute({ intensity: 200, duration: 100 }); // Reduced duration
-      const result = await resultPromise;
-
-      expect(result.success).toBe(true);
-      expect(result.duration).toBe(100);
-      expect(result.intensity).toBe(200);
-    });
-
-    test("should execute shake with custom duration and intensity", async () => {
-      fakeAdb.setCommandResponse("emu sensor set acceleration 150:150:150", { stdout: "", stderr: "" });
-      fakeAdb.setCommandResponse("emu sensor set acceleration 0:0:0", { stdout: "", stderr: "" });
-      const mockObservation = createObserveResult();
-      fakeObserveScreen.setObserveResult(mockObservation);
-
-      const resultPromise = shake.execute({ duration: 100, intensity: 150 }); // Reduced duration
-      const result = await resultPromise;
-
-      expect(result.success).toBe(true);
-      expect(result.duration).toBe(100);
-      expect(result.intensity).toBe(150);
-    });
-
-    test("should execute shake with empty options object", async () => {
-      fakeAdb.setCommandResponse("emu sensor set acceleration 100:100:100", { stdout: "", stderr: "" });
-      fakeAdb.setCommandResponse("emu sensor set acceleration 0:0:0", { stdout: "", stderr: "" });
-      const mockObservation = createObserveResult();
-      fakeObserveScreen.setObserveResult(mockObservation);
-
-      const resultPromise = shake.execute({});
-      const result = await resultPromise;
-
-      expect(result.success).toBe(true);
-      expect(result.duration).toBe(1000);
-      expect(result.intensity).toBe(100);
-
-      // Verify timer was called with default duration
-      expect(fakeTimer.wasSleepCalled(1000)).toBe(true);
-    });
-
-    test("should handle zero duration", async () => {
-      fakeAdb.setCommandResponse("emu sensor set acceleration 100:100:100", { stdout: "", stderr: "" });
-      fakeAdb.setCommandResponse("emu sensor set acceleration 0:0:0", { stdout: "", stderr: "" });
-      const mockObservation = createObserveResult();
-      fakeObserveScreen.setObserveResult(mockObservation);
-
-      const resultPromise = shake.execute({ duration: 0 });
-      const result = await resultPromise;
-
-      expect(result.success).toBe(true);
-      expect(result.duration).toBe(0);
-      expect(result.intensity).toBe(100);
-    });
-
-    test("should handle zero intensity", async () => {
-      fakeAdb.setCommandResponse("emu sensor set acceleration 0:0:0", { stdout: "", stderr: "" });
-      const mockObservation = createObserveResult();
-      fakeObserveScreen.setObserveResult(mockObservation);
-
-      const resultPromise = shake.execute({ intensity: 0, duration: 100 });
-      const result = await resultPromise;
-
-      expect(result.success).toBe(true);
-      expect(result.duration).toBe(100);
-      expect(result.intensity).toBe(0);
+      expect(fakeTimer.wasSleepCalled(duration)).toBe(true);
+      expect(fakeAdb.wasCommandExecuted(`emu sensor set acceleration ${intensity}:${intensity}:${intensity}`)).toBe(true);
+      expect(fakeAdb.wasCommandExecuted("emu sensor set acceleration 0:0:0")).toBe(true);
     });
 
     test("should work with progress callback", async () => {
@@ -179,8 +85,7 @@ describe("Shake", () => {
       const result = await resultPromise;
 
       expect(result.success).toBe(true);
-      // Progress callback should be called by BaseVisualChange
-      expect(callbackCalled || fakeObserveScreen.wasMethodCalled("execute")).toBe(true);
+      expect(callbackCalled).toBe(true);
     });
 
     test("should use CtrlProxy shake on iOS simulator without invoking adb", async () => {
@@ -263,57 +168,27 @@ describe("Shake", () => {
     });
 
     test("should handle ADB command failure during shake start", async () => {
-      fakeAdb.setCommandResponse("emu sensor set acceleration 100:100:100", { stdout: "", stderr: "error" });
+      fakeAdb.setCommandError("emu sensor set acceleration 100:100:100", new Error("shake start failed"));
 
-      const mockObservation = createObserveResult();
-      fakeObserveScreen.setObserveResult(mockObservation);
+      const result = await shake.execute({ duration: 100 });
 
-      try {
-        const resultPromise = shake.execute({ duration: 100 });
-        const result = await resultPromise;
-        // If we get here, command succeeded despite fake error
-        expect(result.duration).toBe(100);
-        expect(result.intensity).toBe(100);
-      } catch (caughtError) {
-        // If the error bubbled up, that's also valid behavior
-        expect(caughtError).toBeDefined();
-      }
+      expect(result.success).toBe(false);
+      expect(result.duration).toBe(100);
+      expect(result.intensity).toBe(100);
+      expect(result.error).toContain("shake start failed");
+      expect(fakeTimer.getSleepHistory()).toEqual([]);
     });
 
     test("should handle ADB command failure during shake stop", async () => {
-      fakeAdb.setCommandResponse("emu sensor set acceleration 100:100:100", { stdout: "", stderr: "" });
-      fakeAdb.setCommandResponse("emu sensor set acceleration 0:0:0", { stdout: "", stderr: "error" });
+      fakeAdb.setCommandError("emu sensor set acceleration 0:0:0", new Error("shake stop failed"));
 
-      const mockObservation = createObserveResult();
-      fakeObserveScreen.setObserveResult(mockObservation);
+      const result = await shake.execute({ duration: 50 });
 
-      try {
-        const resultPromise = shake.execute({ duration: 50 }); // Very short duration
-        const result = await resultPromise;
-        // If we get here, BaseVisualChange caught the error
-        expect(result).toBeDefined();
-      } catch (caughtError) {
-        // If the error bubbled up, that's also valid behavior
-        expect(caughtError).toBeDefined();
-      }
-    });
-  });
-
-  describe("constructor", () => {
-    test("should work with null deviceId", () => {
-      const shakeInstance = new Shake(testDevice, fakeAdb, fakeTimer);
-      expect(shakeInstance).toBeDefined();
-    });
-
-    test("should work with custom AdbClient", () => {
-      const customAdb = new FakeAdbExecutor();
-      const shakeInstance = new Shake(testDevice, customAdb, fakeTimer);
-      expect(shakeInstance).toBeDefined();
-    });
-
-    test("should work with default timer when not provided", () => {
-      const shakeInstance = new Shake(testDevice, fakeAdb);
-      expect(shakeInstance).toBeDefined();
+      expect(result.success).toBe(false);
+      expect(result.duration).toBe(50);
+      expect(result.intensity).toBe(100);
+      expect(result.error).toContain("shake stop failed");
+      expect(fakeTimer.wasSleepCalled(50)).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

Make device-action tests assert concrete failure contracts instead of accepting either outcome. Consolidate Shake parameter coverage into a table and remove constructor-only existence checks.

## Linked Issue

Closes #3509

## Bug / Regression Context

- **Observed symptom:** Failure-path and constructor tests could pass without exercising the intended behavior, masking regressions in the device-action layer.

## Validation

- [x] Focused device-action tests: 85 passing
- [x] `bun run turbo:validate`
- [x] `bun run typecheck`
- [x] `git diff --check`
- [x] Rebased onto latest `main`
