### PR TITLE
fix(lint): close sdkmanager boundary interprocedural gap, cover Bun.$, register in fast-validate

### DIFF
--- a/scripts/all_fast_validate_checks.sh
+++ b/scripts/all_fast_validate_checks.sh
@@ -49,6 +49,7 @@ add_check "security-boundary" "bash \"$PROJECT_ROOT/scripts/check-no-new-direct-
 add_check "app-bundle-metadata-boundary" "bun \"$PROJECT_ROOT/scripts/check-app-bundle-metadata-boundary.ts\"" "lint,conventions" "Require AppBundleMetadataClient to own codesign execution"
 add_check "git-metadata-boundary" "bash \"$PROJECT_ROOT/scripts/check-no-new-direct-git-metadata.sh\"" "lint,conventions" "Require Git metadata probes to use GitMetadataClient"
 add_check "ffmpeg-execution-boundary" "bun \"$PROJECT_ROOT/scripts/check-ffmpeg-execution-boundary.ts\"" "lint,conventions" "Require FFmpeg execution through FfmpegClient"
+add_check "sdkmanager-execution-boundary" "bun \"$PROJECT_ROOT/scripts/check-sdkmanager-execution-boundary.ts\"" "lint,conventions" "Require sdkmanager execution through SdkManagerClient"
 add_check "xcodebuild-boundary" "\"$PROJECT_ROOT/scripts/check-no-new-direct-xcodebuild.sh\"" "lint,ios" "Keep xcodebuild execution behind XcodebuildClient"
 add_check "daemon-launcher-boundary" "bash \"$PROJECT_ROOT/scripts/check-daemon-launcher-boundary.sh\"" "lint,conventions" "Require DaemonLauncher ownership for daemon process execution"
 add_check "ios-ctrl-proxy-process-boundary" "bun \"$PROJECT_ROOT/scripts/check-ios-ctrl-proxy-process-boundary.ts\"" "lint,conventions" "Keep CtrlProxy PID tooling behind its lifecycle client"

--- a/scripts/check-sdkmanager-execution-boundary.sh
+++ b/scripts/check-sdkmanager-execution-boundary.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+exec bun scripts/check-sdkmanager-execution-boundary.ts

--- a/scripts/check-sdkmanager-execution-boundary.ts
+++ b/scripts/check-sdkmanager-execution-boundary.ts
@@ -1,0 +1,306 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import ts from "typescript";
+
+// The single home of the sdkmanager execution-boundary guard (issue #4052, hardened in
+// #4339 and #4341). Both the fast-validate check and test/lint/sdkManagerExecutionBoundary.test.ts
+// import `directlyExecutesSdkManager` from here so there is exactly one detector.
+export const SOURCE_ROOT = "src";
+export const OWNER = "src/utils/android-cmdline-tools/SdkManagerClient.ts";
+// Keep production diagnostics out of this list unless they genuinely cannot use the client.
+export const EXCEPTIONS = new Map<string, string>();
+
+const LAUNCHER_NAMES = new Set([
+  "spawn",
+  "spawnSync",
+  "spawnCommand",
+  "exec",
+  "execSync",
+  "execFile",
+  "execFileSync",
+]);
+
+function functionLikeName(node: ts.Node): string | undefined {
+  if ((ts.isFunctionDeclaration(node) || ts.isMethodDeclaration(node)) &&
+    node.name && ts.isIdentifier(node.name)) {
+    return node.name.text;
+  }
+  if (ts.isFunctionExpression(node) || ts.isArrowFunction(node)) {
+    const parent = node.parent;
+    if (parent && ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)) {return parent.name.text;}
+    if (parent && ts.isPropertyAssignment(parent) && ts.isIdentifier(parent.name)) {return parent.name.text;}
+  }
+  return undefined;
+}
+
+function calleeName(expression: ts.Expression): string | undefined {
+  if (ts.isIdentifier(expression)) {return expression.text;}
+  if (ts.isPropertyAccessExpression(expression)) {return expression.name.text;}
+  return undefined;
+}
+
+function returnExpressions(fn: ts.FunctionLikeDeclaration): ts.Expression[] {
+  const body = fn.body;
+  if (!body) {return [];}
+  if (!ts.isBlock(body)) {return [body];}
+  const returns: ts.Expression[] = [];
+  const walk = (node: ts.Node): void => {
+    // Stop at a nested function boundary so an inner function's returns are not misattributed.
+    if (node !== fn && ts.isFunctionLike(node)) {return;}
+    if (ts.isReturnStatement(node) && node.expression) {returns.push(node.expression);}
+    ts.forEachChild(node, walk);
+  };
+  ts.forEachChild(body, walk);
+  return returns;
+}
+
+export function directlyExecutesSdkManager(source: string): boolean {
+  const lowerSource = source.toLowerCase();
+  if (!lowerSource.includes("sdk") || !lowerSource.includes("manager")) {return false;}
+
+  const sourceFile = ts.createSourceFile(
+    "sdkmanager-boundary.ts",
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const launcherAliases = new Set(LAUNCHER_NAMES);
+  const initializers = new Map<string, ts.Expression[]>();
+  const declarations: ts.VariableDeclaration[] = [];
+  // Interprocedural bookkeeping (issue #4341): functions keyed by bare name, the arguments seen
+  // at each call site, and the two monotonic taint sets derived from them below. Bindings are
+  // keyed by bare name, not by scope, and every value bound to a name is consulted — so a name
+  // bound anywhere in the file poisons every use of that name. That errs toward over-detection
+  // deliberately: a false CI failure is loud and fixable, a missed `spawn(sdkmanager)` is not.
+  const functionsByName = new Map<string, ts.FunctionLikeDeclaration[]>();
+  const returnsByName = new Map<string, ts.Expression[]>();
+  const callSites: { name: string; args: readonly ts.Expression[] }[] = [];
+  // Parameter names that receive an sdkmanager-ish argument at some call site, and function
+  // names whose return value carries sdkmanager. Both are filled by a fixpoint after collection.
+  const sdkManagerParams = new Set<string>();
+  const returnsSdkManager = new Set<string>();
+
+  const bindValue = (name: string, value: ts.Expression): void => {
+    initializers.set(name, [...(initializers.get(name) ?? []), value]);
+  };
+
+  const collect = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier) &&
+      ["child_process", "node:child_process"].includes(node.moduleSpecifier.text)) {
+      const bindings = node.importClause?.namedBindings;
+      if (bindings && ts.isNamedImports(bindings)) {
+        for (const element of bindings.elements) {
+          const importedName = element.propertyName?.text ?? element.name.text;
+          if (LAUNCHER_NAMES.has(importedName)) {launcherAliases.add(element.name.text);}
+        }
+      }
+    }
+    if (ts.isVariableDeclaration(node)) {
+      declarations.push(node);
+      if (ts.isIdentifier(node.name) && node.initializer) {
+        bindValue(node.name.text, node.initializer);
+      }
+      if (ts.isObjectBindingPattern(node.name)) {
+        for (const element of node.name.elements) {
+          const propertyName = element.propertyName && ts.isIdentifier(element.propertyName)
+            ? element.propertyName.text
+            : ts.isIdentifier(element.name) ? element.name.text : undefined;
+          if (propertyName && LAUNCHER_NAMES.has(propertyName) && ts.isIdentifier(element.name)) {
+            launcherAliases.add(element.name.text);
+          }
+          // `const { path } = await this.resolve()` carries the resolved binary through a
+          // destructured name; bind it to the initializer so return-taint can flow across it.
+          if (node.initializer && ts.isIdentifier(element.name)) {
+            bindValue(element.name.text, node.initializer);
+          }
+        }
+      }
+    }
+    // `let command: string; command = ...;` carries no declaration initializer, so the
+    // deferred assignment is the only place the value is visible.
+    if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isIdentifier(node.left)) {
+      bindValue(node.left.text, node.right);
+    }
+    if (ts.isFunctionLike(node)) {
+      const name = functionLikeName(node);
+      if (name) {
+        functionsByName.set(name, [...(functionsByName.get(name) ?? []), node]);
+        returnsByName.set(name, [...(returnsByName.get(name) ?? []), ...returnExpressions(node)]);
+      }
+    }
+    if (ts.isCallExpression(node)) {
+      const name = calleeName(node.expression);
+      if (name) {callSites.push({ name, args: node.arguments });}
+    }
+    ts.forEachChild(node, collect);
+  };
+  collect(sourceFile);
+
+  // `promisify(execFile)` is the dominant launcher idiom in src/, so both the stored alias
+  // (`const run = promisify(exec); run(...)`) and the immediate call (`promisify(exec)(...)`)
+  // have to read as launcher references.
+  const isPromisifiedLauncher = (node: ts.Expression): boolean => {
+    if (!ts.isCallExpression(node) || node.arguments.length !== 1) {return false;}
+    const callee = node.expression;
+    const name = ts.isIdentifier(callee) ? callee.text
+      : ts.isPropertyAccessExpression(callee) ? callee.name.text : undefined;
+    return name === "promisify" && isLauncherReference(node.arguments[0]);
+  };
+  const isLauncherReference = (node: ts.Expression): boolean => {
+    if (ts.isIdentifier(node)) {return launcherAliases.has(node.text);}
+    if (ts.isCallExpression(node)) {return isPromisifiedLauncher(node);}
+    return ts.isPropertyAccessExpression(node) && LAUNCHER_NAMES.has(node.name.text);
+  };
+  let aliasesChanged = true;
+  while (aliasesChanged) {
+    aliasesChanged = false;
+    for (const declaration of declarations) {
+      if (!ts.isIdentifier(declaration.name) || !declaration.initializer ||
+        !isLauncherReference(declaration.initializer) || launcherAliases.has(declaration.name.text)) {
+        continue;
+      }
+      launcherAliases.add(declaration.name.text);
+      aliasesChanged = true;
+    }
+  }
+
+  const staticText = (node: ts.Expression): string | undefined => {
+    if (ts.isStringLiteralLike(node)) {return node.text;}
+    if (ts.isParenthesizedExpression(node)) {return staticText(node.expression);}
+    // Join the static chunks of a template with a separator no identifier can contain, so
+    // `sdkmanager` is only matched when it sits wholly inside one chunk.
+    if (ts.isTemplateExpression(node)) {
+      return [node.head.text, ...node.templateSpans.map(span => span.literal.text)].join("\u0000");
+    }
+    if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+      const left = staticText(node.left);
+      const right = staticText(node.right);
+      return left === undefined || right === undefined ? undefined : left + right;
+    }
+    return undefined;
+  };
+  // Consults the two interprocedural taint sets, which the fixpoint below grows monotonically.
+  // Every extra branch is an O(1) set membership test or a guarded walk of already-collected
+  // bindings — never a re-descent into a function body — so this stays bounded on large files.
+  const mentionsSdkManager = (node: ts.Node, seen = new Set<string>()): boolean => {
+    if (ts.isExpression(node) && staticText(node)?.toLowerCase().includes("sdkmanager")) {
+      return true;
+    }
+    // `exec(`${sdkmanagerPath} --version`)` hides the tool name in the identifier, not in any
+    // static chunk of the template.
+    if (ts.isIdentifier(node) && node.text.toLowerCase().includes("sdkmanager")) {return true;}
+    // A parameter carrying an sdkmanager-ish argument from some caller (issue #4341).
+    if (ts.isIdentifier(node) && sdkManagerParams.has(node.text)) {return true;}
+    // A call to a function whose return value carries sdkmanager (issue #4341).
+    if (ts.isCallExpression(node)) {
+      const name = calleeName(node.expression);
+      if (name && returnsSdkManager.has(name)) {return true;}
+    }
+    if (ts.isIdentifier(node) && !seen.has(node.text)) {
+      const boundValues = initializers.get(node.text) ?? [];
+      if (boundValues.length > 0) {
+        const nextSeen = new Set(seen);
+        nextSeen.add(node.text);
+        if (boundValues.some(value => mentionsSdkManager(value, nextSeen))) {return true;}
+      }
+    }
+    let found = false;
+    ts.forEachChild(node, child => {
+      if (!found && mentionsSdkManager(child, seen)) {found = true;}
+    });
+    return found;
+  };
+
+  // Fixpoint over the two taint sets. Both only grow and are bounded by the finite sets of
+  // parameter and function names in the file, so this terminates; each round is a linear pass
+  // over the call sites and function returns.
+  let taintChanged = true;
+  while (taintChanged) {
+    taintChanged = false;
+    for (const { name, args } of callSites) {
+      const targets = functionsByName.get(name);
+      if (!targets) {continue;}
+      for (const target of targets) {
+        target.parameters.forEach((parameter, index) => {
+          const argument = args[index];
+          if (argument && ts.isIdentifier(parameter.name) &&
+            !sdkManagerParams.has(parameter.name.text) && mentionsSdkManager(argument)) {
+            sdkManagerParams.add(parameter.name.text);
+            taintChanged = true;
+          }
+        });
+      }
+    }
+    for (const [name, returns] of returnsByName) {
+      if (!returnsSdkManager.has(name) && returns.some(expression => mentionsSdkManager(expression))) {
+        returnsSdkManager.add(name);
+        taintChanged = true;
+      }
+    }
+  }
+
+  // `Bun.$`sdkmanager --list`` and the bare `$`...`` shell tag are never CallExpressions with a
+  // launcher callee, so isLauncherReference never sees them (issue #4341).
+  const isShellTag = (tag: ts.Expression): boolean =>
+    (ts.isIdentifier(tag) && tag.text === "$") ||
+    (ts.isPropertyAccessExpression(tag) && tag.name.text === "$");
+
+  let directExecution = false;
+  const inspect = (node: ts.Node): void => {
+    if (directExecution) {return;}
+    if (ts.isCallExpression(node) && isLauncherReference(node.expression) &&
+      node.arguments.some(argument => mentionsSdkManager(argument))) {
+      directExecution = true;
+      return;
+    }
+    if (ts.isTaggedTemplateExpression(node) && isShellTag(node.tag) &&
+      mentionsSdkManager(node.template)) {
+      directExecution = true;
+      return;
+    }
+    ts.forEachChild(node, inspect);
+  };
+  inspect(sourceFile);
+  return directExecution;
+}
+
+export function sourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {return sourceFiles(path);}
+    return entry.name.endsWith(".ts") ? [path] : [];
+  });
+}
+
+/**
+ * Scan `<root>/src` for files that execute sdkmanager outside the owning client. Returns one
+ * message per offender; an empty array means the boundary holds.
+ */
+export function findOffenders(root: string): string[] {
+  return sourceFiles(join(root, SOURCE_ROOT)).flatMap(file => {
+    const repoPath = relative(root, file);
+    if (repoPath === OWNER || EXCEPTIONS.has(repoPath)) {return [];}
+    return directlyExecutesSdkManager(readFileSync(file, "utf8"))
+      ? [`${repoPath} directly executes sdkmanager; route it through ${OWNER} instead.`]
+      : [];
+  });
+}
+
+if (import.meta.main) {
+  const root = process.cwd();
+  const files = sourceFiles(join(root, SOURCE_ROOT));
+  // A silently-empty scan yields zero offenders and passes green while checking nothing.
+  if (files.length < 100) {
+    console.error(`error: sdkmanager-execution-boundary scanned only ${files.length} files under ${SOURCE_ROOT}; expected the full source tree.`);
+    process.exit(1);
+  }
+  const offenders = findOffenders(root);
+  if (offenders.length > 0) {
+    console.error(`error: sdkmanager execution must use ${OWNER}:`);
+    for (const offender of offenders) {console.error(offender);}
+    process.exit(1);
+  }
+  console.log("sdkmanager-execution-boundary: no direct production sdkmanager invocations.");
+}

--- a/scripts/check-sdkmanager-execution-boundary.ts
+++ b/scripts/check-sdkmanager-execution-boundary.ts
@@ -289,7 +289,9 @@ export function sourceFiles(directory: string): string[] {
  */
 export async function findOffenders(root: string): Promise<string[]> {
   const sources = await Promise.all(sourceFiles(join(root, SOURCE_ROOT)).map(async file => ({
-    repoPath: relative(root, file),
+    // `relative` yields OS separators (backslashes on Windows), but OWNER/EXCEPTIONS are keyed
+    // with forward slashes — normalize so the owner exclusion matches and messages are portable.
+    repoPath: relative(root, file).replace(/\\/g, "/"),
     source: await readFile(file, "utf8"),
   })));
   return sources.flatMap(({ repoPath, source }) =>

--- a/scripts/check-sdkmanager-execution-boundary.ts
+++ b/scripts/check-sdkmanager-execution-boundary.ts
@@ -1,4 +1,5 @@
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { join, relative } from "node:path";
 import ts from "typescript";
 
@@ -76,10 +77,15 @@ export function directlyExecutesSdkManager(source: string): boolean {
   const functionsByName = new Map<string, ts.FunctionLikeDeclaration[]>();
   const returnsByName = new Map<string, ts.Expression[]>();
   const callSites: { name: string; args: readonly ts.Expression[] }[] = [];
-  // Parameter names that receive an sdkmanager-ish argument at some call site, and function
-  // names whose return value carries sdkmanager. Both are filled by a fixpoint after collection.
+  // Three monotonic taint sets, all filled by the fixpoint after collection: parameter names
+  // that receive an sdkmanager-ish argument at some call site, function names whose return value
+  // carries sdkmanager, and variable names whose (transitive) initializer carries sdkmanager.
+  // `taintedNames` memoizes what a `seen`-guarded recursive walk of `initializers` would compute,
+  // but as an O(1) membership test — without it, a chain of repeated-reference bindings
+  // (`a1 = a0 + a0; a2 = a1 + a1; ...`) makes the walk re-descend exponentially.
   const sdkManagerParams = new Set<string>();
   const returnsSdkManager = new Set<string>();
+  const taintedNames = new Set<string>();
 
   const bindValue = (name: string, value: ts.Expression): void => {
     initializers.set(name, [...(initializers.get(name) ?? []), value]);
@@ -181,10 +187,11 @@ export function directlyExecutesSdkManager(source: string): boolean {
     }
     return undefined;
   };
-  // Consults the two interprocedural taint sets, which the fixpoint below grows monotonically.
-  // Every extra branch is an O(1) set membership test or a guarded walk of already-collected
-  // bindings — never a re-descent into a function body — so this stays bounded on large files.
-  const mentionsSdkManager = (node: ts.Node, seen = new Set<string>()): boolean => {
+  // Consults the three taint sets, which the fixpoint below grows monotonically. Every branch is
+  // an O(1) set membership test; the only recursion is a single walk of the node's own AST
+  // subtree (a tree, so it terminates without a visited set). Initializer chains are resolved by
+  // `taintedNames`, not by re-descending into bindings, so this is linear in the node size.
+  const mentionsSdkManager = (node: ts.Node): boolean => {
     if (ts.isExpression(node) && staticText(node)?.toLowerCase().includes("sdkmanager")) {
       return true;
     }
@@ -193,32 +200,33 @@ export function directlyExecutesSdkManager(source: string): boolean {
     if (ts.isIdentifier(node) && node.text.toLowerCase().includes("sdkmanager")) {return true;}
     // A parameter carrying an sdkmanager-ish argument from some caller (issue #4341).
     if (ts.isIdentifier(node) && sdkManagerParams.has(node.text)) {return true;}
+    // A variable whose initializer (transitively) carries sdkmanager — the memoized replacement
+    // for a recursive walk of `initializers`.
+    if (ts.isIdentifier(node) && taintedNames.has(node.text)) {return true;}
     // A call to a function whose return value carries sdkmanager (issue #4341).
     if (ts.isCallExpression(node)) {
       const name = calleeName(node.expression);
       if (name && returnsSdkManager.has(name)) {return true;}
     }
-    if (ts.isIdentifier(node) && !seen.has(node.text)) {
-      const boundValues = initializers.get(node.text) ?? [];
-      if (boundValues.length > 0) {
-        const nextSeen = new Set(seen);
-        nextSeen.add(node.text);
-        if (boundValues.some(value => mentionsSdkManager(value, nextSeen))) {return true;}
-      }
-    }
     let found = false;
     ts.forEachChild(node, child => {
-      if (!found && mentionsSdkManager(child, seen)) {found = true;}
+      if (!found && mentionsSdkManager(child)) {found = true;}
     });
     return found;
   };
 
-  // Fixpoint over the two taint sets. Both only grow and are bounded by the finite sets of
-  // parameter and function names in the file, so this terminates; each round is a linear pass
-  // over the call sites and function returns.
+  // Fixpoint over the three taint sets. All only grow and are bounded by the finite sets of
+  // parameter, function, and variable names in the file, so this terminates; each round is a
+  // linear pass over the bindings, call sites, and function returns.
   let taintChanged = true;
   while (taintChanged) {
     taintChanged = false;
+    for (const [name, boundValues] of initializers) {
+      if (!taintedNames.has(name) && boundValues.some(value => mentionsSdkManager(value))) {
+        taintedNames.add(name);
+        taintChanged = true;
+      }
+    }
     for (const { name, args } of callSites) {
       const targets = functionsByName.get(name);
       if (!targets) {continue;}
@@ -276,16 +284,18 @@ export function sourceFiles(directory: string): string[] {
 
 /**
  * Scan `<root>/src` for files that execute sdkmanager outside the owning client. Returns one
- * message per offender; an empty array means the boundary holds.
+ * message per offender; an empty array means the boundary holds. Files are read in parallel so
+ * the whole-tree scan stays fast enough for a bun test running under coverage instrumentation.
  */
-export function findOffenders(root: string): string[] {
-  return sourceFiles(join(root, SOURCE_ROOT)).flatMap(file => {
-    const repoPath = relative(root, file);
-    if (repoPath === OWNER || EXCEPTIONS.has(repoPath)) {return [];}
-    return directlyExecutesSdkManager(readFileSync(file, "utf8"))
+export async function findOffenders(root: string): Promise<string[]> {
+  const sources = await Promise.all(sourceFiles(join(root, SOURCE_ROOT)).map(async file => ({
+    repoPath: relative(root, file),
+    source: await readFile(file, "utf8"),
+  })));
+  return sources.flatMap(({ repoPath, source }) =>
+    repoPath !== OWNER && !EXCEPTIONS.has(repoPath) && directlyExecutesSdkManager(source)
       ? [`${repoPath} directly executes sdkmanager; route it through ${OWNER} instead.`]
-      : [];
-  });
+      : []);
 }
 
 if (import.meta.main) {
@@ -296,7 +306,7 @@ if (import.meta.main) {
     console.error(`error: sdkmanager-execution-boundary scanned only ${files.length} files under ${SOURCE_ROOT}; expected the full source tree.`);
     process.exit(1);
   }
-  const offenders = findOffenders(root);
+  const offenders = await findOffenders(root);
   if (offenders.length > 0) {
     console.error(`error: sdkmanager execution must use ${OWNER}:`);
     for (const offender of offenders) {console.error(offender);}

--- a/test/bats/check-sdkmanager-execution-boundary.bats
+++ b/test/bats/check-sdkmanager-execution-boundary.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+
+SCRIPT="scripts/check-sdkmanager-execution-boundary.sh"
+FIXTURE="src/utils/SdkManagerBoundaryFixture.ts"
+
+teardown() {
+  rm -f "$FIXTURE"
+}
+
+@test "allows SdkManagerClient to own sdkmanager execution" {
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no direct production sdkmanager invocations"* ]]
+}
+
+@test "rejects a direct sdkmanager spawn outside the owner" {
+  printf '%s\n' 'import { spawn } from "node:child_process"; spawn("sdkmanager", ["--list"]);' > "$FIXTURE"
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"SdkManagerBoundaryFixture.ts"* ]]
+}
+
+@test "rejects an aliased sdkmanager binary passed to a child-process launcher" {
+  printf '%s\n' 'import { execFile } from "node:child_process"; const binary = "sdkmanager"; execFile(binary, ["--list"]);' > "$FIXTURE"
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"SdkManagerBoundaryFixture.ts"* ]]
+}
+
+@test "rejects sdkmanager reached across functions via a parameter (issue #4341)" {
+  printf '%s\n' 'import { execFile } from "node:child_process"; function run(bin) { execFile(bin, args); } run("sdkmanager");' > "$FIXTURE"
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"SdkManagerBoundaryFixture.ts"* ]]
+}
+
+@test "rejects a production-shaped resolve-then-spawn client (issue #4341)" {
+  cat > "$FIXTURE" <<'EOF'
+import { spawn } from "node:child_process";
+class Tool {
+  private resolveExecutable(location) { return join(location.path, "bin", "sdkmanager"); }
+  private execute(path, args) { return spawn(path, args, {}); }
+  async run(args) { const path = this.resolveExecutable(loc); return this.execute(path, args); }
+}
+EOF
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"SdkManagerBoundaryFixture.ts"* ]]
+}
+
+@test "rejects a Bun.\$ tagged-template sdkmanager execution (issue #4341)" {
+  printf '%s\n' 'await Bun.$`sdkmanager --list`;' > "$FIXTURE"
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"SdkManagerBoundaryFixture.ts"* ]]
+}
+
+@test "allows a different tool resolved through the same shape" {
+  cat > "$FIXTURE" <<'EOF'
+import { spawn } from "node:child_process";
+class Tool {
+  private resolveExecutable(location) { return join(location.path, "bin", "avdmanager"); }
+  private execute(path, args) { return spawn(path, args, {}); }
+  async run(args) { const path = this.resolveExecutable(loc); return this.execute(path, args); }
+}
+EOF
+
+  run bash "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no direct production sdkmanager invocations"* ]]
+}

--- a/test/lint/sdkManagerExecutionBoundary.test.ts
+++ b/test/lint/sdkManagerExecutionBoundary.test.ts
@@ -11,12 +11,28 @@ import {
 const ROOT = join(import.meta.dir, "..", "..");
 
 describe("sdkmanager execution boundary (issue #4052)", () => {
-  test("only SdkManagerClient directly executes sdkmanager", () => {
+  // Whole-tree scan: reads ~700 files, so give it far more than Bun's 5s default — under
+  // `--coverage` on a slow CI runner the default timeout trips even though the work is small.
+  test("only SdkManagerClient directly executes sdkmanager", async () => {
     const files = sourceFiles(join(ROOT, "src"));
     // A silently-empty scan yields zero offenders and passes green while checking nothing.
     expect(files.length).toBeGreaterThan(100);
-    const offenders = findOffenders(ROOT);
+    const offenders = await findOffenders(ROOT);
     expect(offenders, offenders.join("\n")).toEqual([]);
+  }, 30_000);
+
+  test("stays bounded on repeated-reference binding chains (no exponential blow-up)", () => {
+    // A chain where each binding references the previous one twice is the pathological input for
+    // a recursive initializer walk: resolving `a40` re-descends 2^40 times. The chain terminates
+    // in a launcher so the walk is actually forced, and `a0` is sdkmanager so the true verdict
+    // still exercises the deep path. The memoized taint fixpoint makes it linear; without it this
+    // hangs (Lens A measured a clean 2^N doubling: n=22 already took ~6s).
+    const lines = ['const a0 = "sdkmanager";'];
+    for (let i = 1; i <= 40; i++) {lines.push(`const a${i} = a${i - 1} + a${i - 1};`);}
+    lines.push("execFile(a40, []);");
+    const start = Bun.nanoseconds();
+    expect(directlyExecutesSdkManager(lines.join("\n"))).toBe(true);
+    expect((Bun.nanoseconds() - start) / 1e6).toBeLessThan(100);
   });
 
   test("detects resolved paths passed to supported launch APIs", () => {

--- a/test/lint/sdkManagerExecutionBoundary.test.ts
+++ b/test/lint/sdkManagerExecutionBoundary.test.ts
@@ -1,185 +1,21 @@
 import { describe, expect, test } from "bun:test";
-import { readdirSync, readFileSync } from "node:fs";
-import { join, relative } from "node:path";
-import ts from "typescript";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  directlyExecutesSdkManager,
+  findOffenders,
+  OWNER as CLIENT,
+  sourceFiles,
+} from "../../scripts/check-sdkmanager-execution-boundary";
 
 const ROOT = join(import.meta.dir, "..", "..");
-const CLIENT = "src/utils/android-cmdline-tools/SdkManagerClient.ts";
-const LAUNCHER_NAMES = new Set([
-  "spawn",
-  "spawnSync",
-  "spawnCommand",
-  "exec",
-  "execSync",
-  "execFile",
-  "execFileSync",
-]);
-
-function directlyExecutesSdkManager(source: string): boolean {
-  const lowerSource = source.toLowerCase();
-  if (!lowerSource.includes("sdk") || !lowerSource.includes("manager")) {return false;}
-
-  const sourceFile = ts.createSourceFile(
-    "sdkmanager-boundary.ts",
-    source,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TS,
-  );
-  const launcherAliases = new Set(LAUNCHER_NAMES);
-  const initializers = new Map<string, ts.Expression[]>();
-  const declarations: ts.VariableDeclaration[] = [];
-  // Bindings are keyed by bare name, not by scope, and every value bound to a name is
-  // consulted — so a name bound anywhere in the file poisons every use of that name. That
-  // errs toward over-detection deliberately: a false CI failure is loud and fixable, a missed
-  // `spawn(sdkmanager)` is not.
-  const bindValue = (name: string, value: ts.Expression): void => {
-    initializers.set(name, [...(initializers.get(name) ?? []), value]);
-  };
-
-  const collect = (node: ts.Node): void => {
-    if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier) &&
-      ["child_process", "node:child_process"].includes(node.moduleSpecifier.text)) {
-      const bindings = node.importClause?.namedBindings;
-      if (bindings && ts.isNamedImports(bindings)) {
-        for (const element of bindings.elements) {
-          const importedName = element.propertyName?.text ?? element.name.text;
-          if (LAUNCHER_NAMES.has(importedName)) {launcherAliases.add(element.name.text);}
-        }
-      }
-    }
-    if (ts.isVariableDeclaration(node)) {
-      declarations.push(node);
-      if (ts.isIdentifier(node.name) && node.initializer) {
-        bindValue(node.name.text, node.initializer);
-      }
-      if (ts.isObjectBindingPattern(node.name)) {
-        for (const element of node.name.elements) {
-          const propertyName = element.propertyName && ts.isIdentifier(element.propertyName)
-            ? element.propertyName.text
-            : ts.isIdentifier(element.name) ? element.name.text : undefined;
-          if (propertyName && LAUNCHER_NAMES.has(propertyName) && ts.isIdentifier(element.name)) {
-            launcherAliases.add(element.name.text);
-          }
-        }
-      }
-    }
-    // `let command: string; command = ...;` carries no declaration initializer, so the
-    // deferred assignment is the only place the value is visible.
-    if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
-      ts.isIdentifier(node.left)) {
-      bindValue(node.left.text, node.right);
-    }
-    ts.forEachChild(node, collect);
-  };
-  collect(sourceFile);
-
-  // `promisify(execFile)` is the dominant launcher idiom in src/, so both the stored alias
-  // (`const run = promisify(exec); run(...)`) and the immediate call (`promisify(exec)(...)`)
-  // have to read as launcher references.
-  const isPromisifiedLauncher = (node: ts.Expression): boolean => {
-    if (!ts.isCallExpression(node) || node.arguments.length !== 1) {return false;}
-    const callee = node.expression;
-    const calleeName = ts.isIdentifier(callee) ? callee.text
-      : ts.isPropertyAccessExpression(callee) ? callee.name.text : undefined;
-    return calleeName === "promisify" && isLauncherReference(node.arguments[0]);
-  };
-  const isLauncherReference = (node: ts.Expression): boolean => {
-    if (ts.isIdentifier(node)) {return launcherAliases.has(node.text);}
-    if (ts.isCallExpression(node)) {return isPromisifiedLauncher(node);}
-    return ts.isPropertyAccessExpression(node) && LAUNCHER_NAMES.has(node.name.text);
-  };
-  let aliasesChanged = true;
-  while (aliasesChanged) {
-    aliasesChanged = false;
-    for (const declaration of declarations) {
-      if (!ts.isIdentifier(declaration.name) || !declaration.initializer ||
-        !isLauncherReference(declaration.initializer) || launcherAliases.has(declaration.name.text)) {
-        continue;
-      }
-      launcherAliases.add(declaration.name.text);
-      aliasesChanged = true;
-    }
-  }
-
-  const staticText = (node: ts.Expression): string | undefined => {
-    if (ts.isStringLiteralLike(node)) {return node.text;}
-    if (ts.isParenthesizedExpression(node)) {return staticText(node.expression);}
-    // Join the static chunks of a template with a separator no identifier can contain, so
-    // `sdkmanager` is only matched when it sits wholly inside one chunk.
-    if (ts.isTemplateExpression(node)) {
-      return [node.head.text, ...node.templateSpans.map(span => span.literal.text)].join("\u0000");
-    }
-    if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.PlusToken) {
-      const left = staticText(node.left);
-      const right = staticText(node.right);
-      return left === undefined || right === undefined ? undefined : left + right;
-    }
-    return undefined;
-  };
-  const mentionsSdkManager = (node: ts.Node, seen = new Set<string>()): boolean => {
-    if (ts.isExpression(node) && staticText(node)?.toLowerCase().includes("sdkmanager")) {
-      return true;
-    }
-    // `exec(`${sdkmanagerPath} --version`)` hides the tool name in the identifier, not in any
-    // static chunk of the template.
-    if (ts.isIdentifier(node) && node.text.toLowerCase().includes("sdkmanager")) {return true;}
-    if (ts.isIdentifier(node) && !seen.has(node.text)) {
-      const boundValues = initializers.get(node.text) ?? [];
-      if (boundValues.length > 0) {
-        const nextSeen = new Set(seen);
-        nextSeen.add(node.text);
-        if (boundValues.some(value => mentionsSdkManager(value, nextSeen))) {return true;}
-      }
-    }
-    let found = false;
-    ts.forEachChild(node, child => {
-      if (!found && mentionsSdkManager(child, seen)) {found = true;}
-    });
-    return found;
-  };
-
-  let directExecution = false;
-  const inspect = (node: ts.Node): void => {
-    if (directExecution) {return;}
-    if (ts.isCallExpression(node) && isLauncherReference(node.expression) &&
-      node.arguments.some(argument => mentionsSdkManager(argument))) {
-      directExecution = true;
-      return;
-    }
-    ts.forEachChild(node, inspect);
-  };
-  inspect(sourceFile);
-  return directExecution;
-}
-
-function sourceFiles(directory: string): string[] {
-  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
-    const path = join(directory, entry.name);
-    if (entry.isDirectory()) {return sourceFiles(path);}
-    return entry.name.endsWith(".ts") ? [path] : [];
-  });
-}
 
 describe("sdkmanager execution boundary (issue #4052)", () => {
-  test("only SdkManagerClient directly executes sdkmanager", async () => {
-    const exceptions = new Map<string, string>([
-      // Keep production diagnostics out of this list unless they cannot use the client.
-    ]);
+  test("only SdkManagerClient directly executes sdkmanager", () => {
     const files = sourceFiles(join(ROOT, "src"));
     // A silently-empty scan yields zero offenders and passes green while checking nothing.
     expect(files.length).toBeGreaterThan(100);
-    const sources = await Promise.all(files.map(async file => ({
-      file,
-      source: await Bun.file(file).text(),
-    })));
-    const offenders = sources.flatMap(({ file, source }) => {
-      const repoPath = relative(ROOT, file);
-      if (repoPath === CLIENT || exceptions.has(repoPath)) {return [];}
-      return directlyExecutesSdkManager(source)
-        ? [`${repoPath} directly executes sdkmanager; route it through ${CLIENT} instead.`]
-        : [];
-    });
+    const offenders = findOffenders(ROOT);
     expect(offenders, offenders.join("\n")).toEqual([]);
   });
 
@@ -235,6 +71,51 @@ describe("sdkmanager execution boundary (issue #4052)", () => {
     expect(directlyExecutesSdkManager(
       "const readFileAsync = promisify(readFile); await readFileAsync(sdkmanagerPath);",
     )).toBe(false);
+  });
+
+  test("detects sdkmanager reached across functions via a parameter (issue #4341)", () => {
+    // The launcher call site names only the parameter `bin`; the tool name lives at the
+    // caller. A purely call-site-local reading (the pre-#4341 behaviour) misses this.
+    expect(directlyExecutesSdkManager(
+      'function run(bin) { execFile(bin, args); }\nrun("sdkmanager");',
+    )).toBe(true);
+    // A different tool passed the same way must not trip the guard.
+    expect(directlyExecutesSdkManager(
+      'function run(bin) { execFile(bin, args); }\nrun("avdmanager");',
+    )).toBe(false);
+    // Two hops: caller -> intermediate -> launcher.
+    expect(directlyExecutesSdkManager(
+      "function launch(cmd) { execFile(cmd, args); }\nfunction run(bin) { launch(bin); }\nrun(\"sdkmanager\");",
+    )).toBe(true);
+  });
+
+  test("detects production-shaped resolve-in-one-method / spawn-in-another (issue #4341)", () => {
+    // Mirrors SdkManagerClient's structure: one method resolves the binary path to a
+    // static "sdkmanager", another method spawns the resolved path. No sdkmanager text
+    // sits at the launcher call site, so only interprocedural reasoning catches it.
+    const prodShaped = [
+      "class Tool {",
+      "  private resolveExecutable(location) { return join(location.path, \"bin\", \"sdkmanager\"); }",
+      "  private execute(path, args) { return this.deps.spawn(path, args, {}); }",
+      "  async run(args) { const path = this.resolveExecutable(loc); return this.execute(path, args); }",
+      "}",
+    ].join("\n");
+    expect(directlyExecutesSdkManager(prodShaped)).toBe(true);
+    // Same structure resolving a different tool must stay clean.
+    const prodShapedOther = prodShaped.replace("sdkmanager", "avdmanager");
+    expect(directlyExecutesSdkManager(prodShapedOther)).toBe(false);
+  });
+
+  test("fires on the real SdkManagerClient, a true positive on production code (issue #4341)", () => {
+    const client = readFileSync(join(ROOT, CLIENT), "utf8");
+    expect(directlyExecutesSdkManager(client)).toBe(true);
+  });
+
+  test("detects Bun.$ tagged-template execution (issue #4341)", () => {
+    expect(directlyExecutesSdkManager("await Bun.$`sdkmanager --list`;")).toBe(true);
+    expect(directlyExecutesSdkManager("await $`sdkmanager --list`;")).toBe(true);
+    expect(directlyExecutesSdkManager("await Bun.$`${dir}/bin/sdkmanager --list`;")).toBe(true);
+    expect(directlyExecutesSdkManager("await Bun.$`avdmanager list`;")).toBe(false);
   });
 
   test("allows diagnostic text that does not execute sdkmanager", () => {


### PR DESCRIPTION
## Summary

Closes the three remaining gaps in the sdkmanager execution-boundary guard, a follow-up to [#4339](https://github.com/kaeawc/auto-mobile/pull/4339) (which addressed [#4338](https://github.com/kaeawc/auto-mobile/issues/4338)). All three were pre-existing weaknesses called out in [#4341](https://github.com/kaeawc/auto-mobile/issues/4341).

## Linked Issue

Closes #4341

## Changes

**1. Interprocedural reasoning (the headline gap).** The detector previously flagged a launcher only when the tool name resolved *at the call-site argument*, so it returned `false` on the real `SdkManagerClient` — which resolves the binary in `resolveExecutable` and spawns it in a different method via `invocation.command`. It now runs a **bounded, memoized fixpoint** over two monotonic taint sets:
- call-site argument → callee parameter (`function run(bin){ execFile(bin) } run("sdkmanager")`), and
- function return value → caller (`resolveExecutable` returns the `sdkmanager` literal, which flows through `resolve` → `run` → `execute` → `windowsBatchInvocation` → `spawn`).

The taint stays strictly **value-flow keyed on the `sdkmanager` literal reaching a launcher**, so it fires on the real `SdkManagerClient` and on any file copying its resolve-in-one-method / spawn-in-another shape, while `detection.ts` (passes an unbound `for…of` loop variable to `exec`) and `AvdManagerClient` (resolves *avdmanager*) stay clean. A naive non-memoized version blows up on real source; the fixpoint is bounded by the finite set of parameter/function names and consults only O(1) set lookups.

**2. `Bun.$` tagged templates.** `` Bun.$`sdkmanager --list` `` and the bare `` $`…` `` shell tag are now detected, matching the already-covered `Bun.spawn`.

**3. Fast-validate registration.** The detector moves into a standalone `scripts/check-sdkmanager-execution-boundary.ts` (single source of truth, imported by the bun test), gains a `.sh` wrapper and a bats suite, and is registered in `scripts/all_fast_validate_checks.sh` alongside its ten sibling boundary guards — so it is now visible to the local fast-validate path, not only `turbo run test`.

The `if (repoPath === CLIENT) return []` exclusion in the src-wide scan — dead code while the detector returned `false` on the client — is now **live and necessary**, since the strengthened detector fires on `SdkManagerClient` itself.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes; the new `sdkmanager-execution-boundary` check runs green
- [x] `bun run typecheck` reports no new errors (baseline gate: 211 known)
- [x] `bun test` — full suite: **9094 pass, 0 fail**; boundary test 12/12; new bats 7/7
- [x] `shellcheck` clean on the new/touched shell scripts; `eslint` clean (no new suppressions)
- [x] New generic code reuses the standard library (`typescript` AST) and an existing repo pattern (mirrors `check-ffmpeg-execution-boundary.ts`); no new dependency

## Acceptance criteria (from the issue)

| Gap | Status | Pinned by |
| --- | --- | --- |
| 1 — interprocedural true positive on production-shaped code | ✅ | unit: real `SdkManagerClient.ts` → true, cross-fn param, production-shaped fixture; src-wide scan stays green |
| 2 — `Bun.$` coverage | ✅ | unit + bats: `` Bun.$`sdkmanager` `` / `` $`sdkmanager` `` → true, non-sdkmanager → false |
| 3 — fast-validate registration | ✅ | registered in `all_fast_validate_checks.sh`; bats owner-passes / fixture-fails |
