### PR TITLE
feat: support Android permission revoke and reset

### DIFF
--- a/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
+++ b/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
@@ -438,7 +438,7 @@
               },
               "permissions": {
                 "type": "array",
-                "description": "Runtime permissions or simulator privacy services to change; Android and iOS physical reset accept only 'all'",
+                "description": "Runtime permissions or simulator privacy services to change; Android reset accepts only 'all'; physical iOS accepts it too",
                 "minItems": 1,
                 "items": {
                   "type": "string",
@@ -535,10 +535,41 @@
                   ]
                 },
                 "then": {
+                  "required": [
+                    "permissions"
+                  ],
                   "not": {
                     "required": [
                       "userId"
                     ]
+                  }
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "action": {
+                      "const": "reset"
+                    },
+                    "platform": {
+                      "const": "android"
+                    }
+                  },
+                  "required": [
+                    "action",
+                    "platform"
+                  ]
+                },
+                "then": {
+                  "properties": {
+                    "permissions": {
+                      "type": "array",
+                      "minItems": 1,
+                      "maxItems": 1,
+                      "items": {
+                        "const": "all"
+                      }
+                    }
                   }
                 }
               }
@@ -810,7 +841,7 @@
             "type": "string",
             "minLength": 1
           },
-          "description": "Runtime permissions or simulator privacy services to change; Android and iOS physical reset accept only 'all'"
+          "description": "Runtime permissions or simulator privacy services to change; Android reset accepts only 'all'; physical iOS accepts it too"
         },
         "userId": {
           "type": "integer",
@@ -893,10 +924,41 @@
             ]
           },
           "then": {
+            "required": [
+              "permissions"
+            ],
             "not": {
               "required": [
                 "userId"
               ]
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "action": {
+                "const": "reset"
+              },
+              "platform": {
+                "const": "android"
+              }
+            },
+            "required": [
+              "action",
+              "platform"
+            ]
+          },
+          "then": {
+            "properties": {
+              "permissions": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 1,
+                "items": {
+                  "const": "all"
+                }
+              }
             }
           }
         }

--- a/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
+++ b/android/test-plan-validation/src/main/resources/schemas/test-plan.schema.json
@@ -405,6 +405,145 @@
               }
             ]
           }
+        },
+        {
+          "if": {
+            "properties": {
+              "tool": {
+                "const": "setAppPermissions"
+              }
+            },
+            "required": [
+              "tool"
+            ]
+          },
+          "then": {
+            "properties": {
+              "params": {
+                "$ref": "#/$defs/setAppPermissionsParams"
+              },
+              "appId": {
+                "type": "string",
+                "description": "App package ID or bundle identifier",
+                "minLength": 1
+              },
+              "action": {
+                "type": "string",
+                "enum": [
+                  "grant",
+                  "revoke",
+                  "reset"
+                ],
+                "description": "Permission action. Defaults to grant. Android reset requires permissions=['all'] and resets runtime permissions device-wide."
+              },
+              "permissions": {
+                "type": "array",
+                "description": "Runtime permissions or simulator privacy services to change; Android and iOS physical reset accept only 'all'",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "userId": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Android user ID for grant/revoke, not reset"
+              },
+              "notificationsEnabled": {
+                "type": "boolean",
+                "description": "Android notification state, independent of POST_NOTIFICATIONS"
+              },
+              "notificationPolicyAccess": {
+                "type": "boolean",
+                "description": "Android only: set notification policy / DND access"
+              },
+              "scheduleExactAlarm": {
+                "type": "string",
+                "enum": [
+                  "allow",
+                  "deny"
+                ],
+                "description": "Android only: set UID-level SCHEDULE_EXACT_ALARM appop"
+              },
+              "platform": {
+                "type": "string",
+                "enum": [
+                  "android",
+                  "ios"
+                ],
+                "description": "Platform"
+              },
+              "sessionUuid": {
+                "type": "string",
+                "description": "Session UUID for device targeting"
+              },
+              "keepScreenAwake": {
+                "type": "boolean",
+                "description": "Keep physical Android devices awake during the session (default: true)"
+              },
+              "device": {
+                "type": "string",
+                "description": "Device label for multi-device plans (e.g., \"A\", \"B\")"
+              },
+              "deviceId": {
+                "type": "string",
+                "description": "Device ID override"
+              }
+            },
+            "anyOf": [
+              {
+                "required": [
+                  "appId",
+                  "permissions"
+                ]
+              },
+              {
+                "required": [
+                  "appId",
+                  "notificationsEnabled"
+                ]
+              },
+              {
+                "required": [
+                  "appId",
+                  "notificationPolicyAccess"
+                ]
+              },
+              {
+                "required": [
+                  "appId",
+                  "scheduleExactAlarm"
+                ]
+              },
+              {
+                "required": [
+                  "params"
+                ]
+              }
+            ],
+            "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "action": {
+                      "const": "reset"
+                    }
+                  },
+                  "required": [
+                    "action"
+                  ]
+                },
+                "then": {
+                  "not": {
+                    "required": [
+                      "userId"
+                    ]
+                  }
+                }
+              }
+            ]
+          }
         }
       ]
     },
@@ -642,6 +781,127 @@
       },
       "additionalProperties": true,
       "description": "Parameters for highlight"
+    },
+    "setAppPermissionsParams": {
+      "type": "object",
+      "required": [
+        "appId"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "appId": {
+          "type": "string",
+          "minLength": 1,
+          "description": "App package ID or bundle identifier"
+        },
+        "action": {
+          "type": "string",
+          "enum": [
+            "grant",
+            "revoke",
+            "reset"
+          ],
+          "description": "Permission action. Defaults to grant. Android reset requires permissions=['all'] and resets runtime permissions device-wide."
+        },
+        "permissions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Runtime permissions or simulator privacy services to change; Android and iOS physical reset accept only 'all'"
+        },
+        "userId": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Android user ID for grant/revoke, not reset"
+        },
+        "notificationsEnabled": {
+          "type": "boolean",
+          "description": "Android notification state, independent of POST_NOTIFICATIONS"
+        },
+        "notificationPolicyAccess": {
+          "type": "boolean",
+          "description": "Android only: set notification policy / DND access"
+        },
+        "scheduleExactAlarm": {
+          "type": "string",
+          "enum": [
+            "allow",
+            "deny"
+          ],
+          "description": "Android only: set UID-level SCHEDULE_EXACT_ALARM appop"
+        },
+        "platform": {
+          "type": "string",
+          "enum": [
+            "android",
+            "ios"
+          ],
+          "description": "Platform"
+        },
+        "sessionUuid": {
+          "type": "string",
+          "description": "Session UUID for device targeting"
+        },
+        "keepScreenAwake": {
+          "type": "boolean",
+          "description": "Keep physical Android devices awake during the session (default: true)"
+        },
+        "device": {
+          "type": "string",
+          "description": "Device label for multi-device plans"
+        },
+        "deviceId": {
+          "type": "string",
+          "description": "Device ID override"
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "notificationsEnabled"
+          ]
+        },
+        {
+          "required": [
+            "permissions"
+          ]
+        },
+        {
+          "required": [
+            "notificationPolicyAccess"
+          ]
+        },
+        {
+          "required": [
+            "scheduleExactAlarm"
+          ]
+        }
+      ],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "action": {
+                "const": "reset"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          },
+          "then": {
+            "not": {
+              "required": [
+                "userId"
+              ]
+            }
+          }
+        }
+      ],
+      "description": "Parameters for setAppPermissions"
     },
     "expectation": {
       "type": "object",

--- a/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
+++ b/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
@@ -582,6 +582,46 @@ class TestPlanValidatorTest {
   }
 
   @Test
+  fun `rejects reset without permissions`() {
+    val yaml =
+      """
+      name: invalid-reset-without-permissions
+      steps:
+        - tool: setAppPermissions
+          params:
+            appId: com.example.app
+            action: reset
+            notificationsEnabled: false
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+
+    assertFalse(result.valid, "Reset must require permissions: ${result.errors}")
+  }
+
+  @Test
+  fun `rejects Android reset without all permissions`() {
+    val yaml =
+      """
+      name: invalid-android-reset-scope
+      steps:
+        - tool: setAppPermissions
+          params:
+            appId: com.example.app
+            action: reset
+            platform: android
+            permissions:
+              - camera
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+
+    assertFalse(result.valid, "Android reset must require permissions=['all']: ${result.errors}")
+  }
+
+  @Test
   fun `accepts accessibilityFocus tool published in generated definitions`() {
     val yaml =
       """

--- a/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
+++ b/android/test-plan-validation/src/test/kotlin/dev/jasonpearson/automobile/validation/TestPlanValidatorTest.kt
@@ -544,6 +544,10 @@ class TestPlanValidatorTest {
             action: revoke
             permissions:
               - camera
+        - tool: setAppPermissions
+          params:
+            appId: com.example.app
+            notificationsEnabled: true
         - tool: getAppPermissions
           params:
             appId: com.example.app
@@ -554,6 +558,27 @@ class TestPlanValidatorTest {
 
     val result = TestPlanValidator.validateYaml(yaml)
     assertTrue(result.valid, "YAML with valid tools should pass validation: ${result.errors}")
+  }
+
+  @Test
+  fun `rejects reset with userId`() {
+    val yaml =
+      """
+      name: invalid-reset-user
+      steps:
+        - tool: setAppPermissions
+          params:
+            appId: com.example.app
+            action: reset
+            permissions:
+              - all
+            userId: 10
+      """
+        .trimIndent()
+
+    val result = TestPlanValidator.validateYaml(yaml)
+
+    assertFalse(result.valid, "Android reset must reject userId: ${result.errors}")
   }
 
   @Test

--- a/schemas/test-plan.schema.json
+++ b/schemas/test-plan.schema.json
@@ -453,11 +453,11 @@
                   "revoke",
                   "reset"
                 ],
-                "description": "Permission action. Defaults to grant."
+                "description": "Permission action. Defaults to grant. Android reset requires permissions=['all'] and resets runtime permissions device-wide."
               },
               "permissions": {
                 "type": "array",
-                "description": "Runtime permissions or simulator privacy services to change; iOS physical reset accepts 'all'",
+                "description": "Runtime permissions or simulator privacy services to change; Android and iOS physical reset accept only 'all'",
                 "minItems": 1,
                 "items": {
                   "type": "string",
@@ -467,7 +467,11 @@
               "userId": {
                 "type": "integer",
                 "minimum": 0,
-                "description": "Android user id for runtime permission grants"
+                "description": "Android user id for runtime permission grants and revokes"
+              },
+              "notificationsEnabled": {
+                "type": "boolean",
+                "description": "Android only: enable or disable app notifications independently of POST_NOTIFICATIONS"
               },
               "notificationPolicyAccess": {
                 "type": "boolean",
@@ -511,6 +515,12 @@
                 "required": [
                   "appId",
                   "permissions"
+                ]
+              },
+              {
+                "required": [
+                  "appId",
+                  "notificationsEnabled"
                 ]
               },
               {
@@ -1173,7 +1183,7 @@
             "revoke",
             "reset"
           ],
-          "description": "Permission action. Defaults to grant."
+          "description": "Permission action. Defaults to grant. Android reset requires permissions=['all'] and resets runtime permissions device-wide."
         },
         "permissions": {
           "type": "array",
@@ -1182,12 +1192,16 @@
             "type": "string",
             "minLength": 1
           },
-          "description": "Runtime permissions or simulator privacy services to change; iOS physical reset accepts 'all'"
+          "description": "Runtime permissions or simulator privacy services to change; Android and iOS physical reset accept only 'all'"
         },
         "userId": {
           "type": "integer",
           "minimum": 0,
-          "description": "Android user id for runtime permission grants"
+          "description": "Android user id for runtime permission grants and revokes"
+        },
+        "notificationsEnabled": {
+          "type": "boolean",
+          "description": "Android only: enable or disable app notifications independently of POST_NOTIFICATIONS"
         },
         "notificationPolicyAccess": {
           "type": "boolean",
@@ -1227,6 +1241,11 @@
         }
       },
       "anyOf": [
+        {
+          "required": [
+            "notificationsEnabled"
+          ]
+        },
         {
           "required": [
             "permissions"

--- a/schemas/test-plan.schema.json
+++ b/schemas/test-plan.schema.json
@@ -457,7 +457,7 @@
               },
               "permissions": {
                 "type": "array",
-                "description": "Runtime permissions or simulator privacy services to change; Android and iOS physical reset accept only 'all'",
+                "description": "Runtime permissions or simulator privacy services to change; Android reset accepts only 'all'; physical iOS accepts it too",
                 "minItems": 1,
                 "items": {
                   "type": "string",
@@ -554,10 +554,41 @@
                   ]
                 },
                 "then": {
+                  "required": [
+                    "permissions"
+                  ],
                   "not": {
                     "required": [
                       "userId"
                     ]
+                  }
+                }
+              },
+              {
+                "if": {
+                  "properties": {
+                    "action": {
+                      "const": "reset"
+                    },
+                    "platform": {
+                      "const": "android"
+                    }
+                  },
+                  "required": [
+                    "action",
+                    "platform"
+                  ]
+                },
+                "then": {
+                  "properties": {
+                    "permissions": {
+                      "type": "array",
+                      "minItems": 1,
+                      "maxItems": 1,
+                      "items": {
+                        "const": "all"
+                      }
+                    }
                   }
                 }
               }
@@ -1213,7 +1244,7 @@
             "type": "string",
             "minLength": 1
           },
-          "description": "Runtime permissions or simulator privacy services to change; Android and iOS physical reset accept only 'all'"
+          "description": "Runtime permissions or simulator privacy services to change; Android reset accepts only 'all'; physical iOS accepts it too"
         },
         "userId": {
           "type": "integer",
@@ -1296,10 +1327,41 @@
             ]
           },
           "then": {
+            "required": [
+              "permissions"
+            ],
             "not": {
               "required": [
                 "userId"
               ]
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "action": {
+                "const": "reset"
+              },
+              "platform": {
+                "const": "android"
+              }
+            },
+            "required": [
+              "action",
+              "platform"
+            ]
+          },
+          "then": {
+            "properties": {
+              "permissions": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 1,
+                "items": {
+                  "const": "all"
+                }
+              }
             }
           }
         }

--- a/schemas/test-plan.schema.json
+++ b/schemas/test-plan.schema.json
@@ -467,11 +467,11 @@
               "userId": {
                 "type": "integer",
                 "minimum": 0,
-                "description": "Android user id for runtime permission grants and revokes"
+                "description": "Android user ID for grant/revoke, not reset"
               },
               "notificationsEnabled": {
                 "type": "boolean",
-                "description": "Android only: enable or disable app notifications independently of POST_NOTIFICATIONS"
+                "description": "Android notification state, independent of POST_NOTIFICATIONS"
               },
               "notificationPolicyAccess": {
                 "type": "boolean",
@@ -539,6 +539,27 @@
                 "required": [
                   "params"
                 ]
+              }
+            ],
+            "allOf": [
+              {
+                "if": {
+                  "properties": {
+                    "action": {
+                      "const": "reset"
+                    }
+                  },
+                  "required": [
+                    "action"
+                  ]
+                },
+                "then": {
+                  "not": {
+                    "required": [
+                      "userId"
+                    ]
+                  }
+                }
               }
             ]
           }
@@ -1197,11 +1218,11 @@
         "userId": {
           "type": "integer",
           "minimum": 0,
-          "description": "Android user id for runtime permission grants and revokes"
+          "description": "Android user ID for grant/revoke, not reset"
         },
         "notificationsEnabled": {
           "type": "boolean",
-          "description": "Android only: enable or disable app notifications independently of POST_NOTIFICATIONS"
+          "description": "Android notification state, independent of POST_NOTIFICATIONS"
         },
         "notificationPolicyAccess": {
           "type": "boolean",
@@ -1260,6 +1281,27 @@
           "required": [
             "scheduleExactAlarm"
           ]
+        }
+      ],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "action": {
+                "const": "reset"
+              }
+            },
+            "required": [
+              "action"
+            ]
+          },
+          "then": {
+            "not": {
+              "required": [
+                "userId"
+              ]
+            }
+          }
         }
       ],
       "description": "Parameters for setAppPermissions"

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -6903,7 +6903,7 @@
           "type": "string"
         },
         "action": {
-          "description": "Permission action; defaults to grant. Android supports grant/revoke/reset; iOS simulators support grant/revoke/reset; Android reset requires permissions=['all'] and resets runtime permissions device-wide. iOS physical devices support reset only, including permissions=['all'].",
+          "description": "Action (default grant). Android reset requires permissions=['all'] device-wide; iOS physical devices support reset only.",
           "type": "string",
           "enum": [
             "grant",
@@ -6912,7 +6912,7 @@
           ]
         },
         "permissions": {
-          "description": "Runtime permissions or simulator privacy services to change; Android and iOS physical reset accept only 'all'",
+          "description": "Permissions; Android and physical iOS reset accepts only 'all'",
           "type": "array",
           "items": {
             "type": "string",
@@ -6920,13 +6920,13 @@
           }
         },
         "userId": {
-          "description": "Android user id",
+          "description": "Android user ID for grant/revoke, not reset",
           "type": "integer",
           "minimum": 0,
           "maximum": 9007199254740991
         },
         "notificationsEnabled": {
-          "description": "Android: enable or disable app notifications independently of POST_NOTIFICATIONS",
+          "description": "Android notification state, independent of POST_NOTIFICATIONS",
           "type": "boolean"
         },
         "notificationPolicyAccess": {

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -6894,7 +6894,7 @@
   },
   {
     "name": "setAppPermissions",
-    "description": "Grant, revoke, reset, or configure app permissions on Android devices, iOS simulators (grant/revoke/reset), and iOS physical devices (reset only, permissions=['all'] supported)",
+    "description": "Grant, revoke, reset, or configure app permissions and notification state on Android devices, iOS simulators (grant/revoke/reset), and iOS physical devices (reset only, permissions=['all'] supported)",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -6903,7 +6903,7 @@
           "type": "string"
         },
         "action": {
-          "description": "Permission action; defaults to grant. Android supports grant; iOS simulators support grant/revoke/reset; iOS physical devices support reset only, including permissions=['all'].",
+          "description": "Permission action; defaults to grant. Android supports grant/revoke/reset; iOS simulators support grant/revoke/reset; Android reset requires permissions=['all'] and resets runtime permissions device-wide. iOS physical devices support reset only, including permissions=['all'].",
           "type": "string",
           "enum": [
             "grant",
@@ -6912,7 +6912,7 @@
           ]
         },
         "permissions": {
-          "description": "Runtime permissions or simulator privacy services to change; iOS physical reset accepts 'all'",
+          "description": "Runtime permissions or simulator privacy services to change; Android and iOS physical reset accept only 'all'",
           "type": "array",
           "items": {
             "type": "string",
@@ -6924,6 +6924,10 @@
           "type": "integer",
           "minimum": 0,
           "maximum": 9007199254740991
+        },
+        "notificationsEnabled": {
+          "description": "Android: enable or disable app notifications independently of POST_NOTIFICATIONS",
+          "type": "boolean"
         },
         "notificationPolicyAccess": {
           "description": "Android: set DND policy access",

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -6894,7 +6894,7 @@
   },
   {
     "name": "setAppPermissions",
-    "description": "Grant, revoke, reset, or configure app permissions and notification state on Android devices, iOS simulators (grant/revoke/reset), and iOS physical devices (reset only, permissions=['all'] supported)",
+    "description": "Set permissions; notification state excludes POST_NOTIFICATIONS.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -6903,8 +6903,6 @@
           "type": "string"
         },
         "action": {
-          "description": "Action (default grant). Android reset requires permissions=['all'] device-wide; iOS physical devices support reset only.",
-          "type": "string",
           "enum": [
             "grant",
             "revoke",
@@ -6912,7 +6910,6 @@
           ]
         },
         "permissions": {
-          "description": "Permissions; Android and physical iOS reset accepts only 'all'",
           "type": "array",
           "items": {
             "type": "string",
@@ -6920,22 +6917,17 @@
           }
         },
         "userId": {
-          "description": "Android user ID for grant/revoke, not reset",
           "type": "integer",
           "minimum": 0,
           "maximum": 9007199254740991
         },
         "notificationsEnabled": {
-          "description": "Android notification state, independent of POST_NOTIFICATIONS",
           "type": "boolean"
         },
         "notificationPolicyAccess": {
-          "description": "Android: set DND policy access",
           "type": "boolean"
         },
         "scheduleExactAlarm": {
-          "description": "Android: set SCHEDULE_EXACT_ALARM appop",
-          "type": "string",
           "enum": [
             "allow",
             "deny"
@@ -6949,21 +6941,59 @@
           ]
         },
         "sessionUuid": {
-          "description": "Session",
           "type": "string"
         },
         "keepScreenAwake": {
           "type": "boolean"
         },
         "device": {
-          "description": "Device label",
           "type": "string"
         }
       },
       "required": [
         "appId"
       ],
-      "additionalProperties": false
+      "additionalProperties": false,
+      "if": {
+        "properties": {
+          "action": {
+            "const": "reset"
+          }
+        },
+        "required": [
+          "action"
+        ]
+      },
+      "then": {
+        "required": [
+          "permissions"
+        ],
+        "not": {
+          "required": [
+            "userId"
+          ]
+        },
+        "if": {
+          "properties": {
+            "platform": {
+              "const": "android"
+            }
+          },
+          "required": [
+            "platform"
+          ]
+        },
+        "then": {
+          "properties": {
+            "permissions": {
+              "maxItems": 1,
+              "items": {
+                "const": "all"
+              }
+            }
+          }
+        }
+      }
     }
   },
   {

--- a/src/features/action/AppPermissions.ts
+++ b/src/features/action/AppPermissions.ts
@@ -3,6 +3,7 @@ import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/A
 import type { BootedDevice } from "../../models";
 import { AndroidCtrlProxyClient } from "../observe/android";
 import { GrantAndroidPermissions } from "./GrantAndroidPermissions";
+import { SetAndroidNotificationsEnabled } from "./SetAndroidNotificationsEnabled";
 import { SetAndroidNotificationPolicyAccess } from "./SetAndroidNotificationPolicyAccess";
 import { SetAndroidScheduleExactAlarmAppOp, type ScheduleExactAlarmAppOpMode } from "./SetAndroidScheduleExactAlarmAppOp";
 import {
@@ -55,6 +56,7 @@ export interface SetAppPermissionsInput {
   action?: AppPermissionAction;
   permissions?: string[];
   userId?: number;
+  notificationsEnabled?: boolean;
   notificationPolicyAccess?: boolean;
   scheduleExactAlarm?: ScheduleExactAlarmAppOpMode;
 }
@@ -179,6 +181,9 @@ export class AppPermissions {
     if (input.notificationPolicyAccess !== undefined) {
       unsupportedFields.push("notificationPolicyAccess");
     }
+    if (input.notificationsEnabled !== undefined) {
+      unsupportedFields.push("notificationsEnabled");
+    }
     if (input.scheduleExactAlarm !== undefined) {
       unsupportedFields.push("scheduleExactAlarm");
     }
@@ -264,30 +269,35 @@ export class AppPermissions {
     const operations: AppPermissionOperationResult[] = [];
 
     if (permissions.length > 0) {
-      if (action !== "grant") {
-        operations.push({
-          operationId: `android_runtime_permissions:${action}`,
-          success: false,
-          changedCount: 0,
-          failedCount: permissions.length,
-          error: "Android runtime permission mutations currently support action=grant only",
-        });
-      } else {
-        const grantResult = await new GrantAndroidPermissions(this.device, this.adbFactory).execute(appId, {
-          permissions,
-          userId: input.userId,
-        });
-        const changedCount = grantResult.results.filter(result => result.success && !result.skipped).length;
-        const failedCount = grantResult.results.filter(result => result.countsTowardSuccess && !result.success && !result.skipped).length;
-        operations.push({
-          operationId: "android_runtime_permissions:grant",
-          success: grantResult.success,
-          changedCount,
-          failedCount,
-          result: grantResult,
-          ...(grantResult.error ? { error: grantResult.error } : {}),
-        });
-      }
+      const permissionResult = await new GrantAndroidPermissions(this.device, this.adbFactory).execute(appId, {
+        action,
+        permissions,
+        userId: input.userId,
+      });
+      const changedCount = permissionResult.results.filter(result => result.success && !result.skipped).length;
+      const failedCount = permissionResult.results.filter(result => result.countsTowardSuccess && !result.success && !result.skipped).length;
+      operations.push({
+        operationId: `android_runtime_permissions:${action}`,
+        success: permissionResult.success,
+        changedCount,
+        failedCount,
+        result: permissionResult,
+        ...(permissionResult.error ? { error: permissionResult.error } : {}),
+      });
+    }
+
+    if (input.notificationsEnabled !== undefined) {
+      const result = await new SetAndroidNotificationsEnabled(this.device, this.adbFactory).execute(appId, {
+        enabled: input.notificationsEnabled,
+      });
+      operations.push({
+        operationId: "android_notifications_enabled",
+        success: result.success,
+        changedCount: result.success ? 1 : 0,
+        failedCount: result.success ? 0 : 1,
+        result,
+        ...(result.error ? { error: result.error } : {}),
+      });
     }
 
     if (input.notificationPolicyAccess !== undefined) {

--- a/src/features/action/AppPermissions.ts
+++ b/src/features/action/AppPermissions.ts
@@ -267,8 +267,11 @@ export class AppPermissions {
   ): Promise<SetAppPermissionsResult> {
     const permissions = normalizePermissions(input.permissions);
     const operations: AppPermissionOperationResult[] = [];
+    const invalidResetRequest =
+      action === "reset" &&
+      (input.userId !== undefined || permissions.length !== 1 || permissions[0] !== "all");
 
-    if (permissions.length > 0) {
+    if (permissions.length > 0 || invalidResetRequest) {
       const permissionResult = await new GrantAndroidPermissions(this.device, this.adbFactory).execute(appId, {
         action,
         permissions,
@@ -286,7 +289,7 @@ export class AppPermissions {
       });
     }
 
-    if (input.notificationsEnabled !== undefined) {
+    if (!invalidResetRequest && input.notificationsEnabled !== undefined) {
       const result = await new SetAndroidNotificationsEnabled(this.device, this.adbFactory).execute(appId, {
         enabled: input.notificationsEnabled,
       });
@@ -300,7 +303,7 @@ export class AppPermissions {
       });
     }
 
-    if (input.notificationPolicyAccess !== undefined) {
+    if (!invalidResetRequest && input.notificationPolicyAccess !== undefined) {
       const result = await new SetAndroidNotificationPolicyAccess(this.device, this.adbFactory).execute(appId, {
         allowed: input.notificationPolicyAccess,
       });
@@ -314,7 +317,7 @@ export class AppPermissions {
       });
     }
 
-    if (input.scheduleExactAlarm !== undefined) {
+    if (!invalidResetRequest && input.scheduleExactAlarm !== undefined) {
       const result = await new SetAndroidScheduleExactAlarmAppOp(this.device, this.adbFactory).execute(appId, {
         mode: input.scheduleExactAlarm,
       });

--- a/src/features/action/GrantAndroidPermissions.ts
+++ b/src/features/action/GrantAndroidPermissions.ts
@@ -165,12 +165,28 @@ export class GrantAndroidPermissions {
     perf: ReturnType<typeof createGlobalPerformanceTracker>
   ): Promise<GrantAndroidPermissionsResult> {
     const resetPermissions = permissions.map(permission => permission.trim());
+    if (userId !== undefined) {
+      perf.end();
+      return {
+        success: false,
+        appId: packageName,
+        userId: 0,
+        results: [{
+          operationId: "pm_reset_permissions",
+          success: false,
+          countsTowardSuccess: true,
+          error: "Android reset is device-wide and does not support userId",
+        }],
+        error: "Failed step(s): pm_reset_permissions",
+      };
+    }
+
     if (resetPermissions.length !== 1 || resetPermissions[0] !== "all") {
       perf.end();
       return {
         success: false,
         appId: packageName,
-        userId: userId ?? 0,
+        userId: 0,
         results: [{
           operationId: "pm_reset_permissions",
           success: false,
@@ -194,7 +210,7 @@ export class GrantAndroidPermissions {
       return {
         success: true,
         appId: packageName,
-        userId: userId ?? 0,
+        userId: 0,
         results: [{
           operationId: "pm_reset_permissions",
           success: true,
@@ -207,7 +223,7 @@ export class GrantAndroidPermissions {
       return {
         success: false,
         appId: packageName,
-        userId: userId ?? 0,
+        userId: 0,
         results: [{
           operationId: "pm_reset_permissions",
           success: false,

--- a/src/features/action/GrantAndroidPermissions.ts
+++ b/src/features/action/GrantAndroidPermissions.ts
@@ -7,7 +7,10 @@ import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { outputLooksLikeShellFailure } from "../../utils/android-cmdline-tools/shellOutputHeuristics";
 
 
+export type AndroidPermissionChangeAction = "grant" | "revoke" | "reset";
+
 export interface GrantAndroidPermissionsInput {
+  action?: AndroidPermissionChangeAction;
   permissions: string[];
   userId?: number;
 }
@@ -25,9 +28,10 @@ export class GrantAndroidPermissions {
 
   async execute(packageName: string, input: GrantAndroidPermissionsInput): Promise<GrantAndroidPermissionsResult> {
     const perf = createGlobalPerformanceTracker();
-    perf.serial("grantAndroidPermissions");
+    perf.serial("changeAndroidPermissions");
 
     const permissions = input.permissions ?? [];
+    const action = input.action ?? "grant";
 
     if (this.device.platform !== "android") {
       perf.end();
@@ -36,23 +40,37 @@ export class GrantAndroidPermissions {
         appId: packageName,
         userId: input.userId ?? 0,
         results: [],
-        error: "grantAndroidPermissions is only supported on Android devices",
+        error: "Android permission changes are only supported on Android devices",
       };
     }
 
+    if (action === "reset") {
+      return this.resetPermissions(packageName, permissions, input.userId, perf);
+    }
+
+    return this.changePermissions(packageName, permissions, input.userId, action, perf);
+  }
+
+  private async changePermissions(
+    packageName: string,
+    permissions: string[],
+    userId: number | undefined,
+    action: Exclude<AndroidPermissionChangeAction, "reset">,
+    perf: ReturnType<typeof createGlobalPerformanceTracker>
+  ): Promise<GrantAndroidPermissionsResult> {
     if (permissions.length === 0) {
       perf.end();
       return {
         success: false,
         appId: packageName,
-        userId: input.userId ?? 0,
+        userId: userId ?? 0,
         results: [],
         error: "Provide at least one permission in `permissions`",
       };
     }
 
     const targetUserId = await perf.track("detectTargetUser", async () => {
-      return (await new AndroidUserTargetResolver(this.adb).resolve({ packageName, explicitUserId: input.userId })).userId;
+      return (await new AndroidUserTargetResolver(this.adb).resolve({ packageName, explicitUserId: userId })).userId;
     });
 
     const results: GrantAndroidPermissionItemResult[] = [];
@@ -62,7 +80,7 @@ export class GrantAndroidPermissions {
         const trimmed = permission.trim();
         if (!trimmed) {
           results.push({
-            operationId: "pm_grant:(empty)",
+            operationId: `pm_${action}:(empty)`,
             permission,
             success: false,
             countsTowardSuccess: true,
@@ -71,45 +89,45 @@ export class GrantAndroidPermissions {
           continue;
         }
 
-        const cmd = `shell pm grant --user ${targetUserId} ${packageName} ${trimmed}`;
+        const cmd = `shell pm ${action} --user ${targetUserId} ${packageName} ${trimmed}`;
 
         try {
-          await perf.track(`pmGrant:${trimmed}`, async () => {
+          await perf.track(`pm${action[0].toUpperCase()}${action.slice(1)}:${trimmed}`, async () => {
             const execResult = await this.adb.executeCommand(cmd, undefined, undefined, true);
             const stdout = execResult.stdout ?? "";
             const stderr = execResult.stderr ?? "";
 
             if (outputLooksLikeShellFailure(stdout, stderr)) {
-              const message = `${stdout}\n${stderr}`.trim() || "pm grant reported an error";
+              const message = `${stdout}\n${stderr}`.trim() || `pm ${action} reported an error`;
               results.push({
-                operationId: `pm_grant:${trimmed}`,
+                operationId: `pm_${action}:${trimmed}`,
                 permission: trimmed,
                 success: false,
                 countsTowardSuccess: true,
                 error: message,
               });
-              logger.warn(`[GrantAndroidPermissions] Grant failed for ${trimmed}: ${message}`);
+              logger.warn(`[GrantAndroidPermissions] ${action} failed for ${trimmed}: ${message}`);
               return;
             }
 
             results.push({
-              operationId: `pm_grant:${trimmed}`,
+              operationId: `pm_${action}:${trimmed}`,
               permission: trimmed,
               success: true,
               countsTowardSuccess: true,
             });
-            logger.info(`[GrantAndroidPermissions] Granted ${trimmed} to ${packageName} (user ${targetUserId})`);
+            logger.info(`[GrantAndroidPermissions] ${action} ${trimmed} for ${packageName} (user ${targetUserId})`);
           });
         } catch (cause) {
           const message = cause instanceof Error ? cause.message : String(cause);
           results.push({
-            operationId: `pm_grant:${trimmed}`,
+            operationId: `pm_${action}:${trimmed}`,
             permission: trimmed,
             success: false,
             countsTowardSuccess: true,
             error: message,
           });
-          logger.warn(`[GrantAndroidPermissions] Grant threw for ${trimmed}: ${message}`);
+          logger.warn(`[GrantAndroidPermissions] ${action} threw for ${trimmed}: ${message}`);
         }
       }
     } finally {
@@ -135,8 +153,71 @@ export class GrantAndroidPermissions {
           error:
               failedRequired.length > 0
                 ? `Failed step(s): ${failedRequired.map(f => f.operationId).join(", ")}`
-                : "One or more required grant steps failed",
+                : "One or more required Android permission changes failed",
         }),
     };
+  }
+
+  private async resetPermissions(
+    packageName: string,
+    permissions: string[],
+    userId: number | undefined,
+    perf: ReturnType<typeof createGlobalPerformanceTracker>
+  ): Promise<GrantAndroidPermissionsResult> {
+    const resetPermissions = permissions.map(permission => permission.trim());
+    if (resetPermissions.length !== 1 || resetPermissions[0] !== "all") {
+      perf.end();
+      return {
+        success: false,
+        appId: packageName,
+        userId: userId ?? 0,
+        results: [{
+          operationId: "pm_reset_permissions",
+          success: false,
+          countsTowardSuccess: true,
+          error: "Android reset requires permissions=['all'] because pm reset-permissions is device-wide",
+        }],
+        error: "Failed step(s): pm_reset_permissions",
+      };
+    }
+
+    try {
+      await perf.track("pmResetPermissions", async () => {
+        const execResult = await this.adb.executeCommand("shell pm reset-permissions", undefined, undefined, true);
+        const stdout = execResult.stdout ?? "";
+        const stderr = execResult.stderr ?? "";
+
+        if (outputLooksLikeShellFailure(stdout, stderr)) {
+          throw new Error(`${stdout}\n${stderr}`.trim() || "pm reset-permissions reported an error");
+        }
+      });
+      return {
+        success: true,
+        appId: packageName,
+        userId: userId ?? 0,
+        results: [{
+          operationId: "pm_reset_permissions",
+          success: true,
+          countsTowardSuccess: true,
+        }],
+      };
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : String(cause);
+      logger.warn(`[GrantAndroidPermissions] reset threw: ${message}`);
+      return {
+        success: false,
+        appId: packageName,
+        userId: userId ?? 0,
+        results: [{
+          operationId: "pm_reset_permissions",
+          success: false,
+          countsTowardSuccess: true,
+          error: message,
+        }],
+        error: "Failed step(s): pm_reset_permissions",
+      };
+    } finally {
+      perf.end();
+    }
   }
 }

--- a/src/features/action/SetAndroidNotificationsEnabled.ts
+++ b/src/features/action/SetAndroidNotificationsEnabled.ts
@@ -1,0 +1,62 @@
+import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
+import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import { AndroidDeviceShellToolResult, BootedDevice } from "../../models";
+import { logger } from "../../utils/logger";
+import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
+import { outputLooksLikeShellFailure } from "../../utils/android-cmdline-tools/shellOutputHeuristics";
+
+export interface SetAndroidNotificationsEnabledInput {
+  enabled: boolean;
+}
+
+/**
+ * Enables or disables notifications for a package independently of its
+ * POST_NOTIFICATIONS runtime permission.
+ */
+export class SetAndroidNotificationsEnabled {
+  private device: BootedDevice;
+
+  private adb: AdbExecutor;
+
+  constructor(device: BootedDevice, adbFactory: AdbClientFactory = defaultAdbClientFactory) {
+    this.device = device;
+    this.adb = adbFactory.create(device);
+  }
+
+  async execute(
+    packageName: string,
+    input: SetAndroidNotificationsEnabledInput
+  ): Promise<AndroidDeviceShellToolResult> {
+    const perf = createGlobalPerformanceTracker();
+    perf.serial("setAndroidNotificationsEnabled");
+
+    if (this.device.platform !== "android") {
+      perf.end();
+      return {
+        success: false,
+        appId: packageName,
+        error: "setAndroidNotificationsEnabled is only supported on Android devices",
+      };
+    }
+
+    const command = `shell cmd notification set_enabled ${packageName} ${input.enabled}`;
+    try {
+      await perf.track("setEnabled", async () => {
+        const result = await this.adb.executeCommand(command, undefined, undefined, true);
+        const stdout = result.stdout ?? "";
+        const stderr = result.stderr ?? "";
+        if (outputLooksLikeShellFailure(stdout, stderr)) {
+          throw new Error(`${stdout}\n${stderr}`.trim() || "cmd notification set_enabled reported an error");
+        }
+      });
+      logger.info(`[SetAndroidNotificationsEnabled] ${input.enabled ? "enabled" : "disabled"} notifications for ${packageName}`);
+      return { success: true, appId: packageName };
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : String(cause);
+      logger.warn(`[SetAndroidNotificationsEnabled] failed for ${packageName}: ${message}`);
+      return { success: false, appId: packageName, error: message };
+    } finally {
+      perf.end();
+    }
+  }
+}

--- a/src/models/GrantAndroidPermissionsResult.ts
+++ b/src/models/GrantAndroidPermissionsResult.ts
@@ -22,7 +22,10 @@ export interface GrantAndroidPermissionItemResult {
 export interface GrantAndroidPermissionsResult {
   success: boolean;
   appId: string;
-  /** User id used with `pm grant` or `pm revoke` (0 = primary, 10+ = work profile when inferred). */
+  /**
+   * User id used with `pm grant` or `pm revoke` (0 = primary, 10+ = work profile when inferred).
+   * Device-wide `pm reset-permissions` does not target a user and returns 0.
+   */
   userId: number;
   results: GrantAndroidPermissionItemResult[];
   error?: string;

--- a/src/models/GrantAndroidPermissionsResult.ts
+++ b/src/models/GrantAndroidPermissionsResult.ts
@@ -1,10 +1,10 @@
 /**
- * One step in a grantAndroidPermissions run (`pm grant` only).
+ * One step in an Android runtime-permission mutation (`pm grant`, `pm revoke`, or reset).
  */
 export interface GrantAndroidPermissionItemResult {
   /** Stable step id, e.g. pm_grant:android.permission.CAMERA, cmd.notification.allow_dnd */
   operationId: string;
-  /** Present when this row is a runtime `pm grant` */
+  /** Present when this row mutates one runtime permission with `pm grant` or `pm revoke`. */
   permission?: string;
   success: boolean;
   /**
@@ -17,12 +17,12 @@ export interface GrantAndroidPermissionItemResult {
 }
 
 /**
- * Result of batch-granting Android runtime permissions (`pm grant`) for a package.
+ * Result of an Android runtime-permission mutation for a package.
  */
 export interface GrantAndroidPermissionsResult {
   success: boolean;
   appId: string;
-  /** User id used with `pm grant --user` (0 = primary, 10+ = work profile when inferred). */
+  /** User id used with `pm grant` or `pm revoke` (0 = primary, 10+ = work profile when inferred). */
   userId: number;
   results: GrantAndroidPermissionItemResult[];
   error?: string;

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -70,24 +70,23 @@ export const setAppPermissionsSchema = withAppIdAliases(addDeviceTargetingToSche
     action: appPermissionActionSchema
       .optional()
       .describe(
-        "Permission action; defaults to grant. Android supports grant/revoke/reset; iOS simulators " +
-        "support grant/revoke/reset; Android reset requires permissions=['all'] and resets runtime permissions " +
-        "device-wide. iOS physical devices support reset only, including permissions=['all']."
+        "Action (default grant). Android reset requires permissions=['all'] device-wide; " +
+        "iOS physical devices support reset only."
       ),
     permissions: z
       .array(z.string().min(1))
       .optional()
-      .describe("Runtime permissions or simulator privacy services to change; Android and iOS physical reset accept only 'all'"),
+      .describe("Permissions; Android and physical iOS reset accepts only 'all'"),
     userId: z
       .number()
       .int()
       .nonnegative()
       .optional()
-      .describe("Android user id"),
+      .describe("Android user ID for grant/revoke, not reset"),
     notificationsEnabled: z
       .boolean()
       .optional()
-      .describe("Android: enable or disable app notifications independently of POST_NOTIFICATIONS"),
+      .describe("Android notification state, independent of POST_NOTIFICATIONS"),
     notificationPolicyAccess: z
       .boolean()
       .optional()
@@ -104,6 +103,9 @@ export const setAppPermissionsSchema = withAppIdAliases(addDeviceTargetingToSche
     args.notificationPolicyAccess !== undefined ||
     args.scheduleExactAlarm !== undefined,
   "Provide at least one permission or platform-specific permission option"
+).refine(
+  args => args.action !== "reset" || args.userId === undefined,
+  "Android reset is device-wide and does not support userId"
 );
 
 export const getAppPermissionsSchema = withAppIdAliases(addDeviceTargetingToSchema(

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -70,19 +70,24 @@ export const setAppPermissionsSchema = withAppIdAliases(addDeviceTargetingToSche
     action: appPermissionActionSchema
       .optional()
       .describe(
-        "Permission action; defaults to grant. Android supports grant; iOS simulators " +
-        "support grant/revoke/reset; iOS physical devices support reset only, including permissions=['all']."
+        "Permission action; defaults to grant. Android supports grant/revoke/reset; iOS simulators " +
+        "support grant/revoke/reset; Android reset requires permissions=['all'] and resets runtime permissions " +
+        "device-wide. iOS physical devices support reset only, including permissions=['all']."
       ),
     permissions: z
       .array(z.string().min(1))
       .optional()
-      .describe("Runtime permissions or simulator privacy services to change; iOS physical reset accepts 'all'"),
+      .describe("Runtime permissions or simulator privacy services to change; Android and iOS physical reset accept only 'all'"),
     userId: z
       .number()
       .int()
       .nonnegative()
       .optional()
       .describe("Android user id"),
+    notificationsEnabled: z
+      .boolean()
+      .optional()
+      .describe("Android: enable or disable app notifications independently of POST_NOTIFICATIONS"),
     notificationPolicyAccess: z
       .boolean()
       .optional()
@@ -95,6 +100,7 @@ export const setAppPermissionsSchema = withAppIdAliases(addDeviceTargetingToSche
 )).refine(
   args =>
     (args.permissions !== undefined && args.permissions.length > 0) ||
+    args.notificationsEnabled !== undefined ||
     args.notificationPolicyAccess !== undefined ||
     args.scheduleExactAlarm !== undefined,
   "Provide at least one permission or platform-specific permission option"
@@ -276,6 +282,7 @@ export function registerAppTools(
       action: args.action,
       permissions: args.permissions,
       userId: args.userId,
+      notificationsEnabled: args.notificationsEnabled,
       notificationPolicyAccess: args.notificationPolicyAccess,
       scheduleExactAlarm: args.scheduleExactAlarm,
     });
@@ -333,7 +340,7 @@ export function registerAppTools(
 
   ToolRegistry.registerDeviceAware(
     "setAppPermissions",
-    "Grant, revoke, reset, or configure app permissions on Android devices, iOS simulators " +
+    "Grant, revoke, reset, or configure app permissions and notification state on Android devices, iOS simulators " +
     "(grant/revoke/reset), and iOS physical devices (reset only, permissions=['all'] supported)",
     setAppPermissionsSchema,
     setAppPermissionsHandler

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -7,7 +7,7 @@ import { InstallApp } from "../features/action/InstallApp";
 import { UninstallApp } from "../features/action/UninstallApp";
 import { AppPermissions } from "../features/action/AppPermissions";
 import { createJSONToolResponse, DefaultToolResponseFormatter, ToolResponseFormatter } from "../utils/toolUtils";
-import { addDeviceTargetingToSchema, withAppIdAliases } from "./toolSchemaHelpers";
+import { addDeviceTargetingToSchema, withAppIdAliases, withJsonSchemaOverride } from "./toolSchemaHelpers";
 import {
   APPS_RESOURCE_URIS,
   APP_RESOURCE_TEMPLATES,
@@ -64,7 +64,7 @@ export const uninstallAppSchema = withAppIdAliases(addDeviceTargetingToSchema(z.
 
 const appPermissionActionSchema = z.enum(["grant", "revoke", "reset"]);
 
-export const setAppPermissionsSchema = withAppIdAliases(addDeviceTargetingToSchema(
+export const setAppPermissionsSchema = withJsonSchemaOverride(withAppIdAliases(addDeviceTargetingToSchema(
   z.object({
     appId: z.string(),
     action: appPermissionActionSchema
@@ -76,7 +76,7 @@ export const setAppPermissionsSchema = withAppIdAliases(addDeviceTargetingToSche
     permissions: z
       .array(z.string().min(1))
       .optional()
-      .describe("Permissions; Android and physical iOS reset accepts only 'all'"),
+      .describe("Permissions; Android reset accepts only 'all'; physical iOS accepts it too"),
     userId: z
       .number()
       .int()
@@ -106,7 +106,52 @@ export const setAppPermissionsSchema = withAppIdAliases(addDeviceTargetingToSche
 ).refine(
   args => args.action !== "reset" || args.userId === undefined,
   "Android reset is device-wide and does not support userId"
-);
+).refine(
+  args => args.action !== "reset" || args.permissions?.some(permission => permission.trim().length > 0) === true,
+  "Reset requires permissions"
+).refine(
+  args =>
+    args.action !== "reset" ||
+    args.platform !== "android" ||
+    (args.permissions?.length === 1 && args.permissions[0].trim() === "all"),
+  "Android reset requires permissions=['all']"
+), jsonSchema => {
+  const properties = jsonSchema.properties as Record<string, Record<string, unknown>>;
+  delete properties.action?.type;
+  delete properties.scheduleExactAlarm?.type;
+  for (const name of [
+    "action",
+    "permissions",
+    "userId",
+    "notificationsEnabled",
+    "notificationPolicyAccess",
+    "scheduleExactAlarm",
+    "sessionUuid",
+    "device",
+  ]) {
+    delete properties[name]?.description;
+  }
+  jsonSchema.if = {
+    properties: { action: { const: "reset" } },
+    required: ["action"],
+  };
+  jsonSchema.then = {
+    required: ["permissions"],
+    not: { required: ["userId"] },
+    if: {
+      properties: { platform: { const: "android" } },
+      required: ["platform"],
+    },
+    then: {
+      properties: {
+        permissions: {
+          maxItems: 1,
+          items: { const: "all" },
+        },
+      },
+    },
+  };
+});
 
 export const getAppPermissionsSchema = withAppIdAliases(addDeviceTargetingToSchema(
   z.object({
@@ -342,8 +387,7 @@ export function registerAppTools(
 
   ToolRegistry.registerDeviceAware(
     "setAppPermissions",
-    "Grant, revoke, reset, or configure app permissions and notification state on Android devices, iOS simulators " +
-    "(grant/revoke/reset), and iOS physical devices (reset only, permissions=['all'] supported)",
+    "Set permissions; notification state excludes POST_NOTIFICATIONS.",
     setAppPermissionsSchema,
     setAppPermissionsHandler
   );

--- a/test/features/action/AppPermissions.test.ts
+++ b/test/features/action/AppPermissions.test.ts
@@ -44,6 +44,7 @@ describe("AppPermissions", () => {
     const adbFactory = new FakeAdbClientFactory();
     const client = adbFactory.getFakeClient();
     client.setCommandResult("shell pm grant --user 0 com.example.app android.permission.CAMERA", "");
+    client.setCommandResult("shell cmd notification set_enabled com.example.app true", "");
     client.setCommandResult("shell cmd notification allow_dnd com.example.app", "");
     client.setCommandResult("shell appops set --uid com.example.app SCHEDULE_EXACT_ALARM allow", "");
 
@@ -51,20 +52,105 @@ describe("AppPermissions", () => {
     const result = await permissions.setPermissions("com.example.app", {
       permissions: ["android.permission.CAMERA"],
       userId: 0,
+      notificationsEnabled: true,
       notificationPolicyAccess: true,
       scheduleExactAlarm: "allow",
     });
 
     expect(result.success).toBe(true);
-    expect(result.changedCount).toBe(3);
+    expect(result.changedCount).toBe(4);
     expect(result.operations.map(operation => operation.operationId)).toEqual([
       "android_runtime_permissions:grant",
+      "android_notifications_enabled",
       "android_notification_policy_access",
       "android_schedule_exact_alarm_appop",
     ]);
     expect(client.wasCommandExecuted("shell pm grant --user 0 com.example.app android.permission.CAMERA")).toBe(true);
+    expect(client.wasCommandExecuted("shell cmd notification set_enabled com.example.app true")).toBe(true);
     expect(client.wasCommandExecuted("shell cmd notification allow_dnd com.example.app")).toBe(true);
     expect(client.wasCommandExecuted("shell appops set --uid com.example.app SCHEDULE_EXACT_ALARM allow")).toBe(true);
+  });
+
+  test("aggregates Android revoke and notification command failures", async () => {
+    const adbFactory = new FakeAdbClientFactory();
+    const client = adbFactory.getFakeClient();
+    client.setCommandResult("shell pm revoke --user 0 com.example.app android.permission.CAMERA", "");
+    client.setCommandResult(
+      "shell cmd notification set_enabled com.example.app false",
+      "",
+      "SecurityException: notification access denied"
+    );
+
+    const permissions = new AppPermissions(androidDevice, { adbFactory });
+    const result = await permissions.setPermissions("com.example.app", {
+      action: "revoke",
+      permissions: ["android.permission.CAMERA"],
+      userId: 0,
+      notificationsEnabled: false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.changedCount).toBe(1);
+    expect(result.failedCount).toBe(1);
+    expect(result.operations.map(operation => ({
+      operationId: operation.operationId,
+      success: operation.success,
+      changedCount: operation.changedCount,
+      failedCount: operation.failedCount,
+    }))).toEqual([
+      {
+        operationId: "android_runtime_permissions:revoke",
+        success: true,
+        changedCount: 1,
+        failedCount: 0,
+      },
+      {
+        operationId: "android_notifications_enabled",
+        success: false,
+        changedCount: 0,
+        failedCount: 1,
+      },
+    ]);
+    expect(result.error).toContain("SecurityException");
+  });
+
+  test("disables Android notifications independently of runtime permissions", async () => {
+    const adbFactory = new FakeAdbClientFactory();
+    const client = adbFactory.getFakeClient();
+    client.setCommandResult("shell cmd notification set_enabled com.example.app false", "");
+
+    const permissions = new AppPermissions(androidDevice, { adbFactory });
+    const result = await permissions.setPermissions("com.example.app", {
+      notificationsEnabled: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.changedCount).toBe(1);
+    expect(result.failedCount).toBe(0);
+    expect(result.operations.map(operation => operation.operationId)).toEqual([
+      "android_notifications_enabled",
+    ]);
+    expect(client.wasCommandExecuted("shell cmd notification set_enabled com.example.app false")).toBe(true);
+  });
+
+  test("reports Android reset as one standard operation", async () => {
+    const adbFactory = new FakeAdbClientFactory();
+    const client = adbFactory.getFakeClient();
+    client.setCommandResult("shell pm reset-permissions", "");
+
+    const permissions = new AppPermissions(androidDevice, { adbFactory });
+    const result = await permissions.setPermissions("com.example.app", {
+      action: "reset",
+      permissions: ["all"],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.changedCount).toBe(1);
+    expect(result.failedCount).toBe(0);
+    expect(result.operations.map(operation => operation.operationId)).toEqual([
+      "android_runtime_permissions:reset",
+    ]);
+    expect(client.wasCommandExecuted("shell pm reset-permissions")).toBe(true);
   });
 
   test("queries Android runtime permission state from dumpsys package", async () => {

--- a/test/features/action/AppPermissions.test.ts
+++ b/test/features/action/AppPermissions.test.ts
@@ -133,6 +133,31 @@ describe("AppPermissions", () => {
     expect(client.wasCommandExecuted("shell cmd notification set_enabled com.example.app false")).toBe(true);
   });
 
+  test("rejects a notification-only Android reset before executing either operation", async () => {
+    const adbFactory = new FakeAdbClientFactory();
+    const client = adbFactory.getFakeClient();
+    const permissions = new AppPermissions(androidDevice, { adbFactory });
+
+    const result = await permissions.setPermissions("com.example.app", {
+      action: "reset",
+      notificationsEnabled: false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.changedCount).toBe(0);
+    expect(result.failedCount).toBe(1);
+    expect(result.operations.map(operation => operation.operationId)).toEqual([
+      "android_runtime_permissions:reset",
+    ]);
+    expect(result.operations[0].result).toMatchObject({
+      results: [{
+        error: "Android reset requires permissions=['all'] because pm reset-permissions is device-wide",
+      }],
+    });
+    expect(client.wasCommandExecuted("shell pm reset-permissions")).toBe(false);
+    expect(client.wasCommandExecuted("shell cmd notification set_enabled com.example.app false")).toBe(false);
+  });
+
   test("reports Android reset as one standard operation", async () => {
     const adbFactory = new FakeAdbClientFactory();
     const client = adbFactory.getFakeClient();

--- a/test/features/action/GrantAndroidPermissions.test.ts
+++ b/test/features/action/GrantAndroidPermissions.test.ts
@@ -52,6 +52,107 @@ describe("GrantAndroidPermissions", () => {
     expect(calls).toContain("shell pm grant --user 0 com.example.app android.permission.CAMERA");
   });
 
+  test("runs pm revoke for each permission with the resolved target user", async () => {
+    const factory = new FakeAdbClientFactory();
+    const client = factory.getFakeClient();
+    client.setCommandResult(
+      "shell pm revoke --user 12 com.example.app android.permission.POST_NOTIFICATIONS",
+      ""
+    );
+
+    const action = new GrantAndroidPermissions(androidDevice, factory);
+    const result = await action.execute("com.example.app", {
+      action: "revoke",
+      permissions: ["android.permission.POST_NOTIFICATIONS"],
+      userId: 12,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.userId).toBe(12);
+    expect(result.results).toEqual([
+      {
+        operationId: "pm_revoke:android.permission.POST_NOTIFICATIONS",
+        permission: "android.permission.POST_NOTIFICATIONS",
+        success: true,
+        countsTowardSuccess: true,
+      },
+    ]);
+    expect(
+      client.wasCommandExecuted(
+        "shell pm revoke --user 12 com.example.app android.permission.POST_NOTIFICATIONS"
+      )
+    ).toBe(true);
+  });
+
+  test("resets all Android runtime permissions through pm reset-permissions", async () => {
+    const factory = new FakeAdbClientFactory();
+    const client = factory.getFakeClient();
+    client.setCommandResult("shell pm reset-permissions", "");
+
+    const action = new GrantAndroidPermissions(androidDevice, factory);
+    const result = await action.execute("com.example.app", {
+      action: "reset",
+      permissions: ["all"],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.results).toEqual([
+      {
+        operationId: "pm_reset_permissions",
+        success: true,
+        countsTowardSuccess: true,
+      },
+    ]);
+    expect(client.wasCommandExecuted("shell pm reset-permissions")).toBe(true);
+  });
+
+  test("rejects reset scopes other than permissions=['all']", async () => {
+    const factory = new FakeAdbClientFactory();
+    const action = new GrantAndroidPermissions(androidDevice, factory);
+    const result = await action.execute("com.example.app", {
+      action: "reset",
+      permissions: ["android.permission.CAMERA"],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.results).toEqual([
+      {
+        operationId: "pm_reset_permissions",
+        success: false,
+        countsTowardSuccess: true,
+        error: "Android reset requires permissions=['all'] because pm reset-permissions is device-wide",
+      },
+    ]);
+    expect(result.error).toContain("pm_reset_permissions");
+  });
+
+  test("reports a pm reset-permissions failure as a required operation failure", async () => {
+    const factory = new FakeAdbClientFactory();
+    const client = factory.getFakeClient();
+    client.setCommandResult(
+      "shell pm reset-permissions",
+      "",
+      "java.lang.SecurityException: Permission reset denied"
+    );
+
+    const action = new GrantAndroidPermissions(androidDevice, factory);
+    const result = await action.execute("com.example.app", {
+      action: "reset",
+      permissions: ["all"],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.results).toEqual([
+      {
+        operationId: "pm_reset_permissions",
+        success: false,
+        countsTowardSuccess: true,
+        error: "java.lang.SecurityException: Permission reset denied",
+      },
+    ]);
+    expect(result.error).toContain("pm_reset_permissions");
+  });
+
   test("marks failure when stderr contains SecurityException", async () => {
     const factory = new FakeAdbClientFactory();
     const client = factory.getFakeClient();

--- a/test/features/action/GrantAndroidPermissions.test.ts
+++ b/test/features/action/GrantAndroidPermissions.test.ts
@@ -126,6 +126,30 @@ describe("GrantAndroidPermissions", () => {
     expect(result.error).toContain("pm_reset_permissions");
   });
 
+  test("rejects reset with a target user because it is device-wide", async () => {
+    const factory = new FakeAdbClientFactory();
+    const client = factory.getFakeClient();
+    const action = new GrantAndroidPermissions(androidDevice, factory);
+
+    const result = await action.execute("com.example.app", {
+      action: "reset",
+      permissions: ["all"],
+      userId: 10,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.userId).toBe(0);
+    expect(result.results).toEqual([
+      {
+        operationId: "pm_reset_permissions",
+        success: false,
+        countsTowardSuccess: true,
+        error: "Android reset is device-wide and does not support userId",
+      },
+    ]);
+    expect(client.wasCommandExecuted("shell pm reset-permissions")).toBe(false);
+  });
+
   test("reports a pm reset-permissions failure as a required operation failure", async () => {
     const factory = new FakeAdbClientFactory();
     const client = factory.getFakeClient();

--- a/test/plan/PlanSchemaValidator.test.ts
+++ b/test/plan/PlanSchemaValidator.test.ts
@@ -99,6 +99,9 @@ steps:
   - tool: setAppPermissions
     appId: com.example.app
     scheduleExactAlarm: allow
+  - tool: setAppPermissions
+    appId: com.example.app
+    notificationsEnabled: false
 `;
       const result = validator.validateYaml(yaml);
       expect(result.valid).toBe(true);

--- a/test/plan/PlanSchemaValidator.test.ts
+++ b/test/plan/PlanSchemaValidator.test.ts
@@ -409,6 +409,37 @@ steps:
       expect(result.valid).toBe(false);
     });
 
+    it("should reject inline Android reset with a userId", () => {
+      const yaml = `
+name: invalid-inline-reset-user
+steps:
+  - tool: setAppPermissions
+    appId: com.example.app
+    action: reset
+    permissions:
+      - all
+    userId: 10
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
+    it("should reject nested Android reset with a userId", () => {
+      const yaml = `
+name: invalid-nested-reset-user
+steps:
+  - tool: setAppPermissions
+    params:
+      appId: com.example.app
+      action: reset
+      permissions:
+        - all
+      userId: 10
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
     it("should reject setDeviceState with no state", () => {
       const yaml = `
 name: bad-set-device-state

--- a/test/plan/PlanSchemaValidator.test.ts
+++ b/test/plan/PlanSchemaValidator.test.ts
@@ -440,6 +440,64 @@ steps:
       expect(result.valid).toBe(false);
     });
 
+    it("should reject inline reset without permissions", () => {
+      const yaml = `
+name: invalid-inline-reset-without-permissions
+steps:
+  - tool: setAppPermissions
+    appId: com.example.app
+    action: reset
+    notificationsEnabled: false
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
+    it("should reject nested reset without permissions", () => {
+      const yaml = `
+name: invalid-nested-reset-without-permissions
+steps:
+  - tool: setAppPermissions
+    params:
+      appId: com.example.app
+      action: reset
+      notificationsEnabled: false
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
+    it("should reject inline Android reset without permissions=['all']", () => {
+      const yaml = `
+name: invalid-inline-android-reset-scope
+steps:
+  - tool: setAppPermissions
+    appId: com.example.app
+    action: reset
+    platform: android
+    permissions:
+      - camera
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
+    it("should reject nested Android reset without permissions=['all']", () => {
+      const yaml = `
+name: invalid-nested-android-reset-scope
+steps:
+  - tool: setAppPermissions
+    params:
+      appId: com.example.app
+      action: reset
+      platform: android
+      permissions:
+        - camera
+`;
+      const result = validator.validateYaml(yaml);
+      expect(result.valid).toBe(false);
+    });
+
     it("should reject setDeviceState with no state", () => {
       const yaml = `
 name: bad-set-device-state

--- a/test/server/appTools.listApps.test.ts
+++ b/test/server/appTools.listApps.test.ts
@@ -1,3 +1,4 @@
+import Ajv2020 from "ajv/dist/2020";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { registerAppTools, resetListAppsToolDependencies, setListAppsToolDependencies } from "../../src/server/appTools";
 import { APP_RESOURCE_TEMPLATES, APPS_RESOURCE_URIS } from "../../src/server/appResources";
@@ -152,7 +153,24 @@ describe("app permission tools", () => {
       permissions: ["all"],
       userId: 10,
     })).toThrow();
-    expect(setAppTool?.description).toContain("notification state");
+    expect(() => setAppTool!.schema.parse({
+      appId: "com.example.app",
+      action: "reset",
+      notificationsEnabled: false,
+    })).toThrow();
+    expect(() => setAppTool!.schema.parse({
+      appId: "com.example.app",
+      action: "reset",
+      permissions: ["camera"],
+      platform: "android",
+    })).toThrow();
+    expect(() => setAppTool!.schema.parse({
+      appId: "com.example.app",
+      action: "reset",
+      permissions: ["camera"],
+      platform: "ios",
+    })).not.toThrow();
+    expect(setAppTool?.description).toContain("POST_NOTIFICATIONS");
 
     expect(getAppTool).toBeDefined();
     expect(getAppTool?.requiresDevice).toBe(true);
@@ -172,5 +190,40 @@ describe("app permission tools", () => {
     expect(ToolRegistry.getTool("grantIosSimulatorPermissions")).toBeUndefined();
     expect(ToolRegistry.getTool("setIosSimulatorPermissions")).toBeUndefined();
     expect(ToolRegistry.getTool("getIosSimulatorPermissions")).toBeUndefined();
+  });
+
+  test("advertises reset's required permission and device-wide user scope", () => {
+    const setAppPermissions = ToolRegistry.getToolDefinitions({ includeUnavailable: true })
+      .find(tool => tool.name === "setAppPermissions");
+    const validate = new Ajv2020({ strict: false }).compile(setAppPermissions!.inputSchema);
+
+    expect(validate({
+      appId: "com.example.app",
+      action: "reset",
+      permissions: ["all"],
+    })).toBe(true);
+    expect(validate({
+      appId: "com.example.app",
+      action: "reset",
+      permissions: ["all"],
+      userId: 10,
+    })).toBe(false);
+    expect(validate({
+      appId: "com.example.app",
+      action: "reset",
+      notificationsEnabled: false,
+    })).toBe(false);
+    expect(validate({
+      appId: "com.example.app",
+      action: "reset",
+      permissions: ["camera"],
+      platform: "android",
+    })).toBe(false);
+    expect(validate({
+      appId: "com.example.app",
+      action: "reset",
+      permissions: ["camera"],
+      platform: "ios",
+    })).toBe(true);
   });
 });

--- a/test/server/appTools.listApps.test.ts
+++ b/test/server/appTools.listApps.test.ts
@@ -146,6 +146,12 @@ describe("app permission tools", () => {
       permissions: ["android.permission.POST_NOTIFICATIONS"],
       userId: 10,
     })).not.toThrow();
+    expect(() => setAppTool!.schema.parse({
+      appId: "com.example.app",
+      action: "reset",
+      permissions: ["all"],
+      userId: 10,
+    })).toThrow();
     expect(setAppTool?.description).toContain("notification state");
 
     expect(getAppTool).toBeDefined();

--- a/test/server/appTools.listApps.test.ts
+++ b/test/server/appTools.listApps.test.ts
@@ -139,9 +139,14 @@ describe("app permission tools", () => {
     })).not.toThrow();
     expect(() => setAppTool!.schema.parse({
       appId: "com.example.app",
+      notificationsEnabled: false,
+    })).not.toThrow();
+    expect(() => setAppTool!.schema.parse({
+      appId: "com.example.app",
       permissions: ["android.permission.POST_NOTIFICATIONS"],
       userId: 10,
     })).not.toThrow();
+    expect(setAppTool?.description).toContain("notification state");
 
     expect(getAppTool).toBeDefined();
     expect(getAppTool?.requiresDevice).toBe(true);


### PR DESCRIPTION
## Summary

- Add Android `setAppPermissions` support for `revoke` and device-wide `reset`.
- Require `permissions: ["all"]` for `pm reset-permissions` and document its scope.
- Add independent Android notification enable/disable control through `notificationsEnabled`.
- Keep operation accounting consistent across runtime permissions and notification changes.

## Root Cause

The public permission schema exposed `grant`, `revoke`, and `reset`, but the Android implementation rejected every action other than `grant`.

## Validation

- `bun run typecheck`
- `bun run turbo:validate` (`9,842` passed; `14` device/integration tests skipped)

Closes [#4451](https://github.com/kaeawc/auto-mobile/issues/4451)
