### PR TITLE
fix(database): DatabaseInspector failure replies carry a structured JSON envelope

### DIFF
--- a/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProvider.kt
+++ b/android/auto-mobile-sdk/src/debug/kotlin/dev/jasonpearson/automobile/sdk/database/DatabaseInspectorProvider.kt
@@ -40,9 +40,7 @@ class DatabaseInspectorProvider : ContentProvider() {
 
     // Check if inspection is enabled
     if (!DatabaseInspector.isEnabled()) {
-      result.putBoolean("success", false)
-      result.putString("errorType", "DISABLED")
-      result.putString("error", "Database inspection is disabled")
+      result.putError("DISABLED", "Database inspection is disabled")
       return result
     }
 
@@ -60,20 +58,38 @@ class DatabaseInspectorProvider : ContentProvider() {
       result.putBoolean("success", true)
       result.putString("result", response.toString())
     } catch (e: DatabaseError) {
-      result.putBoolean("success", false)
-      result.putString("errorType", e::class.simpleName ?: "UNKNOWN")
-      result.putString("error", e.message ?: "Unknown error")
+      result.putError(e::class.simpleName ?: "UNKNOWN", e.message ?: "Unknown error")
     } catch (e: IllegalArgumentException) {
-      result.putBoolean("success", false)
-      result.putString("errorType", "INVALID_ARGUMENT")
-      result.putString("error", e.message ?: "Invalid argument")
+      result.putError("INVALID_ARGUMENT", e.message ?: "Invalid argument")
     } catch (e: Exception) {
-      result.putBoolean("success", false)
-      result.putString("errorType", e::class.simpleName ?: "UNKNOWN")
-      result.putString("error", e.message ?: "Unknown error")
+      result.putError(e::class.simpleName ?: "UNKNOWN", e.message ?: "Unknown error")
     }
 
     return result
+  }
+
+  /**
+   * Write a failure reply as a single JSON envelope under `result`, mirroring the success path.
+   *
+   * `adb shell content call` prints the returned Bundle with `Bundle.toString()`
+   * (`Bundle[{key=value, ...}]`) and does not escape values, so raw `errorType` / `error` entries
+   * whose text contains a `, <key>=` sequence or a `}]` are indistinguishable from real entry
+   * boundaries once printed. Because SQLite echoes caller-controlled SQL back in its messages, that
+   * ambiguity is reachable. Nesting the values inside a JSON string escapes them, so the TS
+   * consumer can read them back intact with a balanced-brace parser. See
+   * `src/features/database/DatabaseInspector.ts` (`extractError`).
+   */
+  private fun Bundle.putError(errorType: String, error: String) {
+    putBoolean("success", false)
+    putString(
+      "result",
+      JSONObject()
+        .apply {
+          put("errorType", errorType)
+          put("error", error)
+        }
+        .toString(),
+    )
   }
 
   private fun handleListDatabases(driver: DatabaseDriver): JSONObject {

--- a/src/features/database/DatabaseInspector.ts
+++ b/src/features/database/DatabaseInspector.ts
@@ -217,10 +217,16 @@ export class DatabaseInspector {
     if (json) {
       try {
         const parsed = JSON.parse(json) as { errorType?: unknown; error?: unknown };
-        return {
-          errorType: typeof parsed.errorType === "string" ? parsed.errorType : "UNKNOWN",
-          error: typeof parsed.error === "string" ? parsed.error : "Unknown error"
-        };
+        // Only accept it as the envelope if it actually carries a field. Otherwise this is an old
+        // flat reply whose error text merely contains a parseable `result={...}` span: `indexOf`
+        // latched onto that substring, JSON.parse succeeded, but the real flat values are elsewhere
+        // — fall through so the flat reader below still finds them.
+        if (typeof parsed.errorType === "string" || typeof parsed.error === "string") {
+          return {
+            errorType: typeof parsed.errorType === "string" ? parsed.errorType : "UNKNOWN",
+            error: typeof parsed.error === "string" ? parsed.error : "Unknown error"
+          };
+        }
       } catch (error) {
         // Not a structured envelope (e.g. an old flat reply whose error text merely contains
         // a "result=" substring) — expected under version skew, so fall through to the flat form.

--- a/src/features/database/DatabaseInspector.ts
+++ b/src/features/database/DatabaseInspector.ts
@@ -1,5 +1,6 @@
 import { ActionableError, BootedDevice } from "../../models";
 import { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import { logger } from "../../utils/logger";
 import { shellQuote } from "../../utils/shellQuote";
 
 /**
@@ -180,8 +181,7 @@ export class DatabaseInspector {
     const success = this.extractBundleValue(output, "success") === "true";
 
     if (!success) {
-      const errorType = this.extractBundleValue(output, "errorType") || "UNKNOWN";
-      const error = this.extractBundleValue(output, "error") || "Unknown error";
+      const { errorType, error } = this.extractError(output);
       throw new ActionableError(`Database error (${errorType}): ${error}`);
     }
 
@@ -199,6 +199,42 @@ export class DatabaseInspector {
   }
 
   /**
+   * Resolve the `errorType` / `error` of a failure reply.
+   *
+   * Newer SDK builds put the failure payload in a single JSON envelope under `result=`, exactly
+   * as the success path does (see DatabaseInspectorProvider.kt). Because the values live inside a
+   * JSON string they are escaped, so they can no longer collide with Bundle.toString()'s
+   * delimiters (", ", "=", "}]") — the balanced-brace `extractJsonFromBundle` reads them back
+   * intact even when a caller-controlled fragment such as `near "x, error=y": syntax` is echoed.
+   *
+   * Older SDK builds emit the flat form (`errorType=...`, `error=...` as raw Bundle entries).
+   * Version skew is the normal state between releases, so when there is no parseable envelope we
+   * fall back to reading the flat entries with {@link extractBundleValue}, preserving the prior
+   * behavior (and its documented ambiguity, which only the envelope form can eliminate).
+   */
+  private extractError(output: string): { errorType: string; error: string } {
+    const json = this.extractJsonFromBundle(output);
+    if (json) {
+      try {
+        const parsed = JSON.parse(json) as { errorType?: unknown; error?: unknown };
+        return {
+          errorType: typeof parsed.errorType === "string" ? parsed.errorType : "UNKNOWN",
+          error: typeof parsed.error === "string" ? parsed.error : "Unknown error"
+        };
+      } catch (error) {
+        // Not a structured envelope (e.g. an old flat reply whose error text merely contains
+        // a "result=" substring) — expected under version skew, so fall through to the flat form.
+        logger.debug(`database error envelope was not valid JSON, using flat form: ${error}`);
+      }
+    }
+
+    return {
+      errorType: this.extractBundleValue(output, "errorType") || "UNKNOWN",
+      error: this.extractBundleValue(output, "error") || "Unknown error"
+    };
+  }
+
+  /**
    * Extract a single Bundle entry value from `content call` output.
    *
    * `adb shell content call` prints the returned Bundle with Bundle.toString(), i.e.
@@ -210,8 +246,10 @@ export class DatabaseInspector {
    *
    * Bundle.toString() does not escape its values, so a value that itself contains a literal
    * `, <knownKey>=` sequence is indistinguishable from a real entry boundary and would still be
-   * cut short. That ambiguity is in the wire format, not in this parser, and no SQLite message
-   * produces it in practice.
+   * cut short. That ambiguity is in the wire format, not in this parser. Newer SDK builds remove
+   * it at the producer by nesting the failure payload in a JSON envelope (see {@link extractError}
+   * and DatabaseInspectorProvider.kt); this flat reader remains only as the version-skew fallback
+   * for older SDK builds that still emit raw `errorType=` / `error=` entries.
    */
   private extractBundleValue(output: string, key: string): string | null {
     // A key always starts the bundle ("Bundle[{key=") or follows an entry separator.

--- a/test/features/database/DatabaseInspector.test.ts
+++ b/test/features/database/DatabaseInspector.test.ts
@@ -279,6 +279,17 @@ describe("DatabaseInspector", () => {
 
       expect(message).toBe("Database error (UNKNOWN): Unknown error");
     });
+
+    test("keeps flat values when an old reply's error text embeds a parseable result={}", async () => {
+      // Version skew: an old flat-form SDK whose SQLite message happens to echo a `result={...}`
+      // span. The envelope reader latches onto that substring and parses it, but it carries no
+      // errorType/error field, so the real flat values must still win.
+      const message = await errorFor(
+        `Bundle[{success=false, errorType=SQLiteException, error=near result={"a":1} bad}]`
+      );
+
+      expect(message).toBe(`Database error (SQLiteException): near result={"a":1} bad`);
+    });
   });
 
   describe("structured error envelope (SDK wire format)", () => {

--- a/test/features/database/DatabaseInspector.test.ts
+++ b/test/features/database/DatabaseInspector.test.ts
@@ -281,6 +281,61 @@ describe("DatabaseInspector", () => {
     });
   });
 
+  describe("structured error envelope (SDK wire format)", () => {
+    // Newer SDK builds put the failure payload in a single JSON envelope under `result=`,
+    // exactly as the success path does, so `errorType`/`error` values are JSON-escaped and
+    // can no longer collide with Bundle.toString() delimiters (", ", "=", "}]"). The TS side
+    // reads this with the balanced-brace `extractJsonFromBundle`, and falls back to the flat
+    // form for older SDK builds still in the field (see "error envelope parsing" above).
+    const errorFor = async (response: string): Promise<string> => {
+      fakeAdb.setCommandResult(
+        `shell content call --uri content://${appId}.automobile.database --method listDatabases`,
+        response
+      );
+      try {
+        await inspector.listDatabases(appId);
+      } catch (error) {
+        return (error as Error).message;
+      }
+      throw new Error("expected listDatabases to reject");
+    };
+
+    test("round-trips a caller-controlled fragment that mimics a delimiter", async () => {
+      // The value contains a literal `, error=` sequence; the flat parser cuts it short, the
+      // envelope carries it verbatim because it is inside a JSON string.
+      const message = await errorFor(
+        `Bundle[{success=false, result={"errorType":"SQLiteException","error":"near \\"x, error=y\\": syntax"}}]`
+      );
+
+      expect(message).toBe(`Database error (SQLiteException): near "x, error=y": syntax`);
+    });
+
+    test("round-trips values containing every Bundle delimiter", async () => {
+      const message = await errorFor(
+        `Bundle[{success=false, result={"errorType":"SQL, errorType=Error}]","error":"no such column: foo, bar}] errorType=x"}}]`
+      );
+
+      expect(message).toBe(
+        `Database error (SQL, errorType=Error}]): no such column: foo, bar}] errorType=x`
+      );
+    });
+
+    test("reads the envelope regardless of Bundle entry order", async () => {
+      // Bundle is backed by a hash-ordered ArrayMap, so `result` may print before `success`.
+      const message = await errorFor(
+        `Bundle[{result={"errorType":"SQLiteException","error":"disk I/O error"}, success=false}]`
+      );
+
+      expect(message).toBe("Database error (SQLiteException): disk I/O error");
+    });
+
+    test("falls back to UNKNOWN when the envelope omits the fields", async () => {
+      const message = await errorFor(`Bundle[{success=false, result={}}]`);
+
+      expect(message).toBe("Database error (UNKNOWN): Unknown error");
+    });
+  });
+
   describe("error handling", () => {
     test("throws ActionableError when ContentProvider not found", async () => {
       // Simulate when the app doesn't have the SDK or provider


### PR DESCRIPTION
## Summary

Failure replies from `DatabaseInspectorProvider` previously wrote raw, unescaped `errorType`/`error` entries into the returned `Bundle`. `adb shell content call` prints the Bundle with `Bundle.toString()` (`Bundle[{key=value, ...}]`), whose delimiters — `", "`, `"="`, and the map terminator `"}]"` — can all appear inside a caller-controlled SQLite message. Since SQLite echoes fragments of the caller's SQL back in its error text, a value boundary becomes ambiguous *once printed*, and the information is lost before the string ever reaches the TypeScript parser. No parser-side cleverness could recover it (the residual limitation documented at `DatabaseInspector.ts:230` after [#4206](https://github.com/kaeawc/auto-mobile/pull/4206)).

This fixes it **at the producer**:

- **Producer (`DatabaseInspectorProvider.kt`):** every failure path now writes a single JSON envelope `{"errorType": ..., "error": ...}` into `result`, mirroring the success path. Nested inside a JSON string the values are escaped, so they can no longer collide with the printed Bundle delimiters. Entry order (hash-based `ArrayMap`) no longer matters.
- **Consumer (`DatabaseInspector.ts`):** a new `extractError()` reads the envelope with the existing balanced-brace, quote-aware `extractJsonFromBundle`, and **falls back to the flat reader** for older SDK builds still in the field. Version skew is the normal state between releases, so the flat `extractBundleValue` path is retained purely as that fallback.

Note: this changes the **SDK-to-TS wire format** and so reaches the field only after an SDK re-cut/release; the TS fallback is the version-skew bridge (new TS reads both forms).

## Linked Issue

Closes #4216

## Bug / Regression Context

- **Prior attempts:** [#4206](https://github.com/kaeawc/auto-mobile/pull/4206) split the printed Bundle at `, <knownKey>=` boundaries — correct for every message SQLite produces *in practice*, but it left a wire-format ambiguity the parser cannot resolve.
- **Observed symptom:** a value containing a literal delimiter sequence, e.g. `near "x, error=y": syntax`, is misparsed to `near "x` (errorType lost).
- **Repro steps / conditions:** any failure reply whose `error` text contains `, errorType=`, `, error=`, or `}]` — reachable via caller-controlled SQL that SQLite echoes back.

## Validation

- [x] `scripts/all_fast_validate_checks.sh` passes (`bun run lint` + `bun test`) — full suite: 9150 pass / 0 fail; `DatabaseInspector.test.ts`: 25 pass
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android changes: `scripts/ktfmt/validate_ktfmt.sh` passes. Local Kotlin compile is blocked by an unrelated `desktop-app`/`desktop-core` compose-plugin resolution failure in this environment; relying on Android CI to compile/test.
- [x] New code uses interfaces + fakes (`FakeAdbClient`); unit tests run in <100ms
- [x] New generic code reuses existing project helpers (`extractJsonFromBundle`, `extractBundleValue`, shared `logger`); no new dependency
- [x] Rebased onto latest `main`

## Kotlin Reuse Check

- [x] Reused the already-imported `org.json.JSONObject` and a standard Kotlin `Bundle` extension; no new helper file, `*Util`, wrapper, or dependency
- [x] No custom implementation or new dependency introduced

## Acceptance Criteria

- [x] **Failure replies carry a structured envelope whose values cannot collide with the delimiters** — `putError` writes a JSON envelope into `result`.
- [x] **TS parser reads the structured form and still degrades against the flat form** — `extractError` (envelope-first, flat-fallback); existing flat-form tests stay green.
- [x] **`near "x, error=y": syntax` round-trips intact (red today)** — new test `round-trips a caller-controlled fragment that mimics a delimiter`.
- [x] **The `}` / comma cases stay green** — existing `error envelope parsing` tests unchanged and passing.

## Follow-ups

- [ ] None required. Producer output is pinned by the TS wire-format contract tests + the mechanical Kotlin change (a dedicated Kotlin `testDebug` unit test was considered and deferred to avoid adding a variant-specific test sourceset); it is additionally covered by Android CI and manual/integration.
