### PR TITLE
fix: secure Android permission commands

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -6909,6 +6909,7 @@
           "type": "string"
         },
         "action": {
+          "description": "Action (default grant). Android reset requires permissions=['all'] device-wide; iOS physical devices support reset only.",
           "enum": [
             "grant",
             "revoke",
@@ -6916,6 +6917,7 @@
           ]
         },
         "permissions": {
+          "description": "Permissions; Android reset accepts only 'all'; physical iOS accepts it too",
           "type": "array",
           "items": {
             "type": "string",
@@ -6923,11 +6925,13 @@
           }
         },
         "userId": {
+          "description": "Android user ID for grant/revoke, not reset",
           "type": "integer",
           "minimum": 0,
           "maximum": 9007199254740991
         },
         "notificationsEnabled": {
+          "description": "Android notification state, independent of POST_NOTIFICATIONS",
           "type": "boolean"
         },
         "notificationPolicyAccess": {

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -6900,7 +6900,7 @@
   },
   {
     "name": "setAppPermissions",
-    "description": "Set permissions; notification state excludes POST_NOTIFICATIONS.",
+    "description": "Set permissions; Android grant/revoke use userId, reset is device-wide ['all'], notifications exclude POST_NOTIFICATIONS.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -6909,7 +6909,6 @@
           "type": "string"
         },
         "action": {
-          "description": "Action (default grant). Android reset requires permissions=['all'] device-wide; iOS physical devices support reset only.",
           "enum": [
             "grant",
             "revoke",
@@ -6917,7 +6916,6 @@
           ]
         },
         "permissions": {
-          "description": "Permissions; Android reset accepts only 'all'; physical iOS accepts it too",
           "type": "array",
           "items": {
             "type": "string",
@@ -6925,13 +6923,11 @@
           }
         },
         "userId": {
-          "description": "Android user ID for grant/revoke, not reset",
           "type": "integer",
           "minimum": 0,
           "maximum": 9007199254740991
         },
         "notificationsEnabled": {
-          "description": "Android notification state, independent of POST_NOTIFICATIONS",
           "type": "boolean"
         },
         "notificationPolicyAccess": {

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -6900,7 +6900,7 @@
   },
   {
     "name": "setAppPermissions",
-    "description": "Set permissions; Android grant/revoke use userId, reset is device-wide ['all'], notifications exclude POST_NOTIFICATIONS.",
+    "description": "userId grant/revoke; device-wide reset ['all']; no POST_NOTIFICATIONS.",
     "inputSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",
@@ -6992,6 +6992,7 @@
         "then": {
           "properties": {
             "permissions": {
+              "minItems": 1,
               "maxItems": 1,
               "items": {
                 "const": "all"

--- a/src/features/action/AppPermissions.ts
+++ b/src/features/action/AppPermissions.ts
@@ -266,15 +266,16 @@ export class AppPermissions {
     input: SetAppPermissionsInput
   ): Promise<SetAppPermissionsResult> {
     const permissions = normalizePermissions(input.permissions);
+    const requestedPermissions = input.permissions ?? [];
     const operations: AppPermissionOperationResult[] = [];
     const invalidResetRequest =
       action === "reset" &&
-      (input.userId !== undefined || permissions.length !== 1 || permissions[0] !== "all");
+      (input.userId !== undefined || requestedPermissions.length !== 1 || requestedPermissions[0] !== "all");
 
     if (permissions.length > 0 || invalidResetRequest) {
       const permissionResult = await new GrantAndroidPermissions(this.device, this.adbFactory).execute(appId, {
         action,
-        permissions,
+        permissions: action === "reset" ? requestedPermissions : permissions,
         userId: input.userId,
       });
       const changedCount = permissionResult.results.filter(result => result.success && !result.skipped).length;

--- a/src/features/action/GrantAndroidPermissions.ts
+++ b/src/features/action/GrantAndroidPermissions.ts
@@ -5,6 +5,7 @@ import { BootedDevice, GrantAndroidPermissionItemResult, GrantAndroidPermissions
 import { logger } from "../../utils/logger";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { outputLooksLikeShellFailure } from "../../utils/android-cmdline-tools/shellOutputHeuristics";
+import { shellQuote } from "../../utils/shellQuote";
 
 
 export type AndroidPermissionChangeAction = "grant" | "revoke" | "reset";
@@ -89,7 +90,7 @@ export class GrantAndroidPermissions {
           continue;
         }
 
-        const cmd = `shell pm ${action} --user ${targetUserId} ${packageName} ${trimmed}`;
+        const cmd = `shell pm ${action} --user ${targetUserId} ${shellQuote(packageName)} ${shellQuote(trimmed)}`;
 
         try {
           await perf.track(`pm${action[0].toUpperCase()}${action.slice(1)}:${trimmed}`, async () => {
@@ -164,7 +165,7 @@ export class GrantAndroidPermissions {
     userId: number | undefined,
     perf: ReturnType<typeof createGlobalPerformanceTracker>
   ): Promise<GrantAndroidPermissionsResult> {
-    const resetPermissions = permissions.map(permission => permission.trim());
+    const resetPermissions = permissions;
     if (userId !== undefined) {
       perf.end();
       return {

--- a/src/features/action/SetAndroidNotificationPolicyAccess.ts
+++ b/src/features/action/SetAndroidNotificationPolicyAccess.ts
@@ -4,6 +4,7 @@ import { AndroidDeviceShellToolResult, BootedDevice } from "../../models";
 import { logger } from "../../utils/logger";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { outputLooksLikeShellFailure } from "../../utils/android-cmdline-tools/shellOutputHeuristics";
+import { shellQuote } from "../../utils/shellQuote";
 
 
 export interface SetAndroidNotificationPolicyAccessInput {
@@ -43,7 +44,7 @@ export class SetAndroidNotificationPolicyAccess {
     }
 
     const sub = input.allowed ? "allow_dnd" : "disallow_dnd";
-    const cmd = `shell cmd notification ${sub} ${packageName}`;
+    const cmd = `shell cmd notification ${sub} ${shellQuote(packageName)}`;
 
     try {
       await perf.track(sub, async () => {

--- a/src/features/action/SetAndroidNotificationsEnabled.ts
+++ b/src/features/action/SetAndroidNotificationsEnabled.ts
@@ -4,6 +4,7 @@ import { AndroidDeviceShellToolResult, BootedDevice } from "../../models";
 import { logger } from "../../utils/logger";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { outputLooksLikeShellFailure } from "../../utils/android-cmdline-tools/shellOutputHeuristics";
+import { shellQuote } from "../../utils/shellQuote";
 
 export interface SetAndroidNotificationsEnabledInput {
   enabled: boolean;
@@ -39,7 +40,7 @@ export class SetAndroidNotificationsEnabled {
       };
     }
 
-    const command = `shell cmd notification set_enabled ${packageName} ${input.enabled}`;
+    const command = `shell cmd notification set_enabled ${shellQuote(packageName)} ${input.enabled}`;
     try {
       await perf.track("setEnabled", async () => {
         const result = await this.adb.executeCommand(command, undefined, undefined, true);

--- a/src/features/action/SetAndroidScheduleExactAlarmAppOp.ts
+++ b/src/features/action/SetAndroidScheduleExactAlarmAppOp.ts
@@ -5,6 +5,7 @@ import { logger } from "../../utils/logger";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { readAndroidDeviceApiLevel } from "../../utils/android-cmdline-tools/readAndroidDeviceApiLevel";
 import { outputLooksLikeShellFailure } from "../../utils/android-cmdline-tools/shellOutputHeuristics";
+import { shellQuote } from "../../utils/shellQuote";
 
 
 const API_LEVEL_SCHEDULE_EXACT_ALARM = 31;
@@ -64,7 +65,7 @@ export class SetAndroidScheduleExactAlarmAppOp {
       }
     }
 
-    const cmd = `shell appops set --uid ${packageName} SCHEDULE_EXACT_ALARM ${input.mode}`;
+    const cmd = `shell appops set --uid ${shellQuote(packageName)} SCHEDULE_EXACT_ALARM ${input.mode}`;
 
     try {
       await perf.track(`appops.${input.mode}`, async () => {

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -120,6 +120,10 @@ export const setAppPermissionsSchema = withJsonSchemaOverride(withAppIdAliases(a
   delete properties.action?.type;
   delete properties.scheduleExactAlarm?.type;
   for (const name of [
+    "action",
+    "permissions",
+    "userId",
+    "notificationsEnabled",
     "notificationPolicyAccess",
     "scheduleExactAlarm",
     "sessionUuid",
@@ -383,7 +387,7 @@ export function registerAppTools(
 
   ToolRegistry.registerDeviceAware(
     "setAppPermissions",
-    "Set permissions; notification state excludes POST_NOTIFICATIONS.",
+    "Set permissions; Android grant/revoke use userId, reset is device-wide ['all'], notifications exclude POST_NOTIFICATIONS.",
     setAppPermissionsSchema,
     setAppPermissionsHandler
   );

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -113,17 +113,13 @@ export const setAppPermissionsSchema = withJsonSchemaOverride(withAppIdAliases(a
   args =>
     args.action !== "reset" ||
     args.platform !== "android" ||
-    (args.permissions?.length === 1 && args.permissions[0].trim() === "all"),
+    (args.permissions?.length === 1 && args.permissions[0] === "all"),
   "Android reset requires permissions=['all']"
 ), jsonSchema => {
   const properties = jsonSchema.properties as Record<string, Record<string, unknown>>;
   delete properties.action?.type;
   delete properties.scheduleExactAlarm?.type;
   for (const name of [
-    "action",
-    "permissions",
-    "userId",
-    "notificationsEnabled",
     "notificationPolicyAccess",
     "scheduleExactAlarm",
     "sessionUuid",

--- a/src/server/appTools.ts
+++ b/src/server/appTools.ts
@@ -66,7 +66,7 @@ const appPermissionActionSchema = z.enum(["grant", "revoke", "reset"]);
 
 export const setAppPermissionsSchema = withJsonSchemaOverride(withAppIdAliases(addDeviceTargetingToSchema(
   z.object({
-    appId: z.string(),
+    appId: z.string().trim().min(1),
     action: appPermissionActionSchema
       .optional()
       .describe(
@@ -117,6 +117,7 @@ export const setAppPermissionsSchema = withJsonSchemaOverride(withAppIdAliases(a
   "Android reset requires permissions=['all']"
 ), jsonSchema => {
   const properties = jsonSchema.properties as Record<string, Record<string, unknown>>;
+  delete properties.appId?.minLength;
   delete properties.action?.type;
   delete properties.scheduleExactAlarm?.type;
   for (const name of [
@@ -145,6 +146,7 @@ export const setAppPermissionsSchema = withJsonSchemaOverride(withAppIdAliases(a
     then: {
       properties: {
         permissions: {
+          minItems: 1,
           maxItems: 1,
           items: { const: "all" },
         },
@@ -387,7 +389,7 @@ export function registerAppTools(
 
   ToolRegistry.registerDeviceAware(
     "setAppPermissions",
-    "Set permissions; Android grant/revoke use userId, reset is device-wide ['all'], notifications exclude POST_NOTIFICATIONS.",
+    "userId grant/revoke; device-wide reset ['all']; no POST_NOTIFICATIONS.",
     setAppPermissionsSchema,
     setAppPermissionsHandler
   );

--- a/test/features/action/AppPermissions.test.ts
+++ b/test/features/action/AppPermissions.test.ts
@@ -43,10 +43,10 @@ describe("AppPermissions", () => {
   test("sets Android runtime permissions and Android-specific options through one action", async () => {
     const adbFactory = new FakeAdbClientFactory();
     const client = adbFactory.getFakeClient();
-    client.setCommandResult("shell pm grant --user 0 com.example.app android.permission.CAMERA", "");
-    client.setCommandResult("shell cmd notification set_enabled com.example.app true", "");
-    client.setCommandResult("shell cmd notification allow_dnd com.example.app", "");
-    client.setCommandResult("shell appops set --uid com.example.app SCHEDULE_EXACT_ALARM allow", "");
+    client.setCommandResult("shell pm grant --user 0 'com.example.app' 'android.permission.CAMERA'", "");
+    client.setCommandResult("shell cmd notification set_enabled 'com.example.app' true", "");
+    client.setCommandResult("shell cmd notification allow_dnd 'com.example.app'", "");
+    client.setCommandResult("shell appops set --uid 'com.example.app' SCHEDULE_EXACT_ALARM allow", "");
 
     const permissions = new AppPermissions(androidDevice, { adbFactory });
     const result = await permissions.setPermissions("com.example.app", {
@@ -65,18 +65,18 @@ describe("AppPermissions", () => {
       "android_notification_policy_access",
       "android_schedule_exact_alarm_appop",
     ]);
-    expect(client.wasCommandExecuted("shell pm grant --user 0 com.example.app android.permission.CAMERA")).toBe(true);
-    expect(client.wasCommandExecuted("shell cmd notification set_enabled com.example.app true")).toBe(true);
-    expect(client.wasCommandExecuted("shell cmd notification allow_dnd com.example.app")).toBe(true);
-    expect(client.wasCommandExecuted("shell appops set --uid com.example.app SCHEDULE_EXACT_ALARM allow")).toBe(true);
+    expect(client.wasCommandExecuted("shell pm grant --user 0 'com.example.app' 'android.permission.CAMERA'")).toBe(true);
+    expect(client.wasCommandExecuted("shell cmd notification set_enabled 'com.example.app' true")).toBe(true);
+    expect(client.wasCommandExecuted("shell cmd notification allow_dnd 'com.example.app'")).toBe(true);
+    expect(client.wasCommandExecuted("shell appops set --uid 'com.example.app' SCHEDULE_EXACT_ALARM allow")).toBe(true);
   });
 
   test("aggregates Android revoke and notification command failures", async () => {
     const adbFactory = new FakeAdbClientFactory();
     const client = adbFactory.getFakeClient();
-    client.setCommandResult("shell pm revoke --user 0 com.example.app android.permission.CAMERA", "");
+    client.setCommandResult("shell pm revoke --user 0 'com.example.app' 'android.permission.CAMERA'", "");
     client.setCommandResult(
-      "shell cmd notification set_enabled com.example.app false",
+      "shell cmd notification set_enabled 'com.example.app' false",
       "",
       "SecurityException: notification access denied"
     );
@@ -117,7 +117,7 @@ describe("AppPermissions", () => {
   test("disables Android notifications independently of runtime permissions", async () => {
     const adbFactory = new FakeAdbClientFactory();
     const client = adbFactory.getFakeClient();
-    client.setCommandResult("shell cmd notification set_enabled com.example.app false", "");
+    client.setCommandResult("shell cmd notification set_enabled 'com.example.app' false", "");
 
     const permissions = new AppPermissions(androidDevice, { adbFactory });
     const result = await permissions.setPermissions("com.example.app", {
@@ -130,7 +130,23 @@ describe("AppPermissions", () => {
     expect(result.operations.map(operation => operation.operationId)).toEqual([
       "android_notifications_enabled",
     ]);
-    expect(client.wasCommandExecuted("shell cmd notification set_enabled com.example.app false")).toBe(true);
+    expect(client.wasCommandExecuted("shell cmd notification set_enabled 'com.example.app' false")).toBe(true);
+  });
+
+  test("quotes notification package names before passing them to the device shell", async () => {
+    const adbFactory = new FakeAdbClientFactory();
+    const client = adbFactory.getFakeClient();
+    const appId = "com.example.app; id #";
+    const command = "shell cmd notification set_enabled 'com.example.app; id #' false";
+    client.setCommandResult(command, "");
+
+    const permissions = new AppPermissions(androidDevice, { adbFactory });
+    const result = await permissions.setPermissions(appId, {
+      notificationsEnabled: false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(client.getAllCommands()).toContain(command);
   });
 
   test("rejects a notification-only Android reset before executing either operation", async () => {
@@ -176,6 +192,25 @@ describe("AppPermissions", () => {
       "android_runtime_permissions:reset",
     ]);
     expect(client.wasCommandExecuted("shell pm reset-permissions")).toBe(true);
+  });
+
+  test("rejects a whitespace-padded Android reset sentinel", async () => {
+    const adbFactory = new FakeAdbClientFactory();
+    const client = adbFactory.getFakeClient();
+    const permissions = new AppPermissions(androidDevice, { adbFactory });
+
+    const result = await permissions.setPermissions("com.example.app", {
+      action: "reset",
+      permissions: [" all "],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.operations[0].result).toMatchObject({
+      results: [{
+        error: "Android reset requires permissions=['all'] because pm reset-permissions is device-wide",
+      }],
+    });
+    expect(client.wasCommandExecuted("shell pm reset-permissions")).toBe(false);
   });
 
   test("queries Android runtime permission state from dumpsys package", async () => {

--- a/test/features/action/GrantAndroidPermissions.test.ts
+++ b/test/features/action/GrantAndroidPermissions.test.ts
@@ -24,11 +24,11 @@ describe("GrantAndroidPermissions", () => {
     const factory = new FakeAdbClientFactory();
     const client = factory.getFakeClient();
     client.setCommandResult(
-      "shell pm grant --user 0 com.example.app android.permission.POST_NOTIFICATIONS",
+      "shell pm grant --user 0 'com.example.app' 'android.permission.POST_NOTIFICATIONS'",
       ""
     );
     client.setCommandResult(
-      "shell pm grant --user 0 com.example.app android.permission.CAMERA",
+      "shell pm grant --user 0 'com.example.app' 'android.permission.CAMERA'",
       ""
     );
 
@@ -48,15 +48,15 @@ describe("GrantAndroidPermissions", () => {
     ]);
 
     const calls = client.getCommandCalls().map(c => c.command);
-    expect(calls).toContain("shell pm grant --user 0 com.example.app android.permission.POST_NOTIFICATIONS");
-    expect(calls).toContain("shell pm grant --user 0 com.example.app android.permission.CAMERA");
+    expect(calls).toContain("shell pm grant --user 0 'com.example.app' 'android.permission.POST_NOTIFICATIONS'");
+    expect(calls).toContain("shell pm grant --user 0 'com.example.app' 'android.permission.CAMERA'");
   });
 
   test("runs pm revoke for each permission with the resolved target user", async () => {
     const factory = new FakeAdbClientFactory();
     const client = factory.getFakeClient();
     client.setCommandResult(
-      "shell pm revoke --user 12 com.example.app android.permission.POST_NOTIFICATIONS",
+      "shell pm revoke --user 12 'com.example.app' 'android.permission.POST_NOTIFICATIONS'",
       ""
     );
 
@@ -79,9 +79,28 @@ describe("GrantAndroidPermissions", () => {
     ]);
     expect(
       client.wasCommandExecuted(
-        "shell pm revoke --user 12 com.example.app android.permission.POST_NOTIFICATIONS"
+        "shell pm revoke --user 12 'com.example.app' 'android.permission.POST_NOTIFICATIONS'"
       )
     ).toBe(true);
+  });
+
+  test("quotes package and permission values before passing them to the device shell", async () => {
+    const factory = new FakeAdbClientFactory();
+    const client = factory.getFakeClient();
+    const packageName = "com.example.app; id #";
+    const permission = "android.permission.CAMERA; id #";
+    const command = "shell pm revoke --user 0 'com.example.app; id #' 'android.permission.CAMERA; id #'";
+    client.setCommandResult(command, "");
+
+    const action = new GrantAndroidPermissions(androidDevice, factory);
+    const result = await action.execute(packageName, {
+      action: "revoke",
+      permissions: [permission],
+      userId: 0,
+    });
+
+    expect(result.success).toBe(true);
+    expect(client.getAllCommands()).toContain(command);
   });
 
   test("resets all Android runtime permissions through pm reset-permissions", async () => {
@@ -104,6 +123,20 @@ describe("GrantAndroidPermissions", () => {
       },
     ]);
     expect(client.wasCommandExecuted("shell pm reset-permissions")).toBe(true);
+  });
+
+  test("rejects a whitespace-padded reset sentinel", async () => {
+    const factory = new FakeAdbClientFactory();
+    const client = factory.getFakeClient();
+    const action = new GrantAndroidPermissions(androidDevice, factory);
+    const result = await action.execute("com.example.app", {
+      action: "reset",
+      permissions: [" all "],
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.results[0].error).toContain("permissions=['all']");
+    expect(client.wasCommandExecuted("shell pm reset-permissions")).toBe(false);
   });
 
   test("rejects reset scopes other than permissions=['all']", async () => {
@@ -181,7 +214,7 @@ describe("GrantAndroidPermissions", () => {
     const factory = new FakeAdbClientFactory();
     const client = factory.getFakeClient();
     client.setCommandResult(
-      "shell pm grant --user 0 com.example.app android.permission.SEND_SMS",
+      "shell pm grant --user 0 'com.example.app' 'android.permission.SEND_SMS'",
       "",
       "java.lang.SecurityException: Permission denial"
     );

--- a/test/features/action/SetAndroidNotificationPolicyAccess.test.ts
+++ b/test/features/action/SetAndroidNotificationPolicyAccess.test.ts
@@ -13,20 +13,34 @@ describe("SetAndroidNotificationPolicyAccess", () => {
   test("allow_dnd on success", async () => {
     const factory = new FakeAdbClientFactory();
     const client = factory.getFakeClient();
-    client.setCommandResult("shell cmd notification allow_dnd com.example.app", "");
+    client.setCommandResult("shell cmd notification allow_dnd 'com.example.app'", "");
 
     const action = new SetAndroidNotificationPolicyAccess(androidDevice, factory);
     const result = await action.execute("com.example.app", { allowed: true });
 
     expect(result.success).toBe(true);
-    expect(client.wasCommandExecuted("shell cmd notification allow_dnd com.example.app")).toBe(true);
+    expect(client.wasCommandExecuted("shell cmd notification allow_dnd 'com.example.app'")).toBe(true);
+  });
+
+  test("quotes package names before passing them to the device shell", async () => {
+    const factory = new FakeAdbClientFactory();
+    const client = factory.getFakeClient();
+    const packageName = "com.example.app; id #";
+    const command = "shell cmd notification allow_dnd 'com.example.app; id #'";
+    client.setCommandResult(command, "");
+
+    const action = new SetAndroidNotificationPolicyAccess(androidDevice, factory);
+    const result = await action.execute(packageName, { allowed: true });
+
+    expect(result.success).toBe(true);
+    expect(client.getAllCommands()).toContain(command);
   });
 
   test("allow_dnd fails on SecurityException output", async () => {
     const factory = new FakeAdbClientFactory();
     const client = factory.getFakeClient();
     client.setCommandResult(
-      "shell cmd notification allow_dnd com.example.app",
+      "shell cmd notification allow_dnd 'com.example.app'",
       "",
       "java.lang.SecurityException: nope"
     );
@@ -42,7 +56,7 @@ describe("SetAndroidNotificationPolicyAccess", () => {
     const factory = new FakeAdbClientFactory();
     const client = factory.getFakeClient();
     client.setCommandResult(
-      "shell cmd notification disallow_dnd com.example.app",
+      "shell cmd notification disallow_dnd 'com.example.app'",
       "",
       "java.lang.SecurityException: ignored"
     );

--- a/test/features/action/SetAndroidScheduleExactAlarmAppOp.test.ts
+++ b/test/features/action/SetAndroidScheduleExactAlarmAppOp.test.ts
@@ -13,7 +13,7 @@ describe("SetAndroidScheduleExactAlarmAppOp", () => {
   test("allow runs appops allow", async () => {
     const factory = new FakeAdbClientFactory();
     const client = factory.getFakeClient();
-    client.setCommandResult("shell appops set --uid com.example.app SCHEDULE_EXACT_ALARM allow", "");
+    client.setCommandResult("shell appops set --uid 'com.example.app' SCHEDULE_EXACT_ALARM allow", "");
 
     const action = new SetAndroidScheduleExactAlarmAppOp(androidDevice, factory);
     const result = await action.execute("com.example.app", { mode: "allow" });
@@ -21,8 +21,22 @@ describe("SetAndroidScheduleExactAlarmAppOp", () => {
     expect(result.success).toBe(true);
     expect(result.skipped).toBeUndefined();
     expect(
-      client.wasCommandExecuted("shell appops set --uid com.example.app SCHEDULE_EXACT_ALARM allow")
+      client.wasCommandExecuted("shell appops set --uid 'com.example.app' SCHEDULE_EXACT_ALARM allow")
     ).toBe(true);
+  });
+
+  test("quotes package names before passing them to the device shell", async () => {
+    const factory = new FakeAdbClientFactory();
+    const client = factory.getFakeClient();
+    const packageName = "com.example.app; id #";
+    const command = "shell appops set --uid 'com.example.app; id #' SCHEDULE_EXACT_ALARM allow";
+    client.setCommandResult(command, "");
+
+    const action = new SetAndroidScheduleExactAlarmAppOp(androidDevice, factory);
+    const result = await action.execute(packageName, { mode: "allow" });
+
+    expect(result.success).toBe(true);
+    expect(client.getAllCommands()).toContain(command);
   });
 
   test("deny skipped below API 31", async () => {
@@ -43,7 +57,7 @@ describe("SetAndroidScheduleExactAlarmAppOp", () => {
     const factory = new FakeAdbClientFactory();
     const client = factory.getFakeClient();
     client.setCommandResult("shell getprop ro.build.version.sdk", "34\n");
-    client.setCommandResult("shell appops set --uid com.example.app SCHEDULE_EXACT_ALARM deny", "");
+    client.setCommandResult("shell appops set --uid 'com.example.app' SCHEDULE_EXACT_ALARM deny", "");
 
     const action = new SetAndroidScheduleExactAlarmAppOp(androidDevice, factory);
     const result = await action.execute("com.example.app", { mode: "deny" });
@@ -51,7 +65,7 @@ describe("SetAndroidScheduleExactAlarmAppOp", () => {
     expect(result.success).toBe(true);
     expect(result.skipped).toBeUndefined();
     expect(
-      client.wasCommandExecuted("shell appops set --uid com.example.app SCHEDULE_EXACT_ALARM deny")
+      client.wasCommandExecuted("shell appops set --uid 'com.example.app' SCHEDULE_EXACT_ALARM deny")
     ).toBe(true);
   });
 
@@ -59,7 +73,7 @@ describe("SetAndroidScheduleExactAlarmAppOp", () => {
     const factory = new FakeAdbClientFactory();
     const client = factory.getFakeClient();
     client.setCommandResult(
-      "shell appops set --uid com.example.app SCHEDULE_EXACT_ALARM allow",
+      "shell appops set --uid 'com.example.app' SCHEDULE_EXACT_ALARM allow",
       "",
       "Error: bad"
     );

--- a/test/features/utility/NotificationPolicy.test.ts
+++ b/test/features/utility/NotificationPolicy.test.ts
@@ -48,7 +48,7 @@ describe("NotificationPolicy", () => {
   test("sets Android notification policy access through cmd notification", async () => {
     const adbFactory = new FakeAdbClientFactory();
     const client = adbFactory.getFakeClient();
-    client.setCommandResult("shell cmd notification allow_dnd com.example.app", "");
+    client.setCommandResult("shell cmd notification allow_dnd 'com.example.app'", "");
 
     const notificationPolicy = new NotificationPolicy(androidDevice, { adbFactory });
     const result = await notificationPolicy.setPolicy("com.example.app", {
@@ -61,7 +61,7 @@ describe("NotificationPolicy", () => {
       allowed: true,
       method: "android_cmd_notification",
     });
-    expect(client.wasCommandExecuted("shell cmd notification allow_dnd com.example.app")).toBe(true);
+    expect(client.wasCommandExecuted("shell cmd notification allow_dnd 'com.example.app'")).toBe(true);
   });
 
   test("reports iOS notification policy as unsupported", async () => {

--- a/test/server/appTools.listApps.test.ts
+++ b/test/server/appTools.listApps.test.ts
@@ -147,6 +147,14 @@ describe("app permission tools", () => {
       permissions: ["android.permission.POST_NOTIFICATIONS"],
       userId: 10,
     })).not.toThrow();
+    expect(setAppTool!.schema.parse({
+      appId: " com.example.app ",
+      notificationsEnabled: false,
+    }).appId).toBe("com.example.app");
+    expect(() => setAppTool!.schema.parse({
+      appId: " ",
+      notificationsEnabled: false,
+    })).toThrow();
     expect(() => setAppTool!.schema.parse({
       appId: "com.example.app",
       action: "reset",
@@ -228,11 +236,17 @@ describe("app permission tools", () => {
     expect(validate({
       appId: "com.example.app",
       action: "reset",
+      permissions: [],
+      platform: "android",
+    })).toBe(false);
+    expect(validate({
+      appId: "com.example.app",
+      action: "reset",
       permissions: ["camera"],
       platform: "ios",
     })).toBe(true);
-    expect(setAppPermissions!.description).toContain("grant/revoke use userId");
-    expect(setAppPermissions.description).toContain("reset is device-wide ['all']");
-    expect(setAppPermissions.description).toContain("exclude POST_NOTIFICATIONS");
+    expect(setAppPermissions!.description).toContain("userId grant/revoke");
+    expect(setAppPermissions.description).toContain("device-wide reset ['all']");
+    expect(setAppPermissions.description).toContain("no POST_NOTIFICATIONS");
   });
 });

--- a/test/server/appTools.listApps.test.ts
+++ b/test/server/appTools.listApps.test.ts
@@ -169,6 +169,11 @@ describe("app permission tools", () => {
     expect(() => setAppTool!.schema.parse({
       appId: "com.example.app",
       action: "reset",
+      permissions: [],
+    })).toThrow();
+    expect(() => setAppTool!.schema.parse({
+      appId: "com.example.app",
+      action: "reset",
       permissions: ["camera"],
       platform: "android",
     })).toThrow();

--- a/test/server/appTools.listApps.test.ts
+++ b/test/server/appTools.listApps.test.ts
@@ -167,6 +167,12 @@ describe("app permission tools", () => {
     expect(() => setAppTool!.schema.parse({
       appId: "com.example.app",
       action: "reset",
+      permissions: [" all "],
+      platform: "android",
+    })).toThrow();
+    expect(() => setAppTool!.schema.parse({
+      appId: "com.example.app",
+      action: "reset",
       permissions: ["camera"],
       platform: "ios",
     })).not.toThrow();
@@ -225,5 +231,9 @@ describe("app permission tools", () => {
       permissions: ["camera"],
       platform: "ios",
     })).toBe(true);
+    expect(setAppPermissions!.inputSchema.properties?.action.description).toContain("Android reset");
+    expect(setAppPermissions.inputSchema.properties?.permissions.description).toContain("Android reset");
+    expect(setAppPermissions.inputSchema.properties?.userId.description).toContain("grant/revoke");
+    expect(setAppPermissions.inputSchema.properties?.notificationsEnabled.description).toContain("POST_NOTIFICATIONS");
   });
 });

--- a/test/server/appTools.listApps.test.ts
+++ b/test/server/appTools.listApps.test.ts
@@ -198,7 +198,7 @@ describe("app permission tools", () => {
     expect(ToolRegistry.getTool("getIosSimulatorPermissions")).toBeUndefined();
   });
 
-  test("advertises reset's required permission and device-wide user scope", () => {
+  test("advertises Android permission action scope", () => {
     const setAppPermissions = ToolRegistry.getToolDefinitions({ includeUnavailable: true })
       .find(tool => tool.name === "setAppPermissions");
     const validate = new Ajv2020({ strict: false }).compile(setAppPermissions!.inputSchema);
@@ -231,9 +231,8 @@ describe("app permission tools", () => {
       permissions: ["camera"],
       platform: "ios",
     })).toBe(true);
-    expect(setAppPermissions!.inputSchema.properties?.action.description).toContain("Android reset");
-    expect(setAppPermissions.inputSchema.properties?.permissions.description).toContain("Android reset");
-    expect(setAppPermissions.inputSchema.properties?.userId.description).toContain("grant/revoke");
-    expect(setAppPermissions.inputSchema.properties?.notificationsEnabled.description).toContain("POST_NOTIFICATIONS");
+    expect(setAppPermissions!.description).toContain("grant/revoke use userId");
+    expect(setAppPermissions.description).toContain("reset is device-wide ['all']");
+    expect(setAppPermissions.description).toContain("exclude POST_NOTIFICATIONS");
   });
 });


### PR DESCRIPTION
## Summary

- Quote all caller-controlled package and permission values in Android `setAppPermissions` device-shell commands.
- Normalize non-empty package IDs before Android permission operations, preserving prior whitespace handling after shell quoting.
- Publish the permission action, reset scope, user-targeting, and notification-state contract through a compact public tool description that stays within the MCP context budget.
- Require Android reset's documented exact non-empty `permissions: ["all"]` sentinel at the runtime and schema boundaries.

## Root Cause

[#4453](https://github.com/kaeawc/auto-mobile/pull/4453) added Android revoke, reset, and notification controls but left dynamic device-shell words unquoted and stripped the new field descriptions from the published schema.

## Validation

- `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-issue-4484-test bun test ...` (46 focused tests)
- `bun run benchmark-context` (`16,830 / 16,830` tool-context tokens)
- `bun run lint`
- `bun run typecheck`
- `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-issue-4484-validate bun run turbo:validate` (10,292 passed; 14 expected device/integration skips)

Closes [#4484](https://github.com/kaeawc/auto-mobile/issues/4484)
