### PR TITLE
test(a11y): burn down 23 verified test-quality findings (#4179)

### DIFF
--- a/src/features/accessibility/BaselineManager.ts
+++ b/src/features/accessibility/BaselineManager.ts
@@ -7,6 +7,7 @@ import { getDatabase } from "../../db/database";
 import type { Database } from "../../db/types";
 import type { WcagViolation } from "../../models/AccessibilityAudit";
 import { getCutoffDate, DEFAULT_TTL } from "../shared/MetricsUtils";
+import { logger } from "../../utils/logger";
 
 interface BaselineData {
   screenId: string;
@@ -48,11 +49,34 @@ export class BaselineManager {
       return null;
     }
 
+    const violations = this.parseViolations(result.violations_json, result.screen_id);
+    if (violations === null) {
+      // A corrupt row is treated as "no usable baseline" rather than letting a
+      // raw SyntaxError escape getBaseline (issue #4179).
+      return null;
+    }
+
     return {
       screenId: result.screen_id,
-      violations: JSON.parse(result.violations_json),
+      violations,
       updatedAt: result.updated_at,
     };
+  }
+
+  /**
+   * Parse a stored `violations_json` blob, returning null (and logging) when the
+   * row is corrupt rather than throwing a raw `SyntaxError` at the read boundary.
+   */
+  private parseViolations(violationsJson: string, screenId: string): WcagViolation[] | null {
+    try {
+      return JSON.parse(violationsJson) as WcagViolation[];
+    } catch (error) {
+      logger.warn(
+        `[BaselineManager] Corrupt violations_json for screen "${screenId}"; ignoring baseline row`,
+        error
+      );
+      return null;
+    }
   }
 
   /**
@@ -102,11 +126,21 @@ export class BaselineManager {
       .selectAll()
       .execute();
 
-    return results.map(row => ({
-      screenId: row.screen_id,
-      violations: JSON.parse(row.violations_json),
-      updatedAt: row.updated_at,
-    }));
+    const baselines: BaselineData[] = [];
+    for (const row of results) {
+      const violations = this.parseViolations(row.violations_json, row.screen_id);
+      if (violations === null) {
+        // Skip a corrupt row instead of letting a raw SyntaxError escape
+        // listBaselines (issue #4179).
+        continue;
+      }
+      baselines.push({
+        screenId: row.screen_id,
+        violations,
+        updatedAt: row.updated_at,
+      });
+    }
+    return baselines;
   }
 
   /**

--- a/src/features/accessibility/SecureSettingsRpc.ts
+++ b/src/features/accessibility/SecureSettingsRpc.ts
@@ -1,0 +1,53 @@
+import type { BootedDevice } from "../../models";
+import type { SettingsValueType } from "../observe/android/types";
+import { AndroidCtrlProxyClient } from "../observe/android/AndroidCtrlProxyClient";
+
+/**
+ * Result of a secure-settings write via the accessibility service.
+ */
+export interface SecureSettingsPutResult {
+  success: boolean;
+}
+
+/**
+ * Result of a secure-settings read via the accessibility service.
+ */
+export interface SecureSettingsGetResult {
+  success: boolean;
+  found: boolean;
+  value?: string;
+}
+
+/**
+ * Narrow seam over the CtrlProxy accessibility-service `Settings.Secure` RPC.
+ *
+ * TalkBackToggle only ever touches the `secure` namespace, so this interface
+ * bakes that in and exposes exactly the two operations the toggle needs. It
+ * exists so the a11y-first / ADB-fallback path can be unit-tested with a fake
+ * instead of forcing `AndroidCtrlProxyClient.getInstance(device)` to build a
+ * real `AdbClient` into the static singleton map (issue #4179).
+ */
+export interface SecureSettingsRpc {
+  put(key: string, value: string | null, valueType?: SettingsValueType): Promise<SecureSettingsPutResult>;
+  get(key: string): Promise<SecureSettingsGetResult>;
+}
+
+/**
+ * Production adapter that resolves the live CtrlProxy client lazily (only when a
+ * setting is actually written/read) and delegates to its secure-namespace RPC.
+ */
+export class CtrlProxySecureSettingsRpc implements SecureSettingsRpc {
+  constructor(private readonly device: BootedDevice) {}
+
+  async put(key: string, value: string | null, valueType?: SettingsValueType): Promise<SecureSettingsPutResult> {
+    const client = AndroidCtrlProxyClient.getInstance(this.device);
+    const result = await client.requestSettingsPut("secure", key, value, valueType);
+    return { success: result.success };
+  }
+
+  async get(key: string): Promise<SecureSettingsGetResult> {
+    const client = AndroidCtrlProxyClient.getInstance(this.device);
+    const result = await client.requestSettingsGet("secure", key);
+    return { success: result.success, found: result.found, value: result.value };
+  }
+}

--- a/src/features/accessibility/TalkBackToggle.ts
+++ b/src/features/accessibility/TalkBackToggle.ts
@@ -6,7 +6,7 @@ import { defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbCl
 import type { AccessibilityDetector } from "../../utils/interfaces/AccessibilityDetector";
 import { accessibilityDetector } from "../../utils/AccessibilityDetector";
 import { type Timer, defaultTimer } from "../../utils/SystemTimer";
-import { AndroidCtrlProxyClient } from "../observe/android/AndroidCtrlProxyClient";
+import { type SecureSettingsRpc, CtrlProxySecureSettingsRpc } from "./SecureSettingsRpc";
 
 const TALKBACK_PACKAGE = "com.google.android.marvin.talkback";
 const TALKBACK_SERVICE_FALLBACK = `${TALKBACK_PACKAGE}/${TALKBACK_PACKAGE}.TalkBackService`;
@@ -15,14 +15,17 @@ const DIALOG_DISMISS_DELAY_MS = 500;
 
 export class TalkBackToggle {
   private readonly adb: AdbExecutor;
+  private readonly secureSettings: SecureSettingsRpc;
 
   constructor(
     private readonly device: BootedDevice,
     adb: AdbExecutor | null = null,
     private readonly detector: AccessibilityDetector = accessibilityDetector,
-    private readonly timer: Timer = defaultTimer
+    private readonly timer: Timer = defaultTimer,
+    secureSettings: SecureSettingsRpc | null = null
   ) {
     this.adb = adb ?? defaultAdbClientFactory.create(device);
+    this.secureSettings = secureSettings ?? new CtrlProxySecureSettingsRpc(device);
   }
 
   async toggle(enabled: boolean): Promise<TalkBackResult> {
@@ -105,8 +108,7 @@ export class TalkBackToggle {
   // because Settings.Secure writes require system-app privileges that the service may lack.
   private async writeSecureSetting(key: string, value: string, valueType: "string" | "int" = "string"): Promise<void> {
     try {
-      const a11y = AndroidCtrlProxyClient.getInstance(this.device);
-      const result = await a11y.requestSettingsPut("secure", key, value, valueType);
+      const result = await this.secureSettings.put(key, value, valueType);
       if (result.success) {
         return;
       }
@@ -118,8 +120,7 @@ export class TalkBackToggle {
 
   private async deleteSecureSetting(key: string): Promise<void> {
     try {
-      const a11y = AndroidCtrlProxyClient.getInstance(this.device);
-      const result = await a11y.requestSettingsPut("secure", key, null);
+      const result = await this.secureSettings.put(key, null);
       if (result.success) {
         return;
       }
@@ -131,8 +132,7 @@ export class TalkBackToggle {
 
   private async readSecureSetting(key: string): Promise<string> {
     try {
-      const a11y = AndroidCtrlProxyClient.getInstance(this.device);
-      const result = await a11y.requestSettingsGet("secure", key);
+      const result = await this.secureSettings.get(key);
       if (result.success) {
         return result.found ? (result.value ?? "") : "";
       }

--- a/src/features/accessibility/WcagAudit.ts
+++ b/src/features/accessibility/WcagAudit.ts
@@ -22,9 +22,9 @@ export class WcagAudit {
   private baselineManager: BaselineManager;
   private timer: Timer;
 
-  constructor(timer: Timer = defaultTimer) {
+  constructor(timer: Timer = defaultTimer, baselineManager: BaselineManager = new BaselineManager()) {
     this.contrastChecker = new ContrastChecker({}, timer);
-    this.baselineManager = new BaselineManager();
+    this.baselineManager = baselineManager;
     this.timer = timer;
   }
 

--- a/src/features/talkback/FocusNavigationExecutor.ts
+++ b/src/features/talkback/FocusNavigationExecutor.ts
@@ -139,7 +139,13 @@ export class FocusNavigationExecutor {
 
     const driver = this.driverFactory.createDriver(device);
     const screenSize = await driver.getScreenSize();
-    if (!screenSize || !Number.isFinite(screenSize.width) || !Number.isFinite(screenSize.height)) {
+    if (
+      !screenSize ||
+      !Number.isFinite(screenSize.width) ||
+      !Number.isFinite(screenSize.height) ||
+      screenSize.width <= 0 ||
+      screenSize.height <= 0
+    ) {
       throw new ActionableError("Unable to determine screen size for focus navigation.");
     }
 

--- a/test/fakes/FakeSecureSettingsRpc.ts
+++ b/test/fakes/FakeSecureSettingsRpc.ts
@@ -1,0 +1,42 @@
+import type {
+  SecureSettingsRpc,
+  SecureSettingsGetResult,
+  SecureSettingsPutResult
+} from "../../src/features/accessibility/SecureSettingsRpc";
+import type { SettingsValueType } from "../../src/features/observe/android/types";
+
+/**
+ * Fake {@link SecureSettingsRpc} for TalkBackToggle unit tests.
+ *
+ * Defaults to reporting the a11y-service path as unavailable (`put`/`get` return
+ * `success: false`) so the toggle falls back to the injected ADB executor —
+ * mirroring the real behaviour when no CtrlProxy accessibility service is
+ * connected, WITHOUT building a real `AdbClient` into the static singleton map
+ * (issue #4179). Tests that want to exercise the a11y-first path flip
+ * {@link setPutResult}/{@link setGetResult}.
+ */
+export class FakeSecureSettingsRpc implements SecureSettingsRpc {
+  private putResult: SecureSettingsPutResult = { success: false };
+  private getResult: SecureSettingsGetResult = { success: false, found: false };
+
+  public readonly putCalls: Array<{ key: string; value: string | null; valueType?: SettingsValueType }> = [];
+  public readonly getCalls: string[] = [];
+
+  setPutResult(result: SecureSettingsPutResult): void {
+    this.putResult = result;
+  }
+
+  setGetResult(result: SecureSettingsGetResult): void {
+    this.getResult = result;
+  }
+
+  async put(key: string, value: string | null, valueType?: SettingsValueType): Promise<SecureSettingsPutResult> {
+    this.putCalls.push({ key, value, valueType });
+    return this.putResult;
+  }
+
+  async get(key: string): Promise<SecureSettingsGetResult> {
+    this.getCalls.push(key);
+    return this.getResult;
+  }
+}

--- a/test/features/accessibility/BaselineManager.test.ts
+++ b/test/features/accessibility/BaselineManager.test.ts
@@ -10,7 +10,7 @@
  * production.
  */
 
-import { expect, describe, it, beforeEach, afterEach } from "bun:test";
+import { expect, describe, it, test, beforeEach, afterEach } from "bun:test";
 import type { WcagViolation } from "../../../src/models/AccessibilityAudit";
 import { createTestDatabase } from "../../db/testDbHelper";
 import { BaselineManager } from "../../../src/features/accessibility/BaselineManager";
@@ -296,6 +296,40 @@ describe("BaselineManager", function() {
       const baseline = await manager.getBaseline(screenId);
       expect(baseline).not.toBeNull();
       expect(baseline!.screenId).toBe(screenId);
+    });
+
+    test("getBaseline returns null instead of throwing when a row has corrupt violations_json", async function() {
+      const now = new Date().toISOString();
+      await testDb
+        .insertInto("accessibility_baselines")
+        .values({
+          screen_id: "corrupt_screen",
+          violations_json: "{ this is not valid json",
+          created_at: now,
+          updated_at: now,
+        })
+        .execute();
+
+      // A raw SyntaxError must not escape the read boundary (issue #4179).
+      const baseline = await manager.getBaseline("corrupt_screen");
+      expect(baseline).toBeNull();
+    });
+
+    test("listBaselines skips a corrupt row and still returns the intact ones", async function() {
+      const now = new Date().toISOString();
+      await manager.saveBaseline("good_screen", []);
+      await testDb
+        .insertInto("accessibility_baselines")
+        .values({
+          screen_id: "corrupt_screen",
+          violations_json: "not json at all",
+          created_at: now,
+          updated_at: now,
+        })
+        .execute();
+
+      const baselines = await manager.listBaselines();
+      expect(baselines.map(b => b.screenId)).toEqual(["good_screen"]);
     });
 
     it("should store and retrieve updated_at timestamp", async function() {

--- a/test/features/accessibility/ContrastChecker.test.ts
+++ b/test/features/accessibility/ContrastChecker.test.ts
@@ -8,6 +8,7 @@ import * as path from "path";
 import { ContrastChecker } from "../../../src/features/accessibility/ContrastChecker";
 import type { Element } from "../../../src/models/Element";
 import { FakeImageBackend } from "../../fakes/FakeImageBackend";
+import { FakeTimer } from "../../fakes/FakeTimer";
 
 /** Build a uniform RGBA raw image for backend-seam tests. */
 function uniformRaw(width: number, height: number, r: number, g: number, b: number): {
@@ -277,16 +278,18 @@ describe("ContrastChecker", function() {
 
       const result = await checker.checkContrast(screenshotPath, edgeElement, "AA");
 
-      // Should either return valid result or null, but not throw
-      if (result !== null) {
-        expect(result.ratio).toBeTypeOf("number");
-      }
+      // A 5x5 element flush against the image edge is analyzable (>= 2px on both
+      // axes) and must yield a concrete, finite ratio >= 1 — not silently null.
+      expect(result).not.toBeNull();
+      expect(Number.isFinite(result!.ratio)).toBe(true);
+      expect(result!.ratio).toBeGreaterThanOrEqual(1);
     });
 
     it("should handle elements larger than screenshot", async function() {
       const screenshotPath = path.join(fixturesDir, "small-element.png");
 
-      // Element bounds larger than the 20x10 image
+      // Element bounds larger than the image: pixel sampling edge-clamps rather
+      // than throwing, so this must still produce a finite ratio >= 1.
       const oversizedElement: Element = {
         bounds: { left: 0, top: 0, right: 200, bottom: 100 },
         text: "Oversized",
@@ -294,8 +297,9 @@ describe("ContrastChecker", function() {
 
       const result = await checker.checkContrast(screenshotPath, oversizedElement, "AA");
 
-      // Should handle gracefully
-      expect(result === null || typeof result?.ratio === "number").toBe(true);
+      expect(result).not.toBeNull();
+      expect(Number.isFinite(result!.ratio)).toBe(true);
+      expect(result!.ratio).toBeGreaterThanOrEqual(1);
     });
   });
 
@@ -433,6 +437,111 @@ describe("ContrastChecker", function() {
       const result = await seamChecker.checkContrast(syntheticScreenshotPath, element, "AA");
 
       expect(result).not.toBeNull();
+    });
+  });
+
+  describe("Required ratio (parameterized)", function() {
+    // getRequiredContrastRatio keys off isLargeText (height >= 24) and the level.
+    // 23/24/25 straddle the large-text boundary; level "A" falls through to the
+    // same ratios as AA. requiredRatio is independent of the sampled contrast,
+    // so a uniform fake image is sufficient and keeps this fast.
+    function ratioChecker(): ContrastChecker {
+      const backend = new FakeImageBackend();
+      backend.setRawPixelsResult(uniformRaw(200, 200, 255, 255, 255));
+      return new ContrastChecker({}, new FakeTimer(), backend, {
+        readFile: async () => Buffer.from("synthetic"),
+      });
+    }
+
+    it.each([
+      [23, "A", 4.5],
+      [24, "A", 3.0],
+      [25, "A", 3.0],
+      [23, "AA", 4.5],
+      [24, "AA", 3.0],
+      [25, "AA", 3.0],
+      [23, "AAA", 7.0],
+      [24, "AAA", 4.5],
+      [25, "AAA", 4.5],
+    ])(
+      "height %i at level %s requires %f:1",
+      async function(height, level, expected) {
+        const element: Element = {
+          bounds: { left: 0, top: 0, right: 100, bottom: height as number },
+          text: "Sample",
+        };
+        const result = await ratioChecker().checkContrast(
+          syntheticScreenshotPath,
+          element,
+          level as "A" | "AA" | "AAA"
+        );
+
+        expect(result).not.toBeNull();
+        expect(result!.requiredRatio).toBe(expected as number);
+      }
+    );
+  });
+
+  describe("Screenshot cache (TTL + fingerprint)", function() {
+    // A real fixture path is used where a STABLE fingerprint is needed:
+    // getScreenshotFingerprint stats the real file, so its mtime/size are fixed
+    // across a FakeTimer advance — isolating the TTL check from the fingerprint
+    // check. Element caching is disabled so the second call actually reaches the
+    // screenshot cache instead of short-circuiting on the element result.
+    const realFixture = path.join(fixturesDir, "black-on-white.png");
+    const element: Element = {
+      bounds: { left: 0, top: 0, right: 100, bottom: 50 },
+      text: "Sample",
+    };
+
+    function cachingChecker(timer: FakeTimer, backend: FakeImageBackend): ContrastChecker {
+      return new ContrastChecker({ enableElementCache: false }, timer, backend, {
+        readFile: async () => Buffer.from("synthetic"),
+      });
+    }
+
+    it("decodes once when the same screenshot is reused within the TTL", async function() {
+      const timer = new FakeTimer();
+      const backend = new FakeImageBackend();
+      backend.setRawPixelsResult(uniformRaw(100, 50, 255, 255, 255));
+      const cache = cachingChecker(timer, backend);
+
+      await cache.checkContrast(realFixture, element, "AA");
+      // No time advance and an unchanged (real-file) fingerprint → cache hit.
+      await cache.checkContrast(realFixture, element, "AA");
+
+      expect(backend.rawPixelsCalls).toHaveLength(1);
+    });
+
+    it("re-decodes a screenshot whose cache entry has aged past the TTL", async function() {
+      const timer = new FakeTimer();
+      const backend = new FakeImageBackend();
+      backend.setRawPixelsResult(uniformRaw(100, 50, 255, 255, 255));
+      const cache = cachingChecker(timer, backend);
+
+      await cache.checkContrast(realFixture, element, "AA");
+      // Age the entry past the default 60s TTL. The fingerprint is stable (real
+      // file stat), so ONLY the TTL expiry can force the re-decode.
+      timer.advanceTime(60_001);
+      await cache.checkContrast(realFixture, element, "AA");
+
+      expect(backend.rawPixelsCalls).toHaveLength(2);
+    });
+
+    it("re-decodes when the screenshot fingerprint changes within the TTL", async function() {
+      const timer = new FakeTimer();
+      const backend = new FakeImageBackend();
+      backend.setRawPixelsResult(uniformRaw(100, 50, 255, 255, 255));
+      const cache = cachingChecker(timer, backend);
+
+      // A nonexistent path makes the fingerprint fall back to `path:timer.now()`,
+      // so a small (sub-TTL) advance changes the fingerprint without expiring the
+      // TTL — isolating the fingerprint check.
+      await cache.checkContrast(syntheticScreenshotPath, element, "AA");
+      timer.advanceTime(100);
+      await cache.checkContrast(syntheticScreenshotPath, element, "AA");
+
+      expect(backend.rawPixelsCalls).toHaveLength(2);
     });
   });
 });

--- a/test/features/accessibility/TalkBackToggle.test.ts
+++ b/test/features/accessibility/TalkBackToggle.test.ts
@@ -3,6 +3,7 @@ import { TalkBackToggle } from "../../../src/features/accessibility/TalkBackTogg
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { FakeAccessibilityDetector } from "../../fakes/FakeAccessibilityDetector";
 import { FakeTimer } from "../../fakes/FakeTimer";
+import { FakeSecureSettingsRpc } from "../../fakes/FakeSecureSettingsRpc";
 import type { BootedDevice } from "../../../src/models";
 
 const ANDROID_DEVICE: BootedDevice = {
@@ -10,17 +11,6 @@ const ANDROID_DEVICE: BootedDevice = {
   name: "Pixel 7 API 35",
   platform: "android"
 };
-
-const DUMPSYS_WITH_TALKBACK = `
-Installed Services:
-  Service[label=TalkBack, feedbackType[spokenFeedback], targetSdkVersion=32]
-    Id: com.google.android.marvin.talkback/com.google.android.marvin.talkback.TalkBackService
-`;
-
-const DUMPSYS_WITHOUT_TALKBACK = `
-Installed Services:
-  (none)
-`;
 
 const PACKAGE_LIST_WITH_TALKBACK = `
 package:com.google.android.marvin.talkback
@@ -53,12 +43,17 @@ describe("TalkBackToggle", () => {
   let fakeAdb: FakeAdbExecutor;
   let fakeDetector: FakeAccessibilityDetector;
   let fakeTimer: FakeTimer;
+  let fakeSecureSettings: FakeSecureSettingsRpc;
 
   beforeEach(() => {
     fakeAdb = new FakeAdbExecutor();
     fakeDetector = new FakeAccessibilityDetector();
     fakeTimer = new FakeTimer();
     fakeTimer.enableAutoAdvance();
+    // Default: a11y-service path unavailable, so writes fall back to ADB (the
+    // path the existing assertions target). No real AdbClient enters the static
+    // singleton map (issue #4179).
+    fakeSecureSettings = new FakeSecureSettingsRpc();
     fakeAdb.setCommandResponse(
       "pm list packages com.google.android.marvin.talkback",
       makeExecResult(PACKAGE_LIST_WITH_TALKBACK)
@@ -73,12 +68,11 @@ describe("TalkBackToggle", () => {
 
   describe("enable TalkBack", () => {
     test("returns supported:true applied:true when TalkBack is installed and currently disabled", async () => {
-      fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
       // Pre-apply idempotency detect: not talkback -> proceed. Post-apply
       // confirmation detect: talkback -> applied:true (#3921).
       fakeDetector.enqueueDetectMethodResults("unknown", "talkback");
 
-      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
       const result = await toggle.toggle(true);
 
       expect(result.supported).toBe(true);
@@ -88,12 +82,11 @@ describe("TalkBackToggle", () => {
     });
 
     test("reports applied:false when TalkBack did not activate after apply (e.g. consent dialog blocked it)", async () => {
-      fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
       // Idempotency detect: not talkback -> proceed. Confirmation detect: STILL
       // not talkback -> the toggle must not claim success optimistically (#3921).
       fakeDetector.enqueueDetectMethodResults("unknown", "unknown");
 
-      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
       const result = await toggle.toggle(true);
 
       expect(result.supported).toBe(true);
@@ -102,10 +95,9 @@ describe("TalkBackToggle", () => {
     });
 
     test("runs the correct enable ADB commands", async () => {
-      fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
       fakeDetector.setDefaultResult(false);
 
-      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
       await toggle.toggle(true);
 
       expect(
@@ -119,20 +111,18 @@ describe("TalkBackToggle", () => {
     });
 
     test("invalidates the detector cache after enabling", async () => {
-      fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
       fakeDetector.setDefaultResult(false);
 
-      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
       await toggle.toggle(true);
 
       expect(fakeDetector.getInvalidatedDevices()).toContain(ANDROID_DEVICE.deviceId);
     });
 
     test("invalidates cache before idempotency check to avoid stale state", async () => {
-      fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
       fakeDetector.setDefaultResult(false);
 
-      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
       await toggle.toggle(true);
 
       // Cache must have been invalidated at least once before detectMethod was called
@@ -140,10 +130,9 @@ describe("TalkBackToggle", () => {
     });
 
     test("attempts dialog dismissal via a file dump (not /dev/tty) after enabling", async () => {
-      fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
       fakeDetector.setDefaultResult(false);
 
-      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
       await toggle.toggle(true);
 
       // #3921: dump to a device file and read it back, never to /dev/tty.
@@ -153,14 +142,13 @@ describe("TalkBackToggle", () => {
     });
 
     test("taps Allow button when permission dialog is present (English)", async () => {
-      fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
       fakeAdb.setCommandResponse(
         "shell cat /sdcard/window_dump.xml",
         makeExecResult(DIALOG_XML_WITH_BUTTON1)
       );
       fakeDetector.setDefaultResult(false);
 
-      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
       await toggle.toggle(true);
 
       // Center of [180,684][540,740] = (360, 712)
@@ -168,14 +156,13 @@ describe("TalkBackToggle", () => {
     });
 
     test("taps Allow button on non-English locale using resource-id", async () => {
-      fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
       fakeAdb.setCommandResponse(
         "shell cat /sdcard/window_dump.xml",
         makeExecResult(DIALOG_XML_NON_ENGLISH)
       );
       fakeDetector.setDefaultResult(false);
 
-      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
       await toggle.toggle(true);
 
       // Center of [180,684][540,740] = (360, 712)
@@ -183,7 +170,6 @@ describe("TalkBackToggle", () => {
     });
 
     test("does not tap when no permission dialog appears", async () => {
-      fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
       fakeAdb.setCommandResponse(
         "shell cat /sdcard/window_dump.xml",
         makeExecResult("<hierarchy><node text='Home' /></hierarchy>")
@@ -191,7 +177,7 @@ describe("TalkBackToggle", () => {
       // Idempotency: not talkback -> proceed. Confirmation: talkback -> applied:true.
       fakeDetector.enqueueDetectMethodResults("unknown", "talkback");
 
-      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
       const result = await toggle.toggle(true);
 
       expect(fakeAdb.wasCommandExecuted("shell input tap")).toBe(false);
@@ -205,7 +191,6 @@ describe("TalkBackToggle", () => {
   <node index="0" text="Allow this app to access your location?" resource-id="" />
   <node index="1" text="Allow" resource-id="android:id/button1" bounds="[180,684][540,740]" />
 </hierarchy>`;
-      fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
       fakeAdb.setCommandResponse(
         "shell cat /sdcard/window_dump.xml",
         makeExecResult(unrelatedDialogXml)
@@ -213,7 +198,7 @@ describe("TalkBackToggle", () => {
       // Idempotency: not talkback -> proceed. Confirmation: talkback -> applied:true.
       fakeDetector.enqueueDetectMethodResults("unknown", "talkback");
 
-      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
       const result = await toggle.toggle(true);
 
       expect(fakeAdb.wasCommandExecuted("shell input tap")).toBe(false);
@@ -221,10 +206,9 @@ describe("TalkBackToggle", () => {
     });
 
     test("is idempotent when TalkBack is already enabled", async () => {
-      fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
       fakeDetector.setDefaultResult(true, "talkback");
 
-      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
       const result = await toggle.toggle(true);
 
       expect(result.supported).toBe(true);
@@ -234,12 +218,11 @@ describe("TalkBackToggle", () => {
     });
 
     test("enables TalkBack when another service is active but TalkBack is not", async () => {
-      fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
       // Idempotency: another service active but not talkback ("unknown") -> proceed.
       // Confirmation: talkback -> applied:true (#3921).
       fakeDetector.enqueueDetectMethodResults("unknown", "talkback");
 
-      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
       const result = await toggle.toggle(true);
 
       expect(result.applied).toBe(true);
@@ -247,14 +230,13 @@ describe("TalkBackToggle", () => {
     });
 
     test("appends TalkBack to existing services list when enabling", async () => {
-      fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
       fakeAdb.setCommandResponse(
         "settings get secure enabled_accessibility_services",
         makeExecResult("com.example.other/OtherService")
       );
       fakeDetector.setDefaultResult(false);
 
-      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
       await toggle.toggle(true);
 
       expect(
@@ -279,7 +261,7 @@ describe("TalkBackToggle", () => {
       );
       fakeDetector.enqueueDetectMethodResults("talkback", "unknown");
 
-      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
       const result = await toggle.toggle(false);
 
       expect(result).toEqual({ supported: true, applied: true, currentState: false });
@@ -292,12 +274,11 @@ describe("TalkBackToggle", () => {
     });
 
     test("returns supported:true applied:true when TalkBack is installed and currently enabled", async () => {
-      fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
       // Idempotency: talkback (currently on) -> proceed to disable. Confirmation:
       // not talkback -> applied:true, currentState:false (#3921).
       fakeDetector.enqueueDetectMethodResults("talkback", "unknown");
 
-      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
       const result = await toggle.toggle(false);
 
       expect(result.supported).toBe(true);
@@ -306,10 +287,9 @@ describe("TalkBackToggle", () => {
     });
 
     test("runs the correct disable ADB commands", async () => {
-      fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
       fakeDetector.setDefaultResult(true, "talkback");
 
-      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
       await toggle.toggle(false);
 
       expect(
@@ -321,27 +301,24 @@ describe("TalkBackToggle", () => {
     });
 
     test("does not attempt dialog dismissal when disabling", async () => {
-      fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
       fakeDetector.setDefaultResult(true, "talkback");
 
-      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
       await toggle.toggle(false);
 
       expect(fakeAdb.wasCommandExecuted("shell uiautomator dump /sdcard/window_dump.xml")).toBe(false);
     });
 
     test("invalidates the detector cache after disabling", async () => {
-      fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
       fakeDetector.setDefaultResult(true, "talkback");
 
-      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
       await toggle.toggle(false);
 
       expect(fakeDetector.getInvalidatedDevices()).toContain(ANDROID_DEVICE.deviceId);
     });
 
     test("preserves other accessibility services when disabling TalkBack", async () => {
-      fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
       fakeAdb.setCommandResponse(
         "settings get secure enabled_accessibility_services",
         makeExecResult(
@@ -350,7 +327,7 @@ describe("TalkBackToggle", () => {
       );
       fakeDetector.setDefaultResult(true, "talkback");
 
-      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
       await toggle.toggle(false);
 
       expect(
@@ -368,10 +345,9 @@ describe("TalkBackToggle", () => {
     });
 
     test("is idempotent when TalkBack is already disabled", async () => {
-      fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITH_TALKBACK));
       fakeDetector.setDefaultResult(false);
 
-      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
       const result = await toggle.toggle(false);
 
       expect(result.supported).toBe(true);
@@ -388,7 +364,7 @@ describe("TalkBackToggle", () => {
         makeExecResult("")
       );
 
-      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
       const result = await toggle.toggle(true);
 
       expect(result.supported).toBe(false);
@@ -402,7 +378,7 @@ describe("TalkBackToggle", () => {
         makeExecResult("")
       );
 
-      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
       await toggle.toggle(true);
 
       expect(fakeAdb.wasCommandExecuted("accessibility_enabled")).toBe(false);
@@ -414,7 +390,7 @@ describe("TalkBackToggle", () => {
         new Error("ADB connection failed")
       );
 
-      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
       const result = await toggle.toggle(true);
 
       expect(result.supported).toBe(false);
@@ -432,7 +408,7 @@ describe("TalkBackToggle", () => {
       );
       fakeDetector.setDefaultResult(false);
 
-      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
       // #3921: the apply failure is wrapped into a typed result, matching the
       // graceful contract of the other paths, rather than propagating raw.
       const result = await toggle.toggle(true);
@@ -445,10 +421,9 @@ describe("TalkBackToggle", () => {
 
   describe("TalkBack service component", () => {
     test("enables an installed but disabled TalkBack that is absent from dumpsys", async () => {
-      fakeAdb.setCommandResponse("dumpsys accessibility", makeExecResult(DUMPSYS_WITHOUT_TALKBACK));
       fakeDetector.enqueueDetectMethodResults("unknown", "talkback");
 
-      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
       const result = await toggle.toggle(true);
 
       expect(result).toEqual({ supported: true, applied: true, currentState: true });
@@ -466,7 +441,7 @@ describe("TalkBackToggle", () => {
     test("uses the known TalkBack service component", async () => {
       fakeDetector.setDefaultResult(false);
 
-      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer);
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
       await toggle.toggle(true);
 
       expect(
@@ -475,5 +450,79 @@ describe("TalkBackToggle", () => {
         )
       ).toBe(true);
     });
+  });
+
+  describe("secure settings seam (a11y-first / ADB fallback)", () => {
+    test("writes settings through the a11y service and skips the ADB fallback when the a11y put succeeds", async () => {
+      // a11y path reports success for every write, so the toggle must NOT issue
+      // the `settings put` ADB fallback for the enable writes.
+      fakeSecureSettings.setPutResult({ success: true });
+      fakeSecureSettings.setGetResult({ success: true, found: false });
+      fakeDetector.setDefaultResult(false);
+
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
+      await toggle.toggle(true);
+
+      // The a11y seam received the enable writes...
+      expect(fakeSecureSettings.putCalls.map(c => c.key)).toEqual(
+        expect.arrayContaining(["enabled_accessibility_services", "accessibility_enabled"])
+      );
+      // ...and the ADB `settings put secure` fallback was never used.
+      expect(fakeAdb.wasCommandExecuted("shell settings put secure enabled_accessibility_services")).toBe(false);
+      expect(fakeAdb.wasCommandExecuted("shell settings put secure accessibility_enabled")).toBe(false);
+    });
+
+    test("falls back to the ADB write when the a11y put reports failure", async () => {
+      // a11y path unavailable (default) → the toggle must issue the ADB fallback.
+      fakeSecureSettings.setPutResult({ success: false });
+      fakeDetector.setDefaultResult(false);
+
+      const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
+      await toggle.toggle(true);
+
+      expect(
+        fakeAdb.wasCommandExecuted(
+          "shell settings put secure enabled_accessibility_services com.google.android.marvin.talkback/com.google.android.marvin.talkback.TalkBackService"
+        )
+      ).toBe(true);
+      expect(fakeAdb.wasCommandExecuted("shell settings put secure accessibility_enabled 1")).toBe(true);
+    });
+  });
+
+  describe("enabled_accessibility_services parsing", () => {
+    // getOtherServices() reads the existing list and appends TalkBack while
+    // preserving unrelated services. These rows pin the parse rules: a literal
+    // "null"/empty/whitespace value contributes no other services, and duplicate
+    // or padded entries are trimmed. The observable outcome is the exact
+    // `enabled_accessibility_services` value written back on enable.
+    const TALKBACK = "com.google.android.marvin.talkback/com.google.android.marvin.talkback.TalkBackService";
+    const OTHER = "com.example.other/OtherService";
+
+    test.each([
+      ["literal string \"null\"", "null", TALKBACK],
+      ["empty string", "", TALKBACK],
+      ["whitespace only", "   ", TALKBACK],
+      ["single other service", OTHER, `${OTHER}:${TALKBACK}`],
+      ["padded entries with blanks", `  ${OTHER}  : `, `${OTHER}:${TALKBACK}`],
+      ["duplicate other services", `${OTHER}:${OTHER}`, `${OTHER}:${OTHER}:${TALKBACK}`],
+    ])(
+      "writes the correct services list when the existing value is %s",
+      async (_label, existing, expected) => {
+        fakeAdb.setCommandResponse(
+          "settings get secure enabled_accessibility_services",
+          makeExecResult(existing)
+        );
+        fakeDetector.setDefaultResult(false);
+
+        const toggle = new TalkBackToggle(ANDROID_DEVICE, fakeAdb, fakeDetector, fakeTimer, fakeSecureSettings);
+        await toggle.toggle(true);
+
+        expect(
+          fakeAdb.wasCommandExecuted(
+            `shell settings put secure enabled_accessibility_services ${expected}`
+          )
+        ).toBe(true);
+      }
+    );
   });
 });

--- a/test/features/accessibility/VoiceOverToggle.test.ts
+++ b/test/features/accessibility/VoiceOverToggle.test.ts
@@ -133,6 +133,27 @@ describe("VoiceOverToggle", () => {
       ).toBe(true);
     });
 
+    test("reports applied:false with the failure reason when the enable kickstart fails", async () => {
+      // On enable, a failing `launchctl kickstart` must NOT be swallowed as an
+      // already-stopped service (that swallow is disable-only). Even when the
+      // error text matches the already-stopped signature, the enable path must
+      // surface it as a typed failure rather than claim success.
+      fakeExec.setCommandHandler("launchctl kickstart", () => {
+        throw new Error("Command failed: launchctl kickstart\nexit code: 3\nstderr:\nNo process to signal.");
+      });
+      // Detection returns off by default; autoAdvance keeps the (mutated) confirm
+      // loop from blocking on real time.
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+
+      const toggle = new VoiceOverToggle(SIMULATOR_DEVICE, fakeDetector, fakeExec, fakeTimer);
+      const result = await toggle.toggle(true);
+
+      expect(result.supported).toBe(true);
+      expect(result.applied).toBe(false);
+      expect(result.reason).toContain("No process to signal.");
+    });
+
     test("always applies even when detection would report already-enabled (CtrlProxy-safe)", async () => {
       // Simulates a CtrlProxy outage: detection always returns false regardless of reality.
       // toggle(false) must still run simctl rather than silently no-op.

--- a/test/features/accessibility/WcagAudit.test.ts
+++ b/test/features/accessibility/WcagAudit.test.ts
@@ -5,9 +5,26 @@
 
 import { expect, describe, it, beforeEach } from "bun:test";
 import { WcagAudit } from "../../../src/features/accessibility/WcagAudit";
+import { BaselineManager } from "../../../src/features/accessibility/BaselineManager";
+import { FakeTimer } from "../../fakes/FakeTimer";
 import type { Element } from "../../../src/models/Element";
 import type { ViewHierarchyNode } from "../../../src/models/ViewHierarchyResult";
 import type { AccessibilityAuditConfig } from "../../../src/models/AccessibilityAudit";
+
+/**
+ * BaselineManager double that returns a canned baseline without touching any
+ * database. Construction alone never resolves the file-backed singleton (the DB
+ * handle is resolved lazily), and getBaseline is overridden so the query path is
+ * never reached (issue #3067).
+ */
+class StubBaselineManager extends BaselineManager {
+  constructor(private readonly stub: Awaited<ReturnType<BaselineManager["getBaseline"]>>) {
+    super();
+  }
+  async getBaseline(): Promise<Awaited<ReturnType<BaselineManager["getBaseline"]>>> {
+    return this.stub;
+  }
+}
 
 describe("WcagAudit", function() {
   let audit: WcagAudit;
@@ -253,8 +270,13 @@ describe("WcagAudit", function() {
 
       const result = await audit.audit(elements, hierarchy, undefined, "com.test", config);
 
-      expect(result.summary.totalViolations).toBeGreaterThan(0);
-      expect(result.summary.bySeverity.error).toBeGreaterThan(0);
+      // The fixture is two clickable, unlabelled elements both under 44x44dp, so
+      // each yields a missing-content-description (error) AND a
+      // touch-target-too-small (warning): exactly 4 violations.
+      expect(result.summary.totalViolations).toBe(4);
+      expect(result.summary.bySeverity).toEqual({ error: 2, warning: 2, info: 0 });
+      expect(result.summary.byType["missing-content-description"]).toBe(2);
+      expect(result.summary.byType["touch-target-too-small"]).toBe(2);
       expect(result.summary.passed).toBe(false);
     });
 
@@ -331,6 +353,160 @@ describe("WcagAudit", function() {
         { class: "android.widget.TextView", bounds: { left: 0, top: 40, right: 200, bottom: 80 } },
       ];
       expect(await formInputViolations(elements)).toHaveLength(1);
+    });
+  });
+
+  describe("Touch Target Size (parameterized)", function() {
+    const hierarchy: ViewHierarchyNode = { class: "View", children: [] };
+
+    // width × height × level → (violation?, severity). checkTouchTargetSizes
+    // flags a clickable element when EITHER axis is < 44dp, and the severity is
+    // `error` at AAA but `warning` at AA/A. Includes asymmetric-axis rows and the
+    // AAA severity flip.
+    it.each([
+      [40, 40, "AA", true, "warning"],
+      [44, 44, "AA", false, undefined],
+      [100, 50, "AA", false, undefined],
+      [44, 40, "AA", true, "warning"],   // height under, width exactly at bound
+      [40, 44, "AA", true, "warning"],   // width under, height exactly at bound
+      [43, 100, "AA", true, "warning"],  // single axis under
+      [40, 40, "AAA", true, "error"],    // severity flip at AAA
+      [44, 44, "AAA", false, undefined],
+      [100, 43, "AAA", true, "error"],   // single axis under, AAA severity
+    ])(
+      "%ix%i at level %s flags=%p severity=%s",
+      async function(width, height, level, expectViolation, expectedSeverity) {
+        const elements: Element[] = [
+          {
+            bounds: { left: 0, top: 0, right: width as number, bottom: height as number },
+            clickable: true,
+            text: "Tap",
+          },
+        ];
+        const config: AccessibilityAuditConfig = {
+          level: level as AccessibilityAuditConfig["level"],
+          failureMode: "report",
+          useBaseline: false,
+        };
+
+        const result = await audit.audit(elements, hierarchy, undefined, "com.test", config);
+        const sizeViolations = result.violations.filter(v => v.type === "touch-target-too-small");
+
+        if (expectViolation) {
+          expect(sizeViolations).toHaveLength(1);
+          expect(sizeViolations[0].severity).toBe(expectedSeverity as "warning" | "error");
+          expect(sizeViolations[0].message).toContain(`${width}x${height}dp`);
+        } else {
+          expect(sizeViolations).toHaveLength(0);
+        }
+      }
+    );
+  });
+
+  describe("Heading Hierarchy", function() {
+    const config: AccessibilityAuditConfig = {
+      level: "AA",
+      failureMode: "report",
+      useBaseline: false,
+    };
+
+    // extractHeadings maps text height to a heading level using the bands
+    // >48→h1, >36→h2, >28→h3, >22→h4, >18→h5, and only includes nodes taller
+    // than 20dp. A violation is raised when a level is skipped (curr > prev + 1).
+    function hierarchyWithHeadingHeights(heights: number[]): ViewHierarchyNode {
+      return {
+        class: "View",
+        children: heights.map((h, i) => ({
+          class: "android.widget.TextView",
+          text: `Heading ${i}`,
+          bounds: { left: 0, top: i * 200, right: 300, bottom: i * 200 + h },
+        })),
+      } as unknown as ViewHierarchyNode;
+    }
+
+    it.each([
+      ["h1→h3 skips a level", [50, 30], 1],
+      ["h1→h2 is contiguous", [50, 40], 0],
+      ["h2→h4 skips a level", [40, 25], 1],
+      ["h1→h2→h3 is contiguous", [50, 40, 30], 0],
+      ["descending levels never skip", [30, 50], 0],
+      ["a 20dp node is below the inclusion gate", [50, 20], 0],
+      ["h1→h5 skips (21dp is included as h5)", [50, 21], 1],
+      ["only one skip across three headings", [50, 30, 25], 1],
+    ])(
+      "%s",
+      async function(_label, heights, expectedSkips) {
+        const result = await audit.audit(
+          [],
+          hierarchyWithHeadingHeights(heights as number[]),
+          undefined,
+          "com.test",
+          config
+        );
+        const skips = result.violations.filter(v => v.type === "heading-hierarchy-skip");
+        expect(skips).toHaveLength(expectedSkips as number);
+      }
+    );
+  });
+
+  describe("Baseline Suppression", function() {
+    const hierarchy: ViewHierarchyNode = { class: "View", children: [] };
+    // Two clickable, unlabelled, undersized elements → 4 violations.
+    const elements: Element[] = [
+      { bounds: { left: 0, top: 0, right: 20, bottom: 20 }, clickable: true },
+      { bounds: { left: 0, top: 30, right: 30, bottom: 60 }, clickable: true },
+    ];
+
+    async function baselineAndFindings() {
+      const seed = new WcagAudit();
+      const seedResult = await seed.audit(elements, hierarchy, undefined, "com.test", {
+        level: "AA",
+        failureMode: "report",
+        useBaseline: false,
+      });
+      return seedResult;
+    }
+
+    it("suppresses violations whose fingerprint is present in the baseline", async function() {
+      const seedResult = await baselineAndFindings();
+      expect(seedResult.violations.length).toBeGreaterThanOrEqual(2);
+      const suppressed = seedResult.violations[0];
+
+      const stub = new StubBaselineManager({
+        screenId: seedResult.screenId,
+        violations: [suppressed],
+        updatedAt: new Date().toISOString(),
+      });
+      const withBaseline = new WcagAudit(new FakeTimer(), stub);
+      const result = await withBaseline.audit(elements, hierarchy, undefined, "com.test", {
+        level: "AA",
+        failureMode: "report",
+        useBaseline: true,
+      });
+
+      expect(result.violations.find(v => v.fingerprint === suppressed.fingerprint)).toBeUndefined();
+      expect(result.violations).toHaveLength(seedResult.violations.length - 1);
+      expect(result.summary.baselinedViolations).toBe(1);
+      expect(result.summary.totalViolations).toBe(seedResult.violations.length);
+    });
+
+    it("suppresses every violation and counts them when the whole finding set is baselined", async function() {
+      const seedResult = await baselineAndFindings();
+
+      const stub = new StubBaselineManager({
+        screenId: seedResult.screenId,
+        violations: seedResult.violations,
+        updatedAt: new Date().toISOString(),
+      });
+      const withBaseline = new WcagAudit(new FakeTimer(), stub);
+      const result = await withBaseline.audit(elements, hierarchy, undefined, "com.test", {
+        level: "AA",
+        failureMode: "report",
+        useBaseline: true,
+      });
+
+      expect(result.violations).toHaveLength(0);
+      expect(result.summary.baselinedViolations).toBe(seedResult.violations.length);
     });
   });
 });

--- a/test/features/action/TapOnElement.talkback.test.ts
+++ b/test/features/action/TapOnElement.talkback.test.ts
@@ -209,7 +209,7 @@ describe("TapOnElement TalkBack mode detection", () => {
   });
 
   describe("TalkBack detection integration", () => {
-    test("calls accessibility detector on each tap", async () => {
+    test("checks TalkBack state once per tap (no cross-tap caching in the executor)", async () => {
       fakeAccessibilityDetector.setTalkBackEnabled(true);
 
       const element = {
@@ -217,17 +217,14 @@ describe("TapOnElement TalkBack mode detection", () => {
         "resource-id": "test:id/button",
       } as any;
 
-      // First call
+      // Each executeAndroidTap consults the detector exactly once; two taps
+      // therefore produce exactly two checks. (Caching lives in the real
+      // AccessibilityDetector, not this executor, and is tested there.)
       await (tapOnElement as any).executeAndroidTap("tap", 50, 50, 500, element, undefined, {});
-      const firstCheckCount = fakeAccessibilityDetector.getCheckCount();
-      expect(firstCheckCount).toBe(1);
+      expect(fakeAccessibilityDetector.getCheckCount()).toBe(1);
 
-      // Second call - note: real AccessibilityDetector would cache, but FakeAccessibilityDetector doesn't
       await (tapOnElement as any).executeAndroidTap("tap", 50, 50, 500, element, undefined, {});
-      const secondCheckCount = fakeAccessibilityDetector.getCheckCount();
-
-      // Verify detector was called for second tap (caching is tested in AccessibilityDetector tests)
-      expect(secondCheckCount).toBeGreaterThanOrEqual(1);
+      expect(fakeAccessibilityDetector.getCheckCount()).toBe(2);
     });
 
     test("respects cache invalidation", async () => {

--- a/test/features/action/TapOnElement.voiceover.test.ts
+++ b/test/features/action/TapOnElement.voiceover.test.ts
@@ -235,46 +235,4 @@ describe("TapOnElement VoiceOver mode", () => {
     });
   });
 
-  describe("Android platform unaffected", () => {
-    test("does not call iosVoiceOverDetector for Android device", async () => {
-      const androidTapOnElement = new TapOnElement(
-        {
-          name: "test-device",
-          platform: "android",
-          id: "emulator-5554",
-          deviceId: "emulator-5554",
-        } as any,
-        fakeAdb as any,
-        {
-          iosVoiceOverDetector: fakeVoiceOverDetector,
-          timer: fakeTimer,
-        }
-      );
-
-      fakeVoiceOverDetector.setVoiceOverEnabled(true);
-
-      spyOn(
-        androidTapOnElement as any,
-        "executeAndroidTap"
-      ).mockResolvedValue(undefined);
-
-      // The isVoiceOverEnabled should not be called for Android
-      // We verify via call count
-      const initialCallCount = fakeVoiceOverDetector.getCallCount();
-
-      await (androidTapOnElement as any).executeAndroidTap(
-        "tap",
-        50,
-        50,
-        500,
-        {} as any,
-        undefined,
-        undefined,
-        undefined,
-        []
-      );
-
-      expect(fakeVoiceOverDetector.getCallCount()).toBe(initialCallCount);
-    });
-  });
 });

--- a/test/features/action/swipeon/TalkBackSwipeExecutor.test.ts
+++ b/test/features/action/swipeon/TalkBackSwipeExecutor.test.ts
@@ -168,10 +168,9 @@ describe("TalkBackSwipeExecutor", () => {
       expect(fakeCtrlProxy.getTwoFingerSwipeHistory()).toHaveLength(0);
     });
 
-    test("uses standard swipe for all directions", async () => {
-      const directions: SwipeDirection[] = ["up", "down", "left", "right"];
-
-      for (const direction of directions) {
+    test.each(["up", "down", "left", "right"] as SwipeDirection[])(
+      "dispatches a standard coordinate swipe for direction %s",
+      async direction => {
         fakeGestureExecutor.getSwipeCalls().length = 0;
 
         const fresh = makeExecutor(
@@ -190,10 +189,15 @@ describe("TalkBackSwipeExecutor", () => {
           perf
         );
 
+        // The dispatch the name claims: a single standard gesture swipe with the
+        // exact coordinates, and NO accessibility action/two-finger path.
+        const swipeCalls = fakeGestureExecutor.getSwipeCalls();
+        expect(swipeCalls).toHaveLength(1);
+        expect(swipeCalls[0]).toMatchObject({ x1: 100, y1: 500, x2: 100, y2: 200 });
         expect(fakeCtrlProxy.getActionHistory()).toHaveLength(0);
         expect(fakeCtrlProxy.getTwoFingerSwipeHistory()).toHaveLength(0);
       }
-    });
+    );
   });
 
   describe("when TalkBack is enabled (android)", () => {
@@ -247,11 +251,40 @@ describe("TalkBackSwipeExecutor", () => {
       expect(fakeCtrlProxy.getTwoFingerSwipeHistory()).toHaveLength(1);
     });
 
-    test("uses accessibility method for all swipe directions", async () => {
-      const directions: SwipeDirection[] = ["up", "down", "left", "right"];
+    test("surfaces a failed two-finger swipe as an ActionableError instead of a successful scroll", async () => {
+      fakeCtrlProxy.setTwoFingerSwipeResult({ success: false, totalTimeMs: 1, error: "scroll rejected" });
 
-      for (const direction of directions) {
+      await expect(
+        executor.executeSwipeGesture(
+          100, 500, 100, 200,
+          "up" as SwipeDirection,
+          null,
+          { duration: 300 },
+          perf
+        )
+      ).rejects.toThrow("Two-finger swipe failed: scroll rejected");
+    });
+
+    test("uses the \"Unknown error\" fallback when the two-finger failure carries an empty message", async () => {
+      // "" is falsy, so this exercises the `|| "Unknown error"` boundary.
+      fakeCtrlProxy.setTwoFingerSwipeResult({ success: false, totalTimeMs: 1, error: "" });
+
+      await expect(
+        executor.executeSwipeGesture(
+          100, 500, 100, 200,
+          "up" as SwipeDirection,
+          null,
+          { duration: 300 },
+          perf
+        )
+      ).rejects.toThrow("Two-finger swipe failed: Unknown error");
+    });
+
+    test.each(["up", "down", "left", "right"] as SwipeDirection[])(
+      "dispatches an accessibility two-finger swipe for direction %s (no container)",
+      async direction => {
         fakeCtrlProxy.clearHistory();
+        fakeGestureExecutor.getSwipeCalls().length = 0;
         const fresh = makeExecutor(
           ANDROID_DEVICE,
           fakeGestureExecutor,
@@ -268,9 +301,13 @@ describe("TalkBackSwipeExecutor", () => {
           perf
         );
 
+        // The dispatch the name claims: with TalkBack on and no container, the
+        // swipe routes through the accessibility two-finger path, never the
+        // standard coordinate gesture.
+        expect(fakeCtrlProxy.getTwoFingerSwipeHistory()).toHaveLength(1);
         expect(fakeGestureExecutor.getSwipeCalls()).toHaveLength(0);
       }
-    });
+    );
 
     test("boomerang mode announces swipeable element instead of swiping", async () => {
       const containerElement = {

--- a/test/features/action/swipeon/VoiceOverSwipeExecutor.test.ts
+++ b/test/features/action/swipeon/VoiceOverSwipeExecutor.test.ts
@@ -311,44 +311,36 @@ describe("VoiceOverSwipeExecutor", () => {
       expect(fakeIosClient.getActionHistory()).toHaveLength(0);
     });
 
-    test("does not invoke a configured container action while VoiceOver is active", async () => {
+    // Both a failing container action (result success:false) and a throwing one
+    // must yield the same conservative "not supported" fallback without touching
+    // gestures, multi-finger swipes, or reporting a synthesized scroll. The rows
+    // preserve the original pair's distinctions: swipe direction and whether a
+    // FakeTimer is injected.
+    test.each([
+      {
+        label: "a configured failing container action",
+        direction: "down" as const,
+        arrange: () => fakeIosClient.setActionResult({ success: false, error: "Element not found" }),
+        withTimer: false,
+      },
+      {
+        label: "a throwing container action",
+        direction: "up" as const,
+        arrange: () => fakeIosClient.setFailureMode("action", new Error("Connection lost")),
+        withTimer: true,
+      },
+    ])("does not invoke $label while VoiceOver is active", async ({ direction, arrange, withTimer }) => {
       const { executor, calls } = makeFakeGestureExecutor();
       fakeVoiceOverDetector.setVoiceOverEnabled(true);
-      fakeIosClient.setActionResult({ success: false, error: "Element not found" });
+      arrange();
       const container = makeContainerElement({ "resource-id": "com.example:id/list" });
 
-      const voiceOverExecutor = new VoiceOverSwipeExecutor(
-        { platform: "ios", id: "00001234-ABCD" } as any,
-        executor,
-        fakeIosClient as any,
-        fakeVoiceOverDetector
-      );
+      const device = { platform: "ios", id: "00001234-ABCD" } as any;
+      const voiceOverExecutor = withTimer
+        ? new VoiceOverSwipeExecutor(device, executor, fakeIosClient as any, fakeVoiceOverDetector, fakeTimer)
+        : new VoiceOverSwipeExecutor(device, executor, fakeIosClient as any, fakeVoiceOverDetector);
 
-      const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "down", container, { duration: 300 }, perf);
-
-      expect(result.success).toBe(false);
-      expect(result.error).toContain("not supported");
-      expect(result.fallbackReason).toContain("do not reach VoiceOver");
-      expect(calls).toHaveLength(0);
-      expect(fakeIosClient.getMultiFingerSwipeHistory()).toHaveLength(0);
-      expect(fakeIosClient.getActionHistory()).toHaveLength(0);
-    });
-
-    test("does not invoke a throwing container action while VoiceOver is active", async () => {
-      const { executor, calls } = makeFakeGestureExecutor();
-      fakeVoiceOverDetector.setVoiceOverEnabled(true);
-      fakeIosClient.setFailureMode("action", new Error("Connection lost"));
-      const container = makeContainerElement({ "resource-id": "com.example:id/list" });
-
-      const voiceOverExecutor = new VoiceOverSwipeExecutor(
-        { platform: "ios", id: "00001234-ABCD" } as any,
-        executor,
-        fakeIosClient as any,
-        fakeVoiceOverDetector,
-        fakeTimer
-      );
-
-      const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, "up", container, { duration: 300 }, perf);
+      const result = await voiceOverExecutor.executeSwipeGesture(100, 500, 100, 200, direction, container, { duration: 300 }, perf);
 
       expect(result.success).toBe(false);
       expect(result.error).toContain("not supported");

--- a/test/features/talkback/FocusElementMatcher.test.ts
+++ b/test/features/talkback/FocusElementMatcher.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { FocusElementMatcher } from "../../../src/features/talkback/FocusElementMatcher";
+import type { Element } from "../../../src/models/Element";
+
+/**
+ * findCurrentFocusIndex resolves the TalkBack cursor's position in the traversal
+ * order by trying identifiers in a fixed precedence:
+ *   1. resource-id  2. test-tag  3. content-desc  4. text  5. bounds.
+ *
+ * Each rung must win over the ones below it. These rows pin that order by giving
+ * the current-focus element a strong identifier that points at one traversal
+ * entry while a weaker identifier (shared with a DIFFERENT entry) would resolve
+ * elsewhere — so a dropped rung resolves the cursor to the wrong row.
+ */
+describe("FocusElementMatcher.findCurrentFocusIndex", () => {
+  const matcher = new FocusElementMatcher();
+
+  const boundsAt = (i: number) => ({ left: i, top: i, right: i + 5, bottom: i + 5 });
+
+  test("returns null when there is no current focus", () => {
+    expect(matcher.findCurrentFocusIndex(null, [{ "resource-id": "a", "bounds": boundsAt(0) }])).toBeNull();
+  });
+
+  test("returns null when the traversal order is empty", () => {
+    expect(matcher.findCurrentFocusIndex({ "resource-id": "a", "bounds": boundsAt(0) }, [])).toBeNull();
+  });
+
+  // Each row: an ordered traversal list, the current-focus element, and the index
+  // the cursor should resolve to via the named rung.
+  test.each([
+    [
+      "resource-id wins",
+      [
+        { "resource-id": "row-0", "content-desc": "shared", "text": "shared", "bounds": boundsAt(0) },
+        { "resource-id": "row-1", "content-desc": "shared", "text": "shared", "bounds": boundsAt(1) },
+      ] as Element[],
+      { "resource-id": "row-1", "content-desc": "shared", "text": "shared", "bounds": boundsAt(9) } as Element,
+      1,
+    ],
+    [
+      "test-tag wins when resource-id is absent",
+      [
+        { "test-tag": "tag-0", "content-desc": "shared", "bounds": boundsAt(0) },
+        { "test-tag": "tag-1", "content-desc": "shared", "bounds": boundsAt(1) },
+      ] as Element[],
+      { "test-tag": "tag-1", "content-desc": "shared", "bounds": boundsAt(9) } as Element,
+      1,
+    ],
+    [
+      "content-desc wins when resource-id and test-tag are absent",
+      [
+        { "content-desc": "desc-0", "text": "shared", "bounds": boundsAt(0) },
+        { "content-desc": "desc-1", "text": "shared", "bounds": boundsAt(1) },
+      ] as Element[],
+      { "content-desc": "desc-1", "text": "shared", "bounds": boundsAt(9) } as Element,
+      1,
+    ],
+    [
+      "text wins when only text and bounds identify the element",
+      [
+        { text: "text-0", bounds: boundsAt(0) },
+        { text: "text-1", bounds: boundsAt(1) },
+      ] as Element[],
+      { text: "text-1", bounds: boundsAt(9) } as Element,
+      1,
+    ],
+    [
+      "bounds are the last resort when no identifiers are present",
+      [
+        { bounds: boundsAt(0) },
+        { bounds: boundsAt(1) },
+      ] as Element[],
+      { bounds: boundsAt(1) } as Element,
+      1,
+    ],
+  ])("%s", (_label, elements, currentFocus, expectedIndex) => {
+    expect(matcher.findCurrentFocusIndex(currentFocus as Element, elements as Element[])).toBe(
+      expectedIndex as number
+    );
+  });
+});

--- a/test/features/talkback/FocusNavigationExecutor.test.ts
+++ b/test/features/talkback/FocusNavigationExecutor.test.ts
@@ -385,4 +385,91 @@ describe("FocusNavigationExecutor", () => {
     expect(driver.getSwipeCount()).toBe(4);
     expect(observed).toEqual([elements[0], elements[0], elements[0], elements[4]]);
   });
+
+  describe("navigation guards", () => {
+    const makeDriverFactory = (driver: FakeFocusNavigationDriver): FocusNavigationDriverFactory => ({
+      createDriver: () => driver
+    });
+
+    test("rejects a path that needs more swipes than the maxSwipes cap", async () => {
+      const driver = new FakeFocusNavigationDriver();
+      driver.setElements([makeElement("a", 0), makeElement("c", 2)], 0);
+      const executor = new FocusNavigationExecutor({
+        timer: new FakeTimer(),
+        driverFactory: makeDriverFactory(driver)
+      });
+
+      await expect(
+        executor.navigateToElement(
+          "device-1",
+          { resourceId: "c" },
+          { currentFocusIndex: 0, targetFocusIndex: 2, swipeCount: 5, direction: "forward" },
+          { maxSwipes: 2, swipeDelay: 0 }
+        )
+      ).rejects.toThrow(/max: 2/);
+      // Bailed before touching the device — no swipes issued.
+      expect(driver.getSwipeCount()).toBe(0);
+    });
+
+    test("rejects focus navigation on a non-Android device", async () => {
+      const driver = new FakeFocusNavigationDriver();
+      driver.setElements([makeElement("a", 0), makeElement("c", 2)], 0);
+      const executor = new FocusNavigationExecutor({
+        timer: new FakeTimer(),
+        driverFactory: makeDriverFactory(driver),
+        deviceResolver: deviceId => ({ name: deviceId, deviceId, platform: "ios" })
+      });
+
+      await expect(
+        executor.navigateToElement(
+          "udid-ios",
+          { resourceId: "c" },
+          { currentFocusIndex: 0, targetFocusIndex: 2, swipeCount: 2, direction: "forward" },
+          { swipeDelay: 0 }
+        )
+      ).rejects.toThrow(/only supported on Android/);
+      expect(driver.getSwipeCount()).toBe(0);
+    });
+
+    test("rejects a zero-sized screen instead of hanging", async () => {
+      const driver = new FakeFocusNavigationDriver();
+      driver.setElements([makeElement("a", 0), makeElement("c", 2)], 0);
+      // A finite-but-non-positive screen size must be rejected, not marched into
+      // the swipe loop (which would wedge to the test timeout).
+      driver.setScreenSize({ width: 0, height: 0 });
+      const executor = new FocusNavigationExecutor({
+        timer: new FakeTimer(),
+        driverFactory: makeDriverFactory(driver)
+      });
+
+      await expect(
+        executor.navigateToElement(
+          "device-1",
+          { resourceId: "c" },
+          { currentFocusIndex: 0, targetFocusIndex: 2, swipeCount: 3, direction: "forward" },
+          { swipeDelay: 0 }
+        )
+      ).rejects.toThrow(/screen size/);
+      expect(driver.getSwipeCount()).toBe(0);
+    });
+
+    test("surfaces a failed swipe as a navigation failure rather than success", async () => {
+      const driver = new FakeFocusNavigationDriver();
+      driver.setElements([makeElement("a", 0), makeElement("c", 2)], 0);
+      driver.setSwipeResult({ success: false, totalTimeMs: 1, error: "proxy swipe rejected" });
+      const executor = new FocusNavigationExecutor({
+        timer: new FakeTimer(),
+        driverFactory: makeDriverFactory(driver)
+      });
+
+      await expect(
+        executor.navigateToElement(
+          "device-1",
+          { resourceId: "c" },
+          { currentFocusIndex: 0, targetFocusIndex: 2, swipeCount: 1, direction: "forward" },
+          { swipeDelay: 0 }
+        )
+      ).rejects.toThrow(/proxy swipe rejected/);
+    });
+  });
 });

--- a/test/features/talkback/TalkBackTapStrategy.test.ts
+++ b/test/features/talkback/TalkBackTapStrategy.test.ts
@@ -161,6 +161,30 @@ describe("TalkBackTapStrategy", () => {
       });
     });
 
+    // isFocusTrapError classifies exactly the three navigation-failure messages
+    // the FocusNavigationExecutor can throw; any other error is NOT a focus trap.
+    // Asserted via the observable focusTrapDetected flag on the result.
+    test.each([
+      ["Focus did not move after multiple swipes. Try scrolling the container.", true],
+      ["Focus navigation could not track the TalkBack cursor position. Try narrowing.", true],
+      ["Focus navigation is not converging on the target. Try scrolling.", true],
+      ["Navigation failed for an unrelated reason", false],
+    ])(
+      "maps navigation error %j to focusTrapDetected=%p",
+      async (message, expectedTrap) => {
+        const element = {
+          "resource-id": "test:id/button",
+          "bounds": { left: 0, top: 0, right: 100, bottom: 100 }
+        } as Element;
+        driver.setElements([element], 0);
+        spyOn(mockExecutor, "navigateToElement").mockRejectedValue(new Error(message as string));
+
+        const result = await strategy.executeTap("device-1", element, driver);
+
+        expect(result.screenReaderNavigation?.focusTrapDetected).toBe(expectedTrap as boolean);
+      }
+    );
+
     test("uses ACTION_CLICK fallback if double-tap activation fails", async () => {
       const element = {
         "resource-id": "test:id/button",

--- a/test/server/accessibilityFocusTools.test.ts
+++ b/test/server/accessibilityFocusTools.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { registerAccessibilityFocusTools } from "../../src/server/accessibilityFocusTools";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+
+/**
+ * accessibilityFocus is a debug-only device-aware tool. `getTool`/the default
+ * listing gate on availability (which is false for a debugOnly tool when --debug
+ * is off), so it must be resolved via getAllTools({ includeUnavailable: true }).
+ */
+describe("accessibilityFocusTools", () => {
+  beforeEach(() => {
+    ToolRegistry.clearTools();
+  });
+
+  afterEach(() => {
+    ToolRegistry.clearTools();
+  });
+
+  function focusTool() {
+    return ToolRegistry.getAllTools({ includeUnavailable: true }).find(
+      t => t.name === "accessibilityFocus"
+    );
+  }
+
+  test("registers the accessibilityFocus device-aware tool", () => {
+    registerAccessibilityFocusTools();
+
+    const tool = focusTool();
+    expect(tool).toBeDefined();
+    expect(tool!.requiresDevice).toBe(true);
+    expect(tool!.deviceAwareHandler).toBeDefined();
+  });
+
+  test("marks the tool debugOnly", () => {
+    registerAccessibilityFocusTools();
+
+    expect(focusTool()!.debugOnly).toBe(true);
+  });
+
+  test("hides the tool from the default (non-debug) listing", () => {
+    registerAccessibilityFocusTools();
+
+    // With --debug off a debugOnly tool is unavailable, so it is absent from the
+    // default listing and from getToolDefinitions but present when unavailable
+    // tools are included. Removing the debugOnly flag would leak it to every
+    // client.
+    const defaultNames = ToolRegistry.getAllTools().map(t => t.name);
+    const allNames = ToolRegistry.getAllTools({ includeUnavailable: true }).map(t => t.name);
+    const advertisedNames = ToolRegistry.getToolDefinitions().map(t => t.name);
+
+    expect(allNames).toContain("accessibilityFocus");
+    expect(defaultNames).not.toContain("accessibilityFocus");
+    expect(advertisedNames).not.toContain("accessibilityFocus");
+  });
+});

--- a/test/server/accessibilityTools.test.ts
+++ b/test/server/accessibilityTools.test.ts
@@ -1,14 +1,26 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { registerAccessibilityTools, accessibilitySchema } from "../../src/server/accessibilityTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
+import type { BootedDevice } from "../../src/models";
+
+const ANDROID_DEVICE = { name: "a", deviceId: "emulator-5554", platform: "android" } as BootedDevice;
+const IOS_DEVICE = { name: "i", deviceId: "00008130-001", platform: "ios" } as BootedDevice;
+
+function accessibilityHandler() {
+  const tool = ToolRegistry.getAllTools({ includeUnavailable: true }).find(t => t.name === "accessibility");
+  if (!tool?.deviceAwareHandler) {
+    throw new Error("accessibility tool not registered");
+  }
+  return tool.deviceAwareHandler;
+}
 
 describe("accessibilityTools", () => {
   beforeEach(() => {
-    (ToolRegistry as any).tools.clear();
+    ToolRegistry.clearTools();
   });
 
   afterEach(() => {
-    (ToolRegistry as any).tools.clear();
+    ToolRegistry.clearTools();
   });
 
   describe("registration", () => {
@@ -16,6 +28,24 @@ describe("accessibilityTools", () => {
       registerAccessibilityTools();
       const names = ToolRegistry.getToolDefinitions().map(t => t.name);
       expect(names).toContain("accessibility");
+    });
+  });
+
+  describe("platform rejection", () => {
+    // Both rows short-circuit before any toggle/client is constructed, so no real
+    // device is touched. Only the two THROW rows are covered (issue #4179).
+    test("rejects voiceover on an Android device", async () => {
+      registerAccessibilityTools();
+      await expect(
+        accessibilityHandler()(ANDROID_DEVICE, { voiceover: true })
+      ).rejects.toThrow("VoiceOver is not supported on Android devices");
+    });
+
+    test("rejects talkback on an iOS device", async () => {
+      registerAccessibilityTools();
+      await expect(
+        accessibilityHandler()(IOS_DEVICE, { talkback: true })
+      ).rejects.toThrow("TalkBack is not supported on iOS devices");
     });
   });
 


### PR DESCRIPTION
## Summary

Milestone 32 (Unit Test Quality Audit), slice **a11y**: 23 verified test-quality findings burned down, each verified red-green.

**src seams/fixes (behavior-preserving on default paths):**
- New `SecureSettingsRpc` interface + `CtrlProxySecureSettingsRpc` adapter; `TalkBackToggle` now writes/reads secure settings through the injectable seam (default = the same lazy `AndroidCtrlProxyClient.getInstance` path, calling the identical `requestSettingsPut/Get("secure", …)`), so the a11y-first / ADB-fallback path is unit-testable without building a real `AdbClient` into the static singleton.
- `WcagAudit` takes an injectable `BaselineManager` (default preserves prod) — baseline suppression + `baselinedViolations` now testable.
- `FocusNavigationExecutor` screen-size guard now also rejects `<= 0` dimensions (**behavior change**: a 0-size screen throws instead of entering the swipe loop — and the `{0,0}` guard test no longer hangs bun).
- `BaselineManager` guards both `JSON.parse` sites so a corrupt `violations_json` row yields a typed skip/null + a logged warning instead of escaping `getBaseline`/`listBaselines`.

Test-side: WcagAudit heading-hierarchy / touch-target / required-ratio tables + exact summary counts; ContrastChecker cache TTL+fingerprint (FakeTimer) + real boundary assertions; TalkBack a11y-first vs ADB fallback + `enabled_accessibility_services` parsing; FocusElementMatcher cursor precedence; two-finger-swipe error; VoiceOver failed-kickstart; `accessibilityFocusTools` `debugOnly` registration; direction→dispatch + tautology rewrites; `ToolRegistry.clearTools()`; deleted 20 dead dumpsys stubs + a stub-then-call test.

## Linked Issue

Closes #4179

## Validation

- [x] `bun test`: **10789 tests, 0 fail / 13 skip** (nothing hangs — the `{0,0}` guard runs in ~1.5ms)
- [x] `bun run typecheck`: no new errors (206 baseline)
- [x] `bun run lint`: clean

## Follow-ups

- [ ] Item 23 (renames) deferred — the issue body's rename table was truncated; behavior-first names were applied to every rewritten test, remainder needs the full mapping.
