### PR TITLE
test(lint): activate 10 inert assertions in AdbClient-listUsers + ban bare expect() with no matcher

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -290,11 +290,46 @@ function noAccumulatorForEachRule() {
 	};
 }
 
+// A bare `expect(...)` used as a statement asserts nothing: no matcher is
+// chained, so nothing runs and it can never fail (issue #4198 — 10 such dead
+// assertions were hiding in one test file). Flag an ExpressionStatement whose
+// expression is a direct `expect()` CallExpression.
+//
+// This deliberately targets the MISSING matcher, not the arity: bun honours a
+// second argument as a label (`expect(x, "label").toBe(y)` fails as `error:
+// label`), so a labeled assertion WITH a matcher is legitimate. Because a
+// chained matcher makes the statement's callee a MemberExpression rather than
+// the `expect` Identifier, that form is inherently excluded by this selector.
+//
+// Report-only (no `fix`) so the repo's `eslint . --fix` lint command cannot
+// rewrite it — the ratchet convention requires ratchet rules be non-auto-fixable
+// (see CLAUDE.md). Kept as its own rule rather than folded into
+// no-restricted-syntax so its suppression budget stays isolated, matching
+// no-accumulator-foreach.
+function noBareExpectRule() {
+	return {
+		meta: {
+			type: "problem",
+			messages: {
+				bareExpect: "`expect(...)` with no matcher chained asserts nothing and can never fail. Chain a matcher (e.g. .toBe/.toEqual). Note: `expect(x, \"label\")` is a valid labeled assertion only when a matcher follows.",
+			},
+		},
+		create(context) {
+			return {
+				"ExpressionStatement > CallExpression[callee.name='expect']"(node) {
+					context.report({ node, messageId: "bareExpect" });
+				},
+			};
+		},
+	};
+}
+
 const catchConventionPlugin = {
 	rules: {
 		"catch-convention": catchConventionRule(),
 		"no-unknown-cast": noUnknownCastRule(),
 		"no-accumulator-foreach": noAccumulatorForEachRule(),
+		"no-bare-expect": noBareExpectRule(),
 	},
 };
 
@@ -623,6 +658,9 @@ export default [
 		rules: {
 			...baseRules,
 			"no-unused-expressions": "off",
+			// A bare `expect(...)` statement asserts nothing (issue #4198). Only
+			// test files use `expect`, so scope the gate here.
+			"auto-mobile/no-bare-expect": 2,
 		},
 	},
 	{

--- a/test/lint/bareExpectRule.test.ts
+++ b/test/lint/bareExpectRule.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import { ESLint } from "eslint";
+
+const BARE_EXPECT = "`expect(...)` with no matcher chained";
+
+async function lintSnippet(code: string, filePath = "test/bareExpectFixture.test.ts"): Promise<string[]> {
+  const eslint = new ESLint({
+    cwd: process.cwd(),
+    overrideConfigFile: "eslint.config.mjs",
+    // Same rationale as accumulatorForEachRule.test.ts: these snippets live at
+    // paths that do not exist on disk, so opt out of the type-aware config that
+    // would make projectService reject them.
+    overrideConfig: {
+      languageOptions: { parserOptions: { projectService: false, project: null } },
+      rules: {
+        "@typescript-eslint/no-floating-promises": "off",
+        "@typescript-eslint/no-misused-promises": "off",
+      },
+    },
+    fix: false,
+  });
+  const [result] = await eslint.lintText(code, { filePath });
+  return result.messages.map(message => message.message);
+}
+
+function matches(messages: string[], fragment: string): boolean {
+  return messages.some(message => message.startsWith(fragment));
+}
+
+describe("auto-mobile/no-bare-expect", () => {
+  // AC #3 — the gate must be proven to fire. A bare `expect(x);` statement with
+  // no matcher chained asserts nothing and can never fail; it must be flagged.
+  test("flags a bare expect() statement with no matcher", async () => {
+    const messages = await lintSnippet(`import { expect, test } from "bun:test";
+test("dead", () => {
+  const x = 1;
+  expect(x);
+});
+`);
+    expect(matches(messages, BARE_EXPECT)).toBe(true);
+  });
+
+  // The exact inert shape from the issue: object passed as arg 2 with no matcher.
+  test("flags a bare expect(actual, expected) statement", async () => {
+    const messages = await lintSnippet(`import { expect, test } from "bun:test";
+test("dead", () => {
+  const users = [{ userId: 0 }];
+  expect(users[0], { userId: 0 });
+});
+`);
+    expect(matches(messages, BARE_EXPECT)).toBe(true);
+  });
+
+  // AC #4 — a labeled assertion is legitimate: bun honours arg 2 as a label and
+  // the matcher still runs. The rule targets the MISSING matcher, not arity, so
+  // it must NOT flag this.
+  test("does not flag a labeled assertion with a matcher chained", async () => {
+    const messages = await lintSnippet(`import { expect, test } from "bun:test";
+test("live", () => {
+  const x = 1;
+  expect(x, "label").toBe(1);
+});
+`);
+    expect(matches(messages, BARE_EXPECT)).toBe(false);
+  });
+
+  test("does not flag a plain chained assertion", async () => {
+    const messages = await lintSnippet(`import { expect, test } from "bun:test";
+test("live", () => {
+  const x = 1;
+  expect(x).toBe(1);
+});
+`);
+    expect(matches(messages, BARE_EXPECT)).toBe(false);
+  });
+
+  // A bare expect used as a value (not a statement) — e.g. building a matcher —
+  // is not the inert-statement foot-gun and must not be flagged.
+  test("does not flag expect() used as a sub-expression", async () => {
+    const messages = await lintSnippet(`import { expect, test } from "bun:test";
+test("live", () => {
+  const x = 1;
+  const assertion = expect(x);
+  assertion.toBe(1);
+});
+`);
+    expect(matches(messages, BARE_EXPECT)).toBe(false);
+  });
+});

--- a/test/utils/android-cmdline-tools/AdbClient-listUsers.test.ts
+++ b/test/utils/android-cmdline-tools/AdbClient-listUsers.test.ts
@@ -51,7 +51,7 @@ Users:
       const users = await adbClient.listUsers();
 
       expect(users.length).toBe(1);
-      expect(users[0], {
+      expect(users[0]).toEqual({
         userId: 0,
         name: "Owner",
         flags: 0x4c13,
@@ -93,13 +93,13 @@ Users:
       const users = await adbClient.listUsers();
 
       expect(users.length).toBe(2);
-      expect(users[0], {
+      expect(users[0]).toEqual({
         userId: 0,
         name: "Owner",
         flags: 0x4c13,
         running: true
       });
-      expect(users[1], {
+      expect(users[1]).toEqual({
         userId: 10,
         name: "Work profile",
         flags: 0x30,
@@ -229,13 +229,13 @@ Users:
       const users = await adbClient.listUsers();
 
       expect(users.length).toBe(2);
-      expect(users[0], {
+      expect(users[0]).toEqual({
         userId: 0,
         name: "Owner",
         flags: 0x4c13,
         running: true
       });
-      expect(users[1], {
+      expect(users[1]).toEqual({
         userId: 10,
         name: "Work profile",
         flags: 0x30,
@@ -272,7 +272,7 @@ Users:
       const users = await adbClient.listUsers();
 
       expect(users.length).toBe(1);
-      expect(users[0], {
+      expect(users[0]).toEqual({
         userId: 0,
         name: "Owner",
         flags: 0x4c13,
@@ -360,7 +360,7 @@ Users:
       const users = await adbClient.listUsers();
 
       expect(users.length).toBe(1);
-      expect(users[0], {
+      expect(users[0]).toEqual({
         userId: 0,
         name: "Owner",
         flags: 0x13,
@@ -387,7 +387,7 @@ Users:
       const users = await adbClient.listUsers();
 
       expect(users.length).toBe(1);
-      expect(users[0], {
+      expect(users[0]).toEqual({
         userId: 0,
         name: "Owner",
         flags: 0x13,
@@ -422,8 +422,8 @@ Users:
       const users = await adbClient.listUsers();
 
       expect(users.length).toBe(2);
-      expect(users[0].flags, 0x4c13); // 19475 in decimal
-      expect(users[1].flags, 0x1a2b); // 6699 in decimal
+      expect(users[0].flags).toBe(0x4c13); // 19475 in decimal
+      expect(users[1].flags).toBe(0x1a2b); // 6699 in decimal
     });
   });
 });


### PR DESCRIPTION
## Summary

`expect(...)` used as a statement with no matcher chained asserts nothing and can
never fail. An AST scan found **exactly 10** such statements, all in
`test/utils/android-cmdline-tools/AdbClient-listUsers.test.ts`. This PR activates
all 10 with real matchers and adds a lint rule so the inert form cannot return.

- **8 object sites** → `expect(users[i]).toEqual({...})`
- **2 scalar `flags` sites** → `expect(users[i].flags).toBe(0x...)`

The file now executes **38** assertions (was 28) and stays green — `AndroidUser`
has exactly the four asserted fields (`userId`, `name`, `flags`, `running`), so
`.toEqual` matches exactly. This is dead coverage, not a latent product defect:
`listUsers` parsing was correct, it simply was not being checked.

The new `auto-mobile/no-bare-expect` rule flags an `ExpressionStatement` whose
expression is a bare `expect()` `CallExpression`. It targets the **missing
matcher**, not arity — bun honours a second argument as a label and the matcher
still runs, so `expect(x, "label").toBe(y)` is legitimate and is **not** flagged
(a chained matcher makes the statement's callee a `MemberExpression`, inherently
excluded by the selector). The rule is report-only (non-auto-fixable, per the
ratchet convention) and lands with **no `eslint-suppressions.json` entry**. It
lives in its own plugin rule rather than `no-restricted-syntax` so its
suppression budget stays isolated, matching `no-accumulator-foreach`.

## Linked Issue

Closes #4198

## Acceptance criteria

- [x] All 10 sites given real matchers; file executes 38 assertions and stays green (`12 pass / 0 fail`, `38 expect() calls`).
- [x] Lint rule added; `bun run lint` is clean with no new suppressions (`eslint-suppressions.json` unchanged).
- [x] Rule proven to fire — `test/lint/bareExpectRule.test.ts` asserts a bare `expect(x);` statement is flagged (the permanent, repeatable form of the "prove it fires" check).
- [x] Rule does **not** flag `expect(x, "label").toBe(y)` — included as a negative case, alongside `expect(x).toBe(y)` and `expect()` used as a sub-expression.

## Validation

- [x] `bun run lint` passes; `eslint-suppressions.json` unchanged.
- [x] `bun test` — full suite green (8830 pass / 0 fail).
- [x] `bun run build` succeeds.
- [x] New code uses no new dependencies; lint rule mirrors the existing `no-accumulator-foreach` rule + test structure.
- [ ] `bun run typecheck` — a pre-existing, unrelated ajv/ajv-formats type error in `src/utils/plan/PlanSchemaValidator.ts` reproduces on pristine `main` in this worktree (node_modules resolution drift); it is not in this PR's diff and is not introduced here.

## Follow-ups

None required for this scope.
