### PR TITLE
docs(webrtc): echo a result-reading legend in both device lanes

### DIFF
--- a/.github/workflows/webrtc-device-integration.yml
+++ b/.github/workflows/webrtc-device-integration.yml
@@ -97,6 +97,9 @@ jobs:
       # is there for failed runs too, when it is most needed.
       - name: "Explain WebRTC device results"
         if: always()
+        # Diagnostic-only: a failure here must never redden a green capture lane,
+        # same as the upload step below.
+        continue-on-error: true
         run: bash scripts/webrtc/explain-device-results.sh android
       # Always keep the stage-latency record (#4343): p50/p95 baselines need the
       # passing runs too. continue-on-error keeps a missing or failed upload from
@@ -146,6 +149,9 @@ jobs:
       # is there for failed runs too, when it is most needed.
       - name: "Explain WebRTC device results"
         if: always()
+        # Diagnostic-only: a failure here must never redden a green capture lane,
+        # same as the upload step below.
+        continue-on-error: true
         run: bash scripts/webrtc/explain-device-results.sh ios
       # Always keep the stage-latency record (#4343): p50/p95 baselines need the
       # passing runs too. continue-on-error keeps a missing or failed upload from

--- a/.github/workflows/webrtc-device-integration.yml
+++ b/.github/workflows/webrtc-device-integration.yml
@@ -92,6 +92,12 @@ jobs:
               bun run test:integration:webrtc-device
           working-directory: './android/'
           accessibility-apk-path: control-proxy/build/outputs/apk/debug/control-proxy-debug.apk
+      # Print the legend for reading result.txt / stage-latency.json and the
+      # benign chrome.log/mediamtx.log ERROR lines (#4308). if: always() so it
+      # is there for failed runs too, when it is most needed.
+      - name: "Explain WebRTC device results"
+        if: always()
+        run: bash scripts/webrtc/explain-device-results.sh android
       # Always keep the stage-latency record (#4343): p50/p95 baselines need the
       # passing runs too. continue-on-error keeps a missing or failed upload from
       # turning a green capture lane red.
@@ -135,6 +141,12 @@ jobs:
           AUTOMOBILE_WEBRTC_DEVICE_INTEGRATION: "1"
           AUTOMOBILE_WEBRTC_DEVICE_PLATFORM: ios
         run: bun run test:integration:webrtc-device
+      # Print the legend for reading result.txt / stage-latency.json and the
+      # benign chrome.log/mediamtx.log ERROR lines (#4308). if: always() so it
+      # is there for failed runs too, when it is most needed.
+      - name: "Explain WebRTC device results"
+        if: always()
+        run: bash scripts/webrtc/explain-device-results.sh ios
       # Always keep the stage-latency record (#4343): p50/p95 baselines need the
       # passing runs too. continue-on-error keeps a missing or failed upload from
       # turning a green capture lane red.

--- a/scripts/webrtc/explain-device-results.sh
+++ b/scripts/webrtc/explain-device-results.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Explain how to read the WebRTC device-capture artifacts, printed into the job
+# log (and the run summary) by both device lanes (#4308).
+#
+# A green run still emits ERROR lines into chrome.log/mediamtx.log — STUN DNS
+# failures, an SDP congestion-control warning, a pre-validation non-STUN packet,
+# and the SCTP abort at teardown — that are expected under the localhost/offline
+# CI environment and are NOT what the test gates on. This legend keeps a reader
+# from mistaking that noise for a failure, and points at the fields in
+# result.txt / stage-latency.json that actually decide pass/fail.
+
+set -euo pipefail
+
+platform="${1:-device}"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+results_dir="${AUTOMOBILE_WEBRTC_RESULTS_DIR:-${repo_root}/scratch/webrtc-device-integration}"
+
+# Echo to the job log, and mirror to the run-summary page when one is available
+# (that is where a reader downloads the artifacts from).
+emit() {
+  printf '%s\n' "$*"
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    printf '%s\n' "$*" >>"${GITHUB_STEP_SUMMARY}"
+  fi
+}
+
+render_legend() {
+  cat <<EOF
+## How to read the ${platform} WebRTC device-capture results
+
+This lane proves the full pipeline works:
+\`capture -> WHIP -> MediaMTX -> WHEP -> browser decode\`. The artifacts uploaded
+below (result.txt, stage-latency.json, chrome.log, mediamtx.log) record it.
+
+### What decides pass/fail
+The test passes when a real frame is decoded in the browser and keeps advancing,
+then the stream tears down cleanly. Concretely, in result.txt / stage-latency.json:
+- \`outcome=passed\` — the capture pipeline reached the browser.
+- \`missingStages\` is empty — all six stages below were observed, in order.
+- \`captureToBrowser=<n>ms\` is present — first browser-decoded frame was timed.
+- \`decodedSize\` width/height > 0 and frames advanced across the sample window.
+
+### The six stages (elapsed from startRequest; +delta from the previous stage)
+- \`startRequest\`      the daemon was asked to start the stream (origin, 0ms).
+- \`whipConnected\`     the device's WHIP publish PeerConnection came up.
+- \`sourceStarted\`     the device began producing encoded frames.
+- \`firstEncodedFrame\` MediaMTX saw the first H264 frame on the path.
+- \`whepConnected\`     the browser's WHEP subscribe PeerConnection came up.
+- \`firstDecodedFrame\` the browser decoded the first frame (== captureToBrowser).
+
+### Lifecycle phases (reported separately from outcome, per #4354)
+\`[phase] ... ok|failed|timedOut\` lines (e.g. pipelineTeardown, fixtureRestore)
+time bounded cleanup. A phase can fail or time out WITHOUT recolouring \`outcome\`:
+outcome describes the capture pipeline, a phase describes teardown/restore. Read
+both — an \`ok\` pipeline with a \`timedOut\` teardown is a real (separate) signal.
+
+### Throughput metrics (measured at the browser, #4349)
+- \`egress=<n>kbps\`   mean inbound-RTP bitrate the reader actually received.
+- \`decodedFps=<n>\`   frames/s the runner sustained, vs the configured \`fps=\`.
+These characterize the pipeline; they are diagnostic, not the pass gate. Source
+vs decoded resolution differ by design (device portrait framing + the
+resolution-aware bitrate cap, #4371) — that is not an error.
+
+### ERROR lines that are EXPECTED here (green runs still print these)
+chrome.log runs Chrome fully offline on a private/localhost network, so:
+- "Failed to resolve address for stun.l.google.com., errorcode: -105" — no
+  public DNS on the runner. Harmless: ICE succeeds on host candidates because
+  every peer is on 127.0.0.1 / the local private net; no STUN reflexive
+  candidate is needed.
+- "Inconsistent congestion control feedback types, ignoring all." — a cosmetic
+  SDP negotiation warning that Chromium logs at ERROR severity (note the literal
+  "Warning:" prefix). WebRTC just ignores CC feedback and proceeds.
+- "Received non-STUN packet from unknown address: ..." — RTP arrived a beat
+  before ICE promoted that peer to a validated candidate. A normal startup race;
+  the candidate validates moments later and media flows.
+- "DcSctpTransport...OnAborted(...User-Initiated Abort...)" — the peer closing
+  the data channel at end of test. This IS the deliberate teardown, matching
+  MediaMTX's "closed: terminated" / "peer connection closed".
+
+### When a run really failed
+Look for \`outcome=failed\`, a non-empty \`missingStages=...\` (which stage was
+never reached localizes the break), a \`[phase] ... failed|timedOut\` line, or an
+absent \`captureToBrowser\`. The benign lines above do NOT indicate any of these.
+EOF
+}
+
+emit "$(render_legend)"
+
+# When the run produced a summary, echo the real numbers right under the legend
+# so the log has both the interpretation and the data.
+if [[ -f "${results_dir}/result.txt" ]]; then
+  emit ""
+  emit "### This run's result.txt"
+  emit '```'
+  emit "$(cat "${results_dir}/result.txt")"
+  emit '```'
+else
+  emit ""
+  emit "(No result.txt at ${results_dir} — the run did not get far enough to write one.)"
+fi

--- a/scripts/webrtc/explain-device-results.sh
+++ b/scripts/webrtc/explain-device-results.sh
@@ -25,38 +25,40 @@ emit() {
 }
 
 render_legend() {
-  cat <<EOF
-## How to read the ${platform} WebRTC device-capture results
-
+  # Heading carries the only interpolation; the body is a quoted heredoc so its
+  # backticks and any future `$(...)` stay literal text rather than running as
+  # command substitution in a script whose whole job is printing static prose.
+  printf '## How to read the %s WebRTC device-capture results\n\n' "${platform}"
+  cat <<'EOF'
 This lane proves the full pipeline works:
-\`capture -> WHIP -> MediaMTX -> WHEP -> browser decode\`. The artifacts uploaded
+`capture -> WHIP -> MediaMTX -> WHEP -> browser decode`. The artifacts uploaded
 below (result.txt, stage-latency.json, chrome.log, mediamtx.log) record it.
 
 ### What decides pass/fail
 The test passes when a real frame is decoded in the browser and keeps advancing,
 then the stream tears down cleanly. Concretely, in result.txt / stage-latency.json:
-- \`outcome=passed\` — the capture pipeline reached the browser.
-- \`missingStages\` is empty — all six stages below were observed, in order.
-- \`captureToBrowser=<n>ms\` is present — first browser-decoded frame was timed.
-- \`decodedSize\` width/height > 0 and frames advanced across the sample window.
+- `outcome=passed` — the capture pipeline reached the browser.
+- `missingStages` is empty — all six stages below were observed, in order.
+- `captureToBrowser=<n>ms` is present — first browser-decoded frame was timed.
+- `decodedSize` width/height > 0 and frames advanced across the sample window.
 
 ### The six stages (elapsed from startRequest; +delta from the previous stage)
-- \`startRequest\`      the daemon was asked to start the stream (origin, 0ms).
-- \`whipConnected\`     the device's WHIP publish PeerConnection came up.
-- \`sourceStarted\`     the device began producing encoded frames.
-- \`firstEncodedFrame\` MediaMTX saw the first H264 frame on the path.
-- \`whepConnected\`     the browser's WHEP subscribe PeerConnection came up.
-- \`firstDecodedFrame\` the browser decoded the first frame (== captureToBrowser).
+- `startRequest`      the daemon was asked to start the stream (origin, 0ms).
+- `whipConnected`     the device's WHIP publish PeerConnection came up.
+- `sourceStarted`     the device began producing encoded frames.
+- `firstEncodedFrame` MediaMTX saw the first H264 frame on the path.
+- `whepConnected`     the browser's WHEP subscribe PeerConnection came up.
+- `firstDecodedFrame` the browser decoded the first frame (== captureToBrowser).
 
 ### Lifecycle phases (reported separately from outcome, per #4354)
-\`[phase] ... ok|failed|timedOut\` lines (e.g. pipelineTeardown, fixtureRestore)
-time bounded cleanup. A phase can fail or time out WITHOUT recolouring \`outcome\`:
+`[phase] ... ok|failed|timedOut` lines (e.g. pipelineTeardown, fixtureRestore)
+time bounded cleanup. A phase can fail or time out WITHOUT recolouring `outcome`:
 outcome describes the capture pipeline, a phase describes teardown/restore. Read
-both — an \`ok\` pipeline with a \`timedOut\` teardown is a real (separate) signal.
+both — an `ok` pipeline with a `timedOut` teardown is a real (separate) signal.
 
 ### Throughput metrics (measured at the browser, #4349)
-- \`egress=<n>kbps\`   mean inbound-RTP bitrate the reader actually received.
-- \`decodedFps=<n>\`   frames/s the runner sustained, vs the configured \`fps=\`.
+- `egress=<n>kbps`   mean inbound-RTP bitrate the reader actually received.
+- `decodedFps=<n>`   frames/s the runner sustained, vs the configured `fps=`.
 These characterize the pipeline; they are diagnostic, not the pass gate. Source
 vs decoded resolution differ by design (device portrait framing + the
 resolution-aware bitrate cap, #4371) — that is not an error.
@@ -78,9 +80,9 @@ chrome.log runs Chrome fully offline on a private/localhost network, so:
   MediaMTX's "closed: terminated" / "peer connection closed".
 
 ### When a run really failed
-Look for \`outcome=failed\`, a non-empty \`missingStages=...\` (which stage was
-never reached localizes the break), a \`[phase] ... failed|timedOut\` line, or an
-absent \`captureToBrowser\`. The benign lines above do NOT indicate any of these.
+Look for `outcome=failed`, a non-empty `missingStages=...` (which stage was
+never reached localizes the break), a `[phase] ... failed|timedOut` line, or an
+absent `captureToBrowser`. The benign lines above do NOT indicate any of these.
 EOF
 }
 

--- a/test/scripts/webrtcDeviceIntegrationWorkflow.test.ts
+++ b/test/scripts/webrtcDeviceIntegrationWorkflow.test.ts
@@ -17,6 +17,7 @@ interface WorkflowDocument {
       id?: string;
       name?: string;
       uses?: string;
+      run?: string;
       if?: string;
       "continue-on-error"?: boolean;
       with?: {
@@ -111,6 +112,29 @@ describe("#4308 device WebRTC integration workflow", () => {
       // collide on a fixed name — and continue-on-error would swallow the 409,
       // silently costing a sample.
       expect(upload?.with?.name).toContain("github.run_attempt");
+    }
+  });
+
+  test("prints the result-reading legend in both lanes, even on failure (#4308)", () => {
+    const document = workflow();
+
+    for (const [jobId, platform] of [
+      ["android-device-webrtc", "android"],
+      ["ios-device-webrtc", "ios"],
+    ] as const) {
+      const steps = document.jobs?.[jobId]?.steps ?? [];
+      const explain = steps.find(step => step.name === "Explain WebRTC device results");
+
+      expect(explain?.if).toBe("always()");
+      expect(explain?.run).toContain("scripts/webrtc/explain-device-results.sh");
+      expect(explain?.run).toContain(platform);
+
+      // The legend documents the artifacts, so it must run after the capture
+      // step that writes them and before they are uploaded away.
+      const explainIndex = steps.findIndex(step => step.name === "Explain WebRTC device results");
+      const uploadIndex = steps.findIndex(step => step.uses?.startsWith("actions/upload-artifact") === true);
+      expect(explainIndex).toBeGreaterThanOrEqual(0);
+      expect(uploadIndex).toBeGreaterThan(explainIndex);
     }
   });
 

--- a/test/scripts/webrtcDeviceIntegrationWorkflow.test.ts
+++ b/test/scripts/webrtcDeviceIntegrationWorkflow.test.ts
@@ -128,6 +128,8 @@ describe("#4308 device WebRTC integration workflow", () => {
       expect(explain?.if).toBe("always()");
       expect(explain?.run).toContain("scripts/webrtc/explain-device-results.sh");
       expect(explain?.run).toContain(platform);
+      // A diagnostic-only step must not redden a green capture lane if it throws.
+      expect(explain?.["continue-on-error"]).toBe(true);
 
       // The legend documents the artifacts, so it must run after the capture
       // step that writes them and before they are uploaded away.


### PR DESCRIPTION
## What

The WebRTC device-capture lanes (Android + iOS) upload `result.txt`,
`stage-latency.json`, `chrome.log`, and `mediamtx.log`. A **passing** run still
prints ERROR lines into `chrome.log`/`mediamtx.log` that look like failures to
anyone opening the artifacts:

- `Failed to resolve address for stun.l.google.com., errorcode: -105` — no public DNS on the runner; ICE succeeds on host candidates anyway.
- `Inconsistent congestion control feedback types, ignoring all.` — a cosmetic SDP warning Chromium logs at ERROR severity.
- `Received non-STUN packet from unknown address: ...` — RTP arriving a beat before ICE promotes the peer; a normal startup race.
- `DcSctpTransport...OnAborted(...User-Initiated Abort...)` — the deliberate connection close at teardown.

## Change

- **New shared script** `scripts/webrtc/explain-device-results.sh` — a shellcheck-clean legend both lanes echo into the job log and mirror to the run summary (`$GITHUB_STEP_SUMMARY`). It explains:
  - what actually gates pass/fail (`outcome`, empty `missingStages`, a present `captureToBrowser`, advancing frames);
  - the six pipeline stages `startRequest → firstDecodedFrame`;
  - the phase-vs-`outcome` split ([#4354](https://github.com/kaeawc/auto-mobile/issues/4354));
  - the throughput metrics ([#4349](https://github.com/kaeawc/auto-mobile/issues/4349)) and why source-vs-decoded resolution differs by design ([#4371](https://github.com/kaeawc/auto-mobile/issues/4371));
  - each expected ERROR line and why it is benign under localhost/offline CI.

  It also echoes the run's own `result.txt` under the legend so the log has interpretation + data together.
- **Workflow wiring** — an `Explain WebRTC device results` step (`if: always()`, so it prints on failed runs too) in **both** the Android and iOS jobs, after the capture step and before the artifact upload.
- **Test** — `webrtcDeviceIntegrationWorkflow.test.ts` asserts both lanes run the script with the right platform arg, `if: always()`, ordered before the upload.

Placed in a shared script rather than duplicated inline: `scripts/webrtc/**` is already in the paths-filter that triggers this workflow, so edits to the legend correctly re-run the lanes.

## Validation

- `bun test test/scripts/webrtcDeviceIntegrationWorkflow.test.ts` — 7 pass.
- `scripts/all_fast_validate_checks.sh --only yaml,shellcheck` — both green.
- Dry-ran the script against a real downloaded iOS artifact set; renders correctly.
