### PR TITLE
feat(ctrl-proxy): skip iOS runner prefetch when Xcode prerequisites are absent

### DIFF
--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -34,6 +34,10 @@ import {
   SKIP_CTRL_PROXY_DOWNLOAD_ENV,
   isTruthyEnvValue,
 } from "./ctrlProxyDownloadControl";
+import {
+  type IosPrerequisiteDetector,
+  DefaultIosPrerequisiteDetector
+} from "./ios-cmdline-tools/IosPrerequisiteDetector";
 
 /**
  * Result of CtrlProxy download/install
@@ -60,6 +64,16 @@ interface CtrlProxyIosBuildConfig {
 interface CtrlProxyIosBuilderDependencies {
   downloader?: CtrlProxyIosBundleDownloader;
 }
+
+/**
+ * The narrow builder surface {@link IOSCtrlProxyBuilder.doPrefetch} drives.
+ * Exposed so the prefetch gate can be tested without a real build/download
+ * (issue #4407); grow it only when the prefetch needs another method.
+ */
+export type PrefetchBuilder = Pick<
+  IOSCtrlProxyBuilder,
+  "needsRebuild" | "getBuildProductsPath" | "getXctestrunPath" | "build"
+>;
 
 type IOSCtrlProxyPlatform = "simulator" | "device";
 
@@ -98,6 +112,12 @@ export class IOSCtrlProxyBuilder {
   private static expectedRunnerChecksumOverride: string | null = null;
   private static expectedRunnerChecksumTargetOverride: RunnerSha256Target | null = null;
   private static timer: Timer = defaultTimer;
+
+  // Gate that decides whether the startup runner-bundle prefetch should run at
+  // all (issue #4407). Skips cleanly on hosts without a usable Xcode toolchain.
+  private static iosPrerequisiteDetector: IosPrerequisiteDetector = new DefaultIosPrerequisiteDetector();
+  // Test seam for the builder the static prefetch drives; null uses getInstance().
+  private static prefetchBuilderOverride: PrefetchBuilder | null = null;
 
   // Singleton instances per configuration
   private static instances: Map<string, IOSCtrlProxyBuilder> = new Map();
@@ -163,6 +183,8 @@ export class IOSCtrlProxyBuilder {
     IOSCtrlProxyBuilder.expectedRunnerChecksumOverride = null;
     IOSCtrlProxyBuilder.expectedRunnerChecksumTargetOverride = null;
     IOSCtrlProxyBuilder.timer = defaultTimer;
+    IOSCtrlProxyBuilder.iosPrerequisiteDetector = new DefaultIosPrerequisiteDetector();
+    IOSCtrlProxyBuilder.prefetchBuilderOverride = null;
   }
 
   /**
@@ -177,6 +199,16 @@ export class IOSCtrlProxyBuilder {
    */
   public static setExpectedChecksumForTesting(checksum: string | null): void {
     IOSCtrlProxyBuilder.expectedChecksumOverride = checksum;
+  }
+
+  /** Override the iOS-prerequisite gate for the prefetch (issue #4407). Null restores the default detector. */
+  public static setIosPrerequisiteDetectorForTesting(detector: IosPrerequisiteDetector | null): void {
+    IOSCtrlProxyBuilder.iosPrerequisiteDetector = detector ?? new DefaultIosPrerequisiteDetector();
+  }
+
+  /** Override the builder driven by the static prefetch (issue #4407). Null restores getInstance(). */
+  public static setPrefetchBuilderForTesting(builder: PrefetchBuilder | null): void {
+    IOSCtrlProxyBuilder.prefetchBuilderOverride = builder;
   }
 
   public static setExpectedRunnerChecksumForTesting(
@@ -550,7 +582,20 @@ export class IOSCtrlProxyBuilder {
    * Internal prefetch implementation
    */
   private static async doPrefetch(): Promise<CtrlProxyIosBuildResult | null> {
-    const builder = IOSCtrlProxyBuilder.getInstance();
+    // Skip cleanly on hosts that cannot consume the runner. Without the Xcode
+    // toolchain (xcrun/xcodebuild) the bundle can never be installed or run, so
+    // there is no reason to download and extract it at startup (issue #4407).
+    // Returning null (not throwing) keeps the daemon healthy and non-iOS
+    // workflows intact; the on-demand build path still runs when a device connects.
+    if (!(await IOSCtrlProxyBuilder.iosPrerequisiteDetector.hasIosPrerequisites())) {
+      logger.info(
+        "[IOSCtrlProxyBuilder] Prefetch skipped: iOS prerequisites (xcrun/xcodebuild) not detected; " +
+        "the runner bundle is only needed for iOS device work"
+      );
+      return null;
+    }
+
+    const builder: PrefetchBuilder = IOSCtrlProxyBuilder.prefetchBuilderOverride ?? IOSCtrlProxyBuilder.getInstance();
     const needsDownload = await builder.needsRebuild();
     if (!needsDownload) {
       const buildPath = await builder.getBuildProductsPath();

--- a/src/utils/ios-cmdline-tools/IosPrerequisiteDetector.ts
+++ b/src/utils/ios-cmdline-tools/IosPrerequisiteDetector.ts
@@ -1,0 +1,57 @@
+import { SystemDetection, DefaultSystemDetection } from "../system/SystemDetection";
+import { logger } from "../logger";
+
+/**
+ * Detects whether the iOS prerequisites needed to consume a CtrlProxy runner
+ * bundle are present. Used to gate startup-time work (e.g. the runner-bundle
+ * prefetch) so hosts without a usable Xcode toolchain don't do unnecessary
+ * network/disk work.
+ */
+export interface IosPrerequisiteDetector {
+  /**
+   * Resolve to true when iOS device work is possible in this environment.
+   * The runner is installed via `xcrun simctl`/`devicectl` and run via
+   * `xcodebuild test-without-building`, so either tool being runnable is taken
+   * as the minimum signal that the Xcode toolchain is present.
+   */
+  hasIosPrerequisites(): Promise<boolean>;
+}
+
+/**
+ * Default Xcode-toolchain detector. iOS device work only runs on macOS and
+ * fundamentally needs `xcrun` (simctl/devicectl) and `xcodebuild`. Probing
+ * either cheaply is enough to know the toolchain exists; a host with neither
+ * cannot consume the runner regardless.
+ */
+export class DefaultIosPrerequisiteDetector implements IosPrerequisiteDetector {
+  private readonly systemDetection: SystemDetection;
+
+  constructor(systemDetection: SystemDetection = new DefaultSystemDetection()) {
+    this.systemDetection = systemDetection;
+  }
+
+  async hasIosPrerequisites(): Promise<boolean> {
+    // iOS device work only runs on macOS.
+    if (this.systemDetection.getCurrentPlatform() !== "darwin") {
+      return false;
+    }
+
+    // Either tool being runnable proves an Xcode toolchain is installed. Skip
+    // only when neither works — the clear "no iOS tooling" case.
+    if (await this.canRun("xcrun --version")) {
+      return true;
+    }
+    return this.canRun("xcodebuild -version");
+  }
+
+  private async canRun(command: string): Promise<boolean> {
+    try {
+      await this.systemDetection.exec(command);
+      return true;
+    } catch (error) {
+      // A non-zero exit / missing binary is a normal "not available", not a fault.
+      logger.debug(`[IOS_PREREQ] probe failed for '${command}': ${error}`, error);
+      return false;
+    }
+  }
+}

--- a/test/utils/ios-cmdline-tools/IosPrerequisiteDetector.test.ts
+++ b/test/utils/ios-cmdline-tools/IosPrerequisiteDetector.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { DefaultIosPrerequisiteDetector } from "../../../src/utils/ios-cmdline-tools/IosPrerequisiteDetector";
+import { FakeSystemDetection } from "../../fakes/FakeSystemDetection";
+
+describe("DefaultIosPrerequisiteDetector", function() {
+  let system: FakeSystemDetection;
+
+  beforeEach(function() {
+    system = new FakeSystemDetection();
+    system.setPlatform("darwin");
+  });
+
+  test("returns true when xcrun is runnable", async function() {
+    system.setExecResponse("xcrun --version", "xcrun version 70\n");
+
+    const detector = new DefaultIosPrerequisiteDetector(system);
+
+    expect(await detector.hasIosPrerequisites()).toBe(true);
+  });
+
+  test("returns true when only xcodebuild is runnable", async function() {
+    // xcrun probe fails (default), xcodebuild succeeds.
+    system.setExecResponse("xcodebuild -version", "Xcode 16.0\n");
+
+    const detector = new DefaultIosPrerequisiteDetector(system);
+
+    expect(await detector.hasIosPrerequisites()).toBe(true);
+  });
+
+  test("returns false on macOS when neither xcrun nor xcodebuild is runnable", async function() {
+    // No exec responses -> FakeSystemDetection throws for both probes.
+    const detector = new DefaultIosPrerequisiteDetector(system);
+
+    expect(await detector.hasIosPrerequisites()).toBe(false);
+  });
+
+  test("returns false when not running on macOS, without probing tools", async function() {
+    system.setPlatform("linux");
+    // Even if the tools would somehow answer, a non-darwin host cannot run iOS work.
+    system.setExecResponse("xcrun --version", "xcrun version 70\n");
+
+    const detector = new DefaultIosPrerequisiteDetector(system);
+
+    expect(await detector.hasIosPrerequisites()).toBe(false);
+  });
+});

--- a/test/utils/iosCtrlProxyPrefetchGate.test.ts
+++ b/test/utils/iosCtrlProxyPrefetchGate.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { IOSCtrlProxyBuilder } from "../../src/utils/IOSCtrlProxyBuilder";
+import type { PrefetchBuilder } from "../../src/utils/IOSCtrlProxyBuilder";
+import type { IosPrerequisiteDetector } from "../../src/utils/ios-cmdline-tools/IosPrerequisiteDetector";
+
+/**
+ * Gate for the startup runner-bundle prefetch: it must skip cleanly when iOS
+ * prerequisites are absent and still reach the builder when present (#4407).
+ */
+describe("IOSCtrlProxyBuilder prefetch prerequisite gate", function() {
+  let originalPlatform: PropertyDescriptor | undefined;
+  let recordingBuilder: PrefetchBuilder & { needsRebuildCalls: number; buildCalls: number };
+
+  const detectorReturning = (value: boolean): IosPrerequisiteDetector => ({
+    hasIosPrerequisites: async () => value
+  });
+
+  beforeEach(function() {
+    IOSCtrlProxyBuilder.resetInstances();
+    // prefetchBuild() early-returns off macOS; force darwin so the gate is what decides.
+    originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+
+    recordingBuilder = {
+      needsRebuildCalls: 0,
+      buildCalls: 0,
+      async needsRebuild() {
+        this.needsRebuildCalls++;
+        return true;
+      },
+      async build() {
+        this.buildCalls++;
+        return { success: true, message: "recorded build" };
+      },
+      async getBuildProductsPath() {
+        return null;
+      },
+      async getXctestrunPath() {
+        return null;
+      }
+    } as PrefetchBuilder & { needsRebuildCalls: number; buildCalls: number };
+    IOSCtrlProxyBuilder.setPrefetchBuilderForTesting(recordingBuilder);
+  });
+
+  afterEach(function() {
+    IOSCtrlProxyBuilder.resetInstances();
+    if (originalPlatform) {
+      Object.defineProperty(process, "platform", originalPlatform);
+    }
+  });
+
+  test("does not reach the builder when iOS prerequisites are absent", async function() {
+    IOSCtrlProxyBuilder.setIosPrerequisiteDetectorForTesting(detectorReturning(false));
+
+    IOSCtrlProxyBuilder.prefetchBuild();
+    // Draining the prefetch must resolve null without throwing, so the daemon
+    // stays healthy and non-iOS workflows are unaffected.
+    const result = await IOSCtrlProxyBuilder.waitForPrefetch();
+
+    expect(result).toBeNull();
+    expect(IOSCtrlProxyBuilder.getPrefetchError()).toBeNull();
+    expect(recordingBuilder.needsRebuildCalls).toBe(0);
+    expect(recordingBuilder.buildCalls).toBe(0);
+  });
+
+  test("reaches the builder when iOS prerequisites are present", async function() {
+    IOSCtrlProxyBuilder.setIosPrerequisiteDetectorForTesting(detectorReturning(true));
+
+    IOSCtrlProxyBuilder.prefetchBuild();
+    await IOSCtrlProxyBuilder.waitForPrefetch();
+
+    // The gate let the prefetch through, so the build path ran.
+    expect(recordingBuilder.needsRebuildCalls).toBe(1);
+    expect(recordingBuilder.buildCalls).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Daemon startup began the iOS CtrlProxy runner-bundle prefetch (`IOSCtrlProxyBuilder.prefetchBuild()`) on any macOS host, gated only by `process.platform === "darwin"`. A Mac without a usable Xcode toolchain (`xcrun`/`xcodebuild`) can never consume the runner — it is installed via `xcrun simctl`/`devicectl` and run via `xcodebuild test-without-building` — so downloading and extracting the bundle at startup is wasted network/disk/startup work.

This is the iOS counterpart of #4404 / [#4406](https://github.com/kaeawc/auto-mobile/pull/4406) (Android).

Adds an Xcode-toolchain prerequisite gate that `IOSCtrlProxyBuilder.doPrefetch()` consults **before** any builder/download work. When the host is not macOS, or neither `xcrun --version` nor `xcodebuild -version` runs, the prefetch **skips cleanly** — returns `null` and logs a concise non-error diagnostic, mirroring the Android `AndroidPrerequisiteDetector` gate. Skipping (not throwing) keeps the daemon healthy and non-iOS workflows unaffected; the on-demand build path still runs when a device connects.

## Changes

- New `src/utils/ios-cmdline-tools/IosPrerequisiteDetector.ts` — `IosPrerequisiteDetector` interface + `DefaultIosPrerequisiteDetector`, reusing the existing `SystemDetection` seam (tested via `FakeSystemDetection`).
- `IOSCtrlProxyBuilder.doPrefetch()` gates on the detector; new `setIosPrerequisiteDetectorForTesting` / `setPrefetchBuilderForTesting` seams and a narrow `PrefetchBuilder` type so both paths are unit-testable without a real build/download.

## Linked Issue

Closes #4407

## Acceptance criteria

- [x] A macOS environment without a usable Xcode toolchain does not download the runner bundle at startup — `iosCtrlProxyPrefetchGate.test.ts` (detector=false ⇒ builder never reached).
- [x] The skipped prefetch keeps the daemon healthy / non-iOS workflows intact — `waitForPrefetch()` resolves `null`, `getPrefetchError()` stays `null`, on-demand build path untouched.
- [x] Environments with Xcode tooling continue to prefetch — same suite (detector=true ⇒ builder reached).
- [x] Unit coverage verifies both paths — plus `IosPrerequisiteDetector.test.ts` drives xcrun-only / xcodebuild-only / neither / non-macOS via `FakeSystemDetection`.

## Validation

- [x] `bun run lint` + `bun test` pass (9358 pass, 0 fail)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run build` succeeds
- [x] New code uses interfaces + fakes; unit tests run in <100ms

## Follow-ups

- None.
