### PR TITLE
test(action): property-based tests for press-button and auto-input policy

### DIFF
--- a/test/features/action/pressButtonPolicy.property.test.ts
+++ b/test/features/action/pressButtonPolicy.property.test.ts
@@ -13,8 +13,10 @@ const NAV_BUTTONS = ["back", "home", "recent", "power"] as const;
 const IN_PLACE_BUTTONS = ["menu", "volume_up", "volume_down"] as const;
 const ALL_BUTTONS = [...NAV_BUTTONS, ...IN_PLACE_BUTTONS];
 const KEY_CODES = new Set([3, 4, 82, 26, 24, 25, 187]);
-// Object.prototype members that a naive `{}` map would leak (issue #4187).
-const PROTO_KEYS = ["constructor", "toString", "__proto__", "hasOwnProperty", "valueOf", "isPrototypeOf"];
+// EVERY Object.prototype member a naive `{}` map could leak (issue #4187) —
+// derived from the runtime so a future normal-object + denylist regression that
+// omits one (e.g. __defineGetter__) can't slip past a hand-picked subset.
+const PROTO_KEYS = Object.getOwnPropertyNames(Object.prototype);
 
 const mixedCase = (word: string): fc.Arbitrary<string> =>
   fc.array(fc.boolean(), { minLength: word.length, maxLength: word.length })
@@ -79,7 +81,7 @@ describe("resolveAndroidKeyCode (property-based)", () => {
 
   test("never leaks an Object.prototype member (issue #4187)", () => {
     fc.assert(
-      fc.property(fc.constantFrom(...PROTO_KEYS).chain(mixedCase), key => resolveAndroidKeyCode(key) === undefined),
+      fc.property(fc.constantFrom(...PROTO_KEYS), key => resolveAndroidKeyCode(key) === undefined),
       RUN_OPTIONS
     );
   });

--- a/test/features/action/pressButtonPolicy.property.test.ts
+++ b/test/features/action/pressButtonPolicy.property.test.ts
@@ -1,0 +1,95 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import {
+  isInPlacePressButton,
+  isNavigationPressButton,
+  resolveAndroidKeyCode
+} from "../../../src/features/action/pressButtonPolicy";
+
+// Property-based tests. See test/utils/Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+const NAV_BUTTONS = ["back", "home", "recent", "power"] as const;
+const IN_PLACE_BUTTONS = ["menu", "volume_up", "volume_down"] as const;
+const ALL_BUTTONS = [...NAV_BUTTONS, ...IN_PLACE_BUTTONS];
+const KEY_CODES = new Set([3, 4, 82, 26, 24, 25, 187]);
+// Object.prototype members that a naive `{}` map would leak (issue #4187).
+const PROTO_KEYS = ["constructor", "toString", "__proto__", "hasOwnProperty", "valueOf", "isPrototypeOf"];
+
+const mixedCase = (word: string): fc.Arbitrary<string> =>
+  fc.array(fc.boolean(), { minLength: word.length, maxLength: word.length })
+    .map(bits => word.split("").map((ch, i) => (bits[i] ? ch.toUpperCase() : ch)).join(""));
+
+const knownButton = fc.constantFrom(...ALL_BUTTONS);
+// A grab-bag exercising every branch: known buttons, prototype keys, randoms.
+const anyButtonName = fc.oneof(knownButton, fc.constantFrom(...PROTO_KEYS), fc.string({ maxLength: 12 }));
+
+describe("isNavigationPressButton / isInPlacePressButton (property-based)", () => {
+  test("both are total (boolean) and false for any non-string", () => {
+    fc.assert(
+      fc.property(fc.anything(), value => {
+        const nav = isNavigationPressButton(value);
+        const inPlace = isInPlacePressButton(value);
+        const nonStringIsFalse = typeof value === "string" || (!nav && !inPlace);
+        return typeof nav === "boolean" && typeof inPlace === "boolean" && nonStringIsFalse;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("the two categories are disjoint for any input", () => {
+    fc.assert(
+      fc.property(anyButtonName, value => !(isNavigationPressButton(value) && isInPlacePressButton(value))),
+      RUN_OPTIONS
+    );
+  });
+
+  test("classify their own members case-insensitively", () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...NAV_BUTTONS).chain(mixedCase), b => isNavigationPressButton(b) && !isInPlacePressButton(b)),
+      RUN_OPTIONS
+    );
+    fc.assert(
+      fc.property(fc.constantFrom(...IN_PLACE_BUTTONS).chain(mixedCase), b => isInPlacePressButton(b) && !isNavigationPressButton(b)),
+      RUN_OPTIONS
+    );
+  });
+});
+
+describe("resolveAndroidKeyCode (property-based)", () => {
+  test("returns a known key code for a supported button (any casing), else undefined", () => {
+    fc.assert(
+      fc.property(anyButtonName, button => {
+        const code = resolveAndroidKeyCode(button);
+        return code === undefined || KEY_CODES.has(code);
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("is defined exactly for navigation or in-place buttons (cross-invariant)", () => {
+    fc.assert(
+      fc.property(anyButtonName, button => {
+        const defined = resolveAndroidKeyCode(button) !== undefined;
+        return defined === (isNavigationPressButton(button) || isInPlacePressButton(button));
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("never leaks an Object.prototype member (issue #4187)", () => {
+    fc.assert(
+      fc.property(fc.constantFrom(...PROTO_KEYS).chain(mixedCase), key => resolveAndroidKeyCode(key) === undefined),
+      RUN_OPTIONS
+    );
+  });
+
+  test("is case-insensitive", () => {
+    fc.assert(
+      fc.property(knownButton.chain(mixedCase), button =>
+        resolveAndroidKeyCode(button) === resolveAndroidKeyCode(button.toLowerCase())
+      ),
+      RUN_OPTIONS
+    );
+  });
+});

--- a/test/features/action/resolveAutoInputMode.property.test.ts
+++ b/test/features/action/resolveAutoInputMode.property.test.ts
@@ -1,0 +1,59 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import { resolveAutoInputMode } from "../../../src/features/action/resolveAutoInputMode";
+
+// Property-based tests. See test/utils/Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+const text = fc.string({ maxLength: 40 });
+const markers = fc.array(fc.string({ maxLength: 8 }), { maxLength: 6 });
+
+describe("resolveAutoInputMode (property-based)", () => {
+  test("only ever returns \"eventAll\" or undefined", () => {
+    fc.assert(
+      fc.property(text, markers, (t, m) => {
+        const r = resolveAutoInputMode(t, m);
+        return r === "eventAll" || r === undefined;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("promotes iff some non-empty marker is a substring of the text", () => {
+    fc.assert(
+      fc.property(text, markers, (t, m) => {
+        const expected = m.some(marker => marker.length > 0 && t.includes(marker)) ? "eventAll" : undefined;
+        return resolveAutoInputMode(t, m) === expected;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("an empty marker list never promotes", () => {
+    fc.assert(
+      fc.property(text, t => resolveAutoInputMode(t, []) === undefined),
+      RUN_OPTIONS
+    );
+  });
+
+  test("an empty-string marker is ignored despite text.includes(\"\") being true", () => {
+    fc.assert(
+      fc.property(text, t => resolveAutoInputMode(t, [""]) === undefined),
+      RUN_OPTIONS
+    );
+  });
+
+  test("a non-empty substring of the text always promotes", () => {
+    // A guaranteed non-empty slice of the text is always a present marker.
+    const textAndMarker = fc
+      .string({ minLength: 1, maxLength: 40 })
+      .chain(t =>
+        fc.record({ t: fc.constant(t), start: fc.integer({ min: 0, max: t.length - 1 }), extra: fc.integer({ min: 0, max: t.length }) })
+      )
+      .map(({ t, start, extra }) => ({ t, marker: t.slice(start, Math.min(t.length, start + 1 + extra)) }));
+    fc.assert(
+      fc.property(textAndMarker, ({ t, marker }) => marker.length >= 1 && resolveAutoInputMode(t, [marker]) === "eventAll"),
+      RUN_OPTIONS
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Continues the fast-check property-testing expansion (pattern from [PR #4427](https://github.com/kaeawc/auto-mobile/pull/4427)) with two pure, dependency-free action-policy helpers under `src/features/action/`. Test-only, additive — no production changes, no new dependencies. Co-located under `test/features/action/`.

Invariants asserted:

- **`pressButtonPolicy`** — `isNavigationPressButton`/`isInPlacePressButton` are total (boolean) and `false` for any non-string, the two categories are **disjoint**, and each classifies its own members case-insensitively; `resolveAndroidKeyCode` returns a known key code or `undefined`, is defined **exactly** for navigation-or-in-place buttons (a cross-invariant tying the three functions together), **never leaks an `Object.prototype` member** ([issue #4187](https://github.com/kaeawc/auto-mobile/issues/4187) — the null-prototype-map guard), and is case-insensitive.
- **`resolveAutoInputMode`** — only ever returns `"eventAll"` or `undefined`; promotes **iff** some non-empty marker is a substring of the text (checked against an independent oracle); an empty marker list never promotes; an empty-string marker is ignored despite `text.includes("")` being `true`; any non-empty substring of the text always promotes.

No defects surfaced.

## Validation

- [x] `bun test test/features/action/{pressButtonPolicy,resolveAutoInputMode}.property.test.ts` — 12 pass, ~155ms
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run lint` — no new violations
- [x] New tests are pure (no device/network/filesystem/DB); each runs in <100ms

## Follow-ups

- [ ] More pure `src/features/**` helpers remain (e.g. `asciiKeyEvents.buildAsciiKeyEventPlan`, `iosHelpers.buildAppleLanguages`, `screenshotCacheEviction.selectScreenshotsToEvict`, `sdkCrashIngestion` normalizers, `AppearanceConfig`/`DeviceSnapshotConfig` parsers). Kept separate to keep each PR small.
