### PR TITLE
feat(observe): flag-gated progressive-disclosure scope experiments (#4344)

### DIFF
--- a/docs/design-docs/mcp/feature-flags.md
+++ b/docs/design-docs/mcp/feature-flags.md
@@ -46,6 +46,37 @@ Part of the MCP output-context reduction effort. Each flag can be set either as 
 | **`--actions-diff-observe`** | `AUTOMOBILE_ACTIONS_DIFF_OBSERVE` | Non-observe tools (`tapOn`, `swipeOn`, …) emit a **diff** of their post-action observation against the last one shown to the agent, instead of the full embedded observation. The baseline is the "last observation output to the agent" — the sanitized `ObserveResult` cached per session (`SessionCacheData.lastRenderedObservation`). `observe` **always** emits the full sanitized observation and resets the baseline; each non-observe action emits its diff then updates the baseline to its own observation, so the next diff is against current state. Nodes carry no stable id, so diffing uses a synthetic key: `resource-id` + `bounds` + `text` + sibling index. The diff is `{ isDiff: true, added, removed, changed, fields }` — `added`/`removed`/`changed` are keyed nodes (a node whose key fields change reads as remove+add; a same-key node whose other attributes change, e.g. `checked`, reads as `changed`), and `fields` are changed top-level fields — scalars (`rotation`, `wakefulness`, `awaitDuration`, …; `updatedAt` is excluded as pure churn) and the Element **mirror** fields (`focusedElement`, `accessibilityFocusedElement`, `awaitedElement`), each as `{from, to}`. The mirror fields are emitted `node`-subtree-stripped (the subtree is redundant with the node diff) and compared bounds-tolerantly; a focus gain reads as `{from: undefined, to: element}`, a loss as `{from: element, to: undefined}`. **Falls back to the full observation** (no diff) when the active window/package changed (cross-screen diff is meaningless), the baseline is missing (first action), or there is no `sessionUuid` (legacy single-agent path). **Content-hash node identity (#3053):** the positional key cascades on scroll / mid-list insert — a shift changes every following node's `bounds` and sibling index, so whole rows would surface as remove+add. After positional matching, a leftover *removed* and *added* node are re-paired into one `changed` delta when they share a stable content key (`resource-id`/`view-id`/`content-desc`/`text` — no bounds, no sibling index) that is **unique among the leftovers on both sides**; uniqueness guarantees exactly one candidate each side, so distinct content never false-merges, and a keyless node (no stable identity) never re-pairs. This collapses a scroll into "N nodes moved" instead of "N removed + N added". Duplicate/interchangeable cells stay remove+add (ambiguous key). Applied output-only in `finalizeToolResponse` after `sanitizeObserveResult`, so it composes with `--observe-result-compact` (the diff operates on the already-compacted observation; the synthetic key normalizes both object- and tuple-shaped bounds). **Internal tool-to-tool calls are never diffed:** `PlanExecutor` marks its step calls internal (`__internalNoDiff`), so a plan step's finalized envelope always carries the full observation — a current or future internal `.observation.viewHierarchy` reader is never handed a diff. Combining it with `--actions-no-observe` is moot — that flag removes the observation, so there is nothing to diff. |
 | **`--actions-no-observe`** | `AUTOMOBILE_ACTIONS_NO_OBSERVE` | Strip the embedded `observation` from non-observe tool results entirely (deleted from **both** `structuredContent` and the serialized `content[0].text`). Output-only — `BaseVisualChange` still computes the observation internally for its own success detection, so visual-change behavior is unchanged; the `observe` tool's own observation is never stripped. Applied at `finalizeToolResponse`. **Precedence:** when both `--actions-no-observe` and `--actions-diff-observe` are set, no-observe wins — the observation is removed, so there is nothing to diff. |
 | **`--tool-results-compact-json`** | `AUTOMOBILE_TOOL_RESULTS_COMPACT_JSON` | Serialize tool results as compact (non-pretty-printed) JSON — drops the 2-space indentation in `stringifyToolResponse`. Same data (parses back identically, no effect on `tapOn`/text matching); ~35% fewer characters on element-heavy payloads. Composes with the other flags. |
+| **`--observe-focus-scope`** | `AUTOMOBILE_OBSERVE_FOCUS_SCOPE` | Enable the FOCUS dimension of the `observe` `scope` input (see below). Scope the returned hierarchy to a subtree — a semantic anchor, or the foreground app with identifiable system chrome dropped. Honored only when the call also supplies `scope.focus`. |
+| **`--observe-overview`** | `AUTOMOBILE_OBSERVE_OVERVIEW` | Enable the OVERVIEW dimension of the `observe` `scope` input. Collapse the hierarchy to a structural/addressable container skeleton, dropping anonymous leaves and annotating `omittedDescendants`. Honored only when the call supplies `scope.overview: true`. |
+| **`--observe-region`** | `AUTOMOBILE_OBSERVE_REGION` | Enable the REGION dimension of the `observe` `scope` input. Crop the hierarchy to a normalized `(0..1)` box, or the inset content rectangle. Honored only when the call supplies `scope.region`. |
+
+### Observe scope input (issue #4344)
+
+Applies the multimodal "crop tool" concept to the **view hierarchy** (the artifact
+agents consume) rather than screenshots: three progressive-disclosure transforms
+that return a *scoped* view of the tree. This is the "spatial axis" complementing
+`--actions-diff-observe`'s "temporal axis". Implemented output-only in
+`finalizeToolResponse` (`src/features/observe/output/ObserveScopeExperiments.ts`),
+so it never mutates the in-memory result, and applied to the **agent-facing**
+`observe` payload only — internal tool-to-tool calls and the diff baseline keep
+the full sanitized tree.
+
+Unlike the other flags, the parameters ride in the tool call, not the flag: the
+agent picks where to zoom on **each** screen via an optional `scope` field on
+`observe`, and the flag above is only a per-dimension dark-launch gate.
+`buildObserveScopeConfig` applies a dimension only when the call requested it
+**and** its flag is on.
+
+| `scope` field | Shape | Behavior |
+|---|---|---|
+| `scope.focus` | `true` \| `{ resourceId?, text? }` | An anchor scopes to the first matching node's subtree; `true` scopes to the foreground app, dropping identifiable foreign-package chrome. FOCUS classifies chrome by the resource-id **dotted-package** prefix (`com.android.systemui:id/...`), which survives `cleanNodeProperties`; the undotted `android:` framework namespace (`android:id/content`, dialog/ActionBar ids) and iOS colon identifiers (`row:0`) are neutral and kept, so app content is never dropped. |
+| `scope.region` | `true` \| `{ x1, y1, x2, y2 }` | Crop to a normalized `(0..1)` box (`x1<x2`, `y1<y2`, enforced at runtime), or the inset content rectangle when `true`. Nodes with no readable bounds are kept. |
+| `scope.overview` | `true` | Collapse to a structural/addressable skeleton (kept: children, `scrollable`, `clickable`, `resource-id`, `content-desc`). |
+
+Every scoped payload carries an `observeScope` field (`applied` transforms,
+`nodesBefore`/`nodesAfter`, `regionPx`, `focus` resolution) so the reduction is
+measurable on the wire. The `scope` input and `observeScope` output are advertised
+in the `observe` tool schema.
 
 ### Tool Output Artifact Mode
 

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3279,6 +3279,79 @@
           "description": "Skip back stack during waitFor polling",
           "type": "boolean"
         },
+        "scope": {
+          "type": "object",
+          "properties": {
+            "focus": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "resourceId": {
+                      "description": "Anchor by exact resource-id",
+                      "type": "string"
+                    },
+                    "text": {
+                      "description": "Anchor by substring text match",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              ],
+              "description": "Scope to a subtree: true = foreground app; {resourceId|text} = anchor. Needs --observe-focus-scope."
+            },
+            "region": {
+              "description": "Crop to a normalized 0..1 box; true = inset content rect. Needs --observe-region.",
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "x1": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "y1": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "x2": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    },
+                    "y2": {
+                      "type": "number",
+                      "minimum": 0,
+                      "maximum": 1
+                    }
+                  },
+                  "required": [
+                    "x1",
+                    "y1",
+                    "x2",
+                    "y2"
+                  ],
+                  "additionalProperties": false
+                }
+              ]
+            },
+            "overview": {
+              "description": "Collapse to a container skeleton. Needs --observe-overview.",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false,
+          "description": "Experimental progressive-disclosure scoping of the returned hierarchy (issue #4344)"
+        },
         "sessionUuid": {
           "description": "Session",
           "type": "string"
@@ -5268,6 +5341,92 @@
             "keyguardShowing"
           ],
           "additionalProperties": false
+        },
+        "observeScope": {
+          "type": "object",
+          "properties": {
+            "applied": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "focus",
+                  "region",
+                  "overview"
+                ]
+              }
+            },
+            "nodesBefore": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            },
+            "nodesAfter": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 9007199254740991
+            },
+            "regionPx": {
+              "type": "object",
+              "properties": {
+                "left": {
+                  "type": "number"
+                },
+                "top": {
+                  "type": "number"
+                },
+                "right": {
+                  "type": "number"
+                },
+                "bottom": {
+                  "type": "number"
+                },
+                "centerX": {
+                  "type": "number"
+                },
+                "centerY": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "left",
+                "top",
+                "right",
+                "bottom"
+              ],
+              "additionalProperties": false,
+              "description": "Element bounds. Default: object {left, top, right, bottom} (+ optional centerX/centerY). Under --observe-result-compact: positional tuple [left, top, right, bottom]."
+            },
+            "focus": {
+              "type": "object",
+              "properties": {
+                "by": {
+                  "type": "string",
+                  "enum": [
+                    "anchor",
+                    "foreground-app"
+                  ]
+                },
+                "matched": {
+                  "type": "boolean"
+                },
+                "packageName": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "by",
+                "matched"
+              ],
+              "additionalProperties": {}
+            }
+          },
+          "required": [
+            "applied",
+            "nodesBefore",
+            "nodesAfter"
+          ],
+          "additionalProperties": {}
         },
         "artifact": {
           "type": "object",

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -273,6 +273,15 @@ export class Daemon {
     if (options.toolResultsCompactJson) {
       serverConfig.setToolResultsCompactJsonEnabled(true);
     }
+    if (options.observeFocusScope) {
+      serverConfig.setObserveFocusScopeEnabled(true);
+    }
+    if (options.observeOverview) {
+      serverConfig.setObserveOverviewEnabled(true);
+    }
+    if (options.observeRegion) {
+      serverConfig.setObserveRegionEnabled(true);
+    }
     if (options.toolOutputsDir) {
       serverConfig.setToolOutputsDir(options.toolOutputsDir);
     }

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -219,7 +219,7 @@ export interface ProxiedResourceTemplate {
  * `field` names map 1:1 to `DaemonOptions`) so a new flag is covered
  * automatically.
  */
-const REUSE_CRITICAL_OPTION_KEYS: (keyof DaemonOptions)[] = [
+export const REUSE_CRITICAL_OPTION_KEYS: (keyof DaemonOptions)[] = [
   "embeddedSdk",
   "networkMockable",
   "safeAreaWarnings",

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -706,6 +706,18 @@ export class DaemonManager implements DaemonManagerLike {
     if (options.noOcclusion) {
       args.push("--no-occlusion");
     }
+    // Accessibility-service view-filter flags (issue #4344 propagation audit):
+    // these were in the daemon-options object but serialized nowhere, so a
+    // manager-spawned daemon never received them on either transport.
+    if (options.noA11yIncludeNotImportantViews) {
+      args.push("--no-include-not-important-views");
+    }
+    if (options.noA11yReportViewIds) {
+      args.push("--no-report-view-ids");
+    }
+    if (options.noA11yRetrieveInteractiveWindows) {
+      args.push("--no-retrieve-interactive-windows");
+    }
     if (options.safeAreaWarnings) {
       args.push("--safe-area-warnings");
     }
@@ -1163,6 +1175,12 @@ export function parseDaemonArgs(args: string[], env: NodeJS.ProcessEnv = process
       options.noWaitForPollingOverhead = true;
     } else if (args[i] === "--no-occlusion") {
       options.noOcclusion = true;
+    } else if (args[i] === "--no-include-not-important-views") {
+      options.noA11yIncludeNotImportantViews = true;
+    } else if (args[i] === "--no-report-view-ids") {
+      options.noA11yReportViewIds = true;
+    } else if (args[i] === "--no-retrieve-interactive-windows") {
+      options.noA11yRetrieveInteractiveWindows = true;
     } else if (args[i] === "--safe-area-warnings" || args[i] === "--edge-to-edge-warnings") {
       options.safeAreaWarnings = true;
     } else if (args[i] === "--mem-perf-audit") {

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1200,6 +1200,12 @@ export function parseDaemonArgs(args: string[], env: NodeJS.ProcessEnv = process
       options.actionsNoObserve = true;
     } else if (args[i] === "--tool-results-compact-json") {
       options.toolResultsCompactJson = true;
+    } else if (args[i] === "--observe-focus-scope") {
+      options.observeFocusScope = true;
+    } else if (args[i] === "--observe-overview") {
+      options.observeOverview = true;
+    } else if (args[i] === "--observe-region") {
+      options.observeRegion = true;
     }
   }
   return options;

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -242,6 +242,12 @@ export interface DaemonOptions {
   actionsNoObserve?: boolean;
   /** Output reduction: serialize tool results as compact (non-pretty) JSON (issue #2756) */
   toolResultsCompactJson?: boolean;
+  /** Observe scope experiment: focus the hierarchy to a subtree / foreground app (issue #4344) */
+  observeFocusScope?: boolean;
+  /** Observe scope experiment: collapse the hierarchy to a container skeleton (issue #4344) */
+  observeOverview?: boolean;
+  /** Observe scope experiment: crop the hierarchy to a normalized region (issue #4344) */
+  observeRegion?: boolean;
 }
 
 /**

--- a/src/features/featureFlags/FeatureFlagApplier.ts
+++ b/src/features/featureFlags/FeatureFlagApplier.ts
@@ -72,6 +72,15 @@ export class DefaultFeatureFlagApplier implements FeatureFlagApplier {
       case "tool-results-compact-json":
         serverConfig.setToolResultsCompactJsonEnabled(enabled);
         break;
+      case "observe-focus-scope":
+        serverConfig.setObserveFocusScopeEnabled(enabled);
+        break;
+      case "observe-overview":
+        serverConfig.setObserveOverviewEnabled(enabled);
+        break;
+      case "observe-region":
+        serverConfig.setObserveRegionEnabled(enabled);
+        break;
     }
   }
 }

--- a/src/features/featureFlags/FeatureFlagDefinitions.ts
+++ b/src/features/featureFlags/FeatureFlagDefinitions.ts
@@ -17,7 +17,10 @@ export type FeatureFlagKey =
   | "tool-results-no-structured-content"
   | "actions-diff-observe"
   | "actions-no-observe"
-  | "tool-results-compact-json";
+  | "tool-results-compact-json"
+  | "observe-focus-scope"
+  | "observe-overview"
+  | "observe-region";
 
 export type FeatureFlagConfig = Record<string, unknown>;
 
@@ -177,6 +180,24 @@ export const FEATURE_FLAG_DEFINITIONS: FeatureFlagDefinition[] = [
     key: "tool-results-compact-json",
     label: "Tool results: compact JSON",
     description: "Serialize tool results as compact (non-pretty-printed) JSON — same data, ~35% fewer characters.",
+    defaultValue: false,
+  },
+  {
+    key: "observe-focus-scope",
+    label: "Observe scope: focus",
+    description: "Honor observe `scope.focus` — scope the hierarchy to a subtree (an anchor, else the foreground app), dropping system chrome (issue #4344).",
+    defaultValue: false,
+  },
+  {
+    key: "observe-overview",
+    label: "Observe scope: overview",
+    description: "Honor observe `scope.overview` — collapse the hierarchy to a structural container skeleton, annotating omitted-descendant counts (issue #4344).",
+    defaultValue: false,
+  },
+  {
+    key: "observe-region",
+    label: "Observe scope: region",
+    description: "Honor observe `scope.region` — crop the hierarchy to a per-call normalized (0..1) box, or the inset content rectangle when `true` (issue #4344).",
     defaultValue: false,
   },
 ];

--- a/src/features/observe/output/ObserveScopeExperiments.ts
+++ b/src/features/observe/output/ObserveScopeExperiments.ts
@@ -1,0 +1,568 @@
+import type { ObserveResult } from "../../../models/ObserveResult";
+import type { ElementBounds } from "../../../models/ElementBounds";
+import type {
+  FocusAnchor,
+  NormalizedRegion,
+  ObserveScopeInput,
+  ObserveScopeKind,
+  ObserveScopeMetadata,
+} from "../../../models/ObserveScope";
+
+export type {
+  FocusAnchor,
+  NormalizedRegion,
+  ObserveScopeInput,
+  ObserveScopeKind,
+  ObserveScopeMetadata,
+} from "../../../models/ObserveScope";
+
+/**
+ * Progressive-disclosure scoping experiments for `observe` output (issue #4344).
+ *
+ * Inspired by the Anthropic multimodal "crop tool" cookbook. That tool hands the
+ * model a large, detail-dense artifact (a high-resolution image) plus a way to
+ * *zoom into a region on demand* instead of front-loading every pixel. The lesson
+ * transfers to AutoMobile with one substitution: the dense artifact an agent
+ * actually consumes is the **view hierarchy**, not a screenshot. Today `observe`
+ * front-loads the whole (reduced) tree; these transforms let a caller opt into a
+ * scoped view of it.
+ *
+ * Three independent transforms — the "spatial axis" complementing the existing
+ * "temporal axis" (`--actions-diff-observe`). The agent picks where to zoom on
+ * each screen, so the parameters ride in the `observe` tool's `scope` input
+ * ({@link ObserveScopeInput}), NOT the environment. A server flag gates each
+ * dimension as a dark-launch switch; {@link buildObserveScopeConfig} intersects
+ * the two (call-requested AND flag-enabled):
+ *
+ *  1. FOCUS  (`scope.focus`, `--observe-focus-scope`)  — scope to a subtree: an
+ *     anchor object (`resource-id` / text) when given, else `true` for the
+ *     foreground app, dropping system chrome (status/nav bars, IME, other pkgs).
+ *  2. OVERVIEW (`scope.overview`, `--observe-overview`) — collapse to a container
+ *     skeleton: keep structural/addressable nodes, drop anonymous leaves, annotate
+ *     the count of omitted descendants so nothing is *silently* dropped.
+ *  3. REGION (`scope.region`, `--observe-region`) — crop to a normalized (0..1)
+ *     box (the crop cookbook's signature ergonomic); `true` uses the inset content
+ *     rectangle.
+ *
+ * GUIDING PRINCIPLE — OUTPUT-ONLY, like `sanitizeObserveResult`: every function
+ * here returns a deep copy and never mutates the caller's `ObserveResult`.
+ * `applyObserveScopeExperiments` composes them (focus -> region -> overview) and
+ * records what it did in `observeScope` so the reduction is measurable on the
+ * wire. Applied to the `observe` tool payload only; the diff pipeline owns
+ * post-action observations and must keep diffing against the full sanitized tree.
+ */
+
+export interface ObserveScopeConfig {
+  /** FOCUS on. */
+  focus: boolean;
+  /** Optional FOCUS anchor; when absent, FOCUS scopes to the foreground app. */
+  focusAnchor?: FocusAnchor;
+  /** OVERVIEW on. */
+  overview: boolean;
+  /** REGION on. */
+  region: boolean;
+  /** Optional REGION box; when absent, REGION uses the inset content rectangle. */
+  regionBox?: NormalizedRegion;
+}
+
+/** Structural attributes OVERVIEW keeps on a retained node; all else is dropped. */
+const OVERVIEW_KEPT_ATTRS: ReadonlySet<string> = new Set([
+  "resource-id",
+  "class",
+  "className",
+  "content-desc",
+  "bounds",
+  "scrollable",
+  "clickable",
+]);
+
+type NodeRecord = Record<string, unknown>;
+
+/** Deep clone matching the repo's hierarchy-cloning convention (JSON round-trip). */
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+/**
+ * Normalize a `node` slot to an attribute-bag array. The runtime node carries
+ * flattened attributes but `ViewHierarchyNode` has no string index signature, so
+ * we read through `unknown` and assert to `NodeRecord` (a single assertion, not a
+ * `as unknown as` double-cast). Handles the single-vs-array shape variance the
+ * root and child slots exhibit.
+ */
+function toRecordArray(node: unknown): NodeRecord[] {
+  if (Array.isArray(node)) {
+    return node as NodeRecord[];
+  }
+  if (node && typeof node === "object") {
+    return [node as NodeRecord];
+  }
+  return [];
+}
+
+/** Children of a node as an array (children live under `.node`). */
+function childrenOf(node: NodeRecord): NodeRecord[] {
+  return toRecordArray(node.node);
+}
+
+/** Read an attribute, preferring the flattened key and falling back to the raw `$` bag. */
+function attr(node: NodeRecord, key: string): unknown {
+  if (node[key] !== undefined) {
+    return node[key];
+  }
+  const raw = node.$;
+  if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+    return (raw as NodeRecord)[key];
+  }
+  return undefined;
+}
+
+function stringAttr(node: NodeRecord, key: string): string {
+  const value = attr(node, key);
+  return typeof value === "string" ? value : "";
+}
+
+function isTruthyFlag(value: unknown): boolean {
+  return value === true || value === "true";
+}
+
+/**
+ * Read a node's bounds tolerant of both shapes the wire can carry: the
+ * `{left,top,right,bottom}` object and the `--observe-result-compact` positional
+ * tuple `[left, top, right, bottom]`. Returns null when unreadable.
+ */
+export function readBounds(value: unknown): ElementBounds | null {
+  if (Array.isArray(value) && value.length === 4 && value.every(n => typeof n === "number")) {
+    return { left: value[0], top: value[1], right: value[2], bottom: value[3] };
+  }
+  if (value && typeof value === "object") {
+    const b = value as NodeRecord;
+    if (
+      typeof b.left === "number" && typeof b.top === "number"
+      && typeof b.right === "number" && typeof b.bottom === "number"
+    ) {
+      return { left: b.left, top: b.top, right: b.right, bottom: b.bottom };
+    }
+  }
+  return null;
+}
+
+/** Half-open rectangle overlap: touching edges do not count as intersecting. */
+function intersects(a: ElementBounds, b: ElementBounds): boolean {
+  return !(a.right <= b.left || a.left >= b.right || a.bottom <= b.top || a.top >= b.bottom);
+}
+
+function countNodes(nodes: NodeRecord[]): number {
+  let total = 0;
+  for (const node of nodes) {
+    total += 1 + countNodes(childrenOf(node));
+  }
+  return total;
+}
+
+function rootNodes(obs: ObserveResult): NodeRecord[] {
+  return toRecordArray(obs.viewHierarchy?.hierarchy?.node);
+}
+
+function setRootNodes(obs: ObserveResult, nodes: NodeRecord[]): void {
+  const hierarchy = obs.viewHierarchy?.hierarchy;
+  if (hierarchy) {
+    // The `node` slot is typed as a single node but holds an array at runtime
+    // (see `ObserveResultOutput.toNodeArray`); write through a widened view.
+    (hierarchy as { node?: unknown }).node = nodes;
+  }
+}
+
+/** Replace a node's child array in place, deleting the key when empty. */
+function withChildren(node: NodeRecord, children: NodeRecord[]): NodeRecord {
+  const copy: NodeRecord = { ...node };
+  if (children.length > 0) {
+    copy.node = children;
+  } else {
+    delete copy.node;
+  }
+  return copy;
+}
+
+/* ------------------------------------------------------------------------ *
+ * FOCUS
+ * ------------------------------------------------------------------------ */
+
+/** Depth-first search for the first node matching a semantic anchor. */
+function findAnchor(nodes: NodeRecord[], anchor: FocusAnchor): NodeRecord | null {
+  for (const node of nodes) {
+    if (anchor.resourceId !== undefined && stringAttr(node, "resource-id") === anchor.resourceId) {
+      return node;
+    }
+    if (anchor.text !== undefined && anchor.text !== "" && stringAttr(node, "text").includes(anchor.text)) {
+      return node;
+    }
+    const found = findAnchor(childrenOf(node), anchor);
+    if (found) {
+      return found;
+    }
+  }
+  return null;
+}
+
+/** True when the node or any descendant belongs to the foreground package. */
+function subtreeHasPackage(node: NodeRecord, pkg: string): boolean {
+  const nodePkg = stringAttr(node, "package");
+  if (nodePkg === pkg) {
+    return true;
+  }
+  return childrenOf(node).some(child => subtreeHasPackage(child, pkg));
+}
+
+/**
+ * Prune a subtree to nodes belonging to (or on the path to) the foreground
+ * package. A node is retained when its own package matches, is unset (a generic
+ * container), or any descendant is retained — so chrome from other packages
+ * (`com.android.systemui`, IME) drops while app containers stay.
+ */
+function pruneToPackage(node: NodeRecord, pkg: string): NodeRecord | null {
+  const keptChildren = childrenOf(node)
+    .map(child => pruneToPackage(child, pkg))
+    .filter((child): child is NodeRecord => child !== null);
+  const nodePkg = stringAttr(node, "package");
+  const selfMatches = nodePkg === pkg || nodePkg === "";
+  if (keptChildren.length === 0 && !selfMatches) {
+    return null;
+  }
+  if (keptChildren.length === 0 && nodePkg === "") {
+    // A generic container with no matching descendants is empty chrome — drop it.
+    return null;
+  }
+  return withChildren(node, keptChildren);
+}
+
+function foregroundPackage(obs: ObserveResult): string {
+  return obs.viewHierarchy?.packageName || obs.activeWindow?.appId || "";
+}
+
+/**
+ * FOCUS transform. With an anchor, keep only the matched node's subtree. Without
+ * one, keep only the foreground app's nodes. Returns the (possibly unchanged)
+ * result plus how it resolved, for `observeScope`.
+ */
+export function scopeToFocus(
+  input: ObserveResult,
+  anchor?: FocusAnchor
+): { result: ObserveResult; focus: NonNullable<ObserveScopeMetadata["focus"]> } {
+  const obs = clone(input);
+  const roots = rootNodes(obs);
+
+  if (anchor && (anchor.resourceId !== undefined || anchor.text !== undefined)) {
+    const matched = findAnchor(roots, anchor);
+    if (matched) {
+      setRootNodes(obs, [matched]);
+    }
+    return { result: obs, focus: { by: "anchor", matched: matched !== null } };
+  }
+
+  const pkg = foregroundPackage(obs);
+  if (pkg === "") {
+    return { result: obs, focus: { by: "foreground-app", matched: false } };
+  }
+  const hasPackageAnywhere = roots.some(root => subtreeHasPackage(root, pkg));
+  if (!hasPackageAnywhere) {
+    // No node advertises the foreground package (e.g. iOS single-app roots) —
+    // scoping would blank the tree, so leave it untouched.
+    return { result: obs, focus: { by: "foreground-app", matched: false, packageName: pkg } };
+  }
+  const kept = roots
+    .map(root => pruneToPackage(root, pkg))
+    .filter((root): root is NodeRecord => root !== null);
+  setRootNodes(obs, kept);
+  return { result: obs, focus: { by: "foreground-app", matched: true, packageName: pkg } };
+}
+
+/* ------------------------------------------------------------------------ *
+ * REGION
+ * ------------------------------------------------------------------------ */
+
+/** The inset-adjusted content rectangle in pixels (screen minus system insets). */
+function contentRectPx(obs: ObserveResult): ElementBounds | null {
+  const size = obs.screenSize;
+  if (!size || typeof size.width !== "number" || typeof size.height !== "number") {
+    return null;
+  }
+  const insets = obs.systemInsets ?? { top: 0, bottom: 0, left: 0, right: 0 };
+  return {
+    left: insets.left ?? 0,
+    top: insets.top ?? 0,
+    right: size.width - (insets.right ?? 0),
+    bottom: size.height - (insets.bottom ?? 0),
+  };
+}
+
+/** Convert a normalized box to pixels using screen dimensions. */
+function regionToPx(obs: ObserveResult, box: NormalizedRegion): ElementBounds | null {
+  const size = obs.screenSize;
+  if (!size || typeof size.width !== "number" || typeof size.height !== "number") {
+    return null;
+  }
+  return {
+    left: box.x1 * size.width,
+    top: box.y1 * size.height,
+    right: box.x2 * size.width,
+    bottom: box.y2 * size.height,
+  };
+}
+
+/**
+ * Prune a node to the crop rectangle: keep it when its own bounds intersect the
+ * rect, or any descendant is kept, or it has no readable bounds (structural
+ * containers are never geometrically excluded). Off-rect leaves drop.
+ */
+function pruneToRect(node: NodeRecord, rect: ElementBounds): NodeRecord | null {
+  const keptChildren = childrenOf(node)
+    .map(child => pruneToRect(child, rect))
+    .filter((child): child is NodeRecord => child !== null);
+  if (keptChildren.length > 0) {
+    return withChildren(node, keptChildren);
+  }
+  const bounds = readBounds(attr(node, "bounds"));
+  if (bounds === null) {
+    return null;
+  }
+  return intersects(bounds, rect) ? withChildren(node, []) : null;
+}
+
+function filterElementsByRect(obs: ObserveResult, rect: ElementBounds): void {
+  const elements = obs.elements;
+  if (!elements) {
+    return;
+  }
+  const keep = <T extends { bounds?: unknown }>(item: T): boolean => {
+    const bounds = readBounds(item.bounds);
+    return bounds === null || intersects(bounds, rect);
+  };
+  elements.clickable = elements.clickable.filter(keep);
+  elements.scrollable = elements.scrollable.filter(keep);
+  elements.text = elements.text.filter(keep);
+  elements.media = elements.media.filter(keep);
+}
+
+/**
+ * REGION transform. Crops the hierarchy and the categorized `elements` to the
+ * pixel rectangle, and returns it for `observeScope`. When `box` is omitted the
+ * inset-adjusted content rectangle is used.
+ */
+export function scopeToRegion(
+  input: ObserveResult,
+  box?: NormalizedRegion
+): { result: ObserveResult; rectPx: ElementBounds | null } {
+  const obs = clone(input);
+  const rect = box ? regionToPx(obs, box) : contentRectPx(obs);
+  if (rect === null) {
+    return { result: obs, rectPx: null };
+  }
+  const kept = rootNodes(obs)
+    .map(root => pruneToRect(root, rect))
+    .filter((root): root is NodeRecord => root !== null);
+  setRootNodes(obs, kept);
+  filterElementsByRect(obs, rect);
+  return { result: obs, rectPx: rect };
+}
+
+/* ------------------------------------------------------------------------ *
+ * OVERVIEW
+ * ------------------------------------------------------------------------ */
+
+/** A node is structural when it has children, scrolls, or is addressable. */
+function isStructural(node: NodeRecord, hasKeptChildren: boolean): boolean {
+  return hasKeptChildren
+    || isTruthyFlag(attr(node, "scrollable"))
+    || stringAttr(node, "resource-id") !== "";
+}
+
+/** Keep only the structural-attribute allowlist on an overview node. */
+function trimToStructuralAttrs(node: NodeRecord): NodeRecord {
+  const out: NodeRecord = {};
+  for (const key of Object.keys(node)) {
+    if (key === "node") {
+      continue;
+    }
+    if (OVERVIEW_KEPT_ATTRS.has(key)) {
+      out[key] = node[key];
+    }
+  }
+  return out;
+}
+
+/**
+ * Collapse a subtree to its structural skeleton. Returns the retained node (or
+ * null when this node is an anonymous leaf) and `dropped` — the count of original
+ * nodes in this subtree NOT represented in the output. A dropped node has no kept
+ * descendants (`isStructural` forces any node with kept children to be kept), so
+ * dropping one drops its whole subtree. `dropped` below a kept node is surfaced as
+ * `omittedDescendants` so nothing vanishes silently.
+ */
+function toOverviewNode(node: NodeRecord): { node: NodeRecord | null; dropped: number } {
+  const results = childrenOf(node).map(toOverviewNode);
+  const keptChildren = results.map(r => r.node).filter((n): n is NodeRecord => n !== null);
+  const droppedBelow = results.reduce((sum, r) => sum + r.dropped, 0);
+
+  if (!isStructural(node, keptChildren.length > 0)) {
+    return { node: null, dropped: 1 + droppedBelow };
+  }
+
+  const trimmed = trimToStructuralAttrs(node);
+  if (keptChildren.length > 0) {
+    trimmed.node = keptChildren;
+  }
+  if (droppedBelow > 0) {
+    trimmed.omittedDescendants = droppedBelow;
+  }
+  return { node: trimmed, dropped: droppedBelow };
+}
+
+/**
+ * OVERVIEW transform. Drops `elements` (leaf-level detail the skeleton replaces)
+ * and collapses the hierarchy to structural/addressable nodes.
+ */
+export function toOverview(input: ObserveResult): ObserveResult {
+  const obs = clone(input);
+  const kept = rootNodes(obs)
+    .map(toOverviewNode)
+    .map(r => r.node)
+    .filter((n): n is NodeRecord => n !== null);
+  setRootNodes(obs, kept);
+  delete obs.elements;
+  return obs;
+}
+
+/* ------------------------------------------------------------------------ *
+ * Compose + resolve
+ * ------------------------------------------------------------------------ */
+
+/** Mutable accumulator threaded through the scope stages. */
+interface ScopeRun {
+  current: ObserveResult;
+  applied: ObserveScopeKind[];
+  regionPx?: ElementBounds;
+  focus?: ObserveScopeMetadata["focus"];
+}
+
+/** True when a stage changed the node count (i.e. it materially scoped). */
+function nodeCountChanged(before: ObserveResult, after: ObserveResult): boolean {
+  return countNodes(rootNodes(before)) !== countNodes(rootNodes(after));
+}
+
+function runFocusStage(run: ScopeRun, cfg: ObserveScopeConfig): void {
+  const { result, focus } = scopeToFocus(run.current, cfg.focusAnchor);
+  run.focus = focus;
+  if (nodeCountChanged(run.current, result)) {
+    run.applied.push("focus");
+  }
+  run.current = result;
+}
+
+function runRegionStage(run: ScopeRun, cfg: ObserveScopeConfig): void {
+  const { result, rectPx } = scopeToRegion(run.current, cfg.regionBox);
+  if (rectPx) {
+    run.regionPx = rectPx;
+  }
+  if (nodeCountChanged(run.current, result)) {
+    run.applied.push("region");
+  }
+  run.current = result;
+}
+
+function runOverviewStage(run: ScopeRun): void {
+  // OVERVIEW always materially transforms (trims attributes, drops `elements`)
+  // even when the node count is unchanged, so it is unconditionally recorded.
+  run.current = toOverview(run.current);
+  run.applied.push("overview");
+}
+
+function buildScopeMetadata(run: ScopeRun, nodesBefore: number): ObserveScopeMetadata {
+  const metadata: ObserveScopeMetadata = {
+    applied: run.applied,
+    nodesBefore,
+    nodesAfter: countNodes(rootNodes(run.current)),
+  };
+  if (run.regionPx) {
+    metadata.regionPx = run.regionPx;
+  }
+  if (run.focus) {
+    metadata.focus = run.focus;
+  }
+  return metadata;
+}
+
+/**
+ * Apply the enabled scope transforms in order (focus -> region -> overview) and
+ * annotate `observeScope`. Pure: the input is never mutated. When nothing is
+ * enabled, returns the input unchanged (no clone, no metadata).
+ */
+export function applyObserveScopeExperiments(
+  input: ObserveResult,
+  cfg: ObserveScopeConfig
+): ObserveResult {
+  if (!cfg.focus && !cfg.region && !cfg.overview) {
+    return input;
+  }
+
+  const nodesBefore = countNodes(rootNodes(input));
+  const run: ScopeRun = { current: input, applied: [] };
+
+  if (cfg.focus) {
+    runFocusStage(run, cfg);
+  }
+  if (cfg.region) {
+    runRegionStage(run, cfg);
+  }
+  if (cfg.overview) {
+    runOverviewStage(run);
+  }
+
+  // Every stage returns a fresh clone, so `run.current` is never the input here;
+  // guard the theoretically-unreachable no-op case anyway.
+  const out = run.current === input ? clone(input) : run.current;
+  out.observeScope = buildScopeMetadata({ ...run, current: out }, nodesBefore);
+  return out;
+}
+
+/** The server experiment gates; each honors its `scope` dimension only when on. */
+export interface ObserveScopeFlags {
+  focus: boolean;
+  overview: boolean;
+  region: boolean;
+}
+
+/** A dimension is requested when the call set it to `true` or an object (not `false`/absent). */
+function isDimensionRequested(dim: boolean | object | undefined): boolean {
+  return dim !== undefined && dim !== false;
+}
+
+/** The anchor object of a `focus` request, or undefined for the `true` (foreground) form. */
+function focusAnchorOf(focus: ObserveScopeInput["focus"]): FocusAnchor | undefined {
+  return typeof focus === "object" ? focus : undefined;
+}
+
+/** The box of a `region` request, or undefined for the `true` (content-rect) form. */
+function regionBoxOf(region: ObserveScopeInput["region"]): NormalizedRegion | undefined {
+  return typeof region === "object" ? region : undefined;
+}
+
+/**
+ * Build an {@link ObserveScopeConfig} by intersecting the per-call `scope` request
+ * (from the `observe` tool input — where the agent picks where to zoom on THIS
+ * screen) with the server experiment flags. A dimension is applied only when both
+ * the call asked for it AND its flag is enabled, so the flag stays the dark-launch
+ * gate while the parameters travel in the tool call, not the environment.
+ */
+export function buildObserveScopeConfig(
+  flags: ObserveScopeFlags,
+  scope: ObserveScopeInput | undefined
+): ObserveScopeConfig {
+  return {
+    focus: flags.focus && isDimensionRequested(scope?.focus),
+    focusAnchor: focusAnchorOf(scope?.focus),
+    overview: flags.overview && scope?.overview === true,
+    region: flags.region && isDimensionRequested(scope?.region),
+    regionBox: regionBoxOf(scope?.region),
+  };
+}

--- a/src/features/observe/output/ObserveScopeExperiments.ts
+++ b/src/features/observe/output/ObserveScopeExperiments.ts
@@ -212,24 +212,40 @@ function findAnchor(nodes: NodeRecord[], anchor: FocusAnchor): NodeRecord | null
  * resource-id (and its package qualifier) is on the allow-list, and Android
  * system chrome carries ids like `com.android.systemui:id/...`.
  */
-function resourceIdPackage(node: NodeRecord): string {
-  const rid = stringAttr(node, "resource-id");
+function resourceIdPackage(rid: string): string {
   const colon = rid.indexOf(":");
   return colon > 0 ? rid.slice(0, colon) : "";
 }
 
 /**
- * Drop subtrees rooted at an identifiable NON-foreground package — status bar,
- * nav bar, and IME all carry package-qualified resource-ids
- * (`com.android.systemui:id/...`, the keyboard package, …). A node with no
- * package-qualified id (a generic container, or an app/Compose/iOS leaf whose
- * identity is text/content-desc) is neutral and kept, so real app content is
- * never dropped merely for lacking a qualified id. On iOS, where nodes carry no
- * `pkg:id/...` resource-ids at all, nothing is foreign, so this is a safe no-op.
+ * A resource-id package prefix names FOREIGN system chrome only when it is a
+ * REAL dotted Android package other than the foreground app. The dot test is
+ * load-bearing and prevents two catastrophic false positives:
+ *
+ *  - The `android:` framework namespace (`android:id/content` — the setContentView
+ *    host present in EVERY app window — plus AlertDialog `android:id/button1`,
+ *    ActionBar, and list framework ids) belongs to APP content, not chrome.
+ *    Prefix `android` has no dot, so it is neutral and kept; without this guard
+ *    FOCUS would empty the app subtree in the common dialog / content-view case.
+ *  - iOS accessibility identifiers (`row:0`, `section:2:cell:1`) split on their
+ *    colon to an undotted prefix, so iOS is a natural no-op — a dotted-package
+ *    prefix is an Android shape iOS does not produce.
+ *
+ * Real chrome (`com.android.systemui:id/...`, the dotted IME package) and other
+ * apps' windows keep their dotted prefixes and are correctly dropped.
+ */
+function isForeignPackage(pkg: string, fgPackage: string): boolean {
+  return pkg.includes(".") && pkg !== fgPackage;
+}
+
+/**
+ * Drop subtrees rooted at an identifiable foreign-package node — status bar, nav
+ * bar, IME. A node with no dotted-package resource-id (a generic container, an
+ * `android:`-framework host, or an app/Compose/iOS leaf) is neutral and kept, so
+ * real app content is never dropped merely for its id namespace.
  */
 function pruneForeignChrome(node: NodeRecord, fgPackage: string): NodeRecord | null {
-  const pkg = resourceIdPackage(node);
-  if (pkg !== "" && pkg !== fgPackage) {
+  if (isForeignPackage(resourceIdPackage(stringAttr(node, "resource-id")), fgPackage)) {
     return null;
   }
   const keptChildren = childrenOf(node)
@@ -242,12 +258,10 @@ function foregroundPackage(obs: ObserveResult): string {
   return obs.viewHierarchy?.packageName || obs.activeWindow?.appId || "";
 }
 
-/** Whether an `Element`-shaped record belongs to an identifiable non-fg package. */
+/** Whether an `Element`-shaped record belongs to a foreign (chrome) package. */
 function isForeignElement(item: { "resource-id"?: unknown }, fgPackage: string): boolean {
   const rid = typeof item["resource-id"] === "string" ? item["resource-id"] : "";
-  const colon = rid.indexOf(":");
-  const pkg = colon > 0 ? rid.slice(0, colon) : "";
-  return pkg !== "" && pkg !== fgPackage;
+  return isForeignPackage(resourceIdPackage(rid), fgPackage);
 }
 
 /**

--- a/src/features/observe/output/ObserveScopeExperiments.ts
+++ b/src/features/observe/output/ObserveScopeExperiments.ts
@@ -205,34 +205,36 @@ function findAnchor(nodes: NodeRecord[], anchor: FocusAnchor): NodeRecord | null
   return null;
 }
 
-/** True when the node or any descendant belongs to the foreground package. */
-function subtreeHasPackage(node: NodeRecord, pkg: string): boolean {
-  const nodePkg = stringAttr(node, "package");
-  if (nodePkg === pkg) {
-    return true;
-  }
-  return childrenOf(node).some(child => subtreeHasPackage(child, pkg));
+/**
+ * The package prefix of a resource-id — `com.pkg:id/name` -> `com.pkg`, `""` when
+ * absent or unqualified. This is the app-vs-chrome signal that SURVIVES capture:
+ * per-node `package` is dropped by `ViewHierarchy.cleanNodeProperties`, but the
+ * resource-id (and its package qualifier) is on the allow-list, and Android
+ * system chrome carries ids like `com.android.systemui:id/...`.
+ */
+function resourceIdPackage(node: NodeRecord): string {
+  const rid = stringAttr(node, "resource-id");
+  const colon = rid.indexOf(":");
+  return colon > 0 ? rid.slice(0, colon) : "";
 }
 
 /**
- * Prune a subtree to nodes belonging to (or on the path to) the foreground
- * package. A node is retained when its own package matches, is unset (a generic
- * container), or any descendant is retained — so chrome from other packages
- * (`com.android.systemui`, IME) drops while app containers stay.
+ * Drop subtrees rooted at an identifiable NON-foreground package — status bar,
+ * nav bar, and IME all carry package-qualified resource-ids
+ * (`com.android.systemui:id/...`, the keyboard package, …). A node with no
+ * package-qualified id (a generic container, or an app/Compose/iOS leaf whose
+ * identity is text/content-desc) is neutral and kept, so real app content is
+ * never dropped merely for lacking a qualified id. On iOS, where nodes carry no
+ * `pkg:id/...` resource-ids at all, nothing is foreign, so this is a safe no-op.
  */
-function pruneToPackage(node: NodeRecord, pkg: string): NodeRecord | null {
+function pruneForeignChrome(node: NodeRecord, fgPackage: string): NodeRecord | null {
+  const pkg = resourceIdPackage(node);
+  if (pkg !== "" && pkg !== fgPackage) {
+    return null;
+  }
   const keptChildren = childrenOf(node)
-    .map(child => pruneToPackage(child, pkg))
+    .map(child => pruneForeignChrome(child, fgPackage))
     .filter((child): child is NodeRecord => child !== null);
-  const nodePkg = stringAttr(node, "package");
-  const selfMatches = nodePkg === pkg || nodePkg === "";
-  if (keptChildren.length === 0 && !selfMatches) {
-    return null;
-  }
-  if (keptChildren.length === 0 && nodePkg === "") {
-    // A generic container with no matching descendants is empty chrome — drop it.
-    return null;
-  }
   return withChildren(node, keptChildren);
 }
 
@@ -240,10 +242,34 @@ function foregroundPackage(obs: ObserveResult): string {
   return obs.viewHierarchy?.packageName || obs.activeWindow?.appId || "";
 }
 
+/** Whether an `Element`-shaped record belongs to an identifiable non-fg package. */
+function isForeignElement(item: { "resource-id"?: unknown }, fgPackage: string): boolean {
+  const rid = typeof item["resource-id"] === "string" ? item["resource-id"] : "";
+  const colon = rid.indexOf(":");
+  const pkg = colon > 0 ? rid.slice(0, colon) : "";
+  return pkg !== "" && pkg !== fgPackage;
+}
+
+/**
+ * Drop categorized elements whose resource-id names a non-foreground package.
+ * Only the three id-bearing categories are filtered — `media` (MediaView) carries
+ * no resource-id, so it has no package identity to be foreign by and is left as-is.
+ */
+function filterElementsByForeignPackage(obs: ObserveResult, fgPackage: string): void {
+  const elements = obs.elements;
+  if (!elements) {
+    return;
+  }
+  const keep = (item: { "resource-id"?: unknown }): boolean => !isForeignElement(item, fgPackage);
+  elements.clickable = (elements.clickable ?? []).filter(keep);
+  elements.scrollable = (elements.scrollable ?? []).filter(keep);
+  elements.text = (elements.text ?? []).filter(keep);
+}
+
 /**
  * FOCUS transform. With an anchor, keep only the matched node's subtree. Without
- * one, keep only the foreground app's nodes. Returns the (possibly unchanged)
- * result plus how it resolved, for `observeScope`.
+ * one (`scope.focus: true`), drop identifiable non-foreground chrome. Returns the
+ * (possibly unchanged) result plus how it resolved, for `observeScope`.
  */
 export function scopeToFocus(
   input: ObserveResult,
@@ -264,17 +290,17 @@ export function scopeToFocus(
   if (pkg === "") {
     return { result: obs, focus: { by: "foreground-app", matched: false } };
   }
-  const hasPackageAnywhere = roots.some(root => subtreeHasPackage(root, pkg));
-  if (!hasPackageAnywhere) {
-    // No node advertises the foreground package (e.g. iOS single-app roots) —
-    // scoping would blank the tree, so leave it untouched.
-    return { result: obs, focus: { by: "foreground-app", matched: false, packageName: pkg } };
-  }
+  const before = countNodes(roots);
   const kept = roots
-    .map(root => pruneToPackage(root, pkg))
+    .map(root => pruneForeignChrome(root, pkg))
     .filter((root): root is NodeRecord => root !== null);
   setRootNodes(obs, kept);
-  return { result: obs, focus: { by: "foreground-app", matched: true, packageName: pkg } };
+  filterElementsByForeignPackage(obs, pkg);
+  // `matched` reports whether any foreign chrome was actually pruned. When the
+  // tree is already just the app (or iOS carries no qualified ids) nothing drops
+  // and it stays false — an honest "no reduction" signal.
+  const matched = countNodes(kept) !== before;
+  return { result: obs, focus: { by: "foreground-app", matched, packageName: pkg } };
 }
 
 /* ------------------------------------------------------------------------ *
@@ -324,7 +350,9 @@ function pruneToRect(node: NodeRecord, rect: ElementBounds): NodeRecord | null {
   }
   const bounds = readBounds(attr(node, "bounds"));
   if (bounds === null) {
-    return null;
+    // No readable bounds: never geometrically excluded — a container/leaf we
+    // cannot place is kept rather than silently dropped.
+    return withChildren(node, []);
   }
   return intersects(bounds, rect) ? withChildren(node, []) : null;
 }
@@ -338,10 +366,12 @@ function filterElementsByRect(obs: ObserveResult, rect: ElementBounds): void {
     const bounds = readBounds(item.bounds);
     return bounds === null || intersects(bounds, rect);
   };
-  elements.clickable = elements.clickable.filter(keep);
-  elements.scrollable = elements.scrollable.filter(keep);
-  elements.text = elements.text.filter(keep);
-  elements.media = elements.media.filter(keep);
+  // Guard each category: the ObserveResult type makes them non-optional arrays,
+  // but this runs at the wire chokepoint where a malformed payload must not throw.
+  elements.clickable = (elements.clickable ?? []).filter(keep);
+  elements.scrollable = (elements.scrollable ?? []).filter(keep);
+  elements.text = (elements.text ?? []).filter(keep);
+  elements.media = (elements.media ?? []).filter(keep);
 }
 
 /**
@@ -370,11 +400,21 @@ export function scopeToRegion(
  * OVERVIEW
  * ------------------------------------------------------------------------ */
 
-/** A node is structural when it has children, scrolls, or is addressable. */
+/**
+ * A node is structural — kept in the skeleton — when it has kept children,
+ * scrolls, or is addressable. "Addressable" is any of the identity/interaction
+ * attributes an agent targets: `resource-id`, `content-desc`, or `clickable`.
+ * Consulting `clickable`/`content-desc` (both in `OVERVIEW_KEPT_ATTRS`) is what
+ * keeps id-less-but-tappable controls — common on Compose and iOS, where the
+ * accessibility label, not a resource-id, is the identity — instead of collapsing
+ * them into an `omittedDescendants` count.
+ */
 function isStructural(node: NodeRecord, hasKeptChildren: boolean): boolean {
   return hasKeptChildren
     || isTruthyFlag(attr(node, "scrollable"))
-    || stringAttr(node, "resource-id") !== "";
+    || isTruthyFlag(attr(node, "clickable"))
+    || stringAttr(node, "resource-id") !== ""
+    || stringAttr(node, "content-desc") !== "";
 }
 
 /** Keep only the structural-attribute allowlist on an overview node. */
@@ -421,6 +461,13 @@ function toOverviewNode(node: NodeRecord): { node: NodeRecord | null; dropped: n
 /**
  * OVERVIEW transform. Drops `elements` (leaf-level detail the skeleton replaces)
  * and collapses the hierarchy to structural/addressable nodes.
+ *
+ * `omittedDescendants` annotates each SURVIVING node with the count of nodes
+ * dropped beneath it. A root subtree that collapses entirely (all-anonymous) has
+ * no surviving node to annotate; that omission is still surfaced globally by
+ * `observeScope.nodesBefore` vs `nodesAfter`, so nothing vanishes unaccounted for.
+ * A consumer must NOT sum `omittedDescendants` across nodes — an ancestor's count
+ * already subsumes its descendants'.
  */
 export function toOverview(input: ObserveResult): ObserveResult {
   const obs = clone(input);
@@ -445,15 +492,30 @@ interface ScopeRun {
   focus?: ObserveScopeMetadata["focus"];
 }
 
-/** True when a stage changed the node count (i.e. it materially scoped). */
-function nodeCountChanged(before: ObserveResult, after: ObserveResult): boolean {
-  return countNodes(rootNodes(before)) !== countNodes(rootNodes(after));
+/** Total categorized elements across all four buckets. */
+function elementsCount(obs: ObserveResult): number {
+  const e = obs.elements;
+  if (!e) {
+    return 0;
+  }
+  return (e.clickable?.length ?? 0) + (e.scrollable?.length ?? 0) + (e.text?.length ?? 0) + (e.media?.length ?? 0);
+}
+
+/**
+ * True when a stage materially scoped the payload — a change in either the node
+ * count OR the categorized element count. FOCUS and REGION both prune `elements`,
+ * so a crop that removed only off-scope elements (no hierarchy nodes) still counts
+ * as applied; without the element check `applied[]` would under-report it.
+ */
+function scopeChanged(before: ObserveResult, after: ObserveResult): boolean {
+  return countNodes(rootNodes(before)) !== countNodes(rootNodes(after))
+    || elementsCount(before) !== elementsCount(after);
 }
 
 function runFocusStage(run: ScopeRun, cfg: ObserveScopeConfig): void {
   const { result, focus } = scopeToFocus(run.current, cfg.focusAnchor);
   run.focus = focus;
-  if (nodeCountChanged(run.current, result)) {
+  if (scopeChanged(run.current, result)) {
     run.applied.push("focus");
   }
   run.current = result;
@@ -464,7 +526,7 @@ function runRegionStage(run: ScopeRun, cfg: ObserveScopeConfig): void {
   if (rectPx) {
     run.regionPx = rectPx;
   }
-  if (nodeCountChanged(run.current, result)) {
+  if (scopeChanged(run.current, result)) {
     run.applied.push("region");
   }
   run.current = result;

--- a/src/index.ts
+++ b/src/index.ts
@@ -377,11 +377,56 @@ async function main() {
       process.exit(0);
     }
 
+    // Single source of truth for the startup options handed to the daemon,
+    // shared by BOTH transports (issue #4344 propagation audit). Threading the
+    // full set into the `--cli` path too — not just
+    // `{safeAreaWarnings, embeddedSdk, networkMockable}` — closes a gap where
+    // output-reduction / observe-scope / a11y-audit / predictive flags requested
+    // on the CLI transport never reached (or restarted) the daemon, while the
+    // stdio proxy path relayed them. One object also means the two transports can
+    // never drift apart again.
+    const daemonStartupOptions: DaemonOptions = {
+      debug,
+      debugPerf,
+      planExecutionLockScope,
+      mcpRecording,
+      videoQualityPreset: videoRecordingDefaults.qualityPreset,
+      videoTargetBitrateKbps: videoRecordingDefaults.targetBitrateKbps,
+      videoMaxThroughputMbps: videoRecordingDefaults.maxThroughputMbps,
+      videoFps: videoRecordingDefaults.fps,
+      videoFormat: videoRecordingDefaults.format,
+      videoMaxArchiveSizeMb: videoRecordingDefaults.maxArchiveSizeMb,
+      toolOutputsDir,
+      networkMockable,
+      embeddedSdk,
+      dismissKeyboardAfterInput,
+      ...eventAllMarkerDaemonOptions,
+      noUiPerfMode: !uiPerfMode,
+      memPerfAudit: memPerfAuditMode,
+      accessibilityAudit: a11yAuditMode,
+      accessibilityLevel: a11yLevel,
+      accessibilityFailureMode: a11yFailureMode,
+      accessibilityMinSeverity: a11yMinSeverity,
+      accessibilityUseBaseline: a11yUseBaseline,
+      predictiveUi,
+      rawElementSearch,
+      skipCtrlProxyDownload,
+      noNavigationScreenshots: !navigationScreenshots,
+      noWaitForPollingOverhead,
+      noA11yIncludeNotImportantViews,
+      noA11yReportViewIds,
+      noA11yRetrieveInteractiveWindows,
+      noOcclusion,
+      safeAreaWarnings,
+      // OutputReductionFlags field names match these DaemonOptions fields 1:1.
+      ...outputReduction,
+    };
+
     if (cliMode) {
       // Run in CLI mode
       logger.info("Running in CLI mode");
       // logger.enableStdoutLogging();
-      await runCliCommand(cliArgs, { safeAreaWarnings, embeddedSdk, networkMockable });
+      await runCliCommand(cliArgs, daemonStartupOptions);
       // CRITICAL: Exit explicitly after CLI command completes to prevent process from hanging
       // The event loop may have pending operations (ADB connections, file descriptors) that
       // prevent Node.js from exiting naturally. Force exit with code 0 to ensure clean termination.
@@ -392,44 +437,6 @@ async function main() {
       // The daemon manages device state and tool execution
       // In no-proxy mode (--no-proxy flag), the MCP server executes tools directly
       const useProxyMode = !noProxy;
-
-      // Construct daemon options from CLI args to pass when auto-starting daemon
-      const proxyDaemonOptions: DaemonOptions = {
-        debug,
-        debugPerf,
-        planExecutionLockScope,
-        mcpRecording,
-        videoQualityPreset: videoRecordingDefaults.qualityPreset,
-        videoTargetBitrateKbps: videoRecordingDefaults.targetBitrateKbps,
-        videoMaxThroughputMbps: videoRecordingDefaults.maxThroughputMbps,
-        videoFps: videoRecordingDefaults.fps,
-        videoFormat: videoRecordingDefaults.format,
-        videoMaxArchiveSizeMb: videoRecordingDefaults.maxArchiveSizeMb,
-        toolOutputsDir,
-        networkMockable,
-        embeddedSdk,
-        dismissKeyboardAfterInput,
-        ...eventAllMarkerDaemonOptions,
-        noUiPerfMode: !uiPerfMode,
-        memPerfAudit: memPerfAuditMode,
-        accessibilityAudit: a11yAuditMode,
-        accessibilityLevel: a11yLevel,
-        accessibilityFailureMode: a11yFailureMode,
-        accessibilityMinSeverity: a11yMinSeverity,
-        accessibilityUseBaseline: a11yUseBaseline,
-        predictiveUi,
-        rawElementSearch,
-        skipCtrlProxyDownload,
-        noNavigationScreenshots: !navigationScreenshots,
-        noWaitForPollingOverhead,
-        noA11yIncludeNotImportantViews,
-        noA11yReportViewIds,
-        noA11yRetrieveInteractiveWindows,
-        noOcclusion,
-        safeAreaWarnings,
-        // OutputReductionFlags field names match these DaemonOptions fields 1:1.
-        ...outputReduction,
-      };
 
       if (useProxyMode) {
         logger.info("Starting MCP server in proxy mode (connecting to daemon)");
@@ -463,7 +470,7 @@ async function main() {
       try {
         if (useProxyMode) {
           const result = createProxyMcpServer({
-            proxyConfig: { autoStartDaemon: !noDaemon, daemonOptions: proxyDaemonOptions }
+            proxyConfig: { autoStartDaemon: !noDaemon, daemonOptions: daemonStartupOptions }
           });
           server = result.server;
           stdioProxy = result.proxy;

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -16,6 +16,7 @@ import { RawViewHierarchyResult } from "./RawViewHierarchyResult";
 import type { MediaView } from "../features/observe/IdentifyMediaViews";
 import type { ObserveError } from "../features/observe/ObserveError";
 import type { LayoutWarning, ObservationInsets } from "./ObservationInsets";
+import type { ObserveScopeMetadata } from "./ObserveScope";
 
 export interface PredictionTarget {
   text?: string;
@@ -263,6 +264,15 @@ export interface ObserveResult {
    * the pre-offscreen-filter hierarchy (iOS)
    */
   rawViewHierarchy?: RawViewHierarchyResult;
+
+  /**
+   * Progressive-disclosure scoping metadata (issue #4344), present only when an
+   * `--observe-focus-scope` / `--observe-overview` / `--observe-region`
+   * experiment scoped this observe payload. Records which transforms ran and the
+   * node-count reduction so the experiment is measurable on the wire. See
+   * `features/observe/output/ObserveScopeExperiments.ts`.
+   */
+  observeScope?: ObserveScopeMetadata;
 }
 
 /**

--- a/src/models/ObserveScope.ts
+++ b/src/models/ObserveScope.ts
@@ -1,0 +1,60 @@
+import type { ElementBounds } from "./ElementBounds";
+
+/**
+ * Wire-data types for the `observe` progressive-disclosure scoping experiments
+ * (issue #4344). Kept in `models/` (not the feature module) so `ObserveResult`
+ * can carry `observeScope` without depending on `features/`. The transforms that
+ * produce these live in `features/observe/output/ObserveScopeExperiments.ts`.
+ */
+
+/** A normalized crop box, each coordinate in [0, 1]; `(0,0)` is the top-left. */
+export interface NormalizedRegion {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+/** A semantic anchor for FOCUS: match the first node by resource-id or text. */
+export interface FocusAnchor {
+  resourceId?: string;
+  text?: string;
+}
+
+/**
+ * Per-call scoping request carried on the `observe` tool input (`scope`). The
+ * agent chooses where to zoom on THIS screen — env vars can't vary per call.
+ * Each dimension is honored only when its server experiment flag is enabled.
+ *
+ *  - `focus`: `true` scopes to the foreground app; an anchor object scopes to the
+ *    first node matching `resourceId`/`text`.
+ *  - `region`: `true` crops to the inset content rectangle; a box crops to that
+ *    normalized rectangle.
+ *  - `overview`: `true` collapses to the container skeleton.
+ */
+export interface ObserveScopeInput {
+  focus?: boolean | FocusAnchor;
+  region?: boolean | NormalizedRegion;
+  overview?: boolean;
+}
+
+/** Which scope transform ran, in application order. */
+export type ObserveScopeKind = "focus" | "region" | "overview";
+
+/** Measurement metadata attached to a scoped `ObserveResult` (`observeScope`). */
+export interface ObserveScopeMetadata {
+  /** Transforms that actually changed the tree, in application order. */
+  applied: ObserveScopeKind[];
+  /** Hierarchy node count before any scoping. */
+  nodesBefore: number;
+  /** Hierarchy node count after all scoping. */
+  nodesAfter: number;
+  /** The pixel rectangle REGION cropped to, when REGION applied. */
+  regionPx?: ElementBounds;
+  /** How FOCUS resolved its subtree, when FOCUS applied. */
+  focus?: {
+    by: "anchor" | "foreground-app";
+    matched: boolean;
+    packageName?: string;
+  };
+}

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -5,6 +5,11 @@ import {
   isSameObservationScreen,
   type SanitizeObserveConfig,
 } from "../features/observe/output/ObserveResultOutput";
+import {
+  applyObserveScopeExperiments,
+  buildObserveScopeConfig,
+} from "../features/observe/output/ObserveScopeExperiments";
+import type { ObserveScopeInput } from "../models/ObserveScope";
 import { isInPlacePressButton, isNavigationPressButton } from "../features/action/pressButtonPolicy";
 import { serverConfig } from "../utils/ServerConfig";
 import { getStructuredPayload, stringifyToolResponse } from "../utils/toolUtils";
@@ -209,6 +214,16 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
     compact: serverConfig.isObserveResultCompactEnabled(),
   };
 
+  // Progressive-disclosure scoping experiments (issue #4344). Agent-facing only:
+  // internal tool-to-tool consumers read the full `.observation.viewHierarchy`, so
+  // scoping (like the diff/strip transforms) is suppressed for `ctx.internal`.
+  const scopeFlags = {
+    focus: serverConfig.isObserveFocusScopeEnabled(),
+    overview: serverConfig.isObserveOverviewEnabled(),
+    region: serverConfig.isObserveRegionEnabled(),
+  };
+  const scopeActive = !ctx.internal && (scopeFlags.focus || scopeFlags.overview || scopeFlags.region);
+
   // Internal tool-to-tool calls (#3053) always get the full sanitized observation:
   // the diff/strip transforms are for the agent-facing wire only, so an internal
   // consumer reading `.observation.viewHierarchy` off a finalized step envelope is
@@ -229,9 +244,17 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
     // strips the observe tool itself) and resets the diff baseline to it (#2761).
     const sanitized = sanitizeObserveResult(payload as unknown as ObserveResult, cfg);
     if (canDiff) {
+      // Diff against the full sanitized tree, never the scoped copy — the next
+      // action must see real state, not what this observe payload was cropped to.
       pendingBaselineUpdate = { sessionUuid: ctx.sessionUuid!, observation: sanitized };
     }
-    sanitizedPayload = sanitized as unknown as Record<string, unknown>;
+    const served = scopeActive
+      ? applyObserveScopeExperiments(
+        sanitized,
+        buildObserveScopeConfig(scopeFlags, ctx.args?.scope as ObserveScopeInput | undefined)
+      )
+      : sanitized;
+    sanitizedPayload = served as unknown as Record<string, unknown>;
     hasArtifactableObservation = true;
   } else if (!isObserveTool && payload.observation !== undefined) {
     if (noObserveEnabled) {

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -196,11 +196,41 @@ const COMPACT_WAITFOR_ADVERTISED_SCHEMA: Record<string, unknown> = {
   ],
 };
 
+// Progressive-disclosure scoping of the returned hierarchy (issue #4344). The
+// agent picks where to zoom on THIS screen, so region/anchor are per-call inputs
+// (not env). Each dimension is honored only when its server experiment flag is
+// enabled: --observe-focus-scope, --observe-region, --observe-overview.
+const observeScopeFocusSchema = z.union([
+  z.boolean(),
+  z.object({
+    resourceId: z.string().optional().describe("Anchor by exact resource-id"),
+    text: z.string().optional().describe("Anchor by substring text match")
+  })
+]).describe("Scope to a subtree: true = foreground app; {resourceId|text} = anchor. Needs --observe-focus-scope.");
+
+const observeScopeRegionBoxSchema = z.object({
+  x1: z.number().min(0).max(1),
+  y1: z.number().min(0).max(1),
+  x2: z.number().min(0).max(1),
+  y2: z.number().min(0).max(1)
+}).refine(b => b.x1 < b.x2 && b.y1 < b.y2, {
+  message: "region requires x1 < x2 and y1 < y2"
+});
+
+const observeScopeSchema = z.object({
+  focus: observeScopeFocusSchema.optional(),
+  region: z.union([z.boolean(), observeScopeRegionBoxSchema])
+    .optional()
+    .describe("Crop to a normalized 0..1 box; true = inset content rect. Needs --observe-region."),
+  overview: z.boolean().optional().describe("Collapse to a container skeleton. Needs --observe-overview.")
+}).describe("Experimental progressive-disclosure scoping of the returned hierarchy (issue #4344)");
+
 const observeBaseSchema = withJsonSchemaOverride(addDeviceTargetingToSchema(z.object({
   platform: platformSchema,
   waitFor: waitForSchema.optional().describe("Wait for element to appear before returning observation"),
   raw: z.boolean().optional().describe("Include raw view hierarchy"),
-  skipBackStack: z.boolean().optional().describe("Skip back stack during waitFor polling")
+  skipBackStack: z.boolean().optional().describe("Skip back stack during waitFor polling"),
+  scope: observeScopeSchema.optional()
 })).superRefine((value, ctx) => {
   const activeWindow = value.waitFor?.activeWindow;
   if (

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -411,6 +411,24 @@ export const deviceLockSchema = z.object({
   secure: z.boolean().optional(),
 });
 
+/**
+ * Progressive-disclosure scoping metadata (issue #4344), present only when an
+ * `--observe-focus-scope` / `--observe-overview` / `--observe-region` experiment
+ * scoped the payload. `regionPx` routes through {@link elementBoundsSchema} so its
+ * bounds advertise the `--observe-result-compact` tuple like every other bounds.
+ */
+export const observeScopeMetadataSchema = z.object({
+  applied: z.array(z.enum(["focus", "region", "overview"])),
+  nodesBefore: z.number().int().nonnegative(),
+  nodesAfter: z.number().int().nonnegative(),
+  regionPx: elementBoundsSchema.optional(),
+  focus: z.object({
+    by: z.enum(["anchor", "foreground-app"]),
+    matched: z.boolean(),
+    packageName: z.string().optional()
+  }).passthrough().optional()
+}).passthrough();
+
 export const observeResultSchema = z.object({
   screenSize: screenSizeSchema.optional(),
   systemInsets: systemInsetsSchema.optional(),
@@ -427,7 +445,8 @@ export const observeResultSchema = z.object({
   freshness: freshnessSchema.optional(),
   predictions: predictionsSchema.optional(),
   accessibilityState: accessibilityStateSchema.optional(),
-  deviceLock: deviceLockSchema.optional()
+  deviceLock: deviceLockSchema.optional(),
+  observeScope: observeScopeMetadataSchema.optional()
 }).passthrough();
 
 export const observeToolResultSchema = z.union([

--- a/src/utils/ServerConfig.ts
+++ b/src/utils/ServerConfig.ts
@@ -43,6 +43,9 @@ class ServerConfig {
   private _actionsDiffObserve: boolean = false;
   private _actionsNoObserve: boolean = false;
   private _toolResultsCompactJson: boolean = false;
+  private _observeFocusScope: boolean = false;
+  private _observeOverview: boolean = false;
+  private _observeRegion: boolean = false;
   private _safeAreaWarningsEnabled: boolean = false;
   private _toolOutputsDir: string | undefined;
 
@@ -302,6 +305,30 @@ class ServerConfig {
 
   isToolResultsCompactJsonEnabled(): boolean {
     return this._toolResultsCompactJson;
+  }
+
+  setObserveFocusScopeEnabled(enabled: boolean): void {
+    this._observeFocusScope = enabled;
+  }
+
+  isObserveFocusScopeEnabled(): boolean {
+    return this._observeFocusScope;
+  }
+
+  setObserveOverviewEnabled(enabled: boolean): void {
+    this._observeOverview = enabled;
+  }
+
+  isObserveOverviewEnabled(): boolean {
+    return this._observeOverview;
+  }
+
+  setObserveRegionEnabled(enabled: boolean): void {
+    this._observeRegion = enabled;
+  }
+
+  isObserveRegionEnabled(): boolean {
+    return this._observeRegion;
   }
 
 }

--- a/src/utils/outputReductionFlags.ts
+++ b/src/utils/outputReductionFlags.ts
@@ -14,6 +14,14 @@ export interface OutputReductionFlags {
   actionsDiffObserve: boolean;
   actionsNoObserve: boolean;
   toolResultsCompactJson: boolean;
+  /**
+   * Progressive-disclosure scoping experiments for the `observe` payload
+   * (issue #4344). Independent transforms — see
+   * `features/observe/output/ObserveScopeExperiments.ts`.
+   */
+  observeFocusScope: boolean;
+  observeOverview: boolean;
+  observeRegion: boolean;
 }
 
 export type OutputReductionFlagField = keyof OutputReductionFlags;
@@ -74,6 +82,27 @@ export const OUTPUT_REDUCTION_FLAG_SPECS: OutputReductionFlagSpec[] = [
     featureFlagKey: "tool-results-compact-json",
     label: "--tool-results-compact-json",
   },
+  {
+    field: "observeFocusScope",
+    cli: "--observe-focus-scope",
+    env: "AUTOMOBILE_OBSERVE_FOCUS_SCOPE",
+    featureFlagKey: "observe-focus-scope",
+    label: "--observe-focus-scope",
+  },
+  {
+    field: "observeOverview",
+    cli: "--observe-overview",
+    env: "AUTOMOBILE_OBSERVE_OVERVIEW",
+    featureFlagKey: "observe-overview",
+    label: "--observe-overview",
+  },
+  {
+    field: "observeRegion",
+    cli: "--observe-region",
+    env: "AUTOMOBILE_OBSERVE_REGION",
+    featureFlagKey: "observe-region",
+    label: "--observe-region",
+  },
 ];
 
 /**
@@ -97,6 +126,9 @@ export function parseOutputReductionFlags(
     actionsDiffObserve: false,
     actionsNoObserve: false,
     toolResultsCompactJson: false,
+    observeFocusScope: false,
+    observeOverview: false,
+    observeRegion: false,
   };
   for (const spec of OUTPUT_REDUCTION_FLAG_SPECS) {
     flags[spec.field] = resolve(spec);

--- a/test/daemon/daemonOptionsPropagation.test.ts
+++ b/test/daemon/daemonOptionsPropagation.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import { DaemonManager, parseDaemonArgs } from "../../src/daemon/manager";
+import { REUSE_CRITICAL_OPTION_KEYS } from "../../src/daemon/daemonMcpProxy";
+import { OUTPUT_REDUCTION_FLAG_SPECS } from "../../src/utils/outputReductionFlags";
+import type { DaemonOptions } from "../../src/daemon/types";
+
+/**
+ * Daemon startup-option propagation guards (issue #4344 propagation audit).
+ *
+ * The relay MCP/CLI process -> spawned daemon is hand-maintained across several
+ * lists: `withDaemonOptions` (serialize), `parseDaemonArgs`/`parseArgs` (parse),
+ * and `REUSE_CRITICAL_OPTION_KEYS` (reuse/restart). A flag added to `DaemonOptions`
+ * but forgotten in one of them is silently dropped — that is exactly how the three
+ * `noA11y*` flags never reached a manager-spawned daemon. These tests round-trip
+ * the propagation-critical boolean flags through the REAL serializer
+ * (`DaemonManager.withDaemonOptions`, not just the `outputReductionFlagsToArgs`
+ * sub-helper) so a future drop fails here instead of in the field.
+ */
+
+/** Reach the pure private arg-builder without spawning anything. */
+function serialize(options: DaemonOptions): string[] {
+  const manager = new DaemonManager();
+  const built = (manager as unknown as {
+    withDaemonOptions: (l: { command: string; args: string[] }, o: DaemonOptions) => { args: string[] };
+  }).withDaemonOptions({ command: "auto-mobile", args: [] }, options);
+  return built.args;
+}
+
+/**
+ * Boolean DaemonOptions that MUST survive the spawn relay. A new propagating
+ * boolean flag should be added here; if it is not serialized+parsed, this fails.
+ */
+const PROPAGATING_BOOLEAN_FLAGS: (keyof DaemonOptions)[] = [
+  // Observe-scope experiments (issue #4344) — via outputReductionFlagsToArgs.
+  "observeFocusScope",
+  "observeOverview",
+  "observeRegion",
+  // The rest of the output-reduction family.
+  "observeResultDropElements",
+  "observeResultCompact",
+  "toolResultsNoStructuredContent",
+  "actionsDiffObserve",
+  "actionsNoObserve",
+  "toolResultsCompactJson",
+  // Accessibility-service view filters — the flags the audit found dropped.
+  "noA11yIncludeNotImportantViews",
+  "noA11yReportViewIds",
+  "noA11yRetrieveInteractiveWindows",
+  // A representative sample of the hand-written relay.
+  "predictiveUi",
+  "rawElementSearch",
+  "mcpRecording",
+  "safeAreaWarnings",
+  "memPerfAudit",
+  "noOcclusion",
+];
+
+describe("daemon startup-option propagation", () => {
+  test("each propagating boolean flag round-trips serialize -> parse", () => {
+    for (const field of PROPAGATING_BOOLEAN_FLAGS) {
+      const args = serialize({ [field]: true } as DaemonOptions);
+      const parsed = parseDaemonArgs(args);
+      expect({ field, value: parsed[field] }).toEqual({ field, value: true });
+    }
+  });
+
+  test("all propagating boolean flags round-trip together (no cross-interference)", () => {
+    const allOn = Object.fromEntries(PROPAGATING_BOOLEAN_FLAGS.map(f => [f, true])) as DaemonOptions;
+    const parsed = parseDaemonArgs(serialize(allOn));
+    for (const field of PROPAGATING_BOOLEAN_FLAGS) {
+      expect({ field, value: parsed[field] }).toEqual({ field, value: true });
+    }
+  });
+
+  test("the noA11y flags specifically reach a spawned daemon (regression: audit #4344)", () => {
+    const args = serialize({
+      noA11yIncludeNotImportantViews: true,
+      noA11yReportViewIds: true,
+      noA11yRetrieveInteractiveWindows: true,
+    });
+    expect(args).toContain("--no-include-not-important-views");
+    expect(args).toContain("--no-report-view-ids");
+    expect(args).toContain("--no-retrieve-interactive-windows");
+  });
+
+  test("no flags -> no propagation args beyond the base launch", () => {
+    // A bare options object must not emit any of the propagating flags.
+    const args = serialize({});
+    for (const field of PROPAGATING_BOOLEAN_FLAGS) {
+      const parsed = parseDaemonArgs(args);
+      expect(parsed[field]).toBeUndefined();
+    }
+  });
+});
+
+describe("reuse-critical drift guard", () => {
+  test("every output-reduction flag (incl. observe-scope) is reuse-critical", () => {
+    // A reuse-critical flag forces a preserving daemon restart when a client
+    // requests it and the running daemon lacks it — the mechanism that makes the
+    // observe-scope flags propagate to an already-running daemon. Spec-driven, so
+    // a new output-reduction flag is covered automatically; this pins that.
+    for (const spec of OUTPUT_REDUCTION_FLAG_SPECS) {
+      expect(REUSE_CRITICAL_OPTION_KEYS).toContain(spec.field);
+    }
+  });
+});

--- a/test/features/observe/output/ObserveScopeExperiments.test.ts
+++ b/test/features/observe/output/ObserveScopeExperiments.test.ts
@@ -21,16 +21,29 @@ interface Node {
   "resource-id"?: string;
   text?: string;
   class?: string;
-  package?: string;
+  "content-desc"?: string;
   scrollable?: boolean | string;
   clickable?: boolean | string;
   bounds?: { left: number; top: number; right: number; bottom: number } | number[];
   node?: Node[];
 }
 
+const SYSUI = "com.android.systemui";
+const APP = "com.example.app";
+// Package-qualified resource-ids — the app-vs-chrome signal that SURVIVES
+// `cleanNodeProperties` (per-node `package` does not). System chrome carries
+// `com.android.systemui:id/...`; app nodes carry `com.example.app:id/...`; app
+// leaves (list items) carry NO id, as on real Compose/list surfaces.
+const STATUS_BAR = `${SYSUI}:id/status_bar`;
+const NAV_BAR = `${SYSUI}:id/navigation_bar`;
+const HEADER = `${APP}:id/header`;
+const LIST = `${APP}:id/list`;
+
 /**
  * An Android-shaped tree: a container root with system chrome (status/nav bars,
- * `com.android.systemui`) flanking the foreground app's own subtree.
+ * `com.android.systemui`) flanking the foreground app's own subtree. App leaf
+ * rows deliberately carry NO resource-id, so FOCUS must keep them (it only drops
+ * identifiable FOREIGN packages, never id-less content).
  */
 function androidFixture(): ObserveResult {
   const root: Node = {
@@ -38,41 +51,35 @@ function androidFixture(): ObserveResult {
     bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
     node: [
       {
-        "resource-id": "statusBar",
-        "package": "com.android.systemui",
+        "resource-id": STATUS_BAR,
         "bounds": { left: 0, top: 0, right: 1080, bottom: 80 },
       },
       {
         class: "LinearLayout",
-        package: "com.example.app",
         bounds: { left: 0, top: 80, right: 1080, bottom: 2300 },
         node: [
           {
-            "resource-id": "header",
-            "package": "com.example.app",
+            "resource-id": HEADER,
             "text": "Title",
             "bounds": { left: 0, top: 80, right: 1080, bottom: 200 },
           },
           {
-            "resource-id": "list",
-            "package": "com.example.app",
+            "resource-id": LIST,
             "scrollable": true,
             "bounds": { left: 0, top: 200, right: 1080, bottom: 2200 },
             "node": [
-              { text: "Item 1", package: "com.example.app", bounds: { left: 0, top: 200, right: 1080, bottom: 400 } },
-              { text: "Item 2", package: "com.example.app", bounds: { left: 0, top: 400, right: 1080, bottom: 600 } },
+              { text: "Item 1", bounds: { left: 0, top: 200, right: 1080, bottom: 400 } },
+              { text: "Item 2", bounds: { left: 0, top: 400, right: 1080, bottom: 600 } },
             ],
           },
           {
             class: "View",
-            package: "com.example.app",
             bounds: { left: 0, top: 2200, right: 1080, bottom: 2300 },
           },
         ],
       },
       {
-        "resource-id": "navBar",
-        "package": "com.android.systemui",
+        "resource-id": NAV_BAR,
         "bounds": { left: 0, top: 2300, right: 1080, bottom: 2400 },
       },
     ],
@@ -82,17 +89,17 @@ function androidFixture(): ObserveResult {
     updatedAt: 0,
     screenSize: { width: 1080, height: 2400 },
     systemInsets: { top: 80, bottom: 100, left: 0, right: 0 },
-    activeWindow: { appId: "com.example.app" } as ObserveResult["activeWindow"],
+    activeWindow: { appId: APP } as ObserveResult["activeWindow"],
     viewHierarchy: {
-      packageName: "com.example.app",
+      packageName: APP,
       hierarchy: { node: root as unknown as ViewHierarchyNode },
     },
     elements: {
-      clickable: [{ bounds: { left: 0, top: 80, right: 1080, bottom: 200 } } as never],
-      scrollable: [{ bounds: { left: 0, top: 200, right: 1080, bottom: 2200 } } as never],
+      clickable: [{ "resource-id": HEADER, "bounds": { left: 0, top: 80, right: 1080, bottom: 200 } } as never],
+      scrollable: [{ "resource-id": LIST, "bounds": { left: 0, top: 200, right: 1080, bottom: 2200 } } as never],
       text: [
-        { bounds: { left: 0, top: 0, right: 1080, bottom: 80 } } as never, // status bar clock
-        { bounds: { left: 0, top: 400, right: 1080, bottom: 600 } } as never, // Item 2
+        { "resource-id": `${SYSUI}:id/clock`, "bounds": { left: 0, top: 0, right: 1080, bottom: 80 } } as never, // chrome
+        { "bounds": { left: 0, top: 400, right: 1080, bottom: 600 } } as never, // Item 2 (app, no id)
       ],
       media: [],
     },
@@ -209,24 +216,52 @@ describe("buildObserveScopeConfig", () => {
 });
 
 describe("scopeToFocus", () => {
-  test("foreground-app scoping drops system chrome", () => {
+  test("foreground-app scoping drops identifiable foreign chrome (by resource-id package)", () => {
     const obs = androidFixture();
     const { result, focus } = scopeToFocus(obs);
-    expect(focus).toEqual({ by: "foreground-app", matched: true, packageName: "com.example.app" });
+    expect(focus).toEqual({ by: "foreground-app", matched: true, packageName: APP });
     const ids = resourceIds(result);
-    expect(ids).not.toContain("statusBar");
-    expect(ids).not.toContain("navBar");
-    expect(ids).toContain("header");
-    expect(ids).toContain("list");
+    expect(ids.some(id => id.startsWith(SYSUI))).toBe(false); // status/nav bars gone
+    expect(ids).toContain(HEADER);
+    expect(ids).toContain(LIST);
   });
 
-  test("anchor scoping keeps only the matched subtree", () => {
+  test("foreground-app scoping keeps id-less app leaves (never drops content for lacking an id)", () => {
     const obs = androidFixture();
-    const { result, focus } = scopeToFocus(obs, { resourceId: "list" });
+    const { result } = scopeToFocus(obs);
+    // The two id-less list rows and the anonymous View survive.
+    const texts: string[] = [];
+    const walk = (nodes: Node[]): void => {
+      for (const n of nodes) { if (n.text) { texts.push(n.text); } walk(toNodeArray(n.node)); }
+    };
+    walk(roots(result));
+    expect(texts).toContain("Item 1");
+    expect(texts).toContain("Item 2");
+  });
+
+  test("foreground-app scoping filters elements with a foreign package resource-id", () => {
+    const obs = androidFixture();
+    const { result } = scopeToFocus(obs);
+    // The com.android.systemui:id/clock text element drops; the id-less Item 2 stays.
+    expect(result.elements?.text).toHaveLength(1);
+    expect(result.elements?.clickable).toHaveLength(1); // app header element kept
+  });
+
+  test("anchor scoping by resource-id keeps only the matched subtree", () => {
+    const obs = androidFixture();
+    const { result, focus } = scopeToFocus(obs, { resourceId: LIST });
     expect(focus).toEqual({ by: "anchor", matched: true });
     expect(roots(result)).toHaveLength(1);
-    expect(roots(result)[0]["resource-id"]).toBe("list");
+    expect(roots(result)[0]["resource-id"]).toBe(LIST);
     expect(countNodes(roots(result))).toBe(3); // list + 2 items
+  });
+
+  test("anchor scoping by substring text keeps the matching node's subtree", () => {
+    const obs = androidFixture();
+    const { result, focus } = scopeToFocus(obs, { text: "Title" });
+    expect(focus).toEqual({ by: "anchor", matched: true });
+    expect(roots(result)).toHaveLength(1);
+    expect(roots(result)[0]["resource-id"]).toBe(HEADER);
   });
 
   test("unmatched anchor leaves the tree untouched", () => {
@@ -237,9 +272,13 @@ describe("scopeToFocus", () => {
     expect(countNodes(roots(result))).toBe(before);
   });
 
-  test("iOS-style tree with no matching package is a no-op", () => {
+  test("iOS-style tree (no package-qualified ids) is a no-op", () => {
     const obs = androidFixture();
-    obs.viewHierarchy!.packageName = "com.apple.springboard"; // no node advertises it
+    // Strip the qualified ids so no node looks foreign — the real iOS shape.
+    const strip = (nodes: Node[]): void => {
+      for (const n of nodes) { delete n["resource-id"]; strip(toNodeArray(n.node)); }
+    };
+    strip(roots(obs));
     const before = countNodes(roots(obs));
     const { result, focus } = scopeToFocus(obs);
     expect(focus.matched).toBe(false);
@@ -261,9 +300,9 @@ describe("scopeToRegion", () => {
     // insets top:80 bottom:100 -> content rect [0,80,1080,2300].
     expect(rectPx).toEqual({ left: 0, top: 80, right: 1080, bottom: 2300 });
     const ids = resourceIds(result);
-    expect(ids).not.toContain("statusBar"); // 0..80, touches top edge only
-    expect(ids).not.toContain("navBar"); // 2300..2400, touches bottom edge only
-    expect(ids).toContain("header");
+    expect(ids).not.toContain(STATUS_BAR); // 0..80, touches top edge only
+    expect(ids).not.toContain(NAV_BAR); // 2300..2400, touches bottom edge only
+    expect(ids).toContain(HEADER);
   });
 
   test("normalized box crops to the top half", () => {
@@ -271,9 +310,9 @@ describe("scopeToRegion", () => {
     const { result, rectPx } = scopeToRegion(obs, { x1: 0, y1: 0, x2: 1, y2: 0.5 });
     expect(rectPx).toEqual({ left: 0, top: 0, right: 1080, bottom: 1200 });
     const ids = resourceIds(result);
-    expect(ids).toContain("statusBar");
-    expect(ids).toContain("header");
-    expect(ids).not.toContain("navBar"); // 2300..2400 is below y=1200
+    expect(ids).toContain(STATUS_BAR);
+    expect(ids).toContain(HEADER);
+    expect(ids).not.toContain(NAV_BAR); // 2300..2400 is below y=1200
   });
 
   test("filters the categorized elements by the same rect", () => {
@@ -284,12 +323,20 @@ describe("scopeToRegion", () => {
     expect(result.elements?.clickable).toHaveLength(1);
   });
 
+  test("keeps a leaf with no readable bounds (never geometrically excluded)", () => {
+    const obs = androidFixture();
+    // A bounds-less node the crop cannot place must survive, per the contract.
+    roots(obs)[0].node!.push({ "resource-id": `${APP}:id/boundless` });
+    const { result } = scopeToRegion(obs, { x1: 0, y1: 0, x2: 0.1, y2: 0.1 });
+    expect(resourceIds(result)).toContain(`${APP}:id/boundless`);
+  });
+
   test("reads compacted-tuple bounds", () => {
     const obs = androidFixture();
     const statusBar = roots(obs)[0].node![0];
     statusBar.bounds = [0, 0, 1080, 80]; // compact form
     const { result } = scopeToRegion(obs, { x1: 0, y1: 0, x2: 1, y2: 0.5 });
-    expect(resourceIds(result)).toContain("statusBar");
+    expect(resourceIds(result)).toContain(STATUS_BAR);
   });
 
   test("is pure — input is not mutated", () => {
@@ -306,20 +353,37 @@ describe("toOverview", () => {
     const result = toOverview(obs);
     const ids = resourceIds(result);
     // list is addressable + scrollable -> kept; its two anonymous item leaves drop.
-    expect(ids).toContain("list");
-    expect(ids).toContain("header");
-    const list = findById(result, "list")!;
+    expect(ids).toContain(LIST);
+    expect(ids).toContain(HEADER);
+    const list = findById(result, LIST)!;
     expect(list.node).toBeUndefined(); // both leaf items collapsed
     expect((list as unknown as { omittedDescendants?: number }).omittedDescendants).toBe(2);
     // the anonymous `View` leaf under the app root has no id/children -> dropped.
     expect(result.elements).toBeUndefined();
   });
 
+  test("keeps id-less but addressable leaves (clickable / content-desc)", () => {
+    const obs = androidFixture();
+    // A tappable, id-less control (Compose/iOS shape) with an a11y label.
+    roots(obs)[0].node![1].node!.push({
+      "clickable": true,
+      "content-desc": "Add item",
+      "bounds": { left: 0, top: 2100, right: 200, bottom: 2200 },
+    });
+    const result = toOverview(obs);
+    const labels: string[] = [];
+    const walk = (nodes: Node[]): void => {
+      for (const n of nodes) { if (n["content-desc"]) { labels.push(n["content-desc"]); } walk(toNodeArray(n.node)); }
+    };
+    walk(roots(result));
+    expect(labels).toContain("Add item"); // NOT collapsed into omittedDescendants
+  });
+
   test("strips non-structural attributes from retained nodes", () => {
     const obs = androidFixture();
     const result = toOverview(obs);
-    const header = findById(result, "header")!;
-    expect(header["resource-id"]).toBe("header");
+    const header = findById(result, HEADER)!;
+    expect(header["resource-id"]).toBe(HEADER);
     expect(header.text).toBeUndefined(); // leaf detail dropped
     expect(header.bounds).toBeDefined(); // structural attr kept
   });

--- a/test/features/observe/output/ObserveScopeExperiments.test.ts
+++ b/test/features/observe/output/ObserveScopeExperiments.test.ts
@@ -247,6 +247,56 @@ describe("scopeToFocus", () => {
     expect(result.elements?.clickable).toHaveLength(1); // app header element kept
   });
 
+  test("foreground-app scoping KEEPS android: framework ids (app content, not chrome)", () => {
+    const obs = androidFixture();
+    // android:id/content is the setContentView host in every app window; an
+    // AlertDialog's buttons are android:id/button1 etc. All belong to app content.
+    roots(obs)[0].node!.push({
+      "resource-id": "android:id/content",
+      "bounds": { left: 0, top: 300, right: 1080, bottom: 500 },
+      "node": [
+        { "resource-id": `${APP}:id/ok`, "text": "OK", "bounds": { left: 0, top: 300, right: 200, bottom: 500 } },
+        { "resource-id": "android:id/button1", "text": "Cancel", "bounds": { left: 200, top: 300, right: 400, bottom: 500 } },
+      ],
+    });
+    const ids = resourceIds(scopeToFocus(obs).result);
+    expect(ids).toContain("android:id/content"); // framework host kept
+    expect(ids).toContain("android:id/button1"); // dialog button kept
+    expect(ids).toContain(`${APP}:id/ok`); // app child under a framework host kept
+    expect(ids.some(id => id.startsWith(SYSUI))).toBe(false); // real chrome still dropped
+  });
+
+  test("foreground-app scoping drops a dotted foreign IME package subtree", () => {
+    const obs = androidFixture();
+    roots(obs)[0].node!.push({
+      "resource-id": "com.google.android.inputmethod.latin:id/keyboard",
+      "bounds": { left: 0, top: 1800, right: 1080, bottom: 2300 },
+    });
+    const ids = resourceIds(scopeToFocus(obs).result);
+    expect(ids.some(id => id.startsWith("com.google.android.inputmethod"))).toBe(false);
+  });
+
+  test("foreground-app scoping is a no-op on iOS-style colon identifiers (undotted prefix)", () => {
+    const iosRoot: Node = {
+      class: "XCUIElementTypeApplication",
+      node: [
+        { "resource-id": "row:0", "text": "First", "bounds": { left: 0, top: 0, right: 400, bottom: 100 } },
+        { "resource-id": "section:2:cell:1", "text": "Second", "bounds": { left: 0, top: 100, right: 400, bottom: 200 } },
+      ],
+    };
+    const obs = {
+      updatedAt: 0,
+      screenSize: { width: 400, height: 800 },
+      systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+      viewHierarchy: { packageName: "com.example.iosapp", hierarchy: { node: iosRoot as unknown as ViewHierarchyNode } },
+    } as ObserveResult;
+    const before = countNodes(roots(obs));
+    const { result, focus } = scopeToFocus(obs);
+    expect(focus.matched).toBe(false); // undotted prefixes are never foreign
+    expect(countNodes(roots(result))).toBe(before);
+    expect(resourceIds(result)).toContain("row:0");
+  });
+
   test("anchor scoping by resource-id keeps only the matched subtree", () => {
     const obs = androidFixture();
     const { result, focus } = scopeToFocus(obs, { resourceId: LIST });
@@ -418,10 +468,14 @@ describe("applyObserveScopeExperiments", () => {
     const obs = androidFixture();
     const result = applyObserveScopeExperiments(obs, { focus: true, overview: true, region: true });
     const applied = result.observeScope?.applied ?? [];
-    // focus + overview definitely change the tree; region may already be covered
-    // by focus, so assert order-preserving subset of the enabled set.
-    expect(applied).toEqual(applied.filter(k => ["focus", "region", "overview"].includes(k)));
-    expect(result.observeScope?.applied).toContain("overview");
+    // `applied` must be a subsequence of the canonical stage order (focus, region,
+    // overview) — i.e. each entry's stage index strictly increases. This catches a
+    // real regression (a stage recorded out of order) the type system cannot.
+    const order = ["focus", "region", "overview"];
+    const indices = applied.map(k => order.indexOf(k));
+    expect(indices).toEqual([...indices].sort((a, b) => a - b));
+    expect(new Set(applied).size).toBe(applied.length); // no duplicate stages
+    expect(applied).toContain("overview");
     expect(result.elements).toBeUndefined(); // overview drops elements
   });
 

--- a/test/features/observe/output/ObserveScopeExperiments.test.ts
+++ b/test/features/observe/output/ObserveScopeExperiments.test.ts
@@ -1,0 +1,370 @@
+import { describe, expect, test } from "bun:test";
+import type { ObserveResult } from "../../../../src/models/ObserveResult";
+import type { ViewHierarchyNode } from "../../../../src/models/ViewHierarchyResult";
+import {
+  applyObserveScopeExperiments,
+  buildObserveScopeConfig,
+  readBounds,
+  scopeToFocus,
+  scopeToRegion,
+  toOverview,
+} from "../../../../src/features/observe/output/ObserveScopeExperiments";
+
+/**
+ * Unit tests for the `observe` progressive-disclosure scoping experiments
+ * (issue #4344). Each transform is PURE and OUTPUT-ONLY: it returns a deep copy
+ * and never mutates the caller's `ObserveResult`. Fixtures are hand-built so the
+ * suite stays well under the 100ms budget.
+ */
+
+interface Node {
+  "resource-id"?: string;
+  text?: string;
+  class?: string;
+  package?: string;
+  scrollable?: boolean | string;
+  clickable?: boolean | string;
+  bounds?: { left: number; top: number; right: number; bottom: number } | number[];
+  node?: Node[];
+}
+
+/**
+ * An Android-shaped tree: a container root with system chrome (status/nav bars,
+ * `com.android.systemui`) flanking the foreground app's own subtree.
+ */
+function androidFixture(): ObserveResult {
+  const root: Node = {
+    class: "FrameLayout",
+    bounds: { left: 0, top: 0, right: 1080, bottom: 2400 },
+    node: [
+      {
+        "resource-id": "statusBar",
+        "package": "com.android.systemui",
+        "bounds": { left: 0, top: 0, right: 1080, bottom: 80 },
+      },
+      {
+        class: "LinearLayout",
+        package: "com.example.app",
+        bounds: { left: 0, top: 80, right: 1080, bottom: 2300 },
+        node: [
+          {
+            "resource-id": "header",
+            "package": "com.example.app",
+            "text": "Title",
+            "bounds": { left: 0, top: 80, right: 1080, bottom: 200 },
+          },
+          {
+            "resource-id": "list",
+            "package": "com.example.app",
+            "scrollable": true,
+            "bounds": { left: 0, top: 200, right: 1080, bottom: 2200 },
+            "node": [
+              { text: "Item 1", package: "com.example.app", bounds: { left: 0, top: 200, right: 1080, bottom: 400 } },
+              { text: "Item 2", package: "com.example.app", bounds: { left: 0, top: 400, right: 1080, bottom: 600 } },
+            ],
+          },
+          {
+            class: "View",
+            package: "com.example.app",
+            bounds: { left: 0, top: 2200, right: 1080, bottom: 2300 },
+          },
+        ],
+      },
+      {
+        "resource-id": "navBar",
+        "package": "com.android.systemui",
+        "bounds": { left: 0, top: 2300, right: 1080, bottom: 2400 },
+      },
+    ],
+  };
+
+  return {
+    updatedAt: 0,
+    screenSize: { width: 1080, height: 2400 },
+    systemInsets: { top: 80, bottom: 100, left: 0, right: 0 },
+    activeWindow: { appId: "com.example.app" } as ObserveResult["activeWindow"],
+    viewHierarchy: {
+      packageName: "com.example.app",
+      hierarchy: { node: root as unknown as ViewHierarchyNode },
+    },
+    elements: {
+      clickable: [{ bounds: { left: 0, top: 80, right: 1080, bottom: 200 } } as never],
+      scrollable: [{ bounds: { left: 0, top: 200, right: 1080, bottom: 2200 } } as never],
+      text: [
+        { bounds: { left: 0, top: 0, right: 1080, bottom: 80 } } as never, // status bar clock
+        { bounds: { left: 0, top: 400, right: 1080, bottom: 600 } } as never, // Item 2
+      ],
+      media: [],
+    },
+  };
+}
+
+function toNodeArray(node: unknown): Node[] {
+  if (!node) {
+    return [];
+  }
+  return (Array.isArray(node) ? node : [node]) as Node[];
+}
+
+function countNodes(node: unknown): number {
+  return toNodeArray(node).reduce((sum, n) => sum + 1 + countNodes(n.node), 0);
+}
+
+function roots(obs: ObserveResult): Node[] {
+  return toNodeArray(obs.viewHierarchy?.hierarchy?.node);
+}
+
+function findById(obs: ObserveResult, id: string): Node | undefined {
+  let found: Node | undefined;
+  const walk = (nodes: Node[]): void => {
+    for (const n of nodes) {
+      if (n["resource-id"] === id) {
+        found = n;
+        return;
+      }
+      walk(toNodeArray(n.node));
+    }
+  };
+  walk(roots(obs));
+  return found;
+}
+
+function resourceIds(obs: ObserveResult): string[] {
+  const out: string[] = [];
+  const walk = (nodes: Node[]): void => {
+    for (const n of nodes) {
+      if (n["resource-id"]) {
+        out.push(n["resource-id"]);
+      }
+      walk(toNodeArray(n.node));
+    }
+  };
+  walk(roots(obs));
+  return out;
+}
+
+describe("readBounds", () => {
+  test("reads the object shape", () => {
+    expect(readBounds({ left: 1, top: 2, right: 3, bottom: 4 })).toEqual({ left: 1, top: 2, right: 3, bottom: 4 });
+  });
+  test("reads the compacted tuple shape", () => {
+    expect(readBounds([1, 2, 3, 4])).toEqual({ left: 1, top: 2, right: 3, bottom: 4 });
+  });
+  test("returns null for unreadable values", () => {
+    expect(readBounds(undefined)).toBeNull();
+    expect(readBounds([1, 2, 3])).toBeNull();
+    expect(readBounds({ left: 1 })).toBeNull();
+    expect(readBounds("[0,0][1,1]")).toBeNull();
+  });
+});
+
+describe("buildObserveScopeConfig", () => {
+  const allFlags = { focus: true, overview: true, region: true };
+
+  test("intersects per-call scope with flags (anchor + box)", () => {
+    const cfg = buildObserveScopeConfig(allFlags, {
+      focus: { resourceId: "list" },
+      region: { x1: 0, y1: 0, x2: 1, y2: 0.5 },
+      overview: true,
+    });
+    expect(cfg.focus).toBe(true);
+    expect(cfg.focusAnchor).toEqual({ resourceId: "list" });
+    expect(cfg.region).toBe(true);
+    expect(cfg.regionBox).toEqual({ x1: 0, y1: 0, x2: 1, y2: 0.5 });
+    expect(cfg.overview).toBe(true);
+  });
+
+  test("focus:true / region:true request the flag defaults (no anchor / no box)", () => {
+    const cfg = buildObserveScopeConfig(allFlags, { focus: true, region: true });
+    expect(cfg.focus).toBe(true);
+    expect(cfg.focusAnchor).toBeUndefined(); // foreground app
+    expect(cfg.region).toBe(true);
+    expect(cfg.regionBox).toBeUndefined(); // content rect
+    expect(cfg.overview).toBe(false);
+  });
+
+  test("a dimension the call did not request is off even when its flag is on", () => {
+    const cfg = buildObserveScopeConfig(allFlags, { region: { x1: 0, y1: 0, x2: 1, y2: 1 } });
+    expect(cfg.focus).toBe(false);
+    expect(cfg.overview).toBe(false);
+    expect(cfg.region).toBe(true);
+  });
+
+  test("a dimension the flag disabled is off even when the call requested it", () => {
+    const cfg = buildObserveScopeConfig(
+      { focus: false, overview: false, region: false },
+      { focus: { resourceId: "x" }, region: true, overview: true }
+    );
+    expect(cfg.focus).toBe(false);
+    expect(cfg.region).toBe(false);
+    expect(cfg.overview).toBe(false);
+  });
+
+  test("no scope input yields an all-off config", () => {
+    const cfg = buildObserveScopeConfig(allFlags, undefined);
+    expect(cfg.focus).toBe(false);
+    expect(cfg.region).toBe(false);
+    expect(cfg.overview).toBe(false);
+  });
+});
+
+describe("scopeToFocus", () => {
+  test("foreground-app scoping drops system chrome", () => {
+    const obs = androidFixture();
+    const { result, focus } = scopeToFocus(obs);
+    expect(focus).toEqual({ by: "foreground-app", matched: true, packageName: "com.example.app" });
+    const ids = resourceIds(result);
+    expect(ids).not.toContain("statusBar");
+    expect(ids).not.toContain("navBar");
+    expect(ids).toContain("header");
+    expect(ids).toContain("list");
+  });
+
+  test("anchor scoping keeps only the matched subtree", () => {
+    const obs = androidFixture();
+    const { result, focus } = scopeToFocus(obs, { resourceId: "list" });
+    expect(focus).toEqual({ by: "anchor", matched: true });
+    expect(roots(result)).toHaveLength(1);
+    expect(roots(result)[0]["resource-id"]).toBe("list");
+    expect(countNodes(roots(result))).toBe(3); // list + 2 items
+  });
+
+  test("unmatched anchor leaves the tree untouched", () => {
+    const obs = androidFixture();
+    const before = countNodes(roots(obs));
+    const { result, focus } = scopeToFocus(obs, { resourceId: "does-not-exist" });
+    expect(focus.matched).toBe(false);
+    expect(countNodes(roots(result))).toBe(before);
+  });
+
+  test("iOS-style tree with no matching package is a no-op", () => {
+    const obs = androidFixture();
+    obs.viewHierarchy!.packageName = "com.apple.springboard"; // no node advertises it
+    const before = countNodes(roots(obs));
+    const { result, focus } = scopeToFocus(obs);
+    expect(focus.matched).toBe(false);
+    expect(countNodes(roots(result))).toBe(before);
+  });
+
+  test("is pure — input is not mutated", () => {
+    const obs = androidFixture();
+    const before = JSON.stringify(obs);
+    scopeToFocus(obs);
+    expect(JSON.stringify(obs)).toBe(before);
+  });
+});
+
+describe("scopeToRegion", () => {
+  test("default content rect drops off-content chrome", () => {
+    const obs = androidFixture();
+    const { result, rectPx } = scopeToRegion(obs);
+    // insets top:80 bottom:100 -> content rect [0,80,1080,2300].
+    expect(rectPx).toEqual({ left: 0, top: 80, right: 1080, bottom: 2300 });
+    const ids = resourceIds(result);
+    expect(ids).not.toContain("statusBar"); // 0..80, touches top edge only
+    expect(ids).not.toContain("navBar"); // 2300..2400, touches bottom edge only
+    expect(ids).toContain("header");
+  });
+
+  test("normalized box crops to the top half", () => {
+    const obs = androidFixture();
+    const { result, rectPx } = scopeToRegion(obs, { x1: 0, y1: 0, x2: 1, y2: 0.5 });
+    expect(rectPx).toEqual({ left: 0, top: 0, right: 1080, bottom: 1200 });
+    const ids = resourceIds(result);
+    expect(ids).toContain("statusBar");
+    expect(ids).toContain("header");
+    expect(ids).not.toContain("navBar"); // 2300..2400 is below y=1200
+  });
+
+  test("filters the categorized elements by the same rect", () => {
+    const obs = androidFixture();
+    const { result } = scopeToRegion(obs);
+    // status-bar clock (0..80) drops; Item 2 text (400..600) stays.
+    expect(result.elements?.text).toHaveLength(1);
+    expect(result.elements?.clickable).toHaveLength(1);
+  });
+
+  test("reads compacted-tuple bounds", () => {
+    const obs = androidFixture();
+    const statusBar = roots(obs)[0].node![0];
+    statusBar.bounds = [0, 0, 1080, 80]; // compact form
+    const { result } = scopeToRegion(obs, { x1: 0, y1: 0, x2: 1, y2: 0.5 });
+    expect(resourceIds(result)).toContain("statusBar");
+  });
+
+  test("is pure — input is not mutated", () => {
+    const obs = androidFixture();
+    const before = JSON.stringify(obs);
+    scopeToRegion(obs);
+    expect(JSON.stringify(obs)).toBe(before);
+  });
+});
+
+describe("toOverview", () => {
+  test("keeps structural nodes, drops anonymous leaves, counts omissions, drops elements", () => {
+    const obs = androidFixture();
+    const result = toOverview(obs);
+    const ids = resourceIds(result);
+    // list is addressable + scrollable -> kept; its two anonymous item leaves drop.
+    expect(ids).toContain("list");
+    expect(ids).toContain("header");
+    const list = findById(result, "list")!;
+    expect(list.node).toBeUndefined(); // both leaf items collapsed
+    expect((list as unknown as { omittedDescendants?: number }).omittedDescendants).toBe(2);
+    // the anonymous `View` leaf under the app root has no id/children -> dropped.
+    expect(result.elements).toBeUndefined();
+  });
+
+  test("strips non-structural attributes from retained nodes", () => {
+    const obs = androidFixture();
+    const result = toOverview(obs);
+    const header = findById(result, "header")!;
+    expect(header["resource-id"]).toBe("header");
+    expect(header.text).toBeUndefined(); // leaf detail dropped
+    expect(header.bounds).toBeDefined(); // structural attr kept
+  });
+
+  test("is pure — input is not mutated", () => {
+    const obs = androidFixture();
+    const before = JSON.stringify(obs);
+    toOverview(obs);
+    expect(JSON.stringify(obs)).toBe(before);
+  });
+});
+
+describe("applyObserveScopeExperiments", () => {
+  test("no flags on returns the input unchanged (same reference)", () => {
+    const obs = androidFixture();
+    const result = applyObserveScopeExperiments(obs, { focus: false, overview: false, region: false });
+    expect(result).toBe(obs);
+    expect(result.observeScope).toBeUndefined();
+  });
+
+  test("records applied transforms and node counts in observeScope", () => {
+    const obs = androidFixture();
+    const before = countNodes(roots(obs));
+    const result = applyObserveScopeExperiments(obs, { focus: true, overview: false, region: false });
+    expect(result.observeScope?.applied).toEqual(["focus"]);
+    expect(result.observeScope?.nodesBefore).toBe(before);
+    expect(result.observeScope?.nodesAfter).toBeLessThan(before);
+    expect(result.observeScope?.focus?.by).toBe("foreground-app");
+  });
+
+  test("composes focus -> region -> overview", () => {
+    const obs = androidFixture();
+    const result = applyObserveScopeExperiments(obs, { focus: true, overview: true, region: true });
+    const applied = result.observeScope?.applied ?? [];
+    // focus + overview definitely change the tree; region may already be covered
+    // by focus, so assert order-preserving subset of the enabled set.
+    expect(applied).toEqual(applied.filter(k => ["focus", "region", "overview"].includes(k)));
+    expect(result.observeScope?.applied).toContain("overview");
+    expect(result.elements).toBeUndefined(); // overview drops elements
+  });
+
+  test("is pure — input is not mutated", () => {
+    const obs = androidFixture();
+    const before = JSON.stringify(obs);
+    applyObserveScopeExperiments(obs, { focus: true, overview: true, region: true });
+    expect(JSON.stringify(obs)).toBe(before);
+  });
+});

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -1643,3 +1643,118 @@ describe("finalizeToolResponse", () => {
     });
   });
 });
+
+/**
+ * Observe scope experiments (issue #4344). The per-call `scope` request arrives on
+ * the observe tool args; a server flag gates each dimension. Scoping is applied to
+ * the agent-facing payload only — it must leave the diff baseline (the full
+ * sanitized tree) intact and never touch internal tool-to-tool calls.
+ */
+describe("finalizeToolResponse observe scope experiments (#4344)", () => {
+  beforeEach(() => {
+    serverConfig.setObserveFocusScopeEnabled(false);
+    serverConfig.setObserveOverviewEnabled(false);
+    serverConfig.setObserveRegionEnabled(false);
+    serverConfig.setActionsDiffObserveEnabled(false);
+  });
+
+  afterEach(() => {
+    serverConfig.setObserveFocusScopeEnabled(false);
+    serverConfig.setObserveOverviewEnabled(false);
+    serverConfig.setObserveRegionEnabled(false);
+    serverConfig.setActionsDiffObserveEnabled(false);
+  });
+
+  function chromeObserve(): ObserveResult {
+    return {
+      updatedAt: 1,
+      screenSize: { width: 1000, height: 2000 },
+      systemInsets: { top: 100, bottom: 100, left: 0, right: 0 },
+      activeWindow: { appId: "com.example.app" } as ObserveResult["activeWindow"],
+      viewHierarchy: {
+        packageName: "com.example.app",
+        hierarchy: {
+          node: {
+            "class": "Root",
+            "bounds": { left: 0, top: 0, right: 1000, bottom: 2000 },
+            "node": [
+              { "resource-id": "statusBar", "package": "com.android.systemui", "bounds": { left: 0, top: 0, right: 1000, bottom: 100 } },
+              { "resource-id": "content", "package": "com.example.app", "text": "Hi", "bounds": { left: 0, top: 100, right: 1000, bottom: 1900 } },
+            ],
+          } as any,
+        },
+      },
+    } as ObserveResult;
+  }
+
+  test("no scope flags: observe payload is untouched even when the call requests scope", () => {
+    const finalized = finalizeToolResponse(createStructuredToolResponse(chromeObserve()), {
+      name: "observe",
+      args: { scope: { focus: true } },
+    });
+    expect((finalized.structuredContent as ObserveResult).observeScope).toBeUndefined();
+  });
+
+  test("flag on but no scope in the call: payload is untouched", () => {
+    serverConfig.setObserveFocusScopeEnabled(true);
+    const finalized = finalizeToolResponse(createStructuredToolResponse(chromeObserve()), { name: "observe", args: {} });
+    expect((finalized.structuredContent as ObserveResult).observeScope).toBeUndefined();
+  });
+
+  test("scope.focus in the call (flag on) scopes the payload and records observeScope", () => {
+    serverConfig.setObserveFocusScopeEnabled(true);
+    const finalized = finalizeToolResponse(createStructuredToolResponse(chromeObserve()), {
+      name: "observe",
+      args: { scope: { focus: true } },
+    });
+    const out = finalized.structuredContent as ObserveResult;
+    expect(out.observeScope?.applied).toContain("focus");
+    expect(out.observeScope!.nodesAfter).toBeLessThan(out.observeScope!.nodesBefore);
+    // text mirror agrees with structuredContent.
+    expect(finalized.content[0].text).toBe(stringifyToolResponse(finalized.structuredContent));
+  });
+
+  test("scope.region box in the call (flag on) crops to the normalized rectangle", () => {
+    serverConfig.setObserveRegionEnabled(true);
+    const finalized = finalizeToolResponse(createStructuredToolResponse(chromeObserve()), {
+      name: "observe",
+      args: { scope: { region: { x1: 0, y1: 0, x2: 1, y2: 0.5 } } }, // top half only
+    });
+    const out = finalized.structuredContent as ObserveResult;
+    expect(out.observeScope?.regionPx).toEqual({ left: 0, top: 0, right: 1000, bottom: 1000 });
+  });
+
+  test("internal observe calls are never scoped", () => {
+    serverConfig.setObserveFocusScopeEnabled(true);
+    const finalized = finalizeToolResponse(
+      createStructuredToolResponse(chromeObserve()),
+      { name: "observe", internal: true, args: { scope: { focus: true } } }
+    );
+    expect((finalized.structuredContent as ObserveResult).observeScope).toBeUndefined();
+  });
+
+  test("diff baseline is the full sanitized tree, not the scoped copy", () => {
+    serverConfig.setObserveFocusScopeEnabled(true);
+    serverConfig.setActionsDiffObserveEnabled(true);
+    const map = new Map<string, ObserveResult>();
+    const store = { get: (u: string) => map.get(u), set: (u: string, o: ObserveResult) => { map.set(u, o); } };
+
+    finalizeToolResponse(createStructuredToolResponse(chromeObserve()), {
+      name: "observe",
+      sessionUuid: "s1",
+      baselineStore: store,
+      args: { scope: { focus: true } },
+    });
+
+    // Baseline retains the system-chrome node the served payload dropped.
+    const baseline = map.get("s1")!;
+    expect(baseline.observeScope).toBeUndefined();
+    const ids: string[] = [];
+    const walk = (n: any): void => {
+      if (n["resource-id"]) { ids.push(n["resource-id"]); }
+      for (const c of (n.node ?? [])) { walk(c); }
+    };
+    walk(baseline.viewHierarchy!.hierarchy.node);
+    expect(ids).toContain("statusBar");
+  });
+});

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -1677,9 +1677,11 @@ describe("finalizeToolResponse observe scope experiments (#4344)", () => {
           node: {
             "class": "Root",
             "bounds": { left: 0, top: 0, right: 1000, bottom: 2000 },
+            // Package-qualified resource-ids are the app-vs-chrome signal that
+            // survives cleanNodeProperties (per-node `package` does not).
             "node": [
-              { "resource-id": "statusBar", "package": "com.android.systemui", "bounds": { left: 0, top: 0, right: 1000, bottom: 100 } },
-              { "resource-id": "content", "package": "com.example.app", "text": "Hi", "bounds": { left: 0, top: 100, right: 1000, bottom: 1900 } },
+              { "resource-id": "com.android.systemui:id/status_bar", "bounds": { left: 0, top: 0, right: 1000, bottom: 100 } },
+              { "resource-id": "com.example.app:id/content", "text": "Hi", "bounds": { left: 0, top: 100, right: 1000, bottom: 1900 } },
             ],
           } as any,
         },
@@ -1755,6 +1757,6 @@ describe("finalizeToolResponse observe scope experiments (#4344)", () => {
       for (const c of (n.node ?? [])) { walk(c); }
     };
     walk(baseline.viewHierarchy!.hierarchy.node);
-    expect(ids).toContain("statusBar");
+    expect(ids).toContain("com.android.systemui:id/status_bar");
   });
 });

--- a/test/server/observeScopeSchema.test.ts
+++ b/test/server/observeScopeSchema.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { observeSchema } from "../../src/server/observeTools";
+
+/**
+ * The `observe` tool's `scope` input (issue #4344). The agent picks where to zoom
+ * per screen, so region/anchor are per-call inputs — this pins the schema contract
+ * a client relies on: booleans, anchor objects, and normalized region validation.
+ */
+const BASE = { platform: "android" as const };
+
+function parse(scope: unknown): { success: boolean } {
+  return observeSchema.safeParse({ ...BASE, scope });
+}
+
+describe("observe scope input schema", () => {
+  test("scope is optional (backward compatible)", () => {
+    expect(observeSchema.safeParse(BASE).success).toBe(true);
+  });
+
+  test("accepts focus:true and an anchor object", () => {
+    expect(parse({ focus: true }).success).toBe(true);
+    expect(parse({ focus: { resourceId: "com.app:id/list" } }).success).toBe(true);
+    expect(parse({ focus: { text: "Inbox" } }).success).toBe(true);
+  });
+
+  test("accepts region:true and a normalized box", () => {
+    expect(parse({ region: true }).success).toBe(true);
+    expect(parse({ region: { x1: 0, y1: 0, x2: 1, y2: 0.5 } }).success).toBe(true);
+  });
+
+  test("accepts overview and a combined scope", () => {
+    expect(parse({ overview: true }).success).toBe(true);
+    expect(parse({ focus: true, region: { x1: 0, y1: 0.25, x2: 1, y2: 0.75 }, overview: true }).success).toBe(true);
+  });
+
+  test("rejects a region box outside [0,1]", () => {
+    expect(parse({ region: { x1: 0, y1: 0, x2: 1, y2: 2 } }).success).toBe(false);
+    expect(parse({ region: { x1: -0.1, y1: 0, x2: 1, y2: 1 } }).success).toBe(false);
+  });
+
+  test("rejects a misordered region box (x1 >= x2 or y1 >= y2)", () => {
+    expect(parse({ region: { x1: 0.5, y1: 0, x2: 0.5, y2: 1 } }).success).toBe(false);
+    expect(parse({ region: { x1: 1, y1: 0, x2: 0, y2: 1 } }).success).toBe(false);
+    expect(parse({ region: { x1: 0, y1: 0.8, x2: 1, y2: 0.2 } }).success).toBe(false);
+  });
+});

--- a/test/utils/outputReductionFlags.test.ts
+++ b/test/utils/outputReductionFlags.test.ts
@@ -14,6 +14,9 @@ describe("parseOutputReductionFlags", () => {
       actionsDiffObserve: false,
       actionsNoObserve: false,
       toolResultsCompactJson: false,
+      observeFocusScope: false,
+      observeOverview: false,
+      observeRegion: false,
     });
   });
 


### PR DESCRIPTION
## Summary

Applies the multimodal ["crop tool" cookbook](https://platform.claude.com/cookbook/multimodal-crop-tool) concept to AutoMobile — but to the **view hierarchy**, the dense artifact agents actually consume, not screenshots. `observe` can now return a *scoped* view of the tree via a per-call `scope` input, so an agent can zoom into the part of the screen it cares about instead of reasoning over the whole (reduced) hierarchy every time. This is the "spatial axis" complementing the existing "temporal axis" ([`--actions-diff-observe`](https://github.com/kaeawc/auto-mobile/issues/2761)).

Closes [#4344](https://github.com/kaeawc/auto-mobile/issues/4344).

## Three scope transforms

All are pure, output-only `ObserveResult -> ObserveResult` applied to the agent-facing observe payload in `finalizeToolResponse` (see `src/features/observe/output/ObserveScopeExperiments.ts`):

| Dimension | Input | Flag | Behavior |
|---|---|---|---|
| **FOCUS** | `scope.focus: true \| {resourceId\|text}` | `--observe-focus-scope` | Scope to a subtree — an anchor, or `true` to drop identifiable non-foreground chrome (status/nav bars, IME) |
| **OVERVIEW** | `scope.overview: true` | `--observe-overview` | Collapse to a container skeleton, dropping anonymous leaves and annotating `omittedDescendants` |
| **REGION** | `scope.region: true \| {x1,y1,x2,y2}` | `--observe-region` | Crop to a normalized (0..1) box, or the inset content rectangle when `true` |

## Design

- **Per-call parameters, not env.** The agent picks where to zoom on each screen, so region/anchor ride in the tool call. A server experiment flag gates each dimension as a dark-launch switch; `buildObserveScopeConfig` applies a dimension only when the call requested it **and** its flag is enabled. All flags default off.
- **Agent-facing only.** The diff baseline stays the full sanitized tree and internal tool-to-tool calls are never scoped.
- **Measurable.** Every scoped payload carries `observeScope` metadata (applied transforms, node-count reduction, region/focus resolution).
- **Real signals.** FOCUS keys off the resource-id package prefix (`com.android.systemui:id/...`), which survives `cleanNodeProperties` — the per-node `package` attribute does not. OVERVIEW retains `clickable`/`content-desc`-addressable leaves (the identity on Compose/iOS). Bounds are read tolerant of both the object and the `--observe-result-compact` tuple shape.

Flags flow through the existing output-reduction pipeline; the `scope` input and `observeScope` output are advertised in the tool schema.

## Review

This branch was put through a parallel code review (three lenses: transform correctness, flag/schema wiring, tests & contracts). The second commit addresses the substantive findings — most importantly that foreground-app FOCUS was originally keyed off a per-node `package` attribute that production strips (masked by fixtures that invented it), now rekeyed to the surviving resource-id package prefix. Fixtures were rebuilt to the real post-sanitize node shape.

## Testing

- `bun run lint` / `bun run typecheck` / `bun run build` — all green
- New: `ObserveScopeExperiments.test.ts`, `observeScopeSchema.test.ts`, plus additions to `finalizeToolResponse.test.ts` and `outputReductionFlags.test.ts`
- Coverage includes anchor-by-text, id-less-leaf retention under FOCUS, element filtering, clickable/content-desc retention under OVERVIEW, no-bounds-leaf retention under REGION, purity, and flag/schema round-trips
