### PR TITLE
fix(snapshot): guard parsePositiveNumber against rounding-to-zero

### DIFF
--- a/src/features/snapshot/DeviceSnapshotConfig.ts
+++ b/src/features/snapshot/DeviceSnapshotConfig.ts
@@ -43,7 +43,11 @@ function parsePositiveNumber(
     return fallback;
   }
 
-  return allowFloat ? parsed : Math.round(parsed);
+  // Apply rounding before the final positivity check: a positive input in
+  // (0, 0.5) rounds to 0 for integer fields, which would violate the
+  // positive-number contract and break idempotence (parse(parse(x)) !== parse(x)).
+  const result = allowFloat ? parsed : Math.round(parsed);
+  return result > 0 ? result : fallback;
 }
 
 function parseUserApps(value: string | undefined, fallback: "current" | "all"): "current" | "all" {

--- a/src/server/deviceSnapshotManager.ts
+++ b/src/server/deviceSnapshotManager.ts
@@ -448,7 +448,11 @@ export async function getDeviceSnapshotConfig(): Promise<DeviceSnapshotConfig> {
   const { configRepository } = await getDeviceSnapshotDependencies();
   const stored = await configRepository.getConfig();
   if (stored) {
-    return stored;
+    // Re-parse on read so configurations persisted by an older parser (which
+    // could round a (0, 0.5) timeout down to a non-positive 0) are normalized
+    // back to the fallback. parseDeviceSnapshotConfig is idempotent for valid
+    // values, so this is a no-op for configs written by the current parser.
+    return parseDeviceSnapshotConfig(stored);
   }
   return parseDeviceSnapshotConfig(serverConfig.getDeviceSnapshotDefaults());
 }

--- a/test/features/snapshot/DeviceSnapshotConfig.property.test.ts
+++ b/test/features/snapshot/DeviceSnapshotConfig.property.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import fc from "fast-check";
+import {
+  DEFAULT_DEVICE_SNAPSHOT_CONFIG,
+  parseDeviceSnapshotConfig,
+} from "../../../src/features/snapshot";
+
+// Property-based tests. See test/utils/Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+// Positive numeric inputs, deliberately including the (0, 0.5) zone that rounds
+// to 0 for the integer (allowFloat:false) fields. Before the fix this zone was
+// excluded because parsePositiveNumber checked positivity before rounding and
+// returned 0; the check now runs after rounding, so the zone is back in scope
+// and locks the regression.
+const positiveNumber = fc.oneof(
+  fc.double({ min: Number.EPSILON, max: 0.499_999, noNaN: true }),
+  fc.double({ min: 0.5, max: 1e9, noNaN: true }),
+  fc.integer({ min: 1, max: 1_000_000 })
+);
+
+describe("parseDeviceSnapshotConfig (property-based)", () => {
+  test("the (0, 0.5) rounding-to-zero repro no longer returns 0", () => {
+    expect(parseDeviceSnapshotConfig({ backupTimeoutMs: 0.3 }).backupTimeoutMs).toBe(
+      DEFAULT_DEVICE_SNAPSHOT_CONFIG.backupTimeoutMs
+    );
+    expect(parseDeviceSnapshotConfig({ vmSnapshotTimeoutMs: 0.3 }).vmSnapshotTimeoutMs).toBe(
+      DEFAULT_DEVICE_SNAPSHOT_CONFIG.vmSnapshotTimeoutMs
+    );
+  });
+
+  test("integer timeout fields are always positive integers for positive input", () => {
+    fc.assert(
+      fc.property(positiveNumber, positiveNumber, (backup, vm) => {
+        const config = parseDeviceSnapshotConfig({
+          backupTimeoutMs: backup,
+          vmSnapshotTimeoutMs: vm,
+        });
+        return (
+          Number.isInteger(config.backupTimeoutMs) &&
+          config.backupTimeoutMs > 0 &&
+          Number.isInteger(config.vmSnapshotTimeoutMs) &&
+          config.vmSnapshotTimeoutMs > 0
+        );
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("maxArchiveSizeMb stays positive for positive input", () => {
+    fc.assert(
+      fc.property(positiveNumber, size => {
+        return parseDeviceSnapshotConfig({ maxArchiveSizeMb: size }).maxArchiveSizeMb > 0;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("parsing is idempotent: parse(parse(x)) === parse(x)", () => {
+    fc.assert(
+      fc.property(positiveNumber, positiveNumber, positiveNumber, (backup, vm, size) => {
+        const once = parseDeviceSnapshotConfig({
+          backupTimeoutMs: backup,
+          vmSnapshotTimeoutMs: vm,
+          maxArchiveSizeMb: size,
+        });
+        const twice = parseDeviceSnapshotConfig(once);
+        return (
+          twice.backupTimeoutMs === once.backupTimeoutMs &&
+          twice.vmSnapshotTimeoutMs === once.vmSnapshotTimeoutMs &&
+          twice.maxArchiveSizeMb === once.maxArchiveSizeMb
+        );
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("non-positive and non-finite inputs fall back to defaults", () => {
+    const nonPositive = fc.oneof(
+      fc.double({ min: -1e9, max: 0, noNaN: true }),
+      fc.constantFrom(NaN, Infinity, -Infinity)
+    );
+    fc.assert(
+      fc.property(nonPositive, value => {
+        const config = parseDeviceSnapshotConfig({
+          backupTimeoutMs: value,
+          vmSnapshotTimeoutMs: value,
+          maxArchiveSizeMb: value,
+        });
+        return (
+          config.backupTimeoutMs === DEFAULT_DEVICE_SNAPSHOT_CONFIG.backupTimeoutMs &&
+          config.vmSnapshotTimeoutMs === DEFAULT_DEVICE_SNAPSHOT_CONFIG.vmSnapshotTimeoutMs &&
+          config.maxArchiveSizeMb === DEFAULT_DEVICE_SNAPSHOT_CONFIG.maxArchiveSizeMb
+        );
+      }),
+      RUN_OPTIONS
+    );
+  });
+});

--- a/test/server/deviceSnapshotManager.test.ts
+++ b/test/server/deviceSnapshotManager.test.ts
@@ -5,6 +5,7 @@ import * as os from "os";
 import type { BootedDevice, DeviceSnapshotConfig, DeviceSnapshotManifest } from "../../src/models";
 import {
   captureDeviceSnapshot,
+  getDeviceSnapshotConfig,
   listDeviceSnapshots,
   resetDeviceSnapshotManagerDependencies,
   restoreDeviceSnapshot,
@@ -314,5 +315,28 @@ describe("deviceSnapshotManager", () => {
     } finally {
       await fs.rm(tempRoot, { recursive: true, force: true });
     }
+  });
+
+  test("getDeviceSnapshotConfig normalizes a legacy zero timeout persisted by the old parser", async () => {
+    // Simulate a config written by the pre-fix parser, which could round a
+    // (0, 0.5) timeout down to a non-positive 0.
+    const legacyConfig: DeviceSnapshotConfig = {
+      includeAppData: true,
+      includeSettings: true,
+      useVmSnapshot: true,
+      strictBackupMode: false,
+      backupTimeoutMs: 0,
+      userApps: "current",
+      vmSnapshotTimeoutMs: 0,
+      maxArchiveSizeMb: 100,
+    };
+    await configRepository.setConfig(legacyConfig);
+
+    const config = await getDeviceSnapshotConfig();
+
+    expect(config.backupTimeoutMs).toBeGreaterThan(0);
+    expect(config.vmSnapshotTimeoutMs).toBeGreaterThan(0);
+    expect(config.backupTimeoutMs).toBe(30000);
+    expect(config.vmSnapshotTimeoutMs).toBe(30000);
   });
 });


### PR DESCRIPTION
## What

`parsePositiveNumber` in `src/features/snapshot/DeviceSnapshotConfig.ts` applied its positivity guard (`parsed <= 0`) **before** `Math.round(parsed)` for the integer (`allowFloat:false`) fields. A positive input in the interval `(0, 0.5)` passed the guard and then rounded to `0`.

```ts
parseDeviceSnapshotConfig({ backupTimeoutMs: 0.3 }).backupTimeoutMs // => 0  (before)
```

The fix rounds first, then checks positivity:

```ts
const result = allowFloat ? parsed : Math.round(parsed);
return result > 0 ? result : fallback;
```

## Why

The two `allowFloat:false` fields (`backupTimeoutMs`, `vmSnapshotTimeoutMs`) could return `0` — a non-positive "timeout" that violates the `parsePositiveNumber` contract and could mean an immediate 0ms timeout downstream. It also broke idempotence: re-parsing that `0` yields the fallback, so `parse(parse(x)) !== parse(x)`. `maxArchiveSizeMb` (`allowFloat:true`) was unaffected since it is never rounded.

## Tests

Adds a property suite at `test/features/snapshot/DeviceSnapshotConfig.property.test.ts` whose numeric generator deliberately spans the `(0, 0.5)` rounding zone, covering:

- the exact `{ backupTimeoutMs: 0.3 }` → fallback repro,
- integer timeout fields always positive integers for positive input,
- idempotence `parse(parse(x)) === parse(x)`,
- non-positive / non-finite inputs → defaults.

Verified the suite genuinely gates the regression: reverting the fix fails 3 of its 5 tests.

## Validation

- `bun test test/features/snapshot/DeviceSnapshotConfig.property.test.ts` — 5 pass
- `bun run typecheck` — no new errors
- `bun run lint` — all boundary gates pass

## Reviewer notes

The referenced property suite did not exist in this branch (PR [#4477](https://github.com/kaeawc/auto-mobile/pull/4477) is not merged here), so it is created new rather than extended.
