### PR TITLE
feat(observe): scope waitFor predicates

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3107,20 +3107,16 @@
               "description": "DSL condition; stable is whole-screen"
             },
             "pollMs": {
-              "type": "number",
-              "description": "Poll interval ms (default 150)"
+              "type": "number"
             },
             "stableReads": {
-              "type": "number",
-              "description": "Stable reads for countStable/stable (default 2)"
+              "type": "number"
             },
             "elementId": {
-              "type": "string",
-              "description": "Element resource ID / accessibility identifier"
+              "type": "string"
             },
             "text": {
-              "type": "string",
-              "description": "Element text; for `for:textEquals` the exact expected value"
+              "type": "string"
             },
             "textAny": {
               "type": "array",
@@ -3241,15 +3237,26 @@
                 "text": {
                   "type": "string"
                 }
-              }
+              },
+              "additionalProperties": false,
+              "oneOf": [
+                {
+                  "required": [
+                    "elementId"
+                  ]
+                },
+                {
+                  "required": [
+                    "text"
+                  ]
+                }
+              ]
             },
             "timeout": {
-              "type": "number",
-              "description": "Wait timeout ms (default 5000)"
+              "type": "number"
             },
             "timeoutMs": {
-              "type": "number",
-              "description": "Alias for timeout; matches waitForCondition"
+              "type": "number"
             }
           },
           "anyOf": [
@@ -3264,6 +3271,13 @@
               ]
             },
             {
+              "properties": {
+                "for": {
+                  "not": {
+                    "const": "textEquals"
+                  }
+                }
+              },
               "required": [
                 "for",
                 "elementId"
@@ -5831,20 +5845,16 @@
               "description": "DSL condition; stable is whole-screen"
             },
             "pollMs": {
-              "type": "number",
-              "description": "Poll interval ms (default 150)"
+              "type": "number"
             },
             "stableReads": {
-              "type": "number",
-              "description": "Stable reads for countStable/stable (default 2)"
+              "type": "number"
             },
             "elementId": {
-              "type": "string",
-              "description": "Element resource ID / accessibility identifier"
+              "type": "string"
             },
             "text": {
-              "type": "string",
-              "description": "Element text; for `for:textEquals` the exact expected value"
+              "type": "string"
             },
             "textAny": {
               "type": "array",
@@ -5965,15 +5975,26 @@
                 "text": {
                   "type": "string"
                 }
-              }
+              },
+              "additionalProperties": false,
+              "oneOf": [
+                {
+                  "required": [
+                    "elementId"
+                  ]
+                },
+                {
+                  "required": [
+                    "text"
+                  ]
+                }
+              ]
             },
             "timeout": {
-              "type": "number",
-              "description": "Wait timeout ms (default 5000)"
+              "type": "number"
             },
             "timeoutMs": {
-              "type": "number",
-              "description": "Alias for timeout; matches waitForCondition"
+              "type": "number"
             }
           },
           "anyOf": [
@@ -5988,6 +6009,13 @@
               ]
             },
             {
+              "properties": {
+                "for": {
+                  "not": {
+                    "const": "textEquals"
+                  }
+                }
+              },
               "required": [
                 "for",
                 "elementId"

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3092,7 +3092,7 @@
         "waitFor": {
           "type": "object",
           "additionalProperties": false,
-          "description": "Wait for a predicate before returning. Either `for` (DSL: appear|disappear|clickable|textEquals|countStable|stable) with elementId/text, or a legacy predicate: elementId, text, textAny, className, contentDescription, activeWindow, absent. textAny excludes the element predicates.",
+          "description": "Wait by DSL (`for`) or legacy selector.",
           "properties": {
             "for": {
               "type": "string",
@@ -3104,7 +3104,7 @@
                 "countStable",
                 "stable"
               ],
-              "description": "DSL condition (selector-based, or stable=whole screen)"
+              "description": "DSL condition; stable is whole-screen"
             },
             "pollMs": {
               "type": "number",
@@ -3126,24 +3126,20 @@
               "type": "array",
               "items": {
                 "type": "string"
-              },
-              "description": "Ordered text variants; first visible match wins"
+              }
             },
             "className": {
-              "type": "string",
-              "description": "Element class name"
+              "type": "string"
             },
             "contentDescription": {
-              "type": "string",
-              "description": "Element content description / accessibility label"
+              "type": "string"
             },
             "matchType": {
               "type": "string",
               "enum": [
                 "all",
                 "any"
-              ],
-              "description": "Whether element predicates must all match one node, or any one may match"
+              ]
             },
             "textMatch": {
               "type": "string",
@@ -3157,23 +3153,18 @@
             "activeWindow": {
               "type": "object",
               "additionalProperties": false,
-              "description": "Foreground app/window predicates (provide an app id or activityName)",
               "properties": {
                 "appId": {
-                  "type": "string",
-                  "description": "Foreground app bundle ID / package name"
+                  "type": "string"
                 },
                 "packageName": {
-                  "type": "string",
-                  "description": "appId alias (Android package)"
+                  "type": "string"
                 },
                 "bundleId": {
-                  "type": "string",
-                  "description": "appId alias (iOS bundle)"
+                  "type": "string"
                 },
                 "activityName": {
-                  "type": "string",
-                  "description": "Foreground Android activity name (Android-only)"
+                  "type": "string"
                 }
               },
               "anyOf": [
@@ -3255,12 +3246,33 @@
             "timeout": {
               "type": "number",
               "description": "Wait timeout ms (default 5000)"
+            },
+            "timeoutMs": {
+              "type": "number",
+              "description": "Alias for timeout; matches waitForCondition"
             }
           },
           "anyOf": [
             {
+              "properties": {
+                "for": {
+                  "const": "stable"
+                }
+              },
               "required": [
                 "for"
+              ]
+            },
+            {
+              "required": [
+                "for",
+                "elementId"
+              ]
+            },
+            {
+              "required": [
+                "for",
+                "text"
               ]
             },
             {
@@ -5804,7 +5816,7 @@
         "waitFor": {
           "type": "object",
           "additionalProperties": false,
-          "description": "Wait for a predicate before returning. Either `for` (DSL: appear|disappear|clickable|textEquals|countStable|stable) with elementId/text, or a legacy predicate: elementId, text, textAny, className, contentDescription, activeWindow, absent. textAny excludes the element predicates.",
+          "description": "Wait by DSL (`for`) or legacy selector.",
           "properties": {
             "for": {
               "type": "string",
@@ -5816,7 +5828,7 @@
                 "countStable",
                 "stable"
               ],
-              "description": "DSL condition (selector-based, or stable=whole screen)"
+              "description": "DSL condition; stable is whole-screen"
             },
             "pollMs": {
               "type": "number",
@@ -5838,24 +5850,20 @@
               "type": "array",
               "items": {
                 "type": "string"
-              },
-              "description": "Ordered text variants; first visible match wins"
+              }
             },
             "className": {
-              "type": "string",
-              "description": "Element class name"
+              "type": "string"
             },
             "contentDescription": {
-              "type": "string",
-              "description": "Element content description / accessibility label"
+              "type": "string"
             },
             "matchType": {
               "type": "string",
               "enum": [
                 "all",
                 "any"
-              ],
-              "description": "Whether element predicates must all match one node, or any one may match"
+              ]
             },
             "textMatch": {
               "type": "string",
@@ -5869,23 +5877,18 @@
             "activeWindow": {
               "type": "object",
               "additionalProperties": false,
-              "description": "Foreground app/window predicates (provide an app id or activityName)",
               "properties": {
                 "appId": {
-                  "type": "string",
-                  "description": "Foreground app bundle ID / package name"
+                  "type": "string"
                 },
                 "packageName": {
-                  "type": "string",
-                  "description": "appId alias (Android package)"
+                  "type": "string"
                 },
                 "bundleId": {
-                  "type": "string",
-                  "description": "appId alias (iOS bundle)"
+                  "type": "string"
                 },
                 "activityName": {
-                  "type": "string",
-                  "description": "Foreground Android activity name (Android-only)"
+                  "type": "string"
                 }
               },
               "anyOf": [
@@ -5967,12 +5970,33 @@
             "timeout": {
               "type": "number",
               "description": "Wait timeout ms (default 5000)"
+            },
+            "timeoutMs": {
+              "type": "number",
+              "description": "Alias for timeout; matches waitForCondition"
             }
           },
           "anyOf": [
             {
+              "properties": {
+                "for": {
+                  "const": "stable"
+                }
+              },
               "required": [
                 "for"
+              ]
+            },
+            {
+              "required": [
+                "for",
+                "elementId"
+              ]
+            },
+            {
+              "required": [
+                "for",
+                "text"
               ]
             },
             {
@@ -10305,6 +10329,37 @@
         "text": {
           "description": "Element text; for `textEquals` the exact expected value",
           "type": "string"
+        },
+        "container": {
+          "description": "Scope match to a container",
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "elementId": {
+                  "type": "string",
+                  "description": "Container resource ID"
+                }
+              },
+              "required": [
+                "elementId"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "text": {
+                  "type": "string",
+                  "description": "Container text"
+                }
+              },
+              "required": [
+                "text"
+              ],
+              "additionalProperties": false
+            }
+          ]
         },
         "timeoutMs": {
           "description": "Budget ms (default 5000)",

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3092,6 +3092,12 @@
         "waitFor": {
           "type": "object",
           "additionalProperties": false,
+          "not": {
+            "required": [
+              "timeout",
+              "timeoutMs"
+            ]
+          },
           "description": "Wait by DSL (`for`) or legacy selector.",
           "properties": {
             "for": {
@@ -5830,6 +5836,12 @@
         "waitFor": {
           "type": "object",
           "additionalProperties": false,
+          "not": {
+            "required": [
+              "timeout",
+              "timeoutMs"
+            ]
+          },
           "description": "Wait by DSL (`for`) or legacy selector.",
           "properties": {
             "for": {

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -3098,7 +3098,6 @@
               "timeoutMs"
             ]
           },
-          "description": "Wait by DSL (`for`) or legacy selector.",
           "properties": {
             "for": {
               "type": "string",
@@ -3109,8 +3108,7 @@
                 "textEquals",
                 "countStable",
                 "stable"
-              ],
-              "description": "DSL condition; stable is whole-screen"
+              ]
             },
             "pollMs": {
               "type": "number"
@@ -3235,7 +3233,6 @@
             },
             "container": {
               "type": "object",
-              "description": "Scope the match to a container element (by elementId or text)",
               "properties": {
                 "elementId": {
                   "type": "string"
@@ -3274,13 +3271,21 @@
               },
               "required": [
                 "for"
-              ]
+              ],
+              "not": {
+                "required": [
+                  "container"
+                ]
+              }
             },
             {
               "properties": {
                 "for": {
                   "not": {
-                    "const": "textEquals"
+                    "enum": [
+                      "stable",
+                      "textEquals"
+                    ]
                   }
                 }
               },
@@ -3290,6 +3295,13 @@
               ]
             },
             {
+              "properties": {
+                "for": {
+                  "not": {
+                    "const": "stable"
+                  }
+                }
+              },
               "required": [
                 "for",
                 "text"
@@ -5842,7 +5854,6 @@
               "timeoutMs"
             ]
           },
-          "description": "Wait by DSL (`for`) or legacy selector.",
           "properties": {
             "for": {
               "type": "string",
@@ -5853,8 +5864,7 @@
                 "textEquals",
                 "countStable",
                 "stable"
-              ],
-              "description": "DSL condition; stable is whole-screen"
+              ]
             },
             "pollMs": {
               "type": "number"
@@ -5979,7 +5989,6 @@
             },
             "container": {
               "type": "object",
-              "description": "Scope the match to a container element (by elementId or text)",
               "properties": {
                 "elementId": {
                   "type": "string"
@@ -6018,13 +6027,21 @@
               },
               "required": [
                 "for"
-              ]
+              ],
+              "not": {
+                "required": [
+                  "container"
+                ]
+              }
             },
             {
               "properties": {
                 "for": {
                   "not": {
-                    "const": "textEquals"
+                    "enum": [
+                      "stable",
+                      "textEquals"
+                    ]
                   }
                 }
               },
@@ -6034,6 +6051,13 @@
               ]
             },
             {
+              "properties": {
+                "for": {
+                  "not": {
+                    "const": "stable"
+                  }
+                }
+              },
               "required": [
                 "for",
                 "text"

--- a/src/features/observe/ConditionPredicates.ts
+++ b/src/features/observe/ConditionPredicates.ts
@@ -5,16 +5,15 @@ import type { ConditionEvaluation, ConditionPredicate } from "./interfaces/WaitF
 
 /**
  * A declarative selector for the built-in condition predicates. Deliberately the
- * narrow `{ elementId?, text? }` shape the `ElementFinder` container API already
- * speaks (issue #4389) — the predicates evaluate through the finder rather than
- * re-walking the tree.
+ * narrow selector/container shapes the `ElementFinder` API already speaks (issue
+ * #4389) — the predicates evaluate through the finder rather than re-walking the
+ * tree.
  */
 export interface ConditionSelector {
   elementId?: string;
   text?: string;
+  container?: { elementId?: string; text?: string };
 }
-
-const NO_CONTAINER = null;
 
 /** Exact match for the selector via the finder (resource-id preferred, then text). */
 function findMatch(
@@ -22,11 +21,12 @@ function findMatch(
   viewHierarchy: ViewHierarchyResult,
   selector: ConditionSelector
 ): Element | null {
+  const container = selector.container ?? null;
   if (selector.elementId !== undefined) {
-    return finder.findElementByResourceId(viewHierarchy, selector.elementId, NO_CONTAINER);
+    return finder.findElementByResourceId(viewHierarchy, selector.elementId, container);
   }
   if (selector.text !== undefined) {
-    return finder.findElementByText(viewHierarchy, selector.text, NO_CONTAINER, false, false);
+    return finder.findElementByText(viewHierarchy, selector.text, container, false, false);
   }
   return null;
 }
@@ -41,11 +41,12 @@ function findNearMatches(
   viewHierarchy: ViewHierarchyResult,
   selector: ConditionSelector
 ): Element[] {
+  const container = selector.container ?? null;
   if (selector.elementId !== undefined) {
-    return finder.findElementsByResourceId(viewHierarchy, selector.elementId, NO_CONTAINER, true);
+    return finder.findElementsByResourceId(viewHierarchy, selector.elementId, container, true);
   }
   if (selector.text !== undefined) {
-    return finder.findElementsByText(viewHierarchy, selector.text, NO_CONTAINER, true, false);
+    return finder.findElementsByText(viewHierarchy, selector.text, container, true, false);
   }
   return [];
 }
@@ -87,17 +88,18 @@ export function disappear(finder: ElementFinder, selector: ConditionSelector): C
   };
 }
 
-/** All elements matching the selector (exact match, no container scope). */
+/** All elements matching the selector (exact match, optionally container-scoped). */
 function findAllMatches(
   finder: ElementFinder,
   viewHierarchy: ViewHierarchyResult,
   selector: ConditionSelector
 ): Element[] {
+  const container = selector.container ?? null;
   if (selector.elementId !== undefined) {
-    return finder.findElementsByResourceId(viewHierarchy, selector.elementId, NO_CONTAINER, false);
+    return finder.findElementsByResourceId(viewHierarchy, selector.elementId, container, false);
   }
   if (selector.text !== undefined) {
-    return finder.findElementsByText(viewHierarchy, selector.text, NO_CONTAINER, false, false);
+    return finder.findElementsByText(viewHierarchy, selector.text, container, false, false);
   }
   return [];
 }
@@ -152,18 +154,18 @@ export function textEquals(
       return { matched: false, candidates: [] };
     }
     if (selector.elementId !== undefined) {
-      const located = finder.findElementByResourceId(viewHierarchy, selector.elementId, NO_CONTAINER);
+      const located = finder.findElementByResourceId(viewHierarchy, selector.elementId, selector.container ?? null);
       if (located && (located.text ?? "") === expected) {
         return { matched: true, matchedElement: located, candidates: [located] };
       }
       return { matched: false, candidates: located ? [located] : [] };
     }
     // No locator: an exact (case-sensitive) text match IS the located element.
-    const located = finder.findElementByText(viewHierarchy, expected, NO_CONTAINER, false, true);
+    const located = finder.findElementByText(viewHierarchy, expected, selector.container ?? null, false, true);
     if (located) {
       return { matched: true, matchedElement: located, candidates: [located] };
     }
-    return { matched: false, candidates: findNearMatches(finder, viewHierarchy, { text: expected }) };
+    return { matched: false, candidates: findNearMatches(finder, viewHierarchy, { text: expected, container: selector.container }) };
   };
 }
 

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -87,6 +87,18 @@ const waitForCommonShape = {
   container: waitForContainerField
 };
 
+const validateWaitForTimeoutAliases = (
+  value: { timeout?: number; timeoutMs?: number },
+  ctx: z.RefinementCtx
+): void => {
+  if (value.timeout !== undefined && value.timeoutMs !== undefined && value.timeout !== value.timeoutMs) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "waitFor timeout and timeoutMs must match when both are provided",
+    });
+  }
+};
+
 // Stability / "settled" gate (issue #3490 §3). After the waitFor predicate first
 // matches, keep observing until the view hierarchy is unchanged for this long.
 export const settledSchema = z.object({
@@ -103,7 +115,7 @@ const waitForTextAnySchema = z.object({
   matchType: z.never().optional(),
   textMatch: z.never().optional(),
   ...waitForCommonShape,
-}).strict();
+}).strict().superRefine(validateWaitForTimeoutAliases);
 
 const waitForElementBaseSchema = z.object({
   for: z.never().optional(),
@@ -116,6 +128,7 @@ const waitForElementBaseSchema = z.object({
   textMatch: z.enum(["exact", "contains", "regex"]).optional().describe("How to match waitFor.text; does not affect contentDescription"),
   ...waitForCommonShape,
 }).strict().superRefine((value, ctx) => {
+  validateWaitForTimeoutAliases(value, ctx);
 
   if (value.textMatch === "regex" && value.text !== undefined) {
     try {
@@ -166,12 +179,7 @@ const waitForConditionDslSchema = z.object({
   activeWindow: z.never().optional(),
   absent: z.never().optional(),
 }).strict().superRefine((value, ctx) => {
-  if (value.timeout !== undefined && value.timeoutMs !== undefined && value.timeout !== value.timeoutMs) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      message: "waitFor timeout and timeoutMs must match when both are provided",
-    });
-  }
+  validateWaitForTimeoutAliases(value, ctx);
   if (value.for === "stable") {
     return;
   }
@@ -235,10 +243,10 @@ const COMPACT_WAITFOR_ADVERTISED_SCHEMA: Record<string, unknown> = {
       enum: ["appear", "disappear", "clickable", "textEquals", "countStable", "stable"],
       description: "DSL condition; stable is whole-screen",
     },
-    pollMs: { type: "number", description: "Poll interval ms (default 150)" },
-    stableReads: { type: "number", description: "Stable reads for countStable/stable (default 2)" },
-    elementId: { type: "string", description: "Element resource ID / accessibility identifier" },
-    text: { type: "string", description: "Element text; for `for:textEquals` the exact expected value" },
+    pollMs: { type: "number" },
+    stableReads: { type: "number" },
+    elementId: { type: "string" },
+    text: { type: "string" },
     textAny: {
       type: "array",
       items: { type: "string" },
@@ -275,9 +283,11 @@ const COMPACT_WAITFOR_ADVERTISED_SCHEMA: Record<string, unknown> = {
       type: "object",
       description: "Scope the match to a container element (by elementId or text)",
       properties: { elementId: { type: "string" }, text: { type: "string" } },
+      additionalProperties: false,
+      oneOf: [{ required: ["elementId"] }, { required: ["text"] }],
     },
-    timeout: { type: "number", description: "Wait timeout ms (default 5000)" },
-    timeoutMs: { type: "number", description: "Alias for timeout; matches waitForCondition" },
+    timeout: { type: "number" },
+    timeoutMs: { type: "number" },
   },
   // Enforce the same shape the runtime does: either the `for` DSL, or at least one
   // legacy predicate with textAny mutually exclusive from the element predicates /
@@ -285,7 +295,7 @@ const COMPACT_WAITFOR_ADVERTISED_SCHEMA: Record<string, unknown> = {
   // so it is not part of the textAny exclusion set.
   anyOf: [
     { properties: { for: { const: "stable" } }, required: ["for"] },
-    { required: ["for", "elementId"] },
+    { properties: { for: { not: { const: "textEquals" } } }, required: ["for", "elementId"] },
     { required: ["for", "text"] },
     {
       required: ["textAny"],
@@ -506,7 +516,7 @@ export const buildConditionPredicate = (
       if (selector.text === undefined) {
         throw new ActionableError("waitFor \"for: textEquals\" requires text (the exact expected value)");
       }
-      return textEquals(finder, { elementId: selector.elementId }, selector.text);
+      return textEquals(finder, selector, selector.text);
     case "countStable":
       return countStable(finder, selector, options);
     default: {

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -83,6 +83,7 @@ const waitForCommonShape = {
   activeWindow: activeWindowWaitForSchema.optional().describe("Foreground app/window predicates"),
   absent: absentPredicateSchema.optional().describe("Wait until an element matching these fields is absent"),
   timeout: z.number().optional().describe("Wait timeout ms (default: 5000)"),
+  timeoutMs: z.number().optional().describe("Alias for timeout; use timeoutMs when migrating to waitForCondition"),
   container: waitForContainerField
 };
 
@@ -155,12 +156,8 @@ const waitForConditionDslSchema = z.object({
   pollMs: z.number().optional().describe("Poll interval ms (default 150)"),
   stableReads: z.number().optional().describe("Consecutive stable reads for countStable/stable (default 2)"),
   timeout: z.number().optional().describe("Wait timeout ms (default 5000; stable default 2500)"),
-  // `container` is declared `never` (not accepted) on the DSL form: the #4389
-  // predicate builders match whole-screen (NO_CONTAINER), so accepting it would
-  // silently ignore it. Threading container scope into the predicates is a
-  // follow-up. `never` keeps the inferred union structurally compatible with the
-  // legacy arms (which do read `container`) while rejecting it on DSL requests.
-  container: z.never().optional(),
+  timeoutMs: z.number().optional().describe("Alias for timeout; matches waitForCondition"),
+  container: waitForContainerField,
   textAny: z.never().optional(),
   className: z.never().optional(),
   contentDescription: z.never().optional(),
@@ -169,6 +166,12 @@ const waitForConditionDslSchema = z.object({
   activeWindow: z.never().optional(),
   absent: z.never().optional(),
 }).strict().superRefine((value, ctx) => {
+  if (value.timeout !== undefined && value.timeoutMs !== undefined && value.timeout !== value.timeoutMs) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "waitFor timeout and timeoutMs must match when both are provided",
+    });
+  }
   if (value.for === "stable") {
     return;
   }
@@ -225,16 +228,12 @@ const ABSENT_PREDICATE_ADVERTISED_SCHEMA: Record<string, unknown> = {
 const COMPACT_WAITFOR_ADVERTISED_SCHEMA: Record<string, unknown> = {
   type: "object",
   additionalProperties: false,
-  description:
-    "Wait for a predicate before returning. Either `for` (DSL: appear|disappear|clickable|" +
-    "textEquals|countStable|stable) with elementId/text, or a legacy predicate: elementId, " +
-    "text, textAny, className, contentDescription, activeWindow, absent. textAny excludes " +
-    "the element predicates.",
+  description: "Wait by DSL (`for`) or legacy selector.",
   properties: {
     for: {
       type: "string",
       enum: ["appear", "disappear", "clickable", "textEquals", "countStable", "stable"],
-      description: "DSL condition (selector-based, or stable=whole screen)",
+      description: "DSL condition; stable is whole-screen",
     },
     pollMs: { type: "number", description: "Poll interval ms (default 150)" },
     stableReads: { type: "number", description: "Stable reads for countStable/stable (default 2)" },
@@ -243,17 +242,12 @@ const COMPACT_WAITFOR_ADVERTISED_SCHEMA: Record<string, unknown> = {
     textAny: {
       type: "array",
       items: { type: "string" },
-      description: "Ordered text variants; first visible match wins",
     },
-    className: { type: "string", description: "Element class name" },
-    contentDescription: {
-      type: "string",
-      description: "Element content description / accessibility label",
-    },
+    className: { type: "string" },
+    contentDescription: { type: "string" },
     matchType: {
       type: "string",
       enum: ["all", "any"],
-      description: "Whether element predicates must all match one node, or any one may match",
     },
     textMatch: {
       type: "string",
@@ -263,15 +257,11 @@ const COMPACT_WAITFOR_ADVERTISED_SCHEMA: Record<string, unknown> = {
     activeWindow: {
       type: "object",
       additionalProperties: false,
-      description: "Foreground app/window predicates (provide an app id or activityName)",
       properties: {
-        appId: { type: "string", description: "Foreground app bundle ID / package name" },
-        packageName: { type: "string", description: "appId alias (Android package)" },
-        bundleId: { type: "string", description: "appId alias (iOS bundle)" },
-        activityName: {
-          type: "string",
-          description: "Foreground Android activity name (Android-only)",
-        },
+        appId: { type: "string" },
+        packageName: { type: "string" },
+        bundleId: { type: "string" },
+        activityName: { type: "string" },
       },
       anyOf: [
         { required: ["appId"] },
@@ -287,13 +277,16 @@ const COMPACT_WAITFOR_ADVERTISED_SCHEMA: Record<string, unknown> = {
       properties: { elementId: { type: "string" }, text: { type: "string" } },
     },
     timeout: { type: "number", description: "Wait timeout ms (default 5000)" },
+    timeoutMs: { type: "number", description: "Alias for timeout; matches waitForCondition" },
   },
   // Enforce the same shape the runtime does: either the `for` DSL, or at least one
   // legacy predicate with textAny mutually exclusive from the element predicates /
   // matchType / textMatch. `absent` composes with everything (including textAny),
   // so it is not part of the textAny exclusion set.
   anyOf: [
-    { required: ["for"] },
+    { properties: { for: { const: "stable" } }, required: ["for"] },
+    { required: ["for", "elementId"] },
+    { required: ["for", "text"] },
     {
       required: ["textAny"],
       not: {
@@ -440,6 +433,7 @@ export const waitForConditionSchema = addDeviceTargetingToSchema(z.object({
   for: z.enum(WAIT_FOR_CONDITION_KINDS).describe("appear|disappear|clickable|textEquals|countStable"),
   elementId: z.string().optional().describe("Element resource ID / accessibility identifier"),
   text: z.string().optional().describe("Element text; for `textEquals` the exact expected value"),
+  container: waitForContainerField,
   timeoutMs: z.number().optional().describe("Budget ms (default 5000)"),
   pollMs: z.number().optional().describe("Poll interval ms (default 150)"),
   stableReads: z.number().optional().describe("Stable reads for countStable (default 2)")
@@ -528,8 +522,7 @@ export const buildConditionPredicate = (
  * (`RealSettleObserve`); every other kind runs `RealWaitForCondition` with the
  * predicate for that kind. `awaitedElement` carries the matched element (never set
  * for settle / countStable, which have no single element); `awaitTimeout` reflects
- * "did not settle" / "timed out". `container` is not yet threaded into the
- * primitives' finder path — a follow-up.
+ * "did not settle" / "timed out".
  */
 const runWaitForConditionDsl = async (
   observeScreen: ObserveScreen,
@@ -540,7 +533,7 @@ const runWaitForConditionDsl = async (
   const pollMs = waitFor.pollMs;
   if (waitFor.for === "stable") {
     const settle = await new RealSettleObserve(observeScreen, timer).execute({
-      timeoutMs: waitFor.timeout,
+      timeoutMs: waitFor.timeout ?? waitFor.timeoutMs,
       pollMs,
       stableReads: waitFor.stableReads,
       signal,
@@ -557,11 +550,11 @@ const runWaitForConditionDsl = async (
   const predicate = buildConditionPredicate(
     finder,
     waitFor.for,
-    { elementId: waitFor.elementId, text: waitFor.text },
+    { elementId: waitFor.elementId, text: waitFor.text, container: waitFor.container },
     { stableReads: waitFor.stableReads }
   );
   const result = await new RealWaitForCondition(observeScreen, timer).execute(predicate, {
-    timeoutMs: waitFor.timeout,
+    timeoutMs: waitFor.timeout ?? waitFor.timeoutMs,
     pollMs,
     signal,
   });
@@ -608,7 +601,7 @@ export const runWaitForConditionTool = async (
   const predicate = buildConditionPredicate(
     finder,
     args.for,
-    { elementId: args.elementId, text: args.text },
+    { elementId: args.elementId, text: args.text, container: args.container },
     { stableReads: args.stableReads }
   );
   return new RealWaitForCondition(observeScreen, timer).execute(predicate, {
@@ -955,7 +948,7 @@ export const waitForObservation = async (
   }
 
   const startTime = timer.now();
-  const timeoutMs = waitFor.timeout ?? 5000;
+  const timeoutMs = waitFor.timeout ?? waitFor.timeoutMs ?? 5000;
   const settled = waitFor.settled;
   const finder = new DefaultElementFinder();
   const queryOptions = {

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -91,10 +91,10 @@ const validateWaitForTimeoutAliases = (
   value: { timeout?: number; timeoutMs?: number },
   ctx: z.RefinementCtx
 ): void => {
-  if (value.timeout !== undefined && value.timeoutMs !== undefined && value.timeout !== value.timeoutMs) {
+  if (value.timeout !== undefined && value.timeoutMs !== undefined) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: "waitFor timeout and timeoutMs must match when both are provided",
+      message: "waitFor accepts either timeout or timeoutMs, not both",
     });
   }
 };
@@ -236,6 +236,7 @@ const ABSENT_PREDICATE_ADVERTISED_SCHEMA: Record<string, unknown> = {
 const COMPACT_WAITFOR_ADVERTISED_SCHEMA: Record<string, unknown> = {
   type: "object",
   additionalProperties: false,
+  not: { required: ["timeout", "timeoutMs"] },
   description: "Wait by DSL (`for`) or legacy selector.",
   properties: {
     for: {

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -181,6 +181,12 @@ const waitForConditionDslSchema = z.object({
 }).strict().superRefine((value, ctx) => {
   validateWaitForTimeoutAliases(value, ctx);
   if (value.for === "stable") {
+    if (value.container !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'waitFor "for: stable" does not support container',
+      });
+    }
     return;
   }
   if (value.elementId === undefined && value.text === undefined) {
@@ -237,12 +243,10 @@ const COMPACT_WAITFOR_ADVERTISED_SCHEMA: Record<string, unknown> = {
   type: "object",
   additionalProperties: false,
   not: { required: ["timeout", "timeoutMs"] },
-  description: "Wait by DSL (`for`) or legacy selector.",
   properties: {
     for: {
       type: "string",
       enum: ["appear", "disappear", "clickable", "textEquals", "countStable", "stable"],
-      description: "DSL condition; stable is whole-screen",
     },
     pollMs: { type: "number" },
     stableReads: { type: "number" },
@@ -282,7 +286,6 @@ const COMPACT_WAITFOR_ADVERTISED_SCHEMA: Record<string, unknown> = {
     absent: ABSENT_PREDICATE_ADVERTISED_SCHEMA,
     container: {
       type: "object",
-      description: "Scope the match to a container element (by elementId or text)",
       properties: { elementId: { type: "string" }, text: { type: "string" } },
       additionalProperties: false,
       oneOf: [{ required: ["elementId"] }, { required: ["text"] }],
@@ -295,9 +298,9 @@ const COMPACT_WAITFOR_ADVERTISED_SCHEMA: Record<string, unknown> = {
   // matchType / textMatch. `absent` composes with everything (including textAny),
   // so it is not part of the textAny exclusion set.
   anyOf: [
-    { properties: { for: { const: "stable" } }, required: ["for"] },
-    { properties: { for: { not: { const: "textEquals" } } }, required: ["for", "elementId"] },
-    { required: ["for", "text"] },
+    { properties: { for: { const: "stable" } }, required: ["for"], not: { required: ["container"] } },
+    { properties: { for: { not: { enum: ["stable", "textEquals"] } } }, required: ["for", "elementId"] },
+    { properties: { for: { not: { const: "stable" } } }, required: ["for", "text"] },
     {
       required: ["textAny"],
       not: {

--- a/test/features/observe/ConditionPredicates.test.ts
+++ b/test/features/observe/ConditionPredicates.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { ObserveResult } from "../../../src/models/ObserveResult";
-import { clickable, countStable, textEquals } from "../../../src/features/observe/ConditionPredicates";
+import { clickable, countStable, disappear, textEquals } from "../../../src/features/observe/ConditionPredicates";
 import { DefaultElementFinder } from "../../../src/features/utility/ElementFinder";
 
 /**
@@ -89,6 +89,15 @@ describe("clickable predicate", () => {
     expect(evaluation.matched).toBe(false);
     expect(evaluation.candidates).toEqual([]);
   });
+
+  test("only evaluates a matching element inside its container", () => {
+    const predicate = clickable(finder, { elementId: "submit", container: { elementId: "checkout" } });
+    const evaluation = predicate(obs([
+      node({ "resource-id": "other", "node": [node({ "resource-id": "submit", "clickable": true })] }),
+      node({ "resource-id": "checkout", "node": [node({ "resource-id": "submit", "clickable": false })] }),
+    ]));
+    expect(evaluation.matched).toBe(false);
+  });
 });
 
 describe("textEquals predicate", () => {
@@ -119,6 +128,15 @@ describe("textEquals predicate", () => {
   test("does NOT match when the located element is absent", () => {
     const predicate = textEquals(finder, { elementId: "counter" }, "5");
     const evaluation = predicate(obs([node({ "resource-id": "other", "text": "5" })]));
+    expect(evaluation.matched).toBe(false);
+  });
+
+  test("does not use an exact-text match outside its container", () => {
+    const predicate = textEquals(finder, { elementId: "counter", container: { elementId: "checkout" } }, "5");
+    const evaluation = predicate(obs([
+      node({ "resource-id": "other", "node": [node({ "resource-id": "counter", "text": "5" })] }),
+      node({ "resource-id": "checkout", "node": [node({ "resource-id": "counter", "text": "4" })] }),
+    ]));
     expect(evaluation.matched).toBe(false);
   });
 });
@@ -167,5 +185,30 @@ describe("countStable predicate", () => {
       node({ "resource-id": "row", "text": "b" }),
     ])).matched).toBe(false);
     expect(predicate(obs([node({ "resource-id": "row", "text": "a" })])).matched).toBe(false);
+  });
+
+  test("counts only matches in its container", () => {
+    const predicate = countStable(finder, { elementId: "row", container: { elementId: "checkout" } });
+    expect(predicate(obs([
+      node({ "resource-id": "other", "node": [node({ "resource-id": "row" })] }),
+      node({ "resource-id": "checkout", "node": [] }),
+    ])).matched).toBe(false);
+    expect(predicate(obs([
+      node({ "resource-id": "other", "node": [node({ "resource-id": "row" }), node({ "resource-id": "row" })] }),
+      node({ "resource-id": "checkout", "node": [] }),
+    ])).matched).toBe(true);
+  });
+});
+
+describe("disappear predicate", () => {
+  const finder = new DefaultElementFinder();
+
+  test("treats a matching element outside its container as absent", () => {
+    const predicate = disappear(finder, { elementId: "spinner", container: { elementId: "checkout" } });
+    const evaluation = predicate(obs([
+      node({ "resource-id": "other", "node": [node({ "resource-id": "spinner" })] }),
+      node({ "resource-id": "checkout", "node": [] }),
+    ]));
+    expect(evaluation.matched).toBe(true);
   });
 });

--- a/test/server/observeWaitForConditionDsl.test.ts
+++ b/test/server/observeWaitForConditionDsl.test.ts
@@ -259,7 +259,7 @@ describe("waitFor back-compat", () => {
     });
   });
 
-  test("rejects conflicting timeout aliases across all waitFor forms", () => {
+  test("rejects dual timeout aliases across all waitFor forms", () => {
     for (const waitFor of [
       { for: "appear", elementId: "x" },
       { elementId: "x" },
@@ -268,7 +268,7 @@ describe("waitFor back-compat", () => {
       expect(() =>
         observeSchema.parse({
           platform: "android",
-          waitFor: { ...waitFor, timeout: 1000, timeoutMs: 2000 },
+          waitFor: { ...waitFor, timeout: 1000, timeoutMs: 1000 },
         })
       ).toThrow(/timeout/);
     }

--- a/test/server/observeWaitForConditionDsl.test.ts
+++ b/test/server/observeWaitForConditionDsl.test.ts
@@ -74,6 +74,19 @@ describe("buildConditionPredicate", () => {
     expect(predicate(makeObservation([node({ "resource-id": "submit" })])).matched).toBe(true);
   });
 
+  test("appear -> scopes its finder lookup to the requested container", () => {
+    const predicate = buildConditionPredicate(finder, "appear", {
+      elementId: "submit",
+      container: { elementId: "checkout" },
+    });
+    const observation = makeObservation([
+      node({ "resource-id": "other", "node": [node({ "resource-id": "submit" })] }),
+      node({ "resource-id": "checkout", "node": [] }),
+    ]);
+
+    expect(predicate(observation).matched).toBe(false);
+  });
+
   test("disappear -> matches an absent element", () => {
     const predicate = buildConditionPredicate(finder, "disappear", { elementId: "spinner" });
     expect(predicate(makeObservation([node({ "resource-id": "content" })])).matched).toBe(true);
@@ -218,6 +231,31 @@ describe("waitFor back-compat", () => {
     expect(parsed.waitFor).toMatchObject({ for: "clickable", elementId: "com.app:id/submit" });
   });
 
+  test("DSL form accepts a container scope and the timeoutMs alias", () => {
+    const parsed = observeSchema.parse({
+      platform: "android",
+      waitFor: {
+        for: "clickable",
+        elementId: "com.app:id/submit",
+        container: { elementId: "com.app:id/form" },
+        timeoutMs: 8000,
+      },
+    });
+    expect(parsed.waitFor).toMatchObject({
+      container: { elementId: "com.app:id/form" },
+      timeoutMs: 8000,
+    });
+  });
+
+  test("DSL form rejects conflicting timeout and timeoutMs values", () => {
+    expect(() =>
+      observeSchema.parse({
+        platform: "android",
+        waitFor: { for: "appear", elementId: "x", timeout: 1000, timeoutMs: 2000 },
+      })
+    ).toThrow(/timeout/);
+  });
+
   test("DSL `for: stable` needs no selector", () => {
     const parsed = observeSchema.parse({
       platform: "android",
@@ -284,6 +322,15 @@ describe("waitForConditionSchema", () => {
   test("requires a selector for appear", () => {
     expect(() => waitForConditionSchema.parse({ platform: "android", for: "appear" })).toThrow();
   });
+
+  test("accepts a container scope", () => {
+    expect(waitForConditionSchema.parse({
+      platform: "android",
+      for: "appear",
+      elementId: "row",
+      container: { text: "Recent orders" },
+    })).toMatchObject({ container: { text: "Recent orders" } });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -324,6 +371,36 @@ describe("runWaitForConditionTool", () => {
     );
     expect(result.matched).toBe(true);
     expect(result.matchedElement?.["resource-id"]).toBe("submit");
+  });
+
+  test("does not satisfy a condition from outside the requested container", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const observeScreen = new FakeObserveScreen();
+    observeScreen.setObserveSequence([
+      makeObservation([
+        node({ "resource-id": "other", "node": [node({ "resource-id": "submit" })] }),
+        node({ "resource-id": "checkout", "node": [] }),
+      ], 10),
+      makeObservation([
+        node({ "resource-id": "other", "node": [node({ "resource-id": "submit" })] }),
+        node({ "resource-id": "checkout", "node": [node({ "resource-id": "submit" })] }),
+      ], 20),
+    ]);
+
+    const result = await runWaitForConditionTool(
+      observeScreen,
+      {
+        platform: "android",
+        for: "appear",
+        elementId: "submit",
+        container: { elementId: "checkout" },
+      } as any,
+      timer
+    );
+
+    expect(result.matched).toBe(true);
+    expect(result.observation.updatedAt).toBe(20);
   });
 });
 

--- a/test/server/observeWaitForConditionDsl.test.ts
+++ b/test/server/observeWaitForConditionDsl.test.ts
@@ -104,6 +104,18 @@ describe("buildConditionPredicate", () => {
     expect(predicate(makeObservation([node({ "resource-id": "counter", "text": "5" })])).matched).toBe(true);
   });
 
+  test("textEquals -> retains its container scope", () => {
+    const predicate = buildConditionPredicate(finder, "textEquals", {
+      elementId: "counter",
+      text: "5",
+      container: { elementId: "checkout" },
+    });
+    expect(predicate(makeObservation([
+      node({ "resource-id": "other", "node": [node({ "resource-id": "counter", "text": "5" })] }),
+      node({ "resource-id": "checkout", "node": [] }),
+    ])).matched).toBe(false);
+  });
+
   test("countStable -> settles once the match count repeats", () => {
     const predicate = buildConditionPredicate(finder, "countStable", { elementId: "row" }, { stableReads: 2 });
     expect(predicate(makeObservation([node({ "resource-id": "row" })])).matched).toBe(false);
@@ -247,13 +259,19 @@ describe("waitFor back-compat", () => {
     });
   });
 
-  test("DSL form rejects conflicting timeout and timeoutMs values", () => {
-    expect(() =>
-      observeSchema.parse({
-        platform: "android",
-        waitFor: { for: "appear", elementId: "x", timeout: 1000, timeoutMs: 2000 },
-      })
-    ).toThrow(/timeout/);
+  test("rejects conflicting timeout aliases across all waitFor forms", () => {
+    for (const waitFor of [
+      { for: "appear", elementId: "x" },
+      { elementId: "x" },
+      { textAny: ["x"] },
+    ]) {
+      expect(() =>
+        observeSchema.parse({
+          platform: "android",
+          waitFor: { ...waitFor, timeout: 1000, timeoutMs: 2000 },
+        })
+      ).toThrow(/timeout/);
+    }
   });
 
   test("DSL `for: stable` needs no selector", () => {

--- a/test/server/observeWaitForConditionDsl.test.ts
+++ b/test/server/observeWaitForConditionDsl.test.ts
@@ -282,6 +282,15 @@ describe("waitFor back-compat", () => {
     expect(parsed.waitFor).toMatchObject({ for: "stable" });
   });
 
+  test("DSL `for: stable` rejects container because settling is whole-screen", () => {
+    expect(() =>
+      observeSchema.parse({
+        platform: "android",
+        waitFor: { for: "stable", container: { elementId: "scope" } },
+      })
+    ).toThrow(/does not support container/);
+  });
+
   test("DSL `for: appear` without a selector is rejected", () => {
     expect(() =>
       observeSchema.parse({ platform: "android", waitFor: { for: "appear" } })

--- a/test/server/observeWaitForSchema.test.ts
+++ b/test/server/observeWaitForSchema.test.ts
@@ -268,6 +268,17 @@ describe("published observe waitFor input schema", () => {
     ]));
   });
 
+  test("rejects selectorless predicate DSL forms while permitting whole-screen stable", () => {
+    expect(validatePublishedObserveInput({
+      platform: "android",
+      waitFor: { for: "appear" },
+    }).valid).toBe(false);
+    expect(validatePublishedObserveInput({
+      platform: "android",
+      waitFor: { for: "stable" },
+    }).valid).toBe(true);
+  });
+
   test("committed tool definitions document textMatch as applying only to waitFor.text", () => {
     const toolDefinitions = JSON.parse(readFileSync(
       new URL("../../schemas/tool-definitions.json", import.meta.url),

--- a/test/server/observeWaitForSchema.test.ts
+++ b/test/server/observeWaitForSchema.test.ts
@@ -277,6 +277,10 @@ describe("published observe waitFor input schema", () => {
       platform: "android",
       waitFor: { for: "stable" },
     }).valid).toBe(true);
+    expect(validatePublishedObserveInput({
+      platform: "android",
+      waitFor: { for: "stable", container: { elementId: "scope" } },
+    }).valid).toBe(false);
   });
 
   test("requires text for the advertised textEquals DSL form", () => {

--- a/test/server/observeWaitForSchema.test.ts
+++ b/test/server/observeWaitForSchema.test.ts
@@ -299,6 +299,13 @@ describe("published observe waitFor input schema", () => {
     }
   });
 
+  test("rejects dual timeout aliases in the advertised schema", () => {
+    expect(validatePublishedObserveInput({
+      platform: "android",
+      waitFor: { for: "appear", elementId: "target", timeout: 1000, timeoutMs: 1000 },
+    }).valid).toBe(false);
+  });
+
   test("committed tool definitions document textMatch as applying only to waitFor.text", () => {
     const toolDefinitions = JSON.parse(readFileSync(
       new URL("../../schemas/tool-definitions.json", import.meta.url),

--- a/test/server/observeWaitForSchema.test.ts
+++ b/test/server/observeWaitForSchema.test.ts
@@ -279,6 +279,26 @@ describe("published observe waitFor input schema", () => {
     }).valid).toBe(true);
   });
 
+  test("requires text for the advertised textEquals DSL form", () => {
+    expect(validatePublishedObserveInput({
+      platform: "android",
+      waitFor: { for: "textEquals", elementId: "counter" },
+    }).valid).toBe(false);
+    expect(validatePublishedObserveInput({
+      platform: "android",
+      waitFor: { for: "textEquals", elementId: "counter", text: "5" },
+    }).valid).toBe(true);
+  });
+
+  test("enforces the advertised container selector shape", () => {
+    for (const container of [{}, { elementId: "scope", text: "Scope" }]) {
+      expect(validatePublishedObserveInput({
+        platform: "android",
+        waitFor: { for: "appear", elementId: "target", container },
+      }).valid).toBe(false);
+    }
+  });
+
   test("committed tool definitions document textMatch as applying only to waitFor.text", () => {
     const toolDefinitions = JSON.parse(readFileSync(
       new URL("../../schemas/tool-definitions.json", import.meta.url),


### PR DESCRIPTION
## Summary

- Scope `appear`, `disappear`, `clickable`, `textEquals`, and `countStable` wait predicates to an optional container.
- Expose container scoping through both `observe.waitFor` DSL and `waitForCondition`.
- Accept `timeoutMs` as an `observe.waitFor` alias and tighten the compact advertised DSL schema.
- Keep the MCP tool-context budget under its configured threshold.

## Why

The declarative wait predicates previously always searched the full screen, unlike legacy `observe.waitFor`. This restores parity and prevents duplicate elements outside the intended container from satisfying a wait.

## Validation

- `bun test test/features/observe/ConditionPredicates.test.ts test/server/observeWaitForConditionDsl.test.ts test/server/observeWaitForSchema.test.ts`
- `bun run typecheck`
- `bun run benchmark-context` (Tools: 16,767 / 16,830)
- `bun run turbo:validate` (9,552 passed, 0 failed; 14 device-dependent skips)

Closes [#4405](https://github.com/kaeawc/auto-mobile/issues/4405)
