### PR TITLE
test(utils-ios): burn down 15 verified test-quality findings (#4177)

### DIFF
--- a/src/utils/ios-cmdline-tools/SimCtlClient.ts
+++ b/src/utils/ios-cmdline-tools/SimCtlClient.ts
@@ -1406,9 +1406,12 @@ export class SimCtlClient implements SimCtl {
    * Determine whether the current host can launch the Simulator GUI.
    *
    * Resolution order:
-   *  1. `AUTOMOBILE_IOS_HEADLESS` env override (`true`/`1` => headless,
+   *  1. Non-darwin platforms are always headless (Simulator.app is macOS-only).
+   *     This gate comes BEFORE the env override so `AUTOMOBILE_IOS_HEADLESS=false`
+   *     (or `""`) can never make `openSimulatorApp` shell `open -a Simulator` on
+   *     Linux/Windows, where that binary does not exist (issue #4177).
+   *  2. `AUTOMOBILE_IOS_HEADLESS` env override (`true`/`1` => headless,
    *     `false`/`0` => force GUI launch).
-   *  2. Non-darwin platforms are always headless (Simulator.app is macOS-only).
    *  3. Auto-detect via `launchctl managername`: an `Aqua` manager means a GUI
    *     login session; anything else (`System`/`Background`) is a daemon/SSH
    *     context with no GUI domain.
@@ -1417,13 +1420,13 @@ export class SimCtlClient implements SimCtl {
    * behavior. The result is cached so launchctl is probed at most once.
    */
   private async isHeadlessSession(): Promise<boolean> {
+    if (this.platform !== "darwin") {
+      return true;
+    }
+
     const override = process.env.AUTOMOBILE_IOS_HEADLESS;
     if (override !== undefined) {
       return override === "true" || override === "1";
-    }
-
-    if (this.platform !== "darwin") {
-      return true;
     }
 
     if (this.headlessSessionCache === null) {

--- a/src/utils/ios-cmdline-tools/XcodebuildClient.ts
+++ b/src/utils/ios-cmdline-tools/XcodebuildClient.ts
@@ -105,7 +105,7 @@ export class XcodebuildClient implements Xcodebuild {
         logger.warn(`[iOS] Command failed after ${duration}ms: ${fullCommand} - ${(error as Error).message}`);
         throw controller.signal.aborted ? timeoutError : error;
       } finally {
-        clearTimeout(timeoutId!);
+        this.timer.clearTimeout(timeoutId!);
       }
     }
 
@@ -161,7 +161,7 @@ export class XcodebuildClient implements Xcodebuild {
     try {
       return await Promise.race([this.isLocalXcodebuildAvailable(controller.signal), timeout]);
     } finally {
-      clearTimeout(timeoutId!);
+      this.timer.clearTimeout(timeoutId!);
     }
   }
 

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -522,6 +522,31 @@ describe("IOSCtrlProxyManager", function() {
       manager.clearCaches();
       expect(await manager.isRunning()).toBe(true);     // cache cleared → re-probe
     });
+
+    test("drops a cached positive availability so a now-down runner is re-probed", async function() {
+      // isAvailable only serves a cache when it is POSITIVE, so this pins the
+      // cachedAvailability clear specifically: deleting `this.cachedAvailability = null`
+      // (or `this.cachedRunning = null`) from clearCaches leaves the stale positive and
+      // reds the final assertion. cachedInstalled has no such test here because for a
+      // simulator device isInstalled is unconditionally true — clearing it is unobservable.
+      const fakeExecutor = new FakeProcessExecutor();
+      let healthy = true;
+      fakeExecutor.setCommandHandler("curl -s", () =>
+        createExecResult(
+          healthy ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId }) : "",
+          ""
+        )
+      );
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice, fakeTimer, undefined, fakeExecutor
+      );
+
+      expect(await manager.isAvailable()).toBe(true);   // installed(true)+running(true) → cached positive
+      healthy = false;
+      expect(await manager.isAvailable()).toBe(true);   // positive availability cache is served (stale)
+      manager.clearCaches();
+      expect(await manager.isAvailable()).toBe(false);  // caches dropped → re-probes the down runner
+    });
   });
 
   describe("resetSetupState", function() {

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -2,10 +2,9 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { IOSCtrlProxyManager } from "../../src/utils/IOSCtrlProxyManager";
 import { BootedDevice } from "../../src/models";
 import { FakeTimer } from "../fakes/FakeTimer";
-import { FakeIOSCtrlProxyManager } from "../fakes/FakeIOSCtrlProxyManager";
 import { FakeProcessExecutor } from "../fakes/FakeProcessExecutor";
 import { FakeChildProcess } from "../fakes/FakeChildProcess";
-import type { ExecResult } from "../../src/models";
+import { createExecResult } from "../../src/utils/execResult";
 import { PortManager } from "../../src/utils/PortManager";
 import { IOSCtrlProxyBuilder } from "../../src/utils/IOSCtrlProxyBuilder";
 import { IOSCtrlProxyProcessClient } from "../../src/utils/ios/IOSCtrlProxyProcessClient";
@@ -436,6 +435,42 @@ describe("IOSCtrlProxyManager", function() {
 
       expect(await manager.getReportedRunnerPort()).toBeNull();
     });
+
+    // PARAM-2 (#4177 item 8): the #2731 service-port-beats-default ordering had
+    // no test with BOTH candidate ports answering. The service port is probed
+    // first, so when both a runner on the service port and one on the default
+    // port answer validly for this device, the service port's report wins.
+    test("prefers the service port over the default when BOTH answer for this device (#2731)", async function() {
+      installHealthFakes({
+        8767: JSON.stringify({ status: "ok", deviceId: testDevice.deviceId, port: 8767 }),
+        8765: JSON.stringify({ status: "ok", deviceId: testDevice.deviceId, port: 8765 }),
+      });
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor
+      );
+      (manager as unknown as { servicePort: number }).servicePort = 8767;
+
+      expect(await manager.getReportedRunnerPort()).toBe(8767);
+    });
+
+    // PARAM-2: a truncated/non-JSON health body can't confirm the device, so the
+    // reported port must be nulled rather than partially parsed.
+    test("returns null when the health body is truncated JSON", async function() {
+      installHealthFakes({
+        8765: `{"status":"ok","deviceId":"${testDevice.deviceId}","port":87`,
+      });
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        undefined,
+        fakeExecutor
+      );
+
+      expect(await manager.getReportedRunnerPort()).toBeNull();
+    });
   });
 
   describe("getCapabilities", function() {
@@ -462,21 +497,52 @@ describe("IOSCtrlProxyManager", function() {
     });
   });
 
+  // REWRITE-2 (#4177 item 6): the old "should not throw" tests passed even with
+  // the method bodies deleted. `isRunning` caches its health result for
+  // STATUS_CACHE_TTL, so a stale cached `false` is served until the cache is
+  // cleared. These assert the observable re-probe: only after clearing does a
+  // now-healthy endpoint flip the cached answer.
   describe("clearCaches", function() {
-    test("should clear all cached state", function() {
-      const manager = IOSCtrlProxyManager.getInstance(testDevice);
+    test("forces isRunning to re-probe the health endpoint after clearing", async function() {
+      const fakeExecutor = new FakeProcessExecutor();
+      let healthy = false;
+      fakeExecutor.setCommandHandler("curl -s", () =>
+        createExecResult(
+          healthy ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId }) : "",
+          ""
+        )
+      );
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice, fakeTimer, undefined, fakeExecutor
+      );
 
-      // This should not throw
+      expect(await manager.isRunning()).toBe(false);   // probes, caches false
+      healthy = true;
+      expect(await manager.isRunning()).toBe(false);   // cached false is served
       manager.clearCaches();
+      expect(await manager.isRunning()).toBe(true);     // cache cleared → re-probe
     });
   });
 
   describe("resetSetupState", function() {
-    test("should reset setup state and clear caches", function() {
-      const manager = IOSCtrlProxyManager.getInstance(testDevice);
+    test("clears the running cache so isRunning re-probes", async function() {
+      const fakeExecutor = new FakeProcessExecutor();
+      let healthy = false;
+      fakeExecutor.setCommandHandler("curl -s", () =>
+        createExecResult(
+          healthy ? JSON.stringify({ status: "ok", deviceId: testDevice.deviceId }) : "",
+          ""
+        )
+      );
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice, fakeTimer, undefined, fakeExecutor
+      );
 
-      // This should not throw
+      expect(await manager.isRunning()).toBe(false);
+      healthy = true;
+      expect(await manager.isRunning()).toBe(false);
       manager.resetSetupState();
+      expect(await manager.isRunning()).toBe(true);
     });
   });
 
@@ -2188,162 +2254,6 @@ describe("IOSCtrlProxyManager", function() {
         /port 8765 still held by PID 5555 .*xcodebuild test-without-building/
       );
       expect(fakeExecutor.getSpawnedProcesses()).toHaveLength(0);
-    });
-  });
-});
-
-function createExecResult(stdout: string, stderr: string): ExecResult {
-  return {
-    stdout,
-    stderr,
-    toString: () => stdout,
-    trim: () => stdout.trim(),
-    includes: (searchString: string) => stdout.includes(searchString)
-  };
-}
-
-describe("FakeIOSCtrlProxyManager", function() {
-  let fakeManager: FakeIOSCtrlProxyManager;
-
-  beforeEach(function() {
-    fakeManager = new FakeIOSCtrlProxyManager();
-  });
-
-  describe("state configuration", function() {
-    test("should configure installed state", async function() {
-      expect(await fakeManager.isInstalled()).toBe(false);
-
-      fakeManager.setInstalled(true);
-      expect(await fakeManager.isInstalled()).toBe(true);
-    });
-
-    test("should configure running state", async function() {
-      expect(await fakeManager.isRunning()).toBe(false);
-
-      fakeManager.setRunning(true);
-      expect(await fakeManager.isRunning()).toBe(true);
-    });
-
-    test("should configure available state", async function() {
-      expect(await fakeManager.isAvailable()).toBe(false);
-
-      fakeManager.setAvailable(true);
-      expect(await fakeManager.isAvailable()).toBe(true);
-    });
-  });
-
-  describe("operation tracking", function() {
-    test("should track isInstalled calls", async function() {
-      await fakeManager.isInstalled();
-      await fakeManager.isInstalled();
-
-      expect(fakeManager.wasMethodCalled("isInstalled")).toBe(true);
-      expect(fakeManager.getCallCount("isInstalled")).toBe(2);
-    });
-
-    test("should track isRunning calls", async function() {
-      await fakeManager.isRunning();
-
-      expect(fakeManager.wasMethodCalled("isRunning")).toBe(true);
-      expect(fakeManager.getCallCount("isRunning")).toBe(1);
-    });
-
-    test("should track setup calls with force parameter", async function() {
-      await fakeManager.setup(false);
-      await fakeManager.setup(true);
-
-      const operations = fakeManager.getExecutedOperations();
-      expect(operations).toContain("setup:force=false");
-      expect(operations).toContain("setup:force=true");
-    });
-
-    test("should clear history", async function() {
-      await fakeManager.isInstalled();
-      await fakeManager.isRunning();
-
-      expect(fakeManager.getExecutedOperations().length).toBe(2);
-
-      fakeManager.clearHistory();
-      expect(fakeManager.getExecutedOperations().length).toBe(0);
-    });
-  });
-
-  describe("start and stop", function() {
-    test("should set running state on start", async function() {
-      expect(await fakeManager.isRunning()).toBe(false);
-
-      await fakeManager.start();
-      expect(await fakeManager.isRunning()).toBe(true);
-      expect(fakeManager.wasMethodCalled("start")).toBe(true);
-    });
-
-    test("should clear running state on stop", async function() {
-      fakeManager.setRunning(true);
-      expect(await fakeManager.isRunning()).toBe(true);
-
-      await fakeManager.stop();
-      expect(await fakeManager.isRunning()).toBe(false);
-      expect(fakeManager.wasMethodCalled("stop")).toBe(true);
-    });
-
-    test("should fail start when configured to fail", async function() {
-      fakeManager.setStartShouldFail(true);
-
-      await expect(fakeManager.start()).rejects.toThrow("Failed to start IOSCtrlProxy");
-    });
-
-    test("should fail stop when configured to fail", async function() {
-      fakeManager.setStopShouldFail(true);
-
-      await expect(fakeManager.stop()).rejects.toThrow("Failed to stop IOSCtrlProxy");
-    });
-  });
-
-  describe("setup", function() {
-    test("should return success when service starts", async function() {
-      const result = await fakeManager.setup();
-
-      expect(result.success).toBe(true);
-      expect(result.message).toBe("IOSCtrlProxy started successfully");
-    });
-
-    test("should return already running message when service is running", async function() {
-      fakeManager.setRunning(true);
-
-      const result = await fakeManager.setup(false);
-
-      expect(result.success).toBe(true);
-      expect(result.message).toBe("IOSCtrlProxy was already running");
-    });
-
-    test("should force restart even when running", async function() {
-      fakeManager.setRunning(true);
-
-      const result = await fakeManager.setup(true);
-
-      expect(result.success).toBe(true);
-      expect(result.message).toBe("IOSCtrlProxy started successfully");
-    });
-
-    test("should return failure when setup fails", async function() {
-      fakeManager.setSetupShouldFail(true);
-
-      const result = await fakeManager.setup();
-
-      expect(result.success).toBe(false);
-      expect(result.message).toBe("Failed to setup IOSCtrlProxy");
-      expect(result.error).toBe("Mock setup failure");
-    });
-  });
-
-  describe("getServicePort", function() {
-    test("should return default port", function() {
-      expect(fakeManager.getServicePort()).toBe(8765);
-    });
-
-    test("should return configured port", function() {
-      fakeManager.setServicePort(9999);
-      expect(fakeManager.getServicePort()).toBe(9999);
     });
   });
 });

--- a/test/utils/ios-cmdline-tools/AppBundleHasher.test.ts
+++ b/test/utils/ios-cmdline-tools/AppBundleHasher.test.ts
@@ -43,14 +43,22 @@ const bundle = (root: string, files: Record<string, string>, options: BundleOpti
     return options.reverseReaddir ? sorted.reverse() : sorted;
   };
 
+  // The hasher builds the paths it passes here with node's `join` (see
+  // AppBundleHasher.ts), so on Windows they arrive back-slash-separated while our
+  // keys are forward-slash. Normalize on lookup so the in-memory seam matches on
+  // every platform (the hasher already normalizes separators for the hash itself).
+  const norm = (p: string): string => p.replace(/\\/g, "/");
   return {
-    readDir: async (path: string): Promise<string[]> => childrenOf(path),
-    stat: async (path: string) => ({
-      isDirectory: () => dirs.has(path),
-      isFile: () => fileContents.has(path),
-    }),
+    readDir: async (path: string): Promise<string[]> => childrenOf(norm(path)),
+    stat: async (path: string) => {
+      const key = norm(path);
+      return {
+        isDirectory: () => dirs.has(key),
+        isFile: () => fileContents.has(key),
+      };
+    },
     readFile: async (path: string): Promise<Buffer> =>
-      Buffer.from(fileContents.get(path) ?? "", "utf-8"),
+      Buffer.from(fileContents.get(norm(path)) ?? "", "utf-8"),
   };
 };
 

--- a/test/utils/ios-cmdline-tools/AppBundleHasher.test.ts
+++ b/test/utils/ios-cmdline-tools/AppBundleHasher.test.ts
@@ -1,43 +1,120 @@
 import { describe, expect, test } from "bun:test";
-import { promises as fs } from "fs";
-import { tmpdir } from "os";
-import { dirname, join } from "path";
 import { hashAppBundle } from "../../../src/utils/ios-cmdline-tools/AppBundleHasher";
 
-const createTempDir = async (): Promise<string> => {
-  return fs.mkdtemp(join(tmpdir(), "automobile-hash-"));
+// ADD-8 (#4177 item 9): the previous suite drove `hashAppBundle` through the
+// real filesystem (`fs.mkdtemp`) and leaked two temp trees per run. This
+// replaces that with an in-memory `bundle()` seam implementing the hasher's
+// injected {readDir, stat, readFile} dependencies — no real fs, no cleanup, and
+// it lets us pin the full skip-list, rename sensitivity, and readdir-order
+// independence that the fs-backed tests never covered.
+
+interface BundleOptions {
+  /** Return directory children in reverse-sorted order, to prove order-independence. */
+  reverseReaddir?: boolean;
+}
+
+const bundle = (root: string, files: Record<string, string>, options: BundleOptions = {}) => {
+  const fileContents = new Map<string, string>();
+  const dirs = new Set<string>([root]);
+  for (const [rel, content] of Object.entries(files)) {
+    const full = `${root}/${rel}`;
+    fileContents.set(full, content);
+    const parts = rel.split("/");
+    let cur = root;
+    for (let i = 0; i < parts.length - 1; i++) {
+      cur = `${cur}/${parts[i]}`;
+      dirs.add(cur);
+    }
+  }
+
+  const childrenOf = (dir: string): string[] => {
+    const prefix = `${dir}/`;
+    const names = new Set<string>();
+    for (const p of [...fileContents.keys(), ...dirs]) {
+      if (p === dir || !p.startsWith(prefix)) {
+        continue;
+      }
+      const name = p.slice(prefix.length).split("/")[0];
+      if (name) {
+        names.add(name);
+      }
+    }
+    const sorted = [...names].sort();
+    return options.reverseReaddir ? sorted.reverse() : sorted;
+  };
+
+  return {
+    readDir: async (path: string): Promise<string[]> => childrenOf(path),
+    stat: async (path: string) => ({
+      isDirectory: () => dirs.has(path),
+      isFile: () => fileContents.has(path),
+    }),
+    readFile: async (path: string): Promise<Buffer> =>
+      Buffer.from(fileContents.get(path) ?? "", "utf-8"),
+  };
 };
 
-const writeFile = async (path: string, contents: string): Promise<void> => {
-  await fs.mkdir(dirname(path), { recursive: true });
-  await fs.writeFile(path, contents, "utf-8");
+const ROOT = "/CtrlProxyApp.app";
+const hashOf = (files: Record<string, string>, options?: BundleOptions): Promise<string> =>
+  hashAppBundle(ROOT, bundle(ROOT, files, options));
+
+const baseFiles: Record<string, string> = {
+  "Info.plist": "info",
+  "CtrlProxyApp": "mach-o-binary",
+  "Frameworks/Lib.framework/Lib": "lib-binary",
 };
 
 describe("hashAppBundle", () => {
-  test("ignores signing artifacts", async () => {
-    const root = await createTempDir();
-    await fs.mkdir(join(root, "_CodeSignature"), { recursive: true });
-    await writeFile(join(root, "_CodeSignature", "CodeResources"), "sig");
-    await writeFile(join(root, "embedded.mobileprovision"), "sig");
-    await writeFile(join(root, "Info.plist"), "info");
-
-    const first = await hashAppBundle(root);
-
-    await writeFile(join(root, "_CodeSignature", "CodeResources"), "sig2");
-    await writeFile(join(root, "embedded.mobileprovision"), "sig2");
-
-    const second = await hashAppBundle(root);
-    expect(first).toBe(second);
+  test("is stable across repeated hashing of identical contents", async () => {
+    expect(await hashOf(baseFiles)).toBe(await hashOf(baseFiles));
   });
 
-  test("changes when app contents change", async () => {
-    const root = await createTempDir();
-    await writeFile(join(root, "Info.plist"), "info");
+  // Skip-list table: signing/packaging artifacts that vary between otherwise
+  // identical builds must NOT change the hash.
+  const skipArtifacts: ReadonlyArray<{ label: string; extra: Record<string, string> }> = [
+    { label: "_CodeSignature contents", extra: { "_CodeSignature/CodeResources": "signature" } },
+    { label: "SC_Info supplemental data", extra: { "SC_Info/CtrlProxyApp.sinf": "sc-info" } },
+    { label: "embedded.mobileprovision", extra: { "embedded.mobileprovision": "provision" } },
+    { label: "PkgInfo", extra: { "PkgInfo": "APPL????" } },
+    { label: "a top-level .xcent entitlements blob", extra: { "CtrlProxyApp.xcent": "entitlements" } },
+    { label: "a nested .xcent entitlements blob", extra: { "Frameworks/Lib.xcent": "entitlements" } },
+  ];
 
-    const first = await hashAppBundle(root);
-    await writeFile(join(root, "Info.plist"), "info2");
-    const second = await hashAppBundle(root);
+  for (const { label, extra } of skipArtifacts) {
+    test(`ignores ${label}`, async () => {
+      expect(await hashOf({ ...baseFiles, ...extra })).toBe(await hashOf(baseFiles));
+    });
+  }
 
-    expect(first).not.toBe(second);
+  test("ignores all skip-list artifacts at once", async () => {
+    const withAll = {
+      ...baseFiles,
+      "_CodeSignature/CodeResources": "signature",
+      "SC_Info/CtrlProxyApp.sinf": "sc-info",
+      "embedded.mobileprovision": "provision",
+      "PkgInfo": "APPL????",
+      "CtrlProxyApp.xcent": "entitlements",
+    };
+    expect(await hashOf(withAll)).toBe(await hashOf(baseFiles));
+  });
+
+  test("changes when a hashed file's contents change", async () => {
+    const changed = { ...baseFiles, "Info.plist": "info-v2" };
+    expect(await hashOf(changed)).not.toBe(await hashOf(baseFiles));
+  });
+
+  test("is sensitive to a rename (the relative path is part of the hash)", async () => {
+    const renamed = { "Info.plist": "info", "Renamed": "mach-o-binary", "Frameworks/Lib.framework/Lib": "lib-binary" };
+    // Same byte contents, different file name → different hash.
+    expect(await hashOf(renamed)).not.toBe(await hashOf(baseFiles));
+  });
+
+  test("is independent of readdir order (entries are sorted before hashing)", async () => {
+    expect(await hashOf(baseFiles, { reverseReaddir: true })).toBe(await hashOf(baseFiles));
+  });
+
+  test("distinguishes two files with swapped contents (position is not conflated)", async () => {
+    const swapped = { ...baseFiles, "Info.plist": "mach-o-binary", "CtrlProxyApp": "info" };
+    expect(await hashOf(swapped)).not.toBe(await hashOf(baseFiles));
   });
 });

--- a/test/utils/ios-cmdline-tools/XcodeSigning.test.ts
+++ b/test/utils/ios-cmdline-tools/XcodeSigning.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { createHash, X509Certificate } from "crypto";
 import { join, resolve } from "path";
 import { XcodeSigningManager } from "../../../src/utils/ios-cmdline-tools/XcodeSigning";
@@ -108,6 +108,190 @@ const createFakeDependencies = (options?: { identities?: string; profiles?: stri
   };
 };
 
+// ADD-4 (#4177 item 5): profile-eligibility table. `resolveSigningForDevice`
+// reads the PREFERRED profile from the env var AUTOMOBILE_IOS_PROFILE_UUID (it
+// takes exactly one param, the device udid — there is no options arg). Fixed
+// `now` (mid-2026, inside the CERT validity window) so expiry rows are
+// deterministic rather than host-clock-dependent.
+const ELIGIBILITY_NOW = Date.parse("2026-06-01T00:00:00Z");
+
+interface ProfileSpec {
+  uuid: string;
+  name: string;
+  expiration: string; // ISO date
+  provisionsAllDevices?: boolean;
+  provisionedDevices?: string[] | null;
+  getTaskAllow?: boolean;
+  includeMatchingCert?: boolean;
+}
+
+const makeProfileXml = (spec: ProfileSpec): string => {
+  const devicesBlock = spec.provisionedDevices
+    ? `<key>ProvisionedDevices</key>\n<array>${spec.provisionedDevices.map(d => `<string>${d}</string>`).join("")}</array>`
+    : "";
+  const certBlock = spec.includeMatchingCert
+    ? `<key>DeveloperCertificates</key>\n<array><data>${CERT_BASE64}</data></array>`
+    : "";
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+  <dict>
+    <key>UUID</key><string>${spec.uuid}</string>
+    <key>Name</key><string>${spec.name}</string>
+    <key>TeamIdentifier</key><array><string>${teamId}</string></array>
+    <key>TeamName</key><string>AutoMobile Team</string>
+    <key>CreationDate</key><date>2024-01-01T00:00:00Z</date>
+    <key>ExpirationDate</key><date>${spec.expiration}</date>
+    <key>ProvisionsAllDevices</key><${spec.provisionsAllDevices ? "true" : "false"}/>
+    ${devicesBlock}
+    <key>Entitlements</key>
+    <dict>
+      <key>get-task-allow</key><${spec.getTaskAllow ? "true" : "false"}/>
+      <key>application-identifier</key><string>${teamId}.dev.jasonpearson.automobile.ctrlproxy</string>
+    </dict>
+    ${certBlock}
+  </dict>
+</plist>`;
+};
+
+const createEligibilityDependencies = (specs: ProfileSpec[]) => {
+  const fingerprint = buildFingerprint(CERT_BASE64);
+  const byFile = new Map<string, string>();
+  const fileNames: string[] = [];
+  for (const spec of specs) {
+    const fileName = `${spec.uuid}.mobileprovision`;
+    fileNames.push(fileName);
+    byFile.set(fileName, makeProfileXml(spec));
+  }
+  return {
+    platform: () => "darwin" as const,
+    securityClient: {
+      getDiagnostics: async () => ({ available: true, version: null }),
+      listCodeSigningIdentities: async () => [
+        { fingerprint, name: `Apple Development: Test (${teamId})` }
+      ],
+      // decodeCms is called with the full profile path; key on the file name.
+      decodeCms: async (path: string) => {
+        const match = [...byFile.keys()].find(name => path.includes(name));
+        return match ? byFile.get(match)! : "";
+      }
+    },
+    xcodebuild: {
+      executeCommand: async () => ({
+        stdout: "", stderr: "",
+        toString() { return this.stdout; },
+        trim() { return this.stdout.trim(); },
+        includes(s: string) { return this.stdout.includes(s); }
+      }),
+      isAvailable: async () => true
+    },
+    readDir: async () => fileNames,
+    readFile: async () => "",
+    stat: async () => ({ isFile: () => true }),
+    writeFile: async () => {},
+    mkdir: async () => {},
+    homedir: () => "/Users/test",
+    now: () => ELIGIBILITY_NOW
+  };
+};
+
+describe("XcodeSigningManager profile eligibility (env-selected preferred profile)", () => {
+  const SIGNING_ENV_VARS = [
+    "AUTOMOBILE_IOS_TEAM_IDS",
+    "AUTOMOBILE_IOS_TEAM_ID",
+    "AUTOMOBILE_IOS_PROFILE_UUID",
+    "AUTOMOBILE_IOS_PROFILE_NAME",
+    "AUTOMOBILE_IOS_PROFILE_SPECIFIER",
+    "AUTOMOBILE_IOS_CODE_SIGN_IDENTITY",
+  ] as const;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of SIGNING_ENV_VARS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of SIGNING_ENV_VARS) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+  });
+
+  const otherDevice = "00008030FFFFFFFFFF";
+
+  test("selects a valid device-included development profile named via env (manual, no expiry/device warning)", async () => {
+    const uuid = "11111111-1111-1111-1111-111111111111";
+    process.env.AUTOMOBILE_IOS_PROFILE_UUID = uuid;
+    const manager = new XcodeSigningManager(createEligibilityDependencies([
+      { uuid, name: "Valid Dev", expiration: "2030-01-01T00:00:00Z", provisionedDevices: [deviceUdid], getTaskAllow: true, includeMatchingCert: true }
+    ]));
+
+    const resolution = await manager.resolveSigningForDevice(deviceUdid);
+
+    expect(resolution.style).toBe("manual");
+    expect(resolution.profile?.uuid).toBe(uuid);
+    expect(resolution.warnings.some(w => w.includes("expired"))).toBe(false);
+    expect(resolution.warnings.some(w => w.includes("does not include device"))).toBe(false);
+  });
+
+  test("warns when the env-selected profile is expired", async () => {
+    const uuid = "22222222-2222-2222-2222-222222222222";
+    process.env.AUTOMOBILE_IOS_PROFILE_UUID = uuid;
+    const manager = new XcodeSigningManager(createEligibilityDependencies([
+      { uuid, name: "Expired Dev", expiration: "2020-01-01T00:00:00Z", provisionedDevices: [deviceUdid], getTaskAllow: true, includeMatchingCert: true }
+    ]));
+
+    const resolution = await manager.resolveSigningForDevice(deviceUdid);
+
+    expect(resolution.warnings.some(w => w.includes("Expired Dev") && w.includes("expired"))).toBe(true);
+  });
+
+  test("warns when the env-selected profile does not provision the target device", async () => {
+    const uuid = "33333333-3333-3333-3333-333333333333";
+    process.env.AUTOMOBILE_IOS_PROFILE_UUID = uuid;
+    const manager = new XcodeSigningManager(createEligibilityDependencies([
+      { uuid, name: "Wrong Device", expiration: "2030-01-01T00:00:00Z", provisionedDevices: [otherDevice], getTaskAllow: true, includeMatchingCert: true }
+    ]));
+
+    const resolution = await manager.resolveSigningForDevice(deviceUdid);
+
+    expect(resolution.warnings.some(w => w.includes("does not include device") && w.includes(deviceUdid))).toBe(true);
+  });
+
+  test("warns when the env-requested profile UUID is not present", async () => {
+    process.env.AUTOMOBILE_IOS_PROFILE_UUID = "99999999-0000-0000-0000-000000000000";
+    const manager = new XcodeSigningManager(createEligibilityDependencies([
+      { uuid: "44444444-4444-4444-4444-444444444444", name: "Some Dev", expiration: "2030-01-01T00:00:00Z", provisionedDevices: [deviceUdid], getTaskAllow: true, includeMatchingCert: true }
+    ]));
+
+    const resolution = await manager.resolveSigningForDevice(deviceUdid);
+
+    expect(resolution.warnings.some(w => w.includes("99999999-0000-0000-0000-000000000000") && w.includes("not found"))).toBe(true);
+  });
+
+  test("with no preferred profile, prefers development over enterprise/ad-hoc (development-first ordering)", async () => {
+    // All three are eligible (not expired, device-included or all-devices) and
+    // carry the matching cert, so whichever is selected resolves to manual. The
+    // ordering contract must pick the development profile.
+    const devUuid = "aaaaaaaa-0000-0000-0000-000000000000";
+    const manager = new XcodeSigningManager(createEligibilityDependencies([
+      { uuid: "cccccccc-0000-0000-0000-000000000000", name: "Enterprise", expiration: "2030-01-01T00:00:00Z", provisionsAllDevices: true, includeMatchingCert: true },
+      { uuid: "bbbbbbbb-0000-0000-0000-000000000000", name: "AdHoc", expiration: "2030-01-01T00:00:00Z", provisionedDevices: [deviceUdid], getTaskAllow: false, includeMatchingCert: true },
+      { uuid: devUuid, name: "Development", expiration: "2030-01-01T00:00:00Z", provisionedDevices: [deviceUdid], getTaskAllow: true, includeMatchingCert: true },
+    ]));
+
+    const resolution = await manager.resolveSigningForDevice(deviceUdid);
+
+    expect(resolution.profile?.profileType).toBe("development");
+    expect(resolution.profile?.uuid).toBe(devUuid);
+  });
+});
+
 describe("XcodeSigningManager", () => {
   const originalLaunchCwd = process.env[DAEMON_LAUNCH_CWD_ENV];
 
@@ -154,9 +338,16 @@ describe("XcodeSigningManager", () => {
 
     await expect(manager.detectTeamIdsFromXcode()).resolves.toEqual([teamId]);
 
-    const args = xcodebuildArgs[0];
-    const projectFlagIndex = args.indexOf("-project");
-    expect(projectFlagIndex).toBeGreaterThan(-1);
-    expect(args[projectFlagIndex + 1]).toBe(join(launchCwd, "ios", "control-proxy", "CtrlProxy.xcodeproj"));
+    // REWRITE-4 (#4177 item 14): assert the WHOLE argv, not just the
+    // -project/value pair. A `-project value` proximity check still passes if an
+    // extra argument is inserted between the flag and its value, or if the
+    // scheme/showBuildSettings flags drift; the full-array form catches all three.
+    expect(xcodebuildArgs[0]).toEqual([
+      "-showBuildSettings",
+      "-project",
+      join(launchCwd, "ios", "control-proxy", "CtrlProxy.xcodeproj"),
+      "-scheme",
+      "CtrlProxyApp",
+    ]);
   });
 });

--- a/test/utils/ios-cmdline-tools/XcodebuildClient.test.ts
+++ b/test/utils/ios-cmdline-tools/XcodebuildClient.test.ts
@@ -169,4 +169,20 @@ describe("XcodebuildClient streaming runner", () => {
       "xcodebuild is not available"
     );
   });
+
+  test("startStreaming releases the availability-probe timer handle", async () => {
+    // Covers the SECOND clearTimeout site (isAvailableWithin), independent of
+    // executeCommand's: `-version` failing makes the probe resolve unavailable
+    // before any spawn, and its timeout must be cleared on the INJECTED timer.
+    const timer = new FakeTimer();
+    const client = new XcodebuildClient(async () => {
+      throw new Error("not found");
+    }, timer);
+
+    await expect(
+      client.startStreaming(["test-without-building"], { timeoutMs: 5000 })
+    ).rejects.toThrow("xcodebuild is not available");
+
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+  });
 });

--- a/test/utils/ios-cmdline-tools/XcodebuildClient.test.ts
+++ b/test/utils/ios-cmdline-tools/XcodebuildClient.test.ts
@@ -70,6 +70,39 @@ describe("XcodebuildClient executeCommand timeout", () => {
     expect(capturedSignal?.aborted).toBe(false);
   });
 
+  test("refuses to run a non-probe command when xcodebuild is not installed", async () => {
+    // The only refusal branch in the file (executeCommand, not-a-probe path) was
+    // untested. The availability probe (`-version`) fails, so a real command
+    // must be turned away rather than executed against a missing toolchain.
+    const client = new XcodebuildClient(async (_file, args) => {
+      if (args.join(" ") === "-version") {
+        throw new Error("xcodebuild: command not found");
+      }
+      return createExecResult("should not reach", "");
+    });
+
+    await expect(client.executeCommand(["-showBuildSettings"])).rejects.toThrow(
+      "xcodebuild is not available. Please install Xcode to continue."
+    );
+  });
+
+  test("releases the injected timer handle after a timed command completes", async () => {
+    // Timer hygiene: the finally must clear the timeout on the INJECTED timer, not
+    // the global one, or the FakeTimer keeps a dangling pending timeout (a real
+    // handle leak in production). getPendingTimeoutCount() must return to 0.
+    const timer = new FakeTimer();
+    const client = new XcodebuildClient(async (_file, args) => {
+      if (args.join(" ") === "-version") {
+        return createExecResult("Xcode 26.5", "");
+      }
+      return createExecResult("ok", "");
+    }, timer);
+
+    await client.executeCommand(["-list"], { timeoutMs: 5000 });
+
+    expect(timer.getPendingTimeoutCount()).toBe(0);
+  });
+
   test("bounds the availability probe within the command timeout", async () => {
     const timer = new FakeTimer();
     let probeSignal: AbortSignal | undefined;

--- a/test/utils/ios-cmdline-tools/iosAppContainer.test.ts
+++ b/test/utils/ios-cmdline-tools/iosAppContainer.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import {
+  IOS_APP_DATA_FOLDERS,
+  getAppDataContainerPath,
+  terminateAppIfRunning,
+} from "../../../src/utils/ios-cmdline-tools/iosAppContainer";
+import { createExecResult } from "../../../src/utils/execResult";
+import type { ExecResult } from "../../../src/models";
+
+const deviceId = "7B3A3792-DB53-4654-BA94-27A1D305C3B7";
+const bundleId = "dev.jasonpearson.automobile.ctrlproxy";
+
+// iosAppContainer.ts holds two of the slice's only unasserted log-and-continue
+// catches. Both must degrade to a non-fatal result (resolve / null) rather than
+// propagate, but a real regression that let the error escape would go unnoticed
+// without these.
+describe("terminateAppIfRunning", () => {
+  test("terminates the app on the target device", async () => {
+    const calls: Array<{ bundleId: string; deviceId?: string }> = [];
+    const simctl = {
+      terminateApp: async (id: string, device?: string) => {
+        calls.push({ bundleId: id, deviceId: device });
+      },
+    };
+
+    await terminateAppIfRunning(simctl, deviceId, bundleId);
+
+    expect(calls).toEqual([{ bundleId, deviceId }]);
+  });
+
+  test("swallows a terminate failure instead of propagating (app not running is expected)", async () => {
+    const simctl = {
+      terminateApp: async () => {
+        throw new Error("Unable to terminate: found nothing to terminate");
+      },
+    };
+
+    // Observable contract: resolves (does NOT reject) even though the underlying
+    // terminate failed. `await` would throw here if the catch were removed.
+    await expect(terminateAppIfRunning(simctl, deviceId, bundleId)).resolves.toBeUndefined();
+  });
+});
+
+describe("getAppDataContainerPath", () => {
+  const containerClient = (result: ExecResult | Error) => {
+    const calls: string[][] = [];
+    const simctl = {
+      executeCommandArgs: async (args: string[]): Promise<ExecResult> => {
+        calls.push(args);
+        if (result instanceof Error) {
+          throw result;
+        }
+        return result;
+      },
+    };
+    return { simctl, calls };
+  };
+
+  test("returns the trimmed container path and issues the exact argv", async () => {
+    const { simctl, calls } = containerClient(
+      createExecResult("/Users/test/data/Containers/Data/Application/ABC\n", "")
+    );
+
+    const result = await getAppDataContainerPath(simctl, deviceId, bundleId);
+
+    expect(result).toBe("/Users/test/data/Containers/Data/Application/ABC");
+    expect(calls).toEqual([["get_app_container", deviceId, bundleId, "data"]]);
+  });
+
+  const nullRows: ReadonlyArray<{ label: string; result: ExecResult | Error }> = [
+    { label: "empty stdout", result: createExecResult("", "") },
+    { label: "whitespace-only stdout", result: createExecResult("   \n", "") },
+    { label: "the command throws (app not installed)", result: new Error("No such file or directory") },
+  ];
+
+  for (const { label, result } of nullRows) {
+    test(`returns null when ${label}`, async () => {
+      const { simctl } = containerClient(result);
+      expect(await getAppDataContainerPath(simctl, deviceId, bundleId)).toBeNull();
+    });
+  }
+});
+
+describe("IOS_APP_DATA_FOLDERS", () => {
+  test("wipes the standard iOS data-container top-level folders", () => {
+    expect(IOS_APP_DATA_FOLDERS).toEqual(["Documents", "Library", "tmp"]);
+  });
+});

--- a/test/utils/ios-cmdline-tools/iosProcessErrors.test.ts
+++ b/test/utils/ios-cmdline-tools/iosProcessErrors.test.ts
@@ -6,39 +6,46 @@ import { isProcessAlreadyGoneError } from "../../../src/utils/ios-cmdline-tools/
 // phrasings common to both the simulator (`simctl terminate`) and the physical
 // device (`devicectl device process terminate`) paths. Each call site OR-s in
 // its own tool-specific extras on top of this.
+//
+// PARAM-4 (#4177): collapsed into one decision table so every phrasing — and,
+// crucially, every NON-match (device-scoped "not running", devicectl-only
+// extras) — is a first-class row. The device/daemon-scoped rows are the
+// load-bearing ones: mistaking them for an already-exited PID would let a
+// disconnected device masquerade as a terminated app.
 describe("isProcessAlreadyGoneError", () => {
-  test("matches the shared already-gone phrasings (case-insensitive)", () => {
-    expect(isProcessAlreadyGoneError("No such process")).toBe(true);
-    expect(isProcessAlreadyGoneError("The operation couldn’t be completed. No such process")).toBe(true);
-    expect(isProcessAlreadyGoneError("found nothing to terminate")).toBe(true);
-    expect(isProcessAlreadyGoneError("Unable to terminate: found nothing to terminate")).toBe(true);
-    // Process-scoped "not running": with and without the "is".
-    expect(isProcessAlreadyGoneError("The process is not running")).toBe(true);
-    expect(isProcessAlreadyGoneError("process not running")).toBe(true);
-    // Case-insensitive.
-    expect(isProcessAlreadyGoneError("NO SUCH PROCESS")).toBe(true);
-    expect(isProcessAlreadyGoneError("FOUND NOTHING TO TERMINATE")).toBe(true);
-  });
+  const rows: ReadonlyArray<{ message: string; expected: boolean }> = [
+    // Already-gone: ESRCH strerror phrasing (case-insensitive).
+    { message: "No such process", expected: true },
+    { message: "The operation couldn’t be completed. No such process", expected: true },
+    { message: "NO SUCH PROCESS", expected: true },
+    // Already-gone: simctl "nothing to kill".
+    { message: "found nothing to terminate", expected: true },
+    { message: "Unable to terminate: found nothing to terminate", expected: true },
+    { message: "FOUND NOTHING TO TERMINATE", expected: true },
+    // Already-gone: process-scoped "not running", with and without "is".
+    { message: "The process is not running", expected: true },
+    { message: "process not running", expected: true },
+    { message: "PROCESS IS NOT RUNNING", expected: true },
+    // Unrelated hard failures must propagate.
+    { message: "The device is locked.", expected: false },
+    { message: "Could not connect to the device.", expected: false },
+    { message: "Unable to terminate: permission denied", expected: false },
+    { message: "", expected: false },
+    // "not running" scoped to the DEVICE/CoreDevice, never the process.
+    { message: "The device is not running.", expected: false },
+    { message: "device not running", expected: false },
+    { message: "CoreDevice tunnel is not running", expected: false },
+    { message: "the daemon is not running", expected: false },
+    // devicectl-only extras are OR-ed in at the call site, NOT here.
+    { message: "NSPOSIXErrorDomain error 3", expected: false },
+    { message: "The process is no longer running", expected: false },
+    // A bare unrelated code.
+    { message: "error 42", expected: false },
+  ];
 
-  test("does not match unrelated failures", () => {
-    expect(isProcessAlreadyGoneError("The device is locked.")).toBe(false);
-    expect(isProcessAlreadyGoneError("Could not connect to the device.")).toBe(false);
-    expect(isProcessAlreadyGoneError("Unable to terminate: permission denied")).toBe(false);
-    expect(isProcessAlreadyGoneError("")).toBe(false);
-  });
-
-  test("scopes 'not running' to the process, never the device/CoreDevice", () => {
-    // A device-level "not running" must NOT be swallowed as an already-exited
-    // process — otherwise a disconnected device would masquerade as terminated.
-    expect(isProcessAlreadyGoneError("The device is not running.")).toBe(false);
-    expect(isProcessAlreadyGoneError("device not running")).toBe(false);
-    expect(isProcessAlreadyGoneError("CoreDevice tunnel is not running")).toBe(false);
-  });
-
-  test("does NOT include devicectl-only extras (those OR-in at the call site)", () => {
-    // The bare POSIX ESRCH code and the "no longer running" phrasing are
-    // devicectl-specific; the shared helper stays minimal and simctl-safe.
-    expect(isProcessAlreadyGoneError("NSPOSIXErrorDomain error 3")).toBe(false);
-    expect(isProcessAlreadyGoneError("The process is no longer running")).toBe(false);
-  });
+  for (const { message, expected } of rows) {
+    test(`${expected ? "matches" : "does not match"}: ${JSON.stringify(message)}`, () => {
+      expect(isProcessAlreadyGoneError(message)).toBe(expected);
+    });
+  }
 });

--- a/test/utils/ios-cmdline-tools/iosVersion.test.ts
+++ b/test/utils/ios-cmdline-tools/iosVersion.test.ts
@@ -26,6 +26,48 @@ describe("parseIosMajorVersion", () => {
     expect(parseIosMajorVersion("")).toBeNull();
     expect(parseIosMajorVersion("unknown")).toBeNull();
   });
+
+  // Boundary table: the leading-digit regex `/^(\d+)/` on trimmed input has
+  // several surprising-but-load-bearing outcomes that no earlier test pins.
+  // `"0"` returns the falsy `0` (NOT null), so callers must use `=== null`, not
+  // truthiness, to detect "unknown". `"1e309"` reads only the leading `1` (the
+  // exponent is not part of the leading digit run — it is NOT parsed as
+  // Infinity). `"018"` reads `18` (base-10, no octal). Negatives and
+  // leading-dot forms have no leading digit and are "unknown".
+  const boundaryRows: ReadonlyArray<{ input: string; expected: number | null }> = [
+    { input: "0", expected: 0 },
+    { input: "1", expected: 1 },
+    { input: "018", expected: 18 },
+    { input: "1e309", expected: 1 },
+    { input: "26.2", expected: 26 },
+    { input: "17.5.1", expected: 17 },
+    { input: "18", expected: 18 },
+    { input: "007", expected: 7 },
+    { input: "42abc", expected: 42 },
+    { input: "  9 ", expected: 9 },
+    { input: "\t26.0\n", expected: 26 },
+    { input: "-3", expected: null },
+    { input: ".5", expected: null },
+    { input: "v18", expected: null },
+    { input: "iOS 18", expected: null },
+    { input: "unknown", expected: null },
+    { input: " ", expected: null },
+    { input: "NaN", expected: null },
+    { input: "Infinity", expected: null },
+  ];
+
+  for (const { input, expected } of boundaryRows) {
+    test(`parses ${JSON.stringify(input)} as ${expected === null ? "null" : expected}`, () => {
+      expect(parseIosMajorVersion(input)).toBe(expected);
+    });
+  }
+
+  test("distinguishes the falsy 0 from unknown (null)", () => {
+    // Regression guard: callers must not collapse `0` into "unknown".
+    expect(parseIosMajorVersion("0")).toBe(0);
+    expect(parseIosMajorVersion("0")).not.toBeNull();
+    expect(parseIosMajorVersion("x")).toBeNull();
+  });
 });
 
 describe("iosMajorVersionFromSimctlListDevices", () => {

--- a/test/utils/ios-cmdline-tools/notifyutil.test.ts
+++ b/test/utils/ios-cmdline-tools/notifyutil.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import {
+  IOS_NOTIFYUTIL_REGISTERED_SET_TIMEOUT_MS,
+  iosNotifyutilGetCommand,
+  iosNotifyutilRegisteredSetReadPostCommand,
+  parseNotifyutilState,
+} from "../../../src/utils/ios-cmdline-tools/notifyutil";
+
+// notifyutil.ts previously had zero tests. `parseNotifyutilState` decides
+// whether a Darwin notification key reads registered/on (true), off (false), or
+// could-not-be-determined (null). Collapsing unknown into "off" would report
+// "DND off" after a probe that actually returned nothing, so the null contract
+// is load-bearing. The parser reverses the lines and returns the LAST line that
+// ends in a standalone 0/1 (the digit must start the line or follow whitespace).
+describe("parseNotifyutilState", () => {
+  const rows: ReadonlyArray<{ label: string; raw: string; expected: boolean | null }> = [
+    { label: "bare 1 is registered/on", raw: "1", expected: true },
+    { label: "bare 0 is off", raw: "0", expected: false },
+    { label: "value preceded by a label word", raw: "state 1", expected: true },
+    { label: "0 preceded by a label word", raw: "key = 0", expected: false },
+    { label: "surrounding whitespace is trimmed", raw: "   1   ", expected: true },
+    { label: "trailing CRLF", raw: "1\r\n", expected: true },
+    { label: "reads the LAST decisive line (on after off)", raw: "0\n1", expected: true },
+    { label: "reads the LAST decisive line (off after on)", raw: "1\n0", expected: false },
+    { label: "skips non-decisive trailing lines", raw: "1\nregistered check complete", expected: true },
+    { label: "empty input is unknown", raw: "", expected: null },
+    { label: "whitespace-only input is unknown", raw: "   \n  ", expected: null },
+    { label: "a digit glued to a non-space char is not decisive", raw: "x1", expected: null },
+    { label: "a multi-digit number is not a standalone 0/1", raw: "10", expected: null },
+    { label: "digit not at end of line is ignored", raw: "1 registered", expected: null },
+    { label: "out-of-range digit is unknown", raw: "state 2", expected: null },
+    { label: "non-numeric output is unknown", raw: "no such key", expected: null },
+    { label: "later unknown line does not erase an earlier decisive one", raw: "0\nfoo", expected: false },
+  ];
+
+  for (const { label, raw, expected } of rows) {
+    test(`${label} → ${expected}`, () => {
+      expect(parseNotifyutilState(raw)).toBe(expected);
+    });
+  }
+});
+
+describe("notifyutil command builders", () => {
+  const deviceId = "7B3A3792-DB53-4654-BA94-27A1D305C3B7";
+  const key = "com.apple.donotdisturb.state";
+
+  test("iosNotifyutilGetCommand issues a spawn/get for the key", () => {
+    expect(iosNotifyutilGetCommand(deviceId, key)).toBe(
+      `spawn ${deviceId} notifyutil -g ${key}`
+    );
+  });
+
+  test("registered-set-read-post command sets, gets, and posts in one spawn (value 1)", () => {
+    expect(iosNotifyutilRegisteredSetReadPostCommand(deviceId, key, "1")).toBe(
+      `spawn ${deviceId} notifyutil -1 ${key} -s ${key} 1 -g ${key} -p ${key}`
+    );
+  });
+
+  test("registered-set-read-post command carries the value 0 through unchanged", () => {
+    expect(iosNotifyutilRegisteredSetReadPostCommand(deviceId, key, "0")).toBe(
+      `spawn ${deviceId} notifyutil -1 ${key} -s ${key} 0 -g ${key} -p ${key}`
+    );
+  });
+
+  test("exposes a positive registered-set timeout budget", () => {
+    expect(IOS_NOTIFYUTIL_REGISTERED_SET_TIMEOUT_MS).toBeGreaterThan(0);
+  });
+});

--- a/test/utils/ios-cmdline-tools/simctl.test.ts
+++ b/test/utils/ios-cmdline-tools/simctl.test.ts
@@ -638,13 +638,49 @@ describe("Simctl", function() {
       expect(runtimes[0].isAvailable).toBe(true);
     });
 
-    test("should throw when runtimes command fails", async function() {
-      mockExecAsync = async (): Promise<ExecResult> => {
-        throw new Error("simctl failed");
+    // REWRITE (#4177 item 2): a bare `rejects.toThrow()` here passed on the
+    // availability-probe error, not the `list runtimes` command error, because
+    // `ensureLocalSimctlAvailable` fires first. Let the probe succeed so only the
+    // real command fails, and assert the *command's* message surfaces.
+    test("surfaces the runtimes command error, not the availability-probe error", async function() {
+      mockExecAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
+        if (args.join(" ") === "simctl --version") {
+          return createExecResult("simctl version 0.0", "");
+        }
+        throw new Error("simctl list runtimes exploded");
       };
 
       simctl = new Simctl(null, mockExecAsync);
-      await expect(simctl.getRuntimes()).rejects.toThrow();
+      await expect(simctl.getRuntimes()).rejects.toThrow("simctl list runtimes exploded");
+    });
+
+    // ADD (#4177 item 3): malformed simctl output must degrade to "no runtimes"
+    // via the catch, and a valid payload that simply omits the `runtimes` key
+    // must degrade via `data.runtimes ?? []` — a different branch (SimCtlClient
+    // :1119) that no test pinned. A regression in either would silently report
+    // zero installed runtimes with no error.
+    test("returns an empty list when the runtimes JSON is malformed (swallow)", async function() {
+      mockExecAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
+        if (args.join(" ") === "simctl --version") {
+          return createExecResult("simctl version 0.0", "");
+        }
+        return createExecResult("this is not { valid json", "");
+      };
+
+      simctl = new Simctl(null, mockExecAsync);
+      expect(await simctl.getRuntimes()).toEqual([]);
+    });
+
+    test("returns an empty list when the runtimes key is absent (data.runtimes ?? [])", async function() {
+      mockExecAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
+        if (args.join(" ") === "simctl --version") {
+          return createExecResult("simctl version 0.0", "");
+        }
+        return createExecResult(JSON.stringify({ notRuntimes: [] }), "");
+      };
+
+      simctl = new Simctl(null, mockExecAsync);
+      expect(await simctl.getRuntimes()).toEqual([]);
     });
   });
 
@@ -671,13 +707,43 @@ describe("Simctl", function() {
       expect(types[0].name).toBe("iPhone 17 Pro");
     });
 
-    test("should throw when devicetypes command fails", async function() {
-      mockExecAsync = async (): Promise<ExecResult> => {
-        throw new Error("simctl failed");
+    // REWRITE (#4177 item 2): as with getRuntimes, assert the command error and
+    // not the availability probe.
+    test("surfaces the devicetypes command error, not the availability-probe error", async function() {
+      mockExecAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
+        if (args.join(" ") === "simctl --version") {
+          return createExecResult("simctl version 0.0", "");
+        }
+        throw new Error("simctl list devicetypes exploded");
       };
 
       simctl = new Simctl(null, mockExecAsync);
-      await expect(simctl.getDeviceTypes()).rejects.toThrow();
+      await expect(simctl.getDeviceTypes()).rejects.toThrow("simctl list devicetypes exploded");
+    });
+
+    // ADD (#4177 item 3): malformed / key-absent payloads degrade to [].
+    test("returns an empty list when the devicetypes JSON is malformed (swallow)", async function() {
+      mockExecAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
+        if (args.join(" ") === "simctl --version") {
+          return createExecResult("simctl version 0.0", "");
+        }
+        return createExecResult("<<< not json >>>", "");
+      };
+
+      simctl = new Simctl(null, mockExecAsync);
+      expect(await simctl.getDeviceTypes()).toEqual([]);
+    });
+
+    test("returns an empty list when the devicetypes key is absent (data.devicetypes ?? [])", async function() {
+      mockExecAsync = async (_file: string, args: string[]): Promise<ExecResult> => {
+        if (args.join(" ") === "simctl --version") {
+          return createExecResult("simctl version 0.0", "");
+        }
+        return createExecResult(JSON.stringify({ somethingElse: 1 }), "");
+      };
+
+      simctl = new Simctl(null, mockExecAsync);
+      expect(await simctl.getDeviceTypes()).toEqual([]);
     });
   });
 
@@ -721,56 +787,62 @@ describe("Simctl", function() {
       }
     }
 
-    test("skips open -a Simulator when AUTOMOBILE_IOS_HEADLESS=true (no launchctl probe)", async function() {
-      process.env[HEADLESS_ENV] = "true";
-      try {
-        simctl = new Simctl(null, recordingExec("Aqua"), new FakeTimer(), "darwin");
-        await simctl.openSimulatorApp();
-        expect(openCalls()).toHaveLength(0);
-        expect(launchctlCalls()).toHaveLength(0);
-      } finally {
-        restoreEnv();
-      }
-    });
+    // Decision table (#4177 item 4 / PARAM-1). Resolution order that MUST hold:
+    //   1. A non-darwin host can never launch Simulator.app, so it is headless
+    //      regardless of the override — this gate must come BEFORE the override
+    //      is consumed, otherwise AUTOMOBILE_IOS_HEADLESS=false (or "") would
+    //      shell `open -a Simulator` on Linux/Windows (the bug this pins).
+    //   2. On darwin, the env override short-circuits the launchctl probe:
+    //      "true"/"1" ⇒ headless (skip), anything else defined ⇒ force GUI.
+    //   3. With no override on darwin, probe launchctl: "Aqua" ⇒ GUI, otherwise
+    //      headless; a probe failure falls back to GUI.
+    // expectedProbes is the launchctl-probe count; the override path must never
+    // probe (short-circuit), so an override row always expects 0 probes.
+    type Manager = "Aqua" | "System" | Error;
+    const headlessRows: ReadonlyArray<{
+      override: string | undefined;
+      platform: NodeJS.Platform;
+      manager: Manager;
+      expectedOpens: number;
+      expectedProbes: number;
+    }> = [
+      // darwin, no override → launchctl decides
+      { override: undefined, platform: "darwin", manager: "Aqua", expectedOpens: 1, expectedProbes: 1 },
+      { override: undefined, platform: "darwin", manager: "System", expectedOpens: 0, expectedProbes: 1 },
+      { override: undefined, platform: "darwin", manager: new Error("launchctl unavailable"), expectedOpens: 1, expectedProbes: 1 },
+      // darwin, override short-circuits the probe
+      { override: "true", platform: "darwin", manager: "Aqua", expectedOpens: 0, expectedProbes: 0 },
+      { override: "1", platform: "darwin", manager: "System", expectedOpens: 0, expectedProbes: 0 },
+      { override: "false", platform: "darwin", manager: "System", expectedOpens: 1, expectedProbes: 0 },
+      { override: "0", platform: "darwin", manager: "System", expectedOpens: 1, expectedProbes: 0 },
+      { override: "", platform: "darwin", manager: "System", expectedOpens: 1, expectedProbes: 0 },
+      { override: "maybe", platform: "darwin", manager: "Aqua", expectedOpens: 1, expectedProbes: 0 },
+      // non-darwin → always headless, never probes, never opens, whatever the override
+      { override: undefined, platform: "linux", manager: "Aqua", expectedOpens: 0, expectedProbes: 0 },
+      { override: "true", platform: "linux", manager: "Aqua", expectedOpens: 0, expectedProbes: 0 },
+      { override: "false", platform: "linux", manager: "Aqua", expectedOpens: 0, expectedProbes: 0 },
+      { override: "false", platform: "win32", manager: "Aqua", expectedOpens: 0, expectedProbes: 0 },
+      { override: "", platform: "linux", manager: "Aqua", expectedOpens: 0, expectedProbes: 0 },
+    ];
 
-    test("forces open -a Simulator when AUTOMOBILE_IOS_HEADLESS=false even if session is non-Aqua", async function() {
-      process.env[HEADLESS_ENV] = "false";
-      try {
-        simctl = new Simctl(null, recordingExec("System"), new FakeTimer(), "darwin");
-        await simctl.openSimulatorApp();
-        expect(openCalls()).toHaveLength(1);
-        expect(launchctlCalls()).toHaveLength(0);
-      } finally {
-        restoreEnv();
-      }
-    });
-
-    test("calls open -a Simulator when launchctl reports an Aqua GUI session", async function() {
-      simctl = new Simctl(null, recordingExec("Aqua"), new FakeTimer(), "darwin");
-      await simctl.openSimulatorApp();
-      expect(launchctlCalls()).toHaveLength(1);
-      expect(openCalls()).toHaveLength(1);
-    });
-
-    test("skips open -a Simulator when launchctl reports a non-Aqua (headless) session", async function() {
-      simctl = new Simctl(null, recordingExec("System"), new FakeTimer(), "darwin");
-      await simctl.openSimulatorApp();
-      expect(launchctlCalls()).toHaveLength(1);
-      expect(openCalls()).toHaveLength(0);
-    });
-
-    test("skips open -a Simulator on non-darwin platforms without any exec", async function() {
-      simctl = new Simctl(null, recordingExec("Aqua"), new FakeTimer(), "linux");
-      await simctl.openSimulatorApp();
-      expect(calls).toHaveLength(0);
-    });
-
-    test("attempts open -a Simulator when launchctl probe fails (safe fallback)", async function() {
-      simctl = new Simctl(null, recordingExec(new Error("launchctl unavailable")), new FakeTimer(), "darwin");
-      await simctl.openSimulatorApp();
-      expect(launchctlCalls()).toHaveLength(1);
-      expect(openCalls()).toHaveLength(1);
-    });
+    for (const row of headlessRows) {
+      const label = `override=${JSON.stringify(row.override)} platform=${row.platform} manager=${row.manager instanceof Error ? "probe-error" : row.manager}`;
+      test(`opens×${row.expectedOpens} probes×${row.expectedProbes} for ${label}`, async function() {
+        if (row.override === undefined) {
+          delete process.env[HEADLESS_ENV];
+        } else {
+          process.env[HEADLESS_ENV] = row.override;
+        }
+        try {
+          simctl = new Simctl(null, recordingExec(row.manager), new FakeTimer(), row.platform);
+          await simctl.openSimulatorApp();
+          expect(openCalls()).toHaveLength(row.expectedOpens);
+          expect(launchctlCalls()).toHaveLength(row.expectedProbes);
+        } finally {
+          restoreEnv();
+        }
+      });
+    }
 
     test("caches the headless detection so launchctl is probed at most once", async function() {
       simctl = new Simctl(null, recordingExec("Aqua"), new FakeTimer(), "darwin");

--- a/test/utils/ios-cmdline-tools/simctlArgvIntegrity.test.ts
+++ b/test/utils/ios-cmdline-tools/simctlArgvIntegrity.test.ts
@@ -140,6 +140,55 @@ describe("simctl argv integrity (#4196)", () => {
     }
   });
 
+  // ADD-1 (#4177 item 1): a round-trip table proving `executeCommandArgs` — the
+  // argv seam every command method now routes through — delivers each
+  // device-controlled value to `xcrun simctl` byte-for-byte, with NO positional
+  // shift. The empty value is the dangerous one: dropping it turns
+  // `defaults write <domain> <key> ""` into the shorter `defaults read`. The
+  // legacy string `executeCommand` still mangles the unquoted `newline`/`tab`
+  // rows (it re-splits on whitespace); those callers were migrated to
+  // `executeCommandArgs`, which is why the table drives the argv path.
+  describe("executeCommandArgs delivers every value to xcrun simctl unchanged", () => {
+    for (const { label, value } of TRICKY_VALUES) {
+      test(`round-trips ${label} into argv`, async () => {
+        const seen: string[][] = [];
+        const client = new Simctl(null, async (_file, args) => {
+          if (args.join(" ") !== "simctl --version") {
+            seen.push(args);
+          }
+          return createExecResult("", "");
+        });
+
+        await client.executeCommandArgs([
+          "spawn", UDID, "defaults", "write", "domain", "key", value
+        ]);
+
+        expect(seen).toEqual([[
+          "simctl", "spawn", UDID, "defaults", "write", "domain", "key", value
+        ]]);
+      });
+    }
+
+    test("an empty value keeps the argv length and does not shift later positions", async () => {
+      const seen: string[][] = [];
+      const client = new Simctl(null, async (_file, args) => {
+        if (args.join(" ") !== "simctl --version") {
+          seen.push(args);
+        }
+        return createExecResult("", "");
+      });
+
+      await client.executeCommandArgs([
+        "spawn", UDID, "defaults", "write", "domain", "key", ""
+      ]);
+
+      // 1 (simctl) + 7 caller args = 8 entries; `write` stays the verb.
+      expect(seen[0]).toHaveLength(8);
+      expect(seen[0][4]).toBe("write");
+      expect(seen[0][7]).toBe("");
+    });
+  });
+
   describe("legacy string command path no longer drops empty quoted arguments", () => {
     test("an empty quoted token is preserved as an empty argv entry", async () => {
       const seen: string[][] = [];


### PR DESCRIPTION
## Summary

Milestone 32 (Unit Test Quality Audit), slice **utils-ios**: 15 of 16 verified
test-quality findings burned down, each verified red-green. (Item 13/REWRITE-3 was
deferred — see Follow-ups.)

**Two surgical `src` fixes:**
- **`SimCtlClient.isHeadlessSession`** applies the `platform !== "darwin"` gate **before**
  consuming the `AUTOMOBILE_IOS_HEADLESS` override, so `false`/`""` can no longer shell
  `open -a Simulator` on Linux/Windows (a live cross-platform bug).
- **`XcodebuildClient`** releases the injected `Timer` handle via `this.timer.clearTimeout`
  instead of the global `clearTimeout`, so the handle count returns to zero.

Test-side: `executeCommand` argv round-trip table (driven through the existing
`executeCommandArgs`); the command-fails and malformed-JSON contracts; a headless decision
table with the non-darwin override rows; `XcodeSigning` profile-eligibility (env
`AUTOMOBILE_IOS_PROFILE_UUID`, with the 6 signing env vars saved/restored) and a whole
`-project` argv assertion; `clearCaches`/`resetSetupState` re-probe rewrites;
`parseNotifyutilState`, `iosAppContainer`, `XcodebuildClient` refusal, `AppBundleHasher`
(injected `bundle()` seam, no real fs), `parseIosMajorVersion`, `isProcessAlreadyGoneError`,
and `getReportedRunnerPort` ordering (#2731) tables; and deletion of the 145-line dead
`FakeIOSCtrlProxyManager` describe + a local `createExecResult` shadow.

Rebased onto current main, which now includes #4464 ("constrain host shell execution").

## Linked Issue

Closes #4177

## Validation

- [x] `bun test`: **10277 tests, 0 fail / 14 skip** across 771 files (rebased on current main incl. #4464)
- [x] `bun run typecheck`: no new errors
- [x] `bun run lint`: clean (all boundary-guard scans pass)

## Follow-ups

- [ ] REWRITE-3 (item 13) deferred to #4472 — #4464 migrated `DeviceAppManager` to an argv
  `execute(file, args)` seam mid-flight; the no-data-wipe-on-failed-resolve test must be
  re-authored against the new seam.
- [ ] Item 16 (RENAME) not applied — the issue's `§RENAME` table is absent from the body.
