### PR TITLE
test(utils): property-based tests for device version matching

### DIFF
--- a/test/utils/deviceMatcher.property.test.ts
+++ b/test/utils/deviceMatcher.property.test.ts
@@ -1,0 +1,143 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import type { BootedDevice, Platform } from "../../src/models";
+import type { MatchingStrategy } from "../../src/models/DeviceMatchCriteria";
+import { compareVersions, DefaultDeviceMatcher } from "../../src/utils/deviceMatcher";
+import { SeededRandom } from "../fakes/SeededRandom";
+
+// Property-based tests. See Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+// Dotted numeric versions are the comparator's realistic domain — non-numeric
+// components make parseVersion produce NaN, which is out of contract.
+const versionParts = fc.array(fc.nat(99), { minLength: 1, maxLength: 4 });
+const versionOf = (parts: number[]): string => parts.join(".");
+
+// Independent oracle: compare component-wise, treating missing trailing
+// components as 0 (exactly the contract compareVersions documents).
+const refCompareSign = (a: number[], b: number[]): number => {
+  const length = Math.max(a.length, b.length);
+  for (let i = 0; i < length; i++) {
+    const delta = (a[i] ?? 0) - (b[i] ?? 0);
+    if (delta !== 0) {
+      return Math.sign(delta);
+    }
+  }
+  return 0;
+};
+
+describe("compareVersions (property-based)", () => {
+  test("is reflexive: a version compares equal to itself", () => {
+    fc.assert(
+      fc.property(versionParts, parts => compareVersions(versionOf(parts), versionOf(parts)) === 0),
+      RUN_OPTIONS
+    );
+  });
+
+  test("is sign-antisymmetric", () => {
+    fc.assert(
+      fc.property(versionParts, versionParts, (a, b) => {
+        const va = versionOf(a);
+        const vb = versionOf(b);
+        return Math.sign(compareVersions(va, vb)) === -Math.sign(compareVersions(vb, va));
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("agrees in sign with a component-wise numeric oracle", () => {
+    fc.assert(
+      fc.property(versionParts, versionParts, (a, b) => {
+        return Math.sign(compareVersions(versionOf(a), versionOf(b))) === refCompareSign(a, b);
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("trailing zero components do not change the ordering", () => {
+    fc.assert(
+      fc.property(versionParts, fc.integer({ min: 0, max: 3 }), (parts, extraZeros) => {
+        const padded = versionOf([...parts, ...Array(extraZeros).fill(0)]);
+        return compareVersions(versionOf(parts), padded) === 0;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("ordering is transitive", () => {
+    fc.assert(
+      fc.property(versionParts, versionParts, versionParts, (a, b, c) => {
+        const va = versionOf(a);
+        const vb = versionOf(b);
+        const vc = versionOf(c);
+        // a <= b <= c  ⇒  a <= c
+        return !(compareVersions(va, vb) <= 0 && compareVersions(vb, vc) <= 0) || compareVersions(va, vc) <= 0;
+      }),
+      RUN_OPTIONS
+    );
+  });
+});
+
+const platform = fc.constantFrom<Platform>("android", "ios");
+const device: fc.Arbitrary<BootedDevice> = fc.record({
+  name: fc.string({ maxLength: 12 }),
+  platform,
+  deviceId: fc.string({ minLength: 1, maxLength: 8 }),
+  osVersion: fc.option(versionParts.map(versionOf), { nil: undefined })
+});
+const deviceList = fc.array(device, { maxLength: 16 });
+
+describe("DefaultDeviceMatcher.matchBootedDevice (property-based)", () => {
+  test("returns null or a device from the list matching the requested platform", () => {
+    const strategy = fc.constantFrom<MatchingStrategy>("LATEST", "MINIMUM", "RANDOM");
+    fc.assert(
+      fc.property(deviceList, platform, strategy, (devices, p, s) => {
+        const result = new DefaultDeviceMatcher(new SeededRandom(1)).matchBootedDevice({ platform: p }, devices, s);
+        return result === null || (devices.includes(result) && result.platform === p);
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("returns null exactly when no device has the requested platform", () => {
+    const strategy = fc.constantFrom<MatchingStrategy>("LATEST", "MINIMUM", "RANDOM");
+    fc.assert(
+      fc.property(deviceList, platform, strategy, (devices, p, s) => {
+        const result = new DefaultDeviceMatcher(new SeededRandom(1)).matchBootedDevice({ platform: p }, devices, s);
+        const hasMatch = devices.some(d => d.platform === p);
+        return (result === null) === !hasMatch;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("LATEST/MINIMUM select an extremal version among the platform matches", () => {
+    const extremum = fc.constantFrom<MatchingStrategy>("LATEST", "MINIMUM");
+    fc.assert(
+      fc.property(deviceList, platform, extremum, (devices, p, s) => {
+        const result = new DefaultDeviceMatcher(new SeededRandom(1)).matchBootedDevice({ platform: p }, devices, s);
+        if (result === null) {
+          return true;
+        }
+        const matches = devices.filter(d => d.platform === p);
+        const resultVersion = result.osVersion ?? "0";
+        return matches.every(d => {
+          const cmp = compareVersions(resultVersion, d.osVersion ?? "0");
+          return s === "LATEST" ? cmp >= 0 : cmp <= 0;
+        });
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("RANDOM selection is deterministic under a fixed seed", () => {
+    fc.assert(
+      fc.property(deviceList, platform, fc.integer({ min: 1, max: 1_000 }), (devices, p, seed) => {
+        const a = new DefaultDeviceMatcher(new SeededRandom(seed)).matchBootedDevice({ platform: p }, devices, "RANDOM");
+        const b = new DefaultDeviceMatcher(new SeededRandom(seed)).matchBootedDevice({ platform: p }, devices, "RANDOM");
+        return a === b;
+      }),
+      RUN_OPTIONS
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Continues the fast-check property-testing expansion (pattern from [PR #4427](https://github.com/kaeawc/auto-mobile/pull/4427); prior suites in [PR #4434](https://github.com/kaeawc/auto-mobile/pull/4434), [PR #4438](https://github.com/kaeawc/auto-mobile/pull/4438), [PR #4440](https://github.com/kaeawc/auto-mobile/pull/4440)) with the pure version comparator and matching logic in `src/utils/deviceMatcher.ts`. `DefaultDeviceMatcher` is driven by an injected `SeededRandom`, so the suite is fully pure and deterministic. Test-only, additive — no production changes, no new dependencies.

Invariants asserted:

- **`compareVersions`** — reflexive (`compare(v, v) == 0`); sign-antisymmetric (`sign(compare(a,b)) == -sign(compare(b,a))`); agrees in sign with an **independent** component-wise numeric oracle; trailing-zero components don't change the ordering (`1.2` ≡ `1.2.0`); transitive.
- **`DefaultDeviceMatcher.matchBootedDevice`** — result is `null` or a listed device matching the requested platform (membership + totality); `null` **exactly** when no device has that platform; `LATEST`/`MINIMUM` select an extremal version among the platform matches; `RANDOM` selection is deterministic under a fixed seed.

Generators are bounded to the comparator's realistic domain — dotted **numeric** version strings. (Non-numeric components make `parseVersion` yield `NaN`, which is out of contract; deliberately not exercised rather than papered over.) No defects surfaced.

## Validation

- [x] `bun test test/utils/deviceMatcher.property.test.ts` — 9 pass, ~150ms
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run lint` — no new violations
- [x] New tests are pure (injected `SeededRandom`; no device/network/filesystem/DB); each runs in <100ms

## Follow-ups

- [ ] More pure `src/utils/` modules remain good candidates (e.g. `describeUnknownError`, `execResult`, `elementProperties`). Kept separate to keep each PR small.
