### PR TITLE
fix(android): own persistent video server sessions

### DIFF
--- a/.github/workflows/webrtc-device-integration.yml
+++ b/.github/workflows/webrtc-device-integration.yml
@@ -148,6 +148,17 @@ jobs:
           # The capture source is a ScreenCaptureKit stream of Simulator.app's
           # window, not the booted runtime alone. Product boot intentionally
           # avoids opening the GUI; CI needs it visible before the first frame.
+          if pgrep -x Simulator >/dev/null; then
+            killall Simulator
+            for _ in {1..30}; do
+              pgrep -x Simulator >/dev/null || break
+              sleep 1
+            done
+            if pgrep -x Simulator >/dev/null; then
+              echo "::error::Simulator.app did not exit before activation." >&2
+              exit 1
+            fi
+          fi
           open -a Simulator --args -CurrentDeviceUDID "${simulator_udid}"
       - name: "Run iOS device capture integration"
         env:

--- a/.github/workflows/webrtc-device-integration.yml
+++ b/.github/workflows/webrtc-device-integration.yml
@@ -160,6 +160,28 @@ jobs:
             fi
           fi
           open -a Simulator --args -CurrentDeviceUDID "${simulator_udid}"
+          helper_path="${GITHUB_WORKSPACE}/ios/screen-capture/.build/debug/screen-capture-helper"
+          simulator_name="$(xcrun simctl list devices --json | jq -r --arg udid "${simulator_udid}" \
+            '[.devices[][] | select(.udid == $udid) | .name] | first // empty')"
+          if [[ -z "${simulator_name}" ]]; then
+            echo "::error::Could not resolve the selected Simulator name." >&2
+            exit 1
+          fi
+          simulator_window_ready=0
+          for _ in {1..30}; do
+            simulator_windows="$("${helper_path}" --list-simulators 2>/dev/null || true)"
+            if printf '%s' "${simulator_windows}" | jq -e --arg name "${simulator_name}" \
+              '.windows | map(select((.title // "") | ascii_downcase | contains($name | ascii_downcase))) | length == 1' \
+              >/dev/null; then
+              simulator_window_ready=1
+              break
+            fi
+            sleep 1
+          done
+          if [[ "${simulator_window_ready}" != "1" ]]; then
+            echo "::error::Selected Simulator window did not become discoverable by ScreenCaptureKit." >&2
+            exit 1
+          fi
       - name: "Run iOS device capture integration"
         env:
           AUTOMOBILE_WEBRTC_DEVICE_INTEGRATION: "1"

--- a/.github/workflows/webrtc-device-integration.yml
+++ b/.github/workflows/webrtc-device-integration.yml
@@ -137,8 +137,18 @@ jobs:
           brew list ffmpeg >/dev/null 2>&1 || brew install ffmpeg
           test -x "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" || brew install --cask google-chrome
           (cd ios/screen-capture && swift build)
-      - name: "Boot iOS Simulator"
-        run: bun run src/index.ts --boot-device --platform ios --create-if-missing --timeout-ms 300000
+      - name: "Boot and activate iOS Simulator"
+        run: |
+          result="$(bun run src/index.ts --boot-device --platform ios --create-if-missing --timeout-ms 300000)"
+          simulator_udid="$(printf '%s' "${result}" | jq -r '.deviceId')"
+          if [[ -z "${simulator_udid}" || "${simulator_udid}" == "null" ]]; then
+            echo "::error::AutoMobile product boot returned no deviceId." >&2
+            exit 1
+          fi
+          # The capture source is a ScreenCaptureKit stream of Simulator.app's
+          # window, not the booted runtime alone. Product boot intentionally
+          # avoids opening the GUI; CI needs it visible before the first frame.
+          open -a Simulator --args -CurrentDeviceUDID "${simulator_udid}"
       - name: "Run iOS device capture integration"
         env:
           AUTOMOBILE_WEBRTC_DEVICE_INTEGRATION: "1"

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
@@ -34,7 +34,7 @@ object VideoServer {
   @Volatile private var capture: ScreenCapture? = null
   private var audioCapture: AudioCapture? = null
   private var streamWriter: VideoStreamWriter? = null
-  private var sessionLease: VideoSessionLease? = null
+  @Volatile private var sessionLease: VideoSessionLease? = null
 
   @JvmStatic
   fun main(args: Array<String>) {

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
@@ -80,7 +80,9 @@ object VideoServer {
 
     try {
       sessionLease =
-        session.token?.let { VideoSessionLease(session, android.os.Process.myPid()) }?.also { it.start() }
+        session.token
+          ?.let { VideoSessionLease(session, android.os.Process.myPid()) }
+          ?.also { it.start() }
       run(
         outputWidth,
         outputHeight,

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
@@ -27,8 +27,6 @@ import dev.jasonpearson.automobile.video.wrappers.DisplayControl
  * - `high`: 1080p @ 8 Mbps @ 60fps
  */
 object VideoServer {
-  private const val SOCKET_NAME = "automobile_video"
-
   @Volatile private var running = true
 
   @Volatile private var encoder: VideoEncoder? = null
@@ -36,6 +34,7 @@ object VideoServer {
   @Volatile private var capture: ScreenCapture? = null
   private var audioCapture: AudioCapture? = null
   private var streamWriter: VideoStreamWriter? = null
+  private var sessionLease: VideoSessionLease? = null
 
   @JvmStatic
   fun main(args: Array<String>) {
@@ -46,11 +45,12 @@ object VideoServer {
       android.os.Looper.prepareMainLooper()
     }
 
-    // Parse arguments
+    running = true
     val quality = parseQuality(args)
     val bitrateOverride = parseIntFlag(args, "--bit-rate")
     val sizeOverride = parseSizeFlag(args)
     val audioEnabled = args.contains("--audio")
+    val session = VideoSessionArguments.parse(args)
 
     println("AutoMobile Video Server")
     println("Quality preset: ${quality.name}")
@@ -79,10 +79,21 @@ object VideoServer {
       )
 
     try {
-      run(outputWidth, outputHeight, displayInfo.densityDpi, bitrate, quality.fps, audioEnabled)
+      sessionLease =
+        session.token?.let { VideoSessionLease(session, android.os.Process.myPid()) }?.also { it.start() }
+      run(
+        outputWidth,
+        outputHeight,
+        displayInfo.densityDpi,
+        bitrate,
+        quality.fps,
+        audioEnabled,
+        session,
+      )
     } catch (e: Exception) {
       System.err.println("Error: ${e.message}")
       e.printStackTrace()
+    } finally {
       shutdown()
     }
   }
@@ -203,6 +214,7 @@ object VideoServer {
     bitrate: Int,
     fps: Int,
     audioEnabled: Boolean,
+    session: VideoSessionOptions,
   ) {
     // Create encoder
     encoder =
@@ -226,18 +238,29 @@ object VideoServer {
       FrameHeartbeat(clock = FrameHeartbeat.Clock { android.os.SystemClock.uptimeMillis() })
     heartbeat.start()
 
-    // The writer keeps the encoder alive while its LocalSocket client
-    // reconnects, replays cached decoder state, and requests a new IDR at attach.
-    streamWriter = VideoStreamWriter(SOCKET_NAME, width, height, audioEnabled)
+    // The writer keeps the encoder alive while its LocalSocket client reconnects, replays cached
+    // decoder state, and requests a new IDR at attach.
+    streamWriter = VideoStreamWriter(session.socketName, width, height, audioEnabled)
     streamWriter!!.startCommandReader { command ->
       if (command == VideoStreamProtocol.COMMAND_REQUEST_KEY_FRAME) {
         encoder?.requestKeyFrame()
         heartbeat.onKeyFrameRequested()
       }
     }
-    streamWriter!!.start {
-      encoder?.requestKeyFrame()
-      heartbeat.onKeyFrameRequested()
+    try {
+      streamWriter!!.start {
+        println("VIDEO_SESSION_CLIENT_ATTACH socket=${session.socketName}")
+        encoder?.requestKeyFrame()
+        heartbeat.onKeyFrameRequested()
+      }
+    } catch (error: Exception) {
+      VideoSessionLease.collisionDiagnostic(session.socketName, session.token)?.let(::println)
+      throw error
+    }
+    session.token?.let {
+      println(
+        "VIDEO_SESSION_READY token=$it pid=${android.os.Process.myPid()} socket=${session.socketName}"
+      )
     }
 
     if (audioEnabled) {
@@ -283,15 +306,16 @@ object VideoServer {
       }
 
       if (streamWriter!!.reconnectWindowExpired()) {
-        println("Client did not reconnect before the video reconnect window expired")
-        break
+        println("VIDEO_CLIENT_RECONNECT_EXPIRED socket=${session.socketName}")
+        running = false
       }
     }
 
-    shutdown()
+    running = false
   }
 
   private fun shutdown() {
+    running = false
     audioCapture?.stop()
     streamWriter?.stop()
     capture?.stop()
@@ -301,6 +325,8 @@ object VideoServer {
     streamWriter = null
     capture = null
     encoder = null
+    sessionLease?.stop()
+    sessionLease = null
 
     println("Shutdown complete")
   }

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoSessionLease.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoSessionLease.kt
@@ -95,7 +95,7 @@ class VideoSessionLease(
 
   fun start() {
     if (running) return
-    if (!leaseDirectory.exists() && !leaseDirectory.mkdirs()) {
+    if (!leaseDirectory.mkdirs() && !leaseDirectory.isDirectory) {
       throw IllegalStateException("Unable to create video session lease directory")
     }
 

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoSessionLease.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoSessionLease.kt
@@ -7,9 +7,9 @@ import org.json.JSONObject
 /**
  * Device-side record of one host-owned video-server process.
  *
- * The host uses these records only after their heartbeat expires. The token is
- * included in both this file and the process command line so a reused PID can
- * never make stale cleanup terminate an unrelated process.
+ * The host uses these records only after their heartbeat expires. The token is included in both
+ * this file and the process command line so a reused PID can never make stale cleanup terminate an
+ * unrelated process.
  */
 data class VideoSessionOptions(
   val socketName: String,
@@ -165,8 +165,8 @@ class VideoSessionLease(
     private const val HEARTBEAT_INTERVAL_MS = 5_000L
 
     /**
-     * Describes a lease that owns [socketName], if one exists for another token.
-     * This is diagnostic-only: collision handling never kills a process.
+     * Describes a lease that owns [socketName], if one exists for another token. This is
+     * diagnostic-only: collision handling never kills a process.
      */
     fun collisionDiagnostic(socketName: String, requestedToken: String?): String? {
       val record =
@@ -183,17 +183,14 @@ class VideoSessionLease(
           ?.firstOrNull {
             it.optString("socketName") == socketName &&
               it.optString("sessionToken") != requestedToken
-          }
-          ?: return null
+          } ?: return null
 
       val heartbeatAtMs = record.optLong("heartbeatAtMs", 0)
       val ageMs = (System.currentTimeMillis() - heartbeatAtMs).coerceAtLeast(0)
-      return (
-        "VIDEO_SESSION_COLLISION socket=$socketName " +
-          "existingOwnerPid=${record.optLong("ownerPid", -1)} " +
-          "existingToken=${record.optString("sessionToken")} " +
-          "requestedToken=$requestedToken tokenMismatch=true ageMs=$ageMs"
-        )
+      return ("VIDEO_SESSION_COLLISION socket=$socketName " +
+        "existingOwnerPid=${record.optLong("ownerPid", -1)} " +
+        "existingToken=${record.optString("sessionToken")} " +
+        "requestedToken=$requestedToken tokenMismatch=true ageMs=$ageMs")
     }
   }
 }

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoSessionLease.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoSessionLease.kt
@@ -1,0 +1,199 @@
+package dev.jasonpearson.automobile.video
+
+import android.os.SystemClock
+import java.io.File
+import org.json.JSONObject
+
+/**
+ * Device-side record of one host-owned video-server process.
+ *
+ * The host uses these records only after their heartbeat expires. The token is
+ * included in both this file and the process command line so a reused PID can
+ * never make stale cleanup terminate an unrelated process.
+ */
+data class VideoSessionOptions(
+  val socketName: String,
+  val token: String?,
+  val ownerPid: Long?,
+  val deviceSerial: String?,
+  val forwardPort: Int?,
+)
+
+data class VideoSessionLeaseRecord(
+  val socketName: String,
+  val sessionToken: String,
+  val pid: Int,
+  val ownerPid: Long?,
+  val deviceSerial: String?,
+  val forwardPort: Int?,
+  val startedAtMs: Long,
+  val heartbeatAtMs: Long,
+  val heartbeatElapsedRealtimeMs: Long,
+)
+
+fun interface VideoSessionLeaseSerializer {
+  fun serialize(record: VideoSessionLeaseRecord): String
+}
+
+private object JsonVideoSessionLeaseSerializer : VideoSessionLeaseSerializer {
+  override fun serialize(record: VideoSessionLeaseRecord): String =
+    JSONObject()
+      .put("version", 1)
+      .put("socketName", record.socketName)
+      .put("sessionToken", record.sessionToken)
+      .put("pid", record.pid)
+      .put("ownerPid", record.ownerPid)
+      .put("deviceSerial", record.deviceSerial)
+      .put("forwardPort", record.forwardPort)
+      .put("startedAtMs", record.startedAtMs)
+      .put("heartbeatAtMs", record.heartbeatAtMs)
+      .put("heartbeatElapsedRealtimeMs", record.heartbeatElapsedRealtimeMs)
+      .toString()
+}
+
+object VideoSessionArguments {
+  private const val DEFAULT_SOCKET_NAME = "automobile_video"
+  private val SAFE_SOCKET_NAME = Regex("[A-Za-z0-9_.-]{1,100}")
+  private val SAFE_TOKEN = Regex("[A-Za-z0-9-]{8,80}")
+
+  fun parse(args: Array<String>): VideoSessionOptions {
+    val socketName = valueAfter(args, "--socket-name") ?: DEFAULT_SOCKET_NAME
+    require(SAFE_SOCKET_NAME.matches(socketName)) { "Invalid --socket-name" }
+
+    val token = valueAfter(args, "--session-token")
+    require(token == null || SAFE_TOKEN.matches(token)) { "Invalid --session-token" }
+
+    return VideoSessionOptions(
+      socketName = socketName,
+      token = token,
+      ownerPid = valueAfter(args, "--owner-pid")?.toLongOrNull()?.takeIf { it > 0 },
+      deviceSerial = valueAfter(args, "--device-serial"),
+      forwardPort = valueAfter(args, "--forward-port")?.toIntOrNull()?.takeIf { it > 0 },
+    )
+  }
+
+  private fun valueAfter(args: Array<String>, flag: String): String? {
+    val index = args.indexOf(flag)
+    return if (index >= 0 && index + 1 < args.size) args[index + 1] else null
+  }
+}
+
+class VideoSessionLease(
+  private val options: VideoSessionOptions,
+  private val processId: Int,
+  private val nowMs: () -> Long = System::currentTimeMillis,
+  private val elapsedRealtimeMs: () -> Long = SystemClock::elapsedRealtime,
+  private val leaseDirectory: File = File(LEASE_DIRECTORY),
+  private val serializer: VideoSessionLeaseSerializer = JsonVideoSessionLeaseSerializer,
+) {
+  private val token = requireNotNull(options.token)
+  private val leaseFile = File(leaseDirectory, "$token.json")
+  private val startedAtMs = nowMs()
+
+  @Volatile private var running = false
+  private var heartbeatThread: Thread? = null
+
+  fun start() {
+    if (running) return
+    if (!leaseDirectory.exists() && !leaseDirectory.mkdirs()) {
+      throw IllegalStateException("Unable to create video session lease directory")
+    }
+
+    running = true
+    writeHeartbeat()
+    heartbeatThread =
+      Thread(
+          {
+            while (running) {
+              try {
+                Thread.sleep(HEARTBEAT_INTERVAL_MS)
+              } catch (_: InterruptedException) {
+                break
+              }
+              if (running) writeHeartbeat()
+            }
+          },
+          "automobile-video-session-heartbeat",
+        )
+        .also {
+          it.isDaemon = true
+          it.start()
+        }
+  }
+
+  fun stop() {
+    running = false
+    heartbeatThread?.interrupt()
+    try {
+      heartbeatThread?.join(1_000)
+    } catch (_: InterruptedException) {
+      Thread.currentThread().interrupt()
+    }
+    heartbeatThread = null
+    leaseFile.delete()
+  }
+
+  private fun writeHeartbeat() {
+    try {
+      val payload =
+        serializer.serialize(
+          VideoSessionLeaseRecord(
+            socketName = options.socketName,
+            sessionToken = token,
+            pid = processId,
+            ownerPid = options.ownerPid,
+            deviceSerial = options.deviceSerial,
+            forwardPort = options.forwardPort,
+            startedAtMs = startedAtMs,
+            heartbeatAtMs = nowMs(),
+            heartbeatElapsedRealtimeMs = elapsedRealtimeMs(),
+          )
+        )
+      val temporary = File(leaseFile.parentFile, "${leaseFile.name}.tmp")
+      temporary.writeText(payload)
+      if (!temporary.renameTo(leaseFile)) {
+        temporary.copyTo(leaseFile, overwrite = true)
+        temporary.delete()
+      }
+    } catch (error: Exception) {
+      System.err.println("VIDEO_SESSION_HEARTBEAT_FAILED token=$token error=${error.message}")
+    }
+  }
+
+  companion object {
+    const val LEASE_DIRECTORY = "/data/local/tmp/automobile-video-sessions"
+    private const val HEARTBEAT_INTERVAL_MS = 5_000L
+
+    /**
+     * Describes a lease that owns [socketName], if one exists for another token.
+     * This is diagnostic-only: collision handling never kills a process.
+     */
+    fun collisionDiagnostic(socketName: String, requestedToken: String?): String? {
+      val record =
+        File(LEASE_DIRECTORY)
+          .listFiles { file -> file.extension == "json" }
+          ?.asSequence()
+          ?.mapNotNull { file ->
+            try {
+              JSONObject(file.readText())
+            } catch (_: Exception) {
+              null
+            }
+          }
+          ?.firstOrNull {
+            it.optString("socketName") == socketName &&
+              it.optString("sessionToken") != requestedToken
+          }
+          ?: return null
+
+      val heartbeatAtMs = record.optLong("heartbeatAtMs", 0)
+      val ageMs = (System.currentTimeMillis() - heartbeatAtMs).coerceAtLeast(0)
+      return (
+        "VIDEO_SESSION_COLLISION socket=$socketName " +
+          "existingOwnerPid=${record.optLong("ownerPid", -1)} " +
+          "existingToken=${record.optString("sessionToken")} " +
+          "requestedToken=$requestedToken tokenMismatch=true ageMs=$ageMs"
+        )
+    }
+  }
+}

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
@@ -20,6 +20,12 @@ class VideoStreamWriter(
   private val audioEnabled: Boolean = false,
   private val nowMs: () -> Long = { SystemClock.elapsedRealtime() },
 ) {
+  private data class CachedPacket(
+    val trackId: Int,
+    val ptsAndFlags: Long,
+    val data: ByteArray,
+  )
+
   private var serverSocket: LocalServerSocket? = null
   private var clientSocket: LocalSocket? = null
   private var outputStream: OutputStream? = null
@@ -125,7 +131,7 @@ class VideoStreamWriter(
     Thread(
         {
           try {
-            while (!stopped) {
+            while (!stopped && isCurrentClient(client)) {
               val command = input.read()
               if (command < 0) break
               commandHandler?.invoke(command)
@@ -221,6 +227,9 @@ class VideoStreamWriter(
       return true
     }
   }
+
+  private fun isCurrentClient(client: LocalSocket): Boolean =
+    synchronized(lock) { clientSocket === client }
 
   private fun closeClientLocked() {
     try {

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
@@ -9,6 +9,38 @@ import java.io.OutputStream
 import java.nio.ByteBuffer
 
 /**
+ * Tracks the bounded clientless window using a monotonic clock so wall-clock changes cannot
+ * prematurely expire or indefinitely extend a capture session.
+ */
+internal class ReconnectWindow(
+  private val clock: () -> Long,
+  private val durationMs: Long,
+) {
+  private var clientlessSinceMs: Long? = null
+  private var clientAttached = false
+
+  fun start() {
+    clientAttached = false
+    clientlessSinceMs = clock()
+  }
+
+  fun onClientAttached() {
+    clientAttached = true
+    clientlessSinceMs = null
+  }
+
+  fun onClientDetached() {
+    clientAttached = false
+    clientlessSinceMs = clock()
+  }
+
+  fun isExpired(): Boolean {
+    val clientlessSince = clientlessSinceMs ?: return false
+    return !clientAttached && clock() - clientlessSince >= durationMs
+  }
+}
+
+/**
  * Writes encoded video packets to a LocalSocket using the VideoStreamProtocol binary framing. A
  * disconnected client is replaceable: the writer retains codec configuration plus the latest
  * complete keyframe and replays them before live packets to the next client.
@@ -32,7 +64,7 @@ class VideoStreamWriter(
   private var commandHandler: ((Int) -> Unit)? = null
   private val lock = Any()
   private val packetCache = VideoPacketCache()
-  private val reconnectWindow = ClientReconnectWindow()
+  private val reconnectWindow = ReconnectWindow(nowMs, CLIENT_RECONNECT_WINDOW_MS)
 
   @Volatile private var stopped = false
 
@@ -67,6 +99,7 @@ class VideoStreamWriter(
    */
   fun start(onClientConnected: () -> Unit = {}) {
     serverSocket = LocalServerSocket(socketName)
+    synchronized(lock) { reconnectWindow.start() }
     println("Waiting for client connection on localabstract:$socketName")
     Thread(
         { acceptClients(onClientConnected) },
@@ -107,12 +140,12 @@ class VideoStreamWriter(
           try {
             writeStreamHeaderLocked()
             replayCachedVideoLocked()
-            reconnectWindow.onClientConnected()
+            reconnectWindow.onClientAttached()
             true
           } catch (e: IOException) {
             println("Error attaching video client: ${e.message}")
             closeClientLocked()
-            reconnectWindow.onClientDisconnected(nowMs())
+            reconnectWindow.onClientDetached()
             false
           }
         }
@@ -142,7 +175,7 @@ class VideoStreamWriter(
             synchronized(lock) {
               if (clientSocket === client) {
                 closeClientLocked()
-                reconnectWindow.onClientDisconnected(nowMs())
+                reconnectWindow.onClientDetached()
               }
             }
           }
@@ -178,10 +211,10 @@ class VideoStreamWriter(
       writePacketDataLocked(TRACK_ID_AUDIO, ptsUs and PTS_MASK, data)
     }
 
-  /** True once a prior client has failed to reconnect inside the bounded window. */
+  /** True once the initial or replacement client misses the bounded reconnect window. */
   fun reconnectWindowExpired(): Boolean =
     synchronized(lock) {
-      reconnectWindow.hasExpired(nowMs())
+      reconnectWindow.isExpired()
     }
 
   private fun writeStreamHeaderLocked() {
@@ -223,7 +256,7 @@ class VideoStreamWriter(
     } catch (e: IOException) {
       println("Error writing packet: ${e.message}")
       closeClientLocked()
-      reconnectWindow.onClientDisconnected(nowMs())
+      reconnectWindow.onClientDetached()
       return true
     }
   }
@@ -285,24 +318,4 @@ internal class VideoPacketCache {
       else -> listOf(cachedConfig.copyPacket(), cachedIdr.copyPacket())
     }
   }
-}
-
-internal class ClientReconnectWindow(
-  private val windowMs: Long = VideoStreamWriter.CLIENT_RECONNECT_WINDOW_MS
-) {
-  private var hasConnected = false
-  private var disconnectedAtMs: Long? = null
-
-  fun onClientConnected() {
-    hasConnected = true
-    disconnectedAtMs = null
-  }
-
-  fun onClientDisconnected(nowMs: Long) {
-    if (hasConnected && disconnectedAtMs == null) {
-      disconnectedAtMs = nowMs
-    }
-  }
-
-  fun hasExpired(nowMs: Long): Boolean = disconnectedAtMs?.let { nowMs - it >= windowMs } ?: false
 }

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoSessionLeaseTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoSessionLeaseTest.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.automobile.video
 import java.io.File
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -38,6 +39,7 @@ class VideoSessionLeaseTest {
     lease.start()
 
     val leaseFile = File(leaseDirectory, "session-0001.json")
+    assertTrue(leaseFile.exists())
     assertEquals(42_000L, writtenRecord?.heartbeatElapsedRealtimeMs)
     assertEquals(1_000L, writtenRecord?.heartbeatAtMs)
 

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoSessionLeaseTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoSessionLeaseTest.kt
@@ -1,0 +1,47 @@
+package dev.jasonpearson.automobile.video
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class VideoSessionLeaseTest {
+  @get:Rule val temporaryFolder = TemporaryFolder()
+
+  @Test
+  fun writesHeartbeatInDeviceElapsedRealtimeDomainAndRemovesLeaseOnStop() {
+    val leaseDirectory = File(temporaryFolder.root, "leases")
+    var writtenRecord: VideoSessionLeaseRecord? = null
+    val lease =
+      VideoSessionLease(
+        options =
+          VideoSessionOptions(
+            socketName = "automobile_video_session",
+            token = "session-0001",
+            ownerPid = 456,
+            deviceSerial = "emulator-5554",
+            forwardPort = 61234,
+          ),
+        processId = 123,
+        nowMs = { 1_000L },
+        elapsedRealtimeMs = { 42_000L },
+        leaseDirectory = leaseDirectory,
+        serializer =
+          VideoSessionLeaseSerializer { record ->
+            writtenRecord = record
+            "{}"
+          },
+      )
+
+    lease.start()
+
+    val leaseFile = File(leaseDirectory, "session-0001.json")
+    assertEquals(42_000L, writtenRecord?.heartbeatElapsedRealtimeMs)
+    assertEquals(1_000L, writtenRecord?.heartbeatAtMs)
+
+    lease.stop()
+    assertFalse(leaseFile.exists())
+  }
+}

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamProtocolTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamProtocolTest.kt
@@ -236,16 +236,23 @@ class VideoStreamProtocolTest {
   }
 
   @Test
-  fun reconnectWindowOnlyExpiresAfterAConnectedClientIsLost() {
-    val window = ClientReconnectWindow(windowMs = 5_000)
+  fun reconnectWindowExpiresAfterInitialAttachOrClientDisconnect() {
+    var elapsedRealtimeMs = 0L
+    val window = ReconnectWindow({ elapsedRealtimeMs }, durationMs = 5_000L)
 
-    assertEquals(false, window.hasExpired(10_000))
-    window.onClientConnected()
-    window.onClientDisconnected(100)
-    assertEquals(false, window.hasExpired(5_099))
-    assertEquals(true, window.hasExpired(5_100))
+    window.start()
+    elapsedRealtimeMs = 4_999L
+    assertEquals(false, window.isExpired())
+    elapsedRealtimeMs = 5_000L
+    assertEquals(true, window.isExpired())
 
-    window.onClientConnected()
-    assertEquals(false, window.hasExpired(10_000))
+    window.onClientAttached()
+    assertEquals(false, window.isExpired())
+    elapsedRealtimeMs = 5_200L
+    window.onClientDetached()
+    elapsedRealtimeMs = 10_199L
+    assertEquals(false, window.isExpired())
+    elapsedRealtimeMs = 10_200L
+    assertEquals(true, window.isExpired())
   }
 }

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriterTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriterTest.kt
@@ -1,0 +1,25 @@
+package dev.jasonpearson.automobile.video
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VideoStreamWriterTest {
+  @Test
+  fun reconnectWindowUsesElapsedTimeDespiteWallClockJumps() {
+    var elapsedRealtimeMs = 1_000L
+    val window = ReconnectWindow({ elapsedRealtimeMs }, durationMs = 10_000L)
+
+    window.start()
+    window.onClientAttached()
+    elapsedRealtimeMs = 2_000L
+    window.onClientDetached()
+
+    // Wall-clock changes do not affect the injected elapsed-time domain.
+    elapsedRealtimeMs = 11_999L
+    assertFalse(window.isExpired())
+
+    elapsedRealtimeMs = 12_000L
+    assertTrue(window.isExpired())
+  }
+}

--- a/src/features/webrtc/AndroidH264Source.ts
+++ b/src/features/webrtc/AndroidH264Source.ts
@@ -113,19 +113,20 @@ export class AndroidH264Source implements H264CaptureSource {
    * emit an IDR mid-stream, so rotate the segment — restarting it re-emits
    * SPS/PPS + IDR. Throttled, and a no-op when not actively streaming.
    */
-  requestKeyFrame(): void {
+  requestKeyFrame(): boolean {
     const process = this.current;
     if (!this.running || !process) {
-      return;
+      return false;
     }
     const now = this.timer.now();
     if (now - this.lastForcedKeyFrameMs < ANDROID_FORCED_KEYFRAME_MIN_INTERVAL_MS) {
-      return;
+      return false;
     }
     this.lastForcedKeyFrameMs = now;
     logger.info(`[AndroidH264Source] keyframe requested; rotating segment ${this.segmentCount} to emit a fresh IDR`);
     // Terminating triggers the exit handler, which starts the next segment.
     process.kill("SIGINT");
+    return true;
   }
 
   private async startSegment(): Promise<void> {

--- a/src/features/webrtc/H264CaptureSource.ts
+++ b/src/features/webrtc/H264CaptureSource.ts
@@ -71,7 +71,7 @@ export interface H264CaptureSource {
    * rely on the periodic IDR interval. Implementations must be safe to call
    * frequently (throttle internally) and before/after the stream is running.
    */
-  requestKeyFrame?(): void;
+  requestKeyFrame?(): boolean;
   /** Optional precise encoder telemetry for the stream-status control plane. */
   getTelemetry?(): H264CaptureSourceTelemetry;
 }

--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -254,6 +254,8 @@ export class IosH264Source implements H264CaptureSource {
   private nativeFrameMetrics: NativeFrameMetrics | null = null;
   private forcedKeyFrameEncoder: IosH264EncoderProcess | null = null;
   private forcedKeyFrameParser: H264AnnexBParser | null = null;
+  private encoderIdrParser = new H264AnnexBParser();
+  private encoderHasProducedIdr = false;
   private phase: IosH264SourcePhase = "idle";
 
   constructor(private readonly options: IosH264SourceOptions) {
@@ -352,13 +354,20 @@ export class IosH264Source implements H264CaptureSource {
    * the steady-state bitrate cost at zero: no extra keyframes are emitted unless
    * a viewer actually asks. A burst of PLIs is throttled to one restart per
    * {@link IOS_FORCED_KEYFRAME_MIN_INTERVAL_MS}; later requests are also held
-   * until that replacement emits its IDR. Safe to call before the encoder exists
-   * (the first frame is already an IDR) or after the source has stopped.
+   * until that replacement emits its IDR. Safe to call before the initial
+   * encoder emits its first IDR (that encoder will already satisfy the request)
+   * or after the source has stopped.
    */
   requestKeyFrame(): boolean {
     const oldEncoder = this.encoder;
     const size = this.encoderSize;
-    if (this.phase !== "running" || !oldEncoder || !size || this.forcedKeyFrameEncoder) {
+    if (
+      this.phase !== "running" ||
+      !oldEncoder ||
+      !size ||
+      !this.encoderHasProducedIdr ||
+      this.forcedKeyFrameEncoder
+    ) {
       return false;
     }
     const now = this.timer.now();
@@ -705,6 +714,8 @@ export class IosH264Source implements H264CaptureSource {
     this.encoder = encoder;
     this.encoderSize = size;
     this.encoderBackpressured = false;
+    this.encoderIdrParser = new H264AnnexBParser();
+    this.encoderHasProducedIdr = false;
     this.lastEncoderStderr = null;
     if (awaitsForcedKeyFrame) {
       this.forcedKeyFrameEncoder = encoder;
@@ -714,6 +725,7 @@ export class IosH264Source implements H264CaptureSource {
     encoder.stdout.on("data", chunk => {
       if (this.isActive() && this.encoder === encoder) {
         const data = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        this.recordEncoderIdr(encoder, data);
         this.recordForcedKeyFrame(encoder, data);
         this.options.onData(data);
       }
@@ -809,6 +821,18 @@ export class IosH264Source implements H264CaptureSource {
       // failure. Keep this recovery guard closed rather than restarting an
       // encoder whose replacement output we cannot prove contains an IDR.
       logger.debug(`[IosH264Source] could not parse forced-keyframe output: ${error}`);
+    }
+  }
+
+  /** Track the initial IDR before allowing a PLI to recycle the warming encoder. */
+  private recordEncoderIdr(encoder: IosH264EncoderProcess, chunk: Buffer): void {
+    if (this.encoder !== encoder || this.encoderHasProducedIdr) {
+      return;
+    }
+    try {
+      this.encoderHasProducedIdr = this.encoderIdrParser.push(chunk).some(isKeyFrameNal);
+    } catch (error) {
+      logger.debug(`[IosH264Source] could not parse encoder output while awaiting initial IDR: ${error}`);
     }
   }
 

--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -355,15 +355,15 @@ export class IosH264Source implements H264CaptureSource {
    * until that replacement emits its IDR. Safe to call before the encoder exists
    * (the first frame is already an IDR) or after the source has stopped.
    */
-  requestKeyFrame(): void {
+  requestKeyFrame(): boolean {
     const oldEncoder = this.encoder;
     const size = this.encoderSize;
     if (this.phase !== "running" || !oldEncoder || !size || this.forcedKeyFrameEncoder) {
-      return;
+      return false;
     }
     const now = this.timer.now();
     if (now - this.lastForcedKeyFrameMs < IOS_FORCED_KEYFRAME_MIN_INTERVAL_MS) {
-      return;
+      return false;
     }
     this.lastForcedKeyFrameMs = now;
     logger.info("[IosH264Source] keyframe requested; restarting encoder to emit a fresh IDR");
@@ -378,6 +378,7 @@ export class IosH264Source implements H264CaptureSource {
     }
     oldEncoder.stdin.end();
     oldEncoder.kill("SIGTERM");
+    return true;
   }
 
   private async resolveCaptureTarget(helperPath: string): Promise<CaptureTarget> {

--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -34,7 +34,7 @@ import type {
   H264CaptureSourceOptions,
   H264EncoderFrameMetrics,
 } from "./H264CaptureSource";
-import { H264AnnexBParser, isKeyFrameNal } from "./h264";
+import { H264AnnexBParser, isKeyFrameNal, NAL_TYPE_IDR } from "./h264";
 import { h264MacroblocksPerFrame, WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME } from "./h264Level";
 import { WEBRTC_IOS_SIMULATOR_FPS_DEFAULT } from "./webrtcStreamingConfig";
 
@@ -830,8 +830,12 @@ export class IosH264Source implements H264CaptureSource {
       return;
     }
     try {
-      this.encoderHasProducedIdr = this.encoderIdrParser.push(chunk).some(isKeyFrameNal);
+      this.encoderHasProducedIdr =
+        this.encoderIdrParser.push(chunk).some(isKeyFrameNal) ||
+        this.encoderIdrParser.hasBufferedNalType(NAL_TYPE_IDR);
     } catch (error) {
+      // The RTP writer will surface malformed Annex-B separately. Leave this
+      // gate closed so an unverified warming encoder is not recycled into PLI churn.
       logger.debug(`[IosH264Source] could not parse encoder output while awaiting initial IDR: ${error}`);
     }
   }

--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -240,6 +240,7 @@ export class IosH264Source implements H264CaptureSource {
   private encoder: IosH264EncoderProcess | null = null;
   private encoderSize: EncoderSize | null = null;
   private encoderBackpressured = false;
+  private lastHelperFrame: DecodedFrame | null = null;
   private teardownPromise: Promise<void> | null = null;
   private cancelFirstFrameWait: (() => void) | null = null;
   private cancelFirstAudioWait: (() => void) | null = null;
@@ -307,6 +308,7 @@ export class IosH264Source implements H264CaptureSource {
     this.lastHelperStderr = null;
     this.helperFrameMetrics = null;
     this.nativeFrameMetrics = null;
+    this.lastHelperFrame = null;
 
     try {
       const helperPath = await this.resolveHelperPath();
@@ -371,6 +373,9 @@ export class IosH264Source implements H264CaptureSource {
     this.pendingFrames.clear(true);
     this.reportFrameMetrics();
     this.startEncoder(size, true);
+    if (this.lastHelperFrame) {
+      this.writeFrameToEncoder(this.lastHelperFrame);
+    }
     oldEncoder.stdin.end();
     oldEncoder.kill("SIGTERM");
   }
@@ -674,6 +679,10 @@ export class IosH264Source implements H264CaptureSource {
       this.outputWriteHighWaterDurationMs,
       this.lastOutputWriteDurationMs
     );
+    this.lastHelperFrame = {
+      header: { ...frame.header },
+      pixels: Buffer.from(frame.pixels),
+    };
     if (accepted === false) {
       this.encoderBackpressured = true;
     }
@@ -924,6 +933,7 @@ export class IosH264Source implements H264CaptureSource {
     this.pendingFrames.clear();
     this.forcedKeyFrameEncoder = null;
     this.forcedKeyFrameParser = null;
+    this.lastHelperFrame = null;
     encoder?.stdin.end();
     encoder?.kill("SIGTERM");
 

--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -378,11 +378,15 @@ export class IosH264Source implements H264CaptureSource {
     logger.info("[IosH264Source] keyframe requested; restarting encoder to emit a fresh IDR");
     // Spawn the replacement first so the outgoing encoder's exit/error handlers
     // — all guarded by `this.encoder === encoder` — no-op instead of tearing the
-    // source down as a fatal crash. Then end its stdin and terminate it.
+    // source down as a fatal crash. Two retained input frames make the first
+    // IDR's Annex-B NAL terminate at the following access-unit boundary even
+    // while the capture helper is otherwise quiet. Then end its stdin and
+    // terminate it.
     this.pendingFrames.clear(true);
     this.reportFrameMetrics();
     this.startEncoder(size, true);
     if (this.lastHelperFrame) {
+      this.writeFrameToEncoder(this.lastHelperFrame);
       this.writeFrameToEncoder(this.lastHelperFrame);
     }
     oldEncoder.stdin.end();

--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -812,7 +812,10 @@ export class IosH264Source implements H264CaptureSource {
       return;
     }
     try {
-      if (this.forcedKeyFrameParser.push(chunk).some(isKeyFrameNal)) {
+      if (
+        this.forcedKeyFrameParser.push(chunk).some(isKeyFrameNal) ||
+        this.forcedKeyFrameParser.hasBufferedNalType(NAL_TYPE_IDR)
+      ) {
         this.forcedKeyFrameEncoder = null;
         this.forcedKeyFrameParser = null;
       }

--- a/src/features/webrtc/PersistentEncoderH264Source.ts
+++ b/src/features/webrtc/PersistentEncoderH264Source.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { connect as netConnect } from "node:net";
 import { ActionableError, type BootedDevice } from "../../models";
 import { logger } from "../../utils/logger";
@@ -18,11 +19,15 @@ import {
 
 /** Remote path the DEX jar is pushed to before launch. */
 export const VIDEO_SERVER_REMOTE_JAR_PATH = "/data/local/tmp/automobile-video.jar";
-/** Abstract LocalSocket name the server binds (matches VideoServer.SOCKET_NAME). */
-export const VIDEO_SERVER_SOCKET_NAME = "automobile_video";
+/** Prefix for host-owned per-session LocalSocket names. */
+export const VIDEO_SERVER_SOCKET_PREFIX = "automobile_video";
 const VIDEO_SERVER_MAIN_CLASS = "dev.jasonpearson.automobile.video.VideoServer";
-/** Server stdout line printed once it is ready to accept the socket client. */
-const READY_MARKER = "Waiting for client connection";
+/** Device-side directory containing JSON lease files for owned capture sessions. */
+export const VIDEO_SERVER_LEASE_DIRECTORY = "/data/local/tmp/automobile-video-sessions";
+/** A device heartbeat older than this is eligible for owned stale cleanup. */
+const STALE_LEASE_MS = 30_000;
+/** Server stdout line that carries its validated app_process PID and token. */
+const SESSION_READY_MARKER = "VIDEO_SESSION_READY";
 /** Server stdout line printed after capture has fully started. */
 const STREAMING_STARTED_MARKER = "Streaming started";
 
@@ -48,6 +53,27 @@ export interface StreamSocket {
 
 /** Connects to a forwarded local TCP port and resolves once connected. */
 export type SocketConnector = (port: number, signal?: AbortSignal) => Promise<StreamSocket>;
+
+export interface VideoServerSession {
+  token: string;
+  socketName: string;
+  ownerPid: number;
+  deviceSerial: string;
+}
+
+interface RawVideoServerLease {
+  socketName: string;
+  sessionToken: string;
+  ownerPid: number;
+  deviceSerial: string;
+  pid: number;
+  forwardPort: number;
+  startedAtMs: number;
+  heartbeatAtMs: number;
+  heartbeatElapsedRealtimeMs?: number;
+}
+
+interface VideoServerLease extends VideoServerSession, Omit<RawVideoServerLease, "sessionToken"> {}
 
 const defaultConnector: SocketConnector = (port, signal) =>
   new Promise<StreamSocket>((resolve, reject) => {
@@ -103,9 +129,67 @@ export interface PersistentEncoderH264SourceOptions {
   localSocketReconnectWindowMs?: number;
   /** Spacing between local socket reconnect attempts. */
   localSocketReconnectRetryMs?: number;
+  /** Injectable session token source for deterministic tests. */
+  sessionTokenFactory?: () => string;
 }
 
 const DEFAULT_READY_TIMEOUT_MS = 10_000;
+
+function socketNameForToken(token: string): string {
+  return `${VIDEO_SERVER_SOCKET_PREFIX}_${token.replaceAll("-", "")}`;
+}
+
+function isSafeSessionToken(value: string): boolean {
+  return /^[A-Za-z0-9-]{8,80}$/.test(value);
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+function isVideoServerLease(value: unknown): value is RawVideoServerLease {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const lease = value as Record<string, unknown>;
+  if (typeof lease.sessionToken !== "string" || !isSafeSessionToken(lease.sessionToken)) {return false;}
+  if (typeof lease.socketName !== "string" || typeof lease.deviceSerial !== "string") {return false;}
+  if (!isPositiveInteger(lease.ownerPid) || !isPositiveInteger(lease.pid)) {return false;}
+  if (!isPositiveInteger(lease.forwardPort)) {return false;}
+  if (!isFiniteNumber(lease.startedAtMs) || !isFiniteNumber(lease.heartbeatAtMs)) {
+    return false;
+  }
+  return (
+    lease.heartbeatElapsedRealtimeMs === undefined ||
+    (isFiniteNumber(lease.heartbeatElapsedRealtimeMs) && lease.heartbeatElapsedRealtimeMs >= 0)
+  );
+}
+
+function parseLeases(output: string): VideoServerLease[] {
+  return output
+    .split(/\r?\n/)
+    .flatMap(line => {
+      try {
+        const parsed: unknown = JSON.parse(line);
+        if (!isVideoServerLease(parsed)) {
+          return [];
+        }
+        return [
+          {
+            ...parsed,
+            token: parsed.sessionToken,
+          },
+        ];
+      } catch (error) {
+        logger.debug(`[PersistentEncoderH264Source] ignoring malformed video session lease: ${error}`);
+        return [];
+      }
+    });
+}
 
 /**
  * Produces a continuous H.264 Annex-B elementary stream from a persistent
@@ -127,10 +211,13 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
   private readonly readyTimeoutMs: number;
   private readonly localSocketReconnectWindowMs: number;
   private readonly localSocketReconnectRetryMs: number;
+  private readonly sessionTokenFactory: () => string;
 
   private server: AdbProcess | null = null;
   private socket: StreamSocket | null = null;
   private forwardedPort: number | null = null;
+  private session: VideoServerSession | null = null;
+  private deviceProcessId: number | null = null;
   private running = false;
   private teardownPromise: Promise<void> | null = null;
   private resolveStartupAudioHeader: ((header: VideoServerStreamHeader) => void) | undefined;
@@ -144,6 +231,9 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
   private idrCompletionCount = 0;
   private pendingIdrRequests = 0;
   private encodedAccessUnitCount = 0;
+  private serverOutputObserver: ((chunk: Buffer) => void) | null = null;
+  private serverOutputBuffer = "";
+  private sawStreamingStarted = false;
 
   constructor(options: PersistentEncoderH264SourceOptions) {
     this.options = options;
@@ -158,6 +248,7 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     if (this.localSocketReconnectWindowMs <= 0 || this.localSocketReconnectRetryMs <= 0) {
       throw new ActionableError("Local socket reconnect timings must be positive milliseconds.");
     }
+    this.sessionTokenFactory = options.sessionTokenFactory ?? randomUUID;
   }
 
   get isRunning(): boolean {
@@ -234,23 +325,47 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
 
   private async launch(): Promise<void> {
     const adb = this.adbFactory.create(this.options.device);
-    if (!this.running) {
+    const port = await this.prepareSession(adb);
+    if (port === null) {
       return;
     }
+    const server = await this.spawnAndWaitForServer(adb);
+    if (!server) {
+      return;
+    }
+    await this.connectToServer(server, port);
+  }
 
-    // Push the DEX jar (idempotent; overwrites any prior copy).
+  private async prepareSession(adb: ReturnType<AdbClientFactory["create"]>): Promise<number | null> {
+    if (!this.running) {return null;}
+    const session = this.createSession();
+    this.session = session;
+    this.deviceProcessId = null;
+    await this.reconcileExpiredLeases(adb);
+    if (!this.running) {return null;}
     await adb.executeCommand(`push "${this.options.jarPath}" ${VIDEO_SERVER_REMOTE_JAR_PATH}`);
-    if (!this.running) {
-      return;
+    if (!this.running) {return null;}
+    const forward = await adb.executeCommand(
+      `forward tcp:0 localabstract:${session.socketName}`
+    );
+    const port = Number.parseInt(forward.stdout.trim(), 10);
+    if (!Number.isInteger(port) || port <= 0) {
+      throw new ActionableError(`adb forward returned an invalid port: "${forward.stdout.trim()}"`);
     }
+    this.forwardedPort = port;
+    return port;
+  }
 
-    // Launch the persistent server as a long-lived process.
+  private async spawnAndWaitForServer(
+    adb: ReturnType<AdbClientFactory["create"]>
+  ): Promise<AdbProcess | null> {
     const server = await adb.spawn(this.buildServerArgs());
     if (!this.running) {
       server.kill("SIGINT");
-      return;
+      return null;
     }
     this.server = server;
+    this.attachServerOutputObserver(server);
     server.stderr.on("data", (chunk: Buffer) => {
       const text = chunk.toString().trim();
       if (text) {
@@ -258,25 +373,11 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
       }
     });
 
-    // Wait until the server has bound its LocalSocket and is ready for a client.
-    // Readiness owns the startup window: a server crash here must REJECT start()
-    // (so the factory falls back), not fire onError (which would trigger a
-    // pointless reconnect against a source that never came up).
-    await this.waitForReady(server);
-    if (!this.running) {
-      return;
-    }
+    this.deviceProcessId = await this.waitForReady(server);
+    return this.running ? server : null;
+  }
 
-    // Forward an ephemeral local port to the server's abstract socket and connect.
-    const forward = await adb.executeCommand(
-      `forward tcp:0 localabstract:${VIDEO_SERVER_SOCKET_NAME}`
-    );
-    const port = Number.parseInt(forward.stdout.trim(), 10);
-    if (!Number.isInteger(port) || port <= 0) {
-      throw new ActionableError(`adb forward returned an invalid port: "${forward.stdout.trim()}"`);
-    }
-    this.forwardedPort = port;
-
+  private async connectToServer(server: AdbProcess, port: number): Promise<void> {
     const streamingStarted = this.options.audioEnabled
       ? this.waitForStreamingStarted(server)
       : null;
@@ -324,13 +425,13 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
       }
     }
     socketFailureMode = "post-start";
+    this.watchServer(server);
+  }
 
-    // Now that the source is live, a later server exit or socket drop IS a fatal
-    // post-start failure: surface it via onError so the publisher reconnects.
+  private watchServer(server: AdbProcess): void {
     server.once("exit", (code, signal) => {
-      if (this.server !== server) {
-        return; // superseded / already torn down
-      }
+      if (this.server !== server) {return;}
+      this.detachServerOutputObserver(server);
       this.server = null;
       this.failIfRunning(new Error(`video-server exited (code=${code}, signal=${signal})`));
     });
@@ -338,6 +439,10 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
   }
 
   private buildServerArgs(): string[] {
+    const session = this.session;
+    if (!session || this.forwardedPort === null) {
+      throw new Error("Video server session was not initialized.");
+    }
     const args = [
       "shell",
       `CLASSPATH=${VIDEO_SERVER_REMOTE_JAR_PATH}`,
@@ -346,6 +451,16 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
       VIDEO_SERVER_MAIN_CLASS,
       "--quality",
       this.options.quality ?? "medium",
+      "--socket-name",
+      session.socketName,
+      "--session-token",
+      session.token,
+      "--owner-pid",
+      String(session.ownerPid),
+      "--device-serial",
+      session.deviceSerial,
+      "--forward-port",
+      String(this.forwardedPort),
     ];
     if (this.options.bitrateBps && this.options.bitrateBps > 0) {
       args.push("--bit-rate", String(Math.round(this.options.bitrateBps)));
@@ -359,16 +474,92 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     return args;
   }
 
-  private waitForReady(server: AdbProcess): Promise<void> {
-    return this.waitForServerLine(
-      server,
-      READY_MARKER,
-      `video-server did not become ready within ${this.readyTimeoutMs}ms`,
-      "video-server exited before ready"
-    );
+  private createSession(): VideoServerSession {
+    const token = this.sessionTokenFactory();
+    if (!isSafeSessionToken(token)) {
+      throw new Error("Video server session token factory returned an unsafe token.");
+    }
+    return {
+      token,
+      socketName: socketNameForToken(token),
+      ownerPid: process.pid,
+      deviceSerial: this.options.device.deviceId,
+    };
+  }
+
+  private waitForReady(server: AdbProcess): Promise<number> {
+    const token = this.session?.token;
+    if (!token) {
+      throw new Error("Video server session token was unavailable.");
+    }
+    return new Promise<number>((resolve, reject) => {
+      let settled = false;
+      let stdoutBuffer = "";
+      const finish = (fn: () => void): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        this.timer.clearTimeout(timeout);
+        server.stdout.off("data", onData);
+        server.removeListener("exit", onExit);
+        server.removeListener("error", onError);
+        fn();
+      };
+      const timeout = this.timer.setTimeout(() => {
+        finish(() =>
+          reject(
+            new ActionableError(
+              `video-server did not become session-ready within ${this.readyTimeoutMs}ms. ` +
+              "Set AUTOMOBILE_VIDEO_SERVER_JAR to a current automobile-video.jar."
+            )
+          )
+        );
+      }, this.readyTimeoutMs);
+      const onData = (chunk: Buffer): void => {
+        if (settled) {
+          return;
+        }
+        stdoutBuffer += chunk.toString();
+        for (const line of stdoutBuffer.split(/\r?\n/)) {
+          const match = new RegExp(`^${SESSION_READY_MARKER} token=([^ ]+) pid=(\\d+) socket=([^ ]+)$`).exec(line);
+          if (!match) {
+            continue;
+          }
+          if (match[1] !== token || match[3] !== this.session?.socketName) {
+            finish(() =>
+              reject(
+                new ActionableError(
+                  `video-server session readiness token mismatch (expected=${token}, got=${match[1]})`
+                )
+              )
+            );
+            return;
+          }
+          const pid = Number.parseInt(match[2], 10);
+          if (!Number.isInteger(pid) || pid <= 0) {
+            finish(() => reject(new ActionableError("video-server returned an invalid session PID")));
+            return;
+          }
+          finish(() => resolve(pid));
+          return;
+        }
+      };
+      const onExit = (code: number | null, signal: NodeJS.Signals | null): void => {
+        finish(() => reject(new Error(`video-server exited before ready (code=${code}, signal=${signal})`)));
+      };
+      const onError = (error: Error): void => finish(() => reject(error));
+
+      server.stdout.on("data", onData);
+      server.once("exit", onExit);
+      server.once("error", onError);
+    });
   }
 
   private waitForStreamingStarted(server: AdbProcess): Promise<void> {
+    if (this.sawStreamingStarted) {
+      return Promise.resolve();
+    }
     return this.waitForServerLine(
       server,
       STREAMING_STARTED_MARKER,
@@ -503,8 +694,16 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
       },
     });
     socket.on("data", chunk => parser.push(chunk));
-    socket.on("error", onSocketFailure);
-    socket.on("close", () => onSocketFailure(new Error("video-server socket closed")));
+    let failed = false;
+    const reportFailure = (error: Error): void => {
+      if (failed || this.socket !== socket) {
+        return;
+      }
+      failed = true;
+      onSocketFailure(error);
+    };
+    socket.on("error", reportFailure);
+    socket.on("close", () => reportFailure(new Error("video-server socket closed")));
   }
 
   private observeVideoPacket(packet: VideoServerPacket): void {
@@ -698,22 +897,230 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
 
     const server = this.server;
     this.server = null;
+    if (server) {
+      this.detachServerOutputObserver(server);
+    }
     // Terminating the host `adb shell` process closes the exec stream, which
     // stops the device-side server for THIS session. We deliberately do NOT run
     // a device-wide `pkill` (unlike the file-recording backend): it would also
     // kill a concurrent `videoRecording` on the same device.
     server?.kill("SIGINT");
 
+    const session = this.session;
     const port = this.forwardedPort;
+    const deviceProcessId = this.deviceProcessId;
     this.forwardedPort = null;
-    if (port !== null) {
-      try {
-        const adb = this.adbFactory.create(this.options.device);
-        await adb.executeCommand(`forward --remove tcp:${port}`);
-      } catch (error) {
-        // Best-effort: the forward is torn down with the device/adb server anyway.
-        logger.debug(`[PersistentEncoderH264Source] forward --remove failed: ${error}`);
-      }
+    this.deviceProcessId = null;
+    this.session = null;
+    if (session) {
+      await this.cleanupOwnedSession(session, port, deviceProcessId);
+    } else if (port !== null) {
+      await this.removeForward(port);
     }
+  }
+
+  private async reconcileExpiredLeases(adb: ReturnType<AdbClientFactory["create"]>): Promise<void> {
+    let leases: VideoServerLease[];
+    try {
+      const result = await adb.executeCommand(`shell cat ${VIDEO_SERVER_LEASE_DIRECTORY}/*.json`);
+      leases = parseLeases(result.stdout);
+    } catch (error) {
+      logger.debug(`[PersistentEncoderH264Source] unable to read video session leases: ${error}`);
+      return;
+    }
+
+    if (leases.length === 0) {
+      return;
+    }
+    const deviceElapsedRealtimeMs = await this.readDeviceElapsedRealtimeMs(adb);
+    if (deviceElapsedRealtimeMs === null) {
+      logger.warn("[PersistentEncoderH264Source] unable to read device uptime; skipping stale-session cleanup");
+      return;
+    }
+
+    for (const lease of leases) {
+      const heartbeatElapsedRealtimeMs = lease.heartbeatElapsedRealtimeMs;
+      if (
+        lease.deviceSerial !== this.options.device.deviceId ||
+        heartbeatElapsedRealtimeMs === undefined
+      ) {
+        continue;
+      }
+      const ageMs = deviceElapsedRealtimeMs - heartbeatElapsedRealtimeMs;
+      if (ageMs < STALE_LEASE_MS) {
+        continue;
+      }
+      logger.info(
+        `[PersistentEncoderH264Source] stale-session-cleanup token=${lease.token} ageMs=${ageMs}`
+      );
+      await this.removeForwardIfMatching(adb, lease.forwardPort, lease.socketName);
+      await this.terminateProcessIfMatching(adb, lease);
+      await this.removeLeaseIfMatching(adb, lease);
+    }
+  }
+
+  private async cleanupOwnedSession(
+    session: VideoServerSession,
+    port: number | null,
+    expectedProcessId: number | null
+  ): Promise<void> {
+    const adb = this.adbFactory.create(this.options.device);
+    const lease = await this.readLease(adb, session.token);
+    if (
+      lease &&
+      lease.token === session.token &&
+      lease.socketName === session.socketName &&
+      lease.ownerPid === session.ownerPid &&
+      lease.deviceSerial === session.deviceSerial &&
+      lease.pid === expectedProcessId
+    ) {
+      await this.removeForwardIfMatching(adb, lease.forwardPort, lease.socketName);
+      await this.terminateProcessIfMatching(adb, lease);
+      await this.removeLeaseIfMatching(adb, lease);
+      return;
+    }
+    if (lease) {
+      logger.warn(
+        `[PersistentEncoderH264Source] refusing owned-session process cleanup token=${session.token}: lease identity or PID mismatch`
+      );
+      await this.removeForwardIfMatching(adb, lease.forwardPort, session.socketName);
+      return;
+    }
+    if (port !== null) {
+      await this.removeForward(port);
+    }
+  }
+
+  private async readLease(
+    adb: ReturnType<AdbClientFactory["create"]>,
+    token: string
+  ): Promise<VideoServerLease | null> {
+    try {
+      const result = await adb.executeCommand(`shell cat ${VIDEO_SERVER_LEASE_DIRECTORY}/${token}.json`);
+      return parseLeases(result.stdout).find(lease => lease.token === token) ?? null;
+    } catch (error) {
+      logger.debug(`[PersistentEncoderH264Source] unable to read owned video session lease: ${error}`);
+      return null;
+    }
+  }
+
+  private async terminateProcessIfMatching(
+    adb: ReturnType<AdbClientFactory["create"]>,
+    lease: VideoServerLease
+  ): Promise<void> {
+    try {
+      const commandLine = await adb.executeCommand(`shell cat /proc/${lease.pid}/cmdline`);
+      const argv = commandLine.stdout.split("\u0000");
+      const ownsSession = argv.some(
+        (argument, index) =>
+          argument === "--session-token" && argv[index + 1] === lease.token
+      );
+      if (
+        !argv.includes(VIDEO_SERVER_MAIN_CLASS) ||
+        !ownsSession
+      ) {
+        logger.warn(
+          `[PersistentEncoderH264Source] refusing stale-session process cleanup token=${lease.token}: PID/token mismatch`
+        );
+        return;
+      }
+      await adb.executeCommand(`shell kill -2 ${lease.pid}`);
+    } catch (error) {
+      logger.debug(
+        `[PersistentEncoderH264Source] stale-session process cleanup skipped token=${lease.token}: ${error}`
+      );
+    }
+  }
+
+  private async removeForwardIfMatching(
+    adb: ReturnType<AdbClientFactory["create"]>,
+    port: number,
+    socketName: string
+  ): Promise<void> {
+    try {
+      const listed = await adb.executeCommand("forward --list");
+      const expectedPort = `tcp:${port}`;
+      const expectedDestination = `localabstract:${socketName}`;
+      const matches = listed.stdout.split(/\r?\n/).some(line => {
+        const fields = line.trim().split(/\s+/);
+        return fields.includes(expectedPort) && fields.includes(expectedDestination);
+      });
+      if (!matches) {
+        logger.warn(
+          `[PersistentEncoderH264Source] refusing stale-session forward cleanup port=${port}: destination mismatch`
+        );
+        return;
+      }
+      await adb.executeCommand(`forward --remove tcp:${port}`);
+    } catch (error) {
+      logger.debug(`[PersistentEncoderH264Source] forward --remove failed: ${error}`);
+    }
+  }
+
+  private async removeLeaseIfMatching(
+    adb: ReturnType<AdbClientFactory["create"]>,
+    lease: VideoServerLease
+  ): Promise<void> {
+    const current = await this.readLease(adb, lease.token);
+    if (
+      current?.token !== lease.token ||
+      current.socketName !== lease.socketName ||
+      current.pid !== lease.pid
+    ) {
+      return;
+    }
+    try {
+      await adb.executeCommand(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/${lease.token}.json`);
+    } catch (error) {
+      logger.debug(`[PersistentEncoderH264Source] stale-session lease cleanup failed: ${error}`);
+    }
+  }
+
+  private async removeForward(port: number): Promise<void> {
+    try {
+      const adb = this.adbFactory.create(this.options.device);
+      await adb.executeCommand(`forward --remove tcp:${port}`);
+    } catch (error) {
+      logger.debug(`[PersistentEncoderH264Source] forward --remove failed: ${error}`);
+    }
+  }
+
+  private attachServerOutputObserver(server: AdbProcess): void {
+    this.serverOutputBuffer = "";
+    this.sawStreamingStarted = false;
+    const observer = (chunk: Buffer): void => {
+      this.serverOutputBuffer += chunk.toString();
+      const lines = this.serverOutputBuffer.split(/\r?\n/);
+      this.serverOutputBuffer = lines.pop() ?? "";
+      if (lines.includes(STREAMING_STARTED_MARKER)) {
+        this.sawStreamingStarted = true;
+      }
+    };
+    this.serverOutputObserver = observer;
+    server.stdout.on("data", observer);
+  }
+
+  private detachServerOutputObserver(server: AdbProcess): void {
+    if (this.serverOutputObserver) {
+      server.stdout.off("data", this.serverOutputObserver);
+    }
+    this.serverOutputObserver = null;
+    this.serverOutputBuffer = "";
+    this.sawStreamingStarted = false;
+  }
+
+  private async readDeviceElapsedRealtimeMs(
+    adb: ReturnType<AdbClientFactory["create"]>
+  ): Promise<number | null> {
+    try {
+      const result = await adb.executeCommand("shell cat /proc/uptime");
+      const uptimeSeconds = Number.parseFloat(result.stdout.trim().split(/\s+/, 1)[0] ?? "");
+      if (Number.isFinite(uptimeSeconds) && uptimeSeconds >= 0) {
+        return Math.floor(uptimeSeconds * 1_000);
+      }
+    } catch (error) {
+      logger.debug(`[PersistentEncoderH264Source] unable to read device uptime: ${error}`);
+    }
+    return null;
   }
 }

--- a/src/features/webrtc/PersistentEncoderH264Source.ts
+++ b/src/features/webrtc/PersistentEncoderH264Source.ts
@@ -151,22 +151,29 @@ function isFiniteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
 }
 
+function hasValidLeaseHeartbeat(lease: Record<string, unknown>): boolean {
+  const elapsedRealtimeMs = lease.heartbeatElapsedRealtimeMs;
+  return elapsedRealtimeMs === undefined ||
+    (isFiniteNumber(elapsedRealtimeMs) && elapsedRealtimeMs >= 0);
+}
+
 function isVideoServerLease(value: unknown): value is RawVideoServerLease {
   if (typeof value !== "object" || value === null) {
     return false;
   }
   const lease = value as Record<string, unknown>;
-  if (typeof lease.sessionToken !== "string" || !isSafeSessionToken(lease.sessionToken)) {return false;}
-  if (typeof lease.socketName !== "string" || typeof lease.deviceSerial !== "string") {return false;}
-  if (!isPositiveInteger(lease.ownerPid) || !isPositiveInteger(lease.pid)) {return false;}
-  if (!isPositiveInteger(lease.forwardPort)) {return false;}
-  if (!isFiniteNumber(lease.startedAtMs) || !isFiniteNumber(lease.heartbeatAtMs)) {
-    return false;
-  }
-  return (
-    lease.heartbeatElapsedRealtimeMs === undefined ||
-    (isFiniteNumber(lease.heartbeatElapsedRealtimeMs) && lease.heartbeatElapsedRealtimeMs >= 0)
-  );
+  return [
+    typeof lease.sessionToken === "string",
+    typeof lease.sessionToken === "string" && isSafeSessionToken(lease.sessionToken),
+    typeof lease.socketName === "string",
+    typeof lease.deviceSerial === "string",
+    isPositiveInteger(lease.ownerPid),
+    isPositiveInteger(lease.pid),
+    isPositiveInteger(lease.forwardPort),
+    isFiniteNumber(lease.startedAtMs),
+    isFiniteNumber(lease.heartbeatAtMs),
+    hasValidLeaseHeartbeat(lease),
+  ].every(Boolean);
 }
 
 function parseLeases(output: string): VideoServerLease[] {
@@ -360,8 +367,8 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     }
     if (!this.running) {
       // This forward completed after stop() snapshotted its resources. It is
-      // still ours because this call just created it, so remove it directly.
-      await this.removeForward(port);
+      // still ours only while it retains this session's destination.
+      await this.removeForwardIfMatching(adb, port, session.socketName);
       return null;
     }
     this.forwardedPort = port;
@@ -977,7 +984,9 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     if (session) {
       await this.cleanupOwnedSession(session, port, deviceProcessId);
     } else if (port !== null) {
-      await this.removeForward(port);
+      logger.warn(
+        `[PersistentEncoderH264Source] refusing forward cleanup port=${port}: session identity is unavailable`
+      );
     }
   }
 
@@ -1033,19 +1042,9 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
   ): Promise<void> {
     const adb = this.adbFactory.create(this.options.device);
     const lease = await this.readLease(adb, session.token);
-    if (
-      lease &&
-      lease.token === session.token &&
-      lease.socketName === session.socketName &&
-      lease.ownerPid === session.ownerPid &&
-      lease.deviceSerial === session.deviceSerial &&
-      // A cancellation can arrive after the server persisted its lease but
-      // before VIDEO_SESSION_READY handed its PID back to the host. The
-      // lease identity plus terminateProcessIfMatching's argv check still
-      // make that owned cleanup safe.
-      (expectedProcessId === null || lease.pid === expectedProcessId)
-    ) {
+    if (lease && this.isOwnedSessionLease(lease, session, expectedProcessId)) {
       await this.removeForwardIfMatching(adb, lease.forwardPort, lease.socketName);
+      await this.removeOwnedForward(adb, port, session.socketName, lease.forwardPort);
       await this.terminateProcessIfMatching(adb, lease);
       await this.removeLeaseIfMatching(adb, lease);
       return;
@@ -1054,14 +1053,35 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
       logger.warn(
         `[PersistentEncoderH264Source] refusing owned-session process cleanup token=${session.token}: lease identity or PID mismatch`
       );
-      await this.removeForwardIfMatching(adb, lease.forwardPort, session.socketName);
-      if (port !== null && port !== lease.forwardPort) {
-        await this.removeForward(port);
-      }
+      await this.removeOwnedForward(adb, port, session.socketName);
       return;
     }
-    if (port !== null) {
-      await this.removeForward(port);
+    await this.removeOwnedForward(adb, port, session.socketName);
+  }
+
+  private isOwnedSessionLease(
+    lease: VideoServerLease,
+    session: VideoServerSession,
+    expectedProcessId: number | null
+  ): boolean {
+    // A cancellation can arrive after the server persisted its lease but before
+    // VIDEO_SESSION_READY handed its PID back to the host. The lease identity
+    // plus terminateProcessIfMatching's argv check still make owned cleanup safe.
+    return lease.token === session.token &&
+      lease.socketName === session.socketName &&
+      lease.ownerPid === session.ownerPid &&
+      lease.deviceSerial === session.deviceSerial &&
+      (expectedProcessId === null || lease.pid === expectedProcessId);
+  }
+
+  private async removeOwnedForward(
+    adb: ReturnType<AdbClientFactory["create"]>,
+    port: number | null,
+    socketName: string,
+    exceptPort?: number
+  ): Promise<void> {
+    if (port !== null && port !== exceptPort) {
+      await this.removeForwardIfMatching(adb, port, socketName);
     }
   }
 
@@ -1147,15 +1167,6 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
       await adb.executeCommand(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/${lease.token}.json`);
     } catch (error) {
       logger.debug(`[PersistentEncoderH264Source] stale-session lease cleanup failed: ${error}`);
-    }
-  }
-
-  private async removeForward(port: number): Promise<void> {
-    try {
-      const adb = this.adbFactory.create(this.options.device);
-      await adb.executeCommand(`forward --remove tcp:${port}`);
-    } catch (error) {
-      logger.debug(`[PersistentEncoderH264Source] forward --remove failed: ${error}`);
     }
   }
 

--- a/src/features/webrtc/PersistentEncoderH264Source.ts
+++ b/src/features/webrtc/PersistentEncoderH264Source.ts
@@ -352,6 +352,12 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     if (!Number.isInteger(port) || port <= 0) {
       throw new ActionableError(`adb forward returned an invalid port: "${forward.stdout.trim()}"`);
     }
+    if (!this.running) {
+      // This forward completed after stop() snapshotted its resources. It is
+      // still ours because this call just created it, so remove it directly.
+      await this.removeForward(port);
+      return null;
+    }
     this.forwardedPort = port;
     return port;
   }
@@ -947,7 +953,9 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
         continue;
       }
       const ageMs = deviceElapsedRealtimeMs - heartbeatElapsedRealtimeMs;
-      if (ageMs < STALE_LEASE_MS) {
+      // elapsedRealtime resets when Android reboots. A negative age therefore
+      // proves this persisted lease belongs to a previous boot.
+      if (ageMs >= 0 && ageMs < STALE_LEASE_MS) {
         continue;
       }
       logger.info(
@@ -972,7 +980,11 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
       lease.socketName === session.socketName &&
       lease.ownerPid === session.ownerPid &&
       lease.deviceSerial === session.deviceSerial &&
-      lease.pid === expectedProcessId
+      // A cancellation can arrive after the server persisted its lease but
+      // before VIDEO_SESSION_READY handed its PID back to the host. The
+      // lease identity plus terminateProcessIfMatching's argv check still
+      // make that owned cleanup safe.
+      (expectedProcessId === null || lease.pid === expectedProcessId)
     ) {
       await this.removeForwardIfMatching(adb, lease.forwardPort, lease.socketName);
       await this.terminateProcessIfMatching(adb, lease);

--- a/src/features/webrtc/PersistentEncoderH264Source.ts
+++ b/src/features/webrtc/PersistentEncoderH264Source.ts
@@ -234,6 +234,7 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
   private serverOutputObserver: ((chunk: Buffer) => void) | null = null;
   private serverOutputBuffer = "";
   private sawStreamingStarted = false;
+  private serverStartupInProgress: AdbProcess | null = null;
 
   constructor(options: PersistentEncoderH264SourceOptions) {
     this.options = options;
@@ -306,20 +307,22 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
    * without waiting for the periodic two-second I-frame interval. The publisher
    * throttles calls.
    */
-  requestKeyFrame(): void {
+  requestKeyFrame(): boolean {
     const socket = this.socket;
     if (!this.running || !socket) {
-      return;
+      return false;
     }
     this.telemetryInitialized = true;
     this.idrRequestCount++;
     this.pendingIdrRequests++;
     try {
       socket.write(Buffer.from([VIDEO_SERVER_COMMAND_REQUEST_KEY_FRAME]));
+      return true;
     } catch (error) {
       this.pendingIdrRequests--;
       // Best-effort: a dropped socket surfaces via its own error/close handler.
       logger.debug(`[PersistentEncoderH264Source] keyframe request write failed: ${error}`);
+      return false;
     }
   }
 
@@ -380,10 +383,12 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     });
 
     this.deviceProcessId = await this.waitForReady(server);
+    this.watchServer(server);
     return this.running ? server : null;
   }
 
   private async connectToServer(server: AdbProcess, port: number): Promise<void> {
+    this.serverStartupInProgress = server;
     const streamingStarted = this.options.audioEnabled
       ? this.waitForStreamingStarted(server)
       : null;
@@ -391,47 +396,72 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     // the marker in the gap between client connect and the later startup await.
     streamingStarted?.catch(() => {});
 
-    const socket = await this.connector(port);
-    if (!this.running) {
-      socket.destroy();
-      return;
-    }
-    this.socket = socket;
-    const startupAudioReady = this.options.audioEnabled
-      ? this.waitForStartupAudioReady()
-      : null;
-    let socketFailureMode: "startup" | "post-start" = this.options.audioEnabled
-      ? "startup"
-      : "post-start";
-    let rejectStartupSocketFailure: ((error: Error) => void) | undefined;
-    const startupSocketFailure = this.options.audioEnabled
-      ? new Promise<never>((_, reject) => {
-        rejectStartupSocketFailure = reject;
-      })
-      : null;
-    this.wireSocket(socket, error => {
-      if (socketFailureMode === "startup") {
-        rejectStartupSocketFailure?.(error);
-        return;
-      }
-      this.reconnectSocket(socket, error);
-    }, header => this.resolveStartupAudioHeader?.(header));
-
-    // For audio-enabled streams, REMOTE_SUBMIX initialization happens after the
-    // socket client connects. Do not resolve start() until that succeeds, or an
-    // unavailable audio source would look like a successful start followed by a
-    // reconnect-looping post-start failure.
-    if (this.options.audioEnabled) {
-      await Promise.race([
-        Promise.all([streamingStarted, startupAudioReady]),
-        startupSocketFailure,
-      ]);
+    const connection = this.connector(port);
+    let connectionWon = false;
+    let rejectServerFailure!: (error: Error) => void;
+    const serverFailure = new Promise<never>((_, reject) => {
+      rejectServerFailure = reject;
+    });
+    const onServerExit = (code: number | null, signal: NodeJS.Signals | null): void => {
+      rejectServerFailure(new Error(`video-server exited (code=${code}, signal=${signal})`));
+    };
+    const onServerError = (error: Error): void => {
+      rejectServerFailure(error);
+    };
+    server.once("exit", onServerExit);
+    server.once("error", onServerError);
+    try {
+      const socket = await Promise.race([connection, serverFailure]);
+      connectionWon = true;
       if (!this.running) {
+        socket.destroy();
         return;
       }
+      this.socket = socket;
+      const startupAudioReady = this.options.audioEnabled
+        ? this.waitForStartupAudioReady()
+        : null;
+      let socketFailureMode: "startup" | "post-start" = this.options.audioEnabled
+        ? "startup"
+        : "post-start";
+      let rejectStartupSocketFailure: ((error: Error) => void) | undefined;
+      const startupSocketFailure = this.options.audioEnabled
+        ? new Promise<never>((_, reject) => {
+          rejectStartupSocketFailure = reject;
+        })
+        : null;
+      this.wireSocket(socket, error => {
+        if (socketFailureMode === "startup") {
+          rejectStartupSocketFailure?.(error);
+          return;
+        }
+        this.reconnectSocket(socket, error);
+      }, header => this.resolveStartupAudioHeader?.(header));
+
+      // For audio-enabled streams, REMOTE_SUBMIX initialization happens after the
+      // socket client connects. Do not resolve start() until that succeeds, or an
+      // unavailable audio source would look like a successful start followed by a
+      // reconnect-looping post-start failure.
+      if (this.options.audioEnabled) {
+        await Promise.race([
+          Promise.all([streamingStarted, startupAudioReady]),
+          startupSocketFailure,
+        ]);
+        if (!this.running) {
+          return;
+        }
+      }
+      socketFailureMode = "post-start";
+    } finally {
+      server.removeListener("exit", onServerExit);
+      server.removeListener("error", onServerError);
+      if (!connectionWon) {
+        void connection.then(socket => socket.destroy(), () => {});
+      }
+      if (this.serverStartupInProgress === server) {
+        this.serverStartupInProgress = null;
+      }
     }
-    socketFailureMode = "post-start";
-    this.watchServer(server);
   }
 
   private watchServer(server: AdbProcess): void {
@@ -439,9 +469,13 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
       if (this.server !== server) {return;}
       this.detachServerOutputObserver(server);
       this.server = null;
+      if (this.serverStartupInProgress === server) {return;}
       this.failIfRunning(new Error(`video-server exited (code=${code}, signal=${signal})`));
     });
-    server.once("error", (error: Error) => this.failIfRunning(error));
+    server.once("error", (error: Error) => {
+      if (this.serverStartupInProgress === server) {return;}
+      this.failIfRunning(error);
+    });
   }
 
   private buildServerArgs(): string[] {
@@ -1001,6 +1035,9 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
         `[PersistentEncoderH264Source] refusing owned-session process cleanup token=${session.token}: lease identity or PID mismatch`
       );
       await this.removeForwardIfMatching(adb, lease.forwardPort, session.socketName);
+      if (port !== null && port !== lease.forwardPort) {
+        await this.removeForward(port);
+      }
       return;
     }
     if (port !== null) {

--- a/src/features/webrtc/PersistentEncoderH264Source.ts
+++ b/src/features/webrtc/PersistentEncoderH264Source.ts
@@ -1,7 +1,8 @@
-import { randomUUID } from "node:crypto";
 import { connect as netConnect } from "node:net";
 import { ActionableError, type BootedDevice } from "../../models";
 import { logger } from "../../utils/logger";
+import { defaultIdGenerator } from "../../utils/IdGenerator";
+import { shellQuote } from "../../utils/shellQuote";
 import { defaultTimer, type Timer } from "../../utils/SystemTimer";
 import {
   defaultAdbClientFactory,
@@ -26,8 +27,7 @@ const VIDEO_SERVER_MAIN_CLASS = "dev.jasonpearson.automobile.video.VideoServer";
 export const VIDEO_SERVER_LEASE_DIRECTORY = "/data/local/tmp/automobile-video-sessions";
 /** A device heartbeat older than this is eligible for owned stale cleanup. */
 const STALE_LEASE_MS = 30_000;
-/** Server stdout line that carries its validated app_process PID and token. */
-const SESSION_READY_MARKER = "VIDEO_SESSION_READY";
+const SESSION_READY_PATTERN = /^VIDEO_SESSION_READY token=([^ ]+) pid=(\d+) socket=([^ ]+)$/;
 /** Server stdout line printed after capture has fully started. */
 const STREAMING_STARTED_MARKER = "Streaming started";
 
@@ -248,7 +248,7 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     if (this.localSocketReconnectWindowMs <= 0 || this.localSocketReconnectRetryMs <= 0) {
       throw new ActionableError("Local socket reconnect timings must be positive milliseconds.");
     }
-    this.sessionTokenFactory = options.sessionTokenFactory ?? randomUUID;
+    this.sessionTokenFactory = options.sessionTokenFactory ?? (() => defaultIdGenerator.next());
   }
 
   get isRunning(): boolean {
@@ -527,8 +527,10 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
           return;
         }
         stdoutBuffer += chunk.toString();
-        for (const line of stdoutBuffer.split(/\r?\n/)) {
-          const match = new RegExp(`^${SESSION_READY_MARKER} token=([^ ]+) pid=(\\d+) socket=([^ ]+)$`).exec(line);
+        const lines = stdoutBuffer.split(/\r?\n/);
+        stdoutBuffer = lines.pop() ?? "";
+        for (const line of lines) {
+          const match = SESSION_READY_PATTERN.exec(line);
           if (!match) {
             continue;
           }
@@ -928,7 +930,10 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
   private async reconcileExpiredLeases(adb: ReturnType<AdbClientFactory["create"]>): Promise<void> {
     let leases: VideoServerLease[];
     try {
-      const result = await adb.executeCommand(`shell cat ${VIDEO_SERVER_LEASE_DIRECTORY}/*.json`);
+      const leaseListCommand =
+        `for f in ${VIDEO_SERVER_LEASE_DIRECTORY}/*.json; do ` +
+        '[ -f "$f" ] || continue; cat "$f"; printf "\\n"; done';
+      const result = await adb.executeCommand(`shell sh -c ${shellQuote(leaseListCommand)}`);
       leases = parseLeases(result.stdout);
     } catch (error) {
       logger.debug(`[PersistentEncoderH264Source] unable to read video session leases: ${error}`);

--- a/src/features/webrtc/PersistentEncoderH264Source.ts
+++ b/src/features/webrtc/PersistentEncoderH264Source.ts
@@ -235,6 +235,7 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
   private serverOutputBuffer = "";
   private sawStreamingStarted = false;
   private serverStartupInProgress: AdbProcess | null = null;
+  private serverStartupFailure: { server: AdbProcess; error: Error } | null = null;
 
   constructor(options: PersistentEncoderH264SourceOptions) {
     this.options = options;
@@ -280,6 +281,8 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
       throw new ActionableError("Persistent encoder H.264 source already started.");
     }
     this.running = true;
+    this.serverStartupInProgress = null;
+    this.serverStartupFailure = null;
     try {
       await this.launch();
     } catch (error) {
@@ -383,12 +386,13 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     });
 
     this.deviceProcessId = await this.waitForReady(server);
+    this.serverStartupInProgress = server;
     this.watchServer(server);
     return this.running ? server : null;
   }
 
   private async connectToServer(server: AdbProcess, port: number): Promise<void> {
-    this.serverStartupInProgress = server;
+    this.throwIfServerStartupFailed(server);
     const streamingStarted = this.options.audioEnabled
       ? this.waitForStreamingStarted(server)
       : null;
@@ -464,16 +468,32 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     }
   }
 
+  private throwIfServerStartupFailed(server: AdbProcess): void {
+    const failure = this.serverStartupFailure;
+    if (failure?.server === server) {
+      throw failure.error;
+    }
+  }
+
   private watchServer(server: AdbProcess): void {
     server.once("exit", (code, signal) => {
       if (this.server !== server) {return;}
       this.detachServerOutputObserver(server);
       this.server = null;
-      if (this.serverStartupInProgress === server) {return;}
+      if (this.serverStartupInProgress === server) {
+        this.serverStartupFailure = {
+          server,
+          error: new Error(`video-server exited (code=${code}, signal=${signal})`),
+        };
+        return;
+      }
       this.failIfRunning(new Error(`video-server exited (code=${code}, signal=${signal})`));
     });
     server.once("error", (error: Error) => {
-      if (this.serverStartupInProgress === server) {return;}
+      if (this.serverStartupInProgress === server) {
+        this.serverStartupFailure = { server, error };
+        return;
+      }
       this.failIfRunning(error);
     });
   }

--- a/src/features/webrtc/WebRtcPublisher.ts
+++ b/src/features/webrtc/WebRtcPublisher.ts
@@ -370,6 +370,10 @@ export class WebRtcPublisher {
     this.noteKeyFrameRequest();
     try {
       this.onKeyFrameRequest();
+      // An accepted PLI can restart the iOS encoder. Do not let a watchdog
+      // deadline that was already nearly expired tear down that recovery before
+      // its replacement has a chance to emit the requested IDR.
+      this.resetFrameWatchdogDeadline(pc);
     } catch (error) {
       logger.debug(`[WebRTC] keyframe request failed for ${this.config.streamId}: ${error}`);
     }
@@ -622,6 +626,20 @@ export class WebRtcPublisher {
     this.frameWatchdogLastAdvanceMs = this.timer.now();
     const intervalMs = Math.max(500, Math.min(timeout, 2000));
     this.frameWatchdogHandle = this.timer.setInterval(() => this.checkFrameProgress(pc, timeout), intervalMs);
+  }
+
+  /** Give an accepted keyframe recovery one bounded frame-stall interval to produce its IDR. */
+  private resetFrameWatchdogDeadline(pc: RTCPeerConnection): void {
+    if (
+      !this.frameWatchdogHandle ||
+      this.closed ||
+      this.pc !== pc ||
+      pc.connectionState !== "connected"
+    ) {
+      return;
+    }
+    this.frameWatchdogLastFrames = this.writer?.stats.framesWritten ?? 0;
+    this.frameWatchdogLastAdvanceMs = this.timer.now();
   }
 
   private checkFrameProgress(pc: RTCPeerConnection, timeoutMs: number): void {

--- a/src/features/webrtc/WebRtcPublisher.ts
+++ b/src/features/webrtc/WebRtcPublisher.ts
@@ -367,13 +367,13 @@ export class WebRtcPublisher {
     }
     this.lastKeyFrameRequestMs = now;
     logger.debug(`[WebRTC] stream ${this.config.streamId} received PLI; requesting keyframe`);
-    this.noteKeyFrameRequest();
     try {
       const recoveryStarted = this.onKeyFrameRequest();
       // An accepted PLI can restart the iOS encoder. Do not let a watchdog
       // deadline that was already nearly expired tear down that recovery before
       // its replacement has a chance to emit the requested IDR.
       if (recoveryStarted) {
+        this.noteKeyFrameRequest();
         this.resetFrameWatchdogDeadline(pc);
       }
     } catch (error) {

--- a/src/features/webrtc/WebRtcPublisher.ts
+++ b/src/features/webrtc/WebRtcPublisher.ts
@@ -92,7 +92,7 @@ export interface WebRtcPublisherDeps {
    * encoder emits a fresh IDR, letting a late or recovering viewer decode
    * without waiting for the periodic IDR interval. Throttled by the publisher.
    */
-  onKeyFrameRequest?: () => void;
+  onKeyFrameRequest?: () => boolean;
   /**
    * Called when packetization rejects source media after H.264 capability
    * validation. The manager must expose the failure and recreate capture for
@@ -210,7 +210,7 @@ export class WebRtcPublisher {
   private readonly timer: Timer;
   private readonly onBeforeEstablish?: () => Promise<void> | void;
   private readonly onConnected?: () => Promise<void> | void;
-  private readonly onKeyFrameRequest?: () => void;
+  private readonly onKeyFrameRequest?: () => boolean;
   private readonly onSourceFailure?: (error: Error) => void;
   private readonly onLifecycleEvent?: (event: WebRtcPublisherLifecycleEvent) => void;
   private readonly controller: ReconnectController;
@@ -369,11 +369,13 @@ export class WebRtcPublisher {
     logger.debug(`[WebRTC] stream ${this.config.streamId} received PLI; requesting keyframe`);
     this.noteKeyFrameRequest();
     try {
-      this.onKeyFrameRequest();
+      const recoveryStarted = this.onKeyFrameRequest();
       // An accepted PLI can restart the iOS encoder. Do not let a watchdog
       // deadline that was already nearly expired tear down that recovery before
       // its replacement has a chance to emit the requested IDR.
-      this.resetFrameWatchdogDeadline(pc);
+      if (recoveryStarted) {
+        this.resetFrameWatchdogDeadline(pc);
+      }
     } catch (error) {
       logger.debug(`[WebRTC] keyframe request failed for ${this.config.streamId}: ${error}`);
     }

--- a/src/features/webrtc/androidH264CaptureSourceFactory.ts
+++ b/src/features/webrtc/androidH264CaptureSourceFactory.ts
@@ -63,8 +63,8 @@ class FallbackH264CaptureSource implements H264CaptureSource {
     await active?.stop();
   }
 
-  requestKeyFrame(): void {
-    this.active?.requestKeyFrame?.();
+  requestKeyFrame(): boolean {
+    return this.active?.requestKeyFrame?.() ?? false;
   }
 
   get getTelemetry(): H264CaptureSource["getTelemetry"] {

--- a/src/features/webrtc/h264.ts
+++ b/src/features/webrtc/h264.ts
@@ -96,6 +96,21 @@ export class H264AnnexBParser {
     return this.drain(true);
   }
 
+  /**
+   * Whether the incomplete trailing NAL has the requested type. This inspects
+   * only a complete start code plus its header and leaves the NAL buffered for
+   * normal boundary-aware delivery.
+   */
+  hasBufferedNalType(type: number): boolean {
+    const startCodes = this.findStartCodes(this.buffered);
+    const last = startCodes.at(-1);
+    if (!last) {
+      return false;
+    }
+    const headerOffset = last.offset + last.length;
+    return headerOffset < this.buffered.length && nalUnitType(this.buffered.subarray(headerOffset)) === type;
+  }
+
   private drain(final: boolean): Buffer[] {
     const nals: Buffer[] = [];
     const startCodes = this.findStartCodes(this.buffered);

--- a/src/server/webrtcStreamManager.ts
+++ b/src/server/webrtcStreamManager.ts
@@ -344,7 +344,7 @@ function createStreamRecord(
           });
         }
       },
-      onKeyFrameRequest: () => streams.get(streamId)?.source?.requestKeyFrame?.(),
+      onKeyFrameRequest: () => streams.get(streamId)?.source?.requestKeyFrame?.() ?? false,
       onConnected: () => {
         const record = streams.get(streamId);
         if (record && record.publisher === publisherRef.current && !record.sourceFailed) {

--- a/test/features/webrtc/AndroidH264Source.test.ts
+++ b/test/features/webrtc/AndroidH264Source.test.ts
@@ -140,12 +140,12 @@ describe("AndroidH264Source", () => {
     expect(processes).toHaveLength(1);
 
     // screenrecord cannot be signalled for an IDR mid-stream; a request rotates.
-    source.requestKeyFrame();
+    expect(source.requestKeyFrame()).toBe(true);
     expect(processes[0].killed).toContain("SIGINT");
     const killsAfterFirst = processes[0].killed.length;
 
     // A second request within the throttle window is coalesced away.
-    source.requestKeyFrame();
+    expect(source.requestKeyFrame()).toBe(false);
     expect(processes[0].killed).toHaveLength(killsAfterFirst);
 
     // Complete the rotation so a fresh segment is running.
@@ -156,7 +156,7 @@ describe("AndroidH264Source", () => {
 
     // After the throttle interval, a request rotates the new segment.
     timer.advanceTime(ANDROID_FORCED_KEYFRAME_MIN_INTERVAL_MS);
-    source.requestKeyFrame();
+    expect(source.requestKeyFrame()).toBe(true);
     expect(processes[processes.length - 1].killed).toContain("SIGINT");
 
     await source.stop();

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -1407,8 +1407,9 @@ describe("IosH264Source", () => {
       Buffer.from([
         0, 0, 0, 1, 0x67, 0x42, 0xe0, 0x2a,
         0, 0, 0, 1, 0x68, 0xce, 0x3c, 0x80,
+        // The output stream can pause immediately after the IDR, leaving it
+        // un-terminated until a later frame arrives.
         0, 0, 0, 1, 0x65, 0x80,
-        0, 0, 0, 1, 0x41, 0x80,
       ])
     );
     await flush();

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -126,6 +126,13 @@ function flush(): Promise<void> {
   return new Promise(resolve => setImmediate(resolve));
 }
 
+function emitIdr(encoder: FakeChildProcess): void {
+  encoder.stdout.push(Buffer.from([
+    0, 0, 0, 1, 0x65, 0x80,
+    0, 0, 0, 1, 0x41, 0x80,
+  ]));
+}
+
 async function startWithFrame(
   source: IosH264Source,
   helper: FakeFrameCaptureHelper,
@@ -1241,6 +1248,8 @@ describe("IosH264Source", () => {
 
     await startWithFrame(source, helper, frame(1, 1, 0x11));
     helper.emitFrame(frame(1, 1, 0x22));
+    emitIdr(encoders[0]);
+    await flush();
 
     source.requestKeyFrame();
     helper.emitFrame(frame(1, 1, 0x33));
@@ -1334,6 +1343,8 @@ describe("IosH264Source", () => {
     await startWithFrame(source, helper, firstFrame);
     expect(encoderSpawns).toHaveLength(1);
     firstFrame.pixels.fill(0xff);
+    emitIdr(encoders[0]);
+    await flush();
 
     // ffmpeg cannot be signalled for an IDR mid-stream over a pipe; a request
     // restarts the encoder. Replay the most recent frame so static capture can
@@ -1368,6 +1379,8 @@ describe("IosH264Source", () => {
 
     await startWithFrame(source, helper, frame(2, 2, 0x11));
     expect(encoderSpawns).toHaveLength(1);
+    emitIdr(encoders[0]);
+    await flush();
 
     // A burst of relayed viewer PLIs collapses to a single restart.
     expect(source.requestKeyFrame()).toBe(true);
@@ -1400,6 +1413,22 @@ describe("IosH264Source", () => {
     // can start another recovery attempt.
     expect(source.requestKeyFrame()).toBe(true);
     expect(encoderSpawns).toHaveLength(3);
+  });
+
+  test("does not replace an encoder while its initial IDR is still pending", async () => {
+    const { source, helper, encoders, encoderSpawns } = createRestartHarness();
+
+    await startWithFrame(source, helper, frame(2, 2, 0x11));
+
+    // VideoToolbox begins every encoder with an IDR. Replacing the initial
+    // encoder before it emits that frame turns an early PLI into restart churn.
+    expect(source.requestKeyFrame()).toBe(false);
+    expect(encoderSpawns).toHaveLength(1);
+
+    emitIdr(encoders[0]);
+    await flush();
+    expect(source.requestKeyFrame()).toBe(true);
+    expect(encoderSpawns).toHaveLength(2);
   });
 
   test("requestKeyFrame is a no-op before the first frame and after stop", async () => {

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -1260,7 +1260,11 @@ describe("IosH264Source", () => {
     inputs[1].emit("drain");
 
     expect(encoders).toHaveLength(2);
-    expect(inputs[1].writes).toEqual([Buffer.alloc(4, 0x11), Buffer.alloc(4, 0x33)]);
+    expect(inputs[1].writes).toEqual([
+      Buffer.alloc(4, 0x11),
+      Buffer.alloc(4, 0x11),
+      Buffer.alloc(4, 0x33),
+    ]);
     expect(source.getFrameMetrics().encoder.droppedFrames).toBe(1);
   });
 
@@ -1340,7 +1344,7 @@ describe("IosH264Source", () => {
     expect(errors).toEqual([]);
   });
 
-  test("requestKeyFrame replays a defensive copy of the latest frame into the replacement encoder", async () => {
+  test("requestKeyFrame preloads a replacement encoder with two defensive copies of the latest frame", async () => {
     const { source, helper, encoders, encoderSpawns, chunks, errors } = createRestartHarness();
 
     const firstFrame = frame(2, 2, 0x11);
@@ -1351,9 +1355,9 @@ describe("IosH264Source", () => {
     await flush();
 
     // ffmpeg cannot be signalled for an IDR mid-stream over a pipe; a request
-    // restarts the encoder. Replay the most recent frame so static capture can
-    // produce the replacement encoder's first SPS/PPS + IDR without waiting for
-    // the screen to change.
+    // restarts the encoder. Replay two copies of the most recent frame so static
+    // capture produces the replacement encoder's first SPS/PPS + IDR and the
+    // following access-unit boundary without waiting for the screen to change.
     expect(source.requestKeyFrame()).toBe(true);
 
     // A second encoder is spawned with identical argv, and the old one is ended
@@ -1361,13 +1365,13 @@ describe("IosH264Source", () => {
     expect(encoderSpawns).toHaveLength(2);
     expect(encoderSpawns[1].args).toEqual(encoderSpawns[0].args);
     expect(encoders[0].killed).toBe(true);
-    expect(encoders[1].getStdinData()).toEqual(Buffer.alloc(16, 0x11));
+    expect(encoders[1].getStdinData()).toEqual(Buffer.alloc(32, 0x11));
 
     // Later helper frames continue flowing into the replacement encoder, whose
     // output is forwarded to the same onData sink.
     helper.emitFrame(frame(2, 2, 0x22));
     expect(encoders[1].getStdinData()).toEqual(
-      Buffer.concat([Buffer.alloc(16, 0x11), Buffer.alloc(16, 0x22)])
+      Buffer.concat([Buffer.alloc(32, 0x11), Buffer.alloc(16, 0x22)])
     );
     encoders[1].stdout.push(Buffer.from([0, 0, 0, 1, 0x65]));
     await flush();

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -133,6 +133,10 @@ function emitIdr(encoder: FakeChildProcess): void {
   ]));
 }
 
+function emitTerminalIdr(encoder: FakeChildProcess): void {
+  encoder.stdout.push(Buffer.from([0, 0, 0, 1, 0x65, 0x80]));
+}
+
 async function startWithFrame(
   source: IosH264Source,
   helper: FakeFrameCaptureHelper,
@@ -1425,7 +1429,7 @@ describe("IosH264Source", () => {
     expect(source.requestKeyFrame()).toBe(false);
     expect(encoderSpawns).toHaveLength(1);
 
-    emitIdr(encoders[0]);
+    emitTerminalIdr(encoders[0]);
     await flush();
     expect(source.requestKeyFrame()).toBe(true);
     expect(encoderSpawns).toHaveLength(2);

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -1228,7 +1228,7 @@ describe("IosH264Source", () => {
     ]);
   });
 
-  test("discards a retired encoder's queued frame when restarting for a keyframe", async () => {
+  test("discards a retired encoder's queued frame while replaying the last accepted frame", async () => {
     const inputs: BackpressuredWritable[] = [];
     const { source, helper, encoders } = createRestartHarness(
       {},
@@ -1247,7 +1247,7 @@ describe("IosH264Source", () => {
     inputs[1].emit("drain");
 
     expect(encoders).toHaveLength(2);
-    expect(inputs[1].writes).toEqual([Buffer.alloc(4, 0x33)]);
+    expect(inputs[1].writes).toEqual([Buffer.alloc(4, 0x11), Buffer.alloc(4, 0x33)]);
     expect(source.getFrameMetrics().encoder.droppedFrames).toBe(1);
   });
 
@@ -1327,14 +1327,18 @@ describe("IosH264Source", () => {
     expect(errors).toEqual([]);
   });
 
-  test("requestKeyFrame restarts the ffmpeg encoder to emit a fresh IDR, keeping output flowing", async () => {
+  test("requestKeyFrame replays a defensive copy of the latest frame into the replacement encoder", async () => {
     const { source, helper, encoders, encoderSpawns, chunks, errors } = createRestartHarness();
 
-    await startWithFrame(source, helper, frame(2, 2, 0x11));
+    const firstFrame = frame(2, 2, 0x11);
+    await startWithFrame(source, helper, firstFrame);
     expect(encoderSpawns).toHaveLength(1);
+    firstFrame.pixels.fill(0xff);
 
     // ffmpeg cannot be signalled for an IDR mid-stream over a pipe; a request
-    // restarts the encoder, whose first encoded frame is an SPS/PPS + IDR.
+    // restarts the encoder. Replay the most recent frame so static capture can
+    // produce the replacement encoder's first SPS/PPS + IDR without waiting for
+    // the screen to change.
     source.requestKeyFrame();
 
     // A second encoder is spawned with identical argv, and the old one is ended
@@ -1342,11 +1346,14 @@ describe("IosH264Source", () => {
     expect(encoderSpawns).toHaveLength(2);
     expect(encoderSpawns[1].args).toEqual(encoderSpawns[0].args);
     expect(encoders[0].killed).toBe(true);
+    expect(encoders[1].getStdinData()).toEqual(Buffer.alloc(16, 0x11));
 
-    // The next delivered frame flows into the new encoder, and its output (the
-    // fresh IDR) is forwarded to the same onData sink.
+    // Later helper frames continue flowing into the replacement encoder, whose
+    // output is forwarded to the same onData sink.
     helper.emitFrame(frame(2, 2, 0x22));
-    expect(encoders[1].getStdinData()).toEqual(Buffer.alloc(16, 0x22));
+    expect(encoders[1].getStdinData()).toEqual(
+      Buffer.concat([Buffer.alloc(16, 0x11), Buffer.alloc(16, 0x22)])
+    );
     encoders[1].stdout.push(Buffer.from([0, 0, 0, 1, 0x65]));
     await flush();
 

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -1339,7 +1339,7 @@ describe("IosH264Source", () => {
     // restarts the encoder. Replay the most recent frame so static capture can
     // produce the replacement encoder's first SPS/PPS + IDR without waiting for
     // the screen to change.
-    source.requestKeyFrame();
+    expect(source.requestKeyFrame()).toBe(true);
 
     // A second encoder is spawned with identical argv, and the old one is ended
     // and killed rather than treated as a fatal crash.
@@ -1370,20 +1370,20 @@ describe("IosH264Source", () => {
     expect(encoderSpawns).toHaveLength(1);
 
     // A burst of relayed viewer PLIs collapses to a single restart.
-    source.requestKeyFrame();
-    source.requestKeyFrame();
-    source.requestKeyFrame();
+    expect(source.requestKeyFrame()).toBe(true);
+    expect(source.requestKeyFrame()).toBe(false);
+    expect(source.requestKeyFrame()).toBe(false);
     expect(encoderSpawns).toHaveLength(2);
 
     // Within the throttle window, another request is coalesced away.
     timer.advanceTime(IOS_FORCED_KEYFRAME_MIN_INTERVAL_MS - 1);
-    source.requestKeyFrame();
+    expect(source.requestKeyFrame()).toBe(false);
     expect(encoderSpawns).toHaveLength(2);
 
     // A replacement can take longer than the interval to initialize. Do not
     // replace it before its SPS/PPS + IDR confirms the prior request completed.
     timer.advanceTime(1);
-    source.requestKeyFrame();
+    expect(source.requestKeyFrame()).toBe(false);
     expect(encoderSpawns).toHaveLength(2);
 
     encoders[1].stdout.push(
@@ -1398,7 +1398,7 @@ describe("IosH264Source", () => {
 
     // Once the replacement emits its IDR, the next request after the interval
     // can start another recovery attempt.
-    source.requestKeyFrame();
+    expect(source.requestKeyFrame()).toBe(true);
     expect(encoderSpawns).toHaveLength(3);
   });
 
@@ -1407,7 +1407,7 @@ describe("IosH264Source", () => {
 
     // No encoder yet: the first frame is already an IDR, so there is nothing to
     // restart. Must not throw or spawn.
-    source.requestKeyFrame();
+    expect(source.requestKeyFrame()).toBe(false);
     expect(encoderSpawns).toHaveLength(0);
 
     await startWithFrame(source, helper, frame(2, 2, 0x11));
@@ -1415,7 +1415,7 @@ describe("IosH264Source", () => {
 
     await source.stop();
     // After teardown there is no live encoder to restart.
-    source.requestKeyFrame();
+    expect(source.requestKeyFrame()).toBe(false);
     expect(encoderSpawns).toHaveLength(1);
   });
 

--- a/test/features/webrtc/PersistentEncoderH264Source.test.ts
+++ b/test/features/webrtc/PersistentEncoderH264Source.test.ts
@@ -756,7 +756,20 @@ describe("PersistentEncoderH264Source", () => {
     await ctx.source.stop();
 
     expect(ctx.commands).toContain(`forward --remove tcp:${FORWARD_PORT}`);
+    expect(ctx.commands).not.toContain("forward --remove tcp:61234");
     expect(ctx.commands).not.toContain("shell kill -2 5678");
+  });
+
+  test("does not remove a replacement forward after this session's lease disappears", async () => {
+    const ctx = makeSource({
+      forwardListOutput: `${DEVICE.deviceId} tcp:${FORWARD_PORT} localabstract:someone_elses_socket\n`,
+    });
+    await startReady(ctx);
+
+    await ctx.source.stop();
+
+    expect(ctx.commands).toContain("forward --list");
+    expect(ctx.commands).not.toContain(`forward --remove tcp:${FORWARD_PORT}`);
   });
 
   test("reconciles an expired owned lease with a matching forward", async () => {

--- a/test/features/webrtc/PersistentEncoderH264Source.test.ts
+++ b/test/features/webrtc/PersistentEncoderH264Source.test.ts
@@ -123,6 +123,9 @@ function makeSource(overrides: Record<string, unknown> = {}) {
   let forwardedSocket: string | null = null;
   const leaseOutput = (overrides.leaseOutput as string | undefined) ?? "";
   const deviceUptimeMs = (overrides.deviceUptimeMs as number | undefined) ?? 100_000;
+  const forwardResult = overrides.forwardResult as
+    | Promise<{ stdout: string; stderr: string; exitCode: number }>
+    | undefined;
   const processCommandLine =
     (overrides.processCommandLine as string | undefined) ??
     `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--session-token\u0000stale-session`;
@@ -135,6 +138,9 @@ function makeSource(overrides: Record<string, unknown> = {}) {
           commands.push(command);
           if (command.startsWith("forward tcp:0")) {
             forwardedSocket = command.split("localabstract:")[1] ?? null;
+            if (forwardResult) {
+              return forwardResult;
+            }
             return { stdout: `${FORWARD_PORT}\n`, stderr: "", exitCode: 0 };
           }
           if (command === "forward --list") {
@@ -455,6 +461,27 @@ describe("PersistentEncoderH264Source", () => {
     expect(ctx.commands.some(c => c.includes("pkill"))).toBe(false);
   });
 
+  test("removes a forward created after stop races startup", async () => {
+    let resolveForward!: (result: { stdout: string; stderr: string; exitCode: number }) => void;
+    const forwardResult = new Promise<{ stdout: string; stderr: string; exitCode: number }>(
+      resolve => {
+        resolveForward = resolve;
+      }
+    );
+    const ctx = makeSource({ forwardResult });
+
+    const startPromise = ctx.source.start();
+    await tick();
+    await tick();
+    expect(ctx.commands).toContain(`forward tcp:0 localabstract:${SESSION_SOCKET}`);
+
+    const stopPromise = ctx.source.stop();
+    resolveForward({ stdout: `${FORWARD_PORT}\n`, stderr: "", exitCode: 0 });
+    await Promise.all([startPromise, stopPromise]);
+
+    expect(ctx.commands).toContain(`forward --remove tcp:${FORWARD_PORT}`);
+  });
+
   test("rejects start (for fallback) when the server never becomes ready", async () => {
     const ctx = makeSource({ readyTimeoutMs: 5000 });
     const startPromise = ctx.source.start();
@@ -466,6 +493,35 @@ describe("PersistentEncoderH264Source", () => {
     expect(ctx.errors).toEqual([]);
     expect(ctx.processes[0].killed).toContain("SIGINT");
     expect(ctx.commands).toContain(`forward --remove tcp:${FORWARD_PORT}`);
+  });
+
+  test("cleans up a matching lease when stop wins before PID handoff", async () => {
+    const lease = JSON.stringify({
+      version: 1,
+      socketName: SESSION_SOCKET,
+      sessionToken: SESSION_TOKEN,
+      pid: 1234,
+      ownerPid: process.pid,
+      deviceSerial: DEVICE.deviceId,
+      forwardPort: Number(FORWARD_PORT),
+      startedAtMs: 1_000,
+      heartbeatAtMs: 95_000,
+      heartbeatElapsedRealtimeMs: 95_000,
+    });
+    const ctx = makeSource({
+      leaseOutput: lease,
+      processCommandLine:
+        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--session-token\u0000${SESSION_TOKEN}`,
+    });
+
+    const startPromise = ctx.source.start();
+    await tick(); // startup reached the server, but it has not emitted readiness.
+    await ctx.source.stop();
+    ctx.processes[0].exit();
+    await expect(startPromise).rejects.toThrow(/exited before ready/);
+
+    expect(ctx.commands).toContain("shell kill -2 1234");
+    expect(ctx.commands).toContain(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/${SESSION_TOKEN}.json`);
   });
 
   test("rejects start when the server exits before ready", async () => {
@@ -772,6 +828,39 @@ describe("PersistentEncoderH264Source", () => {
 
     expect(ctx.commands).not.toContain("forward --remove tcp:61234");
     expect(ctx.commands).not.toContain("shell kill -2 987");
+
+    ctx.processes[0].ready();
+    await startPromise;
+    await ctx.source.stop();
+  });
+
+  test("reconciles a stale lease from before the device rebooted", async () => {
+    const staleLeaseBeforeReboot = JSON.stringify({
+      version: 1,
+      socketName: "automobile_video_stale",
+      sessionToken: "stale-session",
+      pid: 987,
+      ownerPid: 456,
+      deviceSerial: DEVICE.deviceId,
+      forwardPort: 61234,
+      startedAtMs: -40_000,
+      heartbeatAtMs: -31_000,
+      heartbeatElapsedRealtimeMs: 120_000,
+    });
+    const ctx = makeSource({
+      leaseOutput: staleLeaseBeforeReboot,
+      deviceUptimeMs: 5_000,
+      forwardListOutput: `${DEVICE.deviceId} tcp:61234 localabstract:automobile_video_stale\n`,
+      processCommandLine:
+        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--session-token\u0000stale-session`,
+    });
+
+    const startPromise = ctx.source.start();
+    await tick();
+
+    expect(ctx.commands).toContain("forward --remove tcp:61234");
+    expect(ctx.commands).toContain("shell kill -2 987");
+    expect(ctx.commands).toContain(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/stale-session.json`);
 
     ctx.processes[0].ready();
     await startPromise;

--- a/test/features/webrtc/PersistentEncoderH264Source.test.ts
+++ b/test/features/webrtc/PersistentEncoderH264Source.test.ts
@@ -257,12 +257,12 @@ describe("PersistentEncoderH264Source", () => {
     const ctx = makeSource();
     await startReady(ctx);
 
-    ctx.source.requestKeyFrame();
+    expect(ctx.source.requestKeyFrame()).toBe(true);
     expect(ctx.sockets[0].written).toEqual([Buffer.from([0x01])]);
 
     await ctx.source.stop();
     // After stop, no socket is available; the request is a safe no-op.
-    ctx.source.requestKeyFrame();
+    expect(ctx.source.requestKeyFrame()).toBe(false);
     expect(ctx.sockets[0].written).toEqual([Buffer.from([0x01])]);
   });
 
@@ -697,6 +697,53 @@ describe("PersistentEncoderH264Source", () => {
     ctx.processes[0].exit(137, "SIGKILL");
     expect(ctx.errors).toHaveLength(1);
     expect(ctx.errors[0].message).toContain("video-server exited");
+  });
+
+  test("handles a server error while socket connection is pending", async () => {
+    const lateSocket = new FakeSocket();
+    let resolveConnector: ((socket: StreamSocket) => void) | undefined;
+    const ctx = makeSource({
+      connector: () => new Promise<StreamSocket>(resolve => {
+        resolveConnector = resolve;
+      }),
+    });
+
+    const startPromise = ctx.source.start();
+    await tick();
+    ctx.processes[0].ready();
+    await tick();
+
+    expect(ctx.processes[0].listenerCount("error")).toBeGreaterThan(0);
+    expect(() => ctx.processes[0].emit("error", new Error("server failed while connecting"))).not.toThrow();
+    await expect(startPromise).rejects.toThrow("server failed while connecting");
+    expect(ctx.errors).toEqual([]);
+    expect(ctx.source.isRunning).toBe(false);
+
+    resolveConnector?.(lateSocket);
+    await tick();
+    expect(lateSocket.destroyed).toBe(true);
+  });
+
+  test("removes this source's forward when a matching-token lease has different identity", async () => {
+    const mismatchedLease = JSON.stringify({
+      version: 1,
+      socketName: "automobile_video_replacement",
+      sessionToken: SESSION_TOKEN,
+      pid: 5678,
+      ownerPid: process.pid,
+      deviceSerial: DEVICE.deviceId,
+      forwardPort: 61234,
+      startedAtMs: 95_000,
+      heartbeatAtMs: 100_000,
+      heartbeatElapsedRealtimeMs: 100_000,
+    });
+    const ctx = makeSource({ leaseOutput: mismatchedLease });
+    await startReady(ctx);
+
+    await ctx.source.stop();
+
+    expect(ctx.commands).toContain(`forward --remove tcp:${FORWARD_PORT}`);
+    expect(ctx.commands).not.toContain("shell kill -2 5678");
   });
 
   test("reconciles an expired owned lease with a matching forward", async () => {

--- a/test/features/webrtc/PersistentEncoderH264Source.test.ts
+++ b/test/features/webrtc/PersistentEncoderH264Source.test.ts
@@ -151,7 +151,7 @@ function makeSource(overrides: Record<string, unknown> = {}) {
                 : "");
             return { stdout, stderr: "", exitCode: 0 };
           }
-          if (command === `shell cat ${VIDEO_SERVER_LEASE_DIRECTORY}/*.json`) {
+          if (command.includes(`for f in ${VIDEO_SERVER_LEASE_DIRECTORY}/*.json`)) {
             return { stdout: leaseOutput, stderr: "", exitCode: 0 };
           }
           if (command.startsWith(`shell cat ${VIDEO_SERVER_LEASE_DIRECTORY}/`)) {
@@ -544,6 +544,25 @@ describe("PersistentEncoderH264Source", () => {
     expect(ctx.processes[0].killed).toContain("SIGINT");
   });
 
+  test("waits for a complete readiness line when stdout splits the socket name", async () => {
+    const ctx = makeSource();
+    const startPromise = ctx.source.start();
+    await tick();
+
+    const socketPrefix = SESSION_SOCKET.slice(0, -1);
+    ctx.processes[0].stdout.write(
+      Buffer.from(`VIDEO_SESSION_READY token=${SESSION_TOKEN} pid=1234 socket=${socketPrefix}`)
+    );
+    await tick();
+    expect(ctx.sockets).toHaveLength(0);
+
+    ctx.processes[0].stdout.write(Buffer.from(`${SESSION_SOCKET.slice(-1)}\n`));
+    await startPromise;
+    expect(ctx.source.isRunning).toBe(true);
+
+    await ctx.source.stop();
+  });
+
   test("reconnects a post-start socket close without failing the retained encoder source", async () => {
     const ctx = makeSource();
     await startReady(ctx);
@@ -706,6 +725,52 @@ describe("PersistentEncoderH264Source", () => {
     expect(ctx.commands).toContain("forward --remove tcp:61234");
     expect(ctx.commands).toContain("shell kill -2 987");
     expect(ctx.commands).toContain(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/stale-session.json`);
+
+    ctx.processes[0].ready();
+    await startPromise;
+    await ctx.source.stop();
+  });
+
+  test("reconciles a stale lease when multiple lease records are listed", async () => {
+    const staleLease = JSON.stringify({
+      version: 1,
+      socketName: "automobile_video_stale",
+      sessionToken: "stale-session",
+      pid: 987,
+      ownerPid: 456,
+      deviceSerial: DEVICE.deviceId,
+      forwardPort: 61234,
+      startedAtMs: -40_000,
+      heartbeatAtMs: -31_000,
+      heartbeatElapsedRealtimeMs: 60_000,
+    });
+    const freshLease = JSON.stringify({
+      version: 1,
+      socketName: "automobile_video_fresh",
+      sessionToken: "fresh-session",
+      pid: 988,
+      ownerPid: 456,
+      deviceSerial: DEVICE.deviceId,
+      forwardPort: 61235,
+      startedAtMs: 95_000,
+      heartbeatAtMs: 95_000,
+      heartbeatElapsedRealtimeMs: 95_000,
+    });
+    const ctx = makeSource({
+      leaseOutput: `${staleLease}\n${freshLease}\n`,
+      forwardListOutput: `${DEVICE.deviceId} tcp:61234 localabstract:automobile_video_stale\n`,
+      processCommandLine:
+        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--session-token\u0000stale-session`,
+    });
+
+    const startPromise = ctx.source.start();
+    await tick();
+
+    expect(ctx.commands.some(command => command.includes(`for f in ${VIDEO_SERVER_LEASE_DIRECTORY}/*.json`))).toBe(
+      true
+    );
+    expect(ctx.commands).toContain("shell kill -2 987");
+    expect(ctx.commands).not.toContain("shell kill -2 988");
 
     ctx.processes[0].ready();
     await startPromise;

--- a/test/features/webrtc/PersistentEncoderH264Source.test.ts
+++ b/test/features/webrtc/PersistentEncoderH264Source.test.ts
@@ -3,7 +3,8 @@ import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
 import {
   PersistentEncoderH264Source,
-  VIDEO_SERVER_SOCKET_NAME,
+  VIDEO_SERVER_LEASE_DIRECTORY,
+  VIDEO_SERVER_SOCKET_PREFIX,
   type SocketConnector,
   type StreamSocket,
 } from "../../../src/features/webrtc/PersistentEncoderH264Source";
@@ -21,6 +22,9 @@ import { FakeTimer } from "../../fakes/FakeTimer";
 
 const DEVICE: BootedDevice = { deviceId: "emulator-5554", platform: "android", name: "t" } as BootedDevice;
 const FORWARD_PORT = "45999";
+const SESSION_TOKEN = "session-0001";
+const SESSION_SOCKET = `${VIDEO_SERVER_SOCKET_PREFIX}_session0001`;
+const VIDEO_SERVER_MAIN_CLASS = "dev.jasonpearson.automobile.video.VideoServer";
 // Flush the nextTick + microtask queues so the source's async launch steps and
 // the PassThrough `data` emissions settle (no fake timer involved here).
 const tick = (): Promise<void> => new Promise(resolve => setImmediate(resolve));
@@ -33,8 +37,17 @@ class FakeProcess extends EventEmitter implements SpawnedProcess {
     this.killed.push(signal ?? "SIGTERM");
     return true;
   }
-  ready(): void {
-    this.stdout.write(Buffer.from("Waiting for client connection on localabstract:x\n"));
+  ready(token: string = SESSION_TOKEN, socketName: string = SESSION_SOCKET, pid: number = 1234): void {
+    this.stdout.write(Buffer.from(`VIDEO_SESSION_READY token=${token} pid=${pid} socket=${socketName}\n`));
+    this.stdout.write(Buffer.from(`Waiting for client connection on localabstract:${socketName}\n`));
+  }
+  readyAndStreamingStarted(): void {
+    this.stdout.write(
+      Buffer.from(
+        `VIDEO_SESSION_READY token=${SESSION_TOKEN} pid=1234 socket=${SESSION_SOCKET}\n` +
+        "Streaming started\n"
+      )
+    );
   }
   streamingStarted(): void {
     this.stdout.write(Buffer.from("Streaming started\n"));
@@ -107,6 +120,12 @@ function makeSource(overrides: Record<string, unknown> = {}) {
   const errors: Error[] = [];
   const timer = new FakeTimer();
   const audioEnabled = overrides.audioEnabled === true;
+  let forwardedSocket: string | null = null;
+  const leaseOutput = (overrides.leaseOutput as string | undefined) ?? "";
+  const deviceUptimeMs = (overrides.deviceUptimeMs as number | undefined) ?? 100_000;
+  const processCommandLine =
+    (overrides.processCommandLine as string | undefined) ??
+    `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--session-token\u0000stale-session`;
 
   const adbFactory: AdbClientFactory = {
     create() {
@@ -115,7 +134,28 @@ function makeSource(overrides: Record<string, unknown> = {}) {
         executeCommand: async (command: string) => {
           commands.push(command);
           if (command.startsWith("forward tcp:0")) {
+            forwardedSocket = command.split("localabstract:")[1] ?? null;
             return { stdout: `${FORWARD_PORT}\n`, stderr: "", exitCode: 0 };
+          }
+          if (command === "forward --list") {
+            const stdout =
+              (overrides.forwardListOutput as string | undefined) ??
+              (forwardedSocket
+                ? `${DEVICE.deviceId} tcp:${FORWARD_PORT} localabstract:${forwardedSocket}\n`
+                : "");
+            return { stdout, stderr: "", exitCode: 0 };
+          }
+          if (command === `shell cat ${VIDEO_SERVER_LEASE_DIRECTORY}/*.json`) {
+            return { stdout: leaseOutput, stderr: "", exitCode: 0 };
+          }
+          if (command.startsWith(`shell cat ${VIDEO_SERVER_LEASE_DIRECTORY}/`)) {
+            return { stdout: leaseOutput, stderr: "", exitCode: 0 };
+          }
+          if (command === "shell cat /proc/uptime") {
+            return { stdout: `${deviceUptimeMs / 1000} 0.00\n`, stderr: "", exitCode: 0 };
+          }
+          if (command.startsWith("shell cat /proc/")) {
+            return { stdout: processCommandLine, stderr: "", exitCode: 0 };
           }
           return { stdout: "", stderr: "", exitCode: 0 };
         },
@@ -145,6 +185,7 @@ function makeSource(overrides: Record<string, unknown> = {}) {
     adbFactory,
     connector,
     timer,
+    sessionTokenFactory: () => SESSION_TOKEN,
     ...overrides,
   });
 
@@ -159,6 +200,7 @@ function makeSource(overrides: Record<string, unknown> = {}) {
     errors,
     timer,
     audioEnabled,
+    sessionSocket: () => forwardedSocket,
   };
 }
 
@@ -186,7 +228,7 @@ describe("PersistentEncoderH264Source", () => {
     await startReady(ctx);
 
     expect(ctx.commands.some(c => c.startsWith("push") && c.includes("/data/local/tmp/automobile-video.jar"))).toBe(true);
-    expect(ctx.commands).toContain(`forward tcp:0 localabstract:${VIDEO_SERVER_SOCKET_NAME}`);
+    expect(ctx.commands).toContain(`forward tcp:0 localabstract:${SESSION_SOCKET}`);
 
     const args = ctx.spawnArgs[0].join(" ");
     expect(args).not.toContain("-s emulator-5554");
@@ -194,6 +236,8 @@ describe("PersistentEncoderH264Source", () => {
     expect(args).toContain("--quality low");
     expect(args).toContain("--bit-rate 1500000");
     expect(args).toContain("--size 480x1040");
+    expect(args).toContain(`--session-token ${SESSION_TOKEN}`);
+    expect(args).toContain(`--socket-name ${SESSION_SOCKET}`);
 
     // A stream header + one packet: only the packet payload reaches onData.
     ctx.sockets[0].feed(streamHeader(480, 1040));
@@ -306,6 +350,22 @@ describe("PersistentEncoderH264Source", () => {
     await ctx.source.stop();
   });
 
+  test("audio startup observes a streaming marker emitted with session readiness", async () => {
+    const ctx = makeSource({ audioEnabled: true });
+    const startPromise = ctx.source.start();
+    await tick(); // push + spawn
+    ctx.processes[0].readyAndStreamingStarted();
+    await tick(); // readiness resolves, forward + connect
+    ctx.sockets[0].feed(muxHeader());
+    ctx.sockets[0].feed(muxPacket(VIDEO_SERVER_TRACK_ID_AUDIO, Buffer.from([0x7f])));
+
+    await startPromise;
+    expect(ctx.source.isRunning).toBe(true);
+    expect(ctx.audioChunks).toEqual([Buffer.from([0x7f])]);
+
+    await ctx.source.stop();
+  });
+
   test("audio startup rejects when the server exits before the post-audio-ready marker", async () => {
     const ctx = makeSource({ audioEnabled: true });
     const startPromise = ctx.source.start();
@@ -400,11 +460,12 @@ describe("PersistentEncoderH264Source", () => {
     const startPromise = ctx.source.start();
     await tick(); // spawn
     ctx.timer.advanceTime(5000); // readiness timeout fires
-    await expect(startPromise).rejects.toThrow(/did not become ready/);
+    await expect(startPromise).rejects.toThrow(/did not become session-ready.*AUTOMOBILE_VIDEO_SERVER_JAR/);
     // A startup failure must NOT be reported via onError (that path is for
     // post-start failures / reconnect); it surfaces as the rejection.
     expect(ctx.errors).toEqual([]);
     expect(ctx.processes[0].killed).toContain("SIGINT");
+    expect(ctx.commands).toContain(`forward --remove tcp:${FORWARD_PORT}`);
   });
 
   test("rejects start when the server exits before ready", async () => {
@@ -414,6 +475,17 @@ describe("PersistentEncoderH264Source", () => {
     ctx.processes[0].exit(1, null);
     await expect(startPromise).rejects.toThrow(/exited before ready/);
     expect(ctx.errors).toEqual([]);
+  });
+
+  test("rejects a readiness line whose token does not match this session", async () => {
+    const ctx = makeSource();
+    const startPromise = ctx.source.start();
+    await tick();
+    ctx.processes[0].ready("different-session", `${VIDEO_SERVER_SOCKET_PREFIX}_differentsession`);
+
+    await expect(startPromise).rejects.toThrow(/readiness token mismatch/);
+    expect(ctx.errors).toEqual([]);
+    expect(ctx.processes[0].killed).toContain("SIGINT");
   });
 
   test("reconnects a post-start socket close without failing the retained encoder source", async () => {
@@ -550,5 +622,180 @@ describe("PersistentEncoderH264Source", () => {
     ctx.processes[0].exit(137, "SIGKILL");
     expect(ctx.errors).toHaveLength(1);
     expect(ctx.errors[0].message).toContain("video-server exited");
+  });
+
+  test("reconciles an expired owned lease with a matching forward", async () => {
+    const staleLease = JSON.stringify({
+      version: 1,
+      socketName: "automobile_video_stale",
+      sessionToken: "stale-session",
+      pid: 987,
+      ownerPid: 456,
+      deviceSerial: DEVICE.deviceId,
+      forwardPort: 61234,
+      startedAtMs: -40_000,
+      heartbeatAtMs: -31_000,
+      heartbeatElapsedRealtimeMs: 60_000,
+    });
+    const ctx = makeSource({
+      leaseOutput: staleLease,
+      forwardListOutput: `${DEVICE.deviceId} tcp:61234 localabstract:automobile_video_stale\n`,
+      processCommandLine:
+        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--session-token\u0000stale-session`,
+    });
+
+    const startPromise = ctx.source.start();
+    await tick();
+
+    expect(ctx.commands).toContain("forward --remove tcp:61234");
+    expect(ctx.commands).toContain("shell kill -2 987");
+    expect(ctx.commands).toContain(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/stale-session.json`);
+
+    ctx.processes[0].ready();
+    await startPromise;
+    await ctx.source.stop();
+  });
+
+  test("does not remove a mismatched stale-session forward", async () => {
+    const staleLease = JSON.stringify({
+      version: 1,
+      socketName: "automobile_video_stale",
+      sessionToken: "stale-session",
+      pid: 987,
+      ownerPid: 456,
+      deviceSerial: DEVICE.deviceId,
+      forwardPort: 61234,
+      startedAtMs: -40_000,
+      heartbeatAtMs: -31_000,
+      heartbeatElapsedRealtimeMs: 60_000,
+    });
+    const ctx = makeSource({
+      leaseOutput: staleLease,
+      forwardListOutput: `${DEVICE.deviceId} tcp:61234 localabstract:someone_elses_socket\n`,
+      processCommandLine:
+        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--session-token\u0000stale-session`,
+    });
+
+    const startPromise = ctx.source.start();
+    await tick();
+
+    expect(ctx.commands).not.toContain("forward --remove tcp:61234");
+    expect(ctx.commands).toContain("shell kill -2 987");
+
+    ctx.processes[0].ready();
+    await startPromise;
+    await ctx.source.stop();
+  });
+
+  test("refuses stale cleanup when the PID command line does not contain the lease token", async () => {
+    const staleLease = JSON.stringify({
+      version: 1,
+      socketName: "automobile_video_stale",
+      sessionToken: "stale-session",
+      pid: 987,
+      ownerPid: 456,
+      deviceSerial: DEVICE.deviceId,
+      forwardPort: 61234,
+      startedAtMs: -40_000,
+      heartbeatAtMs: -31_000,
+      heartbeatElapsedRealtimeMs: 60_000,
+    });
+    const ctx = makeSource({
+      leaseOutput: staleLease,
+      forwardListOutput: `${DEVICE.deviceId} tcp:61234 localabstract:automobile_video_stale\n`,
+      processCommandLine:
+        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--session-token\u0000another-session`,
+    });
+
+    const startPromise = ctx.source.start();
+    await tick();
+
+    expect(ctx.commands).toContain("forward --remove tcp:61234");
+    expect(ctx.commands).not.toContain("shell kill -2 987");
+
+    ctx.processes[0].ready();
+    await startPromise;
+    await ctx.source.stop();
+  });
+
+  test("refuses stale cleanup when the lease token is not the --session-token value", async () => {
+    const staleLease = JSON.stringify({
+      version: 1,
+      socketName: "automobile_video_stale",
+      sessionToken: "stale-session",
+      pid: 987,
+      ownerPid: 456,
+      deviceSerial: DEVICE.deviceId,
+      forwardPort: 61234,
+      startedAtMs: -40_000,
+      heartbeatAtMs: -31_000,
+      heartbeatElapsedRealtimeMs: 60_000,
+    });
+    const ctx = makeSource({
+      leaseOutput: staleLease,
+      forwardListOutput: `${DEVICE.deviceId} tcp:61234 localabstract:automobile_video_stale\n`,
+      processCommandLine:
+        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--session-token\u0000other-session\u0000--quality\u0000stale-session`,
+    });
+
+    const startPromise = ctx.source.start();
+    await tick();
+
+    expect(ctx.commands).toContain("forward --remove tcp:61234");
+    expect(ctx.commands).not.toContain("shell kill -2 987");
+
+    ctx.processes[0].ready();
+    await startPromise;
+    await ctx.source.stop();
+  });
+
+  test("uses device uptime instead of a lease wall-clock timestamp for expiry", async () => {
+    const freshLeaseWithOldWallClock = JSON.stringify({
+      version: 1,
+      socketName: "automobile_video_fresh",
+      sessionToken: "fresh-session",
+      pid: 987,
+      ownerPid: 456,
+      deviceSerial: DEVICE.deviceId,
+      forwardPort: 61234,
+      startedAtMs: -1_000_000,
+      heartbeatAtMs: -1_000_000,
+      heartbeatElapsedRealtimeMs: 95_000,
+    });
+    const ctx = makeSource({
+      leaseOutput: freshLeaseWithOldWallClock,
+      deviceUptimeMs: 100_000,
+    });
+
+    const startPromise = ctx.source.start();
+    await tick();
+
+    expect(ctx.commands).not.toContain("forward --remove tcp:61234");
+    expect(ctx.commands).not.toContain("shell kill -2 987");
+
+    ctx.processes[0].ready();
+    await startPromise;
+    await ctx.source.stop();
+  });
+
+  test("uses separate socket leases for separate device sources", async () => {
+    const first = makeSource({ sessionTokenFactory: () => "first-session" });
+    const second = makeSource({
+      sessionTokenFactory: () => "second-session",
+      device: { ...DEVICE, deviceId: "emulator-5556" },
+    });
+
+    const firstStart = first.source.start();
+    const secondStart = second.source.start();
+    await tick();
+    first.processes[0].ready("first-session", `${VIDEO_SERVER_SOCKET_PREFIX}_firstsession`);
+    second.processes[0].ready("second-session", `${VIDEO_SERVER_SOCKET_PREFIX}_secondsession`);
+    await Promise.all([firstStart, secondStart]);
+
+    expect(first.sessionSocket()).toBe(`${VIDEO_SERVER_SOCKET_PREFIX}_firstsession`);
+    expect(second.sessionSocket()).toBe(`${VIDEO_SERVER_SOCKET_PREFIX}_secondsession`);
+
+    await first.source.stop();
+    await second.source.stop();
   });
 });

--- a/test/features/webrtc/PersistentEncoderH264Source.test.ts
+++ b/test/features/webrtc/PersistentEncoderH264Source.test.ts
@@ -495,6 +495,19 @@ describe("PersistentEncoderH264Source", () => {
     expect(ctx.commands).toContain(`forward --remove tcp:${FORWARD_PORT}`);
   });
 
+  test("rejects start (for fallback) when the server exits after readiness before socket connection", async () => {
+    const ctx = makeSource();
+    const startPromise = ctx.source.start();
+    await tick(); // push + spawn
+    ctx.processes[0].ready();
+    queueMicrotask(() => ctx.processes[0].exit(1, null));
+
+    await expect(startPromise).rejects.toThrow(/video-server exited \(code=1, signal=null\)/);
+    expect(ctx.errors).toEqual([]);
+    expect(ctx.source.isRunning).toBe(false);
+    expect(ctx.commands).toContain(`forward --remove tcp:${FORWARD_PORT}`);
+  });
+
   test("cleans up a matching lease when stop wins before PID handoff", async () => {
     const lease = JSON.stringify({
       version: 1,

--- a/test/features/webrtc/WebRtcPublisher.test.ts
+++ b/test/features/webrtc/WebRtcPublisher.test.ts
@@ -627,6 +627,7 @@ describe("WebRtcPublisher frame-stall watchdog", () => {
     recoveryStarts = false;
     timer.advanceTime(KEYFRAME_REQUEST_MIN_INTERVAL_MS * 2);
     pc.pliSubscribers[0]();
+    expect(publisher.getDescriptor().readiness.idrRequestCount).toBe(1);
 
     // The first PLI resets the deadline to t=7000. The second is throttled by
     // the source and must not move it to t=9000. The watchdog checks at t=6000

--- a/test/features/webrtc/WebRtcPublisher.test.ts
+++ b/test/features/webrtc/WebRtcPublisher.test.ts
@@ -558,6 +558,44 @@ describe("WebRtcPublisher frame-stall watchdog", () => {
     await publisher.stop();
   });
 
+  test("gives an accepted PLI recovery a fresh bounded watchdog interval", async () => {
+    const timer = new FakeTimer();
+    const pc = new FakePeerConnection();
+    pc.connectionState = "connected";
+    const publisher = new WebRtcPublisher(
+      { streamId: "s", whipEndpoint: "https://coord/whip", frameStallTimeoutMs: 4000 },
+      {
+        timer,
+        onKeyFrameRequest: () => {},
+        createPeerConnection: () => pc as unknown as RTCPeerConnection,
+        createWhipClient: () =>
+          ({
+            publish: async () => ({ answerSdp: ACCEPTED_VIDEO_ANSWER, resourceUrl: "https://coord/whip/s" }),
+            delete: async () => {},
+          }) as unknown as WhipClient,
+      }
+    );
+    const internals = publisher as unknown as { notifySourceFailed: () => void };
+    let recoveries = 0;
+    internals.notifySourceFailed = () => { recoveries++; };
+
+    await publisher.start();
+    timer.advanceTime(3000);
+    pc.pliSubscribers[0]();
+
+    // The previous deadline was one second away, but this PLI starts a bounded
+    // source recovery and must not be immediately classified as a stalled source.
+    timer.advanceTime(3000);
+    expect(recoveries).toBe(0);
+
+    // The recovery remains bounded: an encoder that never emits an IDR still
+    // follows the normal stalled-source reconnect path.
+    timer.advanceTime(2000);
+    expect(recoveries).toBe(1);
+
+    await publisher.stop();
+  });
+
   test("is disabled when no timeout is configured", async () => {
     const timer = new FakeTimer();
     const publisher = connectedPublisher(undefined, timer);

--- a/test/features/webrtc/WebRtcPublisher.test.ts
+++ b/test/features/webrtc/WebRtcPublisher.test.ts
@@ -411,7 +411,10 @@ describe("WebRtcPublisher keyframe requests", () => {
             publish: async () => ({ answerSdp: ACCEPTED_VIDEO_ANSWER, resourceUrl: "https://coord/whip/s" }),
             delete: async () => {},
           }) as unknown as WhipClient,
-        onKeyFrameRequest: () => { requests++; },
+        onKeyFrameRequest: () => {
+          requests++;
+          return true;
+        },
       }
     );
     await publisher.start();
@@ -442,7 +445,7 @@ describe("WebRtcPublisher keyframe requests", () => {
             publish: async () => ({ answerSdp: ACCEPTED_VIDEO_ANSWER, resourceUrl: "https://coord/whip/s" }),
             delete: async () => {},
           }) as unknown as WhipClient,
-        onKeyFrameRequest: () => {},
+        onKeyFrameRequest: () => true,
       }
     );
     await publisher.start();
@@ -566,7 +569,7 @@ describe("WebRtcPublisher frame-stall watchdog", () => {
       { streamId: "s", whipEndpoint: "https://coord/whip", frameStallTimeoutMs: 4000 },
       {
         timer,
-        onKeyFrameRequest: () => {},
+        onKeyFrameRequest: () => true,
         createPeerConnection: () => pc as unknown as RTCPeerConnection,
         createWhipClient: () =>
           ({
@@ -590,6 +593,46 @@ describe("WebRtcPublisher frame-stall watchdog", () => {
 
     // The recovery remains bounded: an encoder that never emits an IDR still
     // follows the normal stalled-source reconnect path.
+    timer.advanceTime(2000);
+    expect(recoveries).toBe(1);
+
+    await publisher.stop();
+  });
+
+  test("does not extend the watchdog when a throttled PLI starts no recovery", async () => {
+    const timer = new FakeTimer();
+    const pc = new FakePeerConnection();
+    pc.connectionState = "connected";
+    let recoveryStarts = true;
+    const publisher = new WebRtcPublisher(
+      { streamId: "s", whipEndpoint: "https://coord/whip", frameStallTimeoutMs: 4000 },
+      {
+        timer,
+        onKeyFrameRequest: () => recoveryStarts,
+        createPeerConnection: () => pc as unknown as RTCPeerConnection,
+        createWhipClient: () =>
+          ({
+            publish: async () => ({ answerSdp: ACCEPTED_VIDEO_ANSWER, resourceUrl: "https://coord/whip/s" }),
+            delete: async () => {},
+          }) as unknown as WhipClient,
+      }
+    );
+    const internals = publisher as unknown as { notifySourceFailed: () => void };
+    let recoveries = 0;
+    internals.notifySourceFailed = () => { recoveries++; };
+
+    await publisher.start();
+    timer.advanceTime(3000);
+    pc.pliSubscribers[0]();
+    recoveryStarts = false;
+    timer.advanceTime(KEYFRAME_REQUEST_MIN_INTERVAL_MS * 2);
+    pc.pliSubscribers[0]();
+
+    // The first PLI resets the deadline to t=7000. The second is throttled by
+    // the source and must not move it to t=9000. The watchdog checks at t=6000
+    // and t=8000, so only the latter can detect the original deadline.
+    timer.advanceTime(1000);
+    expect(recoveries).toBe(0);
     timer.advanceTime(2000);
     expect(recoveries).toBe(1);
 

--- a/test/features/webrtc/androidH264CaptureSourceFactory.test.ts
+++ b/test/features/webrtc/androidH264CaptureSourceFactory.test.ts
@@ -27,8 +27,9 @@ class FakeSource implements H264CaptureSource {
 class PersistentFakeSource extends FakeSource {
   keyFrameRequests = 0;
 
-  requestKeyFrame(): void {
+  requestKeyFrame(): boolean {
     this.keyFrameRequests++;
+    return true;
   }
 
   getTelemetry() {
@@ -91,7 +92,7 @@ describe("createAndroidH264CaptureSource", () => {
     const source = createAndroidH264CaptureSource(baseOptions(), "/tmp/automobile-video.jar", deps);
 
     await source.start();
-    source.requestKeyFrame?.();
+    expect(source.requestKeyFrame?.()).toBe(true);
 
     expect(persistent.keyFrameRequests).toBe(1);
     expect(source.getTelemetry?.()).toEqual({

--- a/test/features/webrtc/h264.test.ts
+++ b/test/features/webrtc/h264.test.ts
@@ -90,6 +90,15 @@ describe("H264AnnexBParser", () => {
     expect(afterFlush[0].equals(second)).toBe(true);
   });
 
+  test("identifies a complete header for the buffered trailing NAL without flushing it", () => {
+    const parser = new H264AnnexBParser();
+    const idr = makeNal(NAL_TYPE_IDR, 4);
+
+    expect(parser.push(Buffer.concat([START_4, idr]))).toEqual([]);
+    expect(parser.hasBufferedNalType(NAL_TYPE_IDR)).toBe(true);
+    expect(parser.flush()).toEqual([idr]);
+  });
+
   test("drops an unterminated oversized NAL instead of retaining it indefinitely", () => {
     const parser = new H264AnnexBParser(8);
 

--- a/test/integration/webrtcDeviceCapture.integration.test.ts
+++ b/test/integration/webrtcDeviceCapture.integration.test.ts
@@ -11,6 +11,8 @@ import { sendWebRtcStreamRequest } from "../../src/daemon/webrtcStreamClient";
 import { SimCtlClient } from "../../src/utils/ios-cmdline-tools/SimCtlClient";
 import { WEBRTC_IOS_SIMULATOR_FPS_DEFAULT } from "../../src/features/webrtc/webrtcStreamingConfig";
 import { IOS_FORCED_KEYFRAME_MIN_INTERVAL_MS } from "../../src/features/webrtc/IosH264Source";
+import { WEBRTC_STREAM_LEASE_TTL_MS } from "../../src/server/webrtcStreamManager";
+import { defaultTimer, type Timer } from "../../src/utils/SystemTimer";
 import {
   CaptureStageTimeline,
   captureRunIdentity,
@@ -580,6 +582,56 @@ let outcome: "passed" | "failed" = "failed";
 // interval between the fixture toggles that keep the screen changing across it.
 const EGRESS_WINDOW_MS = 2_000;
 const EGRESS_TOGGLE_INTERVAL_MS = 400;
+const STREAM_LEASE_HEARTBEAT_INTERVAL_MS = WEBRTC_STREAM_LEASE_TTL_MS / 3;
+
+interface StreamLeaseHeartbeat {
+  stop(): Promise<Error | null>;
+}
+
+/**
+ * Device capture exercises startup, active streaming, and a recovery viewer for
+ * longer than one stream lease. Keep the started stream owned for the duration
+ * of the test, while still allowing the manager to reclaim abandoned streams.
+ */
+function startStreamLeaseHeartbeat(
+  streamId: string,
+  leaseId: string,
+  socketPath: string,
+  timer: Timer = defaultTimer
+): StreamLeaseHeartbeat {
+  let stopped = false;
+  let failure: Error | null = null;
+  let inFlight: Promise<void> | null = null;
+
+  const renew = (): void => {
+    if (stopped || failure || inFlight) {
+      return;
+    }
+    inFlight = sendWebRtcStreamRequest(
+      { action: "status", id: `${streamId}-lease-heartbeat`, streamId, leaseId },
+      { socketPath, timeoutMs: 1_000 }
+    ).then(response => {
+      if (!response.success) {
+        throw new Error(`failed to renew WebRTC stream lease: ${response.error ?? "no error detail returned"}`);
+      }
+    }).catch(error => {
+      failure = error instanceof Error ? error : new Error(String(error));
+    }).finally(() => {
+      inFlight = null;
+    });
+  };
+
+  const interval = timer.setInterval(renew, STREAM_LEASE_HEARTBEAT_INTERVAL_MS);
+  (interval as { unref?: () => void }).unref?.();
+  return {
+    async stop(): Promise<Error | null> {
+      stopped = true;
+      timer.clearInterval(interval);
+      await inFlight;
+      return failure;
+    },
+  };
+}
 
 describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => {
   afterAll(async () => {
@@ -637,6 +689,7 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
     let started = false;
     let observingStart = true;
     let startObserver: Promise<void> = Promise.resolve();
+    let leaseHeartbeat: StreamLeaseHeartbeat | undefined;
     try {
       await waitFor(async () => {
         if (mediamtx.exitCode !== null || mediamtx.signalCode !== null) {
@@ -694,9 +747,14 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
       if (!response.success) {
         throw new Error(`failed to start device WebRTC stream: ${response.error ?? "no error detail returned"}`);
       }
+      const leaseId = response.stream?.lease?.id;
+      if (!leaseId) {
+        throw new Error("started device WebRTC stream did not return an ownership lease");
+      }
+      leaseHeartbeat = startStreamLeaseHeartbeat(streamId, leaseId, webRtcSocketPath);
       await waitFor(async () => {
         const status = await sendWebRtcStreamRequest(
-          { action: "status", id: `${streamId}-capture-status`, streamId },
+          { action: "status", id: `${streamId}-capture-status`, streamId, leaseId },
           { socketPath: webRtcSocketPath, timeoutMs: 1_000 }
         ).catch(() => undefined);
         if ((status?.stream?.framesSent ?? 0) === 0) {
@@ -800,6 +858,11 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
           expect(keyframeRecovered(baseline, recovered!)).toBe(true);
         });
       }
+      const leaseHeartbeatError = await leaseHeartbeat.stop();
+      leaseHeartbeat = undefined;
+      if (leaseHeartbeatError) {
+        throw leaseHeartbeatError;
+      }
       const stopped = await sendWebRtcStreamRequest(
         { action: "stop", id: `${streamId}-stop`, streamId },
         { socketPath: webRtcSocketPath }
@@ -818,6 +881,10 @@ describeIntegration("device capture -> WHIP -> MediaMTX -> WHEP (#4308)", () => 
       // only from job logs. runPhase re-throws, preserving the prior semantics
       // where a failed cleanup surfaces as a test failure.
       await timeline.runPhase("pipelineTeardown", async () => {
+        const leaseHeartbeatError = await leaseHeartbeat?.stop();
+        if (leaseHeartbeatError) {
+          console.warn(`WebRTC stream lease heartbeat failed during teardown: ${leaseHeartbeatError.message}`);
+        }
         // Nothing in the observer rejects today; swallow anyway so a future edit
         // cannot skip the teardown below and replace the real test failure.
         await startObserver.catch(() => undefined);

--- a/test/scripts/webrtcDeviceIntegrationWorkflow.test.ts
+++ b/test/scripts/webrtcDeviceIntegrationWorkflow.test.ts
@@ -160,7 +160,7 @@ describe("#4308 device WebRTC integration workflow", () => {
     );
   });
 
-  test("activates the product-booted Simulator window before iOS ScreenCaptureKit capture", () => {
+  test("waits for the product-booted Simulator window to be discoverable before iOS ScreenCaptureKit capture", () => {
     const iosSteps = workflow().jobs?.["ios-device-webrtc"]?.steps ?? [];
     const boot = iosSteps.find(step => step.name === "Boot and activate iOS Simulator");
     const capture = iosSteps.find(step => step.name === "Run iOS device capture integration");
@@ -171,6 +171,10 @@ describe("#4308 device WebRTC integration workflow", () => {
     expect(boot?.run).toContain("jq -r '.deviceId'");
     expect(boot?.run).toContain("killall Simulator");
     expect(boot?.run).toContain("open -a Simulator --args -CurrentDeviceUDID");
+    expect(boot?.run).toContain("xcrun simctl list devices --json");
+    expect(boot?.run).toContain('"${helper_path}" --list-simulators');
+    expect(boot?.run).toContain("simulator_window_ready=0");
+    expect(boot?.run).toContain("Selected Simulator window did not become discoverable by ScreenCaptureKit");
     expect(iosSteps.indexOf(boot!)).toBeLessThan(iosSteps.indexOf(capture!));
   });
 });

--- a/test/scripts/webrtcDeviceIntegrationWorkflow.test.ts
+++ b/test/scripts/webrtcDeviceIntegrationWorkflow.test.ts
@@ -165,8 +165,11 @@ describe("#4308 device WebRTC integration workflow", () => {
     const boot = iosSteps.find(step => step.name === "Boot and activate iOS Simulator");
     const capture = iosSteps.find(step => step.name === "Run iOS device capture integration");
 
+    expect(boot).toBeDefined();
+    expect(capture).toBeDefined();
     expect(boot?.run).toContain("bun run src/index.ts --boot-device --platform ios --create-if-missing --timeout-ms 300000");
     expect(boot?.run).toContain("jq -r '.deviceId'");
+    expect(boot?.run).toContain("killall Simulator");
     expect(boot?.run).toContain("open -a Simulator --args -CurrentDeviceUDID");
     expect(iosSteps.indexOf(boot!)).toBeLessThan(iosSteps.indexOf(capture!));
   });

--- a/test/scripts/webrtcDeviceIntegrationWorkflow.test.ts
+++ b/test/scripts/webrtcDeviceIntegrationWorkflow.test.ts
@@ -159,4 +159,15 @@ describe("#4308 device WebRTC integration workflow", () => {
       "ios/screen-capture/.build/debug/screen-capture-helper"
     );
   });
+
+  test("activates the product-booted Simulator window before iOS ScreenCaptureKit capture", () => {
+    const iosSteps = workflow().jobs?.["ios-device-webrtc"]?.steps ?? [];
+    const boot = iosSteps.find(step => step.name === "Boot and activate iOS Simulator");
+    const capture = iosSteps.find(step => step.name === "Run iOS device capture integration");
+
+    expect(boot?.run).toContain("bun run src/index.ts --boot-device --platform ios --create-if-missing --timeout-ms 300000");
+    expect(boot?.run).toContain("jq -r '.deviceId'");
+    expect(boot?.run).toContain("open -a Simulator --args -CurrentDeviceUDID");
+    expect(iosSteps.indexOf(boot!)).toBeLessThan(iosSteps.indexOf(capture!));
+  });
 });

--- a/test/server/webrtcStreamManager.test.ts
+++ b/test/server/webrtcStreamManager.test.ts
@@ -954,6 +954,35 @@ describe("webrtcStreamManager", () => {
     expect(listWebRtcStreams()).toHaveLength(1);
   });
 
+  test("renews an owned lease through a status descriptor before capture expiry", async () => {
+    const timer = new FakeTimer();
+    const { publishers, sources } = installFakes();
+    setWebRtcStreamManagerDependencies({ timer });
+
+    const started = await startWebRtcStream({ device: ANDROID, overrides: { whipEndpoint: ENDPOINT } });
+    expect(started.lease?.id).toBeDefined();
+
+    timer.advanceTime(WEBRTC_STREAM_LEASE_TTL_MS - 1);
+    const renewed = getWebRtcStreamDescriptor(started.streamId, started.lease?.id);
+    expect(renewed?.lease?.id).toBe(started.lease?.id);
+
+    // The original deadline has passed, but the status heartbeat retained the
+    // manager-owned source for another lease interval.
+    timer.advanceTime(1);
+    await flushPublisherStart();
+    expect(listWebRtcStreams()).toHaveLength(1);
+    expect(publishers[0].stopped).toBe(false);
+    expect(sources[0].stopped).toBe(false);
+
+    timer.advanceTime(WEBRTC_STREAM_LEASE_TTL_MS - 2);
+    expect(listWebRtcStreams()).toHaveLength(1);
+    timer.advanceTime(1);
+    await flushPublisherStart();
+    expect(listWebRtcStreams()).toEqual([]);
+    expect(publishers[0].stopped).toBe(true);
+    expect(sources[0].stopped).toBe(true);
+  });
+
   test("returns a typed stopped result when a waiting stream is stopped", async () => {
     const timer = new FakeTimer();
     setWebRtcStreamManagerDependencies({

--- a/test/server/webrtcStreamManager.test.ts
+++ b/test/server/webrtcStreamManager.test.ts
@@ -37,7 +37,7 @@ class FakePublisher {
   sourceFailureErrors: Error[] = [];
   onBeforeEstablish?: () => Promise<void> | void;
   onConnected?: () => Promise<void> | void;
-  onKeyFrameRequest?: () => void;
+  onKeyFrameRequest?: () => boolean;
   onSourceFailure?: (error: Error) => void;
   onLifecycleEvent?: (event: WebRtcPublisherLifecycleEvent) => void;
   parameterSetPrimes: Array<{ sps: Buffer | null; pps: Buffer | null }> = [];
@@ -46,7 +46,7 @@ class FakePublisher {
     deps: {
       onBeforeEstablish?: () => Promise<void> | void;
       onConnected?: () => Promise<void> | void;
-      onKeyFrameRequest?: () => void;
+      onKeyFrameRequest?: () => boolean;
       onSourceFailure?: (error: Error) => void;
       onLifecycleEvent?: (event: WebRtcPublisherLifecycleEvent) => void;
     }
@@ -126,8 +126,9 @@ class FakeSource {
   async stop(): Promise<void> {
     this.stopped = true;
   }
-  requestKeyFrame(): void {
+  requestKeyFrame(): boolean {
     this.keyFrameRequests++;
+    return true;
   }
 }
 


### PR DESCRIPTION
## Summary

- create uniquely tokened Android video-server sessions with device-side leases and owned cleanup
- keep capture alive through bounded client reconnects, replay codec configuration, and request a fresh keyframe on attach
- use device uptime for lease expiry and exact NUL-delimited argv matching before terminating a stale process
- fail stale video-server artifacts with an actionable current-JAR override instead of treating them as a ready session

## Delivery

The release workflow rebuilds, verifies, and pins `automobile-video.jar` with the next AutoMobile release. Until then, a checkout using the older released JAR falls back safely for video or asks audio users to provide a current JAR override.

## Validation

- `bun test test/features/webrtc/PersistentEncoderH264Source.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `(cd android && ./gradlew :video-server:test :video-server:d8Dex :video-server:detekt)`
