### PR TITLE
fix(navigation): complete iOS graph workflow parity

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -316,6 +316,10 @@ jobs:
               - 'src/daemon/**'
               - 'src/features/observe/**'
               - 'src/features/action/**'
+              # Navigation replays share the iOS CtrlProxy interaction path, so
+              # these changes need the Simulator workflow rather than only fast
+              # TypeScript validation.
+              - 'src/features/navigation/**'
               - 'src/features/**/ios/**'
               - 'src/utils/IOSCtrlProxy*'
               - 'src/utils/Ios*'
@@ -339,6 +343,8 @@ jobs:
               # would land unvalidated and only surface on nightly / the next
               # native_integration PR.
               - '.github/actions/ios-simulator-bring-up/**'
+              # This workflow owns the Simulator workflow's command and gating.
+              - '.github/workflows/pull_request.yml'
               # This job runs a bun-side integration test (iosVideoRecordingStartStop),
               # so the bun test config and any test-setup preload affect it. bunfig.toml
               # wires a [test].preload that runs before EVERY bun test the job invokes,
@@ -1744,8 +1750,7 @@ jobs:
         if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
         timeout-minutes: 5
         run: |
-          xcrun simctl getenv "${{ steps.ctrlproxy-simulator.outputs.simulator_udid }}" HOME >/dev/null
-          bun test test/features/navigation/iosNavigationGraphWorkflow.test.ts
+          ./scripts/ios/navigation-graph-sdk-event-integration.sh "${{ steps.ctrlproxy-simulator.outputs.simulator_udid }}"
 
       # Compile the XCTest bundle BEFORE the target-app warm-up. Otherwise `swift test`
       # in the timed Reminders step spends tens of seconds compiling first, letting the

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1734,6 +1734,8 @@ jobs:
       # by `bun add -g .`) is thereby on PATH for the swift-test step.
       - name: "Ensure AutoMobile daemon ready (Xcode 26.5)"
         if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
+        env:
+          AUTOMOBILE_DAEMON_DEBUG: "1"
         run: ./scripts/ci/ensure-daemon-ready.sh
 
       # Launch CtrlProxy on the booted sim now (a slow, one-time xcodebuild launch)

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -348,6 +348,7 @@ jobs:
               - 'bunfig.toml'
               - 'test/setup/**'
               - 'test/integration/iosVideoRecordingStartStop.integration.test.ts'
+              - 'test/features/navigation/iosNavigationGraphWorkflow.test.ts'
               - 'package.json'
               - 'bun.lock'
 
@@ -1738,6 +1739,13 @@ jobs:
         if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
         timeout-minutes: 12
         run: ./scripts/ci/ensure-ctrl-proxy-ready.sh
+
+      - name: "Run iOS navigation graph Simulator workflow"
+        if: ${{ !cancelled() && steps.build-ctrlproxy.outcome == 'success' }}
+        timeout-minutes: 5
+        run: |
+          xcrun simctl getenv "${{ steps.ctrlproxy-simulator.outputs.simulator_udid }}" HOME >/dev/null
+          bun test test/features/navigation/iosNavigationGraphWorkflow.test.ts
 
       # Compile the XCTest bundle BEFORE the target-app warm-up. Otherwise `swift test`
       # in the timed Reminders step spends tens of seconds compiling first, letting the

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -526,6 +526,8 @@ class WebSocketConnection: WebSocketResponding {
     /// can detect a runner/client port mismatch (issue #2735).
     private let boundPort: UInt16
     private var isWebSocketUpgraded = false
+    private var pendingHTTPRequest = Data()
+    private static let maximumHTTPRequestLength = 1_000_000
 
     init(
         id: Int,
@@ -578,7 +580,7 @@ class WebSocketConnection: WebSocketResponding {
     // MARK: - WebSocket Handshake
 
     private func receiveHTTPUpgrade() {
-        connection.receive(minimumIncompleteLength: 1, maximumLength: 1_000_000) { [weak self] data, _, isComplete, error in
+        connection.receive(minimumIncompleteLength: 1, maximumLength: Self.maximumHTTPRequestLength) { [weak self] data, _, isComplete, error in
             guard let self = self else { return }
 
             if let error = error {
@@ -592,8 +594,27 @@ class WebSocketConnection: WebSocketResponding {
                 return
             }
 
-            guard let data = data, let request = String(data: data, encoding: .utf8) else {
+            guard let data = data else {
                 self.receiveHTTPUpgrade()
+                return
+            }
+
+            self.pendingHTTPRequest.append(data)
+            guard self.pendingHTTPRequest.count <= Self.maximumHTTPRequestLength else {
+                print("[WebSocketConnection] HTTP request exceeds maximum length")
+                self.connection.cancel()
+                return
+            }
+
+            guard let requestLength = Self.completeHTTPRequestLength(in: self.pendingHTTPRequest) else {
+                self.receiveHTTPUpgrade()
+                return
+            }
+
+            let requestData = Data(self.pendingHTTPRequest.prefix(requestLength))
+            self.pendingHTTPRequest.removeFirst(requestLength)
+            guard let request = String(data: requestData, encoding: .utf8) else {
+                self.connection.cancel()
                 return
             }
 
@@ -610,6 +631,45 @@ class WebSocketConnection: WebSocketResponding {
                 self.receiveHTTPUpgrade()
             }
         }
+    }
+
+    /// Returns the byte count of one complete HTTP request, including its body,
+    /// or `nil` until another network read supplies the missing bytes.
+    static func completeHTTPRequestLength(in data: Data) -> Int? {
+        let separator = Data("\r\n\r\n".utf8)
+        guard let headerRange = data.range(of: separator) else {
+            return nil
+        }
+
+        let headerLength = headerRange.upperBound
+        guard let header = String(data: data.prefix(headerLength), encoding: .utf8) else {
+            return nil
+        }
+
+        let contentLength = header
+            .components(separatedBy: "\r\n")
+            .compactMap { line -> Int? in
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                guard let delimiter = trimmed.firstIndex(of: ":") else {
+                    return nil
+                }
+                let name = String(trimmed[..<delimiter])
+                guard name.caseInsensitiveCompare("Content-Length") == .orderedSame
+                else {
+                    return nil
+                }
+                let value = String(trimmed[trimmed.index(after: delimiter)...].trimmingCharacters(in: .whitespaces))
+                return Int(value)
+            }
+            .first ?? 0
+        guard contentLength >= 0,
+              headerLength <= Self.maximumHTTPRequestLength - contentLength
+        else {
+            return nil
+        }
+
+        let requestLength = headerLength + contentLength
+        return data.count >= requestLength ? requestLength : nil
     }
 
     private func handleHealthCheck() {

--- a/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
@@ -227,4 +227,20 @@ final class WebSocketServerTests: XCTestCase {
         XCTAssertNil(WebSocketConnection.frameReadLength(payloadLength: UInt64(Int.max) + 1, isMasked: false))
         XCTAssertNil(WebSocketConnection.frameReadLength(payloadLength: .max, isMasked: true))
     }
+
+    // MARK: - HTTP request framing
+
+    func testCompleteHTTPRequestLengthWaitsForSplitPostBody() {
+        let header = Data("POST /sdk-events HTTP/1.1\r\nContent-Length: 19\r\n\r\n".utf8)
+        XCTAssertNil(WebSocketConnection.completeHTTPRequestLength(in: header))
+
+        var completeRequest = header
+        completeRequest.append(Data("{\"events\":[],\"x\":1}".utf8))
+        XCTAssertEqual(WebSocketConnection.completeHTTPRequestLength(in: completeRequest), completeRequest.count)
+    }
+
+    func testCompleteHTTPRequestLengthAcceptsHeaderOnlyHealthRequest() {
+        let request = Data("GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n".utf8)
+        XCTAssertEqual(WebSocketConnection.completeHTTPRequestLength(in: request), request.count)
+    }
 }

--- a/scripts/ci/ensure-daemon-ready.sh
+++ b/scripts/ci/ensure-daemon-ready.sh
@@ -25,6 +25,7 @@
 # Env overrides (used by tests to keep runs fast):
 #   DAEMON_READY_MAX_ATTEMPTS   max health-poll attempts (default 30)
 #   DAEMON_READY_DELAY_SECONDS  initial delay between polls, seconds (default 1)
+#   AUTOMOBILE_DAEMON_DEBUG      start the daemon with --debug when set to 1
 
 set -uo pipefail
 
@@ -70,8 +71,14 @@ fi
 echo "auto-mobile resolved at: $(command -v auto-mobile)"
 
 # Start the daemon (idempotent — an already-running, version-matched daemon is
-# reused by the Swift test's ensureDaemonRunning()).
-auto-mobile --daemon start || true
+# reused by the Swift test's ensureDaemonRunning()). Some CI integrations query
+# debug-only tools after readiness, so let their workflow opt in before this
+# first start rather than trying to retrofit debug mode onto a live daemon.
+daemon_start_args=(--daemon start)
+if [[ "${AUTOMOBILE_DAEMON_DEBUG:-}" == "1" ]]; then
+  daemon_start_args+=(--debug)
+fi
+auto-mobile "${daemon_start_args[@]}" || true
 
 max_attempts="${DAEMON_READY_MAX_ATTEMPTS:-30}"
 delay="${DAEMON_READY_DELAY_SECONDS:-1}"

--- a/scripts/ios/navigation-graph-sdk-event-integration.sh
+++ b/scripts/ios/navigation-graph-sdk-event-integration.sh
@@ -25,7 +25,28 @@ require_command jq
 require_command xcrun
 
 xcrun simctl getenv "${device_id}" HOME >/dev/null
-curl --fail --silent --show-error --max-time 5 http://127.0.0.1:8765/health >/dev/null
+
+# CtrlProxy allocates a per-device host port; 8765 is only its preferred default
+# and may already belong to another local service. Ask the daemon that warmed the
+# runner for the selected simulator's reported port instead of probing a stale
+# default. `doctor` can exit non-zero for unrelated diagnostics, but still emits
+# the JSON report that contains this ready runner's round-trip result.
+doctor_report="$(auto-mobile --cli doctor --ios --json || true)"
+ctrl_proxy_port="$(jq -er --arg device_id "${device_id}" '
+  .ios.checks[]
+  | select(.name == "iOS Observe Round Trip")
+  | .message
+  | split(" | ")
+  | map(select(contains("device=" + $device_id + ";")))
+  | .[0]
+  | capture("runnerPort=(?<port>[0-9]+)")
+  | .port
+' <<<"${doctor_report}")" || {
+  echo "error: could not determine CtrlProxy port for simulator ${device_id}" >&2
+  exit 1
+}
+
+curl --fail --silent --show-error --max-time 5 "http://127.0.0.1:${ctrl_proxy_port}/health" >/dev/null
 
 event_payload() {
   local destination="$1"
@@ -48,7 +69,7 @@ curl --fail --silent --show-error --max-time 5 \
   --request POST \
   --header 'Content-Type: application/json' \
   --data "${batch}" \
-  http://127.0.0.1:8765/sdk-events >/dev/null
+  "http://127.0.0.1:${ctrl_proxy_port}/sdk-events" >/dev/null
 
 # CtrlProxy polls its SDK endpoint every two seconds after the warm-up observe.
 # Query through the public, daemon-backed tool until the batched events appear.

--- a/scripts/ios/navigation-graph-sdk-event-integration.sh
+++ b/scripts/ios/navigation-graph-sdk-event-integration.sh
@@ -53,7 +53,11 @@ curl --fail --silent --show-error --max-time 5 \
 # CtrlProxy polls its SDK endpoint every two seconds after the warm-up observe.
 # Query through the public, daemon-backed tool until the batched events appear.
 for attempt in 1 2 3 4 5; do
-  graph="$(auto-mobile --debug --cli getNavigationGraph --platform ios --deviceId "${device_id}")"
+  if ! graph="$(auto-mobile --debug --cli getNavigationGraph --platform ios --deviceId "${device_id}")"; then
+    echo "getNavigationGraph attempt ${attempt} failed; retrying in 2s..." >&2
+    sleep 2
+    continue
+  fi
   if jq -e --arg home "${home_screen}" --arg detail "${detail_screen}" \
     '(if .content? then (.content[] | select(.type == "text").text | fromjson) else . end) as $result
       | ([$result.screens[].name] | index($home)) != null

--- a/scripts/ios/navigation-graph-sdk-event-integration.sh
+++ b/scripts/ios/navigation-graph-sdk-event-integration.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Verify the iOS CtrlProxy SDK-event path reaches the daemon's public navigation
+# graph surface on the booted Simulator. The focused TypeScript tests cover path
+# replay deterministically; this job owns the real runner/HTTP/daemon boundary.
+
+set -euo pipefail
+
+device_id="${1:?usage: navigation-graph-sdk-event-integration.sh <simulator-udid>}"
+timestamp_ms="$(($(date +%s) * 1000))"
+bundle_id="dev.jasonpearson.automobile.issue4460"
+home_screen="Issue4460Home"
+detail_screen="Issue4460Detail"
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "error: required command not found: $1" >&2
+    exit 1
+  }
+}
+
+require_command auto-mobile
+require_command base64
+require_command curl
+require_command jq
+require_command xcrun
+
+xcrun simctl getenv "${device_id}" HOME >/dev/null
+curl --fail --silent --show-error --max-time 5 http://127.0.0.1:8765/health >/dev/null
+
+event_payload() {
+  local destination="$1"
+  jq -cn \
+    --argjson timestamp "${timestamp_ms}" \
+    --arg destination "${destination}" \
+    '{eventType:"navigation", timestamp:$timestamp, destination:$destination, source:"swiftui", arguments:{}, metadata:{}}' \
+    | base64 | tr -d '\n'
+}
+
+batch="$(jq -cn \
+  --arg bundle_id "${bundle_id}" \
+  --argjson timestamp "${timestamp_ms}" \
+  --arg home_payload "$(event_payload "${home_screen}")" \
+  --arg detail_payload "$(event_payload "${detail_screen}")" \
+  '{bundleId:$bundle_id, timestamp:$timestamp, events:[{eventType:"navigation", payload:$home_payload}, {eventType:"navigation", payload:$detail_payload}]}'
+)"
+
+curl --fail --silent --show-error --max-time 5 \
+  --request POST \
+  --header 'Content-Type: application/json' \
+  --data "${batch}" \
+  http://127.0.0.1:8765/sdk-events >/dev/null
+
+# CtrlProxy polls its SDK endpoint every two seconds after the warm-up observe.
+# Query through the public, daemon-backed tool until the batched events appear.
+for attempt in 1 2 3 4 5; do
+  graph="$(auto-mobile --debug --cli getNavigationGraph --platform ios --deviceId "${device_id}")"
+  if jq -e --arg home "${home_screen}" --arg detail "${detail_screen}" \
+    '(if .content? then (.content[] | select(.type == "text").text | fromjson) else . end) as $result
+      | ([$result.screens[].name] | index($home)) != null
+      and ([$result.screens[].name] | index($detail)) != null' \
+    <<<"${graph}" >/dev/null; then
+    echo "iOS SDK navigation events reached getNavigationGraph on attempt ${attempt}."
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "error: iOS SDK navigation events did not reach getNavigationGraph" >&2
+echo "last graph response: ${graph}" >&2
+exit 1

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -414,10 +414,20 @@ async function runToolViaDaemon(
  * {@link handleDoctorResult}/`applyClientBuildIdentity` step reports the mismatch. Throws (→ direct
  * fallback) only when the daemon is unreachable.
  */
+/** Remove CLI-only presentation options before calling the daemon's doctor tool. */
+export function doctorToolParams(params: Record<string, any>): Record<string, any> {
+  const doctorParams = { ...params };
+  delete doctorParams.json;
+  return doctorParams;
+}
+
 async function runDoctorViaDaemon(params: Record<string, any>): Promise<any> {
   const client = new DaemonClient(undefined, undefined, undefined, {}, null);
   try {
-    const result = await client.callTool("doctor", params);
+    // `json` controls CLI presentation only. The daemon's doctor tool accepts
+    // diagnostic options, so do not forward the local formatting flag through
+    // its strict schema.
+    const result = await client.callTool("doctor", doctorToolParams(params));
     if (result === null) {
       throw new ActionableError(
         "Daemon returned null result for doctor. " +

--- a/src/features/action/PressButton.ts
+++ b/src/features/action/PressButton.ts
@@ -1,4 +1,4 @@
-import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
+import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { BaseVisualChange, ProgressCallback } from "./BaseVisualChange";
 import { BootedDevice, PressButtonResult } from "../../models";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
@@ -7,10 +7,15 @@ import { AndroidCtrlProxyClient } from "../observe/android";
 import { logger } from "../../utils/logger";
 import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType";
 import { isNavigationPressButton, resolveAndroidKeyCode } from "./pressButtonPolicy";
+import { Timer, defaultTimer } from "../../utils/SystemTimer";
 
 export class PressButton extends BaseVisualChange {
-  constructor(device: BootedDevice, adb: AdbClient | null = null) {
-    super(device, adb);
+  constructor(
+    device: BootedDevice,
+    adb: AdbExecutor | null = null,
+    timer: Timer = defaultTimer
+  ) {
+    super(device, adb, timer);
     this.device = device;
   }
 

--- a/src/features/navigation/DefaultUIStateSetup.ts
+++ b/src/features/navigation/DefaultUIStateSetup.ts
@@ -2,8 +2,8 @@ import { BootedDevice } from "../../models";
 import { ObserveResult } from "../../models/ObserveResult";
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { logger } from "../../utils/logger";
-import { AndroidCtrlProxyClient } from "../observe/android";
 import { ToolRegistry } from "../../server/toolRegistry";
+import { throwIfInternalToolFailed } from "../../server/internalToolCall";
 import { NavigationEdge, UIState } from "./NavigationGraphManager";
 import { ModalState, ScrollPosition } from "../../utils/interfaces/NavigationGraph";
 import { UIStateExtractor } from "./UIStateExtractor";
@@ -29,16 +29,19 @@ export class DefaultUIStateSetup implements UIStateSetup {
   private adb: AdbClient;
   private observeScreenProvider: () => ObserveScreenLike;
   private timer: Timer;
+  private sessionUuid?: string;
 
   constructor(
     device: BootedDevice,
     adb: AdbClient,
     observeScreenProvider?: () => ObserveScreenLike,
-    timer: Timer = defaultTimer
+    timer: Timer = defaultTimer,
+    sessionUuid?: string
   ) {
     this.device = device;
     this.adb = adb;
     this.timer = timer;
+    this.sessionUuid = sessionUuid;
     // The setup holds a resolved AdbClient (not a factory), so wrap it in a
     // trivial factory to satisfy ObserveScreen's factory-only contract (matches
     // the AndroidCtrlProxyClient.getInstance call below).
@@ -144,6 +147,8 @@ export class DefaultUIStateSetup implements UIStateSetup {
 
       const swipeOnArgs: any = {
         platform,
+        deviceId: this.device.deviceId,
+        ...(this.sessionUuid ? { sessionUuid: this.sessionUuid } : {}),
         direction: scrollPosition.direction,
         lookFor
       };
@@ -271,15 +276,17 @@ export class DefaultUIStateSetup implements UIStateSetup {
     logger.info(`[UI_STATE_SETUP] Setting up UI state: tapping "${identifier}"`);
 
     try {
-      const args: Record<string, string> = {
+      const args: Record<string, unknown> = {
         action: "tap",
-        platform
+        platform,
+        deviceId: this.device.deviceId,
+        ...(this.sessionUuid ? { sessionUuid: this.sessionUuid } : {})
       };
 
       if (element.text) {
-        args.text = element.text;
+        args.selector = { text: element.text };
       } else if (element.resourceId) {
-        args.elementId = element.resourceId;
+        args.selector = { elementId: element.resourceId };
       }
 
       // Internal setup tap (#3087) via the callInternal seam (#3108): no
@@ -347,7 +354,7 @@ export class DefaultUIStateSetup implements UIStateSetup {
     // Strategy 1: Try back button (works for most dialogs)
     if (modal.type === "dialog") {
       try {
-        await this.pressBack();
+        await this.pressBack(platform);
         await this.sleep(200);
 
         // Verify dismissal
@@ -383,7 +390,9 @@ export class DefaultUIStateSetup implements UIStateSetup {
           await ToolRegistry.callInternal(swipeTool, {
             direction: "down",
             autoTarget: false,
-            platform
+            platform,
+            deviceId: this.device.deviceId,
+            ...(this.sessionUuid ? { sessionUuid: this.sessionUuid } : {})
           });
           await this.sleep(200);
 
@@ -397,7 +406,7 @@ export class DefaultUIStateSetup implements UIStateSetup {
         }
 
         // Fallback to back button
-        await this.pressBack();
+        await this.pressBack(platform);
         await this.sleep(200);
 
         const currentState = await this.getCurrentUIState(platform);
@@ -434,8 +443,10 @@ export class DefaultUIStateSetup implements UIStateSetup {
     // Strategy 4: Tap outside (for popups and menus)
     if (modal.type === "popup" || modal.type === "menu" || modal.type === "overlay") {
       try {
-        // Tap top-left corner (usually outside modal)
-        await this.adb.executeCommand("shell input tap 50 50");
+        // There is no coordinate-tap interaction tool. Use the platform-aware
+        // back action rather than sending an Android-only shell command; iOS
+        // CtrlProxy maps it to its native modal dismissal behavior.
+        await this.pressBack(platform);
         await this.sleep(200);
 
         // Verify dismissal
@@ -452,7 +463,7 @@ export class DefaultUIStateSetup implements UIStateSetup {
 
     // Final fallback: back button
     try {
-      await this.pressBack();
+      await this.pressBack(platform);
       await this.sleep(200);
 
       const currentState = await this.getCurrentUIState(platform);
@@ -486,9 +497,11 @@ export class DefaultUIStateSetup implements UIStateSetup {
         // Internal close-button tap (#3087) via the callInternal seam (#3108):
         // no diff/strip, no baseline advance.
         await ToolRegistry.callInternal(tapTool, {
+          selector: { text },
           action: "tap",
-          text,
-          platform
+          platform,
+          deviceId: this.device.deviceId,
+          ...(this.sessionUuid ? { sessionUuid: this.sessionUuid } : {})
         });
         logger.debug(`[UI_STATE_SETUP] Tapped close button: "${text}"`);
         return true;
@@ -504,19 +517,15 @@ export class DefaultUIStateSetup implements UIStateSetup {
   /**
    * Press the back button.
    */
-  private async pressBack(): Promise<void> {
-    try {
-      const client = AndroidCtrlProxyClient.getInstance(this.device, { create: () => this.adb });
-      const result = await client.requestGlobalAction("back", 3000);
-      if (result.success) {
-        logger.debug("[UI_STATE_SETUP] Pressed back via accessibility service");
-        return;
-      }
-    } catch {
-      // Fall through to ADB
-    }
-    await this.adb.executeCommand("shell input keyevent 4");
-    logger.debug("[UI_STATE_SETUP] Pressed back via ADB keyevent");
+  private async pressBack(platform: string): Promise<void> {
+    const response = await ToolRegistry.callInternal("pressButton", {
+      button: "back",
+      platform,
+      deviceId: this.device.deviceId,
+      ...(this.sessionUuid ? { sessionUuid: this.sessionUuid } : {})
+    });
+    throwIfInternalToolFailed(response, "pressButton", platform);
+    logger.debug(`[UI_STATE_SETUP] Pressed back via ${platform} interaction tool`);
   }
 
   /**

--- a/src/features/navigation/DefaultUIStateSetup.ts
+++ b/src/features/navigation/DefaultUIStateSetup.ts
@@ -8,6 +8,7 @@ import { NavigationEdge, UIState } from "./NavigationGraphManager";
 import { ModalState, ScrollPosition } from "../../utils/interfaces/NavigationGraph";
 import { UIStateExtractor } from "./UIStateExtractor";
 import { RealObserveScreen } from "../observe/ObserveScreen";
+import { PressButton } from "../action/PressButton";
 import { getStructuredField } from "../../utils/toolUtils";
 import { UIStateSetup } from "./interfaces/UIStateSetup";
 import { defaultTimer, Timer } from "../../utils/SystemTimer";
@@ -538,6 +539,18 @@ export class DefaultUIStateSetup implements UIStateSetup {
    * Press the back button.
    */
   private async pressBack(platform: string): Promise<void> {
+    if (platform === "android") {
+      // Modal recovery belongs to this instance's injected ADB/timer boundary.
+      // Calling press() avoids a nested observed interaction while preserving
+      // the accessibility-service then ADB fallback behavior.
+      const result = await new PressButton(this.device, this.adb, this.timer).press("back");
+      if (!result.success) {
+        throw new Error(result.error ?? "Android back navigation failed");
+      }
+      logger.debug("[UI_STATE_SETUP] Pressed back via Android action dependencies");
+      return;
+    }
+
     const response = await ToolRegistry.callInternal("pressButton", {
       button: "back",
       platform,

--- a/src/features/navigation/DefaultUIStateSetup.ts
+++ b/src/features/navigation/DefaultUIStateSetup.ts
@@ -89,18 +89,11 @@ export class DefaultUIStateSetup implements UIStateSetup {
         : currentState;
 
       if (updatedState) {
-        const missingElements = this.findMissingSelections(
+        setupActions.push(...await this.setupMissingSelections(
           requiredState.selectedElements,
-          updatedState.selectedElements
-        );
-
-        // Tap on missing elements to set up the required state
-        for (const element of missingElements) {
-          const tapped = await this.tapOnElement(element, platform);
-          if (tapped) {
-            setupActions.push(`tapOn(${JSON.stringify(element)})`);
-          }
-        }
+          updatedState.selectedElements,
+          platform
+        ));
       }
     }
 
@@ -253,6 +246,20 @@ export class DefaultUIStateSetup implements UIStateSetup {
     return missing;
   }
 
+  private async setupMissingSelections(
+    required: Array<{ text?: string; resourceId?: string; contentDesc?: string }>,
+    current: Array<{ text?: string; resourceId?: string; contentDesc?: string }>,
+    platform: string
+  ): Promise<string[]> {
+    const actions: string[] = [];
+    for (const element of this.findMissingSelections(required, current)) {
+      if (await this.tapOnElement(element, platform)) {
+        actions.push(`tapOn(${JSON.stringify(element)})`);
+      }
+    }
+    return actions;
+  }
+
   /**
    * Tap on an element to select it.
    */
@@ -370,95 +377,20 @@ export class DefaultUIStateSetup implements UIStateSetup {
     }
 
     // Strategy 2: Swipe down for bottom sheets
-    if (modal.type === "bottomsheet") {
-      try {
-        // The registered interaction tool is `swipeOn`, not `swipe` (see
-        // src/server/interactionTools.ts). Resolving `getTool("swipe")` always
-        // returned undefined, so this whole branch was dead code and bottom
-        // sheets that only dismiss via swipe-down silently fell through to the
-        // back-button fallback below (issue #3106).
-        const swipeTool = ToolRegistry.getTool("swipeOn");
-        if (swipeTool) {
-          // Swipe down from mid-screen to drag the sheet down and dismiss it.
-          // `swipeOn` takes `direction` (no `action` field). `autoTarget: false`
-          // is essential here: with the default (true) and no lookFor/container,
-          // swipeOn targets a scrollable child and would scroll the sheet's inner
-          // list instead of dragging the sheet itself down (SwipeOn.execute). We
-          // want the full-screen downward swipe (executeScreenSwipe) that a
-          // dismissal needs. Internal setup swipe (#3087) via the callInternal
-          // seam (#3108): no diff/strip, no baseline advance.
-          await ToolRegistry.callInternal(swipeTool, {
-            direction: "down",
-            autoTarget: false,
-            platform,
-            deviceId: this.device.deviceId,
-            ...(this.sessionUuid ? { sessionUuid: this.sessionUuid } : {})
-          });
-          await this.sleep(200);
-
-          // Verify dismissal
-          const currentState = await this.getCurrentUIState(platform);
-          const dismissed = !currentState?.modalStack?.some(m => m.windowId === modal.windowId);
-          if (dismissed) {
-            logger.info(`[UI_STATE_SETUP] Dismissed bottom sheet with swipe down`);
-            return true;
-          }
-        }
-
-        // Fallback to back button
-        await this.pressBack(platform);
-        await this.sleep(200);
-
-        const currentState = await this.getCurrentUIState(platform);
-        const dismissed = !currentState?.modalStack?.some(m => m.windowId === modal.windowId);
-        if (dismissed) {
-          logger.info(`[UI_STATE_SETUP] Dismissed bottom sheet with back button`);
-          return true;
-        }
-      } catch (error) {
-        logger.debug(`[UI_STATE_SETUP] Swipe down failed for bottom sheet: ${error}`);
-      }
+    if (modal.type === "bottomsheet" && await this.dismissBottomSheet(modal, platform)) {
+      return true;
     }
 
     // Strategy 3: Look for close/cancel button
-    if (modal.type === "dialog" || modal.type === "bottomsheet") {
-      try {
-        const closeButtonTapped = await this.tapCloseButton(platform);
-        if (closeButtonTapped) {
-          await this.sleep(200);
-
-          // Verify dismissal
-          const currentState = await this.getCurrentUIState(platform);
-          const dismissed = !currentState?.modalStack?.some(m => m.windowId === modal.windowId);
-          if (dismissed) {
-            logger.info(`[UI_STATE_SETUP] Dismissed ${modal.type} with close button`);
-            return true;
-          }
-        }
-      } catch (error) {
-        logger.debug(`[UI_STATE_SETUP] Close button tap failed: ${error}`);
-      }
+    if ((modal.type === "dialog" || modal.type === "bottomsheet")
+      && await this.dismissWithCloseButton(modal, platform)) {
+      return true;
     }
 
     // Strategy 4: Tap outside (for popups and menus)
-    if (modal.type === "popup" || modal.type === "menu" || modal.type === "overlay") {
-      try {
-        // There is no coordinate-tap interaction tool. Use the platform-aware
-        // back action rather than sending an Android-only shell command; iOS
-        // CtrlProxy maps it to its native modal dismissal behavior.
-        await this.pressBack(platform);
-        await this.sleep(200);
-
-        // Verify dismissal
-        const currentState = await this.getCurrentUIState(platform);
-        const dismissed = !currentState?.modalStack?.some(m => m.windowId === modal.windowId);
-        if (dismissed) {
-          logger.info(`[UI_STATE_SETUP] Dismissed ${modal.type} by tapping outside`);
-          return true;
-        }
-      } catch (error) {
-        logger.debug(`[UI_STATE_SETUP] Tap outside failed: ${error}`);
-      }
+    if ((modal.type === "popup" || modal.type === "menu" || modal.type === "overlay")
+      && await this.dismissByTappingOutside(modal, platform)) {
+      return true;
     }
 
     // Final fallback: back button
@@ -478,6 +410,89 @@ export class DefaultUIStateSetup implements UIStateSetup {
 
     logger.warn(`[UI_STATE_SETUP] All dismissal strategies failed for ${modal.type}`);
     return false;
+  }
+
+  private async dismissBottomSheet(modal: ModalState, platform: string): Promise<boolean> {
+    try {
+      // The registered interaction tool is `swipeOn`, not `swipe` (see
+      // src/server/interactionTools.ts). Resolving `getTool("swipe")` always
+      // returned undefined, so this whole branch was dead code and bottom
+      // sheets that only dismiss via swipe-down silently fell through to the
+      // back-button fallback below (issue #3106).
+      const swipeTool = ToolRegistry.getTool("swipeOn");
+      if (swipeTool) {
+        // Swipe down from mid-screen to drag the sheet down and dismiss it.
+        // `swipeOn` takes `direction` (no `action` field). `autoTarget: false`
+        // is essential here: with the default (true) and no lookFor/container,
+        // swipeOn targets a scrollable child and would scroll the sheet's inner
+        // list instead of dragging the sheet itself down (SwipeOn.execute). We
+        // want the full-screen downward swipe (executeScreenSwipe) that a
+        // dismissal needs. Internal setup swipe (#3087) via the callInternal
+        // seam (#3108): no diff/strip, no baseline advance.
+        await ToolRegistry.callInternal(swipeTool, {
+          direction: "down",
+          autoTarget: false,
+          platform,
+          deviceId: this.device.deviceId,
+          ...(this.sessionUuid ? { sessionUuid: this.sessionUuid } : {})
+        });
+        await this.sleep(200);
+        if (await this.isModalDismissed(modal, platform)) {
+          logger.info("[UI_STATE_SETUP] Dismissed bottom sheet with swipe down");
+          return true;
+        }
+      }
+
+      await this.pressBack(platform);
+      await this.sleep(200);
+      if (await this.isModalDismissed(modal, platform)) {
+        logger.info("[UI_STATE_SETUP] Dismissed bottom sheet with back button");
+        return true;
+      }
+    } catch (error) {
+      logger.debug(`[UI_STATE_SETUP] Swipe down failed for bottom sheet: ${error}`);
+    }
+    return false;
+  }
+
+  private async dismissWithCloseButton(modal: ModalState, platform: string): Promise<boolean> {
+    try {
+      if (await this.tapCloseButton(platform)) {
+        await this.sleep(200);
+        if (await this.isModalDismissed(modal, platform)) {
+          logger.info(`[UI_STATE_SETUP] Dismissed ${modal.type} with close button`);
+          return true;
+        }
+      }
+    } catch (error) {
+      logger.debug(`[UI_STATE_SETUP] Close button tap failed: ${error}`);
+    }
+    return false;
+  }
+
+  private async dismissByTappingOutside(modal: ModalState, platform: string): Promise<boolean> {
+    if (platform !== "android") {
+      return false;
+    }
+    try {
+      // Android supports coordinate taps, which preserve the established
+      // scrim-dismissal behavior. iOS has no equivalent public interaction
+      // tool, so it proceeds to the single platform-aware back fallback.
+      await this.adb.executeCommand("shell input tap 50 50");
+      await this.sleep(200);
+      if (await this.isModalDismissed(modal, platform)) {
+        logger.info(`[UI_STATE_SETUP] Dismissed ${modal.type} by tapping outside`);
+        return true;
+      }
+    } catch (error) {
+      logger.debug(`[UI_STATE_SETUP] Tap outside failed: ${error}`);
+    }
+    return false;
+  }
+
+  private async isModalDismissed(modal: ModalState, platform: string): Promise<boolean> {
+    const currentState = await this.getCurrentUIState(platform);
+    return !currentState?.modalStack?.some(m => m.windowId === modal.windowId);
   }
 
   /**

--- a/src/features/navigation/DefaultUIStateSetup.ts
+++ b/src/features/navigation/DefaultUIStateSetup.ts
@@ -295,13 +295,15 @@ export class DefaultUIStateSetup implements UIStateSetup {
       } else if (element.resourceId) {
         args.selector = { elementId: element.resourceId };
       } else if (element.contentDesc) {
-        args.selector = { contentDesc: element.contentDesc };
+        // tapOn exposes accessible labels through its text selector; contentDesc
+        // is not a public selector field on the internal tool contract.
+        args.selector = { text: element.contentDesc };
       }
 
       // Internal setup tap (#3087) via the callInternal seam (#3108): no
       // diff/strip, no baseline advance.
       const response = await ToolRegistry.callInternal(tapTool, args);
-      throwIfInternalToolFailed(response, tapTool, platform);
+      throwIfInternalToolFailed(response, "tapOn", platform);
 
       // Small delay for UI to update
       await this.sleep(100);

--- a/src/features/navigation/DefaultUIStateSetup.ts
+++ b/src/features/navigation/DefaultUIStateSetup.ts
@@ -226,20 +226,20 @@ export class DefaultUIStateSetup implements UIStateSetup {
     const missing: Array<{ text?: string; resourceId?: string; contentDesc?: string }> = [];
 
     for (const req of required) {
-      // Skip elements without text (we need text to tap on them)
-      if (!req.text) {
+      if (!req.text && !req.resourceId && !req.contentDesc) {
         continue;
       }
 
       // Check if this element is already selected
       const isSelected = current.some(curr =>
         (req.text && curr.text === req.text) ||
-        (req.resourceId && curr.resourceId === req.resourceId)
+        (req.resourceId && curr.resourceId === req.resourceId) ||
+        (req.contentDesc && curr.contentDesc === req.contentDesc)
       );
 
       if (!isSelected) {
         missing.push(req);
-        logger.info(`[UI_STATE_SETUP] Missing selection: ${req.text || req.resourceId}`);
+        logger.info(`[UI_STATE_SETUP] Missing selection: ${req.text || req.resourceId || req.contentDesc}`);
       }
     }
 
@@ -294,11 +294,14 @@ export class DefaultUIStateSetup implements UIStateSetup {
         args.selector = { text: element.text };
       } else if (element.resourceId) {
         args.selector = { elementId: element.resourceId };
+      } else if (element.contentDesc) {
+        args.selector = { contentDesc: element.contentDesc };
       }
 
       // Internal setup tap (#3087) via the callInternal seam (#3108): no
       // diff/strip, no baseline advance.
-      await ToolRegistry.callInternal(tapTool, args);
+      const response = await ToolRegistry.callInternal(tapTool, args);
+      throwIfInternalToolFailed(response, tapTool, platform);
 
       // Small delay for UI to update
       await this.sleep(100);

--- a/src/features/navigation/Explore.ts
+++ b/src/features/navigation/Explore.ts
@@ -787,6 +787,7 @@ export class Explore extends BaseVisualChange {
       await this.timer.sleep(1000);
     } catch (error) {
       logger.warn(`[Explore] Failed to navigate back: ${error}`);
+      throw error;
     }
   }
 
@@ -820,6 +821,7 @@ export class Explore extends BaseVisualChange {
       this.consecutiveBackCount = 0;
     } catch (error) {
       logger.warn(`[Explore] Failed to reset to home: ${error}`);
+      throw error;
     }
   }
 

--- a/src/features/navigation/Explore.ts
+++ b/src/features/navigation/Explore.ts
@@ -9,6 +9,7 @@ import { NavigationGraphManager, type NavigationEdge, type NavigationGraphServic
 import { ExportedGraph } from "../../utils/interfaces/NavigationGraph";
 import { TapOnElement } from "../action/TapOnElement";
 import { SwipeOnElement } from "../action/SwipeOnElement";
+import { PressButton } from "../action/PressButton";
 import { DefaultElementParser } from "../utility/ElementParser";
 import type { ElementParser } from "../../utils/interfaces/ElementParser";
 import { throwIfAborted } from "../../utils/toolUtils";
@@ -775,16 +776,25 @@ export class Explore extends BaseVisualChange {
         );
       }
 
-      // Recovery is an internal interaction, not an Android transport detail.
-      // callInternal marks it no-diff so the observation it produces does not
-      // advance the caller-visible baseline during exploration.
-      const response = await ToolRegistry.callInternal("pressButton", {
-        button: "back",
-        platform: this.device.platform,
-        deviceId: this.device.deviceId,
-        ...(this.sessionUuid ? { sessionUuid: this.sessionUuid } : {})
-      }, progress);
-      throwIfInternalToolFailed(response, "pressButton", this.device.platform);
+      if (this.device.platform === "android") {
+        // Preserve the Explore instance's injected transport and timer. Calling
+        // press() avoids nested observed-interaction progress on this operation.
+        const result = await new PressButton(this.device, this.adb, this.timer).press("back");
+        if (!result.success) {
+          throw new Error(result.error ?? "Android back navigation failed");
+        }
+      } else {
+        // iOS recovery must route through the selected device/session tool.
+        // Do not forward the outer progress callback: the nested action has a
+        // different scale and would make exploration progress jump backward.
+        const response = await ToolRegistry.callInternal("pressButton", {
+          button: "back",
+          platform: this.device.platform,
+          deviceId: this.device.deviceId,
+          ...(this.sessionUuid ? { sessionUuid: this.sessionUuid } : {})
+        });
+        throwIfInternalToolFailed(response, "pressButton", this.device.platform);
+      }
       this.consecutiveBackCount++;
 
       // Wait briefly for navigation
@@ -808,15 +818,22 @@ export class Explore extends BaseVisualChange {
         );
       }
 
-      // `homeScreen` owns the platform-specific implementation and its
-      // actionable failures. Keep the internal recovery call out of the
-      // external observation-diff baseline.
-      const response = await ToolRegistry.callInternal("homeScreen", {
-        platform: this.device.platform,
-        deviceId: this.device.deviceId,
-        ...(this.sessionUuid ? { sessionUuid: this.sessionUuid } : {})
-      }, progress);
-      throwIfInternalToolFailed(response, "homeScreen", this.device.platform);
+      if (this.device.platform === "android") {
+        // PressButton's Android home path retains the injected ADB/timer and
+        // performs the same accessibility-service then ADB fallback.
+        const result = await new PressButton(this.device, this.adb, this.timer).press("home");
+        if (!result.success) {
+          throw new Error(result.error ?? "Android home navigation failed");
+        }
+      } else {
+        // Keep iOS recovery session/device-aware without nested progress.
+        const response = await ToolRegistry.callInternal("homeScreen", {
+          platform: this.device.platform,
+          deviceId: this.device.deviceId,
+          ...(this.sessionUuid ? { sessionUuid: this.sessionUuid } : {})
+        });
+        throwIfInternalToolFailed(response, "homeScreen", this.device.platform);
+      }
 
       // Wait for home screen
       await this.timer.sleep(2000);

--- a/src/features/navigation/Explore.ts
+++ b/src/features/navigation/Explore.ts
@@ -4,6 +4,7 @@ import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { createGlobalPerformanceTracker, PerformanceTracker } from "../../utils/PerformanceTracker";
 import { logger } from "../../utils/logger";
 import { ToolRegistry } from "../../server/toolRegistry";
+import { throwIfInternalToolFailed } from "../../server/internalToolCall";
 import { NavigationGraphManager, type NavigationEdge, type NavigationGraphService } from "./NavigationGraphManager";
 import { ExportedGraph } from "../../utils/interfaces/NavigationGraph";
 import { TapOnElement } from "../action/TapOnElement";
@@ -89,6 +90,7 @@ export class Explore extends BaseVisualChange {
   private graphTraversalState: GraphTraversalState | null = null;
   private currentTargetEdge: NavigationEdge | null = null;
   private currentElementConfidence: number = 0;
+  private sessionUuid?: string;
 
   // Constants for safety limits
   private static readonly MAX_CONSECUTIVE_BACKS = 5;
@@ -103,12 +105,14 @@ export class Explore extends BaseVisualChange {
     device: BootedDevice,
     adb: AdbClient | null = null,
     timer: Timer = defaultTimer,
-    navigationManager?: NavigationGraphService
+    navigationManager?: NavigationGraphService,
+    sessionUuid?: string
   ) {
     super(device, adb, timer);
     this.navigationManager = navigationManager ?? NavigationGraphManager.getInstance();
     this.exploredElements = new Map();
     this.elementParser = new DefaultElementParser();
+    this.sessionUuid = sessionUuid;
   }
 
   /**
@@ -770,10 +774,13 @@ export class Explore extends BaseVisualChange {
       // Recovery is an internal interaction, not an Android transport detail.
       // callInternal marks it no-diff so the observation it produces does not
       // advance the caller-visible baseline during exploration.
-      await ToolRegistry.callInternal("pressButton", {
+      const response = await ToolRegistry.callInternal("pressButton", {
         button: "back",
-        platform: this.device.platform
+        platform: this.device.platform,
+        deviceId: this.device.deviceId,
+        ...(this.sessionUuid ? { sessionUuid: this.sessionUuid } : {})
       }, progress);
+      throwIfInternalToolFailed(response, "pressButton", this.device.platform);
       this.consecutiveBackCount++;
 
       // Wait briefly for navigation
@@ -799,9 +806,12 @@ export class Explore extends BaseVisualChange {
       // `homeScreen` owns the platform-specific implementation and its
       // actionable failures. Keep the internal recovery call out of the
       // external observation-diff baseline.
-      await ToolRegistry.callInternal("homeScreen", {
-        platform: this.device.platform
+      const response = await ToolRegistry.callInternal("homeScreen", {
+        platform: this.device.platform,
+        deviceId: this.device.deviceId,
+        ...(this.sessionUuid ? { sessionUuid: this.sessionUuid } : {})
       }, progress);
+      throwIfInternalToolFailed(response, "homeScreen", this.device.platform);
 
       // Wait for home screen
       await this.timer.sleep(2000);

--- a/src/features/navigation/Explore.ts
+++ b/src/features/navigation/Explore.ts
@@ -3,7 +3,7 @@ import { BaseVisualChange, ProgressCallback } from "../action/BaseVisualChange";
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { createGlobalPerformanceTracker, PerformanceTracker } from "../../utils/PerformanceTracker";
 import { logger } from "../../utils/logger";
-import { AndroidCtrlProxyClient } from "../observe/android";
+import { ToolRegistry } from "../../server/toolRegistry";
 import { NavigationGraphManager, type NavigationEdge, type NavigationGraphService } from "./NavigationGraphManager";
 import { ExportedGraph } from "../../utils/interfaces/NavigationGraph";
 import { TapOnElement } from "../action/TapOnElement";
@@ -767,18 +767,13 @@ export class Explore extends BaseVisualChange {
         );
       }
 
-      // Press back button via accessibility service, fall back to ADB
-      let backSuccess = false;
-      try {
-        const client = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
-        const result = await client.requestGlobalAction("back", 3000);
-        backSuccess = result.success;
-      } catch {
-        // Fall through to ADB
-      }
-      if (!backSuccess) {
-        await this.adb.executeCommand("shell input keyevent KEYCODE_BACK");
-      }
+      // Recovery is an internal interaction, not an Android transport detail.
+      // callInternal marks it no-diff so the observation it produces does not
+      // advance the caller-visible baseline during exploration.
+      await ToolRegistry.callInternal("pressButton", {
+        button: "back",
+        platform: this.device.platform
+      }, progress);
       this.consecutiveBackCount++;
 
       // Wait briefly for navigation
@@ -801,18 +796,12 @@ export class Explore extends BaseVisualChange {
         );
       }
 
-      // Press home button via accessibility service, fall back to ADB
-      let homeSuccess = false;
-      try {
-        const client = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
-        const result = await client.requestGlobalAction("home", 3000);
-        homeSuccess = result.success;
-      } catch {
-        // Fall through to ADB
-      }
-      if (!homeSuccess) {
-        await this.adb.executeCommand("shell input keyevent KEYCODE_HOME");
-      }
+      // `homeScreen` owns the platform-specific implementation and its
+      // actionable failures. Keep the internal recovery call out of the
+      // external observation-diff baseline.
+      await ToolRegistry.callInternal("homeScreen", {
+        platform: this.device.platform
+      }, progress);
 
       // Wait for home screen
       await this.timer.sleep(2000);

--- a/src/features/navigation/Explore.ts
+++ b/src/features/navigation/Explore.ts
@@ -478,6 +478,10 @@ export class Explore extends BaseVisualChange {
     timeoutMs: number,
     startTime: number
   ): boolean {
+    if (this.stopReason) {
+      return false;
+    }
+
     const elapsed = this.timer.now() - startTime;
 
     if (this.interactionCount >= maxInteractions) {
@@ -787,7 +791,7 @@ export class Explore extends BaseVisualChange {
       await this.timer.sleep(1000);
     } catch (error) {
       logger.warn(`[Explore] Failed to navigate back: ${error}`);
-      throw error;
+      this.stopReason = `Back-navigation recovery failed: ${error instanceof Error ? error.message : String(error)}`;
     }
   }
 
@@ -821,7 +825,7 @@ export class Explore extends BaseVisualChange {
       this.consecutiveBackCount = 0;
     } catch (error) {
       logger.warn(`[Explore] Failed to reset to home: ${error}`);
-      throw error;
+      this.stopReason = `Home-screen recovery failed: ${error instanceof Error ? error.message : String(error)}`;
     }
   }
 

--- a/src/features/navigation/NavigateTo.ts
+++ b/src/features/navigation/NavigateTo.ts
@@ -39,7 +39,7 @@ export class NavigateTo {
   private device: BootedDevice;
   private adb: AdbExecutor;
   private navigationManager: NavigationGraphService;
-  private uiStateSetup: UIStateSetup;
+  private uiStateSetup: UIStateSetup | null;
   private screenWaiter: ScreenTransitionWaiter;
   private timer: Timer;
   private pathOptimizer: PathOptimizer | undefined;
@@ -66,8 +66,7 @@ export class NavigateTo {
     this.pathOptimizer = pathOptimizer;
     this.sessionUuid = sessionUuid;
 
-    // Use injected dependencies or create defaults
-    this.uiStateSetup = uiStateSetup || new DefaultUIStateSetup(this.device, this.adb, undefined, timer, sessionUuid);
+    this.uiStateSetup = uiStateSetup;
     this.screenWaiter = screenWaiter || new DefaultScreenTransitionWaiter(
       this.navigationManager,
       NavigateTo.POLL_INTERVAL_MS
@@ -87,6 +86,9 @@ export class NavigateTo {
     const startTime = this.timer.now();
     const { targetScreen } = options;
     this.sessionUuid ??= options.sessionUuid;
+    const uiStateSetup = this.uiStateSetup
+      ?? new DefaultUIStateSetup(this.device, this.adb, undefined, this.timer, this.sessionUuid);
+    this.uiStateSetup = uiStateSetup;
 
     try {
       // Get current screen from navigation graph
@@ -235,14 +237,14 @@ export class NavigateTo {
           if (edge.interaction) {
             // Set up scroll position if required (must happen before UI state setup)
             if (edge.uiState?.scrollPosition) {
-              const scrollAction = await this.uiStateSetup.setupScrollPosition(edge.uiState.scrollPosition, options.platform);
+              const scrollAction = await uiStateSetup.setupScrollPosition(edge.uiState.scrollPosition, options.platform);
               if (scrollAction) {
                 executedPath.push(scrollAction);
               }
             }
 
             // Set up required UI state before executing the tool call
-            const setupActions = await this.uiStateSetup.setupUIState(edge, options.platform);
+            const setupActions = await uiStateSetup.setupUIState(edge, options.platform);
             if (setupActions.length > 0) {
               executedPath.push(...setupActions);
             }

--- a/src/features/navigation/NavigateTo.ts
+++ b/src/features/navigation/NavigateTo.ts
@@ -18,6 +18,7 @@ import { DefaultUIStateSetup } from "./DefaultUIStateSetup";
 import { ScreenTransitionWaiter } from "./interfaces/ScreenTransitionWaiter";
 import { DefaultScreenTransitionWaiter } from "./DefaultScreenTransitionWaiter";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
+import { PressButton } from "../action/PressButton";
 
 /**
  * Options for the navigateTo tool.
@@ -340,9 +341,20 @@ export class NavigateTo {
    * Press the back button as a fallback navigation action.
    */
   private async pressBack(): Promise<void> {
-    // Keep learned-path recovery platform-aware. The interaction tool selects
-    // CtrlProxy on iOS and retains Android's accessibility/ADB fallback; the
-    // registry call also preserves the internal no-diff contract.
+    if (this.device.platform === "android") {
+      // Keep the caller's injected ADB executor and timer for Android recovery.
+      // PressButton retains the accessibility-service/ADB fallback without
+      // observing, so this internal recovery does not advance any diff baseline.
+      const result = await new PressButton(this.device, this.adb, this.timer).press("back");
+      if (!result.success) {
+        throw new Error(result.error ?? "Android back navigation failed");
+      }
+      logger.debug("[NAVIGATE_TO] Pressed back via Android interaction action");
+      return;
+    }
+
+    // iOS has no injected host transport, so retain its internal tool routing
+    // for the selected device and no-diff behavior.
     const response = await ToolRegistry.callInternal("pressButton", {
       button: "back",
       platform: this.device.platform,

--- a/src/features/navigation/NavigateTo.ts
+++ b/src/features/navigation/NavigateTo.ts
@@ -4,6 +4,7 @@ import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/A
 import { logger } from "../../utils/logger";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { ToolRegistry } from "../../server/toolRegistry";
+import { throwIfInternalToolFailed } from "../../server/internalToolCall";
 import {
   NavigationGraphManager,
   ToolCallInteraction,
@@ -26,6 +27,8 @@ export interface NavigateToOptions {
   targetScreen: string;
   /** Platform (android/ios) */
   platform: "android" | "ios";
+  /** Session that selected the outer device, retained by internal replays. */
+  sessionUuid?: string;
 }
 
 /**
@@ -40,6 +43,7 @@ export class NavigateTo {
   private screenWaiter: ScreenTransitionWaiter;
   private timer: Timer;
   private pathOptimizer: PathOptimizer | undefined;
+  private sessionUuid?: string;
 
   private static readonly MAX_TIMEOUT_MS = 30000; // 30 seconds
   private static readonly STEP_TIMEOUT_MS = 5000; // 5 seconds per step
@@ -52,16 +56,18 @@ export class NavigateTo {
     screenWaiter: ScreenTransitionWaiter | null = null,
     navigationManager?: NavigationGraphService,
     timer: Timer = defaultTimer,
-    pathOptimizer?: PathOptimizer
+    pathOptimizer?: PathOptimizer,
+    sessionUuid?: string
   ) {
     this.device = device;
     this.adb = adbFactory.create(device);
     this.navigationManager = navigationManager ?? NavigationGraphManager.getInstance();
     this.timer = timer;
     this.pathOptimizer = pathOptimizer;
+    this.sessionUuid = sessionUuid;
 
     // Use injected dependencies or create defaults
-    this.uiStateSetup = uiStateSetup || new DefaultUIStateSetup(this.device, this.adb);
+    this.uiStateSetup = uiStateSetup || new DefaultUIStateSetup(this.device, this.adb, undefined, timer, sessionUuid);
     this.screenWaiter = screenWaiter || new DefaultScreenTransitionWaiter(
       this.navigationManager,
       NavigateTo.POLL_INTERVAL_MS
@@ -80,6 +86,7 @@ export class NavigateTo {
 
     const startTime = this.timer.now();
     const { targetScreen } = options;
+    this.sessionUuid ??= options.sessionUuid;
 
     try {
       // Get current screen from navigation graph
@@ -315,10 +322,16 @@ export class NavigateTo {
     // `interaction.args` is never mutated. Under `--actions-diff-observe` this
     // replay neither diffs its observation nor advances the agent-facing diff
     // baseline. Throws ActionableError if the tool is not registered.
-    await ToolRegistry.callInternal(
+    const response = await ToolRegistry.callInternal(
       interaction.toolName,
-      interaction.args as Record<string, unknown>
+      {
+        ...(interaction.args as Record<string, unknown>),
+        platform: this.device.platform,
+        deviceId: this.device.deviceId,
+        ...(this.sessionUuid ? { sessionUuid: this.sessionUuid } : {})
+      }
     );
+    throwIfInternalToolFailed(response, interaction.toolName, this.device.platform);
   }
 
   /**
@@ -328,10 +341,13 @@ export class NavigateTo {
     // Keep learned-path recovery platform-aware. The interaction tool selects
     // CtrlProxy on iOS and retains Android's accessibility/ADB fallback; the
     // registry call also preserves the internal no-diff contract.
-    await ToolRegistry.callInternal("pressButton", {
+    const response = await ToolRegistry.callInternal("pressButton", {
       button: "back",
-      platform: this.device.platform
+      platform: this.device.platform,
+      deviceId: this.device.deviceId,
+      ...(this.sessionUuid ? { sessionUuid: this.sessionUuid } : {})
     });
+    throwIfInternalToolFailed(response, "pressButton", this.device.platform);
     logger.debug(`[NAVIGATE_TO] Pressed back via ${this.device.platform} interaction tool`);
   }
 

--- a/src/features/navigation/NavigateTo.ts
+++ b/src/features/navigation/NavigateTo.ts
@@ -2,7 +2,6 @@ import { BootedDevice, NavigateToResult } from "../../models";
 import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { logger } from "../../utils/logger";
-import { AndroidCtrlProxyClient } from "../observe/android";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { ToolRegistry } from "../../server/toolRegistry";
 import {
@@ -36,7 +35,6 @@ export interface NavigateToOptions {
 export class NavigateTo {
   private device: BootedDevice;
   private adb: AdbExecutor;
-  private adbFactory: AdbClientFactory;
   private navigationManager: NavigationGraphService;
   private uiStateSetup: UIStateSetup;
   private screenWaiter: ScreenTransitionWaiter;
@@ -57,7 +55,6 @@ export class NavigateTo {
     pathOptimizer?: PathOptimizer
   ) {
     this.device = device;
-    this.adbFactory = adbFactory;
     this.adb = adbFactory.create(device);
     this.navigationManager = navigationManager ?? NavigationGraphManager.getInstance();
     this.timer = timer;
@@ -328,19 +325,14 @@ export class NavigateTo {
    * Press the back button as a fallback navigation action.
    */
   private async pressBack(): Promise<void> {
-    // Try accessibility service global action first, fall back to ADB
-    try {
-      const client = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
-      const result = await client.requestGlobalAction("back", 3000);
-      if (result.success) {
-        logger.debug("[NAVIGATE_TO] Pressed back via accessibility service");
-        return;
-      }
-    } catch {
-      // Fall through to ADB
-    }
-    await this.adb.executeCommand("shell input keyevent 4");
-    logger.debug("[NAVIGATE_TO] Pressed back via ADB keyevent");
+    // Keep learned-path recovery platform-aware. The interaction tool selects
+    // CtrlProxy on iOS and retains Android's accessibility/ADB fallback; the
+    // registry call also preserves the internal no-diff contract.
+    await ToolRegistry.callInternal("pressButton", {
+      button: "back",
+      platform: this.device.platform
+    });
+    logger.debug(`[NAVIGATE_TO] Pressed back via ${this.device.platform} interaction tool`);
   }
 
   /**

--- a/src/server/internalToolCall.ts
+++ b/src/server/internalToolCall.ts
@@ -1,3 +1,6 @@
+import { ActionableError } from "../models";
+import { logger } from "../utils/logger";
+
 /**
  * Shared marker for internal tool-to-tool calls (issues #3053 / #3087).
  *
@@ -32,4 +35,48 @@ export function markInternalToolCall<T extends Record<string, unknown>>(
   args: T
 ): T & { [INTERNAL_NO_DIFF_PARAM]: true } {
   return { ...args, [INTERNAL_NO_DIFF_PARAM]: true };
+}
+
+/**
+ * Surface a failed internal interaction instead of treating its MCP envelope as
+ * a successful recovery. Most interaction tools return JSON content rather
+ * than throw for an unsuccessful device action.
+ */
+export function throwIfInternalToolFailed(
+  response: unknown,
+  toolName: string,
+  platform: string
+): void {
+  if (!response || typeof response !== "object") {
+    return;
+  }
+
+  const envelope = response as {
+    success?: unknown;
+    error?: unknown;
+    structuredContent?: unknown;
+    content?: Array<{ type?: unknown; text?: unknown }>;
+  };
+  const payload = envelope.structuredContent && typeof envelope.structuredContent === "object"
+    ? envelope.structuredContent as { success?: unknown; error?: unknown }
+    : (() => {
+      const textPart = envelope.content?.find(item => item.type === "text");
+      if (typeof textPart?.text !== "string") {
+        return undefined;
+      }
+      try {
+        const parsed = JSON.parse(textPart.text);
+        return parsed && typeof parsed === "object"
+          ? parsed as { success?: unknown; error?: unknown }
+          : undefined;
+      } catch (error) {
+        logger.debug(`[internalToolCall] Could not parse ${toolName} response: ${error}`);
+        return undefined;
+      }
+    })();
+
+  if (payload?.success === false || envelope.success === false) {
+    const error = payload?.error ?? envelope.error ?? "unknown failure";
+    throw new ActionableError(`${toolName} failed on ${platform}: ${String(error)}`);
+  }
 }

--- a/src/server/internalToolCall.ts
+++ b/src/server/internalToolCall.ts
@@ -70,6 +70,7 @@ export function throwIfInternalToolFailed(
           ? parsed as { success?: unknown; error?: unknown }
           : undefined;
       } catch (error) {
+        // Plain-text tool output has no structured failure signal to propagate.
         logger.debug(`[internalToolCall] Could not parse ${toolName} response: ${error}`);
         return undefined;
       }

--- a/src/server/navigationTools.ts
+++ b/src/server/navigationTools.ts
@@ -72,11 +72,13 @@ export function registerNavigationTools() {
         null,
         navigationManager,
         undefined,
-        new DefaultPathOptimizer(navigationManager)
+        new DefaultPathOptimizer(navigationManager),
+        args.sessionUuid
       );
       const options: NavigateToOptions = {
         targetScreen: args.targetScreen,
-        platform: args.platform || "android"
+        platform: args.platform || "android",
+        sessionUuid: args.sessionUuid
       };
       const result = await navigateTo.execute(options, progress);
 
@@ -145,7 +147,13 @@ export function registerNavigationTools() {
     signal?: AbortSignal
   ) => {
     try {
-      const explore = new Explore(device, null, undefined, getNavigationManager(args.sessionUuid));
+      const explore = new Explore(
+        device,
+        null,
+        undefined,
+        getNavigationManager(args.sessionUuid),
+        args.sessionUuid
+      );
       const options: ExploreOptions = {
         maxInteractions: args.maxInteractions,
         timeoutMs: args.timeoutMs,

--- a/test/bats/ensure-daemon-ready.bats
+++ b/test/bats/ensure-daemon-ready.bats
@@ -28,6 +28,9 @@ make_mock_auto_mobile() {
   cat > "${MOCK_BIN}/auto-mobile" <<SCRIPT
 #!/usr/bin/env bash
 if [ "\$1" = "--daemon" ] && [ "\$2" = "start" ]; then
+  if [ "\$3" = "--debug" ]; then
+    printf '%s\n' "enabled" > "${MOCK_BIN}/debug-mode"
+  fi
   printf '%s\n' "\${AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS:-unset}" > "${MOCK_BIN}/startup-timeout"
   exit 0
 elif [ "\$1" = "--daemon" ] && [ "\$2" = "health" ]; then
@@ -117,4 +120,11 @@ SCRIPT
   run env AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS=45000 bash "$SCRIPT"
   [ "$status" -eq 0 ]
   [ "$(cat "${MOCK_BIN}/startup-timeout")" = "45000" ]
+}
+
+@test "starts the daemon in debug mode when requested" {
+  make_mock_auto_mobile 0
+  run env AUTOMOBILE_DAEMON_DEBUG=1 bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [ "$(cat "${MOCK_BIN}/debug-mode")" = "enabled" ]
 }

--- a/test/bats/navigation-graph-sdk-event-integration.bats
+++ b/test/bats/navigation-graph-sdk-event-integration.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+
+SCRIPT="scripts/ios/navigation-graph-sdk-event-integration.sh"
+
+setup() {
+  MOCK_BIN="$(mktemp -d)"
+  ORIG_PATH="$PATH"
+  export GRAPH_ATTEMPTS_FILE="${MOCK_BIN}/graph-attempts"
+}
+
+teardown() {
+  rm -rf "$MOCK_BIN"
+  export PATH="$ORIG_PATH"
+}
+
+make_mock() {
+  local name="$1"
+  local body="$2"
+  cat > "${MOCK_BIN}/${name}" <<SCRIPT
+#!/usr/bin/env bash
+${body}
+SCRIPT
+  chmod +x "${MOCK_BIN}/${name}"
+}
+
+@test "retries getNavigationGraph after an initial CLI failure" {
+  make_mock xcrun 'exit 0'
+  make_mock curl 'exit 0'
+  make_mock base64 'cat'
+  make_mock sleep 'exit 0'
+  make_mock jq '
+if [ "$1" = "-cn" ]; then
+  printf "{}\\n"
+  exit 0
+fi
+exit 0
+'
+  make_mock auto-mobile '
+if [ "$1" = "--debug" ] && [ "$2" = "--cli" ] && [ "$3" = "getNavigationGraph" ]; then
+  attempts=0
+  [ -f "$GRAPH_ATTEMPTS_FILE" ] && attempts="$(cat "$GRAPH_ATTEMPTS_FILE")"
+  attempts=$((attempts + 1))
+  printf "%s\\n" "$attempts" > "$GRAPH_ATTEMPTS_FILE"
+  if [ "$attempts" -eq 1 ]; then
+    exit 1
+  fi
+  printf "{}\\n"
+fi
+'
+
+  run env PATH="${MOCK_BIN}:${PATH}" bash "$SCRIPT" "simulator-udid"
+
+  [ "$status" -eq 0 ]
+  [ "$(cat "$GRAPH_ATTEMPTS_FILE")" = "2" ]
+  [[ "$output" == *"getNavigationGraph attempt 1 failed"* ]]
+}

--- a/test/bats/navigation-graph-sdk-event-integration.bats
+++ b/test/bats/navigation-graph-sdk-event-integration.bats
@@ -6,6 +6,7 @@ setup() {
   MOCK_BIN="$(mktemp -d)"
   ORIG_PATH="$PATH"
   export GRAPH_ATTEMPTS_FILE="${MOCK_BIN}/graph-attempts"
+  export CURL_URL_FILE="${MOCK_BIN}/curl-urls"
 }
 
 teardown() {
@@ -25,7 +26,7 @@ SCRIPT
 
 @test "retries getNavigationGraph after an initial CLI failure" {
   make_mock xcrun 'exit 0'
-  make_mock curl 'exit 0'
+  make_mock curl 'printf "%s\\n" "${!#}" >> "$CURL_URL_FILE"'
   make_mock base64 'cat'
   make_mock sleep 'exit 0'
   make_mock jq '
@@ -33,9 +34,17 @@ if [ "$1" = "-cn" ]; then
   printf "{}\\n"
   exit 0
 fi
+if [ "$1" = "-er" ]; then
+  printf "8768\\n"
+  exit 0
+fi
 exit 0
 '
   make_mock auto-mobile '
+if [ "$1" = "--cli" ] && [ "$2" = "doctor" ]; then
+  printf "{\"ios\":{\"checks\":[]}}\\n"
+  exit 0
+fi
 if [ "$1" = "--debug" ] && [ "$2" = "--cli" ] && [ "$3" = "getNavigationGraph" ]; then
   attempts=0
   [ -f "$GRAPH_ATTEMPTS_FILE" ] && attempts="$(cat "$GRAPH_ATTEMPTS_FILE")"
@@ -53,4 +62,6 @@ fi
   [ "$status" -eq 0 ]
   [ "$(cat "$GRAPH_ATTEMPTS_FILE")" = "2" ]
   [[ "$output" == *"getNavigationGraph attempt 1 failed"* ]]
+  grep -qx "http://127.0.0.1:8768/health" "$CURL_URL_FILE"
+  grep -qx "http://127.0.0.1:8768/sdk-events" "$CURL_URL_FILE"
 }

--- a/test/cli/doctorCommand.test.ts
+++ b/test/cli/doctorCommand.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test } from "bun:test";
+import { doctorToolParams } from "../../src/cli";
+
+describe("doctorToolParams", () => {
+  test("keeps CLI JSON formatting out of the daemon doctor request", () => {
+    expect(doctorToolParams({ ios: true, json: true })).toEqual({ ios: true });
+  });
+});

--- a/test/features/navigation/DefaultUIStateSetup.test.ts
+++ b/test/features/navigation/DefaultUIStateSetup.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { DefaultUIStateSetup, type ObserveScreenLike } from "../../../src/features/navigation/DefaultUIStateSetup";
 import { RealObserveScreen } from "../../../src/features/observe/ObserveScreen";
 import { FakeAdbClient } from "../../fakes/FakeAdbClient";
@@ -11,6 +11,7 @@ import { ToolRegistry } from "../../../src/server/toolRegistry";
 import { createStructuredToolResponse } from "../../../src/utils/toolUtils";
 import { INTERNAL_NO_DIFF_PARAM } from "../../../src/server/internalToolCall";
 import type { ModalState, ScrollPosition } from "../../../src/utils/interfaces/NavigationGraph";
+import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
 
 const device: BootedDevice = {
   deviceId: "test-device",
@@ -251,10 +252,8 @@ describe("DefaultUIStateSetup", () => {
       ToolRegistry.register("swipeOn", "swipeOn", {}, async () =>
         createStructuredToolResponse({ success: true })
       );
-      let backArgs: Record<string, unknown> | undefined;
-      ToolRegistry.register("pressButton", "pressButton", {}, async (args: Record<string, unknown>) => {
-        backArgs = args;
-        return createStructuredToolResponse({ success: true });
+      ToolRegistry.register("pressButton", "pressButton", {}, async () => {
+        throw new Error("Android modal recovery must not use the global tool registry");
       });
 
       // Stateful observe provider: the first post-swipe observation still
@@ -272,27 +271,29 @@ describe("DefaultUIStateSetup", () => {
         },
       });
 
+      const ctrlProxySpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+        requestGlobalAction: async () => ({ success: false, error: "unavailable" })
+      } as never);
       const setup = makeSetup(statefulObserve);
-      const dismissed = await (
-        setup as unknown as {
-          dismissTopModal: (modal: ModalState, platform: string) => Promise<boolean>;
-        }
-      ).dismissTopModal(bottomSheet, "android");
+      let dismissed: boolean;
+      try {
+        dismissed = await (
+          setup as unknown as {
+            dismissTopModal: (modal: ModalState, platform: string) => Promise<boolean>;
+          }
+        ).dismissTopModal(bottomSheet, "android");
+      } finally {
+        ctrlProxySpy.mockRestore();
+      }
 
       expect(dismissed).toBe(true);
       // The swipe ran but did not dismiss (windowId still present on observe #1),
       // so both post-swipe and post-back observations were consulted.
       expect(observeCalls).toBe(2);
-      // The fallback routes through the platform-aware interaction tool, which
-      // retains the internal no-diff marker and delegates Android fallback to
-      // PressButton itself.
+      // Android recovery uses the setup instance's injected dependencies rather
+      // than the global interaction registry.
       const fakeAdb = (setup as unknown as { adb: FakeAdbClient }).adb;
-      expect(backArgs).toMatchObject({
-        button: "back",
-        platform: "android",
-        [INTERNAL_NO_DIFF_PARAM]: true,
-      });
-      expect(fakeAdb.getAllCommands()).toEqual([]);
+      expect(fakeAdb.getAllCommands()).toEqual(["shell input keyevent 4"]);
     });
 
     test("does not mistakenly resolve a tool registered under the old name `swipe`", async () => {

--- a/test/features/navigation/DefaultUIStateSetup.test.ts
+++ b/test/features/navigation/DefaultUIStateSetup.test.ts
@@ -101,7 +101,7 @@ describe("DefaultUIStateSetup", () => {
       return setup;
     }
 
-    test("uses a content-description selector for a missing content-description-only selection", async () => {
+    test("routes a missing content-description-only selection through tapOn's text selector", async () => {
       let capturedArgs: Record<string, unknown> | undefined;
       ToolRegistry.register("tapOn", "tapOn", {}, async args => {
         capturedArgs = args;
@@ -113,7 +113,7 @@ describe("DefaultUIStateSetup", () => {
         uiState: { selectedElements: [{ contentDesc: "Open settings" }] },
       } as NavigationEdge, "android");
 
-      expect(capturedArgs?.selector).toEqual({ contentDesc: "Open settings" });
+      expect(capturedArgs?.selector).toEqual({ text: "Open settings" });
       expect(actions).toEqual(['tapOn({"contentDesc":"Open settings"})']);
     });
 

--- a/test/features/navigation/DefaultUIStateSetup.test.ts
+++ b/test/features/navigation/DefaultUIStateSetup.test.ts
@@ -298,5 +298,19 @@ describe("DefaultUIStateSetup", () => {
       });
       expect(fakeAdb.getAllCommands()).toEqual([]);
     });
+
+    test("preserves Android's coordinate outside-tap recovery for popups", async () => {
+      const setup = makeSetup(nullObserve);
+
+      const dismissed = await (
+        setup as unknown as {
+          dismissTopModal: (modal: ModalState, platform: string) => Promise<boolean>;
+        }
+      ).dismissTopModal({ type: "popup", layer: 1, windowId: 42 }, "android");
+
+      expect(dismissed).toBe(true);
+      const fakeAdb = (setup as unknown as { adb: FakeAdbClient }).adb;
+      expect(fakeAdb.wasCommandExecuted("shell input tap 50 50")).toBe(true);
+    });
   });
 });

--- a/test/features/navigation/DefaultUIStateSetup.test.ts
+++ b/test/features/navigation/DefaultUIStateSetup.test.ts
@@ -208,6 +208,11 @@ describe("DefaultUIStateSetup", () => {
       ToolRegistry.register("swipeOn", "swipeOn", {}, async () =>
         createStructuredToolResponse({ success: true })
       );
+      let backArgs: Record<string, unknown> | undefined;
+      ToolRegistry.register("pressButton", "pressButton", {}, async (args: Record<string, unknown>) => {
+        backArgs = args;
+        return createStructuredToolResponse({ success: true });
+      });
 
       // Stateful observe provider: the first post-swipe observation still
       // contains the bottomsheet's windowId (swipe did NOT dismiss it), forcing
@@ -235,11 +240,16 @@ describe("DefaultUIStateSetup", () => {
       // The swipe ran but did not dismiss (windowId still present on observe #1),
       // so both post-swipe and post-back observations were consulted.
       expect(observeCalls).toBe(2);
-      // The back-button fallback fired via the ADB keyevent seam — the
-      // AndroidCtrlProxy accessibility path is not connected in a unit context
-      // (requestGlobalAction fast-fails), so pressBack falls through to ADB.
+      // The fallback routes through the platform-aware interaction tool, which
+      // retains the internal no-diff marker and delegates Android fallback to
+      // PressButton itself.
       const fakeAdb = (setup as unknown as { adb: FakeAdbClient }).adb;
-      expect(fakeAdb.wasCommandExecuted("shell input keyevent 4")).toBe(true);
+      expect(backArgs).toMatchObject({
+        button: "back",
+        platform: "android",
+        [INTERNAL_NO_DIFF_PARAM]: true,
+      });
+      expect(fakeAdb.getAllCommands()).toEqual([]);
     });
 
     test("does not mistakenly resolve a tool registered under the old name `swipe`", async () => {
@@ -260,6 +270,33 @@ describe("DefaultUIStateSetup", () => {
       ).dismissTopModal(bottomSheet, "android");
 
       expect(legacySwipeCalls).toBe(0);
+    });
+
+    test("uses iOS pressButton recovery without Android shell fallbacks", async () => {
+      const iosDevice: BootedDevice = { ...device, deviceId: "ios-device", platform: "ios" };
+      const fakeAdb = new FakeAdbClient();
+      const timer = new FakeTimer();
+      timer.enableAutoAdvance();
+      const setup = new DefaultUIStateSetup(iosDevice, fakeAdb, nullObserve, timer);
+      let backArgs: Record<string, unknown> | undefined;
+      ToolRegistry.register("pressButton", "pressButton", {}, async (args: Record<string, unknown>) => {
+        backArgs = args;
+        return createStructuredToolResponse({ success: true });
+      });
+
+      const dismissed = await (
+        setup as unknown as {
+          dismissTopModal: (modal: ModalState, platform: string) => Promise<boolean>;
+        }
+      ).dismissTopModal({ type: "popup", layer: 1, windowId: 42 }, "ios");
+
+      expect(dismissed).toBe(true);
+      expect(backArgs).toMatchObject({
+        button: "back",
+        platform: "ios",
+        [INTERNAL_NO_DIFF_PARAM]: true,
+      });
+      expect(fakeAdb.getAllCommands()).toEqual([]);
     });
   });
 });

--- a/test/features/navigation/DefaultUIStateSetup.test.ts
+++ b/test/features/navigation/DefaultUIStateSetup.test.ts
@@ -88,6 +88,49 @@ describe("DefaultUIStateSetup", () => {
     expect(calls).toBe(0);
   });
 
+  describe("selected-element setup", () => {
+    afterEach(() => {
+      ToolRegistry.clearTools();
+    });
+
+    function setupWithNoSelections(): DefaultUIStateSetup {
+      const setup = makeSetup();
+      (setup as unknown as {
+        getCurrentUIState: () => Promise<{ modalStack: ModalState[]; selectedElements: [] }>;
+      }).getCurrentUIState = async () => ({ modalStack: [], selectedElements: [] });
+      return setup;
+    }
+
+    test("uses a content-description selector for a missing content-description-only selection", async () => {
+      let capturedArgs: Record<string, unknown> | undefined;
+      ToolRegistry.register("tapOn", "tapOn", {}, async args => {
+        capturedArgs = args;
+        return createStructuredToolResponse({ success: true });
+      });
+      const setup = setupWithNoSelections();
+
+      const actions = await setup.setupUIState({
+        uiState: { selectedElements: [{ contentDesc: "Open settings" }] },
+      } as NavigationEdge, "android");
+
+      expect(capturedArgs?.selector).toEqual({ contentDesc: "Open settings" });
+      expect(actions).toEqual(['tapOn({"contentDesc":"Open settings"})']);
+    });
+
+    test("does not report a selected-element tap when its internal tool response fails", async () => {
+      ToolRegistry.register("tapOn", "tapOn", {}, async () =>
+        createStructuredToolResponse({ success: false, error: "element is disabled" })
+      );
+      const setup = setupWithNoSelections();
+
+      const actions = await setup.setupUIState({
+        uiState: { selectedElements: [{ text: "Settings" }] },
+      } as NavigationEdge, "android");
+
+      expect(actions).toEqual([]);
+    });
+  });
+
   // Regression for issue #2897 (sibling of the toolRegistry scroll-position fix):
   // `swipeOn`'s handler returns an MCP envelope from createStructuredToolResponse,
   // which hoists only `success`/`error` to the top level — `found` lives under

--- a/test/features/navigation/Explore.test.ts
+++ b/test/features/navigation/Explore.test.ts
@@ -4,6 +4,8 @@ import { BootedDevice, Element, ObserveResult } from "../../../src/models";
 import { AdbClient } from "../../../src/utils/android-cmdline-tools/AdbClient";
 import { FakeNavigationGraphManager } from "../../fakes/FakeNavigationGraphManager";
 import { FakeTimer } from "../../fakes/FakeTimer";
+import { ToolRegistry } from "../../../src/server/toolRegistry";
+import { INTERNAL_NO_DIFF_PARAM } from "../../../src/server/internalToolCall";
 
 // Import extracted functions for testing
 import {
@@ -99,7 +101,7 @@ describe("Explore", () => {
   });
 
   afterEach(() => {
-    // No cleanup needed since we're using injected fakes
+    ToolRegistry.clearTools();
   });
 
   function createMockViewHierarchyNode(overrides: any = {}): any {
@@ -408,6 +410,49 @@ describe("Explore", () => {
 
       expect(result.stopReason).toContain("com.test.app");
       expect(backPresses.length).toBe(outOfAppLimit);
+    });
+  });
+
+  describe("platform-aware recovery", () => {
+    test("routes iOS dead-end and home recovery through internal interaction tools without ADB", async () => {
+      const iOSDevice = {
+        deviceId: "ios-simulator-123",
+        platform: "ios",
+        source: "local"
+      } as BootedDevice;
+      const adbCommands: string[] = [];
+      const adb = {
+        executeCommand: async (command: string) => {
+          adbCommands.push(command);
+          return "";
+        }
+      } as AdbClient;
+      const calls: Array<{ name: string; args: Record<string, unknown> }> = [];
+
+      ToolRegistry.register("pressButton", "pressButton", {}, async args => {
+        calls.push({ name: "pressButton", args });
+        return { success: true };
+      });
+      ToolRegistry.register("homeScreen", "homeScreen", {}, async args => {
+        calls.push({ name: "homeScreen", args });
+        return { success: true };
+      });
+
+      explore = new Explore(iOSDevice, adb, fakeTimer, fakeGraph);
+      await (explore as any).handleDeadEnd();
+      await (explore as any).resetToHome();
+
+      expect(calls).toEqual([
+        {
+          name: "pressButton",
+          args: { button: "back", platform: "ios", [INTERNAL_NO_DIFF_PARAM]: true }
+        },
+        {
+          name: "homeScreen",
+          args: { platform: "ios", [INTERNAL_NO_DIFF_PARAM]: true }
+        }
+      ]);
+      expect(adbCommands).toEqual([]);
     });
   });
 

--- a/test/features/navigation/Explore.test.ts
+++ b/test/features/navigation/Explore.test.ts
@@ -481,6 +481,18 @@ describe("Explore", () => {
         registry.deviceSessionManager = originalDeviceSessionManager;
       }
     });
+
+    test("propagates a failed dead-end recovery instead of reporting exploration success", async () => {
+      ToolRegistry.register("pressButton", "pressButton", {}, async () => ({
+        success: false,
+        error: "Back navigation was rejected"
+      }));
+      explore = new Explore(device, null, fakeTimer, fakeGraph);
+
+      await expect((explore as any).handleDeadEnd()).rejects.toThrow(
+        "pressButton failed on android: Back navigation was rejected"
+      );
+    });
   });
 
   describe("element tracking", () => {

--- a/test/features/navigation/Explore.test.ts
+++ b/test/features/navigation/Explore.test.ts
@@ -482,15 +482,54 @@ describe("Explore", () => {
       }
     });
 
-    test("propagates a failed dead-end recovery instead of reporting exploration success", async () => {
+    test("records failed dead-end recovery as a terminal partial-report reason", async () => {
       ToolRegistry.register("pressButton", "pressButton", {}, async () => ({
         success: false,
         error: "Back navigation was rejected"
       }));
       explore = new Explore(device, null, fakeTimer, fakeGraph);
 
-      await expect((explore as any).handleDeadEnd()).rejects.toThrow(
-        "pressButton failed on android: Back navigation was rejected"
+      await (explore as any).handleDeadEnd();
+
+      expect((explore as any).stopReason).toBe(
+        "Back-navigation recovery failed: pressButton failed on android: Back navigation was rejected"
+      );
+    });
+
+    test("records failed home reset as a terminal partial-report reason", async () => {
+      ToolRegistry.register("homeScreen", "homeScreen", {}, async () => ({
+        success: false,
+        error: "Home navigation was rejected"
+      }));
+      explore = new Explore(device, null, fakeTimer, fakeGraph);
+
+      await (explore as any).resetToHome();
+
+      expect((explore as any).stopReason).toBe(
+        "Home-screen recovery failed: homeScreen failed on android: Home navigation was rejected"
+      );
+    });
+
+    test("returns a partial report when dead-end recovery fails", async () => {
+      ToolRegistry.register("pressButton", "pressButton", {}, async () => ({
+        success: false,
+        error: "Back navigation was rejected"
+      }));
+      explore = new Explore(device, null, fakeTimer, fakeGraph);
+      (explore as any).observeScreen = {
+        execute: async () => createMockObservation([], "com.test.app")
+      };
+      (explore as any).selectNextElement = async () => undefined;
+
+      const result = await explore.execute({
+        maxInteractions: 1,
+        timeoutMs: 5000,
+        packageName: "com.test.app"
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.stopReason).toBe(
+        "Back-navigation recovery failed: pressButton failed on android: Back navigation was rejected"
       );
     });
   });

--- a/test/features/navigation/Explore.test.ts
+++ b/test/features/navigation/Explore.test.ts
@@ -4,6 +4,7 @@ import { BootedDevice, Element, ObserveResult } from "../../../src/models";
 import { AdbClient } from "../../../src/utils/android-cmdline-tools/AdbClient";
 import { FakeNavigationGraphManager } from "../../fakes/FakeNavigationGraphManager";
 import { FakeTimer } from "../../fakes/FakeTimer";
+import { FakeDeviceSessionManager } from "../../fakes/FakeDeviceSessionManager";
 import { ToolRegistry } from "../../../src/server/toolRegistry";
 import { INTERNAL_NO_DIFF_PARAM } from "../../../src/server/internalToolCall";
 
@@ -445,14 +446,40 @@ describe("Explore", () => {
       expect(calls).toEqual([
         {
           name: "pressButton",
-          args: { button: "back", platform: "ios", [INTERNAL_NO_DIFF_PARAM]: true }
+          args: { button: "back", platform: "ios", deviceId: "ios-simulator-123", [INTERNAL_NO_DIFF_PARAM]: true }
         },
         {
           name: "homeScreen",
-          args: { platform: "ios", [INTERNAL_NO_DIFF_PARAM]: true }
+          args: { platform: "ios", deviceId: "ios-simulator-123", [INTERNAL_NO_DIFF_PARAM]: true }
         }
       ]);
       expect(adbCommands).toEqual([]);
+    });
+
+    test("targets the selected iOS device when another iOS simulator is booted", async () => {
+      const iosA = { deviceId: "ios-simulator-a", name: "iPhone A", platform: "ios" } as BootedDevice;
+      const iosB = { deviceId: "ios-simulator-b", name: "iPhone B", platform: "ios" } as BootedDevice;
+      const sessions = new FakeDeviceSessionManager();
+      sessions.setConnectedDevices([iosA, iosB]);
+      const registry = ToolRegistry as unknown as { deviceSessionManager: unknown };
+      const originalDeviceSessionManager = registry.deviceSessionManager;
+      registry.deviceSessionManager = sessions;
+      const selectedDeviceIds: string[] = [];
+
+      try {
+        ToolRegistry.registerDeviceAware("pressButton", "pressButton", { parse: (args: unknown) => args } as any,
+                                         async selectedDevice => {
+                                           selectedDeviceIds.push(selectedDevice.deviceId);
+                                           return { success: true };
+                                         });
+        explore = new Explore(iosB, null, fakeTimer, fakeGraph);
+
+        await (explore as any).handleDeadEnd();
+
+        expect(selectedDeviceIds).toEqual([iosB.deviceId]);
+      } finally {
+        registry.deviceSessionManager = originalDeviceSessionManager;
+      }
     });
   });
 

--- a/test/features/navigation/Explore.test.ts
+++ b/test/features/navigation/Explore.test.ts
@@ -1,4 +1,4 @@
-import { expect, describe, test, beforeEach, afterEach } from "bun:test";
+import { expect, describe, test, beforeEach, afterEach, spyOn } from "bun:test";
 import { Explore } from "../../../src/features/navigation/Explore";
 import { BootedDevice, Element, ObserveResult } from "../../../src/models";
 import { AdbClient } from "../../../src/utils/android-cmdline-tools/AdbClient";
@@ -30,6 +30,7 @@ import {
 } from "../../../src/features/navigation/ExploreValidateMode";
 import { DefaultElementParser } from "../../../src/features/utility/ElementParser";
 import type { ElementParser } from "../../../src/utils/interfaces/ElementParser";
+import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
 
 describe("Explore", () => {
   let explore: Explore;
@@ -482,54 +483,111 @@ describe("Explore", () => {
       }
     });
 
-    test("records failed dead-end recovery as a terminal partial-report reason", async () => {
-      ToolRegistry.register("pressButton", "pressButton", {}, async () => ({
-        success: false,
-        error: "Back navigation was rejected"
-      }));
-      explore = new Explore(device, null, fakeTimer, fakeGraph);
+    test("uses injected Android recovery dependencies without nested progress", async () => {
+      const commands: string[] = [];
+      const adb = {
+        executeCommand: async (command: string) => {
+          commands.push(command);
+          return "";
+        }
+      } as AdbClient;
+      const progressUpdates: Array<{ current: number; total?: number; message?: string }> = [];
+      const ctrlProxySpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+        requestGlobalAction: async () => ({ success: false, error: "unavailable" })
+      } as never);
+      ToolRegistry.register("pressButton", "pressButton", {}, async () => {
+        throw new Error("Android recovery must not use the global tool registry");
+      });
+      ToolRegistry.register("homeScreen", "homeScreen", {}, async () => {
+        throw new Error("Android recovery must not use the global tool registry");
+      });
+      explore = new Explore(device, adb, fakeTimer, fakeGraph);
 
-      await (explore as any).handleDeadEnd();
+      try {
+        await (explore as any).handleDeadEnd(async (current: number, total?: number, message?: string) => {
+          progressUpdates.push({ current, total, message });
+        });
+        await (explore as any).resetToHome(async (current: number, total?: number, message?: string) => {
+          progressUpdates.push({ current, total, message });
+        });
+      } finally {
+        ctrlProxySpy.mockRestore();
+      }
+
+      expect(commands).toEqual(["shell input keyevent 4", "shell input keyevent 3"]);
+      expect(progressUpdates).toEqual([
+        { current: 0, total: 1, message: "Dead end detected, navigating back..." },
+        { current: 0, total: 1, message: "Resetting to home screen..." }
+      ]);
+    });
+
+    test("records failed dead-end recovery as a terminal partial-report reason", async () => {
+      const ctrlProxySpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+        requestGlobalAction: async () => ({ success: false, error: "unavailable" })
+      } as never);
+      const adb = {
+        executeCommand: async () => { throw new Error("Back navigation was rejected"); }
+      } as AdbClient;
+      explore = new Explore(device, adb, fakeTimer, fakeGraph);
+
+      try {
+        await (explore as any).handleDeadEnd();
+      } finally {
+        ctrlProxySpy.mockRestore();
+      }
 
       expect((explore as any).stopReason).toBe(
-        "Back-navigation recovery failed: pressButton failed on android: Back navigation was rejected"
+        "Back-navigation recovery failed: Failed to press button: Back navigation was rejected"
       );
     });
 
     test("records failed home reset as a terminal partial-report reason", async () => {
-      ToolRegistry.register("homeScreen", "homeScreen", {}, async () => ({
-        success: false,
-        error: "Home navigation was rejected"
-      }));
-      explore = new Explore(device, null, fakeTimer, fakeGraph);
+      const ctrlProxySpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+        requestGlobalAction: async () => ({ success: false, error: "unavailable" })
+      } as never);
+      const adb = {
+        executeCommand: async () => { throw new Error("Home navigation was rejected"); }
+      } as AdbClient;
+      explore = new Explore(device, adb, fakeTimer, fakeGraph);
 
-      await (explore as any).resetToHome();
+      try {
+        await (explore as any).resetToHome();
+      } finally {
+        ctrlProxySpy.mockRestore();
+      }
 
       expect((explore as any).stopReason).toBe(
-        "Home-screen recovery failed: homeScreen failed on android: Home navigation was rejected"
+        "Home-screen recovery failed: Failed to press button: Home navigation was rejected"
       );
     });
 
     test("returns a partial report when dead-end recovery fails", async () => {
-      ToolRegistry.register("pressButton", "pressButton", {}, async () => ({
-        success: false,
-        error: "Back navigation was rejected"
-      }));
-      explore = new Explore(device, null, fakeTimer, fakeGraph);
+      const ctrlProxySpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+        requestGlobalAction: async () => ({ success: false, error: "unavailable" })
+      } as never);
+      const adb = {
+        executeCommand: async () => { throw new Error("Back navigation was rejected"); }
+      } as AdbClient;
+      explore = new Explore(device, adb, fakeTimer, fakeGraph);
       (explore as any).observeScreen = {
         execute: async () => createMockObservation([], "com.test.app")
       };
       (explore as any).selectNextElement = async () => undefined;
 
-      const result = await explore.execute({
-        maxInteractions: 1,
-        timeoutMs: 5000,
-        packageName: "com.test.app"
-      });
+      let result;
+      try {
+        result = await explore.execute({
+          maxInteractions: 1,
+          timeoutMs: 5000,
+          packageName: "com.test.app"
+        });
+      } finally {
+        ctrlProxySpy.mockRestore();
+      }
 
       expect(result.success).toBe(true);
       expect(result.stopReason).toBe(
-        "Back-navigation recovery failed: pressButton failed on android: Back navigation was rejected"
+        "Back-navigation recovery failed: Failed to press button: Back navigation was rejected"
       );
     });
   });

--- a/test/features/navigation/NavigateTo.test.ts
+++ b/test/features/navigation/NavigateTo.test.ts
@@ -10,6 +10,7 @@ import { z } from "zod";
 import { FakeNavigationGraphManager } from "../../fakes/FakeNavigationGraphManager";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 import { FakeTimer } from "../../fakes/FakeTimer";
+import { INTERNAL_NO_DIFF_PARAM } from "../../../src/server/internalToolCall";
 
 describe("NavigateTo", () => {
   let navigateTo: NavigateTo;
@@ -333,6 +334,11 @@ describe("NavigateTo", () => {
         backPresses: 1,
         reason: "test recommendation"
       });
+      let pressButtonArgs: Record<string, unknown> | undefined;
+      ToolRegistry.register("pressButton", "pressButton", {}, async args => {
+        pressButtonArgs = args;
+        return { success: true };
+      });
 
       const screenWaiter: ScreenTransitionWaiter = {
         waitForScreen: async screenName => screenName === "HomeScreen"
@@ -358,8 +364,64 @@ describe("NavigateTo", () => {
       expect(result.message).toBe("Successfully navigated to \"HomeScreen\" using back button");
       expect(result.stepsExecuted).toBe(1);
       expect(result.path).toEqual(["pressButton(back)"]);
-      expect(fakeAdbFactory.getFakeClient().getAllCommands()).toEqual(["shell input keyevent 4"]);
+      expect(pressButtonArgs).toEqual({
+        button: "back",
+        platform: "android",
+        [INTERNAL_NO_DIFF_PARAM]: true
+      });
+      expect(fakeAdbFactory.getFakeClient().getAllCommands()).toEqual([]);
       expect(fakeTimer.getSleepHistory()).toEqual([300]);
+    });
+
+    test("routes iOS smart-back recovery through the internal pressButton tool without ADB", async () => {
+      const now = 1;
+      const iOSDevice = {
+        deviceId: "ios-simulator-123",
+        platform: "ios",
+        source: "local"
+      } as BootedDevice;
+      await fakeGraph.recordNavigationEvent({
+        destination: "DetailScreen",
+        source: "TEST",
+        arguments: {},
+        metadata: {},
+        timestamp: now,
+        sequenceNumber: 0
+      });
+      fakeGraph.addNode({
+        screenName: "DetailScreen",
+        firstSeenAt: now,
+        lastSeenAt: now,
+        visitCount: 1,
+        backStackDepth: 1
+      });
+      shouldUseBackButtonSpy = spyOn(SmartNavigationHelper, "shouldUseBackButton").mockResolvedValue({
+        shouldUseBack: true,
+        backPresses: 1,
+        reason: "test recommendation"
+      });
+
+      let pressButtonArgs: Record<string, unknown> | undefined;
+      ToolRegistry.register("pressButton", "pressButton", {}, async args => {
+        pressButtonArgs = args;
+        return { success: true };
+      });
+      const screenWaiter: ScreenTransitionWaiter = {
+        waitForScreen: async screenName => screenName === "HomeScreen"
+      };
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+      navigateTo = new NavigateTo(iOSDevice, fakeAdbFactory, null, screenWaiter, fakeGraph, fakeTimer);
+
+      const result = await navigateTo.execute({ targetScreen: "HomeScreen", platform: "ios" });
+
+      expect(result.success).toBe(true);
+      expect(pressButtonArgs).toEqual({
+        button: "back",
+        platform: "ios",
+        [INTERNAL_NO_DIFF_PARAM]: true
+      });
+      expect(fakeAdbFactory.getFakeClient().getAllCommands()).toEqual([]);
     });
   });
 

--- a/test/features/navigation/NavigateTo.test.ts
+++ b/test/features/navigation/NavigateTo.test.ts
@@ -11,6 +11,7 @@ import { FakeNavigationGraphManager } from "../../fakes/FakeNavigationGraphManag
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import { INTERNAL_NO_DIFF_PARAM } from "../../../src/server/internalToolCall";
+import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
 
 describe("NavigateTo", () => {
   let navigateTo: NavigateTo;
@@ -349,11 +350,9 @@ describe("NavigateTo", () => {
         backPresses: 1,
         reason: "test recommendation"
       });
-      let pressButtonArgs: Record<string, unknown> | undefined;
-      ToolRegistry.register("pressButton", "pressButton", {}, async args => {
-        pressButtonArgs = args;
-        return { success: true };
-      });
+      const ctrlProxySpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+        requestGlobalAction: async () => ({ success: false, error: "unavailable" })
+      } as never);
 
       const screenWaiter: ScreenTransitionWaiter = {
         waitForScreen: async screenName => screenName === "HomeScreen"
@@ -369,24 +368,22 @@ describe("NavigateTo", () => {
         fakeTimer
       );
 
-      const result = await navigateTo.execute({
-        targetScreen: "HomeScreen",
-        platform: "android"
-      });
+      try {
+        const result = await navigateTo.execute({
+          targetScreen: "HomeScreen",
+          platform: "android"
+        });
 
-      expect(shouldUseBackButtonSpy).toHaveBeenCalledWith("DetailScreen", "HomeScreen", 1);
-      expect(result.success).toBe(true);
-      expect(result.message).toBe("Successfully navigated to \"HomeScreen\" using back button");
-      expect(result.stepsExecuted).toBe(1);
-      expect(result.path).toEqual(["pressButton(back)"]);
-      expect(pressButtonArgs).toEqual({
-        button: "back",
-        platform: "android",
-        deviceId: "test-device-123",
-        [INTERNAL_NO_DIFF_PARAM]: true
-      });
-      expect(fakeAdbFactory.getFakeClient().getAllCommands()).toEqual([]);
-      expect(fakeTimer.getSleepHistory()).toEqual([300]);
+        expect(shouldUseBackButtonSpy).toHaveBeenCalledWith("DetailScreen", "HomeScreen", 1);
+        expect(result.success).toBe(true);
+        expect(result.message).toBe("Successfully navigated to \"HomeScreen\" using back button");
+        expect(result.stepsExecuted).toBe(1);
+        expect(result.path).toEqual(["pressButton(back)"]);
+        expect(fakeAdbFactory.getFakeClient().getAllCommands()).toEqual(["shell input keyevent 4"]);
+        expect(fakeTimer.getSleepHistory()).toEqual([300]);
+      } finally {
+        ctrlProxySpy.mockRestore();
+      }
     });
 
     test("routes iOS smart-back recovery through the internal pressButton tool without ADB", async () => {

--- a/test/features/navigation/NavigateTo.test.ts
+++ b/test/features/navigation/NavigateTo.test.ts
@@ -82,6 +82,21 @@ describe("NavigateTo", () => {
   });
 
   describe("execute", () => {
+    test("creates the default UI-state setup after resolving an options session", async () => {
+      navigateTo = new NavigateTo(device, fakeAdbFactory, null, null, fakeGraph);
+
+      await navigateTo.execute({
+        targetScreen: "HomeScreen",
+        platform: "android",
+        sessionUuid: "options-session"
+      });
+
+      const uiStateSetup = (navigateTo as unknown as {
+        uiStateSetup: { sessionUuid?: string } | null;
+      }).uiStateSetup;
+      expect(uiStateSetup?.sessionUuid).toBe("options-session");
+    });
+
     test("should return error when no current screen", async () => {
       // Inject fakeGraph via constructor
       navigateTo = new NavigateTo(device, fakeAdbFactory, null, null, fakeGraph);

--- a/test/features/navigation/NavigateTo.test.ts
+++ b/test/features/navigation/NavigateTo.test.ts
@@ -367,6 +367,7 @@ describe("NavigateTo", () => {
       expect(pressButtonArgs).toEqual({
         button: "back",
         platform: "android",
+        deviceId: "test-device-123",
         [INTERNAL_NO_DIFF_PARAM]: true
       });
       expect(fakeAdbFactory.getFakeClient().getAllCommands()).toEqual([]);
@@ -419,9 +420,46 @@ describe("NavigateTo", () => {
       expect(pressButtonArgs).toEqual({
         button: "back",
         platform: "ios",
+        deviceId: "ios-simulator-123",
         [INTERNAL_NO_DIFF_PARAM]: true
       });
       expect(fakeAdbFactory.getFakeClient().getAllCommands()).toEqual([]);
+    });
+
+    test("reports an unsuccessful iOS smart-back recovery instead of claiming navigation succeeded", async () => {
+      const iOSDevice = { ...device, deviceId: "ios-simulator-456", platform: "ios" } as BootedDevice;
+      await fakeGraph.recordNavigationEvent({
+        destination: "DetailScreen",
+        source: "TEST",
+        arguments: {},
+        metadata: {},
+        timestamp: 1,
+        sequenceNumber: 0
+      });
+      fakeGraph.addNode({
+        screenName: "DetailScreen",
+        firstSeenAt: 1,
+        lastSeenAt: 1,
+        visitCount: 1,
+        backStackDepth: 1
+      });
+      shouldUseBackButtonSpy = spyOn(SmartNavigationHelper, "shouldUseBackButton").mockResolvedValue({
+        shouldUseBack: true,
+        backPresses: 1,
+        reason: "test recommendation"
+      });
+      ToolRegistry.register("pressButton", "pressButton", {}, async () => ({
+        success: false,
+        error: "back unavailable"
+      }));
+      navigateTo = new NavigateTo(iOSDevice, fakeAdbFactory, null, {
+        waitForScreen: async () => true
+      }, fakeGraph);
+
+      const result = await navigateTo.execute({ targetScreen: "HomeScreen", platform: "ios" });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("pressButton failed on ios: back unavailable");
     });
   });
 

--- a/test/features/navigation/NavigateTo.test.ts
+++ b/test/features/navigation/NavigateTo.test.ts
@@ -616,6 +616,7 @@ describe("NavigateTo", () => {
       };
       const timer = new FakeTimer();
       timer.enableAutoAdvance();
+      ToolRegistry.register("pressButton", "Fake back tool", {}, async () => ({ success: true }));
       navigateTo = new NavigateTo(
         device,
         fakeAdbFactory,

--- a/test/features/navigation/iosNavigationGraphWorkflow.test.ts
+++ b/test/features/navigation/iosNavigationGraphWorkflow.test.ts
@@ -90,6 +90,7 @@ describe("iOS navigation-event graph workflow", () => {
       text: "Settings",
       action: "tap",
       platform: "ios",
+      deviceId: "ios-simulator-navigation-workflow",
       [INTERNAL_NO_DIFF_PARAM]: true
     });
   });

--- a/test/features/navigation/iosNavigationGraphWorkflow.test.ts
+++ b/test/features/navigation/iosNavigationGraphWorkflow.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { NavigateTo } from "../../../src/features/navigation/NavigateTo";
+import {
+  DefaultIosSdkEventIngestor,
+  type IosTelemetryRecorder
+} from "../../../src/features/observe/ios/IosSdkEventIngestor";
+import { ToolRegistry } from "../../../src/server/toolRegistry";
+import { INTERNAL_NO_DIFF_PARAM } from "../../../src/server/internalToolCall";
+import type { BootedDevice } from "../../../src/models";
+import type { SdkEvent } from "../../../src/features/observe/interfaces/SdkEventIngestor";
+import { FakeNavigationGraphManager } from "../../fakes/FakeNavigationGraphManager";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
+import { FakeTimer } from "../../fakes/FakeTimer";
+import type { ScreenTransitionWaiter } from "../../../src/features/navigation/interfaces/ScreenTransitionWaiter";
+
+const iOSDevice: BootedDevice = {
+  deviceId: "ios-simulator-navigation-workflow",
+  platform: "ios",
+  source: "local"
+} as BootedDevice;
+
+const noOpTelemetryRecorder: IosTelemetryRecorder = {
+  getContext: () => ({ deviceId: null, sessionId: null }),
+  setContext: () => {},
+  recordNetworkEvent: async () => {},
+  recordLogEvent: async () => {},
+  recordOsEvent: async () => {},
+  recordNavigationEvent: async () => {},
+  recordStorageEvent: async () => {},
+  recordLayoutEvent: async () => {}
+};
+
+describe("iOS navigation-event graph workflow", () => {
+  afterEach(() => {
+    ToolRegistry.clearTools();
+  });
+
+  test("ingests SDK events, reports the learned graph, and replays its iOS path", async () => {
+    const graph = new FakeNavigationGraphManager();
+    const ingestor = new DefaultIosSdkEventIngestor({
+      deviceId: iOSDevice.deviceId,
+      getNavigationGraphManager: () => graph,
+      captureScreenshot: async () => ({ success: false }),
+      telemetryRecorder: noOpTelemetryRecorder,
+      navigationScreenshotsEnabled: () => false
+    });
+    const navigationEvent = (destination: string): SdkEvent => ({
+      type: "navigation",
+      timestamp: Date.now(),
+      payload: { destination, source: "swiftui_navigation", arguments: {}, metadata: {} }
+    });
+
+    await ingestor.recordSdkEvent(navigationEvent("Home"), "dev.jasonpearson.automobile.Playground");
+    graph.recordToolCall("tapOn", { text: "Settings", action: "tap", platform: "ios" });
+    await ingestor.recordSdkEvent(navigationEvent("Settings"), "dev.jasonpearson.automobile.Playground");
+
+    const graphReport = await graph.exportGraph();
+    expect(graphReport.nodes.map(node => node.screenName)).toEqual(["Home", "Settings"]);
+    expect(graphReport.edges).toHaveLength(1);
+    expect(graphReport.edges[0]).toMatchObject({
+      from: "Home",
+      to: "Settings",
+      interaction: { toolName: "tapOn", args: { text: "Settings", platform: "ios" } }
+    });
+
+    // Model the iOS back action that returns the user to the learned source screen.
+    graph.setCurrentScreenValue("Home");
+    let replayArgs: Record<string, unknown> | undefined;
+    ToolRegistry.register("tapOn", "tapOn", {}, async args => {
+      replayArgs = args;
+      return { success: true };
+    });
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    const screenWaiter: ScreenTransitionWaiter = { waitForScreen: async screen => screen === "Settings" };
+    const navigateTo = new NavigateTo(
+      iOSDevice,
+      new FakeAdbClientFactory(),
+      null,
+      screenWaiter,
+      graph,
+      timer
+    );
+
+    const replay = await navigateTo.execute({ targetScreen: "Settings", platform: "ios" });
+
+    expect(replay.success).toBe(true);
+    expect(replay.path).toEqual(['tapOn({"text":"Settings","action":"tap","platform":"ios"})']);
+    expect(replayArgs).toEqual({
+      text: "Settings",
+      action: "tap",
+      platform: "ios",
+      [INTERNAL_NO_DIFF_PARAM]: true
+    });
+  });
+});

--- a/test/server/navigationTools.test.ts
+++ b/test/server/navigationTools.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { Explore } from "../../src/features/navigation/Explore";
+import { NavigateTo } from "../../src/features/navigation/NavigateTo";
+import { NavigationGraphManager } from "../../src/features/navigation/NavigationGraphManager";
+import { registerNavigationTools } from "../../src/server/navigationTools";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { setDebugModeEnabled } from "../../src/utils/debug";
+import type { BootedDevice } from "../../src/models";
+import { FakeNavigationGraphManager } from "../fakes/FakeNavigationGraphManager";
+
+describe("navigation tool session graph selection", () => {
+  const device: BootedDevice = {
+    deviceId: "ios-simulator-123",
+    name: "iPhone",
+    platform: "ios",
+  };
+
+  beforeEach(() => {
+    ToolRegistry.clearTools();
+    setDebugModeEnabled(true);
+    registerNavigationTools();
+  });
+
+  afterEach(() => {
+    ToolRegistry.clearTools();
+    setDebugModeEnabled(false);
+  });
+
+  test("routes navigateTo and explore through the label-resolved session graph", async () => {
+    const sessionGraph = new FakeNavigationGraphManager();
+    const usedManagers: unknown[] = [];
+    const usedSessions: unknown[] = [];
+    const sessionManagerSpy = spyOn(NavigationGraphManager, "getInstanceForSession")
+      .mockReturnValue(sessionGraph as unknown as NavigationGraphManager);
+    const navigateExecuteSpy = spyOn(NavigateTo.prototype, "execute").mockImplementation(async function() {
+      usedManagers.push((this as unknown as { navigationManager: unknown }).navigationManager);
+      usedSessions.push((this as unknown as { sessionUuid: unknown }).sessionUuid);
+      return {
+        success: false,
+        error: "No path",
+        currentScreen: null,
+        targetScreen: "Settings",
+        stepsExecuted: 0,
+      };
+    });
+    const exploreExecuteSpy = spyOn(Explore.prototype, "execute").mockImplementation(async function() {
+      usedManagers.push((this as unknown as { navigationManager: unknown }).navigationManager);
+      usedSessions.push((this as unknown as { sessionUuid: unknown }).sessionUuid);
+      return {
+        success: true,
+        interactionsPerformed: 0,
+        screensDiscovered: 0,
+        coverage: { explored: 0, total: 0, percentage: 0 },
+      } as any;
+    });
+
+    try {
+      const tools = ToolRegistry as unknown as {
+        tools: Map<string, { deviceAwareHandler?: (device: BootedDevice, args: any) => Promise<unknown> }>;
+      };
+      const navigateHandler = tools.tools.get("navigateTo")?.deviceAwareHandler;
+      const exploreHandler = tools.tools.get("explore")?.deviceAwareHandler;
+
+      expect(navigateHandler).toBeDefined();
+      expect(exploreHandler).toBeDefined();
+
+      await navigateHandler!(device, {
+        targetScreen: "Settings",
+        platform: "ios",
+        // ToolRegistry resolves a labelled device's base session to this child
+        // session before invoking the device-aware handler.
+        sessionUuid: "session-123:B",
+      });
+      await exploreHandler!(device, {
+        platform: "ios",
+        sessionUuid: "session-123:B",
+      });
+
+      expect(sessionManagerSpy).toHaveBeenCalledTimes(2);
+      expect(sessionManagerSpy).toHaveBeenCalledWith("session-123:B");
+      expect(usedManagers).toEqual([sessionGraph, sessionGraph]);
+      expect(usedSessions).toEqual(["session-123:B", "session-123:B"]);
+    } finally {
+      sessionManagerSpy.mockRestore();
+      navigateExecuteSpy.mockRestore();
+      exploreExecuteSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- route exploration recovery and learned-path back fallback through internal platform-aware interaction tools
- add iOS fake-based coverage for recovery, SDK event graph ingestion, inspection, and path replay
- run the iOS navigation graph workflow in the existing booted-Simulator CI lane

## Root cause

`Explore` and `NavigateTo` invoked Android CtrlProxy/ADB recovery directly, bypassing the iOS CtrlProxy interaction path.

## Validation

- `bun run turbo:validate`
- `bun run typecheck`
- focused navigation, iOS SDK-ingestion, and workflow-wiring tests

Closes [#4460](https://github.com/kaeawc/auto-mobile/issues/4460)
