### PR TITLE
test: enforce fake timer and contract hygiene

### DIFF
--- a/test/fakes/FakeAdbClient.ts
+++ b/test/fakes/FakeAdbClient.ts
@@ -1,8 +1,15 @@
+import type { AdbExecutor } from "../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
+
+type FakeAdbClientContract = Pick<
+  AdbExecutor,
+  "executeCommand" | "getForegroundApp" | "listUsers"
+>;
+
 /**
  * Fake implementation of AdbClient for testing
  * Captures commands executed without actually running ADB
  */
-export class FakeAdbClient {
+export class FakeAdbClient implements FakeAdbClientContract {
   private commandCalls: Array<{
     command: string;
     timeoutMs?: number;

--- a/test/fakes/FakeDeviceSnapshotConfigRepository.ts
+++ b/test/fakes/FakeDeviceSnapshotConfigRepository.ts
@@ -1,6 +1,7 @@
 import type { DeviceSnapshotConfig } from "../../src/models";
+import type { ConfigRepository } from "../../src/db/keyedJsonConfigRepository";
 
-export class FakeDeviceSnapshotConfigRepository {
+export class FakeDeviceSnapshotConfigRepository implements ConfigRepository<DeviceSnapshotConfig> {
   private config: DeviceSnapshotConfig | null = null;
 
   async getConfig(): Promise<DeviceSnapshotConfig | null> {

--- a/test/fakes/FakeDeviceSnapshotRepository.ts
+++ b/test/fakes/FakeDeviceSnapshotRepository.ts
@@ -1,9 +1,20 @@
 import type {
+  DeviceSnapshotRepository,
   DeviceSnapshotQuery,
   DeviceSnapshotRecord,
 } from "../../src/db/deviceSnapshotRepository";
 
-export class FakeDeviceSnapshotRepository {
+type DeviceSnapshotRepositoryContract = Pick<
+  DeviceSnapshotRepository,
+  | "insertSnapshot"
+  | "updateSnapshot"
+  | "getSnapshot"
+  | "listSnapshots"
+  | "touchSnapshot"
+  | "deleteSnapshot"
+>;
+
+export class FakeDeviceSnapshotRepository implements DeviceSnapshotRepositoryContract {
   private readonly records = new Map<string, DeviceSnapshotRecord>();
 
   async insertSnapshot(record: DeviceSnapshotRecord): Promise<void> {

--- a/test/fakes/FakeDeviceSnapshotStore.ts
+++ b/test/fakes/FakeDeviceSnapshotStore.ts
@@ -1,7 +1,18 @@
 import * as os from "os";
 import * as path from "path";
+import type { DeviceSnapshotStore } from "../../src/utils/DeviceSnapshotStore";
 
-export class FakeDeviceSnapshotStore {
+type DeviceSnapshotStoreContract = Pick<
+  DeviceSnapshotStore,
+  | "getBasePath"
+  | "getSnapshotPath"
+  | "generateSnapshotName"
+  | "snapshotDirectoryExists"
+  | "getSnapshotSizeBytes"
+  | "deleteSnapshotData"
+>;
+
+export class FakeDeviceSnapshotStore implements DeviceSnapshotStoreContract {
   private basePath: string;
   private sizes = new Map<string, number>();
   private existing = new Set<string>();

--- a/test/fakes/FakeHighlightClient.ts
+++ b/test/fakes/FakeHighlightClient.ts
@@ -1,7 +1,10 @@
 import type { HighlightOperationResult, HighlightShape } from "../../src/models";
-import type { HighlightOptions } from "../../src/features/debug/VisualHighlight";
+import type {
+  HighlightOptions,
+  VisualHighlightClient,
+} from "../../src/features/debug/VisualHighlight";
 
-export class FakeHighlightClient {
+export class FakeHighlightClient implements Pick<VisualHighlightClient, "addHighlight"> {
   readonly addCalls: Array<{ id: string; shape: HighlightShape; options: HighlightOptions }> = [];
 
   async addHighlight(

--- a/test/fakes/FakeNetServer.ts
+++ b/test/fakes/FakeNetServer.ts
@@ -1,10 +1,13 @@
 import { EventEmitter } from "events";
+import type { Socket } from "node:net";
+
+type FakeSocketContract = Pick<Socket, "destroyed" | "writable" | "destroy">;
 
 /**
  * Fake Socket for testing socket-based servers without real network connections.
  * Works cross-platform (Windows, macOS, Linux) and doesn't require file system.
  */
-export class FakeSocket extends EventEmitter {
+export class FakeSocket extends EventEmitter implements FakeSocketContract {
   public destroyed = false;
   public writable = true;
   private _writtenData: string[] = [];
@@ -74,12 +77,13 @@ export class FakeSocket extends EventEmitter {
   /**
    * Destroy the socket
    */
-  destroy(): void {
+  destroy(_error?: Error): this {
     if (!this.destroyed) {
       this.destroyed = true;
       this.writable = false;
       this.emit("close");
     }
+    return this;
   }
 
   /**

--- a/test/fakes/FakeSetUIStateDependencies.ts
+++ b/test/fakes/FakeSetUIStateDependencies.ts
@@ -311,7 +311,17 @@ export class FakeObserveScreenForSetUIState implements ObserveScreen {
 /**
  * Fake FieldTypeDetector for testing
  */
-export class FakeFieldTypeDetector {
+type FieldTypeDetectorContract = Pick<
+  FieldTypeDetector,
+  | "detect"
+  | "isChecked"
+  | "getTextValue"
+  | "isIOSElement"
+  | "isPasswordField"
+  | "shouldSkipVerification"
+>;
+
+export class FakeFieldTypeDetector implements FieldTypeDetectorContract {
   private typeOverrides: Map<string, FieldType> = new Map();
   private checkedOverrides: Map<string, boolean> = new Map();
   private textOverrides: Map<string, string> = new Map();

--- a/test/fakes/FakeSimCtlClient.ts
+++ b/test/fakes/FakeSimCtlClient.ts
@@ -1,5 +1,10 @@
 import type { ExecResult } from "../../src/models";
-import type { AppleDevice, AppleDeviceRuntime, AppleDeviceType } from "../../src/utils/ios-cmdline-tools/SimCtlClient";
+import type {
+  AppleDevice,
+  AppleDeviceRuntime,
+  AppleDeviceType,
+  SimCtl,
+} from "../../src/utils/ios-cmdline-tools/SimCtlClient";
 
 const buildExecResult = (stdout: string): ExecResult => ({
   stdout,
@@ -9,7 +14,20 @@ const buildExecResult = (stdout: string): ExecResult => ({
   includes: (value: string) => stdout.includes(value),
 });
 
-export class FakeSimCtlClient {
+type FakeSimCtlClientContract = Pick<
+  SimCtl,
+  | "executeCommand"
+  | "executeCommandArgs"
+  | "getDeviceInfo"
+  | "getDeviceTypes"
+  | "getRuntimes"
+  | "listApps"
+  | "terminateApp"
+  | "openSimulatorApp"
+  | "pushNotification"
+>;
+
+export class FakeSimCtlClient implements FakeSimCtlClientContract {
   private deviceInfo = new Map<string, AppleDevice | null>();
   private runtimes: AppleDeviceRuntime[] = [];
   private installedApps: any[] = [];

--- a/test/fakes/FakeTalkBackTapStrategy.ts
+++ b/test/fakes/FakeTalkBackTapStrategy.ts
@@ -1,14 +1,23 @@
 import type { Element } from "../../src/models/Element";
 import type {
   TalkBackTapResult,
-  TalkBackFallbackAction
+  TalkBackFallbackAction,
+  TalkBackTapStrategy,
 } from "../../src/features/talkback/TalkBackTapStrategy";
 import type { TalkBackNavigationDriver } from "../../src/features/talkback/TalkBackNavigationDriver";
+
+type TalkBackTapStrategyContract = Pick<
+  TalkBackTapStrategy,
+  | "executeTap"
+  | "executeDirectActivation"
+  | "executeCoordinateFallback"
+  | "executeLongPress"
+>;
 
 /**
  * Fake implementation of TalkBackTapStrategy for testing TapOnElement delegation.
  */
-export class FakeTalkBackTapStrategy {
+export class FakeTalkBackTapStrategy implements TalkBackTapStrategyContract {
   tapResult: TalkBackTapResult = { success: true, method: "focus-navigation" };
   fallbackResult: TalkBackTapResult = { success: true, method: "coordinate-fallback" };
   longPressResult: TalkBackTapResult = { success: true, method: "accessibility-action" };

--- a/test/fakes/FakeTimer.test.ts
+++ b/test/fakes/FakeTimer.test.ts
@@ -38,3 +38,36 @@ describe("FakeTimer auto-advance", function() {
     expect(events).toEqual(["first", "second"]);
   });
 });
+
+describe("FakeTimer async manual advancement", function() {
+  test("yields between caught-up async interval callbacks", async function() {
+    const timer = new FakeTimer();
+    const events: string[] = [];
+    let pending = false;
+
+    timer.setInterval(async () => {
+      if (pending) {
+        events.push(`dropped@${timer.now()}`);
+        return;
+      }
+
+      pending = true;
+      events.push(`start@${timer.now()}`);
+      await Promise.resolve();
+      await Promise.resolve();
+      events.push(`end@${timer.now()}`);
+      pending = false;
+    }, 10);
+
+    await timer.advanceTimeAsync(30);
+
+    expect(events).toEqual([
+      "start@10",
+      "end@10",
+      "start@20",
+      "end@20",
+      "start@30",
+      "end@30",
+    ]);
+  });
+});

--- a/test/fakes/FakeTimer.ts
+++ b/test/fakes/FakeTimer.ts
@@ -143,6 +143,30 @@ export class FakeTimer implements Timer {
   }
 
   /**
+   * Advance time like advanceTime(), yielding an event-loop turn after each due
+   * event.
+   *
+   * Use this when callbacks begin asynchronous work that must settle before the
+   * next caught-up interval tick. The synchronous advanceTime() remains useful
+   * for deterministic single-turn tests.
+   */
+  async advanceTimeAsync(ms: number): Promise<void> {
+    const target = this.currentTime + ms;
+
+    for (;;) {
+      const next = this.nextDueEvent(target);
+      if (next === undefined) {
+        break;
+      }
+      this.currentTime = next.dueAt;
+      next.fire();
+      await new Promise<void>(resolve => setImmediate(resolve));
+    }
+
+    this.currentTime = target;
+  }
+
+  /**
    * Find the earliest-due pending sleep/timeout/interval whose due time is at or
    * before `target`, breaking equal-time ties by registration order. Returns a
    * closure that removes-and-fires (sleeps/timeouts) or advances-and-fires

--- a/test/fakes/FakeVideoRecordingConfigRepository.ts
+++ b/test/fakes/FakeVideoRecordingConfigRepository.ts
@@ -1,6 +1,7 @@
 import type { VideoRecordingConfig } from "../../src/models";
+import type { ConfigRepository } from "../../src/db/keyedJsonConfigRepository";
 
-export class FakeVideoRecordingConfigRepository {
+export class FakeVideoRecordingConfigRepository implements ConfigRepository<VideoRecordingConfig> {
   private config: VideoRecordingConfig | null = null;
 
   async getConfig(): Promise<VideoRecordingConfig | null> {

--- a/test/fakes/FakeVideoRecordingRepository.ts
+++ b/test/fakes/FakeVideoRecordingRepository.ts
@@ -1,9 +1,21 @@
 import type {
+  VideoRecordingRepository,
   VideoRecordingQuery,
   VideoRecordingRecord,
 } from "../../src/db/videoRecordingRepository";
 
-export class FakeVideoRecordingRepository {
+type VideoRecordingRepositoryContract = Pick<
+  VideoRecordingRepository,
+  | "insertRecording"
+  | "updateRecording"
+  | "getRecording"
+  | "listRecordings"
+  | "getLatestRecording"
+  | "touchRecording"
+  | "deleteRecording"
+>;
+
+export class FakeVideoRecordingRepository implements VideoRecordingRepositoryContract {
   private readonly records = new Map<string, VideoRecordingRecord>();
 
   async insertRecording(record: VideoRecordingRecord): Promise<void> {

--- a/test/fakes/FakeWebSocket.ts
+++ b/test/fakes/FakeWebSocket.ts
@@ -16,7 +16,7 @@ export enum WebSocketState {
  * Fake WebSocket implementation for testing
  * Allows simulating instant connection failures without waiting for timeout
  */
-export class FakeWebSocket extends EventEmitter {
+export class FakeWebSocket extends EventEmitter implements Pick<WebSocket, "readyState" | "send" | "close"> {
   public readyState: WebSocketState = WebSocketState.CONNECTING;
   private failureMode: "instant" | "timeout" | "none" = "none";
   private connectTimeoutMs: number = 0;

--- a/test/fakes/fakeRealConformance.test.ts
+++ b/test/fakes/fakeRealConformance.test.ts
@@ -1,60 +1,126 @@
 import { describe, expect, test } from "bun:test";
-import { DeviceSnapshotRepository } from "../../src/db/deviceSnapshotRepository";
-import { VideoRecordingRepository } from "../../src/db/videoRecordingRepository";
-import { FakeDeviceSnapshotRepository } from "./FakeDeviceSnapshotRepository";
-import { FakeVideoRecordingRepository } from "./FakeVideoRecordingRepository";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import ts from "typescript";
 
 /**
- * Conformance ratchet for fakes that do NOT carry an `implements` clause (so the
- * compiler cannot catch interface drift). For each pair, every PUBLIC method the
- * real class exposes must also exist on the fake — otherwise a consumer that
- * casts the fake `as any` would silently miss a method the real object grows
- * (issue #4186). A pure method-name check, no `"get" + "Db"` string games: the
- * one private method (`getDb`) is excluded by name.
+ * Every fake must declare its narrowest production contract. The TypeScript
+ * compiler then catches method/signature drift, while this AST check prevents a
+ * new fake from omitting the `implements` clause entirely (issue #4439).
  */
+const FAKES_DIR = path.join(import.meta.dir);
+const EXPECTED_CONTRACT_TYPES: Record<string, string> = {
+  "FakeAdbClient.ts:FakeAdbClient": "AdbExecutor",
+  "FakeDeviceSnapshotConfigRepository.ts:FakeDeviceSnapshotConfigRepository": "ConfigRepository",
+  "FakeDeviceSnapshotRepository.ts:FakeDeviceSnapshotRepository": "DeviceSnapshotRepository",
+  "FakeDeviceSnapshotStore.ts:FakeDeviceSnapshotStore": "DeviceSnapshotStore",
+  "FakeHighlightClient.ts:FakeHighlightClient": "VisualHighlightClient",
+  "FakeNetServer.ts:FakeSocket": "Socket",
+  "FakeSetUIStateDependencies.ts:FakeFieldTypeDetector": "FieldTypeDetector",
+  "FakeSimCtlClient.ts:FakeSimCtlClient": "SimCtl",
+  "FakeTalkBackTapStrategy.ts:FakeTalkBackTapStrategy": "TalkBackTapStrategy",
+  "FakeVideoRecordingConfigRepository.ts:FakeVideoRecordingConfigRepository": "ConfigRepository",
+  "FakeVideoRecordingRepository.ts:FakeVideoRecordingRepository": "VideoRecordingRepository",
+  "FakeWebSocket.ts:FakeWebSocket": "WebSocket",
+};
 
-// Methods present on the real prototype that are not part of the substitutable
-// public surface a fake must mirror.
-const NON_PUBLIC = new Set(["constructor", "getDb"]);
-
-function publicMethodNames(realClass: { prototype: object }): string[] {
-  return Object.getOwnPropertyNames(realClass.prototype).filter(name => {
-    if (NON_PUBLIC.has(name) || name.startsWith("_")) {
-      return false;
+function exportedFakeClassesWithoutContracts(fileName: string): Array<{
+  name: string;
+  hasContract: boolean;
+  contractTypes: string[];
+}> {
+  const source = ts.createSourceFile(
+    fileName,
+    readFileSync(path.join(FAKES_DIR, fileName), "utf8"),
+    ts.ScriptTarget.Latest,
+    false,
+    ts.ScriptKind.TS
+  );
+  const aliases = new Map<string, ts.TypeNode>();
+  for (const statement of source.statements) {
+    if (ts.isTypeAliasDeclaration(statement)) {
+      aliases.set(statement.name.text, statement.type);
     }
-    return typeof (realClass.prototype as Record<string, unknown>)[name] === "function";
-  });
+  }
+  const classes: Array<{
+    name: string;
+    hasContract: boolean;
+    contractTypes: string[];
+  }> = [];
+
+  for (const statement of source.statements) {
+    if (!ts.isClassDeclaration(statement) || !statement.name) {
+      continue;
+    }
+    const isExported = statement.modifiers?.some(
+      modifier => modifier.kind === ts.SyntaxKind.ExportKeyword
+    );
+    const hasContract = statement.heritageClauses?.some(
+      clause => clause.token === ts.SyntaxKind.ImplementsKeyword
+    ) ?? false;
+    if (isExported && statement.name.text.startsWith("Fake")) {
+      const contractTypes: string[] = [];
+      const visitedAliases = new Set<string>();
+      const visitTypeName = (name: string): void => {
+        contractTypes.push(name);
+        const alias = aliases.get(name);
+        if (alias && !visitedAliases.has(name)) {
+          visitedAliases.add(name);
+          visit(alias);
+        }
+      };
+      const visit = (node: ts.Node): void => {
+        if (ts.isTypeReferenceNode(node)) {
+          visitTypeName(node.typeName.getText(source));
+        }
+        if (
+          ts.isExpressionWithTypeArguments(node) &&
+          ts.isIdentifier(node.expression)
+        ) {
+          visitTypeName(node.expression.text);
+        }
+        ts.forEachChild(node, visit);
+      };
+      for (const clause of statement.heritageClauses ?? []) {
+        if (clause.token !== ts.SyntaxKind.ImplementsKeyword) {
+          continue;
+        }
+        for (const type of clause.types) {
+          visit(type);
+        }
+      }
+      classes.push({
+        name: `${fileName}:${statement.name.text}`,
+        hasContract,
+        contractTypes,
+      });
+    }
+  }
+
+  return classes;
 }
 
-const pairs: Array<{
-  name: string;
-  realClass: { prototype: object };
-  fake: object;
-}> = [
-  {
-    name: "DeviceSnapshotRepository",
-    realClass: DeviceSnapshotRepository,
-    fake: new FakeDeviceSnapshotRepository(),
-  },
-  {
-    name: "VideoRecordingRepository",
-    realClass: VideoRecordingRepository,
-    fake: new FakeVideoRecordingRepository(),
-  },
-];
+describe("fake contract conformance (#4439)", () => {
+  test("every exported fake declares its compile-time contract", () => {
+    const classes = readdirSync(FAKES_DIR)
+      .filter(fileName => fileName.endsWith(".ts") && !fileName.endsWith(".test.ts"))
+      .flatMap(exportedFakeClassesWithoutContracts)
+      .sort((left, right) => left.name.localeCompare(right.name));
+    const missing = classes
+      .filter(fakeClass => !fakeClass.hasContract)
+      .map(fakeClass => fakeClass.name);
+    const expectedClasses = classes.filter(fakeClass =>
+      Object.hasOwn(EXPECTED_CONTRACT_TYPES, fakeClass.name)
+    );
 
-describe("fake/real conformance (#4186)", () => {
-  for (const { name, realClass, fake } of pairs) {
-    test(`the fake for ${name} exposes every public method of the real class`, () => {
-      const expected = publicMethodNames(realClass);
-      // Sanity: the introspection must actually find methods, else the guard is
-      // vacuous.
-      expect(expected.length).toBeGreaterThan(0);
-
-      const missing = expected.filter(
-        method => typeof (fake as Record<string, unknown>)[method] !== "function"
+    expect(missing).toEqual([]);
+    expect(expectedClasses.map(fakeClass => fakeClass.name)).toEqual(
+      Object.keys(EXPECTED_CONTRACT_TYPES).sort()
+    );
+    for (const fakeClass of expectedClasses) {
+      expect(fakeClass.contractTypes).toContain(
+        EXPECTED_CONTRACT_TYPES[fakeClass.name]!
       );
-      expect(missing).toEqual([]);
-    });
-  }
+    }
+  });
 });

--- a/test/lint/fakeHygiene.test.ts
+++ b/test/lint/fakeHygiene.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
+import ts from "typescript";
 
 /**
  * Source-scan ratchet: a test double under test/fakes must not reach for the
@@ -18,8 +19,6 @@ import path from "node:path";
  */
 
 const FAKES_DIR = path.join(import.meta.dir, "..", "fakes");
-
-const FORBIDDEN_TOKENS = ["defaultTimer", "Date.now(", "Math.random(", "randomUUID("];
 
 // relative filename -> trimmed source lines that are allowed to contain a
 // forbidden token (duplicates listed once per occurrence).
@@ -62,21 +61,273 @@ const ALLOWLIST: Record<string, string[]> = {
   "FakeAwaitIdle.ts": ["const now = Date.now();"],
 };
 
-function lineHasForbiddenToken(line: string): boolean {
-  // Ignore comment-only mentions: a token inside a `//` or `*` comment is not a
-  // real clock/randomness reach.
-  const trimmed = line.trim();
-  if (trimmed.startsWith("//") || trimmed.startsWith("*")) {
+type ForbiddenMethod = "Date.now" | "Math.random" | "crypto.randomUUID";
+type StandardObject = "Date" | "Math" | "crypto";
+type ForbiddenValue = StandardObject | ForbiddenMethod | "defaultTimer";
+
+class Scope {
+  private readonly bindings = new Map<string, ForbiddenValue | null>();
+
+  constructor(private readonly parent?: Scope) {}
+
+  bind(name: string, value: ForbiddenValue | null): void {
+    this.bindings.set(name, value);
+  }
+
+  lookup(name: string): ForbiddenValue | null | undefined {
+    if (this.bindings.has(name)) {
+      return this.bindings.get(name);
+    }
+    return this.parent?.lookup(name);
+  }
+}
+
+function standardObjectFor(expression: ts.Expression, scope: Scope): StandardObject | undefined {
+  if (ts.isIdentifier(expression)) {
+    const binding = scope.lookup(expression.text);
+    if (binding === "Date" || binding === "Math" || binding === "crypto") {
+      return binding;
+    }
+    if (binding !== undefined) {
+      return undefined;
+    }
+    if (expression.text === "Date" || expression.text === "Math" || expression.text === "crypto") {
+      return expression.text;
+    }
+    return undefined;
+  }
+
+  const globalPropertyName = (value: ts.Expression): string | undefined => {
+    if (ts.isPropertyAccessExpression(value) && ts.isIdentifier(value.expression)) {
+      return value.expression.text === "globalThis" && scope.lookup("globalThis") === undefined
+        ? value.name.text
+        : undefined;
+    }
+    if (
+      ts.isElementAccessExpression(value) &&
+      ts.isIdentifier(value.expression) &&
+      value.expression.text === "globalThis" &&
+      scope.lookup("globalThis") === undefined &&
+      ts.isStringLiteral(value.argumentExpression)
+    ) {
+      return value.argumentExpression.text;
+    }
+    return undefined;
+  };
+  const name = globalPropertyName(expression);
+  return name === "Date" || name === "Math" || name === "crypto" ? name : undefined;
+}
+
+function forbiddenMethodForProperty(
+  object: StandardObject | undefined,
+  property: string
+): ForbiddenMethod | undefined {
+  if (object === "Date" && property === "now") {
+    return "Date.now";
+  }
+  if (object === "Math" && property === "random") {
+    return "Math.random";
+  }
+  if (object === "crypto" && property === "randomUUID") {
+    return "crypto.randomUUID";
+  }
+  return undefined;
+}
+
+function forbiddenMethodFor(expression: ts.Expression, scope: Scope): ForbiddenMethod | undefined {
+  if (ts.isIdentifier(expression)) {
+    const binding = scope.lookup(expression.text);
+    if (binding === "Date.now" || binding === "Math.random" || binding === "crypto.randomUUID") {
+      return binding;
+    }
+    if (expression.text === "randomUUID" && binding === undefined) {
+      return "crypto.randomUUID";
+    }
+    return undefined;
+  }
+
+  if (ts.isPropertyAccessExpression(expression)) {
+    return forbiddenMethodForProperty(
+      standardObjectFor(expression.expression, scope),
+      expression.name.text
+    );
+  }
+
+  if (
+    ts.isElementAccessExpression(expression) &&
+    ts.isStringLiteral(expression.argumentExpression)
+  ) {
+    return forbiddenMethodForProperty(
+      standardObjectFor(expression.expression, scope),
+      expression.argumentExpression.text
+    );
+  }
+
+  return undefined;
+}
+
+function bindName(scope: Scope, name: ts.BindingName, value: ForbiddenValue | null): void {
+  if (ts.isIdentifier(name)) {
+    scope.bind(name.text, value);
+    return;
+  }
+  for (const element of name.elements) {
+    if (ts.isBindingElement(element)) {
+      bindName(scope, element.name, null);
+    }
+  }
+}
+
+function isDefaultTimer(expression: ts.Expression, scope: Scope): boolean {
+  if (!ts.isIdentifier(expression) || expression.text !== "defaultTimer") {
     return false;
   }
-  return FORBIDDEN_TOKENS.some(token => line.includes(token));
+  return scope.lookup(expression.text) !== null;
+}
+
+function bindVariableDeclaration(
+  declaration: ts.VariableDeclaration,
+  scope: Scope
+): void {
+  const initializer = declaration.initializer;
+  if (!initializer) {
+    bindName(scope, declaration.name, null);
+    return;
+  }
+
+  const object = standardObjectFor(initializer, scope);
+  const method = forbiddenMethodFor(initializer, scope);
+  const value = object ?? method ?? (isDefaultTimer(initializer, scope) ? "defaultTimer" : null);
+  if (ts.isIdentifier(declaration.name)) {
+    bindName(scope, declaration.name, value);
+    return;
+  }
+
+  if (ts.isObjectBindingPattern(declaration.name) && object) {
+    for (const element of declaration.name.elements) {
+      const property = element.propertyName ?? element.name;
+      const propertyName = ts.isIdentifier(property) || ts.isStringLiteral(property)
+        ? property.text
+        : undefined;
+      bindName(
+        scope,
+        element.name,
+        propertyName ? forbiddenMethodForProperty(object, propertyName) ?? null : null
+      );
+    }
+    return;
+  }
+
+  bindName(scope, declaration.name, null);
 }
 
 function forbiddenLinesIn(source: string): string[] {
-  return source
-    .split("\n")
-    .filter(lineHasForbiddenToken)
-    .map(line => line.trim());
+  const sourceFile = ts.createSourceFile(
+    "fake.ts",
+    source,
+    ts.ScriptTarget.Latest,
+    false,
+    ts.ScriptKind.TS
+  );
+  const lines: string[] = [];
+
+  const lineAt = (position: number): string => {
+    const line = sourceFile.getLineAndCharacterOfPosition(position).line;
+    return sourceFile.text.split("\n")[line]?.trim() ?? "";
+  };
+  const reportDefaultTimer = (identifier: ts.Identifier, scope: Scope): void => {
+    if (identifier.text === "defaultTimer" && scope.lookup(identifier.text) !== null) {
+      lines.push(lineAt(identifier.getStart(sourceFile)));
+    }
+  };
+  const bindImport = (declaration: ts.ImportDeclaration, scope: Scope): void => {
+    const importedBindings = declaration.importClause;
+    if (!importedBindings) {
+      return;
+    }
+    if (importedBindings.name) {
+      bindName(scope, importedBindings.name, null);
+    }
+    if (
+      !importedBindings.namedBindings ||
+      !ts.isNamedImports(importedBindings.namedBindings)
+    ) {
+      return;
+    }
+    for (const element of importedBindings.namedBindings.elements) {
+      const importedName = (element.propertyName ?? element.name).text;
+      const value = importedName === "defaultTimer"
+        ? "defaultTimer"
+        : importedName === "randomUUID" && declaration.moduleSpecifier.getText(sourceFile).includes("crypto")
+          ? "crypto.randomUUID"
+          : null;
+      bindName(scope, element.name, value);
+      if (value === "defaultTimer") {
+        reportDefaultTimer(element.name, scope);
+      }
+    }
+  };
+  const visit = (node: ts.Node, scope: Scope): void => {
+    if (ts.isSourceFile(node)) {
+      for (const statement of node.statements) {
+        visit(statement, scope);
+      }
+      return;
+    }
+    if (ts.isBlock(node)) {
+      const blockScope = new Scope(scope);
+      for (const statement of node.statements) {
+        visit(statement, blockScope);
+      }
+      return;
+    }
+    if (ts.isImportDeclaration(node)) {
+      bindImport(node, scope);
+      return;
+    }
+    if (ts.isVariableDeclaration(node)) {
+      if (node.initializer) {
+        visit(node.initializer, scope);
+      }
+      bindVariableDeclaration(node, scope);
+      return;
+    }
+    if (ts.isFunctionLike(node)) {
+      const functionScope = new Scope(scope);
+      for (const parameter of node.parameters) {
+        if (parameter.initializer) {
+          visit(parameter.initializer, scope);
+        }
+        bindName(functionScope, parameter.name, null);
+      }
+      if (node.body) {
+        visit(node.body, functionScope);
+      }
+      return;
+    }
+    if (ts.isClassDeclaration(node)) {
+      const classScope = new Scope(scope);
+      if (node.name) {
+        classScope.bind(node.name.text, null);
+      }
+      ts.forEachChild(node, child => visit(child, classScope));
+      return;
+    }
+    if (ts.isIdentifier(node)) {
+      reportDefaultTimer(node, scope);
+      return;
+    }
+    if (
+      ts.isCallExpression(node) &&
+      forbiddenMethodFor(node.expression, scope)
+    ) {
+      lines.push(lineAt(node.getStart(sourceFile)));
+    }
+    ts.forEachChild(node, child => visit(child, scope));
+  };
+
+  visit(sourceFile, new Scope());
+  return lines;
 }
 
 function sortedMultiset(values: string[]): string[] {
@@ -87,6 +338,38 @@ describe("fake hygiene source scan (#4186)", () => {
   const fakeFiles = readdirSync(FAKES_DIR).filter(
     name => name.endsWith(".ts") && !name.endsWith(".test.ts")
   );
+
+  test("rejects aliased, computed, and whitespace-obscured nondeterminism", () => {
+    const bypasses = [
+      "const { random } = Math; random()",
+      "Math . random()",
+      'Math["random"]()',
+      'crypto["randomUUID"]()',
+      "const clock = Date; clock.now()",
+      'Date["now"]()',
+      "const { now } = Date; now()",
+      "const { randomUUID: makeId } = crypto; makeId()",
+      "globalThis.Date.now()",
+    ];
+
+    for (const source of bypasses) {
+      expect(forbiddenLinesIn(source)).toHaveLength(1);
+    }
+  });
+
+  test("does not flag shadowed local clock and randomness methods", () => {
+    const source = `
+      function safe(
+        Date: { now(): number },
+        Math: { random(): number },
+        crypto: { randomUUID(): string }
+      ) {
+        return [Date.now(), Math.random(), crypto["randomUUID"]()];
+      }
+    `;
+
+    expect(forbiddenLinesIn(source)).toEqual([]);
+  });
 
   test("scans a non-trivial number of fakes", () => {
     // Guards against a glob/path regression silently scanning nothing.


### PR DESCRIPTION
## Summary

- Add `FakeTimer.advanceTimeAsync()` so catch-up interval callbacks yield an event-loop turn between ticks.
- Replace the fake nondeterminism substring scan with TypeScript AST detection, including aliases, computed properties, destructuring, and shadowed bindings.
- Add compile-time production contracts for the 12 uncovered exported fakes and ratchet the expected contracts with an AST inventory.

## Linked Issue

Closes [#4439](https://github.com/kaeawc/auto-mobile/issues/4439).

## Bug / Regression Context

- **Observed symptom:** fake timer catch-up could overlap asynchronous interval work, and fake hygiene/conformance checks could be bypassed or drift without a compiler error.
- **Repro steps / conditions:** advance a fake timer over multiple interval deadlines while a callback awaits, or express a real clock/random source through an alias, computed property, or destructuring.

## Validation

- [x] Focused fake timer, fake hygiene, and fake contract tests: 105 pass.
- [x] `bun run typecheck` reports no new errors.
- [x] Full `bun run turbo:validate` completed its lint/build stages; its test task is blocked locally by shared `PortManager` exhaustion and socket bind errors in unchanged action/device tests.
- [x] New behavior uses the existing `Timer` interface and `FakeTimer`; no dependency was added.
- [x] Rebased onto latest `main`, conflicts resolved.
