### PR TITLE
Improve safe-area warning details

### DIFF
--- a/docs/design-docs/mcp/observe/index.md
+++ b/docs/design-docs/mcp/observe/index.md
@@ -27,7 +27,7 @@ All collected data is assembled into an object containing (fields may be omitted
 - `gfxMetrics`: emitted in sanitized output for action UI-stability summaries; frame timing fields may be trimmed when `performanceAudit.metrics` already carries non-null computed replacements
 - `error`: error messages encountered during observation
 
-Start AutoMobile with `--safe-area-warnings` or its equivalent alias `--edge-to-edge-warnings` to add report-only `layoutWarnings`. These flag text or interactive elements that may overlap safe areas, system bars, display cutouts, or Android gesture regions. Intentional edge-to-edge backgrounds and scrollable content remain advisory rather than failures.
+Start AutoMobile with `--safe-area-warnings` or its equivalent alias `--edge-to-edge-warnings` to add report-only `layoutWarnings`. These flag text or interactive elements that may overlap safe areas, system bars, display cutouts, or Android gesture regions. Each warning includes `overflowPx` (how far the element extends into the unsafe region) and `insetPx` (the effective inset on that side), both in the observation's coordinate units. When a flagged descendant is fully contained by a flagged ancestor on the same unsafe side, the output keeps the descendant finding. Intentional edge-to-edge backgrounds and scrollable content remain advisory rather than failures.
 
 The observation gracefully handles various error conditions:
 

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3980,6 +3980,42 @@
                   ]
                 }
               },
+              "overflowPx": {
+                "type": "object",
+                "properties": {
+                  "top": {
+                    "type": "number"
+                  },
+                  "right": {
+                    "type": "number"
+                  },
+                  "bottom": {
+                    "type": "number"
+                  },
+                  "left": {
+                    "type": "number"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "insetPx": {
+                "type": "object",
+                "properties": {
+                  "top": {
+                    "type": "number"
+                  },
+                  "right": {
+                    "type": "number"
+                  },
+                  "bottom": {
+                    "type": "number"
+                  },
+                  "left": {
+                    "type": "number"
+                  }
+                },
+                "additionalProperties": false
+              },
               "overlapPercent": {
                 "type": "integer",
                 "minimum": -9007199254740991,
@@ -4000,6 +4036,8 @@
               "categories",
               "insetTypes",
               "sides",
+              "overflowPx",
+              "insetPx",
               "overlapPercent",
               "confidence"
             ],

--- a/src/features/observe/audits/SafeAreaAuditor.ts
+++ b/src/features/observe/audits/SafeAreaAuditor.ts
@@ -398,8 +398,8 @@ function dedupeWarnings(candidates: WarningCandidate[]): LayoutWarning[] {
     for (const ancestor of ancestors) {
       if (
         ancestor.warning.type === descendant.warning.type
-        && sharesSide(ancestor.warning.sides, descendant.warning.sides)
-        && strictlyContains(ancestor.warning.element.bounds, descendant.warning.element.bounds)
+        && coversSides(ancestor.warning.sides, descendant.warning.sides)
+        && contains(ancestor.warning.element.bounds, descendant.warning.element.bounds)
       ) {
         containerWarnings.add(ancestor);
       }
@@ -415,17 +415,13 @@ function dedupeWarnings(candidates: WarningCandidate[]): LayoutWarning[] {
   }).map(candidate => candidate.warning);
 }
 
-function sharesSide(first: Side[], second: Side[]): boolean {
-  return first.some(side => second.includes(side));
+function coversSides(required: Side[], candidate: Side[]): boolean {
+  return required.every(side => candidate.includes(side));
 }
 
-function strictlyContains(container: ObservationEdgeInsets, contained: ObservationEdgeInsets): boolean {
+function contains(container: ObservationEdgeInsets, contained: ObservationEdgeInsets): boolean {
   return container.left <= contained.left
     && container.top <= contained.top
     && container.right >= contained.right
-    && container.bottom >= contained.bottom
-    && (container.left < contained.left
-      || container.top < contained.top
-      || container.right > contained.right
-      || container.bottom > contained.bottom);
+    && container.bottom >= contained.bottom;
 }

--- a/src/features/observe/audits/SafeAreaAuditor.ts
+++ b/src/features/observe/audits/SafeAreaAuditor.ts
@@ -7,6 +7,11 @@ type ContentInsets = {
   edges: ObservationEdgeInsets;
   typesForSides: (sides: Side[]) => LayoutWarning["insetTypes"];
 };
+type WarningCandidate = {
+  warning: LayoutWarning;
+  node: Node;
+  ancestors: Node[];
+};
 
 /**
  * Report-only edge-to-edge inspection. It intentionally warns about potential
@@ -27,9 +32,9 @@ export class SafeAreaAuditor {
 
     const contentInsets = this.contentInsets(insets);
     const foregroundPackage = result.activeWindow?.appId ?? result.viewHierarchy.packageName;
-    const warnings: LayoutWarning[] = [];
+    const warnings: WarningCandidate[] = [];
     for (const root of asNodes(result.viewHierarchy.hierarchy.node)) {
-      this.inspectNode(root, screen, contentInsets, insets.systemGestures, insets.mandatorySystemGestures, foregroundPackage, warnings);
+      this.inspectNode(root, screen, contentInsets, insets.systemGestures, insets.mandatorySystemGestures, foregroundPackage, [], warnings);
     }
     return dedupeWarnings(warnings);
   }
@@ -58,50 +63,85 @@ export class SafeAreaAuditor {
     systemGestures: ObservationEdgeInsets | undefined,
     mandatorySystemGestures: ObservationEdgeInsets | undefined,
     foregroundPackage: string | undefined,
-    warnings: LayoutWarning[]
+    ancestors: Node[],
+    warnings: WarningCandidate[]
   ): void {
     const inspectedNode = withHierarchyAttributes(node);
-    if (!isForeignNode(inspectedNode, foregroundPackage)) {this.inspectElement(inspectedNode, screen, content, systemGestures, mandatorySystemGestures, foregroundPackage, warnings);}
+    if (!isForeignNode(inspectedNode, foregroundPackage)) {
+      this.inspectElement(
+        inspectedNode,
+        node,
+        ancestors,
+        screen,
+        content,
+        systemGestures,
+        mandatorySystemGestures,
+        foregroundPackage,
+        warnings
+      );
+    }
     for (const child of asNodes(node.node)) {
-      this.inspectNode(child, screen, content, systemGestures, mandatorySystemGestures, foregroundPackage, warnings);
+      this.inspectNode(child, screen, content, systemGestures, mandatorySystemGestures, foregroundPackage, [...ancestors, node], warnings);
     }
   }
 
   private inspectElement(
     node: Node,
+    sourceNode: Node,
+    ancestors: Node[],
     screen: { width: number; height: number },
     content: ContentInsets | null,
     systemGestures: ObservationEdgeInsets | undefined,
     mandatorySystemGestures: ObservationEdgeInsets | undefined,
     foregroundPackage: string | undefined,
-    warnings: LayoutWarning[]
+    warnings: WarningCandidate[]
   ): void {
     const bounds = readBounds(node);
     const categories = categoriesFor(node);
     if (!bounds || categories.length === 0 || !isOnScreen(bounds, screen) || isScreenSized(bounds, screen) || node.enabled === "false") {return;}
-    this.inspectContent(node, bounds, categories, screen, content, foregroundPackage, warnings);
-    this.inspectGestureRegion(node, bounds, categories, screen, systemGestures, mandatorySystemGestures, warnings);
+    this.inspectContent(node, sourceNode, ancestors, bounds, categories, screen, content, foregroundPackage, warnings);
+    this.inspectGestureRegion(node, sourceNode, ancestors, bounds, categories, screen, systemGestures, mandatorySystemGestures, warnings);
   }
 
-  private inspectContent(node: Node, bounds: ObservationEdgeInsets, categories: LayoutWarning["categories"], screen: { width: number; height: number }, content: ContentInsets | null, foregroundPackage: string | undefined, warnings: LayoutWarning[]): void {
+  private inspectContent(
+    node: Node,
+    sourceNode: Node,
+    ancestors: Node[],
+    bounds: ObservationEdgeInsets,
+    categories: LayoutWarning["categories"],
+    screen: { width: number; height: number },
+    content: ContentInsets | null,
+    foregroundPackage: string | undefined,
+    warnings: WarningCandidate[]
+  ): void {
     if (!content) {return;}
     const sides = intersectingSides(bounds, screen, content.edges)
       .filter(side => content.typesForSides([side]).length > 0);
     if (sides.length === 0) {return;}
-    warnings.push(this.warning(
-      node,
-      bounds,
-      categories,
-      content.typesForSides(sides),
-      sides,
-      "important-content-under-inset",
-      this.contentSeverity(node, bounds, screen, content.edges, foregroundPackage),
-      screen,
-      content.edges
-    ));
+    warnings.push({
+      warning: this.warning(
+        node,
+        bounds,
+        categories,
+        content.typesForSides(sides),
+        sides,
+        "important-content-under-inset",
+        this.contentSeverity(node, bounds, screen, content.edges, foregroundPackage),
+        screen,
+        content.edges
+      ),
+      node: sourceNode,
+      ancestors,
+    });
   }
 
-  private contentSeverity(node: Node, bounds: ObservationEdgeInsets, screen: { width: number; height: number }, insets: ObservationEdgeInsets, foregroundPackage: string | undefined): LayoutWarning["severity"] {
+  private contentSeverity(
+    node: Node,
+    bounds: ObservationEdgeInsets,
+    screen: { width: number; height: number },
+    insets: ObservationEdgeInsets,
+    foregroundPackage: string | undefined
+  ): LayoutWarning["severity"] {
     const overlap = overlapPercent(bounds, screen, insets);
     if (isLargeContainer(node, bounds, screen) && !hasOverlappingContentDescendant(node, screen, insets, foregroundPackage)) {
       return "info";
@@ -109,12 +149,18 @@ export class SafeAreaAuditor {
     return overlap >= 50 ? "warning" : "info";
   }
 
-  private inspectGestureRegion(node: Node, bounds: ObservationEdgeInsets, categories: LayoutWarning["categories"], screen: { width: number; height: number }, systemGestures: ObservationEdgeInsets | undefined, mandatorySystemGestures: ObservationEdgeInsets | undefined, warnings: LayoutWarning[]): void {
+  private inspectGestureRegion(node: Node, sourceNode: Node, ancestors: Node[], bounds: ObservationEdgeInsets, categories: LayoutWarning["categories"], screen: { width: number; height: number }, systemGestures: ObservationEdgeInsets | undefined, mandatorySystemGestures: ObservationEdgeInsets | undefined, warnings: WarningCandidate[]): void {
     if (!categories.includes("interaction")) {return;}
     const gesture = maxInsets(systemGestures, mandatorySystemGestures);
     if (!gesture) {return;}
     const sides = intersectingSides(bounds, screen, gesture);
-    if (sides.length > 0) {warnings.push(this.warning(node, bounds, ["interaction"], insetTypes(systemGestures, mandatorySystemGestures, "systemGestures", "mandatorySystemGestures", sides), sides, "interaction-in-system-gesture-region", "info", screen, gesture));}
+    if (sides.length > 0) {
+      warnings.push({
+        warning: this.warning(node, bounds, ["interaction"], insetTypes(systemGestures, mandatorySystemGestures, "systemGestures", "mandatorySystemGestures", sides), sides, "interaction-in-system-gesture-region", "info", screen, gesture),
+        node: sourceNode,
+        ancestors,
+      });
+    }
   }
 
   private warning(
@@ -141,6 +187,8 @@ export class SafeAreaAuditor {
       categories,
       insetTypes,
       sides,
+      overflowPx: overflowPx(bounds, screen, insets, sides),
+      insetPx: sideValues(insets, sides),
       overlapPercent: overlapPercent(bounds, screen, insets),
       confidence: node.occlusionState === "partial" ? "high" : "medium",
     };
@@ -249,6 +297,25 @@ function intersectingSides(bounds: ObservationEdgeInsets, screen: { width: numbe
   ].filter((side): side is Side => side !== undefined);
 }
 
+function overflowPx(
+  bounds: ObservationEdgeInsets,
+  screen: { width: number; height: number },
+  insets: ObservationEdgeInsets,
+  sides: Side[]
+): LayoutWarning["overflowPx"] {
+  const values: Record<Side, number> = {
+    top: Math.max(0, insets.top - bounds.top),
+    right: Math.max(0, bounds.right - (screen.width - insets.right)),
+    bottom: Math.max(0, bounds.bottom - (screen.height - insets.bottom)),
+    left: Math.max(0, insets.left - bounds.left),
+  };
+  return sideValues(values, sides);
+}
+
+function sideValues(insets: ObservationEdgeInsets, sides: Side[]): LayoutWarning["insetPx"] {
+  return Object.fromEntries(sides.map(side => [side, insets[side]]));
+}
+
 function overlapPercent(bounds: ObservationEdgeInsets, screen: { width: number; height: number }, insets: ObservationEdgeInsets): number {
   const area = Math.max(1, (bounds.right - bounds.left) * (bounds.bottom - bounds.top));
   const overlap = unionArea([
@@ -317,12 +384,48 @@ function stringValue(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
-function dedupeWarnings(warnings: LayoutWarning[]): LayoutWarning[] {
+function dedupeWarnings(candidates: WarningCandidate[]): LayoutWarning[] {
+  const candidatesByNode = new Map<Node, WarningCandidate[]>();
+  for (const candidate of candidates) {
+    const nodeCandidates = candidatesByNode.get(candidate.node) ?? [];
+    nodeCandidates.push(candidate);
+    candidatesByNode.set(candidate.node, nodeCandidates);
+  }
+
+  const containerWarnings = new Set<WarningCandidate>();
+  for (const descendant of candidates) {
+    const ancestors = descendant.ancestors.flatMap(ancestorNode => candidatesByNode.get(ancestorNode) ?? []);
+    for (const ancestor of ancestors) {
+      if (
+        ancestor.warning.type === descendant.warning.type
+        && sharesSide(ancestor.warning.sides, descendant.warning.sides)
+        && strictlyContains(ancestor.warning.element.bounds, descendant.warning.element.bounds)
+      ) {
+        containerWarnings.add(ancestor);
+      }
+    }
+  }
+
   const seen = new Set<string>();
-  return warnings.filter(warning => {
+  return candidates.filter(candidate => !containerWarnings.has(candidate)).filter(({ warning }) => {
     const key = `${warning.type}:${warning.element.viewId ?? warning.element.resourceId ?? warning.element.text ?? "unknown"}:${warning.sides.join(",")}`;
     if (seen.has(key)) {return false;}
     seen.add(key);
     return true;
-  });
+  }).map(candidate => candidate.warning);
+}
+
+function sharesSide(first: Side[], second: Side[]): boolean {
+  return first.some(side => second.includes(side));
+}
+
+function strictlyContains(container: ObservationEdgeInsets, contained: ObservationEdgeInsets): boolean {
+  return container.left <= contained.left
+    && container.top <= contained.top
+    && container.right >= contained.right
+    && container.bottom >= contained.bottom
+    && (container.left < contained.left
+      || container.top < contained.top
+      || container.right > contained.right
+      || container.bottom > contained.bottom);
 }

--- a/src/models/ObservationInsets.ts
+++ b/src/models/ObservationInsets.ts
@@ -43,6 +43,10 @@ export interface LayoutWarning {
   categories: Array<"text" | "interaction">;
   insetTypes: Array<"systemBars" | "displayCutout" | "safeArea" | "systemGestures" | "mandatorySystemGestures">;
   sides: Array<"top" | "right" | "bottom" | "left">;
+  /** Distance the element extends into each reported inset, in observation coordinate units. */
+  overflowPx: Partial<Record<"top" | "right" | "bottom" | "left", number>>;
+  /** Effective inset size for each reported side, in observation coordinate units. */
+  insetPx: Partial<Record<"top" | "right" | "bottom" | "left", number>>;
   overlapPercent: number;
   confidence: "high" | "medium";
 }

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -237,6 +237,8 @@ const layoutWarningSchema = z.object({
   categories: z.array(z.enum(["text", "interaction"])),
   insetTypes: z.array(z.enum(["systemBars", "displayCutout", "safeArea", "systemGestures", "mandatorySystemGestures"])),
   sides: z.array(z.enum(["top", "right", "bottom", "left"])),
+  overflowPx: edgeInsetsSchema.partial(),
+  insetPx: edgeInsetsSchema.partial(),
   overlapPercent: z.number().int(),
   confidence: z.enum(["high", "medium"]),
 });

--- a/test/features/observe/audits/SafeAreaAuditor.test.ts
+++ b/test/features/observe/audits/SafeAreaAuditor.test.ts
@@ -150,6 +150,39 @@ describe("SafeAreaAuditor", () => {
     }]);
   });
 
+  test("includes the effective inset and overflow for each reported side", () => {
+    const warnings = new SafeAreaAuditor().inspect(observation());
+
+    expect(warnings).toMatchObject([
+      { element: { viewId: "title" }, overflowPx: { top: 12 }, insetPx: { top: 20 } },
+      { element: { viewId: "continue" }, overflowPx: { bottom: 16 }, insetPx: { bottom: 20 } },
+    ]);
+  });
+
+  test("collapses an under-inset container into its flagged leaf", () => {
+    const result = observation();
+    result.screenSize = { width: 1440, height: 3120 };
+    result.insets!.systemBars!.visible = { top: 0, right: 0, bottom: 84, left: 0 };
+    result.viewHierarchy!.hierarchy.node = [{
+      clickable: "true",
+      bounds: { left: 0, top: 2987, right: 1440, bottom: 3120 },
+      node: [{
+        text: "Row 19",
+        bounds: { left: 56, top: 3036, right: 521, bottom: 3106 },
+      }],
+    }] as any;
+
+    expect(new SafeAreaAuditor().inspect(result)).toEqual([
+      expect.objectContaining({
+        element: expect.objectContaining({ text: "Row 19" }),
+        sides: ["bottom"],
+        overflowPx: { bottom: 70 },
+        insetPx: { bottom: 84 },
+        overlapPercent: 100,
+      }),
+    ]);
+  });
+
   test("returns no warnings when measurements are unavailable", () => {
     const result = observation();
     result.insets = { available: false, source: "unavailable", units: "unknown" };

--- a/test/features/observe/audits/SafeAreaAuditor.test.ts
+++ b/test/features/observe/audits/SafeAreaAuditor.test.ts
@@ -183,6 +183,39 @@ describe("SafeAreaAuditor", () => {
     ]);
   });
 
+  test("collapses an equal-bounds container into its flagged leaf", () => {
+    const result = observation();
+    result.viewHierarchy!.hierarchy.node = [{
+      clickable: "true",
+      bounds: { left: 1, top: 180, right: 99, bottom: 199 },
+      node: [{
+        text: "Label",
+        bounds: { left: 1, top: 180, right: 99, bottom: 199 },
+      }],
+    }] as any;
+
+    expect(new SafeAreaAuditor().inspect(result)).toEqual([
+      expect.objectContaining({ element: expect.objectContaining({ text: "Label" }), sides: ["bottom"] }),
+    ]);
+  });
+
+  test("keeps an ancestor warning when its leaf does not cover every unsafe side", () => {
+    const result = observation();
+    result.viewHierarchy!.hierarchy.node = [{
+      clickable: "true",
+      bounds: { left: 1, top: 10, right: 99, bottom: 195 },
+      node: [{
+        text: "Label",
+        bounds: { left: 1, top: 180, right: 99, bottom: 195 },
+      }],
+    }] as any;
+
+    expect(new SafeAreaAuditor().inspect(result)).toMatchObject([
+      { element: { bounds: { left: 1, top: 10, right: 99, bottom: 195 } }, sides: ["top", "bottom"] },
+      { element: { text: "Label" }, sides: ["bottom"] },
+    ]);
+  });
+
   test("returns no warnings when measurements are unavailable", () => {
     const result = observation();
     result.insets = { available: false, source: "unavailable", units: "unknown" };

--- a/test/features/observe/output/diffObserveResult.test.ts
+++ b/test/features/observe/output/diffObserveResult.test.ts
@@ -426,6 +426,8 @@ describe("diffObserveResult", () => {
       categories: ["text"],
       insetTypes: ["safeArea"],
       sides: ["top"],
+      overflowPx: { top: 30 },
+      insetPx: { top: 59.5 },
       overlapPercent: 100,
       confidence: "high",
     } as const;

--- a/test/server/observeOutputSchema.test.ts
+++ b/test/server/observeOutputSchema.test.ts
@@ -66,12 +66,18 @@ describe("observeResultSchema: parses real captures (#3025)", () => {
         categories: ["text"],
         insetTypes: ["safeArea"],
         sides: ["top"],
+        overflowPx: { top: 30 },
+        insetPx: { top: 59.5 },
         overlapPercent: 100,
         confidence: "high",
       }],
     });
 
     expect(parsed.success).toBe(true);
+    expect(parsed.data?.layoutWarnings?.[0]).toMatchObject({
+      overflowPx: { top: 30 },
+      insetPx: { top: 59.5 },
+    });
   });
 
   test("accepts nullable Android inset categories", () => {
@@ -113,6 +119,8 @@ describe("observeResultSchema: parses real captures (#3025)", () => {
         categories: ["text"],
         insetTypes: ["safeArea"],
         sides: ["top"],
+        overflowPx: { top: 30 },
+        insetPx: { top: 59.5 },
         overlapPercent: 100,
         confidence: "high",
       }],

--- a/test/utils/ProcessExecutor.test.ts
+++ b/test/utils/ProcessExecutor.test.ts
@@ -11,7 +11,10 @@ import { DefaultHostCommandExecutor } from "../../src/utils/HostCommandExecutor"
 // The bulk of these assertions inject a fake exec seam so they never spawn a real
 // subprocess — real forks stall past a 30s timeout on contended CI runners (#2914).
 // A single retry-tolerant smoke test (bottom of the file) still exercises a real spawn.
-const FAST_TEST_TIMEOUT_MS = 100;
+// The injected seams complete in under 1ms, but a 100ms deadline flakes when the
+// full parallel suite pauses this worker. Keep a short bound without coupling
+// correctness to CI scheduler latency.
+const FAST_TEST_TIMEOUT_MS = 1_000;
 // Real subprocess smoke test only; forking under CI load can take seconds.
 const SMOKE_TEST_TIMEOUT_MS = 30_000;
 


### PR DESCRIPTION
## Summary
- Add per-edge overflow and inset measurements to safe-area warnings.
- Prefer nested leaf findings while preserving warnings on additional unsafe edges.
- Cover equal-bounds and multi-edge warning scenarios.

## Validation
- `bun test test/features/observe/audits/SafeAreaAuditor.test.ts test/server/observeOutputSchema.test.ts test/features/observe/output/diffObserveResult.test.ts`
- `node_modules/.bin/eslint src/features/observe/audits/SafeAreaAuditor.ts test/features/observe/audits/SafeAreaAuditor.test.ts`
- `bun run build`
