### PR TITLE
Fix safe area warnings from keyboard controls

### DIFF
--- a/src/features/observe/audits/SafeAreaAuditor.ts
+++ b/src/features/observe/audits/SafeAreaAuditor.ts
@@ -170,12 +170,24 @@ function hasSdkInteraction(value: unknown): boolean {
 }
 
 function isForeignNode(node: Node, foregroundPackage: string | undefined): boolean {
+  const resourceId = stringValue(node["resource-id"]);
   const nodePackage = stringValue(node.packageName);
-  if (foregroundPackage && nodePackage && nodePackage !== foregroundPackage) {
+  const resourcePackage = resourceIdPackage(resourceId);
+  if (foregroundPackage && (
+    (nodePackage !== undefined && nodePackage !== foregroundPackage)
+    || (resourcePackage?.includes(".") && resourcePackage !== foregroundPackage)
+    || resourceId?.startsWith("android:id/input_method_")
+  )) {
     return true;
   }
-  const id = `${stringValue(node["resource-id"]) ?? ""} ${stringValue(node.packageName) ?? ""}`;
+  const id = `${resourceId ?? ""} ${nodePackage ?? ""}`;
   return id.includes("com.android.systemui") || id.includes("com.apple.springboard");
+}
+
+function resourceIdPackage(resourceId: string | undefined): string | undefined {
+  if (!resourceId) {return undefined;}
+  const separator = resourceId.indexOf(":");
+  return separator > 0 ? resourceId.slice(0, separator) : undefined;
 }
 
 function isScreenSized(bounds: ObservationEdgeInsets, screen: { width: number; height: number }): boolean {

--- a/src/features/observe/audits/SafeAreaAuditor.ts
+++ b/src/features/observe/audits/SafeAreaAuditor.ts
@@ -26,9 +26,10 @@ export class SafeAreaAuditor {
     }
 
     const contentInsets = this.contentInsets(insets);
+    const foregroundPackage = result.activeWindow?.appId ?? result.viewHierarchy.packageName;
     const warnings: LayoutWarning[] = [];
     for (const root of asNodes(result.viewHierarchy.hierarchy.node)) {
-      this.inspectNode(root, screen, contentInsets, insets.systemGestures, insets.mandatorySystemGestures, warnings);
+      this.inspectNode(root, screen, contentInsets, insets.systemGestures, insets.mandatorySystemGestures, foregroundPackage, warnings);
     }
     return dedupeWarnings(warnings);
   }
@@ -56,12 +57,13 @@ export class SafeAreaAuditor {
     content: ContentInsets | null,
     systemGestures: ObservationEdgeInsets | undefined,
     mandatorySystemGestures: ObservationEdgeInsets | undefined,
+    foregroundPackage: string | undefined,
     warnings: LayoutWarning[]
   ): void {
     const inspectedNode = withHierarchyAttributes(node);
-    if (!isSystemNode(inspectedNode)) {this.inspectElement(inspectedNode, screen, content, systemGestures, mandatorySystemGestures, warnings);}
+    if (!isForeignNode(inspectedNode, foregroundPackage)) {this.inspectElement(inspectedNode, screen, content, systemGestures, mandatorySystemGestures, warnings);}
     for (const child of asNodes(node.node)) {
-      this.inspectNode(child, screen, content, systemGestures, mandatorySystemGestures, warnings);
+      this.inspectNode(child, screen, content, systemGestures, mandatorySystemGestures, foregroundPackage, warnings);
     }
   }
 
@@ -167,7 +169,11 @@ function hasSdkInteraction(value: unknown): boolean {
     || stringValue(value["sdk.accessibilityCustomActions"]) !== undefined;
 }
 
-function isSystemNode(node: Node): boolean {
+function isForeignNode(node: Node, foregroundPackage: string | undefined): boolean {
+  const nodePackage = stringValue(node.packageName);
+  if (foregroundPackage && nodePackage && nodePackage !== foregroundPackage) {
+    return true;
+  }
   const id = `${stringValue(node["resource-id"]) ?? ""} ${stringValue(node.packageName) ?? ""}`;
   return id.includes("com.android.systemui") || id.includes("com.apple.springboard");
 }

--- a/test/features/observe/audits/SafeAreaAuditor.test.ts
+++ b/test/features/observe/audits/SafeAreaAuditor.test.ts
@@ -39,16 +39,20 @@ describe("SafeAreaAuditor", () => {
     expect(warnings[1]).toMatchObject({ categories: ["text", "interaction"], sides: ["bottom"], insetTypes: ["systemBars"] });
   });
 
-  test("excludes nodes from a foreign package while retaining untagged app nodes", () => {
+  test("excludes foreign resource IDs when nodes omit package metadata", () => {
     const result = observation();
     result.insets!.systemGestures = { top: 0, right: 0, bottom: 20, left: 0 };
     result.viewHierarchy!.hierarchy.node = [
-      { "text": "Compose", "view-id": "composer", "bounds": { left: 10, top: 170, right: 90, bottom: 196 } },
+      {
+        "text": "Compose",
+        "view-id": "composer",
+        "resource-id": "com.example:id/composer",
+        "bounds": { left: 10, top: 170, right: 90, bottom: 196 },
+      },
       {
         "text": "Back",
         "view-id": "ime-nav-back",
         "resource-id": "android:id/input_method_nav_back",
-        "packageName": "com.google.android.inputmethod.latin",
         "clickable": "true",
         "bounds": { left: 10, top: 170, right: 90, bottom: 196 },
       },
@@ -56,18 +60,22 @@ describe("SafeAreaAuditor", () => {
         "text": "q",
         "view-id": "ime-key",
         "resource-id": "com.google.android.inputmethod.latin:id/key_pos_q",
-        "packageName": "com.google.android.inputmethod.latin",
         "clickable": "true",
         "bounds": { left: 10, top: 170, right: 90, bottom: 196 },
+      },
+      {
+        "text": "Framework button",
+        "view-id": "framework-button",
+        "resource-id": "android:id/button1",
+        "clickable": "true",
+        "bounds": { left: 10, top: 8, right: 90, bottom: 28 },
       },
     ] as any;
 
     const warnings = new SafeAreaAuditor().inspect(result);
 
-    expect(warnings).toHaveLength(1);
-    expect(warnings).toMatchObject([
-      { element: { viewId: "composer" } },
-    ]);
+    expect(warnings).toHaveLength(2);
+    expect(warnings.map(warning => warning.element.viewId)).toEqual(["composer", "framework-button"]);
   });
 
   test("returns no warnings when measurements are unavailable", () => {

--- a/test/features/observe/audits/SafeAreaAuditor.test.ts
+++ b/test/features/observe/audits/SafeAreaAuditor.test.ts
@@ -7,6 +7,7 @@ function observation(): ObserveResult {
     updatedAt: 1,
     screenSize: { width: 100, height: 200 },
     systemInsets: { top: 20, right: 0, bottom: 20, left: 0 },
+    activeWindow: { appId: "com.example", activityName: ".MainActivity", layoutSeqSum: 1 },
     insets: {
       available: true,
       source: "android-window-metrics",
@@ -36,6 +37,37 @@ describe("SafeAreaAuditor", () => {
     expect(warnings).toHaveLength(2);
     expect(warnings.map(warning => warning.element.viewId)).toEqual(["title", "continue"]);
     expect(warnings[1]).toMatchObject({ categories: ["text", "interaction"], sides: ["bottom"], insetTypes: ["systemBars"] });
+  });
+
+  test("excludes nodes from a foreign package while retaining untagged app nodes", () => {
+    const result = observation();
+    result.insets!.systemGestures = { top: 0, right: 0, bottom: 20, left: 0 };
+    result.viewHierarchy!.hierarchy.node = [
+      { "text": "Compose", "view-id": "composer", "bounds": { left: 10, top: 170, right: 90, bottom: 196 } },
+      {
+        "text": "Back",
+        "view-id": "ime-nav-back",
+        "resource-id": "android:id/input_method_nav_back",
+        "packageName": "com.google.android.inputmethod.latin",
+        "clickable": "true",
+        "bounds": { left: 10, top: 170, right: 90, bottom: 196 },
+      },
+      {
+        "text": "q",
+        "view-id": "ime-key",
+        "resource-id": "com.google.android.inputmethod.latin:id/key_pos_q",
+        "packageName": "com.google.android.inputmethod.latin",
+        "clickable": "true",
+        "bounds": { left: 10, top: 170, right: 90, bottom: 196 },
+      },
+    ] as any;
+
+    const warnings = new SafeAreaAuditor().inspect(result);
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings).toMatchObject([
+      { element: { viewId: "composer" } },
+    ]);
   });
 
   test("returns no warnings when measurements are unavailable", () => {


### PR DESCRIPTION
## Summary

- Limit safe-area findings to nodes owned by the foreground app
- Exclude soft keyboard and other non-app controls from reported warnings
- Use resource IDs when nodes do not include package metadata
- Keep ordinary Android framework controls auditable

## Why

Text-entry screens could report warnings for keyboard controls that the app cannot address, even when their hierarchy entries omit package metadata.

## Validation

- `bun test test/features/observe/audits/SafeAreaAuditor.test.ts`
- `bun run lint`
- `bun run typecheck`
