### PR TITLE
build(turbo): gate the test cache on native sources its guards read

### DIFF
--- a/test/lint/turboTestInputsCoverNativeSources.test.ts
+++ b/test/lint/turboTestInputsCoverNativeSources.test.ts
@@ -94,6 +94,13 @@ describe("turbo test inputs cover native sources a guard reads (issue #4351)", (
           walk(abs);
         } else if (entry.name.endsWith(".ts")) {
           const rel = abs.slice(ROOT.length + 1);
+          // Skip this guard itself: its REQUIRED_NATIVE_GLOBS and
+          // NOT_READ_EXEMPTIONS literals would otherwise make every entry
+          // trivially "referenced" by its own definition, so the stale-exemption
+          // and coverage checks below would be self-satisfying and never bite.
+          if (rel === GUARD_PATH) {
+            continue;
+          }
           const source = readFileSync(abs, "utf8");
           for (const match of source.matchAll(/(?<![A-Za-z0-9_.-])(android|ios)\/[A-Za-z0-9._/-]+/g)) {
             const path = match[0].replace(/\/+$/, "");

--- a/test/lint/turboTestInputsCoverNativeSources.test.ts
+++ b/test/lint/turboTestInputsCoverNativeSources.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * `turbo run test` cache-key guard (issue #4351).
+ *
+ * The Bun test suite includes source-scan meta-tests that read Kotlin/Swift
+ * files straight off disk — cross-language contract guards that no `import` can
+ * reach (`registrationTeardownGuard`, `ctrlProxyProtocol`, `ctrlProxyWireParity`,
+ * `webrtcDeviceCaptureLatency`). CI restores `.turbo` across runs and replays a
+ * cached `test` result whenever none of `tasks.test.inputs` changed
+ * (`.github/workflows/pull_request.yml`). Those native trees are NOT under any
+ * declared input, so a PR that changes only Kotlin/Swift hits the cache and the
+ * guards never run — the exact drift they exist to catch ships silently.
+ *
+ * This guard makes the coupling explicit and self-policing:
+ *
+ *  1. Every native source tree a test reads is a declared `inputs` glob on both
+ *     the `test` and `test:coverage` tasks, so touching it busts the cache.
+ *  2. `turbo.json` itself is an input of both, so editing one task's input list
+ *     can never leave the other replaying a stale hash.
+ *  3. Each task's `description` names this file, so the "why is a directory no TS
+ *     test imports in the input list" note cannot be dropped in a later cleanup.
+ *  4. Any `android/`/`ios/` path literal a test references that exists on disk is
+ *     either covered by a declared glob OR carries a one-line not-read exemption
+ *     here — so a future guard that starts reading a new native dir fails HERE
+ *     instead of going quietly stale.
+ */
+describe("turbo test inputs cover native sources a guard reads (issue #4351)", () => {
+  const ROOT = join(import.meta.dir, "..", "..");
+  const GUARD_PATH = "test/lint/turboTestInputsCoverNativeSources.test.ts";
+  const CACHED_TASKS = ["test", "test:coverage"] as const;
+
+  /**
+   * Native trees that a TS test reads off disk. Each must gate both cached tasks
+   * so a change there busts the cache. Keep these narrow (per-module
+   * `src/main/kotlin` / `Sources`) — widening to `android/**` would invalidate
+   * the whole TS test cache on unrelated Gradle/AGP/doc churn (issue #4351
+   * non-goal).
+   */
+  const REQUIRED_NATIVE_GLOBS = [
+    // registrationTeardownGuard.test.ts walks these four for listener leaks.
+    "android/auto-mobile-sdk/src/main/kotlin/**",
+    "android/control-proxy/src/main/kotlin/**",
+    "ios/auto-mobile-sdk/Sources/**",
+    "ios/control-proxy/Sources/**",
+    // ctrlProxyProtocol.test.ts reads the @SerialName set from this tree.
+    "android/protocol/src/main/kotlin/**",
+    // webrtcDeviceCaptureLatency.test.ts mirrors QualityPreset.MEDIUM.fps.
+    "android/video-server/src/main/kotlin/**",
+  ] as const;
+
+  interface TurboConfig {
+    readonly tasks: Record<string, { readonly inputs?: readonly string[]; readonly description?: string }>;
+  }
+
+  function loadTurbo(): TurboConfig {
+    return JSON.parse(readFileSync(join(ROOT, "turbo.json"), "utf8")) as TurboConfig;
+  }
+
+  for (const taskName of CACHED_TASKS) {
+    describe(`tasks.${taskName}.inputs`, () => {
+      test("declares every native source tree a guard reads", () => {
+        const inputs = loadTurbo().tasks[taskName]?.inputs ?? [];
+        const missing = REQUIRED_NATIVE_GLOBS.filter(glob => !inputs.includes(glob));
+        expect(missing, `tasks.${taskName}.inputs is missing: ${missing.join(", ")}`).toEqual([]);
+      });
+
+      test("includes turbo.json so editing the other task's inputs busts this hash", () => {
+        const inputs = loadTurbo().tasks[taskName]?.inputs ?? [];
+        expect(inputs).toContain("turbo.json");
+      });
+
+      test("description points at this guard so the native-input note is not cleaned up later", () => {
+        const description = loadTurbo().tasks[taskName]?.description ?? "";
+        expect(description).toContain(GUARD_PATH);
+      });
+    });
+  }
+
+  /**
+   * `android/`/`ios/` path literals referenced by any test that resolve to a real
+   * file or directory on disk. Comment or docstring mentions count too — the
+   * point is to notice a native path entering the test tree, not to prove it is
+   * a live `readFileSync` target.
+   */
+  function referencedNativePaths(): Map<string, Set<string>> {
+    const found = new Map<string, Set<string>>();
+    const walk = (dir: string): void => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const abs = join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(abs);
+        } else if (entry.name.endsWith(".ts")) {
+          const rel = abs.slice(ROOT.length + 1);
+          const source = readFileSync(abs, "utf8");
+          for (const match of source.matchAll(/(?<![A-Za-z0-9_.-])(android|ios)\/[A-Za-z0-9._/-]+/g)) {
+            const path = match[0].replace(/\/+$/, "");
+            if (!existsSync(join(ROOT, path))) {
+              continue;
+            }
+            if (!found.has(path)) {
+              found.set(path, new Set());
+            }
+            found.get(path)!.add(rel);
+          }
+        }
+      }
+    };
+    walk(join(ROOT, "test"));
+    return found;
+  }
+
+  /** Prefixes a declared glob matches, i.e. `foo/bar/**` covers `foo/bar` and below. */
+  function coveredBy(inputs: readonly string[], path: string): boolean {
+    return inputs.some(glob => {
+      const prefix = glob.replace(/\/\*\*$/, "");
+      return path === prefix || path.startsWith(`${prefix}/`);
+    });
+  }
+
+  /**
+   * Native paths a test references but deliberately does NOT read as a cache
+   * input — bare parent dirs mentioned in prose, xcodegen fixtures rebuilt in a
+   * temp dir, workflow-YAML string contents. Each stays honest: the guard fails
+   * if an entry is no longer referenced (prune it) so this cannot rot into a
+   * blanket allow-list.
+   */
+  const NOT_READ_EXEMPTIONS: ReadonlyMap<string, string> = new Map([
+    ["android/video-server", "bare dir named in a comment / workflow-YAML string; the kotlin tree under it is a declared input"],
+    ["ios/control-proxy", "bare dir in a `cd ios/control-proxy && swift test` doc line; Sources/ under it is a declared input"],
+    ["ios/screen-capture", "named only inside the workflow-YAML text asserted by webrtcDeviceIntegrationWorkflow.test.ts"],
+    ["ios/control-proxy/CtrlProxy.xcodeproj", "xcodegen drift check rebuilds a copy in a temp dir; the tracked pbxproj is not a test cache input"],
+    ["ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj", "same xcodegen drift fixture, copied into a temp repo"],
+  ]);
+
+  test("every native path a test references is a declared input or a documented not-read exemption", () => {
+    const inputs = loadTurbo().tasks.test?.inputs ?? [];
+    const referenced = referencedNativePaths();
+    const uncovered = [...referenced.entries()]
+      .filter(([path]) => !coveredBy(inputs, path) && !NOT_READ_EXEMPTIONS.has(path))
+      .map(([path, tests]) => `${path} (referenced by ${[...tests].join(", ")})`);
+    expect(
+      uncovered,
+      `Native paths referenced by tests but neither a declared test input nor exempted:\n${uncovered.join("\n")}\n` +
+        `Add a narrow glob to REQUIRED_NATIVE_GLOBS (and turbo.json) if a test reads it, or a NOT_READ_EXEMPTIONS entry if it does not.`
+    ).toEqual([]);
+  });
+
+  test("no not-read exemption is stale", () => {
+    const referenced = referencedNativePaths();
+    const stale = [...NOT_READ_EXEMPTIONS.keys()].filter(path => !referenced.has(path));
+    expect(stale, `NOT_READ_EXEMPTIONS entries no longer referenced by any test — prune them: ${stale.join(", ")}`).toEqual([]);
+  });
+});

--- a/turbo.json
+++ b/turbo.json
@@ -38,7 +38,7 @@
       "passThroughEnv": ["CI", "GITHUB_ACTIONS"]
     },
     "test": {
-      "description": "Run Bun test suite",
+      "description": "Run Bun test suite. The android/** and ios/** globs below are read off disk by cross-language source-scan guards no TS import can reach (registrationTeardownGuard, ctrlProxyProtocol, ctrlProxyWireParity, webrtcDeviceCaptureLatency); without them a Kotlin/Swift-only diff replays a cached result and the guard never runs. turbo.json is an input so editing test:coverage's list cannot leave this hash stale. Do not narrow or drop these without updating test/lint/turboTestInputsCoverNativeSources.test.ts (issue #4351).",
       "inputs": [
         "src/**",
         "test/**",
@@ -46,7 +46,14 @@
         "scripts/**",
         "package.json",
         "bunfig.toml",
-        ".github/workflows/**"
+        ".github/workflows/**",
+        "turbo.json",
+        "android/auto-mobile-sdk/src/main/kotlin/**",
+        "android/control-proxy/src/main/kotlin/**",
+        "android/protocol/src/main/kotlin/**",
+        "android/video-server/src/main/kotlin/**",
+        "ios/auto-mobile-sdk/Sources/**",
+        "ios/control-proxy/Sources/**"
       ],
       "outputs": [],
       "outputLogs": "new-only",
@@ -75,14 +82,21 @@
       "outputLogs": "new-only"
     },
     "test:coverage": {
-      "description": "Run tests with coverage reporting to coverage/",
+      "description": "Run tests with coverage reporting to coverage/. The android/** and ios/** globs below are read off disk by cross-language source-scan guards no TS import can reach; without them a Kotlin/Swift-only diff replays a cached result and the guard never runs. turbo.json is an input so editing test's list cannot leave this hash stale. Do not narrow or drop these without updating test/lint/turboTestInputsCoverNativeSources.test.ts (issue #4351).",
       "inputs": [
         "src/**",
         "test/**",
         "schemas/**",
         "scripts/**",
         "package.json",
-        "bunfig.toml"
+        "bunfig.toml",
+        "turbo.json",
+        "android/auto-mobile-sdk/src/main/kotlin/**",
+        "android/control-proxy/src/main/kotlin/**",
+        "android/protocol/src/main/kotlin/**",
+        "android/video-server/src/main/kotlin/**",
+        "ios/auto-mobile-sdk/Sources/**",
+        "ios/control-proxy/Sources/**"
       ],
       "outputs": ["coverage/**"],
       "outputLogs": "new-only",


### PR DESCRIPTION
## Summary

`turbo.json`'s `test` and `test:coverage` input lists declared only `src/**`,
`test/**`, `schemas/**`, `scripts/**`, and a few config files — never the
`android/**` / `ios/**` trees. But several Bun tests are cross-language
source-scan guards that read Kotlin/Swift straight off disk (no `import` can
reach them). CI restores `.turbo` across runs and runs `turbo run test`, so a PR
that changed only Kotlin/Swift touched none of the declared inputs, hit the
cached result, and the guards never executed — the exact drift they exist to
catch shipped silently.

Concrete failure mode: change `MEDIUM(… fps = 60)` in
`android/video-server/.../QualityPreset.kt` in a Kotlin-only PR and
`webrtcDeviceCaptureLatency.test.ts`'s mirror check does not run, so the constant
drifts unnoticed.

## Changes

- Add narrow per-module globs to both `tasks.test.inputs` and
  `tasks["test:coverage"].inputs`, so touching a tree a guard reads busts the
  cache. Kept per-module (`src/main/kotlin/**`, `Sources/**`) rather than
  `android/**` so unrelated Gradle/AGP/doc churn does not invalidate the whole TS
  test cache (issue non-goal):
  - `android/auto-mobile-sdk/src/main/kotlin/**`, `android/control-proxy/src/main/kotlin/**`,
    `android/protocol/src/main/kotlin/**`, `android/video-server/src/main/kotlin/**`
  - `ios/auto-mobile-sdk/Sources/**`, `ios/control-proxy/Sources/**`
- Add `turbo.json` itself as an input of both tasks, so editing one task's input
  list can never leave the other replaying a stale hash.
- Note in each task's `description` why a directory no TS test imports is an
  input, pointing at the new guard so it is not "cleaned up" later.
- New guard `test/lint/turboTestInputsCoverNativeSources.test.ts` keeps the two
  coupled: it asserts each required glob (and `turbo.json`) is present on both
  tasks, that the description names the guard, and — anti-rot — that any
  `android/`/`ios/` path a test references and that exists on disk is either
  covered by a declared glob or carries a one-line not-read exemption. A future
  guard that starts reading a new native dir fails here instead of going stale.

Beyond the two guards named in the issue, the scan surfaced two more affected
readers now covered: `ctrlProxyProtocol.test.ts` (reads the `@SerialName` set
from `android/protocol/.../WebSocketRequest.kt`) and the identical iOS bug —
`registrationTeardownGuard` also walks Swift `Sources/`, and
`ctrlProxyWireParity.test.ts` mirrors `ios/control-proxy/.../Models.swift`.

## Linked Issue

Closes #4351

## Validation

- [x] `bun run lint` + `bun test` pass (9098 pass, 0 fail across 710 files)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New guard test uses only disk reads + JSON parse; runs in <500ms, no DB, no timers
- **Cache-miss proof (the issue's verify step):** primed the cache, then
  `bunx turbo run test --dry=json` hash before/after editing only
  `QualityPreset.kt`:
  - before: `2d4df644710034e8`
  - after Kotlin edit: `f7159bda8b18c3b0`  ← cache miss
  - after revert: `2d4df644710034e8`  ← restored

## Kotlin Reuse Check

N/A — no Kotlin/Swift source changed; this only adds those trees to the TS test
cache key.

## Follow-ups

None. Out-of-scope observations, if any, are noted on the issue.
