### PR TITLE
test(observe-ctrlproxy): burn down 12 verified test-quality findings (#4173)

### DIFF
--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -399,6 +399,151 @@ describe("AndroidCtrlProxyClient", function() {
     });
   });
 
+  describe("a11y screenshot support latch", function() {
+    // Drives AndroidCtrlProxyClient.captureScreenshotForObservationStream() through the real socket:
+    // each failed a11y screenshot increments a consecutive-failure counter; on the
+    // A11Y_SCREENSHOT_MAX_FAILURES-th (=3) it latches a11yScreenshotSupported=false so every future
+    // capture goes straight to ADB (no wasted a11y round-trips), and any success resets the counter.
+    // Flip the constant 3->1 and two of the three tests below go red — the latch threshold is pinned,
+    // not merely "eventually latches".
+    const setupConnectedCapturingClient = async (): Promise<{
+      client: AndroidCtrlProxyClient;
+      socket: CapturingWebSocket;
+    }> => {
+      await accessibilityServiceClient.close();
+      AndroidCtrlProxyClient.resetInstances();
+      // Manual (non-auto-advance) timer: the per-request 3s screenshot timeout must NOT auto-fire and
+      // preempt the wire frame we emit — we resolve each capture by socket, exactly as the backoff
+      // stream tests above do.
+      const localTimer = new FakeTimer();
+      const { factory, getSocket } = createCapturingWebSocketFactory(localTimer);
+      accessibilityServiceClient = AndroidCtrlProxyClient.createForTesting(
+        testDevice,
+        fakeAdb,
+        factory,
+        localTimer
+      );
+      accessibilityServiceClient.invalidateCache();
+      // ADB PNG fallback used whenever an a11y capture fails or the latch is set.
+      setAdbPngScreenshotResponse();
+
+      await accessibilityServiceClient.ensureConnected();
+      const socket = await waitForSocket(getSocket) as CapturingWebSocket | null;
+      await waitForSocketOpen(socket);
+      if (!socket) {
+        throw new Error("Expected capturing CtrlProxy socket");
+      }
+      return { client: accessibilityServiceClient, socket };
+    };
+
+    const countScreenshotRequests = (socket: CapturingWebSocket): number =>
+      socket.sentMessages.filter(raw => {
+        try {
+          return JSON.parse(raw).type === "request_screenshot";
+        } catch {
+          return false;
+        }
+      }).length;
+
+    const driveA11yScreenshot = async (
+      client: AndroidCtrlProxyClient,
+      socket: CapturingWebSocket,
+      resolveWith: { kind: "error" } | { kind: "success" }
+    ): Promise<any> => {
+      const before = countScreenshotRequests(socket);
+      const capturePromise = (client as any).captureScreenshotForObservationStream() as Promise<any>;
+      await waitForSentMessages(socket, socket.sentMessages.length + 1);
+      const request = findSentMessage(socket, "request_screenshot");
+      expect(countScreenshotRequests(socket)).toBe(before + 1);
+      const frame = resolveWith.kind === "error"
+        ? { type: "screenshot_error", requestId: request.requestId, error: "Runner failed to capture screenshot" }
+        : { type: "screenshot", requestId: request.requestId, data: "jpeg-base64", format: "jpeg", timestamp: 1 };
+      socket.emit("message", JSON.stringify(frame));
+      await flushPromises();
+      return capturePromise;
+    };
+
+    const findSentMessage = (socket: CapturingWebSocket, type: string): any => {
+      for (let i = socket.sentMessages.length - 1; i >= 0; i--) {
+        try {
+          const parsed = JSON.parse(socket.sentMessages[i]);
+          if (parsed.type === type) { return parsed; }
+        } catch {
+          // skip non-JSON control frames
+        }
+      }
+      throw new Error(`No message of type ${type} in: ${socket.sentMessages.join(", ")}`);
+    };
+
+    // Threshold-agnostic failure driver used only by the "eventually latches" test: it fails the
+    // a11y capture when one is attempted, but tolerates a capture that already short-circuited to
+    // ADB (so this test stays green whether the threshold is 3 or lower — the too-low case is what
+    // the other two tests catch).
+    const driveFailureTolerant = async (
+      client: AndroidCtrlProxyClient,
+      socket: CapturingWebSocket
+    ): Promise<void> => {
+      const before = countScreenshotRequests(socket);
+      const capturePromise = (client as any).captureScreenshotForObservationStream() as Promise<any>;
+      await flushPromises();
+      if (countScreenshotRequests(socket) > before) {
+        const request = findSentMessage(socket, "request_screenshot");
+        socket.emit("message", JSON.stringify({
+          type: "screenshot_error", requestId: request.requestId, error: "Runner failed to capture screenshot",
+        }));
+        await flushPromises();
+      }
+      await capturePromise;
+    };
+
+    test("latches to permanent ADB fallback after three consecutive a11y screenshot failures", async function() {
+      const { client, socket } = await setupConnectedCapturingClient();
+
+      await driveFailureTolerant(client, socket);
+      await driveFailureTolerant(client, socket);
+      await driveFailureTolerant(client, socket);
+
+      expect((client as any).a11yScreenshotSupported).toBe(false);
+
+      // Once latched, a further capture must NOT send another a11y request — it goes straight to ADB.
+      const requestsBefore = countScreenshotRequests(socket);
+      const result = await (client as any).captureScreenshotForObservationStream() as any;
+      await flushPromises();
+      expect(countScreenshotRequests(socket)).toBe(requestsBefore);
+      expect(result.screenshotCaptureSource).toBe("android_adb_screencap");
+    });
+
+    test("keeps attempting a11y screenshots after only two consecutive failures", async function() {
+      const { client, socket } = await setupConnectedCapturingClient();
+
+      await driveA11yScreenshot(client, socket, { kind: "error" });
+      await driveA11yScreenshot(client, socket, { kind: "error" });
+
+      // Two failures is below the threshold: the latch must NOT be set yet...
+      expect((client as any).a11yScreenshotSupported).not.toBe(false);
+      // ...and the next capture must still ATTEMPT an a11y screenshot over the socket.
+      const requestsBefore = countScreenshotRequests(socket);
+      await driveA11yScreenshot(client, socket, { kind: "error" });
+      expect(countScreenshotRequests(socket)).toBe(requestsBefore + 1);
+    });
+
+    test("resets the failure counter after a successful a11y screenshot", async function() {
+      const { client, socket } = await setupConnectedCapturingClient();
+
+      await driveA11yScreenshot(client, socket, { kind: "error" });
+      await driveA11yScreenshot(client, socket, { kind: "error" });
+      // A success (a wire "screenshot" frame the client actually handles) clears the counter.
+      const success = await driveA11yScreenshot(client, socket, { kind: "success" });
+      expect(success.success).toBe(true);
+      expect((client as any).a11yScreenshotSupported).toBe(true);
+
+      // Because the counter reset, two more failures still do not reach the latch threshold.
+      await driveA11yScreenshot(client, socket, { kind: "error" });
+      await driveA11yScreenshot(client, socket, { kind: "error" });
+      expect((client as any).a11yScreenshotSupported).not.toBe(false);
+    });
+  });
+
   test("allocates an Android forwarding port while skipping the iOS SDK hierarchy server port", async function() {
     await accessibilityServiceClient.close();
     AndroidCtrlProxyClient.resetInstances();
@@ -1137,8 +1282,6 @@ describe("AndroidCtrlProxyClient", function() {
 
       const result = accessibilityServiceClient.convertToViewHierarchyResult(accessibilityHierarchy);
 
-      expect(result).toBeDefined();
-      expect(result.hierarchy).toBeDefined();
       expect(result.hierarchy.text).toBe("6:43 AM");
       expect(result.hierarchy["content-desc"]).toBe("6:43 AM");
       expect(result.hierarchy.class).toBe("android.widget.TextClock");
@@ -1210,8 +1353,6 @@ describe("AndroidCtrlProxyClient", function() {
 
       const result = accessibilityServiceClient.convertToViewHierarchyResult(problematicHierarchy);
 
-      expect(result).toBeDefined();
-      expect(result.hierarchy).toBeDefined();
       expect(result.hierarchy.error).toContain("Accessibility hierarchy missing from accessibility service");
     });
 
@@ -1325,37 +1466,52 @@ describe("AndroidCtrlProxyClient", function() {
 
     // WebSocket-based hierarchy retrieval is tested through integration tests
 
-    test("should return null when hierarchy retrieval fails", async function() {
-      // Configure service as available but WebSocket connection will fail
-      fakeAdb.setCommandResponse("pm list packages", {
-        stdout: `package:${AndroidCtrlProxyManager.PACKAGE}\n`,
-        stderr: ""
-      });
-      fakeAdb.setCommandResponse("settings get secure", {
-        stdout: `${AndroidCtrlProxyManager.PACKAGE}/${AndroidCtrlProxyManager.PACKAGE}.CtrlProxy`,
-        stderr: ""
-      });
+    test("fresh-hierarchy wait fails fast — well under the timeout budget — when the screen is off", async function() {
       fakeAdb.setCommandResponse("forward", { stdout: `${serverPort}`, stderr: "" });
 
-      // Set screen to off - this triggers fast-fail in waitForFreshData after ~1 second
+      // Screen off: the connection succeeds (so the fresh-data wait is actually entered), but no
+      // hierarchy is ever pushed, so waitForFreshData can only exit via the periodic screen check
+      // firing settleResolve(null) (CtrlProxyHierarchy.ts:737-740) or by burning the whole timeout.
       fakeAdb.setScreenState(false);
 
-      // Use delayed mode with 1ms for faster test execution
-
-      // Create a new client with FakeWebSocket that fails instantly and FakeTimer
-      const failingClient = AndroidCtrlProxyClient.createForTesting(
+      // A manual (non-auto-advance) timer: waitForFreshData polls on a repeating setInterval, which
+      // auto-advance models as a one-shot, so we drive virtual time explicitly and step past the
+      // ~1s screen-check cadence ourselves.
+      const manualTimer = new FakeTimer();
+      const asleepClient = AndroidCtrlProxyClient.createForTesting(
         testDevice,
         fakeAdb,
-        createInstantFailureWebSocketFactory(fakeTimer),
-        fakeTimer
+        createSuccessWebSocketFactory(manualTimer),
+        manualTimer
       );
 
+      // A generous wait budget so the fast-fail signal is unmistakable: the screen-off exit lands
+      // near the ~1s screen-check cadence, an order of magnitude below this ceiling. Asserting the
+      // VIRTUAL time at resolution proves the fast fail BY ASSERTION — deleting the screen-off
+      // settleResolve(null) makes the wait run to the full budget and the toBeLessThan below FAILS,
+      // rather than the old test which only "passed" by never fast-failing and hanging to bun's real
+      // timeout. waitForFresh=true with no pushed hierarchy forces the wait; a fresh client has no
+      // recent-timeout cooldown, so shouldSkipWebSocketWait() does not short-circuit it.
+      const budgetMs = 8000;
       try {
-        const result = await failingClient.getAccessibilityHierarchy();
-        expect(result).toBeNull();
+        let response: { hierarchy: unknown; fresh: boolean } | undefined;
+        void asleepClient.getLatestHierarchy(true, budgetMs).then(r => { response = r; });
+
+        // Let ensureConnected + the interval registration settle before advancing time.
+        await flushPromises();
+
+        for (let stepped = 0; stepped <= budgetMs + 500 && response === undefined; stepped += 250) {
+          await manualTimer.advanceTimersByTimeAsync(250);
+          await flushPromises();
+        }
+        const resolvedAtMs = manualTimer.now();
+
+        expect(response).toBeDefined();
+        expect(response!.hierarchy).toBeNull();
+        expect(response!.fresh).toBe(false);
+        expect(resolvedAtMs).toBeLessThan(budgetMs / 2);
       } finally {
-        // Clean up the test client
-        await failingClient.close();
+        await asleepClient.close();
       }
     });
   });
@@ -2819,48 +2975,6 @@ describe("AndroidCtrlProxyClient", function() {
   describe("bindSession", function() {
     afterEach(function() {
       NavigationGraphManager.resetInstance();
-    });
-
-    test("should use session-scoped NavigationGraphManager after binding", function() {
-      // This test asserts only on instance ROUTING/identity, not on per-instance
-      // navigation state, so it deliberately does not call setCurrentApp: that
-      // would resolve the real getDatabase() (session instances have no in-memory
-      // injection seam) and trip the unit-test DB guard (issue #3067).
-      const globalNav = NavigationGraphManager.getInstance();
-      const sessionNav = NavigationGraphManager.getInstanceForSession("test-session-123");
-
-      // Before binding: client uses global instance
-      // After binding: client should use session instance
-      accessibilityServiceClient.bindSession("test-session-123");
-
-      // Verify the client is now bound to this session
-      // We can't directly call getNavigationGraphManager() since it's private,
-      // but we can verify the binding was stored by binding again and checking
-      // that the session is overwritten
-      accessibilityServiceClient.bindSession("other-session");
-
-      // The client should now be bound to "other-session"
-      // This validates bindSession is a simple setter that changes routing
-      const otherNav = NavigationGraphManager.getInstanceForSession("other-session");
-      expect(otherNav).not.toBe(sessionNav);
-      expect(otherNav).not.toBe(globalNav);
-    });
-
-    test("should use global NavigationGraphManager when no session bound", function() {
-      // Without calling bindSession, client should use the global singleton
-      // We verify by checking that no session instances are created
-      NavigationGraphManager.resetInstance();
-
-      const client = AndroidCtrlProxyClient.createForTesting(
-        testDevice,
-        fakeAdb,
-        createSuccessWebSocketFactory(),
-        fakeTimer
-      );
-
-      // No session bound — global singleton should be used
-      // Simply verify the client was created without error
-      expect(client).toBeDefined();
     });
 
     // Pins the session-isolation invariants a per-device client relies on. A

--- a/test/features/observe/DeviceServiceInterface.test.ts
+++ b/test/features/observe/DeviceServiceInterface.test.ts
@@ -28,9 +28,7 @@ describe("DeviceService Interface Compliance", () => {
   // ===========================================================================
 
   describe("Type Compliance", () => {
-    test("AndroidCtrlProxyClient implements DeviceService interface", () => {
-      // This test verifies at compile-time that AndroidCtrlProxyClient
-      // is assignable to the DeviceService interface
+    test("AndroidCtrlProxyClient is assignable to DeviceService and reports disconnected before connecting", () => {
       const fakeTimer = new FakeTimer();
       fakeTimer.enableAutoAdvance();
       const fakeAdb = new FakeAdbExecutor();
@@ -52,30 +50,17 @@ describe("DeviceService Interface Compliance", () => {
         fakeTimer
       );
 
-      // Type assertion: AndroidCtrlProxyClient should be assignable to DeviceService
+      // The assignment is the interface-conformance check (tsc fails the build if the class stops
+      // implementing DeviceService) — no runtime `typeof method === "function"` echo of what the
+      // compiler already proves. The behavioral assertion exercises a DeviceService method through
+      // the interface reference: a freshly created client reports itself disconnected.
       const deviceService: DeviceService = client;
+      expect(deviceService.isConnected()).toBe(false);
 
-      // Verify the interface methods exist
-      expect(typeof deviceService.ensureConnected).toBe("function");
-      expect(typeof deviceService.waitForConnection).toBe("function");
-      expect(typeof deviceService.isConnected).toBe("function");
-      expect(typeof deviceService.close).toBe("function");
-      expect(typeof deviceService.requestTapCoordinates).toBe("function");
-      expect(typeof deviceService.requestSwipe).toBe("function");
-      expect(typeof deviceService.requestDrag).toBe("function");
-      expect(typeof deviceService.requestPinch).toBe("function");
-      expect(typeof deviceService.requestSetText).toBe("function");
-      expect(typeof deviceService.requestClearText).toBe("function");
-      expect(typeof deviceService.requestImeAction).toBe("function");
-      expect(typeof deviceService.requestScreenshot).toBe("function");
-
-      // Cleanup
       void client.close();
     });
 
-    test("AndroidCtrlProxyClient (iOS) implements DeviceService interface", () => {
-      // This test verifies at compile-time that AndroidCtrlProxyClient (iOS)
-      // is assignable to the DeviceService interface
+    test("IOSCtrlProxyClient is assignable to DeviceService and reports disconnected before connecting", () => {
       const fakeTimer = new FakeTimer();
       fakeTimer.enableAutoAdvance();
 
@@ -93,28 +78,13 @@ describe("DeviceService Interface Compliance", () => {
         fakeTimer
       );
 
-      // Type assertion: AndroidCtrlProxyClient (iOS) should be assignable to DeviceService
       const deviceService: DeviceService = client;
+      expect(deviceService.isConnected()).toBe(false);
 
-      // Verify the interface methods exist
-      expect(typeof deviceService.ensureConnected).toBe("function");
-      expect(typeof deviceService.waitForConnection).toBe("function");
-      expect(typeof deviceService.isConnected).toBe("function");
-      expect(typeof deviceService.close).toBe("function");
-      expect(typeof deviceService.requestTapCoordinates).toBe("function");
-      expect(typeof deviceService.requestSwipe).toBe("function");
-      expect(typeof deviceService.requestDrag).toBe("function");
-      expect(typeof deviceService.requestPinch).toBe("function");
-      expect(typeof deviceService.requestSetText).toBe("function");
-      expect(typeof deviceService.requestClearText).toBe("function");
-      expect(typeof deviceService.requestImeAction).toBe("function");
-      expect(typeof deviceService.requestScreenshot).toBe("function");
-
-      // Cleanup
       void client.close();
     });
 
-    test("AndroidCtrlProxyClient implements AndroidDeviceService interface", () => {
+    test("AndroidCtrlProxyClient is assignable to AndroidDeviceService and reports disconnected before connecting", () => {
       const fakeTimer = new FakeTimer();
       fakeTimer.enableAutoAdvance();
       const fakeAdb = new FakeAdbExecutor();
@@ -136,21 +106,15 @@ describe("DeviceService Interface Compliance", () => {
         fakeTimer
       );
 
-      // Type assertion: AndroidCtrlProxyClient should be assignable to AndroidDeviceService
+      // Assignment proves AndroidDeviceService conformance at compile time; the assertion exercises
+      // the interface reference's base behavior.
       const androidService: AndroidDeviceService = client;
+      expect(androidService.isConnected()).toBe(false);
 
-      // Verify Android-specific interface methods exist
-      expect(typeof androidService.requestClipboard).toBe("function");
-      expect(typeof androidService.requestSelectAll).toBe("function");
-      expect(typeof androidService.requestAction).toBe("function");
-      expect(typeof androidService.requestCurrentFocus).toBe("function");
-      expect(typeof androidService.requestTraversalOrder).toBe("function");
-
-      // Cleanup
       void client.close();
     });
 
-    test("AndroidCtrlProxyClient (iOS) has Apple-specific methods", () => {
+    test("IOSCtrlProxyClient exposes Apple-specific control methods", () => {
       const fakeTimer = new FakeTimer();
       fakeTimer.enableAutoAdvance();
 
@@ -168,15 +132,10 @@ describe("DeviceService Interface Compliance", () => {
         fakeTimer
       );
 
-      // Verify Apple-specific interface methods exist
-      expect(typeof client.requestLaunchApp).toBe("function");
-      expect(typeof client.requestPressHome).toBe("function");
-      expect(typeof client.requestPressBack).toBe("function");
-      expect(typeof client.requestPressButton).toBe("function");
-      expect(typeof client.requestRecentApps).toBe("function");
-      expect(typeof client.requestKeyboard).toBe("function");
+      // The Apple-specific methods (requestLaunchApp/requestPressHome/…) are compile-time-proven by
+      // the client's type; the behavioral assertion exercises the client's initial disconnected state.
+      expect(client.isConnected()).toBe(false);
 
-      // Cleanup
       void client.close();
     });
   });

--- a/test/features/observe/DeviceServiceInterface.test.ts
+++ b/test/features/observe/DeviceServiceInterface.test.ts
@@ -132,8 +132,19 @@ describe("DeviceService Interface Compliance", () => {
         fakeTimer
       );
 
-      // The Apple-specific methods (requestLaunchApp/requestPressHome/…) are compile-time-proven by
-      // the client's type; the behavioral assertion exercises the client's initial disconnected state.
+      // Pin the Apple-specific control surface at compile time: dropping any of these
+      // from IOSCtrlProxyClient fails tsc HERE, which is what this test's name guards.
+      const appleControls: {
+        requestLaunchApp: typeof client.requestLaunchApp;
+        requestPressHome: typeof client.requestPressHome;
+        requestPressButton: typeof client.requestPressButton;
+      } = {
+        requestLaunchApp: client.requestLaunchApp,
+        requestPressHome: client.requestPressHome,
+        requestPressButton: client.requestPressButton,
+      };
+      void appleControls;
+      // The behavioral assertion exercises the client's initial disconnected state.
       expect(client.isConnected()).toBe(false);
 
       void client.close();

--- a/test/features/observe/android/CtrlProxyCertificates.test.ts
+++ b/test/features/observe/android/CtrlProxyCertificates.test.ts
@@ -1,0 +1,564 @@
+/**
+ * Wire-driven tests for the CtrlProxyCertificates delegate, exercised through AndroidCtrlProxyClient.
+ *
+ * The delegate owns CA certificate install/remove (device-owner only), device-owner status, and
+ * permission queries. Each public method: (1) validates its input, (2) ensures a WebSocket
+ * connection, (3) sends a typed request and awaits the runner's result frame. These tests drive the
+ * real socket — asserting the request that goes out AND the result that comes back — so a cert
+ * installed under the wrong alias, a permission reported granted on a timeout, or a cert pushed for a
+ * nonexistent host file fails a test rather than silently shipping.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { AndroidCtrlProxyClient } from "../../../../src/features/observe/android";
+import { NavigationGraphManager } from "../../../../src/features/navigation/NavigationGraphManager";
+import { FakeAdbExecutor } from "../../../fakes/FakeAdbExecutor";
+import { AndroidCtrlProxyManager } from "../../../../src/utils/CtrlProxyManager";
+import { FakeAdbClientFactory } from "../../../fakes/FakeAdbClientFactory";
+import { BootedDevice } from "../../../../src/models";
+import { FakeWebSocket, WebSocketState, createInstantFailureWebSocketFactory } from "../../../fakes/FakeWebSocket";
+import { FakeTimer } from "../../../fakes/FakeTimer";
+
+describe("CtrlProxyCertificates (Android)", function() {
+  let fakeAdb: FakeAdbExecutor;
+  let testDevice: BootedDevice;
+  // Manual (non-auto-advance) timer: request timeouts must NOT auto-fire and preempt the wire result
+  // frames we emit. Timeout tests advance the clock explicitly.
+  let fakeTimer: FakeTimer;
+  const serverPort: number = 8765;
+
+  beforeEach(function() {
+    fakeTimer = new FakeTimer();
+
+    fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setCommandResponse("forward", { stdout: `${serverPort}`, stderr: "" });
+    fakeAdb.setScreenState(true);
+
+    testDevice = {
+      deviceId: "test-device-certs",
+      platform: "android",
+      isEmulator: true,
+      name: "Test Device"
+    };
+
+    AndroidCtrlProxyManager.resetInstances();
+    AndroidCtrlProxyClient.resetInstances();
+    AndroidCtrlProxyManager.getInstance(testDevice, new FakeAdbClientFactory()).clearAvailabilityCache();
+  });
+
+  afterEach(function() {
+    NavigationGraphManager.getInstance();
+  });
+
+  class CapturingWebSocket extends FakeWebSocket {
+    sentMessages: string[] = [];
+    send(data: any): void {
+      this.sentMessages.push(data.toString());
+      super.send(data);
+    }
+  }
+
+  const createCapturingFactory = (timer: FakeTimer): {
+    factory: (url: string) => CapturingWebSocket;
+    getSocket: () => CapturingWebSocket | null;
+  } => {
+    let socket: CapturingWebSocket | null = null;
+    return {
+      factory: (url: string) => {
+        socket = new CapturingWebSocket(url, "none", 0, timer);
+        return socket;
+      },
+      getSocket: () => socket
+    };
+  };
+
+  const waitForSocketOpen = async (socket: FakeWebSocket | null): Promise<void> => {
+    if (!socket || socket.readyState === WebSocketState.OPEN) { return; }
+    await new Promise<void>(resolve => socket.once("open", () => resolve()));
+  };
+
+  const waitForSocket = async (getSocket: () => CapturingWebSocket | null): Promise<CapturingWebSocket | null> => {
+    for (let i = 0; i < 5; i++) {
+      const s = getSocket();
+      if (s) { return s; }
+      await new Promise(r => setImmediate(r));
+    }
+    return getSocket();
+  };
+
+  const waitForSentMessages = async (socket: CapturingWebSocket | null, minCount = 1): Promise<void> => {
+    if (!socket) { return; }
+    for (let i = 0; i < 10; i++) {
+      if (socket.sentMessages.length >= minCount) { return; }
+      await new Promise(r => setImmediate(r));
+    }
+  };
+
+  const flushPromises = async (iterations = 5): Promise<void> => {
+    for (let i = 0; i < iterations; i++) {
+      await new Promise(r => setImmediate(r));
+    }
+  };
+
+  const findSentMessage = (socket: CapturingWebSocket, type: string): any => {
+    for (let i = socket.sentMessages.length - 1; i >= 0; i--) {
+      try {
+        const parsed = JSON.parse(socket.sentMessages[i]);
+        if (parsed.type === type) { return parsed; }
+      } catch {
+        // skip non-JSON control frames
+      }
+    }
+    throw new Error(`No message of type ${type} in: ${socket.sentMessages.join(", ")}`);
+  };
+
+  const hasSentMessage = (socket: CapturingWebSocket, type: string): boolean =>
+    socket.sentMessages.some(raw => {
+      try {
+        return JSON.parse(raw).type === type;
+      } catch {
+        return false;
+      }
+    });
+
+  /** Connect a capturing client and return the client + its socket. */
+  const connectClient = async (): Promise<{
+    client: AndroidCtrlProxyClient;
+    socket: CapturingWebSocket;
+  }> => {
+    const { factory, getSocket } = createCapturingFactory(fakeTimer);
+    const client = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, fakeTimer);
+    await client.ensureConnected();
+    const socket = await waitForSocket(getSocket);
+    await waitForSocketOpen(socket);
+    if (!socket) {
+      throw new Error("Expected capturing CtrlProxy socket");
+    }
+    return { client, socket };
+  };
+
+  const failingClient = (): AndroidCtrlProxyClient =>
+    AndroidCtrlProxyClient.createForTesting(
+      testDevice,
+      fakeAdb,
+      createInstantFailureWebSocketFactory(fakeTimer),
+      fakeTimer
+    );
+
+  // ===========================================================================
+  // requestInstallCaCertificate
+  // ===========================================================================
+
+  describe("requestInstallCaCertificate", function() {
+    test("sends install_ca_cert and resolves with the installed alias on success", async function() {
+      const { client, socket } = await connectClient();
+      try {
+        const baseCount = socket.sentMessages.length;
+        const resultPromise = client.requestInstallCaCertificate("PEMDATA");
+        await waitForSentMessages(socket, baseCount + 1);
+
+        const sent = findSentMessage(socket, "install_ca_cert");
+        expect(sent.certificate).toBe("PEMDATA");
+
+        socket.simulateMessage(JSON.stringify({
+          type: "ca_cert_result",
+          requestId: sent.requestId,
+          success: true,
+          action: "install",
+          alias: "user-alias-123",
+          totalTimeMs: 5,
+        }));
+
+        const result = await resultPromise;
+        expect(result.success).toBe(true);
+        expect(result.action).toBe("install");
+        expect(result.alias).toBe("user-alias-123");
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("rejects an empty certificate payload without sending a request", async function() {
+      const { client, socket } = await connectClient();
+      try {
+        const result = await client.requestInstallCaCertificate("");
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("Certificate payload is required");
+        expect(hasSentMessage(socket, "install_ca_cert")).toBe(false);
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("rejects a whitespace-only certificate payload", async function() {
+      const { client, socket } = await connectClient();
+      try {
+        const result = await client.requestInstallCaCertificate("   \n  ");
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("Certificate payload is required");
+        expect(hasSentMessage(socket, "install_ca_cert")).toBe(false);
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("surfaces the device error when installation fails", async function() {
+      const { client, socket } = await connectClient();
+      try {
+        const baseCount = socket.sentMessages.length;
+        const resultPromise = client.requestInstallCaCertificate("PEMDATA");
+        await waitForSentMessages(socket, baseCount + 1);
+        const sent = findSentMessage(socket, "install_ca_cert");
+
+        socket.simulateMessage(JSON.stringify({
+          type: "ca_cert_result",
+          requestId: sent.requestId,
+          success: false,
+          action: "install",
+          error: "Device is not a device owner",
+          totalTimeMs: 2,
+        }));
+
+        const result = await resultPromise;
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("device owner");
+        expect(result.alias).toBeUndefined();
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("returns a connection error when the socket cannot connect", async function() {
+      const client = failingClient();
+      try {
+        const result = await client.requestInstallCaCertificate("PEMDATA");
+        expect(result.success).toBe(false);
+        expect(result.error).toMatch(/connect/i);
+      } finally {
+        await client.close();
+      }
+    });
+  });
+
+  // ===========================================================================
+  // requestInstallCaCertificateFromFile
+  // ===========================================================================
+
+  describe("requestInstallCaCertificateFromFile", function() {
+    test("rejects an empty path without touching the device", async function() {
+      const { client, socket } = await connectClient();
+      try {
+        const result = await client.requestInstallCaCertificateFromFile("   ");
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("valid host file path");
+        expect(fakeAdb.getExecutedCommands().some(c => c.startsWith("push"))).toBe(false);
+        expect(hasSentMessage(socket, "install_ca_cert_from_path")).toBe(false);
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("rejects an on-device sdcard path (not a host file)", async function() {
+      const { client } = await connectClient();
+      try {
+        const result = await client.requestInstallCaCertificateFromFile("/sdcard/Download/ca.crt");
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("valid host file path");
+        expect(fakeAdb.getExecutedCommands().some(c => c.startsWith("push"))).toBe(false);
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("rejects a content:// path", async function() {
+      const { client } = await connectClient();
+      try {
+        const result = await client.requestInstallCaCertificateFromFile("content://downloads/ca.crt");
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("valid host file path");
+        expect(fakeAdb.getExecutedCommands().some(c => c.startsWith("push"))).toBe(false);
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("does not push a certificate for a nonexistent host file", async function() {
+      const { client, socket } = await connectClient();
+      try {
+        const missing = `/tmp/automobile-cert-does-not-exist-${Date.now()}.crt`;
+        const result = await client.requestInstallCaCertificateFromFile(missing);
+        expect(result.success).toBe(false);
+        // Never pushed the file and never asked the runner to install it.
+        expect(fakeAdb.getExecutedCommands().some(c => c.startsWith("push"))).toBe(false);
+        expect(hasSentMessage(socket, "install_ca_cert_from_path")).toBe(false);
+      } finally {
+        await client.close();
+      }
+    });
+  });
+
+  // ===========================================================================
+  // requestRemoveCaCertificate
+  // ===========================================================================
+
+  describe("requestRemoveCaCertificate", function() {
+    test("sends remove_ca_cert and resolves via the delegate handler on success", async function() {
+      const { client, socket } = await connectClient();
+      try {
+        const baseCount = socket.sentMessages.length;
+        const resultPromise = client.requestRemoveCaCertificate("user-alias-123");
+        await waitForSentMessages(socket, baseCount + 1);
+
+        const sent = findSentMessage(socket, "remove_ca_cert");
+        expect(sent.alias).toBe("user-alias-123");
+
+        socket.simulateMessage(JSON.stringify({
+          type: "ca_cert_result",
+          requestId: sent.requestId,
+          success: true,
+          action: "remove",
+          alias: "user-alias-123",
+          totalTimeMs: 4,
+        }));
+
+        const result = await resultPromise;
+        expect(result.success).toBe(true);
+        expect(result.action).toBe("remove");
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("rejects an empty alias without sending a request", async function() {
+      const { client, socket } = await connectClient();
+      try {
+        const result = await client.requestRemoveCaCertificate("  ");
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("alias is required");
+        expect(hasSentMessage(socket, "remove_ca_cert")).toBe(false);
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("surfaces the device error when removal fails", async function() {
+      const { client, socket } = await connectClient();
+      try {
+        const baseCount = socket.sentMessages.length;
+        const resultPromise = client.requestRemoveCaCertificate("user-alias-123");
+        await waitForSentMessages(socket, baseCount + 1);
+        const sent = findSentMessage(socket, "remove_ca_cert");
+
+        socket.simulateMessage(JSON.stringify({
+          type: "ca_cert_result",
+          requestId: sent.requestId,
+          success: false,
+          action: "remove",
+          error: "Alias not found",
+          totalTimeMs: 1,
+        }));
+
+        const result = await resultPromise;
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("Alias not found");
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("returns a connection error when the socket cannot connect", async function() {
+      const client = failingClient();
+      try {
+        const result = await client.requestRemoveCaCertificate("user-alias-123");
+        expect(result.success).toBe(false);
+        expect(result.error).toMatch(/connect/i);
+      } finally {
+        await client.close();
+      }
+    });
+  });
+
+  // ===========================================================================
+  // requestDeviceOwnerStatus
+  // ===========================================================================
+
+  describe("requestDeviceOwnerStatus", function() {
+    test("sends get_device_owner_status and resolves with owner/admin flags", async function() {
+      const { client, socket } = await connectClient();
+      try {
+        const baseCount = socket.sentMessages.length;
+        const resultPromise = client.requestDeviceOwnerStatus();
+        await waitForSentMessages(socket, baseCount + 1);
+        const sent = findSentMessage(socket, "get_device_owner_status");
+
+        socket.simulateMessage(JSON.stringify({
+          type: "device_owner_status_result",
+          requestId: sent.requestId,
+          success: true,
+          isDeviceOwner: true,
+          isAdminActive: true,
+          packageName: "com.example.owner",
+          totalTimeMs: 3,
+        }));
+
+        const result = await resultPromise;
+        expect(result.success).toBe(true);
+        expect(result.isDeviceOwner).toBe(true);
+        expect(result.isAdminActive).toBe(true);
+        expect(result.packageName).toBe("com.example.owner");
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("reports a non-owner device", async function() {
+      const { client, socket } = await connectClient();
+      try {
+        const baseCount = socket.sentMessages.length;
+        const resultPromise = client.requestDeviceOwnerStatus();
+        await waitForSentMessages(socket, baseCount + 1);
+        const sent = findSentMessage(socket, "get_device_owner_status");
+
+        socket.simulateMessage(JSON.stringify({
+          type: "device_owner_status_result",
+          requestId: sent.requestId,
+          success: true,
+          isDeviceOwner: false,
+          isAdminActive: false,
+          totalTimeMs: 3,
+        }));
+
+        const result = await resultPromise;
+        expect(result.success).toBe(true);
+        expect(result.isDeviceOwner).toBe(false);
+        expect(result.isAdminActive).toBe(false);
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("returns a connection error when the socket cannot connect", async function() {
+      const client = failingClient();
+      try {
+        const result = await client.requestDeviceOwnerStatus();
+        expect(result.success).toBe(false);
+        expect(result.isDeviceOwner).toBe(false);
+        expect(result.error).toMatch(/connect/i);
+      } finally {
+        await client.close();
+      }
+    });
+  });
+
+  // ===========================================================================
+  // requestPermission
+  // ===========================================================================
+
+  describe("requestPermission", function() {
+    test("sends get_permission and resolves granted", async function() {
+      const { client, socket } = await connectClient();
+      try {
+        const baseCount = socket.sentMessages.length;
+        const resultPromise = client.requestPermission("android.permission.CAMERA", true);
+        await waitForSentMessages(socket, baseCount + 1);
+
+        const sent = findSentMessage(socket, "get_permission");
+        expect(sent.permission).toBe("android.permission.CAMERA");
+        expect(sent.requestPermission).toBe(true);
+
+        socket.simulateMessage(JSON.stringify({
+          type: "permission_result",
+          requestId: sent.requestId,
+          success: true,
+          permission: "android.permission.CAMERA",
+          granted: true,
+          requestLaunched: true,
+          canRequest: true,
+          requiresSettings: false,
+          totalTimeMs: 6,
+        }));
+
+        const result = await resultPromise;
+        expect(result.success).toBe(true);
+        expect(result.granted).toBe(true);
+        expect(result.permission).toBe("android.permission.CAMERA");
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("rejects an empty permission name without sending a request", async function() {
+      const { client, socket } = await connectClient();
+      try {
+        const result = await client.requestPermission("   ");
+        expect(result.success).toBe(false);
+        expect(result.granted).toBe(false);
+        expect(result.error).toContain("Permission name is required");
+        expect(hasSentMessage(socket, "get_permission")).toBe(false);
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("reports a not-granted permission that requires settings", async function() {
+      const { client, socket } = await connectClient();
+      try {
+        const baseCount = socket.sentMessages.length;
+        const resultPromise = client.requestPermission("android.permission.SYSTEM_ALERT_WINDOW");
+        await waitForSentMessages(socket, baseCount + 1);
+        const sent = findSentMessage(socket, "get_permission");
+
+        socket.simulateMessage(JSON.stringify({
+          type: "permission_result",
+          requestId: sent.requestId,
+          success: true,
+          permission: "android.permission.SYSTEM_ALERT_WINDOW",
+          granted: false,
+          requestLaunched: false,
+          canRequest: false,
+          requiresSettings: true,
+          totalTimeMs: 6,
+        }));
+
+        const result = await resultPromise;
+        expect(result.success).toBe(true);
+        expect(result.granted).toBe(false);
+        expect(result.requiresSettings).toBe(true);
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("returns success:false (not a granted permission) when the request times out", async function() {
+      const { client, socket } = await connectClient();
+      try {
+        const baseCount = socket.sentMessages.length;
+        const resultPromise = client.requestPermission("android.permission.CAMERA", true, 50);
+        await waitForSentMessages(socket, baseCount + 1);
+
+        // Never answer; advance past the request timeout so the RequestManager resolves the failure.
+        await fakeTimer.advanceTimersByTimeAsync(60);
+        await flushPromises();
+
+        const result = await resultPromise;
+        expect(result.success).toBe(false);
+        expect(result.granted).toBe(false);
+        expect(result.error).toMatch(/timeout/i);
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("returns a connection error when the socket cannot connect", async function() {
+      const client = failingClient();
+      try {
+        const result = await client.requestPermission("android.permission.CAMERA");
+        expect(result.success).toBe(false);
+        expect(result.granted).toBe(false);
+        expect(result.error).toMatch(/connect/i);
+      } finally {
+        await client.close();
+      }
+    });
+  });
+});

--- a/test/features/observe/android/CtrlProxyFocus.test.ts
+++ b/test/features/observe/android/CtrlProxyFocus.test.ts
@@ -5,7 +5,7 @@ import { FakeAdbExecutor } from "../../../fakes/FakeAdbExecutor";
 import { AndroidCtrlProxyManager } from "../../../../src/utils/CtrlProxyManager";
 import { FakeAdbClientFactory } from "../../../fakes/FakeAdbClientFactory";
 import { BootedDevice } from "../../../../src/models";
-import { FakeWebSocket, WebSocketState } from "../../../fakes/FakeWebSocket";
+import { FakeWebSocket, WebSocketState, createInstantFailureWebSocketFactory } from "../../../fakes/FakeWebSocket";
 import { FakeTimer } from "../../../fakes/FakeTimer";
 
 describe("CtrlProxyFocus (Android) - set/clear accessibility focus", function() {
@@ -207,14 +207,21 @@ describe("CtrlProxyFocus (Android) - set/clear accessibility focus", function() 
     }
   });
 
-  test("returns error (throws) when WebSocket is not connected", async function() {
-    const { factory } = createCapturingFactory(fakeTimer);
-    const client = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, fakeTimer);
+  test("setAccessibilityFocus throws a connection error when the socket cannot connect", async function() {
+    // Drive a genuine connection failure: sendAction calls ensureConnected itself, so an
+    // instant-failure socket makes ensureConnected return false and the delegate surfaces the
+    // "Failed to connect to accessibility service" error. The /connect/i matcher pins THAT cause
+    // so a harness TypeError can no longer masquerade as a connection failure (the old bare
+    // rejects.toThrow() accepted any throw, and — because the capturing socket connects fine —
+    // actually exercised the RequestManager timeout path, duplicating the timeout test above).
+    const client = AndroidCtrlProxyClient.createForTesting(
+      testDevice,
+      fakeAdb,
+      createInstantFailureWebSocketFactory(fakeTimer),
+      fakeTimer
+    );
     try {
-      // No ensureConnected; fakeAdb forward is set but we never open the socket via the client.
-      // sendAction will attempt to connect; if it cannot it returns a connection error.
-      const result = client.setAccessibilityFocus("com.example:id/title", 50);
-      await expect(result).rejects.toThrow();
+      await expect(client.setAccessibilityFocus("com.example:id/title", 50)).rejects.toThrow(/connect/i);
     } finally {
       await client.close();
     }

--- a/test/features/observe/android/CtrlProxyPackages.test.ts
+++ b/test/features/observe/android/CtrlProxyPackages.test.ts
@@ -88,6 +88,34 @@ describe("CtrlProxyPackages (Android)", function() {
     }
   };
 
+  const flushPromises = async (iterations = 5): Promise<void> => {
+    for (let i = 0; i < iterations; i++) {
+      await new Promise(r => setImmediate(r));
+    }
+  };
+
+  const waitForCondition = async (predicate: () => boolean, iterations = 20): Promise<void> => {
+    for (let i = 0; i < iterations; i++) {
+      if (predicate()) {return;}
+      await new Promise(r => setImmediate(r));
+    }
+  };
+
+  /**
+   * Emit the runner's `connected` handshake frame so the client populates `supportedCommands`
+   * from the wire (the real capability-negotiation path), instead of a test poking the private
+   * field. The handshake also triggers an immediate cadence refresh, so callers clear
+   * `sentMessages` afterward to isolate the message under assertion.
+   */
+  const emitConnectedFrame = async (
+    socket: CapturingWebSocket,
+    supportedCommands: string[]
+  ): Promise<void> => {
+    socket.simulateMessage(JSON.stringify({ type: "connected", supportedCommands }));
+    await flushPromises();
+    socket.sentMessages = [];
+  };
+
   /**
    * Find the most recent message of a given type. The client sends control messages
    * on connect (e.g. set_network_mock_rules) that interleave with test sends.
@@ -105,15 +133,26 @@ describe("CtrlProxyPackages (Android)", function() {
   };
 
   describe("connection lifecycle", function() {
-    test("cancels screenshot backoff when the connection closes", function() {
-      const { factory } = createCapturingFactory(fakeTimer);
+    test("cancels screenshot backoff when the underlying socket closes", async function() {
+      const { factory, getSocket } = createCapturingFactory(fakeTimer);
       const client = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, fakeTimer);
       const scheduler = new FakeScreenshotBackoffScheduler();
+      try {
+        await client.ensureConnected();
+        const socket = await waitForSocket(getSocket);
+        await waitForSocketOpen(socket);
+        (client as any).screenshotBackoffScheduler = scheduler;
 
-      (client as any).screenshotBackoffScheduler = scheduler;
-      (client as any).onConnectionClosed();
+        // A genuine WebSocket "close" must run the client's close handler, which cancels pending
+        // screenshot captures. The old test poked (client as any).onConnectionClosed() directly, so
+        // it stayed green even if the ws.on("close") -> onConnectionClosed() wiring was severed.
+        socket!.close();
+        await waitForCondition(() => scheduler.cancelPendingCapturesCalls >= 1);
 
-      expect(scheduler.cancelPendingCapturesCalls).toBe(1);
+        expect(scheduler.cancelPendingCapturesCalls).toBe(1);
+      } finally {
+        await client.close();
+      }
     });
 
     test("refreshes screenshot cadence by rescheduling keepalive", function() {
@@ -135,8 +174,7 @@ describe("CtrlProxyPackages (Android)", function() {
       const socket = await waitForSocket(getSocket);
       await waitForSocketOpen(socket);
       expect(connected).toBe(true);
-      (client as any).supportedCommands = new Set(["set_hierarchy_interval"]);
-      socket!.sentMessages = [];
+      await emitConnectedFrame(socket!, ["set_hierarchy_interval"]);
 
       client.refreshObservationStreamHierarchyCadence(500);
 
@@ -152,8 +190,7 @@ describe("CtrlProxyPackages (Android)", function() {
       const socket = await waitForSocket(getSocket);
       await waitForSocketOpen(socket);
       expect(connected).toBe(true);
-      (client as any).supportedCommands = new Set();
-      socket!.sentMessages = [];
+      await emitConnectedFrame(socket!, []);
 
       client.refreshObservationStreamHierarchyCadence(500);
 
@@ -178,8 +215,7 @@ describe("CtrlProxyPackages (Android)", function() {
       const socket = await waitForSocket(getSocket);
       await waitForSocketOpen(socket);
       expect(connected).toBe(true);
-      (client as any).supportedCommands = new Set(["set_hierarchy_interval"]);
-      socket!.sentMessages = [];
+      await emitConnectedFrame(socket!, ["set_hierarchy_interval"]);
 
       client.refreshObservationStreamHierarchyCadence();
 

--- a/test/features/observe/android/ctrlProxyProtocol.test.ts
+++ b/test/features/observe/android/ctrlProxyProtocol.test.ts
@@ -102,250 +102,386 @@ describe("ctrlProxyProtocol — Kotlin contract coverage", () => {
   );
 });
 
+
+/**
+ * Byte-for-byte wire contract for every builder in `ctrlProxyRequests`, as a single parameterized
+ * table. Each row pairs a builder invocation with the exact JSON string the device must receive.
+ * The rows are the specification: a drift in field name, order, optionality, or null-vs-omitted
+ * handling fails the matching row rather than silently breaking the wire.
+ *
+ * The `builder` tag on each row feeds the completeness guard below, which fails when a new builder
+ * ships with zero wire coverage (builder #37) — closing the gap the old per-case tests left open.
+ */
 describe("ctrlProxyProtocol — builders serialize byte-identically", () => {
-  test("request_hierarchy", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.requestHierarchy({ requestId: "req-1", disableAllFiltering: false })))
-      .toBe('{"type":"request_hierarchy","requestId":"req-1","disableAllFiltering":false}');
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.requestHierarchy({ requestId: "req-2", disableAllFiltering: true })))
-      .toBe('{"type":"request_hierarchy","requestId":"req-2","disableAllFiltering":true}');
+  const shape: HighlightBoxShape = { type: "box", bounds: { x: 1, y: 2, width: 3, height: 4 } };
+  const shapeJson = '{"type":"box","bounds":{"x":1,"y":2,"width":3,"height":4}}';
+  const longCert = "A".repeat(4096);
+  const networkRules: NetworkMockRuleSync[] = [{
+    mockId: "m1", host: "example.com", path: "/v1", method: "GET",
+    limit: null, remaining: null, statusCode: 200,
+    responseHeaders: { "content-type": "application/json" },
+    responseBody: "{}", contentType: "application/json",
+  }];
+
+  interface BuilderCase {
+    builder: keyof typeof ctrlProxyRequests;
+    name: string;
+    actual: string;
+    expected: string;
+  }
+
+  const cases: BuilderCase[] = [
+    {
+      builder: "requestHierarchy",
+      name: "disableAllFiltering false",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.requestHierarchy({ requestId: "req-1", disableAllFiltering: false })),
+      expected: '{"type":"request_hierarchy","requestId":"req-1","disableAllFiltering":false}',
+    },
+    {
+      builder: "requestHierarchy",
+      name: "disableAllFiltering true",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.requestHierarchy({ requestId: "req-2", disableAllFiltering: true })),
+      expected: '{"type":"request_hierarchy","requestId":"req-2","disableAllFiltering":true}',
+    },
+    {
+      builder: "requestHierarchyIfStale",
+      name: "positive sinceTimestamp",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.requestHierarchyIfStale({ requestId: "stale-1", sinceTimestamp: 1720000000000 })),
+      expected: '{"type":"request_hierarchy_if_stale","requestId":"stale-1","sinceTimestamp":1720000000000}',
+    },
+    {
+      builder: "requestHierarchyIfStale",
+      name: "negative sinceTimestamp (boundary) is sent verbatim",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.requestHierarchyIfStale({ requestId: "stale-neg", sinceTimestamp: -1 })),
+      expected: '{"type":"request_hierarchy_if_stale","requestId":"stale-neg","sinceTimestamp":-1}',
+    },
+    {
+      builder: "setHierarchyInterval",
+      name: "numeric interval",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.setHierarchyInterval({ intervalMs: 500 })),
+      expected: '{"type":"set_hierarchy_interval","intervalMs":500}',
+    },
+    {
+      builder: "setHierarchyInterval",
+      name: "explicit null interval is kept (not omitted)",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.setHierarchyInterval({ intervalMs: null })),
+      expected: '{"type":"set_hierarchy_interval","intervalMs":null}',
+    },
+    {
+      builder: "setHierarchyInterval",
+      name: "non-finite interval (boundary) serializes to null per JSON.stringify",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.setHierarchyInterval({ intervalMs: Number.POSITIVE_INFINITY })),
+      expected: '{"type":"set_hierarchy_interval","intervalMs":null}',
+    },
+    {
+      builder: "requestScreenshot",
+      name: "requestId only",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.requestScreenshot({ requestId: "s-1" })),
+      expected: '{"type":"request_screenshot","requestId":"s-1"}',
+    },
+    {
+      builder: "requestAction",
+      name: "resourceId included when present",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.requestAction({ requestId: "a-1", action: "long_click", resourceId: "res" })),
+      expected: '{"type":"request_action","requestId":"a-1","action":"long_click","resourceId":"res"}',
+    },
+    {
+      builder: "requestAction",
+      name: "resourceId omitted when undefined",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.requestAction({ requestId: "a-2", action: "clear_focus" })),
+      expected: '{"type":"request_action","requestId":"a-2","action":"clear_focus"}',
+    },
+    {
+      builder: "requestAction",
+      name: "empty-string resourceId (boundary) is sent, not omitted",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.requestAction({ requestId: "a-empty", action: "x", resourceId: "" })),
+      expected: '{"type":"request_action","requestId":"a-empty","action":"x","resourceId":""}',
+    },
+    {
+      builder: "requestAction",
+      name: "stable node selector carried alongside the legacy resource id",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.requestAction({
+        requestId: "a-3",
+        action: "long_click",
+        resourceId: "com.example:id/row",
+        selector: { resourceId: "com.example:id/row", testTag: "message_row_42", collectionRow: 4, collectionColumn: 0 },
+      })),
+      expected: '{"type":"request_action","requestId":"a-3","action":"long_click","resourceId":"com.example:id/row","selector":{"resourceId":"com.example:id/row","testTag":"message_row_42","collectionRow":4,"collectionColumn":0}}',
+    },
+    {
+      builder: "requestClipboard",
+      name: "text included for copy",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.requestClipboard({ requestId: "c-1", action: "copy", text: "hi" })),
+      expected: '{"type":"request_clipboard","requestId":"c-1","action":"copy","text":"hi"}',
+    },
+    {
+      builder: "requestClipboard",
+      name: "text omitted for paste",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.requestClipboard({ requestId: "c-2", action: "paste" })),
+      expected: '{"type":"request_clipboard","requestId":"c-2","action":"paste"}',
+    },
+    {
+      builder: "requestClipboard",
+      name: "empty-string text (boundary) is sent",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.requestClipboard({ requestId: "c-3", action: "copy", text: "" })),
+      expected: '{"type":"request_clipboard","requestId":"c-3","action":"copy","text":""}',
+    },
+    {
+      builder: "requestClipboard",
+      name: "unicode text (boundary) is sent unescaped",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.requestClipboard({ requestId: "c-u", action: "copy", text: "café ☕ 日本語" })),
+      expected: '{"type":"request_clipboard","requestId":"c-u","action":"copy","text":"café ☕ 日本語"}',
+    },
+    {
+      builder: "requestSettingsGet",
+      name: "namespace + key",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.requestSettingsGet({ requestId: "sg-1", namespace: "system", key: "font_scale" })),
+      expected: '{"type":"request_settings_get","requestId":"sg-1","namespace":"system","key":"font_scale"}',
+    },
+    {
+      builder: "requestSettingsPut",
+      name: "string value",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.requestSettingsPut({ requestId: "sp-1", namespace: "secure", key: "k", value: "v", valueType: "string" })),
+      expected: '{"type":"request_settings_put","requestId":"sp-1","namespace":"secure","key":"k","value":"v","valueType":"string"}',
+    },
+    {
+      builder: "requestSettingsPut",
+      name: "explicit null value is kept",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.requestSettingsPut({ requestId: "sp-2", namespace: "global", key: "k", value: null, valueType: "int" })),
+      expected: '{"type":"request_settings_put","requestId":"sp-2","namespace":"global","key":"k","value":null,"valueType":"int"}',
+    },
+    {
+      builder: "requestSettingsList",
+      name: "namespace",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.requestSettingsList({ requestId: "sl-1", namespace: "global" })),
+      expected: '{"type":"request_settings_list","requestId":"sl-1","namespace":"global"}',
+    },
+    {
+      builder: "installCaCert",
+      name: "certificate payload",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.installCaCert({ requestId: "ca-1", certificate: "PEMDATA" })),
+      expected: '{"type":"install_ca_cert","requestId":"ca-1","certificate":"PEMDATA"}',
+    },
+    {
+      builder: "installCaCert",
+      name: "very-long certificate (boundary) is sent verbatim",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.installCaCert({ requestId: "ca-long", certificate: longCert })),
+      expected: `{"type":"install_ca_cert","requestId":"ca-long","certificate":"${longCert}"}`,
+    },
+    {
+      builder: "installCaCertFromPath",
+      name: "device path",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.installCaCertFromPath({ requestId: "ca-2", devicePath: "/sdcard/x.crt" })),
+      expected: '{"type":"install_ca_cert_from_path","requestId":"ca-2","devicePath":"/sdcard/x.crt"}',
+    },
+    {
+      builder: "removeCaCert",
+      name: "alias",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.removeCaCert({ requestId: "ca-3", alias: "user-alias" })),
+      expected: '{"type":"remove_ca_cert","requestId":"ca-3","alias":"user-alias"}',
+    },
+    {
+      builder: "getDeviceOwnerStatus",
+      name: "requestId only",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.getDeviceOwnerStatus({ requestId: "do-1" })),
+      expected: '{"type":"get_device_owner_status","requestId":"do-1"}',
+    },
+    {
+      builder: "getPermission",
+      name: "permission + requestPermission",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.getPermission({ requestId: "p-1", permission: "android.permission.CAMERA", requestPermission: true })),
+      expected: '{"type":"get_permission","requestId":"p-1","permission":"android.permission.CAMERA","requestPermission":true}',
+    },
+    {
+      builder: "requestDeviceInfo",
+      name: "requestId only",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.requestDeviceInfo({ requestId: "di-1" })),
+      expected: '{"type":"request_device_info","requestId":"di-1"}',
+    },
+    {
+      builder: "getCurrentFocus",
+      name: "requestId only",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.getCurrentFocus({ requestId: "cf-1" })),
+      expected: '{"type":"get_current_focus","requestId":"cf-1"}',
+    },
+    {
+      builder: "getTraversalOrder",
+      name: "requestId only",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.getTraversalOrder({ requestId: "to-1" })),
+      expected: '{"type":"get_traversal_order","requestId":"to-1"}',
+    },
+    {
+      builder: "addHighlight",
+      name: "id and shape both present",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.addHighlight({ requestId: "h-1", id: "hi", shape })),
+      expected: `{"type":"add_highlight","requestId":"h-1","id":"hi","shape":${shapeJson}}`,
+    },
+    {
+      builder: "addHighlight",
+      name: "id and shape both absent",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.addHighlight({ requestId: "h-2" })),
+      expected: '{"type":"add_highlight","requestId":"h-2"}',
+    },
+    {
+      builder: "addHighlight",
+      name: "id only drops shape without disturbing key order",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.addHighlight({ requestId: "h-3", id: "hi" })),
+      expected: '{"type":"add_highlight","requestId":"h-3","id":"hi"}',
+    },
+    {
+      builder: "addHighlight",
+      name: "shape only",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.addHighlight({ requestId: "h-4", shape })),
+      expected: `{"type":"add_highlight","requestId":"h-4","shape":${shapeJson}}`,
+    },
+    {
+      builder: "listPreferenceFiles",
+      name: "packageName",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.listPreferenceFiles({ requestId: "lp-1", packageName: "com.x" })),
+      expected: '{"type":"list_preference_files","requestId":"lp-1","packageName":"com.x"}',
+    },
+    {
+      builder: "getPreferences",
+      name: "packageName + fileName",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.getPreferences({ requestId: "gp-1", packageName: "com.x", fileName: "prefs" })),
+      expected: '{"type":"get_preferences","requestId":"gp-1","packageName":"com.x","fileName":"prefs"}',
+    },
+    {
+      builder: "subscribeStorage",
+      name: "packageName + fileName",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.subscribeStorage({ requestId: "ss-1", packageName: "com.x", fileName: "prefs" })),
+      expected: '{"type":"subscribe_storage","requestId":"ss-1","packageName":"com.x","fileName":"prefs"}',
+    },
+    {
+      builder: "unsubscribeStorage",
+      name: "latent-bug shape: only subscriptionId is sent",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.unsubscribeStorage({ requestId: "us-1", subscriptionId: "com.x:prefs" })),
+      expected: '{"type":"unsubscribe_storage","requestId":"us-1","subscriptionId":"com.x:prefs"}',
+    },
+    {
+      builder: "getPreference",
+      name: "packageName + fileName + key",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.getPreference({ requestId: "gpr-1", packageName: "com.x", fileName: "prefs", key: "k" })),
+      expected: '{"type":"get_preference","requestId":"gpr-1","packageName":"com.x","fileName":"prefs","key":"k"}',
+    },
+    {
+      builder: "setPreference",
+      name: "string value",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.setPreference({ requestId: "setp-1", packageName: "com.x", fileName: "prefs", key: "k", value: "v", valueType: "STRING" })),
+      expected: '{"type":"set_preference","requestId":"setp-1","packageName":"com.x","fileName":"prefs","key":"k","value":"v","valueType":"STRING"}',
+    },
+    {
+      builder: "setPreference",
+      name: "explicit null value is kept",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.setPreference({ requestId: "setp-2", packageName: "com.x", fileName: "prefs", key: "k", value: null, valueType: "INT" })),
+      expected: '{"type":"set_preference","requestId":"setp-2","packageName":"com.x","fileName":"prefs","key":"k","value":null,"valueType":"INT"}',
+    },
+    {
+      builder: "removePreference",
+      name: "packageName + fileName + key",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.removePreference({ requestId: "rp-1", packageName: "com.x", fileName: "prefs", key: "k" })),
+      expected: '{"type":"remove_preference","requestId":"rp-1","packageName":"com.x","fileName":"prefs","key":"k"}',
+    },
+    {
+      builder: "clearPreferences",
+      name: "packageName + fileName",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.clearPreferences({ requestId: "cp-1", packageName: "com.x", fileName: "prefs" })),
+      expected: '{"type":"clear_preferences","requestId":"cp-1","packageName":"com.x","fileName":"prefs"}',
+    },
+    {
+      builder: "requestGlobalAction",
+      name: "action",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.requestGlobalAction({ requestId: "ga-1", action: "back" })),
+      expected: '{"type":"request_global_action","requestId":"ga-1","action":"back"}',
+    },
+    {
+      builder: "setRecompositionTracking",
+      name: "enabled flag",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.setRecompositionTracking({ requestId: "rt-1", enabled: true })),
+      expected: '{"type":"set_recomposition_tracking","requestId":"rt-1","enabled":true}',
+    },
+    {
+      builder: "setAccessibilityFlags",
+      name: "no requestId on the wire",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.setAccessibilityFlags({
+        includeNotImportantViews: true, reportViewIds: false, retrieveInteractiveWindows: true, occlusionEnabled: false,
+      })),
+      expected: '{"type":"set_accessibility_flags","includeNotImportantViews":true,"reportViewIds":false,"retrieveInteractiveWindows":true,"occlusionEnabled":false}',
+    },
+    {
+      builder: "setNetworkMockRules",
+      name: "no requestId, rules array passed through",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.setNetworkMockRules({ rules: networkRules })),
+      expected: '{"type":"set_network_mock_rules","rules":[{"mockId":"m1","host":"example.com","path":"/v1","method":"GET","limit":null,"remaining":null,"statusCode":200,"responseHeaders":{"content-type":"application/json"},"responseBody":"{}","contentType":"application/json"}]}',
+    },
+    {
+      builder: "setNetworkErrorSimulation",
+      name: "enabled with values",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.setNetworkErrorSimulation({ enabled: true, errorType: "timeout", limit: 3, expiresAtEpochMs: 1720000000000 })),
+      expected: '{"type":"set_network_error_simulation","enabled":true,"errorType":"timeout","limit":3,"expiresAtEpochMs":1720000000000}',
+    },
+    {
+      builder: "setNetworkErrorSimulation",
+      name: "disabled normalizes omitted fields to explicit nulls",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.setNetworkErrorSimulation({ enabled: false })),
+      expected: '{"type":"set_network_error_simulation","enabled":false,"errorType":null,"limit":null,"expiresAtEpochMs":null}',
+    },
+    {
+      builder: "requestInstalledPackages",
+      name: "userId present",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.requestInstalledPackages({ requestId: "ip-1", includeSystem: true, userId: 0 })),
+      expected: '{"type":"request_installed_packages","requestId":"ip-1","includeSystem":true,"userId":0}',
+    },
+    {
+      builder: "requestInstalledPackages",
+      name: "omitted userId normalized to explicit null",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.requestInstalledPackages({ requestId: "ip-2", includeSystem: false })),
+      expected: '{"type":"request_installed_packages","requestId":"ip-2","includeSystem":false,"userId":null}',
+    },
+    {
+      builder: "requestInstalledPackages",
+      name: "negative userId (boundary) is sent verbatim",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.requestInstalledPackages({ requestId: "ip-neg", includeSystem: false, userId: -5 })),
+      expected: '{"type":"request_installed_packages","requestId":"ip-neg","includeSystem":false,"userId":-5}',
+    },
+    {
+      builder: "requestPackageInfo",
+      name: "packageName + includePermissions",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.requestPackageInfo({ requestId: "pi-1", packageName: "com.x", includePermissions: true })),
+      expected: '{"type":"request_package_info","requestId":"pi-1","packageName":"com.x","includePermissions":true}',
+    },
+    {
+      builder: "requestLaunchIntent",
+      name: "packageName",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.requestLaunchIntent({ requestId: "li-1", packageName: "com.x" })),
+      expected: '{"type":"request_launch_intent","requestId":"li-1","packageName":"com.x"}',
+    },
+    {
+      builder: "startRecording",
+      name: "no requestId on the wire",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.startRecording()),
+      expected: '{"type":"start_recording"}',
+    },
+    {
+      builder: "stopRecording",
+      name: "no requestId on the wire",
+      actual: serializeCtrlProxyRequest(ctrlProxyRequests.stopRecording()),
+      expected: '{"type":"stop_recording"}',
+    },
+  ];
+
+  test.each(cases)("$builder — $name", ({ actual, expected }) => {
+    expect(actual).toBe(expected);
   });
 
-  test("request_hierarchy_if_stale", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.requestHierarchyIfStale({ requestId: "stale-1", sinceTimestamp: 1720000000000 })))
-      .toBe('{"type":"request_hierarchy_if_stale","requestId":"stale-1","sinceTimestamp":1720000000000}');
-  });
-
-  test("set_hierarchy_interval", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.setHierarchyInterval({ intervalMs: 500 })))
-      .toBe('{"type":"set_hierarchy_interval","intervalMs":500}');
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.setHierarchyInterval({ intervalMs: null })))
-      .toBe('{"type":"set_hierarchy_interval","intervalMs":null}');
-  });
-
-  test("request_screenshot", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.requestScreenshot({ requestId: "s-1" })))
-      .toBe('{"type":"request_screenshot","requestId":"s-1"}');
-  });
-
-  // `request_two_finger_swipe` has no builder here: like the other gesture commands
-  // (request_swipe/tap/drag/pinch), it is emitted through the shared sendCommand()/createMessage()
-  // path (#2988), and its field-level wire shape is asserted in CtrlProxyGestures.test.ts. The type
-  // stays in the union + KOTLIN_SERIAL_NAMES drift check above.
-
-  test("request_action — resourceId included when present, omitted when undefined", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.requestAction({ requestId: "a-1", action: "long_click", resourceId: "res" })))
-      .toBe('{"type":"request_action","requestId":"a-1","action":"long_click","resourceId":"res"}');
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.requestAction({ requestId: "a-2", action: "clear_focus" })))
-      .toBe('{"type":"request_action","requestId":"a-2","action":"clear_focus"}');
-  });
-
-  test("request_action carries a stable node selector with the legacy resource ID", () => {
-    expect(
-      serializeCtrlProxyRequest(
-        ctrlProxyRequests.requestAction({
-          requestId: "a-3",
-          action: "long_click",
-          resourceId: "com.example:id/row",
-          selector: {
-            resourceId: "com.example:id/row",
-            testTag: "message_row_42",
-            collectionRow: 4,
-            collectionColumn: 0,
-          },
-        })
-      )
-    ).toBe(
-      '{"type":"request_action","requestId":"a-3","action":"long_click","resourceId":"com.example:id/row","selector":{"resourceId":"com.example:id/row","testTag":"message_row_42","collectionRow":4,"collectionColumn":0}}'
-    );
-  });
-
-  test("request_clipboard — text included for copy, omitted when undefined", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.requestClipboard({ requestId: "c-1", action: "copy", text: "hi" })))
-      .toBe('{"type":"request_clipboard","requestId":"c-1","action":"copy","text":"hi"}');
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.requestClipboard({ requestId: "c-2", action: "paste" })))
-      .toBe('{"type":"request_clipboard","requestId":"c-2","action":"paste"}');
-  });
-
-  test("request_settings_get", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.requestSettingsGet({ requestId: "sg-1", namespace: "system", key: "font_scale" })))
-      .toBe('{"type":"request_settings_get","requestId":"sg-1","namespace":"system","key":"font_scale"}');
-  });
-
-  test("request_settings_put — value string and explicit null", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.requestSettingsPut({ requestId: "sp-1", namespace: "secure", key: "k", value: "v", valueType: "string" })))
-      .toBe('{"type":"request_settings_put","requestId":"sp-1","namespace":"secure","key":"k","value":"v","valueType":"string"}');
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.requestSettingsPut({ requestId: "sp-2", namespace: "global", key: "k", value: null, valueType: "int" })))
-      .toBe('{"type":"request_settings_put","requestId":"sp-2","namespace":"global","key":"k","value":null,"valueType":"int"}');
-  });
-
-  test("request_settings_list", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.requestSettingsList({ requestId: "sl-1", namespace: "global" })))
-      .toBe('{"type":"request_settings_list","requestId":"sl-1","namespace":"global"}');
-  });
-
-  test("install_ca_cert", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.installCaCert({ requestId: "ca-1", certificate: "PEMDATA" })))
-      .toBe('{"type":"install_ca_cert","requestId":"ca-1","certificate":"PEMDATA"}');
-  });
-
-  test("install_ca_cert_from_path", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.installCaCertFromPath({ requestId: "ca-2", devicePath: "/sdcard/x.crt" })))
-      .toBe('{"type":"install_ca_cert_from_path","requestId":"ca-2","devicePath":"/sdcard/x.crt"}');
-  });
-
-  test("remove_ca_cert", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.removeCaCert({ requestId: "ca-3", alias: "user-alias" })))
-      .toBe('{"type":"remove_ca_cert","requestId":"ca-3","alias":"user-alias"}');
-  });
-
-  test("get_device_owner_status", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.getDeviceOwnerStatus({ requestId: "do-1" })))
-      .toBe('{"type":"get_device_owner_status","requestId":"do-1"}');
-  });
-
-  test("get_permission", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.getPermission({ requestId: "p-1", permission: "android.permission.CAMERA", requestPermission: true })))
-      .toBe('{"type":"get_permission","requestId":"p-1","permission":"android.permission.CAMERA","requestPermission":true}');
-  });
-
-  test("request_device_info", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.requestDeviceInfo({ requestId: "di-1" })))
-      .toBe('{"type":"request_device_info","requestId":"di-1"}');
-  });
-
-  test("get_current_focus", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.getCurrentFocus({ requestId: "cf-1" })))
-      .toBe('{"type":"get_current_focus","requestId":"cf-1"}');
-  });
-
-  test("get_traversal_order", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.getTraversalOrder({ requestId: "to-1" })))
-      .toBe('{"type":"get_traversal_order","requestId":"to-1"}');
-  });
-
-  test("add_highlight — id/shape included, omitted, and mixed (independent guards)", () => {
-    const shape: HighlightBoxShape = { type: "box", bounds: { x: 1, y: 2, width: 3, height: 4 } };
-    const shapeJson = '{"type":"box","bounds":{"x":1,"y":2,"width":3,"height":4}}';
-    // both present
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.addHighlight({ requestId: "h-1", id: "hi", shape })))
-      .toBe(`{"type":"add_highlight","requestId":"h-1","id":"hi","shape":${shapeJson}}`);
-    // both absent
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.addHighlight({ requestId: "h-2" })))
-      .toBe('{"type":"add_highlight","requestId":"h-2"}');
-    // id only (shape undefined) — guard must drop shape without disturbing key order
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.addHighlight({ requestId: "h-3", id: "hi" })))
-      .toBe('{"type":"add_highlight","requestId":"h-3","id":"hi"}');
-    // shape only (id undefined)
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.addHighlight({ requestId: "h-4", shape })))
-      .toBe(`{"type":"add_highlight","requestId":"h-4","shape":${shapeJson}}`);
-  });
-
-  test("empty strings are sent (not omitted) — matches the unconditional legacy send", () => {
-    // resourceId/text are assigned unconditionally by the builder, so "" serializes as "" (only
-    // `undefined` is omitted). This mirrors the pre-migration JSON.stringify send sites.
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.requestAction({ requestId: "a-3", action: "x", resourceId: "" })))
-      .toBe('{"type":"request_action","requestId":"a-3","action":"x","resourceId":""}');
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.requestClipboard({ requestId: "c-3", action: "copy", text: "" })))
-      .toBe('{"type":"request_clipboard","requestId":"c-3","action":"copy","text":""}');
-  });
-
-  test("list_preference_files", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.listPreferenceFiles({ requestId: "lp-1", packageName: "com.x" })))
-      .toBe('{"type":"list_preference_files","requestId":"lp-1","packageName":"com.x"}');
-  });
-
-  test("get_preferences", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.getPreferences({ requestId: "gp-1", packageName: "com.x", fileName: "prefs" })))
-      .toBe('{"type":"get_preferences","requestId":"gp-1","packageName":"com.x","fileName":"prefs"}');
-  });
-
-  test("subscribe_storage", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.subscribeStorage({ requestId: "ss-1", packageName: "com.x", fileName: "prefs" })))
-      .toBe('{"type":"subscribe_storage","requestId":"ss-1","packageName":"com.x","fileName":"prefs"}');
-  });
-
-  test("unsubscribe_storage — latent-bug shape: only subscriptionId is sent", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.unsubscribeStorage({ requestId: "us-1", subscriptionId: "com.x:prefs" })))
-      .toBe('{"type":"unsubscribe_storage","requestId":"us-1","subscriptionId":"com.x:prefs"}');
-  });
-
-  test("get_preference", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.getPreference({ requestId: "gpr-1", packageName: "com.x", fileName: "prefs", key: "k" })))
-      .toBe('{"type":"get_preference","requestId":"gpr-1","packageName":"com.x","fileName":"prefs","key":"k"}');
-  });
-
-  test("set_preference — value string and explicit null", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.setPreference({ requestId: "setp-1", packageName: "com.x", fileName: "prefs", key: "k", value: "v", valueType: "STRING" })))
-      .toBe('{"type":"set_preference","requestId":"setp-1","packageName":"com.x","fileName":"prefs","key":"k","value":"v","valueType":"STRING"}');
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.setPreference({ requestId: "setp-2", packageName: "com.x", fileName: "prefs", key: "k", value: null, valueType: "INT" })))
-      .toBe('{"type":"set_preference","requestId":"setp-2","packageName":"com.x","fileName":"prefs","key":"k","value":null,"valueType":"INT"}');
-  });
-
-  test("remove_preference", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.removePreference({ requestId: "rp-1", packageName: "com.x", fileName: "prefs", key: "k" })))
-      .toBe('{"type":"remove_preference","requestId":"rp-1","packageName":"com.x","fileName":"prefs","key":"k"}');
-  });
-
-  test("clear_preferences", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.clearPreferences({ requestId: "cp-1", packageName: "com.x", fileName: "prefs" })))
-      .toBe('{"type":"clear_preferences","requestId":"cp-1","packageName":"com.x","fileName":"prefs"}');
-  });
-
-  test("request_global_action", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.requestGlobalAction({ requestId: "ga-1", action: "back" })))
-      .toBe('{"type":"request_global_action","requestId":"ga-1","action":"back"}');
-  });
-
-  test("set_recomposition_tracking", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.setRecompositionTracking({ requestId: "rt-1", enabled: true })))
-      .toBe('{"type":"set_recomposition_tracking","requestId":"rt-1","enabled":true}');
-  });
-
-  test("set_accessibility_flags — no requestId on the wire", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.setAccessibilityFlags({
-      includeNotImportantViews: true, reportViewIds: false, retrieveInteractiveWindows: true, occlusionEnabled: false,
-    }))).toBe('{"type":"set_accessibility_flags","includeNotImportantViews":true,"reportViewIds":false,"retrieveInteractiveWindows":true,"occlusionEnabled":false}');
-  });
-
-  test("set_network_mock_rules — no requestId, rules array passed through", () => {
-    const rules: NetworkMockRuleSync[] = [{
-      mockId: "m1", host: "example.com", path: "/v1", method: "GET",
-      limit: null, remaining: null, statusCode: 200,
-      responseHeaders: { "content-type": "application/json" },
-      responseBody: "{}", contentType: "application/json",
-    }];
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.setNetworkMockRules({ rules })))
-      .toBe('{"type":"set_network_mock_rules","rules":[{"mockId":"m1","host":"example.com","path":"/v1","method":"GET","limit":null,"remaining":null,"statusCode":200,"responseHeaders":{"content-type":"application/json"},"responseBody":"{}","contentType":"application/json"}]}');
-  });
-
-  test("set_network_error_simulation — enabled with values, disabled with explicit nulls", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.setNetworkErrorSimulation({
-      enabled: true, errorType: "timeout", limit: 3, expiresAtEpochMs: 1720000000000,
-    }))).toBe('{"type":"set_network_error_simulation","enabled":true,"errorType":"timeout","limit":3,"expiresAtEpochMs":1720000000000}');
-    // Mirrors the reconnect sync passing sim?.errorType (undefined) → normalized to explicit null.
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.setNetworkErrorSimulation({ enabled: false })))
-      .toBe('{"type":"set_network_error_simulation","enabled":false,"errorType":null,"limit":null,"expiresAtEpochMs":null}');
-  });
-
-  test("request_installed_packages — userId present vs. explicit null", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.requestInstalledPackages({ requestId: "ip-1", includeSystem: true, userId: 0 })))
-      .toBe('{"type":"request_installed_packages","requestId":"ip-1","includeSystem":true,"userId":0}');
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.requestInstalledPackages({ requestId: "ip-2", includeSystem: false })))
-      .toBe('{"type":"request_installed_packages","requestId":"ip-2","includeSystem":false,"userId":null}');
-  });
-
-  test("request_package_info", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.requestPackageInfo({ requestId: "pi-1", packageName: "com.x", includePermissions: true })))
-      .toBe('{"type":"request_package_info","requestId":"pi-1","packageName":"com.x","includePermissions":true}');
-  });
-
-  test("request_launch_intent", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.requestLaunchIntent({ requestId: "li-1", packageName: "com.x" })))
-      .toBe('{"type":"request_launch_intent","requestId":"li-1","packageName":"com.x"}');
-  });
-
-  test("start_recording / stop_recording — no requestId on the wire", () => {
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.startRecording())).toBe('{"type":"start_recording"}');
-    expect(serializeCtrlProxyRequest(ctrlProxyRequests.stopRecording())).toBe('{"type":"stop_recording"}');
+  // Completeness guard: every builder in the module must have at least one wire row above, and the
+  // total builder count is pinned. Ship builder #37 without a row and this fails — not a silently
+  // uncovered send site. `request_two_finger_swipe` has no builder here by design (it goes through
+  // the shared sendCommand path, asserted in CtrlProxyGestures.test.ts), so it is not a builder key.
+  test("every ctrlProxyRequests builder has wire coverage and the count is pinned at 36", () => {
+    const builderNames = Object.keys(ctrlProxyRequests);
+    expect(builderNames.length).toBe(36);
+    const covered = new Set(cases.map(row => row.builder));
+    expect([...covered].sort()).toEqual([...builderNames].sort());
   });
 });


### PR DESCRIPTION
## Summary

Milestone 32 (Unit Test Quality Audit), slice **observe-ctrlproxy**: 12 verified
test-quality findings burned down. Every action was verified red-green — the test
passes, breaking the `src/` behavior it guards makes it go red for the right reason,
and restoring makes it green again. REFUTED items (ADD-3 `pendingHierarchyRejectors`
cleanup, REWRITE-1) were **not** implemented per the adversarial critic.

Notable changes:
- **New `CtrlProxyCertificates.test.ts`** — the 5 public methods driven over the wire
  (CA cert alias, permission-grant timeout reported as failure, cert-path resolution).
  No wrong-wire rows, no 5s hang.
- **a11y-screenshot 3-failure latch** driven through the socket using a wire type the
  client actually handles; flipping `A11Y_SCREENSHOT_MAX_FAILURES` 3→1 fails 2 of 3.
- **`ctrlProxyProtocol`**: 30 builder cases → a `test.each` table with boundary rows
  (empty / unicode / very-long / negative / non-finite) + a 36-builder completeness
  guard that fires on builder #37.
- **`supportedCommands`** now driven via the `connected` frame (all four cadence
  behaviors kept, none dropped); real socket-close wiring; sharpened
  `rejects.toThrow(/connect/i)`; screen-off fast-fail now fails by assertion, not by
  hanging to the timeout.
- Deleted vacuous `bindSession` smoke tests, `toBeDefined()` preludes, and the
  `typeof x === "function"` assertions (the emptied type tests each received a real
  `isConnected()` behavioral assertion).

No `src/` changes — test-only.

## Linked Issue

Closes #4173

## Validation

- [x] `bun test`: **9786 pass / 14 skip / 0 fail** across 753 files (rebased on current main)
- [x] `bun run typecheck`: no new errors (211 baseline)
- [x] `bun run lint`: clean
- [x] New code uses interfaces + fakes + FakeTimer; hang-prone cases use manual timers and fail by assertion

## Follow-ups

- [ ] `requestInstallCaCertificateFromFile` happy-path / empty-file branch needs an
  `fs`-stat injection seam to unit-test without real fs (the delegate imports `fs`
  directly) — worth a small separate issue.
