### PR TITLE
test(cmdline): property-based tests for process-gone and shell-failure classifiers

### DIFF
--- a/test/utils/android-cmdline-tools/shellOutputHeuristics.property.test.ts
+++ b/test/utils/android-cmdline-tools/shellOutputHeuristics.property.test.ts
@@ -1,0 +1,59 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import { outputLooksLikeShellFailure } from "../../../src/utils/android-cmdline-tools/shellOutputHeuristics";
+
+// Property-based tests. See test/utils/Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+// Independent oracle mirroring the module's heuristic.
+const oracle = (stdout: string, stderr: string): boolean => {
+  const combined = `${stdout}\n${stderr}`.trim();
+  return combined ? /exception|error:/i.test(combined) : false;
+};
+
+const text = fc.string({ maxLength: 24 });
+const whitespace = fc.string({ unit: fc.constantFrom(" ", "\t", "\n"), maxLength: 4 });
+const failureMarker = fc.constantFrom("Exception", "exception", "NullPointerException", "error:", "ERROR:");
+const benign = fc.constantFrom("Success", "OK", "done", "error occurred", "no errors found", "warning: low battery", "Broadcast completed");
+
+describe("outputLooksLikeShellFailure (property-based)", () => {
+  test("is total (a boolean) for arbitrary output", () => {
+    fc.assert(
+      fc.property(text, text, (o, e) => typeof outputLooksLikeShellFailure(o, e) === "boolean"),
+      RUN_OPTIONS
+    );
+  });
+
+  test("agrees with the exception|error: heuristic oracle", () => {
+    fc.assert(
+      fc.property(text, text, (o, e) => outputLooksLikeShellFailure(o, e) === oracle(o, e)),
+      RUN_OPTIONS
+    );
+  });
+
+  test("whitespace-only (or empty) output is never a failure", () => {
+    fc.assert(
+      fc.property(whitespace, whitespace, (o, e) => outputLooksLikeShellFailure(o, e) === false),
+      RUN_OPTIONS
+    );
+  });
+
+  test("a failure marker in either stream flags failure (symmetric)", () => {
+    fc.assert(
+      fc.property(failureMarker, text, (marker, other) => {
+        return (
+          outputLooksLikeShellFailure(`${other}${marker}`, "") &&
+          outputLooksLikeShellFailure("", `${other}${marker}`)
+        );
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("benign output (including a plain 'error' without a colon) is not a failure", () => {
+    fc.assert(
+      fc.property(benign, benign, (o, e) => outputLooksLikeShellFailure(o, e) === false),
+      RUN_OPTIONS
+    );
+  });
+});

--- a/test/utils/ios-cmdline-tools/iosProcessErrors.property.test.ts
+++ b/test/utils/ios-cmdline-tools/iosProcessErrors.property.test.ts
@@ -1,0 +1,64 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import { isProcessAlreadyGoneError } from "../../../src/utils/ios-cmdline-tools/iosProcessErrors";
+
+// Property-based tests. See test/utils/Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+const positivePhrase = fc.constantFrom(
+  "no such process",
+  "found nothing to terminate",
+  "process not running",
+  "process is not running"
+);
+// Realistic messages that must NOT match — device-scoped "not running", unrelated
+// failures, and the devicectl ESRCH code (OR-ed in at the call site, not here).
+const nonMatching = fc.constantFrom(
+  "The device is not connected",
+  "Unable to launch: device locked",
+  "Permission denied",
+  "Device not running",
+  "CoreDevice not running",
+  "Operation timed out",
+  "An error occurred",
+  "NSPOSIXErrorDomain error 3"
+);
+const mixedCase = (w: string): fc.Arbitrary<string> =>
+  fc.array(fc.boolean(), { minLength: w.length, maxLength: w.length })
+    .map(bits => w.split("").map((ch, i) => (bits[i] ? ch.toUpperCase() : ch)).join(""));
+const filler = fc.string({ maxLength: 12 });
+
+describe("isProcessAlreadyGoneError (property-based)", () => {
+  test("is total (a boolean) for any string", () => {
+    fc.assert(
+      fc.property(fc.string(), m => typeof isProcessAlreadyGoneError(m) === "boolean"),
+      RUN_OPTIONS
+    );
+  });
+
+  test("is case-insensitive", () => {
+    fc.assert(
+      fc.property(fc.string({ maxLength: 40 }), m =>
+        isProcessAlreadyGoneError(m) === isProcessAlreadyGoneError(m.toUpperCase()) &&
+        isProcessAlreadyGoneError(m) === isProcessAlreadyGoneError(m.toLowerCase())
+      ),
+      RUN_OPTIONS
+    );
+  });
+
+  test("matches any message containing a shared process-gone phrase (any casing)", () => {
+    fc.assert(
+      fc.property(positivePhrase.chain(mixedCase), filler, filler, (phrase, pre, post) =>
+        isProcessAlreadyGoneError(`${pre}${phrase}${post}`)
+      ),
+      RUN_OPTIONS
+    );
+  });
+
+  test("does not match device-scoped or unrelated failures", () => {
+    fc.assert(
+      fc.property(nonMatching, m => isProcessAlreadyGoneError(m) === false),
+      RUN_OPTIONS
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Continues the fast-check property-testing expansion (pattern from [PR #4427](https://github.com/kaeawc/auto-mobile/pull/4427)) with two pure cmdline-output classifiers. Test-only, additive — no production changes, no new dependencies.

Invariants asserted:

- **`isProcessAlreadyGoneError`** (`src/utils/ios-cmdline-tools/iosProcessErrors.ts`, [issue #3076](https://github.com/kaeawc/auto-mobile/issues/3076)) — total; case-insensitive; matches any message containing a shared process-gone phrase (`no such process`, `found nothing to terminate`, `process (is) not running`) in **any casing**; and — the key discriminator the docstring insists on — **does NOT match** device-scoped `not running` or unrelated failures (`device locked`, `permission denied`, `not connected`, and the devicectl `NSPOSIXErrorDomain error 3` ESRCH code that is OR-ed in at the call site, not here). This locks the "deliberately narrow" contract that keeps a disconnected device from masquerading as a terminated app.
- **`outputLooksLikeShellFailure`** (`src/utils/android-cmdline-tools/shellOutputHeuristics.ts`) — total; agrees with the `exception|error:` heuristic oracle; whitespace-only/empty output is **never** a failure; a failure marker in **either** stream flags failure (symmetric); benign output — including a plain `error` **without** a colon — is not a failure.

No defects surfaced.

## Validation

- [x] `bun test test/utils/ios-cmdline-tools/iosProcessErrors.property.test.ts test/utils/android-cmdline-tools/shellOutputHeuristics.property.test.ts` — 9 pass, ~190ms
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run lint` — no new violations
- [x] New tests are pure (no device/network/filesystem/DB); each runs in <100ms

## Note

Commit is **unsigned** — the local 1Password SSH signing agent is erroring (environment issue); pushed over HTTPS. The repo does not enforce signed commits.

## Follow-ups

- [ ] `features/action/androidPreTapStablePolicy` (sibling → strict stable-match count) remains a small pure candidate.
- [ ] Unrelated: `main`'s typecheck baseline has drifted (3 baselined errors no longer occur) — worth a standalone `bun run typecheck:update` ratchet.
