### PR TITLE
feat(desktop): client click-to-tap via daemon input API (#3347)

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -55,6 +55,9 @@ fun AutoMobileDesktopApp(menuBarActions: MenuBarActions = remember { MenuBarActi
           )
         },
         menuBarActions = menuBarActions,
+        // The reference desktop client opts into device control (issue #3347): a click on the live
+        // layout screen taps the device via the daemon. The IDE plugin leaves this off.
+        enableDeviceControl = true,
       )
     }
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -194,6 +194,10 @@ internal fun isActiveDeviceStreamFrame(deviceId: String?, activeDeviceId: String
  *   independently (the hierarchy is debounced), so a click could otherwise be mapped against one
  *   device's dimensions yet sent to another. When the observation stream disconnects both ids are
  *   invalidated, which also drops control on a frozen mirror.
+ * - the observation stream is live ([isObservationStreamConnected]) — a stale frame must not
+ *   re-enable control while the stream is down, and
+ * - the rendered screenshot and hierarchy geometry agree ([isRenderedGeometryConsistent], see
+ *   [isRenderedGeometryConsistent]) so a click is not mapped through a mismatched scale.
  *
  * When any condition fails the view falls back to inspector mode, so the user is never tapping
  * blind.
@@ -205,13 +209,57 @@ internal fun isDeviceControlActive(
   connectionType: McpConnectionType?,
   renderedDeviceId: String?,
   renderedHierarchyDeviceId: String?,
+  isObservationStreamConnected: Boolean,
+  isRenderedGeometryConsistent: Boolean,
 ): Boolean {
   return enableDeviceControl &&
     isRealDeviceMode &&
     activeDeviceId != null &&
     connectionType?.supportsDaemonInput == true &&
+    isObservationStreamConnected &&
+    isRenderedGeometryConsistent &&
     renderedDeviceId == activeDeviceId &&
     renderedHierarchyDeviceId == activeDeviceId
+}
+
+/** Relative aspect-ratio tolerance for [isRenderedGeometryConsistent]. */
+private const val GEOMETRY_ASPECT_TOLERANCE = 0.05f
+
+/**
+ * Whether the rendered screenshot and the hit-tested hierarchy describe a geometrically-consistent
+ * view of the same screen (issue #3347). `DeviceScreenView` maps a click through the hierarchy-root
+ * dimensions while fitting the screenshot by its own aspect ratio, so if the two disagree in aspect
+ * a tap is mapped through the wrong scale. This requires their aspect ratios to agree up to a 90°
+ * rotation (the mapper aligns screenshot orientation to the hierarchy) within
+ * [GEOMETRY_ASPECT_TOLERANCE].
+ *
+ * A non-positive screenshot dimension (no frame yet) is inconsistent. Non-positive hierarchy-root
+ * dimensions mean the hierarchy carries no explicit bounds, in which case the mapper falls back to
+ * the screenshot dimensions and the two are consistent by construction.
+ *
+ * Note: this catches resolution/aspect mismatches, not a same-device, same-aspect rotation while
+ * the hierarchy is still debounced — that transient is indistinguishable from a normal iOS
+ * native-orientation screenshot without a per-frame device-orientation signal (tracked as a
+ * follow-up).
+ */
+internal fun isRenderedGeometryConsistent(
+  screenshotWidth: Int,
+  screenshotHeight: Int,
+  hierarchyRootWidth: Int,
+  hierarchyRootHeight: Int,
+): Boolean {
+  if (screenshotWidth <= 0 || screenshotHeight <= 0) return false
+  if (hierarchyRootWidth <= 0 || hierarchyRootHeight <= 0) return true
+  val screenshotAspect = screenshotWidth.toFloat() / screenshotHeight.toFloat()
+  val hierarchyAspect = hierarchyRootWidth.toFloat() / hierarchyRootHeight.toFloat()
+  val matchesDirect =
+    kotlin.math.abs(screenshotAspect - hierarchyAspect) <=
+      GEOMETRY_ASPECT_TOLERANCE * hierarchyAspect
+  val rotatedHierarchyAspect = 1f / hierarchyAspect
+  val matchesRotated =
+    kotlin.math.abs(screenshotAspect - rotatedHierarchyAspect) <=
+      GEOMETRY_ASPECT_TOLERANCE * rotatedHierarchyAspect
+  return matchesDirect || matchesRotated
 }
 
 /**
@@ -824,6 +872,9 @@ fun AutoMobileContent(
     if (!isLiveLayoutMode || liveStreamClient == null) return@LaunchedEffect
     liveStreamClient.hierarchyUpdates.collect { update ->
       if (!isActiveDeviceStreamFrame(update.deviceId, activeDeviceId)) return@collect
+      // Capture the generation before the async parse so a frame decoded across an invalidation
+      // (device change / stream disconnect) is dropped instead of restoring stale bounds (#3347).
+      val generation = layoutInspectorState.frameGeneration
       update.data?.let { hierarchyJson ->
         val result =
           kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Default) {
@@ -840,7 +891,12 @@ fun AutoMobileContent(
           // Tag the hierarchy with its source device so the device-control gate can require the
           // hit-tested hierarchy (not just the screenshot) to match the selected device (issue
           // #3347). The frame already passed the active-device filter above.
-          layoutInspectorState.applyHierarchyUpdate(it.first, it.second, deviceId = update.deviceId)
+          layoutInspectorState.applyHierarchyUpdate(
+            it.first,
+            it.second,
+            deviceId = update.deviceId,
+            generation = generation,
+          )
         }
       }
     }
@@ -849,6 +905,10 @@ fun AutoMobileContent(
     if (!isLiveLayoutMode || liveStreamClient == null) return@LaunchedEffect
     liveStreamClient.screenshotUpdates.collect { update ->
       if (!isActiveDeviceStreamFrame(update.deviceId, activeDeviceId)) return@collect
+      // Capture the generation before the async decode so a screenshot decoded across an
+      // invalidation (device change / stream disconnect) is dropped rather than restoring a stale
+      // frame that would silently re-enable device control (#3347).
+      val generation = layoutInspectorState.frameGeneration
       update.screenshotBase64?.let { base64 ->
         val screenshotData =
           kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Default) {
@@ -865,10 +925,11 @@ fun AutoMobileContent(
           format = update.screenshotFormat,
           captureSource = update.screenshotCaptureSource,
           // Tag the rendered frame with its source device so device control can require the
-          // on-screen
-          // frame to match the selected device (issue #3347). The frame already passed the
+          // on-screen frame to match the selected device (issue #3347). The frame already passed
+          // the
           // active-device filter above, so this equals activeDeviceId at apply time.
           deviceId = update.deviceId,
+          generation = generation,
         )
       }
     }
@@ -1108,10 +1169,27 @@ fun AutoMobileContent(
       if (connectionState is ConnectionState.Disconnected) {
         clearPerformanceMetrics()
         // The observation stream is dead, so the on-screen mirror is frozen/stale even if the input
-        // socket still works. Invalidate the rendered frame's device identity so device control
-        // deactivates (issue #3347) — a click on a frozen mirror must not actuate the real device.
+        // socket still works. Mark it disconnected AND invalidate the rendered frame's device
+        // identity so device control deactivates (issue #3347) — a click on a frozen mirror must
+        // not
+        // actuate the real device. The generation bump inside the invalidation also drops any
+        // decode
+        // or debounced hierarchy job still in flight when the stream dropped.
+        layoutInspectorState.updateConnectionStatus(ConnectionStatus.Disconnected)
         layoutInspectorState.invalidateRenderedDeviceIdentity()
       }
+    }
+  }
+
+  // Drop the rendered frame's device identity the instant the selected device changes (issue
+  // #3347):
+  // the previous device's screenshot/hierarchy linger until new frames arrive, and control must
+  // stay
+  // off (Inspector) until a fresh, matching frame is applied. The generation bump also drops any
+  // in-flight frame work queued for the previous device.
+  LaunchedEffect(activeDeviceId) {
+    if (isLiveLayoutMode) {
+      layoutInspectorState.invalidateRenderedDeviceIdentity()
     }
   }
 
@@ -1468,6 +1546,7 @@ fun AutoMobileContent(
           // a rendered frame that belongs to that selected device (so a click on a stale mirror
           // after
           // a device switch can't actuate the wrong device). Otherwise we stay in inspector mode.
+          val hierarchyRootBounds = layoutInspectorState.hierarchy?.bounds
           val deviceControlActive =
             isDeviceControlActive(
               enableDeviceControl = enableDeviceControl,
@@ -1476,6 +1555,15 @@ fun AutoMobileContent(
               connectionType = connectedMcpProcess?.connectionType,
               renderedDeviceId = layoutInspectorState.renderedDeviceId,
               renderedHierarchyDeviceId = layoutInspectorState.renderedHierarchyDeviceId,
+              isObservationStreamConnected =
+                layoutInspectorState.connectionStatus == ConnectionStatus.Connected,
+              isRenderedGeometryConsistent =
+                isRenderedGeometryConsistent(
+                  screenshotWidth = layoutInspectorState.screenWidth,
+                  screenshotHeight = layoutInspectorState.screenHeight,
+                  hierarchyRootWidth = hierarchyRootBounds?.width ?: 0,
+                  hierarchyRootHeight = hierarchyRootBounds?.height ?: 0,
+                ),
             )
           Box(mod.background(colors.text.normal.copy(alpha = 0.02f))) {
             DeviceScreenView(

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -64,6 +64,8 @@ import androidx.compose.ui.unit.sp
 import dev.jasonpearson.automobile.desktop.core.components.Tooltip
 import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import dev.jasonpearson.automobile.desktop.core.control.ControlTapErrorGate
+import dev.jasonpearson.automobile.desktop.core.control.DeviceControlTapCommand
+import dev.jasonpearson.automobile.desktop.core.control.DeviceControlTapDispatcher
 import dev.jasonpearson.automobile.desktop.core.control.DeviceControlTapForwarder
 import dev.jasonpearson.automobile.desktop.core.daemon.AppearanceClient
 import dev.jasonpearson.automobile.desktop.core.daemon.AppearanceSocketClient
@@ -702,6 +704,41 @@ fun AutoMobileContent(
   // MCP client are cancelled when this composable leaves composition instead of
   // leaking a hung coroutine + client if the daemon is unresponsive (#3603).
   val screenshotScope = rememberCoroutineScope()
+
+  // Serializes control taps so their daemon requests execute in click order (issue #3347). The
+  // click-time snapshot is enqueued in order; a single consumer forwards each tap to completion —
+  // closing its per-tap client in a finally and publishing any error through the token gate on the
+  // UI thread — before the next begins.
+  val deviceControlTapDispatcher =
+    remember(screenshotScope) {
+      DeviceControlTapDispatcher(screenshotScope) { command ->
+        var tapError: String? = null
+        try {
+          withContext(Dispatchers.IO) {
+            deviceControlTapForwarder.forward(
+              point = command.point,
+              client = command.client,
+              platform = command.platform,
+              deviceId = command.deviceId,
+              onError = { message -> tapError = message },
+            )
+          }
+        } finally {
+          command.client?.close()
+        }
+        val message = tapError
+        if (message != null) {
+          // Serialize the token check + banner write with nextToken()/clear on the UI thread so a
+          // superseded tap's stale error can't resurrect a banner a newer tap already cleared.
+          withContext(Dispatchers.Main) {
+            if (deviceControlTapGate.isCurrent(command.token)) {
+              deviceControlTapError = message
+            }
+          }
+        }
+      }
+    }
+
   val takeScreenshot: () -> Unit =
     remember(clientProvider, screenshotScope) {
       takeScreenshot@{
@@ -1181,16 +1218,16 @@ fun AutoMobileContent(
     }
   }
 
-  // Drop the rendered frame's device identity the instant the selected device changes (issue
-  // #3347):
-  // the previous device's screenshot/hierarchy linger until new frames arrive, and control must
-  // stay
-  // off (Inspector) until a fresh, matching frame is applied. The generation bump also drops any
-  // in-flight frame work queued for the previous device.
-  LaunchedEffect(activeDeviceId) {
-    if (isLiveLayoutMode) {
-      layoutInspectorState.invalidateRenderedDeviceIdentity()
-    }
+  // Reset the control gate to an invalidated, not-live state on device change AND whenever Live
+  // Layout opens or closes (issue #3347). While the panel is closed the screenshot/hierarchy
+  // collectors stop, but the previous frame's device identity + Connected status persist — so
+  // reopening for the same device would otherwise enable Control against a mirror frozen for the
+  // whole closed period. Keying on isLiveLayoutMode makes reopen start invalidated; fresh
+  // screenshot+hierarchy frames (a newer generation) re-arm it, and the generation guard drops the
+  // replayed stale frame.
+  LaunchedEffect(activeDeviceId, isLiveLayoutMode) {
+    layoutInspectorState.updateConnectionStatus(ConnectionStatus.Disconnected)
+    layoutInspectorState.invalidateRenderedDeviceIdentity()
   }
 
   // Populate telemetry event cache for global search (mirroring TelemetryDashboard's collection)
@@ -1596,47 +1633,29 @@ fun AutoMobileContent(
                 if (deviceControlActive) {
                   { point: DevicePoint ->
                     // Snapshot the whole tap target atomically on the UI thread: the active device
-                    // can change before the IO coroutine runs, and resolving client/platform/device
+                    // can change before the tap is forwarded, and resolving client/platform/device
                     // late would send this coordinate to the wrong device.
                     val tapDeviceId = activeDeviceId
                     // Refuse a tap with no explicitly selected device: deviceControlActive already
                     // requires a non-null selection, this guards the click-vs-recompose race so the
                     // daemon can never pick a device the user did not choose.
                     if (tapDeviceId != null) {
-                      // clientProvider mints a fresh McpDaemonClient (a new Unix socket) per call,
-                      // so
-                      // close it after the tap or every click leaks a socket. Mirrors the
-                      // take-screenshot path's close-in-finally.
+                      // clientProvider mints a fresh McpDaemonClient (a new Unix socket) per call;
+                      // the dispatcher's consumer closes it after the tap (else every click leaks a
+                      // socket). Enqueue in click order so the daemon requests execute in that
+                      // order.
                       val tapClient = clientProvider?.invoke()
-                      val tapPlatform = platformString
                       val tapToken = deviceControlTapGate.nextToken()
                       deviceControlTapError = null
-                      screenshotScope.launch(Dispatchers.IO) {
-                        var tapError: String? = null
-                        try {
-                          deviceControlTapForwarder.forward(
-                            point = point,
-                            client = tapClient,
-                            platform = tapPlatform,
-                            deviceId = tapDeviceId,
-                            onError = { message -> tapError = message },
-                          )
-                        } finally {
-                          tapClient?.close()
-                        }
-                        // Publish on the UI dispatcher so the token check and the banner write are
-                        // serialized with nextToken()/clear (which also run on the UI thread). Only
-                        // the latest tap may publish; a superseded tap's stale error is dropped and
-                        // can't resurrect a banner a newer tap already cleared.
-                        val message = tapError
-                        if (message != null) {
-                          withContext(Dispatchers.Main) {
-                            if (deviceControlTapGate.isCurrent(tapToken)) {
-                              deviceControlTapError = message
-                            }
-                          }
-                        }
-                      }
+                      deviceControlTapDispatcher.enqueue(
+                        DeviceControlTapCommand(
+                          point = point,
+                          client = tapClient,
+                          platform = platformString,
+                          deviceId = tapDeviceId,
+                          token = tapToken,
+                        )
+                      )
                     }
                   }
                 } else {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -228,27 +228,36 @@ internal fun isDeviceControlActive(
 private const val GEOMETRY_ASPECT_TOLERANCE = 0.05f
 
 /**
- * Whether the rendered screenshot and the hit-tested hierarchy describe a geometrically-consistent
- * view of the same screen (issue #3347). `DeviceScreenView` maps a click through the hierarchy-root
- * dimensions while fitting the screenshot by its own aspect ratio, so if the two disagree in aspect
- * a tap is mapped through the wrong scale. This requires their aspect ratios to agree up to a 90°
- * rotation (the mapper aligns screenshot orientation to the hierarchy) within
- * [GEOMETRY_ASPECT_TOLERANCE].
+ * Whether the frame actually displayed and the effective device bounds used for mapping describe a
+ * geometrically-consistent view of the same screen (issue #3347). `DeviceScreenView` maps a click
+ * through the effective device bounds while fitting the displayed frame by its own aspect ratio, so
+ * if the two disagree in aspect a tap is mapped through the wrong scale. Aspect ratios must agree
+ * within [GEOMETRY_ASPECT_TOLERANCE].
  *
- * A non-positive screenshot dimension (no frame yet) is inconsistent. Non-positive hierarchy-root
- * dimensions mean the hierarchy carries no explicit bounds, in which case the mapper falls back to
- * the screenshot dimensions and the two are consistent by construction.
+ * [allowRotation] selects how strict the orientation match is:
+ * - true (a polled **screenshot** is displayed): agreement is checked up to a 90° rotation, because
+ *   a screenshot can arrive in native pixel orientation (portrait) even when the device is
+ *   landscape — the mapper rotates it to align, so an orientation difference is expected (notably
+ *   on iOS).
+ * - false (a live **video** frame is displayed): the video is always in display orientation, so an
+ *   orientation difference means the frame and the mapping bounds are out of sync (a rotate/resize
+ *   the observation stream hasn't caught up to). Agreement is required in the SAME orientation, so
+ *   control drops until they realign.
  *
- * Note: this catches resolution/aspect mismatches, not a same-device, same-aspect rotation while
- * the hierarchy is still debounced — that transient is indistinguishable from a normal iOS
- * native-orientation screenshot without a per-frame device-orientation signal (tracked as a
- * follow-up).
+ * A non-positive displayed dimension (no frame yet) is inconsistent. Non-positive device dimensions
+ * mean neither the hierarchy nor the observation stream reported a size, so the mapper falls back
+ * to the displayed frame itself and the two are consistent by construction.
+ *
+ * The caller passes the SAME effective device bounds the mapper uses (hierarchy-root bounds when
+ * present, else the observation stream's screen size), so the check is not bypassed on the common
+ * Android path where the accessibility root has no explicit bounds.
  */
 internal fun isRenderedGeometryConsistent(
   screenshotWidth: Int,
   screenshotHeight: Int,
   hierarchyRootWidth: Int,
   hierarchyRootHeight: Int,
+  allowRotation: Boolean = true,
 ): Boolean {
   if (screenshotWidth <= 0 || screenshotHeight <= 0) return false
   if (hierarchyRootWidth <= 0 || hierarchyRootHeight <= 0) return true
@@ -257,6 +266,7 @@ internal fun isRenderedGeometryConsistent(
   val matchesDirect =
     kotlin.math.abs(screenshotAspect - hierarchyAspect) <=
       GEOMETRY_ASPECT_TOLERANCE * hierarchyAspect
+  if (!allowRotation) return matchesDirect
   val rotatedHierarchyAspect = 1f / hierarchyAspect
   val matchesRotated =
     kotlin.math.abs(screenshotAspect - rotatedHierarchyAspect) <=
@@ -919,6 +929,11 @@ fun AutoMobileContent(
   val liveStreamClient = observationStreamClient
   LaunchedEffect(liveStreamClient, isLiveLayoutMode, activeDeviceId) {
     if (!isLiveLayoutMode || liveStreamClient == null) return@LaunchedEffect
+    // Drop any buffered pre-(re)subscribe frame so a Live Layout reopen doesn't replay the stale
+    // pre-close frame and re-arm control from it (issue #3347). Only genuinely post-subscribe
+    // frames
+    // arm control.
+    liveStreamClient.resetLayoutReplayCache()
     liveStreamClient.hierarchyUpdates.collect { update ->
       if (!isActiveDeviceStreamFrame(update.deviceId, activeDeviceId)) return@collect
       // Capture the generation before the async parse so a frame decoded across an invalidation
@@ -952,6 +967,9 @@ fun AutoMobileContent(
   }
   LaunchedEffect(liveStreamClient, isLiveLayoutMode, activeDeviceId) {
     if (!isLiveLayoutMode || liveStreamClient == null) return@LaunchedEffect
+    // See the hierarchy collector: drop the buffered replay before resubscribing so a reopen can't
+    // re-arm control from a stale pre-close screenshot (issue #3347).
+    liveStreamClient.resetLayoutReplayCache()
     liveStreamClient.screenshotUpdates.collect { update ->
       if (!isActiveDeviceStreamFrame(update.deviceId, activeDeviceId)) return@collect
       // Capture the generation before the async decode so a screenshot decoded across an
@@ -1611,8 +1629,18 @@ fun AutoMobileContent(
           // catches up, the gate must follow the live frame's dims — else a tap maps through stale
           // dims. The live frame is device-scoped (rememberLiveVideoFrame keyed on
           // source+deviceId).
+          val hasLiveFrame = liveVideoFrame != null
           val displayedFrameWidth = liveVideoFrame?.width ?: layoutInspectorState.screenWidth
           val displayedFrameHeight = liveVideoFrame?.height ?: layoutInspectorState.screenHeight
+          // The SAME effective device bounds DeviceScreenView maps through: hierarchy-root bounds
+          // when present, else the observation stream's screen size (the common Android path where
+          // the accessibility root is (0,0,0,0)). Feeding these — not zero — keeps the geometry
+          // gate
+          // from no-op'ing on that path.
+          val effectiveDeviceWidth =
+            hierarchyRootBounds?.width?.takeIf { it > 0 } ?: layoutInspectorState.screenWidth
+          val effectiveDeviceHeight =
+            hierarchyRootBounds?.height?.takeIf { it > 0 } ?: layoutInspectorState.screenHeight
           val deviceControlActive =
             isDeviceControlActive(
               enableDeviceControl = enableDeviceControl,
@@ -1627,8 +1655,11 @@ fun AutoMobileContent(
                 isRenderedGeometryConsistent(
                   screenshotWidth = displayedFrameWidth,
                   screenshotHeight = displayedFrameHeight,
-                  hierarchyRootWidth = hierarchyRootBounds?.width ?: 0,
-                  hierarchyRootHeight = hierarchyRootBounds?.height ?: 0,
+                  hierarchyRootWidth = effectiveDeviceWidth,
+                  hierarchyRootHeight = effectiveDeviceHeight,
+                  // A live video frame is display-oriented, so an orientation mismatch is a stale
+                  // frame (strict); a polled screenshot may be native-oriented (rotation-tolerant).
+                  allowRotation = !hasLiveFrame,
                 ),
             )
           Box(mod.background(colors.text.normal.copy(alpha = 0.02f))) {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -739,6 +739,18 @@ fun AutoMobileContent(
       }
     }
 
+  // One coherent reset of the tap-dispatch context (issue #3347), run at every point that
+  // invalidates the rendered frame identity (device change, transport/mode change, stream
+  // disconnect, Live Layout open/close). Drops the queued tap backlog (closing captured clients so
+  // a
+  // stalled/aged tap can't fire in the new context), advances the error-ordering gate so a late
+  // failure from a pre-reset tap is no longer "current", and clears any shown banner.
+  val resetControlTapContext: () -> Unit = {
+    deviceControlTapDispatcher.reset()
+    deviceControlTapGate.nextToken()
+    deviceControlTapError = null
+  }
+
   val takeScreenshot: () -> Unit =
     remember(clientProvider, screenshotScope) {
       takeScreenshot@{
@@ -1186,6 +1198,7 @@ fun AutoMobileContent(
           object : AutoMobileDeviceStreamEventSink {
             override fun disconnectLayout() {
               layoutInspectorState.disconnect()
+              resetControlTapContext()
             }
 
             override fun clearPerformanceMetrics() {
@@ -1214,6 +1227,7 @@ fun AutoMobileContent(
         // or debounced hierarchy job still in flight when the stream dropped.
         layoutInspectorState.updateConnectionStatus(ConnectionStatus.Disconnected)
         layoutInspectorState.invalidateRenderedDeviceIdentity()
+        resetControlTapContext()
       }
     }
   }
@@ -1224,10 +1238,15 @@ fun AutoMobileContent(
   // reopening for the same device would otherwise enable Control against a mirror frozen for the
   // whole closed period. Keying on isLiveLayoutMode makes reopen start invalidated; fresh
   // screenshot+hierarchy frames (a newer generation) re-arm it, and the generation guard drops the
-  // replayed stale frame.
-  LaunchedEffect(activeDeviceId, isLiveLayoutMode) {
+  // replayed stale frame. resetControlTapContext() also drops any queued tap backlog and clears a
+  // stale error banner so nothing from the previous context leaks into the new one. Keyed on the
+  // data-source mode and connected process too, so a transport/mode change resets the tap context
+  // as
+  // well.
+  LaunchedEffect(activeDeviceId, isLiveLayoutMode, dataSourceMode, connectedMcpProcess) {
     layoutInspectorState.updateConnectionStatus(ConnectionStatus.Disconnected)
     layoutInspectorState.invalidateRenderedDeviceIdentity()
+    resetControlTapContext()
   }
 
   // Populate telemetry event cache for global search (mirroring TelemetryDashboard's collection)
@@ -1584,6 +1603,16 @@ fun AutoMobileContent(
           // after
           // a device switch can't actuate the wrong device). Otherwise we stay in inspector mode.
           val hierarchyRootBounds = layoutInspectorState.hierarchy?.bounds
+          // Gate geometry against the frame actually displayed and used for mapping:
+          // DeviceScreenView
+          // prefers the live WebRTC frame over the observation screenshot and fits taps to THAT
+          // bitmap's dimensions, so when the video rotates/resizes before the observation
+          // screenshot
+          // catches up, the gate must follow the live frame's dims — else a tap maps through stale
+          // dims. The live frame is device-scoped (rememberLiveVideoFrame keyed on
+          // source+deviceId).
+          val displayedFrameWidth = liveVideoFrame?.width ?: layoutInspectorState.screenWidth
+          val displayedFrameHeight = liveVideoFrame?.height ?: layoutInspectorState.screenHeight
           val deviceControlActive =
             isDeviceControlActive(
               enableDeviceControl = enableDeviceControl,
@@ -1596,8 +1625,8 @@ fun AutoMobileContent(
                 layoutInspectorState.connectionStatus == ConnectionStatus.Connected,
               isRenderedGeometryConsistent =
                 isRenderedGeometryConsistent(
-                  screenshotWidth = layoutInspectorState.screenWidth,
-                  screenshotHeight = layoutInspectorState.screenHeight,
+                  screenshotWidth = displayedFrameWidth,
+                  screenshotHeight = displayedFrameHeight,
                   hierarchyRootWidth = hierarchyRootBounds?.width ?: 0,
                   hierarchyRootHeight = hierarchyRootBounds?.height ?: 0,
                 ),
@@ -1647,15 +1676,22 @@ fun AutoMobileContent(
                       val tapClient = clientProvider?.invoke()
                       val tapToken = deviceControlTapGate.nextToken()
                       deviceControlTapError = null
-                      deviceControlTapDispatcher.enqueue(
-                        DeviceControlTapCommand(
-                          point = point,
-                          client = tapClient,
-                          platform = platformString,
-                          deviceId = tapDeviceId,
-                          token = tapToken,
+                      val accepted =
+                        deviceControlTapDispatcher.enqueue(
+                          DeviceControlTapCommand(
+                            point = point,
+                            client = tapClient,
+                            platform = platformString,
+                            deviceId = tapDeviceId,
+                            token = tapToken,
+                          )
                         )
-                      )
+                      if (!accepted) {
+                        // Bounded queue full: a stalled/slow daemon is holding up the consumer. The
+                        // rejected client was already closed by enqueue; surface an actionable
+                        // overload error (this runs on the UI thread, in click order).
+                        deviceControlTapError = "Tap dropped — device busy"
+                      }
                     }
                   }
                 } else {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -63,6 +63,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.jasonpearson.automobile.desktop.core.components.Tooltip
 import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
+import dev.jasonpearson.automobile.desktop.core.control.ControlTapErrorGate
 import dev.jasonpearson.automobile.desktop.core.control.DeviceControlTapForwarder
 import dev.jasonpearson.automobile.desktop.core.daemon.AppearanceClient
 import dev.jasonpearson.automobile.desktop.core.daemon.AppearanceSocketClient
@@ -113,6 +114,7 @@ import dev.jasonpearson.automobile.desktop.core.mcp.McpResourceClientFactory
 import dev.jasonpearson.automobile.desktop.core.mcp.RealMcpProcessDetector
 import dev.jasonpearson.automobile.desktop.core.mcp.ResourceReadResult
 import dev.jasonpearson.automobile.desktop.core.mcp.SystemImage
+import dev.jasonpearson.automobile.desktop.core.mcp.supportsDaemonInput
 import dev.jasonpearson.automobile.desktop.core.navigation.NavigationMockData
 import dev.jasonpearson.automobile.desktop.core.navigation.NavigationScreenshotLoader
 import dev.jasonpearson.automobile.desktop.core.platform.NoOpNotificationHandler
@@ -378,6 +380,10 @@ fun AutoMobileContent(
   // Last device-control tap error (issue #3347). Set from the daemon's actionable error when a
   // control-mode tap fails so the live layout view can surface it; cleared on the next tap attempt.
   var deviceControlTapError by remember { mutableStateOf<String?>(null) }
+  val deviceControlTapForwarder = remember { DeviceControlTapForwarder() }
+  // Orders overlapping taps so only the latest may publish deviceControlTapError; a stale failure
+  // from a superseded tap is ignored (see ControlTapErrorGate).
+  val deviceControlTapGate = remember { ControlTapErrorGate() }
 
   // Command palette & global search state (delegated to MenuBarActions)
   var showCommandPalette by actions::showCommandPalette
@@ -1407,7 +1413,14 @@ fun AutoMobileContent(
       vimModeEnabled = vimModeEnabled,
       centerContent = { mod ->
         if (isLiveLayoutMode) {
-          // Live layout mode: center shows device screenshot with element overlays
+          // Live layout mode: center shows device screenshot with element overlays.
+          // Device control (issue #3347) is only offered when the app opted in AND the connected
+          // transport can actually carry daemon input (Unix socket). On an input-incapable
+          // transport
+          // (HTTP/STDIO) every tap would fail, so staying in inspector mode (element selection) is
+          // strictly better than a control mode whose clicks always error.
+          val deviceControlActive =
+            enableDeviceControl && connectedMcpProcess?.connectionType?.supportsDaemonInput == true
           Box(mod.background(colors.text.normal.copy(alpha = 0.02f))) {
             DeviceScreenView(
               screenshotData = layoutInspectorState.screenshotData,
@@ -1427,25 +1440,40 @@ fun AutoMobileContent(
               elementMap = layoutInspectorState.currentElementMap.takeIf { it.isNotEmpty() },
               modifier = Modifier.fillMaxSize(),
               // Device control (issue #3347): the reference desktop app opts in via
-              // enableDeviceControl; the IDE plugin leaves it false and stays inspector-only.
+              // enableDeviceControl; the IDE plugin leaves it false and stays inspector-only. Also
+              // requires an input-capable transport (see deviceControlActive above).
               controlMode =
-                if (enableDeviceControl) DeviceScreenControlMode.Control
+                if (deviceControlActive) DeviceScreenControlMode.Control
                 else DeviceScreenControlMode.Inspector,
               // The view only maps a click to a device coordinate; forwarding it to the daemon
               // input/tap helper is our job. Runs off the UI thread and never crashes on failure —
               // the daemon's actionable error surfaces in deviceControlTapError instead.
               onControlTap =
-                if (enableDeviceControl) {
+                if (deviceControlActive) {
                   { point: DevicePoint ->
+                    // Snapshot the whole tap target atomically on the UI thread: the active device
+                    // can change before the IO coroutine runs, and resolving client/platform/device
+                    // late would send this coordinate to the wrong device.
+                    val tapClient = clientProvider?.invoke()
+                    val tapPlatform = platformString
+                    val tapDeviceId = activeDeviceId
+                    val tapToken = deviceControlTapGate.nextToken()
                     deviceControlTapError = null
                     screenshotScope.launch(Dispatchers.IO) {
-                      DeviceControlTapForwarder(
-                          clientProvider = { clientProvider?.invoke() },
-                          platformProvider = { platformString },
-                          deviceIdProvider = { activeDeviceId },
-                          onError = { message -> deviceControlTapError = message },
-                        )
-                        .forward(point)
+                      deviceControlTapForwarder.forward(
+                        point = point,
+                        client = tapClient,
+                        platform = tapPlatform,
+                        deviceId = tapDeviceId,
+                        onError = { message ->
+                          // Only the latest tap may publish an error; a stale failure from a
+                          // superseded tap is ignored so it can't resurrect a banner a newer tap
+                          // already cleared.
+                          if (deviceControlTapGate.isCurrent(tapToken)) {
+                            deviceControlTapError = message
+                          }
+                        },
+                      )
                     }
                   }
                 } else {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -180,6 +180,37 @@ internal fun isActiveDeviceStreamFrame(deviceId: String?, activeDeviceId: String
 }
 
 /**
+ * Whether client device control (issue #3347) may be active for the live layout view. Control taps
+ * actuate a real device, so this gate is deliberately strict: it is true only when
+ * - the app opted in ([enableDeviceControl]),
+ * - we are in Real device mode (not Fake mock data),
+ * - a device is explicitly selected ([activeDeviceId] non-null) — switching Fake→Real clears the
+ *   selection while keeping the socket and last frame, and a null selection must not let the daemon
+ *   pick a device the user never chose,
+ * - the connected transport can carry daemon input ([McpConnectionType.supportsDaemonInput]), and
+ * - the currently rendered frame belongs to that same selected device ([renderedDeviceId] ==
+ *   [activeDeviceId]) — after a device switch the previous frame lingers until a new one arrives,
+ *   and a click on that stale mirror would be mapped against the old device yet sent to the new
+ *   one.
+ *
+ * When any condition fails the view falls back to inspector mode, so the user is never tapping
+ * blind.
+ */
+internal fun isDeviceControlActive(
+  enableDeviceControl: Boolean,
+  isRealDeviceMode: Boolean,
+  activeDeviceId: String?,
+  connectionType: McpConnectionType?,
+  renderedDeviceId: String?,
+): Boolean {
+  return enableDeviceControl &&
+    isRealDeviceMode &&
+    activeDeviceId != null &&
+    connectionType?.supportsDaemonInput == true &&
+    renderedDeviceId == activeDeviceId
+}
+
+/**
  * Connects a live-mirroring source for this composition and exposes only its newest decoded frame.
  *
  * The source already drops old decoded frames; conflation here also prevents Compose conversion
@@ -826,6 +857,11 @@ fun AutoMobileContent(
           fallbackReason = update.screenshotFallbackReason,
           format = update.screenshotFormat,
           captureSource = update.screenshotCaptureSource,
+          // Tag the rendered frame with its source device so device control can require the
+          // on-screen
+          // frame to match the selected device (issue #3347). The frame already passed the
+          // active-device filter above, so this equals activeDeviceId at apply time.
+          deviceId = update.deviceId,
         )
       }
     }
@@ -1414,13 +1450,21 @@ fun AutoMobileContent(
       centerContent = { mod ->
         if (isLiveLayoutMode) {
           // Live layout mode: center shows device screenshot with element overlays.
-          // Device control (issue #3347) is only offered when the app opted in AND the connected
-          // transport can actually carry daemon input (Unix socket). On an input-incapable
-          // transport
-          // (HTTP/STDIO) every tap would fail, so staying in inspector mode (element selection) is
-          // strictly better than a control mode whose clicks always error.
+          // Device control (issue #3347) is strict about which device a tap can actuate: it
+          // requires
+          // the app opt-in, Real mode, an explicitly selected device, an input-capable transport,
+          // and
+          // a rendered frame that belongs to that selected device (so a click on a stale mirror
+          // after
+          // a device switch can't actuate the wrong device). Otherwise we stay in inspector mode.
           val deviceControlActive =
-            enableDeviceControl && connectedMcpProcess?.connectionType?.supportsDaemonInput == true
+            isDeviceControlActive(
+              enableDeviceControl = enableDeviceControl,
+              isRealDeviceMode = dataSourceMode == DataSourceMode.Real,
+              activeDeviceId = activeDeviceId,
+              connectionType = connectedMcpProcess?.connectionType,
+              renderedDeviceId = layoutInspectorState.renderedDeviceId,
+            )
           Box(mod.background(colors.text.normal.copy(alpha = 0.02f))) {
             DeviceScreenView(
               screenshotData = layoutInspectorState.screenshotData,
@@ -1454,26 +1498,31 @@ fun AutoMobileContent(
                     // Snapshot the whole tap target atomically on the UI thread: the active device
                     // can change before the IO coroutine runs, and resolving client/platform/device
                     // late would send this coordinate to the wrong device.
-                    val tapClient = clientProvider?.invoke()
-                    val tapPlatform = platformString
                     val tapDeviceId = activeDeviceId
-                    val tapToken = deviceControlTapGate.nextToken()
-                    deviceControlTapError = null
-                    screenshotScope.launch(Dispatchers.IO) {
-                      deviceControlTapForwarder.forward(
-                        point = point,
-                        client = tapClient,
-                        platform = tapPlatform,
-                        deviceId = tapDeviceId,
-                        onError = { message ->
-                          // Only the latest tap may publish an error; a stale failure from a
-                          // superseded tap is ignored so it can't resurrect a banner a newer tap
-                          // already cleared.
-                          if (deviceControlTapGate.isCurrent(tapToken)) {
-                            deviceControlTapError = message
-                          }
-                        },
-                      )
+                    // Refuse a tap with no explicitly selected device: deviceControlActive already
+                    // requires a non-null selection, this guards the click-vs-recompose race so the
+                    // daemon can never pick a device the user did not choose.
+                    if (tapDeviceId != null) {
+                      val tapClient = clientProvider?.invoke()
+                      val tapPlatform = platformString
+                      val tapToken = deviceControlTapGate.nextToken()
+                      deviceControlTapError = null
+                      screenshotScope.launch(Dispatchers.IO) {
+                        deviceControlTapForwarder.forward(
+                          point = point,
+                          client = tapClient,
+                          platform = tapPlatform,
+                          deviceId = tapDeviceId,
+                          onError = { message ->
+                            // Only the latest tap may publish an error; a stale failure from a
+                            // superseded tap is ignored so it can't resurrect a banner a newer tap
+                            // already cleared.
+                            if (deviceControlTapGate.isCurrent(tapToken)) {
+                              deviceControlTapError = message
+                            }
+                          },
+                        )
+                      }
                     }
                   }
                 } else {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -188,10 +188,12 @@ internal fun isActiveDeviceStreamFrame(deviceId: String?, activeDeviceId: String
  *   selection while keeping the socket and last frame, and a null selection must not let the daemon
  *   pick a device the user never chose,
  * - the connected transport can carry daemon input ([McpConnectionType.supportsDaemonInput]), and
- * - the currently rendered frame belongs to that same selected device ([renderedDeviceId] ==
- *   [activeDeviceId]) — after a device switch the previous frame lingers until a new one arrives,
- *   and a click on that stale mirror would be mapped against the old device yet sent to the new
- *   one.
+ * - BOTH the rendered screenshot ([renderedDeviceId]) AND the hit-tested hierarchy
+ *   ([renderedHierarchyDeviceId]) belong to that same selected device — after a device switch the
+ *   previous frame lingers until a new one arrives, and the screenshot and hierarchy streams update
+ *   independently (the hierarchy is debounced), so a click could otherwise be mapped against one
+ *   device's dimensions yet sent to another. When the observation stream disconnects both ids are
+ *   invalidated, which also drops control on a frozen mirror.
  *
  * When any condition fails the view falls back to inspector mode, so the user is never tapping
  * blind.
@@ -202,12 +204,14 @@ internal fun isDeviceControlActive(
   activeDeviceId: String?,
   connectionType: McpConnectionType?,
   renderedDeviceId: String?,
+  renderedHierarchyDeviceId: String?,
 ): Boolean {
   return enableDeviceControl &&
     isRealDeviceMode &&
     activeDeviceId != null &&
     connectionType?.supportsDaemonInput == true &&
-    renderedDeviceId == activeDeviceId
+    renderedDeviceId == activeDeviceId &&
+    renderedHierarchyDeviceId == activeDeviceId
 }
 
 /**
@@ -833,7 +837,10 @@ fun AutoMobileContent(
           }
         result?.let {
           layoutInspectorState.updateConnectionStatus(ConnectionStatus.Connected)
-          layoutInspectorState.applyHierarchyUpdate(it.first, it.second)
+          // Tag the hierarchy with its source device so the device-control gate can require the
+          // hit-tested hierarchy (not just the screenshot) to match the selected device (issue
+          // #3347). The frame already passed the active-device filter above.
+          layoutInspectorState.applyHierarchyUpdate(it.first, it.second, deviceId = update.deviceId)
         }
       }
     }
@@ -1100,6 +1107,10 @@ fun AutoMobileContent(
     client.connectionState.collect { connectionState ->
       if (connectionState is ConnectionState.Disconnected) {
         clearPerformanceMetrics()
+        // The observation stream is dead, so the on-screen mirror is frozen/stale even if the input
+        // socket still works. Invalidate the rendered frame's device identity so device control
+        // deactivates (issue #3347) — a click on a frozen mirror must not actuate the real device.
+        layoutInspectorState.invalidateRenderedDeviceIdentity()
       }
     }
   }
@@ -1464,6 +1475,7 @@ fun AutoMobileContent(
               activeDeviceId = activeDeviceId,
               connectionType = connectedMcpProcess?.connectionType,
               renderedDeviceId = layoutInspectorState.renderedDeviceId,
+              renderedHierarchyDeviceId = layoutInspectorState.renderedHierarchyDeviceId,
             )
           Box(mod.background(colors.text.normal.copy(alpha = 0.02f))) {
             DeviceScreenView(
@@ -1503,25 +1515,39 @@ fun AutoMobileContent(
                     // requires a non-null selection, this guards the click-vs-recompose race so the
                     // daemon can never pick a device the user did not choose.
                     if (tapDeviceId != null) {
+                      // clientProvider mints a fresh McpDaemonClient (a new Unix socket) per call,
+                      // so
+                      // close it after the tap or every click leaks a socket. Mirrors the
+                      // take-screenshot path's close-in-finally.
                       val tapClient = clientProvider?.invoke()
                       val tapPlatform = platformString
                       val tapToken = deviceControlTapGate.nextToken()
                       deviceControlTapError = null
                       screenshotScope.launch(Dispatchers.IO) {
-                        deviceControlTapForwarder.forward(
-                          point = point,
-                          client = tapClient,
-                          platform = tapPlatform,
-                          deviceId = tapDeviceId,
-                          onError = { message ->
-                            // Only the latest tap may publish an error; a stale failure from a
-                            // superseded tap is ignored so it can't resurrect a banner a newer tap
-                            // already cleared.
+                        var tapError: String? = null
+                        try {
+                          deviceControlTapForwarder.forward(
+                            point = point,
+                            client = tapClient,
+                            platform = tapPlatform,
+                            deviceId = tapDeviceId,
+                            onError = { message -> tapError = message },
+                          )
+                        } finally {
+                          tapClient?.close()
+                        }
+                        // Publish on the UI dispatcher so the token check and the banner write are
+                        // serialized with nextToken()/clear (which also run on the UI thread). Only
+                        // the latest tap may publish; a superseded tap's stale error is dropped and
+                        // can't resurrect a banner a newer tap already cleared.
+                        val message = tapError
+                        if (message != null) {
+                          withContext(Dispatchers.Main) {
                             if (deviceControlTapGate.isCurrent(tapToken)) {
                               deviceControlTapError = message
                             }
-                          },
-                        )
+                          }
+                        }
                       }
                     }
                   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -63,6 +63,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.jasonpearson.automobile.desktop.core.components.Tooltip
 import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
+import dev.jasonpearson.automobile.desktop.core.control.DeviceControlTapForwarder
 import dev.jasonpearson.automobile.desktop.core.daemon.AppearanceClient
 import dev.jasonpearson.automobile.desktop.core.daemon.AppearanceSocketClient
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
@@ -96,6 +97,7 @@ import dev.jasonpearson.automobile.desktop.core.failures.McpFailuresDataSource
 import dev.jasonpearson.automobile.desktop.core.failures.StreamingFailuresDataSource
 import dev.jasonpearson.automobile.desktop.core.failures.TimeAggregation
 import dev.jasonpearson.automobile.desktop.core.layout.ConnectionStatus
+import dev.jasonpearson.automobile.desktop.core.layout.DeviceControlTapErrorBanner
 import dev.jasonpearson.automobile.desktop.core.layout.DeviceScreenView
 import dev.jasonpearson.automobile.desktop.core.layout.ScreenshotMetadataOverlay
 import dev.jasonpearson.automobile.desktop.core.layout.parseHierarchyFromJson
@@ -149,6 +151,8 @@ import dev.jasonpearson.automobile.desktop.core.video.VideoStreamClient
 import dev.jasonpearson.automobile.desktop.core.video.VideoStreamSource
 import dev.jasonpearson.automobile.desktop.core.video.VideoStreamState
 import dev.jasonpearson.automobile.desktop.core.video.toImageBitmap
+import dev.jasonpearson.automobile.desktop.domain.DevicePoint
+import dev.jasonpearson.automobile.desktop.domain.DeviceScreenControlMode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.launch
@@ -336,6 +340,14 @@ fun AutoMobileContent(
   onOpenSource: ((String, Int, String) -> Unit)? = null,
   menuBarActions: MenuBarActions? = null,
   videoStreamSourceFactory: () -> VideoStreamSource = { VideoStreamClient() },
+  /**
+   * Opt-in device control for the live layout view (issue #3347). When true, a click on the
+   * mirrored device screen in live-layout mode is mapped to a device coordinate and forwarded to
+   * the daemon `input/tap` helper instead of selecting an inspector element. Defaults to false so
+   * the IDE plugin (which shares this composable) stays inspector-only with no source change; the
+   * reference desktop app opts in.
+   */
+  enableDeviceControl: Boolean = false,
 ) {
   // When a MenuBarActions bridge is supplied (from Main.kt's MenuBar), delegate
   // pane-visibility and overlay state to it so the native menu items and the
@@ -362,6 +374,10 @@ fun AutoMobileContent(
   var selectedTelemetryEvent by remember { mutableStateOf<TelemetryDisplayEvent?>(null) }
   var isLiveLayoutMode by remember { mutableStateOf(false) }
   val layoutInspectorState = rememberLayoutInspectorState()
+
+  // Last device-control tap error (issue #3347). Set from the daemon's actionable error when a
+  // control-mode tap fails so the live layout view can surface it; cleared on the next tap attempt.
+  var deviceControlTapError by remember { mutableStateOf<String?>(null) }
 
   // Command palette & global search state (delegated to MenuBarActions)
   var showCommandPalette by actions::showCommandPalette
@@ -1410,6 +1426,31 @@ fun AutoMobileContent(
               socketExists = true,
               elementMap = layoutInspectorState.currentElementMap.takeIf { it.isNotEmpty() },
               modifier = Modifier.fillMaxSize(),
+              // Device control (issue #3347): the reference desktop app opts in via
+              // enableDeviceControl; the IDE plugin leaves it false and stays inspector-only.
+              controlMode =
+                if (enableDeviceControl) DeviceScreenControlMode.Control
+                else DeviceScreenControlMode.Inspector,
+              // The view only maps a click to a device coordinate; forwarding it to the daemon
+              // input/tap helper is our job. Runs off the UI thread and never crashes on failure —
+              // the daemon's actionable error surfaces in deviceControlTapError instead.
+              onControlTap =
+                if (enableDeviceControl) {
+                  { point: DevicePoint ->
+                    deviceControlTapError = null
+                    screenshotScope.launch(Dispatchers.IO) {
+                      DeviceControlTapForwarder(
+                          clientProvider = { clientProvider?.invoke() },
+                          platformProvider = { platformString },
+                          deviceIdProvider = { activeDeviceId },
+                          onError = { message -> deviceControlTapError = message },
+                        )
+                        .forward(point)
+                    }
+                  }
+                } else {
+                  null
+                },
             )
 
             ScreenshotMetadataOverlay(
@@ -1419,6 +1460,14 @@ fun AutoMobileContent(
               captureSource = layoutInspectorState.screenshotCaptureSource,
               modifier = Modifier.align(Alignment.TopStart).padding(8.dp),
             )
+
+            deviceControlTapError?.let { message ->
+              DeviceControlTapErrorBanner(
+                message = message,
+                onDismiss = { deviceControlTapError = null },
+                modifier = Modifier.align(Alignment.BottomCenter).padding(16.dp),
+              )
+            }
           }
         } else {
           Column(mod) {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/ControlTapErrorGate.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/ControlTapErrorGate.kt
@@ -1,0 +1,26 @@
+package dev.jasonpearson.automobile.desktop.core.control
+
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Orders overlapping device-control tap attempts so only the latest one may publish (or leave
+ * cleared) the shared error banner (issue #3347).
+ *
+ * Taps are asynchronous: a click snapshots its target and launches an IO coroutine. Two clicks in
+ * quick succession race — the newer tap clears the banner before launching, and without ordering a
+ * late failure from the older tap would resurrect its stale error over the newer attempt. Each tap
+ * claims a monotonically increasing token at click time via [nextToken] (on the UI thread) and,
+ * when it completes on the IO dispatcher, publishes its error only while [isCurrent] still holds.
+ *
+ * Backed by an [AtomicLong] so the UI-thread claim and the IO-thread check are safe without extra
+ * synchronization.
+ */
+class ControlTapErrorGate {
+  private val latest = AtomicLong(0L)
+
+  /** Claim the newest attempt slot and return this attempt's token. Call once per click. */
+  fun nextToken(): Long = latest.incrementAndGet()
+
+  /** True while [token] is still the most recently claimed attempt (nothing newer has started). */
+  fun isCurrent(token: Long): Boolean = token == latest.get()
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/ControlTapErrorGate.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/ControlTapErrorGate.kt
@@ -12,8 +12,13 @@ import java.util.concurrent.atomic.AtomicLong
  * claims a monotonically increasing token at click time via [nextToken] (on the UI thread) and,
  * when it completes on the IO dispatcher, publishes its error only while [isCurrent] still holds.
  *
- * Backed by an [AtomicLong] so the UI-thread claim and the IO-thread check are safe without extra
- * synchronization.
+ * Backed by an [AtomicLong] so the claim and the check are memory-safe across threads; correctness
+ * against the check-then-publish race additionally relies on the caller marshaling both
+ * [nextToken]/clear and the [isCurrent]-then-publish onto the same (UI) dispatcher.
+ *
+ * Its only consumer is `AutoMobileContent`; it is a deliberate testability seam extracted from that
+ * Compose host so the ordering logic is Compose-free and unit-testable per the repo's
+ * fakes/fast-tests rule. Do not inline it.
  */
 class ControlTapErrorGate {
   private val latest = AtomicLong(0L)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlTapDispatcher.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlTapDispatcher.kt
@@ -1,0 +1,60 @@
+package dev.jasonpearson.automobile.desktop.core.control
+
+import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
+import dev.jasonpearson.automobile.desktop.domain.DevicePoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+
+/**
+ * One device-control tap, snapshotted at click time (issue #3347). Carries the tap target — client,
+ * platform, device id — captured atomically on the UI thread, plus the [token] the error-ordering
+ * gate ([ControlTapErrorGate]) issued for this attempt.
+ */
+data class DeviceControlTapCommand(
+  val point: DevicePoint,
+  val client: AutoMobileClient?,
+  val platform: String,
+  val deviceId: String,
+  val token: Long,
+)
+
+/**
+ * Serializes device-control taps so their daemon requests execute in **click order** (issue #3347).
+ *
+ * Each click launched its own `Dispatchers.IO` coroutine before, so two rapid taps could connect
+ * and write their socket requests out of order — the daemon's per-device queue preserves arrival
+ * order, not click order, so a tap sequence could execute reversed. A [Mutex] would not fix this:
+ * with independent launches, which coroutine acquires the lock first is scheduling-dependent, not
+ * click-ordered. A single-consumer FIFO channel does: taps are enqueued synchronously on the UI
+ * thread in click order and drained one at a time, so each [handle] completes before the next
+ * begins.
+ *
+ * Its only consumer is `AutoMobileContent`; it is a deliberate testability seam extracted from that
+ * Compose host so the ordering guarantee is Compose-free and unit-testable. Do not inline it.
+ *
+ * @param scope the coroutine scope the single consumer runs in (cancelled with the composition).
+ * @param handle processes one command to completion — forwards the tap, closes its client, and
+ *   publishes any error. The next command waits until it returns, which is what preserves order.
+ */
+class DeviceControlTapDispatcher(
+  scope: CoroutineScope,
+  private val handle: suspend (DeviceControlTapCommand) -> Unit,
+) {
+  // UNLIMITED so the UI-thread enqueue never suspends or drops a tap; taps are rare relative to the
+  // buffer.
+  private val commands = Channel<DeviceControlTapCommand>(Channel.UNLIMITED)
+
+  init {
+    scope.launch {
+      for (command in commands) {
+        handle(command)
+      }
+    }
+  }
+
+  /** Enqueue a tap in click order. Non-blocking; safe to call from the UI thread. */
+  fun enqueue(command: DeviceControlTapCommand) {
+    commands.trySend(command)
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlTapDispatcher.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlTapDispatcher.kt
@@ -24,14 +24,22 @@ data class DeviceControlTapCommand(
  *
  * Each click launched its own `Dispatchers.IO` coroutine before, so two rapid taps could connect
  * and write their socket requests out of order — the daemon's per-device queue preserves arrival
- * order, not click order, so a tap sequence could execute reversed. A [Mutex] would not fix this:
- * with independent launches, which coroutine acquires the lock first is scheduling-dependent, not
- * click-ordered. A single-consumer FIFO channel does: taps are enqueued synchronously on the UI
- * thread in click order and drained one at a time, so each [handle] completes before the next
- * begins.
+ * order, not click order, so a tap sequence could execute reversed. A
+ * [kotlinx.coroutines.sync.Mutex] would not fix this: with independent launches, which coroutine
+ * acquires the lock first is scheduling-dependent, not click-ordered. A single-consumer FIFO
+ * channel does: taps are enqueued synchronously on the UI thread in click order and drained one at
+ * a time, so each [handle] completes before the next begins.
+ *
+ * The queue is **bounded** ([TAP_QUEUE_CAPACITY]). An unbounded queue would retain every rapid
+ * click and its captured [AutoMobileClient] while a slow/stalled daemon blocks the sole consumer,
+ * and would later fire a large aged backlog. On overflow [enqueue] rejects the newest tap (closing
+ * its captured client) and returns false so the caller can surface an overload error. [reset] drops
+ * the queued backlog (closing each pending client) when the control context changes, so a
+ * stalled/aged tap can't fire after a device/mode/stream change.
  *
  * Its only consumer is `AutoMobileContent`; it is a deliberate testability seam extracted from that
- * Compose host so the ordering guarantee is Compose-free and unit-testable. Do not inline it.
+ * Compose host so the ordering/back-pressure guarantees are Compose-free and unit-testable. Do not
+ * inline it.
  *
  * @param scope the coroutine scope the single consumer runs in (cancelled with the composition).
  * @param handle processes one command to completion — forwards the tap, closes its client, and
@@ -41,9 +49,7 @@ class DeviceControlTapDispatcher(
   scope: CoroutineScope,
   private val handle: suspend (DeviceControlTapCommand) -> Unit,
 ) {
-  // UNLIMITED so the UI-thread enqueue never suspends or drops a tap; taps are rare relative to the
-  // buffer.
-  private val commands = Channel<DeviceControlTapCommand>(Channel.UNLIMITED)
+  private val commands = Channel<DeviceControlTapCommand>(TAP_QUEUE_CAPACITY)
 
   init {
     scope.launch {
@@ -53,8 +59,37 @@ class DeviceControlTapDispatcher(
     }
   }
 
-  /** Enqueue a tap in click order. Non-blocking; safe to call from the UI thread. */
-  fun enqueue(command: DeviceControlTapCommand) {
-    commands.trySend(command)
+  /**
+   * Enqueue a tap in click order. Non-blocking; safe to call from the UI thread. Returns true when
+   * accepted, or false when the bounded queue is full — in which case the newest tap is rejected
+   * and its captured client is closed so it does not leak. The caller should surface an overload
+   * error.
+   */
+  fun enqueue(command: DeviceControlTapCommand): Boolean {
+    if (commands.trySend(command).isSuccess) return true
+    // Full (or closed): reject the newest and close its client rather than block or leak.
+    command.client?.close()
+    return false
+  }
+
+  /**
+   * Drop every queued-but-not-yet-started tap, closing each pending command's captured client, so a
+   * stalled/aged backlog can't actuate a device after the control context changes. The one command
+   * already in flight in [handle] is not interrupted (it targets its own snapshotted device id);
+   * only the pending queue is cleared. Safe to call from the UI thread.
+   */
+  fun reset() {
+    while (true) {
+      val command = commands.tryReceive().getOrNull() ?: break
+      command.client?.close()
+    }
+  }
+
+  companion object {
+    /**
+     * Bounded queue depth. Small: a human cannot out-click a working daemon by more than a few
+     * taps, and a stalled daemon must not let the backlog grow without bound.
+     */
+    const val TAP_QUEUE_CAPACITY: Int = 16
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlTapForwarder.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlTapForwarder.kt
@@ -22,6 +22,11 @@ import dev.jasonpearson.automobile.desktop.domain.DevicePoint
  * thread (e.g. a `Dispatchers.IO` coroutine, matching the existing daemon-action pattern in
  * `McpProcessesPanel`): if the active device changed between the click and the coroutine running,
  * resolving the target late would send the clicked coordinate to the wrong device.
+ *
+ * Its only consumer is `AutoMobileContent`; it is a deliberate testability seam extracted from that
+ * Compose host so this logic is Compose-free and unit-testable per the repo's fakes/fast-tests
+ * rule. Do not inline it — the unit tests below would be impossible to write against the
+ * composable.
  */
 class DeviceControlTapForwarder {
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlTapForwarder.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlTapForwarder.kt
@@ -1,0 +1,80 @@
+package dev.jasonpearson.automobile.desktop.core.control
+
+import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
+import dev.jasonpearson.automobile.desktop.domain.DevicePoint
+
+/**
+ * Forwards a device-control tap (a [DevicePoint] produced by
+ * [dev.jasonpearson.automobile.desktop.domain.DeviceScreenCoordinateMapper] in
+ * [dev.jasonpearson.automobile.desktop.domain.DeviceScreenControlMode.Control]) to the typed daemon
+ * `input/tap` helper. This is the client-side glue for issue #3347: the device-screen view only
+ * maps a click to a coordinate and reports it; wiring that coordinate to the daemon is this class's
+ * job.
+ *
+ * The class is deliberately Compose-free and synchronous so it can be unit tested against
+ * [dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient] (or a real
+ * [dev.jasonpearson.automobile.desktop.core.daemon.McpDaemonClient] over a socket) without
+ * rendering a device or opening a real daemon connection. The caller is responsible for running
+ * [forward] off the UI thread (e.g. a `Dispatchers.IO` coroutine), matching the existing
+ * daemon-action pattern in `McpProcessesPanel`.
+ *
+ * Collaborators are supplied as providers because the connected client, active platform, and active
+ * device id can all change between taps in the reference desktop client; each tap resolves the
+ * latest value.
+ *
+ * @param clientProvider resolves the daemon client for the connected process, or null when nothing
+ *   is connected (no daemon input is sent in that case).
+ * @param platformProvider the daemon platform string for the active device ("android" / "ios").
+ * @param deviceIdProvider the active device id, or null to let the daemon pick its active device.
+ * @param onError invoked with the daemon's actionable error message (or an exception message) when
+ *   a tap fails, so the UI can surface it. Never called for an out-of-bounds point (that is dropped
+ *   silently) or a successful tap.
+ */
+class DeviceControlTapForwarder(
+  private val clientProvider: () -> AutoMobileClient?,
+  private val platformProvider: () -> String,
+  private val deviceIdProvider: () -> String?,
+  private val onError: (String) -> Unit,
+) {
+
+  /**
+   * Send [point] to the daemon as a tap. Out-of-bounds points (see [DevicePoint.inBounds]) are
+   * dropped without contacting the daemon, per the coordinate-mapping contract — a control client
+   * must never tap an off-screen coordinate. A daemon failure or a thrown client exception is
+   * routed to [onError] instead of propagating, so a failed tap can never crash the UI.
+   */
+  fun forward(point: DevicePoint) {
+    // Out of bounds: the mapping never clamps, so a click outside the device screen produces an
+    // off-screen coordinate. Dropping it honors the screen-control-mapping contract (the daemon
+    // must not receive an off-screen tap).
+    if (!point.inBounds) return
+
+    val client = clientProvider() ?: return
+
+    val result =
+      try {
+        client.inputTap(
+          x = point.x.toDouble(),
+          y = point.y.toDouble(),
+          platform = platformProvider(),
+          deviceId = deviceIdProvider(),
+        )
+      } catch (error: Exception) {
+        // A transport/client failure must surface, not crash the UI. Reuse the client's own
+        // message.
+        onError(error.message ?: DEFAULT_TAP_ERROR)
+        return
+      }
+
+    if (!result.success) {
+      // The daemon rejected the tap; surface its actionable error verbatim rather than inventing a
+      // generic message. Error semantics come from the daemon response (InputActionResult.error).
+      onError(result.error ?: DEFAULT_TAP_ERROR)
+    }
+  }
+
+  companion object {
+    /** Fallback shown only when the daemon/client failure carries no message of its own. */
+    const val DEFAULT_TAP_ERROR: String = "Failed to send tap to the device"
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlTapForwarder.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlTapForwarder.kt
@@ -11,53 +11,56 @@ import dev.jasonpearson.automobile.desktop.domain.DevicePoint
  * maps a click to a coordinate and reports it; wiring that coordinate to the daemon is this class's
  * job.
  *
- * The class is deliberately Compose-free and synchronous so it can be unit tested against
+ * The class is deliberately Compose-free and stateless so it can be unit tested against
  * [dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient] (or a real
  * [dev.jasonpearson.automobile.desktop.core.daemon.McpDaemonClient] over a socket) without
- * rendering a device or opening a real daemon connection. The caller is responsible for running
- * [forward] off the UI thread (e.g. a `Dispatchers.IO` coroutine), matching the existing
- * daemon-action pattern in `McpProcessesPanel`.
+ * rendering a device or opening a real daemon connection.
  *
- * Collaborators are supplied as providers because the connected client, active platform, and active
- * device id can all change between taps in the reference desktop client; each tap resolves the
- * latest value.
- *
- * @param clientProvider resolves the daemon client for the connected process, or null when nothing
- *   is connected (no daemon input is sent in that case).
- * @param platformProvider the daemon platform string for the active device ("android" / "ios").
- * @param deviceIdProvider the active device id, or null to let the daemon pick its active device.
- * @param onError invoked with the daemon's actionable error message (or an exception message) when
- *   a tap fails, so the UI can surface it. Never called for an out-of-bounds point (that is dropped
- *   silently) or a successful tap.
+ * The tap target — client, platform, and device id — is passed in per call rather than resolved
+ * lazily, so the caller can **snapshot** all of {coordinate, client, platform, deviceId} atomically
+ * at click time on the UI thread. This matters because [forward] is expected to run off the UI
+ * thread (e.g. a `Dispatchers.IO` coroutine, matching the existing daemon-action pattern in
+ * `McpProcessesPanel`): if the active device changed between the click and the coroutine running,
+ * resolving the target late would send the clicked coordinate to the wrong device.
  */
-class DeviceControlTapForwarder(
-  private val clientProvider: () -> AutoMobileClient?,
-  private val platformProvider: () -> String,
-  private val deviceIdProvider: () -> String?,
-  private val onError: (String) -> Unit,
-) {
+class DeviceControlTapForwarder {
 
   /**
-   * Send [point] to the daemon as a tap. Out-of-bounds points (see [DevicePoint.inBounds]) are
-   * dropped without contacting the daemon, per the coordinate-mapping contract — a control client
-   * must never tap an off-screen coordinate. A daemon failure or a thrown client exception is
-   * routed to [onError] instead of propagating, so a failed tap can never crash the UI.
+   * Send [point] to [client] as a tap at the given [platform] / [deviceId]. Out-of-bounds points
+   * (see [DevicePoint.inBounds]) are dropped without contacting the daemon, per the
+   * coordinate-mapping contract — a control client must never tap an off-screen coordinate. A null
+   * [client] (nothing connected) is likewise dropped silently. A daemon failure or a thrown client
+   * exception is routed to [onError] instead of propagating, so a failed tap can never crash the
+   * UI.
+   *
+   * @param client the daemon client to tap through, snapshotted at click time; null drops the tap.
+   * @param platform the daemon platform string for the tapped device ("android" / "ios").
+   * @param deviceId the target device id, or null to let the daemon pick its active device.
+   * @param onError invoked with the daemon's actionable error message (or an exception message)
+   *   when the tap fails. Never called for an out-of-bounds point or a successful tap.
    */
-  fun forward(point: DevicePoint) {
+  fun forward(
+    point: DevicePoint,
+    client: AutoMobileClient?,
+    platform: String,
+    deviceId: String?,
+    onError: (String) -> Unit,
+  ) {
     // Out of bounds: the mapping never clamps, so a click outside the device screen produces an
     // off-screen coordinate. Dropping it honors the screen-control-mapping contract (the daemon
     // must not receive an off-screen tap).
     if (!point.inBounds) return
 
-    val client = clientProvider() ?: return
+    // Nothing connected: drop silently rather than surfacing a spurious error.
+    if (client == null) return
 
     val result =
       try {
         client.inputTap(
           x = point.x.toDouble(),
           y = point.y.toDouble(),
-          platform = platformProvider(),
-          deviceId = deviceIdProvider(),
+          platform = platform,
+          deviceId = deviceId,
         )
       } catch (error: Exception) {
         // A transport/client failure must surface, not crash the UI. Reuse the client's own

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
@@ -449,6 +449,24 @@ class ObservationStreamClient {
   }
 
   /**
+   * Drop the buffered replay of the layout streams (screenshot + hierarchy) so a subscriber that
+   * (re)subscribes afterward does not immediately receive the last pre-existing frame
+   * (issue #3347).
+   *
+   * `screenshotUpdates`/`hierarchyUpdates` are `replay = 1` SharedFlows, so on Live Layout reopen
+   * the restarted collectors would otherwise replay the stale pre-close frame and re-arm client
+   * device control from it. Clearing the replay right before resubscribing means only genuinely
+   * post-open frames arm control. Active collectors are unaffected — this only clears what a new
+   * subscriber would replay — so it is safe to call at every (re)subscribe. Mirrors the reset
+   * already done on a device-connection-lost event.
+   */
+  @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+  fun resetLayoutReplayCache() {
+    _screenshotUpdates.resetReplayCache()
+    _hierarchyUpdates.resetReplayCache()
+  }
+
+  /**
    * Request the current navigation graph from the server. The response arrives through the existing
    * navigation_update flow.
    *

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorState.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorState.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -20,16 +21,39 @@ import kotlinx.coroutines.launch
  * - Changed element tracking for visual feedback
  *
  * Phase 1: Uses mock data Phase 2: Will add WebSocket connection for live data
+ *
+ * @param debounceContext coroutine context for the hierarchy-update debounce. Defaults to the UI
+ *   dispatcher in production; tests inject a `TestDispatcher` to drive the debounce
+ *   deterministically with virtual time (no real timers).
  */
-class LayoutInspectorState {
+class LayoutInspectorState(debounceContext: CoroutineContext = Dispatchers.Main) {
   /** Debounce window for rapid hierarchy updates from the stream. */
   companion object {
     const val HIERARCHY_DEBOUNCE_MS = 100L
   }
 
   // Coroutine scope for debouncing hierarchy updates
-  private val debounceScope = CoroutineScope(Dispatchers.Main)
+  private val debounceScope = CoroutineScope(debounceContext)
   private var debounceJob: Job? = null
+
+  // Monotonic frame generation (issue #3347). Bumps whenever the rendered frame's device identity
+  // is
+  // invalidated (device change, observation-stream disconnect, explicit invalidation). Any
+  // in-flight
+  // screenshot decode or debounced hierarchy job captures the generation it was queued under and is
+  // DROPPED if the generation advanced by the time it completes — so a late frame from a superseded
+  // context can never restore stale identity/bounds and silently re-enable device control.
+  private var generation: Long = 0L
+
+  /**
+   * The current frame generation; capture before async frame work and pass it back to the setter.
+   */
+  val frameGeneration: Long
+    get() = generation
+
+  private fun advanceGeneration() {
+    generation++
+  }
 
   // Connection state
   var connectionStatus by mutableStateOf(ConnectionStatus.Disconnected)
@@ -182,7 +206,12 @@ class LayoutInspectorState {
     lastScreenshotTimestamp = System.currentTimeMillis()
   }
 
-  /** Update screenshot data. Called when receiving screenshot frames from device. */
+  /**
+   * Update screenshot data. Called when receiving screenshot frames from device. [generation], when
+   * provided, is the [frameGeneration] captured before the (async) decode; the update is dropped if
+   * the generation has advanced since — a late decode from a superseded context must not restore a
+   * stale frame.
+   */
   fun updateScreenshot(
     data: ByteArray,
     width: Int,
@@ -193,7 +222,9 @@ class LayoutInspectorState {
     format: String? = null,
     captureSource: String? = null,
     deviceId: String? = null,
+    generation: Long? = null,
   ) {
+    if (generation != null && generation != this.generation) return
     screenshotData = data
     screenWidth = width
     screenHeight = height
@@ -211,6 +242,10 @@ class LayoutInspectorState {
    * [ParsedHierarchy].
    */
   fun updateHierarchy(newHierarchy: UIElementInfo, newRotation: Int = 0, deviceId: String? = null) {
+    // Cancel any queued debounced update so a stale, later-firing job can't overwrite this
+    // immediate
+    // one (or restore stale hierarchy identity/bounds).
+    debounceJob?.cancel()
     val parsed = buildParsedHierarchy(newHierarchy).copy(rotation = newRotation)
     val changedIds = computeChangedElements(currentElementMap, parsed.elementMap)
     applyHierarchyUpdateImmediate(parsed, changedIds, deviceId)
@@ -228,10 +263,14 @@ class LayoutInspectorState {
     parsed: ParsedHierarchy,
     changedIds: Set<String>,
     deviceId: String? = null,
+    generation: Long? = null,
   ) {
     debounceJob?.cancel()
     debounceJob = debounceScope.launch {
       delay(HIERARCHY_DEBOUNCE_MS)
+      // Drop a debounced job whose generation was superseded while it waited (device change,
+      // invalidation, or disconnect) so it can't restore stale hierarchy identity/bounds.
+      if (generation != null && generation != this@LayoutInspectorState.generation) return@launch
       applyHierarchyUpdateImmediate(parsed, changedIds, deviceId)
     }
   }
@@ -276,8 +315,14 @@ class LayoutInspectorState {
    * ids to match the selection) even though the frame stays visible for inspection. Unlike
    * [disconnect] this keeps the screenshot and hierarchy so the user can still inspect the last
    * frame.
+   *
+   * Cancels any pending debounced hierarchy update and advances the frame generation, so a late
+   * decode or debounced job queued before the invalidation cannot restore the identity we just
+   * cleared.
    */
   fun invalidateRenderedDeviceIdentity() {
+    debounceJob?.cancel()
+    advanceGeneration()
     renderedDeviceId = null
     renderedHierarchyDeviceId = null
   }
@@ -336,6 +381,9 @@ class LayoutInspectorState {
   /** Disconnect from device. Clears all device-specific stale data. */
   fun disconnect() {
     debounceJob?.cancel()
+    // Advance the generation so any in-flight decode/debounced job from before the disconnect is
+    // dropped instead of repopulating stale state.
+    advanceGeneration()
     connectionStatus = ConnectionStatus.Disconnected
     streamingMode = StreamingMode.Paused
     screenshotData = null

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorState.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorState.kt
@@ -64,6 +64,15 @@ class LayoutInspectorState {
   var renderedDeviceId by mutableStateOf<String?>(null)
     private set
 
+  // Device id the currently applied hierarchy came from (issue #3347). Distinct from
+  // [renderedDeviceId] because clicks are mapped using the hierarchy root bounds, and the hierarchy
+  // stream is debounced (~100ms) independently of the screenshot: right after a device switch the
+  // new device's screenshot can arrive while the hierarchy is still the previous device's. Device
+  // control requires BOTH ids to match the selection so a click is never mapped with one device's
+  // dimensions and sent to another. Null until the first hierarchy is applied.
+  var renderedHierarchyDeviceId by mutableStateOf<String?>(null)
+    private set
+
   // Screenshot capture metadata (from the observation stream's screenshot_update message). Absent
   // (null/false) when the daemon predates this metadata or a field wasn't reported.
   var screenshotFallback by mutableStateOf(false)
@@ -201,10 +210,10 @@ class LayoutInspectorState {
    * internally. For the streaming path, prefer [applyHierarchyUpdate] with a pre-computed
    * [ParsedHierarchy].
    */
-  fun updateHierarchy(newHierarchy: UIElementInfo, newRotation: Int = 0) {
+  fun updateHierarchy(newHierarchy: UIElementInfo, newRotation: Int = 0, deviceId: String? = null) {
     val parsed = buildParsedHierarchy(newHierarchy).copy(rotation = newRotation)
     val changedIds = computeChangedElements(currentElementMap, parsed.elementMap)
-    applyHierarchyUpdateImmediate(parsed, changedIds)
+    applyHierarchyUpdateImmediate(parsed, changedIds, deviceId)
   }
 
   /**
@@ -215,22 +224,32 @@ class LayoutInspectorState {
    * prevents excessive recompositions during rapid streaming. Use [applyHierarchyUpdateImmediate]
    * to bypass debouncing.
    */
-  fun applyHierarchyUpdate(parsed: ParsedHierarchy, changedIds: Set<String>) {
+  fun applyHierarchyUpdate(
+    parsed: ParsedHierarchy,
+    changedIds: Set<String>,
+    deviceId: String? = null,
+  ) {
     debounceJob?.cancel()
     debounceJob = debounceScope.launch {
       delay(HIERARCHY_DEBOUNCE_MS)
-      applyHierarchyUpdateImmediate(parsed, changedIds)
+      applyHierarchyUpdateImmediate(parsed, changedIds, deviceId)
     }
   }
 
   /**
    * Apply a hierarchy update immediately without debouncing. Used for programmatic updates (e.g.
-   * initial load, refresh) that should be visible right away.
+   * initial load, refresh) that should be visible right away. [deviceId] tags the hierarchy with
+   * its source device for the device-control gate (issue #3347).
    */
-  fun applyHierarchyUpdateImmediate(parsed: ParsedHierarchy, changedIds: Set<String>) {
+  fun applyHierarchyUpdateImmediate(
+    parsed: ParsedHierarchy,
+    changedIds: Set<String>,
+    deviceId: String? = null,
+  ) {
     changedElementIds = changedIds
     currentParsedHierarchy = parsed
     rotation = parsed.rotation
+    renderedHierarchyDeviceId = deviceId
 
     // Clear selection if the selected element no longer exists — O(1) map check
     val currentSelectedId = selectedElementId
@@ -248,6 +267,19 @@ class LayoutInspectorState {
   /** Clear the changed elements set. Called after flash animation completes. */
   fun clearChangedElements() {
     changedElementIds = emptySet()
+  }
+
+  /**
+   * Invalidate the rendered frame's device identity (issue #3347) without discarding the frame.
+   * Call when the observation stream disconnects but the input socket may still be usable: the
+   * on-screen mirror is now frozen/stale, so device control must deactivate (its gate requires both
+   * ids to match the selection) even though the frame stays visible for inspection. Unlike
+   * [disconnect] this keeps the screenshot and hierarchy so the user can still inspect the last
+   * frame.
+   */
+  fun invalidateRenderedDeviceIdentity() {
+    renderedDeviceId = null
+    renderedHierarchyDeviceId = null
   }
 
   /**
@@ -312,6 +344,7 @@ class LayoutInspectorState {
     screenshotFormat = null
     screenshotCaptureSource = null
     renderedDeviceId = null
+    renderedHierarchyDeviceId = null
     currentParsedHierarchy = null
     rotation = 0
     selectedElementId = null

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorState.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorState.kt
@@ -55,6 +55,15 @@ class LayoutInspectorState {
   var lastScreenshotTimestamp by mutableStateOf(0L)
     private set
 
+  // Device id the currently rendered screenshot came from (issue #3347). Frames are filtered to the
+  // active device before they reach [updateScreenshot], so this records which device the on-screen
+  // frame belongs to. Device control compares it against the selected device: after a device switch
+  // the previous frame lingers until a new one arrives, and a control tap must not actuate the
+  // newly
+  // selected device against a stale mirror of the previous one. Null until the first live frame.
+  var renderedDeviceId by mutableStateOf<String?>(null)
+    private set
+
   // Screenshot capture metadata (from the observation stream's screenshot_update message). Absent
   // (null/false) when the daemon predates this metadata or a field wasn't reported.
   var screenshotFallback by mutableStateOf(false)
@@ -174,6 +183,7 @@ class LayoutInspectorState {
     fallbackReason: String? = null,
     format: String? = null,
     captureSource: String? = null,
+    deviceId: String? = null,
   ) {
     screenshotData = data
     screenWidth = width
@@ -183,6 +193,7 @@ class LayoutInspectorState {
     screenshotFallbackReason = fallbackReason
     screenshotFormat = format
     screenshotCaptureSource = captureSource
+    renderedDeviceId = deviceId
   }
 
   /**
@@ -300,6 +311,7 @@ class LayoutInspectorState {
     screenshotFallbackReason = null
     screenshotFormat = null
     screenshotCaptureSource = null
+    renderedDeviceId = null
     currentParsedHierarchy = null
     rotation = 0
     selectedElementId = null

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/ScreenshotMetadataBadge.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/ScreenshotMetadataBadge.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.desktop.core.layout
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -8,8 +9,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
@@ -37,6 +41,40 @@ fun ScreenshotMetadataOverlay(
     if (hasSourceLabel) {
       ScreenshotSourceLabel(format = format, captureSource = captureSource)
     }
+  }
+}
+
+/**
+ * Non-blocking error banner for a failed device-control tap (issue #3347). Surfaces the daemon's
+ * actionable error message returned by the `input/tap` helper so a failed tap is visible without
+ * crashing the live layout view. Click the banner to dismiss it.
+ */
+@Composable
+fun DeviceControlTapErrorBanner(
+  message: String,
+  onDismiss: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Row(
+    modifier =
+      modifier
+        .background(Color(0xFFD32F2F).copy(alpha = 0.9f), RoundedCornerShape(6.dp))
+        .clickable(onClick = onDismiss)
+        .pointerHoverIcon(PointerIcon.Hand)
+        .padding(horizontal = 12.dp, vertical = 8.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
+    Text(
+      text = "Tap failed: $message",
+      color = Color.White,
+      fontSize = 11.sp,
+    )
+    Text(
+      text = "✕", // ✕ dismiss
+      color = Color.White.copy(alpha = 0.8f),
+      fontSize = 11.sp,
+    )
   }
 }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/McpProcessDetector.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/McpProcessDetector.kt
@@ -22,6 +22,17 @@ enum class McpConnectionType(val label: String, val icon: String) {
   UnixSocket("Unix Socket", "🔌"),
 }
 
+/**
+ * Whether this transport can carry the typed daemon input helpers (`input/tap`, `input/swipe`, …).
+ * Only the Unix-socket daemon ([McpConnectionType.UnixSocket] / `McpDaemonClient`) implements them;
+ * the HTTP and STDIO clients reject them with an "unsupported" error. Device-control (issue #3347)
+ * gates on this so a control-mode click is only offered on a transport that can actually tap — on
+ * an input-incapable transport we stay in inspector mode rather than suppress element selection for
+ * clicks that would always fail.
+ */
+val McpConnectionType.supportsDaemonInput: Boolean
+  get() = this == McpConnectionType.UnixSocket
+
 /** Interface for detecting MCP server processes */
 interface McpProcessDetector {
   fun detectProcesses(): List<McpProcess>

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContentDeviceEventTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContentDeviceEventTest.kt
@@ -104,6 +104,8 @@ class AutoMobileContentDeviceEventTest {
     connectionType: McpConnectionType? = McpConnectionType.UnixSocket,
     renderedDeviceId: String? = "emulator-5554",
     renderedHierarchyDeviceId: String? = "emulator-5554",
+    isObservationStreamConnected: Boolean = true,
+    isRenderedGeometryConsistent: Boolean = true,
   ) =
     isDeviceControlActive(
       enableDeviceControl = enableDeviceControl,
@@ -112,6 +114,8 @@ class AutoMobileContentDeviceEventTest {
       connectionType = connectionType,
       renderedDeviceId = renderedDeviceId,
       renderedHierarchyDeviceId = renderedHierarchyDeviceId,
+      isObservationStreamConnected = isObservationStreamConnected,
+      isRenderedGeometryConsistent = isRenderedGeometryConsistent,
     )
 
   @Test
@@ -173,6 +177,81 @@ class AutoMobileContentDeviceEventTest {
     // On observation-stream disconnect both ids are cleared; the frozen mirror must not be
     // tappable.
     assertFalse(controlActive(renderedDeviceId = null, renderedHierarchyDeviceId = null))
+  }
+
+  @Test
+  fun `device control inactive while the observation stream is not connected`() {
+    // Even if a stale frame's ids still match, a dead stream must keep control off.
+    assertFalse(controlActive(isObservationStreamConnected = false))
+  }
+
+  @Test
+  fun `device control inactive while screenshot and hierarchy geometry disagree`() {
+    // e.g. a same-device rotation where the new screenshot and still-debounced old hierarchy
+    // describe different orientations — a tap would map through the wrong scale.
+    assertFalse(controlActive(isRenderedGeometryConsistent = false))
+  }
+
+  // ---- Rendered geometry consistency (issue #3347, part D) ------------------
+
+  @Test
+  fun `geometry consistent for matching portrait dimensions`() {
+    assertTrue(
+      isRenderedGeometryConsistent(
+        screenshotWidth = 1080,
+        screenshotHeight = 2340,
+        hierarchyRootWidth = 1080,
+        hierarchyRootHeight = 2340,
+      )
+    )
+  }
+
+  @Test
+  fun `geometry consistent up to rotation and scale (iOS points vs pixels)`() {
+    // Screenshot in device pixels, hierarchy in logical points at a 3x scale, rotated 90 degrees.
+    assertTrue(
+      isRenderedGeometryConsistent(
+        screenshotWidth = 2340,
+        screenshotHeight = 1080,
+        hierarchyRootWidth = 360,
+        hierarchyRootHeight = 780,
+      )
+    )
+  }
+
+  @Test
+  fun `geometry inconsistent when aspect ratios disagree beyond rotation`() {
+    // A 16:9 screenshot cannot be a rotation of a 4:3 hierarchy — a genuinely mismatched frame.
+    assertFalse(
+      isRenderedGeometryConsistent(
+        screenshotWidth = 1920,
+        screenshotHeight = 1080,
+        hierarchyRootWidth = 1024,
+        hierarchyRootHeight = 768,
+      )
+    )
+  }
+
+  @Test
+  fun `geometry inconsistent with no screenshot but consistent when hierarchy has no bounds`() {
+    // No frame yet -> inconsistent (control stays off).
+    assertFalse(
+      isRenderedGeometryConsistent(
+        screenshotWidth = 0,
+        screenshotHeight = 0,
+        hierarchyRootWidth = 1080,
+        hierarchyRootHeight = 2340,
+      )
+    )
+    // Hierarchy root without explicit bounds -> mapper falls back to screenshot dims -> consistent.
+    assertTrue(
+      isRenderedGeometryConsistent(
+        screenshotWidth = 1080,
+        screenshotHeight = 2340,
+        hierarchyRootWidth = 0,
+        hierarchyRootHeight = 0,
+      )
+    )
   }
 
   private fun deviceConnectionLostEvent(deviceId: String): DeviceStreamEvent.DeviceConnectionLost =

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContentDeviceEventTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContentDeviceEventTest.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.desktop.core
 
 import dev.jasonpearson.automobile.desktop.core.daemon.DeviceStreamEvent
+import dev.jasonpearson.automobile.desktop.core.mcp.McpConnectionType
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -91,6 +92,100 @@ class AutoMobileContentDeviceEventTest {
   @Test
   fun `stream frame ignores missing active device`() {
     assertFalse(isActiveDeviceStreamFrame(deviceId = "emulator-5554", activeDeviceId = null))
+  }
+
+  // ---- Device-control activation gate (issue #3347) -------------------------
+
+  @Test
+  fun `device control active when opted-in real device selected socket transport and frame matches`() {
+    assertTrue(
+      isDeviceControlActive(
+        enableDeviceControl = true,
+        isRealDeviceMode = true,
+        activeDeviceId = "emulator-5554",
+        connectionType = McpConnectionType.UnixSocket,
+        renderedDeviceId = "emulator-5554",
+      )
+    )
+  }
+
+  @Test
+  fun `device control inactive when not opted in`() {
+    assertFalse(
+      isDeviceControlActive(
+        enableDeviceControl = false,
+        isRealDeviceMode = true,
+        activeDeviceId = "emulator-5554",
+        connectionType = McpConnectionType.UnixSocket,
+        renderedDeviceId = "emulator-5554",
+      )
+    )
+  }
+
+  @Test
+  fun `device control inactive in fake mode`() {
+    assertFalse(
+      isDeviceControlActive(
+        enableDeviceControl = true,
+        isRealDeviceMode = false,
+        activeDeviceId = "emulator-5554",
+        connectionType = McpConnectionType.UnixSocket,
+        renderedDeviceId = "emulator-5554",
+      )
+    )
+  }
+
+  @Test
+  fun `device control inactive with no explicitly selected device (Fake to Real clears selection)`() {
+    // Switching Fake->Real keeps the socket and last frame but clears activeDeviceId; a tap then
+    // would send deviceId=null and the daemon would pick a device the user never chose.
+    assertFalse(
+      isDeviceControlActive(
+        enableDeviceControl = true,
+        isRealDeviceMode = true,
+        activeDeviceId = null,
+        connectionType = McpConnectionType.UnixSocket,
+        renderedDeviceId = null,
+      )
+    )
+  }
+
+  @Test
+  fun `device control inactive on an input-incapable transport`() {
+    assertFalse(
+      isDeviceControlActive(
+        enableDeviceControl = true,
+        isRealDeviceMode = true,
+        activeDeviceId = "emulator-5554",
+        connectionType = McpConnectionType.StreamableHttp,
+        renderedDeviceId = "emulator-5554",
+      )
+    )
+    assertFalse(
+      isDeviceControlActive(
+        enableDeviceControl = true,
+        isRealDeviceMode = true,
+        activeDeviceId = "emulator-5554",
+        connectionType = null,
+        renderedDeviceId = "emulator-5554",
+      )
+    )
+  }
+
+  @Test
+  fun `device control inactive while the rendered frame belongs to a different device`() {
+    // Device just switched to B; the previous frame (A) still renders. A tap would be mapped
+    // against
+    // A's screen yet sent to B — control must be inactive until B's frame arrives.
+    assertFalse(
+      isDeviceControlActive(
+        enableDeviceControl = true,
+        isRealDeviceMode = true,
+        activeDeviceId = "emulator-5556",
+        connectionType = McpConnectionType.UnixSocket,
+        renderedDeviceId = "emulator-5554",
+      )
+    )
   }
 
   private fun deviceConnectionLostEvent(deviceId: String): DeviceStreamEvent.DeviceConnectionLost =

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContentDeviceEventTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContentDeviceEventTest.kt
@@ -96,43 +96,37 @@ class AutoMobileContentDeviceEventTest {
 
   // ---- Device-control activation gate (issue #3347) -------------------------
 
-  @Test
-  fun `device control active when opted-in real device selected socket transport and frame matches`() {
-    assertTrue(
-      isDeviceControlActive(
-        enableDeviceControl = true,
-        isRealDeviceMode = true,
-        activeDeviceId = "emulator-5554",
-        connectionType = McpConnectionType.UnixSocket,
-        renderedDeviceId = "emulator-5554",
-      )
+  /** All conditions satisfied by default; each test flips exactly one to prove it gates. */
+  private fun controlActive(
+    enableDeviceControl: Boolean = true,
+    isRealDeviceMode: Boolean = true,
+    activeDeviceId: String? = "emulator-5554",
+    connectionType: McpConnectionType? = McpConnectionType.UnixSocket,
+    renderedDeviceId: String? = "emulator-5554",
+    renderedHierarchyDeviceId: String? = "emulator-5554",
+  ) =
+    isDeviceControlActive(
+      enableDeviceControl = enableDeviceControl,
+      isRealDeviceMode = isRealDeviceMode,
+      activeDeviceId = activeDeviceId,
+      connectionType = connectionType,
+      renderedDeviceId = renderedDeviceId,
+      renderedHierarchyDeviceId = renderedHierarchyDeviceId,
     )
+
+  @Test
+  fun `device control active when everything matches the selected device`() {
+    assertTrue(controlActive())
   }
 
   @Test
   fun `device control inactive when not opted in`() {
-    assertFalse(
-      isDeviceControlActive(
-        enableDeviceControl = false,
-        isRealDeviceMode = true,
-        activeDeviceId = "emulator-5554",
-        connectionType = McpConnectionType.UnixSocket,
-        renderedDeviceId = "emulator-5554",
-      )
-    )
+    assertFalse(controlActive(enableDeviceControl = false))
   }
 
   @Test
   fun `device control inactive in fake mode`() {
-    assertFalse(
-      isDeviceControlActive(
-        enableDeviceControl = true,
-        isRealDeviceMode = false,
-        activeDeviceId = "emulator-5554",
-        connectionType = McpConnectionType.UnixSocket,
-        renderedDeviceId = "emulator-5554",
-      )
-    )
+    assertFalse(controlActive(isRealDeviceMode = false))
   }
 
   @Test
@@ -140,52 +134,45 @@ class AutoMobileContentDeviceEventTest {
     // Switching Fake->Real keeps the socket and last frame but clears activeDeviceId; a tap then
     // would send deviceId=null and the daemon would pick a device the user never chose.
     assertFalse(
-      isDeviceControlActive(
-        enableDeviceControl = true,
-        isRealDeviceMode = true,
+      controlActive(
         activeDeviceId = null,
-        connectionType = McpConnectionType.UnixSocket,
         renderedDeviceId = null,
+        renderedHierarchyDeviceId = null,
       )
     )
   }
 
   @Test
   fun `device control inactive on an input-incapable transport`() {
+    assertFalse(controlActive(connectionType = McpConnectionType.StreamableHttp))
+    assertFalse(controlActive(connectionType = null))
+  }
+
+  @Test
+  fun `device control inactive while the rendered screenshot belongs to a different device`() {
+    // Device just switched to B; the previous screenshot (A) still renders. A tap would be mapped
+    // against A's screen yet sent to B — control must be inactive until B's frame arrives.
+    assertFalse(controlActive(activeDeviceId = "emulator-5556"))
+  }
+
+  @Test
+  fun `device control inactive while the hierarchy still belongs to a different device`() {
+    // Screenshot for B has arrived but the hierarchy is still A's (streams update independently and
+    // the hierarchy is debounced). A click would be hit-tested against A's bounds yet sent to B.
     assertFalse(
-      isDeviceControlActive(
-        enableDeviceControl = true,
-        isRealDeviceMode = true,
-        activeDeviceId = "emulator-5554",
-        connectionType = McpConnectionType.StreamableHttp,
-        renderedDeviceId = "emulator-5554",
-      )
-    )
-    assertFalse(
-      isDeviceControlActive(
-        enableDeviceControl = true,
-        isRealDeviceMode = true,
-        activeDeviceId = "emulator-5554",
-        connectionType = null,
-        renderedDeviceId = "emulator-5554",
+      controlActive(
+        activeDeviceId = "emulator-5556",
+        renderedDeviceId = "emulator-5556",
+        renderedHierarchyDeviceId = "emulator-5554",
       )
     )
   }
 
   @Test
-  fun `device control inactive while the rendered frame belongs to a different device`() {
-    // Device just switched to B; the previous frame (A) still renders. A tap would be mapped
-    // against
-    // A's screen yet sent to B — control must be inactive until B's frame arrives.
-    assertFalse(
-      isDeviceControlActive(
-        enableDeviceControl = true,
-        isRealDeviceMode = true,
-        activeDeviceId = "emulator-5556",
-        connectionType = McpConnectionType.UnixSocket,
-        renderedDeviceId = "emulator-5554",
-      )
-    )
+  fun `device control inactive once the rendered device identity is invalidated (stream disconnect)`() {
+    // On observation-stream disconnect both ids are cleared; the frozen mirror must not be
+    // tappable.
+    assertFalse(controlActive(renderedDeviceId = null, renderedHierarchyDeviceId = null))
   }
 
   private fun deviceConnectionLostEvent(deviceId: String): DeviceStreamEvent.DeviceConnectionLost =

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContentDeviceEventTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContentDeviceEventTest.kt
@@ -233,6 +233,49 @@ class AutoMobileContentDeviceEventTest {
   }
 
   @Test
+  fun `live-frame geometry is strict about orientation`() {
+    // Zero-bound Android path: the mapper uses the observation stream's screenWidth/screenHeight as
+    // device bounds; the wiring feeds those effective bounds (never zero). A live video frame is
+    // display-oriented, so a video whose orientation disagrees with those bounds is a stale frame
+    // ->
+    // control inactive.
+    assertFalse(
+      isRenderedGeometryConsistent(
+        screenshotWidth = 2340, // live video: landscape
+        screenshotHeight = 1080,
+        hierarchyRootWidth = 1080, // effective device bounds (screenWidth/Height): portrait
+        hierarchyRootHeight = 2340,
+        allowRotation = false,
+      )
+    )
+    // Same orientation -> consistent.
+    assertTrue(
+      isRenderedGeometryConsistent(
+        screenshotWidth = 2340,
+        screenshotHeight = 1080,
+        hierarchyRootWidth = 2340,
+        hierarchyRootHeight = 1080,
+        allowRotation = false,
+      )
+    )
+  }
+
+  @Test
+  fun `screenshot geometry tolerates the mappers rotation (iOS native orientation)`() {
+    // A polled screenshot can arrive portrait-pixels while the device is landscape; the mapper
+    // rotates it. That orientation difference must NOT disable control (allowRotation defaults
+    // true).
+    assertTrue(
+      isRenderedGeometryConsistent(
+        screenshotWidth = 1080, // screenshot: portrait pixels
+        screenshotHeight = 2340,
+        hierarchyRootWidth = 2340, // device bounds: landscape
+        hierarchyRootHeight = 1080,
+      )
+    )
+  }
+
+  @Test
   fun `geometry inconsistent with no screenshot but consistent when hierarchy has no bounds`() {
     // No frame yet -> inconsistent (control stays off).
     assertFalse(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/ControlTapErrorGateTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/ControlTapErrorGateTest.kt
@@ -1,0 +1,63 @@
+package dev.jasonpearson.automobile.desktop.core.control
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.Test
+
+/** Coverage for the overlapping-tap error ordering (issue #3347). */
+class ControlTapErrorGateTest {
+
+  @Test
+  fun `a fresh token is current until a newer one is claimed`() {
+    val gate = ControlTapErrorGate()
+
+    val a = gate.nextToken()
+    assertTrue(gate.isCurrent(a))
+
+    val b = gate.nextToken()
+    assertFalse(gate.isCurrent(a), "an older attempt is no longer current once a newer one starts")
+    assertTrue(gate.isCurrent(b))
+  }
+
+  @Test
+  fun `a stale failure from a superseded tap is suppressed while the latest publishes`() {
+    val gate = ControlTapErrorGate()
+    var published: String? = "previous-banner"
+
+    // Two overlapping clicks: A then B (B supersedes A before either completes).
+    val tokenA = gate.nextToken()
+    val tokenB = gate.nextToken()
+    // Latest tap clears the banner at click time.
+    published = null
+
+    fun completeWithError(token: Long, message: String) {
+      if (gate.isCurrent(token)) published = message
+    }
+
+    // A fails late — it is no longer the latest, so its stale error must not resurrect the banner.
+    completeWithError(tokenA, "A: no active device")
+    assertEquals(null, published)
+
+    // B then fails — it is the latest, so its error is the one the user sees.
+    completeWithError(tokenB, "B: tap out of range")
+    assertEquals("B: tap out of range", published)
+  }
+
+  @Test
+  fun `a late success does not let a stale failure overwrite it`() {
+    val gate = ControlTapErrorGate()
+    var published: String? = null
+
+    val tokenA = gate.nextToken()
+    val tokenB = gate.nextToken()
+
+    fun completeWithError(token: Long, message: String) {
+      if (gate.isCurrent(token)) published = message
+    }
+
+    // B succeeds (success path never touches the banner), then A's late failure is suppressed.
+    completeWithError(tokenA, "A: stale failure")
+    assertEquals(null, published, "B succeeded and is latest; A's stale failure must be ignored")
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlTapDispatcherTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlTapDispatcherTest.kt
@@ -1,7 +1,12 @@
 package dev.jasonpearson.automobile.desktop.core.control
 
+import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
 import dev.jasonpearson.automobile.desktop.domain.DevicePoint
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
@@ -11,14 +16,14 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
-/** Ordering coverage for the serialized control-tap dispatcher (issue #3347). */
+/** Ordering + back-pressure coverage for the serialized control-tap dispatcher (issue #3347). */
 @OptIn(ExperimentalCoroutinesApi::class)
 class DeviceControlTapDispatcherTest {
 
-  private fun command(token: Long) =
+  private fun command(token: Long = 0L, client: AutoMobileClient? = null) =
     DeviceControlTapCommand(
       point = DevicePoint(x = 0, y = 0, inBounds = true),
-      client = null,
+      client = client,
       platform = "android",
       deviceId = "emulator-5554",
       token = token,
@@ -39,7 +44,7 @@ class DeviceControlTapDispatcherTest {
         processed.add(cmd.token)
       }
 
-    (0L until 5L).forEach { dispatcher.enqueue(command(it)) }
+    (0L until 5L).forEach { dispatcher.enqueue(command(token = it)) }
     advanceUntilIdle()
 
     assertEquals(listOf(0L, 1L, 2L, 3L, 4L), processed)
@@ -59,10 +64,58 @@ class DeviceControlTapDispatcherTest {
         inFlight--
       }
 
-    repeat(4) { dispatcher.enqueue(command(it.toLong())) }
+    repeat(4) { dispatcher.enqueue(command(token = it.toLong())) }
     advanceUntilIdle()
 
     assertEquals(1, maxConcurrent, "the consumer must forward taps one at a time")
+    scope.cancel()
+  }
+
+  @Test
+  fun `a full queue rejects the newest tap and closes its client`() = runTest {
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val stall = CompletableDeferred<Unit>() // never completes: the consumer stays on the first tap
+    val dispatcher = DeviceControlTapDispatcher(scope) { _ -> stall.await() }
+
+    // One tap is in flight (stalled), the bounded buffer holds the rest, the remainder overflow.
+    val clients =
+      (0..DeviceControlTapDispatcher.TAP_QUEUE_CAPACITY + 2).map { FakeAutoMobileClient() }
+    val accepted = clients.map { dispatcher.enqueue(command(client = it)) }
+
+    assertTrue(accepted.any { !it }, "taps past the bounded capacity must be rejected")
+    clients.zip(accepted).forEach { (client, ok) ->
+      if (!ok) assertTrue("close" in client.calls, "a rejected tap's client must be closed")
+    }
+    scope.cancel()
+  }
+
+  @Test
+  fun `reset closes every pending tap's client and none of them forward`() = runTest {
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val stall = CompletableDeferred<Unit>()
+    val forwarded = mutableListOf<Long>()
+    val dispatcher =
+      DeviceControlTapDispatcher(scope) { cmd ->
+        if (cmd.token == 0L) stall.await() else forwarded.add(cmd.token)
+      }
+
+    // Tap 0 is in flight (stalled); taps 1..5 sit pending in the queue.
+    val clients = (0L..5L).map { FakeAutoMobileClient() }
+    clients.forEachIndexed { index, client ->
+      dispatcher.enqueue(command(token = index.toLong(), client = client))
+    }
+
+    dispatcher.reset()
+    advanceUntilIdle()
+
+    (1..5).forEach {
+      assertTrue("close" in clients[it].calls, "pending client $it closed by reset")
+    }
+    assertFalse(
+      "close" in clients[0].calls,
+      "the in-flight tap's client is left to its own finally",
+    )
+    assertEquals(emptyList(), forwarded, "no pending tap forwards after reset")
     scope.cancel()
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlTapDispatcherTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlTapDispatcherTest.kt
@@ -1,0 +1,68 @@
+package dev.jasonpearson.automobile.desktop.core.control
+
+import dev.jasonpearson.automobile.desktop.domain.DevicePoint
+import kotlin.test.assertEquals
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/** Ordering coverage for the serialized control-tap dispatcher (issue #3347). */
+@OptIn(ExperimentalCoroutinesApi::class)
+class DeviceControlTapDispatcherTest {
+
+  private fun command(token: Long) =
+    DeviceControlTapCommand(
+      point = DevicePoint(x = 0, y = 0, inBounds = true),
+      client = null,
+      platform = "android",
+      deviceId = "emulator-5554",
+      token = token,
+    )
+
+  @Test
+  fun `taps are processed in click order even when earlier taps take longer`() = runTest {
+    // Unconfined test dispatcher so the single consumer starts eagerly; virtual delays still
+    // advance
+    // via the shared scheduler.
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val processed = mutableListOf<Long>()
+    val dispatcher =
+      DeviceControlTapDispatcher(scope) { cmd ->
+        // Earlier taps (lower token) take LONGER. Independent per-tap coroutines would finish in
+        // reverse order; the single-consumer FIFO queue must keep them in click order.
+        delay(50 - cmd.token * 10)
+        processed.add(cmd.token)
+      }
+
+    (0L until 5L).forEach { dispatcher.enqueue(command(it)) }
+    advanceUntilIdle()
+
+    assertEquals(listOf(0L, 1L, 2L, 3L, 4L), processed)
+    scope.cancel()
+  }
+
+  @Test
+  fun `each tap completes before the next begins`() = runTest {
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    var inFlight = 0
+    var maxConcurrent = 0
+    val dispatcher =
+      DeviceControlTapDispatcher(scope) { _ ->
+        inFlight++
+        maxConcurrent = maxOf(maxConcurrent, inFlight)
+        delay(10)
+        inFlight--
+      }
+
+    repeat(4) { dispatcher.enqueue(command(it.toLong())) }
+    advanceUntilIdle()
+
+    assertEquals(1, maxConcurrent, "the consumer must forward taps one at a time")
+    scope.cancel()
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlTapForwarderTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlTapForwarderTest.kt
@@ -32,25 +32,26 @@ import org.junit.Test
  */
 class DeviceControlTapForwarderTest {
 
-  private fun forwarder(
+  private val forwarder = DeviceControlTapForwarder()
+
+  private fun forward(
+    point: DevicePoint,
     client: AutoMobileClient?,
     platform: String = "android",
     deviceId: String? = "emulator-5554",
     onError: (String) -> Unit = { error("unexpected error: $it") },
-  ) =
-    DeviceControlTapForwarder(
-      clientProvider = { client },
-      platformProvider = { platform },
-      deviceIdProvider = { deviceId },
-      onError = onError,
-    )
+  ) = forwarder.forward(point, client, platform, deviceId, onError)
 
   @Test
   fun `in-bounds tap forwards mapped device coordinates to inputTap`() {
     val fake = FakeAutoMobileClient()
 
-    forwarder(fake, platform = "android", deviceId = "emulator-5554")
-      .forward(DevicePoint(x = 540, y = 1100, inBounds = true))
+    forward(
+      DevicePoint(x = 540, y = 1100, inBounds = true),
+      client = fake,
+      platform = "android",
+      deviceId = "emulator-5554",
+    )
 
     // Payload-level assertion on the typed helper: coordinates map verbatim (Int device px ->
     // Double)
@@ -74,8 +75,11 @@ class DeviceControlTapForwarderTest {
     val fake = FakeAutoMobileClient()
     var error: String? = null
 
-    forwarder(fake, onError = { error = it })
-      .forward(DevicePoint(x = -3, y = 4000, inBounds = false))
+    forward(
+      DevicePoint(x = -3, y = 4000, inBounds = false),
+      client = fake,
+      onError = { error = it },
+    )
 
     assertTrue(fake.inputTapCalls.isEmpty(), "off-screen tap must not be sent")
     assertTrue("inputTap" !in fake.calls)
@@ -86,8 +90,7 @@ class DeviceControlTapForwarderTest {
   fun `no connected client drops the tap without error`() {
     var error: String? = null
 
-    forwarder(client = null, onError = { error = it })
-      .forward(DevicePoint(x = 10, y = 20, inBounds = true))
+    forward(DevicePoint(x = 10, y = 20, inBounds = true), client = null, onError = { error = it })
 
     assertNull(error)
   }
@@ -105,8 +108,7 @@ class DeviceControlTapForwarderTest {
       }
     var error: String? = null
 
-    forwarder(fake, onError = { error = it })
-      .forward(DevicePoint(x = 100, y = 200, inBounds = true))
+    forward(DevicePoint(x = 100, y = 200, inBounds = true), client = fake, onError = { error = it })
 
     // The surfaced message is the daemon's own, not an invented generic string.
     assertEquals("No active android device to tap", error)
@@ -126,8 +128,7 @@ class DeviceControlTapForwarderTest {
       }
     var error: String? = null
 
-    forwarder(throwing, onError = { error = it })
-      .forward(DevicePoint(x = 5, y = 6, inBounds = true))
+    forward(DevicePoint(x = 5, y = 6, inBounds = true), client = throwing, onError = { error = it })
 
     assertEquals("daemon socket closed", error)
   }
@@ -140,7 +141,7 @@ class DeviceControlTapForwarderTest {
       }
     var error: String? = null
 
-    forwarder(fake, onError = { error = it }).forward(DevicePoint(x = 1, y = 2, inBounds = true))
+    forward(DevicePoint(x = 1, y = 2, inBounds = true), client = fake, onError = { error = it })
 
     assertEquals(DeviceControlTapForwarder.DEFAULT_TAP_ERROR, error)
   }
@@ -152,13 +153,12 @@ class DeviceControlTapForwarderTest {
           """{ "action": "input/tap", "platform": "android", "deviceId": "emulator-5554", "success": true }"""
       )
       .use { server ->
-        DeviceControlTapForwarder(
-            clientProvider = { McpDaemonClient(socketPathValue = server.socketPath.toString()) },
-            platformProvider = { "android" },
-            deviceIdProvider = { "emulator-5554" },
-            onError = { error("unexpected error: $it") },
-          )
-          .forward(DevicePoint(x = 240, y = 640, inBounds = true))
+        forward(
+          DevicePoint(x = 240, y = 640, inBounds = true),
+          client = McpDaemonClient(socketPathValue = server.socketPath.toString()),
+          platform = "android",
+          deviceId = "emulator-5554",
+        )
 
         val request = server.awaitRequest()
         assertEquals("input/tap", request.method)
@@ -180,7 +180,7 @@ class DeviceControlTapForwarderTest {
   private class TestDaemonSocket(private val resultJson: String) : AutoCloseable {
     private val json = Json { ignoreUnknownKeys = true }
     private val tempDir = Files.createTempDirectory(Path.of("/tmp"), "amk-tap-")
-    val socketPath = tempDir.resolve("daemon.sock")
+    val socketPath: Path = tempDir.resolve("daemon.sock")
     private val serverChannel =
       ServerSocketChannel.open(StandardProtocolFamily.UNIX)
         .bind(UnixDomainSocketAddress.of(socketPath))

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlTapForwarderTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlTapForwarderTest.kt
@@ -2,33 +2,18 @@ package dev.jasonpearson.automobile.desktop.core.control
 
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
 import dev.jasonpearson.automobile.desktop.core.daemon.InputActionResult
-import dev.jasonpearson.automobile.desktop.core.daemon.McpDaemonClient
 import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
 import dev.jasonpearson.automobile.desktop.domain.DevicePoint
-import java.io.BufferedReader
-import java.io.BufferedWriter
-import java.io.InputStreamReader
-import java.io.OutputStreamWriter
-import java.net.StandardProtocolFamily
-import java.net.UnixDomainSocketAddress
-import java.nio.channels.Channels
-import java.nio.channels.ServerSocketChannel
-import java.nio.charset.StandardCharsets
-import java.nio.file.Files
-import java.nio.file.Path
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Test
 
 /**
- * Coverage for the client-side click-to-tap glue (issue #3347). All tests use fakes or a temporary
- * Unix socket — no real device or daemon connection — so they stay fast and deterministic.
+ * Coverage for the client-side click-to-tap glue (issue #3347). All tests use fakes — no real
+ * device or daemon connection — so they stay fast and non-flaky. The wire serialization of the
+ * `input/tap` request is covered separately by `McpDaemonClientInputTest`; here the payload-level
+ * assertion runs against [FakeAutoMobileClient]'s recorded call.
  */
 class DeviceControlTapForwarderTest {
 
@@ -145,95 +130,4 @@ class DeviceControlTapForwarderTest {
 
     assertEquals(DeviceControlTapForwarder.DEFAULT_TAP_ERROR, error)
   }
-
-  @Test
-  fun `forwarded tap serializes to the input tap socket request a third-party client can match`() {
-    TestDaemonSocket(
-        resultJson =
-          """{ "action": "input/tap", "platform": "android", "deviceId": "emulator-5554", "success": true }"""
-      )
-      .use { server ->
-        forward(
-          DevicePoint(x = 240, y = 640, inBounds = true),
-          client = McpDaemonClient(socketPathValue = server.socketPath.toString()),
-          platform = "android",
-          deviceId = "emulator-5554",
-        )
-
-        val request = server.awaitRequest()
-        assertEquals("input/tap", request.method)
-        assertEquals(
-          JsonObject(
-            mapOf(
-              "platform" to JsonPrimitive("android"),
-              "deviceId" to JsonPrimitive("emulator-5554"),
-              "x" to JsonPrimitive(240.0),
-              "y" to JsonPrimitive(640.0),
-            )
-          ),
-          request.params,
-        )
-      }
-  }
-
-  /** Minimal single-request Unix-socket daemon that captures the request and replies once. */
-  private class TestDaemonSocket(private val resultJson: String) : AutoCloseable {
-    private val json = Json { ignoreUnknownKeys = true }
-    private val tempDir = Files.createTempDirectory(Path.of("/tmp"), "amk-tap-")
-    val socketPath: Path = tempDir.resolve("daemon.sock")
-    private val serverChannel =
-      ServerSocketChannel.open(StandardProtocolFamily.UNIX)
-        .bind(UnixDomainSocketAddress.of(socketPath))
-    private var captured: CapturedRequest? = null
-    private var failure: Throwable? = null
-    private val thread = Thread {
-      try {
-        serverChannel.accept().use { channel ->
-          val reader =
-            BufferedReader(
-              InputStreamReader(Channels.newInputStream(channel), StandardCharsets.UTF_8)
-            )
-          val writer =
-            BufferedWriter(
-              OutputStreamWriter(Channels.newOutputStream(channel), StandardCharsets.UTF_8)
-            )
-          val request = json.parseToJsonElement(reader.readLine()).jsonObject
-          captured =
-            CapturedRequest(
-              method = request.getValue("method").jsonPrimitive.content,
-              params = request.getValue("params").jsonObject,
-            )
-          val id = request.getValue("id").jsonPrimitive.content
-          val compact = resultJson.lineSequence().joinToString("") { it.trim() }
-          writer.write(
-            """{ "id": "$id", "type": "mcp_response", "success": true, "result": $compact }"""
-          )
-          writer.newLine()
-          writer.flush()
-        }
-      } catch (throwable: Throwable) {
-        failure = throwable
-      }
-    }
-      .also { it.start() }
-
-    fun awaitRequest(): CapturedRequest {
-      thread.join(REQUEST_TIMEOUT_MILLIS)
-      if (thread.isAlive) throw AssertionError("Forwarder did not send a request before timeout")
-      failure?.let { throw AssertionError("Test daemon socket failed", it) }
-      return captured ?: throw AssertionError("Forwarder did not send a request")
-    }
-
-    override fun close() {
-      serverChannel.close()
-      Files.deleteIfExists(socketPath)
-      Files.deleteIfExists(tempDir)
-    }
-
-    private companion object {
-      const val REQUEST_TIMEOUT_MILLIS = 5_000L
-    }
-  }
-
-  private data class CapturedRequest(val method: String, val params: JsonObject)
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlTapForwarderTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlTapForwarderTest.kt
@@ -1,0 +1,239 @@
+package dev.jasonpearson.automobile.desktop.core.control
+
+import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.daemon.InputActionResult
+import dev.jasonpearson.automobile.desktop.core.daemon.McpDaemonClient
+import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
+import dev.jasonpearson.automobile.desktop.domain.DevicePoint
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.ServerSocketChannel
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Test
+
+/**
+ * Coverage for the client-side click-to-tap glue (issue #3347). All tests use fakes or a temporary
+ * Unix socket — no real device or daemon connection — so they stay fast and deterministic.
+ */
+class DeviceControlTapForwarderTest {
+
+  private fun forwarder(
+    client: AutoMobileClient?,
+    platform: String = "android",
+    deviceId: String? = "emulator-5554",
+    onError: (String) -> Unit = { error("unexpected error: $it") },
+  ) =
+    DeviceControlTapForwarder(
+      clientProvider = { client },
+      platformProvider = { platform },
+      deviceIdProvider = { deviceId },
+      onError = onError,
+    )
+
+  @Test
+  fun `in-bounds tap forwards mapped device coordinates to inputTap`() {
+    val fake = FakeAutoMobileClient()
+
+    forwarder(fake, platform = "android", deviceId = "emulator-5554")
+      .forward(DevicePoint(x = 540, y = 1100, inBounds = true))
+
+    // Payload-level assertion on the typed helper: coordinates map verbatim (Int device px ->
+    // Double)
+    // and the active platform/device id are carried through so a third-party client can match it.
+    assertEquals(
+      listOf(
+        FakeAutoMobileClient.InputTapCall(
+          x = 540.0,
+          y = 1100.0,
+          platform = "android",
+          deviceId = "emulator-5554",
+          duration = null,
+        )
+      ),
+      fake.inputTapCalls,
+    )
+  }
+
+  @Test
+  fun `out-of-bounds tap is dropped and never reaches the daemon`() {
+    val fake = FakeAutoMobileClient()
+    var error: String? = null
+
+    forwarder(fake, onError = { error = it })
+      .forward(DevicePoint(x = -3, y = 4000, inBounds = false))
+
+    assertTrue(fake.inputTapCalls.isEmpty(), "off-screen tap must not be sent")
+    assertTrue("inputTap" !in fake.calls)
+    assertNull(error, "dropping an off-screen tap is silent, not an error")
+  }
+
+  @Test
+  fun `no connected client drops the tap without error`() {
+    var error: String? = null
+
+    forwarder(client = null, onError = { error = it })
+      .forward(DevicePoint(x = 10, y = 20, inBounds = true))
+
+    assertNull(error)
+  }
+
+  @Test
+  fun `daemon failure surfaces the actionable error without crashing`() {
+    val fake =
+      FakeAutoMobileClient().apply {
+        inputTapResult =
+          InputActionResult(
+            action = "input/tap",
+            success = false,
+            error = "No active android device to tap",
+          )
+      }
+    var error: String? = null
+
+    forwarder(fake, onError = { error = it })
+      .forward(DevicePoint(x = 100, y = 200, inBounds = true))
+
+    // The surfaced message is the daemon's own, not an invented generic string.
+    assertEquals("No active android device to tap", error)
+  }
+
+  @Test
+  fun `thrown client exception surfaces its message instead of propagating`() {
+    val throwing =
+      object : AutoMobileClient by FakeAutoMobileClient() {
+        override fun inputTap(
+          x: Double,
+          y: Double,
+          platform: String,
+          deviceId: String?,
+          duration: Int?,
+        ): InputActionResult = throw IllegalStateException("daemon socket closed")
+      }
+    var error: String? = null
+
+    forwarder(throwing, onError = { error = it })
+      .forward(DevicePoint(x = 5, y = 6, inBounds = true))
+
+    assertEquals("daemon socket closed", error)
+  }
+
+  @Test
+  fun `failure with no message falls back to the default error`() {
+    val fake =
+      FakeAutoMobileClient().apply {
+        inputTapResult = InputActionResult(action = "input/tap", success = false, error = null)
+      }
+    var error: String? = null
+
+    forwarder(fake, onError = { error = it }).forward(DevicePoint(x = 1, y = 2, inBounds = true))
+
+    assertEquals(DeviceControlTapForwarder.DEFAULT_TAP_ERROR, error)
+  }
+
+  @Test
+  fun `forwarded tap serializes to the input tap socket request a third-party client can match`() {
+    TestDaemonSocket(
+        resultJson =
+          """{ "action": "input/tap", "platform": "android", "deviceId": "emulator-5554", "success": true }"""
+      )
+      .use { server ->
+        DeviceControlTapForwarder(
+            clientProvider = { McpDaemonClient(socketPathValue = server.socketPath.toString()) },
+            platformProvider = { "android" },
+            deviceIdProvider = { "emulator-5554" },
+            onError = { error("unexpected error: $it") },
+          )
+          .forward(DevicePoint(x = 240, y = 640, inBounds = true))
+
+        val request = server.awaitRequest()
+        assertEquals("input/tap", request.method)
+        assertEquals(
+          JsonObject(
+            mapOf(
+              "platform" to JsonPrimitive("android"),
+              "deviceId" to JsonPrimitive("emulator-5554"),
+              "x" to JsonPrimitive(240.0),
+              "y" to JsonPrimitive(640.0),
+            )
+          ),
+          request.params,
+        )
+      }
+  }
+
+  /** Minimal single-request Unix-socket daemon that captures the request and replies once. */
+  private class TestDaemonSocket(private val resultJson: String) : AutoCloseable {
+    private val json = Json { ignoreUnknownKeys = true }
+    private val tempDir = Files.createTempDirectory(Path.of("/tmp"), "amk-tap-")
+    val socketPath = tempDir.resolve("daemon.sock")
+    private val serverChannel =
+      ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+        .bind(UnixDomainSocketAddress.of(socketPath))
+    private var captured: CapturedRequest? = null
+    private var failure: Throwable? = null
+    private val thread = Thread {
+      try {
+        serverChannel.accept().use { channel ->
+          val reader =
+            BufferedReader(
+              InputStreamReader(Channels.newInputStream(channel), StandardCharsets.UTF_8)
+            )
+          val writer =
+            BufferedWriter(
+              OutputStreamWriter(Channels.newOutputStream(channel), StandardCharsets.UTF_8)
+            )
+          val request = json.parseToJsonElement(reader.readLine()).jsonObject
+          captured =
+            CapturedRequest(
+              method = request.getValue("method").jsonPrimitive.content,
+              params = request.getValue("params").jsonObject,
+            )
+          val id = request.getValue("id").jsonPrimitive.content
+          val compact = resultJson.lineSequence().joinToString("") { it.trim() }
+          writer.write(
+            """{ "id": "$id", "type": "mcp_response", "success": true, "result": $compact }"""
+          )
+          writer.newLine()
+          writer.flush()
+        }
+      } catch (throwable: Throwable) {
+        failure = throwable
+      }
+    }
+      .also { it.start() }
+
+    fun awaitRequest(): CapturedRequest {
+      thread.join(REQUEST_TIMEOUT_MILLIS)
+      if (thread.isAlive) throw AssertionError("Forwarder did not send a request before timeout")
+      failure?.let { throw AssertionError("Test daemon socket failed", it) }
+      return captured ?: throw AssertionError("Forwarder did not send a request")
+    }
+
+    override fun close() {
+      serverChannel.close()
+      Files.deleteIfExists(socketPath)
+      Files.deleteIfExists(tempDir)
+    }
+
+    private companion object {
+      const val REQUEST_TIMEOUT_MILLIS = 5_000L
+    }
+  }
+
+  private data class CapturedRequest(val method: String, val params: JsonObject)
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClientTest.kt
@@ -242,6 +242,49 @@ class ObservationStreamClientTest {
       }
     }
 
+  @Test
+  fun `resetLayoutReplayCache drops the buffered layout frame for new subscribers`() = runTest {
+    // Reproduces Live Layout reopen: a screenshot+hierarchy frame is buffered (replay=1), then the
+    // layout replay is cleared so a resubscribing collector must NOT replay the stale pre-close
+    // frame
+    // and re-arm control from it (issue #3347).
+    val client = ObservationStreamClient()
+
+    client.handleMessage(
+      """
+      {
+        "type": "hierarchy_update",
+        "deviceId": "emulator-5554",
+        "timestamp": 1000,
+        "data": { "packageName": "com.example" }
+      }
+      """
+        .trimIndent()
+    )
+    client.handleMessage(
+      """
+      {
+        "type": "screenshot_update",
+        "deviceId": "emulator-5554",
+        "timestamp": 1001,
+        "screenshotBase64": "aW1hZ2U=",
+        "screenWidth": 100,
+        "screenHeight": 200
+      }
+      """
+        .trimIndent()
+    )
+
+    // Before reset, a new subscriber replays the buffered frame.
+    client.screenshotUpdates.test { assertEquals("emulator-5554", awaitItem().deviceId) }
+
+    client.resetLayoutReplayCache()
+
+    // After reset, a new subscriber gets nothing until a genuinely fresh frame arrives.
+    client.hierarchyUpdates.test { expectNoEvents() }
+    client.screenshotUpdates.test { expectNoEvents() }
+  }
+
   private fun deviceConnectionLostMessage(): String =
     """
     {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceScreenViewControlTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceScreenViewControlTest.kt
@@ -1,0 +1,118 @@
+package dev.jasonpearson.automobile.desktop.core.layout
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.domain.DevicePoint
+import dev.jasonpearson.automobile.desktop.domain.DeviceScreenControlMode
+import dev.jasonpearson.automobile.desktop.domain.ElementBounds
+import dev.jasonpearson.automobile.desktop.domain.UIElementInfo
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import org.junit.Test
+
+/**
+ * View-level routing coverage for issue #3347: a click in [DeviceScreenControlMode.Control] is
+ * reported to `onControlTap` (and never selects an element), while a click in the default
+ * [DeviceScreenControlMode.Inspector] still selects an element and reports no control tap. Neither
+ * path sends daemon input from the view itself — the control tap is only a reported coordinate.
+ * Renders the real view with fakes; no device or daemon.
+ */
+@OptIn(ExperimentalTestApi::class)
+class DeviceScreenViewControlTest {
+
+  private val root =
+    UIElementInfo(
+      id = "root",
+      className = "android.widget.FrameLayout",
+      resourceId = null,
+      text = null,
+      contentDescription = null,
+      bounds = ElementBounds(0, 0, 1080, 2340),
+      isClickable = false,
+      isEnabled = true,
+      isFocused = false,
+      isSelected = false,
+      isScrollable = false,
+      isCheckable = false,
+      isChecked = false,
+      depth = 0,
+      children = emptyList(),
+    )
+
+  @Test
+  fun `control-mode click reports a device tap and does not select`() = runComposeUiTest {
+    val controlTaps = mutableListOf<DevicePoint>()
+    val selections = mutableListOf<String?>()
+
+    setContent {
+      MaterialTheme {
+        DeviceScreenView(
+          screenshotData = null,
+          screenWidth = 1080,
+          screenHeight = 2340,
+          hierarchy = root,
+          selectedElementId = null,
+          hoveredElementId = null,
+          onElementSelected = { selections.add(it) },
+          onElementHovered = {},
+          elementMap = mapOf("root" to root),
+          controlMode = DeviceScreenControlMode.Control,
+          onControlTap = { controlTaps.add(it) },
+        )
+      }
+    }
+
+    onRoot().performTouchInput { click() }
+    waitForIdle()
+
+    assertEquals(1, controlTaps.size, "control click should report exactly one tap")
+    assertTrue(controlTaps.single().inBounds, "a center click maps inside the device screen")
+    // Control mode suppresses selection: the only selection callbacks are the null clears the mode
+    // entry emits, never a selected element id.
+    assertTrue(
+      selections.all { it == null },
+      "control mode must not select an element (got $selections)",
+    )
+  }
+
+  @Test
+  fun `inspector-mode click still selects an element and reports no control tap`() =
+    runComposeUiTest {
+      val controlTaps = mutableListOf<DevicePoint>()
+      val selections = mutableListOf<String?>()
+
+      setContent {
+        MaterialTheme {
+          DeviceScreenView(
+            screenshotData = null,
+            screenWidth = 1080,
+            screenHeight = 2340,
+            hierarchy = root,
+            selectedElementId = null,
+            hoveredElementId = null,
+            onElementSelected = { selections.add(it) },
+            onElementHovered = {},
+            elementMap = mapOf("root" to root),
+            // controlMode defaults to Inspector; onControlTap is wired only to prove it stays
+            // inert.
+            onControlTap = { controlTaps.add(it) },
+          )
+        }
+      }
+
+      onRoot().performTouchInput { click() }
+      waitForIdle()
+
+      assertTrue(controlTaps.isEmpty(), "inspector mode must not report a control tap")
+      assertNotNull(
+        selections.lastOrNull { it != null },
+        "inspector click over the root should select it",
+      )
+      assertEquals("root", selections.last())
+    }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorStateFrameGenerationTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorStateFrameGenerationTest.kt
@@ -1,7 +1,15 @@
 package dev.jasonpearson.automobile.desktop.core.layout
 
+import dev.jasonpearson.automobile.desktop.core.isDeviceControlActive
+import dev.jasonpearson.automobile.desktop.core.isRenderedGeometryConsistent
+import dev.jasonpearson.automobile.desktop.core.mcp.McpConnectionType
+import dev.jasonpearson.automobile.desktop.domain.ConnectionStatus
+import dev.jasonpearson.automobile.desktop.domain.ElementBounds
+import dev.jasonpearson.automobile.desktop.domain.UIElementInfo
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -77,5 +85,80 @@ class LayoutInspectorStateFrameGenerationTest {
     advanceUntilIdle()
 
     assertEquals("emulator-5554", state.renderedHierarchyDeviceId)
+  }
+
+  // A full-screen root so screenshot (1080x2340) and hierarchy geometry agree.
+  private fun rootBounds(deviceWidth: Int = 1080, deviceHeight: Int = 2340) =
+    UIElementInfo(
+      id = "root",
+      className = "android.widget.FrameLayout",
+      resourceId = null,
+      text = null,
+      contentDescription = null,
+      bounds = ElementBounds(0, 0, deviceWidth, deviceHeight),
+      isClickable = false,
+      isEnabled = true,
+      isFocused = false,
+      isSelected = false,
+      isScrollable = false,
+      isCheckable = false,
+      isChecked = false,
+      depth = 0,
+      children = emptyList(),
+    )
+
+  private fun gateFor(state: LayoutInspectorState, device: String) =
+    isDeviceControlActive(
+      enableDeviceControl = true,
+      isRealDeviceMode = true,
+      activeDeviceId = device,
+      connectionType = McpConnectionType.UnixSocket,
+      renderedDeviceId = state.renderedDeviceId,
+      renderedHierarchyDeviceId = state.renderedHierarchyDeviceId,
+      isObservationStreamConnected = state.connectionStatus == ConnectionStatus.Connected,
+      isRenderedGeometryConsistent =
+        isRenderedGeometryConsistent(
+          screenshotWidth = state.screenWidth,
+          screenshotHeight = state.screenHeight,
+          hierarchyRootWidth = state.hierarchy?.bounds?.width ?: 0,
+          hierarchyRootHeight = state.hierarchy?.bounds?.height ?: 0,
+        ),
+    )
+
+  @Test
+  fun `reopening live layout for the same device stays inactive until fresh frames arrive`() {
+    val state = LayoutInspectorState()
+    val device = "emulator-5554"
+
+    // A prior Live Layout session rendered a live frame for this device.
+    state.updateScreenshot(
+      byteArrayOf(1),
+      1080,
+      2340,
+      1L,
+      deviceId = device,
+      generation = state.frameGeneration,
+    )
+    state.updateHierarchy(rootBounds(), deviceId = device)
+    state.updateConnectionStatus(ConnectionStatus.Connected)
+    assertTrue(gateFor(state, device), "control was active in the prior session")
+
+    // Closing then reopening Live Layout runs the lifecycle reset (mark not-live + invalidate).
+    state.updateConnectionStatus(ConnectionStatus.Disconnected)
+    state.invalidateRenderedDeviceIdentity()
+    assertFalse(gateFor(state, device), "reopen must start invalidated, not tap the frozen mirror")
+
+    // Only genuinely fresh screenshot + hierarchy frames re-arm control.
+    state.updateScreenshot(
+      byteArrayOf(2),
+      1080,
+      2340,
+      2L,
+      deviceId = device,
+      generation = state.frameGeneration,
+    )
+    state.updateHierarchy(rootBounds(), deviceId = device)
+    state.updateConnectionStatus(ConnectionStatus.Connected)
+    assertTrue(gateFor(state, device), "fresh frames re-arm control")
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorStateFrameGenerationTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorStateFrameGenerationTest.kt
@@ -1,0 +1,81 @@
+package dev.jasonpearson.automobile.desktop.core.layout
+
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+/**
+ * Coverage for the frame-generation + debounce-cancellation guards that keep device control
+ * (issue #3347) from being re-enabled by a stale/superseded frame. Uses a virtual-time test
+ * dispatcher for the debounce — no real timers or sockets.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class LayoutInspectorStateFrameGenerationTest {
+
+  private fun screenshot(
+    state: LayoutInspectorState,
+    deviceId: String,
+    generation: Long,
+  ) {
+    state.updateScreenshot(
+      data = byteArrayOf(1),
+      width = 1080,
+      height = 2340,
+      timestamp = 1L,
+      deviceId = deviceId,
+      generation = generation,
+    )
+  }
+
+  @Test
+  fun `a screenshot from a superseded generation is dropped`() {
+    val state = LayoutInspectorState()
+    val stale = state.frameGeneration
+
+    state.invalidateRenderedDeviceIdentity() // advances the generation
+
+    screenshot(state, deviceId = "emulator-5554", generation = stale)
+    assertNull(state.renderedDeviceId, "a late decode from before the invalidation must be dropped")
+
+    // A current-generation update still applies.
+    screenshot(state, deviceId = "emulator-5556", generation = state.frameGeneration)
+    assertEquals("emulator-5556", state.renderedDeviceId)
+  }
+
+  @Test
+  fun `invalidation cancels a pending debounced hierarchy so it cannot restore identity`() =
+    runTest {
+      val state = LayoutInspectorState(StandardTestDispatcher(testScheduler))
+      val parsed = buildParsedHierarchy(LayoutInspectorMockData.mockHierarchy)
+
+      state.applyHierarchyUpdate(parsed, emptySet(), deviceId = "emulator-5554")
+      // Supersede it before the debounce fires (device change / stream disconnect).
+      state.invalidateRenderedDeviceIdentity()
+      advanceUntilIdle()
+
+      assertNull(
+        state.renderedHierarchyDeviceId,
+        "the cancelled debounced job must not restore stale hierarchy identity",
+      )
+    }
+
+  @Test
+  fun `a debounced hierarchy applies after the debounce when it is not superseded`() = runTest {
+    val state = LayoutInspectorState(StandardTestDispatcher(testScheduler))
+    val parsed = buildParsedHierarchy(LayoutInspectorMockData.mockHierarchy)
+
+    state.applyHierarchyUpdate(
+      parsed,
+      emptySet(),
+      deviceId = "emulator-5554",
+      generation = state.frameGeneration,
+    )
+    advanceUntilIdle()
+
+    assertEquals("emulator-5554", state.renderedHierarchyDeviceId)
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorStateScreenshotMetadataTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorStateScreenshotMetadataTest.kt
@@ -59,6 +59,24 @@ class LayoutInspectorStateScreenshotMetadataTest {
   }
 
   @Test
+  fun `updateScreenshot records the source device and disconnect clears it`() {
+    val state = LayoutInspectorState()
+    assertNull(state.renderedDeviceId)
+
+    state.updateScreenshot(
+      data = byteArrayOf(1),
+      width = 100,
+      height = 200,
+      timestamp = 1L,
+      deviceId = "emulator-5554",
+    )
+    assertEquals("emulator-5554", state.renderedDeviceId)
+
+    state.disconnect()
+    assertNull(state.renderedDeviceId)
+  }
+
+  @Test
   fun `disconnect clears screenshot metadata`() {
     val state = LayoutInspectorState()
     state.updateScreenshot(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorStateScreenshotMetadataTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorStateScreenshotMetadataTest.kt
@@ -2,6 +2,7 @@ package dev.jasonpearson.automobile.desktop.core.layout
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Test
 
@@ -74,6 +75,44 @@ class LayoutInspectorStateScreenshotMetadataTest {
 
     state.disconnect()
     assertNull(state.renderedDeviceId)
+  }
+
+  @Test
+  fun `updateHierarchy records the source device and disconnect clears it`() {
+    val state = LayoutInspectorState()
+
+    state.updateHierarchy(
+      newHierarchy = LayoutInspectorMockData.mockHierarchy,
+      deviceId = "emulator-5554",
+    )
+    assertEquals("emulator-5554", state.renderedHierarchyDeviceId)
+
+    state.disconnect()
+    assertNull(state.renderedHierarchyDeviceId)
+  }
+
+  @Test
+  fun `invalidateRenderedDeviceIdentity clears both device ids but keeps the frame`() {
+    val state = LayoutInspectorState()
+    state.updateScreenshot(
+      data = byteArrayOf(1),
+      width = 100,
+      height = 200,
+      timestamp = 1L,
+      deviceId = "emulator-5554",
+    )
+    state.updateHierarchy(
+      newHierarchy = LayoutInspectorMockData.mockHierarchy,
+      deviceId = "emulator-5554",
+    )
+
+    state.invalidateRenderedDeviceIdentity()
+
+    assertNull(state.renderedDeviceId)
+    assertNull(state.renderedHierarchyDeviceId)
+    // The frame is retained for inspection.
+    assertNotNull(state.screenshotData)
+    assertNotNull(state.hierarchy)
   }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/McpProcessDetectorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/McpProcessDetectorTest.kt
@@ -1,13 +1,24 @@
 package dev.jasonpearson.automobile.desktop.core.mcp
 
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import org.junit.Test
 
 class McpProcessDetectorTest {
 
   private val timeProvider = FakeTimeProvider(currentTime = 1_700_000_000_000L)
+
+  @Test
+  fun `only the unix-socket transport supports daemon input`() {
+    // Device control (issue #3347) gates on this: the Unix-socket daemon (McpDaemonClient) is the
+    // only transport whose inputTap/inputSwipe reach the device; HTTP and STDIO reject them.
+    assertTrue(McpConnectionType.UnixSocket.supportsDaemonInput)
+    assertFalse(McpConnectionType.StreamableHttp.supportsDaemonInput)
+    assertFalse(McpConnectionType.Stdio.supportsDaemonInput)
+  }
 
   @Test
   fun parseProcessLineExtractsPidAndCommand() {


### PR DESCRIPTION
## Summary

Wires the reference desktop client so that a click on the mirrored device screen in **Control mode** taps the device through the typed daemon `input/tap` helper. This is item 2/6 of milestone 28 (Client Screen Control), parent [#1099](https://github.com/kaeawc/auto-mobile/issues/1099), and builds directly on the coordinate-mapping foundation from [#3346](https://github.com/kaeawc/auto-mobile/pull/3346) plus the typed daemon input helpers from [#3345](https://github.com/kaeawc/auto-mobile/issues/3345).

The device-screen view (from [#3346](https://github.com/kaeawc/auto-mobile/pull/3346)) already maps a click to a `DevicePoint` and reports it via `onControlTap`; this PR supplies the client side that forwards that coordinate to the daemon.

## What changed

- **`DeviceControlTapForwarder`** (new, Compose-free): maps a `DevicePoint` to `AutoMobileClient.inputTap(x, y, platform, deviceId)`. Out-of-bounds points (`DevicePoint.inBounds == false`) are dropped and never sent; daemon failures and thrown client exceptions route to an `onError` callback instead of propagating, so a failed tap can never crash the UI.
- **`AutoMobileContent`**: Control mode is gated behind a new `enableDeviceControl` parameter (default `false`). The desktop app opts in; the IDE plugin — which shares this composable — leaves it off and stays inspector-only **with no source change**. The `onControlTap` callback runs the forwarder off the UI thread (`Dispatchers.IO`), matching the existing `McpProcessesPanel` daemon-action pattern.
- **`DeviceControlTapErrorBanner`** (new): a non-blocking banner surfacing the daemon's own actionable error (`InputActionResult.error`), reusing the established state-var error pattern rather than an invented generic message.

Inspector-mode clicks are unchanged — they still select the deepest element and send no daemon input. Zoom/pan behavior is untouched (the #3346 mode contract is preserved).

## What was tested

`cd android && ./gradlew :desktop-core:test` — **597 tests, 0 failures, 0 errors** (6 pre-existing skips). `:desktop-app:compileKotlin` green. New coverage (all fakes / temp socket, no real daemon or device):

- **`DeviceControlTapForwarderTest`** (7): in-bounds tap forwards mapped device coordinates to `inputTap`; out-of-bounds tap dropped; no-client drop; daemon-failure surfaces the actionable error; thrown exception surfaces its message; empty-message fallback; and a **socket-level payload assertion** of the emitted `input/tap` request params (`platform`, `deviceId`, `x`, `y`) so a third-party client can match it.
- **`DeviceScreenViewControlTest`** (2): a Control-mode click reports exactly one tap and never selects; an Inspector-mode click still selects the element and reports no control tap.

## Scope

- Zero `ide-plugin` changes (verified) — it stays inspector-only via the default `enableDeviceControl = false`.
- Out of scope (unchanged): drag-to-swipe ([#3350](https://github.com/kaeawc/auto-mobile/issues/3350)), keyboard/text forwarding ([#3351](https://github.com/kaeawc/auto-mobile/issues/3351)), touch-feedback animation, and any daemon endpoint changes.

Closes [#3347](https://github.com/kaeawc/auto-mobile/issues/3347)
