### PR TITLE
fix(xctestrunner): activate checkout-aware daemon identity

### DIFF
--- a/docs/using/hermetic-ci-pinning.md
+++ b/docs/using/hermetic-ci-pinning.md
@@ -95,13 +95,17 @@ mirror can only serve unverified assets if you deliberately opt out of verificat
 1. **Pin the runner + daemon:**
    ```bash
    export AUTOMOBILE_VERSION=0.0.40
+   export AUTOMOBILE_REPO_ROOT="$GITHUB_WORKSPACE" # checkout with dist/src/index.js
    ```
-   Pin the XCTestRunner SPM dependency to the matching git tag. Note: the iOS
-   XCTestRunner autostart currently spawns a bare-PATH `auto-mobile --daemon start`
-   (`AutoMobileEnvironment.swift`) — it does **not** yet pin the daemon package version
-   itself. Pin it by installing the exact `@kaeawc/auto-mobile@0.0.40` on the runner's
-   PATH, or start the daemon yourself before the test job. (Baking the pin into the
-   Swift runner is tracked as follow-up work for #2746.)
+   Pin the XCTestRunner SPM dependency to the matching git tag. When
+   `AUTOMOBILE_REPO_ROOT` (or the runner's source checkout) contains
+   `dist/src/index.js`, XCTestRunner starts or restarts that exact checkout's daemon and
+   rejects a same-release daemon from a different checkout. Set the variable explicitly
+   for an embedding project or CI layout where the runner source cannot identify the
+   checkout. For a package consumer without a built checkout, XCTestRunner falls back to
+   the PATH `auto-mobile` CLI; pin the exact `@kaeawc/auto-mobile@0.0.40` there or start
+   the daemon yourself before the test job. (Embedding a package-version pin in the Swift
+   runner remains tracked by [#2746](https://github.com/kaeawc/auto-mobile/issues/2746).)
 2. **Vendor the IPA** so nothing is fetched or compiled at test time:
    ```bash
    export AUTOMOBILE_CTRL_PROXY_IOS_IPA_PATH=/opt/automobile/control-proxy.ipa

--- a/docs/using/hermetic-ci-pinning.md
+++ b/docs/using/hermetic-ci-pinning.md
@@ -126,16 +126,24 @@ mirror can only serve unverified assets if you deliberately opt out of verificat
 
 The pin is a property of **the daemon's launch environment**, resolved where the download
 happens. AutoMobile runs **one daemon per UID**, shared across worktrees via a single
-socket + PID file, and runners **reuse an already-running daemon** rather than restart it.
-So if a daemon is already up with a different `AUTOMOBILE_VERSION` (or none), a second job
-that exports a new pin will silently be served by the **existing** daemon — the pin is
-ignored until the daemon is restarted.
+socket + PID file.
 
-For hermetic CI, force a clean daemon so the pin actually takes effect:
+The checkout-aware iOS XCTestRunner path above is an exception: when it has a built
+`AUTOMOBILE_REPO_ROOT` (or can identify its source checkout), it reconciles a running daemon
+whose release or checkout build identity differs by restarting it from that checkout. A
+pin-only asset mismatch fails closed with a diagnostic instead of silently reusing the daemon;
+restart the daemon from the runner's environment to reconcile that case.
+
+Other runners reuse an already-running daemon rather than restart it. If a daemon is already
+up with a different `AUTOMOBILE_VERSION` (or none), a second job that exports a new pin will
+silently be served by the **existing** daemon — the pin is ignored until the daemon is restarted.
+
+For hermetic CI runners that do not use the checkout-aware XCTestRunner path, force a clean
+daemon so the pin actually takes effect:
 
 - **Android:** `-Dautomobile.daemon.force.restart=true` (already in the recipe above).
-- **Any platform:** `bunx @kaeawc/auto-mobile@<version> --daemon restart` before the job,
-  then confirm via `ide/status` (below) that `releaseVersion` matches your pin.
+- **Other unreconciled runners:** `bunx @kaeawc/auto-mobile@<version> --daemon restart` before
+  the job, then confirm via `ide/status` (below) that `releaseVersion` matches your pin.
 
 ## Verifying the pin
 

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
@@ -473,7 +473,8 @@ public enum DaemonManager {
     static func ensureDaemonRunningResult(
         repoRoot: String?,
         timeoutSeconds: TimeInterval,
-        runtime: DaemonRuntime
+        runtime: DaemonRuntime,
+        callerAssetVersion: String? = resolveCallerAssetVersionPin()
     )
         -> DaemonStartupResult
     {
@@ -494,7 +495,7 @@ public enum DaemonManager {
             )
             let assetVersionSkew = requiresAssetVersionPinFailure(
                 daemonAssetVersion: runtime.readDaemonAssetVersion(),
-                callerPinnedVersion: resolveCallerAssetVersionPin()
+                callerPinnedVersion: callerAssetVersion
             )
             if requiresImmediateAssetVersionPinFailure(
                 assetVersionSkew: assetVersionSkew,
@@ -510,7 +511,12 @@ public enum DaemonManager {
                     PerfTimer.log("ensureDaemonRunning: restartDaemon failed - \(failure)")
                     return failure
                 }
-                return waitForVersionMatchedDaemon(repoRoot: repoRoot, timeoutSeconds: timeoutSeconds, runtime: runtime)
+                return waitForVersionMatchedDaemon(
+                    repoRoot: repoRoot,
+                    timeoutSeconds: timeoutSeconds,
+                    runtime: runtime,
+                    callerAssetVersion: callerAssetVersion
+                )
             }
             PerfTimer.log("ensureDaemonRunning: daemon already running")
             return .ready
@@ -522,7 +528,12 @@ public enum DaemonManager {
             return failure
         }
 
-        return waitForVersionMatchedDaemon(repoRoot: repoRoot, timeoutSeconds: timeoutSeconds, runtime: runtime)
+        return waitForVersionMatchedDaemon(
+            repoRoot: repoRoot,
+            timeoutSeconds: timeoutSeconds,
+            runtime: runtime,
+            callerAssetVersion: callerAssetVersion
+        )
     }
 
     /// Wait for the daemon to become ready and confirm its recorded version matches this runner's.
@@ -534,7 +545,8 @@ public enum DaemonManager {
     private static func waitForVersionMatchedDaemon(
         repoRoot: String?,
         timeoutSeconds: TimeInterval,
-        runtime: DaemonRuntime
+        runtime: DaemonRuntime,
+        callerAssetVersion: String?
     )
         -> DaemonStartupResult
     {
@@ -549,9 +561,9 @@ public enum DaemonManager {
             daemonBuildId: runtime.readDaemonBuildId(),
             daemonEntryScript: runtime.readDaemonEntryScript(),
             repoRoot: repoRoot
-        ) || requiresAssetVersionPinFailure(
-            daemonAssetVersion: runtime.readDaemonAssetVersion(),
-            callerPinnedVersion: resolveCallerAssetVersionPin()
+            ) || requiresAssetVersionPinFailure(
+                daemonAssetVersion: runtime.readDaemonAssetVersion(),
+                callerPinnedVersion: callerAssetVersion
         ) {
             PerfTimer.log("ensureDaemonRunning: daemon still differs from runner after launch")
             if requiresAssetVersionPinFailure(

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
@@ -142,6 +142,12 @@ protocol DaemonRuntime {
 }
 
 public enum DaemonManager {
+    private struct PackageMetadata: Decodable {
+        let name: String?
+    }
+
+    private static let packageName = "@kaeawc/auto-mobile"
+
     /// Outcome of launching an `auto-mobile --daemon <subcommand>` process, distinguishing a
     /// missing executable from a launched-but-failed process so callers can report the real cause.
     enum DaemonSubcommandOutcome: Equatable {
@@ -365,10 +371,11 @@ public enum DaemonManager {
     }
 
     /// When a caller supplies a repo root with a built entrypoint, whether the running daemon was
-    /// started from a *different* build (#2744). Prefers comparing the entry-script content hash
-    /// against the daemon's recorded `buildId` — this catches the same repoRoot path rebuilt or
-    /// checked out to another commit — and falls back to comparing entry-script paths when a hash is
-    /// unavailable. No-op without a repoRoot build or when neither signal is available.
+    /// started from a *different* build (#2744). The daemon must identify both the expected
+    /// entry-script path and its content hash: the path keeps separately copied runtime artifacts
+    /// (such as `dist/schemas/`) scoped to this checkout, while the hash catches an in-place rebuild.
+    /// Falls back to the entry-script path when a hash is unavailable. No-op without a repoRoot
+    /// build or when neither signal is available.
     static func requiresRepoRootBuildSkew(
         daemonBuildId: String?,
         daemonEntryScript: String?,
@@ -381,15 +388,14 @@ public enum DaemonManager {
         }
         let expectedHash = computeBuildId(expectedEntry)
         let daemonHash = daemonBuildId?.trimmingCharacters(in: .whitespaces)
-        if let expectedHash = expectedHash,
-           let daemonHash = daemonHash, !daemonHash.isEmpty, daemonHash != "unknown"
-        {
-            return daemonHash != expectedHash
+        let daemonEntry = daemonEntryScript?.trimmingCharacters(in: .whitespaces)
+        let hasExpectedEntry = daemonEntry == expectedEntry
+        guard let expectedHash = expectedHash,
+              let daemonHash = daemonHash, !daemonHash.isEmpty, daemonHash != "unknown"
+        else {
+            return daemonEntry.map { !$0.isEmpty && !hasExpectedEntry } ?? false
         }
-        guard let daemonEntry = daemonEntryScript?.trimmingCharacters(in: .whitespaces), !daemonEntry.isEmpty else {
-            return false
-        }
-        return daemonEntry != expectedEntry
+        return daemonHash != expectedHash || !hasExpectedEntry
     }
 
     /// The release portion of a version string — everything before the `+g<sha>` dev stamp.
@@ -595,10 +601,15 @@ public enum DaemonManager {
 
     /// Finds the owning AutoMobile checkout for a runner source path. The caller still verifies the
     /// built entrypoint before using it, so package consumers without `dist/` retain PATH behavior.
+    /// A package file alone is not enough: XCTestRunner may be vendored in a host JavaScript project.
     static func findRepoRoot(startingAt sourcePath: String) -> String? {
         var directory = URL(fileURLWithPath: sourcePath).deletingLastPathComponent()
         while directory.path != "/" {
-            if FileManager.default.fileExists(atPath: directory.appendingPathComponent("package.json").path) {
+            let packageURL = directory.appendingPathComponent("package.json")
+            if let data = try? Data(contentsOf: packageURL),
+               let package = try? JSONDecoder().decode(PackageMetadata.self, from: data),
+               package.name == packageName
+            {
                 return directory.path
             }
             directory.deleteLastPathComponent()

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileEnvironment.swift
@@ -129,6 +129,18 @@ public enum DaemonStartupResult: Equatable {
     }
 }
 
+/// Injectable process and PID-file boundary for daemon lifecycle decisions. Tests use a fake so
+/// build-skew restarts are verified without touching the caller's shared daemon.
+protocol DaemonRuntime {
+    func isDaemonRunning() -> Bool
+    func readDaemonVersion() -> String?
+    func readDaemonAssetVersion() -> String?
+    func readDaemonEntryScript() -> String?
+    func readDaemonBuildId() -> String?
+    func runDaemonSubcommand(_ subcommand: String, repoRoot: String?) -> DaemonManager.DaemonSubcommandOutcome
+    func waitForDaemon(timeoutSeconds: TimeInterval) -> Bool
+}
+
 public enum DaemonManager {
     /// Outcome of launching an `auto-mobile --daemon <subcommand>` process, distinguishing a
     /// missing executable from a launched-but-failed process so callers can report the real cause.
@@ -136,6 +148,36 @@ public enum DaemonManager {
         case launched
         case executableNotFound
         case failed
+    }
+
+    private struct SystemDaemonRuntime: DaemonRuntime {
+        func isDaemonRunning() -> Bool {
+            DaemonManager.isDaemonRunning()
+        }
+
+        func readDaemonVersion() -> String? {
+            DaemonManager.readDaemonVersionFromPidFile()
+        }
+
+        func readDaemonAssetVersion() -> String? {
+            DaemonManager.readDaemonAssetVersionFromPidFile()
+        }
+
+        func readDaemonEntryScript() -> String? {
+            DaemonManager.readDaemonEntryScriptFromPidFile()
+        }
+
+        func readDaemonBuildId() -> String? {
+            DaemonManager.readDaemonBuildIdFromPidFile()
+        }
+
+        func runDaemonSubcommand(_ subcommand: String, repoRoot: String?) -> DaemonSubcommandOutcome {
+            DaemonManager.runDaemonSubcommand(subcommand, repoRoot: repoRoot)
+        }
+
+        func waitForDaemon(timeoutSeconds: TimeInterval) -> Bool {
+            DaemonManager.waitForDaemon(timeoutSeconds: timeoutSeconds)
+        }
     }
 
     public struct PidFileData: Decodable {
@@ -210,7 +252,7 @@ public enum DaemonManager {
         return runDaemonSubcommand("restart", repoRoot: repoRoot) == .launched
     }
 
-    private static func runDaemonSubcommand(_ subcommand: String, repoRoot: String? = nil) -> DaemonSubcommandOutcome {
+    static func runDaemonSubcommand(_ subcommand: String, repoRoot: String? = nil) -> DaemonSubcommandOutcome {
         // When a repo root with a built entrypoint is provided, launch *that* checkout's daemon
         // (`<repoRoot>/dist/src/index.js`) rather than whatever `auto-mobile` is on PATH — so a
         // caller that knows its source build gets a version/build-matched daemon (#2744) instead of
@@ -418,24 +460,40 @@ public enum DaemonManager {
     public static func ensureDaemonRunningResult(
         repoRoot: String? = nil,
         timeoutSeconds: TimeInterval = 15
-    ) -> DaemonStartupResult {
+    )
+        -> DaemonStartupResult
+    {
+        return ensureDaemonRunningResult(
+            repoRoot: repoRoot,
+            timeoutSeconds: timeoutSeconds,
+            runtime: SystemDaemonRuntime()
+        )
+    }
+
+    static func ensureDaemonRunningResult(
+        repoRoot: String?,
+        timeoutSeconds: TimeInterval,
+        runtime: DaemonRuntime
+    )
+        -> DaemonStartupResult
+    {
         PerfTimer.log("ensureDaemonRunning: checking isDaemonRunning")
-        if isDaemonRunning() {
+        if runtime.isDaemonRunning() {
             // A stale different-build daemon on the shared socket would reject this runner's
             // version handshake (#2744). Restart it before reuse so we self-heal instead of
             // failing, mirroring the Android/TS version-skew restart. When a repoRoot is supplied,
             // also restart a same-release daemon started from a different checkout's entry script.
             let versionSkew = requiresVersionSkewRestart(
-                daemonVersion: readDaemonVersionFromPidFile(),
+                daemonVersion: runtime.readDaemonVersion(),
                 clientVersion: AutoMobileVersion.current
             )
             let buildSkew = requiresRepoRootBuildSkew(
-                daemonBuildId: readDaemonBuildIdFromPidFile(),
-                daemonEntryScript: readDaemonEntryScriptFromPidFile(),
+                daemonBuildId: runtime.readDaemonBuildId(),
+                daemonEntryScript: runtime.readDaemonEntryScript(),
                 repoRoot: repoRoot
             )
             let assetVersionSkew = requiresAssetVersionPinFailure(
-                daemonAssetVersion: readDaemonAssetVersionFromPidFile(),
+                daemonAssetVersion: runtime.readDaemonAssetVersion(),
                 callerPinnedVersion: resolveCallerAssetVersionPin()
             )
             if requiresImmediateAssetVersionPinFailure(
@@ -448,23 +506,23 @@ public enum DaemonManager {
             }
             if versionSkew || buildSkew || assetVersionSkew {
                 PerfTimer.log("ensureDaemonRunning: daemon version/build skew, restarting")
-                if let failure = startupFailure(for: runDaemonSubcommand("restart", repoRoot: repoRoot)) {
+                if let failure = startupFailure(for: runtime.runDaemonSubcommand("restart", repoRoot: repoRoot)) {
                     PerfTimer.log("ensureDaemonRunning: restartDaemon failed - \(failure)")
                     return failure
                 }
-                return waitForVersionMatchedDaemon(repoRoot: repoRoot, timeoutSeconds: timeoutSeconds)
+                return waitForVersionMatchedDaemon(repoRoot: repoRoot, timeoutSeconds: timeoutSeconds, runtime: runtime)
             }
             PerfTimer.log("ensureDaemonRunning: daemon already running")
             return .ready
         }
 
         PerfTimer.log("ensureDaemonRunning: starting daemon")
-        if let failure = startupFailure(for: startDaemonOutcome(repoRoot: repoRoot)) {
+        if let failure = startupFailure(for: runtime.runDaemonSubcommand("start", repoRoot: repoRoot)) {
             PerfTimer.log("ensureDaemonRunning: startDaemon failed - \(failure)")
             return failure
         }
 
-        return waitForVersionMatchedDaemon(repoRoot: repoRoot, timeoutSeconds: timeoutSeconds)
+        return waitForVersionMatchedDaemon(repoRoot: repoRoot, timeoutSeconds: timeoutSeconds, runtime: runtime)
     }
 
     /// Wait for the daemon to become ready and confirm its recorded version matches this runner's.
@@ -475,26 +533,29 @@ public enum DaemonManager {
     /// accepted (a skew cannot be proven), matching the gate's lenient stance.
     private static func waitForVersionMatchedDaemon(
         repoRoot: String?,
-        timeoutSeconds: TimeInterval
-    ) -> DaemonStartupResult {
+        timeoutSeconds: TimeInterval,
+        runtime: DaemonRuntime
+    )
+        -> DaemonStartupResult
+    {
         PerfTimer.log("ensureDaemonRunning: waiting for daemon")
-        guard waitForDaemon(timeoutSeconds: timeoutSeconds) else {
+        guard runtime.waitForDaemon(timeoutSeconds: timeoutSeconds) else {
             return .readinessTimeout
         }
         if requiresVersionSkewRestart(
-            daemonVersion: readDaemonVersionFromPidFile(),
+            daemonVersion: runtime.readDaemonVersion(),
             clientVersion: AutoMobileVersion.current
         ) || requiresRepoRootBuildSkew(
-            daemonBuildId: readDaemonBuildIdFromPidFile(),
-            daemonEntryScript: readDaemonEntryScriptFromPidFile(),
+            daemonBuildId: runtime.readDaemonBuildId(),
+            daemonEntryScript: runtime.readDaemonEntryScript(),
             repoRoot: repoRoot
         ) || requiresAssetVersionPinFailure(
-            daemonAssetVersion: readDaemonAssetVersionFromPidFile(),
+            daemonAssetVersion: runtime.readDaemonAssetVersion(),
             callerPinnedVersion: resolveCallerAssetVersionPin()
         ) {
             PerfTimer.log("ensureDaemonRunning: daemon still differs from runner after launch")
             if requiresAssetVersionPinFailure(
-                daemonAssetVersion: readDaemonAssetVersionFromPidFile(),
+                daemonAssetVersion: runtime.readDaemonAssetVersion(),
                 callerPinnedVersion: resolveCallerAssetVersionPin()
             ) {
                 return .assetVersionSkew
@@ -518,6 +579,19 @@ public enum DaemonManager {
         }
         PerfTimer.log("waitForDaemon: TIMEOUT after \(pollCount) polls")
         return false
+    }
+
+    /// Finds the owning AutoMobile checkout for a runner source path. The caller still verifies the
+    /// built entrypoint before using it, so package consumers without `dist/` retain PATH behavior.
+    static func findRepoRoot(startingAt sourcePath: String) -> String? {
+        var directory = URL(fileURLWithPath: sourcePath).deletingLastPathComponent()
+        while directory.path != "/" {
+            if FileManager.default.fileExists(atPath: directory.appendingPathComponent("package.json").path) {
+                return directory.path
+            }
+            directory.deleteLastPathComponent()
+        }
+        return nil
     }
 
     /// Resolve the built daemon entrypoint under a caller-provided repo root, or nil when no root

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobilePlanExecutor.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobilePlanExecutor.swift
@@ -58,6 +58,20 @@ public final class FakeTimer: AutoMobileTimer {
     }
 }
 
+/// The daemon lifecycle boundary used by plan execution. Kept injectable so executor tests never
+/// start or restart a real shared daemon.
+public protocol AutoMobileDaemonEnsuring {
+    func ensureDaemonRunning(repoRoot: String?) -> Bool
+}
+
+public struct SystemDaemonEnsurer: AutoMobileDaemonEnsuring {
+    public init() {}
+
+    public func ensureDaemonRunning(repoRoot: String?) -> Bool {
+        return DaemonManager.ensureDaemonRunning(repoRoot: repoRoot)
+    }
+}
+
 public protocol AutoMobilePlanLoading {
     func loadPlan(at path: String, bundle: Bundle?) throws -> String
 }
@@ -663,6 +677,8 @@ public final class AutoMobilePlanExecutor {
 
     public struct Configuration {
         public let transport: Transport
+        /// Source checkout whose built daemon should own the managed socket, when available.
+        public let daemonRepoRoot: String?
         public let planPath: String
         public let retryCount: Int
         public let timeoutSeconds: TimeInterval
@@ -680,6 +696,7 @@ public final class AutoMobilePlanExecutor {
         public init(
             transport: Transport,
             planPath: String,
+            daemonRepoRoot: String? = nil,
             retryCount: Int = 0,
             timeoutSeconds: TimeInterval = 300,
             retryDelaySeconds: TimeInterval = 1,
@@ -691,6 +708,7 @@ public final class AutoMobilePlanExecutor {
             aiAssistance: Bool = true
         ) {
             self.transport = transport
+            self.daemonRepoRoot = daemonRepoRoot
             self.planPath = planPath
             self.retryCount = max(0, retryCount)
             self.timeoutSeconds = timeoutSeconds
@@ -791,6 +809,7 @@ public final class AutoMobilePlanExecutor {
     private let mcpClient: AutoMobileMCPClient
     private let timer: AutoMobileTimer
     private let logger: AutoMobileLogger
+    private let daemonEnsurer: AutoMobileDaemonEnsuring
     private let sessionIdProvider: () -> String
     private let recoveryConfigProvider: RecoveryConfigProviding
     // Nil = no AI recovery (no injected handler and no model API key in the environment); the executor
@@ -806,12 +825,14 @@ public final class AutoMobilePlanExecutor {
         sessionIdProvider: @escaping () -> String = { AutoMobileSession.currentSessionUuid() },
         recoveryHandler: PlanRecoveryHandler? = nil,
         recoveryConfigProvider: RecoveryConfigProviding? = nil,
-        recoveryModelConfig: RecoveryModelConfig? = RecoveryModelConfig.resolve()
+        recoveryModelConfig: RecoveryModelConfig? = RecoveryModelConfig.resolve(),
+        daemonEnsurer: AutoMobileDaemonEnsuring = SystemDaemonEnsurer()
     ) {
         self.configuration = configuration
         self.planLoader = planLoader
         self.timer = timer
         self.logger = logger
+        self.daemonEnsurer = daemonEnsurer
         self.sessionIdProvider = sessionIdProvider
 
         if let mcpClient = mcpClient {
@@ -862,7 +883,7 @@ public final class AutoMobilePlanExecutor {
         // manages (its env/default path) — a custom socket path is the caller's own daemon that
         // DaemonManager can't target. No-op for HTTP transport.
         if case let .daemonUnixSocket(path) = configuration.transport, path == DaemonManager.socketPath {
-            _ = DaemonManager.ensureDaemonRunning()
+            _ = daemonEnsurer.ensureDaemonRunning(repoRoot: configuration.daemonRepoRoot)
         }
 
         for attempt in 0 ... configuration.retryCount {
@@ -907,7 +928,7 @@ public final class AutoMobilePlanExecutor {
         // Only the DaemonManager-managed (env/default) socket can be restarted here; for a custom
         // socket path (the caller's own daemon) just drop the session so the retry reconnects.
         if path == DaemonManager.socketPath {
-            _ = DaemonManager.ensureDaemonRunning()
+            _ = daemonEnsurer.ensureDaemonRunning(repoRoot: configuration.daemonRepoRoot)
         }
         mcpClient.resetSession()
     }

--- a/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileTestCase.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunner/AutoMobileTestCase.swift
@@ -83,6 +83,16 @@ open class AutoMobileTestCase: XCTestCase {
         ]) ?? AutoMobileDaemonSocket.defaultPath
     }
 
+    /// The source checkout whose built daemon should own the default shared socket. Override this
+    /// for an embedding project, or set `AUTOMOBILE_REPO_ROOT`; without a built entrypoint the
+    /// daemon manager safely falls back to the PATH-launched CLI.
+    open var daemonRepoRoot: String? {
+        if let configuredRoot = environment.firstNonEmpty(["AUTOMOBILE_REPO_ROOT"]) {
+            return configuredRoot
+        }
+        return DaemonManager.findRepoRoot(startingAt: #filePath)
+    }
+
     open var retryCount: Int {
         return environment.intValue(["AUTOMOBILE_TEST_RETRY_COUNT", "RETRY_COUNT"]) ?? 0
     }
@@ -202,6 +212,7 @@ open class AutoMobileTestCase: XCTestCase {
         return AutoMobilePlanExecutor.Configuration(
             transport: transport,
             planPath: planPath,
+            daemonRepoRoot: daemonRepoRoot,
             retryCount: retryCount,
             timeoutSeconds: timeoutSeconds,
             retryDelaySeconds: retryDelaySeconds,
@@ -405,7 +416,7 @@ open class AutoMobileTestCase: XCTestCase {
     /// (#2744) would keep rejecting the retry. Route through the version-matched ensure path, which
     /// restarts a version-skewed daemon and confirms the running version matches this runner.
     private func recoverDaemonForRetry() throws {
-        guard DaemonManager.ensureDaemonRunning() else {
+        guard DaemonManager.ensureDaemonRunning(repoRoot: daemonRepoRoot) else {
             throw AutoMobileTestCaseError.devicePoolUnavailable(
                 "AutoMobile daemon is unavailable or a different build than this runner on the "
                     + "shared socket; restart it from the same @kaeawc/auto-mobile version."

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
@@ -222,7 +222,8 @@ final class AutoMobileVersionTests: XCTestCase {
         let result = DaemonManager.ensureDaemonRunningResult(
             repoRoot: repoRoot.path,
             timeoutSeconds: 0,
-            runtime: runtime
+            runtime: runtime,
+            callerAssetVersion: nil
         )
 
         XCTAssertEqual(result, .ready)

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
@@ -145,6 +145,24 @@ final class AutoMobileVersionTests: XCTestCase {
         XCTAssertEqual(DaemonManager.resolveRepoRootDaemonEntryScript(repoRoot.path), entry.path)
     }
 
+    func testFindRepoRootFindsNearestPackageJsonAncestor() throws {
+        let repoRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("automobile-root-discovery-\(UUID().uuidString)")
+        let sourceDirectory = repoRoot.appendingPathComponent("ios/XCTestRunner/Sources/XCTestRunner")
+        try FileManager.default.createDirectory(at: sourceDirectory, withIntermediateDirectories: true)
+        try "{}".write(
+            to: repoRoot.appendingPathComponent("package.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+        defer { try? FileManager.default.removeItem(at: repoRoot) }
+
+        XCTAssertEqual(
+            DaemonManager.findRepoRoot(startingAt: sourceDirectory.appendingPathComponent("Runner.swift").path),
+            repoRoot.path
+        )
+    }
+
     func testRequiresRepoRootBuildSkew() throws {
         // No repoRoot build -> never a skew, regardless of the daemon's identity.
         XCTAssertFalse(DaemonManager.requiresRepoRootBuildSkew(
@@ -182,5 +200,92 @@ final class AutoMobileVersionTests: XCTestCase {
         XCTAssertFalse(DaemonManager.requiresRepoRootBuildSkew(
             daemonBuildId: nil, daemonEntryScript: nil, repoRoot: repoRoot.path
         ))
+    }
+
+    func testEnsureDaemonRunningRestartsSameReleaseDaemonFromDifferentCheckout() throws {
+        let repoRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("automobile-activation-\(UUID().uuidString)")
+        let distDir = repoRoot.appendingPathComponent("dist/src")
+        try FileManager.default.createDirectory(at: distDir, withIntermediateDirectories: true)
+        let entry = distDir.appendingPathComponent("index.js")
+        try "// current checkout".write(to: entry, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: repoRoot) }
+
+        let currentBuildId = try XCTUnwrap(DaemonManager.computeBuildId(entry.path))
+        let runtime = FakeDaemonRuntime(
+            daemonVersion: AutoMobileVersion.current,
+            daemonBuildId: "different-checkout",
+            daemonEntryScript: "/other-checkout/dist/src/index.js",
+            buildIdAfterRestart: currentBuildId
+        )
+
+        let result = DaemonManager.ensureDaemonRunningResult(
+            repoRoot: repoRoot.path,
+            timeoutSeconds: 0,
+            runtime: runtime
+        )
+
+        XCTAssertEqual(result, .ready)
+        XCTAssertEqual(runtime.subcommands, [.init(name: "restart", repoRoot: repoRoot.path)])
+    }
+}
+
+private final class FakeDaemonRuntime: DaemonRuntime {
+    struct Invocation: Equatable {
+        let name: String
+        let repoRoot: String?
+    }
+
+    private let daemonVersion: String?
+    private var daemonBuildId: String?
+    private let daemonEntryScript: String?
+    private let buildIdAfterRestart: String
+    private(set) var subcommands: [Invocation] = []
+
+    init(
+        daemonVersion: String?,
+        daemonBuildId: String?,
+        daemonEntryScript: String?,
+        buildIdAfterRestart: String
+    ) {
+        self.daemonVersion = daemonVersion
+        self.daemonBuildId = daemonBuildId
+        self.daemonEntryScript = daemonEntryScript
+        self.buildIdAfterRestart = buildIdAfterRestart
+    }
+
+    func isDaemonRunning() -> Bool {
+        true
+    }
+
+    func readDaemonVersion() -> String? {
+        daemonVersion
+    }
+
+    func readDaemonAssetVersion() -> String? {
+        nil
+    }
+
+    func readDaemonEntryScript() -> String? {
+        daemonEntryScript
+    }
+
+    func readDaemonBuildId() -> String? {
+        daemonBuildId
+    }
+
+    func runDaemonSubcommand(
+        _ subcommand: String,
+        repoRoot: String?
+    )
+        -> DaemonManager.DaemonSubcommandOutcome
+    {
+        subcommands.append(.init(name: subcommand, repoRoot: repoRoot))
+        daemonBuildId = buildIdAfterRestart
+        return .launched
+    }
+
+    func waitForDaemon(timeoutSeconds _: TimeInterval) -> Bool {
+        true
     }
 }

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/AutoMobileVersionTests.swift
@@ -150,7 +150,7 @@ final class AutoMobileVersionTests: XCTestCase {
             .appendingPathComponent("automobile-root-discovery-\(UUID().uuidString)")
         let sourceDirectory = repoRoot.appendingPathComponent("ios/XCTestRunner/Sources/XCTestRunner")
         try FileManager.default.createDirectory(at: sourceDirectory, withIntermediateDirectories: true)
-        try "{}".write(
+        try #"{"name": "@kaeawc/auto-mobile"}"#.write(
             to: repoRoot.appendingPathComponent("package.json"),
             atomically: true,
             encoding: .utf8
@@ -161,6 +161,26 @@ final class AutoMobileVersionTests: XCTestCase {
             DaemonManager.findRepoRoot(startingAt: sourceDirectory.appendingPathComponent("Runner.swift").path),
             repoRoot.path
         )
+    }
+
+    func testFindRepoRootSkipsHostPackageWithBuiltEntryScript() throws {
+        let hostRoot = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("automobile-host-\(UUID().uuidString)")
+        let runnerSourceDirectory = hostRoot.appendingPathComponent("vendor/XCTestRunner/Sources/XCTestRunner")
+        try FileManager.default.createDirectory(at: runnerSourceDirectory, withIntermediateDirectories: true)
+        try #"{"name": "host-project"}"#.write(
+            to: hostRoot.appendingPathComponent("package.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let hostEntry = hostRoot.appendingPathComponent("dist/src/index.js")
+        try FileManager.default.createDirectory(at: hostEntry.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "// unrelated host entry".write(to: hostEntry, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: hostRoot) }
+
+        XCTAssertNil(DaemonManager.findRepoRoot(
+            startingAt: runnerSourceDirectory.appendingPathComponent("Runner.swift").path
+        ))
     }
 
     func testRequiresRepoRootBuildSkew() throws {
@@ -184,9 +204,14 @@ final class AutoMobileVersionTests: XCTestCase {
         XCTAssertTrue(DaemonManager.requiresRepoRootBuildSkew(
             daemonBuildId: "deadbeefdeadbeef", daemonEntryScript: entry.path, repoRoot: repoRoot.path
         ))
-        // Matching build id -> no skew.
+        // Matching build id and entry path -> no skew.
         XCTAssertFalse(DaemonManager.requiresRepoRootBuildSkew(
             daemonBuildId: matchingHash, daemonEntryScript: entry.path, repoRoot: repoRoot.path
+        ))
+        // The entry-file hash can match across checkouts while copied runtime assets differ, so
+        // the daemon must still come from this checkout's expected entry path.
+        XCTAssertTrue(DaemonManager.requiresRepoRootBuildSkew(
+            daemonBuildId: matchingHash, daemonEntryScript: "/other/dist/src/index.js", repoRoot: repoRoot.path
         ))
         // No build id -> fall back to entry-script path: different path is a skew.
         XCTAssertTrue(DaemonManager.requiresRepoRootBuildSkew(
@@ -239,7 +264,7 @@ private final class FakeDaemonRuntime: DaemonRuntime {
 
     private let daemonVersion: String?
     private var daemonBuildId: String?
-    private let daemonEntryScript: String?
+    private var daemonEntryScript: String?
     private let buildIdAfterRestart: String
     private(set) var subcommands: [Invocation] = []
 
@@ -283,6 +308,10 @@ private final class FakeDaemonRuntime: DaemonRuntime {
     {
         subcommands.append(.init(name: subcommand, repoRoot: repoRoot))
         daemonBuildId = buildIdAfterRestart
+        if let repoRoot = repoRoot {
+            daemonEntryScript = URL(fileURLWithPath: repoRoot)
+                .appendingPathComponent("dist/src/index.js").path
+        }
         return .launched
     }
 

--- a/ios/XCTestRunner/Sources/XCTestRunnerTests/XCTestRunnerTests.swift
+++ b/ios/XCTestRunner/Sources/XCTestRunnerTests/XCTestRunnerTests.swift
@@ -96,6 +96,32 @@ final class XCTestRunnerTests: XCTestCase {
         XCTAssertEqual(timer.sleeps, [1])
     }
 
+    func testDaemonSocketPreflightPassesConfiguredRepoRootToDaemonManager() throws {
+        let planLoader = FakePlanLoader(content: "name: Daemon Plan\nsteps:\n  - tool: observe")
+        let mcpClient = FakeMCPClient()
+        let daemonEnsurer = FakeDaemonEnsurer()
+        let repoRoot = "/checkout/current"
+        mcpClient.queueResponse(success: true, executedSteps: 1, totalSteps: 1)
+
+        let config = AutoMobilePlanExecutor.Configuration(
+            transport: .daemonUnixSocket(path: DaemonManager.socketPath),
+            planPath: "daemon-plan.yaml",
+            daemonRepoRoot: repoRoot
+        )
+        let executor = AutoMobilePlanExecutor(
+            configuration: config,
+            planLoader: planLoader,
+            mcpClient: mcpClient,
+            timer: FakeTimer(),
+            logger: NullLogger(),
+            daemonEnsurer: daemonEnsurer
+        )
+
+        _ = try executor.execute(testMetadata: nil)
+
+        XCTAssertEqual(daemonEnsurer.repoRoots, [repoRoot])
+    }
+
     func testExecutePlanStopsAfterRetries() throws {
         let planLoader = FakePlanLoader(content: "name: Fail Plan\nsteps:\n  - tool: observe")
         let mcpClient = FakeMCPClient()
@@ -478,6 +504,15 @@ private struct NullLogger: AutoMobileLogger {
     func info(_: String) {}
     func warn(_: String) {}
     func error(_: String) {}
+}
+
+private final class FakeDaemonEnsurer: AutoMobileDaemonEnsuring {
+    private(set) var repoRoots: [String?] = []
+
+    func ensureDaemonRunning(repoRoot: String?) -> Bool {
+        repoRoots.append(repoRoot)
+        return true
+    }
 }
 
 private func decodePlanContent(from encoded: String?) -> String? {

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -940,10 +940,19 @@ export class DaemonManager implements DaemonManagerLike {
    */
   async restart(options: DaemonOptions = {}): Promise<void> {
     stderrLog("Restarting daemon...");
+    // A bare `--daemon restart` has no CLI options, but it is commonly used to
+    // replace a stale checkout. Preserve the daemon's PID-recorded options so
+    // that replacement cannot silently discard configuration such as debug,
+    // output, or accessibility flags.
+    const runningOptions = (await this.status()).options ?? {};
+    const requestedOptions = Object.fromEntries(
+      Object.entries(options).filter(([, value]) => value !== undefined)
+    ) as DaemonOptions;
+    const restartOptions: DaemonOptions = { ...runningOptions, ...requestedOptions };
     await this.stop();
     // Wait a bit before starting
     await this.timer.sleep(1000);
-    await this.start(options);
+    await this.start(restartOptions);
   }
 
   /**

--- a/src/server/barrierTools.ts
+++ b/src/server/barrierTools.ts
@@ -95,7 +95,7 @@ export function registerBarrierTools(): void {
     // Plan-only: a multi-device coordination primitive that only makes sense as
     // a plan step (a single direct call would just block). Hidden from tools/list
     // discovery, still runnable in plans via getToolForPlan.
-    { planOnly: true, planExecutable: true }
+    { planOnly: true, planExecutable: true, acceptsPlanLockNamespace: true }
   );
 
   logger.info("Barrier tools registered");

--- a/src/server/criticalSectionTools.ts
+++ b/src/server/criticalSectionTools.ts
@@ -235,7 +235,7 @@ export function registerCriticalSectionTools(): void {
     // Plan-only: a multi-device coordination primitive that only makes sense as
     // a plan step (a single direct call would just block). Hidden from tools/list
     // discovery, still runnable in plans via getToolForPlan.
-    { planOnly: true, planExecutable: true }
+    { planOnly: true, planExecutable: true, acceptsPlanLockNamespace: true }
   );
 
   logger.info("Critical section tools registered");

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -79,6 +79,8 @@ interface ToolRegistrationOptions {
   supportsProgress?: boolean;
   debugOnly?: boolean;
   outputSchema?: any;
+  /** Accept the plan executor's internal coordination namespace. */
+  acceptsPlanLockNamespace?: boolean;
 }
 
 interface DeviceAwareToolOptions<T = any> extends ToolRegistrationOptions {
@@ -114,6 +116,7 @@ export interface RegisteredTool {
   embeddedSdkOnly?: boolean;
   planExecutable?: boolean;
   planOnly?: boolean;
+  acceptsPlanLockNamespace?: boolean;
   outputSchema?: any;
 }
 
@@ -791,6 +794,7 @@ export class ToolRegistryClass {
       requiresDevice: false,
       debugOnly: options.debugOnly ?? false,
       embeddedSdkOnly: false,
+      acceptsPlanLockNamespace: options.acceptsPlanLockNamespace ?? false,
       outputSchema: options.outputSchema
     });
   }
@@ -894,6 +898,7 @@ export class ToolRegistryClass {
       embeddedSdkOnly: options.embeddedSdkOnly ?? false,
       planExecutable: options.planExecutable ?? false,
       planOnly: options.planOnly ?? false,
+      acceptsPlanLockNamespace: options.acceptsPlanLockNamespace ?? false,
       outputSchema: options.outputSchema
     });
   }

--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -349,11 +349,10 @@ export class DefaultPlanExecutor implements PlanExecutor {
 
     // Scope the shared CriticalSectionCoordinator by the plan's base session UUID
     // (identical across every device track of one plan, distinct across plans),
-    // so two concurrent plans reusing a lock name get isolated barriers. Only the
-    // criticalSection/barrier schemas declare __lockNamespace, so every other
-    // tool strips it at schema.parse; resolveExecutionTarget ignores __-params,
-    // so device routing is unaffected.
-    if (sessionUuid && !enhancedParams.__lockNamespace) {
+    // so two concurrent plans reusing a lock name get isolated barriers. Strict
+    // schemas reject unknown keys, so only explicitly opted-in coordination tools
+    // may receive the internal namespace.
+    if (tool.acceptsPlanLockNamespace && sessionUuid && !enhancedParams.__lockNamespace) {
       enhancedParams.__lockNamespace = sessionUuid;
     }
 

--- a/test/daemon/manager.test.ts
+++ b/test/daemon/manager.test.ts
@@ -16,7 +16,7 @@ import {
 } from "../../src/daemon/manager";
 import { DaemonLauncher } from "../../src/daemon/DaemonLauncher";
 import type { BuildIdentity } from "../../src/daemon/buildIdentity";
-import type { DaemonStatus } from "../../src/daemon/types";
+import type { DaemonOptions, DaemonStatus } from "../../src/daemon/types";
 import type {
   DaemonProcessFinder,
   DaemonProcessLivenessChecker,
@@ -75,6 +75,31 @@ describe("daemonBuildIdentityStatusLines", () => {
     expect(text).toContain("1111111111111111");
     expect(text).toContain("/wt/dist/src/index.js");
     expect(text).toContain("--daemon restart");
+  });
+});
+
+describe("DaemonManager restart", () => {
+  test("preserves PID-recorded options when no replacement options are requested", async () => {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const manager = new DaemonManager(undefined, undefined, timer);
+    const recordedOptions: DaemonOptions = {
+      debug: true,
+      toolOutputsDir: "/tmp/automobile-artifacts",
+      eventAllMarkers: ["@", "#"],
+    };
+    const statusSpy = spyOn(manager, "status").mockResolvedValue({
+      running: true,
+      options: recordedOptions,
+    });
+    const stopSpy = spyOn(manager, "stop").mockResolvedValue(undefined);
+    const startSpy = spyOn(manager, "start").mockResolvedValue(undefined);
+
+    await manager.restart();
+
+    expect(statusSpy).toHaveBeenCalledTimes(1);
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+    expect(startSpy).toHaveBeenCalledWith(recordedOptions);
   });
 });
 

--- a/test/plan/planExecutorSessionRouting.test.ts
+++ b/test/plan/planExecutorSessionRouting.test.ts
@@ -255,7 +255,8 @@ describe("PlanExecutor - Session-based Device Routing", () => {
       "testLockNamespaceTool",
       "Test tool that declares __lockNamespace",
       testToolSchema,
-      mockHandler
+      mockHandler,
+      { acceptsPlanLockNamespace: true }
     );
     (ToolRegistry.getTool("testLockNamespaceTool")! as any).requiresDevice = true;
 
@@ -285,7 +286,7 @@ describe("PlanExecutor - Session-based Device Routing", () => {
       platform: z.string().optional(),
       sessionUuid: z.string().optional(),
       testParam: z.string().optional(),
-    });
+    }).strict();
 
     ToolRegistry.register(
       "testNoLockNamespaceTool",


### PR DESCRIPTION
## Summary

Activates the iOS XCTestRunner checkout-aware daemon build-identity path for [#2808](https://github.com/kaeawc/auto-mobile/issues/2808).

- Derives the AutoMobile repository root from the runner source (or `AUTOMOBILE_REPO_ROOT`) and routes daemon preflight/recovery through that checkout's built entrypoint.
- Restarts a same-release daemon when its PID metadata identifies a different checkout, preventing it from serving a mismatched XCTestRunner.
- Preserves the running daemon's PID-recorded launch options during that restart.
- Adds injectable daemon lifecycle seams and regression coverage for the restart and executor propagation paths.
- Fixes the plan executor's internal `__lockNamespace` injection so strict schemas receive it only for the opted-in `barrier` and `criticalSection` coordination tools.
- Documents the checkout-aware behavior and `AUTOMOBILE_REPO_ROOT` in the iOS hermetic CI recipe.

## Why

The build-identity detection added in [#2749](https://github.com/kaeawc/auto-mobile/pull/2749) was dormant because XCTestRunner never supplied a repository root. That left same-release daemons from a different checkout eligible for reuse.

## Validation

- `swift test` in `ios/XCTestRunner` — 83 tests, 0 failures (2 live-device tests skipped because no simulator was booted)
- `bun test test/plan/planExecutorSessionRouting.test.ts`
- `bun run typecheck`
- `bun run turbo:validate`
- `ONLY_TOUCHED_FILES=true bash scripts/swiftlint/validate_swiftlint.sh` — 0 errors
- `git diff --check`

`swiftformat --lint` still reports pre-existing formatting violations on `origin/main` in the touched Swift files; this PR does not expand into an unrelated formatting cleanup.

Closes [#2808](https://github.com/kaeawc/auto-mobile/issues/2808).
