### PR TITLE
fix: address merged PR feedback

### DIFF
--- a/scripts/check-no-local-shell-quote.ts
+++ b/scripts/check-no-local-shell-quote.ts
@@ -62,19 +62,21 @@ function isCanonicalShellQuoteExpression(expression: ts.Expression): boolean {
   return !!span && span.literal.text === "'" && isSingleQuoteEscapeCall(span.expression);
 }
 
-function hasCanonicalShellQuoteReturn(body: ts.Block | ts.Expression | undefined): boolean {
+function containsSingleQuoteEscapeCall(node: ts.Node): boolean {
+  if (ts.isExpression(node) && isSingleQuoteEscapeCall(node)) {
+    return true;
+  }
+  return ts.forEachChild(node, containsSingleQuoteEscapeCall) ?? false;
+}
+
+function hasLocalShellQuoteImplementation(body: ts.Block | ts.Expression | undefined): boolean {
   if (!body) {
     return false;
   }
   if (!ts.isBlock(body)) {
-    return isCanonicalShellQuoteExpression(body);
+    return isCanonicalShellQuoteExpression(body) || containsSingleQuoteEscapeCall(body);
   }
-  return body.statements.some(
-    statement =>
-      ts.isReturnStatement(statement) &&
-      !!statement.expression &&
-      (isCanonicalShellQuoteExpression(statement.expression) || isSingleQuoteEscapeCall(statement.expression)),
-  );
+  return containsSingleQuoteEscapeCall(body);
 }
 
 function localHelperName(node: ts.Node): string | null {
@@ -82,7 +84,7 @@ function localHelperName(node: ts.Node): string | null {
     if (isBannedHelperName(node.name)) {
       return node.name.text;
     }
-    return hasCanonicalShellQuoteReturn(node.body) && node.name ? node.name.getText() : null;
+    return hasLocalShellQuoteImplementation(node.body) && node.name ? node.name.getText() : null;
   }
   if (
     (ts.isVariableDeclaration(node) ||
@@ -97,7 +99,7 @@ function localHelperName(node: ts.Node): string | null {
     (ts.isVariableDeclaration(node) || ts.isPropertyDeclaration(node) || ts.isPropertyAssignment(node)) &&
     !isBannedHelperName(node.name) &&
     isFunctionValue(node.initializer) &&
-    hasCanonicalShellQuoteReturn(node.initializer.body)
+    hasLocalShellQuoteImplementation(node.initializer.body)
   ) {
     return node.name.getText();
   }

--- a/scripts/codex-automation-thread-report.sh
+++ b/scripts/codex-automation-thread-report.sh
@@ -132,11 +132,6 @@ for path in iter_jsonl_files():
                 last_run[title] = (ts, rel)
 
     for idx, line in enumerate(lines, start=1):
-        has_create_mode = '"mode":"create"' in line or '\\"mode\\":\\"create\\"' in line
-        if "automation_update" not in line or not has_create_mode:
-            continue
-        if not any(title in line for title in titles):
-            continue
         obj = json_obj(line)
         if not obj:
             continue
@@ -145,10 +140,16 @@ for path in iter_jsonl_files():
             continue
 
         raw_args = payload.get("arguments", "{}")
+        if not isinstance(raw_args, str):
+            continue
         try:
             args = json.loads(raw_args)
         except json.JSONDecodeError:
             args = {}
+        if not isinstance(args, dict):
+            continue
+        if args.get("mode") != "create":
+            continue
         title = args.get("name")
         if title not in titles:
             continue

--- a/scripts/webrtc/run-mediamtx-publisher-integration.sh
+++ b/scripts/webrtc/run-mediamtx-publisher-integration.sh
@@ -87,6 +87,8 @@ else
   download_mediamtx
 fi
 
+mediamtx_binary="$(cd "$(dirname "${mediamtx_binary}")" && pwd -P)/$(basename "${mediamtx_binary}")"
+
 cd "${repo_root}"
 AUTOMOBILE_MEDIAMTX_WEBRTC_INTEGRATION=1 \
 AUTOMOBILE_MEDIAMTX_BINARY="${mediamtx_binary}" \

--- a/src/features/action/Clipboard.ts
+++ b/src/features/action/Clipboard.ts
@@ -3,6 +3,7 @@ import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/A
 import { BootedDevice, ClipboardResult } from "../../models";
 import { logger } from "../../utils/logger";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
+import { shellQuote } from "../../utils/shellQuote";
 import { AndroidCtrlProxyClient } from "../observe/android";
 import { IOSCtrlProxyClient } from "../observe/ios";
 
@@ -175,10 +176,8 @@ export class Clipboard {
               error: "Text is required for copy action"
             };
           }
-          // Escape text for shell command using single quotes (safer than double quotes)
-          // In single-quoted strings, only single quotes need escaping: ' becomes '\''
-          const escapedText = text.replace(/'/g, "'\\''");
-          const result = await this.adb.executeCommand(`shell cmd clipboard set '${escapedText}'`);
+          // ADB hands the command to the device shell, so preserve user text as one literal word.
+          const result = await this.adb.executeCommand(`shell cmd clipboard set ${shellQuote(text)}`);
 
           // Check if cmd clipboard is supported
           if (result.includes("No shell command implementation")) {

--- a/src/features/action/RestoreSnapshot.ts
+++ b/src/features/action/RestoreSnapshot.ts
@@ -10,6 +10,7 @@ import {
 } from "../../utils/android-cmdline-tools/vmSnapshot";
 import { DeviceSnapshotStore } from "../../utils/DeviceSnapshotStore";
 import { logger } from "../../utils/logger";
+import { shellQuote } from "../../utils/shellQuote";
 import { promises as fs } from "fs";
 import * as path from "path";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
@@ -247,9 +248,8 @@ export class RestoreSnapshot implements SnapshotRestoreProvider {
             logger.debug(`[RestoreSnapshot] a11y settings put failed for ${settingsType}/${key}: ${error}`);
           }
           if (!applied) {
-            // Escape special characters in value
-            const escapedValue = value.replace(/'/g, "'\\''");
-            await this.adb.executeCommand(`shell settings put ${settingsType} ${key} '${escapedValue}'`);
+            // ADB hands the command to the device shell, so preserve the setting value as one literal word.
+            await this.adb.executeCommand(`shell settings put ${settingsType} ${key} ${shellQuote(value)}`);
           }
           successCount++;
         } catch (error) {

--- a/src/features/utility/PostNotification.ts
+++ b/src/features/utility/PostNotification.ts
@@ -10,6 +10,7 @@ import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType"
 import { fileURLToPath } from "url";
 import fs from "fs/promises";
 import path from "path";
+import { shellQuote } from "../../utils/shellQuote";
 import { resolvePathFromDaemonLaunchWorkingDirectory } from "../../utils/workingDirectory";
 
 interface PostNotificationAction {
@@ -417,8 +418,7 @@ export class PostNotification {
 }
 
 const quoteForShell = (value: string): string => {
-  const escaped = value.replace(/'/g, "'\\''").replace(/\r?\n/g, "\\n");
-  return `'${escaped}'`;
+  return shellQuote(value.replace(/\r?\n/g, "\\n"));
 };
 
 const quoteForAdbArg = (value: string): string => {

--- a/test/bats/check-no-local-shell-quote.bats
+++ b/test/bats/check-no-local-shell-quote.bats
@@ -69,3 +69,25 @@ teardown() {
   [ "$status" -eq 1 ]
   [[ "$output" == *"ShellQuoteBoundaryFixture.ts"* ]]
 }
+
+@test "rejects a helper that quotes an escaped temporary value" {
+  printf '%s\n' \
+    "export function quoteForShell(value: string): string { const escaped = value.replace(/'/g, \"'\\\\''\"); return \`'\${escaped}'\`; }" \
+    > "$FIXTURE"
+
+  run env SHELL_QUOTE_SOURCE_ROOT="$fixture_root" bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ShellQuoteBoundaryFixture.ts"* ]]
+}
+
+@test "rejects a helper that escapes a temporary inside a nested block" {
+  printf '%s\n' \
+    "export function quoteForShell(value: string): string { let escaped: string; if (value) { escaped = value.replace(/'/g, \"'\\\\''\"); } else { escaped = value; } return \`'\${escaped}'\`; }" \
+    > "$FIXTURE"
+
+  run env SHELL_QUOTE_SOURCE_ROOT="$fixture_root" bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ShellQuoteBoundaryFixture.ts"* ]]
+}

--- a/test/bats/codex-automation-thread-report.bats
+++ b/test/bats/codex-automation-thread-report.bats
@@ -26,3 +26,25 @@ teardown() {
   [[ "$output" == *"First observed run: 2026-07-22T12:00:00Z"* ]]
   [[ "$output" == *"Last observed run: 2026-07-23T12:00:00Z"* ]]
 }
+
+@test "reports a creation call whose JSON arguments contain ordinary whitespace" {
+  printf '%s\n' \
+    '{"timestamp":"2026-07-23T12:00:00Z","payload":{"type":"function_call","name":"automation_update","arguments":"{\"mode\": \"create\", \"name\": \"Test automation\"}"}}' \
+    > "$CODEX_FIXTURE/sessions/creation.jsonl"
+
+  run "$ABS" --codex-home "$CODEX_FIXTURE" --title "Test automation"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"\`Test automation\`: 1 create call(s)"* ]]
+}
+
+@test "ignores a creation call whose arguments are not a JSON object" {
+  printf '%s\n' \
+    '{"timestamp":"2026-07-23T12:00:00Z","payload":{"type":"function_call","name":"automation_update","arguments":"[]"}}' \
+    > "$CODEX_FIXTURE/sessions/invalid-creation.jsonl"
+
+  run "$ABS" --codex-home "$CODEX_FIXTURE" --title "Test automation"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"\`Test automation\`: no creation event found"* ]]
+}

--- a/test/bats/mediamtx-webrtc-integration.bats
+++ b/test/bats/mediamtx-webrtc-integration.bats
@@ -10,6 +10,7 @@ setup() {
   TEST_DIR="$(mktemp -d)"
   MOCK_BIN="${TEST_DIR}/bin"
   INVOCATIONS_FILE="${TEST_DIR}/invocations"
+  ABS="$(cd "$(dirname "$SCRIPT")" && pwd)/$(basename "$SCRIPT")"
   mkdir -p "${MOCK_BIN}"
   ORIG_PATH="${PATH}"
 }
@@ -44,15 +45,37 @@ SCRIPT
 exit 0
 SCRIPT
   chmod +x "${binary}"
+  local resolved_binary="$(cd "$(dirname "${binary}")" && pwd -P)/$(basename "${binary}")"
 
   run env \
     PATH="${MOCK_BIN}:${PATH}" \
     AUTOMOBILE_MEDIAMTX_BINARY="${binary}" \
     INVOCATIONS_FILE="${INVOCATIONS_FILE}" \
-    bash "${SCRIPT}"
+    bash "${ABS}"
 
   [ "${status}" -eq 0 ]
-  [ "$(cat "${INVOCATIONS_FILE}")" = "gate=1 binary=${binary} args=test ${TEST_FILE}" ]
+  [ "$(cat "${INVOCATIONS_FILE}")" = "gate=1 binary=${resolved_binary} args=test ${TEST_FILE}" ]
+}
+
+@test "runner resolves an injected relative MediaMTX binary before forwarding it" {
+  make_bun_stub
+  local binary="${TEST_DIR}/mediamtx"
+  cat > "${binary}" <<'SCRIPT'
+#!/usr/bin/env bash
+exit 0
+SCRIPT
+  chmod +x "${binary}"
+  local resolved_binary="$(cd "$(dirname "${binary}")" && pwd -P)/$(basename "${binary}")"
+
+  cd "${TEST_DIR}"
+  run env \
+    PATH="${MOCK_BIN}:${PATH}" \
+    AUTOMOBILE_MEDIAMTX_BINARY="./mediamtx" \
+    INVOCATIONS_FILE="${INVOCATIONS_FILE}" \
+    bash "${ABS}"
+
+  [ "${status}" -eq 0 ]
+  [ "$(cat "${INVOCATIONS_FILE}")" = "gate=1 binary=${resolved_binary} args=test ${TEST_FILE}" ]
 }
 
 @test "download path rejects a MediaMTX archive whose pinned checksum does not match" {

--- a/test/integration/mediamtxWebRtcPublisher.integration.test.ts
+++ b/test/integration/mediamtxWebRtcPublisher.integration.test.ts
@@ -37,6 +37,12 @@ interface DecodedVideo {
   decodedFrames: number;
 }
 
+interface StartedProcess {
+  readonly process: ChildProcessWithoutNullStreams;
+  readonly logs: () => string;
+  readonly error: () => Error | undefined;
+}
+
 class CdpClient {
   private readonly socket: WebSocket;
   private nextId = 1;
@@ -92,16 +98,21 @@ function appendLog(current: string, chunk: Buffer): string {
   return `${current}${chunk.toString()}`.slice(-MAX_LOG_CHARS);
 }
 
-function startProcess(command: string, args: string[], cwd: string): { process: ChildProcessWithoutNullStreams; logs: () => string } {
+function startProcess(command: string, args: string[], cwd: string): StartedProcess {
   const process = spawn(command, args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
   let output = "";
+  let spawnError: Error | undefined;
   process.stdout.on("data", chunk => {
     output = appendLog(output, chunk);
   });
   process.stderr.on("data", chunk => {
     output = appendLog(output, chunk);
   });
-  return { process, logs: () => output };
+  process.on("error", error => {
+    spawnError = error;
+    output = appendLog(output, Buffer.from(`${error.message}\n`));
+  });
+  return { process, logs: () => output, error: () => spawnError };
 }
 
 async function waitFor(predicate: () => boolean | Promise<boolean>, message: string, timeoutMs: number = 15_000): Promise<void> {
@@ -132,8 +143,13 @@ async function waitForHttpServer(
   logs: () => string,
   url: string,
   name: string,
+  processError?: () => Error | undefined,
 ): Promise<void> {
   await waitFor(async () => {
+    const spawnError = processError?.();
+    if (spawnError) {
+      throw new Error(`${name} failed to start: ${spawnError.message}\n${logs()}`);
+    }
     const exited = exitedProcessDescription(process);
     if (exited) {
       throw new Error(`${name} exited before readiness (${exited}):\n${logs()}`);
@@ -150,7 +166,10 @@ async function waitForHttpServer(
       }
       return true;
     } catch (error) {
-      if (error instanceof Error && error.message.startsWith(`${name} exited before readiness`)) {
+      if (
+        error instanceof Error &&
+        (error.message.startsWith(`${name} exited before readiness`) || error.message.startsWith(`${name} failed to start`))
+      ) {
         throw error;
       }
       return false;
@@ -159,7 +178,7 @@ async function waitForHttpServer(
 }
 
 async function stopProcess(process: ChildProcessWithoutNullStreams | undefined, graceMs: number = 3_000): Promise<void> {
-  if (!process || process.exitCode !== null || process.signalCode !== null) {
+  if (!process || process.pid === undefined || process.exitCode !== null || process.signalCode !== null) {
     return;
   }
   process.kill("SIGTERM");
@@ -230,6 +249,17 @@ async function openReader(chrome: ChildProcessWithoutNullStreams, debugPort: num
   await cdp.command("Page.enable");
   await cdp.command("Runtime.enable");
   await cdp.command("Page.navigate", { url: `http://127.0.0.1:${WEBRTC_PORT}/${STREAM_NAME}` });
+  await waitFor(async () => {
+    try {
+      const response = await cdp.command("Runtime.evaluate", {
+        expression: 'document.readyState === "complete" && document.querySelector("video") !== null',
+        returnByValue: true,
+      });
+      return response.result?.result?.value === true;
+    } catch {
+      return false;
+    }
+  }, "Chrome did not load the MediaMTX reader page");
   return cdp;
 }
 
@@ -280,6 +310,16 @@ test.skipIf(process.platform === "win32")("rejects a stale listener when the ser
     .rejects.toThrow("MediaMTX exited before readiness (exit code 7):\naddress already in use");
 });
 
+test.skipIf(process.platform === "win32")("captures a child spawn error for the test body", async () => {
+  const started = startProcess(join(tmpdir(), "missing-mediamtx-test-binary"), [], tmpdir());
+
+  await once(started.process, "error");
+
+  expect(started.error()).toBeInstanceOf(Error);
+  await stopProcess(started.process, 1);
+  expect(started.process.pid).toBeUndefined();
+});
+
 describeIntegration("MediaMTX WebRTC publisher integration (#4290)", () => {
   test("publishes real H.264 through WHIP and Chrome decodes the MediaMTX WHEP reader", async () => {
     const mediamtxBinary = process.env.AUTOMOBILE_MEDIAMTX_BINARY;
@@ -304,23 +344,31 @@ describeIntegration("MediaMTX WebRTC publisher integration (#4290)", () => {
         mediaMtx.logs,
         `http://127.0.0.1:${WEBRTC_PORT}/`,
         "MediaMTX",
+        mediaMtx.error,
       );
 
       await publisher.start();
-      ffmpeg = spawn("ffmpeg", [
+      const ffmpegProcess = startProcess("ffmpeg", [
         "-hide_banner", "-loglevel", "error", "-re",
         "-f", "lavfi", "-i", "testsrc2=size=320x240:rate=10",
         "-an", "-c:v", "libx264", "-profile:v", "baseline", "-level:v", "3.1",
         "-preset", "ultrafast", "-tune", "zerolatency", "-g", "10", "-keyint_min", "10",
         "-f", "h264", "pipe:1",
-      ], { stdio: ["ignore", "pipe", "pipe"] });
+      ], tempDir);
+      ffmpeg = ffmpegProcess.process;
       let ffmpegErrors = "";
       ffmpeg.stderr.on("data", chunk => {
         ffmpegErrors = appendLog(ffmpegErrors, chunk);
       });
       ffmpeg.stdout.on("data", chunk => publisher.writeH264Chunk(chunk));
 
-      await waitFor(() => publisher.getDescriptor().framesSent >= 10, "publisher did not send synthetic H.264 frames");
+      await waitFor(() => {
+        const spawnError = ffmpegProcess.error();
+        if (spawnError) {
+          throw new Error(`FFmpeg failed to start: ${spawnError.message}`);
+        }
+        return publisher.getDescriptor().framesSent >= 10;
+      }, "publisher did not send synthetic H.264 frames");
       const profileDir = join(tempDir, "chrome-profile");
       const debugPort = await reserveLoopbackPort();
       chrome = startProcess(resolveChromeBinary(), [


### PR DESCRIPTION
## Summary

- parse `automation_update` creation calls structurally, including ordinarily spaced JSON arguments
- route `PostNotification` shell quoting through the canonical `shellQuote` helper and extend the ratchet to catch escaped temporaries
- forward an absolute MediaMTX binary path, wait for its reader page's video element, and surface FFmpeg spawn failures through the integration test body

## Why

This follows up on valid, unaddressed P2 feedback left on merged [PR #4304](https://github.com/kaeawc/auto-mobile/pull/4304), [PR #4306](https://github.com/kaeawc/auto-mobile/pull/4306), and [PR #4302](https://github.com/kaeawc/auto-mobile/pull/4302).

## Validation

- `bats test/bats/codex-automation-thread-report.bats test/bats/check-no-local-shell-quote.bats test/bats/mediamtx-webrtc-integration.bats`
- `bun test test/integration/mediamtxWebRtcPublisher.integration.test.ts test/features/utility/PostNotification.test.ts`
- `bun run test:integration:webrtc-mediamtx`
- `shellcheck scripts/codex-automation-thread-report.sh scripts/check-no-local-shell-quote.sh scripts/webrtc/run-mediamtx-publisher-integration.sh`
- `bun run typecheck`
- `bun run build`
- `bun run lint`
- `bun run turbo:validate`
- `git diff --check`
