### PR TITLE
chore(local-dev): pin local builds to the source-built CtrlProxy APK

### DIFF
--- a/scripts/local-dev/hot-reload.sh
+++ b/scripts/local-dev/hot-reload.sh
@@ -32,6 +32,14 @@
 #   CTRL_PROXY_IOS_PORT   Override CtrlProxy iOS port (default: 8765)
 #   HOT_RELOAD_MANAGE_IOS_RUNNER  Set to "true" to make the watcher own the
 #                        CtrlProxy iOS runner (same as --manage-ios-runner).
+#
+# Daemons restarted by this script are pinned to the locally-built CtrlProxy APK
+# (AUTOMOBILE_CTRL_PROXY_APK_PATH + AUTOMOBILE_SKIP_ACCESSIBILITY_DOWNLOAD_IF_INSTALLED)
+# so they cannot reinstall a released APK over it. Note this only covers daemons
+# THIS script starts: another checkout's daemon sharing the socket will still
+# replace the APK. If a runner-gated change seems missing, check what is actually
+# installed:
+#   adb shell dumpsys package dev.jasonpearson.automobile.ctrlproxy | grep versionName
 
 set -euo pipefail
 
@@ -246,6 +254,17 @@ reload_mcp_daemon() {
 
   if [[ -f "${VIDEO_SERVER_JAR_PATH}" ]]; then
     daemon_env+=("AUTOMOBILE_VIDEO_SERVER_JAR=${VIDEO_SERVER_JAR_PATH}")
+  fi
+
+  # Pin the daemon to the APK this watcher just built. update_checksum() rewrites
+  # src/constants/release.ts so the local sha256 is the expected one, but that
+  # only takes effect once TypeScript is rebuilt — and the daemon is restarted
+  # before that happens on the initial run. Without these the daemon compares
+  # against the stale compiled-in checksum, treats the fresh APK as unknown, and
+  # reinstalls the released one, silently downgrading the build being iterated on.
+  if [[ -f "${APK_PATH}" ]]; then
+    daemon_env+=("AUTOMOBILE_CTRL_PROXY_APK_PATH=${APK_PATH}")
+    daemon_env+=("AUTOMOBILE_SKIP_ACCESSIBILITY_DOWNLOAD_IF_INSTALLED=true")
   fi
 
   log_info "Restarting MCP daemon..."

--- a/scripts/local-dev/use-source-ctrl-proxy.sh
+++ b/scripts/local-dev/use-source-ctrl-proxy.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Build the Android CtrlProxy from source, install it, and print the env that
+# pins a daemon to that build.
+#
+# Why this exists: the daemon verifies the installed APK's SHA256 against
+# RELEASE_CHECKSUM_REGISTRY. A locally-built APK matches no registry entry, so a
+# daemon started without the development-mode escape hatches treats it as
+# unknown and reinstalls the released APK — silently downgrading your build and
+# reverting any runner-gated feature you were trying to exercise.
+#
+# Usage:
+#   scripts/local-dev/use-source-ctrl-proxy.sh              # build + install + print env
+#   eval "$(scripts/local-dev/use-source-ctrl-proxy.sh --export)"   # ...and apply it here
+#   SKIP_BUILD=true scripts/local-dev/use-source-ctrl-proxy.sh      # reuse existing APK
+
+set -euo pipefail
+
+ADB_SERIAL="${ADB_SERIAL:-}"
+SKIP_BUILD="${SKIP_BUILD:-false}"
+EXPORT_MODE="false"
+[ "${1:-}" = "--export" ] && EXPORT_MODE="true"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+APK="$REPO_ROOT/android/control-proxy/build/outputs/apk/debug/control-proxy-debug.apk"
+SERVICE="dev.jasonpearson.automobile.ctrlproxy/dev.jasonpearson.automobile.ctrlproxy.CtrlProxy"
+
+log() { [ "$EXPORT_MODE" = "true" ] || printf '==> %s\n' "$*"; }
+
+adb_target() {
+  if [ -n "$ADB_SERIAL" ]; then adb -s "$ADB_SERIAL" "$@"; else adb "$@"; fi
+}
+
+if [ "$SKIP_BUILD" != "true" ]; then
+  log "Building control-proxy from source"
+  # local.properties is gitignored and absent in fresh worktrees.
+  if [ ! -f "$REPO_ROOT/android/local.properties" ]; then
+    printf 'sdk.dir=%s\n' "${ANDROID_HOME:-$HOME/Library/Android/sdk}" \
+      > "$REPO_ROOT/android/local.properties"
+  fi
+  # Send build chatter to stderr: in --export mode stdout is eval'd by the
+  # caller, and Gradle emits plugin warnings even under -q.
+  ( cd "$REPO_ROOT/android" && ./gradlew :control-proxy:assembleDebug --console=plain -q ) 1>&2
+fi
+
+[ -f "$APK" ] || { echo "APK not found: $APK" >&2; exit 1; }
+
+log "Installing $(basename "$APK")"
+adb_target install -r -d "$APK" >/dev/null 2>&1
+
+# Reinstalling clears the enabled-services setting, so re-assert it. A freshly
+# booted emulator also refuses to bind non-encryption-aware services until the
+# keyguard is dismissed — unlock before relying on the service.
+adb_target shell settings put secure enabled_accessibility_services "$SERVICE"
+adb_target shell settings put secure accessibility_enabled 1
+
+INSTALLED="$(adb_target shell dumpsys package dev.jasonpearson.automobile.ctrlproxy \
+  | tr -d '\r' | grep -m1 'versionName' | tr -d ' ')"
+log "Installed: ${INSTALLED:-unknown}  sha256: $(shasum -a 256 "$APK" | cut -c1-16)..."
+
+if [ "$EXPORT_MODE" != "true" ]; then
+  cat <<'EOF'
+
+Start the daemon with these so it does not replace your build:
+
+EOF
+fi
+
+# AUTOMOBILE_SKIP_ACCESSIBILITY_CHECKSUM is the documented development-mode knob;
+# the other two keep the daemon pointed at this file and stop it re-downloading.
+printf 'export AUTOMOBILE_CTRL_PROXY_APK_PATH=%q\n' "$APK"
+printf 'export AUTOMOBILE_SKIP_ACCESSIBILITY_CHECKSUM=1\n'
+printf 'export AUTOMOBILE_SKIP_ACCESSIBILITY_DOWNLOAD_IF_INSTALLED=true\n'
+
+if [ "$EXPORT_MODE" != "true" ]; then
+  cat <<'EOF'
+
+Note: any OTHER daemon on the shared socket that lacks these will reinstall the
+released APK over this one. Check before trusting a runner-gated result:
+
+  adb shell dumpsys package dev.jasonpearson.automobile.ctrlproxy | grep versionName
+EOF
+fi


### PR DESCRIPTION
## Summary

Local-dev tooling for iterating on the Android CtrlProxy from source. Fixes one specific, recurring trap: **the daemon silently downgrading your source-built CtrlProxy APK back to the released one.**

The daemon verifies the installed APK's sha256 against `RELEASE_CHECKSUM_REGISTRY`. A source-built APK matches no registry entry, so a daemon started without the development-mode escape hatches treats it as unknown and reinstalls the released APK — reverting whatever runner-gated change you were trying to exercise, with no error. This cost real debugging time during the 0.0.44 manual-test campaign (a "fix didn't work" that was actually a downgraded APK).

Dev tooling only — no `src/` changes, no CI surface.

## Changes

**`scripts/local-dev/hot-reload.sh`** — pin daemons *this watcher restarts* to the APK it just built, via `AUTOMOBILE_CTRL_PROXY_APK_PATH` + `AUTOMOBILE_SKIP_ACCESSIBILITY_DOWNLOAD_IF_INSTALLED`.

The subtlety worth recording: `update_checksum()` already rewrites `src/constants/release.ts` so the local sha256 *is* the expected one — but that only takes effect once TypeScript is rebuilt, and the daemon is restarted **before** that happens on the initial run. Without the pin it compares against the stale compiled-in checksum, treats the fresh APK as unknown, and reinstalls.

**`scripts/local-dev/use-source-ctrl-proxy.sh`** (new) — standalone: build from source → install → re-assert the accessibility settings that reinstalling clears → print the env that pins a daemon to that build.

```bash
scripts/local-dev/use-source-ctrl-proxy.sh                    # build + install + print env
eval "$(scripts/local-dev/use-source-ctrl-proxy.sh --export)" # ...and apply it to this shell
SKIP_BUILD=true scripts/local-dev/use-source-ctrl-proxy.sh    # reuse an existing APK
```

Details: writes the gitignored `android/local.properties` when absent (fresh worktrees), routes Gradle chatter to stderr so `--export` stdout stays `eval`-safe, and honors `ADB_SERIAL` for a multi-device fleet.

## Known limitation (documented in both scripts)

The pin only covers daemons these scripts start. **Another checkout's daemon sharing the socket will still replace the APK.** Both scripts say so and point at the check to run before trusting a runner-gated result:

```bash
adb shell dumpsys package dev.jasonpearson.automobile.ctrlproxy | grep versionName
```

## Testing

- `shellcheck` clean on both scripts.
- Applies cleanly on current `main` — no conflict with the recent `set -u` empty-array fixes (`${daemon_env[@]+"${daemon_env[@]}"}`); the pin block and those fixes coexist.
- Verified all three env knobs are live on `main` with the semantics the scripts rely on, in `src/utils/CtrlProxyManager.ts`: `AUTOMOBILE_CTRL_PROXY_APK_PATH` skips prefetch (`:200`), is the path override (`:1687`), and counts as an escape hatch (`:1713`); `shouldSkipDownloadIfInstalled()` (`:1750`) accepts the `"true"` both scripts set.
- Exercised in practice against a live emulator during the 0.0.44 manual-test campaign.
