### PR TITLE
refactor(android): centralize sdkmanager execution

### DIFF
--- a/src/utils/android-cmdline-tools/SdkManagerClient.ts
+++ b/src/utils/android-cmdline-tools/SdkManagerClient.ts
@@ -15,6 +15,7 @@ import {
 
 const SDK_ROOT_MARKERS = ["system-images", "platforms", "platform-tools", "build-tools"];
 const DEFAULT_MAX_OUTPUT_CHARS = 16_384;
+const UNBOUNDED_OUTPUT_CHARS = Number.MAX_SAFE_INTEGER;
 const DEFAULT_TERMINATION_GRACE_MS = 5_000;
 
 export interface SdkManagerExecutionOptions {
@@ -90,7 +91,10 @@ export class SdkManagerClient {
   constructor(private readonly dependencies: SdkManagerClientDependencies = defaults()) {}
 
   async list(options: SdkManagerExecutionOptions = {}): Promise<SdkManagerCommandResult> {
-    return this.run(["--list"], { timeoutMs: 60_000 }, options);
+    return this.run(["--list"], { timeoutMs: 60_000 }, {
+      ...options,
+      maxOutputChars: options.maxOutputChars ?? UNBOUNDED_OUTPUT_CHARS,
+    });
   }
 
   async acceptLicenses(options: SdkManagerExecutionOptions = {}): Promise<SdkManagerCommandResult> {

--- a/src/utils/android-cmdline-tools/SdkManagerClient.ts
+++ b/src/utils/android-cmdline-tools/SdkManagerClient.ts
@@ -1,0 +1,257 @@
+import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { defaultTimer, type Timer } from "../SystemTimer";
+import { logger } from "../logger";
+import {
+  detectAndroidCommandLineTools,
+  getAndroidHomeWithSystemImages,
+  getBestAndroidToolsLocation,
+  getCmdlineToolsRoot,
+  isHomebrewToolsPath,
+  validateRequiredTools,
+  type AndroidToolsLocation,
+} from "./detection";
+
+const SDK_ROOT_MARKERS = ["system-images", "platforms", "platform-tools", "build-tools"];
+const DEFAULT_MAX_OUTPUT_CHARS = 16_384;
+const DEFAULT_TERMINATION_GRACE_MS = 5_000;
+
+export interface SdkManagerExecutionOptions {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  terminationGraceMs?: number;
+  maxOutputChars?: number;
+}
+
+export interface SdkManagerCommandResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+  outputTruncated: boolean;
+}
+
+export interface SdkManagerClientDependencies {
+  spawn: (command: string, args: string[], options: SpawnOptions) => ChildProcess;
+  existsSync: typeof existsSync;
+  logger: Pick<typeof logger, "info" | "warn" | "error">;
+  detectAndroidCommandLineTools: typeof detectAndroidCommandLineTools;
+  getAndroidHomeWithSystemImages: typeof getAndroidHomeWithSystemImages;
+  getBestAndroidToolsLocation: typeof getBestAndroidToolsLocation;
+  validateRequiredTools: typeof validateRequiredTools;
+  timer: Timer;
+  environment: NodeJS.ProcessEnv;
+  platform: NodeJS.Platform;
+}
+
+function defaults(): SdkManagerClientDependencies {
+  return {
+    spawn,
+    existsSync,
+    logger,
+    detectAndroidCommandLineTools,
+    getAndroidHomeWithSystemImages,
+    getBestAndroidToolsLocation,
+    validateRequiredTools,
+    timer: defaultTimer,
+    environment: process.env,
+    platform: process.platform,
+  };
+}
+
+function normalizePath(value: string): string {
+  return value.replace(/\\/g, "/");
+}
+
+function redact(value: string): string {
+  return value.replace(
+    /\b(token|password|secret|api[_-]?key)\s*=\s*[^\s]+/gi,
+    (_match, key: string) => `${key}=[REDACTED]`,
+  );
+}
+
+function appendBounded(current: string, next: string, maximum: number): { value: string; truncated: boolean } {
+  const available = maximum - current.length;
+  if (available <= 0) {return { value: current, truncated: next.length > 0 };}
+  if (next.length <= available) {return { value: current + next, truncated: false };}
+  return { value: current + next.slice(0, available), truncated: true };
+}
+
+function quoteForWindowsCmd(value: string): string {
+  if (/[\r\n"]/.test(value)) {
+    throw new Error("sdkmanager arguments cannot contain Windows command-line quotes or newlines");
+  }
+  return `"${value.replace(/%/g, "%%")}"`;
+}
+
+export class SdkManagerClient {
+  private static readonly homebrewWarningLoggers = new WeakSet<object>();
+
+  constructor(private readonly dependencies: SdkManagerClientDependencies = defaults()) {}
+
+  async list(options: SdkManagerExecutionOptions = {}): Promise<SdkManagerCommandResult> {
+    return this.run(["--list"], { timeoutMs: 60_000 }, options);
+  }
+
+  async acceptLicenses(options: SdkManagerExecutionOptions = {}): Promise<SdkManagerCommandResult> {
+    return this.run(["--licenses"], { input: "y\n".repeat(20), timeoutMs: 60_000 }, options);
+  }
+
+  async installPackage(packageName: string, options: SdkManagerExecutionOptions & { acceptLicenses?: boolean } = {}): Promise<SdkManagerCommandResult> {
+    return this.run([packageName], {
+      input: options.acceptLicenses ? "y\n".repeat(10) : undefined,
+      timeoutMs: 600_000,
+    }, options);
+  }
+
+  private async run(
+    args: string[],
+    defaultsForCommand: { input?: string; timeoutMs: number },
+    options: SdkManagerExecutionOptions,
+  ): Promise<SdkManagerCommandResult> {
+    const { path, env } = await this.resolve();
+    return this.execute(path, args, { ...defaultsForCommand, env }, options);
+  }
+
+  private async resolve(): Promise<{ path: string; env: NodeJS.ProcessEnv }> {
+    const locations = await this.dependencies.detectAndroidCommandLineTools();
+    const location = this.dependencies.getBestAndroidToolsLocation(locations);
+    if (!location) {
+      throw new Error("Android command line tools not found. Tool installation functionality has been removed. Please install Android SDK Command-line Tools and set ANDROID_HOME or ANDROID_SDK_ROOT to the SDK root.");
+    }
+    const validation = this.dependencies.validateRequiredTools(location, ["sdkmanager"]);
+    if (!validation.valid) {
+      throw new Error(`Missing required tools: ${validation.missing.join(", ")}. Tool installation functionality has been removed. Install Android SDK Command-line Tools under ANDROID_HOME/cmdline-tools/latest.`);
+    }
+    const path = this.resolveExecutable(location);
+    const sdkRoot = this.resolveSdkRoot(location);
+    if (!sdkRoot) {
+      throw new Error(`Unable to resolve the Android SDK root for sdkmanager at ${path}. Set ANDROID_HOME or ANDROID_SDK_ROOT to the SDK root containing platforms or system-images.`);
+    }
+    this.warnHomebrewMismatch(location, sdkRoot);
+    return { path, env: { ...this.dependencies.environment, ANDROID_HOME: sdkRoot, ANDROID_SDK_ROOT: sdkRoot } };
+  }
+
+  private resolveExecutable(location: AndroidToolsLocation): string {
+    const executable = join(location.path, "bin", "sdkmanager");
+    if (this.dependencies.existsSync(executable)) {return executable;}
+    const batch = join(location.path, "bin", "sdkmanager.bat");
+    if (this.dependencies.existsSync(batch)) {return batch;}
+    throw new Error(`SDK manager not found at ${location.path}. Install Android SDK Command-line Tools under ANDROID_HOME/cmdline-tools/latest.`);
+  }
+
+  private resolveSdkRoot(location: AndroidToolsLocation): string | undefined {
+    const environment = this.dependencies.environment;
+    const candidates = [
+      environment.ANDROID_SDK_ROOT,
+      environment.ANDROID_HOME,
+      environment.ANDROID_SDK_HOME,
+      this.stripCmdlineToolsPath(location.path),
+      location.path,
+      resolve(location.path, ".."),
+      resolve(location.path, "..", ".."),
+      ...this.typicalSdkPaths(),
+    ].filter(Boolean) as string[];
+    return candidates.find(candidate => this.dependencies.existsSync(join(candidate, "system-images"))) ??
+      candidates.find(candidate => this.looksLikeSdkRoot(candidate));
+  }
+
+  private stripCmdlineToolsPath(path: string): string | undefined {
+    const normalized = normalizePath(path);
+    return normalized.endsWith("/cmdline-tools/latest")
+      ? normalized.replace(/\/cmdline-tools\/latest$/, "")
+      : undefined;
+  }
+
+  private typicalSdkPaths(): string[] {
+    const home = this.dependencies.environment.HOME ?? this.dependencies.environment.USERPROFILE;
+    if (this.dependencies.platform === "darwin") {return [...(home ? [join(home, "Library/Android/sdk")] : []), "/opt/android-sdk", "/usr/local/android-sdk"];}
+    if (this.dependencies.platform === "linux") {return [...(home ? [join(home, "Android/Sdk")] : []), "/opt/android-sdk", "/usr/local/android-sdk"];}
+    if (this.dependencies.platform === "win32") {return [...(home ? [join(home, "AppData/Local/Android/Sdk")] : []), "C:/Android/Sdk", "C:/android-sdk"];}
+    return [];
+  }
+
+  private looksLikeSdkRoot(path: string): boolean {
+    return this.dependencies.existsSync(path) && SDK_ROOT_MARKERS.filter(marker => this.dependencies.existsSync(join(path, marker))).length >= 2;
+  }
+
+  private warnHomebrewMismatch(location: AndroidToolsLocation, sdkRoot: string): void {
+    if (!isHomebrewToolsPath(location.path) || SdkManagerClient.homebrewWarningLoggers.has(this.dependencies.logger)) {return;}
+    const info = this.dependencies.getAndroidHomeWithSystemImages();
+    if (!info || normalizePath(getCmdlineToolsRoot(location.path)) === normalizePath(info.androidHome)) {return;}
+    this.dependencies.logger.warn(`Warning: Homebrew Android cmdline-tools detected, but system images are in ANDROID_HOME. sdkmanager location: ${location.path} ANDROID_HOME: ${info.androidHome} Effective SDK root: ${sdkRoot}. Fix: ensure cmdline-tools are present under ANDROID_HOME.`);
+    SdkManagerClient.homebrewWarningLoggers.add(this.dependencies.logger);
+  }
+
+  private execute(
+    path: string,
+    args: string[],
+    inputOptions: { input?: string; env: NodeJS.ProcessEnv; timeoutMs: number },
+    options: SdkManagerExecutionOptions,
+  ): Promise<SdkManagerCommandResult> {
+    return new Promise((resolvePromise, reject) => {
+      if (options.signal?.aborted) {reject(new Error("sdkmanager command cancelled")); return;}
+      const invocation = this.windowsBatchInvocation(path, args, inputOptions.env);
+      const child = this.dependencies.spawn(invocation.command, invocation.args, {
+        env: inputOptions.env,
+        stdio: ["pipe", "pipe", "pipe"],
+        shell: false,
+      });
+      const maxOutputChars = options.maxOutputChars ?? DEFAULT_MAX_OUTPUT_CHARS;
+      const timeoutMs = options.timeoutMs ?? inputOptions.timeoutMs;
+      const terminationGraceMs = options.terminationGraceMs ?? DEFAULT_TERMINATION_GRACE_MS;
+      let stdout = "";
+      let stderr = "";
+      let outputTruncated = false;
+      let settled = false;
+      let terminationError: Error | undefined;
+      let terminationTimeout: NodeJS.Timeout | undefined;
+      const settle = (callback: () => void) => {
+        if (settled) {return;}
+        settled = true;
+        this.dependencies.timer.clearTimeout(timeout);
+        if (terminationTimeout) {this.dependencies.timer.clearTimeout(terminationTimeout);}
+        options.signal?.removeEventListener("abort", onAbort);
+        callback();
+      };
+      const terminate = (error: Error) => {
+        if (terminationError) {return;}
+        terminationError = error;
+        child.kill("SIGTERM");
+        terminationTimeout = this.dependencies.timer.setTimeout(() => settle(() => {
+          child.kill("SIGKILL");
+          reject(error);
+        }), terminationGraceMs);
+      };
+      const onAbort = () => terminate(new Error("sdkmanager command cancelled"));
+      options.signal?.addEventListener("abort", onAbort, { once: true });
+      const timeout = this.dependencies.timer.setTimeout(() => {
+        terminate(new Error(`sdkmanager command timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      this.dependencies.logger.info(`Executing: ${path} ${args.join(" ")}`);
+      child.stdout?.on("data", data => {
+        const appended = appendBounded(stdout, data.toString(), maxOutputChars);
+        stdout = appended.value;
+        outputTruncated ||= appended.truncated;
+      });
+      child.stderr?.on("data", data => {
+        const appended = appendBounded(stderr, data.toString(), maxOutputChars);
+        stderr = appended.value;
+        outputTruncated ||= appended.truncated;
+      });
+      child.on("close", code => settle(() => {
+        if (terminationError) {reject(terminationError); return;}
+        resolvePromise({ stdout: redact(stdout), stderr: redact(stderr), exitCode: code, outputTruncated });
+      }));
+      child.on("error", error => settle(() => reject(new Error(`Failed to spawn command: sdkmanager: ${error.message}`))));
+      if (inputOptions.input) {child.stdin?.write(inputOptions.input); child.stdin?.end();}
+    });
+  }
+
+  private windowsBatchInvocation(path: string, args: string[], environment: NodeJS.ProcessEnv): { command: string; args: string[] } {
+    if (this.dependencies.platform !== "win32" || !path.toLowerCase().endsWith(".bat")) {return { command: path, args };}
+    const command = `"${[quoteForWindowsCmd(path), ...args.map(quoteForWindowsCmd)].join(" ")}"`;
+    return { command: environment.ComSpec ?? environment.COMSPEC ?? "cmd.exe", args: ["/d", "/v:off", "/s", "/c", command] };
+  }
+}

--- a/src/utils/android-cmdline-tools/SdkManagerClient.ts
+++ b/src/utils/android-cmdline-tools/SdkManagerClient.ts
@@ -15,7 +15,7 @@ import {
 
 const SDK_ROOT_MARKERS = ["system-images", "platforms", "platform-tools", "build-tools"];
 const DEFAULT_MAX_OUTPUT_CHARS = 16_384;
-const UNBOUNDED_OUTPUT_CHARS = Number.MAX_SAFE_INTEGER;
+const UNBOUNDED_STDOUT_CHARS = Number.MAX_SAFE_INTEGER;
 const DEFAULT_TERMINATION_GRACE_MS = 5_000;
 
 export interface SdkManagerExecutionOptions {
@@ -91,10 +91,10 @@ export class SdkManagerClient {
   constructor(private readonly dependencies: SdkManagerClientDependencies = defaults()) {}
 
   async list(options: SdkManagerExecutionOptions = {}): Promise<SdkManagerCommandResult> {
-    return this.run(["--list"], { timeoutMs: 60_000 }, {
-      ...options,
-      maxOutputChars: options.maxOutputChars ?? UNBOUNDED_OUTPUT_CHARS,
-    });
+    return this.run(["--list"], {
+      timeoutMs: 60_000,
+      maxStdoutChars: UNBOUNDED_STDOUT_CHARS,
+    }, options);
   }
 
   async acceptLicenses(options: SdkManagerExecutionOptions = {}): Promise<SdkManagerCommandResult> {
@@ -110,7 +110,7 @@ export class SdkManagerClient {
 
   private async run(
     args: string[],
-    defaultsForCommand: { input?: string; timeoutMs: number },
+    defaultsForCommand: { input?: string; timeoutMs: number; maxStdoutChars?: number },
     options: SdkManagerExecutionOptions,
   ): Promise<SdkManagerCommandResult> {
     const { path, env } = await this.resolve();
@@ -190,9 +190,13 @@ export class SdkManagerClient {
   private execute(
     path: string,
     args: string[],
-    inputOptions: { input?: string; env: NodeJS.ProcessEnv; timeoutMs: number },
+    inputOptions: { input?: string; env: NodeJS.ProcessEnv; timeoutMs: number; maxStdoutChars?: number },
     options: SdkManagerExecutionOptions,
   ): Promise<SdkManagerCommandResult> {
+    const maxStdoutChars = options.maxOutputChars ?? inputOptions.maxStdoutChars ?? DEFAULT_MAX_OUTPUT_CHARS;
+    const maxStderrChars = options.maxOutputChars ?? DEFAULT_MAX_OUTPUT_CHARS;
+    const timeoutMs = options.timeoutMs ?? inputOptions.timeoutMs;
+    const terminationGraceMs = options.terminationGraceMs ?? DEFAULT_TERMINATION_GRACE_MS;
     return new Promise((resolvePromise, reject) => {
       if (options.signal?.aborted) {reject(new Error("sdkmanager command cancelled")); return;}
       const invocation = this.windowsBatchInvocation(path, args, inputOptions.env);
@@ -201,9 +205,6 @@ export class SdkManagerClient {
         stdio: ["pipe", "pipe", "pipe"],
         shell: false,
       });
-      const maxOutputChars = options.maxOutputChars ?? DEFAULT_MAX_OUTPUT_CHARS;
-      const timeoutMs = options.timeoutMs ?? inputOptions.timeoutMs;
-      const terminationGraceMs = options.terminationGraceMs ?? DEFAULT_TERMINATION_GRACE_MS;
       let stdout = "";
       let stderr = "";
       let outputTruncated = false;
@@ -235,12 +236,12 @@ export class SdkManagerClient {
 
       this.dependencies.logger.info(`Executing: ${path} ${args.join(" ")}`);
       child.stdout?.on("data", data => {
-        const appended = appendBounded(stdout, data.toString(), maxOutputChars);
+        const appended = appendBounded(stdout, data.toString(), maxStdoutChars);
         stdout = appended.value;
         outputTruncated ||= appended.truncated;
       });
       child.stderr?.on("data", data => {
-        const appended = appendBounded(stderr, data.toString(), maxOutputChars);
+        const appended = appendBounded(stderr, data.toString(), maxStderrChars);
         stderr = appended.value;
         outputTruncated ||= appended.truncated;
       });

--- a/src/utils/android-cmdline-tools/avdmanager.ts
+++ b/src/utils/android-cmdline-tools/avdmanager.ts
@@ -1,31 +1,26 @@
-import { spawn } from "child_process";
-import { existsSync } from "fs";
-import { join, resolve } from "path";
-import { logger } from "../logger";
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
 import { defaultTimer } from "../SystemTimer";
+import { logger } from "../logger";
 import {
   detectAndroidCommandLineTools,
   getAndroidHomeWithSystemImages,
   getBestAndroidToolsLocation,
-  getCmdlineToolsRoot,
-  isHomebrewToolsPath,
   validateRequiredTools,
-  type AndroidToolsLocation
 } from "./detection";
 import { AvdManagerClient } from "./AvdManagerClient";
+import {
+  SdkManagerClient,
+  type SdkManagerCommandResult,
+  type SdkManagerClientDependencies,
+} from "./SdkManagerClient";
 
-// Dependencies interface for dependency injection
-export interface AvdManagerDependencies {
-  spawn: typeof spawn;
-  existsSync: typeof existsSync;
-  logger: typeof logger;
-  detectAndroidCommandLineTools: typeof detectAndroidCommandLineTools;
-  getAndroidHomeWithSystemImages: typeof getAndroidHomeWithSystemImages;
-  getBestAndroidToolsLocation: typeof getBestAndroidToolsLocation;
-  validateRequiredTools: typeof validateRequiredTools;
-}
+/** Dependencies shared by the functional AVD facade and its two typed clients. */
+export type AvdManagerDependencies = Omit<
+  SdkManagerClientDependencies,
+  "timer" | "environment" | "platform"
+>;
 
-// Create default dependencies
 const createDefaultDependencies = (): AvdManagerDependencies => ({
   spawn,
   existsSync,
@@ -36,316 +31,31 @@ const createDefaultDependencies = (): AvdManagerDependencies => ({
   validateRequiredTools,
 });
 
-const SDK_ROOT_MARKERS = ["system-images", "platforms", "platform-tools", "build-tools"];
-let hasWarnedHomebrewSystemImagesMismatch = false;
-
-function normalizePath(value: string): string {
-  return value.replace(/\\/g, "/");
-}
-
-function maybeWarnHomebrewSystemImagesMismatch(
-  location: AndroidToolsLocation,
-  dependencies: AvdManagerDependencies
-): void {
-  if (hasWarnedHomebrewSystemImagesMismatch) {
-    return;
-  }
-
-  if (!isHomebrewToolsPath(location.path)) {
-    return;
-  }
-
-  const androidHomeInfo = dependencies.getAndroidHomeWithSystemImages();
-  if (!androidHomeInfo) {
-    return;
-  }
-
-  const toolsRoot = getCmdlineToolsRoot(location.path);
-  if (normalizePath(toolsRoot) === normalizePath(androidHomeInfo.androidHome)) {
-    return;
-  }
-
-  const warningMessage = [
-    "Warning: Homebrew Android cmdline-tools detected, but system images are in ANDROID_HOME.",
-    "avdmanager may report missing system images because Homebrew sets com.android.sdkmanager.toolsdir to its own root.",
-    `avdmanager location: ${location.path}`,
-    `ANDROID_HOME: ${androidHomeInfo.androidHome}`,
-    `System images: ${androidHomeInfo.systemImagesPath}`,
-    "Fix: ensure cmdline-tools are present under ANDROID_HOME."
-  ].join(" ");
-
-  dependencies.logger.warn(warningMessage);
-  hasWarnedHomebrewSystemImagesMismatch = true;
-}
-
-function looksLikeAndroidSdkRoot(sdkRoot: string, dependencies: AvdManagerDependencies): boolean {
-  if (!dependencies.existsSync(sdkRoot)) {
-    return false;
-  }
-
-  // For avdmanager operations, system-images is required
-  // Check if system-images exists, OR if at least 2 other markers exist (for backward compatibility)
-  const hasSystemImages = dependencies.existsSync(join(sdkRoot, "system-images"));
-  if (hasSystemImages) {
-    return true;
-  }
-
-  // Fall back to checking if at least 2 markers exist (for SDK roots without system-images yet)
-  const markerCount = SDK_ROOT_MARKERS.filter(marker =>
-    dependencies.existsSync(join(sdkRoot, marker))
-  ).length;
-
-  return markerCount >= 2;
-}
-
-function stripCmdlineToolsPath(pathValue: string): string | undefined {
-  const normalized = pathValue.replace(/\\/g, "/");
-  if (normalized.endsWith("/cmdline-tools/latest")) {
-    return normalized.replace(/\/cmdline-tools\/latest$/, "");
-  }
-  if (normalized.endsWith("/cmdline-tools")) {
-    return normalized.replace(/\/cmdline-tools$/, "");
-  }
-  return undefined;
-}
-
-function getTypicalSdkPaths(): string[] {
-  const homeDir = process.env.HOME || process.env.USERPROFILE;
-
-  switch (process.platform) {
-    case "darwin":
-      return [
-        ...(homeDir ? [join(homeDir, "Library/Android/sdk")] : []),
-        "/opt/android-sdk",
-        "/usr/local/android-sdk"
-      ];
-    case "linux":
-      return [
-        ...(homeDir ? [join(homeDir, "Android/Sdk")] : []),
-        "/opt/android-sdk",
-        "/usr/local/android-sdk"
-      ];
-    case "win32":
-      return [
-        ...(homeDir ? [join(homeDir, "AppData/Local/Android/Sdk")] : []),
-        "C:/Android/Sdk",
-        "C:/android-sdk"
-      ];
-    default:
-      return [];
-  }
-}
-
-function resolveAndroidSdkRoot(
-  location: AndroidToolsLocation,
-  dependencies: AvdManagerDependencies
-): string | undefined {
-  const candidates = new Set<string>();
-
-  const envCandidates = [
-    process.env.ANDROID_SDK_ROOT,
-    process.env.ANDROID_HOME,
-    process.env.ANDROID_SDK_HOME
-  ].filter(Boolean) as string[];
-
-  for (const candidate of envCandidates) {
-    candidates.add(candidate);
-  }
-
-  const strippedPath = stripCmdlineToolsPath(location.path);
-  if (strippedPath) {
-    candidates.add(strippedPath);
-  }
-
-  candidates.add(location.path);
-  candidates.add(resolve(location.path, ".."));
-  candidates.add(resolve(location.path, "..", ".."));
-
-  for (const typicalPath of getTypicalSdkPaths()) {
-    candidates.add(typicalPath);
-  }
-
-  // Two-pass search: First pass prioritizes SDK roots with system-images
-  // This ensures we pick a complete SDK (with system-images) over an incomplete one
-  // (e.g., Homebrew with only platforms/platform-tools/build-tools)
-
-  // Pass 1: Only accept candidates with system-images
-  for (const candidate of candidates) {
-    if (!dependencies.existsSync(candidate)) {
-      continue;
-    }
-    const hasSystemImages = dependencies.existsSync(join(candidate, "system-images"));
-    if (hasSystemImages) {
-      return candidate;
-    }
-  }
-
-  // Pass 2: Fall back to candidates with 2+ markers (backward compatibility)
-  for (const candidate of candidates) {
-    if (looksLikeAndroidSdkRoot(candidate, dependencies)) {
-      return candidate;
-    }
-  }
-
-  return undefined;
-}
-
-function getAndroidSdkEnv(
-  location: AndroidToolsLocation,
-  dependencies: AvdManagerDependencies
-): NodeJS.ProcessEnv | undefined {
-  const sdkRoot = resolveAndroidSdkRoot(location, dependencies);
-  if (!sdkRoot) {
-    return undefined;
-  }
-
-  return {
-    ...process.env,
-    ANDROID_HOME: sdkRoot,
-    ANDROID_SDK_ROOT: sdkRoot
-  };
-}
-
-/**
- * Execute a command using spawn with proper error handling and logging
- */
-async function spawnCommand(command: string, args: string[], options: {
-  cwd?: string;
-  input?: string;
-  timeout?: number;
-  env?: NodeJS.ProcessEnv;
-} = {}, dependencies = createDefaultDependencies()): Promise<{
-  stdout: string;
-  stderr: string;
-  exitCode: number;
-}> {
-  return new Promise((resolve, reject) => {
-    dependencies.logger.info(`Executing: ${command} ${args.join(" ")}`);
-
-    const child = dependencies.spawn(command, args, {
-      cwd: options.cwd,
-      env: options.env,
-      stdio: ["pipe", "pipe", "pipe"]
-    });
-
-    let stdout = "";
-    let stderr = "";
-    let timeoutId: NodeJS.Timeout | undefined;
-
-    // Set up timeout if specified
-    if (options.timeout) {
-      timeoutId = defaultTimer.setTimeout(() => {
-        child.kill("SIGTERM");
-        reject(new Error(`Command timed out after ${options.timeout}ms: ${command} ${args.join(" ")}`));
-      }, options.timeout);
-    }
-
-    child.stdout?.on("data", data => {
-      const output = data.toString();
-      stdout += output;
-      if (output.trim()) {
-        dependencies.logger.info(`[${command}] ${output.trim()}`);
-      }
-    });
-
-    child.stderr?.on("data", data => {
-      const output = data.toString();
-      stderr += output;
-      if (output.trim()) {
-        dependencies.logger.warn(`[${command}] ${output.trim()}`);
-      }
-    });
-
-    child.on("close", code => {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
-      resolve({ stdout, stderr, exitCode: code || 0 });
-    });
-
-    child.on("error", error => {
-      if (timeoutId) {
-        clearTimeout(timeoutId);
-      }
-      reject(new Error(`Failed to spawn command: ${command} ${args.join(" ")}\nError: ${error.message}`));
-    });
-
-    // Send input if provided (for license acceptance)
-    if (options.input) {
-      child.stdin?.write(options.input);
-      child.stdin?.end();
-    }
+function createSdkManagerClient(dependencies: AvdManagerDependencies): SdkManagerClient {
+  return new SdkManagerClient({
+    ...dependencies,
+    timer: defaultTimer,
+    environment: process.env,
+    platform: process.platform,
   });
 }
 
-/**
- * Ensure required Android tools are available, installing if necessary
- */
-async function ensureToolsAvailable(dependencies = createDefaultDependencies()): Promise<AndroidToolsLocation> {
-  const locations = await dependencies.detectAndroidCommandLineTools();
-  const bestLocation = dependencies.getBestAndroidToolsLocation(locations);
-
-  if (!bestLocation) {
-    dependencies.logger.error("Android command line tools not found and tool installation has been removed");
-    throw new Error("Android command line tools not found. Tool installation functionality has been removed. Please install Android SDK manually from https://developer.android.com/studio or using Homebrew: brew install --cask android-commandlinetools");
-  }
-
-  // Validate that required tools are available
-  const validation = dependencies.validateRequiredTools(bestLocation, ["avdmanager", "sdkmanager"]);
-  if (!validation.valid) {
-    dependencies.logger.error(`Missing required tools: ${validation.missing.join(", ")} and tool installation has been removed`);
-    throw new Error(`Missing required tools: ${validation.missing.join(", ")}. Tool installation functionality has been removed. Please install Android SDK manually.`);
-  }
-
-  maybeWarnHomebrewSystemImagesMismatch(bestLocation, dependencies);
-
-  return bestLocation;
+function failureDiagnostics(result: SdkManagerCommandResult): string {
+  const output = result.stderr || result.stdout || "Unknown sdkmanager failure";
+  return result.outputTruncated ? `${output}\n[output truncated]` : output;
 }
 
-/**
- * Get the sdkmanager executable path
- */
-function getSdkManagerPath(location: AndroidToolsLocation, dependencies = createDefaultDependencies()): string {
-  const sdkmanagerPath = join(location.path, "bin", "sdkmanager");
-  const sdkmanagerBatPath = join(location.path, "bin", "sdkmanager.bat");
-
-  if (dependencies.existsSync(sdkmanagerPath)) {
-    return sdkmanagerPath;
-  } else if (dependencies.existsSync(sdkmanagerBatPath)) {
-    return sdkmanagerBatPath;
-  }
-
-  throw new Error(`SDK manager not found at ${location.path}`);
-}
-
-/**
- * Accept Android SDK licenses
- */
+/** Accept Android SDK licenses through the dedicated sdkmanager boundary. */
 export async function acceptLicenses(dependencies = createDefaultDependencies()): Promise<{
   success: boolean;
-  message: string
+  message: string;
 }> {
   try {
-    const location = await ensureToolsAvailable(dependencies);
-    const sdkmanagerPath = getSdkManagerPath(location, dependencies);
-    const env = getAndroidSdkEnv(location, dependencies);
-
-    dependencies.logger.info("Accepting Android SDK licenses...");
-
-    // Provide "y" responses to all license prompts
-    const licenseInput = "y\n".repeat(20);
-    const result = await spawnCommand(sdkmanagerPath, ["--licenses"], {
-      input: licenseInput,
-      timeout: 60000, // 60 second timeout
-      env
-    }, dependencies);
-
+    const result = await createSdkManagerClient(dependencies).acceptLicenses();
     if (result.exitCode === 0) {
-      dependencies.logger.info("Successfully accepted Android SDK licenses");
       return { success: true, message: "Android SDK licenses accepted" };
-    } else {
-      return { success: false, message: `License acceptance failed: ${result.stderr}` };
     }
+    return { success: false, message: `License acceptance failed: ${failureDiagnostics(result)}` };
   } catch (error) {
     const message = `Failed to accept licenses: ${(error as Error).message}`;
     dependencies.logger.error(message);
@@ -353,85 +63,42 @@ export async function acceptLicenses(dependencies = createDefaultDependencies())
   }
 }
 
-/**
- * List available system images
- */
-export async function listSystemImages(filter?: SystemImageFilter, dependencies = createDefaultDependencies()): Promise<SystemImage[]> {
-  try {
-    const location = await ensureToolsAvailable(dependencies);
-    const sdkmanagerPath = getSdkManagerPath(location, dependencies);
-    const env = getAndroidSdkEnv(location, dependencies);
-
-    const result = await spawnCommand(sdkmanagerPath, ["--list"], { env }, dependencies);
-
-    if (result.exitCode !== 0) {
-      throw new Error(`Failed to list system images: ${result.stderr}`);
-    }
-
-    return parseSystemImages(result.stdout, filter);
-  } catch (error) {
-    dependencies.logger.error(`Failed to list system images: ${(error as Error).message}`);
-    throw error;
+/** List downloadable system images through the dedicated sdkmanager boundary. */
+export async function listSystemImages(
+  filter?: SystemImageFilter,
+  dependencies = createDefaultDependencies(),
+): Promise<SystemImage[]> {
+  const result = await createSdkManagerClient(dependencies).list();
+  if (result.exitCode !== 0) {
+    throw new Error(`Failed to list system images: ${failureDiagnostics(result)}`);
   }
+  return parseSystemImages(result.stdout, filter);
 }
 
-/**
- * List system images that are already **installed** in the SDK.
- *
- * {@link listSystemImages} deliberately reports the downloadable "Available
- * Packages" catalogue. AVD creation needs the installed set instead: passing
- * `avdmanager create avd -k` a package that is not on disk fails.
- */
+/** List installed system images through the dedicated sdkmanager boundary. */
 export async function listInstalledSystemImages(
   filter?: SystemImageFilter,
-  dependencies = createDefaultDependencies()
+  dependencies = createDefaultDependencies(),
 ): Promise<SystemImage[]> {
-  try {
-    const location = await ensureToolsAvailable(dependencies);
-    const sdkmanagerPath = getSdkManagerPath(location, dependencies);
-    const env = getAndroidSdkEnv(location, dependencies);
-
-    const result = await spawnCommand(sdkmanagerPath, ["--list"], { env }, dependencies);
-
-    if (result.exitCode !== 0) {
-      throw new Error(`Failed to list installed system images: ${result.stderr}`);
-    }
-
-    return parseSystemImages(result.stdout, filter, "installed");
-  } catch (error) {
-    dependencies.logger.error(`Failed to list installed system images: ${(error as Error).message}`);
-    throw error;
+  const result = await createSdkManagerClient(dependencies).list();
+  if (result.exitCode !== 0) {
+    throw new Error(`Failed to list installed system images: ${failureDiagnostics(result)}`);
   }
+  return parseSystemImages(result.stdout, filter, "installed");
 }
 
-/**
- * Download and install a system image
- */
-export async function installSystemImage(packageName: string, acceptLicense = true, dependencies = createDefaultDependencies()): Promise<{
-  success: boolean;
-  message: string;
-}> {
+/** Download and install a system image through the dedicated sdkmanager boundary. */
+export async function installSystemImage(
+  packageName: string,
+  acceptLicense = true,
+  dependencies = createDefaultDependencies(),
+): Promise<{ success: boolean; message: string }> {
   try {
-    const location = await ensureToolsAvailable(dependencies);
-    const sdkmanagerPath = getSdkManagerPath(location, dependencies);
-    const env = getAndroidSdkEnv(location, dependencies);
-
-    dependencies.logger.info(`Installing system image: ${packageName}`);
-
-    // Accept license and install
-    const input = acceptLicense ? "y\n".repeat(10) : undefined;
-    const result = await spawnCommand(sdkmanagerPath, [packageName], {
-      input,
-      timeout: 600000, // 10 minute timeout for downloads
-      env
-    }, dependencies);
-
+    const result = await createSdkManagerClient(dependencies).installPackage(packageName, { acceptLicenses: acceptLicense });
     if (result.exitCode === 0) {
-      dependencies.logger.info(`Successfully installed system image: ${packageName}`);
       return { success: true, message: `System image ${packageName} installed successfully` };
-    } else {
-      return { success: false, message: `Installation failed: ${result.stderr}` };
     }
+    return { success: false, message: `Installation failed: ${failureDiagnostics(result)}` };
   } catch (error) {
     const message = `Failed to install system image ${packageName}: ${(error as Error).message}`;
     dependencies.logger.error(message);
@@ -439,49 +106,30 @@ export async function installSystemImage(packageName: string, acceptLicense = tr
   }
 }
 
-/**
- * List available AVDs
- */
+/** List AVDs through the dedicated avdmanager boundary. */
 export async function listDeviceImages(dependencies = createDefaultDependencies()): Promise<AvdInfo[]> {
-  try {
-    return await createAvdManagerClient(dependencies).listDeviceImages();
-  } catch (error) {
-    dependencies.logger.error(`Failed to list AVDs: ${(error as Error).message}`);
-    throw error;
-  }
+  return createAvdManagerClient(dependencies).listDeviceImages();
 }
 
-/**
- * Create a new AVD
- */
-export async function createAvd(params: CreateAvdParams, dependencies = createDefaultDependencies()): Promise<{
-  success: boolean;
-  message: string;
-  avdName?: string;
-}> {
+/** Create an AVD through the dedicated avdmanager boundary. */
+export async function createAvd(
+  params: CreateAvdParams,
+  dependencies = createDefaultDependencies(),
+): Promise<{ success: boolean; message: string; avdName?: string }> {
   return createAvdManagerClient(dependencies).createAvd(params);
 }
 
-/**
- * Delete an AVD
- */
-export async function deleteAvd(name: string, dependencies = createDefaultDependencies()): Promise<{
-  success: boolean;
-  message: string;
-}> {
+/** Delete an AVD through the dedicated avdmanager boundary. */
+export async function deleteAvd(
+  name: string,
+  dependencies = createDefaultDependencies(),
+): Promise<{ success: boolean; message: string }> {
   return createAvdManagerClient(dependencies).deleteAvd(name);
 }
 
-/**
- * List available device profiles
- */
+/** List device profiles through the dedicated avdmanager boundary. */
 export async function listDevices(dependencies = createDefaultDependencies()): Promise<DeviceProfile[]> {
-  try {
-    return await createAvdManagerClient(dependencies).listDevices();
-  } catch (error) {
-    dependencies.logger.error(`Failed to list devices: ${(error as Error).message}`);
-    throw error;
-  }
+  return createAvdManagerClient(dependencies).listDevices();
 }
 
 function createAvdManagerClient(dependencies: AvdManagerDependencies): AvdManagerClient {
@@ -493,156 +141,75 @@ function createAvdManagerClient(dependencies: AvdManagerDependencies): AvdManage
   });
 }
 
-/**
- * Parse system images from sdkmanager output
- */
+/** Parse one section of sdkmanager --list output into typed system-image data. */
 export function parseSystemImages(
   output: string,
   filter?: SystemImageFilter,
-  section: SdkManagerSection = "available"
+  section: SdkManagerSection = "available",
 ): SystemImage[] {
-  const lines = output.split("\n");
   const images: SystemImage[] = [];
   let currentSection: SdkManagerSection | null = null;
-
-  for (const line of lines) {
+  for (const line of output.split("\n")) {
     const trimmedLine = line.trim();
-
-    if (trimmedLine.includes("Available Packages:")) {
-      currentSection = "available";
-      continue;
-    }
-
-    if (trimmedLine.includes("Installed packages:")) {
-      currentSection = "installed";
-      continue;
-    }
-
-    if (trimmedLine.includes("Available Updates:")) {
-      currentSection = null;
-      continue;
-    }
-
-    if (currentSection === section && trimmedLine.startsWith("system-images;")) {
-      // The "Installed packages" table is pipe-delimited, the "Available Packages"
-      // listing is whitespace-delimited; split on either so both shapes parse.
-      const parts = trimmedLine.split(/\s+/);
-      const packageName = parts[0].split("|")[0];
-      const versionInfo = parts.slice(1).join(" ");
-
-      // Parse package name: system-images;android-XX;tag;abi
-      const packageParts = packageName.split(";");
-      if (packageParts.length >= 4) {
-        const apiLevel = parseInt(packageParts[1].replace("android-", ""), 10);
-        const tag = packageParts[2];
-        const abi = packageParts[3];
-
-        const image: SystemImage = {
-          packageName,
-          apiLevel,
-          tag,
-          abi,
-          versionInfo: versionInfo || ""
-        };
-
-        // Apply filter if provided
-        if (!filter || matchesFilter(image, filter)) {
-          images.push(image);
-        }
-      }
-    }
+    if (trimmedLine.includes("Available Packages:")) {currentSection = "available"; continue;}
+    if (trimmedLine.includes("Installed packages:")) {currentSection = "installed"; continue;}
+    if (trimmedLine.includes("Available Updates:")) {currentSection = null; continue;}
+    if (currentSection !== section || !trimmedLine.startsWith("system-images;")) {continue;}
+    const parts = trimmedLine.split(/\s+/);
+    const packageName = parts[0].split("|")[0];
+    const packageParts = packageName.split(";");
+    if (packageParts.length < 4) {continue;}
+    const image: SystemImage = {
+      packageName,
+      apiLevel: Number.parseInt(packageParts[1].replace("android-", ""), 10),
+      tag: packageParts[2],
+      abi: packageParts[3],
+      versionInfo: parts.slice(1).join(" "),
+    };
+    if (!filter || matchesFilter(image, filter)) {images.push(image);}
   }
-
   return images;
 }
 
-/**
- * Check if system image matches filter criteria
- */
 function matchesFilter(image: SystemImage, filter: SystemImageFilter): boolean {
-  if (filter.apiLevel && image.apiLevel !== filter.apiLevel) {
-    return false;
-  }
-  if (filter.tag && image.tag !== filter.tag) {
-    return false;
-  }
-  if (filter.abi && image.abi !== filter.abi) {
-    return false;
-  }
-  return true;
+  return (!filter.apiLevel || image.apiLevel === filter.apiLevel) &&
+    (!filter.tag || image.tag === filter.tag) &&
+    (!filter.abi || image.abi === filter.abi);
 }
 
-// Type definitions
-
-export interface SystemImageFilter {
-  apiLevel?: number;
-  tag?: string;
-  abi?: string;
-}
-
-/** Which `sdkmanager --list` section a parse should read from. */
+export interface SystemImageFilter { apiLevel?: number; tag?: string; abi?: string; }
 export type SdkManagerSection = "available" | "installed";
+export interface SystemImage { packageName: string; apiLevel: number; tag: string; abi: string; versionInfo: string; }
+export interface CreateAvdParams { name: string; package: string; device?: string; force?: boolean; path?: string; tag?: string; abi?: string; }
+export interface AvdInfo { name: string; path?: string; target?: string; basedOn?: string; error?: string; }
+export interface DeviceProfile { id: string; name?: string; oem?: string; }
 
-export interface SystemImage {
-  packageName: string;
-  apiLevel: number;
-  tag: string;
-  abi: string;
-  versionInfo: string;
-}
-
-export interface CreateAvdParams {
-  name: string;
-  package: string;
-  device?: string;
-  force?: boolean;
-  path?: string;
-  tag?: string;
-  abi?: string;
-}
-
-export interface AvdInfo {
-  name: string;
-  path?: string;
-  target?: string;
-  basedOn?: string;
-  error?: string;
-}
-
-export interface DeviceProfile {
-  id: string;
-  name?: string;
-  oem?: string;
-}
-
-// Common system image packages for convenience
 export const COMMON_SYSTEM_IMAGES = {
   API_35: {
     GOOGLE_APIS_ARM64: "system-images;android-35;google_apis;arm64-v8a",
     GOOGLE_APIS_X86_64: "system-images;android-35;google_apis;x86_64",
     PLAYSTORE_ARM64: "system-images;android-35;google_apis_playstore;arm64-v8a",
-    PLAYSTORE_X86_64: "system-images;android-35;google_apis_playstore;x86_64"
+    PLAYSTORE_X86_64: "system-images;android-35;google_apis_playstore;x86_64",
   },
   API_34: {
     GOOGLE_APIS_ARM64: "system-images;android-34;google_apis;arm64-v8a",
     GOOGLE_APIS_X86_64: "system-images;android-34;google_apis;x86_64",
     PLAYSTORE_ARM64: "system-images;android-34;google_apis_playstore;arm64-v8a",
-    PLAYSTORE_X86_64: "system-images;android-34;google_apis_playstore;x86_64"
+    PLAYSTORE_X86_64: "system-images;android-34;google_apis_playstore;x86_64",
   },
   API_33: {
     GOOGLE_APIS_ARM64: "system-images;android-33;google_apis;arm64-v8a",
     GOOGLE_APIS_X86_64: "system-images;android-33;google_apis;x86_64",
     PLAYSTORE_ARM64: "system-images;android-33;google_apis_playstore;arm64-v8a",
-    PLAYSTORE_X86_64: "system-images;android-33;google_apis_playstore;x86_64"
-  }
+    PLAYSTORE_X86_64: "system-images;android-33;google_apis_playstore;x86_64",
+  },
 } as const;
 
-// Common device profiles
 export const COMMON_DEVICES = {
   PIXEL_4: "pixel_4",
   PIXEL_6: "pixel_6",
   PIXEL_7: "pixel_7",
   NEXUS_5X: "Nexus 5X",
   MEDIUM_PHONE: "Medium Phone",
-  SMALL_PHONE: "Small Phone"
+  SMALL_PHONE: "Small Phone",
 } as const;

--- a/src/utils/android-cmdline-tools/detection.ts
+++ b/src/utils/android-cmdline-tools/detection.ts
@@ -255,35 +255,6 @@ export function getAvailableToolsInDirectory(toolsDir: string, systemDetection =
 }
 
 /**
- * Get version information for Android command line tools at a specific location
- */
-async function getAndroidToolsVersion(toolsPath: string, systemDetection = createDefaultSystemDetection()): Promise<string | undefined> {
-  try {
-    // Try to get version from various tools
-    const binDir = join(toolsPath, "bin");
-
-    // Try sdkmanager first
-    const sdkmanagerPath = join(binDir, "sdkmanager");
-    const sdkmanagerBatPath = join(binDir, "sdkmanager.bat");
-
-    let command: string;
-    if (systemDetection.fileExistsSync(sdkmanagerPath)) {
-      command = `${sdkmanagerPath} --version`;
-    } else if (systemDetection.fileExistsSync(sdkmanagerBatPath)) {
-      command = `${sdkmanagerBatPath} --version`;
-    } else {
-      return undefined;
-    }
-
-    const result = await systemDetection.exec(command);
-    return result.stdout.trim() || result.stderr.trim() || undefined;
-  } catch (error) {
-    logger.warn(`Failed to get Android tools version at ${toolsPath}: ${(error as Error).message}`);
-    return undefined;
-  }
-}
-
-/**
  * Detect Android command line tools installation from Homebrew (macOS only)
  */
 export async function detectHomebrewAndroidTools(systemDetection = createDefaultSystemDetection()): Promise<AndroidToolsLocation | null> {
@@ -297,12 +268,9 @@ export async function detectHomebrewAndroidTools(systemDetection = createDefault
     return null;
   }
 
-  const version = await getAndroidToolsVersion(homebrewPath, systemDetection);
-
   return {
     path: homebrewPath,
     source: "homebrew",
-    version,
     available_tools: availableTools
   };
 }
@@ -321,13 +289,11 @@ export async function detectAndroidSdkTools(systemDetection = createDefaultSyste
     const availableTools = getAvailableToolsInDirectory(cmdlineToolsPath, systemDetection);
 
     if (availableTools.length > 0) {
-      const version = await getAndroidToolsVersion(cmdlineToolsPath, systemDetection);
       const source = systemDetection.getEnvVar("ANDROID_HOME") ? "android_home" : "android_sdk_root";
 
       locations.push({
         path: cmdlineToolsPath,
         source,
-        version,
         available_tools: availableTools
       });
     }
@@ -348,12 +314,9 @@ export async function detectAndroidSdkTools(systemDetection = createDefaultSyste
     const availableTools = getAvailableToolsInDirectory(cmdlineToolsPath, systemDetection);
 
     if (availableTools.length > 0) {
-      const version = await getAndroidToolsVersion(cmdlineToolsPath, systemDetection);
-
       locations.push({
         path: cmdlineToolsPath,
         source: "typical",
-        version,
         available_tools: availableTools
       });
     }

--- a/test/lint/sdkManagerExecutionBoundary.test.ts
+++ b/test/lint/sdkManagerExecutionBoundary.test.ts
@@ -1,21 +1,124 @@
 import { describe, expect, test } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
 import { join, relative } from "node:path";
+import ts from "typescript";
 
 const ROOT = join(import.meta.dir, "..", "..");
 const CLIENT = "src/utils/android-cmdline-tools/SdkManagerClient.ts";
+const LAUNCHER_NAMES = new Set([
+  "spawn",
+  "spawnSync",
+  "spawnCommand",
+  "exec",
+  "execSync",
+  "execFile",
+  "execFileSync",
+]);
 
 function directlyExecutesSdkManager(source: string): boolean {
-  const launcher = /\b(?:spawn|spawnSync|spawnCommand|exec|execFile|execFileSync|Bun\.spawn)\s*\(/;
-  const directLiteral = /\b(?:spawn|spawnSync|spawnCommand|exec|execFile|execFileSync)\s*\(\s*["'`][^"'`]*sdkmanager|\bBun\.spawn\s*\(\s*\[\s*["'`][^"'`]*sdkmanager/i;
-  const variableNames = new Set([
-    ...source.matchAll(/\b(?:const|let|var)\s+(\w+)\s*=\s*[^;]*?(?:\b(?:join|resolve)\s*\([^;]*?)?["'`]sdkmanager(?:\.bat)?["'`][^;]*;/gi),
-    ...source.matchAll(/\b(?:const|let|var)\s+(\w+)\s*=\s*["'`]sdkmanager(?:\.bat)?["'`]/gi),
-    ...source.matchAll(/\b(?:const|let|var)\s+(\w+)\s*=\s*["'`]sdk["'`]\s*\+\s*["'`]manager(?:\.bat)?["'`]/gi),
-  ].map(match => match[1]));
-  const variableLaunch = [...variableNames].some(name => new RegExp(`\\b(?:spawn|spawnSync|spawnCommand|exec|execFile|execFileSync)\\s*\\(\\s*${name}\\b|\\bBun\\.spawn\\s*\\(\\s*\\[\\s*${name}\\b`).test(source));
-  const inlineLaunch = /\b(?:spawn|spawnSync|spawnCommand|exec|execFile|execFileSync)\s*\(\s*(?:join|resolve)\s*\([^;\n]*["'`]sdkmanager|\bBun\.spawn\s*\(\s*\[\s*(?:join|resolve)\s*\([^;\n]*["'`]sdkmanager/i;
-  return directLiteral.test(source) || inlineLaunch.test(source) || (launcher.test(source) && variableLaunch);
+  const lowerSource = source.toLowerCase();
+  if (!lowerSource.includes("sdk") || !lowerSource.includes("manager")) {return false;}
+
+  const sourceFile = ts.createSourceFile(
+    "sdkmanager-boundary.ts",
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const launcherAliases = new Set(LAUNCHER_NAMES);
+  const initializers = new Map<string, ts.Expression>();
+  const declarations: ts.VariableDeclaration[] = [];
+
+  const collect = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier) &&
+      ["child_process", "node:child_process"].includes(node.moduleSpecifier.text)) {
+      const bindings = node.importClause?.namedBindings;
+      if (bindings && ts.isNamedImports(bindings)) {
+        for (const element of bindings.elements) {
+          const importedName = element.propertyName?.text ?? element.name.text;
+          if (LAUNCHER_NAMES.has(importedName)) {launcherAliases.add(element.name.text);}
+        }
+      }
+    }
+    if (ts.isVariableDeclaration(node)) {
+      declarations.push(node);
+      if (ts.isIdentifier(node.name) && node.initializer) {
+        initializers.set(node.name.text, node.initializer);
+      }
+      if (ts.isObjectBindingPattern(node.name)) {
+        for (const element of node.name.elements) {
+          const propertyName = element.propertyName && ts.isIdentifier(element.propertyName)
+            ? element.propertyName.text
+            : ts.isIdentifier(element.name) ? element.name.text : undefined;
+          if (propertyName && LAUNCHER_NAMES.has(propertyName) && ts.isIdentifier(element.name)) {
+            launcherAliases.add(element.name.text);
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, collect);
+  };
+  collect(sourceFile);
+
+  const isLauncherReference = (node: ts.Expression): boolean => {
+    if (ts.isIdentifier(node)) {return launcherAliases.has(node.text);}
+    return ts.isPropertyAccessExpression(node) && LAUNCHER_NAMES.has(node.name.text);
+  };
+  let aliasesChanged = true;
+  while (aliasesChanged) {
+    aliasesChanged = false;
+    for (const declaration of declarations) {
+      if (!ts.isIdentifier(declaration.name) || !declaration.initializer ||
+        !isLauncherReference(declaration.initializer) || launcherAliases.has(declaration.name.text)) {
+        continue;
+      }
+      launcherAliases.add(declaration.name.text);
+      aliasesChanged = true;
+    }
+  }
+
+  const staticText = (node: ts.Expression): string | undefined => {
+    if (ts.isStringLiteralLike(node)) {return node.text;}
+    if (ts.isParenthesizedExpression(node)) {return staticText(node.expression);}
+    if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+      const left = staticText(node.left);
+      const right = staticText(node.right);
+      return left === undefined || right === undefined ? undefined : left + right;
+    }
+    return undefined;
+  };
+  const mentionsSdkManager = (node: ts.Node, seen = new Set<string>()): boolean => {
+    if (ts.isExpression(node) && staticText(node)?.toLowerCase().includes("sdkmanager")) {
+      return true;
+    }
+    if (ts.isIdentifier(node) && !seen.has(node.text)) {
+      const initializer = initializers.get(node.text);
+      if (initializer) {
+        const nextSeen = new Set(seen);
+        nextSeen.add(node.text);
+        if (mentionsSdkManager(initializer, nextSeen)) {return true;}
+      }
+    }
+    let found = false;
+    ts.forEachChild(node, child => {
+      if (!found && mentionsSdkManager(child, seen)) {found = true;}
+    });
+    return found;
+  };
+
+  let directExecution = false;
+  const inspect = (node: ts.Node): void => {
+    if (directExecution) {return;}
+    if (ts.isCallExpression(node) && isLauncherReference(node.expression) &&
+      node.arguments.some(argument => mentionsSdkManager(argument))) {
+      directExecution = true;
+      return;
+    }
+    ts.forEachChild(node, inspect);
+  };
+  inspect(sourceFile);
+  return directExecution;
 }
 
 function sourceFiles(directory: string): string[] {
@@ -27,14 +130,19 @@ function sourceFiles(directory: string): string[] {
 }
 
 describe("sdkmanager execution boundary (issue #4052)", () => {
-  test("only SdkManagerClient directly executes sdkmanager", () => {
+  test("only SdkManagerClient directly executes sdkmanager", async () => {
     const exceptions = new Map<string, string>([
       // Keep production diagnostics out of this list unless they cannot use the client.
     ]);
-    const offenders = sourceFiles(join(ROOT, "src")).flatMap(file => {
+    const files = sourceFiles(join(ROOT, "src"));
+    const sources = await Promise.all(files.map(async file => ({
+      file,
+      source: await Bun.file(file).text(),
+    })));
+    const offenders = sources.flatMap(({ file, source }) => {
       const repoPath = relative(ROOT, file);
       if (repoPath === CLIENT || exceptions.has(repoPath)) {return [];}
-      return directlyExecutesSdkManager(readFileSync(file, "utf8"))
+      return directlyExecutesSdkManager(source)
         ? [`${repoPath} directly executes sdkmanager; route it through ${CLIENT} instead.`]
         : [];
     });
@@ -47,6 +155,18 @@ describe("sdkmanager execution boundary (issue #4052)", () => {
     expect(directlyExecutesSdkManager('const binary = "sdkmanager"; spawn(binary, args);')).toBe(true);
     expect(directlyExecutesSdkManager('const binary = `sdkmanager`; Bun.spawn([binary, "--list"]);')).toBe(true);
     expect(directlyExecutesSdkManager('const binary = "sdk" + "manager"; execFile(binary, args);')).toBe(true);
+  });
+
+  test("detects aliased launchers and shell wrappers", () => {
+    expect(directlyExecutesSdkManager('const { spawn: launch } = childProcess; launch("sdkmanager", ["--list"]);')).toBe(true);
+    expect(directlyExecutesSdkManager('const run = childProcess.spawn; run("sdkmanager", ["--list"]);')).toBe(true);
+    expect(directlyExecutesSdkManager('import { execFile as run } from "node:child_process"; run("sdkmanager", ["--list"]);')).toBe(true);
+    expect(directlyExecutesSdkManager('execFile("/bin/sh", ["-c", "sdkmanager --list"]);')).toBe(true);
+    expect(directlyExecutesSdkManager('execSync("sdkmanager --list");')).toBe(true);
+  });
+
+  test("allows diagnostic text that does not execute sdkmanager", () => {
+    expect(directlyExecutesSdkManager('logger.info("Install with sdkmanager --list");')).toBe(false);
   });
 
   test("does not allow tool discovery to execute sdkmanager for version probing", () => {

--- a/test/lint/sdkManagerExecutionBoundary.test.ts
+++ b/test/lint/sdkManagerExecutionBoundary.test.ts
@@ -8,7 +8,6 @@ const CLIENT = "src/utils/android-cmdline-tools/SdkManagerClient.ts";
 function directlyExecutesSdkManager(source: string): boolean {
   const launcher = /\b(?:spawn|spawnSync|spawnCommand|exec|execFile|execFileSync|Bun\.spawn)\s*\(/;
   const directLiteral = /\b(?:spawn|spawnSync|spawnCommand|exec|execFile|execFileSync)\s*\(\s*["'`][^"'`]*sdkmanager|\bBun\.spawn\s*\(\s*\[\s*["'`][^"'`]*sdkmanager/i;
-  const constructedPath = /\b(?:join|resolve)\s*\([^;\n]*["'`]sdkmanager(?:\.bat)?["'`]/i;
   const variableNames = new Set([
     ...source.matchAll(/\b(?:const|let|var)\s+(\w+)\s*=\s*[^;]*?(?:\b(?:join|resolve)\s*\([^;]*?)?["'`]sdkmanager(?:\.bat)?["'`][^;]*;/gi),
     ...source.matchAll(/\b(?:const|let|var)\s+(\w+)\s*=\s*["'`]sdkmanager(?:\.bat)?["'`]/gi),

--- a/test/lint/sdkManagerExecutionBoundary.test.ts
+++ b/test/lint/sdkManagerExecutionBoundary.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const ROOT = join(import.meta.dir, "..", "..");
+const CLIENT = "src/utils/android-cmdline-tools/SdkManagerClient.ts";
+
+function directlyExecutesSdkManager(source: string): boolean {
+  const launcher = /\b(?:spawn|spawnSync|spawnCommand|exec|execFile|execFileSync|Bun\.spawn)\s*\(/;
+  const directLiteral = /\b(?:spawn|spawnSync|spawnCommand|exec|execFile|execFileSync)\s*\(\s*["'`][^"'`]*sdkmanager|\bBun\.spawn\s*\(\s*\[\s*["'`][^"'`]*sdkmanager/i;
+  const constructedPath = /\b(?:join|resolve)\s*\([^;\n]*["'`]sdkmanager(?:\.bat)?["'`]/i;
+  const variableNames = new Set([
+    ...source.matchAll(/\b(?:const|let|var)\s+(\w+)\s*=\s*[^;]*?(?:\b(?:join|resolve)\s*\([^;]*?)?["'`]sdkmanager(?:\.bat)?["'`][^;]*;/gi),
+    ...source.matchAll(/\b(?:const|let|var)\s+(\w+)\s*=\s*["'`]sdkmanager(?:\.bat)?["'`]/gi),
+    ...source.matchAll(/\b(?:const|let|var)\s+(\w+)\s*=\s*["'`]sdk["'`]\s*\+\s*["'`]manager(?:\.bat)?["'`]/gi),
+  ].map(match => match[1]));
+  const variableLaunch = [...variableNames].some(name => new RegExp(`\\b(?:spawn|spawnSync|spawnCommand|exec|execFile|execFileSync)\\s*\\(\\s*${name}\\b|\\bBun\\.spawn\\s*\\(\\s*\\[\\s*${name}\\b`).test(source));
+  const inlineLaunch = /\b(?:spawn|spawnSync|spawnCommand|exec|execFile|execFileSync)\s*\(\s*(?:join|resolve)\s*\([^;\n]*["'`]sdkmanager|\bBun\.spawn\s*\(\s*\[\s*(?:join|resolve)\s*\([^;\n]*["'`]sdkmanager/i;
+  return directLiteral.test(source) || inlineLaunch.test(source) || (launcher.test(source) && variableLaunch);
+}
+
+function sourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {return sourceFiles(path);}
+    return entry.name.endsWith(".ts") ? [path] : [];
+  });
+}
+
+describe("sdkmanager execution boundary (issue #4052)", () => {
+  test("only SdkManagerClient directly executes sdkmanager", () => {
+    const exceptions = new Map<string, string>([
+      // Keep production diagnostics out of this list unless they cannot use the client.
+    ]);
+    const offenders = sourceFiles(join(ROOT, "src")).flatMap(file => {
+      const repoPath = relative(ROOT, file);
+      if (repoPath === CLIENT || exceptions.has(repoPath)) {return [];}
+      return directlyExecutesSdkManager(readFileSync(file, "utf8"))
+        ? [`${repoPath} directly executes sdkmanager; route it through ${CLIENT} instead.`]
+        : [];
+    });
+    expect(offenders, offenders.join("\n")).toEqual([]);
+  });
+
+  test("detects resolved paths passed to supported launch APIs", () => {
+    expect(directlyExecutesSdkManager('const binary = join(root, "bin", "sdkmanager"); execFile(binary, args);')).toBe(true);
+    expect(directlyExecutesSdkManager('Bun.spawn([join(root, "bin", "sdkmanager"), ...args]);')).toBe(true);
+    expect(directlyExecutesSdkManager('const binary = "sdkmanager"; spawn(binary, args);')).toBe(true);
+    expect(directlyExecutesSdkManager('const binary = `sdkmanager`; Bun.spawn([binary, "--list"]);')).toBe(true);
+    expect(directlyExecutesSdkManager('const binary = "sdk" + "manager"; execFile(binary, args);')).toBe(true);
+  });
+
+  test("does not allow tool discovery to execute sdkmanager for version probing", () => {
+    const detection = readFileSync(join(ROOT, "src/utils/android-cmdline-tools/detection.ts"), "utf8");
+    expect(detection).not.toContain("sdkmanagerPath} --version");
+    expect(detection).not.toContain("sdkmanagerBatPath} --version");
+  });
+});

--- a/test/utils/android-cmdline-tools/SdkManagerClient.test.ts
+++ b/test/utils/android-cmdline-tools/SdkManagerClient.test.ts
@@ -99,6 +99,23 @@ describe("SdkManagerClient", () => {
     });
   });
 
+  test("keeps list diagnostics bounded while preserving the catalogue", async () => {
+    const { client, child } = createClient();
+    const catalogue = "available package\n".repeat(2_000);
+    const diagnostics = "sdkmanager failure\n".repeat(2_000);
+    const pending = client.list();
+    await settleSpawn();
+    child.stdoutText(catalogue);
+    child.stderrText(diagnostics);
+    child.close(1);
+
+    const result = await pending;
+    expect(result.stdout).toBe(catalogue);
+    expect(result.stderr).toHaveLength(16_384);
+    expect(result.outputTruncated).toBe(true);
+    expect(result.exitCode).toBe(1);
+  });
+
   test("writes repeated license confirmation to stdin without shell interpolation", async () => {
     const { client, child, spawns } = createClient();
     const pending = client.acceptLicenses();

--- a/test/utils/android-cmdline-tools/SdkManagerClient.test.ts
+++ b/test/utils/android-cmdline-tools/SdkManagerClient.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from "bun:test";
+import type { ChildProcess } from "node:child_process";
+import { SdkManagerClient } from "../../../src/utils/android-cmdline-tools/SdkManagerClient";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+class FakeChild {
+  readonly stdout = { on: (_event: string, callback: (data: Buffer) => void) => { this.stdoutCallback = callback; } };
+  readonly stderr = { on: (_event: string, callback: (data: Buffer) => void) => { this.stderrCallback = callback; } };
+  readonly stdin = {
+    write: (value: string) => { this.stdinWrites.push(value); },
+    end: () => { this.stdinEnded = true; },
+  };
+  readonly kills: NodeJS.Signals[] = [];
+  readonly stdinWrites: string[] = [];
+  stdinEnded = false;
+  private stdoutCallback?: (data: Buffer) => void;
+  private stderrCallback?: (data: Buffer) => void;
+  private closeCallback?: (code: number | null) => void;
+  private errorCallback?: (error: Error) => void;
+
+  on(event: string, callback: (value: never) => void): this {
+    if (event === "close") {this.closeCallback = callback as (code: number | null) => void;}
+    if (event === "error") {this.errorCallback = callback as (error: Error) => void;}
+    return this;
+  }
+
+  kill(signal: NodeJS.Signals): boolean {
+    this.kills.push(signal);
+    return true;
+  }
+
+  stdoutText(value: string): void { this.stdoutCallback?.(Buffer.from(value)); }
+  stderrText(value: string): void { this.stderrCallback?.(Buffer.from(value)); }
+  close(code: number | null): void { this.closeCallback?.(code); }
+  error(error: Error): void { this.errorCallback?.(error); }
+}
+
+function createClient(overrides: Partial<ConstructorParameters<typeof SdkManagerClient>[0]> = {}) {
+  const child = new FakeChild();
+  const timer = new FakeTimer();
+  const spawns: Array<{ command: string; args: string[]; options: unknown }> = [];
+  const client = new SdkManagerClient({
+    spawn: (command, args, options) => {
+      spawns.push({ command, args, options });
+      return child as unknown as ChildProcess;
+    },
+    existsSync: () => true,
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+    detectAndroidCommandLineTools: async () => [{
+      path: "/sdk/cmdline-tools/latest",
+      source: "manual",
+      version: "test",
+      available_tools: ["sdkmanager"],
+    }],
+    getAndroidHomeWithSystemImages: () => null,
+    getBestAndroidToolsLocation: locations => locations[0] ?? null,
+    validateRequiredTools: () => ({ valid: true, missing: [] }),
+    timer,
+    environment: {},
+    platform: "linux",
+    ...overrides,
+  });
+  return { client, child, timer, spawns };
+}
+
+async function settleSpawn(): Promise<void> {
+  await new Promise<void>(resolve => setImmediate(resolve));
+}
+
+describe("SdkManagerClient", () => {
+  test("lists packages through the resolved sdkmanager argv boundary", async () => {
+    const { client, child, spawns } = createClient();
+    const pending = client.list();
+    await settleSpawn();
+    child.stdoutText("Installed packages:\n");
+    child.close(0);
+
+    await expect(pending).resolves.toMatchObject({ stdout: "Installed packages:\n", exitCode: 0 });
+    expect(spawns).toEqual([{
+      command: "/sdk/cmdline-tools/latest/bin/sdkmanager",
+      args: ["--list"],
+      options: expect.objectContaining({ shell: false }),
+    }]);
+  });
+
+  test("writes repeated license confirmation to stdin without shell interpolation", async () => {
+    const { client, child, spawns } = createClient();
+    const pending = client.acceptLicenses();
+    await settleSpawn();
+    child.close(0);
+
+    await expect(pending).resolves.toMatchObject({ exitCode: 0 });
+    expect(spawns[0]?.args).toEqual(["--licenses"]);
+    expect(child.stdinWrites).toEqual(["y\n".repeat(20)]);
+    expect(child.stdinEnded).toBe(true);
+  });
+
+  test("executes a Windows batch sdkmanager through cmd without enabling a shell", async () => {
+    const { client, child, spawns } = createClient({
+      existsSync: path => !path.endsWith("/sdkmanager"),
+      environment: { ComSpec: "C:/Windows/System32/cmd.exe" },
+      platform: "win32",
+    });
+    const pending = client.list();
+    await settleSpawn();
+    child.close(0);
+
+    await expect(pending).resolves.toMatchObject({ exitCode: 0 });
+    expect(spawns).toEqual([{
+      command: "C:/Windows/System32/cmd.exe",
+      args: ["/d", "/v:off", "/s", "/c", '""/sdk/cmdline-tools/latest/bin/sdkmanager.bat" "--list""'],
+      options: expect.objectContaining({ shell: false }),
+    }]);
+  });
+
+  test("keeps a package name as one argv element and supports opted-in license input", async () => {
+    const { client, child, spawns } = createClient();
+    const packageName = "system-images;android-35;google_apis;arm64-v8a";
+    const pending = client.installPackage(packageName, { acceptLicenses: true });
+    await settleSpawn();
+    child.close(0);
+
+    await expect(pending).resolves.toMatchObject({ exitCode: 0 });
+    expect(spawns[0]?.args).toEqual([packageName]);
+    expect(child.stdinWrites).toEqual(["y\n".repeat(10)]);
+  });
+
+  test("terminates a slow install, then escalates after its grace period", async () => {
+    const { client, child, timer } = createClient();
+    const pending = client.installPackage("system-images;android-35;google_apis;arm64-v8a", {
+      timeoutMs: 600_000,
+      terminationGraceMs: 1_000,
+    });
+    await settleSpawn();
+    timer.advanceTime(600_000);
+    expect(child.kills).toEqual(["SIGTERM"]);
+    timer.advanceTime(1_000);
+    child.close(null);
+
+    await expect(pending).rejects.toThrow("timed out after 600000ms");
+    expect(child.kills).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+  });
+
+  test("cancels once, escalates if needed, and ignores a late close", async () => {
+    const { client, child, timer } = createClient();
+    const abort = new AbortController();
+    const pending = client.list({ signal: abort.signal, terminationGraceMs: 1_000 });
+    await settleSpawn();
+    abort.abort();
+    timer.advanceTime(1_000);
+    child.close(0);
+
+    await expect(pending).rejects.toThrow("cancelled");
+    expect(child.kills).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+  });
+
+  test("bounds and redacts noisy diagnostics", async () => {
+    const { client, child } = createClient();
+    const pending = client.list({ maxOutputChars: 24 });
+    await settleSpawn();
+    child.stderrText("token=super-secret-value ".repeat(4));
+    child.close(1);
+
+    const result = await pending;
+    const stderr = result.stderr;
+    expect(result).toMatchObject({
+      stderr: expect.stringContaining("[REDACTED]"),
+      outputTruncated: true,
+      exitCode: 1,
+    });
+    expect(stderr.includes("super-secret-value")).toBe(false);
+  });
+
+  test("explains the effective SDK root when Homebrew tools and Android home disagree", async () => {
+    const warnings: string[] = [];
+    const { client, child } = createClient({
+      logger: { info: () => {}, warn: message => warnings.push(message), error: () => {} },
+      environment: { ANDROID_HOME: "/sdk" },
+      getAndroidHomeWithSystemImages: () => ({ androidHome: "/sdk", systemImagesPath: "/sdk/system-images" }),
+      detectAndroidCommandLineTools: async () => [{
+        path: "/opt/homebrew/share/android-commandlinetools",
+        source: "homebrew",
+        version: "test",
+        available_tools: ["sdkmanager"],
+      }],
+    });
+    const pending = client.list();
+    await settleSpawn();
+    child.close(0);
+
+    await expect(pending).resolves.toMatchObject({ exitCode: 0 });
+    expect(warnings.join(" ")).toContain("ANDROID_HOME");
+    expect(warnings.join(" ")).toContain("sdkmanager");
+  });
+});

--- a/test/utils/android-cmdline-tools/SdkManagerClient.test.ts
+++ b/test/utils/android-cmdline-tools/SdkManagerClient.test.ts
@@ -83,6 +83,21 @@ describe("SdkManagerClient", () => {
     }]);
   });
 
+  test("does not truncate the sdkmanager catalogue by default", async () => {
+    const { client, child } = createClient();
+    const output = "available package\n".repeat(2_000);
+    const pending = client.list();
+    await settleSpawn();
+    child.stdoutText(output);
+    child.close(0);
+
+    await expect(pending).resolves.toMatchObject({
+      stdout: output,
+      outputTruncated: false,
+      exitCode: 0,
+    });
+  });
+
   test("writes repeated license confirmation to stdin without shell interpolation", async () => {
     const { client, child, spawns } = createClient();
     const pending = client.acceptLicenses();

--- a/test/utils/android-cmdline-tools/SdkManagerClient.test.ts
+++ b/test/utils/android-cmdline-tools/SdkManagerClient.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { ChildProcess } from "node:child_process";
+import { join } from "node:path";
 import { SdkManagerClient } from "../../../src/utils/android-cmdline-tools/SdkManagerClient";
 import { FakeTimer } from "../../fakes/FakeTimer";
 
@@ -77,7 +78,7 @@ describe("SdkManagerClient", () => {
 
     await expect(pending).resolves.toMatchObject({ stdout: "Installed packages:\n", exitCode: 0 });
     expect(spawns).toEqual([{
-      command: "/sdk/cmdline-tools/latest/bin/sdkmanager",
+      command: join("/sdk", "cmdline-tools", "latest", "bin", "sdkmanager"),
       args: ["--list"],
       options: expect.objectContaining({ shell: false }),
     }]);
@@ -112,7 +113,7 @@ describe("SdkManagerClient", () => {
 
   test("executes a Windows batch sdkmanager through cmd without enabling a shell", async () => {
     const { client, child, spawns } = createClient({
-      existsSync: path => !path.endsWith("/sdkmanager"),
+      existsSync: path => !/[\\/]sdkmanager$/.test(path),
       environment: { ComSpec: "C:/Windows/System32/cmd.exe" },
       platform: "win32",
     });
@@ -123,7 +124,7 @@ describe("SdkManagerClient", () => {
     await expect(pending).resolves.toMatchObject({ exitCode: 0 });
     expect(spawns).toEqual([{
       command: "C:/Windows/System32/cmd.exe",
-      args: ["/d", "/v:off", "/s", "/c", '""/sdk/cmdline-tools/latest/bin/sdkmanager.bat" "--list""'],
+      args: ["/d", "/v:off", "/s", "/c", `""${join("/sdk", "cmdline-tools", "latest", "bin", "sdkmanager.bat")}" "--list""`],
       options: expect.objectContaining({ shell: false }),
     }]);
   });

--- a/test/utils/android-cmdline-tools/avdmanager.test.ts
+++ b/test/utils/android-cmdline-tools/avdmanager.test.ts
@@ -712,6 +712,29 @@ id: pixel_4
 
       expect(result.success).toBe(true);
     });
+
+    test("annotates a bounded sdkmanager failure diagnostic", async () => {
+      const mockDeps = createDependencies();
+      const originalSpawn = mockDeps.spawn;
+      const fakeTimer = createFakeTimer();
+
+      mockDeps.spawn = (command: string, args: string[], options?: any) => {
+        const child: any = originalSpawn(command, args, options);
+        fakeTimer.setTimeout(() => {
+          child.triggerStderr(Buffer.from("sdkmanager failure ".repeat(2_000)));
+          child.triggerClose(1);
+        }, 0);
+        return child;
+      };
+
+      const result = await resolveWithFakeTimer(
+        fakeTimer,
+        avdmanager.installSystemImage("system-images;android-35;google_apis;arm64-v8a", true, mockDeps)
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain("[output truncated]");
+    });
   });
 
   describe("Constants", () => {

--- a/test/utils/android-cmdline-tools/avdmanager.test.ts
+++ b/test/utils/android-cmdline-tools/avdmanager.test.ts
@@ -235,6 +235,26 @@ Available Packages:
       expect(result[0].apiLevel).toBe(33);
       expect(result[0].tag).toBe("google_apis");
     });
+
+    test("annotates bounded diagnostics when listing fails", async () => {
+      const mockDeps = createDependencies();
+      const originalSpawn = mockDeps.spawn;
+      const fakeTimer = createFakeTimer();
+
+      mockDeps.spawn = (command: string, args: string[], options?: any) => {
+        const child: any = originalSpawn(command, args, options);
+        fakeTimer.setTimeout(() => {
+          child.triggerStderr(Buffer.from("sdkmanager failure ".repeat(2_000)));
+          child.triggerClose(1);
+        }, 0);
+        return child;
+      };
+
+      await expect(resolveWithFakeTimer(
+        fakeTimer,
+        avdmanager.listSystemImages(undefined, mockDeps)
+      )).rejects.toThrow("[output truncated]");
+    });
   });
 
   describe("listInstalledSystemImages", () => {


### PR DESCRIPTION
## Summary

Centralizes production `sdkmanager` resolution and execution in `SdkManagerClient`.

- Routes listing, package installation, and license acceptance through typed argv/stdin execution.
- Adds explicit package-download timeouts, cancellation cleanup with SIGTERM-to-SIGKILL escalation, and bounded redacted diagnostics.
- Removes the discovery-time `sdkmanager --version` subprocess and blocks new direct production invocations with a focused static test.

## Validation

- `bun run turbo:validate`
- `bun run typecheck`
- `git diff --check`

Closes #4052
