### PR TITLE
fix(webrtc): scope the iOS default -b:v to Simulator capture (#4375)

### DIFF
--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -175,6 +175,7 @@ export class IosH264Source implements H264CaptureSource {
   private readonly firstFrameTimeoutMs: number;
 
   private helper: IosFrameCaptureHelper | null = null;
+  private captureKind: CaptureTarget["kind"] | null = null;
   private encoder: IosH264EncoderProcess | null = null;
   private encoderSize: EncoderSize | null = null;
   private encoderBackpressured = false;
@@ -229,6 +230,7 @@ export class IosH264Source implements H264CaptureSource {
       });
       await validateFfmpegAvailability(this.ffmpegClient, this.ffmpegPath, this.options.commandRunner);
       const target = await this.resolveCaptureTarget(helperPath);
+      this.captureKind = target.kind;
       if (!this.isActive()) {
         return;
       }
@@ -587,18 +589,30 @@ export class IosH264Source implements H264CaptureSource {
       "-forced-idr",
       "1"
     );
-    // Always emit an explicit target bitrate. Left unset, VideoToolbox picks a
-    // default that scales with resolution x rate with no ceiling — and since
-    // #4346 stopped upscaling toward 1920x1080, a Retina host now encodes the
-    // native backing store, so egress can climb several-fold (#4349). Honor an
-    // operator override; otherwise budget from the *encoded* size (post any
-    // downscale) and the declared rate.
+    // Resolve the target encoder bitrate. An operator override
+    // (`AUTOMOBILE_WEBRTC_BITRATE_KBPS`) always wins, on either capture kind.
+    // Otherwise the resolution-derived default is applied *only* to a Simulator
+    // target: #4349 justified the 0.1 bpp budget entirely from Simulator
+    // screen-content measurements, so a physical device — whose higher-entropy
+    // content 0.1 bpp may under-serve — falls back to VideoToolbox's own default
+    // rather than inheriting a Simulator-scoped cap (#4375).
+    //
+    // Note on what this bounds: `-b:v` is an *average* (ABR) target for
+    // h264_videotoolbox, not a peak ceiling — egress peaks above it by design.
+    // The default therefore bounds *average* egress, which is the intended goal.
+    // Bounding *peak* would require `-maxrate`/`-bufsize` (VideoToolbox
+    // DataRateLimits), whose h264_videotoolbox support is ffmpeg-version-
+    // dependent and unverified on our builds; that is deferred to a follow-up
+    // rather than added speculatively (#4375).
     const encodedSize = scale ?? size;
+    const explicitBitrateBps =
+      this.options.bitrateBps && this.options.bitrateBps > 0 ? this.options.bitrateBps : undefined;
     const bitrateBps =
-      this.options.bitrateBps && this.options.bitrateBps > 0
-        ? this.options.bitrateBps
-        : defaultIosBitrateBps(encodedSize, this.fps);
-    args.push("-b:v", String(Math.round(bitrateBps)));
+      explicitBitrateBps ??
+      (this.captureKind === "simulator" ? defaultIosBitrateBps(encodedSize, this.fps) : undefined);
+    if (bitrateBps !== undefined) {
+      args.push("-b:v", String(Math.round(bitrateBps)));
+    }
     args.push("-f", "h264", "pipe:1");
     return args;
   }

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -484,6 +484,30 @@ describe("IosH264Source", () => {
     );
   });
 
+  test("does not apply the resolution-derived default bitrate to a physical device (#4375)", async () => {
+    // #4349 justified the 0.1 bpp default entirely from Simulator screen-content
+    // measurements, so a physical iPhone must not inherit it — with no operator
+    // override it falls back to VideoToolbox's own default (no -b:v emitted).
+    const { source, helper, encoderSpawns } = createHarness(IOS_DEVICE);
+
+    await startWithFrame(source, helper, frame(750, 1334, 0x11));
+
+    expect(encoderSpawns[0].args).not.toContain("-b:v");
+  });
+
+  test("still honors an explicit bitrate override for a physical device (#4375)", async () => {
+    // Only the resolution-derived *default* is Simulator-scoped; an operator
+    // ceiling (AUTOMOBILE_WEBRTC_BITRATE_KBPS -> bitrateBps) still applies to a
+    // physical device.
+    const { source, helper, encoderSpawns } = createHarnessWithOverrides({ bitrateBps: 900_000 });
+
+    await startWithFrame(source, helper, frame(750, 1334, 0x11));
+
+    const rateIndex = encoderSpawns[0].args.indexOf("-b:v");
+    expect(rateIndex).toBeGreaterThanOrEqual(0);
+    expect(encoderSpawns[0].args[rateIndex + 1]).toBe("900000");
+  });
+
   test("packs padded BGRA frame rows before writing rawvideo to ffmpeg", async () => {
     const { source, helper, encoder } = createHarness();
     const padded = frame(2, 2, 0);


### PR DESCRIPTION
## Summary

Two follow-ups from [PR #4371](https://github.com/kaeawc/auto-mobile/pull/4371) (which added the resolution-aware default `-b:v` for iOS WebRTC under [#4349](https://github.com/kaeawc/auto-mobile/issues/4349)).

**Follow-up 2 (implemented) — scope the default to Simulator capture.** `buildFfmpegArgs` applied `defaultIosBitrateBps` unconditionally, but `resolveCaptureTarget` also returns a `kind: "device"` target. So a physical iPhone inherited the `0.1` bpp budget that was justified entirely from Simulator screen-content measurements — content whose higher entropy `0.1` bpp may under-serve. The resolution-derived default is now gated to `kind === "simulator"`; a physical device falls back to VideoToolbox's own default (no `-b:v`) unless an operator override is set. The operator override (`AUTOMOBILE_WEBRTC_BITRATE_KBPS` → `bitrateBps`) stays unconditional and still applies to both capture kinds.

**Follow-up 1 (decision recorded) — average vs. peak egress.** `-b:v` on `h264_videotoolbox` is an *average* (ABR) target, so tuning the `0.1` bpp constant can't bound *peak* egress — egress peaks above `-b:v` by design. The default therefore bounds **average** egress, which is the intended goal; this is now documented inline in `buildFfmpegArgs`. The issue's measured 405 kbps sample is explicitly *not* a clean over-average violation (includes RTP overhead, sampled over a deliberately high-motion 400 ms window, reflects only 11.7/15 delivered fps). Bounding *peak* would require `-maxrate`/`-bufsize` (VideoToolbox `DataRateLimits`), whose `h264_videotoolbox` support is ffmpeg-version-dependent and unverified on our builds — deferred to a follow-up rather than added speculatively.

## Linked Issue

Closes #4375

## Changes

- `src/features/webrtc/IosH264Source.ts` — persist the resolved `CaptureTarget.kind` on the source; in `buildFfmpegArgs`, emit the resolution-derived default `-b:v` only for a Simulator target. Override path unchanged. Comment records the average-vs-peak decision.
- `test/features/webrtc/IosH264Source.test.ts` — pin that a physical device gets no default `-b:v`, and that an explicit override still emits `-b:v` on a physical device.

## Validation

- [x] `bun test` — 9205 pass, 0 fail (full suite); `IosH264Source.test.ts` 57 pass in ~150 ms
- [x] `bun run lint` (+ all boundary checks, incl. ffmpeg-execution-boundary)
- [x] `bun run build`
- [x] `bun run typecheck` — no new errors (the local-only `ajv`/`ajv-formats` drift in `PlanSchemaValidator.ts` cleared with `bun install --frozen-lockfile`; CI runs on a clean install)
- [x] New code uses interfaces + fakes + injected clock

## Acceptance criteria

- [x] Resolution-derived default bitrate applied only to `kind: "simulator"` targets; physical device no longer inherits it.
- [x] Operator override still emits `-b:v` for both simulator and device.
- [x] Average-vs-peak decision recorded (bounds average; peak lever deferred).

## Follow-ups

- [ ] Verify `-maxrate`/`-bufsize` on `h264_videotoolbox` before any *peak* egress ceiling, and collect an iOS egress p50/p95 baseline — tracked in [#4387](https://github.com/kaeawc/auto-mobile/issues/4387).

