### PR TITLE
test(observe): property-based tests for observe-error accumulation

### DIFF
--- a/test/features/observe/ObserveError.property.test.ts
+++ b/test/features/observe/ObserveError.property.test.ts
@@ -1,0 +1,79 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import type { ObserveResult } from "../../../src/models";
+import { appendObserveError, type ObserveError, type ObservePhase } from "../../../src/features/observe/ObserveError";
+
+// Property-based tests. See test/utils/Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+const PHASES: ObservePhase[] = [
+  "screenSize", "systemInsets", "rotation", "wakefulness", "backStack", "viewHierarchy",
+  "rawViewHierarchy", "intentChooser", "activeWindow", "screenshot", "performanceAudit",
+  "accessibilityAudit", "accessibilityState", "predictiveUI", "cache", "critical"
+];
+const observeError: fc.Arbitrary<ObserveError> = fc.record(
+  { phase: fc.constantFrom(...PHASES), message: fc.string({ maxLength: 20 }), cause: fc.option(fc.string({ maxLength: 8 }), { nil: undefined }) },
+  { requiredKeys: ["phase", "message"] }
+);
+// A non-empty legacy `error` string (the `if (result.error)` migration is truthy-gated), or none.
+const legacy = fc.option(fc.string({ minLength: 1, maxLength: 12 }), { nil: undefined });
+const errors = fc.array(observeError, { minLength: 1, maxLength: 6 });
+
+const freshResult = (legacyError: string | undefined): ObserveResult =>
+  (legacyError !== undefined ? { error: legacyError } : {}) as ObserveResult;
+
+describe("appendObserveError (property-based)", () => {
+  test("result.error is always the '; '-join of every accumulated message", () => {
+    fc.assert(
+      fc.property(legacy, errors, (legacyError, errs) => {
+        const result = freshResult(legacyError);
+        errs.forEach(e => appendObserveError(result, e));
+        return result.error === result.errors!.map(e => e.message).join("; ");
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("the appended errors are exactly the (migrated legacy, then each err) sequence", () => {
+    fc.assert(
+      fc.property(legacy, errors, (legacyError, errs) => {
+        const result = freshResult(legacyError);
+        errs.forEach(e => appendObserveError(result, e));
+        const expected = (legacyError !== undefined ? [legacyError] : []).concat(errs.map(e => e.message));
+        return (
+          result.errors!.length === expected.length &&
+          result.errors!.every((e, i) => e.message === expected[i])
+        );
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("a pre-existing legacy error string is migrated once, as a leading 'critical' entry", () => {
+    fc.assert(
+      fc.property(fc.string({ minLength: 1, maxLength: 12 }), errors, (legacyError, errs) => {
+        const result = freshResult(legacyError);
+        errs.forEach(e => appendObserveError(result, e));
+        const first = result.errors![0];
+        // Only one migrated entry, at the front, and never re-migrated on later appends.
+        const onlyOneCritical = result.errors!.filter(e => e.phase === "critical" && e.message === legacyError).length >= 1;
+        return first.phase === "critical" && first.message === legacyError && onlyOneCritical &&
+          result.errors!.length === errs.length + 1;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("the errors array grows by exactly one per append (monotonic accumulation)", () => {
+    fc.assert(
+      fc.property(errors, errs => {
+        const result = freshResult(undefined);
+        return errs.every((e, i) => {
+          appendObserveError(result, e);
+          return result.errors!.length === i + 1 && result.errors![i] === e;
+        });
+      }),
+      RUN_OPTIONS
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Continues the fast-check property-testing expansion (pattern from [PR #4427](https://github.com/kaeawc/auto-mobile/pull/4427)) with `appendObserveError` in `src/features/observe/ObserveError.ts` — the accumulator that collects per-phase `observe` failures and keeps the derived `error` string in sync. Test-only, additive — no production changes, no new dependencies.

Invariants asserted (a sequence of phase errors is appended to a fresh result, optionally seeded with a legacy `error` string):

- `result.error` is **always** the `"; "`-join of every accumulated message.
- The appended errors are **exactly** the `(migrated legacy, then each err)` sequence, in order.
- A pre-existing legacy `error` string is **migrated once** as a leading `"critical"` entry and **never re-migrated** on later appends (the guard that keeps the derived `error` concatenating instead of overwriting).
- The errors array grows by **exactly one** per append and each appended error lands at its index (monotonic accumulation).

`appendObserveError` mutates its `result` argument but performs no I/O and is fully deterministic, so it is exercised against a fresh in-memory result per case. No defects surfaced.

## Validation

- [x] `bun test test/features/observe/ObserveError.property.test.ts` — 4 pass, ~145ms
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run lint` — no new violations
- [x] New tests are pure (no device/network/filesystem/DB); each runs in <100ms

## Note

Commit is **unsigned** — the local 1Password SSH signing agent is erroring (environment issue); pushed over HTTPS. The repo does not enforce signed commits.

## Follow-ups

- [ ] `features/action/androidPreTapStablePolicy` (sibling → strict stable-match count) remains a small pure candidate.
- [ ] Unrelated: `main`'s typecheck baseline has drifted (3 baselined errors no longer occur) — worth a standalone `bun run typecheck:update` ratchet.
