### PR TITLE
fix(webrtc): make keyframe delivery deterministic

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/WebRtcStreamSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/WebRtcStreamSocketClient.kt
@@ -27,6 +27,22 @@ data class WebRtcIceServer(
 )
 
 /**
+ * Readiness observations from the encoder/publisher path. Null counters and
+ * timestamps mean that the corresponding producer has not initialized yet.
+ */
+@Serializable
+data class WebRtcStreamReadiness(
+  val lastEncodedFrameTimestampUs: Long? = null,
+  val lastIdrTimestampUs: Long? = null,
+  val idrRequestCount: Long? = null,
+  val idrCompletionCount: Long? = null,
+  val encodedAccessUnitCount: Long? = null,
+  val publisherRtpPacketCount: Long? = null,
+  val captureSourceState: String = "not_initialized",
+  val lastSourceError: String? = null,
+)
+
+/**
  * State of one published stream.
  *
  * Note the counters are *send*-side: this describes the daemon publishing the device's screen to a
@@ -45,6 +61,7 @@ data class WebRtcStreamDescriptor(
   val packetsSent: Long = 0,
   val audioPacketsSent: Long = 0,
   val audioSamplesSent: Long = 0,
+  val readiness: WebRtcStreamReadiness = WebRtcStreamReadiness(),
 )
 
 /**

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/WebRtcStreamSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/WebRtcStreamSocketClient.kt
@@ -27,8 +27,8 @@ data class WebRtcIceServer(
 )
 
 /**
- * Readiness observations from the encoder/publisher path. Null counters and
- * timestamps mean that the corresponding producer has not initialized yet.
+ * Readiness observations from the encoder/publisher path. Null counters and timestamps mean that
+ * the corresponding producer has not initialized yet.
  */
 @Serializable
 data class WebRtcStreamReadiness(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/WebRtcStreamSocketClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/WebRtcStreamSocketClientTest.kt
@@ -22,7 +22,17 @@ class WebRtcStreamSocketClientTest {
       "framesSent": 120,
       "packetsSent": 480,
       "audioPacketsSent": 0,
-      "audioSamplesSent": 0
+      "audioSamplesSent": 0,
+      "readiness": {
+        "lastEncodedFrameTimestampUs": 1000,
+        "lastIdrTimestampUs": 900,
+        "idrRequestCount": 2,
+        "idrCompletionCount": 1,
+        "encodedAccessUnitCount": 3,
+        "publisherRtpPacketCount": 6,
+        "captureSourceState": "running",
+        "lastSourceError": null
+      }
     }
     """
 
@@ -88,6 +98,8 @@ class WebRtcStreamSocketClientTest {
       assertEquals("https://coord.example.com/whip", stream.whipEndpoint)
       assertEquals(120L, stream.framesSent)
       assertEquals("stun:stun.example.com:3478", stream.iceServers.single().urls)
+      assertEquals(1000L, stream.readiness.lastEncodedFrameTimestampUs)
+      assertEquals("running", stream.readiness.captureSourceState)
     }
   }
 

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoEncoder.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoEncoder.kt
@@ -84,6 +84,9 @@ class VideoEncoder(
 
     encoder.start()
     codec = encoder
+    // The first surface submission can otherwise be a non-IDR on some devices.
+    // Make decoder readiness an explicit startup requirement.
+    requestKeyFrame()
 
     return surface
   }

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
@@ -218,10 +218,6 @@ object VideoServer {
     capture = ScreenCapture(width, height, densityDpi)
     capture!!.start(surface)
 
-    // Create stream writer
-    streamWriter = VideoStreamWriter(SOCKET_NAME, width, height, audioEnabled)
-    streamWriter!!.start()
-
     // Backstop for idle-screen frame starvation (#4383): on a static screen the mirror
     // stops submitting buffers, so KEY_REPEAT_PREVIOUS_FRAME_AFTER alone does not reliably
     // sustain output and a keyframe request cannot yield a fresh IDR. The heartbeat tells us
@@ -230,15 +226,18 @@ object VideoServer {
       FrameHeartbeat(clock = FrameHeartbeat.Clock { android.os.SystemClock.uptimeMillis() })
     heartbeat.start()
 
-    // Read host→device commands (e.g. a relayed WHEP viewer PLI) and ask the
-    // encoder for a fresh IDR so late/recovering viewers decode without waiting
-    // for the 2s I-frame interval. Also arm the heartbeat so an idle screen that
-    // produces no frame for the request still gets a forced fresh submission.
+    // The writer keeps the encoder alive while its LocalSocket client
+    // reconnects, replays cached decoder state, and requests a new IDR at attach.
+    streamWriter = VideoStreamWriter(SOCKET_NAME, width, height, audioEnabled)
     streamWriter!!.startCommandReader { command ->
       if (command == VideoStreamProtocol.COMMAND_REQUEST_KEY_FRAME) {
         encoder?.requestKeyFrame()
         heartbeat.onKeyFrameRequested()
       }
+    }
+    streamWriter!!.start {
+      encoder?.requestKeyFrame()
+      heartbeat.onKeyFrameRequested()
     }
 
     if (audioEnabled) {
@@ -281,6 +280,11 @@ object VideoServer {
       // keyframe request produced nothing), nudge it into re-submitting a fresh frame.
       if (heartbeat.poll()) {
         capture?.forceFrame()
+      }
+
+      if (streamWriter!!.reconnectWindowExpired()) {
+        println("Client did not reconnect before the video reconnect window expired")
+        break
       }
     }
 

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamProtocol.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamProtocol.kt
@@ -27,8 +27,11 @@ object VideoStreamProtocol {
   /** Bit 62: key frame (I-frame) */
   const val PACKET_FLAG_KEY_FRAME = 1L shl 62
 
-  /** Mask for PTS (bits 0-61) */
-  const val PTS_MASK = (1L shl 62) - 1
+  /** Bit 61: cached packet replayed for a replacement LocalSocket client. */
+  const val PACKET_FLAG_REPLAYED = 1L shl 61
+
+  /** Mask for PTS (bits 0-60). */
+  const val PTS_MASK = (1L shl 61) - 1
 
   fun legacyHeader(width: Int, height: Int): ByteArray =
     ByteBuffer.allocate(12).putInt(CODEC_ID_H264).putInt(width).putInt(height).array()
@@ -58,6 +61,8 @@ object VideoStreamProtocol {
     }
     return ptsAndFlags
   }
+
+  fun replayed(ptsAndFlags: Long): Long = ptsAndFlags or PACKET_FLAG_REPLAYED
 
   fun packetHeader(audioEnabled: Boolean, trackId: Int, ptsAndFlags: Long, size: Int): ByteArray =
     if (audioEnabled) {

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
@@ -9,10 +9,9 @@ import java.io.OutputStream
 import java.nio.ByteBuffer
 
 /**
- * Writes encoded video packets to a LocalSocket using the VideoStreamProtocol
- * binary framing. A disconnected client is replaceable: the writer retains
- * codec configuration plus the latest complete keyframe and replays them before
- * live packets to the next client.
+ * Writes encoded video packets to a LocalSocket using the VideoStreamProtocol binary framing. A
+ * disconnected client is replaceable: the writer retains codec configuration plus the latest
+ * complete keyframe and replays them before live packets to the next client.
  */
 class VideoStreamWriter(
   private val socketName: String,
@@ -57,8 +56,8 @@ class VideoStreamWriter(
   /**
    * Bind the abstract LocalSocket and accept clients in the background.
    *
-   * The callback runs after the cached packets are written, so callers can
-   * request a current IDR without delaying initial decoder setup.
+   * The callback runs after the cached packets are written, so callers can request a current IDR
+   * without delaying initial decoder setup.
    */
   fun start(onClientConnected: () -> Unit = {}) {
     serverSocket = LocalServerSocket(socketName)
@@ -72,9 +71,9 @@ class VideoStreamWriter(
   }
 
   /**
-   * Registers a callback for every current or future bidirectional client.
-   * The reader is deliberately owned by the writer so reconnects do not lose
-   * the keyframe-request control channel.
+   * Registers a callback for every current or future bidirectional client. The reader is
+   * deliberately owned by the writer so reconnects do not lose the keyframe-request control
+   * channel.
    */
   fun startCommandReader(onCommand: (Int) -> Unit) {
     synchronized(lock) {
@@ -149,8 +148,8 @@ class VideoStreamWriter(
   }
 
   /**
-   * Write one encoded video packet. It is cached before writing, allowing a
-   * later client to decode immediately even if this client fails mid-write.
+   * Write one encoded video packet. It is cached before writing, allowing a later client to decode
+   * immediately even if this client fails mid-write.
    */
   fun writePacket(buffer: ByteBuffer, bufferInfo: MediaCodec.BufferInfo): Boolean {
     val data = ByteArray(bufferInfo.size)
@@ -270,7 +269,7 @@ internal class VideoPacketCache {
     val cachedIdr = idr
     return when {
       cachedConfig == null && cachedIdr == null -> emptyList()
-      cachedConfig == null -> listOf(cachedIdr!!.copyPacket())
+      cachedConfig == null -> listOfNotNull(cachedIdr).map(CachedVideoPacket::copyPacket)
       cachedIdr == null -> listOf(cachedConfig.copyPacket())
       cachedConfig.ptsAndFlags == cachedIdr.ptsAndFlags &&
         cachedConfig.data.contentEquals(cachedIdr.data) -> listOf(cachedConfig.copyPacket())
@@ -280,7 +279,7 @@ internal class VideoPacketCache {
 }
 
 internal class ClientReconnectWindow(
-  private val windowMs: Long = VideoStreamWriter.CLIENT_RECONNECT_WINDOW_MS,
+  private val windowMs: Long = VideoStreamWriter.CLIENT_RECONNECT_WINDOW_MS
 ) {
   private var hasConnected = false
   private var disconnectedAtMs: Long? = null
@@ -296,6 +295,5 @@ internal class ClientReconnectWindow(
     }
   }
 
-  fun hasExpired(nowMs: Long): Boolean =
-    disconnectedAtMs?.let { nowMs - it >= windowMs } ?: false
+  fun hasExpired(nowMs: Long): Boolean = disconnectedAtMs?.let { nowMs - it >= windowMs } ?: false
 }

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
@@ -3,63 +3,38 @@ package dev.jasonpearson.automobile.video
 import android.media.MediaCodec
 import android.net.LocalServerSocket
 import android.net.LocalSocket
+import android.os.SystemClock
 import java.io.IOException
 import java.io.OutputStream
 import java.nio.ByteBuffer
 
 /**
- * Writes encoded video packets to a LocalSocket using a binary protocol.
- *
- * ## Protocol
- *
- * ### Stream Header (12 bytes)
- *
- * ```
- * ┌─────────────────┬─────────────────┬─────────────────┐
- * │ codec_id (4)    │ width (4)       │ height (4)      │
- * │ big-endian      │ big-endian      │ big-endian      │
- * └─────────────────┴─────────────────┴─────────────────┘
- * ```
- *
- * codec_id values:
- * - 0x68323634 = "h264" (H.264/AVC)
- *
- * ### Packet Header (12 bytes per packet)
- *
- * ```
- * ┌─────────────────────────────────────┬─────────────────┐
- * │ pts_and_flags (8)                   │ size (4)        │
- * │ big-endian                          │ big-endian      │
- * └─────────────────────────────────────┴─────────────────┘
- * ```
- *
- * pts_and_flags bit layout:
- * - bit 63: CONFIG flag (codec config data, not a frame)
- * - bit 62: KEY_FRAME flag (I-frame)
- * - bits 0-61: presentation timestamp in microseconds
- *
- * Followed by `size` bytes of encoded frame data.
- *
- * When audio is enabled, the stream uses a multiplexed header:
- * ```
- * amux header: magic "amux" (4) | version (4) | track_count (4)
- * track:       track_id (4) | codec_id (4) | param1 (4) | param2 (4)
- * packet:      track_id (4) | pts_and_flags (8) | size (4) | payload
- * ```
+ * Writes encoded video packets to a LocalSocket using the VideoStreamProtocol
+ * binary framing. A disconnected client is replaceable: the writer retains
+ * codec configuration plus the latest complete keyframe and replays them before
+ * live packets to the next client.
  */
 class VideoStreamWriter(
   private val socketName: String,
   private val width: Int,
   private val height: Int,
   private val audioEnabled: Boolean = false,
+  private val nowMs: () -> Long = { SystemClock.elapsedRealtime() },
 ) {
   private var serverSocket: LocalServerSocket? = null
   private var clientSocket: LocalSocket? = null
   private var outputStream: OutputStream? = null
+  private var commandHandler: ((Int) -> Unit)? = null
+  private val lock = Any()
+  private val packetCache = VideoPacketCache()
+  private val reconnectWindow = ClientReconnectWindow()
 
   @Volatile private var stopped = false
 
   companion object {
+    /** Keep capture warm long enough for ADB/daemon local-socket recovery. */
+    const val CLIENT_RECONNECT_WINDOW_MS = 5_000L
+
     /** "h264" as big-endian int: 0x68323634 */
     const val CODEC_ID_H264 = VideoStreamProtocol.CODEC_ID_H264
     /** "amux" as big-endian int: 0x616d7578 */
@@ -80,51 +55,91 @@ class VideoStreamWriter(
   }
 
   /**
-   * Start the server and wait for a client connection.
+   * Bind the abstract LocalSocket and accept clients in the background.
    *
-   * This method blocks until a client connects.
-   *
-   * @throws IOException if the socket cannot be created or written to
+   * The callback runs after the cached packets are written, so callers can
+   * request a current IDR without delaying initial decoder setup.
    */
-  fun start() {
-    // Create LocalServerSocket in abstract namespace
+  fun start(onClientConnected: () -> Unit = {}) {
     serverSocket = LocalServerSocket(socketName)
     println("Waiting for client connection on localabstract:$socketName")
-
-    // Accept a single client connection (blocking)
-    val client = serverSocket!!.accept()
-    clientSocket = client
-    outputStream = client.outputStream
-
-    println("Client connected, writing stream header")
-
-    // Write stream header
-    if (audioEnabled) {
-      writeMuxHeader()
-    } else {
-      writeLegacyHeader()
-    }
+    Thread(
+        { acceptClients(onClientConnected) },
+        "video-client-acceptor",
+      )
+      .apply { isDaemon = true }
+      .start()
   }
 
   /**
-   * Read host→device command bytes on a background daemon thread, invoking [onCommand] for each
-   * byte. The LocalSocket is bidirectional; the host writes single-byte commands (e.g.
-   * [VideoStreamProtocol.COMMAND_REQUEST_KEY_FRAME]). The video stream is strictly server→client,
-   * so this is the only reader of the client input stream. Returns immediately; the thread exits on
-   * EOF or stop().
+   * Registers a callback for every current or future bidirectional client.
+   * The reader is deliberately owned by the writer so reconnects do not lose
+   * the keyframe-request control channel.
    */
   fun startCommandReader(onCommand: (Int) -> Unit) {
-    val input = clientSocket?.inputStream ?: return
+    synchronized(lock) {
+      commandHandler = onCommand
+    }
+  }
+
+  private fun acceptClients(onClientConnected: () -> Unit) {
+    while (!stopped) {
+      val client =
+        try {
+          serverSocket?.accept() ?: return
+        } catch (e: IOException) {
+          if (!stopped) {
+            println("Error accepting video client: ${e.message}")
+          }
+          return
+        }
+
+      val attached =
+        synchronized(lock) {
+          closeClientLocked()
+          clientSocket = client
+          outputStream = client.outputStream
+          try {
+            writeStreamHeaderLocked()
+            replayCachedVideoLocked()
+            reconnectWindow.onClientConnected()
+            true
+          } catch (e: IOException) {
+            println("Error attaching video client: ${e.message}")
+            closeClientLocked()
+            reconnectWindow.onClientDisconnected(nowMs())
+            false
+          }
+        }
+      if (!attached) {
+        continue
+      }
+
+      println("Client connected, writing stream header")
+      startCommandReaderFor(client)
+      onClientConnected()
+    }
+  }
+
+  private fun startCommandReaderFor(client: LocalSocket) {
+    val input = client.inputStream
     Thread(
         {
           try {
             while (!stopped) {
               val command = input.read()
-              if (command < 0) break // EOF: the host closed the connection.
-              onCommand(command)
+              if (command < 0) break
+              commandHandler?.invoke(command)
             }
           } catch (_: IOException) {
-            // Socket closed during shutdown; nothing to recover.
+            // The write path or a replacement connection owns cleanup.
+          } finally {
+            synchronized(lock) {
+              if (clientSocket === client) {
+                closeClientLocked()
+                reconnectWindow.onClientDisconnected(nowMs())
+              }
+            }
           }
         },
         "video-command-reader",
@@ -133,29 +148,9 @@ class VideoStreamWriter(
       .start()
   }
 
-  private fun writeLegacyHeader() {
-    outputStream!!.write(VideoStreamProtocol.legacyHeader(width, height))
-    outputStream!!.flush()
-  }
-
-  private fun writeMuxHeader() {
-    outputStream!!.write(
-      VideoStreamProtocol.muxHeader(
-        width,
-        height,
-        AudioCapture.SAMPLE_RATE_HZ,
-        AudioCapture.CHANNELS,
-      )
-    )
-    outputStream!!.flush()
-  }
-
   /**
-   * Write an encoded packet to the stream.
-   *
-   * @param buffer The encoded data buffer
-   * @param bufferInfo The buffer info from MediaCodec
-   * @return true if the packet was written successfully, false if the stream was closed
+   * Write one encoded video packet. It is cached before writing, allowing a
+   * later client to decode immediately even if this client fails mid-write.
    */
   fun writePacket(buffer: ByteBuffer, bufferInfo: MediaCodec.BufferInfo): Boolean {
     val data = ByteArray(bufferInfo.size)
@@ -167,49 +162,140 @@ class VideoStreamWriter(
         (bufferInfo.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0,
         (bufferInfo.flags and MediaCodec.BUFFER_FLAG_KEY_FRAME) != 0,
       )
-
-    return writePacketData(TRACK_ID_VIDEO, ptsAndFlags, data)
+    synchronized(lock) {
+      packetCache.remember(CachedVideoPacket(ptsAndFlags, data))
+      return writePacketDataLocked(TRACK_ID_VIDEO, ptsAndFlags, data)
+    }
   }
 
-  fun writeAudioPacket(data: ByteArray, ptsUs: Long): Boolean {
-    return writePacketData(TRACK_ID_AUDIO, ptsUs and PTS_MASK, data)
+  fun writeAudioPacket(data: ByteArray, ptsUs: Long): Boolean =
+    synchronized(lock) {
+      writePacketDataLocked(TRACK_ID_AUDIO, ptsUs and PTS_MASK, data)
+    }
+
+  /** True once a prior client has failed to reconnect inside the bounded window. */
+  fun reconnectWindowExpired(): Boolean =
+    synchronized(lock) {
+      reconnectWindow.hasExpired(nowMs())
+    }
+
+  private fun writeStreamHeaderLocked() {
+    if (audioEnabled) {
+      outputStream!!.write(
+        VideoStreamProtocol.muxHeader(
+          width,
+          height,
+          AudioCapture.SAMPLE_RATE_HZ,
+          AudioCapture.CHANNELS,
+        )
+      )
+    } else {
+      outputStream!!.write(VideoStreamProtocol.legacyHeader(width, height))
+    }
+    outputStream!!.flush()
   }
 
-  @Synchronized
-  private fun writePacketData(trackId: Int, ptsAndFlags: Long, data: ByteArray): Boolean {
+  private fun replayCachedVideoLocked() {
+    for (packet in packetCache.replay()) {
+      writePacketDataLocked(
+        TRACK_ID_VIDEO,
+        VideoStreamProtocol.replayed(packet.ptsAndFlags),
+        packet.data,
+      )
+    }
+  }
+
+  private fun writePacketDataLocked(trackId: Int, ptsAndFlags: Long, data: ByteArray): Boolean {
     if (stopped) return false
 
-    val output = outputStream ?: return false
-
+    // Keep the encoder alive during local client recovery. Video data is cached;
+    // audio resumes live when the replacement mux client attaches.
+    val output = outputStream ?: return true
     try {
       output.write(VideoStreamProtocol.packetHeader(audioEnabled, trackId, ptsAndFlags, data.size))
       output.write(data)
-
       return true
     } catch (e: IOException) {
       println("Error writing packet: ${e.message}")
-      return false
+      closeClientLocked()
+      reconnectWindow.onClientDisconnected(nowMs())
+      return true
     }
+  }
+
+  private fun closeClientLocked() {
+    try {
+      outputStream?.close()
+    } catch (_: IOException) {}
+    try {
+      clientSocket?.close()
+    } catch (_: IOException) {}
+    outputStream = null
+    clientSocket = null
   }
 
   /** Stop the stream writer and close all sockets. */
   fun stop() {
     stopped = true
-
-    try {
-      outputStream?.close()
-    } catch (_: IOException) {}
-
-    try {
-      clientSocket?.close()
-    } catch (_: IOException) {}
-
+    synchronized(lock) {
+      closeClientLocked()
+    }
     try {
       serverSocket?.close()
     } catch (_: IOException) {}
-
-    outputStream = null
-    clientSocket = null
     serverSocket = null
   }
+}
+
+/** Cached decoder setup and latest complete keyframe for a replacement client. */
+internal data class CachedVideoPacket(val ptsAndFlags: Long, val data: ByteArray) {
+  fun copyPacket(): CachedVideoPacket = CachedVideoPacket(ptsAndFlags, data.copyOf())
+}
+
+internal class VideoPacketCache {
+  private var config: CachedVideoPacket? = null
+  private var idr: CachedVideoPacket? = null
+
+  fun remember(packet: CachedVideoPacket) {
+    if ((packet.ptsAndFlags and VideoStreamProtocol.PACKET_FLAG_CONFIG) != 0L) {
+      config = packet.copyPacket()
+    }
+    if ((packet.ptsAndFlags and VideoStreamProtocol.PACKET_FLAG_KEY_FRAME) != 0L) {
+      idr = packet.copyPacket()
+    }
+  }
+
+  fun replay(): List<CachedVideoPacket> {
+    val cachedConfig = config
+    val cachedIdr = idr
+    return when {
+      cachedConfig == null && cachedIdr == null -> emptyList()
+      cachedConfig == null -> listOf(cachedIdr!!.copyPacket())
+      cachedIdr == null -> listOf(cachedConfig.copyPacket())
+      cachedConfig.ptsAndFlags == cachedIdr.ptsAndFlags &&
+        cachedConfig.data.contentEquals(cachedIdr.data) -> listOf(cachedConfig.copyPacket())
+      else -> listOf(cachedConfig.copyPacket(), cachedIdr.copyPacket())
+    }
+  }
+}
+
+internal class ClientReconnectWindow(
+  private val windowMs: Long = VideoStreamWriter.CLIENT_RECONNECT_WINDOW_MS,
+) {
+  private var hasConnected = false
+  private var disconnectedAtMs: Long? = null
+
+  fun onClientConnected() {
+    hasConnected = true
+    disconnectedAtMs = null
+  }
+
+  fun onClientDisconnected(nowMs: Long) {
+    if (hasConnected && disconnectedAtMs == null) {
+      disconnectedAtMs = nowMs
+    }
+  }
+
+  fun hasExpired(nowMs: Long): Boolean =
+    disconnectedAtMs?.let { nowMs - it >= windowMs } ?: false
 }

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamProtocolTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamProtocolTest.kt
@@ -151,6 +151,24 @@ class VideoStreamProtocolTest {
   }
 
   @Test
+  fun replayedPacketFlagPreservesTheOriginalFlagsAndPts() {
+    val original =
+      VideoStreamProtocol.ptsAndFlags(
+        presentationTimeUs = 123,
+        isConfig = false,
+        isKeyFrame = true,
+      )
+
+    val replayed = VideoStreamProtocol.replayed(original)
+
+    assertEquals(
+      VideoStreamProtocol.PACKET_FLAG_REPLAYED or VideoStreamProtocol.PACKET_FLAG_KEY_FRAME or 123,
+      replayed,
+    )
+    assertEquals(123, replayed and VideoStreamProtocol.PTS_MASK)
+  }
+
+  @Test
   fun requestKeyFrameCommandByteMatchesHostContract() {
     // The host (PersistentEncoderH264Source.ts) writes this exact byte to request
     // a fresh IDR. Changing it silently would break keyframe-on-demand.
@@ -185,5 +203,49 @@ class VideoStreamProtocolTest {
         size = 4,
       ),
     )
+  }
+
+  @Test
+  fun cachedDecoderStateReplaysConfigThenLatestIdr() {
+    val cache = VideoPacketCache()
+    cache.remember(
+      CachedVideoPacket(
+        VideoStreamProtocol.PACKET_FLAG_CONFIG or 10,
+        byteArrayOf(0, 0, 0, 1, 0x67),
+      )
+    )
+    cache.remember(
+      CachedVideoPacket(
+        VideoStreamProtocol.PACKET_FLAG_KEY_FRAME or 20,
+        byteArrayOf(0, 0, 0, 1, 0x65, 1),
+      )
+    )
+    cache.remember(
+      CachedVideoPacket(
+        VideoStreamProtocol.PACKET_FLAG_KEY_FRAME or 30,
+        byteArrayOf(0, 0, 0, 1, 0x65, 2),
+      )
+    )
+
+    val replay = cache.replay()
+
+    assertEquals(2, replay.size)
+    assertEquals(VideoStreamProtocol.PACKET_FLAG_CONFIG or 10, replay[0].ptsAndFlags)
+    assertEquals(VideoStreamProtocol.PACKET_FLAG_KEY_FRAME or 30, replay[1].ptsAndFlags)
+    assertArrayEquals(byteArrayOf(0, 0, 0, 1, 0x65, 2), replay[1].data)
+  }
+
+  @Test
+  fun reconnectWindowOnlyExpiresAfterAConnectedClientIsLost() {
+    val window = ClientReconnectWindow(windowMs = 5_000)
+
+    assertEquals(false, window.hasExpired(10_000))
+    window.onClientConnected()
+    window.onClientDisconnected(100)
+    assertEquals(false, window.hasExpired(5_099))
+    assertEquals(true, window.hasExpired(5_100))
+
+    window.onClientConnected()
+    assertEquals(false, window.hasExpired(10_000))
   }
 }

--- a/docs/design-docs/mcp/observe/webrtc-streaming.md
+++ b/docs/design-docs/mcp/observe/webrtc-streaming.md
@@ -195,10 +195,26 @@ Newline-delimited JSON request/response.
     "framesSent": 0,
     "packetsSent": 0,
     "audioPacketsSent": 0,
-    "audioSamplesSent": 0
+    "audioSamplesSent": 0,
+    "readiness": {
+      "lastEncodedFrameTimestampUs": null,
+      "lastIdrTimestampUs": null,
+      "idrRequestCount": null,
+      "idrCompletionCount": null,
+      "encodedAccessUnitCount": null,
+      "publisherRtpPacketCount": null,
+      "captureSourceState": "not_initialized",
+      "lastSourceError": null
+    }
   }
 }
 ```
+
+`readiness` separates capture-source, encoder, IDR, and RTP-publication
+progress. A `null` counter or timestamp has not been initialized by its
+producer; a numeric zero is a measured value. `captureSourceState` is
+`not_initialized`, `starting`, `running`, `failed`, or `stopped`, and
+`lastSourceError` identifies the latest capture failure when present.
 
 ## Configuration
 

--- a/src/features/webrtc/H264CaptureSource.ts
+++ b/src/features/webrtc/H264CaptureSource.ts
@@ -23,6 +23,18 @@ export interface H264CaptureSourceOptions {
 }
 
 /**
+ * Source-side encoder observations. `null` means that the source has not
+ * initialized that measurement yet; a zero counter is therefore meaningful.
+ */
+export interface H264CaptureSourceTelemetry {
+  lastEncodedFrameTimestampUs: number | null;
+  lastIdrTimestampUs: number | null;
+  idrRequestCount: number | null;
+  idrCompletionCount: number | null;
+  encodedAccessUnitCount: number | null;
+}
+
+/**
  * Common contract for a device H.264 capture source feeding the WebRTC
  * publisher. Both the segment-rotated `screenrecord` source
  * (`AndroidH264Source`) and the persistent on-device encoder source
@@ -42,4 +54,6 @@ export interface H264CaptureSource {
    * frequently (throttle internally) and before/after the stream is running.
    */
   requestKeyFrame?(): void;
+  /** Optional precise encoder telemetry for the stream-status control plane. */
+  getTelemetry?(): H264CaptureSourceTelemetry;
 }

--- a/src/features/webrtc/PersistentEncoderH264Source.ts
+++ b/src/features/webrtc/PersistentEncoderH264Source.ts
@@ -7,7 +7,7 @@ import {
   type AdbClientFactory,
 } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbProcess } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
-import type { H264CaptureSource } from "./H264CaptureSource";
+import type { H264CaptureSource, H264CaptureSourceTelemetry } from "./H264CaptureSource";
 import {
   VIDEO_SERVER_CODEC_ID_H264,
   VIDEO_SERVER_CODEC_ID_PCM16,
@@ -32,6 +32,9 @@ const STREAMING_STARTED_MARKER = "Streaming started";
  * `VideoStreamProtocol.COMMAND_REQUEST_KEY_FRAME` in the Kotlin video-server.
  */
 export const VIDEO_SERVER_COMMAND_REQUEST_KEY_FRAME = 0x01;
+/** Retry a replaced local ADB socket without tearing down the device encoder. */
+export const DEFAULT_LOCAL_SOCKET_RECONNECT_WINDOW_MS = 5_000;
+export const DEFAULT_LOCAL_SOCKET_RECONNECT_RETRY_MS = 100;
 
 /** Minimal socket surface the source needs, for injectable testing. */
 export interface StreamSocket {
@@ -44,13 +47,37 @@ export interface StreamSocket {
 }
 
 /** Connects to a forwarded local TCP port and resolves once connected. */
-export type SocketConnector = (port: number) => Promise<StreamSocket>;
+export type SocketConnector = (port: number, signal?: AbortSignal) => Promise<StreamSocket>;
 
-const defaultConnector: SocketConnector = port =>
+const defaultConnector: SocketConnector = (port, signal) =>
   new Promise<StreamSocket>((resolve, reject) => {
     const socket = netConnect(port, "127.0.0.1");
-    socket.once("connect", () => resolve(socket));
-    socket.once("error", reject);
+    let settled = false;
+    const finish = (fn: () => void): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      socket.off("connect", onConnect);
+      socket.off("error", onError);
+      signal?.removeEventListener("abort", onAbort);
+      fn();
+    };
+    const onConnect = (): void => finish(() => resolve(socket));
+    const onError = (error: Error): void => finish(() => reject(error));
+    const onAbort = (): void =>
+      finish(() => {
+        socket.destroy();
+        reject(new Error("video-server socket connection aborted"));
+      });
+
+    socket.once("connect", onConnect);
+    socket.once("error", onError);
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
+    signal?.addEventListener("abort", onAbort, { once: true });
   });
 
 export interface PersistentEncoderH264SourceOptions {
@@ -72,6 +99,10 @@ export interface PersistentEncoderH264SourceOptions {
   timer?: Timer;
   /** How long to wait for the server to signal readiness (ms). */
   readyTimeoutMs?: number;
+  /** Bounded time to reconnect a dropped local socket before failing the source. */
+  localSocketReconnectWindowMs?: number;
+  /** Spacing between local socket reconnect attempts. */
+  localSocketReconnectRetryMs?: number;
 }
 
 const DEFAULT_READY_TIMEOUT_MS = 10_000;
@@ -94,6 +125,8 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
   private readonly connector: SocketConnector;
   private readonly timer: Timer;
   private readonly readyTimeoutMs: number;
+  private readonly localSocketReconnectWindowMs: number;
+  private readonly localSocketReconnectRetryMs: number;
 
   private server: AdbProcess | null = null;
   private socket: StreamSocket | null = null;
@@ -102,6 +135,14 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
   private teardownPromise: Promise<void> | null = null;
   private resolveStartupAudioHeader: ((header: VideoServerStreamHeader) => void) | undefined;
   private resolveStartupAudioPacket: ((packet: VideoServerPacket) => void) | undefined;
+  private socketReconnectPromise: Promise<void> | null = null;
+  private telemetryInitialized = false;
+  private lastEncodedFrameTimestampUs: number | null = null;
+  private lastIdrTimestampUs: number | null = null;
+  private idrRequestCount = 0;
+  private idrCompletionCount = 0;
+  private pendingIdrRequests = 0;
+  private encodedAccessUnitCount = 0;
 
   constructor(options: PersistentEncoderH264SourceOptions) {
     this.options = options;
@@ -109,10 +150,36 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     this.connector = options.connector ?? defaultConnector;
     this.timer = options.timer ?? defaultTimer;
     this.readyTimeoutMs = options.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS;
+    this.localSocketReconnectWindowMs =
+      options.localSocketReconnectWindowMs ?? DEFAULT_LOCAL_SOCKET_RECONNECT_WINDOW_MS;
+    this.localSocketReconnectRetryMs =
+      options.localSocketReconnectRetryMs ?? DEFAULT_LOCAL_SOCKET_RECONNECT_RETRY_MS;
+    if (this.localSocketReconnectWindowMs <= 0 || this.localSocketReconnectRetryMs <= 0) {
+      throw new ActionableError("Local socket reconnect timings must be positive milliseconds.");
+    }
   }
 
   get isRunning(): boolean {
     return this.running;
+  }
+
+  getTelemetry(): H264CaptureSourceTelemetry {
+    if (!this.telemetryInitialized) {
+      return {
+        lastEncodedFrameTimestampUs: null,
+        lastIdrTimestampUs: null,
+        idrRequestCount: null,
+        idrCompletionCount: null,
+        encodedAccessUnitCount: null,
+      };
+    }
+    return {
+      lastEncodedFrameTimestampUs: this.lastEncodedFrameTimestampUs,
+      lastIdrTimestampUs: this.lastIdrTimestampUs,
+      idrRequestCount: this.idrRequestCount,
+      idrCompletionCount: this.idrCompletionCount,
+      encodedAccessUnitCount: this.encodedAccessUnitCount,
+    };
   }
 
   async start(): Promise<void> {
@@ -152,9 +219,13 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     if (!this.running || !socket) {
       return;
     }
+    this.telemetryInitialized = true;
+    this.idrRequestCount++;
+    this.pendingIdrRequests++;
     try {
       socket.write(Buffer.from([VIDEO_SERVER_COMMAND_REQUEST_KEY_FRAME]));
     } catch (error) {
+      this.pendingIdrRequests--;
       // Best-effort: a dropped socket surfaces via its own error/close handler.
       logger.debug(`[PersistentEncoderH264Source] keyframe request write failed: ${error}`);
     }
@@ -235,7 +306,7 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
         rejectStartupSocketFailure?.(error);
         return;
       }
-      this.failIfRunning(error);
+      this.reconnectSocket(socket, error);
     }, header => this.resolveStartupAudioHeader?.(header));
 
     // For audio-enabled streams, REMOTE_SUBMIX initialization happens after the
@@ -410,6 +481,10 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     const parser = new VideoServerStreamParser({
       onHeader: header => {
         onStreamHeader?.(header);
+        // Every local client attach, including a replacement socket, triggers a
+        // fresh encoder request. The video-server has already replayed cached
+        // SPS/PPS + IDR; this makes the next frame current without a GOP wait.
+        this.requestKeyFrame();
         logger.info(
           `[PersistentEncoderH264Source] stream ${header.width}x${header.height} codec=0x${header.codecId.toString(16)}`
         );
@@ -417,6 +492,7 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
       onPacket: packet => {
         if (this.socket === socket) {
           if (packet.codecId === VIDEO_SERVER_CODEC_ID_H264) {
+            this.observeVideoPacket(packet);
             this.options.onData(packet.data);
           } else if (packet.codecId === VIDEO_SERVER_CODEC_ID_PCM16) {
             this.options.onAudioData?.(packet.data);
@@ -428,6 +504,120 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     socket.on("data", chunk => parser.push(chunk));
     socket.on("error", onSocketFailure);
     socket.on("close", () => onSocketFailure(new Error("video-server socket closed")));
+  }
+
+  private observeVideoPacket(packet: VideoServerPacket): void {
+    if (packet.config) {
+      return;
+    }
+    this.telemetryInitialized = true;
+    if (packet.replayed) {
+      // The cached IDR makes the replacement client decodable, but it was emitted
+      // before this request. Preserve its timestamp only when no live observation
+      // exists; it cannot complete a pending encoder IDR request or increment the
+      // newly encoded access-unit counter.
+      this.lastEncodedFrameTimestampUs ??= packet.ptsUs;
+      if (packet.keyFrame) {
+        this.lastIdrTimestampUs ??= packet.ptsUs;
+      }
+      return;
+    }
+    this.lastEncodedFrameTimestampUs = packet.ptsUs;
+    this.encodedAccessUnitCount++;
+    if (!packet.keyFrame) {
+      return;
+    }
+    this.lastIdrTimestampUs = packet.ptsUs;
+    if (this.pendingIdrRequests > 0) {
+      this.pendingIdrRequests--;
+      this.idrCompletionCount++;
+    }
+  }
+
+  private reconnectSocket(failedSocket: StreamSocket, error: Error): void {
+    if (
+      !this.running ||
+      this.socket !== failedSocket ||
+      this.socketReconnectPromise !== null
+    ) {
+      return;
+    }
+    this.socket = null;
+    failedSocket.destroy();
+    this.socketReconnectPromise = this.tryReconnectSocket(error).finally(() => {
+      this.socketReconnectPromise = null;
+    });
+  }
+
+  private async tryReconnectSocket(initialError: Error): Promise<void> {
+    const port = this.forwardedPort;
+    if (port === null) {
+      this.failIfRunning(initialError);
+      return;
+    }
+
+    const deadline = this.timer.now() + this.localSocketReconnectWindowMs;
+    let lastError = initialError;
+    while (this.running && this.server !== null) {
+      try {
+        const socket = await this.connectBeforeDeadline(port, deadline);
+        if (!this.running || this.server === null) {
+          socket.destroy();
+          return;
+        }
+        this.socket = socket;
+        this.wireSocket(socket, error => this.reconnectSocket(socket, error));
+        logger.info("[PersistentEncoderH264Source] reconnected to retained video-server socket");
+        return;
+      } catch (error) {
+        lastError = error instanceof Error ? error : new Error(String(error));
+      }
+
+      const remainingMs = deadline - this.timer.now();
+      if (remainingMs <= 0) {
+        break;
+      }
+      await this.timer.sleep(Math.min(this.localSocketReconnectRetryMs, remainingMs));
+    }
+
+    this.failIfRunning(
+      new Error(
+        `video-server socket did not reconnect within ${this.localSocketReconnectWindowMs}ms: ${lastError.message}`
+      )
+    );
+  }
+
+  private async connectBeforeDeadline(port: number, deadline: number): Promise<StreamSocket> {
+    const remainingMs = deadline - this.timer.now();
+    if (remainingMs <= 0) {
+      throw new Error("video-server socket reconnect deadline elapsed");
+    }
+
+    const controller = new AbortController();
+    let timedOut = false;
+    const connection = this.connector(port, controller.signal);
+    const timeout = this.timer.setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, remainingMs);
+    const timeoutFailure = new Promise<never>((_, reject) => {
+      controller.signal.addEventListener(
+        "abort",
+        () => reject(new Error("video-server socket reconnect attempt timed out")),
+        { once: true }
+      );
+    });
+
+    try {
+      return await Promise.race([connection, timeoutFailure]);
+    } finally {
+      this.timer.clearTimeout(timeout);
+      if (timedOut) {
+        // A connector that ignored cancellation may still resolve. Do not leave
+        // that late local socket open after the source has failed its deadline.
+        void connection.then(socket => socket.destroy(), () => {});
+      }
+    }
   }
 
   /** Surface a post-start fatal failure exactly once and stop feeding data. */

--- a/src/features/webrtc/RtpH264TrackWriter.ts
+++ b/src/features/webrtc/RtpH264TrackWriter.ts
@@ -40,6 +40,12 @@ export interface RtpH264TrackWriterOptions {
   initialSequenceNumber?: number;
   /** Observes each complete SPS before it can be sent to the negotiated peer. */
   onSps?: (nal: Buffer) => void;
+  /** Observes each complete H.264 access unit after it is published to RTP. */
+  onAccessUnit?: (event: {
+    timestampMs: number;
+    isIdr: boolean;
+    rtpPacketCount: number;
+  }) => void;
 }
 
 /**
@@ -57,6 +63,7 @@ export class RtpH264TrackWriter {
   private readonly mtu: number;
   private readonly timer: Timer;
   private readonly onSps?: (nal: Buffer) => void;
+  private readonly onAccessUnit?: RtpH264TrackWriterOptions["onAccessUnit"];
   private readonly parser = new H264AnnexBParser();
   private readonly assembler = new H264AccessUnitAssembler();
 
@@ -79,6 +86,7 @@ export class RtpH264TrackWriter {
     }
     this.timer = options.timer ?? defaultTimer;
     this.onSps = options.onSps;
+    this.onAccessUnit = options.onAccessUnit;
     this.sequenceNumber = (options.initialSequenceNumber ?? 0) & 0xffff;
   }
 
@@ -139,6 +147,7 @@ export class RtpH264TrackWriter {
 
   private writeAccessUnit(accessUnit: Buffer[], startMs: number): void {
     const timestamp = this.rtpTimestamp(startMs);
+    const isIdr = accessUnit.some(isKeyFrameNal);
     const units = packetizeAccessUnit(this.withParameterSets(accessUnit), this.mtu);
     if (units.length === 0) {
       return;
@@ -159,6 +168,11 @@ export class RtpH264TrackWriter {
     }
 
     this.framesWritten++;
+    this.onAccessUnit?.({
+      timestampMs: startMs,
+      isIdr,
+      rtpPacketCount: units.length,
+    });
   }
 
   /**

--- a/src/features/webrtc/VideoServerStreamParser.ts
+++ b/src/features/webrtc/VideoServerStreamParser.ts
@@ -10,7 +10,8 @@
  *   big-endian, followed by `size` bytes of encoded data.
  *   - bit 63 of `pts_and_flags`: CONFIG (codec config / SPS+PPS)
  *   - bit 62: KEY_FRAME (IDR)
- *   - bits 0-61: presentation timestamp (microseconds)
+ *   - bit 61: REPLAYED (cached packet for a replacement client)
+ *   - bits 0-60: presentation timestamp (microseconds)
  *
  * Each packet payload is already Annex-B (MediaCodec AVC byte-buffer output), so
  * the concatenation of payloads is a valid Annex-B elementary stream — exactly
@@ -33,6 +34,8 @@ const MUX_TRACK_BYTES = 16;
 const MUX_PACKET_HEADER_BYTES = 16;
 const FLAG_CONFIG = 1n << 63n;
 const FLAG_KEY_FRAME = 1n << 62n;
+const FLAG_REPLAYED = 1n << 61n;
+const PTS_MASK = FLAG_REPLAYED - 1n;
 
 export interface VideoServerStreamHeader {
   codecId: number;
@@ -51,6 +54,8 @@ export interface VideoServerPacket {
   config: boolean;
   /** Key frame (IDR). */
   keyFrame: boolean;
+  /** Cached packet replayed for a replacement LocalSocket client. */
+  replayed: boolean;
   /** Presentation timestamp in microseconds. */
   ptsUs: number;
 }
@@ -142,7 +147,8 @@ export class VideoServerStreamParser {
         data,
         config: (flags & FLAG_CONFIG) !== 0n,
         keyFrame: (flags & FLAG_KEY_FRAME) !== 0n,
-        ptsUs: Number(flags & (FLAG_KEY_FRAME - 1n)),
+        replayed: (flags & FLAG_REPLAYED) !== 0n,
+        ptsUs: Number(flags & PTS_MASK),
       });
     }
   }
@@ -169,7 +175,8 @@ export class VideoServerStreamParser {
         data,
         config: (flags & FLAG_CONFIG) !== 0n,
         keyFrame: (flags & FLAG_KEY_FRAME) !== 0n,
-        ptsUs: Number(flags & (FLAG_KEY_FRAME - 1n)),
+        replayed: (flags & FLAG_REPLAYED) !== 0n,
+        ptsUs: Number(flags & PTS_MASK),
       });
     }
   }

--- a/src/features/webrtc/WebRtcPublisher.ts
+++ b/src/features/webrtc/WebRtcPublisher.ts
@@ -95,6 +95,29 @@ export interface WebRtcPublisherDeps {
   onStateChange?: (state: ReconnectState) => void;
 }
 
+export type WebRtcCaptureSourceState =
+  | "not_initialized"
+  | "starting"
+  | "running"
+  | "failed"
+  | "stopped";
+
+/**
+ * Readiness observations exposed through the stream coordinator's status API.
+ * Timestamp and counter fields use `null` until their producer is initialized,
+ * avoiding ambiguity between absent data and a measured zero.
+ */
+export interface WebRtcStreamReadiness {
+  lastEncodedFrameTimestampUs: number | null;
+  lastIdrTimestampUs: number | null;
+  idrRequestCount: number | null;
+  idrCompletionCount: number | null;
+  encodedAccessUnitCount: number | null;
+  publisherRtpPacketCount: number | null;
+  captureSourceState: WebRtcCaptureSourceState;
+  lastSourceError: string | null;
+}
+
 /** Reconnect descriptor surfaced to callers and the coordination-server API. */
 export interface WebRtcStreamDescriptor {
   streamId: string;
@@ -107,6 +130,7 @@ export interface WebRtcStreamDescriptor {
   packetsSent: number;
   audioPacketsSent: number;
   audioSamplesSent: number;
+  readiness: WebRtcStreamReadiness;
   /**
    * True once the capture source for the current session has started. A
    * video-only stream connects and *then* starts capture, so `state` alone
@@ -159,6 +183,14 @@ export class WebRtcPublisher {
   private frameWatchdogHandle: NodeJS.Timeout | null = null;
   private frameWatchdogLastFrames = 0;
   private frameWatchdogLastAdvanceMs = 0;
+  private mediaTelemetryInitialized = false;
+  private lastEncodedFrameTimestampUs: number | null = null;
+  private lastIdrTimestampUs: number | null = null;
+  private idrRequestCount = 0;
+  private idrCompletionCount = 0;
+  private pendingIdrRequests = 0;
+  private encodedAccessUnitCount = 0;
+  private publisherRtpPacketCount = 0;
 
   constructor(config: WebRtcPublisherConfig, deps: WebRtcPublisherDeps = {}) {
     this.config = config;
@@ -258,6 +290,7 @@ export class WebRtcPublisher {
     }
     this.lastKeyFrameRequestMs = now;
     logger.debug(`[WebRTC] stream ${this.config.streamId} received PLI; requesting keyframe`);
+    this.noteKeyFrameRequest();
     try {
       this.onKeyFrameRequest();
     } catch (error) {
@@ -282,6 +315,7 @@ export class WebRtcPublisher {
       packetsSent: stats?.packetsWritten ?? 0,
       audioPacketsSent: audioStats?.packetsWritten ?? 0,
       audioSamplesSent: audioStats?.samplesWritten ?? 0,
+      readiness: this.getReadiness(),
     };
   }
 
@@ -340,7 +374,9 @@ export class WebRtcPublisher {
             );
           }
         },
+        onAccessUnit: event => this.recordAccessUnit(event),
       });
+      this.mediaTelemetryInitialized = true;
       if (this.audioEnabled) {
         const audioTrack = new MediaStreamTrack({ kind: "audio", streamId: this.config.streamId });
         const audioTransceiver = pc.addTransceiver(audioTrack, { direction: "sendonly" });
@@ -527,6 +563,56 @@ export class WebRtcPublisher {
     if (this.frameWatchdogHandle) {
       this.timer.clearInterval(this.frameWatchdogHandle);
       this.frameWatchdogHandle = null;
+    }
+  }
+
+  private noteKeyFrameRequest(): void {
+    this.mediaTelemetryInitialized = true;
+    this.idrRequestCount++;
+    this.pendingIdrRequests++;
+  }
+
+  private getReadiness(): WebRtcStreamReadiness {
+    if (!this.mediaTelemetryInitialized) {
+      return {
+        lastEncodedFrameTimestampUs: null,
+        lastIdrTimestampUs: null,
+        idrRequestCount: null,
+        idrCompletionCount: null,
+        encodedAccessUnitCount: null,
+        publisherRtpPacketCount: null,
+        captureSourceState: "not_initialized",
+        lastSourceError: null,
+      };
+    }
+    return {
+      lastEncodedFrameTimestampUs: this.lastEncodedFrameTimestampUs,
+      lastIdrTimestampUs: this.lastIdrTimestampUs,
+      idrRequestCount: this.idrRequestCount,
+      idrCompletionCount: this.idrCompletionCount,
+      encodedAccessUnitCount: this.encodedAccessUnitCount,
+      publisherRtpPacketCount: this.publisherRtpPacketCount,
+      captureSourceState: "not_initialized",
+      lastSourceError: null,
+    };
+  }
+
+  private recordAccessUnit(event: {
+    timestampMs: number;
+    isIdr: boolean;
+    rtpPacketCount: number;
+  }): void {
+    this.mediaTelemetryInitialized = true;
+    this.lastEncodedFrameTimestampUs = event.timestampMs * 1000;
+    this.encodedAccessUnitCount++;
+    this.publisherRtpPacketCount += event.rtpPacketCount;
+    if (!event.isIdr) {
+      return;
+    }
+    this.lastIdrTimestampUs = event.timestampMs * 1000;
+    if (this.pendingIdrRequests > 0) {
+      this.pendingIdrRequests--;
+      this.idrCompletionCount++;
     }
   }
 

--- a/src/features/webrtc/androidH264CaptureSourceFactory.ts
+++ b/src/features/webrtc/androidH264CaptureSourceFactory.ts
@@ -62,6 +62,15 @@ class FallbackH264CaptureSource implements H264CaptureSource {
     this.active = null;
     await active?.stop();
   }
+
+  requestKeyFrame(): void {
+    this.active?.requestKeyFrame?.();
+  }
+
+  get getTelemetry(): H264CaptureSource["getTelemetry"] {
+    const active = this.active;
+    return active?.getTelemetry?.bind(active);
+  }
 }
 
 /**

--- a/src/server/webrtcStreamManager.ts
+++ b/src/server/webrtcStreamManager.ts
@@ -9,6 +9,8 @@ import {
   resolveWebRtcStreamingConfig,
   type H264CaptureSource,
   type H264CaptureSourceOptions,
+  type H264CaptureSourceTelemetry,
+  type WebRtcCaptureSourceState,
   type WebRtcPublisherConfig,
   type WebRtcPublisherDeps,
   type WebRtcStreamDescriptor,
@@ -40,6 +42,9 @@ interface WebRtcStreamRecord {
    * "capture running" — a video-only start returns before capture begins.
    */
   sourceStarted: boolean;
+  sourceState: WebRtcCaptureSourceState;
+  lastSourceError: string | null;
+  sourceTelemetry: H264CaptureSourceTelemetry | null;
   /** Reservation token for a start that has not returned to its caller yet. */
   startToken: symbol;
 }
@@ -126,17 +131,30 @@ async function withRecord(
 
 /** Descriptor for a record, including the manager-owned capture-source state. */
 function describeRecord(record: WebRtcStreamRecord): WebRtcStreamDescriptor {
-  return { ...record.publisher.getDescriptor(), sourceStarted: record.sourceStarted };
+  const descriptor = record.publisher.getDescriptor();
+  const sourceTelemetry = record.source?.getTelemetry?.() ?? record.sourceTelemetry;
+  return {
+    ...descriptor,
+    sourceStarted: record.sourceStarted,
+    readiness: {
+      ...descriptor.readiness,
+      ...sourceTelemetry,
+      captureSourceState: record.sourceState,
+      lastSourceError: record.lastSourceError,
+    },
+  };
 }
 
 /** Stop and clear the capture source for a stream (before each (re)establish). */
 async function stopSource(record: WebRtcStreamRecord): Promise<void> {
   record.sourceStarted = false;
   if (record.source) {
+    record.sourceTelemetry = record.source.getTelemetry?.() ?? record.sourceTelemetry;
     await record.source.stop().catch(error => {
       logger.debug(`[WebRtcStream] source stop failed: ${error}`);
     });
     record.source = null;
+    record.sourceState = "stopped";
   }
 }
 
@@ -156,12 +174,16 @@ async function startSource(record: WebRtcStreamRecord): Promise<boolean> {
   if (streams.get(record.streamId) !== record) {
     return false;
   }
+  record.sourceState = "starting";
   const source = dependencies.createSource(
     {
       device: record.device,
       onData: chunk => record.publisher.writeH264Chunk(chunk),
       onAudioData: chunk => record.publisher.writePcmAudioChunk(chunk),
       onError: error => {
+        record.sourceState = "failed";
+        record.lastSourceError = error.message;
+        record.sourceTelemetry = source.getTelemetry?.() ?? record.sourceTelemetry;
         record.publisher.notifySourceFailed(error);
       },
       bitrateBps: record.bitrateBps,
@@ -172,7 +194,14 @@ async function startSource(record: WebRtcStreamRecord): Promise<boolean> {
     record.jarPath
   );
   record.source = source;
-  await source.start();
+  try {
+    await source.start();
+  } catch (error) {
+    record.sourceState = "failed";
+    record.lastSourceError = error instanceof Error ? error.message : String(error);
+    record.sourceTelemetry = source.getTelemetry?.() ?? record.sourceTelemetry;
+    throw error;
+  }
   // The stream may have been stopped while the source was starting. stop() only
   // reaches record.source, which was still null when it ran, so stop the source
   // we just spawned to avoid an orphaned screenrecord process.
@@ -182,6 +211,8 @@ async function startSource(record: WebRtcStreamRecord): Promise<boolean> {
     return false;
   }
   record.sourceStarted = true;
+  record.sourceState = "running";
+  record.sourceTelemetry = source.getTelemetry?.() ?? record.sourceTelemetry;
   return true;
 }
 
@@ -232,6 +263,16 @@ function stoppedPendingDescriptor(pending: PendingWebRtcStart): WebRtcStreamDesc
     packetsSent: 0,
     audioPacketsSent: 0,
     audioSamplesSent: 0,
+    readiness: {
+      lastEncodedFrameTimestampUs: null,
+      lastIdrTimestampUs: null,
+      idrRequestCount: null,
+      idrCompletionCount: null,
+      encodedAccessUnitCount: null,
+      publisherRtpPacketCount: null,
+      captureSourceState: "stopped",
+      lastSourceError: null,
+    },
   };
 }
 
@@ -270,9 +311,7 @@ function cancelRecordStart(record: WebRtcStreamRecord): void {
 
 /** Stop live media components while retaining best-effort cleanup semantics. */
 async function stopActiveRecord(record: WebRtcStreamRecord): Promise<void> {
-  await record.source?.stop().catch(error => {
-    logger.debug(`[WebRtcStream] source stop failed: ${error}`);
-  });
+  await stopSource(record);
   await record.publisher.stop().catch(error => {
     logger.debug(`[WebRtcStream] publisher stop failed: ${error}`);
   });
@@ -411,6 +450,9 @@ export async function startWebRtcStream(
       audioEnabled: config.audioEnabled,
       startedAt: dependencies.now().toISOString(),
       sourceStarted: false,
+      sourceState: "not_initialized",
+      lastSourceError: null,
+      sourceTelemetry: null,
       startToken,
     };
     streams.set(streamId, record);
@@ -451,9 +493,8 @@ export async function stopWebRtcStream(streamId?: string): Promise<WebRtcStreamD
   const record = resolveStreamRecord(streamId);
   streams.delete(record.streamId);
   cancelRecordStart(record);
-  const descriptor = describeRecord(record);
   await stopActiveRecord(record);
-  return { ...descriptor, state: "stopped" };
+  return { ...describeRecord(record), state: "stopped" };
 }
 
 /** List reconnect descriptors for all active streams. */

--- a/test/daemon/webrtcStreamSocketServer.test.ts
+++ b/test/daemon/webrtcStreamSocketServer.test.ts
@@ -47,6 +47,18 @@ function descriptor(streamId: string, state: WebRtcStreamDescriptor["state"] = "
     iceServers: [],
     framesSent: 0,
     packetsSent: 0,
+    audioPacketsSent: 0,
+    audioSamplesSent: 0,
+    readiness: {
+      lastEncodedFrameTimestampUs: null,
+      lastIdrTimestampUs: null,
+      idrRequestCount: null,
+      idrCompletionCount: null,
+      encodedAccessUnitCount: null,
+      publisherRtpPacketCount: null,
+      captureSourceState: "not_initialized",
+      lastSourceError: null,
+    },
   };
 }
 

--- a/test/features/webrtc/PersistentEncoderH264Source.test.ts
+++ b/test/features/webrtc/PersistentEncoderH264Source.test.ts
@@ -66,9 +66,9 @@ function streamHeader(width: number, height: number): Buffer {
   return buf;
 }
 
-function framedPacket(payload: Buffer): Buffer {
+function framedPacket(payload: Buffer, flags: bigint = 0n): Buffer {
   const header = Buffer.alloc(12);
-  header.writeBigUInt64BE(0n, 0);
+  header.writeBigUInt64BE(flags, 0);
   header.writeUInt32BE(payload.length, 8);
   return Buffer.concat([header, payload]);
 }
@@ -214,6 +214,59 @@ describe("PersistentEncoderH264Source", () => {
     // After stop, no socket is available; the request is a safe no-op.
     ctx.source.requestKeyFrame();
     expect(ctx.sockets[0].written).toEqual([Buffer.from([0x01])]);
+  });
+
+  test("reports null-before-initialization and then precise IDR readiness telemetry", async () => {
+    const ctx = makeSource();
+    expect(ctx.source.getTelemetry()).toEqual({
+      lastEncodedFrameTimestampUs: null,
+      lastIdrTimestampUs: null,
+      idrRequestCount: null,
+      idrCompletionCount: null,
+      encodedAccessUnitCount: null,
+    });
+    await startReady(ctx);
+
+    ctx.sockets[0].feed(streamHeader(480, 1040));
+    ctx.sockets[0].feed(
+      framedPacket(
+        Buffer.from([0, 0, 0, 1, 0x65, 0x80]),
+        0x4000000000000000n | 123n
+      )
+    );
+
+    expect(ctx.source.getTelemetry()).toEqual({
+      lastEncodedFrameTimestampUs: 123,
+      lastIdrTimestampUs: 123,
+      idrRequestCount: 1,
+      idrCompletionCount: 1,
+      encodedAccessUnitCount: 1,
+    });
+
+    await ctx.source.stop();
+  });
+
+  test("does not count a replayed IDR as completion of the new keyframe request", async () => {
+    const ctx = makeSource();
+    await startReady(ctx);
+
+    ctx.sockets[0].feed(streamHeader(480, 1040));
+    ctx.sockets[0].feed(
+      framedPacket(
+        Buffer.from([0, 0, 0, 1, 0x65, 0x80]),
+        0x6000000000000000n | 123n
+      )
+    );
+
+    expect(ctx.source.getTelemetry()).toEqual({
+      lastEncodedFrameTimestampUs: 123,
+      lastIdrTimestampUs: 123,
+      idrRequestCount: 1,
+      idrCompletionCount: 0,
+      encodedAccessUnitCount: 0,
+    });
+
+    await ctx.source.stop();
   });
 
   test("passes --audio and routes muxed PCM audio packets separately from video", async () => {
@@ -363,12 +416,94 @@ describe("PersistentEncoderH264Source", () => {
     expect(ctx.errors).toEqual([]);
   });
 
-  test("surfaces a post-start socket close via onError", async () => {
+  test("reconnects a post-start socket close without failing the retained encoder source", async () => {
     const ctx = makeSource();
     await startReady(ctx);
+
     ctx.sockets[0].emit("close");
+    await tick();
+
+    expect(ctx.sockets).toHaveLength(2);
+    expect(ctx.sockets[0].destroyed).toBe(true);
+    expect(ctx.errors).toEqual([]);
+    expect(ctx.source.isRunning).toBe(true);
+
+    ctx.sockets[1].feed(streamHeader(480, 1040));
+    expect(ctx.sockets[1].written).toEqual([Buffer.from([0x01])]);
+
+    await ctx.source.stop();
+  });
+
+  test("fails after the bounded local socket reconnect window", async () => {
+    const firstSocket = new FakeSocket();
+    let connectAttempts = 0;
+    const ctx = makeSource({
+      localSocketReconnectWindowMs: 200,
+      localSocketReconnectRetryMs: 100,
+      connector: async () => {
+        connectAttempts++;
+        if (connectAttempts === 1) {
+          return firstSocket;
+        }
+        throw new Error("forward unavailable");
+      },
+    });
+
+    const startPromise = ctx.source.start();
+    await tick();
+    ctx.processes[0].ready();
+    await tick();
+    await startPromise;
+
+    firstSocket.emit("close");
+    await tick(); // first failed retry is now waiting 100ms
+    ctx.timer.advanceTime(100);
+    await tick(); // second failed retry is now waiting 100ms
+    ctx.timer.advanceTime(100);
+    await tick(); // deadline expires before another connection attempt
+
+    expect(connectAttempts).toBe(3);
     expect(ctx.errors).toHaveLength(1);
+    expect(ctx.errors[0].message).toContain("did not reconnect within 200ms");
     expect(ctx.source.isRunning).toBe(false);
+  });
+
+  test("fails a hung reconnect attempt at the deadline and closes a late socket", async () => {
+    const firstSocket = new FakeSocket();
+    const lateSocket = new FakeSocket();
+    let resolveHangingConnect: ((socket: StreamSocket) => void) | undefined;
+    let connectAttempts = 0;
+    const ctx = makeSource({
+      localSocketReconnectWindowMs: 200,
+      connector: async () => {
+        connectAttempts++;
+        if (connectAttempts === 1) {
+          return firstSocket;
+        }
+        return new Promise<StreamSocket>(resolve => {
+          resolveHangingConnect = resolve;
+        });
+      },
+    });
+
+    const startPromise = ctx.source.start();
+    await tick();
+    ctx.processes[0].ready();
+    await tick();
+    await startPromise;
+
+    firstSocket.emit("close");
+    await tick();
+    ctx.timer.advanceTime(200);
+    await tick();
+
+    expect(ctx.errors).toHaveLength(1);
+    expect(ctx.errors[0].message).toContain("did not reconnect within 200ms");
+    expect(ctx.source.isRunning).toBe(false);
+
+    resolveHangingConnect?.(lateSocket);
+    await tick();
+    expect(lateSocket.destroyed).toBe(true);
   });
 
   test("surfaces a post-start server exit via onError", async () => {

--- a/test/features/webrtc/VideoServerStreamParser.test.ts
+++ b/test/features/webrtc/VideoServerStreamParser.test.ts
@@ -12,6 +12,8 @@ import {
 
 const FLAG_CONFIG = 1n << 63n;
 const FLAG_KEY_FRAME = 1n << 62n;
+const FLAG_REPLAYED = 1n << 61n;
+const PTS_MASK = FLAG_REPLAYED - 1n;
 
 function streamHeader(width: number, height: number): Buffer {
   const buf = Buffer.alloc(12);
@@ -23,7 +25,7 @@ function streamHeader(width: number, height: number): Buffer {
 
 function packet(payload: Buffer, flags: bigint, ptsUs: number): Buffer {
   const header = Buffer.alloc(12);
-  header.writeBigUInt64BE(flags | (BigInt(ptsUs) & (FLAG_KEY_FRAME - 1n)), 0);
+  header.writeBigUInt64BE(flags | (BigInt(ptsUs) & PTS_MASK), 0);
   header.writeUInt32BE(payload.length, 8);
   return Buffer.concat([header, payload]);
 }
@@ -47,7 +49,7 @@ function muxHeader(): Buffer {
 function muxPacket(trackId: number, payload: Buffer, flags: bigint, ptsUs: number): Buffer {
   const header = Buffer.alloc(16);
   header.writeUInt32BE(trackId, 0);
-  header.writeBigUInt64BE(flags | (BigInt(ptsUs) & (FLAG_KEY_FRAME - 1n)), 4);
+  header.writeBigUInt64BE(flags | (BigInt(ptsUs) & PTS_MASK), 4);
   header.writeUInt32BE(payload.length, 12);
   return Buffer.concat([header, payload]);
 }
@@ -81,6 +83,7 @@ describe("VideoServerStreamParser", () => {
       data: Buffer.from([0, 0, 0, 1, 0x67]),
       config: true,
       keyFrame: false,
+      replayed: false,
       ptsUs: 0,
     });
     expect(packets[1]).toEqual({
@@ -89,6 +92,7 @@ describe("VideoServerStreamParser", () => {
       data: Buffer.from([0, 0, 0, 1, 0x65]),
       config: false,
       keyFrame: true,
+      replayed: false,
       ptsUs: 1234,
     });
   });
@@ -126,6 +130,20 @@ describe("VideoServerStreamParser", () => {
     ]);
     parser.push(combined);
     expect(packets.map(p => p.data[0])).toEqual([0xaa, 0xbb, 0xcc]);
+  });
+
+  test("reports replayed packets without changing their flags or timestamp", () => {
+    const { parser, packets } = collect();
+    parser.push(Buffer.concat([
+      streamHeader(1, 1),
+      packet(Buffer.from([0, 0, 0, 1, 0x65]), FLAG_KEY_FRAME | FLAG_REPLAYED, 20),
+    ]));
+
+    expect(packets[0]).toMatchObject({
+      keyFrame: true,
+      replayed: true,
+      ptsUs: 20,
+    });
   });
 
   test("parses muxed video and audio packets", () => {

--- a/test/features/webrtc/WebRtcPublisher.test.ts
+++ b/test/features/webrtc/WebRtcPublisher.test.ts
@@ -368,6 +368,47 @@ describe("WebRtcPublisher keyframe requests", () => {
     pc.pliSubscribers[0]();
     expect(requests).toBe(2);
   });
+
+  test("reports IDR completion and RTP publication readiness after a relayed PLI", async () => {
+    const pc = new FakePeerConnection();
+    const timer = new FakeTimer();
+    const publisher = new WebRtcPublisher(
+      { streamId: "s", whipEndpoint: "https://coord/whip" },
+      {
+        timer,
+        createPeerConnection: () => pc as unknown as RTCPeerConnection,
+        createWhipClient: () =>
+          ({
+            publish: async () => ({ answerSdp: ACCEPTED_VIDEO_ANSWER, resourceUrl: "https://coord/whip/s" }),
+            delete: async () => {},
+          }) as unknown as WhipClient,
+        onKeyFrameRequest: () => {},
+      }
+    );
+    await publisher.start();
+    pc.pliSubscribers[0]();
+
+    const start = Buffer.from([0, 0, 0, 1]);
+    publisher.writeH264Chunk(
+      Buffer.concat([
+        start, Buffer.from([0x67, 0x42, 0xe0, 0x2a]),
+        start, Buffer.from([0x68, 0xce, 0x3c, 0x80]),
+        start, Buffer.from([0x65, 0x80, 0x00]),
+        start, Buffer.from([0x41, 0x80, 0x01]),
+        start, Buffer.from([0x41, 0x80, 0x02]),
+      ])
+    );
+
+    expect(publisher.getDescriptor().readiness).toMatchObject({
+      lastEncodedFrameTimestampUs: 0,
+      lastIdrTimestampUs: 0,
+      idrRequestCount: 1,
+      idrCompletionCount: 1,
+      encodedAccessUnitCount: 1,
+    });
+    expect(publisher.getDescriptor().readiness.publisherRtpPacketCount).toBeGreaterThan(0);
+    await publisher.stop();
+  });
 });
 
 describe("WebRtcPublisher frame-stall watchdog", () => {

--- a/test/features/webrtc/androidH264CaptureSourceFactory.test.ts
+++ b/test/features/webrtc/androidH264CaptureSourceFactory.test.ts
@@ -24,6 +24,24 @@ class FakeSource implements H264CaptureSource {
   }
 }
 
+class PersistentFakeSource extends FakeSource {
+  keyFrameRequests = 0;
+
+  requestKeyFrame(): void {
+    this.keyFrameRequests++;
+  }
+
+  getTelemetry() {
+    return {
+      lastEncodedFrameTimestampUs: 123,
+      lastIdrTimestampUs: 123,
+      idrRequestCount: 1,
+      idrCompletionCount: 1,
+      encodedAccessUnitCount: 2,
+    };
+  }
+}
+
 function baseOptions(): AndroidH264SourceOptions {
   return { device: DEVICE, onData: () => {} };
 }
@@ -62,6 +80,27 @@ describe("createAndroidH264CaptureSource", () => {
     await source.stop();
     expect(persistent.stopped).toBe(1);
     expect(screenrecord.stopped).toBe(0);
+  });
+
+  test("forwards persistent keyframe control and telemetry through the fallback wrapper", async () => {
+    const persistent = new PersistentFakeSource();
+    const deps: AndroidH264CaptureSourceDeps = {
+      createPersistent: () => persistent,
+      createScreenrecord: () => new FakeSource(),
+    };
+    const source = createAndroidH264CaptureSource(baseOptions(), "/tmp/automobile-video.jar", deps);
+
+    await source.start();
+    source.requestKeyFrame?.();
+
+    expect(persistent.keyFrameRequests).toBe(1);
+    expect(source.getTelemetry?.()).toEqual({
+      lastEncodedFrameTimestampUs: 123,
+      lastIdrTimestampUs: 123,
+      idrRequestCount: 1,
+      idrCompletionCount: 1,
+      encodedAccessUnitCount: 2,
+    });
   });
 
   test("falls back to screenrecord when the persistent encoder fails to start", async () => {

--- a/test/server/webrtcStreamManager.test.ts
+++ b/test/server/webrtcStreamManager.test.ts
@@ -76,6 +76,18 @@ class FakePublisher {
       iceServers: [],
       framesSent: 0,
       packetsSent: 0,
+      audioPacketsSent: 0,
+      audioSamplesSent: 0,
+      readiness: {
+        lastEncodedFrameTimestampUs: null,
+        lastIdrTimestampUs: null,
+        idrRequestCount: null,
+        idrCompletionCount: null,
+        encodedAccessUnitCount: null,
+        publisherRtpPacketCount: null,
+        captureSourceState: "not_initialized",
+        lastSourceError: null,
+      },
     };
   }
 }
@@ -145,6 +157,8 @@ describe("webrtcStreamManager", () => {
     // onBeforeEstablish started the capture source.
     expect(sources[0].started).toBe(true);
     expect(listWebRtcStreams()).toHaveLength(1);
+    expect(descriptor.readiness.captureSourceState).toBe("running");
+    expect(descriptor.readiness.lastSourceError).toBeNull();
   });
 
   test("relays a downstream keyframe request (WHEP viewer PLI) to the capture source", async () => {


### PR DESCRIPTION
## Summary

- make Android VideoServer client replacement deterministic by retaining encoder output during a bounded reconnect window and replaying cached decoder state
- forward keyframe control and encoder telemetry through the Android fallback capture source
- bound hung local socket reconnect attempts, and distinguish replayed IDRs from newly emitted IDRs in readiness telemetry
- expose and document readiness status for source, encoder, IDR, and RTP publication diagnosis

## Root Cause

The fallback wrapper hid the persistent encoder's control-plane methods, a pending local TCP connect could outlive the reconnect deadline, and cached IDRs were incorrectly treated as completion of a newly requested encoder IDR.

## Validation

- `bun test test/features/webrtc/androidH264CaptureSourceFactory.test.ts test/features/webrtc/PersistentEncoderH264Source.test.ts test/features/webrtc/VideoServerStreamParser.test.ts test/features/webrtc/WebRtcPublisher.test.ts test/server/webrtcStreamManager.test.ts test/daemon/webrtcStreamSocketServer.test.ts`
- `(cd android && ./gradlew :video-server:test :desktop-core:test --tests dev.jasonpearson.automobile.video.VideoStreamProtocolTest --tests dev.jasonpearson.automobile.desktop.core.daemon.WebRtcStreamSocketClientTest)`
- `bun run build`
- `bun run lint`

The branch was rebased onto current `main` before this PR. The physical Android/iOS device and WHEP timing matrix still require dedicated device-environment validation.
