### PR TITLE
perf(webrtc): measure and cap iOS native-resolution encoder load and egress bitrate

### DIFF
--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -42,6 +42,36 @@ const IOS_KEYFRAME_INTERVAL_SECONDS = 2;
 const H264_MACROBLOCK_SIZE = 16;
 /** Smallest dimension ffmpeg can encode as 4:2:0 chroma-subsampled video. */
 const MIN_ENCODER_DIMENSION = 2;
+/**
+ * Bits budgeted per encoded pixel per frame for the default WebRTC bitrate.
+ *
+ * Chosen from the two measured hosted-lane operating points (#4349): after
+ * #4346 stopped upscaling toward 1920x1080, a Retina developer host encodes the
+ * Simulator window at its native ~910x1940 backing store, so an uncapped
+ * VideoToolbox default scales egress with resolution x rate with no ceiling. A
+ * 0.1 bpp budget bounds that worst case (910x1940 @ 15 fps -> ~2.6 Mbps) while
+ * a headless CI runner's much smaller frame (286x658 @ 15 fps -> ~0.28 Mbps)
+ * stays far below it — so the same budget caps the large case without inflating
+ * the small one. 0.1 bpp is a conventional target for baseline-profile screen
+ * content, whose largely-static frames leave headroom for scroll/animation
+ * transients within the 2s GOP. Override per-worker with
+ * `AUTOMOBILE_WEBRTC_BITRATE_KBPS` when a specific ceiling is required.
+ */
+export const IOS_WEBRTC_DEFAULT_BITS_PER_PIXEL = 0.1;
+
+/**
+ * Resolution-aware default encoder bitrate (bps) for an iOS WebRTC stream that
+ * did not configure one, derived from the *encoded* size (after any downscale)
+ * and the declared frame rate. Scales the target with the encoder's real
+ * workload rather than pinning a fixed ceiling, and always returns a positive
+ * finite integer — a non-finite input (which real capture never produces) falls
+ * back to the 1 bps floor rather than passing `NaN` to ffmpeg. See
+ * {@link IOS_WEBRTC_DEFAULT_BITS_PER_PIXEL}.
+ */
+export function defaultIosBitrateBps(size: EncoderSize, fps: number): number {
+  const budget = Math.round(size.width * size.height * fps * IOS_WEBRTC_DEFAULT_BITS_PER_PIXEL);
+  return Number.isFinite(budget) ? Math.max(1, budget) : 1;
+}
 
 export interface IosFrameCaptureHelper {
   start(): void;
@@ -511,9 +541,18 @@ export class IosH264Source implements H264CaptureSource {
       "-forced-idr",
       "1"
     );
-    if (this.options.bitrateBps && this.options.bitrateBps > 0) {
-      args.push("-b:v", String(Math.round(this.options.bitrateBps)));
-    }
+    // Always emit an explicit target bitrate. Left unset, VideoToolbox picks a
+    // default that scales with resolution x rate with no ceiling — and since
+    // #4346 stopped upscaling toward 1920x1080, a Retina host now encodes the
+    // native backing store, so egress can climb several-fold (#4349). Honor an
+    // operator override; otherwise budget from the *encoded* size (post any
+    // downscale) and the declared rate.
+    const encodedSize = scale ?? size;
+    const bitrateBps =
+      this.options.bitrateBps && this.options.bitrateBps > 0
+        ? this.options.bitrateBps
+        : defaultIosBitrateBps(encodedSize, this.fps);
+    args.push("-b:v", String(Math.round(bitrateBps)));
     args.push("-f", "h264", "pipe:1");
     return args;
   }

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -11,7 +11,9 @@ import {
   IOS_SCREEN_CAPTURE_HELPER_ENV_ALIAS,
   IOS_WEBRTC_FFMPEG_ENV,
   IOS_WEBRTC_FFMPEG_ENV_ALIAS,
+  IOS_WEBRTC_DEFAULT_BITS_PER_PIXEL,
   IosH264Source,
+  defaultIosBitrateBps,
   resolveIosEncoderScale,
   resolveIosScreenCaptureHelperPath,
   type IosFrameCaptureHelper,
@@ -410,6 +412,44 @@ describe("IosH264Source", () => {
     expect(encoderSpawns[0].args).toContain("1200000");
     expect(encoderSpawns[0].args).toContain("-vf");
     expect(encoderSpawns[0].args).toContain("scale=720:1280");
+  });
+
+  test("emits a resolution-aware default bitrate when none is configured (#4349)", async () => {
+    const { source, helper, encoderSpawns } = createHarness(IOS_SIMULATOR);
+
+    // Native encode (even, inside budget) at the default 15 fps.
+    await startWithFrame(source, helper, frame(750, 1334, 0x11));
+
+    const rateIndex = encoderSpawns[0].args.indexOf("-b:v");
+    expect(rateIndex).toBeGreaterThanOrEqual(0);
+    expect(encoderSpawns[0].args[rateIndex + 1]).toBe(
+      String(defaultIosBitrateBps({ width: 750, height: 1334 }, WEBRTC_IOS_SIMULATOR_FPS_DEFAULT))
+    );
+  });
+
+  test("derives the default bitrate from the downscaled size, not the native capture (#4349)", async () => {
+    const { source, helper, encoderSpawns } = createHarness(IOS_SIMULATOR);
+
+    await startWithFrame(source, helper, frame(3840, 2160, 0x11));
+
+    const scaled = resolveIosEncoderScale({ width: 3840, height: 2160 })!;
+    const rateIndex = encoderSpawns[0].args.indexOf("-b:v");
+    expect(rateIndex).toBeGreaterThanOrEqual(0);
+    expect(encoderSpawns[0].args[rateIndex + 1]).toBe(
+      String(defaultIosBitrateBps(scaled, WEBRTC_IOS_SIMULATOR_FPS_DEFAULT))
+    );
+  });
+
+  test("an explicit bitrate still overrides the resolution-derived default (#4349)", async () => {
+    const { source, helper, encoderSpawns } = createHarnessWithOverrides({ bitrateBps: 1_200_000 });
+
+    await startWithFrame(source, helper, frame(750, 1334, 0x11));
+
+    const rateIndex = encoderSpawns[0].args.indexOf("-b:v");
+    expect(encoderSpawns[0].args[rateIndex + 1]).toBe("1200000");
+    expect(encoderSpawns[0].args[rateIndex + 1]).not.toBe(
+      String(defaultIosBitrateBps({ width: 750, height: 1334 }, WEBRTC_IOS_SIMULATOR_FPS_DEFAULT))
+    );
   });
 
   test("packs padded BGRA frame rows before writing rawvideo to ffmpeg", async () => {
@@ -992,5 +1032,40 @@ describe("resolveIosEncoderScale", () => {
     );
     expect(scale.width).toBeGreaterThan(0);
     expect(scale.height).toBeGreaterThan(0);
+  });
+});
+
+describe("defaultIosBitrateBps (#4349)", () => {
+  test("budgets a fixed number of bits per encoded pixel per frame", () => {
+    // width * height * fps * bpp, so the target scales with the encoder's real
+    // workload rather than a fixed ceiling.
+    expect(defaultIosBitrateBps({ width: 1_000, height: 1_000 }, 10)).toBe(
+      Math.round(1_000 * 1_000 * 10 * IOS_WEBRTC_DEFAULT_BITS_PER_PIXEL)
+    );
+  });
+
+  test("bounds the Retina developer host without inflating the hosted CI runner", () => {
+    // The two measured operating points behind the AC2 decision. Retina dev host
+    // (910x1940 @ 15) is bounded to ~2.6 Mbps; the headless CI runner
+    // (286x658 @ 15) is a fraction of that, so the same budget never inflates it.
+    const retina = defaultIosBitrateBps({ width: 910, height: 1_940 }, 15);
+    const hostedCi = defaultIosBitrateBps({ width: 286, height: 658 }, 15);
+
+    expect(retina).toBe(2_648_100);
+    expect(hostedCi).toBe(282_282);
+    expect(retina).toBeGreaterThan(hostedCi);
+  });
+
+  test("never returns a non-positive bitrate for a degenerate frame", () => {
+    expect(defaultIosBitrateBps({ width: 2, height: 2 }, 1)).toBeGreaterThanOrEqual(1);
+  });
+
+  test("falls back to the floor rather than passing NaN to ffmpeg", () => {
+    // Real capture never produces a non-finite dimension, but the guarantee is
+    // cheap: Math.max(1, NaN) is NaN, so the floor must be applied after a finite
+    // check, not by the max alone.
+    const bitrate = defaultIosBitrateBps({ width: Number.NaN, height: 1_080 }, 15);
+    expect(Number.isFinite(bitrate)).toBe(true);
+    expect(bitrate).toBeGreaterThanOrEqual(1);
   });
 });

--- a/test/helpers/captureStageTimeline.test.ts
+++ b/test/helpers/captureStageTimeline.test.ts
@@ -4,9 +4,12 @@ import {
   CAPTURE_STAGE_RECORD_SCHEMA_VERSION,
   CaptureStageTimeline,
   captureRunIdentity,
+  decodedFpsBetween,
+  egressKbpsBetween,
   formatCaptureStageRecord,
   monotonicNowMs,
   type CaptureStageContext,
+  type EgressSample,
 } from "./captureStageTimeline";
 
 /** Deterministic monotonic clock: advance() is the only way time moves. */
@@ -27,6 +30,8 @@ const context: CaptureStageContext = {
   sourceSize: { width: 1080, height: 2400 },
   configuredFps: 60,
   decodedSize: { width: 720, height: 1600 },
+  egressKbps: 2_648,
+  decodedFps: 14.7,
   run: {
     runId: "30053647851",
     runAttempt: "2",
@@ -161,6 +166,26 @@ describe("#4343 capture stage timeline", () => {
     expect(record.decodedSize).toEqual({ width: 720, height: 1600 });
   });
 
+  test("carries the measured egress bitrate and decoded fps (#4349)", () => {
+    const timeline = new CaptureStageTimeline(fakeClock().nowMs);
+    timeline.mark("startRequest");
+
+    const record = timeline.toRecord(context);
+
+    expect(record.egressKbps).toBe(2_648);
+    expect(record.decodedFps).toBe(14.7);
+  });
+
+  test("carries a null egress bitrate and decoded fps when they could not be sampled", () => {
+    const timeline = new CaptureStageTimeline(fakeClock().nowMs);
+    timeline.mark("startRequest");
+
+    const record = timeline.toRecord({ ...context, egressKbps: null, decodedFps: null });
+
+    expect(record.egressKbps).toBeNull();
+    expect(record.decodedFps).toBeNull();
+  });
+
   test("carries the run identity and sampling error bar so samples can be aggregated", () => {
     const timeline = new CaptureStageTimeline(fakeClock().nowMs);
     timeline.mark("startRequest");
@@ -235,12 +260,31 @@ describe("#4343 capture stage timeline", () => {
     timeline.mark("startRequest");
 
     const formatted = formatCaptureStageRecord(
-      timeline.toRecord({ ...context, sourceSize: null, configuredFps: null, decodedSize: null })
+      timeline.toRecord({
+        ...context,
+        sourceSize: null,
+        configuredFps: null,
+        decodedSize: null,
+        egressKbps: null,
+        decodedFps: null,
+      })
     );
 
     expect(formatted).toContain("source=none");
     expect(formatted).toContain("fps=none");
     expect(formatted).toContain("decoded=none");
+    expect(formatted).toContain("egress=none");
+    expect(formatted).toContain("decodedFps=none");
+  });
+
+  test("formats the measured egress bitrate and decoded fps (#4349)", () => {
+    const timeline = new CaptureStageTimeline(fakeClock().nowMs);
+    timeline.mark("startRequest");
+
+    const formatted = formatCaptureStageRecord(timeline.toRecord(context));
+
+    expect(formatted).toContain("egress=2648kbps");
+    expect(formatted).toContain("decodedFps=14.7");
   });
 
   test("defaults to a monotonic clock that never runs backwards", () => {
@@ -364,7 +408,7 @@ describe("#4354 teardown phase instrumentation", () => {
   });
 
   test("bumps the record schema version so a parser can span the phases addition", () => {
-    expect(CAPTURE_STAGE_RECORD_SCHEMA_VERSION).toBe(2);
+    expect(CAPTURE_STAGE_RECORD_SCHEMA_VERSION).toBe(3);
   });
 
   test("formats every phase with its status and elapsed time", async () => {
@@ -400,5 +444,33 @@ describe("#4354 teardown phase instrumentation", () => {
 
     expect(record.phases).toEqual([]);
     expect(formatCaptureStageRecord(record)).not.toContain("phase");
+  });
+});
+
+describe("#4349 egress bitrate and decoded fps between two inbound-rtp samples", () => {
+  const sample = (bytesReceived: number, framesDecoded: number, timestampMs: number): EgressSample => ({
+    bytesReceived,
+    framesDecoded,
+    timestampMs,
+  });
+
+  test("computes egress kbps: bits per millisecond equal kilobits per second", () => {
+    // 1,000,000 bytes over 2s == 8,000,000 bits / 2000 ms == 4000 kbps.
+    expect(egressKbpsBetween(sample(0, 0, 1_000), sample(1_000_000, 0, 3_000))).toBe(4_000);
+  });
+
+  test("computes decoded fps from the cumulative frame counter", () => {
+    // 30 frames over 2s == 15 fps.
+    expect(decodedFpsBetween(sample(0, 0, 1_000), sample(0, 30, 3_000))).toBe(15);
+  });
+
+  test("returns null for a non-positive window rather than dividing by zero", () => {
+    expect(egressKbpsBetween(sample(0, 0, 2_000), sample(1_000, 0, 2_000))).toBeNull();
+    expect(decodedFpsBetween(sample(0, 0, 2_000), sample(0, 5, 1_500))).toBeNull();
+  });
+
+  test("clamps a counter that reset between samples to zero rather than reporting negative", () => {
+    expect(egressKbpsBetween(sample(5_000, 0, 1_000), sample(1_000, 0, 3_000))).toBe(0);
+    expect(decodedFpsBetween(sample(0, 90, 1_000), sample(0, 10, 3_000))).toBe(0);
   });
 });

--- a/test/helpers/captureStageTimeline.ts
+++ b/test/helpers/captureStageTimeline.ts
@@ -104,6 +104,19 @@ export interface CaptureStageContext {
   configuredFps: number | null;
   /** Dimensions of the first frame the browser decoded. */
   decodedSize: CaptureDimensions | null;
+  /**
+   * Mean egress bitrate in kbps, measured at the browser over a sampling window
+   * (#4349), or null when it could not be sampled. This is the number the
+   * "default `-b:v` vs. rely on the VideoToolbox default" decision turns on, so
+   * a whole-test duration cannot stand in for it.
+   */
+  egressKbps: number | null;
+  /**
+   * Decoded frame rate in fps, measured at the browser over the same window
+   * (#4349), or null when it could not be sampled. The configured fps is what
+   * the pipeline requested; this is what a hosted runner actually sustained.
+   */
+  decodedFps: number | null;
   run: CaptureRunIdentity;
   /**
    * Poll interval each stage was observed with. Every measurement carries up to
@@ -131,9 +144,52 @@ export interface CaptureStageRecord extends CaptureStageContext {
 
 /**
  * Current {@link CaptureStageRecord.schemaVersion}. Bumped to 2 when `phases`
- * was added (#4354).
+ * was added (#4354), and to 3 when `egressKbps` / `decodedFps` were added (#4349).
  */
-export const CAPTURE_STAGE_RECORD_SCHEMA_VERSION = 2;
+export const CAPTURE_STAGE_RECORD_SCHEMA_VERSION = 3;
+
+/**
+ * A cumulative inbound-RTP counter read from the browser at one instant. Egress
+ * bitrate and decoded fps are rates, so they are computed from two of these
+ * bracketing a window rather than from a single reading.
+ */
+export interface EgressSample {
+  /** Cumulative bytes the reader has received on the video track. */
+  bytesReceived: number;
+  /** Cumulative frames the reader has decoded. */
+  framesDecoded: number;
+  /** Reader-side timestamp (ms) the counters were read at. */
+  timestampMs: number;
+}
+
+/**
+ * Mean egress bitrate (kbps) between two cumulative inbound-RTP samples, or null
+ * when the window is non-positive (a single sample, or reader clock skew). Bits
+ * per millisecond are numerically identical to kilobits per second, so no unit
+ * scaling is needed. A counter that reset between samples clamps to zero rather
+ * than reporting a negative rate.
+ */
+export function egressKbpsBetween(first: EgressSample, second: EgressSample): number | null {
+  const windowMs = second.timestampMs - first.timestampMs;
+  if (windowMs <= 0) {
+    return null;
+  }
+  const bits = Math.max(0, second.bytesReceived - first.bytesReceived) * 8;
+  return bits / windowMs;
+}
+
+/**
+ * Mean decoded frame rate (fps) between two cumulative samples, or null when the
+ * window is non-positive. Clamps a reset counter to zero, as {@link egressKbpsBetween} does.
+ */
+export function decodedFpsBetween(first: EgressSample, second: EgressSample): number | null {
+  const windowMs = second.timestampMs - first.timestampMs;
+  if (windowMs <= 0) {
+    return null;
+  }
+  const frames = Math.max(0, second.framesDecoded - first.framesDecoded);
+  return (frames / windowMs) * 1_000;
+}
 
 /** Monotonic millisecond reader used when none is injected. */
 export function monotonicNowMs(): number {
@@ -229,6 +285,7 @@ export function formatCaptureStageRecord(record: CaptureStageRecord): string {
   const lines = [
     `platform=${record.platform} stream=${record.streamId} outcome=${record.outcome}`,
     `source=${formatDimensions(record.sourceSize)} fps=${record.configuredFps ?? "none"} decoded=${formatDimensions(record.decodedSize)}`,
+    `egress=${record.egressKbps === null ? "none" : `${Math.round(record.egressKbps)}kbps`} decodedFps=${record.decodedFps === null ? "none" : Math.round(record.decodedFps * 10) / 10}`,
     `run=${record.run.runId ?? "local"}/${record.run.runAttempt ?? "1"} sha=${record.run.commitSha ?? "unknown"} runner=${record.run.runnerImage ?? record.run.runnerOs ?? "unknown"}`,
     ...record.stages.map(
       measurement =>

--- a/test/integration/webrtcDeviceCapture.integration.test.ts
+++ b/test/integration/webrtcDeviceCapture.integration.test.ts
@@ -8,15 +8,18 @@ import { join, resolve } from "node:path";
 import { promisify } from "node:util";
 import WebSocket from "ws";
 import { sendWebRtcStreamRequest } from "../../src/daemon/webrtcStreamClient";
-import { SIMULATOR_FPS_DEFAULT } from "../../src/features/screen-stream";
 import { SimCtlClient } from "../../src/utils/ios-cmdline-tools/SimCtlClient";
+import { WEBRTC_IOS_SIMULATOR_FPS_DEFAULT } from "../../src/features/webrtc/webrtcStreamingConfig";
 import {
   CaptureStageTimeline,
   captureRunIdentity,
+  decodedFpsBetween,
+  egressKbpsBetween,
   formatCaptureStageRecord,
   type CaptureDimensions,
   type CaptureStage,
   type CaptureStageContext,
+  type EgressSample,
 } from "../helpers/captureStageTimeline";
 
 const execFileAsync = promisify(execFile);
@@ -211,6 +214,34 @@ async function readerDiagnostics(cdp: CdpClient): Promise<ReaderDiagnostics> {
   return response.result?.result?.value as ReaderDiagnostics;
 }
 
+/**
+ * One cumulative inbound-RTP reading for the egress-bitrate / decoded-fps
+ * measurement (#4349). Uses the WebRTC stat's own `timestamp` for the window so
+ * the rate does not depend on the test host's wall clock. Returns null when no
+ * inbound-video stat is available yet — a missing sample must never fail the
+ * lane, so the caller treats null as "not measured".
+ */
+async function egressSample(cdp: CdpClient): Promise<EgressSample | null> {
+  const expression = `(async () => {
+    const connections = Array.from(window.__automobilePeerConnections ?? []);
+    const reports = (await Promise.all(connections.map(connection => connection.getStats())))
+      .flatMap(report => Array.from(report.values()));
+    const inbound = reports.find(stat => stat.type === "inbound-rtp" && stat.kind === "video");
+    if (!inbound) { return null; }
+    return {
+      bytesReceived: inbound.bytesReceived ?? 0,
+      framesDecoded: inbound.framesDecoded ?? 0,
+      timestampMs: inbound.timestamp ?? 0,
+    };
+  })()`;
+  const response = await cdp.command("Runtime.evaluate", {
+    expression,
+    awaitPromise: true,
+    returnByValue: true,
+  });
+  return (response.result?.result?.value as EgressSample | null) ?? null;
+}
+
 async function waitForDecodedFrames(cdp: CdpClient, minimum: number, message: string): Promise<void> {
   try {
     await waitFor(async () => (await videoSample(cdp)).frames > minimum, message);
@@ -242,9 +273,13 @@ async function captureProfile(): Promise<CaptureProfile> {
   // never configures; only the persistent encoder publishes a chosen fps.
   const usesVideoServer =
     Boolean(process.env.AUTOMOBILE_VIDEO_SERVER_JAR) || process.env.AUTOMOBILE_REQUIRE_VIDEO_SERVER === "1";
+  // iOS WebRTC captures at the streaming default, which is deliberately separate
+  // from the generic MCP-observation `SIMULATOR_FPS_DEFAULT` (5): the lane never
+  // overrides AUTOMOBILE_WEBRTC_IOS_SIMULATOR_FPS, so the record must reflect the
+  // rate the pipeline actually configures, not the observation constant (#4349).
   const configuredFps = platform === "android"
     ? (usesVideoServer ? ANDROID_VIDEO_SERVER_MEDIUM_FPS : null)
-    : SIMULATOR_FPS_DEFAULT;
+    : WEBRTC_IOS_SIMULATOR_FPS_DEFAULT;
   try {
     if (platform === "android") {
       const { stdout } = await execFileAsync("adb", ["-s", androidDeviceId(), "shell", "wm", "size"]);
@@ -338,7 +373,13 @@ const SAMPLING_INTERVALS_MS: Partial<Record<CaptureStage, number>> = {
 const timeline = new CaptureStageTimeline();
 let profile: CaptureProfile = { sourceSize: null, configuredFps: null };
 let decodedSize: CaptureDimensions | null = null;
+let egressKbps: number | null = null;
+let decodedFps: number | null = null;
 let outcome: "passed" | "failed" = "failed";
+// Window over which egress bitrate and decoded fps are averaged, and the
+// interval between the fixture toggles that keep the screen changing across it.
+const EGRESS_WINDOW_MS = 2_000;
+const EGRESS_TOGGLE_INTERVAL_MS = 400;
 
 describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => {
   afterAll(async () => {
@@ -349,6 +390,8 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
       sourceSize: profile.sourceSize,
       configuredFps: profile.configuredFps,
       decodedSize,
+      egressKbps,
+      decodedFps,
       run: captureRunIdentity(),
       samplingIntervalsMs: SAMPLING_INTERVALS_MS,
     } satisfies CaptureStageContext);
@@ -475,6 +518,32 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
       expect(first.height).toBeGreaterThan(0);
       expect(second.frames).toBeGreaterThan(first.frames);
       expect(second.sample).not.toBe(first.sample);
+      // Measure the operating point the AC2 decision turns on (#4349): average
+      // egress bitrate and decoded fps over a window while the stream is live.
+      // Drive continuous visible change across the window rather than sampling a
+      // static screen — H.264 inter-prediction compresses an idle fixture to
+      // near-zero, which would under-report the active-screen egress this is
+      // meant to capture (SimulatorCaptureSession also drops non-`.complete`
+      // frames, so a still screen delivers far fewer than the configured fps).
+      // Diagnostic only — a stats hiccup leaves both null and must never fail the
+      // lane, so this asserts nothing about the values.
+      try {
+        const before = await egressSample(cdp);
+        const windowDeadline = Date.now() + EGRESS_WINDOW_MS;
+        while (Date.now() < windowDeadline) {
+          await changeFixture();
+          await Bun.sleep(EGRESS_TOGGLE_INTERVAL_MS);
+          await launchFixture();
+          await Bun.sleep(EGRESS_TOGGLE_INTERVAL_MS);
+        }
+        const after = await egressSample(cdp);
+        if (before && after) {
+          egressKbps = egressKbpsBetween(before, after);
+          decodedFps = decodedFpsBetween(before, after);
+        }
+      } catch (error) {
+        console.warn(`[#4349] could not sample egress bitrate / decoded fps: ${error}`);
+      }
       const stopped = await sendWebRtcStreamRequest(
         { action: "stop", id: `${streamId}-stop`, streamId },
         { socketPath: webRtcSocketPath }

--- a/test/integration/webrtcDeviceCaptureLatency.test.ts
+++ b/test/integration/webrtcDeviceCaptureLatency.test.ts
@@ -167,6 +167,38 @@ describe("#4343 device capture latency instrumentation", () => {
     expect(source.indexOf("writeFile", afterAllIndex)).toBeGreaterThan(afterAllIndex);
   });
 
+  test("records the iOS WebRTC streaming fps, not the MCP-observation default (#4349)", () => {
+    const source = withoutComments(read(INTEGRATION_TEST_PATH));
+
+    // The generic SIMULATOR_FPS_DEFAULT is 5, tuned for one-shot observation; the
+    // WebRTC path runs WEBRTC_IOS_SIMULATOR_FPS_DEFAULT (15). Sourcing the record
+    // from the wrong constant made every prior iOS sample wrong by 3x.
+    expect(source).toContain("WEBRTC_IOS_SIMULATOR_FPS_DEFAULT");
+    // Word-boundary match, so the bare MCP-observation constant is caught in any
+    // position — import, ternary, a local, a call argument — while the
+    // `WEBRTC_IOS_`-prefixed constant never matches (the boundary before
+    // SIMULATOR fails when preceded by `_`). A substring scan for
+    // `SIMULATOR_FPS_DEFAULT}` both missed the indirect forms and would have
+    // false-failed once anyone wrapped the correct constant in a template.
+    expect(source).not.toMatch(/\bSIMULATOR_FPS_DEFAULT\b/);
+  });
+
+  test("samples egress bitrate and decoded fps into the record (#4349)", () => {
+    const source = withoutComments(read(INTEGRATION_TEST_PATH));
+
+    // Two cumulative inbound-RTP readings bracket the measured window; both feed
+    // the record so the operating point behind the AC2 decision is observable.
+    const first = indexOfRequired(source, "const before = await egressSample(cdp)");
+    const second = indexOfRequired(source, "const after = await egressSample(cdp)");
+    expect(first).toBeLessThan(second);
+    expect(source).toContain("egressKbps = egressKbpsBetween(before, after)");
+    expect(source).toContain("decodedFps = decodedFpsBetween(before, after)");
+    // Carried on the record written from afterAll.
+    const afterAllIndex = indexOfRequired(source, "afterAll(");
+    expect(source.indexOf("egressKbps,", afterAllIndex)).toBeGreaterThan(afterAllIndex);
+    expect(source.indexOf("decodedFps,", afterAllIndex)).toBeGreaterThan(afterAllIndex);
+  });
+
   test("mirrors the Android capture fps from the video-server default quality preset", () => {
     const integration = read(INTEGRATION_TEST_PATH);
     const encoder = read("src/features/webrtc/PersistentEncoderH264Source.ts");


### PR DESCRIPTION
## Summary

Follow-up from [PR #4346](https://github.com/kaeawc/auto-mobile/pull/4346) / [issue #4344](https://github.com/kaeawc/auto-mobile/issues/4344). Now that iOS Simulator capture encodes at its native resolution rather than being forced toward 1920×1080, the encoder workload and WHIP egress bitrate scale with the host's Retina backing store, and there was no default bitrate cap. This measures the real operating point using the [#4343](https://github.com/kaeawc/auto-mobile/issues/4343) timing record, then adds the missing instrumentation and a resolution-aware default bitrate the AC2 decision turns on.

## Linked Issue

Closes #4349

## Measurements (AC1)

Pulled the real `stage-latency.json` artifacts from the hosted `macos26` runner, plus a local Retina measurement on a 2.0× host:

| Operating point | Resolution | MB/frame | fps | MB/s | vs old 498×1080@5 |
| --- | --- | --- | --- | --- | --- |
| Old fixed 1920×1080 filter | 498×1080 | 2 176 | 5 | 10 880 | 1.0× |
| **Hosted CI runner** ([run 30058014124](https://github.com/kaeawc/auto-mobile/actions/runs/30058014124), decoded from artifact) | 286×658 | 756 | 15 | 11 340 | **1.04×** — flat |
| **Retina dev host** (iPhone 16 Pro window 455×970 pt → 2× → 910×1940 px) | 910×1940 | 6 954 | 15 | 104 310 | **9.6×** |

The issue estimated ~860×1864 / 6 318 MB on a Retina host and ~8.7× throughput. The local measurement confirms that premise on a **developer** Mac (910×1940, 9.6×). It does **not** hold on the **headless CI runner**, which has no Retina backing store and delivers a sub-1× 286×658 frame. Both points are well inside the 522 240 MaxMBPS the SDP advertises (Retina = 20%).

Two instrument gaps surfaced and are fixed here:
- **Egress bitrate was not recorded at all** — the #4343 record had no bitrate field. Now sampled at the browser from `inbound-rtp` over a steady-state window.
- **`configuredFps` was mis-sourced** — the iOS lane recorded `SIMULATOR_FPS_DEFAULT` (5, the MCP-observation constant) while the WebRTC path runs `WEBRTC_IOS_SIMULATOR_FPS_DEFAULT` (15). Every prior iOS sample was 3× off. Also records decoded fps.

## Decision (AC2)

**Yes — the iOS WebRTC path needs a default bitrate.** On a Retina dev host the native-resolution capture (910×1940@15) with an uncapped VideoToolbox default can push egress several-fold with no ceiling; on CI it is negligible. Rather than a fixed cap (which would inflate the small CI frame) or a resolution ceiling (which would fight #4344's native-resolution goal), this budgets a **resolution-aware default** from the *encoded* size × fps at **0.1 bits/pixel**:

- Retina 910×1940@15 → **~2.6 Mbps** (bounded).
- Hosted CI 286×658@15 → **~0.28 Mbps** (never inflated — the same budget scales down).

0.1 bpp is a conventional target for baseline-profile screen content, whose largely-static frames leave headroom for scroll/animation within the 2 s GOP. An operator `AUTOMOBILE_WEBRTC_BITRATE_KBPS` override still wins.

**Measurement limitation (stated plainly):** the Retina *egress* worst case cannot be measured by any lane — CI is sub-1×, and a local full-pipeline egress measurement is blocked by Screen Recording TCC on this shell. The default is therefore justified by the *resolution* measurement × a documented bpp target, not a measured Retina egress number. This PR's own device lane re-runs (both touched files are in the workflow's paths filter) and produces the first CI egress + decoded-fps sample under the new record.

## Changes

- `src/features/webrtc/IosH264Source.ts` — always emit an explicit `-b:v`; when none is configured, `defaultIosBitrateBps(encodedSize, fps)` at `IOS_WEBRTC_DEFAULT_BITS_PER_PIXEL` (0.1). Derived from the *encoded* size (post any downscale), so it composes with `resolveIosEncoderScale`.
- `test/helpers/captureStageTimeline.ts` — add `egressKbps` + `decodedFps` to the record (schemaVersion 1 → 2); pure `egressKbpsBetween` / `decodedFpsBetween` over two cumulative `inbound-rtp` samples (bits/ms ≡ kbps; reset counters clamp to 0).
- `test/integration/webrtcDeviceCapture.integration.test.ts` — sample egress + decoded fps over a 2 s steady-state window (diagnostic only, never fails the lane); fix iOS `configuredFps` to the WebRTC streaming default.
- `test/integration/webrtcDeviceCaptureLatency.test.ts` — guards pinning the fps source and the egress sampling.
- Unit tests pin the bpp math, both measured operating points, argv default/override, and the record shape.

## Non-goals honored (AC3)

No hard-coded capture resolution or fixed Simulator window size is introduced — the default reads the actual encoded dimensions; `resolveIosEncoderScale` is unchanged.

## Validation

- [x] `bun test` — 9105 pass, 0 fail (full suite)
- [x] `bun run lint` (+ all boundary checks)
- [x] `bun run build`
- [x] `bun run typecheck` — no new errors (the local-only `ajv`/`ajv-formats` drift in `PlanSchemaValidator.ts` cleared with `bun install --frozen-lockfile`; CI runs on a clean install)
- [x] New code uses interfaces + fakes + injected clock; unit suites run in ~160 ms

## Device Verification

This PR's own iOS + Android device lanes are the first samples under schemaVersion 2, exercising the new `-b:v` on a live runner and recording egress + decoded fps.

## Follow-ups

- [ ] Collect several CI egress/decoded-fps samples and report p50/p95 before tightening the bpp budget or any timeout contract — tracked in [#4375](https://github.com/kaeawc/auto-mobile/issues/4375).

---

## Review round (second commit)

Rebased onto latest `main` and ran a three-lens review (Runtime Behavior, Delivery & Enforcement, Numeric/Measurement Correctness). No blockers; ACs confirmed met. Changes made:

- **Merged with [#4354](https://github.com/kaeawc/auto-mobile/pull/4354)**, which landed on `main` while this was in flight and independently added `phases` to the same timeline record, also bumping `schemaVersion` 1→2. The two are orthogonal except that collision — resolved by carrying both and bumping `schemaVersion` to **3** (`phases` + `egressKbps`/`decodedFps`).
- **Egress window now drives continuous visible change** instead of sampling a static screen. Two lenses independently flagged that a still fixture compresses to near-zero under H.264 inter-prediction (and `SimulatorCaptureSession` drops non-`.complete` frames), so the old static window would under-report the active-screen egress AC1 asks for. The window now alternates `changeFixture`/`launchFixture` every 400 ms so the recorded number reflects an active screen.
- **`defaultIosBitrateBps` hardened against non-finite input** — `Math.max(1, NaN)` is `NaN`, so the floor is now applied after a `Number.isFinite` check rather than by `max` alone, making the "always a positive finite integer" guarantee airtight (unreachable from real capture, but cheap). Pinned by a new test.
- **fps guard made precise** — replaced the fragile `not.toContain("SIMULATOR_FPS_DEFAULT}")` substring scan (which both missed indirect reintroductions and would false-*fail* once anyone wrapped the correct `WEBRTC_IOS_SIMULATOR_FPS_DEFAULT` in a template literal) with a word-boundary `not.toMatch(/\bSIMULATOR_FPS_DEFAULT\b/)` — the `_` before `SIMULATOR` in the WebRTC constant defeats the leading boundary, so only the bare MCP constant matches, in any syntactic position.

Full suite re-run post-rebase: 9162 pass, 0 fail; lint + typecheck + build green.
