### PR TITLE
test(stress): explicit timeout on memory-leak loop + guard the class (#4342)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -324,12 +324,70 @@ function noBareExpectRule() {
 	};
 }
 
+// A stress test runs an inherently unbounded loop (issue #4342: a 200-iteration
+// observe/interaction loop came in at 5015ms, 0.3% over bun's *default* 5000ms
+// per-test timeout, and failed as a hard red on an unrelated PR). The fix is not
+// to shrink the loop — that changes what the test measures across platforms — but
+// to state the deadline as intent with real headroom rather than let the loop
+// happen to fit under a default it never declared.
+//
+// This rule requires every `test(...)`/`it(...)` in test/stress to pass a numeric
+// literal timeout of at least MIN_STRESS_TIMEOUT_MS. A missing timeout, or a
+// literal too small to clear the observed worst case, both fail. `test.todo` /
+// `test.each` (callee is a MemberExpression, not the `test` Identifier) and calls
+// whose second argument is not a function body are inherently excluded.
+//
+// Report-only (no `fix`), matching no-bare-expect: the ratchet convention requires
+// ratchet rules be non-auto-fixable (see CLAUDE.md), and there is no single correct
+// timeout to auto-insert. Scoped to test/stress in the config below so the rest of
+// the suite's fast unit tests are unaffected.
+const MIN_STRESS_TIMEOUT_MS = 10_000;
+
+function stressExplicitTimeoutRule() {
+	return {
+		meta: {
+			type: "problem",
+			messages: {
+				missingTimeout: `A stress test declares no explicit timeout, so it silently inherits bun's 5000ms default (issue #4342). Pass a numeric-literal timeout of at least ${MIN_STRESS_TIMEOUT_MS}ms as the third argument, e.g. \`test(name, fn, 30_000)\`.`,
+				timeoutTooSmall: `A stress test's ${MIN_STRESS_TIMEOUT_MS}ms floor is not enough headroom (issue #4342: the loop was observed at 5015ms). Raise the third-argument timeout to at least ${MIN_STRESS_TIMEOUT_MS}ms.`,
+			},
+		},
+		create(context) {
+			const isFunction = node =>
+				node?.type === "ArrowFunctionExpression" || node?.type === "FunctionExpression";
+			return {
+				"CallExpression[callee.name=/^(test|it)$/]"(node) {
+					const [, body, timeout] = node.arguments;
+					// Only name+body test declarations carry a per-test deadline.
+					if (!isFunction(body)) {
+						return;
+					}
+					if (timeout === undefined) {
+						context.report({ node, messageId: "missingTimeout" });
+						return;
+					}
+					// A non-literal (identifier, expression) can't be checked statically
+					// and hides the deadline from the call site — treat as unstated.
+					if (timeout.type !== "Literal" || typeof timeout.value !== "number") {
+						context.report({ node, messageId: "missingTimeout" });
+						return;
+					}
+					if (timeout.value < MIN_STRESS_TIMEOUT_MS) {
+						context.report({ node, messageId: "timeoutTooSmall" });
+					}
+				},
+			};
+		},
+	};
+}
+
 const catchConventionPlugin = {
 	rules: {
 		"catch-convention": catchConventionRule(),
 		"no-unknown-cast": noUnknownCastRule(),
 		"no-accumulator-foreach": noAccumulatorForEachRule(),
 		"no-bare-expect": noBareExpectRule(),
+		"stress-explicit-timeout": stressExplicitTimeoutRule(),
 	},
 };
 
@@ -661,6 +719,18 @@ export default [
 			// A bare `expect(...)` statement asserts nothing (issue #4198). Only
 			// test files use `expect`, so scope the gate here.
 			"auto-mobile/no-bare-expect": 2,
+		},
+	},
+	{
+		// Stress tests run inherently-unbounded loops; a missing or too-tight
+		// per-test timeout is a coin flip on a loaded CI runner (issue #4342). This
+		// gate is scoped here so the rest of the fast unit suite is unaffected.
+		files: ["test/stress/**/*.ts"],
+		plugins,
+		languageOptions,
+		rules: {
+			...baseRules,
+			"auto-mobile/stress-explicit-timeout": 2,
 		},
 	},
 	{

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -331,11 +331,17 @@ function noBareExpectRule() {
 // to state the deadline as intent with real headroom rather than let the loop
 // happen to fit under a default it never declared.
 //
-// This rule requires every `test(...)`/`it(...)` in test/stress to pass a numeric
-// literal timeout of at least MIN_STRESS_TIMEOUT_MS. A missing timeout, or a
-// literal too small to clear the observed worst case, both fail. `test.todo` /
-// `test.each` (callee is a MemberExpression, not the `test` Identifier) and calls
-// whose second argument is not a function body are inherently excluded.
+// This rule requires every stress test that RUNS a body in test/stress to pass a
+// numeric-literal timeout of at least MIN_STRESS_TIMEOUT_MS. A missing timeout, or
+// a literal too small to clear the observed worst case, both fail.
+//
+// It covers every running form: bare `test(...)`/`it(...)` and the chained variants
+// that still execute a body — `test.only`, `it.each(table)(...)`, `test.concurrent`,
+// combos like `test.concurrent.each`, etc. `test.skip` and `test.todo` never run a
+// body and are excluded; `describe`/`expect` and any call whose second argument is
+// not a function are excluded because they carry no per-test deadline. The name,
+// body, and timeout sit at argument positions 0/1/2 across all these forms, so one
+// extraction serves them all — only the callee shape (unwound below) differs.
 //
 // Report-only (no `fix`), matching no-bare-expect: the ratchet convention requires
 // ratchet rules be non-auto-fixable (see CLAUDE.md), and there is no single correct
@@ -355,8 +361,36 @@ function stressExplicitTimeoutRule() {
 		create(context) {
 			const isFunction = node =>
 				node?.type === "ArrowFunctionExpression" || node?.type === "FunctionExpression";
+			// Unwind an arbitrarily-chained test callee to its root identifier and the
+			// set of member names in the chain: `test.concurrent.each(t)` → { root:
+			// "test", props: {"concurrent","each"} }. The curried `.each(table)(...)`
+			// step is a CallExpression in the chain, so recurse through `.callee`.
+			const unwind = node => {
+				if (node.type === "Identifier") {
+					return { root: node.name, props: new Set() };
+				}
+				if (node.type === "MemberExpression" && node.property.type === "Identifier") {
+					const inner = unwind(node.object);
+					if (inner) {
+						inner.props.add(node.property.name);
+					}
+					return inner;
+				}
+				if (node.type === "CallExpression") {
+					return unwind(node.callee);
+				}
+				return null;
+			};
 			return {
-				"CallExpression[callee.name=/^(test|it)$/]"(node) {
+				CallExpression(node) {
+					const callee = unwind(node.callee);
+					if (!callee || (callee.root !== "test" && callee.root !== "it")) {
+						return;
+					}
+					// `.skip`/`.todo` never execute a body, so they carry no deadline.
+					if (callee.props.has("skip") || callee.props.has("todo")) {
+						return;
+					}
 					const [, body, timeout] = node.arguments;
 					// Only name+body test declarations carry a per-test deadline.
 					if (!isFunction(body)) {

--- a/test/lint/stressExplicitTimeoutRule.test.ts
+++ b/test/lint/stressExplicitTimeoutRule.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import { ESLint } from "eslint";
+
+const MISSING_TIMEOUT = "declares no explicit timeout";
+const TIMEOUT_TOO_SMALL = "is not enough headroom";
+
+// The rule is scoped to `test/stress/**`, so snippets must lint under a path in
+// that directory or the rule never runs.
+const STRESS_FIXTURE = "test/stress/fixture.stress.test.ts";
+
+async function lintSnippet(code: string, filePath = STRESS_FIXTURE): Promise<string[]> {
+  const eslint = new ESLint({
+    cwd: process.cwd(),
+    overrideConfigFile: "eslint.config.mjs",
+    // Same rationale as bareExpectRule.test.ts: these snippets live at paths that
+    // do not exist on disk, so opt out of the type-aware config that would make
+    // projectService reject them.
+    overrideConfig: {
+      languageOptions: { parserOptions: { projectService: false, project: null } },
+      rules: {
+        "@typescript-eslint/no-floating-promises": "off",
+        "@typescript-eslint/no-misused-promises": "off",
+      },
+    },
+    fix: false,
+  });
+  const [result] = await eslint.lintText(code, { filePath });
+  return result.messages.map(message => message.message);
+}
+
+function matches(messages: string[], fragment: string): boolean {
+  return messages.some(message => message.includes(fragment));
+}
+
+describe("auto-mobile/stress-explicit-timeout", () => {
+  // AC1 — the exact shape from issue #4342: a long stress loop that never
+  // declares a timeout and therefore silently inherits bun's 5000ms default.
+  test("flags a stress test that declares no timeout", async () => {
+    const messages = await lintSnippet(`import { test } from "bun:test";
+test("high-frequency loop", async () => {
+  await Promise.resolve();
+});
+`);
+    expect(matches(messages, MISSING_TIMEOUT)).toBe(true);
+  });
+
+  // AC2 — a declared timeout with no headroom over the observed 5015ms failure
+  // is the same coin flip with extra steps, so a stated-but-tight deadline must
+  // fail too rather than read as compliance.
+  test("flags a declared timeout with no headroom over the observed failure", async () => {
+    const messages = await lintSnippet(`import { test } from "bun:test";
+test("high-frequency loop", async () => {
+  await Promise.resolve();
+}, 5_000);
+`);
+    expect(matches(messages, TIMEOUT_TOO_SMALL)).toBe(true);
+  });
+
+  test("accepts a timeout with real headroom", async () => {
+    const messages = await lintSnippet(`import { test } from "bun:test";
+test("high-frequency loop", async () => {
+  await Promise.resolve();
+}, 30_000);
+`);
+    expect(matches(messages, MISSING_TIMEOUT)).toBe(false);
+    expect(matches(messages, TIMEOUT_TOO_SMALL)).toBe(false);
+  });
+
+  // `it` is bun's alias for `test`; the invariant is about the test body's
+  // deadline, not which spelling declared it.
+  test("flags an it() stress test with no timeout", async () => {
+    const messages = await lintSnippet(`import { it } from "bun:test";
+it("high-frequency loop", async () => {
+  await Promise.resolve();
+});
+`);
+    expect(matches(messages, MISSING_TIMEOUT)).toBe(true);
+  });
+
+  // A non-literal timeout cannot be checked statically. Requiring a literal
+  // keeps the deadline readable at the call site, which is the whole point.
+  test("flags a timeout that is not a numeric literal", async () => {
+    const messages = await lintSnippet(`import { test } from "bun:test";
+const LIMIT = 30_000;
+test("high-frequency loop", async () => {
+  await Promise.resolve();
+}, LIMIT);
+`);
+    expect(matches(messages, MISSING_TIMEOUT)).toBe(true);
+  });
+
+  // `test.todo("name")` has no body to time out, and `test.each` takes a table
+  // rather than a name+body pair. Neither is the shape the rule is about.
+  test("does not flag declarations with no test body", async () => {
+    const messages = await lintSnippet(`import { test } from "bun:test";
+test.todo("not written yet");
+`);
+    expect(matches(messages, MISSING_TIMEOUT)).toBe(false);
+    expect(matches(messages, TIMEOUT_TOO_SMALL)).toBe(false);
+  });
+
+  // AC4 is scoped: the rest of the suite is thousands of sub-100ms unit tests
+  // where a mandatory timeout literal would be noise. Only stress tests, whose
+  // runtime is inherently unbounded, carry the requirement.
+  test("does not flag tests outside test/stress", async () => {
+    const messages = await lintSnippet(`import { test } from "bun:test";
+test("ordinary unit test", () => {
+  const x = 1;
+  if (x !== 1) { throw new Error("unreachable"); }
+});
+`, "test/features/ordinary.test.ts");
+    expect(matches(messages, MISSING_TIMEOUT)).toBe(false);
+  });
+});

--- a/test/lint/stressExplicitTimeoutRule.test.ts
+++ b/test/lint/stressExplicitTimeoutRule.test.ts
@@ -89,11 +89,55 @@ test("high-frequency loop", async () => {
     expect(matches(messages, MISSING_TIMEOUT)).toBe(true);
   });
 
-  // `test.todo("name")` has no body to time out, and `test.each` takes a table
-  // rather than a name+body pair. Neither is the shape the rule is about.
+  // `test.todo("name")` has no body to time out. `.skip`/`.todo` never run a body,
+  // so they carry no per-test deadline and must not be flagged.
   test("does not flag declarations with no test body", async () => {
     const messages = await lintSnippet(`import { test } from "bun:test";
 test.todo("not written yet");
+`);
+    expect(matches(messages, MISSING_TIMEOUT)).toBe(false);
+    expect(matches(messages, TIMEOUT_TOO_SMALL)).toBe(false);
+  });
+
+  test("does not flag test.skip with no timeout", async () => {
+    const messages = await lintSnippet(`import { test } from "bun:test";
+test.skip("skipped", async () => {
+  await Promise.resolve();
+});
+`);
+    expect(matches(messages, MISSING_TIMEOUT)).toBe(false);
+    expect(matches(messages, TIMEOUT_TOO_SMALL)).toBe(false);
+  });
+
+  // Runnable chained forms execute a body and so inherit the same 5000ms default.
+  // `test.only` is the escape hatch a developer reaches for while debugging one
+  // stress case — exactly when the flake would bite — so it must be covered too.
+  test("flags test.only with no timeout", async () => {
+    const messages = await lintSnippet(`import { test } from "bun:test";
+test.only("only this one", async () => {
+  await Promise.resolve();
+});
+`);
+    expect(matches(messages, MISSING_TIMEOUT)).toBe(true);
+  });
+
+  // `it.each(table)(name, fn, timeout)` is the realistic shape for a parametrized
+  // stress load. The callee is a curried CallExpression, not a bare identifier, but
+  // the body/timeout still sit at arg positions 1/2, so the rule applies.
+  test("flags it.each with no timeout", async () => {
+    const messages = await lintSnippet(`import { it } from "bun:test";
+it.each([1, 2, 3])("load %i", async () => {
+  await Promise.resolve();
+});
+`);
+    expect(matches(messages, MISSING_TIMEOUT)).toBe(true);
+  });
+
+  test("accepts test.concurrent.each with real headroom", async () => {
+    const messages = await lintSnippet(`import { test } from "bun:test";
+test.concurrent.each([1, 2])("load %i", async () => {
+  await Promise.resolve();
+}, 30_000);
 `);
     expect(matches(messages, MISSING_TIMEOUT)).toBe(false);
     expect(matches(messages, TIMEOUT_TOO_SMALL)).toBe(false);

--- a/test/stress/memory-leak.stress.test.ts
+++ b/test/stress/memory-leak.stress.test.ts
@@ -51,5 +51,12 @@ describe("MCP Server Memory Leak Tests", () => {
     } finally {
       await harness.cleanup();
     }
-  });
+    // The 200-iteration loop runs in ~300ms locally but was observed at 5015ms on
+    // a loaded windows-latest runner (issue #4342), 0.3% over bun's 5000ms default
+    // per-test timeout — a hard red on an unrelated PR. State the deadline as
+    // intent with real headroom instead of relying on the loop happening to fit
+    // under a default it never declared. This keeps `iterations` (and therefore
+    // what the test measures) identical across platforms.
+    // https://github.com/kaeawc/auto-mobile/actions/runs/30043326977/job/89328362082
+  }, 30_000);
 });


### PR DESCRIPTION
## Summary

`test/stress/memory-leak.stress.test.ts` runs a 200-iteration observe/interaction loop that declared **no explicit timeout**, so it silently inherited bun's 5000ms default per-test deadline. On a loaded `windows-latest` runner the loop was observed at **5015ms** — 0.3% over — and failed as a hard red on an unrelated PR. Locally the loop runs in ~300ms, so this is a coin flip on the slowest CI leg, not a real leak.

This fixes the deadline as **stated intent with real headroom** (`30_000ms`) rather than relying on the loop happening to fit under a default it never declared. `iterations` (and therefore what the test measures) is left identical across platforms, which the per-platform loop-scaling alternative discussed in the issue would not preserve.

It also adds a lint rule so the next stress test cannot silently re-acquire the 5s default and re-derive the same diagnosis.

## Linked Issue

Closes #4342

## Bug / Regression Context

- **Prior attempts:** none — long-standing since [#2221](https://github.com/kaeawc/auto-mobile/pull/2221), not a recent regression. Noticed while shipping [#4339](https://github.com/kaeawc/auto-mobile/pull/4339) but not caused by it.
- **Observed symptom:** `MCP Server Memory Leak Tests > should not leak during high-frequency observe and interaction cycles [5015.00ms] — timed out after 5000ms`. 8982 pass, 1 fail. [The run.](https://github.com/kaeawc/auto-mobile/actions/runs/30043326977/job/89328362082) Re-running the leg passes.
- **Repro steps / conditions:** the 200-iteration loop's wall time exceeds 5000ms on a slow/loaded runner (`windows-latest` is the slowest leg).

## Changes

- **`test/stress/memory-leak.stress.test.ts`** — declare an explicit `30_000ms` timeout on the test, with a comment recording the 5015ms observation and the failing-run link. No change to the loop body, operation list, or `memoryLimitBytes` delta assertion.
- **`eslint.config.mjs`** — add `auto-mobile/stress-explicit-timeout`, scoped to `test/stress/**`. A stress `test(...)`/`it(...)` with a missing timeout, a non-literal timeout, or a numeric literal below a `10_000ms` floor fails lint. Report-only (non-auto-fixable), matching the `no-bare-expect` ratchet convention. Zero violations after the fix, so no suppressions-baseline entry.
- **`test/lint/stressExplicitTimeoutRule.test.ts`** — new unit test proving the rule fires on the missing/tight/non-literal cases and stays quiet on a compliant `30_000ms` test and on tests outside `test/stress`. Modeled on `test/lint/bareExpectRule.test.ts`.

## Acceptance criteria (inferred from the issue, confirmed with the requester)

| # | Criterion | Where |
|---|---|---|
| AC1 | The test declares an explicit per-test timeout instead of bun's 5000ms default | `memory-leak.stress.test.ts:56` (`}, 30_000);`) |
| AC2 | The timeout has real headroom over the 5015ms worst case, with rationale in-repo | `30_000ms` literal + comment |
| AC3 | What the test measures is unchanged and identical across platforms | loop body untouched — same `iterations: 200`, ops, and delta assertion |
| AC4 | A future stress test cannot silently re-acquire the 5s default | `auto-mobile/stress-explicit-timeout` + its unit test |

## Validation

- [x] `bun run lint` passes (rule scoped to `test/stress`; full boundary scripts green)
- [x] `bun run typecheck` reports no new errors (211 baseline)
- [x] `bun run build` succeeds
- [x] `bun test` — 9097 pass, 14 skip, 0 fail across 710 files
- [x] New rule unit test runs in <100ms per case; uses `ESLint.lintText` (no fakes needed — pure static analysis)

## Device Verification

N/A — test and lint-config only; no on-device behavior touched.
