### PR TITLE
test(webrtc): instrument iOS capture startup to localize the #4350 no-frames stall

### DIFF
--- a/ios/screen-capture/Sources/ScreenCaptureCore/CaptureStartupMarker.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/CaptureStartupMarker.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// A stage in the iOS Simulator capture startup sequence, emitted on stderr so a
+/// CI failure can be pinpointed to the stage that stalled.
+///
+/// The helper drives ScreenCaptureKit through `runBlocking`, which parks the main
+/// thread on a semaphore. The pre-existing 10s no-frames hint is scheduled on
+/// `DispatchQueue.main`, so it is never delivered when `startCapture()` itself
+/// hangs — the exact failure in issue #4350, where a run reached WHIP but never
+/// produced a frame and emitted no diagnostic at all. These markers are written
+/// synchronously to stderr around each blocking call, so the last one observed
+/// identifies the stalled stage:
+///
+/// - `resolvingWindow` seen, `resolvedWindow` absent → stalled in window discovery
+/// - `startingCapture` seen, `captureStarted` absent → stalled in `startCapture()`
+/// - `captureStarted` seen, `firstFrame` absent      → started but delivered no frames
+public enum CaptureStartupPhase: Equatable {
+    case resolvingWindow(windowID: UInt32)
+    case resolvedWindow(windowID: UInt32, width: Int, height: Int)
+    case startingCapture(windowID: UInt32, fps: Int)
+    case captureStarted(windowID: UInt32)
+    case firstFrame(windowID: UInt32, width: Int, height: Int)
+}
+
+/// Formats {@link CaptureStartupPhase} into a stable, greppable stderr line.
+public enum CaptureStartupMarker {
+    /// Line prefix. Deliberately not `error:` — the TS supervisor
+    /// (`IosH264Source`) treats an `error:`-prefixed line as a fatal helper error
+    /// — and free of the `no frames received` token it matches as a permission
+    /// denial. See `CaptureStartupMarkerTests`.
+    public static let prefix = "capture-phase:"
+
+    public static func line(_ phase: CaptureStartupPhase) -> String {
+        switch phase {
+        case let .resolvingWindow(windowID):
+            return "\(prefix) resolving-window id=\(windowID)"
+        case let .resolvedWindow(windowID, width, height):
+            return "\(prefix) resolved-window id=\(windowID) size=\(width)x\(height)"
+        case let .startingCapture(windowID, fps):
+            return "\(prefix) starting-capture id=\(windowID) fps=\(fps)"
+        case let .captureStarted(windowID):
+            return "\(prefix) capture-started id=\(windowID)"
+        case let .firstFrame(windowID, width, height):
+            return "\(prefix) first-frame id=\(windowID) size=\(width)x\(height)"
+        }
+    }
+}

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
@@ -18,6 +18,7 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
     private var hasReceivedFrame = false
     private var fps: Int = CommandLineOptions.defaultSimulatorFPS
     private var audioEnabled = false
+    private var windowID: UInt32 = 0
 
     init(writer: FrameWriter, onFatalError: @escaping (Error) -> Void) {
         self.writer = writer
@@ -27,6 +28,7 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
     func start(window: SCWindow, fps: Int, audio: Bool) async throws {
         self.fps = fps
         audioEnabled = audio
+        windowID = window.windowID
         let filter = SCContentFilter(desktopIndependentWindow: window)
         let config = SimulatorCaptureSession.makeConfiguration(window: window, fps: fps, audio: audio)
         configuredPixelWidth = config.width
@@ -85,6 +87,16 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
         }
 
         if writer.write(sampleBuffer: sampleBuffer) {
+            if !hasReceivedFrame {
+                // Emitted from the frame queue, not the (possibly parked) main
+                // thread, so it survives to confirm the source actually started
+                // delivering frames — the "captureStarted but no firstFrame"
+                // distinction issue #4350 needs.
+                let marker = CaptureStartupMarker.line(
+                    .firstFrame(windowID: windowID, width: actualWidth, height: actualHeight)
+                )
+                FileHandle.standardError.write(Data("\(marker)\n".utf8))
+            }
             hasReceivedFrame = true
         }
     }

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
@@ -112,10 +112,20 @@ case .captureSimulator(let windowID, let fps, let audio):
         }
     }
 
+    // Emit stage markers synchronously to stderr before each blocking call. When
+    // `startCapture()` hangs, `runBlocking` parks the main thread, so the 10s
+    // permission hint (scheduled on the main queue) never fires — the last marker
+    // observed is then the only signal of which stage stalled (issue #4350).
+    logError(CaptureStartupMarker.line(.resolvingWindow(windowID: windowID)))
     let window: SCWindow
     switch runBlocking({ try await SimulatorWindowDiscovery.find(windowID: windowID) }) {
     case .success(.some(let resolved)):
         window = resolved
+        logError(CaptureStartupMarker.line(.resolvedWindow(
+            windowID: windowID,
+            width: Int(resolved.frame.width),
+            height: Int(resolved.frame.height)
+        )))
     case .success(.none):
         logError("error: no window with CGWindowID \(windowID)")
         exit(1)
@@ -130,12 +140,14 @@ case .captureSimulator(let windowID, let fps, let audio):
         logError("error: ScreenCaptureKit stream stopped: \(error)")
     }
 
+    logError(CaptureStartupMarker.line(.startingCapture(windowID: windowID, fps: fps)))
     if case .failure(let error) = runBlocking({
         try await simSession.start(window: window, fps: fps, audio: audio)
     }) {
         logError("error: failed to start simulator capture: \(error)")
         exit(1)
     }
+    logError(CaptureStartupMarker.line(.captureStarted(windowID: windowID)))
 
     // ScreenCaptureKit silently emits no frames when the host process lacks
     // Screen Recording permission — there's no error to surface. Emit a hint

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/CaptureStartupMarkerTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/CaptureStartupMarkerTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import ScreenCaptureCore
+
+final class CaptureStartupMarkerTests: XCTestCase {
+    func testFormatsEachPhaseWithStablePrefix() {
+        XCTAssertEqual(
+            CaptureStartupMarker.line(.resolvingWindow(windowID: 32)),
+            "capture-phase: resolving-window id=32"
+        )
+        XCTAssertEqual(
+            CaptureStartupMarker.line(.resolvedWindow(windowID: 32, width: 402, height: 874)),
+            "capture-phase: resolved-window id=32 size=402x874"
+        )
+        XCTAssertEqual(
+            CaptureStartupMarker.line(.startingCapture(windowID: 32, fps: 15)),
+            "capture-phase: starting-capture id=32 fps=15"
+        )
+        XCTAssertEqual(
+            CaptureStartupMarker.line(.captureStarted(windowID: 32)),
+            "capture-phase: capture-started id=32"
+        )
+        XCTAssertEqual(
+            CaptureStartupMarker.line(.firstFrame(windowID: 32, width: 804, height: 1748)),
+            "capture-phase: first-frame id=32 size=804x1748"
+        )
+    }
+
+    func testPrefixConstant() {
+        XCTAssertEqual(CaptureStartupMarker.prefix, "capture-phase:")
+    }
+
+    /// The TS supervisor (`IosH264Source`) treats an `error:`-prefixed helper
+    /// line as fatal and a line containing "no frames received" as a permission
+    /// denial. Diagnostic markers must trip neither, or they would abort or
+    /// misreport the capture (issue #4350).
+    func testMarkersAreNotMisclassifiedBySupervisor() {
+        let lines = [
+            CaptureStartupMarker.line(.resolvingWindow(windowID: 1)),
+            CaptureStartupMarker.line(.resolvedWindow(windowID: 1, width: 2, height: 3)),
+            CaptureStartupMarker.line(.startingCapture(windowID: 1, fps: 5)),
+            CaptureStartupMarker.line(.captureStarted(windowID: 1)),
+            CaptureStartupMarker.line(.firstFrame(windowID: 1, width: 2, height: 3)),
+        ]
+        for line in lines {
+            XCTAssertFalse(
+                line.trimmingCharacters(in: .whitespaces).lowercased().hasPrefix("error:"),
+                "marker must not be classified as a fatal helper error: \(line)"
+            )
+            XCTAssertFalse(
+                line.lowercased().contains("no frames received"),
+                "marker must not be classified as a permission denial: \(line)"
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The iOS device-capture lane intermittently fails with `capture source did not deliver H.264 frames` ([#4350](https://github.com/kaeawc/auto-mobile/issues/4350)). A [diagnostic batch](https://github.com/kaeawc/auto-mobile/issues/4350#issuecomment-5069984391) on the corrected [#4347](https://github.com/kaeawc/auto-mobile/pull/4347) instrumentation localized the failure to **`IosH264Source` startup**: under failure `sourceStarted` is never reached and the helper delivers no frame — yet it emits *no diagnostic at all*, because the helper's 10s no-frames hint is scheduled on `DispatchQueue.main`, which `runBlocking` parks while `SCStream.startCapture()` is in flight. A hung start is therefore silent.

This PR is **diagnostics-first** (the direction chosen for #4350): it adds greppable stderr markers around each blocking startup stage so a future occurrence identifies the stalled stage — **without changing capture behavior** and without needing a real device to test. It does not fix the stall; #4350 stays open pending a confirming CI run.

## Changes

- New `CaptureStartupMarker` (in `ScreenCaptureCore`) formats stable, greppable stderr lines for each startup stage:
  - `resolvingWindow` → `resolvedWindow` — ScreenCaptureKit window discovery
  - `startingCapture` → `captureStarted` — `SCStream.startCapture()`
  - `firstFrame` — first delivered frame
- `main.swift` emits the discovery/start markers synchronously **before each blocking call**, so they survive even when the main thread is parked in `runBlocking`. The last marker observed pinpoints the stalled stage.
- `SimulatorCaptureSession` emits `firstFrame` from the **frame queue** (not the possibly-parked main thread), giving the "`captureStarted` but no `firstFrame`" signal that distinguishes a hung start from started-but-zero-frames.

Interpreting a future failure log:
- `resolvingWindow` seen, `resolvedWindow` absent → stalled in window discovery
- `startingCapture` seen, `captureStarted` absent → stalled in `startCapture()`
- `captureStarted` seen, `firstFrame` absent → started but delivered no frames

## Linked Issue

Refs [#4350](https://github.com/kaeawc/auto-mobile/issues/4350) — intentionally **not** `Closes`; this localizes the failure, it does not fix it.

## Bug / Regression Context

- **Prior attempts:** [#4347](https://github.com/kaeawc/auto-mobile/pull/4347) corrected the `sourceStarted` mark; [#4354](https://github.com/kaeawc/auto-mobile/issues/4354) fixed the teardown-hook mis-attribution that inflated the apparent failure rate.
- **Observed symptom:** WHIP connects, then no H.264 frame within the 15s first-frame timeout; the helper logs nothing, so the stalled stage was previously unknowable.
- **Repro conditions:** intermittent (~1/6 in a 6-run `main` batch) on hosted `macos26` runners; the failing run reached `whipConnected` in 1374ms then `missing=sourceStarted,…`.

## Validation

- [x] `swift build` + `swift test` for `ios/screen-capture` pass (41 tests, incl. new `CaptureStartupMarkerTests`)
- [x] `swiftlint` clean on all touched files
- [x] New marker code is unit-tested and does not depend on a real device; markers are pinned to not be misclassified by the TS supervisor as a fatal `error:` line or a "no frames received" permission denial
- [x] No TypeScript changed (typecheck baseline gate unaffected)
- [ ] Not device-verified locally — no capture hardware in this environment; the added markers are exercised by the `webrtc-device-integration.yml` iOS lane

## Follow-ups

Once merged, dispatch an iOS lane batch to capture a failure log with the new markers and confirm which stage stalls; then decide the startup-hardening fix (bound `startCapture()` with its own timeout, make the 10s hint fire off the blocked main thread, re-query the window list on reconnect) on [#4350](https://github.com/kaeawc/auto-mobile/issues/4350).
