### PR TITLE
feat(ios): AI-assisted failure recovery for XCTestRunner via Tachikoma

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,16 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 import PackageDescription
 
+// This root manifest is the published SPM entry point (consumers add the repo URL and pick the
+// `XCTestRunner` / `AutoMobileSDK` products). The `XCTestRunner` target compiles the same sources as
+// ios/XCTestRunner, which now depend on Tachikoma for AI-assisted recovery — so the dependency,
+// Swift 6.0 tools, and the iOS 17 / macOS 14 floor are declared here too. Existing sources keep
+// compiling in the Swift 5 language mode via `.swiftLanguageMode(.v5)`.
 let package = Package(
     name: "auto-mobile",
     platforms: [
-        .iOS(.v15),
-        .macOS(.v13),
+        .iOS(.v17),
+        .macOS(.v14),
     ],
     products: [
         .library(
@@ -19,16 +24,21 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.4.3"),
+        // Powers AI-assisted recovery in XCTestRunner. Pinned to an exact tag for reproducible builds.
+        .package(url: "https://github.com/steipete/Tachikoma.git", exact: "1.0.0"),
     ],
     targets: [
         .target(
             name: "AutoMobileSDK",
             path: "ios/auto-mobile-sdk/Sources/AutoMobileSDK",
-            resources: [.process("PrivacyInfo.xcprivacy")]
+            resources: [.process("PrivacyInfo.xcprivacy")],
+            swiftSettings: [.swiftLanguageMode(.v5)]
         ),
         .target(
             name: "XCTestRunner",
-            path: "ios/XCTestRunner/Sources/XCTestRunner"
+            dependencies: [.product(name: "Tachikoma", package: "Tachikoma")],
+            path: "ios/XCTestRunner/Sources/XCTestRunner",
+            swiftSettings: [.swiftLanguageMode(.v5)]
         ),
     ]
 )

--- a/docs/design-docs/plat/ios/xctestrunner/index.md
+++ b/docs/design-docs/plat/ios/xctestrunner/index.md
@@ -3,10 +3,12 @@
 <kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd> <kbd>📱 Simulator Only</kbd>
 
 > **Current state:** `XCTestRunner` is a fully implemented Swift package (`ios/XCTestRunner/`) with
-> `AutoMobileTestCase`, `AutoMobilePlanExecutor`, `AutoMobileTestObserver`, `TestTimingCache`, and
-> `AutoMobileSession`. Plans execute against a booted iOS Simulator via the AutoMobile daemon over a
-> Unix domain socket. Published as a local SPM package; remote GitHub release in progress. See the
-> [Status Glossary](../../../status-glossary.md) for chip definitions.
+> `AutoMobileTestCase`, `AutoMobilePlanExecutor`, `AutoMobileTestObserver`, `TestTimingCache`,
+> `AutoMobileSession`, and AI-assisted failure recovery (`TachikomaPlanRecoveryHandler`). Plans
+> execute against a booted iOS Simulator via the AutoMobile daemon over a Unix domain socket.
+> Published as a local SPM package; remote GitHub release in progress. Requires Swift 6.0+ and
+> iOS 17 / macOS 14 (raised from iOS 15 / macOS 13 when the Tachikoma dependency was added for
+> recovery). See the [Status Glossary](../../../status-glossary.md) for chip definitions.
 
 The AutoMobile XCTestRunner lets you write host-side XCTest classes that drive a real iOS Simulator
 over the AutoMobile daemon. Tests execute as ordinary unit tests inside a dedicated test target, so
@@ -47,14 +49,15 @@ runner binary is involved.
 | **Build required** | Pre-built `.xctestrun` reused | Full UI test host recompile |
 | **Device needed at** | Test execution only | Build time (linking) + execution |
 | **Parallel devices** | Daemon-managed pool | One device per test bundle |
-| **AI recovery** | Optional self-healing | Not available |
+| **AI recovery** | Optional self-healing ([details](#ai-assisted-recovery)) | Not available |
 | **Test authoring** | YAML plans or AI prompt | Swift/Objective-C code |
 | **App under test** | Any installed app | App compiled into UI test host |
 
 ## Requirements
 
-- macOS 13.0+ (Ventura or newer)
-- Xcode 15.0+ and Command Line Tools
+- macOS 14.0+ (Sonoma or newer)
+- Xcode 16.0+ and Command Line Tools (Swift 6.0+ toolchain)
+- iOS 17.0+ deployment target for the test host
 - A booted iOS Simulator
 - AutoMobile daemon running (`auto-mobile --daemon start`)
 - CtrlProxy iOS installed in the simulator (see [CtrlProxy iOS](../ctrl-proxy-ios.md))
@@ -165,6 +168,49 @@ xcodebuild test-without-building \
 
 See [Project Setup → Running tests locally](project-setup.md#running-tests-locally) for the full
 step-by-step walkthrough.
+
+## AI-assisted recovery
+
+When a plan step fails, the executor can hand the failure to an AI agent that drives AutoMobile tools
+to get the app back into the state the plan expects, then resumes from the **next** step — the iOS
+counterpart to the Android JUnit runner's recovery loop. It is built on
+[Tachikoma](https://github.com/steipete/Tachikoma) (a Swift AI SDK) rather than a bespoke client.
+
+```mermaid
+sequenceDiagram
+    participant E as AutoMobilePlanExecutor
+    participant H as TachikomaPlanRecoveryHandler
+    participant M as LLM (Anthropic/OpenAI/Google)
+    participant D as AutoMobile Daemon
+
+    E->>D: executePlan(startStep = 0)
+    D-->>E: failedStep(index = N, error, failureObservation)
+    E->>H: attemptRecovery(FailedStepContext)
+    loop up to maxToolCalls
+        H->>M: prompt + tool results
+        M-->>H: tool call (observe / tapOn / …)
+        H->>D: callTool(...)
+        D-->>H: result
+    end
+    H->>D: observe (verify device state)
+    H-->>E: RecoveryOutcome(success)
+    E->>D: executePlan(startStep = N + 1, pinned to device)
+```
+
+Key properties (parity with Android):
+
+- **Gated**: runs only when `aiAssistance` is on, the `ai-recovery` feature flag is enabled, a model
+  API key is present, and the run is not in CI.
+- **At most once per test**: a second failure after a resume fails the test with the original error.
+- **Backward compatible**: with no API key (CI, most unit tests) the handler is never constructed and
+  the executor behaves exactly as before — a failed step throws.
+- **Reuses the wire**: consumes the `failedStep.failureObservation` digest the daemon already sends,
+  and reads the gate from the `automobile:config/feature-flags/ai-recovery` resource.
+
+Configuration and model-selection env vars are documented in
+[Writing Tests → AI-assisted recovery](writing-tests.md#ai-assisted-recovery). The implementation
+lives in `AutoMobileRecovery.swift` (types + config) and `TachikomaPlanRecoveryHandler.swift` (the
+agent loop); the executor wiring is in `AutoMobilePlanExecutor.handleFailure`.
 
 ## Pages in this section
 

--- a/docs/design-docs/plat/ios/xctestrunner/project-setup.md
+++ b/docs/design-docs/plat/ios/xctestrunner/project-setup.md
@@ -9,6 +9,13 @@ running your first test locally.
 The XCTestRunner is a Swift Package Manager library. It can be consumed as a local path dependency
 (for reproducibility before a GitHub release is available) or as a remote dependency once published.
 
+> **Toolchain requirements (updated):** XCTestRunner now targets **Swift tools 6.0**, **iOS 17**, and
+> **macOS 14**, and depends on [Tachikoma](https://github.com/steipete/Tachikoma) (pinned to an exact
+> tag) for [AI-assisted recovery](index.md#ai-assisted-recovery). Consuming projects must raise their
+> deployment target to iOS 17+ and allow SPM to resolve the Tachikoma dependency (and its transitive
+> deps: swift-log). If you vendor the package source for offline CI, vendor Tachikoma too, or resolve
+> it from the network. The manifest snippets below reflect these versions.
+
 ### Local path dependency (current approach)
 
 The recommended approach is to commit the XCTestRunner source alongside your project so CI can
@@ -30,26 +37,36 @@ cp -r ~/path/to/auto-mobile/ios/XCTestRunner/Sources \
 
 ```swift
 // libs/spm/XCTestRunner/Package.swift
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 import PackageDescription
 
 let package = Package(
     name: "XCTestRunner",
     platforms: [
-        .iOS(.v15),
-        .macOS(.v13),
+        .iOS(.v17),
+        .macOS(.v14),
     ],
     products: [
         .library(name: "XCTestRunner", targets: ["XCTestRunner"]),
     ],
+    dependencies: [
+        // Powers AI-assisted recovery. Pin to an exact tag for reproducible CI.
+        .package(url: "https://github.com/steipete/Tachikoma.git", exact: "1.0.0"),
+    ],
     targets: [
-        .target(name: "XCTestRunner", path: "Sources/XCTestRunner"),
+        .target(
+            name: "XCTestRunner",
+            dependencies: [.product(name: "Tachikoma", package: "Tachikoma")],
+            path: "Sources/XCTestRunner",
+            // The runner sources compile in the Swift 5 language mode; only the manifest is Swift 6.
+            swiftSettings: [.swiftLanguageMode(.v5)]
+        ),
     ]
 )
 ```
 
-**Step 3 — Commit both the manifest and the source files.** CI runners resolve them from disk with
-no network dependency.
+**Step 3 — Commit the manifest and source files.** For fully offline CI, also vendor the Tachikoma
+package (and swift-log) or allow the runner to resolve them from the network on first build.
 
 ### Remote dependency (once published)
 

--- a/docs/design-docs/plat/ios/xctestrunner/writing-tests.md
+++ b/docs/design-docs/plat/ios/xctestrunner/writing-tests.md
@@ -58,6 +58,7 @@ test method is called.
 | `timeoutSeconds` | `TimeInterval` | `300` (env: `AUTOMOBILE_TEST_TIMEOUT_SECONDS`) | Maximum wall-clock seconds the executor waits for the daemon. |
 | `retryDelaySeconds` | `TimeInterval` | `1` (env: `AUTOMOBILE_TEST_RETRY_DELAY_SECONDS`) | Seconds to wait between retry attempts. |
 | `startStep` | `Int` | `0` | Resume execution from this step index (0-based). Useful when debugging a specific step. |
+| `aiAssistance` | `Bool` | `true` (env: `AUTOMOBILE_AI_ASSISTANCE`) | Per-test switch for AI-assisted failure recovery. When true (and the `ai-recovery` flag is on and a model API key is configured), a failed step triggers one recovery attempt before the test fails. See [AI-assisted recovery](#ai-assisted-recovery). |
 | `planParameters` | `[String: String]` | `[:]` | Key–value substitutions applied to `${KEY}` references in the plan at execution time. |
 | `planBundle` | `Bundle?` | `Bundle(for: type(of: self))` | Bundle used to resolve the `planPath`. Defaults to the test bundle. |
 
@@ -120,6 +121,38 @@ In the plan:
 - tool: launchApp
   appId: ${appId}
   label: Launch ${env} build
+```
+
+### AI-assisted recovery
+
+When a plan step fails, the executor can hand the failure to an AI agent (built on
+[Tachikoma](https://github.com/steipete/Tachikoma)) that drives AutoMobile tools — `observe`,
+`tapOn`, `inputText`, `swipeOn`, etc. — to get the app back into the expected state, then resumes the
+plan from the **next** step. This mirrors the Android JUnit runner's recovery loop.
+
+Recovery runs only when **all** of the following hold, and it is attempted **at most once per test**:
+
+1. `aiAssistance` is `true` (the default; set `AUTOMOBILE_AI_ASSISTANCE=false` to force fail-fast).
+2. The `ai-recovery` feature flag is enabled on the daemon (default on; carries a `maxToolCalls`
+   budget, default 5).
+3. A model API key is present in the environment. Recovery is a no-op without one — the test fails
+   exactly as it would have before.
+4. The run is **not** in CI (`CI` / `GITHUB_ACTIONS` unset). CI runs fail deterministically.
+
+Model selection is env-driven:
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `AUTOMOBILE_AI_PROVIDER` | `anthropic` | `anthropic`, `openai`, or `google`. |
+| `AUTOMOBILE_AI_MODEL` | provider default (Anthropic: `claude-sonnet-4-20250514`) | Override the model. |
+| `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` | — | Read by Tachikoma for the selected provider. |
+
+"Recovered" means a post-recovery `observe` succeeded; the resumed step is the real test of whether
+recovery worked. If recovery fails or the resumed run still fails, the test fails with the original
+error. To debug a single test without recovery, override `aiAssistance`:
+
+```swift
+override var aiAssistance: Bool { false }
 ```
 
 ## Lifecycle hooks

--- a/ios/XCTestRunner/Package.swift
+++ b/ios/XCTestRunner/Package.swift
@@ -1,11 +1,15 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 import PackageDescription
 
+// AI-assisted failure recovery (see AutoMobileRecovery.swift / TachikomaPlanRecoveryHandler.swift)
+// depends on Tachikoma, which requires Swift tools 6.0 and iOS 17 / macOS 14. The existing runner
+// code keeps compiling in the Swift 5 language mode via `.swiftLanguageMode(.v5)` on each target, so
+// consuming a Swift 6 package does not force a strict-concurrency migration of this module.
 let package = Package(
     name: "XCTestRunner",
     platforms: [
-        .iOS(.v15),
-        .macOS(.v13),
+        .iOS(.v17),
+        .macOS(.v14),
     ],
     products: [
         .library(
@@ -13,17 +17,28 @@ let package = Package(
             targets: ["XCTestRunner"]
         ),
     ],
-    dependencies: [],
+    dependencies: [
+        // Pinned to an exact released tag for hermetic, reproducible CI builds.
+        .package(url: "https://github.com/steipete/Tachikoma.git", exact: "1.0.0"),
+    ],
     targets: [
         .target(
             name: "XCTestRunner",
-            dependencies: []
+            dependencies: [
+                .product(name: "Tachikoma", package: "Tachikoma"),
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v5),
+            ]
         ),
         .testTarget(
             name: "XCTestRunnerTests",
             dependencies: ["XCTestRunner"],
             resources: [
                 .process("Resources"),
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v5),
             ]
         ),
     ]

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobilePlanExecutor.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobilePlanExecutor.swift
@@ -672,6 +672,10 @@ public final class AutoMobilePlanExecutor {
         public let cleanup: CleanupOptions?
         public let planBundle: Bundle?
         public let defaultPlatform: PlanPlatform
+        /// Per-run kill switch for AI-assisted recovery. Mirrors Android's
+        /// `AutoMobilePlanExecutionOptions.aiAssistance`. When false, a failed step throws exactly as
+        /// before this feature, regardless of the `ai-recovery` flag.
+        public let aiAssistance: Bool
 
         public init(
             transport: Transport,
@@ -683,7 +687,8 @@ public final class AutoMobilePlanExecutor {
             parameters: [String: String] = [:],
             cleanup: CleanupOptions? = nil,
             planBundle: Bundle? = nil,
-            defaultPlatform: PlanPlatform = .ios
+            defaultPlatform: PlanPlatform = .ios,
+            aiAssistance: Bool = true
         ) {
             self.transport = transport
             self.planPath = planPath
@@ -695,6 +700,7 @@ public final class AutoMobilePlanExecutor {
             self.cleanup = cleanup
             self.planBundle = planBundle
             self.defaultPlatform = defaultPlatform
+            self.aiAssistance = aiAssistance
         }
     }
 
@@ -725,6 +731,9 @@ public final class AutoMobilePlanExecutor {
         public let tool: String
         public let error: String
         public let device: String?
+        // The daemon attaches a failure-observation digest to a failed step (src/models/
+        // FailureObservation.ts). Decoded here so AI recovery can include it in the agent prompt.
+        public let failureObservation: FailureObservationSummary?
     }
 
     public struct ExecutePlanResult: Decodable {
@@ -735,6 +744,14 @@ public final class AutoMobilePlanExecutor {
         public let error: String?
         public let platform: String?
         public let deviceMapping: [String: String]?
+        // Set by the executor after an AI-recovery attempt (not decoded from the wire). Mirrors the
+        // Android result's aiRecoveryAttempted/aiRecoverySuccessful flags.
+        public var aiRecoveryAttempted: Bool = false
+        public var aiRecoverySuccessful: Bool = false
+
+        private enum CodingKeys: String, CodingKey {
+            case success, executedSteps, totalSteps, failedStep, error, platform, deviceMapping
+        }
     }
 
     public enum ExecutorError: Error, CustomStringConvertible {
@@ -775,6 +792,10 @@ public final class AutoMobilePlanExecutor {
     private let timer: AutoMobileTimer
     private let logger: AutoMobileLogger
     private let sessionIdProvider: () -> String
+    private let recoveryConfigProvider: RecoveryConfigProviding
+    // Nil = no AI recovery (no injected handler and no model API key in the environment); the executor
+    // then behaves exactly as it did before this feature — a failed step throws.
+    private let recoveryHandler: PlanRecoveryHandler?
 
     public init(
         configuration: Configuration,
@@ -782,7 +803,10 @@ public final class AutoMobilePlanExecutor {
         mcpClient: AutoMobileMCPClient? = nil,
         timer: AutoMobileTimer = SystemTimer(),
         logger: AutoMobileLogger = StdoutLogger(),
-        sessionIdProvider: @escaping () -> String = { AutoMobileSession.currentSessionUuid() }
+        sessionIdProvider: @escaping () -> String = { AutoMobileSession.currentSessionUuid() },
+        recoveryHandler: PlanRecoveryHandler? = nil,
+        recoveryConfigProvider: RecoveryConfigProviding? = nil,
+        recoveryModelConfig: RecoveryModelConfig? = RecoveryModelConfig.resolve()
     ) {
         self.configuration = configuration
         self.planLoader = planLoader
@@ -804,6 +828,29 @@ public final class AutoMobilePlanExecutor {
                 }
             }
         }
+
+        // Recovery config provider reads the `ai-recovery` feature flag over the same MCP client the
+        // plan runs on. Consulted only when a handler exists (see handleFailure), so no extra daemon
+        // traffic in the common no-recovery path.
+        let resolvedClient = self.mcpClient
+        self.recoveryConfigProvider = recoveryConfigProvider
+            ?? DaemonRecoveryConfigProvider(clientProvider: { resolvedClient }, logger: logger)
+
+        // Auto-wire the Tachikoma handler only when recovery can actually run — a model API key must be
+        // present. Without a key (CI, most unit tests) the handler stays nil and behavior is unchanged.
+        if let recoveryHandler = recoveryHandler {
+            self.recoveryHandler = recoveryHandler
+        } else if let recoveryModelConfig = recoveryModelConfig {
+            self.recoveryHandler = TachikomaPlanRecoveryHandler(
+                mcpClient: resolvedClient,
+                configProvider: self.recoveryConfigProvider,
+                modelConfig: recoveryModelConfig,
+                timer: timer,
+                logger: logger
+            )
+        } else {
+            self.recoveryHandler = nil
+        }
     }
 
     public func execute(testMetadata: TestMetadata? = nil) throws -> ExecutePlanResult {
@@ -823,7 +870,13 @@ public final class AutoMobilePlanExecutor {
                 if attempt > 0 {
                     logger.info("Retry attempt \(attempt + 1) of \(configuration.retryCount + 1)")
                 }
-                return try executeOnce(testMetadata: testMetadata)
+                return try executeAttempt(
+                    startStep: configuration.startStep,
+                    recoveryAlreadyAttempted: false,
+                    deviceIdOverride: nil,
+                    sessionUuidOverride: nil,
+                    testMetadata: testMetadata
+                )
             } catch {
                 lastError = error
                 let shouldRetry = shouldRetry(error: error, attempt: attempt)
@@ -859,8 +912,19 @@ public final class AutoMobilePlanExecutor {
         mcpClient.resetSession()
     }
 
-    private func executeOnce(testMetadata: TestMetadata?) throws -> ExecutePlanResult {
-        PerfTimer.log("executeOnce START")
+    /// Execute the plan once from `startStep`. On a step failure, if AI recovery is enabled and has not
+    /// yet been attempted for this test, hand the failure to the recovery handler and — on success —
+    /// resume from the step after the failed one (see `handleFailure`). `sessionUuidOverride` lets a
+    /// resume reuse the failed attempt's session so it continues on the same device; the transient
+    /// retry loop passes nil and gets a fresh session each attempt, as before.
+    private func executeAttempt(
+        startStep: Int,
+        recoveryAlreadyAttempted: Bool,
+        deviceIdOverride: String?,
+        sessionUuidOverride: String?,
+        testMetadata: TestMetadata?
+    ) throws -> ExecutePlanResult {
+        PerfTimer.log("executeAttempt START (startStep=\(startStep), recoveryAlreadyAttempted=\(recoveryAlreadyAttempted))")
         let planContent: String
         do {
             planContent = try PerfTimer.measure("loadPlan") {
@@ -887,7 +951,7 @@ public final class AutoMobilePlanExecutor {
         let platform = try resolvePlatform(from: planMetadata)
         PerfTimer.log("resolved platform=\(platform)")
 
-        let sessionUuid = sessionIdProvider()
+        let sessionUuid = sessionUuidOverride ?? sessionIdProvider()
         PerfTimer.log("sessionUuid=\(sessionUuid)")
 
         let arguments = PerfTimer.measure("buildExecutePlanArguments") {
@@ -895,6 +959,8 @@ public final class AutoMobilePlanExecutor {
                 planContent: substituted,
                 sessionUuid: sessionUuid,
                 platform: platform,
+                startStep: startStep,
+                deviceIdOverride: deviceIdOverride,
                 deviceLabels: planMetadata.deviceLabels,
                 testMetadata: testMetadata
             )
@@ -918,27 +984,127 @@ public final class AutoMobilePlanExecutor {
                 try decodeExecutePlanResult(from: response.text)
             }
             PerfTimer
-                .log("executeOnce END - success=\(result.success), steps=\(result.executedSteps)/\(result.totalSteps)")
+                .log("executeAttempt END - success=\(result.success), steps=\(result.executedSteps)/\(result.totalSteps)")
             if result.success {
                 return result
             }
-            throw ExecutorError.executionFailed(buildFailureMessage(from: result))
+            return try handleFailure(
+                result: result,
+                planContent: substituted,
+                platform: platform,
+                sessionUuid: sessionUuid,
+                deviceIdOverride: deviceIdOverride,
+                recoveryAlreadyAttempted: recoveryAlreadyAttempted,
+                testMetadata: testMetadata
+            )
         } catch let error as MCPClientError {
-            PerfTimer.log("executeOnce ERROR: MCPClientError - \(error.description)")
+            PerfTimer.log("executeAttempt ERROR: MCPClientError - \(error.description)")
             throw ExecutorError.mcpFailure(error.description)
         } catch let error as ExecutorError {
-            PerfTimer.log("executeOnce ERROR: ExecutorError - \(error)")
+            PerfTimer.log("executeAttempt ERROR: ExecutorError - \(error)")
             throw error
         } catch {
-            PerfTimer.log("executeOnce ERROR: \(error.localizedDescription)")
+            PerfTimer.log("executeAttempt ERROR: \(error.localizedDescription)")
             throw ExecutorError.executionFailed(error.localizedDescription)
         }
+    }
+
+    /// Handle a failed `executePlan` result: gate AI recovery, and on a successful recovery resume the
+    /// plan from the step after the failed one. Mirrors the Android runner's `handleFailure`. When
+    /// recovery is not eligible or does not succeed, throws the same `ExecutorError.executionFailed` the
+    /// executor threw before this feature existed.
+    private func handleFailure(
+        result: ExecutePlanResult,
+        planContent: String,
+        platform: PlanPlatform,
+        sessionUuid: String,
+        deviceIdOverride: String?,
+        recoveryAlreadyAttempted: Bool,
+        testMetadata: TestMetadata?
+    ) throws -> ExecutePlanResult {
+        let failureMessage = buildFailureMessage(from: result)
+
+        // Cheap local gates first; the feature-flag read (which may hit the daemon) is last and runs
+        // only when a handler is present, so the no-recovery path adds zero daemon traffic.
+        guard configuration.aiAssistance,
+              !recoveryAlreadyAttempted,
+              let handler = recoveryHandler,
+              let failedStep = result.failedStep,
+              failedStep.stepIndex >= 0,
+              !(testMetadata?.isCi ?? false),
+              recoveryConfigProvider.isRecoveryEnabled()
+        else {
+            throw ExecutorError.executionFailed(failureMessage)
+        }
+
+        logger.info("Attempting AI-assisted recovery for failed step \(failedStep.stepIndex + 1) (\(failedStep.tool))")
+        let context = buildFailedStepContext(
+            failedStep: failedStep,
+            planContent: planContent,
+            platform: platform,
+            sessionUuid: sessionUuid,
+            deviceIdOverride: deviceIdOverride
+        )
+
+        let outcome = handler.attemptRecovery(context)
+        if !outcome.success {
+            logger.warn("AI recovery failed")
+            throw ExecutorError.executionFailed("\(failureMessage)\n  AI recovery attempted but did not succeed.")
+        }
+
+        // Recovery succeeded — resume from the next step, pinned to the recovered device and the same
+        // session. `recoveryAlreadyAttempted: true` prevents a second recovery within this attempt.
+        let resumeStep = failedStep.stepIndex + 1
+        logger.info("AI recovery succeeded, resuming plan from step \(resumeStep + 1)")
+        var resumeResult = try executeAttempt(
+            startStep: resumeStep,
+            recoveryAlreadyAttempted: true,
+            deviceIdOverride: context.deviceId,
+            sessionUuidOverride: sessionUuid,
+            testMetadata: testMetadata
+        )
+        resumeResult.aiRecoveryAttempted = true
+        resumeResult.aiRecoverySuccessful = resumeResult.success
+        return resumeResult
+    }
+
+    private func buildFailedStepContext(
+        failedStep: FailedStep,
+        planContent: String,
+        platform: PlanPlatform,
+        sessionUuid: String,
+        deviceIdOverride: String?
+    ) -> FailedStepContext {
+        // Sequential execution stops at the first failure, so every step before failedStep.stepIndex
+        // completed. Reconstruct their tool names from the plan for the agent prompt (best effort).
+        let stepTools = PlanStepToolParser.toolNames(from: planContent)
+        var succeeded: [SucceededStepSummary] = []
+        var index = 0
+        while index < failedStep.stepIndex {
+            let tool = index < stepTools.count ? stepTools[index] : "step"
+            succeeded.append(SucceededStepSummary(stepIndex: index, tool: tool))
+            index += 1
+        }
+
+        return FailedStepContext(
+            failedStepIndex: failedStep.stepIndex,
+            failedTool: failedStep.tool,
+            error: failedStep.error,
+            succeededSteps: succeeded,
+            planContent: planContent,
+            platform: platform.rawValue,
+            sessionUuid: sessionUuid,
+            deviceId: failedStep.device ?? deviceIdOverride,
+            failureObservation: failedStep.failureObservation
+        )
     }
 
     private func buildExecutePlanArguments(
         planContent: String,
         sessionUuid: String,
         platform: PlanPlatform,
+        startStep: Int,
+        deviceIdOverride: String?,
         deviceLabels: [String],
         testMetadata: TestMetadata?
     )
@@ -948,9 +1114,14 @@ public final class AutoMobilePlanExecutor {
         var args: [String: Any] = [
             "planContent": "base64:\(base64Content)",
             "platform": platform.rawValue,
-            "startStep": configuration.startStep,
+            "startStep": startStep,
             "sessionUuid": sessionUuid,
         ]
+
+        // Pin a resumed plan to the device the recovery agent just fixed (single-device path).
+        if let deviceIdOverride = deviceIdOverride {
+            args["deviceId"] = deviceIdOverride
+        }
 
         if let cleanup = configuration.cleanup {
             args["cleanupAppId"] = cleanup.appId

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileRecovery.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileRecovery.swift
@@ -1,0 +1,343 @@
+import Foundation
+
+// AI-assisted failure recovery — the iOS counterpart to the Android JUnit runner's recovery loop
+// (android/junit-runner … RecoveryTypes.kt / RecoveryConfigProvider.kt). These are the
+// dependency-free core types: the executor is wired against the `PlanRecoveryHandler` protocol so it
+// stays unit-testable with a fake, while the Tachikoma-backed implementation lives in
+// TachikomaPlanRecoveryHandler.swift.
+
+// MARK: - Recovery context types
+
+/// A step that completed successfully before the failing step. Mirrors Android `SucceededStepSummary`.
+public struct SucceededStepSummary: Equatable {
+    public let stepIndex: Int
+    public let tool: String
+
+    public init(stepIndex: Int, tool: String) {
+        self.stepIndex = stepIndex
+        self.tool = tool
+    }
+}
+
+/// Everything a `PlanRecoveryHandler` needs to try to get the device back on track after a plan step
+/// failed. Mirrors Android `FailedStepContext`.
+public struct FailedStepContext {
+    public let failedStepIndex: Int
+    public let failedTool: String
+    public let error: String
+    public let succeededSteps: [SucceededStepSummary]
+    public let planContent: String
+    public let deviceId: String?
+    public let failureObservation: FailureObservationSummary?
+    /// Platform the plan targets ("ios"/"android"). Injected into every recovery tool call so the
+    /// daemon routes it exactly like the plan's own steps.
+    public let platform: String
+    /// Session the failed plan ran under. Injected into recovery tool calls so they target the same
+    /// device/session the plan was using.
+    public let sessionUuid: String?
+
+    public init(
+        failedStepIndex: Int,
+        failedTool: String,
+        error: String,
+        succeededSteps: [SucceededStepSummary],
+        planContent: String,
+        platform: String,
+        sessionUuid: String? = nil,
+        deviceId: String? = nil,
+        failureObservation: FailureObservationSummary? = nil
+    ) {
+        self.failedStepIndex = failedStepIndex
+        self.failedTool = failedTool
+        self.error = error
+        self.succeededSteps = succeededSteps
+        self.planContent = planContent
+        self.platform = platform
+        self.sessionUuid = sessionUuid
+        self.deviceId = deviceId
+        self.failureObservation = failureObservation
+    }
+}
+
+/// The result of an AI recovery attempt. Mirrors Android `RecoveryOutcome`: `success` reflects that a
+/// post-recovery observe succeeded (the device is in a queryable state), not a guarantee that the next
+/// step's precondition is met — the resumed step itself is the real verification.
+public struct RecoveryOutcome {
+    public let success: Bool
+    public let recoveryTimeMs: Int
+    public let observeResultAfterRecovery: String?
+
+    public init(success: Bool, recoveryTimeMs: Int = 0, observeResultAfterRecovery: String? = nil) {
+        self.success = success
+        self.recoveryTimeMs = recoveryTimeMs
+        self.observeResultAfterRecovery = observeResultAfterRecovery
+    }
+}
+
+/// Attempts AI-assisted recovery of device state after a failed plan step so the plan can resume from
+/// the next step. Injected into `AutoMobilePlanExecutor`; the production implementation is
+/// `TachikomaPlanRecoveryHandler`, and unit tests inject a fake.
+public protocol PlanRecoveryHandler {
+    func attemptRecovery(_ context: FailedStepContext) -> RecoveryOutcome
+}
+
+// MARK: - Failure observation (wire subset)
+
+/// The safely-typed subset of the `failedStep.failureObservation` payload the daemon attaches to a
+/// failed `executePlan` result (see src/models/FailureObservation.ts). Heavy hierarchy fields
+/// (`viewHierarchy` / `rawViewHierarchy` / `activeWindow`) are intentionally omitted — `Decodable`
+/// ignores the unknown keys — so the recovery prompt carries the compact digest, not a full dump.
+public struct FailureObservationSummary: Decodable, Equatable {
+    public let capturedAtMs: Double?
+    public let observeError: String?
+    public let awaitTimeout: Bool?
+    public let visibleTextsSample: [String]?
+    public let resourceIdsSample: [String]?
+
+    public init(
+        capturedAtMs: Double? = nil,
+        observeError: String? = nil,
+        awaitTimeout: Bool? = nil,
+        visibleTextsSample: [String]? = nil,
+        resourceIdsSample: [String]? = nil
+    ) {
+        self.capturedAtMs = capturedAtMs
+        self.observeError = observeError
+        self.awaitTimeout = awaitTimeout
+        self.visibleTextsSample = visibleTextsSample
+        self.resourceIdsSample = resourceIdsSample
+    }
+}
+
+// MARK: - Recovery feature-flag configuration
+
+/// Reads the `ai-recovery` gate. Mirrors Android `RecoveryConfigProvider`.
+public protocol RecoveryConfigProviding {
+    func isRecoveryEnabled() -> Bool
+    func maxRecoveryToolCalls() -> Int
+}
+
+/// Test double with fixed values. Mirrors Android `StaticRecoveryConfigProvider`.
+public struct StaticRecoveryConfigProvider: RecoveryConfigProviding {
+    private let enabled: Bool
+    private let maxToolCalls: Int
+
+    public init(enabled: Bool = true, maxToolCalls: Int = 5) {
+        self.enabled = enabled
+        self.maxToolCalls = maxToolCalls
+    }
+
+    public func isRecoveryEnabled() -> Bool { enabled }
+    public func maxRecoveryToolCalls() -> Int { maxToolCalls }
+}
+
+/// Resolves the `ai-recovery` gate by reading the `automobile:config/feature-flags/ai-recovery`
+/// resource from the daemon over the shared `AutoMobileMCPClient`. Mirrors Android
+/// `DaemonRecoveryConfigProvider`. The result is memoized for the life of the provider (one executor /
+/// one test), so at most one resource read happens per test. On any read/parse failure it logs and
+/// falls back to the daemon-side defaults (enabled, `maxToolCalls: 5`).
+public final class DaemonRecoveryConfigProvider: RecoveryConfigProviding {
+    public static let resourceURI = "automobile:config/feature-flags/ai-recovery"
+    private static let defaultEnabled = true
+    private static let defaultMaxToolCalls = 5
+
+    private let clientProvider: () -> AutoMobileMCPClient?
+    private let timeoutSeconds: TimeInterval
+    private let logger: AutoMobileLogger
+    private var cached: (enabled: Bool, maxToolCalls: Int)?
+
+    public init(
+        clientProvider: @escaping () -> AutoMobileMCPClient?,
+        timeoutSeconds: TimeInterval = 5,
+        logger: AutoMobileLogger = StdoutLogger()
+    ) {
+        self.clientProvider = clientProvider
+        self.timeoutSeconds = timeoutSeconds
+        self.logger = logger
+    }
+
+    public func isRecoveryEnabled() -> Bool { resolve().enabled }
+    public func maxRecoveryToolCalls() -> Int { resolve().maxToolCalls }
+
+    private func resolve() -> (enabled: Bool, maxToolCalls: Int) {
+        if let cached = cached {
+            return cached
+        }
+        let resolved = fetch()
+        cached = resolved
+        return resolved
+    }
+
+    private func fetch() -> (enabled: Bool, maxToolCalls: Int) {
+        guard let client = clientProvider() else {
+            return (Self.defaultEnabled, Self.defaultMaxToolCalls)
+        }
+        do {
+            try client.initialize(timeout: timeoutSeconds)
+            let response = try client.readResource(uri: Self.resourceURI, timeout: timeoutSeconds)
+            return Self.parse(response.text)
+        } catch {
+            // Log-then-default: a missing/unreadable flag must not block a test run; the daemon-side
+            // default is "enabled", so recovery still engages when a key is configured.
+            logger.warn("Failed to read ai-recovery feature flag; defaulting to enabled: \(error)")
+            return (Self.defaultEnabled, Self.defaultMaxToolCalls)
+        }
+    }
+
+    static func parse(_ text: String) -> (enabled: Bool, maxToolCalls: Int) {
+        guard let data = text.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data, options: []),
+              let dict = object as? [String: Any]
+        else {
+            return (defaultEnabled, defaultMaxToolCalls)
+        }
+        let enabled = dict["enabled"] as? Bool ?? defaultEnabled
+        var maxToolCalls = defaultMaxToolCalls
+        if let config = dict["config"] as? [String: Any], let value = config["maxToolCalls"] as? Int {
+            maxToolCalls = value
+        }
+        return (enabled, maxToolCalls)
+    }
+}
+
+// MARK: - Model / provider resolution
+
+/// The LLM provider used for recovery. Key resolution is delegated to Tachikoma (it reads the standard
+/// env vars itself); we only need to know which key must be present to decide whether to engage.
+public enum RecoveryModelProvider: String {
+    case anthropic
+    case openai
+    case google
+
+    /// Env var Tachikoma reads for this provider's key. We gate on its presence so recovery can no-op
+    /// cleanly instead of surfacing an authentication error mid-test.
+    public var apiKeyEnvVar: String {
+        switch self {
+        case .anthropic: return "ANTHROPIC_API_KEY"
+        case .openai: return "OPENAI_API_KEY"
+        case .google: return "GEMINI_API_KEY"
+        }
+    }
+
+    /// Tachikoma model alias used when `AUTOMOBILE_AI_MODEL` is not set.
+    public var defaultModelName: String {
+        switch self {
+        case .anthropic: return "claude-sonnet-4-20250514"
+        case .openai: return "gpt-4.1"
+        case .google: return "gemini-2.0-flash"
+        }
+    }
+}
+
+/// The resolved provider + model for a recovery attempt. `resolve` returns `nil` when the selected
+/// provider has no API key in the environment, which the handler treats as "recovery unavailable".
+public struct RecoveryModelConfig: Equatable {
+    public let provider: RecoveryModelProvider
+    public let modelName: String
+
+    public init(provider: RecoveryModelProvider, modelName: String) {
+        self.provider = provider
+        self.modelName = modelName
+    }
+
+    /// Env-driven resolution. Provider from `AUTOMOBILE_AI_PROVIDER` (default `anthropic`), model from
+    /// `AUTOMOBILE_AI_MODEL` (default = provider's `defaultModelName`). Returns `nil` if the provider's
+    /// API-key env var is absent or empty.
+    public static func resolve(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> RecoveryModelConfig? {
+        let providerRaw = (environment["AUTOMOBILE_AI_PROVIDER"] ?? "anthropic")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let provider = RecoveryModelProvider(rawValue: providerRaw) ?? .anthropic
+
+        let apiKey = environment[provider.apiKeyEnvVar]?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let apiKey = apiKey, !apiKey.isEmpty else {
+            return nil
+        }
+
+        let overrideModel = environment["AUTOMOBILE_AI_MODEL"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let modelName = (overrideModel?.isEmpty == false ? overrideModel : nil) ?? provider.defaultModelName
+        return RecoveryModelConfig(provider: provider, modelName: modelName)
+    }
+}
+
+// MARK: - Plan step tool-name extraction
+
+/// Best-effort extraction of per-step `tool:` names from a plan's YAML `steps:` list, used to label the
+/// "previously succeeded steps" in the recovery prompt. Tolerant by design: the full plan YAML is also
+/// handed to the agent, so a missed name degrades to a generic label rather than causing a failure.
+public enum PlanStepToolParser {
+    public static func toolNames(from yaml: String) -> [String] {
+        var names: [String] = []
+        var inSteps = false
+        var stepsIndent = 0
+        var awaitingToolForCurrentItem = false
+
+        for rawLine in yaml.split(whereSeparator: \.isNewline).map(String.init) {
+            let line = stripComment(rawLine)
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.isEmpty {
+                continue
+            }
+            let indent = line.prefix { $0 == " " }.count
+
+            if !inSteps {
+                if trimmed == "steps:" || trimmed.hasPrefix("steps:") {
+                    inSteps = true
+                    stepsIndent = indent
+                }
+                continue
+            }
+
+            // A non-list line at or above the steps key ends the steps block.
+            if indent <= stepsIndent, !trimmed.hasPrefix("-") {
+                break
+            }
+
+            if trimmed.hasPrefix("-") {
+                let remainder = trimmed.dropFirst().trimmingCharacters(in: .whitespaces)
+                if let tool = toolValue(String(remainder)) {
+                    names.append(tool)
+                    awaitingToolForCurrentItem = false
+                } else {
+                    names.append("step")
+                    awaitingToolForCurrentItem = true
+                }
+            } else if awaitingToolForCurrentItem, let tool = toolValue(trimmed), !names.isEmpty {
+                names[names.count - 1] = tool
+                awaitingToolForCurrentItem = false
+            }
+        }
+
+        return names
+    }
+
+    private static func toolValue(_ text: String) -> String? {
+        guard text.hasPrefix("tool:") else {
+            return nil
+        }
+        let value = text.dropFirst("tool:".count).trimmingCharacters(in: .whitespaces)
+        if value.isEmpty {
+            return nil
+        }
+        return unquote(String(value))
+    }
+
+    private static func stripComment(_ line: String) -> String {
+        guard let hashIndex = line.firstIndex(of: "#") else {
+            return line
+        }
+        return String(line[..<hashIndex])
+    }
+
+    private static func unquote(_ value: String) -> String {
+        guard value.count >= 2 else {
+            return value
+        }
+        if (value.hasPrefix("\"") && value.hasSuffix("\"")) || (value.hasPrefix("'") && value.hasSuffix("'")) {
+            return String(value.dropFirst().dropLast())
+        }
+        return value
+    }
+}

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileTestCase.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileTestCase.swift
@@ -99,6 +99,14 @@ open class AutoMobileTestCase: XCTestCase {
         return 0
     }
 
+    /// Per-test kill switch for AI-assisted failure recovery. When true (the default) and the
+    /// `ai-recovery` flag is enabled and a model API key is configured, a failed step triggers one
+    /// recovery attempt before the test fails. Set `AUTOMOBILE_AI_ASSISTANCE=false` (or override) to
+    /// force the pre-recovery behavior of failing immediately.
+    open var aiAssistance: Bool {
+        return environment.boolValue(["AUTOMOBILE_AI_ASSISTANCE"]) ?? true
+    }
+
     open var planParameters: [String: String] {
         return [:]
     }
@@ -200,7 +208,8 @@ open class AutoMobileTestCase: XCTestCase {
             startStep: startStep,
             parameters: planParameters,
             cleanup: cleanupOptions,
-            planBundle: planBundle
+            planBundle: planBundle,
+            aiAssistance: aiAssistance
         )
     }
 

--- a/ios/XCTestRunner/Sources/XCTestRunner/TachikomaPlanRecoveryHandler.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/TachikomaPlanRecoveryHandler.swift
@@ -1,0 +1,425 @@
+import Foundation
+import Tachikoma
+
+// Tachikoma-backed implementation of `PlanRecoveryHandler` — the iOS counterpart to the Android JUnit
+// runner's `AutoMobileAgent.attemptAiRecovery` (which uses Koog). Tachikoma v1.0.0 exposes a low-level
+// `ModelInterface.getResponse` primitive rather than a packaged agent loop, so the multi-step
+// tool-calling loop is implemented here: prompt the model with the failure context + the AutoMobile
+// tool set, execute each requested tool over the shared `AutoMobileMCPClient`, feed results back, and
+// repeat up to the `maxToolCalls` budget. After the agent finishes we observe the device ourselves
+// (outside the budget) to verify it is in a queryable state — the same success signal Android uses.
+
+// MARK: - Model seam (for testability)
+
+/// Narrow seam over the Tachikoma model call so the recovery loop can be unit-tested with a fake model
+/// (no network, no API key). The production implementation is `TachikomaModelResponder`.
+public protocol ModelResponding {
+    func respond(_ request: ModelRequest) async throws -> ModelResponse
+}
+
+/// Resolves a Tachikoma model by name (Anthropic/OpenAI/Google — keys read from the environment by
+/// Tachikoma itself) and forwards the request to it.
+public struct TachikomaModelResponder: ModelResponding {
+    private let modelName: String
+
+    public init(modelName: String) {
+        self.modelName = modelName
+    }
+
+    public func respond(_ request: ModelRequest) async throws -> ModelResponse {
+        let model = try await ModelProvider.shared.getModel(modelName: modelName)
+        return try await model.getResponse(request: request)
+    }
+}
+
+// MARK: - Handler
+
+public final class TachikomaPlanRecoveryHandler: PlanRecoveryHandler {
+    private let mcpClient: AutoMobileMCPClient
+    private let configProvider: RecoveryConfigProviding
+    private let modelConfig: RecoveryModelConfig?
+    private let timeoutSeconds: TimeInterval
+    private let timer: AutoMobileTimer
+    private let logger: AutoMobileLogger
+    private let responderFactory: (RecoveryModelConfig) -> ModelResponding
+
+    public init(
+        mcpClient: AutoMobileMCPClient,
+        configProvider: RecoveryConfigProviding,
+        modelConfig: RecoveryModelConfig? = RecoveryModelConfig.resolve(),
+        timeoutSeconds: TimeInterval = 120,
+        timer: AutoMobileTimer = SystemTimer(),
+        logger: AutoMobileLogger = StdoutLogger(),
+        responderFactory: @escaping (RecoveryModelConfig) -> ModelResponding = { config in
+            TachikomaModelResponder(modelName: config.modelName)
+        }
+    ) {
+        self.mcpClient = mcpClient
+        self.configProvider = configProvider
+        self.modelConfig = modelConfig
+        self.timeoutSeconds = timeoutSeconds
+        self.timer = timer
+        self.logger = logger
+        self.responderFactory = responderFactory
+    }
+
+    public func attemptRecovery(_ context: FailedStepContext) -> RecoveryOutcome {
+        let start = timer.now()
+
+        guard let modelConfig = modelConfig else {
+            // No API key for the configured provider — recovery is unavailable. Return failure so the
+            // executor falls back to throwing the original plan failure, exactly as before this feature.
+            logger.warn("AI recovery unavailable: no API key for the configured provider; skipping.")
+            return RecoveryOutcome(success: false, recoveryTimeMs: elapsedMs(since: start))
+        }
+
+        let maxToolCalls = configProvider.maxRecoveryToolCalls()
+        let responder = responderFactory(modelConfig)
+        logger.info(
+            "Starting AI recovery for step \(context.failedStepIndex + 1) (\(context.failedTool)) "
+                + "with model \(modelConfig.modelName), budget \(maxToolCalls) tool calls..."
+        )
+
+        do {
+            try runAgentLoop(context: context, responder: responder, settings: modelSettings(for: modelConfig), maxToolCalls: maxToolCalls)
+        } catch {
+            logger.warn("AI recovery execution failed: \(error)")
+            return RecoveryOutcome(success: false, recoveryTimeMs: elapsedMs(since: start))
+        }
+
+        // Verify the device is in a queryable state after recovery (outside the tool budget). Mirrors
+        // Android: success == a post-recovery observe returned something. The resumed step is the real
+        // check of whether recovery actually worked.
+        logger.info("AI recovery agent finished, verifying device state...")
+        let observeResult = observeDeviceState(context: context)
+        return RecoveryOutcome(
+            success: observeResult != nil,
+            recoveryTimeMs: elapsedMs(since: start),
+            observeResultAfterRecovery: observeResult
+        )
+    }
+
+    // MARK: - Agent loop
+
+    private func runAgentLoop(
+        context: FailedStepContext,
+        responder: ModelResponding,
+        settings: ModelSettings,
+        maxToolCalls: Int
+    ) throws {
+        let tools = Self.buildToolDefinitions()
+        var messages: [Message] = [
+            .user(content: .text(Self.buildRecoveryPrompt(context: context, maxToolCalls: maxToolCalls))),
+        ]
+
+        var toolCallsUsed = 0
+        while true {
+            let request = ModelRequest(
+                messages: messages,
+                tools: tools,
+                settings: settings,
+                systemInstructions: Self.systemInstructions
+            )
+
+            let response = try runBlocking { try await responder.respond(request) }
+            messages.append(.assistant(content: response.content))
+
+            let toolCalls = response.content.compactMap { content -> ToolCallItem? in
+                if case let .toolCall(item) = content {
+                    return item
+                }
+                return nil
+            }
+
+            if toolCalls.isEmpty {
+                // The model produced a final answer with no further actions — recovery attempt done.
+                return
+            }
+            if toolCallsUsed >= maxToolCalls {
+                // Budget spent and the model still wants to act. Stop here; the resumed step is the
+                // real verification of whether the device recovered.
+                return
+            }
+
+            for call in toolCalls {
+                guard toolCallsUsed < maxToolCalls else {
+                    // Budget exhausted mid-batch: acknowledge the remaining calls so the transcript
+                    // stays well-formed, but do not touch the device.
+                    messages.append(.tool(toolCallId: call.id, content: "{\"error\":\"tool-call budget exhausted\"}"))
+                    continue
+                }
+                toolCallsUsed += 1
+                let resultText = executeTool(name: call.function.name, argumentsJSON: call.function.arguments, context: context)
+                messages.append(.tool(toolCallId: call.id, content: resultText))
+            }
+        }
+    }
+
+    private func modelSettings(for config: RecoveryModelConfig) -> ModelSettings {
+        ModelSettings(modelName: config.modelName, maxTokens: 4096, toolChoice: .auto)
+    }
+
+    // MARK: - Tool execution over the AutoMobile MCP client
+
+    private func executeTool(name: String, argumentsJSON: String, context: FailedStepContext) -> String {
+        var arguments = Self.parseArguments(argumentsJSON)
+        // Required routing fields are injected by us, not trusted from the model, so every recovery
+        // call is valid and targets the same platform/session/device as the plan.
+        arguments["platform"] = context.platform
+        if let session = context.sessionUuid {
+            arguments["sessionUuid"] = session
+        }
+        if let device = context.deviceId {
+            arguments["device"] = device
+        }
+        if name == "tapOn", arguments["action"] == nil {
+            arguments["action"] = "tap"
+        }
+
+        do {
+            let response = try mcpClient.callTool(name: name, arguments: arguments, timeout: timeoutSeconds)
+            return response.text
+        } catch {
+            logger.warn("Recovery tool \(name) failed: \(error)")
+            return "{\"error\":\"\(Self.escapeForJSON(String(describing: error)))\"}"
+        }
+    }
+
+    private func observeDeviceState(context: FailedStepContext) -> String? {
+        var arguments: [String: Any] = ["platform": context.platform]
+        if let session = context.sessionUuid {
+            arguments["sessionUuid"] = session
+        }
+        if let device = context.deviceId {
+            arguments["device"] = device
+        }
+        do {
+            let response = try mcpClient.callTool(name: "observe", arguments: arguments, timeout: timeoutSeconds)
+            return response.text
+        } catch {
+            logger.warn("Post-recovery observe failed: \(error)")
+            return nil
+        }
+    }
+
+    // MARK: - Prompt
+
+    static let systemInstructions = """
+    You are an iOS UI test recovery agent. A recorded test plan hit a failing step. Your job is to use \
+    the provided AutoMobile tools to get the app back into the state the plan expects so it can resume \
+    from the next step. Start by calling observe to see the current screen. Then take the minimal \
+    corrective actions needed (dismiss dialogs, navigate to the right screen, wait for elements, retry \
+    with a better selector). Do not try to complete the whole test — only fix the immediate blocker so \
+    the next step can run. When the device is ready, stop and briefly say what you did.
+    """
+
+    static func buildRecoveryPrompt(context: FailedStepContext, maxToolCalls: Int) -> String {
+        let succeeded: String
+        if context.succeededSteps.isEmpty {
+            succeeded = "  (none — the first step failed)"
+        } else {
+            succeeded = context.succeededSteps
+                .map { "  - Step \($0.stepIndex + 1): \($0.tool) (completed)" }
+                .joined(separator: "\n")
+        }
+
+        var prompt = """
+        A test plan step failed. Here is the context:
+
+        FAILED STEP: Step \(context.failedStepIndex + 1) using tool "\(context.failedTool)"
+        ERROR: \(context.error)
+
+        PREVIOUSLY SUCCEEDED STEPS:
+        \(succeeded)
+        """
+
+        if let observation = context.failureObservation {
+            var lines: [String] = []
+            if let observeError = observation.observeError {
+                lines.append("  observeError: \(observeError)")
+            }
+            if observation.awaitTimeout == true {
+                lines.append("  awaitTimeout: true")
+            }
+            if let texts = observation.visibleTextsSample, !texts.isEmpty {
+                lines.append("  visibleTexts: \(texts.prefix(40).joined(separator: ", "))")
+            }
+            if let ids = observation.resourceIdsSample, !ids.isEmpty {
+                lines.append("  resourceIds: \(ids.prefix(40).joined(separator: ", "))")
+            }
+            if !lines.isEmpty {
+                prompt += "\n\nDEVICE STATE AT FAILURE:\n" + lines.joined(separator: "\n")
+            }
+        }
+
+        prompt += """
+
+
+        PLAN YAML:
+        \(context.planContent)
+
+        You have a maximum of \(maxToolCalls) tool calls to recover the device state so the test can \
+        resume from step \(context.failedStepIndex + 2). Focus on getting the device ready for the NEXT \
+        step in the plan.
+        """
+
+        return prompt
+    }
+
+    // MARK: - Tool definitions (mirror the Android SimpleTool set; schemas from schemas/tool-definitions.json)
+
+    static func buildToolDefinitions() -> [ToolDefinition] {
+        let selectorSchema = ParameterSchema.object(
+            properties: [
+                "text": .string(description: "Visible text or accessibility label of the element"),
+                "id": .string(description: "Resource id / accessibility identifier of the element"),
+                "description": .string(description: "Accessibility description of the element"),
+            ],
+            description: "How to find the element — provide at least one of text, id, or description"
+        )
+
+        return [
+            tool(
+                name: "observe",
+                description: "Capture the current screen state and UI hierarchy. Call this first.",
+                properties: [:],
+                required: []
+            ),
+            tool(
+                name: "tapOn",
+                description: "Tap an element located by text, id, or accessibility description.",
+                properties: [
+                    "selector": selectorSchema,
+                    "action": .enumeration(
+                        ["tap", "doubleTap", "longPress"],
+                        description: "Gesture to perform; defaults to tap"
+                    ),
+                ],
+                required: ["selector"]
+            ),
+            tool(
+                name: "inputText",
+                description: "Type text into the currently focused input field.",
+                properties: [
+                    "text": .string(description: "The text to type"),
+                    "imeAction": .string(description: "Optional keyboard action to submit, e.g. done/next/search"),
+                ],
+                required: ["text"]
+            ),
+            tool(
+                name: "clearText",
+                description: "Clear text from the currently focused input field.",
+                properties: [:],
+                required: []
+            ),
+            tool(
+                name: "pressButton",
+                description: "Press a device or navigation button (e.g. back, home, enter).",
+                properties: [
+                    "button": .string(description: "The button to press, e.g. back, home, enter"),
+                ],
+                required: ["button"]
+            ),
+            tool(
+                name: "swipeOn",
+                description: "Swipe or scroll the screen in a direction to reveal off-screen content.",
+                properties: [
+                    "direction": .enumeration(
+                        ["up", "down", "left", "right"],
+                        description: "Direction to swipe/scroll"
+                    ),
+                ],
+                required: ["direction"]
+            ),
+            tool(
+                name: "launchApp",
+                description: "Launch an app by its bundle/package id.",
+                properties: [
+                    "appId": .string(description: "The app bundle identifier / package name"),
+                ],
+                required: ["appId"]
+            ),
+            tool(
+                name: "terminateApp",
+                description: "Terminate a running app by its bundle/package id.",
+                properties: [
+                    "appId": .string(description: "The app bundle identifier / package name"),
+                ],
+                required: ["appId"]
+            ),
+        ]
+    }
+
+    private static func tool(
+        name: String,
+        description: String,
+        properties: [String: ParameterSchema],
+        required: [String]
+    ) -> ToolDefinition {
+        ToolDefinition(
+            function: FunctionDefinition(
+                name: name,
+                description: description,
+                parameters: ToolParameters.object(properties: properties, required: required),
+                strict: false
+            )
+        )
+    }
+
+    // MARK: - Helpers
+
+    static func parseArguments(_ json: String) -> [String: Any] {
+        let trimmed = json.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              let data = trimmed.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data, options: []),
+              let dict = object as? [String: Any]
+        else {
+            return [:]
+        }
+        return dict
+    }
+
+    private static func escapeForJSON(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\n", with: " ")
+    }
+
+    private func elapsedMs(since start: TimeInterval) -> Int {
+        Int((timer.now() - start) * 1000)
+    }
+
+    /// Bridge a single async model call to the synchronous executor thread. The rest of the recovery
+    /// loop (MCP tool calls) stays synchronous on the caller's thread, matching how the executor
+    /// already drives `AutoMobileMCPClient`. The executor runs on the XCTest thread, not the Swift
+    /// concurrency cooperative pool, so blocking here is safe.
+    private func runBlocking<T>(_ operation: @escaping () async throws -> T) throws -> T {
+        let box = ResultBox<T>()
+        let semaphore = DispatchSemaphore(value: 0)
+        Task {
+            do {
+                box.result = .success(try await operation())
+            } catch {
+                box.result = .failure(error)
+            }
+            semaphore.signal()
+        }
+        semaphore.wait()
+        switch box.result {
+        case let .success(value):
+            return value
+        case let .failure(error):
+            throw error
+        case .none:
+            throw MCPClientError.requestFailed("Recovery model call produced no result")
+        }
+    }
+}
+
+/// Mutable, thread-crossing result holder for `runBlocking`. `@unchecked Sendable` because access is
+/// serialized by the semaphore (write happens-before the signal; read happens-after the wait).
+private final class ResultBox<T>: @unchecked Sendable {
+    var result: Result<T, Error>?
+}

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/RecoveryTests.swift
@@ -1,0 +1,445 @@
+import XCTest
+import Tachikoma
+@testable import XCTestRunner
+
+// Unit tests for AI-assisted failure recovery. All tests are hermetic: the model is faked
+// (`StubModelResponder`) so nothing here touches the network or needs an API key.
+
+final class RecoveryExecutorTests: XCTestCase {
+    private let fourStepPlan = """
+    name: Recovery Plan
+    steps:
+      - tool: observe
+      - tool: launchApp
+      - tool: tapOn
+      - tool: inputText
+    """
+
+    func testRecoverySucceedsAndResumesFromNextStep() throws {
+        let client = RecoveryMCPClient()
+        client.queueExecutePlan(planJSON(
+            success: false, executedSteps: 2, totalSteps: 4,
+            failedStep: ["stepIndex": 2, "tool": "tapOn", "error": "no element", "device": "sim-1"]
+        ))
+        client.queueExecutePlan(planJSON(success: true, executedSteps: 4, totalSteps: 4))
+
+        let handler = SpyRecoveryHandler(outcome: RecoveryOutcome(success: true))
+        let executor = makeExecutor(client: client, handler: handler, recoveryEnabled: true)
+
+        let result = try executor.execute(testMetadata: nil)
+
+        XCTAssertTrue(result.success)
+        XCTAssertTrue(result.aiRecoveryAttempted)
+        XCTAssertTrue(result.aiRecoverySuccessful)
+
+        XCTAssertEqual(handler.receivedContexts.count, 1)
+        let context = try XCTUnwrap(handler.receivedContexts.first)
+        XCTAssertEqual(context.failedStepIndex, 2)
+        XCTAssertEqual(context.failedTool, "tapOn")
+        XCTAssertEqual(context.platform, "ios")
+        XCTAssertEqual(context.deviceId, "sim-1")
+        XCTAssertEqual(context.succeededSteps.map { $0.stepIndex }, [0, 1])
+        XCTAssertEqual(context.succeededSteps.map { $0.tool }, ["observe", "launchApp"])
+
+        let executePlanCalls = client.executePlanCalls
+        XCTAssertEqual(executePlanCalls.count, 2)
+        XCTAssertEqual(executePlanCalls[0].arguments["startStep"] as? Int, 0)
+        XCTAssertEqual(executePlanCalls[1].arguments["startStep"] as? Int, 3)
+        XCTAssertEqual(executePlanCalls[1].arguments["deviceId"] as? String, "sim-1")
+    }
+
+    func testRecoveryFailureThrowsOriginalAndDoesNotResume() throws {
+        let client = RecoveryMCPClient()
+        client.queueExecutePlan(planJSON(
+            success: false, executedSteps: 1, totalSteps: 3,
+            failedStep: ["stepIndex": 1, "tool": "tapOn", "error": "boom"]
+        ))
+
+        let handler = SpyRecoveryHandler(outcome: RecoveryOutcome(success: false))
+        let executor = makeExecutor(client: client, handler: handler, recoveryEnabled: true)
+
+        XCTAssertThrowsError(try executor.execute(testMetadata: nil)) { error in
+            let description = String(describing: error)
+            XCTAssertTrue(description.contains("boom"), "should retain the original failure message")
+            XCTAssertTrue(description.contains("AI recovery attempted"), "should note the failed recovery")
+        }
+        XCTAssertEqual(handler.receivedContexts.count, 1)
+        XCTAssertEqual(client.executePlanCalls.count, 1, "must not resume when recovery failed")
+    }
+
+    func testRecoverySkippedWhenFlagDisabled() throws {
+        let client = RecoveryMCPClient()
+        client.queueExecutePlan(planJSON(
+            success: false, executedSteps: 1, totalSteps: 3,
+            failedStep: ["stepIndex": 1, "tool": "tapOn", "error": "nope"]
+        ))
+
+        let handler = SpyRecoveryHandler(outcome: RecoveryOutcome(success: true))
+        let executor = makeExecutor(client: client, handler: handler, recoveryEnabled: false)
+
+        XCTAssertThrowsError(try executor.execute(testMetadata: nil))
+        XCTAssertTrue(handler.receivedContexts.isEmpty, "flag off must not call the handler")
+        XCTAssertEqual(client.executePlanCalls.count, 1)
+    }
+
+    func testRecoverySkippedInCiMode() throws {
+        let client = RecoveryMCPClient()
+        client.queueExecutePlan(planJSON(
+            success: false, executedSteps: 1, totalSteps: 3,
+            failedStep: ["stepIndex": 1, "tool": "tapOn", "error": "nope"]
+        ))
+
+        let handler = SpyRecoveryHandler(outcome: RecoveryOutcome(success: true))
+        let executor = makeExecutor(client: client, handler: handler, recoveryEnabled: true)
+
+        let metadata = AutoMobilePlanExecutor.TestMetadata(testClass: "T", testMethod: "m", isCi: true)
+        XCTAssertThrowsError(try executor.execute(testMetadata: metadata))
+        XCTAssertTrue(handler.receivedContexts.isEmpty, "CI mode must skip recovery")
+    }
+
+    func testRecoverySkippedWhenAiAssistanceDisabled() throws {
+        let client = RecoveryMCPClient()
+        client.queueExecutePlan(planJSON(
+            success: false, executedSteps: 1, totalSteps: 3,
+            failedStep: ["stepIndex": 1, "tool": "tapOn", "error": "nope"]
+        ))
+
+        let handler = SpyRecoveryHandler(outcome: RecoveryOutcome(success: true))
+        let executor = makeExecutor(client: client, handler: handler, recoveryEnabled: true, aiAssistance: false)
+
+        XCTAssertThrowsError(try executor.execute(testMetadata: nil))
+        XCTAssertTrue(handler.receivedContexts.isEmpty, "aiAssistance=false must skip recovery")
+    }
+
+    func testRecoveryAttemptedAtMostOncePerTest() throws {
+        let client = RecoveryMCPClient()
+        // Initial failure, then the resumed run also fails: recovery must NOT fire a second time.
+        client.queueExecutePlan(planJSON(
+            success: false, executedSteps: 1, totalSteps: 3,
+            failedStep: ["stepIndex": 1, "tool": "tapOn", "error": "first"]
+        ))
+        client.queueExecutePlan(planJSON(
+            success: false, executedSteps: 2, totalSteps: 3,
+            failedStep: ["stepIndex": 2, "tool": "inputText", "error": "second"]
+        ))
+
+        let handler = SpyRecoveryHandler(outcome: RecoveryOutcome(success: true))
+        let executor = makeExecutor(client: client, handler: handler, recoveryEnabled: true)
+
+        XCTAssertThrowsError(try executor.execute(testMetadata: nil))
+        XCTAssertEqual(handler.receivedContexts.count, 1, "recovery is allowed at most once per test")
+        XCTAssertEqual(client.executePlanCalls.count, 2, "initial attempt + one resume")
+        XCTAssertEqual(client.executePlanCalls[1].arguments["startStep"] as? Int, 2)
+    }
+
+    // MARK: - Helpers
+
+    private func makeExecutor(
+        client: RecoveryMCPClient,
+        handler: PlanRecoveryHandler,
+        recoveryEnabled: Bool,
+        aiAssistance: Bool = true
+    ) -> AutoMobilePlanExecutor {
+        let config = AutoMobilePlanExecutor.Configuration(
+            transport: .daemonUnixSocket(path: "/tmp/xctestrunner-recovery-test.sock"),
+            planPath: "recovery-plan.yaml",
+            retryCount: 0,
+            timeoutSeconds: 5,
+            retryDelaySeconds: 0,
+            startStep: 0,
+            aiAssistance: aiAssistance
+        )
+        return AutoMobilePlanExecutor(
+            configuration: config,
+            planLoader: StubPlanLoader(content: fourStepPlan),
+            mcpClient: client,
+            timer: FakeTimer(),
+            logger: SilentLogger(),
+            recoveryHandler: handler,
+            recoveryConfigProvider: StaticRecoveryConfigProvider(enabled: recoveryEnabled, maxToolCalls: 5)
+        )
+    }
+}
+
+final class RecoveryConfigAndModelTests: XCTestCase {
+    func testDaemonRecoveryConfigReadsFlagFromResource() {
+        let client = RecoveryMCPClient()
+        client.flagResourceText = jsonString(["enabled": false, "config": ["maxToolCalls": 9]])
+        let provider = DaemonRecoveryConfigProvider(clientProvider: { client }, logger: SilentLogger())
+        XCTAssertFalse(provider.isRecoveryEnabled())
+        XCTAssertEqual(provider.maxRecoveryToolCalls(), 9)
+    }
+
+    func testDaemonRecoveryConfigParseDefaultsOnGarbage() {
+        let parsed = DaemonRecoveryConfigProvider.parse("this is not json")
+        XCTAssertTrue(parsed.enabled)
+        XCTAssertEqual(parsed.maxToolCalls, 5)
+    }
+
+    func testModelConfigDefaultsToAnthropicWhenKeyPresent() {
+        let config = RecoveryModelConfig.resolve(environment: ["ANTHROPIC_API_KEY": "sk-test"])
+        XCTAssertEqual(config?.provider, .anthropic)
+        XCTAssertEqual(config?.modelName, "claude-sonnet-4-20250514")
+    }
+
+    func testModelConfigReturnsNilWithoutKey() {
+        XCTAssertNil(RecoveryModelConfig.resolve(environment: [:]))
+    }
+
+    func testModelConfigHonorsProviderAndModelOverride() {
+        let config = RecoveryModelConfig.resolve(environment: [
+            "AUTOMOBILE_AI_PROVIDER": "openai",
+            "OPENAI_API_KEY": "k",
+            "AUTOMOBILE_AI_MODEL": "gpt-4o",
+        ])
+        XCTAssertEqual(config?.provider, .openai)
+        XCTAssertEqual(config?.modelName, "gpt-4o")
+    }
+
+    func testModelConfigNilWhenSelectedProviderKeyMissing() {
+        // Provider is openai but only an Anthropic key is present — recovery is unavailable.
+        XCTAssertNil(RecoveryModelConfig.resolve(environment: [
+            "AUTOMOBILE_AI_PROVIDER": "openai",
+            "ANTHROPIC_API_KEY": "k",
+        ]))
+    }
+
+    func testPlanStepToolParserExtractsInlineToolNames() {
+        let yaml = """
+        name: P
+        steps:
+          - tool: observe
+          - tool: tapOn
+            selector:
+              text: Foo
+          - tool: inputText
+        """
+        XCTAssertEqual(PlanStepToolParser.toolNames(from: yaml), ["observe", "tapOn", "inputText"])
+    }
+
+    func testPlanStepToolParserFindsToolOnLaterLine() {
+        let yaml = """
+        steps:
+          - selector:
+              text: X
+            tool: tapOn
+        """
+        XCTAssertEqual(PlanStepToolParser.toolNames(from: yaml), ["tapOn"])
+    }
+}
+
+final class TachikomaPlanRecoveryHandlerTests: XCTestCase {
+    private func makeContext() -> FailedStepContext {
+        FailedStepContext(
+            failedStepIndex: 2,
+            failedTool: "tapOn",
+            error: "element not found",
+            succeededSteps: [SucceededStepSummary(stepIndex: 0, tool: "observe")],
+            planContent: "name: P\nsteps:\n  - tool: observe",
+            platform: "ios",
+            sessionUuid: "sess-1",
+            deviceId: "dev-1",
+            failureObservation: nil
+        )
+    }
+
+    func testHandlerRunsToolLoopThenVerifiesWithObserve() {
+        let client = RecoveryMCPClient()
+        let responder = StubModelResponder([
+            StubModelResponder.toolCall(name: "observe"),
+            StubModelResponder.toolCall(name: "tapOn", arguments: "{\"selector\":{\"text\":\"OK\"}}"),
+            StubModelResponder.final(),
+        ])
+        let handler = makeHandler(client: client, responder: responder, maxToolCalls: 5)
+
+        let outcome = handler.attemptRecovery(makeContext())
+
+        XCTAssertTrue(outcome.success, "a non-nil post-recovery observe means success")
+        XCTAssertEqual(client.calls.map { $0.name }, ["observe", "tapOn", "observe"])
+
+        let tapCall = client.calls.first { $0.name == "tapOn" }
+        XCTAssertEqual(tapCall?.arguments["platform"] as? String, "ios")
+        XCTAssertEqual(tapCall?.arguments["sessionUuid"] as? String, "sess-1")
+        XCTAssertEqual(tapCall?.arguments["device"] as? String, "dev-1")
+        XCTAssertEqual(tapCall?.arguments["action"] as? String, "tap", "tapOn action is injected when omitted")
+        XCTAssertNotNil(tapCall?.arguments["selector"], "model-provided selector is preserved")
+    }
+
+    func testHandlerNoOpsWithoutModelConfig() {
+        let client = RecoveryMCPClient()
+        let handler = TachikomaPlanRecoveryHandler(
+            mcpClient: client,
+            configProvider: StaticRecoveryConfigProvider(enabled: true, maxToolCalls: 5),
+            modelConfig: nil,
+            timer: FakeTimer(),
+            logger: SilentLogger(),
+            responderFactory: { _ in StubModelResponder([]) }
+        )
+
+        let outcome = handler.attemptRecovery(makeContext())
+
+        XCTAssertFalse(outcome.success)
+        XCTAssertTrue(client.calls.isEmpty, "no model config means no device interaction")
+    }
+
+    func testHandlerRespectsMaxToolCallBudget() {
+        let client = RecoveryMCPClient()
+        // The model keeps asking to tap forever; the budget of 2 must cap real device tool calls.
+        let responder = StubModelResponder(alwaysReturn: StubModelResponder.toolCall(name: "tapOn"))
+        let handler = makeHandler(client: client, responder: responder, maxToolCalls: 2)
+
+        _ = handler.attemptRecovery(makeContext())
+
+        XCTAssertEqual(client.calls.filter { $0.name == "tapOn" }.count, 2, "budget caps tool calls")
+        XCTAssertEqual(client.calls.filter { $0.name == "observe" }.count, 1, "one final verification observe")
+    }
+
+    private func makeHandler(
+        client: RecoveryMCPClient,
+        responder: ModelResponding,
+        maxToolCalls: Int
+    ) -> TachikomaPlanRecoveryHandler {
+        TachikomaPlanRecoveryHandler(
+            mcpClient: client,
+            configProvider: StaticRecoveryConfigProvider(enabled: true, maxToolCalls: maxToolCalls),
+            modelConfig: RecoveryModelConfig(provider: .anthropic, modelName: "claude-sonnet-4-20250514"),
+            timer: FakeTimer(),
+            logger: SilentLogger(),
+            responderFactory: { _ in responder }
+        )
+    }
+}
+
+// MARK: - Shared fakes
+
+private struct StubPlanLoader: AutoMobilePlanLoading {
+    let content: String
+    func loadPlan(at _: String, bundle _: Bundle?) throws -> String { content }
+}
+
+private struct SilentLogger: AutoMobileLogger {
+    func info(_: String) {}
+    func warn(_: String) {}
+    func error(_: String) {}
+}
+
+private final class SpyRecoveryHandler: PlanRecoveryHandler {
+    private let outcome: RecoveryOutcome
+    private(set) var receivedContexts: [FailedStepContext] = []
+
+    init(outcome: RecoveryOutcome) {
+        self.outcome = outcome
+    }
+
+    func attemptRecovery(_ context: FailedStepContext) -> RecoveryOutcome {
+        receivedContexts.append(context)
+        return outcome
+    }
+}
+
+private final class RecoveryMCPClient: AutoMobileMCPClient {
+    struct Call {
+        let name: String
+        let arguments: [String: Any]
+    }
+
+    private(set) var calls: [Call] = []
+    private var executePlanResponses: [MCPToolResponse] = []
+    var flagResourceText = "{\"key\":\"ai-recovery\",\"enabled\":true,\"config\":{\"maxToolCalls\":5}}"
+    var toolResponseText = "{\"ok\":true}"
+    var observeText = "{\"elements\":{}}"
+
+    var executePlanCalls: [Call] { calls.filter { $0.name == "executePlan" } }
+
+    func queueExecutePlan(_ text: String) {
+        executePlanResponses.append(MCPToolResponse(text: text))
+    }
+
+    func initialize(timeout _: TimeInterval) throws {}
+
+    func callTool(name: String, arguments: [String: Any], timeout _: TimeInterval) throws -> MCPToolResponse {
+        calls.append(Call(name: name, arguments: arguments))
+        if name == "executePlan" {
+            guard !executePlanResponses.isEmpty else {
+                return MCPToolResponse(text: "{\"success\":true,\"executedSteps\":0,\"totalSteps\":0}")
+            }
+            return executePlanResponses.removeFirst()
+        }
+        if name == "observe" {
+            return MCPToolResponse(text: observeText)
+        }
+        return MCPToolResponse(text: toolResponseText)
+    }
+
+    func readResource(uri _: String, timeout _: TimeInterval) throws -> MCPResourceResponse {
+        MCPResourceResponse(text: flagResourceText)
+    }
+
+    func resetSession() {}
+}
+
+/// Fake `ModelResponding` that replays a fixed script of responses (or repeats one forever).
+private final class StubModelResponder: ModelResponding {
+    private var scripted: [ModelResponse]
+    private let repeated: ModelResponse?
+
+    init(_ scripted: [ModelResponse]) {
+        self.scripted = scripted
+        self.repeated = nil
+    }
+
+    init(alwaysReturn response: ModelResponse) {
+        self.scripted = []
+        self.repeated = response
+    }
+
+    func respond(_: ModelRequest) async throws -> ModelResponse {
+        if let repeated = repeated {
+            return repeated
+        }
+        if scripted.isEmpty {
+            return StubModelResponder.final()
+        }
+        return scripted.removeFirst()
+    }
+
+    static func toolCall(name: String, arguments: String = "{}") -> ModelResponse {
+        ModelResponse(
+            id: "resp",
+            content: [.toolCall(ToolCallItem(id: "call-\(name)", function: FunctionCall(name: name, arguments: arguments)))]
+        )
+    }
+
+    static func final() -> ModelResponse {
+        ModelResponse(id: "resp", content: [.outputText("recovery complete")])
+    }
+}
+
+private func planJSON(
+    success: Bool,
+    executedSteps: Int,
+    totalSteps: Int,
+    failedStep: [String: Any]? = nil
+) -> String {
+    var payload: [String: Any] = [
+        "success": success,
+        "executedSteps": executedSteps,
+        "totalSteps": totalSteps,
+    ]
+    if let failedStep = failedStep {
+        payload["failedStep"] = failedStep
+        if let error = failedStep["error"] {
+            payload["error"] = error
+        }
+    }
+    return jsonString(payload)
+}
+
+private func jsonString(_ payload: [String: Any]) -> String {
+    guard let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys]),
+          let text = String(data: data, encoding: .utf8)
+    else {
+        return "{}"
+    }
+    return text
+}

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/XCTestRunnerTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/XCTestRunnerTests.swift
@@ -284,7 +284,10 @@ final class XCTestRunnerTests: XCTestCase {
             planLoader: planLoader,
             mcpClient: mcpClient,
             timer: timer,
-            logger: NullLogger()
+            logger: NullLogger(),
+            // Disable AI recovery so this test deterministically exercises the failure-throw path
+            // regardless of whether the environment has a model API key configured.
+            recoveryModelConfig: nil
         )
 
         XCTAssertThrowsError(try executor.execute(testMetadata: nil)) { error in
@@ -371,7 +374,10 @@ final class XCTestRunnerTests: XCTestCase {
             planLoader: planLoader,
             mcpClient: mcpClient,
             timer: timer,
-            logger: NullLogger()
+            logger: NullLogger(),
+            // Disable AI recovery so this test deterministically exercises the failure-throw path
+            // regardless of whether the environment has a model API key configured.
+            recoveryModelConfig: nil
         )
 
         XCTAssertThrowsError(try executor.execute(testMetadata: nil)) { error in


### PR DESCRIPTION
## Summary

Ports the Android JUnit runner's **failure → agent-with-MCP-tools → verify → resume-at-next-step** recovery loop to the iOS `XCTestRunner`, using [Tachikoma](https://github.com/steipete/Tachikoma) (Peter Steinberger's Swift AI SDK) as the agent engine — the iOS counterpart to Android's Koog. **No Android code is changed.**

Before this change the iOS runner only re-ran the whole plan and then threw, even though the docs advertised "AI recovery — Optional self-healing." The daemon already sends everything needed (`failedStep.failureObservation`, the `automobile:config/feature-flags/ai-recovery` resource); iOS just ignored it. This makes the advertised capability real.

**What's added**
- `AutoMobileRecovery.swift` — dependency-free core: `PlanRecoveryHandler` protocol, `FailedStepContext`/`RecoveryOutcome`, `DaemonRecoveryConfigProvider` (reads the `ai-recovery` flag), `RecoveryModelConfig.resolve` (env-driven, Anthropic default), `FailureObservationSummary`, `PlanStepToolParser`.
- `TachikomaPlanRecoveryHandler.swift` — the tool-calling loop: prompts the model with the failure context + the AutoMobile tool set, executes each requested tool over the existing `AutoMobileMCPClient`, then verifies with `observe`.
- `AutoMobilePlanExecutor.handleFailure` — gates recovery and, on success, resumes from `failedStepIndex + 1` pinned to the recovered device/session. `FailedStep` now decodes `failureObservation`; `ExecutePlanResult` carries `aiRecoveryAttempted`/`aiRecoverySuccessful`.
- `AutoMobileTestCase.aiAssistance` knob (env `AUTOMOBILE_AI_ASSISTANCE`).

**Gating (parity with Android):** `aiAssistance` && `ai-recovery` flag && not-CI && once-per-test && a model API key present. With no key (CI, most unit tests) the handler is never constructed and a failed step throws exactly as before — fully backward compatible.

## Linked Issue

No tracking issue; implements the previously-unbacked "Optional self-healing" row in the XCTestRunner docs.

## Dependency decision (Tachikoma)

`docs/decisions/` is not an established directory in this repo, so recording the rationale here:

- **Why a dependency at all:** an LLM tool-calling agent is out of scope to hand-roll; the user explicitly chose Tachikoma as the iOS equivalent of Android's Koog.
- **Alternatives checked:** Tachikoma's `main` branch has a higher-level `generateText`/`createTool`/`TachikomaAgent`/`TachikomaMCP` API, but it is unreleased. I pinned the stable **v1.0.0** tag (exact pin, hermetic) and built the tool-calling loop on its lower-level `ModelInterface.getResponse` primitive — which is also *more* testable (the model is faked in unit tests, zero network). Tachikoma's built-in MCP client (`TachikomaMCP`, main-only) was not used because our daemon speaks a custom Unix-socket/HTTP wire; instead each AutoMobile MCP call is exposed as a Tachikoma tool, exactly as Android wraps them as Koog tools.
- **Transitive deps:** only `swift-log`.
- **Packaging impact:** bumps the package to swift-tools **6.0** / **iOS 17** / **macOS 14** (from 5.9 / iOS 15 / 13). Existing sources keep compiling in the Swift 5 language mode via `.swiftLanguageMode(.v5)`, avoiding a strict-concurrency migration.

## Validation

- [x] `bash scripts/ios/swift-build.sh`-equivalent: `swift build -Xswiftc -warnings-as-errors` builds clean from scratch **including** the Tachikoma dependency.
- [x] `bash scripts/ios/swift-test.sh`-equivalent: `swift test -Xswiftc -warnings-as-errors` — 17 new hermetic tests pass in ~5ms; the rest of the suite is green. (The one `RemindersAddPlanTests` failure is a pre-existing live-daemon integration test needing a configured simulator; logs confirm the new recovery path stays inert without an API key, so it is unaffected.)
- [x] New code uses interface + hand-written fakes + `FakeTimer`; unit tests run <100ms.
- [x] SwiftLint clean on changed files (0 error-severity; the 2 remaining warnings are pre-existing, untouched code — `PlanMetadataParser` complexity, `TimingOrderingStrategy.none`).
- [ ] Rebased onto latest `main` (branch is behind `main`; PR diff is scoped to this change — happy to rebase if preferred).

## Device Verification

Not run here (requires `ANTHROPIC_API_KEY` + a booted simulator + daemon). To verify end-to-end: author a plan with a deliberately-wrong selector on step N, run the XCTest with a key set, and confirm the logs show the agent recovering and the plan resuming at step N+1 with `result.aiRecoverySuccessful == true`.

## Reviewer notes

- **Backward compatibility** is the key property: without a model key the executor's behavior is byte-for-byte the old throw-on-failure path.
- "Recovered" == a post-recovery `observe` returned non-nil; the resumed step is the real verification (same weak-but-parity signal Android uses). Called out in `RecoveryOutcome`'s doc comment.
- `docs/design-docs/plat/ios/xctestrunner/{index,writing-tests,project-setup}.md` updated (new "AI-assisted recovery" section with a sequence diagram; `aiAssistance` property; raised toolchain/platform floor).
