### PR TITLE
fix(webrtc): bound iOS raw-frame handoff

### DIFF
--- a/ios/screen-capture/Sources/ScreenCaptureCore/FrameWriter.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/FrameWriter.swift
@@ -141,7 +141,10 @@ public final class FrameWriter {
     /// Queues bounded, ordered audio records on the same serial writer. Unlike
     /// video, PCM records cannot be replaced without creating audible gaps.
     public func writeAudio(pcm16le: Data) {
-        guard pcm16le.count <= configuration.maximumPendingAudioBytes else { return }
+        guard !pcm16le.isEmpty,
+              pcm16le.count <= configuration.maximumPendingAudioBytes else {
+            return
+        }
         let record = PendingRecord(
             header: FrameProtocol.encodeAudioHeader(payloadLength: pcm16le.count),
             payload: pcm16le,
@@ -235,8 +238,8 @@ public final class FrameWriter {
         return nil
     }
 
-    private func takeFrameLocked() -> PendingRecord {
-        let frame = pendingFrame!
+    private func takeFrameLocked() -> PendingRecord? {
+        guard let frame = pendingFrame else { return nil }
         pendingFrame = nil
         lastWrittenRecordKind = .frame
         return frame

--- a/ios/screen-capture/Sources/ScreenCaptureCore/FrameWriter.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/FrameWriter.swift
@@ -6,45 +6,251 @@ public protocol FrameSink: AnyObject {
     func write(_ data: Data)
 }
 
-/// Writes encoded frame header + BGRA payload to a `FrameSink`.
-public final class FrameWriter {
-    private let sink: FrameSink
-    private let startTime: Date
+/// Snapshot of the raw-frame handoff. The video queue is structurally one slot:
+/// at most one newest frame can wait while stdout is blocked.
+public struct FrameWriterMetrics: Codable, Equatable {
+    public let captureTimestampMs: UInt32?
+    public let frameQueueAgeMs: Double?
+    public let frameQueueDepth: Int
+    public let droppedFrames: UInt64
+    public let bytesQueued: Int
+    public let highWaterMarkBytes: Int
+    public let lastOutputWriteDurationMs: Double?
 
-    public init(sink: FrameSink, startTime: Date = Date()) {
-        self.sink = sink
-        self.startTime = startTime
+    public init(
+        captureTimestampMs: UInt32?,
+        frameQueueAgeMs: Double?,
+        frameQueueDepth: Int,
+        droppedFrames: UInt64,
+        bytesQueued: Int,
+        highWaterMarkBytes: Int,
+        lastOutputWriteDurationMs: Double?
+    ) {
+        self.captureTimestampMs = captureTimestampMs
+        self.frameQueueAgeMs = frameQueueAgeMs
+        self.frameQueueDepth = frameQueueDepth
+        self.droppedFrames = droppedFrames
+        self.bytesQueued = bytesQueued
+        self.highWaterMarkBytes = highWaterMarkBytes
+        self.lastOutputWriteDurationMs = lastOutputWriteDurationMs
+    }
+}
+
+/// Writes framed BGRA records to a `FrameSink` without blocking the capture
+/// callback. Pixel data is copied while the caller holds its CVPixelBuffer lock,
+/// then a serial output worker writes only the newest pending frame.
+public final class FrameWriter {
+    public struct Configuration {
+        /// Enough for current iPhone and iPad BGRA captures, while bounding raw
+        /// buffering to one frame when stdout's consumer is slow.
+        public static let defaultMaximumPendingFrameBytes = 32 * 1024 * 1024
+        public static let defaultMaximumPendingAudioBytes = 64 * 1024
+
+        public let maximumPendingFrameBytes: Int
+        public let maximumPendingAudioBytes: Int
+
+        public init(
+            maximumPendingFrameBytes: Int = defaultMaximumPendingFrameBytes,
+            maximumPendingAudioBytes: Int = defaultMaximumPendingAudioBytes
+        ) {
+            precondition(maximumPendingFrameBytes > 0)
+            precondition(maximumPendingAudioBytes > 0)
+            self.maximumPendingFrameBytes = maximumPendingFrameBytes
+            self.maximumPendingAudioBytes = maximumPendingAudioBytes
+        }
     }
 
+    private struct PendingRecord {
+        let header: Data
+        let payload: Data
+        let captureTimestampMs: UInt32?
+        let enqueuedAt: Date
+    }
+
+    private enum RecordKind {
+        case frame
+        case audio
+    }
+
+    private let sink: FrameSink
+    private let startTime: Date
+    private let configuration: Configuration
+    private let stateLock = NSLock()
+    private let outputQueue = DispatchQueue(label: "automobile.screen-capture.stdout")
+    private var pendingFrame: PendingRecord?
+    private var pendingAudio: [PendingRecord] = []
+    private var pendingAudioBytes = 0
+    private var lastWrittenRecordKind: RecordKind?
+    private var outputWorkerScheduled = false
+    private var droppedFrames: UInt64 = 0
+    private var latestCaptureTimestampMs: UInt32?
+    private var highWaterMarkBytes = 0
+    private var lastOutputWriteDurationMs: Double?
+
+    public init(
+        sink: FrameSink,
+        startTime: Date = Date(),
+        configuration: Configuration = Configuration()
+    ) {
+        self.sink = sink
+        self.startTime = startTime
+        self.configuration = configuration
+    }
+
+    /// Copies an unlocked-safe frame and atomically replaces any unread older
+    /// frame. `false` means the raw frame exceeded the fixed memory budget.
+    @discardableResult
     public func write(
         width: Int,
         height: Int,
         bytesPerRow: Int,
         baseAddress: UnsafeRawPointer,
         timestamp: Date = Date()
-    ) {
+    ) -> Bool {
+        let payloadLength = bytesPerRow * height
         let elapsedMs = max(0, timestamp.timeIntervalSince(startTime) * 1000)
-        let header = FrameProtocol.Header(
+        let captureTimestampMs = UInt32(truncatingIfNeeded: UInt64(elapsedMs))
+        guard payloadLength <= configuration.maximumPendingFrameBytes else {
+            stateLock.lock()
+            latestCaptureTimestampMs = captureTimestampMs
+            droppedFrames += 1
+            stateLock.unlock()
+            return false
+        }
+
+        let header = FrameProtocol.encodeHeader(FrameProtocol.Header(
             width: UInt32(width),
             height: UInt32(height),
             bytesPerRow: UInt32(bytesPerRow),
-            timestampMs: UInt32(truncatingIfNeeded: UInt64(elapsedMs))
+            timestampMs: captureTimestampMs
+        ))
+        // The capture callback owns the pixel-buffer lock. This one copy lets it
+        // release that lock before stdout can block on a slow Node consumer.
+        let payload = Data(bytes: baseAddress, count: payloadLength)
+        let record = PendingRecord(
+            header: header,
+            payload: payload,
+            captureTimestampMs: captureTimestampMs,
+            enqueuedAt: Date()
         )
-        sink.write(FrameProtocol.encodeHeader(header))
-        // bytesNoCopy avoids copying the pixel buffer into a transient Data.
-        // The caller (DeviceCaptureSession.captureOutput) holds the underlying
-        // CVPixelBuffer locked for the duration of this synchronous write.
-        let payload = Data(
-            bytesNoCopy: UnsafeMutableRawPointer(mutating: baseAddress),
-            count: bytesPerRow * height,
-            deallocator: .none
-        )
-        sink.write(payload)
+
+        enqueueFrame(record)
+        return true
     }
 
+    /// Queues bounded, ordered audio records on the same serial writer. Unlike
+    /// video, PCM records cannot be replaced without creating audible gaps.
     public func writeAudio(pcm16le: Data) {
-        sink.write(FrameProtocol.encodeAudioHeader(payloadLength: pcm16le.count))
-        sink.write(pcm16le)
+        guard pcm16le.count <= configuration.maximumPendingAudioBytes else { return }
+        let record = PendingRecord(
+            header: FrameProtocol.encodeAudioHeader(payloadLength: pcm16le.count),
+            payload: pcm16le,
+            captureTimestampMs: nil,
+            enqueuedAt: Date()
+        )
+
+        stateLock.lock()
+        while pendingAudioBytes + record.payload.count > configuration.maximumPendingAudioBytes,
+              let dropped = pendingAudio.first {
+            pendingAudio.removeFirst()
+            pendingAudioBytes -= dropped.payload.count
+        }
+        pendingAudio.append(record)
+        pendingAudioBytes += record.payload.count
+        highWaterMarkBytes = max(highWaterMarkBytes, queuedBytesLocked())
+        let shouldSchedule = !outputWorkerScheduled
+        outputWorkerScheduled = true
+        stateLock.unlock()
+        if shouldSchedule {
+            outputQueue.async { self.drain() }
+        }
+    }
+
+    public func metrics(now: Date = Date()) -> FrameWriterMetrics {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        let pending = pendingFrame
+        return FrameWriterMetrics(
+            captureTimestampMs: pending?.captureTimestampMs ?? latestCaptureTimestampMs,
+            frameQueueAgeMs: pending.map { max(0, now.timeIntervalSince($0.enqueuedAt) * 1000) },
+            frameQueueDepth: pending == nil ? 0 : 1,
+            droppedFrames: droppedFrames,
+            bytesQueued: queuedBytesLocked(),
+            highWaterMarkBytes: highWaterMarkBytes,
+            lastOutputWriteDurationMs: lastOutputWriteDurationMs
+        )
+    }
+
+    /// Waits for all records scheduled before this call. Intended for tests and
+    /// orderly shutdown; production capture never blocks its callback on this.
+    public func flush() {
+        outputQueue.sync {}
+    }
+
+    private func enqueueFrame(_ record: PendingRecord) {
+        stateLock.lock()
+        latestCaptureTimestampMs = record.captureTimestampMs
+        if pendingFrame != nil {
+            droppedFrames += 1
+        }
+        pendingFrame = record
+        highWaterMarkBytes = max(highWaterMarkBytes, queuedBytesLocked())
+        let shouldSchedule = !outputWorkerScheduled
+        outputWorkerScheduled = true
+        stateLock.unlock()
+        if shouldSchedule {
+            outputQueue.async { self.drain() }
+        }
+    }
+
+    private func drain() {
+        while let record = takeNextRecord() {
+            let startedAt = Date()
+            sink.write(record.header)
+            sink.write(record.payload)
+            let durationMs = max(0, Date().timeIntervalSince(startedAt) * 1000)
+            stateLock.lock()
+            lastOutputWriteDurationMs = durationMs
+            stateLock.unlock()
+        }
+    }
+
+    private func takeNextRecord() -> PendingRecord? {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+
+        if pendingFrame != nil, !pendingAudio.isEmpty {
+            if lastWrittenRecordKind == .frame {
+                return takeAudioLocked()
+            }
+            return takeFrameLocked()
+        }
+        if pendingFrame != nil {
+            return takeFrameLocked()
+        }
+        if !pendingAudio.isEmpty {
+            return takeAudioLocked()
+        }
+        outputWorkerScheduled = false
+        return nil
+    }
+
+    private func takeFrameLocked() -> PendingRecord {
+        let frame = pendingFrame!
+        pendingFrame = nil
+        lastWrittenRecordKind = .frame
+        return frame
+    }
+
+    private func takeAudioLocked() -> PendingRecord {
+        let audio = pendingAudio.removeFirst()
+        pendingAudioBytes -= audio.payload.count
+        lastWrittenRecordKind = .audio
+        return audio
+    }
+
+    private func queuedBytesLocked() -> Int {
+        (pendingFrame?.payload.count ?? 0) + pendingAudioBytes
     }
 }
 

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/FrameWriter+PixelBuffer.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/FrameWriter+PixelBuffer.swift
@@ -4,9 +4,10 @@ import Foundation
 import ScreenCaptureCore
 
 extension FrameWriter {
-    /// Writes one frame from a `CMSampleBuffer`, locking the underlying pixel
-    /// buffer for the duration of the synchronous sink write. Returns `false`
-    /// when the sample buffer has no image (e.g. dropped/idle frames).
+    /// Copies one frame from a `CMSampleBuffer` into the bounded latest-frame
+    /// queue. The pixel buffer stays locked only for that copy, never for a
+    /// potentially blocking stdout write. Returns `false` when no image exists
+    /// or when the raw frame exceeds the queue's fixed byte cap.
     @discardableResult
     func write(sampleBuffer: CMSampleBuffer) -> Bool {
         guard let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return false }
@@ -14,12 +15,11 @@ extension FrameWriter {
         defer { CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly) }
         guard let base = CVPixelBufferGetBaseAddress(pixelBuffer) else { return false }
 
-        write(
+        return write(
             width: CVPixelBufferGetWidth(pixelBuffer),
             height: CVPixelBufferGetHeight(pixelBuffer),
             bytesPerRow: CVPixelBufferGetBytesPerRow(pixelBuffer),
             baseAddress: base
         )
-        return true
     }
 }

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
@@ -22,6 +22,44 @@ func logError(_ message: String) {
     FileHandle.standardError.write(Data("\(message)\n".utf8))
 }
 
+private final class FrameMetricsReporter {
+    private static let linePrefix = "automobile-frame-metrics:"
+
+    private let writer: FrameWriter
+    private let output: (String) -> Void
+    private let queue = DispatchQueue(label: "automobile.screen-capture.metrics")
+    private var timer: DispatchSourceTimer?
+
+    init(writer: FrameWriter, output: @escaping (String) -> Void) {
+        self.writer = writer
+        self.output = output
+    }
+
+    func start() {
+        guard timer == nil else { return }
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + 1, repeating: 1)
+        timer.setEventHandler { [weak self] in
+            self?.emitSnapshot()
+        }
+        self.timer = timer
+        timer.resume()
+    }
+
+    func stop() {
+        timer?.cancel()
+        timer = nil
+    }
+
+    private func emitSnapshot() {
+        guard let encoded = try? JSONEncoder().encode(writer.metrics()),
+              let json = String(data: encoded, encoding: .utf8) else {
+            return
+        }
+        output("\(Self.linePrefix)\(json)")
+    }
+}
+
 // ScreenCaptureKit failures can surface as Objective-C exceptions, which would
 // otherwise terminate this subprocess with only SIGABRT visible to its parent.
 // Emit the exception while stderr is still connected so the daemon artifact
@@ -136,6 +174,8 @@ case .captureSimulator(let windowID, let fps, let audio):
 
     let sink = FileHandleFrameSink(handle: .standardOutput)
     let writer = FrameWriter(sink: sink)
+    let metricsReporter = FrameMetricsReporter(writer: writer, output: logError)
+    metricsReporter.start()
     let simSession = SimulatorCaptureSession(writer: writer) { error in
         logError("error: ScreenCaptureKit stream stopped: \(error)")
     }
@@ -164,6 +204,7 @@ case .captureSimulator(let windowID, let fps, let audio):
     }
 
     installShutdownHandlers {
+        metricsReporter.stop()
         runBlocking { await simSession.stop() }
         exit(0)
     }
@@ -191,6 +232,8 @@ case .capture(let deviceID):
 
     let sink = FileHandleFrameSink(handle: .standardOutput)
     let writer = FrameWriter(sink: sink)
+    let metricsReporter = FrameMetricsReporter(writer: writer, output: logError)
+    metricsReporter.start()
     let captureSession = DeviceCaptureSession(writer: writer) { error in
         logError("error: iOS device capture failed: \(error)")
     }
@@ -203,6 +246,7 @@ case .capture(let deviceID):
     }
 
     installShutdownHandlers {
+        metricsReporter.stop()
         captureSession.stop()
         exit(0)
     }

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/FrameWriterTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/FrameWriterTests.swift
@@ -167,4 +167,28 @@ final class FrameWriterTests: XCTestCase {
         )
         XCTAssertEqual(writer.metrics().bytesQueued, 0)
     }
+
+    func testSlowSinkDiscardsEmptyAudioRecords() {
+        let sink = BlockingPayloadSink()
+        let writer = FrameWriter(
+            sink: sink,
+            configuration: .init(maximumPendingFrameBytes: 4)
+        )
+        let first: [UInt8] = [0x11, 0x11, 0x11, 0x11]
+
+        first.withUnsafeBufferPointer { ptr in
+            XCTAssertTrue(writer.write(width: 1, height: 1, bytesPerRow: 4, baseAddress: ptr.baseAddress!))
+        }
+        XCTAssertTrue(sink.waitForFirstPayload())
+
+        for _ in 0..<10 {
+            writer.writeAudio(pcm16le: Data())
+        }
+
+        sink.allowOutput()
+        writer.flush()
+
+        XCTAssertEqual(sink.payloads(), [Data(first)])
+        XCTAssertEqual(writer.metrics().bytesQueued, 0)
+    }
 }

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/FrameWriterTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/FrameWriterTests.swift
@@ -9,6 +9,45 @@ final class BufferSink: FrameSink {
     func write(_ chunk: Data) { data.append(chunk) }
 }
 
+final class BlockingPayloadSink: FrameSink {
+    private let lock = NSLock()
+    private var writeCount = 0
+    private let firstPayloadStarted = DispatchSemaphore(value: 0)
+    private let allowFirstPayload = DispatchSemaphore(value: 0)
+    private(set) var writes: [Data] = []
+    private var writtenPayloads: [Data] = []
+
+    func write(_ chunk: Data) {
+        lock.lock()
+        writes.append(chunk)
+        writeCount += 1
+        if writeCount.isMultiple(of: 2) {
+            writtenPayloads.append(chunk)
+        }
+        let shouldBlock = writeCount == 2
+        lock.unlock()
+
+        if shouldBlock {
+            firstPayloadStarted.signal()
+            _ = allowFirstPayload.wait(timeout: .now() + 1)
+        }
+    }
+
+    func waitForFirstPayload() -> Bool {
+        firstPayloadStarted.wait(timeout: .now() + 1) == .success
+    }
+
+    func allowOutput() {
+        allowFirstPayload.signal()
+    }
+
+    func payloads() -> [Data] {
+        lock.lock()
+        defer { lock.unlock() }
+        return writtenPayloads
+    }
+}
+
 final class FrameWriterTests: XCTestCase {
     func testWritesHeaderFollowedByPayload() {
         let sink = BufferSink()
@@ -21,7 +60,7 @@ final class FrameWriterTests: XCTestCase {
         // 24 bytes of BGRA: 2px × 3 rows × 4 bytes
         let payload = Array(0..<UInt8(bytesPerRow * height))
 
-        payload.withUnsafeBufferPointer { ptr in
+        _ = payload.withUnsafeBufferPointer { ptr in
             writer.write(
                 width: width,
                 height: height,
@@ -30,6 +69,7 @@ final class FrameWriterTests: XCTestCase {
                 timestamp: Date(timeIntervalSince1970: 0.5)
             )
         }
+        writer.flush()
 
         XCTAssertEqual(sink.data.count, FrameProtocol.headerSize + bytesPerRow * height)
         let header = FrameProtocol.decodeHeader(sink.data.prefix(FrameProtocol.headerSize))
@@ -47,7 +87,7 @@ final class FrameWriterTests: XCTestCase {
             startTime: Date(timeIntervalSince1970: 100)
         )
         let payload: [UInt8] = [0, 1, 2, 3]
-        payload.withUnsafeBufferPointer { ptr in
+        _ = payload.withUnsafeBufferPointer { ptr in
             writer.write(
                 width: 1,
                 height: 1,
@@ -56,7 +96,75 @@ final class FrameWriterTests: XCTestCase {
                 timestamp: Date(timeIntervalSince1970: 0)
             )
         }
+        writer.flush()
         let header = FrameProtocol.decodeHeader(sink.data.prefix(FrameProtocol.headerSize))
         XCTAssertEqual(header?.timestampMs, 0)
+    }
+
+    func testSlowSinkKeepsOnlyTheNewestPendingFrame() {
+        let sink = BlockingPayloadSink()
+        let writer = FrameWriter(
+            sink: sink,
+            configuration: .init(maximumPendingFrameBytes: 4)
+        )
+        let first: [UInt8] = [0x11, 0x11, 0x11, 0x11]
+        let stale: [UInt8] = [0x22, 0x22, 0x22, 0x22]
+        let newest: [UInt8] = [0x33, 0x33, 0x33, 0x33]
+
+        first.withUnsafeBufferPointer { ptr in
+            XCTAssertTrue(writer.write(width: 1, height: 1, bytesPerRow: 4, baseAddress: ptr.baseAddress!))
+        }
+        XCTAssertTrue(sink.waitForFirstPayload())
+        stale.withUnsafeBufferPointer { ptr in
+            XCTAssertTrue(writer.write(width: 1, height: 1, bytesPerRow: 4, baseAddress: ptr.baseAddress!))
+        }
+        newest.withUnsafeBufferPointer { ptr in
+            XCTAssertTrue(writer.write(width: 1, height: 1, bytesPerRow: 4, baseAddress: ptr.baseAddress!))
+        }
+
+        let metrics = writer.metrics()
+        XCTAssertEqual(metrics.frameQueueDepth, 1)
+        XCTAssertEqual(metrics.droppedFrames, 1)
+        XCTAssertEqual(metrics.bytesQueued, 4)
+        XCTAssertEqual(metrics.highWaterMarkBytes, 4)
+
+        sink.allowOutput()
+        writer.flush()
+
+        XCTAssertEqual(sink.payloads(), [Data(first), Data(newest)])
+        XCTAssertEqual(writer.metrics().frameQueueDepth, 0)
+    }
+
+    func testSlowSinkDrainsOrderedAudioBeforeAnotherPendingFrame() {
+        let sink = BlockingPayloadSink()
+        let writer = FrameWriter(
+            sink: sink,
+            configuration: .init(maximumPendingFrameBytes: 4, maximumPendingAudioBytes: 8)
+        )
+        let first: [UInt8] = [0x11, 0x11, 0x11, 0x11]
+        let newest: [UInt8] = [0x33, 0x33, 0x33, 0x33]
+        let firstAudio = Data([0xaa, 0xaa, 0xaa, 0xaa])
+        let secondAudio = Data([0xbb, 0xbb, 0xbb, 0xbb])
+
+        first.withUnsafeBufferPointer { ptr in
+            XCTAssertTrue(writer.write(width: 1, height: 1, bytesPerRow: 4, baseAddress: ptr.baseAddress!))
+        }
+        XCTAssertTrue(sink.waitForFirstPayload())
+
+        writer.writeAudio(pcm16le: firstAudio)
+        writer.writeAudio(pcm16le: secondAudio)
+        newest.withUnsafeBufferPointer { ptr in
+            XCTAssertTrue(writer.write(width: 1, height: 1, bytesPerRow: 4, baseAddress: ptr.baseAddress!))
+        }
+
+        XCTAssertEqual(writer.metrics().bytesQueued, 12)
+        sink.allowOutput()
+        writer.flush()
+
+        XCTAssertEqual(
+            sink.payloads(),
+            [Data(first), firstAudio, Data(newest), secondAudio]
+        )
+        XCTAssertEqual(writer.metrics().bytesQueued, 0)
     }
 }

--- a/src/daemon/webrtcStreamSocketServer.ts
+++ b/src/daemon/webrtcStreamSocketServer.ts
@@ -156,7 +156,7 @@ export class WebRtcStreamSocketServer extends RequestResponseSocketServer<
     if (request.whipToken) {
       overrides.bearerToken = request.whipToken;
     }
-    if (request.iceServers && request.iceServers.length > 0) {
+    if (request.iceServers !== undefined) {
       overrides.iceServers = request.iceServers;
     }
     if (request.bitrateKbps !== undefined) {

--- a/src/features/screen-stream/IOSScreenCaptureHelper.ts
+++ b/src/features/screen-stream/IOSScreenCaptureHelper.ts
@@ -10,6 +10,17 @@ import {
   FrameDecoder,
   type MalformedFrameError,
 } from "./frameProtocol";
+import {
+  LatestFrameQueue,
+  type FrameQueueMetrics,
+} from "./LatestFrameQueue";
+
+export { type FrameQueueMetrics } from "./LatestFrameQueue";
+
+/** Fixed bound for the one decoded BGRA frame waiting for delivery. */
+export const IOS_SCREEN_CAPTURE_MAX_FRAME_BYTES = 32 * 1024 * 1024;
+/** Prefix used by the helper to send JSON queue snapshots over stderr. */
+export const NATIVE_FRAME_METRICS_PREFIX = "automobile-frame-metrics:";
 
 export type HelperSpawner = (
   command: string,
@@ -35,15 +46,36 @@ export interface IosScreenCaptureHelperOptions {
   target: CaptureTarget;
   /** Override the spawner for tests. Defaults to `child_process.spawn`. */
   spawner?: HelperSpawner;
+  /** Clock seam for queue-age metrics. */
+  now?: () => number;
+  /** Scheduling seam for tests and embedders with a controlled event loop. */
+  frameDeliveryScheduler?: FrameDeliveryScheduler;
 }
 
 export interface IosScreenCaptureHelperEvents {
   frame: (frame: DecodedFrame) => void;
+  frameMetrics: (metrics: FrameQueueMetrics) => void;
+  captureMetrics: (metrics: NativeFrameMetrics) => void;
   audio: (audio: DecodedAudio) => void;
   malformed: (error: MalformedFrameError) => void;
   stderr: (line: string) => void;
   exit: (info: { code: number | null; signal: NodeJS.Signals | null }) => void;
   error: (error: Error) => void;
+}
+
+export interface FrameDeliveryScheduler {
+  schedule(callback: () => void): void;
+}
+
+/** Snapshot emitted by the Swift writer's bounded stdout handoff. */
+export interface NativeFrameMetrics {
+  captureTimestampMs: number | null;
+  frameQueueAgeMs: number | null;
+  frameQueueDepth: 0 | 1;
+  droppedFrames: number;
+  bytesQueued: number;
+  highWaterMarkBytes: number;
+  lastOutputWriteDurationMs: number | null;
 }
 
 /**
@@ -64,15 +96,23 @@ export class IOSScreenCaptureHelper extends EventEmitter {
   private readonly target: CaptureTarget;
   private readonly spawner: HelperSpawner;
   private readonly decoder = new FrameDecoder();
+  private readonly frameQueue: LatestFrameQueue;
+  private readonly frameDeliveryScheduler: FrameDeliveryScheduler;
   private process: ChildProcessWithoutNullStreams | null = null;
   private stderrBuffer = "";
   private exitPromise: Promise<{ code: number | null; signal: NodeJS.Signals | null }> | null = null;
+  private frameDeliveryScheduled = false;
 
   constructor(options: IosScreenCaptureHelperOptions) {
     super();
     this.binaryPath = options.binaryPath;
     this.target = options.target;
     this.spawner = options.spawner ?? (nodeSpawn as HelperSpawner);
+    this.frameQueue = new LatestFrameQueue({
+      maxFrameBytes: IOS_SCREEN_CAPTURE_MAX_FRAME_BYTES,
+      now: options.now ?? Date.now,
+    });
+    this.frameDeliveryScheduler = options.frameDeliveryScheduler ?? immediateFrameDeliveryScheduler;
   }
 
   override on<E extends keyof IosScreenCaptureHelperEvents>(
@@ -93,6 +133,11 @@ export class IOSScreenCaptureHelper extends EventEmitter {
     return this.process !== null && this.process.exitCode === null && !this.process.killed;
   }
 
+  /** Snapshot of the bounded decoded-frame handoff. */
+  getFrameMetrics(): FrameQueueMetrics {
+    return this.frameQueue.metrics();
+  }
+
   /** Throws if already started — instances are single-shot. */
   start(): void {
     if (this.process !== null) {
@@ -108,10 +153,13 @@ export class IOSScreenCaptureHelper extends EventEmitter {
       const frames = this.decoder.push(
         buf,
         err => this.emit("malformed", err),
-        audio => this.emit("audio", audio)
+        audio => this.emit("audio", audio),
+        frame => this.enqueueFrame(frame)
       );
+      // `onFrame` keeps the decoder from allocating an array for a coalesced
+      // stdout chunk. Preserve the fallback return path for direct decoder use.
       for (const frame of frames) {
-        this.emit("frame", frame);
+        this.enqueueFrame(frame);
       }
     });
 
@@ -127,7 +175,7 @@ export class IOSScreenCaptureHelper extends EventEmitter {
     this.exitPromise = new Promise(resolve => {
       proc.once("exit", (code, signal) => {
         if (this.stderrBuffer.length > 0) {
-          this.emit("stderr", this.stderrBuffer);
+          this.handleStderrLine(this.stderrBuffer);
           this.stderrBuffer = "";
         }
         const info = { code, signal };
@@ -152,6 +200,7 @@ export class IOSScreenCaptureHelper extends EventEmitter {
     proc.stdout.removeAllListeners();
     proc.stderr.removeAllListeners();
     proc.removeAllListeners();
+    this.frameQueue.clear();
     this.process = null;
     return result;
   }
@@ -167,12 +216,92 @@ export class IOSScreenCaptureHelper extends EventEmitter {
     const lines = this.stderrBuffer.split("\n");
     this.stderrBuffer = lines.pop() ?? "";
     for (const line of lines) {
-      this.emit("stderr", line);
+      this.handleStderrLine(line);
     }
+  }
+
+  private enqueueFrame(frame: DecodedFrame): void {
+    if (!this.frameQueue.enqueue(frame)) {
+      this.emit("frameMetrics", this.frameQueue.metrics());
+      return;
+    }
+    this.emit("frameMetrics", this.frameQueue.metrics());
+    if (this.frameDeliveryScheduled) {return;}
+    this.frameDeliveryScheduled = true;
+    this.frameDeliveryScheduler.schedule(() => this.deliverLatestFrame());
+  }
+
+  private deliverLatestFrame(): void {
+    this.frameDeliveryScheduled = false;
+    const frame = this.frameQueue.take();
+    if (frame === null) {return;}
+    this.emit("frame", frame);
+    this.emit("frameMetrics", this.frameQueue.metrics());
+    if (this.frameQueue.metrics().queueDepth === 1) {
+      this.frameDeliveryScheduled = true;
+      this.frameDeliveryScheduler.schedule(() => this.deliverLatestFrame());
+    }
+  }
+
+  private handleStderrLine(line: string): void {
+    const metrics = parseNativeFrameMetrics(line);
+    if (metrics !== null) {
+      this.emit("captureMetrics", metrics);
+      return;
+    }
+    this.emit("stderr", line);
   }
 
   private static readonly STDERR_BUFFER_MAX = 64 * 1024;
 }
+
+function parseNativeFrameMetrics(line: string): NativeFrameMetrics | null {
+  if (!line.startsWith(NATIVE_FRAME_METRICS_PREFIX)) {
+    return null;
+  }
+  try {
+    const value: unknown = JSON.parse(line.slice(NATIVE_FRAME_METRICS_PREFIX.length));
+    if (!isNativeFrameMetrics(value)) {
+      return null;
+    }
+    return value;
+  } catch (error) {
+    logger.debug(
+      `[IOSScreenCaptureHelper] ignored malformed native frame metrics: ${error instanceof Error ? error.message : String(error)}`
+    );
+    return null;
+  }
+}
+
+function isNativeFrameMetrics(value: unknown): value is NativeFrameMetrics {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+  const metrics = value as Record<string, unknown>;
+  return (
+    isNullableNumber(metrics.captureTimestampMs) &&
+    isNullableNumber(metrics.frameQueueAgeMs) &&
+    (metrics.frameQueueDepth === 0 || metrics.frameQueueDepth === 1) &&
+    isNonNegativeNumber(metrics.droppedFrames) &&
+    isNonNegativeNumber(metrics.bytesQueued) &&
+    isNonNegativeNumber(metrics.highWaterMarkBytes) &&
+    isNullableNumber(metrics.lastOutputWriteDurationMs)
+  );
+}
+
+function isNullableNumber(value: unknown): value is number | null {
+  return value === null || (typeof value === "number" && Number.isFinite(value));
+}
+
+function isNonNegativeNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+const immediateFrameDeliveryScheduler: FrameDeliveryScheduler = {
+  schedule(callback): void {
+    setImmediate(callback);
+  },
+};
 
 function buildArgs(target: CaptureTarget): string[] {
   switch (target.kind) {

--- a/src/features/screen-stream/LatestFrameQueue.ts
+++ b/src/features/screen-stream/LatestFrameQueue.ts
@@ -1,0 +1,81 @@
+import type { DecodedFrame } from "./frameProtocol";
+
+/**
+ * A one-slot queue for live video. Replacing an unread frame is intentional:
+ * viewers need the newest image, not lossless history.
+ */
+export class LatestFrameQueue {
+  private pending: QueuedFrame | null = null;
+  private droppedFrames = 0;
+  private highWaterMarkBytes = 0;
+  private lastCaptureTimestampMs: number | null = null;
+
+  constructor(
+    private readonly options: {
+      maxFrameBytes: number;
+      now: () => number;
+    }
+  ) {}
+
+  /**
+   * Keeps the supplied frame only when it fits the fixed memory budget. A newer
+   * frame always replaces an unread older one.
+   */
+  enqueue(frame: DecodedFrame): boolean {
+    this.lastCaptureTimestampMs = frame.header.timestampMs;
+    if (frame.pixels.length > this.options.maxFrameBytes) {
+      this.droppedFrames++;
+      return false;
+    }
+    if (this.pending !== null) {
+      this.droppedFrames++;
+    }
+    this.pending = { frame, enqueuedAtMs: this.options.now() };
+    this.highWaterMarkBytes = Math.max(this.highWaterMarkBytes, frame.pixels.length);
+    return true;
+  }
+
+  take(): DecodedFrame | null {
+    const queued = this.pending;
+    this.pending = null;
+    return queued?.frame ?? null;
+  }
+
+  clear(countPendingAsDropped = false): void {
+    if (countPendingAsDropped && this.pending !== null) {
+      this.droppedFrames++;
+    }
+    this.pending = null;
+  }
+
+  metrics(): FrameQueueMetrics {
+    const pending = this.pending;
+    return {
+      captureTimestampMs: pending?.frame.header.timestampMs ?? this.lastCaptureTimestampMs,
+      frameAgeMs: pending === null ? null : Math.max(0, this.options.now() - pending.enqueuedAtMs),
+      queueDepth: pending === null ? 0 : 1,
+      droppedFrames: this.droppedFrames,
+      bytesQueued: pending?.frame.pixels.length ?? 0,
+      highWaterMarkBytes: this.highWaterMarkBytes,
+      maxFrameBytes: this.options.maxFrameBytes,
+    };
+  }
+}
+
+export interface FrameQueueMetrics {
+  /** Capture time reported by the helper, relative to the helper start. */
+  captureTimestampMs: number | null;
+  /** Time a pending frame has spent waiting in this queue. */
+  frameAgeMs: number | null;
+  /** Always zero or one. */
+  queueDepth: 0 | 1;
+  droppedFrames: number;
+  bytesQueued: number;
+  highWaterMarkBytes: number;
+  maxFrameBytes: number;
+}
+
+interface QueuedFrame {
+  frame: DecodedFrame;
+  enqueuedAtMs: number;
+}

--- a/src/features/screen-stream/frameProtocol.ts
+++ b/src/features/screen-stream/frameProtocol.ts
@@ -45,8 +45,11 @@ const MAX_FRAME_DIMENSION = 16_384;
  * observed at exactly `width * 4`), so a full page of slack is generous.
  */
 const MAX_ROW_PADDING_BYTES = 4096;
-/** Largest plausible single-frame pixel payload (256 MiB). */
-const MAX_FRAME_PAYLOAD_BYTES = 256 * 1024 * 1024;
+/**
+ * Largest raw frame retained by the Node handoff. 32 MiB covers current iPhone
+ * and iPad BGRA captures while keeping one incomplete frame bounded.
+ */
+export const MAX_RAW_FRAME_BYTES = 32 * 1024 * 1024;
 /** Largest plausible audio record (16 MiB ≈ 17 minutes of 8 kHz PCM16LE). */
 const MAX_AUDIO_PAYLOAD_BYTES = 16 * 1024 * 1024;
 
@@ -83,8 +86,9 @@ export interface MalformedFrameError {
 }
 
 export class FrameDecoder {
-  private buffer: Buffer = Buffer.alloc(0);
+  private readonly buffer = new BufferQueue();
   private pendingHeader: FrameHeader | null = null;
+  private highWaterMarkBytes = 0;
   /**
    * True while the decoder has lost frame alignment and is scanning for the next
    * valid marker. Malformed callbacks are suppressed in this state so one
@@ -101,41 +105,80 @@ export class FrameDecoder {
   push(
     chunk: Buffer,
     onMalformed?: (error: MalformedFrameError) => void,
-    onAudio?: (audio: DecodedAudio) => void
+    onAudio?: (audio: DecodedAudio) => void,
+    onFrame?: (frame: DecodedFrame) => void
   ): DecodedFrame[] {
-    if (chunk.length > 0) {
-      this.buffer = this.buffer.length === 0 ? chunk : Buffer.concat([this.buffer, chunk]);
-    }
-
     const frames: DecodedFrame[] = [];
+    let offset = 0;
+    while (offset < chunk.length) {
+      // Do not retain more than one valid raw frame plus its header, even when
+      // a synthetic or unusually coalesced stdout chunk carries many frames.
+      const available = FRAME_HEADER_SIZE + MAX_RAW_FRAME_BYTES - this.buffer.length;
+      if (available === 0) {
+        if (!this.decodeAvailable(frames, onMalformed, onAudio, onFrame)) {
+          throw new Error("FrameDecoder reached its raw-frame buffer limit without a complete frame");
+        }
+        continue;
+      }
+      const end = Math.min(chunk.length, offset + available);
+      this.buffer.append(chunk.subarray(offset, end));
+      this.highWaterMarkBytes = Math.max(this.highWaterMarkBytes, this.buffer.length);
+      offset = end;
+      this.decodeAvailable(frames, onMalformed, onAudio, onFrame);
+    }
+    return frames;
+  }
 
+  getMetrics(): FrameDecoderMetrics {
+    return {
+      bufferedBytes: this.buffer.length,
+      highWaterMarkBytes: this.highWaterMarkBytes,
+      maxBufferedBytes: FRAME_HEADER_SIZE + MAX_RAW_FRAME_BYTES,
+    };
+  }
+
+  private decodeAvailable(
+    frames: DecodedFrame[],
+    onMalformed?: (error: MalformedFrameError) => void,
+    onAudio?: (audio: DecodedAudio) => void,
+    onFrame?: (frame: DecodedFrame) => void
+  ): boolean {
+    let madeProgress = false;
     while (true) {
-      if (this.resynchronizing && !this.resynchronize()) {break;}
+      if (this.resynchronizing && !this.resynchronize()) {return madeProgress;}
 
       if (this.pendingHeader === null) {
         const outcome = this.takeHeader(onMalformed);
-        if (outcome === "starved") {break;}
-        if (outcome === "malformed") {continue;}
+        if (outcome === "starved") {return madeProgress;}
+        if (outcome === "malformed") {
+          madeProgress = true;
+          continue;
+        }
         this.pendingHeader = outcome;
+        madeProgress = true;
       }
 
       const pending = this.pendingHeader;
       const expected = payloadSize(pending);
-      if (this.buffer.length < expected) {break;}
+      if (this.buffer.length < expected) {return madeProgress;}
 
-      // Copy pixels to release the underlying chunk allocation; otherwise
-      // every emitted frame pins the entire upstream buffer in memory.
-      const payload = Buffer.from(this.buffer.subarray(0, expected));
-      this.buffer = this.buffer.subarray(expected);
+      // A single copy detaches the emitted frame from stdout chunks. The queue
+      // avoids the former concatenate-on-every-chunk behavior while retaining
+      // no more than this one completed payload.
+      const payload = this.buffer.takeDetached(expected);
       if (isAudioHeader(pending)) {
         onAudio?.({ pcm16le: payload });
       } else {
-        frames.push({ header: pending, pixels: payload });
+        const frame = { header: pending, pixels: payload };
+        if (onFrame) {
+          onFrame(frame);
+        } else {
+          frames.push(frame);
+        }
       }
       this.pendingHeader = null;
+      madeProgress = true;
     }
-
-    return frames;
   }
 
   /**
@@ -148,14 +191,15 @@ export class FrameDecoder {
     onMalformed?: (error: MalformedFrameError) => void
   ): FrameHeader | "starved" | "malformed" {
     if (this.buffer.length < FRAME_HEADER_SIZE) {return "starved";}
-    const reason = headerErrorAt(this.buffer, 0);
+    const bytes = this.buffer.peek(FRAME_HEADER_SIZE);
+    const reason = headerErrorAt(bytes, 0);
     if (reason) {
       this.resynchronizing = true;
-      onMalformed?.({ reason, header: parseFields(this.buffer, 0) });
+      onMalformed?.({ reason, header: parseFields(bytes, 0) });
       return "malformed";
     }
-    const header = parseFields(this.buffer, 0);
-    this.buffer = this.buffer.subarray(FRAME_HEADER_SIZE);
+    const header = parseFields(bytes, 0);
+    this.buffer.discard(FRAME_HEADER_SIZE);
     return header;
   }
 
@@ -172,18 +216,19 @@ export class FrameDecoder {
    * corrupt header follows it).
    */
   private resynchronize(): boolean {
+    const buffer = this.buffer.toBuffer();
     let searchFrom = 0;
-    while (searchFrom <= this.buffer.length - FRAME_MAGIC_BYTES.length) {
-      const index = this.buffer.indexOf(FRAME_MAGIC_BYTES, searchFrom);
+    while (searchFrom <= buffer.length - FRAME_MAGIC_BYTES.length) {
+      const index = buffer.indexOf(FRAME_MAGIC_BYTES, searchFrom);
       if (index < 0) {break;}
-      if (index + FRAME_HEADER_SIZE > this.buffer.length) {
+      if (index + FRAME_HEADER_SIZE > buffer.length) {
         // Marker present but the full header has not arrived yet: keep from here
         // and wait for more bytes before validating.
-        this.trimTo(index);
+        this.replaceBuffer(buffer.subarray(index));
         return false;
       }
-      if (headerErrorAt(this.buffer, index) === null) {
-        this.trimTo(index);
+      if (headerErrorAt(buffer, index) === null) {
+        this.replaceBuffer(buffer.subarray(index));
         this.resynchronizing = false;
         return true;
       }
@@ -192,16 +237,20 @@ export class FrameDecoder {
     // No validating marker in what has arrived. Keep only a possible marker
     // prefix straddling the chunk boundary; discard the rest so the retained
     // buffer never grows without bound during sustained garbage.
-    this.trimTo(Math.max(0, this.buffer.length - (FRAME_MAGIC_BYTES.length - 1)));
+    this.replaceBuffer(buffer.subarray(Math.max(0, buffer.length - (FRAME_MAGIC_BYTES.length - 1))));
     return false;
   }
 
-  /** Drop `offset` leading bytes, copying so the discarded allocation is freed. */
-  private trimTo(offset: number): void {
-    if (offset > 0) {
-      this.buffer = Buffer.from(this.buffer.subarray(offset));
-    }
+  /** Compact retained corrupt-stream bytes so discarded chunks can be released. */
+  private replaceBuffer(bytes: Buffer): void {
+    this.buffer.replace(bytes.length === 0 ? Buffer.alloc(0) : Buffer.from(bytes));
   }
+}
+
+export interface FrameDecoderMetrics {
+  bufferedBytes: number;
+  highWaterMarkBytes: number;
+  maxBufferedBytes: number;
 }
 
 function isAudioHeader(header: FrameHeader): boolean {
@@ -254,10 +303,100 @@ function fieldBoundsError(header: FrameHeader): MalformedFrameReason | null {
   if (header.bytesPerRow > header.width * 4 + MAX_ROW_PADDING_BYTES) {
     return "header_bytes_per_row_too_large";
   }
-  if (header.height * header.bytesPerRow > MAX_FRAME_PAYLOAD_BYTES) {
+  if (header.height * header.bytesPerRow > MAX_RAW_FRAME_BYTES) {
     return "header_payload_too_large";
   }
   return null;
+}
+
+/**
+ * Chunked byte storage prevents repeated whole-frame `Buffer.concat` copies as
+ * stdout arrives in pipe-sized pieces. Payload extraction performs one detached
+ * copy, which is needed because decoded frames outlive their stdout chunks.
+ */
+class BufferQueue {
+  private chunks: Buffer[] = [];
+  private headOffset = 0;
+  length = 0;
+
+  append(chunk: Buffer): void {
+    if (chunk.length === 0) {return;}
+    this.chunks.push(chunk);
+    this.length += chunk.length;
+  }
+
+  peek(length: number): Buffer {
+    if (length > this.length) {
+      throw new RangeError(`cannot peek ${length} bytes from ${this.length}-byte queue`);
+    }
+    const first = this.chunks[0];
+    const firstAvailable = first.length - this.headOffset;
+    if (firstAvailable >= length) {
+      return first.subarray(this.headOffset, this.headOffset + length);
+    }
+    const out = Buffer.allocUnsafe(length);
+    this.copyTo(out, length);
+    return out;
+  }
+
+  takeDetached(length: number): Buffer {
+    if (length > this.length) {
+      throw new RangeError(`cannot take ${length} bytes from ${this.length}-byte queue`);
+    }
+    const out = Buffer.allocUnsafe(length);
+    this.copyTo(out, length);
+    this.discard(length);
+    return out;
+  }
+
+  discard(length: number): void {
+    if (length > this.length) {
+      throw new RangeError(`cannot discard ${length} bytes from ${this.length}-byte queue`);
+    }
+    let remaining = length;
+    while (remaining > 0) {
+      const first = this.chunks[0];
+      const available = first.length - this.headOffset;
+      if (remaining < available) {
+        this.headOffset += remaining;
+        this.length -= remaining;
+        return;
+      }
+      this.chunks.shift();
+      this.headOffset = 0;
+      this.length -= available;
+      remaining -= available;
+    }
+  }
+
+  toBuffer(): Buffer {
+    if (this.length === 0) {return Buffer.alloc(0);}
+    const first = this.chunks[0];
+    if (this.chunks.length === 1) {
+      return first.subarray(this.headOffset);
+    }
+    const out = Buffer.allocUnsafe(this.length);
+    this.copyTo(out, this.length);
+    return out;
+  }
+
+  replace(bytes: Buffer): void {
+    this.chunks = bytes.length === 0 ? [] : [bytes];
+    this.headOffset = 0;
+    this.length = bytes.length;
+  }
+
+  private copyTo(destination: Buffer, length: number): void {
+    let copied = 0;
+    for (let index = 0; copied < length; index++) {
+      const chunk = this.chunks[index];
+      const start = index === 0 ? this.headOffset : 0;
+      const available = chunk.length - start;
+      const count = Math.min(available, length - copied);
+      chunk.copy(destination, copied, start, start + count);
+      copied += count;
+    }
+  }
 }
 
 /**

--- a/src/features/screen-stream/index.ts
+++ b/src/features/screen-stream/index.ts
@@ -2,15 +2,23 @@ export {
   FRAME_HEADER_SIZE,
   FRAME_MAGIC,
   FrameDecoder,
+  MAX_RAW_FRAME_BYTES,
   crc32,
   encodeFrameHeader,
   type DecodedFrame,
   type DecodedAudio,
   type FrameHeader,
   type MalformedFrameError,
+  type FrameDecoderMetrics,
 } from "./frameProtocol";
 export {
+  LatestFrameQueue,
+  type FrameQueueMetrics,
+} from "./LatestFrameQueue";
+export {
   IOSScreenCaptureHelper,
+  IOS_SCREEN_CAPTURE_MAX_FRAME_BYTES,
+  NATIVE_FRAME_METRICS_PREFIX,
   SIMULATOR_FPS_DEFAULT,
   SIMULATOR_FPS_MAX,
   SIMULATOR_FPS_MIN,
@@ -18,4 +26,6 @@ export {
   type HelperSpawner,
   type IosScreenCaptureHelperOptions,
   type IosScreenCaptureHelperEvents,
+  type FrameDeliveryScheduler,
+  type NativeFrameMetrics,
 } from "./IOSScreenCaptureHelper";

--- a/src/features/webrtc/H264CaptureSource.ts
+++ b/src/features/webrtc/H264CaptureSource.ts
@@ -1,4 +1,20 @@
 import type { BootedDevice } from "../../models";
+import type { NativeFrameMetrics } from "../screen-stream/IOSScreenCaptureHelper";
+import type { FrameQueueMetrics } from "../screen-stream/LatestFrameQueue";
+
+export interface H264EncoderFrameMetrics extends FrameQueueMetrics {
+  /** Duration of the last synchronous write into the encoder stdin buffer. */
+  outputWriteDurationMs: number | null;
+  /** Largest observed synchronous encoder-stdin write duration. */
+  outputWriteHighWaterDurationMs: number;
+}
+
+/** Queue and write-latency snapshots for the iOS raw-frame pipeline. */
+export interface H264CaptureSourceMetrics {
+  native: NativeFrameMetrics | null;
+  helper: FrameQueueMetrics | null;
+  encoder: H264EncoderFrameMetrics;
+}
 
 export interface H264CaptureSourceOptions {
   device: BootedDevice;
@@ -20,6 +36,8 @@ export interface H264CaptureSourceOptions {
    */
   fps?: number;
   audioEnabled?: boolean;
+  /** Receives bounded iOS capture-pipeline metrics when the source supports them. */
+  onFrameMetrics?: (metrics: H264CaptureSourceMetrics) => void;
 }
 
 /**

--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -7,10 +7,13 @@ import type {
   CaptureTarget,
   DecodedAudio,
   DecodedFrame,
+  FrameQueueMetrics,
   IosScreenCaptureHelperOptions,
   MalformedFrameError,
+  NativeFrameMetrics,
 } from "../screen-stream";
 import { AUTOMOBILE_VERSION_ENV } from "../../constants/release";
+import { LatestFrameQueue } from "../screen-stream/LatestFrameQueue";
 import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
 import { isTruthyEnvValue } from "../../utils/ctrlProxyDownloadControl";
 import { logger } from "../../utils/logger";
@@ -22,7 +25,12 @@ import {
   type FfmpegProcess,
 } from "../../utils/media/FfmpegClient";
 import { defaultTimer, type Timer } from "../../utils/SystemTimer";
-import type { H264CaptureSource, H264CaptureSourceOptions } from "./H264CaptureSource";
+import type {
+  H264CaptureSource,
+  H264CaptureSourceMetrics,
+  H264CaptureSourceOptions,
+  H264EncoderFrameMetrics,
+} from "./H264CaptureSource";
 import { h264MacroblocksPerFrame, WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME } from "./h264Level";
 import { WEBRTC_IOS_SIMULATOR_FPS_DEFAULT } from "./webrtcStreamingConfig";
 
@@ -60,6 +68,8 @@ export const IOS_FORCED_KEYFRAME_MIN_INTERVAL_MS = 3000;
 const H264_MACROBLOCK_SIZE = 16;
 /** Smallest dimension ffmpeg can encode as 4:2:0 chroma-subsampled video. */
 const MIN_ENCODER_DIMENSION = 2;
+/** One iPhone/iPad-sized BGRA frame awaiting encoder drain. */
+const IOS_ENCODER_PENDING_FRAME_MAX_BYTES = 32 * 1024 * 1024;
 /**
  * Bits budgeted per encoded pixel per frame for the default WebRTC bitrate.
  *
@@ -95,6 +105,8 @@ export interface IosFrameCaptureHelper {
   start(): void;
   stop(): Promise<unknown>;
   on(event: "frame", listener: (frame: DecodedFrame) => void): this;
+  on(event: "frameMetrics", listener: (metrics: FrameQueueMetrics) => void): this;
+  on(event: "captureMetrics", listener: (metrics: NativeFrameMetrics) => void): this;
   on(event: "audio", listener: (audio: DecodedAudio) => void): this;
   on(event: "malformed", listener: (error: MalformedFrameError) => void): this;
   on(event: "stderr", listener: (line: string) => void): this;
@@ -172,6 +184,8 @@ export interface EncoderSize {
   height: number;
 }
 
+export interface IosH264FrameMetrics extends H264CaptureSourceMetrics {}
+
 type IosH264SourcePhase = "idle" | "starting" | "running" | "stopping";
 
 export class IosH264Source implements H264CaptureSource {
@@ -186,6 +200,7 @@ export class IosH264Source implements H264CaptureSource {
   private readonly helperProvider?: ScreenCaptureHelperEnsurer;
   private readonly timer: Timer;
   private readonly firstFrameTimeoutMs: number;
+  private readonly pendingFrames: LatestFrameQueue;
 
   private helper: IosFrameCaptureHelper | null = null;
   private captureKind: CaptureTarget["kind"] | null = null;
@@ -199,6 +214,10 @@ export class IosH264Source implements H264CaptureSource {
   private lastHelperStderr: string | null = null;
   private lastEncoderStderr: string | null = null;
   private lastForcedKeyFrameMs = Number.NEGATIVE_INFINITY;
+  private lastOutputWriteDurationMs: number | null = null;
+  private outputWriteHighWaterDurationMs = 0;
+  private helperFrameMetrics: FrameQueueMetrics | null = null;
+  private nativeFrameMetrics: NativeFrameMetrics | null = null;
   private phase: IosH264SourcePhase = "idle";
 
   constructor(private readonly options: IosH264SourceOptions) {
@@ -224,10 +243,23 @@ export class IosH264Source implements H264CaptureSource {
     this.helperProvider = options.helperProvider;
     this.timer = options.timer ?? defaultTimer;
     this.firstFrameTimeoutMs = options.firstFrameTimeoutMs ?? IOS_FIRST_FRAME_TIMEOUT_MS;
+    this.pendingFrames = new LatestFrameQueue({
+      maxFrameBytes: IOS_ENCODER_PENDING_FRAME_MAX_BYTES,
+      now: () => this.timer.now(),
+    });
     this.simulatorWindowResolver =
       options.simulatorWindowResolver ??
       ((helperPath, device, audioEnabled) =>
         defaultResolveSimulatorWindowId(helperPath, device, this.commandRunner, audioEnabled));
+  }
+
+  /** Snapshot of each bounded handoff from capture through VideoToolbox. */
+  getFrameMetrics(): IosH264FrameMetrics {
+    return {
+      native: this.nativeFrameMetrics,
+      helper: this.helperFrameMetrics,
+      encoder: this.getEncoderFrameMetrics(),
+    };
   }
 
   async start(): Promise<void> {
@@ -237,6 +269,8 @@ export class IosH264Source implements H264CaptureSource {
     await this.teardownPromise;
     this.phase = "starting";
     this.lastHelperStderr = null;
+    this.helperFrameMetrics = null;
+    this.nativeFrameMetrics = null;
 
     try {
       const helperPath = await ensureIosScreenCaptureHelper({
@@ -308,6 +342,8 @@ export class IosH264Source implements H264CaptureSource {
     // Spawn the replacement first so the outgoing encoder's exit/error handlers
     // — all guarded by `this.encoder === encoder` — no-op instead of tearing the
     // source down as a fatal crash. Then end its stdin and terminate it.
+    this.pendingFrames.clear(true);
+    this.reportFrameMetrics();
     this.startEncoder(size);
     oldEncoder.stdin.end();
     oldEncoder.kill("SIGTERM");
@@ -439,6 +475,18 @@ export class IosH264Source implements H264CaptureSource {
 
   private wireHelperFrames(helper: IosFrameCaptureHelper): void {
     helper.on("frame", frame => this.handleFrame(frame));
+    helper.on("frameMetrics", metrics => {
+      if (this.helper === helper && this.isActive()) {
+        this.helperFrameMetrics = metrics;
+        this.reportFrameMetrics();
+      }
+    });
+    helper.on("captureMetrics", metrics => {
+      if (this.helper === helper && this.isActive()) {
+        this.nativeFrameMetrics = metrics;
+        this.reportFrameMetrics();
+      }
+    });
     helper.on("audio", audio => {
       if (this.isActive() && this.options.audioEnabled) {
         this.options.onAudioData?.(audio.pcm16le);
@@ -471,6 +519,8 @@ export class IosH264Source implements H264CaptureSource {
     if (!this.encoder) {
       this.startEncoder(size);
     } else if (this.encoderBackpressured) {
+      this.pendingFrames.enqueue(frame);
+      this.reportFrameMetrics();
       return;
     } else if (
       this.encoderSize &&
@@ -484,10 +534,23 @@ export class IosH264Source implements H264CaptureSource {
       return;
     }
 
-    const accepted = this.encoder?.stdin.write(tightlyPackBgraFrame(frame));
+    this.writeFrameToEncoder(frame);
+  }
+
+  private writeFrameToEncoder(frame: DecodedFrame): void {
+    const encoder = this.encoder;
+    if (!encoder) {return;}
+    const startedAt = this.timer.now();
+    const accepted = encoder.stdin.write(tightlyPackBgraFrame(frame));
+    this.lastOutputWriteDurationMs = Math.max(0, this.timer.now() - startedAt);
+    this.outputWriteHighWaterDurationMs = Math.max(
+      this.outputWriteHighWaterDurationMs,
+      this.lastOutputWriteDurationMs
+    );
     if (accepted === false) {
       this.encoderBackpressured = true;
     }
+    this.reportFrameMetrics();
   }
 
   private startEncoder(size: EncoderSize): void {
@@ -522,6 +585,7 @@ export class IosH264Source implements H264CaptureSource {
     encoder.stdin.on("drain", () => {
       if (this.encoder === encoder) {
         this.encoderBackpressured = false;
+        this.writePendingFrameToEncoder();
       }
     });
     encoder.stdin.on("error", error => {
@@ -543,6 +607,38 @@ export class IosH264Source implements H264CaptureSource {
         );
       }
     });
+  }
+
+  private writePendingFrameToEncoder(): void {
+    if (!this.isActive() || this.encoderBackpressured) {return;}
+    const frame = this.pendingFrames.take();
+    this.reportFrameMetrics();
+    if (frame === null) {return;}
+    const size = { width: frame.header.width, height: frame.header.height };
+    if (
+      this.encoderSize &&
+      (this.encoderSize.width !== size.width || this.encoderSize.height !== size.height)
+    ) {
+      this.failIfRunning(
+        new Error(
+          `iOS capture frame changed size from ${this.encoderSize.width}x${this.encoderSize.height} to ${size.width}x${size.height}`
+        )
+      );
+      return;
+    }
+    this.writeFrameToEncoder(frame);
+  }
+
+  private getEncoderFrameMetrics(): H264EncoderFrameMetrics {
+    return {
+      ...this.pendingFrames.metrics(),
+      outputWriteDurationMs: this.lastOutputWriteDurationMs,
+      outputWriteHighWaterDurationMs: this.outputWriteHighWaterDurationMs,
+    };
+  }
+
+  private reportFrameMetrics(): void {
+    this.options.onFrameMetrics?.(this.getFrameMetrics());
   }
 
   private withEncoderDiagnostics(error: Error): Error {
@@ -671,6 +767,7 @@ export class IosH264Source implements H264CaptureSource {
     this.encoder = null;
     this.encoderSize = null;
     this.encoderBackpressured = false;
+    this.pendingFrames.clear();
     encoder?.stdin.end();
     encoder?.kill("SIGTERM");
 

--- a/src/features/webrtc/WebRtcPublisher.ts
+++ b/src/features/webrtc/WebRtcPublisher.ts
@@ -21,6 +21,7 @@ import {
 } from "./h264Level";
 import { parseTrickleIceMediaContexts, TrickleIceForwarder } from "./trickleIce";
 import { WhipClient, type WhipClientOptions } from "./WhipClient";
+import type { H264CaptureSourceMetrics } from "./H264CaptureSource";
 
 /**
  * How long to wait for ICE gathering before publishing the offer.
@@ -139,6 +140,8 @@ export interface WebRtcStreamDescriptor {
    * publisher builds on its own.
    */
   sourceStarted?: boolean;
+  /** Latest capture-pipeline metrics, when supplied by the active source. */
+  frameMetrics?: H264CaptureSourceMetrics;
 }
 
 /**

--- a/src/server/webrtcStreamManager.ts
+++ b/src/server/webrtcStreamManager.ts
@@ -8,6 +8,7 @@ import {
   WebRtcPublisher,
   resolveWebRtcStreamingConfig,
   type H264CaptureSource,
+  type H264CaptureSourceMetrics,
   type H264CaptureSourceOptions,
   type H264CaptureSourceTelemetry,
   type WebRtcCaptureSourceState,
@@ -45,6 +46,7 @@ interface WebRtcStreamRecord {
   sourceState: WebRtcCaptureSourceState;
   lastSourceError: string | null;
   sourceTelemetry: H264CaptureSourceTelemetry | null;
+  frameMetrics?: H264CaptureSourceMetrics;
   /** Reservation token for a start that has not returned to its caller yet. */
   startToken: symbol;
 }
@@ -142,12 +144,14 @@ function describeRecord(record: WebRtcStreamRecord): WebRtcStreamDescriptor {
       captureSourceState: record.sourceState,
       lastSourceError: record.lastSourceError,
     },
+    frameMetrics: record.frameMetrics,
   };
 }
 
 /** Stop and clear the capture source for a stream (before each (re)establish). */
 async function stopSource(record: WebRtcStreamRecord): Promise<void> {
   record.sourceStarted = false;
+  record.frameMetrics = undefined;
   if (record.source) {
     record.sourceTelemetry = record.source.getTelemetry?.() ?? record.sourceTelemetry;
     await record.source.stop().catch(error => {
@@ -175,6 +179,7 @@ async function startSource(record: WebRtcStreamRecord): Promise<boolean> {
     return false;
   }
   record.sourceState = "starting";
+  const sourceRef: { current: H264CaptureSource | null } = { current: null };
   const source = dependencies.createSource(
     {
       device: record.device,
@@ -190,9 +195,15 @@ async function startSource(record: WebRtcStreamRecord): Promise<boolean> {
       size: record.size,
       fps: record.fps,
       audioEnabled: record.audioEnabled,
+      onFrameMetrics: metrics => {
+        if (record.source === sourceRef.current) {
+          record.frameMetrics = metrics;
+        }
+      },
     },
     record.jarPath
   );
+  sourceRef.current = source;
   record.source = source;
   try {
     await source.start();

--- a/test/daemon/webrtcStreamSocketServer.test.ts
+++ b/test/daemon/webrtcStreamSocketServer.test.ts
@@ -192,6 +192,20 @@ describe("WebRtcStreamSocketServer", () => {
     expect(started[0].overrides).toEqual({ iosSimulatorFps: 24 });
   });
 
+  test("start forwards an explicit empty ICE server list to disable the default STUN server", async () => {
+    const server = new TestableServer(makeDeps());
+    const socket = new FakeSocket();
+
+    await server.simulate(socket, {
+      id: "start-without-ice",
+      action: "start",
+      streamId: "no-ice",
+      iceServers: [],
+    });
+
+    expect(started[0].overrides).toEqual({ iceServers: [] });
+  });
+
   test("start forwards WHIP endpoint and stream stays visible until stop", async () => {
     const server = new TestableServer(makeDeps());
     const socket = new FakeSocket();

--- a/test/features/screen-stream/IOSScreenCaptureHelper.test.ts
+++ b/test/features/screen-stream/IOSScreenCaptureHelper.test.ts
@@ -4,8 +4,10 @@ import { FakeChildProcess } from "../../fakes/FakeChildProcess";
 import {
   encodeFrameHeader,
   IOSScreenCaptureHelper,
+  NATIVE_FRAME_METRICS_PREFIX,
   type CaptureTarget,
   type DecodedFrame,
+  type FrameDeliveryScheduler,
   type MalformedFrameError,
 } from "../../../src/features/screen-stream";
 
@@ -44,6 +46,27 @@ function withFakeSpawner(
 
 function flush(): Promise<void> {
   return new Promise(resolve => setImmediate(resolve));
+}
+
+async function flushFrameDelivery(): Promise<void> {
+  await flush();
+  await flush();
+}
+
+class ManualFrameDeliveryScheduler implements FrameDeliveryScheduler {
+  private callbacks: Array<() => void> = [];
+
+  schedule(callback: () => void): void {
+    this.callbacks.push(callback);
+  }
+
+  runNext(): void {
+    this.callbacks.shift()?.();
+  }
+
+  get size(): number {
+    return this.callbacks.length;
+  }
 }
 
 describe("IOSScreenCaptureHelper", () => {
@@ -104,7 +127,7 @@ describe("IOSScreenCaptureHelper", () => {
     expect(() => helper.start()).toThrow(/integer/);
   });
 
-  test("emits frame events for each decoded frame", async () => {
+  test("coalesces a burst into the newest decoded frame", async () => {
     const { fake, helper } = withFakeSpawner();
     const frames: DecodedFrame[] = [];
     helper.on("frame", f => frames.push(f));
@@ -115,13 +138,53 @@ describe("IOSScreenCaptureHelper", () => {
       encodeFrame(1, 1, 4, 20, 0x22),
     ]);
     fake.stdout.push(buf);
-    await flush();
+    await flushFrameDelivery();
 
-    expect(frames).toHaveLength(2);
-    expect(frames[0].header.timestampMs).toBe(10);
-    expect(frames[1].header.timestampMs).toBe(20);
-    expect(frames[0].pixels[0]).toBe(0x11);
-    expect(frames[1].pixels[0]).toBe(0x22);
+    expect(frames).toHaveLength(1);
+    expect(frames[0].header.timestampMs).toBe(20);
+    expect(frames[0].pixels[0]).toBe(0x22);
+  });
+
+  test("bounds the pending frame and recovers with the newest frame once delivery runs", async () => {
+    const fake = new FakeChildProcess();
+    const scheduler = new ManualFrameDeliveryScheduler();
+    let now = 1_000;
+    const helper = new IOSScreenCaptureHelper({
+      binaryPath: "/fake/screen-capture-helper",
+      target: { kind: "device" },
+      now: () => now,
+      frameDeliveryScheduler: scheduler,
+      spawner: () => fake as unknown as ChildProcessWithoutNullStreams,
+    });
+    const frames: DecodedFrame[] = [];
+    helper.on("frame", frame => frames.push(frame));
+    helper.start();
+
+    fake.stdout.push(Buffer.concat([
+      encodeFrame(1, 1, 4, 10, 0x10),
+      encodeFrame(1, 1, 4, 20, 0x20),
+      encodeFrame(1, 1, 4, 30, 0x30),
+    ]));
+
+    await flush();
+    now += 25;
+    expect(scheduler.size).toBe(1);
+    expect(helper.getFrameMetrics()).toEqual({
+      captureTimestampMs: 30,
+      frameAgeMs: 25,
+      queueDepth: 1,
+      droppedFrames: 2,
+      bytesQueued: 4,
+      highWaterMarkBytes: 4,
+      maxFrameBytes: 32 * 1024 * 1024,
+    });
+
+    scheduler.runNext();
+
+    expect(frames).toHaveLength(1);
+    expect(frames[0].header.timestampMs).toBe(30);
+    expect(frames[0].pixels).toEqual(Buffer.alloc(4, 0x30));
+    expect(helper.getFrameMetrics().queueDepth).toBe(0);
   });
 
   test("simulator target also emits frame events", async () => {
@@ -130,7 +193,7 @@ describe("IOSScreenCaptureHelper", () => {
     helper.on("frame", f => frames.push(f));
     helper.start();
     fake.stdout.push(encodeFrame(2, 2, 8, 33, 0xfa));
-    await flush();
+    await flushFrameDelivery();
     expect(frames).toHaveLength(1);
     expect(frames[0].header.width).toBe(2);
   });
@@ -154,6 +217,39 @@ describe("IOSScreenCaptureHelper", () => {
 
     expect(audio).toEqual([Buffer.from([0x34, 0x12, 0xcc, 0xed])]);
     expect(malformed).toEqual([]);
+  });
+
+  test("emits native capture metrics carried over stderr without logging them", async () => {
+    const { fake, helper } = withFakeSpawner();
+    const metrics = [];
+    const stderr: string[] = [];
+    helper.on("captureMetrics", value => metrics.push(value));
+    helper.on("stderr", line => stderr.push(line));
+    helper.start();
+
+    fake.stderr.push(Buffer.from(
+      `${NATIVE_FRAME_METRICS_PREFIX}${JSON.stringify({
+        captureTimestampMs: 42,
+        frameQueueAgeMs: 7.5,
+        frameQueueDepth: 1,
+        droppedFrames: 3,
+        bytesQueued: 8,
+        highWaterMarkBytes: 16,
+        lastOutputWriteDurationMs: 2,
+      })}\n`
+    ));
+    await flush();
+
+    expect(metrics).toEqual([{
+      captureTimestampMs: 42,
+      frameQueueAgeMs: 7.5,
+      frameQueueDepth: 1,
+      droppedFrames: 3,
+      bytesQueued: 8,
+      highWaterMarkBytes: 16,
+      lastOutputWriteDurationMs: 2,
+    }]);
+    expect(stderr).toEqual([]);
   });
 
   test("emits malformed events for invalid headers", async () => {

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -187,7 +187,8 @@ function createHarnessWithOverrides(options: Partial<ConstructorParameters<typeo
 // (requestKeyFrame) can be observed as a second spawn rather than reusing the
 // single encoder the other harnesses share.
 function createRestartHarness(
-  overrides: Partial<ConstructorParameters<typeof IosH264Source>[0]> = {}
+  overrides: Partial<ConstructorParameters<typeof IosH264Source>[0]> = {},
+  configureEncoder?: (encoder: FakeChildProcess) => void
 ) {
   const helper = new FakeFrameCaptureHelper();
   const encoders: FakeChildProcess[] = [];
@@ -204,6 +205,7 @@ function createRestartHarness(
     spawner: (command, args) => {
       encoderSpawns.push({ command, args });
       const encoder = new FakeChildProcess();
+      configureEncoder?.(encoder);
       encoders.push(encoder);
       return encoder as unknown as ChildProcessWithoutNullStreams;
     },
@@ -809,7 +811,7 @@ describe("IosH264Source", () => {
     expect(helper.started).toBe(false);
   });
 
-  test("drops frames while encoder stdin is backpressured and resumes on drain", async () => {
+  test("keeps only the newest frame while encoder stdin is backpressured and resumes on drain", async () => {
     const helper = new FakeFrameCaptureHelper();
     const encoder = new FakeChildProcess();
     const stdin = new BackpressuredWritable();
@@ -826,13 +828,92 @@ describe("IosH264Source", () => {
 
     await startWithFrame(source, helper, frame(1, 1, 0x11));
     helper.emitFrame(frame(1, 1, 0x22));
-    stdin.emit("drain");
     helper.emitFrame(frame(1, 1, 0x33));
+
+    expect(source.getFrameMetrics()).toMatchObject({
+      encoder: {
+        captureTimestampMs: 1,
+        queueDepth: 1,
+        droppedFrames: 1,
+        bytesQueued: 4,
+        highWaterMarkBytes: 4,
+      },
+    });
+
+    stdin.emit("drain");
 
     expect(stdin.writes).toEqual([
       Buffer.alloc(4, 0x11),
       Buffer.alloc(4, 0x33),
     ]);
+  });
+
+  test("discards a retired encoder's queued frame when restarting for a keyframe", async () => {
+    const inputs: BackpressuredWritable[] = [];
+    const { source, helper, encoders } = createRestartHarness(
+      {},
+      encoder => {
+        const input = new BackpressuredWritable();
+        encoder.stdin = input as unknown as Writable;
+        inputs.push(input);
+      }
+    );
+
+    await startWithFrame(source, helper, frame(1, 1, 0x11));
+    helper.emitFrame(frame(1, 1, 0x22));
+
+    source.requestKeyFrame();
+    helper.emitFrame(frame(1, 1, 0x33));
+    inputs[1].emit("drain");
+
+    expect(encoders).toHaveLength(2);
+    expect(inputs[1].writes).toEqual([Buffer.alloc(4, 0x33)]);
+    expect(source.getFrameMetrics().encoder.droppedFrames).toBe(1);
+  });
+
+  test("reports native, helper, and encoder queue metrics through the source callback", async () => {
+    const metrics: ReturnType<IosH264Source["getFrameMetrics"]>[] = [];
+    const { source, helper } = createHarness(IOS_DEVICE, {
+      onFrameMetrics: value => metrics.push(value),
+    });
+    await startWithFrame(source, helper, frame(1, 1, 0x11));
+
+    helper.emit("frameMetrics", {
+      captureTimestampMs: 2,
+      frameAgeMs: 3,
+      queueDepth: 1,
+      droppedFrames: 4,
+      bytesQueued: 5,
+      highWaterMarkBytes: 6,
+      maxFrameBytes: 7,
+    });
+    helper.emit("captureMetrics", {
+      captureTimestampMs: 8,
+      frameQueueAgeMs: 9,
+      frameQueueDepth: 1,
+      droppedFrames: 10,
+      bytesQueued: 11,
+      highWaterMarkBytes: 12,
+      lastOutputWriteDurationMs: 13,
+    });
+
+    expect(metrics.at(-1)).toMatchObject({
+      native: {
+        captureTimestampMs: 8,
+        droppedFrames: 10,
+        lastOutputWriteDurationMs: 13,
+      },
+      helper: {
+        captureTimestampMs: 2,
+        frameAgeMs: 3,
+        highWaterMarkBytes: 6,
+      },
+      encoder: {
+        queueDepth: 0,
+        outputWriteDurationMs: expect.any(Number),
+        outputWriteHighWaterDurationMs: expect.any(Number),
+      },
+    });
   });
 
   test("ignores stale encoder errors after a restart creates a new encoder", async () => {

--- a/test/integration/webrtcDeviceCapture.integration.test.ts
+++ b/test/integration/webrtcDeviceCapture.integration.test.ts
@@ -549,6 +549,10 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
       AUTOMOBILE_DAEMON_PID_FILE_PATH: join(daemonDir, "daemon.pid"),
       AUTOMOBILE_DAEMON_LOCK_FILE_PATH: join(daemonDir, "daemon.lock"),
       AUTOMOBILE_WEBRTC_STREAM_SOCKET_PATH: webRtcSocketPath,
+      // This test controls its Simulator fixture through simctl and does not
+      // use CtrlProxy, so do not compete for the hosted runner with a release
+      // download that is unrelated to capture -> WHIP -> WHEP.
+      AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD: "1",
     };
     delete daemonEnvironment.AUTOMOBILE_DB_PATH;
     delete daemonEnvironment.AUTO_MOBILE_DB_PATH;
@@ -608,7 +612,16 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
         }
       })();
       const response = await sendWebRtcStreamRequest(
-        { action: "start", id: streamId, streamId, platform, whipEndpoint: `http://127.0.0.1:${webRtcPort}/${streamId}/whip` },
+        {
+          action: "start",
+          id: streamId,
+          streamId,
+          platform,
+          whipEndpoint: `http://127.0.0.1:${webRtcPort}/${streamId}/whip`,
+          // Both peers are local to the CI worker. Suppress the public STUN
+          // default so host-candidate negotiation cannot depend on runner DNS.
+          iceServers: [],
+        },
         { socketPath: webRtcSocketPath }
       );
       if (!response.success) {

--- a/test/lint/turboTestInputsCoverNativeSources.test.ts
+++ b/test/lint/turboTestInputsCoverNativeSources.test.ts
@@ -138,6 +138,7 @@ describe("turbo test inputs cover native sources a guard reads (issue #4351)", (
     ["android/video-server", "bare dir named in a comment / workflow-YAML string; the kotlin tree under it is a declared input"],
     ["ios/control-proxy", "bare dir in a `cd ios/control-proxy && swift test` doc line; Sources/ under it is a declared input"],
     ["ios/screen-capture", "named only inside the workflow-YAML text asserted by webrtcDeviceIntegrationWorkflow.test.ts"],
+    ["ios/screen-capture/.build", "IosH264Source resolver test constructs this hypothetical path but uses an injected exists fake"],
     ["ios/control-proxy/CtrlProxy.xcodeproj", "xcodegen drift check rebuilds a copy in a temp dir; the tracked pbxproj is not a test cache input"],
     ["ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj", "same xcodegen drift fixture, copied into a temp repo"],
   ]);

--- a/test/lint/turboTestInputsCoverNativeSources.test.ts
+++ b/test/lint/turboTestInputsCoverNativeSources.test.ts
@@ -104,6 +104,11 @@ describe("turbo test inputs cover native sources a guard reads (issue #4351)", (
           const source = readFileSync(abs, "utf8");
           for (const match of source.matchAll(/(?<![A-Za-z0-9_.-])(android|ios)\/[A-Za-z0-9._/-]+/g)) {
             const path = match[0].replace(/\/+$/, "");
+            // SwiftPM's generated output can exist after a local native build
+            // but is never a source input for a TypeScript unit test.
+            if (path.split("/").includes(".build")) {
+              continue;
+            }
             if (!existsSync(join(ROOT, path))) {
               continue;
             }
@@ -138,7 +143,6 @@ describe("turbo test inputs cover native sources a guard reads (issue #4351)", (
     ["android/video-server", "bare dir named in a comment / workflow-YAML string; the kotlin tree under it is a declared input"],
     ["ios/control-proxy", "bare dir in a `cd ios/control-proxy && swift test` doc line; Sources/ under it is a declared input"],
     ["ios/screen-capture", "named only inside the workflow-YAML text asserted by webrtcDeviceIntegrationWorkflow.test.ts"],
-    ["ios/screen-capture/.build", "IosH264Source resolver test constructs this hypothetical path but uses an injected exists fake"],
     ["ios/control-proxy/CtrlProxy.xcodeproj", "xcodegen drift check rebuilds a copy in a temp dir; the tracked pbxproj is not a test cache input"],
     ["ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj", "same xcodegen drift fixture, copied into a temp repo"],
   ]);

--- a/test/server/webrtcStreamManager.test.ts
+++ b/test/server/webrtcStreamManager.test.ts
@@ -11,6 +11,7 @@ import { CountingIdGenerator } from "../../src/utils/IdGenerator";
 import { ActionableError, type BootedDevice } from "../../src/models";
 import type {
   AndroidH264Source,
+  H264CaptureSourceMetrics,
   WebRtcPublisher,
   WebRtcStreamDescriptor,
 } from "../../src/features/webrtc";
@@ -492,6 +493,54 @@ describe("webrtcStreamManager", () => {
 
     capturedSourceOptions?.onAudioData?.(Buffer.from([1, 2, 3, 4]));
     expect(publishers[0].pcmAudioChunks).toEqual([Buffer.from([1, 2, 3, 4])]);
+  });
+
+  test("surfaces capture pipeline metrics on the live stream descriptor", async () => {
+    let sourceOptions:
+      | Parameters<NonNullable<Parameters<typeof setWebRtcStreamManagerDependencies>[0]["createSource"]>>[0]
+      | undefined;
+    const metrics: H264CaptureSourceMetrics = {
+      native: {
+        captureTimestampMs: 10,
+        frameQueueAgeMs: 20,
+        frameQueueDepth: 1,
+        droppedFrames: 1,
+        bytesQueued: 2,
+        highWaterMarkBytes: 3,
+        lastOutputWriteDurationMs: 4,
+      },
+      helper: null,
+      encoder: {
+        captureTimestampMs: 5,
+        frameAgeMs: null,
+        queueDepth: 0,
+        droppedFrames: 6,
+        bytesQueued: 0,
+        highWaterMarkBytes: 7,
+        maxFrameBytes: 8,
+        outputWriteDurationMs: 9,
+        outputWriteHighWaterDurationMs: 10,
+      },
+    };
+    setWebRtcStreamManagerDependencies({
+      idGenerator: new CountingIdGenerator("id"),
+      createPublisher: (config, deps) => new FakePublisher(config, deps) as unknown as WebRtcPublisher,
+      createSource: options => {
+        sourceOptions = options;
+        return new FakeSource() as unknown as AndroidH264Source;
+      },
+      resolveVideoJar: async () => null,
+      now: () => new Date("2026-07-24T00:00:00.000Z"),
+    });
+
+    const descriptor = await startWebRtcStream({
+      device: IOS,
+      overrides: { whipEndpoint: ENDPOINT },
+    });
+    sourceOptions?.onFrameMetrics?.(metrics);
+
+    expect(getWebRtcStreamDescriptor(descriptor.streamId)?.frameMetrics).toEqual(metrics);
+    expect(listWebRtcStreams()[0].frameMetrics).toEqual(metrics);
   });
 
   test("threads the resolved iOS Simulator fps into the capture source options", async () => {


### PR DESCRIPTION
## Summary

- Bound iOS raw-frame handoffs to latest-frame queues and discard queued pre-restart frames when rotating the VideoToolbox encoder.
- Keep Simulator PCM audio ordered in a bounded FIFO and alternate pending audio/video records so video cannot starve audio.
- Emit native capture metrics over the helper control channel and expose native, helper, and encoder snapshots on WebRTC stream descriptors.

## Validation

- `bun run lint`
- `bun run build`
- `bun test test/features/screen-stream/IOSScreenCaptureHelper.test.ts test/features/screen-stream/frameProtocol.test.ts test/features/webrtc/IosH264Source.test.ts test/server/webrtcStreamManager.test.ts`
- `(cd ios/screen-capture && swift test)`
