### PR TITLE
fix(navigation): preserve Android session graph workflow

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -1614,7 +1614,7 @@
   },
   {
     "name": "getNavigationGraph",
-    "description": "Get navigation graph for debugging",
+    "description": "Get navigation graph",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -1614,7 +1614,7 @@
   },
   {
     "name": "getNavigationGraph",
-    "description": "Get navigation graph",
+    "description": "Get navigation graph for debugging",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",

--- a/src/features/navigation/NavigateTo.ts
+++ b/src/features/navigation/NavigateTo.ts
@@ -12,6 +12,7 @@ import {
 } from "./NavigationGraphManager";
 import { ProgressCallback } from "../../server/toolRegistry";
 import { SmartNavigationHelper } from "./SmartNavigationHelper";
+import type { PathOptimizer } from "./interfaces/PathOptimizer";
 import { UIStateSetup } from "./interfaces/UIStateSetup";
 import { DefaultUIStateSetup } from "./DefaultUIStateSetup";
 import { ScreenTransitionWaiter } from "./interfaces/ScreenTransitionWaiter";
@@ -40,6 +41,7 @@ export class NavigateTo {
   private uiStateSetup: UIStateSetup;
   private screenWaiter: ScreenTransitionWaiter;
   private timer: Timer;
+  private pathOptimizer: PathOptimizer | undefined;
 
   private static readonly MAX_TIMEOUT_MS = 30000; // 30 seconds
   private static readonly STEP_TIMEOUT_MS = 5000; // 5 seconds per step
@@ -51,13 +53,15 @@ export class NavigateTo {
     uiStateSetup: UIStateSetup | null = null,
     screenWaiter: ScreenTransitionWaiter | null = null,
     navigationManager?: NavigationGraphService,
-    timer: Timer = defaultTimer
+    timer: Timer = defaultTimer,
+    pathOptimizer?: PathOptimizer
   ) {
     this.device = device;
     this.adbFactory = adbFactory;
     this.adb = adbFactory.create(device);
     this.navigationManager = navigationManager ?? NavigationGraphManager.getInstance();
     this.timer = timer;
+    this.pathOptimizer = pathOptimizer;
 
     // Use injected dependencies or create defaults
     this.uiStateSetup = uiStateSetup || new DefaultUIStateSetup(this.device, this.adb);
@@ -114,7 +118,7 @@ export class NavigateTo {
       const currentBackStackDepth = currentNode?.backStackDepth ?? 0;
 
       if (currentBackStackDepth > 0) {
-        const backNavResult = await SmartNavigationHelper.shouldUseBackButton(
+        const backNavResult = await (this.pathOptimizer ?? SmartNavigationHelper).shouldUseBackButton(
           currentScreen,
           targetScreen,
           currentBackStackDepth

--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -216,6 +216,19 @@ export class NavigationGraphManager implements NavigationGraphService {
   }
 
   /**
+   * Install a session-scoped instance for testing only.
+   *
+   * This preserves the production session lookup path while allowing focused
+   * tests to use an in-memory database instead of the shared file database.
+   */
+  public static setInstanceForSessionForTesting(
+    sessionId: string,
+    instance: NavigationGraphManager
+  ): void {
+    NavigationGraphManager.sessionInstances.set(sessionId, instance);
+  }
+
+  /**
    * Create a new instance for testing with injected dependencies.
    *
    * Precondition for recordNavigationEvent's atomicity: `repository` and
@@ -233,9 +246,10 @@ export class NavigationGraphManager implements NavigationGraphService {
    */
   public static createForTesting(
     repository?: NavigationRepository,
-    testCoverageRepository?: TestCoverageRepository
+    testCoverageRepository?: TestCoverageRepository,
+    timer?: Timer
   ): NavigationGraphManager {
-    return new NavigationGraphManager(repository, testCoverageRepository);
+    return new NavigationGraphManager(repository, testCoverageRepository, timer);
   }
 
   /**

--- a/src/server/navigationTools.ts
+++ b/src/server/navigationTools.ts
@@ -3,6 +3,7 @@ import { ToolRegistry, ProgressCallback } from "./toolRegistry";
 import { ActionableError, BootedDevice } from "../models";
 import { NavigateTo, NavigateToOptions } from "../features/navigation/NavigateTo";
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
+import { DefaultPathOptimizer } from "../features/navigation/DefaultPathOptimizer";
 import { Explore, ExploreOptions } from "../features/navigation/Explore";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { Platform } from "../models";
@@ -63,12 +64,15 @@ export function registerNavigationTools() {
     progress?: ProgressCallback
   ) => {
     try {
+      const navigationManager = getNavigationManager(args.sessionUuid);
       const navigateTo = new NavigateTo(
         device,
         undefined,
         null,
         null,
-        getNavigationManager(args.sessionUuid)
+        navigationManager,
+        undefined,
+        new DefaultPathOptimizer(navigationManager)
       );
       const options: NavigateToOptions = {
         targetScreen: args.targetScreen,

--- a/src/server/navigationTools.ts
+++ b/src/server/navigationTools.ts
@@ -35,14 +35,23 @@ export const exploreSchema = addDeviceTargetingToSchema(z.object({
 export interface NavigateToArgs {
   targetScreen: string;
   platform: Platform;
+  sessionUuid?: string;
 }
 
 export interface GetNavigationGraphArgs {
   platform: Platform;
+  sessionUuid?: string;
 }
 
 export interface ExploreArgs extends ExploreOptions {
   platform: Platform;
+  sessionUuid?: string;
+}
+
+function getNavigationManager(sessionUuid?: string): NavigationGraphManager {
+  return sessionUuid
+    ? NavigationGraphManager.getInstanceForSession(sessionUuid)
+    : NavigationGraphManager.getInstance();
 }
 
 // Register navigation tools
@@ -54,7 +63,13 @@ export function registerNavigationTools() {
     progress?: ProgressCallback
   ) => {
     try {
-      const navigateTo = new NavigateTo(device);
+      const navigateTo = new NavigateTo(
+        device,
+        undefined,
+        null,
+        null,
+        getNavigationManager(args.sessionUuid)
+      );
       const options: NavigateToOptions = {
         targetScreen: args.targetScreen,
         platform: args.platform || "android"
@@ -83,9 +98,7 @@ export function registerNavigationTools() {
     args: GetNavigationGraphArgs
   ) => {
     try {
-      const manager = args.sessionUuid
-        ? NavigationGraphManager.getInstanceForSession(args.sessionUuid)
-        : NavigationGraphManager.getInstance();
+      const manager = getNavigationManager(args.sessionUuid);
       const stats = await manager.getStats();
       const graph = await manager.exportGraph();
 
@@ -116,9 +129,9 @@ export function registerNavigationTools() {
   };
 
   // Register with the tool registry
-  ToolRegistry.registerDeviceAware("navigateTo", "Navigate to screen using navigation graph", navigateToSchema, navigateToHandler, { supportsProgress: true });
+  ToolRegistry.registerDeviceAware("navigateTo", "Navigate to screen using navigation graph", navigateToSchema, navigateToHandler, { supportsProgress: true, debugOnly: true });
 
-  ToolRegistry.registerDeviceAware("getNavigationGraph", "Get navigation graph", getNavigationGraphSchema, getNavigationGraphHandler);
+  ToolRegistry.registerDeviceAware("getNavigationGraph", "Get navigation graph for debugging", getNavigationGraphSchema, getNavigationGraphHandler, { debugOnly: true });
 
   // Explore handler
   const exploreHandler = async (
@@ -128,7 +141,7 @@ export function registerNavigationTools() {
     signal?: AbortSignal
   ) => {
     try {
-      const explore = new Explore(device);
+      const explore = new Explore(device, null, undefined, getNavigationManager(args.sessionUuid));
       const options: ExploreOptions = {
         maxInteractions: args.maxInteractions,
         timeoutMs: args.timeoutMs,
@@ -157,5 +170,5 @@ export function registerNavigationTools() {
     }
   };
 
-  ToolRegistry.registerDeviceAware("explore", "Automatically explore app to build navigation graph", exploreSchema, exploreHandler, { supportsProgress: true });
+  ToolRegistry.registerDeviceAware("explore", "Automatically explore app to build navigation graph", exploreSchema, exploreHandler, { supportsProgress: true, debugOnly: true });
 }

--- a/src/server/navigationTools.ts
+++ b/src/server/navigationTools.ts
@@ -116,9 +116,9 @@ export function registerNavigationTools() {
   };
 
   // Register with the tool registry
-  ToolRegistry.registerDeviceAware("navigateTo", "Navigate to screen using navigation graph", navigateToSchema, navigateToHandler, { supportsProgress: true, debugOnly: true });
+  ToolRegistry.registerDeviceAware("navigateTo", "Navigate to screen using navigation graph", navigateToSchema, navigateToHandler, { supportsProgress: true });
 
-  ToolRegistry.registerDeviceAware("getNavigationGraph", "Get navigation graph for debugging", getNavigationGraphSchema, getNavigationGraphHandler, { debugOnly: true });
+  ToolRegistry.registerDeviceAware("getNavigationGraph", "Get navigation graph", getNavigationGraphSchema, getNavigationGraphHandler);
 
   // Explore handler
   const exploreHandler = async (
@@ -157,5 +157,5 @@ export function registerNavigationTools() {
     }
   };
 
-  ToolRegistry.registerDeviceAware("explore", "Automatically explore app to build navigation graph", exploreSchema, exploreHandler, { supportsProgress: true, debugOnly: true });
+  ToolRegistry.registerDeviceAware("explore", "Automatically explore app to build navigation graph", exploreSchema, exploreHandler, { supportsProgress: true });
 }

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -284,8 +284,13 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
       const implicitSessionUuid = this.resolveImplicitAutolockSession(platform, sessionUuid, providedDeviceId, mcpSessionId);
       if (implicitSessionUuid) {
         sessionUuid = implicitSessionUuid;
-        args.sessionUuid = implicitSessionUuid;
         logger.info(`[ToolRegistry] Resolved implicit autolock session for MCP session ${mcpSessionId}: ${implicitSessionUuid}`);
+      }
+      if (sessionUuid) {
+        // Handlers must use the resolved label or implicit session, not the
+        // caller's base session, so session-scoped state stays on the device
+        // that ToolRegistry selected.
+        args.sessionUuid = sessionUuid;
       }
       await this.enforceSessionUuidForMultipleIos(platform, sessionUuid, providedDeviceId, deviceSessionManager);
       await this.enforceSessionUuidForAutolock(platform, sessionUuid, providedDeviceId, deviceSessionManager);

--- a/test/server/androidNavigationWorkflow.test.ts
+++ b/test/server/androidNavigationWorkflow.test.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import type { BootedDevice } from "../../src/models";
 import { Explore } from "../../src/features/navigation/Explore";
 import { NavigationGraphManager } from "../../src/features/navigation/NavigationGraphManager";
+import { DefaultPathOptimizer } from "../../src/features/navigation/DefaultPathOptimizer";
 import { NavigationRepository } from "../../src/db/navigationRepository";
 import { TestCoverageRepository } from "../../src/db/testCoverageRepository";
 import { createMcpServer } from "../../src/server/index";
@@ -81,6 +82,7 @@ describe("Android navigation graph workflow (#4459)", () => {
       sequenceNumber: 1,
       applicationId: appId,
     });
+    await sessionManager.recordBackStack({ depth: 0, currentTaskId: 1 });
 
     let replayedArgs: Record<string, unknown> | undefined;
     ToolRegistry.register(
@@ -161,6 +163,13 @@ describe("Android navigation graph workflow (#4459)", () => {
       to: "Settings",
       tool: "tapOn",
     }));
+    await sessionManager.recordBackStack({ depth: 1, currentTaskId: 1 });
+    const backRecommendation = await new DefaultPathOptimizer(sessionManager).shouldUseBackButton(
+      "Settings",
+      "Home",
+      1
+    );
+    expect(backRecommendation).toMatchObject({ shouldUseBack: true, backPresses: 1 });
 
     await sessionManager.recordNavigationEvent({
       destination: "Home",

--- a/test/server/androidNavigationWorkflow.test.ts
+++ b/test/server/androidNavigationWorkflow.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { z } from "zod";
+import type { BootedDevice } from "../../src/models";
+import { NavigateTo } from "../../src/features/navigation/NavigateTo";
+import { registerNavigationTools } from "../../src/server/navigationTools";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { createJSONToolResponse } from "../../src/utils/toolUtils";
+import { setDebugModeEnabled } from "../../src/utils/debug";
+import { installInMemoryNavManager, type InMemoryNavManagerHarness } from "../helpers/navigationTestHarness";
+import { FakeAdbClientFactory } from "../fakes/FakeAdbClientFactory";
+import { FakeTimer } from "../fakes/FakeTimer";
+import type { ScreenTransitionWaiter } from "../../src/features/navigation/interfaces/ScreenTransitionWaiter";
+import type { UIStateSetup } from "../../src/features/navigation/interfaces/UIStateSetup";
+
+describe("Android navigation graph workflow (#4459)", () => {
+  const device: BootedDevice = {
+    deviceId: "emulator-5554",
+    name: "Pixel API 35",
+    platform: "android",
+  };
+  const appId = "com.example.navigation-fixture";
+  let harness: InMemoryNavManagerHarness;
+
+  beforeEach(async () => {
+    ToolRegistry.clearTools();
+    setDebugModeEnabled(false);
+    harness = await installInMemoryNavManager();
+  });
+
+  afterEach(async () => {
+    ToolRegistry.clearTools();
+    setDebugModeEnabled(false);
+    await harness.dispose();
+  });
+
+  test("creates and inspects a graph, replays its learned Android path, and serves every navigation tool without --debug", async () => {
+    const homeTimestamp = Date.now();
+    await harness.manager.recordNavigationEvent({
+      destination: "Home",
+      source: "ANDROID_FIXTURE",
+      arguments: {},
+      metadata: {},
+      timestamp: homeTimestamp,
+      sequenceNumber: 1,
+      applicationId: appId,
+    });
+    harness.manager.recordToolCall("tapOn", { text: "Settings", action: "tap", platform: "android" });
+    const settingsTimestamp = Date.now();
+    await harness.manager.recordNavigationEvent({
+      destination: "Settings",
+      source: "ANDROID_FIXTURE",
+      arguments: {},
+      metadata: {},
+      timestamp: settingsTimestamp,
+      sequenceNumber: 2,
+      applicationId: appId,
+    });
+    const returnHomeTimestamp = Date.now();
+    await harness.manager.recordNavigationEvent({
+      destination: "Home",
+      source: "ANDROID_FIXTURE",
+      arguments: {},
+      metadata: {},
+      timestamp: returnHomeTimestamp,
+      sequenceNumber: 3,
+      applicationId: appId,
+    });
+
+    let replayedArgs: Record<string, unknown> | undefined;
+    ToolRegistry.register(
+      "tapOn",
+      "Deterministic Android fixture tap",
+      z.object({}),
+      async args => {
+        replayedArgs = args;
+        await harness.manager.recordNavigationEvent({
+          destination: "Settings",
+          source: "ANDROID_FIXTURE",
+          arguments: {},
+          metadata: {},
+          timestamp: Date.now(),
+          sequenceNumber: 4,
+          applicationId: appId,
+        });
+        return createJSONToolResponse({ success: true });
+      }
+    );
+    registerNavigationTools();
+
+    const served = new Map(ToolRegistry.getAllTools().map(tool => [tool.name, tool]));
+    for (const name of ["explore", "navigateTo", "getNavigationGraph"]) {
+      expect(served.get(name)?.requiresDevice).toBe(true);
+    }
+
+    const graphTool = ToolRegistry.getTool("getNavigationGraph");
+    expect(graphTool).toBeDefined();
+    const graphResponse = await graphTool!.deviceAwareHandler!(device, { platform: "android" });
+    const graph = JSON.parse(graphResponse.content[0].text);
+    expect(graph).toMatchObject({
+      currentScreen: "Home",
+      nodeCount: 2,
+      edgeCount: 2,
+      knownEdges: 2,
+      unknownEdges: 0,
+    });
+    expect(graph.screens.map((screen: { name: string }) => screen.name)).toEqual(["Home", "Settings"]);
+    expect(graph.transitions).toContainEqual(expect.objectContaining({
+      from: "Home",
+      to: "Settings",
+      tool: "tapOn",
+    }));
+
+    const uiStateSetup: UIStateSetup = {
+      setupUIState: async () => [],
+      setupScrollPosition: async () => null,
+    };
+    const screenWaiter: ScreenTransitionWaiter = {
+      waitForScreen: async screen => harness.manager.getCurrentScreen() === screen,
+    };
+    const timer = new FakeTimer();
+    const navigateTo = new NavigateTo(
+      device,
+      new FakeAdbClientFactory(),
+      uiStateSetup,
+      screenWaiter,
+      harness.manager,
+      timer
+    );
+
+    const result = await navigateTo.execute({ targetScreen: "Settings", platform: "android" });
+
+    expect(result).toMatchObject({
+      success: true,
+      currentScreen: "Settings",
+      targetScreen: "Settings",
+      stepsExecuted: 1,
+    });
+    expect(replayedArgs).toMatchObject({ text: "Settings", action: "tap", platform: "android" });
+  });
+});

--- a/test/server/androidNavigationWorkflow.test.ts
+++ b/test/server/androidNavigationWorkflow.test.ts
@@ -1,16 +1,19 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { z } from "zod";
 import type { BootedDevice } from "../../src/models";
-import { NavigateTo } from "../../src/features/navigation/NavigateTo";
+import { Explore } from "../../src/features/navigation/Explore";
+import { NavigationGraphManager } from "../../src/features/navigation/NavigationGraphManager";
+import { NavigationRepository } from "../../src/db/navigationRepository";
+import { TestCoverageRepository } from "../../src/db/testCoverageRepository";
+import { createMcpServer } from "../../src/server/index";
 import { registerNavigationTools } from "../../src/server/navigationTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import { createJSONToolResponse } from "../../src/utils/toolUtils";
 import { setDebugModeEnabled } from "../../src/utils/debug";
 import { installInMemoryNavManager, type InMemoryNavManagerHarness } from "../helpers/navigationTestHarness";
-import { FakeAdbClientFactory } from "../fakes/FakeAdbClientFactory";
 import { FakeTimer } from "../fakes/FakeTimer";
-import type { ScreenTransitionWaiter } from "../../src/features/navigation/interfaces/ScreenTransitionWaiter";
-import type { UIStateSetup } from "../../src/features/navigation/interfaces/UIStateSetup";
 
 describe("Android navigation graph workflow (#4459)", () => {
   const device: BootedDevice = {
@@ -33,36 +36,49 @@ describe("Android navigation graph workflow (#4459)", () => {
     await harness.dispose();
   });
 
-  test("creates and inspects a graph, replays its learned Android path, and serves every navigation tool without --debug", async () => {
-    const homeTimestamp = Date.now();
-    await harness.manager.recordNavigationEvent({
+  test("serves the debug-gated navigation tools through MCP tools/list", async () => {
+    setDebugModeEnabled(true);
+    const server = createMcpServer();
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const client = new Client({ name: "navigation-workflow-test", version: "0.0.1" });
+    await client.connect(clientTransport);
+
+    try {
+      const result = await client.request({ method: "tools/list", params: {} }, z.object({
+        tools: z.array(z.object({ name: z.string() }).passthrough())
+      }));
+      const toolNames = result.tools.map(tool => tool.name);
+
+      expect(toolNames).toEqual(expect.arrayContaining([
+        "explore",
+        "getNavigationGraph",
+        "navigateTo",
+      ]));
+    } finally {
+      await client.close();
+    }
+  });
+
+  test("discovers, inspects, and replays a learned Android path within one session", async () => {
+    const sessionUuid = "android-navigation-session";
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const sessionManager = NavigationGraphManager.createForTesting(
+      new NavigationRepository(harness.db),
+      new TestCoverageRepository(undefined, harness.db),
+      timer
+    );
+    NavigationGraphManager.setInstanceForSessionForTesting(sessionUuid, sessionManager);
+    expect(harness.manager.getCurrentScreen()).toBeNull();
+
+    await sessionManager.recordNavigationEvent({
       destination: "Home",
       source: "ANDROID_FIXTURE",
       arguments: {},
       metadata: {},
-      timestamp: homeTimestamp,
+      timestamp: 1,
       sequenceNumber: 1,
-      applicationId: appId,
-    });
-    harness.manager.recordToolCall("tapOn", { text: "Settings", action: "tap", platform: "android" });
-    const settingsTimestamp = Date.now();
-    await harness.manager.recordNavigationEvent({
-      destination: "Settings",
-      source: "ANDROID_FIXTURE",
-      arguments: {},
-      metadata: {},
-      timestamp: settingsTimestamp,
-      sequenceNumber: 2,
-      applicationId: appId,
-    });
-    const returnHomeTimestamp = Date.now();
-    await harness.manager.recordNavigationEvent({
-      destination: "Home",
-      source: "ANDROID_FIXTURE",
-      arguments: {},
-      metadata: {},
-      timestamp: returnHomeTimestamp,
-      sequenceNumber: 3,
       applicationId: appId,
     });
 
@@ -73,34 +89,70 @@ describe("Android navigation graph workflow (#4459)", () => {
       z.object({}),
       async args => {
         replayedArgs = args;
-        await harness.manager.recordNavigationEvent({
+        await sessionManager.recordNavigationEvent({
           destination: "Settings",
           source: "ANDROID_FIXTURE",
           arguments: {},
           metadata: {},
-          timestamp: Date.now(),
-          sequenceNumber: 4,
+          timestamp: 3,
+          sequenceNumber: 3,
           applicationId: appId,
         });
         return createJSONToolResponse({ success: true });
       }
     );
-    registerNavigationTools();
+    const explore = new Explore(device, { executeCommand: async () => "" } as never, timer, sessionManager);
+    (explore as any).observeScreen = {
+      execute: async () => ({
+        viewHierarchy: {
+          hierarchy: {
+            node: [{
+              $: {
+                "class": "android.widget.Button",
+                "text": "Settings",
+                "resource-id": "com.example:id/settings",
+                "clickable": "true",
+                "enabled": "true",
+              },
+              bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+            }],
+          },
+          packageName: appId,
+        },
+      }),
+    };
+    (explore as any).performInteraction = async () => {
+      sessionManager.recordToolCall("tapOn", { text: "Settings", action: "tap", platform: "android" });
+      await sessionManager.recordNavigationEvent({
+        destination: "Settings",
+        source: "ANDROID_FIXTURE",
+        arguments: {},
+        metadata: {},
+        timestamp: 2,
+        sequenceNumber: 2,
+        applicationId: appId,
+      });
+      return true;
+    };
+    const exploration = await explore.execute({
+      maxInteractions: 1,
+      timeoutMs: 5000,
+      packageName: appId,
+    });
+    expect(exploration).toMatchObject({ success: true, interactionsPerformed: 1, screensDiscovered: 1 });
 
-    const served = new Map(ToolRegistry.getAllTools().map(tool => [tool.name, tool]));
-    for (const name of ["explore", "navigateTo", "getNavigationGraph"]) {
-      expect(served.get(name)?.requiresDevice).toBe(true);
-    }
+    setDebugModeEnabled(true);
+    registerNavigationTools();
 
     const graphTool = ToolRegistry.getTool("getNavigationGraph");
     expect(graphTool).toBeDefined();
-    const graphResponse = await graphTool!.deviceAwareHandler!(device, { platform: "android" });
+    const graphResponse = await graphTool!.deviceAwareHandler!(device, { platform: "android", sessionUuid });
     const graph = JSON.parse(graphResponse.content[0].text);
     expect(graph).toMatchObject({
-      currentScreen: "Home",
+      currentScreen: "Settings",
       nodeCount: 2,
-      edgeCount: 2,
-      knownEdges: 2,
+      edgeCount: 1,
+      knownEdges: 1,
       unknownEdges: 0,
     });
     expect(graph.screens.map((screen: { name: string }) => screen.name)).toEqual(["Home", "Settings"]);
@@ -110,25 +162,22 @@ describe("Android navigation graph workflow (#4459)", () => {
       tool: "tapOn",
     }));
 
-    const uiStateSetup: UIStateSetup = {
-      setupUIState: async () => [],
-      setupScrollPosition: async () => null,
-    };
-    const screenWaiter: ScreenTransitionWaiter = {
-      waitForScreen: async screen => harness.manager.getCurrentScreen() === screen,
-    };
-    const timer = new FakeTimer();
-    const navigateTo = new NavigateTo(
-      device,
-      new FakeAdbClientFactory(),
-      uiStateSetup,
-      screenWaiter,
-      harness.manager,
-      timer
-    );
-
-    const result = await navigateTo.execute({ targetScreen: "Settings", platform: "android" });
-
+    await sessionManager.recordNavigationEvent({
+      destination: "Home",
+      source: "ANDROID_FIXTURE",
+      arguments: {},
+      metadata: {},
+      timestamp: 4,
+      sequenceNumber: 4,
+      applicationId: appId,
+    });
+    const navigateTool = ToolRegistry.getTool("navigateTo");
+    const response = await navigateTool!.deviceAwareHandler!(device, {
+      targetScreen: "Settings",
+      platform: "android",
+      sessionUuid,
+    });
+    const result = JSON.parse(response.content[0].text);
     expect(result).toMatchObject({
       success: true,
       currentScreen: "Settings",

--- a/test/server/toolRegistration.test.ts
+++ b/test/server/toolRegistration.test.ts
@@ -118,6 +118,9 @@ class ToolRegistrationValidator {
     "mockNetwork",
     "clearMockNetwork",
     "getNetworkGraph",
+    "explore",
+    "getNavigationGraph",
+    "navigateTo",
 
     // Feature-flag controlled tools
     "criticalSection",

--- a/test/server/toolRegistration.test.ts
+++ b/test/server/toolRegistration.test.ts
@@ -123,8 +123,6 @@ class ToolRegistrationValidator {
     "criticalSection",
     "executePlan",
 
-    // Resource-only tools (exposed as resources, not tools)
-    "getNavigationGraph",
   ]);
 
   extractSchemaNames(module: ToolModule): string[] {


### PR DESCRIPTION
## Summary

- Keep `explore`, `navigateTo`, and `getNavigationGraph` debug-gated while [iOS graph workflow parity](https://github.com/kaeawc/auto-mobile/issues/4460) remains open.
- Route graph exploration and learned-path replay through the caller's session-scoped graph, matching graph inspection.
- Cover deterministic Android graph discovery, inspection, replay, and actual debug `tools/list` exposure.

This is the Android validation portion of [issue #4459](https://github.com/kaeawc/auto-mobile/issues/4459). It intentionally does not close that issue: normal tool publication, plugin updates, and user documentation remain gated on [issue #4460](https://github.com/kaeawc/auto-mobile/issues/4460).

## Validation

- `bun test test/server/androidNavigationWorkflow.test.ts test/server/toolRegistration.test.ts`
- `bun run build`
- `bun run benchmark-context`
- `bun run typecheck` (no new errors; 211 baseline errors)
- `bun run turbo:validate` ran build, tests, and boundary checks; its lint task remains blocked by the pre-existing direct-`simctl` guard findings in untouched files.
