### PR TITLE
fix(observe): make GetBackStack parser CRLF-tolerant (#4333)

### DIFF
--- a/src/features/observe/GetBackStack.ts
+++ b/src/features/observe/GetBackStack.ts
@@ -184,7 +184,7 @@ export class GetBackStack implements BackStack {
    */
   private parseActivities(dumpsysOutput: string): ActivityInfo[] {
     const activities: ActivityInfo[] = [];
-    const lines = dumpsysOutput.split("\n");
+    const lines = dumpsysOutput.split(/\r?\n/);
 
     let currentTaskId = -1;
     let currentTaskAffinity: string | undefined;
@@ -249,7 +249,7 @@ export class GetBackStack implements BackStack {
    */
   private parseTasks(dumpsysOutput: string): TaskInfo[] {
     const tasks: Map<number, TaskInfo> = new Map();
-    const lines = dumpsysOutput.split("\n");
+    const lines = dumpsysOutput.split(/\r?\n/);
 
     let currentTaskId = -1;
     let currentTask: Partial<TaskInfo> = {};
@@ -380,7 +380,7 @@ export class GetBackStack implements BackStack {
    * @returns Current ActivityInfo or undefined
    */
   private getCurrentActivity(dumpsysOutput: string): ActivityInfo | undefined {
-    const lines = dumpsysOutput.split("\n");
+    const lines = dumpsysOutput.split(/\r?\n/);
 
     for (const line of lines) {
       // Match mResumedActivity or mFocusedActivity

--- a/test/features/observe/GetBackStackCrlf.test.ts
+++ b/test/features/observe/GetBackStackCrlf.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "fs";
+import * as path from "path";
+import { GetBackStack } from "../../../src/features/observe/GetBackStack";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
+import { BackStackInfo, BootedDevice } from "../../../src/models";
+
+/**
+ * `GetBackStack` must parse CRLF `dumpsys activity activities` output the same
+ * as LF (issue #4333).
+ *
+ * The parser splits on `\n` and matches each line with regexes anchored on
+ * `(.*)$` / `$` (e.g. `MODERN_TASK_HEADER`). With CRLF input every line keeps a
+ * trailing `\r`, which those anchors reject, so the parser silently returns
+ * ZERO tasks and degrades to `partial: true`. A Windows `adb.exe shell` whose
+ * shell-protocol layer performs CRLF translation emits exactly this at runtime.
+ *
+ * Deferred from PR #4332, which worked around it test-side (fixture
+ * `\r\n`->`\n` normalization + `.gitattributes eol=lf`) without making the
+ * production parser CRLF-tolerant. This suite pins the parser itself: it feeds a
+ * REAL capture as both LF and CRLF and asserts identical, non-empty results.
+ */
+
+const CAPTURE_DIR = path.join(__dirname, "activityActivitiesDumps");
+const device: BootedDevice = { name: "test", platform: "android", deviceId: "test-device" };
+
+function readCaptureLf(file: string): string {
+  // Normalize any incidental CRLF from the checkout to LF so the CRLF variant
+  // below is the ONLY carriage-return source under test.
+  return fs.readFileSync(path.join(CAPTURE_DIR, file), "utf8").replace(/\r\n/g, "\n");
+}
+
+async function parse(stdout: string): Promise<BackStackInfo> {
+  const adb = new FakeAdbExecutor();
+  adb.setCommandResponse("dumpsys activity activities", { stdout, stderr: "" });
+  return new GetBackStack(device, new FakeAdbClientFactory(adb)).execute();
+}
+
+// Every real capture, so the tolerance is proven across all supported levels
+// rather than one hand-picked one.
+const CAPTURES = fs
+  .readdirSync(CAPTURE_DIR)
+  .filter(f => f.endsWith(".log"))
+  .sort();
+
+describe("GetBackStack CRLF tolerance (issue #4333)", () => {
+  test("has real captures to assert against", () => {
+    expect(CAPTURES.length).toBeGreaterThan(0);
+  });
+
+  for (const file of CAPTURES) {
+    test(`${file}: CRLF input parses identically to LF`, async () => {
+      const lf = readCaptureLf(file);
+      const crlf = lf.replace(/\n/g, "\r\n");
+
+      const lfResult = await parse(lf);
+      const crlfResult = await parse(crlf);
+
+      // The LF baseline must itself be a real, non-empty parse, otherwise the
+      // equality below would be vacuously satisfied by two empty results.
+      expect(lfResult.tasks.length).toBeGreaterThan(0);
+      expect(lfResult.activities.length).toBeGreaterThan(0);
+      expect(lfResult.partial).toBeUndefined();
+
+      // CRLF must produce the SAME structured result -- this is the failure the
+      // issue reproduces: CRLF -> 0 tasks today.
+      expect(crlfResult.tasks.length).toBe(lfResult.tasks.length);
+      expect(crlfResult.activities.length).toBe(lfResult.activities.length);
+      expect(crlfResult.tasks).toEqual(lfResult.tasks);
+      expect(crlfResult.activities).toEqual(lfResult.activities);
+      expect(crlfResult.currentActivity).toEqual(lfResult.currentActivity);
+      expect(crlfResult.currentTaskId).toBe(lfResult.currentTaskId);
+      expect(crlfResult.depth).toBe(lfResult.depth);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

`GetBackStack` parses `dumpsys activity activities` by splitting on `"\n"` and matching each line with regexes anchored on `(.*)$` / `$` (e.g. `MODERN_TASK_HEADER`, `LEGACY_TASK_HEADER`). With CRLF input every line keeps a trailing `\r`, which those anchors reject, so the parser silently returns **zero tasks** and degrades to `partial: true` — no error surfaced.

The fix splits on `/\r?\n/` in all three parse methods (`parseActivities`, `parseTasks`, `getCurrentActivity`), so a trailing `\r` never reaches the line regexes.

## Linked Issue

Closes [#4333](https://github.com/kaeawc/auto-mobile/issues/4333)

## Bug / Regression Context

- **Prior attempts:** [PR #4332](https://github.com/kaeawc/auto-mobile/pull/4332) (issue [#4329](https://github.com/kaeawc/auto-mobile/issues/4329)) worked around this **test-side** — `\r\n`→`\n` fixture normalization plus a `.gitattributes eol=lf` pin — but left the production parser CRLF-intolerant. This PR fixes the parser itself.
- **Observed symptom:** On the `windows-latest` CI leg, git's `core.autocrlf` rewrote committed LF fixtures to CRLF and the entire new suite parsed 0 tasks. Reproduced directly: LF → 8 tasks, CRLF → **0 tasks**, CRLF-normalized-to-LF → 8 tasks.
- **Repro steps / conditions:** A Windows `adb.exe shell` whose shell-protocol layer performs CRLF translation emits CRLF `dumpsys` output, producing an empty back stack at runtime with no error.

## Validation

- [x] `bun test test/features/observe/` — 1223 pass, 0 fail
- [x] `bun run typecheck` reports no new errors from this change (the one gate error, `PlanSchemaValidator.ts` TS2345, is a pre-existing nested-ajv dependency-drift issue that reproduces without this diff)
- [x] New test uses the existing `FakeAdbExecutor`/`FakeAdbClientFactory` fakes; unit tests run in <100ms each
- [x] Reuses the existing real-capture fixtures — no new dependency

## Testing

New `test/features/observe/GetBackStackCrlf.test.ts` feeds **every** real `activity activities` capture (API 24–36) as both LF and CRLF and asserts identical, non-empty results. Before the fix, the CRLF variant parsed 0 tasks (red confirmed); after, all 14 cases pass.

## Follow-ups

None — scope is limited to parser CRLF tolerance as the issue specifies.
