### PR TITLE
fix(observe): suppress occlusion diff churn

### DIFF
--- a/docs/design-docs/plat/android/actions-diff-observe-signoff.md
+++ b/docs/design-docs/plat/android/actions-diff-observe-signoff.md
@@ -213,7 +213,7 @@ above:
 
 ### Follow-ups
 
-### Addendum: occlusion-metadata stability (#4399)
+### Addendum: occlusion-metadata stability ([#4399](https://github.com/kaeawc/auto-mobile/issues/4399))
 
 The Android occlusion pass is enabled by default and emits
 `occlusionState`/`occludedBy`/`occludedByViewId` on hierarchy nodes. The

--- a/docs/design-docs/plat/android/actions-diff-observe-signoff.md
+++ b/docs/design-docs/plat/android/actions-diff-observe-signoff.md
@@ -213,6 +213,29 @@ above:
 
 ### Follow-ups
 
+### Addendum: occlusion-metadata stability (#4399)
+
+The Android occlusion pass is enabled by default and emits
+`occlusionState`/`occludedBy`/`occludedByViewId` on hierarchy nodes. The
+capture-layer stable-identity code already excludes these fields because they
+can churn between captures of the same screen. The action-diff comparison now
+uses the same policy: matched-node deltas and Element mirror fields ignore all
+three attributes. `SafeAreaAuditor` derives a warning's `confidence` from
+`occlusionState`, so the diff also treats a confidence-only `layoutWarnings`
+change as unchanged; any material warning change remains emitted.
+
+**Android emulator sign-off (2026-07-25):** with a branch daemon running
+`--actions-diff-observe --safe-area-warnings` and occlusion enabled, two
+consecutive real Android emulator captures were fed through the same
+`sanitizeObserveResult → diffObserveResult` path used by
+`finalizeToolResponse`. The output had `added=0`, `removed=0`, `changed=0`, and
+no `fields`. This sample did not itself exhibit the documented nondeterministic
+occlusion churn, so the exact churn suppression is pinned by the deterministic
+unit regressions in `diffObserveResult.test.ts`: node-only churn, mirror-only
+churn, and `layoutWarnings.confidence`-only churn produce no diff, while a real
+node or warning change remains visible. `recompositionMetrics` remains diffed;
+there is no evidence that it is volatile.
+
 - Capture-layer: emit real stable node identity so scroll diffs collapse the
   id-less/text-less cascade (the residual opacity in §4) — the genuine fix
   #3107 pointed at, orthogonal to the diff format. **Landed as #3228**: the TS

--- a/src/features/observe/SettleObserve.ts
+++ b/src/features/observe/SettleObserve.ts
@@ -10,41 +10,18 @@ const DEFAULT_POLL_MS = 150;
 const DEFAULT_STABLE_READS = 2;
 
 /**
- * Node attributes that churn nondeterministically between two captures of the
- * *same* screen and therefore must not, on their own, read as instability.
- *
- * `diffObserveResult`'s own `DIFF_IGNORED_ATTRS` already drops `extras` and the
- * synthetic `view-id`, but the occlusion attributes are diffed — and the Android
- * capture layer documents them as volatile for exactly this reason: they are
- * excluded from the content-identity hash in
- * `src/features/observe/android/StableNodeIdentity.ts` ("`occlusionState` /
- * `occludedBy` / `occludedByViewId` churn nondeterministically between captures",
- * #3051, #3519). Occlusion is on by default (`ServerConfig`), so without this a
- * genuinely idle Android screen would produce a `changed` entry every poll and
- * `settleObserve` would never settle. The action-diff (`--actions-diff-observe`)
- * path has the same latent exposure but is out of scope here (follow-up).
- */
-const STABILITY_VOLATILE_ATTRS: ReadonlySet<string> = new Set([
-  "occlusionState",
-  "occludedBy",
-  "occludedByViewId",
-]);
-
-/**
  * Whether a structural diff represents a *stable* screen for settle purposes.
  * Stable means: nothing added or removed, no diffed top-level `fields` changed
  * (`diffObserveResult` only sets `fields` on an actual change, so absence means
- * unchanged), and every `changed` entry touches only volatile attributes that do
- * not count as instability (see {@link STABILITY_VOLATILE_ATTRS}). A `changed`
- * entry that touches any real attribute keeps the screen not-yet-settled.
+ * unchanged), and no matched node changes. The shared diff ignores volatile
+ * capture attributes, including occlusion metadata, so every remaining change is
+ * actionable instability.
  */
 function isStabilityDiffEmpty(diff: ObserveDiff): boolean {
-  if (diff.added.length !== 0 || diff.removed.length !== 0 || diff.fields !== undefined) {
-    return false;
-  }
-  return diff.changed.every(entry =>
-    Object.keys(entry.changes).every(attr => STABILITY_VOLATILE_ATTRS.has(attr))
-  );
+  return diff.added.length === 0
+    && diff.removed.length === 0
+    && diff.changed.length === 0
+    && diff.fields === undefined;
 }
 
 /**

--- a/src/features/observe/output/ObserveResultOutput.ts
+++ b/src/features/observe/output/ObserveResultOutput.ts
@@ -701,8 +701,22 @@ function elementValuesEqual(a: unknown, b: unknown): boolean {
  * re-flood localized diffs the way `extras` once did. Excluded from the
  * *changed* comparison only; pairing and `added`/`removed` reconstruction are
  * unaffected.
+ *
+ * `occlusionState` / `occludedBy` / `occludedByViewId` (issue #4399): the
+ * Android occlusion pass reports these as capture metadata, not durable UI
+ * state. They are excluded from the Android stable-identity content hash because
+ * two captures of an unchanged screen can disagree on all three. Emitting them
+ * here would therefore make `--actions-diff-observe` report phantom changes and
+ * make element mirrors disagree for a stable focused node. They remain on
+ * added/removed nodes for reconstruction and are never identity keys.
  */
-export const DIFF_IGNORED_ATTRS: ReadonlySet<string> = new Set(["extras", "view-id"]);
+export const DIFF_IGNORED_ATTRS: ReadonlySet<string> = new Set([
+  "extras",
+  "view-id",
+  "occlusionState",
+  "occludedBy",
+  "occludedByViewId",
+]);
 
 /** Per-attribute diff of two attribute maps (union of keys). */
 function diffAttributes(
@@ -726,6 +740,30 @@ function diffAttributes(
     }
   }
   return changes;
+}
+
+/**
+ * `SafeAreaAuditor` derives a warning's confidence from `occlusionState`.
+ * Occlusion is volatile capture metadata, so confidence-only warning churn must
+ * not reintroduce the phantom action diff excluded at the node level. Preserve
+ * all other warning fields and preserve the original values when a material
+ * warning change is emitted.
+ */
+function layoutWarningsEqual(a: unknown, b: unknown): boolean {
+  const withoutDerivedConfidence = (value: unknown): unknown => {
+    if (!Array.isArray(value)) {
+      return value;
+    }
+    return value.map(warning => {
+      if (!warning || typeof warning !== "object" || Array.isArray(warning)) {
+        return warning;
+      }
+      const copy = { ...(warning as Record<string, unknown>) };
+      delete copy.confidence;
+      return copy;
+    });
+  };
+  return valuesEqual(withoutDerivedConfidence(a), withoutDerivedConfidence(b));
 }
 
 /**
@@ -1123,7 +1161,10 @@ export function diffObserveResult(
   const baseRecord = baseline as unknown as Record<string, unknown>;
   const nextRecord = next as unknown as Record<string, unknown>;
   for (const field of scalarFields) {
-    if (!valuesEqual(baseRecord[field], nextRecord[field])) {
+    const equal = field === "layoutWarnings"
+      ? layoutWarningsEqual(baseRecord[field], nextRecord[field])
+      : valuesEqual(baseRecord[field], nextRecord[field]);
+    if (!equal) {
       fields[field] = { from: baseRecord[field], to: nextRecord[field] };
     }
   }

--- a/test/features/observe/output/diffObserveResult.test.ts
+++ b/test/features/observe/output/diffObserveResult.test.ts
@@ -1331,6 +1331,96 @@ describe("diffObserveResult — volatile `extras` metadata exclusion (#3051)", (
   });
 });
 
+describe("diffObserveResult — volatile occlusion exclusion (#4399)", () => {
+  const node = (extra: Record<string, unknown> = {}) => ({
+    "resource-id": "covered",
+    "bounds": { left: 0, top: 0, right: 100, bottom: 40 },
+    "text": "Continue",
+    ...extra,
+  });
+
+  const warning = (confidence: "high" | "medium") => ({
+    type: "important-content-under-inset",
+    severity: "warning",
+    element: { viewId: "covered", bounds: { left: 0, top: 0, right: 100, bottom: 40 } },
+    categories: ["text"],
+    insetTypes: ["systemBars"],
+    sides: ["top"],
+    overflowPx: { top: 40 },
+    insetPx: { top: 59 },
+    overlapPercent: 100,
+    confidence,
+  } as const);
+
+  test("occlusion-only node churn produces no changed entry", () => {
+    const baseline = obs(node({
+      occlusionState: "partial",
+      occludedBy: "android.view.View",
+      occludedByViewId: "overlay-a",
+    }));
+    const next = obs(node({
+      occlusionState: "visible",
+      occludedBy: "",
+      occludedByViewId: "overlay-b",
+    }));
+
+    expect(diffObserveResult(baseline, next).changed).toEqual([]);
+  });
+
+  test("a real node change remains visible beside occlusion churn", () => {
+    const baseline = obs(node({ occlusionState: "partial", occludedBy: "overlay-a" }));
+    const next = obs(node({ occlusionState: "visible", occludedBy: "overlay-b", checked: "true" }));
+
+    const diff = diffObserveResult(baseline, next);
+    expect(diff.changed).toHaveLength(1);
+    expect(Object.keys(diff.changed[0].changes)).toEqual(["checked"]);
+  });
+
+  test("an element mirror whose only change is occlusion churn is not reported", () => {
+    const baseline = obs(node(), {
+      focusedElement: node({ occlusionState: "partial", occludedBy: "overlay-a" }) as any,
+    });
+    const next = obs(node(), {
+      focusedElement: node({ occlusionState: "visible", occludedBy: "overlay-b" }) as any,
+    });
+
+    expect(diffObserveResult(baseline, next).fields).toBeUndefined();
+  });
+
+  test("layout-warning confidence churn caused by occlusion is not reported", () => {
+    const baseline = obs(node(), { layoutWarnings: [warning("high")] });
+    const next = obs(node(), { layoutWarnings: [warning("medium")] });
+
+    expect(diffObserveResult(baseline, next).fields).toBeUndefined();
+  });
+
+  test("a substantive layout-warning change remains visible", () => {
+    const baseline = obs(node(), { layoutWarnings: [warning("high")] });
+    const next = obs(node(), {
+      layoutWarnings: [{ ...warning("medium"), severity: "info" }],
+    });
+
+    expect(diffObserveResult(baseline, next).fields!.layoutWarnings).toBeDefined();
+  });
+
+  test("recomposition metrics remain a visible node change", () => {
+    const baseline = obs(node({ recompositionMetrics: { count: 2 } }));
+    const next = obs(node({ recompositionMetrics: { count: 3 } }));
+
+    const diff = diffObserveResult(baseline, next);
+    expect(diff.changed).toHaveLength(1);
+    expect(Object.keys(diff.changed[0].changes)).toEqual(["recompositionMetrics"]);
+  });
+
+  test("the shared ignore set names every volatile occlusion attribute", () => {
+    expect([...DIFF_IGNORED_ATTRS]).toEqual(expect.arrayContaining([
+      "occlusionState",
+      "occludedBy",
+      "occludedByViewId",
+    ]));
+  });
+});
+
 describe("isSameObservationScreen", () => {
   const iosIdentity = (
     key: string,


### PR DESCRIPTION
## Summary

Suppresses volatile Android occlusion metadata from shared action-observation diffs.

- Adds `occlusionState`, `occludedBy`, and `occludedByViewId` to the shared matched-node and Element-mirror ignore set.
- Keeps `layoutWarnings` actionable while ignoring only confidence-only churn derived from volatile occlusion state.
- Removes the duplicate settle-specific occlusion exception; `settleObserve` now follows the shared diff policy.
- Documents the Android emulator sign-off and preserves `recompositionMetrics` as a real diff signal.

## Root cause

Android capture documents the occlusion attributes as nondeterministic. `diffObserveResult` still emitted them for matched nodes and mirrors, and `SafeAreaAuditor` propagated `occlusionState` into `layoutWarnings.confidence`, producing phantom action deltas.

## Validation

- `bun test test/features/observe/output/diffObserveResult.test.ts test/features/observe/SettleObserve.test.ts`
- `bun run turbo:validate` (9,549 passed, 0 failed)
- `bun run typecheck` (no new errors)
- Android emulator captures through `sanitizeObserveResult → diffObserveResult` with `--actions-diff-observe --safe-area-warnings`: empty same-screen diff. The sampled captures did not reproduce the nondeterministic churn, so exact suppression is pinned by deterministic unit tests.

Closes [#4399](https://github.com/kaeawc/auto-mobile/issues/4399)
