### PR TITLE
fix(lint): close residual sdkmanager boundary false-negatives (class field, callback param, member-assigned fn)

### DIFF
--- a/scripts/check-sdkmanager-execution-boundary.ts
+++ b/scripts/check-sdkmanager-execution-boundary.ts
@@ -21,6 +21,23 @@ const LAUNCHER_NAMES = new Set([
   "execFileSync",
 ]);
 
+// Array-iteration methods that bind a callback's parameters to the receiver's elements. When the
+// receiver carries an sdkmanager literal, those parameters are tainted just like a named
+// function's parameters at a call site (issue #4368) — there is no explicit call site to key on.
+const ITERATION_METHODS = new Set([
+  "forEach",
+  "map",
+  "flatMap",
+  "filter",
+  "find",
+  "findIndex",
+  "findLast",
+  "some",
+  "every",
+  "reduce",
+  "reduceRight",
+]);
+
 function functionLikeName(node: ts.Node): string | undefined {
   if ((ts.isFunctionDeclaration(node) || ts.isMethodDeclaration(node)) &&
     node.name && ts.isIdentifier(node.name)) {
@@ -30,6 +47,11 @@ function functionLikeName(node: ts.Node): string | undefined {
     const parent = node.parent;
     if (parent && ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)) {return parent.name.text;}
     if (parent && ts.isPropertyAssignment(parent) && ts.isIdentifier(parent.name)) {return parent.name.text;}
+    // `obj.run = (bin) => ...` binds the arrow to a member expression, not a variable or
+    // object-literal property; key it by the property name so its call sites are found (#4368).
+    if (parent && ts.isBinaryExpression(parent) &&
+      parent.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isPropertyAccessExpression(parent.left)) {return parent.left.name.text;}
   }
   return undefined;
 }
@@ -77,6 +99,10 @@ export function directlyExecutesSdkManager(source: string): boolean {
   const functionsByName = new Map<string, ts.FunctionLikeDeclaration[]>();
   const returnsByName = new Map<string, ts.Expression[]>();
   const callSites: { name: string; args: readonly ts.Expression[] }[] = [];
+  // Iteration-method callbacks paired with the receiver whose elements bind their parameters, e.g.
+  // `["sdkmanager"].forEach(bin => spawn(bin))`. If the receiver mentions sdkmanager the fixpoint
+  // taints the callback's parameters (issue #4368).
+  const iterationCallbacks: { receiver: ts.Expression; callback: ts.FunctionLikeDeclaration }[] = [];
   // Three monotonic taint sets, all filled by the fixpoint after collection: parameter names
   // that receive an sdkmanager-ish argument at some call site, function names whose return value
   // carries sdkmanager, and variable names whose (transitive) initializer carries sdkmanager.
@@ -128,6 +154,23 @@ export function directlyExecutesSdkManager(source: string): boolean {
     if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
       ts.isIdentifier(node.left)) {
       bindValue(node.left.text, node.right);
+    }
+    // `private bin = "sdkmanager"` is a PropertyDeclaration; bind its initializer by the field
+    // name so a `this.bin` reference at a launcher call site resolves through the value flow,
+    // mirroring the local-variable handling above (issue #4368).
+    if (ts.isPropertyDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      bindValue(node.name.text, node.initializer);
+    }
+    // `receiver.map(bin => ...)` binds `bin` to the receiver's elements; record the pairing so the
+    // fixpoint can taint the callback parameters when the receiver mentions sdkmanager (#4368).
+    if (ts.isCallExpression(node) && ts.isPropertyAccessExpression(node.expression) &&
+      ITERATION_METHODS.has(node.expression.name.text)) {
+      const receiver = node.expression.expression;
+      for (const argument of node.arguments) {
+        if (ts.isArrowFunction(argument) || ts.isFunctionExpression(argument)) {
+          iterationCallbacks.push({ receiver, callback: argument });
+        }
+      }
     }
     if (ts.isFunctionLike(node)) {
       const name = functionLikeName(node);
@@ -245,6 +288,15 @@ export function directlyExecutesSdkManager(source: string): boolean {
       if (!returnsSdkManager.has(name) && returns.some(expression => mentionsSdkManager(expression))) {
         returnsSdkManager.add(name);
         taintChanged = true;
+      }
+    }
+    for (const { receiver, callback } of iterationCallbacks) {
+      if (!mentionsSdkManager(receiver)) {continue;}
+      for (const parameter of callback.parameters) {
+        if (ts.isIdentifier(parameter.name) && !sdkManagerParams.has(parameter.name.text)) {
+          sdkManagerParams.add(parameter.name.text);
+          taintChanged = true;
+        }
       }
     }
   }

--- a/test/lint/sdkManagerExecutionBoundary.test.ts
+++ b/test/lint/sdkManagerExecutionBoundary.test.ts
@@ -134,6 +134,45 @@ describe("sdkmanager execution boundary (issue #4052)", () => {
     expect(directlyExecutesSdkManager("await Bun.$`avdmanager list`;")).toBe(false);
   });
 
+  test("detects sdkmanager stored in a class field and spawned via this.field (issue #4368)", () => {
+    // `private bin = "sdkmanager"` is a PropertyDeclaration; feeding its initializer into the
+    // value flow lets `this.bin` resolve to the tool name at the launcher call site.
+    expect(directlyExecutesSdkManager(
+      'class Tool { private bin = "sdkmanager"; run(args) { spawn(this.bin, args); } }',
+    )).toBe(true);
+    // A different tool stored the same way must not trip the guard.
+    expect(directlyExecutesSdkManager(
+      'class Tool { private bin = "avdmanager"; run(args) { spawn(this.bin, args); } }',
+    )).toBe(false);
+  });
+
+  test("detects sdkmanager reached through an iteration-callback parameter (issue #4368)", () => {
+    // The arrow's `bin` parameter is bound by `.forEach` to the array element, which is the tool
+    // name; there is no named-function call site, so only receiver-driven taint catches it.
+    expect(directlyExecutesSdkManager(
+      '["sdkmanager"].forEach(bin => spawn(bin));',
+    )).toBe(true);
+    expect(directlyExecutesSdkManager(
+      '["sdkmanager"].map(bin => execFile(bin, args));',
+    )).toBe(true);
+    // A different tool iterated the same way must stay clean.
+    expect(directlyExecutesSdkManager(
+      '["avdmanager"].forEach(bin => spawn(bin));',
+    )).toBe(false);
+  });
+
+  test("detects sdkmanager reached through a member-assigned function (issue #4368)", () => {
+    // `obj.run = (bin) => execFile(bin, args)` binds the arrow to a member expression, not a
+    // variable or object-literal property, so its parameter was previously untracked.
+    expect(directlyExecutesSdkManager(
+      'obj.run = (bin) => execFile(bin, args);\nobj.run("sdkmanager");',
+    )).toBe(true);
+    // A different tool passed the same way must not trip the guard.
+    expect(directlyExecutesSdkManager(
+      'obj.run = (bin) => execFile(bin, args);\nobj.run("avdmanager");',
+    )).toBe(false);
+  });
+
   test("allows diagnostic text that does not execute sdkmanager", () => {
     expect(directlyExecutesSdkManager('logger.info("Install with sdkmanager --list");')).toBe(false);
   });


### PR DESCRIPTION
## Summary

Follow-up to #4367 (which resolved issue 4341). The sdkmanager execution-boundary detector
(`scripts/check-sdkmanager-execution-boundary.ts`) was deliberately bounded rather than sound,
leaving three residual false-negative shapes where a **non-owner** file could execute
`sdkmanager` and pass the guard. This closes all three, each a clean mirror of logic already
present, and pins each with a before/after unit assertion.

## Linked Issue

Closes #4368

## Changes

Each shape now resolves the tool name to the launcher call site:

1. **Class field** — `private bin = "sdkmanager"` spawned via `this.bin`. `PropertyDeclaration`
   initializers are now fed into the value flow (`bindValue`), mirroring the existing
   `VariableDeclaration` handling.
2. **Iteration-callback parameter** — `["sdkmanager"].forEach(bin => spawn(bin))`. Callbacks
   passed to array-iteration methods (`forEach`/`map`/`filter`/…) whose receiver mentions
   sdkmanager have their parameters tainted in the fixpoint. There is no explicit call site to
   key on, so the receiver drives the taint.
3. **Member-assigned function** — `obj.run = (bin) => execFile(bin, args); obj.run("sdkmanager")`.
   `functionLikeName` now keys an arrow/fn-expression assigned via a member expression by its
   property name, so its call sites (and thus parameter taint) are found.

All three preserve the detector's deliberate over-detection bias: unknowns fail loud (a CI red),
never silent.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes (`bun run lint` + `bun test`) — full suite 9149 pass / 0 fail
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New tests run in <1ms each (pure AST, no I/O)
- [x] Full-tree scan still green and `detection.ts` version-probe path still not flagged (negative pins hold)

## Acceptance criteria (from #4368)

| Shape | Test | Before | After |
| --- | --- | --- | --- |
| Class field | `detects sdkmanager stored in a class field …` | false | **true** |
| Callback param | `detects sdkmanager reached through an iteration-callback parameter …` | false | **true** |
| Member-assigned fn | `detects sdkmanager reached through a member-assigned function …` | false | **true** |

Each has an `avdmanager` negative variant asserting `false` so the guard stays specific.

## Follow-ups

None. The one explicitly out-of-scope item named in the issue — the generic tool-name version
probe in `detection.ts` — is correctly still not flagged (pinned by an existing negative test).
