### PR TITLE
feat(ios): add SDK-backed observe screen identity

### DIFF
--- a/docs/design-docs/plat/ios/auto-mobile-sdk.md
+++ b/docs/design-docs/plat/ios/auto-mobile-sdk.md
@@ -158,7 +158,7 @@ AutoMobileSDK.shared.initialize(
 
 Events flow through a three-stage pipeline:
 
-1. **Buffer** -- `SdkEventBuffer` collects events from all subsystems. Flushes when capacity is reached or on a periodic timer. When the buffer is disabled or a flush fails, the `DropCounter` records the loss reason.
+1. **Buffer** -- `SdkEventBuffer` collects events from all subsystems. Most events flush when capacity is reached or on a periodic timer. `notifyNavigationEvent(_:)` also flushes immediately: navigation routes and their arguments are the SDK-backed screen identity used by `observe` and action diffs, so they must be available before the next observation. When the buffer is disabled or a flush fails, the `DropCounter` records the loss reason.
 
 2. **Persist** -- `SdkEventBroadcaster` writes each batch to disk via `FileEventPersistence` before attempting delivery. On next app launch, `replayPending()` retries any unsent batches.
 

--- a/ios/Playground/Sources/ContentView.swift
+++ b/ios/Playground/Sources/ContentView.swift
@@ -1,7 +1,7 @@
 import AutoMobileSDK
 import SwiftUI
 
-enum Tab: Hashable {
+enum Tab: String, Hashable {
     case discover
     case demos
     case settings
@@ -45,12 +45,19 @@ struct ContentView: View {
                 .tag(Tab.settings)
         }
         .tint(.autoMobileRed)
-        .onChange(of: selectedTab) { _, newTab in
-            SwiftUINavigationAdapter.shared.trackNavigation(
-                destination: "\(newTab)",
-                metadata: ["type": "tab_switch"]
-            )
+        .onAppear {
+            trackTab(selectedTab)
         }
+        .onChange(of: selectedTab) { _, newTab in
+            trackTab(newTab)
+        }
+    }
+
+    private func trackTab(_ tab: Tab) {
+        SwiftUINavigationAdapter.shared.trackNavigation(
+            destination: tab.rawValue,
+            metadata: ["type": "tab_switch"]
+        )
     }
 }
 

--- a/ios/Playground/Sources/Tabs/DemosTab.swift
+++ b/ios/Playground/Sources/Tabs/DemosTab.swift
@@ -138,6 +138,7 @@ struct DemosTab: View {
                 }
             }
             .navigationTitle("Demos")
+            .trackNavigation(destination: "demos", metadata: ["type": "tab_switch"])
         }
     }
 }

--- a/ios/Playground/Sources/Tabs/DiscoverTab.swift
+++ b/ios/Playground/Sources/Tabs/DiscoverTab.swift
@@ -36,6 +36,12 @@ struct DiscoverTab: View {
             .background(theme.background)
             .navigationTitle("Discover")
             .searchable(text: $searchText, prompt: "Search videos")
+            .onAppear {
+                SwiftUINavigationAdapter.shared.trackNavigation(
+                    destination: "discover",
+                    metadata: ["type": "navigation_pop_or_tab_appear"]
+                )
+            }
             .navigationDestination(for: VideoItem.self) { video in
                 VideoDetailView(video: video)
             }

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.swift
@@ -337,10 +337,12 @@ public final class AutoMobileSDK: @unchecked Sendable {
     /// are paused. When re-enabled, subsystems resume.
     public func setEnabled(_ enabled: Bool) {
         lock.lock()
+        let wasEnabled = _isEnabled
         _isEnabled = enabled
         let buffer = eventBuffer
         let initialized = _isInitialized
         let config = _configuration
+        let bundleId = _bundleId
         lock.unlock()
 
         buffer?.isBufferEnabled = enabled
@@ -348,6 +350,19 @@ public final class AutoMobileSDK: @unchecked Sendable {
             buffer?.start()
         } else {
             buffer?.stop()
+        }
+
+        // Screen identity is control-plane state. Send this transition directly
+        // instead of through the disabled buffer so CtrlProxy can discard an
+        // identity that would otherwise outlive SDK tracking.
+        if initialized && wasEnabled != enabled {
+            SdkEventBroadcaster.shared.broadcastBatch(
+                bundleId: bundleId,
+                events: [SdkLifecycleEvent(
+                    state: enabled ? "sdk_tracking_enabled" : "sdk_tracking_disabled",
+                    bundleId: bundleId
+                )]
+            )
         }
 
         // Propagate to all subsystems (only if initialized). Skip subsystems

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.swift
@@ -17,6 +17,7 @@ public final class AutoMobileSDK: @unchecked Sendable {
     private var _sdkContext: SdkContext?
     private var _configuration: AutoMobileConfiguration?
     private var eventBuffer: SdkEventBuffer?
+    private var navigationSequenceNumber: Int64 = 0
     private var _dropCounter: DefaultDropCounter?
     private var eventPersistence: (any EventPersisting)?
     private var sessionTracker: SessionTracker?
@@ -188,6 +189,8 @@ public final class AutoMobileSDK: @unchecked Sendable {
 
         lock.lock()
         let currentListeners = listeners
+        navigationSequenceNumber += 1
+        let sequenceNumber = navigationSequenceNumber
         lock.unlock()
 
         for listener in currentListeners {
@@ -197,6 +200,7 @@ public final class AutoMobileSDK: @unchecked Sendable {
         // Buffer as SDK event
         let sdkEvent = SdkNavigationEvent(
             timestamp: event.timestamp,
+            sequenceNumber: sequenceNumber,
             destination: event.destination,
             source: NavigationSourceType(rawValue: event.source.rawValue) ?? .custom,
             arguments: event.arguments,
@@ -312,6 +316,7 @@ public final class AutoMobileSDK: @unchecked Sendable {
         _isInitialized = false
         _bundleId = nil
         _configuration = nil
+        navigationSequenceNumber = 0
         lock.unlock()
 
         bufferToShutdown?.shutdown()

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.swift
@@ -18,6 +18,8 @@ public final class AutoMobileSDK: @unchecked Sendable {
     private var _configuration: AutoMobileConfiguration?
     private var eventBuffer: SdkEventBuffer?
     private var navigationSequenceNumber: Int64 = 0
+    private var sdkSessionId: String?
+    private var trackingGeneration: Int64 = 0
     private var _dropCounter: DefaultDropCounter?
     private var eventPersistence: (any EventPersisting)?
     private var sessionTracker: SessionTracker?
@@ -50,6 +52,9 @@ public final class AutoMobileSDK: @unchecked Sendable {
 
         let resolvedBundleId = bundleId ?? Bundle.main.bundleIdentifier
         _bundleId = resolvedBundleId
+        let newSessionId = UUID().uuidString
+        sdkSessionId = newSessionId
+        trackingGeneration = 0
         _configuration = configuration
 
         let counter = DefaultDropCounter()
@@ -86,6 +91,10 @@ public final class AutoMobileSDK: @unchecked Sendable {
         lock.unlock()
 
         buffer.start()
+        SdkEventBroadcaster.shared.broadcastBatch(
+            bundleId: resolvedBundleId,
+            events: [SdkLifecycleEvent(state: "sdk_session_started", bundleId: resolvedBundleId, sessionId: newSessionId, trackingGeneration: 0)]
+        )
 
         // Replay any pending batches from previous sessions and clean up old ones
         persistence.cleanup(maxAgeDays: 7)
@@ -191,6 +200,8 @@ public final class AutoMobileSDK: @unchecked Sendable {
         let currentListeners = listeners
         navigationSequenceNumber += 1
         let sequenceNumber = navigationSequenceNumber
+        let currentSessionId = sdkSessionId
+        let currentTrackingGeneration = trackingGeneration
         lock.unlock()
 
         for listener in currentListeners {
@@ -201,6 +212,8 @@ public final class AutoMobileSDK: @unchecked Sendable {
         let sdkEvent = SdkNavigationEvent(
             timestamp: event.timestamp,
             sequenceNumber: sequenceNumber,
+            sessionId: currentSessionId,
+            trackingGeneration: currentTrackingGeneration,
             destination: event.destination,
             source: NavigationSourceType(rawValue: event.source.rawValue) ?? .custom,
             arguments: event.arguments,
@@ -317,6 +330,8 @@ public final class AutoMobileSDK: @unchecked Sendable {
         _bundleId = nil
         _configuration = nil
         navigationSequenceNumber = 0
+        sdkSessionId = nil
+        trackingGeneration = 0
         lock.unlock()
 
         bufferToShutdown?.shutdown()
@@ -338,11 +353,16 @@ public final class AutoMobileSDK: @unchecked Sendable {
     public func setEnabled(_ enabled: Bool) {
         lock.lock()
         let wasEnabled = _isEnabled
+        if wasEnabled != enabled {
+            trackingGeneration += 1
+        }
         _isEnabled = enabled
         let buffer = eventBuffer
         let initialized = _isInitialized
         let config = _configuration
         let bundleId = _bundleId
+        let currentSessionId = sdkSessionId
+        let currentTrackingGeneration = trackingGeneration
         lock.unlock()
 
         buffer?.isBufferEnabled = enabled
@@ -360,7 +380,9 @@ public final class AutoMobileSDK: @unchecked Sendable {
                 bundleId: bundleId,
                 events: [SdkLifecycleEvent(
                     state: enabled ? "sdk_tracking_enabled" : "sdk_tracking_disabled",
-                    bundleId: bundleId
+                    bundleId: bundleId,
+                    sessionId: currentSessionId,
+                    trackingGeneration: currentTrackingGeneration
                 )]
             )
         }

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.swift
@@ -203,6 +203,10 @@ public final class AutoMobileSDK: @unchecked Sendable {
             metadata: event.metadata
         )
         eventBuffer?.add(sdkEvent)
+        // Navigation is control-plane state for observe/diff, not bulk telemetry.
+        // Flush it immediately so a post-action observation can fetch the current
+        // screen identity instead of waiting for the regular telemetry cadence.
+        eventBuffer?.flush()
     }
 
     /// Number of registered listeners.

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/AutoMobileSDK.swift
@@ -8,6 +8,7 @@ import UIKit
 /// crash detection, and more.
 public final class AutoMobileSDK: @unchecked Sendable {
     public static let shared = AutoMobileSDK()
+    private static let sessionEpochDefaultsKey = "com.kaeawc.auto-mobile.sdk.session-epoch"
 
     private let lock = NSLock()
     private var listeners: [NavigationListener] = []
@@ -19,6 +20,7 @@ public final class AutoMobileSDK: @unchecked Sendable {
     private var eventBuffer: SdkEventBuffer?
     private var navigationSequenceNumber: Int64 = 0
     private var sdkSessionId: String?
+    private var sdkSessionEpoch: Int64?
     private var trackingGeneration: Int64 = 0
     private var _dropCounter: DefaultDropCounter?
     private var eventPersistence: (any EventPersisting)?
@@ -53,7 +55,9 @@ public final class AutoMobileSDK: @unchecked Sendable {
         let resolvedBundleId = bundleId ?? Bundle.main.bundleIdentifier
         _bundleId = resolvedBundleId
         let newSessionId = UUID().uuidString
+        let newSessionEpoch = Self.nextSessionEpoch()
         sdkSessionId = newSessionId
+        sdkSessionEpoch = newSessionEpoch
         trackingGeneration = 0
         _configuration = configuration
 
@@ -93,7 +97,7 @@ public final class AutoMobileSDK: @unchecked Sendable {
         buffer.start()
         SdkEventBroadcaster.shared.broadcastBatch(
             bundleId: resolvedBundleId,
-            events: [SdkLifecycleEvent(state: "sdk_session_started", bundleId: resolvedBundleId, sessionId: newSessionId, trackingGeneration: 0)]
+            events: [SdkLifecycleEvent(state: "sdk_session_started", bundleId: resolvedBundleId, sessionId: newSessionId, sessionEpoch: newSessionEpoch, trackingGeneration: 0)]
         )
 
         // Replay any pending batches from previous sessions and clean up old ones
@@ -201,6 +205,7 @@ public final class AutoMobileSDK: @unchecked Sendable {
         navigationSequenceNumber += 1
         let sequenceNumber = navigationSequenceNumber
         let currentSessionId = sdkSessionId
+        let currentSessionEpoch = sdkSessionEpoch
         let currentTrackingGeneration = trackingGeneration
         lock.unlock()
 
@@ -213,6 +218,7 @@ public final class AutoMobileSDK: @unchecked Sendable {
             timestamp: event.timestamp,
             sequenceNumber: sequenceNumber,
             sessionId: currentSessionId,
+            sessionEpoch: currentSessionEpoch,
             trackingGeneration: currentTrackingGeneration,
             destination: event.destination,
             source: NavigationSourceType(rawValue: event.source.rawValue) ?? .custom,
@@ -331,6 +337,7 @@ public final class AutoMobileSDK: @unchecked Sendable {
         _configuration = nil
         navigationSequenceNumber = 0
         sdkSessionId = nil
+        sdkSessionEpoch = nil
         trackingGeneration = 0
         lock.unlock()
 
@@ -362,6 +369,7 @@ public final class AutoMobileSDK: @unchecked Sendable {
         let config = _configuration
         let bundleId = _bundleId
         let currentSessionId = sdkSessionId
+        let currentSessionEpoch = sdkSessionEpoch
         let currentTrackingGeneration = trackingGeneration
         lock.unlock()
 
@@ -382,6 +390,7 @@ public final class AutoMobileSDK: @unchecked Sendable {
                     state: enabled ? "sdk_tracking_enabled" : "sdk_tracking_disabled",
                     bundleId: bundleId,
                     sessionId: currentSessionId,
+                    sessionEpoch: currentSessionEpoch,
                     trackingGeneration: currentTrackingGeneration
                 )]
             )
@@ -403,6 +412,15 @@ public final class AutoMobileSDK: @unchecked Sendable {
         }
         // Crashes: signal handlers can't be safely uninstalled; the exception handler
         // already checks AutoMobileSDK.shared.isEnabled before posting events.
+    }
+
+    private static func nextSessionEpoch() -> Int64 {
+        let defaults = UserDefaults.standard
+        let previousEpoch = Int64(defaults.integer(forKey: sessionEpochDefaultsKey))
+        let currentMilliseconds = Int64(Date().timeIntervalSince1970 * 1000)
+        let nextEpoch = previousEpoch == Int64.max ? currentMilliseconds : max(previousEpoch + 1, currentMilliseconds)
+        defaults.set(nextEpoch, forKey: sessionEpochDefaultsKey)
+        return nextEpoch
     }
 
     /// Whether the SDK has been initialized.

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEvent.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEvent.swift
@@ -33,6 +33,10 @@ public struct SdkNavigationEvent: SdkEvent {
     public let timestamp: Int64
     /// Monotonic per-SDK navigation order used to break same-millisecond timestamp ties.
     public let sequenceNumber: Int64?
+    /// Per-process SDK identity used to reject navigation from replaced app processes.
+    public let sessionId: String?
+    /// Monotonic SDK tracking state used to order enable/disable control events.
+    public let trackingGeneration: Int64?
     public let destination: String
     public let source: NavigationSourceType
     public let arguments: [String: String]
@@ -41,6 +45,8 @@ public struct SdkNavigationEvent: SdkEvent {
     public init(
         timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000),
         sequenceNumber: Int64? = nil,
+        sessionId: String? = nil,
+        trackingGeneration: Int64? = nil,
         destination: String,
         source: NavigationSourceType,
         arguments: [String: String] = [:],
@@ -48,6 +54,8 @@ public struct SdkNavigationEvent: SdkEvent {
     ) {
         self.timestamp = timestamp
         self.sequenceNumber = sequenceNumber
+        self.sessionId = sessionId
+        self.trackingGeneration = trackingGeneration
         self.destination = destination
         self.source = source
         self.arguments = arguments
@@ -280,17 +288,23 @@ public struct SdkLifecycleEvent: SdkEvent {
     public let state: String
     public let bundleId: String?
     public let details: [String: String]
+    public let sessionId: String?
+    public let trackingGeneration: Int64?
 
     public init(
         timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000),
         state: String,
         bundleId: String? = nil,
-        details: [String: String] = [:]
+        details: [String: String] = [:],
+        sessionId: String? = nil,
+        trackingGeneration: Int64? = nil
     ) {
         self.timestamp = timestamp
         self.state = state
         self.bundleId = bundleId
         self.details = details
+        self.sessionId = sessionId
+        self.trackingGeneration = trackingGeneration
     }
 }
 

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEvent.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEvent.swift
@@ -31,6 +31,8 @@ public enum SdkEventType: String, Codable, Sendable {
 public struct SdkNavigationEvent: SdkEvent {
     public private(set) var eventType: SdkEventType = .navigation
     public let timestamp: Int64
+    /// Monotonic per-SDK navigation order used to break same-millisecond timestamp ties.
+    public let sequenceNumber: Int64?
     public let destination: String
     public let source: NavigationSourceType
     public let arguments: [String: String]
@@ -38,12 +40,14 @@ public struct SdkNavigationEvent: SdkEvent {
 
     public init(
         timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000),
+        sequenceNumber: Int64? = nil,
         destination: String,
         source: NavigationSourceType,
         arguments: [String: String] = [:],
         metadata: [String: String] = [:]
     ) {
         self.timestamp = timestamp
+        self.sequenceNumber = sequenceNumber
         self.destination = destination
         self.source = source
         self.arguments = arguments

--- a/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEvent.swift
+++ b/ios/auto-mobile-sdk/Sources/AutoMobileSDK/Events/SdkEvent.swift
@@ -35,6 +35,8 @@ public struct SdkNavigationEvent: SdkEvent {
     public let sequenceNumber: Int64?
     /// Per-process SDK identity used to reject navigation from replaced app processes.
     public let sessionId: String?
+    /// Persistent process order used to reject delayed events from an older SDK session.
+    public let sessionEpoch: Int64?
     /// Monotonic SDK tracking state used to order enable/disable control events.
     public let trackingGeneration: Int64?
     public let destination: String
@@ -46,6 +48,7 @@ public struct SdkNavigationEvent: SdkEvent {
         timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000),
         sequenceNumber: Int64? = nil,
         sessionId: String? = nil,
+        sessionEpoch: Int64? = nil,
         trackingGeneration: Int64? = nil,
         destination: String,
         source: NavigationSourceType,
@@ -55,6 +58,7 @@ public struct SdkNavigationEvent: SdkEvent {
         self.timestamp = timestamp
         self.sequenceNumber = sequenceNumber
         self.sessionId = sessionId
+        self.sessionEpoch = sessionEpoch
         self.trackingGeneration = trackingGeneration
         self.destination = destination
         self.source = source
@@ -289,6 +293,7 @@ public struct SdkLifecycleEvent: SdkEvent {
     public let bundleId: String?
     public let details: [String: String]
     public let sessionId: String?
+    public let sessionEpoch: Int64?
     public let trackingGeneration: Int64?
 
     public init(
@@ -297,6 +302,7 @@ public struct SdkLifecycleEvent: SdkEvent {
         bundleId: String? = nil,
         details: [String: String] = [:],
         sessionId: String? = nil,
+        sessionEpoch: Int64? = nil,
         trackingGeneration: Int64? = nil
     ) {
         self.timestamp = timestamp
@@ -304,6 +310,7 @@ public struct SdkLifecycleEvent: SdkEvent {
         self.bundleId = bundleId
         self.details = details
         self.sessionId = sessionId
+        self.sessionEpoch = sessionEpoch
         self.trackingGeneration = trackingGeneration
     }
 }

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/AutoMobileSDKTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/AutoMobileSDKTests.swift
@@ -8,6 +8,13 @@ private final class NavEventHolder: @unchecked Sendable {
     func set(_ event: NavigationEvent) { lock.lock(); _event = event; lock.unlock() }
 }
 
+private final class LifecycleStateHolder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _state: String?
+    var state: String? { lock.lock(); defer { lock.unlock() }; return _state }
+    func set(_ state: String) { lock.lock(); _state = state; lock.unlock() }
+}
+
 final class AutoMobileSDKTests: XCTestCase {
     override func tearDown() {
         AutoMobileSDK.shared.reset()
@@ -100,5 +107,28 @@ final class AutoMobileSDKTests: XCTestCase {
         XCTAssertFalse(AutoMobileSDK.shared.isEnabled)
         AutoMobileSDK.shared.setEnabled(true)
         XCTAssertTrue(AutoMobileSDK.shared.isEnabled)
+    }
+
+    func testSetEnabledBroadcastsTrackingDisabledControlEvent() {
+        let holder = LifecycleStateHolder()
+        let observer = NotificationCenter.default.addObserver(
+            forName: SdkEventBroadcaster.eventBatchNotification,
+            object: nil,
+            queue: nil
+        ) { notification in
+            guard let data = notification.userInfo?[SdkEventBroadcaster.eventBatchUserInfoKey] as? Data,
+                  let batch = try? JSONDecoder().decode(SdkEventBatch.self, from: data),
+                  let event = batch.events.first,
+                  let lifecycle = try? JSONDecoder().decode(SdkLifecycleEvent.self, from: event.payload),
+                  lifecycle.state == "sdk_tracking_disabled"
+            else { return }
+            holder.set(lifecycle.state)
+        }
+
+        AutoMobileSDK.shared.initialize(bundleId: "com.test.app")
+        AutoMobileSDK.shared.setEnabled(false)
+
+        NotificationCenter.default.removeObserver(observer)
+        XCTAssertEqual(holder.state, "sdk_tracking_disabled")
     }
 }

--- a/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/EventPersistenceTests.swift
+++ b/ios/auto-mobile-sdk/Tests/AutoMobileSDKTests/EventPersistenceTests.swift
@@ -88,6 +88,7 @@ final class EventPersistenceTests: XCTestCase {
     func testPersistAndLoadNavigationEvent() {
         let event = SdkNavigationEvent(
             timestamp: 1000,
+            sequenceNumber: 7,
             destination: "/home",
             source: .swiftUINavigation,
             arguments: ["id": "42"],
@@ -102,9 +103,21 @@ final class EventPersistenceTests: XCTestCase {
             XCTAssertEqual(nav.destination, "/home")
             XCTAssertEqual(nav.source, .swiftUINavigation)
             XCTAssertEqual(nav.arguments["id"], "42")
+            XCTAssertEqual(nav.sequenceNumber, 7)
         } else {
             XCTFail("Expected SdkNavigationEvent")
         }
+    }
+
+    func testNavigationEventDecodesLegacyPayloadWithoutSequenceNumber() throws {
+        let legacyJson = Data("""
+        {"eventType":"navigation","timestamp":1000,"destination":"/home",\
+        "source":"swiftui_navigation","arguments":{},"metadata":{}}
+        """.utf8)
+
+        let event = try JSONDecoder().decode(SdkNavigationEvent.self, from: legacyJson)
+
+        XCTAssertNil(event.sequenceNumber)
     }
 
     func testPersistEmptyArrayReturnsNil() {

--- a/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -92,11 +92,13 @@ public struct SdkNavigationEvent: SdkEvent
   public private(set) var eventType: SdkEventType = .navigation
   public let timestamp: Int64
   public let sequenceNumber: Int64?
+  public let sessionId: String?
+  public let trackingGeneration: Int64?
   public let destination: String
   public let source: NavigationSourceType
   public let arguments: [String: String]
   public let metadata: [String: String]
-  public init( timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000), sequenceNumber: Int64? = nil, destination: String, source: NavigationSourceType, arguments: [String: String] = [:], metadata: [String: String] = [:] )
+  public init( timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000), sequenceNumber: Int64? = nil, sessionId: String? = nil, trackingGeneration: Int64? = nil, destination: String, source: NavigationSourceType, arguments: [String: String] = [:], metadata: [String: String] = [:] )
 public struct SdkHandledExceptionEvent: SdkEvent
   public private(set) var eventType: SdkEventType = .handledException
   public let timestamp: Int64
@@ -170,7 +172,9 @@ public struct SdkLifecycleEvent: SdkEvent
   public let state: String
   public let bundleId: String?
   public let details: [String: String]
-  public init( timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000), state: String, bundleId: String? = nil, details: [String: String] = [:] )
+  public let sessionId: String?
+  public let trackingGeneration: Int64?
+  public init( timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000), state: String, bundleId: String? = nil, details: [String: String] = [:], sessionId: String? = nil, trackingGeneration: Int64? = nil )
 public struct SdkNotificationActionEvent: SdkEvent
   public private(set) var eventType: SdkEventType = .notificationAction
   public let timestamp: Int64

--- a/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -93,12 +93,13 @@ public struct SdkNavigationEvent: SdkEvent
   public let timestamp: Int64
   public let sequenceNumber: Int64?
   public let sessionId: String?
+  public let sessionEpoch: Int64?
   public let trackingGeneration: Int64?
   public let destination: String
   public let source: NavigationSourceType
   public let arguments: [String: String]
   public let metadata: [String: String]
-  public init( timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000), sequenceNumber: Int64? = nil, sessionId: String? = nil, trackingGeneration: Int64? = nil, destination: String, source: NavigationSourceType, arguments: [String: String] = [:], metadata: [String: String] = [:] )
+  public init( timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000), sequenceNumber: Int64? = nil, sessionId: String? = nil, sessionEpoch: Int64? = nil, trackingGeneration: Int64? = nil, destination: String, source: NavigationSourceType, arguments: [String: String] = [:], metadata: [String: String] = [:] )
 public struct SdkHandledExceptionEvent: SdkEvent
   public private(set) var eventType: SdkEventType = .handledException
   public let timestamp: Int64
@@ -173,8 +174,9 @@ public struct SdkLifecycleEvent: SdkEvent
   public let bundleId: String?
   public let details: [String: String]
   public let sessionId: String?
+  public let sessionEpoch: Int64?
   public let trackingGeneration: Int64?
-  public init( timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000), state: String, bundleId: String? = nil, details: [String: String] = [:], sessionId: String? = nil, trackingGeneration: Int64? = nil )
+  public init( timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000), state: String, bundleId: String? = nil, details: [String: String] = [:], sessionId: String? = nil, sessionEpoch: Int64? = nil, trackingGeneration: Int64? = nil )
 public struct SdkNotificationActionEvent: SdkEvent
   public private(set) var eventType: SdkEventType = .notificationAction
   public let timestamp: Int64

--- a/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
+++ b/ios/auto-mobile-sdk/api/auto-mobile-sdk.api
@@ -91,11 +91,12 @@ public enum SdkEventType: String, Codable, Sendable
 public struct SdkNavigationEvent: SdkEvent
   public private(set) var eventType: SdkEventType = .navigation
   public let timestamp: Int64
+  public let sequenceNumber: Int64?
   public let destination: String
   public let source: NavigationSourceType
   public let arguments: [String: String]
   public let metadata: [String: String]
-  public init( timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000), destination: String, source: NavigationSourceType, arguments: [String: String] = [:], metadata: [String: String] = [:] )
+  public init( timestamp: Int64 = Int64(Date().timeIntervalSince1970 * 1000), sequenceNumber: Int64? = nil, destination: String, source: NavigationSourceType, arguments: [String: String] = [:], metadata: [String: String] = [:] )
 public struct SdkHandledExceptionEvent: SdkEvent
   public private(set) var eventType: SdkEventType = .handledException
   public let timestamp: Int64

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -4723,10 +4723,16 @@
                 "bundleId": {
                   "type": "string"
                 },
+                "navigationRoute": {
+                  "type": "string"
+                },
                 "navigationTitle": {
                   "type": "string"
                 },
                 "selectedTab": {
+                  "type": "string"
+                },
+                "presentation": {
                   "type": "string"
                 },
                 "modalClass": {
@@ -8851,10 +8857,16 @@
                         "bundleId": {
                           "type": "string"
                         },
+                        "navigationRoute": {
+                          "type": "string"
+                        },
                         "navigationTitle": {
                           "type": "string"
                         },
                         "selectedTab": {
+                          "type": "string"
+                        },
+                        "presentation": {
                           "type": "string"
                         },
                         "modalClass": {
@@ -9009,10 +9021,16 @@
                         "bundleId": {
                           "type": "string"
                         },
+                        "navigationRoute": {
+                          "type": "string"
+                        },
                         "navigationTitle": {
                           "type": "string"
                         },
                         "selectedTab": {
+                          "type": "string"
+                        },
+                        "presentation": {
                           "type": "string"
                         },
                         "modalClass": {
@@ -9103,10 +9121,16 @@
                         "bundleId": {
                           "type": "string"
                         },
+                        "navigationRoute": {
+                          "type": "string"
+                        },
                         "navigationTitle": {
                           "type": "string"
                         },
                         "selectedTab": {
+                          "type": "string"
+                        },
+                        "presentation": {
                           "type": "string"
                         },
                         "modalClass": {

--- a/src/features/action/InstallApp.ts
+++ b/src/features/action/InstallApp.ts
@@ -13,6 +13,7 @@ import { AndroidCtrlProxyClient } from "../observe/android";
 import { logger } from "../../utils/logger";
 import { resolvePathFromDaemonLaunchWorkingDirectory } from "../../utils/workingDirectory";
 import { PlistClient, type PlistReader } from "../../utils/ios-cmdline-tools/PlistClient";
+import { IOSCtrlProxyClient } from "../observe/ios";
 
 export interface DeviceAppInstaller {
   installApp(deviceUdid: string, artifactPath: string): Promise<void>;
@@ -70,10 +71,16 @@ export class InstallApp {
       this.validateiOSArtifact(ext);
       if (ext === ".ipa") {
         const result = await perf.track("iOSPhysicalInstall", () => this.executeiOSPhysical(artifactPath, perf, signal));
+        if (result.success) {
+          IOSCtrlProxyClient.getExistingInstance(this.device.deviceId)?.clearSdkScreenIdentity();
+        }
         perf.end();
         return { ...result, userId: 0 };
       }
       const result = await perf.track("iOSInstall", () => this.executeiOSSimulator(artifactPath, perf, signal));
+      if (result.success) {
+        IOSCtrlProxyClient.getExistingInstance(this.device.deviceId)?.clearSdkScreenIdentity(result.packageName);
+      }
       perf.end();
       return { ...result, userId: 0 };
     }

--- a/src/features/action/LaunchApp.ts
+++ b/src/features/action/LaunchApp.ts
@@ -353,7 +353,9 @@ export class LaunchApp extends BaseVisualChange {
           // need here: invalidateCache() (fixed in #4193) forces a refetch, but the
           // invalidated entry is still served as a stale fallback if that refetch
           // fails — and pre-terminate data for a wiped app must never be served.
-          IOSCtrlProxyClient.getInstance(this.device).clearCache();
+          const ctrlProxyClient = IOSCtrlProxyClient.getInstance(this.device);
+          ctrlProxyClient.clearCache();
+          IOSCtrlProxyClient.getExistingInstance(this.device.deviceId)?.clearSdkScreenIdentity(bundleId);
           launchResult = await perf.track("launch", () =>
             simulator
               ? this.simctl.launchApp(bundleId, { foregroundIfRunning: false })
@@ -365,6 +367,9 @@ export class LaunchApp extends BaseVisualChange {
           // Warm launch. Simulator: simctl launch foregrounds a backgrounded app
           // and is faster than the CtrlProxy WebSocket round-trip (~4-5s). Device:
           // devicectl has no foreground verb, so relaunch via --terminate-existing.
+          if (!simulator) {
+            IOSCtrlProxyClient.getExistingInstance(this.device.deviceId)?.clearSdkScreenIdentity(bundleId);
+          }
           launchResult = await perf.track("launch", () =>
             simulator
               ? this.simctl.launchApp(bundleId)

--- a/src/features/action/LaunchApp.ts
+++ b/src/features/action/LaunchApp.ts
@@ -367,10 +367,6 @@ export class LaunchApp extends BaseVisualChange {
           // Warm launch. Simulator: simctl launch foregrounds a backgrounded app
           // and is faster than the CtrlProxy WebSocket round-trip (~4-5s). Device:
           // devicectl has no foreground verb, so relaunch via --terminate-existing.
-          // simctl launch can either foreground a backgrounded process or start
-          // a replacement process after an external crash. Clear conservatively:
-          // the next identity refresh drains any queued pre-launch SDK events.
-          IOSCtrlProxyClient.getExistingInstance(this.device.deviceId)?.clearSdkScreenIdentity(bundleId);
           launchResult = await perf.track("launch", () =>
             simulator
               ? this.simctl.launchApp(bundleId)

--- a/src/features/action/LaunchApp.ts
+++ b/src/features/action/LaunchApp.ts
@@ -367,9 +367,10 @@ export class LaunchApp extends BaseVisualChange {
           // Warm launch. Simulator: simctl launch foregrounds a backgrounded app
           // and is faster than the CtrlProxy WebSocket round-trip (~4-5s). Device:
           // devicectl has no foreground verb, so relaunch via --terminate-existing.
-          if (!simulator) {
-            IOSCtrlProxyClient.getExistingInstance(this.device.deviceId)?.clearSdkScreenIdentity(bundleId);
-          }
+          // simctl launch can either foreground a backgrounded process or start
+          // a replacement process after an external crash. Clear conservatively:
+          // the next identity refresh drains any queued pre-launch SDK events.
+          IOSCtrlProxyClient.getExistingInstance(this.device.deviceId)?.clearSdkScreenIdentity(bundleId);
           launchResult = await perf.track("launch", () =>
             simulator
               ? this.simctl.launchApp(bundleId)

--- a/src/features/action/TerminateApp.ts
+++ b/src/features/action/TerminateApp.ts
@@ -10,6 +10,7 @@ import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType"
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 import { logger } from "../../utils/logger";
 import { AndroidCtrlProxyClient } from "../observe/android";
+import { IOSCtrlProxyClient } from "../observe/ios";
 
 /**
  * Physical-device app terminator. `DeviceAppManager` satisfies this
@@ -176,9 +177,16 @@ export class TerminateApp extends BaseVisualChange {
 
     // Physical iOS devices (00008XXX / 40-char UDID) can't be driven by simctl;
     // route them through devicectl instead. Simulators keep the simctl path.
-    const terminateLogic = isIosSimulatorUdid(this.device.deviceId)
+    const terminateTransport = isIosSimulatorUdid(this.device.deviceId)
       ? () => this.terminateSimulator(bundleId, perf)
       : () => this.terminatePhysicalDevice(bundleId, perf);
+    const terminateLogic = async (): Promise<TerminateAppResult> => {
+      const result = await terminateTransport();
+      if (result.success) {
+        IOSCtrlProxyClient.getExistingInstance(this.device.deviceId)?.clearSdkScreenIdentity(bundleId);
+      }
+      return result;
+    };
 
     // Perf-tree ownership (issue #3037): `executeiOS` opens the "terminateApp"
     // block, so it — the single owner — must close it. The terminate helpers no

--- a/src/features/action/UninstallApp.ts
+++ b/src/features/action/UninstallApp.ts
@@ -9,6 +9,7 @@ import { DeviceAppManager } from "../../utils/ios-cmdline-tools/DeviceAppManager
 import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { logger } from "../../utils/logger";
+import { IOSCtrlProxyClient } from "../observe/ios";
 
 export interface DeviceAppUninstaller {
   uninstallApp(deviceUdid: string, bundleId: string, isSimulator?: boolean): Promise<void>;
@@ -90,6 +91,7 @@ export class UninstallApp {
       const installed = (await listApps.execute()).find(app => app === bundleId) !== undefined;
 
       if (!installed) {
+        IOSCtrlProxyClient.getExistingInstance(this.device.deviceId)?.clearSdkScreenIdentity(bundleId);
         return {
           success: true,
           packageName: bundleId,
@@ -122,6 +124,8 @@ export class UninstallApp {
           error: "Failed to uninstall application"
         };
       }
+
+      IOSCtrlProxyClient.getExistingInstance(this.device.deviceId)?.clearSdkScreenIdentity(bundleId);
 
       return {
         success: true,

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -485,7 +485,7 @@ export class RealObserveScreen implements ObserveScreen {
 
         break;
 
-      case "ios":
+      case "ios": {
         perf.serial("ios_collect");
         await this.hierarchyCollector.collect(result, queryOptions, perf, skipWaitForFresh, minTimestamp, signal);
 
@@ -551,6 +551,7 @@ export class RealObserveScreen implements ObserveScreen {
 
         perf.end();
         break;
+      }
     }
   }
 

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -1,6 +1,6 @@
 import { logger } from "../../utils/logger";
 import { throwIfAborted } from "../../utils/toolUtils";
-import { BootedDevice, ObserveResult } from "../../models";
+import { BootedDevice, ObserveResult, ScreenIdentity } from "../../models";
 import { ViewHierarchy } from "./ViewHierarchy";
 import { Window } from "./Window";
 import { TakeScreenshot } from "./TakeScreenshot";
@@ -540,8 +540,14 @@ export class RealObserveScreen implements ObserveScreen {
           };
         }
 
-        result.screenIdentity = await this.viewHierarchy.getScreenIdentity?.(result.viewHierarchy?.packageName)
-          ?? deriveIosScreenIdentity(result.viewHierarchy);
+        let sdkScreenIdentity: ScreenIdentity | undefined;
+        try {
+          sdkScreenIdentity = await this.viewHierarchy.getScreenIdentity?.(result.viewHierarchy?.packageName);
+        } catch (error) {
+          // The hierarchy remains valid when the optional SDK refresh fails.
+          logger.debug(`[iOS] SDK screen identity refresh failed; using hierarchy identity: ${error}`);
+        }
+        result.screenIdentity = sdkScreenIdentity ?? deriveIosScreenIdentity(result.viewHierarchy);
 
         perf.end();
         break;

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -540,7 +540,8 @@ export class RealObserveScreen implements ObserveScreen {
           };
         }
 
-        result.screenIdentity = deriveIosScreenIdentity(result.viewHierarchy);
+        result.screenIdentity = this.viewHierarchy.getScreenIdentity?.(result.viewHierarchy?.packageName)
+          ?? deriveIosScreenIdentity(result.viewHierarchy);
 
         perf.end();
         break;

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -547,7 +547,10 @@ export class RealObserveScreen implements ObserveScreen {
           // The hierarchy remains valid when the optional SDK refresh fails.
           logger.debug(`[iOS] SDK screen identity refresh failed; using hierarchy identity: ${error}`);
         }
-        result.screenIdentity = sdkScreenIdentity ?? deriveIosScreenIdentity(result.viewHierarchy);
+        const hierarchyScreenIdentity = deriveIosScreenIdentity(result.viewHierarchy);
+        result.screenIdentity = hierarchyScreenIdentity?.components.modalClass
+          ? hierarchyScreenIdentity
+          : sdkScreenIdentity ?? hierarchyScreenIdentity;
 
         perf.end();
         break;

--- a/src/features/observe/ObserveScreen.ts
+++ b/src/features/observe/ObserveScreen.ts
@@ -540,7 +540,7 @@ export class RealObserveScreen implements ObserveScreen {
           };
         }
 
-        result.screenIdentity = this.viewHierarchy.getScreenIdentity?.(result.viewHierarchy?.packageName)
+        result.screenIdentity = await this.viewHierarchy.getScreenIdentity?.(result.viewHierarchy?.packageName)
           ?? deriveIosScreenIdentity(result.viewHierarchy);
 
         perf.end();

--- a/src/features/observe/ViewHierarchy.ts
+++ b/src/features/observe/ViewHierarchy.ts
@@ -69,12 +69,12 @@ export class ViewHierarchy implements ViewHierarchyInterface {
     await this.accessibilityServiceClient.setRecompositionTrackingEnabled(enabled, perf);
   }
 
-  getScreenIdentity(applicationId?: string): ScreenIdentity | undefined {
+  async getScreenIdentity(applicationId?: string): Promise<ScreenIdentity | undefined> {
     if (this.device.platform !== "ios") {
       return undefined;
     }
     return IOSCtrlProxyClient.getExistingInstance(this.device.deviceId)
-      ?.getSdkScreenIdentity(applicationId);
+      ?.refreshSdkScreenIdentity(applicationId);
   }
 
   /**

--- a/src/features/observe/ViewHierarchy.ts
+++ b/src/features/observe/ViewHierarchy.ts
@@ -2,6 +2,7 @@ import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-c
 import { logger, LogLevel } from "../../utils/logger";
 import { BootedDevice } from "../../models";
 import { Element } from "../../models";
+import { ScreenIdentity } from "../../models";
 import { ViewHierarchyResult } from "../../models";
 import type { ElementParser } from "../../utils/interfaces/ElementParser";
 import type { ElementGeometry } from "../../utils/interfaces/ElementGeometry";
@@ -66,6 +67,14 @@ export class ViewHierarchy implements ViewHierarchyInterface {
     }
 
     await this.accessibilityServiceClient.setRecompositionTrackingEnabled(enabled, perf);
+  }
+
+  getScreenIdentity(applicationId?: string): ScreenIdentity | undefined {
+    if (this.device.platform !== "ios") {
+      return undefined;
+    }
+    return IOSCtrlProxyClient.getExistingInstance(this.device.deviceId)
+      ?.getSdkScreenIdentity(applicationId);
   }
 
   /**

--- a/src/features/observe/interfaces/ViewHierarchy.ts
+++ b/src/features/observe/interfaces/ViewHierarchy.ts
@@ -10,7 +10,7 @@ export interface ViewHierarchy {
    * Return the latest app-provided iOS navigation identity, if this hierarchy
    * reader has one. Optional so hierarchy-only fakes do not need an SDK seam.
    */
-  getScreenIdentity?(applicationId?: string): ScreenIdentity | undefined;
+  getScreenIdentity?(applicationId?: string): ScreenIdentity | undefined | Promise<ScreenIdentity | undefined>;
 
   /**
    * Retrieve the view hierarchy of the current screen.

--- a/src/features/observe/interfaces/ViewHierarchy.ts
+++ b/src/features/observe/interfaces/ViewHierarchy.ts
@@ -1,4 +1,4 @@
-import type { Element, ViewHierarchyResult } from "../../../models";
+import type { Element, ScreenIdentity, ViewHierarchyResult } from "../../../models";
 import type { ViewHierarchyQueryOptions } from "../../../models/ViewHierarchyQueryOptions";
 import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
 
@@ -6,6 +6,12 @@ import type { PerformanceTracker } from "../../../utils/PerformanceTracker";
  * Interface for retrieving and managing view hierarchy data.
  */
 export interface ViewHierarchy {
+  /**
+   * Return the latest app-provided iOS navigation identity, if this hierarchy
+   * reader has one. Optional so hierarchy-only fakes do not need an SDK seam.
+   */
+  getScreenIdentity?(applicationId?: string): ScreenIdentity | undefined;
+
   /**
    * Retrieve the view hierarchy of the current screen.
    * @param queryOptions - Optional query options for targeted element retrieval

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -441,6 +441,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   private readonly sdkScreenIdentityGenerationsByApplicationId = new Map<string, number>();
   private readonly sdkScreenIdentitySessionsByApplicationId = new Map<string, string>();
   private readonly sdkScreenIdentityStartedSessionsByApplicationId = new Map<string, string>();
+  private readonly sdkScreenIdentitySessionEpochsByApplicationId = new Map<string, number>();
   private readonly sdkScreenIdentityRetiredSessionsByApplicationId = new Map<string, Set<string>>();
   private readonly sdkScreenIdentityTrackingGenerationsByApplicationId = new Map<string, number>();
   private readonly sdkScreenIdentityTrackingDisabledApplicationIds = new Set<string>();
@@ -531,6 +532,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     this.sdkScreenIdentityTrackingDisabledApplicationIds.clear();
     this.sdkScreenIdentitySessionsByApplicationId.clear();
     this.sdkScreenIdentityStartedSessionsByApplicationId.clear();
+    this.sdkScreenIdentitySessionEpochsByApplicationId.clear();
     this.sdkScreenIdentityRetiredSessionsByApplicationId.clear();
     this.sdkScreenIdentityTrackingGenerationsByApplicationId.clear();
     this.sdkScreenIdentitiesByApplicationId.clear();
@@ -1218,6 +1220,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     }
     if (retireSession) {
       this.sdkScreenIdentityStartedSessionsByApplicationId.delete(applicationId);
+      this.sdkScreenIdentitySessionEpochsByApplicationId.delete(applicationId);
     }
     this.sdkScreenIdentitiesByApplicationId.delete(applicationId);
     this.sdkScreenIdentityOrdersByApplicationId.delete(applicationId);
@@ -1260,34 +1263,49 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     if (this.sdkScreenIdentityRetiredSessionsByApplicationId.get(applicationId)?.has(sessionId)) {
       return false;
     }
-    const startedSessionId = this.sdkScreenIdentityStartedSessionsByApplicationId.get(applicationId);
-    if (startedSessionId && startedSessionId !== sessionId) {
+    const sessionEpoch = this.getSdkScreenIdentitySessionEpoch(payload);
+    const currentEpoch = this.sdkScreenIdentitySessionEpochsByApplicationId.get(applicationId);
+    const currentSessionId = this.sdkScreenIdentitySessionsByApplicationId.get(applicationId);
+    if (sessionEpoch !== undefined && currentEpoch !== undefined
+      && (sessionEpoch < currentEpoch || (sessionEpoch === currentEpoch && currentSessionId && currentSessionId !== sessionId))) {
       return false;
     }
-    const currentSessionId = this.sdkScreenIdentitySessionsByApplicationId.get(applicationId);
+    const startedSessionId = this.sdkScreenIdentityStartedSessionsByApplicationId.get(applicationId);
+    if (startedSessionId && startedSessionId !== sessionId
+      && (sessionEpoch === undefined || currentEpoch === undefined || sessionEpoch <= currentEpoch)) {
+      return false;
+    }
     if (currentSessionId && currentSessionId !== sessionId) {
       this.retireSdkScreenIdentitySession(applicationId, currentSessionId);
       this.sdkScreenIdentitiesByApplicationId.delete(applicationId);
       this.sdkScreenIdentityOrdersByApplicationId.delete(applicationId);
+      this.resetSdkScreenIdentityTrackingState(applicationId, payload);
+      this.sdkScreenIdentityStartedSessionsByApplicationId.set(applicationId, sessionId);
     }
     this.sdkScreenIdentitySessionsByApplicationId.set(applicationId, sessionId);
+    if (sessionEpoch !== undefined) {
+      this.sdkScreenIdentitySessionEpochsByApplicationId.set(applicationId, sessionEpoch);
+    }
     return true;
   }
 
   private startSdkScreenIdentitySession(applicationId: string, payload: Record<string, unknown>): boolean {
     const sessionId = typeof payload.sessionId === "string" ? payload.sessionId : undefined;
-    if (!sessionId || this.sdkScreenIdentityRetiredSessionsByApplicationId.get(applicationId)?.has(sessionId)) {
+    if (!sessionId || !this.activateSdkScreenIdentitySession(applicationId, payload)) {
       return false;
     }
-    const currentSessionId = this.sdkScreenIdentitySessionsByApplicationId.get(applicationId);
-    if (currentSessionId && currentSessionId !== sessionId) {
-      this.retireSdkScreenIdentitySession(applicationId, currentSessionId);
-      this.sdkScreenIdentitiesByApplicationId.delete(applicationId);
-      this.sdkScreenIdentityOrdersByApplicationId.delete(applicationId);
-    }
-    this.sdkScreenIdentitySessionsByApplicationId.set(applicationId, sessionId);
     this.sdkScreenIdentityStartedSessionsByApplicationId.set(applicationId, sessionId);
     return true;
+  }
+
+  private resetSdkScreenIdentityTrackingState(applicationId: string, payload: Record<string, unknown>): void {
+    this.sdkScreenIdentityTrackingDisabledApplicationIds.delete(applicationId);
+    const trackingGeneration = this.getSdkScreenIdentityTrackingGeneration(payload);
+    if (trackingGeneration === undefined) {
+      this.sdkScreenIdentityTrackingGenerationsByApplicationId.delete(applicationId);
+    } else {
+      this.sdkScreenIdentityTrackingGenerationsByApplicationId.set(applicationId, trackingGeneration);
+    }
   }
 
   private retireSdkScreenIdentitySession(applicationId: string, sessionId: string): void {
@@ -1317,6 +1335,12 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   private getSdkScreenIdentityTrackingGeneration(payload: Record<string, unknown>): number | undefined {
     return typeof payload.trackingGeneration === "number" && Number.isSafeInteger(payload.trackingGeneration)
       ? payload.trackingGeneration
+      : undefined;
+  }
+
+  private getSdkScreenIdentitySessionEpoch(payload: Record<string, unknown>): number | undefined {
+    return typeof payload.sessionEpoch === "number" && Number.isSafeInteger(payload.sessionEpoch)
+      ? payload.sessionEpoch
       : undefined;
   }
 

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -414,9 +414,10 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   >();
   private sdkEventPollGeneration = 0;
   private sdkEventPollAbortController: AbortController | null = null;
-  private sdkEventPollInFlight: { generation: number; promise: Promise<void> } | null = null;
+  private sdkEventPollInFlight: { generation: number; promise: Promise<boolean> } | null = null;
   private static readonly SDK_EVENT_POLL_TIMEOUT_MS = 2000;
   private static readonly SDK_IDENTITY_REFRESH_TIMEOUT_MS = 100;
+  private static readonly SDK_IDENTITY_REFRESH_RETRY_MS = 10;
 
   private constructor(
     device: BootedDevice,
@@ -485,22 +486,52 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     return applicationId ? this.sdkScreenIdentitiesByApplicationId.get(applicationId) : undefined;
   }
 
+  /** Remove SDK navigation state after an app process is replaced. */
+  public clearSdkScreenIdentity(applicationId?: string): void {
+    if (applicationId) {
+      this.sdkScreenIdentitiesByApplicationId.delete(applicationId);
+      this.sdkScreenIdentityOrdersByApplicationId.delete(applicationId);
+      return;
+    }
+    this.sdkScreenIdentitiesByApplicationId.clear();
+    this.sdkScreenIdentityOrdersByApplicationId.clear();
+  }
+
   /**
    * Drain the CtrlProxy SDK-event queue before returning the current identity.
    * Observe calls this after reading the hierarchy so a navigation event does
    * not wait for the background poll interval before it reaches the diff gate.
    */
   public async refreshSdkScreenIdentity(applicationId?: string): Promise<ScreenIdentity | undefined> {
-    const poll = this.pollSdkEvents();
+    const deadline = this.timer.now() + IOSCtrlProxyClient.SDK_IDENTITY_REFRESH_TIMEOUT_MS;
+    while (this.timer.now() < deadline) {
+      const drained = await this.pollSdkEventsUntil(deadline);
+      if (drained !== false) {
+        break;
+      }
+      const remaining = deadline - this.timer.now();
+      if (remaining <= 0) {
+        break;
+      }
+      await this.timer.sleep(Math.min(IOSCtrlProxyClient.SDK_IDENTITY_REFRESH_RETRY_MS, remaining));
+    }
+    return this.getSdkScreenIdentity(applicationId);
+  }
+
+  private async pollSdkEventsUntil(deadline: number): Promise<boolean | undefined> {
+    const remaining = deadline - this.timer.now();
+    if (remaining <= 0) {
+      return undefined;
+    }
     let timeoutId: ReturnType<Timer["setTimeout"]> | null = null;
-    const timeout = new Promise<void>(resolve => {
-      timeoutId = this.timer.setTimeout(resolve, IOSCtrlProxyClient.SDK_IDENTITY_REFRESH_TIMEOUT_MS);
+    const timeout = new Promise<undefined>(resolve => {
+      timeoutId = this.timer.setTimeout(() => resolve(undefined), remaining);
     });
-    await Promise.race([poll, timeout]);
+    const drained = await Promise.race([this.pollSdkEvents(), timeout]);
     if (timeoutId) {
       this.timer.clearTimeout(timeoutId);
     }
-    return this.getSdkScreenIdentity(applicationId);
+    return drained;
   }
 
   /**
@@ -955,7 +986,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     }, 2000);
   }
 
-  private async pollSdkEvents(): Promise<void> {
+  private async pollSdkEvents(): Promise<boolean> {
     const generation = this.sdkEventPollGeneration;
     if (this.sdkEventPollInFlight?.generation === generation) {
       return this.sdkEventPollInFlight.promise;
@@ -972,7 +1003,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     return promise;
   }
 
-  private async pollSdkEventsOnce(generation: number): Promise<void> {
+  private async pollSdkEventsOnce(generation: number): Promise<boolean> {
     const host = this.resolveWebSocketHost();
     const url = `http://${host}:${this.port}/sdk-events`;
     const abortController = new AbortController();
@@ -983,16 +1014,17 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     );
     try {
       const resp = await fetch(url, { signal: abortController.signal });
-      if (generation !== this.sdkEventPollGeneration) {return;}
-      if (!resp.ok) {return;}
+      if (generation !== this.sdkEventPollGeneration) {return false;}
+      if (!resp.ok) {return false;}
       const batches = await resp.json() as Array<{
         bundleId?: string;
         events?: Array<{ eventType: string; payload: string }>;
       }>;
-      await this.processSdkEventBatches(batches, generation);
+      return this.processSdkEventBatches(batches, generation);
     } catch (error) {
       // Polling failure is non-fatal (endpoint down, timeout) — trace at debug.
       logger.debug(`[IOSCtrlProxy] SDK event poll failed: ${error}`);
+      return false;
     } finally {
       this.timer.clearTimeout(timeoutId);
       if (this.sdkEventPollAbortController === abortController) {
@@ -1004,61 +1036,72 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   private async processSdkEventBatches(
     batches: Array<{ bundleId?: string; events?: Array<{ eventType: string; payload: string }> }>,
     generation: number,
-  ): Promise<void> {
-    for (const batch of batches) {
+  ): Promise<boolean> {
+    const events = this.decodeSdkEventBatches(batches, generation);
+    for (const event of events) {
       if (generation !== this.sdkEventPollGeneration) {
-        return;
-      }
-      await this.processSdkEventBatch(batch, generation);
-    }
-  }
-
-  private async processSdkEventBatch(
-    batch: { bundleId?: string; events?: Array<{ eventType: string; payload: string }> },
-    generation: number,
-  ): Promise<void> {
-    if (!batch.events) {
-      return;
-    }
-    for (const envelope of batch.events) {
-      if (generation !== this.sdkEventPollGeneration) {
-        return;
-      }
-      await this.processSdkEventEnvelope(envelope, batch.bundleId, generation);
-    }
-  }
-
-  private async processSdkEventEnvelope(
-    envelope: { eventType: string; payload: string },
-    applicationId: string | undefined,
-    generation: number,
-  ): Promise<void> {
-    try {
-      // SDK envelopes have base64-encoded payload.
-      const payloadJson = Buffer.from(envelope.payload, "base64").toString("utf-8");
-      const payload = JSON.parse(payloadJson) as Record<string, unknown>;
-      const timestamp = (payload.timestamp as number) ?? Date.now();
-      const sequenceNumber = typeof payload.sequenceNumber === "number"
-        ? payload.sequenceNumber
-        : undefined;
-      if (generation !== this.sdkEventPollGeneration) {
-        return;
+        return false;
       }
       this.rememberSdkScreenIdentity(
-        envelope.eventType,
-        applicationId,
-        payload,
-        timestamp,
-        sequenceNumber,
+        event.eventType,
+        event.applicationId,
+        event.payload,
+        event.timestamp,
+        event.sequenceNumber,
       );
-      await this.sdkEventIngestor.recordSdkEvent(
-        { type: envelope.eventType, timestamp, payload },
-        applicationId ?? null,
-      );
-    } catch (error) {
-      // Malformed SDK envelope (bad base64/JSON) — skip it, but leave a trace.
-      logger.debug(`[IOSCtrlProxy] skipping malformed SDK event envelope: ${error}`);
     }
+    for (const event of events) {
+      if (generation !== this.sdkEventPollGeneration) {
+        return false;
+      }
+      await this.sdkEventIngestor.recordSdkEvent(
+        { type: event.eventType, timestamp: event.timestamp, payload: event.payload },
+        event.applicationId ?? null,
+      );
+    }
+    return events.length > 0;
+  }
+
+  private decodeSdkEventBatches(
+    batches: Array<{ bundleId?: string; events?: Array<{ eventType: string; payload: string }> }>,
+    generation: number,
+  ): Array<{
+    eventType: string;
+    applicationId: string | undefined;
+    payload: Record<string, unknown>;
+    timestamp: number;
+    sequenceNumber: number | undefined;
+  }> {
+    const decodedEvents: Array<{
+      eventType: string;
+      applicationId: string | undefined;
+      payload: Record<string, unknown>;
+      timestamp: number;
+      sequenceNumber: number | undefined;
+    }> = [];
+    for (const batch of batches) {
+      if (generation !== this.sdkEventPollGeneration) {
+        return [];
+      }
+      for (const envelope of batch.events ?? []) {
+        try {
+          // SDK envelopes have base64-encoded payload.
+          const payloadJson = Buffer.from(envelope.payload, "base64").toString("utf-8");
+          const payload = JSON.parse(payloadJson) as Record<string, unknown>;
+          decodedEvents.push({
+            eventType: envelope.eventType,
+            applicationId: batch.bundleId,
+            payload,
+            timestamp: (payload.timestamp as number) ?? Date.now(),
+            sequenceNumber: typeof payload.sequenceNumber === "number" ? payload.sequenceNumber : undefined,
+          });
+        } catch (error) {
+          // Malformed SDK envelope (bad base64/JSON) — skip it, but leave a trace.
+          logger.debug(`[IOSCtrlProxy] skipping malformed SDK event envelope: ${error}`);
+        }
+      }
+    }
+    return decodedEvents;
   }
 
   private stopSdkEventPolling(): void {

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -327,7 +327,6 @@ type SdkEventPollResult = {
 type SdkScreenIdentityPollGeneration = {
   clearGeneration: number;
   applicationGenerations: Map<string, number>;
-  applicationIdsToDrain: Set<string>;
 };
 
 type DecodedSdkEvent = {
@@ -440,7 +439,10 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     { timestamp: number; sequenceNumber?: number }
   >();
   private readonly sdkScreenIdentityGenerationsByApplicationId = new Map<string, number>();
-  private readonly sdkScreenIdentityPendingQueueDrains = new Set<string>();
+  private readonly sdkScreenIdentitySessionsByApplicationId = new Map<string, string>();
+  private readonly sdkScreenIdentityStartedSessionsByApplicationId = new Map<string, string>();
+  private readonly sdkScreenIdentityRetiredSessionsByApplicationId = new Map<string, Set<string>>();
+  private readonly sdkScreenIdentityTrackingGenerationsByApplicationId = new Map<string, number>();
   private readonly sdkScreenIdentityTrackingDisabledApplicationIds = new Set<string>();
   private sdkScreenIdentityClearGeneration = 0;
   private sdkEventPollGeneration = 0;
@@ -526,8 +528,11 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     }
     this.sdkScreenIdentityClearGeneration++;
     this.sdkScreenIdentityGenerationsByApplicationId.clear();
-    this.sdkScreenIdentityPendingQueueDrains.clear();
     this.sdkScreenIdentityTrackingDisabledApplicationIds.clear();
+    this.sdkScreenIdentitySessionsByApplicationId.clear();
+    this.sdkScreenIdentityStartedSessionsByApplicationId.clear();
+    this.sdkScreenIdentityRetiredSessionsByApplicationId.clear();
+    this.sdkScreenIdentityTrackingGenerationsByApplicationId.clear();
     this.sdkScreenIdentitiesByApplicationId.clear();
     this.sdkScreenIdentityOrdersByApplicationId.clear();
   }
@@ -1044,7 +1049,6 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     const pollGeneration: SdkScreenIdentityPollGeneration = {
       clearGeneration: this.sdkScreenIdentityClearGeneration,
       applicationGenerations: new Map(this.sdkScreenIdentityGenerationsByApplicationId),
-      applicationIdsToDrain: new Set(this.sdkScreenIdentityPendingQueueDrains),
     };
     const host = this.resolveWebSocketHost();
     const url = `http://${host}:${this.port}/sdk-events`;
@@ -1089,8 +1093,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       if (this.applySdkScreenIdentityLifecycleEvent(event)) {
         continue;
       }
-      if (!this.shouldDrainSdkScreenIdentityEvent(event.applicationId, pollGeneration)
-        && this.isSdkScreenIdentityPollCurrent(event.applicationId, pollGeneration)
+      if (this.isSdkScreenIdentityPollCurrent(event.applicationId, pollGeneration)
         && this.rememberSdkScreenIdentity(
           event.eventType,
           event.applicationId,
@@ -1101,7 +1104,6 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
         rememberedApplicationIds.add(event.applicationId!);
       }
     }
-    this.completeSdkScreenIdentityQueueDrains(pollGeneration, generation);
     for (const event of events) {
       if (generation !== this.sdkEventPollGeneration) {
         return this.emptySdkEventPollResult();
@@ -1176,7 +1178,9 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     timestamp: number,
     sequenceNumber: number | undefined,
   ): boolean {
-    if (!applicationId || this.sdkScreenIdentityTrackingDisabledApplicationIds.has(applicationId)) {
+    if (!applicationId
+      || !this.activateSdkScreenIdentitySession(applicationId, payload)
+      || !this.isSdkScreenIdentityTrackingEnabled(applicationId, payload)) {
       return false;
     }
     const identity = deriveIosSdkScreenIdentity(eventType, applicationId, payload);
@@ -1203,12 +1207,18 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     return this.sdkScreenIdentityGenerationsByApplicationId.get(applicationId) ?? 0;
   }
 
-  private invalidateSdkScreenIdentity(applicationId: string): void {
+  private invalidateSdkScreenIdentity(applicationId: string, retireSession: boolean = true): void {
     this.sdkScreenIdentityGenerationsByApplicationId.set(
       applicationId,
       this.getSdkScreenIdentityGeneration(applicationId) + 1,
     );
-    this.sdkScreenIdentityPendingQueueDrains.add(applicationId);
+    const sessionId = this.sdkScreenIdentitySessionsByApplicationId.get(applicationId);
+    if (retireSession && sessionId) {
+      this.retireSdkScreenIdentitySession(applicationId, sessionId);
+    }
+    if (retireSession) {
+      this.sdkScreenIdentityStartedSessionsByApplicationId.delete(applicationId);
+    }
     this.sdkScreenIdentitiesByApplicationId.delete(applicationId);
     this.sdkScreenIdentityOrdersByApplicationId.delete(applicationId);
   }
@@ -1217,9 +1227,22 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     if (!event.applicationId || event.eventType !== "lifecycle") {
       return false;
     }
+    if (event.payload.state === "sdk_session_started") {
+      this.startSdkScreenIdentitySession(event.applicationId, event.payload);
+      return true;
+    }
+    const trackingGeneration = this.getSdkScreenIdentityTrackingGeneration(event.payload);
+    const currentGeneration = this.sdkScreenIdentityTrackingGenerationsByApplicationId.get(event.applicationId);
+    if (trackingGeneration === undefined || currentGeneration === undefined || trackingGeneration >= currentGeneration) {
+      if (trackingGeneration !== undefined) {
+        this.sdkScreenIdentityTrackingGenerationsByApplicationId.set(event.applicationId, trackingGeneration);
+      }
+    } else {
+      return true;
+    }
     if (event.payload.state === "sdk_tracking_disabled") {
       this.sdkScreenIdentityTrackingDisabledApplicationIds.add(event.applicationId);
-      this.invalidateSdkScreenIdentity(event.applicationId);
+      this.invalidateSdkScreenIdentity(event.applicationId, false);
       return true;
     }
     if (event.payload.state === "sdk_tracking_enabled") {
@@ -1229,26 +1252,72 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     return false;
   }
 
-  private shouldDrainSdkScreenIdentityEvent(
-    applicationId: string | undefined,
-    pollGeneration: SdkScreenIdentityPollGeneration,
-  ): boolean {
-    return applicationId !== undefined && pollGeneration.applicationIdsToDrain.has(applicationId);
+  private activateSdkScreenIdentitySession(applicationId: string, payload: Record<string, unknown>): boolean {
+    const sessionId = typeof payload.sessionId === "string" ? payload.sessionId : undefined;
+    if (!sessionId) {
+      return true;
+    }
+    if (this.sdkScreenIdentityRetiredSessionsByApplicationId.get(applicationId)?.has(sessionId)) {
+      return false;
+    }
+    const startedSessionId = this.sdkScreenIdentityStartedSessionsByApplicationId.get(applicationId);
+    if (startedSessionId && startedSessionId !== sessionId) {
+      return false;
+    }
+    const currentSessionId = this.sdkScreenIdentitySessionsByApplicationId.get(applicationId);
+    if (currentSessionId && currentSessionId !== sessionId) {
+      this.retireSdkScreenIdentitySession(applicationId, currentSessionId);
+      this.sdkScreenIdentitiesByApplicationId.delete(applicationId);
+      this.sdkScreenIdentityOrdersByApplicationId.delete(applicationId);
+    }
+    this.sdkScreenIdentitySessionsByApplicationId.set(applicationId, sessionId);
+    return true;
   }
 
-  private completeSdkScreenIdentityQueueDrains(
-    pollGeneration: SdkScreenIdentityPollGeneration,
-    generation: number,
-  ): void {
-    if (generation !== this.sdkEventPollGeneration) {
-      return;
+  private startSdkScreenIdentitySession(applicationId: string, payload: Record<string, unknown>): boolean {
+    const sessionId = typeof payload.sessionId === "string" ? payload.sessionId : undefined;
+    if (!sessionId || this.sdkScreenIdentityRetiredSessionsByApplicationId.get(applicationId)?.has(sessionId)) {
+      return false;
     }
-    for (const applicationId of pollGeneration.applicationIdsToDrain) {
-      if ((pollGeneration.applicationGenerations.get(applicationId) ?? 0)
-        === this.getSdkScreenIdentityGeneration(applicationId)) {
-        this.sdkScreenIdentityPendingQueueDrains.delete(applicationId);
+    const currentSessionId = this.sdkScreenIdentitySessionsByApplicationId.get(applicationId);
+    if (currentSessionId && currentSessionId !== sessionId) {
+      this.retireSdkScreenIdentitySession(applicationId, currentSessionId);
+      this.sdkScreenIdentitiesByApplicationId.delete(applicationId);
+      this.sdkScreenIdentityOrdersByApplicationId.delete(applicationId);
+    }
+    this.sdkScreenIdentitySessionsByApplicationId.set(applicationId, sessionId);
+    this.sdkScreenIdentityStartedSessionsByApplicationId.set(applicationId, sessionId);
+    return true;
+  }
+
+  private retireSdkScreenIdentitySession(applicationId: string, sessionId: string): void {
+    let retiredSessions = this.sdkScreenIdentityRetiredSessionsByApplicationId.get(applicationId);
+    if (!retiredSessions) {
+      retiredSessions = new Set<string>();
+      this.sdkScreenIdentityRetiredSessionsByApplicationId.set(applicationId, retiredSessions);
+    }
+    retiredSessions.add(sessionId);
+  }
+
+  private isSdkScreenIdentityTrackingEnabled(applicationId: string, payload: Record<string, unknown>): boolean {
+    const trackingGeneration = this.getSdkScreenIdentityTrackingGeneration(payload);
+    const currentGeneration = this.sdkScreenIdentityTrackingGenerationsByApplicationId.get(applicationId);
+    if (this.sdkScreenIdentityTrackingDisabledApplicationIds.has(applicationId)) {
+      if (trackingGeneration === undefined || currentGeneration === undefined || trackingGeneration <= currentGeneration) {
+        return false;
       }
+      this.sdkScreenIdentityTrackingDisabledApplicationIds.delete(applicationId);
     }
+    if (trackingGeneration !== undefined && (currentGeneration === undefined || trackingGeneration > currentGeneration)) {
+      this.sdkScreenIdentityTrackingGenerationsByApplicationId.set(applicationId, trackingGeneration);
+    }
+    return true;
+  }
+
+  private getSdkScreenIdentityTrackingGeneration(payload: Record<string, unknown>): number | undefined {
+    return typeof payload.trackingGeneration === "number" && Number.isSafeInteger(payload.trackingGeneration)
+      ? payload.trackingGeneration
+      : undefined;
   }
 
   private isSdkScreenIdentityPollCurrent(

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -1043,7 +1043,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       if (this.sdkEventPollInFlight === inFlight) {
         this.sdkEventPollInFlight = null;
       }
-    });
+    }).catch(error => logger.debug(`[IOSCtrlProxy] SDK event poll cleanup failed: ${error}`));
     return promise;
   }
 
@@ -1068,7 +1068,8 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
         bundleId?: string;
         events?: Array<{ eventType: string; payload: string }>;
       }>;
-      return this.processSdkEventBatches(batches, generation, pollGeneration);
+      const pollResult = await this.processSdkEventBatches(batches, generation, pollGeneration);
+      return pollResult;
     } catch (error) {
       // Polling failure is non-fatal (endpoint down, timeout) — trace at debug.
       logger.debug(`[IOSCtrlProxy] SDK event poll failed: ${error}`);
@@ -1092,7 +1093,14 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       if (generation !== this.sdkEventPollGeneration) {
         return this.emptySdkEventPollResult();
       }
+      const lifecycleEventHasCurrentPoll = this.isSdkScreenIdentityPollCurrent(event.applicationId, pollGeneration);
       if (this.applySdkScreenIdentityLifecycleEvent(event)) {
+        if (lifecycleEventHasCurrentPoll && event.applicationId) {
+          pollGeneration.applicationGenerations.set(
+            event.applicationId,
+            this.getSdkScreenIdentityGeneration(event.applicationId),
+          );
+        }
         continue;
       }
       if (this.isSdkScreenIdentityPollCurrent(event.applicationId, pollGeneration)

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -1234,6 +1234,9 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       this.startSdkScreenIdentitySession(event.applicationId, event.payload);
       return true;
     }
+    if (!this.activateSdkScreenIdentitySession(event.applicationId, event.payload)) {
+      return true;
+    }
     const trackingGeneration = this.getSdkScreenIdentityTrackingGeneration(event.payload);
     const currentGeneration = this.sdkScreenIdentityTrackingGenerationsByApplicationId.get(event.applicationId);
     if (trackingGeneration === undefined || currentGeneration === undefined || trackingGeneration >= currentGeneration) {

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -408,7 +408,10 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   // SDK-event ingestion (telemetry/failure fan-out + layout telemetry)
   private readonly sdkEventIngestor: IosSdkEventIngestor;
   private readonly sdkScreenIdentitiesByApplicationId = new Map<string, ScreenIdentity>();
-  private readonly sdkScreenIdentityTimestampsByApplicationId = new Map<string, number>();
+  private readonly sdkScreenIdentityOrdersByApplicationId = new Map<
+    string,
+    { timestamp: number; sequenceNumber?: number }
+  >();
   private sdkEventPollGeneration = 0;
   private sdkEventPollAbortController: AbortController | null = null;
   private sdkEventPollInFlight: { generation: number; promise: Promise<void> } | null = null;
@@ -924,7 +927,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     this.sdkEventPollAbortController = null;
     this.cachedHierarchy = null;
     this.sdkScreenIdentitiesByApplicationId.clear();
-    this.sdkScreenIdentityTimestampsByApplicationId.clear();
+    this.sdkScreenIdentityOrdersByApplicationId.clear();
     this.supportedCommands = null;
     this.deviceConnectionLostNotifier.onDeviceConnectionLost(this.device.deviceId);
 
@@ -1035,10 +1038,19 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       const payloadJson = Buffer.from(envelope.payload, "base64").toString("utf-8");
       const payload = JSON.parse(payloadJson) as Record<string, unknown>;
       const timestamp = (payload.timestamp as number) ?? Date.now();
+      const sequenceNumber = typeof payload.sequenceNumber === "number"
+        ? payload.sequenceNumber
+        : undefined;
       if (generation !== this.sdkEventPollGeneration) {
         return;
       }
-      this.rememberSdkScreenIdentity(envelope.eventType, applicationId, payload, timestamp);
+      this.rememberSdkScreenIdentity(
+        envelope.eventType,
+        applicationId,
+        payload,
+        timestamp,
+        sequenceNumber,
+      );
       await this.sdkEventIngestor.recordSdkEvent(
         { type: envelope.eventType, timestamp, payload },
         applicationId ?? null,
@@ -1061,15 +1073,22 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     applicationId: string | undefined,
     payload: Record<string, unknown>,
     timestamp: number,
+    sequenceNumber: number | undefined,
   ): void {
     if (!applicationId) {
       return;
     }
     const identity = deriveIosSdkScreenIdentity(eventType, applicationId, payload);
-    const currentTimestamp = this.sdkScreenIdentityTimestampsByApplicationId.get(applicationId);
-    if (identity && (currentTimestamp === undefined || timestamp >= currentTimestamp)) {
+    const currentOrder = this.sdkScreenIdentityOrdersByApplicationId.get(applicationId);
+    const isNewer = currentOrder === undefined
+      || timestamp > currentOrder.timestamp
+      || (timestamp === currentOrder.timestamp
+        && sequenceNumber !== undefined
+        && currentOrder.sequenceNumber !== undefined
+        && sequenceNumber > currentOrder.sequenceNumber);
+    if (identity && isNewer) {
       this.sdkScreenIdentitiesByApplicationId.set(applicationId, identity);
-      this.sdkScreenIdentityTimestampsByApplicationId.set(applicationId, timestamp);
+      this.sdkScreenIdentityOrdersByApplicationId.set(applicationId, { timestamp, sequenceNumber });
     }
   }
 

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -408,6 +408,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   // SDK-event ingestion (telemetry/failure fan-out + layout telemetry)
   private readonly sdkEventIngestor: IosSdkEventIngestor;
   private readonly sdkScreenIdentitiesByApplicationId = new Map<string, ScreenIdentity>();
+  private sdkEventPollInFlight: Promise<void> | null = null;
 
   private constructor(
     device: BootedDevice,
@@ -474,6 +475,16 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   /** Return the latest app-provided navigation identity without doing I/O. */
   public getSdkScreenIdentity(applicationId?: string): ScreenIdentity | undefined {
     return applicationId ? this.sdkScreenIdentitiesByApplicationId.get(applicationId) : undefined;
+  }
+
+  /**
+   * Drain the CtrlProxy SDK-event queue before returning the current identity.
+   * Observe calls this after reading the hierarchy so a navigation event does
+   * not wait for the background poll interval before it reaches the diff gate.
+   */
+  public async refreshSdkScreenIdentity(applicationId?: string): Promise<ScreenIdentity | undefined> {
+    await this.pollSdkEvents();
+    return this.getSdkScreenIdentity(applicationId);
   }
 
   /**
@@ -918,40 +929,58 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
 
   private startSdkEventPolling(): void {
     this.stopSdkEventPolling();
+    void this.pollSdkEvents();
+    this.sdkEventPollInterval = this.timer.setInterval(() => {
+      void this.pollSdkEvents();
+    }, 2000);
+  }
+
+  private async pollSdkEvents(): Promise<void> {
+    if (this.sdkEventPollInFlight) {
+      return this.sdkEventPollInFlight;
+    }
+
+    this.sdkEventPollInFlight = this.pollSdkEventsOnce();
+    try {
+      await this.sdkEventPollInFlight;
+    } finally {
+      this.sdkEventPollInFlight = null;
+    }
+  }
+
+  private async pollSdkEventsOnce(): Promise<void> {
     const host = this.resolveWebSocketHost();
     const url = `http://${host}:${this.port}/sdk-events`;
-    this.sdkEventPollInterval = this.timer.setInterval(async () => {
-      try {
-        const resp = await fetch(url, { signal: AbortSignal.timeout(2000) });
-        if (!resp.ok) {return;}
-        const batches = await resp.json() as Array<{
-          bundleId?: string;
-          events?: Array<{ eventType: string; payload: string }>;
-        }>;
-        for (const batch of batches) {
-          if (!batch.events) {continue;}
-          for (const envelope of batch.events) {
-            try {
-              // SDK envelopes have base64-encoded payload
-              const payloadJson = Buffer.from(envelope.payload, "base64").toString("utf-8");
-              const payload = JSON.parse(payloadJson) as Record<string, unknown>;
-              const timestamp = (payload.timestamp as number) ?? Date.now();
-              this.rememberSdkScreenIdentity(envelope.eventType, batch.bundleId, payload);
-              await this.sdkEventIngestor.recordSdkEvent(
-                { type: envelope.eventType, timestamp, payload },
-                batch.bundleId ?? null,
-              );
-            } catch (error) {
-              // Malformed SDK envelope (bad base64/JSON) — skip it, but leave a trace.
-              logger.debug(`[IOSCtrlProxy] skipping malformed SDK event envelope: ${error}`);
-            }
+    try {
+      const resp = await fetch(url, { signal: AbortSignal.timeout(2000) });
+      if (!resp.ok) {return;}
+      const batches = await resp.json() as Array<{
+        bundleId?: string;
+        events?: Array<{ eventType: string; payload: string }>;
+      }>;
+      for (const batch of batches) {
+        if (!batch.events) {continue;}
+        for (const envelope of batch.events) {
+          try {
+            // SDK envelopes have base64-encoded payload
+            const payloadJson = Buffer.from(envelope.payload, "base64").toString("utf-8");
+            const payload = JSON.parse(payloadJson) as Record<string, unknown>;
+            const timestamp = (payload.timestamp as number) ?? Date.now();
+            this.rememberSdkScreenIdentity(envelope.eventType, batch.bundleId, payload);
+            await this.sdkEventIngestor.recordSdkEvent(
+              { type: envelope.eventType, timestamp, payload },
+              batch.bundleId ?? null,
+            );
+          } catch (error) {
+            // Malformed SDK envelope (bad base64/JSON) — skip it, but leave a trace.
+            logger.debug(`[IOSCtrlProxy] skipping malformed SDK event envelope: ${error}`);
           }
         }
-      } catch (error) {
-        // Polling failure is non-fatal (endpoint down, timeout) — trace at debug.
-        logger.debug(`[IOSCtrlProxy] SDK event poll failed: ${error}`);
       }
-    }, 2000);
+    } catch (error) {
+      // Polling failure is non-fatal (endpoint down, timeout) — trace at debug.
+      logger.debug(`[IOSCtrlProxy] SDK event poll failed: ${error}`);
+    }
   }
 
   private stopSdkEventPolling(): void {

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -319,6 +319,32 @@ export interface IosNetworkErrorSimulationConfig {
   expiresAtEpochMs?: number | null;
 }
 
+type SdkEventPollResult = {
+  receivedEvents: boolean;
+  rememberedApplicationIds: Set<string>;
+};
+
+type SdkScreenIdentityPollGeneration = {
+  clearGeneration: number;
+  applicationGenerations: Map<string, number>;
+};
+
+type DecodedSdkEvent = {
+  eventType: string;
+  applicationId: string | undefined;
+  payload: Record<string, unknown>;
+  timestamp: number;
+  sequenceNumber: number | undefined;
+};
+
+function numberOrDefault(value: number | null | undefined): number {
+  return value ?? 0;
+}
+
+function nullWhenAbsent<T>(value: T | null | undefined): T | null {
+  return value ?? null;
+}
+
 /**
  * Command rawValues a *fresh* iOS CtrlProxy runner advertises in its `connected`
  * handshake that the released v0.0.38 runner predates. The runner exposes no
@@ -412,9 +438,11 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     string,
     { timestamp: number; sequenceNumber?: number }
   >();
+  private readonly sdkScreenIdentityGenerationsByApplicationId = new Map<string, number>();
+  private sdkScreenIdentityClearGeneration = 0;
   private sdkEventPollGeneration = 0;
   private sdkEventPollAbortController: AbortController | null = null;
-  private sdkEventPollInFlight: { generation: number; promise: Promise<boolean> } | null = null;
+  private sdkEventPollInFlight: { generation: number; promise: Promise<SdkEventPollResult> } | null = null;
   private static readonly SDK_EVENT_POLL_TIMEOUT_MS = 2000;
   private static readonly SDK_IDENTITY_REFRESH_TIMEOUT_MS = 100;
   private static readonly SDK_IDENTITY_REFRESH_RETRY_MS = 10;
@@ -489,10 +517,16 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   /** Remove SDK navigation state after an app process is replaced. */
   public clearSdkScreenIdentity(applicationId?: string): void {
     if (applicationId) {
+      this.sdkScreenIdentityGenerationsByApplicationId.set(
+        applicationId,
+        this.getSdkScreenIdentityGeneration(applicationId) + 1,
+      );
       this.sdkScreenIdentitiesByApplicationId.delete(applicationId);
       this.sdkScreenIdentityOrdersByApplicationId.delete(applicationId);
       return;
     }
+    this.sdkScreenIdentityClearGeneration++;
+    this.sdkScreenIdentityGenerationsByApplicationId.clear();
     this.sdkScreenIdentitiesByApplicationId.clear();
     this.sdkScreenIdentityOrdersByApplicationId.clear();
   }
@@ -505,8 +539,11 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   public async refreshSdkScreenIdentity(applicationId?: string): Promise<ScreenIdentity | undefined> {
     const deadline = this.timer.now() + IOSCtrlProxyClient.SDK_IDENTITY_REFRESH_TIMEOUT_MS;
     while (this.timer.now() < deadline) {
-      const drained = await this.pollSdkEventsUntil(deadline);
-      if (drained !== false) {
+      const result = await this.pollSdkEventsUntil(deadline);
+      const refreshed = applicationId
+        ? result?.rememberedApplicationIds.has(applicationId)
+        : result?.receivedEvents;
+      if (refreshed) {
         break;
       }
       const remaining = deadline - this.timer.now();
@@ -518,7 +555,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     return this.getSdkScreenIdentity(applicationId);
   }
 
-  private async pollSdkEventsUntil(deadline: number): Promise<boolean | undefined> {
+  private async pollSdkEventsUntil(deadline: number): Promise<SdkEventPollResult | undefined> {
     const remaining = deadline - this.timer.now();
     if (remaining <= 0) {
       return undefined;
@@ -957,8 +994,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     this.sdkEventPollAbortController?.abort();
     this.sdkEventPollAbortController = null;
     this.cachedHierarchy = null;
-    this.sdkScreenIdentitiesByApplicationId.clear();
-    this.sdkScreenIdentityOrdersByApplicationId.clear();
+    this.clearSdkScreenIdentity();
     this.supportedCommands = null;
     this.deviceConnectionLostNotifier.onDeviceConnectionLost(this.device.deviceId);
 
@@ -986,7 +1022,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     }, 2000);
   }
 
-  private async pollSdkEvents(): Promise<boolean> {
+  private async pollSdkEvents(): Promise<SdkEventPollResult> {
     const generation = this.sdkEventPollGeneration;
     if (this.sdkEventPollInFlight?.generation === generation) {
       return this.sdkEventPollInFlight.promise;
@@ -1003,7 +1039,11 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     return promise;
   }
 
-  private async pollSdkEventsOnce(generation: number): Promise<boolean> {
+  private async pollSdkEventsOnce(generation: number): Promise<SdkEventPollResult> {
+    const pollGeneration: SdkScreenIdentityPollGeneration = {
+      clearGeneration: this.sdkScreenIdentityClearGeneration,
+      applicationGenerations: new Map(this.sdkScreenIdentityGenerationsByApplicationId),
+    };
     const host = this.resolveWebSocketHost();
     const url = `http://${host}:${this.port}/sdk-events`;
     const abortController = new AbortController();
@@ -1014,17 +1054,17 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     );
     try {
       const resp = await fetch(url, { signal: abortController.signal });
-      if (generation !== this.sdkEventPollGeneration) {return false;}
-      if (!resp.ok) {return false;}
+      if (generation !== this.sdkEventPollGeneration) {return this.emptySdkEventPollResult();}
+      if (!resp.ok) {return this.emptySdkEventPollResult();}
       const batches = await resp.json() as Array<{
         bundleId?: string;
         events?: Array<{ eventType: string; payload: string }>;
       }>;
-      return this.processSdkEventBatches(batches, generation);
+      return this.processSdkEventBatches(batches, generation, pollGeneration);
     } catch (error) {
       // Polling failure is non-fatal (endpoint down, timeout) — trace at debug.
       logger.debug(`[IOSCtrlProxy] SDK event poll failed: ${error}`);
-      return false;
+      return this.emptySdkEventPollResult();
     } finally {
       this.timer.clearTimeout(timeoutId);
       if (this.sdkEventPollAbortController === abortController) {
@@ -1036,72 +1076,83 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   private async processSdkEventBatches(
     batches: Array<{ bundleId?: string; events?: Array<{ eventType: string; payload: string }> }>,
     generation: number,
-  ): Promise<boolean> {
+    pollGeneration: SdkScreenIdentityPollGeneration,
+  ): Promise<SdkEventPollResult> {
     const events = this.decodeSdkEventBatches(batches, generation);
+    const rememberedApplicationIds = new Set<string>();
     for (const event of events) {
       if (generation !== this.sdkEventPollGeneration) {
-        return false;
+        return this.emptySdkEventPollResult();
       }
-      this.rememberSdkScreenIdentity(
-        event.eventType,
-        event.applicationId,
-        event.payload,
-        event.timestamp,
-        event.sequenceNumber,
-      );
+      if (this.isSdkScreenIdentityPollCurrent(event.applicationId, pollGeneration)
+        && this.rememberSdkScreenIdentity(
+          event.eventType,
+          event.applicationId,
+          event.payload,
+          event.timestamp,
+          event.sequenceNumber,
+        )) {
+        rememberedApplicationIds.add(event.applicationId!);
+      }
     }
     for (const event of events) {
       if (generation !== this.sdkEventPollGeneration) {
-        return false;
+        return this.emptySdkEventPollResult();
       }
       await this.sdkEventIngestor.recordSdkEvent(
         { type: event.eventType, timestamp: event.timestamp, payload: event.payload },
         event.applicationId ?? null,
       );
     }
-    return events.length > 0;
+    return { receivedEvents: events.length > 0, rememberedApplicationIds };
   }
 
   private decodeSdkEventBatches(
     batches: Array<{ bundleId?: string; events?: Array<{ eventType: string; payload: string }> }>,
     generation: number,
-  ): Array<{
-    eventType: string;
-    applicationId: string | undefined;
-    payload: Record<string, unknown>;
-    timestamp: number;
-    sequenceNumber: number | undefined;
-  }> {
-    const decodedEvents: Array<{
-      eventType: string;
-      applicationId: string | undefined;
-      payload: Record<string, unknown>;
-      timestamp: number;
-      sequenceNumber: number | undefined;
-    }> = [];
+  ): DecodedSdkEvent[] {
+    const decodedEvents: DecodedSdkEvent[] = [];
     for (const batch of batches) {
       if (generation !== this.sdkEventPollGeneration) {
         return [];
       }
       for (const envelope of batch.events ?? []) {
-        try {
-          // SDK envelopes have base64-encoded payload.
-          const payloadJson = Buffer.from(envelope.payload, "base64").toString("utf-8");
-          const payload = JSON.parse(payloadJson) as Record<string, unknown>;
-          decodedEvents.push({
-            eventType: envelope.eventType,
-            applicationId: batch.bundleId,
-            payload,
-            timestamp: (payload.timestamp as number) ?? Date.now(),
-            sequenceNumber: typeof payload.sequenceNumber === "number" ? payload.sequenceNumber : undefined,
-          });
-        } catch (error) {
-          // Malformed SDK envelope (bad base64/JSON) — skip it, but leave a trace.
-          logger.debug(`[IOSCtrlProxy] skipping malformed SDK event envelope: ${error}`);
+        const event = this.decodeSdkEventEnvelope(batch.bundleId, envelope);
+        if (event) {
+          decodedEvents.push(event);
         }
       }
     }
     return decodedEvents;
+  }
+
+  private decodeSdkEventEnvelope(
+    applicationId: string | undefined,
+    envelope: { eventType: string; payload: string },
+  ): DecodedSdkEvent | undefined {
+    try {
+      const payloadJson = Buffer.from(envelope.payload, "base64").toString("utf-8");
+      const decodedPayload = JSON.parse(payloadJson);
+      if (!decodedPayload || typeof decodedPayload !== "object" || Array.isArray(decodedPayload)) {
+        throw new Error("SDK event payload must be an object");
+      }
+      const payload = decodedPayload as Record<string, unknown>;
+      return {
+        eventType: envelope.eventType,
+        applicationId,
+        payload,
+        timestamp: typeof payload.timestamp === "number" && Number.isFinite(payload.timestamp)
+          ? payload.timestamp
+          : Date.now(),
+        sequenceNumber: typeof payload.sequenceNumber === "number" && Number.isSafeInteger(payload.sequenceNumber)
+          ? payload.sequenceNumber
+          : undefined,
+      };
+    } catch (error) {
+      // Malformed SDK envelope (bad base64/JSON) — skip it, but leave a trace.
+      logger.debug(`[IOSCtrlProxy] skipping malformed SDK event envelope: ${error}`);
+      return undefined;
+    }
   }
 
   private stopSdkEventPolling(): void {
@@ -1117,9 +1168,9 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     payload: Record<string, unknown>,
     timestamp: number,
     sequenceNumber: number | undefined,
-  ): void {
+  ): boolean {
     if (!applicationId) {
-      return;
+      return false;
     }
     const identity = deriveIosSdkScreenIdentity(eventType, applicationId, payload);
     const currentOrder = this.sdkScreenIdentityOrdersByApplicationId.get(applicationId);
@@ -1132,7 +1183,27 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     if (identity && isNewer) {
       this.sdkScreenIdentitiesByApplicationId.set(applicationId, identity);
       this.sdkScreenIdentityOrdersByApplicationId.set(applicationId, { timestamp, sequenceNumber });
+      return true;
     }
+    return false;
+  }
+
+  private emptySdkEventPollResult(): SdkEventPollResult {
+    return { receivedEvents: false, rememberedApplicationIds: new Set() };
+  }
+
+  private getSdkScreenIdentityGeneration(applicationId: string): number {
+    return this.sdkScreenIdentityGenerationsByApplicationId.get(applicationId) ?? 0;
+  }
+
+  private isSdkScreenIdentityPollCurrent(
+    applicationId: string | undefined,
+    pollGeneration: SdkScreenIdentityPollGeneration,
+  ): applicationId is string {
+    return applicationId !== undefined
+      && pollGeneration.clearGeneration === this.sdkScreenIdentityClearGeneration
+      && (pollGeneration.applicationGenerations.get(applicationId) ?? 0)
+        === this.getSdkScreenIdentityGeneration(applicationId);
   }
 
   /**
@@ -1327,17 +1398,18 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     }
 
     // Convert iOS performance snapshot to PerformanceStreamData format
+    const fps = numberOrDefault(snapshot.fps);
     const streamData: PerformanceStreamData = {
-      fps: snapshot.fps ?? 0,
-      frameTimeMs: snapshot.frameTimeMs ?? 0,
-      jankFrames: snapshot.jankFrames ?? 0,
+      fps,
+      frameTimeMs: numberOrDefault(snapshot.frameTimeMs),
+      jankFrames: numberOrDefault(snapshot.jankFrames),
       droppedFrames: 0, // iOS doesn't report this separately
-      memoryUsageMb: snapshot.memoryUsageMb ?? 0,
-      cpuUsagePercent: snapshot.cpuUsagePercent ?? 0,
-      touchLatencyMs: snapshot.touchLatencyMs ?? null,
-      timeToInteractiveMs: snapshot.ttiMs ?? null,
-      screenName: snapshot.screenName ?? null,
-      isResponsive: (snapshot.fps ?? 0) >= 50, // Consider responsive if FPS >= 50
+      memoryUsageMb: numberOrDefault(snapshot.memoryUsageMb),
+      cpuUsagePercent: numberOrDefault(snapshot.cpuUsagePercent),
+      touchLatencyMs: nullWhenAbsent(snapshot.touchLatencyMs),
+      timeToInteractiveMs: nullWhenAbsent(snapshot.ttiMs),
+      screenName: nullWhenAbsent(snapshot.screenName),
+      isResponsive: fps >= 50, // Consider responsive if FPS >= 50
       recompositionCount: null,
       recompositionRate: null,
     };
@@ -1884,16 +1956,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
         return { success: false, error: result.error || "No screenshot data" };
       }
 
-      // Cache screen dimensions from hierarchy if available.
-      // screenWidth/screenHeight are in iOS points — multiply by screenScale to get pixels,
-      // matching the screenshot image resolution and the TakeScreenshot path (which reads PNG header pixels).
-      if (this.cachedHierarchy?.hierarchy?.screenWidth && this.cachedHierarchy?.hierarchy?.screenHeight) {
-        const scale = this.cachedHierarchy.hierarchy.screenScale ?? 1;
-        this.cachedScreenDimensions = {
-          width: Math.round(this.cachedHierarchy.hierarchy.screenWidth * scale),
-          height: Math.round(this.cachedHierarchy.hierarchy.screenHeight * scale),
-        };
-      }
+      this.cacheScreenDimensionsFromHierarchy();
 
       return {
         success: true,
@@ -1903,6 +1966,20 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     } catch (error) {
       return { success: false, error: `${error}` };
     }
+  }
+
+  private cacheScreenDimensionsFromHierarchy(): void {
+    const hierarchy = this.cachedHierarchy?.hierarchy;
+    if (!hierarchy?.screenWidth || !hierarchy.screenHeight) {
+      return;
+    }
+    // screenWidth/screenHeight are in iOS points — multiply by screenScale to get pixels,
+    // matching the screenshot image resolution and the TakeScreenshot path (which reads PNG header pixels).
+    const scale = hierarchy.screenScale ?? 1;
+    this.cachedScreenDimensions = {
+      width: Math.round(hierarchy.screenWidth * scale),
+      height: Math.round(hierarchy.screenHeight * scale),
+    };
   }
 
   /**

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -327,6 +327,7 @@ type SdkEventPollResult = {
 type SdkScreenIdentityPollGeneration = {
   clearGeneration: number;
   applicationGenerations: Map<string, number>;
+  applicationIdsToDrain: Set<string>;
 };
 
 type DecodedSdkEvent = {
@@ -439,6 +440,8 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     { timestamp: number; sequenceNumber?: number }
   >();
   private readonly sdkScreenIdentityGenerationsByApplicationId = new Map<string, number>();
+  private readonly sdkScreenIdentityPendingQueueDrains = new Set<string>();
+  private readonly sdkScreenIdentityTrackingDisabledApplicationIds = new Set<string>();
   private sdkScreenIdentityClearGeneration = 0;
   private sdkEventPollGeneration = 0;
   private sdkEventPollAbortController: AbortController | null = null;
@@ -517,16 +520,14 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   /** Remove SDK navigation state after an app process is replaced. */
   public clearSdkScreenIdentity(applicationId?: string): void {
     if (applicationId) {
-      this.sdkScreenIdentityGenerationsByApplicationId.set(
-        applicationId,
-        this.getSdkScreenIdentityGeneration(applicationId) + 1,
-      );
-      this.sdkScreenIdentitiesByApplicationId.delete(applicationId);
-      this.sdkScreenIdentityOrdersByApplicationId.delete(applicationId);
+      this.sdkScreenIdentityTrackingDisabledApplicationIds.delete(applicationId);
+      this.invalidateSdkScreenIdentity(applicationId);
       return;
     }
     this.sdkScreenIdentityClearGeneration++;
     this.sdkScreenIdentityGenerationsByApplicationId.clear();
+    this.sdkScreenIdentityPendingQueueDrains.clear();
+    this.sdkScreenIdentityTrackingDisabledApplicationIds.clear();
     this.sdkScreenIdentitiesByApplicationId.clear();
     this.sdkScreenIdentityOrdersByApplicationId.clear();
   }
@@ -1043,6 +1044,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     const pollGeneration: SdkScreenIdentityPollGeneration = {
       clearGeneration: this.sdkScreenIdentityClearGeneration,
       applicationGenerations: new Map(this.sdkScreenIdentityGenerationsByApplicationId),
+      applicationIdsToDrain: new Set(this.sdkScreenIdentityPendingQueueDrains),
     };
     const host = this.resolveWebSocketHost();
     const url = `http://${host}:${this.port}/sdk-events`;
@@ -1084,7 +1086,11 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       if (generation !== this.sdkEventPollGeneration) {
         return this.emptySdkEventPollResult();
       }
-      if (this.isSdkScreenIdentityPollCurrent(event.applicationId, pollGeneration)
+      if (this.applySdkScreenIdentityLifecycleEvent(event)) {
+        continue;
+      }
+      if (!this.shouldDrainSdkScreenIdentityEvent(event.applicationId, pollGeneration)
+        && this.isSdkScreenIdentityPollCurrent(event.applicationId, pollGeneration)
         && this.rememberSdkScreenIdentity(
           event.eventType,
           event.applicationId,
@@ -1095,6 +1101,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
         rememberedApplicationIds.add(event.applicationId!);
       }
     }
+    this.completeSdkScreenIdentityQueueDrains(pollGeneration, generation);
     for (const event of events) {
       if (generation !== this.sdkEventPollGeneration) {
         return this.emptySdkEventPollResult();
@@ -1169,7 +1176,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     timestamp: number,
     sequenceNumber: number | undefined,
   ): boolean {
-    if (!applicationId) {
+    if (!applicationId || this.sdkScreenIdentityTrackingDisabledApplicationIds.has(applicationId)) {
       return false;
     }
     const identity = deriveIosSdkScreenIdentity(eventType, applicationId, payload);
@@ -1194,6 +1201,54 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
 
   private getSdkScreenIdentityGeneration(applicationId: string): number {
     return this.sdkScreenIdentityGenerationsByApplicationId.get(applicationId) ?? 0;
+  }
+
+  private invalidateSdkScreenIdentity(applicationId: string): void {
+    this.sdkScreenIdentityGenerationsByApplicationId.set(
+      applicationId,
+      this.getSdkScreenIdentityGeneration(applicationId) + 1,
+    );
+    this.sdkScreenIdentityPendingQueueDrains.add(applicationId);
+    this.sdkScreenIdentitiesByApplicationId.delete(applicationId);
+    this.sdkScreenIdentityOrdersByApplicationId.delete(applicationId);
+  }
+
+  private applySdkScreenIdentityLifecycleEvent(event: DecodedSdkEvent): boolean {
+    if (!event.applicationId || event.eventType !== "lifecycle") {
+      return false;
+    }
+    if (event.payload.state === "sdk_tracking_disabled") {
+      this.sdkScreenIdentityTrackingDisabledApplicationIds.add(event.applicationId);
+      this.invalidateSdkScreenIdentity(event.applicationId);
+      return true;
+    }
+    if (event.payload.state === "sdk_tracking_enabled") {
+      this.sdkScreenIdentityTrackingDisabledApplicationIds.delete(event.applicationId);
+      return true;
+    }
+    return false;
+  }
+
+  private shouldDrainSdkScreenIdentityEvent(
+    applicationId: string | undefined,
+    pollGeneration: SdkScreenIdentityPollGeneration,
+  ): boolean {
+    return applicationId !== undefined && pollGeneration.applicationIdsToDrain.has(applicationId);
+  }
+
+  private completeSdkScreenIdentityQueueDrains(
+    pollGeneration: SdkScreenIdentityPollGeneration,
+    generation: number,
+  ): void {
+    if (generation !== this.sdkEventPollGeneration) {
+      return;
+    }
+    for (const applicationId of pollGeneration.applicationIdsToDrain) {
+      if ((pollGeneration.applicationGenerations.get(applicationId) ?? 0)
+        === this.getSdkScreenIdentityGeneration(applicationId)) {
+        this.sdkScreenIdentityPendingQueueDrains.delete(applicationId);
+      }
+    }
   }
 
   private isSdkScreenIdentityPollCurrent(

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -18,6 +18,7 @@ import { logger } from "../../../utils/logger";
 import {
   BootedDevice,
   HighlightShape,
+  ScreenIdentity,
   ImeAction,
   ViewHierarchyResult,
 } from "../../../models";
@@ -119,6 +120,7 @@ import { CtrlProxyDatabase } from "./CtrlProxyDatabase";
 import { CtrlProxyPermissions } from "./CtrlProxyPermissions";
 import { decodeCtrlProxyMessage } from "./decodeCtrlProxyMessage";
 import { DefaultIosSdkEventIngestor, type IosSdkEventIngestor } from "./IosSdkEventIngestor";
+import { deriveIosSdkScreenIdentity } from "./IosSdkScreenIdentity";
 
 // Import types
 import type {
@@ -405,6 +407,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
 
   // SDK-event ingestion (telemetry/failure fan-out + layout telemetry)
   private readonly sdkEventIngestor: IosSdkEventIngestor;
+  private readonly sdkScreenIdentitiesByApplicationId = new Map<string, ScreenIdentity>();
 
   private constructor(
     device: BootedDevice,
@@ -466,6 +469,11 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
    */
   public static getExistingInstance(deviceId: string): IOSCtrlProxyClient | null {
     return IOSCtrlProxyClient.instances.get(deviceId) ?? null;
+  }
+
+  /** Return the latest app-provided navigation identity without doing I/O. */
+  public getSdkScreenIdentity(applicationId?: string): ScreenIdentity | undefined {
+    return applicationId ? this.sdkScreenIdentitiesByApplicationId.get(applicationId) : undefined;
   }
 
   /**
@@ -888,6 +896,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     this.cancelScreenshotBackoff();
     this.stopSdkEventPolling();
     this.cachedHierarchy = null;
+    this.sdkScreenIdentitiesByApplicationId.clear();
     this.supportedCommands = null;
     this.deviceConnectionLostNotifier.onDeviceConnectionLost(this.device.deviceId);
 
@@ -927,6 +936,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
               const payloadJson = Buffer.from(envelope.payload, "base64").toString("utf-8");
               const payload = JSON.parse(payloadJson) as Record<string, unknown>;
               const timestamp = (payload.timestamp as number) ?? Date.now();
+              this.rememberSdkScreenIdentity(envelope.eventType, batch.bundleId, payload);
               await this.sdkEventIngestor.recordSdkEvent(
                 { type: envelope.eventType, timestamp, payload },
                 batch.bundleId ?? null,
@@ -948,6 +958,20 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     if (this.sdkEventPollInterval) {
       this.timer.clearInterval(this.sdkEventPollInterval);
       this.sdkEventPollInterval = null;
+    }
+  }
+
+  private rememberSdkScreenIdentity(
+    eventType: string,
+    applicationId: string | undefined,
+    payload: Record<string, unknown>,
+  ): void {
+    if (!applicationId) {
+      return;
+    }
+    const identity = deriveIosSdkScreenIdentity(eventType, applicationId, payload);
+    if (identity) {
+      this.sdkScreenIdentitiesByApplicationId.set(applicationId, identity);
     }
   }
 

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -408,7 +408,12 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   // SDK-event ingestion (telemetry/failure fan-out + layout telemetry)
   private readonly sdkEventIngestor: IosSdkEventIngestor;
   private readonly sdkScreenIdentitiesByApplicationId = new Map<string, ScreenIdentity>();
-  private sdkEventPollInFlight: Promise<void> | null = null;
+  private readonly sdkScreenIdentityTimestampsByApplicationId = new Map<string, number>();
+  private sdkEventPollGeneration = 0;
+  private sdkEventPollAbortController: AbortController | null = null;
+  private sdkEventPollInFlight: { generation: number; promise: Promise<void> } | null = null;
+  private static readonly SDK_EVENT_POLL_TIMEOUT_MS = 2000;
+  private static readonly SDK_IDENTITY_REFRESH_TIMEOUT_MS = 100;
 
   private constructor(
     device: BootedDevice,
@@ -483,7 +488,15 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
    * not wait for the background poll interval before it reaches the diff gate.
    */
   public async refreshSdkScreenIdentity(applicationId?: string): Promise<ScreenIdentity | undefined> {
-    await this.pollSdkEvents();
+    const poll = this.pollSdkEvents();
+    let timeoutId: ReturnType<Timer["setTimeout"]> | null = null;
+    const timeout = new Promise<void>(resolve => {
+      timeoutId = this.timer.setTimeout(resolve, IOSCtrlProxyClient.SDK_IDENTITY_REFRESH_TIMEOUT_MS);
+    });
+    await Promise.race([poll, timeout]);
+    if (timeoutId) {
+      this.timer.clearTimeout(timeoutId);
+    }
     return this.getSdkScreenIdentity(applicationId);
   }
 
@@ -906,8 +919,12 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   protected onConnectionClosed(): void {
     this.cancelScreenshotBackoff();
     this.stopSdkEventPolling();
+    this.sdkEventPollGeneration++;
+    this.sdkEventPollAbortController?.abort();
+    this.sdkEventPollAbortController = null;
     this.cachedHierarchy = null;
     this.sdkScreenIdentitiesByApplicationId.clear();
+    this.sdkScreenIdentityTimestampsByApplicationId.clear();
     this.supportedCommands = null;
     this.deviceConnectionLostNotifier.onDeviceConnectionLost(this.device.deviceId);
 
@@ -936,50 +953,99 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   }
 
   private async pollSdkEvents(): Promise<void> {
-    if (this.sdkEventPollInFlight) {
-      return this.sdkEventPollInFlight;
+    const generation = this.sdkEventPollGeneration;
+    if (this.sdkEventPollInFlight?.generation === generation) {
+      return this.sdkEventPollInFlight.promise;
     }
 
-    this.sdkEventPollInFlight = this.pollSdkEventsOnce();
-    try {
-      await this.sdkEventPollInFlight;
-    } finally {
-      this.sdkEventPollInFlight = null;
-    }
+    const promise = this.pollSdkEventsOnce(generation);
+    const inFlight = { generation, promise };
+    this.sdkEventPollInFlight = inFlight;
+    void promise.finally(() => {
+      if (this.sdkEventPollInFlight === inFlight) {
+        this.sdkEventPollInFlight = null;
+      }
+    });
+    return promise;
   }
 
-  private async pollSdkEventsOnce(): Promise<void> {
+  private async pollSdkEventsOnce(generation: number): Promise<void> {
     const host = this.resolveWebSocketHost();
     const url = `http://${host}:${this.port}/sdk-events`;
+    const abortController = new AbortController();
+    this.sdkEventPollAbortController = abortController;
+    const timeoutId = this.timer.setTimeout(
+      () => abortController.abort(),
+      IOSCtrlProxyClient.SDK_EVENT_POLL_TIMEOUT_MS,
+    );
     try {
-      const resp = await fetch(url, { signal: AbortSignal.timeout(2000) });
+      const resp = await fetch(url, { signal: abortController.signal });
+      if (generation !== this.sdkEventPollGeneration) {return;}
       if (!resp.ok) {return;}
       const batches = await resp.json() as Array<{
         bundleId?: string;
         events?: Array<{ eventType: string; payload: string }>;
       }>;
-      for (const batch of batches) {
-        if (!batch.events) {continue;}
-        for (const envelope of batch.events) {
-          try {
-            // SDK envelopes have base64-encoded payload
-            const payloadJson = Buffer.from(envelope.payload, "base64").toString("utf-8");
-            const payload = JSON.parse(payloadJson) as Record<string, unknown>;
-            const timestamp = (payload.timestamp as number) ?? Date.now();
-            this.rememberSdkScreenIdentity(envelope.eventType, batch.bundleId, payload);
-            await this.sdkEventIngestor.recordSdkEvent(
-              { type: envelope.eventType, timestamp, payload },
-              batch.bundleId ?? null,
-            );
-          } catch (error) {
-            // Malformed SDK envelope (bad base64/JSON) — skip it, but leave a trace.
-            logger.debug(`[IOSCtrlProxy] skipping malformed SDK event envelope: ${error}`);
-          }
-        }
-      }
+      await this.processSdkEventBatches(batches, generation);
     } catch (error) {
       // Polling failure is non-fatal (endpoint down, timeout) — trace at debug.
       logger.debug(`[IOSCtrlProxy] SDK event poll failed: ${error}`);
+    } finally {
+      this.timer.clearTimeout(timeoutId);
+      if (this.sdkEventPollAbortController === abortController) {
+        this.sdkEventPollAbortController = null;
+      }
+    }
+  }
+
+  private async processSdkEventBatches(
+    batches: Array<{ bundleId?: string; events?: Array<{ eventType: string; payload: string }> }>,
+    generation: number,
+  ): Promise<void> {
+    for (const batch of batches) {
+      if (generation !== this.sdkEventPollGeneration) {
+        return;
+      }
+      await this.processSdkEventBatch(batch, generation);
+    }
+  }
+
+  private async processSdkEventBatch(
+    batch: { bundleId?: string; events?: Array<{ eventType: string; payload: string }> },
+    generation: number,
+  ): Promise<void> {
+    if (!batch.events) {
+      return;
+    }
+    for (const envelope of batch.events) {
+      if (generation !== this.sdkEventPollGeneration) {
+        return;
+      }
+      await this.processSdkEventEnvelope(envelope, batch.bundleId, generation);
+    }
+  }
+
+  private async processSdkEventEnvelope(
+    envelope: { eventType: string; payload: string },
+    applicationId: string | undefined,
+    generation: number,
+  ): Promise<void> {
+    try {
+      // SDK envelopes have base64-encoded payload.
+      const payloadJson = Buffer.from(envelope.payload, "base64").toString("utf-8");
+      const payload = JSON.parse(payloadJson) as Record<string, unknown>;
+      const timestamp = (payload.timestamp as number) ?? Date.now();
+      if (generation !== this.sdkEventPollGeneration) {
+        return;
+      }
+      this.rememberSdkScreenIdentity(envelope.eventType, applicationId, payload, timestamp);
+      await this.sdkEventIngestor.recordSdkEvent(
+        { type: envelope.eventType, timestamp, payload },
+        applicationId ?? null,
+      );
+    } catch (error) {
+      // Malformed SDK envelope (bad base64/JSON) — skip it, but leave a trace.
+      logger.debug(`[IOSCtrlProxy] skipping malformed SDK event envelope: ${error}`);
     }
   }
 
@@ -994,13 +1060,16 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     eventType: string,
     applicationId: string | undefined,
     payload: Record<string, unknown>,
+    timestamp: number,
   ): void {
     if (!applicationId) {
       return;
     }
     const identity = deriveIosSdkScreenIdentity(eventType, applicationId, payload);
-    if (identity) {
+    const currentTimestamp = this.sdkScreenIdentityTimestampsByApplicationId.get(applicationId);
+    if (identity && (currentTimestamp === undefined || timestamp >= currentTimestamp)) {
       this.sdkScreenIdentitiesByApplicationId.set(applicationId, identity);
+      this.sdkScreenIdentityTimestampsByApplicationId.set(applicationId, timestamp);
     }
   }
 

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -1143,7 +1143,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
         payload,
         timestamp: typeof payload.timestamp === "number" && Number.isFinite(payload.timestamp)
           ? payload.timestamp
-          : Date.now(),
+          : this.timer.now(),
         sequenceNumber: typeof payload.sequenceNumber === "number" && Number.isSafeInteger(payload.sequenceNumber)
           ? payload.sequenceNumber
           : undefined,
@@ -1177,9 +1177,9 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     const isNewer = currentOrder === undefined
       || timestamp > currentOrder.timestamp
       || (timestamp === currentOrder.timestamp
-        && sequenceNumber !== undefined
-        && currentOrder.sequenceNumber !== undefined
-        && sequenceNumber > currentOrder.sequenceNumber);
+        && (sequenceNumber === undefined
+          || currentOrder.sequenceNumber === undefined
+          || sequenceNumber > currentOrder.sequenceNumber));
     if (identity && isNewer) {
       this.sdkScreenIdentitiesByApplicationId.set(applicationId, identity);
       this.sdkScreenIdentityOrdersByApplicationId.set(applicationId, { timestamp, sequenceNumber });

--- a/src/features/observe/ios/IosSdkScreenIdentity.ts
+++ b/src/features/observe/ios/IosSdkScreenIdentity.ts
@@ -32,13 +32,25 @@ function presentation(metadata: StringMap): string | undefined {
   return firstNonEmpty(metadata.presentation, metadata.modal, metadata.sheet);
 }
 
-function makeKey(bundleId: string, route: string, tab?: string, presentationRoute?: string): string {
+function makeKey(
+  bundleId: string,
+  route: string,
+  arguments_: StringMap,
+  tab?: string,
+  presentationRoute?: string,
+): string {
   const parts: string[][] = [["bundle", bundleId], ["route", route]];
   if (tab) {
     parts.push(["tab", tab]);
   }
   if (presentationRoute) {
     parts.push(["presentation", presentationRoute]);
+  }
+  for (const [name, value] of Object.entries(arguments_)
+    .map(([name, value]) => [stringValue(name), stringValue(value)] as const)
+    .filter((entry): entry is readonly [string, string] => entry[0] !== undefined && entry[1] !== undefined && entry[0] !== "tab")
+    .sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0)) {
+    parts.push(["argument", name, value]);
   }
   return JSON.stringify(parts);
 }
@@ -60,13 +72,14 @@ export function deriveIosSdkScreenIdentity(
     return undefined;
   }
 
-  const tab = selectedTab(stringMap(payload.arguments), stringMap(payload.metadata), route);
+  const arguments_ = stringMap(payload.arguments);
+  const tab = selectedTab(arguments_, stringMap(payload.metadata), route);
   const presentationRoute = presentation(stringMap(payload.metadata));
   return {
     platform: "ios",
     source: "sdk",
     confidence: "high",
-    key: makeKey(applicationId, route, tab, presentationRoute),
+    key: makeKey(applicationId, route, arguments_, tab, presentationRoute),
     components: {
       bundleId: applicationId,
       navigationRoute: route,

--- a/src/features/observe/ios/IosSdkScreenIdentity.ts
+++ b/src/features/observe/ios/IosSdkScreenIdentity.ts
@@ -1,0 +1,77 @@
+import type { ScreenIdentity } from "../../../models";
+
+type StringMap = Record<string, string>;
+
+function stringValue(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed === "" ? undefined : trimmed;
+}
+
+function stringMap(value: unknown): StringMap {
+  return value && typeof value === "object" ? value as StringMap : {};
+}
+
+function firstNonEmpty(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    const string = stringValue(value);
+    if (string) {
+      return string;
+    }
+  }
+  return undefined;
+}
+
+function selectedTab(arguments_: StringMap, metadata: StringMap, route: string): string | undefined {
+  return firstNonEmpty(arguments_.tab, metadata.tab, metadata.type === "tab_switch" ? route : undefined);
+}
+
+function presentation(metadata: StringMap): string | undefined {
+  return firstNonEmpty(metadata.presentation, metadata.modal, metadata.sheet);
+}
+
+function makeKey(bundleId: string, route: string, tab?: string, presentationRoute?: string): string {
+  const parts: string[][] = [["bundle", bundleId], ["route", route]];
+  if (tab) {
+    parts.push(["tab", tab]);
+  }
+  if (presentationRoute) {
+    parts.push(["presentation", presentationRoute]);
+  }
+  return JSON.stringify(parts);
+}
+
+/**
+ * Build a high-confidence screen identity from an iOS SDK navigation event.
+ * The caller owns event ordering and stores the newest result per bundle.
+ */
+export function deriveIosSdkScreenIdentity(
+  eventType: string,
+  applicationId: string | null | undefined,
+  payload: Record<string, unknown>,
+): ScreenIdentity | undefined {
+  if (eventType !== "navigation") {
+    return undefined;
+  }
+  const route = stringValue(payload.destination);
+  if (!applicationId || !route) {
+    return undefined;
+  }
+
+  const tab = selectedTab(stringMap(payload.arguments), stringMap(payload.metadata), route);
+  const presentationRoute = presentation(stringMap(payload.metadata));
+  return {
+    platform: "ios",
+    source: "sdk",
+    confidence: "high",
+    key: makeKey(applicationId, route, tab, presentationRoute),
+    components: {
+      bundleId: applicationId,
+      navigationRoute: route,
+      ...(tab ? { selectedTab: tab } : {}),
+      ...(presentationRoute ? { presentation: presentationRoute } : {}),
+    },
+  };
+}

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -95,8 +95,12 @@ export interface ScreenIdentity {
   key: string;
   components: {
     bundleId?: string;
+    /** SDK-reported destination / route, when the app integrates AutoMobileSDK. */
+    navigationRoute?: string;
     navigationTitle?: string;
     selectedTab?: string;
+    /** SDK-reported modal or sheet presentation route, when available. */
+    presentation?: string;
     modalClass?: string;
     modalTitle?: string;
     focusedElementId?: string;

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -111,8 +111,10 @@ const screenIdentitySchema = z.object({
   key: z.string(),
   components: z.object({
     bundleId: z.string().optional(),
+    navigationRoute: z.string().optional(),
     navigationTitle: z.string().optional(),
     selectedTab: z.string().optional(),
+    presentation: z.string().optional(),
     modalClass: z.string().optional(),
     modalTitle: z.string().optional(),
     focusedElementId: z.string().optional(),

--- a/test/fakes/FakeViewHierarchy.ts
+++ b/test/fakes/FakeViewHierarchy.ts
@@ -39,8 +39,16 @@ export class FakeViewHierarchy implements ViewHierarchy {
     // No-op for testing
   }
 
-  getScreenIdentity(_applicationId?: string): ScreenIdentity | undefined {
-    return this.configuredScreenIdentity;
+  getScreenIdentity(applicationId?: string): ScreenIdentity | undefined {
+    const identity = this.configuredScreenIdentity;
+    if (
+      applicationId
+      && identity?.components.bundleId
+      && identity.components.bundleId !== applicationId
+    ) {
+      return undefined;
+    }
+    return identity;
   }
 
   /**

--- a/test/fakes/FakeViewHierarchy.ts
+++ b/test/fakes/FakeViewHierarchy.ts
@@ -1,5 +1,5 @@
 import type { ViewHierarchy } from "../../src/features/observe/interfaces/ViewHierarchy";
-import type { Element, ViewHierarchyResult } from "../../src/models";
+import type { Element, ScreenIdentity, ViewHierarchyResult } from "../../src/models";
 
 /**
  * Fake implementation of ViewHierarchy for testing.
@@ -10,6 +10,7 @@ export class FakeViewHierarchy implements ViewHierarchy {
   private configuredHierarchy: ViewHierarchyResult = { hierarchy: {} };
   private configuredFocusedElement: Element | null = null;
   private configuredAccessibilityFocusedElement: Element | null = null;
+  private configuredScreenIdentity: ScreenIdentity | undefined;
   private shouldFail = false;
   private failureError: Error | null = null;
 
@@ -36,6 +37,10 @@ export class FakeViewHierarchy implements ViewHierarchy {
    */
   async configureRecompositionTracking(_enabled: boolean, _perf?: any): Promise<void> {
     // No-op for testing
+  }
+
+  getScreenIdentity(_applicationId?: string): ScreenIdentity | undefined {
+    return this.configuredScreenIdentity;
   }
 
   /**
@@ -94,6 +99,11 @@ export class FakeViewHierarchy implements ViewHierarchy {
     this.configuredAccessibilityFocusedElement = element;
   }
 
+  /** Configure the optional SDK-backed iOS screen identity. */
+  configureScreenIdentity(identity: ScreenIdentity | undefined): void {
+    this.configuredScreenIdentity = identity;
+  }
+
   /**
    * Configure to throw an error on getViewHierarchy().
    */
@@ -132,6 +142,7 @@ export class FakeViewHierarchy implements ViewHierarchy {
     this.configuredHierarchy = { hierarchy: {} };
     this.configuredFocusedElement = null;
     this.configuredAccessibilityFocusedElement = null;
+    this.configuredScreenIdentity = undefined;
     this.shouldFail = false;
     this.failureError = null;
   }

--- a/test/features/action/LaunchApp.test.ts
+++ b/test/features/action/LaunchApp.test.ts
@@ -421,7 +421,7 @@ describe("LaunchApp", () => {
       }
     });
 
-    test("clears a simulator SDK identity before a warm launch", async () => {
+    test("preserves a simulator SDK identity when a warm launch only foregrounds", async () => {
       fakeTimer.enableAutoAdvance();
       const { iosLaunchApp, cleanup } = createIOSTestHarness({ bundleId: userBundleId, launchSuccess: true });
       const clearedBundleIds: string[] = [];
@@ -433,7 +433,7 @@ describe("LaunchApp", () => {
         const result = await iosLaunchApp.execute(userBundleId, false, false);
 
         expect(result.success).toBe(true);
-        expect(clearedBundleIds).toEqual([userBundleId]);
+        expect(clearedBundleIds).toEqual([]);
       } finally {
         existingClientSpy.mockRestore();
         cleanup();

--- a/test/features/action/LaunchApp.test.ts
+++ b/test/features/action/LaunchApp.test.ts
@@ -421,6 +421,25 @@ describe("LaunchApp", () => {
       }
     });
 
+    test("clears a simulator SDK identity before a warm launch", async () => {
+      fakeTimer.enableAutoAdvance();
+      const { iosLaunchApp, cleanup } = createIOSTestHarness({ bundleId: userBundleId, launchSuccess: true });
+      const clearedBundleIds: string[] = [];
+      const existingClientSpy = spyOn(IOSCtrlProxyClient, "getExistingInstance").mockReturnValue({
+        clearSdkScreenIdentity: (bundleId: string) => clearedBundleIds.push(bundleId),
+      } as unknown as IOSCtrlProxyClient);
+
+      try {
+        const result = await iosLaunchApp.execute(userBundleId, false, false);
+
+        expect(result.success).toBe(true);
+        expect(clearedBundleIds).toEqual([userBundleId]);
+      } finally {
+        existingClientSpy.mockRestore();
+        cleanup();
+      }
+    });
+
     test("re-observes until the iOS launch observation hierarchy reports the launched bundle", async () => {
       fakeTimer.enableAutoAdvance();
       const iosDevice: BootedDevice = { name: "test-ios", platform: "ios", deviceId: "44444444-4444-4444-4444-444444444444" };

--- a/test/features/observe/ObserveScreen.test.ts
+++ b/test/features/observe/ObserveScreen.test.ts
@@ -275,7 +275,7 @@ describe("ObserveScreen", function() {
           },
         },
       } as any);
-      viewHierarchy.getScreenIdentity = async () => {
+      viewHierarchy.getScreenIdentity = () => {
         throw new Error("SDK refresh unavailable");
       };
 

--- a/test/features/observe/ObserveScreen.test.ts
+++ b/test/features/observe/ObserveScreen.test.ts
@@ -261,6 +261,92 @@ describe("ObserveScreen", function() {
         resetObserveCacheStore();
       }
     });
+
+    test("falls back to a hierarchy identity when SDK identity refresh rejects", async function() {
+      const viewHierarchy = new FakeViewHierarchy();
+      viewHierarchy.configureHierarchy({
+        packageName: "com.apple.reminders",
+        screenWidth: 402,
+        screenHeight: 874,
+        hierarchy: {
+          node: {
+            $: { class: "XCUIApplication" },
+            node: [{ $: { class: "UINavigationBar", text: "New Reminder" } }],
+          },
+        },
+      } as any);
+      viewHierarchy.getScreenIdentity = async () => {
+        throw new Error("SDK refresh unavailable");
+      };
+
+      try {
+        const screen = new RealObserveScreen(
+          { deviceId: "ios-test-device", name: "iPhone", platform: "ios" },
+          new FakeAdbClientFactory(fakeAdb),
+          {
+            viewHierarchy,
+            cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+            performanceAuditor: { run: async () => undefined } as any,
+            accessibilityAuditor: { run: async () => undefined } as any,
+            accessibilityStateDetector: { run: async () => undefined } as any,
+          }
+        );
+
+        const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+        expect(result.screenIdentity).toMatchObject({
+          source: "heuristic",
+          components: { bundleId: "com.apple.reminders", navigationTitle: "New Reminder" },
+        });
+      } finally {
+        resetObserveCacheStore();
+      }
+    });
+
+    test("does not return an SDK identity for a different observed bundle", async function() {
+      const viewHierarchy = new FakeViewHierarchy();
+      viewHierarchy.configureHierarchy({
+        packageName: "com.apple.reminders",
+        screenWidth: 402,
+        screenHeight: 874,
+        hierarchy: {
+          node: {
+            $: { class: "XCUIApplication" },
+            node: [{ $: { class: "UINavigationBar", text: "New Reminder" } }],
+          },
+        },
+      } as any);
+      viewHierarchy.configureScreenIdentity({
+        platform: "ios",
+        source: "sdk",
+        confidence: "high",
+        key: '[["bundle","com.example.other"]]',
+        components: { bundleId: "com.example.other" },
+      });
+
+      try {
+        const screen = new RealObserveScreen(
+          { deviceId: "ios-test-device", name: "iPhone", platform: "ios" },
+          new FakeAdbClientFactory(fakeAdb),
+          {
+            viewHierarchy,
+            cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+            performanceAuditor: { run: async () => undefined } as any,
+            accessibilityAuditor: { run: async () => undefined } as any,
+            accessibilityStateDetector: { run: async () => undefined } as any,
+          }
+        );
+
+        const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+        expect(result.screenIdentity).toMatchObject({
+          source: "heuristic",
+          components: { bundleId: "com.apple.reminders", navigationTitle: "New Reminder" },
+        });
+      } finally {
+        resetObserveCacheStore();
+      }
+    });
   });
 
   describe("Unit Tests for Focused Element Functionality", function() {

--- a/test/features/observe/ObserveScreen.test.ts
+++ b/test/features/observe/ObserveScreen.test.ts
@@ -215,6 +215,52 @@ describe("ObserveScreen", function() {
         resetObserveCacheStore();
       }
     });
+
+    test("prefers an SDK-backed iOS screen identity for the observed bundle", async function() {
+      const viewHierarchy = new FakeViewHierarchy();
+      viewHierarchy.configureHierarchy({
+        packageName: "dev.jasonpearson.automobile.Playground",
+        updatedAt: 123,
+        screenScale: 3,
+        screenWidth: 402,
+        screenHeight: 874,
+        hierarchy: { node: { $: { class: "XCUIApplication" } } },
+      } as any);
+      viewHierarchy.configureScreenIdentity({
+        platform: "ios",
+        source: "sdk",
+        confidence: "high",
+        key: '[["bundle","dev.jasonpearson.automobile.Playground"],["route","SettingsTab"]]',
+        components: {
+          bundleId: "dev.jasonpearson.automobile.Playground",
+          navigationRoute: "SettingsTab",
+        },
+      });
+
+      try {
+        const screen = new RealObserveScreen(
+          { deviceId: "ios-test-device", name: "iPhone", platform: "ios" },
+          new FakeAdbClientFactory(fakeAdb),
+          {
+            viewHierarchy,
+            cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+            performanceAuditor: { run: async () => undefined } as any,
+            accessibilityAuditor: { run: async () => undefined } as any,
+            accessibilityStateDetector: { run: async () => undefined } as any,
+          }
+        );
+
+        const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+        expect(result.screenIdentity).toMatchObject({
+          source: "sdk",
+          confidence: "high",
+          components: { navigationRoute: "SettingsTab" },
+        });
+      } finally {
+        resetObserveCacheStore();
+      }
+    });
   });
 
   describe("Unit Tests for Focused Element Functionality", function() {

--- a/test/features/observe/ObserveScreen.test.ts
+++ b/test/features/observe/ObserveScreen.test.ts
@@ -262,6 +262,55 @@ describe("ObserveScreen", function() {
       }
     });
 
+    test("prefers a live iOS modal boundary over a cached SDK route", async function() {
+      const viewHierarchy = new FakeViewHierarchy();
+      viewHierarchy.configureHierarchy({
+        packageName: "dev.jasonpearson.automobile.Playground",
+        screenScale: 3,
+        screenWidth: 402,
+        screenHeight: 874,
+        hierarchy: {
+          node: {
+            $: { class: "XCUIApplication" },
+            node: [{
+              $: { class: "XCUIElementTypeAlert" },
+              node: [{ $: { class: "XCUIElementTypeStaticText", text: "Allow Notifications?" } }],
+            }],
+          },
+        },
+      } as any);
+      viewHierarchy.configureScreenIdentity({
+        platform: "ios",
+        source: "sdk",
+        confidence: "high",
+        key: '["route","SettingsTab"]',
+        components: { navigationRoute: "SettingsTab" },
+      });
+
+      try {
+        const screen = new RealObserveScreen(
+          { deviceId: "ios-test-device", name: "iPhone", platform: "ios" },
+          new FakeAdbClientFactory(fakeAdb),
+          {
+            viewHierarchy,
+            cacheStore: new FakeObserveCacheStore(new FakeTimer()),
+            performanceAuditor: { run: async () => undefined } as any,
+            accessibilityAuditor: { run: async () => undefined } as any,
+            accessibilityStateDetector: { run: async () => undefined } as any,
+          }
+        );
+
+        const result = await screen.execute({ skipScreenshot: true, skipBackStack: true });
+
+        expect(result.screenIdentity).toMatchObject({
+          source: "heuristic",
+          components: { modalClass: "XCUIElementTypeAlert", modalTitle: "Allow Notifications?" },
+        });
+      } finally {
+        resetObserveCacheStore();
+      }
+    });
+
     test("falls back to a hierarchy identity when SDK identity refresh rejects", async function() {
       const viewHierarchy = new FakeViewHierarchy();
       viewHierarchy.configureHierarchy({

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -2400,22 +2400,26 @@ describe("IOSCtrlProxyClient", function() {
       }
     });
 
-    test("drains queued navigation from a replaced application process", async function() {
+    test("rejects late navigation from a process replaced by a session announcement", async function() {
       const { factory } = createCapturingWebSocketFactory(fakeTimer);
       const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
-      const encode = (destination: string, timestamp: number): string => Buffer.from(JSON.stringify({ destination, timestamp })).toString("base64");
-      const oldEvent = { bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encode("OldProcess", 1) }] };
-      const newEvent = { bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encode("NewProcess", 2) }] };
+      const encode = (destination: string, timestamp: number, sessionId: string): string => Buffer.from(JSON.stringify({ destination, timestamp, sessionId })).toString("base64");
+      const oldEvent = { bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encode("OldProcess", 1, "old-session") }] };
+      const newSessionEvent = { bundleId: "com.example.ios", events: [{ eventType: "lifecycle", payload: Buffer.from(JSON.stringify({ state: "sdk_session_started", timestamp: 2, sessionId: "new-session" })).toString("base64") }] };
+      const newEvent = { bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encode("NewProcess", 2, "new-session") }] };
       let polls = 0;
       const originalFetch = globalThis.fetch;
       globalThis.fetch = (async () => {
         polls += 1;
-        return { ok: true, json: async () => polls === 1 ? [oldEvent] : polls === 2 ? [oldEvent] : [newEvent] };
+        return { ok: true, json: async () => polls === 1 ? [oldEvent] : polls === 2 ? [newSessionEvent] : polls === 3 ? [oldEvent] : [newEvent] };
       }) as unknown as typeof fetch;
 
       try {
         await (testClient as unknown as { pollSdkEvents(): Promise<void> }).pollSdkEvents();
-        testClient.clearSdkScreenIdentity("com.example.ios");
+        expect(testClient.getSdkScreenIdentity("com.example.ios")?.components.navigationRoute).toBe("OldProcess");
+
+        await (testClient as unknown as { pollSdkEvents(): Promise<void> }).pollSdkEvents();
+        expect(testClient.getSdkScreenIdentity("com.example.ios")).toBeUndefined();
 
         await (testClient as unknown as { pollSdkEvents(): Promise<void> }).pollSdkEvents();
         expect(testClient.getSdkScreenIdentity("com.example.ios")).toBeUndefined();
@@ -2428,14 +2432,14 @@ describe("IOSCtrlProxyClient", function() {
       }
     });
 
-    test("clears and fences SDK identity when tracking is disabled", async function() {
+    test("orders tracking re-enable before an earlier-arriving navigation event", async function() {
       const { factory } = createCapturingWebSocketFactory(fakeTimer);
       const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
       const encode = (payload: Record<string, unknown>): string => Buffer.from(JSON.stringify(payload)).toString("base64");
       const batches = [
-        [{ bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encode({ destination: "Settings", timestamp: 1 }) }] }],
-        [{ bundleId: "com.example.ios", events: [{ eventType: "lifecycle", payload: encode({ state: "sdk_tracking_disabled", timestamp: 2 }) }] }],
-        [{ bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encode({ destination: "Discover", timestamp: 3 }) }] }],
+        [{ bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encode({ destination: "Settings", timestamp: 1, sessionId: "session", trackingGeneration: 0 }) }] }],
+        [{ bundleId: "com.example.ios", events: [{ eventType: "lifecycle", payload: encode({ state: "sdk_tracking_disabled", timestamp: 2, sessionId: "session", trackingGeneration: 1 }) }] }],
+        [{ bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encode({ destination: "Discover", timestamp: 3, sessionId: "session", trackingGeneration: 2 }) }] }],
       ];
       let polls = 0;
       const originalFetch = globalThis.fetch;
@@ -2449,7 +2453,7 @@ describe("IOSCtrlProxyClient", function() {
         expect(testClient.getSdkScreenIdentity("com.example.ios")).toBeUndefined();
 
         await (testClient as unknown as { pollSdkEvents(): Promise<void> }).pollSdkEvents();
-        expect(testClient.getSdkScreenIdentity("com.example.ios")).toBeUndefined();
+        expect(testClient.getSdkScreenIdentity("com.example.ios")?.components.navigationRoute).toBe("Discover");
       } finally {
         globalThis.fetch = originalFetch;
         await testClient.close();

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -2403,10 +2403,10 @@ describe("IOSCtrlProxyClient", function() {
     test("rejects late navigation from a process replaced by a session announcement", async function() {
       const { factory } = createCapturingWebSocketFactory(fakeTimer);
       const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
-      const encode = (destination: string, timestamp: number, sessionId: string): string => Buffer.from(JSON.stringify({ destination, timestamp, sessionId })).toString("base64");
-      const oldEvent = { bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encode("OldProcess", 1, "old-session") }] };
-      const newSessionEvent = { bundleId: "com.example.ios", events: [{ eventType: "lifecycle", payload: Buffer.from(JSON.stringify({ state: "sdk_session_started", timestamp: 2, sessionId: "new-session" })).toString("base64") }] };
-      const newEvent = { bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encode("NewProcess", 2, "new-session") }] };
+      const encode = (destination: string, timestamp: number, sessionId: string, sessionEpoch: number): string => Buffer.from(JSON.stringify({ destination, timestamp, sessionId, sessionEpoch })).toString("base64");
+      const oldEvent = { bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encode("OldProcess", 1, "old-session", 1) }] };
+      const newSessionEvent = { bundleId: "com.example.ios", events: [{ eventType: "lifecycle", payload: Buffer.from(JSON.stringify({ state: "sdk_session_started", timestamp: 2, sessionId: "new-session", sessionEpoch: 2, trackingGeneration: 0 })).toString("base64") }] };
+      const newEvent = { bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encode("NewProcess", 3, "new-session", 2) }] };
       let polls = 0;
       const originalFetch = globalThis.fetch;
       globalThis.fetch = (async () => {
@@ -2426,6 +2426,61 @@ describe("IOSCtrlProxyClient", function() {
 
         await (testClient as unknown as { pollSdkEvents(): Promise<void> }).pollSdkEvents();
         expect(testClient.getSdkScreenIdentity("com.example.ios")?.components.navigationRoute).toBe("NewProcess");
+      } finally {
+        globalThis.fetch = originalFetch;
+        await testClient.close();
+      }
+    });
+
+    test("resets tracking fences when a newer SDK session starts", async function() {
+      const { factory } = createCapturingWebSocketFactory(fakeTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+      const encode = (payload: Record<string, unknown>): string => Buffer.from(JSON.stringify(payload)).toString("base64");
+      const batches = [
+        [{ bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encode({ destination: "Old", timestamp: 1, sessionId: "old-session", sessionEpoch: 1, trackingGeneration: 0 }) }] }],
+        [{ bundleId: "com.example.ios", events: [{ eventType: "lifecycle", payload: encode({ state: "sdk_tracking_disabled", timestamp: 2, sessionId: "old-session", sessionEpoch: 1, trackingGeneration: 1 }) }] }],
+        [{ bundleId: "com.example.ios", events: [{ eventType: "lifecycle", payload: encode({ state: "sdk_session_started", timestamp: 3, sessionId: "new-session", sessionEpoch: 2, trackingGeneration: 0 }) }] }],
+        [{ bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encode({ destination: "New", timestamp: 4, sessionId: "new-session", sessionEpoch: 2, trackingGeneration: 0 }) }] }],
+      ];
+      let polls = 0;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () => ({ ok: true, json: async () => batches[polls++] })) as unknown as typeof fetch;
+
+      try {
+        await (testClient as unknown as { pollSdkEvents(): Promise<void> }).pollSdkEvents();
+        expect(testClient.getSdkScreenIdentity("com.example.ios")?.components.navigationRoute).toBe("Old");
+
+        await (testClient as unknown as { pollSdkEvents(): Promise<void> }).pollSdkEvents();
+        await (testClient as unknown as { pollSdkEvents(): Promise<void> }).pollSdkEvents();
+        expect(testClient.getSdkScreenIdentity("com.example.ios")).toBeUndefined();
+
+        await (testClient as unknown as { pollSdkEvents(): Promise<void> }).pollSdkEvents();
+        expect(testClient.getSdkScreenIdentity("com.example.ios")?.components.navigationRoute).toBe("New");
+      } finally {
+        globalThis.fetch = originalFetch;
+        await testClient.close();
+      }
+    });
+
+    test("ignores a delayed session announcement from an older epoch", async function() {
+      const { factory } = createCapturingWebSocketFactory(fakeTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+      const encode = (payload: Record<string, unknown>): string => Buffer.from(JSON.stringify(payload)).toString("base64");
+      const batches = [
+        [{ bundleId: "com.example.ios", events: [{ eventType: "lifecycle", payload: encode({ state: "sdk_session_started", timestamp: 2, sessionId: "current-session", sessionEpoch: 2, trackingGeneration: 0 }) }] }],
+        [{ bundleId: "com.example.ios", events: [{ eventType: "lifecycle", payload: encode({ state: "sdk_session_started", timestamp: 1, sessionId: "persisted-session", sessionEpoch: 1, trackingGeneration: 0 }) }] }],
+        [{ bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encode({ destination: "Current", timestamp: 3, sessionId: "current-session", sessionEpoch: 2, trackingGeneration: 0 }) }] }],
+      ];
+      let polls = 0;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () => ({ ok: true, json: async () => batches[polls++] })) as unknown as typeof fetch;
+
+      try {
+        await (testClient as unknown as { pollSdkEvents(): Promise<void> }).pollSdkEvents();
+        await (testClient as unknown as { pollSdkEvents(): Promise<void> }).pollSdkEvents();
+        await (testClient as unknown as { pollSdkEvents(): Promise<void> }).pollSdkEvents();
+
+        expect(testClient.getSdkScreenIdentity("com.example.ios")?.components.navigationRoute).toBe("Current");
       } finally {
         globalThis.fetch = originalFetch;
         await testClient.close();

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -2244,6 +2244,32 @@ describe("IOSCtrlProxyClient", function() {
       }
     });
 
+    test("keeps the last navigation event when same-millisecond events lack a sequence", async function() {
+      const { factory } = createCapturingWebSocketFactory(fakeTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+      const encode = (destination: string): string => Buffer.from(JSON.stringify({ destination, timestamp: 100 })).toString("base64");
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () => ({
+        ok: true,
+        json: async () => [{
+          bundleId: "com.example.ios",
+          events: [
+            { eventType: "navigation", payload: encode("OldScreen") },
+            { eventType: "navigation", payload: encode("NewScreen") },
+          ],
+        }],
+      })) as unknown as typeof fetch;
+
+      try {
+        const identity = await testClient.refreshSdkScreenIdentity("com.example.ios");
+
+        expect(identity?.components.navigationRoute).toBe("NewScreen");
+      } finally {
+        globalThis.fetch = originalFetch;
+        await testClient.close();
+      }
+    });
+
     test("retries an empty SDK-event drain within the identity refresh budget", async function() {
       const { factory } = createCapturingWebSocketFactory(fakeTimer);
       const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
@@ -2438,7 +2464,7 @@ describe("IOSCtrlProxyClient", function() {
               eventType: "navigation",
               payload: encode(polls === 1
                 ? { destination: "Poisoned", timestamp: "not-a-number" }
-                : { destination: "Fresh", timestamp: Date.now() + 1_000 }),
+                : { destination: "Fresh", timestamp: fakeTimer.now() + 1_000 }),
             }],
           }],
         };

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -2400,6 +2400,62 @@ describe("IOSCtrlProxyClient", function() {
       }
     });
 
+    test("drains queued navigation from a replaced application process", async function() {
+      const { factory } = createCapturingWebSocketFactory(fakeTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+      const encode = (destination: string, timestamp: number): string => Buffer.from(JSON.stringify({ destination, timestamp })).toString("base64");
+      const oldEvent = { bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encode("OldProcess", 1) }] };
+      const newEvent = { bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encode("NewProcess", 2) }] };
+      let polls = 0;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () => {
+        polls += 1;
+        return { ok: true, json: async () => polls === 1 ? [oldEvent] : polls === 2 ? [oldEvent] : [newEvent] };
+      }) as unknown as typeof fetch;
+
+      try {
+        await (testClient as unknown as { pollSdkEvents(): Promise<void> }).pollSdkEvents();
+        testClient.clearSdkScreenIdentity("com.example.ios");
+
+        await (testClient as unknown as { pollSdkEvents(): Promise<void> }).pollSdkEvents();
+        expect(testClient.getSdkScreenIdentity("com.example.ios")).toBeUndefined();
+
+        await (testClient as unknown as { pollSdkEvents(): Promise<void> }).pollSdkEvents();
+        expect(testClient.getSdkScreenIdentity("com.example.ios")?.components.navigationRoute).toBe("NewProcess");
+      } finally {
+        globalThis.fetch = originalFetch;
+        await testClient.close();
+      }
+    });
+
+    test("clears and fences SDK identity when tracking is disabled", async function() {
+      const { factory } = createCapturingWebSocketFactory(fakeTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+      const encode = (payload: Record<string, unknown>): string => Buffer.from(JSON.stringify(payload)).toString("base64");
+      const batches = [
+        [{ bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encode({ destination: "Settings", timestamp: 1 }) }] }],
+        [{ bundleId: "com.example.ios", events: [{ eventType: "lifecycle", payload: encode({ state: "sdk_tracking_disabled", timestamp: 2 }) }] }],
+        [{ bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encode({ destination: "Discover", timestamp: 3 }) }] }],
+      ];
+      let polls = 0;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () => ({ ok: true, json: async () => batches[polls++] })) as unknown as typeof fetch;
+
+      try {
+        await (testClient as unknown as { pollSdkEvents(): Promise<void> }).pollSdkEvents();
+        expect(testClient.getSdkScreenIdentity("com.example.ios")?.components.navigationRoute).toBe("Settings");
+
+        await (testClient as unknown as { pollSdkEvents(): Promise<void> }).pollSdkEvents();
+        expect(testClient.getSdkScreenIdentity("com.example.ios")).toBeUndefined();
+
+        await (testClient as unknown as { pollSdkEvents(): Promise<void> }).pollSdkEvents();
+        expect(testClient.getSdkScreenIdentity("com.example.ios")).toBeUndefined();
+      } finally {
+        globalThis.fetch = originalFetch;
+        await testClient.close();
+      }
+    });
+
     test("clears every SDK identity when the CtrlProxy connection resets", async function() {
       const { factory } = createCapturingWebSocketFactory(fakeTimer);
       const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -2487,6 +2487,31 @@ describe("IOSCtrlProxyClient", function() {
       }
     });
 
+    test("ignores a delayed tracking control from an older session", async function() {
+      const { factory } = createCapturingWebSocketFactory(fakeTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+      const encode = (payload: Record<string, unknown>): string => Buffer.from(JSON.stringify(payload)).toString("base64");
+      const batches = [
+        [{ bundleId: "com.example.ios", events: [{ eventType: "lifecycle", payload: encode({ state: "sdk_session_started", timestamp: 2, sessionId: "current-session", sessionEpoch: 2, trackingGeneration: 0 }) }] }],
+        [{ bundleId: "com.example.ios", events: [{ eventType: "lifecycle", payload: encode({ state: "sdk_tracking_disabled", timestamp: 1, sessionId: "persisted-session", sessionEpoch: 1, trackingGeneration: 5 }) }] }],
+        [{ bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encode({ destination: "Current", timestamp: 3, sessionId: "current-session", sessionEpoch: 2, trackingGeneration: 0 }) }] }],
+      ];
+      let polls = 0;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () => ({ ok: true, json: async () => batches[polls++] })) as unknown as typeof fetch;
+
+      try {
+        await (testClient as unknown as { pollSdkEvents(): Promise<void> }).pollSdkEvents();
+        await (testClient as unknown as { pollSdkEvents(): Promise<void> }).pollSdkEvents();
+        await (testClient as unknown as { pollSdkEvents(): Promise<void> }).pollSdkEvents();
+
+        expect(testClient.getSdkScreenIdentity("com.example.ios")?.components.navigationRoute).toBe("Current");
+      } finally {
+        globalThis.fetch = originalFetch;
+        await testClient.close();
+      }
+    });
+
     test("orders tracking re-enable before an earlier-arriving navigation event", async function() {
       const { factory } = createCapturingWebSocketFactory(fakeTimer);
       const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -2129,10 +2129,7 @@ describe("IOSCtrlProxyClient", function() {
       })) as unknown as typeof fetch;
 
       try {
-        (testClient as unknown as { startSdkEventPolling(): void }).startSdkEventPolling();
-        // Auto-advance timer fires the interval via setImmediate; flush the async
-        // fetch → decode → recordSdkEvent chain.
-        await flushPromises(8);
+        await (testClient as unknown as { pollSdkEvents(): Promise<void> }).pollSdkEvents();
 
         expect(fakeIngestor.sdkEvents.length).toBe(1);
         expect(fakeIngestor.sdkEvents[0].applicationId).toBe("com.example.ios");
@@ -2144,7 +2141,49 @@ describe("IOSCtrlProxyClient", function() {
         });
       } finally {
         globalThis.fetch = originalFetch;
-        (testClient as unknown as { stopSdkEventPolling(): void }).stopSdkEventPolling();
+        await testClient.close();
+      }
+    });
+
+    test("drains a navigation envelope before returning the SDK screen identity", async function() {
+      const { factory } = createCapturingWebSocketFactory(fakeTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        factory,
+        fakeTimer,
+      );
+      const payload = {
+        destination: "ScrollPerformanceDemo",
+        timestamp: 4242,
+        arguments: { tab: "demos" },
+        metadata: { presentation: "push" },
+      };
+      const encoded = Buffer.from(JSON.stringify(payload)).toString("base64");
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () => ({
+        ok: true,
+        json: async () => [
+          { bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encoded }] },
+        ],
+      })) as unknown as typeof fetch;
+
+      try {
+        const identity = await testClient.refreshSdkScreenIdentity("com.example.ios");
+
+        expect(identity).toMatchObject({
+          platform: "ios",
+          source: "sdk",
+          confidence: "high",
+          components: {
+            bundleId: "com.example.ios",
+            navigationRoute: "ScrollPerformanceDemo",
+            selectedTab: "demos",
+            presentation: "push",
+          },
+        });
+      } finally {
+        globalThis.fetch = originalFetch;
         await testClient.close();
       }
     });

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -2187,5 +2187,81 @@ describe("IOSCtrlProxyClient", function() {
         await testClient.close();
       }
     });
+
+    test("keeps the newest navigation identity when SDK events arrive out of order", async function() {
+      const { factory } = createCapturingWebSocketFactory(fakeTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+      const encode = (destination: string, timestamp: number): string => Buffer.from(JSON.stringify({ destination, timestamp })).toString("base64");
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () => ({
+        ok: true,
+        json: async () => [{
+          bundleId: "com.example.ios",
+          events: [
+            { eventType: "navigation", payload: encode("NewScreen", 200) },
+            { eventType: "navigation", payload: encode("OldScreen", 100) },
+          ],
+        }],
+      })) as unknown as typeof fetch;
+
+      try {
+        const identity = await testClient.refreshSdkScreenIdentity("com.example.ios");
+
+        expect(identity?.components.navigationRoute).toBe("NewScreen");
+      } finally {
+        globalThis.fetch = originalFetch;
+        await testClient.close();
+      }
+    });
+
+    test("does not restore an SDK identity after the connection closes during a poll", async function() {
+      const { factory } = createCapturingWebSocketFactory(fakeTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+      const encoded = Buffer.from(JSON.stringify({ destination: "StaleScreen", timestamp: 100 })).toString("base64");
+      let releaseFetch: ((response: { ok: boolean; json: () => Promise<unknown> }) => void) | undefined;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (() => new Promise(resolve => {
+        releaseFetch = resolve;
+      })) as unknown as typeof fetch;
+
+      try {
+        const poll = (testClient as unknown as { pollSdkEvents(): Promise<void> }).pollSdkEvents();
+        await flushPromises();
+        (testClient as unknown as { onConnectionClosed(): void }).onConnectionClosed();
+        releaseFetch?.({
+          ok: true,
+          json: async () => [{ bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encoded }] }],
+        });
+        await poll;
+
+        expect(testClient.getSdkScreenIdentity("com.example.ios")).toBeUndefined();
+      } finally {
+        globalThis.fetch = originalFetch;
+        await testClient.close();
+      }
+    });
+
+    test("falls back without waiting for a stalled SDK-event poll", async function() {
+      const controlledTimer = new FakeTimer();
+      const { factory } = createCapturingWebSocketFactory(controlledTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, controlledTimer);
+      let releaseFetch: ((response: { ok: boolean; json: () => Promise<unknown> }) => void) | undefined;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (() => new Promise(resolve => {
+        releaseFetch = resolve;
+      })) as unknown as typeof fetch;
+
+      try {
+        const identity = testClient.refreshSdkScreenIdentity("com.example.ios");
+        controlledTimer.advanceTime(100);
+
+        expect(await identity).toBeUndefined();
+        releaseFetch?.({ ok: true, json: async () => [] });
+        await flushPromises();
+      } finally {
+        globalThis.fetch = originalFetch;
+        await testClient.close();
+      }
+    });
   });
 });

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -2214,6 +2214,36 @@ describe("IOSCtrlProxyClient", function() {
       }
     });
 
+    test("uses the navigation sequence to order same-millisecond SDK events", async function() {
+      const { factory } = createCapturingWebSocketFactory(fakeTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+      const encode = (destination: string, sequenceNumber: number): string => Buffer.from(JSON.stringify({
+        destination,
+        timestamp: 100,
+        sequenceNumber,
+      })).toString("base64");
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () => ({
+        ok: true,
+        json: async () => [{
+          bundleId: "com.example.ios",
+          events: [
+            { eventType: "navigation", payload: encode("NewScreen", 2) },
+            { eventType: "navigation", payload: encode("OldScreen", 1) },
+          ],
+        }],
+      })) as unknown as typeof fetch;
+
+      try {
+        const identity = await testClient.refreshSdkScreenIdentity("com.example.ios");
+
+        expect(identity?.components.navigationRoute).toBe("NewScreen");
+      } finally {
+        globalThis.fetch = originalFetch;
+        await testClient.close();
+      }
+    });
+
     test("does not restore an SDK identity after the connection closes during a poll", async function() {
       const { factory } = createCapturingWebSocketFactory(fakeTimer);
       const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -2281,6 +2281,36 @@ describe("IOSCtrlProxyClient", function() {
       }
     });
 
+    test("retries after telemetry until the requested app reports navigation", async function() {
+      const { factory } = createCapturingWebSocketFactory(fakeTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+      const encode = (payload: Record<string, unknown>): string => Buffer.from(JSON.stringify(payload)).toString("base64");
+      const oldEvent = { bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encode({ destination: "OldScreen", timestamp: 1 }) }] };
+      const telemetry = { bundleId: "com.example.ios", events: [{ eventType: "network_request", payload: encode({ timestamp: 2, url: "https://example.test" }) }] };
+      const newEvent = { bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encode({ destination: "NewScreen", timestamp: 3 }) }] };
+      let polls = 0;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () => {
+        polls += 1;
+        return {
+          ok: true,
+          json: async () => polls === 1 ? [oldEvent] : polls === 2 ? [telemetry] : [newEvent],
+        };
+      }) as unknown as typeof fetch;
+
+      try {
+        await testClient.refreshSdkScreenIdentity("com.example.ios");
+
+        const identity = await testClient.refreshSdkScreenIdentity("com.example.ios");
+
+        expect(identity?.components.navigationRoute).toBe("NewScreen");
+        expect(polls).toBe(3);
+      } finally {
+        globalThis.fetch = originalFetch;
+        await testClient.close();
+      }
+    });
+
     test("caches navigation identities before awaited telemetry ingestion", async function() {
       const { factory } = createCapturingWebSocketFactory(fakeTimer);
       let releaseTelemetry: (() => void) | undefined;
@@ -2338,6 +2368,87 @@ describe("IOSCtrlProxyClient", function() {
         testClient.clearSdkScreenIdentity("com.example.ios");
 
         expect(testClient.getSdkScreenIdentity("com.example.ios")).toBeUndefined();
+      } finally {
+        globalThis.fetch = originalFetch;
+        await testClient.close();
+      }
+    });
+
+    test("clears every SDK identity when the CtrlProxy connection resets", async function() {
+      const { factory } = createCapturingWebSocketFactory(fakeTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+      const encoded = Buffer.from(JSON.stringify({ destination: "OldScreen", timestamp: 1 })).toString("base64");
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () => ({
+        ok: true,
+        json: async () => [{ bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encoded }] }],
+      })) as unknown as typeof fetch;
+
+      try {
+        await testClient.refreshSdkScreenIdentity("com.example.ios");
+        (testClient as unknown as { onConnectionClosed(): void }).onConnectionClosed();
+
+        expect(testClient.getSdkScreenIdentity("com.example.ios")).toBeUndefined();
+      } finally {
+        globalThis.fetch = originalFetch;
+        await testClient.close();
+      }
+    });
+
+    test("does not restore an SDK identity after the application is cleared during a poll", async function() {
+      const { factory } = createCapturingWebSocketFactory(fakeTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+      const encoded = Buffer.from(JSON.stringify({ destination: "StaleScreen", timestamp: 100 })).toString("base64");
+      let releaseFetch: ((response: { ok: boolean; json: () => Promise<unknown> }) => void) | undefined;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (() => new Promise(resolve => {
+        releaseFetch = resolve;
+      })) as unknown as typeof fetch;
+
+      try {
+        const poll = (testClient as unknown as { pollSdkEvents(): Promise<void> }).pollSdkEvents();
+        await flushPromises();
+        testClient.clearSdkScreenIdentity("com.example.ios");
+        releaseFetch?.({
+          ok: true,
+          json: async () => [{ bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encoded }] }],
+        });
+        await poll;
+
+        expect(testClient.getSdkScreenIdentity("com.example.ios")).toBeUndefined();
+      } finally {
+        globalThis.fetch = originalFetch;
+        await testClient.close();
+      }
+    });
+
+    test("does not let a malformed navigation timestamp poison later identity ordering", async function() {
+      const { factory } = createCapturingWebSocketFactory(fakeTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+      const encode = (payload: Record<string, unknown>): string => Buffer.from(JSON.stringify(payload)).toString("base64");
+      let polls = 0;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () => {
+        polls += 1;
+        return {
+          ok: true,
+          json: async () => [{
+            bundleId: "com.example.ios",
+            events: [{
+              eventType: "navigation",
+              payload: encode(polls === 1
+                ? { destination: "Poisoned", timestamp: "not-a-number" }
+                : { destination: "Fresh", timestamp: Date.now() + 1_000 }),
+            }],
+          }],
+        };
+      }) as unknown as typeof fetch;
+
+      try {
+        await testClient.refreshSdkScreenIdentity("com.example.ios");
+        const identity = await testClient.refreshSdkScreenIdentity("com.example.ios");
+
+        expect(identity?.components.navigationRoute).toBe("Fresh");
       } finally {
         globalThis.fetch = originalFetch;
         await testClient.close();

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -2244,6 +2244,106 @@ describe("IOSCtrlProxyClient", function() {
       }
     });
 
+    test("retries an empty SDK-event drain within the identity refresh budget", async function() {
+      const { factory } = createCapturingWebSocketFactory(fakeTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+      const encode = (destination: string, timestamp: number): string => Buffer.from(JSON.stringify({
+        destination,
+        timestamp,
+      })).toString("base64");
+      const oldEvent = { bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encode("OldScreen", 1) }] };
+      const newEvent = { bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encode("NewScreen", 2) }] };
+      let polls = 0;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () => {
+        polls += 1;
+        return {
+          ok: true,
+          json: async () => {
+            if (polls === 1) {
+              return [oldEvent];
+            }
+            return fakeTimer.now() >= 50 ? [newEvent] : [];
+          },
+        };
+      }) as unknown as typeof fetch;
+
+      try {
+        await testClient.refreshSdkScreenIdentity("com.example.ios");
+
+        const identity = await testClient.refreshSdkScreenIdentity("com.example.ios");
+
+        expect(identity?.components.navigationRoute).toBe("NewScreen");
+        expect(fakeTimer.now()).toBe(50);
+      } finally {
+        globalThis.fetch = originalFetch;
+        await testClient.close();
+      }
+    });
+
+    test("caches navigation identities before awaited telemetry ingestion", async function() {
+      const { factory } = createCapturingWebSocketFactory(fakeTimer);
+      let releaseTelemetry: (() => void) | undefined;
+      const blockingIngestor = new FakeIosSdkEventIngestor();
+      blockingIngestor.recordSdkEvent = async () => new Promise<void>(resolve => {
+        releaseTelemetry = resolve;
+      });
+      const testClient = IOSCtrlProxyClient.createForTesting(
+        testDevice,
+        serverPort,
+        factory,
+        fakeTimer,
+        undefined,
+        undefined,
+        undefined,
+        blockingIngestor,
+      );
+      const encode = (payload: Record<string, unknown>): string => Buffer.from(JSON.stringify(payload)).toString("base64");
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () => ({
+        ok: true,
+        json: async () => [{
+          bundleId: "com.example.ios",
+          events: [
+            { eventType: "network_request", payload: encode({ timestamp: 1, url: "https://example.test" }) },
+            { eventType: "navigation", payload: encode({ timestamp: 2, destination: "NewScreen" }) },
+          ],
+        }],
+      })) as unknown as typeof fetch;
+
+      try {
+        const identity = testClient.refreshSdkScreenIdentity("com.example.ios");
+        fakeTimer.advanceTime(100);
+
+        expect((await identity)?.components.navigationRoute).toBe("NewScreen");
+      } finally {
+        releaseTelemetry?.();
+        globalThis.fetch = originalFetch;
+        await testClient.close();
+      }
+    });
+
+    test("clears SDK identities for a replaced application process", async function() {
+      const { factory } = createCapturingWebSocketFactory(fakeTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+      const encoded = Buffer.from(JSON.stringify({ destination: "OldScreen", timestamp: 1 })).toString("base64");
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () => ({
+        ok: true,
+        json: async () => [{ bundleId: "com.example.ios", events: [{ eventType: "navigation", payload: encoded }] }],
+      })) as unknown as typeof fetch;
+
+      try {
+        await testClient.refreshSdkScreenIdentity("com.example.ios");
+        testClient.clearSdkScreenIdentity("com.example.ios");
+
+        expect(testClient.getSdkScreenIdentity("com.example.ios")).toBeUndefined();
+      } finally {
+        globalThis.fetch = originalFetch;
+        await testClient.close();
+      }
+    });
+
     test("does not restore an SDK identity after the connection closes during a poll", async function() {
       const { factory } = createCapturingWebSocketFactory(fakeTimer);
       const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -2512,6 +2512,52 @@ describe("IOSCtrlProxyClient", function() {
       }
     });
 
+    test("accepts navigation after an in-band tracking disable and enable", async function() {
+      const { factory } = createCapturingWebSocketFactory(fakeTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+      const encode = (payload: Record<string, unknown>): string => Buffer.from(JSON.stringify(payload)).toString("base64");
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () => ({
+        ok: true,
+        json: async () => [{
+          bundleId: "com.example.ios",
+          events: [
+            { eventType: "lifecycle", payload: encode({ state: "sdk_tracking_disabled", timestamp: 1, sessionId: "session", sessionEpoch: 1, trackingGeneration: 1 }) },
+            { eventType: "lifecycle", payload: encode({ state: "sdk_tracking_enabled", timestamp: 2, sessionId: "session", sessionEpoch: 1, trackingGeneration: 2 }) },
+            { eventType: "navigation", payload: encode({ destination: "Discover", timestamp: 3, sessionId: "session", sessionEpoch: 1, trackingGeneration: 2 }) },
+          ],
+        }],
+      })) as unknown as typeof fetch;
+
+      try {
+        await (testClient as unknown as { pollSdkEvents(): Promise<void> }).pollSdkEvents();
+
+        expect(testClient.getSdkScreenIdentity("com.example.ios")?.components.navigationRoute).toBe("Discover");
+      } finally {
+        globalThis.fetch = originalFetch;
+        await testClient.close();
+      }
+    });
+
+    test("treats a malformed SDK event batch as a non-fatal empty poll", async function() {
+      const { factory } = createCapturingWebSocketFactory(fakeTimer);
+      const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async () => ({
+        ok: true,
+        json: async () => [{ bundleId: "com.example.ios", events: {} }],
+      })) as unknown as typeof fetch;
+
+      try {
+        const result = await (testClient as unknown as { pollSdkEvents(): Promise<{ receivedEvents: boolean }> }).pollSdkEvents();
+
+        expect(result.receivedEvents).toBe(false);
+      } finally {
+        globalThis.fetch = originalFetch;
+        await testClient.close();
+      }
+    });
+
     test("orders tracking re-enable before an earlier-arriving navigation event", async function() {
       const { factory } = createCapturingWebSocketFactory(fakeTimer);
       const testClient = IOSCtrlProxyClient.createForTesting(testDevice, serverPort, factory, fakeTimer);

--- a/test/features/observe/ios/IosSdkScreenIdentity.test.ts
+++ b/test/features/observe/ios/IosSdkScreenIdentity.test.ts
@@ -41,6 +41,25 @@ describe("deriveIosSdkScreenIdentity", () => {
     expect(deriveIosSdkScreenIdentity("navigation", PLAYGROUND_BUNDLE, routes[2])!.key).toBe(keys[2]);
   });
 
+  test("distinguishes destination instances by canonical navigation arguments", () => {
+    const first = deriveIosSdkScreenIdentity("navigation", PLAYGROUND_BUNDLE, {
+      destination: "VideoDetail",
+      arguments: { title: "First video", videoId: "video-1" },
+    })!;
+    const second = deriveIosSdkScreenIdentity("navigation", PLAYGROUND_BUNDLE, {
+      destination: "VideoDetail",
+      arguments: { videoId: "video-2", title: "Second video" },
+    })!;
+    const reordered = deriveIosSdkScreenIdentity("navigation", PLAYGROUND_BUNDLE, {
+      destination: "VideoDetail",
+      arguments: { videoId: "video-1", title: "First video" },
+    })!;
+
+    expect(first.key).not.toBe(second.key);
+    expect(first.key).toBe(reordered.key);
+    expect(first.key).toContain(JSON.stringify(["argument", "videoId", "video-1"]));
+  });
+
   test("omits identity without a bundle or destination", () => {
     expect(deriveIosSdkScreenIdentity("navigation", undefined, { destination: "Settings" })).toBeUndefined();
     expect(deriveIosSdkScreenIdentity("navigation", PLAYGROUND_BUNDLE, { destination: "  " })).toBeUndefined();

--- a/test/features/observe/ios/IosSdkScreenIdentity.test.ts
+++ b/test/features/observe/ios/IosSdkScreenIdentity.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { deriveIosSdkScreenIdentity } from "../../../../src/features/observe/ios/IosSdkScreenIdentity";
+
+const PLAYGROUND_BUNDLE = "dev.jasonpearson.automobile.Playground";
+
+describe("deriveIosSdkScreenIdentity", () => {
+  test("includes the SDK route, selected tab, and presentation metadata", () => {
+    expect(deriveIosSdkScreenIdentity("navigation", PLAYGROUND_BUNDLE, {
+      destination: "ScrollPerformanceDemo",
+      arguments: { tab: "Demos" },
+      metadata: { presentation: "sheet" },
+    })).toEqual({
+      platform: "ios",
+      source: "sdk",
+      confidence: "high",
+      key: JSON.stringify([
+        ["bundle", PLAYGROUND_BUNDLE],
+        ["route", "ScrollPerformanceDemo"],
+        ["tab", "Demos"],
+        ["presentation", "sheet"],
+      ]),
+      components: {
+        bundleId: PLAYGROUND_BUNDLE,
+        navigationRoute: "ScrollPerformanceDemo",
+        selectedTab: "Demos",
+        presentation: "sheet",
+      },
+    });
+  });
+
+  test("gives Playground tab and destination routes distinct, stable identities", () => {
+    const routes = [
+      { destination: "discover", metadata: { type: "tab_switch" } },
+      { destination: "demos", metadata: { type: "tab_switch" } },
+      { destination: "ScrollPerformanceDemo", arguments: { tab: "demos" } },
+      { destination: "settings", metadata: { type: "tab_switch" } },
+    ];
+    const keys = routes.map(route => deriveIosSdkScreenIdentity("navigation", PLAYGROUND_BUNDLE, route)!.key);
+
+    expect(new Set(keys).size).toBe(4);
+    expect(deriveIosSdkScreenIdentity("navigation", PLAYGROUND_BUNDLE, routes[2])!.key).toBe(keys[2]);
+  });
+
+  test("omits identity without a bundle or destination", () => {
+    expect(deriveIosSdkScreenIdentity("navigation", undefined, { destination: "Settings" })).toBeUndefined();
+    expect(deriveIosSdkScreenIdentity("navigation", PLAYGROUND_BUNDLE, { destination: "  " })).toBeUndefined();
+  });
+
+  test("ignores a destination-shaped payload from a non-navigation SDK event", () => {
+    expect(deriveIosSdkScreenIdentity("custom", PLAYGROUND_BUNDLE, {
+      destination: "Settings",
+    })).toBeUndefined();
+  });
+});

--- a/test/features/observe/output/ObserveResultOutput.test.ts
+++ b/test/features/observe/output/ObserveResultOutput.test.ts
@@ -92,6 +92,26 @@ describe("sanitizeObserveResult", () => {
       expect(out.viewHierarchy).not.toBe(observe.viewHierarchy);
     });
 
+    test("preserves an SDK-backed screen identity while compacting observation output", () => {
+      const observe: ObserveResult = {
+        updatedAt: 1,
+        screenSize: { width: 100, height: 200 },
+        systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+        screenIdentity: {
+          platform: "ios",
+          source: "sdk",
+          confidence: "high",
+          key: '[["bundle","dev.jasonpearson.automobile.Playground"],["route","SettingsTab"]]',
+          components: {
+            bundleId: "dev.jasonpearson.automobile.Playground",
+            navigationRoute: "SettingsTab",
+          },
+        },
+      };
+
+      expect(sanitizeObserveResult(observe, COMPACT).screenIdentity).toEqual(observe.screenIdentity);
+    });
+
     test("completes well under the 100ms unit-test budget", () => {
       const { observe } = loadAndroidHomeObserve();
       const start = performance.now();

--- a/test/features/observe/output/diffObserveResult.test.ts
+++ b/test/features/observe/output/diffObserveResult.test.ts
@@ -1424,10 +1424,11 @@ describe("diffObserveResult — volatile occlusion exclusion (#4399)", () => {
 describe("isSameObservationScreen", () => {
   const iosIdentity = (
     key: string,
-    confidence: "high" | "medium" | "low" = "high"
+    confidence: "high" | "medium" | "low" = "high",
+    source: "heuristic" | "sdk" = "heuristic",
   ): ObserveResult["screenIdentity"] => ({
     platform: "ios",
-    source: "heuristic",
+    source,
     confidence,
     key,
     components: {
@@ -1486,6 +1487,21 @@ describe("isSameObservationScreen", () => {
       screenIdentity: iosIdentity("bundle=com.apple.reminders|nav=New Reminder"),
     });
     expect(isSameObservationScreen(a, b)).toBe(false);
+  });
+
+  test("SDK navigation route changes prevent a cross-screen diff", () => {
+    const a = obs({ "resource-id": "a" }, {
+      screenIdentity: iosIdentity("sdk:Discover", "high", "sdk"),
+    });
+    const sameRoute = obs({ "resource-id": "b" }, {
+      screenIdentity: iosIdentity("sdk:Discover", "high", "sdk"),
+    });
+    const nextRoute = obs({ "resource-id": "c" }, {
+      screenIdentity: iosIdentity("sdk:Settings", "high", "sdk"),
+    });
+
+    expect(isSameObservationScreen(a, sameRoute)).toBe(true);
+    expect(isSameObservationScreen(a, nextRoute)).toBe(false);
   });
 
   test("different medium-confidence iOS screen identity → false", () => {


### PR DESCRIPTION
## Summary

Implements [issue 3313](https://github.com/kaeawc/auto-mobile/issues/3313) by deriving iOS `observe` screen identities from SDK navigation events.

Closes #3313.

- retain the latest valid SDK navigation identity per iOS app while CtrlProxy receives `/sdk-events`
- prefer the SDK identity in `observe`, while preserving the hierarchy-derived fallback
- carry navigation-route, selected-tab, and presentation components through compact and diff output
- emit initial and tab navigation events from the iOS Playground

## Why

Hierarchy labels can change after in-place mutations and are not a stable representation of an iOS screen. The SDK event stream already provides the navigation boundary, so using it yields stable identities for mutations and distinct identities after navigation.

## Validation

- `bun run turbo:validate` (9,922 passed; 14 skipped; 0 failed)
- `bun run typecheck`
- `xcodebuild -project ios/Playground/Playground.xcodeproj -scheme Playground -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build`
- `git diff --check`
