### PR TITLE
fix(observe): ignore off-screen safe-area content

### DIFF
--- a/src/features/observe/audits/SafeAreaAuditor.ts
+++ b/src/features/observe/audits/SafeAreaAuditor.ts
@@ -75,14 +75,15 @@ export class SafeAreaAuditor {
   ): void {
     const bounds = readBounds(node);
     const categories = categoriesFor(node);
-    if (!bounds || categories.length === 0 || isScreenSized(bounds, screen) || node.enabled === "false") {return;}
+    if (!bounds || categories.length === 0 || !isOnScreen(bounds, screen) || isScreenSized(bounds, screen) || node.enabled === "false") {return;}
     this.inspectContent(node, bounds, categories, screen, content, warnings);
     this.inspectGestureRegion(node, bounds, categories, screen, systemGestures, mandatorySystemGestures, warnings);
   }
 
   private inspectContent(node: Node, bounds: ObservationEdgeInsets, categories: LayoutWarning["categories"], screen: { width: number; height: number }, content: ContentInsets | null, warnings: LayoutWarning[]): void {
     if (!content) {return;}
-    const sides = intersectingSides(bounds, screen, content.edges);
+    const sides = intersectingSides(bounds, screen, content.edges)
+      .filter(side => content.typesForSides([side]).length > 0);
     if (sides.length > 0) {warnings.push(this.warning(node, bounds, categories, content.typesForSides(sides), sides, "important-content-under-inset", "warning", screen, content.edges));}
   }
 
@@ -174,6 +175,10 @@ function isSystemNode(node: Node): boolean {
 
 function isScreenSized(bounds: ObservationEdgeInsets, screen: { width: number; height: number }): boolean {
   return bounds.left === 0 && bounds.top === 0 && bounds.right === screen.width && bounds.bottom === screen.height;
+}
+
+function isOnScreen(bounds: ObservationEdgeInsets, screen: { width: number; height: number }): boolean {
+  return bounds.right > 0 && bounds.bottom > 0 && bounds.left < screen.width && bounds.top < screen.height;
 }
 
 function intersectingSides(bounds: ObservationEdgeInsets, screen: { width: number; height: number }, insets: ObservationEdgeInsets): Side[] {

--- a/test/features/observe/audits/SafeAreaAuditor.test.ts
+++ b/test/features/observe/audits/SafeAreaAuditor.test.ts
@@ -60,6 +60,33 @@ describe("SafeAreaAuditor", () => {
     expect(new SafeAreaAuditor().inspect(result)[0]?.insetTypes).toEqual(["systemBars"]);
   });
 
+  test("ignores fully off-screen content", () => {
+    const result = observation();
+    result.insets!.systemBars!.visible.left = 16;
+    result.insets!.systemGestures!.left = 16;
+    result.viewHierarchy!.hierarchy.node = [{
+      "text": "Previous page",
+      "clickable": "true",
+      "view-id": "previous-page",
+      "bounds": { left: -100, top: 50, right: 0, bottom: 100 },
+    }] as any;
+
+    expect(new SafeAreaAuditor().inspect(result)).toEqual([]);
+  });
+
+  test("only reports content overlap on sides with an inset", () => {
+    const result = observation();
+    result.viewHierarchy!.hierarchy.node = [{
+      "text": "Title",
+      "view-id": "title",
+      "bounds": { left: -5, top: 8, right: 60, bottom: 28 },
+    }] as any;
+
+    expect(new SafeAreaAuditor().inspect(result)).toMatchObject([
+      { sides: ["top"], insetTypes: ["systemBars"] },
+    ]);
+  });
+
   test("uses the iOS safe area rather than Android bar fields", () => {
     const result = observation();
     result.insets = {


### PR DESCRIPTION
## Summary

- Ignore layout-audit candidates that have no visible screen area.
- Report content overlap only on sides with a nonzero inset.

## Root Cause

The audit evaluated bounds against individual edges even when an element was
fully outside the displayed screen. It could also include sides without a
contributing inset.

## Impact

Off-screen panes kept mounted by pager or drawer navigation no longer produce
misleading warnings. Visible content that overlaps a real inset remains
reported.

## Validation

- `bun test test/features/observe/audits/SafeAreaAuditor.test.ts`
- `bun run lint -- src/features/observe/audits/SafeAreaAuditor.ts test/features/observe/audits/SafeAreaAuditor.test.ts`
