### PR TITLE
fix(desktop-core): version-match daemon lifecycle

### DIFF
--- a/android/desktop-core/build.gradle.kts
+++ b/android/desktop-core/build.gradle.kts
@@ -1,3 +1,5 @@
+import groovy.json.JsonSlurper
+
 plugins {
   kotlin("jvm")
   alias(libs.plugins.kotlin.serialization)
@@ -13,6 +15,17 @@ repositories {
 
 java {
   toolchain { languageVersion.set(JavaLanguageVersion.of(libs.versions.build.java.target.get())) }
+}
+
+// Keep the desktop socket client's handshake version aligned with the daemon package it launches.
+// Resolve from this project directory because desktop-core also builds under android/ide-plugin.
+val npmPackageVersion =
+  providers.fileContents(layout.projectDirectory.file("../../package.json")).asText.map { packageJson ->
+    (JsonSlurper().parseText(packageJson) as Map<*, *>)["version"].toString()
+  }
+
+tasks.named<Jar>("jar") {
+  manifest { attributes("Implementation-Version" to npmPackageVersion.get()) }
 }
 
 sourceSets {

--- a/android/desktop-core/build.gradle.kts
+++ b/android/desktop-core/build.gradle.kts
@@ -20,8 +20,10 @@ java {
 // Keep the desktop socket client's handshake version aligned with the daemon package it launches.
 // Resolve from this project directory because desktop-core also builds under android/ide-plugin.
 val npmPackageVersion =
-  providers.fileContents(layout.projectDirectory.file("../../package.json")).asText.map { packageJson ->
-    (JsonSlurper().parseText(packageJson) as Map<*, *>)["version"].toString()
+  providers.fileContents(layout.projectDirectory.file("../../package.json")).asText.map {
+    packageJson ->
+    val version = (JsonSlurper().parseText(packageJson) as Map<*, *>)["version"] as? String
+    requireNotNull(version) { "package.json is missing a \"version\" field" }
   }
 
 tasks.named<Jar>("jar") {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/McpProcessesPanel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/McpProcessesPanel.kt
@@ -32,8 +32,8 @@ import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import dev.jasonpearson.automobile.desktop.core.daemon.DaemonNotificationClient
 import dev.jasonpearson.automobile.desktop.core.daemon.DaemonLifecycleResult
+import dev.jasonpearson.automobile.desktop.core.daemon.DaemonNotificationClient
 import dev.jasonpearson.automobile.desktop.core.daemon.DaemonSocketPaths
 import dev.jasonpearson.automobile.desktop.core.daemon.DesktopDaemonLifecycle
 import dev.jasonpearson.automobile.desktop.core.daemon.McpDaemonClient
@@ -173,12 +173,19 @@ internal fun McpProcessesPanel(
         process.connectionType == McpConnectionType.UnixSocket &&
           process.socketPath == DaemonSocketPaths.socketPath()
       ) {
-        when (val result = withContext(Dispatchers.IO) {
-          DesktopDaemonLifecycle().ensureVersionMatchedDaemon()
-        }) {
+        devicesLoading = true
+        bootedDevices = emptyList()
+        deviceImages = emptyList()
+        when (
+          val result =
+            withContext(Dispatchers.IO) {
+              DesktopDaemonLifecycle().ensureVersionMatchedDaemon()
+            }
+        ) {
           is DaemonLifecycleResult.Failure -> {
             daemonStartError = result.message
             devicesError = result.message
+            devicesLoading = false
             return@LaunchedEffect
           }
           is DaemonLifecycleResult.Ready -> Unit
@@ -319,9 +326,12 @@ internal fun McpProcessesPanel(
     if (isDaemonStarting) {
       try {
         LOG.debug("[AutoMobile IDE] Starting daemon...")
-        when (val result = withContext(Dispatchers.IO) {
-          DesktopDaemonLifecycle().ensureVersionMatchedDaemon()
-        }) {
+        when (
+          val result =
+            withContext(Dispatchers.IO) {
+              DesktopDaemonLifecycle().ensureVersionMatchedDaemon()
+            }
+        ) {
           is DaemonLifecycleResult.Ready -> {
             LOG.debug("[AutoMobile IDE] Daemon started with a matching version")
             refreshCounter++

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/McpProcessesPanel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/McpProcessesPanel.kt
@@ -33,6 +33,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.jasonpearson.automobile.desktop.core.daemon.DaemonNotificationClient
+import dev.jasonpearson.automobile.desktop.core.daemon.DaemonLifecycleResult
+import dev.jasonpearson.automobile.desktop.core.daemon.DaemonSocketPaths
+import dev.jasonpearson.automobile.desktop.core.daemon.DesktopDaemonLifecycle
 import dev.jasonpearson.automobile.desktop.core.daemon.McpDaemonClient
 import dev.jasonpearson.automobile.desktop.core.daemon.McpHttpClient
 import dev.jasonpearson.automobile.desktop.core.daemon.McpResource
@@ -45,6 +48,7 @@ import dev.jasonpearson.automobile.desktop.core.mcp.RealMcpProcessDetector
 import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 // Test result state
 data class TestResult(
@@ -165,6 +169,21 @@ internal fun McpProcessesPanel(
   LaunchedEffect(connectedProcess) {
     val process = connectedProcess
     if (process != null) {
+      if (
+        process.connectionType == McpConnectionType.UnixSocket &&
+          process.socketPath == DaemonSocketPaths.socketPath()
+      ) {
+        when (val result = withContext(Dispatchers.IO) {
+          DesktopDaemonLifecycle().ensureVersionMatchedDaemon()
+        }) {
+          is DaemonLifecycleResult.Failure -> {
+            daemonStartError = result.message
+            devicesError = result.message
+            return@LaunchedEffect
+          }
+          is DaemonLifecycleResult.Ready -> Unit
+        }
+      }
       devicesLoading = true
       devicesError = null
       try {
@@ -300,22 +319,17 @@ internal fun McpProcessesPanel(
     if (isDaemonStarting) {
       try {
         LOG.debug("[AutoMobile IDE] Starting daemon...")
-        val processBuilder = ProcessBuilder("auto-mobile", "--daemon", "start")
-        processBuilder.redirectErrorStream(true)
-        val process = processBuilder.start()
-
-        // Read output
-        val output = process.inputStream.bufferedReader().readText()
-        val exitCode = process.waitFor()
-
-        if (exitCode == 0) {
-          LOG.debug("[AutoMobile IDE] Daemon started successfully")
-          // Wait a bit for daemon to initialize, then refresh
-          kotlinx.coroutines.delay(2000)
-          refreshCounter++
-        } else {
-          LOG.debug("[AutoMobile IDE] Daemon start failed with exit code $exitCode: $output")
-          daemonStartError = "Failed to start daemon (exit code $exitCode)"
+        when (val result = withContext(Dispatchers.IO) {
+          DesktopDaemonLifecycle().ensureVersionMatchedDaemon()
+        }) {
+          is DaemonLifecycleResult.Ready -> {
+            LOG.debug("[AutoMobile IDE] Daemon started with a matching version")
+            refreshCounter++
+          }
+          is DaemonLifecycleResult.Failure -> {
+            LOG.debug("[AutoMobile IDE] Daemon start failed: ${result.message}")
+            daemonStartError = result.message
+          }
         }
       } catch (e: Exception) {
         LOG.debug("[AutoMobile IDE] Exception starting daemon: ${e.message}")

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/McpProcessesPanel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/McpProcessesPanel.kt
@@ -48,6 +48,7 @@ import dev.jasonpearson.automobile.desktop.core.mcp.RealMcpProcessDetector
 import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
 
 // Test result state
@@ -178,7 +179,7 @@ internal fun McpProcessesPanel(
         deviceImages = emptyList()
         when (
           val result =
-            withContext(Dispatchers.IO) {
+            runInterruptible(Dispatchers.IO) {
               DesktopDaemonLifecycle().ensureVersionMatchedDaemon()
             }
         ) {
@@ -328,7 +329,7 @@ internal fun McpProcessesPanel(
         LOG.debug("[AutoMobile IDE] Starting daemon...")
         when (
           val result =
-            withContext(Dispatchers.IO) {
+            runInterruptible(Dispatchers.IO) {
               DesktopDaemonLifecycle().ensureVersionMatchedDaemon()
             }
         ) {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -131,17 +131,45 @@ internal interface DaemonCommandExecutor {
 internal object SystemDaemonCommandExecutor : DaemonCommandExecutor {
   override fun execute(command: List<String>): DaemonCommandResult {
     val process = ProcessBuilder(command).redirectErrorStream(true).start()
+    val output = StringBuffer()
+    val outputDrainer = Thread {
+      process.inputStream.bufferedReader().useLines { lines ->
+        lines.forEach { line -> output.appendLine(line) }
+      }
+    }
+      .apply {
+        isDaemon = true
+        start()
+      }
     if (!process.waitFor(COMMAND_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
       process.destroy()
       if (!process.waitFor(TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
         process.destroyForcibly()
         process.waitFor(TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)
       }
-      val output = process.inputStream.bufferedReader().use { it.readText() }
-      return DaemonCommandResult(exitCode = TIMEOUT_EXIT_CODE, output = output, timedOut = true)
+      return DaemonCommandResult(
+        exitCode = TIMEOUT_EXIT_CODE,
+        output = drainOutput(process, outputDrainer, output),
+        timedOut = true,
+      )
     }
-    val output = process.inputStream.bufferedReader().use { it.readText() }
-    return DaemonCommandResult(exitCode = process.exitValue(), output = output)
+    return DaemonCommandResult(
+      exitCode = process.exitValue(),
+      output = drainOutput(process, outputDrainer, output),
+    )
+  }
+
+  private fun drainOutput(
+    process: Process,
+    outputDrainer: Thread,
+    output: StringBuffer,
+  ): String {
+    outputDrainer.join(TERMINATION_TIMEOUT_SECONDS * 1_000)
+    if (outputDrainer.isAlive) {
+      process.inputStream.close()
+      outputDrainer.join(TERMINATION_TIMEOUT_SECONDS * 1_000)
+    }
+    return output.toString()
   }
 
   private const val COMMAND_TIMEOUT_SECONDS = 60L
@@ -259,7 +287,7 @@ internal class DesktopDaemonLifecycle(
       "@kaeawc/auto-mobile@${DaemonSocketPaths.releaseVersion(version)}",
       "--daemon",
       action,
-    ) + if (action == "restart") existingOptions else emptyList()
+    ) + existingOptions
 
   private fun versionsMatch(
     actualVersion: String?,

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -1,0 +1,164 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import java.io.File
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+internal interface DaemonSocketChecker {
+  fun exists(): Boolean
+}
+
+internal class FileDaemonSocketChecker(
+  private val socketPath: String = DaemonSocketPaths.socketPath(),
+) : DaemonSocketChecker {
+  override fun exists(): Boolean = File(socketPath).exists()
+}
+
+internal interface DaemonPidFileReader {
+  fun readVersion(): String?
+}
+
+internal class JsonDaemonPidFileReader(
+  private val pidFilePath: String = DaemonSocketPaths.pidFilePath(),
+  private val json: Json = DaemonJson,
+) : DaemonPidFileReader {
+  override fun readVersion(): String? {
+    return try {
+      val pidFile = File(pidFilePath)
+      if (!pidFile.exists()) return null
+      json
+        .parseToJsonElement(pidFile.readText())
+        .jsonObject["version"]
+        ?.jsonPrimitive
+        ?.contentOrNull
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+    } catch (_: Exception) {
+      null
+    }
+  }
+}
+
+internal data class DaemonCommandResult(
+  val exitCode: Int,
+  val output: String,
+)
+
+internal interface DaemonCommandExecutor {
+  fun execute(command: List<String>): DaemonCommandResult
+}
+
+internal object SystemDaemonCommandExecutor : DaemonCommandExecutor {
+  override fun execute(command: List<String>): DaemonCommandResult {
+    val process = ProcessBuilder(command).redirectErrorStream(true).start()
+    val output = process.inputStream.bufferedReader().use { it.readText() }
+    return DaemonCommandResult(exitCode = process.waitFor(), output = output)
+  }
+}
+
+internal interface DaemonRetryTimer {
+  fun sleep(milliseconds: Long)
+}
+
+internal object SystemDaemonRetryTimer : DaemonRetryTimer {
+  override fun sleep(milliseconds: Long) {
+    Thread.sleep(milliseconds)
+  }
+}
+
+internal sealed interface DaemonLifecycleResult {
+  data class Ready(
+    val restarted: Boolean,
+  ) : DaemonLifecycleResult
+
+  data class Failure(
+    val message: String,
+  ) : DaemonLifecycleResult
+}
+
+/**
+ * Ensures the desktop only connects to a daemon that reports the same release version as the
+ * desktop jar. The socket protocol gate remains the final authority; this lifecycle makes the
+ * UI restart a skewed shared daemon before that gate rejects every ordinary request.
+ */
+internal class DesktopDaemonLifecycle(
+  private val expectedVersionProvider: () -> String? = DaemonSocketPaths::resolveClientVersion,
+  private val socketChecker: DaemonSocketChecker = FileDaemonSocketChecker(),
+  private val pidFileReader: DaemonPidFileReader = JsonDaemonPidFileReader(),
+  private val commandExecutor: DaemonCommandExecutor = SystemDaemonCommandExecutor,
+  private val timer: DaemonRetryTimer = SystemDaemonRetryTimer,
+  private val verificationAttempts: Int = DEFAULT_VERIFICATION_ATTEMPTS,
+) {
+  fun ensureVersionMatchedDaemon(): DaemonLifecycleResult {
+    val expectedVersion = expectedVersionProvider()
+      ?: return DaemonLifecycleResult.Failure(
+        "Cannot verify the AutoMobile daemon version because this desktop build has no version. " +
+          "Rebuild or reinstall the desktop application, then try again."
+      )
+    val currentVersion = pidFileReader.readVersion()
+    if (versionsMatch(currentVersion, expectedVersion)) {
+      return DaemonLifecycleResult.Ready(restarted = false)
+    }
+
+    val action = if (socketChecker.exists()) "restart" else "start"
+    val command = packageDaemonCommand(expectedVersion, action)
+    val commandResult =
+      try {
+        commandExecutor.execute(command)
+      } catch (error: Exception) {
+        return DaemonLifecycleResult.Failure(
+          "Could not $action AutoMobile $expectedVersion: ${error.message ?: error.javaClass.simpleName}. " +
+            "Install Node.js with npx available, then try again."
+        )
+    }
+    if (commandResult.exitCode != 0) {
+      val detail =
+        commandResult.output.trim().takeIf { it.isNotEmpty() }
+          ?: "Install @kaeawc/auto-mobile@$expectedVersion and try again."
+      return DaemonLifecycleResult.Failure(
+        "Could not $action AutoMobile $expectedVersion (exit code ${commandResult.exitCode}). $detail"
+      )
+    }
+
+    var actualVersion: String? = null
+    repeat(verificationAttempts.coerceAtLeast(1)) { attempt ->
+      actualVersion = pidFileReader.readVersion()
+      if (versionsMatch(actualVersion, expectedVersion)) {
+        return DaemonLifecycleResult.Ready(restarted = true)
+      }
+      if (attempt + 1 < verificationAttempts.coerceAtLeast(1)) {
+        timer.sleep(VERIFICATION_RETRY_DELAY_MS)
+      }
+    }
+    return DaemonLifecycleResult.Failure(
+      "AutoMobile daemon version mismatch: desktop requires $expectedVersion, but the daemon " +
+        "reports ${actualVersion ?: "no version"}. Stop the existing daemon and retry so " +
+        "@kaeawc/auto-mobile@$expectedVersion can start."
+    )
+  }
+
+  private fun packageDaemonCommand(version: String, action: String): List<String> =
+    listOf(
+      "npx",
+      "-y",
+      "@kaeawc/auto-mobile@${DaemonSocketPaths.releaseVersion(version)}",
+      "--daemon",
+      action,
+    )
+
+  private fun versionsMatch(
+    actualVersion: String?,
+    expectedVersion: String,
+  ): Boolean {
+    val actualRelease = DaemonSocketPaths.releaseVersion(actualVersion?.trim().orEmpty())
+    val expectedRelease = DaemonSocketPaths.releaseVersion(expectedVersion.trim())
+    return actualRelease.isNotEmpty() && actualRelease == expectedRelease
+  }
+
+  private companion object {
+    const val DEFAULT_VERIFICATION_ATTEMPTS = 20
+    const val VERIFICATION_RETRY_DELAY_MS = 100L
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -59,7 +59,7 @@ internal class JsonDaemonPidFileReader(
         DaemonPidState(
           version =
             pidData["version"]?.jsonPrimitive?.contentOrNull?.trim()?.takeIf { it.isNotEmpty() },
-          launchArguments = pidData["options"]?.jsonObject?.toLaunchArguments().orEmpty(),
+          launchArguments = (pidData["options"] as? JsonObject)?.toLaunchArguments().orEmpty(),
         )
       )
     } catch (_: Exception) {
@@ -100,7 +100,10 @@ internal class JsonDaemonPidFileReader(
     booleanOption("embeddedSdk", "--embedded-sdk")
     booleanOption("dismissKeyboardAfterInput", "--dismiss-keyboard-after-input")
     val eventAllMarkers = this@toLaunchArguments["eventAllMarkers"] as? JsonArray
-    val markerValues = eventAllMarkers?.mapNotNull { it.jsonPrimitive.contentOrNull }.orEmpty()
+    val markerValues =
+      eventAllMarkers
+        ?.mapNotNull { (it as? kotlinx.serialization.json.JsonPrimitive)?.contentOrNull }
+        .orEmpty()
     if (markerValues.isNotEmpty()) {
       addAll(listOf("--event-all-markers", markerValues.joinToString(",")))
     } else {
@@ -187,10 +190,10 @@ internal object SystemDaemonCommandExecutor : DaemonCommandExecutor {
     descendants.forEach(ProcessHandle::destroy)
     process.destroy()
     if (!process.waitFor(TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-      descendants.filter(ProcessHandle::isAlive).forEach(ProcessHandle::destroyForcibly)
       process.destroyForcibly()
       process.waitFor(TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)
     }
+    descendants.filter(ProcessHandle::isAlive).forEach(ProcessHandle::destroyForcibly)
   }
 
   internal fun commandTimeoutMillis(
@@ -296,10 +299,10 @@ internal class DesktopDaemonLifecycle(
       }
 
       val action = if (daemonAvailable) "restart" else "start"
-      val command =
-        packageDaemonCommand(expectedVersion, action, currentDaemon?.launchArguments.orEmpty())
       val commandResult =
         try {
+          val command =
+            packageDaemonCommand(expectedVersion, action, currentDaemon?.launchArguments.orEmpty())
           commandExecutor.execute(command)
         } catch (error: Exception) {
           return DaemonLifecycleResult.Failure(
@@ -371,7 +374,6 @@ internal class DesktopDaemonLifecycle(
     currentVersion: String?,
     expectedVersion: String,
   ): Boolean {
-    if (!versionsMatch(currentVersion, expectedVersion)) return socketChecker.isReady()
     repeat(SOCKET_PROBE_ATTEMPTS) { attempt ->
       if (socketChecker.isReady()) return true
       if (attempt + 1 < SOCKET_PROBE_ATTEMPTS) timer.sleep(SOCKET_PROBE_RETRY_DELAY_MS)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -162,7 +162,7 @@ internal object SystemDaemonCommandExecutor : DaemonCommandExecutor {
         start()
       }
     try {
-      if (!process.waitFor(COMMAND_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+      if (!process.waitFor(commandTimeoutMillis(), TimeUnit.MILLISECONDS)) {
         terminate(process)
         return DaemonCommandResult(
           exitCode = TIMEOUT_EXIT_CODE,
@@ -183,12 +183,28 @@ internal object SystemDaemonCommandExecutor : DaemonCommandExecutor {
   }
 
   private fun terminate(process: Process) {
+    val descendants = process.toHandle().descendants().toList().asReversed()
+    descendants.forEach(ProcessHandle::destroy)
     process.destroy()
     if (!process.waitFor(TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+      descendants.filter(ProcessHandle::isAlive).forEach(ProcessHandle::destroyForcibly)
       process.destroyForcibly()
       process.waitFor(TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)
     }
   }
+
+  internal fun commandTimeoutMillis(
+    startupTimeoutOverride: String? =
+      System.getenv("AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS")
+        ?: System.getenv("AUTO_MOBILE_DAEMON_STARTUP_TIMEOUT_MS")
+  ): Long =
+    maxOf(
+      DEFAULT_COMMAND_TIMEOUT_MILLIS,
+      startupTimeoutOverride
+        ?.toLongOrNull()
+        ?.takeIf { it > 0 }
+        ?.plus(TERMINATION_TIMEOUT_SECONDS * 1_000) ?: DEFAULT_COMMAND_TIMEOUT_MILLIS,
+    )
 
   private fun drainOutput(
     process: Process,
@@ -203,7 +219,7 @@ internal object SystemDaemonCommandExecutor : DaemonCommandExecutor {
     return output.toString()
   }
 
-  private const val COMMAND_TIMEOUT_SECONDS = 60L
+  private const val DEFAULT_COMMAND_TIMEOUT_MILLIS = 60_000L
   private const val TERMINATION_TIMEOUT_SECONDS = 5L
   private const val TIMEOUT_EXIT_CODE = -1
   private const val CANCELLED_EXIT_CODE = -2

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -2,6 +2,9 @@ package dev.jasonpearson.automobile.desktop.core.daemon
 
 import java.io.File
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -17,27 +20,100 @@ internal class FileDaemonSocketChecker(
 }
 
 internal interface DaemonPidFileReader {
-  fun readVersion(): String?
+  fun read(): DaemonPidState?
 }
+
+internal data class DaemonPidState(
+  val version: String?,
+  val launchArguments: List<String> = emptyList(),
+)
 
 internal class JsonDaemonPidFileReader(
   private val pidFilePath: String = DaemonSocketPaths.pidFilePath(),
   private val json: Json = DaemonJson,
 ) : DaemonPidFileReader {
-  override fun readVersion(): String? {
+  override fun read(): DaemonPidState? {
     return try {
       val pidFile = File(pidFilePath)
       if (!pidFile.exists()) return null
-      json
-        .parseToJsonElement(pidFile.readText())
-        .jsonObject["version"]
-        ?.jsonPrimitive
-        ?.contentOrNull
-        ?.trim()
-        ?.takeIf { it.isNotEmpty() }
+      val pidData = json.parseToJsonElement(pidFile.readText()).jsonObject
+      DaemonPidState(
+        version =
+          pidData["version"]?.jsonPrimitive?.contentOrNull?.trim()?.takeIf { it.isNotEmpty() },
+        launchArguments = pidData["options"]?.jsonObject?.toLaunchArguments().orEmpty(),
+      )
     } catch (_: Exception) {
       null
     }
+  }
+
+  /**
+   * Mirrors the daemon CLI's option parser for the stable PID-file options boundary. A closed list
+   * avoids forwarding unknown JSON values into a process invocation while retaining every
+   * behavior-affecting option that a running daemon has already accepted.
+   */
+  private fun JsonObject.toLaunchArguments(): List<String> = buildList {
+    fun booleanOption(key: String, flag: String) {
+      if (this@toLaunchArguments[key]?.jsonPrimitive?.booleanOrNull == true) add(flag)
+    }
+    fun valueOption(key: String, flag: String) {
+      this@toLaunchArguments[key]
+        ?.jsonPrimitive
+        ?.contentOrNull
+        ?.takeIf { it.isNotEmpty() }
+        ?.let { value -> addAll(listOf(flag, value)) }
+    }
+
+    valueOption("port", "--port")
+    valueOption("host", "--host")
+    booleanOption("debug", "--debug")
+    booleanOption("debugPerf", "--debug-perf")
+    valueOption("planExecutionLockScope", "--plan-execution-lock-scope")
+    valueOption("videoQualityPreset", "--video-quality")
+    valueOption("videoTargetBitrateKbps", "--video-target-bitrate-kbps")
+    valueOption("videoMaxThroughputMbps", "--video-max-throughput-mbps")
+    valueOption("videoFps", "--video-fps")
+    valueOption("videoFormat", "--video-format")
+    valueOption("videoMaxArchiveSizeMb", "--video-archive-size-mb")
+    valueOption("toolOutputsDir", "--tool-outputs-dir")
+    booleanOption("networkMockable", "--network-mockable")
+    booleanOption("embeddedSdk", "--embedded-sdk")
+    booleanOption("dismissKeyboardAfterInput", "--dismiss-keyboard-after-input")
+    val eventAllMarkers = this@toLaunchArguments["eventAllMarkers"] as? JsonArray
+    val markerValues = eventAllMarkers?.mapNotNull { it.jsonPrimitive.contentOrNull }.orEmpty()
+    if (markerValues.isNotEmpty()) {
+      addAll(listOf("--event-all-markers", markerValues.joinToString(",")))
+    } else {
+      booleanOption("eventAllMarkersCliOverride", "--event-all-markers=")
+    }
+    booleanOption("noUiPerfMode", "--no-ui-perf-mode")
+    booleanOption("memPerfAudit", "--mem-perf-audit")
+    booleanOption("accessibilityAudit", "--accessibility-audit")
+    valueOption("accessibilityLevel", "--accessibility-level")
+    valueOption("accessibilityFailureMode", "--accessibility-failure-mode")
+    valueOption("accessibilityMinSeverity", "--accessibility-min-severity")
+    booleanOption("accessibilityUseBaseline", "--accessibility-use-baseline")
+    booleanOption("predictiveUi", "--predictive-ui")
+    booleanOption("rawElementSearch", "--raw-element-search")
+    booleanOption("skipCtrlProxyDownload", "--skip-ctrl-proxy-download")
+    booleanOption("mcpRecording", "--mcp-recording")
+    booleanOption("noNavigationScreenshots", "--no-navigation-screenshots")
+    booleanOption("noWaitForPollingOverhead", "--no-waitfor-polling-overhead")
+    booleanOption("noA11yIncludeNotImportantViews", "--no-include-not-important-views")
+    booleanOption("noA11yReportViewIds", "--no-report-view-ids")
+    booleanOption("noA11yRetrieveInteractiveWindows", "--no-retrieve-interactive-windows")
+    booleanOption("noOcclusion", "--no-occlusion")
+    booleanOption("safeAreaWarnings", "--safe-area-warnings")
+    booleanOption("observeResultDropElements", "--observe-result-drop-elements")
+    booleanOption("observeResultCompact", "--observe-result-compact")
+    booleanOption("observeResultProjectSkeleton", "--observe-result-project-skeleton")
+    booleanOption("toolResultsNoStructuredContent", "--tool-results-no-structured-content")
+    booleanOption("actionsDiffObserve", "--actions-diff-observe")
+    booleanOption("actionsNoObserve", "--actions-no-observe")
+    booleanOption("toolResultsCompactJson", "--tool-results-compact-json")
+    booleanOption("observeFocusScope", "--observe-focus-scope")
+    booleanOption("observeOverview", "--observe-overview")
+    booleanOption("observeRegion", "--observe-region")
   }
 }
 
@@ -99,7 +175,8 @@ internal class DesktopDaemonLifecycle(
             "Cannot verify the AutoMobile daemon version because this desktop build has no version. " +
               "Rebuild or reinstall the desktop application, then try again."
           )
-      val currentVersion = pidFileReader.readVersion()
+      val currentDaemon = pidFileReader.read()
+      val currentVersion = currentDaemon?.version
       val daemonAvailable = socketChecker.exists()
       if (daemonAvailable && versionsMatch(currentVersion, expectedVersion)) {
         return DaemonLifecycleResult.Ready(restarted = false)
@@ -113,7 +190,8 @@ internal class DesktopDaemonLifecycle(
       }
 
       val action = if (daemonAvailable) "restart" else "start"
-      val command = packageDaemonCommand(expectedVersion, action)
+      val command =
+        packageDaemonCommand(expectedVersion, action, currentDaemon?.launchArguments.orEmpty())
       val commandResult =
         try {
           commandExecutor.execute(command)
@@ -134,7 +212,7 @@ internal class DesktopDaemonLifecycle(
 
       var actualVersion: String? = null
       repeat(verificationAttempts.coerceAtLeast(1)) { attempt ->
-        actualVersion = pidFileReader.readVersion()
+        actualVersion = pidFileReader.read()?.version
         if (socketChecker.exists() && versionsMatch(actualVersion, expectedVersion)) {
           return DaemonLifecycleResult.Ready(restarted = true)
         }
@@ -149,14 +227,18 @@ internal class DesktopDaemonLifecycle(
       )
     }
 
-  private fun packageDaemonCommand(version: String, action: String): List<String> =
+  private fun packageDaemonCommand(
+    version: String,
+    action: String,
+    existingOptions: List<String>,
+  ): List<String> =
     listOf(
       npxExecutable(System.getProperty("os.name", "")),
       "-y",
       "@kaeawc/auto-mobile@${DaemonSocketPaths.releaseVersion(version)}",
       "--daemon",
       action,
-    )
+    ) + if (action == "restart") existingOptions else emptyList()
 
   private fun versionsMatch(
     actualVersion: String?,

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -11,7 +11,7 @@ internal interface DaemonSocketChecker {
 }
 
 internal class FileDaemonSocketChecker(
-  private val socketPath: String = DaemonSocketPaths.socketPath(),
+  private val socketPath: String = DaemonSocketPaths.socketPath()
 ) : DaemonSocketChecker {
   override fun exists(): Boolean = File(socketPath).exists()
 }
@@ -69,19 +69,19 @@ internal object SystemDaemonRetryTimer : DaemonRetryTimer {
 }
 
 internal sealed interface DaemonLifecycleResult {
-  data class Ready(
-    val restarted: Boolean,
-  ) : DaemonLifecycleResult
+  data class Ready(val restarted: Boolean) : DaemonLifecycleResult
 
-  data class Failure(
-    val message: String,
-  ) : DaemonLifecycleResult
+  data class Failure(val message: String) : DaemonLifecycleResult
+}
+
+internal interface DaemonLifecycleEnsurer {
+  fun ensureVersionMatchedDaemon(): DaemonLifecycleResult
 }
 
 /**
  * Ensures the desktop only connects to a daemon that reports the same release version as the
- * desktop jar. The socket protocol gate remains the final authority; this lifecycle makes the
- * UI restart a skewed shared daemon before that gate rejects every ordinary request.
+ * desktop jar. The socket protocol gate remains the final authority; this lifecycle makes the UI
+ * restart a skewed shared daemon before that gate rejects every ordinary request.
  */
 internal class DesktopDaemonLifecycle(
   private val expectedVersionProvider: () -> String? = DaemonSocketPaths::resolveClientVersion,
@@ -90,58 +90,68 @@ internal class DesktopDaemonLifecycle(
   private val commandExecutor: DaemonCommandExecutor = SystemDaemonCommandExecutor,
   private val timer: DaemonRetryTimer = SystemDaemonRetryTimer,
   private val verificationAttempts: Int = DEFAULT_VERIFICATION_ATTEMPTS,
-) {
-  fun ensureVersionMatchedDaemon(): DaemonLifecycleResult {
-    val expectedVersion = expectedVersionProvider()
-      ?: return DaemonLifecycleResult.Failure(
-        "Cannot verify the AutoMobile daemon version because this desktop build has no version. " +
-          "Rebuild or reinstall the desktop application, then try again."
-      )
-    val currentVersion = pidFileReader.readVersion()
-    if (versionsMatch(currentVersion, expectedVersion)) {
-      return DaemonLifecycleResult.Ready(restarted = false)
-    }
+) : DaemonLifecycleEnsurer {
+  override fun ensureVersionMatchedDaemon(): DaemonLifecycleResult =
+    synchronized(lifecycleLock) {
+      val expectedVersion =
+        expectedVersionProvider()
+          ?: return DaemonLifecycleResult.Failure(
+            "Cannot verify the AutoMobile daemon version because this desktop build has no version. " +
+              "Rebuild or reinstall the desktop application, then try again."
+          )
+      val currentVersion = pidFileReader.readVersion()
+      val daemonAvailable = socketChecker.exists()
+      if (daemonAvailable && versionsMatch(currentVersion, expectedVersion)) {
+        return DaemonLifecycleResult.Ready(restarted = false)
+      }
 
-    val action = if (socketChecker.exists()) "restart" else "start"
-    val command = packageDaemonCommand(expectedVersion, action)
-    val commandResult =
-      try {
-        commandExecutor.execute(command)
-      } catch (error: Exception) {
+      if (declaresFullVersion(expectedVersion)) {
         return DaemonLifecycleResult.Failure(
-          "Could not $action AutoMobile $expectedVersion: ${error.message ?: error.javaClass.simpleName}. " +
-            "Install Node.js with npx available, then try again."
+          "AutoMobile desktop source build $expectedVersion cannot start a matching published daemon. " +
+            "Start the daemon from the same checkout, then try again."
         )
-    }
-    if (commandResult.exitCode != 0) {
-      val detail =
-        commandResult.output.trim().takeIf { it.isNotEmpty() }
-          ?: "Install @kaeawc/auto-mobile@$expectedVersion and try again."
+      }
+
+      val action = if (daemonAvailable) "restart" else "start"
+      val command = packageDaemonCommand(expectedVersion, action)
+      val commandResult =
+        try {
+          commandExecutor.execute(command)
+        } catch (error: Exception) {
+          return DaemonLifecycleResult.Failure(
+            "Could not $action AutoMobile $expectedVersion: ${error.message ?: error.javaClass.simpleName}. " +
+              "Install Node.js with npx available, then try again."
+          )
+        }
+      if (commandResult.exitCode != 0) {
+        val detail =
+          commandResult.output.trim().takeIf { it.isNotEmpty() }
+            ?: "Install @kaeawc/auto-mobile@$expectedVersion and try again."
+        return DaemonLifecycleResult.Failure(
+          "Could not $action AutoMobile $expectedVersion (exit code ${commandResult.exitCode}). $detail"
+        )
+      }
+
+      var actualVersion: String? = null
+      repeat(verificationAttempts.coerceAtLeast(1)) { attempt ->
+        actualVersion = pidFileReader.readVersion()
+        if (socketChecker.exists() && versionsMatch(actualVersion, expectedVersion)) {
+          return DaemonLifecycleResult.Ready(restarted = true)
+        }
+        if (attempt + 1 < verificationAttempts.coerceAtLeast(1)) {
+          timer.sleep(VERIFICATION_RETRY_DELAY_MS)
+        }
+      }
       return DaemonLifecycleResult.Failure(
-        "Could not $action AutoMobile $expectedVersion (exit code ${commandResult.exitCode}). $detail"
+        "AutoMobile daemon version mismatch: desktop requires $expectedVersion, but the daemon " +
+          "reports ${actualVersion ?: "no version"}. Stop the existing daemon and retry so " +
+          "@kaeawc/auto-mobile@$expectedVersion can start."
       )
     }
-
-    var actualVersion: String? = null
-    repeat(verificationAttempts.coerceAtLeast(1)) { attempt ->
-      actualVersion = pidFileReader.readVersion()
-      if (versionsMatch(actualVersion, expectedVersion)) {
-        return DaemonLifecycleResult.Ready(restarted = true)
-      }
-      if (attempt + 1 < verificationAttempts.coerceAtLeast(1)) {
-        timer.sleep(VERIFICATION_RETRY_DELAY_MS)
-      }
-    }
-    return DaemonLifecycleResult.Failure(
-      "AutoMobile daemon version mismatch: desktop requires $expectedVersion, but the daemon " +
-        "reports ${actualVersion ?: "no version"}. Stop the existing daemon and retry so " +
-        "@kaeawc/auto-mobile@$expectedVersion can start."
-    )
-  }
 
   private fun packageDaemonCommand(version: String, action: String): List<String> =
     listOf(
-      "npx",
+      npxExecutable(System.getProperty("os.name", "")),
       "-y",
       "@kaeawc/auto-mobile@${DaemonSocketPaths.releaseVersion(version)}",
       "--daemon",
@@ -152,12 +162,24 @@ internal class DesktopDaemonLifecycle(
     actualVersion: String?,
     expectedVersion: String,
   ): Boolean {
-    val actualRelease = DaemonSocketPaths.releaseVersion(actualVersion?.trim().orEmpty())
-    val expectedRelease = DaemonSocketPaths.releaseVersion(expectedVersion.trim())
+    val actual = actualVersion?.trim().orEmpty()
+    val expected = expectedVersion.trim()
+    if (declaresFullVersion(expected)) {
+      return actual.isNotEmpty() && actual == expected
+    }
+    val actualRelease = DaemonSocketPaths.releaseVersion(actual)
+    val expectedRelease = DaemonSocketPaths.releaseVersion(expected)
     return actualRelease.isNotEmpty() && actualRelease == expectedRelease
   }
 
+  private fun declaresFullVersion(version: String): Boolean =
+    DaemonSocketPaths.releaseVersion(version) != version
+
+  internal fun npxExecutable(osName: String): String =
+    if (osName.lowercase().contains("win")) "npx.cmd" else "npx"
+
   private companion object {
+    val lifecycleLock = Any()
     const val DEFAULT_VERIFICATION_ATTEMPTS = 20
     const val VERIFICATION_RETRY_DELAY_MS = 100L
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -1,6 +1,8 @@
 package dev.jasonpearson.automobile.desktop.core.daemon
 
 import java.io.File
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.SocketChannel
 import java.util.concurrent.TimeUnit
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -11,17 +13,24 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
 internal interface DaemonSocketChecker {
-  fun exists(): Boolean
+  fun isReady(): Boolean
 }
 
 internal class FileDaemonSocketChecker(
   private val socketPath: String = DaemonSocketPaths.socketPath()
 ) : DaemonSocketChecker {
-  override fun exists(): Boolean = File(socketPath).exists()
+  override fun isReady(): Boolean {
+    if (!File(socketPath).exists()) return false
+    return try {
+      SocketChannel.open(UnixDomainSocketAddress.of(socketPath)).use { true }
+    } catch (_: Exception) {
+      false
+    }
+  }
 }
 
 internal interface DaemonPidFileReader {
-  fun read(): DaemonPidState?
+  fun read(): DaemonPidReadResult
 }
 
 internal data class DaemonPidState(
@@ -29,22 +38,32 @@ internal data class DaemonPidState(
   val launchArguments: List<String> = emptyList(),
 )
 
+internal sealed interface DaemonPidReadResult {
+  data object Absent : DaemonPidReadResult
+
+  data object Unreadable : DaemonPidReadResult
+
+  data class Present(val state: DaemonPidState) : DaemonPidReadResult
+}
+
 internal class JsonDaemonPidFileReader(
   private val pidFilePath: String = DaemonSocketPaths.pidFilePath(),
   private val json: Json = DaemonJson,
 ) : DaemonPidFileReader {
-  override fun read(): DaemonPidState? {
+  override fun read(): DaemonPidReadResult {
+    val pidFile = File(pidFilePath)
+    if (!pidFile.exists()) return DaemonPidReadResult.Absent
     return try {
-      val pidFile = File(pidFilePath)
-      if (!pidFile.exists()) return null
       val pidData = json.parseToJsonElement(pidFile.readText()).jsonObject
-      DaemonPidState(
-        version =
-          pidData["version"]?.jsonPrimitive?.contentOrNull?.trim()?.takeIf { it.isNotEmpty() },
-        launchArguments = pidData["options"]?.jsonObject?.toLaunchArguments().orEmpty(),
+      DaemonPidReadResult.Present(
+        DaemonPidState(
+          version =
+            pidData["version"]?.jsonPrimitive?.contentOrNull?.trim()?.takeIf { it.isNotEmpty() },
+          launchArguments = pidData["options"]?.jsonObject?.toLaunchArguments().orEmpty(),
+        )
       )
     } catch (_: Exception) {
-      null
+      DaemonPidReadResult.Unreadable
     }
   }
 
@@ -122,6 +141,7 @@ internal data class DaemonCommandResult(
   val exitCode: Int,
   val output: String,
   val timedOut: Boolean = false,
+  val cancelled: Boolean = false,
 )
 
 internal interface DaemonCommandExecutor {
@@ -141,22 +161,33 @@ internal object SystemDaemonCommandExecutor : DaemonCommandExecutor {
         isDaemon = true
         start()
       }
-    if (!process.waitFor(COMMAND_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-      process.destroy()
-      if (!process.waitFor(TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-        process.destroyForcibly()
-        process.waitFor(TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+    try {
+      if (!process.waitFor(COMMAND_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+        terminate(process)
+        return DaemonCommandResult(
+          exitCode = TIMEOUT_EXIT_CODE,
+          output = drainOutput(process, outputDrainer, output),
+          timedOut = true,
+        )
       }
       return DaemonCommandResult(
-        exitCode = TIMEOUT_EXIT_CODE,
+        exitCode = process.exitValue(),
         output = drainOutput(process, outputDrainer, output),
-        timedOut = true,
       )
+    } catch (_: InterruptedException) {
+      terminate(process)
+      process.inputStream.close()
+      Thread.currentThread().interrupt()
+      return DaemonCommandResult(exitCode = CANCELLED_EXIT_CODE, output = "", cancelled = true)
     }
-    return DaemonCommandResult(
-      exitCode = process.exitValue(),
-      output = drainOutput(process, outputDrainer, output),
-    )
+  }
+
+  private fun terminate(process: Process) {
+    process.destroy()
+    if (!process.waitFor(TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+      process.destroyForcibly()
+      process.waitFor(TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+    }
   }
 
   private fun drainOutput(
@@ -175,6 +206,7 @@ internal object SystemDaemonCommandExecutor : DaemonCommandExecutor {
   private const val COMMAND_TIMEOUT_SECONDS = 60L
   private const val TERMINATION_TIMEOUT_SECONDS = 5L
   private const val TIMEOUT_EXIT_CODE = -1
+  private const val CANCELLED_EXIT_CODE = -2
 }
 
 internal interface DaemonRetryTimer {
@@ -218,9 +250,17 @@ internal class DesktopDaemonLifecycle(
             "Cannot verify the AutoMobile daemon version because this desktop build has no version. " +
               "Rebuild or reinstall the desktop application, then try again."
           )
-      val currentDaemon = pidFileReader.read()
+      val currentDaemon =
+        when (val readResult = readPidStateWithRetry()) {
+          is DaemonPidReadResult.Present -> readResult.state
+          DaemonPidReadResult.Absent -> null
+          DaemonPidReadResult.Unreadable ->
+            return DaemonLifecycleResult.Failure(
+              "Could not read the AutoMobile daemon state. Wait a moment for startup to finish, then retry."
+            )
+        }
       val currentVersion = currentDaemon?.version
-      val daemonAvailable = socketChecker.exists()
+      val daemonAvailable = socketChecker.isReady()
       if (daemonAvailable && versionsMatch(currentVersion, expectedVersion)) {
         return DaemonLifecycleResult.Ready(restarted = false)
       }
@@ -244,6 +284,9 @@ internal class DesktopDaemonLifecycle(
               "Install Node.js with npx available, then try again."
           )
         }
+      if (commandResult.cancelled) {
+        return DaemonLifecycleResult.Failure("AutoMobile daemon startup was cancelled.")
+      }
       if (commandResult.exitCode != 0) {
         if (commandResult.timedOut) {
           return DaemonLifecycleResult.Failure(
@@ -261,8 +304,8 @@ internal class DesktopDaemonLifecycle(
 
       var actualVersion: String? = null
       repeat(verificationAttempts.coerceAtLeast(1)) { attempt ->
-        actualVersion = pidFileReader.read()?.version
-        if (socketChecker.exists() && versionsMatch(actualVersion, expectedVersion)) {
+        actualVersion = (pidFileReader.read() as? DaemonPidReadResult.Present)?.state?.version
+        if (socketChecker.isReady() && versionsMatch(actualVersion, expectedVersion)) {
           return DaemonLifecycleResult.Ready(restarted = true)
         }
         if (attempt + 1 < verificationAttempts.coerceAtLeast(1)) {
@@ -281,13 +324,25 @@ internal class DesktopDaemonLifecycle(
     action: String,
     existingOptions: List<String>,
   ): List<String> =
-    listOf(
-      npxExecutable(System.getProperty("os.name", "")),
-      "-y",
-      "@kaeawc/auto-mobile@${DaemonSocketPaths.releaseVersion(version)}",
-      "--daemon",
-      action,
-    ) + existingOptions
+    commandForPlatform(
+      listOf(
+        npxExecutable(System.getProperty("os.name", "")),
+        "-y",
+        "@kaeawc/auto-mobile@${DaemonSocketPaths.releaseVersion(version)}",
+        "--daemon",
+        action,
+      ) + existingOptions,
+      System.getProperty("os.name", ""),
+    )
+
+  private fun readPidStateWithRetry(): DaemonPidReadResult {
+    repeat(PID_READ_ATTEMPTS) { attempt ->
+      val result = pidFileReader.read()
+      if (result != DaemonPidReadResult.Unreadable) return result
+      if (attempt + 1 < PID_READ_ATTEMPTS) timer.sleep(PID_READ_RETRY_DELAY_MS)
+    }
+    return DaemonPidReadResult.Unreadable
+  }
 
   private fun versionsMatch(
     actualVersion: String?,
@@ -309,9 +364,24 @@ internal class DesktopDaemonLifecycle(
   internal fun npxExecutable(osName: String): String =
     if (osName.lowercase().contains("win")) "npx.cmd" else "npx"
 
+  internal fun commandForPlatform(command: List<String>, osName: String): List<String> {
+    if (!osName.lowercase().contains("win")) return command
+    val quotedCommand = command.joinToString(" ") { quoteForWindowsCmd(it) }
+    return listOf("cmd.exe", "/d", "/v:off", "/s", "/c", "\"$quotedCommand\"")
+  }
+
+  private fun quoteForWindowsCmd(value: String): String {
+    require(!value.contains('"') && !value.contains('\n') && !value.contains('\r')) {
+      "AutoMobile daemon arguments cannot contain Windows command-line quotes or newlines"
+    }
+    return "\"${value.replace("%", "%%")}\""
+  }
+
   private companion object {
     val lifecycleLock = Any()
     const val DEFAULT_VERIFICATION_ATTEMPTS = 20
     const val VERIFICATION_RETRY_DELAY_MS = 100L
+    const val PID_READ_ATTEMPTS = 3
+    const val PID_READ_RETRY_DELAY_MS = 100L
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.desktop.core.daemon
 
 import java.io.File
+import java.util.concurrent.TimeUnit
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
@@ -120,6 +121,7 @@ internal class JsonDaemonPidFileReader(
 internal data class DaemonCommandResult(
   val exitCode: Int,
   val output: String,
+  val timedOut: Boolean = false,
 )
 
 internal interface DaemonCommandExecutor {
@@ -129,9 +131,22 @@ internal interface DaemonCommandExecutor {
 internal object SystemDaemonCommandExecutor : DaemonCommandExecutor {
   override fun execute(command: List<String>): DaemonCommandResult {
     val process = ProcessBuilder(command).redirectErrorStream(true).start()
+    if (!process.waitFor(COMMAND_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+      process.destroy()
+      if (!process.waitFor(TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+        process.destroyForcibly()
+        process.waitFor(TERMINATION_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+      }
+      val output = process.inputStream.bufferedReader().use { it.readText() }
+      return DaemonCommandResult(exitCode = TIMEOUT_EXIT_CODE, output = output, timedOut = true)
+    }
     val output = process.inputStream.bufferedReader().use { it.readText() }
-    return DaemonCommandResult(exitCode = process.waitFor(), output = output)
+    return DaemonCommandResult(exitCode = process.exitValue(), output = output)
   }
+
+  private const val COMMAND_TIMEOUT_SECONDS = 60L
+  private const val TERMINATION_TIMEOUT_SECONDS = 5L
+  private const val TIMEOUT_EXIT_CODE = -1
 }
 
 internal interface DaemonRetryTimer {
@@ -202,6 +217,12 @@ internal class DesktopDaemonLifecycle(
           )
         }
       if (commandResult.exitCode != 0) {
+        if (commandResult.timedOut) {
+          return DaemonLifecycleResult.Failure(
+            "Timed out while trying to $action AutoMobile $expectedVersion. " +
+              "Check the daemon logs and retry."
+          )
+        }
         val detail =
           commandResult.output.trim().takeIf { it.isNotEmpty() }
             ?: "Install @kaeawc/auto-mobile@$expectedVersion and try again."

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycle.kt
@@ -260,9 +260,16 @@ internal class DesktopDaemonLifecycle(
             )
         }
       val currentVersion = currentDaemon?.version
-      val daemonAvailable = socketChecker.isReady()
+      val daemonAvailable = socketIsReady(currentVersion, expectedVersion)
       if (daemonAvailable && versionsMatch(currentVersion, expectedVersion)) {
         return DaemonLifecycleResult.Ready(restarted = false)
+      }
+
+      if (daemonAvailable && daemonIsNewer(currentVersion, expectedVersion)) {
+        return DaemonLifecycleResult.Failure(
+          "AutoMobile daemon $currentVersion is newer than desktop $expectedVersion. " +
+            "Update the desktop application before connecting."
+        )
       }
 
       if (declaresFullVersion(expectedVersion)) {
@@ -344,6 +351,35 @@ internal class DesktopDaemonLifecycle(
     return DaemonPidReadResult.Unreadable
   }
 
+  private fun socketIsReady(
+    currentVersion: String?,
+    expectedVersion: String,
+  ): Boolean {
+    if (!versionsMatch(currentVersion, expectedVersion)) return socketChecker.isReady()
+    repeat(SOCKET_PROBE_ATTEMPTS) { attempt ->
+      if (socketChecker.isReady()) return true
+      if (attempt + 1 < SOCKET_PROBE_ATTEMPTS) timer.sleep(SOCKET_PROBE_RETRY_DELAY_MS)
+    }
+    return false
+  }
+
+  private fun daemonIsNewer(
+    currentVersion: String?,
+    expectedVersion: String,
+  ): Boolean {
+    val currentRelease = currentVersion?.let(DaemonSocketPaths::releaseVersion).orEmpty()
+    val expectedRelease = DaemonSocketPaths.releaseVersion(expectedVersion)
+    val currentParts = currentRelease.split('.').map { it.toIntOrNull() ?: return false }
+    val expectedParts = expectedRelease.split('.').map { it.toIntOrNull() ?: return false }
+    val length = maxOf(currentParts.size, expectedParts.size)
+    for (index in 0 until length) {
+      val difference =
+        (currentParts.getOrElse(index) { 0 }).compareTo(expectedParts.getOrElse(index) { 0 })
+      if (difference != 0) return difference > 0
+    }
+    return false
+  }
+
   private fun versionsMatch(
     actualVersion: String?,
     expectedVersion: String,
@@ -383,5 +419,7 @@ internal class DesktopDaemonLifecycle(
     const val VERIFICATION_RETRY_DELAY_MS = 100L
     const val PID_READ_ATTEMPTS = 3
     const val PID_READ_RETRY_DELAY_MS = 100L
+    const val SOCKET_PROBE_ATTEMPTS = 3
+    const val SOCKET_PROBE_RETRY_DELAY_MS = 150L
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
@@ -578,13 +578,21 @@ object DaemonSocketPaths {
   }
 
   /** Version this desktop client declares to the daemon's version handshake gate. */
-  fun resolveClientVersion(): String? {
-    val raw =
-      System.getenv("AUTOMOBILE_DAEMON_PACKAGE_VERSION")?.takeIf { it.isNotBlank() }
-        ?: System.getenv("AUTOMOBILE_VERSION")?.takeIf { it.isNotBlank() }
-        ?: DaemonSocketPaths::class.java.`package`?.implementationVersion
-    return normalizeClientVersion(raw)
-  }
+  fun resolveClientVersion(): String? =
+    resolveClientVersion(
+      daemonPackageVersion = System.getenv("AUTOMOBILE_DAEMON_PACKAGE_VERSION"),
+      automobileVersion = System.getenv("AUTOMOBILE_VERSION"),
+      manifestVersion = DaemonSocketPaths::class.java.`package`?.implementationVersion,
+    )
+
+  internal fun resolveClientVersion(
+    daemonPackageVersion: String?,
+    automobileVersion: String?,
+    manifestVersion: String?,
+  ): String? =
+    sequenceOf(daemonPackageVersion, automobileVersion, manifestVersion)
+      .mapNotNull(::normalizeClientVersion)
+      .firstOrNull()
 
   internal fun normalizeClientVersion(raw: String?): String? {
     val trimmed = raw?.trim().orEmpty()

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
@@ -27,6 +27,7 @@ import kotlinx.serialization.serializer
 class McpDaemonClient(
   private val socketPathValue: String = DaemonSocketPaths.socketPath(),
   private val json: Json = DaemonJson,
+  private val clientVersion: String? = DaemonSocketPaths.resolveClientVersion(),
 ) : AutoMobileClient {
   val socketPath: String
     get() = socketPathValue
@@ -488,6 +489,7 @@ class McpDaemonClient(
           type = "mcp_request",
           method = method,
           params = params,
+          clientVersion = clientVersion,
         )
 
       writer.write(json.encodeToString(request))
@@ -544,10 +546,36 @@ class McpDaemonClient(
 }
 
 object DaemonSocketPaths {
+  private val ignoredVersions = setOf("latest", "unknown")
+
   fun socketPath(): String {
     val userId = getUserId()
     return "/tmp/auto-mobile-daemon-$userId.sock"
   }
+
+  fun pidFilePath(): String {
+    val userId = getUserId()
+    return "/tmp/auto-mobile-daemon-$userId.pid"
+  }
+
+  /** Version this desktop client declares to the daemon's version handshake gate. */
+  fun resolveClientVersion(): String? {
+    val raw =
+      System.getenv("AUTOMOBILE_DAEMON_PACKAGE_VERSION")?.takeIf { it.isNotBlank() }
+        ?: System.getenv("AUTOMOBILE_VERSION")?.takeIf { it.isNotBlank() }
+        ?: DaemonSocketPaths::class.java.`package`?.implementationVersion
+    return normalizeClientVersion(raw)
+  }
+
+  internal fun normalizeClientVersion(raw: String?): String? {
+    val trimmed = raw?.trim().orEmpty()
+    if (trimmed.isEmpty() || ignoredVersions.contains(trimmed.lowercase())) {
+      return null
+    }
+    return trimmed
+  }
+
+  internal fun releaseVersion(version: String): String = version.substringBefore('+')
 
   private fun getUserId(): String {
     val userName = System.getProperty("user.name", "default").ifBlank { "default" }
@@ -572,11 +600,12 @@ object DaemonSocketPaths {
 }
 
 @Serializable
-private data class DaemonRequest(
+internal data class DaemonRequest(
   val id: String,
   val type: String,
   val method: String,
   val params: JsonObject,
+  val clientVersion: String? = null,
 )
 
 @Serializable

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
@@ -10,6 +10,7 @@ import java.nio.channels.Channels
 import java.nio.channels.SocketChannel
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
+import java.nio.file.Path
 import java.util.UUID
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
@@ -574,7 +575,23 @@ object DaemonSocketPaths {
 
   fun pidFilePath(): String {
     val userId = getUserId()
-    return "/tmp/auto-mobile-daemon-$userId.pid"
+    return resolvePidFilePath(
+      System.getenv("AUTOMOBILE_DAEMON_PID_FILE_PATH")
+        ?: System.getenv("AUTO_MOBILE_DAEMON_PID_FILE_PATH"),
+      "/tmp/auto-mobile-daemon-$userId.pid",
+      System.getenv("AUTOMOBILE_DAEMON_LAUNCH_CWD") ?: System.getProperty("user.dir", "."),
+    )
+  }
+
+  internal fun resolvePidFilePath(
+    override: String?,
+    defaultPath: String,
+    daemonLaunchCwd: String,
+  ): String {
+    val configuredPath = override?.trim().takeUnless { it.isNullOrEmpty() } ?: return defaultPath
+    val path = Path.of(configuredPath)
+    return if (path.isAbsolute) configuredPath
+    else Path.of(daemonLaunchCwd, configuredPath).toString()
   }
 
   /** Version this desktop client declares to the daemon's version handshake gate. */

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
@@ -29,6 +29,16 @@ class McpDaemonClient(
   private val json: Json = DaemonJson,
   private val clientVersion: String? = DaemonSocketPaths.resolveClientVersion(),
 ) : AutoMobileClient {
+  private var daemonLifecycle: DaemonLifecycleEnsurer? =
+    if (socketPathValue == DaemonSocketPaths.socketPath()) DesktopDaemonLifecycle() else null
+
+  internal constructor(
+    socketPathValue: String,
+    daemonLifecycle: DaemonLifecycleEnsurer,
+  ) : this(socketPathValue = socketPathValue) {
+    this.daemonLifecycle = daemonLifecycle
+  }
+
   val socketPath: String
     get() = socketPathValue
 
@@ -472,6 +482,7 @@ class McpDaemonClient(
     method: String,
     params: JsonObject = JsonObject(emptyMap()),
   ): DaemonResponse {
+    ensureVersionMatchedDaemon()
     ensureSocketExists()
 
     val address = UnixDomainSocketAddress.of(socketPathValue)
@@ -505,6 +516,14 @@ class McpDaemonClient(
     val path = File(socketPathValue).toPath()
     if (!Files.exists(path)) {
       throw DaemonUnavailableException("Daemon socket not found at $socketPathValue")
+    }
+  }
+
+  private fun ensureVersionMatchedDaemon() {
+    when (val result = daemonLifecycle?.ensureVersionMatchedDaemon()) {
+      is DaemonLifecycleResult.Failure -> throw DaemonUnavailableException(result.message)
+      is DaemonLifecycleResult.Ready,
+      null -> Unit
     }
   }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
@@ -570,12 +570,16 @@ object DaemonSocketPaths {
 
   fun socketPath(): String {
     val userId = getUserId()
-    return "/tmp/auto-mobile-daemon-$userId.sock"
+    return resolveDaemonPath(
+      System.getenv("AUTOMOBILE_DAEMON_SOCKET_PATH")
+        ?: System.getenv("AUTO_MOBILE_DAEMON_SOCKET_PATH"),
+      "/tmp/auto-mobile-daemon-$userId.sock",
+    )
   }
 
   fun pidFilePath(): String {
     val userId = getUserId()
-    return resolvePidFilePath(
+    return resolveDaemonPath(
       System.getenv("AUTOMOBILE_DAEMON_PID_FILE_PATH")
         ?: System.getenv("AUTO_MOBILE_DAEMON_PID_FILE_PATH"),
       "/tmp/auto-mobile-daemon-$userId.pid",
@@ -583,10 +587,11 @@ object DaemonSocketPaths {
     )
   }
 
-  internal fun resolvePidFilePath(
+  internal fun resolveDaemonPath(
     override: String?,
     defaultPath: String,
-    daemonLaunchCwd: String,
+    daemonLaunchCwd: String =
+      System.getenv("AUTOMOBILE_DAEMON_LAUNCH_CWD") ?: System.getProperty("user.dir", "."),
   ): String {
     val configuredPath = override?.trim().takeUnless { it.isNullOrEmpty() } ?: return defaultPath
     val path = Path.of(configuredPath)
@@ -599,7 +604,8 @@ object DaemonSocketPaths {
     resolveClientVersion(
       daemonPackageVersion = System.getenv("AUTOMOBILE_DAEMON_PACKAGE_VERSION"),
       automobileVersion = System.getenv("AUTOMOBILE_VERSION"),
-      manifestVersion = DaemonSocketPaths::class.java.`package`?.implementationVersion,
+      manifestVersion =
+        DaemonSocketPaths::class.java.`package`?.implementationVersion ?: DesktopBuildInfo.VERSION,
     )
 
   internal fun resolveClientVersion(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -272,6 +272,12 @@ class DesktopDaemonLifecycleTest {
   }
 
   @Test
+  fun `extends the command timeout for a configured daemon startup timeout`() {
+    assertEquals(125_000L, SystemDaemonCommandExecutor.commandTimeoutMillis("120000"))
+    assertEquals(60_000L, SystemDaemonCommandExecutor.commandTimeoutMillis("invalid"))
+  }
+
+  @Test
   fun `retries a transient PID-file read before deciding to restart`() {
     val commands = FakeDaemonCommandExecutor()
     val timer = FakeDaemonRetryTimer()

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -14,7 +14,7 @@ class DesktopDaemonLifecycleTest {
     val lifecycle =
       DesktopDaemonLifecycle(
         expectedVersionProvider = { "0.0.40" },
-        socketChecker = FakeDaemonSocketChecker(exists = true),
+        socketChecker = FakeDaemonSocketChecker(listOf(true)),
         pidFileReader = FakeDaemonPidFileReader(listOf("0.0.40+gabc123")),
         commandExecutor = commands,
         timer = FakeDaemonRetryTimer(),
@@ -28,12 +28,34 @@ class DesktopDaemonLifecycleTest {
   }
 
   @Test
+  fun `starts when a matching pid file remains after the daemon socket disappears`() {
+    val commands = FakeDaemonCommandExecutor()
+    val lifecycle =
+      DesktopDaemonLifecycle(
+        expectedVersionProvider = { "0.0.40" },
+        socketChecker = FakeDaemonSocketChecker(listOf(false, true)),
+        pidFileReader = FakeDaemonPidFileReader(listOf("0.0.40", "0.0.40")),
+        commandExecutor = commands,
+        timer = FakeDaemonRetryTimer(),
+      )
+
+    val result = lifecycle.ensureVersionMatchedDaemon()
+
+    assertIs<DaemonLifecycleResult.Ready>(result)
+    assertTrue(result.restarted)
+    assertEquals(
+      listOf(listOf("npx", "-y", "@kaeawc/auto-mobile@0.0.40", "--daemon", "start")),
+      commands.commands,
+    )
+  }
+
+  @Test
   fun `restarts a skewed daemon through the pinned desktop package`() {
     val commands = FakeDaemonCommandExecutor()
     val lifecycle =
       DesktopDaemonLifecycle(
         expectedVersionProvider = { "0.0.40" },
-        socketChecker = FakeDaemonSocketChecker(exists = true),
+        socketChecker = FakeDaemonSocketChecker(listOf(true, true)),
         pidFileReader = FakeDaemonPidFileReader(listOf("0.0.39", "0.0.40")),
         commandExecutor = commands,
         timer = FakeDaemonRetryTimer(),
@@ -55,7 +77,7 @@ class DesktopDaemonLifecycleTest {
     val lifecycle =
       DesktopDaemonLifecycle(
         expectedVersionProvider = { "0.0.40" },
-        socketChecker = FakeDaemonSocketChecker(exists = false),
+        socketChecker = FakeDaemonSocketChecker(listOf(false, true)),
         pidFileReader = FakeDaemonPidFileReader(listOf(null, "0.0.40")),
         commandExecutor = commands,
         timer = FakeDaemonRetryTimer(),
@@ -72,12 +94,12 @@ class DesktopDaemonLifecycleTest {
   }
 
   @Test
-  fun `uses the release package when the desktop build has a source stamp`() {
+  fun `reports source build skew instead of launching a release daemon`() {
     val commands = FakeDaemonCommandExecutor()
     val lifecycle =
       DesktopDaemonLifecycle(
         expectedVersionProvider = { "0.0.40+gabc123" },
-        socketChecker = FakeDaemonSocketChecker(exists = false),
+        socketChecker = FakeDaemonSocketChecker(listOf(true)),
         pidFileReader = FakeDaemonPidFileReader(listOf(null, "0.0.40+gdef456")),
         commandExecutor = commands,
         timer = FakeDaemonRetryTimer(),
@@ -85,11 +107,9 @@ class DesktopDaemonLifecycleTest {
 
     val result = lifecycle.ensureVersionMatchedDaemon()
 
-    assertIs<DaemonLifecycleResult.Ready>(result)
-    assertEquals(
-      listOf(listOf("npx", "-y", "@kaeawc/auto-mobile@0.0.40", "--daemon", "start")),
-      commands.commands,
-    )
+    assertIs<DaemonLifecycleResult.Failure>(result)
+    assertTrue(result.message.contains("source build"))
+    assertTrue(commands.commands.isEmpty())
   }
 
   @Test
@@ -98,7 +118,7 @@ class DesktopDaemonLifecycleTest {
     val lifecycle =
       DesktopDaemonLifecycle(
         expectedVersionProvider = { "0.0.40" },
-        socketChecker = FakeDaemonSocketChecker(exists = true),
+        socketChecker = FakeDaemonSocketChecker(listOf(true, true, true)),
         pidFileReader = FakeDaemonPidFileReader(listOf("0.0.39", "0.0.39")),
         commandExecutor = FakeDaemonCommandExecutor(),
         timer = timer,
@@ -118,7 +138,7 @@ class DesktopDaemonLifecycleTest {
     val lifecycle =
       DesktopDaemonLifecycle(
         expectedVersionProvider = { "0.0.40" },
-        socketChecker = FakeDaemonSocketChecker(exists = false),
+        socketChecker = FakeDaemonSocketChecker(listOf(false)),
         pidFileReader = FakeDaemonPidFileReader(listOf(null)),
         commandExecutor = FakeDaemonCommandExecutor(exitCode = 1, output = ""),
         timer = FakeDaemonRetryTimer(),
@@ -130,15 +150,25 @@ class DesktopDaemonLifecycleTest {
     assertTrue(result.message.contains("Install @kaeawc/auto-mobile@0.0.40"))
   }
 
-  private class FakeDaemonSocketChecker(
-    private val exists: Boolean,
-  ) : DaemonSocketChecker {
-    override fun exists(): Boolean = exists
+  @Test
+  fun `uses the Windows npm command shim`() {
+    val lifecycle = DesktopDaemonLifecycle()
+
+    assertEquals("npx.cmd", lifecycle.npxExecutable("Windows 11"))
+    assertEquals("npx", lifecycle.npxExecutable("Mac OS X"))
   }
 
-  private class FakeDaemonPidFileReader(
-    private val versions: List<String?>,
-  ) : DaemonPidFileReader {
+  private class FakeDaemonSocketChecker(private val states: List<Boolean>) : DaemonSocketChecker {
+    private var reads = 0
+
+    override fun exists(): Boolean {
+      val index = reads.coerceAtMost(states.lastIndex)
+      reads++
+      return states[index]
+    }
+  }
+
+  private class FakeDaemonPidFileReader(private val versions: List<String?>) : DaemonPidFileReader {
     private var reads = 0
 
     override fun readVersion(): String? {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -223,6 +223,57 @@ class DesktopDaemonLifecycleTest {
 
     assertEquals("npx.cmd", lifecycle.npxExecutable("Windows 11"))
     assertEquals("npx", lifecycle.npxExecutable("Mac OS X"))
+    assertEquals(
+      listOf("cmd.exe", "/d", "/v:off", "/s", "/c", "\"\"npx.cmd\" \"-y\"\""),
+      lifecycle.commandForPlatform(listOf("npx.cmd", "-y"), "Windows 11"),
+    )
+  }
+
+  @Test
+  fun `retries a transient PID-file read before deciding to restart`() {
+    val commands = FakeDaemonCommandExecutor()
+    val timer = FakeDaemonRetryTimer()
+    val lifecycle =
+      DesktopDaemonLifecycle(
+        expectedVersionProvider = { "0.0.40" },
+        socketChecker = FakeDaemonSocketChecker(listOf(true)),
+        pidFileReader =
+          FakeDaemonPidFileReader(
+            results =
+              listOf(
+                DaemonPidReadResult.Unreadable,
+                DaemonPidReadResult.Present(DaemonPidState("0.0.40")),
+              )
+          ),
+        commandExecutor = commands,
+        timer = timer,
+      )
+
+    val result = lifecycle.ensureVersionMatchedDaemon()
+
+    assertIs<DaemonLifecycleResult.Ready>(result)
+    assertFalse(result.restarted)
+    assertTrue(commands.commands.isEmpty())
+    assertEquals(listOf(100L), timer.delays)
+  }
+
+  @Test
+  fun `does not restart while the daemon PID-file remains unreadable`() {
+    val commands = FakeDaemonCommandExecutor()
+    val lifecycle =
+      DesktopDaemonLifecycle(
+        expectedVersionProvider = { "0.0.40" },
+        socketChecker = FakeDaemonSocketChecker(listOf(true)),
+        pidFileReader = FakeDaemonPidFileReader(results = listOf(DaemonPidReadResult.Unreadable)),
+        commandExecutor = commands,
+        timer = FakeDaemonRetryTimer(),
+      )
+
+    val result = lifecycle.ensureVersionMatchedDaemon()
+
+    assertIs<DaemonLifecycleResult.Failure>(result)
+    assertTrue(result.message.contains("Could not read"))
+    assertTrue(commands.commands.isEmpty())
   }
 
   @Test
@@ -236,12 +287,13 @@ class DesktopDaemonLifecycleTest {
     )
 
     try {
-      val state = JsonDaemonPidFileReader(pidFile.absolutePath).read()
+      val result = JsonDaemonPidFileReader(pidFile.absolutePath).read()
+      val state = assertIs<DaemonPidReadResult.Present>(result).state
 
-      assertEquals("0.0.39", state?.version)
+      assertEquals("0.0.39", state.version)
       assertEquals(
         listOf("--video-fps", "30", "--network-mockable", "--event-all-markers", "login,save"),
-        state?.launchArguments,
+        state.launchArguments,
       )
     } finally {
       pidFile.delete()
@@ -251,7 +303,7 @@ class DesktopDaemonLifecycleTest {
   private class FakeDaemonSocketChecker(private val states: List<Boolean>) : DaemonSocketChecker {
     private var reads = 0
 
-    override fun exists(): Boolean {
+    override fun isReady(): Boolean {
       val index = reads.coerceAtMost(states.lastIndex)
       reads++
       return states[index]
@@ -259,17 +311,24 @@ class DesktopDaemonLifecycleTest {
   }
 
   private class FakeDaemonPidFileReader(
-    private val versions: List<String?>,
+    private val versions: List<String?> = emptyList(),
     private val launchArguments: List<String> = emptyList(),
+    private val results: List<DaemonPidReadResult>? = null,
   ) : DaemonPidFileReader {
     private var reads = 0
 
-    override fun read(): DaemonPidState? {
+    override fun read(): DaemonPidReadResult {
+      val suppliedResults = results
+      if (suppliedResults != null) {
+        val index = reads.coerceAtMost(suppliedResults.lastIndex)
+        reads++
+        return suppliedResults[index]
+      }
       val index = reads.coerceAtMost(versions.lastIndex)
       reads++
       return versions[index]?.let {
-        DaemonPidState(version = it, launchArguments = launchArguments)
-      }
+        DaemonPidReadResult.Present(DaemonPidState(it, launchArguments))
+      } ?: DaemonPidReadResult.Absent
     }
   }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -31,17 +31,18 @@ class DesktopDaemonLifecycleTest {
   @Test
   fun `starts when a matching pid file remains after the daemon socket disappears`() {
     val commands = FakeDaemonCommandExecutor()
+    val timer = FakeDaemonRetryTimer()
     val lifecycle =
       DesktopDaemonLifecycle(
         expectedVersionProvider = { "0.0.40" },
-        socketChecker = FakeDaemonSocketChecker(listOf(false, true)),
+        socketChecker = FakeDaemonSocketChecker(listOf(false, false, false, true)),
         pidFileReader =
           FakeDaemonPidFileReader(
             versions = listOf("0.0.40", "0.0.40"),
             launchArguments = listOf("--network-mockable"),
           ),
         commandExecutor = commands,
-        timer = FakeDaemonRetryTimer(),
+        timer = timer,
       )
 
     val result = lifecycle.ensureVersionMatchedDaemon()
@@ -61,6 +62,47 @@ class DesktopDaemonLifecycleTest {
       ),
       commands.commands,
     )
+    assertEquals(listOf(150L, 150L), timer.delays)
+  }
+
+  @Test
+  fun `retries a transient socket refusal before replacing a matching daemon`() {
+    val commands = FakeDaemonCommandExecutor()
+    val timer = FakeDaemonRetryTimer()
+    val lifecycle =
+      DesktopDaemonLifecycle(
+        expectedVersionProvider = { "0.0.40" },
+        socketChecker = FakeDaemonSocketChecker(listOf(false, true)),
+        pidFileReader = FakeDaemonPidFileReader(listOf("0.0.40")),
+        commandExecutor = commands,
+        timer = timer,
+      )
+
+    val result = lifecycle.ensureVersionMatchedDaemon()
+
+    assertIs<DaemonLifecycleResult.Ready>(result)
+    assertFalse(result.restarted)
+    assertTrue(commands.commands.isEmpty())
+    assertEquals(listOf(150L), timer.delays)
+  }
+
+  @Test
+  fun `rejects a newer daemon without restarting it`() {
+    val commands = FakeDaemonCommandExecutor()
+    val lifecycle =
+      DesktopDaemonLifecycle(
+        expectedVersionProvider = { "0.0.40" },
+        socketChecker = FakeDaemonSocketChecker(listOf(true)),
+        pidFileReader = FakeDaemonPidFileReader(listOf("0.0.41")),
+        commandExecutor = commands,
+        timer = FakeDaemonRetryTimer(),
+      )
+
+    val result = lifecycle.ensureVersionMatchedDaemon()
+
+    assertIs<DaemonLifecycleResult.Failure>(result)
+    assertTrue(result.message.contains("newer"))
+    assertTrue(commands.commands.isEmpty())
   }
 
   @Test
@@ -298,6 +340,22 @@ class DesktopDaemonLifecycleTest {
     } finally {
       pidFile.delete()
     }
+  }
+
+  @Test
+  fun `resolves PID-file overrides using the daemon launch directory`() {
+    assertEquals(
+      "/tmp/automobile/daemon.pid",
+      DaemonSocketPaths.resolvePidFilePath("daemon.pid", "/tmp/default.pid", "/tmp/automobile"),
+    )
+    assertEquals(
+      "/var/run/automobile.pid",
+      DaemonSocketPaths.resolvePidFilePath(
+        "/var/run/automobile.pid",
+        "/tmp/default.pid",
+        "/tmp/automobile",
+      ),
+    )
   }
 
   private class FakeDaemonSocketChecker(private val states: List<Boolean>) : DaemonSocketChecker {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -35,7 +35,11 @@ class DesktopDaemonLifecycleTest {
       DesktopDaemonLifecycle(
         expectedVersionProvider = { "0.0.40" },
         socketChecker = FakeDaemonSocketChecker(listOf(false, true)),
-        pidFileReader = FakeDaemonPidFileReader(listOf("0.0.40", "0.0.40")),
+        pidFileReader =
+          FakeDaemonPidFileReader(
+            versions = listOf("0.0.40", "0.0.40"),
+            launchArguments = listOf("--network-mockable"),
+          ),
         commandExecutor = commands,
         timer = FakeDaemonRetryTimer(),
       )
@@ -45,7 +49,16 @@ class DesktopDaemonLifecycleTest {
     assertIs<DaemonLifecycleResult.Ready>(result)
     assertTrue(result.restarted)
     assertEquals(
-      listOf(listOf("npx", "-y", "@kaeawc/auto-mobile@0.0.40", "--daemon", "start")),
+      listOf(
+        listOf(
+          "npx",
+          "-y",
+          "@kaeawc/auto-mobile@0.0.40",
+          "--daemon",
+          "start",
+          "--network-mockable",
+        )
+      ),
       commands.commands,
     )
   }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.desktop.core.daemon
 
+import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -67,6 +68,42 @@ class DesktopDaemonLifecycleTest {
     assertTrue(result.restarted)
     assertEquals(
       listOf(listOf("npx", "-y", "@kaeawc/auto-mobile@0.0.40", "--daemon", "restart")),
+      commands.commands,
+    )
+  }
+
+  @Test
+  fun `preserves the skewed daemon options when restarting`() {
+    val commands = FakeDaemonCommandExecutor()
+    val lifecycle =
+      DesktopDaemonLifecycle(
+        expectedVersionProvider = { "0.0.40" },
+        socketChecker = FakeDaemonSocketChecker(listOf(true, true)),
+        pidFileReader =
+          FakeDaemonPidFileReader(
+            versions = listOf("0.0.39", "0.0.40"),
+            launchArguments = listOf("--network-mockable", "--video-fps", "30"),
+          ),
+        commandExecutor = commands,
+        timer = FakeDaemonRetryTimer(),
+      )
+
+    val result = lifecycle.ensureVersionMatchedDaemon()
+
+    assertIs<DaemonLifecycleResult.Ready>(result)
+    assertEquals(
+      listOf(
+        listOf(
+          "npx",
+          "-y",
+          "@kaeawc/auto-mobile@0.0.40",
+          "--daemon",
+          "restart",
+          "--network-mockable",
+          "--video-fps",
+          "30",
+        )
+      ),
       commands.commands,
     )
   }
@@ -158,6 +195,29 @@ class DesktopDaemonLifecycleTest {
     assertEquals("npx", lifecycle.npxExecutable("Mac OS X"))
   }
 
+  @Test
+  fun `reads supported daemon options as restart arguments`() {
+    val pidFile = Files.createTempFile("automobile-daemon", ".json").toFile()
+    pidFile.writeText(
+      """
+      {"version":"0.0.39","options":{"networkMockable":true,"videoFps":30,"eventAllMarkers":["login","save"]}}
+      """
+        .trimIndent()
+    )
+
+    try {
+      val state = JsonDaemonPidFileReader(pidFile.absolutePath).read()
+
+      assertEquals("0.0.39", state?.version)
+      assertEquals(
+        listOf("--video-fps", "30", "--network-mockable", "--event-all-markers", "login,save"),
+        state?.launchArguments,
+      )
+    } finally {
+      pidFile.delete()
+    }
+  }
+
   private class FakeDaemonSocketChecker(private val states: List<Boolean>) : DaemonSocketChecker {
     private var reads = 0
 
@@ -168,13 +228,18 @@ class DesktopDaemonLifecycleTest {
     }
   }
 
-  private class FakeDaemonPidFileReader(private val versions: List<String?>) : DaemonPidFileReader {
+  private class FakeDaemonPidFileReader(
+    private val versions: List<String?>,
+    private val launchArguments: List<String> = emptyList(),
+  ) : DaemonPidFileReader {
     private var reads = 0
 
-    override fun readVersion(): String? {
+    override fun read(): DaemonPidState? {
       val index = reads.coerceAtMost(versions.lastIndex)
       reads++
-      return versions[index]
+      return versions[index]?.let {
+        DaemonPidState(version = it, launchArguments = launchArguments)
+      }
     }
   }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -164,7 +164,7 @@ class DesktopDaemonLifecycleTest {
   }
 
   @Test
-  fun `starts a version-pinned daemon when no socket exists`() {
+  fun `restarts a daemon that becomes reachable before PID state is available`() {
     val commands = FakeDaemonCommandExecutor()
     val lifecycle =
       DesktopDaemonLifecycle(
@@ -180,7 +180,7 @@ class DesktopDaemonLifecycleTest {
     assertIs<DaemonLifecycleResult.Ready>(result)
     assertTrue(result.restarted)
     assertEquals(
-      listOf(listOf("npx", "-y", "@kaeawc/auto-mobile@0.0.40", "--daemon", "start")),
+      listOf(listOf("npx", "-y", "@kaeawc/auto-mobile@0.0.40", "--daemon", "restart")),
       commands.commands,
     )
   }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -1,0 +1,170 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class DesktopDaemonLifecycleTest {
+
+  @Test
+  fun `reuses a daemon with the desktop release version`() {
+    val commands = FakeDaemonCommandExecutor()
+    val lifecycle =
+      DesktopDaemonLifecycle(
+        expectedVersionProvider = { "0.0.40" },
+        socketChecker = FakeDaemonSocketChecker(exists = true),
+        pidFileReader = FakeDaemonPidFileReader(listOf("0.0.40+gabc123")),
+        commandExecutor = commands,
+        timer = FakeDaemonRetryTimer(),
+      )
+
+    val result = lifecycle.ensureVersionMatchedDaemon()
+
+    assertIs<DaemonLifecycleResult.Ready>(result)
+    assertFalse(result.restarted)
+    assertTrue(commands.commands.isEmpty())
+  }
+
+  @Test
+  fun `restarts a skewed daemon through the pinned desktop package`() {
+    val commands = FakeDaemonCommandExecutor()
+    val lifecycle =
+      DesktopDaemonLifecycle(
+        expectedVersionProvider = { "0.0.40" },
+        socketChecker = FakeDaemonSocketChecker(exists = true),
+        pidFileReader = FakeDaemonPidFileReader(listOf("0.0.39", "0.0.40")),
+        commandExecutor = commands,
+        timer = FakeDaemonRetryTimer(),
+      )
+
+    val result = lifecycle.ensureVersionMatchedDaemon()
+
+    assertIs<DaemonLifecycleResult.Ready>(result)
+    assertTrue(result.restarted)
+    assertEquals(
+      listOf(listOf("npx", "-y", "@kaeawc/auto-mobile@0.0.40", "--daemon", "restart")),
+      commands.commands,
+    )
+  }
+
+  @Test
+  fun `starts a version-pinned daemon when no socket exists`() {
+    val commands = FakeDaemonCommandExecutor()
+    val lifecycle =
+      DesktopDaemonLifecycle(
+        expectedVersionProvider = { "0.0.40" },
+        socketChecker = FakeDaemonSocketChecker(exists = false),
+        pidFileReader = FakeDaemonPidFileReader(listOf(null, "0.0.40")),
+        commandExecutor = commands,
+        timer = FakeDaemonRetryTimer(),
+      )
+
+    val result = lifecycle.ensureVersionMatchedDaemon()
+
+    assertIs<DaemonLifecycleResult.Ready>(result)
+    assertTrue(result.restarted)
+    assertEquals(
+      listOf(listOf("npx", "-y", "@kaeawc/auto-mobile@0.0.40", "--daemon", "start")),
+      commands.commands,
+    )
+  }
+
+  @Test
+  fun `uses the release package when the desktop build has a source stamp`() {
+    val commands = FakeDaemonCommandExecutor()
+    val lifecycle =
+      DesktopDaemonLifecycle(
+        expectedVersionProvider = { "0.0.40+gabc123" },
+        socketChecker = FakeDaemonSocketChecker(exists = false),
+        pidFileReader = FakeDaemonPidFileReader(listOf(null, "0.0.40+gdef456")),
+        commandExecutor = commands,
+        timer = FakeDaemonRetryTimer(),
+      )
+
+    val result = lifecycle.ensureVersionMatchedDaemon()
+
+    assertIs<DaemonLifecycleResult.Ready>(result)
+    assertEquals(
+      listOf(listOf("npx", "-y", "@kaeawc/auto-mobile@0.0.40", "--daemon", "start")),
+      commands.commands,
+    )
+  }
+
+  @Test
+  fun `reports an actionable error when the restarted daemon remains skewed`() {
+    val timer = FakeDaemonRetryTimer()
+    val lifecycle =
+      DesktopDaemonLifecycle(
+        expectedVersionProvider = { "0.0.40" },
+        socketChecker = FakeDaemonSocketChecker(exists = true),
+        pidFileReader = FakeDaemonPidFileReader(listOf("0.0.39", "0.0.39")),
+        commandExecutor = FakeDaemonCommandExecutor(),
+        timer = timer,
+        verificationAttempts = 2,
+      )
+
+    val result = lifecycle.ensureVersionMatchedDaemon()
+
+    assertIs<DaemonLifecycleResult.Failure>(result)
+    assertTrue(result.message.contains("0.0.39"))
+    assertTrue(result.message.contains("0.0.40"))
+    assertEquals(listOf(100L), timer.delays)
+  }
+
+  @Test
+  fun `reports installation guidance when the pinned launch command fails without output`() {
+    val lifecycle =
+      DesktopDaemonLifecycle(
+        expectedVersionProvider = { "0.0.40" },
+        socketChecker = FakeDaemonSocketChecker(exists = false),
+        pidFileReader = FakeDaemonPidFileReader(listOf(null)),
+        commandExecutor = FakeDaemonCommandExecutor(exitCode = 1, output = ""),
+        timer = FakeDaemonRetryTimer(),
+      )
+
+    val result = lifecycle.ensureVersionMatchedDaemon()
+
+    assertIs<DaemonLifecycleResult.Failure>(result)
+    assertTrue(result.message.contains("Install @kaeawc/auto-mobile@0.0.40"))
+  }
+
+  private class FakeDaemonSocketChecker(
+    private val exists: Boolean,
+  ) : DaemonSocketChecker {
+    override fun exists(): Boolean = exists
+  }
+
+  private class FakeDaemonPidFileReader(
+    private val versions: List<String?>,
+  ) : DaemonPidFileReader {
+    private var reads = 0
+
+    override fun readVersion(): String? {
+      val index = reads.coerceAtMost(versions.lastIndex)
+      reads++
+      return versions[index]
+    }
+  }
+
+  private class FakeDaemonCommandExecutor(
+    private val exitCode: Int = 0,
+    private val output: String = "started",
+  ) : DaemonCommandExecutor {
+    val commands = mutableListOf<List<String>>()
+
+    override fun execute(command: List<String>): DaemonCommandResult {
+      commands += command
+      return DaemonCommandResult(exitCode = exitCode, output = output)
+    }
+  }
+
+  private class FakeDaemonRetryTimer : DaemonRetryTimer {
+    val delays = mutableListOf<Long>()
+
+    override fun sleep(milliseconds: Long) {
+      delays += milliseconds
+    }
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -352,11 +352,11 @@ class DesktopDaemonLifecycleTest {
   fun `resolves PID-file overrides using the daemon launch directory`() {
     assertEquals(
       "/tmp/automobile/daemon.pid",
-      DaemonSocketPaths.resolvePidFilePath("daemon.pid", "/tmp/default.pid", "/tmp/automobile"),
+      DaemonSocketPaths.resolveDaemonPath("daemon.pid", "/tmp/default.pid", "/tmp/automobile"),
     )
     assertEquals(
       "/var/run/automobile.pid",
-      DaemonSocketPaths.resolvePidFilePath(
+      DaemonSocketPaths.resolveDaemonPath(
         "/var/run/automobile.pid",
         "/tmp/default.pid",
         "/tmp/automobile",

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/DesktopDaemonLifecycleTest.kt
@@ -188,6 +188,23 @@ class DesktopDaemonLifecycleTest {
   }
 
   @Test
+  fun `reports an actionable error when the pinned launch command times out`() {
+    val lifecycle =
+      DesktopDaemonLifecycle(
+        expectedVersionProvider = { "0.0.40" },
+        socketChecker = FakeDaemonSocketChecker(listOf(false)),
+        pidFileReader = FakeDaemonPidFileReader(listOf(null)),
+        commandExecutor = FakeDaemonCommandExecutor(exitCode = -1, timedOut = true),
+        timer = FakeDaemonRetryTimer(),
+      )
+
+    val result = lifecycle.ensureVersionMatchedDaemon()
+
+    assertIs<DaemonLifecycleResult.Failure>(result)
+    assertTrue(result.message.contains("Timed out"))
+  }
+
+  @Test
   fun `uses the Windows npm command shim`() {
     val lifecycle = DesktopDaemonLifecycle()
 
@@ -246,12 +263,13 @@ class DesktopDaemonLifecycleTest {
   private class FakeDaemonCommandExecutor(
     private val exitCode: Int = 0,
     private val output: String = "started",
+    private val timedOut: Boolean = false,
   ) : DaemonCommandExecutor {
     val commands = mutableListOf<List<String>>()
 
     override fun execute(command: List<String>): DaemonCommandResult {
       commands += command
-      return DaemonCommandResult(exitCode = exitCode, output = output)
+      return DaemonCommandResult(exitCode = exitCode, output = output, timedOut = timedOut)
     }
   }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientHandshakeTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientHandshakeTest.kt
@@ -1,0 +1,55 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+
+class McpDaemonClientHandshakeTest {
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  @Test
+  fun `normalizeClientVersion keeps concrete versions and drops unpinnable aliases`() {
+    assertEquals("0.0.40", DaemonSocketPaths.normalizeClientVersion(" 0.0.40 "))
+    assertNull(DaemonSocketPaths.normalizeClientVersion("latest"))
+    assertNull(DaemonSocketPaths.normalizeClientVersion("UNKNOWN"))
+    assertNull(DaemonSocketPaths.normalizeClientVersion("   "))
+    assertNull(DaemonSocketPaths.normalizeClientVersion(null))
+  }
+
+  @Test
+  fun `daemon request serializes clientVersion for the handshake`() {
+    val request =
+      DaemonRequest(
+        id = "req-1",
+        type = "mcp_request",
+        method = "ide/ping",
+        params = JsonObject(emptyMap()),
+        clientVersion = "0.0.40",
+      )
+
+    val encoded = json.encodeToString(request)
+
+    assertTrue(encoded.contains("\"clientVersion\":\"0.0.40\""))
+  }
+
+  @Test
+  fun `daemon request omits clientVersion when the desktop build is unknown`() {
+    val request =
+      DaemonRequest(
+        id = "req-1",
+        type = "mcp_request",
+        method = "ide/ping",
+        params = JsonObject(emptyMap()),
+      )
+
+    val encoded = json.encodeToString(request)
+
+    assertFalse(encoded.contains("clientVersion"))
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientHandshakeTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientHandshakeTest.kt
@@ -23,6 +23,18 @@ class McpDaemonClientHandshakeTest {
   }
 
   @Test
+  fun `resolveClientVersion falls back after an unpinnable environment alias`() {
+    assertEquals(
+      "0.0.40",
+      DaemonSocketPaths.resolveClientVersion(
+        daemonPackageVersion = "latest",
+        automobileVersion = "unknown",
+        manifestVersion = "0.0.40",
+      ),
+    )
+  }
+
+  @Test
   fun `daemon request serializes clientVersion for the handshake`() {
     val request =
       DaemonRequest(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
@@ -25,6 +25,19 @@ class McpDaemonClientInputTest {
   private val json = Json { ignoreUnknownKeys = true }
 
   @Test
+  fun `socket requests declare the desktop client version`() {
+    TestDaemonSocket(resultJson = "{}", error = null).use { server ->
+      McpDaemonClient(
+          socketPathValue = server.socketPath.toString(),
+          clientVersion = "0.0.40",
+        )
+        .ping()
+
+      assertEquals("0.0.40", server.awaitRequest().clientVersion)
+    }
+  }
+
+  @Test
   fun `inputTap serializes to input tap socket request`() {
     val responseResult =
       """
@@ -256,6 +269,7 @@ class McpDaemonClientInputTest {
             CapturedDaemonRequest(
               method = request.getValue("method").jsonPrimitive.content,
               params = request.getValue("params").jsonObject,
+              clientVersion = request["clientVersion"]?.jsonPrimitive?.content,
             )
           writer.write(responseLine(request.getValue("id").jsonPrimitive.content))
           writer.newLine()
@@ -310,4 +324,5 @@ private data class CapturedInputCall(
 private data class CapturedDaemonRequest(
   val method: String,
   val params: JsonObject,
+  val clientVersion: String?,
 )

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
@@ -38,6 +38,26 @@ class McpDaemonClientInputTest {
   }
 
   @Test
+  fun `socket requests surface lifecycle failures before opening the socket`() {
+    val lifecycle =
+      object : DaemonLifecycleEnsurer {
+        override fun ensureVersionMatchedDaemon(): DaemonLifecycleResult =
+          DaemonLifecycleResult.Failure("daemon version mismatch")
+      }
+
+    val error =
+      assertFailsWith<DaemonUnavailableException> {
+        McpDaemonClient(
+            socketPathValue = "/tmp/not-a-daemon.sock",
+            daemonLifecycle = lifecycle,
+          )
+          .ping()
+      }
+
+    assertEquals("daemon version mismatch", error.message)
+  }
+
+  @Test
   fun `inputTap serializes to input tap socket request`() {
     val responseResult =
       """


### PR DESCRIPTION
## Summary

Closes [#2809](https://github.com/kaeawc/auto-mobile/issues/2809).

The desktop socket client had been deliberately left ungated because its Start Daemon action launched whichever `auto-mobile` happened to be on `PATH`. That could report success while the daemon's server-side handshake rejected every later desktop request.

- Restore the desktop `clientVersion` handshake and stamp the desktop JAR with the npm package version.
- Add a version-matched desktop daemon lifecycle: reuse a matching daemon, or restart/start the exact `@kaeawc/auto-mobile` release through `npx` and verify the PID-file version before UI work continues.
- Surface actionable failure text instead of treating an unverified or skewed daemon as ready.

## Validation

- `bun run turbo:validate` — 9,915 passed, 0 failed (14 integration tests skipped by design)
- `bun run typecheck` — no new errors over the baseline
- `(cd android && ./gradlew :desktop-core:test :desktop-core:detekt)` — 575 tests passed, 6 skipped
- Verified the desktop-core JAR manifest contains `Implementation-Version: 0.0.46`.
