### PR TITLE
perf(webrtc): stop upscaling iOS capture and add a streaming fps seam

### DIFF
--- a/docs/design-docs/mcp/observe/webrtc-streaming.md
+++ b/docs/design-docs/mcp/observe/webrtc-streaming.md
@@ -209,7 +209,7 @@ Newline-delimited JSON request/response.
 | `AUTOMOBILE_WEBRTC_ICE_SERVERS` | Comma-separated STUN/TURN URLs, or a JSON array of `{urls,username,credential}` |
 | `AUTOMOBILE_WEBRTC_BITRATE_KBPS` | Target encoder bitrate |
 | `AUTOMOBILE_WEBRTC_MAX_SIZE` | Capture downscale, `WIDTHxHEIGHT` |
-| `AUTOMOBILE_WEBRTC_IOS_SIMULATOR_FPS` | iOS Simulator capture rate, integer in `[5, 60]` (default `15`) |
+| `AUTOMOBILE_WEBRTC_IOS_SIMULATOR_FPS` | iOS Simulator capture rate, integer in `[5, 60]` (default `15`; `iosSimulatorFps` per request) |
 | `AUTOMOBILE_WEBRTC_AUDIO` | Enable optional audio (`audio: true` per request). Android requires the persistent `video-server` jar; iOS supports Simulator-window audio only. |
 
 Per-request fields override the environment defaults.

--- a/docs/design-docs/mcp/observe/webrtc-streaming.md
+++ b/docs/design-docs/mcp/observe/webrtc-streaming.md
@@ -209,6 +209,7 @@ Newline-delimited JSON request/response.
 | `AUTOMOBILE_WEBRTC_ICE_SERVERS` | Comma-separated STUN/TURN URLs, or a JSON array of `{urls,username,credential}` |
 | `AUTOMOBILE_WEBRTC_BITRATE_KBPS` | Target encoder bitrate |
 | `AUTOMOBILE_WEBRTC_MAX_SIZE` | Capture downscale, `WIDTHxHEIGHT` |
+| `AUTOMOBILE_WEBRTC_IOS_SIMULATOR_FPS` | iOS Simulator capture rate, integer in `[5, 60]` (default `15`) |
 | `AUTOMOBILE_WEBRTC_AUDIO` | Enable optional audio (`audio: true` per request). Android requires the persistent `video-server` jar; iOS supports Simulator-window audio only. |
 
 Per-request fields override the environment defaults.

--- a/docs/using/environment-variables.md
+++ b/docs/using/environment-variables.md
@@ -114,6 +114,7 @@ overridden per request on the `webrtc-stream.sock` control socket.
 | `AUTOMOBILE_WEBRTC_ICE_SERVERS` | Comma-separated STUN/TURN URLs, or a JSON array of `{urls,username,credential}`. | `stun:stun.l.google.com:19302` |
 | `AUTOMOBILE_WEBRTC_BITRATE_KBPS` | Target encoder bitrate (kbps). | encoder default |
 | `AUTOMOBILE_WEBRTC_MAX_SIZE` | Capture downscale as `WIDTHxHEIGHT` (e.g. `720x1280`). | native |
+| `AUTOMOBILE_WEBRTC_IOS_SIMULATOR_FPS` | iOS Simulator WebRTC capture rate. Integer in `[5, 60]`; values outside the range are rejected at stream start. Separate from the generic screen-capture rate used for MCP observation. | `15` |
 | `AUTOMOBILE_VIDEO_SERVER_JAR` | Explicit path to a built `automobile-video.jar` (persistent on-device encoder). Highest resolution precedence: when set it is used directly, ahead of the cached/downloaded release jar and the Gradle build output. | (resolution precedence, see below) |
 | `AUTOMOBILE_REQUIRE_VIDEO_SERVER` | When `1`/`true`, a degrade-to-`screenrecord` case (no verifiable jar available) becomes a hard `ActionableError` instead. For CI that must run the persistent encoder. A checksum **mismatch** is always fatal regardless of this flag. | unset |
 | `AUTOMOBILE_SKIP_VIDEO_SERVER_DOWNLOAD` | When `1`/`true`, never fetch the jar from the network: resolve from the local override or Gradle build output only. Dedicated flag — **not** `AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD` (the CtrlProxy APK is mandatory; the jar is optional and degrades). | unset |

--- a/docs/webrtc-streaming-ci-worker.md
+++ b/docs/webrtc-streaming-ci-worker.md
@@ -63,6 +63,7 @@ export AUTOMOBILE_WEBRTC_ICE_SERVERS="stun:stun.l.google.com:19302"
 # Optional tuning:
 export AUTOMOBILE_WEBRTC_BITRATE_KBPS="4000"
 export AUTOMOBILE_WEBRTC_MAX_SIZE="720x1280"
+export AUTOMOBILE_WEBRTC_IOS_SIMULATOR_FPS="15"   # iOS Simulator capture rate, 5-60
 # Optional audio: Android requires a video-server jar; iOS requires Simulator-window capture.
 export AUTOMOBILE_WEBRTC_AUDIO="1"
 ```

--- a/src/daemon/videoStreamSocketServer.ts
+++ b/src/daemon/videoStreamSocketServer.ts
@@ -26,6 +26,8 @@ export type CaptureSourceFactory = (options: {
   onError: (error: Error) => void;
   bitrateBps?: number;
   size?: { width: number; height: number };
+  /** Capture rate for iOS Simulator sources; see the call site for why it is pinned. */
+  fps?: number;
 }) => Promise<H264CaptureSource>;
 
 export interface VideoStreamSocketServerDependencies {

--- a/src/daemon/videoStreamSocketServer.ts
+++ b/src/daemon/videoStreamSocketServer.ts
@@ -5,6 +5,7 @@ import { ActionableError } from "../models";
 import { DeviceSessionManager } from "../utils/DeviceSessionManager";
 import { createH264CaptureSource } from "../features/webrtc/h264CaptureSourceFactory";
 import { resolveVideoServerJar } from "../features/webrtc/videoServerJar";
+import { SIMULATOR_FPS_DEFAULT } from "../features/screen-stream/IOSScreenCaptureHelper";
 import type { BootedDevice } from "../models";
 import { Timer, defaultTimer } from "../utils/SystemTimer";
 import type { H264CaptureSource } from "../features/webrtc/H264CaptureSource";
@@ -207,6 +208,11 @@ export class VideoStreamSocketServer extends BaseSocketServer {
         },
         bitrateBps: request.bitrateKbps ? request.bitrateKbps * 1000 : undefined,
         size: request.size,
+        // Pin the observation rate explicitly. This relay borrows the WebRTC
+        // capture sources, so without this it would silently inherit whatever
+        // the *WebRTC* iOS Simulator default happens to be — a knob that is
+        // tuned for an interactive WHEP feed and is not configurable here.
+        fps: SIMULATOR_FPS_DEFAULT,
       });
       // The final subscriber may disconnect while source construction is in
       // flight. Do not attach an unreachable capture process to a removed entry.

--- a/src/daemon/webrtcStreamSocketServer.ts
+++ b/src/daemon/webrtcStreamSocketServer.ts
@@ -165,6 +165,9 @@ export class WebRtcStreamSocketServer extends RequestResponseSocketServer<
     if (request.size) {
       overrides.size = request.size;
     }
+    if (request.iosSimulatorFps !== undefined) {
+      overrides.iosSimulatorFps = request.iosSimulatorFps;
+    }
     if (request.audio !== undefined) {
       overrides.audioEnabled = request.audio;
     }

--- a/src/daemon/webrtcStreamSocketTypes.ts
+++ b/src/daemon/webrtcStreamSocketTypes.ts
@@ -26,6 +26,8 @@ export interface WebRtcStreamSocketRequest extends SocketRequest {
   iceServers?: WebRtcIceServerInput[];
   bitrateKbps?: number;
   size?: { width: number; height: number };
+  /** iOS Simulator capture rate; integer in the range documented by the seam. */
+  iosSimulatorFps?: number;
   /** Enable optional audio capture/publishing. */
   audio?: boolean;
 }

--- a/src/features/webrtc/H264CaptureSource.ts
+++ b/src/features/webrtc/H264CaptureSource.ts
@@ -10,6 +10,12 @@ export interface H264CaptureSourceOptions {
   onError?: (error: Error) => void;
   bitrateBps?: number;
   size?: { width: number; height: number };
+  /**
+   * Capture frame rate requested from the source. Only the iOS Simulator source
+   * honours it — Android and physical-iOS capture at their own device rate — so
+   * it carries `WebRtcStreamingConfig.iosSimulatorFps`.
+   */
+  fps?: number;
   audioEnabled?: boolean;
 }
 

--- a/src/features/webrtc/H264CaptureSource.ts
+++ b/src/features/webrtc/H264CaptureSource.ts
@@ -11,9 +11,12 @@ export interface H264CaptureSourceOptions {
   bitrateBps?: number;
   size?: { width: number; height: number };
   /**
-   * Capture frame rate requested from the source. Only the iOS Simulator source
-   * honours it — Android and physical-iOS capture at their own device rate — so
-   * it carries `WebRtcStreamingConfig.iosSimulatorFps`.
+   * Capture frame rate, carrying `WebRtcStreamingConfig.iosSimulatorFps`.
+   *
+   * Only the iOS Simulator source uses it to *request* a capture rate. Android
+   * ignores it entirely, and physical iOS captures at its own AVFoundation rate
+   * — but on both iOS paths it still sets ffmpeg's declared rawvideo input rate
+   * and therefore the GOP length, so it is not inert there.
    */
   fps?: number;
   audioEnabled?: boolean;

--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -2,10 +2,7 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import type { Readable, Writable } from "node:stream";
 import { ActionableError, type BootedDevice } from "../../models";
-import {
-  IOSScreenCaptureHelper,
-  SIMULATOR_FPS_DEFAULT,
-} from "../screen-stream/IOSScreenCaptureHelper";
+import { IOSScreenCaptureHelper } from "../screen-stream/IOSScreenCaptureHelper";
 import type {
   CaptureTarget,
   DecodedAudio,
@@ -23,16 +20,22 @@ import {
 } from "../../utils/media/FfmpegClient";
 import { defaultTimer, type Timer } from "../../utils/SystemTimer";
 import type { H264CaptureSource, H264CaptureSourceOptions } from "./H264CaptureSource";
+import { h264MacroblocksPerFrame, WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME } from "./h264Level";
+import { WEBRTC_IOS_SIMULATOR_FPS_DEFAULT } from "./webrtcStreamingConfig";
 
 export const IOS_SCREEN_CAPTURE_HELPER_ENV = "AUTOMOBILE_IOS_SCREEN_CAPTURE_HELPER";
 export const IOS_SCREEN_CAPTURE_HELPER_ENV_ALIAS = "AUTO_MOBILE_IOS_SCREEN_CAPTURE_HELPER";
 export const IOS_WEBRTC_FFMPEG_ENV = "AUTOMOBILE_IOS_WEBRTC_FFMPEG";
 export const IOS_WEBRTC_FFMPEG_ENV_ALIAS = "AUTO_MOBILE_IOS_WEBRTC_FFMPEG";
-const DEFAULT_IOS_WEBRTC_FPS = SIMULATOR_FPS_DEFAULT;
+const DEFAULT_IOS_WEBRTC_FPS = WEBRTC_IOS_SIMULATOR_FPS_DEFAULT;
 const DEFAULT_FIRST_FRAME_TIMEOUT_MS = 15_000;
 const NO_FRAMES_PERMISSION_WARNING = "warn: no frames received";
 /** Target seconds between IDRs in the ffmpeg GOP (see buildFfmpegArgs). */
 const IOS_KEYFRAME_INTERVAL_SECONDS = 2;
+/** H.264 macroblock edge, in pixels. */
+const H264_MACROBLOCK_SIZE = 16;
+/** Smallest dimension ffmpeg can encode as 4:2:0 chroma-subsampled video. */
+const MIN_ENCODER_DIMENSION = 2;
 
 export interface IosFrameCaptureHelper {
   start(): void;
@@ -91,7 +94,6 @@ const defaultCommandRunner: CommandRunner = (command, args) =>
 export interface IosH264SourceOptions extends H264CaptureSourceOptions {
   helperPath?: string;
   ffmpegPath?: string;
-  fps?: number;
   createHelper?: IosFrameCaptureHelperFactory;
   spawner?: IosH264EncoderSpawner;
   simulatorWindowResolver?: IosSimulatorWindowResolver;
@@ -109,7 +111,7 @@ interface SimulatorWindowInfo {
   bundleIdentifier?: string;
 }
 
-interface EncoderSize {
+export interface EncoderSize {
   width: number;
   height: number;
 }
@@ -465,13 +467,12 @@ export class IosH264Source implements H264CaptureSource {
       "-i",
       "pipe:0",
     ];
-    if (this.options.size) {
-      args.push("-vf", `scale=${this.options.size.width}:${this.options.size.height}`);
-    } else {
-      // Keep an unconstrained macOS capture inside the Level 4.2 capability
-      // advertised in the WHIP SDP. Explicit sizes are validated before source
-      // creation by webrtcStreamingConfig.
-      args.push("-vf", "scale=1920:1080:force_original_aspect_ratio=decrease:force_divisible_by=2");
+    // Explicit sizes are validated before source creation by
+    // webrtcStreamingConfig; otherwise keep the capture native unless it has to
+    // shrink to stay inside the Level 4.2 capability advertised in the WHIP SDP.
+    const scale = this.options.size ?? resolveIosEncoderScale(size);
+    if (scale) {
+      args.push("-vf", `scale=${scale.width}:${scale.height}`);
     }
     args.push(
       "-an",
@@ -556,8 +557,58 @@ export class IosH264Source implements H264CaptureSource {
 
 function describeCaptureTarget(target: CaptureTarget): string {
   return target.kind === "simulator"
-    ? `iOS Simulator window ${target.windowID} at ${target.fps ?? SIMULATOR_FPS_DEFAULT} fps`
+    ? `iOS Simulator window ${target.windowID} at ${target.fps ?? DEFAULT_IOS_WEBRTC_FPS} fps`
     : `iOS device ${target.deviceId ?? "default"}`;
+}
+
+function evenFloor(value: number): number {
+  return Math.max(MIN_ENCODER_DIMENSION, Math.floor(value / 2) * 2);
+}
+
+/**
+ * Resolve the ffmpeg output size for a captured frame, or `null` when the frame
+ * can be encoded at its native size.
+ *
+ * A Simulator window is routinely far smaller than 1920x1080, so scaling every
+ * capture toward that box spent encoder time inventing pixels the WHEP viewer
+ * gained no detail from. Instead this only ever scales *down*: native dimensions
+ * are kept whenever they are even and already inside the Level 4.2 macroblock
+ * budget advertised in the WHIP SDP, odd dimensions round down to even (ffmpeg's
+ * 4:2:0 chroma subsampling cannot encode an odd edge), and an oversized capture
+ * shrinks just far enough to fit the budget with its aspect ratio intact.
+ */
+export function resolveIosEncoderScale(size: EncoderSize): EncoderSize | null {
+  const { width, height } = size;
+  if (h264MacroblocksPerFrame(width, height) <= WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME) {
+    const even = { width: evenFloor(width), height: evenFloor(height) };
+    return even.width === width && even.height === height ? null : even;
+  }
+
+  // Shrink the macroblock grid rather than the pixel dimensions: flooring both
+  // axes of an area-preserving scale keeps `columns * rows` inside the budget by
+  // construction, so no iterative search (and no risk of overshoot) is needed.
+  const columns = Math.ceil(width / H264_MACROBLOCK_SIZE);
+  const rows = Math.ceil(height / H264_MACROBLOCK_SIZE);
+  const factor = Math.sqrt(WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME / (columns * rows));
+  const targetRows = clampMacroblockAxis(Math.floor(rows * factor));
+  const targetColumns = clampMacroblockAxis(
+    // An extreme aspect ratio can floor one axis to the 1-macroblock clamp, which
+    // would otherwise let the product escape the budget; re-cap the other axis.
+    Math.min(
+      Math.floor(columns * factor),
+      Math.floor(WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME / targetRows)
+    )
+  );
+
+  const scale = Math.min(
+    (targetColumns * H264_MACROBLOCK_SIZE) / width,
+    (targetRows * H264_MACROBLOCK_SIZE) / height
+  );
+  return { width: evenFloor(width * scale), height: evenFloor(height * scale) };
+}
+
+function clampMacroblockAxis(value: number): number {
+  return Math.min(WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME, Math.max(1, value));
 }
 
 function makeNoFramesError(target: CaptureTarget): ActionableError {

--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -489,11 +489,17 @@ export class IosH264Source implements H264CaptureSource {
       "4.2",
       "-bf",
       "0",
-      // Cap the keyframe interval at ~2s. ffmpeg cannot be signalled to emit an
-      // IDR mid-stream over a pipe (so there is no requestKeyFrame() for this
-      // source), so a bounded GOP is what lets a late or recovering WHEP viewer
-      // decode promptly instead of waiting for a long default GOP. The h264
-      // muxer prepends SPS/PPS to each keyframe, so every IDR is self-decodable.
+      // Cap the keyframe interval at ~2s of *declared* rate. ffmpeg cannot be
+      // signalled to emit an IDR mid-stream over a pipe, so this source has no
+      // requestKeyFrame() and a bounded GOP is the only thing that lets a late
+      // or recovering WHEP viewer decode promptly. The h264 muxer prepends
+      // SPS/PPS to each keyframe, so every IDR is self-decodable.
+      //
+      // -g counts encoded frames, not seconds, and the helper delivers fewer
+      // than `fps` whenever the screen is static (SimulatorCaptureSession drops
+      // every non-.complete ScreenCaptureKit status) or the host is saturated.
+      // The wall-clock interval is therefore `-g / delivered_fps`, which only
+      // equals 2s when delivery keeps up with the request.
       "-g",
       String(Math.max(1, Math.round(this.fps * IOS_KEYFRAME_INTERVAL_SECONDS))),
       "-forced-idr",
@@ -571,11 +577,16 @@ function evenFloor(value: number): number {
  *
  * A Simulator window is routinely far smaller than 1920x1080, so scaling every
  * capture toward that box spent encoder time inventing pixels the WHEP viewer
- * gained no detail from. Instead this only ever scales *down*: native dimensions
- * are kept whenever they are even and already inside the Level 4.2 macroblock
- * budget advertised in the WHIP SDP, odd dimensions round down to even (ffmpeg's
- * 4:2:0 chroma subsampling cannot encode an odd edge), and an oversized capture
- * shrinks just far enough to fit the budget with its aspect ratio intact.
+ * gained no detail from. Instead this scales down or not at all: native
+ * dimensions are kept whenever they are even and already inside the Level 4.2
+ * macroblock budget advertised in the WHIP SDP, odd dimensions round down to
+ * even (ffmpeg's 4:2:0 chroma subsampling cannot encode an odd edge), and an
+ * oversized capture shrinks just far enough to fit the budget with its aspect
+ * ratio intact.
+ *
+ * The single exception is the `MIN_ENCODER_DIMENSION` floor: an axis of 0 or 1
+ * pixel is raised to 2, because 4:2:0 has no smaller legal edge. No real capture
+ * produces such a frame.
  */
 export function resolveIosEncoderScale(size: EncoderSize): EncoderSize | null {
   const { width, height } = size;

--- a/src/features/webrtc/webrtcStreamingConfig.ts
+++ b/src/features/webrtc/webrtcStreamingConfig.ts
@@ -1,6 +1,26 @@
 import { ActionableError } from "../../models";
 import type { RTCIceServer } from "werift";
 import { h264MacroblocksPerFrame, WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME } from "./h264Level";
+import { SIMULATOR_FPS_MAX, SIMULATOR_FPS_MIN } from "../screen-stream/IOSScreenCaptureHelper";
+
+/**
+ * Safe range for the iOS Simulator WebRTC capture rate. These mirror the
+ * screen-capture helper's own bounds so a configured value can never be
+ * rejected downstream by the helper's argv validation.
+ */
+export const WEBRTC_IOS_SIMULATOR_FPS_MIN = SIMULATOR_FPS_MIN;
+export const WEBRTC_IOS_SIMULATOR_FPS_MAX = SIMULATOR_FPS_MAX;
+/**
+ * Conservative default for an interactive WebRTC feed, deliberately separate
+ * from `SIMULATOR_FPS_DEFAULT` (which is tuned for one-shot MCP observation,
+ * where 5 fps is plenty). 15 fps is smooth enough to follow a gesture or an
+ * animation while leaving headroom on a hosted macOS runner, where the Simulator
+ * processes and VideoToolbox share one CPU/encoder budget and `-allow_sw` may
+ * put the encoder in software. 30/60 leaves no such margin. Raise it per-worker
+ * with `AUTOMOBILE_WEBRTC_IOS_SIMULATOR_FPS` once the hosted-lane decode and
+ * first-frame timings show the host can afford it.
+ */
+export const WEBRTC_IOS_SIMULATOR_FPS_DEFAULT = 15;
 
 /**
  * WebRTC streaming configuration. On a CI worker this is typically supplied
@@ -19,6 +39,12 @@ export interface WebRtcStreamingConfig {
   /** Optional capture downscale. */
   size?: { width: number; height: number };
   /**
+   * Frame rate requested from the iOS Simulator screen-capture helper, in
+   * `[WEBRTC_IOS_SIMULATOR_FPS_MIN, WEBRTC_IOS_SIMULATOR_FPS_MAX]`. Ignored by
+   * Android and physical-iOS sources, which capture at their own device rate.
+   */
+  iosSimulatorFps: number;
+  /**
    * Use trickle ICE: publish the WHIP offer immediately and send local
    * candidates incrementally (HTTP PATCH) instead of blocking on ICE gathering.
    * Opt-in — the ingest server must support the WHIP PATCH trickle extension.
@@ -34,6 +60,7 @@ export interface WebRtcStreamingOverrides {
   iceServers?: RTCIceServer[];
   bitrateKbps?: number;
   size?: { width: number; height: number };
+  iosSimulatorFps?: number;
   trickleIce?: boolean;
   audioEnabled?: boolean;
 }
@@ -45,6 +72,7 @@ export const WEBRTC_ENV = {
   ICE_SERVERS: "AUTOMOBILE_WEBRTC_ICE_SERVERS",
   BITRATE_KBPS: "AUTOMOBILE_WEBRTC_BITRATE_KBPS",
   MAX_SIZE: "AUTOMOBILE_WEBRTC_MAX_SIZE",
+  IOS_SIMULATOR_FPS: "AUTOMOBILE_WEBRTC_IOS_SIMULATOR_FPS",
   TRICKLE_ICE: "AUTOMOBILE_WEBRTC_TRICKLE_ICE",
   AUDIO: "AUTOMOBILE_WEBRTC_AUDIO",
 } as const;
@@ -154,6 +182,9 @@ export function resolveWebRtcStreamingConfig(
   const size = overrides.size === undefined
     ? parseSize(env[WEBRTC_ENV.MAX_SIZE])
     : validateSize(overrides.size);
+  const iosSimulatorFps = overrides.iosSimulatorFps === undefined
+    ? parseIosSimulatorFps(env[WEBRTC_ENV.IOS_SIMULATOR_FPS]) ?? WEBRTC_IOS_SIMULATOR_FPS_DEFAULT
+    : validateIosSimulatorFps(overrides.iosSimulatorFps);
   const trickleIce = overrides.trickleIce ?? parseBooleanFlag(env[WEBRTC_ENV.TRICKLE_ICE]);
   const audioEnabled = overrides.audioEnabled ?? parseBooleanFlag(env[WEBRTC_ENV.AUDIO]);
 
@@ -163,9 +194,30 @@ export function resolveWebRtcStreamingConfig(
     iceServers,
     bitrateKbps,
     size,
+    iosSimulatorFps,
     trickleIce,
     audioEnabled,
   };
+}
+
+function parseIosSimulatorFps(raw: string | undefined): number | undefined {
+  if (!raw || !raw.trim()) {
+    return undefined;
+  }
+  return validateIosSimulatorFps(Number(raw.trim()), raw.trim());
+}
+
+function validateIosSimulatorFps(value: number, raw: string = String(value)): number {
+  if (
+    !Number.isInteger(value) ||
+    value < WEBRTC_IOS_SIMULATOR_FPS_MIN ||
+    value > WEBRTC_IOS_SIMULATOR_FPS_MAX
+  ) {
+    throw new ActionableError(
+      `Invalid iOS Simulator capture fps "${raw}"; expected an integer in [${WEBRTC_IOS_SIMULATOR_FPS_MIN}, ${WEBRTC_IOS_SIMULATOR_FPS_MAX}].`
+    );
+  }
+  return value;
 }
 
 function validateBitrate(value: number): number {

--- a/src/features/webrtc/webrtcStreamingConfig.ts
+++ b/src/features/webrtc/webrtcStreamingConfig.ts
@@ -40,8 +40,9 @@ export interface WebRtcStreamingConfig {
   size?: { width: number; height: number };
   /**
    * Frame rate requested from the iOS Simulator screen-capture helper, in
-   * `[WEBRTC_IOS_SIMULATOR_FPS_MIN, WEBRTC_IOS_SIMULATOR_FPS_MAX]`. Ignored by
-   * Android and physical-iOS sources, which capture at their own device rate.
+   * `[WEBRTC_IOS_SIMULATOR_FPS_MIN, WEBRTC_IOS_SIMULATOR_FPS_MAX]`. Android
+   * ignores it; physical iOS captures at its own device rate but still takes
+   * its declared encoder input rate and GOP length from it.
    */
   iosSimulatorFps: number;
   /**
@@ -214,7 +215,7 @@ function validateIosSimulatorFps(value: number, raw: string = String(value)): nu
     value > WEBRTC_IOS_SIMULATOR_FPS_MAX
   ) {
     throw new ActionableError(
-      `Invalid iOS Simulator capture fps "${raw}"; expected an integer in [${WEBRTC_IOS_SIMULATOR_FPS_MIN}, ${WEBRTC_IOS_SIMULATOR_FPS_MAX}].`
+      `Invalid iOS Simulator capture fps "${raw}"; expected an integer in [${WEBRTC_IOS_SIMULATOR_FPS_MIN}, ${WEBRTC_IOS_SIMULATOR_FPS_MAX}]. Set ${WEBRTC_ENV.IOS_SIMULATOR_FPS} or pass iosSimulatorFps.`
     );
   }
   return value;

--- a/src/server/webrtcStreamManager.ts
+++ b/src/server/webrtcStreamManager.ts
@@ -30,6 +30,8 @@ interface WebRtcStreamRecord {
   jarPath: string | null;
   bitrateBps?: number;
   size?: { width: number; height: number };
+  /** iOS Simulator capture rate; ignored by Android and physical-iOS sources. */
+  fps: number;
   audioEnabled: boolean;
   startedAt: string;
   /** Reservation token for a start that has not returned to its caller yet. */
@@ -152,6 +154,7 @@ async function startSource(record: WebRtcStreamRecord): Promise<boolean> {
       },
       bitrateBps: record.bitrateBps,
       size: record.size,
+      fps: record.fps,
       audioEnabled: record.audioEnabled,
     },
     record.jarPath
@@ -391,6 +394,7 @@ export async function startWebRtcStream(
       jarPath,
       bitrateBps,
       size: config.size,
+      fps: config.iosSimulatorFps,
       audioEnabled: config.audioEnabled,
       startedAt: dependencies.now().toISOString(),
       startToken,

--- a/test/daemon/videoStreamSocketServer.test.ts
+++ b/test/daemon/videoStreamSocketServer.test.ts
@@ -8,6 +8,8 @@ import type { BootedDevice } from "../../src/models";
 import type { H264CaptureSource } from "../../src/features/webrtc/H264CaptureSource";
 import { VideoStreamSocketServer } from "../../src/daemon/videoStreamSocketServer";
 import { CODEC_ID_H264 } from "../../src/daemon/videoStreamFraming";
+import { SIMULATOR_FPS_DEFAULT } from "../../src/features/screen-stream/IOSScreenCaptureHelper";
+import { WEBRTC_IOS_SIMULATOR_FPS_DEFAULT } from "../../src/features/webrtc/webrtcStreamingConfig";
 
 const DEVICE: BootedDevice = {
   deviceId: "emulator-5554",
@@ -37,6 +39,7 @@ interface Harness {
   server: VideoStreamSocketServer;
   socketPath: string;
   sources: FakeCaptureSource[];
+  captureOptions: Array<{ fps?: number }>;
   emit: (chunk: Buffer) => void;
   cleanup: () => Promise<void>;
 }
@@ -50,6 +53,7 @@ async function startHarness(
   const socketPath = path.join(dir, "video-stream.sock");
   const sources: FakeCaptureSource[] = [];
   let onData: ((chunk: Buffer) => void) | null = null;
+  const captureOptions: Array<{ fps?: number }> = [];
 
   const server = new VideoStreamSocketServer(
     {
@@ -61,6 +65,7 @@ async function startHarness(
       },
       createCaptureSource: async opts => {
         onData = opts.onData;
+        captureOptions.push(opts);
         const source = new FakeCaptureSource();
         source.startError = options.startError ?? null;
         sources.push(source);
@@ -76,6 +81,7 @@ async function startHarness(
     server,
     socketPath,
     sources,
+    captureOptions,
     emit: chunk => onData?.(chunk),
     cleanup: async () => {
       await server.close();
@@ -154,6 +160,17 @@ describe("VideoStreamSocketServer", () => {
     expect(ack.type).toBe("video_stream_response");
     expect(ack.deviceId).toBe(DEVICE.deviceId);
     expect(ack.framing).toBe("h264");
+  });
+
+  test("pins the observation capture rate rather than inheriting the WebRTC default", async () => {
+    const h = await startHarness();
+
+    await subscribe(h.socketPath);
+
+    // This relay borrows the WebRTC capture sources. Leaving fps unset would
+    // silently adopt whatever the interactive WHEP default happens to be.
+    expect(h.captureOptions[0].fps).toBe(SIMULATOR_FPS_DEFAULT);
+    expect(SIMULATOR_FPS_DEFAULT).not.toBe(WEBRTC_IOS_SIMULATOR_FPS_DEFAULT);
   });
 
   test("sends the stream header immediately after the ack", async () => {

--- a/test/daemon/webrtcStreamSocketServer.test.ts
+++ b/test/daemon/webrtcStreamSocketServer.test.ts
@@ -166,6 +166,20 @@ describe("WebRtcStreamSocketServer", () => {
     expect(response.streams?.map(s => s.streamId).sort()).toEqual(["s1", "s2"]);
   });
 
+  test("start forwards the iOS Simulator fps override into the streaming config", async () => {
+    const server = new TestableServer(makeDeps());
+    const socket = new FakeSocket();
+
+    await server.simulate(socket, {
+      id: "start",
+      action: "start",
+      streamId: "fps-1",
+      iosSimulatorFps: 24,
+    });
+
+    expect(started[0].overrides).toEqual({ iosSimulatorFps: 24 });
+  });
+
   test("start forwards WHIP endpoint and stream stays visible until stop", async () => {
     const server = new TestableServer(makeDeps());
     const socket = new FakeSocket();

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -12,9 +12,15 @@ import {
   IOS_WEBRTC_FFMPEG_ENV,
   IOS_WEBRTC_FFMPEG_ENV_ALIAS,
   IosH264Source,
+  resolveIosEncoderScale,
   resolveIosScreenCaptureHelperPath,
   type IosFrameCaptureHelper,
 } from "../../../src/features/webrtc/IosH264Source";
+import {
+  WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME,
+  h264MacroblocksPerFrame,
+} from "../../../src/features/webrtc/h264Level";
+import { WEBRTC_IOS_SIMULATOR_FPS_DEFAULT } from "../../../src/features/webrtc/webrtcStreamingConfig";
 import type { CaptureTarget, DecodedFrame } from "../../../src/features/screen-stream";
 
 const IOS_DEVICE: BootedDevice = {
@@ -195,22 +201,65 @@ describe("IosH264Source", () => {
   test("captures a physical device, encodes BGRA frames, and forwards Annex-B output", async () => {
     const { source, helper, encoder, helperTargets, encoderSpawns, chunks } = createHarness();
 
-    await startWithFrame(source, helper, frame(2, 1, 0x44));
+    await startWithFrame(source, helper, frame(2, 2, 0x44));
     encoder.stdout.push(Buffer.from([0, 0, 0, 1, 0x65]));
     await flush();
 
     expect(helper.started).toBe(true);
     expect(helperTargets).toEqual([{ kind: "device", deviceId: IOS_DEVICE.deviceId }]);
     expect(encoderSpawns[0].command).toBe("ffmpeg");
-    expect(encoderSpawns[0].args).toContain("2x1");
+    expect(encoderSpawns[0].args).toContain("2x2");
     expect(encoderSpawns[0].args).toContain("-level:v");
     expect(encoderSpawns[0].args).toContain("4.2");
     const allowSoftwareIndex = encoderSpawns[0].args.indexOf("-allow_sw");
     expect(allowSoftwareIndex).toBeGreaterThanOrEqual(0);
     expect(encoderSpawns[0].args[allowSoftwareIndex + 1]).toBe("1");
-    expect(encoderSpawns[0].args).toContain("scale=1920:1080:force_original_aspect_ratio=decrease:force_divisible_by=2");
-    expect(encoder.getStdinData()).toEqual(Buffer.alloc(8, 0x44));
+    expect(encoder.getStdinData()).toEqual(Buffer.alloc(16, 0x44));
     expect(chunks).toEqual([Buffer.from([0, 0, 0, 1, 0x65])]);
+  });
+
+  test("encodes a Simulator-sized capture natively instead of upscaling toward 1920x1080", async () => {
+    const { source, helper, encoderSpawns } = createHarness(IOS_SIMULATOR);
+
+    await startWithFrame(source, helper, frame(750, 1334, 0x11));
+
+    expect(encoderSpawns[0].args).toContain("750x1334");
+    // No scale filter at all: the frame is already even and inside the Level 4.2
+    // macroblock budget, so upscaling would only cost encoder time.
+    expect(encoderSpawns[0].args).not.toContain("-vf");
+    expect(encoderSpawns[0].args.some(arg => arg.startsWith("scale="))).toBe(false);
+  });
+
+  test("downscales an oversized capture into the Level 4.2 macroblock budget", async () => {
+    const { source, helper, encoderSpawns } = createHarness(IOS_SIMULATOR);
+
+    await startWithFrame(source, helper, frame(3840, 2160, 0x11));
+
+    const filterIndex = encoderSpawns[0].args.indexOf("-vf");
+    expect(filterIndex).toBeGreaterThanOrEqual(0);
+    const filter = encoderSpawns[0].args[filterIndex + 1];
+    const match = /^scale=(\d+):(\d+)$/.exec(filter);
+    expect(match).not.toBeNull();
+    const width = Number(match![1]);
+    const height = Number(match![2]);
+    expect(width).toBeLessThan(3840);
+    expect(height).toBeLessThan(2160);
+    expect(width % 2).toBe(0);
+    expect(height % 2).toBe(0);
+    expect(h264MacroblocksPerFrame(width, height)).toBeLessThanOrEqual(
+      WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME
+    );
+    // 16:9 in, 16:9 out (within one even-pixel rounding step).
+    expect(Math.abs(width / height - 3840 / 2160)).toBeLessThan(0.02);
+  });
+
+  test("rounds an odd capture down to even dimensions ffmpeg can encode", async () => {
+    const { source, helper, encoderSpawns } = createHarness(IOS_SIMULATOR);
+
+    await startWithFrame(source, helper, frame(801, 601, 0x11));
+
+    expect(encoderSpawns[0].args).toContain("-vf");
+    expect(encoderSpawns[0].args).toContain("scale=800:600");
   });
 
   test("resolves simulator window ids before starting simulator capture", async () => {
@@ -218,7 +267,9 @@ describe("IosH264Source", () => {
 
     await startWithFrame(source, helper, frame(1, 1, 0x11));
 
-    expect(helperTargets).toEqual([{ kind: "simulator", windowID: 42, fps: 5 }]);
+    expect(helperTargets).toEqual([
+      { kind: "simulator", windowID: 42, fps: WEBRTC_IOS_SIMULATOR_FPS_DEFAULT },
+    ]);
   });
 
   test("requests simulator audio and forwards its PCM16LE chunks unchanged", async () => {
@@ -234,7 +285,9 @@ describe("IosH264Source", () => {
     helper.emit("audio", { pcm16le: Buffer.from([0x34, 0x12]) });
     await started;
 
-    expect(helperTargets).toEqual([{ kind: "simulator", windowID: 42, fps: 5, audio: true }]);
+    expect(helperTargets).toEqual([
+      { kind: "simulator", windowID: 42, fps: WEBRTC_IOS_SIMULATOR_FPS_DEFAULT, audio: true },
+    ]);
     expect(audio).toEqual([Buffer.from([0x34, 0x12])]);
   });
 
@@ -327,6 +380,22 @@ describe("IosH264Source", () => {
     expect(gopIndex).toBeGreaterThanOrEqual(0);
     expect(encoderSpawns[0].args[gopIndex + 1]).toBe("30");
     expect(encoderSpawns[0].args).toContain("-forced-idr");
+  });
+
+  test("keeps the two-second IDR cadence at the default streaming fps", async () => {
+    const { source, helper, encoderSpawns } = createHarness(IOS_SIMULATOR);
+
+    await startWithFrame(source, helper, frame(750, 1334, 0x11));
+
+    const rateIndex = encoderSpawns[0].args.indexOf("-r");
+    expect(rateIndex).toBeGreaterThanOrEqual(0);
+    expect(encoderSpawns[0].args[rateIndex + 1]).toBe(String(WEBRTC_IOS_SIMULATOR_FPS_DEFAULT));
+    const gopIndex = encoderSpawns[0].args.indexOf("-g");
+    expect(gopIndex).toBeGreaterThanOrEqual(0);
+    expect(encoderSpawns[0].args[gopIndex + 1]).toBe(String(WEBRTC_IOS_SIMULATOR_FPS_DEFAULT * 2));
+    expect(encoderSpawns[0].args).toContain("-forced-idr");
+    expect(encoderSpawns[0].args).toContain("baseline");
+    expect(encoderSpawns[0].args).toContain("4.2");
   });
 
   test("passes bitrate and output size overrides to ffmpeg", async () => {
@@ -859,5 +928,62 @@ describe("IosH264Source", () => {
         process.env[IOS_WEBRTC_FFMPEG_ENV_ALIAS] = originalLegacy;
       }
     }
+  });
+});
+
+describe("resolveIosEncoderScale", () => {
+  test("returns null for even frames already inside the Level 4.2 budget", () => {
+    expect(resolveIosEncoderScale({ width: 750, height: 1334 })).toBeNull();
+    expect(resolveIosEncoderScale({ width: 828, height: 1792 })).toBeNull();
+    expect(resolveIosEncoderScale({ width: 1920, height: 1080 })).toBeNull();
+  });
+
+  test("still downscales a native capture that exceeds the budget on its own", () => {
+    // iPhone 14 Pro backing store: 74 x 159 macroblocks, well past the 8192 cap.
+    const scale = resolveIosEncoderScale({ width: 1170, height: 2532 })!;
+    expect(scale.width).toBeLessThan(1170);
+    expect(scale.height).toBeLessThan(2532);
+    expect(h264MacroblocksPerFrame(scale.width, scale.height)).toBeLessThanOrEqual(
+      WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME
+    );
+  });
+
+  test("rounds odd dimensions down to even without changing the other axis", () => {
+    expect(resolveIosEncoderScale({ width: 801, height: 600 })).toEqual({ width: 800, height: 600 });
+    expect(resolveIosEncoderScale({ width: 800, height: 601 })).toEqual({ width: 800, height: 600 });
+  });
+
+  test("only ever scales down, and always lands inside the macroblock budget", () => {
+    const captures = [
+      { width: 320, height: 568 },
+      { width: 750, height: 1334 },
+      { width: 828, height: 1792 },
+      { width: 1179, height: 2556 },
+      { width: 1920, height: 1080 },
+      { width: 2048, height: 1536 },
+      { width: 2778, height: 1284 },
+      { width: 3840, height: 2160 },
+      { width: 5120, height: 2880 },
+    ];
+
+    for (const capture of captures) {
+      const scale = resolveIosEncoderScale(capture) ?? capture;
+      expect(scale.width).toBeLessThanOrEqual(capture.width);
+      expect(scale.height).toBeLessThanOrEqual(capture.height);
+      expect(scale.width % 2).toBe(0);
+      expect(scale.height % 2).toBe(0);
+      expect(h264MacroblocksPerFrame(scale.width, scale.height)).toBeLessThanOrEqual(
+        WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME
+      );
+    }
+  });
+
+  test("stays inside the budget for an extreme aspect ratio", () => {
+    const scale = resolveIosEncoderScale({ width: 16_000, height: 200 })!;
+    expect(h264MacroblocksPerFrame(scale.width, scale.height)).toBeLessThanOrEqual(
+      WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME
+    );
+    expect(scale.width).toBeGreaterThan(0);
+    expect(scale.height).toBeGreaterThan(0);
   });
 });

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -953,7 +953,7 @@ describe("resolveIosEncoderScale", () => {
     expect(resolveIosEncoderScale({ width: 800, height: 601 })).toEqual({ width: 800, height: 600 });
   });
 
-  test("only ever scales down, and always lands inside the macroblock budget", () => {
+  test("never scales up, and always lands inside the macroblock budget", () => {
     const captures = [
       { width: 320, height: 568 },
       { width: 750, height: 1334 },
@@ -976,6 +976,13 @@ describe("resolveIosEncoderScale", () => {
         WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME
       );
     }
+  });
+
+  test("raises a sub-2-pixel axis to the 4:2:0 floor, the one case it grows a dimension", () => {
+    // 4:2:0 has no legal edge below 2px, so this is a floor rather than an
+    // upscale toward some target size. No real capture produces such a frame.
+    expect(resolveIosEncoderScale({ width: 2, height: 1 })).toEqual({ width: 2, height: 2 });
+    expect(resolveIosEncoderScale({ width: 1, height: 1 })).toEqual({ width: 2, height: 2 });
   });
 
   test("stays inside the budget for an extreme aspect ratio", () => {

--- a/test/features/webrtc/webrtcStreamingConfig.test.ts
+++ b/test/features/webrtc/webrtcStreamingConfig.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import {
   WEBRTC_ENV,
+  WEBRTC_IOS_SIMULATOR_FPS_DEFAULT,
+  WEBRTC_IOS_SIMULATOR_FPS_MAX,
+  WEBRTC_IOS_SIMULATOR_FPS_MIN,
   parseIceServers,
   parseSize,
   resolveWebRtcStreamingConfig,
 } from "../../../src/features/webrtc/webrtcStreamingConfig";
+import { SIMULATOR_FPS_DEFAULT } from "../../../src/features/screen-stream/IOSScreenCaptureHelper";
 
 describe("parseIceServers", () => {
   test("parses a comma-separated URL list", () => {
@@ -129,6 +133,54 @@ describe("resolveWebRtcStreamingConfig", () => {
       resolveWebRtcStreamingConfig({ whipEndpoint: "https://coord/whip", bitrateKbps: 0 })
     ).toThrow(/positive number/);
     expect(() => resolveWebRtcStreamingConfig({ whipEndpoint: "not a URL" })).toThrow(/absolute http/);
+  });
+
+  test("defaults the iOS Simulator capture rate to the streaming default, not the observation default", () => {
+    const config = resolveWebRtcStreamingConfig(
+      { whipEndpoint: "https://coord/whip" },
+      {} as NodeJS.ProcessEnv
+    );
+    expect(config.iosSimulatorFps).toBe(WEBRTC_IOS_SIMULATOR_FPS_DEFAULT);
+    // The generic screen-capture default is tuned for MCP observation. An
+    // interactive WebRTC feed gets its own, higher, seam.
+    expect(WEBRTC_IOS_SIMULATOR_FPS_DEFAULT).toBeGreaterThan(SIMULATOR_FPS_DEFAULT);
+    expect(WEBRTC_IOS_SIMULATOR_FPS_DEFAULT).toBeGreaterThanOrEqual(WEBRTC_IOS_SIMULATOR_FPS_MIN);
+    expect(WEBRTC_IOS_SIMULATOR_FPS_DEFAULT).toBeLessThanOrEqual(WEBRTC_IOS_SIMULATOR_FPS_MAX);
+  });
+
+  test("reads the iOS Simulator capture rate from the environment", () => {
+    const env = {
+      [WEBRTC_ENV.WHIP_ENDPOINT]: "https://coord/whip",
+      [WEBRTC_ENV.IOS_SIMULATOR_FPS]: "30",
+    } as NodeJS.ProcessEnv;
+    expect(resolveWebRtcStreamingConfig({}, env).iosSimulatorFps).toBe(30);
+  });
+
+  test("iOS Simulator fps override takes precedence over the environment", () => {
+    const env = {
+      [WEBRTC_ENV.WHIP_ENDPOINT]: "https://coord/whip",
+      [WEBRTC_ENV.IOS_SIMULATOR_FPS]: "30",
+    } as NodeJS.ProcessEnv;
+    expect(resolveWebRtcStreamingConfig({ iosSimulatorFps: 10 }, env).iosSimulatorFps).toBe(10);
+  });
+
+  test("rejects an iOS Simulator fps outside the documented safe range", () => {
+    const endpoint = { whipEndpoint: "https://coord/whip" };
+    expect(() =>
+      resolveWebRtcStreamingConfig({ ...endpoint, iosSimulatorFps: WEBRTC_IOS_SIMULATOR_FPS_MIN - 1 })
+    ).toThrow(/integer in \[5, 60\]/);
+    expect(() =>
+      resolveWebRtcStreamingConfig({ ...endpoint, iosSimulatorFps: WEBRTC_IOS_SIMULATOR_FPS_MAX + 1 })
+    ).toThrow(/integer in \[5, 60\]/);
+    expect(() =>
+      resolveWebRtcStreamingConfig({ ...endpoint, iosSimulatorFps: 12.5 })
+    ).toThrow(/integer in \[5, 60\]/);
+    expect(() =>
+      resolveWebRtcStreamingConfig({}, {
+        [WEBRTC_ENV.WHIP_ENDPOINT]: "https://coord/whip",
+        [WEBRTC_ENV.IOS_SIMULATOR_FPS]: "not-a-number",
+      } as NodeJS.ProcessEnv)
+    ).toThrow(/integer in \[5, 60\]/);
   });
 
   test("falls back to a default STUN server", () => {

--- a/test/features/webrtc/webrtcStreamingConfig.test.ts
+++ b/test/features/webrtc/webrtcStreamingConfig.test.ts
@@ -141,6 +141,9 @@ describe("resolveWebRtcStreamingConfig", () => {
       {} as NodeJS.ProcessEnv
     );
     expect(config.iosSimulatorFps).toBe(WEBRTC_IOS_SIMULATOR_FPS_DEFAULT);
+    // Pin the literal too: three docs files quote 15, and asserting only the
+    // symbol would let the constant drift away from them silently.
+    expect(WEBRTC_IOS_SIMULATOR_FPS_DEFAULT).toBe(15);
     // The generic screen-capture default is tuned for MCP observation. An
     // interactive WebRTC feed gets its own, higher, seam.
     expect(WEBRTC_IOS_SIMULATOR_FPS_DEFAULT).toBeGreaterThan(SIMULATOR_FPS_DEFAULT);

--- a/test/server/webrtcStreamManager.test.ts
+++ b/test/server/webrtcStreamManager.test.ts
@@ -463,6 +463,29 @@ describe("webrtcStreamManager", () => {
     expect(publishers[0].pcmAudioChunks).toEqual([Buffer.from([1, 2, 3, 4])]);
   });
 
+  test("threads the resolved iOS Simulator fps into the capture source options", async () => {
+    let capturedSourceOptions:
+      | Parameters<NonNullable<Parameters<typeof setWebRtcStreamManagerDependencies>[0]["createSource"]>>[0]
+      | undefined;
+    setWebRtcStreamManagerDependencies({
+      idGenerator: new CountingIdGenerator("id"),
+      createPublisher: (config, deps) => new FakePublisher(config, deps) as unknown as WebRtcPublisher,
+      createSource: options => {
+        capturedSourceOptions = options;
+        return new FakeSource() as unknown as AndroidH264Source;
+      },
+      resolveVideoJar: async () => null,
+      now: () => new Date("2026-07-23T00:00:00.000Z"),
+    });
+
+    await startWebRtcStream({
+      device: ANDROID,
+      overrides: { whipEndpoint: ENDPOINT, iosSimulatorFps: 24 },
+    });
+
+    expect(capturedSourceOptions?.fps).toBe(24);
+  });
+
   test("rejects audio stream start when the initial async source start fails", async () => {
     const publishers: AsyncConnectedPublisher[] = [];
     const sources: FakeSource[] = [];


### PR DESCRIPTION
## Summary

The iOS WebRTC path scaled every capture toward a fixed `1920x1080` box. Because
`force_original_aspect_ratio=decrease` fits the box in *both* directions, a
Simulator window smaller than 1080p was **upscaled** — spending VideoToolbox time
inventing pixels the WHEP viewer gained no detail from. It also inherited
`SIMULATOR_FPS_DEFAULT` (5 fps), which is right for one-shot MCP observation but
unnecessarily conservative for an interactive feed.

This replaces the fixed box with `resolveIosEncoderScale()`, which only ever
scales *down*, and adds an iOS-Simulator streaming FPS seam that is separate from
the generic screen-capture default.

## Linked Issue

Closes [#4344](https://github.com/kaeawc/auto-mobile/issues/4344)

## Changes

**Capture scaling** (`src/features/webrtc/IosH264Source.ts`)

`resolveIosEncoderScale(size)` returns the ffmpeg output size, or `null` when the
frame encodes natively:

- **Native** when dimensions are even and already inside the Level 4.2 macroblock
  budget (`WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME`) — no `-vf` emitted at all.
- **Round down to even** for odd edges, which ffmpeg's 4:2:0 chroma subsampling
  cannot encode.
- **Downscale** an oversized capture by shrinking the *macroblock grid* rather
  than the pixel dimensions. Flooring both axes of an area-preserving scale keeps
  `columns * rows` inside the budget by construction, so there is no iterative
  search and no way to overshoot. Aspect ratio is preserved.

An explicit `size` override still wins, and is still validated up front by
`webrtcStreamingConfig`.

**FPS seam** (`src/features/webrtc/webrtcStreamingConfig.ts`)

- `AUTOMOBILE_WEBRTC_IOS_SIMULATOR_FPS` env var + `iosSimulatorFps` override.
- Safe range is `[WEBRTC_IOS_SIMULATOR_FPS_MIN, WEBRTC_IOS_SIMULATOR_FPS_MAX]` =
  `[5, 60]`, taken from the screen-capture helper's *own* bounds so a configured
  value can never be accepted here and then rejected by the helper's argv
  validation.
- Default `WEBRTC_IOS_SIMULATOR_FPS_DEFAULT = 15`: smooth enough to follow a
  gesture, while leaving headroom on a hosted macOS runner where the Simulator
  processes and VideoToolbox share one CPU/encoder budget and `-allow_sw` may put
  the encoder in software. 30/60 leaves no such margin.
- Threads through `H264CaptureSourceOptions.fps` → `webrtcStreamManager` →
  `IosH264Source`. Only the iOS Simulator source honours it; Android and
  physical-iOS capture at their own device rate.

**Unchanged by design:** the 2-second IDR cadence (`-g` still tracks fps, so the
new default is a keyframe every 30 frames), `-forced-idr`, baseline profile,
level 4.2, and `-allow_sw`. VideoToolbox is still the encoder; nothing pins a
fixed resolution or a Simulator window size.

## Validation

- [x] `bun run lint` passes (incl. all boundary guards)
- [x] `bun test` — **9043 pass / 0 fail** across 707 files
- [x] `bun run build` passes
- [x] New code uses interfaces + fakes + FakeTimer; the new tests are pure argv /
      pure-function assertions and run in ~1s for the whole webrtc directory
- [x] New tests confirmed **red before** the implementation, for the right reason
- [x] `bun run typecheck` — no new errors (see note below)

> **Typecheck note.** Locally the baseline gate reports one error in
> `src/utils/plan/PlanSchemaValidator.ts` (`TS2345`, two `ajv` module identities).
> It is **not** from this diff: it reproduces identically on a pristine `main`
> tree checked out against the same `node_modules`, and CI confirmed it — the gate
> passed on the first head. The cause is a stale nested `ajv@8.17.1` under
> `ajv-formats/` in the local install; `bun.lock` pins a single `ajv@8.20.0`, so a
> fresh CI install resolves one copy. The baseline is deliberately left untouched.
>
> That local noise did cost something worth recording: it led me to skip the gate
> after the review-fix commit, which then shipped a real `TS2353` — pinning `fps`
> at the video-stream call site did not satisfy `CaptureSourceFactory`'s narrower
> re-declared option type. `bun`'s bundler skips type-checking, so the full local
> suite and CI's test job both stayed green and only `tsc` caught it. Fixed in
> `782acbbbf`; the gate is now clean apart from the `ajv` artifact.

### Acceptance criteria

| Criterion | Where it is pinned |
|---|---|
| No upscaling solely to meet the 1920×1080 cap; native-or-downscaled even dims within Level 4.2 | `IosH264Source.test.ts` — "encodes a Simulator-sized capture natively instead of upscaling toward 1920x1080", "downscales an oversized capture into the Level 4.2 macroblock budget", "rounds an odd capture down to even dimensions ffmpeg can encode", plus the `resolveIosEncoderScale` table (only-ever-scales-down + budget invariant across 9 real capture sizes, and an extreme-aspect-ratio case) |
| Explicit iOS Simulator FPS seam, separate from the generic default, documented range, conservative default | `webrtcStreamingConfig.test.ts` — default is the streaming default *and* strictly greater than `SIMULATOR_FPS_DEFAULT`; env read; override precedence; range rejection at both ends and for a non-integer. `webrtcStreamManager.test.ts` pins the plumbing into `createSource`. |
| Two-second IDR cadence and H.264 compatibility validation preserved | `IosH264Source.test.ts` — "keeps the two-second IDR cadence at the default streaming fps" (`-r 15`, `-g 30`, `-forced-idr`, `baseline`, `4.2`); the existing explicit-fps GOP test still pins `-g 30` at 15 fps |
| Focused argv/config tests using interfaces and fakes | Existing `FakeChildProcess` / `FakeTimer` / fake capture helper; no new test infrastructure |
| Hosted iOS lane: browser decode + visual-change assertions | **Verified green.** `iOS Device Capture to WHEP` passed (161s, 6 expect() calls). The lane asserts `width > 0`, `height > 0`, frame growth and a changed pixel sample ([webrtcDeviceCapture.integration.test.ts:303](test/integration/webrtcDeviceCapture.integration.test.ts#L303)) — so it can't be broken by a dimension change, which also honours the "no fixed resolution" non-goal. |
| Hosted iOS lane: first-frame latency and decoded FPS vs. the baseline-timing issue | **Not measurable yet — deferred.** The lane's successful output reports only a whole-test duration, which is precisely what [#4343](https://github.com/kaeawc/auto-mobile/issues/4343) exists to add. Tracked in [#4349](https://github.com/kaeawc/auto-mobile/issues/4349), which is blocked on it. |

## Device Verification

Not run locally: the changed path needs a macOS host with Screen Recording
permission and a live WHIP ingest endpoint. Both hosted device lanes exercise it
and pass — `iOS Device Capture to WHEP` (161s) and `Android Device Capture to
WHEP`.

> **Flaky lane.** `iOS Device Capture to WHEP` failed once on the review-fix head
> with `a beforeEach/afterEach hook timed out` — the `afterEach` runs
> `xcrun simctl ui booted appearance light`, which is `.catch()`'d so it cannot
> throw but can hang on a wedged Simulator. Classified transient, not PR-caused:
> the same lane alternated 8 failures across 11 runs on `work/issue-4308` before
> this PR existed, and failed on `work/issue-4343-8835ce` too, neither of which
> contains this change. It passed on the first head of this PR.

## Review outcome

A three-lens review (runtime behavior, delivery/enforcement, and a generated
media/numeric-boundary lens) produced two real defects, both fixed in
`523f3b987`:

1. **The per-request override was unreachable.** `WebRtcStreamSocketRequest` had
   no fps field and `handleStart` maps overrides field-by-field, so only the env
   var ever reached the encoder — while the design doc claims "per-request fields
   override the environment defaults". Wired through, with a socket-server test.
2. **The video-stream relay silently inherited the new default.**
   `VideoStreamSocketServer` borrows the WebRTC capture sources but passes no
   fps, so moving `IosH264Source`'s fallback from 5 to 15 tripled local iOS
   mirroring load on a path this issue doesn't cover. Pinned to
   `SIMULATOR_FPS_DEFAULT` explicitly, with a test asserting the two defaults
   stay distinct.

Three comment claims were measured and found overstated, and corrected rather
than papered over: `-g` counts encoded frames (not seconds) so the ~2s IDR figure
holds only when delivery keeps up; `fps` is not inert on physical iOS, where it
still sets the declared input rate and GOP; and `resolveIosEncoderScale` does
grow a dimension in exactly one case — the 4:2:0 2px floor.

Verified and **declined**: pinning `-g` to `MIN * 2` (costs ~46% more bits at 15
fps to buy a guarantee against a delivery shortfall — deferred to
[#4348](https://github.com/kaeawc/auto-mobile/issues/4348) so it's a deliberate,
measured trade); `Buffer.allocUnsafe` in `tightlyPackBgraFrame` (measured at
4.2ms/s of CPU at 15 fps, 0.4% of one core — noise).

Independent verification worth recording: a ~1.1M-input sweep of
`resolveIosEncoderScale` found **zero** violations of the macroblock invariant
and zero upscales for any input with both axes ≥ 2; worst aspect-ratio error on a
realistic capture size is 0.267%. The barrel-import cycle risk was checked
empirically (`DEFAULT:15, isNaN:false`) — no cycle. And the new tests were
confirmed to fail on surgical revert.

## Follow-ups

- [ ] [#4348](https://github.com/kaeawc/auto-mobile/issues/4348) — iOS WebRTC
      keyframe recovery is bounded in frames, not seconds, and the source has no
      `requestKeyFrame()`, so a relayed WHEP PLI is a no-op.
- [ ] [#4349](https://github.com/kaeawc/auto-mobile/issues/4349) — native-resolution
      encoding on a Retina host raises encoder throughput ~8.7x with no default
      bitrate cap; blocked on [#4343](https://github.com/kaeawc/auto-mobile/issues/4343)
      for measurement.

Minor observations not worth their own issues: `h264Level.ts` documents Level 4.2
`MaxFS` as 8,192 where H.264 Table A-1 gives 8,704 (8,192 is Level 4.0/4.1) — the
conservative value is harmless and the file isn't touched here; and neither
`resolveIosEncoderScale` nor the pre-existing `validateSize` enforces the Level
4.2 *per-axis* 256-macroblock cap, which needs an aspect ratio past ~8:1 to bite
and so is unreachable from a real Simulator window.
