### PR TITLE
test(utils): property-based tests for ctrl-proxy skip flag and envelope accessors

### DIFF
--- a/test/utils/ctrlProxyDownloadControl.property.test.ts
+++ b/test/utils/ctrlProxyDownloadControl.property.test.ts
@@ -1,0 +1,92 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import {
+  isTruthyEnvValue,
+  LEGACY_SKIP_ACCESSIBILITY_DOWNLOAD_FLAG,
+  shouldSkipCtrlProxyDownload,
+  SKIP_CTRL_PROXY_DOWNLOAD_ENV,
+  SKIP_CTRL_PROXY_DOWNLOAD_FLAG
+} from "../../src/utils/ctrlProxyDownloadControl";
+
+// Property-based tests. See Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+// "true" in an arbitrary mix of upper/lower case — exercises the case-insensitive branch.
+const mixedCaseTrue = fc
+  .array(fc.boolean(), { minLength: 4, maxLength: 4 })
+  .map(bits => "true".split("").map((ch, i) => (bits[i] ? ch.toUpperCase() : ch)).join(""));
+
+describe("isTruthyEnvValue (property-based)", () => {
+  test("is total and matches its exact definition for arbitrary strings", () => {
+    fc.assert(
+      fc.property(fc.option(fc.string({ maxLength: 8 }), { nil: undefined }), value => {
+        const result = isTruthyEnvValue(value);
+        return typeof result === "boolean" && result === (value === "1" || value?.toLowerCase() === "true");
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("accepts \"1\" and any casing of \"true\"", () => {
+    fc.assert(
+      fc.property(mixedCaseTrue, variant => isTruthyEnvValue("1") && isTruthyEnvValue(variant)),
+      RUN_OPTIONS
+    );
+  });
+
+  test("rejects undefined and unrelated tokens", () => {
+    const notTruthy = fc
+      .constantFrom("", "0", "false", "yes", "2", "on", "enabled", " true", "true ")
+      .filter(v => v !== "1" && v.toLowerCase() !== "true");
+    fc.assert(
+      fc.property(notTruthy, value => isTruthyEnvValue(value) === false && isTruthyEnvValue(undefined) === false),
+      RUN_OPTIONS
+    );
+  });
+});
+
+describe("shouldSkipCtrlProxyDownload (property-based)", () => {
+  test("is total (boolean) for arbitrary argv and env", () => {
+    const envRecord = fc.dictionary(fc.string({ maxLength: 8 }), fc.string({ maxLength: 8 }));
+    fc.assert(
+      fc.property(fc.array(fc.string({ maxLength: 8 })), envRecord, (args, env) => {
+        return typeof shouldSkipCtrlProxyDownload(args, env) === "boolean";
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("either skip flag forces skip, regardless of env", () => {
+    const anyEnvValue = fc.dictionary(fc.string(), fc.string());
+    const flag = fc.constantFrom(SKIP_CTRL_PROXY_DOWNLOAD_FLAG, LEGACY_SKIP_ACCESSIBILITY_DOWNLOAD_FLAG);
+    fc.assert(
+      fc.property(fc.array(fc.string({ maxLength: 6 })), flag, anyEnvValue, (rest, f, env) => {
+        return shouldSkipCtrlProxyDownload([...rest, f], env) === true;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("without a flag, the result tracks the env value's truthiness", () => {
+    const positionals = fc.array(fc.string({ maxLength: 6 }).map(t => `p${t}`), { maxLength: 6 });
+    fc.assert(
+      fc.property(positionals, fc.option(fc.string({ maxLength: 8 }), { nil: undefined }), (args, envValue) => {
+        const env = { [SKIP_CTRL_PROXY_DOWNLOAD_ENV]: envValue };
+        return shouldSkipCtrlProxyDownload(args, env) === isTruthyEnvValue(envValue);
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("adding a skip flag is monotonic — it never flips skip off", () => {
+    const envRecord = fc.dictionary(fc.string(), fc.string());
+    fc.assert(
+      fc.property(fc.array(fc.string({ maxLength: 6 })), envRecord, (args, env) => {
+        const before = shouldSkipCtrlProxyDownload(args, env);
+        const after = shouldSkipCtrlProxyDownload([...args, SKIP_CTRL_PROXY_DOWNLOAD_FLAG], env);
+        return !before || after;
+      }),
+      RUN_OPTIONS
+    );
+  });
+});

--- a/test/utils/toolUtils.property.test.ts
+++ b/test/utils/toolUtils.property.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+import {
+  getStructuredField,
+  getStructuredPayload,
+  throwIfAborted,
+  type StructuredToolResponse
+} from "../../src/utils/toolUtils";
+
+// Property-based tests. See Backoff.property.test.ts for the pinned-seed rationale.
+// These accessors read the payload off the `structuredContent` slot of an MCP
+// tool-call envelope (issues #2907 / #2932) — never the envelope top level.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+const payloadObject = fc.dictionary(fc.string({ maxLength: 8 }), fc.jsonValue(), { maxKeys: 6 });
+// structuredContent may be a valid object payload, a non-object, or absent.
+const structuredContent = fc.oneof(payloadObject, fc.string(), fc.integer(), fc.constant(null));
+const asResponse = (sc: unknown): StructuredToolResponse<Record<string, unknown>> =>
+  ({ structuredContent: sc }) as unknown as StructuredToolResponse<Record<string, unknown>>;
+
+describe("getStructuredPayload (property-based)", () => {
+  test("returns the structuredContent object by identity, else undefined", () => {
+    fc.assert(
+      fc.property(structuredContent, sc => {
+        const result = getStructuredPayload(asResponse(sc));
+        const isObject = sc !== null && typeof sc === "object";
+        return isObject ? result === sc : result === undefined;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("null or undefined responses yield undefined", () => {
+    fc.assert(
+      fc.property(fc.constantFrom(null, undefined), response =>
+        getStructuredPayload(response) === undefined
+      ),
+      RUN_OPTIONS
+    );
+  });
+});
+
+describe("getStructuredField (property-based)", () => {
+  test("returns an own field's value and undefined for an absent field", () => {
+    const extraKey = fc.string({ maxLength: 8 });
+    fc.assert(
+      fc.property(payloadObject, extraKey, (payload, key) => {
+        const value = getStructuredField(asResponse(payload), key);
+        return Object.hasOwn(payload, key) ? value === (payload as Record<string, unknown>)[key] : value === undefined;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("never leaks an inherited prototype key", () => {
+    // `toString`/`hasOwnProperty` exist on the prototype but are not own keys.
+    const protoKey = fc.constantFrom("toString", "hasOwnProperty", "constructor", "valueOf");
+    fc.assert(
+      fc.property(payloadObject.filter(p => Object.keys(p).length === 0), protoKey, (empty, key) => {
+        return getStructuredField(asResponse(empty), key) === undefined;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("agrees with reading the field off getStructuredPayload", () => {
+    fc.assert(
+      fc.property(structuredContent, fc.string({ maxLength: 8 }), (sc, key) => {
+        const field = getStructuredField(asResponse(sc), key);
+        const payload = getStructuredPayload(asResponse(sc));
+        const expected = payload && Object.hasOwn(payload, key) ? (payload as Record<string, unknown>)[key] : undefined;
+        return field === expected;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("null or undefined responses yield undefined", () => {
+    fc.assert(
+      fc.property(fc.constantFrom(null, undefined), fc.string({ maxLength: 8 }), (response, key) =>
+        getStructuredField(response, key) === undefined
+      ),
+      RUN_OPTIONS
+    );
+  });
+});
+
+describe("throwIfAborted (property-based)", () => {
+  test("throws exactly when the signal is already aborted", () => {
+    fc.assert(
+      fc.property(fc.boolean(), aborted => {
+        const controller = new AbortController();
+        if (aborted) {
+          controller.abort();
+          expect(() => throwIfAborted(controller.signal)).toThrow();
+          return true;
+        }
+        // A fresh (non-aborted) signal must not throw.
+        throwIfAborted(controller.signal);
+        return true;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("an undefined signal never throws", () => {
+    fc.assert(
+      fc.property(fc.constant(undefined), signal => {
+        throwIfAborted(signal);
+        return true;
+      }),
+      RUN_OPTIONS
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Continues the fast-check property-testing expansion (pattern from [PR #4427](https://github.com/kaeawc/auto-mobile/pull/4427); prior suites merged in [PR #4434](https://github.com/kaeawc/auto-mobile/pull/4434), [#4438](https://github.com/kaeawc/auto-mobile/pull/4438), [#4440](https://github.com/kaeawc/auto-mobile/pull/4440), [#4441](https://github.com/kaeawc/auto-mobile/pull/4441), [#4442](https://github.com/kaeawc/auto-mobile/pull/4442), [#4443](https://github.com/kaeawc/auto-mobile/pull/4443); open in [#4444](https://github.com/kaeawc/auto-mobile/pull/4444), [#4446](https://github.com/kaeawc/auto-mobile/pull/4446)) with two pure clusters. Test-only, additive — no production changes, no new dependencies.

Invariants asserted:

- **`ctrlProxyDownloadControl`** — `isTruthyEnvValue` is total and accepts `"1"` or **any casing** of `"true"`, rejecting everything else (including `undefined`, `"0"`, `"false"`, and surrounding-whitespace variants); `shouldSkipCtrlProxyDownload` is total, either skip flag (`--skip-ctrl-proxy-download` or the legacy `--skip-accessibility-download`) forces skip regardless of env, without a flag the result tracks the env value's truthiness, and adding a skip flag is **monotonic** — it never flips skip off.
- **`toolUtils` envelope accessors** ([#2907](https://github.com/kaeawc/auto-mobile/issues/2907) / [#2932](https://github.com/kaeawc/auto-mobile/issues/2932)) — `getStructuredPayload` returns the `structuredContent` object by identity, else `undefined`; `getStructuredField` returns an **own** field's value, `undefined` for absent or inherited-prototype keys, agrees with reading the field off `getStructuredPayload`, and is `undefined` for null/undefined responses; `throwIfAborted` throws **exactly** when the signal is already aborted and never for an `undefined`/fresh signal.

Scope note: only the `toolUtils` helpers that don't read the `serverConfig` singleton are covered — `stringifyToolResponse`/`createJSONToolResponse` branch on `serverConfig.isToolResultsCompactJsonEnabled()`, so a pure property test would depend on mutable global state and is deliberately excluded. No defects surfaced.

## Validation

- [x] `bun test test/utils/{ctrlProxyDownloadControl,toolUtils}.property.test.ts` — 15 pass, ~195ms
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run lint` — no new violations
- [x] New tests are pure (no device/network/filesystem/DB); each runs in <100ms

## Follow-ups

- [ ] `androidTransientLoading` is pure given an injected `ElementParser` (fake-driven) — a good next target. `src/utils/` pure surface is nearly exhausted; future iterations will sweep `src/models/` value objects and pure `src/features/**` transforms.
