### PR TITLE
fix(ios): recover silent pooled ScreenCaptureKit capture

### DIFF
--- a/src/features/screen-stream/IOSSimulatorCaptureHelperPool.ts
+++ b/src/features/screen-stream/IOSSimulatorCaptureHelperPool.ts
@@ -323,7 +323,8 @@ function helperTargetKey(target: CaptureTarget, binaryPath: string): string {
 }
 
 function isFatalHelperStderr(line: string): boolean {
-  return line.trimStart().toLowerCase().startsWith("error:");
+  const normalized = line.trimStart().toLowerCase();
+  return normalized.startsWith("error:") || normalized.includes("warn: no frames received");
 }
 
 export const iosSimulatorCaptureHelperPool = new IOSSimulatorCaptureHelperPool();

--- a/src/features/screen-stream/IOSSimulatorCaptureHelperPool.ts
+++ b/src/features/screen-stream/IOSSimulatorCaptureHelperPool.ts
@@ -54,6 +54,9 @@ interface HelperEntry {
   leases: Set<PooledSimulatorCaptureHelperLease>;
   latestFrame: DecodedFrame | null;
   idleTimer: NodeJS.Timeout | null;
+  failed: boolean;
+  failedStopFailed: boolean;
+  failedStopError: unknown;
 }
 
 /**
@@ -122,11 +125,17 @@ export class IOSSimulatorCaptureHelperPool {
           leases: new Set(),
           latestFrame: null,
           idleTimer: null,
+          failed: false,
+          failedStopFailed: false,
+          failedStopError: undefined,
         };
         this.entries.set(targetKey, entry);
         this.wireHelper(entry);
       }
 
+      if (entry.failedStopFailed) {
+        throw entry.failedStopError;
+      }
       this.clearEntryIdleTimer(entry);
       entry.leases.add(lease);
       lease.entryKey = targetKey;
@@ -178,6 +187,10 @@ export class IOSSimulatorCaptureHelperPool {
       if (!entry || !entry.leases.has(lease)) {
         return;
       }
+      if (entry.failed) {
+        await this.stopFailedEntry(entry);
+        return;
+      }
       await this.stopEntry(entry);
     });
   }
@@ -192,19 +205,21 @@ export class IOSSimulatorCaptureHelperPool {
     entry.helper.on("audio", audio => this.broadcast(entry, "audio", audio));
     entry.helper.on("malformed", error => this.broadcast(entry, "malformed", error));
     entry.helper.on("stderr", line => {
-      this.broadcast(entry, "stderr", line);
       // The helper can report a terminal ScreenCaptureKit error without exiting.
       // Keeping that process warm would hand the next reconnect a frozen session.
       if (isFatalHelperStderr(line) && this.entries.get(entry.key) === entry) {
+        entry.failed = true;
         this.enqueueBestEffort(() => this.stopFailedEntry(entry), "failed helper stop failed");
       }
+      this.broadcast(entry, "stderr", line);
     });
     entry.helper.on("readiness", readiness => this.broadcast(entry, "readiness", readiness));
     entry.helper.on("error", error => {
-      this.broadcast(entry, "error", error);
       if (this.entries.get(entry.key) === entry) {
+        entry.failed = true;
         this.enqueueBestEffort(() => this.stopFailedEntry(entry), "failed helper stop failed");
       }
+      this.broadcast(entry, "error", error);
     });
     entry.helper.on("exit", info => {
       this.broadcast(entry, "exit", info);
@@ -236,7 +251,20 @@ export class IOSSimulatorCaptureHelperPool {
     if (this.entries.get(entry.key) !== entry) {
       return;
     }
-    await this.stopEntry(entry);
+    if (entry.failedStopFailed) {
+      throw entry.failedStopError;
+    }
+    this.clearEntryIdleTimer(entry);
+    try {
+      await entry.helper.stop();
+    } catch (error) {
+      entry.failedStopFailed = true;
+      entry.failedStopError = error;
+      throw error;
+    }
+    if (this.entries.get(entry.key) === entry) {
+      this.entries.delete(entry.key);
+    }
   }
 
   private async stopEntry(entry: HelperEntry): Promise<void> {

--- a/src/features/screen-stream/IOSSimulatorCaptureHelperPool.ts
+++ b/src/features/screen-stream/IOSSimulatorCaptureHelperPool.ts
@@ -21,6 +21,7 @@ export const IOS_SIMULATOR_HELPER_IDLE_TTL_MS = 45_000;
 export interface IosSimulatorCaptureHelperLease {
   start(): void | Promise<void>;
   stop(): Promise<unknown>;
+  invalidate(): Promise<void>;
   on(event: "frame", listener: (frame: DecodedFrame) => void): this;
   on(event: "frameMetrics", listener: (metrics: FrameQueueMetrics) => void): this;
   on(event: "captureMetrics", listener: (metrics: NativeFrameMetrics) => void): this;
@@ -166,6 +167,23 @@ export class IOSSimulatorCaptureHelperPool {
     }, this.idleTtlMs);
   }
 
+  async invalidate(lease: PooledSimulatorCaptureHelperLease): Promise<void> {
+    const entryKey = lease.entryKey;
+    lease.entryKey = null;
+    if (!entryKey) {
+      return;
+    }
+    await this.enqueue(async () => {
+      const entry = this.entries.get(entryKey);
+      if (!entry || !entry.leases.has(lease)) {
+        return;
+      }
+      await this.stopEntry(entry);
+    }).catch(error => {
+      logger.warn(`[IOSSimulatorCaptureHelperPool] failed helper stop failed: ${error}`);
+    });
+  }
+
   private wireHelper(entry: HelperEntry): void {
     entry.helper.on("frame", frame => {
       entry.latestFrame = frame;
@@ -294,6 +312,16 @@ class PooledSimulatorCaptureHelperLease extends EventEmitter implements IosSimul
     await this.attachment?.catch(() => undefined);
     await this.pool.detach(this);
     return null;
+  }
+
+  async invalidate(): Promise<void> {
+    if (!this.started) {
+      return;
+    }
+    this.started = false;
+    this.removeAllListeners();
+    await this.attachment?.catch(() => undefined);
+    await this.pool.invalidate(this);
   }
 
   get isStarted(): boolean {

--- a/src/features/screen-stream/IOSSimulatorCaptureHelperPool.ts
+++ b/src/features/screen-stream/IOSSimulatorCaptureHelperPool.ts
@@ -179,8 +179,6 @@ export class IOSSimulatorCaptureHelperPool {
         return;
       }
       await this.stopEntry(entry);
-    }).catch(error => {
-      logger.warn(`[IOSSimulatorCaptureHelperPool] failed helper stop failed: ${error}`);
     });
   }
 

--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -217,6 +217,8 @@ export interface ScreenCaptureHelperEnsurer {
   ensure(): Promise<string | null>;
 }
 
+class NoFirstFrameError extends ActionableError {}
+
 export class IosH264Source implements H264CaptureSource {
   private readonly helperPath?: string;
   private readonly ffmpegPath: string;
@@ -314,14 +316,7 @@ export class IosH264Source implements H264CaptureSource {
         return;
       }
 
-      logger.info(`[IosH264Source] starting screen-capture-helper for ${describeCaptureTarget(target)}`);
-      const helper = this.createCaptureHelper({ binaryPath: helperPath, target });
-      this.helper = helper;
-      this.wireHelperFrames(helper);
-      const firstAudio = this.options.audioEnabled ? this.waitForFirstAudio(helper) : null;
-      const firstFrame = this.waitForFirstFrame(helper, target);
-      await helper.start();
-      await Promise.all([firstFrame, firstAudio]);
+      await this.startCaptureWithSimulatorRetry(helperPath, target);
     } catch (error) {
       this.phase = "stopping";
       await this.beginTeardown();
@@ -447,6 +442,35 @@ export class IosH264Source implements H264CaptureSource {
       return this.simulatorHelperPool.acquire(options) as IosSimulatorCaptureHelperLease;
     }
     return this.createHelper(options);
+  }
+
+  private async startCaptureWithSimulatorRetry(helperPath: string, target: CaptureTarget): Promise<void> {
+    const shouldRetryNoFirstFrame = target.kind === "simulator" && !this.options.createHelper;
+    for (let attempt = 0; ; attempt++) {
+      try {
+        await this.startCaptureAttempt(helperPath, target);
+        return;
+      } catch (error) {
+        if (!shouldRetryNoFirstFrame || attempt !== 0 || !(error instanceof NoFirstFrameError)) {
+          throw error;
+        }
+        logger.warn(
+          `[IosH264Source] no first frame from pooled Simulator helper for ${describeCaptureTarget(target)}; retrying once`
+        );
+        await this.stopCurrentHelper();
+      }
+    }
+  }
+
+  private async startCaptureAttempt(helperPath: string, target: CaptureTarget): Promise<void> {
+    logger.info(`[IosH264Source] starting screen-capture-helper for ${describeCaptureTarget(target)}`);
+    const helper = this.createCaptureHelper({ binaryPath: helperPath, target });
+    this.helper = helper;
+    this.wireHelperFrames(helper);
+    const firstAudio = this.options.audioEnabled ? this.waitForFirstAudio(helper) : null;
+    const firstFrame = this.waitForFirstFrame(helper, target);
+    await helper.start();
+    await Promise.all([firstFrame, firstAudio]);
   }
 
   private waitForFirstFrame(helper: IosFrameCaptureHelper, target: CaptureTarget): Promise<void> {
@@ -879,8 +903,6 @@ export class IosH264Source implements H264CaptureSource {
   }
 
   private async teardown(): Promise<void> {
-    this.cancelFirstAudioWait?.();
-    this.cancelFirstAudioWait = null;
     const encoder = this.encoder;
     this.encoder = null;
     this.encoderSize = null;
@@ -891,6 +913,15 @@ export class IosH264Source implements H264CaptureSource {
     encoder?.stdin.end();
     encoder?.kill("SIGTERM");
 
+    await this.stopCurrentHelper();
+  }
+
+  private async stopCurrentHelper(): Promise<void> {
+    this.cancelFirstFrameWait?.();
+    this.cancelFirstFrameWait = null;
+    this.cancelFirstAudioWait?.();
+    this.cancelFirstAudioWait = null;
+    this.rejectFirstAudioWait = null;
     const helper = this.helper;
     this.helper = null;
     await helper?.stop().catch(error => {
@@ -960,11 +991,11 @@ function clampMacroblockAxis(value: number): number {
   return Math.min(WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME, Math.max(1, value));
 }
 
-function makeNoFramesError(target: CaptureTarget): ActionableError {
+function makeNoFramesError(target: CaptureTarget): NoFirstFrameError {
   const hint = target.kind === "simulator"
     ? " Grant Screen Recording permission to your terminal/IDE in System Settings > Privacy & Security > Screen Recording."
     : "";
-  return new ActionableError(`iOS screen capture did not produce a first frame.${hint}`);
+  return new NoFirstFrameError(`iOS screen capture did not produce a first frame.${hint}`);
 }
 
 function isNoFramesPermissionWarning(line: string): boolean {

--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import type { Readable, Writable } from "node:stream";
-import { ActionableError, type BootedDevice } from "../../models";
+import { ActionableError, toActionableError, type BootedDevice } from "../../models";
 import { IOSScreenCaptureHelper } from "../screen-stream/IOSScreenCaptureHelper";
 import type {
   CaptureTarget,
@@ -453,9 +453,11 @@ export class IosH264Source implements H264CaptureSource {
         return;
       } catch (error) {
         if (!shouldRetryNoFirstFrame || attempt !== 0 || !(error instanceof NoFirstFrameError)) {
-          throw error;
+          throw toActionableError(error, "Failed to start iOS screen capture");
         }
-        logger.warn(
+        // The failed lease is invalidated below, so one new ScreenCaptureKit session
+        // can recover a transient no-frame startup without surfacing a warning.
+        logger.debug(
           `[IosH264Source] no first frame from pooled Simulator helper for ${describeCaptureTarget(target)}; retrying once`
         );
         await this.helper?.invalidate?.();

--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -455,7 +455,11 @@ export class IosH264Source implements H264CaptureSource {
         if (!shouldRetryNoFirstFrame || !(error instanceof NoFirstFrameError)) {
           throw toActionableError(error, "Failed to start iOS screen capture");
         }
-        await this.helper?.invalidate?.();
+        try {
+          await this.helper?.invalidate?.();
+        } catch (error) {
+          throw toActionableError(error, "Failed to invalidate silent iOS Simulator capture");
+        }
         await this.stopCurrentHelper();
         if (!this.isActive()) {
           return;

--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -452,16 +452,22 @@ export class IosH264Source implements H264CaptureSource {
         await this.startCaptureAttempt(helperPath, target);
         return;
       } catch (error) {
-        if (!shouldRetryNoFirstFrame || attempt !== 0 || !(error instanceof NoFirstFrameError)) {
+        if (!shouldRetryNoFirstFrame || !(error instanceof NoFirstFrameError)) {
           throw toActionableError(error, "Failed to start iOS screen capture");
         }
-        // The failed lease is invalidated below, so one new ScreenCaptureKit session
+        await this.helper?.invalidate?.();
+        await this.stopCurrentHelper();
+        if (!this.isActive()) {
+          return;
+        }
+        if (attempt !== 0) {
+          throw toActionableError(error, "Failed to start iOS screen capture");
+        }
+        // The failed lease is invalidated above, so one new ScreenCaptureKit session
         // can recover a transient no-frame startup without surfacing a warning.
         logger.debug(
           `[IosH264Source] no first frame from pooled Simulator helper for ${describeCaptureTarget(target)}; retrying once`
         );
-        await this.helper?.invalidate?.();
-        await this.stopCurrentHelper();
       }
     }
   }

--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -106,6 +106,7 @@ export function defaultIosBitrateBps(size: EncoderSize, fps: number): number {
 export interface IosFrameCaptureHelper {
   start(): void | Promise<void>;
   stop(): Promise<unknown>;
+  invalidate?(): Promise<void>;
   on(event: "frame", listener: (frame: DecodedFrame) => void): this;
   on(event: "frameMetrics", listener: (metrics: FrameQueueMetrics) => void): this;
   on(event: "captureMetrics", listener: (metrics: NativeFrameMetrics) => void): this;
@@ -457,6 +458,7 @@ export class IosH264Source implements H264CaptureSource {
         logger.warn(
           `[IosH264Source] no first frame from pooled Simulator helper for ${describeCaptureTarget(target)}; retrying once`
         );
+        await this.helper?.invalidate?.();
         await this.stopCurrentHelper();
       }
     }

--- a/test/features/screen-stream/IOSSimulatorCaptureHelperPool.test.ts
+++ b/test/features/screen-stream/IOSSimulatorCaptureHelperPool.test.ts
@@ -132,6 +132,39 @@ describe("IOSSimulatorCaptureHelperPool", () => {
     await pool.shutdown();
   });
 
+  test("discards a silent helper before reusing its window and keeps another window active", async () => {
+    const helpers: FakeSimulatorHelper[] = [];
+    const pool = new IOSSimulatorCaptureHelperPool({
+      createHelper: () => {
+        const helper = new FakeSimulatorHelper();
+        helpers.push(helper);
+        return helper;
+      },
+    });
+    const silent = pool.acquire(simulatorOptions(42));
+    const concurrent = pool.acquire(simulatorOptions(99));
+    await silent.start();
+    await concurrent.start();
+
+    helpers[0].emit(
+      "stderr",
+      "warn: no frames received within 10s. Grant 'Screen Recording' to your terminal/IDE."
+    );
+    await flushMicrotasks();
+
+    const replacement = pool.acquire(simulatorOptions(42));
+    await replacement.start();
+
+    expect(helpers).toHaveLength(3);
+    expect(helpers[0].stops).toBe(1);
+    expect(helpers[1].stops).toBe(0);
+    expect(helpers[2].starts).toBe(1);
+    await replacement.stop();
+    await concurrent.stop();
+    await silent.stop();
+    await pool.shutdown();
+  });
+
   test("logs a rejected failed-helper cleanup instead of leaving an unhandled rejection", async () => {
     const helpers: FakeSimulatorHelper[] = [];
     const pool = new IOSSimulatorCaptureHelperPool({

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -479,7 +479,9 @@ describe("IosH264Source", () => {
 
     const error = await started;
     expect(error).toBeInstanceOf(Error);
-    expect(error?.message).toContain("Screen Recording permission is required");
+    expect(error?.message).toBe(
+      "Failed to start iOS screen capture: screen-capture-helper reported an error: error: Screen Recording permission is required. Grant Screen Recording to your terminal/IDE."
+    );
     expect(helpers).toHaveLength(1);
     expect(helpers[0].stopped).toBe(true);
     await pool.shutdown();

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -364,6 +364,159 @@ describe("IosH264Source", () => {
     expect(helper.stopped).toBe(true);
   });
 
+  test("retries a silent pooled Simulator helper once without replacing the source", async () => {
+    const helpers: FakeFrameCaptureHelper[] = [];
+    const pool = new IOSSimulatorCaptureHelperPool({
+      createHelper: () => {
+        const helper = new FakeFrameCaptureHelper();
+        helpers.push(helper);
+        return helper;
+      },
+    });
+    const source = new IosH264Source({
+      device: IOS_SIMULATOR,
+      helperPath: FAKE_HELPER_PATH,
+      helperPathExists: fakeHelperPathExists,
+      onData: () => {},
+      simulatorHelperPool: pool,
+      spawner: () => new FakeChildProcess() as unknown as ChildProcessWithoutNullStreams,
+      simulatorWindowResolver: async () => 42,
+      commandRunner: successfulCommandRunner,
+    });
+
+    const started = source.start().then(
+      () => null,
+      error => error as Error
+    );
+    await flush();
+    helpers[0].emitStderr(
+      "warn: no frames received within 10s. Grant 'Screen Recording' to your terminal/IDE."
+    );
+    await flush();
+
+    expect(helpers).toHaveLength(2);
+    helpers[1].emitFrame(frame(1, 1, 0x11));
+
+    expect(await started).toBeNull();
+    expect(helpers[0].stopped).toBe(true);
+    expect(helpers[1].started).toBe(true);
+    await source.stop();
+    await pool.shutdown();
+  });
+
+  test("reports the existing no-frame error after a second silent pooled Simulator attempt", async () => {
+    const helpers: FakeFrameCaptureHelper[] = [];
+    const pool = new IOSSimulatorCaptureHelperPool({
+      createHelper: () => {
+        const helper = new FakeFrameCaptureHelper();
+        helpers.push(helper);
+        return helper;
+      },
+    });
+    const source = new IosH264Source({
+      device: IOS_SIMULATOR,
+      helperPath: FAKE_HELPER_PATH,
+      helperPathExists: fakeHelperPathExists,
+      onData: () => {},
+      simulatorHelperPool: pool,
+      spawner: () => new FakeChildProcess() as unknown as ChildProcessWithoutNullStreams,
+      simulatorWindowResolver: async () => 42,
+      commandRunner: successfulCommandRunner,
+    });
+
+    const started = source.start().then(
+      () => null,
+      error => error as Error
+    );
+    await flush();
+    helpers[0].emitStderr(
+      "warn: no frames received within 10s. Grant 'Screen Recording' to your terminal/IDE."
+    );
+    await flush();
+
+    expect(helpers).toHaveLength(2);
+    helpers[1].emitStderr(
+      "warn: no frames received within 10s. Grant 'Screen Recording' to your terminal/IDE."
+    );
+
+    const error = await started;
+    expect(error).toBeInstanceOf(Error);
+    expect(error?.message).toContain("Screen Recording permission");
+    expect(helpers[0].stopped).toBe(true);
+    expect(helpers[1].stopped).toBe(true);
+    await pool.shutdown();
+  });
+
+  test("does not retry a direct Screen Recording denial from a pooled Simulator helper", async () => {
+    const helpers: FakeFrameCaptureHelper[] = [];
+    const pool = new IOSSimulatorCaptureHelperPool({
+      createHelper: () => {
+        const helper = new FakeFrameCaptureHelper();
+        helpers.push(helper);
+        return helper;
+      },
+    });
+    const source = new IosH264Source({
+      device: IOS_SIMULATOR,
+      helperPath: FAKE_HELPER_PATH,
+      helperPathExists: fakeHelperPathExists,
+      onData: () => {},
+      simulatorHelperPool: pool,
+      spawner: () => new FakeChildProcess() as unknown as ChildProcessWithoutNullStreams,
+      simulatorWindowResolver: async () => 42,
+      commandRunner: successfulCommandRunner,
+    });
+
+    const started = source.start().then(
+      () => null,
+      error => error as Error
+    );
+    await flush();
+    helpers[0].emitStderr(
+      "error: Screen Recording permission is required. Grant Screen Recording to your terminal/IDE."
+    );
+
+    const error = await started;
+    expect(error).toBeInstanceOf(Error);
+    expect(error?.message).toContain("Screen Recording permission is required");
+    expect(helpers).toHaveLength(1);
+    expect(helpers[0].stopped).toBe(true);
+    await pool.shutdown();
+  });
+
+  test("does not retry a silent physical-device helper", async () => {
+    const timer = new FakeTimer();
+    const helpers: FakeFrameCaptureHelper[] = [];
+    const source = new IosH264Source({
+      device: IOS_DEVICE,
+      helperPath: FAKE_HELPER_PATH,
+      helperPathExists: fakeHelperPathExists,
+      firstFrameTimeoutMs: 1,
+      timer,
+      onData: () => {},
+      createHelper: () => {
+        const helper = new FakeFrameCaptureHelper();
+        helpers.push(helper);
+        return helper;
+      },
+      spawner: () => new FakeChildProcess() as unknown as ChildProcessWithoutNullStreams,
+      commandRunner: successfulCommandRunner,
+    });
+
+    const started = source.start().then(
+      () => null,
+      error => error as Error
+    );
+    await flush();
+    timer.advanceTime(1);
+
+    const error = await started;
+    expect(error).toBeInstanceOf(Error);
+    expect(error?.message).toBe("iOS screen capture did not produce a first frame.");
+    expect(helpers).toHaveLength(1);
+    expect(helpers[0].stopped).toBe(true);
+  });
+
   test("requests simulator audio and forwards its PCM16LE chunks unchanged", async () => {
     const audio: Buffer[] = [];
     const { source, helper, helperTargets } = createHarness(IOS_SIMULATOR, {

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -46,6 +46,7 @@ class FakeFrameCaptureHelper extends EventEmitter implements IosFrameCaptureHelp
   started = false;
   stopped = false;
   isRunning = false;
+  stopError: Error | null = null;
 
   start(): void {
     this.started = true;
@@ -55,6 +56,9 @@ class FakeFrameCaptureHelper extends EventEmitter implements IosFrameCaptureHelp
   async stop(): Promise<null> {
     this.stopped = true;
     this.isRunning = false;
+    if (this.stopError) {
+      throw this.stopError;
+    }
     return null;
   }
 
@@ -528,6 +532,41 @@ describe("IosH264Source", () => {
     timer.advanceTime(1);
 
     await expect(started).resolves.toBeUndefined();
+    expect(helpers).toHaveLength(1);
+    await pool.shutdown();
+  });
+
+  test("fails instead of retrying when invalidating a silent pooled Simulator helper fails", async () => {
+    const timer = new FakeTimer();
+    const helpers: FakeFrameCaptureHelper[] = [];
+    const pool = new IOSSimulatorCaptureHelperPool({
+      createHelper: () => {
+        const helper = new FakeFrameCaptureHelper();
+        helpers.push(helper);
+        return helper;
+      },
+    });
+    const source = new IosH264Source({
+      device: IOS_SIMULATOR,
+      helperPath: FAKE_HELPER_PATH,
+      helperPathExists: fakeHelperPathExists,
+      onData: () => {},
+      firstFrameTimeoutMs: 1,
+      simulatorHelperPool: pool,
+      spawner: () => new FakeChildProcess() as unknown as ChildProcessWithoutNullStreams,
+      simulatorWindowResolver: async () => 42,
+      commandRunner: successfulCommandRunner,
+      timer,
+    });
+
+    const started = source.start();
+    await flush();
+    helpers[0].stopError = new Error("helper stop failed");
+    timer.advanceTime(1);
+
+    await expect(started).rejects.toThrow(
+      "Failed to invalidate silent iOS Simulator capture: helper stop failed"
+    );
     expect(helpers).toHaveLength(1);
     await pool.shutdown();
   });

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -452,6 +452,51 @@ describe("IosH264Source", () => {
     await pool.shutdown();
   });
 
+  test("fails closed when warning-triggered silent-helper cleanup fails", async () => {
+    const helpers: FakeFrameCaptureHelper[] = [];
+    const pool = new IOSSimulatorCaptureHelperPool({
+      createHelper: () => {
+        const helper = new FakeFrameCaptureHelper();
+        helpers.push(helper);
+        return helper;
+      },
+    });
+    const source = new IosH264Source({
+      device: IOS_SIMULATOR,
+      helperPath: FAKE_HELPER_PATH,
+      helperPathExists: fakeHelperPathExists,
+      onData: () => {},
+      simulatorHelperPool: pool,
+      spawner: () => new FakeChildProcess() as unknown as ChildProcessWithoutNullStreams,
+      simulatorWindowResolver: async () => 42,
+      commandRunner: successfulCommandRunner,
+    });
+
+    const started = source.start().then(
+      () => null,
+      error => error as Error
+    );
+    await flush();
+    helpers[0].stopError = new Error("helper stop failed");
+    helpers[0].emitStderr(
+      "warn: no frames received within 10s. Grant 'Screen Recording' to your terminal/IDE."
+    );
+
+    try {
+      await flush();
+
+      expect(helpers).toHaveLength(1);
+      const error = await started;
+      expect(error).toBeInstanceOf(Error);
+      expect(error?.message).toBe(
+        "Failed to invalidate silent iOS Simulator capture: helper stop failed"
+      );
+    } finally {
+      await source.stop();
+      await pool.shutdown();
+    }
+  });
+
   test("evicts a second timed-out pooled Simulator helper before a later lease", async () => {
     const timer = new FakeTimer();
     const helpers: FakeFrameCaptureHelper[] = [];

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -448,6 +448,90 @@ describe("IosH264Source", () => {
     await pool.shutdown();
   });
 
+  test("evicts a second timed-out pooled Simulator helper before a later lease", async () => {
+    const timer = new FakeTimer();
+    const helpers: FakeFrameCaptureHelper[] = [];
+    const pool = new IOSSimulatorCaptureHelperPool({
+      createHelper: () => {
+        const helper = new FakeFrameCaptureHelper();
+        helpers.push(helper);
+        return helper;
+      },
+    });
+    const source = new IosH264Source({
+      device: IOS_SIMULATOR,
+      helperPath: FAKE_HELPER_PATH,
+      helperPathExists: fakeHelperPathExists,
+      onData: () => {},
+      firstFrameTimeoutMs: 1,
+      simulatorHelperPool: pool,
+      spawner: () => new FakeChildProcess() as unknown as ChildProcessWithoutNullStreams,
+      simulatorWindowResolver: async () => 42,
+      commandRunner: successfulCommandRunner,
+      timer,
+    });
+
+    const started = source.start().then(
+      () => null,
+      error => error as Error
+    );
+    await flush();
+    timer.advanceTime(1);
+    await flush();
+    timer.advanceTime(1);
+
+    const error = await started;
+    expect(error).toBeInstanceOf(Error);
+    expect(helpers).toHaveLength(2);
+    expect(helpers[0].stopped).toBe(true);
+    expect(helpers[1].stopped).toBe(true);
+
+    const replacement = pool.acquire({
+      binaryPath: FAKE_HELPER_PATH,
+      target: { kind: "simulator", windowID: 42, fps: WEBRTC_IOS_SIMULATOR_FPS_DEFAULT },
+    });
+    await replacement.start();
+
+    expect(helpers).toHaveLength(3);
+    await replacement.stop();
+    await source.stop();
+    await pool.shutdown();
+  });
+
+  test("does not retry a pooled Simulator timeout after the source stops", async () => {
+    const timer = new FakeTimer();
+    const helpers: FakeFrameCaptureHelper[] = [];
+    const pool = new IOSSimulatorCaptureHelperPool({
+      createHelper: () => {
+        const helper = new FakeFrameCaptureHelper();
+        helpers.push(helper);
+        return helper;
+      },
+    });
+    const source = new IosH264Source({
+      device: IOS_SIMULATOR,
+      helperPath: FAKE_HELPER_PATH,
+      helperPathExists: fakeHelperPathExists,
+      onData: () => {},
+      firstFrameTimeoutMs: 1,
+      simulatorHelperPool: pool,
+      spawner: () => new FakeChildProcess() as unknown as ChildProcessWithoutNullStreams,
+      simulatorWindowResolver: async () => 42,
+      commandRunner: successfulCommandRunner,
+      timer,
+    });
+
+    const started = source.start();
+    await flush();
+    timer.advanceTime(1);
+    await source.stop();
+    timer.advanceTime(1);
+
+    await expect(started).resolves.toBeUndefined();
+    expect(helpers).toHaveLength(1);
+    await pool.shutdown();
+  });
+
   test("does not retry a direct Screen Recording denial from a pooled Simulator helper", async () => {
     const helpers: FakeFrameCaptureHelper[] = [];
     const pool = new IOSSimulatorCaptureHelperPool({

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -365,6 +365,7 @@ describe("IosH264Source", () => {
   });
 
   test("retries a silent pooled Simulator helper once without replacing the source", async () => {
+    const timer = new FakeTimer();
     const helpers: FakeFrameCaptureHelper[] = [];
     const pool = new IOSSimulatorCaptureHelperPool({
       createHelper: () => {
@@ -378,10 +379,12 @@ describe("IosH264Source", () => {
       helperPath: FAKE_HELPER_PATH,
       helperPathExists: fakeHelperPathExists,
       onData: () => {},
+      firstFrameTimeoutMs: 1,
       simulatorHelperPool: pool,
       spawner: () => new FakeChildProcess() as unknown as ChildProcessWithoutNullStreams,
       simulatorWindowResolver: async () => 42,
       commandRunner: successfulCommandRunner,
+      timer,
     });
 
     const started = source.start().then(
@@ -389,9 +392,7 @@ describe("IosH264Source", () => {
       error => error as Error
     );
     await flush();
-    helpers[0].emitStderr(
-      "warn: no frames received within 10s. Grant 'Screen Recording' to your terminal/IDE."
-    );
+    timer.advanceTime(1);
     await flush();
 
     expect(helpers).toHaveLength(2);


### PR DESCRIPTION
## Summary

- evict pooled Simulator ScreenCaptureKit helpers that report no frames before they can be leased again
- retry one silent Simulator capture startup with a fresh helper while preserving the WebRTC source lifecycle
- retain actionable failures for direct Screen Recording denials, repeated silence, and physical-device capture

## Linked Issue

Closes [#4423](https://github.com/kaeawc/auto-mobile/issues/4423)

## Bug / Regression Context

- **Prior attempts:** the warm helper lifecycle was introduced by [#4415](https://github.com/kaeawc/auto-mobile/pull/4415); the symptom was observed while investigating [#4413](https://github.com/kaeawc/auto-mobile/pull/4413).
- **Observed symptom:** a live-but-silent `SCStream` remained eligible for the next reconnect after reporting `warn: no frames received`.
- **Repro steps / conditions:** Simulator ScreenCaptureKit starts without delivering a first frame, source startup rejects, then a reconnect leases the retained helper.

## Validation

- [x] `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-issue-4423-test bun test test/features/screen-stream/IOSSimulatorCaptureHelperPool.test.ts test/features/webrtc/IosH264Source.test.ts`
- [x] `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-issue-4423-test bun run turbo:validate`
- [x] `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-issue-4423-test bun run typecheck`
- [x] New code uses existing pool/source interfaces, fakes, and `FakeTimer`; no new dependency or generic helper
- [x] Created from current `origin/main`

## Follow-ups

- [x] No out-of-scope gaps identified
