### PR TITLE
test(release): address the 0.0.44 checksum entry by version, not by index

### DIFF
--- a/test/constants/release.test.ts
+++ b/test/constants/release.test.ts
@@ -508,12 +508,15 @@ describe("iOS runner-binary checksum", function() {
     expect(IOS_CTRL_PROXY_RUNNER_SHA256_CHECKSUM).toBe(RELEASE_CHECKSUM_REGISTRY[0].runnerSha256);
   });
 
-  test("registry[0] (0.0.44) is a coherent triple after the #3784 runner-sha repair", function() {
-    const v0044 = RELEASE_CHECKSUM_REGISTRY[0];
-    expect(v0044.version).toBe("0.0.44");
+  test("the 0.0.44 entry is a coherent triple after the #3784 runner-sha repair", function() {
+    // Addressed by version, not by index: the registry is prepended on every
+    // release, so pinning [0] made each version bump red main (#4353) — and bumps
+    // ship [skip ci], so nothing caught it until the next PR branched.
+    const v0044 = RELEASE_CHECKSUM_REGISTRY.find(entry => entry.version === "0.0.44");
+    expect(v0044).toBeDefined();
     // The runner inside the published 0.0.44 IPA, not the orphaned nightly sha.
-    expect(v0044.runnerSha256).toBe("b281f9fd516116164a76dc049a413d5123bfb7bf96c79c6ad654ba90c08ed982");
-    expect(v0044.runnerSha256).not.toBe(NIGHTLY_CHECKSUM_ENTRY.runnerSha256);
+    expect(v0044?.runnerSha256).toBe("b281f9fd516116164a76dc049a413d5123bfb7bf96c79c6ad654ba90c08ed982");
+    expect(v0044?.runnerSha256).not.toBe(NIGHTLY_CHECKSUM_ENTRY.runnerSha256);
   });
 });
 


### PR DESCRIPTION
## Summary

`main` is red and every PR branched after [`2c3468867`](https://github.com/kaeawc/auto-mobile/commit/2c3468867) inherits the failure. This unblocks it.

`test/constants/release.test.ts` asserted the registry's **first element** by hard-coded version. `RELEASE_CHECKSUM_REGISTRY` is prepended on every release, so the v0.0.45 bump displaced 0.0.44 from index 0:

```
error: expect(received).toBe(expected)
Expected: "0.0.44"
Received: "0.0.45"
  at test/constants/release.test.ts:513:27
```

Version-bump commits ship `[skip ci]`, so nothing ran on the bump itself — the breakage only surfaced on the next PR to branch from `main` ([PR #4352](https://github.com/kaeawc/auto-mobile/pull/4352)).

## Linked Issue

Closes [#4353](https://github.com/kaeawc/auto-mobile/issues/4353)

## Bug / Regression Context

- **Prior attempts:** none — this is the first occurrence since the registry gained a second entry.
- **Observed symptom:** `Node TypeScript Build and Test` fails on all three OS legs with a single failing assertion, on any branch cut from `main` at or after the v0.0.45 bump.
- **Repro steps / conditions:** `bun test test/constants/release.test.ts` on current `main`.

## Changes

Look the 0.0.44 entry up by `version` rather than position, so a later release cannot displace it:

```ts
const v0044 = RELEASE_CHECKSUM_REGISTRY.find(entry => entry.version === "0.0.44");
expect(v0044).toBeDefined();
```

The properties the test actually cares about — the repaired runner sha from [#3784](https://github.com/kaeawc/auto-mobile/issues/3784) and its distinctness from the nightly slot — are unchanged. The test name loses its now-misleading `registry[0]` prefix.

The sibling test `module-level runner checksum export resolves from registry[0]` is deliberately left alone: it compares the export against whatever `registry[0]` currently is, which is the "latest wins" property it exists to pin, and it does not hard-code a version.

## Deliberately not in scope

[#4353](https://github.com/kaeawc/auto-mobile/issues/4353) also raises whether release bumps should carry `[skip ci]` at all, given a commit that edits `src/` can red `main` invisibly. That is a release-automation decision, not a test fix, and is left on the issue.

## Validation

- [x] `bun test` — 9067 pass, 0 fail (fresh worktree on this branch)
- [x] `bun test test/constants/release.test.ts` — 71 pass, 0 fail (was 70 pass / 1 fail on `main`)
- [x] `bun run lint`
- [x] Rebased onto latest `main` (branched from `2c3468867`)
