### PR TITLE
fix: rank safe-area findings by clipping risk

### DIFF
--- a/src/features/observe/audits/SafeAreaAuditor.ts
+++ b/src/features/observe/audits/SafeAreaAuditor.ts
@@ -251,18 +251,40 @@ function intersectingSides(bounds: ObservationEdgeInsets, screen: { width: numbe
 
 function overlapPercent(bounds: ObservationEdgeInsets, screen: { width: number; height: number }, insets: ObservationEdgeInsets): number {
   const area = Math.max(1, (bounds.right - bounds.left) * (bounds.bottom - bounds.top));
-  const overlap = [
-    intersectArea(bounds, { left: 0, top: 0, right: screen.width, bottom: insets.top }),
-    intersectArea(bounds, { left: 0, top: screen.height - insets.bottom, right: screen.width, bottom: screen.height }),
-    intersectArea(bounds, { left: 0, top: 0, right: insets.left, bottom: screen.height }),
-    intersectArea(bounds, { left: screen.width - insets.right, top: 0, right: screen.width, bottom: screen.height }),
-  ].reduce((total, current) => total + current, 0);
+  const overlap = unionArea([
+    intersectBounds(bounds, { left: 0, top: 0, right: screen.width, bottom: insets.top }),
+    intersectBounds(bounds, { left: 0, top: screen.height - insets.bottom, right: screen.width, bottom: screen.height }),
+    intersectBounds(bounds, { left: 0, top: 0, right: insets.left, bottom: screen.height }),
+    intersectBounds(bounds, { left: screen.width - insets.right, top: 0, right: screen.width, bottom: screen.height }),
+  ].filter((region): region is ObservationEdgeInsets => region !== null));
   return Math.min(100, Math.round((overlap / area) * 100));
 }
 
-function intersectArea(a: ObservationEdgeInsets, b: ObservationEdgeInsets): number {
-  return Math.max(0, Math.min(a.right, b.right) - Math.max(a.left, b.left))
-    * Math.max(0, Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top));
+function intersectBounds(a: ObservationEdgeInsets, b: ObservationEdgeInsets): ObservationEdgeInsets | null {
+  const left = Math.max(a.left, b.left);
+  const top = Math.max(a.top, b.top);
+  const right = Math.min(a.right, b.right);
+  const bottom = Math.min(a.bottom, b.bottom);
+  return left < right && top < bottom ? { left, top, right, bottom } : null;
+}
+
+function unionArea(regions: ObservationEdgeInsets[]): number {
+  const xEdges = [...new Set(regions.flatMap(region => [region.left, region.right]))].sort((a, b) => a - b);
+  const yEdges = [...new Set(regions.flatMap(region => [region.top, region.bottom]))].sort((a, b) => a - b);
+  let area = 0;
+
+  for (let x = 0; x < xEdges.length - 1; x += 1) {
+    for (let y = 0; y < yEdges.length - 1; y += 1) {
+      const left = xEdges[x]!;
+      const top = yEdges[y]!;
+      const right = xEdges[x + 1]!;
+      const bottom = yEdges[y + 1]!;
+      if (regions.some(region => region.left <= left && region.top <= top && region.right >= right && region.bottom >= bottom)) {
+        area += (right - left) * (bottom - top);
+      }
+    }
+  }
+  return area;
 }
 
 function maxInsets(

--- a/src/features/observe/audits/SafeAreaAuditor.ts
+++ b/src/features/observe/audits/SafeAreaAuditor.ts
@@ -61,7 +61,7 @@ export class SafeAreaAuditor {
     warnings: LayoutWarning[]
   ): void {
     const inspectedNode = withHierarchyAttributes(node);
-    if (!isForeignNode(inspectedNode, foregroundPackage)) {this.inspectElement(inspectedNode, screen, content, systemGestures, mandatorySystemGestures, warnings);}
+    if (!isForeignNode(inspectedNode, foregroundPackage)) {this.inspectElement(inspectedNode, screen, content, systemGestures, mandatorySystemGestures, foregroundPackage, warnings);}
     for (const child of asNodes(node.node)) {
       this.inspectNode(child, screen, content, systemGestures, mandatorySystemGestures, foregroundPackage, warnings);
     }
@@ -73,20 +73,40 @@ export class SafeAreaAuditor {
     content: ContentInsets | null,
     systemGestures: ObservationEdgeInsets | undefined,
     mandatorySystemGestures: ObservationEdgeInsets | undefined,
+    foregroundPackage: string | undefined,
     warnings: LayoutWarning[]
   ): void {
     const bounds = readBounds(node);
     const categories = categoriesFor(node);
     if (!bounds || categories.length === 0 || !isOnScreen(bounds, screen) || isScreenSized(bounds, screen) || node.enabled === "false") {return;}
-    this.inspectContent(node, bounds, categories, screen, content, warnings);
+    this.inspectContent(node, bounds, categories, screen, content, foregroundPackage, warnings);
     this.inspectGestureRegion(node, bounds, categories, screen, systemGestures, mandatorySystemGestures, warnings);
   }
 
-  private inspectContent(node: Node, bounds: ObservationEdgeInsets, categories: LayoutWarning["categories"], screen: { width: number; height: number }, content: ContentInsets | null, warnings: LayoutWarning[]): void {
+  private inspectContent(node: Node, bounds: ObservationEdgeInsets, categories: LayoutWarning["categories"], screen: { width: number; height: number }, content: ContentInsets | null, foregroundPackage: string | undefined, warnings: LayoutWarning[]): void {
     if (!content) {return;}
     const sides = intersectingSides(bounds, screen, content.edges)
       .filter(side => content.typesForSides([side]).length > 0);
-    if (sides.length > 0) {warnings.push(this.warning(node, bounds, categories, content.typesForSides(sides), sides, "important-content-under-inset", "warning", screen, content.edges));}
+    if (sides.length === 0) {return;}
+    warnings.push(this.warning(
+      node,
+      bounds,
+      categories,
+      content.typesForSides(sides),
+      sides,
+      "important-content-under-inset",
+      this.contentSeverity(node, bounds, screen, content.edges, foregroundPackage),
+      screen,
+      content.edges
+    ));
+  }
+
+  private contentSeverity(node: Node, bounds: ObservationEdgeInsets, screen: { width: number; height: number }, insets: ObservationEdgeInsets, foregroundPackage: string | undefined): LayoutWarning["severity"] {
+    const overlap = overlapPercent(bounds, screen, insets);
+    if (isLargeContainer(node, bounds, screen) && !hasOverlappingContentDescendant(node, screen, insets, foregroundPackage)) {
+      return "info";
+    }
+    return overlap >= 50 ? "warning" : "info";
   }
 
   private inspectGestureRegion(node: Node, bounds: ObservationEdgeInsets, categories: LayoutWarning["categories"], screen: { width: number; height: number }, systemGestures: ObservationEdgeInsets | undefined, mandatorySystemGestures: ObservationEdgeInsets | undefined, warnings: LayoutWarning[]): void {
@@ -197,6 +217,27 @@ function isScreenSized(bounds: ObservationEdgeInsets, screen: { width: number; h
 
 function isOnScreen(bounds: ObservationEdgeInsets, screen: { width: number; height: number }): boolean {
   return bounds.right > 0 && bounds.bottom > 0 && bounds.left < screen.width && bounds.top < screen.height;
+}
+
+function isLargeContainer(node: Node, bounds: ObservationEdgeInsets, screen: { width: number; height: number }): boolean {
+  return asNodes(node.node).length > 0
+    && bounds.right - bounds.left >= screen.width * 0.9
+    && (bounds.right - bounds.left) * (bounds.bottom - bounds.top) >= screen.width * screen.height * 0.2;
+}
+
+function hasOverlappingContentDescendant(node: Node, screen: { width: number; height: number }, insets: ObservationEdgeInsets, foregroundPackage: string | undefined): boolean {
+  return descendants(node).some(descendant => {
+    if (isForeignNode(descendant, foregroundPackage) || categoriesFor(descendant).length === 0) {return false;}
+    const bounds = readBounds(descendant);
+    return bounds !== null && intersectingSides(bounds, screen, insets).length > 0;
+  });
+}
+
+function descendants(node: Node): Node[] {
+  return asNodes(node.node).flatMap(child => {
+    const inspectedChild = withHierarchyAttributes(child);
+    return [inspectedChild, ...descendants(child)];
+  });
 }
 
 function intersectingSides(bounds: ObservationEdgeInsets, screen: { width: number; height: number }, insets: ObservationEdgeInsets): Side[] {

--- a/test/daemon/webrtcStreamSocketServer.test.ts
+++ b/test/daemon/webrtcStreamSocketServer.test.ts
@@ -243,6 +243,7 @@ describe("WebRtcStreamSocketServer", () => {
         sources.push(source);
         return source as unknown as AndroidH264Source;
       },
+      resolveVideoJar: async () => null,
       now: () => new Date("2026-07-14T00:00:00.000Z"),
     });
     const server = new TestableServer({

--- a/test/features/observe/audits/SafeAreaAuditor.test.ts
+++ b/test/features/observe/audits/SafeAreaAuditor.test.ts
@@ -129,6 +129,27 @@ describe("SafeAreaAuditor", () => {
     }]);
   });
 
+  test("does not double count a corner shared by safe-area insets", () => {
+    const result = observation();
+    result.insets = {
+      available: true,
+      source: "ios-sdk-safe-area",
+      units: "points",
+      safeArea: { top: 10, right: 0, bottom: 0, left: 10 },
+    };
+    result.viewHierarchy!.hierarchy.node = [{
+      "text": "Corner leaf",
+      "view-id": "corner",
+      "bounds": { left: 0, top: 0, right: 40, bottom: 40 },
+    }] as any;
+
+    expect(new SafeAreaAuditor().inspect(result)).toMatchObject([{
+      element: { viewId: "corner" },
+      severity: "info",
+      overlapPercent: 44,
+    }]);
+  });
+
   test("returns no warnings when measurements are unavailable", () => {
     const result = observation();
     result.insets = { available: false, source: "unavailable", units: "unknown" };

--- a/test/features/observe/audits/SafeAreaAuditor.test.ts
+++ b/test/features/observe/audits/SafeAreaAuditor.test.ts
@@ -78,6 +78,57 @@ describe("SafeAreaAuditor", () => {
     expect(warnings.map(warning => warning.element.viewId)).toEqual(["composer", "framework-button"]);
   });
 
+  test("downgrades large edge-to-edge containers when their content is inset", () => {
+    const result = observation();
+    result.insets!.systemBars!.visible = { top: 80, right: 0, bottom: 80, left: 0 };
+    result.viewHierarchy!.hierarchy.node = [{
+      "view-id": "close-sheet",
+      "content-desc": "Close sheet",
+      "clickable": "true",
+      "bounds": { left: 0, top: 0, right: 100, bottom: 180 },
+      "node": [
+        { "text": "Forward", "bounds": { left: 10, top: 80, right: 90, bottom: 110 } },
+        { "text": "Save", "bounds": { left: 10, top: 110, right: 90, bottom: 120 } },
+      ],
+    }] as any;
+
+    expect(new SafeAreaAuditor().inspect(result)).toMatchObject([{
+      element: { viewId: "close-sheet" },
+      severity: "info",
+      overlapPercent: 78,
+    }]);
+  });
+
+  test("keeps fully occluded leaf content at warning severity", () => {
+    const result = observation();
+    result.viewHierarchy!.hierarchy.node = [{
+      "text": "Last item",
+      "view-id": "last-item",
+      "bounds": { left: 10, top: 180, right: 90, bottom: 200 },
+    }] as any;
+
+    expect(new SafeAreaAuditor().inspect(result)).toMatchObject([{
+      element: { viewId: "last-item" },
+      severity: "warning",
+      overlapPercent: 100,
+    }]);
+  });
+
+  test("downgrades leaf content with limited inset overlap", () => {
+    const result = observation();
+    result.viewHierarchy!.hierarchy.node = [{
+      "text": "Partially inset",
+      "view-id": "partial-item",
+      "bounds": { left: 10, top: 170, right: 90, bottom: 187 },
+    }] as any;
+
+    expect(new SafeAreaAuditor().inspect(result)).toMatchObject([{
+      element: { viewId: "partial-item" },
+      severity: "info",
+      overlapPercent: 41,
+    }]);
+  });
+
   test("returns no warnings when measurements are unavailable", () => {
     const result = observation();
     result.insets = { available: false, source: "unavailable", units: "unknown" };


### PR DESCRIPTION
## Summary

- Reduce advisory noise from intentional edge-to-edge sheets and overlays.
- Keep substantially obscured labels and controls at warning severity.

## Why

Some surfaces are designed to extend behind system bars while their actionable content remains visible. This change makes the findings reflect that distinction, so genuinely clipped content is easier to prioritize.

## Validation

- `bun run lint`
- `bun run build`
- `bun test test/features/observe/audits/SafeAreaAuditor.test.ts`
