### PR TITLE
refactor(ios): centralize CtrlProxy process lifecycle

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -771,7 +771,7 @@ jobs:
           KTFMT_ONLY_TOUCHED_FILES: "false"
         run: |
           scripts/all_fast_validate_checks.sh \
-            --only yaml,xml,shellcheck,shell-portability,shell-sete,stdlib-first,dependency-decisions,shell-quote-boundary,security-boundary,app-bundle-metadata-boundary,mkdocs-nav,ktfmt,claude-plugin,codex-skills \
+            --only yaml,xml,shellcheck,shell-portability,shell-sete,stdlib-first,dependency-decisions,shell-quote-boundary,security-boundary,app-bundle-metadata-boundary,ios-ctrl-proxy-process-boundary,mkdocs-nav,ktfmt,claude-plugin,codex-skills \
             --max-parallel 4
 
       - name: "Run BATS Tests (Ubuntu)"
@@ -1190,6 +1190,11 @@ jobs:
         if: env.RUN_MCP_BUILD_TEST == 'true'
         shell: bash
         run: bun run check:android-emulator-boundary
+
+      - name: "Check iOS CtrlProxy process execution boundary"
+        if: env.RUN_MCP_BUILD_TEST == 'true'
+        shell: bash
+        run: bun run check:ios-ctrl-proxy-process-boundary
 
       - name: "Run Build"
         if: env.RUN_MCP_BUILD_TEST == 'true'

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "check:ffmpeg-boundary": "bash scripts/check-ffmpeg-execution-boundary.sh",
     "check:simulator-tcc-sqlite-boundary": "bash scripts/check-simulator-tcc-sqlite-boundary.sh",
     "check:daemon-launcher-boundary": "bash scripts/check-daemon-launcher-boundary.sh",
+    "check:ios-ctrl-proxy-process-boundary": "bash scripts/check-ios-ctrl-proxy-process-boundary.sh",
     "dead-code:ts": "bash scripts/detect-dead-code-ts.sh",
     "dead-code:ts:prune": "bash -o pipefail -c 'bunx ts-prune --project tsconfig.dead-code.json -i src/db/migrations | (grep -v \"(used in module)\" || true) | bash scripts/filter-ts-prune-allowlist.sh'",
     "dead-code:ts:knip": "bunx knip",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "dead-code:ts:knip": "bunx knip",
     "prepublishOnly": "cp README.md README.md.backup && bun scripts/npm/transform-readme.js",
     "postpublish": "mv README.md.backup README.md || true",
-    "turbo:validate": "turbo run lint build test check:android-emulator-boundary check:ffmpeg-boundary",
+    "turbo:validate": "turbo run lint build test check:android-emulator-boundary check:ffmpeg-boundary check:ios-ctrl-proxy-process-boundary",
     "turbo:build": "turbo run build",
     "turbo:lint": "turbo run lint",
     "turbo:test": "turbo run test"

--- a/scripts/all_fast_validate_checks.sh
+++ b/scripts/all_fast_validate_checks.sh
@@ -51,6 +51,7 @@ add_check "git-metadata-boundary" "bash \"$PROJECT_ROOT/scripts/check-no-new-dir
 add_check "ffmpeg-execution-boundary" "bun \"$PROJECT_ROOT/scripts/check-ffmpeg-execution-boundary.ts\"" "lint,conventions" "Require FFmpeg execution through FfmpegClient"
 add_check "xcodebuild-boundary" "\"$PROJECT_ROOT/scripts/check-no-new-direct-xcodebuild.sh\"" "lint,ios" "Keep xcodebuild execution behind XcodebuildClient"
 add_check "daemon-launcher-boundary" "bash \"$PROJECT_ROOT/scripts/check-daemon-launcher-boundary.sh\"" "lint,conventions" "Require DaemonLauncher ownership for daemon process execution"
+add_check "ios-ctrl-proxy-process-boundary" "bun \"$PROJECT_ROOT/scripts/check-ios-ctrl-proxy-process-boundary.ts\"" "lint,conventions" "Keep CtrlProxy PID tooling behind its lifecycle client"
 add_check "datetime-now-literal" "\"$PROJECT_ROOT/scripts/validate-no-datetime-now-literal.sh\"" "lint" "Reject string-literal SQL time-expression defaults in migrations"
 add_check "desktop-core-unified" "\"$PROJECT_ROOT/scripts/android/validate-no-desktop-core-unified.sh\"" "lint,android" "Reject abandoned desktop-core unified socket-client package"
 add_check "workflow-assertion-triggers" "\"$PROJECT_ROOT/scripts/ci/validate_workflow_assertion_triggers.sh\"" "config,ci" "Ensure workflow-YAML assertion tests are triggered by the paths they assert"

--- a/scripts/check-ios-ctrl-proxy-process-boundary.sh
+++ b/scripts/check-ios-ctrl-proxy-process-boundary.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+exec bun scripts/check-ios-ctrl-proxy-process-boundary.ts

--- a/scripts/check-ios-ctrl-proxy-process-boundary.ts
+++ b/scripts/check-ios-ctrl-proxy-process-boundary.ts
@@ -1,10 +1,21 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { join, relative } from "node:path";
+import ts from "typescript";
 
 const SOURCE_ROOT = "src";
 const OWNER = "src/utils/ios/IOSCtrlProxyProcessClient.ts";
-const EXCEPTIONS = new Map<string, string>();
-const FORBIDDEN = /(?:\.(?:exec|executeCommand)\s*\(\s*["'`])(?:ps|pgrep|kill)(?:\s|["'`])/;
+const PROCESS_TOOLS = new Set(["ps", "pgrep", "kill", "lsof"]);
+const EXECUTION_METHODS = new Set(["exec", "execFile", "execFileSync", "executeCommand", "spawn", "spawnSync"]);
+const EXCEPTIONS = new Map<string, string>([
+  ["src/features/performance/PerformanceMonitor.ts", "Collects app metrics, not CtrlProxy lifecycle state."],
+]);
+
+export interface Violation {
+  readonly file: string;
+  readonly line: number;
+  readonly column: number;
+  readonly text: string;
+}
 
 function sourceFiles(directory: string): string[] {
   return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
@@ -13,17 +24,53 @@ function sourceFiles(directory: string): string[] {
   });
 }
 
-const offenders = sourceFiles(SOURCE_ROOT).flatMap(file => {
-  const repoPath = relative(".", file);
-  if (repoPath === OWNER || EXCEPTIONS.has(repoPath)) {return [];}
-  return FORBIDDEN.test(readFileSync(file, "utf8"))
-    ? [`${repoPath} directly executes CtrlProxy PID tooling; route it through ${OWNER}.`]
-    : [];
-});
-
-if (offenders.length > 0) {
-  console.error(offenders.join("\n"));
-  process.exit(1);
+function commandFromCall(node: ts.CallExpression): string | null {
+  const firstArgument = node.arguments[0];
+  if (ts.isStringLiteral(firstArgument)) {return firstArgument.text;}
+  if (ts.isArrayLiteralExpression(firstArgument) && ts.isStringLiteral(firstArgument.elements[0])) {
+    return firstArgument.elements[0].text;
+  }
+  return null;
 }
 
-console.log("ios-ctrl-proxy-process-boundary: no direct production PID tooling.");
+function executesProcessTool(node: ts.CallExpression): boolean {
+  const expression = node.expression;
+  if (ts.isIdentifier(expression)) {
+    return EXECUTION_METHODS.has(expression.text) && PROCESS_TOOLS.has(commandFromCall(node) ?? "");
+  }
+  if (!ts.isPropertyAccessExpression(expression) || !EXECUTION_METHODS.has(expression.name.text)) {
+    return false;
+  }
+  return PROCESS_TOOLS.has(commandFromCall(node) ?? "");
+}
+
+export function findViolationsInSource(file: string, source: string): Violation[] {
+  const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const violations: Violation[] = [];
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node) && executesProcessTool(node)) {
+      const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+      violations.push({ file, line: line + 1, column: character + 1, text: node.getText(sourceFile) });
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return violations;
+}
+
+export function findViolations(): Violation[] {
+  return sourceFiles(SOURCE_ROOT)
+    .filter(file => relative(".", file) !== OWNER && !EXCEPTIONS.has(relative(".", file)))
+    .flatMap(file => findViolationsInSource(file, readFileSync(file, "utf8")));
+}
+
+if (import.meta.main) {
+  const violations = findViolations();
+  if (violations.length > 0) {
+    for (const violation of violations) {
+      console.error(`${violation.file}:${violation.line}:${violation.column}: ${violation.text}`);
+    }
+    process.exit(1);
+  }
+  console.log("ios-ctrl-proxy-process-boundary: no direct production PID tooling.");
+}

--- a/scripts/check-ios-ctrl-proxy-process-boundary.ts
+++ b/scripts/check-ios-ctrl-proxy-process-boundary.ts
@@ -1,0 +1,29 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const SOURCE_ROOT = "src";
+const OWNER = "src/utils/ios/IOSCtrlProxyProcessClient.ts";
+const EXCEPTIONS = new Map<string, string>();
+const FORBIDDEN = /(?:\.(?:exec|executeCommand)\s*\(\s*["'`])(?:ps|pgrep|kill)(?:\s|["'`])/;
+
+function sourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const path = join(directory, entry.name);
+    return entry.isDirectory() ? sourceFiles(path) : entry.name.endsWith(".ts") ? [path] : [];
+  });
+}
+
+const offenders = sourceFiles(SOURCE_ROOT).flatMap(file => {
+  const repoPath = relative(".", file);
+  if (repoPath === OWNER || EXCEPTIONS.has(repoPath)) {return [];}
+  return FORBIDDEN.test(readFileSync(file, "utf8"))
+    ? [`${repoPath} directly executes CtrlProxy PID tooling; route it through ${OWNER}.`]
+    : [];
+});
+
+if (offenders.length > 0) {
+  console.error(offenders.join("\n"));
+  process.exit(1);
+}
+
+console.log("ios-ctrl-proxy-process-boundary: no direct production PID tooling.");

--- a/scripts/check-ios-ctrl-proxy-process-boundary.ts
+++ b/scripts/check-ios-ctrl-proxy-process-boundary.ts
@@ -10,6 +10,10 @@ const EXCEPTIONS = new Map<string, string>([
   ["src/features/performance/PerformanceMonitor.ts", "Collects app metrics, not CtrlProxy lifecycle state."],
 ]);
 
+export function repositoryPath(file: string): string {
+  return relative(".", file).replaceAll("\\", "/");
+}
+
 export interface Violation {
   readonly file: string;
   readonly line: number;
@@ -60,7 +64,7 @@ export function findViolationsInSource(file: string, source: string): Violation[
 
 export function findViolations(): Violation[] {
   return sourceFiles(SOURCE_ROOT)
-    .filter(file => relative(".", file) !== OWNER && !EXCEPTIONS.has(relative(".", file)))
+    .filter(file => repositoryPath(file) !== OWNER && !EXCEPTIONS.has(repositoryPath(file)))
     .flatMap(file => findViolationsInSource(file, readFileSync(file, "utf8")));
 }
 

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -21,6 +21,10 @@ import {
   type HostPortAvailabilityChecker
 } from "./ios/IOSHostPortAvailabilityChecker";
 import { IOSCtrlProxyHealthClient, isValidCtrlProxyPort } from "./ios/IOSCtrlProxyHealthClient";
+import { IOSCtrlProxyProcessClient } from "./ios/IOSCtrlProxyProcessClient";
+import type { HostCommandExecutor } from "./HostCommandExecutor";
+import { IOSCtrlProxyProcessClient } from "./ios/IOSCtrlProxyProcessClient";
+import type { HostCommandExecutor } from "./HostCommandExecutor";
 import type { ProxyManager, ProxySetupResult } from "./interfaces/ProxyManager";
 
 /**
@@ -132,6 +136,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   private readonly builder: IOSCtrlProxyBuilder;
   private readonly processExecutor: ProcessExecutor;
   private readonly xcodebuild: Xcodebuild;
+  private readonly processClient: IOSCtrlProxyProcessClient;
   private readonly signingManager: XcodeSigningManager;
   private readonly deviceAppManager: DeviceAppManager;
   private readonly remoteRunner: RemoteCtrlProxyIOSRunner;
@@ -214,7 +219,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     deviceAppManager: DeviceAppManager = new DeviceAppManager(),
     remoteRunner?: RemoteCtrlProxyIOSRunner,
     hostPortAvailabilityChecker: HostPortAvailabilityChecker = new TcpHostPortAvailabilityChecker(),
-    xcodebuild: Xcodebuild = new XcodebuildClient()
+    xcodebuild: Xcodebuild = new XcodebuildClient(),
+    processClient?: IOSCtrlProxyProcessClient
   ) {
     this.device = device;
     this.timer = timer;
@@ -222,6 +228,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     this.builder = builder || IOSCtrlProxyBuilder.getInstance();
     this.processExecutor = processExecutor;
     this.xcodebuild = xcodebuild;
+    this.processClient = processClient ?? new IOSCtrlProxyProcessClient();
     this.signingManager = signingManager;
     this.deviceAppManager = deviceAppManager;
     this.hostPortAvailabilityChecker = hostPortAvailabilityChecker;
@@ -328,7 +335,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     deviceAppManager?: DeviceAppManager,
     remoteRunner?: RemoteCtrlProxyIOSRunner,
     hostPortAvailabilityChecker?: HostPortAvailabilityChecker,
-    xcodebuild?: Xcodebuild
+    xcodebuild?: Xcodebuild,
+    processClient?: IOSCtrlProxyProcessClient
   ): IOSCtrlProxyManager {
     return new IOSCtrlProxyManager(
       device,
@@ -343,8 +351,16 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         async (file, args) => processExecutor.exec([file, ...args].join(" ")),
         timer,
         (command, args, options) => processExecutor.spawn(command, args, options)
-      )
+      ),
+      processClient ?? IOSCtrlProxyManager.processClientForTesting(processExecutor, timer)
     );
+  }
+
+  private static processClientForTesting(processExecutor: ProcessExecutor, timer: Timer): IOSCtrlProxyProcessClient {
+    const host = processExecutor as unknown as Partial<HostCommandExecutor>;
+    return typeof host.executeCommand === "function"
+      ? new IOSCtrlProxyProcessClient(host as HostCommandExecutor, timer)
+      : new IOSCtrlProxyProcessClient(undefined, timer);
   }
 
   /**
@@ -371,9 +387,10 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     processExecutor: ProcessExecutor = new DefaultProcessExecutor(),
     timer: Timer = defaultTimer
   ): Promise<void> {
+    const processClient = IOSCtrlProxyManager.processClientForTesting(processExecutor, timer);
     let pids: number[] = [];
     try {
-      pids = await IOSCtrlProxyManager.findStartupCtrlProxyCandidatePids(processExecutor);
+      pids = await processClient.findStartupCandidatePids();
     } catch (error) {
       logger.debug(`[IOSCtrlProxy] Failed to enumerate CtrlProxy iOS processes during startup sweep: ${error}`);
       return;
@@ -381,8 +398,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
     for (const pid of pids) {
       try {
-        const processInfo = await IOSCtrlProxyManager.getProcessInfo(processExecutor, pid);
-        if (!processInfo || !IOSCtrlProxyManager.isCtrlProxyRunnerCommand(processInfo.command)) {
+        const processInfo = await processClient.getProcessInfo(pid);
+        if (!processInfo || !processClient.isCtrlProxyRunnerCommand(processInfo.command)) {
           continue;
         }
         const rootPid = await IOSCtrlProxyManager.findDaemonManagedRunnerTreeRoot(
@@ -400,7 +417,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
           continue;
         }
         logger.info(`[IOSCtrlProxy] Reaping orphaned CtrlProxy iOS process tree rooted at ${rootPid}`);
-        await IOSCtrlProxyManager.terminateProcessTree(processExecutor, timer, rootPid);
+        await processClient.terminateProcessTree(rootPid);
       } catch (error) {
         logger.debug(`[IOSCtrlProxy] Failed to reap orphaned CtrlProxy iOS process ${pid}: ${error}`);
       }
@@ -1395,16 +1412,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    * Check if a process is still running
    */
   private async isProcessRunning(pid: number): Promise<boolean> {
-    try {
-      // On macOS/Linux, kill -0 checks if process exists without actually killing it
-      await this.processExecutor.exec(`kill -0 ${pid} 2>/dev/null`);
-      return true;
-    } catch (error) {
-      // `kill -0` exits non-zero (throwing) when the PID is gone or unreachable;
-      // treat that as "not running" rather than failing the liveness check.
-      logger.debug(`src/utils/IOSCtrlProxyManager.ts fallback failed: ${error}`, error);
-      return false;
-    }
+    return this.processClient.isRunning(pid);
   }
 
   /**
@@ -1446,10 +1454,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     // for THIS device before treating it as "still starting" — otherwise a recycled
     // PID (our runner exited, its PID reassigned to an unrelated process) would make
     // us defer to a health endpoint that never comes.
-    const info = await IOSCtrlProxyManager.getProcessInfo(this.processExecutor, this.xcTestProcessId);
-    if (!info) {
-      return false;
-    }
+    const info = await this.processClient.getProcessInfo(this.xcTestProcessId);
+    if (!info) {return false;}
     // Require CtrlProxy-specific identity, not merely any xcodebuild for this device
     // (#2834 review): a user's own `xcodebuild … -destination id=<deviceId>` on the same
     // simulator must NOT be mistaken for our runner, or we would wait on it and later
@@ -1543,50 +1549,18 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   }
 
   private async findExternalXcodebuildCtrlProxyProcess(): Promise<ExternalCtrlProxyProcess | null> {
-    try {
-      // pgrep -x matches only processes whose binary name is exactly "xcodebuild"
-      const { stdout: pgrepOut } = await this.processExecutor.exec(
-        "pgrep -x xcodebuild 2>/dev/null"
-      );
-      const pids = pgrepOut.trim().split("\n").filter(line => line.length > 0);
-      if (pids.length === 0) {
-        return null;
-      }
-
-      // Filter to PIDs whose args contain CtrlProxy, excluding our tracked PID
-      for (const pidStr of pids) {
-        const pid = parseInt(pidStr, 10);
-        if (this.xcTestProcessId && pid === this.xcTestProcessId) {
-          continue;
-        }
-        try {
-          const processInfo = await IOSCtrlProxyManager.getProcessInfo(this.processExecutor, pid);
-          const argsOut = processInfo?.command ?? "";
-          if (argsOut.includes("CtrlProxy")) {
-            if (await this.isDaemonManagedSimulatorXcodebuildProcess(argsOut, processInfo)) {
-              continue;
-            }
-            const identityText = `${argsOut} ${processInfo?.environment ?? ""}`;
-            if (!IOSCtrlProxyManager.hasDeviceIdentity(identityText, this.device.deviceId)) {
-              continue;
-            }
-            const port = this.parseCtrlProxyPortFromProcessArgs(argsOut) ??
-              this.parseCtrlProxyPortFromProcessArgs(processInfo?.environment ?? "") ??
-              IOSCtrlProxyManager.DEFAULT_PORT;
-            logger.info(`[IOSCtrlProxy] Found external xcodebuild CtrlProxy process: ${pid}`);
-            return { pid, port };
-          }
-        } catch {
-          // Process may have exited between pgrep and ps
-        }
-      }
-      return null;
-    } catch (error) {
-      // pgrep exits non-zero (throwing) when no xcodebuild process matches; that
-      // just means there's no external runner to adopt, not a real failure.
-      logger.debug(`src/utils/IOSCtrlProxyManager.ts fallback failed: ${error}`, error);
-      return null;
+    for (const pid of await this.processClient.findXcodebuildPids()) {
+      if (pid === this.xcTestProcessId) {continue;}
+      const processInfo = await this.processClient.getProcessInfo(pid);
+      const argsOut = processInfo?.command ?? "";
+      if (!argsOut.includes("CtrlProxy") || await this.isDaemonManagedSimulatorXcodebuildProcess(argsOut, processInfo)) {continue;}
+      const identityText = `${argsOut} ${processInfo?.environment ?? ""}`;
+      if (!IOSCtrlProxyManager.hasDeviceIdentity(identityText, this.device.deviceId)) {continue;}
+      const port = this.parseCtrlProxyPortFromProcessArgs(argsOut) ?? this.parseCtrlProxyPortFromProcessArgs(processInfo?.environment ?? "") ?? IOSCtrlProxyManager.DEFAULT_PORT;
+      logger.info(`[IOSCtrlProxy] Found external xcodebuild CtrlProxy process: ${pid}`);
+      return { pid, port };
     }
+    return null;
   }
 
   private async findExternalDirectCtrlProxyProcess(): Promise<ExternalCtrlProxyProcess | null> {
@@ -1701,22 +1675,12 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   }
 
   private async findListeningProcessesOnPort(port: number): Promise<ListeningProcess[]> {
-    try {
-      const { stdout } = await this.processExecutor.exec(
-        `lsof -nP -iTCP:${port} -sTCP:LISTEN -Fp 2>/dev/null`
-      );
-      const pids = IOSCtrlProxyManager.parseLsofPids(stdout);
-      const processes: ListeningProcess[] = [];
-      for (const pid of pids) {
-        const processInfo = await IOSCtrlProxyManager.getProcessInfo(this.processExecutor, pid);
-        if (processInfo) {
-          processes.push({ pid, port, ...processInfo });
-        }
-      }
-      return processes;
-    } catch {
-      return [];
+    const processes: ListeningProcess[] = [];
+    for (const pid of await this.processClient.findListeningPids(port)) {
+      const processInfo = await this.processClient.getProcessInfo(pid);
+      if (processInfo) {processes.push({ pid, port, ...processInfo });}
     }
+    return processes;
   }
 
   private isOwnedCtrlProxyRunnerProcess(process: ListeningProcess): boolean {
@@ -1733,7 +1697,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
     while (parentPid !== undefined && parentPid > 1 && !visitedPids.has(parentPid)) {
       visitedPids.add(parentPid);
-      const processInfo = await IOSCtrlProxyManager.getProcessInfo(this.processExecutor, parentPid);
+      const processInfo = await this.processClient.getProcessInfo(parentPid);
       if (!processInfo) {
         return false;
       }
@@ -1802,24 +1766,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   }
 
   private static async findStartupCtrlProxyCandidatePids(processExecutor: ProcessExecutor): Promise<number[]> {
-    const pids = new Set<number>();
-    for (const command of [
-      "pgrep -x xcodebuild 2>/dev/null",
-      "pgrep -f 'CtrlProxyUITests-Runner' 2>/dev/null",
-    ]) {
-      try {
-        const { stdout } = await processExecutor.exec(command);
-        for (const line of stdout.trim().split("\n")) {
-          const pid = Number.parseInt(line, 10);
-          if (!Number.isNaN(pid)) {
-            pids.add(pid);
-          }
-        }
-      } catch {
-        // pgrep exits non-zero when no process matches.
-      }
-    }
-    return [...pids];
+    return IOSCtrlProxyManager.processClientForTesting(processExecutor, defaultTimer).findStartupCandidatePids();
   }
 
   private static parseLsofPids(stdout: string): number[] {
@@ -1841,44 +1788,14 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     processExecutor: ProcessExecutor,
     pid: number
   ): Promise<{ ppid?: number; command: string; environment?: string } | null> {
-    try {
-      const { stdout } = await processExecutor.exec(`ps -p ${pid} -o ppid= -o args= 2>/dev/null`);
-      const output = stdout.trim();
-      if (!output) {
-        return null;
-      }
-      const match = output.match(/^(\d+)\s+([\s\S]+)$/);
-      const environment = await IOSCtrlProxyManager.getProcessEnvironment(processExecutor, pid);
-      if (!match) {
-        return { command: output, environment };
-      }
-      return {
-        ppid: Number.parseInt(match[1], 10),
-        command: match[2],
-        environment,
-      };
-    } catch (error) {
-      // `ps -p <pid>` exits non-zero (throwing) if the process exited between
-      // discovery and this lookup; treat it as "no info available", not an error.
-      logger.debug(`src/utils/IOSCtrlProxyManager.ts fallback failed: ${error}`, error);
-      return null;
-    }
+    return IOSCtrlProxyManager.processClientForTesting(processExecutor, defaultTimer).getProcessInfo(pid);
   }
 
   private static async getProcessEnvironment(
     processExecutor: ProcessExecutor,
     pid: number
   ): Promise<string | undefined> {
-    try {
-      const { stdout } = await processExecutor.exec(`ps eww -p ${pid} -o command= 2>/dev/null`);
-      const output = stdout.trim();
-      return output.length > 0 ? output : undefined;
-    } catch (error) {
-      // Same-pid race as getProcessInfo: the process may be gone by the time we
-      // read its full command line, so an absent environment string is expected.
-      logger.debug(`src/utils/IOSCtrlProxyManager.ts fallback failed: ${error}`, error);
-      return undefined;
-    }
+    return (await IOSCtrlProxyManager.processClientForTesting(processExecutor, defaultTimer).getProcessInfo(pid))?.environment;
   }
 
   private static hasDeviceIdentity(text: string, deviceId: string): boolean {
@@ -1961,63 +1878,14 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     timer: Timer,
     pid: number
   ): Promise<void> {
-    const processTreePids = await IOSCtrlProxyManager.findDescendantProcessIds(processExecutor, pid);
-    const descendantFirstPids = [...processTreePids].reverse();
-
-    try {
-      await processExecutor.exec(`kill -TERM -- -${pid} 2>/dev/null`);
-    } catch {
-      // Process group may not exist when pid is not a group leader.
-    }
-    await IOSCtrlProxyManager.signalProcessIds(processExecutor, [...descendantFirstPids, pid], "TERM");
-
-    if (!await IOSCtrlProxyManager.waitForProcessesExit(processExecutor, timer, [pid, ...processTreePids])) {
-      try {
-        await processExecutor.exec(`kill -KILL -- -${pid} 2>/dev/null`);
-      } catch {
-        // Process group may not exist when pid is not a group leader.
-      }
-      await IOSCtrlProxyManager.signalProcessIds(processExecutor, [...descendantFirstPids, pid], "KILL");
-      await IOSCtrlProxyManager.waitForProcessesExit(processExecutor, timer, [pid, ...processTreePids]);
-    }
+    await IOSCtrlProxyManager.processClientForTesting(processExecutor, timer).terminateProcessTree(pid);
   }
 
   private static async findDescendantProcessIds(
     processExecutor: ProcessExecutor,
     rootPid: number
   ): Promise<number[]> {
-    try {
-      const { stdout } = await processExecutor.exec("ps -axo pid=,ppid=");
-      const childrenByParent = new Map<number, number[]>();
-      for (const line of stdout.trim().split("\n")) {
-        const match = line.trim().match(/^(\d+)\s+(\d+)$/);
-        if (!match) {
-          continue;
-        }
-        const pid = Number(match[1]);
-        const ppid = Number(match[2]);
-        const siblings = childrenByParent.get(ppid) ?? [];
-        siblings.push(pid);
-        childrenByParent.set(ppid, siblings);
-      }
-
-      const descendants: number[] = [];
-      const queue = [...(childrenByParent.get(rootPid) ?? [])];
-      const visited = new Set<number>();
-      while (queue.length > 0) {
-        const pid = queue.shift()!;
-        if (visited.has(pid)) {
-          continue;
-        }
-        visited.add(pid);
-        descendants.push(pid);
-        queue.push(...(childrenByParent.get(pid) ?? []));
-      }
-      return descendants;
-    } catch (error) {
-      logger.debug(`[IOSCtrlProxy] Failed to enumerate descendants for PID ${rootPid}: ${error}`);
-      return [];
-    }
+    return IOSCtrlProxyManager.processClientForTesting(processExecutor, defaultTimer).findDescendantProcessIds(rootPid);
   }
 
   private static async signalProcessIds(
@@ -2025,13 +1893,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     pids: number[],
     signal: "TERM" | "KILL"
   ): Promise<void> {
-    for (const pid of pids) {
-      try {
-        await processExecutor.exec(`kill -${signal} ${pid} 2>/dev/null`);
-      } catch {
-        // Process may have already exited.
-      }
-    }
+    for (const pid of pids) {await IOSCtrlProxyManager.processClientForTesting(processExecutor, defaultTimer).terminateProcess(pid);}
   }
 
   private static async terminateProcess(
@@ -2039,20 +1901,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     timer: Timer,
     pid: number
   ): Promise<void> {
-    try {
-      await processExecutor.exec(`kill -TERM ${pid} 2>/dev/null`);
-    } catch {
-      // Process may have already exited.
-    }
-
-    if (!await IOSCtrlProxyManager.waitForProcessExit(processExecutor, timer, pid)) {
-      try {
-        await processExecutor.exec(`kill -KILL ${pid} 2>/dev/null`);
-      } catch {
-        // Process may have exited between liveness check and kill.
-      }
-      await IOSCtrlProxyManager.waitForProcessExit(processExecutor, timer, pid);
-    }
+    await IOSCtrlProxyManager.processClientForTesting(processExecutor, timer).terminateProcess(pid);
   }
 
   private static async waitForProcessesExit(
@@ -2099,15 +1948,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     processExecutor: ProcessExecutor,
     pid: number
   ): Promise<boolean> {
-    try {
-      await processExecutor.exec(`kill -0 ${pid} 2>/dev/null`);
-      return true;
-    } catch (error) {
-      // `kill -0` throws once the pid has exited, which is exactly the "not
-      // running" case the port-release / exit-wait callers are polling for.
-      logger.debug(`src/utils/IOSCtrlProxyManager.ts fallback failed: ${error}`, error);
-      return false;
-    }
+    return IOSCtrlProxyManager.processClientForTesting(processExecutor, defaultTimer).isRunning(pid);
   }
 
   /**

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -328,7 +328,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     device: BootedDevice,
     timer: Timer,
     builder: IOSCtrlProxyBuilder | undefined,
-    processExecutor: ProcessExecutor,
+    processExecutor: ProcessExecutor & HostCommandExecutor,
     signingManager?: XcodeSigningManager,
     deviceAppManager?: DeviceAppManager,
     remoteRunner?: RemoteCtrlProxyIOSRunner,
@@ -350,7 +350,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         timer,
         (command, args, options) => processExecutor.spawn(command, args, options)
       ),
-      processClient ?? IOSCtrlProxyManager.processClientForTesting(processExecutor, timer)
+      processClient ?? new IOSCtrlProxyProcessClient(processExecutor, timer)
     );
   }
 

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -23,8 +23,6 @@ import {
 import { IOSCtrlProxyHealthClient, isValidCtrlProxyPort } from "./ios/IOSCtrlProxyHealthClient";
 import { IOSCtrlProxyProcessClient } from "./ios/IOSCtrlProxyProcessClient";
 import type { HostCommandExecutor } from "./HostCommandExecutor";
-import { IOSCtrlProxyProcessClient } from "./ios/IOSCtrlProxyProcessClient";
-import type { HostCommandExecutor } from "./HostCommandExecutor";
 import type { ProxyManager, ProxySetupResult } from "./interfaces/ProxyManager";
 
 /**
@@ -356,13 +354,6 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     );
   }
 
-  private static processClientForTesting(processExecutor: ProcessExecutor, timer: Timer): IOSCtrlProxyProcessClient {
-    const host = processExecutor as unknown as Partial<HostCommandExecutor>;
-    return typeof host.executeCommand === "function"
-      ? new IOSCtrlProxyProcessClient(host as HostCommandExecutor, timer)
-      : new IOSCtrlProxyProcessClient(undefined, timer);
-  }
-
   /**
    * Reset all instances (for testing)
    */
@@ -384,10 +375,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    * behind by a previously crashed daemon.
    */
   public static async reapOrphanedRunnerProcessesOnStartup(
-    processExecutor: ProcessExecutor = new DefaultProcessExecutor(),
+    processClient: IOSCtrlProxyProcessClient = new IOSCtrlProxyProcessClient(),
     timer: Timer = defaultTimer
   ): Promise<void> {
-    const processClient = IOSCtrlProxyManager.processClientForTesting(processExecutor, timer);
     let pids: number[] = [];
     try {
       pids = await processClient.findStartupCandidatePids();
@@ -403,7 +393,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
           continue;
         }
         const rootPid = await IOSCtrlProxyManager.findDaemonManagedRunnerTreeRoot(
-          processExecutor,
+          processClient,
           {
             pid,
             port: IOSCtrlProxyManager.DEFAULT_PORT,
@@ -853,7 +843,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
             // signaling only it would orphan the xcodebuild child, which keeps the
             // hung in-sim runner alive to be re-adopted or contend the port on the
             // next start (#2834 review).
-            await IOSCtrlProxyManager.terminateProcessTree(this.processExecutor, this.timer, hungPid);
+            await this.processClient.terminateProcessTree(hungPid);
           }
         } else {
           logger.warn(
@@ -928,7 +918,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     if (this.xcTestProcessId) {
       try {
         if (await this.isOwnRunnerProcessAlive()) {
-          await IOSCtrlProxyManager.terminateProcessTree(this.processExecutor, this.timer, this.xcTestProcessId);
+          await this.processClient.terminateProcessTree(this.xcTestProcessId);
         } else {
           logger.debug(
             `[IOSCtrlProxy] Tracked runner PID ${this.xcTestProcessId} is not an owned CtrlProxy runner; ` +
@@ -1579,7 +1569,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         // stale daemon state, not an external hot-reload runner. Let port cleanup reap
         // the owning tree instead of adopting a runner whose health endpoint is down.
         const daemonManagedRoot = await IOSCtrlProxyManager.findDaemonManagedRunnerTreeRoot(
-          this.processExecutor,
+          this.processClient,
           process
         );
         if (daemonManagedRoot !== null && daemonManagedRoot !== process.pid) {
@@ -1628,7 +1618,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
             `[IOSCtrlProxy] Terminating stale CtrlProxy process tree rooted at ${rootPid} ` +
             `for listener ${process.pid} on port ${this.servicePort}`
           );
-          await IOSCtrlProxyManager.terminateProcessTree(this.processExecutor, this.timer, rootPid);
+          await this.processClient.terminateProcessTree(rootPid);
         }
 
         const remainingProcesses = await this.findListeningProcessesOnPort(this.servicePort);
@@ -1644,7 +1634,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
               `[IOSCtrlProxy] CtrlProxy listener ${process.pid} still holds port ${this.servicePort}; ` +
               `force-terminating remaining owned process tree`
             );
-            await IOSCtrlProxyManager.terminateProcessTree(this.processExecutor, this.timer, process.pid);
+            await this.processClient.terminateProcessTree(process.pid);
           }
         }
 
@@ -1714,12 +1704,12 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   }
 
   private async findDaemonManagedRunnerTreeRoot(process: ListeningProcess): Promise<number> {
-    return (await IOSCtrlProxyManager.findDaemonManagedRunnerTreeRoot(this.processExecutor, process)) ??
+    return (await IOSCtrlProxyManager.findDaemonManagedRunnerTreeRoot(this.processClient, process)) ??
       process.pid;
   }
 
   private static async findDaemonManagedRunnerTreeRoot(
-    processExecutor: ProcessExecutor,
+    processClient: IOSCtrlProxyProcessClient,
     process: ListeningProcess,
     options: { requireOrphanedRoot?: boolean } = {}
   ): Promise<number | null> {
@@ -1737,7 +1727,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
     while (parentPid !== undefined && parentPid > 1 && !visitedPids.has(parentPid)) {
       visitedPids.add(parentPid);
-      const parentInfo = await IOSCtrlProxyManager.getProcessInfo(processExecutor, parentPid);
+      const parentInfo = await processClient.getProcessInfo(parentPid);
       if (!parentInfo) {
         break;
       }
@@ -1763,39 +1753,6 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     return processes
       .map(process => `PID ${process.pid} (cmd: ${process.command})`)
       .join(", ");
-  }
-
-  private static async findStartupCtrlProxyCandidatePids(processExecutor: ProcessExecutor): Promise<number[]> {
-    return IOSCtrlProxyManager.processClientForTesting(processExecutor, defaultTimer).findStartupCandidatePids();
-  }
-
-  private static parseLsofPids(stdout: string): number[] {
-    const pids = new Set<number>();
-    for (const line of stdout.split("\n")) {
-      const match = line.match(/^p(\d+)$/);
-      if (!match) {
-        continue;
-      }
-      const pid = Number.parseInt(match[1], 10);
-      if (!Number.isNaN(pid)) {
-        pids.add(pid);
-      }
-    }
-    return [...pids];
-  }
-
-  private static async getProcessInfo(
-    processExecutor: ProcessExecutor,
-    pid: number
-  ): Promise<{ ppid?: number; command: string; environment?: string } | null> {
-    return IOSCtrlProxyManager.processClientForTesting(processExecutor, defaultTimer).getProcessInfo(pid);
-  }
-
-  private static async getProcessEnvironment(
-    processExecutor: ProcessExecutor,
-    pid: number
-  ): Promise<string | undefined> {
-    return (await IOSCtrlProxyManager.processClientForTesting(processExecutor, defaultTimer).getProcessInfo(pid))?.environment;
   }
 
   private static hasDeviceIdentity(text: string, deviceId: string): boolean {
@@ -1825,7 +1782,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     if (parentPid === undefined || parentPid <= 1) {
       return false;
     }
-    const parentInfo = await IOSCtrlProxyManager.getProcessInfo(this.processExecutor, parentPid);
+    const parentInfo = await this.processClient.getProcessInfo(parentPid);
     if (!parentInfo || parentInfo.ppid !== 1) {
       return false;
     }
@@ -1865,90 +1822,6 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
   private static isDirectCtrlProxyRunnerCommand(command: string): boolean {
     return command.includes("CtrlProxyUITests-Runner");
-  }
-
-  /**
-   * Terminate a runner process TREE rooted at `pid` (TERM → wait → KILL). The process
-   * group signal handles current detached launches; the descendant fallback handles
-   * legacy/orphaned shell roots that are not process-group leaders. Scoped to this tree —
-   * deliberately NOT a machine-wide pkill sweep, which would hit other devices' runners.
-   */
-  private static async terminateProcessTree(
-    processExecutor: ProcessExecutor,
-    timer: Timer,
-    pid: number
-  ): Promise<void> {
-    await IOSCtrlProxyManager.processClientForTesting(processExecutor, timer).terminateProcessTree(pid);
-  }
-
-  private static async findDescendantProcessIds(
-    processExecutor: ProcessExecutor,
-    rootPid: number
-  ): Promise<number[]> {
-    return IOSCtrlProxyManager.processClientForTesting(processExecutor, defaultTimer).findDescendantProcessIds(rootPid);
-  }
-
-  private static async signalProcessIds(
-    processExecutor: ProcessExecutor,
-    pids: number[],
-    signal: "TERM" | "KILL"
-  ): Promise<void> {
-    for (const pid of pids) {await IOSCtrlProxyManager.processClientForTesting(processExecutor, defaultTimer).terminateProcess(pid);}
-  }
-
-  private static async terminateProcess(
-    processExecutor: ProcessExecutor,
-    timer: Timer,
-    pid: number
-  ): Promise<void> {
-    await IOSCtrlProxyManager.processClientForTesting(processExecutor, timer).terminateProcess(pid);
-  }
-
-  private static async waitForProcessesExit(
-    processExecutor: ProcessExecutor,
-    timer: Timer,
-    pids: number[]
-  ): Promise<boolean> {
-    for (let attempt = 0; attempt < IOSCtrlProxyManager.PORT_RELEASE_ATTEMPTS; attempt++) {
-      if (await IOSCtrlProxyManager.haveProcessesExited(processExecutor, pids)) {
-        return true;
-      }
-      await timer.sleep(IOSCtrlProxyManager.PORT_RELEASE_GRACE_MS);
-    }
-    return IOSCtrlProxyManager.haveProcessesExited(processExecutor, pids);
-  }
-
-  private static async haveProcessesExited(
-    processExecutor: ProcessExecutor,
-    pids: number[]
-  ): Promise<boolean> {
-    for (const pid of pids) {
-      if (await IOSCtrlProxyManager.isProcessRunningWithExecutor(processExecutor, pid)) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  private static async waitForProcessExit(
-    processExecutor: ProcessExecutor,
-    timer: Timer,
-    pid: number
-  ): Promise<boolean> {
-    for (let attempt = 0; attempt < IOSCtrlProxyManager.PORT_RELEASE_ATTEMPTS; attempt++) {
-      if (!await IOSCtrlProxyManager.isProcessRunningWithExecutor(processExecutor, pid)) {
-        return true;
-      }
-      await timer.sleep(IOSCtrlProxyManager.PORT_RELEASE_GRACE_MS);
-    }
-    return !await IOSCtrlProxyManager.isProcessRunningWithExecutor(processExecutor, pid);
-  }
-
-  private static async isProcessRunningWithExecutor(
-    processExecutor: ProcessExecutor,
-    pid: number
-  ): Promise<boolean> {
-    return IOSCtrlProxyManager.processClientForTesting(processExecutor, defaultTimer).isRunning(pid);
   }
 
   /**

--- a/src/utils/ios/IOSCtrlProxyProcessClient.ts
+++ b/src/utils/ios/IOSCtrlProxyProcessClient.ts
@@ -2,14 +2,15 @@ import type { HostCommandExecutor } from "../HostCommandExecutor";
 import { DefaultHostCommandExecutor } from "../HostCommandExecutor";
 import type { Timer } from "../SystemTimer";
 import { defaultTimer } from "../SystemTimer";
+import { logger } from "../logger";
 
-export interface IOSCtrlProxyProcessInfo {
+export interface CtrlProxyProcessInfo {
   readonly ppid?: number;
   readonly command: string;
   readonly environment?: string;
 }
 
-export interface IOSCtrlProxyExternalProcess {
+export interface CtrlProxyExternalProcess {
   readonly pid: number;
   readonly port: number;
 }
@@ -42,7 +43,7 @@ export class IOSCtrlProxyProcessClient {
   async findExternalXcodebuildCtrlProxyProcess(
     deviceId: string,
     excludedPid?: number
-  ): Promise<IOSCtrlProxyExternalProcess | null> {
+  ): Promise<CtrlProxyExternalProcess | null> {
     const pids = await this.findPids("xcodebuild", true);
     for (const pid of pids) {
       if (pid === excludedPid) {
@@ -84,12 +85,13 @@ export class IOSCtrlProxyProcessClient {
         const match = line.match(/^p(\d+)$/);
         return match ? [Number.parseInt(match[1], 10)] : [];
       }))];
-    } catch {
+    } catch (error) {
+      logger.debug(`[IOSCtrlProxy] Failed to find listener PIDs for port ${port}: ${error}`);
       return [];
     }
   }
 
-  async getProcessInfo(pid: number): Promise<IOSCtrlProxyProcessInfo | null> {
+  async getProcessInfo(pid: number): Promise<CtrlProxyProcessInfo | null> {
     try {
       const { stdout } = await this.host.executeCommand("ps", ["-p", String(pid), "-o", "ppid=", "-o", "args="]);
       const output = stdout.trim();
@@ -99,7 +101,8 @@ export class IOSCtrlProxyProcessClient {
       const environment = await this.getProcessEnvironment(pid);
       const match = output.match(/^(\d+)\s+([\s\S]+)$/);
       return match ? { ppid: Number.parseInt(match[1], 10), command: match[2], environment } : { command: output, environment };
-    } catch {
+    } catch (error) {
+      logger.debug(`[IOSCtrlProxy] Failed to inspect PID ${pid}: ${error}`);
       return null;
     }
   }
@@ -108,7 +111,8 @@ export class IOSCtrlProxyProcessClient {
     try {
       const result = await this.host.executeCommand("kill", ["-0", String(pid)]);
       return !/operation not permitted|permission denied/i.test(result.stderr);
-    } catch {
+    } catch (error) {
+      logger.debug(`[IOSCtrlProxy] Failed to check PID ${pid}: ${error}`);
       return false;
     }
   }
@@ -144,7 +148,8 @@ export class IOSCtrlProxyProcessClient {
         queue.push(...(children.get(pid) ?? []));
       }
       return descendants;
-    } catch {
+    } catch (error) {
+      logger.debug(`[IOSCtrlProxy] Failed to enumerate descendants of PID ${rootPid}: ${error}`);
       return [];
     }
   }
@@ -179,7 +184,7 @@ export class IOSCtrlProxyProcessClient {
     return command.includes("CtrlProxyUITests-Runner");
   }
 
-  isDaemonManagedSimulatorXcodebuildProcess(process: IOSCtrlProxyProcessInfo): boolean {
+  isDaemonManagedSimulatorXcodebuildProcess(process: CtrlProxyProcessInfo): boolean {
     const command = process.command;
     const shape = command.includes("xcodebuild") && command.includes("test-without-building") && command.includes("-xctestrun") && command.includes("platform=iOS Simulator") && command.includes("-only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService") && !command.includes("CTRL_PROXY_IOS_PORT=") && !command.includes("AUTOMOBILE_DEVICE_ID=");
     return shape && (process.ppid === 1 || !this.hasExternalXcodebuildIdentity(process.environment ?? ""));
@@ -192,7 +197,8 @@ export class IOSCtrlProxyProcessClient {
         const pid = Number.parseInt(line, 10);
         return Number.isNaN(pid) ? [] : [pid];
       });
-    } catch {
+    } catch (error) {
+      logger.debug(`[IOSCtrlProxy] Failed to enumerate ${pattern} PIDs: ${error}`);
       return [];
     }
   }
@@ -201,7 +207,8 @@ export class IOSCtrlProxyProcessClient {
     try {
       const { stdout } = await this.host.executeCommand("ps", ["eww", "-p", String(pid), "-o", "command="]);
       return stdout.trim() || undefined;
-    } catch {
+    } catch (error) {
+      logger.debug(`[IOSCtrlProxy] Failed to inspect environment for PID ${pid}: ${error}`);
       return undefined;
     }
   }
@@ -216,12 +223,20 @@ export class IOSCtrlProxyProcessClient {
   }
 
   private async signalGroup(pid: number, signal: "TERM" | "KILL"): Promise<void> {
-    try { await this.host.executeCommand("kill", [`-${signal}`, "--", `-${pid}`]); } catch { /* not a group leader */ }
+    try {
+      await this.host.executeCommand("kill", [`-${signal}`, "--", `-${pid}`]);
+    } catch (error) {
+      logger.debug(`[IOSCtrlProxy] PID ${pid} is not a signalable process group: ${error}`);
+    }
   }
 
   private async signalPids(pids: number[], signal: "TERM" | "KILL"): Promise<void> {
     for (const pid of pids) {
-      try { await this.host.executeCommand("kill", [`-${signal}`, String(pid)]); } catch { /* exited race */ }
+      try {
+        await this.host.executeCommand("kill", [`-${signal}`, String(pid)]);
+      } catch (error) {
+        logger.debug(`[IOSCtrlProxy] PID ${pid} exited before ${signal}: ${error}`);
+      }
     }
   }
 

--- a/src/utils/ios/IOSCtrlProxyProcessClient.ts
+++ b/src/utils/ios/IOSCtrlProxyProcessClient.ts
@@ -1,0 +1,242 @@
+import type { HostCommandExecutor } from "../HostCommandExecutor";
+import { DefaultHostCommandExecutor } from "../HostCommandExecutor";
+import type { Timer } from "../SystemTimer";
+import { defaultTimer } from "../SystemTimer";
+
+export interface IOSCtrlProxyProcessInfo {
+  readonly ppid?: number;
+  readonly command: string;
+  readonly environment?: string;
+}
+
+export interface IOSCtrlProxyExternalProcess {
+  readonly pid: number;
+  readonly port: number;
+}
+
+interface ProcessClientOptions {
+  readonly releaseAttempts?: number;
+  readonly releaseGraceMs?: number;
+}
+
+/**
+ * The sole host-process boundary for the CtrlProxy XCTest runner.
+ *
+ * Keeping PID discovery, ownership checks and signaling here prevents device IDs,
+ * ports and PIDs from being interpolated into shell commands by lifecycle callers.
+ */
+export class IOSCtrlProxyProcessClient {
+  private static readonly DEFAULT_PORT = 8765;
+  private readonly releaseAttempts: number;
+  private readonly releaseGraceMs: number;
+
+  constructor(
+    private readonly host: HostCommandExecutor = new DefaultHostCommandExecutor(),
+    private readonly timer: Timer = defaultTimer,
+    options: ProcessClientOptions = {}
+  ) {
+    this.releaseAttempts = options.releaseAttempts ?? 4;
+    this.releaseGraceMs = options.releaseGraceMs ?? 250;
+  }
+
+  async findExternalXcodebuildCtrlProxyProcess(
+    deviceId: string,
+    excludedPid?: number
+  ): Promise<IOSCtrlProxyExternalProcess | null> {
+    const pids = await this.findPids("xcodebuild", true);
+    for (const pid of pids) {
+      if (pid === excludedPid) {
+        continue;
+      }
+      const process = await this.getProcessInfo(pid);
+      if (!process || !process.command.includes("CtrlProxy")) {
+        continue;
+      }
+      if (this.isDaemonManagedSimulatorXcodebuildProcess(process)) {
+        continue;
+      }
+      if (!this.hasDeviceIdentity(`${process.command} ${process.environment ?? ""}`, deviceId)) {
+        continue;
+      }
+      return { pid, port: this.parseCtrlProxyPort(process.command) ?? this.parseCtrlProxyPort(process.environment ?? "") ?? IOSCtrlProxyProcessClient.DEFAULT_PORT };
+    }
+    return null;
+  }
+
+  async findStartupCandidatePids(): Promise<number[]> {
+    const pids = new Set<number>();
+    for (const [pattern, exact] of [["xcodebuild", true], ["CtrlProxyUITests-Runner", false]] as const) {
+      for (const pid of await this.findPids(pattern, exact)) {
+        pids.add(pid);
+      }
+    }
+    return [...pids];
+  }
+
+  async findXcodebuildPids(): Promise<number[]> {
+    return this.findPids("xcodebuild", true);
+  }
+
+  async findListeningPids(port: number): Promise<number[]> {
+    try {
+      const { stdout } = await this.host.executeCommand("lsof", ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-Fp"]);
+      return [...new Set(stdout.split("\n").flatMap(line => {
+        const match = line.match(/^p(\d+)$/);
+        return match ? [Number.parseInt(match[1], 10)] : [];
+      }))];
+    } catch {
+      return [];
+    }
+  }
+
+  async getProcessInfo(pid: number): Promise<IOSCtrlProxyProcessInfo | null> {
+    try {
+      const { stdout } = await this.host.executeCommand("ps", ["-p", String(pid), "-o", "ppid=", "-o", "args="]);
+      const output = stdout.trim();
+      if (!output) {
+        return null;
+      }
+      const environment = await this.getProcessEnvironment(pid);
+      const match = output.match(/^(\d+)\s+([\s\S]+)$/);
+      return match ? { ppid: Number.parseInt(match[1], 10), command: match[2], environment } : { command: output, environment };
+    } catch {
+      return null;
+    }
+  }
+
+  async isRunning(pid: number): Promise<boolean> {
+    try {
+      const result = await this.host.executeCommand("kill", ["-0", String(pid)]);
+      return !/operation not permitted|permission denied/i.test(result.stderr);
+    } catch {
+      return false;
+    }
+  }
+
+  async isOwnedRunnerAlive(pid: number, deviceId: string): Promise<boolean> {
+    if (!await this.isRunning(pid)) {
+      return false;
+    }
+    const process = await this.getProcessInfo(pid);
+    return !!process && this.isCtrlProxyRunnerCommand(process.command) &&
+      this.hasDeviceIdentity(`${process.command} ${process.environment ?? ""}`, deviceId);
+  }
+
+  async findDescendantProcessIds(rootPid: number): Promise<number[]> {
+    try {
+      const { stdout } = await this.host.executeCommand("ps", ["-axo", "pid=,ppid="]);
+      const children = new Map<number, number[]>();
+      for (const line of stdout.trim().split("\n")) {
+        const match = line.trim().match(/^(\d+)\s+(\d+)$/);
+        if (!match) {continue;}
+        const pid = Number(match[1]);
+        const parent = Number(match[2]);
+        children.set(parent, [...(children.get(parent) ?? []), pid]);
+      }
+      const descendants: number[] = [];
+      const queue = [...(children.get(rootPid) ?? [])];
+      const visited = new Set<number>();
+      while (queue.length > 0) {
+        const pid = queue.shift()!;
+        if (visited.has(pid)) {continue;}
+        visited.add(pid);
+        descendants.push(pid);
+        queue.push(...(children.get(pid) ?? []));
+      }
+      return descendants;
+    } catch {
+      return [];
+    }
+  }
+
+  async terminateProcessTree(pid: number): Promise<void> {
+    const descendants = await this.findDescendantProcessIds(pid);
+    const targets = [...descendants].reverse().concat(pid);
+    await this.signalGroup(pid, "TERM");
+    await this.signalPids(targets, "TERM");
+    if (await this.waitForExit([pid, ...descendants])) {return;}
+    await this.signalGroup(pid, "KILL");
+    await this.signalPids(targets, "KILL");
+    await this.waitForExit([pid, ...descendants]);
+  }
+
+  async terminateProcess(pid: number): Promise<void> {
+    await this.signalPids([pid], "TERM");
+    if (await this.waitForExit([pid])) {return;}
+    await this.signalPids([pid], "KILL");
+    await this.waitForExit([pid]);
+  }
+
+  hasDeviceIdentity(text: string, deviceId: string): boolean {
+    return text.includes(`id=${deviceId}`) || text.includes(`AUTOMOBILE_DEVICE_ID=${deviceId}`) || text.includes(`SIMCTL_CHILD_AUTOMOBILE_DEVICE_ID=${deviceId}`);
+  }
+
+  isCtrlProxyRunnerCommand(command: string): boolean {
+    return command.includes("CtrlProxy") && (command.includes("xcodebuild") || command.includes("CtrlProxyUITests") || command.includes("CtrlProxyUITests-Runner") || command.includes(".xctestrun"));
+  }
+
+  isDirectCtrlProxyRunnerCommand(command: string): boolean {
+    return command.includes("CtrlProxyUITests-Runner");
+  }
+
+  isDaemonManagedSimulatorXcodebuildProcess(process: IOSCtrlProxyProcessInfo): boolean {
+    const command = process.command;
+    const shape = command.includes("xcodebuild") && command.includes("test-without-building") && command.includes("-xctestrun") && command.includes("platform=iOS Simulator") && command.includes("-only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService") && !command.includes("CTRL_PROXY_IOS_PORT=") && !command.includes("AUTOMOBILE_DEVICE_ID=");
+    return shape && (process.ppid === 1 || !this.hasExternalXcodebuildIdentity(process.environment ?? ""));
+  }
+
+  private async findPids(pattern: string, exact: boolean): Promise<number[]> {
+    try {
+      const { stdout } = await this.host.executeCommand("pgrep", [exact ? "-x" : "-f", pattern]);
+      return stdout.trim().split("\n").flatMap(line => {
+        const pid = Number.parseInt(line, 10);
+        return Number.isNaN(pid) ? [] : [pid];
+      });
+    } catch {
+      return [];
+    }
+  }
+
+  private async getProcessEnvironment(pid: number): Promise<string | undefined> {
+    try {
+      const { stdout } = await this.host.executeCommand("ps", ["eww", "-p", String(pid), "-o", "command="]);
+      return stdout.trim() || undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private parseCtrlProxyPort(text: string): number | null {
+    const match = text.match(/(?:^|\s)(?:SIMCTL_CHILD_)?CTRL_PROXY_IOS_PORT=(\d+)(?:\s|$)/);
+    return match ? Number.parseInt(match[1], 10) : null;
+  }
+
+  private hasExternalXcodebuildIdentity(environment: string): boolean {
+    return environment.includes("CTRL_PROXY_IOS_PORT=") || environment.includes("AUTOMOBILE_DEVICE_ID=") || environment.includes("SIMCTL_CHILD_AUTOMOBILE_DEVICE_ID=");
+  }
+
+  private async signalGroup(pid: number, signal: "TERM" | "KILL"): Promise<void> {
+    try { await this.host.executeCommand("kill", [`-${signal}`, "--", `-${pid}`]); } catch { /* not a group leader */ }
+  }
+
+  private async signalPids(pids: number[], signal: "TERM" | "KILL"): Promise<void> {
+    for (const pid of pids) {
+      try { await this.host.executeCommand("kill", [`-${signal}`, String(pid)]); } catch { /* exited race */ }
+    }
+  }
+
+  private async waitForExit(pids: number[]): Promise<boolean> {
+    for (let attempt = 0; attempt < this.releaseAttempts; attempt++) {
+      if (await this.haveExited(pids)) {return true;}
+      await this.timer.sleep(this.releaseGraceMs);
+    }
+    return this.haveExited(pids);
+  }
+
+  private async haveExited(pids: number[]): Promise<boolean> {
+    for (const pid of pids) {
+      if (await this.isRunning(pid)) {return false;}
+    }
+    return true;
+  }
+}

--- a/test/fakes/FakeProcessExecutor.ts
+++ b/test/fakes/FakeProcessExecutor.ts
@@ -1,12 +1,13 @@
 import type { ChildProcess, SpawnOptions } from "child_process";
 import type { ExecResult } from "../../src/models";
 import type { ProcessExecOptions, ProcessExecutor } from "../../src/utils/ProcessExecutor";
+import type { HostCommandOptions, HostCommandExecutor } from "../../src/utils/HostCommandExecutor";
 import { FakeChildProcess } from "./FakeChildProcess";
 
 /**
  * Fake ProcessExecutor for testing command execution and process spawning.
  */
-export class FakeProcessExecutor implements ProcessExecutor {
+export class FakeProcessExecutor implements ProcessExecutor, HostCommandExecutor {
   private commandResponses: Map<string, ExecResult> = new Map();
   private commandHandlers: Array<{ pattern: string; handler: (command: string) => ExecResult | Promise<ExecResult> }> = [];
   private defaultResponse: ExecResult = this.createExecResult("", "");
@@ -55,6 +56,13 @@ export class FakeProcessExecutor implements ProcessExecutor {
       }
     }
     return this.defaultResponse;
+  }
+
+  async executeCommand(command: string, args: string[] = [], _options?: HostCommandOptions): Promise<ExecResult> {
+    const renderedArgs = args.map((arg, index) =>
+      command === "pgrep" && args[index - 1] === "-f" ? `'${arg}'` : arg.includes(" ") ? `'${arg}'` : arg
+    );
+    return this.exec([command, ...renderedArgs].join(" "));
   }
 
   spawn(command: string, args: string[], options?: SpawnOptions): ChildProcess {

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { findViolationsInSource } from "../../scripts/check-ios-ctrl-proxy-process-boundary";
+import { findViolationsInSource, repositoryPath } from "../../scripts/check-ios-ctrl-proxy-process-boundary";
 
 const ROOT = join(import.meta.dir, "..", "..");
 const OWNER = join(ROOT, "src/utils/ios/IOSCtrlProxyProcessClient.ts");
@@ -29,5 +29,11 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
     expect(readFileSync(join(ROOT, "scripts/all_fast_validate_checks.sh"), "utf8")).toContain("ios-ctrl-proxy-process-boundary");
     expect(readFileSync(join(ROOT, "turbo.json"), "utf8")).toContain('"check:ios-ctrl-proxy-process-boundary"');
     expect(readFileSync(join(ROOT, ".github/workflows/pull_request.yml"), "utf8")).toContain("Check iOS CtrlProxy process execution boundary");
+  });
+
+  test("normalizes Windows separators before applying ownership exceptions", () => {
+    expect(repositoryPath("src\\utils\\ios\\IOSCtrlProxyProcessClient.ts")).toBe(
+      "src/utils/ios/IOSCtrlProxyProcessClient.ts",
+    );
   });
 });

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { findViolationsInSource } from "../../scripts/check-ios-ctrl-proxy-process-boundary";
 
 const ROOT = join(import.meta.dir, "..", "..");
 const OWNER = join(ROOT, "src/utils/ios/IOSCtrlProxyProcessClient.ts");
@@ -13,9 +14,16 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
     expect(readFileSync(OWNER, "utf8")).toContain("executeCommand(\"pgrep\"");
   });
 
+  test("rejects direct and wrapped process APIs for lifecycle tools", () => {
+    expect(findViolationsInSource("fixture.ts", 'execFile("kill", ["-9", "42"]);')).toHaveLength(1);
+    expect(findViolationsInSource("fixture.ts", 'host.executeCommand("ps", ["-p", "42"]);')).toHaveLength(1);
+    expect(findViolationsInSource("fixture.ts", 'Bun.spawn(["pgrep", "-x", "xcodebuild"]);')).toHaveLength(1);
+    expect(findViolationsInSource("fixture.ts", 'host.executeCommand("xcrun", ["simctl", "list"]);')).toEqual([]);
+  });
+
   test("has a production check with documented exceptions", () => {
     const source = readFileSync(CHECK, "utf8");
-    expect(source).toContain("const EXCEPTIONS = new Map<string, string>();");
+    expect(source).toContain("const EXCEPTIONS = new Map<string, string>([");
     expect(source).toContain("IOSCtrlProxyProcessClient.ts");
     expect(readFileSync(join(ROOT, "package.json"), "utf8")).toContain("check:ios-ctrl-proxy-process-boundary");
     expect(readFileSync(join(ROOT, "scripts/all_fast_validate_checks.sh"), "utf8")).toContain("ios-ctrl-proxy-process-boundary");

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -17,5 +17,9 @@ describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
     const source = readFileSync(CHECK, "utf8");
     expect(source).toContain("const EXCEPTIONS = new Map<string, string>();");
     expect(source).toContain("IOSCtrlProxyProcessClient.ts");
+    expect(readFileSync(join(ROOT, "package.json"), "utf8")).toContain("check:ios-ctrl-proxy-process-boundary");
+    expect(readFileSync(join(ROOT, "scripts/all_fast_validate_checks.sh"), "utf8")).toContain("ios-ctrl-proxy-process-boundary");
+    expect(readFileSync(join(ROOT, "turbo.json"), "utf8")).toContain('"check:ios-ctrl-proxy-process-boundary"');
+    expect(readFileSync(join(ROOT, ".github/workflows/pull_request.yml"), "utf8")).toContain("Check iOS CtrlProxy process execution boundary");
   });
 });

--- a/test/lint/iosCtrlProxyProcessBoundary.test.ts
+++ b/test/lint/iosCtrlProxyProcessBoundary.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dir, "..", "..");
+const OWNER = join(ROOT, "src/utils/ios/IOSCtrlProxyProcessClient.ts");
+const CHECK = join(ROOT, "scripts/check-ios-ctrl-proxy-process-boundary.ts");
+
+describe("iOS CtrlProxy process execution boundary (issue #4063)", () => {
+  test("keeps ps, pgrep, and kill ownership in the lifecycle client", () => {
+    const manager = readFileSync(join(ROOT, "src/utils/IOSCtrlProxyManager.ts"), "utf8");
+    expect(manager).not.toMatch(/processExecutor\.exec\(\s*["'`](?:ps|pgrep|kill)/);
+    expect(readFileSync(OWNER, "utf8")).toContain("executeCommand(\"pgrep\"");
+  });
+
+  test("has a production check with documented exceptions", () => {
+    const source = readFileSync(CHECK, "utf8");
+    expect(source).toContain("const EXCEPTIONS = new Map<string, string>();");
+    expect(source).toContain("IOSCtrlProxyProcessClient.ts");
+  });
+});

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -8,6 +8,7 @@ import { FakeChildProcess } from "../fakes/FakeChildProcess";
 import type { ExecResult } from "../../src/models";
 import { PortManager } from "../../src/utils/PortManager";
 import { IOSCtrlProxyBuilder } from "../../src/utils/IOSCtrlProxyBuilder";
+import { IOSCtrlProxyProcessClient } from "../../src/utils/ios/IOSCtrlProxyProcessClient";
 import { parsePlist } from "../../src/utils/ios-cmdline-tools/XctestrunPlist";
 import type { XcodeSigningManager } from "../../src/utils/ios-cmdline-tools/XcodeSigning";
 import * as fs from "fs/promises";
@@ -2066,7 +2067,7 @@ describe("IOSCtrlProxyManager", function() {
       fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("4444\n", ""));
       fakeTimer.enableAutoAdvance();
 
-      await IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup(fakeExecutor, fakeTimer);
+      await IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup(new IOSCtrlProxyProcessClient(fakeExecutor, fakeTimer), fakeTimer);
 
       expect(orphanProcess.alive).toBe(false);
       expect(fakeExecutor.wasCommandExecuted("kill -TERM 4444")).toBe(true);
@@ -2085,7 +2086,7 @@ describe("IOSCtrlProxyManager", function() {
       fakeExecutor.setCommandResponse("pgrep -f 'CtrlProxyUITests-Runner'", createExecResult("4445\n", ""));
       fakeTimer.enableAutoAdvance();
 
-      await IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup(fakeExecutor, fakeTimer);
+      await IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup(new IOSCtrlProxyProcessClient(fakeExecutor, fakeTimer), fakeTimer);
 
       expect(orphanProcess.alive).toBe(false);
       expect(fakeExecutor.wasCommandExecuted("kill -TERM 4445")).toBe(true);
@@ -2123,7 +2124,7 @@ describe("IOSCtrlProxyManager", function() {
       fakeExecutor.setCommandResponse("pgrep -f 'CtrlProxyUITests-Runner'", createExecResult("4448\n", ""));
       fakeTimer.enableAutoAdvance();
 
-      await IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup(fakeExecutor, fakeTimer);
+      await IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup(new IOSCtrlProxyProcessClient(fakeExecutor, fakeTimer), fakeTimer);
 
       expect(fakeExecutor.wasCommandExecuted("kill -TERM -- -4446")).toBe(true);
       expect(orphanedShell.alive).toBe(false);
@@ -2156,7 +2157,7 @@ describe("IOSCtrlProxyManager", function() {
       fakeExecutor.setCommandResponse("pgrep -f 'CtrlProxyUITests-Runner'", createExecResult("", ""));
       fakeTimer.enableAutoAdvance();
 
-      await IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup(fakeExecutor, fakeTimer);
+      await IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup(new IOSCtrlProxyProcessClient(fakeExecutor, fakeTimer), fakeTimer);
 
       expect(fakeExecutor.wasCommandExecuted("kill -TERM -- -4451")).toBe(false);
       expect(fakeExecutor.wasCommandExecuted("kill -TERM 4451")).toBe(false);

--- a/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
+++ b/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { IOSCtrlProxyProcessClient } from "../../../src/utils/ios/IOSCtrlProxyProcessClient";
+import { FakeHostCommandExecutor } from "../../fakes/FakeHostCommandExecutor";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+function result(stdout = "", stderr = "") {
+  return { stdout, stderr, toString: () => stdout, trim: () => stdout.trim(), includes: (text: string) => stdout.includes(text) };
+}
+
+describe("IOSCtrlProxyProcessClient", () => {
+  test("uses argv for PID lookup and preserves device identity validation", async () => {
+    const host = new FakeHostCommandExecutor();
+    host.setCommandResponse("pgrep -x xcodebuild", result("42\n"));
+    host.setCommandResponse("ps -p 42 -o ppid= -o args=", result("2 xcodebuild test-without-building -xctestrun /tmp/CtrlProxy.xctestrun -destination platform=iOS Simulator,id=DEVICE-1 -only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService"));
+    host.setCommandResponse("ps eww -p 42 -o command=", result("AUTOMOBILE_DEVICE_ID=DEVICE-1"));
+    const client = new IOSCtrlProxyProcessClient(host, new FakeTimer());
+
+    const process = await client.findExternalXcodebuildCtrlProxyProcess("DEVICE-1");
+
+    expect(process).toEqual({ pid: 42, port: 8765 });
+    expect(host.getExecutedCommands()).toContain("pgrep -x xcodebuild");
+    expect(host.getExecutedCommands()).toContain("ps -p 42 -o ppid= -o args=");
+  });
+
+  test("does not identify a recycled PID as a CtrlProxy runner", async () => {
+    const host = new FakeHostCommandExecutor();
+    host.setCommandResponse("kill -0 42", result());
+    host.setCommandResponse("ps -p 42 -o ppid= -o args=", result("1 xcodebuild test -destination id=DEVICE-1"));
+    const client = new IOSCtrlProxyProcessClient(host, new FakeTimer());
+
+    await expect(client.isOwnedRunnerAlive(42, "DEVICE-1")).resolves.toBe(false);
+  });
+
+  test("signals the owned process group, then descendants, and escalates after the bounded wait", async () => {
+    const host = new FakeHostCommandExecutor();
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    host.setCommandResponse("ps -axo pid=,ppid=", result("42 1\n43 42\n"));
+    host.setCommandResponse("kill -0 42", result());
+    host.setCommandResponse("kill -0 43", result());
+    const client = new IOSCtrlProxyProcessClient(host, timer, { releaseAttempts: 1, releaseGraceMs: 1 });
+
+    await client.terminateProcessTree(42);
+
+    expect(host.getExecutedCommands()).toEqual(expect.arrayContaining([
+      "kill -TERM -- -42", "kill -TERM 43", "kill -TERM 42",
+      "kill -KILL -- -42", "kill -KILL 43", "kill -KILL 42",
+    ]));
+  });
+
+  test("treats permission failures as an unavailable PID rather than signaling it", async () => {
+    const host = new FakeHostCommandExecutor();
+    host.setCommandResponse("kill -0 77", result("", "Operation not permitted"));
+    const client = new IOSCtrlProxyProcessClient(host, new FakeTimer());
+
+    await expect(client.isRunning(77)).resolves.toBe(false);
+    expect(host.getExecutedCommands()).toEqual(["kill -0 77"]);
+  });
+});

--- a/turbo.json
+++ b/turbo.json
@@ -63,6 +63,17 @@
       "outputs": [],
       "outputLogs": "new-only"
     },
+    "check:ios-ctrl-proxy-process-boundary": {
+      "description": "Keep CtrlProxy PID tooling behind IOSCtrlProxyProcessClient",
+      "inputs": [
+        "src/**",
+        "scripts/check-ios-ctrl-proxy-process-boundary.ts",
+        "scripts/check-ios-ctrl-proxy-process-boundary.sh",
+        "package.json"
+      ],
+      "outputs": [],
+      "outputLogs": "new-only"
+    },
     "test:coverage": {
       "description": "Run tests with coverage reporting to coverage/",
       "inputs": [


### PR DESCRIPTION
## Summary

- centralize iOS CtrlProxy runner PID inspection and signaling behind an injected argv-safe lifecycle client
- preserve PID-reuse, ownership, process-group, descendant-cleanup, and bounded-wait safeguards
- add a production boundary check and focused tests for lifecycle safety

## Validation

- `bun test test/utils/ios/IOSCtrlProxyProcessClient.test.ts test/utils/IOSCtrlProxyManager.test.ts test/lint/iosCtrlProxyProcessBoundary.test.ts`
- `bun run check:ios-ctrl-proxy-process-boundary`
- `bun run typecheck`
- `bun run build`
- `bun run lint`
- `bun run turbo:validate`

Closes #4063
