### PR TITLE
feat(observe): wire settleObserve + waitForCondition into MCP tools + waitFor DSL

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3091,15 +3091,35 @@
         "waitFor": {
           "type": "object",
           "additionalProperties": false,
-          "description": "Wait for a predicate before returning the observation. Provide at least one of: elementId, text, textAny, className, contentDescription, or activeWindow. textAny is mutually exclusive with the element predicates.",
+          "description": "Wait for a predicate before returning the observation. Either set `for` (DSL: appear|disappear|clickable|textEquals|countStable|stable) with elementId/text, or provide a legacy predicate: elementId, text, textAny, className, contentDescription, or activeWindow. textAny is mutually exclusive with the element predicates.",
           "properties": {
+            "for": {
+              "type": "string",
+              "enum": [
+                "appear",
+                "disappear",
+                "clickable",
+                "textEquals",
+                "countStable",
+                "stable"
+              ],
+              "description": "Condition: appear/disappear/clickable/textEquals/countStable (selector) or stable (whole screen)"
+            },
+            "pollMs": {
+              "type": "number",
+              "description": "Poll interval ms (default 150)"
+            },
+            "stableReads": {
+              "type": "number",
+              "description": "Consecutive stable reads for countStable/stable (default 2)"
+            },
             "elementId": {
               "type": "string",
               "description": "Element resource ID / accessibility identifier"
             },
             "text": {
               "type": "string",
-              "description": "Element text"
+              "description": "Element text; for `for:textEquals` the exact expected value"
             },
             "textAny": {
               "type": "array",
@@ -3198,6 +3218,11 @@
           "anyOf": [
             {
               "required": [
+                "for"
+              ]
+            },
+            {
+              "required": [
                 "textAny"
               ],
               "not": {
@@ -3237,8 +3262,17 @@
             },
             {
               "not": {
-                "required": [
-                  "textAny"
+                "anyOf": [
+                  {
+                    "required": [
+                      "textAny"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "for"
+                    ]
+                  }
                 ]
               },
               "anyOf": [
@@ -6478,6 +6512,50 @@
     }
   },
   {
+    "name": "settleObserve",
+    "description": "Observe once the screen stops changing (structural settle); returns only the final snapshot.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "platform": {
+          "type": "string",
+          "enum": [
+            "android",
+            "ios"
+          ]
+        },
+        "timeoutMs": {
+          "description": "Hard budget ms (default 2500)",
+          "type": "number"
+        },
+        "pollMs": {
+          "description": "Poll interval ms (default 150)",
+          "type": "number"
+        },
+        "stableReads": {
+          "description": "Consecutive structurally-equal snapshots to settle (default 2)",
+          "type": "number"
+        },
+        "sessionUuid": {
+          "description": "Session",
+          "type": "string"
+        },
+        "keepScreenAwake": {
+          "type": "boolean"
+        },
+        "device": {
+          "description": "Device label",
+          "type": "string"
+        }
+      },
+      "required": [
+        "platform"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
     "name": "setUIState",
     "description": "Set multiple form fields by desired state.",
     "inputSchema": {
@@ -9567,6 +9645,70 @@
       "required": [
         "action",
         "platform"
+      ],
+      "additionalProperties": false
+    }
+  },
+  {
+    "name": "waitForCondition",
+    "description": "Wait until a predicate holds: appear|disappear|clickable|textEquals|countStable.",
+    "inputSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "platform": {
+          "type": "string",
+          "enum": [
+            "android",
+            "ios"
+          ]
+        },
+        "for": {
+          "type": "string",
+          "enum": [
+            "appear",
+            "disappear",
+            "clickable",
+            "textEquals",
+            "countStable"
+          ],
+          "description": "Condition: appear|disappear|clickable|textEquals|countStable"
+        },
+        "elementId": {
+          "description": "Element resource ID / accessibility identifier",
+          "type": "string"
+        },
+        "text": {
+          "description": "Element text; for `textEquals` the exact expected value",
+          "type": "string"
+        },
+        "timeoutMs": {
+          "description": "Hard budget ms (default 5000)",
+          "type": "number"
+        },
+        "pollMs": {
+          "description": "Poll interval ms (default 150)",
+          "type": "number"
+        },
+        "stableReads": {
+          "description": "Consecutive stable reads for countStable (default 2)",
+          "type": "number"
+        },
+        "sessionUuid": {
+          "description": "Session",
+          "type": "string"
+        },
+        "keepScreenAwake": {
+          "type": "boolean"
+        },
+        "device": {
+          "description": "Device label",
+          "type": "string"
+        }
+      },
+      "required": [
+        "platform",
+        "for"
       ],
       "additionalProperties": false
     }

--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -339,6 +339,7 @@ src/utils/plan/PlanSchemaValidator.ts: error TS1343: The 'import.meta' meta-prop
 # swap-fp: 7 :: src/index.ts: error TS2322: Type '["ui-perf-mode", boolean, string]' is not assignable to type '[FeatureFlagKey, boolean, string, Record<string, unknown> | null | undefined]'.
 # swap-fp: 7 :: src/server/deviceTools.ts: error TS2322: Type 'TimingData | null' is not assignable to type 'Record<string, number>'.
 # swap-fp: 7 :: src/server/interactionTools.ts: error TS2322: Type 'SwipeDirection | undefined' is not assignable to type 'SwipeDirection'.
+# swap-fp: 7,7,7,7,9,9,9,9 :: src/index.ts: error TS2322: Type 'number | string | undefined' is not assignable to type 'number | undefined'.
 # swap-fp: 74 :: src/features/utility/ElementParser.ts: error TS2339: Property 'hierarchy' does not exist on type '{ windowLayer: number; }'.
 # swap-fp: 74,75,76,77,77 :: src/features/action/SetUIState.ts: error TS2554: Expected 0-1 arguments, but got 5.
 # swap-fp: 78 :: src/features/navigation/NavigateTo.ts: error TS2345: Argument of type 'AdbExecutor' is not assignable to parameter of type 'AdbClient'.
@@ -353,7 +354,6 @@ src/utils/plan/PlanSchemaValidator.ts: error TS1343: The 'import.meta' meta-prop
 # swap-fp: 9,12 :: src/server/interactionTools.ts: error TS18048: 'searchStats' is possibly 'undefined'.
 # swap-fp: 9,9,11,11 :: src/utils/image/backend/JimpBackend.ts: error TS2322: Type 'JimpInstanceMethods<{ bitmap: Bitmap; background: number; formats: Format<any, undefined, undefined>[]; mime?: string | undefined; inspect(): string; toString(): string; readonly width: number; ... 11 more ...; scanIterator(x?: number | undefined, y?: number | undefined, w?: number | undefined, h?: number | undefine...' is not assignable to type '{ bitmap: Bitmap; background: number; formats: Format<any, undefined, undefined>[]; mime?: string | undefined; inspect(): string; toString(): string; readonly width: number; ... 11 more ...; scanIterator(x?: number | undefined, y?: number | undefined, w?: number | undefined, h?: number | undefined): Generator<...>; ...'.
 # swap-fp: 9,9,9 :: src/features/navigation/ExploreElementExtraction.ts: error TS2322: Type '{}' is not assignable to type 'string'.
-# swap-fp: 9,9,9,9,9,9,9,9 :: src/index.ts: error TS2322: Type 'number | string | undefined' is not assignable to type 'number | undefined'.
 # swap-fp: 91 :: src/server/testTimingResources.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type '"appVersion" | "deviceId" | "deviceName" | "devicePlatform" | "deviceType" | "gitCommit" | "jdkVersion" | "limit" | "sessionUuid" | "targetSdk" | "testClass" | "testMethod" | ... 6 more ... | "orderDirection"'.
 # swap-fp: 95 :: src/features/observe/DeviceServiceUtils.ts: error TS2694: Namespace '"src/features/observe/DeviceService"' has no exported member 'ImeActionResult'.
 # swap-fp: 97 :: src/server/navigationTools.ts: error TS2339: Property 'screensDiscovered' does not exist on type 'ExploreExecutionResult'.

--- a/src/features/observe/ConditionPredicates.ts
+++ b/src/features/observe/ConditionPredicates.ts
@@ -1,5 +1,6 @@
 import type { Element, ObserveResult, ViewHierarchyResult } from "../../models";
 import type { ElementFinder } from "../../utils/interfaces/ElementFinder";
+import { isClickableElementProperties } from "../../utils/elementProperties";
 import type { ConditionEvaluation, ConditionPredicate } from "./interfaces/WaitForCondition";
 
 /**
@@ -102,12 +103,14 @@ function findAllMatches(
 }
 
 /**
- * The Android/iOS `clickable` node attribute is typed `boolean | string` — the
- * accessibility bridges emit it either way — so accept the boolean `true` and the
- * stringified `"true"` identically.
+ * Whether an element is clickable, using the SAME signal `TapOnElement` taps on
+ * (`isClickableElementProperties`): the truthy `clickable` flag OR a `"click"`
+ * accessibility action. Matching the tap definition matters — iOS nodes are
+ * frequently tappable via a `click` action with `clickable` unset, so a narrower
+ * flag-only check would make "wait for clickable, then tap" disagree with `tapOn`.
  */
 function isElementClickable(element: Element): boolean {
-  return element.clickable === true || element.clickable === "true";
+  return isClickableElementProperties(element);
 }
 
 /**

--- a/src/features/observe/ConditionPredicates.ts
+++ b/src/features/observe/ConditionPredicates.ts
@@ -85,3 +85,115 @@ export function disappear(finder: ElementFinder, selector: ConditionSelector): C
     return { matched: true, candidates: [] };
   };
 }
+
+/** All elements matching the selector (exact match, no container scope). */
+function findAllMatches(
+  finder: ElementFinder,
+  viewHierarchy: ViewHierarchyResult,
+  selector: ConditionSelector
+): Element[] {
+  if (selector.elementId !== undefined) {
+    return finder.findElementsByResourceId(viewHierarchy, selector.elementId, NO_CONTAINER, false);
+  }
+  if (selector.text !== undefined) {
+    return finder.findElementsByText(viewHierarchy, selector.text, NO_CONTAINER, false, false);
+  }
+  return [];
+}
+
+/**
+ * The Android/iOS `clickable` node attribute is typed `boolean | string` — the
+ * accessibility bridges emit it either way — so accept the boolean `true` and the
+ * stringified `"true"` identically.
+ */
+function isElementClickable(element: Element): boolean {
+  return element.clickable === true || element.clickable === "true";
+}
+
+/**
+ * Predicate: the selector's element is present AND clickable. A present-but-not-
+ * clickable element (a disabled button mid-transition) is reported as a candidate
+ * rather than a match, so a timeout shows the element was there but never became
+ * tappable — the common "button enables after validation" wait.
+ */
+export function clickable(finder: ElementFinder, selector: ConditionSelector): ConditionPredicate {
+  return (observation: ObserveResult): ConditionEvaluation => {
+    const viewHierarchy = observation.viewHierarchy;
+    if (!viewHierarchy) {
+      return { matched: false, candidates: [] };
+    }
+    const match = findMatch(finder, viewHierarchy, selector);
+    if (match && isElementClickable(match)) {
+      return { matched: true, matchedElement: match, candidates: [match] };
+    }
+    // Present-but-not-clickable → surface the element itself; absent → near matches.
+    return { matched: false, candidates: match ? [match] : findNearMatches(finder, viewHierarchy, selector) };
+  };
+}
+
+/**
+ * Predicate: an element shows `expected` text EXACTLY. `expected` is always the
+ * required value; `selector.elementId`, when given, is the locator (wait for a
+ * specific label to reach a value — a counter hitting "5"). Without an elementId
+ * the predicate matches any element whose text equals `expected` exactly, which
+ * differs from `appear`'s looser/normalized text matching by requiring equality.
+ */
+export function textEquals(
+  finder: ElementFinder,
+  selector: ConditionSelector,
+  expected: string
+): ConditionPredicate {
+  return (observation: ObserveResult): ConditionEvaluation => {
+    const viewHierarchy = observation.viewHierarchy;
+    if (!viewHierarchy) {
+      return { matched: false, candidates: [] };
+    }
+    if (selector.elementId !== undefined) {
+      const located = finder.findElementByResourceId(viewHierarchy, selector.elementId, NO_CONTAINER);
+      if (located && (located.text ?? "") === expected) {
+        return { matched: true, matchedElement: located, candidates: [located] };
+      }
+      return { matched: false, candidates: located ? [located] : [] };
+    }
+    // No locator: an exact (case-sensitive) text match IS the located element.
+    const located = finder.findElementByText(viewHierarchy, expected, NO_CONTAINER, false, true);
+    if (located) {
+      return { matched: true, matchedElement: located, candidates: [located] };
+    }
+    return { matched: false, candidates: findNearMatches(finder, viewHierarchy, { text: expected }) };
+  };
+}
+
+/** Options for the {@link countStable} predicate. */
+export interface CountStableOptions {
+  /** Consecutive polls with an unchanged match count required to settle (default 2). */
+  stableReads?: number;
+}
+
+/**
+ * Predicate: the number of elements matching the selector has stopped changing.
+ * The canonical "a list finished loading" wait. This builder is STATEFUL — it
+ * returns a closure that tracks the previous count across polls; the
+ * `WaitForCondition` loop calls the predicate exactly once per poll in order, so
+ * the run counter mirrors `RealSettleObserve`'s `equalRun`. A count that keeps
+ * changing never settles and the loop's mandatory timeout governs. Note a count
+ * that is stable at zero (nothing ever matched) settles too — scope the selector
+ * so an empty result is a real answer, not a missed wait.
+ */
+export function countStable(
+  finder: ElementFinder,
+  selector: ConditionSelector,
+  options: CountStableOptions = {}
+): ConditionPredicate {
+  const stableReads = options.stableReads ?? 2;
+  let previousCount: number | undefined;
+  let equalRun = 0;
+  return (observation: ObserveResult): ConditionEvaluation => {
+    const viewHierarchy = observation.viewHierarchy;
+    const matches = viewHierarchy ? findAllMatches(finder, viewHierarchy, selector) : [];
+    const count = matches.length;
+    equalRun = previousCount !== undefined && count === previousCount ? equalRun + 1 : 1;
+    previousCount = count;
+    return { matched: equalRun >= stableReads, candidates: matches };
+  };
+}

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -5,6 +5,11 @@ import { RESOURCE_URIS } from "./observationResources";
 import { ActionableError } from "../models/ActionableError";
 import { RealObserveScreen } from "../features/observe/ObserveScreen";
 import type { ObserveScreen } from "../features/observe/interfaces/ObserveScreen";
+import { RealSettleObserve } from "../features/observe/SettleObserve";
+import { RealWaitForCondition } from "../features/observe/WaitForCondition";
+import type { SettleResult } from "../features/observe/interfaces/SettleObserve";
+import type { ConditionPredicate, WaitForConditionResult } from "../features/observe/interfaces/WaitForCondition";
+import { appear, disappear, clickable, textEquals, countStable, ConditionSelector } from "../features/observe/ConditionPredicates";
 import { createJSONToolResponse, createStructuredToolResponse, throwIfAborted, StructuredToolResponse } from "../utils/toolUtils";
 import { BootedDevice, Element, ObserveResult, ObserveToolPayload, ViewHierarchyResult } from "../models";
 import { createGlobalPerformanceTracker } from "../utils/PerformanceTracker";
@@ -105,7 +110,49 @@ const waitForPredicatePresenceSchema = z.union([
 
 const waitForElementSchema = waitForElementBaseSchema.and(waitForPredicatePresenceSchema);
 
+// Declarative predicate DSL (issue #4398): `for` selects a condition backed by a
+// #4389 primitive. Everything but `stable` is a WaitForCondition predicate; the
+// handler routes `stable` (whole-screen structural settle) to SettleObserve. The
+// legacy-only fields are declared `never` here so the inferred union stays
+// structurally compatible with the element/textAny arms (same pattern those arms
+// use to exclude each other), keeping the legacy handler's field access valid.
+const WAIT_FOR_CONDITION_KINDS = ["appear", "disappear", "clickable", "textEquals", "countStable"] as const;
+const WAIT_FOR_DSL_KINDS = [...WAIT_FOR_CONDITION_KINDS, "stable"] as const;
+
+const waitForConditionDslSchema = z.object({
+  for: z.enum(WAIT_FOR_DSL_KINDS).describe("Declarative condition to wait for"),
+  elementId: z.string().optional().describe("Element resource ID / accessibility identifier"),
+  text: z.string().optional().describe("Element text; for `textEquals` this is the exact expected value"),
+  pollMs: z.number().optional().describe("Poll interval ms (default 150)"),
+  stableReads: z.number().optional().describe("Consecutive stable reads for countStable/stable (default 2)"),
+  timeout: z.number().optional().describe("Wait timeout ms (default 5000; stable default 2500)"),
+  container: waitForContainerField,
+  textAny: z.never().optional(),
+  className: z.never().optional(),
+  contentDescription: z.never().optional(),
+  matchType: z.never().optional(),
+  textMatch: z.never().optional(),
+  activeWindow: z.never().optional(),
+}).strict().superRefine((value, ctx) => {
+  if (value.for === "stable") {
+    return;
+  }
+  if (value.elementId === undefined && value.text === undefined) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `waitFor "for: ${value.for}" requires elementId or text`
+    });
+  }
+  if (value.for === "textEquals" && value.text === undefined) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "waitFor \"for: textEquals\" requires text (the exact expected value)"
+    });
+  }
+});
+
 const waitForSchema = z.union([
+  waitForConditionDslSchema,
   waitForTextAnySchema,
   waitForElementSchema,
 ]);
@@ -127,12 +174,20 @@ const COMPACT_WAITFOR_ADVERTISED_SCHEMA: Record<string, unknown> = {
   type: "object",
   additionalProperties: false,
   description:
-    "Wait for a predicate before returning the observation. Provide at least one of: " +
-    "elementId, text, textAny, className, contentDescription, or activeWindow. " +
-    "textAny is mutually exclusive with the element predicates.",
+    "Wait for a predicate before returning the observation. Either set `for` (DSL: " +
+    "appear|disappear|clickable|textEquals|countStable|stable) with elementId/text, or " +
+    "provide a legacy predicate: elementId, text, textAny, className, contentDescription, " +
+    "or activeWindow. textAny is mutually exclusive with the element predicates.",
   properties: {
+    for: {
+      type: "string",
+      enum: ["appear", "disappear", "clickable", "textEquals", "countStable", "stable"],
+      description: "Condition: appear/disappear/clickable/textEquals/countStable (selector) or stable (whole screen)",
+    },
+    pollMs: { type: "number", description: "Poll interval ms (default 150)" },
+    stableReads: { type: "number", description: "Consecutive stable reads for countStable/stable (default 2)" },
     elementId: { type: "string", description: "Element resource ID / accessibility identifier" },
-    text: { type: "string", description: "Element text" },
+    text: { type: "string", description: "Element text; for `for:textEquals` the exact expected value" },
     textAny: {
       type: "array",
       items: { type: "string" },
@@ -180,9 +235,10 @@ const COMPACT_WAITFOR_ADVERTISED_SCHEMA: Record<string, unknown> = {
     },
     timeout: { type: "number", description: "Wait timeout ms (default 5000)" },
   },
-  // Enforce the same shape the runtime does: at least one predicate, and textAny
-  // mutually exclusive with the element predicates / matchType / textMatch.
+  // Enforce the same shape the runtime does: either the `for` DSL, or at least one
+  // legacy predicate with textAny mutually exclusive from the element predicates.
   anyOf: [
+    { required: ["for"] },
     {
       required: ["textAny"],
       not: {
@@ -190,7 +246,7 @@ const COMPACT_WAITFOR_ADVERTISED_SCHEMA: Record<string, unknown> = {
       },
     },
     {
-      not: { required: ["textAny"] },
+      not: { anyOf: [{ required: ["textAny"] }, { required: ["for"] }] },
       anyOf: [...ELEMENT_PREDICATE_REQUIRED, { required: ["activeWindow"] }],
     },
   ],
@@ -281,6 +337,39 @@ const observeBaseSchema = withJsonSchemaOverride(addDeviceTargetingToSchema(z.ob
 
 export const observeSchema = withAppIdAliases(observeBaseSchema);
 
+// Standalone settle/wait tools (issue #4398) expose the #4389 primitives directly.
+// They use the primitive option names (timeoutMs/pollMs/stableReads) so the tool
+// surface reads the same as the class it drives.
+export const settleObserveSchema = addDeviceTargetingToSchema(z.object({
+  platform: platformSchema,
+  timeoutMs: z.number().optional().describe("Hard budget ms (default 2500)"),
+  pollMs: z.number().optional().describe("Poll interval ms (default 150)"),
+  stableReads: z.number().optional().describe("Consecutive structurally-equal snapshots to settle (default 2)")
+}));
+
+export const waitForConditionSchema = addDeviceTargetingToSchema(z.object({
+  platform: platformSchema,
+  for: z.enum(WAIT_FOR_CONDITION_KINDS).describe("Condition: appear|disappear|clickable|textEquals|countStable"),
+  elementId: z.string().optional().describe("Element resource ID / accessibility identifier"),
+  text: z.string().optional().describe("Element text; for `textEquals` the exact expected value"),
+  timeoutMs: z.number().optional().describe("Hard budget ms (default 5000)"),
+  pollMs: z.number().optional().describe("Poll interval ms (default 150)"),
+  stableReads: z.number().optional().describe("Consecutive stable reads for countStable (default 2)")
+}).superRefine((value, ctx) => {
+  if (value.elementId === undefined && value.text === undefined) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `waitForCondition "for: ${value.for}" requires elementId or text`
+    });
+  }
+  if (value.for === "textEquals" && value.text === undefined) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "waitForCondition \"for: textEquals\" requires text (the exact expected value)"
+    });
+  }
+}));
+
 export const identifyInteractionsSchema = addDeviceTargetingToSchema(z.object({
   platform: platformSchema,
   filter: z.object({
@@ -301,6 +390,142 @@ const WAIT_FOR_POLL_INTERVAL_MS = 100;
 
 type ObserveWaitForOptions = z.infer<typeof waitForSchema>;
 type ObserveArgs = z.infer<typeof observeSchema>;
+type WaitForConditionDsl = z.infer<typeof waitForConditionDslSchema>;
+type WaitForConditionKind = (typeof WAIT_FOR_CONDITION_KINDS)[number];
+
+/** True when the waitFor options are the #4398 declarative `for` DSL form. */
+const isConditionDsl = (waitFor: ObserveWaitForOptions): waitFor is WaitForConditionDsl =>
+  (waitFor as { for?: unknown }).for !== undefined;
+
+/**
+ * Build the #4389 {@link ConditionPredicate} for a DSL `for` kind (issue #4398).
+ * `stable` is intentionally not handled here — the handler routes it to
+ * `RealSettleObserve` (whole-screen settle) rather than a predicate. Throws an
+ * `ActionableError` for `textEquals` without a `text` value, mirroring the zod
+ * refinement so the standalone tool path fails with the same actionable message.
+ */
+export const buildConditionPredicate = (
+  finder: ElementFinder,
+  kind: WaitForConditionKind,
+  selector: ConditionSelector,
+  options?: { stableReads?: number }
+): ConditionPredicate => {
+  switch (kind) {
+    case "appear":
+      return appear(finder, selector);
+    case "disappear":
+      return disappear(finder, selector);
+    case "clickable":
+      return clickable(finder, selector);
+    case "textEquals":
+      if (selector.text === undefined) {
+        throw new ActionableError("waitFor \"for: textEquals\" requires text (the exact expected value)");
+      }
+      return textEquals(finder, { elementId: selector.elementId }, selector.text);
+    case "countStable":
+      return countStable(finder, selector, options);
+    default: {
+      const exhaustive: never = kind;
+      throw new ActionableError(`Unknown waitFor condition: ${String(exhaustive)}`);
+    }
+  }
+};
+
+/**
+ * Run the declarative `for` DSL (issue #4398) and adapt its result to the shared
+ * `waitForObservation` return shape. `stable` runs the settle loop
+ * (`RealSettleObserve`); every other kind runs `RealWaitForCondition` with the
+ * predicate for that kind. `awaitedElement` carries the matched element (never set
+ * for settle / countStable, which have no single element); `awaitTimeout` reflects
+ * "did not settle" / "timed out". `container` is not yet threaded into the
+ * primitives' finder path — a follow-up.
+ */
+const runWaitForConditionDsl = async (
+  observeScreen: ObserveScreen,
+  waitFor: WaitForConditionDsl,
+  signal: AbortSignal | undefined,
+  timer: Timer
+): Promise<{ observation: ObserveResult; awaitedElement?: Element; awaitDuration: number; awaitTimeout: boolean }> => {
+  const pollMs = waitFor.pollMs;
+  if (waitFor.for === "stable") {
+    const settle = await new RealSettleObserve(observeScreen, timer).execute({
+      timeoutMs: waitFor.timeout,
+      pollMs,
+      stableReads: waitFor.stableReads,
+      signal,
+    });
+    return {
+      observation: settle.observation,
+      awaitedElement: undefined,
+      awaitDuration: settle.waitMs,
+      awaitTimeout: !settle.settled,
+    };
+  }
+
+  const finder = new DefaultElementFinder();
+  const predicate = buildConditionPredicate(
+    finder,
+    waitFor.for,
+    { elementId: waitFor.elementId, text: waitFor.text },
+    { stableReads: waitFor.stableReads }
+  );
+  const result = await new RealWaitForCondition(observeScreen, timer).execute(predicate, {
+    timeoutMs: waitFor.timeout,
+    pollMs,
+    signal,
+  });
+  return {
+    observation: result.observation,
+    awaitedElement: result.matchedElement,
+    awaitDuration: result.waitMs,
+    awaitTimeout: result.timedOut,
+  };
+};
+
+type SettleObserveArgs = z.infer<typeof settleObserveSchema>;
+type WaitForConditionArgs = z.infer<typeof waitForConditionSchema>;
+
+/**
+ * Core of the `settleObserve` tool (issue #4398): drive `RealSettleObserve` over
+ * the injected screen. Separated from the registered handler so it is testable
+ * with a fake screen + FakeTimer (no device, no ADB).
+ */
+export const runSettleObserveTool = async (
+  observeScreen: ObserveScreen,
+  args: SettleObserveArgs,
+  timer: Timer = defaultTimer,
+  signal?: AbortSignal
+): Promise<SettleResult> =>
+  new RealSettleObserve(observeScreen, timer).execute({
+    timeoutMs: args.timeoutMs,
+    pollMs: args.pollMs,
+    stableReads: args.stableReads,
+    signal,
+  });
+
+/**
+ * Core of the `waitForCondition` tool (issue #4398): build the predicate from the
+ * declarative selector and drive `RealWaitForCondition` over the injected screen.
+ */
+export const runWaitForConditionTool = async (
+  observeScreen: ObserveScreen,
+  args: WaitForConditionArgs,
+  timer: Timer = defaultTimer,
+  signal?: AbortSignal
+): Promise<WaitForConditionResult> => {
+  const finder = new DefaultElementFinder();
+  const predicate = buildConditionPredicate(
+    finder,
+    args.for,
+    { elementId: args.elementId, text: args.text },
+    { stableReads: args.stableReads }
+  );
+  return new RealWaitForCondition(observeScreen, timer).execute(predicate, {
+    timeoutMs: args.timeoutMs,
+    pollMs: args.pollMs,
+    signal,
+  });
+};
 
 const waitForContainerForFinder = (
   waitFor: ObserveWaitForOptions
@@ -588,6 +813,12 @@ export const waitForObservation = async (
   awaitDuration: number;
   awaitTimeout: boolean;
 }> => {
+  // Declarative `for` DSL (issue #4398) routes to the #4389 primitives; the
+  // legacy element/textAny/activeWindow path below is unchanged (back-compat).
+  if (isConditionDsl(waitFor)) {
+    return runWaitForConditionDsl(observeScreen, waitFor, signal, timer);
+  }
+
   const startTime = timer.now();
   const timeoutMs = waitFor.timeout ?? 5000;
   const finder = new DefaultElementFinder();
@@ -740,6 +971,50 @@ export function registerObserveTools() {
     }
   };
 
+  // settleObserve: poll until the screen is structurally stable, return only the
+  // final snapshot (issue #4398, primitive #4389). Mirrors the `shake` 5-step
+  // pattern — construct RealObserveScreen, delegate to the primitive core.
+  const settleObserveHandler = async (device: BootedDevice, args: SettleObserveArgs, _progress?: unknown, signal?: AbortSignal) => {
+    try {
+      const observeScreen = new RealObserveScreen(device);
+      const result = await runSettleObserveTool(observeScreen, args, defaultTimer, signal);
+      return createJSONToolResponse({
+        message: result.settled
+          ? `Screen settled after ${result.polls} polls (${result.waitMs}ms)`
+          : `Screen did not settle within budget (${result.polls} polls, ${result.waitMs}ms)`,
+        settled: result.settled,
+        polls: result.polls,
+        waitMs: result.waitMs,
+        observation: result.observation,
+      });
+    } catch (error) {
+      throw new ActionableError(`Failed to settle observe: ${error}`);
+    }
+  };
+
+  // waitForCondition: poll until a declarative predicate holds, returning the
+  // matched element or (on timeout) the last-seen near-matches (issue #4398).
+  const waitForConditionHandler = async (device: BootedDevice, args: WaitForConditionArgs, _progress?: unknown, signal?: AbortSignal) => {
+    try {
+      const observeScreen = new RealObserveScreen(device);
+      const result = await runWaitForConditionTool(observeScreen, args, defaultTimer, signal);
+      return createJSONToolResponse({
+        message: result.matched
+          ? `Condition "${args.for}" met after ${result.polls} polls (${result.waitMs}ms)`
+          : `Condition "${args.for}" not met within ${result.waitMs}ms; ${result.candidates.length} near-match(es)`,
+        matched: result.matched,
+        matchedElement: result.matchedElement,
+        candidates: result.candidates,
+        timedOut: result.timedOut,
+        polls: result.polls,
+        waitMs: result.waitMs,
+        observation: result.observation,
+      });
+    } catch (error) {
+      throw new ActionableError(`Failed to wait for condition: ${error}`);
+    }
+  };
+
   const identifyInteractionsHandler = async (
     device: BootedDevice,
     args: IdentifyInteractionsOptions
@@ -777,6 +1052,22 @@ export function registerObserveTools() {
     observeSchema,
     observeHandler,
     { outputSchema: observeToolResultSchema }
+  );
+
+  ToolRegistry.registerDeviceAware(
+    "settleObserve",
+    "Observe once the screen stops changing (structural settle); returns only the final snapshot.",
+    settleObserveSchema,
+    settleObserveHandler,
+    { supportsProgress: true }
+  );
+
+  ToolRegistry.registerDeviceAware(
+    "waitForCondition",
+    "Wait until a predicate holds: appear|disappear|clickable|textEquals|countStable.",
+    waitForConditionSchema,
+    waitForConditionHandler,
+    { supportsProgress: true }
   );
 
   ToolRegistry.registerDeviceAware("identifyInteractions", "Suggest likely interactions", identifyInteractionsSchema, identifyInteractionsHandler, { debugOnly: true });

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -67,6 +67,7 @@ const waitForCommonShape = {
 };
 
 const waitForTextAnySchema = z.object({
+  for: z.never().optional(),
   textAny: z.array(z.string().min(1)).min(1).describe("Ordered text variants; first visible match wins"),
   elementId: z.never().optional(),
   text: z.never().optional(),
@@ -78,6 +79,7 @@ const waitForTextAnySchema = z.object({
 }).strict();
 
 const waitForElementBaseSchema = z.object({
+  for: z.never().optional(),
   elementId: z.string().optional().describe("Element resource ID / accessibility identifier"),
   text: z.string().optional().describe("Element text"),
   textAny: z.never().optional(),
@@ -126,7 +128,12 @@ const waitForConditionDslSchema = z.object({
   pollMs: z.number().optional().describe("Poll interval ms (default 150)"),
   stableReads: z.number().optional().describe("Consecutive stable reads for countStable/stable (default 2)"),
   timeout: z.number().optional().describe("Wait timeout ms (default 5000; stable default 2500)"),
-  container: waitForContainerField,
+  // `container` is declared `never` (not accepted) on the DSL form: the #4389
+  // predicate builders match whole-screen (NO_CONTAINER), so accepting it would
+  // silently ignore it. Threading container scope into the predicates is a
+  // follow-up. `never` keeps the inferred union structurally compatible with the
+  // legacy arms (which do read `container`) while rejecting it on DSL requests.
+  container: z.never().optional(),
   textAny: z.never().optional(),
   className: z.never().optional(),
   contentDescription: z.never().optional(),

--- a/test/features/observe/ConditionPredicates.test.ts
+++ b/test/features/observe/ConditionPredicates.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from "bun:test";
+import type { ObserveResult } from "../../../src/models/ObserveResult";
+import { clickable, countStable, textEquals } from "../../../src/features/observe/ConditionPredicates";
+import { DefaultElementFinder } from "../../../src/features/utility/ElementFinder";
+
+/**
+ * Unit tests for the declarative condition-predicate builders that back the
+ * observe `waitFor` DSL and the standalone `waitForCondition` tool (issue #4398).
+ *
+ * `appear` / `disappear` are already covered in `WaitForCondition.test.ts`; this
+ * file pins the remaining builders — `clickable`, `textEquals`, `countStable` —
+ * as pure functions, driving each returned predicate directly (no poll loop, no
+ * device, no DB). `stable` is deliberately NOT a predicate: the DSL routes it to
+ * `RealSettleObserve` (whole-screen settle), so it has no builder here.
+ */
+
+/** Build an ObserveResult wrapping a single root node with the given children. */
+function obs(children: Record<string, unknown>[]): ObserveResult {
+  return {
+    updatedAt: 1,
+    screenSize: { width: 1080, height: 1920 },
+    systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+    activeWindow: { appId: "com.example", activityName: ".MainActivity", layoutSeqSum: 1 },
+    viewHierarchy: {
+      packageName: "com.example",
+      hierarchy: {
+        node: {
+          "resource-id": "root",
+          "bounds": { left: 0, top: 0, right: 100, bottom: 100 },
+          "node": children,
+        },
+      },
+    },
+  } as ObserveResult;
+}
+
+/** An ObserveResult with no hierarchy — the loop's screen-off / no-data shape. */
+function emptyObs(): ObserveResult {
+  return {
+    updatedAt: 1,
+    screenSize: { width: 1080, height: 1920 },
+    systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+    activeWindow: { appId: "com.example", activityName: ".MainActivity", layoutSeqSum: 1 },
+  } as ObserveResult;
+}
+
+function node(props: Record<string, unknown>): Record<string, unknown> {
+  return { "bounds": { left: 0, top: 0, right: 10, bottom: 10 }, ...props };
+}
+
+describe("clickable predicate", () => {
+  const finder = new DefaultElementFinder();
+
+  test("matches when the selector's element is present AND clickable", () => {
+    const predicate = clickable(finder, { elementId: "submit" });
+    const evaluation = predicate(obs([node({ "resource-id": "submit", "text": "Go", "clickable": true })]));
+    expect(evaluation.matched).toBe(true);
+    expect(evaluation.matchedElement!["resource-id"]).toBe("submit");
+  });
+
+  test("accepts the string-typed clickable attribute ('true')", () => {
+    const predicate = clickable(finder, { elementId: "submit" });
+    const evaluation = predicate(obs([node({ "resource-id": "submit", "text": "Go", "clickable": "true" })]));
+    expect(evaluation.matched).toBe(true);
+  });
+
+  test("does NOT match a present-but-not-clickable element, surfacing it as a candidate", () => {
+    const predicate = clickable(finder, { elementId: "submit" });
+    const evaluation = predicate(obs([node({ "resource-id": "submit", "text": "Go", "clickable": false })]));
+    expect(evaluation.matched).toBe(false);
+    expect(evaluation.candidates!.some(c => c["resource-id"] === "submit")).toBe(true);
+  });
+
+  test("does NOT match when the element is absent", () => {
+    const predicate = clickable(finder, { elementId: "submit" });
+    const evaluation = predicate(obs([node({ "resource-id": "other", "text": "x", "clickable": true })]));
+    expect(evaluation.matched).toBe(false);
+  });
+
+  test("no hierarchy reads as no-match, not a throw", () => {
+    const predicate = clickable(finder, { elementId: "submit" });
+    const evaluation = predicate(emptyObs());
+    expect(evaluation.matched).toBe(false);
+    expect(evaluation.candidates).toEqual([]);
+  });
+});
+
+describe("textEquals predicate", () => {
+  const finder = new DefaultElementFinder();
+
+  test("matches when the element located by elementId shows the expected text EXACTLY", () => {
+    const predicate = textEquals(finder, { elementId: "counter" }, "5");
+    const evaluation = predicate(obs([node({ "resource-id": "counter", "text": "5" })]));
+    expect(evaluation.matched).toBe(true);
+    expect(evaluation.matchedElement!.text).toBe("5");
+  });
+
+  test("does NOT match on a substring/partial text (exactness required)", () => {
+    const predicate = textEquals(finder, { elementId: "counter" }, "5");
+    const evaluation = predicate(obs([node({ "resource-id": "counter", "text": "50" })]));
+    expect(evaluation.matched).toBe(false);
+    // The located element is surfaced so a timeout shows what value it was stuck on.
+    expect(evaluation.candidates!.some(c => c.text === "50")).toBe(true);
+  });
+
+  test("without an elementId, matches any element whose text equals the expected value exactly", () => {
+    const predicate = textEquals(finder, {}, "Done");
+    const evaluation = predicate(obs([node({ "resource-id": "label", "text": "Done" })]));
+    expect(evaluation.matched).toBe(true);
+    expect(evaluation.matchedElement!.text).toBe("Done");
+  });
+
+  test("does NOT match when the located element is absent", () => {
+    const predicate = textEquals(finder, { elementId: "counter" }, "5");
+    const evaluation = predicate(obs([node({ "resource-id": "other", "text": "5" })]));
+    expect(evaluation.matched).toBe(false);
+  });
+});
+
+describe("countStable predicate", () => {
+  const finder = new DefaultElementFinder();
+
+  test("becomes stable once the matching-element count repeats for stableReads polls (default 2)", () => {
+    const predicate = countStable(finder, { elementId: "row" });
+    // Poll 1: 2 rows -> first read, run=1, not yet stable.
+    const first = predicate(obs([
+      node({ "resource-id": "row", "text": "a" }),
+      node({ "resource-id": "row", "text": "b" }),
+    ]));
+    expect(first.matched).toBe(false);
+    // Poll 2: 3 rows -> count changed, run resets.
+    const second = predicate(obs([
+      node({ "resource-id": "row", "text": "a" }),
+      node({ "resource-id": "row", "text": "b" }),
+      node({ "resource-id": "row", "text": "c" }),
+    ]));
+    expect(second.matched).toBe(false);
+    // Poll 3: still 3 rows -> count matches previous, run=2 >= 2 -> stable.
+    const third = predicate(obs([
+      node({ "resource-id": "row", "text": "a" }),
+      node({ "resource-id": "row", "text": "b" }),
+      node({ "resource-id": "row", "text": "c" }),
+    ]));
+    expect(third.matched).toBe(true);
+    expect(third.candidates!.length).toBe(3);
+  });
+
+  test("honors an explicit stableReads (3 consecutive equal counts)", () => {
+    const predicate = countStable(finder, { elementId: "row" }, { stableReads: 3 });
+    const rows = obs([node({ "resource-id": "row", "text": "a" })]);
+    expect(predicate(rows).matched).toBe(false); // run=1
+    expect(predicate(obs([node({ "resource-id": "row", "text": "a" })])).matched).toBe(false); // run=2
+    expect(predicate(obs([node({ "resource-id": "row", "text": "a" })])).matched).toBe(true); // run=3
+  });
+
+  test("a fluctuating count never settles (relies on the loop's timeout)", () => {
+    const predicate = countStable(finder, { elementId: "row" });
+    expect(predicate(obs([node({ "resource-id": "row", "text": "a" })])).matched).toBe(false);
+    expect(predicate(obs([
+      node({ "resource-id": "row", "text": "a" }),
+      node({ "resource-id": "row", "text": "b" }),
+    ])).matched).toBe(false);
+    expect(predicate(obs([node({ "resource-id": "row", "text": "a" })])).matched).toBe(false);
+  });
+});

--- a/test/features/observe/ConditionPredicates.test.ts
+++ b/test/features/observe/ConditionPredicates.test.ts
@@ -64,6 +64,12 @@ describe("clickable predicate", () => {
     expect(evaluation.matched).toBe(true);
   });
 
+  test("matches an element tappable via a 'click' accessibility action (clickable unset) — the iOS/tapOn signal", () => {
+    const predicate = clickable(finder, { elementId: "submit" });
+    const evaluation = predicate(obs([node({ "resource-id": "submit", "text": "Go", "actions": ["click"] })]));
+    expect(evaluation.matched).toBe(true);
+  });
+
   test("does NOT match a present-but-not-clickable element, surfacing it as a candidate", () => {
     const predicate = clickable(finder, { elementId: "submit" });
     const evaluation = predicate(obs([node({ "resource-id": "submit", "text": "Go", "clickable": false })]));

--- a/test/server/observeWaitForConditionDsl.test.ts
+++ b/test/server/observeWaitForConditionDsl.test.ts
@@ -1,0 +1,318 @@
+import { describe, expect, test } from "bun:test";
+import type { ObserveResult, ViewHierarchyResult } from "../../src/models";
+import {
+  buildConditionPredicate,
+  observeSchema,
+  registerObserveTools,
+  runSettleObserveTool,
+  runWaitForConditionTool,
+  settleObserveSchema,
+  waitForConditionSchema,
+  waitForObservation,
+} from "../../src/server/observeTools";
+import { DefaultElementFinder } from "../../src/features/utility/ElementFinder";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { FakeObserveScreen } from "../fakes/FakeObserveScreen";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+/**
+ * Tests for the observe `waitFor` predicate DSL and the standalone
+ * `settleObserve` / `waitForCondition` tools (issue #4398). These wire the
+ * #4389 primitives (RealSettleObserve, RealWaitForCondition, the predicate
+ * builders) into reachable MCP tool calls.
+ *
+ * All poll-loop cases run under FakeTimer + FakeObserveScreen — no device, no DB,
+ * < 100ms — the same seam `waitForObservation` was already tested through.
+ */
+
+const flatBounds = (left: number, top: number, right: number, bottom: number) => ({
+  left,
+  top,
+  right,
+  bottom,
+});
+
+/** A flat (resource-id-addressable) view hierarchy wrapping the given children. */
+const makeHierarchy = (children: Record<string, unknown>[]): ViewHierarchyResult =>
+  ({
+    hierarchy: {
+      node: {
+        "resource-id": "root",
+        "bounds": flatBounds(0, 0, 200, 200),
+        "node": children,
+      },
+    },
+    screenWidth: 200,
+    screenHeight: 200,
+  } as unknown as ViewHierarchyResult);
+
+const makeObservation = (
+  children: Record<string, unknown>[],
+  updatedAt = 0
+): ObserveResult =>
+  ({
+    updatedAt,
+    screenSize: { width: 200, height: 200 },
+    systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+    activeWindow: { appId: "com.example", activityName: ".Main", layoutSeqSum: 0 },
+    viewHierarchy: makeHierarchy(children),
+  } as ObserveResult);
+
+const node = (props: Record<string, unknown>): Record<string, unknown> => ({
+  "bounds": flatBounds(0, 0, 10, 10),
+  ...props,
+});
+
+// ---------------------------------------------------------------------------
+// buildConditionPredicate — the DSL branching (AC3 core)
+// ---------------------------------------------------------------------------
+describe("buildConditionPredicate", () => {
+  const finder = new DefaultElementFinder();
+
+  test("appear -> matches a present element", () => {
+    const predicate = buildConditionPredicate(finder, "appear", { elementId: "submit" });
+    expect(predicate(makeObservation([node({ "resource-id": "submit" })])).matched).toBe(true);
+  });
+
+  test("disappear -> matches an absent element", () => {
+    const predicate = buildConditionPredicate(finder, "disappear", { elementId: "spinner" });
+    expect(predicate(makeObservation([node({ "resource-id": "content" })])).matched).toBe(true);
+  });
+
+  test("clickable -> requires the element to be clickable", () => {
+    const predicate = buildConditionPredicate(finder, "clickable", { elementId: "btn" });
+    expect(predicate(makeObservation([node({ "resource-id": "btn", "clickable": false })])).matched).toBe(false);
+    expect(predicate(makeObservation([node({ "resource-id": "btn", "clickable": true })])).matched).toBe(true);
+  });
+
+  test("textEquals -> uses text as the exact expected value", () => {
+    const predicate = buildConditionPredicate(finder, "textEquals", { elementId: "counter", text: "5" });
+    expect(predicate(makeObservation([node({ "resource-id": "counter", "text": "50" })])).matched).toBe(false);
+    expect(predicate(makeObservation([node({ "resource-id": "counter", "text": "5" })])).matched).toBe(true);
+  });
+
+  test("countStable -> settles once the match count repeats", () => {
+    const predicate = buildConditionPredicate(finder, "countStable", { elementId: "row" }, { stableReads: 2 });
+    expect(predicate(makeObservation([node({ "resource-id": "row" })])).matched).toBe(false);
+    expect(predicate(makeObservation([node({ "resource-id": "row" })])).matched).toBe(true);
+  });
+
+  test("textEquals without text is rejected (text is the required expected value)", () => {
+    expect(() => buildConditionPredicate(finder, "textEquals", { elementId: "counter" })).toThrow(/text/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// observe waitFor DSL path via the injectable waitForObservation seam (AC3)
+// ---------------------------------------------------------------------------
+describe("waitForObservation DSL branch", () => {
+  test("for:'appear' polls until the element shows up and reports it as awaitedElement", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const observeScreen = new FakeObserveScreen();
+    observeScreen.setObserveSequence([
+      makeObservation([node({ "resource-id": "spinner" })], 10),
+      makeObservation([node({ "resource-id": "submit", "text": "Go" })], 20),
+    ]);
+
+    const outcome = await waitForObservation(
+      observeScreen,
+      { for: "appear", elementId: "submit" } as any,
+      undefined,
+      false,
+      timer
+    );
+
+    expect(outcome.awaitTimeout).toBe(false);
+    expect(outcome.awaitedElement?.["resource-id"]).toBe("submit");
+  });
+
+  test("for:'stable' routes to the settle loop and returns the final settled snapshot (no awaitedElement)", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const observeScreen = new FakeObserveScreen();
+    const settled = makeObservation([node({ "resource-id": "content", "text": "done" })], 30);
+    observeScreen.setObserveSequence([
+      makeObservation([node({ "resource-id": "content", "text": "loading" })], 10),
+      settled,
+      settled,
+    ]);
+
+    const outcome = await waitForObservation(
+      observeScreen,
+      { for: "stable" } as any,
+      undefined,
+      false,
+      timer
+    );
+
+    expect(outcome.awaitTimeout).toBe(false);
+    expect(outcome.awaitedElement).toBeUndefined();
+  });
+
+  test("for:'textEquals' waits until the located element shows the exact value", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const observeScreen = new FakeObserveScreen();
+    observeScreen.setObserveSequence([
+      makeObservation([node({ "resource-id": "counter", "text": "4" })], 10),
+      makeObservation([node({ "resource-id": "counter", "text": "5" })], 20),
+    ]);
+
+    const outcome = await waitForObservation(
+      observeScreen,
+      { for: "textEquals", elementId: "counter", text: "5" } as any,
+      undefined,
+      false,
+      timer
+    );
+
+    expect(outcome.awaitTimeout).toBe(false);
+    expect(outcome.awaitedElement?.text).toBe("5");
+  });
+
+  test("for:'appear' times out (no bare crash) when the element never appears", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const observeScreen = new FakeObserveScreen();
+    observeScreen.setObserveResult(index => makeObservation([node({ "resource-id": "spinner" })], (index + 1) * 10));
+
+    const outcome = await waitForObservation(
+      observeScreen,
+      { for: "appear", elementId: "submit", timeout: 300 } as any,
+      undefined,
+      false,
+      timer
+    );
+
+    expect(outcome.awaitTimeout).toBe(true);
+    expect(outcome.awaitedElement).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Back-compat: the legacy element-appear waitFor form is untouched (AC4)
+// ---------------------------------------------------------------------------
+describe("waitFor back-compat", () => {
+  test("legacy element-appear form (no `for`) still parses", () => {
+    const parsed = observeSchema.parse({
+      platform: "android",
+      waitFor: { elementId: "com.app:id/name", timeout: 8000 },
+    });
+    expect(parsed.waitFor).toMatchObject({ elementId: "com.app:id/name" });
+  });
+
+  test("legacy textAny form (no `for`) still parses", () => {
+    const parsed = observeSchema.parse({
+      platform: "android",
+      waitFor: { textAny: ["OK", "Done"] },
+    });
+    expect(parsed.waitFor).toMatchObject({ textAny: ["OK", "Done"] });
+  });
+
+  test("DSL form with `for` parses alongside the legacy forms", () => {
+    const parsed = observeSchema.parse({
+      platform: "android",
+      waitFor: { for: "clickable", elementId: "com.app:id/submit" },
+    });
+    expect(parsed.waitFor).toMatchObject({ for: "clickable", elementId: "com.app:id/submit" });
+  });
+
+  test("DSL `for: stable` needs no selector", () => {
+    const parsed = observeSchema.parse({
+      platform: "android",
+      waitFor: { for: "stable", timeout: 3000 },
+    });
+    expect(parsed.waitFor).toMatchObject({ for: "stable" });
+  });
+
+  test("DSL `for: appear` without a selector is rejected", () => {
+    expect(() =>
+      observeSchema.parse({ platform: "android", waitFor: { for: "appear" } })
+    ).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Standalone tool schemas (AC1 / AC2)
+// ---------------------------------------------------------------------------
+describe("settleObserveSchema", () => {
+  test("accepts an empty settle request (all defaults)", () => {
+    expect(settleObserveSchema.parse({ platform: "android" })).toMatchObject({ platform: "android" });
+  });
+
+  test("accepts tuning knobs", () => {
+    const parsed = settleObserveSchema.parse({ platform: "ios", timeoutMs: 4000, pollMs: 200, stableReads: 3 });
+    expect(parsed).toMatchObject({ timeoutMs: 4000, pollMs: 200, stableReads: 3 });
+  });
+});
+
+describe("waitForConditionSchema", () => {
+  test("accepts a valid appear condition", () => {
+    expect(waitForConditionSchema.parse({ platform: "android", for: "appear", elementId: "x" })).toMatchObject({
+      for: "appear",
+      elementId: "x",
+    });
+  });
+
+  test("does not offer `stable` (that is the settleObserve tool)", () => {
+    expect(() => waitForConditionSchema.parse({ platform: "android", for: "stable" })).toThrow();
+  });
+
+  test("requires a selector for appear", () => {
+    expect(() => waitForConditionSchema.parse({ platform: "android", for: "appear" })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Standalone tool handler cores (AC1 / AC2) — injected ObserveScreen + timer
+// ---------------------------------------------------------------------------
+describe("runSettleObserveTool", () => {
+  test("returns the settled final snapshot", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const observeScreen = new FakeObserveScreen();
+    const settled = makeObservation([node({ "resource-id": "content", "text": "done" })], 30);
+    observeScreen.setObserveSequence([
+      makeObservation([node({ "resource-id": "content", "text": "loading" })], 10),
+      settled,
+      settled,
+    ]);
+
+    const result = await runSettleObserveTool(observeScreen, { platform: "android" } as any, timer);
+    expect(result.settled).toBe(true);
+    expect(result.observation.viewHierarchy).toBeDefined();
+  });
+});
+
+describe("runWaitForConditionTool", () => {
+  test("builds the predicate from the DSL and resolves with the matched element", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const observeScreen = new FakeObserveScreen();
+    observeScreen.setObserveSequence([
+      makeObservation([node({ "resource-id": "spinner" })], 10),
+      makeObservation([node({ "resource-id": "submit", "text": "Go" })], 20),
+    ]);
+
+    const result = await runWaitForConditionTool(
+      observeScreen,
+      { platform: "android", for: "appear", elementId: "submit" } as any,
+      timer
+    );
+    expect(result.matched).toBe(true);
+    expect(result.matchedElement?.["resource-id"]).toBe("submit");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Registration (AC1 / AC2) — the tools are reachable from the registry
+// ---------------------------------------------------------------------------
+describe("tool registration", () => {
+  test("registers settleObserve and waitForCondition as device-aware tools", () => {
+    registerObserveTools();
+    const names = ToolRegistry.getAllTools({ includeUnavailable: true }).map(tool => tool.name);
+    expect(names).toContain("settleObserve");
+    expect(names).toContain("waitForCondition");
+  });
+});

--- a/test/server/observeWaitForConditionDsl.test.ts
+++ b/test/server/observeWaitForConditionDsl.test.ts
@@ -231,6 +231,28 @@ describe("waitFor back-compat", () => {
       observeSchema.parse({ platform: "android", waitFor: { for: "appear" } })
     ).toThrow();
   });
+
+  test("mixing `for` with a legacy-only field (activeWindow) is rejected, not silently dropped", () => {
+    // Regression guard: the DSL arm declares activeWindow as `never`, and the legacy
+    // arms declare `for` as `never`, so a `for`+activeWindow request matches no arm.
+    // Without the legacy-arm `for: never`, the passthrough element arm re-admitted
+    // `for` and silently discarded activeWindow.
+    expect(() =>
+      observeSchema.parse({
+        platform: "android",
+        waitFor: { for: "appear", elementId: "x", activeWindow: { appId: "com.z" } },
+      })
+    ).toThrow();
+  });
+
+  test("mixing `for` with a legacy-only element field (className) is rejected", () => {
+    expect(() =>
+      observeSchema.parse({
+        platform: "android",
+        waitFor: { for: "appear", elementId: "x", className: "android.widget.Button" },
+      })
+    ).toThrow();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -309,9 +331,12 @@ describe("runWaitForConditionTool", () => {
 // Registration (AC1 / AC2) — the tools are reachable from the registry
 // ---------------------------------------------------------------------------
 describe("tool registration", () => {
-  test("registers settleObserve and waitForCondition as device-aware tools", () => {
+  test("registers settleObserve and waitForCondition as served (not debug-only) device-aware tools", () => {
     registerObserveTools();
-    const names = ToolRegistry.getAllTools({ includeUnavailable: true }).map(tool => tool.name);
+    // The default getAllTools() is the served, availability-filtered set — asserting
+    // against it (not includeUnavailable) proves the tools are actually reachable,
+    // not merely present but gated off as debugOnly.
+    const names = ToolRegistry.getAllTools().map(tool => tool.name);
     expect(names).toContain("settleObserve");
     expect(names).toContain("waitForCondition");
   });


### PR DESCRIPTION
## Summary

Wires the observe primitives that [#4389](https://github.com/kaeawc/auto-mobile/issues/4389) / [PR #4395](https://github.com/kaeawc/auto-mobile/pull/4395) shipped as tested-but-unreachable classes into actual MCP tool calls. This is the deferred **wiring** slice — it changes public tool schemas, which is why it was kept out of the primitives PR.

## Linked Issue

Closes #4398

## Changes

- **Two new device-aware tools** (`ToolRegistry.registerDeviceAware`, the `shake` 5-step pattern, reusing `RealObserveScreen.execute()`):
  - `settleObserve` → `RealSettleObserve` (poll until the hierarchy is structurally stable; returns only the final snapshot).
  - `waitForCondition` → `RealWaitForCondition` (poll until a declarative predicate holds; returns the matched element or, on timeout, last-seen near-matches).
- **Generalized `observe.waitFor` into a declarative predicate DSL** — `for: "appear" | "disappear" | "clickable" | "textEquals" | "countStable" | "stable"`. The handler branches: `stable` routes to `RealSettleObserve` (whole-screen settle); every other kind routes to `RealWaitForCondition`. The legacy element / `textAny` / `activeWindow` `waitFor` forms are **untouched** — `for` is an additive union arm, so back-compat is preserved.
- **Remaining `ConditionPredicate` builders** — `clickable`, `textEquals`, `countStable` (PR #4395 shipped only `appear`/`disappear`). `countStable` is a stateful closure mirroring `RealSettleObserve`'s `equalRun`.
- **Regenerated `schemas/tool-definitions.json`** via `scripts/generate-tool-definitions.ts` (74 tools).

`stable` routes to `SettleObserve` rather than being a predicate (per the "branch to WaitForCondition / SettleObserve" scope); it is therefore not a `ConditionPredicate` builder.

## Acceptance criteria → coverage

| Criterion | Where |
|---|---|
| `settleObserve` reachable → `RealSettleObserve` | `registerObserveTools`; `runSettleObserveTool` + registration tests |
| `waitForCondition` reachable → `RealWaitForCondition` | `registerObserveTools`; `runWaitForConditionTool` + registration tests |
| `observe.waitFor` DSL branches to WaitFor/Settle | `waitForObservation` DSL branch; `observeWaitForConditionDsl.test.ts` |
| Back-compat with legacy `waitFor` | additive union arm; back-compat tests + existing `observeWaitForSchema.test.ts` green |
| `clickable`/`textEquals`/`countStable` builders | `ConditionPredicates.ts`; `ConditionPredicates.test.ts` |
| Regenerate `tool-definitions.json` | committed; `toolRegistration.test.ts` sync gate green |
| On-device verify (Android + iOS) | see Device Verification below |

## Validation

- [x] `bun run lint` + `bun test` pass (9327 pass / 0 fail)
- [x] `bun run typecheck` reports no new errors (baseline refreshed for a positional shift only, count-neutral at 211)
- [x] New code uses interfaces + fakes + FakeTimer; unit tests run in <100ms
- [x] MCP context-threshold gate green (Tools 14763/15000)
- [x] Rebased onto latest `main`

## Device Verification

Verified on-device with the daemon rebuilt from this branch (`0.0.45+g62721e5d2`), driven via the `--cli` path:

- **iOS simulator (iPhone 16 Pro):**
  - `settleObserve` → `settled: true`, 2 polls, 453ms (real structural convergence on springboard).
  - `waitForCondition for:appear text=Safari` → matched, `matchedElement.text=Safari`, 1 poll/247ms.
  - `waitForCondition for:disappear` (absent) → matched, 1 poll/248ms.
  - `waitForCondition for:appear` (absent) → `timedOut: true`, structured result (not a bare false).
  - `observe waitFor {for:appear}` → routed to WaitForCondition (`awaitedElement.text=Safari`, `awaitTimeout:false`).
  - `observe waitFor {for:stable}` → routed to SettleObserve (`awaitedElement:undefined`, `awaitTimeout:false`).
  - `observe waitFor {text:Safari}` (legacy, no `for`) → back-compat path intact.
- **Android emulator-5554:** `settleObserve` reached `RealSettleObserve` and returned a correct `SettleResult`; the budget-exceeded and screen-off fast-fail paths were exercised on a real device. Full `settled:true` convergence was blocked only by the shared emulator being stuck in an `Asleep` power state (device artifact, not a code issue — the same code path returned `settled:true` on iOS).

The shared daemon was restored to the mainline build afterward.

## Risk

Higher-risk: touches **public tool schemas** (two new tools + generalized `observe.waitFor`). Merge decision left to a human per the ship-issue conservative gate.

