### PR TITLE
test(server): property-based tests for internal tool-call helpers

### DIFF
--- a/test/server/internalToolCall.property.test.ts
+++ b/test/server/internalToolCall.property.test.ts
@@ -1,0 +1,73 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import { INTERNAL_NO_DIFF_PARAM, markInternalToolCall } from "../../src/server/internalToolCall";
+
+// Property-based tests. See test/utils/Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+const args = fc.dictionary(fc.string({ maxLength: 6 }), fc.jsonValue(), { maxKeys: 5 }) as fc.Arbitrary<Record<string, unknown>>;
+
+describe("markInternalToolCall (property-based)", () => {
+  test("returns a new object carrying the marker set to true", () => {
+    fc.assert(
+      fc.property(args, a => {
+        const marked = markInternalToolCall(a);
+        return marked !== a && marked[INTERNAL_NO_DIFF_PARAM] === true;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("never mutates the input", () => {
+    fc.assert(
+      fc.property(args, a => {
+        const before = JSON.stringify(a);
+        markInternalToolCall(a);
+        return JSON.stringify(a) === before;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("preserves every original entry except the marker, which it forces true", () => {
+    fc.assert(
+      fc.property(args, a => {
+        const marked = markInternalToolCall(a);
+        const preserved = Object.keys(a).every(k => k === INTERNAL_NO_DIFF_PARAM || marked[k] === a[k]);
+        return preserved && marked[INTERNAL_NO_DIFF_PARAM] === true;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("adds exactly the marker key to the key set", () => {
+    fc.assert(
+      fc.property(args, a => {
+        const marked = markInternalToolCall(a);
+        const expected = new Set([...Object.keys(a), INTERNAL_NO_DIFF_PARAM]);
+        const actual = new Set(Object.keys(marked));
+        return actual.size === expected.size && [...actual].every(k => expected.has(k));
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("overrides a pre-existing marker value to true", () => {
+    fc.assert(
+      fc.property(args, fc.oneof(fc.boolean(), fc.string(), fc.integer()), (a, existing) => {
+        return markInternalToolCall({ ...a, [INTERNAL_NO_DIFF_PARAM]: existing })[INTERNAL_NO_DIFF_PARAM] === true;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("is idempotent", () => {
+    fc.assert(
+      fc.property(args, a => {
+        const once = markInternalToolCall(a);
+        return JSON.stringify(markInternalToolCall(once)) === JSON.stringify(once);
+      }),
+      RUN_OPTIONS
+    );
+  });
+});

--- a/test/server/internalToolPayloads.property.test.ts
+++ b/test/server/internalToolPayloads.property.test.ts
@@ -1,0 +1,61 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import { narrowInternalToolEnvelope } from "../../src/server/internalToolPayloads";
+
+// Property-based tests. See test/utils/Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+const name = fc.constantFrom("swipeOn", "observe");
+const objectPayload = fc.dictionary(fc.string({ maxLength: 6 }), fc.jsonValue(), { maxKeys: 4 });
+// Envelopes: some carry a valid object structuredContent, some do not.
+const envelope = fc.oneof(
+  fc.record({ structuredContent: objectPayload }),
+  fc.record({ structuredContent: fc.oneof(fc.constant(null), fc.string(), fc.integer()) }),
+  fc.record({ other: fc.string() }),
+  fc.constant(null),
+  fc.constant(undefined),
+  fc.string(),
+  fc.integer(),
+  fc.boolean()
+);
+
+describe("narrowInternalToolEnvelope (property-based)", () => {
+  test("is total — returns undefined or an object, never throwing", () => {
+    fc.assert(
+      fc.property(name, envelope, (n, response) => {
+        const r = narrowInternalToolEnvelope(n, response);
+        return r === undefined || typeof r === "object";
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("returns the same envelope by identity iff structuredContent is an object", () => {
+    fc.assert(
+      fc.property(name, envelope, (n, response) => {
+        const sc = (response as { structuredContent?: unknown } | null | undefined)?.structuredContent;
+        const valid = !!response && typeof response === "object" && !!sc && typeof sc === "object";
+        const r = narrowInternalToolEnvelope(n, response);
+        return valid ? r === response : r === undefined;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("null/non-object responses always narrow to undefined", () => {
+    const nonObject = fc.oneof(fc.constant(null), fc.constant(undefined), fc.string(), fc.integer(), fc.boolean());
+    fc.assert(
+      fc.property(name, nonObject, (n, response) => narrowInternalToolEnvelope(n, response) === undefined),
+      RUN_OPTIONS
+    );
+  });
+
+  test("the result is independent of the tool name", () => {
+    fc.assert(
+      fc.property(envelope, response =>
+        narrowInternalToolEnvelope("swipeOn", response) === narrowInternalToolEnvelope("observe", response)
+      ),
+      RUN_OPTIONS
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Continues the fast-check property-testing expansion (pattern from [PR #4427](https://github.com/kaeawc/auto-mobile/pull/4427)) with two pure internal tool-call helpers. Test-only, additive — no production changes, no new dependencies.

Invariants asserted:

- **`markInternalToolCall`** (`src/server/internalToolCall.ts`, [issue #3053](https://github.com/kaeawc/auto-mobile/issues/3053)) — returns a **new** object carrying the marker set to `true`; **never mutates the input** (the non-mutation contract that keeps shared nav-graph edge args untainted); preserves every original entry except the marker, which it forces `true`; adds **exactly** the marker key; overrides a pre-existing marker value to `true`; idempotent.
- **`narrowInternalToolEnvelope`** (`src/server/internalToolPayloads.ts`, [issue #3222](https://github.com/kaeawc/auto-mobile/issues/3222)) — total (`undefined` or an object, never throws); returns the same envelope **by identity iff** `structuredContent` is an object; null/non-object responses narrow to `undefined`; the result is **independent of the tool name** (the name selects only the compile-time payload type).

No defects surfaced.

## Validation

- [x] `bun test test/server/internalToolCall.property.test.ts test/server/internalToolPayloads.property.test.ts` — 10 pass, ~190ms
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run lint` — no new violations
- [x] New tests are pure (no device/network/filesystem/DB); each runs in <100ms

## Note

Commit is **unsigned** — the local 1Password SSH signing agent is erroring (environment issue); pushed over HTTPS. The repo does not enforce signed commits.

## Follow-ups

- [ ] Unrelated: `main`'s typecheck baseline has drifted (3 baselined errors no longer occur) — worth a standalone `bun run typecheck:update` ratchet.
