### PR TITLE
test(utils): property-based tests for argv, error-describe, exec-result helpers

### DIFF
--- a/test/utils/cliArgs.property.test.ts
+++ b/test/utils/cliArgs.property.test.ts
@@ -1,0 +1,78 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import { firstFlagValue } from "../../src/utils/cliArgs";
+
+// Property-based tests. See Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+// Flag names are `--` followed by letters — no `=` or whitespace, matching real
+// argv flags and keeping the inline `--flag=value` split unambiguous.
+const flagName = fc
+  .array(fc.constantFrom("a", "b", "c", "d", "e", "f"), { minLength: 1, maxLength: 6 })
+  .map(chars => `--${chars.join("")}`);
+
+// A value usable in the space-separated form: non-empty and not itself a flag.
+const spaceValue = fc.string({ minLength: 1, maxLength: 16 }).filter(v => !v.startsWith("--"));
+
+describe("firstFlagValue (property-based)", () => {
+  test("never throws and returns a string or undefined for arbitrary argv", () => {
+    fc.assert(
+      fc.property(fc.array(fc.string()), fc.array(fc.string()), (args, flags) => {
+        const result = firstFlagValue(args, flags);
+        return result === undefined || typeof result === "string";
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("recovers the inline value for any value (round-trip)", () => {
+    // The inline form has no flag-lookalike restriction, so ANY value round-trips.
+    fc.assert(
+      fc.property(flagName, fc.string({ maxLength: 24 }), (flag, value) => {
+        return firstFlagValue([`${flag}=${value}`], [flag]) === value;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("recovers the space-separated value when it is a non-flag token", () => {
+    fc.assert(
+      fc.property(flagName, spaceValue, (flag, value) => {
+        return firstFlagValue([flag, value], [flag]) === value;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("a flag with no value, or followed by another flag, yields undefined", () => {
+    fc.assert(
+      fc.property(flagName, flagName, (flag, other) => {
+        const loneAtEnd = firstFlagValue([flag], [flag]) === undefined;
+        const followedByFlag = firstFlagValue([flag, other], [flag]) === undefined;
+        return loneAtEnd && followedByFlag;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("argv with no matching flag yields undefined", () => {
+    // Prefixing every token with "p" guarantees none is a `--flag` or `--flag=…`.
+    const positionals = fc.array(fc.string({ maxLength: 12 }).map(t => `p${t}`), { maxLength: 10 });
+    fc.assert(
+      fc.property(positionals, fc.array(flagName, { minLength: 1, maxLength: 3 }), (args, flags) => {
+        return firstFlagValue(args, flags) === undefined;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("the first matching flag in argv wins", () => {
+    fc.assert(
+      fc.property(fc.string({ maxLength: 12 }), fc.string({ maxLength: 12 }), (v1, v2) => {
+        const result = firstFlagValue(["--one=" + v1, "--two=" + v2], ["--one", "--two"]);
+        return result === v1;
+      }),
+      RUN_OPTIONS
+    );
+  });
+});

--- a/test/utils/describeUnknownError.property.test.ts
+++ b/test/utils/describeUnknownError.property.test.ts
@@ -1,0 +1,61 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import { describeUnknownError } from "../../src/utils/describeUnknownError";
+
+// Property-based tests. See Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+describe("describeUnknownError (property-based)", () => {
+  test("always returns a string for any input (totality — its whole purpose)", () => {
+    fc.assert(
+      fc.property(fc.anything(), value => typeof describeUnknownError(value) === "string"),
+      RUN_OPTIONS
+    );
+  });
+
+  test("primitives stringify exactly like String()", () => {
+    const primitive = fc.oneof(
+      fc.string(),
+      fc.integer(),
+      fc.double({ noNaN: true }),
+      fc.boolean(),
+      fc.bigInt()
+    );
+    fc.assert(
+      fc.property(primitive, value => describeUnknownError(value) === String(value)),
+      RUN_OPTIONS
+    );
+  });
+
+  test("null and undefined render as their String() form", () => {
+    fc.assert(
+      fc.property(fc.constantFrom(null, undefined), value => describeUnknownError(value) === String(value)),
+      RUN_OPTIONS
+    );
+  });
+
+  test("an Error's rendering starts with its name and contains its message", () => {
+    fc.assert(
+      fc.property(fc.string({ minLength: 1, maxLength: 40 }), message => {
+        const rendered = describeUnknownError(new Error(message));
+        return rendered.startsWith("Error") && rendered.includes(message);
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("a plain object with enumerable keys renders as its JSON serialization", () => {
+    const jsonObject = fc.dictionary(fc.string(), fc.jsonValue(), { minKeys: 1, maxKeys: 6 });
+    fc.assert(
+      fc.property(jsonObject, obj => describeUnknownError(obj) === JSON.stringify(obj)),
+      RUN_OPTIONS
+    );
+  });
+
+  test("an object with no enumerable keys is flagged as such", () => {
+    fc.assert(
+      fc.property(fc.constant({}), obj => describeUnknownError(obj).includes("no enumerable keys")),
+      RUN_OPTIONS
+    );
+  });
+});

--- a/test/utils/execResult.property.test.ts
+++ b/test/utils/execResult.property.test.ts
@@ -1,0 +1,64 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import { createExecResult } from "../../src/utils/execResult";
+
+// Property-based tests. See Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+// Well-formed UTF-16 (no lone surrogates) so Buffer utf-8 round-trips exactly.
+const text = fc
+  .array(fc.integer({ min: 0, max: 0x10ffff }).filter(cp => cp < 0xd800 || cp > 0xdfff), { maxLength: 100 })
+  .map(cps => String.fromCodePoint(...cps));
+
+describe("createExecResult (property-based)", () => {
+  test("string inputs pass through unchanged on stdout/stderr", () => {
+    fc.assert(
+      fc.property(text, text, (out, err) => {
+        const result = createExecResult(out, err);
+        return result.stdout === out && result.stderr === err;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("Buffer inputs are decoded and round-trip through utf-8", () => {
+    fc.assert(
+      fc.property(text, text, (out, err) => {
+        const result = createExecResult(Buffer.from(out, "utf8"), Buffer.from(err, "utf8"));
+        return result.stdout === out && result.stderr === err;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("toString() and trim() are stdout-derived", () => {
+    fc.assert(
+      fc.property(text, text, (out, err) => {
+        const result = createExecResult(out, err);
+        return result.toString() === result.stdout && result.trim() === result.stdout.trim();
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("includes() agrees with String.prototype.includes on stdout", () => {
+    fc.assert(
+      fc.property(text, text, fc.string({ maxLength: 8 }), (out, err, needle) => {
+        const result = createExecResult(out, err);
+        return result.includes(needle) === result.stdout.includes(needle);
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("a substring of stdout is always reported as included", () => {
+    fc.assert(
+      fc.property(text, text, (out, err) => {
+        const result = createExecResult(out, err);
+        // Every prefix of stdout is a substring, so includes() must accept it.
+        return result.includes(out.slice(0, Math.floor(out.length / 2)));
+      }),
+      RUN_OPTIONS
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Continues the fast-check property-testing expansion (pattern from [PR #4427](https://github.com/kaeawc/auto-mobile/pull/4427); prior suites in [PR #4434](https://github.com/kaeawc/auto-mobile/pull/4434), [PR #4438](https://github.com/kaeawc/auto-mobile/pull/4438), [PR #4440](https://github.com/kaeawc/auto-mobile/pull/4440), [PR #4441](https://github.com/kaeawc/auto-mobile/pull/4441)) with a cluster of three small, pure, dependency-free helpers. Test-only, additive — no production changes, no new dependencies.

Invariants asserted:

- **`cliArgs.firstFlagValue`** — total (never throws; returns `string | undefined`); the inline `--flag=value` form round-trips **any** value; the space-separated form recovers a non-flag value; a lone flag (or a flag followed by another flag) yields `undefined`; argv with no matching flag yields `undefined`; the first matching flag in argv wins.
- **`describeUnknownError`** — total (always a string for any input — its whole purpose); primitives and `null`/`undefined` match `String()`; an `Error` starts with its name and contains its message; a plain object with enumerable keys renders as its JSON serialization; a keyless object is flagged `"no enumerable keys"`.
- **`execResult.createExecResult`** — string inputs pass through on `stdout`/`stderr`; `Buffer` inputs decode and round-trip through utf-8; `toString()`/`trim()` are stdout-derived; `includes()` agrees with `String.prototype.includes` and accepts any stdout substring.

`createExecResult`'s Buffer round-trip is scoped to well-formed UTF-16 (lone surrogates don't survive a utf-8 encode/decode — out of realistic domain). No defects surfaced.

## Validation

- [x] `bun test test/utils/{cliArgs,describeUnknownError,execResult}.property.test.ts` — 17 pass, ~160ms
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run lint` — no new violations
- [x] New tests are pure (no device/network/filesystem/DB); each runs in <100ms

## Follow-ups

- [ ] More pure `src/utils/` modules remain good candidates (e.g. `elementProperties`, `eventAllMarkers`, `topContributors`, `predictionUtils`). Kept separate to keep each PR small.
