### PR TITLE
test(db): guard trackExisting ordering

### DIFF
--- a/src/db/dbWriteBarrier.ts
+++ b/src/db/dbWriteBarrier.ts
@@ -37,7 +37,7 @@ export interface DbWriteBarrier {
    *
    * Why not {@link track} here? `await track(() => write())` starts the write at
    * the same time, but adds one promise-resolution turn before the navigation
-   * handler resumes. The #3506 ordering guard proves that lets a concurrent
+   * handler resumes. The #3506 ordering guards prove that lets a concurrent
    * hierarchy path resume first. Keep `trackExisting` for this narrow hot path so
    * the caller can await its original promise with no extra turn. Prefer plain
    * {@link track} everywhere the caller does not already own the started promise

--- a/src/db/dbWriteBarrier.ts
+++ b/src/db/dbWriteBarrier.ts
@@ -35,15 +35,14 @@ export interface DbWriteBarrier {
    * touching the hot-path nav-event↔hierarchy-update ordering that "preserve SDK
    * screen names" depends on.
    *
-   * Why not {@link track} here? `await track(() => write())` would work today —
-   * the current post-#3063 ordering test tolerates the one extra microtask tick
-   * `track` adds — but the #2885 author flagged this specific interleaving as
-   * timing-sensitive, and a future regression from that tick would be SILENT (no
-   * test guards it). `trackExisting` takes on *zero* ordering risk instead of a
-   * small-but-untested one, which is the right trade for a best-effort drain
-   * feature. Prefer plain {@link track} everywhere the caller does not already own
-   * the started promise on an ordering-sensitive path — this method is the narrow
-   * exception, not the default.
+   * Why not {@link track} here? `await track(() => write())` starts the write at
+   * the same time, but adds one promise-resolution turn before the navigation
+   * handler resumes. The #3506 ordering guard proves that lets a concurrent
+   * hierarchy path resume first. Keep `trackExisting` for this narrow hot path so
+   * the caller can await its original promise with no extra turn. Prefer plain
+   * {@link track} everywhere the caller does not already own the started promise
+   * on an ordering-sensitive path — this method is the narrow exception, not the
+   * default.
    *
    * Contract / misuse warning: the returned promise NEVER rejects (it resolves the
    * value on success and `undefined` on rejection) so a fire-and-forget

--- a/test/db/dbWriteBarrier.test.ts
+++ b/test/db/dbWriteBarrier.test.ts
@@ -103,6 +103,29 @@ describe("InMemoryDbWriteBarrier", () => {
   });
 
   describe("trackExisting (issue #2885)", () => {
+    it("preserves the navigation handler's original-promise continuation ahead of a concurrent hierarchy path (#3506)", async () => {
+      const navWrite = deferred<void>();
+      const resolutionOrder: string[] = [];
+
+      const navigationHandler = (async () => {
+        // This is the ordering-sensitive CtrlProxy idiom. Its caller must await
+        // the original write promise, not the barrier's derived promise.
+        void barrier.trackExisting(navWrite.promise);
+        await navWrite.promise;
+        resolutionOrder.push("navigation");
+      })();
+      const hierarchyPath = navWrite.promise.then(() => {
+        resolutionOrder.push("hierarchy");
+      });
+
+      navWrite.resolve();
+      await Promise.all([navigationHandler, hierarchyPath]);
+
+      // `track(() => navWrite)` adds one promise turn before navigation resumes,
+      // allowing hierarchy to run first. This guard makes that regression visible.
+      expect(resolutionOrder).toEqual(["navigation", "hierarchy"]);
+    });
+
     it("counts an already-started promise and clears on settle (E1)", async () => {
       const d = deferred<number>();
       const started = d.promise; // the write is already in flight

--- a/test/db/dbWriteBarrier.test.ts
+++ b/test/db/dbWriteBarrier.test.ts
@@ -111,6 +111,7 @@ describe("InMemoryDbWriteBarrier", () => {
         // This is the ordering-sensitive CtrlProxy idiom. Its caller must await
         // the original write promise, not the barrier's derived promise.
         void barrier.trackExisting(navWrite.promise);
+        expect(barrier.inFlightCount()).toBe(1);
         await navWrite.promise;
         resolutionOrder.push("navigation");
       })();
@@ -121,9 +122,26 @@ describe("InMemoryDbWriteBarrier", () => {
       navWrite.resolve();
       await Promise.all([navigationHandler, hierarchyPath]);
 
-      // `track(() => navWrite)` adds one promise turn before navigation resumes,
-      // allowing hierarchy to run first. This guard makes that regression visible.
       expect(resolutionOrder).toEqual(["navigation", "hierarchy"]);
+    });
+
+    it("shows a track wrapper lets the concurrent hierarchy path resume first (#3506)", async () => {
+      const navWrite = deferred<void>();
+      const resolutionOrder: string[] = [];
+
+      const navigationHandler = (async () => {
+        await barrier.track(() => navWrite.promise);
+        resolutionOrder.push("navigation");
+      })();
+      const hierarchyPath = navWrite.promise.then(() => {
+        resolutionOrder.push("hierarchy");
+      });
+
+      navWrite.resolve();
+      await Promise.all([navigationHandler, hierarchyPath]);
+
+      // `track` adds one promise-resolution turn before navigation resumes.
+      expect(resolutionOrder).toEqual(["hierarchy", "navigation"]);
     });
 
     it("counts an already-started promise and clears on settle (E1)", async () => {

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -146,6 +146,65 @@ describe("AndroidCtrlProxyClient", function() {
     }
   };
 
+  const settleNavigationHierarchyInterleaving = async (timer: FakeTimer): Promise<void> => {
+    // recordNavigationEvent commits its in-memory writes across several async
+    // query hops before assigning currentScreen. Drain setImmediate + microtasks
+    // so the navigation and hierarchy paths settle deterministically (#3063).
+    for (let i = 0; i < 10; i++) {
+      await new Promise<void>(resolve => setImmediate(resolve));
+      await timer.advanceTimersByTimeAsync(1);
+    }
+  };
+
+  const startSdkNavigationHierarchyInterleaving = async () => {
+    NavigationGraphManager.resetInstance();
+    const navHarness = await installInMemoryNavManager();
+    const navManager = navHarness.manager;
+    const testTimer = new FakeTimer();
+    testTimer.enableAutoAdvance();
+    const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
+    const testClient = AndroidCtrlProxyClient.createForTesting(
+      testDevice,
+      fakeAdb,
+      factory,
+      testTimer
+    );
+    const resultPromise = testClient.getLatestHierarchy(true, 2000);
+    const socket = await waitForSocket(getSocket);
+    if (!socket) {
+      throw new Error("Expected capturing CtrlProxy socket");
+    }
+    await waitForSocketOpen(socket);
+
+    socket.simulateMessage(JSON.stringify({
+      type: "navigation_event",
+      event: {
+        destination: "SdkHome",
+        source: "SdkStart",
+        arguments: {},
+        metadata: {},
+        timestamp: testTimer.now(),
+        sequenceNumber: 1,
+        applicationId: "com.example.sdk",
+      }
+    }));
+
+    socket.simulateMessage(JSON.stringify({
+      type: "hierarchy_update",
+      timestamp: testTimer.now(),
+      data: {
+        updatedAt: testTimer.now(),
+        packageName: "com.example.sdk",
+        hierarchy: {
+          "text": "SDK Home",
+          "resource-id": "com.example.sdk:id/home",
+        }
+      }
+    }));
+
+    return { navHarness, navManager, resultPromise, testClient, testTimer };
+  };
+
   interface ScreenshotUpdateMessage {
     type: string;
     deviceId?: string;
@@ -970,61 +1029,12 @@ describe("AndroidCtrlProxyClient", function() {
     });
 
     test("should preserve SDK screen names when hierarchy updates follow navigation events", async function() {
-      NavigationGraphManager.resetInstance();
-      const navHarness = await installInMemoryNavManager();
-      const navManager = navHarness.manager;
-
-      const testTimer = new FakeTimer();
-      testTimer.enableAutoAdvance();
-      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
-      const testClient = AndroidCtrlProxyClient.createForTesting(
-        testDevice,
-        fakeAdb,
-        factory,
-        testTimer
-      );
+      const { navHarness, navManager, resultPromise, testClient, testTimer } =
+        await startSdkNavigationHierarchyInterleaving();
 
       try {
-        const resultPromise = testClient.getLatestHierarchy(true, 2000);
-        const socket = await waitForSocket(getSocket);
-        expect(socket).not.toBeNull();
-        await waitForSocketOpen(socket);
-
-        socket!.simulateMessage(JSON.stringify({
-          type: "navigation_event",
-          event: {
-            destination: "SdkHome",
-            source: "SdkStart",
-            arguments: {},
-            metadata: {},
-            timestamp: testTimer.now(),
-            sequenceNumber: 1,
-            applicationId: "com.example.sdk",
-          }
-        }));
-
-        socket!.simulateMessage(JSON.stringify({
-          type: "hierarchy_update",
-          timestamp: testTimer.now(),
-          data: {
-            updatedAt: testTimer.now(),
-            packageName: "com.example.sdk",
-            hierarchy: {
-              "text": "SDK Home",
-              "resource-id": "com.example.sdk:id/home",
-            }
-          }
-        }));
-
         await resultPromise;
-        // recordNavigationEvent (fired from the navigation_event handler) commits its
-        // in-memory writes across several async query hops before assigning
-        // currentScreen. Drain setImmediate + microtasks so those settle
-        // deterministically (issue #3063).
-        for (let i = 0; i < 10; i++) {
-          await new Promise<void>(resolve => setImmediate(resolve));
-          await testTimer.advanceTimersByTimeAsync(1);
-        }
+        await settleNavigationHierarchyInterleaving(testTimer);
 
         expect(navManager.getCurrentScreen()).toBe("SdkHome");
       } finally {
@@ -1162,65 +1172,20 @@ describe("AndroidCtrlProxyClient", function() {
     });
 
     test("routes the navigation-graph write through the DB-write barrier for shutdown drain (#2885)", async function() {
-      NavigationGraphManager.resetInstance();
       resetDbWriteBarrier();
       // The Android handler resolves getDbWriteBarrier() per write (#2912), so a
       // spy on the freshly-reset shared barrier observes the nav write's
       // registration. trackExisting (not track) proves the write is drain-covered
-      // without a track() await hop that would perturb the ordering the preceding
-      // test guards.
+      // while #3506's unit guard proves its await continuation stays ahead of the
+      // concurrent hierarchy path.
       const barrier = getDbWriteBarrier();
       const trackExistingSpy = spyOn(barrier, "trackExisting");
-      const navHarness = await installInMemoryNavManager();
-      const navManager = navHarness.manager;
-
-      const testTimer = new FakeTimer();
-      testTimer.enableAutoAdvance();
-      const { factory, getSocket } = createCapturingWebSocketFactory(testTimer);
-      const testClient = AndroidCtrlProxyClient.createForTesting(
-        testDevice,
-        fakeAdb,
-        factory,
-        testTimer
-      );
+      const { navHarness, navManager, resultPromise, testClient, testTimer } =
+        await startSdkNavigationHierarchyInterleaving();
 
       try {
-        const resultPromise = testClient.getLatestHierarchy(true, 2000);
-        const socket = await waitForSocket(getSocket);
-        expect(socket).not.toBeNull();
-        await waitForSocketOpen(socket);
-
-        socket!.simulateMessage(JSON.stringify({
-          type: "navigation_event",
-          event: {
-            destination: "SdkHome",
-            source: "SdkStart",
-            arguments: {},
-            metadata: {},
-            timestamp: testTimer.now(),
-            sequenceNumber: 1,
-            applicationId: "com.example.sdk",
-          }
-        }));
-
-        socket!.simulateMessage(JSON.stringify({
-          type: "hierarchy_update",
-          timestamp: testTimer.now(),
-          data: {
-            updatedAt: testTimer.now(),
-            packageName: "com.example.sdk",
-            hierarchy: {
-              "text": "SDK Home",
-              "resource-id": "com.example.sdk:id/home",
-            }
-          }
-        }));
-
         await resultPromise;
-        for (let i = 0; i < 10; i++) {
-          await new Promise<void>(resolve => setImmediate(resolve));
-          await testTimer.advanceTimersByTimeAsync(1);
-        }
+        await settleNavigationHierarchyInterleaving(testTimer);
 
         expect(trackExistingSpy).toHaveBeenCalledTimes(1);
         // Ordering still preserved: the write committed the SDK screen name.

--- a/test/features/observe/ios/IosSdkEventIngestor.test.ts
+++ b/test/features/observe/ios/IosSdkEventIngestor.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { getDbWriteBarrier, resetDbWriteBarrier } from "../../../../src/db/dbWriteBarrier";
 import {
   DefaultIosSdkEventIngestor,
   type IosTelemetryRecorder,
@@ -286,6 +287,21 @@ describe("DefaultIosSdkEventIngestor", () => {
     expect(navSink.recorded).toHaveLength(1);
     expect(navSink.recorded[0]).toMatchObject({ applicationId: "com.app", destination: "Home", source: "Login" });
     expect(recorder.navigation[0].event).toMatchObject({ destination: "Home", source: "Login", applicationId: "com.app" });
+  });
+
+  test("routes the navigation-graph write through the DB-write barrier for shutdown drain (#3506)", async () => {
+    resetDbWriteBarrier();
+    const barrier = getDbWriteBarrier();
+    const trackExistingSpy = spyOn(barrier, "trackExisting");
+
+    try {
+      await ingestor.recordSdkEvent(event("navigation", { destination: "Home" }), "com.app");
+
+      expect(trackExistingSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      trackExistingSpy.mockRestore();
+      resetDbWriteBarrier();
+    }
   });
 
   test("navigation without applicationId still records telemetry but not the nav graph", async () => {


### PR DESCRIPTION
## Summary

Adds a deterministic, FakeTimer-backed ordering guard for the navigation-write
continuation and records the resulting design decision: retain `trackExisting`.
Wrapping the write in `track()` would add a promise-resolution turn that lets a
concurrent hierarchy path resume first. The PR also extracts the shared Android
navigation/hierarchy fixture from the existing coverage and asserts the same
barrier registration at the Android and iOS call sites.

## Linked Issue

Closes [#3506](https://github.com/kaeawc/auto-mobile/issues/3506)

## Validation

- [x] `bun run turbo:validate` — lint, build, boundary checks, and 9,918 tests passed
- [x] `bun run typecheck` — no new errors (211 known baseline errors)
- [x] Focused barrier and CtrlProxy tests passed; the new guard runs in under 1 ms
- [x] New coverage uses the existing in-memory barrier, `FakeTimer`, and test harness; no dependencies added
- [x] Rebased onto the latest `origin/main` before implementation

## Follow-ups

- None.
