### PR TITLE
test(observe-ctrlproxy): cover CA certificate file install

### DIFF
--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -101,7 +101,7 @@ import { CtrlProxyGestures } from "./CtrlProxyGestures";
 import { CtrlProxyText } from "./CtrlProxyText";
 import { CtrlProxyHierarchy } from "./CtrlProxyHierarchy";
 import { CtrlProxyStorage } from "./CtrlProxyStorage";
-import { CtrlProxyCertificates } from "./CtrlProxyCertificates";
+import { CtrlProxyCertificates, type CertificateFileSystem } from "./CtrlProxyCertificates";
 import { CtrlProxyFocus } from "./CtrlProxyFocus";
 import { CtrlProxyHighlights } from "./CtrlProxyHighlights";
 import { CtrlProxyPackages, type PackageInfoOptions } from "./CtrlProxyPackages";
@@ -938,6 +938,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
 
   private readonly crashEventSink: CrashEventSink;
   private readonly deviceConnectionLostNotifier: DeviceConnectionLostNotifier;
+  private readonly certificateFileSystem: CertificateFileSystem | undefined;
 
   /**
    * Owns SDK telemetry/crash/ANR ingestion (issue #2764). Lazily built so it can
@@ -963,7 +964,8 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     crashEventSink?: CrashEventSink,
     deviceConnectionLostNotifier?: DeviceConnectionLostNotifier,
     sdkEventIngestor?: AndroidSdkEventIngestor,
-    loggerInstance: Logger = logger
+    loggerInstance: Logger = logger,
+    certificateFileSystem?: CertificateFileSystem
   ) {
     super(timer ?? defaultTimer, webSocketFactory ?? defaultWebSocketFactory, {}, retryExecutor ?? defaultRetryExecutor);
     this.sdkEventIngestorInstance = sdkEventIngestor ?? null;
@@ -974,6 +976,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     this.crashEventSink = crashEventSink ?? new FailureEventRepository();
     this.deviceConnectionLostNotifier =
       deviceConnectionLostNotifier ?? observationStreamDeviceConnectionLostNotifier;
+    this.certificateFileSystem = certificateFileSystem;
     this.localPort = PortManager.allocate(device.deviceId, {
       reservedPorts: IOS_CTRL_PROXY_RESERVED_PORTS,
     });
@@ -1088,7 +1091,8 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     crashEventSink?: CrashEventSink,
     deviceConnectionLostNotifier?: DeviceConnectionLostNotifier,
     sdkEventIngestor?: AndroidSdkEventIngestor,
-    loggerInstance?: Logger
+    loggerInstance?: Logger,
+    certificateFileSystem?: CertificateFileSystem
   ): AndroidCtrlProxyClient {
     return new AndroidCtrlProxyClient(
       device,
@@ -1100,7 +1104,8 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       crashEventSink,
       deviceConnectionLostNotifier,
       sdkEventIngestor,
-      loggerInstance
+      loggerInstance,
+      certificateFileSystem
     );
   }
 
@@ -1171,7 +1176,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
 
   private get certificates(): CtrlProxyCertificates {
     if (!this._certificates) {
-      this._certificates = new CtrlProxyCertificates(this.createCertificatesDelegateContext());
+      this._certificates = new CtrlProxyCertificates(
+        this.createCertificatesDelegateContext(),
+        this.certificateFileSystem
+      );
     }
     return this._certificates;
   }

--- a/src/features/observe/android/CtrlProxyCertificates.ts
+++ b/src/features/observe/android/CtrlProxyCertificates.ts
@@ -24,18 +24,28 @@ import { ctrlProxyRequests, serializeCtrlProxyRequest } from "./ctrlProxyProtoco
 /** Directory on device for pushing certificate files */
 const DEVICE_CERT_DIR = "/sdcard/Download/automobile/ca_certs";
 
+export interface CertificateFileSystem {
+  stat(filePath: string): Promise<{ size: number; isFile(): boolean }>;
+}
+
+const nodeCertificateFileSystem: CertificateFileSystem = {
+  stat: filePath => fs.stat(filePath),
+};
+
 /**
  * Delegate class for handling CA certificate and permission operations.
  */
 export class CtrlProxyCertificates {
   private readonly context: CertificatesDelegateContext;
+  private readonly fileSystem: CertificateFileSystem;
 
   // Legacy pending request state for CA cert removal (still uses manual promise pattern)
   private pendingCaCertRequestId: string | null = null;
   private pendingCaCertResolve: ((result: A11yCaCertResult) => void) | null = null;
 
-  constructor(context: CertificatesDelegateContext) {
+  constructor(context: CertificatesDelegateContext, fileSystem: CertificateFileSystem = nodeCertificateFileSystem) {
     this.context = context;
+    this.fileSystem = fileSystem;
   }
 
   /**
@@ -142,7 +152,7 @@ export class CtrlProxyCertificates {
     }
 
     try {
-      const stats = await fs.stat(resolvedPath);
+      const stats = await this.fileSystem.stat(resolvedPath);
       if (!stats.isFile()) {
         return {
           success: false,

--- a/src/features/observe/android/CtrlProxyCertificates.ts
+++ b/src/features/observe/android/CtrlProxyCertificates.ts
@@ -12,6 +12,7 @@ import { fileURLToPath } from "node:url";
 import { logger } from "../../../utils/logger";
 import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
 import { NoOpPerformanceTracker } from "../../../utils/PerformanceTracker";
+import { resolvePathFromDaemonLaunchWorkingDirectory } from "../../../utils/workingDirectory";
 import type {
   CertificatesDelegateContext,
   A11yCaCertResult,
@@ -528,7 +529,7 @@ export class CtrlProxyCertificates {
       return null;
     }
 
-    return path.resolve(trimmedPath);
+    return resolvePathFromDaemonLaunchWorkingDirectory(trimmedPath);
   }
 
   /**

--- a/test/features/observe/android/CtrlProxyCertificates.test.ts
+++ b/test/features/observe/android/CtrlProxyCertificates.test.ts
@@ -10,6 +10,8 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { AndroidCtrlProxyClient } from "../../../../src/features/observe/android";
 import { NavigationGraphManager } from "../../../../src/features/navigation/NavigationGraphManager";
 import { FakeAdbExecutor } from "../../../fakes/FakeAdbExecutor";
@@ -282,6 +284,11 @@ describe("CtrlProxyCertificates (Android)", function() {
   // ===========================================================================
 
   describe("requestInstallCaCertificateFromFile", function() {
+    const relativeCertificatePath = path.join("fixtures", "certs", "relative ca.crt");
+    const daemonLaunchCwd = path.join(process.cwd(), "tmp", "automobile-launch");
+    const relativeResolvedPath = path.join(daemonLaunchCwd, relativeCertificatePath);
+    const fileUrlResolvedPath = path.join(process.cwd(), "tmp", "automobile ca.crt");
+
     test("rejects an empty path without touching the device", async function() {
       const { client, socket } = await connectClient();
       try {
@@ -336,14 +343,14 @@ describe("CtrlProxyCertificates (Android)", function() {
     test.each([
       {
         name: "a relative path from the daemon launch directory",
-        certificatePath: "fixtures/certs/relative ca.crt",
-        resolvedPath: "/tmp/automobile-launch/fixtures/certs/relative ca.crt",
-        daemonLaunchCwd: "/tmp/automobile-launch",
+        certificatePath: relativeCertificatePath,
+        resolvedPath: relativeResolvedPath,
+        daemonLaunchCwd,
       },
       {
         name: "a file URL",
-        certificatePath: "file:///tmp/automobile%20ca.crt",
-        resolvedPath: "/tmp/automobile ca.crt",
+        certificatePath: pathToFileURL(fileUrlResolvedPath).href,
+        resolvedPath: fileUrlResolvedPath,
         daemonLaunchCwd: undefined,
       },
     ])("pushes $name and resolves the install result over the wire", async function({

--- a/test/features/observe/android/CtrlProxyCertificates.test.ts
+++ b/test/features/observe/android/CtrlProxyCertificates.test.ts
@@ -10,7 +10,6 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import path from "node:path";
 import { AndroidCtrlProxyClient } from "../../../../src/features/observe/android";
 import { NavigationGraphManager } from "../../../../src/features/navigation/NavigationGraphManager";
 import { FakeAdbExecutor } from "../../../fakes/FakeAdbExecutor";
@@ -20,6 +19,7 @@ import { BootedDevice } from "../../../../src/models";
 import { FakeWebSocket, WebSocketState, createInstantFailureWebSocketFactory } from "../../../fakes/FakeWebSocket";
 import { FakeTimer } from "../../../fakes/FakeTimer";
 import { PortManager } from "../../../../src/utils/PortManager";
+import { DAEMON_LAUNCH_CWD_ENV } from "../../../../src/utils/workingDirectory";
 
 describe("CtrlProxyCertificates (Android)", function() {
   let fakeAdb: FakeAdbExecutor;
@@ -335,48 +335,67 @@ describe("CtrlProxyCertificates (Android)", function() {
 
     test.each([
       {
-        name: "a relative path",
+        name: "a relative path from the daemon launch directory",
         certificatePath: "fixtures/certs/relative ca.crt",
-        resolvedPath: path.resolve("fixtures/certs/relative ca.crt"),
+        resolvedPath: "/tmp/automobile-launch/fixtures/certs/relative ca.crt",
+        daemonLaunchCwd: "/tmp/automobile-launch",
       },
       {
         name: "a file URL",
         certificatePath: "file:///tmp/automobile%20ca.crt",
         resolvedPath: "/tmp/automobile ca.crt",
+        daemonLaunchCwd: undefined,
       },
-    ])("pushes $name and resolves the install result over the wire", async function({ certificatePath, resolvedPath }) {
-      const fakeFileSystem = new FakeCertificateFileSystem();
-      fakeFileSystem.setFile(resolvedPath, 128);
-      const { client, socket } = await connectClient(fakeFileSystem);
+    ])("pushes $name and resolves the install result over the wire", async function({
+      certificatePath,
+      resolvedPath,
+      daemonLaunchCwd,
+    }) {
+      const previousLaunchCwd = process.env[DAEMON_LAUNCH_CWD_ENV];
+      if (daemonLaunchCwd !== undefined) {
+        process.env[DAEMON_LAUNCH_CWD_ENV] = daemonLaunchCwd;
+      }
+
       try {
-        const baseCount = socket.sentMessages.length;
-        const resultPromise = client.requestInstallCaCertificateFromFile(certificatePath);
-        await waitForSentMessages(socket, baseCount + 1);
+        const fakeFileSystem = new FakeCertificateFileSystem();
+        fakeFileSystem.setFile(resolvedPath, 128);
+        const { client, socket } = await connectClient(fakeFileSystem);
+        try {
+          const baseCount = socket.sentMessages.length;
+          const resultPromise = client.requestInstallCaCertificateFromFile(certificatePath);
+          await waitForSentMessages(socket, baseCount + 1);
 
-        const sent = findSentMessage(socket, "install_ca_cert_from_path");
-        expect(fakeFileSystem.statCalls).toEqual([resolvedPath]);
+          const sent = findSentMessage(socket, "install_ca_cert_from_path");
+          expect(fakeFileSystem.statCalls).toEqual([resolvedPath]);
 
-        const push = fakeAdb.getExecutedCommands().find(command => command.startsWith("push "));
-        expect(push).toContain(`"${resolvedPath}"`);
-        expect(push).toEndWith(`"${sent.devicePath}"`);
+          const push = fakeAdb.getExecutedCommands().find(command => command.startsWith("push "));
+          expect(push).toContain(`"${resolvedPath}"`);
+          expect(push).toEndWith(`"${sent.devicePath}"`);
 
-        socket.simulateMessage(JSON.stringify({
-          type: "ca_cert_result",
-          requestId: sent.requestId,
-          success: true,
-          action: "install",
-          alias: "user-ca-cert",
-          totalTimeMs: 3,
-        }));
+          socket.simulateMessage(JSON.stringify({
+            type: "ca_cert_result",
+            requestId: sent.requestId,
+            success: true,
+            action: "install",
+            alias: "user-ca-cert",
+            totalTimeMs: 3,
+          }));
 
-        const result = await resultPromise;
-        expect(result).toMatchObject({
-          success: true,
-          action: "install",
-          alias: "user-ca-cert",
-        });
+          const result = await resultPromise;
+          expect(result).toMatchObject({
+            success: true,
+            action: "install",
+            alias: "user-ca-cert",
+          });
+        } finally {
+          await client.close();
+        }
       } finally {
-        await client.close();
+        if (previousLaunchCwd === undefined) {
+          delete process.env[DAEMON_LAUNCH_CWD_ENV];
+        } else {
+          process.env[DAEMON_LAUNCH_CWD_ENV] = previousLaunchCwd;
+        }
       }
     });
 

--- a/test/features/observe/android/CtrlProxyCertificates.test.ts
+++ b/test/features/observe/android/CtrlProxyCertificates.test.ts
@@ -376,7 +376,7 @@ describe("CtrlProxyCertificates (Android)", function() {
           expect(fakeFileSystem.statCalls).toEqual([resolvedPath]);
 
           const push = fakeAdb.getExecutedCommands().find(command => command.startsWith("push "));
-          expect(push).toContain(`"${resolvedPath}"`);
+          expect(push?.replace(/\\\\/g, "\\")).toContain(`"${resolvedPath}"`);
           expect(push).toEndWith(`"${sent.devicePath}"`);
 
           socket.simulateMessage(JSON.stringify({

--- a/test/features/observe/android/CtrlProxyCertificates.test.ts
+++ b/test/features/observe/android/CtrlProxyCertificates.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import path from "node:path";
 import { AndroidCtrlProxyClient } from "../../../../src/features/observe/android";
 import { NavigationGraphManager } from "../../../../src/features/navigation/NavigationGraphManager";
 import { FakeAdbExecutor } from "../../../fakes/FakeAdbExecutor";
@@ -18,6 +19,7 @@ import { FakeAdbClientFactory } from "../../../fakes/FakeAdbClientFactory";
 import { BootedDevice } from "../../../../src/models";
 import { FakeWebSocket, WebSocketState, createInstantFailureWebSocketFactory } from "../../../fakes/FakeWebSocket";
 import { FakeTimer } from "../../../fakes/FakeTimer";
+import { PortManager } from "../../../../src/utils/PortManager";
 
 describe("CtrlProxyCertificates (Android)", function() {
   let fakeAdb: FakeAdbExecutor;
@@ -29,6 +31,7 @@ describe("CtrlProxyCertificates (Android)", function() {
 
   beforeEach(function() {
     fakeTimer = new FakeTimer();
+    PortManager.setPortAvailabilityCheckerForTesting({ isPortAvailable: () => true });
 
     fakeAdb = new FakeAdbExecutor();
     fakeAdb.setCommandResponse("forward", { stdout: `${serverPort}`, stderr: "" });
@@ -48,6 +51,7 @@ describe("CtrlProxyCertificates (Android)", function() {
 
   afterEach(function() {
     NavigationGraphManager.getInstance();
+    PortManager.setPortAvailabilityCheckerForTesting(null);
   });
 
   class CapturingWebSocket extends FakeWebSocket {
@@ -55,6 +59,27 @@ describe("CtrlProxyCertificates (Android)", function() {
     send(data: any): void {
       this.sentMessages.push(data.toString());
       super.send(data);
+    }
+  }
+
+  class FakeCertificateFileSystem {
+    readonly statCalls: string[] = [];
+    private readonly files = new Map<string, { size: number; isFile: boolean }>();
+
+    setFile(filePath: string, size: number, isFile = true): void {
+      this.files.set(filePath, { size, isFile });
+    }
+
+    async stat(filePath: string): Promise<{ size: number; isFile(): boolean }> {
+      this.statCalls.push(filePath);
+      const file = this.files.get(filePath);
+      if (!file) {
+        throw new Error(`File not found: ${filePath}`);
+      }
+      return {
+        size: file.size,
+        isFile: () => file.isFile,
+      };
     }
   }
 
@@ -122,12 +147,24 @@ describe("CtrlProxyCertificates (Android)", function() {
     });
 
   /** Connect a capturing client and return the client + its socket. */
-  const connectClient = async (): Promise<{
+  const connectClient = async (certificateFileSystem?: FakeCertificateFileSystem): Promise<{
     client: AndroidCtrlProxyClient;
     socket: CapturingWebSocket;
   }> => {
     const { factory, getSocket } = createCapturingFactory(fakeTimer);
-    const client = AndroidCtrlProxyClient.createForTesting(testDevice, fakeAdb, factory, fakeTimer);
+    const client = AndroidCtrlProxyClient.createForTesting(
+      testDevice,
+      fakeAdb,
+      factory,
+      fakeTimer,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      certificateFileSystem
+    );
     await client.ensureConnected();
     const socket = await waitForSocket(getSocket);
     await waitForSocketOpen(socket);
@@ -290,6 +327,71 @@ describe("CtrlProxyCertificates (Android)", function() {
         expect(result.success).toBe(false);
         // Never pushed the file and never asked the runner to install it.
         expect(fakeAdb.getExecutedCommands().some(c => c.startsWith("push"))).toBe(false);
+        expect(hasSentMessage(socket, "install_ca_cert_from_path")).toBe(false);
+      } finally {
+        await client.close();
+      }
+    });
+
+    test.each([
+      {
+        name: "a relative path",
+        certificatePath: "fixtures/certs/relative ca.crt",
+        resolvedPath: path.resolve("fixtures/certs/relative ca.crt"),
+      },
+      {
+        name: "a file URL",
+        certificatePath: "file:///tmp/automobile%20ca.crt",
+        resolvedPath: "/tmp/automobile ca.crt",
+      },
+    ])("pushes $name and resolves the install result over the wire", async function({ certificatePath, resolvedPath }) {
+      const fakeFileSystem = new FakeCertificateFileSystem();
+      fakeFileSystem.setFile(resolvedPath, 128);
+      const { client, socket } = await connectClient(fakeFileSystem);
+      try {
+        const baseCount = socket.sentMessages.length;
+        const resultPromise = client.requestInstallCaCertificateFromFile(certificatePath);
+        await waitForSentMessages(socket, baseCount + 1);
+
+        const sent = findSentMessage(socket, "install_ca_cert_from_path");
+        expect(fakeFileSystem.statCalls).toEqual([resolvedPath]);
+
+        const push = fakeAdb.getExecutedCommands().find(command => command.startsWith("push "));
+        expect(push).toContain(`"${resolvedPath}"`);
+        expect(push).toEndWith(`"${sent.devicePath}"`);
+
+        socket.simulateMessage(JSON.stringify({
+          type: "ca_cert_result",
+          requestId: sent.requestId,
+          success: true,
+          action: "install",
+          alias: "user-ca-cert",
+          totalTimeMs: 3,
+        }));
+
+        const result = await resultPromise;
+        expect(result).toMatchObject({
+          success: true,
+          action: "install",
+          alias: "user-ca-cert",
+        });
+      } finally {
+        await client.close();
+      }
+    });
+
+    test("rejects an empty certificate file before pushing or sending a wire request", async function() {
+      const resolvedPath = "/tmp/empty-ca.crt";
+      const fakeFileSystem = new FakeCertificateFileSystem();
+      fakeFileSystem.setFile(resolvedPath, 0);
+      const { client, socket } = await connectClient(fakeFileSystem);
+      try {
+        const result = await client.requestInstallCaCertificateFromFile(resolvedPath);
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("Certificate file is empty");
+        expect(fakeFileSystem.statCalls).toEqual([resolvedPath]);
+        expect(fakeAdb.getExecutedCommands().some(command => command.startsWith("push "))).toBe(false);
         expect(hasSentMessage(socket, "install_ca_cert_from_path")).toBe(false);
       } finally {
         await client.close();


### PR DESCRIPTION
## Summary

Inject a narrow certificate-file stat interface into the Android CtrlProxy certificate delegate. The default remains Node's `fs.promises.stat`; test clients can provide a fake without touching the host filesystem. Relative certificate paths resolve from the daemon launch directory rather than its stable post-start working directory.

Extend the wire-driven certificate tests to cover relative paths, `file://` URLs, ADB push arguments, the `install_ca_cert_from_path` request/result exchange, and zero-byte-file rejection.

## Linked Issue

Closes [#4447](https://github.com/kaeawc/auto-mobile/issues/4447)

## Bug / Regression Context

- **Prior attempts:** [#4445](https://github.com/kaeawc/auto-mobile/pull/4445) added the certificate wire tests but deliberately stopped before the valid-file path because it would require a real filesystem file.
- **Observed symptom:** Direct `fs.stat` prevented a unit test from exercising the valid-file and zero-byte branches; relative paths were also incorrectly resolved after the daemon changed its current working directory.
- **Repro steps / conditions:** Invoke `requestInstallCaCertificateFromFile` with a syntactically valid relative path or `file://` URL after setting a daemon launch directory distinct from the current working directory.

## Validation

- [x] `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-4447-turbo bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors (211 known baseline errors)
- [x] `bun run lint`
- [x] `bun run build`
- [x] `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-4447-test bun test test/features/observe/android/CtrlProxyCertificates.test.ts`
- [x] New code uses an injected interface and fake; the focused suite is deterministic and sub-100ms per test
