### PR TITLE
test(utils): property-based tests for CommandError (surfaces a null-error crash)

### DIFF
--- a/test/utils/CommandError.property.test.ts
+++ b/test/utils/CommandError.property.test.ts
@@ -1,0 +1,129 @@
+import { describe, test } from "bun:test";
+import fc from "fast-check";
+import { formatCommandError, wrapCommandError } from "../../src/utils/CommandError";
+
+// Property-based tests. See Backoff.property.test.ts for the pinned-seed rationale.
+const RUN_OPTIONS = { seed: 1_234_567, numRuns: 300 } as const;
+
+const MAX = 4000;
+// Newline-free tokens so the structured, line-per-field output stays parseable.
+const safe = fc.string({ unit: fc.constantFrom("a", "b", "/", ".", "-", "_", " ", "1"), maxLength: 12 });
+const options = fc.record(
+  {
+    command: safe,
+    args: fc.array(safe, { maxLength: 3 }),
+    cwd: fc.option(safe.filter(s => s.length > 0), { nil: undefined }),
+    stdout: fc.option(fc.string({ maxLength: 40 }), { nil: undefined }),
+    stderr: fc.option(fc.string({ maxLength: 40 }), { nil: undefined })
+  },
+  { requiredKeys: ["command"] }
+);
+
+// DEFECT SURFACED (see PR body + follow-up fix task): formatCommandError THROWS
+// on a null/undefined `error` — it dereferences `err.stdout` (line 40) before
+// null-checking. Scope the error generator to the realistic non-null caught-error
+// domain (Error objects, primitives, plain objects), which do not crash.
+const errorValue = fc.anything().filter(v => v !== null && v !== undefined);
+
+const excerpt = (v: string): string => {
+  const t = v.trim();
+  return t.length <= MAX ? t : `...${t.slice(-MAX)}`;
+};
+
+describe("formatCommandError (property-based)", () => {
+  test("is total and opens with the failed command line", () => {
+    fc.assert(
+      fc.property(errorValue, options, (error, opts) => {
+        const out = formatCommandError(error, opts);
+        const commandLine = [opts.command, ...(opts.args ?? [])].join(" ");
+        return typeof out === "string" && out.startsWith(`Command failed: ${commandLine}`);
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("always includes a raw-error line", () => {
+    fc.assert(
+      fc.property(errorValue, options, (error, opts) => formatCommandError(error, opts).includes("raw error:")),
+      RUN_OPTIONS
+    );
+  });
+
+  test("includes a cwd line exactly when cwd is provided", () => {
+    fc.assert(
+      fc.property(errorValue, options, (error, opts) => {
+        const hasCwdLine = formatCommandError(error, opts).split("\n").includes(`cwd: ${opts.cwd}`);
+        return hasCwdLine === (opts.cwd !== undefined);
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("renders numeric err.code as an exit code and string err.code as an error code", () => {
+    const code = fc.oneof(fc.integer(), fc.string({ maxLength: 6 }), fc.constant(undefined));
+    fc.assert(
+      fc.property(fc.string({ maxLength: 10 }), code, options, (message, c, opts) => {
+        const err = new Error(message) as Error & { code?: unknown };
+        if (c !== undefined) {
+          err.code = c;
+        }
+        const lines = formatCommandError(err, opts).split("\n");
+        if (typeof c === "number") {
+          return lines.includes(`exit code: ${c}`) && !lines.some(l => l.startsWith("error code:"));
+        }
+        if (typeof c === "string") {
+          return lines.includes(`error code: ${c}`) && !lines.some(l => l.startsWith("exit code:"));
+        }
+        return !lines.some(l => l.startsWith("exit code:") || l.startsWith("error code:"));
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("includes an stdout section exactly when the stdout has non-whitespace content", () => {
+    fc.assert(
+      fc.property(fc.string({ maxLength: 40 }), options, (stdout, opts) => {
+        const out = formatCommandError(new Error("x"), { ...opts, stdout, stderr: undefined });
+        const hasSection = out.includes("stdout: (last");
+        return hasSection === (stdout.trim().length > 0);
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("bounds each output excerpt to at most MAX+3 chars and reproduces the excerpt oracle", () => {
+    const maybeLong = fc.string({ maxLength: 4300 });
+    fc.assert(
+      fc.property(maybeLong, opts => {
+        const out = formatCommandError(new Error("x"), { command: "cmd", stdout: opts });
+        const ex = excerpt(opts);
+        return ex.length <= MAX + 3 && (ex.length === 0 || out.includes(ex));
+      }),
+      RUN_OPTIONS
+    );
+  });
+});
+
+describe("wrapCommandError (property-based)", () => {
+  test("wraps into an Error whose message is the formatted string", () => {
+    fc.assert(
+      fc.property(errorValue, options, (error, opts) => {
+        const wrapped = wrapCommandError(error, opts);
+        return wrapped instanceof Error && wrapped.message === formatCommandError(error, opts);
+      }),
+      RUN_OPTIONS
+    );
+  });
+
+  test("preserves the original error's name when the input is an Error", () => {
+    const named = fc.string({ maxLength: 12 }).map(n => {
+      const e = new Error("boom");
+      e.name = n || "Error";
+      return e;
+    });
+    fc.assert(
+      fc.property(named, options, (error, opts) => wrapCommandError(error, opts).name === error.name),
+      RUN_OPTIONS
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Continues the fast-check property-testing expansion (pattern from [PR #4427](https://github.com/kaeawc/auto-mobile/pull/4427)) with `src/utils/CommandError.ts` — and **surfaced a genuine defect** in the process. Test-only, additive — no production changes, no new dependencies.

Invariants asserted:

- **`formatCommandError`** — total over non-null errors, opens with `Command failed: <command> <args>`; always includes a `raw error:` line; includes a `cwd:` line **exactly** when `cwd` is provided; renders a numeric `err.code` as `exit code: N` and a string `err.code` as `error code: X`; includes an `stdout:` section **exactly** when stdout has non-whitespace content; bounds each output excerpt to `MAX + 3` chars (the `...`-prefixed last-4000 tail), reproduced against an independent excerpt oracle.
- **`wrapCommandError`** — returns an `Error` whose `message` equals the formatted string; preserves the original error's `name` when the input is an `Error`.

## 🐞 Defect surfaced (not hidden)

`formatCommandError(null | undefined, opts)` **throws** instead of formatting:

```
TypeError: undefined is not an object (evaluating 'err.stdout')
```

**Repro:**
```ts
formatCommandError(undefined, { command: "adb" }); // throws
formatCommandError(null, { command: "adb" });      // throws
```

**Mechanism:** [CommandError.ts:34-40](src/utils/CommandError.ts#L34-L40) casts `error` to `err`, then line 40 evaluates `textFrom(err.stdout)` (and line 41 `err.stderr`). When `error` is `null`/`undefined`, `err` is nullish and the property access throws. It only triggers when `options.stdout` is also falsy (otherwise `||` short-circuits before reaching `err.stdout`). The message on line 39 already handles nullish `error` via `String(error)`, but the stdout/stderr reads assume `err` is an object. A `catch (e)` where `e` is `undefined` (or a `throw undefined`) hits this.

**Fix (follow-up):** null-guard the cast, e.g. `const err = (error ?? {}) as …` (or optional-chain the `err.stdout`/`err.stderr` reads). A follow-up task is filed; once it lands, the `error` generator here can be widened back to `fc.anything()` and the totality property will hold for all inputs.

**In this PR:** the error generator is deliberately scoped to non-null values (with an in-file note) so the suite is green and mergeable — the defect is documented here rather than papered over.

## Validation

- [x] `bun test test/utils/CommandError.property.test.ts` — 8 pass, ~150ms
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] `bun run lint` — no new violations
- [x] New tests are pure (no device/network/filesystem/DB); each runs in <100ms

## Note

Commit is **unsigned** — the local 1Password SSH signing agent is erroring; pushed over HTTPS. The repo does not enforce signed commits.
