### PR TITLE
fix(observe): resolve tasks[].rootActivity from rootOfTask=true, not first Hist #0

### DIFF
--- a/src/features/observe/GetBackStack.ts
+++ b/src/features/observe/GetBackStack.ts
@@ -137,6 +137,17 @@ const HIST_LINE = /\bHist\s+#\d+:/;
  */
 const ROOT_OF_TASK_LINE = /^\s*rootOfTask=(true|false)\b/;
 
+/**
+ * The two candidate root components for a task, gathered from its `Hist` rows.
+ * `firstHist0` is the index-derived value (the only source on API <= 29);
+ * `authoritative` is the component whose ActivityRecord block prints
+ * rootOfTask=true and, when present, is preferred (issue #4359).
+ */
+interface HistRootEntry {
+  firstHist0?: string;
+  authoritative?: string;
+}
+
 /** Fields carried by a modern task header line. */
 interface TaskHeaderFields {
   id: number;
@@ -305,16 +316,48 @@ export class GetBackStack implements BackStack {
     // for the same task ("Task id #N" then "* TaskRecord{... #N ...}"), so the
     // second must resume the first's count rather than restart it.
     const histCounts: Map<number, number> = new Map();
-    // The component of each task's "Hist #0" row. `Hist #0` is normally the
-    // task root (see #4197; the authoritative rootOfTask= field can disagree
-    // on API 30+, see #4340 -- close enough for the package-name fallback this
-    // feeds), and its "pkg/.Cls" is the same shape legacy `realActivity=`
-    // prints. This is the ONLY package source on the modern path (issue #4263):
-    // a modern header's `A=` is `Task.affinity`, which is uid-prefixed on
-    // Android 11+, is an app-declarable string that need not name a package,
-    // and is empty for `android:taskAffinity=""`. It is applied at flush time,
-    // and only as a fallback, so `I=`/`aI=` and `realActivity=` still win.
-    const histRoots: Map<number, string> = new Map();
+    // The root component of each task, derived from its `Hist` rows. `Hist #0`
+    // is normally the task root (see #4197), and its "pkg/.Cls" is the same
+    // shape legacy `realActivity=` prints. This is the ONLY package source on
+    // the modern path (issue #4263): a modern header's `A=` is `Task.affinity`,
+    // which is uid-prefixed on Android 11+, is an app-declarable string that
+    // need not name a package, and is empty for `android:taskAffinity=""`. It
+    // is applied at flush time, and only as a fallback, so `I=`/`aI=` and
+    // `realActivity=` still win.
+    //
+    // `Hist #0` is not authoritative: on API 30+ a task can print two `Hist #0`
+    // rows in different TaskFragments and only one's block says rootOfTask=true
+    // (issue #4359, api34 task #9). `firstHist0` keeps the index-derived value
+    // (the sole source on API <= 29, where rootOfTask= is absent); `authoritative`
+    // captures the component whose block prints rootOfTask=true and, when set,
+    // is preferred. This override only ever *replaces* a firstHist0 value -- a
+    // task that prints no `Hist #0` row stays undefined even if a later `Hist #N`
+    // says rootOfTask=true, matching the pre-#4359 "no Hist #0 -> no root" rule.
+    const histRoots: Map<number, HistRootEntry> = new Map();
+    // The still-open ActivityRecord block: the `Hist` row whose `rootOfTask=`
+    // field, if printed, we are waiting on. Mirrors parseActivities' openActivity
+    // discipline (issue #4340) -- cleared at the next Hist row / task header /
+    // consumed rootOfTask= so a value never bleeds across records.
+    let openHist: { owner: number; component: string } | undefined;
+
+    const histRootEntry = (owner: number): HistRootEntry => {
+      let entry = histRoots.get(owner);
+      if (entry === undefined) {
+        entry = {};
+        histRoots.set(owner, entry);
+      }
+      return entry;
+    };
+    // First `Hist #0` wins; first rootOfTask=true wins. Encapsulated so the scan
+    // loop stays flat (the max-depth ratchet caps nesting at 3).
+    const recordFirstHist0 = (owner: number, component: string): void => {
+      const entry = histRootEntry(owner);
+      entry.firstHist0 ??= component;
+    };
+    const recordAuthoritative = (owner: number, component: string): void => {
+      const entry = histRootEntry(owner);
+      entry.authoritative ??= component;
+    };
 
     const flush = (): void => {
       if (currentTaskId === -1 || currentTask.id === undefined) {
@@ -341,6 +384,8 @@ export class GetBackStack implements BackStack {
         // "Running activities"; restarting there discarded everything already
         // parsed for that task (issue #4263).
         currentTask = tasks.get(currentTaskId) ?? { id: currentTaskId };
+        // A task header ends the previous record's block (see openHist).
+        openHist = undefined;
         if (header.affinity) {
           currentTask.affinity = header.affinity;
         }
@@ -361,12 +406,28 @@ export class GetBackStack implements BackStack {
         // printed under another header.
         const owner = hist.taskId ?? currentTaskId;
         histCounts.set(owner, (histCounts.get(owner) ?? 0) + 1);
-        if (hist.histIndex === 0 && !histRoots.has(owner)) {
-          histRoots.set(owner, hist.component);
+        if (hist.histIndex === 0) {
+          recordFirstHist0(owner, hist.component);
         }
+        // This row opens a new ActivityRecord block; its own rootOfTask= (if
+        // printed a few lines below) targets this row.
+        openHist = { owner, component: hist.component };
       } else if (HIST_LINE.test(line)) {
-        // A Hist row in a shape parseHistRow does not recognize still counts.
+        // A Hist row in a shape parseHistRow does not recognize still counts,
+        // and still ends the previous record's block.
         histCounts.set(currentTaskId, (histCounts.get(currentTaskId) ?? 0) + 1);
+        openHist = undefined;
+      }
+
+      // The open record's own rootOfTask= field (see ROOT_OF_TASK_LINE / #4340).
+      // First rootOfTask=true wins, so the api34 double-`Hist #0` task resolves
+      // to the row the dump actually marks as the root.
+      const rootOfTask = line.match(ROOT_OF_TASK_LINE);
+      if (rootOfTask && openHist) {
+        if (rootOfTask[1] === "true") {
+          recordAuthoritative(openHist.owner, openHist.component);
+        }
+        openHist = undefined;
       }
 
       // Match affinity
@@ -402,13 +463,16 @@ export class GetBackStack implements BackStack {
       if (task.numActivities === undefined) {
         task.numActivities = histCounts.get(task.id) ?? 0;
       }
-      const histRoot = histRoots.get(task.id);
-      // No Hist #0 row and no I=/aI=/realActivity= means nothing in this dump
-      // identifies the task's package. Leaving both undefined is the honest
-      // answer; the affinity is not a package name and is not guessed from.
-      if (histRoot === undefined) {
+      const entry = histRoots.get(task.id);
+      // No `Hist #0` row means nothing here resolves the task's root the way
+      // this fallback is scoped to. A rootOfTask=true row alone does NOT
+      // populate an otherwise-undefined root (issue #4359): the override only
+      // ever replaces the index-derived `firstHist0` value. Leaving both
+      // undefined is the honest answer; the affinity is not a package name.
+      if (entry === undefined || entry.firstHist0 === undefined) {
         continue;
       }
+      const histRoot = entry.authoritative ?? entry.firstHist0;
       if (task.rootActivity === undefined) {
         task.rootActivity = histRoot;
       }

--- a/test/features/observe/GetBackStackRealCaptures.test.ts
+++ b/test/features/observe/GetBackStackRealCaptures.test.ts
@@ -253,6 +253,33 @@ describe("GetBackStack against real captures (#4329)", () => {
         });
       }
 
+      if (readCapture(file).includes("rootOfTask=")) {
+        test("tasks[].rootActivity agrees with the activity marked isTaskRoot (#4359)", async () => {
+          // Cross-consistency: whichever activity `activities[]` reports as the
+          // task root (driven by the block's own rootOfTask= field since #4357)
+          // must be the same component `tasks[].rootActivity` names for that
+          // task. Before #4359, parseTasks resolved rootActivity from the first
+          // `Hist #0` row, which can name an activity the dump says is NOT the
+          // root (api34 task #9). Scoped to tasks that actually carry a marked
+          // root activity -- container tasks with no Hist rows leave rootActivity
+          // undefined, which this invariant cannot speak to.
+          const result = await parse(readCapture(file));
+          const rootByTask = new Map<number, string>();
+          for (const activity of result.activities) {
+            if (activity.isTaskRoot) {
+              rootByTask.set(activity.taskId, activity.name);
+            }
+          }
+          for (const task of result.tasks) {
+            const markedRoot = rootByTask.get(task.id);
+            if (markedRoot === undefined || task.rootActivity === undefined) {
+              continue;
+            }
+            expect(qualify(task.rootActivity)).toBe(markedRoot);
+          }
+        });
+      }
+
       test("parses tasks via the header format this level actually emits", async () => {
         // Ties each level to the parser path it exercises: a modern-format level
         // whose `* Task{...}` parsing regressed, or a legacy-format level whose
@@ -318,6 +345,76 @@ describe("GetBackStack against real captures (#4329)", () => {
       expect(wifi).toBeDefined();
       expect(wifi!.isTaskRoot).toBe(false);
     });
+  });
+
+  // AC1: parseTasks must resolve rootActivity from the Hist row the dump marks
+  // rootOfTask=true, not the first `Hist #0` row (issue #4359). Task #9 prints
+  // two `Hist #0` rows in different TaskFragments; the first (Wifi) says
+  // rootOfTask=false, the second (DeepLinkHomepage) says true.
+  describe("api34 task #9 rootActivity prefers rootOfTask=true (#4359)", () => {
+    test("rootActivity names DeepLinkHomepageActivity, not the first Hist #0 Wifi row", async () => {
+      const result = await parse(readCapture("api34-home-settings-secondapp.log"));
+      const task9 = result.tasks.find(t => t.id === 9);
+      expect(task9).toBeDefined();
+      expect(task9!.rootActivity).toBe("com.android.settings/.homepage.DeepLinkHomepageActivity");
+      // packageName is unaffected -- both Hist #0 rows are com.android.settings.
+      expect(task9!.packageName).toBe("com.android.settings");
+    });
+  });
+
+  // AC2: API <= 29 fixtures print no rootOfTask= field, so the first-`Hist #0`
+  // fallback stays the only source; their rootActivity values must not move
+  // (issue #4359). Pinned to the exact values the committed captures carry.
+  describe("API <= 29 rootActivity is unchanged (#4359)", () => {
+    const BASELINE: Record<string, Array<[number, string]>> = {
+      "api24-home-settings-secondapp.log": [
+        [5, "com.android.contacts/.activities.PeopleActivity"],
+        [4, "com.android.settings/.Settings"],
+        [3, "com.android.launcher3/.Launcher"]
+      ],
+      "api25-home-settings-secondapp.log": [
+        [8, "com.android.contacts/.activities.PeopleActivity"],
+        [7, "com.android.settings/.Settings$WifiSettingsActivity"],
+        [6, "com.android.settings/.Settings"],
+        [5, "com.android.launcher3/.Launcher"]
+      ],
+      "api26-home-settings-secondapp.log": [
+        [8, "com.android.contacts/.activities.PeopleActivity"],
+        [7, "com.android.settings/.Settings$WifiSettingsActivity"],
+        [6, "com.android.settings/.Settings"],
+        [5, "com.google.android.apps.nexuslauncher/.NexusLauncherActivity"]
+      ],
+      "api27-home-settings-secondapp.log": [
+        [8, "com.android.contacts/.activities.PeopleActivity"],
+        [7, "com.android.settings/.Settings$WifiSettingsActivity"],
+        [6, "com.android.settings/.Settings"],
+        [5, "com.google.android.apps.nexuslauncher/.NexusLauncherActivity"]
+      ],
+      "api28-home-settings-secondapp.log": [
+        [8, "com.android.contacts/.activities.PeopleActivity"],
+        [7, "com.android.settings/.Settings$WifiSettingsActivity"],
+        [6, "com.android.settings/.Settings"],
+        [5, "com.android.launcher3/.Launcher"]
+      ],
+      "api29-home-settings-secondapp.log": [
+        [7, "com.android.contacts/.activities.PeopleActivity"],
+        [6, "com.android.settings/.homepage.SettingsHomepageActivity"],
+        [5, "com.google.android.apps.nexuslauncher/.NexusLauncherActivity"]
+      ]
+    };
+
+    for (const [file, expected] of Object.entries(BASELINE)) {
+      test(`${file} keeps its rootActivity values`, async () => {
+        const raw = readCapture(file);
+        // Guard the premise: these levels genuinely print no rootOfTask= field.
+        expect(raw).not.toContain("rootOfTask=");
+        const result = await parse(raw);
+        for (const [id, rootActivity] of expected) {
+          const task = result.tasks.find(t => t.id === id);
+          expect(task?.rootActivity).toBe(rootActivity);
+        }
+      });
+    }
   });
 
   describe("api34 modern capture, exact values", () => {

--- a/test/features/observe/GetBackStackTaskAnchoring.test.ts
+++ b/test/features/observe/GetBackStackTaskAnchoring.test.ts
@@ -211,3 +211,75 @@ Display #0 (activities from top to bottom):
     expect(result.tasks[0].rootActivity).toBeUndefined();
   });
 });
+
+describe("Hist #0 root component defers to rootOfTask=true (#4359)", () => {
+  // Mirrors api34 task #9: two `Hist #0` rows in different TaskFragments. The
+  // first says rootOfTask=false, the second rootOfTask=true. The first-`Hist #0`
+  // heuristic named the activity the dump itself calls NOT the root.
+  const TWO_HIST0_ROWS = `
+ACTIVITY MANAGER ACTIVITIES (dumpsys activity activities)
+  * Task{9de9b7 #9 type=standard A=1000:com.android.settings U=0 mode=fullscreen sz=2}
+    * TaskFragment{aaa mode=fullscreen}
+      * Hist  #0: ActivityRecord{459683c u0 com.android.settings/.Settings$WifiSettingsActivity t9}
+          packageName=com.android.settings processName=com.android.settings
+          rootOfTask=false task=Task{9de9b7 #9 type=standard A=1000:com.android.settings}
+    * TaskFragment{bbb mode=fullscreen}
+      * Hist  #0: ActivityRecord{5059d6b u0 com.android.settings/.homepage.DeepLinkHomepageActivity t9}
+          packageName=com.android.settings processName=com.android.settings
+          rootOfTask=true task=Task{9de9b7 #9 type=standard A=1000:com.android.settings}
+`;
+
+  test("rootActivity is the rootOfTask=true row, not the first Hist #0", async () => {
+    const result = await parse(TWO_HIST0_ROWS);
+
+    expect(result.tasks[0].rootActivity).toBe(
+      "com.android.settings/.homepage.DeepLinkHomepageActivity"
+    );
+    expect(result.tasks[0].packageName).toBe("com.android.settings");
+  });
+
+  test("API <= 29: with no rootOfTask= printed, the first Hist #0 still wins", async () => {
+    // The authoritative field is absent pre-API-30, so the index heuristic
+    // remains the only source and its behavior must not change.
+    const result = await parse(`
+    Task id #14418
+    * TaskRecord{1d3813b #14418 A=com.example U=0 StackId=436 sz=2}
+      * Hist #0: ActivityRecord{aaa u0 com.example/.FirstActivity t14418}
+          frontOfTask=true task=TaskRecord{1d3813b #14418}
+      * Hist #0: ActivityRecord{bbb u0 com.example/.SecondActivity t14418}
+          frontOfTask=false task=TaskRecord{1d3813b #14418}
+`);
+
+    expect(result.tasks[0].rootActivity).toBe("com.example/.FirstActivity");
+  });
+
+  test("rootOfTask=true does NOT populate a task that prints no Hist #0", async () => {
+    // Narrowed to overriding an existing Hist #0-derived value: a task whose
+    // only rootOfTask=true row is a Hist #N (N>0) with no Hist #0 stays
+    // undefined, exactly as before #4359. rootActivity must not appear where it
+    // was absent.
+    const result = await parse(`
+  * Task{d19dee2 #61 type=standard A=10164:com.example U=0 mode=fullscreen sz=1}
+    * Hist  #1: ActivityRecord{2b2ce0f u0 com.example/.RootActivity t61}
+        packageName=com.example processName=com.example
+        rootOfTask=true task=Task{d19dee2 #61 type=standard A=10164:com.example}
+`);
+
+    expect(result.tasks[0].id).toBe(61);
+    expect(result.tasks[0].rootActivity).toBeUndefined();
+    expect(result.tasks[0].packageName).toBeUndefined();
+  });
+
+  test("rootOfTask=true does not override an I= header component", async () => {
+    // The header's own intent component still outranks the Hist-derived root,
+    // just as the first-Hist #0 path did.
+    const result = await parse(`
+  * Task{9c31af0 #1 type=home I=com.android.launcher3/.Launcher U=0 mode=fullscreen sz=1}
+    * Hist  #0: ActivityRecord{3177c30 u0 com.android.launcher3/.OtherEntry t1}
+        rootOfTask=true task=Task{9c31af0 #1 type=home I=com.android.launcher3/.Launcher}
+`);
+
+    expect(result.tasks[0].rootActivity).toBe("com.android.launcher3/.Launcher");
+    expect(result.tasks[0].packageName).toBe("com.android.launcher3");
+  });
+});


### PR DESCRIPTION
## Summary

`GetBackStack.parseTasks` resolved each task's `rootActivity` / `packageName`
from `histRoots` — the component of the task's **first** `Hist #0` row. On
API 30+ a task can print two `Hist #0` rows in different TaskFragments where only
one's `ActivityRecord` block says `rootOfTask=true`, so first-`Hist #0`-wins named
the activity the dump itself calls **not** the root. This PR makes `parseTasks`
prefer the `Hist` row whose block prints `rootOfTask=true` — the same
`ROOT_OF_TASK_LINE` pass [#4357](https://github.com/kaeawc/auto-mobile/pull/4357)
added to `parseActivities` — falling back to the first-`Hist #0` behavior where
the field is absent (API ≤ 29).

The override only ever **replaces** an existing `Hist #0`-derived value: a task
that prints no `Hist #0` row stays `undefined`, unchanged from before — no
`undefined → defined` behavior change.

## Linked Issue

Closes #4359

## Bug / Regression Context

- **Prior attempts:** [#4357](https://github.com/kaeawc/auto-mobile/pull/4357) fixed
  `activities[].isTaskRoot` via the block's own `rootOfTask=` field but left
  `tasks[].rootActivity` on the first-`Hist #0` heuristic, creating an internal
  inconsistency within the same result.
- **Observed symptom:** In `api34-home-settings-secondapp.log`, task #9 has two
  `Hist #0` rows — `Settings$WifiSettingsActivity` (`rootOfTask=false`, printed
  first) and `.homepage.DeepLinkHomepageActivity` (`rootOfTask=true`).
  `tasks[].rootActivity` named Wifi while `activities[]` marked DeepLinkHomepage as
  the task root.
- **Repro steps / conditions:** Parse any API 30+ dump where a task prints a
  `Hist #0` row whose block says `rootOfTask=false` ahead of the true root.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes (`bun run lint` + `bun test`) — full suite 9108 pass / 0 fail
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New tests use interfaces + fakes (`FakeAdbExecutor`); unit tests run in <100ms
- [x] Reuses the existing `ROOT_OF_TASK_LINE` / `HIST_LINE` constants and the `openActivity`-block discipline — no new dependency or parser

## Acceptance Criteria (from #4359)

- [x] `tasks[].rootActivity` for api34 task #9 resolves to `com.android.settings/.homepage.DeepLinkHomepageActivity`.
- [x] API ≤ 29 fixtures keep their current `rootActivity` values.
- [x] `tasks[].rootActivity` never disagrees with the activity `activities[]` marks `isTaskRoot: true` for the same task, across all committed fixtures that print `rootOfTask=`.

A before/after diff across all 13 committed API-level fixtures confirms the **only**
value that moved is api34 task #9's `rootActivity`; every other task (including all
API ≤ 29 values and every `undefined` container task) is byte-for-byte unchanged.

## Device Verification

- N/A — pure text-parser change, asserted against committed real-device captures
  (`activityActivitiesDumps/`, one per API level 24–36).
