### PR TITLE
test(webrtc): assert iOS WHEP PLI recovery to a fresh IDR on the hosted device lane

### DIFF
--- a/test/helpers/captureStageTimeline.test.ts
+++ b/test/helpers/captureStageTimeline.test.ts
@@ -7,9 +7,11 @@ import {
   decodedFpsBetween,
   egressKbpsBetween,
   formatCaptureStageRecord,
+  keyframeRecovered,
   monotonicNowMs,
   type CaptureStageContext,
   type EgressSample,
+  type KeyframeRecoverySample,
 } from "./captureStageTimeline";
 
 /** Deterministic monotonic clock: advance() is the only way time moves. */
@@ -472,5 +474,48 @@ describe("#4349 egress bitrate and decoded fps between two inbound-rtp samples",
   test("clamps a counter that reset between samples to zero rather than reporting negative", () => {
     expect(egressKbpsBetween(sample(5_000, 0, 1_000), sample(1_000, 0, 3_000))).toBe(0);
     expect(decodedFpsBetween(sample(0, 90, 1_000), sample(0, 10, 3_000))).toBe(0);
+  });
+});
+
+describe("#4376 WHEP keyframe recovery after a relayed PLI", () => {
+  const sample = (keyFramesDecoded: number, framesDecoded: number): KeyframeRecoverySample => ({
+    keyFramesDecoded,
+    framesDecoded,
+  });
+
+  test("recovers when a fresh IDR is decoded on a newly delivered frame", () => {
+    // AC1: a WHEP viewer that relayed a PLI receives a decodable SPS/PPS + IDR —
+    // observed as keyFramesDecoded advancing — carried by a delivered frame.
+    expect(keyframeRecovered(sample(1, 30), sample(2, 31))).toBe(true);
+  });
+
+  test("recovers a fresh viewer that starts from no decoded frames at all", () => {
+    // A recovery viewer subscribes cold: its baseline is zero on both counters,
+    // and connecting relays the PLI that forces the fresh IDR.
+    expect(keyframeRecovered(sample(0, 0), sample(1, 1))).toBe(true);
+  });
+
+  test("does not recover until a delivered frame carries the IDR (delivery shortfall)", () => {
+    // AC2: under a static Simulator screen the restarted encoder's IDR only
+    // rides out on the next delivered frame. A keyframe counter that advances
+    // without framesDecoded advancing cannot happen on the wire, but the check
+    // is defined on the delivered frame — not a fixed wall clock — so a stalled
+    // delivery is reported as "not yet recovered", never as recovered.
+    expect(keyframeRecovered(sample(1, 30), sample(2, 30))).toBe(false);
+  });
+
+  test("does not treat ordinary inter-frame decode progress as a recovery", () => {
+    // Frames keep flowing without a new keyframe: no fresh IDR was delivered.
+    expect(keyframeRecovered(sample(1, 30), sample(1, 45))).toBe(false);
+  });
+
+  test("does not recover when nothing changed between the two samples", () => {
+    expect(keyframeRecovered(sample(1, 30), sample(1, 30))).toBe(false);
+    expect(keyframeRecovered(sample(0, 0), sample(0, 0))).toBe(false);
+  });
+
+  test("clamps a reset keyframe counter to no-recovery rather than a spurious pass", () => {
+    // A reconnect that reset the reader's counters must not read as a recovery.
+    expect(keyframeRecovered(sample(5, 90), sample(1, 91))).toBe(false);
   });
 });

--- a/test/helpers/captureStageTimeline.ts
+++ b/test/helpers/captureStageTimeline.ts
@@ -191,6 +191,43 @@ export function decodedFpsBetween(first: EgressSample, second: EgressSample): nu
   return (frames / windowMs) * 1_000;
 }
 
+/**
+ * Two counters read from a WHEP viewer's inbound-RTP video stat, used to decide
+ * whether a relayed PLI recovered the stream to a fresh, self-decodable IDR
+ * (#4376). Cumulative, like {@link EgressSample}, so recovery is judged from two
+ * readings bracketing the request rather than from a single instant.
+ */
+export interface KeyframeRecoverySample {
+  /** Cumulative count of keyframes (SPS/PPS + IDR) the reader has decoded. */
+  keyFramesDecoded: number;
+  /** Cumulative count of all frames the reader has decoded. */
+  framesDecoded: number;
+}
+
+/**
+ * Whether a WHEP viewer recovered to a fresh, self-decodable IDR after a relayed
+ * PLI (#4376), comparing a baseline reading to a later one.
+ *
+ * Recovery is a *new* keyframe (`keyFramesDecoded` advanced — the reader decoded
+ * a fresh SPS/PPS + IDR, AC1) that rode out on a *delivered* frame
+ * (`framesDecoded` advanced). Requiring both is the delivery-shortfall tolerance
+ * (AC2): `IosH264Source.requestKeyFrame` restarts the encoder, but under a
+ * static Simulator screen its IDR only reaches the viewer on the next delivered
+ * frame — so the recovery point is defined on that delivered frame, never on a
+ * fixed wall clock. A reader whose counters reset (reconnect) reads as
+ * no-recovery rather than a spurious pass, since neither counter strictly
+ * advances.
+ */
+export function keyframeRecovered(
+  baseline: KeyframeRecoverySample,
+  latest: KeyframeRecoverySample
+): boolean {
+  return (
+    latest.keyFramesDecoded > baseline.keyFramesDecoded &&
+    latest.framesDecoded > baseline.framesDecoded
+  );
+}
+
 /** Monotonic millisecond reader used when none is injected. */
 export function monotonicNowMs(): number {
   return performance.now();

--- a/test/integration/webrtcDeviceCapture.integration.test.ts
+++ b/test/integration/webrtcDeviceCapture.integration.test.ts
@@ -10,16 +10,19 @@ import WebSocket from "ws";
 import { sendWebRtcStreamRequest } from "../../src/daemon/webrtcStreamClient";
 import { SimCtlClient } from "../../src/utils/ios-cmdline-tools/SimCtlClient";
 import { WEBRTC_IOS_SIMULATOR_FPS_DEFAULT } from "../../src/features/webrtc/webrtcStreamingConfig";
+import { IOS_FORCED_KEYFRAME_MIN_INTERVAL_MS } from "../../src/features/webrtc/IosH264Source";
 import {
   CaptureStageTimeline,
   captureRunIdentity,
   decodedFpsBetween,
   egressKbpsBetween,
   formatCaptureStageRecord,
+  keyframeRecovered,
   type CaptureDimensions,
   type CaptureStage,
   type CaptureStageContext,
   type EgressSample,
+  type KeyframeRecoverySample,
 } from "../helpers/captureStageTimeline";
 
 const execFileAsync = promisify(execFile);
@@ -249,6 +252,34 @@ async function waitForDecodedFrames(cdp: CdpClient, minimum: number, message: st
     const diagnostics = await readerDiagnostics(cdp).catch(() => undefined);
     throw new Error(`${message}; reader diagnostics=${JSON.stringify(diagnostics ?? "unavailable")}`);
   }
+}
+
+/**
+ * Cumulative keyframe/frame decode counters for the recovery viewer — the most
+ * recent WHEP subscription, so the last peer connection the hook recorded
+ * (#4376). Returns null when no inbound-video stat is available yet (the fresh
+ * subscription has not decoded anything), which the caller treats as "not yet
+ * recovered" rather than a failure.
+ */
+async function recoverySample(cdp: CdpClient): Promise<KeyframeRecoverySample | null> {
+  const expression = `(async () => {
+    const connections = Array.from(window.__automobilePeerConnections ?? []);
+    const latest = connections[connections.length - 1];
+    if (!latest) { return null; }
+    const reports = Array.from((await latest.getStats()).values());
+    const inbound = reports.find(stat => stat.type === "inbound-rtp" && stat.kind === "video");
+    if (!inbound) { return null; }
+    return {
+      keyFramesDecoded: inbound.keyFramesDecoded ?? 0,
+      framesDecoded: inbound.framesDecoded ?? 0,
+    };
+  })()`;
+  const response = await cdp.command("Runtime.evaluate", {
+    expression,
+    awaitPromise: true,
+    returnByValue: true,
+  });
+  return (response.result?.result?.value as KeyframeRecoverySample | null) ?? null;
 }
 
 function androidDeviceId(): string {
@@ -543,6 +574,45 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
         }
       } catch (error) {
         console.warn(`[#4349] could not sample egress bitrate / decoded fps: ${error}`);
+      }
+      // #4376: prove the on-demand keyframe path end-to-end. iOS only — the path
+      // under a delivery shortfall is IosH264Source.requestKeyFrame (encoder
+      // restart, PR #4374); AndroidH264Source has its own keyframe path, out of
+      // scope here. Fresh viewer subscribing relays a PLI upstream through
+      // MediaMTX to the WHIP publisher, which calls source.requestKeyFrame().
+      if (platform === "ios") {
+        await timeline.runPhase("keyframeRecovery", async () => {
+          // A brand-new WHEP subscription is the relayed PLI: it renegotiates
+          // with MediaMTX, which requests a keyframe upstream. The recovery
+          // viewer starts cold, so its baseline is zero on both counters.
+          await subscribeReader(cdp!);
+          const baseline: KeyframeRecoverySample = { keyFramesDecoded: 0, framesDecoded: 0 };
+          // Under a static Simulator screen the restarted encoder's IDR only
+          // rides out on the next delivered frame (SimulatorCaptureSession drops
+          // non-`.complete` frames), so keep driving a visible change and poll
+          // for the fresh keyframe on that delivered frame — never a fixed
+          // wall-clock sleep. The throttle floors one restart per
+          // IOS_FORCED_KEYFRAME_MIN_INTERVAL_MS; allow delivery slack on top so a
+          // shortfall does not flake the lane.
+          let recovered: KeyframeRecoverySample | null = null;
+          let toggle = false;
+          await waitFor(
+            async () => {
+              toggle = !toggle;
+              await (toggle ? changeFixture() : launchFixture());
+              const latest = await recoverySample(cdp!);
+              if (latest && keyframeRecovered(baseline, latest)) {
+                recovered = latest;
+                return true;
+              }
+              return false;
+            },
+            `iOS WHEP viewer did not recover to a fresh IDR within ~${IOS_FORCED_KEYFRAME_MIN_INTERVAL_MS}ms of the relayed PLI`,
+            IOS_FORCED_KEYFRAME_MIN_INTERVAL_MS + 30_000
+          );
+          expect(recovered).not.toBeNull();
+          expect(keyframeRecovered(baseline, recovered!)).toBe(true);
+        });
       }
       const stopped = await sendWebRtcStreamRequest(
         { action: "stop", id: `${streamId}-stop`, streamId },


### PR DESCRIPTION
## Summary

Adds the missing end-to-end assertion for [PR #4374](https://github.com/kaeawc/auto-mobile/pull/4374) / [issue #4348](https://github.com/kaeawc/auto-mobile/issues/4348): on the hosted iOS lane, a WHEP viewer that relays a PLI recovers to a fresh, self-decodable IDR.

`#4374` gave `IosH264Source` a real `requestKeyFrame()` that restarts the ffmpeg encoder so a relayed WHEP PLI forces a fresh IDR. That mechanism is fully fake-encoder/fake-timer covered, and `webrtcStreamManager` relaying `onKeyFrameRequest` → `source.requestKeyFrame()` is pinned. What was **not** covered is the real path: nothing asserted that on a live Simulator, a WHEP viewer's PLI relayed through MediaMTX actually recovers the browser to a fresh IDR within the throttle interval. The hosted lane asserted frame growth and a changed pixel sample, but not keyframe-on-demand recovery.

## Changes

- **`test/helpers/captureStageTimeline.ts`** — a hermetic `keyframeRecovered(baseline, latest)` helper (+ `KeyframeRecoverySample`). Recovery is a *new* keyframe (`keyFramesDecoded` advanced — a decoded SPS/PPS + IDR) carried on a *delivered* frame (`framesDecoded` advanced). Requiring both is the delivery-shortfall tolerance: under a static Simulator screen the restarted encoder's IDR only rides out on the next delivered frame, so recovery is defined on that frame, never on a fixed wall clock. A reset counter (reconnect) reads as no-recovery, not a spurious pass.
- **`test/integration/webrtcDeviceCapture.integration.test.ts`** — an iOS-gated block in the device-capture lane: a fresh WHEP subscription relays a PLI upstream through MediaMTX to the WHIP publisher, the lane keeps driving a visible change and polls the recovery viewer's inbound-rtp until `keyframeRecovered`, bounded by `IOS_FORCED_KEYFRAME_MIN_INTERVAL_MS` plus delivery slack and timed as its own `keyframeRecovery` phase. Android keeps its existing behavior (its keyframe path is out of scope).

## Acceptance criteria

| Criterion | Where it is satisfied |
|---|---|
| Extend the hosted iOS lane to connect a WHEP viewer, relay a PLI, and assert the viewer receives a decodable IDR (SPS/PPS + IDR) within roughly `IOS_FORCED_KEYFRAME_MIN_INTERVAL_MS` | iOS-gated `keyframeRecovery` phase in the device-capture lane; `keyframeRecovered` requires `keyFramesDecoded` to advance (a decoded IDR). Logic pinned by `keyframeRecovered` unit tests. |
| Tolerate the delivery-shortfall case (mostly-static screen): the IDR arrives on the next delivered frame after the restart, not a fixed wall clock | `keyframeRecovered` also requires `framesDecoded` to advance; the lane drives a visible change and polls for the next delivered frame rather than sleeping. Pinned by the "does not recover until a delivered frame carries the IDR" unit test. |
| Keep it in the hosted-device lane only; no real-device dependency in the unit suite | The assertion lives inside `describeIntegration` (gated by `AUTOMOBILE_WEBRTC_DEVICE_INTEGRATION=1`) + `platform === "ios"`; the unit suite gets only the pure, device-free helper. |

## Linked Issue

Closes #4376

## Validation

- [x] `bun run lint` passes (incl. all boundary guards)
- [x] `bun test` — **9209 pass / 0 fail** across 714 files
- [x] `bun run build` passes
- [x] `bun run typecheck` — no new errors (211 baseline)
- [x] New helper is a pure function with hermetic unit tests (<100ms); no device dependency in the unit suite
- [x] New helper tests confirmed **red before** the implementation (missing `keyframeRecovered` export), green after

## Device Verification

Not run locally: the hosted lane needs a macOS host with Screen Recording permission, a booted Simulator, a MediaMTX runner, and Chrome — the same infra every other assertion in this file requires. The end-to-end wiring validates in the hosted `iOS Device Capture to WHEP` CI lane; the recovery *decision logic* is fully unit-pinned by the `keyframeRecovered` tests.

## Follow-ups

None.
