### PR TITLE
test(models): property-based tests for toActionableError

### DIFF
--- a/test/models/ActionableError.property.test.ts
+++ b/test/models/ActionableError.property.test.ts
@@ -1,0 +1,81 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import { ActionableError, toActionableError } from "../../src/models/ActionableError";
+
+// Property-based tests. See test/utils/Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+const context = fc.string({ maxLength: 40 });
+// Arbitrary caught values that are NOT already actionable: primitives, plain
+// objects, and plain Errors (which take the wrapping branch).
+const nonActionable = fc.oneof(
+  fc.string(),
+  fc.integer(),
+  fc.double({ noNaN: true }),
+  fc.boolean(),
+  fc.constant(null),
+  fc.constant(undefined),
+  fc.object(),
+  fc.string().map(m => new Error(m))
+);
+
+describe("toActionableError (property-based)", () => {
+  test("always returns an ActionableError for any caught value (totality)", () => {
+    fc.assert(
+      fc.property(fc.anything(), context, (error, ctx) => {
+        const result = toActionableError(error, ctx);
+        return result instanceof ActionableError && result instanceof Error;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("passes an already-actionable error through unchanged, ignoring context", () => {
+    fc.assert(
+      fc.property(fc.string({ maxLength: 40 }), context, (message, ctx) => {
+        const original = new ActionableError(message);
+        const result = toActionableError(original, ctx);
+        return result === original && result.message === message;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("wraps a plain Error as `context: message`", () => {
+    fc.assert(
+      fc.property(fc.string({ maxLength: 40 }), context, (message, ctx) => {
+        return toActionableError(new Error(message), ctx).message === `${ctx}: ${message}`;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("wraps a non-Error value as `context: String(value)`", () => {
+    const nonError = fc.oneof(fc.string(), fc.integer(), fc.boolean(), fc.constant(null), fc.constant(undefined), fc.object());
+    fc.assert(
+      fc.property(nonError, context, (value, ctx) => {
+        return toActionableError(value, ctx).message === `${ctx}: ${String(value)}`;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("the result is a fixed point — re-wrapping never doubles the context", () => {
+    fc.assert(
+      fc.property(fc.anything(), context, context, (error, c1, c2) => {
+        const once = toActionableError(error, c1);
+        return toActionableError(once, c2) === once;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("a wrapped (non-actionable) value's message starts with its context prefix", () => {
+    fc.assert(
+      fc.property(nonActionable, context, (error, ctx) => {
+        return toActionableError(error, ctx).message.startsWith(`${ctx}: `);
+      }),
+      RUN_OPTIONS
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Continues the fast-check property-testing expansion (pattern from [PR #4427](https://github.com/kaeawc/auto-mobile/pull/4427); prior suites merged in [#4434](https://github.com/kaeawc/auto-mobile/pull/4434), [#4438](https://github.com/kaeawc/auto-mobile/pull/4438), [#4440](https://github.com/kaeawc/auto-mobile/pull/4440), [#4441](https://github.com/kaeawc/auto-mobile/pull/4441), [#4442](https://github.com/kaeawc/auto-mobile/pull/4442), [#4443](https://github.com/kaeawc/auto-mobile/pull/4443), [#4444](https://github.com/kaeawc/auto-mobile/pull/4444), [#4448](https://github.com/kaeawc/auto-mobile/pull/4448), [#4450](https://github.com/kaeawc/auto-mobile/pull/4450); open in [#4446](https://github.com/kaeawc/auto-mobile/pull/4446), [#4452](https://github.com/kaeawc/auto-mobile/pull/4452)) with `toActionableError` — the wrapper that backs the repo's error-handling convention (see `CLAUDE.md`). Test-only, additive — no production changes, no new dependencies. Co-located at `test/models/ActionableError.property.test.ts` beside the existing example-based suite.

Invariants asserted:

- **Totality** — always returns an `ActionableError` (and `Error`) for any caught value, never throwing (even for symbols, `null`, plain objects).
- **Passthrough identity** — an already-actionable error is returned by reference unchanged, ignoring `context`.
- **Message composition** — a plain `Error` wraps as `` `${context}: ${message}` ``; a non-Error value wraps as `` `${context}: ${String(value)}` ``.
- **Fixed point** — re-wrapping the result never doubles the context (`toActionableError(toActionableError(e, c1), c2) === toActionableError(e, c1)`), the documented "context isn't doubled up" guarantee.
- **Context prefix** — a wrapped (non-actionable) value's message starts with `` `${context}: ` ``.

No defects surfaced.

## Validation

- [x] `bun test test/models/ActionableError.property.test.ts` — 6 pass, ~150ms
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run lint` — no new violations
- [x] New tests are pure (no device/network/filesystem/DB); each runs in <100ms

## Follow-ups

- [ ] The pure, self-contained function surface is now largely exhausted; remaining candidates operate on full `ObserveResult` hierarchies and are better suited to example-based fixtures than property-based generators.
