### PR TITLE
test(navigation): burn down 22 verified test-quality findings (#4171)

### DIFF
--- a/src/features/navigation/ScreenFingerprint.ts
+++ b/src/features/navigation/ScreenFingerprint.ts
@@ -152,7 +152,7 @@ export class ScreenFingerprint {
       options?.cachedNavigationId &&
       options?.cachedNavigationIdTimestamp
     ) {
-      const cacheTTL = options.cacheTTL || DEFAULT_CACHE_TTL;
+      const cacheTTL = options.cacheTTL ?? DEFAULT_CACHE_TTL;
       const cacheAge = hierarchy.updatedAt - options.cachedNavigationIdTimestamp;
 
       if (cacheAge < cacheTTL) {

--- a/test/fakes/FakeNavigationGraphManager.test.ts
+++ b/test/fakes/FakeNavigationGraphManager.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { FakeNavigationGraphManager } from "./FakeNavigationGraphManager";
+
+/**
+ * The real NavigationGraphManager supports multiple graph-update listeners and
+ * clears them all on null. The fake must mirror that fan-out so consumers wired
+ * against it observe the same notification fidelity (issue #4171).
+ */
+describe("FakeNavigationGraphManager graph-update listeners", () => {
+  test("notifies every registered listener on a graph update", () => {
+    const fake = new FakeNavigationGraphManager();
+    const calls: string[] = [];
+    fake.setGraphUpdateListener(() => calls.push("first"));
+    fake.setGraphUpdateListener(() => calls.push("second"));
+
+    fake.setCurrentApp("com.test.app");
+
+    expect(calls.sort()).toEqual(["first", "second"]);
+  });
+
+  test("clears all listeners when set to null", () => {
+    const fake = new FakeNavigationGraphManager();
+    const calls: string[] = [];
+    fake.setGraphUpdateListener(() => calls.push("first"));
+    fake.setGraphUpdateListener(null);
+
+    fake.setCurrentApp("com.test.app");
+
+    expect(calls).toEqual([]);
+  });
+});

--- a/test/fakes/FakeNavigationGraphManager.ts
+++ b/test/fakes/FakeNavigationGraphManager.ts
@@ -32,7 +32,7 @@ export class FakeNavigationGraphManager implements NavigationGraph, NavigationGr
   private edgeSummaries: NavigationGraphSummaryEdge[] = [];
   private nextNodeId = 1;
   private nextEdgeId = 1;
-  private graphUpdateListener?: () => void;
+  private graphUpdateListeners: Array<() => void> = [];
 
   // Call tracking
   private methodCalls: Map<string, any[][]> = new Map();
@@ -143,7 +143,7 @@ export class FakeNavigationGraphManager implements NavigationGraph, NavigationGr
     this.edgeSummaries = [];
     this.nextNodeId = 1;
     this.nextEdgeId = 1;
-    this.graphUpdateListener = undefined;
+    this.graphUpdateListeners = [];
     this.pathResult = null;
     this.methodCalls.clear();
   }
@@ -366,12 +366,16 @@ export class FakeNavigationGraphManager implements NavigationGraph, NavigationGr
   }
 
   setGraphUpdateListener(listener: (() => void) | null): void {
-    this.graphUpdateListener = listener ?? undefined;
+    if (listener === null) {
+      this.graphUpdateListeners = [];
+    } else {
+      this.graphUpdateListeners.push(listener);
+    }
   }
 
   private emitGraphUpdated(): void {
-    if (this.graphUpdateListener) {
-      this.graphUpdateListener();
+    for (const listener of this.graphUpdateListeners) {
+      listener();
     }
   }
 

--- a/test/features/navigation/DefaultPathOptimizer.test.ts
+++ b/test/features/navigation/DefaultPathOptimizer.test.ts
@@ -1,0 +1,279 @@
+import { expect, describe, test } from "bun:test";
+import { DefaultPathOptimizer } from "../../../src/features/navigation/DefaultPathOptimizer";
+import { NavigationGraphManager } from "../../../src/features/navigation/NavigationGraphManager";
+import type {
+  NavigationNode,
+  NavigationEdge,
+  PathResult,
+} from "../../../src/utils/interfaces/NavigationGraph";
+
+/**
+ * DefaultPathOptimizer only depends on two NavigationGraphManager methods:
+ * getNode(screen) and findPath(target). We inject a narrow stub exposing exactly
+ * those so the back-button heuristic is exercised in isolation without touching a
+ * real graph/DB (issue #3067) and with fully deterministic node/path fixtures.
+ */
+function makeNode(overrides: Partial<NavigationNode> & { screenName: string }): NavigationNode {
+  return {
+    firstSeenAt: 0,
+    lastSeenAt: 0,
+    visitCount: 1,
+    ...overrides,
+  };
+}
+
+function edge(from: string, to: string): NavigationEdge {
+  return { from, to, timestamp: 0, edgeType: "tool" };
+}
+
+function makeStub(config: {
+  nodes?: Record<string, NavigationNode | undefined>;
+  paths?: Record<string, PathResult>;
+}): NavigationGraphManager {
+  const nodes = config.nodes ?? {};
+  const paths = config.paths ?? {};
+  const stub = {
+    async getNode(screen: string): Promise<NavigationNode | undefined> {
+      return nodes[screen];
+    },
+    async findPath(target: string): Promise<PathResult> {
+      return (
+        paths[target] ?? {
+          found: false,
+          path: [],
+          startScreen: "",
+          targetScreen: target,
+        }
+      );
+    },
+  };
+  return stub as unknown as NavigationGraphManager;
+}
+
+describe("DefaultPathOptimizer", function() {
+  describe("shouldUseBackButton", function() {
+    interface Row {
+      name: string;
+      currentScreen: string;
+      targetScreen: string;
+      currentDepth: number;
+      node?: NavigationNode;
+      path?: PathResult;
+      expectedUseBack: boolean;
+      expectedBackPresses: number;
+      reasonPattern: RegExp;
+    }
+
+    const rows: Row[] = [
+      {
+        name: "declines back when target screen is unknown to the graph",
+        currentScreen: "B",
+        targetScreen: "A",
+        currentDepth: 3,
+        node: undefined,
+        expectedUseBack: false,
+        expectedBackPresses: 0,
+        reasonPattern: /not in navigation graph/,
+      },
+      {
+        name: "declines back when target has no back stack information",
+        currentScreen: "B",
+        targetScreen: "A",
+        currentDepth: 3,
+        node: makeNode({ screenName: "A" }),
+        expectedUseBack: false,
+        expectedBackPresses: 0,
+        reasonPattern: /no back stack information/,
+      },
+      {
+        name: "declines back when current depth equals target depth",
+        currentScreen: "B",
+        targetScreen: "A",
+        currentDepth: 2,
+        node: makeNode({ screenName: "A", backStackDepth: 2 }),
+        expectedUseBack: false,
+        expectedBackPresses: 0,
+        reasonPattern: /not greater than target depth/,
+      },
+      {
+        name: "declines back when current depth is below target depth",
+        currentScreen: "B",
+        targetScreen: "A",
+        currentDepth: 1,
+        node: makeNode({ screenName: "A", backStackDepth: 4 }),
+        expectedUseBack: false,
+        expectedBackPresses: 0,
+        reasonPattern: /not greater than target depth/,
+      },
+      {
+        name: "uses a single back press for an unverified depth-1 parent",
+        currentScreen: "B",
+        targetScreen: "A",
+        currentDepth: 2,
+        node: makeNode({ screenName: "A", backStackDepth: 1 }),
+        path: { found: false, path: [], startScreen: "", targetScreen: "A" },
+        expectedUseBack: true,
+        expectedBackPresses: 1,
+        reasonPattern: /Depth difference is 1/,
+      },
+      {
+        // Kills the `depthDifference <= 2` mutant of the `=== 1` guard: with no
+        // known forward path and a depth gap of 2, back navigation is unsafe.
+        name: "declines back for an unverified depth-2 gap with no known path",
+        currentScreen: "C",
+        targetScreen: "A",
+        currentDepth: 3,
+        node: makeNode({ screenName: "A", backStackDepth: 1 }),
+        path: { found: false, path: [], startScreen: "", targetScreen: "A" },
+        expectedUseBack: false,
+        expectedBackPresses: 0,
+        reasonPattern: /No known navigation path to verify safety/,
+      },
+      {
+        name: "uses back when known path length matches the depth difference",
+        currentScreen: "C",
+        targetScreen: "A",
+        currentDepth: 3,
+        node: makeNode({ screenName: "A", backStackDepth: 1 }),
+        path: {
+          found: true,
+          path: [edge("A", "B"), edge("B", "C")],
+          startScreen: "A",
+          targetScreen: "A",
+        },
+        expectedUseBack: true,
+        expectedBackPresses: 2,
+        reasonPattern: /matches depth difference/,
+      },
+      {
+        name: "declines back when known path length disagrees with the depth difference",
+        currentScreen: "C",
+        targetScreen: "A",
+        currentDepth: 3,
+        node: makeNode({ screenName: "A", backStackDepth: 1 }),
+        path: {
+          found: true,
+          path: [edge("A", "C")],
+          startScreen: "A",
+          targetScreen: "A",
+        },
+        expectedUseBack: false,
+        expectedBackPresses: 0,
+        reasonPattern: /doesn't match depth difference/,
+      },
+    ];
+
+    test.each(rows)("$name", async function(row) {
+      const optimizer = new DefaultPathOptimizer(
+        makeStub({
+          nodes: { [row.targetScreen]: row.node },
+          paths: row.path ? { [row.targetScreen]: row.path } : {},
+        })
+      );
+
+      const result = await optimizer.shouldUseBackButton(
+        row.currentScreen,
+        row.targetScreen,
+        row.currentDepth
+      );
+
+      expect(result.shouldUseBack).toBe(row.expectedUseBack);
+      expect(result.backPresses).toBe(row.expectedBackPresses);
+      expect(result.reason).toMatch(row.reasonPattern);
+    });
+  });
+
+  describe("areInSameTask", function() {
+    interface Row {
+      name: string;
+      node1?: NavigationNode;
+      node2?: NavigationNode;
+      expected: boolean;
+    }
+
+    const rows: Row[] = [
+      {
+        name: "returns true when both nodes share the same task id",
+        node1: makeNode({ screenName: "A", taskId: 7 }),
+        node2: makeNode({ screenName: "B", taskId: 7 }),
+        expected: true,
+      },
+      {
+        name: "returns false when the two nodes have different task ids",
+        node1: makeNode({ screenName: "A", taskId: 7 }),
+        node2: makeNode({ screenName: "B", taskId: 9 }),
+        expected: false,
+      },
+      {
+        name: "returns false when the first node is unknown",
+        node1: undefined,
+        node2: makeNode({ screenName: "B", taskId: 7 }),
+        expected: false,
+      },
+      {
+        name: "returns false when the second node is unknown",
+        node1: makeNode({ screenName: "A", taskId: 7 }),
+        node2: undefined,
+        expected: false,
+      },
+      {
+        name: "returns false when either node has no task id",
+        node1: makeNode({ screenName: "A", taskId: 7 }),
+        node2: makeNode({ screenName: "B" }),
+        expected: false,
+      },
+    ];
+
+    test.each(rows)("$name", async function(row) {
+      const optimizer = new DefaultPathOptimizer(
+        makeStub({ nodes: { A: row.node1, B: row.node2 } })
+      );
+      expect(await optimizer.areInSameTask("A", "B")).toBe(row.expected);
+    });
+  });
+
+  describe("getNavigationRecommendation", function() {
+    test("recommends back navigation when the back heuristic applies", async function() {
+      const optimizer = new DefaultPathOptimizer(
+        makeStub({
+          nodes: { A: makeNode({ screenName: "A", backStackDepth: 1 }) },
+          paths: { A: { found: false, path: [], startScreen: "", targetScreen: "A" } },
+        })
+      );
+
+      const result = await optimizer.getNavigationRecommendation("A", "B", 2);
+
+      expect(result.method).toBe("back");
+      expect(result.backPresses).toBe(1);
+    });
+
+    test("recommends forward navigation when a known path exists but back is unsafe", async function() {
+      const optimizer = new DefaultPathOptimizer(
+        makeStub({
+          nodes: { A: makeNode({ screenName: "A" }) },
+          paths: {
+            A: {
+              found: true,
+              path: [edge("B", "A")],
+              startScreen: "B",
+              targetScreen: "A",
+            },
+          },
+        })
+      );
+
+      const result = await optimizer.getNavigationRecommendation("A", "B", 0);
+
+      expect(result.method).toBe("forward");
+      expect(result.reason).toMatch(/1 steps/);
+    });
+
+    test("returns unknown when no path to the target screen is known", async function() {
+      const optimizer = new DefaultPathOptimizer(makeStub({}));
+
+      const result = await optimizer.getNavigationRecommendation("Nowhere", "Here", 2);
+
+      expect(result.method).toBe("unknown");
+    });
+  });
+});

--- a/test/features/navigation/DefaultScreenTransitionWaiter.test.ts
+++ b/test/features/navigation/DefaultScreenTransitionWaiter.test.ts
@@ -1,0 +1,97 @@
+import { expect, describe, test } from "bun:test";
+import { DefaultScreenTransitionWaiter } from "../../../src/features/navigation/DefaultScreenTransitionWaiter";
+import { NavigationGraphManager } from "../../../src/features/navigation/NavigationGraphManager";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+/**
+ * A clock whose now() replays a fixed script (last value sticky) and whose
+ * sleep() resolves immediately. The waiter polls getCurrentScreen() between
+ * now()-gated deadline checks, so scripting now() makes the poll loop fully
+ * deterministic and — crucially — guaranteed to terminate (autoAdvance would
+ * leave now() pinned at 0 and spin forever against the deadline check).
+ */
+class ScriptedClock extends FakeTimer {
+  private index = 0;
+  constructor(private readonly times: number[]) {
+    super();
+  }
+  now(): number {
+    const value = this.times[Math.min(this.index, this.times.length - 1)];
+    this.index += 1;
+    return value;
+  }
+  async sleep(): Promise<void> {
+    // Immediate: the deadline is driven by the scripted now(), not real elapsed time.
+  }
+}
+
+/** Navigation-graph stub exposing only the method the waiter consumes. */
+function stubManager(screens: Array<string | null>): {
+  manager: NavigationGraphManager;
+  pollCount: () => number;
+} {
+  let index = 0;
+  const manager = {
+    getCurrentScreen(): string | null {
+      const value = screens[Math.min(index, screens.length - 1)];
+      index += 1;
+      return value;
+    },
+  } as unknown as NavigationGraphManager;
+  return { manager, pollCount: () => index };
+}
+
+describe("DefaultScreenTransitionWaiter", function() {
+  test("resolves true on the first poll when already on the target screen", async function() {
+    const { manager, pollCount } = stubManager(["TargetScreen"]);
+    const waiter = new DefaultScreenTransitionWaiter(
+      manager,
+      500,
+      new ScriptedClock([0, 250])
+    );
+
+    expect(await waiter.waitForScreen("TargetScreen", 1000)).toBe(true);
+    expect(pollCount()).toBe(1);
+  });
+
+  test("resolves true once the target screen appears on a later poll", async function() {
+    const { manager, pollCount } = stubManager(["Splash", "Splash", "TargetScreen"]);
+    const waiter = new DefaultScreenTransitionWaiter(
+      manager,
+      500,
+      new ScriptedClock([0, 200, 400, 600])
+    );
+
+    expect(await waiter.waitForScreen("TargetScreen", 1000)).toBe(true);
+    expect(pollCount()).toBe(3);
+  });
+
+  test("resolves false when the target screen never appears before the deadline", async function() {
+    const { manager, pollCount } = stubManager(["Other"]);
+    // startTime=0, then deadline checks at 250/500/750/1000; 1000 is not < 1000.
+    const waiter = new DefaultScreenTransitionWaiter(
+      manager,
+      500,
+      new ScriptedClock([0, 250, 500, 750, 1000, 1500])
+    );
+
+    expect(await waiter.waitForScreen("TargetScreen", 1000)).toBe(false);
+    expect(pollCount()).toBe(3);
+  });
+
+  test("resolves false when the screen only becomes current exactly at the deadline", async function() {
+    // Elapsed reaches the timeout on the very first check. A strict `< timeoutMs`
+    // gate gives up without polling; the `<= timeoutMs` mutant would poll and
+    // wrongly report success. So a screen that is "ready" at t == timeout is a
+    // miss.
+    const { manager, pollCount } = stubManager(["TargetScreen"]);
+    const waiter = new DefaultScreenTransitionWaiter(
+      manager,
+      500,
+      new ScriptedClock([0, 1000, 1500])
+    );
+
+    expect(await waiter.waitForScreen("TargetScreen", 1000)).toBe(false);
+    expect(pollCount()).toBe(0);
+  });
+});

--- a/test/features/navigation/DefaultUIStateSetup.test.ts
+++ b/test/features/navigation/DefaultUIStateSetup.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { DefaultUIStateSetup, type ObserveScreenLike } from "../../../src/features/navigation/DefaultUIStateSetup";
+import { RealObserveScreen } from "../../../src/features/observe/ObserveScreen";
 import { FakeAdbClient } from "../../fakes/FakeAdbClient";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import type { AdbClient } from "../../../src/utils/android-cmdline-tools/AdbClient";
@@ -34,13 +35,22 @@ describe("DefaultUIStateSetup", () => {
   // resolved AdbClient. After ObserveScreen became factory-only, that call would
   // throw `adbFactory.create is not a function` inside the constructor, get
   // swallowed by getCurrentUIState's catch, and silently skip required UI setup.
-  test("default observe provider constructs from a resolved AdbClient without throwing", () => {
-    const setup = makeSetup();
+  test("default observe provider builds a RealObserveScreen bound to the injected device and adb", () => {
+    const fakeAdb = new FakeAdbClient() as unknown as AdbClient;
+    const timer = new FakeTimer();
+    const setup = new DefaultUIStateSetup(device, fakeAdb, undefined, timer);
     const provider = (setup as unknown as { observeScreenProvider: () => ObserveScreenLike }).observeScreenProvider;
 
     let observeScreen: ObserveScreenLike | undefined;
     expect(() => { observeScreen = provider(); }).not.toThrow();
-    expect(typeof observeScreen!.execute).toBe("function");
+
+    // Assert the concrete type and its binding rather than merely "has an execute
+    // method" (a bare stub would pass that). The default provider must wire the
+    // injected device and the resolved AdbClient into the real observe path.
+    expect(observeScreen).toBeInstanceOf(RealObserveScreen);
+    const internals = observeScreen as unknown as { device: BootedDevice; adb: AdbClient };
+    expect(internals.device).toBe(device);
+    expect(internals.adb).toBe(fakeAdb);
   });
 
   test("setupUIState consults the observe provider when the edge requires UI state", async () => {

--- a/test/features/navigation/Explore.test.ts
+++ b/test/features/navigation/Explore.test.ts
@@ -685,7 +685,11 @@ describe("Explore", () => {
       expect(result.graphTraversal?.edgesTraversed).toBe(1);
       expect(result.graphTraversal?.edgeValidationResults).toBeDefined();
       expect(result.graphTraversal?.edgeValidationResults.length).toBeGreaterThan(0);
-      expect(result.graphTraversal?.coveragePercentage).toBeGreaterThanOrEqual(0);
+      // NOTE (#4171 follow-up): this pins the CURRENT, apparently-buggy output.
+      // With 2/2 nodes visited and 1/1 edges traversed the coverage should read
+      // ~100%, but generateReport computes 0. Asserting the real value keeps the
+      // test truthful; the formula itself needs a separate fix/investigation.
+      expect(result.graphTraversal?.coveragePercentage).toBe(0);
     });
   });
 });

--- a/test/features/navigation/ExploreBlockerDetection.test.ts
+++ b/test/features/navigation/ExploreBlockerDetection.test.ts
@@ -1,9 +1,12 @@
 import { expect, describe, test } from "bun:test";
 import { Element } from "../../../src/models";
+import type { BootedDevice, ObserveResult } from "../../../src/models";
+import type { ElementParser } from "../../../src/utils/interfaces/ElementParser";
 import {
   isPermissionDialog,
   isLoginScreen,
-  isRatingDialog
+  isRatingDialog,
+  detectAndHandleBlockers
 } from "../../../src/features/navigation/ExploreBlockerDetection";
 
 describe("ExploreBlockerDetection", () => {
@@ -294,6 +297,135 @@ describe("ExploreBlockerDetection", () => {
       expect(isPermissionDialog(elements)).toBe(false);
       expect(isLoginScreen(elements)).toBe(false);
       expect(isRatingDialog(elements)).toBe(false);
+    });
+  });
+
+  describe("detectAndHandleBlockers", () => {
+    // A fake ElementParser whose flattenViewHierarchy returns the configured
+    // elements. detectAndHandleBlockers -> extractAllElements only touches
+    // flattenViewHierarchy, so this is the entire seam. Tracks call count so we
+    // can prove the error/missing-hierarchy guards bail out *before* extraction.
+    function makeParser(elements: Element[]): { parser: ElementParser; extractionCount: () => number } {
+      let calls = 0;
+      const parser = {
+        flattenViewHierarchy: () => {
+          calls += 1;
+          return elements.map((element, index) => ({ element, index, depth: 0 }));
+        },
+      } as unknown as ElementParser;
+      return { parser, extractionCount: () => calls };
+    }
+
+    function observationWith(hierarchy: { error?: string }, packageName = "com.test"): ObserveResult {
+      return {
+        viewHierarchy: { hierarchy, packageName },
+      } as unknown as ObserveResult;
+    }
+
+    const device = {} as unknown as BootedDevice;
+
+    // A non-clickable element trips the classifier predicates but makes both
+    // handlePermissionDialog and dismissDialog no-op (they skip non-clickable
+    // nodes and never construct a TapOnElement), so no real device call fires.
+    const permissionAndLoginElements: Element[] = [
+      { "text": "Allow access", "clickable": false } as Element,
+      { "text": "password", "class": "android.widget.EditText", "clickable": false } as Element,
+    ];
+    const loginElements: Element[] = [
+      { "text": "Sign in", "clickable": false } as Element,
+      { "text": "", "class": "android.widget.EditText", "clickable": false } as Element,
+    ];
+
+    test("handles a permission-and-login screen as a permission dialog, not a login dead-end", async () => {
+      // Permission is checked before login, so handleDeadEnd (the login handler)
+      // must never fire. Kills the `false && isPermissionDialog(...)` mutant,
+      // which would fall through to the login branch and invoke handleDeadEnd.
+      let deadEndCalls = 0;
+      const { parser } = makeParser(permissionAndLoginElements);
+
+      const result = await detectAndHandleBlockers(
+        observationWith({}),
+        device,
+        null,
+        parser,
+        async () => { deadEndCalls += 1; }
+      );
+
+      expect(deadEndCalls).toBe(0);
+      // No clickable permission button -> handlePermissionDialog returns false.
+      expect(result).toBe(false);
+    });
+
+    test("routes a login screen to the dead-end handler and reports it handled", async () => {
+      let deadEndCalls = 0;
+      const { parser } = makeParser(loginElements);
+
+      const result = await detectAndHandleBlockers(
+        observationWith({}),
+        device,
+        null,
+        parser,
+        async () => { deadEndCalls += 1; }
+      );
+
+      expect(deadEndCalls).toBe(1);
+      expect(result).toBe(true);
+    });
+
+    test("returns false and never handles blockers on a regular screen", async () => {
+      let deadEndCalls = 0;
+      const { parser } = makeParser([
+        { "text": "Home", "clickable": true } as Element,
+        { "text": "Settings", "clickable": true } as Element,
+      ]);
+
+      const result = await detectAndHandleBlockers(
+        observationWith({}),
+        device,
+        null,
+        parser,
+        async () => { deadEndCalls += 1; }
+      );
+
+      expect(result).toBe(false);
+      expect(deadEndCalls).toBe(0);
+    });
+
+    test("bails out without extracting elements when the hierarchy carries an error", async () => {
+      // The errored hierarchy still resolves to login elements, so dropping the
+      // `|| viewHierarchy.hierarchy.error` guard would extract them and invoke
+      // handleDeadEnd. With the guard, extraction never runs.
+      let deadEndCalls = 0;
+      const { parser, extractionCount } = makeParser(loginElements);
+
+      const result = await detectAndHandleBlockers(
+        observationWith({ error: "accessibility service unavailable" }),
+        device,
+        null,
+        parser,
+        async () => { deadEndCalls += 1; }
+      );
+
+      expect(result).toBe(false);
+      expect(deadEndCalls).toBe(0);
+      expect(extractionCount()).toBe(0);
+    });
+
+    test("returns false when the observation has no view hierarchy", async () => {
+      let deadEndCalls = 0;
+      const { parser, extractionCount } = makeParser(loginElements);
+
+      const result = await detectAndHandleBlockers(
+        { viewHierarchy: undefined } as unknown as ObserveResult,
+        device,
+        null,
+        parser,
+        async () => { deadEndCalls += 1; }
+      );
+
+      expect(result).toBe(false);
+      expect(deadEndCalls).toBe(0);
+      expect(extractionCount()).toBe(0);
     });
   });
 });

--- a/test/features/navigation/HierarchyNavigationDetector.test.ts
+++ b/test/features/navigation/HierarchyNavigationDetector.test.ts
@@ -229,14 +229,83 @@ describe("HierarchyNavigationDetector", () => {
   });
 
   describe("dispose", () => {
-    test("should clear timers", () => {
+    test("stops a pending fingerprint from ever stabilizing after dispose", () => {
       const hierarchy = createHierarchy("Screen A");
       detector.onHierarchyUpdate(hierarchy);
+      expect(detector.hasPendingFingerprint()).toBe(true);
 
       detector.dispose();
 
-      // Advancing time after dispose should not crash
-      fakeTimer.advanceTime(100);
+      // dispose() cancels the debounce and stability timers, so advancing well
+      // past both deadlines must NOT stabilize the pending fingerprint or record
+      // a navigation. A no-op dispose() would let the debounce fire and promote
+      // the fingerprint, so getCurrentFingerprint would become non-null.
+      fakeTimer.advanceTime(10_000);
+
+      expect(detector.getCurrentFingerprint()).toBeNull();
+      expect(detector.getPreviousFingerprint()).toBeNull();
+      // dispose() only tears down timers; it does not reset accumulated state,
+      // so the pending fingerprint is still parked (distinct from reset()).
+      expect(detector.hasPendingFingerprint()).toBe(true);
+    });
+  });
+
+  describe("navigation callback", () => {
+    interface CallbackInfo {
+      packageName: string | null;
+      screenFingerprint: string;
+      timestamp: number;
+    }
+
+    test("invokes the navigation callback once per detected navigation", () => {
+      const seen: CallbackInfo[] = [];
+      detector.setNavigationCallback(info => seen.push(info));
+
+      // The very first stabilization (initial -> Screen A) is itself a recorded
+      // navigation, so the callback fires here too — not only on the A -> B hop.
+      detector.onHierarchyUpdate(createHierarchy("Screen A"));
+      fakeTimer.advanceTime(60);
+
+      detector.onHierarchyUpdate(createHierarchy("Screen B"));
+      fakeTimer.advanceTime(60);
+
+      expect(seen).toHaveLength(2);
+      expect(seen.at(-1)!.packageName).toBe("com.test.app");
+      expect(seen.at(-1)!.screenFingerprint).toBe(detector.getCurrentFingerprint()!.hash);
+    });
+
+    test("keeps detecting navigation when the callback throws", () => {
+      detector.setNavigationCallback(() => {
+        throw new Error("screenshot capture blew up");
+      });
+
+      // A throwing callback must be swallowed: advancing the debounce timer (which
+      // fires the callback synchronously) must not propagate, and fingerprint
+      // state must still advance. Dropping the try/catch would let this throw out
+      // of advanceTime and fail the test.
+      detector.onHierarchyUpdate(createHierarchy("Screen A"));
+      fakeTimer.advanceTime(60);
+      detector.onHierarchyUpdate(createHierarchy("Screen B"));
+      fakeTimer.advanceTime(60);
+
+      const current = detector.getCurrentFingerprint();
+      const previous = detector.getPreviousFingerprint();
+      expect(current).not.toBeNull();
+      expect(previous).not.toBeNull();
+      expect(current!.hash).not.toBe(previous!.hash);
+    });
+
+    test("stops invoking the callback after it is cleared", () => {
+      const seen: CallbackInfo[] = [];
+      detector.setNavigationCallback(info => seen.push(info));
+      detector.setNavigationCallback(null);
+
+      detector.onHierarchyUpdate(createHierarchy("Screen A"));
+      fakeTimer.advanceTime(60);
+      detector.onHierarchyUpdate(createHierarchy("Screen B"));
+      fakeTimer.advanceTime(60);
+
+      expect(seen).toHaveLength(0);
     });
   });
 

--- a/test/features/navigation/NavigateTo.test.ts
+++ b/test/features/navigation/NavigateTo.test.ts
@@ -2,6 +2,8 @@ import { expect, describe, test, beforeEach, afterEach, spyOn } from "bun:test";
 import { NavigateTo } from "../../../src/features/navigation/NavigateTo";
 import { SmartNavigationHelper } from "../../../src/features/navigation/SmartNavigationHelper";
 import type { ScreenTransitionWaiter } from "../../../src/features/navigation/interfaces/ScreenTransitionWaiter";
+import type { UIStateSetup } from "../../../src/features/navigation/interfaces/UIStateSetup";
+import type { NavigationEdge } from "../../../src/utils/interfaces/NavigationGraph";
 import { ToolRegistry } from "../../../src/server/toolRegistry";
 import { BootedDevice } from "../../../src/models";
 import { z } from "zod";
@@ -358,6 +360,166 @@ describe("NavigateTo", () => {
       expect(result.path).toEqual(["pressButton(back)"]);
       expect(fakeAdbFactory.getFakeClient().getAllCommands()).toEqual(["shell input keyevent 4"]);
       expect(fakeTimer.getSleepHistory()).toEqual([300]);
+    });
+  });
+
+  describe("failure envelopes", () => {
+    // A Timer whose now() replays a fixed script (last value sticky), so we can
+    // force the elapsed clock to cross the 30s ceiling or report a real, non-zero
+    // durationMs without any wall-clock dependency. startTime consumes the first
+    // reading; the in-loop timeout check and the envelope's durationMs consume
+    // the rest.
+    class ScriptedTimer extends FakeTimer {
+      private idx = 0;
+      constructor(private readonly script: number[]) {
+        super();
+      }
+      now(): number {
+        const value = this.script[Math.min(this.idx, this.script.length - 1)];
+        this.idx += 1;
+        return value;
+      }
+    }
+
+    function toolEdge(from: string, to: string): NavigationEdge {
+      return {
+        from,
+        to,
+        timestamp: 0,
+        edgeType: "tool",
+        interaction: {
+          toolName: "tapOn",
+          args: { text: "Next", action: "tap", platform: "android" },
+          timestamp: 0,
+        },
+      };
+    }
+
+    test("aborts with a timeout envelope once the 30s ceiling is crossed", async () => {
+      await fakeGraph.recordNavigationEvent({
+        destination: "HomeScreen",
+        source: "TEST",
+        arguments: {},
+        metadata: {},
+        timestamp: Date.now(),
+        sequenceNumber: 0,
+      });
+      fakeGraph.setPathResult({
+        found: true,
+        path: [toolEdge("HomeScreen", "TargetScreen")],
+        startScreen: "HomeScreen",
+        targetScreen: "TargetScreen",
+      });
+
+      // startTime = 0, first in-loop check = 40_000 (> MAX_TIMEOUT_MS 30_000).
+      const timer = new ScriptedTimer([0, 40_000]);
+      navigateTo = new NavigateTo(device, fakeAdbFactory, null, null, fakeGraph, timer);
+
+      const result = await navigateTo.execute({
+        targetScreen: "TargetScreen",
+        platform: "android",
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe("Navigation timeout (30 seconds)");
+      expect(result.stepsExecuted).toBe(0);
+      expect(result.partialPath).toEqual([]);
+      // A real elapsed duration, not a hard-coded 0 (guards the durationMs mutant).
+      expect(result.durationMs).toBe(40_000);
+      // The offending tool step must never have run.
+      expect(toolCallLog).toHaveLength(0);
+    });
+
+    test("reports the failing step number and partial path when a step throws", async () => {
+      await fakeGraph.recordNavigationEvent({
+        destination: "HomeScreen",
+        source: "TEST",
+        arguments: {},
+        metadata: {},
+        timestamp: Date.now(),
+        sequenceNumber: 0,
+      });
+      fakeGraph.setPathResult({
+        found: true,
+        path: [toolEdge("HomeScreen", "TargetScreen")],
+        startScreen: "HomeScreen",
+        targetScreen: "TargetScreen",
+      });
+
+      const throwingUiStateSetup: UIStateSetup = {
+        setupUIState: async () => {
+          throw new Error("ui-state boom");
+        },
+        setupScrollPosition: async () => null,
+      };
+
+      // startTime = 0, in-loop timeout check = 100 (no timeout), catch durationMs = 31_000.
+      const timer = new ScriptedTimer([0, 100, 31_000]);
+      navigateTo = new NavigateTo(
+        device,
+        fakeAdbFactory,
+        throwingUiStateSetup,
+        null,
+        fakeGraph,
+        timer
+      );
+
+      const result = await navigateTo.execute({
+        targetScreen: "TargetScreen",
+        platform: "android",
+      });
+
+      expect(result.success).toBe(false);
+      // 1-based step index (guards the `step ${i}` off-by-one mutant).
+      expect(result.error).toContain("Failed to execute step 1");
+      expect(result.error).toContain("ui-state boom");
+      expect(result.partialPath).toEqual([]);
+      // Bundled with A3 so the durationMs assertion measures a real elapsed span.
+      expect(result.durationMs).toBe(31_000);
+    });
+
+    test("records a back-button hop for an edge with no known interaction", async () => {
+      await fakeGraph.recordNavigationEvent({
+        destination: "HomeScreen",
+        source: "TEST",
+        arguments: {},
+        metadata: {},
+        timestamp: Date.now(),
+        sequenceNumber: 0,
+      });
+      fakeGraph.setPathResult({
+        found: true,
+        path: [
+          { from: "HomeScreen", to: "TargetScreen", timestamp: 0, edgeType: "back" },
+        ],
+        startScreen: "HomeScreen",
+        targetScreen: "TargetScreen",
+      });
+
+      const screenWaiter: ScreenTransitionWaiter = {
+        waitForScreen: async screenName => screenName === "TargetScreen",
+      };
+      const timer = new FakeTimer();
+      timer.enableAutoAdvance();
+      navigateTo = new NavigateTo(
+        device,
+        fakeAdbFactory,
+        null,
+        screenWaiter,
+        fakeGraph,
+        timer
+      );
+
+      const result = await navigateTo.execute({
+        targetScreen: "TargetScreen",
+        platform: "android",
+      });
+
+      expect(result.success).toBe(true);
+      // Guards the dropped `executedPath.push("pressButton(back)")` in the
+      // no-interaction branch of the step loop.
+      expect(result.path).toEqual(["pressButton(back)"]);
+      expect(result.stepsExecuted).toBe(1);
     });
   });
 

--- a/test/features/navigation/NavigationGraphManager.test.ts
+++ b/test/features/navigation/NavigationGraphManager.test.ts
@@ -321,22 +321,11 @@ describe("NavigationGraphManager", () => {
 
       expect(result.found).toBe(true);
       expect(result.path).toHaveLength(40);
-      expect(fromScreenReadCount).toBeLessThanOrEqual(edges.length * 3);
-    });
-
-    test("should keep BFS queue and path tracking linear in source", () => {
-      const managerSource = readFileSync(
-        join(import.meta.dir, "../../../src/features/navigation/NavigationGraphManager.ts"),
-        "utf8"
-      );
-      const findPathBody = extractMethodBody(managerSource, "public async findPath");
-
-      expect(findPathBody).toContain("const edgesBySource = new Map");
-      expect(findPathBody).toContain("let queueHead = 0");
-      expect(findPathBody).not.toContain(".shift(");
-      expect(findPathBody).toContain("const predecessor = new Map");
-      expect(findPathBody).not.toContain("[...path");
-      expect(findPathBody).toContain("this.reconstructPath(");
+      // from_screen is read exactly three times per edge: once building the
+      // edgesBySource index, once during the BFS neighbour scan, and once during
+      // path reconstruction. An exact bound (not <=) also kills a `* 2` regression
+      // that would drop one of those linear passes.
+      expect(fromScreenReadCount).toBe(edges.length * 3);
     });
 
     test("should prefer a shorter path over an earlier longer path", async () => {
@@ -534,6 +523,86 @@ describe("NavigationGraphManager", () => {
       ]);
       expect(history.nodes.every(node => node.id !== null)).toBe(true);
     });
+
+    // N navigation events produce N-1 edges, so 5 events == 4 edges. Requesting a
+    // page smaller than the edge count is what sets hasMore/nextCursor; an
+    // off-by-one seed (edges <= limit) can never reach that boundary.
+    async function seedLinearEdges(edgeCount: number): Promise<void> {
+      for (let i = 0; i <= edgeCount; i++) {
+        await manager.recordNavigationEvent(createEvent(`Screen${i}`, 1000 + i));
+      }
+    }
+
+    interface LimitRow {
+      name: string;
+      limit?: number;
+      expectedEdgeCount: number;
+      expectNextCursor: boolean;
+    }
+
+    const limitRows: LimitRow[] = [
+      { name: "returns every edge and no cursor when no limit is given", limit: undefined, expectedEdgeCount: 4, expectNextCursor: false },
+      { name: "caps the page and emits a cursor when the limit is below the edge count", limit: 2, expectedEdgeCount: 2, expectNextCursor: true },
+      { name: "treats a zero limit as the default page size", limit: 0, expectedEdgeCount: 4, expectNextCursor: false },
+      { name: "treats a negative limit as the default page size", limit: -5, expectedEdgeCount: 4, expectNextCursor: false },
+      { name: "floors a fractional limit toward zero", limit: 2.9, expectedEdgeCount: 2, expectNextCursor: true },
+      { name: "returns every edge when the limit exceeds the edge count", limit: 1000, expectedEdgeCount: 4, expectNextCursor: false },
+    ];
+
+    test.each(limitRows)("$name", async ({ limit, expectedEdgeCount, expectNextCursor }) => {
+      await seedLinearEdges(4);
+
+      const page = await manager.exportGraphHistory({ limit });
+
+      expect(page.edges).toHaveLength(expectedEdgeCount);
+      if (expectNextCursor) {
+        expect(page.nextCursor).not.toBeNull();
+      } else {
+        expect(page.nextCursor).toBeNull();
+      }
+    });
+
+    test("walks the full history across pages using the returned cursor", async () => {
+      await seedLinearEdges(4);
+
+      const firstPage = await manager.exportGraphHistory({ limit: 2 });
+      expect(firstPage.edges).toHaveLength(2);
+      expect(firstPage.nextCursor).not.toBeNull();
+
+      const secondPage = await manager.exportGraphHistory({
+        limit: 2,
+        cursor: firstPage.nextCursor!,
+      });
+      expect(secondPage.edges).toHaveLength(2);
+      expect(secondPage.nextCursor).toBeNull();
+
+      // No edge is dropped or repeated across the two pages.
+      const seenIds = [
+        ...firstPage.edges.map(edge => edge.id),
+        ...secondPage.edges.map(edge => edge.id),
+      ];
+      expect(new Set(seenIds).size).toBe(4);
+    });
+
+    test("returns an empty envelope with the echoed cursor when no app is active", async () => {
+      const freshManager = makeFreshManager();
+
+      const page = await freshManager.exportGraphHistory({ cursor: "123:4" });
+
+      expect(page.appId).toBeNull();
+      expect(page.edges).toEqual([]);
+      expect(page.nodes).toEqual([]);
+      expect(page.cursor).toBe("123:4");
+      expect(page.nextCursor).toBeNull();
+    });
+
+    test("rejects a malformed cursor rather than silently returning the first page", async () => {
+      await seedLinearEdges(2);
+
+      await expect(
+        manager.exportGraphHistory({ cursor: "not-a-cursor" })
+      ).rejects.toThrow(/Invalid history cursor/);
+    });
   });
 
   describe("clearCurrentGraph", () => {
@@ -636,31 +705,6 @@ function createCountingDBEdge(
   });
 
   return edge;
-}
-
-function extractMethodBody(source: string, signature: string): string {
-  const signatureIndex = source.indexOf(signature);
-  if (signatureIndex < 0) {
-    throw new Error(`Could not find method signature: ${signature}`);
-  }
-
-  const openingBrace = source.indexOf("{", signatureIndex);
-  if (openingBrace < 0) {
-    throw new Error(`Could not find method body: ${signature}`);
-  }
-
-  let depth = 1;
-  let index = openingBrace + 1;
-  for (; index < source.length && depth > 0; index++) {
-    const char = source[index];
-    if (char === "{") {
-      depth++;
-    } else if (char === "}") {
-      depth--;
-    }
-  }
-
-  return source.slice(openingBrace + 1, index - 1);
 }
 
 describe("NavigationGraphManager - Scroll Position", () => {
@@ -1327,6 +1371,43 @@ describe("NavigationGraphManager - recordNavigationEvent transaction (#2791)", (
     expect(await countEdges()).toBe(1);
     const otherNode = await otherRepo.getNode("com.test.other", "OtherScreen");
     expect(otherNode).toBeDefined();
+  });
+
+  describe("graph-update listener isolation (#4171)", () => {
+    test("still notifies later listeners after an earlier listener throws", async () => {
+      const manager = makeManager(new TestCoverageRepository(defaultTimer, db));
+      await manager.setCurrentApp(APP_ID);
+
+      const calls: string[] = [];
+      manager.setGraphUpdateListener(() => {
+        calls.push("first");
+        throw new Error("listener boom");
+      });
+      manager.setGraphUpdateListener(() => {
+        calls.push("second");
+      });
+
+      // Switching the app fires notifyGraphUpdated once. A per-listener try/catch
+      // must isolate the first listener's throw so the second still runs; without
+      // it, the throw would propagate out of setCurrentApp and starve later
+      // listeners.
+      await manager.setCurrentApp("com.test.other");
+
+      expect(calls).toEqual(["first", "second"]);
+    });
+
+    test("stops notifying every listener once they are cleared with null", async () => {
+      const manager = makeManager(new TestCoverageRepository(defaultTimer, db));
+      await manager.setCurrentApp(APP_ID);
+
+      const calls: number[] = [];
+      manager.setGraphUpdateListener(() => calls.push(1));
+      manager.setGraphUpdateListener(null);
+
+      await manager.setCurrentApp("com.test.other");
+
+      expect(calls).toEqual([]);
+    });
   });
 });
 

--- a/test/features/navigation/NavigationScreenshotManager.test.ts
+++ b/test/features/navigation/NavigationScreenshotManager.test.ts
@@ -195,36 +195,15 @@ describe("NavigationScreenshotManager", () => {
   });
 
   describe("generateFilename", () => {
-    test("should generate unique filename with hash and timestamp", () => {
+    test("names the file {md5(appId_screenName).slice(0,12)}_{timestamp}.webp", () => {
       const filename = manager.generateFilename("com.test.app", "HomeScreen");
 
-      expect(filename).toMatch(/^[a-f0-9]+_\d+\.webp$/);
-      expect(filename).toContain("0"); // timestamp from fake timer starts at 0
-    });
-
-    test("should generate consistent hash for same app/screen", () => {
-      const filename1 = manager.generateFilename("com.test.app", "HomeScreen");
-      fakeTimer.advanceTime(1000);
-      const filename2 = manager.generateFilename("com.test.app", "HomeScreen");
-
-      // Hash should be the same, but timestamp different
-      const hash1 = filename1.split("_")[0];
-      const hash2 = filename2.split("_")[0];
-      expect(hash1).toBe(hash2);
-
-      // Timestamps should be different
-      const ts1 = filename1.split("_")[1]?.split(".")[0];
-      const ts2 = filename2.split("_")[1]?.split(".")[0];
-      expect(ts1).not.toBe(ts2);
-    });
-
-    test("should generate different hash for different screens", () => {
-      const filename1 = manager.generateFilename("com.test.app", "HomeScreen");
-      const filename2 = manager.generateFilename("com.test.app", "SettingsScreen");
-
-      const hash1 = filename1.split("_")[0];
-      const hash2 = filename2.split("_")[0];
-      expect(hash1).not.toBe(hash2);
+      // Exact 12-char md5 prefix of "com.test.app_HomeScreen". Pinning the exact
+      // hash (not merely "hex prefix") subsumes both the same-input-same-hash and
+      // different-input-different-hash tautologies while also guarding the
+      // hash-input string, the digest, the truncation length, and the .webp
+      // extension against a filename-format change. Timestamp is 0 (fake clock).
+      expect(filename).toBe("6d8c20971f5d_0.webp");
     });
   });
 

--- a/test/features/navigation/ScreenFingerprint.test.ts
+++ b/test/features/navigation/ScreenFingerprint.test.ts
@@ -134,6 +134,47 @@ describe("ScreenFingerprint - Enhanced Implementation", () => {
       expect(result.method).toBe(FingerprintMethod.SHALLOW_SCROLLABLE);
       expect(result.keyboardDetected).toBe(false);
     });
+
+    // The cache freshness gate is `cacheAge < cacheTTL`, where updatedAt is
+    // 1234567890 and cacheAge = updatedAt - cachedNavigationIdTimestamp. These
+    // rows pin the boundary, including the explicit `cacheTTL: 0` "never cache"
+    // request that `||` silently rewrote to the default TTL before the `??` fix.
+    interface CacheTtlRow {
+      name: string;
+      ageMs: number;
+      cacheTTL?: number;
+      usesCache: boolean;
+    }
+
+    const cacheTtlRows: CacheTtlRow[] = [
+      { name: "uses cache when age is within an explicit TTL", ageMs: 5000, cacheTTL: 10000, usesCache: true },
+      { name: "rejects cache when age equals the TTL boundary", ageMs: 10000, cacheTTL: 10000, usesCache: false },
+      { name: "rejects cache when age exceeds the TTL", ageMs: 15000, cacheTTL: 10000, usesCache: false },
+      { name: "rejects cache when the requested TTL is negative", ageMs: 5000, cacheTTL: -1, usesCache: false },
+      { name: "rejects cache when the requested TTL is zero (no cache)", ageMs: 5000, cacheTTL: 0, usesCache: false },
+    ];
+
+    test.each(cacheTtlRows)("$name", ({ ageMs, cacheTTL, usesCache }) => {
+      const hierarchyWithKeyboard = createHierarchy({
+        node: {
+          "content-desc": "Delete",
+          "node": { "content-desc": "Enter" },
+        },
+      });
+
+      const result = ScreenFingerprint.compute(hierarchyWithKeyboard, {
+        cachedNavigationId: "navigation.TextScreen",
+        cachedNavigationIdTimestamp: 1234567890 - ageMs,
+        cacheTTL,
+      });
+
+      expect(result.keyboardDetected).toBe(true);
+      if (usesCache) {
+        expect(result.method).toBe(FingerprintMethod.CACHED_NAVIGATION_ID);
+      } else {
+        expect(result.method).not.toBe(FingerprintMethod.CACHED_NAVIGATION_ID);
+      }
+    });
   });
 
   describe("Keyboard Detection", () => {

--- a/test/features/navigation/SelectionStateDetector.test.ts
+++ b/test/features/navigation/SelectionStateDetector.test.ts
@@ -79,8 +79,21 @@ describe("SelectionStateDetector", () => {
 
     expect(selected).toHaveLength(1);
     expect(selected[0].text).toBe("Tab1");
+    // Exact envelope: similarity 90 -> diff 10.00%; confidence = min(1, 10/scale=5) = 1;
+    // reason pins the diff string and the minDifferencePercent=1 threshold.
     expect(selected[0].selectedState?.method).toBe("visual");
-    expect(selected[0].selectedState?.confidence).toBeGreaterThan(0);
-    expect(imageUtils.wasMethodCalled("crop")).toBe(true);
+    expect(selected[0].selectedState?.confidence).toBe(1);
+    expect(selected[0].selectedState?.reason).toBe("visual diff 10.00% >= 1%");
+
+    // Both the before and after regions are cropped to the element's exact 50x50
+    // bounds at the origin (guards the crop rect that drives the visual diff).
+    const cropCalls = imageUtils.getMethodCalls("crop");
+    expect(cropCalls).toHaveLength(2);
+    for (const call of cropCalls) {
+      expect(call.width).toBe(50);
+      expect(call.height).toBe(50);
+      expect(call.x).toBe(0);
+      expect(call.y).toBe(0);
+    }
   });
 });

--- a/test/features/navigation/SmartNavigationHelper.test.ts
+++ b/test/features/navigation/SmartNavigationHelper.test.ts
@@ -181,14 +181,12 @@ describe("SmartNavigationHelper", function() {
         2 // Current depth
       );
 
-      // This may be true or false depending on whether the path is found
-      // The key is that if shouldUseBack is true, backPresses should equal 2
-      if (result.shouldUseBack) {
-        expect(result.backPresses).toBe(2);
-      } else {
-        // If back button is not recommended, it should be for a valid reason
-        expect(result.reason).toBeDefined();
-      }
+      // findPath(target="ScreenA") searches outward from ScreenA, but the only
+      // recorded edges point forward (A->B->C), so no path back to ScreenA is
+      // found and a depth-2 gap cannot be safely closed with the back button.
+      expect(result.shouldUseBack).toBe(false);
+      expect(result.backPresses).toBe(0);
+      expect(result.reason).toBe("No known navigation path to verify safety");
     });
   });
 

--- a/test/features/navigation/TestCoverageAnalyzer.test.ts
+++ b/test/features/navigation/TestCoverageAnalyzer.test.ts
@@ -44,6 +44,10 @@ class FakeNavigationRepository {
   }
 }
 
+// These arrays keep the single-linear-scan RATCHET (a second full iteration
+// throws) but no longer ban specific Array methods. The iterationCount guard
+// pins the observable O(n) property; filter()/some()/find() bans only dictated
+// *how* the indexing is done, over-constraining the implementation (#4171).
 class NoRepeatedScanEdges extends Array<NavigationEdge> {
   iterationCount = 0;
 
@@ -53,14 +57,6 @@ class NoRepeatedScanEdges extends Array<NavigationEdge> {
       throw new Error("expected edges to be indexed once, not scanned again per gap");
     }
     return super[Symbol.iterator]();
-  }
-
-  filter(): NavigationEdge[] {
-    throw new Error("expected edge lookups to use precomputed maps instead of filter()");
-  }
-
-  some(): boolean {
-    throw new Error("expected entry-point lookup to use precomputed in-degree map instead of some()");
   }
 }
 
@@ -73,10 +69,6 @@ class NoRepeatedScanNodes extends Array<NavigationNode> {
       throw new Error("expected nodes to be indexed once, not scanned again per gap");
     }
     return super[Symbol.iterator]();
-  }
-
-  find(): NavigationNode | undefined {
-    throw new Error("expected node lookups to use precomputed map instead of find()");
   }
 }
 
@@ -135,7 +127,7 @@ function analyzerFor(
 }
 
 describe("TestCoverageAnalyzer", () => {
-  test("uses precomputed graph lookups while preserving critical gap scoring", async () => {
+  test("scores critical coverage gaps in a single pass over nodes and edges", async () => {
     const nodes = new NoRepeatedScanNodes(
       node(1, "Home", 10),
       node(2, "Search", 6),

--- a/test/features/navigation/UIStateExtractor.test.ts
+++ b/test/features/navigation/UIStateExtractor.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { UIStateExtractor } from "../../../src/features/navigation/UIStateExtractor";
 import { ObserveResult } from "../../../src/models";
+import type { SwipeOnOptions } from "../../../src/models";
 import { ViewHierarchyResult } from "../../../src/models/ViewHierarchyResult";
 
 describe("UIStateExtractor (iOS hierarchy)", () => {
@@ -105,5 +106,72 @@ describe("UIStateExtractor (iOS hierarchy)", () => {
       windowId: 22,
       windowType: "3"
     });
+  });
+});
+
+describe("UIStateExtractor.createScrollPosition", () => {
+  function opts(overrides: Partial<SwipeOnOptions>): SwipeOnOptions {
+    return { direction: "up", ...overrides } as SwipeOnOptions;
+  }
+
+  test("returns undefined when there is no lookFor element search", () => {
+    expect(UIStateExtractor.createScrollPosition(opts({ direction: "up" }))).toBeUndefined();
+  });
+
+  test("returns undefined when the swipe direction is missing", () => {
+    const noDirection = { lookFor: { text: "Save" } } as unknown as SwipeOnOptions;
+    expect(UIStateExtractor.createScrollPosition(noDirection)).toBeUndefined();
+  });
+
+  test("records the finger direction verbatim for a default finger-gesture scroll", () => {
+    const result = UIStateExtractor.createScrollPosition(
+      opts({ lookFor: { text: "Save" }, direction: "up" })
+    );
+    expect(result?.direction).toBe("up");
+    expect(result?.targetElement).toEqual({ text: "Save", resourceId: undefined });
+  });
+
+  test("inverts the direction for a scrollTowardsDirection content gesture", () => {
+    // Content scrolling "down" is revealed by a finger swipe "up"
+    // (SCROLL_TO_FINGER_DIRECTION.down === "up"). A non-inverting mutant that
+    // maps down -> down is caught here.
+    const result = UIStateExtractor.createScrollPosition(
+      opts({
+        lookFor: { text: "Save" },
+        direction: "down",
+        gestureType: "scrollTowardsDirection",
+      })
+    );
+    expect(result?.direction).toBe("up");
+  });
+
+  test("carries the requested scroll speed onto the scroll position", () => {
+    const result = UIStateExtractor.createScrollPosition(
+      opts({ lookFor: { text: "Save" }, direction: "up", speed: "fast" })
+    );
+    expect(result?.speed).toBe("fast");
+  });
+
+  test("captures container text and resource id when a container is specified", () => {
+    const result = UIStateExtractor.createScrollPosition(
+      opts({
+        lookFor: { elementId: "id/save" },
+        direction: "up",
+        container: { text: "List", elementId: "id/list" },
+      })
+    );
+    expect(result?.targetElement).toEqual({ text: undefined, resourceId: "id/save" });
+    expect(result?.container).toEqual({ text: "List", resourceId: "id/list" });
+  });
+
+  test("records a target-less scroll position for an empty lookFor", () => {
+    const result = UIStateExtractor.createScrollPosition(
+      opts({ lookFor: {}, direction: "up" })
+    );
+    expect(result).toBeDefined();
+    expect(result?.direction).toBe("up");
+    expect(result?.targetElement).toEqual({ text: undefined, resourceId: undefined });
+    expect(result?.speed).toBeUndefined();
+    expect(result?.container).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Milestone 32 (Unit Test Quality Audit), slice **navigation**: 22 verified test-quality
findings burned down, each verified red-green. **One surgical `src` fix**: `ScreenFingerprint`
now honors an explicit `cacheTTL: 0` (`options.cacheTTL || DEFAULT` → `?? DEFAULT`) so a
"no cache" request isn't swallowed. P1's blocker word-boundary fix already landed on main via
#4203 — its guard is verified here (reverting to substring matching reds 10 rows).

- New unit coverage for previously-dark units: `DefaultPathOptimizer`,
  `DefaultScreenTransitionWaiter`, `createScrollPosition` tables; `NavigateTo` failure envelopes
  (timeout / step-throw / back-edge, real `durationMs`); `detectAndHandleBlockers` precedence +
  bail-out; graph-listener and hierarchy-callback isolation (one throwing listener/callback must
  not kill the rest); `exportGraphHistory` limit/cursor boundaries; the `cacheTTL: 0` row;
  `SelectionStateDetector` confidence/crop; `dispose` non-leak.
- `FakeNavigationGraphManager` now supports multiple graph-update listeners.
- Deletes a source-shape test + the tests R4 subsumes; softens method-choice bans to keep only
  the `iterationCount` ratchet. Behavior-first renames.

R3 records the current (buggy) `coveragePercentage === 0` with follow-up #4498 filed for the
formula (2/2 nodes + 1/1 edges should read ~100%).

## Linked Issue

Closes #4171

## Validation

- [x] `bun test`: **10543 tests, 0 fail / 13 skip** across 796 files (rebased on current main)
- [x] `bun run typecheck`: no new errors (206 baseline)
- [x] `bun run lint`: clean

## Follow-ups

- [ ] #4498 — `coveragePercentage` reports 0% when all nodes/edges are covered (formula bug).
- [ ] The issue's `§Deletes` / `§RENAME` tables were truncated in its body; the concrete anchors
  were actioned, the remainder needs a follow-up pass once the full tables are retrievable.
