### PR TITLE
fix(junit-runner): recover from interrupted steps by re-running them under a hard tool-call cap

### DIFF
--- a/android/junit-runner/build.gradle.kts
+++ b/android/junit-runner/build.gradle.kts
@@ -111,6 +111,12 @@ tasks.configureEach {
 }
 
 tasks.withType<Test> {
+  // Run on the JUnit Platform so JUnit 5 (jupiter) suites like AutoMobileAgentTest are
+  // discovered. Without this the default runner only sees JUnit 4 tests and jupiter
+  // classes are silently skipped. The junit-vintage-engine dependency keeps the existing
+  // JUnit 4 suites (e.g. RecoveryLoopTest) running on the same platform.
+  useJUnitPlatform()
+
   // Enable parallel test execution across multiple devices
   maxParallelForks = Runtime.getRuntime().availableProcessors().coerceAtLeast(2)
   dependsOn(":control-proxy:assembleDebug")

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgent.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgent.kt
@@ -94,9 +94,12 @@ open class AutoMobileAgent(
   /**
    * Attempts AI-assisted recovery for a failed test step using AutoMobile MCP tools.
    *
-   * The agent receives structured context about the failure and uses MCP tools to get the device
-   * back on track. After the agent finishes, we call observe ourselves (outside the tool budget) to
-   * capture the device state for verification.
+   * The agent receives structured context about the failure and uses MCP tools to clear whatever
+   * interrupted the failed step (a modal, notification, permission dialog, etc.). After the agent
+   * finishes, we call observe ourselves (outside the tool budget) as a device-liveness gate: a
+   * non-null result means the device is still responsive and worth resuming on. The authoritative
+   * check that recovery actually worked is the caller re-running the failed step (see
+   * [AutoMobilePlanExecutor]) — if the obstruction is gone that step now passes.
    */
   open fun attemptAiRecovery(context: FailedStepContext): RecoveryOutcome {
     val startTime = timeProvider.currentTimeMillis()
@@ -123,7 +126,8 @@ open class AutoMobileAgent(
 
       val recoveryPrompt =
         """
-        A test plan step failed. Here is the context:
+        A test plan step was interrupted and failed. Your job is to CLEAR whatever is
+        blocking the app — you do NOT need to perform the failed step yourself.
 
         FAILED STEP: Step ${context.failedStepIndex + 1} using tool "${context.failedTool}"
         ERROR: ${context.error}
@@ -134,19 +138,24 @@ open class AutoMobileAgent(
         PLAN YAML:
         ${context.planContent}
 
-        You have a maximum of $maxToolCalls tool calls to recover the device state so the
-        test can resume from step ${context.failedStepIndex + 2}.
+        After you finish, the test runner will AUTOMATICALLY RE-RUN the failed step
+        (step ${context.failedStepIndex + 1}) and then continue with the rest of the plan.
+        So do NOT tap the failed step's own target or otherwise perform its action — just
+        remove whatever is blocking it and leave the app on the screen that step expects.
+
+        You have a maximum of $maxToolCalls tool calls.
 
         Instructions:
         1. Call observe to see the current device state.
-        2. Take corrective actions (tap, type, swipe, wait, etc.) to address the failure.
-        3. Focus on getting the device ready for the NEXT step in the plan.
+        2. Identify anything blocking the failed step and dismiss it, for example:
+           - a system notification or the expanded notification shade
+           - a permission dialog (accept or deny as the plan implies)
+           - a modal, popup, bottom sheet, or interstitial
+           - an ANR ("isn't responding") or crash ("has stopped") dialog
+           Dismiss it with its close / OK / allow / deny affordance, or press Back.
+        3. Return the app to the screen the failed step expects, then stop.
 
-        Common issues to watch for:
-        - Elements not found (try alternative selectors or wait longer)
-        - Pop-ups or dialogs blocking interaction
-        - Wrong screen (navigate to the correct screen)
-        - Timing issues (add appropriate waits)
+        Do NOT perform the failed step's action — the runner retries it for you.
       """
           .trimIndent()
 
@@ -160,7 +169,9 @@ open class AutoMobileAgent(
 
           println("AI recovery agent finished, verifying device state...")
 
-          // Call observe ourselves to capture post-recovery state
+          // Device-liveness gate: confirm the device is still responsive before the caller
+          // spends a daemon round-trip re-running the failed step. This is NOT proof the
+          // interruption is gone — the failed-step re-run in the executor is that check.
           val observeResult =
             try {
               mcpClient.callTool("observe", mapOf("withViewHierarchy" to true))
@@ -970,14 +981,18 @@ open class AutoMobileAgent(
         """
         You are an expert mobile test automation recovery agent using the AutoMobile framework.
 
-        Your goal is to analyze test failures and take corrective actions using available tools.
-        You have access to AutoMobile tools for observing and interacting with mobile devices.
-        The available tools are discovered dynamically from the MCP server.
+        Your goal is to clear whatever interruption blocked a failing test step — typically a
+        modal, popup, system notification, permission dialog, or crash/ANR dialog — and return
+        the app to the screen that step expects. You have access to AutoMobile tools for
+        observing and interacting with mobile devices, discovered dynamically from the MCP server.
+
+        The test runner re-runs the failed step itself after you finish, so do NOT perform that
+        step's action — just remove the obstruction.
 
         IMPORTANT CONSTRAINTS:
         - You have a maximum of $maxToolCalls tool calls per recovery attempt
         - Always start by observing the current device state
-        - Focus on practical, immediate fixes rather than complex workarounds
+        - Focus on dismissing blockers, not on completing the test's own actions
         - If you can't fix the issue within the tool call limit, explain what you discovered
 
         Core tools typically available:
@@ -997,11 +1012,17 @@ open class AutoMobileAgent(
       """
           .trimIndent()
 
+      // Hard-enforce the tool-call budget: cap Koog's agent loop via maxIterations so a
+      // looping or runaway model cannot exceed the budget the prompt advertises. Without
+      // this the "$maxToolCalls tool calls" line is advisory only. See [recoveryIterationCap]
+      // for why the ceiling is maxToolCalls + 1. When the cap is hit Koog throws, which the
+      // caller's try/catch turns into a failed RecoveryOutcome (we do not resume).
       return AIAgent(
         promptExecutor = executor,
         llmModel = model,
         toolRegistry = toolRegistry,
         systemPrompt = systemPrompt,
+        maxIterations = recoveryIterationCap(maxToolCalls),
       )
     }
 
@@ -1030,3 +1051,15 @@ open class AutoMobileAgent(
     override fun currentTimeMillis(): Long = System.currentTimeMillis()
   }
 }
+
+/**
+ * Hard iteration ceiling for a recovery agent run, derived from the configured tool-call budget.
+ *
+ * Koog's `AIAgentConfig.maxAgentIterations` counts every agent step, so making N tool calls takes
+ * N + 1 iterations — the extra one is the concluding assistant turn that produces no tool call and
+ * ends the loop. We add that +1 of headroom so an agent that spends its full budget still finishes
+ * cleanly, while an agent that attempts an (N + 1)th tool call trips the cap (Koog throws, and the
+ * caller treats that as a failed recovery). [coerceAtLeast] keeps a misconfigured non-positive
+ * budget from yielding a zero or negative cap, which would abort before the agent can even observe.
+ */
+internal fun recoveryIterationCap(maxToolCalls: Int): Int = maxToolCalls.coerceAtLeast(1) + 1

--- a/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanExecutor.kt
+++ b/android/junit-runner/src/main/kotlin/dev/jasonpearson/automobile/junit/AutoMobilePlanExecutor.kt
@@ -291,8 +291,10 @@ internal object AutoMobilePlanExecutor {
 
   /**
    * Execute a plan starting at [startStep]. If the plan fails and recovery has not yet been
-   * attempted, the Koog agent is invoked to work around the failure. On successful recovery the
-   * plan resumes from the step after the failed one. Recovery is allowed at most once per test.
+   * attempted, the Koog agent is invoked to clear whatever interrupted the failed step. On
+   * successful recovery the plan resumes by re-running the failed step (so its action is retried
+   * now that the obstruction is gone) and then continuing. Recovery is allowed at most once per
+   * test.
    */
   /**
    * @param deviceIdOverride When non-null, pins execution to this device. Used after recovery to
@@ -467,10 +469,18 @@ internal object AutoMobilePlanExecutor {
       )
     }
 
-    // Recovery succeeded — resume the plan from the step after the failed one,
-    // pinned to the same device the agent just recovered
-    val resumeStep = failedStepContext.failedStepIndex + 1
-    println("AI recovery succeeded, resuming plan from step ${resumeStep + 1}")
+    // Recovery only cleared whatever was blocking the failed step (a modal,
+    // notification, permission dialog, etc.). The step's own action has NOT run yet, so
+    // resume by RE-RUNNING the failed step itself — the daemon retries its action
+    // deterministically and then continues with the rest of the plan. Resuming at
+    // failedStepIndex + 1 would skip the step and leave the app on the wrong screen.
+    //
+    // This re-run is also the authoritative check that recovery worked: if the
+    // obstruction is truly gone the step now passes; otherwise it fails again and the
+    // once-per-test guard (recoveryAlreadyAttempted) stops us from looping. coerceAtLeast
+    // guards the -1 "unknown step" case by re-running the whole plan from the start.
+    val resumeStep = failedStepContext.failedStepIndex.coerceAtLeast(0)
+    println("AI recovery succeeded, re-running failed step ${resumeStep + 1} and resuming")
 
     val resumeResult =
       executePlanFromStep(

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgentTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/AutoMobileAgentTest.kt
@@ -223,6 +223,69 @@ class AutoMobileAgentTest {
   }
 
   @Test
+  fun `attemptAiRecovery prompt tells agent to clear the interruption, not perform the failed step`() {
+    // Arrange
+    val context =
+      FailedStepContext(
+        failedStepIndex = 2,
+        failedTool = "tapOn",
+        error = "Element not found",
+        succeededSteps = emptyList(),
+        planContent = "name: test\nsteps: []",
+        deviceId = "emulator-5554",
+      )
+    val modelConfig = AutoMobileAgent.ModelConfig(AutoMobileAgent.ModelProvider.OPENAI, "test-key")
+    val promptSlot = slot<String>()
+
+    every { mockTimeProvider.currentTimeMillis() } returns 1000L andThen 2000L
+    every { mockConfigProvider.getMcpServerUrl() } returns "http://localhost:3000"
+    every { mockMcpClient.isConnected() } returns false
+    every { mockMcpClient.connect("http://localhost:3000") } just runs
+    every { mockMcpClient.disconnect() } just runs
+    every { mockConfigProvider.getModelConfig() } returns modelConfig
+    every { mockAiAgentFactory.createAIAgentWithMCPTools(modelConfig, mockMcpClient, 5) } returns
+      mockAIAgent
+    every { mockMcpClient.callTool("observe", any()) } returns """{"elements": []}"""
+    coEvery { mockAIAgent.run(capture(promptSlot)) } returns "Dismissed the dialog"
+
+    // Act
+    autoMobileAgent.attemptAiRecovery(context)
+
+    // Assert - the prompt must steer the agent toward clearing the blocker and away from
+    // performing the failed step itself (the runner re-runs that step deterministically).
+    val prompt = promptSlot.captured
+    assertTrue(
+      prompt.contains("RE-RUN", ignoreCase = true),
+      "Prompt should say the runner re-runs the failed step",
+    )
+    assertTrue(
+      prompt.contains("Do NOT perform the failed step", ignoreCase = true),
+      "Prompt should tell the agent not to perform the failed step's action",
+    )
+    assertTrue(
+      prompt.contains("dismiss", ignoreCase = true),
+      "Prompt should mention dismissing blockers like dialogs/notifications",
+    )
+  }
+
+  @Test
+  fun `recoveryIterationCap allows the full tool-call budget plus one concluding turn`() {
+    // N tool calls need N+1 Koog iterations (the last iteration is the finishing
+    // assistant turn), so the hard cap is maxToolCalls + 1.
+    assertEquals(6, recoveryIterationCap(5))
+    assertEquals(11, recoveryIterationCap(10))
+  }
+
+  @Test
+  fun `recoveryIterationCap floors a non-positive budget so the agent can still observe`() {
+    // A misconfigured 0 / negative budget must not produce a zero or negative cap that
+    // aborts before the agent observes — it floors to 1 tool call (+1 => 2 iterations).
+    assertEquals(2, recoveryIterationCap(0))
+    assertEquals(2, recoveryIterationCap(-3))
+    assertEquals(2, recoveryIterationCap(1))
+  }
+
+  @Test
   fun `attemptAiRecovery returns failure when agent throws exception`() {
     // Arrange
     val context =

--- a/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/RecoveryLoopTest.kt
+++ b/android/junit-runner/src/test/kotlin/dev/jasonpearson/automobile/junit/RecoveryLoopTest.kt
@@ -110,8 +110,8 @@ class RecoveryLoopTest {
   }
 
   @Test
-  fun `resume-from-step passes correct startStep to daemon`() {
-    // First call fails at step 2
+  fun `resume re-runs the failed step so its action is retried, not skipped`() {
+    // First call fails at step 2 (index)
     fakeDaemonClient.responses.add(buildFailureResponse(failedStepIndex = 2, failedTool = "tapOn"))
     fakeDaemonClient.responses.add(buildSuccessResponse())
     fakeAgent.recoveryOutcome =
@@ -119,10 +119,12 @@ class RecoveryLoopTest {
 
     executePlan(aiAssistance = true)
 
-    // The second daemon call should have startStep = 3 (failedStepIndex + 1)
+    // The resume call must re-run the FAILED step itself (startStep == failedStepIndex),
+    // not skip ahead to failedStepIndex + 1 — the agent only cleared the interruption, so
+    // the step's own action still needs to run.
     assertEquals("Should have made 2 daemon calls", 2, fakeDaemonClient.callArgs.size)
     val resumeArgs = fakeDaemonClient.callArgs[1]
-    assertEquals(3, resumeArgs["startStep"]?.let { (it as JsonPrimitive).content.toInt() })
+    assertEquals(2, resumeArgs["startStep"]?.let { (it as JsonPrimitive).content.toInt() })
   }
 
   @Test


### PR DESCRIPTION
## What & why

The JUnit runner's Koog-powered failure recovery was structurally unable to make a test succeed after a dismissable interruption (notification, modal, permission dialog, ANR/crash dialog), and its tool-call budget was advisory only. This makes recovery actually work and bounds the agent loop programmatically.

### The bugs
1. **The failed step was skipped.** On successful recovery, execution resumed at `failedStepIndex + 1`. So even if the agent perfectly dismissed a blocking modal, the failed step's actual action (e.g. `tapOn "Continue"`) never ran — the resumed plan started on the wrong screen and failed at the next step.
2. **"Recovery succeeded" was meaningless.** Success was `observe != null` — any responsive device counted, with no check that the obstruction was gone.
3. **The tool-call budget wasn't enforced.** `maxToolCalls` was only injected into the prompt text; nothing stopped a looping model from running unbounded.

### The fixes
- **Resume by re-running the failed step** (`startStep = failedStepIndex`), not the next step. The daemon deterministically re-executes the now-unblocked step and continues. That re-run *is* the authoritative verification: if the blocker is gone the step passes; if not it fails again and the existing once-per-test guard prevents a loop. No daemon change needed — it only supports `startStep`.
- **Rewrote the recovery + system prompts** so the agent *only* clears the interruption and returns to the expected screen, and explicitly does **not** perform the failed step's action (keeps the re-run free of double-execution). The post-agent `observe` is demoted to an honest device-liveness gate.
- **Hard-enforce the budget:** the recovery `AIAgent` is built with `maxIterations = recoveryIterationCap(maxToolCalls)` (= `maxToolCalls + 1`, floored). `+1` because N tool calls take N+1 Koog iterations (the last is the concluding turn); the floor stops a misconfigured non-positive budget from producing a zero/negative cap. When the cap is hit Koog throws `AIAgentMaxNumberOfIterationsReachedException` (extends `java.lang.Exception`), which the existing `catch` turns into a failed `RecoveryOutcome` (we don't resume).

### Drive-by fix (needed for the tests to run)
- **Enabled `useJUnitPlatform()` in `junit-runner`.** The module had no platform configured, so its entire JUnit5 (jupiter) test set — `AutoMobileAgentTest` and `DefaultConfigProviderTest`, ~16 tests — was **silently never executed**, despite `junit-jupiter-engine`/`junit-vintage-engine` already being dependencies. Vintage keeps the JUnit4 suites (e.g. `RecoveryLoopTest`) running.

## Reviewer notes
- **Semantic choice:** I resume at the *failed* step and re-run it, rather than the literal "next step." Skipping to the next step is precisely the bug — it drops the failed step's action. End-to-end the plan proceeds past the interruption; the mechanism is "clear the blocker, let the deterministic runner redo the real step."
- The Koog `maxIterations` param name and overload resolution were verified against the resolved `agents-core-jvm-1.1.1.jar` (not guessed).

## Tests (JDK 21, all green)
- `RecoveryLoopTest` 9/9 — updated the resume assertion to `startStep == failedStepIndex`.
- `AutoMobileAgentTest` 16/16 — added a prompt-contract test and two `recoveryIterationCap` tests; the other 13 now run for the first time.
- `DefaultConfigProviderTest` 2/2 — now runs.