### PR TITLE
feat(android): track CircuitX navigation destinations

### DIFF
--- a/android/auto-mobile-sdk/README.md
+++ b/android/auto-mobile-sdk/README.md
@@ -81,15 +81,64 @@ fun AppNavigation() {
 
 ### Circuit Integration
 
-For Circuit navigation, use manual tracking:
+For automatic Circuit destination tracking, add CircuitX Navigation to your application:
 
 ```kotlin
-// When navigating in Circuit
+dependencies {
+    implementation("com.slack.circuit:circuitx-navigation:0.35.1")
+}
+```
+
+Create the AutoMobile listener and add it to your existing CircuitX navigator wrapper:
+
+```kotlin
+@Composable
+fun App() {
+    val autoMobileListener =
+        CircuitAdapter.rememberCircuitNavigationEventListener(
+            extractArguments = { screen -> screen.autoMobileArguments() },
+            extractMetadata = { screen -> screen.autoMobileMetadata() },
+        )
+
+    val navigator =
+        rememberInterceptingNavigator(
+            navigator = baseNavigator,
+            interceptors = interceptors,
+            eventListeners = existingListeners + autoMobileListener,
+        )
+
+    NavigableCircuitContent(navigator, navStack)
+}
+```
+
+The listener records the initial active screen and later committed stack mutations. It records the
+final active screen after an interceptor rewrites a navigation operation, and does not emit a
+destination for a consumed operation that leaves the stack unchanged.
+
+Register a listener with every independent or nested `InterceptingNavigator` whose destinations
+you want to track. The SDK keeps CircuitX optional, so the application provides the CircuitX
+dependency and chooses its version.
+
+Use manual tracking for plain `rememberCircuitNavigator(...)` instances, destinations outside the
+Circuit stack, or presentation-lifecycle events:
+
+```kotlin
+// Track a Circuit screen while preserving its type-derived destination name.
+CircuitAdapter.trackScreen(
+    screen = profileScreen,
+    arguments = mapOf("userId" to userId),
+)
+
+// Track a destination that is not represented by a Circuit Screen.
 CircuitAdapter.trackNavigation(
-    destination = "ProfileScreen",
-    arguments = mapOf("userId" to userId)
+    destination = "ExternalProfile",
+    arguments = mapOf("userId" to userId),
 )
 ```
+
+CircuitX listeners do not observe plain Circuit navigators, consumed drawer or overlay operations,
+legacy fragments or activities, custom tabs, external intents, or a screen's visual-settled state
+after an animation. Track those destinations at the layer that presents them.
 
 ### Manual Tracking
 

--- a/android/auto-mobile-sdk/README.md
+++ b/android/auto-mobile-sdk/README.md
@@ -123,6 +123,9 @@ Use manual tracking for plain `rememberCircuitNavigator(...)` instances, destina
 Circuit stack, or presentation-lifecycle events:
 
 ```kotlin
+// Start the adapter once during application initialization.
+CircuitAdapter.start()
+
 // Track a Circuit screen while preserving its type-derived destination name.
 CircuitAdapter.trackScreen(
     screen = profileScreen,

--- a/android/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/android/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -273,16 +273,6 @@ public final class dev.jasonpearson.automobile.sdk.SdkConstants {
   public static final int $stable;
 }
 Compiled from "CircuitAdapter.kt"
-public final class dev.jasonpearson.automobile.sdk.adapters.CircuitAdapter$rememberCircuitNavigationEventListener$3$1 implements com.slack.circuitx.navigation.intercepting.NavigationEventListener {
-  public void onNavStackChanged(com.slack.circuit.runtime.navigation.NavStackList<com.slack.circuit.runtime.screen.Screen>, com.slack.circuitx.navigation.intercepting.NavigationContext);
-  public void onBackStackChanged(java.util.List<? extends com.slack.circuit.runtime.screen.Screen>, com.slack.circuitx.navigation.intercepting.NavigationContext);
-  public void goTo(com.slack.circuit.runtime.screen.Screen, com.slack.circuitx.navigation.intercepting.NavigationContext);
-  public void pop(com.slack.circuit.runtime.screen.PopResult, com.slack.circuitx.navigation.intercepting.NavigationContext);
-  public void forward(com.slack.circuitx.navigation.intercepting.NavigationContext);
-  public void backward(com.slack.circuitx.navigation.intercepting.NavigationContext);
-  public void resetRoot(com.slack.circuit.runtime.screen.Screen, com.slack.circuit.runtime.Navigator$StateOptions, com.slack.circuitx.navigation.intercepting.NavigationContext);
-}
-Compiled from "CircuitAdapter.kt"
 public final class dev.jasonpearson.automobile.sdk.adapters.CircuitAdapter implements dev.jasonpearson.automobile.sdk.adapters.NavigationFrameworkAdapter {
   public static final dev.jasonpearson.automobile.sdk.adapters.CircuitAdapter INSTANCE;
   public static final int $stable;

--- a/android/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/android/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -273,12 +273,25 @@ public final class dev.jasonpearson.automobile.sdk.SdkConstants {
   public static final int $stable;
 }
 Compiled from "CircuitAdapter.kt"
+public final class dev.jasonpearson.automobile.sdk.adapters.CircuitAdapter$rememberCircuitNavigationEventListener$3$1 implements com.slack.circuitx.navigation.intercepting.NavigationEventListener {
+  public void onNavStackChanged(com.slack.circuit.runtime.navigation.NavStackList<com.slack.circuit.runtime.screen.Screen>, com.slack.circuitx.navigation.intercepting.NavigationContext);
+  public void onBackStackChanged(java.util.List<? extends com.slack.circuit.runtime.screen.Screen>, com.slack.circuitx.navigation.intercepting.NavigationContext);
+  public void goTo(com.slack.circuit.runtime.screen.Screen, com.slack.circuitx.navigation.intercepting.NavigationContext);
+  public void pop(com.slack.circuit.runtime.screen.PopResult, com.slack.circuitx.navigation.intercepting.NavigationContext);
+  public void forward(com.slack.circuitx.navigation.intercepting.NavigationContext);
+  public void backward(com.slack.circuitx.navigation.intercepting.NavigationContext);
+  public void resetRoot(com.slack.circuit.runtime.screen.Screen, com.slack.circuit.runtime.Navigator$StateOptions, com.slack.circuitx.navigation.intercepting.NavigationContext);
+}
+Compiled from "CircuitAdapter.kt"
 public final class dev.jasonpearson.automobile.sdk.adapters.CircuitAdapter implements dev.jasonpearson.automobile.sdk.adapters.NavigationFrameworkAdapter {
   public static final dev.jasonpearson.automobile.sdk.adapters.CircuitAdapter INSTANCE;
   public static final int $stable;
   public void start();
   public void stop();
   public boolean isActive();
+  public final com.slack.circuitx.navigation.intercepting.NavigationEventListener rememberCircuitNavigationEventListener(kotlin.jvm.functions.Function1<? super com.slack.circuit.runtime.screen.Screen, ? extends java.util.Map<java.lang.String, ? extends java.lang.Object>>, kotlin.jvm.functions.Function1<? super com.slack.circuit.runtime.screen.Screen, ? extends java.util.Map<java.lang.String, java.lang.String>>, androidx.compose.runtime.Composer, int, int);
+  public final void trackScreen(com.slack.circuit.runtime.screen.Screen, java.util.Map<java.lang.String, ? extends java.lang.Object>, java.util.Map<java.lang.String, java.lang.String>);
+  public static void trackScreen$default(dev.jasonpearson.automobile.sdk.adapters.CircuitAdapter, com.slack.circuit.runtime.screen.Screen, java.util.Map, java.util.Map, int, java.lang.Object);
   public final void trackNavigation(java.lang.String, java.util.Map<java.lang.String, ? extends java.lang.Object>, java.util.Map<java.lang.String, java.lang.String>);
   public static void trackNavigation$default(dev.jasonpearson.automobile.sdk.adapters.CircuitAdapter, java.lang.String, java.util.Map, java.util.Map, int, java.lang.Object);
 }

--- a/android/auto-mobile-sdk/build.gradle.kts
+++ b/android/auto-mobile-sdk/build.gradle.kts
@@ -71,12 +71,17 @@ dependencies {
   // Navigation3 support for Compose navigation tracking
   implementation(libs.navigation3.runtime)
 
+  // Optional CircuitX support. Consumers provide CircuitX when using this integration.
+  compileOnly(libs.circuitx.navigation)
+
   // Test dependencies
   testImplementation(libs.kotlin.test)
   testImplementation(libs.junit)
   testImplementation(libs.bundles.unit.test)
   testImplementation(libs.robolectric)
   testImplementation(libs.okhttp)
+  testImplementation(libs.circuit.test)
+  testImplementation(libs.circuitx.navigation)
 }
 
 // Configure Kotlin compilation options

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/adapters/CircuitAdapter.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/adapters/CircuitAdapter.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.sdk.adapters
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import com.slack.circuit.runtime.navigation.NavStackList
@@ -61,19 +62,24 @@ object CircuitAdapter : NavigationFrameworkAdapter {
     return remember {
       if (!isActive) start()
 
-      object : NavigationEventListener {
-        override fun onNavStackChanged(
-          navStack: NavStackList<Screen>?,
-          navigationContext: NavigationContext,
-        ) {
-          val screen = navStack?.active ?: return
-          trackScreen(
-            screen = screen,
-            arguments = currentExtractArguments.value(screen),
-            metadata = currentExtractMetadata.value(screen),
-          )
-        }
-      }
+      CircuitNavigationEventListener(currentExtractArguments, currentExtractMetadata)
+    }
+  }
+
+  private class CircuitNavigationEventListener(
+    private val extractArguments: State<(Screen) -> Map<String, Any?>>,
+    private val extractMetadata: State<(Screen) -> Map<String, String>>,
+  ) : NavigationEventListener {
+    override fun onNavStackChanged(
+      navStack: NavStackList<Screen>?,
+      navigationContext: NavigationContext,
+    ) {
+      val screen = navStack?.active ?: return
+      CircuitAdapter.trackScreen(
+        screen = screen,
+        arguments = extractArguments.value(screen),
+        metadata = extractMetadata.value(screen),
+      )
     }
   }
 

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/adapters/CircuitAdapter.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/adapters/CircuitAdapter.kt
@@ -1,5 +1,12 @@
 package dev.jasonpearson.automobile.sdk.adapters
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import com.slack.circuit.runtime.navigation.NavStackList
+import com.slack.circuit.runtime.screen.Screen
+import com.slack.circuitx.navigation.intercepting.NavigationContext
+import com.slack.circuitx.navigation.intercepting.NavigationEventListener
 import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import dev.jasonpearson.automobile.sdk.NavigationEvent
 import dev.jasonpearson.automobile.sdk.NavigationSource
@@ -7,20 +14,17 @@ import dev.jasonpearson.automobile.sdk.NavigationSource
 /**
  * Adapter for Circuit navigation library by Slack.
  *
- * Circuit uses a different navigation approach with screens and presenters. To use this adapter,
- * you'll need to manually call trackNavigation when navigating.
+ * Circuit uses a different navigation approach with screens and presenters. Applications using
+ * CircuitX can register [rememberCircuitNavigationEventListener] with each
+ * `rememberInterceptingNavigator` instance to track committed stack changes automatically.
  *
- * Usage:
+ * Manual tracking remains available for navigation that CircuitX does not observe:
  * ```kotlin
- * // When navigating in Circuit
  * CircuitAdapter.trackNavigation(
  *     destination = screen::class.simpleName ?: "Unknown",
  *     arguments = mapOf("screenParam" to value)
  * )
  * ```
- *
- * For automatic tracking, consider wrapping your Circuit Navigator implementation to call
- * trackNavigation on navigation events.
  */
 object CircuitAdapter : NavigationFrameworkAdapter {
   private var isActive = false
@@ -34,6 +38,63 @@ object CircuitAdapter : NavigationFrameworkAdapter {
   }
 
   override fun isActive(): Boolean = isActive
+
+  /**
+   * Creates a listener for CircuitX
+   * [com.slack.circuitx.navigation.intercepting.InterceptingNavigator] instances.
+   *
+   * Register the returned listener with each navigator whose destinations should be tracked. It
+   * reports the initial active screen and each subsequent committed stack change. Extractors use
+   * their latest recomposed values without replacing the listener.
+   *
+   * @param extractArguments Extracts navigation arguments from the active screen.
+   * @param extractMetadata Extracts navigation metadata from the active screen.
+   */
+  @Composable
+  fun rememberCircuitNavigationEventListener(
+    extractArguments: (Screen) -> Map<String, Any?> = { emptyMap() },
+    extractMetadata: (Screen) -> Map<String, String> = { emptyMap() },
+  ): NavigationEventListener {
+    val currentExtractArguments = rememberUpdatedState(extractArguments)
+    val currentExtractMetadata = rememberUpdatedState(extractMetadata)
+
+    if (!isActive) start()
+
+    return remember {
+      object : NavigationEventListener {
+        override fun onNavStackChanged(
+          navStack: NavStackList<Screen>?,
+          navigationContext: NavigationContext,
+        ) {
+          val screen = navStack?.active ?: return
+          trackScreen(
+            screen = screen,
+            arguments = currentExtractArguments.value(screen),
+            metadata = currentExtractMetadata.value(screen),
+          )
+        }
+      }
+    }
+  }
+
+  /**
+   * Manually track a Circuit [Screen].
+   *
+   * @param screen The Circuit screen to track.
+   * @param arguments Optional navigation arguments.
+   * @param metadata Optional navigation metadata.
+   */
+  fun trackScreen(
+    screen: Screen,
+    arguments: Map<String, Any?> = emptyMap(),
+    metadata: Map<String, String> = emptyMap(),
+  ) {
+    trackNavigation(
+      destination = screen::class.simpleName ?: screen::class.java.name,
+      arguments = arguments,
+      metadata = metadata,
+    )
+  }
 
   /**
    * Manually track a navigation event in Circuit.

--- a/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/adapters/CircuitAdapter.kt
+++ b/android/auto-mobile-sdk/src/main/kotlin/dev/jasonpearson/automobile/sdk/adapters/CircuitAdapter.kt
@@ -58,9 +58,9 @@ object CircuitAdapter : NavigationFrameworkAdapter {
     val currentExtractArguments = rememberUpdatedState(extractArguments)
     val currentExtractMetadata = rememberUpdatedState(extractMetadata)
 
-    if (!isActive) start()
-
     return remember {
+      if (!isActive) start()
+
       object : NavigationEventListener {
         override fun onNavStackChanged(
           navStack: NavStackList<Screen>?,

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/adapters/CircuitNavigationEventListenerTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/adapters/CircuitNavigationEventListenerTest.kt
@@ -1,0 +1,387 @@
+package dev.jasonpearson.automobile.sdk.adapters
+
+import android.os.Parcel
+import androidx.compose.runtime.Applier
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Composition
+import androidx.compose.runtime.MonotonicFrameClock
+import androidx.compose.runtime.Recomposer
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.Snapshot
+import com.slack.circuit.foundation.NavEvent
+import com.slack.circuit.foundation.navstack.SaveableNavStack
+import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.screen.Screen
+import com.slack.circuit.test.FakeNavigator
+import com.slack.circuitx.navigation.intercepting.InterceptedResult
+import com.slack.circuitx.navigation.intercepting.NavigationContext
+import com.slack.circuitx.navigation.intercepting.NavigationEventListener
+import com.slack.circuitx.navigation.intercepting.NavigationInterceptor
+import com.slack.circuitx.navigation.intercepting.rememberInterceptingNavigator
+import dev.jasonpearson.automobile.sdk.AutoMobileSDK
+import dev.jasonpearson.automobile.sdk.NavigationEvent
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.CoroutineContext
+
+class CircuitNavigationEventListenerTest {
+
+  @Before
+  fun setUp() {
+    AutoMobileSDK.clearNavigationListeners()
+    AutoMobileSDK.setEnabled(true)
+    CircuitAdapter.stop()
+  }
+
+  @After
+  fun tearDown() {
+    AutoMobileSDK.clearNavigationListeners()
+    CircuitAdapter.stop()
+  }
+
+  @Test
+  fun `listener tracks the initial screen and committed navigation stack changes`() = runTest {
+    val events = collectEvents()
+    val delegate = fakeNavigator(HomeScreen)
+    lateinit var navigator: Navigator
+    val composition = TestComposition()
+
+    try {
+      composition.setContent {
+        val listener = CircuitAdapter.rememberCircuitNavigationEventListener()
+        navigator =
+          rememberInterceptingNavigator(
+            navigator = delegate,
+            eventListeners = listOf(listener),
+            enableBackHandler = false,
+          )
+      }
+
+      composition.awaitIdle()
+      navigator.goTo(DetailScreen("one"))
+      composition.awaitIdle()
+      navigator.backward()
+      composition.awaitIdle()
+      navigator.forward()
+      composition.awaitIdle()
+      navigator.pop()
+      composition.awaitIdle()
+      navigator.resetRoot(SettingsScreen)
+      composition.awaitIdle()
+
+      assertEquals(
+        listOf(
+          "HomeScreen",
+          "DetailScreen",
+          "HomeScreen",
+          "DetailScreen",
+          "HomeScreen",
+          "SettingsScreen",
+        ),
+        events.map(NavigationEvent::destination),
+      )
+    } finally {
+      composition.dispose()
+    }
+  }
+
+  @Test
+  fun `trackScreen remains available for manual Circuit tracking`() {
+    val events = collectEvents()
+
+    CircuitAdapter.start()
+    CircuitAdapter.trackScreen(
+      screen = DetailScreen("manual"),
+      arguments = mapOf("id" to "manual"),
+      metadata = mapOf("source" to "manual"),
+    )
+
+    assertEquals("DetailScreen", events.single().destination)
+    assertEquals(mapOf("id" to "manual"), events.single().arguments)
+    assertEquals(mapOf("source" to "manual"), events.single().metadata)
+  }
+
+  @Test
+  fun `listener reports equal screen values for each committed stack mutation`() = runTest {
+    val events = collectEvents()
+    val delegate = fakeNavigator(HomeScreen)
+    lateinit var navigator: Navigator
+    val composition = TestComposition()
+
+    try {
+      composition.setContent {
+        val listener = CircuitAdapter.rememberCircuitNavigationEventListener()
+        navigator =
+          rememberInterceptingNavigator(
+            navigator = delegate,
+            eventListeners = listOf(listener),
+            enableBackHandler = false,
+          )
+      }
+
+      composition.awaitIdle()
+      navigator.goTo(DetailScreen("same"))
+      composition.awaitIdle()
+      navigator.resetRoot(DetailScreen("same"))
+      composition.awaitIdle()
+
+      assertEquals(
+        listOf("HomeScreen", "DetailScreen", "DetailScreen"),
+        events.map(NavigationEvent::destination),
+      )
+    } finally {
+      composition.dispose()
+    }
+  }
+
+  @Test
+  fun `listener reports the rewritten destination and ignores consumed operations`() = runTest {
+    val events = collectEvents()
+    val rewrittenNavigator = fakeNavigator(HomeScreen)
+    val consumedNavigator = fakeNavigator(SettingsScreen)
+    lateinit var rewritten: Navigator
+    lateinit var consumed: Navigator
+    val composition = TestComposition()
+
+    try {
+      composition.setContent {
+        val listener = CircuitAdapter.rememberCircuitNavigationEventListener()
+        rewritten =
+          rememberInterceptingNavigator(
+            navigator = rewrittenNavigator,
+            interceptors = listOf(RewriteGoToInterceptor),
+            eventListeners = listOf(listener),
+            enableBackHandler = false,
+          )
+        consumed =
+          rememberInterceptingNavigator(
+            navigator = consumedNavigator,
+            interceptors = listOf(ConsumeGoToInterceptor),
+            eventListeners = listOf(listener),
+            enableBackHandler = false,
+          )
+      }
+
+      composition.awaitIdle()
+      rewritten.goTo(RequestedScreen)
+      composition.awaitIdle()
+      consumed.goTo(RequestedScreen)
+      composition.awaitIdle()
+
+      assertEquals(
+        listOf("HomeScreen", "SettingsScreen", "RewrittenScreen"),
+        events.map(NavigationEvent::destination),
+      )
+    } finally {
+      composition.dispose()
+    }
+  }
+
+  @Test
+  fun `listener remains stable and uses updated extractors after recomposition`() = runTest {
+    val events = collectEvents()
+    val delegate = fakeNavigator(HomeScreen)
+    var useUpdatedExtractors by mutableStateOf(false)
+    lateinit var navigator: Navigator
+    var listener: NavigationEventListener? = null
+    val composition = TestComposition()
+
+    try {
+      composition.setContent {
+        listener =
+          CircuitAdapter.rememberCircuitNavigationEventListener(
+            extractArguments = { screen ->
+              mapOf(
+                "extractor" to if (useUpdatedExtractors) "updated" else "initial",
+                "screen" to screen,
+              )
+            },
+            extractMetadata = {
+              mapOf("metadata" to if (useUpdatedExtractors) "updated" else "initial")
+            },
+          )
+        navigator =
+          rememberInterceptingNavigator(
+            navigator = delegate,
+            eventListeners = listOf(requireNotNull(listener)),
+            enableBackHandler = false,
+          )
+      }
+
+      composition.awaitIdle()
+      val initialListener = requireNotNull(listener)
+      useUpdatedExtractors = true
+      composition.awaitIdle()
+      navigator.goTo(DetailScreen("updated"))
+      composition.awaitIdle()
+
+      assertSame(initialListener, listener)
+      assertEquals("updated", events.last().arguments["extractor"])
+      assertEquals("updated", events.last().metadata["metadata"])
+    } finally {
+      composition.dispose()
+    }
+  }
+
+  @Test
+  fun `independent navigator registrations each track their destinations`() = runTest {
+    val events = collectEvents()
+    val outerDelegate = fakeNavigator(HomeScreen)
+    val nestedDelegate = fakeNavigator(SettingsScreen)
+    lateinit var outerNavigator: Navigator
+    lateinit var nestedNavigator: Navigator
+    val composition = TestComposition()
+
+    try {
+      composition.setContent {
+        val outerListener = CircuitAdapter.rememberCircuitNavigationEventListener()
+        val nestedListener = CircuitAdapter.rememberCircuitNavigationEventListener()
+        outerNavigator =
+          rememberInterceptingNavigator(
+            navigator = outerDelegate,
+            eventListeners = listOf(outerListener),
+            enableBackHandler = false,
+          )
+        nestedNavigator =
+          rememberInterceptingNavigator(
+            navigator = nestedDelegate,
+            eventListeners = listOf(nestedListener),
+            enableBackHandler = false,
+          )
+      }
+
+      composition.awaitIdle()
+      outerNavigator.goTo(DetailScreen("outer"))
+      nestedNavigator.goTo(DetailScreen("nested"))
+      composition.awaitIdle()
+
+      assertEquals(
+        listOf("HomeScreen", "SettingsScreen", "DetailScreen", "DetailScreen"),
+        events.map(NavigationEvent::destination),
+      )
+    } finally {
+      composition.dispose()
+    }
+  }
+
+  private fun collectEvents(): MutableList<NavigationEvent> {
+    return mutableListOf<NavigationEvent>().also { events ->
+      AutoMobileSDK.addNavigationListener(events::add)
+    }
+  }
+
+  private fun fakeNavigator(root: Screen): FakeNavigator = FakeNavigator(SaveableNavStack(root))
+
+  private data object HomeScreen : Screen {
+    override fun describeContents(): Int = 0
+
+    override fun writeToParcel(dest: Parcel, flags: Int) = Unit
+  }
+
+  private data object SettingsScreen : Screen {
+    override fun describeContents(): Int = 0
+
+    override fun writeToParcel(dest: Parcel, flags: Int) = Unit
+  }
+
+  private data class DetailScreen(val id: String) : Screen {
+    override fun describeContents(): Int = 0
+
+    override fun writeToParcel(dest: Parcel, flags: Int) = Unit
+  }
+
+  private data object RequestedScreen : Screen {
+    override fun describeContents(): Int = 0
+
+    override fun writeToParcel(dest: Parcel, flags: Int) = Unit
+  }
+
+  private data object RewrittenScreen : Screen {
+    override fun describeContents(): Int = 0
+
+    override fun writeToParcel(dest: Parcel, flags: Int) = Unit
+  }
+
+  private object RewriteGoToInterceptor : NavigationInterceptor {
+    override fun goTo(
+      screen: Screen,
+      navigationContext: NavigationContext,
+    ): InterceptedResult {
+      return if (screen == RequestedScreen) {
+        InterceptedResult.Rewrite(NavEvent.GoTo(RewrittenScreen))
+      } else {
+        InterceptedResult.Success(consumed = false)
+      }
+    }
+  }
+
+  private object ConsumeGoToInterceptor : NavigationInterceptor {
+    override fun goTo(
+      screen: Screen,
+      navigationContext: NavigationContext,
+    ): InterceptedResult {
+      return NavigationInterceptor.SuccessConsumed
+    }
+  }
+
+  private class TestComposition {
+    private val scope = CoroutineScope(Dispatchers.Unconfined + ImmediateFrameClock)
+    private val recomposer = Recomposer(scope.coroutineContext)
+    private val composition = Composition(UnitApplier(), recomposer)
+
+    init {
+      scope.launch { recomposer.runRecomposeAndApplyChanges() }
+    }
+
+    fun setContent(content: @Composable () -> Unit) {
+      composition.setContent(content)
+    }
+
+    suspend fun awaitIdle() {
+      Snapshot.sendApplyNotifications()
+      recomposer.awaitIdle()
+    }
+
+    fun dispose() {
+      composition.dispose()
+      recomposer.close()
+      scope.cancel()
+    }
+  }
+
+  private object ImmediateFrameClock : MonotonicFrameClock {
+    override val key: CoroutineContext.Key<*> = MonotonicFrameClock
+
+    override suspend fun <R> withFrameNanos(onFrame: (Long) -> R): R {
+      return onFrame(System.nanoTime())
+    }
+  }
+
+  private class UnitApplier : Applier<Unit> {
+    override val current: Unit = Unit
+
+    override fun down(node: Unit) = Unit
+
+    override fun up() = Unit
+
+    override fun insertBottomUp(index: Int, instance: Unit) = Unit
+
+    override fun insertTopDown(index: Int, instance: Unit) = Unit
+
+    override fun move(from: Int, to: Int, count: Int) = Unit
+
+    override fun remove(index: Int, count: Int) = Unit
+
+    override fun clear() = Unit
+  }
+}

--- a/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/adapters/CircuitNavigationEventListenerTest.kt
+++ b/android/auto-mobile-sdk/src/test/kotlin/dev/jasonpearson/automobile/sdk/adapters/CircuitNavigationEventListenerTest.kt
@@ -22,17 +22,19 @@ import com.slack.circuitx.navigation.intercepting.NavigationInterceptor
 import com.slack.circuitx.navigation.intercepting.rememberInterceptingNavigator
 import dev.jasonpearson.automobile.sdk.AutoMobileSDK
 import dev.jasonpearson.automobile.sdk.NavigationEvent
-import org.junit.After
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertSame
-import org.junit.Before
-import org.junit.Test
+import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
-import kotlin.coroutines.CoroutineContext
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
 
 class CircuitNavigationEventListenerTest {
 
@@ -228,6 +230,32 @@ class CircuitNavigationEventListenerTest {
       assertSame(initialListener, listener)
       assertEquals("updated", events.last().arguments["extractor"])
       assertEquals("updated", events.last().metadata["metadata"])
+    } finally {
+      composition.dispose()
+    }
+  }
+
+  @Test
+  fun `stop remains effective after listener recomposition`() = runTest {
+    var recompositionVersion by mutableStateOf(0)
+    val composition = TestComposition()
+
+    try {
+      composition.setContent {
+        val currentVersion = recompositionVersion
+        CircuitAdapter.rememberCircuitNavigationEventListener(
+          extractMetadata = { mapOf("version" to currentVersion.toString()) }
+        )
+      }
+
+      composition.awaitIdle()
+      assertTrue(CircuitAdapter.isActive())
+
+      CircuitAdapter.stop()
+      recompositionVersion = 1
+      composition.awaitIdle()
+
+      assertFalse(CircuitAdapter.isActive())
     } finally {
       composition.dispose()
     }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -60,6 +60,7 @@ test-androidx-espresso = "3.7.0"
 
 # Navigation versions
 navigation3 = "1.1.4"              # Used in playground app
+circuit = "0.35.1"
 
 # Kotlin ecosystem
 kotlinx-serialization-json = "1.11.0"
@@ -117,6 +118,8 @@ metro-runtime = { module = "dev.zacsweers.metro:runtime", version.ref = "metro" 
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 navigation3-runtime = { module = "androidx.navigation3:navigation3-runtime", version.ref = "navigation3" }
 navigation3-ui = { module = "androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
+circuit-test = { module = "com.slack.circuit:circuit-test", version.ref = "circuit" }
+circuitx-navigation = { module = "com.slack.circuit:circuitx-navigation", version.ref = "circuit" }
 
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }


### PR DESCRIPTION
## Summary

- Adds optional CircuitX navigation support to the Android SDK.
- Adds a composition-time navigation listener that records initial and subsequent destinations, with current metadata extractors across recomposition.
- Adds `trackScreen` for manual destination tracking plus focused navigation coverage and SDK documentation.

## Impact

Android SDK consumers can automatically capture CircuitX navigation destinations without replacing their existing navigator behavior.

Closes https://github.com/kaeawc/auto-mobile/issues/4430

## Validation

- `GRADLE_USER_HOME=/private/tmp/auto-mobile-gradle-4430 ./gradlew :auto-mobile-sdk:testDebugUnitTest :auto-mobile-sdk:detektMain :auto-mobile-sdk:detektTest`
- `ONLY_TOUCHED_FILES=true scripts/ktfmt/validate_ktfmt.sh`
- `GRADLE_USER_HOME=/private/tmp/auto-mobile-gradle-4430 ./gradlew --no-configuration-cache :auto-mobile-sdk:apiDump`
- `bun run turbo:validate` (9,495 passed, 14 skipped)
- `bun run typecheck` (no new errors; 211 existing baseline errors)
- `git diff --check`

## Known Limitation

`GRADLE_USER_HOME=/private/tmp/auto-mobile-gradle-4430 ./gradlew --no-configuration-cache :auto-mobile-sdk:apiCheck` still fails because the checked-in API baseline has unrelated stale drift. The API dump was reviewed and reduced to the new CircuitX listener and `trackScreen` entries only.
