### PR TITLE
feat(ctrl-proxy): skip Android APK prefetch when Android prerequisites are absent

### DIFF
--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -24,6 +24,10 @@ import { type FileDownloader, DefaultFileDownloader } from "./FileDownloader";
 import { type ChecksumCalculator, DefaultChecksumCalculator } from "./ChecksumCalculator";
 import type { ProxyManager, ProxySetupResult } from "./interfaces/ProxyManager";
 import { resolvePathFromDaemonLaunchWorkingDirectory } from "./workingDirectory";
+import {
+  type AndroidPrerequisiteDetector,
+  DefaultAndroidPrerequisiteDetector
+} from "./android-cmdline-tools/AndroidPrerequisiteDetector";
 
 /**
  * Android-specific accessibility-service lifecycle, extending the
@@ -120,6 +124,11 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
   private readonly checksumCalculator: ChecksumCalculator;
   private static readonly defaultFileDownloader: FileDownloader = new DefaultFileDownloader();
   private static readonly defaultChecksumCalculator: ChecksumCalculator = new DefaultChecksumCalculator();
+
+  // Gate that decides whether the startup APK prefetch should run at all (#4404).
+  private static androidPrerequisiteDetector: AndroidPrerequisiteDetector = new DefaultAndroidPrerequisiteDetector();
+  // Test seam for the static prefetch's downloader; null uses defaultFileDownloader.
+  private static prefetchFileDownloaderOverride: FileDownloader | null = null;
 
   private constructor(
     device: BootedDevice,
@@ -232,6 +241,18 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
    * Internal prefetch implementation
    */
   private static async doPrefetch(): Promise<string | null> {
+    // Skip cleanly in environments that cannot consume the APK. Without ADB (and
+    // the SDK tooling behind it) no Android device work is possible, so there is
+    // no reason to download and verify the APK during startup (#4404). Returning
+    // null (not throwing) keeps the daemon healthy and non-Android workflows intact.
+    if (!(await AndroidCtrlProxyManager.androidPrerequisiteDetector.hasAndroidPrerequisites())) {
+      logger.info(
+        "[CTRL_PROXY] Prefetch skipped: Android prerequisites (adb/SDK) not detected; " +
+        "the APK is only needed for Android device work"
+      );
+      return null;
+    }
+
     // Fail closed before touching the network: don't background-download and cache
     // an unverifiable APK for an unknown explicit pin (#2746). Skipping (not
     // throwing) keeps daemon startup alive; the install path still fails closed.
@@ -250,7 +271,8 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       // Download the APK (URL honors AUTOMOBILE_VERSION + AUTOMOBILE_ASSET_BASE_URL)
       const apkUrl = resolveApkUrl();
       logger.info("[CTRL_PROXY] Prefetch: downloading APK", { url: apkUrl, destination: apkPath });
-      await AndroidCtrlProxyManager.defaultFileDownloader.download(apkUrl, apkPath);
+      const downloader = AndroidCtrlProxyManager.prefetchFileDownloaderOverride ?? AndroidCtrlProxyManager.defaultFileDownloader;
+      await downloader.download(apkUrl, apkPath);
 
       // Verify the file exists and has reasonable size
       const stats = await fs.stat(apkPath);
@@ -450,6 +472,16 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
 
   public static setAccessibilityDetectorForTesting(detector: AccessibilityDetector | null): void {
     AndroidCtrlProxyManager.accessibilityDetectorOverride = detector;
+  }
+
+  /** Override the Android-prerequisite gate for the prefetch (#4404). Null restores the default detector. */
+  public static setAndroidPrerequisiteDetectorForTesting(detector: AndroidPrerequisiteDetector | null): void {
+    AndroidCtrlProxyManager.androidPrerequisiteDetector = detector ?? new DefaultAndroidPrerequisiteDetector();
+  }
+
+  /** Override the downloader used by the static prefetch (#4404). Null restores the default. */
+  public static setPrefetchFileDownloaderForTesting(downloader: FileDownloader | null): void {
+    AndroidCtrlProxyManager.prefetchFileDownloaderOverride = downloader;
   }
 
   private getAccessibilityDetector(): AccessibilityDetector {

--- a/src/utils/android-cmdline-tools/AndroidPrerequisiteDetector.ts
+++ b/src/utils/android-cmdline-tools/AndroidPrerequisiteDetector.ts
@@ -1,0 +1,61 @@
+import { join } from "path";
+import { SystemDetection, DefaultSystemDetection } from "../system/SystemDetection";
+import {
+  isToolInPath,
+  getAndroidSdkFromEnvironment,
+  detectAndroidSdkTools,
+  detectHomebrewAndroidTools
+} from "./detection";
+
+/**
+ * Detects whether the Android prerequisites needed to consume a CtrlProxy APK
+ * are present. Used to gate startup-time work (e.g. the APK prefetch) so
+ * environments without Android tooling don't do unnecessary network/disk work.
+ */
+export interface AndroidPrerequisiteDetector {
+  /**
+   * Resolve to true when Android device work is possible in this environment.
+   * The minimum requirement is ADB; SDK tooling is accepted as a positive signal.
+   */
+  hasAndroidPrerequisites(): Promise<boolean>;
+}
+
+/**
+ * Default ADB-centric detector. Android device work fundamentally needs ADB to
+ * install and talk to the APK, so ADB availability is the minimum gate. An SDK
+ * install (env var or detected cmdline-tools) implies bundled platform-tools and
+ * is treated as a positive signal too.
+ */
+export class DefaultAndroidPrerequisiteDetector implements AndroidPrerequisiteDetector {
+  private readonly systemDetection: SystemDetection;
+
+  constructor(systemDetection: SystemDetection = new DefaultSystemDetection()) {
+    this.systemDetection = systemDetection;
+  }
+
+  async hasAndroidPrerequisites(): Promise<boolean> {
+    // 1. ADB on PATH is the strongest signal the APK can be consumed.
+    if (await isToolInPath("adb", this.systemDetection)) {
+      return true;
+    }
+
+    // 2. An SDK env var pointing at a real platform-tools/adb binary.
+    const sdkPath = getAndroidSdkFromEnvironment(this.systemDetection);
+    if (sdkPath) {
+      const adbBinary = this.systemDetection.getCurrentPlatform() === "win32" ? "adb.exe" : "adb";
+      if (this.systemDetection.fileExistsSync(join(sdkPath, "platform-tools", adbBinary))) {
+        return true;
+      }
+    }
+
+    // 3. A detected cmdline-tools installation implies an SDK (and its bundled
+    //    platform-tools/adb) is present. Use the uncached detectors directly so
+    //    this gate never reads or writes the shared detection cache.
+    const homebrew = await detectHomebrewAndroidTools(this.systemDetection);
+    if (homebrew) {
+      return true;
+    }
+    const sdkLocations = await detectAndroidSdkTools(this.systemDetection);
+    return sdkLocations.length > 0;
+  }
+}

--- a/test/utils/CtrlProxyManager.test.ts
+++ b/test/utils/CtrlProxyManager.test.ts
@@ -46,6 +46,13 @@ describe("CtrlProxyManager", function() {
     // Reset singleton instances
     AndroidCtrlProxyManager.resetInstances();
 
+    // These tests exercise download/checksum/retry behavior, not the prefetch
+    // prerequisite gate (#4404). Neutralize the gate so the default detector
+    // doesn't skip the prefetch on CI hosts without Android tooling (e.g. Windows).
+    AndroidCtrlProxyManager.setAndroidPrerequisiteDetectorForTesting({
+      hasAndroidPrerequisites: async () => true
+    });
+
     accessibilityServiceClient = AndroidCtrlProxyManager.getInstance(testDevice, fakeAdbFactory);
     accessibilityServiceClient.clearAvailabilityCache();
   });
@@ -53,6 +60,7 @@ describe("CtrlProxyManager", function() {
   afterEach(async function() {
     AndroidCtrlProxyManager.setExpectedChecksumForTesting(null);
     AndroidCtrlProxyManager.setAccessibilityDetectorForTesting(null);
+    AndroidCtrlProxyManager.setAndroidPrerequisiteDetectorForTesting(null);
     await AndroidCtrlProxyManager.cleanupPrefetchedApk();
     if (originalApkPathEnv === undefined) {
       delete process.env.AUTOMOBILE_CTRL_PROXY_APK_PATH;

--- a/test/utils/android-cmdline-tools/AndroidPrerequisiteDetector.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidPrerequisiteDetector.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { DefaultAndroidPrerequisiteDetector } from "../../../src/utils/android-cmdline-tools/AndroidPrerequisiteDetector";
+import { FakeSystemDetection } from "../../fakes/FakeSystemDetection";
+
+describe("DefaultAndroidPrerequisiteDetector", function() {
+  let system: FakeSystemDetection;
+
+  beforeEach(function() {
+    system = new FakeSystemDetection();
+    system.setPlatform("linux");
+  });
+
+  test("returns true when adb is on PATH", async function() {
+    system.setExecResponse("which adb", "/usr/bin/adb\n");
+
+    const detector = new DefaultAndroidPrerequisiteDetector(system);
+
+    expect(await detector.hasAndroidPrerequisites()).toBe(true);
+  });
+
+  test("returns true when ANDROID_HOME points at a real platform-tools/adb", async function() {
+    system.setEnvVar("ANDROID_HOME", "/opt/android-sdk");
+    system.addExistingFile("/opt/android-sdk");
+    system.addExistingFile("/opt/android-sdk/platform-tools/adb");
+
+    const detector = new DefaultAndroidPrerequisiteDetector(system);
+
+    expect(await detector.hasAndroidPrerequisites()).toBe(true);
+  });
+
+  test("returns true when cmdline-tools are detected via ANDROID_HOME", async function() {
+    system.setEnvVar("ANDROID_HOME", "/opt/android-sdk");
+    system.addExistingFile("/opt/android-sdk");
+    const binDir = "/opt/android-sdk/cmdline-tools/latest/bin";
+    system.addExistingFile("/opt/android-sdk/cmdline-tools/latest");
+    system.addExistingFile(binDir);
+    system.addExistingFile(`${binDir}/sdkmanager`);
+
+    const detector = new DefaultAndroidPrerequisiteDetector(system);
+
+    expect(await detector.hasAndroidPrerequisites()).toBe(true);
+  });
+
+  test("returns false when no adb and no SDK tooling exist", async function() {
+    // No exec response for `which adb` -> FakeSystemDetection throws (not found).
+    // No env vars, no files.
+    const detector = new DefaultAndroidPrerequisiteDetector(system);
+
+    expect(await detector.hasAndroidPrerequisites()).toBe(false);
+  });
+
+  test("returns false when an SDK env var is set but platform-tools/adb is absent", async function() {
+    system.setEnvVar("ANDROID_HOME", "/opt/android-sdk");
+    system.addExistingFile("/opt/android-sdk");
+    // platform-tools/adb intentionally not added, and no cmdline-tools present.
+
+    const detector = new DefaultAndroidPrerequisiteDetector(system);
+
+    expect(await detector.hasAndroidPrerequisites()).toBe(false);
+  });
+});

--- a/test/utils/ctrlProxyPrefetchGate.test.ts
+++ b/test/utils/ctrlProxyPrefetchGate.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { AndroidCtrlProxyManager } from "../../src/utils/CtrlProxyManager";
+import type { AndroidPrerequisiteDetector } from "../../src/utils/android-cmdline-tools/AndroidPrerequisiteDetector";
+import { FakeFileDownloader } from "../fakes/FakeFileDownloader";
+
+/**
+ * Gate for the startup APK prefetch: it must skip cleanly when Android
+ * prerequisites are absent and still download when they are present (#4404).
+ */
+describe("AndroidCtrlProxyManager prefetch prerequisite gate", function() {
+  let fakeDownloader: FakeFileDownloader;
+  let originalApkPathEnv: string | undefined;
+
+  const detectorReturning = (value: boolean): AndroidPrerequisiteDetector => ({
+    hasAndroidPrerequisites: async () => value
+  });
+
+  beforeEach(async function() {
+    originalApkPathEnv = process.env.AUTOMOBILE_CTRL_PROXY_APK_PATH;
+    // The local-APK override short-circuits prefetch entirely; keep it unset.
+    delete process.env.AUTOMOBILE_CTRL_PROXY_APK_PATH;
+    await AndroidCtrlProxyManager.cleanupPrefetchedApk();
+    fakeDownloader = new FakeFileDownloader();
+    AndroidCtrlProxyManager.setPrefetchFileDownloaderForTesting(fakeDownloader);
+  });
+
+  afterEach(async function() {
+    AndroidCtrlProxyManager.setAndroidPrerequisiteDetectorForTesting(null);
+    AndroidCtrlProxyManager.setPrefetchFileDownloaderForTesting(null);
+    await AndroidCtrlProxyManager.cleanupPrefetchedApk();
+    if (originalApkPathEnv === undefined) {
+      delete process.env.AUTOMOBILE_CTRL_PROXY_APK_PATH;
+    } else {
+      process.env.AUTOMOBILE_CTRL_PROXY_APK_PATH = originalApkPathEnv;
+    }
+  });
+
+  test("does not download the APK when Android prerequisites are absent", async function() {
+    AndroidCtrlProxyManager.setAndroidPrerequisiteDetectorForTesting(detectorReturning(false));
+
+    AndroidCtrlProxyManager.prefetchApk();
+    // Draining the prefetch promise must resolve null without throwing, so the
+    // daemon stays healthy and non-Android workflows are unaffected.
+    const result = await AndroidCtrlProxyManager.getPrefetchedApkPath();
+
+    expect(result).toBeNull();
+    expect(fakeDownloader.downloadedUrls).toHaveLength(0);
+  });
+
+  test("attempts the APK download when Android prerequisites are present", async function() {
+    AndroidCtrlProxyManager.setAndroidPrerequisiteDetectorForTesting(detectorReturning(true));
+
+    AndroidCtrlProxyManager.prefetchApk();
+    await AndroidCtrlProxyManager.getPrefetchedApkPath();
+
+    // The gate let the prefetch through, so the download was attempted.
+    expect(fakeDownloader.downloadedUrls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Daemon startup unconditionally prefetched (downloaded + verified) the Android CtrlProxy APK, doing needless network/disk work in environments that cannot run Android device work because ADB/SDK tooling is unavailable.

This adds an ADB-centric prerequisite gate that the prefetch consults before any network/disk work. When neither `adb` on PATH, an SDK env var pointing at a real `platform-tools/adb`, nor a detected SDK install is present, the prefetch **skips cleanly** — it returns `null` and logs a concise non-error diagnostic, mirroring the existing `isPinnedVersionUnverifiable()` fail-safe skip. Skipping (not throwing) keeps the daemon healthy and non-Android workflows unaffected; environments with Android tooling prefetch exactly as before.

The default detector uses the **uncached** SDK detectors (`detectAndroidSdkTools` / `detectHomebrewAndroidTools`) rather than the globally-cached `detectAndroidCommandLineTools`, so the gate never reads or writes shared detection-cache state (which would otherwise cross-contaminate concurrent tests).

## Changes

- New `src/utils/android-cmdline-tools/AndroidPrerequisiteDetector.ts` — `AndroidPrerequisiteDetector` interface + `DefaultAndroidPrerequisiteDetector` (injectable `SystemDetection`).
- `CtrlProxyManager.doPrefetch()` gates on the detector before download; new `setAndroidPrerequisiteDetectorForTesting` / `setPrefetchFileDownloaderForTesting` seams.

## Linked Issue

Closes #4404

## Acceptance criteria

- [x] An environment without Android tooling does not download an Android CtrlProxy APK during daemon startup — pinned by `ctrlProxyPrefetchGate.test.ts` (detector=false ⇒ `FakeFileDownloader` never called).
- [x] The skipped prefetch does not make the daemon unhealthy or affect non-Android workflows — `getPrefetchedApkPath()` resolves `null` without throwing.
- [x] Environments with the required Android tooling continue to prefetch — same suite (detector=true ⇒ download attempted).
- [x] Unit coverage verifies both paths — plus `AndroidPrerequisiteDetector.test.ts` drives present/absent tooling via `FakeSystemDetection`.

## Validation

- [x] `bun run lint` + `bun test` pass (9299 pass, 0 fail)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] New code uses interfaces + fakes; unit tests run in <100ms

## Follow-ups

- None.
