### PR TITLE
test: property-based tests for image-backend dispatch and pre-tap policy

### DIFF
--- a/test/features/action/androidPreTapStablePolicy.property.test.ts
+++ b/test/features/action/androidPreTapStablePolicy.property.test.ts
@@ -1,0 +1,44 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import type { TapOnElementOptions } from "../../../src/models/TapOnElementOptions";
+import {
+  ANDROID_PRE_TAP_STABLE_MATCHES_STRICT,
+  androidPreTapConsecutiveStableMatchesRequired
+} from "../../../src/features/action/androidPreTapStablePolicy";
+
+// Property-based tests. See test/utils/Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+const sibling = fc.constantFrom<boolean | undefined>(true, false, undefined);
+const optionsOf = (s: boolean | undefined): TapOnElementOptions => ({ sibling: s }) as unknown as TapOnElementOptions;
+
+describe("androidPreTapConsecutiveStableMatchesRequired (property-based)", () => {
+  test("returns only 1 or the strict count", () => {
+    fc.assert(
+      fc.property(sibling, s => {
+        const n = androidPreTapConsecutiveStableMatchesRequired(optionsOf(s));
+        return n === 1 || n === ANDROID_PRE_TAP_STABLE_MATCHES_STRICT;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("requires the strict count iff sibling is exactly true", () => {
+    fc.assert(
+      fc.property(sibling, s => {
+        const n = androidPreTapConsecutiveStableMatchesRequired(optionsOf(s));
+        return n === (s === true ? ANDROID_PRE_TAP_STABLE_MATCHES_STRICT : 1);
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("a non-sibling tap (false or absent) requires a single stable match", () => {
+    fc.assert(
+      fc.property(fc.constantFrom<boolean | undefined>(false, undefined), s =>
+        androidPreTapConsecutiveStableMatchesRequired(optionsOf(s)) === 1
+      ),
+      RUN_OPTIONS
+    );
+  });
+});

--- a/test/utils/image/backend/resolveImageBackend.property.test.ts
+++ b/test/utils/image/backend/resolveImageBackend.property.test.ts
@@ -1,0 +1,63 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import { resolveImageBackend } from "../../../../src/utils/image/backend/resolveImageBackend";
+import { JimpBackend } from "../../../../src/utils/image/backend/JimpBackend";
+import { JimpCliBackend } from "../../../../src/utils/image/backend/JimpCliBackend";
+import { SharpBackend } from "../../../../src/utils/image/backend/SharpBackend";
+
+// Property-based tests. See test/utils/Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+const KNOWN_PLATFORMS: NodeJS.Platform[] = [
+  "aix", "android", "darwin", "freebsd", "haiku", "linux", "openbsd", "sunos", "win32", "cygwin", "netbsd"
+];
+const knownPlatform = fc.constantFrom(...KNOWN_PLATFORMS);
+const nonPrimary = fc.constantFrom(...KNOWN_PLATFORMS.filter(p => p !== "win32" && p !== "darwin" && p !== "linux"));
+
+describe("resolveImageBackend (property-based)", () => {
+  test("dispatches each platform to the documented backend", () => {
+    fc.assert(
+      fc.property(knownPlatform, platform => {
+        const backend = resolveImageBackend({ platform });
+        if (platform === "win32") {
+          return backend instanceof JimpCliBackend;
+        }
+        if (platform === "darwin" || platform === "linux") {
+          return backend instanceof SharpBackend;
+        }
+        return backend instanceof JimpBackend;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("is total — returns an ImageBackend object for any platform string, never throwing", () => {
+    fc.assert(
+      fc.property(fc.string({ maxLength: 10 }), s => {
+        const backend = resolveImageBackend({ platform: s as NodeJS.Platform });
+        return backend !== null && typeof backend === "object";
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("every non-primary platform falls back to the jimp backend", () => {
+    fc.assert(
+      fc.property(fc.oneof(nonPrimary, fc.string({ maxLength: 8 }).map(s => `${s}x` as NodeJS.Platform)), platform => {
+        return resolveImageBackend({ platform }) instanceof JimpBackend;
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("is deterministic — the same platform resolves to the same backend class", () => {
+    fc.assert(
+      fc.property(knownPlatform, platform => {
+        const a = resolveImageBackend({ platform });
+        const b = resolveImageBackend({ platform });
+        return a.constructor === b.constructor;
+      }),
+      RUN_OPTIONS
+    );
+  });
+});

--- a/test/utils/image/backend/resolveImageBackend.property.test.ts
+++ b/test/utils/image/backend/resolveImageBackend.property.test.ts
@@ -35,7 +35,9 @@ describe("resolveImageBackend (property-based)", () => {
     fc.assert(
       fc.property(fc.string({ maxLength: 10 }), s => {
         const backend = resolveImageBackend({ platform: s as NodeJS.Platform });
-        return backend !== null && typeof backend === "object";
+        // The property completing without throwing IS the totality check; the
+        // return type is non-nullable, so assert only that it is an object.
+        return typeof backend === "object";
       }),
       RUN_OPTIONS
     );


### PR DESCRIPTION
## Summary

Continues the fast-check property-testing expansion (pattern from [PR #4427](https://github.com/kaeawc/auto-mobile/pull/4427)) with two pure dispatch/policy helpers. Test-only, additive — no production changes, no new dependencies. The image-backend selector takes an **injected** `platform`, so the tests carry no OS dependency.

Invariants asserted:

- **`resolveImageBackend`** (`src/utils/image/backend/resolveImageBackend.ts`) — dispatches each platform to the documented backend (`win32` → `JimpCliBackend`, `darwin`/`linux` → `SharpBackend`, everything else → `JimpBackend`); **total** (returns an `ImageBackend` object for any platform string, never throws); every **non-primary** platform falls back to the jimp backend; **deterministic** (same platform → same backend class). Backends use lazy `loadJimp`/`loadSharp` loaders, so construction is I/O-free.
- **`androidPreTapConsecutiveStableMatchesRequired`** (`src/features/action/androidPreTapStablePolicy.ts`) — returns **only** `1` or the strict count; requires the strict count **iff** `sibling` is exactly `true`; a non-sibling tap (`false` or absent) requires a single stable match.

No defects surfaced.

## Validation

- [x] `bun test test/utils/image/backend/resolveImageBackend.property.test.ts test/features/action/androidPreTapStablePolicy.property.test.ts` — 7 pass, ~130ms
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run lint` — no new violations
- [x] New tests are pure (no device/network/filesystem/DB); each runs in <100ms

## Note

Commit is **unsigned** — the local 1Password SSH signing agent is erroring (environment issue); pushed over HTTPS. The repo does not enforce signed commits.

## Follow-ups

- [ ] `main`'s typecheck baseline continues to drift (now 206 known vs the committed 211 — 5 baselined errors no longer occur) — a standalone `bun run typecheck:update` ratchet is increasingly worth doing.
