### PR TITLE
Add automatic Circuit navigation destination hook to Android SDK

### DIFF
--- a/android/auto-mobile-sdk/README.md
+++ b/android/auto-mobile-sdk/README.md
@@ -81,14 +81,40 @@ fun AppNavigation() {
 
 ### Circuit Integration
 
-For Circuit navigation, use manual tracking:
+For Circuit navigation, register the automatic hook once with your `Navigator`. It observes
+the back stack and tracks every destination change (forward navigation, pops, and root resets)
+without any per-call bookkeeping:
 
 ```kotlin
-// When navigating in Circuit
-CircuitAdapter.trackNavigation(
-    destination = "ProfileScreen",
-    arguments = mapOf("userId" to userId)
-)
+@Composable
+fun App(circuit: Circuit) {
+    val backStack = rememberSaveableBackStack(root = HomeScreen)
+    val navigator = rememberCircuitNavigator(backStack)
+
+    // Register once — destinations are tracked as the back stack changes.
+    CircuitAdapter.TrackCircuitNavigation(navigator)
+
+    // Optionally extract arguments/metadata from the current Screen:
+    // CircuitAdapter.TrackCircuitNavigation(
+    //     navigator,
+    //     extractArguments = { screen -> mapOf("userId" to (screen as? ProfileScreen)?.userId) }
+    // )
+
+    NavigableCircuitContent(navigator, backStack)
+}
+```
+
+The Circuit dependency is declared `compileOnly`, so this integration only compiles when your app
+already depends on Circuit.
+
+For finer-grained control you can track a single `Screen`, or a raw destination string:
+
+```kotlin
+// Track a specific Screen; the destination name is derived from the screen's class.
+CircuitAdapter.trackScreen(ProfileScreen(userId), arguments = mapOf("userId" to userId))
+
+// Track a raw destination name when you are not holding a Screen.
+CircuitAdapter.trackNavigation(destination = "ProfileScreen", arguments = mapOf("userId" to userId))
 ```
 
 ### Manual Tracking

--- a/android/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/android/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -273,14 +273,33 @@ public final class dev.jasonpearson.automobile.sdk.SdkConstants {
   public static final int $stable;
 }
 Compiled from "CircuitAdapter.kt"
+final class dev.jasonpearson.automobile.sdk.adapters.CircuitAdapter$TrackCircuitNavigation$4$1$2<T> implements kotlinx.coroutines.flow.FlowCollector {
+  public final java.lang.Object emit(com.slack.circuit.runtime.screen.Screen, kotlin.coroutines.Continuation<? super kotlin.Unit>);
+  public java.lang.Object emit(java.lang.Object, kotlin.coroutines.Continuation);
+}
+Compiled from "CircuitAdapter.kt"
+final class dev.jasonpearson.automobile.sdk.adapters.CircuitAdapter$TrackCircuitNavigation$4$1 extends kotlin.coroutines.jvm.internal.SuspendLambda implements kotlin.jvm.functions.Function2<kotlinx.coroutines.CoroutineScope, kotlin.coroutines.Continuation<? super kotlin.Unit>, java.lang.Object> {
+  public final java.lang.Object invokeSuspend(java.lang.Object);
+  public final kotlin.coroutines.Continuation<kotlin.Unit> create(java.lang.Object, kotlin.coroutines.Continuation<?>);
+  public final java.lang.Object invoke(kotlinx.coroutines.CoroutineScope, kotlin.coroutines.Continuation<? super kotlin.Unit>);
+  public java.lang.Object invoke(java.lang.Object, java.lang.Object);
+}
+Compiled from "CircuitAdapter.kt"
 public final class dev.jasonpearson.automobile.sdk.adapters.CircuitAdapter implements dev.jasonpearson.automobile.sdk.adapters.NavigationFrameworkAdapter {
   public static final dev.jasonpearson.automobile.sdk.adapters.CircuitAdapter INSTANCE;
   public static final int $stable;
   public void start();
   public void stop();
   public boolean isActive();
+  public final void TrackCircuitNavigation(com.slack.circuit.runtime.Navigator, kotlin.jvm.functions.Function1<? super com.slack.circuit.runtime.screen.Screen, ? extends java.util.Map<java.lang.String, ? extends java.lang.Object>>, kotlin.jvm.functions.Function1<? super com.slack.circuit.runtime.screen.Screen, ? extends java.util.Map<java.lang.String, java.lang.String>>, androidx.compose.runtime.Composer, int, int);
+  public final void trackScreen(com.slack.circuit.runtime.screen.Screen, java.util.Map<java.lang.String, ? extends java.lang.Object>, java.util.Map<java.lang.String, java.lang.String>);
+  public static void trackScreen$default(dev.jasonpearson.automobile.sdk.adapters.CircuitAdapter, com.slack.circuit.runtime.screen.Screen, java.util.Map, java.util.Map, int, java.lang.Object);
   public final void trackNavigation(java.lang.String, java.util.Map<java.lang.String, ? extends java.lang.Object>, java.util.Map<java.lang.String, java.lang.String>);
   public static void trackNavigation$default(dev.jasonpearson.automobile.sdk.adapters.CircuitAdapter, java.lang.String, java.util.Map, java.util.Map, int, java.lang.Object);
+}
+Compiled from "CircuitAdapter.kt"
+public final class dev.jasonpearson.automobile.sdk.adapters.CircuitAdapterKt {
+  public static final java.lang.String circuitDestinationName(java.lang.Object);
 }
 Compiled from "Navigation3Adapter.kt"
 final class dev.jasonpearson.automobile.sdk.adapters.Navigation3Adapter$TrackNavigation$4$1 extends kotlin.coroutines.jvm.internal.SuspendLambda implements kotlin.jvm.functions.Function2<kotlinx.coroutines.CoroutineScope, kotlin.coroutines.Continuation<? super kotlin.Unit>, java.lang.Object> {

--- a/android/auto-mobile-sdk/build.gradle.kts
+++ b/android/auto-mobile-sdk/build.gradle.kts
@@ -71,12 +71,17 @@ dependencies {
   // Navigation3 support for Compose navigation tracking
   implementation(libs.navigation3.runtime)
 
+  // Circuit — compileOnly so consumers who use Circuit bring their own dependency.
+  // The SDK only references the stable Navigator/Screen surface for automatic tracking.
+  compileOnly(libs.circuit.runtime)
+
   // Test dependencies
   testImplementation(libs.kotlin.test)
   testImplementation(libs.junit)
   testImplementation(libs.bundles.unit.test)
   testImplementation(libs.robolectric)
   testImplementation(libs.okhttp)
+  testImplementation(libs.circuit.runtime)
 }
 
 // Configure Kotlin compilation options

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/adapters/CircuitAdapter.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/adapters/CircuitAdapter.kt
@@ -141,9 +141,12 @@ object CircuitAdapter : NavigationFrameworkAdapter {
 /**
  * Derives a stable, human-readable destination name from a Circuit destination.
  *
- * Prefers the runtime class's simple name (e.g. `ProfileScreen`) and falls back to `toString()` for
- * anonymous destinations whose class has no simple name. Accepts [Any] rather than `Screen` so the
- * logic can be unit-tested without depending on Circuit types.
+ * Prefers the runtime class's simple name (e.g. `ProfileScreen`) and falls back to the fully
+ * qualified class name for anonymous destinations whose class has no simple name. The fallback uses
+ * `javaClass.name` rather than `toString()` because the default `Any.toString()` is identity-based
+ * on the JVM (`ClassName@hashCode`), which would give two instances of the same anonymous screen
+ * different names. Accepts [Any] rather than `Screen` so the logic can be unit-tested without
+ * depending on Circuit types.
  */
 internal fun circuitDestinationName(destination: Any): String =
-  destination::class.simpleName ?: destination.toString()
+  destination::class.simpleName ?: destination.javaClass.name

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/adapters/CircuitAdapter.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/adapters/CircuitAdapter.kt
@@ -1,26 +1,39 @@
 package dev.jasonpearson.automobile.sdk.adapters
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
+import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.screen.Screen
 import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import dev.jasonpearson.automobile.sdk.NavigationEvent
 import dev.jasonpearson.automobile.sdk.NavigationSource
+import kotlinx.coroutines.flow.distinctUntilChanged
 
 /**
- * Adapter for Circuit navigation library by Slack.
+ * Adapter for the Circuit navigation library by Slack.
  *
- * Circuit uses a different navigation approach with screens and presenters. To use this adapter,
- * you'll need to manually call trackNavigation when navigating.
+ * There are three ways to integrate, from most to least automatic:
+ * 1. [TrackCircuitNavigation] — a drop-in Composable hook. Register it once with your [Navigator]
+ *    and every destination change (goTo/pop/resetRoot) is tracked automatically.
+ * 2. [trackScreen] — track a single [Screen] instance; the destination name is derived from the
+ *    screen's class.
+ * 3. [trackNavigation] — track a raw destination string when you are not holding a [Screen].
  *
- * Usage:
+ * Automatic usage:
  * ```kotlin
- * // When navigating in Circuit
- * CircuitAdapter.trackNavigation(
- *     destination = screen::class.simpleName ?: "Unknown",
- *     arguments = mapOf("screenParam" to value)
- * )
- * ```
+ * @Composable
+ * fun App(circuit: Circuit) {
+ *   val backStack = rememberSaveableBackStack(root = HomeScreen)
+ *   val navigator = rememberCircuitNavigator(backStack)
  *
- * For automatic tracking, consider wrapping your Circuit Navigator implementation to call
- * trackNavigation on navigation events.
+ *   // Register once — destinations are tracked as the back stack changes.
+ *   CircuitAdapter.TrackCircuitNavigation(navigator)
+ *
+ *   NavigableCircuitContent(navigator, backStack)
+ * }
+ * ```
  */
 object CircuitAdapter : NavigationFrameworkAdapter {
   private var isActive = false
@@ -36,7 +49,72 @@ object CircuitAdapter : NavigationFrameworkAdapter {
   override fun isActive(): Boolean = isActive
 
   /**
-   * Manually track a navigation event in Circuit.
+   * Composable hook that automatically tracks Circuit navigation for the given [navigator].
+   *
+   * Observes the top of the navigator's back stack via [snapshotFlow] and emits a [NavigationEvent]
+   * whenever the current [Screen] changes — covering forward navigation, pops, and root resets
+   * without any per-call bookkeeping. The adapter is started automatically the first time this hook
+   * enters composition.
+   *
+   * Reactive tracking relies on the navigator's back stack being backed by Compose snapshot state,
+   * which is the case for the standard `rememberCircuitNavigator`.
+   *
+   * @param navigator The Circuit [Navigator] whose destinations should be tracked
+   * @param extractArguments Optional function to extract arguments from the current [Screen]
+   * @param extractMetadata Optional function to extract metadata from the current [Screen]
+   */
+  @Composable
+  fun TrackCircuitNavigation(
+    navigator: Navigator,
+    extractArguments: (Screen) -> Map<String, Any?> = { emptyMap() },
+    extractMetadata: (Screen) -> Map<String, String> = { emptyMap() },
+  ) {
+    // Enable tracking when first used.
+    DisposableEffect(Unit) {
+      if (!isActive) start()
+      onDispose {}
+    }
+
+    LaunchedEffect(navigator) {
+      snapshotFlow { navigator.peek() }
+        .distinctUntilChanged()
+        .collect { screen ->
+          if (screen == null) return@collect
+          val arguments =
+            try {
+              extractArguments(screen)
+            } catch (e: Exception) {
+              emptyMap()
+            }
+          val metadata =
+            try {
+              extractMetadata(screen)
+            } catch (e: Exception) {
+              emptyMap()
+            }
+          trackScreen(screen, arguments, metadata)
+        }
+    }
+  }
+
+  /**
+   * Track a navigation event for a Circuit [Screen]. The destination name is derived from the
+   * screen's class name.
+   *
+   * @param screen The destination screen being navigated to
+   * @param arguments Optional navigation arguments
+   * @param metadata Optional metadata about the navigation
+   */
+  fun trackScreen(
+    screen: Screen,
+    arguments: Map<String, Any?> = emptyMap(),
+    metadata: Map<String, String> = emptyMap(),
+  ) {
+    trackNavigation(circuitDestinationName(screen), arguments, metadata)
+  }
+
+  /**
+   * Manually track a navigation event in Circuit using a raw destination name.
    *
    * @param destination The destination screen name
    * @param arguments Optional navigation arguments
@@ -59,3 +137,13 @@ object CircuitAdapter : NavigationFrameworkAdapter {
     )
   }
 }
+
+/**
+ * Derives a stable, human-readable destination name from a Circuit destination.
+ *
+ * Prefers the runtime class's simple name (e.g. `ProfileScreen`) and falls back to `toString()` for
+ * anonymous destinations whose class has no simple name. Accepts [Any] rather than `Screen` so the
+ * logic can be unit-tested without depending on Circuit types.
+ */
+internal fun circuitDestinationName(destination: Any): String =
+  destination::class.simpleName ?: destination.toString()

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/adapters/CircuitAdapterTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/adapters/CircuitAdapterTest.kt
@@ -1,5 +1,7 @@
 package dev.jasonpearson.automobile.sdk.adapters
 
+import android.os.Parcel
+import com.slack.circuit.runtime.screen.Screen
 import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import dev.jasonpearson.automobile.sdk.NavigationEvent
 import dev.jasonpearson.automobile.sdk.NavigationSource
@@ -108,6 +110,46 @@ class CircuitAdapterTest {
   }
 
   @Test
+  fun `trackScreen should derive destination from screen class name`() {
+    var receivedEvent: NavigationEvent? = null
+    AutoMobileSDK.addNavigationListener { event -> receivedEvent = event }
+
+    CircuitAdapter.start()
+    CircuitAdapter.trackScreen(ProfileScreen)
+
+    assertNotNull(receivedEvent)
+    assertEquals("ProfileScreen", receivedEvent?.destination)
+    assertEquals(NavigationSource.CIRCUIT, receivedEvent?.source)
+  }
+
+  @Test
+  fun `trackScreen should forward arguments and metadata`() {
+    var receivedEvent: NavigationEvent? = null
+    AutoMobileSDK.addNavigationListener { event -> receivedEvent = event }
+
+    val arguments = mapOf("userId" to "123")
+    val metadata = mapOf("transition" to "slide")
+
+    CircuitAdapter.start()
+    CircuitAdapter.trackScreen(ProfileScreen, arguments = arguments, metadata = metadata)
+
+    assertNotNull(receivedEvent)
+    assertEquals(arguments, receivedEvent?.arguments)
+    assertEquals(metadata, receivedEvent?.metadata)
+  }
+
+  @Test
+  fun `trackScreen should not notify SDK when inactive`() {
+    var receivedEvent: NavigationEvent? = null
+    AutoMobileSDK.addNavigationListener { event -> receivedEvent = event }
+
+    // Don't start the adapter.
+    CircuitAdapter.trackScreen(ProfileScreen)
+
+    assertNull(receivedEvent)
+  }
+
+  @Test
   fun `multiple trackNavigation calls should trigger multiple events`() {
     val receivedEvents = mutableListOf<NavigationEvent>()
     AutoMobileSDK.addNavigationListener { event -> receivedEvents.add(event) }
@@ -121,5 +163,12 @@ class CircuitAdapterTest {
     assertEquals("Screen1", receivedEvents[0].destination)
     assertEquals("Screen2", receivedEvents[1].destination)
     assertEquals("Screen3", receivedEvents[2].destination)
+  }
+
+  /** Minimal fake Circuit [Screen] used to exercise class-name-based destination derivation. */
+  private object ProfileScreen : Screen {
+    override fun describeContents(): Int = 0
+
+    override fun writeToParcel(dest: Parcel, flags: Int) = Unit
   }
 }

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/adapters/CircuitDestinationNameTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/adapters/CircuitDestinationNameTest.kt
@@ -1,0 +1,33 @@
+package dev.jasonpearson.automobile.sdk.adapters
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Unit tests for [circuitDestinationName], the Circuit destination-name derivation helper. */
+class CircuitDestinationNameTest {
+
+  private object HomeScreen
+
+  private class ProfileScreen
+
+  @Test
+  fun `named object resolves to its simple name`() {
+    assertEquals("HomeScreen", circuitDestinationName(HomeScreen))
+  }
+
+  @Test
+  fun `named class instance resolves to its simple name`() {
+    assertEquals("ProfileScreen", circuitDestinationName(ProfileScreen()))
+  }
+
+  @Test
+  fun `anonymous destination falls back to toString`() {
+    val anonymous = object {}
+
+    val name = circuitDestinationName(anonymous)
+
+    // Anonymous classes have no simple name, so the helper must fall back to a non-empty value.
+    assertTrue(name.isNotEmpty())
+  }
+}

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/adapters/CircuitDestinationNameTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/adapters/CircuitDestinationNameTest.kt
@@ -22,12 +22,15 @@ class CircuitDestinationNameTest {
   }
 
   @Test
-  fun `anonymous destination falls back to toString`() {
-    val anonymous = object {}
+  fun `anonymous destinations resolve to a stable name across instances`() {
+    // Each call instantiates the same anonymous class, so the derived name must be identical —
+    // the identity-based Any#toString() would otherwise differ per instance.
+    fun newAnonymousDestination(): Any = object {}
 
-    val name = circuitDestinationName(anonymous)
+    val first = circuitDestinationName(newAnonymousDestination())
+    val second = circuitDestinationName(newAnonymousDestination())
 
-    // Anonymous classes have no simple name, so the helper must fall back to a non-empty value.
-    assertTrue(name.isNotEmpty())
+    assertTrue(first.isNotEmpty())
+    assertEquals(first, second)
   }
 }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -60,6 +60,7 @@ test-androidx-espresso = "3.7.0"
 
 # Navigation versions
 navigation3 = "1.1.4"              # Used in playground app
+circuit = "0.35.1"                 # Slack Circuit; compileOnly in auto-mobile-sdk
 
 # Kotlin ecosystem
 kotlinx-serialization-json = "1.11.0"
@@ -117,6 +118,7 @@ metro-runtime = { module = "dev.zacsweers.metro:runtime", version.ref = "metro" 
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "navigation3" }
 navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
+circuit-runtime = { module = "com.slack.circuit:circuit-runtime", version.ref = "circuit" }
 
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }


### PR DESCRIPTION
## Summary

The Android SDK's Circuit integration previously required calling `CircuitAdapter.trackNavigation(...)` manually on every navigation — there was no automatic "register once and forget" hook like `Navigation3Adapter` offers for Navigation3.

This adds a drop-in `@Composable` hook, **`CircuitAdapter.TrackCircuitNavigation(navigator)`**, that observes the navigator's back stack via `snapshotFlow { navigator.peek() }` and tracks every destination change — forward navigation, pops, and root resets — automatically. It auto-starts the adapter on first composition and supports optional `extractArguments` / `extractMetadata` lambdas, mirroring `Navigation3Adapter.TrackNavigation`.

Also adds:
- **`CircuitAdapter.trackScreen(screen: Screen, …)`** — track a single Circuit `Screen`, deriving the destination name from the screen's class.
- **`circuitDestinationName(Any)`** — the destination-name derivation extracted into an internal, Circuit-free helper so the logic is unit-tested without depending on Circuit types.

Circuit is declared **`compileOnly`** (mirroring the existing OkHttp pattern), so apps that use Circuit bring their own dependency and the SDK stays lean for everyone else. The hook only touches the stable `Navigator.peek()` / `Screen` surface to stay resilient across Circuit versions (the `Navigator` interface itself changes shape between releases, so a decorator was deliberately avoided).

## Linked Issue

<!-- No tracking issue; opened from a direct request. -->

## Validation

- [x] Android changes: ran the matching `scripts/` validation — `scripts/ktfmt/validate_ktfmt.sh` passes tree-wide
- [x] `:auto-mobile-sdk:testDebugUnitTest` passes (14 Circuit tests, incl. 3 new `trackScreen` cases + 3 new `circuitDestinationName` cases)
- [x] `:auto-mobile-sdk:detektMain` / `:detektTest` pass
- [x] New code uses a Circuit-free helper + fakes; unit tests run in <100ms
- [x] `:auto-mobile-sdk:apiDump` regenerated for the new public surface (Circuit section only, to keep the diff focused)

## Kotlin Reuse Check

- [x] Checked existing adapters (`Navigation3Adapter`), Compose runtime (`snapshotFlow`), and coroutines (`distinctUntilChanged`) before adding anything; no new helper/util files
- [x] New dependency (`com.slack.circuit:circuit-runtime`) is declared `compileOnly` and justified above: it is the framework this hook integrates with, referenced only via its stable `Navigator`/`Screen` surface

## Device Verification

- [ ] Not run — this is a library API/composable addition. The Android SDK build isn't part of on-device `observe` flows; covered by unit tests instead.

## Follow-ups

- The checked-in `api/auto-mobile-sdk.api` baseline was already stale relative to `main` (unrelated public-API drift). This PR updates only the `CircuitAdapter` section to stay focused; a full `apiDump` regeneration is left as a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zETuxFeiy1uXrKjaex1Xs

---
_Generated by [Claude Code](https://claude.ai/code/session_014zETuxFeiy1uXrKjaex1Xs)_