### PR TITLE
feat(observe): add deferred waitFor settled, absence, and openLink integration

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3091,7 +3091,7 @@
         "waitFor": {
           "type": "object",
           "additionalProperties": false,
-          "description": "Wait for a predicate before returning the observation. Provide at least one of: elementId, text, textAny, className, contentDescription, activeWindow, or absent. textAny is mutually exclusive with the element predicates.",
+          "description": "Wait for a predicate before returning. Provide at least one of: elementId, text, textAny, className, contentDescription, activeWindow, absent. textAny excludes the element predicates.",
           "properties": {
             "elementId": {
               "type": "string",
@@ -3144,11 +3144,11 @@
                 },
                 "packageName": {
                   "type": "string",
-                  "description": "Alias for appId (Android package name)"
+                  "description": "appId alias (Android package)"
                 },
                 "bundleId": {
                   "type": "string",
-                  "description": "Alias for appId (iOS bundle ID)"
+                  "description": "appId alias (iOS bundle)"
                 },
                 "activityName": {
                   "type": "string",
@@ -3181,23 +3181,19 @@
             "absent": {
               "type": "object",
               "additionalProperties": false,
-              "description": "Wait until an element matching these fields is absent",
+              "description": "Wait until an element matching these fields is absent (text uses contains match)",
               "properties": {
                 "elementId": {
-                  "type": "string",
-                  "description": "Resource ID / accessibility identifier that must be absent"
+                  "type": "string"
                 },
                 "text": {
-                  "type": "string",
-                  "description": "Element text that must be absent (contains match)"
+                  "type": "string"
                 },
                 "className": {
-                  "type": "string",
-                  "description": "Element class name that must be absent"
+                  "type": "string"
                 },
                 "contentDescription": {
-                  "type": "string",
-                  "description": "Content description / accessibility label that must be absent"
+                  "type": "string"
                 }
               },
               "anyOf": [
@@ -3322,14 +3318,14 @@
           ]
         },
         "settled": {
-          "description": "After waitFor matches, wait for a quiet (no hierarchy change) period before returning",
+          "description": "After waitFor matches, wait for a quiet hierarchy period (requires waitFor)",
           "type": "object",
           "properties": {
             "quietPeriodMs": {
               "type": "integer",
               "exclusiveMinimum": 0,
               "maximum": 9007199254740991,
-              "description": "Wait for this many ms with no hierarchy changes after the waitFor predicate matches"
+              "description": "Quiet-period ms (no hierarchy change) required after waitFor matches"
             }
           },
           "required": [
@@ -5395,7 +5391,7 @@
         "waitFor": {
           "type": "object",
           "additionalProperties": false,
-          "description": "Wait for a predicate before returning the observation. Provide at least one of: elementId, text, textAny, className, contentDescription, activeWindow, or absent. textAny is mutually exclusive with the element predicates.",
+          "description": "Wait for a predicate before returning. Provide at least one of: elementId, text, textAny, className, contentDescription, activeWindow, absent. textAny excludes the element predicates.",
           "properties": {
             "elementId": {
               "type": "string",
@@ -5448,11 +5444,11 @@
                 },
                 "packageName": {
                   "type": "string",
-                  "description": "Alias for appId (Android package name)"
+                  "description": "appId alias (Android package)"
                 },
                 "bundleId": {
                   "type": "string",
-                  "description": "Alias for appId (iOS bundle ID)"
+                  "description": "appId alias (iOS bundle)"
                 },
                 "activityName": {
                   "type": "string",
@@ -5485,23 +5481,19 @@
             "absent": {
               "type": "object",
               "additionalProperties": false,
-              "description": "Wait until an element matching these fields is absent",
+              "description": "Wait until an element matching these fields is absent (text uses contains match)",
               "properties": {
                 "elementId": {
-                  "type": "string",
-                  "description": "Resource ID / accessibility identifier that must be absent"
+                  "type": "string"
                 },
                 "text": {
-                  "type": "string",
-                  "description": "Element text that must be absent (contains match)"
+                  "type": "string"
                 },
                 "className": {
-                  "type": "string",
-                  "description": "Element class name that must be absent"
+                  "type": "string"
                 },
                 "contentDescription": {
-                  "type": "string",
-                  "description": "Content description / accessibility label that must be absent"
+                  "type": "string"
                 }
               },
               "anyOf": [
@@ -5626,14 +5618,14 @@
           ]
         },
         "settled": {
-          "description": "After waitFor matches, wait for a quiet (no hierarchy change) period before returning",
+          "description": "After waitFor matches, wait for a quiet hierarchy period (requires waitFor)",
           "type": "object",
           "properties": {
             "quietPeriodMs": {
               "type": "integer",
               "exclusiveMinimum": 0,
               "maximum": 9007199254740991,
-              "description": "Wait for this many ms with no hierarchy changes after the waitFor predicate matches"
+              "description": "Quiet-period ms (no hierarchy change) required after waitFor matches"
             }
           },
           "required": [

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3091,7 +3091,7 @@
         "waitFor": {
           "type": "object",
           "additionalProperties": false,
-          "description": "Wait for a predicate before returning the observation. Provide at least one of: elementId, text, textAny, className, contentDescription, or activeWindow. textAny is mutually exclusive with the element predicates.",
+          "description": "Wait for a predicate before returning the observation. Provide at least one of: elementId, text, textAny, className, contentDescription, activeWindow, or absent. textAny is mutually exclusive with the element predicates.",
           "properties": {
             "elementId": {
               "type": "string",
@@ -3174,6 +3174,51 @@
                 {
                   "required": [
                     "activityName"
+                  ]
+                }
+              ]
+            },
+            "absent": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Wait until an element matching these fields is absent",
+              "properties": {
+                "elementId": {
+                  "type": "string",
+                  "description": "Resource ID / accessibility identifier that must be absent"
+                },
+                "text": {
+                  "type": "string",
+                  "description": "Element text that must be absent (contains match)"
+                },
+                "className": {
+                  "type": "string",
+                  "description": "Element class name that must be absent"
+                },
+                "contentDescription": {
+                  "type": "string",
+                  "description": "Content description / accessibility label that must be absent"
+                }
+              },
+              "anyOf": [
+                {
+                  "required": [
+                    "elementId"
+                  ]
+                },
+                {
+                  "required": [
+                    "text"
+                  ]
+                },
+                {
+                  "required": [
+                    "className"
+                  ]
+                },
+                {
+                  "required": [
+                    "contentDescription"
                   ]
                 }
               ]
@@ -3266,10 +3311,31 @@
                   "required": [
                     "activeWindow"
                   ]
+                },
+                {
+                  "required": [
+                    "absent"
+                  ]
                 }
               ]
             }
           ]
+        },
+        "settled": {
+          "description": "After waitFor matches, wait for a quiet (no hierarchy change) period before returning",
+          "type": "object",
+          "properties": {
+            "quietPeriodMs": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "description": "Wait for this many ms with no hierarchy changes after the waitFor predicate matches"
+            }
+          },
+          "required": [
+            "quietPeriodMs"
+          ],
+          "additionalProperties": false
         },
         "raw": {
           "description": "Include raw view hierarchy",
@@ -3337,7 +3403,12 @@
           }
         }
       },
-      "then": false
+      "then": false,
+      "dependentRequired": {
+        "settled": [
+          "waitFor"
+        ]
+      }
     },
     "outputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -5321,6 +5392,255 @@
             "ios"
           ]
         },
+        "waitFor": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Wait for a predicate before returning the observation. Provide at least one of: elementId, text, textAny, className, contentDescription, activeWindow, or absent. textAny is mutually exclusive with the element predicates.",
+          "properties": {
+            "elementId": {
+              "type": "string",
+              "description": "Element resource ID / accessibility identifier"
+            },
+            "text": {
+              "type": "string",
+              "description": "Element text"
+            },
+            "textAny": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Ordered text variants; first visible match wins"
+            },
+            "className": {
+              "type": "string",
+              "description": "Element class name"
+            },
+            "contentDescription": {
+              "type": "string",
+              "description": "Element content description / accessibility label"
+            },
+            "matchType": {
+              "type": "string",
+              "enum": [
+                "all",
+                "any"
+              ],
+              "description": "Whether element predicates must all match one node, or any one may match"
+            },
+            "textMatch": {
+              "type": "string",
+              "enum": [
+                "exact",
+                "contains",
+                "regex"
+              ],
+              "description": "How to match waitFor.text; does not affect contentDescription"
+            },
+            "activeWindow": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Foreground app/window predicates (provide an app id or activityName)",
+              "properties": {
+                "appId": {
+                  "type": "string",
+                  "description": "Foreground app bundle ID / package name"
+                },
+                "packageName": {
+                  "type": "string",
+                  "description": "Alias for appId (Android package name)"
+                },
+                "bundleId": {
+                  "type": "string",
+                  "description": "Alias for appId (iOS bundle ID)"
+                },
+                "activityName": {
+                  "type": "string",
+                  "description": "Foreground Android activity name (Android-only)"
+                }
+              },
+              "anyOf": [
+                {
+                  "required": [
+                    "appId"
+                  ]
+                },
+                {
+                  "required": [
+                    "packageName"
+                  ]
+                },
+                {
+                  "required": [
+                    "bundleId"
+                  ]
+                },
+                {
+                  "required": [
+                    "activityName"
+                  ]
+                }
+              ]
+            },
+            "absent": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Wait until an element matching these fields is absent",
+              "properties": {
+                "elementId": {
+                  "type": "string",
+                  "description": "Resource ID / accessibility identifier that must be absent"
+                },
+                "text": {
+                  "type": "string",
+                  "description": "Element text that must be absent (contains match)"
+                },
+                "className": {
+                  "type": "string",
+                  "description": "Element class name that must be absent"
+                },
+                "contentDescription": {
+                  "type": "string",
+                  "description": "Content description / accessibility label that must be absent"
+                }
+              },
+              "anyOf": [
+                {
+                  "required": [
+                    "elementId"
+                  ]
+                },
+                {
+                  "required": [
+                    "text"
+                  ]
+                },
+                {
+                  "required": [
+                    "className"
+                  ]
+                },
+                {
+                  "required": [
+                    "contentDescription"
+                  ]
+                }
+              ]
+            },
+            "container": {
+              "type": "object",
+              "description": "Scope the match to a container element (by elementId or text)",
+              "properties": {
+                "elementId": {
+                  "type": "string"
+                },
+                "text": {
+                  "type": "string"
+                }
+              }
+            },
+            "timeout": {
+              "type": "number",
+              "description": "Wait timeout ms (default 5000)"
+            }
+          },
+          "anyOf": [
+            {
+              "required": [
+                "textAny"
+              ],
+              "not": {
+                "anyOf": [
+                  {
+                    "required": [
+                      "elementId"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "text"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "className"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "contentDescription"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "matchType"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "textMatch"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "not": {
+                "required": [
+                  "textAny"
+                ]
+              },
+              "anyOf": [
+                {
+                  "required": [
+                    "elementId"
+                  ]
+                },
+                {
+                  "required": [
+                    "text"
+                  ]
+                },
+                {
+                  "required": [
+                    "className"
+                  ]
+                },
+                {
+                  "required": [
+                    "contentDescription"
+                  ]
+                },
+                {
+                  "required": [
+                    "activeWindow"
+                  ]
+                },
+                {
+                  "required": [
+                    "absent"
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "settled": {
+          "description": "After waitFor matches, wait for a quiet (no hierarchy change) period before returning",
+          "type": "object",
+          "properties": {
+            "quietPeriodMs": {
+              "type": "integer",
+              "exclusiveMinimum": 0,
+              "maximum": 9007199254740991,
+              "description": "Wait for this many ms with no hierarchy changes after the waitFor predicate matches"
+            }
+          },
+          "required": [
+            "quietPeriodMs"
+          ],
+          "additionalProperties": false
+        },
         "sessionUuid": {
           "description": "Session",
           "type": "string"
@@ -5337,7 +5657,55 @@
         "url",
         "platform"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "if": {
+        "required": [
+          "platform",
+          "waitFor"
+        ],
+        "properties": {
+          "platform": {
+            "const": "ios"
+          },
+          "waitFor": {
+            "required": [
+              "activeWindow"
+            ],
+            "properties": {
+              "activeWindow": {
+                "required": [
+                  "activityName"
+                ],
+                "not": {
+                  "anyOf": [
+                    {
+                      "required": [
+                        "appId"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "bundleId"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "packageName"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": false,
+      "dependentRequired": {
+        "settled": [
+          "waitFor"
+        ]
+      }
     }
   },
   {

--- a/scripts/context-thresholds.json
+++ b/scripts/context-thresholds.json
@@ -1,18 +1,18 @@
 {
   "version": "1.0.0",
   "metadata": {
-    "generatedAt": "2026-07-11",
-    "description": "MCP context usage thresholds with manual headroom for resource/template growth",
+    "generatedAt": "2026-07-24",
+    "description": "MCP context usage thresholds with manual headroom for resource/template growth. tools baseline/threshold raised in #3490: openLink gained an integrated waitFor (the whole predicate surface, previously observe-only) plus new absent/settled fields; shared waitFor descriptions were trimmed to minimize the net increase.",
     "baseline": {
-      "tools": 14910,
+      "tools": 15104,
       "resources": 440,
       "resourceTemplates": 1885,
-      "total": 17235
+      "total": 17429
     },
     "buffer": "custom"
   },
   "thresholds": {
-    "tools": 15000,
+    "tools": 15200,
     "resources": 1000,
     "resourceTemplates": 2000,
     "total": 20000

--- a/src/server/interactionToolTypes.ts
+++ b/src/server/interactionToolTypes.ts
@@ -3,6 +3,7 @@
  * Extracted from interactionTools.ts for maintainability.
  */
 import type { Platform, ElementSelectionStrategy, ImeAction } from "../models";
+import type { ObserveWaitForOptions, SettledOptions } from "./observeTools";
 
 // ============================================================================
 // Tool Argument Types
@@ -51,6 +52,8 @@ export interface WakeAndUnlockArgs {
 export interface OpenLinkArgs {
   url: string;
   platform: Platform;
+  waitFor?: ObserveWaitForOptions;
+  settled?: SettledOptions;
 }
 
 export interface TapOnArgs {

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -24,9 +24,21 @@ import {
   ActionableError,
   BootedDevice,
   ClipboardResult,
+  Element,
+  ObserveResult,
+  OpenURLResult,
   SwipeOnToolPayload,
 } from "../models";
 import { ListInstalledApps } from "../features/observe/ListInstalledApps";
+import { RealObserveScreen } from "../features/observe/ObserveScreen";
+import {
+  overrideWaitForJsonSchema,
+  refineWaitForArgs,
+  settledSchema,
+  waitForObservation,
+  waitForSchema,
+} from "./observeTools";
+import { defaultTimer } from "../utils/SystemTimer";
 import { createJSONToolResponse, createStructuredToolResponse, StructuredToolResponse } from "../utils/toolUtils";
 import { resolveSwipeDirection } from "../utils/swipeOnUtils";
 import { RecompositionTracker } from "../features/performance/RecompositionTracker";
@@ -340,10 +352,50 @@ export const wakeAndUnlockSchema = addDeviceTargetingToSchema(z.object({
   platform: platformSchema
 }));
 
-export const openLinkSchema = addDeviceTargetingToSchema(z.object({
+// openLink gains an optional integrated waitFor (issue #3490 §5): after opening
+// the URL, poll for the predicate — reusing observe's waitFor/settled schema and
+// semantics — so the open→settle→observe→verify workaround collapses into one call.
+export const openLinkSchema = withAppIdAliases(withJsonSchemaOverride(addDeviceTargetingToSchema(z.object({
   url: z.string().describe("URL to open"),
-  platform: platformSchema
-}));
+  platform: platformSchema,
+  waitFor: waitForSchema.optional().describe("After opening, wait for this predicate before returning the observation"),
+  settled: settledSchema.optional().describe("After waitFor matches, wait for a quiet (no hierarchy change) period before returning")
+})).superRefine(refineWaitForArgs), overrideWaitForJsonSchema));
+
+/** Outcome of a post-open waitFor poll, as produced by {@link waitForObservation}. */
+export interface OpenLinkWaitOutcome {
+  observation: ObserveResult;
+  awaitedElement?: Element;
+  awaitDuration: number;
+  awaitTimeout: boolean;
+}
+
+/**
+ * Build the openLink response payload. Without a wait it is the plain open
+ * result; with a wait (issue #3490 §5) the awaited observation replaces the
+ * open-time snapshot and the await metadata is surfaced to the caller.
+ */
+export const buildOpenLinkPayload = (
+  url: string,
+  openResult: OpenURLResult,
+  waitOutcome: OpenLinkWaitOutcome | null
+) => {
+  if (!waitOutcome) {
+    return {
+      message: `Opened link ${url}`,
+      ...openResult,
+      observation: openResult.observation,
+    };
+  }
+  return {
+    message: `Opened link ${url}`,
+    ...openResult,
+    observation: waitOutcome.observation,
+    awaitedElement: waitOutcome.awaitedElement,
+    awaitDuration: waitOutcome.awaitDuration,
+    awaitTimeout: waitOutcome.awaitTimeout,
+  };
+};
 
 export const imeActionSchema = addDeviceTargetingToSchema(z.object({
   action: z.enum(["done", "next", "search", "send", "go", "previous"]).describe("IME action"),
@@ -856,15 +908,25 @@ export function registerInteractionTools() {
   };
 
   // Open link handler
-  const openLinkHandler = async (device: BootedDevice, args: OpenLinkArgs) => {
+  const openLinkHandler = async (device: BootedDevice, args: OpenLinkArgs, _progress?: ProgressCallback, signal?: AbortSignal) => {
     const openUrl = new OpenURL(device);
     const result = await openUrl.execute(args.url);
 
-    return createJSONToolResponse({
-      message: `Opened link ${args.url}`,
-      observation: result.observation,
-      ...result
-    });
+    // Integrated waitFor (issue #3490 §5): once the URL is opened, poll for the
+    // predicate exactly as `observe` does, surfacing the awaited observation and
+    // await metadata so callers no longer need a separate observe round-trip.
+    const waitOutcome = args.waitFor
+      ? await waitForObservation(
+        new RealObserveScreen(device),
+        { ...args.waitFor, settled: args.settled },
+        signal,
+        false,
+        defaultTimer,
+        device.platform
+      )
+      : null;
+
+    return createJSONToolResponse(buildOpenLinkPayload(args.url, result, waitOutcome));
   };
 
   // Shake handler

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -359,7 +359,7 @@ export const openLinkSchema = withAppIdAliases(withJsonSchemaOverride(addDeviceT
   url: z.string().describe("URL to open"),
   platform: platformSchema,
   waitFor: waitForSchema.optional().describe("After opening, wait for this predicate before returning the observation"),
-  settled: settledSchema.optional().describe("After waitFor matches, wait for a quiet (no hierarchy change) period before returning")
+  settled: settledSchema.optional().describe("After waitFor matches, wait for a quiet hierarchy period (requires waitFor)")
 })).superRefine(refineWaitForArgs), overrideWaitForJsonSchema));
 
 /** Outcome of a post-open waitFor poll, as produced by {@link waitForObservation}. */

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -10,7 +10,7 @@ import { BootedDevice, Element, ObserveResult, ObserveToolPayload, ViewHierarchy
 import { createGlobalPerformanceTracker } from "../utils/PerformanceTracker";
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
 import { IdentifyInteractions, IdentifyInteractionsOptions } from "../features/observe/IdentifyInteractions";
-import { addDeviceTargetingToSchema, platformSchema, withAppIdAliases, withJsonSchemaOverride } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, JsonSchemaOverride, platformSchema, withAppIdAliases, withJsonSchemaOverride } from "./toolSchemaHelpers";
 import { elementContainerSchema } from "./elementSelectorSchemas";
 import { observeToolResultSchema } from "./toolOutputSchemas";
 import { DefaultElementFinder } from "../features/utility/ElementFinder";
@@ -22,6 +22,7 @@ import { consumeSetupTiming } from "./ToolExecutionContext";
 import { AndroidCtrlProxyManager } from "../utils/CtrlProxyManager";
 import { logger } from "../utils/logger";
 import { serverConfig } from "../utils/ServerConfig";
+import { NodeCryptoService } from "../utils/crypto";
 
 // Schema definitions
 // waitFor accepts legacy selectors plus richer predicates. Element predicates are
@@ -55,11 +56,36 @@ const activeWindowWaitForSchema = activeWindowWaitForBaseSchema.and(z.union([
   z.object({ activityName: z.string() }).passthrough(),
 ]));
 
+// Absence / negation predicate (issue #3490 §4). Same element-matching fields as
+// a positive predicate; the wait resolves only when NO element matches these.
+const absentPredicateBaseSchema = z.object({
+  elementId: z.string().optional().describe("Resource ID / accessibility identifier that must be absent"),
+  text: z.string().optional().describe("Element text that must be absent (contains match)"),
+  className: z.string().optional().describe("Element class name that must be absent"),
+  contentDescription: z.string().optional().describe("Content description / accessibility label that must be absent"),
+}).strict();
+
+const absentPredicatePresenceSchema = z.union([
+  z.object({ elementId: z.string() }).passthrough(),
+  z.object({ text: z.string() }).passthrough(),
+  z.object({ className: z.string() }).passthrough(),
+  z.object({ contentDescription: z.string() }).passthrough(),
+]);
+
+const absentPredicateSchema = absentPredicateBaseSchema.and(absentPredicatePresenceSchema);
+
 const waitForCommonShape = {
   activeWindow: activeWindowWaitForSchema.optional().describe("Foreground app/window predicates"),
+  absent: absentPredicateSchema.optional().describe("Wait until an element matching these fields is absent"),
   timeout: z.number().optional().describe("Wait timeout ms (default: 5000)"),
   container: waitForContainerField
 };
+
+// Stability / "settled" gate (issue #3490 §3). After the waitFor predicate first
+// matches, keep observing until the view hierarchy is unchanged for this long.
+export const settledSchema = z.object({
+  quietPeriodMs: z.number().int().positive().describe("Wait for this many ms with no hierarchy changes after the waitFor predicate matches")
+}).strict();
 
 const waitForTextAnySchema = z.object({
   textAny: z.array(z.string().min(1)).min(1).describe("Ordered text variants; first visible match wins"),
@@ -101,11 +127,12 @@ const waitForPredicatePresenceSchema = z.union([
   z.object({ className: z.string() }).passthrough(),
   z.object({ contentDescription: z.string() }).passthrough(),
   z.object({ activeWindow: activeWindowWaitForSchema }).passthrough(),
+  z.object({ absent: absentPredicateSchema }).passthrough(),
 ]);
 
 const waitForElementSchema = waitForElementBaseSchema.and(waitForPredicatePresenceSchema);
 
-const waitForSchema = z.union([
+export const waitForSchema = z.union([
   waitForTextAnySchema,
   waitForElementSchema,
 ]);
@@ -123,12 +150,29 @@ const ELEMENT_PREDICATE_REQUIRED = [
   { required: ["className"] },
   { required: ["contentDescription"] },
 ];
+const ABSENT_PREDICATE_ADVERTISED_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  additionalProperties: false,
+  description: "Wait until an element matching these fields is absent",
+  properties: {
+    elementId: { type: "string", description: "Resource ID / accessibility identifier that must be absent" },
+    text: { type: "string", description: "Element text that must be absent (contains match)" },
+    className: { type: "string", description: "Element class name that must be absent" },
+    contentDescription: { type: "string", description: "Content description / accessibility label that must be absent" },
+  },
+  anyOf: [
+    { required: ["elementId"] },
+    { required: ["text"] },
+    { required: ["className"] },
+    { required: ["contentDescription"] },
+  ],
+};
 const COMPACT_WAITFOR_ADVERTISED_SCHEMA: Record<string, unknown> = {
   type: "object",
   additionalProperties: false,
   description:
     "Wait for a predicate before returning the observation. Provide at least one of: " +
-    "elementId, text, textAny, className, contentDescription, or activeWindow. " +
+    "elementId, text, textAny, className, contentDescription, activeWindow, or absent. " +
     "textAny is mutually exclusive with the element predicates.",
   properties: {
     elementId: { type: "string", description: "Element resource ID / accessibility identifier" },
@@ -173,6 +217,7 @@ const COMPACT_WAITFOR_ADVERTISED_SCHEMA: Record<string, unknown> = {
         { required: ["activityName"] },
       ],
     },
+    absent: ABSENT_PREDICATE_ADVERTISED_SCHEMA,
     container: {
       type: "object",
       description: "Scope the match to a container element (by elementId or text)",
@@ -182,6 +227,8 @@ const COMPACT_WAITFOR_ADVERTISED_SCHEMA: Record<string, unknown> = {
   },
   // Enforce the same shape the runtime does: at least one predicate, and textAny
   // mutually exclusive with the element predicates / matchType / textMatch.
+  // `absent` composes with everything (including textAny), so it is not part of
+  // the textAny exclusion set.
   anyOf: [
     {
       required: ["textAny"],
@@ -191,17 +238,18 @@ const COMPACT_WAITFOR_ADVERTISED_SCHEMA: Record<string, unknown> = {
     },
     {
       not: { required: ["textAny"] },
-      anyOf: [...ELEMENT_PREDICATE_REQUIRED, { required: ["activeWindow"] }],
+      anyOf: [...ELEMENT_PREDICATE_REQUIRED, { required: ["activeWindow"] }, { required: ["absent"] }],
     },
   ],
 };
 
-const observeBaseSchema = withJsonSchemaOverride(addDeviceTargetingToSchema(z.object({
-  platform: platformSchema,
-  waitFor: waitForSchema.optional().describe("Wait for element to appear before returning observation"),
-  raw: z.boolean().optional().describe("Include raw view hierarchy"),
-  skipBackStack: z.boolean().optional().describe("Skip back stack during waitFor polling")
-})).superRefine((value, ctx) => {
+// Cross-field validation shared by `observe` and `openLink` (both carry
+// platform + waitFor + settled): iOS rejects Android-only activityName, and
+// `settled` requires a `waitFor` predicate to settle after.
+export const refineWaitForArgs = (
+  value: { platform?: "android" | "ios"; waitFor?: ObserveWaitForOptions; settled?: unknown },
+  ctx: z.RefinementCtx
+): void => {
   const activeWindow = value.waitFor?.activeWindow;
   if (
     value.platform === "ios" &&
@@ -214,7 +262,19 @@ const observeBaseSchema = withJsonSchemaOverride(addDeviceTargetingToSchema(z.ob
       message: "activityName is Android-only; use appId/bundleId on iOS"
     });
   }
-}), jsonSchema => {
+  if (value.settled !== undefined && value.waitFor === undefined) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["settled"],
+      message: "settled requires waitFor"
+    });
+  }
+};
+
+// Shared advertised-JSON-schema override for `observe` and `openLink`: enforce
+// the iOS activityName rule, require waitFor whenever settled is present, and
+// swap the verbose generated `waitFor` schema for the compact advertised form.
+export const overrideWaitForJsonSchema: JsonSchemaOverride = jsonSchema => {
   jsonSchema.if = {
     required: ["platform", "waitFor"],
     properties: {
@@ -238,6 +298,12 @@ const observeBaseSchema = withJsonSchemaOverride(addDeviceTargetingToSchema(z.ob
   };
   jsonSchema.then = false;
 
+  // settled has no meaning without a waitFor predicate to settle after.
+  jsonSchema.dependentRequired = {
+    ...(jsonSchema.dependentRequired as Record<string, string[]> | undefined),
+    settled: ["waitFor"]
+  };
+
   // Replace the verbose generated `waitFor` schema with the compact advertised
   // form. Runtime validation still uses the full zod `waitForSchema`; this only
   // shrinks what `tools/list` carries (~2064 -> ~473 tokens). The `if`/`then`
@@ -247,7 +313,15 @@ const observeBaseSchema = withJsonSchemaOverride(addDeviceTargetingToSchema(z.ob
   if (props && props.waitFor) {
     props.waitFor = COMPACT_WAITFOR_ADVERTISED_SCHEMA;
   }
-});
+};
+
+const observeBaseSchema = withJsonSchemaOverride(addDeviceTargetingToSchema(z.object({
+  platform: platformSchema,
+  waitFor: waitForSchema.optional().describe("Wait for element to appear before returning observation"),
+  settled: settledSchema.optional().describe("After waitFor matches, wait for a quiet (no hierarchy change) period before returning"),
+  raw: z.boolean().optional().describe("Include raw view hierarchy"),
+  skipBackStack: z.boolean().optional().describe("Skip back stack during waitFor polling")
+})).superRefine(refineWaitForArgs), overrideWaitForJsonSchema);
 
 export const observeSchema = withAppIdAliases(observeBaseSchema);
 
@@ -269,7 +343,10 @@ export const identifyInteractionsSchema = addDeviceTargetingToSchema(z.object({
 
 const WAIT_FOR_POLL_INTERVAL_MS = 100;
 
-type ObserveWaitForOptions = z.infer<typeof waitForSchema>;
+export type ObserveWaitForOptions = z.infer<typeof waitForSchema>;
+export type SettledOptions = z.infer<typeof settledSchema>;
+/** waitFor options carrying the (top-level) settled gate, as threaded to {@link waitForObservation}. */
+export type WaitForWithSettled = ObserveWaitForOptions & { settled?: SettledOptions };
 type ObserveArgs = z.infer<typeof observeSchema>;
 
 const waitForContainerForFinder = (
@@ -527,6 +604,26 @@ const matchesActiveWindow = (
   return true;
 };
 
+// Absence / negation predicate (issue #3490 §4). Reuses the same element
+// matcher: the `absent` fields describe an element that must NOT be present, so
+// the predicate is satisfied exactly when no element matches them. Returns true
+// (vacuously satisfied) when no `absent` predicate is configured.
+const matchesAbsent = (
+  finder: ElementFinder,
+  waitFor: ObserveWaitForOptions,
+  viewHierarchy: ViewHierarchyResult,
+  platform?: BootedDevice["platform"]
+): boolean => {
+  if (!waitFor.absent) {
+    return true;
+  }
+  const absentAsWaitFor = {
+    ...waitFor.absent,
+    container: waitFor.container,
+  } as ObserveWaitForOptions;
+  return findWaitForElement(finder, absentAsWaitFor, viewHierarchy, platform) === null;
+};
+
 const evaluateWaitForObservation = (
   finder: ElementFinder,
   waitFor: ObserveWaitForOptions,
@@ -538,16 +635,38 @@ const evaluateWaitForObservation = (
   const awaitedElement = needsElementMatch && observation.viewHierarchy
     ? findWaitForElement(finder, waitFor, observation.viewHierarchy, platform)
     : null;
+  // Without a hierarchy we cannot confirm the absent element is gone, so treat
+  // an unconfirmed absence as unsatisfied (keep waiting).
+  const absentSatisfied = waitFor.absent === undefined
+    ? true
+    : observation.viewHierarchy
+      ? matchesAbsent(finder, waitFor, observation.viewHierarchy, platform)
+      : false;
 
   return {
-    matched: activeWindowMatched && (!needsElementMatch || awaitedElement !== null),
+    matched: activeWindowMatched && absentSatisfied && (!needsElementMatch || awaitedElement !== null),
     awaitedElement: awaitedElement ?? undefined
   };
 };
 
+// Compact stable hash of the hierarchy node tree, used only to detect quiet
+// (settled) periods. Screen size / window metadata are excluded so cosmetic,
+// non-hierarchy churn does not defeat the gate. A missing hierarchy hashes to a
+// stable sentinel, so it counts as "quiet".
+const hashHierarchyForSettle = (viewHierarchy?: ViewHierarchyResult): string => {
+  try {
+    return NodeCryptoService.generateCacheKey(JSON.stringify(viewHierarchy?.hierarchy ?? null));
+  } catch (error) {
+    // Non-serializable hierarchy is unexpected; treat it as an unstable tree so
+    // the settle gate keeps polling rather than resolving on a bad snapshot.
+    logger.debug(`[observe] Failed to hash hierarchy for settle gate: ${error}`);
+    return `unstable:${WAIT_FOR_POLL_INTERVAL_MS}`;
+  }
+};
+
 export const waitForObservation = async (
   observeScreen: ObserveScreen,
-  waitFor: ObserveWaitForOptions,
+  waitFor: WaitForWithSettled,
   signal?: AbortSignal,
   skipBackStack: boolean = false,
   timer: Timer = defaultTimer,
@@ -560,6 +679,7 @@ export const waitForObservation = async (
 }> => {
   const startTime = timer.now();
   const timeoutMs = waitFor.timeout ?? 5000;
+  const settled = waitFor.settled;
   const finder = new DefaultElementFinder();
   const queryOptions = {
     text: waitFor.text ?? waitFor.textAny?.[0] ?? waitFor.contentDescription,
@@ -573,8 +693,7 @@ export const waitForObservation = async (
   // exact screen state when waitFor resolved.
   const skipPollingOverhead = !serverConfig.isWaitForPollingOverheadEnabled();
 
-  throwIfAborted(signal);
-  let observation = await observeScreen.execute({
+  const observeOnce = () => observeScreen.execute({
     queryOptions,
     perf: createGlobalPerformanceTracker(),
     skipWaitForFresh: false,
@@ -583,15 +702,39 @@ export const waitForObservation = async (
     skipBackStack: skipPollingOverhead || skipBackStack,
     skipScreenshot: skipPollingOverhead,
   });
+
+  // Settle gate (issue #3490 §3): once the predicate matches, hold until the
+  // hierarchy hash is unchanged for settled.quietPeriodMs. `matchedHash === null`
+  // means "no stable candidate yet"; a changed hash restarts the quiet window.
+  let matchedHash: string | null = null;
+  let quietStart = startTime;
+  const settleReady = (observation: ObserveResult): boolean => {
+    if (!settled) {
+      return true;
+    }
+    const hash = hashHierarchyForSettle(observation.viewHierarchy);
+    if (matchedHash === null || hash !== matchedHash) {
+      matchedHash = hash;
+      quietStart = timer.now();
+      return false;
+    }
+    return timer.now() - quietStart >= settled.quietPeriodMs;
+  };
+
+  throwIfAborted(signal);
+  let observation = await observeOnce();
   let waitEvaluation = evaluateWaitForObservation(finder, waitFor, observation, platform);
 
-  if (waitEvaluation.matched) {
+  if (waitEvaluation.matched && settleReady(observation)) {
     return {
       observation,
       awaitedElement: waitEvaluation.awaitedElement,
       awaitDuration: timer.now() - startTime,
       awaitTimeout: false
     };
+  }
+  if (!waitEvaluation.matched) {
+    matchedHash = null;
   }
 
   if (timer.now() - startTime >= timeoutMs) {
@@ -606,24 +749,20 @@ export const waitForObservation = async (
     await timer.sleep(WAIT_FOR_POLL_INTERVAL_MS);
     throwIfAborted(signal);
 
-    observation = await observeScreen.execute({
-      queryOptions,
-      perf: createGlobalPerformanceTracker(),
-      skipWaitForFresh: false,
-      minTimestamp: startTime,
-      signal,
-      skipBackStack: skipPollingOverhead || skipBackStack,
-      skipScreenshot: skipPollingOverhead,
-    });
+    observation = await observeOnce();
     waitEvaluation = evaluateWaitForObservation(finder, waitFor, observation, platform);
 
     if (waitEvaluation.matched) {
-      return {
-        observation,
-        awaitedElement: waitEvaluation.awaitedElement,
-        awaitDuration: timer.now() - startTime,
-        awaitTimeout: false
-      };
+      if (settleReady(observation)) {
+        return {
+          observation,
+          awaitedElement: waitEvaluation.awaitedElement,
+          awaitDuration: timer.now() - startTime,
+          awaitTimeout: false
+        };
+      }
+    } else {
+      matchedHash = null;
     }
   }
 
@@ -645,7 +784,7 @@ export function registerObserveTools() {
       // source, so every observation reaching here is already platform-validated
       // (raw-mode append below is likewise gated on a validated primary hierarchy).
       const waitOutcome = waitFor
-        ? await waitForObservation(observeScreen, waitFor, signal, args.skipBackStack ?? false, defaultTimer, device.platform)
+        ? await waitForObservation(observeScreen, { ...waitFor, settled: args.settled }, signal, args.skipBackStack ?? false, defaultTimer, device.platform)
         : null;
       const result = waitOutcome
         ? waitOutcome.observation

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -84,7 +84,7 @@ const waitForCommonShape = {
 // Stability / "settled" gate (issue #3490 §3). After the waitFor predicate first
 // matches, keep observing until the view hierarchy is unchanged for this long.
 export const settledSchema = z.object({
-  quietPeriodMs: z.number().int().positive().describe("Wait for this many ms with no hierarchy changes after the waitFor predicate matches")
+  quietPeriodMs: z.number().int().positive().describe("Quiet-period ms (no hierarchy change) required after waitFor matches")
 }).strict();
 
 const waitForTextAnySchema = z.object({
@@ -153,12 +153,12 @@ const ELEMENT_PREDICATE_REQUIRED = [
 const ABSENT_PREDICATE_ADVERTISED_SCHEMA: Record<string, unknown> = {
   type: "object",
   additionalProperties: false,
-  description: "Wait until an element matching these fields is absent",
+  description: "Wait until an element matching these fields is absent (text uses contains match)",
   properties: {
-    elementId: { type: "string", description: "Resource ID / accessibility identifier that must be absent" },
-    text: { type: "string", description: "Element text that must be absent (contains match)" },
-    className: { type: "string", description: "Element class name that must be absent" },
-    contentDescription: { type: "string", description: "Content description / accessibility label that must be absent" },
+    elementId: { type: "string" },
+    text: { type: "string" },
+    className: { type: "string" },
+    contentDescription: { type: "string" },
   },
   anyOf: [
     { required: ["elementId"] },
@@ -171,9 +171,9 @@ const COMPACT_WAITFOR_ADVERTISED_SCHEMA: Record<string, unknown> = {
   type: "object",
   additionalProperties: false,
   description:
-    "Wait for a predicate before returning the observation. Provide at least one of: " +
-    "elementId, text, textAny, className, contentDescription, activeWindow, or absent. " +
-    "textAny is mutually exclusive with the element predicates.",
+    "Wait for a predicate before returning. Provide at least one of: elementId, text, " +
+    "textAny, className, contentDescription, activeWindow, absent. textAny excludes the " +
+    "element predicates.",
   properties: {
     elementId: { type: "string", description: "Element resource ID / accessibility identifier" },
     text: { type: "string", description: "Element text" },
@@ -203,8 +203,8 @@ const COMPACT_WAITFOR_ADVERTISED_SCHEMA: Record<string, unknown> = {
       description: "Foreground app/window predicates (provide an app id or activityName)",
       properties: {
         appId: { type: "string", description: "Foreground app bundle ID / package name" },
-        packageName: { type: "string", description: "Alias for appId (Android package name)" },
-        bundleId: { type: "string", description: "Alias for appId (iOS bundle ID)" },
+        packageName: { type: "string", description: "appId alias (Android package)" },
+        bundleId: { type: "string", description: "appId alias (iOS bundle)" },
         activityName: {
           type: "string",
           description: "Foreground Android activity name (Android-only)",
@@ -318,7 +318,7 @@ export const overrideWaitForJsonSchema: JsonSchemaOverride = jsonSchema => {
 const observeBaseSchema = withJsonSchemaOverride(addDeviceTargetingToSchema(z.object({
   platform: platformSchema,
   waitFor: waitForSchema.optional().describe("Wait for element to appear before returning observation"),
-  settled: settledSchema.optional().describe("After waitFor matches, wait for a quiet (no hierarchy change) period before returning"),
+  settled: settledSchema.optional().describe("After waitFor matches, wait for a quiet hierarchy period (requires waitFor)"),
   raw: z.boolean().optional().describe("Include raw view hierarchy"),
   skipBackStack: z.boolean().optional().describe("Skip back stack during waitFor polling")
 })).superRefine(refineWaitForArgs), overrideWaitForJsonSchema);

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -652,15 +652,17 @@ const evaluateWaitForObservation = (
 // Compact stable hash of the hierarchy node tree, used only to detect quiet
 // (settled) periods. Screen size / window metadata are excluded so cosmetic,
 // non-hierarchy churn does not defeat the gate. A missing hierarchy hashes to a
-// stable sentinel, so it counts as "quiet".
-const hashHierarchyForSettle = (viewHierarchy?: ViewHierarchyResult): string => {
+// stable sentinel, so it counts as "quiet". Returns null when the tree cannot be
+// hashed, which the settle gate treats as unstable (never settle on it).
+const hashHierarchyForSettle = (viewHierarchy?: ViewHierarchyResult): string | null => {
   try {
     return NodeCryptoService.generateCacheKey(JSON.stringify(viewHierarchy?.hierarchy ?? null));
   } catch (error) {
-    // Non-serializable hierarchy is unexpected; treat it as an unstable tree so
-    // the settle gate keeps polling rather than resolving on a bad snapshot.
+    // Non-serializable hierarchy is unexpected; a constant sentinel would compare
+    // equal across consecutive failures and be mistaken for a quiet tree, so
+    // return null and let settleReady restart the quiet window instead.
     logger.debug(`[observe] Failed to hash hierarchy for settle gate: ${error}`);
-    return `unstable:${WAIT_FOR_POLL_INTERVAL_MS}`;
+    return null;
   }
 };
 
@@ -713,7 +715,9 @@ export const waitForObservation = async (
       return true;
     }
     const hash = hashHierarchyForSettle(observation.viewHierarchy);
-    if (matchedHash === null || hash !== matchedHash) {
+    // An unhashable tree (null) is never quiet: fall through to restart the
+    // window so the gate cannot resolve early on an unverifiable snapshot.
+    if (hash === null || matchedHash === null || hash !== matchedHash) {
       matchedHash = hash;
       quietStart = timer.now();
       return false;

--- a/test/server/observeWaitForSchema.test.ts
+++ b/test/server/observeWaitForSchema.test.ts
@@ -372,6 +372,16 @@ describe("published observe waitFor input schema", () => {
       },
     },
     {
+      label: "absent combined with textAny",
+      input: {
+        platform: "android",
+        waitFor: {
+          textAny: ["Home", "Feed"],
+          absent: { elementId: "com.app:id/spinner" },
+        },
+      },
+    },
+    {
       label: "settled with a waitFor predicate",
       input: {
         platform: "android",

--- a/test/server/observeWaitForSchema.test.ts
+++ b/test/server/observeWaitForSchema.test.ts
@@ -354,6 +354,31 @@ describe("published observe waitFor input schema", () => {
         },
       },
     },
+    {
+      label: "absent alone",
+      input: {
+        platform: "ios",
+        waitFor: { absent: { className: "UIActivityIndicatorView" } },
+      },
+    },
+    {
+      label: "absent combined with a positive predicate",
+      input: {
+        platform: "ios",
+        waitFor: {
+          absent: { className: "UIActivityIndicatorView" },
+          elementId: "message_list",
+        },
+      },
+    },
+    {
+      label: "settled with a waitFor predicate",
+      input: {
+        platform: "android",
+        waitFor: { elementId: "home_tab_bar", timeout: 15000 },
+        settled: { quietPeriodMs: 500 },
+      },
+    },
   ])("accepts runtime-valid waitFor input: $label", ({ input }) => {
     expect(observeSchema.safeParse(input).success).toBe(true);
 
@@ -436,6 +461,20 @@ describe("published observe waitFor input schema", () => {
             activityName: "com.example.ios.IgnoredActivity",
           },
         },
+      },
+    },
+    {
+      label: "settled without waitFor",
+      input: {
+        platform: "android",
+        settled: { quietPeriodMs: 500 },
+      },
+    },
+    {
+      label: "empty absent object",
+      input: {
+        platform: "android",
+        waitFor: { absent: {} },
       },
     },
   ])("rejects runtime-invalid waitFor input: $label", ({ input }) => {
@@ -1039,5 +1078,246 @@ describe("waitForObservation activeWindow", () => {
     expect(outcome.awaitTimeout).toBe(true);
     expect(outcome.awaitedElement).toBeUndefined();
     expect(observeScreen.getExecuteCallCount()).toBeGreaterThan(1);
+  });
+});
+
+// --- Issue #3490: settled (stability) gate ------------------------------------
+
+describe("observeSchema settled", () => {
+  test("accepts settled with a waitFor predicate", () => {
+    const parsed = observeSchema.parse({
+      platform: "android",
+      waitFor: { elementId: "home_tab_bar", timeout: 15000 },
+      settled: { quietPeriodMs: 500 },
+    });
+    expect(parsed.settled).toEqual({ quietPeriodMs: 500 });
+  });
+
+  test("rejects settled without a waitFor predicate", () => {
+    expect(
+      observeSchema.safeParse({
+        platform: "android",
+        settled: { quietPeriodMs: 500 },
+      }).success
+    ).toBe(false);
+  });
+
+  test("rejects non-positive quietPeriodMs", () => {
+    expect(
+      observeSchema.safeParse({
+        platform: "android",
+        waitFor: { elementId: "home_tab_bar" },
+        settled: { quietPeriodMs: 0 },
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe("waitForObservation settled", () => {
+  const makeObservation = (markerId: string): ObserveResult => ({
+    updatedAt: 0,
+    screenSize: { width: 200, height: 200 },
+    systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+    activeWindow: { appId: "com.example.app", activityName: "", layoutSeqSum: 0 },
+    viewHierarchy: makeHierarchy([
+      { $: { "resource-id": "home_tab_bar", "bounds": bounds(10, 10, 100, 60) } },
+      { $: { "resource-id": markerId, "bounds": bounds(10, 80, 100, 120) } },
+    ]),
+  });
+
+  test("waits for a quiet hierarchy period after the predicate first matches", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const observeScreen = new FakeObserveScreen();
+    let call = 0;
+    // Predicate (home_tab_bar) matches from the first observation, but the tree
+    // keeps changing for the first three observations before it stabilizes.
+    observeScreen.setObserveResult(() => {
+      call++;
+      return makeObservation(call <= 3 ? `marker_${call}` : "marker_stable");
+    });
+
+    const outcome = await waitForObservation(
+      observeScreen,
+      {
+        elementId: "home_tab_bar",
+        settled: { quietPeriodMs: 300 },
+        timeout: 5000,
+      } as any,
+      undefined,
+      false,
+      timer
+    );
+
+    expect(outcome.awaitTimeout).toBe(false);
+    // Must have kept polling past the first match to confirm the quiet period.
+    expect(observeScreen.getExecuteCallCount()).toBeGreaterThan(4);
+    expect(outcome.awaitedElement?.["resource-id"]).toBe("home_tab_bar");
+  });
+
+  test("times out when the hierarchy never settles", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const observeScreen = new FakeObserveScreen();
+    let call = 0;
+    // Predicate always matches, but every observation is a different tree, so it
+    // never reaches a quiet period.
+    observeScreen.setObserveResult(() => {
+      call++;
+      return makeObservation(`marker_${call}`);
+    });
+
+    const outcome = await waitForObservation(
+      observeScreen,
+      {
+        elementId: "home_tab_bar",
+        settled: { quietPeriodMs: 300 },
+        timeout: 500,
+      } as any,
+      undefined,
+      false,
+      timer
+    );
+
+    expect(outcome.awaitTimeout).toBe(true);
+  });
+});
+
+// --- Issue #3490: absence / negation predicate --------------------------------
+
+describe("observeSchema waitFor.absent", () => {
+  test("accepts absent combined with a positive predicate", () => {
+    const parsed = observeSchema.parse({
+      platform: "ios",
+      waitFor: {
+        absent: { className: "UIActivityIndicatorView" },
+        elementId: "message_list",
+        timeout: 15000,
+      },
+    });
+    expect(parsed.waitFor).toMatchObject({
+      absent: { className: "UIActivityIndicatorView" },
+      elementId: "message_list",
+    });
+  });
+
+  test("accepts absent alone", () => {
+    const parsed = observeSchema.parse({
+      platform: "ios",
+      waitFor: { absent: { className: "UIActivityIndicatorView" } },
+    });
+    expect(parsed.waitFor).toMatchObject({
+      absent: { className: "UIActivityIndicatorView" },
+    });
+  });
+
+  test("accepts absent combined with textAny", () => {
+    const parsed = observeSchema.parse({
+      platform: "android",
+      waitFor: {
+        textAny: ["Home", "Feed"],
+        absent: { elementId: "com.app:id/spinner" },
+      },
+    });
+    expect(parsed.waitFor).toMatchObject({
+      textAny: ["Home", "Feed"],
+      absent: { elementId: "com.app:id/spinner" },
+    });
+  });
+
+  test("rejects an empty absent object", () => {
+    expect(
+      observeSchema.safeParse({
+        platform: "android",
+        waitFor: { absent: {} },
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe("waitForObservation absent", () => {
+  const makeObservation = (nodes: unknown[]): ObserveResult => ({
+    updatedAt: 0,
+    screenSize: { width: 200, height: 200 },
+    systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+    activeWindow: { appId: "com.example.app", activityName: "", layoutSeqSum: 0 },
+    viewHierarchy: makeHierarchy(nodes),
+  });
+
+  const spinner = { $: { "class": "UIActivityIndicatorView", "bounds": bounds(10, 10, 50, 50) } };
+  const list = { $: { "resource-id": "message_list", "bounds": bounds(10, 60, 190, 190) } };
+
+  test("resolves once the absent element disappears and the positive predicate is present", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const observeScreen = new FakeObserveScreen();
+    const observations = [
+      makeObservation([spinner, list]),
+      makeObservation([list]),
+    ];
+    observeScreen.setObserveResult(() => observations.shift() ?? observations[0]);
+
+    const outcome = await waitForObservation(
+      observeScreen,
+      {
+        absent: { className: "UIActivityIndicatorView" },
+        elementId: "message_list",
+        timeout: 500,
+      } as any,
+      undefined,
+      false,
+      timer
+    );
+
+    expect(outcome.awaitTimeout).toBe(false);
+    expect(outcome.awaitedElement?.["resource-id"]).toBe("message_list");
+    expect(observeScreen.getExecuteCallCount()).toBe(2);
+  });
+
+  test("keeps waiting while the absent element is still present", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const observeScreen = new FakeObserveScreen();
+    observeScreen.setObserveResult(() => makeObservation([spinner, list]));
+
+    const outcome = await waitForObservation(
+      observeScreen,
+      {
+        absent: { className: "UIActivityIndicatorView" },
+        elementId: "message_list",
+        timeout: 250,
+      } as any,
+      undefined,
+      false,
+      timer
+    );
+
+    expect(outcome.awaitTimeout).toBe(true);
+    expect(observeScreen.getExecuteCallCount()).toBeGreaterThan(1);
+  });
+
+  test("absent-only predicate resolves when the element is gone", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const observeScreen = new FakeObserveScreen();
+    const observations = [
+      makeObservation([spinner]),
+      makeObservation([]),
+    ];
+    observeScreen.setObserveResult(() => observations.shift() ?? observations[0]);
+
+    const outcome = await waitForObservation(
+      observeScreen,
+      {
+        absent: { className: "UIActivityIndicatorView" },
+        timeout: 500,
+      } as any,
+      undefined,
+      false,
+      timer
+    );
+
+    expect(outcome.awaitTimeout).toBe(false);
+    expect(observeScreen.getExecuteCallCount()).toBe(2);
   });
 });

--- a/test/server/openLinkWaitFor.test.ts
+++ b/test/server/openLinkWaitFor.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import type { Element, ObserveResult, OpenURLResult } from "../../src/models";
+import { buildOpenLinkPayload, openLinkSchema } from "../../src/server/interactionTools";
+
+const makeObservation = (marker: string): ObserveResult => ({
+  updatedAt: 0,
+  screenSize: { width: 200, height: 200 },
+  systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+  activeWindow: { appId: "com.example.app", activityName: marker, layoutSeqSum: 0 },
+});
+
+describe("openLinkSchema waitFor / settled", () => {
+  test("accepts openLink with an integrated waitFor predicate", () => {
+    const parsed = openLinkSchema.parse({
+      platform: "ios",
+      url: "slack://open",
+      waitFor: {
+        activeWindow: { appId: "com.tinyspeck.chatlyio" },
+        elementId: "home_tab_bar",
+        timeout: 25000,
+      },
+    });
+    expect(parsed.waitFor).toMatchObject({
+      activeWindow: { appId: "com.tinyspeck.chatlyio" },
+      elementId: "home_tab_bar",
+    });
+  });
+
+  test("accepts openLink with waitFor and settled together", () => {
+    const parsed = openLinkSchema.parse({
+      platform: "android",
+      url: "myapp://home",
+      waitFor: { elementId: "home_tab_bar", timeout: 25000 },
+      settled: { quietPeriodMs: 500 },
+    });
+    expect(parsed.settled).toEqual({ quietPeriodMs: 500 });
+  });
+
+  test("accepts a plain openLink with no waitFor (unchanged behavior)", () => {
+    const parsed = openLinkSchema.parse({
+      platform: "android",
+      url: "https://example.com",
+    });
+    expect(parsed.url).toBe("https://example.com");
+    expect(parsed.waitFor).toBeUndefined();
+  });
+
+  test("rejects settled without waitFor", () => {
+    expect(
+      openLinkSchema.safeParse({
+        platform: "android",
+        url: "myapp://home",
+        settled: { quietPeriodMs: 500 },
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe("buildOpenLinkPayload", () => {
+  const openResult: OpenURLResult = {
+    success: true,
+    url: "slack://open",
+    observation: makeObservation("open"),
+  };
+
+  test("returns the plain open result when no wait occurred", () => {
+    const payload = buildOpenLinkPayload("slack://open", openResult, null);
+    expect(payload.observation).toBe(openResult.observation);
+    expect("awaitTimeout" in payload).toBe(false);
+    expect("awaitedElement" in payload).toBe(false);
+  });
+
+  test("surfaces the awaited observation and await fields when a wait occurred", () => {
+    const awaited = makeObservation("home");
+    const awaitedElement = { "resource-id": "home_tab_bar" } as unknown as Element;
+    const payload = buildOpenLinkPayload("slack://open", openResult, {
+      observation: awaited,
+      awaitedElement,
+      awaitDuration: 1200,
+      awaitTimeout: false,
+    });
+    expect(payload.observation).toBe(awaited);
+    expect(payload.awaitedElement).toBe(awaitedElement);
+    expect(payload.awaitDuration).toBe(1200);
+    expect(payload.awaitTimeout).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Ships the three deferred `observe.waitFor` enhancements from [#2845](https://github.com/kaeawc/auto-mobile/issues/2845) that [PR #3489](https://github.com/kaeawc/auto-mobile/pull/3489) tracked as follow-ups in [#3490](https://github.com/kaeawc/auto-mobile/issues/3490). All three are purely additive/optional — existing `waitFor` behavior is unchanged.

## Changes

- **Settled / stability gate** (§3): new top-level `settled: { quietPeriodMs }` arg on `observe` (and `openLink`). After the `waitFor` predicate first matches, `waitForObservation` keeps observing until the view-hierarchy hash is unchanged for `quietPeriodMs`, still bounded by the overall `timeout`. `settled` requires a `waitFor` (enforced at runtime via `superRefine` and advertised via `dependentRequired`).
- **Absence / negation predicate** (§4): new `waitFor.absent` sub-object (`elementId` / `text` / `className` / `contentDescription`). The wait resolves only when **no** element matches `absent`, AND the positive predicates match, AND `activeWindow` matches. `absent` alone is a valid predicate and composes with `textAny`.
- **openLink integrated waitFor** (§5): `openLink` accepts optional `waitFor` + `settled`, reusing `observe`'s schema and semantics. After opening the URL it polls via `waitForObservation` and returns the awaited observation plus `awaitedElement` / `awaitDuration` / `awaitTimeout`, collapsing the open→sleep→observe→verify workaround into one call.
- `schemas/tool-definitions.json` regenerated for the `observe` and `openLink` public surfaces.

## Linked Issue

Closes #3490

## Validation

- [x] `scripts/all_fast_validate_checks.sh` equivalents pass (`bun run lint` + `bun test`: 9226 pass, 0 fail)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] New generic code reuses an existing project helper (`NodeCryptoService`, `DefaultElementFinder`, `waitForObservation`) — no new dependency
- [ ] Rebased onto latest `main`, conflicts resolved

## Acceptance criteria → test

- **Settled gate** → `waitForObservation settled` (waits for a quiet period after match; times out if the tree never settles) + `observeSchema settled` (accept with waitFor; reject without; reject non-positive `quietPeriodMs`).
- **Absence predicate** → `waitForObservation absent` (resolves when the absent element disappears + positive present; keeps waiting while present; absent-only resolves when gone) + `observeSchema waitFor.absent` (accept combined / alone / with `textAny`; reject empty).
- **openLink integration** → `openLinkSchema waitFor / settled` (accept `waitFor`, `waitFor`+`settled`, plain; reject `settled` without `waitFor`) + `buildOpenLinkPayload` (await fields surfaced only when a wait occurred).
- Published-schema round-trip cases added to the existing Ajv accept/reject `test.each` for `absent` and `settled`.

## Device Verification

- [ ] Verified on a real Android device / iOS simulator via `observe`

Not run: no real-device verification in this worktree. Behavior is covered by `FakeObserveScreen` + `FakeTimer` polling tests and pure schema/matcher tests; the polling loop and predicate matchers are the same paths [#3489](https://github.com/kaeawc/auto-mobile/pull/3489) shipped.

## Follow-ups

None required — this PR closes out the deferred set from #3490.
