### PR TITLE
test(media): burn down 27 verified test-quality findings (#4170)

### DIFF
--- a/src/features/record/android/DualTrackRecorder.ts
+++ b/src/features/record/android/DualTrackRecorder.ts
@@ -326,7 +326,7 @@ function buildElementKey(event: ReceivedInteraction): string | null {
   return `${resourceId}|${contentDesc}|${className}`;
 }
 
-function resolveSwipeDirection(
+export function resolveSwipeDirection(
   scrollDeltaX?: number,
   scrollDeltaY?: number
 ): "up" | "down" | "left" | "right" | null {

--- a/src/features/video/FfmpegVideoProcessingBackend.ts
+++ b/src/features/video/FfmpegVideoProcessingBackend.ts
@@ -295,6 +295,9 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
     private readonly adbFactory: AdbClientFactory = defaultAdbClientFactory,
     private readonly simctlFactory: (device: BootedDevice) => SimCtl = device => new SimCtlClient(device),
     private readonly ffmpegClient: FfmpegClient = new DefaultFfmpegClient(),
+    // Injectable so hardware-accel detection can be tested for every OS branch on
+    // any CI host, rather than only the branch matching the runner's platform.
+    private readonly platformProvider: () => NodeJS.Platform = platform,
   ) {}
 
   async start(config: VideoCaptureConfig): Promise<RecordingHandle> {
@@ -714,7 +717,7 @@ export class FfmpegVideoProcessingBackend implements VideoCaptureBackend {
   }
 
   private async detectHardwareAccel(): Promise<HardwareAccelInfo> {
-    const os = platform();
+    const os = this.platformProvider();
     const cacheKey = os;
 
     if (this.hwAccelCache.has(cacheKey)) {

--- a/src/features/video/PlatformVideoCaptureBackend.ts
+++ b/src/features/video/PlatformVideoCaptureBackend.ts
@@ -51,7 +51,7 @@ interface IosBackendHandle {
 
 type BackendHandle = AndroidBackendHandle | IosBackendHandle;
 
-function clampBitrateKbps(config: VideoCaptureConfig): number {
+export function clampBitrateKbps(config: VideoCaptureConfig): number {
   const maxBitrateKbps = Math.max(0, Math.floor(config.maxThroughputMbps * 1000));
   if (!maxBitrateKbps) {
     return config.targetBitrateKbps;
@@ -126,7 +126,12 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
 
       await Promise.race([backendHandle.exitPromise, timeoutPromise]);
       if (timeoutId) {
-        clearTimeout(timeoutId);
+        // Disarm through the injected timer, not the global clearTimeout. Once
+        // the host adb has exited the 10 s SIGINT callback is stale; leaving it
+        // armed (as global clearTimeout would, since the handle came from
+        // this.timer.setTimeout) fires a SIGINT after the recording finished
+        // (issue #4170).
+        this.timer.clearTimeout(timeoutId);
       }
 
       if (backendHandle.process.exitCode === null && !backendHandle.process.killed) {
@@ -157,35 +162,39 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
       logger.info(`[VideoCapture] Pulling file from device: ${backendHandle.deviceTempPath} -> ${handle.outputPath}`);
       const adb = this.adbFactory.create(backendHandle.device);
       const pullArgs = ["pull", backendHandle.deviceTempPath, handle.outputPath];
-      const pullProcess = await adb.spawn(pullArgs);
+      try {
+        const pullProcess = await adb.spawn(pullArgs);
 
-      await new Promise<void>((resolve, reject) => {
-        pullProcess.once("exit", code => {
-          if (code === 0) {
-            logger.info(`[VideoCapture] File pulled successfully`);
+        await new Promise<void>((resolve, reject) => {
+          pullProcess.once("exit", code => {
+            if (code === 0) {
+              logger.info(`[VideoCapture] File pulled successfully`);
+              resolve();
+            } else {
+              reject(new Error(`adb pull failed with exit code ${code}`));
+            }
+          });
+          pullProcess.once("error", err => reject(err));
+        });
+      } finally {
+        // Always clean up the /sdcard temp file, even when the pull failed —
+        // otherwise a failed pull leaks the temp recording on the device on
+        // every stop (issue #4170).
+        logger.info(`[VideoCapture] Cleaning up temp file on device`);
+        const rmArgs = ["shell", "rm", backendHandle.deviceTempPath];
+        const rmProcess = await adb.spawn(rmArgs);
+
+        await new Promise<void>(resolve => {
+          rmProcess.once("exit", () => {
+            logger.info(`[VideoCapture] Temp file cleaned up`);
             resolve();
-          } else {
-            reject(new Error(`adb pull failed with exit code ${code}`));
-          }
+          });
+          rmProcess.once("error", err => {
+            logger.warn(`[VideoCapture] Failed to clean up temp file: ${err}`);
+            resolve(); // Don't fail the whole operation if cleanup fails
+          });
         });
-        pullProcess.once("error", err => reject(err));
-      });
-
-      // Clean up temp file on device
-      logger.info(`[VideoCapture] Cleaning up temp file on device`);
-      const rmArgs = ["shell", "rm", backendHandle.deviceTempPath];
-      const rmProcess = await adb.spawn(rmArgs);
-
-      await new Promise<void>(resolve => {
-        rmProcess.once("exit", () => {
-          logger.info(`[VideoCapture] Temp file cleaned up`);
-          resolve();
-        });
-        rmProcess.once("error", err => {
-          logger.warn(`[VideoCapture] Failed to clean up temp file: ${err}`);
-          resolve(); // Don't fail the whole operation if cleanup fails
-        });
-      });
+      }
     } else {
       await this.finalizeIosRecording(backendHandle);
     }

--- a/src/features/webrtc/RtpPcmuTrackWriter.ts
+++ b/src/features/webrtc/RtpPcmuTrackWriter.ts
@@ -1,4 +1,5 @@
 import { RtpHeader, RtpPacket } from "werift";
+import { ActionableError } from "../../models";
 import type { RtpPacketSink } from "./RtpH264TrackWriter";
 
 /**
@@ -38,6 +39,15 @@ export class RtpPcmuTrackWriter {
     this.ssrc = options.ssrc >>> 0;
     this.payloadType = options.payloadType ?? PCMU_PAYLOAD_TYPE;
     this.mtu = options.mtu ?? DEFAULT_AUDIO_MTU;
+    // The packetization loop advances by `mtu` bytes per iteration; a zero,
+    // negative, or non-finite MTU would never advance and wedge the daemon
+    // (issue #4170). Each PCMU sample is one byte, so any mtu >= 1 is legitimate
+    // (the audio path deliberately constructs with small MTUs in tests).
+    if (!Number.isFinite(this.mtu) || this.mtu <= 0) {
+      throw new ActionableError(
+        `PCMU RTP MTU must be a positive number of bytes; got ${this.mtu}.`
+      );
+    }
     this.sequenceNumber = (options.initialSequenceNumber ?? 0) & 0xffff;
   }
 

--- a/src/features/webrtc/h264.ts
+++ b/src/features/webrtc/h264.ts
@@ -17,6 +17,8 @@
  * assignment (sequence numbers, timestamps, SSRC, marker bit).
  */
 
+import { ActionableError } from "../../models";
+
 /** NAL unit type for an Access Unit Delimiter (RFC / H.264 §7.4.1). */
 export const NAL_TYPE_AUD = 9;
 /** NAL unit type for a Sequence Parameter Set. */
@@ -29,6 +31,8 @@ export const NAL_TYPE_IDR = 5;
 export const NAL_TYPE_SEI = 6;
 /** RFC 6184 FU-A fragmentation unit NAL type. */
 export const FU_A_TYPE = 28;
+/** FU-A per-fragment overhead: 1-byte FU indicator + 1-byte FU header. */
+export const FU_A_HEADER_BYTES = 2;
 
 /**
  * Default RTP payload MTU. 1200 bytes leaves headroom under a 1500-byte
@@ -228,6 +232,19 @@ export function packetizeNalUnit(nal: Buffer, mtu: number = DEFAULT_RTP_MTU): Bu
   }
   if (nal.length <= mtu) {
     return [Buffer.from(nal)];
+  }
+
+  // Fragmentation reserves 2 bytes per packet for the FU indicator + FU header.
+  // An MTU that leaves no room for at least one payload byte would make the
+  // fragment loop below never advance, wedging the daemon (issue #4170). A
+  // non-finite MTU (NaN) would silently truncate the NAL to a single empty
+  // fragment. Reject both so a misconfigured MTU fails loudly instead.
+  // Note: Infinity is handled by the single-packet fast path above and never
+  // reaches here.
+  if (!Number.isFinite(mtu) || mtu <= FU_A_HEADER_BYTES) {
+    throw new ActionableError(
+      `RTP MTU ${mtu} is too small to fragment a ${nal.length}-byte NAL unit; it must exceed the ${FU_A_HEADER_BYTES}-byte FU-A header.`
+    );
   }
 
   const nalHeader = nal[0];

--- a/src/server/videoRecordingResources.ts
+++ b/src/server/videoRecordingResources.ts
@@ -9,6 +9,25 @@ import { logger } from "../utils/logger";
 import * as fs from "fs/promises";
 import type { VideoRecordingMetadata } from "../models";
 
+/**
+ * The data-store surface the resource handlers depend on. Injecting it keeps the
+ * handlers unit-testable without resolving the real file-backed video-recording
+ * database (issue #3067) or touching the real filesystem.
+ */
+export interface VideoRecordingResourceStore {
+  getLatest(): Promise<VideoRecordingMetadata | null>;
+  getById(recordingId: string, options?: { touch?: boolean }): Promise<VideoRecordingMetadata | null>;
+  list(): Promise<VideoRecordingMetadata[]>;
+  readFile(filePath: string): Promise<Buffer>;
+}
+
+const defaultVideoRecordingResourceStore: VideoRecordingResourceStore = {
+  getLatest: getLatestVideoRecordingMetadata,
+  getById: getVideoRecordingMetadata,
+  list: listVideoRecordings,
+  readFile: fs.readFile,
+};
+
 function getVideoMimeType(metadata: VideoRecordingMetadata): string {
   if (metadata.format === "mp4") {
     return "video/mp4";
@@ -16,9 +35,10 @@ function getVideoMimeType(metadata: VideoRecordingMetadata): string {
   return "application/octet-stream";
 }
 
-async function buildVideoResourceContent(
+export async function buildVideoResourceContent(
   metadata: VideoRecordingMetadata,
-  uri: string
+  uri: string,
+  store: VideoRecordingResourceStore = defaultVideoRecordingResourceStore
 ): Promise<ResourceContent> {
   if (!metadata.filePath) {
     return {
@@ -32,7 +52,7 @@ async function buildVideoResourceContent(
   }
 
   try {
-    const fileBuffer = await fs.readFile(metadata.filePath);
+    const fileBuffer = await store.readFile(metadata.filePath);
     const blob = fileBuffer.toString("base64");
     return {
       uri,
@@ -53,9 +73,11 @@ async function buildVideoResourceContent(
   }
 }
 
-async function getLatestVideoRecording(): Promise<ResourceContent> {
+export async function getLatestVideoRecording(
+  store: VideoRecordingResourceStore = defaultVideoRecordingResourceStore
+): Promise<ResourceContent> {
   try {
-    const latest = await getLatestVideoRecordingMetadata();
+    const latest = await store.getLatest();
     if (!latest) {
       return {
         uri: VIDEO_RESOURCE_URIS.LATEST,
@@ -66,8 +88,8 @@ async function getLatestVideoRecording(): Promise<ResourceContent> {
       };
     }
 
-    const metadata = await getVideoRecordingMetadata(latest.recordingId, { touch: true }) ?? latest;
-    return buildVideoResourceContent(metadata, VIDEO_RESOURCE_URIS.LATEST);
+    const metadata = await store.getById(latest.recordingId, { touch: true }) ?? latest;
+    return buildVideoResourceContent(metadata, VIDEO_RESOURCE_URIS.LATEST, store);
   } catch (error) {
     logger.error(`[VideoRecordingResources] Failed to get latest recording: ${error}`);
     return {
@@ -80,9 +102,11 @@ async function getLatestVideoRecording(): Promise<ResourceContent> {
   }
 }
 
-async function getVideoArchiveList(): Promise<ResourceContent> {
+export async function getVideoArchiveList(
+  store: VideoRecordingResourceStore = defaultVideoRecordingResourceStore
+): Promise<ResourceContent> {
   try {
-    const recordings = await listVideoRecordings();
+    const recordings = await store.list();
     return {
       uri: VIDEO_RESOURCE_URIS.ARCHIVE,
       mimeType: "application/json",
@@ -103,7 +127,10 @@ async function getVideoArchiveList(): Promise<ResourceContent> {
   }
 }
 
-async function getVideoArchiveItem(params: Record<string, string>): Promise<ResourceContent> {
+export async function getVideoArchiveItem(
+  params: Record<string, string>,
+  store: VideoRecordingResourceStore = defaultVideoRecordingResourceStore
+): Promise<ResourceContent> {
   try {
     const recordingId = params.recordingId;
     if (!recordingId) {
@@ -114,7 +141,7 @@ async function getVideoArchiveItem(params: Record<string, string>): Promise<Reso
       };
     }
 
-    const metadata = await getVideoRecordingMetadata(recordingId, { touch: true });
+    const metadata = await store.getById(recordingId, { touch: true });
     if (!metadata) {
       return {
         uri: buildVideoArchiveItemUri(recordingId),
@@ -125,7 +152,7 @@ async function getVideoArchiveItem(params: Record<string, string>): Promise<Reso
       };
     }
 
-    return buildVideoResourceContent(metadata, buildVideoArchiveItemUri(recordingId));
+    return buildVideoResourceContent(metadata, buildVideoArchiveItemUri(recordingId), store);
   } catch (error) {
     logger.error(`[VideoRecordingResources] Failed to read recording: ${error}`);
     return {

--- a/test/fakes/FakeAdbClient.ts
+++ b/test/fakes/FakeAdbClient.ts
@@ -1,9 +1,22 @@
-import type { AdbExecutor } from "../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
+import type {
+  AdbExecuteOptions,
+  AdbExecutor,
+  AdbProcess,
+  AdbSpawnOptions,
+} from "../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
+import type { ExecResult } from "../../src/models";
+import { FakeAdbProcess } from "./FakeAdbProcess";
 
 type FakeAdbClientContract = Pick<
   AdbExecutor,
-  "executeCommand" | "getForegroundApp" | "listUsers"
+  "execute" | "executeCommand" | "getForegroundApp" | "listUsers" | "spawn"
 >;
+
+/** How a spawned command should terminate, keyed by a substring of its argv. */
+interface SpawnBehavior {
+  match: string;
+  outcome: { kind: "exit"; code: number } | { kind: "error"; error: Error };
+}
 
 /**
  * Fake implementation of AdbClient for testing
@@ -25,6 +38,8 @@ export class FakeAdbClient implements FakeAdbClientContract {
   private foregroundAppError: Error | null = null;
   private hangingCommandPatterns: string[] = [];
   private users: Array<{ userId: number; name: string; flags?: number; running?: boolean }> = [];
+  private spawnCalls: string[][] = [];
+  private spawnBehaviors: SpawnBehavior[] = [];
 
   /**
    * Record a command execution
@@ -71,6 +86,64 @@ export class FakeAdbClient implements FakeAdbClientContract {
       trim: () => result.stdout.trim(),
       includes: (search: string) => result.stdout.includes(search)
     };
+  }
+
+  /**
+   * Execute argv directly. Mirrors {@link executeCommand} but takes the argv
+   * array + {@link AdbExecuteOptions} shape of {@link AdbExecutor.execute} and
+   * returns an {@link ExecResult}. The joined argv is used as the lookup key so
+   * a test can configure a result via {@link setCommandResult}.
+   */
+  async execute(args: string[], options?: AdbExecuteOptions): Promise<ExecResult> {
+    const command = args.join(" ");
+    return this.executeCommand(
+      command,
+      options?.timeoutMs,
+      options?.maxBuffer,
+      options?.noRetry,
+      options?.signal
+    );
+  }
+
+  /**
+   * Spawn a long-lived ADB command. Records the argv and returns a
+   * {@link FakeAdbProcess} that terminates per the configured behavior (default:
+   * a clean exit code 0). The exit/error event fires after the caller attaches
+   * its listeners, matching the real spawn's async lifecycle.
+   */
+  async spawn(args: string[], _options?: AdbSpawnOptions): Promise<AdbProcess> {
+    this.spawnCalls.push([...args]);
+    const proc = new FakeAdbProcess();
+    const joined = args.join(" ");
+    const behavior = this.spawnBehaviors.find(b => joined.includes(b.match));
+    if (behavior?.outcome.kind === "error") {
+      proc.scheduleError(behavior.outcome.error);
+    } else {
+      proc.scheduleExit(behavior?.outcome.kind === "exit" ? behavior.outcome.code : 0);
+    }
+    return proc;
+  }
+
+  /**
+   * Configure how a spawned command whose argv contains `match` terminates.
+   * Without a match a spawned command exits cleanly with code 0.
+   */
+  setSpawnExit(match: string, code: number): void {
+    this.spawnBehaviors.push({ match, outcome: { kind: "exit", code } });
+  }
+
+  setSpawnError(match: string, error: Error): void {
+    this.spawnBehaviors.push({ match, outcome: { kind: "error", error } });
+  }
+
+  /** All recorded spawn argv arrays, in order. */
+  getSpawnCalls(): string[][] {
+    return this.spawnCalls.map(call => [...call]);
+  }
+
+  /** True if any spawned command's argv contained `match`. */
+  wasSpawned(match: string): boolean {
+    return this.spawnCalls.some(call => call.join(" ").includes(match));
   }
 
   /**
@@ -208,6 +281,8 @@ export class FakeAdbClient implements FakeAdbClientContract {
     this.commandSequenceCursor.clear();
     this.foregroundAppError = null;
     this.hangingCommandPatterns = [];
+    this.spawnCalls = [];
+    this.spawnBehaviors = [];
   }
 
   /**

--- a/test/fakes/FakeAdbProcess.ts
+++ b/test/fakes/FakeAdbProcess.ts
@@ -1,0 +1,50 @@
+import { EventEmitter } from "node:events";
+import { Readable, Writable } from "node:stream";
+import type { AdbProcess } from "../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
+
+/**
+ * Controllable fake for a long-lived ADB process returned by {@link AdbExecutor.spawn}.
+ * Satisfies the narrow {@link AdbProcess} surface (stdin/stdout/stderr, exit code,
+ * kill, and the `once`/`on`/`off`/`removeListener` event methods) without spawning
+ * a real process. Tests configure how the process terminates and the fake emits
+ * the corresponding `exit` / `error` event after the caller has attached its
+ * listeners (via `setImmediate`, so a `once("exit")` registered right after the
+ * spawn resolves is guaranteed to observe the event).
+ */
+export class FakeAdbProcess extends EventEmitter implements AdbProcess {
+  readonly stdin: Writable | null;
+  readonly stdout: Readable;
+  readonly stderr: Readable;
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  killed = false;
+
+  constructor() {
+    super();
+    this.stdin = new Writable({ write: (_chunk, _enc, cb) => cb() });
+    this.stdout = new Readable({ read() {} });
+    this.stderr = new Readable({ read() {} });
+  }
+
+  kill(signal?: NodeJS.Signals | number): boolean {
+    this.killed = true;
+    this.signalCode = typeof signal === "number" ? null : (signal ?? "SIGTERM");
+    return true;
+  }
+
+  /** Schedule a clean/failed exit that fires once the caller's listeners attach. */
+  scheduleExit(code: number, signal: NodeJS.Signals | null = null): void {
+    setImmediate(() => {
+      this.exitCode = code;
+      this.signalCode = signal;
+      this.stdout.push(null);
+      this.stderr.push(null);
+      this.emit("exit", code, signal);
+    });
+  }
+
+  /** Schedule an error event (e.g. adb binary missing) after listeners attach. */
+  scheduleError(error: Error): void {
+    setImmediate(() => this.emit("error", error));
+  }
+}

--- a/test/fakes/FakeVideoCaptureBackend.ts
+++ b/test/fakes/FakeVideoCaptureBackend.ts
@@ -12,6 +12,8 @@ import type {
 export class FakeVideoCaptureBackend implements VideoCaptureBackend {
   readonly startCalls: VideoCaptureConfig[] = [];
   readonly stopCalls: RecordingHandle[] = [];
+  /** The exact handle objects returned by start(), for identity assertions. */
+  readonly startResults: RecordingHandle[] = [];
   private stopResolvers: Array<(handle: RecordingHandle) => void> = [];
   private stopResultOverrides: Partial<RecordingResult> | null = null;
   private outputPayload: Buffer = Buffer.from("fake-video");
@@ -32,11 +34,13 @@ export class FakeVideoCaptureBackend implements VideoCaptureBackend {
   async start(config: VideoCaptureConfig): Promise<RecordingHandle> {
     this.startCalls.push(config);
     // No real file I/O - just return the handle
-    return {
+    const handle: RecordingHandle = {
       recordingId: config.recordingId,
       outputPath: config.outputPath,
       startedAt: config.startedAt,
     };
+    this.startResults.push(handle);
+    return handle;
   }
 
   async stop(handle: RecordingHandle): Promise<RecordingResult> {

--- a/test/features/record/McpCallRecorder.test.ts
+++ b/test/features/record/McpCallRecorder.test.ts
@@ -118,6 +118,30 @@ describe("McpCallRecorder", () => {
       expect(steps[0].params).toEqual({ text: "Login", action: "tap" });
     });
 
+    // Every routing param injected by ToolRegistry must be stripped from a
+    // recorded step. The router-internal `__mcpSessionId` and `__lockNamespace`
+    // had no coverage and would otherwise leak into exported plans.
+    test.each([
+      "platform",
+      "deviceId",
+      "sessionUuid",
+      "device",
+      "devices",
+      "keepScreenAwake",
+      "__mcpSessionId",
+      "__lockNamespace",
+      "__internalNoDiff",
+    ])("strips the internal routing param %p from a recorded step", internalParam => {
+      const recorder = new McpCallRecorder();
+      recorder.start();
+
+      recorder.record("tapOn", { text: "keep-me", [internalParam]: "leak" });
+
+      const steps = recorder.stop();
+      expect(steps).toHaveLength(1);
+      expect(steps[0].params).toEqual({ text: "keep-me" });
+    });
+
     test("preserves all non-internal params", () => {
       const recorder = new McpCallRecorder();
       recorder.start();
@@ -177,23 +201,6 @@ describe("stripInternalParams", () => {
 });
 
 describe("PLAN_RELEVANT_TOOLS", () => {
-  test("includes core interaction tools", () => {
-    const expected = [
-      "tapOn", "swipeOn", "inputText", "clearText",
-      "pressButton", "dragAndDrop", "pinchOn", "imeAction",
-    ];
-    for (const tool of expected) {
-      expect(PLAN_RELEVANT_TOOLS.has(tool)).toBe(true);
-    }
-  });
-
-  test("includes observation and lifecycle tools", () => {
-    expect(PLAN_RELEVANT_TOOLS.has("observe")).toBe(true);
-    expect(PLAN_RELEVANT_TOOLS.has("launchApp")).toBe(true);
-    expect(PLAN_RELEVANT_TOOLS.has("terminateApp")).toBe(true);
-    expect(PLAN_RELEVANT_TOOLS.has("setUIState")).toBe(true);
-  });
-
   test("excludes infrastructure tools", () => {
     const excluded = [
       "listDevices", "startDevice", "killDevice", "setActiveDevice",

--- a/test/features/record/android/AxisRanges.test.ts
+++ b/test/features/record/android/AxisRanges.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildScaler,
+  queryDensity,
+  queryRotation,
+} from "../../../../src/features/record/android/AxisRanges";
+import { FakeAdbClient } from "../../../fakes/FakeAdbClient";
+
+/** Full axis+display description accepted by buildScaler. */
+function ranges(overrides: Partial<Parameters<typeof buildScaler>[0]> = {}): Parameters<typeof buildScaler>[0] {
+  return {
+    xMin: 0,
+    xMax: 4095,
+    yMin: 0,
+    yMax: 4095,
+    displayWidth: 1000,
+    displayHeight: 2000,
+    rotation: 0,
+    ...overrides,
+  };
+}
+
+describe("buildScaler", () => {
+  test("portrait maps sensor X to display width and sensor Y to display height", () => {
+    const scaler = buildScaler(ranges({ rotation: 0 }));
+    // norm(4095) = 4095 / (4095 - 0 + 1) = 4095/4096
+    expect(scaler.toScreenX(4095)).toBe(1000);
+    expect(scaler.toScreenY(4095)).toBe(2000);
+    expect(scaler.toScreenX(2048)).toBe(500);
+  });
+
+  test("landscape (rotation 1) swaps the axes: sensor X maps to display height", () => {
+    const scaler = buildScaler(ranges({ rotation: 1 }));
+    expect(scaler.toScreenX(4095)).toBe(2000); // height, not width
+    expect(scaler.toScreenY(4095)).toBe(1000); // width, not height
+  });
+
+  test("landscape (rotation 3) swaps the axes just like rotation 1", () => {
+    const scaler = buildScaler(ranges({ rotation: 3 }));
+    expect(scaler.toScreenX(4095)).toBe(2000);
+    expect(scaler.toScreenY(4095)).toBe(1000);
+  });
+
+  test("reverse-portrait (rotation 2) keeps the portrait axis mapping", () => {
+    const scaler = buildScaler(ranges({ rotation: 2 }));
+    expect(scaler.toScreenX(4095)).toBe(1000);
+    expect(scaler.toScreenY(4095)).toBe(2000);
+  });
+
+  test("the +1 span divisor keeps a max-raw value just inside the display bound", () => {
+    // 4095 raw across [0, 4095] over a 2400px axis lands at 2399, not 2400 —
+    // the off-by-one that a naive (xMax - xMin) divisor would produce.
+    const scaler = buildScaler(ranges({ displayWidth: 2400, rotation: 0 }));
+    expect(scaler.toScreenX(4095)).toBe(2399);
+  });
+});
+
+describe("queryRotation", () => {
+  test.each([
+    ["mCurrentRotation=ROTATION_0", 0],
+    ["mCurrentRotation=ROTATION_90", 1],
+    ["mCurrentRotation=ROTATION_1", 1],
+    ["mCurrentRotation=ROTATION_180", 2],
+    ["mCurrentRotation=ROTATION_270", 3],
+    ["mCurrentRotation=ROTATION_3", 3],
+  ])("normalizes %p to rotation index %p", async (stdout, expected) => {
+    const adb = new FakeAdbClient();
+    adb.setCommandResult("shell dumpsys window displays", stdout);
+    expect(await queryRotation(adb)).toBe(expected);
+  });
+
+  test("defaults to 0 when the rotation cannot be parsed", async () => {
+    const adb = new FakeAdbClient();
+    adb.setCommandResult("shell dumpsys window displays", "no rotation here");
+    expect(await queryRotation(adb)).toBe(0);
+  });
+
+  test("defaults to 0 when the dumpsys command fails", async () => {
+    const adb = new FakeAdbClient();
+    adb.setCommandError("shell dumpsys window displays", new Error("device offline"));
+    expect(await queryRotation(adb)).toBe(0);
+  });
+});
+
+describe("queryDensity", () => {
+  test("converts a physical density to a dp multiplier", async () => {
+    const adb = new FakeAdbClient();
+    adb.setCommandResult("shell wm density", "Physical density: 480");
+    expect(await queryDensity(adb)).toBe(3);
+  });
+
+  test("reads the physical density even when an override density follows", async () => {
+    const adb = new FakeAdbClient();
+    adb.setCommandResult("shell wm density", "Physical density: 480\nOverride density: 320");
+    expect(await queryDensity(adb)).toBe(3);
+  });
+
+  test("falls back to 2.75 when the density cannot be parsed", async () => {
+    const adb = new FakeAdbClient();
+    adb.setCommandResult("shell wm density", "unknown");
+    expect(await queryDensity(adb)).toBe(2.75);
+  });
+
+  test("falls back to 2.75 when the density command fails", async () => {
+    const adb = new FakeAdbClient();
+    adb.setCommandError("shell wm density", new Error("device offline"));
+    expect(await queryDensity(adb)).toBe(2.75);
+  });
+});

--- a/test/features/record/android/DualTrackRecorder.test.ts
+++ b/test/features/record/android/DualTrackRecorder.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach } from "bun:test";
-import { DualTrackRecorder, MERGE_WINDOW_MS } from "../../../../src/features/record/android/DualTrackRecorder";
+import { DualTrackRecorder, MERGE_WINDOW_MS, resolveSwipeDirection } from "../../../../src/features/record/android/DualTrackRecorder";
 import type { GestureEmitter, GestureEvent, A11ySource } from "../../../../src/features/record/android/types";
 import type { BootedDevice } from "../../../../src/models";
 import { FakeTimer } from "../../../fakes/FakeTimer";
@@ -320,5 +320,25 @@ describe("DualTrackRecorder", () => {
     expect(steps[0].tool).toBe("tapOn");
     expect(steps[0].params.text).toBe("Sign in");
     expect(steps[0].params.elementId).toBeUndefined();
+  });
+});
+
+describe("resolveSwipeDirection (scroll-delta axis mapping)", () => {
+  // These deltas are accessibility SCROLL deltas (content movement), so the
+  // mapping is deliberately inverted relative to GestureClassifier's finger
+  // displacement: a positive scrollDeltaX (content moved right) is the user
+  // swiping LEFT, and a positive scrollDeltaY (content moved down) is swiping UP.
+  test.each([
+    [0, 0, null, "no movement"],
+    [10, 0, "left", "positive X delta inverts to left"],
+    [-10, 0, "right", "negative X delta inverts to right"],
+    [0, 10, "up", "positive Y delta inverts to up"],
+    [0, -10, "down", "negative Y delta inverts to down"],
+    [10, 5, "left", "dominant X axis wins"],
+    [5, 10, "up", "dominant Y axis wins"],
+    [10, 10, "left", "an axis tie resolves on the X branch"],
+    [undefined, undefined, null, "absent deltas mean no direction"],
+  ])("resolveSwipeDirection(%p, %p) → %p (%s)", (dx, dy, expected, _why) => {
+    expect(resolveSwipeDirection(dx, dy)).toBe(expected);
   });
 });

--- a/test/features/record/android/GestureClassifier.test.ts
+++ b/test/features/record/android/GestureClassifier.test.ts
@@ -244,6 +244,23 @@ describe("GestureClassifier", () => {
     expect(result).toBeNull();
   });
 
+  test("two fingers starting at the same point emit no pinch (no divide-by-zero scale)", () => {
+    // initialDist === 0 would make scale = finalDist / 0 = Infinity. The guard
+    // must suppress the pinch entirely rather than emit a non-finite scale that
+    // would corrupt a recorded plan.
+    c.feedFrame(makeFrame(0, [
+      { slotId: 0, trackingId: 1, x: 500, y: 500 },
+      { slotId: 1, trackingId: 2, x: 500, y: 500 },
+    ]));
+    c.feedFrame(makeFrame(100, [
+      { slotId: 0, trackingId: 1, x: 300, y: 500 },
+      { slotId: 1, trackingId: 2, x: 700, y: 500 },
+    ]));
+
+    const result = c.feedFrame(makeFrame(200, [], [0, 1]));
+    expect(result).toBeNull();
+  });
+
   // -------------------------------------------------------------------------
   // Edge cases
   // -------------------------------------------------------------------------

--- a/test/features/record/android/TouchFrameReconstructor.test.ts
+++ b/test/features/record/android/TouchFrameReconstructor.test.ts
@@ -124,6 +124,29 @@ describe("TouchFrameReconstructor", () => {
     expect((results[0] as GestureEvent).button).toBe("volume_up");
   });
 
+  // Full KEY_TO_BUTTON map: every hardware key the recorder understands must map
+  // to its AutoMobile button name. Four of these (menu, power, volume_down,
+  // recent) had no coverage.
+  test.each([
+    ["KEY_BACK", "back"],
+    ["KEY_HOME", "home"],
+    ["KEY_MENU", "menu"],
+    ["KEY_POWER", "power"],
+    ["KEY_VOLUMEUP", "volume_up"],
+    ["KEY_VOLUMEDOWN", "volume_down"],
+    ["KEY_APPSELECT", "recent"],
+  ])("EV_KEY %s DOWN emits pressButton with the mapped button name", (keyCode, expectedButton) => {
+    const results = feedLines(r, [`[  5.000000] EV_KEY    ${keyCode}             DOWN`]);
+    expect(results).toHaveLength(1);
+    expect((results[0] as GestureEvent).type).toBe("pressButton");
+    expect((results[0] as GestureEvent).button).toBe(expectedButton);
+  });
+
+  test("EV_KEY DOWN for an unmapped key emits nothing", () => {
+    const results = feedLines(r, ["[  5.000000] EV_KEY    KEY_CAMERA           DOWN"]);
+    expect(results).toHaveLength(0);
+  });
+
   test("EV_KEY UP events are ignored", () => {
     const results = feedLines(r, ["[  5.000000] EV_KEY    KEY_BACK             UP"]);
     expect(results).toHaveLength(0);

--- a/test/features/screen-stream/IOSScreenCaptureHelper.test.ts
+++ b/test/features/screen-stream/IOSScreenCaptureHelper.test.ts
@@ -94,40 +94,27 @@ describe("IOSScreenCaptureHelper", () => {
     expect(spawnArgs.args).toEqual(["--simulator-window", "98765"]);
   });
 
-  test("passes --simulator-fps when fps is provided", () => {
-    const { spawnArgs, helper } = withFakeSpawner({
-      kind: "simulator",
-      windowID: 1,
-      fps: 30,
-    });
+  // The fps guard runs on start() (in buildArgs), not the constructor. Accepted
+  // values are integers in the inclusive [5, 60] range, including both bounds.
+  test.each([5, 30, 60])("accepts a valid simulator fps %p and forwards it", fps => {
+    const { spawnArgs, helper } = withFakeSpawner({ kind: "simulator", windowID: 1, fps });
     helper.start();
-    expect(spawnArgs.args).toEqual([
-      "--simulator-window",
-      "1",
-      "--simulator-fps",
-      "30",
-    ]);
+    expect(spawnArgs.args).toEqual(["--simulator-window", "1", "--simulator-fps", String(fps)]);
   });
 
-  test("rejects simulator fps outside [5, 60]", () => {
-    const fake = new FakeChildProcess();
-    const helper = new IOSScreenCaptureHelper({
-      binaryPath: "/fake/screen-capture-helper",
-      target: { kind: "simulator", windowID: 1, fps: 61 },
-      spawner: () => fake as unknown as ChildProcessWithoutNullStreams,
-    });
-    expect(() => helper.start()).toThrow(/simulator fps must be an integer in \[5, 60\]/);
-  });
-
-  test("rejects non-integer simulator fps", () => {
-    const fake = new FakeChildProcess();
-    const helper = new IOSScreenCaptureHelper({
-      binaryPath: "/fake/screen-capture-helper",
-      target: { kind: "simulator", windowID: 1, fps: 30.5 },
-      spawner: () => fake as unknown as ChildProcessWithoutNullStreams,
-    });
-    expect(() => helper.start()).toThrow(/integer/);
-  });
+  // Below-min, negative, above-max, and non-integer all fail the same guard.
+  test.each([4, 0, -30, 61, 30.5, Number.NaN])(
+    "rejects an out-of-range or non-integer simulator fps %p on start()",
+    fps => {
+      const fake = new FakeChildProcess();
+      const helper = new IOSScreenCaptureHelper({
+        binaryPath: "/fake/screen-capture-helper",
+        target: { kind: "simulator", windowID: 1, fps },
+        spawner: () => fake as unknown as ChildProcessWithoutNullStreams,
+      });
+      expect(() => helper.start()).toThrow(/simulator fps must be an integer in \[5, 60\]/);
+    }
+  );
 
   test("coalesces a burst into the newest decoded frame", async () => {
     const { fake, helper } = withFakeSpawner();

--- a/test/features/screen-stream/frameProtocol.test.ts
+++ b/test/features/screen-stream/frameProtocol.test.ts
@@ -109,6 +109,23 @@ describe("FrameDecoder", () => {
     const decoder = new FrameDecoder();
     expect(decoder.push(Buffer.alloc(0))).toHaveLength(0);
   });
+
+  test("emitted pixels are copied out of the input chunk, not aliased into it", () => {
+    // The decoded frame outlives its stdout chunk. If a "just subarray it"
+    // optimization replaced the detaching copy, the emitted pixels would pin —
+    // and be corrupted by reuse of — the whole socket buffer. Mutating the
+    // input after push() must not change the decoded pixels.
+    const decoder = new FrameDecoder();
+    const frame = makeFrameBytes(2, 2, 8, 100, 0xab);
+    const out = decoder.push(frame);
+    expect(out).toHaveLength(1);
+    expect(out[0].pixels[0]).toBe(0xab);
+
+    frame.fill(0x00);
+
+    expect(out[0].pixels[0]).toBe(0xab);
+    expect(out[0].pixels.every(byte => byte === 0xab)).toBe(true);
+  });
 });
 
 describe("FrameDecoder marker-based resynchronization", () => {

--- a/test/features/video/FfmpegVideoProcessingBackend.test.ts
+++ b/test/features/video/FfmpegVideoProcessingBackend.test.ts
@@ -3,7 +3,7 @@ import { spawn, spawnSync } from "node:child_process";
 import type { ChildProcess, SpawnOptions } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { promises as fsPromises } from "node:fs";
-import os, { platform } from "node:os";
+import os from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 import {
@@ -238,42 +238,40 @@ describe("FfmpegVideoProcessingBackend - Unit Tests", function() {
   });
 
   describe("Hardware Acceleration Detection", function() {
-    test("should detect platform capabilities", async function() {
-      const osPlatform = platform();
-      const hwAccel = await (backend as any).detectHardwareAccel();
+    // The injected platform provider lets every OS branch be verified on any
+    // host, instead of only the one matching the CI runner. listEncoders is
+    // stubbed in beforeEach to advertise all three hardware encoders, so each
+    // platform selects its own preferred encoder.
+    function backendForPlatform(os: NodeJS.Platform): FfmpegVideoProcessingBackend {
+      const scoped = new FfmpegVideoProcessingBackend(undefined, undefined, undefined, () => os);
+      (scoped as any).listEncoders = async () => {
+        listEncodersCalls += 1;
+        return ["h264_nvenc", "h264_vaapi", "h264_videotoolbox"];
+      };
+      return scoped;
+    }
 
-      expect(hwAccel).toBeDefined();
-      expect(hwAccel.encoder).toBeDefined();
-      expect(typeof hwAccel.available).toBe("boolean");
-      expect(hwAccel.description).toBeDefined();
-
-      if (osPlatform === "darwin") {
-        expect(hwAccel.encoder).toBe("h264_videotoolbox");
-        expect(hwAccel.available).toBe(true);
-        expect(listEncodersCalls).toBe(1);
-      } else if (osPlatform === "linux") {
-        expect(hwAccel.encoder).toBe("h264_nvenc");
-        expect(hwAccel.available).toBe(true);
-        expect(listEncodersCalls).toBe(1);
-      } else {
-        expect(hwAccel.encoder).toBe("libx264");
-        expect(hwAccel.available).toBe(false);
-        expect(hwAccel.description).toContain("Unsupported platform");
-        expect(listEncodersCalls).toBe(0);
-      }
+    test.each([
+      ["darwin", "h264_videotoolbox", true],
+      ["linux", "h264_nvenc", true],
+      ["win32", "libx264", false],
+    ])("selects the %s hardware encoder", async (os, encoder, available) => {
+      const hwAccel = await (backendForPlatform(os as NodeJS.Platform) as any).detectHardwareAccel();
+      expect(hwAccel.encoder).toBe(encoder);
+      expect(hwAccel.available).toBe(available);
     });
 
-    test("should cache hardware acceleration detection", async function() {
-      const osPlatform = platform();
-      const hwAccel1 = await (backend as any).detectHardwareAccel();
-      const hwAccel2 = await (backend as any).detectHardwareAccel();
+    test("caches the detection result so encoders are probed at most once", async function() {
+      // Unconditional assertion (not gated on host platform): a darwin backend
+      // probes exactly once across two detect calls.
+      const scoped = backendForPlatform("darwin");
+      listEncodersCalls = 0;
 
-      expect(hwAccel1).toEqual(hwAccel2);
-      if (osPlatform === "darwin" || osPlatform === "linux") {
-        expect(listEncodersCalls).toBe(1);
-      } else {
-        expect(listEncodersCalls).toBe(0);
-      }
+      const first = await (scoped as any).detectHardwareAccel();
+      const second = await (scoped as any).detectHardwareAccel();
+
+      expect(first).toEqual(second);
+      expect(listEncodersCalls).toBe(1);
     });
   });
 

--- a/test/features/video/HybridVideoCaptureBackend.test.ts
+++ b/test/features/video/HybridVideoCaptureBackend.test.ts
@@ -102,6 +102,56 @@ describe("HybridVideoCaptureBackend - Unit Tests", function() {
     expect(platformBackend.stopCalls.length).toBe(0);
   });
 
+  test("routes Android recording to ffmpeg backend when the opt-in flag is the string \"true\"", async function() {
+    process.env.AUTOMOBILE_ANDROID_VIDEO_USE_FFMPEG_PIPE = "true";
+    await backend.start(baseConfig);
+    expect(ffmpegBackend.startCalls.length).toBe(1);
+    expect(platformBackend.startCalls.length).toBe(0);
+  });
+
+  // The opt-in check is case-sensitive: only "1" / "true" enable ffmpeg. An
+  // uppercase "TRUE" must fall through to the default platform backend.
+  test("does NOT treat an uppercase \"TRUE\" opt-in value as enabled", async function() {
+    process.env.AUTOMOBILE_ANDROID_VIDEO_USE_FFMPEG_PIPE = "TRUE";
+    await backend.start(baseConfig);
+    expect(platformBackend.startCalls.length).toBe(1);
+    expect(ffmpegBackend.startCalls.length).toBe(0);
+  });
+
+  test("treats an empty opt-in value as disabled and uses the platform backend", async function() {
+    process.env.AUTOMOBILE_ANDROID_VIDEO_USE_FFMPEG_PIPE = "";
+    await backend.start(baseConfig);
+    expect(platformBackend.startCalls.length).toBe(1);
+    expect(ffmpegBackend.startCalls.length).toBe(0);
+  });
+
+  test("start rejects when no device is provided", async function() {
+    const configWithoutDevice: VideoCaptureConfig = { ...baseConfig, device: undefined };
+    await expect(backend.start(configWithoutDevice)).rejects.toThrow(
+      "Device is required"
+    );
+  });
+
+  test("stop rejects when the backend handle is missing or not a hybrid handle", async function() {
+    await expect(
+      backend.stop({
+        recordingId: "x",
+        outputPath: "/tmp/x.mp4",
+        startedAt: new Date().toISOString(),
+        backendHandle: undefined,
+      })
+    ).rejects.toThrow("Missing backend handle for hybrid");
+
+    await expect(
+      backend.stop({
+        recordingId: "x",
+        outputPath: "/tmp/x.mp4",
+        startedAt: new Date().toISOString(),
+        backendHandle: { kind: "not-hybrid" } as never,
+      })
+    ).rejects.toThrow("Missing backend handle for hybrid");
+  });
+
   test("routes iOS recording to ffmpeg backend", async function() {
     const iosConfig = {
       ...baseConfig,

--- a/test/features/video/PlatformVideoCaptureBackend.test.ts
+++ b/test/features/video/PlatformVideoCaptureBackend.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import os from "node:os";
 import path from "node:path";
 import { promises as fsPromises } from "node:fs";
-import { PlatformVideoCaptureBackend } from "../../../src/features/video/PlatformVideoCaptureBackend";
+import { PlatformVideoCaptureBackend, clampBitrateKbps } from "../../../src/features/video/PlatformVideoCaptureBackend";
 import type {
   RecordingHandle,
   VideoCaptureConfig,
@@ -205,9 +205,7 @@ describe("PlatformVideoCaptureBackend - Unit Tests", () => {
       fakeProcess.exitCode = 0;
       const handle = buildAndroidStopHandle(path.join(tempDir, "out.mp4"), fakeProcess);
 
-      // stop() will throw at the adb pull step (FakeAdbClient has no
-      // getBaseCommandParts) — but pkill must run first regardless.
-      await expect(backend.stop(handle)).rejects.toThrow();
+      await backend.stop(handle);
 
       const commands = fakeClient.getAllCommands();
       expect(commands[0]).toBe("shell pkill -2 screenrecord");
@@ -225,9 +223,46 @@ describe("PlatformVideoCaptureBackend - Unit Tests", () => {
 
       const handle = buildAndroidStopHandle(path.join(tempDir, "out.mp4"), fakeProcess);
 
-      await expect(backend.stop(handle)).rejects.toThrow();
+      await backend.stop(handle);
 
       expect(killSignals).toEqual([]);
+    });
+
+    test("disarms its graceful-exit timeout through the injected timer once host adb has exited", async () => {
+      const fakeFactory = new FakeAdbClientFactory();
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+
+      // Observe the arm/disarm pair on the *injected* timer. The bug used the
+      // global clearTimeout, so the 10 s SIGINT callback armed via
+      // this.timer.setTimeout was never cancelled and could fire after the
+      // recording finished (issue #4170).
+      const armedHandles: NodeJS.Timeout[] = [];
+      const clearedHandles: NodeJS.Timeout[] = [];
+      const originalSetTimeout = fakeTimer.setTimeout.bind(fakeTimer);
+      const originalClearTimeout = fakeTimer.clearTimeout.bind(fakeTimer);
+      fakeTimer.setTimeout = (callback: () => void, ms: number) => {
+        const handle = originalSetTimeout(callback, ms);
+        if (ms === 10000) {
+          armedHandles.push(handle);
+        }
+        return handle;
+      };
+      fakeTimer.clearTimeout = (handle: NodeJS.Timeout) => {
+        clearedHandles.push(handle);
+        originalClearTimeout(handle);
+      };
+
+      const backend = new PlatformVideoCaptureBackend(fakeFactory, fakeTimer);
+      const fakeProcess = new FakeChildProcess();
+      fakeProcess.exitCode = 0; // host adb already exited
+      const handle = buildAndroidStopHandle(path.join(tempDir, "out.mp4"), fakeProcess);
+
+      // stop() rejects later at the adb pull step; the disarm happens first.
+      await backend.stop(handle).catch(() => undefined);
+
+      expect(armedHandles).toHaveLength(1);
+      expect(clearedHandles).toContain(armedHandles[0]);
     });
 
     test("falls back to host SIGINT when device-side pkill fails and host adb is still running", async () => {
@@ -262,258 +297,114 @@ describe("PlatformVideoCaptureBackend - Unit Tests", () => {
       (handle.backendHandle as any).exitPromise = exitPromise;
       (handle.backendHandle as any).exitState.exitCode = null;
 
-      await expect(backend.stop(handle)).rejects.toThrow();
+      await backend.stop(handle);
 
       expect(killSignals).toContain("SIGINT");
       expect(fakeClient.wasCommandExecuted("shell pkill -2 screenrecord")).toBe(true);
     });
-  });
 
-  describe("Bitrate Clamping Logic", () => {
-    test("clamps bitrate based on maxThroughputMbps", () => {
-      // Test the clamping logic by accessing the private method
-      const config = {
-        targetBitrateKbps: 5000,
-        maxThroughputMbps: 2, // 2 Mbps = 2000 Kbps
-      };
+    test("pulls the recording, cleans up the /sdcard temp, and reports the pulled file size", async () => {
+      const fakeFactory = new FakeAdbClientFactory();
+      const fakeClient = fakeFactory.getFakeClient();
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
 
-      // Access private method via any cast
-      const clampedBitrate = (backend as any).clampBitrateKbps?.(config) ??
-        Math.min(config.targetBitrateKbps, config.maxThroughputMbps * 1000);
+      const backend = new PlatformVideoCaptureBackend(fakeFactory, fakeTimer);
+      const fakeProcess = new FakeChildProcess();
+      fakeProcess.exitCode = 0;
 
-      expect(clampedBitrate).toBeLessThanOrEqual(2000);
+      // Simulate the pulled artifact so getFileSize returns a real byte count.
+      const outputPath = path.join(tempDir, "out.mp4");
+      await fsPromises.writeFile(outputPath, Buffer.alloc(4096, 1));
+      const handle = buildAndroidStopHandle(outputPath, fakeProcess);
+
+      const result = await backend.stop(handle);
+
+      // The pull targets the device temp path → the host output path.
+      expect(fakeClient.getSpawnCalls()[0]).toEqual([
+        "pull",
+        "/sdcard/auto-mobile-test.mp4",
+        outputPath,
+      ]);
+      // The /sdcard temp file is removed afterwards.
+      expect(fakeClient.wasSpawned("rm /sdcard/auto-mobile-test.mp4")).toBe(true);
+      expect(result.sizeBytes).toBe(4096);
+      expect(result.recordingId).toBe("test-stop-sequence");
     });
 
-    test("does not clamp when maxThroughputMbps is higher", () => {
-      const config = {
-        targetBitrateKbps: 1000,
-        maxThroughputMbps: 10, // 10 Mbps = 10000 Kbps
-      };
+    test("still removes the /sdcard temp file when the pull itself fails", async () => {
+      const fakeFactory = new FakeAdbClientFactory();
+      const fakeClient = fakeFactory.getFakeClient();
+      fakeClient.setSpawnExit("pull", 1); // adb pull fails
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
 
-      const clampedBitrate = (backend as any).clampBitrateKbps?.(config) ??
-        Math.min(config.targetBitrateKbps, config.maxThroughputMbps * 1000);
+      const backend = new PlatformVideoCaptureBackend(fakeFactory, fakeTimer);
+      const fakeProcess = new FakeChildProcess();
+      fakeProcess.exitCode = 0;
+      const handle = buildAndroidStopHandle(path.join(tempDir, "out.mp4"), fakeProcess);
 
-      expect(clampedBitrate).toBe(1000);
-    });
+      await expect(backend.stop(handle)).rejects.toThrow(/adb pull failed/);
 
-    test("handles zero maxThroughputMbps", () => {
-      const config = {
-        targetBitrateKbps: 1000,
-        maxThroughputMbps: 0,
-      };
-
-      const clampedBitrate = (backend as any).clampBitrateKbps?.(config) ??
-        config.targetBitrateKbps;
-
-      expect(clampedBitrate).toBe(1000);
+      // The finally block runs the cleanup even though the pull rejected.
+      expect(fakeClient.wasSpawned("rm /sdcard/auto-mobile-test.mp4")).toBe(true);
     });
   });
 
-  describe("Android Time Limit Logic", () => {
-    test("respects 180 second maximum", () => {
-      // Test the time limit resolution logic
-      const resolveTimeLimit = (backend as any).resolveAndroidTimeLimit?.bind(backend) ??
-        ((maxDuration?: number) => {
-          const ANDROID_SCREENRECORD_MAX_SECONDS = 180;
-          if (maxDuration && maxDuration > 0) {
-            return Math.min(maxDuration, ANDROID_SCREENRECORD_MAX_SECONDS);
-          }
-          return ANDROID_SCREENRECORD_MAX_SECONDS;
-        });
-
-      expect(resolveTimeLimit(300)).toBe(180);
-      expect(resolveTimeLimit(60)).toBe(60);
-      expect(resolveTimeLimit(180)).toBe(180);
-    });
-
-    test("defaults to 180 seconds when not specified", () => {
-      const resolveTimeLimit = (backend as any).resolveAndroidTimeLimit?.bind(backend) ??
-        ((maxDuration?: number) => {
-          const ANDROID_SCREENRECORD_MAX_SECONDS = 180;
-          if (maxDuration && maxDuration > 0) {
-            return Math.min(maxDuration, ANDROID_SCREENRECORD_MAX_SECONDS);
-          }
-          return ANDROID_SCREENRECORD_MAX_SECONDS;
-        });
-
-      expect(resolveTimeLimit(undefined)).toBe(180);
-      expect(resolveTimeLimit(0)).toBe(180);
-    });
-  });
-});
-
-describe("PlatformVideoCaptureBackend - Integration Tests", () => {
-  let tempDir: string;
-  let androidDevice: BootedDevice;
-  let iosDevice: BootedDevice;
-
-  beforeEach(async () => {
-    tempDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), "platform-video-integration-"));
-
-    androidDevice = {
-      platform: "android",
-      deviceId: "test-emulator",
-      name: "Test Android Emulator",
-    };
-
-    iosDevice = {
-      platform: "ios",
-      deviceId: "test-simulator",
-      name: "Test iOS Simulator",
-    };
-  });
-
-  afterEach(async () => {
-    await fsPromises.rm(tempDir, { recursive: true, force: true });
-  });
-
-  describe("Configuration Structure", () => {
-    test("Android config includes required fields", () => {
-      const config: VideoCaptureConfig = {
-        recordingId: "test-android",
-        outputDirectory: tempDir,
-        outputPath: path.join(tempDir, "android.mp4"),
-        fileName: "android.mp4",
+  describe("clampBitrateKbps", () => {
+    function cfg(targetBitrateKbps: number, maxThroughputMbps: number): VideoCaptureConfig {
+      return {
+        recordingId: "clamp",
+        outputDirectory: "/tmp",
+        outputPath: "/tmp/clamp.mp4",
+        fileName: "clamp.mp4",
         startedAt: new Date().toISOString(),
         qualityPreset: "low",
-        targetBitrateKbps: 1000,
-        maxThroughputMbps: 5,
+        targetBitrateKbps,
+        maxThroughputMbps,
         fps: 15,
         maxArchiveSizeMb: 2048,
         format: "mp4",
-        device: androidDevice,
       };
+    }
 
-      expect(config.device?.platform).toBe("android");
-      expect(config.targetBitrateKbps).toBe(1000);
-      expect(config.format).toBe("mp4");
-    });
-
-    test("iOS config includes required fields", () => {
-      const config: VideoCaptureConfig = {
-        recordingId: "test-ios",
-        outputDirectory: tempDir,
-        outputPath: path.join(tempDir, "ios.mp4"),
-        fileName: "ios.mp4",
-        startedAt: new Date().toISOString(),
-        qualityPreset: "low",
-        targetBitrateKbps: 1000,
-        maxThroughputMbps: 5,
-        fps: 15,
-        maxArchiveSizeMb: 2048,
-        format: "mp4",
-        device: iosDevice,
-      };
-
-      expect(config.device?.platform).toBe("ios");
-      expect(config.outputPath).toContain("ios.mp4");
-    });
-
-    test("Config with resolution override", () => {
-      const config: VideoCaptureConfig = {
-        recordingId: "test-resolution",
-        outputDirectory: tempDir,
-        outputPath: path.join(tempDir, "video.mp4"),
-        fileName: "video.mp4",
-        startedAt: new Date().toISOString(),
-        qualityPreset: "low",
-        targetBitrateKbps: 1000,
-        maxThroughputMbps: 5,
-        fps: 15,
-        maxArchiveSizeMb: 2048,
-        format: "mp4",
-        device: androidDevice,
-        resolution: { width: 1280, height: 720 },
-      };
-
-      expect(config.resolution).toBeDefined();
-      expect(config.resolution?.width).toBe(1280);
-      expect(config.resolution?.height).toBe(720);
-    });
-
-    test("Config with maxDurationSeconds", () => {
-      const config: VideoCaptureConfig = {
-        recordingId: "test-duration",
-        outputDirectory: tempDir,
-        outputPath: path.join(tempDir, "video.mp4"),
-        fileName: "video.mp4",
-        startedAt: new Date().toISOString(),
-        qualityPreset: "low",
-        targetBitrateKbps: 1000,
-        maxThroughputMbps: 5,
-        fps: 15,
-        maxArchiveSizeMb: 2048,
-        format: "mp4",
-        device: androidDevice,
-        maxDurationSeconds: 60,
-      };
-
-      expect(config.maxDurationSeconds).toBe(60);
-    });
+    // The throughput cap is `floor(maxThroughputMbps * 1000)` Kbps; a zero cap is
+    // treated as "no cap" and the target passes through untouched.
+    test.each([
+      [5000, 2, 2000, "caps the target to the lower throughput ceiling"],
+      [1000, 10, 1000, "leaves the target alone when the ceiling is higher"],
+      [1000, 0, 1000, "treats a zero throughput as no cap"],
+      [1000, -5, 1000, "treats a negative throughput as no cap"],
+      [5000, 1, 1000, "caps at an exact 1 Mbps ceiling"],
+      // LIVE DEFECT: floor(0.0005 * 1000) = 0 ⇒ falsy ⇒ cap silently disabled,
+      // so the full 10000 Kbps target ships despite a 0.5 Kbps throughput budget.
+      [10000, 0.0005, 10000, "sub-1-Kbps throughput floors to 0 and disables the cap"],
+    ])(
+      "maps target=%p / maxMbps=%p to %p (%s)",
+      (targetBitrateKbps, maxThroughputMbps, expected, _why) => {
+        expect(clampBitrateKbps(cfg(targetBitrateKbps, maxThroughputMbps))).toBe(expected);
+      }
+    );
   });
 
-  describe("Quality Presets", () => {
-    test("low quality preset", () => {
-      const config: VideoCaptureConfig = {
-        recordingId: "test-low",
-        outputDirectory: tempDir,
-        outputPath: path.join(tempDir, "low.mp4"),
-        fileName: "low.mp4",
-        startedAt: new Date().toISOString(),
-        qualityPreset: "low",
-        targetBitrateKbps: 1000,
-        maxThroughputMbps: 5,
-        fps: 15,
-        maxArchiveSizeMb: 2048,
-        format: "mp4",
-        device: androidDevice,
-      };
+  describe("resolveAndroidTimeLimit", () => {
+    // Bind the real private method directly: if it is renamed the bind throws,
+    // rather than a self-healing `?? reimplementation` fallback keeping the test
+    // green against a method that no longer exists.
+    function resolve(backendInstance: PlatformVideoCaptureBackend, maxDuration?: number): number {
+      return (backendInstance as unknown as {
+        resolveAndroidTimeLimit(maxDuration?: number): number;
+      }).resolveAndroidTimeLimit(maxDuration);
+    }
 
-      expect(config.qualityPreset).toBe("low");
-      expect(config.targetBitrateKbps).toBe(1000);
-      expect(config.fps).toBe(15);
-    });
-
-    test("medium quality preset", () => {
-      const config: VideoCaptureConfig = {
-        recordingId: "test-medium",
-        outputDirectory: tempDir,
-        outputPath: path.join(tempDir, "medium.mp4"),
-        fileName: "medium.mp4",
-        startedAt: new Date().toISOString(),
-        qualityPreset: "medium",
-        targetBitrateKbps: 2500,
-        maxThroughputMbps: 10,
-        fps: 30,
-        maxArchiveSizeMb: 2048,
-        format: "mp4",
-        device: androidDevice,
-      };
-
-      expect(config.qualityPreset).toBe("medium");
-      expect(config.targetBitrateKbps).toBe(2500);
-      expect(config.fps).toBe(30);
-    });
-
-    test("high quality preset", () => {
-      const config: VideoCaptureConfig = {
-        recordingId: "test-high",
-        outputDirectory: tempDir,
-        outputPath: path.join(tempDir, "high.mp4"),
-        fileName: "high.mp4",
-        startedAt: new Date().toISOString(),
-        qualityPreset: "high",
-        targetBitrateKbps: 5000,
-        maxThroughputMbps: 20,
-        fps: 60,
-        maxArchiveSizeMb: 2048,
-        format: "mp4",
-        device: androidDevice,
-      };
-
-      expect(config.qualityPreset).toBe("high");
-      expect(config.targetBitrateKbps).toBe(5000);
-      expect(config.fps).toBe(60);
+    test.each([
+      [300, 180, "caps above the 180s screenrecord maximum"],
+      [60, 60, "passes a sub-maximum duration through"],
+      [180, 180, "keeps the exact maximum"],
+      [undefined, 180, "defaults to the maximum when unspecified"],
+      [0, 180, "treats zero as unspecified"],
+    ])("resolves %p to %p seconds (%s)", (input, expected, _why) => {
+      expect(resolve(backend, input)).toBe(expected);
     });
   });
 });

--- a/test/features/video/VideoRecorderService.test.ts
+++ b/test/features/video/VideoRecorderService.test.ts
@@ -55,6 +55,14 @@ describe("parseVideoRecordingConfig", () => {
     expect(parseVideoRecordingConfig({ fps: 29.7 }).fps).toBe(30);
   });
 
+  // LIVE DEFECT (characterization): fps is validated as > 0 BEFORE being rounded,
+  // so a positive sub-0.5 fps passes the guard and then rounds to 0 — producing a
+  // 0-fps recording rather than falling back to the default. Pinned so a fix that
+  // clamps this to the default is a deliberate, visible change.
+  test("a positive sub-0.5 fps rounds to a broken 0 fps (known defect)", () => {
+    expect(parseVideoRecordingConfig({ fps: 0.4 }).fps).toBe(0);
+  });
+
   test("accepts valid format", () => {
     expect(parseVideoRecordingConfig({ format: "mp4" }).format).toBe("mp4");
   });
@@ -69,6 +77,17 @@ describe("parseVideoRecordingConfig", () => {
       maxThroughputMbps: 2,
     });
     expect(config.targetBitrateKbps).toBe(2000);
+  });
+
+  // LIVE DEFECT (characterization): the cap is floor(maxThroughputMbps * 1000)
+  // Kbps; a throughput below 0.001 Mbps floors to 0, is treated as "no cap", and
+  // the full requested bitrate ships uncapped. Pinned to make a fix visible.
+  test("a sub-1-Kbps throughput silently disables the cap (known defect)", () => {
+    const config = parseVideoRecordingConfig({
+      targetBitrateKbps: 10000,
+      maxThroughputMbps: 0.0005,
+    });
+    expect(config.targetBitrateKbps).toBe(10000);
   });
 
   test("accepts valid resolution", () => {
@@ -172,6 +191,9 @@ describe("VideoRecorderService", () => {
       expect(metadata.sizeBytes).toBe(12345);
       expect(metadata.codec).toBe("h264");
       expect(metadata.format).toBe("mp4");
+      // The service must hand back the exact handle the backend produced at
+      // start — not a look-alike rebuilt from the recordingId.
+      expect(backend.stopCalls[0]).toBe(backend.startResults[0]);
     });
 
     test("throws for unknown recording id", async () => {

--- a/test/features/webrtc/ReconnectController.test.ts
+++ b/test/features/webrtc/ReconnectController.test.ts
@@ -196,6 +196,35 @@ describe("ReconnectController", () => {
 
     expect(controller.getState()).toBe("stopped");
   });
+
+  test("the default reconnect backoff climbs 1s→2s→4s… and caps at 30s", async () => {
+    // No injected backoff: exercise the constructor default (exponential
+    // 1s→30s, ×2). Drive the ladder through notifyConnectionLost() since start()
+    // deliberately does not enter the retry loop.
+    const timer = new FakeTimer();
+    const controller = new ReconnectController({
+      attempt: async () => {
+        throw new Error("still down");
+      },
+      timer,
+    });
+
+    const rungs: number[] = [];
+    controller.notifyConnectionLost();
+    await drain();
+    rungs.push(timer.getPendingTimeouts()[0]);
+
+    // Each failed attempt schedules the next rung; walk seven rungs to see the
+    // 30s ceiling engage (attempt 6 would be 32s uncapped).
+    for (let i = 0; i < 6; i++) {
+      const delay = timer.getPendingTimeouts()[0];
+      timer.advanceTime(delay);
+      await drain();
+      rungs.push(timer.getPendingTimeouts()[0]);
+    }
+
+    expect(rungs).toEqual([1000, 2000, 4000, 8000, 16000, 30000, 30000]);
+  });
 });
 
 /** Let queued microtasks (async attempt bodies) settle after advancing time. */

--- a/test/features/webrtc/RtpPcmuTrackWriter.test.ts
+++ b/test/features/webrtc/RtpPcmuTrackWriter.test.ts
@@ -37,6 +37,43 @@ describe("RtpPcmuTrackWriter", () => {
     expect(writer.stats).toEqual({ packetsWritten: 3, samplesWritten: 5 });
   });
 
+  // Pin the actual encoded mu-law byte per sample, not just the packet count.
+  // A silent regression in linear16ToMuLaw (wrong bias, exponent, or sign) would
+  // otherwise ship undetected. Values verified against the G.711 mu-law encoder.
+  test.each([
+    [0, 0xff],
+    [1, 0xff],
+    [-1, 0x7f],
+    [32767, 0x80],
+    [-32768, 0x00],
+    [8031, 0xa0],
+    [-8031, 0x20],
+  ])("encodes PCM16 sample %p to mu-law byte", (sample, expectedByte) => {
+    const packets: RtpPacket[] = [];
+    const writer = new RtpPcmuTrackWriter({ sink: { writeRtp: packet => packets.push(packet) }, ssrc: 1 });
+    const chunk = Buffer.alloc(2);
+    chunk.writeInt16LE(sample, 0);
+
+    writer.writePcm16Chunk(chunk);
+
+    expect(packets).toHaveLength(1);
+    expect(packets[0].payload[0]).toBe(expectedByte);
+  });
+
+  // A zero / negative / non-finite MTU would make the packetization loop never
+  // advance and wedge the daemon (issue #4170). The guard rejects them at
+  // construction. A small positive MTU (e.g. 2) stays legitimate — one PCMU
+  // sample is a single byte — and is exercised above.
+  test.each([
+    [0, "zero MTU cannot advance the payload loop"],
+    [-1, "negative MTU cannot advance the payload loop"],
+    [Number.NaN, "non-finite MTU cannot advance the payload loop"],
+  ])("rejects a non-advancing mtu %p at construction", (mtu, _why) => {
+    expect(
+      () => new RtpPcmuTrackWriter({ sink: { writeRtp: () => undefined }, ssrc: 1, mtu })
+    ).toThrow(/MTU/i);
+  });
+
   test("preserves a PCM16 sample split across arbitrary chunk boundaries", () => {
     const packets: RtpPacket[] = [];
     const writer = new RtpPcmuTrackWriter({ sink: { writeRtp: packet => packets.push(packet) }, ssrc: 1 });

--- a/test/features/webrtc/VideoServerStreamParser.test.ts
+++ b/test/features/webrtc/VideoServerStreamParser.test.ts
@@ -168,4 +168,50 @@ describe("VideoServerStreamParser", () => {
       [VIDEO_SERVER_TRACK_ID_VIDEO, VIDEO_SERVER_CODEC_ID_H264, 20],
     ]);
   });
+
+  test("skips a mux packet for an unknown track yet keeps parsing later packets", () => {
+    // The buffer advances by the packet size BEFORE the unknown-track `continue`.
+    // A refactor that skipped the advance would spin forever on the unknown
+    // packet; here the following known-track packet must still be delivered.
+    const { parser, packets } = collect();
+    parser.push(Buffer.concat([
+      muxHeader(),
+      muxPacket(99, Buffer.from([0xde, 0xad]), 0n, 5),
+      muxPacket(VIDEO_SERVER_TRACK_ID_VIDEO, Buffer.from([0, 0, 0, 1, 0x65]), FLAG_KEY_FRAME, 20),
+    ]));
+
+    expect(packets.map(packet => packet.trackId)).toEqual([VIDEO_SERVER_TRACK_ID_VIDEO]);
+    expect(packets[0].ptsUs).toBe(20);
+  });
+
+  test("emits a zero-size video packet without stalling the parser", () => {
+    const { parser, packets } = collect();
+    parser.push(Buffer.concat([
+      streamHeader(100, 200),
+      packet(Buffer.alloc(0), FLAG_CONFIG, 7),
+      packet(Buffer.from([0xaa]), 0n, 8),
+    ]));
+
+    expect(packets).toHaveLength(2);
+    expect(packets[0].data).toHaveLength(0);
+    expect(packets[0].ptsUs).toBe(7);
+    expect(packets[1].ptsUs).toBe(8);
+  });
+
+  test("a mux header declaring zero tracks yields no header and drops later packets", () => {
+    // Zero-track amux header: 12-byte stream header, trackCount 0, no track rows.
+    const zeroTrackHeader = Buffer.alloc(12);
+    zeroTrackHeader.writeUInt32BE(VIDEO_SERVER_CODEC_ID_AMUX, 0);
+    zeroTrackHeader.writeUInt32BE(0, 4);
+    zeroTrackHeader.writeUInt32BE(0, 8); // trackCount = 0
+
+    const { parser, headers, packets } = collect();
+    parser.push(Buffer.concat([
+      zeroTrackHeader,
+      muxPacket(VIDEO_SERVER_TRACK_ID_VIDEO, Buffer.from([0xaa]), 0n, 1),
+    ]));
+
+    expect(headers).toEqual([]);
+    expect(packets).toEqual([]);
+  });
 });

--- a/test/features/webrtc/WebRtcPublisher.test.ts
+++ b/test/features/webrtc/WebRtcPublisher.test.ts
@@ -274,13 +274,22 @@ describe("WebRtcPublisher WHIP answer validation", () => {
 });
 
 describe("WebRtcPublisher.notifySourceFailed", () => {
-  test("is a no-op after close (does not throw)", async () => {
+  test("suppresses the source-failure callback and reconnect after close", async () => {
+    // After stop() a late capture-source failure must not trigger recovery — it
+    // must neither invoke onSourceFailure nor kick the reconnect controller,
+    // otherwise a torn-down publisher resurrects itself.
+    const failures: Array<Error | undefined> = [];
     const publisher = new WebRtcPublisher(
       { streamId: "s", whipEndpoint: "https://coord/whip" },
-      { createWhipClient: () => ({}) as unknown as WhipClient }
+      {
+        createWhipClient: () => ({}) as unknown as WhipClient,
+        onSourceFailure: error => failures.push(error),
+      }
     );
     await publisher.stop();
+
     expect(() => publisher.notifySourceFailed()).not.toThrow();
+    expect(failures).toHaveLength(0);
   });
 
   test("routes a synchronously throwing connected hook through recovery", async () => {

--- a/test/features/webrtc/WhipClient.test.ts
+++ b/test/features/webrtc/WhipClient.test.ts
@@ -147,6 +147,36 @@ describe("WhipClient.publish", () => {
     await Promise.resolve();
   });
 
+  test("omits the Authorization header entirely when no bearer token is configured", async () => {
+    // Without a token the header must be absent — not `Bearer undefined`, which
+    // an unauthenticated ingest would reject or, worse, log.
+    const { fetchImpl, calls } = fakeFetch(() => ({ status: 201, body: "answer", location: "/r/1" }));
+    const client = new WhipClient({ endpoint: "https://coord.example.com/whip", fetchImpl });
+
+    await client.publish("offer");
+
+    expect("Authorization" in calls[0].headers).toBe(false);
+  });
+
+  test("still surfaces the status when the error response body cannot be read", async () => {
+    // safeText swallows a failed body read and returns "" so the actionable
+    // error still carries the status code instead of propagating the read error.
+    const client = new WhipClient({
+      endpoint: "https://coord.example.com/whip",
+      fetchImpl: async () => ({
+        status: 503,
+        ok: false,
+        headers: { get: () => null },
+        text: async () => {
+          throw new Error("stream broken");
+        },
+      }),
+    });
+
+    await expect(client.publish("offer")).rejects.toThrow(/got 503/);
+    await expect(client.publish("offer")).rejects.not.toThrow(/stream broken/);
+  });
+
   test("preserves an already-aborted caller signal", async () => {
     let receivedAbortedSignal = false;
     const client = new WhipClient({

--- a/test/features/webrtc/h264.test.ts
+++ b/test/features/webrtc/h264.test.ts
@@ -238,6 +238,31 @@ describe("packetizeNalUnit", () => {
   test("empty NAL yields no packets", () => {
     expect(packetizeNalUnit(Buffer.alloc(0))).toEqual([]);
   });
+
+  // A non-advancing MTU would make the FU-A fragment loop spin forever on a
+  // NAL larger than the MTU, wedging the daemon (issue #4170). The guard must
+  // reject any MTU that leaves no room for a payload byte past the 2-byte
+  // FU-A header, and any non-finite MTU that would silently truncate the NAL.
+  test.each([
+    [2, "MTU equal to the FU-A header leaves zero payload room"],
+    [1, "MTU below the FU-A header cannot advance"],
+    [0, "zero MTU cannot advance"],
+    [-1, "negative MTU cannot advance"],
+    [Number.NaN, "NaN MTU would truncate the NAL to an empty fragment"],
+  ])(
+    "throws instead of looping when a NAL exceeds a non-advancing mtu %p",
+    (mtu, _why) => {
+      const nal = makeNal(NAL_TYPE_IDR, 40);
+      expect(() => packetizeNalUnit(nal, mtu)).toThrow(/MTU/);
+    }
+  );
+
+  test("an infinite mtu sends the whole NAL as one packet (not a defect)", () => {
+    const nal = makeNal(NAL_TYPE_IDR, 40);
+    const packets = packetizeNalUnit(nal, Number.POSITIVE_INFINITY);
+    expect(packets).toHaveLength(1);
+    expect(packets[0].equals(nal)).toBe(true);
+  });
 });
 
 describe("packetizeAccessUnit", () => {

--- a/test/server/videoRecordingResources.test.ts
+++ b/test/server/videoRecordingResources.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildVideoResourceContent,
+  getLatestVideoRecording,
+  getVideoArchiveItem,
+  getVideoArchiveList,
+  type VideoRecordingResourceStore,
+} from "../../src/server/videoRecordingResources";
+import {
+  buildVideoArchiveItemUri,
+  VIDEO_RESOURCE_URIS,
+} from "../../src/server/videoRecordingResourceUris";
+import type { VideoRecordingMetadata } from "../../src/models";
+
+function metadata(overrides: Partial<VideoRecordingMetadata> = {}): VideoRecordingMetadata {
+  return {
+    recordingId: "rec-1",
+    fileName: "rec-1.mp4",
+    filePath: "/tmp/rec-1.mp4",
+    format: "mp4",
+    sizeBytes: 1024,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    startedAt: "2026-01-01T00:00:00.000Z",
+    lastAccessedAt: "2026-01-01T00:00:00.000Z",
+    config: {} as VideoRecordingMetadata["config"],
+    ...overrides,
+  };
+}
+
+function store(overrides: Partial<VideoRecordingResourceStore> = {}): VideoRecordingResourceStore {
+  return {
+    getLatest: async () => null,
+    getById: async () => null,
+    list: async () => [],
+    readFile: async () => Buffer.from("video-bytes"),
+    ...overrides,
+  };
+}
+
+function parse(text: string | undefined): Record<string, unknown> {
+  return JSON.parse(text ?? "{}");
+}
+
+describe("getLatestVideoRecording", () => {
+  test("reports that no recordings are available when the store is empty", async () => {
+    const content = await getLatestVideoRecording(store({ getLatest: async () => null }));
+    expect(content.uri).toBe(VIDEO_RESOURCE_URIS.LATEST);
+    expect(parse(content.text).error).toContain("No video recordings available");
+  });
+
+  test("returns the metadata and base64 video for the latest recording", async () => {
+    const latest = metadata({ recordingId: "latest-1" });
+    const content = await getLatestVideoRecording(
+      store({
+        getLatest: async () => latest,
+        getById: async () => latest,
+        readFile: async () => Buffer.from("abc"),
+      })
+    );
+    expect(content.mimeType).toBe("video/mp4");
+    expect(content.blob).toBe(Buffer.from("abc").toString("base64"));
+    expect((parse(content.text).metadata as VideoRecordingMetadata).recordingId).toBe("latest-1");
+  });
+});
+
+describe("getVideoArchiveList", () => {
+  test("returns an empty archive with a zero count when there are no recordings", async () => {
+    const content = await getVideoArchiveList(store({ list: async () => [] }));
+    const body = parse(content.text);
+    expect(content.uri).toBe(VIDEO_RESOURCE_URIS.ARCHIVE);
+    expect(body.count).toBe(0);
+    expect(body.recordings).toEqual([]);
+  });
+
+  test("reports the count of archived recordings", async () => {
+    const content = await getVideoArchiveList(
+      store({ list: async () => [metadata({ recordingId: "a" }), metadata({ recordingId: "b" })] })
+    );
+    expect(parse(content.text).count).toBe(2);
+  });
+});
+
+describe("getVideoArchiveItem", () => {
+  test("requires a recording ID", async () => {
+    const content = await getVideoArchiveItem({}, store());
+    expect(parse(content.text).error).toBe("Recording ID is required.");
+  });
+
+  test("reports a not-found error for an unknown recording ID", async () => {
+    const content = await getVideoArchiveItem({ recordingId: "ghost" }, store({ getById: async () => null }));
+    expect(content.uri).toBe(buildVideoArchiveItemUri("ghost"));
+    expect(parse(content.text).error).toBe("Recording not found: ghost");
+  });
+
+  test("returns content for a known recording ID", async () => {
+    const content = await getVideoArchiveItem(
+      { recordingId: "rec-1" },
+      store({ getById: async () => metadata(), readFile: async () => Buffer.from("xy") })
+    );
+    expect(content.blob).toBe(Buffer.from("xy").toString("base64"));
+  });
+});
+
+describe("buildVideoResourceContent", () => {
+  test("reports a missing-file error when the metadata has no file path", async () => {
+    const content = await buildVideoResourceContent(
+      metadata({ filePath: "", recordingId: "no-file" }),
+      VIDEO_RESOURCE_URIS.LATEST,
+      store()
+    );
+    expect(content.mimeType).toBe("application/json");
+    expect(parse(content.text).error).toBe("Missing file path for recording no-file");
+    expect(content.blob).toBeUndefined();
+  });
+
+  test("reports a read error when the video file cannot be read", async () => {
+    const content = await buildVideoResourceContent(
+      metadata(),
+      VIDEO_RESOURCE_URIS.LATEST,
+      store({
+        readFile: async () => {
+          throw new Error("ENOENT");
+        },
+      })
+    );
+    expect(content.mimeType).toBe("application/json");
+    expect(parse(content.text).error).toContain("Failed to read video data");
+    expect(content.blob).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Milestone 32 (Unit Test Quality Audit), slice **media**: 27 verified test-quality findings burned down, each mutation-verified red-green. The trickiest slice (many raw proposals had wrong APIs; the critic's corrections were applied and every API verified against source). Several **surgical `src` fixes** the audit surfaced, each pinned by a test that reds on revert:

- **`h264.packetizeNalUnit` + `RtpPcmuTrackWriter`** reject a non-advancing / non-finite MTU — an `mtu <= FU-A-header` / `<= 0` previously **infinite-looped and wedged the daemon**. `Infinity` still returns one packet via the single-packet fast path; legit small audio MTUs stay legal.
- **`PlatformVideoCaptureBackend`**: disarm the graceful-exit timer via `this.timer.clearTimeout` (was global `clearTimeout` → leaked a 10s SIGINT callback); wrap the pull in `try/finally` so the `/sdcard` temp is always removed on a failed pull; export `clampBitrateKbps`.
- Testability seams: `FfmpegVideoProcessingBackend` `platformProvider`, `DualTrackRecorder.resolveSwipeDirection` export, `videoRecordingResources` injectable store + exported handlers.

Test-side: `FakeAdbProcess` + `FakeAdbClient.spawn/execute`; `stop()` pull/cleanup/size + kill ladder; `FrameDecoder` malformed-header resync; `AxisRanges`; `VideoServerStreamParser` edges; `ReconnectController` default backoff ladder; `WhipClient` absent-Auth/abort; copy-out-of-chunk invariant; `TouchFrameReconstructor` + mu-law + `GestureClassifier` + `IOSScreenCaptureHelper` fps + Hybrid routing tables; `McpCallRecorder` `INTERNAL_PARAMS`. REFUTED rows honored (P1/P5/P7 rebuilt from measured values; blocked deletes kept).

## Linked Issue

Closes #4170

## Validation

- [x] `bun test`: **10881 pass / 13 skip / 0 fail** across 816 files; MTU/timer tests under `--timeout 8000` finish in 100–300ms, no hangs
- [x] `bun run typecheck`: no new errors (206 baseline)
- [x] `bun run lint`: clean

## Follow-ups

- [ ] P1's two rows are **characterization** tests pinning known defects (sub-0.5 fps ⇒ 0-fps; sub-1-Kbps throughput ⇒ cap disabled) — a real fix in `parseVideoRecordingConfig`/`capBitrateKbps` should update those expectations deliberately.
- [ ] RENAME (19 cosmetic renames) deferred — high churn, low regression value.
