### PR TITLE
test(action-gestures): burn down 24 verified test-quality findings (#4168)

### DIFF
--- a/test/fakes/FakeCtrlProxy.ts
+++ b/test/fakes/FakeCtrlProxy.ts
@@ -97,6 +97,8 @@ export class FakeCtrlProxy implements AndroidCtrlProxy {
 
   private actionResult: A11yActionResult | null = null;
   private twoFingerSwipeResult: A11ySwipeResult | null = null;
+  private swipeResult: A11ySwipeResult | null = null;
+  private clearTextResult: A11ySetTextResult | null = null;
 
   private setTextHistory: Array<{
     text: string;
@@ -217,6 +219,27 @@ export class FakeCtrlProxy implements AndroidCtrlProxy {
    */
   setTwoFingerSwipeResult(result: A11ySwipeResult | null): void {
     this.twoFingerSwipeResult = result;
+  }
+
+  /**
+   * Configure the result returned by requestSwipe. Unlike setFailureMode("swipe"),
+   * which makes requestSwipe throw, this returns a structured non-throwing result
+   * so tests can exercise the a11y-swipe-failed-but-did-not-throw fallback branch.
+   * @param result - The swipe result to return (or null for the default success)
+   */
+  setSwipeResult(result: A11ySwipeResult | null): void {
+    this.swipeResult = result;
+  }
+
+  /**
+   * Configure the result returned by requestClearText. The a11y clear-text path
+   * treats a `{ success: false }` return (not a throw) as the trigger for the ADB
+   * delete-key fallback; setFailureMode("clearText") throws instead, which the
+   * production code does not catch. This seam is required to reach that fallback.
+   * @param result - The clear-text result to return (or null for the default success)
+   */
+  setClearTextResult(result: A11ySetTextResult | null): void {
+    this.clearTextResult = result;
   }
 
   // Assertion methods
@@ -462,6 +485,10 @@ export class FakeCtrlProxy implements AndroidCtrlProxy {
 
     this.swipeHistory.push({ x1, y1, x2, y2, duration });
 
+    if (this.swipeResult) {
+      return this.swipeResult;
+    }
+
     return {
       success: true,
       totalTimeMs: duration,
@@ -577,6 +604,10 @@ export class FakeCtrlProxy implements AndroidCtrlProxy {
 
     // Clear text is essentially setText with empty string
     this.setTextHistory.push({ text: "", resourceId });
+
+    if (this.clearTextResult) {
+      return this.clearTextResult;
+    }
 
     return {
       success: true,

--- a/test/fakes/FakeElementSelector.ts
+++ b/test/fakes/FakeElementSelector.ts
@@ -18,6 +18,8 @@ export class FakeElementSelector implements ElementSelector {
   textCalls: string[] = [];
   lastResourceId?: string;
   lastTestTag?: string;
+  lastScrollableContainer?: boolean;
+  lastContainer?: { elementId?: string; text?: string } | null;
   nextElement: Element | null;
   nextIndexInMatches?: number;
   nextTotalMatches?: number;
@@ -131,6 +133,8 @@ export class FakeElementSelector implements ElementSelector {
   ): ElementSelectionResult {
     void viewHierarchy;
     this.lastStrategy = options?.strategy;
+    this.lastScrollableContainer = options?.scrollableContainer;
+    this.lastContainer = options?.container ?? undefined;
     return this.buildSelectionResult(options?.strategy);
   }
 

--- a/test/features/action/ClearText.adbFallback.test.ts
+++ b/test/features/action/ClearText.adbFallback.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { ClearText } from "../../../src/features/action/ClearText";
+import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeCtrlProxy } from "../../fakes/FakeCtrlProxy";
+import type { BootedDevice, ObserveResult } from "../../../src/models";
+
+describe("ClearText Android ADB fallback", () => {
+  const device: BootedDevice = {
+    deviceId: "test-device",
+    platform: "android",
+    name: "Test Device"
+  };
+
+  let fakeAdb: FakeAdbExecutor;
+  let fakeA11yService: FakeCtrlProxy;
+  let getInstanceSpy: ReturnType<typeof spyOn> | null = null;
+  let observedSpy: ReturnType<typeof spyOn> | null = null;
+
+  const focusedFieldObserve = (text: string): ObserveResult => ({
+    timestamp: Date.now(),
+    screenSize: { width: 1080, height: 1920 },
+    systemInsets: { top: 0, right: 0, bottom: 0, left: 0 },
+    viewHierarchy: {
+      hierarchy: {
+        node: {
+          $: {
+            "focused": "true",
+            "text": text,
+            "class": "android.widget.EditText"
+          }
+        }
+      }
+    }
+  });
+
+  const noHierarchyObserve = (): ObserveResult => ({
+    timestamp: Date.now(),
+    screenSize: { width: 1080, height: 1920 },
+    systemInsets: { top: 0, right: 0, bottom: 0, left: 0 }
+  });
+
+  const runClearText = (observeResult: ObserveResult) => {
+    const clearText = new ClearText(device, fakeAdb as any);
+    observedSpy = spyOn(
+      clearText as unknown as { observedInteraction: (fn: (o: ObserveResult) => Promise<unknown>) => Promise<unknown> },
+      "observedInteraction"
+    ).mockImplementation(async (fn: (o: ObserveResult) => Promise<unknown>) => fn(observeResult));
+    return clearText.execute();
+  };
+
+  beforeEach(() => {
+    fakeAdb = new FakeAdbExecutor();
+    fakeA11yService = new FakeCtrlProxy();
+    getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue(
+      fakeA11yService as unknown as AndroidCtrlProxyClient
+    );
+  });
+
+  afterEach(() => {
+    getInstanceSpy?.mockRestore();
+    observedSpy?.mockRestore();
+    getInstanceSpy = null;
+    observedSpy = null;
+  });
+
+  test("clears via the accessibility service and never touches ADB when a11y succeeds", async () => {
+    // Default FakeCtrlProxy.requestClearText returns success.
+    const result = await runClearText(focusedFieldObserve("hello"));
+
+    expect(result.success).toBe(true);
+    expect(fakeAdb.getExecutedCommands()).toEqual([]);
+  });
+
+  test("falls back to ADB deletes sized to the focused field when a11y clear fails", async () => {
+    fakeA11yService.setClearTextResult({ success: false, totalTimeMs: 0, error: "no focused node" });
+
+    const result = await runClearText(focusedFieldObserve("hello"));
+
+    expect(result.success).toBe(true);
+    // MOVE_END once, then exactly one KEYCODE_DEL per character (5).
+    expect(fakeAdb.getExecutedCommands()).toEqual([
+      "shell input keyevent KEYCODE_MOVE_END",
+      "shell input keyevent KEYCODE_DEL",
+      "shell input keyevent KEYCODE_DEL",
+      "shell input keyevent KEYCODE_DEL",
+      "shell input keyevent KEYCODE_DEL",
+      "shell input keyevent KEYCODE_DEL"
+    ]);
+  });
+
+  test("issues no key events when the focused field is already empty", async () => {
+    fakeA11yService.setClearTextResult({ success: false, totalTimeMs: 0, error: "no focused node" });
+
+    const result = await runClearText(focusedFieldObserve(""));
+
+    expect(result.success).toBe(true);
+    // A zero-length field must not spam MOVE_END/DEL key events.
+    expect(fakeAdb.getExecutedCommands()).toEqual([]);
+  });
+
+  test("uses the 200-delete default when no view hierarchy is available", async () => {
+    fakeA11yService.setClearTextResult({ success: false, totalTimeMs: 0, error: "no focused node" });
+
+    const result = await runClearText(noHierarchyObserve());
+
+    expect(result.success).toBe(true);
+    const commands = fakeAdb.getExecutedCommands();
+    expect(commands[0]).toBe("shell input keyevent KEYCODE_MOVE_END");
+    const deletes = commands.filter(cmd => cmd === "shell input keyevent KEYCODE_DEL");
+    expect(deletes.length).toBe(200);
+  });
+});

--- a/test/features/action/DragAndDrop.test.ts
+++ b/test/features/action/DragAndDrop.test.ts
@@ -145,4 +145,70 @@ describe("DragAndDrop", () => {
     expect(result.success).toBe(false);
     expect(result.error).toBe("Failed to perform drag and drop: Accessibility service failure");
   });
+
+  test("uses default gesture durations and a 1600ms drag timeout when none are supplied", async () => {
+    await dragAndDrop.execute({
+      source: { elementId: "source-id" },
+      target: { elementId: "target-id" }
+    });
+
+    const [dragCall] = fakeA11yService.getDragHistory();
+    expect(dragCall.pressDurationMs).toBe(600);
+    expect(dragCall.dragDurationMs).toBe(300);
+    expect(dragCall.holdDurationMs).toBe(100);
+    // 600 + 300 + 100 + DROP(100) + BUFFER(500) = 1600
+    expect(dragCall.timeoutMs).toBe(1600);
+  });
+
+  test("derives the drag timeout from the supplied gesture durations", async () => {
+    await dragAndDrop.execute({
+      source: { elementId: "source-id" },
+      target: { elementId: "target-id" },
+      pressDurationMs: 600,
+      dragDurationMs: 500,
+      holdDurationMs: 200
+    });
+
+    const [dragCall] = fakeA11yService.getDragHistory();
+    // 600 + 500 + 200 + DROP(100) + BUFFER(500) = 1900
+    expect(dragCall.timeoutMs).toBe(1900);
+  });
+
+  describe("validateOptions", () => {
+    test.each<[string, any, string]>([
+      ["missing target", { source: { elementId: "source-id" } }, "requires source and target"],
+      [
+        "source with both selectors",
+        { source: { elementId: "source-id", text: "Source" }, target: { elementId: "target-id" } },
+        "source must specify exactly one of text or elementId"
+      ],
+      [
+        "target with both selectors",
+        { source: { elementId: "source-id" }, target: { elementId: "target-id", text: "Target" } },
+        "target must specify exactly one of text or elementId"
+      ],
+      [
+        "pressDurationMs above the maximum",
+        { source: { elementId: "source-id" }, target: { elementId: "target-id" }, pressDurationMs: 5000 },
+        "pressDurationMs must be between 600ms and 3000ms"
+      ],
+      [
+        "dragDurationMs above the maximum",
+        { source: { elementId: "source-id" }, target: { elementId: "target-id" }, dragDurationMs: 5000 },
+        "dragDurationMs must be between 300ms and 2000ms"
+      ],
+      [
+        "holdDurationMs below the minimum",
+        { source: { elementId: "source-id" }, target: { elementId: "target-id" }, holdDurationMs: 5 },
+        "holdDurationMs must be between 100ms and 3000ms"
+      ],
+    ])("rejects %s without dispatching a drag", async (_name, options, expected) => {
+      const result = await dragAndDrop.execute(options);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain(expected);
+      // A rejected request must never reach the accessibility service.
+      expect(fakeA11yService.getDragHistory()).toHaveLength(0);
+    });
+  });
 });

--- a/test/features/action/ExecuteGesture.android.test.ts
+++ b/test/features/action/ExecuteGesture.android.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { ExecuteGesture } from "../../../src/features/action/ExecuteGesture";
+import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeCtrlProxy } from "../../fakes/FakeCtrlProxy";
+import type { BootedDevice } from "../../../src/models";
+
+describe("ExecuteGesture Android swipe", () => {
+  const androidDevice: BootedDevice = {
+    deviceId: "test-device",
+    platform: "android",
+    name: "Test Device"
+  };
+
+  let fakeAdb: FakeAdbExecutor;
+  let fakeA11yService: FakeCtrlProxy;
+  let getInstanceSpy: ReturnType<typeof spyOn> | null = null;
+
+  beforeEach(() => {
+    fakeAdb = new FakeAdbExecutor();
+    fakeA11yService = new FakeCtrlProxy();
+  });
+
+  afterEach(() => {
+    getInstanceSpy?.mockRestore();
+    getInstanceSpy = null;
+  });
+
+  const createGesture = () => new ExecuteGesture(androidDevice, fakeAdb);
+
+  test("dispatches an ADB input swipe with the given coordinates and duration in adb mode", async () => {
+    const result = await createGesture().swipe(10, 20, 30, 40, { duration: 250 });
+
+    expect(result).toEqual({ success: true, x1: 10, y1: 20, x2: 30, y2: 40, duration: 250 });
+    expect(fakeAdb.getExecutedCommands()).toEqual(["shell input swipe 10 20 30 40 250"]);
+  });
+
+  test("defaults the ADB swipe duration to 300ms when none is supplied", async () => {
+    const result = await createGesture().swipe(0, 0, 100, 100);
+
+    expect(result.duration).toBe(300);
+    expect(fakeAdb.getExecutedCommands()).toEqual(["shell input swipe 0 0 100 100 300"]);
+  });
+
+  test("uses the accessibility service and skips ADB when a11y swipe succeeds", async () => {
+    fakeA11yService.setSwipeResult({ success: true, totalTimeMs: 42, gestureTimeMs: 30 });
+    getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue(
+      fakeA11yService as unknown as AndroidCtrlProxyClient
+    );
+
+    const result = await createGesture().swipe(5, 6, 7, 8, { scrollMode: "a11y", duration: 120 });
+
+    expect(result.success).toBe(true);
+    expect(result.a11yTotalTimeMs).toBe(42);
+    expect(result.a11yGestureTimeMs).toBe(30);
+    expect(result.fallbackReason).toBeUndefined();
+    // Success path must not touch ADB.
+    expect(fakeAdb.getExecutedCommands()).toEqual([]);
+    // The a11y service received the exact coordinates.
+    expect(fakeA11yService.getSwipeHistory()).toEqual([{ x1: 5, y1: 6, x2: 7, y2: 8, duration: 120 }]);
+  });
+
+  test("falls back to an ADB swipe when the a11y service reports failure", async () => {
+    fakeA11yService.setSwipeResult({ success: false, totalTimeMs: 0, error: "service unavailable" });
+    getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue(
+      fakeA11yService as unknown as AndroidCtrlProxyClient
+    );
+
+    const result = await createGesture().swipe(5, 6, 7, 8, { scrollMode: "a11y", duration: 120 });
+
+    // Still reports success, but records why it fell back and issues the ADB swipe.
+    expect(result.success).toBe(true);
+    expect(result.fallbackReason).toBe("service unavailable");
+    expect(fakeAdb.getExecutedCommands()).toEqual(["shell input swipe 5 6 7 8 120"]);
+  });
+
+  test("falls back to an ADB swipe when the a11y service throws", async () => {
+    fakeA11yService.setFailureMode("swipe", new Error("socket closed"));
+    getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue(
+      fakeA11yService as unknown as AndroidCtrlProxyClient
+    );
+
+    const result = await createGesture().swipe(5, 6, 7, 8, { scrollMode: "a11y", duration: 90 });
+
+    expect(result.success).toBe(true);
+    expect(result.fallbackReason).toContain("socket closed");
+    expect(fakeAdb.getExecutedCommands()).toEqual(["shell input swipe 5 6 7 8 90"]);
+  });
+
+  test("rejects a platform it has no swipe transport for", async () => {
+    const gesture = createGesture();
+    // The constructor validates the platform in BaseVisualChange, so mutate the
+    // resolved device after construction to reach the swipe() default branch.
+    (gesture as any).device.platform = "web";
+
+    await expect(gesture.swipe(0, 0, 1, 1)).rejects.toThrow("Unsupported platform: web");
+  });
+});

--- a/test/features/action/InputKey.test.ts
+++ b/test/features/action/InputKey.test.ts
@@ -77,6 +77,21 @@ describe("InputKey", () => {
     ]);
   });
 
+  test("wraps an ADB keyevent failure in a stable error envelope", async () => {
+    const fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setCommandError("KEYCODE_TAB", new Error("device offline"));
+    const inputKey = new InputKey(androidDevice, createAdbFactory(fakeAdb));
+
+    const result = await inputKey.press("tab", 500);
+
+    expect(result).toEqual({
+      success: false,
+      key: "tab",
+      keyCode: "KEYCODE_TAB",
+      error: 'Failed to press key "tab": device offline',
+    });
+  });
+
   test("returns an explicit unsupported-platform result for iOS", async () => {
     const fakeAdb = new FakeAdbExecutor();
     const inputKey = new InputKey(iosDevice, createAdbFactory(fakeAdb));

--- a/test/features/action/InputText.execute.test.ts
+++ b/test/features/action/InputText.execute.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { InputText } from "../../../src/features/action/InputText";
+import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
+import { IOSCtrlProxyClient } from "../../../src/features/observe/ios";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeCtrlProxy } from "../../fakes/FakeCtrlProxy";
+import { FakeObserveScreen } from "../../fakes/FakeObserveScreen";
+import { FakeWindow } from "../../fakes/FakeWindow";
+import { FakeAwaitIdle } from "../../fakes/FakeAwaitIdle";
+import { FakeTimer } from "../../fakes/FakeTimer";
+import { serverConfig } from "../../../src/utils/ServerConfig";
+import type { BootedDevice, ObserveResult } from "../../../src/models";
+
+describe("InputText.execute", () => {
+  const androidDevice: BootedDevice = {
+    deviceId: "test-device",
+    platform: "android",
+    name: "Test Device"
+  };
+  const iosDevice: BootedDevice = {
+    deviceId: "ios-test-device",
+    platform: "ios",
+    name: "Test iPhone"
+  };
+
+  let fakeAdb: FakeAdbExecutor;
+  let fakeObserveScreen: FakeObserveScreen;
+  let fakeWindow: FakeWindow;
+  let fakeAwaitIdle: FakeAwaitIdle;
+  let fakeA11yService: FakeCtrlProxy;
+  let fakeTimer: FakeTimer;
+  let getInstanceSpy: ReturnType<typeof spyOn> | null = null;
+  let iosGetInstanceSpy: ReturnType<typeof spyOn> | null = null;
+  let savedMarkers: readonly string[];
+
+  const createObserveResult = (): ObserveResult => ({
+    timestamp: Date.now(),
+    screenSize: { width: 1080, height: 1920 },
+    systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+    viewHierarchy: { hierarchy: { node: { $: {} } } }
+  });
+
+  const wireFakes = (inputText: InputText): void => {
+    (inputText as any).observeScreen = fakeObserveScreen;
+    (inputText as any).window = fakeWindow;
+    (inputText as any).awaitIdle = fakeAwaitIdle;
+    (inputText as any).timer = fakeTimer;
+  };
+
+  beforeEach(() => {
+    savedMarkers = serverConfig.getEventAllMarkers();
+    fakeAdb = new FakeAdbExecutor();
+    fakeAdb.setAndroidApiLevel(34);
+    fakeObserveScreen = new FakeObserveScreen();
+    fakeObserveScreen.enableAutoVaryHierarchy();
+    fakeObserveScreen.setObserveResult(() => createObserveResult());
+    fakeWindow = new FakeWindow();
+    fakeWindow.configureCachedActiveWindow(null);
+    fakeWindow.configureActiveWindow({ appId: "com.test.app", activityName: "MainActivity", layoutSeqSum: 1 });
+    fakeAwaitIdle = new FakeAwaitIdle();
+    fakeA11yService = new FakeCtrlProxy();
+    fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+  });
+
+  afterEach(() => {
+    serverConfig.setEventAllMarkers(savedMarkers);
+    getInstanceSpy?.mockRestore();
+    iosGetInstanceSpy?.mockRestore();
+    getInstanceSpy = null;
+    iosGetInstanceSpy = null;
+  });
+
+  test("returns a no-text failure without invoking any transport when text is undefined", async () => {
+    const inputText = new InputText(androidDevice, fakeAdb as any);
+    wireFakes(inputText);
+
+    const result = await inputText.execute(undefined as any);
+
+    expect(result).toMatchObject({ success: false, text: "", error: "No text provided", method: "a11y" });
+    // Early return: never reaches the accessibility service or ADB.
+    expect(fakeAdb.getExecutedCommands()).toEqual([]);
+  });
+
+  test("uses the atomic a11y setText (no key events) when no marker matches", async () => {
+    serverConfig.setEventAllMarkers([]);
+    getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue(
+      fakeA11yService as unknown as AndroidCtrlProxyClient
+    );
+
+    const inputText = new InputText(androidDevice, fakeAdb as any);
+    wireFakes(inputText);
+
+    const result = await inputText.execute("/a");
+
+    expect(result.success).toBe(true);
+    expect(result.method).toBe("a11y");
+    // a11y mode sets the whole string atomically and issues no per-character keyevents.
+    expect(fakeA11yService.getTextInputHistory()).toEqual([{ text: "/a", resourceId: undefined }]);
+    expect(fakeAdb.getExecutedCommands().some(cmd => cmd.includes("keyevent"))).toBe(false);
+  });
+
+  test("auto-promotes to eventAll key events when the text matches a configured marker", async () => {
+    serverConfig.setEventAllMarkers(["/"]);
+    getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue(
+      fakeA11yService as unknown as AndroidCtrlProxyClient
+    );
+
+    const inputText = new InputText(androidDevice, fakeAdb as any);
+    wireFakes(inputText);
+
+    const result = await inputText.execute("/a");
+
+    expect(result.success).toBe(true);
+    expect(result.method).toBe("eventAll");
+    // eventAll types character-by-character via real key events so keystroke-driven
+    // autocomplete (slash/@ popups) actually opens.
+    expect(fakeAdb.getExecutedCommands().some(cmd => cmd.includes("keyevent"))).toBe(true);
+  });
+
+  test("routes iOS input through the CtrlProxy client and ignores Android modes", async () => {
+    const fakeIosClient = {
+      requestSetText: async () => ({ success: true, totalTimeMs: 5 })
+    };
+    iosGetInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue(
+      fakeIosClient as unknown as IOSCtrlProxyClient
+    );
+
+    const inputText = new InputText(iosDevice, fakeAdb as any);
+    wireFakes(inputText);
+
+    const result = await inputText.execute("hello", undefined, false, "eventAll");
+
+    expect(result.success).toBe(true);
+    // iOS always reports the a11y method regardless of the requested Android mode.
+    expect(result.method).toBe("a11y");
+    expect(fakeAdb.getExecutedCommands()).toEqual([]);
+  });
+});

--- a/test/features/action/PressButton.android.test.ts
+++ b/test/features/action/PressButton.android.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { PressButton } from "../../../src/features/action/PressButton";
+import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import type { BootedDevice } from "../../../src/models";
+
+describe("PressButton Android keycode dispatch", () => {
+  const androidDevice: BootedDevice = {
+    deviceId: "android-device",
+    platform: "android",
+    name: "Pixel"
+  };
+
+  let fakeAdb: FakeAdbExecutor;
+  let getInstanceSpy: ReturnType<typeof spyOn> | null = null;
+
+  beforeEach(() => {
+    fakeAdb = new FakeAdbExecutor();
+  });
+
+  afterEach(() => {
+    getInstanceSpy?.mockRestore();
+    getInstanceSpy = null;
+  });
+
+  const press = (button: string) => {
+    const pressButton = new PressButton(androidDevice, fakeAdb);
+    return (pressButton as any).executeAndroidButtonPress(button) as Promise<{
+      success: boolean;
+      button: string;
+      keyCode: number;
+      error?: string;
+    }>;
+  };
+
+  // In-place hardware buttons dispatch straight to an ADB keyevent (no global action).
+  test.each<[string, number]>([
+    ["menu", 82],
+    ["power", 26],
+    ["volume_up", 24],
+    ["volume_down", 25],
+  ])("dispatches keyevent %i for %s", async (button, keyCode) => {
+    const result = await press(button);
+
+    expect(result).toEqual({ success: true, button, keyCode });
+    expect(fakeAdb.getExecutedCommands()).toEqual([`shell input keyevent ${keyCode}`]);
+  });
+
+  test("normalizes the button name case before resolving the keycode", async () => {
+    const result = await press("MENU");
+
+    expect(result).toEqual({ success: true, button: "MENU", keyCode: 82 });
+    expect(fakeAdb.getExecutedCommands()).toEqual(["shell input keyevent 82"]);
+  });
+
+  test("rejects an unknown button without dispatching a keyevent", async () => {
+    const result = await press("definitely_not_a_button");
+
+    expect(result.success).toBe(false);
+    expect(result.keyCode).toBe(-1);
+    expect(result.error).toContain("Unsupported button");
+    expect(fakeAdb.getExecutedCommands()).toEqual([]);
+  });
+
+  // Navigation buttons fall back to an ADB keyevent when the a11y global action
+  // is unavailable. This pins the keycode each navigation button maps to — e.g.
+  // "back" must be 4 (KEYCODE_BACK), never 3 (KEYCODE_HOME).
+  test.each<[string, number]>([
+    ["back", 4],
+    ["home", 3],
+    ["recent", 187],
+  ])("falls back to keyevent %i for navigation button %s", async (button, keyCode) => {
+    getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+      requestGlobalAction: async () => {
+        throw new Error("global action unavailable");
+      }
+    } as unknown as AndroidCtrlProxyClient);
+
+    const result = await press(button);
+
+    expect(result).toEqual({ success: true, button, keyCode });
+    expect(fakeAdb.getExecutedCommands()).toEqual([`shell input keyevent ${keyCode}`]);
+  });
+});

--- a/test/features/action/SelectAllText.test.ts
+++ b/test/features/action/SelectAllText.test.ts
@@ -1,7 +1,8 @@
-import { expect, describe, test, spyOn } from "bun:test";
+import { expect, describe, test, spyOn, afterEach } from "bun:test";
 import { SelectAllText } from "../../../src/features/action/SelectAllText";
 import { BootedDevice } from "../../../src/models";
 import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
+import { IOSCtrlProxyClient } from "../../../src/features/observe/ios";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 
 describe("SelectAllText Android", () => {
@@ -37,6 +38,99 @@ describe("SelectAllText Android", () => {
     expect(factory.wasCalledForDevice(device.deviceId)).toBe(true);
 
     getInstanceSpy.mockRestore();
+    observedSpy.mockRestore();
+  });
+});
+
+describe("SelectAllText outcomes", () => {
+  let getInstanceSpy: ReturnType<typeof spyOn> | null = null;
+  let iosGetInstanceSpy: ReturnType<typeof spyOn> | null = null;
+
+  afterEach(() => {
+    getInstanceSpy?.mockRestore();
+    iosGetInstanceSpy?.mockRestore();
+    getInstanceSpy = null;
+    iosGetInstanceSpy = null;
+  });
+
+  const androidDevice: BootedDevice = { name: "Android", platform: "android", deviceId: "android-1" };
+  const iosDevice: BootedDevice = { name: "iPhone", platform: "ios", deviceId: "ios-1" };
+
+  const runWithoutObservation = (selectAllText: SelectAllText) => {
+    const observedSpy = spyOn(
+      selectAllText as unknown as { observedInteraction: (fn: () => Promise<unknown>) => Promise<unknown> },
+      "observedInteraction"
+    ).mockImplementation(async (fn: () => Promise<unknown>) => fn());
+    return { promise: selectAllText.execute(), observedSpy };
+  };
+
+  test("reports success when the Android accessibility service selects all", async () => {
+    getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+      requestSelectAll: async () => ({ success: true, totalTimeMs: 3 })
+    } as unknown as AndroidCtrlProxyClient);
+
+    const selectAllText = new SelectAllText(androidDevice, new FakeAdbClientFactory());
+    const { promise, observedSpy } = runWithoutObservation(selectAllText);
+    const result = await promise;
+
+    expect(result).toEqual({ success: true });
+    observedSpy.mockRestore();
+  });
+
+  test("labels the Android accessibility failure with the underlying error", async () => {
+    getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+      requestSelectAll: async () => ({ success: false, totalTimeMs: 3, error: "no focused field" })
+    } as unknown as AndroidCtrlProxyClient);
+
+    const selectAllText = new SelectAllText(androidDevice, new FakeAdbClientFactory());
+    const { promise, observedSpy } = runWithoutObservation(selectAllText);
+    const result = await promise;
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("Accessibility service selectAll failed: no focused field");
+    observedSpy.mockRestore();
+  });
+
+  test("reports success on the iOS CtrlProxy path", async () => {
+    iosGetInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+      requestSelectAll: async () => ({ success: true, totalTimeMs: 3 })
+    } as unknown as IOSCtrlProxyClient);
+
+    const selectAllText = new SelectAllText(iosDevice, new FakeAdbClientFactory());
+    const { promise, observedSpy } = runWithoutObservation(selectAllText);
+    const result = await promise;
+
+    expect(result).toEqual({ success: true });
+    observedSpy.mockRestore();
+  });
+
+  test("surfaces the iOS CtrlProxy failure error verbatim", async () => {
+    iosGetInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+      requestSelectAll: async () => ({ success: false, totalTimeMs: 3, error: "editor not first responder" })
+    } as unknown as IOSCtrlProxyClient);
+
+    const selectAllText = new SelectAllText(iosDevice, new FakeAdbClientFactory());
+    const { promise, observedSpy } = runWithoutObservation(selectAllText);
+    const result = await promise;
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("editor not first responder");
+    observedSpy.mockRestore();
+  });
+
+  test("returns a structured failure when the iOS CtrlProxy throws", async () => {
+    iosGetInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+      requestSelectAll: async () => {
+        throw new Error("socket closed");
+      }
+    } as unknown as IOSCtrlProxyClient);
+
+    const selectAllText = new SelectAllText(iosDevice, new FakeAdbClientFactory());
+    const { promise, observedSpy } = runWithoutObservation(selectAllText);
+    const result = await promise;
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("socket closed");
     observedSpy.mockRestore();
   });
 });

--- a/test/features/action/TapAnyElement.test.ts
+++ b/test/features/action/TapAnyElement.test.ts
@@ -26,42 +26,30 @@ const makeElement = () => ({
 } as any);
 
 describe("TapAnyElement", () => {
-  describe("validation", () => {
-    test("rejects container with both elementId and text", () => {
-      const selector = new FakeElementSelector(makeElement());
-      const tapAny = createTapAnyElement(selector);
-      const error = (tapAny as any).validateOptions({
-        action: "tap",
-        container: { elementId: "com.app:id/list", text: "List" },
-      });
-      expect(error).toContain("container must specify exactly one");
-    });
+  describe("validateOptions", () => {
+    const EXACTLY_ONE = "container must specify exactly one";
 
-    test("accepts no container", () => {
-      const selector = new FakeElementSelector(makeElement());
-      const tapAny = createTapAnyElement(selector);
-      const error = (tapAny as any).validateOptions({ action: "tap" });
-      expect(error).toBeNull();
-    });
-
-    test("accepts container with elementId only", () => {
-      const selector = new FakeElementSelector(makeElement());
-      const tapAny = createTapAnyElement(selector);
-      const error = (tapAny as any).validateOptions({
-        action: "tap",
-        container: { elementId: "com.app:id/list" },
-      });
-      expect(error).toBeNull();
-    });
-
-    test("accepts container with text only", () => {
-      const selector = new FakeElementSelector(makeElement());
-      const tapAny = createTapAnyElement(selector);
-      const error = (tapAny as any).validateOptions({
-        action: "tap",
-        container: { text: "My List" },
-      });
-      expect(error).toBeNull();
+    // A container must resolve to exactly one truthy selector. Zero truthy
+    // selectors ({}, or both empty strings) is an error just like two — an empty
+    // container cannot be located, so it must not pass validation and fall through
+    // to an ambiguous match.
+    test.each<[string, Record<string, unknown> | undefined, string | null]>([
+      ["no container", undefined, null],
+      ["elementId only", { elementId: "com.app:id/list" }, null],
+      ["text only", { text: "My List" }, null],
+      ["empty elementId but real text", { elementId: "", text: "List" }, null],
+      ["real elementId but empty text", { elementId: "com.app:id/list", text: "" }, null],
+      ["both elementId and text", { elementId: "com.app:id/list", text: "List" }, EXACTLY_ONE],
+      ["empty container object", {}, EXACTLY_ONE],
+      ["both selectors empty strings", { elementId: "", text: "" }, EXACTLY_ONE],
+    ])("%s", (_name, container, expected) => {
+      const tapAny = createTapAnyElement(new FakeElementSelector(makeElement()));
+      const error = (tapAny as any).validateOptions({ action: "tap", container });
+      if (expected === null) {
+        expect(error).toBeNull();
+      } else {
+        expect(error).toContain(expected);
+      }
     });
   });
 
@@ -91,7 +79,7 @@ describe("TapAnyElement", () => {
       expect(selector.lastStrategy).toBe("random");
     });
 
-    test("passes scrollableContainer option", () => {
+    test("forwards scrollableContainer=true to the selector", () => {
       const selector = new FakeElementSelector(makeElement());
       const tapAny = createTapAnyElement(selector);
 
@@ -100,7 +88,19 @@ describe("TapAnyElement", () => {
         { hierarchy: { node: {} } }
       );
 
-      expect(selector.lastStrategy).toBeUndefined();
+      expect(selector.lastScrollableContainer).toBe(true);
+    });
+
+    test("leaves scrollableContainer unset when not requested", () => {
+      const selector = new FakeElementSelector(makeElement());
+      const tapAny = createTapAnyElement(selector);
+
+      (tapAny as any).findClickableElement(
+        { action: "tap" },
+        { hierarchy: { node: {} } }
+      );
+
+      expect(selector.lastScrollableContainer).toBeUndefined();
     });
 
     test("returns null element when selector returns null", () => {

--- a/test/features/action/TapOnElement.voiceover.test.ts
+++ b/test/features/action/TapOnElement.voiceover.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, spyOn } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test, spyOn } from "bun:test";
 import { TapOnElement } from "../../../src/features/action/TapOnElement";
 import { FakeAdbClient } from "../../fakes/FakeAdbClient";
 import { FakeIosVoiceOverDetector } from "../../fakes/FakeIosVoiceOverDetector";
@@ -12,7 +12,6 @@ describe("TapOnElement VoiceOver mode", () => {
   let fakeIosClient: FakeIOSCtrlProxy;
   let tapOnElement: TapOnElement;
   let executeiOSTapWithCoordinates: any;
-  let executeIOSTapWithVoiceOver: any;
 
   beforeEach(() => {
     fakeVoiceOverDetector = new FakeIosVoiceOverDetector();
@@ -35,74 +34,78 @@ describe("TapOnElement VoiceOver mode", () => {
       }
     );
 
-    executeiOSTapWithCoordinates = spyOn(
-      tapOnElement as any,
-      "executeiOSTapWithCoordinates"
-    ).mockResolvedValue(undefined);
-
-    executeIOSTapWithVoiceOver = spyOn(
-      tapOnElement as any,
-      "executeIOSTapWithVoiceOver"
-    ).mockResolvedValue(undefined);
+    executeiOSTapWithCoordinates = null;
   });
 
-  describe("when VoiceOver is disabled", () => {
-    beforeEach(() => {
-      fakeVoiceOverDetector.setVoiceOverEnabled(false);
+  // These dispatch-routing tests deliberately do NOT mock the two transport
+  // methods. Instead they let the real transport run against the fake CtrlProxy
+  // and assert the observable artifact each one leaves (a coordinate tap in
+  // tapHistory vs a VoiceOver activation in voiceOverActivateHistory). An earlier
+  // version mocked both targets and only asserted which mock was called, so no
+  // real code ran and the routing could not actually regress the test.
+  describe("dispatch routing (real transport artifacts)", () => {
+    let getInstanceSpy: ReturnType<typeof spyOn> | null = null;
+
+    const wireCtrlProxy = async () => {
+      const iosModule = await import("../../../src/features/observe/ios");
+      getInstanceSpy = spyOn(iosModule.IOSCtrlProxyClient, "getInstance").mockReturnValue(fakeIosClient as any);
+    };
+
+    afterEach(() => {
+      getInstanceSpy?.mockRestore();
+      getInstanceSpy = null;
     });
 
-    test("dispatches to coordinate-based tap method when VoiceOver disabled", async () => {
-      const element = {
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 },
-        "ios-accessibility-label": "Settings",
-      } as any;
+    const element = {
+      "bounds": { left: 0, top: 0, right: 100, bottom: 100 },
+      "ios-accessibility-label": "Settings",
+    } as any;
+
+    test("VoiceOver disabled + element records a coordinate tap only", async () => {
+      fakeVoiceOverDetector.setVoiceOverEnabled(false);
+      await wireCtrlProxy();
 
       await (tapOnElement as any).executeiOSTap("tap", 50, 50, 50, element, false);
 
-      expect(executeiOSTapWithCoordinates).toHaveBeenCalledTimes(1);
-      expect(executeIOSTapWithVoiceOver).not.toHaveBeenCalled();
+      expect(fakeIosClient.getTapHistory()).toEqual([{ x: 50, y: 50, duration: 50 }]);
+      expect(fakeIosClient.getVoiceOverActivateHistory()).toHaveLength(0);
     });
 
-    test("dispatches to coordinate-based tap when no element provided", async () => {
+    test("VoiceOver disabled + no element records a coordinate tap only", async () => {
+      fakeVoiceOverDetector.setVoiceOverEnabled(false);
+      await wireCtrlProxy();
+
       await (tapOnElement as any).executeiOSTap("tap", 50, 50, 50, undefined, false);
 
-      expect(executeiOSTapWithCoordinates).toHaveBeenCalledTimes(1);
-      expect(executeIOSTapWithVoiceOver).not.toHaveBeenCalled();
+      expect(fakeIosClient.getTapHistory()).toHaveLength(1);
+      expect(fakeIosClient.getVoiceOverActivateHistory()).toHaveLength(0);
     });
-  });
 
-  describe("when VoiceOver is enabled", () => {
-    beforeEach(() => {
+    test("VoiceOver enabled + element records a VoiceOver activation only", async () => {
       fakeVoiceOverDetector.setVoiceOverEnabled(true);
-    });
-
-    test("dispatches to VoiceOver tap method when enabled and element provided", async () => {
-      const element = {
-        "bounds": { left: 0, top: 0, right: 100, bottom: 100 },
-        "ios-accessibility-label": "Settings",
-      } as any;
+      await wireCtrlProxy();
 
       await (tapOnElement as any).executeiOSTap("tap", 50, 50, 50, element, true);
 
-      expect(executeIOSTapWithVoiceOver).toHaveBeenCalledTimes(1);
-      expect(executeiOSTapWithCoordinates).not.toHaveBeenCalled();
+      expect(fakeIosClient.getVoiceOverActivateHistory()).toEqual([{ label: "Settings", action: "activate" }]);
+      expect(fakeIosClient.getTapHistory()).toHaveLength(0);
     });
 
-    test("falls back to coordinate tap when element is undefined", async () => {
+    test("VoiceOver enabled + no element falls back to a coordinate tap", async () => {
+      fakeVoiceOverDetector.setVoiceOverEnabled(true);
+      await wireCtrlProxy();
+
       await (tapOnElement as any).executeiOSTap("tap", 50, 50, 50, undefined, true);
 
-      expect(executeiOSTapWithCoordinates).toHaveBeenCalledTimes(1);
-      expect(executeIOSTapWithVoiceOver).not.toHaveBeenCalled();
+      expect(fakeIosClient.getTapHistory()).toHaveLength(1);
+      expect(fakeIosClient.getVoiceOverActivateHistory()).toHaveLength(0);
     });
   });
 
   describe("executeIOSTapWithVoiceOver", () => {
     beforeEach(() => {
-      // Restore real implementation for direct testing
-      executeiOSTapWithCoordinates.mockRestore();
-      executeIOSTapWithVoiceOver.mockRestore();
-
-      // Mock coordinate fallback
+      // Mock only the coordinate fallback so the real VoiceOver path runs and
+      // records its artifact against the fake CtrlProxy client.
       executeiOSTapWithCoordinates = spyOn(
         tapOnElement as any,
         "executeiOSTapWithCoordinates"

--- a/test/features/action/androidPreTapStablePolicy.test.ts
+++ b/test/features/action/androidPreTapStablePolicy.test.ts
@@ -52,4 +52,28 @@ describe("androidPreTapConsecutiveStableMatchesRequired", () => {
       })
     ).toBe(1);
   });
+
+  // Full specification. Only a strict boolean `true` takes the strict path (2);
+  // every other value — including untyped MCP coercions like the number 1 or the
+  // string "true" — takes the lax single-match path (1). This pins that a loosely
+  // typed sibling flag can never silently loosen churn tolerance.
+  test.each<[string, unknown, number]>([
+    ["boolean true", true, ANDROID_PRE_TAP_STABLE_MATCHES_STRICT],
+    ["boolean false", false, 1],
+    ["undefined", undefined, 1],
+    ["number 1", 1, 1],
+    ["number 0", 0, 1],
+    ["string 'true'", "true", 1],
+    ["string 'false'", "false", 1],
+    ["null", null, 1],
+    ["empty string", "", 1],
+  ])("sibling=%s resolves to %i consecutive matches", (_name, sibling, expected) => {
+    expect(
+      androidPreTapConsecutiveStableMatchesRequired({
+        text: "Accept Terms",
+        sibling: sibling as boolean,
+        action: "tap"
+      })
+    ).toBe(expected);
+  });
 });

--- a/test/features/action/resolveAutoInputMode.test.ts
+++ b/test/features/action/resolveAutoInputMode.test.ts
@@ -31,4 +31,30 @@ describe("resolveAutoInputMode", () => {
       expect(resolveAutoInputMode(`a${marker}b`, ["@", "/", "#", ":", "_", "*", "~"])).toBe("eventAll");
     }
   });
+
+  // Full specification table including boundary rows (empty, unicode, duplicate,
+  // very long, whitespace). Unicode rows use the real composed characters "café"
+  // and "é" — not pre-normalized NFD byte sequences, which are invisible in source
+  // and flip on a single normalization.
+  const longText = `${"x".repeat(5000)}@handle`;
+  test.each<[string, string, readonly string[], "eventAll" | undefined]>([
+    ["off with no markers", "/msg @x", [], undefined],
+    ["matches a leading marker", "@handle hi", ["@"], "eventAll"],
+    ["no marker present", "plain text", ["@", "/"], undefined],
+    ["multi-character marker", "see https://x", ["https://"], "eventAll"],
+    ["empty-string marker only", "anything", [""], undefined],
+    ["empty text with real markers", "", ["@", "/"], undefined],
+    ["empty text and empty marker", "", [""], undefined],
+    ["unicode composed character matches", "café", ["é"], "eventAll"],
+    ["unicode marker absent from ASCII text", "cafe", ["é"], undefined],
+    ["marker equal to the entire text", "@", ["@"], "eventAll"],
+    ["matches the second marker in the list", "hello #chan", ["@", "#"], "eventAll"],
+    ["duplicate markers still match once", "a@b", ["@", "@"], "eventAll"],
+    ["very long text with a trailing marker", longText, ["@"], "eventAll"],
+    ["very long text without any marker", "y".repeat(5000), ["@"], undefined],
+    ["whitespace marker present in text", "a b", [" "], "eventAll"],
+    ["empty marker skipped but a later real marker matches", "a#b", ["", "#"], "eventAll"],
+  ])("%s", (_name, text, markers, expected) => {
+    expect(resolveAutoInputMode(text, markers)).toBe(expected);
+  });
 });

--- a/test/features/action/swipeon/AutoTargetSelectorUnit.test.ts
+++ b/test/features/action/swipeon/AutoTargetSelectorUnit.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import { AutoTargetSelector } from "../../../../src/features/action/swipeon/AutoTargetSelector";
+import type { Element, ElementBounds } from "../../../../src/models";
+
+// Direct unit tests for the AutoTargetSelector primitives. The SwipeOn autoTarget
+// suite already covers three selectAutoTargetScrollable rows end-to-end; these
+// exercise the geometry, container-description and warning-merge branches directly.
+describe("AutoTargetSelector", () => {
+  const selector = new AutoTargetSelector();
+
+  const elementWithBounds = (bounds: ElementBounds): Element => ({ bounds } as Element);
+
+  describe("selectAutoTargetScrollable", () => {
+    test("returns null when there are no scrollables", () => {
+      expect(selector.selectAutoTargetScrollable([], null, "up")).toBeNull();
+    });
+
+    test("returns the single scrollable when it matches the requested axis", () => {
+      const tall = elementWithBounds({ left: 0, top: 0, right: 100, bottom: 500 });
+      expect(selector.selectAutoTargetScrollable([tall], null, "up")).toBe(tall);
+    });
+
+    test("returns null when the single scrollable is on the wrong axis", () => {
+      const wide = elementWithBounds({ left: 0, top: 0, right: 500, bottom: 100 });
+      expect(selector.selectAutoTargetScrollable([wide], null, "up")).toBeNull();
+    });
+
+    test("excludes the full-screen scroller and picks the largest remaining", () => {
+      const screenBounds: ElementBounds = { left: 0, top: 0, right: 1000, bottom: 2000 };
+      const fullScreen = elementWithBounds({ ...screenBounds });
+      const small = elementWithBounds({ left: 0, top: 100, right: 400, bottom: 600 });
+      const large = elementWithBounds({ left: 0, top: 100, right: 900, bottom: 1500 });
+
+      const result = selector.selectAutoTargetScrollable([fullScreen, small, large], screenBounds, "up");
+      expect(result).toBe(large);
+    });
+
+    test("falls back to the full-screen scrollers when all match screen bounds", () => {
+      const screenBounds: ElementBounds = { left: 0, top: 0, right: 1000, bottom: 2000 };
+      const a = elementWithBounds({ ...screenBounds });
+      const b = elementWithBounds({ ...screenBounds });
+
+      const result = selector.selectAutoTargetScrollable([a, b], screenBounds, "up");
+      expect(result).toBe(a);
+    });
+
+    test("picks the largest scrollable when no screen bounds are known", () => {
+      const small = elementWithBounds({ left: 0, top: 0, right: 100, bottom: 100 });
+      const large = elementWithBounds({ left: 0, top: 0, right: 800, bottom: 800 });
+
+      expect(selector.selectAutoTargetScrollable([small, large], null, "down")).toBe(large);
+    });
+  });
+
+  describe("pickLargestScrollable", () => {
+    test("returns null for an empty list", () => {
+      expect(selector.pickLargestScrollable([])).toBeNull();
+    });
+
+    test("returns the element with the greatest area", () => {
+      const small = elementWithBounds({ left: 0, top: 0, right: 10, bottom: 10 });
+      const big = elementWithBounds({ left: 0, top: 0, right: 100, bottom: 100 });
+      expect(selector.pickLargestScrollable([small, big])).toBe(big);
+    });
+  });
+
+  describe("matchesDirection", () => {
+    test("treats a tall element as vertically scrollable", () => {
+      const tall = elementWithBounds({ left: 0, top: 0, right: 100, bottom: 500 });
+      expect(selector.matchesDirection(tall, "up")).toBe(true);
+      expect(selector.matchesDirection(tall, "left")).toBe(false);
+    });
+
+    test("treats a wide element as horizontally scrollable", () => {
+      const wide = elementWithBounds({ left: 0, top: 0, right: 500, bottom: 100 });
+      expect(selector.matchesDirection(wide, "left")).toBe(true);
+      expect(selector.matchesDirection(wide, "down")).toBe(false);
+    });
+  });
+
+  describe("describeContainer", () => {
+    test("describes an undefined container as unknown", () => {
+      expect(selector.describeContainer(undefined)).toBe("unknown");
+    });
+
+    test("prefers elementId over text", () => {
+      expect(selector.describeContainer({ elementId: "com.app:id/list", text: "List" })).toBe('elementId="com.app:id/list"');
+    });
+
+    test("falls back to text when only text is present", () => {
+      expect(selector.describeContainer({ text: "My List" })).toBe('text="My List"');
+    });
+
+    test("describes an empty container as unknown", () => {
+      expect(selector.describeContainer({})).toBe("unknown");
+    });
+  });
+
+  describe("mergeWarnings", () => {
+    test("returns undefined when there are no warnings", () => {
+      expect(selector.mergeWarnings(undefined, undefined)).toBeUndefined();
+    });
+
+    test("joins distinct warnings and drops duplicates", () => {
+      expect(selector.mergeWarnings("a", undefined, "b", "a")).toBe("a b");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Milestone 32 (Unit Test Quality Audit), slice **action-gestures**: 24 verified test-quality findings burned down, each mutation-verified red-green. **Test-only — empty `src/` diff** (the src fixes this slice targeted already landed on main: `pressButtonPolicy` prototype-name guard #4210, `ImeAction` projections #4316, Keyboard tap/idempotency/abort). Their guards are verified to stay mutation-sensitive.

- **New**: `ExecuteGesture` android a11y→ADB fallback swipe (`FakeCtrlProxy.setSwipeResult`), `PressButton` keycode table, `ClearText` adb-fallback field-sizing (`setClearTextResult`), `InputText.execute` mode resolution (FakeTimer + stubbed `IOSCtrlProxyClient`, 176ms), `AutoTargetSelector` direct unit tests.
- **Rewrites**: `TapAnyElement` `scrollableContainer` forwarding (fake now records it), `TapOnElement.voiceover` 4 dispatch tests moved off double-mocking to real CtrlProxy artifacts, `SelectAllText` outcomes, `DragAndDrop` timeout+validation, `resolveAutoInputMode` 16-row table (real `café`/`é`), `androidPreTapStablePolicy` coercion rows, `InputKey` failure envelope, `TapAnyElement.validateOptions` table (empty-container / both-empty rows expect the ERROR).

## Linked Issue

Closes #4168

## Validation

- [x] `bun test`: **10802 pass / 13 skip / 0 fail** across 817 files; no test >~200ms, no hangs
- [x] `bun run typecheck`: no new errors (206 baseline)
- [x] `bun run lint`: clean

## Follow-ups

- [ ] DELETE (9) and RENAME (13) items deferred — those sections are absent from the issue body.
