### PR TITLE
fix(video): sustain idle-screen frames for late WebRTC viewers (#4383)

### DIFF
--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/FrameHeartbeat.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/FrameHeartbeat.kt
@@ -24,6 +24,12 @@ class FrameHeartbeat(
   private val idleForceIntervalMs: Long = DEFAULT_IDLE_FORCE_INTERVAL_MS,
   /** After a keyframe request, force a submission if no frame lands within this window. */
   private val keyFrameGraceMs: Long = DEFAULT_KEY_FRAME_GRACE_MS,
+  /**
+   * Cap consecutive grace-window nudges for one unsatisfied request. If this many fire without a
+   * frame the request is abandoned and the slower idle cadence takes over, so a genuinely wedged or
+   * undecodable surface cannot spin a fast `setSurface` storm to system_server forever.
+   */
+  private val maxKeyFrameNudges: Int = DEFAULT_MAX_KEY_FRAME_NUDGES,
 ) {
   /** Injectable monotonic clock; production uses `SystemClock.uptimeMillis()`. */
   fun interface Clock {
@@ -36,11 +42,15 @@ class FrameHeartbeat(
   /** When an unsatisfied keyframe request began, or null when none is outstanding. */
   private var keyFramePendingSinceMs: Long? = null
 
+  /** Grace nudges already fired for the outstanding request; bounded by [maxKeyFrameNudges]. */
+  private var keyFrameNudges = 0
+
   /** Baseline the timers at capture start so the first idle nudge is a full interval out. */
   @Synchronized
   fun start() {
     lastActivityMs = clock.nowMs()
     keyFramePendingSinceMs = null
+    keyFrameNudges = 0
   }
 
   /** Record that the encoder emitted a frame: resets idle timing and clears any request. */
@@ -48,6 +58,7 @@ class FrameHeartbeat(
   fun onFrameEmitted() {
     lastActivityMs = clock.nowMs()
     keyFramePendingSinceMs = null
+    keyFrameNudges = 0
   }
 
   /** Record a keyframe request (a relayed WHEP viewer PLI). Coalesces repeats. */
@@ -55,13 +66,14 @@ class FrameHeartbeat(
   fun onKeyFrameRequested() {
     if (keyFramePendingSinceMs == null) {
       keyFramePendingSinceMs = clock.nowMs()
+      keyFrameNudges = 0
     }
   }
 
   /**
    * @return true if the caller should force a fresh surface submission now. Firing advances the
    *   internal timers so a wedged surface is nudged at most once per interval (idle) or once per
-   *   grace window (pending keyframe) until a frame lands.
+   *   grace window (pending keyframe, up to [maxKeyFrameNudges]) until a frame lands.
    */
   @Synchronized
   fun poll(): Boolean {
@@ -73,10 +85,17 @@ class FrameHeartbeat(
       return false
     }
     lastActivityMs = now
-    if (pending != null) {
-      // Keep the request outstanding but re-throttle: if the nudge produces nothing,
-      // fire again after another grace window rather than every poll.
-      keyFramePendingSinceMs = now
+    if (dueForKeyFrame) {
+      keyFrameNudges++
+      if (keyFrameNudges >= maxKeyFrameNudges) {
+        // Grace budget spent with no frame: abandon the fast retry and let the idle cadence
+        // carry it, so an undecodable surface cannot spin setSurface at the grace rate forever.
+        keyFramePendingSinceMs = null
+        keyFrameNudges = 0
+      } else {
+        // Keep the request outstanding but re-throttle to the next grace window.
+        keyFramePendingSinceMs = now
+      }
     }
     return true
   }
@@ -84,5 +103,6 @@ class FrameHeartbeat(
   companion object {
     const val DEFAULT_IDLE_FORCE_INTERVAL_MS = 1_000L
     const val DEFAULT_KEY_FRAME_GRACE_MS = 150L
+    const val DEFAULT_MAX_KEY_FRAME_NUDGES = 4
   }
 }

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/FrameHeartbeat.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/FrameHeartbeat.kt
@@ -1,0 +1,88 @@
+package dev.jasonpearson.automobile.video
+
+/**
+ * Decides when the capture path must force a fresh surface submission so a WebRTC stream does not
+ * starve a late viewer on a static screen (issue #4383).
+ *
+ * The encoder is fed by a mirrored VirtualDisplay. When the screen is static no new surface buffers
+ * arrive, so the encoder emits its initial SPS/PPS + IDR + a short burst and then stops: a WHEP
+ * viewer that subscribes after that burst never receives a decodable frame.
+ * `MediaFormat.KEY_REPEAT_PREVIOUS_FRAME_AFTER` is meant to keep the encoder producing idle
+ * repeats, but it does not reliably sustain them on every device, and a keyframe request
+ * (`PARAMETER_KEY_REQUEST_SYNC_FRAME`) cannot yield a fresh IDR with no new surface input. This
+ * heartbeat is the backstop: it tells [VideoServer] when to nudge the VirtualDisplay into
+ * re-submitting a frame — periodically while idle, and promptly after a keyframe request that
+ * produced nothing.
+ *
+ * Pure and clock-injectable so it unit-tests without the Android framework. Thread-safe because the
+ * keyframe request arrives on the command-reader thread while the encode loop polls and reports
+ * emitted frames.
+ */
+class FrameHeartbeat(
+  private val clock: Clock,
+  /** Force a fresh submission after this long with no emitted frame (idle repeat backstop). */
+  private val idleForceIntervalMs: Long = DEFAULT_IDLE_FORCE_INTERVAL_MS,
+  /** After a keyframe request, force a submission if no frame lands within this window. */
+  private val keyFrameGraceMs: Long = DEFAULT_KEY_FRAME_GRACE_MS,
+) {
+  /** Injectable monotonic clock; production uses `SystemClock.uptimeMillis()`. */
+  fun interface Clock {
+    fun nowMs(): Long
+  }
+
+  /** Last emitted frame OR issued nudge — whichever is later. Throttles idle nudges. */
+  private var lastActivityMs = 0L
+
+  /** When an unsatisfied keyframe request began, or null when none is outstanding. */
+  private var keyFramePendingSinceMs: Long? = null
+
+  /** Baseline the timers at capture start so the first idle nudge is a full interval out. */
+  @Synchronized
+  fun start() {
+    lastActivityMs = clock.nowMs()
+    keyFramePendingSinceMs = null
+  }
+
+  /** Record that the encoder emitted a frame: resets idle timing and clears any request. */
+  @Synchronized
+  fun onFrameEmitted() {
+    lastActivityMs = clock.nowMs()
+    keyFramePendingSinceMs = null
+  }
+
+  /** Record a keyframe request (a relayed WHEP viewer PLI). Coalesces repeats. */
+  @Synchronized
+  fun onKeyFrameRequested() {
+    if (keyFramePendingSinceMs == null) {
+      keyFramePendingSinceMs = clock.nowMs()
+    }
+  }
+
+  /**
+   * @return true if the caller should force a fresh surface submission now. Firing advances the
+   *   internal timers so a wedged surface is nudged at most once per interval (idle) or once per
+   *   grace window (pending keyframe) until a frame lands.
+   */
+  @Synchronized
+  fun poll(): Boolean {
+    val now = clock.nowMs()
+    val pending = keyFramePendingSinceMs
+    val dueForKeyFrame = pending != null && now - pending >= keyFrameGraceMs
+    val dueForIdle = now - lastActivityMs >= idleForceIntervalMs
+    if (!dueForKeyFrame && !dueForIdle) {
+      return false
+    }
+    lastActivityMs = now
+    if (pending != null) {
+      // Keep the request outstanding but re-throttle: if the nudge produces nothing,
+      // fire again after another grace window rather than every poll.
+      keyFramePendingSinceMs = now
+    }
+    return true
+  }
+
+  companion object {
+    const val DEFAULT_IDLE_FORCE_INTERVAL_MS = 1_000L
+    const val DEFAULT_KEY_FRAME_GRACE_MS = 150L
+  }
+}

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/ScreenCapture.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/ScreenCapture.kt
@@ -16,6 +16,7 @@ class ScreenCapture(
   private val densityDpi: Int,
 ) {
   private var virtualDisplay: VirtualDisplay? = null
+  private var surface: Surface? = null
 
   /**
    * Create a VirtualDisplay that mirrors the main display.
@@ -34,12 +35,32 @@ class ScreenCapture(
         displayIdToMirror = 0, // Mirror the main display
       )
     virtualDisplay = display
+    this.surface = surface
     return display
+  }
+
+  /**
+   * Force the mirror to re-submit a frame to the encoder surface. On a static screen no new buffers
+   * are queued, so the encoder stalls after its initial burst and a keyframe request cannot produce
+   * a fresh IDR (issue #4383). Re-applying the output surface makes DisplayManager re-composite the
+   * mirror, pushing a fresh frame the encoder can emit. Safe to call from the encode loop thread;
+   * the codec's own IDR interval still bounds GOP.
+   */
+  fun forceFrame() {
+    val display = virtualDisplay ?: return
+    val surface = this.surface ?: return
+    try {
+      display.setSurface(surface)
+    } catch (e: Exception) {
+      // Best-effort nudge: a released display surfaces its own failure via the encode loop.
+      System.err.println("forceFrame failed: ${e.message}")
+    }
   }
 
   /** Release the VirtualDisplay. */
   fun stop() {
     virtualDisplay?.release()
     virtualDisplay = null
+    surface = null
   }
 }

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/ScreenCapture.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/ScreenCapture.kt
@@ -42,14 +42,20 @@ class ScreenCapture(
   /**
    * Force the mirror to re-submit a frame to the encoder surface. On a static screen no new buffers
    * are queued, so the encoder stalls after its initial burst and a keyframe request cannot produce
-   * a fresh IDR (issue #4383). Re-applying the output surface makes DisplayManager re-composite the
-   * mirror, pushing a fresh frame the encoder can emit. Safe to call from the encode loop thread;
-   * the codec's own IDR interval still bounds GOP.
+   * a fresh IDR (issue #4383).
+   *
+   * The nudge detaches then re-attaches the output surface: `DisplayManagerService`'s
+   * `VirtualDisplayDevice.setSurfaceLocked` short-circuits on a reference-equality check (`mSurface
+   * != surface`), so re-applying the SAME surface is a no-op. Clearing to null and then re-setting
+   * passes that guard both times, forcing a traversal that re-composites the mirror onto the
+   * surface and pushes a fresh frame the encoder can emit. Safe to call from the encode loop
+   * thread; the codec's own IDR interval still bounds GOP.
    */
   fun forceFrame() {
     val display = virtualDisplay ?: return
     val surface = this.surface ?: return
     try {
+      display.setSurface(null)
       display.setSurface(surface)
     } catch (e: Exception) {
       // Best-effort nudge: a released display surfaces its own failure via the encode loop.

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoEncoder.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoEncoder.kt
@@ -110,7 +110,7 @@ class VideoEncoder(
   }
 
   /**
-   * Ask the encoder to emit an IDR as soon as possible, rather than waiting for the 10s I-frame
+   * Ask the encoder to emit an IDR as soon as possible, rather than waiting for the 2s I-frame
    * interval. Serves a downstream keyframe request (a WHEP viewer PLI relayed by the host) so a
    * late or recovering viewer decodes promptly. Safe to call from any thread and after the codec
    * has been released.

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
@@ -221,12 +221,22 @@ object VideoServer {
     streamWriter = VideoStreamWriter(SOCKET_NAME, width, height, audioEnabled)
     streamWriter!!.start()
 
+    // Backstop for idle-screen frame starvation (#4383): on a static screen the mirror
+    // stops submitting buffers, so KEY_REPEAT_PREVIOUS_FRAME_AFTER alone does not reliably
+    // sustain output and a keyframe request cannot yield a fresh IDR. The heartbeat tells us
+    // when to nudge the VirtualDisplay into re-submitting a frame.
+    val heartbeat =
+      FrameHeartbeat(clock = FrameHeartbeat.Clock { android.os.SystemClock.uptimeMillis() })
+    heartbeat.start()
+
     // Read host→device commands (e.g. a relayed WHEP viewer PLI) and ask the
     // encoder for a fresh IDR so late/recovering viewers decode without waiting
-    // for the 10s I-frame interval.
+    // for the 10s I-frame interval. Also arm the heartbeat so an idle screen that
+    // produces no frame for the request still gets a forced fresh submission.
     streamWriter!!.startCommandReader { command ->
       if (command == VideoStreamProtocol.COMMAND_REQUEST_KEY_FRAME) {
         encoder?.requestKeyFrame()
+        heartbeat.onKeyFrameRequested()
       }
     }
 
@@ -257,12 +267,19 @@ object VideoServer {
           }
         }
         encoder!!.releaseOutputBuffer(index)
+        heartbeat.onFrameEmitted()
 
         // Check for end of stream
         if ((bufferInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
           println("End of stream")
           break
         }
+      }
+
+      // Backstop the encoder's own idle repeats: if the mirror has gone quiet (or a
+      // keyframe request produced nothing), nudge it into re-submitting a fresh frame.
+      if (heartbeat.poll()) {
+        capture?.forceFrame()
       }
     }
 

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
@@ -32,7 +32,8 @@ object VideoServer {
   @Volatile private var running = true
 
   @Volatile private var encoder: VideoEncoder? = null
-  private var capture: ScreenCapture? = null
+  // Volatile: the encode loop reads it for forceFrame() while the shutdown hook nulls it (#4383).
+  @Volatile private var capture: ScreenCapture? = null
   private var audioCapture: AudioCapture? = null
   private var streamWriter: VideoStreamWriter? = null
 
@@ -231,7 +232,7 @@ object VideoServer {
 
     // Read host→device commands (e.g. a relayed WHEP viewer PLI) and ask the
     // encoder for a fresh IDR so late/recovering viewers decode without waiting
-    // for the 10s I-frame interval. Also arm the heartbeat so an idle screen that
+    // for the 2s I-frame interval. Also arm the heartbeat so an idle screen that
     // produces no frame for the request still gets a forced fresh submission.
     streamWriter!!.startCommandReader { command ->
       if (command == VideoStreamProtocol.COMMAND_REQUEST_KEY_FRAME) {

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/FrameHeartbeatTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/FrameHeartbeatTest.kt
@@ -20,7 +20,11 @@ class FrameHeartbeatTest {
     clock: FrameHeartbeat.Clock,
     idleForceIntervalMs: Long = 1_000,
     keyFrameGraceMs: Long = 150,
-  ) = FrameHeartbeat(clock, idleForceIntervalMs, keyFrameGraceMs).also { it.start() }
+    maxKeyFrameNudges: Int = 4,
+  ) =
+    FrameHeartbeat(clock, idleForceIntervalMs, keyFrameGraceMs, maxKeyFrameNudges).also {
+      it.start()
+    }
 
   @Test
   fun idleScreenForcesFrameOncePerInterval() {
@@ -109,6 +113,33 @@ class FrameHeartbeatTest {
     clock.nowMs = 250
     assertFalse(heartbeat.poll())
     clock.nowMs = 300
+    assertTrue(heartbeat.poll())
+  }
+
+  @Test
+  fun keyFrameNudgesAreCappedThenFallBackToIdleCadence() {
+    val clock = FakeClock()
+    val heartbeat =
+      heartbeat(clock, idleForceIntervalMs = 1_000, keyFrameGraceMs = 150, maxKeyFrameNudges = 2)
+
+    clock.nowMs = 0
+    heartbeat.onKeyFrameRequested()
+
+    // Two grace-window nudges fire for the unsatisfied request...
+    clock.nowMs = 150
+    assertTrue(heartbeat.poll())
+    clock.nowMs = 300
+    assertTrue(heartbeat.poll())
+
+    // ...then the grace budget is spent: no more fast nudges — a wedged surface cannot spin
+    // setSurface at the 150ms grace rate forever. The last nudge (t=300) seeds the idle timer.
+    clock.nowMs = 450
+    assertFalse(heartbeat.poll())
+    clock.nowMs = 1_000
+    assertFalse(heartbeat.poll())
+
+    // The slower idle cadence still carries it: 1s after the final nudge, force once.
+    clock.nowMs = 1_300
     assertTrue(heartbeat.poll())
   }
 }

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/FrameHeartbeatTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/FrameHeartbeatTest.kt
@@ -1,0 +1,114 @@
+package dev.jasonpearson.automobile.video
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the idle-screen frame-nudge decision for issue #4383: on a static screen the mirrored
+ * VirtualDisplay stops submitting surface buffers, so the encoder emits its initial burst and then
+ * stalls, and a keyframe request cannot produce a fresh IDR without new surface input.
+ * [FrameHeartbeat] decides when the capture path must force a surface submission — periodically
+ * while idle, and promptly after a keyframe request.
+ */
+class FrameHeartbeatTest {
+  private class FakeClock(var nowMs: Long = 0) : FrameHeartbeat.Clock {
+    override fun nowMs(): Long = nowMs
+  }
+
+  private fun heartbeat(
+    clock: FrameHeartbeat.Clock,
+    idleForceIntervalMs: Long = 1_000,
+    keyFrameGraceMs: Long = 150,
+  ) = FrameHeartbeat(clock, idleForceIntervalMs, keyFrameGraceMs).also { it.start() }
+
+  @Test
+  fun idleScreenForcesFrameOncePerInterval() {
+    val clock = FakeClock()
+    val heartbeat = heartbeat(clock, idleForceIntervalMs = 1_000)
+
+    // Before the idle interval elapses, no nudge.
+    clock.nowMs = 999
+    assertFalse(heartbeat.poll())
+
+    // At the idle interval, force a fresh surface submission.
+    clock.nowMs = 1_000
+    assertTrue(heartbeat.poll())
+
+    // Immediately after a nudge, no second nudge (throttled to once per interval).
+    assertFalse(heartbeat.poll())
+
+    // A full interval after the nudge, force again — a static screen keeps repeating.
+    clock.nowMs = 2_000
+    assertTrue(heartbeat.poll())
+  }
+
+  @Test
+  fun emittedFrameResetsIdleTimer() {
+    val clock = FakeClock()
+    val heartbeat = heartbeat(clock, idleForceIntervalMs = 1_000)
+
+    clock.nowMs = 800
+    heartbeat.onFrameEmitted()
+
+    // Only 900ms since start but 100ms since the frame: not yet due.
+    clock.nowMs = 900
+    assertFalse(heartbeat.poll())
+
+    // 1_000ms after the frame: due again.
+    clock.nowMs = 1_800
+    assertTrue(heartbeat.poll())
+  }
+
+  @Test
+  fun keyFrameRequestForcesFrameAfterGrace() {
+    val clock = FakeClock()
+    val heartbeat = heartbeat(clock, idleForceIntervalMs = 10_000, keyFrameGraceMs = 150)
+
+    clock.nowMs = 500
+    heartbeat.onKeyFrameRequested()
+
+    // Within the grace window the encoder may still emit on its own; do not nudge yet.
+    clock.nowMs = 600
+    assertFalse(heartbeat.poll())
+
+    // Grace elapsed with no frame: force a fresh submission so the IDR request lands.
+    clock.nowMs = 650
+    assertTrue(heartbeat.poll())
+  }
+
+  @Test
+  fun emittedFrameSatisfiesPendingKeyFrameRequest() {
+    val clock = FakeClock()
+    val heartbeat = heartbeat(clock, idleForceIntervalMs = 10_000, keyFrameGraceMs = 150)
+
+    clock.nowMs = 500
+    heartbeat.onKeyFrameRequested()
+
+    // A frame lands before the grace elapses: the request is satisfied, no nudge.
+    clock.nowMs = 600
+    heartbeat.onFrameEmitted()
+
+    clock.nowMs = 800
+    assertFalse(heartbeat.poll())
+  }
+
+  @Test
+  fun keyFrameRequestKeepsNudgingUntilFrameLands() {
+    val clock = FakeClock()
+    val heartbeat = heartbeat(clock, idleForceIntervalMs = 10_000, keyFrameGraceMs = 150)
+
+    clock.nowMs = 0
+    heartbeat.onKeyFrameRequested()
+
+    clock.nowMs = 150
+    assertTrue(heartbeat.poll())
+
+    // The forced submission produced nothing; keep nudging each grace period so a
+    // wedged surface is not left without a fresh frame after a viewer's PLI.
+    clock.nowMs = 250
+    assertFalse(heartbeat.poll())
+    clock.nowMs = 300
+    assertTrue(heartbeat.poll())
+  }
+}

--- a/test/integration/webrtcDeviceCapture.integration.test.ts
+++ b/test/integration/webrtcDeviceCapture.integration.test.ts
@@ -503,14 +503,22 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
       }, "capture source did not deliver H.264 frames to the WHIP publisher");
       await subscribeReader(cdp);
       timeline.mark("whepConnected");
-      // The device can be idle by the time the WHEP reader connects. Trigger a
-      // visible transition after subscription so the reader receives a fresh
-      // encoded access unit rather than waiting on an earlier keyframe.
-      await changeFixture();
-      await waitForDecodedFrames(cdp, 0, "browser did not decode device video");
+      // #4383: the screen has been static since capture started (fixture launched, no further
+      // input), so this exercises a late viewer joining an idle stream. The encoder's
+      // FrameHeartbeat must force a fresh surface submission — the periodic idle nudge plus a
+      // keyframe nudge on the viewer's PLI — so the reader decodes with NO visible screen change.
+      // On the pre-fix jar the reader sat black here indefinitely; this is the device coverage
+      // #4383 asked for, and it fails on the old encoder while passing on the fixed one.
+      await waitForDecodedFrames(cdp, 0, "browser did not decode device video on a static screen (late-viewer starvation, #4383)");
       timeline.mark("firstDecodedFrame");
+      const staticScreenFrame = await videoSample(cdp);
+      expect(staticScreenFrame.frames).toBeGreaterThan(0);
+      decodedSize = { width: staticScreenFrame.width, height: staticScreenFrame.height };
+      // A visible transition must still deliver changing video (regression guard for the
+      // active-screen path that the idle-frame backstop must not disturb).
+      await changeFixture();
+      await waitForDecodedFrames(cdp, staticScreenFrame.frames, "browser did not decode a new frame after a visible change");
       const first = await videoSample(cdp);
-      decodedSize = { width: first.width, height: first.height };
       await launchFixture();
       await waitForDecodedFrames(cdp, first.frames, "browser did not receive video after returning to the fixture");
       const second = await videoSample(cdp);

--- a/test/integration/webrtcDeviceCapture.integration.test.ts
+++ b/test/integration/webrtcDeviceCapture.integration.test.ts
@@ -251,6 +251,30 @@ async function waitForDecodedFrames(cdp: CdpClient, minimum: number, message: st
   }
 }
 
+/**
+ * Wait until the decoded frame's content actually differs from `previousSample`, returning that
+ * frame. Frame *count* is no longer a proxy for a visible change: the encoder's idle-frame backstop
+ * (#4383) advances the counter with forced repeats of an unchanged screen, so a count-based wait can
+ * return on a still frame. Content-difference is what proves a visible transition rendered.
+ */
+async function waitForChangedSample(
+  cdp: CdpClient,
+  previousSample: number,
+  message: string
+): Promise<{ frames: number; width: number; height: number; sample: number }> {
+  let latest = await videoSample(cdp);
+  try {
+    await waitFor(async () => {
+      latest = await videoSample(cdp);
+      return latest.frames > 0 && latest.sample !== previousSample;
+    }, message);
+  } catch {
+    const diagnostics = await readerDiagnostics(cdp).catch(() => undefined);
+    throw new Error(`${message}; reader diagnostics=${JSON.stringify(diagnostics ?? "unavailable")}`);
+  }
+  return latest;
+}
+
 function androidDeviceId(): string {
   return process.env.AUTOMOBILE_ANDROID_H264_DEVICE_ID ?? "emulator-5554";
 }
@@ -515,13 +539,13 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
       expect(staticScreenFrame.frames).toBeGreaterThan(0);
       decodedSize = { width: staticScreenFrame.width, height: staticScreenFrame.height };
       // A visible transition must still deliver changing video (regression guard for the
-      // active-screen path that the idle-frame backstop must not disturb).
+      // active-screen path that the idle-frame backstop must not disturb). Wait on decoded
+      // CONTENT changing, not the frame count — the idle backstop advances the count on a static
+      // screen, so a count-based wait would return on a forced repeat before the transition renders.
       await changeFixture();
-      await waitForDecodedFrames(cdp, staticScreenFrame.frames, "browser did not decode a new frame after a visible change");
-      const first = await videoSample(cdp);
+      const first = await waitForChangedSample(cdp, staticScreenFrame.sample, "browser did not decode changed video after a visible change");
       await launchFixture();
-      await waitForDecodedFrames(cdp, first.frames, "browser did not receive video after returning to the fixture");
-      const second = await videoSample(cdp);
+      const second = await waitForChangedSample(cdp, first.sample, "browser did not receive changed video after returning to the fixture");
       expect(first.width).toBeGreaterThan(0);
       expect(first.height).toBeGreaterThan(0);
       expect(second.frames).toBeGreaterThan(first.frames);


### PR DESCRIPTION
## Summary

On a static Android screen the mirrored `VirtualDisplay` stops submitting buffers, so the persistent on-device H.264 encoder emits its initial SPS/PPS + IDR + short burst and then stalls. `MediaFormat.KEY_REPEAT_PREVIOUS_FRAME_AFTER` does not reliably sustain idle repeats on every device, and a keyframe request (`PARAMETER_KEY_REQUEST_SYNC_FRAME`) cannot yield a fresh IDR with no new surface input. A WHEP viewer that subscribes after the burst therefore never receives a decodable frame and stays black; the publisher's frame-stall watchdog just reconnects without ever producing one.

This adds a backstop in the `video-server` capture path so a static screen keeps producing low-rate frames and a keyframe request always yields a fresh, decodable frame — instead of relying solely on `KEY_REPEAT_PREVIOUS_FRAME_AFTER`.

## Changes

- **`FrameHeartbeat`** (new): a pure, clock-injectable decision object. It tells `VideoServer` when to force a fresh surface submission — periodically while the encoder is idle (`idleForceIntervalMs`, default 1s) and promptly after a keyframe request that produced no frame (`keyFrameGraceMs`, default 150ms). Nudges are throttled to at most once per interval / grace window, consecutive keyframe-grace nudges are capped (`maxKeyFrameNudges`) then fall back to the idle cadence so an undecodable surface can't spin a `setSurface` storm, and it is `@Synchronized` because the keyframe request arrives on the command-reader thread while the encode loop polls and reports emitted frames.
- **`ScreenCapture.forceFrame()`** (new): forces a re-composite by detaching then re-attaching the output surface (`setSurface(null)` → `setSurface(surface)`). AOSP's `VirtualDisplayDevice.setSurfaceLocked` short-circuits on a reference-equality guard (`mSurface != surface`), so re-applying the *same* surface is a no-op — the null-toggle passes the guard both times and pushes a fresh frame the encoder can emit.
- **`VideoServer.run()`**: wires the heartbeat — arms it on a relayed keyframe request (alongside `encoder.requestKeyFrame()`), reports each emitted frame, and nudges `capture.forceFrame()` when the heartbeat is due. `capture` is now `@Volatile` (read by the encode loop, nulled by the shutdown hook).
- **`webrtcDeviceCapture.integration.test.ts`**: asserts a WHEP viewer decodes on a **static** screen (no `changeFixture()` first) — the device coverage #4383 asked for. Discriminating: black on the old encoder, decodes on the fixed one. The old test stepped around the bug by forcing a screen change immediately after subscribe.

## Linked Issue

Closes #4383

## Bug / Regression Context

- **Observed symptom:** WHEP viewer joining after the initial encoder burst renders black indefinitely on a static screen; a visible screen update immediately unblocks frames.
- **Repro steps / conditions:** Start an emulator, leave the screen static, start a WebRTC stream with the persistent encoder, subscribe a WHEP viewer after "connected" — only the initial burst arrives, then the frame counter stops.

## Validation

- [x] `:video-server:test` green — new `FrameHeartbeatTest` (5 cases, <5ms each) pins the idle-force, keyframe-grace, throttle, and frame-reset decisions
- [x] `:video-server:d8Dex` builds the jar
- [x] `scripts/ktfmt/validate_ktfmt.sh` clean
- [x] New code uses an injected `Clock` interface + fake; unit tests run in <100ms
- [x] No new dependency — pure Kotlin stdlib + existing framework `VirtualDisplay.setSurface`

TypeScript, DB, migrations, MCP tool schemas, and the `VideoStreamProtocol` wire format are unchanged.

## Kotlin Reuse Check

- [x] Checked Kotlin stdlib / framework APIs before adding: the nudge uses the existing public `VirtualDisplay.setSurface`; the decision is a small local class with an injected clock (no new util/wrapper, no new dependency)

## Device Verification

- The **Android Device Capture to WHEP** CI lane (`webrtc-device-integration.yml`, triggered by the `android/video-server/**` change) builds this jar and runs the integration test on a real emulator with Chrome WHEP decoding. The new static-screen assertion makes that lane the on-device verification: it will pass only if `forceFrame()` genuinely re-composites and the reader decodes an idle stream.
- Local unit tests pin the `FrameHeartbeat` decision (6 cases, <5ms each); the on-device efficacy of the null-toggle nudge is verified by the CI device lane rather than a synthetic unit test.

## Notes for the reviewer / merge

- The `video-server` jar is a checksummed release artifact (`videoJarSha256` in `src/constants/release.ts`), bumped by periodic release-cut PRs, not here. This behavioral fix reaches released clients only after the jar is re-cut.
- Higher-risk class (on-device capture behavior in a checksummed runner artifact). Auto-merge left off; merge decision deferred to the maintainer once the device lane is green.
