### PR TITLE
test: property-based tests for uri/error-rewrite/trait helpers

### DIFF
--- a/test/features/observe/ios/semanticRoles.property.test.ts
+++ b/test/features/observe/ios/semanticRoles.property.test.ts
@@ -1,0 +1,50 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import { hasIosHeaderTrait } from "../../../../src/features/observe/ios/semanticRoles";
+
+// Property-based tests. See test/utils/Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+const TRAITS_KEY = "sdk.accessibilityTraits";
+// Trait tokens without commas (the value is comma-joined). Case matters — the
+// check is exact "header", so "HEADER"/"headers"/"xheader" must NOT count.
+const traitToken = fc.constantFrom("button", "header", "link", " header ", "HEADER", "headers", "xheader", "");
+const traitsString = fc.array(traitToken, { maxLength: 6 }).map(ts => ts.join(","));
+
+describe("hasIosHeaderTrait (property-based)", () => {
+  test("is total and false for any non-object input", () => {
+    const nonObject = fc.oneof(fc.constant(null), fc.constant(undefined), fc.string(), fc.integer(), fc.boolean());
+    fc.assert(
+      fc.property(nonObject, v => hasIosHeaderTrait(v) === false),
+      RUN_OPTIONS
+    );
+  });
+
+  test("matches an independent comma-segment oracle (exact, trimmed 'header')", () => {
+    fc.assert(
+      fc.property(traitsString, traits => {
+        const expected = traits.split(",").some(t => t.trim() === "header");
+        return hasIosHeaderTrait({ [TRAITS_KEY]: traits }) === expected;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("is false when the traits key is missing or non-string", () => {
+    const badTraits = fc.oneof(fc.constant(undefined), fc.integer(), fc.array(fc.string()), fc.constant({ header: true }));
+    fc.assert(
+      fc.property(badTraits, traits => hasIosHeaderTrait({ [TRAITS_KEY]: traits }) === false && hasIosHeaderTrait({ other: "header" }) === false),
+      RUN_OPTIONS
+    );
+  });
+
+  test("a 'header' segment (with surrounding whitespace) is always detected", () => {
+    const withHeader = fc.array(traitToken, { maxLength: 4 }).chain(rest =>
+      fc.constantFrom("header", " header ", "header ", " header").map(h => [...rest, h].join(","))
+    );
+    fc.assert(
+      fc.property(withHeader, traits => hasIosHeaderTrait({ [TRAITS_KEY]: traits })),
+      RUN_OPTIONS
+    );
+  });
+});

--- a/test/features/observe/shared/rewriteUnknownCommandError.property.test.ts
+++ b/test/features/observe/shared/rewriteUnknownCommandError.property.test.ts
@@ -1,0 +1,43 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import { rewriteUnknownCommandError, type CtrlProxyPlatform } from "../../../../src/features/observe/shared/rewriteUnknownCommandError";
+
+// Property-based tests. See test/utils/Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+const UNKNOWN_RE = /^Unknown command type: (.+)$/;
+const platform = fc.constantFrom<CtrlProxyPlatform>("android", "ios");
+// A command on a single line: the regex `.` never crosses a newline.
+const isSingleLine = (s: string): boolean => s.indexOf("\n") === -1 && s.indexOf("\r") === -1;
+const command = fc.string({ maxLength: 20 }).filter(s => s.length > 0 && isSingleLine(s));
+
+describe("rewriteUnknownCommandError (property-based)", () => {
+  test("passes a non-matching error through unchanged", () => {
+    const nonMatching = fc.string({ maxLength: 40 }).filter(s => !UNKNOWN_RE.test(s));
+    fc.assert(
+      fc.property(nonMatching, platform, (error, p) => rewriteUnknownCommandError(error, p) === error),
+      RUN_OPTIONS
+    );
+  });
+
+  test("rewrites a matching error into a platform-specific, command-carrying message", () => {
+    fc.assert(
+      fc.property(command, platform, (cmd, p) => {
+        const rewritten = rewriteUnknownCommandError(`Unknown command type: ${cmd}`, p);
+        const platformHint = p === "android" ? "APK" : "iOS CtrlProxy runner";
+        return rewritten !== `Unknown command type: ${cmd}` && rewritten.includes(cmd) && rewritten.includes(platformHint);
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("is idempotent — the rewritten message no longer matches and passes through", () => {
+    fc.assert(
+      fc.property(fc.string({ maxLength: 40 }), platform, (error, p) => {
+        const once = rewriteUnknownCommandError(error, p);
+        return rewriteUnknownCommandError(once, p) === once;
+      }),
+      RUN_OPTIONS
+    );
+  });
+});

--- a/test/server/videoRecordingResourceUris.property.test.ts
+++ b/test/server/videoRecordingResourceUris.property.test.ts
@@ -1,0 +1,37 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import { buildVideoArchiveItemUri, VIDEO_RESOURCE_URIS } from "../../src/server/videoRecordingResourceUris";
+
+// Property-based tests. See test/utils/Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+const PREFIX = "automobile:video/archive/";
+const recordingId = fc.string({ maxLength: 24 });
+
+describe("buildVideoArchiveItemUri (property-based)", () => {
+  test("matches the ARCHIVE_ITEM template with {recordingId} substituted verbatim", () => {
+    // Use a function replacement so `$`-patterns in the id are NOT interpreted —
+    // the template-literal build appends the id verbatim, and so must the oracle.
+    fc.assert(
+      fc.property(recordingId, id => buildVideoArchiveItemUri(id) === VIDEO_RESOURCE_URIS.ARCHIVE_ITEM.replace("{recordingId}", () => id)),
+      RUN_OPTIONS
+    );
+  });
+
+  test("carries the id verbatim after the fixed prefix (round-trip)", () => {
+    fc.assert(
+      fc.property(recordingId, id => {
+        const uri = buildVideoArchiveItemUri(id);
+        return uri.startsWith(PREFIX) && uri.slice(PREFIX.length) === id;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("is injective — distinct ids produce distinct uris", () => {
+    fc.assert(
+      fc.property(recordingId, recordingId, (a, b) => a === b || buildVideoArchiveItemUri(a) !== buildVideoArchiveItemUri(b)),
+      RUN_OPTIONS
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Continues the fast-check property-testing expansion (pattern from [PR #4427](https://github.com/kaeawc/auto-mobile/pull/4427)) with three small pure helpers. Test-only, additive — no production changes, no new dependencies.

Invariants asserted:

- **`buildVideoArchiveItemUri`** (`src/server/videoRecordingResourceUris.ts`) — matches the `ARCHIVE_ITEM` template with `{recordingId}` substituted **verbatim**; carries the id after the fixed prefix (round-trip: `uri.slice(prefix.length) === id`); injective.
- **`rewriteUnknownCommandError`** (`src/features/observe/shared/rewriteUnknownCommandError.ts`) — passes a non-matching error through unchanged; rewrites `"Unknown command type: X"` into a platform-specific, command-carrying message (Android → `APK`, iOS → `iOS CtrlProxy runner`); **idempotent** (the rewritten message no longer matches, so a second pass is a no-op).
- **`hasIosHeaderTrait`** (`src/features/observe/ios/semanticRoles.ts`) — total and `false` for any non-object; matches an **independent comma-segment oracle** (exact, trimmed `"header"` — so `HEADER`/`headers`/`xheader` don't count); `false` when the traits key is missing or non-string; a `header` segment (with surrounding whitespace) is always detected.

## Surfaced during authoring (test-oracle subtlety, not a defect)

The first `buildVideoArchiveItemUri` oracle used `ARCHIVE_ITEM.replace("{recordingId}", id)` and failed for an id containing `$` — `String.prototype.replace` interprets `$&`/`$$`/etc. in a **string** replacement, whereas the function uses a template literal (verbatim append). The function is correct; the oracle was switched to a **function replacement** (`() => id`) to suppress `$`-substitution. (Worth noting for any future code that builds this URI via `.replace` with a string arg — it would mis-handle `$`-containing ids.)

## Validation

- [x] `bun test test/server/videoRecordingResourceUris.property.test.ts test/features/observe/shared/rewriteUnknownCommandError.property.test.ts test/features/observe/ios/semanticRoles.property.test.ts` — 10 pass, ~125ms
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run lint` — no new violations
- [x] New tests are pure (no device/network/filesystem/DB); each runs in <100ms

## Follow-ups

- [ ] Unrelated: `main`'s typecheck baseline has drifted (3 baselined errors no longer occur) — worth a standalone `bun run typecheck:update` ratchet.
