### PR TITLE
ci(release): stop the release start and checksum gate from failing open

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -36,6 +36,13 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     needs: [build-ctrl-proxy-ios-ipa, build-control-proxy-apk, build-video-server-jar]
+    # Restates the workflow-level grant because a job-level block replaces it
+    # wholesale. actions: write is for the "Start the release" fallback dispatch,
+    # and is scoped here so the reusable APK/IPA/jar builders do not inherit it.
+    permissions:
+      contents: write
+      issues: read
+      actions: write
 
     steps:
       - name: Checkout code
@@ -207,43 +214,63 @@ jobs:
       - name: Start the release
         shell: bash
         env:
-          # The default GITHUB_TOKEN cannot dispatch a workflow run from inside a
-          # run; reuse the PAT that pushed the tag.
-          GH_TOKEN: ${{ secrets.AUTO_MOBILE_PR_TOKEN }}
+          # workflow_dispatch is one of the two events GitHub exempts from "with
+          # the exception of workflow_dispatch and repository_dispatch, other
+          # GITHUB_TOKEN-triggered events do not create workflow runs at all", so
+          # the default token can start Release. It only needs actions: write,
+          # granted on this job above, rather than a PAT scope to keep in sync.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ inputs.version }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          # Pushing the tag does not start Release on its own: the create event
-          # never fired for the tags CI pushed at 0.0.42 and 0.0.44, so every
-          # release since has been published by hand. Dispatch it explicitly.
-          # (Those two tags were v-prefixed at the time and have since been
-          # deleted, so don't go looking for them in `git tag --list`.)
+          # Pushing the tag normally starts Release by itself, through the
+          # `create:` trigger in release.yml: only refs pushed by GITHUB_TOKEN are
+          # suppressed from starting runs, and the checkout above authenticates
+          # with a PAT. Verify that instead of assuming it -- a tag that queues
+          # nothing is a silent non-release, and CI reports green either way.
+          #
+          # Filter on the tag. Every branch creation queues its own release.yml
+          # run (validate-release-tag skips them), so "newest run changed" would
+          # be satisfied by an unrelated branch and report a release that is not
+          # running.
+          find_release_run() {
+            gh run list --repo "$REPO" --workflow release.yml --branch "$TAG" \
+              --limit 1 --json databaseId --jq '.[].databaseId // empty'
+          }
+
+          for _ in $(seq 1 12); do
+            run_id="$(find_release_run)"
+            if [[ -n "$run_id" ]]; then
+              echo "Release is running for $TAG (run ${run_id})"
+              exit 0
+            fi
+            sleep 5
+          done
+
+          # The tag event did not take. Fall back to dispatching explicitly, so a
+          # regression in that path costs a delay rather than another hand-run
+          # release. Dispatching is only reached when nothing is queued, so this
+          # cannot double-build a tag that already started.
           #
           # Dispatch on the TAG, not on main. github.ref has to stay a tag ref:
           # action-gh-release derives its tag from it, docker/metadata-action's
           # type=semver is inert without it, and the reusable APK/IPA/jar builders
           # run at the caller's ref -- on main they would build a different tree
           # than the checksums minted just above were computed from.
-          #
-          # Re-dispatching an already-released tag is safe: every non-idempotent
-          # publish step consults scripts/release/already-published.sh first.
-          before=$(gh run list --repo "$REPO" --workflow release.yml \
-            --limit 1 --json databaseId --jq '.[].databaseId // 0')
-
+          echo "No Release run appeared for $TAG after 60s; dispatching it" >&2
           gh workflow run release.yml --repo "$REPO" --ref "$TAG" -f tag="$TAG"
 
           # The dispatch API returns 204 before the run exists and gh does not
           # wait, so `gh workflow run` succeeds even if no run is ever created.
           # A green step here with nothing queued is the same silent non-release
-          # this change exists to fix, so confirm a new run actually appeared.
+          # this step exists to catch, so confirm a run actually appeared.
           for _ in $(seq 1 12); do
             sleep 5
-            after=$(gh run list --repo "$REPO" --workflow release.yml \
-              --limit 1 --json databaseId --jq '.[].databaseId // 0')
-            if [[ "$after" != "$before" ]]; then
-              echo "Dispatched release.yml for $TAG (run ${after})"
+            run_id="$(find_release_run)"
+            if [[ -n "$run_id" ]]; then
+              echo "Dispatched release.yml for $TAG (run ${run_id})"
               exit 0
             fi
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,29 +164,47 @@ jobs:
           name: video-server-jar
           path: /tmp
 
+      # These three steps run the release's only artifact-provenance gate, and
+      # both halves of the original form failed open. `bash -e` without pipefail
+      # takes its status from `tee`, so verify-artifact-sha256.sh's exit 1 on a
+      # mismatch was discarded; and `grep | cut` takes its status from `cut`, so
+      # finding no `checksum=` line set an empty output instead of aborting. A
+      # mismatched APK therefore sailed through green and only stopped later, at
+      # generate-release-constants.sh's "requires both" guard, reported as a
+      # missing variable rather than the mismatch it was. Keep pipefail and the
+      # non-empty assertion together: either one alone still lets a case through.
       - name: "Verify APK SHA256 matches source"
         id: verify_checksum
+        shell: bash
         run: |
+          set -euo pipefail
           bash scripts/ci/verify-artifact-sha256.sh \
             /tmp/control-proxy-debug.apk android | tee /tmp/apk-verify.log
           CHECKSUM=$(grep '^checksum=' /tmp/apk-verify.log | cut -d= -f2)
-          echo "checksum=$CHECKSUM" >> $GITHUB_OUTPUT
+          [ -n "$CHECKSUM" ] || { echo "No checksum= line in APK verify log" >&2; exit 1; }
+          echo "checksum=$CHECKSUM" >> "$GITHUB_OUTPUT"
 
       - name: "Verify CtrlProxy iOS IPA SHA256 matches source"
         id: verify_ipa_checksum
+        shell: bash
         run: |
+          set -euo pipefail
           bash scripts/ci/verify-artifact-sha256.sh \
             /tmp/control-proxy.ipa ios | tee /tmp/ipa-verify.log
           CHECKSUM=$(grep '^checksum=' /tmp/ipa-verify.log | cut -d= -f2)
-          echo "checksum=$CHECKSUM" >> $GITHUB_OUTPUT
+          [ -n "$CHECKSUM" ] || { echo "No checksum= line in IPA verify log" >&2; exit 1; }
+          echo "checksum=$CHECKSUM" >> "$GITHUB_OUTPUT"
 
       - name: "Verify video-server jar SHA256 matches source"
         id: verify_video_jar_checksum
+        shell: bash
         run: |
+          set -euo pipefail
           bash scripts/ci/verify-artifact-sha256.sh \
             /tmp/automobile-video.jar videojar | tee /tmp/videojar-verify.log
           CHECKSUM=$(grep '^checksum=' /tmp/videojar-verify.log | cut -d= -f2)
-          echo "checksum=$CHECKSUM" >> $GITHUB_OUTPUT
+          [ -n "$CHECKSUM" ] || { echo "No checksum= line in jar verify log" >&2; exit 1; }
+          echo "checksum=$CHECKSUM" >> "$GITHUB_OUTPUT"
 
       - name: Generate release constants
         env:

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -145,9 +145,12 @@
 # wiring link that regresses silently is the exact defect this whole area exists
 # to prevent. `yq` reads the real trigger and step fields instead.
 #
-# Pushing the tag does not start Release on its own: the `create` event never
-# fired for the tags CI pushed at 0.0.42 and 0.0.44, so ~26 versions were
-# published by hand while CI reported green.
+# Pushing the tag does start Release on its own -- release.yml's `create:`
+# trigger fired for 0.0.43, 0.0.44 and 0.0.45, all pushed by CI. The premise
+# recorded here originally (that `create` never fires for CI-pushed tags) was a
+# misread: what failed at 0.0.44 was a v-prefixed tag losing the validation gate,
+# not a missing run. So prepare-release confirms a run exists for the tag and
+# only dispatches when none does; the assertions below pin that fallback.
 
 # Skipping locally is a convenience; skipping in CI would silently retire every
 # assertion below, which is the same fail-green these guards exist to catch.
@@ -183,6 +186,26 @@ wiring_requires_yq() {
   [[ "$code" == *"gh workflow run release.yml"* ]]
   [[ "$code" == *'--ref "$TAG"'* ]]
   [[ "$code" != *"--ref main"* ]]
+
+  # Whichever route starts Release, the check has to be scoped to this tag.
+  # Comparing against the newest run of any branch matches the release.yml run
+  # that every branch creation queues, which reports a release that is not there.
+  [[ "$code" == *'--branch "$TAG"'* ]]
+}
+
+# The dispatch API rejects a token without actions: write, and the job-level
+# block replaces the workflow-level grant wholesale -- so dropping either half
+# turns the fallback into the 403 that failed Prepare Release #204.
+@test "prepare-release can dispatch and still push (#4157)" {
+  wiring_requires_yq
+  local perms
+  perms="$(yq -r '.jobs.prepare.permissions' ".github/workflows/prepare-release.yml")"
+  [ "$perms" != "null" ]
+
+  run yq -r '.jobs.prepare.permissions.actions' ".github/workflows/prepare-release.yml"
+  [ "$output" = "write" ]
+  run yq -r '.jobs.prepare.permissions.contents' ".github/workflows/prepare-release.yml"
+  [ "$output" = "write" ]
 }
 
 # action-gh-release throws "GitHub Releases requires a tag" when github.ref is not
@@ -226,6 +249,29 @@ wiring_requires_yq() {
     ".github/workflows/release.yml" | grep -v '^[[:space:]]*#')"
   [[ "$runs" == *'state=$(scripts/release/already-published.sh'* ]]
   [[ "$runs" != *'if [ "$(scripts/release/already-published.sh'* ]]
+}
+
+# The artifact checksum gate is the only thing standing between a stale APK/IPA
+# and a published release, and it failed open twice over in release 0.0.45:
+# `bash -e` without pipefail takes the pipeline's status from `tee`, discarding
+# the script's exit 1, and `grep | cut` takes its status from `cut`, so a missing
+# `checksum=` line produced an empty output rather than an abort.
+@test "release.yml artifact checksum gate cannot fail open (#4157)" {
+  wiring_requires_yq
+  local step
+  for step in verify_checksum verify_ipa_checksum verify_video_jar_checksum; do
+    local script
+    script="$(yq -r ".jobs.\"verify-and-release\".steps[] | select(.id == \"$step\") | .run" \
+      ".github/workflows/release.yml" | grep -v '^[[:space:]]*#')"
+    [ -n "$script" ]
+    [ "$script" != "null" ]
+
+    # pipefail propagates the verify script's mismatch exit through `tee`.
+    [[ "$script" == *"pipefail"* ]]
+    # The emptiness check catches the grep-into-cut case, which pipefail alone
+    # does not: cut succeeds on empty input, so the pipeline status stays 0.
+    [[ "$script" == *'[ -n "$CHECKSUM" ]'* ]]
+  done
 }
 
 # A dispatch that merely names the tag is not enough: the Actions UI ref picker


### PR DESCRIPTION
## Summary

[Prepare Release #204](https://github.com/kaeawc/auto-mobile/actions/runs/30062117395) failed at "Start the release" with `HTTP 403: Resource not accessible by personal access token`. The step dispatches `release.yml` using `AUTO_MOBILE_PR_TOKEN`, which has repo `Actions: Read` but not write — the `gh run list` call immediately above it succeeded, and everything else the job did (commit to main, push the tag) is `Contents: write`.

Chasing that turned up two things, and the second is the more serious one.

**The dispatch was never needed.** `release.yml`'s `create:` trigger fired for 0.0.45 on its own — [Release #494](https://github.com/kaeawc/auto-mobile/actions/runs/30062209884) — and for 0.0.43 and 0.0.44 before it. Only refs pushed by `GITHUB_TOKEN` are suppressed from starting workflow runs, and `prepare`'s checkout has authenticated with a PAT since long before any of those tags. The premise recorded in [#4157](https://github.com/kaeawc/auto-mobile/pull/4157) — that `create` never fires for CI-pushed tags — was a misread of 0.0.44, where a `v`-prefixed tag lost the validation gate rather than queueing nothing:

```
494 | 0.0.45  | create | in_progress | 2026-07-24
 27 | 0.0.44  | create | success     | 2026-07-11
 26 | v0.0.44 | create | failure     | 2026-07-11
 20 | 0.0.43  | create | success     | 2026-07-10
```

So this inverts the step: confirm a Release run exists for the tag, and dispatch only if none does. That keeps the verification half of #4157 — which is the valuable half, since a tag that queues nothing is a silent non-release — without double-building every tag once the token is fixed. The fallback moves to `GITHUB_TOKEN` with a job-scoped `actions: write`, so there is no PAT scope to keep in sync; `workflow_dispatch` is one of the two events GitHub exempts from *"other `GITHUB_TOKEN`-triggered events do not create workflow runs at all"*.

The existing `before`/`after` comparison was also wrong on its own terms: it watched the newest `release.yml` run of **any** branch, and every branch creation queues one, so an unrelated branch would have satisfied it. The check is now scoped with `--branch "$TAG"`.

**The artifact checksum gate fails open.** This is the release's only provenance check, and both halves of it swallow failure:

```bash
verify-artifact-sha256.sh /tmp/control-proxy-debug.apk android | tee /tmp/apk-verify.log
CHECKSUM=$(grep '^checksum=' /tmp/apk-verify.log | cut -d= -f2)
```

`bash -e` without `pipefail` takes the pipeline's status from `tee`, discarding the script's `exit 1` on a mismatch. Then `grep | cut` takes its status from `cut`, so finding no `checksum=` line sets an empty output rather than aborting. Demonstrated directly:

```
--- OLD form (bash -e, no pipefail) ---
ERROR: SHA256 mismatch
reached end, CHECKSUM=''
old exit=0
--- NEW form ---
ERROR: SHA256 mismatch
new exit=1
```

Release #494 hit a **real** SHA256 mismatch on both the APK and the IPA, reported both verify steps green, and died two steps later at `generate-release-constants.sh` as `RELEASE_VERSION requires both APK_SHA256_CHECKSUM and IOS_CTRL_PROXY_SHA256_CHECKSUM` — a missing variable rather than the mismatch it was. All three verify steps now set `pipefail` and assert the checksum is non-empty; either guard alone still lets one case through.

> **Note:** this PR briefly carried a second commit fixing the `registry[0]`-pinned test that the 0.0.45 bump turned red. [#4355](https://github.com/kaeawc/auto-mobile/pull/4355) landed the same fix on `main` first, so that commit has been dropped and the branch rebased. This PR is now workflows-only.

## Linked Issue

No issue — this starts from a live release failure.

## Bug / Regression Context

- **Prior attempts:** [#4157](https://github.com/kaeawc/auto-mobile/pull/4157) added the explicit dispatch on a premise this PR corrects.
- **Observed symptom:** `prepare` red at "Start the release" (403); 0.0.45 tagged but unpublished.
- **Repro steps / conditions:** run Prepare Release with `AUTO_MOBILE_PR_TOKEN` lacking `Actions: write`.

## Reviewer note — this does not make 0.0.45 releasable

Landing the fail-closed gate means the next release **hard-fails at the APK step**, because the mismatch is real:

| | prepare-release built | release.yml rebuilt |
|---|---|---|
| APK | `68dbf04b` → committed to `release.ts` | `d9ec7ea0` → attached to the Release |
| IPA | `8c678b2d` → committed | `d1f98462` → attached |
| jar | `bae314fb` | `bae314fb` ✓ |

The cause looks structural. In `prepare-release.yml` the three builders are `needs:` of `prepare`, so they build **main before the version-bump commit** (APK at 02:38:28) and those checksums go into `release.ts`; `prepare` then commits the bump and tags it, and `release.yml` rebuilds from **the tag** (02:42) and attaches its own build. Different tree, different hash. The jar matches because it is built with `verify-reproducible: true`.

That means the shipped `release.ts` can record a checksum for an artifact that is not the one attached to the Release — the same incoherence the `RELEASE_CHECKSUM_REGISTRY` header comment describes for the nightly case. One thing does not fit the theory and is worth closing before trusting it: 0.0.44's registry entry (`e95f2b14` / `73dd4551`) matches its published asset digests exactly.

Two ways out, deliberately **not** decided here:

1. **Attach what you checksummed** — `release.yml` downloads the prepare run's artifacts instead of rebuilding. The gate becomes a true equality check; needs cross-run artifact download.
2. **Checksum what you attach** — move the constants update after the tag, from `release.yml`'s own build. Smaller, but inverts the current prepare→tag ordering.

Reviewers who would rather not have a red gate in `main` while that is open can ask for the `release.yml` half to be split out; the `prepare-release.yml` 403 fix stands alone.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes (25/25)
- [x] `bats test/bats/release-workflow-wiring.bats` passes (25/25, including 2 new guards)
- [x] `bun test test/constants/release.test.ts` passes (71/71) after rebasing onto #4355
- [x] `bun run lint` clean
- [x] Extracted the rewritten "Start the release" script and ran it under `shellcheck -x` (clean) plus a stubbed `gh`, exercising all three paths: run already queued (1 API call, no dispatch), nothing queued (dispatch + confirm), never appears (exit 1)
- [x] Verified the fail-open/fail-closed behavior of the old and new verify-step forms directly, output above
- [ ] `bun run typecheck` — not run; no TypeScript changed
- [ ] Device verification — N/A, CI-only change

## Follow-ups

- [ ] File the checksum/ordering issue once the direction above is chosen.
