### PR TITLE
fix(daemon): sweep stale auto-mobile-prefetch-* dirs on startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -179,6 +179,10 @@ async function main() {
     serverConfig.setNetworkMockableEnabled(networkMockable);
     serverConfig.setDismissKeyboardAfterInputEnabled(dismissKeyboardAfterInput);
     serverConfig.setEventAllMarkers(eventAllMarkers);
+    // Reclaim any auto-mobile-prefetch-* scratch dirs leaked by a previously
+    // crashed/killed daemon before its shutdown cleanup ran (#4334). Runs even
+    // when downloads are disabled, since leaked dirs still need reclaiming.
+    await AndroidCtrlProxyManager.sweepStalePrefetchDirsOnStartup();
     if (skipCtrlProxyDownload) {
       logger.info(`CtrlProxy downloads disabled (${SKIP_CTRL_PROXY_DOWNLOAD_FLAG} or ${SKIP_CTRL_PROXY_DOWNLOAD_ENV})`);
     } else {

--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -2,6 +2,7 @@ import { AdbClientFactory, defaultAdbClientFactory } from "./android-cmdline-too
 import type { AdbExecutor } from "./android-cmdline-tools/interfaces/AdbExecutor";
 import { logger } from "./logger";
 import * as fs from "fs/promises";
+import type { Dirent } from "fs";
 import * as path from "path";
 import { ActionableError, BootedDevice } from "../models";
 import { requireBootedDevice } from "./requireBootedDevice";
@@ -368,6 +369,63 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
     }
     AndroidCtrlProxyManager.prefetchPromise = null;
     AndroidCtrlProxyManager.prefetchError = null;
+  }
+
+  /** Prefix shared by every prefetch scratch dir, including the `-upgrade-` variant. */
+  private static readonly PREFETCH_DIR_PREFIX = "auto-mobile-prefetch-";
+  /**
+   * Only prefetch dirs older than this are swept, so an in-flight prefetch
+   * (this process's or a concurrent one's) is never removed. Matches the
+   * `-mmin +60` guard from the issue's workaround (#4334).
+   */
+  private static readonly STALE_PREFETCH_MAX_AGE_MS = 60 * 60 * 1000;
+
+  /**
+   * Best-effort startup sweep for orphaned `auto-mobile-prefetch-*` scratch
+   * directories. On success `doPrefetch` intentionally retains its dir as the
+   * reusable APK cache; it is removed only by {@link cleanupPrefetchedApk} in the
+   * graceful-shutdown handler. Any process that is SIGKILLed or crashes therefore
+   * leaks one dir (~20+ MB) per lifecycle, growing the runtime dir without bound
+   * (#4334). This reclaims the leaked ones left by previous runs, skipping any
+   * dir younger than {@link STALE_PREFETCH_MAX_AGE_MS} so in-flight work is safe.
+   */
+  public static async sweepStalePrefetchDirsOnStartup(
+    tempRoot: string = os.tmpdir(),
+    timer: Timer = defaultTimer
+  ): Promise<void> {
+    let entries: Dirent[];
+    try {
+      entries = await fs.readdir(tempRoot, { withFileTypes: true });
+    } catch (error) {
+      // A missing/unreadable temp root is expected on some hosts; nothing to sweep.
+      logger.debug(`[CTRL_PROXY] Prefetch sweep skipped: cannot read ${tempRoot}: ${error}`);
+      return;
+    }
+
+    const now = timer.now();
+    let reclaimed = 0;
+    for (const entry of entries) {
+      if (!entry.isDirectory() || !entry.name.startsWith(AndroidCtrlProxyManager.PREFETCH_DIR_PREFIX)) {
+        continue;
+      }
+      const dir = path.join(tempRoot, entry.name);
+      try {
+        const stats = await fs.stat(dir);
+        if (now - stats.mtimeMs < AndroidCtrlProxyManager.STALE_PREFETCH_MAX_AGE_MS) {
+          continue;
+        }
+        await fs.rm(dir, { recursive: true, force: true });
+        reclaimed++;
+      } catch (error) {
+        // Per-entry best-effort: a concurrent process may remove the same dir,
+        // or it may vanish mid-sweep. Skip it and keep going.
+        logger.debug(`[CTRL_PROXY] Failed to sweep stale prefetch dir ${dir}: ${error}`);
+      }
+    }
+
+    if (reclaimed > 0) {
+      logger.info(`[CTRL_PROXY] Swept ${reclaimed} stale prefetch dir(s) from ${tempRoot}`);
+    }
   }
 
   /**

--- a/test/utils/CtrlProxyManager.test.ts
+++ b/test/utils/CtrlProxyManager.test.ts
@@ -2144,4 +2144,84 @@ describe("CtrlProxyManager", function() {
       }
     });
   });
+
+  describe("sweepStalePrefetchDirsOnStartup", function() {
+    // Fixed reference "now" used to age fixtures deterministically.
+    const NOW_MS = 1_700_000_000_000;
+    const HOUR_MS = 60 * 60 * 1000;
+
+    let scratchRoot: string;
+    let sweepTimer: FakeTimer;
+
+    async function makeAgedDir(name: string, ageMs: number): Promise<string> {
+      const dir = path.join(scratchRoot, name);
+      await fs.mkdir(dir, { recursive: true });
+      // Put a payload file inside so it mirrors a real prefetch dir.
+      await fs.writeFile(path.join(dir, "control-proxy.apk"), Buffer.from("x"));
+      const when = new Date(NOW_MS - ageMs);
+      await fs.utimes(dir, when, when);
+      return dir;
+    }
+
+    beforeEach(async function() {
+      scratchRoot = await fs.mkdtemp(path.join(os.tmpdir(), "auto-mobile-sweep-root-"));
+      sweepTimer = new FakeTimer();
+      sweepTimer.setCurrentTime(NOW_MS);
+    });
+
+    afterEach(async function() {
+      await fs.rm(scratchRoot, { recursive: true, force: true });
+    });
+
+    async function exists(target: string): Promise<boolean> {
+      try {
+        await fs.stat(target);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+
+    test("removes stale prefetch dirs older than the 60-minute threshold", async function() {
+      const stale = await makeAgedDir("auto-mobile-prefetch-zzP8qH", 2 * HOUR_MS);
+
+      await AndroidCtrlProxyManager.sweepStalePrefetchDirsOnStartup(scratchRoot, sweepTimer);
+
+      expect(await exists(stale)).toBe(false);
+    });
+
+    test("also removes stale prefetch-upgrade dirs", async function() {
+      const staleUpgrade = await makeAgedDir("auto-mobile-prefetch-upgrade-abc123", 2 * HOUR_MS);
+
+      await AndroidCtrlProxyManager.sweepStalePrefetchDirsOnStartup(scratchRoot, sweepTimer);
+
+      expect(await exists(staleUpgrade)).toBe(false);
+    });
+
+    test("preserves fresh prefetch dirs within the threshold (in-flight guard)", async function() {
+      const fresh = await makeAgedDir("auto-mobile-prefetch-fresh01", 60 * 1000);
+
+      await AndroidCtrlProxyManager.sweepStalePrefetchDirsOnStartup(scratchRoot, sweepTimer);
+
+      expect(await exists(fresh)).toBe(true);
+    });
+
+    test("preserves sibling caches and the installed package even when old", async function() {
+      const bunxCache = await makeAgedDir("bunx-1234-auto-mobile", 5 * HOUR_MS);
+      const sharedCache = await makeAgedDir("automobile-bun-cache-shared", 5 * HOUR_MS);
+
+      await AndroidCtrlProxyManager.sweepStalePrefetchDirsOnStartup(scratchRoot, sweepTimer);
+
+      expect(await exists(bunxCache)).toBe(true);
+      expect(await exists(sharedCache)).toBe(true);
+    });
+
+    test("is best-effort: a missing temp root does not throw", async function() {
+      const missing = path.join(scratchRoot, "does-not-exist");
+
+      await expect(
+        AndroidCtrlProxyManager.sweepStalePrefetchDirsOnStartup(missing, sweepTimer)
+      ).resolves.toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

The daemon leaks `auto-mobile-prefetch-*` scratch directories, growing the
runtime dir without bound until the host runs out of disk (observed: **731 dirs
/ ~17 GB** on a long-running host). Root cause: `AndroidCtrlProxyManager.doPrefetch()`
intentionally *retains* its `os.tmpdir()/auto-mobile-prefetch-<rand>/` dir on
success as the reusable APK cache, and it is removed only by
`cleanupPrefetchedApk()` in the graceful-shutdown handler. Any daemon/client
process that is `SIGKILL`ed or crashes before that handler runs leaks one dir
(~20+ MB) per lifecycle.

This adds `AndroidCtrlProxyManager.sweepStalePrefetchDirsOnStartup()`, a
best-effort startup reclaim that mirrors the existing
`IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup()` pattern. It removes
`auto-mobile-prefetch-*` dirs (including the `-upgrade-` variant) older than 60
minutes — matching the `-mmin +60` in-flight guard from the issue's workaround —
and leaves sibling caches (`bunx-*`, `automobile-bun-cache-shared`, the installed
package) untouched. It is wired into daemon startup and runs even when downloads
are disabled, so previously-leaked dirs are still reclaimed. The success-path
retention is deliberately kept (it is the intended cross-device cache); per-op
cleanup on graceful shutdown already exists.

## Linked Issue

Closes #4334

## Bug / Regression Context

- **Prior attempts:** none — the shutdown-only `cleanupPrefetchedApk()` never covered crash/kill exits.
- **Observed symptom:** `<runtime-dir>/auto-mobile-prefetch-*` accumulate one-per-process-lifecycle, unbounded; disk fills silently.
- **Repro steps / conditions:** run `--daemon-mode` across many sessions/crashes; `ls -1d <runtime-dir>/auto-mobile-prefetch-* | wc -l` and `du -sh` grow without bound.

## Validation

- [x] `bun run lint` passes (ratchet boundary checks green)
- [x] `bun test` — full suite green (8989 pass, 0 fail)
- [x] `bun run typecheck` — no new errors attributable to this diff. One pre-existing local `node_modules` ajv/ajv-formats dedup artifact surfaces in `src/utils/plan/PlanSchemaValidator.ts` (a file this PR does not touch; neither changed file imports ajv). This is the documented merge-commit false-positive class; main's gate is green on CI's clean install.
- [x] New code uses interface + fake + FakeTimer; the 5 new unit tests run in ~120ms
- [x] New code reuses the standard library (`fs/promises`) and existing `Timer` seam — no new dependency
- [x] Rebased onto latest `main`

## Testing

New unit tests in `test/utils/CtrlProxyManager.test.ts` (`sweepStalePrefetchDirsOnStartup`), using a scratch temp root + `fs.utimes` aging + `FakeTimer` for deterministic "now":

- removes stale `auto-mobile-prefetch-*` dirs older than the 60-minute threshold
- also removes stale `auto-mobile-prefetch-upgrade-*` dirs
- preserves fresh prefetch dirs within the threshold (in-flight guard)
- preserves sibling caches (`bunx-*`, `automobile-bun-cache-shared`) even when old
- best-effort: a missing temp root does not throw

## Acceptance criteria (inferred from the issue's "Expected behavior")

| # | Criterion | Status |
|---|-----------|--------|
| 1 | Stale prefetch dirs from previous runs are swept on startup | ✅ sweep + wiring |
| 2 | Only dirs older than a 60-min safety threshold are removed (in-flight safe) | ✅ mtime + threshold test |
| 3 | Only `auto-mobile-prefetch-*` (incl. `-upgrade-`) dirs touched; sibling caches preserved | ✅ prefix guard test |
| 4 | Best-effort: failures logged, never abort startup | ✅ missing-root test |
| 5 | Wired into daemon startup | ✅ `src/index.ts` |
