### PR TITLE
perf(webrtc): add p50/p95 baseline aggregator for iOS device-lane egress records (#4387)

### DIFF
--- a/scripts/webrtc/aggregate-egress-baseline.ts
+++ b/scripts/webrtc/aggregate-egress-baseline.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env bun
+
+/**
+ * Aggregate accumulated WebRTC device-lane `stage-latency.json` records into a
+ * p50/p95 egress / decoded-fps / stage-latency baseline (#4387).
+ *
+ * The device integration lane writes one `CaptureStageRecord` (schemaVersion 3)
+ * per run as an artifact. #4375's follow-up needs "several CI runs accumulated,
+ * then p50/p95 reported" before the `0.1` bpp budget or any timeout contract is
+ * tightened — a measurement-collection task. This script is the *reporting* half
+ * of that task: download the artifacts into one directory, point this at it, and
+ * it computes the percentiles the decision turns on. It does not set or commit a
+ * baseline number and does not change any encoder default.
+ *
+ * Usage:
+ *   bun scripts/webrtc/aggregate-egress-baseline.ts <artifacts-dir> [platform]
+ */
+
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  aggregateCaptureStageRecords,
+  formatCaptureBaselineSummary,
+  type CaptureBaselineSummary,
+  type CaptureStageRecord,
+} from "../../test/helpers/captureStageTimeline";
+
+/** Structural check that a parsed JSON value is a capture-stage record, not some other artifact JSON. */
+function isCaptureStageRecord(value: unknown): value is CaptureStageRecord {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.schemaVersion === "number" &&
+    typeof candidate.platform === "string" &&
+    Array.isArray(candidate.stages)
+  );
+}
+
+/** List every `*.json` file under `dir`, recursing into per-run artifact subdirectories. */
+async function listJsonFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listJsonFiles(full)));
+    } else if (entry.isFile() && entry.name.endsWith(".json")) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+/**
+ * Read every capture-stage record under `dir` (recursively). Files that are not
+ * JSON, or JSON that is not a capture-stage record, are skipped with a warning
+ * rather than failing the run — an artifact directory holds logs and unrelated
+ * JSON alongside the record.
+ */
+export async function readCaptureStageRecords(dir: string): Promise<CaptureStageRecord[]> {
+  const records: CaptureStageRecord[] = [];
+  for (const file of await listJsonFiles(dir)) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(await readFile(file, "utf8"));
+    } catch (error) {
+      // Not JSON, or malformed JSON — an artifact directory mixes logs in; skip it.
+      process.stderr.write(`skipping ${file}: ${error instanceof Error ? error.message : String(error)}\n`);
+      continue;
+    }
+    if (isCaptureStageRecord(parsed)) {
+      records.push(parsed);
+    }
+  }
+  return records;
+}
+
+/** Read the records under `dir` and reduce them to a p50/p95 baseline summary. */
+export async function summarizeBaselineFromDir(
+  dir: string,
+  options: { platform?: string } = {}
+): Promise<CaptureBaselineSummary> {
+  const records = await readCaptureStageRecords(dir);
+  return aggregateCaptureStageRecords(records, options);
+}
+
+async function main(): Promise<void> {
+  const [dir, platform] = process.argv.slice(2);
+  if (!dir) {
+    throw new Error("Usage: bun scripts/webrtc/aggregate-egress-baseline.ts <artifacts-dir> [platform]");
+  }
+  const summary = await summarizeBaselineFromDir(dir, platform ? { platform } : {});
+  process.stdout.write(`${formatCaptureBaselineSummary(summary)}\n`);
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/src/server/networkGraph.ts
+++ b/src/server/networkGraph.ts
@@ -1,4 +1,5 @@
 import type { NetworkEventWithId } from "../db/networkEventRepository";
+import { computePercentile } from "../utils/percentile";
 
 export interface GraphLeaf {
   method?: string;
@@ -40,19 +41,6 @@ function isParameterizedSegment(segment: string): boolean {
     return true;
   }
   return false;
-}
-
-function computePercentile(sorted: number[], p: number): number {
-  if (sorted.length === 0) {
-    return 0;
-  }
-  const index = (p / 100) * (sorted.length - 1);
-  const lower = Math.floor(index);
-  const upper = Math.ceil(index);
-  if (lower === upper) {
-    return sorted[lower];
-  }
-  return sorted[lower] + (sorted[upper] - sorted[lower]) * (index - lower);
 }
 
 interface EventGroup {

--- a/src/server/networkResources.ts
+++ b/src/server/networkResources.ts
@@ -7,6 +7,7 @@ import {
 } from "../db/networkEventRepository";
 import { NetworkState } from "./NetworkState";
 import { BODY_TRUNCATION_LIMIT } from "../utils/truncateBodyText";
+import { computePercentile } from "../utils/percentile";
 
 const NETWORK_RESOURCE_URIS = {
   REQUEST: "automobile:network/request/{requestId}",
@@ -118,15 +119,6 @@ export interface TimeSeriesBucket {
   avgDurationMs: number;
   p50: number;
   p95: number;
-}
-
-function computePercentile(sorted: number[], p: number): number {
-  if (sorted.length === 0) {return 0;}
-  const index = (p / 100) * (sorted.length - 1);
-  const lower = Math.floor(index);
-  const upper = Math.ceil(index);
-  if (lower === upper) {return sorted[lower];}
-  return sorted[lower] + (sorted[upper] - sorted[lower]) * (index - lower);
 }
 
 const MAX_BUCKETS = 1000;

--- a/src/utils/percentile.ts
+++ b/src/utils/percentile.ts
@@ -1,0 +1,26 @@
+/**
+ * Percentile over a pre-sorted ascending array, using linear interpolation
+ * between the two ranks that bracket the requested position.
+ *
+ * This is the canonical percentile primitive for the repo — it was previously
+ * duplicated verbatim as a private helper in both `src/server/networkGraph.ts`
+ * and `src/server/networkResources.ts`, and is reused by the WebRTC egress
+ * baseline aggregation (#4387). The contract is unchanged from those copies:
+ * the caller sorts ascending first (the function reads positionally and does
+ * not re-sort), and an empty array yields `0`.
+ *
+ * @param sorted values sorted ascending
+ * @param p percentile in the range [0, 100]
+ */
+export function computePercentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) {
+    return 0;
+  }
+  const index = (p / 100) * (sorted.length - 1);
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  if (lower === upper) {
+    return sorted[lower];
+  }
+  return sorted[lower] + (sorted[upper] - sorted[lower]) * (index - lower);
+}

--- a/test/helpers/captureStageBaseline.test.ts
+++ b/test/helpers/captureStageBaseline.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from "bun:test";
+import {
+  aggregateCaptureStageRecords,
+  formatCaptureBaselineSummary,
+  type CaptureStageMeasurement,
+  type CaptureStageRecord,
+} from "./captureStageTimeline";
+
+/**
+ * Build a schemaVersion-3 record with only the fields the baseline aggregator
+ * reads; everything else is filled with inert defaults so a test can state just
+ * the sample it cares about.
+ */
+function record(overrides: {
+  platform?: string;
+  egressKbps?: number | null;
+  decodedFps?: number | null;
+  stages?: CaptureStageMeasurement[];
+}): CaptureStageRecord {
+  return {
+    platform: overrides.platform ?? "ios",
+    streamId: "device-capture",
+    outcome: "passed",
+    sourceSize: null,
+    configuredFps: 15,
+    decodedSize: null,
+    egressKbps: overrides.egressKbps === undefined ? null : overrides.egressKbps,
+    decodedFps: overrides.decodedFps === undefined ? null : overrides.decodedFps,
+    run: {
+      runId: null,
+      runAttempt: null,
+      commitSha: null,
+      runnerOs: null,
+      runnerImage: null,
+      startedAtIso: "2026-07-24T00:00:00.000Z",
+    },
+    samplingIntervalsMs: {},
+    schemaVersion: 3,
+    stages: overrides.stages ?? [],
+    phases: [],
+    missingStages: [],
+    captureToBrowserMs: null,
+  };
+}
+
+describe("#4387 iOS egress p50/p95 baseline aggregation", () => {
+  test("reports p50/p95 of egressKbps and decodedFps across samples", () => {
+    const summary = aggregateCaptureStageRecords([
+      record({ egressKbps: 100, decodedFps: 10 }),
+      record({ egressKbps: 200, decodedFps: 11 }),
+      record({ egressKbps: 300, decodedFps: 12 }),
+      record({ egressKbps: 400, decodedFps: 13 }),
+      record({ egressKbps: 500, decodedFps: 14 }),
+    ]);
+
+    expect(summary.sampleCount).toBe(5);
+    // p50 index = 0.5*(5-1)=2 -> 300 ; p95 index = 0.95*4=3.8 -> 400+100*0.8=480
+    expect(summary.egressKbps).toEqual({ count: 5, p50: 300, p95: 480 });
+    // p50 -> 12 ; p95 index 3.8 -> 13 + (14-13)*0.8 = 13.8
+    expect(summary.decodedFps).toEqual({ count: 5, p50: 12, p95: 13.8 });
+  });
+
+  test("excludes null egress/decodedFps samples instead of counting them as zero", () => {
+    const summary = aggregateCaptureStageRecords([
+      record({ egressKbps: 100, decodedFps: 10 }),
+      record({ egressKbps: null, decodedFps: null }),
+      record({ egressKbps: 300, decodedFps: 14 }),
+    ]);
+
+    expect(summary.sampleCount).toBe(3);
+    // Only the two non-null egress values feed the percentiles.
+    expect(summary.egressKbps).toEqual({ count: 2, p50: 200, p95: 290 });
+    expect(summary.decodedFps).toEqual({ count: 2, p50: 12, p95: 13.8 });
+  });
+
+  test("returns null summaries when no sample carried the metric", () => {
+    const summary = aggregateCaptureStageRecords([
+      record({ egressKbps: null, decodedFps: null }),
+      record({ egressKbps: null, decodedFps: null }),
+    ]);
+
+    expect(summary.sampleCount).toBe(2);
+    expect(summary.egressKbps).toBeNull();
+    expect(summary.decodedFps).toBeNull();
+  });
+
+  test("filters to a single platform when one is requested", () => {
+    const summary = aggregateCaptureStageRecords(
+      [
+        record({ platform: "ios", egressKbps: 100 }),
+        record({ platform: "android", egressKbps: 900 }),
+        record({ platform: "ios", egressKbps: 300 }),
+      ],
+      { platform: "ios" }
+    );
+
+    expect(summary.platform).toBe("ios");
+    expect(summary.sampleCount).toBe(2);
+    expect(summary.egressKbps).toEqual({ count: 2, p50: 200, p95: 290 });
+  });
+
+  test("aggregates per-stage elapsedMs across the records that reached each stage", () => {
+    const summary = aggregateCaptureStageRecords([
+      record({
+        stages: [
+          { stage: "startRequest", elapsedMs: 0, deltaMs: 0 },
+          { stage: "firstDecodedFrame", elapsedMs: 1_000, deltaMs: 1_000 },
+        ],
+      }),
+      record({
+        stages: [
+          { stage: "startRequest", elapsedMs: 0, deltaMs: 0 },
+          { stage: "firstDecodedFrame", elapsedMs: 3_000, deltaMs: 3_000 },
+        ],
+      }),
+    ]);
+
+    expect(summary.stages.startRequest).toEqual({ count: 2, p50: 0, p95: 0 });
+    // p50 index = 0.5*(2-1)=0.5 -> 1000 + (3000-1000)*0.5 = 2000
+    expect(summary.stages.firstDecodedFrame).toEqual({ count: 2, p50: 2_000, p95: 2_900 });
+    // A stage no record reached is simply absent.
+    expect(summary.stages.whepConnected).toBeUndefined();
+  });
+
+  test("returns an empty summary for no records", () => {
+    const summary = aggregateCaptureStageRecords([]);
+    expect(summary.sampleCount).toBe(0);
+    expect(summary.egressKbps).toBeNull();
+    expect(summary.decodedFps).toBeNull();
+    expect(summary.stages).toEqual({});
+    expect(summary.platform).toBeNull();
+  });
+
+  test("format renders the sample count, egress, decodedFps and stage percentiles", () => {
+    const summary = aggregateCaptureStageRecords([
+      record({
+        egressKbps: 100,
+        decodedFps: 10,
+        stages: [{ stage: "firstDecodedFrame", elapsedMs: 1_000, deltaMs: 1_000 }],
+      }),
+      record({
+        egressKbps: 500,
+        decodedFps: 14,
+        stages: [{ stage: "firstDecodedFrame", elapsedMs: 3_000, deltaMs: 3_000 }],
+      }),
+    ]);
+
+    const text = formatCaptureBaselineSummary(summary);
+    expect(text).toContain("samples=2");
+    expect(text).toContain("egressKbps");
+    expect(text).toContain("decodedFps");
+    expect(text).toContain("firstDecodedFrame");
+    // A metric with no samples is reported as such rather than as a bare 0.
+    const emptyText = formatCaptureBaselineSummary(aggregateCaptureStageRecords([]));
+    expect(emptyText).toContain("samples=0");
+  });
+});

--- a/test/helpers/captureStageTimeline.ts
+++ b/test/helpers/captureStageTimeline.ts
@@ -1,4 +1,5 @@
 import { performance } from "node:perf_hooks";
+import { computePercentile } from "../../src/utils/percentile";
 
 /**
  * Stage-level latency for the device capture path (#4343).
@@ -343,6 +344,114 @@ export function formatCaptureStageRecord(record: CaptureStageRecord): string {
   }
   if (record.missingStages.length > 0) {
     lines.push(`missing=${record.missingStages.join(",")}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * p50/p95 of one metric over the samples that carried it. `count` is the number
+ * of non-null samples that fed the percentiles — never the number of records —
+ * so a metric that only a few runs sampled reports an honest, small `count`
+ * rather than a percentile diluted by zeros (#4387).
+ */
+export interface PercentileSummary {
+  count: number;
+  p50: number;
+  p95: number;
+}
+
+/**
+ * The p50/p95 baseline over a set of {@link CaptureStageRecord} samples (#4387).
+ * This does not *set* a baseline number or tighten any budget — the issue is
+ * explicit that those need several accumulated CI runs and stay tracked — it
+ * only turns "then p50/p95 reported" into a repeatable computation over the
+ * records the device lane already emits.
+ */
+export interface CaptureBaselineSummary {
+  /** Platform filter applied, or null when every record was included. */
+  platform: string | null;
+  /** Records considered after the platform filter. */
+  sampleCount: number;
+  /** Egress-bitrate percentiles (kbps), or null when no sample carried egress. */
+  egressKbps: PercentileSummary | null;
+  /** Decoded-fps percentiles, or null when no sample carried decoded fps. */
+  decodedFps: PercentileSummary | null;
+  /** Per-stage elapsed-from-origin percentiles (ms); a stage no record reached is omitted. */
+  stages: Partial<Record<CaptureStage, PercentileSummary>>;
+}
+
+/**
+ * p50/p95 over the finite values only. `null`/non-finite samples are dropped
+ * (never coerced to zero), and an all-empty set yields null so a caller can tell
+ * "no samples" from "a real zero".
+ */
+function summarizePercentiles(values: Array<number | null>): PercentileSummary | null {
+  const finite = values.filter((value): value is number => value !== null && Number.isFinite(value));
+  if (finite.length === 0) {
+    return null;
+  }
+  const sorted = [...finite].sort((a, b) => a - b);
+  return {
+    count: sorted.length,
+    p50: computePercentile(sorted, 50),
+    p95: computePercentile(sorted, 95),
+  };
+}
+
+/**
+ * Aggregate a set of capture-stage records into a p50/p95 baseline (#4387).
+ * Aggregates `elapsedMs` per stage — never `deltaMs`, which is anti-correlated
+ * across an out-of-order pair and meaningless in aggregate (see
+ * {@link CaptureStageMeasurement.deltaMs}).
+ */
+export function aggregateCaptureStageRecords(
+  records: CaptureStageRecord[],
+  options: { platform?: string } = {}
+): CaptureBaselineSummary {
+  const platform = options.platform ?? null;
+  const considered = platform === null ? records : records.filter(record => record.platform === platform);
+
+  const stages: Partial<Record<CaptureStage, PercentileSummary>> = {};
+  for (const stage of CAPTURE_STAGES) {
+    const elapsed = considered
+      .map(record => record.stages.find(measurement => measurement.stage === stage)?.elapsedMs ?? null)
+      .filter((value): value is number => value !== null);
+    const summary = summarizePercentiles(elapsed);
+    if (summary !== null) {
+      stages[stage] = summary;
+    }
+  }
+
+  return {
+    platform,
+    sampleCount: considered.length,
+    egressKbps: summarizePercentiles(considered.map(record => record.egressKbps)),
+    decodedFps: summarizePercentiles(considered.map(record => record.decodedFps)),
+    stages,
+  };
+}
+
+function formatPercentile(label: string, summary: PercentileSummary | null): string {
+  if (summary === null) {
+    return `  ${label}: no samples`;
+  }
+  const p50 = Math.round(summary.p50 * 10) / 10;
+  const p95 = Math.round(summary.p95 * 10) / 10;
+  return `  ${label}: p50=${p50} p95=${p95} (n=${summary.count})`;
+}
+
+/** Human-readable rendering of a {@link CaptureBaselineSummary} for a job log. */
+export function formatCaptureBaselineSummary(summary: CaptureBaselineSummary): string {
+  const lines = [
+    `platform=${summary.platform ?? "all"} samples=${summary.sampleCount}`,
+    formatPercentile("egressKbps", summary.egressKbps),
+    formatPercentile("decodedFps", summary.decodedFps),
+  ];
+  for (const stage of CAPTURE_STAGES) {
+    const stageSummary = summary.stages[stage];
+    if (stageSummary !== undefined) {
+      lines.push(formatPercentile(`${stage} (ms)`, stageSummary));
+    }
   }
   return lines.join("\n");
 }

--- a/test/scripts/aggregateEgressBaseline.test.ts
+++ b/test/scripts/aggregateEgressBaseline.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  readCaptureStageRecords,
+  summarizeBaselineFromDir,
+} from "../../scripts/webrtc/aggregate-egress-baseline";
+import type { CaptureStageRecord } from "../../test/helpers/captureStageTimeline";
+
+function sampleRecord(overrides: Partial<CaptureStageRecord> = {}): CaptureStageRecord {
+  return {
+    platform: "ios",
+    streamId: "device-capture-ios",
+    outcome: "passed",
+    sourceSize: null,
+    configuredFps: 15,
+    decodedSize: null,
+    egressKbps: 405,
+    decodedFps: 11.7,
+    run: {
+      runId: "1",
+      runAttempt: "1",
+      commitSha: "abc",
+      runnerOs: "macOS",
+      runnerImage: "macos26",
+      startedAtIso: "2026-07-24T00:00:00.000Z",
+    },
+    samplingIntervalsMs: {},
+    schemaVersion: 3,
+    stages: [],
+    phases: [],
+    missingStages: [],
+    captureToBrowserMs: null,
+    ...overrides,
+  };
+}
+
+describe("#4387 aggregate-egress-baseline script", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "egress-baseline-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("reads every stage-latency record under the directory, recursing into per-run subdirs", async () => {
+    writeFileSync(path.join(dir, "stage-latency.json"), JSON.stringify(sampleRecord({ egressKbps: 100 })));
+    const nested = path.join(dir, "run-2");
+    mkdirSync(nested);
+    writeFileSync(path.join(nested, "stage-latency.json"), JSON.stringify(sampleRecord({ egressKbps: 300 })));
+
+    const records = await readCaptureStageRecords(dir);
+    expect(records).toHaveLength(2);
+    expect(records.map(r => r.egressKbps).sort((a, b) => (a ?? 0) - (b ?? 0))).toEqual([100, 300]);
+  });
+
+  test("skips non-JSON files and JSON that is not a stage-latency record", async () => {
+    writeFileSync(path.join(dir, "stage-latency.json"), JSON.stringify(sampleRecord({ egressKbps: 200 })));
+    writeFileSync(path.join(dir, "chrome.log"), "not json at all");
+    writeFileSync(path.join(dir, "unrelated.json"), JSON.stringify({ hello: "world" }));
+
+    const records = await readCaptureStageRecords(dir);
+    expect(records).toHaveLength(1);
+    expect(records[0].egressKbps).toBe(200);
+  });
+
+  test("summarizes the directory into p50/p95, honoring the platform filter", async () => {
+    writeFileSync(path.join(dir, "a.json"), JSON.stringify(sampleRecord({ platform: "ios", egressKbps: 100 })));
+    writeFileSync(path.join(dir, "b.json"), JSON.stringify(sampleRecord({ platform: "android", egressKbps: 900 })));
+    writeFileSync(path.join(dir, "c.json"), JSON.stringify(sampleRecord({ platform: "ios", egressKbps: 300 })));
+
+    const summary = await summarizeBaselineFromDir(dir, { platform: "ios" });
+    expect(summary.platform).toBe("ios");
+    expect(summary.sampleCount).toBe(2);
+    expect(summary.egressKbps).toEqual({ count: 2, p50: 200, p95: 290 });
+  });
+});

--- a/test/utils/percentile.test.ts
+++ b/test/utils/percentile.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { computePercentile } from "../../src/utils/percentile";
+
+describe("computePercentile", () => {
+  test("returns 0 for an empty array", () => {
+    expect(computePercentile([], 50)).toBe(0);
+    expect(computePercentile([], 95)).toBe(0);
+  });
+
+  test("returns the single value regardless of percentile", () => {
+    expect(computePercentile([42], 50)).toBe(42);
+    expect(computePercentile([42], 95)).toBe(42);
+  });
+
+  test("picks the exact element when the rank lands on an index", () => {
+    // index = 0.5 * (5 - 1) = 2 -> sorted[2]
+    expect(computePercentile([100, 200, 300, 400, 500], 50)).toBe(300);
+  });
+
+  test("linearly interpolates between the bracketing elements", () => {
+    // index = 0.95 * (5 - 1) = 3.8 -> 400 + (500 - 400) * 0.8 = 480
+    expect(computePercentile([100, 200, 300, 400, 500], 95)).toBe(480);
+  });
+
+  test("assumes an ascending sort (does not re-sort its input)", () => {
+    // Contract matches the previous private copies in networkGraph/networkResources:
+    // callers sort first. A descending input is read positionally, not corrected.
+    expect(computePercentile([500, 400, 300, 200, 100], 50)).toBe(300);
+  });
+});


### PR DESCRIPTION
## Summary

Item 2 of [#4387](https://github.com/kaeawc/auto-mobile/issues/4387) needs "several CI runs accumulated, then p50/p95 reported" before the `0.1` bpp budget or any timeout contract is tightened — a measurement-collection task that cannot be a single code PR. Each device-lane run already writes one `CaptureStageRecord` (`schemaVersion` 3, with `egressKbps`/`decodedFps`), but the codebase had per-record formatting only and **no cross-run aggregation**, so "report p50/p95" was a manual task with no tooling.

This PR ships the **reporting half** of that measurement task — a pure, unit-tested percentile aggregator plus a thin script — so accumulating a baseline becomes a repeatable command over artifacts the lane already emits. It deliberately does **not** set/commit a baseline number and does **not** change any encoder default.

## Linked Issue

Part of [#4387](https://github.com/kaeawc/auto-mobile/issues/4387). Does **not** close it — the remaining items are measurement/verification tasks (see Follow-ups).

## Changes

- `test/helpers/captureStageTimeline.ts` — `aggregateCaptureStageRecords()` + `formatCaptureBaselineSummary()`: p50/p95 of `egressKbps`, `decodedFps`, and per-stage `elapsedMs` across records, with an optional platform filter. Null samples are excluded (never coerced to zero); an all-empty metric reports `null` so "no samples" is distinguishable from a real zero. Aggregates `elapsedMs`, never the anti-correlated `deltaMs`.
- `scripts/webrtc/aggregate-egress-baseline.ts` — ingest a directory of downloaded `stage-latency.json` artifacts (recursing per-run subdirs, skipping non-record JSON and logs) and print the baseline.
- `src/utils/percentile.ts` — consolidate the verbatim-duplicated private `computePercentile` from `networkGraph.ts` and `networkResources.ts` into one exported primitive and reuse it in all three call sites, per CLAUDE.md's "one canonical primitive per concern". Behavior is byte-for-byte identical (linear interpolation, empty → 0).

## Validation

- [x] `scripts/all_fast_validate_checks.sh` equivalent: `bun test` — 9226 pass, 0 fail (full suite); new suites run in ~130ms
- [x] `bun run typecheck` — no new errors (baseline gate)
- [x] `bun run lint` (+ all boundary checks) and `bun run build`
- [x] New code uses pure functions / injected inputs; unit tests run in <100ms
- [x] New generic code reuses an existing project helper (`computePercentile`) rather than adding a new one

## Acceptance criteria (this PR's scope)

- [x] Given ≥1 `CaptureStageRecord`, report p50/p95 of `egressKbps`, `decodedFps`, and per-stage `elapsedMs`, filterable by platform.
- [x] Null metric samples excluded, not counted as zero; empty metric reports `null`.
- [x] Percentiles use the repo's existing method (no third copy of `computePercentile`).
- [x] A script ingests a directory of artifact JSONs and prints the baseline.

## Follow-ups

Tracked in [#4387](https://github.com/kaeawc/auto-mobile/issues/4387), intentionally out of scope here (neither is a code change):
- [ ] Accumulate several iOS Simulator lane runs and **set** the p50/p95 baseline number from this tool's output.
- [ ] Verify `-maxrate`/`-bufsize` on `h264_videotoolbox` measurably clamp peak egress on our shipped ffmpeg builds before adding any peak ceiling.
