### PR TITLE
feat(observe): add system chrome context

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -34,6 +34,7 @@ import dev.jasonpearson.automobile.ctrlproxy.models.ObservationInsetsInfo
 import dev.jasonpearson.automobile.ctrlproxy.models.RecompositionSnapshot
 import dev.jasonpearson.automobile.ctrlproxy.models.ScreenDimensions
 import dev.jasonpearson.automobile.ctrlproxy.models.SystemBarsInsetsInfo
+import dev.jasonpearson.automobile.ctrlproxy.models.SystemChromeInfo
 import dev.jasonpearson.automobile.ctrlproxy.models.SystemInsetsInfo
 import dev.jasonpearson.automobile.ctrlproxy.models.UIElementInfo
 import dev.jasonpearson.automobile.ctrlproxy.models.ViewHierarchy
@@ -1792,6 +1793,13 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           tappableElement =
             toSystemInsetsInfo(
               windowInsets.getInsets(android.view.WindowInsets.Type.tappableElement())
+            ),
+          systemChrome =
+            SystemChromeInfo.fromAndroidBars(
+              statusBarVisible =
+                windowInsets.isVisible(android.view.WindowInsets.Type.statusBars()),
+              navigationBarVisible =
+                windowInsets.isVisible(android.view.WindowInsets.Type.navigationBars()),
             ),
         )
       } else {

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/models/SystemInsetsInfo.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/models/SystemInsetsInfo.kt
@@ -18,6 +18,36 @@ data class SystemBarsInsetsInfo(
   val stable: SystemInsetsInfo,
 )
 
+/** Current system-chrome visibility, distinct from edge-to-edge layout policy. */
+@Serializable
+data class SystemChromeInfo(
+  val visibility: String,
+  val statusBar: String,
+  val navigationBar: String? = null,
+  val homeIndicatorAutoHideRequested: Boolean? = null,
+  val source: String,
+) {
+  companion object {
+    fun fromAndroidBars(
+      statusBarVisible: Boolean,
+      navigationBarVisible: Boolean,
+    ): SystemChromeInfo {
+      val visibility =
+        when {
+          statusBarVisible && navigationBarVisible -> "visible"
+          !statusBarVisible && !navigationBarVisible -> "hidden"
+          else -> "partial"
+        }
+      return SystemChromeInfo(
+        visibility = visibility,
+        statusBar = if (statusBarVisible) "visible" else "hidden",
+        navigationBar = if (navigationBarVisible) "visible" else "hidden",
+        source = "android-window-insets",
+      )
+    }
+  }
+}
+
 /** Complete, typed inset snapshot captured with an accessibility hierarchy. */
 @Serializable
 data class ObservationInsetsInfo(
@@ -29,4 +59,5 @@ data class ObservationInsetsInfo(
   val systemGestures: SystemInsetsInfo? = null,
   val mandatorySystemGestures: SystemInsetsInfo? = null,
   val tappableElement: SystemInsetsInfo? = null,
+  val systemChrome: SystemChromeInfo? = null,
 )

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyInsetsTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyInsetsTest.kt
@@ -2,6 +2,7 @@ package dev.jasonpearson.automobile.ctrlproxy
 
 import dev.jasonpearson.automobile.ctrlproxy.models.ObservationInsetsInfo
 import dev.jasonpearson.automobile.ctrlproxy.models.SystemBarsInsetsInfo
+import dev.jasonpearson.automobile.ctrlproxy.models.SystemChromeInfo
 import dev.jasonpearson.automobile.ctrlproxy.models.SystemInsetsInfo
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -23,5 +24,36 @@ class CtrlProxyInsetsTest {
       )
 
     assertEquals(SystemInsetsInfo(top = 24, bottom = 48, left = 32, right = 32), result)
+  }
+
+  @Test
+  fun `system chrome classifies all combinations of status and navigation visibility`() {
+    assertEquals(
+      SystemChromeInfo(
+        visibility = "visible",
+        statusBar = "visible",
+        navigationBar = "visible",
+        source = "android-window-insets",
+      ),
+      SystemChromeInfo.fromAndroidBars(statusBarVisible = true, navigationBarVisible = true),
+    )
+    assertEquals(
+      SystemChromeInfo(
+        visibility = "partial",
+        statusBar = "visible",
+        navigationBar = "hidden",
+        source = "android-window-insets",
+      ),
+      SystemChromeInfo.fromAndroidBars(statusBarVisible = true, navigationBarVisible = false),
+    )
+    assertEquals(
+      SystemChromeInfo(
+        visibility = "hidden",
+        statusBar = "hidden",
+        navigationBar = "hidden",
+        source = "android-window-insets",
+      ),
+      SystemChromeInfo.fromAndroidBars(statusBarVisible = false, navigationBarVisible = false),
+    )
   }
 }

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyInsetsTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyInsetsTest.kt
@@ -48,6 +48,15 @@ class CtrlProxyInsetsTest {
     )
     assertEquals(
       SystemChromeInfo(
+        visibility = "partial",
+        statusBar = "hidden",
+        navigationBar = "visible",
+        source = "android-window-insets",
+      ),
+      SystemChromeInfo.fromAndroidBars(statusBarVisible = false, navigationBarVisible = true),
+    )
+    assertEquals(
+      SystemChromeInfo(
         visibility = "hidden",
         statusBar = "hidden",
         navigationBar = "hidden",

--- a/docs/design-docs/mcp/observe/index.md
+++ b/docs/design-docs/mcp/observe/index.md
@@ -13,7 +13,7 @@ All collected data is assembled into an object containing (fields may be omitted
 
 - `updatedAt`: device timestamp (or server timestamp fallback)
 - `screenSize`: current screen dimensions (rotation-aware)
-- `insets`: typed safe-area and system-inset snapshot, including availability, source, units, system bars, cutouts, and Android gesture regions when available
+- `insets`: typed safe-area and system-inset snapshot, including availability, source, units, system bars, cutouts, Android gesture regions, and current system-chrome visibility when available
 - `systemInsets`: compatibility alias for the stable system-bar edges; prefer `insets` for new consumers
 - `rotation`: current device rotation value
 - `activeWindow`: current app/activity information when resolved
@@ -28,6 +28,15 @@ All collected data is assembled into an object containing (fields may be omitted
 - `error`: error messages encountered during observation
 
 Start AutoMobile with `--safe-area-warnings` or its equivalent alias `--edge-to-edge-warnings` to add report-only `layoutWarnings`. These flag text or interactive elements that may overlap safe areas, system bars, display cutouts, or Android gesture regions. Each warning includes `overflowPx` (how far the element extends into the unsafe region) and `insetPx` (the effective inset on that side), both in the observation's coordinate units. When a flagged descendant is fully contained by a flagged ancestor on the same unsafe side, the output keeps the descendant finding. Intentional edge-to-edge backgrounds and scrollable content remain advisory rather than failures.
+
+When available, `insets.systemChrome` provides the system-chrome state that explains a
+safe-area warning's screen context. Android reports the current visibility of the status
+and navigation bars from `WindowInsets`; hidden bars do not become additional unsafe
+regions. iOS reports actual status-bar visibility from the foreground `UIWindowScene` and
+may include the visible controller's home-indicator auto-hide preference. That preference is
+an app request, not proof that the home indicator is currently hidden. Older runners omit
+`systemChrome`, so clients must treat its absence as unknown rather than inferring it from
+zero insets.
 
 The observation gracefully handles various error conditions:
 

--- a/docs/design-docs/mcp/observe/index.md
+++ b/docs/design-docs/mcp/observe/index.md
@@ -34,9 +34,9 @@ safe-area warning's screen context. Android reports the current visibility of th
 and navigation bars from `WindowInsets`; hidden bars do not become additional unsafe
 regions. iOS reports actual status-bar visibility from the foreground `UIWindowScene` and
 may include the visible controller's home-indicator auto-hide preference. That preference is
-an app request, not proof that the home indicator is currently hidden. Older runners omit
-`systemChrome`, so clients must treat its absence as unknown rather than inferring it from
-zero insets.
+an app request, not proof that the home indicator is currently hidden. Older Android runners
+and iOS apps built with an older AutoMobile SDK omit `systemChrome`, so clients must treat its
+absence as unknown rather than inferring it from zero insets.
 
 The observation gracefully handles various error conditions:
 

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkViewNode.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/SdkViewNode.swift
@@ -11,6 +11,8 @@ public struct SdkViewHierarchy: Codable, Sendable {
     public let screenHeight: Int
     /** UIWindow safe area in the same point coordinate space as view bounds. */
     public let safeAreaInsets: SdkEdgeInsets?
+    /** Current status-bar presentation for this app window. */
+    public let systemChrome: SdkSystemChrome?
     public let root: SdkViewNode?
 
     public init(
@@ -20,6 +22,7 @@ public struct SdkViewHierarchy: Codable, Sendable {
         screenWidth: Int,
         screenHeight: Int,
         safeAreaInsets: SdkEdgeInsets? = nil,
+        systemChrome: SdkSystemChrome? = nil,
         root: SdkViewNode?
     ) {
         self.timestamp = timestamp
@@ -28,6 +31,7 @@ public struct SdkViewHierarchy: Codable, Sendable {
         self.screenWidth = screenWidth
         self.screenHeight = screenHeight
         self.safeAreaInsets = safeAreaInsets
+        self.systemChrome = systemChrome
         self.root = root
     }
 }
@@ -43,6 +47,27 @@ public struct SdkEdgeInsets: Codable, Sendable {
         self.right = right
         self.bottom = bottom
         self.left = left
+    }
+}
+
+/** System-chrome presentation captured from the foreground app's UIWindowScene. */
+public struct SdkSystemChrome: Codable, Sendable {
+    public let visibility: String
+    public let statusBar: String
+    /** The top view controller's preference, not observed home-indicator visibility. */
+    public let homeIndicatorAutoHideRequested: Bool?
+    public let source: String
+
+    public init(
+        visibility: String,
+        statusBar: String,
+        homeIndicatorAutoHideRequested: Bool? = nil,
+        source: String
+    ) {
+        self.visibility = visibility
+        self.statusBar = statusBar
+        self.homeIndicatorAutoHideRequested = homeIndicatorAutoHideRequested
+        self.source = source
     }
 }
 

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/ViewHierarchyWalker.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/ViewHierarchy/ViewHierarchyWalker.swift
@@ -32,6 +32,7 @@ public enum ViewHierarchyWalker {
                 left: Double($0.safeAreaInsets.left)
             )
         }
+        let systemChrome = keyWindow.flatMap(systemChrome(for:))
 
         return SdkViewHierarchy(
             bundleId: bundleId,
@@ -39,6 +40,7 @@ public enum ViewHierarchyWalker {
             screenWidth: screenWidth,
             screenHeight: screenHeight,
             safeAreaInsets: safeAreaInsets,
+            systemChrome: systemChrome,
             root: rootNode
         )
     }
@@ -60,6 +62,15 @@ public enum ViewHierarchyWalker {
             hasher.combine(safeAreaInsets.right)
             hasher.combine(safeAreaInsets.bottom)
             hasher.combine(safeAreaInsets.left)
+        } else {
+            hasher.combine(false)
+        }
+        if let systemChrome = hierarchy.systemChrome {
+            hasher.combine(true)
+            hasher.combine(systemChrome.visibility)
+            hasher.combine(systemChrome.statusBar)
+            hasher.combine(systemChrome.homeIndicatorAutoHideRequested)
+            hasher.combine(systemChrome.source)
         } else {
             hasher.combine(false)
         }
@@ -88,6 +99,54 @@ public enum ViewHierarchyWalker {
                 if a.windowLevel != b.windowLevel { return a.windowLevel < b.windowLevel }
                 return !a.isKeyWindow && b.isKeyWindow
             })
+    }
+
+    private static func systemChrome(for window: UIWindow) -> SdkSystemChrome? {
+        guard #available(iOS 13.0, *),
+              let statusBarManager = window.windowScene?.statusBarManager
+        else {
+            return nil
+        }
+
+        let statusBarHidden = statusBarManager.isStatusBarHidden
+        let homeIndicatorAutoHideRequested = visibleViewController(from: window.rootViewController)?
+            .prefersHomeIndicatorAutoHidden
+        return systemChrome(
+            statusBarHidden: statusBarHidden,
+            homeIndicatorAutoHideRequested: homeIndicatorAutoHideRequested
+        )
+    }
+
+    static func systemChrome(
+        statusBarHidden: Bool,
+        homeIndicatorAutoHideRequested: Bool?
+    ) -> SdkSystemChrome {
+        return SdkSystemChrome(
+            visibility: statusBarHidden ? "hidden" : "visible",
+            statusBar: statusBarHidden ? "hidden" : "visible",
+            homeIndicatorAutoHideRequested: homeIndicatorAutoHideRequested,
+            source: "ios-status-bar-manager"
+        )
+    }
+
+    private static func visibleViewController(from controller: UIViewController?) -> UIViewController? {
+        guard let controller else { return nil }
+        if let presented = controller.presentedViewController, !presented.isBeingDismissed {
+            return visibleViewController(from: presented)
+        }
+        if let navigation = controller as? UINavigationController {
+            return visibleViewController(from: navigation.visibleViewController)
+        }
+        if let tab = controller as? UITabBarController {
+            return visibleViewController(from: tab.selectedViewController)
+        }
+        if let split = controller as? UISplitViewController {
+            return visibleViewController(from: split.viewControllers.last)
+        }
+        if let page = controller as? UIPageViewController {
+            return visibleViewController(from: page.viewControllers?.last)
+        }
+        return controller
     }
 
     private static func walkWindow(_ keyWindow: UIWindow) -> SdkViewNode? {

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/ViewHierarchyTrackerTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/ViewHierarchyTrackerTests.swift
@@ -116,5 +116,48 @@ final class ViewHierarchyTrackerTests: XCTestCase {
         XCTAssertNotEqual(ViewHierarchyWalker.computeHash(baseline), ViewHierarchyWalker.computeHash(changedInsets))
         XCTAssertNotEqual(ViewHierarchyWalker.computeHash(baseline), ViewHierarchyWalker.computeHash(changedDimensions))
     }
+
+    func testHashChangesWhenSystemChromeVisibilityChanges() {
+        let baseline = SdkViewHierarchy(
+            screenScale: 3,
+            screenWidth: 390,
+            screenHeight: 844,
+            systemChrome: SdkSystemChrome(
+                visibility: "visible",
+                statusBar: "visible",
+                homeIndicatorAutoHideRequested: false,
+                source: "ios-status-bar-manager"
+            ),
+            root: nil
+        )
+        let hiddenChrome = SdkViewHierarchy(
+            screenScale: 3,
+            screenWidth: 390,
+            screenHeight: 844,
+            systemChrome: SdkSystemChrome(
+                visibility: "hidden",
+                statusBar: "hidden",
+                homeIndicatorAutoHideRequested: true,
+                source: "ios-status-bar-manager"
+            ),
+            root: nil
+        )
+
+        XCTAssertNotEqual(ViewHierarchyWalker.computeHash(baseline), ViewHierarchyWalker.computeHash(hiddenChrome))
+    }
+
+    func testSystemChromeVisibilityUsesObservedStatusBarRatherThanHomeIndicatorPreference() {
+        let visible = ViewHierarchyWalker.systemChrome(
+            statusBarHidden: false,
+            homeIndicatorAutoHideRequested: true
+        )
+        let hidden = ViewHierarchyWalker.systemChrome(
+            statusBarHidden: true,
+            homeIndicatorAutoHideRequested: false
+        )
+
+        XCTAssertEqual(visible.visibility, "visible")
+        XCTAssertEqual(hidden.visibility, "hidden")
+    }
 }
 #endif

--- a/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -528,14 +528,21 @@ public struct SdkViewHierarchy: Codable, Sendable
   public let screenWidth: Int
   public let screenHeight: Int
   public let safeAreaInsets: SdkEdgeInsets?
+  public let systemChrome: SdkSystemChrome?
   public let root: SdkViewNode?
-  public init( timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000), bundleId: String? = nil, screenScale: Float, screenWidth: Int, screenHeight: Int, safeAreaInsets: SdkEdgeInsets? = nil, root: SdkViewNode? )
+  public init( timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000), bundleId: String? = nil, screenScale: Float, screenWidth: Int, screenHeight: Int, safeAreaInsets: SdkEdgeInsets? = nil, systemChrome: SdkSystemChrome? = nil, root: SdkViewNode? )
 public struct SdkEdgeInsets: Codable, Sendable
   public let top: Double
   public let right: Double
   public let bottom: Double
   public let left: Double
   public init(top: Double, right: Double, bottom: Double, left: Double)
+public struct SdkSystemChrome: Codable, Sendable
+  public let visibility: String
+  public let statusBar: String
+  public let homeIndicatorAutoHideRequested: Bool?
+  public let source: String
+  public init( visibility: String, statusBar: String, homeIndicatorAutoHideRequested: Bool? = nil, source: String )
 public struct SdkViewNode: Codable, Sendable
   public let className: String
   public let bounds: SdkBounds

--- a/ios/control-proxy/Sources/CtrlProxy/CtrlProxy.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CtrlProxy.swift
@@ -17,6 +17,7 @@ public class CtrlProxy {
     private let sdkHierarchyCache: SdkHierarchyCache
     private let sdkHierarchyClient: SdkHierarchyClient
     private let sdkDatabaseClient: SdkDatabaseClient
+    private let sdkHierarchyRefreshPublisher: SdkHierarchyRefreshPublisher
 
     #if canImport(XCTest) && os(iOS)
         private var application: XCUIApplication?
@@ -45,6 +46,20 @@ public class CtrlProxy {
         )
         server = WebSocketServer(port: port, commandHandler: commandHandler, sdkHierarchyCache: sdkHierarchyCache)
         fpsMonitor = DisplayLinkFPSMonitor()
+        sdkHierarchyRefreshPublisher = SdkHierarchyRefreshPublisher(
+            hierarchyProvider: { [weak hierarchyDebouncer] in
+                hierarchyDebouncer?.getLastHierarchy()
+            },
+            enrich: { [weak commandHandler] hierarchy in
+                commandHandler?.enrichWithCachedSdkHierarchy(hierarchy) ?? hierarchy
+            },
+            broadcast: { [weak server] hierarchy in
+                server?.broadcastHierarchyUpdate(hierarchy)
+            }
+        )
+        server.onSdkHierarchyUpdated = { [weak self] in
+            self?.sdkHierarchyRefreshPublisher.publish()
+        }
     }
 
     #if canImport(XCTest) && os(iOS)

--- a/ios/control-proxy/Sources/CtrlProxy/HierarchyMerger.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/HierarchyMerger.swift
@@ -20,9 +20,26 @@ public enum HierarchyMerger {
         let safeArea = sdk.safeAreaInsets.map {
             EdgeInsetsInfo(top: $0.top, right: $0.right, bottom: $0.bottom, left: $0.left)
         }
-        let enrichedInsets = safeArea.map {
-            ObservationInsetsInfo(available: true, source: "ios-sdk-safe-area", units: "points", safeArea: $0)
-        } ?? xcuitest.insets
+        let systemChrome = sdk.systemChrome.map {
+            SystemChromeInfo(
+                visibility: $0.visibility,
+                statusBar: $0.statusBar,
+                homeIndicatorAutoHideRequested: $0.homeIndicatorAutoHideRequested,
+                source: $0.source
+            )
+        }
+        let enrichedInsets =
+            if safeArea != nil || systemChrome != nil {
+                ObservationInsetsInfo(
+                    available: true,
+                    source: "ios-sdk-safe-area",
+                    units: "points",
+                    safeArea: safeArea,
+                    systemChrome: systemChrome
+                )
+            } else {
+                xcuitest.insets
+            }
         guard let sdkRoot = sdk.root else {
             return ViewHierarchy(
                 updatedAt: xcuitest.updatedAt,

--- a/ios/control-proxy/Sources/CtrlProxy/HierarchyMerger.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/HierarchyMerger.swift
@@ -29,12 +29,20 @@ public enum HierarchyMerger {
             )
         }
         let enrichedInsets =
-            if safeArea != nil || systemChrome != nil {
+            if let safeArea {
                 ObservationInsetsInfo(
                     available: true,
                     source: "ios-sdk-safe-area",
                     units: "points",
                     safeArea: safeArea,
+                    systemChrome: systemChrome
+                )
+            } else if let systemChrome {
+                ObservationInsetsInfo(
+                    available: xcuitest.insets.available,
+                    source: xcuitest.insets.source,
+                    units: xcuitest.insets.units,
+                    safeArea: xcuitest.insets.safeArea,
                     systemChrome: systemChrome
                 )
             } else {

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -967,13 +967,37 @@ public struct ObservationInsetsInfo: Codable, Sendable {
     public let source: String
     public let units: String
     public let safeArea: EdgeInsetsInfo?
+    public let systemChrome: SystemChromeInfo?
 
     public static let unavailable = ObservationInsetsInfo(
         available: false,
         source: "unavailable",
         units: "unknown",
-        safeArea: nil
+        safeArea: nil,
+        systemChrome: nil
     )
+}
+
+public struct SystemChromeInfo: Codable, Sendable {
+    public let visibility: String
+    public let statusBar: String
+    public let navigationBar: String?
+    public let homeIndicatorAutoHideRequested: Bool?
+    public let source: String
+
+    public init(
+        visibility: String,
+        statusBar: String,
+        navigationBar: String? = nil,
+        homeIndicatorAutoHideRequested: Bool? = nil,
+        source: String
+    ) {
+        self.visibility = visibility
+        self.statusBar = statusBar
+        self.navigationBar = navigationBar
+        self.homeIndicatorAutoHideRequested = homeIndicatorAutoHideRequested
+        self.source = source
+    }
 }
 
 /// Window information

--- a/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyCache.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyCache.swift
@@ -25,6 +25,31 @@ public final class SdkHierarchyCache: SdkHierarchyCaching, @unchecked Sendable {
     }
 }
 
+/// Re-emits the latest XCUITest hierarchy after an SDK-only change.
+///
+/// The XCUITest structural hash does not include in-process SDK metadata, so
+/// chrome-only changes need this explicit path to refresh normal observations.
+final class SdkHierarchyRefreshPublisher {
+    private let hierarchyProvider: () -> ViewHierarchy?
+    private let enrich: (ViewHierarchy) -> ViewHierarchy
+    private let broadcast: (ViewHierarchy) -> Void
+
+    init(
+        hierarchyProvider: @escaping () -> ViewHierarchy?,
+        enrich: @escaping (ViewHierarchy) -> ViewHierarchy,
+        broadcast: @escaping (ViewHierarchy) -> Void
+    ) {
+        self.hierarchyProvider = hierarchyProvider
+        self.enrich = enrich
+        self.broadcast = broadcast
+    }
+
+    func publish() {
+        guard let hierarchy = hierarchyProvider() else { return }
+        broadcast(enrich(hierarchy))
+    }
+}
+
 // MARK: - Extraction from SDK Event Batches
 
 /// Extracts `view_hierarchy` events from SDK event batches POSTed to `/sdk-events`
@@ -36,17 +61,26 @@ public enum SdkHierarchyExtractor {
 
     /// Try to extract a view hierarchy event from the raw batch data.
     /// Called on every `POST /sdk-events` — skips full decode when no hierarchy event is present.
-    public static func extractIfPresent(from batchData: Data, into cache: any SdkHierarchyCaching) {
+    public static func extractIfPresent(
+        from batchData: Data,
+        into cache: any SdkHierarchyCaching,
+        onHierarchyUpdated: (() -> Void)? = nil
+    ) {
         // Fast path: skip full JSON decode if batch doesn't contain a hierarchy event
         guard let jsonString = String(data: batchData, encoding: .utf8),
               jsonString.contains(viewHierarchyEventType) else { return }
 
         guard let batch = try? JSONDecoder().decode(SdkEventBatchEnvelope.self, from: batchData) else { return }
 
+        var didUpdateHierarchy = false
         for event in batch.events where event.eventType == viewHierarchyEventType {
             if let hierarchy = try? JSONDecoder().decode(SdkViewHierarchyEventPayload.self, from: event.payload) {
                 cache.update(hierarchy.hierarchy)
+                didUpdateHierarchy = true
             }
+        }
+        if didUpdateHierarchy {
+            onHierarchyUpdated?()
         }
     }
 }

--- a/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyModels.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/SdkHierarchyModels.swift
@@ -11,6 +11,7 @@ public struct SdkViewHierarchy: Codable, Sendable {
     public let screenWidth: Int
     public let screenHeight: Int
     public let safeAreaInsets: SdkEdgeInsets?
+    public let systemChrome: SdkSystemChrome?
     public let root: SdkViewNode?
 
     public init(
@@ -20,6 +21,7 @@ public struct SdkViewHierarchy: Codable, Sendable {
         screenWidth: Int,
         screenHeight: Int,
         safeAreaInsets: SdkEdgeInsets? = nil,
+        systemChrome: SdkSystemChrome? = nil,
         root: SdkViewNode?
     ) {
         self.timestamp = timestamp
@@ -28,6 +30,7 @@ public struct SdkViewHierarchy: Codable, Sendable {
         self.screenWidth = screenWidth
         self.screenHeight = screenHeight
         self.safeAreaInsets = safeAreaInsets
+        self.systemChrome = systemChrome
         self.root = root
     }
 }
@@ -37,6 +40,13 @@ public struct SdkEdgeInsets: Codable, Sendable {
     public let right: Double
     public let bottom: Double
     public let left: Double
+}
+
+public struct SdkSystemChrome: Codable, Sendable {
+    public let visibility: String
+    public let statusBar: String
+    public let homeIndicatorAutoHideRequested: Bool?
+    public let source: String
 }
 
 /// Lightweight metadata exposed by the SDK hierarchy server.

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -112,6 +112,7 @@ public class WebSocketServer: WebSocketServing {
     private let perfProvider: PerfProvider
     private let sdkHierarchyCache: SdkHierarchyCache?
     private let queue = DispatchQueue(label: "com.ctrlproxy.server")
+    var onSdkHierarchyUpdated: (() -> Void)?
 
     public var isRunning: Bool {
         listener != nil
@@ -183,7 +184,10 @@ public class WebSocketServer: WebSocketServing {
             connection: nwConnection,
             queue: queue,
             boundPort: port,
-            sdkHierarchyCache: sdkHierarchyCache
+            sdkHierarchyCache: sdkHierarchyCache,
+            onSdkHierarchyUpdated: { [weak self] in
+                self?.onSdkHierarchyUpdated?()
+            }
         ) { [weak self] message in
             self?.handleMessage(message, connectionId: connectionId)
         } onClose: { [weak self] in
@@ -517,6 +521,7 @@ class WebSocketConnection: WebSocketResponding {
     private let onMessage: (Data) -> Void
     private let onClose: () -> Void
     private let sdkHierarchyCache: (any SdkHierarchyCaching)?
+    private let onSdkHierarchyUpdated: (() -> Void)?
     /// The port the server is actually bound to; echoed in /health so the daemon
     /// can detect a runner/client port mismatch (issue #2735).
     private let boundPort: UInt16
@@ -528,6 +533,7 @@ class WebSocketConnection: WebSocketResponding {
         queue: DispatchQueue,
         boundPort: UInt16,
         sdkHierarchyCache: (any SdkHierarchyCaching)? = nil,
+        onSdkHierarchyUpdated: (() -> Void)? = nil,
         onMessage: @escaping (Data) -> Void,
         onClose: @escaping () -> Void
     ) {
@@ -536,6 +542,7 @@ class WebSocketConnection: WebSocketResponding {
         self.queue = queue
         self.boundPort = boundPort
         self.sdkHierarchyCache = sdkHierarchyCache
+        self.onSdkHierarchyUpdated = onSdkHierarchyUpdated
         self.onMessage = onMessage
         self.onClose = onClose
     }
@@ -633,7 +640,11 @@ class WebSocketConnection: WebSocketResponding {
             if let bodyData = body.data(using: .utf8), !bodyData.isEmpty {
                 SdkEventBuffer.shared.append(bodyData)
                 if let cache = sdkHierarchyCache {
-                    SdkHierarchyExtractor.extractIfPresent(from: bodyData, into: cache)
+                    SdkHierarchyExtractor.extractIfPresent(
+                        from: bodyData,
+                        into: cache,
+                        onHierarchyUpdated: onSdkHierarchyUpdated
+                    )
                 }
                 print("[CtrlProxy] Received SDK event batch (\(bodyData.count) bytes)")
             } else {

--- a/ios/control-proxy/Tests/CtrlProxyTests/HierarchyMergerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/HierarchyMergerTests.swift
@@ -158,6 +158,39 @@ final class HierarchyMergerTests: XCTestCase {
         XCTAssertEqual(result.insets.systemChrome?.source, "ios-status-bar-manager")
     }
 
+    func testMergeChromeOnlySdkPayloadPreservesUnavailableInsetMetadata() {
+        let hierarchy = ViewHierarchy(
+            packageName: "com.test.app",
+            hierarchy: makeElement(text: "Hello"),
+            screenScale: 3.0,
+            screenWidth: 375,
+            screenHeight: 812,
+            insets: .unavailable
+        )
+        let sdkHierarchy = SdkViewHierarchy(
+            timestamp: 1000,
+            bundleId: "com.test.app",
+            screenScale: 3.0,
+            screenWidth: 375,
+            screenHeight: 812,
+            systemChrome: SdkSystemChrome(
+                visibility: "hidden",
+                statusBar: "hidden",
+                homeIndicatorAutoHideRequested: true,
+                source: "ios-status-bar-manager"
+            ),
+            root: nil
+        )
+
+        let result = HierarchyMerger.merge(xcuitest: hierarchy, sdk: sdkHierarchy)
+
+        XCTAssertFalse(result.insets.available)
+        XCTAssertEqual(result.insets.source, "unavailable")
+        XCTAssertEqual(result.insets.units, "unknown")
+        XCTAssertNil(result.insets.safeArea)
+        XCTAssertEqual(result.insets.systemChrome?.visibility, "hidden")
+    }
+
     // MARK: - Exact Match
 
     func testExactBoundsMatch() {

--- a/ios/control-proxy/Tests/CtrlProxyTests/HierarchyMergerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/HierarchyMergerTests.swift
@@ -130,6 +130,34 @@ final class HierarchyMergerTests: XCTestCase {
         XCTAssertNil(result.hierarchy?.extras)
     }
 
+    func testMergePropagatesSdkSystemChromeAlongsideSafeArea() {
+        let root = makeElement(text: "Hello")
+        let hierarchy = makeHierarchy(root: root)
+        let sdkHierarchy = SdkViewHierarchy(
+            timestamp: 1000,
+            bundleId: "com.test.app",
+            screenScale: 3.0,
+            screenWidth: 375,
+            screenHeight: 812,
+            safeAreaInsets: SdkEdgeInsets(top: 59, right: 0, bottom: 34, left: 0),
+            systemChrome: SdkSystemChrome(
+                visibility: "hidden",
+                statusBar: "hidden",
+                homeIndicatorAutoHideRequested: true,
+                source: "ios-status-bar-manager"
+            ),
+            root: nil
+        )
+
+        let result = HierarchyMerger.merge(xcuitest: hierarchy, sdk: sdkHierarchy)
+
+        XCTAssertEqual(result.insets.safeArea?.top, 59)
+        XCTAssertEqual(result.insets.systemChrome?.visibility, "hidden")
+        XCTAssertEqual(result.insets.systemChrome?.statusBar, "hidden")
+        XCTAssertEqual(result.insets.systemChrome?.homeIndicatorAutoHideRequested, true)
+        XCTAssertEqual(result.insets.systemChrome?.source, "ios-status-bar-manager")
+    }
+
     // MARK: - Exact Match
 
     func testExactBoundsMatch() {

--- a/ios/control-proxy/Tests/CtrlProxyTests/SdkHierarchyCacheTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/SdkHierarchyCacheTests.swift
@@ -83,4 +83,52 @@ final class SdkHierarchyCacheTests: XCTestCase {
 
         XCTAssertNil(cache.latest)
     }
+
+    func testHierarchyEventBroadcastsFreshChromeForUnchangedXcuitestHierarchy() throws {
+        let cache = SdkHierarchyCache()
+        let xcuitest = ViewHierarchy(
+            packageName: "com.test.app",
+            hierarchy: UIElementInfo(
+                className: "UIView",
+                bounds: ElementBounds(left: 0, top: 0, right: 375, bottom: 812)
+            ),
+            insets: .unavailable
+        )
+        var broadcasts: [ViewHierarchy] = []
+        let publisher = SdkHierarchyRefreshPublisher(
+            hierarchyProvider: { xcuitest },
+            enrich: { HierarchyMerger.merge(xcuitest: $0, sdk: cache.latest) },
+            broadcast: { broadcasts.append($0) }
+        )
+        let hierarchy = SdkViewHierarchy(
+            timestamp: 1000,
+            bundleId: "com.test.app",
+            screenScale: 3,
+            screenWidth: 375,
+            screenHeight: 812,
+            systemChrome: SdkSystemChrome(
+                visibility: "hidden",
+                statusBar: "hidden",
+                homeIndicatorAutoHideRequested: true,
+                source: "ios-status-bar-manager"
+            ),
+            root: nil
+        )
+        let payload = try JSONEncoder().encode(["hierarchy": hierarchy])
+        let batch = Data(
+            """
+            {"events":[{"eventType":"view_hierarchy","payload":"\(payload.base64EncodedString())"}]}
+            """.utf8
+        )
+
+        SdkHierarchyExtractor.extractIfPresent(
+            from: batch,
+            into: cache,
+            onHierarchyUpdated: publisher.publish
+        )
+
+        XCTAssertEqual(broadcasts.count, 1)
+        XCTAssertFalse(broadcasts[0].insets.available)
+        XCTAssertEqual(broadcasts[0].insets.systemChrome?.visibility, "hidden")
+    }
 }

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3897,7 +3897,14 @@
                       ]
                     },
                     "homeIndicatorAutoHideRequested": {
-                      "type": "boolean"
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
                     },
                     "source": {
                       "type": "string",
@@ -4524,7 +4531,14 @@
                           ]
                         },
                         "homeIndicatorAutoHideRequested": {
-                          "type": "boolean"
+                          "anyOf": [
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
                         },
                         "source": {
                           "type": "string",

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3867,50 +3867,57 @@
               "additionalProperties": false
             },
             "systemChrome": {
-              "type": "object",
-              "properties": {
-                "visibility": {
-                  "type": "string",
-                  "enum": [
-                    "visible",
-                    "hidden",
-                    "partial",
-                    "unknown"
-                  ]
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "visibility": {
+                      "type": "string",
+                      "enum": [
+                        "visible",
+                        "hidden",
+                        "partial",
+                        "unknown"
+                      ]
+                    },
+                    "statusBar": {
+                      "type": "string",
+                      "enum": [
+                        "visible",
+                        "hidden",
+                        "unknown"
+                      ]
+                    },
+                    "navigationBar": {
+                      "type": "string",
+                      "enum": [
+                        "visible",
+                        "hidden",
+                        "unknown"
+                      ]
+                    },
+                    "homeIndicatorAutoHideRequested": {
+                      "type": "boolean"
+                    },
+                    "source": {
+                      "type": "string",
+                      "enum": [
+                        "android-window-insets",
+                        "ios-status-bar-manager"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "visibility",
+                    "statusBar",
+                    "source"
+                  ],
+                  "additionalProperties": false
                 },
-                "statusBar": {
-                  "type": "string",
-                  "enum": [
-                    "visible",
-                    "hidden",
-                    "unknown"
-                  ]
-                },
-                "navigationBar": {
-                  "type": "string",
-                  "enum": [
-                    "visible",
-                    "hidden",
-                    "unknown"
-                  ]
-                },
-                "homeIndicatorAutoHideRequested": {
-                  "type": "boolean"
-                },
-                "source": {
-                  "type": "string",
-                  "enum": [
-                    "android-window-insets",
-                    "ios-status-bar-manager"
-                  ]
+                {
+                  "type": "null"
                 }
-              },
-              "required": [
-                "visibility",
-                "statusBar",
-                "source"
-              ],
-              "additionalProperties": false
+              ]
             }
           },
           "required": [
@@ -4487,50 +4494,57 @@
                   "additionalProperties": false
                 },
                 "systemChrome": {
-                  "type": "object",
-                  "properties": {
-                    "visibility": {
-                      "type": "string",
-                      "enum": [
-                        "visible",
-                        "hidden",
-                        "partial",
-                        "unknown"
-                      ]
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "visibility": {
+                          "type": "string",
+                          "enum": [
+                            "visible",
+                            "hidden",
+                            "partial",
+                            "unknown"
+                          ]
+                        },
+                        "statusBar": {
+                          "type": "string",
+                          "enum": [
+                            "visible",
+                            "hidden",
+                            "unknown"
+                          ]
+                        },
+                        "navigationBar": {
+                          "type": "string",
+                          "enum": [
+                            "visible",
+                            "hidden",
+                            "unknown"
+                          ]
+                        },
+                        "homeIndicatorAutoHideRequested": {
+                          "type": "boolean"
+                        },
+                        "source": {
+                          "type": "string",
+                          "enum": [
+                            "android-window-insets",
+                            "ios-status-bar-manager"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "visibility",
+                        "statusBar",
+                        "source"
+                      ],
+                      "additionalProperties": false
                     },
-                    "statusBar": {
-                      "type": "string",
-                      "enum": [
-                        "visible",
-                        "hidden",
-                        "unknown"
-                      ]
-                    },
-                    "navigationBar": {
-                      "type": "string",
-                      "enum": [
-                        "visible",
-                        "hidden",
-                        "unknown"
-                      ]
-                    },
-                    "homeIndicatorAutoHideRequested": {
-                      "type": "boolean"
-                    },
-                    "source": {
-                      "type": "string",
-                      "enum": [
-                        "android-window-insets",
-                        "ios-status-bar-manager"
-                      ]
+                    {
+                      "type": "null"
                     }
-                  },
-                  "required": [
-                    "visibility",
-                    "statusBar",
-                    "source"
-                  ],
-                  "additionalProperties": false
+                  ]
                 }
               },
               "required": [

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3865,6 +3865,52 @@
                 "left"
               ],
               "additionalProperties": false
+            },
+            "systemChrome": {
+              "type": "object",
+              "properties": {
+                "visibility": {
+                  "type": "string",
+                  "enum": [
+                    "visible",
+                    "hidden",
+                    "partial",
+                    "unknown"
+                  ]
+                },
+                "statusBar": {
+                  "type": "string",
+                  "enum": [
+                    "visible",
+                    "hidden",
+                    "unknown"
+                  ]
+                },
+                "navigationBar": {
+                  "type": "string",
+                  "enum": [
+                    "visible",
+                    "hidden",
+                    "unknown"
+                  ]
+                },
+                "homeIndicatorAutoHideRequested": {
+                  "type": "boolean"
+                },
+                "source": {
+                  "type": "string",
+                  "enum": [
+                    "android-window-insets",
+                    "ios-status-bar-manager"
+                  ]
+                }
+              },
+              "required": [
+                "visibility",
+                "statusBar",
+                "source"
+              ],
+              "additionalProperties": false
             }
           },
           "required": [
@@ -4437,6 +4483,52 @@
                     "right",
                     "bottom",
                     "left"
+                  ],
+                  "additionalProperties": false
+                },
+                "systemChrome": {
+                  "type": "object",
+                  "properties": {
+                    "visibility": {
+                      "type": "string",
+                      "enum": [
+                        "visible",
+                        "hidden",
+                        "partial",
+                        "unknown"
+                      ]
+                    },
+                    "statusBar": {
+                      "type": "string",
+                      "enum": [
+                        "visible",
+                        "hidden",
+                        "unknown"
+                      ]
+                    },
+                    "navigationBar": {
+                      "type": "string",
+                      "enum": [
+                        "visible",
+                        "hidden",
+                        "unknown"
+                      ]
+                    },
+                    "homeIndicatorAutoHideRequested": {
+                      "type": "boolean"
+                    },
+                    "source": {
+                      "type": "string",
+                      "enum": [
+                        "android-window-insets",
+                        "ios-status-bar-manager"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "visibility",
+                    "statusBar",
+                    "source"
                   ],
                   "additionalProperties": false
                 }

--- a/src/models/ObservationInsets.ts
+++ b/src/models/ObservationInsets.ts
@@ -41,7 +41,7 @@ export interface ObservationInsets {
   tappableElement?: ObservationEdgeInsets;
   /** UIKit's window safe area, including device and container-bar obstructions. */
   safeArea?: ObservationEdgeInsets;
-  systemChrome?: ObservationSystemChrome;
+  systemChrome?: ObservationSystemChrome | null;
 }
 
 export interface LayoutWarning {

--- a/src/models/ObservationInsets.ts
+++ b/src/models/ObservationInsets.ts
@@ -14,6 +14,19 @@ export interface ObservationSystemBarsInsets {
 }
 
 /**
+ * Current system-chrome visibility for the foreground app window. It describes
+ * presentation state only; edge-to-edge layout remains an independent choice.
+ */
+export interface ObservationSystemChrome {
+  visibility: "visible" | "hidden" | "partial" | "unknown";
+  statusBar: "visible" | "hidden" | "unknown";
+  navigationBar?: "visible" | "hidden" | "unknown";
+  /** iOS only: the top view controller's preference, not observed visibility. */
+  homeIndicatorAutoHideRequested?: boolean;
+  source: "android-window-insets" | "ios-status-bar-manager";
+}
+
+/**
  * Typed platform inset metadata. `systemInsets` remains the backwards-compatible
  * stable-system-bar alias used by existing gesture callers.
  */
@@ -28,6 +41,7 @@ export interface ObservationInsets {
   tappableElement?: ObservationEdgeInsets;
   /** UIKit's window safe area, including device and container-bar obstructions. */
   safeArea?: ObservationEdgeInsets;
+  systemChrome?: ObservationSystemChrome;
 }
 
 export interface LayoutWarning {

--- a/src/models/ObservationInsets.ts
+++ b/src/models/ObservationInsets.ts
@@ -21,8 +21,8 @@ export interface ObservationSystemChrome {
   visibility: "visible" | "hidden" | "partial" | "unknown";
   statusBar: "visible" | "hidden" | "unknown";
   navigationBar?: "visible" | "hidden" | "unknown";
-  /** iOS only: the top view controller's preference, not observed visibility. */
-  homeIndicatorAutoHideRequested?: boolean;
+  /** iOS only: the top view controller's preference, not observed visibility. Android serializes this as null. */
+  homeIndicatorAutoHideRequested?: boolean | null;
   source: "android-window-insets" | "ios-status-bar-manager";
 }
 

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -230,7 +230,7 @@ const observationInsetsSchema = z.object({
   mandatorySystemGestures: edgeInsetsSchema.nullish(),
   tappableElement: edgeInsetsSchema.nullish(),
   safeArea: edgeInsetsSchema.optional(),
-  systemChrome: systemChromeSchema.optional(),
+  systemChrome: systemChromeSchema.nullish(),
 });
 
 const layoutWarningSchema = z.object({

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -214,7 +214,7 @@ const systemChromeSchema = z.object({
   visibility: z.enum(["visible", "hidden", "partial", "unknown"]),
   statusBar: z.enum(["visible", "hidden", "unknown"]),
   navigationBar: z.enum(["visible", "hidden", "unknown"]).optional(),
-  homeIndicatorAutoHideRequested: z.boolean().optional(),
+  homeIndicatorAutoHideRequested: z.boolean().nullish(),
   source: z.enum(["android-window-insets", "ios-status-bar-manager"]),
 });
 

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -210,6 +210,14 @@ const edgeInsetsSchema = z.object({
   left: z.number()
 });
 
+const systemChromeSchema = z.object({
+  visibility: z.enum(["visible", "hidden", "partial", "unknown"]),
+  statusBar: z.enum(["visible", "hidden", "unknown"]),
+  navigationBar: z.enum(["visible", "hidden", "unknown"]).optional(),
+  homeIndicatorAutoHideRequested: z.boolean().optional(),
+  source: z.enum(["android-window-insets", "ios-status-bar-manager"]),
+});
+
 const observationInsetsSchema = z.object({
   available: z.boolean(),
   source: z.enum(["android-window-metrics", "android-resource-fallback", "ios-sdk-safe-area", "unavailable"]),
@@ -222,6 +230,7 @@ const observationInsetsSchema = z.object({
   mandatorySystemGestures: edgeInsetsSchema.nullish(),
   tappableElement: edgeInsetsSchema.nullish(),
   safeArea: edgeInsetsSchema.optional(),
+  systemChrome: systemChromeSchema.optional(),
 });
 
 const layoutWarningSchema = z.object({

--- a/test/features/observe/audits/SafeAreaAuditor.test.ts
+++ b/test/features/observe/audits/SafeAreaAuditor.test.ts
@@ -272,9 +272,17 @@ describe("SafeAreaAuditor", () => {
       source: "ios-sdk-safe-area",
       units: "points",
       safeArea: { top: 30, right: 0, bottom: 30, left: 0 },
+      systemChrome: {
+        visibility: "hidden",
+        statusBar: "hidden",
+        homeIndicatorAutoHideRequested: true,
+        source: "ios-status-bar-manager",
+      },
     };
 
-    expect(new SafeAreaAuditor().inspect(result)[0]?.insetTypes).toEqual(["safeArea"]);
+    const warning = new SafeAreaAuditor().inspect(result)[0];
+    expect(warning?.insetTypes).toEqual(["safeArea"]);
+    expect(warning?.insetPx).toEqual({ top: 30 });
   });
 
   test("reads iOS CtrlProxy attributes from the hierarchy attribute bag", () => {

--- a/test/server/observeOutputSchema.test.ts
+++ b/test/server/observeOutputSchema.test.ts
@@ -58,6 +58,12 @@ describe("observeResultSchema: parses real captures (#3025)", () => {
         source: "ios-sdk-safe-area",
         units: "points",
         safeArea: { top: 59.5, right: 0, bottom: 34, left: 0 },
+        systemChrome: {
+          visibility: "hidden",
+          statusBar: "hidden",
+          homeIndicatorAutoHideRequested: true,
+          source: "ios-status-bar-manager",
+        },
       },
       layoutWarnings: [{
         type: "important-content-under-inset",
@@ -78,6 +84,12 @@ describe("observeResultSchema: parses real captures (#3025)", () => {
       overflowPx: { top: 30 },
       insetPx: { top: 59.5 },
     });
+    expect(parsed.data?.insets?.systemChrome).toEqual({
+      visibility: "hidden",
+      statusBar: "hidden",
+      homeIndicatorAutoHideRequested: true,
+      source: "ios-status-bar-manager",
+    });
   });
 
   test("accepts nullable Android inset categories", () => {
@@ -91,6 +103,12 @@ describe("observeResultSchema: parses real captures (#3025)", () => {
         systemGestures: null,
         mandatorySystemGestures: null,
         tappableElement: null,
+        systemChrome: {
+          visibility: "partial",
+          statusBar: "visible",
+          navigationBar: "hidden",
+          source: "android-window-insets",
+        },
       },
     })).not.toThrow();
   });

--- a/test/server/observeOutputSchema.test.ts
+++ b/test/server/observeOutputSchema.test.ts
@@ -16,6 +16,7 @@ import { loadAndroidHomeObserve, loadIosFractionalObserve } from "../fixtures/ob
 import { ToolRegistry, toolHasOutputSchema } from "../../src/server/toolRegistry";
 import { registerObserveTools } from "../../src/server/observeTools";
 import { serverConfig } from "../../src/utils/ServerConfig";
+import type { ObservationInsets } from "../../src/models/ObservationInsets";
 
 /**
  * `observe` outputSchema coverage (issue #3025). The headline `observe` tool had
@@ -115,13 +116,18 @@ describe("observeResultSchema: parses real captures (#3025)", () => {
   });
 
   test("accepts the Android resource fallback without system-chrome visibility", () => {
+    const fallbackInsets: ObservationInsets = {
+      available: true,
+      source: "android-resource-fallback",
+      units: "physical-pixels",
+      systemBars: { visible: { top: 24, right: 0, bottom: 48, left: 0 }, stable: { top: 24, right: 0, bottom: 48, left: 0 } },
+      systemChrome: null,
+    };
+
+    expect(fallbackInsets.systemChrome).toBeNull();
     expect(() => observeResultSchema.parse({
       insets: {
-        available: true,
-        source: "android-resource-fallback",
-        units: "physical-pixels",
-        systemBars: { visible: { top: 24, right: 0, bottom: 48, left: 0 }, stable: { top: 24, right: 0, bottom: 48, left: 0 } },
-        systemChrome: null,
+        ...fallbackInsets,
       },
     })).not.toThrow();
   });

--- a/test/server/observeOutputSchema.test.ts
+++ b/test/server/observeOutputSchema.test.ts
@@ -107,6 +107,7 @@ describe("observeResultSchema: parses real captures (#3025)", () => {
           visibility: "partial",
           statusBar: "visible",
           navigationBar: "hidden",
+          homeIndicatorAutoHideRequested: null,
           source: "android-window-insets",
         },
       },

--- a/test/server/observeOutputSchema.test.ts
+++ b/test/server/observeOutputSchema.test.ts
@@ -113,6 +113,18 @@ describe("observeResultSchema: parses real captures (#3025)", () => {
     })).not.toThrow();
   });
 
+  test("accepts the Android resource fallback without system-chrome visibility", () => {
+    expect(() => observeResultSchema.parse({
+      insets: {
+        available: true,
+        source: "android-resource-fallback",
+        units: "physical-pixels",
+        systemBars: { visible: { top: 24, right: 0, bottom: 48, left: 0 }, stable: { top: 24, right: 0, bottom: 48, left: 0 } },
+        systemChrome: null,
+      },
+    })).not.toThrow();
+  });
+
   test("accepts the frozen android-home observe fixture (object bounds)", () => {
     const { observe } = loadAndroidHomeObserve();
     expect(() => observeResultSchema.parse(observe)).not.toThrow();


### PR DESCRIPTION
## Summary

Add `insets.systemChrome` to `observe` so safe-area warnings retain the status/navigation chrome context that explains the screen state without changing unsafe-region geometry. Android captures typed `WindowInsets` visibility for status and navigation bars; iOS captures `UIStatusBarManager` state and reports the visible controller's home-indicator auto-hide preference as advisory metadata only. The TypeScript output schema, generated tool definitions, SDK API surface, tests, and observe documentation now carry the contract.

This changes Android and iOS CtrlProxy runners. After merge, the release process must re-cut and publish both runner artifacts, then update `src/constants/release.ts` with their artifact checksums; current clients intentionally keep using the existing pinned release until that happens. iOS target apps must also adopt the new AutoMobile SDK release and rebuild before their observations include the new context.

## Linked Issue

No issue was supplied.

## Bug / Regression Context

- **Prior attempts:** None supplied.
- **Observed symptom:** Safe-area warnings could identify overlap geometry but could not state whether immersive/system chrome was currently hidden, visible, or partial.
- **Repro steps / conditions:** Observe an app that hides Android system bars or an iOS app whose status-bar presentation differs from the default; the old hierarchy contained inset geometry but no chrome-state context.

## Validation

- [ ] `scripts/all_fast_validate_checks.sh` is blocked only by sandboxed external-link access; `ktfmt` passed after formatting and an elevated `scripts/lychee/validate_lychee.sh` run passed with zero errors
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Android/iOS changes: ran focused Android CtrlProxy, full iOS SDK, and iOS CtrlProxy hierarchy-merger tests; verified the iOS SDK API snapshot
- [x] New code uses platform APIs directly; focused unit tests use deterministic pure inputs and run well under 100ms
- [x] Checked standard library and existing project types before adding code; no new dependency or generic helper was introduced
- [x] Rebased onto latest `main`, conflicts resolved

## Kotlin Reuse Check

- [x] Checked Kotlin stdlib/JDK/AndroidX, existing module dependencies, and dependency-compatible AutoMobile modules before adding helpers, wrappers, `*Util` files, or dependencies
- [x] Uses existing `WindowInsets` APIs and a private adjacent classifier; no new dependency or shared utility is needed

## Device Verification

- [ ] Not run against the local emulator/simulator because normal local `observe` uses the currently pinned released CtrlProxy artifacts; verify on both platforms after the release artifact re-cut described above
