### PR TITLE
test(utils): property-based tests for element/contributor/prediction helpers

### DIFF
--- a/test/utils/elementProperties.property.test.ts
+++ b/test/utils/elementProperties.property.test.ts
@@ -1,0 +1,121 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import type { Element } from "../../src/models/Element";
+import {
+  buildContainerFromElement,
+  hasAccessibilityAction,
+  isClickableElementProperties,
+  isTruthyFlag
+} from "../../src/utils/elementProperties";
+
+// Property-based tests. See Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+const bounds = { left: 0, top: 0, right: 100, bottom: 100 };
+// The four string fields buildContainerFromElement inspects, in priority order.
+const optString = fc.option(fc.string({ maxLength: 10 }), { nil: undefined });
+
+describe("isTruthyFlag (property-based)", () => {
+  test("is true for exactly `true` and \"true\", false for everything else", () => {
+    fc.assert(
+      fc.property(fc.anything(), value => isTruthyFlag(value) === (value === true || value === "true")),
+      RUN_OPTIONS
+    );
+  });
+});
+
+describe("hasAccessibilityAction (property-based)", () => {
+  test("agrees with Array.includes for arrays and is false for non-arrays", () => {
+    fc.assert(
+      fc.property(fc.array(fc.string()), fc.string(), (actions, action) => {
+        return hasAccessibilityAction(actions, action) === actions.includes(action);
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("never throws and is always a boolean for arbitrary input", () => {
+    fc.assert(
+      fc.property(fc.anything(), fc.string(), (value, action) => typeof hasAccessibilityAction(value, action) === "boolean"),
+      RUN_OPTIONS
+    );
+  });
+
+  test("an array containing the action is always reported", () => {
+    fc.assert(
+      fc.property(fc.array(fc.string()), fc.string(), (rest, action) =>
+        hasAccessibilityAction([...rest, action], action)
+      ),
+      RUN_OPTIONS
+    );
+  });
+});
+
+describe("isClickableElementProperties (property-based)", () => {
+  test("equals the OR of a truthy `clickable` flag and a \"click\" action", () => {
+    const props = fc.record({
+      clickable: fc.option(fc.oneof(fc.boolean(), fc.string({ maxLength: 6 })), { nil: undefined }),
+      actions: fc.option(fc.array(fc.string({ maxLength: 6 })), { nil: undefined })
+    });
+    fc.assert(
+      fc.property(props, p => {
+        const expected = isTruthyFlag(p.clickable) || hasAccessibilityAction(p.actions, "click");
+        return isClickableElementProperties(p) === expected;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("a `clickable: true` flag or a \"click\" action each force clickable", () => {
+    fc.assert(
+      fc.property(fc.array(fc.string({ maxLength: 6 })), actions => {
+        return (
+          isClickableElementProperties({ clickable: true, actions }) &&
+          isClickableElementProperties({ actions: [...actions, "click"] })
+        );
+      }),
+      RUN_OPTIONS
+    );
+  });
+});
+
+describe("buildContainerFromElement (property-based)", () => {
+  test("resource-id takes priority and maps to elementId", () => {
+    fc.assert(
+      fc.property(fc.string({ minLength: 1, maxLength: 10 }), optString, optString, (rid, text, cd) => {
+        const el = { bounds, "resource-id": rid, text, "content-desc": cd } as Element;
+        const container = buildContainerFromElement(el);
+        return container !== null && container.elementId === rid && container.text === undefined;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("returns null exactly when all four identifying fields are absent/empty", () => {
+    fc.assert(
+      fc.property(fc.constantFrom("", undefined), value => {
+        const el = {
+          bounds,
+          "resource-id": value,
+          "text": value,
+          "content-desc": value,
+          "ios-accessibility-label": value
+        } as Element;
+        return buildContainerFromElement(el) === null;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("a non-null result carries exactly one key", () => {
+    const field = fc.constantFrom("resource-id", "text", "content-desc", "ios-accessibility-label");
+    fc.assert(
+      fc.property(field, fc.string({ minLength: 1, maxLength: 10 }), (key, val) => {
+        const el = { bounds, [key]: val } as Element;
+        const container = buildContainerFromElement(el);
+        return container !== null && Object.keys(container).length === 1;
+      }),
+      RUN_OPTIONS
+    );
+  });
+});

--- a/test/utils/predictionUtils.property.test.ts
+++ b/test/utils/predictionUtils.property.test.ts
@@ -1,0 +1,83 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import { normalizeIdentifier, normalizeToolArgs } from "../../src/utils/predictionUtils";
+
+// Property-based tests. See Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+// Identifier-ish text: letters (mixed case), digits, spaces, and separators.
+const identChar = fc.constantFrom("a", "B", "c", "D", "3", "_", "-", ".", " ", "\t");
+const identifier = fc.string({ unit: identChar, maxLength: 20 });
+
+// Tool-arg objects whose keys are never the stripped ones (deviceId/sessionUuid).
+const argKey = fc.string({ minLength: 1, maxLength: 8 }).filter(k => k !== "deviceId" && k !== "sessionUuid");
+const toolArgs = fc.dictionary(argKey, fc.jsonValue(), { minKeys: 1, maxKeys: 6 });
+
+describe("normalizeIdentifier (property-based)", () => {
+  test("is idempotent", () => {
+    fc.assert(
+      fc.property(identifier, v => normalizeIdentifier(normalizeIdentifier(v)) === normalizeIdentifier(v)),
+      RUN_OPTIONS
+    );
+  });
+
+  test("a defined result is fully trimmed and lower-cased", () => {
+    fc.assert(
+      fc.property(identifier, v => {
+        const result = normalizeIdentifier(v);
+        return result === undefined || (result === result.trim() && result === result.toLowerCase());
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("blank or whitespace-only input normalizes to undefined", () => {
+    const blank = fc.string({ unit: fc.constantFrom(" ", "\t", "\n"), maxLength: 8 });
+    fc.assert(
+      fc.property(blank, v => normalizeIdentifier(v) === undefined && normalizeIdentifier(undefined) === undefined),
+      RUN_OPTIONS
+    );
+  });
+});
+
+describe("normalizeToolArgs (property-based)", () => {
+  test("empty/null/undefined args normalize to the empty string", () => {
+    fc.assert(
+      fc.property(fc.constantFrom(null, undefined, {}), args => normalizeToolArgs(args) === ""),
+      RUN_OPTIONS
+    );
+  });
+
+  test("deviceId and sessionUuid are ignored", () => {
+    fc.assert(
+      fc.property(toolArgs, fc.string(), fc.string(), (args, deviceId, sessionUuid) => {
+        return normalizeToolArgs({ ...args, deviceId, sessionUuid }) === normalizeToolArgs(args);
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("output is insensitive to key insertion order", () => {
+    fc.assert(
+      fc.property(toolArgs, args => {
+        const reordered = Object.fromEntries(Object.entries(args).reverse());
+        return normalizeToolArgs(reordered) === normalizeToolArgs(args);
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("output is always the empty string or valid JSON", () => {
+    fc.assert(
+      fc.property(fc.dictionary(fc.string(), fc.jsonValue(), { maxKeys: 6 }), args => {
+        const result = normalizeToolArgs(args);
+        if (result === "") {
+          return true;
+        }
+        JSON.parse(result);
+        return true;
+      }),
+      RUN_OPTIONS
+    );
+  });
+});

--- a/test/utils/topContributors.property.test.ts
+++ b/test/utils/topContributors.property.test.ts
@@ -1,0 +1,74 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import {
+  selectTopContributors,
+  TOP_CONTRIBUTOR_WEIGHT_THRESHOLD,
+  type WeightedContribution
+} from "../../src/utils/topContributors";
+
+// Property-based tests. See Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+// Weights live in [0, 1] per the audit contract. Each violation is a distinct
+// object so subset membership can be checked by reference.
+const weight = fc.double({ min: 0, max: 1, noNaN: true });
+const violations = fc.array(weight.map(w => ({ contributionWeight: w })), { maxLength: 20 });
+
+describe("selectTopContributors (property-based)", () => {
+  test("an empty input yields an empty result", () => {
+    fc.assert(
+      fc.property(fc.constant([] as WeightedContribution[]), v => selectTopContributors(v).length === 0),
+      RUN_OPTIONS
+    );
+  });
+
+  test("a non-empty input always yields at least one contributor (issue #4167)", () => {
+    fc.assert(
+      fc.property(violations.filter(v => v.length > 0), v => selectTopContributors(v).length >= 1),
+      RUN_OPTIONS
+    );
+  });
+
+  test("the result is a subset of the input and never larger", () => {
+    fc.assert(
+      fc.property(violations, v => {
+        const result = selectTopContributors(v);
+        return result.length <= v.length && result.every(r => v.includes(r));
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("the result is sorted by weight, highest first", () => {
+    fc.assert(
+      fc.property(violations, v => {
+        const result = selectTopContributors(v);
+        return result.every((r, i) => i === 0 || result[i - 1].contributionWeight >= r.contributionWeight);
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("every selected weight is at or above min(threshold, maxWeight), and the max is always selected", () => {
+    fc.assert(
+      fc.property(violations.filter(v => v.length > 0), v => {
+        const maxWeight = Math.max(...v.map(x => x.contributionWeight));
+        const cutoff = Math.min(TOP_CONTRIBUTOR_WEIGHT_THRESHOLD, maxWeight);
+        const result = selectTopContributors(v);
+        const allAboveCutoff = result.every(r => r.contributionWeight >= cutoff);
+        const includesMax = result.some(r => r.contributionWeight === maxWeight);
+        return allAboveCutoff && includesMax;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("when any violation meets the threshold, nothing below it is selected", () => {
+    fc.assert(
+      fc.property(violations.filter(v => v.some(x => x.contributionWeight >= TOP_CONTRIBUTOR_WEIGHT_THRESHOLD)), v => {
+        return selectTopContributors(v).every(r => r.contributionWeight >= TOP_CONTRIBUTOR_WEIGHT_THRESHOLD);
+      }),
+      RUN_OPTIONS
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Continues the fast-check property-testing expansion (pattern from [PR #4427](https://github.com/kaeawc/auto-mobile/pull/4427); prior suites in [PR #4434](https://github.com/kaeawc/auto-mobile/pull/4434), [PR #4438](https://github.com/kaeawc/auto-mobile/pull/4438), [PR #4440](https://github.com/kaeawc/auto-mobile/pull/4440), [PR #4441](https://github.com/kaeawc/auto-mobile/pull/4441), [PR #4442](https://github.com/kaeawc/auto-mobile/pull/4442)) with a cluster of three pure, dependency-free helpers. Test-only, additive — no production changes, no new dependencies.

Invariants asserted:

- **`elementProperties`** — `isTruthyFlag` is true for exactly `true`/`"true"`; `hasAccessibilityAction` agrees with `Array.includes`, is total (always boolean), and reports any contained action; `isClickableElementProperties` equals the OR of a truthy `clickable` flag and a `"click"` action; `buildContainerFromElement` gives `resource-id` priority (→ `elementId`), returns `null` **exactly** when all four identifying fields are absent/empty, and a non-null result carries exactly one key.
- **`topContributors.selectTopContributors`** — empty→empty; non-empty→≥1 selected ([issue #4167](https://github.com/kaeawc/auto-mobile/issues/4167) — never an empty heading); the result is a subset of the input, sorted highest-weight-first; every selected weight is ≥ `min(threshold, maxWeight)` and the max-weight violation is always selected; once any violation meets the threshold, nothing below it is selected.
- **`predictionUtils`** — `normalizeIdentifier` is idempotent, its defined output is fully trimmed and lower-cased, and blank/`undefined` input → `undefined`; `normalizeToolArgs` maps empty/null args to `""`, ignores `deviceId`/`sessionUuid`, is insensitive to key insertion order, and always emits `""` or valid JSON.

No defects surfaced.

## Validation

- [x] `bun test test/utils/{elementProperties,topContributors,predictionUtils}.property.test.ts` — 22 pass, ~200ms
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run lint` — no new violations
- [x] New tests are pure (no device/network/filesystem/DB); each runs in <100ms

## Follow-ups

- [ ] More pure `src/utils/` modules remain good candidates (e.g. `eventAllMarkers`, `deviceAppearance`, `hostAppearance`, `outputReductionFlags`). Kept separate to keep each PR small.
