### PR TITLE
test(webrtc): bound the iOS device-capture teardown hook so a cosmetic restore can't fail a passing run (#4354)

### DIFF
--- a/test/helpers/captureStageTimeline.test.ts
+++ b/test/helpers/captureStageTimeline.test.ts
@@ -251,3 +251,154 @@ describe("#4343 capture stage timeline", () => {
     expect(Number.isFinite(first)).toBe(true);
   });
 });
+
+describe("#4354 teardown phase instrumentation", () => {
+  test("records a successful phase with its own elapsed time and returns the result", async () => {
+    const clock = fakeClock();
+    const timeline = new CaptureStageTimeline(clock.nowMs);
+
+    const value = await timeline.runPhase("daemonStartup", async () => {
+      clock.advance(1_200);
+      return 42;
+    });
+
+    expect(value).toBe(42);
+    expect(timeline.toRecord(context).phases).toEqual([
+      { phase: "daemonStartup", elapsedMs: 1_200, status: "ok" },
+    ]);
+  });
+
+  test("classifies a phase that throws under its budget as failed and re-throws", async () => {
+    const clock = fakeClock();
+    const timeline = new CaptureStageTimeline(clock.nowMs);
+
+    await expect(
+      timeline.runPhase(
+        "fixtureRestore",
+        async () => {
+          clock.advance(800);
+          throw new Error("simctl refused");
+        },
+        5_000
+      )
+    ).rejects.toThrow("simctl refused");
+
+    expect(timeline.toRecord(context).phases).toEqual([
+      { phase: "fixtureRestore", elapsedMs: 800, status: "failed", detail: "simctl refused" },
+    ]);
+  });
+
+  test("classifies a phase that reaches its budget as timedOut", async () => {
+    const clock = fakeClock();
+    const timeline = new CaptureStageTimeline(clock.nowMs);
+
+    await expect(
+      timeline.runPhase(
+        "fixtureRestore",
+        async () => {
+          clock.advance(5_000);
+          throw new Error("simctl killed after timeout");
+        },
+        5_000
+      )
+    ).rejects.toThrow("simctl killed after timeout");
+
+    const phase = timeline.toRecord(context).phases[0];
+    expect(phase.status).toBe("timedOut");
+    expect(phase.elapsedMs).toBe(5_000);
+  });
+
+  test("re-throwing leaves control flow to the caller — instrumentation never swallows", async () => {
+    const clock = fakeClock();
+    const timeline = new CaptureStageTimeline(clock.nowMs);
+    let caught: unknown;
+
+    try {
+      await timeline.runPhase("browserLaunch", async () => {
+        throw new Error("chrome did not start");
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect((caught as Error).message).toBe("chrome did not start");
+  });
+
+  test("records each phase, in the order they ran", async () => {
+    const clock = fakeClock();
+    const timeline = new CaptureStageTimeline(clock.nowMs);
+
+    await timeline.runPhase("daemonStartup", async () => clock.advance(300));
+    await timeline.runPhase("browserLaunch", async () => clock.advance(700));
+    await timeline.runPhase("pipelineTeardown", async () => clock.advance(150));
+
+    expect(timeline.toRecord(context).phases.map(phase => `${phase.phase}:${phase.elapsedMs}`)).toEqual([
+      "daemonStartup:300",
+      "browserLaunch:700",
+      "pipelineTeardown:150",
+    ]);
+  });
+
+  test("a passed pipeline outcome co-exists with a timed-out teardown phase in the record", async () => {
+    const clock = fakeClock();
+    const timeline = new CaptureStageTimeline(clock.nowMs);
+    timeline.mark("startRequest");
+    await timeline
+      .runPhase(
+        "fixtureRestore",
+        async () => {
+          clock.advance(5_000);
+          throw new Error("simctl wedged");
+        },
+        5_000
+      )
+      .catch(() => undefined);
+
+    const record = timeline.toRecord(context);
+
+    // The capture pipeline succeeded; the artifact keeps saying so. The red
+    // teardown is reported in its own field, resolving the #4354 confusion of a
+    // `passed` artifact against a `failed` job.
+    expect(record.outcome).toBe("passed");
+    expect(record.phases[0].status).toBe("timedOut");
+  });
+
+  test("bumps the record schema version so a parser can span the phases addition", () => {
+    expect(CAPTURE_STAGE_RECORD_SCHEMA_VERSION).toBe(2);
+  });
+
+  test("formats every phase with its status and elapsed time", async () => {
+    const clock = fakeClock();
+    const timeline = new CaptureStageTimeline(clock.nowMs);
+    timeline.mark("startRequest");
+    await timeline.runPhase("daemonStartup", async () => clock.advance(1_100));
+    await timeline
+      .runPhase(
+        "fixtureRestore",
+        async () => {
+          clock.advance(5_000);
+          throw new Error("simctl wedged");
+        },
+        5_000
+      )
+      .catch(() => undefined);
+
+    const formatted = formatCaptureStageRecord(timeline.toRecord(context));
+
+    expect(formatted).toContain("daemonStartup");
+    expect(formatted).toContain("1100ms");
+    expect(formatted).toContain("fixtureRestore");
+    expect(formatted).toContain("timedOut");
+    expect(formatted).toContain("simctl wedged");
+  });
+
+  test("omits the phases section entirely when no phase was run", () => {
+    const timeline = new CaptureStageTimeline(fakeClock().nowMs);
+    timeline.mark("startRequest");
+
+    const record = timeline.toRecord(context);
+
+    expect(record.phases).toEqual([]);
+    expect(formatCaptureStageRecord(record)).not.toContain("phase");
+  });
+});

--- a/test/helpers/captureStageTimeline.ts
+++ b/test/helpers/captureStageTimeline.ts
@@ -30,6 +30,24 @@ export interface CaptureDimensions {
   height: number;
 }
 
+/**
+ * Outcome of a bounded lifecycle phase (daemon startup, browser launch,
+ * pipeline teardown, fixture restore). `timedOut` when the phase threw at or
+ * past a supplied budget — the failure mode #4354 was invisible to: a cosmetic
+ * teardown blowing bun's implicit hook deadline while the pipeline `outcome`
+ * still reads `passed`.
+ */
+export type CapturePhaseStatus = "ok" | "failed" | "timedOut";
+
+export interface CapturePhaseMeasurement {
+  phase: string;
+  /** The phase's own wall time, end minus start — not elapsed from the origin. */
+  elapsedMs: number;
+  status: CapturePhaseStatus;
+  /** Failure message, present only when the phase did not end `ok`. */
+  detail?: string;
+}
+
 export interface CaptureStageMeasurement {
   stage: CaptureStage;
   /** Milliseconds between the first mark and this stage. */
@@ -98,14 +116,24 @@ export interface CaptureStageRecord extends CaptureStageContext {
   /** Bumped when the record's shape changes, so a parser can span generations. */
   schemaVersion: number;
   stages: CaptureStageMeasurement[];
+  /**
+   * Bounded lifecycle phases, in run order. Distinct from `stages` and from
+   * `outcome`: `outcome` reports the capture pipeline, while a phase failure
+   * (e.g. a wedged teardown) is recorded here without recolouring the pipeline
+   * result (#4354).
+   */
+  phases: CapturePhaseMeasurement[];
   /** Stages never reached — populated when a run fails part-way through. */
   missingStages: CaptureStage[];
   /** Start request to first browser-decoded frame, or null when never decoded. */
   captureToBrowserMs: number | null;
 }
 
-/** Current {@link CaptureStageRecord.schemaVersion}. */
-export const CAPTURE_STAGE_RECORD_SCHEMA_VERSION = 1;
+/**
+ * Current {@link CaptureStageRecord.schemaVersion}. Bumped to 2 when `phases`
+ * was added (#4354).
+ */
+export const CAPTURE_STAGE_RECORD_SCHEMA_VERSION = 2;
 
 /** Monotonic millisecond reader used when none is injected. */
 export function monotonicNowMs(): number {
@@ -114,9 +142,39 @@ export function monotonicNowMs(): number {
 
 export class CaptureStageTimeline {
   private readonly marks = new Map<CaptureStage, number>();
+  private readonly phases: CapturePhaseMeasurement[] = [];
   private originMs: number | null = null;
 
   constructor(private readonly nowMs: () => number = monotonicNowMs) {}
+
+  /**
+   * Time a bounded lifecycle phase and record its own elapsed duration and
+   * status, then hand control back unchanged — the result is returned and a
+   * rejection re-thrown, so instrumentation never alters what the phase would
+   * otherwise do. `budgetMs`, when supplied, is the deadline the caller bounds
+   * the phase with: a rejection at or past it is classified `timedOut` so a
+   * teardown that blew its deadline is distinguishable from one that failed
+   * fast (#4354).
+   */
+  async runPhase<T>(phase: string, fn: () => Promise<T>, budgetMs?: number): Promise<T> {
+    const start = this.nowMs();
+    try {
+      const result = await fn();
+      this.phases.push({ phase, elapsedMs: this.nowMs() - start, status: "ok" });
+      return result;
+    } catch (error) {
+      const elapsedMs = this.nowMs() - start;
+      const status: CapturePhaseStatus =
+        budgetMs !== undefined && elapsedMs >= budgetMs ? "timedOut" : "failed";
+      this.phases.push({
+        phase,
+        elapsedMs,
+        status,
+        detail: error instanceof Error ? error.message : String(error),
+      });
+      throw error;
+    }
+  }
 
   /**
    * Record the moment a stage was observed. The first mark sets the origin, and
@@ -154,6 +212,7 @@ export class CaptureStageTimeline {
       ...context,
       schemaVersion: CAPTURE_STAGE_RECORD_SCHEMA_VERSION,
       stages,
+      phases: [...this.phases],
       missingStages: CAPTURE_STAGES.filter(stage => !this.marks.has(stage)),
       captureToBrowserMs: this.marks.get("firstDecodedFrame") ?? null,
     };
@@ -178,6 +237,15 @@ export function formatCaptureStageRecord(record: CaptureStageRecord): string {
   ];
   if (record.captureToBrowserMs !== null) {
     lines.push(`captureToBrowser=${Math.round(record.captureToBrowserMs)}ms`);
+  }
+  if (record.phases.length > 0) {
+    const phaseWidth = Math.max(...record.phases.map(phase => phase.phase.length));
+    for (const phase of record.phases) {
+      const detail = phase.detail ? `: ${phase.detail}` : "";
+      lines.push(
+        `  [phase] ${phase.phase.padEnd(phaseWidth)} ${Math.round(phase.elapsedMs)}ms ${phase.status}${detail}`
+      );
+    }
   }
   if (record.missingStages.length > 0) {
     lines.push(`missing=${record.missingStages.join(",")}`);

--- a/test/integration/webrtcDeviceCapture.integration.test.ts
+++ b/test/integration/webrtcDeviceCapture.integration.test.ts
@@ -34,6 +34,16 @@ const deviceIntegrationTimeoutMs = 360_000;
 // test/integration/webrtcDeviceCaptureLatency.test.ts so the two cannot drift.
 const ANDROID_VIDEO_SERVER_MEDIUM_FPS = 60;
 
+// The cosmetic fixture-restore hook contends with a just-stopped capture; a
+// simctl/adb call that wedges must be killed rather than block the hook. Bounds
+// the restore subprocess itself, so the hook deadline below is never reached by
+// a hung child (#4354).
+const FIXTURE_RESTORE_TIMEOUT_MS = 15_000;
+// bun caps a hook with no explicit deadline at 5000ms, which is what turned a
+// slow appearance restore into a failed run whose pipeline recorded `passed`.
+// Give the hook its own generous timeout, comfortably past the restore budget.
+const TEARDOWN_HOOK_TIMEOUT_MS = 30_000;
+
 interface ChromeTarget { type: string; webSocketDebuggerUrl?: string }
 interface CdpResponse { id?: number; result?: { result?: { value?: unknown } }; error?: { message?: string } }
 interface ReaderDiagnostics {
@@ -285,12 +295,30 @@ async function changeFixture(): Promise<void> {
 }
 
 afterEach(async () => {
-  if (platform === "android") {
-    const id = androidDeviceId();
-    await execFileAsync("adb", ["-s", id, "shell", "cmd", "uimode", "night", "no"]).catch(() => undefined);
-  }
-  if (platform === "ios") {await execFileAsync("xcrun", ["simctl", "ui", "booted", "appearance", "light"]).catch(() => undefined);}
-});
+  // Measured as its own phase and swallowed: a cosmetic restore must be
+  // attributable from the artifact (#4354) but must never fail an otherwise
+  // passing run. The explicit hook timeout keeps bun's 5s default from firing;
+  // the subprocess timeout kills a wedged simctl/adb before the budget is hit.
+  await timeline
+    .runPhase(
+      "fixtureRestore",
+      async () => {
+        if (platform === "android") {
+          const id = androidDeviceId();
+          await execFileAsync("adb", ["-s", id, "shell", "cmd", "uimode", "night", "no"], {
+            timeout: FIXTURE_RESTORE_TIMEOUT_MS,
+          });
+        }
+        if (platform === "ios") {
+          await execFileAsync("xcrun", ["simctl", "ui", "booted", "appearance", "light"], {
+            timeout: FIXTURE_RESTORE_TIMEOUT_MS,
+          });
+        }
+      },
+      FIXTURE_RESTORE_TIMEOUT_MS
+    )
+    .catch(() => undefined);
+}, TEARDOWN_HOOK_TIMEOUT_MS);
 
 // Poll cadences the stages are observed with. Each measurement carries up to
 // its interval as positive bias, so the record reports them rather than leaving
@@ -460,18 +488,24 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
       outcome = "passed";
     } finally {
       observingStart = false;
-      // Nothing in the observer rejects today; swallow anyway so a future edit
-      // cannot skip the teardown below and replace the real test failure.
-      await startObserver.catch(() => undefined);
-      cdp?.close();
-      await stop(chrome);
-      if (started) {await execFileAsync("bun", ["dist/src/index.js", "--daemon", "stop"], { env: daemonEnvironment }).catch(() => undefined);}
-      await stop(mediamtx);
-      await rm(webRtcSocketDir, { recursive: true, force: true });
-      // The daemon dir lives under the artifact dir and holds its logs and DB.
-      // Now that artifacts upload on success too, keep it only for a failure to
-      // triage; a green run should ship the latency record, not a sqlite file.
-      if (outcome === "passed") {await rm(daemonDir, { recursive: true, force: true });}
+      // Measured as its own phase (#4354) so a teardown that stalls stopping the
+      // daemon, MediaMTX or Chrome is attributable from the artifact rather than
+      // only from job logs. runPhase re-throws, preserving the prior semantics
+      // where a failed cleanup surfaces as a test failure.
+      await timeline.runPhase("pipelineTeardown", async () => {
+        // Nothing in the observer rejects today; swallow anyway so a future edit
+        // cannot skip the teardown below and replace the real test failure.
+        await startObserver.catch(() => undefined);
+        cdp?.close();
+        await stop(chrome);
+        if (started) {await execFileAsync("bun", ["dist/src/index.js", "--daemon", "stop"], { env: daemonEnvironment }).catch(() => undefined);}
+        await stop(mediamtx);
+        await rm(webRtcSocketDir, { recursive: true, force: true });
+        // The daemon dir lives under the artifact dir and holds its logs and DB.
+        // Now that artifacts upload on success too, keep it only for a failure to
+        // triage; a green run should ship the latency record, not a sqlite file.
+        if (outcome === "passed") {await rm(daemonDir, { recursive: true, force: true });}
+      });
     }
   }, deviceIntegrationTimeoutMs);
 });

--- a/test/integration/webrtcDeviceCaptureLatency.test.ts
+++ b/test/integration/webrtcDeviceCaptureLatency.test.ts
@@ -103,6 +103,70 @@ describe("#4343 device capture latency instrumentation", () => {
     ).toEqual([]);
   });
 
+  test("gives the fixture-restore afterEach hook an explicit timeout past bun's 5s default (#4354)", () => {
+    const source = withoutComments(read(INTEGRATION_TEST_PATH));
+
+    // Bun caps a hook with no explicit deadline at 5000ms, so a cosmetic
+    // simctl/adb restore that contends with a just-stopped capture fails an
+    // otherwise-passing run. The hook must carry its own generous timeout.
+    const hookMatch = /afterEach\([\s\S]*?\},\s*([A-Z_]+)\s*\)/.exec(source);
+    expect(hookMatch).not.toBeNull();
+    const timeoutConstant = hookMatch![1];
+
+    const constantValue = new RegExp(`const ${timeoutConstant} = (\\d[\\d_]*)`).exec(source)?.[1];
+    expect(constantValue).toBeDefined();
+    expect(Number(constantValue!.replace(/_/g, ""))).toBeGreaterThan(5_000);
+  });
+
+  test("bounds each fixture-restore subprocess so a wedged simctl/adb is killed, not waited on (#4354)", () => {
+    const source = withoutComments(read(INTEGRATION_TEST_PATH));
+    const afterEachIndex = indexOfRequired(source, "afterEach(");
+    // The hook closes on its explicit timeout argument; slice to there rather
+    // than to a bare `});`, which an options object `{ timeout: N });` would
+    // trip on and truncate the region mid-hook.
+    const hookEnd = source.indexOf("}, TEARDOWN_HOOK_TIMEOUT_MS)", afterEachIndex);
+    expect(hookEnd).toBeGreaterThan(afterEachIndex);
+    const hookBody = source.slice(afterEachIndex, hookEnd);
+
+    // Every execFileAsync inside the restore hook must pass a timeout; an
+    // unbounded child can outlast even the generous hook deadline.
+    const restoreCalls = hookBody.match(/execFileAsync\(/g) ?? [];
+    expect(restoreCalls.length).toBeGreaterThan(0);
+    const boundedCalls = hookBody.match(/execFileAsync\([\s\S]*?timeout:/g) ?? [];
+    expect(boundedCalls.length).toBe(restoreCalls.length);
+  });
+
+  test("measures the fixture-restore hook as a phase so a teardown failure is attributable from the artifact (#4354)", () => {
+    const source = withoutComments(read(INTEGRATION_TEST_PATH));
+    const afterEachIndex = indexOfRequired(source, "afterEach(");
+
+    // The hook records its own elapsed time and status into the stage record,
+    // so a red teardown is visible without reading job logs. Whitespace-tolerant:
+    // the call is written as a multi-line `timeline\n.runPhase(` chain.
+    const phaseInHook = /runPhase\(\s*"fixtureRestore"/.exec(source.slice(afterEachIndex));
+    expect(phaseInHook).not.toBeNull();
+  });
+
+  test("wraps the pipeline teardown finally in its own measured phase (#4354)", () => {
+    const source = withoutComments(read(INTEGRATION_TEST_PATH));
+
+    expect(source).toContain('runPhase("pipelineTeardown"');
+  });
+
+  test("collects phases on the shared timeline and keeps afterAll the sole record writer (#4354)", () => {
+    const source = withoutComments(read(INTEGRATION_TEST_PATH));
+    const afterAllIndex = source.indexOf("afterAll(");
+
+    // Both phases record onto the module-scope `timeline` — the same instance
+    // afterAll serializes — so they survive a test-body timeout the way the
+    // stage marks do, rather than being lost on a local per-test object.
+    const sharedTimelinePhases = source.match(/timeline\s*\.\s*runPhase\(/g) ?? [];
+    expect(sharedTimelinePhases.length).toBeGreaterThanOrEqual(2);
+    // afterAll is still the only place the record is written to disk.
+    expect(source.indexOf("stage-latency.json")).toBeGreaterThan(afterAllIndex);
+    expect(source.indexOf("writeFile", afterAllIndex)).toBeGreaterThan(afterAllIndex);
+  });
+
   test("mirrors the Android capture fps from the video-server default quality preset", () => {
     const integration = read(INTEGRATION_TEST_PATH);
     const encoder = read("src/features/webrtc/PersistentEncoderH264Source.ts");


### PR DESCRIPTION
## Summary

The iOS device-capture lane could run the entire capture pipeline successfully — recording `outcome=passed` with all six stages and a `captureToBrowser` of 14–32s — and still fail the job in the fixture-restore `afterEach`. bun caps a hook that has no explicit deadline at 5000ms, so a cosmetic `simctl ui appearance` (iOS) / `adb cmd uimode` (Android) restore that contends with a just-stopped capture blew that deadline and reddened an otherwise-green run. The `.catch()` on the restore covered a *rejection*, not a *hang*, so a slow-but-not-failing subprocess still fired the hook deadline.

This reconciles the issue's puzzle exactly: the reported test duration is body + hook, so `183288ms ≈ 178s body + the 5s hook cap`. The extra ~3 minutes are the normal iOS body (daemon bootstrap, Chrome cold start, two 30s decode waits, teardown) — not the bug.

## Linked Issue

Closes #4354

## Bug / Regression Context

- **Observed symptom:** job `failure` while `stage-latency.json` reads `passed` with all six stages; error is `a beforeEach/afterEach hook timed out for this test`.
- **Repro conditions:** the fixture-restore `afterEach` runs an unbounded `simctl`/`adb` subprocess with no explicit hook timeout; when the restore is slow (contending with a just-stopped capture) it exceeds bun's implicit 5000ms hook deadline.
- **Root cause confirmed empirically** on this repo's bun 1.3.14: an `afterEach` with a 6s sleep and no explicit timeout fails with the exact issue string at `[5001.05ms]`, and a 2s body pushes the reported duration to `[7002.12ms]` (body + hook).

## Changes

- **Explicit hook timeout** — the restore `afterEach` now carries a 30s deadline (`TEARDOWN_HOOK_TIMEOUT_MS`), well past bun's 5s default, so a slow cosmetic restore no longer fails the run.
- **Bounded restore subprocess** — each `simctl`/`adb` restore call gets a 15s `timeout` (`FIXTURE_RESTORE_TIMEOUT_MS`), so a genuinely wedged child is killed rather than consuming the hook deadline.
- **Attributable teardown** — new `CaptureStageTimeline.runPhase(name, fn, budgetMs?)` measures the fixture restore and the pipeline teardown as their own phases, recording elapsed time and a status (`ok` / `failed` / `timedOut`) into `stage-latency.json`. A teardown failure is now visible from the artifact without reading job logs.
- **Clear artifact semantics** — a phase failure lands in its own `phases` field; the pipeline `outcome` keeps meaning *the capture pipeline*, resolving the confusing `passed`-artifact/`failed`-job mismatch. Record `schemaVersion` bumped 1 → 2.

## Validation

- [x] `bun test` — whole suite green (9104 pass, 0 fail); new helper unit tests + wiring guards pass in <130ms
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run lint` clean (simctl/adb boundary checks pass — only `{ timeout }` options added, no new invocations)
- [x] `bun run build` succeeds
- [x] New code uses an injected clock (existing `CaptureStageTimeline` fake-clock seam); unit tests run in <100ms

## Acceptance criteria

Inferred from the issue (no explicit AC section) and confirmed at the plan gate:

| # | Criterion | Pinned by |
| --- | --- | --- |
| AC1 | A cosmetic restore can't fail a passing run via bun's implicit 5s hook deadline | guard: `afterEach` carries an explicit timeout > 5000 |
| AC2 | The restore subprocess is itself bounded and a wedged one is killed | guard: every restore `execFileAsync` passes a `timeout` |
| AC3 | The hook phase and its own elapsed time land in the artifact | unit tests for `runPhase` elapsed/status + guards that the hook and teardown record phases |
| AC4 | The artifact explains the `passed`/`failed` mismatch on its face | unit test: `outcome:passed` co-exists with a `timedOut` teardown phase |

## Device Verification

N/A — test-harness-only change (`test/helpers/`, `test/integration/`). The device lane requires a real simulator/emulator; AC1/AC2 are pinned by source-scan guards, the established pattern for this file (#4343). The lane will exercise the wiring on its next scheduled run since `test/helpers/captureStageTimeline.ts` is in the workflow's paths-filter.
