### PR TITLE
test(utils): property-based tests for pure util helpers

### DIFF
--- a/test/utils/Random.property.test.ts
+++ b/test/utils/Random.property.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+import { CryptoRandom } from "../../src/utils/Random";
+
+// Property-based tests. See Backoff.property.test.ts for the pinned-seed rationale.
+//
+// CryptoRandom draws from the crypto RNG and is intentionally NOT seedable, so
+// the pinned fast-check seed makes only the *generated inputs* deterministic.
+// Every property asserted here is invariant over the random draw itself (a value
+// in [0, 1) always lands on a valid index), so the outcome never flakes.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+const nonEmptyArray = fc.array(fc.anything(), { minLength: 1, maxLength: 32 });
+
+describe("CryptoRandom (property-based)", () => {
+  test("next() always returns a value in [0, 1)", () => {
+    fc.assert(
+      // The generated integer is unused: it just drives 300 fresh draws.
+      fc.property(fc.integer(), () => {
+        const value = new CryptoRandom().next();
+        return value >= 0 && value < 1;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("pick() always returns a member of the input array", () => {
+    fc.assert(
+      fc.property(nonEmptyArray, items => items.includes(new CryptoRandom().pick(items))),
+      RUN_OPTIONS
+    );
+  });
+
+  test("pick() from a single-element array returns that element", () => {
+    fc.assert(
+      // includes() uses SameValueZero so a NaN element still matches itself.
+      fc.property(fc.anything(), only => [only].includes(new CryptoRandom().pick([only]))),
+      RUN_OPTIONS
+    );
+  });
+
+  test("pick() from an empty array always throws", () => {
+    const random = new CryptoRandom();
+    fc.assert(
+      fc.property(fc.constant(null), () => {
+        expect(() => random.pick([])).toThrow(/empty array/);
+        return true;
+      }),
+      RUN_OPTIONS
+    );
+  });
+});

--- a/test/utils/percentile.property.test.ts
+++ b/test/utils/percentile.property.test.ts
@@ -1,0 +1,59 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import { computePercentile } from "../../src/utils/percentile";
+
+// Property-based tests. See Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+// Non-empty ascending arrays of finite, bounded values (the function's contract:
+// the caller sorts ascending first). Bounding keeps interpolation error tiny so
+// the monotonicity tolerance below is safe.
+const sortedValues = fc
+  .array(fc.integer({ min: -1_000_000, max: 1_000_000 }), { minLength: 1, maxLength: 64 })
+  .map(xs => [...xs].sort((a, b) => a - b));
+
+const percentileP = fc.double({ min: 0, max: 100, noNaN: true });
+
+describe("computePercentile (property-based)", () => {
+  test("result is bounded by the min and max of the sorted input", () => {
+    fc.assert(
+      fc.property(sortedValues, percentileP, (sorted, p) => {
+        const result = computePercentile(sorted, p);
+        return result >= sorted[0] && result <= sorted[sorted.length - 1];
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("the endpoints select the first and last elements", () => {
+    fc.assert(
+      fc.property(sortedValues, sorted => {
+        return (
+          computePercentile(sorted, 0) === sorted[0] &&
+          computePercentile(sorted, 100) === sorted[sorted.length - 1]
+        );
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("is monotonic non-decreasing in the requested percentile", () => {
+    fc.assert(
+      fc.property(sortedValues, percentileP, percentileP, (sorted, a, b) => {
+        const lo = Math.min(a, b);
+        const hi = Math.max(a, b);
+        // Interpolating over an ascending sequence can only rise; allow a small
+        // absolute epsilon for floating-point rounding at the segment joins.
+        return computePercentile(sorted, lo) <= computePercentile(sorted, hi) + 1e-6;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("returns 0 for an empty array regardless of the percentile", () => {
+    fc.assert(
+      fc.property(percentileP, p => computePercentile([], p) === 0),
+      RUN_OPTIONS
+    );
+  });
+});

--- a/test/utils/shellQuote.property.test.ts
+++ b/test/utils/shellQuote.property.test.ts
@@ -1,0 +1,76 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import { shellQuote } from "../../src/utils/shellQuote";
+
+// Property-based tests. See Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+// Arbitrary strings, deliberately biased toward the characters that make shell
+// quoting hard: single quotes, backslashes, and expansion metacharacters.
+const shellUnit = fc.oneof(
+  fc.constantFrom("'", "\\", "$", "`", '"', " ", "\n", "\t", "*", "?", ";", "|", "&", "(", ")"),
+  fc.integer({ min: 0x20, max: 0x7e }).map(code => String.fromCharCode(code))
+);
+const shellHostile = fc.string({ unit: shellUnit, maxLength: 40 });
+
+/**
+ * Reference implementation of POSIX quote-removal, restricted to the constructs
+ * `shellQuote` can emit: single-quoted spans and backslash-escaped characters.
+ * Running the real quoted word through this recovers the original literal, which
+ * is exactly the guarantee `shellQuote` must provide to the device shell.
+ */
+const posixUnquote = (quoted: string): string => {
+  let out = "";
+  let inSingle = false;
+  let i = 0;
+  while (i < quoted.length) {
+    const c = quoted[i];
+    if (inSingle) {
+      if (c === "'") {
+        inSingle = false;
+      } else {
+        out += c;
+      }
+      i += 1;
+    } else if (c === "'") {
+      inSingle = true;
+      i += 1;
+    } else if (c === "\\") {
+      // Backslash escapes the next character outside of single quotes.
+      out += quoted[i + 1] ?? "";
+      i += 2;
+    } else {
+      out += c;
+      i += 1;
+    }
+  }
+  return out;
+};
+
+describe("shellQuote (property-based)", () => {
+  test("a POSIX shell recovers the exact original literal (round-trip)", () => {
+    fc.assert(
+      fc.property(shellHostile, value => posixUnquote(shellQuote(value)) === value),
+      RUN_OPTIONS
+    );
+  });
+
+  test("the result is always wrapped in single quotes", () => {
+    fc.assert(
+      fc.property(shellHostile, value => {
+        const quoted = shellQuote(value);
+        return quoted.startsWith("'") && quoted.endsWith("'") && quoted.length >= 2;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("adjacent quoted words concatenate to the joined literal", () => {
+    // POSIX joins directly-adjacent quoted words into one literal, so quoting the
+    // parts and concatenating must be indistinguishable from quoting the whole.
+    fc.assert(
+      fc.property(shellHostile, shellHostile, (a, b) => posixUnquote(shellQuote(a) + shellQuote(b)) === a + b),
+      RUN_OPTIONS
+    );
+  });
+});

--- a/test/utils/stableStringify.property.test.ts
+++ b/test/utils/stableStringify.property.test.ts
@@ -1,0 +1,64 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import { stableStringify } from "../../src/utils/stableStringify";
+
+// Property-based tests. See Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+// Arbitrary JSON-compatible values: primitives, arrays, and nested objects.
+const jsonValue = fc.jsonValue();
+
+/**
+ * Deep-clone a JSON value while reversing the key order of every object. Array
+ * order is preserved (it is meaningful). This exercises the whole point of
+ * stableStringify: two objects that differ only in key insertion order must
+ * serialize identically.
+ */
+const reverseKeys = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(reverseKeys);
+  }
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>).reverse();
+    return Object.fromEntries(entries.map(([k, v]) => [k, reverseKeys(v)]));
+  }
+  return value;
+};
+
+describe("stableStringify (property-based)", () => {
+  test("is insensitive to object key ordering", () => {
+    fc.assert(
+      fc.property(jsonValue, value => stableStringify(value) === stableStringify(reverseKeys(value))),
+      RUN_OPTIONS
+    );
+  });
+
+  test("output is always valid JSON that parses back to an equal canonical form", () => {
+    fc.assert(
+      fc.property(jsonValue, value => {
+        const serialized = stableStringify(value);
+        // Re-canonicalizing the round-tripped value must be a fixed point: the
+        // canonical form is idempotent under parse ∘ stringify.
+        return stableStringify(JSON.parse(serialized)) === serialized;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("agrees with JSON.stringify on values that contain no objects", () => {
+    // Without objects there is nothing to reorder, so the canonical form must
+    // coincide exactly with the platform serializer.
+    const objectFree = fc.oneof(
+      fc.constant(null),
+      fc.boolean(),
+      fc.integer(),
+      fc.double({ noNaN: true, noDefaultInfinity: true }),
+      fc.string(),
+      fc.array(fc.oneof(fc.integer(), fc.string(), fc.boolean()))
+    );
+    fc.assert(
+      fc.property(objectFree, value => stableStringify(value) === JSON.stringify(value)),
+      RUN_OPTIONS
+    );
+  });
+});

--- a/test/utils/truncateBodyText.property.test.ts
+++ b/test/utils/truncateBodyText.property.test.ts
@@ -1,0 +1,122 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import {
+  BODY_TRUNCATION_LIMIT,
+  boundStructuredField,
+  truncateBodyText
+} from "../../src/utils/truncateBodyText";
+
+// Property-based tests. See Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+// Arbitrary UTF-16, built from raw code units so it can include lone surrogates
+// (malformed input) — exactly the boundary case truncateBodyText must survive.
+const anyUtf16 = fc
+  .array(fc.integer({ min: 0, max: 0xffff }), { maxLength: 200 })
+  .map(codes => String.fromCharCode(...codes));
+
+// Well-formed UTF-16: every code point is either a BMP non-surrogate or an
+// astral character (a valid high+low pair). This is the function's realistic
+// domain — telemetry bodies are valid strings. Its guarantee is "never split a
+// VALID surrogate pair", so the surrogate property below is asserted over this.
+// (Deliberately malformed input — e.g. two adjacent lone high surrogates — is
+// out of contract; the function caps such input but does not sanitize it.)
+const wellFormedUtf16 = fc
+  .array(fc.integer({ min: 0, max: 0x10ffff }).filter(cp => cp < 0xd800 || cp > 0xdfff), { maxLength: 200 })
+  .map(cps => String.fromCodePoint(...cps));
+
+const limit = fc.integer({ min: 1, max: 128 });
+
+const isHighSurrogate = (code: number): boolean => code >= 0xd800 && code <= 0xdbff;
+const isLowSurrogate = (code: number): boolean => code >= 0xdc00 && code <= 0xdfff;
+
+describe("truncateBodyText (property-based)", () => {
+  test("never exceeds the limit and is always a prefix of the input", () => {
+    fc.assert(
+      fc.property(anyUtf16, limit, (text, max) => {
+        const result = truncateBodyText(text, max);
+        return result !== null && result.length <= max && text.startsWith(result);
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("is idempotent", () => {
+    fc.assert(
+      fc.property(anyUtf16, limit, (text, max) => {
+        const once = truncateBodyText(text, max);
+        return truncateBodyText(once, max) === once;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("never leaves a lone surrogate at the cut, for well-formed input", () => {
+    fc.assert(
+      fc.property(wellFormedUtf16, limit, (text, max) => {
+        const result = truncateBodyText(text, max)!;
+        if (result.length === 0) {
+          return true;
+        }
+        const last = result.charCodeAt(result.length - 1);
+        if (isHighSurrogate(last)) {
+          // A trailing high surrogate is always lone (its mate was past the cut).
+          return false;
+        }
+        if (isLowSurrogate(last)) {
+          // A trailing low surrogate is valid only as the tail of a complete pair.
+          return result.length >= 2 && isHighSurrogate(result.charCodeAt(result.length - 2));
+        }
+        return true;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("returns short-enough text and null unchanged", () => {
+    const shortText = fc
+      .array(fc.integer({ min: 0x20, max: 0x7e }), { maxLength: BODY_TRUNCATION_LIMIT })
+      .map(codes => String.fromCharCode(...codes));
+    fc.assert(
+      fc.property(shortText, text => truncateBodyText(text) === text && truncateBodyText(null) === null),
+      RUN_OPTIONS
+    );
+  });
+});
+
+describe("boundStructuredField (property-based)", () => {
+  test("passes small values through by identity and replaces oversized ones with a marker", () => {
+    fc.assert(
+      fc.property(fc.jsonValue(), fc.integer({ min: 2, max: 4096 }), (value, max) => {
+        const result = boundStructuredField(value, false, max);
+        if (value === null || value === undefined) {
+          return result === value;
+        }
+        const serialized = JSON.stringify(value);
+        if (serialized === undefined) {
+          // Unserializable values are passed through untouched by contract.
+          return result === value;
+        }
+        if (serialized.length <= max) {
+          return result === value;
+        }
+        // Over budget: a small, always-valid marker carrying the original size.
+        const marker = result as { _truncated?: boolean; bytes?: number };
+        return marker._truncated === true && marker.bytes === serialized.length;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("null and undefined always pass through", () => {
+    fc.assert(
+      fc.property(fc.boolean(), fc.integer({ min: 1, max: 4096 }), (asJsonString, max) => {
+        return (
+          boundStructuredField(null, asJsonString, max) === null &&
+          boundStructuredField(undefined, asJsonString, max) === undefined
+        );
+      }),
+      RUN_OPTIONS
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Extends the fast-check property-testing pattern established in [PR #4427](https://github.com/kaeawc/auto-mobile/pull/4427) to a cluster of pure, dependency-free helpers under `src/utils/`. Test-only, additive — no production code changes and no new dependencies (`fast-check` is already a devDependency). Each suite pins a seed (`{ seed: 1_234_567, numRuns: 300 }`), bounds its generators to the module's realistic domain, and asserts boolean-returning invariants (per the repo's no-bare-`expect` lint rule).

Invariants asserted per suite:

- **shellQuote** — a POSIX shell recovers the exact original literal (`unquote ∘ quote == id`); output is always single-quote wrapped; adjacent quoted words concatenate to the joined literal.
- **stableStringify** — insensitive to object key ordering; canonical form is idempotent under `parse ∘ stringify`; agrees with `JSON.stringify` on object-free values.
- **computePercentile** — result is bounded by input min/max; `p=0`/`p=100` select first/last; monotonic non-decreasing in `p`; empty array yields `0`.
- **truncateBodyText / boundStructuredField** — never exceeds the limit and result is a prefix of the input; idempotent; never leaves a lone surrogate at the cut for well-formed input; `null` passthrough; oversized structured fields collapse to the `{ _truncated, bytes }` marker.
- **Random (CryptoRandom)** — `next()` ∈ `[0, 1)`; `pick()` ∈ input; single-element pick; empty-array pick throws.

## Surfaced during authoring (no code change)

While tightening the `truncateBodyText` surrogate generator I confirmed the function's guarantee is precisely "never split a **valid** surrogate pair" — for **well-formed** UTF-16 the cut is always well-formed. For deliberately-malformed input (e.g. two *adjacent lone high surrogates*, `"\uD800\uD800X"` at limit 2) the result can still end in a lone high surrogate: the function caps such input but does not fully sanitize it. This is out of the realistic domain (telemetry bodies are valid strings), so the property is scoped to well-formed input rather than papering over it by constraining a valid case. Worth noting only because the docstring's "the boundary is never a lone surrogate regardless of input well-formedness" is very slightly stronger than the actual behavior — a doc-wording nuance, not a functional bug.

## Validation

- [x] `bun test test/utils/*.property.test.ts` — 20 pass, <200ms total
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run lint` — no new violations
- [x] New tests are pure (no device/network/filesystem/DB); each runs in <100ms

## Follow-ups

- [ ] Further pure modules remain good candidates for the same treatment (e.g. additional `src/utils/` parsers/normalizers/geometry). Kept out of this PR to keep the diff reviewable.
