### PR TITLE
test(observe-output): burn down 30 verified test-quality findings (#4175)

### DIFF
--- a/test/features/observe/output/ObserveResultOutput.test.ts
+++ b/test/features/observe/output/ObserveResultOutput.test.ts
@@ -4,6 +4,7 @@ import type { ViewHierarchyNode } from "../../../../src/models/ViewHierarchyResu
 import {
   sanitizeObserveResult,
   GFXINFO_DUMP_MARKER,
+  type SanitizeObserveConfig,
 } from "../../../../src/features/observe/output/ObserveResultOutput";
 import {
   loadAndroidHomeObserve,
@@ -112,16 +113,10 @@ describe("sanitizeObserveResult", () => {
       expect(sanitizeObserveResult(observe, COMPACT).screenIdentity).toEqual(observe.screenIdentity);
     });
 
-    test("completes well under the 100ms unit-test budget", () => {
-      const { observe } = loadAndroidHomeObserve();
-      const start = performance.now();
-      sanitizeObserveResult(observe, DROP_ELEMENTS);
-      expect(performance.now() - start).toBeLessThan(100);
-    });
   });
 
   describe("perf-audit strip (always)", () => {
-    test("nulls gfxinfoRaw and cpuStatsRaw", () => {
+    test("perf-audit strip nulls gfxinfoRaw and cpuStatsRaw", () => {
       const { observe } = loadAndroidHomeObserve();
       // Precondition: the baseline carries the heavy raw dumps.
       expect(observe.performanceAudit?.metrics.gfxinfoRaw?.length).toBeGreaterThan(0);
@@ -133,7 +128,7 @@ describe("sanitizeObserveResult", () => {
       expect(out.performanceAudit?.metrics.cpuStatsRaw).toBeNull();
     });
 
-    test("truncates diagnostics to the summary above the GFXINFO DUMP marker", () => {
+    test("perf-audit strip truncates diagnostics to the summary above the GFXINFO DUMP marker", () => {
       const { observe } = loadAndroidHomeObserve();
       const original = observe.performanceAudit!.diagnostics!;
       expect(original).toContain(GFXINFO_DUMP_MARKER);
@@ -149,7 +144,7 @@ describe("sanitizeObserveResult", () => {
       expect(diagnostics).toContain("Top contributors:");
     });
 
-    test("preserves computed metrics and violations", () => {
+    test("perf-audit strip preserves computed metrics and violations", () => {
       const { observe } = loadAndroidHomeObserve();
       const out = sanitizeObserveResult(observe, DROP_NONE);
 
@@ -174,7 +169,7 @@ describe("sanitizeObserveResult", () => {
       expect(measureValue(out).bytes).toBeLessThan(measureValue(observe).bytes - 10_000);
     });
 
-    test("is a no-op when performanceAudit is absent", () => {
+    test("perf-audit strip is a no-op when performanceAudit is absent", () => {
       const { observe } = loadAndroidHomeObserve();
       delete observe.performanceAudit;
       const out = sanitizeObserveResult(observe, DROP_NONE);
@@ -328,8 +323,19 @@ describe("sanitizeObserveResult", () => {
       );
       expect(dupBefore.length).toBeGreaterThan(0);
 
+      // Count-guard (R2): the fixture carries view-ids that DIFFER from
+      // resource-id and must survive the dedup. Without this, a trim that
+      // deleted EVERY view-id would pass the loop below vacuously.
+      const distinctBefore = allHierarchyNodes(observe).filter(
+        n => n["view-id"] !== undefined && n["view-id"] !== (n as Record<string, unknown>)["resource-id"]
+      );
+      expect(distinctBefore.length).toBeGreaterThan(0);
+
       const out = sanitizeObserveResult(observe, DROP_NONE);
 
+      const survivingViewIds = allHierarchyNodes(out).filter(n => n["view-id"] !== undefined);
+      // The distinct view-ids are not collateral damage of the dedup.
+      expect(survivingViewIds.length).toBeGreaterThan(0);
       for (const n of allHierarchyNodes(out)) {
         const rec = n as Record<string, unknown>;
         if (rec["resource-id"] !== undefined && n["view-id"] !== undefined) {
@@ -541,7 +547,7 @@ describe("sanitizeObserveResult", () => {
       expect(measureValue(trimmed).tokens).toBeLessThan(measureValue(untrimmed).tokens);
     });
 
-    test("does not touch rawViewHierarchy (raw stays raw)", () => {
+    test("per-node trim does not touch rawViewHierarchy (raw stays raw)", () => {
       const { observe } = loadAndroidHomeObserve();
       observe.rawViewHierarchy = {
         hierarchy: {
@@ -562,7 +568,7 @@ describe("sanitizeObserveResult", () => {
       expect(JSON.stringify(out.rawViewHierarchy)).toBe(rawBefore);
     });
 
-    test("can be disabled via trimNodes:false", () => {
+    test("per-node trim can be disabled via trimNodes:false", () => {
       const { observe } = loadAndroidHomeObserve();
       const out = sanitizeObserveResult(observe, { dropElements: false, trimNodes: false });
       const dup = allHierarchyNodes(out).filter(
@@ -573,7 +579,7 @@ describe("sanitizeObserveResult", () => {
   });
 
   describe("elements-drop (gated)", () => {
-    test("omits the elements block when dropElements is true", () => {
+    test("elements-drop omits the elements block when dropElements is true", () => {
       const { observe } = loadAndroidHomeObserve();
       expect(observe.elements).toBeDefined();
 
@@ -615,12 +621,17 @@ describe("sanitizeObserveResult", () => {
     test("keeps object-shaped bounds when compact is off (today's shape)", () => {
       const { observe } = loadAndroidHomeObserve();
       const out = sanitizeObserveResult(observe, DROP_NONE);
+      let checked = 0;
       for (const n of allHierarchyNodes(out)) {
         if (n.bounds !== undefined) {
           expect(Array.isArray(n.bounds)).toBe(false);
           expect(n.bounds).toHaveProperty("left");
+          checked++;
         }
       }
+      // Count-guard (R4): a trim that dropped every `bounds` would pass the loop
+      // vacuously — mirrors the `checked > 0` idiom in the round-trip test below.
+      expect(checked).toBeGreaterThan(0);
     });
 
     test("bounds tuple round-trips losslessly back to the original object", () => {
@@ -663,7 +674,7 @@ describe("sanitizeObserveResult", () => {
       expect(measureValue(compact).tokens).toBeLessThan(measureValue(nonCompact).tokens);
     });
 
-    test("is a no-op for nodes that carry no bounds", () => {
+    test("bounds compaction is a no-op for nodes that carry no bounds", () => {
       const obs: ObserveResult = {
         updatedAt: 0,
         screenSize: { width: 1, height: 1 },
@@ -735,48 +746,20 @@ describe("sanitizeObserveResult", () => {
   });
 
   describe("iOS XCTest/UIKit cleanup fixture (#3317)", () => {
-    function nodeText(node: ViewHierarchyNode): string | undefined {
-      return (node as unknown as Record<string, unknown>).text as string | undefined;
-    }
+    // R5: the old "before smaller than after" test compared two DIFFERENT
+    // fixtures, so it measured the fixtures' hand-authored size gap, not any
+    // behavior of `sanitizeObserveResult`. Rewritten to a single fixture:
+    // COMPACT must shrink that one observation versus its own non-compact output.
+    // D1/D2 removed the two fixture-only assertions that called no src symbol
+    // (they inspected `loadIosRemindersNoiseObservePair().after` directly).
+    test("compacting a single iOS Reminders observation shrinks its own output", () => {
+      const { before } = loadIosRemindersNoiseObservePair();
 
-    function nodeClass(node: ViewHierarchyNode): string | undefined {
-      return ((node as unknown as Record<string, unknown>).class
-        ?? (node as unknown as Record<string, unknown>).className) as string | undefined;
-    }
+      const nonCompact = sanitizeObserveResult(before, DROP_NONE);
+      const compact = sanitizeObserveResult(before, COMPACT);
 
-    test("Reminders compact observe is smaller after structural-noise cleanup", () => {
-      const { before, after } = loadIosRemindersNoiseObservePair();
-
-      const beforeCompact = sanitizeObserveResult(before, COMPACT);
-      const afterCompact = sanitizeObserveResult(after, COMPACT);
-
-      expect(measureValue(afterCompact).bytes).toBeLessThan(measureValue(beforeCompact).bytes);
-      expect(measureValue(afterCompact).tokens).toBeLessThan(measureValue(beforeCompact).tokens);
-    });
-
-    test("Reminders cleanup preserves actionable buttons, text fields, toolbar controls, and list cells", () => {
-      const { after } = loadIosRemindersNoiseObservePair();
-      const nodes = allHierarchyNodes(after);
-
-      expect(nodes.some(node => nodeText(node) === "New Reminder")).toBe(true);
-      expect(nodes.some(node => nodeClass(node) === "UITextField" && nodeText(node) === "Title")).toBe(true);
-      expect(nodes.some(node => nodeText(node) === "Details")).toBe(true);
-      expect(nodes.some(node => nodeText(node) === "Today")).toBe(true);
-      expect(nodes.some(node => nodeClass(node) === "UITableViewCell" && nodeText(node) === "Buy milk")).toBe(true);
-    });
-
-    test("Playground-style iOS hierarchy remains navigable after cleanup", () => {
-      const { after } = loadIosRemindersNoiseObservePair();
-      const nodes = allHierarchyNodes(after);
-      const actionable = nodes.filter(node => {
-        const attrs = node as unknown as Record<string, unknown>;
-        return attrs.clickable === "true" || attrs.scrollable === "true" || attrs.actions !== undefined;
-      });
-
-      expect(actionable.map(nodeText)).toContain("New Reminder");
-      expect(actionable.map(nodeText)).toContain("Done");
-      expect(actionable.some(node => nodeClass(node) === "UITextField")).toBe(true);
-      expect(nodes.some(node => nodeText(node)?.includes("scroll bar"))).toBe(false);
+      expect(measureValue(compact).bytes).toBeLessThan(measureValue(nonCompact).bytes);
+      expect(measureValue(compact).tokens).toBeLessThan(measureValue(nonCompact).tokens);
     });
   });
 
@@ -863,6 +846,31 @@ describe("sanitizeObserveResult", () => {
       sanitizeObserveResult(obs, COMPACT);
       expect(JSON.stringify(obs)).toBe(before);
     });
+
+    // P2 — purity table. Every sanitize configuration is OUTPUT-ONLY: it deep-
+    // clones and mutates only the copy, so no config may perturb the caller's
+    // in-memory ObserveResult. Placed in this block so `makeMultiSiteObserve`
+    // (which seeds a bounds object at every distinct site) is in scope. One row
+    // per transform toggle; a new transform added without a purity row is the
+    // regression this table exists to catch.
+    const PURITY_CONFIGS: ReadonlyArray<readonly [string, SanitizeObserveConfig]> = [
+      ["elements-drop", { dropElements: true }],
+      ["compact bounds", { dropElements: false, compact: true }],
+      ["node trim", { dropElements: false, trimNodes: true }],
+      ["skeleton projection", { dropElements: false, project: "skeleton" }],
+      ["compact + drop + trim composed", { dropElements: true, compact: true, trimNodes: true }],
+      ["all transforms off (trim disabled)", { dropElements: false, trimNodes: false }],
+    ];
+
+    test.each(PURITY_CONFIGS)("sanitize is output-only under %s", (_label, cfg) => {
+      const input = makeMultiSiteObserve();
+      const before = JSON.stringify(input);
+      const out = sanitizeObserveResult(input, cfg);
+      // The caller's object is byte-for-byte unchanged...
+      expect(JSON.stringify(input)).toBe(before);
+      // ...and the returned copy is a distinct reference.
+      expect(out).not.toBe(input);
+    });
   });
 
   describe("skeleton projection (cfg.project)", () => {
@@ -930,6 +938,352 @@ describe("sanitizeObserveResult", () => {
       const before = measureValue(observe).tokens;
       const after = measureValue(out).tokens;
       expect(after).toBeLessThan(before * 0.7);
+    });
+  });
+
+  // ---- P3: default-false boolean drop table -----------------------------
+  //
+  // The trim drops a view-hierarchy boolean only when it holds its documented
+  // default value (`false` / `"false"`) AND the key is on the allow-list. The
+  // allow-list's whole rationale — "do not nuke a legit text field that happens
+  // to hold the string 'false'" — was previously untested. This table exercises
+  // every allow-listed key in both its string and boolean form (dropped), the
+  // non-default forms (kept), and the survivor rows the allow-list protects.
+  describe("default-false boolean drop table (P3)", () => {
+    /** Trim one synthetic node carrying `attrs` and return the surviving attrs. */
+    function trimmedNode(attrs: Record<string, unknown>): Record<string, unknown> {
+      const obs: ObserveResult = {
+        updatedAt: 0,
+        screenSize: { width: 1, height: 1 },
+        systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+        viewHierarchy: {
+          hierarchy: {
+            node: { "class": "android.view.View", ...attrs, "node": [], "$": {} } as any,
+          },
+        },
+      };
+      return sanitizeObserveResult(obs, DROP_NONE).viewHierarchy!.hierarchy!.node as unknown as Record<string, unknown>;
+    }
+
+    test.each(DEFAULT_FALSE_BOOLEAN_KEYS)("%s='false' (string default) is dropped", key => {
+      expect(trimmedNode({ [key]: "false" })).not.toHaveProperty(key);
+    });
+
+    test.each(DEFAULT_FALSE_BOOLEAN_KEYS)("%s=false (boolean default) is dropped", key => {
+      expect(trimmedNode({ [key]: false })).not.toHaveProperty(key);
+    });
+
+    test.each(DEFAULT_FALSE_BOOLEAN_KEYS)("%s='true' (non-default) is kept", key => {
+      expect(trimmedNode({ [key]: "true" })[key]).toBe("true");
+    });
+
+    test.each(DEFAULT_FALSE_BOOLEAN_KEYS)("%s=true (boolean non-default) is kept", key => {
+      expect(trimmedNode({ [key]: true })[key]).toBe(true);
+    });
+
+    // Survivor rows: a value of "false" on a NON-allow-listed key, or on a text
+    // field, is real content and must never be dropped. The whitespace rows pin
+    // that emptiness is literal `""`, not "blank after trimming": a single space
+    // and a zero-width space are both content the trim keeps.
+    const SURVIVORS: ReadonlyArray<readonly [string, string, unknown]> = [
+      ["text holding the literal 'false'", "text", "false"],
+      ["content-desc holding 'false'", "content-desc", "false"],
+      ["resource-id holding 'false'", "resource-id", "false"],
+      ["a non-allow-listed flag holding 'false'", "custom-flag", "false"],
+      ["text holding '0'", "text", "0"],
+      ["text of a single space (not empty)", "text", " "],
+      ["content-desc of a single space (not empty)", "content-desc", " "],
+      // JS `.trim()` does NOT strip U+200B, so this survives even a trim-based
+      // empty check — it documents current behavior rather than guarding it.
+      ["text of a zero-width space U+200B (not empty)", "text", "​"],
+    ];
+
+    test.each(SURVIVORS)("%s survives the trim", (_label, key, value) => {
+      expect(trimmedNode({ [key]: value })[key]).toBe(value);
+    });
+  });
+
+  // ---- A3 / P4: bounds-compaction shape table ---------------------------
+  //
+  // Compaction flattens a `{left,top,right,bottom}` object to the positional
+  // tuple `[left,top,right,bottom]`. The positional contract means a hole must
+  // stay a hole (an `undefined` slot), NEVER be dropped — dropping it would shift
+  // every following coordinate and silently corrupt the decode. Non-object bounds
+  // (already a tuple, or a string) are left untouched so the transform is
+  // idempotent.
+  describe("bounds-compaction shape table (A3/P4)", () => {
+    /** Compact a single node whose `bounds` is `input`; return the emitted bounds. */
+    function compactNodeBounds(input: unknown): unknown {
+      const obs: ObserveResult = {
+        updatedAt: 0,
+        screenSize: { width: 1, height: 1 },
+        systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+        viewHierarchy: {
+          hierarchy: {
+            node: { "resource-id": "r", "bounds": input as any, "node": [], "$": {} } as any,
+          },
+        },
+      };
+      return (sanitizeObserveResult(obs, COMPACT).viewHierarchy!.hierarchy!.node as any).bounds;
+    }
+
+    const ROWS: ReadonlyArray<readonly [string, unknown, unknown]> = [
+      ["full object", { left: 1, top: 2, right: 3, bottom: 4 }, [1, 2, 3, 4]],
+      ["zero values", { left: 0, top: 0, right: 0, bottom: 0 }, [0, 0, 0, 0]],
+      ["negative values", { left: -5, top: -10, right: 5, bottom: 10 }, [-5, -10, 5, 10]],
+      ["fractional values", { left: 1.5, top: 2.25, right: 3.75, bottom: 4.5 }, [1.5, 2.25, 3.75, 4.5]],
+      // Partial holes: the ONLY rows that catch a hole-dropping compactor. Holes
+      // are `undefined` in-memory (they only serialize to `null` via JSON).
+      ["missing left+top (leading holes)", { right: 30, bottom: 40 }, [undefined, undefined, 30, 40]],
+      ["missing right+bottom (trailing holes)", { left: 10, top: 20 }, [10, 20, undefined, undefined]],
+      ["null-valued left (kept as null, not dropped)", { left: null, top: 0, right: 10, bottom: 10 }, [null, 0, 10, 10]],
+      ["large values", { left: 0, top: 0, right: 100000, bottom: 250000 }, [0, 0, 100000, 250000]],
+      // Non-object bounds are left untouched → idempotent.
+      ["already a tuple (idempotent)", [1, 2, 3, 4], [1, 2, 3, 4]],
+      ["a string bounds (untouched)", "0,0,10,10", "0,0,10,10"],
+    ];
+
+    test.each(ROWS)("%s compacts to the expected tuple", (_label, input, expected) => {
+      expect(compactNodeBounds(input)).toEqual(expected);
+    });
+
+    test("double compaction never nests the tuple ([[...]])", () => {
+      const once = compactNodeBounds({ left: 1, top: 2, right: 3, bottom: 4 });
+      expect(compactNodeBounds(once)).toEqual([1, 2, 3, 4]);
+    });
+
+    test("a node with no bounds stays without bounds (no synthetic tuple)", () => {
+      expect(compactNodeBounds(undefined)).toBeUndefined();
+    });
+
+    // D6: the old diff "tuple-vs-tuple" characterization is folded here — the
+    // shape contract lives with the compactor, not the diff.
+    test("systemInsets (a {top,bottom,left,right} object) is never compacted", () => {
+      const obs: ObserveResult = {
+        updatedAt: 0,
+        screenSize: { width: 1, height: 1 },
+        systemInsets: { top: 5, bottom: 6, left: 7, right: 8 },
+        viewHierarchy: { hierarchy: { node: { "resource-id": "r" } as any } },
+      };
+      expect(sanitizeObserveResult(obs, COMPACT).systemInsets).toEqual({ top: 5, bottom: 6, left: 7, right: 8 });
+    });
+  });
+
+  // ---- A5: gfx-trim 0-boundary table ------------------------------------
+  //
+  // A frame field in `gfxMetrics` is redundant with `performanceAudit.metrics`
+  // only when the audit actually carries a replacement. `0` is a REAL
+  // measurement (zero missed vsyncs), not "missing", so a `0` audit value must
+  // still drop the redundant gfx field. An `if (metrics.x)` refactor treats `0`
+  // as falsy and re-ships the redundancy — this table is the guard.
+  describe("gfx-trim 0-boundary table (A5)", () => {
+    const GFX_AUDIT_PAIRS: ReadonlyArray<readonly [string, string]> = [
+      ["p50Ms", "percentile50thMs"],
+      ["p90Ms", "percentile90thMs"],
+      ["p95Ms", "percentile95thMs"],
+      ["p99Ms", "percentile99thMs"],
+      ["missedVsyncCount", "missedVsyncCount"],
+      ["slowUiThreadCount", "slowUiThreadCount"],
+      ["frameDeadlineMissedCount", "frameDeadlineMissedCount"],
+    ];
+
+    function fullGfxMetrics(): NonNullable<ObserveResult["gfxMetrics"]> {
+      return {
+        packageName: "com.example.app",
+        percentile50thMs: 12,
+        percentile90thMs: 18,
+        percentile95thMs: 22,
+        percentile99thMs: 30,
+        missedVsyncCount: 1,
+        slowUiThreadCount: 1,
+        frameDeadlineMissedCount: 0,
+        pollCount: 7,
+        stabilityWaitMs: 350,
+        isStable: true,
+      };
+    }
+
+    test.each(GFX_AUDIT_PAIRS)("a 0-valued audit %s still drops redundant gfxMetrics.%s", (auditKey, gfxKey) => {
+      const { observe } = loadAndroidHomeObserve();
+      const m = observe.performanceAudit!.metrics as unknown as Record<string, unknown>;
+      // Null every frame replacement so ONLY the tested field's 0 can drive a drop.
+      for (const [ak] of GFX_AUDIT_PAIRS) {
+        m[ak] = null;
+      }
+      m[auditKey] = 0; // a genuine measurement of zero, not "no data"
+      observe.gfxMetrics = fullGfxMetrics();
+
+      const out = sanitizeObserveResult(observe, DROP_NONE);
+
+      expect(out.gfxMetrics).not.toHaveProperty(gfxKey);
+    });
+
+    test("keeps every non-frame UI-stability gfxMetrics field", () => {
+      const { observe } = loadAndroidHomeObserve();
+      observe.gfxMetrics = fullGfxMetrics();
+      const out = sanitizeObserveResult(observe, DROP_NONE);
+      // The action UI-stability fields are not perf-audit duplicates → retained.
+      expect(out.gfxMetrics).toMatchObject({
+        packageName: "com.example.app",
+        pollCount: 7,
+        stabilityWaitMs: 350,
+        isStable: true,
+      });
+    });
+  });
+
+  // ---- A6: GFXINFO diagnostics-marker boundaries ------------------------
+  describe("GFXINFO diagnostics-marker boundaries (A6)", () => {
+    function strippedDiagnostics(diagnostics: string): string {
+      const { observe } = loadAndroidHomeObserve();
+      observe.performanceAudit!.diagnostics = diagnostics;
+      return sanitizeObserveResult(observe, DROP_NONE).performanceAudit!.diagnostics!;
+    }
+
+    test("a marker at index 0 truncates diagnostics to the empty string", () => {
+      // The whole diagnostics string is the dump; nothing survives above it.
+      expect(strippedDiagnostics(`${GFXINFO_DUMP_MARKER}\nraw dump line\nmore`)).toBe("");
+    });
+
+    test("an absent marker leaves diagnostics untouched", () => {
+      expect(strippedDiagnostics("Summary only, no dump present")).toBe("Summary only, no dump present");
+    });
+
+    test("a marker mid-string keeps the summary above it and drops the dump", () => {
+      const diag = strippedDiagnostics(`Performance issues detected:\nline\n${GFXINFO_DUMP_MARKER}\nraw`);
+      expect(diag).toBe("Performance issues detected:\nline");
+      expect(diag).not.toContain(GFXINFO_DUMP_MARKER);
+    });
+  });
+
+  // ---- A10: unicode preservation through trim + compact -----------------
+  //
+  // The slice had zero non-ASCII coverage. Trim/compact must never corrupt or
+  // drop multi-byte, astral (surrogate-pair), or zero-width text.
+  describe("unicode text preservation (A10)", () => {
+    function trimmedCompactNode(attrs: Record<string, unknown>): Record<string, unknown> {
+      const obs: ObserveResult = {
+        updatedAt: 0,
+        screenSize: { width: 1, height: 1 },
+        systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+        viewHierarchy: { hierarchy: { node: { "resource-id": "r", ...attrs, "node": [], "$": {} } as any } },
+      };
+      return sanitizeObserveResult(obs, COMPACT).viewHierarchy!.hierarchy!.node as unknown as Record<string, unknown>;
+    }
+
+    const UNICODE_TEXTS: ReadonlyArray<readonly [string, string]> = [
+      ["combining/NFD accent", "café"],
+      ["precomposed/NFC accent", "café"],
+      ["astral ZWJ family emoji", "\u{1F468}‍\u{1F469}‍\u{1F467}"],
+      ["flag (regional indicators)", "\u{1F1FA}\u{1F1F8}"],
+      ["zero-width joiner inside text", "a‍b"],
+      ["CJK", "設定"],
+    ];
+
+    test.each(UNICODE_TEXTS)("preserves %s in text verbatim through trim+compact", (_label, text) => {
+      expect(trimmedCompactNode({ text })["text"]).toBe(text);
+    });
+
+    test("NFC and NFD forms are preserved as distinct byte sequences (no normalization)", () => {
+      const nfc = trimmedCompactNode({ text: "café" })["text"];
+      const nfd = trimmedCompactNode({ text: "café" })["text"];
+      expect(nfc).not.toBe(nfd);
+    });
+  });
+
+  // ---- P1: reduction table ("measurably shrinks" siblings) --------------
+  //
+  // Every reduction must shrink the payload it targets, and — the boundary the
+  // audit flags — must NEVER grow an observation that lacks the field. `tokensToo`
+  // is `false` for view-id dedup: it removes a duplicate id string that shrinks
+  // bytes without necessarily removing a token.
+  describe("reduction table (P1)", () => {
+    interface ReductionRow {
+      label: string;
+      reduced: () => unknown;
+      reference: () => unknown;
+      tokensToo: boolean;
+    }
+
+    const ROWS: ReductionRow[] = [
+      {
+        label: "perf-audit strip",
+        reduced: () => sanitizeObserveResult(loadAndroidHomeObserve().observe, DROP_NONE),
+        reference: () => loadAndroidHomeObserve().observe,
+        tokensToo: true,
+      },
+      {
+        label: "drop perfTiming",
+        reduced: () => sanitizeObserveResult(loadAndroidHomeObserve().observe, DROP_NONE),
+        reference: () => {
+          const { observe } = loadAndroidHomeObserve();
+          return { ...sanitizeObserveResult(observe, DROP_NONE), perfTiming: observe.perfTiming };
+        },
+        tokensToo: true,
+      },
+      {
+        label: "elements drop",
+        reduced: () => sanitizeObserveResult(loadAndroidHomeObserve().observe, DROP_ELEMENTS),
+        reference: () => sanitizeObserveResult(loadAndroidHomeObserve().observe, DROP_NONE),
+        tokensToo: true,
+      },
+      {
+        label: "compact bounds",
+        reduced: () => sanitizeObserveResult(loadAndroidHomeObserve().observe, COMPACT),
+        reference: () => sanitizeObserveResult(loadAndroidHomeObserve().observe, DROP_NONE),
+        tokensToo: true,
+      },
+      {
+        label: "skeleton projection",
+        reduced: () => sanitizeObserveResult(loadAndroidHomeObserve().observe, { dropElements: false, project: "skeleton" }),
+        reference: () => sanitizeObserveResult(loadAndroidHomeObserve().observe, DROP_NONE),
+        tokensToo: true,
+      },
+      {
+        label: "node trim (view-id dedup)",
+        reduced: () => sanitizeObserveResult(loadAndroidHomeObserve().observe, DROP_NONE),
+        reference: () => sanitizeObserveResult(loadAndroidHomeObserve().observe, { dropElements: false, trimNodes: false }),
+        // View-id dedup removes a duplicate id string: bytes shrink, tokens may not.
+        tokensToo: false,
+      },
+      {
+        label: "combined (perf + elements + trim)",
+        reduced: () => sanitizeObserveResult(loadAndroidHomeObserve().observe, DROP_ELEMENTS),
+        reference: () => loadAndroidHomeObserve().observe,
+        tokensToo: true,
+      },
+    ];
+
+    test.each(ROWS)("$label measurably shrinks the payload", ({ reduced, reference, tokensToo }) => {
+      const r = measureValue(reduced());
+      const ref = measureValue(reference());
+      expect(r.bytes).toBeLessThan(ref.bytes);
+      if (tokensToo) {
+        expect(r.tokens).toBeLessThan(ref.tokens);
+      } else {
+        expect(r.tokens).toBeLessThanOrEqual(ref.tokens);
+      }
+    });
+
+    // Boundary: a reduction applied to an observation LACKING its target field
+    // must be a no-op — never grow the payload.
+    const BARE: ObserveResult = {
+      updatedAt: 0,
+      screenSize: { width: 1, height: 1 },
+      systemInsets: { top: 0, bottom: 0, left: 0, right: 0 },
+      viewHierarchy: { hierarchy: { node: { "resource-id": "r", "node": [], "$": {} } as any } },
+    };
+
+    test("compact on a bounds-free observation does not grow it", () => {
+      const compacted = sanitizeObserveResult(BARE, COMPACT);
+      const plain = sanitizeObserveResult(BARE, DROP_NONE);
+      expect(measureValue(compacted).bytes).toBeLessThanOrEqual(measureValue(plain).bytes);
+    });
+
+    test("dropElements on an elements-free observation does not grow it", () => {
+      const dropped = sanitizeObserveResult(BARE, DROP_ELEMENTS);
+      const kept = sanitizeObserveResult(BARE, DROP_NONE);
+      expect(measureValue(dropped).bytes).toBeLessThanOrEqual(measureValue(kept).bytes);
     });
   });
 });

--- a/test/features/observe/output/diffObserveResult.test.ts
+++ b/test/features/observe/output/diffObserveResult.test.ts
@@ -189,8 +189,11 @@ describe("diffObserveResult", () => {
     const next = obs({ ...node }, { updatedAt: 999 });
 
     const diff = diffObserveResult(baseline, next);
+    // D4: the constant restatement `DIFF_SCALAR_FIELDS.not.toContain("updatedAt")`
+    // was removed — the behavioral assertion above (no `fields` emitted for an
+    // updatedAt-only delta) is what actually guards the exclusion, and the
+    // membership is covered structurally by the P6 table.
     expect(diff.fields).toBeUndefined();
-    expect(DIFF_SCALAR_FIELDS).not.toContain("updatedAt");
   });
 
   test("sibling index disambiguates identical siblings (same resource-id/bounds/text)", () => {
@@ -217,18 +220,10 @@ describe("diffObserveResult", () => {
     expect(JSON.stringify(next)).toBe(beforeNext);
   });
 
-  test("handles compacted tuple bounds equivalently to object bounds", () => {
-    // When --observe-result-compact is on, bounds is a [l,t,r,b] tuple; the key
-    // must normalize both shapes so a compacted stream still diffs correctly.
-    const baseline = obs({ "resource-id": "a", "bounds": [0, 0, 10, 10] as any, "text": "same" });
-    const next = obs({ "resource-id": "a", "bounds": [0, 0, 10, 10] as any, "text": "same" });
-    const diff = diffObserveResult(baseline, next);
-    expect(diff.added).toEqual([]);
-    expect(diff.removed).toEqual([]);
-    expect(diff.changed).toEqual([]);
-  });
-
-  test("completes well under the 100ms unit-test budget", () => {
+  test("dropping the first of 200 uniquely-identified rows yields exactly one removal", () => {
+    // R1: rewritten from a pure wall-clock timing assertion into a diff-SHAPE
+    // assertion. Removing k0 leaves k1..k199 re-pairing cleanly (same content,
+    // only sibling index shifted), so the diff is exactly one removal.
     const kids = Array.from({ length: 200 }, (_, i) => ({
       "resource-id": `k${i}`,
       "bounds": { left: 0, top: i, right: 10, bottom: i + 10 },
@@ -236,9 +231,12 @@ describe("diffObserveResult", () => {
     }));
     const baseline = obs({ "resource-id": "root", "bounds": { left: 0, top: 0, right: 10, bottom: 2000 }, "node": kids });
     const next = obs({ "resource-id": "root", "bounds": { left: 0, top: 0, right: 10, bottom: 2000 }, "node": kids.slice(1) });
-    const start = performance.now();
-    diffObserveResult(baseline, next);
-    expect(performance.now() - start).toBeLessThan(100);
+
+    const diff = diffObserveResult(baseline, next);
+    expect(diff.removed).toHaveLength(1);
+    expect(diff.removed[0].attributes["resource-id"]).toBe("k0");
+    expect(diff.added).toEqual([]);
+    expect(diff.changed).toEqual([]);
   });
 
   test("identical cells in different subtrees do not collide (ancestry path key)", () => {
@@ -297,7 +295,13 @@ describe("diffObserveResult", () => {
     (roots[0] as any).selected = "true"; // toggle one attribute on one node
 
     const diff = diffObserveResult(baseline, next);
-    expect(diff.changed.length + diff.added.length + diff.removed.length).toBeGreaterThan(0);
+    // R3: a "one-node change" must diff to EXACTLY one changed entry — a diff that
+    // exploded into many entries (or that lost the change entirely) is not a
+    // one-node change, even though it would satisfy a `> 0` assertion.
+    expect(diff.changed).toHaveLength(1);
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([]);
+    expect(diff.changed[0].changes.selected).toEqual({ from: undefined, to: "true" });
     expect(measureValue(diff).bytes).toBeLessThan(measureValue(baseline).bytes * 0.1);
   });
 
@@ -723,12 +727,27 @@ describe("diffObserveResult", () => {
     expect(JSON.stringify(next)).toBe(beforeNext);
   });
 
-  test("EC1.6: a large scroll still completes well under the 100ms budget", () => {
+  test("EC1.6: a 300-row scroll re-pairs every row into a bounds `changed` (positional churn would be 600)", () => {
+    // R1: rewritten from a wall-clock timing test into a diff-SHAPE assertion.
+    // A 300-row scroll shifts every row's bounds, so positional-only matching
+    // churns all 600 (300 removed + 300 added). Content identity collapses that
+    // to 300 bounds-only `changed` entries, each carrying a `fromKey` distinct
+    // from `key` (the key embeds bounds, which the scroll changed).
     const baseline = obs(list(300, 0));
     const next = obs(list(300, -50));
-    const start = performance.now();
-    diffObserveResult(baseline, next);
-    expect(performance.now() - start).toBeLessThan(100);
+
+    const positional = diffObserveResult(baseline, next, { contentIdentity: false });
+    expect(positional.added.length + positional.removed.length).toBe(600);
+
+    const diff = diffObserveResult(baseline, next);
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([]);
+    expect(diff.changed).toHaveLength(300);
+    for (const c of diff.changed) {
+      expect(Object.keys(c.changes)).toEqual(["bounds"]);
+      expect(c.fromKey).toBeDefined();
+      expect(c.fromKey).not.toBe(c.key);
+    }
   });
 
   test("EC1.7: contentIdentity:false reproduces positional-only churn exactly", () => {
@@ -1291,10 +1310,6 @@ describe("diffObserveResult — volatile `extras` metadata exclusion (#3051)", (
     expect(Object.keys(diff.changed[0].changes)).toEqual(["bounds"]);
   });
 
-  test("DIFF_IGNORED_ATTRS names `extras` (single source of truth)", () => {
-    expect([...DIFF_IGNORED_ATTRS]).toContain("extras");
-  });
-
   test("a mirror field (focusedElement) whose only change is `extras` churn is not reported", () => {
     // The element mirror fields are diffed separately from node attributes
     // (leanElementForDiff / elementValuesEqual), so the ignore-list must apply
@@ -1421,6 +1436,364 @@ describe("diffObserveResult — volatile occlusion exclusion (#4399)", () => {
   });
 });
 
+// ---- A1: pure sibling reorder (documented "looks unchanged" limitation) ----
+//
+// Node identity is content + geometry, NOT tree order. Swapping two siblings
+// that keep their own bounds is therefore invisible to a content-identity diff
+// (each re-pairs to itself with no attribute change) — a real, documented
+// limitation. A change that folded sibling index into the content key would
+// break the first assertion, which is exactly the regression this characterizes.
+describe("diffObserveResult — pure sibling reorder (A1)", () => {
+  const A = { "resource-id": "A", "text": "Alpha", "bounds": { left: 0, top: 0, right: 10, bottom: 10 } };
+  const B = { "resource-id": "B", "text": "Beta", "bounds": { left: 0, top: 10, right: 10, bottom: 20 } };
+  const parent = (kids: Record<string, unknown>[]) => ({
+    "resource-id": "list",
+    "bounds": { left: 0, top: 0, right: 10, bottom: 100 },
+    "node": kids,
+  });
+
+  test("with content identity (default), a reorder reads as no change (limitation)", () => {
+    const diff = diffObserveResult(obs(parent([{ ...A }, { ...B }])), obs(parent([{ ...B }, { ...A }])));
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([]);
+    expect(diff.changed).toEqual([]);
+  });
+
+  test("positional-only surfaces the reorder as remove+add (a:2, r:2)", () => {
+    const diff = diffObserveResult(
+      obs(parent([{ ...A }, { ...B }])),
+      obs(parent([{ ...B }, { ...A }])),
+      { contentIdentity: false }
+    );
+    expect(diff.added).toHaveLength(2);
+    expect(diff.removed).toHaveLength(2);
+    expect(diff.changed).toEqual([]);
+  });
+});
+
+// ---- A2: scalarFields config override --------------------------------------
+describe("diffObserveResult — scalarFields override (A2)", () => {
+  test("restricts scalar diffing to the override set", () => {
+    const node = { "resource-id": "a", "bounds": { left: 0, top: 0, right: 10, bottom: 10 } };
+    const baseline = obs({ ...node }, { rotation: 0, wakefulness: "Awake" });
+    const next = obs({ ...node }, { rotation: 1, wakefulness: "Asleep" });
+
+    const diff = diffObserveResult(baseline, next, { scalarFields: ["wakefulness"] });
+    // Only the override field is diffed; rotation is ignored entirely.
+    expect(diff.fields!.wakefulness).toEqual({ from: "Awake", to: "Asleep" });
+    expect(diff.fields!.rotation).toBeUndefined();
+  });
+
+  test("an empty override diffs no scalar fields", () => {
+    const node = { "resource-id": "a", "bounds": { left: 0, top: 0, right: 10, bottom: 10 } };
+    const baseline = obs({ ...node }, { rotation: 0 });
+    const next = obs({ ...node }, { rotation: 1 });
+    const diff = diffObserveResult(baseline, next, { scalarFields: [] });
+    expect(diff.fields).toBeUndefined();
+  });
+});
+
+// ---- A7: view-id-driven content identity (#3228) ---------------------------
+describe("diffObserveResult — view-id content identity (A7)", () => {
+  test("view-id alone re-pairs scrolled rows that share all other identity", () => {
+    // Three rows identical except their (content-derived) view-id; the other
+    // three content-key fields (resource-id/content-desc/text) are the SAME on
+    // every row, so ONLY view-id can tell the rows apart. With ≥3 rows the
+    // resource-id fallback is ambiguous, so removing view-id from the content key
+    // collapses re-pairing back to remove+add (the M6 regression).
+    const row = (viewId: string, top: number) => ({
+      "resource-id": "row",
+      "view-id": viewId,
+      "text": "",
+      "bounds": { left: 0, top, right: 100, bottom: top + 10 },
+    });
+    const list = (dy: number) => ({
+      "resource-id": "list",
+      "bounds": { left: 0, top: 0, right: 100, bottom: 1000 },
+      "node": [row("v0", 0 + dy), row("v1", 20 + dy), row("v2", 40 + dy)],
+    });
+
+    const diff = diffObserveResult(obs(list(0)), obs(list(-30)));
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([]);
+    expect(diff.changed).toHaveLength(3);
+    for (const c of diff.changed) {
+      // view-id is in DIFF_IGNORED_ATTRS, so the only reported change is bounds.
+      expect(Object.keys(c.changes)).toEqual(["bounds"]);
+    }
+  });
+
+  test("a node whose only change is view-id churn is never `changed` (M4 guard)", () => {
+    // Post-trim a view-id is a synthetic content-derived id; its churn is not an
+    // actionable UI delta (the descendant whose content changed reports its own
+    // change), so it is excluded from the changed comparison.
+    const baseline = obs({ "resource-id": "a", "view-id": "hash-1", "text": "Same", "bounds": { left: 0, top: 0, right: 10, bottom: 10 } });
+    const next = obs({ "resource-id": "a", "view-id": "hash-2", "text": "Same", "bounds": { left: 0, top: 0, right: 10, bottom: 10 } });
+
+    const diff = diffObserveResult(baseline, next);
+    expect(diff.changed).toEqual([]);
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([]);
+  });
+});
+
+// ---- P6: every advertised DIFF_SCALAR_FIELDS member is diffed --------------
+describe("diffObserveResult — all DIFF_SCALAR_FIELDS members (P6)", () => {
+  const warning = {
+    type: "important-content-under-inset",
+    severity: "warning",
+    element: { text: "T", bounds: { left: 0, top: 0, right: 10, bottom: 10 } },
+    categories: ["text"],
+    insetTypes: ["safeArea"],
+    sides: ["top"],
+    overflowPx: { top: 30 },
+    insetPx: { top: 59.5 },
+    overlapPercent: 100,
+    confidence: "high",
+  } as const;
+
+  const SCALAR_VALUE_PAIRS: Record<string, { from: unknown; to: unknown }> = {
+    rotation: { from: 0, to: 1 },
+    wakefulness: { from: "Awake", to: "Asleep" },
+    userId: { from: 0, to: 10 },
+    intentChooserDetected: { from: false, to: true },
+    notificationPermissionDetected: { from: false, to: true },
+    deviceLock: {
+      from: { locked: false, keyguardShowing: false, secure: true },
+      to: { locked: true, keyguardShowing: true, secure: true },
+    },
+    awaitTimeout: { from: false, to: true },
+    awaitDuration: { from: undefined, to: 250 },
+    layoutWarnings: { from: undefined, to: [warning] },
+    error: { from: undefined, to: "capture failed" },
+  };
+
+  // Independent membership pin: hardcoded so DROPPING a field from
+  // DIFF_SCALAR_FIELDS (which would silently undiff it) reddens here rather than
+  // just removing a generated row. `updatedAt` must stay OUT (churns every capture).
+  const EXPECTED_SCALARS = [
+    "awaitDuration",
+    "awaitTimeout",
+    "deviceLock",
+    "error",
+    "intentChooserDetected",
+    "layoutWarnings",
+    "notificationPermissionDetected",
+    "rotation",
+    "userId",
+    "wakefulness",
+  ];
+
+  test("DIFF_SCALAR_FIELDS holds exactly the advertised members (and not updatedAt)", () => {
+    expect([...DIFF_SCALAR_FIELDS].sort()).toEqual(EXPECTED_SCALARS);
+    expect(DIFF_SCALAR_FIELDS).not.toContain("updatedAt");
+  });
+
+  test("every advertised scalar field has a value pair (coverage guard)", () => {
+    for (const field of DIFF_SCALAR_FIELDS) {
+      expect(SCALAR_VALUE_PAIRS).toHaveProperty(field);
+    }
+  });
+
+  test.each([...DIFF_SCALAR_FIELDS])("scalar field %s is surfaced in the diff `fields`", field => {
+    const { from, to } = SCALAR_VALUE_PAIRS[field];
+    const node = { "resource-id": "a", "bounds": { left: 0, top: 0, right: 10, bottom: 10 } };
+    const diff = diffObserveResult(obs({ ...node }, { [field]: from }), obs({ ...node }, { [field]: to }));
+    expect(diff.fields).toBeDefined();
+    expect(diff.fields![field]).toBeDefined();
+  });
+});
+
+// ---- P5: element mirror-field matrix (3 fields × 7 scenarios) --------------
+describe("diffObserveResult — mirror-field matrix (P5)", () => {
+  const MIRROR_FIELDS = ["focusedElement", "accessibilityFocusedElement", "awaitedElement"] as const;
+  const NODE = { "resource-id": "a", "bounds": { left: 0, top: 0, right: 10, bottom: 10 } };
+  const el = (extra: Record<string, unknown> = {}) => ({ bounds: { left: 0, top: 0, right: 10, bottom: 10 }, ...extra });
+  const heavy = (childText: string) => ({
+    "bounds": { left: 0, top: 0, right: 10, bottom: 10 },
+    "resource-id": "f",
+    "node": [{ "resource-id": "child", "bounds": { left: 1, top: 1, right: 2, bottom: 2 }, "text": childText }],
+  });
+  const withExtras = (t: string) => ({
+    "resource-id": "f",
+    "bounds": { left: 0, top: 0, right: 10, bottom: 10 },
+    "extras": { "android.view.accessibility.extra.EXTRA_DATA_TEST_TRAVERSALBEFORE_VAL": t },
+  });
+
+  const SCENARIOS: ReadonlyArray<readonly [string, unknown, unknown, boolean]> = [
+    ["changed element", el({ "resource-id": "x" }), el({ "resource-id": "y" }), true],
+    ["gained (undefined → element)", undefined, el({ "resource-id": "x" }), true],
+    ["lost (element → undefined)", el({ "resource-id": "x" }), undefined, true],
+    ["unchanged element", el({ "resource-id": "x" }), el({ "resource-id": "x" }), false],
+    ["bounds shape only (object vs tuple)", { "bounds": { left: 0, top: 0, right: 10, bottom: 10 }, "resource-id": "x" }, { "bounds": [0, 0, 10, 10], "resource-id": "x" }, false],
+    ["subtree churn only (.node child edited)", heavy("before"), heavy("after"), false],
+    ["extras churn only", withExtras("84"), withExtras("335"), false],
+  ];
+
+  for (const field of MIRROR_FIELDS) {
+    test.each(SCENARIOS)(`${field}: %s`, (_label, from, to, reported) => {
+      const baseline = obs({ ...NODE }, { [field]: from } as never);
+      const next = obs({ ...NODE }, { [field]: to } as never);
+      const diff = diffObserveResult(baseline, next);
+      expect(diff.fields?.[field] !== undefined).toBe(reported);
+    });
+  }
+});
+
+// ---- A9 / P8: iOS conservative stable-identity boundaries (#3318) ----------
+//
+// The iOS editable-control repair pass keys on a stable id + class + an
+// 8px-quantized region. This table pins the quantization cliff (Δ4 crosses a
+// bucket because Math.round(4/8) === 1), the id-source precedence, the
+// generated-UUID refusal, and the class/ancestor gates. The fields carry NO
+// content-identity key (empty resource-id/text/content-desc/view-id, or a
+// changing text), so the earlier content-identity pass cannot re-pair them —
+// isolating the iOS pass under test.
+describe("diffObserveResult — iOS stable-identity boundaries (A9/P8)", () => {
+  const REGION = { left: 16, top: 120, right: 304, bottom: 160 }; // all coords multiples of 8
+  const shift = (b: typeof REGION, d: number) => ({ left: b.left + d, top: b.top + d, right: b.right + d, bottom: b.bottom + d });
+
+  // A field distinguished ONLY by accessibilityIdentifier (not in the content
+  // key), so a same-text scroll must go through the iOS quantized-region pass.
+  const scrollField = (bounds: Record<string, number>) => ({
+    "className": "XCUIElementTypeTextField",
+    "accessibilityIdentifier": "title",
+    "text": "",
+    "bounds": bounds,
+  });
+
+  const repaired = (d: ReturnType<typeof diffObserveResult>) =>
+    d.changed.length === 1 && d.added.length === 0 && d.removed.length === 0;
+  const splitAddRemove = (d: ReturnType<typeof diffObserveResult>) =>
+    d.added.length === 1 && d.removed.length === 1 && d.changed.length === 0;
+
+  const QUANT_ROWS: ReadonlyArray<readonly [number, boolean]> = [
+    [1, true], [2, true], [3, true], // within the same 8px bucket → re-pair
+    [4, false], [5, false], [6, false], [7, false], [8, false], // Δ4 is the cliff
+  ];
+
+  test.each(QUANT_ROWS)("a Δ%dpx scroll re-pairs=%s under 8px quantization", (delta, expectRepaired) => {
+    const diff = diffObserveResult(iosObs(scrollField(REGION)), iosObs(scrollField(shift(REGION, delta))));
+    if (expectRepaired) {
+      expect(repaired(diff)).toBe(true);
+    } else {
+      expect(splitAddRemove(diff)).toBe(true);
+    }
+  });
+
+  test("a Δ0 (identical) field produces an empty diff, not a re-pair", () => {
+    const diff = diffObserveResult(iosObs(scrollField(REGION)), iosObs(scrollField(REGION)));
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([]);
+    expect(diff.changed).toEqual([]);
+  });
+
+  // Id-source precedence + UUID refusal, exercised via an in-place text edit
+  // (text differs → no content-identity re-pair → iOS pass decides).
+  const textEdit = (idAttrs: Record<string, unknown>, editable = true) => {
+    const node = (t: string) => ({
+      "className": editable ? "XCUIElementTypeTextField" : "XCUIElementTypeStaticText",
+      ...idAttrs,
+      "text": t,
+      "value": t,
+      "bounds": { ...REGION },
+    });
+    return diffObserveResult(iosObs(node("Old")), iosObs(node("New")));
+  };
+
+  const PRECEDENCE_ROWS: ReadonlyArray<readonly [string, Record<string, unknown>, boolean, boolean]> = [
+    ["resource-id resolves the stable id", { "resource-id": "TitleField" }, true, true],
+    ["accessibilityIdentifier resolves when no resource-id", { "accessibilityIdentifier": "title" }, true, true],
+    ["non-UUID view-id resolves when no resource-id/accId", { "view-id": "title-field" }, true, true],
+    ["generated UUID view-id is refused (id-less)", { "view-id": "123e4567-e89b-12d3-a456-426614174000" }, true, false],
+    ["no stable id at all → no repair", {}, true, false],
+    ["non-editable class is not repaired even with a resource-id", { "resource-id": "TitleField" }, false, false],
+  ];
+
+  test.each(PRECEDENCE_ROWS)("%s", (_label, idAttrs, editable, expectRepaired) => {
+    const diff = textEdit(idAttrs, editable);
+    if (expectRepaired) {
+      expect(diff.changed).toHaveLength(1);
+      expect(diff.changed[0].changes.text).toEqual({ from: "Old", to: "New" });
+    } else {
+      expect(diff.added).toHaveLength(1);
+      expect(diff.removed).toHaveLength(1);
+      expect(diff.changed).toEqual([]);
+    }
+  });
+
+  test("an editable field with a list-cell class opts out of the repair", () => {
+    const node = (t: string) => ({
+      "className": "XCUIElementTypeCell",
+      "resource-id": "ReusableCell",
+      "text": t,
+      "value": t,
+      "bounds": { ...REGION },
+    });
+    const diff = diffObserveResult(iosObs(node("Old")), iosObs(node("New")));
+    expect(diff.added).toHaveLength(1);
+    expect(diff.removed).toHaveLength(1);
+    expect(diff.changed).toEqual([]);
+  });
+
+  test("an editable field under a list-cell ancestor opts out of the repair", () => {
+    const tree = (t: string) => ({
+      "resource-id": "Table",
+      "className": "XCUIElementTypeTable",
+      "bounds": { left: 0, top: 100, right: 390, bottom: 700 },
+      "node": [{
+        "className": "XCUIElementTypeCell",
+        "bounds": { left: 0, top: 100, right: 390, bottom: 160 },
+        "node": [{
+          "resource-id": "TitleField",
+          "className": "XCUIElementTypeTextField",
+          "text": t,
+          "value": t,
+          "bounds": { ...REGION },
+        }],
+      }],
+    });
+    const diff = diffObserveResult(iosObs(tree("Old")), iosObs(tree("New")));
+    expect(diff.changed).toEqual([]);
+    expect(diff.added.length + diff.removed.length).toBeGreaterThan(0);
+  });
+});
+
+// ---- A10: unicode identity discrimination ---------------------------------
+//
+// The slice had zero non-ASCII coverage. A content key built by splitting on
+// code points (or truncating a surrogate pair) would collapse distinct emoji
+// sequences that share a leading code point, false-merging an unrelated
+// remove+add into a single `changed`. These rows pin that distinct unicode text
+// stays distinct.
+describe("diffObserveResult — unicode identity discrimination (A10)", () => {
+  // Only `text` distinguishes these nodes (no resource-id), so the content key
+  // is the raw text; they are scrolled so they are leftover remove+add first.
+  const textNode = (text: string, top: number) => ({ text, "bounds": { left: 0, top, right: 10, bottom: top + 10 } });
+  const parent = (kid: Record<string, unknown>) => ({
+    "resource-id": "list",
+    "bounds": { left: 0, top: 0, right: 10, bottom: 100 },
+    "node": [kid],
+  });
+
+  const DISCRIMINATING: ReadonlyArray<readonly [string, string, string]> = [
+    // Family emoji ZWJ sequences that differ ONLY in the final person — same
+    // leading surrogate pair (👨). A first-code-point key would false-merge them.
+    ["astral ZWJ sequences differing past the first surrogate pair", "\u{1F468}‍\u{1F469}‍\u{1F467}", "\u{1F468}‍\u{1F469}‍\u{1F466}"],
+    ["NFC vs NFD forms of the same grapheme", "café", "café"],
+    ["zero-width space presence differs", "ab", "a​b"],
+  ];
+
+  test.each(DISCRIMINATING)("%s does NOT false-merge (stays remove+add)", (_label, a, b) => {
+    const diff = diffObserveResult(obs(parent(textNode(a, 0))), obs(parent(textNode(b, 50))));
+    expect(diff.changed).toEqual([]);
+    expect(diff.added).toHaveLength(1);
+    expect(diff.removed).toHaveLength(1);
+    expect(diff.added[0].attributes.text).toBe(b);
+    expect(diff.removed[0].attributes.text).toBe(a);
+  });
+});
+
 describe("isSameObservationScreen", () => {
   const iosIdentity = (
     key: string,
@@ -1539,5 +1912,46 @@ describe("isSameObservationScreen", () => {
       screenIdentity: iosIdentity("bundle=com.apple.reminders|focus=Title", "low"),
     });
     expect(isSameObservationScreen(a, b)).toBe(false);
+  });
+
+  // ---- A8 / P7: consolidated same-screen decision table -------------------
+  //
+  // When BOTH sides carry a non-low-confidence identity, the decision is
+  // identity-only (platform + source + key) and the app/activity/package
+  // fallback is bypassed. When an identity is missing on either side, the
+  // decision falls through to that fallback. Rows corrected per the audit:
+  // the source-mismatch row uses a real `ScreenIdentitySource` ("sdk"); the
+  // one-missing-identity row is `true` (fallback matches) unless appId is varied.
+  describe("same-screen decision table (A8/P7)", () => {
+    const withIdentity = (
+      appId: string,
+      identity: ObserveResult["screenIdentity"] | undefined
+    ): ObserveResult =>
+      obs({ "resource-id": "a" }, {
+        activeWindow: { appId, activityName: "", layoutSeqSum: 1 },
+        viewHierarchy: { packageName: appId, hierarchy: { node: { "resource-id": "a" } as any } },
+        screenIdentity: identity,
+      });
+
+    const APP = "com.apple.reminders";
+    const idHigh = iosIdentity("bundle=com.apple.reminders|nav=Reminders", "high", "heuristic");
+    const idOtherKey = iosIdentity("bundle=com.apple.reminders|nav=New Reminder", "high", "heuristic");
+    const idSdk = iosIdentity("bundle=com.apple.reminders|nav=Reminders", "high", "sdk");
+
+    const ROWS: ReadonlyArray<readonly [string, ObserveResult, ObserveResult, boolean]> = [
+      ["both identities equal → same", withIdentity(APP, idHigh), withIdentity(APP, { ...idHigh }), true],
+      ["both present, different key → different", withIdentity(APP, idHigh), withIdentity(APP, idOtherKey), false],
+      ["both present, source mismatch (heuristic vs sdk) → different", withIdentity(APP, idHigh), withIdentity(APP, idSdk), false],
+      ["both present, platform mismatch → different", withIdentity(APP, idHigh), withIdentity(APP, { ...idHigh!, platform: "android" }), false],
+      ["identity short-circuits the appId fallback: same identity, differing appId → same", withIdentity(APP, idHigh), withIdentity("com.other.app", { ...idHigh }), true],
+      ["one identity missing, matching app/activity/package → same (fallback)", withIdentity(APP, idHigh), withIdentity(APP, undefined), true],
+      ["one identity missing, differing appId → different (fallback)", withIdentity(APP, idHigh), withIdentity("com.other.app", undefined), false],
+      ["neither identity, matching app/activity/package → same", withIdentity(APP, undefined), withIdentity(APP, undefined), true],
+      ["low confidence on one side forces a full emit → different", withIdentity(APP, idHigh), withIdentity(APP, iosIdentity("k", "low")), false],
+    ];
+
+    test.each(ROWS)("%s", (_label, a, b, expected) => {
+      expect(isSameObservationScreen(a, b)).toBe(expected);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Milestone 32 (Unit Test Quality Audit), slice **observe-output**: 30 verified test-quality findings burned down, each mutation-verified red-green against `ObserveResultOutput.ts` / `diffObserveResult`. **Test-only — empty `src/` diff.** A4 (elementSchema round-trip) dropped as **REFUTED** — observe elements route through `viewHierarchyNodeSchema`, and the existing server test already parses the compacted output.

- Bounds-compaction shape table (partial-hole / non-finite / idempotence / no-double-nest); gfx-trim `0`-boundary; GFXINFO marker at index 0 / absent; iOS stable-identity boundaries (Δ4 quantization cliff, id precedence, UUID refusal); `view-id`-only re-pair (3 ambiguous rows) + `view-id` churn never "changed"; `scalarFields` override; `isSameObservationScreen` table (cross-appId short-circuit, source mismatch); the documented sibling-reorder "looks unchanged" limitation; all 8 `DIFF_SCALAR_FIELDS` + a membership pin; mirror-field matrix; default-false boolean table; unicode/astral rows (discriminating, not tautological).
- Rewrote 3 wall-clock tests + the 300-row scroll into shape assertions; count-guarded the unguarded trim loops; tightened the one-node-change churn assertion. Deleted fixture-only iOS tests + wall-clock / constant-restatement non-tests; behavior-first renames.

## Linked Issue

Closes #4175

## Validation

- [x] `bun test`: **11007 pass / 13 skip / 0 fail** across 816 files
- [x] `bun run typecheck`: no new errors (206 baseline)
- [x] `bun run lint`: clean
