### PR TITLE
test(observe): property-based tests for SDK crash/ANR normalizers

### DIFF
--- a/test/features/observe/crash/sdkCrashIngestion.property.test.ts
+++ b/test/features/observe/crash/sdkCrashIngestion.property.test.ts
@@ -1,0 +1,114 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import type { CrashDeviceInfo } from "../../../../src/utils/interfaces/CrashMonitor";
+import {
+  normalizeAnr,
+  normalizeCrash,
+  type SdkAnrPayload,
+  type SdkCrashPayload
+} from "../../../../src/features/observe/crash/sdkCrashIngestion";
+
+// Property-based tests. See test/utils/Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+const str = fc.string({ maxLength: 16 });
+const optStr = fc.option(str, { nil: undefined });
+const deviceInfo: fc.Arbitrary<CrashDeviceInfo> = fc.record({
+  model: str,
+  manufacturer: str,
+  osVersion: str,
+  sdkInt: fc.integer({ min: 1, max: 40 })
+});
+
+const crashPayload: fc.Arbitrary<SdkCrashPayload> = fc.record({
+  timestamp: fc.integer(),
+  exceptionClass: str,
+  message: optStr,
+  stackTrace: str,
+  threadName: str,
+  currentScreen: optStr,
+  packageName: str,
+  appVersion: optStr,
+  deviceInfo
+});
+
+const anrPayload: fc.Arbitrary<SdkAnrPayload> = fc.record({
+  timestamp: fc.integer(),
+  pid: fc.integer(),
+  processName: str,
+  importance: str,
+  trace: optStr,
+  reason: str,
+  packageName: optStr,
+  appVersion: optStr,
+  deviceInfo
+});
+
+describe("normalizeCrash (property-based)", () => {
+  test("stamps the constant java / sdk_websocket discriminators", () => {
+    fc.assert(
+      fc.property(crashPayload, str, (p, deviceId) => {
+        const e = normalizeCrash(p, deviceId);
+        return e.crashType === "java" && e.detectionSource === "sdk_websocket";
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("carries the deviceId argument and maps every payload field to its slot", () => {
+    fc.assert(
+      fc.property(crashPayload, str, (p, deviceId) => {
+        const e = normalizeCrash(p, deviceId);
+        return (
+          e.deviceId === deviceId &&
+          e.packageName === p.packageName &&
+          e.timestamp === p.timestamp &&
+          e.threadName === p.threadName &&
+          e.exceptionClass === p.exceptionClass &&
+          e.exceptionMessage === p.message &&
+          e.stacktrace === p.stackTrace &&
+          e.currentScreen === p.currentScreen &&
+          e.appVersion === p.appVersion &&
+          e.deviceInfo === p.deviceInfo
+        );
+      }),
+      RUN_OPTIONS
+    );
+  });
+});
+
+describe("normalizeAnr (property-based)", () => {
+  test("stamps the constant sdk_websocket discriminator", () => {
+    fc.assert(
+      fc.property(anrPayload, str, (p, deviceId) => normalizeAnr(p, deviceId).detectionSource === "sdk_websocket"),
+      RUN_OPTIONS
+    );
+  });
+
+  test("packageName falls back to processName only when absent (nullish, not falsy)", () => {
+    fc.assert(
+      fc.property(anrPayload, str, (p, deviceId) => normalizeAnr(p, deviceId).packageName === (p.packageName ?? p.processName)),
+      RUN_OPTIONS
+    );
+  });
+
+  test("carries the deviceId argument and maps every payload field to its slot", () => {
+    fc.assert(
+      fc.property(anrPayload, str, (p, deviceId) => {
+        const e = normalizeAnr(p, deviceId);
+        return (
+          e.deviceId === deviceId &&
+          e.timestamp === p.timestamp &&
+          e.processName === p.processName &&
+          e.pid === p.pid &&
+          e.reason === p.reason &&
+          e.stacktrace === p.trace &&
+          e.importance === p.importance &&
+          e.appVersion === p.appVersion &&
+          e.deviceInfo === p.deviceInfo
+        );
+      }),
+      RUN_OPTIONS
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Continues the fast-check property-testing expansion (pattern from [PR #4427](https://github.com/kaeawc/auto-mobile/pull/4427)) with the pure normalizers in `src/features/observe/crash/sdkCrashIngestion.ts` that map SDK-websocket crash/ANR payloads onto the `CrashEvent`/`AnrEvent` wire shapes. Test-only, additive — no production changes, no new dependencies.

Invariants asserted:

- **`normalizeCrash`** — stamps the constant `crashType: "java"` / `detectionSource: "sdk_websocket"` discriminators; carries the `deviceId` **argument** (not any payload field); maps every payload field to its `CrashEvent` slot, including the renames `message → exceptionMessage` and `stackTrace → stacktrace`, and passes `deviceInfo` through by reference.
- **`normalizeAnr`** — stamps the constant `detectionSource: "sdk_websocket"`; **`packageName` falls back to `processName` only when absent** (`??`, nullish — an empty-string `packageName` is deliberately kept, not replaced); carries the `deviceId` argument and maps every payload field (`trace → stacktrace`, etc.).

These guard the field-mapping and the nullish-fallback contract against silent regressions (a rename or a `??`→`||` slip). No defects surfaced.

## Validation

- [x] `bun test test/features/observe/crash/sdkCrashIngestion.property.test.ts` — 5 pass, ~125ms
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run lint` — no new violations
- [x] New tests are pure (no device/network/filesystem/DB); each runs in <100ms

## Follow-ups

- [ ] Unrelated: `main`'s typecheck baseline has drifted (3 baselined errors no longer occur) — worth a standalone `bun run typecheck:update` ratchet.
