### PR TITLE
test(webrtc): measure device capture-to-browser stage latency

### DIFF
--- a/.github/workflows/webrtc-device-integration.yml
+++ b/.github/workflows/webrtc-device-integration.yml
@@ -100,7 +100,7 @@ jobs:
         continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
-          name: android-webrtc-device-artifacts
+          name: android-webrtc-device-artifacts-${{ github.run_attempt }}
           path: scratch/webrtc-device-integration/
           if-no-files-found: ignore
           retention-days: 7
@@ -143,7 +143,7 @@ jobs:
         continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
-          name: ios-webrtc-device-artifacts
+          name: ios-webrtc-device-artifacts-${{ github.run_attempt }}
           path: scratch/webrtc-device-integration/
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/webrtc-device-integration.yml
+++ b/.github/workflows/webrtc-device-integration.yml
@@ -44,6 +44,7 @@ jobs:
               - 'examples/mediamtx/**'
               - 'scripts/webrtc/**'
               - 'test/integration/webrtcDeviceCapture.integration.test.ts'
+              - 'test/helpers/captureStageTimeline.ts'
               - '.github/workflows/webrtc-device-integration.yml'
 
   android-device-webrtc:
@@ -91,8 +92,12 @@ jobs:
               bun run test:integration:webrtc-device
           working-directory: './android/'
           accessibility-apk-path: control-proxy/build/outputs/apk/debug/control-proxy-debug.apk
-      - name: "Upload WebRTC failure artifacts"
-        if: failure()
+      # Always keep the stage-latency record (#4343): p50/p95 baselines need the
+      # passing runs too. continue-on-error keeps a missing or failed upload from
+      # turning a green capture lane red.
+      - name: "Upload WebRTC device artifacts"
+        if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
           name: android-webrtc-device-artifacts
@@ -130,8 +135,12 @@ jobs:
           AUTOMOBILE_WEBRTC_DEVICE_INTEGRATION: "1"
           AUTOMOBILE_WEBRTC_DEVICE_PLATFORM: ios
         run: bun run test:integration:webrtc-device
-      - name: "Upload WebRTC failure artifacts"
-        if: failure()
+      # Always keep the stage-latency record (#4343): p50/p95 baselines need the
+      # passing runs too. continue-on-error keeps a missing or failed upload from
+      # turning a green capture lane red.
+      - name: "Upload WebRTC device artifacts"
+        if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v6
         with:
           name: ios-webrtc-device-artifacts

--- a/src/features/webrtc/WebRtcPublisher.ts
+++ b/src/features/webrtc/WebRtcPublisher.ts
@@ -107,6 +107,14 @@ export interface WebRtcStreamDescriptor {
   packetsSent: number;
   audioPacketsSent: number;
   audioSamplesSent: number;
+  /**
+   * True once the capture source for the current session has started. A
+   * video-only stream connects and *then* starts capture, so `state` alone
+   * cannot tell "WHIP publish accepted" from "capture running". Set by the
+   * stream manager, which owns source startup; absent on descriptors the
+   * publisher builds on its own.
+   */
+  sourceStarted?: boolean;
 }
 
 /**

--- a/src/server/webrtcStreamManager.ts
+++ b/src/server/webrtcStreamManager.ts
@@ -32,6 +32,12 @@ interface WebRtcStreamRecord {
   size?: { width: number; height: number };
   audioEnabled: boolean;
   startedAt: string;
+  /**
+   * True once this session's capture source started. Surfaced on the descriptor
+   * so an out-of-process observer can separate "WHIP publish accepted" from
+   * "capture running" — a video-only start returns before capture begins.
+   */
+  sourceStarted: boolean;
   /** Reservation token for a start that has not returned to its caller yet. */
   startToken: symbol;
 }
@@ -116,8 +122,14 @@ async function withRecord(
   }
 }
 
+/** Descriptor for a record, including the manager-owned capture-source state. */
+function describeRecord(record: WebRtcStreamRecord): WebRtcStreamDescriptor {
+  return { ...record.publisher.getDescriptor(), sourceStarted: record.sourceStarted };
+}
+
 /** Stop and clear the capture source for a stream (before each (re)establish). */
 async function stopSource(record: WebRtcStreamRecord): Promise<void> {
+  record.sourceStarted = false;
   if (record.source) {
     await record.source.stop().catch(error => {
       logger.debug(`[WebRtcStream] source stop failed: ${error}`);
@@ -166,6 +178,7 @@ async function startSource(record: WebRtcStreamRecord): Promise<boolean> {
     await source.stop().catch(() => {});
     return false;
   }
+  record.sourceStarted = true;
   return true;
 }
 
@@ -393,6 +406,7 @@ export async function startWebRtcStream(
       size: config.size,
       audioEnabled: config.audioEnabled,
       startedAt: dependencies.now().toISOString(),
+      sourceStarted: false,
       startToken,
     };
     streams.set(streamId, record);
@@ -413,7 +427,7 @@ export async function startWebRtcStream(
       );
     }
 
-    return publisher.getDescriptor();
+    return describeRecord(record);
   } finally {
     if (startingDeviceIds.get(request.device.deviceId) === pending) {
       startingDeviceIds.delete(request.device.deviceId);
@@ -433,20 +447,20 @@ export async function stopWebRtcStream(streamId?: string): Promise<WebRtcStreamD
   const record = resolveStreamRecord(streamId);
   streams.delete(record.streamId);
   cancelRecordStart(record);
-  const descriptor = record.publisher.getDescriptor();
+  const descriptor = describeRecord(record);
   await stopActiveRecord(record);
   return { ...descriptor, state: "stopped" };
 }
 
 /** List reconnect descriptors for all active streams. */
 export function listWebRtcStreams(): WebRtcStreamDescriptor[] {
-  return Array.from(streams.values()).map(record => record.publisher.getDescriptor());
+  return Array.from(streams.values()).map(describeRecord);
 }
 
 /** Get the reconnect descriptor for one stream (or null). */
 export function getWebRtcStreamDescriptor(streamId: string): WebRtcStreamDescriptor | null {
   const record = streams.get(streamId);
-  return record ? record.publisher.getDescriptor() : null;
+  return record ? describeRecord(record) : null;
 }
 
 function resolveStreamRecord(streamId?: string): WebRtcStreamRecord {

--- a/test/helpers/captureStageTimeline.test.ts
+++ b/test/helpers/captureStageTimeline.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
   CAPTURE_STAGES,
+  CAPTURE_STAGE_RECORD_SCHEMA_VERSION,
   CaptureStageTimeline,
+  captureRunIdentity,
   formatCaptureStageRecord,
   monotonicNowMs,
   type CaptureStageContext,
@@ -25,6 +27,15 @@ const context: CaptureStageContext = {
   sourceSize: { width: 1080, height: 2400 },
   configuredFps: 60,
   decodedSize: { width: 720, height: 1600 },
+  run: {
+    runId: "30053647851",
+    runAttempt: "2",
+    commitSha: "e573c0cd5379cee61a1d9fffc1f1094fc86dc507",
+    runnerOs: "Linux",
+    runnerImage: "ubuntu24",
+    startedAtIso: "2026-07-23T23:35:08.000Z",
+  },
+  samplingIntervalsMs: { whipConnected: 100, firstDecodedFrame: 100 },
 };
 
 describe("#4343 capture stage timeline", () => {
@@ -150,6 +161,47 @@ describe("#4343 capture stage timeline", () => {
     expect(record.decodedSize).toEqual({ width: 720, height: 1600 });
   });
 
+  test("carries the run identity and sampling error bar so samples can be aggregated", () => {
+    const timeline = new CaptureStageTimeline(fakeClock().nowMs);
+    timeline.mark("startRequest");
+
+    const record = timeline.toRecord(context);
+
+    expect(record.schemaVersion).toBe(CAPTURE_STAGE_RECORD_SCHEMA_VERSION);
+    expect(record.run.runId).toBe("30053647851");
+    expect(record.run.runAttempt).toBe("2");
+    expect(record.run.commitSha).toBe("e573c0cd5379cee61a1d9fffc1f1094fc86dc507");
+    expect(record.samplingIntervalsMs.whipConnected).toBe(100);
+  });
+
+  test("reads the run identity from the CI environment, and nulls it off CI", () => {
+    const onCi = captureRunIdentity(
+      {
+        GITHUB_RUN_ID: "42",
+        GITHUB_RUN_ATTEMPT: "3",
+        GITHUB_SHA: "abc123",
+        RUNNER_OS: "macOS",
+        ImageOS: "macos26",
+      } as NodeJS.ProcessEnv,
+      () => "2026-07-23T23:35:08.000Z"
+    );
+
+    expect(onCi).toEqual({
+      runId: "42",
+      runAttempt: "3",
+      commitSha: "abc123",
+      runnerOs: "macOS",
+      runnerImage: "macos26",
+      startedAtIso: "2026-07-23T23:35:08.000Z",
+    });
+
+    const local = captureRunIdentity({} as NodeJS.ProcessEnv, () => "2026-07-23T23:35:08.000Z");
+
+    expect(local.runId).toBeNull();
+    expect(local.commitSha).toBeNull();
+    expect(local.startedAtIso).toBe("2026-07-23T23:35:08.000Z");
+  });
+
   test("rejects a stage name that is not part of the pipeline", () => {
     const timeline = new CaptureStageTimeline(fakeClock().nowMs);
 
@@ -173,6 +225,8 @@ describe("#4343 capture stage timeline", () => {
     expect(formatted).toContain("decoded=720x1600");
     expect(formatted).toContain("whipConnected");
     expect(formatted).toContain("1500ms");
+    expect(formatted).toContain("run=30053647851/2");
+    expect(formatted).toContain("sha=e573c0cd5379cee61a1d9fffc1f1094fc86dc507");
     expect(formatted).toContain("missing=sourceStarted,firstEncodedFrame,whepConnected,firstDecodedFrame");
   });
 

--- a/test/helpers/captureStageTimeline.test.ts
+++ b/test/helpers/captureStageTimeline.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CAPTURE_STAGES,
+  CaptureStageTimeline,
+  formatCaptureStageRecord,
+  monotonicNowMs,
+  type CaptureStageContext,
+} from "./captureStageTimeline";
+
+/** Deterministic monotonic clock: advance() is the only way time moves. */
+function fakeClock(): { nowMs: () => number; advance: (ms: number) => void } {
+  let current = 1_000;
+  return {
+    nowMs: () => current,
+    advance: ms => {
+      current += ms;
+    },
+  };
+}
+
+const context: CaptureStageContext = {
+  platform: "android",
+  streamId: "device-capture-android",
+  outcome: "passed",
+  sourceSize: { width: 1080, height: 2400 },
+  configuredFps: 60,
+  decodedSize: { width: 720, height: 1600 },
+};
+
+describe("#4343 capture stage timeline", () => {
+  test("names the capture-to-browser stages in pipeline order", () => {
+    expect([...CAPTURE_STAGES]).toEqual([
+      "startRequest",
+      "whipConnected",
+      "sourceStarted",
+      "firstEncodedFrame",
+      "whepConnected",
+      "firstDecodedFrame",
+    ]);
+  });
+
+  test("measures each stage as elapsed time from the first mark", () => {
+    const clock = fakeClock();
+    const timeline = new CaptureStageTimeline(clock.nowMs);
+
+    timeline.mark("startRequest");
+    clock.advance(800);
+    timeline.mark("whipConnected");
+    clock.advance(150);
+    timeline.mark("sourceStarted");
+    clock.advance(400);
+    timeline.mark("firstEncodedFrame");
+    clock.advance(1_200);
+    timeline.mark("whepConnected");
+    clock.advance(250);
+    timeline.mark("firstDecodedFrame");
+
+    const record = timeline.toRecord(context);
+
+    expect(record.stages).toEqual([
+      { stage: "startRequest", elapsedMs: 0, deltaMs: 0 },
+      { stage: "whipConnected", elapsedMs: 800, deltaMs: 800 },
+      { stage: "sourceStarted", elapsedMs: 950, deltaMs: 150 },
+      { stage: "firstEncodedFrame", elapsedMs: 1_350, deltaMs: 400 },
+      { stage: "whepConnected", elapsedMs: 2_550, deltaMs: 1_200 },
+      { stage: "firstDecodedFrame", elapsedMs: 2_800, deltaMs: 250 },
+    ]);
+    expect(record.missingStages).toEqual([]);
+    expect(record.captureToBrowserMs).toBe(2_800);
+  });
+
+  test("keeps the first observation when a stage is marked twice", () => {
+    const clock = fakeClock();
+    const timeline = new CaptureStageTimeline(clock.nowMs);
+
+    timeline.mark("startRequest");
+    clock.advance(500);
+    timeline.mark("whipConnected");
+    clock.advance(500);
+    timeline.mark("whipConnected");
+
+    expect(timeline.toRecord(context).stages).toEqual([
+      { stage: "startRequest", elapsedMs: 0, deltaMs: 0 },
+      { stage: "whipConnected", elapsedMs: 500, deltaMs: 500 },
+    ]);
+  });
+
+  test("reports observed elapsed times even when stages are observed out of order", () => {
+    const clock = fakeClock();
+    const timeline = new CaptureStageTimeline(clock.nowMs);
+
+    timeline.mark("startRequest");
+    clock.advance(900);
+    // A concurrent status poller can see the first encoded frame before the
+    // start request returns, which is what marks the source as started.
+    timeline.mark("firstEncodedFrame");
+    clock.advance(100);
+    timeline.mark("sourceStarted");
+
+    const record = timeline.toRecord(context);
+
+    expect(record.stages).toEqual([
+      { stage: "startRequest", elapsedMs: 0, deltaMs: 0 },
+      { stage: "sourceStarted", elapsedMs: 1_000, deltaMs: 1_000 },
+      { stage: "firstEncodedFrame", elapsedMs: 900, deltaMs: -100 },
+    ]);
+  });
+
+  test("preserves the stages a failed run did reach and names the ones it did not", () => {
+    const clock = fakeClock();
+    const timeline = new CaptureStageTimeline(clock.nowMs);
+
+    timeline.mark("startRequest");
+    clock.advance(700);
+    timeline.mark("whipConnected");
+    clock.advance(300);
+    timeline.mark("sourceStarted");
+
+    const record = timeline.toRecord({
+      ...context,
+      outcome: "failed",
+      decodedSize: null,
+    });
+
+    expect(record.stages.map(measurement => measurement.stage)).toEqual([
+      "startRequest",
+      "whipConnected",
+      "sourceStarted",
+    ]);
+    expect(record.missingStages).toEqual([
+      "firstEncodedFrame",
+      "whepConnected",
+      "firstDecodedFrame",
+    ]);
+    expect(record.captureToBrowserMs).toBeNull();
+    expect(record.outcome).toBe("failed");
+  });
+
+  test("carries the platform, source resolution, configured fps and decoded dimensions", () => {
+    const clock = fakeClock();
+    const timeline = new CaptureStageTimeline(clock.nowMs);
+    timeline.mark("startRequest");
+
+    const record = timeline.toRecord(context);
+
+    expect(record.platform).toBe("android");
+    expect(record.streamId).toBe("device-capture-android");
+    expect(record.sourceSize).toEqual({ width: 1080, height: 2400 });
+    expect(record.configuredFps).toBe(60);
+    expect(record.decodedSize).toEqual({ width: 720, height: 1600 });
+  });
+
+  test("rejects a stage name that is not part of the pipeline", () => {
+    const timeline = new CaptureStageTimeline(fakeClock().nowMs);
+
+    expect(() => timeline.mark("whepConnexted" as never)).toThrow(/whepConnexted/);
+  });
+
+  test("formats a record that reports every measured stage with its context", () => {
+    const clock = fakeClock();
+    const timeline = new CaptureStageTimeline(clock.nowMs);
+    timeline.mark("startRequest");
+    clock.advance(1_500);
+    timeline.mark("whipConnected");
+
+    const formatted = formatCaptureStageRecord(timeline.toRecord({ ...context, outcome: "failed" }));
+
+    expect(formatted).toContain("platform=android");
+    expect(formatted).toContain("stream=device-capture-android");
+    expect(formatted).toContain("outcome=failed");
+    expect(formatted).toContain("source=1080x2400");
+    expect(formatted).toContain("fps=60");
+    expect(formatted).toContain("decoded=720x1600");
+    expect(formatted).toContain("whipConnected");
+    expect(formatted).toContain("1500ms");
+    expect(formatted).toContain("missing=sourceStarted,firstEncodedFrame,whepConnected,firstDecodedFrame");
+  });
+
+  test("formats unavailable context as none rather than dropping the field", () => {
+    const timeline = new CaptureStageTimeline(fakeClock().nowMs);
+    timeline.mark("startRequest");
+
+    const formatted = formatCaptureStageRecord(
+      timeline.toRecord({ ...context, sourceSize: null, configuredFps: null, decodedSize: null })
+    );
+
+    expect(formatted).toContain("source=none");
+    expect(formatted).toContain("fps=none");
+    expect(formatted).toContain("decoded=none");
+  });
+
+  test("defaults to a monotonic clock that never runs backwards", () => {
+    const first = monotonicNowMs();
+    const second = monotonicNowMs();
+
+    expect(second).toBeGreaterThanOrEqual(first);
+    expect(Number.isFinite(first)).toBe(true);
+  });
+});

--- a/test/helpers/captureStageTimeline.ts
+++ b/test/helpers/captureStageTimeline.ts
@@ -36,11 +36,43 @@ export interface CaptureStageMeasurement {
   elapsedMs: number;
   /**
    * Milliseconds since the previous recorded stage. Negative when a stage was
-   * observed out of pipeline order — a concurrent status poller can see the
-   * first encoded frame before the start request returns, and clamping that to
-   * zero would hide the overlap rather than report it.
+   * observed out of pipeline order; clamping that to zero would hide the
+   * overlap rather than report it. Note that a negative delta and the following
+   * positive one are anti-correlated, so aggregate `elapsedMs` across runs —
+   * never `deltaMs`.
    */
   deltaMs: number;
+}
+
+/**
+ * Which CI run produced a sample. Percentiles over "several Android and iOS CI
+ * samples" are indefensible without this: identically-named artifacts are
+ * otherwise indistinguishable, so an outlier cannot be traced back to its run,
+ * and re-runs of one commit cannot be told apart from independent samples.
+ */
+export interface CaptureRunIdentity {
+  runId: string | null;
+  runAttempt: string | null;
+  commitSha: string | null;
+  runnerOs: string | null;
+  runnerImage: string | null;
+  /** Wall clock at the origin mark — ordering metadata, never a measurement. */
+  startedAtIso: string;
+}
+
+/** Read the run identity from the GitHub Actions environment. */
+export function captureRunIdentity(
+  env: NodeJS.ProcessEnv = process.env,
+  nowIso: () => string = () => new Date().toISOString()
+): CaptureRunIdentity {
+  return {
+    runId: env.GITHUB_RUN_ID ?? null,
+    runAttempt: env.GITHUB_RUN_ATTEMPT ?? null,
+    commitSha: env.GITHUB_SHA ?? null,
+    runnerOs: env.RUNNER_OS ?? null,
+    runnerImage: env.ImageOS ?? null,
+    startedAtIso: nowIso(),
+  };
 }
 
 /** Run context recorded alongside the measurements. */
@@ -54,15 +86,26 @@ export interface CaptureStageContext {
   configuredFps: number | null;
   /** Dimensions of the first frame the browser decoded. */
   decodedSize: CaptureDimensions | null;
+  run: CaptureRunIdentity;
+  /**
+   * Poll interval each stage was observed with. Every measurement carries up to
+   * that much positive bias, so an aggregate without this has no error bar.
+   */
+  samplingIntervalsMs: Partial<Record<CaptureStage, number>>;
 }
 
 export interface CaptureStageRecord extends CaptureStageContext {
+  /** Bumped when the record's shape changes, so a parser can span generations. */
+  schemaVersion: number;
   stages: CaptureStageMeasurement[];
   /** Stages never reached — populated when a run fails part-way through. */
   missingStages: CaptureStage[];
   /** Start request to first browser-decoded frame, or null when never decoded. */
   captureToBrowserMs: number | null;
 }
+
+/** Current {@link CaptureStageRecord.schemaVersion}. */
+export const CAPTURE_STAGE_RECORD_SCHEMA_VERSION = 1;
 
 /** Monotonic millisecond reader used when none is injected. */
 export function monotonicNowMs(): number {
@@ -109,6 +152,7 @@ export class CaptureStageTimeline {
     }
     return {
       ...context,
+      schemaVersion: CAPTURE_STAGE_RECORD_SCHEMA_VERSION,
       stages,
       missingStages: CAPTURE_STAGES.filter(stage => !this.marks.has(stage)),
       captureToBrowserMs: this.marks.get("firstDecodedFrame") ?? null,
@@ -126,6 +170,7 @@ export function formatCaptureStageRecord(record: CaptureStageRecord): string {
   const lines = [
     `platform=${record.platform} stream=${record.streamId} outcome=${record.outcome}`,
     `source=${formatDimensions(record.sourceSize)} fps=${record.configuredFps ?? "none"} decoded=${formatDimensions(record.decodedSize)}`,
+    `run=${record.run.runId ?? "local"}/${record.run.runAttempt ?? "1"} sha=${record.run.commitSha ?? "unknown"} runner=${record.run.runnerImage ?? record.run.runnerOs ?? "unknown"}`,
     ...record.stages.map(
       measurement =>
         `  ${measurement.stage.padEnd(width)} ${Math.round(measurement.elapsedMs)}ms (+${Math.round(measurement.deltaMs)}ms)`

--- a/test/helpers/captureStageTimeline.ts
+++ b/test/helpers/captureStageTimeline.ts
@@ -1,0 +1,141 @@
+import { performance } from "node:perf_hooks";
+
+/**
+ * Stage-level latency for the device capture path (#4343).
+ *
+ * The device lane proves `capture → WHIP → MediaMTX → WHEP → browser decode`
+ * works, but a whole-test duration cannot separate daemon preparation from
+ * source startup, relay readiness, or browser decode. This records one elapsed
+ * measurement per stage so those can be compared across runs.
+ *
+ * Time comes from an injected reader so the unit coverage is hermetic; the
+ * default reader is `performance.now()` (monotonic) rather than `Date.now()`,
+ * which a clock adjustment mid-run can move backwards.
+ */
+
+/** Capture-to-browser stages, in pipeline order. */
+export const CAPTURE_STAGES = [
+  "startRequest",
+  "whipConnected",
+  "sourceStarted",
+  "firstEncodedFrame",
+  "whepConnected",
+  "firstDecodedFrame",
+] as const;
+
+export type CaptureStage = (typeof CAPTURE_STAGES)[number];
+
+export interface CaptureDimensions {
+  width: number;
+  height: number;
+}
+
+export interface CaptureStageMeasurement {
+  stage: CaptureStage;
+  /** Milliseconds between the first mark and this stage. */
+  elapsedMs: number;
+  /**
+   * Milliseconds since the previous recorded stage. Negative when a stage was
+   * observed out of pipeline order — a concurrent status poller can see the
+   * first encoded frame before the start request returns, and clamping that to
+   * zero would hide the overlap rather than report it.
+   */
+  deltaMs: number;
+}
+
+/** Run context recorded alongside the measurements. */
+export interface CaptureStageContext {
+  platform: string;
+  streamId: string;
+  outcome: "passed" | "failed";
+  /** Device display resolution feeding the encoder, when it could be queried. */
+  sourceSize: CaptureDimensions | null;
+  /** Frame rate the capture pipeline configures, or null when it does not set one. */
+  configuredFps: number | null;
+  /** Dimensions of the first frame the browser decoded. */
+  decodedSize: CaptureDimensions | null;
+}
+
+export interface CaptureStageRecord extends CaptureStageContext {
+  stages: CaptureStageMeasurement[];
+  /** Stages never reached — populated when a run fails part-way through. */
+  missingStages: CaptureStage[];
+  /** Start request to first browser-decoded frame, or null when never decoded. */
+  captureToBrowserMs: number | null;
+}
+
+/** Monotonic millisecond reader used when none is injected. */
+export function monotonicNowMs(): number {
+  return performance.now();
+}
+
+export class CaptureStageTimeline {
+  private readonly marks = new Map<CaptureStage, number>();
+  private originMs: number | null = null;
+
+  constructor(private readonly nowMs: () => number = monotonicNowMs) {}
+
+  /**
+   * Record the moment a stage was observed. The first mark sets the origin, and
+   * a repeated mark keeps the first observation so a polling loop can call this
+   * on every iteration.
+   */
+  mark(stage: CaptureStage): void {
+    if (!CAPTURE_STAGES.includes(stage)) {
+      throw new Error(`Unknown capture stage "${stage}"; expected one of ${CAPTURE_STAGES.join(", ")}.`);
+    }
+    if (this.marks.has(stage)) {
+      return;
+    }
+    const now = this.nowMs();
+    this.originMs ??= now;
+    this.marks.set(stage, now - this.originMs);
+  }
+
+  has(stage: CaptureStage): boolean {
+    return this.marks.has(stage);
+  }
+
+  toRecord(context: CaptureStageContext): CaptureStageRecord {
+    const stages: CaptureStageMeasurement[] = [];
+    let previousElapsedMs = 0;
+    for (const stage of CAPTURE_STAGES) {
+      const elapsedMs = this.marks.get(stage);
+      if (elapsedMs === undefined) {
+        continue;
+      }
+      stages.push({ stage, elapsedMs, deltaMs: elapsedMs - previousElapsedMs });
+      previousElapsedMs = elapsedMs;
+    }
+    return {
+      ...context,
+      stages,
+      missingStages: CAPTURE_STAGES.filter(stage => !this.marks.has(stage)),
+      captureToBrowserMs: this.marks.get("firstDecodedFrame") ?? null,
+    };
+  }
+}
+
+function formatDimensions(size: CaptureDimensions | null): string {
+  return size ? `${size.width}x${size.height}` : "none";
+}
+
+/** Human-readable summary written to the job log and the artifact directory. */
+export function formatCaptureStageRecord(record: CaptureStageRecord): string {
+  const width = Math.max(...CAPTURE_STAGES.map(stage => stage.length));
+  const lines = [
+    `platform=${record.platform} stream=${record.streamId} outcome=${record.outcome}`,
+    `source=${formatDimensions(record.sourceSize)} fps=${record.configuredFps ?? "none"} decoded=${formatDimensions(record.decodedSize)}`,
+    ...record.stages.map(
+      measurement =>
+        `  ${measurement.stage.padEnd(width)} ${Math.round(measurement.elapsedMs)}ms (+${Math.round(measurement.deltaMs)}ms)`
+    ),
+  ];
+  if (record.captureToBrowserMs !== null) {
+    lines.push(`captureToBrowser=${Math.round(record.captureToBrowserMs)}ms`);
+  }
+  if (record.missingStages.length > 0) {
+    lines.push(`missing=${record.missingStages.join(",")}`);
+  }
+  return lines.join("\n");
+}

--- a/test/integration/webrtcDeviceCapture.integration.test.ts
+++ b/test/integration/webrtcDeviceCapture.integration.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, describe, expect, test } from "bun:test";
 import { execFile, spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { once } from "node:events";
 import { createWriteStream, existsSync } from "node:fs";
@@ -9,10 +9,14 @@ import { promisify } from "node:util";
 import WebSocket from "ws";
 import { sendWebRtcStreamRequest } from "../../src/daemon/webrtcStreamClient";
 import { SIMULATOR_FPS_DEFAULT } from "../../src/features/screen-stream";
+import { SimCtlClient } from "../../src/utils/ios-cmdline-tools/SimCtlClient";
 import {
   CaptureStageTimeline,
+  captureRunIdentity,
   formatCaptureStageRecord,
   type CaptureDimensions,
+  type CaptureStage,
+  type CaptureStageContext,
 } from "../helpers/captureStageTimeline";
 
 const execFileAsync = promisify(execFile);
@@ -105,7 +109,13 @@ function chromeBinary(): string {
   return binary;
 }
 
-async function openReader(chrome: ChildProcessWithoutNullStreams): Promise<CdpClient> {
+/**
+ * Bring the browser up and install the peer-connection hook, without
+ * subscribing yet. Kept separate from {@link subscribeReader} so Chrome's cold
+ * start — seconds on a hosted runner — stays outside the measured window and
+ * does not land in the WHEP-connect stage (#4343).
+ */
+async function launchReader(): Promise<CdpClient> {
   let target: ChromeTarget | undefined;
   await waitFor(async () => {
     try {
@@ -129,6 +139,11 @@ async function openReader(chrome: ChildProcessWithoutNullStreams): Promise<CdpCl
       };
     })();`,
   });
+  return cdp;
+}
+
+/** Subscribe the already-running browser to the WHEP stream. */
+async function subscribeReader(cdp: CdpClient): Promise<void> {
   await cdp.command("Page.navigate", { url: `http://127.0.0.1:${webRtcPort}/${streamId}` });
   await waitFor(async () => {
     try {
@@ -142,7 +157,6 @@ async function openReader(chrome: ChildProcessWithoutNullStreams): Promise<CdpCl
       return false;
     }
   }, "browser WHEP reader did not connect");
-  return cdp;
 }
 
 async function videoSample(cdp: CdpClient): Promise<{ frames: number; width: number; height: number; sample: number }> {
@@ -208,6 +222,10 @@ interface CaptureProfile {
 /**
  * Capture profile recorded with the stage timings (#4343) so latency samples
  * from different runners can be compared like for like.
+ *
+ * `sourceSize` is the display the encoder captures, as each platform reports
+ * it: physical pixels from `wm size` on Android, logical points from SimCtl on
+ * iOS. Compare within a platform, not across one.
  */
 async function captureProfile(): Promise<CaptureProfile> {
   // Android screenrecord follows the display refresh rate, which the pipeline
@@ -223,9 +241,11 @@ async function captureProfile(): Promise<CaptureProfile> {
       const match = /Physical size:\s*(\d+)x(\d+)/.exec(stdout);
       return { sourceSize: match ? { width: Number(match[1]), height: Number(match[2]) } : null, configuredFps };
     }
-    const { stdout } = await execFileAsync("xcrun", ["simctl", "io", "booted", "enumerate"]);
-    const match = /Pixel Size:\s*\{(\d+),\s*(\d+)\}/.exec(stdout);
-    return { sourceSize: match ? { width: Number(match[1]), height: Number(match[2]) } : null, configuredFps };
+    // Not a hand-rolled `simctl io enumerate` regex: the first "Pixel Size:" in
+    // that output belongs to the CarPlay screen, so a naive match reports
+    // 720x480 for every simulator. SimCtlClient gates on the integrated display.
+    const screen = await new SimCtlClient().getScreenSize("booted");
+    return { sourceSize: { width: screen.width, height: screen.height }, configuredFps };
   } catch (error) {
     // Diagnostic metadata only — a failed size query must not fail the lane.
     console.warn(`[#4343] could not query capture source resolution: ${error}`);
@@ -272,7 +292,47 @@ afterEach(async () => {
   if (platform === "ios") {await execFileAsync("xcrun", ["simctl", "ui", "booted", "appearance", "light"]).catch(() => undefined);}
 });
 
+// Poll cadences the stages are observed with. Each measurement carries up to
+// its interval as positive bias, so the record reports them rather than leaving
+// a later percentile analysis to guess the error bar.
+const STREAM_POLL_INTERVAL_MS = 100;
+const SAMPLING_INTERVALS_MS: Partial<Record<CaptureStage, number>> = {
+  whipConnected: STREAM_POLL_INTERVAL_MS,
+  sourceStarted: STREAM_POLL_INTERVAL_MS,
+  firstEncodedFrame: STREAM_POLL_INTERVAL_MS,
+  whepConnected: STREAM_POLL_INTERVAL_MS,
+  firstDecodedFrame: STREAM_POLL_INTERVAL_MS,
+};
+
+// Held at describe scope so the record survives a test timeout: bun skips the
+// test body's `finally` when the deadline fires, but still runs afterAll. Losing
+// exactly the slowest runs would bias the p95 this feeds (#4343) low.
+const timeline = new CaptureStageTimeline();
+let profile: CaptureProfile = { sourceSize: null, configuredFps: null };
+let decodedSize: CaptureDimensions | null = null;
+let outcome: "passed" | "failed" = "failed";
+
 describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => {
+  afterAll(async () => {
+    const record = timeline.toRecord({
+      platform: platform ?? "unknown",
+      streamId,
+      outcome,
+      sourceSize: profile.sourceSize,
+      configuredFps: profile.configuredFps,
+      decodedSize,
+      run: captureRunIdentity(),
+      samplingIntervalsMs: SAMPLING_INTERVALS_MS,
+    } satisfies CaptureStageContext);
+    const summary = formatCaptureStageRecord(record);
+    console.log(`[#4343] device capture stage latency\n${summary}`);
+    // Written for passing runs too: the p50/p95 baselines this feeds need the
+    // successful samples, and a failure keeps whatever stages it reached.
+    await mkdir(artifactDir, { recursive: true });
+    await writeFile(join(artifactDir, "stage-latency.json"), `${JSON.stringify(record, null, 2)}\n`);
+    await writeFile(join(artifactDir, "result.txt"), `${summary}\n`);
+  });
+
   test("the real device capture path renders changing video and stops cleanly", async () => {
     if (!process.env.AUTOMOBILE_MEDIAMTX_BINARY) {throw new Error("MediaMTX runner did not provide AUTOMOBILE_MEDIAMTX_BINARY");}
     await mkdir(artifactDir, { recursive: true });
@@ -300,12 +360,8 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
     let chrome: ChildProcessWithoutNullStreams | undefined;
     let cdp: CdpClient | undefined;
     let started = false;
-    const timeline = new CaptureStageTimeline();
-    let profile: CaptureProfile = { sourceSize: null, configuredFps: null };
-    let decodedSize: CaptureDimensions | null = null;
-    let outcome: "passed" | "failed" = "failed";
-    let observingWhip = true;
-    let whipObserver: Promise<void> = Promise.resolve();
+    let observingStart = true;
+    let startObserver: Promise<void> = Promise.resolve();
     try {
       await waitFor(async () => {
         if (mediamtx.exitCode !== null || mediamtx.signalCode !== null) {
@@ -329,22 +385,31 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
       }, "AutoMobile daemon did not become ready");
       await launchFixture();
       profile = await captureProfile();
+      // Chrome is launched before the measured window opens so its cold start —
+      // seconds on a hosted runner — is not charged to the WHEP-connect stage.
+      chrome = start(chromeBinary(), ["--headless=new", "--autoplay-policy=no-user-gesture-required", "--remote-debugging-port=9222", "--no-first-run", "about:blank"], join(artifactDir, "chrome.log"));
+      cdp = await launchReader();
       timeline.mark("startRequest");
-      // The start request only returns once the publisher has connected AND the
-      // capture source has started, so the WHIP connect has to be observed from
-      // a concurrent poller. It never throws — a lost sample must not fail the
-      // lane, and every wait below keeps its own timeout.
-      whipObserver = (async () => {
-        while (observingWhip && !timeline.has("whipConnected")) {
-          const status = await sendWebRtcStreamRequest(
-            { action: "status", id: `${streamId}-whip-status`, streamId },
+      // A video-only start returns as soon as the WHIP publish is accepted; the
+      // capture source starts afterwards, so both transitions have to be
+      // observed from a concurrent poller. `list` rather than `status` because
+      // status throws (and the daemon logs an error) until the stream registers.
+      // The poller never throws — a lost sample must not fail the lane, and
+      // every wait below keeps its own timeout.
+      startObserver = (async () => {
+        while (observingStart && !(timeline.has("whipConnected") && timeline.has("sourceStarted"))) {
+          const listed = await sendWebRtcStreamRequest(
+            { action: "list", id: `${streamId}-start-observer` },
             { socketPath: webRtcSocketPath, timeoutMs: 1_000 }
           ).catch(() => undefined);
-          if (status?.stream?.state === "connected") {
+          const stream = listed?.streams?.find(candidate => candidate.streamId === streamId);
+          if (stream?.state === "connected") {
             timeline.mark("whipConnected");
-            return;
           }
-          await Bun.sleep(50);
+          if (stream?.sourceStarted === true) {
+            timeline.mark("sourceStarted");
+          }
+          await Bun.sleep(STREAM_POLL_INTERVAL_MS);
         }
       })();
       const response = await sendWebRtcStreamRequest(
@@ -354,7 +419,6 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
       if (!response.success) {
         throw new Error(`failed to start device WebRTC stream: ${response.error ?? "no error detail returned"}`);
       }
-      timeline.mark("sourceStarted");
       await waitFor(async () => {
         const status = await sendWebRtcStreamRequest(
           { action: "status", id: `${streamId}-capture-status`, streamId },
@@ -366,8 +430,7 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
         timeline.mark("firstEncodedFrame");
         return true;
       }, "capture source did not deliver H.264 frames to the WHIP publisher");
-      chrome = start(chromeBinary(), ["--headless=new", "--autoplay-policy=no-user-gesture-required", "--remote-debugging-port=9222", "--no-first-run", "about:blank"], join(artifactDir, "chrome.log"));
-      cdp = await openReader(chrome);
+      await subscribeReader(cdp);
       timeline.mark("whepConnected");
       // The device can be idle by the time the WHEP reader connects. Trigger a
       // visible transition after subscription so the reader receives a fresh
@@ -396,27 +459,19 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
       expect(listed.streams?.some(stream => stream.streamId === streamId)).toBe(false);
       outcome = "passed";
     } finally {
-      observingWhip = false;
-      await whipObserver;
+      observingStart = false;
+      // Nothing in the observer rejects today; swallow anyway so a future edit
+      // cannot skip the teardown below and replace the real test failure.
+      await startObserver.catch(() => undefined);
       cdp?.close();
       await stop(chrome);
       if (started) {await execFileAsync("bun", ["dist/src/index.js", "--daemon", "stop"], { env: daemonEnvironment }).catch(() => undefined);}
       await stop(mediamtx);
       await rm(webRtcSocketDir, { recursive: true, force: true });
-      // Written for passing runs too: the p50/p95 baselines this feeds (#4343)
-      // need the successful samples, and a failure keeps whatever it reached.
-      const record = timeline.toRecord({
-        platform: platform ?? "unknown",
-        streamId,
-        outcome,
-        sourceSize: profile.sourceSize,
-        configuredFps: profile.configuredFps,
-        decodedSize,
-      });
-      const summary = formatCaptureStageRecord(record);
-      await writeFile(join(artifactDir, "stage-latency.json"), `${JSON.stringify(record, null, 2)}\n`);
-      await writeFile(join(artifactDir, "result.txt"), `${summary}\n`);
-      console.log(`[#4343] device capture stage latency\n${summary}`);
+      // The daemon dir lives under the artifact dir and holds its logs and DB.
+      // Now that artifacts upload on success too, keep it only for a failure to
+      // triage; a green run should ship the latency record, not a sqlite file.
+      if (outcome === "passed") {await rm(daemonDir, { recursive: true, force: true });}
     }
   }, deviceIntegrationTimeoutMs);
 });

--- a/test/integration/webrtcDeviceCapture.integration.test.ts
+++ b/test/integration/webrtcDeviceCapture.integration.test.ts
@@ -8,6 +8,12 @@ import { join, resolve } from "node:path";
 import { promisify } from "node:util";
 import WebSocket from "ws";
 import { sendWebRtcStreamRequest } from "../../src/daemon/webrtcStreamClient";
+import { SIMULATOR_FPS_DEFAULT } from "../../src/features/screen-stream";
+import {
+  CaptureStageTimeline,
+  formatCaptureStageRecord,
+  type CaptureDimensions,
+} from "../helpers/captureStageTimeline";
 
 const execFileAsync = promisify(execFile);
 const runIntegration = process.env.AUTOMOBILE_WEBRTC_DEVICE_INTEGRATION === "1";
@@ -19,6 +25,10 @@ const artifactDir = resolve("scratch/webrtc-device-integration");
 // Hosted iOS runners can spend more than three minutes on daemon bootstrap,
 // Simulator commands, and Chrome startup before the bounded 30s decode checks.
 const deviceIntegrationTimeoutMs = 360_000;
+// Mirrors QualityPreset.MEDIUM.fps in android/video-server, which is the quality
+// PersistentEncoderH264Source publishes with. Pinned by
+// test/integration/webrtcDeviceCaptureLatency.test.ts so the two cannot drift.
+const ANDROID_VIDEO_SERVER_MEDIUM_FPS = 60;
 
 interface ChromeTarget { type: string; webSocketDebuggerUrl?: string }
 interface CdpResponse { id?: number; result?: { result?: { value?: unknown } }; error?: { message?: string } }
@@ -186,9 +196,46 @@ async function waitForDecodedFrames(cdp: CdpClient, minimum: number, message: st
   }
 }
 
+function androidDeviceId(): string {
+  return process.env.AUTOMOBILE_ANDROID_H264_DEVICE_ID ?? "emulator-5554";
+}
+
+interface CaptureProfile {
+  sourceSize: CaptureDimensions | null;
+  configuredFps: number | null;
+}
+
+/**
+ * Capture profile recorded with the stage timings (#4343) so latency samples
+ * from different runners can be compared like for like.
+ */
+async function captureProfile(): Promise<CaptureProfile> {
+  // Android screenrecord follows the display refresh rate, which the pipeline
+  // never configures; only the persistent encoder publishes a chosen fps.
+  const usesVideoServer =
+    Boolean(process.env.AUTOMOBILE_VIDEO_SERVER_JAR) || process.env.AUTOMOBILE_REQUIRE_VIDEO_SERVER === "1";
+  const configuredFps = platform === "android"
+    ? (usesVideoServer ? ANDROID_VIDEO_SERVER_MEDIUM_FPS : null)
+    : SIMULATOR_FPS_DEFAULT;
+  try {
+    if (platform === "android") {
+      const { stdout } = await execFileAsync("adb", ["-s", androidDeviceId(), "shell", "wm", "size"]);
+      const match = /Physical size:\s*(\d+)x(\d+)/.exec(stdout);
+      return { sourceSize: match ? { width: Number(match[1]), height: Number(match[2]) } : null, configuredFps };
+    }
+    const { stdout } = await execFileAsync("xcrun", ["simctl", "io", "booted", "enumerate"]);
+    const match = /Pixel Size:\s*\{(\d+),\s*(\d+)\}/.exec(stdout);
+    return { sourceSize: match ? { width: Number(match[1]), height: Number(match[2]) } : null, configuredFps };
+  } catch (error) {
+    // Diagnostic metadata only — a failed size query must not fail the lane.
+    console.warn(`[#4343] could not query capture source resolution: ${error}`);
+    return { sourceSize: null, configuredFps };
+  }
+}
+
 async function launchFixture(): Promise<void> {
   if (platform === "android") {
-    const id = process.env.AUTOMOBILE_ANDROID_H264_DEVICE_ID ?? "emulator-5554";
+    const id = androidDeviceId();
     await execFileAsync("adb", ["-s", id, "shell", "am", "start", "-a", "android.settings.SETTINGS"]);
     await execFileAsync("adb", ["-s", id, "shell", "cmd", "uimode", "night", "no"]);
     return;
@@ -203,7 +250,7 @@ async function launchFixture(): Promise<void> {
 
 async function changeFixture(): Promise<void> {
   if (platform === "android") {
-    const id = process.env.AUTOMOBILE_ANDROID_H264_DEVICE_ID ?? "emulator-5554";
+    const id = androidDeviceId();
     // A Home transition guarantees a visible surface change. The emulator may
     // accept a ui-mode setting without repainting the Settings window, which
     // made the old theme-only fixture indistinguishable from a frozen stream.
@@ -219,7 +266,7 @@ async function changeFixture(): Promise<void> {
 
 afterEach(async () => {
   if (platform === "android") {
-    const id = process.env.AUTOMOBILE_ANDROID_H264_DEVICE_ID ?? "emulator-5554";
+    const id = androidDeviceId();
     await execFileAsync("adb", ["-s", id, "shell", "cmd", "uimode", "night", "no"]).catch(() => undefined);
   }
   if (platform === "ios") {await execFileAsync("xcrun", ["simctl", "ui", "booted", "appearance", "light"]).catch(() => undefined);}
@@ -253,6 +300,12 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
     let chrome: ChildProcessWithoutNullStreams | undefined;
     let cdp: CdpClient | undefined;
     let started = false;
+    const timeline = new CaptureStageTimeline();
+    let profile: CaptureProfile = { sourceSize: null, configuredFps: null };
+    let decodedSize: CaptureDimensions | null = null;
+    let outcome: "passed" | "failed" = "failed";
+    let observingWhip = true;
+    let whipObserver: Promise<void> = Promise.resolve();
     try {
       await waitFor(async () => {
         if (mediamtx.exitCode !== null || mediamtx.signalCode !== null) {
@@ -275,6 +328,25 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
         } catch { return false; }
       }, "AutoMobile daemon did not become ready");
       await launchFixture();
+      profile = await captureProfile();
+      timeline.mark("startRequest");
+      // The start request only returns once the publisher has connected AND the
+      // capture source has started, so the WHIP connect has to be observed from
+      // a concurrent poller. It never throws — a lost sample must not fail the
+      // lane, and every wait below keeps its own timeout.
+      whipObserver = (async () => {
+        while (observingWhip && !timeline.has("whipConnected")) {
+          const status = await sendWebRtcStreamRequest(
+            { action: "status", id: `${streamId}-whip-status`, streamId },
+            { socketPath: webRtcSocketPath, timeoutMs: 1_000 }
+          ).catch(() => undefined);
+          if (status?.stream?.state === "connected") {
+            timeline.mark("whipConnected");
+            return;
+          }
+          await Bun.sleep(50);
+        }
+      })();
       const response = await sendWebRtcStreamRequest(
         { action: "start", id: streamId, streamId, platform, whipEndpoint: `http://127.0.0.1:${webRtcPort}/${streamId}/whip` },
         { socketPath: webRtcSocketPath }
@@ -282,21 +354,29 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
       if (!response.success) {
         throw new Error(`failed to start device WebRTC stream: ${response.error ?? "no error detail returned"}`);
       }
+      timeline.mark("sourceStarted");
       await waitFor(async () => {
         const status = await sendWebRtcStreamRequest(
           { action: "status", id: `${streamId}-capture-status`, streamId },
           { socketPath: webRtcSocketPath, timeoutMs: 1_000 }
         ).catch(() => undefined);
-        return (status?.stream?.framesSent ?? 0) > 0;
+        if ((status?.stream?.framesSent ?? 0) === 0) {
+          return false;
+        }
+        timeline.mark("firstEncodedFrame");
+        return true;
       }, "capture source did not deliver H.264 frames to the WHIP publisher");
       chrome = start(chromeBinary(), ["--headless=new", "--autoplay-policy=no-user-gesture-required", "--remote-debugging-port=9222", "--no-first-run", "about:blank"], join(artifactDir, "chrome.log"));
       cdp = await openReader(chrome);
+      timeline.mark("whepConnected");
       // The device can be idle by the time the WHEP reader connects. Trigger a
       // visible transition after subscription so the reader receives a fresh
       // encoded access unit rather than waiting on an earlier keyframe.
       await changeFixture();
       await waitForDecodedFrames(cdp, 0, "browser did not decode device video");
+      timeline.mark("firstDecodedFrame");
       const first = await videoSample(cdp);
+      decodedSize = { width: first.width, height: first.height };
       await launchFixture();
       await waitForDecodedFrames(cdp, first.frames, "browser did not receive video after returning to the fixture");
       const second = await videoSample(cdp);
@@ -314,13 +394,29 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
         { socketPath: webRtcSocketPath }
       );
       expect(listed.streams?.some(stream => stream.streamId === streamId)).toBe(false);
+      outcome = "passed";
     } finally {
+      observingWhip = false;
+      await whipObserver;
       cdp?.close();
       await stop(chrome);
       if (started) {await execFileAsync("bun", ["dist/src/index.js", "--daemon", "stop"], { env: daemonEnvironment }).catch(() => undefined);}
       await stop(mediamtx);
       await rm(webRtcSocketDir, { recursive: true, force: true });
-      await writeFile(join(artifactDir, "result.txt"), `platform=${platform}\nstream=${streamId}\n`);
+      // Written for passing runs too: the p50/p95 baselines this feeds (#4343)
+      // need the successful samples, and a failure keeps whatever it reached.
+      const record = timeline.toRecord({
+        platform: platform ?? "unknown",
+        streamId,
+        outcome,
+        sourceSize: profile.sourceSize,
+        configuredFps: profile.configuredFps,
+        decodedSize,
+      });
+      const summary = formatCaptureStageRecord(record);
+      await writeFile(join(artifactDir, "stage-latency.json"), `${JSON.stringify(record, null, 2)}\n`);
+      await writeFile(join(artifactDir, "result.txt"), `${summary}\n`);
+      console.log(`[#4343] device capture stage latency\n${summary}`);
     }
   }, deviceIntegrationTimeoutMs);
 });

--- a/test/integration/webrtcDeviceCaptureLatency.test.ts
+++ b/test/integration/webrtcDeviceCaptureLatency.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { CAPTURE_STAGES } from "../helpers/captureStageTimeline";
+
+const repoRoot = join(import.meta.dir, "../..");
+
+function read(relativePath: string): string {
+  return readFileSync(join(repoRoot, relativePath), "utf8");
+}
+
+const INTEGRATION_TEST_PATH = "test/integration/webrtcDeviceCapture.integration.test.ts";
+
+/**
+ * The device lane needs a real emulator/simulator, so its instrumentation
+ * cannot be exercised here. These guards pin the wiring instead: every stage is
+ * marked, the record survives a failure, and no assertion depends on how long a
+ * hosted runner happened to take (#4343).
+ */
+describe("#4343 device capture latency instrumentation", () => {
+  test("marks every capture-to-browser stage in the device lane", () => {
+    const source = read(INTEGRATION_TEST_PATH);
+
+    for (const stage of CAPTURE_STAGES) {
+      expect(source).toContain(`timeline.mark("${stage}")`);
+    }
+  });
+
+  test("writes the latency record from the cleanup path so failures keep it", () => {
+    const source = read(INTEGRATION_TEST_PATH);
+    const finallyIndex = source.indexOf("} finally {");
+    const recordIndex = source.indexOf("stage-latency.json");
+
+    expect(finallyIndex).toBeGreaterThan(0);
+    expect(recordIndex).toBeGreaterThan(finallyIndex);
+  });
+
+  test("prints the formatted record so a passing CI run reports its timings", () => {
+    const source = read(INTEGRATION_TEST_PATH);
+
+    expect(source).toContain("formatCaptureStageRecord");
+    expect(source).toMatch(/console\.log\(/);
+  });
+
+  test("asserts nothing about measured durations", () => {
+    const source = read(INTEGRATION_TEST_PATH);
+    const timingAssertions = source
+      .split("\n")
+      .filter(line => /expect\(/.test(line))
+      .filter(line => /timeline|record|elapsedMs|deltaMs|captureToBrowserMs|latency/.test(line));
+
+    expect(timingAssertions).toEqual([]);
+  });
+
+  test("mirrors the Android capture fps from the video-server default quality preset", () => {
+    const integration = read(INTEGRATION_TEST_PATH);
+    const encoder = read("src/features/webrtc/PersistentEncoderH264Source.ts");
+    const preset = read(
+      "android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/QualityPreset.kt"
+    );
+
+    // The lane runs the persistent encoder, which sends `--quality medium`.
+    expect(encoder).toContain('this.options.quality ?? "medium"');
+    const mediumFps = /MEDIUM\([^)]*fps\s*=\s*(\d+)\)/.exec(preset)?.[1];
+    expect(mediumFps).toBeDefined();
+    expect(integration).toContain(`const ANDROID_VIDEO_SERVER_MEDIUM_FPS = ${mediumFps};`);
+  });
+});

--- a/test/integration/webrtcDeviceCaptureLatency.test.ts
+++ b/test/integration/webrtcDeviceCaptureLatency.test.ts
@@ -11,45 +11,96 @@ function read(relativePath: string): string {
 
 const INTEGRATION_TEST_PATH = "test/integration/webrtcDeviceCapture.integration.test.ts";
 
+/** Source with comments stripped, so a commented-out call cannot satisfy a guard. */
+function withoutComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+}
+
+/**
+ * Index of `needle`, asserted present first. A bare `indexOf` returns -1 when
+ * the call site is deleted outright, and -1 satisfies any "comes before" check —
+ * so an ordering guard built on it passes precisely when the code is gone.
+ */
+function indexOfRequired(source: string, needle: string): number {
+  const index = source.indexOf(needle);
+  expect(`${needle} present: ${index >= 0}`).toBe(`${needle} present: true`);
+  return index;
+}
+
 /**
  * The device lane needs a real emulator/simulator, so its instrumentation
  * cannot be exercised here. These guards pin the wiring instead: every stage is
- * marked, the record survives a failure, and no assertion depends on how long a
- * hosted runner happened to take (#4343).
+ * marked in pipeline order, each stage measures the event it is named for, the
+ * record survives a timeout, and no assertion depends on how long a hosted
+ * runner happened to take (#4343).
  */
 describe("#4343 device capture latency instrumentation", () => {
-  test("marks every capture-to-browser stage in the device lane", () => {
-    const source = read(INTEGRATION_TEST_PATH);
+  test("marks every capture-to-browser stage, in pipeline order", () => {
+    const source = withoutComments(read(INTEGRATION_TEST_PATH));
+    const positions = CAPTURE_STAGES.map(stage => source.indexOf(`timeline.mark("${stage}")`));
 
-    for (const stage of CAPTURE_STAGES) {
-      expect(source).toContain(`timeline.mark("${stage}")`);
+    for (const [index, position] of positions.entries()) {
+      expect(`${CAPTURE_STAGES[index]}:${position >= 0}`).toBe(`${CAPTURE_STAGES[index]}:true`);
     }
+    // A mark that moved out of its pipeline position would still be "present",
+    // so pin the order the call sites appear in as well.
+    expect(positions).toEqual([...positions].sort((left, right) => left - right));
   });
 
-  test("writes the latency record from the cleanup path so failures keep it", () => {
-    const source = read(INTEGRATION_TEST_PATH);
-    const finallyIndex = source.indexOf("} finally {");
-    const recordIndex = source.indexOf("stage-latency.json");
+  test("takes source-started from the daemon rather than from the start response", () => {
+    const source = withoutComments(read(INTEGRATION_TEST_PATH));
 
-    expect(finallyIndex).toBeGreaterThan(0);
-    expect(recordIndex).toBeGreaterThan(finallyIndex);
+    // The stream descriptor's own signal — a video-only start returns before
+    // capture begins, so the start response cannot stand in for it.
+    expect(source).toContain("sourceStarted === true");
+    expect(indexOfRequired(source, 'timeline.mark("sourceStarted")')).toBeLessThan(
+      indexOfRequired(source, 'action: "start"')
+    );
+  });
+
+  test("launches the browser before the measured window opens", () => {
+    const source = withoutComments(read(INTEGRATION_TEST_PATH));
+
+    // Chrome cold start is seconds on a hosted runner; inside the window it
+    // would land in the WHEP-connect stage and dominate it.
+    // Match the call sites, not the declarations of `chromeBinary`/`launchReader`
+    // — those sit at the top of the file and would satisfy any ordering check.
+    const startRequestIndex = indexOfRequired(source, 'timeline.mark("startRequest")');
+    expect(indexOfRequired(source, "chrome = start(chromeBinary()")).toBeLessThan(startRequestIndex);
+    expect(indexOfRequired(source, "cdp = await launchReader()")).toBeLessThan(startRequestIndex);
+  });
+
+  test("writes the latency record from afterAll so a timed-out run still reports", () => {
+    const source = withoutComments(read(INTEGRATION_TEST_PATH));
+    const afterAllIndex = source.indexOf("afterAll(");
+
+    // bun skips the test body's `finally` when the deadline fires but still runs
+    // afterAll, so writing from the body would drop exactly the slowest samples.
+    expect(afterAllIndex).toBeGreaterThan(0);
+    expect(source.indexOf("afterAll(", afterAllIndex + 1)).toBe(-1);
+    expect(source.indexOf("stage-latency.json")).toBeGreaterThan(afterAllIndex);
+    expect(source.indexOf("result.txt")).toBeGreaterThan(afterAllIndex);
   });
 
   test("prints the formatted record so a passing CI run reports its timings", () => {
-    const source = read(INTEGRATION_TEST_PATH);
+    const source = withoutComments(read(INTEGRATION_TEST_PATH));
 
-    expect(source).toContain("formatCaptureStageRecord");
-    expect(source).toMatch(/console\.log\(/);
+    expect(source).toContain("console.log(`[#4343] device capture stage latency");
   });
 
   test("asserts nothing about measured durations", () => {
-    const source = read(INTEGRATION_TEST_PATH);
-    const timingAssertions = source
-      .split("\n")
-      .filter(line => /expect\(/.test(line))
-      .filter(line => /timeline|record|elapsedMs|deltaMs|captureToBrowserMs|latency/.test(line));
+    // Collapsed so a multi-line expect() cannot slip past a line-scoped scan.
+    // An assertion on a variable aliasing a timing value would still evade this;
+    // the guard covers direct use, which is how such an assertion gets written.
+    const collapsed = withoutComments(read(INTEGRATION_TEST_PATH)).replace(/\s+/g, " ");
+    const assertions = collapsed.match(/expect\([^;]*?\)\s*\.[a-zA-Z]+\(/g) ?? [];
 
-    expect(timingAssertions).toEqual([]);
+    expect(assertions.length).toBeGreaterThan(0);
+    expect(
+      assertions.filter(assertion =>
+        /timeline|record|elapsedMs|deltaMs|captureToBrowserMs|latency/.test(assertion)
+      )
+    ).toEqual([]);
   });
 
   test("mirrors the Android capture fps from the video-server default quality preset", () => {
@@ -61,7 +112,12 @@ describe("#4343 device capture latency instrumentation", () => {
 
     // The lane runs the persistent encoder, which sends `--quality medium`.
     expect(encoder).toContain('this.options.quality ?? "medium"');
-    const mediumFps = /MEDIUM\([^)]*fps\s*=\s*(\d+)\)/.exec(preset)?.[1];
+    // Sliced rather than matched in one regex so a ktfmt reflow or an argument
+    // reorder inside MEDIUM(...) does not turn a formatting change into a
+    // spurious failure here.
+    const medium = /MEDIUM\(([\s\S]*?)\)/.exec(preset)?.[1];
+    expect(medium).toBeDefined();
+    const mediumFps = /fps\s*=\s*(\d+)/.exec(medium ?? "")?.[1];
     expect(mediumFps).toBeDefined();
     expect(integration).toContain(`const ANDROID_VIDEO_SERVER_MEDIUM_FPS = ${mediumFps};`);
   });

--- a/test/scripts/webrtcDeviceIntegrationWorkflow.test.ts
+++ b/test/scripts/webrtcDeviceIntegrationWorkflow.test.ts
@@ -23,6 +23,7 @@ interface WorkflowDocument {
         filters?: string;
         "gradle-tasks"?: string;
         script?: string;
+        name?: string;
         path?: string;
         "if-no-files-found"?: string;
       };
@@ -106,6 +107,10 @@ describe("#4308 device WebRTC integration workflow", () => {
       expect(upload?.["continue-on-error"]).toBe(true);
       expect(upload?.with?.path).toBe("scratch/webrtc-device-integration/");
       expect(upload?.with?.["if-no-files-found"]).toBe("ignore");
+      // Artifacts are immutable and run-scoped, so a re-run of the lane would
+      // collide on a fixed name — and continue-on-error would swallow the 409,
+      // silently costing a sample.
+      expect(upload?.with?.name).toContain("github.run_attempt");
     }
   });
 

--- a/test/scripts/webrtcDeviceIntegrationWorkflow.test.ts
+++ b/test/scripts/webrtcDeviceIntegrationWorkflow.test.ts
@@ -13,7 +13,20 @@ interface WorkflowDocument {
   jobs?: Record<string, {
     needs?: string | string[];
     if?: string;
-    steps?: Array<{ id?: string; name?: string; uses?: string; with?: { filters?: string; "gradle-tasks"?: string; script?: string } }>;
+    steps?: Array<{
+      id?: string;
+      name?: string;
+      uses?: string;
+      if?: string;
+      "continue-on-error"?: boolean;
+      with?: {
+        filters?: string;
+        "gradle-tasks"?: string;
+        script?: string;
+        path?: string;
+        "if-no-files-found"?: string;
+      };
+    }>;
   }>;
 }
 
@@ -50,6 +63,9 @@ describe("#4308 device WebRTC integration workflow", () => {
     expect(filter?.with?.filters).toContain("examples/mediamtx/**");
     expect(filter?.with?.filters).toContain("scripts/webrtc/**");
     expect(filter?.with?.filters).toContain("test/integration/webrtcDeviceCapture.integration.test.ts");
+    // The stage-latency helper runs inside the device lane, so a change to it
+    // has to re-run that lane (#4343).
+    expect(filter?.with?.filters).toContain("test/helpers/captureStageTimeline.ts");
     expect(filter?.with?.filters).toContain(WORKFLOW_PATH);
   });
 
@@ -76,6 +92,21 @@ describe("#4308 device WebRTC integration workflow", () => {
     expect(buildIndex).toBeGreaterThanOrEqual(0);
     expect(androidSteps[buildIndex]?.with?.["gradle-tasks"]).toContain(":control-proxy:assembleDebug");
     expect(emulatorIndex).toBeGreaterThan(buildIndex);
+  });
+
+  test("keeps the stage-latency artifacts from passing runs without making the upload required (#4343)", () => {
+    const document = workflow();
+
+    for (const jobId of ["android-device-webrtc", "ios-device-webrtc"]) {
+      const upload = document.jobs?.[jobId]?.steps?.find(
+        step => step.uses?.startsWith("actions/upload-artifact") === true
+      );
+
+      expect(upload?.if).toBe("always()");
+      expect(upload?.["continue-on-error"]).toBe(true);
+      expect(upload?.with?.path).toBe("scratch/webrtc-device-integration/");
+      expect(upload?.with?.["if-no-files-found"]).toBe("ignore");
+    }
   });
 
   test("uses the checkout's video-server jar for Android capture", () => {

--- a/test/server/webrtcStreamManager.test.ts
+++ b/test/server/webrtcStreamManager.test.ts
@@ -560,4 +560,50 @@ describe("webrtcStreamManager", () => {
     expect(publishers[1].stopped).toBe(false);
     expect(sources[1].stopped).toBe(false);
   });
+
+  test("reports sourceStarted only once the capture source has actually started (#4343)", async () => {
+    const publishers: AsyncConnectedPublisher[] = [];
+    const sources: FakeSource[] = [];
+    let releaseSourceStart!: () => void;
+    const sourceStartGate = new Promise<void>(resolve => {
+      releaseSourceStart = resolve;
+    });
+    setWebRtcStreamManagerDependencies({
+      idGenerator: new CountingIdGenerator("id"),
+      createPublisher: (config, deps) => {
+        const publisher = new AsyncConnectedPublisher(config, deps);
+        publishers.push(publisher);
+        return publisher as unknown as WebRtcPublisher;
+      },
+      createSource: () => {
+        const source = new FakeSource();
+        source.start = async () => {
+          await sourceStartGate;
+          source.started = true;
+        };
+        sources.push(source);
+        return source as unknown as AndroidH264Source;
+      },
+      resolveVideoJar: async () => null,
+      now: () => new Date("2026-07-11T00:00:00.000Z"),
+    });
+
+    // A video-only stream returns from start as soon as the publisher connects;
+    // the capture source starts afterwards, so the two are distinguishable.
+    const descriptor = await startWebRtcStream({
+      device: ANDROID,
+      overrides: { whipEndpoint: ENDPOINT },
+    });
+    expect(descriptor.sourceStarted).toBe(false);
+    expect(getWebRtcStreamDescriptor(descriptor.streamId)?.sourceStarted).toBe(false);
+
+    releaseSourceStart();
+    await sourceStartGate;
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(sources[0].started).toBe(true);
+    expect(getWebRtcStreamDescriptor(descriptor.streamId)?.sourceStarted).toBe(true);
+    expect(listWebRtcStreams()[0].sourceStarted).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

The device capture lane added by [PR #4317](https://github.com/kaeawc/auto-mobile/pull/4317) proves `capture → WHIP → MediaMTX → WHEP → browser decode` works, but its successful output reported only a whole-test duration — which cannot separate daemon preparation, WHIP readiness, source startup, relay readiness, and browser decode.

This records one monotonic elapsed measurement per stage of that pipeline, with the capture profile needed to compare samples across runners, and keeps the record on passing runs as well as failures.

## Linked Issue

Closes [#4343](https://github.com/kaeawc/auto-mobile/issues/4343)

## Changes

- `test/helpers/captureStageTimeline.ts` (new) — the six canonical stages in pipeline order, an injected millisecond reader (defaulting to `performance.now()`, not `Date.now()`), and the record/summary shape. First mark sets the origin; repeated marks keep the first observation so a polling loop can call it on every iteration; out-of-order observations report their real elapsed value (negative delta) rather than being clamped, because the concurrent status poller can see the first encoded frame before the start request returns.
- `test/integration/webrtcDeviceCapture.integration.test.ts` — marks all six stages, queries the source resolution (`wm size` / `simctl io enumerate`), and writes `stage-latency.json` + a human-readable `result.txt` from the `finally` block, also echoing the summary to the job log. `whipConnected` needs a concurrent poller: the start request only returns once the publisher has connected **and** the source has started, so those two are otherwise indistinguishable. The poller never throws and every existing wait keeps its own timeout.
- `.github/workflows/webrtc-device-integration.yml` — both device lanes upload artifacts on `always()` with `continue-on-error: true`, so passing runs contribute samples while a missing or failed upload cannot turn a green capture lane red. The paths filter now also includes the stage-latency helper.

Deliberately unchanged: the real-frame and visual-change assertions, and every timeout — `deviceIntegrationTimeoutMs` and each `waitFor` budget stay exactly as they were until CI samples give a p50/p95 baseline.

## Acceptance criteria

| Criterion | Where |
| --- | --- |
| Monotonic elapsed time per stage | `CaptureStageTimeline` + the six `timeline.mark(...)` call sites |
| Preserved on failures **and** successful runs, not a required upload | record written in `finally`; `if: always()` + `continue-on-error: true` + `if-no-files-found: ignore` |
| Platform, source resolution, configured FPS, first decoded dimensions | `CaptureStageContext` fields on the record |
| Hermetic unit coverage with injected time; no device-dependent timing assertion | `test/helpers/captureStageTimeline.test.ts` (fake clock); guard asserting the integration test makes no assertion on a measured duration |
| Several Android/iOS samples → p50/p95 before changing timeout contracts | no timeout contract changed here; sample collection tracked as a follow-up |

## Validation

- [x] `scripts/all_fast_validate_checks.sh` (25/25 pass)
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun test` — 9045 pass, 0 fail
- [x] `bun run typecheck` — one pre-existing local-only `ajv`/`ajv-formats` resolution error in `src/utils/plan/PlanSchemaValidator.ts`, untouched by this PR (no `src/` files change here); CI runs the gate on a clean install
- [x] New code uses an injected clock; the new unit suite runs in ~130ms

## Device Verification

Both device lanes are triggered by this PR (the workflow file is in its own paths filter), so the Android and iOS runs on this PR are the first two latency samples.

## Follow-ups

- [ ] Collect several Android and iOS samples from CI and report p50/p95 before proposing any timeout change (issue filed after merge).


---

## Review round (second commit)

The first CI run produced real samples, and reviewing them showed three of the six stage numbers did not measure the event they were named for. Fixed here:

**`sourceStarted` measured the start response, not the source.** A video-only stream connects and *then* starts capture: `fireConnected` dispatches `onConnected` with `void Promise.resolve().then(...)` ([WebRtcPublisher.ts](src/features/webrtc/WebRtcPublisher.ts)), which `establish()` never awaits, and the audio await is skipped when audio is off. The mark therefore collapsed onto `whipConnected` — the live iOS run recorded `sourceStarted 5517ms` against `whipConnected 5569ms`, a negative delta that was pure poll lag. The stream manager now tracks whether the capture source started and surfaces `sourceStarted` on the descriptor, so the lane observes the real transition. This is the one `src/` change: additive, behavior-free, covered by a new manager test that gates the source start behind a promise.

**`whepConnected` was mostly Chrome cold start.** The browser is now launched before the measured window opens (`launchReader` / `subscribeReader` split), leaving navigate + WHEP connect in the stage.

**iOS source resolution was the CarPlay screen.** The first `Pixel Size:` in `simctl io enumerate` is CarPlay's, so every iOS sample reported `720x480` instead of the display — visible in the run above. Now goes through `SimCtlClient.getScreenSize`, which gates on the integrated display.

Also: the record is written from `afterAll` rather than the body's `finally`, because bun skips that `finally` on a timeout and would drop exactly the slowest samples (biasing the p95 low); the record carries run identity (`runId`/`runAttempt`/`commitSha`/runner) and the poll intervals, without which percentiles over several samples cannot be attributed or given an error bar; the observer polls `list` so it stops writing daemon error lines before the stream registers; artifact names carry `github.run_attempt` so a re-run cannot 409 into a silently lost sample; and a green run no longer uploads the daemon data dir alongside the record.

The guards were failing open — a commented-out mark, a reordered mark, a multi-line timing assertion, and a write moved out of the cleanup path all passed. They now strip comments, pin mark order, match call sites rather than declarations, and were verified against each of those mutations.

### First samples

Android (passed):
```
source=320x640 fps=60 decoded=320x640
  startRequest        0ms
  whipConnected     180ms (+180)
  sourceStarted     139ms (+-41)   <- the bug: same event, poll lag
  firstEncodedFrame 6104ms (+5965)
  whepConnected     7561ms (+1457) <- included Chrome cold start
  firstDecodedFrame 13219ms (+5658)
```

iOS failed at the frame wait with `capture source did not deliver H.264 frames` — the same error, on the same lane, as job 89350836874 on [PR #4317](https://github.com/kaeawc/auto-mobile/pull/4317)'s branch before this change. Pre-existing flake, not caused by this PR; tracked separately. The artifact upload ran and succeeded on that failure, which is AC2 demonstrated on a live runner.
