### PR TITLE
fix(android): add key-event-only input mode

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -2615,12 +2615,13 @@
           "minLength": 1
         },
         "mode": {
-          "description": "Android text mode: a11y default; eventLast helps autocomplete; eventAll sends key events",
+          "description": "Android text mode: a11y default; eventLast and eventAll start with accessibility setText; eventOnly clears and types supported ASCII with key events only",
           "type": "string",
           "enum": [
             "a11y",
             "eventLast",
-            "eventAll"
+            "eventAll",
+            "eventOnly"
           ]
         },
         "imeAction": {

--- a/src/features/action/ClearText.ts
+++ b/src/features/action/ClearText.ts
@@ -1,6 +1,7 @@
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
+import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { BaseVisualChange, ProgressCallback } from "./BaseVisualChange";
-import { BootedDevice, ClearTextResult } from "../../models";
+import { BootedDevice, ClearTextResult, ViewHierarchyResult } from "../../models";
 import type { ElementParser } from "../../utils/interfaces/ElementParser";
 import { DefaultElementParser } from "../utility/ElementParser";
 import { ObserveResult } from "../../models";
@@ -9,6 +10,64 @@ import { AndroidCtrlProxyClient } from "../observe/android";
 import { IOSCtrlProxyClient } from "../observe/ios";
 import { logger } from "../../utils/logger";
 import { ANDROID_INPUT_CLASSES } from "../../utils/elementProperties";
+
+export function getFocusedTextLength(
+  viewHierarchy: ViewHierarchyResult,
+  parser: ElementParser = new DefaultElementParser()
+): number {
+  let textLength = 0;
+  const rootNodes = parser.extractRootNodes(viewHierarchy);
+
+  for (const rootNode of rootNodes) {
+    parser.traverseNode(rootNode, (node: any) => {
+      const nodeProperties = parser.extractNodeProperties(node);
+      if ((nodeProperties.focused === "true" || nodeProperties.focused === true) &&
+        nodeProperties.text && typeof nodeProperties.text === "string") {
+        textLength = Math.max(textLength, nodeProperties.text.length);
+      }
+    });
+  }
+
+  return textLength;
+}
+
+export function hasFocusedTextInput(
+  viewHierarchy: ViewHierarchyResult,
+  parser: ElementParser = new DefaultElementParser()
+): boolean {
+  const rootNodes = parser.extractRootNodes(viewHierarchy);
+
+  for (const rootNode of rootNodes) {
+    let found = false;
+    parser.traverseNode(rootNode, (node: any) => {
+      if (found) {
+        return;
+      }
+
+      const nodeProperties = parser.extractNodeProperties(node);
+      const nodeClass = nodeProperties.class ?? nodeProperties.className;
+      if ((nodeProperties.focused === "true" || nodeProperties.focused === true) &&
+        typeof nodeClass === "string" &&
+        ANDROID_INPUT_CLASSES.some(inputClass => nodeClass.includes(inputClass))) {
+        found = true;
+      }
+    });
+
+    if (found) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export async function clearTextWithKeyEvents(adb: AdbExecutor, count: number): Promise<void> {
+  await adb.executeCommand("shell input keyevent KEYCODE_MOVE_END");
+
+  for (let index = 0; index < count; index++) {
+    await adb.executeCommand("shell input keyevent KEYCODE_DEL");
+  }
+}
 
 export class ClearText extends BaseVisualChange {
   private parser: ElementParser;
@@ -88,10 +147,7 @@ export class ClearText extends BaseVisualChange {
       return { success: true };
     }
 
-    let textLength = 0;
-
-    // Look for focused elements first by traversing and checking attributes
-    textLength = this.findFocusedElementTextLength(observeResult.viewHierarchy);
+    const textLength = getFocusedTextLength(observeResult.viewHierarchy, this.parser);
 
     // TODO: Move cursor to the end of the text
 
@@ -125,23 +181,6 @@ export class ClearText extends BaseVisualChange {
     }
   }
 
-  private findFocusedElementTextLength(viewHierarchy: any): number {
-    let textLength = 0;
-    const rootNodes = this.parser.extractRootNodes(viewHierarchy);
-
-    for (const rootNode of rootNodes) {
-      this.parser.traverseNode(rootNode, (node: any) => {
-        const nodeProperties = this.parser.extractNodeProperties(node);
-        if ((nodeProperties.focused === "true" || nodeProperties.focused === true) &&
-          nodeProperties.text && typeof nodeProperties.text === "string") {
-          textLength = Math.max(textLength, nodeProperties.text.length);
-        }
-      });
-    }
-
-    return textLength;
-  }
-
   private findAnyTextInputLength(viewHierarchy: any): number {
     let textLength = 0;
     const rootNodes = this.parser.extractRootNodes(viewHierarchy);
@@ -161,12 +200,6 @@ export class ClearText extends BaseVisualChange {
   }
 
   private async clearWithDeletes(count: number): Promise<void> {
-    // Move to end of field first to ensure we're deleting from the right position
-    await this.adb.executeCommand("shell input keyevent KEYCODE_MOVE_END");
-
-    // Send KEYCODE_DEL commands with no delay
-    for (let i = 0; i < count; i++) {
-      await this.adb.executeCommand("shell input keyevent KEYCODE_DEL");
-    }
+    await clearTextWithKeyEvents(this.adb, count);
   }
 }

--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -1,5 +1,5 @@
 import { BaseVisualChange } from "./BaseVisualChange";
-import { BootedDevice, ImeAction, SendTextResult } from "../../models";
+import { BootedDevice, ImeAction, KeyboardResult, ObserveResult, SendTextResult } from "../../models";
 import { logger } from "../../utils/logger";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { AndroidCtrlProxyClient } from "../observe/android";
@@ -10,18 +10,37 @@ import type { AdbClientFactory } from "../../utils/android-cmdline-tools/AdbClie
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { resolveAutoInputMode } from "./resolveAutoInputMode";
 import { serverConfig } from "../../utils/ServerConfig";
+import { clearTextWithKeyEvents, getFocusedTextLength, hasFocusedTextInput } from "./ClearText";
 import {
   ANDROID_KEYCOMBINATION_MIN_API_LEVEL,
   buildAsciiKeyEventPlan,
   type KeyEventPlan
 } from "./asciiKeyEvents";
+import { Keyboard } from "./Keyboard";
 
-export type InputTextMode = "a11y" | "eventLast" | "eventAll";
+export type InputTextMode = "a11y" | "eventLast" | "eventAll" | "eventOnly";
+
+interface KeyboardCloser {
+  close(): Promise<KeyboardResult>;
+}
+
+type KeyboardCloserFactory = (device: BootedDevice, adbFactory: AdbClientFactory) => KeyboardCloser;
+
+const defaultKeyboardCloserFactory: KeyboardCloserFactory = (device, adbFactory) => {
+  const keyboard = new Keyboard(device, adbFactory);
+  return {
+    close: () => keyboard.execute("close")
+  };
+};
 
 export class InputText extends BaseVisualChange {
   private androidInputKeyCombinationSupported: boolean | undefined;
 
-  constructor(device: BootedDevice, adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = null) {
+  constructor(
+    device: BootedDevice,
+    adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = null,
+    private readonly keyboardCloserFactory: KeyboardCloserFactory = defaultKeyboardCloserFactory
+  ) {
     super(device, adbFactoryOrExecutor);
     this.device = device;
   }
@@ -62,13 +81,19 @@ export class InputText extends BaseVisualChange {
     }
 
     return this.observedInteraction(
-      async () => {
+      async previousObserveResult => {
         try {
           // Platform-specific text input execution
           switch (this.device.platform) {
             case "android":
               return await perf.track("androidTextInput", () =>
-                this.executeAndroidTextInput(text, imeAction, dismissKeyboard, resolvedMode)
+                this.executeAndroidTextInput(
+                  text,
+                  imeAction,
+                  dismissKeyboard,
+                  resolvedMode,
+                  previousObserveResult
+                )
               );
             case "ios":
               // dismissKeyboard is Android-only — it works around an emulator
@@ -113,7 +138,8 @@ export class InputText extends BaseVisualChange {
     text: string,
     imeAction?: ImeAction,
     dismissKeyboard: boolean = false,
-    mode: InputTextMode = "a11y"
+    mode: InputTextMode = "a11y",
+    previousObserveResult?: ObserveResult
   ): Promise<SendTextResult & { method?: InputTextMode }> {
     if (mode === "eventLast") {
       return this.executeAndroidEventLastTextInput(text, imeAction, dismissKeyboard);
@@ -121,6 +147,15 @@ export class InputText extends BaseVisualChange {
 
     if (mode === "eventAll") {
       return this.executeAndroidEventAllTextInput(text, imeAction, dismissKeyboard);
+    }
+
+    if (mode === "eventOnly") {
+      return this.executeAndroidEventOnlyTextInput(
+        text,
+        imeAction,
+        dismissKeyboard,
+        previousObserveResult
+      );
     }
 
     // Use accessibility service exclusively (fastest method, ~10-30ms vs ~200-300ms for ADB)
@@ -263,6 +298,76 @@ export class InputText extends BaseVisualChange {
       text,
       imeAction,
       method: "eventAll"
+    };
+  }
+
+  private async executeAndroidEventOnlyTextInput(
+    text: string,
+    imeAction: ImeAction | undefined,
+    dismissKeyboard: boolean,
+    previousObserveResult?: ObserveResult
+  ): Promise<SendTextResult & { method?: InputTextMode }> {
+    const keyEventPlans: KeyEventPlan[] = [];
+    for (const char of Array.from(text)) {
+      const keyEventPlan = await this.getAsciiKeyEventPlan(char);
+      if (!keyEventPlan) {
+        return {
+          success: false,
+          text,
+          error: `eventOnly cannot type ${JSON.stringify(char)} with Android key events`,
+          method: "eventOnly"
+        };
+      }
+      keyEventPlans.push(keyEventPlan);
+    }
+
+    const viewHierarchy = previousObserveResult?.viewHierarchy;
+    if (!viewHierarchy) {
+      return {
+        success: false,
+        text,
+        error: "eventOnly requires a current view hierarchy to clear the focused field",
+        method: "eventOnly"
+      };
+    }
+
+    if (!hasFocusedTextInput(viewHierarchy)) {
+      return {
+        success: false,
+        text,
+        error: "eventOnly requires a focused editable field",
+        method: "eventOnly"
+      };
+    }
+
+    await clearTextWithKeyEvents(this.adb, getFocusedTextLength(viewHierarchy));
+    for (const keyEventPlan of keyEventPlans) {
+      await this.executeKeyEventPlan(keyEventPlan);
+    }
+
+    if (dismissKeyboard) {
+      const keyboardResult = await this.keyboardCloserFactory(this.device, this.adbFactory).close();
+      if (!keyboardResult.success) {
+        return {
+          success: false,
+          text,
+          error: `eventOnly input completed but keyboard dismissal failed: ${
+            keyboardResult.error ?? keyboardResult.message ?? "unknown error"
+          }`,
+          method: "eventOnly"
+        };
+      }
+    }
+
+    if (imeAction) {
+      await this.executeImeAction(imeAction);
+    }
+
+    return {
+      success: true,
+      text,
+      imeAction,
+      method: "eventOnly"
     };
   }
 

--- a/src/server/interactionToolTypes.ts
+++ b/src/server/interactionToolTypes.ts
@@ -38,7 +38,7 @@ export interface SystemTrayArgs {
 
 export interface InputTextArgs {
   text: string;
-  mode?: "a11y" | "eventLast" | "eventAll";
+  mode?: "a11y" | "eventLast" | "eventAll" | "eventOnly";
   imeAction?: ImeAction;
   dismissKeyboard?: boolean;
   platform: Platform;

--- a/src/server/interactionTools.ts
+++ b/src/server/interactionTools.ts
@@ -338,8 +338,8 @@ export const clearStateSchema = withAppIdAliases(addDeviceTargetingToSchema(z.ob
 
 export const inputTextSchema = addDeviceTargetingToSchema(z.object({
   text: z.string().min(1),
-  mode: z.enum(["a11y", "eventLast", "eventAll"]).optional()
-    .describe("Android text mode: a11y default; eventLast helps autocomplete; eventAll sends key events"),
+  mode: z.enum(["a11y", "eventLast", "eventAll", "eventOnly"]).optional()
+    .describe("Android text mode: a11y default; eventLast and eventAll start with accessibility setText; eventOnly clears and types supported ASCII with key events only"),
   imeAction: z.enum(["done", "next", "search", "send", "go", "previous"]).optional()
     .describe("IME action after input"),
   dismissKeyboard: z.boolean().optional()

--- a/test/features/action/InputText.test.ts
+++ b/test/features/action/InputText.test.ts
@@ -3,7 +3,7 @@ import { InputText } from "../../../src/features/action/InputText";
 import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 import type { InputTextMode } from "../../../src/features/action/InputText";
-import type { BootedDevice } from "../../../src/models";
+import type { BootedDevice, ObserveResult } from "../../../src/models";
 import type { AdbClientFactory } from "../../../src/utils/android-cmdline-tools/AdbClientFactory";
 
 interface TestInputText {
@@ -11,7 +11,8 @@ interface TestInputText {
     text: string,
     imeAction?: undefined,
     dismissKeyboard?: boolean,
-    mode?: InputTextMode
+    mode?: InputTextMode,
+    previousObserveResult?: ObserveResult
   ) => Promise<{ success: boolean; error?: string; method?: string }>;
 }
 
@@ -38,6 +39,24 @@ function stubAndroidSetText(requestSetText: RequestSetText): void {
 function inputCommands(factory: FakeAdbClientFactory): string[] {
   return factory.getFakeClient().getAllCommands()
     .filter(command => command.startsWith("shell input "));
+}
+
+function observeResultWithFocusedText(
+  text: string,
+  properties: Record<string, unknown> = {}
+): ObserveResult {
+  return {
+    viewHierarchy: {
+      hierarchy: {
+        node: {
+          focused: true,
+          class: "android.widget.EditText",
+          text,
+          ...properties
+        }
+      }
+    }
+  } as ObserveResult;
 }
 
 describe("InputText", () => {
@@ -298,6 +317,241 @@ describe("InputText", () => {
     expect(result.success).toBe(true);
     expect(result.method).toBe("a11y");
     expect(setTextCalls).toEqual(["你好😊"]);
+    expect(inputCommands(factory)).toEqual([]);
+  });
+
+  test("eventOnly clears and types mappable text without requestSetText", async () => {
+    const factory = new FakeAdbClientFactory();
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+    const setTextCalls: string[] = [];
+    factory.getFakeClient().setCommandResult("shell getprop ro.build.version.sdk", "31\n");
+
+    stubAndroidSetText(async text => {
+      setTextCalls.push(text);
+      return { success: true, totalTimeMs: 1 };
+    });
+
+    const result = await testInputText(inputText).executeAndroidTextInput(
+      "@ab C",
+      undefined,
+      false,
+      "eventOnly",
+      observeResultWithFocusedText("old")
+    );
+
+    expect(result).toEqual({
+      success: true,
+      text: "@ab C",
+      imeAction: undefined,
+      method: "eventOnly"
+    });
+    expect(setTextCalls).toEqual([]);
+    expect(inputCommands(factory)).toEqual([
+      "shell input keyevent KEYCODE_MOVE_END",
+      "shell input keyevent KEYCODE_DEL",
+      "shell input keyevent KEYCODE_DEL",
+      "shell input keyevent KEYCODE_DEL",
+      "shell input keyevent KEYCODE_AT",
+      "shell input keyevent KEYCODE_A",
+      "shell input keyevent KEYCODE_B",
+      "shell input keyevent KEYCODE_SPACE",
+      "shell input keycombination KEYCODE_SHIFT_LEFT KEYCODE_C"
+    ]);
+  });
+
+  test("eventOnly rejects unsupported text without requestSetText or key events", async () => {
+    const factory = new FakeAdbClientFactory();
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+    const setTextCalls: string[] = [];
+
+    stubAndroidSetText(async text => {
+      setTextCalls.push(text);
+      return { success: true, totalTimeMs: 1 };
+    });
+
+    const result = await testInputText(inputText).executeAndroidTextInput(
+      "hello 你好",
+      undefined,
+      false,
+      "eventOnly",
+      observeResultWithFocusedText("existing")
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.method).toBe("eventOnly");
+    expect(result.error).toContain("cannot type");
+    expect(setTextCalls).toEqual([]);
+    expect(inputCommands(factory)).toEqual([]);
+  });
+
+  test("eventOnly rejects shifted ASCII before Android 12 without requestSetText or key events", async () => {
+    const factory = new FakeAdbClientFactory();
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+    const setTextCalls: string[] = [];
+    factory.getFakeClient().setCommandResult("shell getprop ro.build.version.sdk", "30\n");
+
+    stubAndroidSetText(async text => {
+      setTextCalls.push(text);
+      return { success: true, totalTimeMs: 1 };
+    });
+
+    const result = await testInputText(inputText).executeAndroidTextInput(
+      "A",
+      undefined,
+      false,
+      "eventOnly",
+      observeResultWithFocusedText("existing")
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.method).toBe("eventOnly");
+    expect(result.error).toContain("cannot type");
+    expect(setTextCalls).toEqual([]);
+    expect(inputCommands(factory)).toEqual([]);
+  });
+
+  test.each([
+    ["no focused node", { focused: false }],
+    ["a focused non-input node", { class: "android.widget.TextView" }]
+  ])("eventOnly rejects %s before sending input events", async (_description, properties) => {
+    const factory = new FakeAdbClientFactory();
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+
+    const result = await testInputText(inputText).executeAndroidTextInput(
+      "next",
+      undefined,
+      false,
+      "eventOnly",
+      observeResultWithFocusedText("existing", properties)
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.method).toBe("eventOnly");
+    expect(result.error).toBe("eventOnly requires a focused editable field");
+    expect(inputCommands(factory)).toEqual([]);
+  });
+
+  test("eventOnly delegates keyboard dismissal to the keyboard closer", async () => {
+    const factory = new FakeAdbClientFactory();
+    const closeCalls: string[] = [];
+    factory.getFakeClient().setCommandResult("shell getprop ro.build.version.sdk", "31\n");
+    const inputText = new InputText(
+      androidDevice,
+      factory as AdbClientFactory,
+      () => ({
+        close: async () => {
+          closeCalls.push("close");
+          return { success: true, open: false, message: "Keyboard already closed" };
+        }
+      })
+    );
+
+    const result = await testInputText(inputText).executeAndroidTextInput(
+      "next",
+      undefined,
+      true,
+      "eventOnly",
+      observeResultWithFocusedText("old")
+    );
+
+    expect(result.success).toBe(true);
+    expect(closeCalls).toEqual(["close"]);
+    expect(inputCommands(factory)).toEqual([
+      "shell input keyevent KEYCODE_MOVE_END",
+      "shell input keyevent KEYCODE_DEL",
+      "shell input keyevent KEYCODE_DEL",
+      "shell input keyevent KEYCODE_DEL",
+      "shell input keyevent KEYCODE_N",
+      "shell input keyevent KEYCODE_E",
+      "shell input keyevent KEYCODE_X",
+      "shell input keyevent KEYCODE_T"
+    ]);
+  });
+
+  test("eventOnly reports a keyboard dismissal failure without sending raw Back", async () => {
+    const factory = new FakeAdbClientFactory();
+    factory.getFakeClient().setCommandResult("shell getprop ro.build.version.sdk", "31\n");
+    const inputText = new InputText(
+      androidDevice,
+      factory as AdbClientFactory,
+      () => ({
+        close: async () => ({
+          success: false,
+          open: true,
+          error: "Keyboard state unavailable"
+        })
+      })
+    );
+
+    const result = await testInputText(inputText).executeAndroidTextInput(
+      "next",
+      undefined,
+      true,
+      "eventOnly",
+      observeResultWithFocusedText("old")
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Keyboard state unavailable");
+    expect(inputCommands(factory)).toEqual([
+      "shell input keyevent KEYCODE_MOVE_END",
+      "shell input keyevent KEYCODE_DEL",
+      "shell input keyevent KEYCODE_DEL",
+      "shell input keyevent KEYCODE_DEL",
+      "shell input keyevent KEYCODE_N",
+      "shell input keyevent KEYCODE_E",
+      "shell input keyevent KEYCODE_X",
+      "shell input keyevent KEYCODE_T"
+    ]);
+  });
+
+  test("a11y reports setText timeouts without sending key events", async () => {
+    const factory = new FakeAdbClientFactory();
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+    const setTextCalls: string[] = [];
+
+    stubAndroidSetText(async text => {
+      setTextCalls.push(text);
+      return { success: false, error: "Set text timed out after 5000ms", totalTimeMs: 5000 };
+    });
+
+    const result = await testInputText(inputText).executeAndroidTextInput(
+      "next",
+      undefined,
+      false,
+      "a11y",
+      observeResultWithFocusedText("old")
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.method).toBe("a11y");
+    expect(result.error).toContain("Set text timed out after 5000ms");
+    expect(setTextCalls).toEqual(["next"]);
+    expect(inputCommands(factory)).toEqual([]);
+  });
+
+  test("a11y does not fall back to eventOnly for non-timeout failures", async () => {
+    const factory = new FakeAdbClientFactory();
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+    const setTextCalls: string[] = [];
+
+    stubAndroidSetText(async text => {
+      setTextCalls.push(text);
+      return { success: false, error: "No focused editable node found", totalTimeMs: 1 };
+    });
+
+    const result = await testInputText(inputText).executeAndroidTextInput(
+      "next",
+      undefined,
+      false,
+      "a11y",
+      observeResultWithFocusedText("old")
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.method).toBe("a11y");
+    expect(result.error).toContain("No focused editable node found");
+    expect(setTextCalls).toEqual(["next"]);
     expect(inputCommands(factory)).toEqual([]);
   });
 });

--- a/test/server/toolSchemaHelpers.test.ts
+++ b/test/server/toolSchemaHelpers.test.ts
@@ -404,14 +404,14 @@ describe("platform field accepted by all device-targeting tool schemas", () => {
 
 describe("inputTextSchema", () => {
   test("accepts supported Android input modes", () => {
-    for (const mode of ["a11y", "eventLast", "eventAll"]) {
+    for (const mode of ["a11y", "eventLast", "eventAll", "eventOnly"]) {
       const result = inputTextSchema.safeParse({ text: "hello", mode, platform: "android" });
       expect(result.success).toBe(true);
     }
   });
 
   test("accepts input modes for iOS callers so runtime can ignore them", () => {
-    for (const mode of ["a11y", "eventLast", "eventAll"]) {
+    for (const mode of ["a11y", "eventLast", "eventAll", "eventOnly"]) {
       const result = inputTextSchema.safeParse({ text: "hello", mode, platform: "ios" });
       expect(result.success).toBe(true);
     }


### PR DESCRIPTION
## Summary

- Add Android `inputText` mode `eventOnly`, which clears the observed focused value and types supported text with ADB key events without calling accessibility `requestSetText`.
- Keep default accessibility input single-path: a timeout is reported to the caller, which can explicitly retry with `eventOnly` when its text is supported.
- Reuse the keyboard state-aware close flow for `eventOnly` so `dismissKeyboard` never sends Back when the IME is already closed.
- Document the existing accessibility dependence of `eventLast` and `eventAll`, and regenerate the published tool definitions.

## Root Cause

All existing Android input modes depended on accessibility `setText`, so an otherwise focused field that timed out had no usable input path.

## Validation

- `bun test test/features/action/InputText.test.ts test/features/action/Keyboard.test.ts test/server/toolSchemaHelpers.test.ts`
- `bun run typecheck`
- `bun run turbo:validate`

Closes [#4429](https://github.com/kaeawc/auto-mobile/issues/4429)
