### PR TITLE
test(server): property-based tests for network-mock-rule build and tool-result log

### DIFF
--- a/test/server/networkMockRules.property.test.ts
+++ b/test/server/networkMockRules.property.test.ts
@@ -1,0 +1,72 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import { buildNetworkMockRules } from "../../src/server/networkMockRules";
+import type { MockRule, NetworkState } from "../../src/server/NetworkState";
+
+// Property-based tests. See test/utils/Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+const nullableCount = fc.option(fc.integer({ min: 0, max: 1000 }), { nil: null });
+const mockRule: fc.Arbitrary<MockRule> = fc.record({
+  mockId: fc.string({ maxLength: 8 }),
+  host: fc.string({ maxLength: 12 }),
+  path: fc.string({ maxLength: 12 }),
+  method: fc.constantFrom("GET", "POST", "PUT", "DELETE", "PATCH"),
+  limit: nullableCount,
+  // `remaining` is intentionally independent of `limit`, to prove it is IGNORED.
+  remaining: nullableCount,
+  statusCode: fc.integer({ min: 100, max: 599 }),
+  responseHeaders: fc.dictionary(fc.string({ maxLength: 6 }), fc.string({ maxLength: 6 }), { maxKeys: 4 }),
+  responseBody: fc.string({ maxLength: 12 }),
+  contentType: fc.string({ maxLength: 10 })
+});
+
+// buildNetworkMockRules only reads state.getMocks(); a minimal seam keeps it pure.
+const stateFrom = (rules: MockRule[]): NetworkState =>
+  ({ getMocks: () => new Map(rules.map((r, i) => [`k${i}`, r] as const)) }) as unknown as NetworkState;
+
+describe("buildNetworkMockRules (property-based)", () => {
+  test("preserves count and insertion order by mockId", () => {
+    fc.assert(
+      fc.property(fc.array(mockRule, { maxLength: 12 }), rules => {
+        const out = buildNetworkMockRules(stateFrom(rules));
+        return out.length === rules.length && out.every((o, i) => o.mockId === rules[i].mockId);
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("reinitializes remaining from limit, never copying the store's remaining", () => {
+    fc.assert(
+      fc.property(fc.array(mockRule, { maxLength: 12 }), rules => {
+        const out = buildNetworkMockRules(stateFrom(rules));
+        return out.every((o, i) => o.remaining === rules[i].limit);
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("passes every other field through unchanged", () => {
+    fc.assert(
+      fc.property(fc.array(mockRule, { minLength: 1, maxLength: 12 }), rules => {
+        const out = buildNetworkMockRules(stateFrom(rules));
+        return out.every((o, i) => {
+          const r = rules[i];
+          return (
+            o.host === r.host && o.path === r.path && o.method === r.method && o.limit === r.limit &&
+            o.statusCode === r.statusCode && o.responseHeaders === r.responseHeaders &&
+            o.responseBody === r.responseBody && o.contentType === r.contentType
+          );
+        });
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("an empty store yields an empty payload", () => {
+    fc.assert(
+      fc.property(fc.constant(null), () => buildNetworkMockRules(stateFrom([])).length === 0),
+      RUN_OPTIONS
+    );
+  });
+});

--- a/test/server/toolResultLog.property.test.ts
+++ b/test/server/toolResultLog.property.test.ts
@@ -1,0 +1,60 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import { formatToolResultLog } from "../../src/server/toolResultLog";
+
+// Property-based tests. See test/utils/Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+const TIMED_OUT_SUFFIX = "(handler completed after the caller's request already timed out; the result was discarded)";
+
+// Realistic tool-name charset (letters/digits) — avoids a `toolName` that itself
+// contains ", error=", which would confuse the substring-based assertions below.
+const toolName = fc.string({ unit: fc.constantFrom("a", "o", "L", "n", "k", "1", "T", "p"), maxLength: 16 });
+const errorValue = fc.option(fc.oneof(fc.string({ maxLength: 12 }), fc.integer(), fc.constant("")), { nil: undefined });
+const input = fc.record({
+  toolName,
+  success: fc.boolean(),
+  error: errorValue,
+  callerTimedOut: fc.boolean()
+});
+
+describe("formatToolResultLog (property-based)", () => {
+  test("level is warn iff the caller timed out, and always info/warn", () => {
+    fc.assert(
+      fc.property(input, i => {
+        const line = formatToolResultLog(i);
+        return (line.level === "warn") === i.callerTimedOut && (line.level === "info" || line.level === "warn");
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("message always opens with the canonical prefix", () => {
+    fc.assert(
+      fc.property(input, i =>
+        formatToolResultLog(i).message.startsWith(`[ToolRegistry] ${i.toolName} result: success=${i.success}`)
+      ),
+      RUN_OPTIONS
+    );
+  });
+
+  test("an error clause appears exactly when success is false", () => {
+    fc.assert(
+      fc.property(input, i => {
+        const { message } = formatToolResultLog(i);
+        if (i.success === false) {
+          return message.includes(`, error=${i.error || "unknown"}`);
+        }
+        return !message.includes(", error=");
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("the timed-out suffix appears exactly when the caller timed out", () => {
+    fc.assert(
+      fc.property(input, i => formatToolResultLog(i).message.includes(TIMED_OUT_SUFFIX) === i.callerTimedOut),
+      RUN_OPTIONS
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Continues the fast-check property-testing expansion (pattern from [PR #4427](https://github.com/kaeawc/auto-mobile/pull/4427)) with two pure server helpers. Test-only, additive — no production changes, no new dependencies.

Invariants asserted:

- **`buildNetworkMockRules`** (`src/server/networkMockRules.ts`) — preserves count and insertion order by `mockId`; **reinitializes `remaining` from `limit`** and never copies the store's `remaining` (the documented "device must start each connection with fresh counts" contract — the generator makes `remaining` independent of `limit` to prove it's ignored); passes every other field through unchanged (`responseHeaders` by reference); an empty store yields an empty payload. Driven via a minimal `getMocks()` seam so the test stays pure.
- **`formatToolResultLog`** (`src/server/toolResultLog.ts`, [issue #2723](https://github.com/kaeawc/auto-mobile/issues/2723)) — `level` is `warn` **iff** the caller timed out (else `info`); the message always opens with the canonical `[ToolRegistry] <tool> result: success=<bool>` prefix; an `, error=` clause appears **exactly** when `success` is false; the timed-out reconciliation suffix appears **exactly** when the caller timed out.

No defects surfaced.

## Validation

- [x] `bun test test/server/{networkMockRules,toolResultLog}.property.test.ts` — 8 pass, ~170ms
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run lint` — no new violations
- [x] New tests are pure (no device/network/filesystem/DB); each runs in <100ms

## Follow-ups

- [ ] More pure candidates remain (`features/observe/ios/semanticRoles`, `features/observe/shared/rewriteUnknownCommandError`, `server/internalToolCall`, `server/videoRecordingResourceUris`).
- [ ] Unrelated: `main`'s typecheck baseline has drifted (3 baselined errors no longer occur) — worth a standalone `bun run typecheck:update` ratchet.
