### PR TITLE
fix(observe): normalize literal control-byte separators

### DIFF
--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -523,7 +523,7 @@ function boundsKey(bounds: unknown): string {
 function nodeKey(node: Record<string, unknown>, siblingIndex: number): string {
   const resourceId = node["resource-id"] ?? "";
   const text = node["text"] ?? "";
-  return [resourceId, boundsKey(node["bounds"]), text, siblingIndex].join(" ");
+  return [resourceId, boundsKey(node["bounds"]), text, siblingIndex].join("\0");
 }
 
 /**
@@ -531,7 +531,7 @@ function nodeKey(node: Record<string, unknown>, siblingIndex: number): string {
  * distinct control char (U+0001) from the intra-key NUL (U+0000) so the two
  * levels of joining can never be confused.
  */
-const PATH_KEY_SEP = "";
+const PATH_KEY_SEP = "\x01";
 
 /** A node's own attributes, excluding the `node` child array (diffed separately). */
 function nodeAttributes(node: Record<string, unknown>): Record<string, unknown> {
@@ -751,7 +751,7 @@ function contentIdentityKey(attrs: Record<string, unknown>): string | null {
   // NUL-joined: `text`/`content-desc` can contain spaces, so a space separator
   // could let a value straddle a field boundary and collide; NUL cannot appear
   // in these attribute strings.
-  return [resourceId, viewId, contentDesc, text].join(" ");
+  return [resourceId, viewId, contentDesc, text].join("\0");
 }
 
 /** Index leftover diff nodes by their content-identity key, dropping keyless nodes. */
@@ -940,7 +940,7 @@ function iosStableIdentityKey(node: DiffRepairNode): string | null {
   if (boundsRegion === "") {
     return null;
   }
-  return [stableId, className, boundsRegion].join(" ");
+  return [stableId, className, boundsRegion].join("\0");
 }
 
 function indexByIosStableKey(nodes: DiffRepairNode[]): Map<string, number[]> {

--- a/test/features/observe/output/ObserveResultOutput.sourceIntegrity.test.ts
+++ b/test/features/observe/output/ObserveResultOutput.sourceIntegrity.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+const SOURCE_PATH = join(import.meta.dir, "../../../../src/features/observe/output/ObserveResultOutput.ts");
+
+describe("ObserveResultOutput source integrity", () => {
+  test("contains no literal ASCII control bytes beyond whitespace", () => {
+    const source = readFileSync(SOURCE_PATH);
+    const controls = source.filter(byte => byte < 32 && byte !== 9 && byte !== 10 && byte !== 13);
+    expect(controls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Replaced literal control bytes in `ObserveResultOutput.ts` with equivalent TypeScript escape sequences. The source now stays text-classified for diffs and merges while preserving every identity-key separator at runtime.

## Linked Issue

Closes [#4397](https://github.com/kaeawc/auto-mobile/issues/4397)

## Bug / Regression Context

- **Observed symptom:** literal NUL bytes caused the source file to be classified as binary data, hiding diffs and degrading merges.
- **Root cause:** identity-key separators were embedded as raw control bytes rather than source escapes.

## Validation

- [x] Focused observe-output suite: 152 passing tests
- [x] `bun run typecheck` reports no new errors
- [x] `bun run turbo:validate` passes (9,543 tests; 14 expected integration skips)
- [x] `file src/features/observe/output/ObserveResultOutput.ts` reports UTF-8 text
- [x] `git diff --check`
