### PR TITLE
fix(observe): derive isTaskRoot from dumpsys rootOfTask, not the Hist index

### DIFF
--- a/src/features/observe/GetBackStack.ts
+++ b/src/features/observe/GetBackStack.ts
@@ -267,6 +267,14 @@ export class GetBackStack implements BackStack {
         continue;
       }
 
+      if (HIST_LINE.test(line)) {
+        // A Hist row in a shape parseHistRow does not recognize still starts a
+        // new record, so the previous record's block is over; without this, the
+        // unrecognized record's rootOfTask= would land on the previous activity.
+        openActivity = undefined;
+        continue;
+      }
+
       // The current record's own rootOfTask= field (see ROOT_OF_TASK_LINE).
       const rootOfTask = line.match(ROOT_OF_TASK_LINE);
       if (rootOfTask && openActivity) {
@@ -297,8 +305,10 @@ export class GetBackStack implements BackStack {
     // for the same task ("Task id #N" then "* TaskRecord{... #N ...}"), so the
     // second must resume the first's count rather than restart it.
     const histCounts: Map<number, number> = new Map();
-    // The component of each task's "Hist #0" row. `Hist #0` is the task root
-    // (see #4197), and its "pkg/.Cls" is the same shape legacy `realActivity=`
+    // The component of each task's "Hist #0" row. `Hist #0` is normally the
+    // task root (see #4197; the authoritative rootOfTask= field can disagree
+    // on API 30+, see #4340 -- close enough for the package-name fallback this
+    // feeds), and its "pkg/.Cls" is the same shape legacy `realActivity=`
     // prints. This is the ONLY package source on the modern path (issue #4263):
     // a modern header's `A=` is `Task.affinity`, which is uid-prefixed on
     // Android 11+, is an app-declarable string that need not name a package,

--- a/src/features/observe/GetBackStack.ts
+++ b/src/features/observe/GetBackStack.ts
@@ -118,6 +118,25 @@ const MODERN_TASK_HEADER = /^\s*\*\s*Task\{\S+\s+#(\d+)\b(.*)$/;
 /** "* Hist  #0: ActivityRecord{...}" -- one printed activity. */
 const HIST_LINE = /\bHist\s+#\d+:/;
 
+/**
+ * `rootOfTask=<bool>` out of an ActivityRecord block (issue #4340). Printed by
+ * `ActivityRecord.dump` from API 30 on as its own field line a few lines below
+ * the record's `Hist #N:` row:
+ *
+ *     * Hist  #1: ActivityRecord{c87b532 u0 com.google...nexuslauncher/.NexusLauncherActivity t7}
+ *         ...
+ *         rootOfTask=true task=Task{97acb18 #7 type=home I=...}
+ *
+ * This is the authoritative task-root answer; the `Hist #N` index is not. Real
+ * captures disagree with the index in both directions: the launcher is the root
+ * of its task yet prints as `Hist #1` on API 35/36, and API 34 prints a
+ * `Hist #0` row whose block says `rootOfTask=false`. Anchored to the start of
+ * the line so the inline `task=Task{...}` tail of the same line -- or any other
+ * mention -- cannot match. Absent on API <= 29, where the index heuristic
+ * remains the only source.
+ */
+const ROOT_OF_TASK_LINE = /^\s*rootOfTask=(true|false)\b/;
+
 /** Fields carried by a modern task header line. */
 interface TaskHeaderFields {
   id: number;
@@ -188,6 +207,11 @@ export class GetBackStack implements BackStack {
 
     let currentTaskId = -1;
     let currentTaskAffinity: string | undefined;
+    // The last parsed activity, while the scan is still inside its
+    // ActivityRecord block -- the target for that block's `rootOfTask=` line.
+    // Cleared at the next Hist row or task header, so a value can never bleed
+    // into the following record (issue #4340).
+    let openActivity: ActivityInfo | undefined;
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
@@ -200,6 +224,7 @@ export class GetBackStack implements BackStack {
         // to the standalone "affinity=" line handled just below. Reset either
         // way so one task's affinity cannot leak onto the next task.
         currentTaskAffinity = header.affinity;
+        openActivity = undefined;
         logger.debug(`[BACK_STACK] Found task ID: ${currentTaskId}`);
       }
 
@@ -231,11 +256,22 @@ export class GetBackStack implements BackStack {
           name: activityName,
           taskId: taskIdFromActivity,
           taskAffinity: currentTaskAffinity,
+          // Index-derived fallback, authoritative only on API <= 29; overridden
+          // below by the block's own rootOfTask= line when one is printed.
           isTaskRoot: histIndex === 0
         };
 
         activities.push(activity);
+        openActivity = activity;
         logger.debug(`[BACK_STACK] Found activity: ${activityName} (task: ${taskIdFromActivity})`);
+        continue;
+      }
+
+      // The current record's own rootOfTask= field (see ROOT_OF_TASK_LINE).
+      const rootOfTask = line.match(ROOT_OF_TASK_LINE);
+      if (rootOfTask && openActivity) {
+        openActivity.isTaskRoot = rootOfTask[1] === "true";
+        openActivity = undefined;
       }
     }
 
@@ -441,8 +477,9 @@ export class GetBackStack implements BackStack {
 
       // Calculate depth: number of activities in current task minus 1 (the current activity).
       // This is the number of entries that can still be popped from the current task.
-      // isTaskRoot is set during parsing from the activity's own "Hist #N" index -- the
-      // root is the #0 entry, which dumpsys prints LAST because it lists top-to-bottom.
+      // isTaskRoot is set during parsing from the record's own rootOfTask= field (API 30+),
+      // falling back to the "Hist #N" index -- #0 is the root -- where the field is not
+      // printed (API <= 29). See ROOT_OF_TASK_LINE and issue #4340.
       const currentTaskId = currentActivity?.taskId || -1;
       const activitiesInCurrentTask = activities.filter(a => a.taskId === currentTaskId);
       const depth = Math.max(0, activitiesInCurrentTask.length - 1);

--- a/test/features/observe/GetBackStackParsing.test.ts
+++ b/test/features/observe/GetBackStackParsing.test.ts
@@ -252,4 +252,45 @@ describe("GetBackStack real-output parsing (#4197)", () => {
       expect(result.activities[0].isTaskRoot).toBe(true);
     });
   });
+
+  // `rootOfTask=` is printed inside each ActivityRecord block from API 30 on and
+  // is the authoritative task-root answer; the Hist-index heuristic disagrees
+  // with it in both directions on real devices (issue #4340). These fixtures are
+  // contrived -- a real task has exactly one root -- to pin the parser mechanics
+  // in isolation: override in both directions, and no bleed across records.
+  describe("rootOfTask overrides the Hist-index heuristic (#4340)", () => {
+    test("an explicit rootOfTask= wins over the index in both directions", async () => {
+      const result = await parse(`
+ACTIVITY MANAGER ACTIVITIES (dumpsys activity activities)
+Display #0 (activities from top to bottom):
+  * Task{d19dee2 #61 type=standard A=10164:com.example U=0 visible=true mode=fullscreen sz=2}
+    * Hist  #1: ActivityRecord{2b2ce0f u0 com.example/.DetailActivity t61}
+        packageName=com.example processName=com.example
+        rootOfTask=true task=Task{d19dee2 #61 type=standard A=10164:com.example}
+    * Hist  #0: ActivityRecord{7ff01aa u0 com.example/.MainActivity t61}
+        packageName=com.example processName=com.example
+        rootOfTask=false task=Task{d19dee2 #61 type=standard A=10164:com.example}
+`);
+
+      expect(result.activities.map(a => a.isTaskRoot)).toEqual([true, false]);
+    });
+
+    test("a rootOfTask value never bleeds into the following record", async () => {
+      // The second record prints no rootOfTask= line, so it must fall back to
+      // its own Hist index (#0 -> true), not inherit the previous record's
+      // `false`.
+      const result = await parse(`
+ACTIVITY MANAGER ACTIVITIES (dumpsys activity activities)
+Display #0 (activities from top to bottom):
+  * Task{d19dee2 #61 type=standard A=10164:com.example U=0 visible=true mode=fullscreen sz=2}
+    * Hist  #1: ActivityRecord{2b2ce0f u0 com.example/.DetailActivity t61}
+        packageName=com.example processName=com.example
+        rootOfTask=false task=Task{d19dee2 #61 type=standard A=10164:com.example}
+    * Hist  #0: ActivityRecord{7ff01aa u0 com.example/.MainActivity t61}
+        packageName=com.example processName=com.example
+`);
+
+      expect(result.activities.map(a => a.isTaskRoot)).toEqual([false, true]);
+    });
+  });
 });

--- a/test/features/observe/GetBackStackParsing.test.ts
+++ b/test/features/observe/GetBackStackParsing.test.ts
@@ -292,5 +292,27 @@ Display #0 (activities from top to bottom):
 
       expect(result.activities.map(a => a.isTaskRoot)).toEqual([false, true]);
     });
+
+    test("an unrecognized Hist row closes the previous record's block", async () => {
+      // The second Hist row is missing its closing brace, so parseHistRow
+      // rejects it -- but it still starts a new record, so the rootOfTask=
+      // printed in ITS block must not land on the previous activity.
+      const result = await parse(`
+ACTIVITY MANAGER ACTIVITIES (dumpsys activity activities)
+Display #0 (activities from top to bottom):
+  * Task{d19dee2 #61 type=standard A=10164:com.example U=0 visible=true mode=fullscreen sz=2}
+    * Hist  #0: ActivityRecord{7ff01aa u0 com.example/.MainActivity t61}
+        packageName=com.example processName=com.example
+    * Hist  #1: ActivityRecord{2b2ce0f u0 com.example/.DetailActivity
+        packageName=com.example processName=com.example
+        rootOfTask=false task=Task{d19dee2 #61 type=standard A=10164:com.example}
+`);
+
+      // Only the well-formed row parses, and it keeps its own index-derived
+      // value rather than absorbing the rejected record's rootOfTask=false.
+      expect(result.activities).toHaveLength(1);
+      expect(result.activities[0].name).toBe("com.example.MainActivity");
+      expect(result.activities[0].isTaskRoot).toBe(true);
+    });
   });
 });

--- a/test/features/observe/GetBackStackRealCaptures.test.ts
+++ b/test/features/observe/GetBackStackRealCaptures.test.ts
@@ -90,6 +90,44 @@ function hasLegacyHeader(raw: string): boolean {
   return raw.split("\n").some(l => /^\s*(?:Task id #\d+|\*?\s*TaskRecord\{\S+\s+#\d+)\b/.test(l));
 }
 
+/**
+ * One `Hist #N` row paired with the `rootOfTask=` value printed inside its own
+ * `ActivityRecord` block (issue #4340). Extracted from the raw capture by an
+ * independent scan so the parser's `isTaskRoot` can be asserted against the
+ * dump's own ground truth rather than against the Hist-index heuristic.
+ */
+interface HistGroundTruth {
+  histIndex: number;
+  /** Verbatim "pkg/.Cls" from the Hist row. */
+  component: string;
+  /** The block's own `rootOfTask=` value; absent on API <= 29 captures. */
+  rootOfTask?: boolean;
+}
+
+function histGroundTruth(raw: string): HistGroundTruth[] {
+  const rows: HistGroundTruth[] = [];
+  for (const line of raw.split("\n")) {
+    const hist = line.match(/\bHist\s+#(\d+):\s+ActivityRecord\{\S+\s+u\d+\s+([^\s}]+)/);
+    if (hist) {
+      rows.push({ histIndex: parseInt(hist[1], 10), component: hist[2] });
+      continue;
+    }
+    // Anchored to the start of the line: `rootOfTask=` is printed as its own
+    // field line inside the ActivityRecord block, always after its Hist row.
+    const root = line.match(/^\s*rootOfTask=(true|false)\b/);
+    if (root && rows.length > 0) {
+      rows[rows.length - 1].rootOfTask = root[1] === "true";
+    }
+  }
+  return rows;
+}
+
+/** "pkg/.Cls" -> fully-qualified class name, mirroring the parser's own rule. */
+function qualify(component: string): string {
+  const [pkg, cls] = component.split("/");
+  return cls.startsWith(".") ? pkg + cls : cls;
+}
+
 /** All `apiNN-*.log` captures, sorted by API level for stable test ordering. */
 const captureFiles = fs.existsSync(CAPTURE_DIR)
   ? fs
@@ -187,6 +225,34 @@ describe("GetBackStack against real captures (#4329)", () => {
         }
       });
 
+      if (apiLevel >= MODERN_FORMAT_MIN_API) {
+        test("isTaskRoot matches the dump's own rootOfTask field (#4340)", async () => {
+          const raw = readCapture(file);
+          const truth = histGroundTruth(raw);
+          // Every modern capture pairs each Hist row with exactly one
+          // rootOfTask= line; a hole here means the extraction regressed, not
+          // the parser.
+          expect(truth.length).toBeGreaterThan(0);
+          for (const row of truth) {
+            expect(row.rootOfTask).toBeDefined();
+          }
+          const result = await parse(raw);
+          expect(result.activities.map(a => ({ name: a.name, isTaskRoot: a.isTaskRoot }))).toEqual(
+            truth.map(r => ({ name: qualify(r.component), isTaskRoot: r.rootOfTask! }))
+          );
+        });
+      } else {
+        test("no rootOfTask printed; isTaskRoot stays index-derived (#4340)", async () => {
+          const raw = readCapture(file);
+          expect(raw).not.toContain("rootOfTask=");
+          const truth = histGroundTruth(raw);
+          const result = await parse(raw);
+          expect(result.activities.map(a => a.isTaskRoot)).toEqual(
+            truth.map(r => r.histIndex === 0)
+          );
+        });
+      }
+
       test("parses tasks via the header format this level actually emits", async () => {
         // Ties each level to the parser path it exercises: a modern-format level
         // whose `* Task{...}` parsing regressed, or a legacy-format level whose
@@ -227,6 +293,30 @@ describe("GetBackStack against real captures (#4329)", () => {
       const result = await parse(readCapture("api24-home-settings-secondapp.log"));
       // Pre-Android-11 affinity is the bare package; contrast api34 below.
       expect(result.tasks[1].affinity).toBe("com.android.settings");
+    });
+  });
+
+  // Both directions the Hist-index heuristic got wrong (issue #4340), pinned
+  // against the exact fixtures the issue reproduced them on.
+  describe("isTaskRoot vs rootOfTask, exact values (#4340)", () => {
+    for (const file of ["api35-home-settings-secondapp.log", "api36-home-settings-secondapp.log"]) {
+      test(`${file}: launcher prints as Hist #1 yet IS the task root`, async () => {
+        const result = await parse(readCapture(file));
+        const launcher = result.activities.find(
+          a => a.name === "com.google.android.apps.nexuslauncher.NexusLauncherActivity"
+        );
+        expect(launcher).toBeDefined();
+        expect(launcher!.isTaskRoot).toBe(true);
+      });
+    }
+
+    test("api34: WifiSettingsActivity prints as Hist #0 yet is NOT the task root", async () => {
+      const result = await parse(readCapture("api34-home-settings-secondapp.log"));
+      const wifi = result.activities.find(
+        a => a.name === "com.android.settings.Settings$WifiSettingsActivity"
+      );
+      expect(wifi).toBeDefined();
+      expect(wifi!.isTaskRoot).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

`GetBackStack.parseActivities` derived `isTaskRoot` from the printed `Hist #N` index (`histIndex === 0`), but that index is not a task-root indicator. `dumpsys activity activities` prints the answer explicitly as `rootOfTask=true|false` inside each `ActivityRecord` block from API 30 onward, and the heuristic disagrees with it in both directions on the committed captures. This PR parses that field as the authoritative value in the same line-by-line pass, keeping the index heuristic only as the fallback for API ≤ 29 where the field is not printed. The pending-record reference is cleared at the next `Hist #N:` row or task header, so a value can never bleed into the following record.

## Linked Issue

Closes #4340

## Bug / Regression Context

- **Prior attempts:** [#4273](https://github.com/kaeawc/auto-mobile/pull/4273) / [#4332](https://github.com/kaeawc/auto-mobile/pull/4332) added the real captures but nothing asserted `isTaskRoot` against `rootOfTask`, which is why the gap survived.
- **Observed symptom:** `observe`'s `backStack.activities[]` reported the launcher (`rootOfTask=true`, printed as `Hist #1`) as `isTaskRoot: false` on API 35/36, and `Settings$WifiSettingsActivity` (`rootOfTask=false`, printed as `Hist #0`) as `isTaskRoot: true` on API 34.
- **Repro steps / conditions:** run the parser over the committed fixtures under `test/features/observe/activityActivitiesDumps/` — the new fixture-pairing tests fail on `main` for exactly api34/api35/api36.

## Acceptance criteria → tests

| Criterion | Test |
|---|---|
| `isTaskRoot` matches `rootOfTask` for every activity in every fixture that prints the field (API 30–36) | `GetBackStackRealCaptures.test.ts` — per-fixture "isTaskRoot matches the dump's own rootOfTask field (#4340)": independently extracts the `(Hist → rootOfTask)` pairing from the raw capture and asserts it 1:1 against parsed `activities[]` |
| The API 34 and API 35/36 shapes are both pinned directly off the committed captures | "isTaskRoot vs rootOfTask, exact values (#4340)": api35/api36 launcher `Hist #1` → `true`; api34 `WifiSettingsActivity` `Hist #0` → `false` |
| API 24–29 fixtures keep their current index-derived behavior | Per-fixture "no rootOfTask printed; isTaskRoot stays index-derived (#4340)" asserts the fixture has no `rootOfTask=` and the parsed values equal the index-derived truth |

Plus two synthetic parser tests in `GetBackStackParsing.test.ts`: override in both directions, and no bleed of a `rootOfTask` value into a following record that lacks one.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes (`bun run lint` + `bun test`) — via `turbo run lint build test`: 9032 pass / 0 fail
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] New generic code reuses the standard library or an existing project helper; no new dependencies
- [x] Based on latest `main` (`44f83116b`)

## Follow-ups

- The issue's secondary suggestion — cross-checking the task root against the task header's `I=<component>` — is intentionally not built: `rootOfTask` is authoritative on every fixture that prints it, and a second source of truth adds its own edge cases. Noted here rather than filed, per the issue marking it secondary.
