### PR TITLE
test(observe-ios): burn down 17 verified test-quality findings (#4174)

### DIFF
--- a/src/features/observe/ios/IosSdkEventIngestor.ts
+++ b/src/features/observe/ios/IosSdkEventIngestor.ts
@@ -348,9 +348,16 @@ export class DefaultIosSdkEventIngestor implements IosSdkEventIngestor {
     } finally {
       // Restore previous context so Android events aren't mis-attributed, even
       // when the body threw after setContext (getContext throwing leaves
-      // prevContext undefined — nothing to restore).
+      // prevContext undefined — nothing to restore). The restore runs in the
+      // finally, OUTSIDE the catch above, so it must guard its own throw or the
+      // exception would escape this best-effort method and break observation
+      // (processMessage calls it).
       if (prevContext) {
-        recorder.setContext(prevContext.deviceId, prevContext.sessionId);
+        try {
+          recorder.setContext(prevContext.deviceId, prevContext.sessionId);
+        } catch (error) {
+          logger.warn(`[IosSdkEventIngestor] Failed to restore telemetry context: ${error}`);
+        }
       }
     }
   }

--- a/src/features/observe/ios/IosSdkEventIngestor.ts
+++ b/src/features/observe/ios/IosSdkEventIngestor.ts
@@ -313,9 +313,14 @@ export class DefaultIosSdkEventIngestor implements IosSdkEventIngestor {
 
   /** Record a layout telemetry event from converted iOS hierarchy (ViewHierarchyResult format) */
   recordLayoutTelemetryEvent(hierarchy: ViewHierarchyResult): void {
+    const recorder = this.telemetryRecorder;
+    // Capture the prior context before the try so it is available in the finally
+    // even if setContext/recordLayoutEvent throws. Without the finally, a recorder
+    // that threw mid-record would leave the shared context pinned to the iOS udid,
+    // permanently mis-attributing subsequent Android telemetry.
+    let prevContext: { deviceId: string | null; sessionId: string | null } | undefined;
     try {
-      const recorder = this.telemetryRecorder;
-      const prevContext = recorder.getContext();
+      prevContext = recorder.getContext();
       recorder.setContext(this.deviceId, null);
       const nodeCount = this.countViewHierarchyNodes(hierarchy.hierarchy);
       // Use the converted ViewHierarchyResult format — same data as the observation stream
@@ -338,9 +343,15 @@ export class DefaultIosSdkEventIngestor implements IosSdkEventIngestor {
         detailsJson: hierarchyJson.length < 200000 ? hierarchyJson : JSON.stringify({ nodeCount, truncated: true }),
         screenName: hierarchy.packageName ?? null,
       });
-      recorder.setContext(prevContext.deviceId, prevContext.sessionId);
     } catch {
       // Non-fatal — telemetry recording should never break observation
+    } finally {
+      // Restore previous context so Android events aren't mis-attributed, even
+      // when the body threw after setContext (getContext throwing leaves
+      // prevContext undefined — nothing to restore).
+      if (prevContext) {
+        recorder.setContext(prevContext.deviceId, prevContext.sessionId);
+      }
     }
   }
 

--- a/test/fakes/FakeIOSCtrlProxyManager.ts
+++ b/test/fakes/FakeIOSCtrlProxyManager.ts
@@ -15,6 +15,7 @@ export class FakeIOSCtrlProxyManager implements CtrlProxyIosManager {
   private shouldStartFail: boolean = false;
   private shouldStopFail: boolean = false;
   private shouldSetupFail: boolean = false;
+  private shouldForceRestartFail: boolean = false;
 
   // MARK: - Configuration Methods
 
@@ -72,6 +73,15 @@ export class FakeIOSCtrlProxyManager implements CtrlProxyIosManager {
    */
   setSetupShouldFail(shouldFail: boolean): void {
     this.shouldSetupFail = shouldFail;
+  }
+
+  /**
+   * Configure forceRestart() to reject. Exercises the client's restart-failure
+   * (catch) branch, which must reset its in-flight-restart guard so later
+   * failures can retry.
+   */
+  setForceRestartShouldFail(shouldFail: boolean): void {
+    this.shouldForceRestartFail = shouldFail;
   }
 
   // MARK: - Assertion Methods
@@ -192,6 +202,11 @@ export class FakeIOSCtrlProxyManager implements CtrlProxyIosManager {
 
   async forceRestart(): Promise<void> {
     this.executedOperations.push("forceRestart");
+
+    if (this.shouldForceRestartFail) {
+      throw new Error("Failed to force-restart IOSCtrlProxy");
+    }
+
     this.runningState = true;
   }
 

--- a/test/fakes/FakeIOSCtrlProxyManager.ts
+++ b/test/fakes/FakeIOSCtrlProxyManager.ts
@@ -16,6 +16,7 @@ export class FakeIOSCtrlProxyManager implements CtrlProxyIosManager {
   private shouldStopFail: boolean = false;
   private shouldSetupFail: boolean = false;
   private shouldForceRestartFail: boolean = false;
+  private shouldIsRunningFail: boolean = false;
 
   // MARK: - Configuration Methods
 
@@ -84,6 +85,15 @@ export class FakeIOSCtrlProxyManager implements CtrlProxyIosManager {
     this.shouldForceRestartFail = shouldFail;
   }
 
+  /**
+   * Configure isRunning() to reject. Exercises the client's status-probe-failure
+   * (outer catch) branch, which must reset its in-flight-restart guard so a later
+   * threshold crossing probes/restarts again rather than being suppressed forever.
+   */
+  setIsRunningShouldFail(shouldFail: boolean): void {
+    this.shouldIsRunningFail = shouldFail;
+  }
+
   // MARK: - Assertion Methods
 
   /**
@@ -123,6 +133,9 @@ export class FakeIOSCtrlProxyManager implements CtrlProxyIosManager {
 
   async isRunning(): Promise<boolean> {
     this.executedOperations.push("isRunning");
+    if (this.shouldIsRunningFail) {
+      throw new Error("FakeIOSCtrlProxyManager: isRunning failure (test seam)");
+    }
     return this.runningState;
   }
 

--- a/test/features/observe/ios/CtrlProxyClientRestartThreshold.test.ts
+++ b/test/features/observe/ios/CtrlProxyClientRestartThreshold.test.ts
@@ -6,8 +6,9 @@ import {
 } from "../../../fakes/FakeWebSocket";
 import { FakeTimer } from "../../../fakes/FakeTimer";
 import type { CtrlProxyIosManager } from "../../../../src/utils/IOSCtrlProxyManager";
+import { FakeIOSCtrlProxyManager } from "../../../fakes/FakeIOSCtrlProxyManager";
 
-function createFakeManager(overrides: Partial<CtrlProxyIosManager> = {}): CtrlProxyIosManager & { forceRestartCount: number } {
+function createFakeManager(): CtrlProxyIosManager & { forceRestartCount: number } {
   const manager = {
     forceRestartCount: 0,
     async setup() { return { success: false as const, message: "test" }; },
@@ -20,7 +21,6 @@ function createFakeManager(overrides: Partial<CtrlProxyIosManager> = {}): CtrlPr
     setAutoRestart() {},
     isAutoRestartEnabled() { return false; },
     async forceRestart() { manager.forceRestartCount++; },
-    ...overrides,
   };
   return manager;
 }
@@ -103,68 +103,6 @@ describe("IOSCtrlProxyClient restart threshold", () => {
     expect(fakeManager.forceRestartCount).toBe(2);
   });
 
-  test("restart counter resets after successful connection allows re-triggering", async () => {
-    const fakeTimer = new FakeTimer();
-    fakeTimer.enableAutoAdvance();
-
-    const fakeManager = createFakeManager();
-    const serviceManagerFactory = (_device: BootedDevice) => fakeManager;
-
-    // Fail 3 times (triggers restart), then succeed on attempt 4, then fail again
-    // DeviceServiceClient has maxConnectionAttempts=3 by default, so we use a fresh
-    // factory that tracks total calls
-    let wsAttempt = 0;
-    const wsFactory = (url: string) => {
-      wsAttempt++;
-      const { FakeWebSocket } = require("../../../fakes/FakeWebSocket");
-      // Succeed on attempt 4, fail otherwise
-      return new FakeWebSocket(url, wsAttempt === 4 ? "none" : "instant", 0, fakeTimer);
-    };
-
-    client = IOSCtrlProxyClient.createForTesting(
-      testDevice,
-      8765,
-      wsFactory,
-      fakeTimer,
-      serviceManagerFactory,
-    );
-
-    // 3 failures → triggers restart
-    await client.ensureConnected();
-    await client.ensureConnected();
-    await client.ensureConnected();
-    await new Promise(resolve => fakeTimer.setTimeout(resolve, 10));
-    expect(fakeManager.forceRestartCount).toBe(1);
-
-    // Advance past the DeviceServiceClient connection cooldown (default 10s)
-    fakeTimer.advanceTime(11000);
-
-    // 4th attempt succeeds → resets consecutiveConnectionFailures to 0
-    const result = await client.ensureConnected();
-    expect(result).toBe(true);
-
-    // Now close and fail 3 more times — should trigger a second restart
-    await client.close();
-    IOSCtrlProxyClient.resetInstances();
-
-    // New client for the next cycle
-    wsAttempt = 0; // Reset factory
-    const fakeManager2 = createFakeManager();
-    client = IOSCtrlProxyClient.createForTesting(
-      testDevice,
-      8765,
-      createInstantFailureWebSocketFactory(fakeTimer),
-      fakeTimer,
-      (_device: BootedDevice) => fakeManager2,
-    );
-
-    for (let i = 0; i < 3; i++) {
-      await client.ensureConnected();
-    }
-    await new Promise(resolve => fakeTimer.setTimeout(resolve, 10));
-    expect(fakeManager2.forceRestartCount).toBe(1);
-  });
-
   test("no restart triggered when failures below threshold", async () => {
     const fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
@@ -187,5 +125,105 @@ describe("IOSCtrlProxyClient restart threshold", () => {
     await new Promise(resolve => fakeTimer.setTimeout(resolve, 10));
 
     expect(fakeManager.forceRestartCount).toBe(0);
+  });
+
+  describe("triggerServiceRestart branches", () => {
+    const driveFailuresPastThreshold = async (
+      c: IOSCtrlProxyClient,
+      fakeTimer: FakeTimer
+    ): Promise<void> => {
+      // Mirror the threshold-crossing pattern the other tests use: a batch of
+      // attempts, then advance past the connection cooldown so the failure counter
+      // can climb to a multiple of MAX_FAILURES_BEFORE_RESTART (3).
+      for (let i = 0; i < 3; i++) {
+        await c.ensureConnected();
+      }
+      fakeTimer.advanceTime(11000);
+      for (let i = 0; i < 3; i++) {
+        await c.ensureConnected();
+      }
+      // Let the async isRunning()/forceRestart() chain settle.
+      await new Promise(resolve => fakeTimer.setTimeout(resolve, 10));
+    };
+
+    test("does not force-restart when the manager reports the runner is still running", async () => {
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+
+      const manager = new FakeIOSCtrlProxyManager();
+      manager.setSetupShouldFail(true);
+      // Runner is alive; the WebSocket failure is transient, so no restart is due.
+      manager.setRunning(true);
+
+      client = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        8765,
+        createInstantFailureWebSocketFactory(fakeTimer),
+        fakeTimer,
+        (_device: BootedDevice) => manager,
+      );
+
+      await driveFailuresPastThreshold(client, fakeTimer);
+
+      expect(manager.getCallCount("forceRestart")).toBe(0);
+    });
+
+    test("force-restarts a down runner and recovers when the restart rejects", async () => {
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+
+      const manager = new FakeIOSCtrlProxyManager();
+      // Failed setup must not flip runningState, so isRunning() stays false and the
+      // restart path is taken; the restart itself then rejects.
+      manager.setSetupShouldFail(true);
+      manager.setForceRestartShouldFail(true);
+
+      client = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        8765,
+        createInstantFailureWebSocketFactory(fakeTimer),
+        fakeTimer,
+        (_device: BootedDevice) => manager,
+      );
+
+      await driveFailuresPastThreshold(client, fakeTimer);
+
+      // The restart was attempted (down-branch entered, not the already-running branch)...
+      expect(manager.getCallCount("forceRestart")).toBeGreaterThanOrEqual(1);
+
+      // ...and the catch branch reset the in-flight-restart guard, so a further
+      // threshold crossing retries. Without that reset the guard wedges forever
+      // and forceRestart never fires again.
+      fakeTimer.advanceTime(11000);
+      for (let i = 0; i < 6; i++) {
+        await client.ensureConnected();
+      }
+      await new Promise(resolve => fakeTimer.setTimeout(resolve, 10));
+      expect(manager.getCallCount("forceRestart")).toBeGreaterThanOrEqual(2);
+    });
+
+    test("probes the running-state and never force-restarts across repeated threshold crossings while running", async () => {
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+
+      const manager = new FakeIOSCtrlProxyManager();
+      manager.setSetupShouldFail(true);
+      manager.setRunning(true);
+
+      client = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        8765,
+        createInstantFailureWebSocketFactory(fakeTimer),
+        fakeTimer,
+        (_device: BootedDevice) => manager,
+      );
+
+      await driveFailuresPastThreshold(client, fakeTimer);
+
+      // Running-state is probed as part of the restart decision on every crossing...
+      expect(manager.getCallCount("isRunning")).toBeGreaterThan(0);
+      // ...and because it stays running, no threshold crossing ever force-restarts.
+      expect(manager.getCallCount("forceRestart")).toBe(0);
+    });
   });
 });

--- a/test/features/observe/ios/CtrlProxyClientRestartThreshold.test.ts
+++ b/test/features/observe/ios/CtrlProxyClientRestartThreshold.test.ts
@@ -225,5 +225,42 @@ describe("IOSCtrlProxyClient restart threshold", () => {
       // ...and because it stays running, no threshold crossing ever force-restarts.
       expect(manager.getCallCount("forceRestart")).toBe(0);
     });
+
+    test("recovers when the status probe rejects so a later crossing probes again", async () => {
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+
+      const manager = new FakeIOSCtrlProxyManager();
+      manager.setSetupShouldFail(true);
+      // The status probe itself rejects — the SEPARATE outer catch (distinct from the
+      // forceRestart-failure catch) must reset the in-flight-restart guard, or every
+      // later restart attempt is suppressed forever.
+      manager.setIsRunningShouldFail(true);
+
+      client = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        8765,
+        createInstantFailureWebSocketFactory(fakeTimer),
+        fakeTimer,
+        (_device: BootedDevice) => manager,
+      );
+
+      await driveFailuresPastThreshold(client, fakeTimer);
+      // The probe rejected before ever reaching forceRestart, so nothing restarted yet.
+      expect(manager.getCallCount("isRunning")).toBeGreaterThan(0);
+      expect(manager.getCallCount("forceRestart")).toBe(0);
+
+      // The probe now succeeds and reports the runner DOWN, so the next crossing is
+      // due to force-restart. That can only happen if the outer catch reset the
+      // in-flight guard; if it wedged the guard, this crossing early-returns and
+      // forceRestart never fires.
+      manager.setIsRunningShouldFail(false);
+      fakeTimer.advanceTime(11000);
+      for (let i = 0; i < 6; i++) {
+        await client.ensureConnected();
+      }
+      await new Promise(resolve => fakeTimer.setTimeout(resolve, 10));
+      expect(manager.getCallCount("forceRestart")).toBeGreaterThanOrEqual(1);
+    });
   });
 });

--- a/test/features/observe/ios/CtrlProxyDatabase.test.ts
+++ b/test/features/observe/ios/CtrlProxyDatabase.test.ts
@@ -169,3 +169,175 @@ describe("CtrlProxyDatabase (iOS)", function() {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// PARAM-2 (issue #4174, item 5): delegate-level 5 ops x outcomes.
+//
+// The client-level executeSQLForIos round-trips above drive a real FakeWebSocket
+// + decode. This block drives the CtrlProxyDatabase DELEGATE directly through a
+// real RequestManager + FakeTimer so the four previously-untested ops
+// (listDatabases/listTables/getTableData/getTableStructure) and every op's
+// timeout / not-connected / failure path get an asserted outcome, and the
+// executeSQL `queryType` default is pinned. Timeouts fire by advancing the fake
+// clock (asserted message), never by a real hang.
+// ---------------------------------------------------------------------------
+import { createIosDelegateHarness, type IosDelegateHarness } from "../../../helpers/iosDelegateHarness";
+import { CtrlProxyDatabase } from "../../../../src/features/observe/ios/CtrlProxyDatabase";
+
+describe("CtrlProxyDatabase delegate outcomes", () => {
+  const flush = (): Promise<void> => new Promise<void>(resolve => setImmediate(resolve));
+  const TIMEOUT = 5000;
+
+  let h: IosDelegateHarness;
+  let db: CtrlProxyDatabase;
+
+  beforeEach(() => {
+    h = createIosDelegateHarness();
+    db = new CtrlProxyDatabase(h.context);
+  });
+
+  interface Op {
+    op: string;
+    wireType: string;
+    timeoutMsg: string;
+    defaultErrorMsg: string;
+    call: () => Promise<unknown>;
+    successPayload: Record<string, unknown>;
+    assertSuccess: (value: unknown) => void;
+  }
+
+  const ops: Op[] = [
+    {
+      op: "executeSQL",
+      wireType: "execute_sql",
+      timeoutMsg: `Execute SQL timeout after ${TIMEOUT}ms`,
+      defaultErrorMsg: "Execute SQL failed",
+      call: () => db.executeSQL("com.app", "/db/main.db", "SELECT 1", TIMEOUT),
+      successPayload: { success: true, totalTimeMs: 1, queryType: "query", columns: ["id"], rows: [[1], [2]] },
+      assertSuccess: value => {
+        expect(value).toEqual({ type: "query", columns: ["id"], rows: [[1], [2]] });
+      },
+    },
+    {
+      op: "listDatabases",
+      wireType: "list_databases",
+      timeoutMsg: `List databases timeout after ${TIMEOUT}ms`,
+      defaultErrorMsg: "List databases failed",
+      call: () => db.listDatabases("com.app", TIMEOUT),
+      successPayload: { success: true, totalTimeMs: 1, databases: [{ name: "main", path: "/db/main.db" }] },
+      assertSuccess: value => {
+        expect(value).toEqual([{ name: "main", path: "/db/main.db" }]);
+      },
+    },
+    {
+      op: "listTables",
+      wireType: "list_tables",
+      timeoutMsg: `List tables timeout after ${TIMEOUT}ms`,
+      defaultErrorMsg: "List tables failed",
+      call: () => db.listTables("com.app", "/db/main.db", TIMEOUT),
+      successPayload: { success: true, totalTimeMs: 1, tables: ["users", "orders"] },
+      assertSuccess: value => {
+        expect(value).toEqual(["users", "orders"]);
+      },
+    },
+    {
+      op: "getTableData",
+      wireType: "get_table_data",
+      timeoutMsg: `Get table data timeout after ${TIMEOUT}ms`,
+      defaultErrorMsg: "Get table data failed",
+      call: () => db.getTableData("com.app", "/db/main.db", "users", 50, 0, TIMEOUT),
+      successPayload: { success: true, totalTimeMs: 1, columns: ["id", "name"], rows: [[1, "a"]], total: 1 },
+      assertSuccess: value => {
+        expect(value).toEqual({ columns: ["id", "name"], rows: [[1, "a"]], total: 1 });
+      },
+    },
+    {
+      op: "getTableStructure",
+      wireType: "get_table_structure",
+      timeoutMsg: `Get table structure timeout after ${TIMEOUT}ms`,
+      defaultErrorMsg: "Get table structure failed",
+      call: () => db.getTableStructure("com.app", "/db/main.db", "users", TIMEOUT),
+      successPayload: {
+        success: true,
+        totalTimeMs: 1,
+        columns: [{ name: "id", type: "INTEGER", nullable: false, primaryKey: true }],
+      },
+      assertSuccess: value => {
+        expect(value).toEqual({ columns: [{ name: "id", type: "INTEGER", nullable: false, primaryKey: true }] });
+      },
+    },
+  ];
+
+  for (const o of ops) {
+    describe(o.op, () => {
+      test(`sends ${o.wireType} and resolves the mapped value on success`, async () => {
+        const promise = o.call();
+        await flush();
+        expect(h.sentMessages[0]).toMatchObject({ type: o.wireType });
+        expect(typeof h.sentMessages[0].requestId).toBe("string");
+        expect(h.resolveLast(o.successPayload)).toBe(true);
+        o.assertSuccess(await promise);
+      });
+
+      test("throws the runner-supplied error when success is false", async () => {
+        const promise = o.call();
+        await flush();
+        h.resolveLast({ success: false, totalTimeMs: 2, error: "runner said no" });
+        await expect(promise).rejects.toThrow("runner said no");
+      });
+
+      test("throws the default message when a failure carries no error string", async () => {
+        const promise = o.call();
+        await flush();
+        h.resolveLast({ success: false, totalTimeMs: 2 });
+        await expect(promise).rejects.toThrow(o.defaultErrorMsg);
+      });
+
+      test("throws an actionable timeout message after the deadline (no silent hang)", async () => {
+        const promise = o.call();
+        await flush();
+        expect(h.requestManager.getPendingCount()).toBe(1);
+        h.advanceTime(TIMEOUT);
+        await expect(promise).rejects.toThrow(o.timeoutMsg);
+      });
+
+      test("throws when not connected without sending on the wire", async () => {
+        h.setConnected(false);
+        await expect(o.call()).rejects.toThrow("Failed to connect to CtrlProxy");
+        expect(h.sentMessages).toHaveLength(0);
+      });
+    });
+  }
+
+  // executeSQL queryType defaulting (the "queryType default unpinned" gap).
+  describe("executeSQL queryType defaulting", () => {
+    test("maps queryType 'mutation' to a rowsAffected result", async () => {
+      const promise = db.executeSQL("com.app", "/db/main.db", "DELETE FROM t", TIMEOUT);
+      await flush();
+      h.resolveLast({ success: true, totalTimeMs: 1, queryType: "mutation", rowsAffected: 4 });
+      expect(await promise).toEqual({ type: "mutation", rowsAffected: 4 });
+    });
+
+    test("defaults rowsAffected to 0 for a mutation that omits it", async () => {
+      const promise = db.executeSQL("com.app", "/db/main.db", "DELETE FROM t", TIMEOUT);
+      await flush();
+      h.resolveLast({ success: true, totalTimeMs: 1, queryType: "mutation" });
+      expect(await promise).toEqual({ type: "mutation", rowsAffected: 0 });
+    });
+
+    test("treats an absent queryType as a query (not a mutation)", async () => {
+      const promise = db.executeSQL("com.app", "/db/main.db", "SELECT 1", TIMEOUT);
+      await flush();
+      // No queryType field at all: the default half must be 'query'.
+      h.resolveLast({ success: true, totalTimeMs: 1, columns: ["n"], rows: [[1]] });
+      expect(await promise).toEqual({ type: "query", columns: ["n"], rows: [[1]] });
+    });
+
+    test("defaults columns and rows to empty arrays for a query that omits them", async () => {
+      const promise = db.executeSQL("com.app", "/db/main.db", "SELECT 1", TIMEOUT);
+      await flush();
+      h.resolveLast({ success: true, totalTimeMs: 1, queryType: "query" });
+      expect(await promise).toEqual({ type: "query", columns: [], rows: [] });
+    });
+  });
+});

--- a/test/features/observe/ios/CtrlProxyGestures.test.ts
+++ b/test/features/observe/ios/CtrlProxyGestures.test.ts
@@ -59,8 +59,8 @@ async function callAndResolve<T>(
 }
 
 describe("iOS CtrlProxyGestures", () => {
-  it("waits for the canonical multi-finger swipe result response type", async () => {
-    const { context, sent, requestManager } = createFakeContext();
+  it("resolves the multi-finger swipe request by matching request id", async () => {
+    const { context, sent } = createFakeContext();
     const gestures = new CtrlProxyGestures(context);
 
     const { sentMsg, result } = await callAndResolve(
@@ -71,7 +71,6 @@ describe("iOS CtrlProxyGestures", () => {
 
     expect(sentMsg.type).toBe("request_multi_finger_swipe");
     expect(sentMsg.fingerCount).toBe(3);
-    expect(requestManager.lastRegisteredType).toBe("multi_finger_swipe_result");
     expect(context.requestManager.getPendingCount()).toBe(0);
     expect(result.success).toBe(true);
   });

--- a/test/features/observe/ios/CtrlProxyStorage.test.ts
+++ b/test/features/observe/ios/CtrlProxyStorage.test.ts
@@ -388,3 +388,151 @@ describe("CtrlProxyStorage (iOS)", function() {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// PARAM-1 (issue #4174, item 3): delegate-level 6 ops x 4 outcomes.
+//
+// The client-level round-trips above drive a real FakeWebSocket + decode; this
+// block drives the CtrlProxyStorage DELEGATE directly through a real
+// RequestManager + FakeTimer (test/helpers/iosDelegateHarness.ts) so the
+// timeout and not-connected paths — previously untested (grep "timeout after"
+// in this dir returned 0) — get an actionable, asserted failure instead of a
+// silent hang. Time is fully controlled: the timeout rows fire by advancing the
+// fake clock and asserting the message, never by a real 5s hang.
+// ---------------------------------------------------------------------------
+import { createIosDelegateHarness, type IosDelegateHarness } from "../../../helpers/iosDelegateHarness";
+import { CtrlProxyStorage } from "../../../../src/features/observe/ios/CtrlProxyStorage";
+
+describe("CtrlProxyStorage delegate outcomes (6 ops x 4)", () => {
+  const flush = (): Promise<void> => new Promise<void>(resolve => setImmediate(resolve));
+  const TIMEOUT = 5000;
+
+  let h: IosDelegateHarness;
+  let storage: CtrlProxyStorage;
+
+  beforeEach(() => {
+    h = createIosDelegateHarness();
+    storage = new CtrlProxyStorage(h.context);
+  });
+
+  interface Op {
+    op: string;
+    wireType: string;
+    timeoutMsg: string;
+    defaultErrorMsg: string;
+    call: () => Promise<unknown>;
+    successPayload: Record<string, unknown>;
+    assertSuccess: (value: unknown) => void;
+  }
+
+  const ops: Op[] = [
+    {
+      op: "listPreferenceFiles",
+      wireType: "list_preference_files",
+      timeoutMsg: `List preference files timeout after ${TIMEOUT}ms`,
+      defaultErrorMsg: "Failed to list preference files",
+      call: () => storage.listPreferenceFiles("com.app", TIMEOUT),
+      successPayload: { success: true, totalTimeMs: 1, files: [{ name: "Standard", path: "Standard", entryCount: 2 }] },
+      assertSuccess: value => {
+        expect(value).toEqual([{ name: "Standard", path: "Standard", entryCount: 2 }]);
+      },
+    },
+    {
+      op: "getPreferenceEntries",
+      wireType: "get_preferences",
+      timeoutMsg: `Get preferences timeout after ${TIMEOUT}ms`,
+      defaultErrorMsg: "Failed to get preference entries",
+      call: () => storage.getPreferenceEntries("com.app", "Standard", TIMEOUT),
+      successPayload: { success: true, totalTimeMs: 1, entries: [{ key: "theme", value: "dark", type: "STRING" }] },
+      assertSuccess: value => {
+        expect(value).toEqual([{ key: "theme", value: "dark", type: "STRING" }]);
+      },
+    },
+    {
+      op: "getPreference",
+      wireType: "get_preference",
+      timeoutMsg: `Get preference timeout after ${TIMEOUT}ms`,
+      defaultErrorMsg: "Failed to get preference",
+      call: () => storage.getPreference("com.app", "Standard", "theme", TIMEOUT),
+      successPayload: { success: true, found: true, totalTimeMs: 1, entry: { key: "theme", value: "dark", type: "STRING" } },
+      assertSuccess: value => {
+        expect(value).toEqual({ key: "theme", value: "dark", type: "STRING" });
+      },
+    },
+    {
+      op: "setPreference",
+      wireType: "set_preference",
+      timeoutMsg: `Set preference timeout after ${TIMEOUT}ms`,
+      defaultErrorMsg: "Failed to set preference",
+      call: () => storage.setPreference("com.app", "Standard", "theme", "dark", "STRING", TIMEOUT),
+      successPayload: { success: true, totalTimeMs: 1 },
+      assertSuccess: value => {
+        expect(value).toBeUndefined();
+      },
+    },
+    {
+      op: "removePreference",
+      wireType: "remove_preference",
+      timeoutMsg: `Remove preference timeout after ${TIMEOUT}ms`,
+      defaultErrorMsg: "Failed to remove preference",
+      call: () => storage.removePreference("com.app", "Standard", "theme", TIMEOUT),
+      successPayload: { success: true, totalTimeMs: 1 },
+      assertSuccess: value => {
+        expect(value).toBeUndefined();
+      },
+    },
+    {
+      op: "clearPreferenceStore",
+      wireType: "clear_preferences",
+      timeoutMsg: `Clear preferences timeout after ${TIMEOUT}ms`,
+      defaultErrorMsg: "Failed to clear preferences",
+      call: () => storage.clearPreferenceStore("com.app", "Standard", TIMEOUT),
+      successPayload: { success: true, totalTimeMs: 1 },
+      assertSuccess: value => {
+        expect(value).toBeUndefined();
+      },
+    },
+  ];
+
+  for (const o of ops) {
+    describe(o.op, () => {
+      test(`sends ${o.wireType} and resolves the mapped value on success`, async () => {
+        const promise = o.call();
+        await flush();
+        expect(h.sentMessages[0]).toMatchObject({ type: o.wireType });
+        expect(typeof h.sentMessages[0].requestId).toBe("string");
+        expect(h.resolveLast(o.successPayload)).toBe(true);
+        o.assertSuccess(await promise);
+      });
+
+      test("throws the runner-supplied error when success is false", async () => {
+        const promise = o.call();
+        await flush();
+        h.resolveLast({ success: false, totalTimeMs: 2, error: "runner said no" });
+        await expect(promise).rejects.toThrow("runner said no");
+      });
+
+      test("throws the default message when a failure carries no error string", async () => {
+        const promise = o.call();
+        await flush();
+        h.resolveLast({ success: false, totalTimeMs: 2 });
+        await expect(promise).rejects.toThrow(o.defaultErrorMsg);
+      });
+
+      test("throws an actionable timeout message after the deadline (no silent hang)", async () => {
+        const promise = o.call();
+        await flush();
+        // Precondition: the request is genuinely registered before the clock moves.
+        expect(h.requestManager.getPendingCount()).toBe(1);
+        h.advanceTime(TIMEOUT);
+        await expect(promise).rejects.toThrow(o.timeoutMsg);
+      });
+
+      test("throws when not connected without sending on the wire", async () => {
+        h.setConnected(false);
+        await expect(o.call()).rejects.toThrow("Failed to connect to CtrlProxy");
+        expect(h.sentMessages).toHaveLength(0);
+      });
+    });
+  }
+});

--- a/test/features/observe/ios/CtrlProxyVoiceOver.test.ts
+++ b/test/features/observe/ios/CtrlProxyVoiceOver.test.ts
@@ -173,32 +173,10 @@ describe("CtrlProxyVoiceOver", function() {
       }
     });
 
-    test("sends correct message type get_voiceover_state", async function() {
-      const { factory, getSocket } = createCapturingFactory(fakeTimer);
-      const client = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
-
-      try {
-        const resultPromise = client.requestVoiceOverState();
-        const socket = await waitForSocket(getSocket);
-        await waitForSocketOpen(socket);
-        await waitForSentMessages(socket, 1);
-
-        const sentMsg = commandPayloads(socket!)[0];
-        expect(sentMsg.type).toBe("get_voiceover_state");
-
-        // Resolve the pending request to avoid leaking
-        socket!.simulateMessage(JSON.stringify({
-          type: "voiceover_state_result",
-          requestId: sentMsg.requestId,
-          success: true,
-          enabled: false,
-        }));
-
-        await resultPromise;
-      } finally {
-        await client.close();
-      }
-    });
+    // NB: a former "sends correct message type get_voiceover_state" test was
+    // deleted here (issue #4174, item 14) — it asserted only `sentMsg.type`, a
+    // strict subset of "returns enabled=true when VoiceOver is running", which
+    // already asserts the type AND the requestId AND the decoded result.
   });
 
   describe("requestVoiceOverActivate", function() {

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -154,32 +154,66 @@ describe("IOSCtrlProxyClient", function() {
       expect(scheduler.rescheduleKeepAliveCalls).toBe(1);
     });
 
-    test("sends hierarchy cadence updates to the runner", function() {
-      const sentMessages: string[] = [];
-      (ctrlProxyClient as any).sendMessage = (message: string) => {
-        sentMessages.push(message);
-        return true;
-      };
+    test("sends hierarchy cadence updates to the runner", async function() {
+      const { factory, getSocket } = createCapturingWebSocketFactory(fakeTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        factory,
+        fakeTimer
+      );
 
-      (ctrlProxyClient as any).refreshObservationStreamHierarchyCadence(500);
+      try {
+        await testClient.ensureConnected();
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
 
-      expect(sentMessages.map(message => JSON.parse(message))).toEqual([{
-        type: "set_hierarchy_poll_interval",
-        intervalMs: 500,
-      }]);
+        testClient.refreshObservationStreamHierarchyCadence(500);
+
+        const cadenceMessages = (socket as CapturingWebSocket).sentMessages
+          .map(message => JSON.parse(message))
+          .filter(payload => payload.type === "set_hierarchy_poll_interval");
+        expect(cadenceMessages).toEqual([{
+          type: "set_hierarchy_poll_interval",
+          intervalMs: 500,
+        }]);
+      } finally {
+        await testClient.close();
+      }
     });
 
-    test("does not send hierarchy cadence updates to stale runners without command support", function() {
-      const sentMessages: string[] = [];
-      (ctrlProxyClient as any).supportedCommands = new Set(["request_hierarchy"]);
-      (ctrlProxyClient as any).sendMessage = (message: string) => {
-        sentMessages.push(message);
-        return true;
-      };
+    test("does not send hierarchy cadence updates to stale runners without command support", async function() {
+      const { factory, getSocket } = createCapturingWebSocketFactory(fakeTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        factory,
+        fakeTimer
+      );
 
-      (ctrlProxyClient as any).refreshObservationStreamHierarchyCadence(500);
+      try {
+        await testClient.ensureConnected();
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        // Runner handshake advertises a command set WITHOUT set_hierarchy_poll_interval.
+        socket!.simulateMessage(JSON.stringify({
+          type: "connected",
+          id: 1,
+          supportedCommands: ["request_hierarchy"],
+        }));
+        await flushPromises();
 
-      expect(sentMessages).toEqual([]);
+        testClient.refreshObservationStreamHierarchyCadence(500);
+
+        const cadenceMessages = (socket as CapturingWebSocket).sentMessages
+          .map(message => JSON.parse(message))
+          .filter(payload => payload.type === "set_hierarchy_poll_interval");
+        expect(cadenceMessages).toEqual([]);
+      } finally {
+        await testClient.close();
+      }
     });
 
     test("notifies the observation stream when the WebSocket connection closes", function() {
@@ -1230,7 +1264,7 @@ describe("IOSCtrlProxyClient", function() {
         expect(imeAction.success).toBe(false);
         expect(imeAction.action).toBe("done");
         expect(imeAction.totalTimeMs).toBe(100);
-        expect(imeAction.error).toContain("IME action timed out");
+        expect(imeAction.error).toBe("IME action timed out after 100ms");
 
         const rotatePromise = testClient.requestRotate("landscape", 100);
         await waitForSentMessages(socket as CapturingWebSocket, 2);
@@ -1242,7 +1276,7 @@ describe("IOSCtrlProxyClient", function() {
         expect(rotate.value).toBe(0);
         expect(rotate.rotationPerformed).toBe(false);
         expect(rotate.totalTimeMs).toBe(100);
-        expect(rotate.error).toContain("Rotate timed out");
+        expect(rotate.error).toBe("Rotate timed out after 100ms");
 
         const clipboardPromise = testClient.requestClipboard("get", undefined, 100);
         await waitForSentMessages(socket as CapturingWebSocket, 3);
@@ -1251,7 +1285,7 @@ describe("IOSCtrlProxyClient", function() {
         expect(clipboard.success).toBe(false);
         expect(clipboard.action).toBe("get");
         expect(clipboard.totalTimeMs).toBe(100);
-        expect(clipboard.error).toContain("Clipboard operation timed out");
+        expect(clipboard.error).toBe("Clipboard operation timed out after 100ms");
       } finally {
         await testClient.close();
       }
@@ -1649,6 +1683,46 @@ describe("IOSCtrlProxyClient", function() {
     });
   });
 
+  describe("service port changes", function() {
+    test("fails in-flight requests instead of stranding them when the CtrlProxy service port changes", async function() {
+      const testTimer = fakeTimer;
+      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        factory,
+        testTimer
+      );
+
+      try {
+        // Register an in-flight request over the live socket. A long timeout keeps
+        // it pending so it can only settle via the port-change cancellation, never
+        // by timing out during the test.
+        const inFlight = testClient.requestSwipe(0, 0, 10, 10, 300, 60000);
+        const socket = await waitForSocket(getSocket);
+        expect(socket).not.toBeNull();
+        await waitForSocketOpen(socket);
+        await waitForSentMessages(socket, 1);
+        // Macrotask flush: ensure the request is registered before the port change.
+        await new Promise(resolve => setImmediate(resolve));
+
+        const requestManager = (testClient as any).requestManager as { getPendingCount(): number };
+        // Precondition: the request is genuinely in-flight before the port change.
+        expect(requestManager.getPendingCount()).toBeGreaterThan(0);
+
+        // Changing the service port on a live socket must FAIL the in-flight request
+        // (cancelAll rejects it), not silently strand it in the pending map.
+        (testClient as any).updatePort(serverPort + 1);
+
+        // cancelAll clears the pending map synchronously — nothing is stranded.
+        expect(requestManager.getPendingCount()).toBe(0);
+        await expect(inFlight).rejects.toThrow("CtrlProxy service port changed");
+      } finally {
+        await testClient.close();
+      }
+    });
+  });
+
   describe("caching", function() {
     test("hasCachedHierarchy should return true after receiving hierarchy", async function() {
       const testTimer = fakeTimer;
@@ -1715,7 +1789,6 @@ describe("IOSCtrlProxyClient", function() {
         }));
 
         await resultPromise;
-        expect(testClient.hasCachedHierarchy()).toBe(true);
 
         // Invalidate cache
         testClient.invalidateCache();

--- a/test/features/observe/ios/IosScreenIdentity.test.ts
+++ b/test/features/observe/ios/IosScreenIdentity.test.ts
@@ -203,3 +203,86 @@ describe("deriveIosScreenIdentity", () => {
     ]))).toBeUndefined();
   });
 });
+
+/**
+ * PARAM-4: confidence-tier table.
+ *
+ * `confidence()` (IosScreenIdentity.ts:236) tiers signals:
+ *   - high   ← modalClass OR navigationTitle present
+ *   - medium ← selectedTab OR focusedElementId OR keyboardVisible present
+ *   - low    ← a useful signal present but none of the above
+ * and `deriveIosScreenIdentity` returns undefined entirely when NO useful
+ * signal is present.
+ *
+ * The selected-tab fixtures use `class: "XCUIElementTypeButton", role: "tab"` —
+ * `findSelectedTab` (IosScreenIdentity.ts:154-159) recognizes a selected tab by
+ * `role === "tab"` (or a tab-bar-child button class). `XCUIElementTypeTabBarButton`
+ * is NOT one of those classes, so a fixture built on it would silently yield no
+ * `selectedTab` and make the row vacuous.
+ *
+ * The "low" tier is intentionally omitted: it is unreachable through the public
+ * deriver, since the only useful-but-non-high/medium signal is `modalTitle`, and
+ * `findModal` never emits `modalTitle` without also emitting `modalClass` (which
+ * forces "high"). Fabricating a "low" fixture would misrepresent real input.
+ */
+describe("deriveIosScreenIdentity confidence tiers (PARAM-4)", () => {
+  function selectedTabBar(selected: string): ViewHierarchyNode {
+    return node({ class: "UITabBar", text: "Tab Bar" }, [
+      node({ "class": "XCUIElementTypeButton", "role": "tab", "text": selected, "selected": "true" }),
+    ]);
+  }
+
+  function focusedField(): ViewHierarchyNode {
+    return node({
+      "class": "UITextField",
+      "text": "Title",
+      "resource-id": "quick-entry-field",
+      "focused": "true",
+    });
+  }
+
+  function keyboard(): ViewHierarchyNode {
+    return node({ class: "UIKeyboard" }, [
+      node({ class: "UIKeyboardKey", text: "Q", clickable: "true" }),
+    ]);
+  }
+
+  function actionSheet(): ViewHierarchyNode {
+    return node({ class: "UIActionSheet" }, [
+      node({ class: "UIButton", text: "Discard Changes", clickable: "true" }),
+    ]);
+  }
+
+  const rows: Array<{
+    name: string;
+    children: ViewHierarchyNode[];
+    expected: "high" | "medium" | undefined;
+  }> = [
+    { name: "a navigation title alone", children: [navigationBar("Home")], expected: "high" },
+    { name: "a modal class alone", children: [actionSheet()], expected: "high" },
+    {
+      name: "a navigation title plus a selected tab (prefers high over medium)",
+      children: [navigationBar("Home"), selectedTabBar("Search")],
+      expected: "high",
+    },
+    { name: "only a selected tab", children: [selectedTabBar("Search")], expected: "medium" },
+    { name: "only a focused element", children: [focusedField()], expected: "medium" },
+    { name: "only a visible keyboard", children: [keyboard()], expected: "medium" },
+    {
+      name: "no useful signal",
+      children: [node({ class: "XCUIApplication" }), node({ class: "UIView", text: "hello" })],
+      expected: undefined,
+    },
+  ];
+
+  for (const { name, children, expected } of rows) {
+    test(`tiers ${name} as ${expected ?? "no identity"}`, () => {
+      const identity = deriveIosScreenIdentity(hierarchy(children));
+      if (expected === undefined) {
+        expect(identity).toBeUndefined();
+      } else {
+        expect(identity?.confidence).toBe(expected);
+      }
+    });
+  }
+});

--- a/test/features/observe/ios/IosSdkEventIngestor.test.ts
+++ b/test/features/observe/ios/IosSdkEventIngestor.test.ts
@@ -386,5 +386,30 @@ describe("DefaultIosSdkEventIngestor", () => {
       // ... and must have restored the prior context despite the throw.
       expect(recorder.getContext()).toEqual({ deviceId: "prev-device", sessionId: "prev-session" });
     });
+
+    test("stays non-fatal when restoring the context itself throws", () => {
+      // The restore runs in the finally, OUTSIDE the catch. If the recorder's
+      // setContext throws while restoring the prior context, the exception must be
+      // swallowed — processMessage calls this and telemetry must never break
+      // observation. Only the restore call (deviceId "prev-device") throws; the
+      // setContext(iOS) at the start still succeeds.
+      class RestoreThrows extends CapturingTelemetryRecorder {
+        setContext(deviceId: string | null, sessionId: string | null): void {
+          if (deviceId === "prev-device") {
+            throw new Error("setContext failed during restore");
+          }
+          super.setContext(deviceId, sessionId);
+        }
+      }
+      const localIngestor = new DefaultIosSdkEventIngestor({
+        deviceId: DEVICE_ID,
+        getNavigationGraphManager: () => navSink,
+        captureScreenshot: async (): Promise<CtrlProxyScreenshotResult> => ({ success: false }),
+        telemetryRecorder: new RestoreThrows() as unknown as IosTelemetryRecorder,
+        failureRecorder,
+        navigationScreenshotsEnabled: () => false,
+      });
+      expect(() => localIngestor.recordLayoutTelemetryEvent(hierarchy())).not.toThrow();
+    });
   });
 });

--- a/test/features/observe/ios/IosSdkEventIngestor.test.ts
+++ b/test/features/observe/ios/IosSdkEventIngestor.test.ts
@@ -329,21 +329,16 @@ describe("DefaultIosSdkEventIngestor", () => {
     expect((crashes[0].input as { exceptionType: string }).exceptionType).toBe("SIGABRT");
   });
 
-  test("ingestion never throws even when a recorder rejects", async () => {
-    const throwingRecorder = {
-      getContext: () => ({ deviceId: null, sessionId: null }),
-      setContext: () => {},
-      recordLogEvent: async () => { throw new Error("db down"); },
-    } as unknown as IosTelemetryRecorder;
-    const resilient = new DefaultIosSdkEventIngestor({
-      deviceId: DEVICE_ID,
-      getNavigationGraphManager: () => navSink,
-      captureScreenshot: async () => ({ success: false }),
-      telemetryRecorder: throwingRecorder,
-      failureRecorder,
-      navigationScreenshotsEnabled: () => false,
-    });
-    await expect(resilient.recordSdkEvent(event("log", {}), null)).resolves.toBeUndefined();
+  test("ingestion never throws and still restores context when a recorder rejects", async () => {
+    // R2 rewrite: the old version stubbed `setContext: () => {}`, so it could not
+    // observe the finally-block restore at all — it passed even if the restore
+    // were deleted. Use the CapturingTelemetryRecorder (seeded with a prior
+    // Android context) and make recordLogEvent throw AFTER setContext(iOS) ran.
+    // The observable guarantee: the promise resolves (never throws) AND the prior
+    // context is restored despite the throw.
+    recorder.recordLogEvent = async (): Promise<void> => { throw new Error("db down"); };
+    await expect(ingestor.recordSdkEvent(event("log", {}), null)).resolves.toBeUndefined();
+    expect(recorder.getContext()).toEqual({ deviceId: "prev-device", sessionId: "prev-session" });
   });
 
   describe("recordLayoutTelemetryEvent", () => {
@@ -362,12 +357,33 @@ describe("DefaultIosSdkEventIngestor", () => {
         applicationId: "com.app",
         screenName: "com.app",
       });
-      expect((recorder.layout[0].event as { recompositionCount: number }).recompositionCount).toBeGreaterThan(0);
+      // Fixture is root ({ node: [...] }) + 2 leaves (each has $), so
+      // countViewHierarchyNodes returns 3 (1 for the root's `node`, +1 per leaf `$`).
+      expect((recorder.layout[0].event as { recompositionCount: number }).recompositionCount).toBe(3);
     });
 
     test("uses device context and restores it", () => {
       ingestor.recordLayoutTelemetryEvent(hierarchy());
       expect(recorder.layout[0].contextAtCall).toEqual({ deviceId: DEVICE_ID, sessionId: null });
+      expect(recorder.getContext()).toEqual({ deviceId: "prev-device", sessionId: "prev-session" });
+    });
+
+    test("restores the previous context when serialization throws (finally, not fall-through)", () => {
+      // ADD-2 live bug: the restore used to sit after the JSON.stringify+record
+      // inside the try, so a synchronous throw between setContext(iOS) and the
+      // restore skipped it, leaving the shared context pinned to the iOS udid and
+      // permanently mis-attributing later Android telemetry. A BigInt in the
+      // hierarchy makes the internal JSON.stringify throw synchronously — after
+      // setContext(iOS) has already run.
+      const unserializable = {
+        hierarchy: { node: [{ $: { bad: BigInt(1) } }] },
+        packageName: "com.app",
+        windows: [],
+        updatedAt: 1,
+      } as unknown as ViewHierarchyResult;
+      // Must not throw (telemetry is best-effort) ...
+      expect(() => ingestor.recordLayoutTelemetryEvent(unserializable)).not.toThrow();
+      // ... and must have restored the prior context despite the throw.
       expect(recorder.getContext()).toEqual({ deviceId: "prev-device", sessionId: "prev-session" });
     });
   });

--- a/test/features/observe/ios/ctrlProxyReadOnlyBackoff.test.ts
+++ b/test/features/observe/ios/ctrlProxyReadOnlyBackoff.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import { createIosDelegateHarness, type IosDelegateHarness } from "../../../helpers/iosDelegateHarness";
+import { CtrlProxyVoiceOver } from "../../../../src/features/observe/ios/CtrlProxyVoiceOver";
+import { CtrlProxyNavigation } from "../../../../src/features/observe/ios/CtrlProxyNavigation";
+import { CtrlProxyClipboard } from "../../../../src/features/observe/ios/CtrlProxyClipboard";
+import { CtrlProxyScreenshot } from "../../../../src/features/observe/ios/CtrlProxyScreenshot";
+import { CtrlProxyPermissions } from "../../../../src/features/observe/ios/CtrlProxyPermissions";
+
+/**
+ * PARAM-6 (issue #4174, item 8): read-only / non-mutating iOS commands must NOT
+ * cancel the pending screenshot backoff. Each of these `sendCommand` call sites
+ * passes `cancelScreenshotBackoff: false`; if any regresses to the default
+ * (`true`), the live-view screenshot backoff is torn down on every VoiceOver /
+ * clipboard / navigation poll and the stream visibly freezes.
+ *
+ * The harness counts `cancelScreenshotBackoff()` invocations. Each row drives one
+ * command and asserts the count stayed 0. The table is mutation-sensitive: flip
+ * any single site to `true` and exactly that row fails.
+ */
+describe("read-only iOS commands do not cancel the screenshot backoff", () => {
+  const flush = (): Promise<void> => new Promise<void>(resolve => setImmediate(resolve));
+
+  let h: IosDelegateHarness;
+  beforeEach(() => {
+    h = createIosDelegateHarness();
+  });
+
+  interface Row {
+    name: string;
+    invoke: (harness: IosDelegateHarness) => Promise<unknown>;
+  }
+
+  const rows: Row[] = [
+    { name: "get_voiceover_state", invoke: hh => new CtrlProxyVoiceOver(hh.context).requestVoiceOverState() },
+    { name: "request_action", invoke: hh => new CtrlProxyVoiceOver(hh.context).requestAction("scroll_forward") },
+    { name: "request_action (voiceover activate)", invoke: hh => new CtrlProxyVoiceOver(hh.context).requestVoiceOverActivate("Submit", "activate") },
+    { name: "request_press_home", invoke: hh => new CtrlProxyNavigation(hh.context).requestPressHome() },
+    { name: "request_press_back", invoke: hh => new CtrlProxyNavigation(hh.context).requestPressBack() },
+    { name: "request_shake", invoke: hh => new CtrlProxyNavigation(hh.context).requestShake() },
+    { name: "request_press_button", invoke: hh => new CtrlProxyNavigation(hh.context).requestPressButton("home") },
+    { name: "request_rotate", invoke: hh => new CtrlProxyNavigation(hh.context).requestRotate("portrait") },
+    { name: "request_recent_apps", invoke: hh => new CtrlProxyNavigation(hh.context).requestRecentApps() },
+    { name: "request_clipboard", invoke: hh => new CtrlProxyClipboard(hh.context).requestClipboard("get") },
+    { name: "request_screenshot", invoke: hh => new CtrlProxyScreenshot(hh.context).requestScreenshot() },
+    { name: "request_reset_permissions", invoke: hh => new CtrlProxyPermissions(hh.context).requestResetPermissions("com.app", ["camera"]) },
+  ];
+
+  for (const row of rows) {
+    test(`${row.name} leaves the screenshot backoff intact`, async () => {
+      const promise = row.invoke(h);
+      await flush();
+      // The observable contract: the command reached the wire but did NOT cancel
+      // the backoff.
+      expect(h.cancelScreenshotBackoffCalls).toBe(0);
+      expect(h.sentMessages).toHaveLength(1);
+      // Settle the pending request so nothing dangles.
+      h.resolveLast({ success: true, totalTimeMs: 0 });
+      await promise;
+    });
+  }
+});

--- a/test/features/observe/ios/decodeCtrlProxyMessage.test.ts
+++ b/test/features/observe/ios/decodeCtrlProxyMessage.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
 import {
   decodeCtrlProxyMessage,
   rewriteUnknownCommandError,
@@ -330,6 +332,221 @@ describe("decodeCtrlProxyMessage", () => {
     const decoded = decodeCtrlProxyMessage(message);
     expect(decoded?.errorMessage).toBeUndefined();
     expect(decoded?.result).toBe(message);
+  });
+});
+
+/**
+ * Parse every `case` rawValue from the Swift `ResponseType: String` enum.
+ *
+ * Swift String-enum semantics: a case without an explicit `= "..."` uses the
+ * case name itself as its rawValue (e.g. `case screenshot` → "screenshot"), so
+ * we fall back to the identifier when no string literal is present.
+ */
+function parseSwiftResponseTypeRawValues(swiftSource: string): string[] {
+  const lines = swiftSource.split("\n");
+  const startIdx = lines.findIndex(line => /enum\s+ResponseType\s*:\s*String\s*\{/.test(line));
+  if (startIdx < 0) {
+    throw new Error("Could not locate `enum ResponseType: String` in Models.swift");
+  }
+  const rawValues: string[] = [];
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() === "}") {
+      break; // end of the (brace-flat) enum body
+    }
+    const match = line.match(/^\s*case\s+([A-Za-z0-9_]+)(?:\s*=\s*"([^"]+)")?/);
+    if (match) {
+      rawValues.push(match[2] ?? match[1]);
+    }
+  }
+  return rawValues;
+}
+
+/**
+ * A rawValue is "explicitly decoded" when the switch has a dedicated case that
+ * reshapes it into a fresh result object. The default branch, by contrast,
+ * resolves the message verbatim (`result === message` by identity), so identity
+ * equality is a precise, source-parsing-free probe for the default fall-through.
+ */
+function isExplicitlyDecoded(rawValue: string): boolean {
+  const message = { type: rawValue, requestId: REQ } as WebSocketMessage;
+  const decoded = decodeCtrlProxyMessage(message);
+  return decoded !== null && decoded.result !== message;
+}
+
+describe("decodeCtrlProxyMessage ↔ Swift ResponseType parity (ADD-3 / item 4)", () => {
+  const swiftSource = readFileSync(
+    join(import.meta.dir, "../../../../ios/control-proxy/Sources/CtrlProxy/Models.swift"),
+    "utf8"
+  );
+  const rawValues = parseSwiftResponseTypeRawValues(swiftSource);
+
+  // Response types the daemon deliberately does NOT reshape: they reach the
+  // decoder's default verbatim-resolve branch on purpose because no client
+  // await path consumes them (fire-and-forget push/ack replies). Documented
+  // here — per the spec we do not assert on their absence from the switch,
+  // only subtract them so the genuinely-unhandled residue is isolated.
+  //   1. set_hierarchy_poll_interval_result — poll-interval ack
+  //   2. screenshot_error                   — error push, handled client-side
+  //   3. current_focus_result               — focus push, no awaiter
+  //   4. traversal_order_result             — traversal push, no awaiter
+  //   5. connected                          — connection handshake push
+  //   6. set_network_mock_rules_result      — mock-rules ack
+  const FIRE_AND_FORGET_EXCUSES = [
+    "set_hierarchy_poll_interval_result",
+    "screenshot_error",
+    "current_focus_result",
+    "traversal_order_result",
+    "connected",
+    "set_network_mock_rules_result",
+  ];
+
+  test("Swift ResponseType declares exactly 42 rawValues", () => {
+    expect(rawValues.length).toBe(42);
+  });
+
+  test("rawValues are unique (no accidental duplicate)", () => {
+    expect(new Set(rawValues).size).toBe(rawValues.length);
+  });
+
+  test("every fire-and-forget excuse is a real Swift rawValue", () => {
+    for (const excuse of FIRE_AND_FORGET_EXCUSES) {
+      expect(rawValues).toContain(excuse);
+    }
+  });
+
+  test("the decoder explicitly reshapes exactly 35 response types", () => {
+    expect(rawValues.filter(isExplicitlyDecoded).length).toBe(35);
+  });
+
+  test("the only unhandled ResponseType (excluding fire-and-forget) is shake_result", () => {
+    const unhandled = rawValues
+      .filter(rawValue => !isExplicitlyDecoded(rawValue))
+      .filter(rawValue => !FIRE_AND_FORGET_EXCUSES.includes(rawValue))
+      .sort();
+    expect(unhandled).toEqual(["shake_result"]);
+  });
+});
+
+/**
+ * PARAM-5 / item 11: per-type `success` defaulting.
+ *
+ * The decoder defaults `success` differently per response type: base-timing and
+ * gesture results default to `true` (a reply that arrived without an explicit
+ * failure flag is treated as success), while storage/database/highlight results
+ * default to `false` (absence of an explicit success is treated as failure).
+ * `screenshot` hardcodes `true`, and `hierarchy_update` carries no `success`.
+ */
+describe("decodeCtrlProxyMessage success defaulting (PARAM-5 / item 11)", () => {
+  // One row per decoded response type → the value of `success` when the wire
+  // message omits it. 35 rows = the 35 explicitly-decoded ResponseTypes.
+  const DEFAULT_WHEN_ABSENT: Array<{ type: string; expected: boolean | undefined }> = [
+    { type: "hierarchy_update", expected: undefined },
+    { type: "screenshot", expected: true },
+    { type: "pinch_result", expected: true },
+    { type: "tap_coordinates_result", expected: true },
+    { type: "swipe_result", expected: true },
+    { type: "drag_result", expected: true },
+    { type: "set_text_result", expected: true },
+    { type: "clear_text_result", expected: true },
+    { type: "select_all_result", expected: true },
+    { type: "press_button_result", expected: true },
+    { type: "press_home_result", expected: true },
+    { type: "press_back_result", expected: true },
+    { type: "recent_apps_result", expected: true },
+    { type: "launch_app_result", expected: true },
+    { type: "reset_permissions_result", expected: true },
+    { type: "keyboard_result", expected: true },
+    { type: "rotate_result", expected: true },
+    { type: "ime_action_result", expected: true },
+    { type: "action_result", expected: true },
+    { type: "voiceover_state_result", expected: true },
+    { type: "multi_finger_swipe_result", expected: true },
+    { type: "clipboard_result", expected: true },
+    { type: "highlight_response", expected: false },
+    { type: "preference_files", expected: false },
+    { type: "preferences", expected: false },
+    { type: "get_preference_result", expected: false },
+    { type: "set_preference_result", expected: false },
+    { type: "remove_preference_result", expected: false },
+    { type: "clear_preferences_result", expected: false },
+    { type: "set_network_error_simulation_result", expected: false },
+    { type: "execute_sql_result", expected: false },
+    { type: "list_databases_result", expected: false },
+    { type: "list_tables_result", expected: false },
+    { type: "table_data_result", expected: false },
+    { type: "table_structure_result", expected: false },
+  ];
+
+  test("the default table covers all 35 explicitly-decoded types", () => {
+    expect(DEFAULT_WHEN_ABSENT.length).toBe(35);
+  });
+
+  for (const { type, expected } of DEFAULT_WHEN_ABSENT) {
+    test(`${type} defaults success to ${String(expected)} when the wire omits it`, () => {
+      const decoded = decodeCtrlProxyMessage(msg({ type }));
+      expect((decoded?.result as { success?: boolean }).success).toBe(expected);
+    });
+  }
+
+  // Every type that reads `message.success` (all decoded types except the
+  // no-success hierarchy_update and the hardcoded-true screenshot) must pass an
+  // explicit success flag straight through, both true and false.
+  const READS_MESSAGE_SUCCESS = DEFAULT_WHEN_ABSENT
+    .filter(row => row.type !== "hierarchy_update" && row.type !== "screenshot")
+    .map(row => row.type);
+
+  test("the passthrough set is the 33 success-reading types", () => {
+    expect(READS_MESSAGE_SUCCESS.length).toBe(33);
+  });
+
+  for (const type of READS_MESSAGE_SUCCESS) {
+    test(`${type} passes an explicit success=true through`, () => {
+      const decoded = decodeCtrlProxyMessage(msg({ type, success: true }));
+      expect((decoded?.result as { success?: boolean }).success).toBe(true);
+    });
+    test(`${type} passes an explicit success=false through`, () => {
+      const decoded = decodeCtrlProxyMessage(msg({ type, success: false }));
+      expect((decoded?.result as { success?: boolean }).success).toBe(false);
+    });
+  }
+
+  test("screenshot hardcodes success=true even when the wire says false", () => {
+    const decoded = decodeCtrlProxyMessage(msg({ type: "screenshot", success: false }));
+    expect((decoded?.result as { success?: boolean }).success).toBe(true);
+  });
+
+  // The four `success ?? ok ?? false` types read the `ok` alias when `success`
+  // is absent (Android wire-protocol carryover), but `success` still wins when
+  // both are present.
+  const OK_ALIAS_TYPES = [
+    "set_preference_result",
+    "remove_preference_result",
+    "clear_preferences_result",
+    "set_network_error_simulation_result",
+  ];
+
+  for (const type of OK_ALIAS_TYPES) {
+    test(`${type} falls back to ok=true when success is absent`, () => {
+      const decoded = decodeCtrlProxyMessage(msg({ type, ok: true }));
+      expect((decoded?.result as { success?: boolean }).success).toBe(true);
+    });
+    test(`${type} defaults to false when both success and ok are absent`, () => {
+      const decoded = decodeCtrlProxyMessage(msg({ type }));
+      expect((decoded?.result as { success?: boolean }).success).toBe(false);
+    });
+    test(`${type} lets explicit success=false win over ok=true`, () => {
+      const decoded = decodeCtrlProxyMessage(msg({ type, success: false, ok: true }));
+      expect((decoded?.result as { success?: boolean }).success).toBe(false);
+    });
+  }
+
+  test("a message with a missing requestId decodes to null", () => {
+    expect(decodeCtrlProxyMessage({ type: "swipe_result", success: false })).toBeNull();
+  });
+
+  test("a message with an empty-string requestId decodes to null", () => {
+    expect(decodeCtrlProxyMessage({ type: "swipe_result", requestId: "", success: false })).toBeNull();
   });
 });
 

--- a/test/features/observe/ios/semanticRoles.test.ts
+++ b/test/features/observe/ios/semanticRoles.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { hasIosHeaderTrait } from "../../../../src/features/observe/ios/semanticRoles";
+
+/**
+ * PARAM-3 (issue #4174, item 9): `hasIosHeaderTrait` parses the runner's
+ * comma-separated `sdk.accessibilityTraits` string and reports whether the
+ * exact token `header` is present. A miss here silently drops the heading role
+ * for VoiceOver users; a false positive mis-labels ordinary controls.
+ *
+ * The implementation is `split(",").some(t => t.trim() === "header")`, so the
+ * boundary rows below (case sensitivity, substring look-alikes, a Cyrillic
+ * homoglyph, whitespace, non-string/absent traits) are the real specification.
+ */
+describe("hasIosHeaderTrait", () => {
+  interface Row {
+    name: string;
+    extras: unknown;
+    expected: boolean;
+  }
+
+  const traits = (value: unknown): Record<string, unknown> => ({ "sdk.accessibilityTraits": value });
+
+  const rows: Row[] = [
+    // --- positive: exact token present, possibly among others / padded ---
+    { name: "the sole trait is header", extras: traits("header"), expected: true },
+    { name: "header is the first of several traits", extras: traits("header,button"), expected: true },
+    { name: "header is the last of several traits", extras: traits("button,header"), expected: true },
+    { name: "header sits in the middle of the list", extras: traits("button,header,image"), expected: true },
+    { name: "header has surrounding spaces after the split", extras: traits("button, header"), expected: true },
+    { name: "the whole value is padded with spaces", extras: traits("  header  "), expected: true },
+    { name: "header appears with tab/space padding among traits", extras: traits("staticText,\theader\t"), expected: true },
+    { name: "a duplicated header token still matches", extras: traits("header,header"), expected: true },
+
+    // --- negative: look-alikes that must NOT match the exact token ---
+    { name: "headerish is a superstring, not the token", extras: traits("headerish"), expected: false },
+    { name: "subheader is a substring, not the token", extras: traits("subheader"), expected: false },
+    { name: "Header differs by case (exact, case-sensitive)", extras: traits("Header"), expected: false },
+    { name: "HEADER differs by case", extras: traits("HEADER"), expected: false },
+    { name: "a Cyrillic-homoglyph header is not the ASCII token", extras: traits("һeader"), expected: false },
+    { name: "head is a prefix, not the token", extras: traits("head"), expected: false },
+    { name: "header embedded without a comma boundary does not match", extras: traits("myheader"), expected: false },
+    { name: "an unrelated trait list has no header", extras: traits("button,staticText,image"), expected: false },
+    { name: "an empty trait string matches nothing", extras: traits(""), expected: false },
+    { name: "a lone comma yields only empty tokens", extras: traits(","), expected: false },
+
+    // --- negative: the trait value is not a usable string ---
+    { name: "traits is a number, not a string", extras: traits(42), expected: false },
+    { name: "traits is null", extras: traits(null), expected: false },
+    { name: "traits is an array (not the parsed string)", extras: traits(["header"]), expected: false },
+    { name: "the traits key is absent from extras", extras: { other: "header" }, expected: false },
+
+    // --- negative: extras itself is not an object ---
+    { name: "extras is null", extras: null, expected: false },
+    { name: "extras is undefined", extras: undefined, expected: false },
+    { name: "extras is a bare string", extras: "header", expected: false },
+  ];
+
+  for (const row of rows) {
+    test(`returns ${row.expected} when ${row.name}`, () => {
+      expect(hasIosHeaderTrait(row.extras)).toBe(row.expected);
+    });
+  }
+});

--- a/test/helpers/iosDelegateHarness.ts
+++ b/test/helpers/iosDelegateHarness.ts
@@ -1,0 +1,154 @@
+/**
+ * iosDelegateHarness - a minimal, socket-free driver for iOS CtrlProxy delegate
+ * classes (`CtrlProxyStorage`, `CtrlProxyDatabase`, `CtrlProxyVoiceOver`,
+ * `CtrlProxyHierarchy`, …).
+ *
+ * The delegates all take a {@link HierarchyDelegateContext} and correlate
+ * requests through a real {@link RequestManager} driven by a {@link FakeTimer}.
+ * This harness wires exactly that: a real `RequestManager(timer)`, a capturing
+ * "web socket" whose sends are parsed into {@link IosDelegateHarness.sentMessages},
+ * and toggles for the connection / advertised-command / cache state a delegate
+ * reads.
+ *
+ * It deliberately does NOT run `decodeCtrlProxyMessage`; a test injects the
+ * already-decoded result with {@link IosDelegateHarness.resolveLast}. Client-level
+ * round-trip coverage (real `FakeWebSocket` + real decode) lives in the
+ * `IOSCtrlProxyClient`-driven suites, not here.
+ *
+ * Time is fully controlled: nothing auto-advances. To fire a request's timeout,
+ * call {@link IosDelegateHarness.advanceTime} past the delegate's `timeoutMs` so
+ * the assertion (not a real hang) proves the timeout path.
+ */
+
+import type WebSocket from "ws";
+import { RequestManager } from "../../src/utils/RequestManager";
+import type { PerformanceTracker } from "../../src/utils/PerformanceTracker";
+import type {
+  HierarchyDelegateContext,
+  CtrlProxyCachedHierarchy,
+} from "../../src/features/observe/ios/types";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+/** Options for {@link createIosDelegateHarness}. */
+export interface IosDelegateHarnessOptions {
+  /** Injected fake clock; a fresh one is created when omitted. */
+  timer?: FakeTimer;
+  /** Initial value returned by `ensureConnected()`. Defaults to `true`. */
+  connected?: boolean;
+  /** `cacheFreshTtlMs` on the context. Defaults to 500. */
+  cacheFreshTtlMs?: number;
+  /** Seed the cached hierarchy. Defaults to `null`. */
+  initialCache?: CtrlProxyCachedHierarchy | null;
+  /**
+   * Advertised command set. When set, `isCommandSupported` answers membership;
+   * when omitted, every command is considered supported.
+   */
+  supportedCommands?: string[];
+}
+
+/** The object returned by {@link createIosDelegateHarness}. */
+export interface IosDelegateHarness {
+  /** The fake clock shared by the context and the RequestManager. */
+  timer: FakeTimer;
+  /** The real RequestManager the context correlates requests through. */
+  requestManager: RequestManager;
+  /** The context to hand to a delegate constructor. */
+  context: HierarchyDelegateContext;
+  /** Every message sent through the fake socket, parsed as a JSON object. */
+  sentMessages: Array<Record<string, unknown>>;
+  /** How many times `cancelScreenshotBackoff()` has been invoked. */
+  cancelScreenshotBackoffCalls: number;
+  /** How many times `ensureConnected()` has been invoked. */
+  ensureConnectedCalls: number;
+  /** Change the value `ensureConnected()` resolves to. */
+  setConnected(connected: boolean): void;
+  /** Replace the advertised command set (`undefined` = all supported). */
+  setSupportedCommands(commands: string[] | undefined): void;
+  /** The requestId of the most-recently-registered pending request, or `null`. */
+  lastRequestId(): string | null;
+  /** Resolve the most-recently-registered pending request with a decoded result. */
+  resolveLast<T>(result: T): boolean;
+  /** Resolve a specific pending request id with a decoded result. */
+  resolve<T>(id: string, result: T): boolean;
+  /** Advance the fake clock, firing any request timeouts that come due. */
+  advanceTime(ms: number): void;
+}
+
+/**
+ * Build an {@link IosDelegateHarness}. See the file header for the contract.
+ */
+export function createIosDelegateHarness(
+  options: IosDelegateHarnessOptions = {}
+): IosDelegateHarness {
+  const timer = options.timer ?? new FakeTimer();
+  const requestManager = new RequestManager(timer);
+  const sentMessages: Array<Record<string, unknown>> = [];
+
+  let connected = options.connected ?? true;
+  let supportedCommands = options.supportedCommands;
+  let cache: CtrlProxyCachedHierarchy | null = options.initialCache ?? null;
+
+  const fakeSocket = {
+    send(data: unknown): void {
+      const text = typeof data === "string" ? data : String(data);
+      try {
+        sentMessages.push(JSON.parse(text) as Record<string, unknown>);
+      } catch {
+        // A delegate should only ever send JSON; a parse failure is a test bug,
+        // surfaced by the missing/wrong entry in sentMessages rather than a throw.
+        sentMessages.push({ raw: text });
+      }
+    },
+  } as unknown as WebSocket;
+
+  const harness: IosDelegateHarness = {
+    timer,
+    requestManager,
+    sentMessages,
+    cancelScreenshotBackoffCalls: 0,
+    ensureConnectedCalls: 0,
+    setConnected(next: boolean): void {
+      connected = next;
+    },
+    setSupportedCommands(commands: string[] | undefined): void {
+      supportedCommands = commands;
+    },
+    lastRequestId(): string | null {
+      const ids = requestManager.getPendingIds();
+      return ids.length > 0 ? ids[ids.length - 1] : null;
+    },
+    resolveLast<T>(result: T): boolean {
+      const id = this.lastRequestId();
+      return id !== null && requestManager.resolve<T>(id, result);
+    },
+    resolve<T>(id: string, result: T): boolean {
+      return requestManager.resolve<T>(id, result);
+    },
+    advanceTime(ms: number): void {
+      timer.advanceTime(ms);
+    },
+    context: {
+      getWebSocket: (): WebSocket | null => fakeSocket,
+      requestManager,
+      timer,
+      ensureConnected: async (_perf?: PerformanceTracker): Promise<boolean> => {
+        harness.ensureConnectedCalls++;
+        return connected;
+      },
+      isCommandSupported: (messageType: string): boolean =>
+        supportedCommands === undefined || supportedCommands.includes(messageType),
+      unsupportedCommandError: (messageType: string): string =>
+        `${messageType} is not supported by the connected device service`,
+      cancelScreenshotBackoff: (): void => {
+        harness.cancelScreenshotBackoffCalls++;
+      },
+      cacheFreshTtlMs: options.cacheFreshTtlMs ?? 500,
+      getCachedHierarchy: (): CtrlProxyCachedHierarchy | null => cache,
+      setCachedHierarchy: (next: CtrlProxyCachedHierarchy | null): void => {
+        cache = next;
+      },
+    },
+  };
+
+  return harness;
+}


### PR DESCRIPTION
## Summary

Milestone 32 (Unit Test Quality Audit), slice **observe-ios**: 17 verified
test-quality findings burned down, each verified red-green. REFUTED items (R7
`CtrlProxyActionResult` guard rewrite; the `RestartThreshold:106` replacement) were
**not** implemented.

**One surgical `src` fix (ADD-2):** `IosSdkEventIngestor.recordLayoutTelemetryEvent`
now restores the previous telemetry context in a `finally`, so a recorder that throws
mid-record no longer leaves the shared context pinned to the iOS udid and
mis-attributes subsequent Android telemetry (`getContext` throwing leaves
`prevContext` undefined — nothing to restore). Item 1 (`invalidateCache` TTL re-fetch)
had already landed via #4230/#4271 — verified still mutation-sensitive, no change needed.

Test-side: a prerequisite `iosDelegateHarness`; storage 6×4 and database 6×5 tables
(keeping the client-level `FakeWebSocket` round-trips the delegate tables don't cover);
a `ResponseType`↔decoder parity guard (42 rawValues, `shake_result` allowlisted);
`success`-defaulting, `hasIosHeaderTrait`, confidence-tier and read-only-backoff tables;
port-change in-flight cancellation; `triggerServiceRestart` branches (via
`setSetupShouldFail`); exact-message rewrites; and deletion of tautological/subset tests.
`FakeIOSCtrlProxyManager` gains an additive `setForceRestartShouldFail` seam.

## Linked Issue

Closes #4174

## Validation

- [x] `bun test`: **10158 tests, 0 fail / 14 skip** across 764 files (rebased on current main)
- [x] `bun run typecheck`: no new errors (211 baseline)
- [x] `bun run lint`: clean
- [x] Sole `src` change is surgical (telemetry context restore), red-green pinned

## Follow-ups

- [ ] Item 15 (20-row behavior-first RENAME) not applied — the issue references a
  `§RENAME` mapping that is absent from the issue body; recommend adding the table or
  dropping the item.
- [ ] R8 partial — 2 of 6 hierarchy-cadence tests migrated off `(client as any).sendMessage`
  (−4 `as any`); the 4 network-sync tests were left as-is because migrating them
  reintroduces equivalent lifecycle stubs + real-fetch flakiness.
