### PR TITLE
test(doctor): injectable check-runner seams + Node/Bun runtime coverage (#4185)

### DIFF
--- a/src/doctor/checks/automobile.ts
+++ b/src/doctor/checks/automobile.ts
@@ -61,6 +61,9 @@ export interface AutoMobileCheckDependencies {
   checkDaemonStatus?: () => Promise<CheckResult>;
   checkDaemonConnectivity?: () => Promise<CheckResult>;
   checkDaemonBuildIdentity?: () => Promise<CheckResult>;
+  /** Android-branch seams so unit tests avoid real CtrlProxy/ADB I/O. */
+  checkCtrlProxy?: () => Promise<CheckResult>;
+  checkWorkProfileAccessibility?: () => Promise<CheckResult>;
 }
 
 export interface ImageBackendDoctorLogger {
@@ -604,8 +607,8 @@ export async function runAutoMobileChecks(
       message: "Skipped for iOS-only doctor run",
     });
   } else {
-    results.push(await checkCtrlProxy());
-    results.push(await checkWorkProfileAccessibility());
+    results.push(await (dependencies.checkCtrlProxy ?? (() => checkCtrlProxy()))());
+    results.push(await (dependencies.checkWorkProfileAccessibility ?? (() => checkWorkProfileAccessibility()))());
   }
 
   return results;

--- a/src/doctor/checks/system.ts
+++ b/src/doctor/checks/system.ts
@@ -36,11 +36,24 @@ export function checkArchitecture(): CheckResult {
 }
 
 /**
- * Check runtime environment (Node.js or Bun)
+ * Detect the Bun version of the current runtime, or `undefined` under Node.js.
+ * Injected into {@link checkRuntime} so the Node arm is testable — `globalThis.Bun`
+ * is a non-configurable property and cannot be deleted or redefined in a test.
  */
-export function checkRuntime(): CheckResult {
-  // Check if running in Bun
-  const bunVersion = (globalThis as any).Bun?.version;
+export function detectBunVersion(): string | undefined {
+  return (globalThis as { Bun?: { version?: string } }).Bun?.version;
+}
+
+/**
+ * Check runtime environment (Node.js or Bun).
+ *
+ * @param detectVersion Injected runtime seam; defaults to the live detection.
+ *   Return `undefined` to exercise the Node.js arm and a version string for the
+ *   Bun arm. A function (not a value) is required because passing `undefined` to
+ *   a defaulted value parameter would re-trigger the default.
+ */
+export function checkRuntime(detectVersion: () => string | undefined = detectBunVersion): CheckResult {
+  const bunVersion = detectVersion();
 
   if (bunVersion) {
     return {

--- a/src/doctor/index.ts
+++ b/src/doctor/index.ts
@@ -58,15 +58,53 @@ function collectRecommendations(allChecks: CheckResult[]): string[] {
 }
 
 /**
+ * Injectable check-runner seams for {@link runDoctor}. Unit tests supply fakes so
+ * the orchestration (which sections run, summary math, version resolution) is
+ * exercised without real ADB / socket / iOS I/O. Defaults call the real runners.
+ */
+export interface RunDoctorDependencies {
+  runSystemChecks?: () => CheckResult[];
+  runAndroidChecks?: (options: DoctorOptions) => Promise<CheckResult[]>;
+  runIosChecks?: (options: DoctorOptions) => Promise<CheckResult[]>;
+  runAutoMobileChecks?: (options: DoctorOptions) => Promise<CheckResult[]>;
+}
+
+interface ResolvedDoctorRunners {
+  system: () => CheckResult[];
+  android: (options: DoctorOptions) => Promise<CheckResult[]>;
+  ios: (options: DoctorOptions) => Promise<CheckResult[]>;
+  autoMobile: (options: DoctorOptions) => Promise<CheckResult[]>;
+}
+
+/**
+ * Resolve each injectable check-runner seam to its live default. Extracted from
+ * {@link runDoctor} so the `??` fallbacks live here rather than inflating the
+ * orchestrator's cyclomatic complexity past the ratchet.
+ */
+function resolveDoctorRunners(dependencies: RunDoctorDependencies): ResolvedDoctorRunners {
+  return {
+    system: dependencies.runSystemChecks ?? runSystemChecks,
+    android: dependencies.runAndroidChecks ?? runAndroidChecks,
+    ios: dependencies.runIosChecks ?? runIosChecks,
+    autoMobile: dependencies.runAutoMobileChecks ?? runAutoMobileChecks,
+  };
+}
+
+/**
  * Run the doctor diagnostic tool
  */
 export async function runDoctor(
-  options: DoctorOptions = {}
+  options: DoctorOptions = {},
+  dependencies: RunDoctorDependencies = {}
 ): Promise<DoctorReport> {
   const allChecks: CheckResult[] = [];
 
+  // Resolve injectable seams to their live defaults once (keeps the `??`
+  // fallbacks out of this function's complexity budget).
+  const runners = resolveDoctorRunners(dependencies);
+
   // Always run system checks
-  const systemChecks = runSystemChecks();
+  const systemChecks = runners.system();
   allChecks.push(...systemChecks);
 
   // Determine which platform checks to run
@@ -76,19 +114,19 @@ export async function runDoctor(
   // Run Android checks if applicable
   let androidChecks: CheckResult[] | undefined;
   if (runAndroid) {
-    androidChecks = await runAndroidChecks(options);
+    androidChecks = await runners.android(options);
     allChecks.push(...androidChecks);
   }
 
   // Run iOS checks if applicable
   let iosChecks: CheckResult[] | undefined;
   if (runIos) {
-    iosChecks = await runIosChecks(options);
+    iosChecks = await runners.ios(options);
     allChecks.push(...iosChecks);
   }
 
   // Always run AutoMobile checks
-  const autoMobileChecks = await runAutoMobileChecks(options);
+  const autoMobileChecks = await runners.autoMobile(options);
   allChecks.push(...autoMobileChecks);
 
   // Calculate summary and recommendations

--- a/test/doctor/automobile.test.ts
+++ b/test/doctor/automobile.test.ts
@@ -632,4 +632,47 @@ describe("runAutoMobileChecks", () => {
     expect(imageBackend?.status).toBe("pass");
     expect(imageBackend?.message).toBe("active=sharp; sharp=loaded");
   });
+
+  const androidStubChecks = {
+    ...stubChecks,
+    checkCtrlProxy: async () => ({
+      name: "CtrlProxy",
+      status: "pass" as const,
+      message: "platform=android; device=emulator-5554",
+    }),
+    checkWorkProfileAccessibility: async () => ({
+      name: "Work Profile Accessibility",
+      status: "warn" as const,
+      message: "Work profile detected",
+    }),
+  };
+
+  test("runs the Android CtrlProxy and work-profile checks for an Android run", async () => {
+    const results = await runAutoMobileChecks({ android: true }, androidStubChecks);
+
+    const ctrlProxy = results.find(result => result.name === "CtrlProxy");
+    const workProfile = results.find(result => result.name === "Work Profile Accessibility");
+
+    expect(ctrlProxy?.status).toBe("pass");
+    expect(ctrlProxy?.message).toBe("platform=android; device=emulator-5554");
+    expect(workProfile?.status).toBe("warn");
+    expect(workProfile?.message).toBe("Work profile detected");
+  });
+
+  test("does not run the Android checks during an iOS-only run", async () => {
+    let androidRan = false;
+    const results = await runAutoMobileChecks(
+      { ios: true },
+      {
+        ...androidStubChecks,
+        checkCtrlProxy: async () => {
+          androidRan = true;
+          return { name: "CtrlProxy", status: "pass" as const, message: "should not run" };
+        },
+      }
+    );
+
+    expect(androidRan).toBe(false);
+    expect(results.find(result => result.name === "CtrlProxy")?.status).toBe("skip");
+  });
 });

--- a/test/doctor/index.test.ts
+++ b/test/doctor/index.test.ts
@@ -402,22 +402,46 @@ describe("formatJsonOutput", () => {
 });
 
 describe("runDoctor", () => {
-  test("explicit iOS doctor on non-darwin returns skipped iOS checks promptly", async () => {
-    await withProcessPlatform("linux", async () => {
-      const startedAt = Date.now();
-      const report = await runDoctor({ ios: true });
+  // Deterministic, I/O-free seams. The real runners shell out to ADB, sockets
+  // and simctl; injecting fakes lets us assert orchestration (section selection,
+  // summary math, version resolution) without real I/O or a wall-clock budget.
+  const fakeDeps = () => ({
+    runSystemChecks: () => [makeCheck({ name: "Runtime", status: "pass" })],
+    runAndroidChecks: async () => [makeCheck({ name: "Android SDK", status: "pass" })],
+    runIosChecks: async () => [makeCheck({ name: "Xcode", status: "skip" })],
+    runAutoMobileChecks: async () => [makeCheck({ name: "AutoMobile Daemon", status: "warn" })],
+  });
 
-      expect(Date.now() - startedAt).toBeLessThan(5000);
+  test("runs android and autoMobile but not iOS for a default run on non-darwin", async () => {
+    await withProcessPlatform("linux", async () => {
+      const report = await runDoctor({}, fakeDeps());
+
+      expect(report.android?.checks.map(c => c.name)).toEqual(["Android SDK"]);
+      expect(report.ios).toBeUndefined();
+      expect(report.autoMobile.checks.map(c => c.name)).toEqual(["AutoMobile Daemon"]);
+    });
+  });
+
+  test("runs iOS and autoMobile but not android for an iOS-only run", async () => {
+    await withProcessPlatform("linux", async () => {
+      const report = await runDoctor({ ios: true }, fakeDeps());
+
       expect(report.platform).toBe("linux");
       expect(report.android).toBeUndefined();
-      expect(report.ios?.checks.length).toBeGreaterThan(0);
-      expect(report.ios?.checks.every(check => check.status === "skip")).toBe(true);
-      const imageBackend = report.autoMobile.checks.find(check => check.name === "Image Backend");
-      expect(imageBackend).toBeDefined();
-      expect(imageBackend?.message).toContain("active=sharp");
+      expect(report.ios?.checks.map(c => c.name)).toEqual(["Xcode"]);
+    });
+  });
+
+  test("summary.total counts every check across all rendered sections", async () => {
+    await withProcessPlatform("linux", async () => {
+      const report = await runDoctor({ ios: true }, fakeDeps());
+
       expect(report.summary.total).toBe(
         report.system.checks.length + (report.ios?.checks.length ?? 0) + report.autoMobile.checks.length
       );
+      expect(report.summary.passed).toBe(1);
+      expect(report.summary.warnings).toBe(1);
+      expect(report.summary.skipped).toBe(1);
     });
   });
 
@@ -426,7 +450,7 @@ describe("runDoctor", () => {
       const prev = process.env.AUTOMOBILE_VERSION;
       process.env.AUTOMOBILE_VERSION = "0.0.18";
       try {
-        const report = await runDoctor({ ios: true });
+        const report = await runDoctor({ ios: true }, fakeDeps());
         expect(report.version).toBe("0.0.18");
       } finally {
         if (prev === undefined) {

--- a/test/doctor/system.test.ts
+++ b/test/doctor/system.test.ts
@@ -25,20 +25,22 @@ describe("system doctor checks", () => {
     expect(result.message).toBe(process.arch);
   });
 
-  test("checkRuntime returns pass with Bun version when running in Bun", () => {
-    const result = checkRuntime();
+  test("checkRuntime reports the Bun runtime when a Bun version is present", () => {
+    const result = checkRuntime(() => "1.2.3");
 
     expect(result.name).toBe("Runtime");
     expect(result.status).toBe("pass");
-    // Tests run under Bun, so we expect Bun version
-    const bunVersion = (globalThis as any).Bun?.version;
-    if (bunVersion) {
-      expect(result.message).toBe(`Bun ${bunVersion}`);
-      expect(result.value).toBe(`bun@${bunVersion}`);
-    } else {
-      expect(result.message).toContain("Node.js");
-      expect(result.value).toContain("node@");
-    }
+    expect(result.message).toBe("Bun 1.2.3");
+    expect(result.value).toBe("bun@1.2.3");
+  });
+
+  test("checkRuntime reports the Node.js runtime when no Bun version is present", () => {
+    const result = checkRuntime(() => undefined);
+
+    expect(result.name).toBe("Runtime");
+    expect(result.status).toBe("pass");
+    expect(result.message).toBe(`Node.js ${process.version}`);
+    expect(result.value).toBe(`node@${process.version}`);
   });
 
   test("runSystemChecks returns all three checks", () => {


### PR DESCRIPTION
## What

Partial burn-down of the misc test-quality findings in [#4185](https://github.com/kaeawc/auto-mobile/issues/4185), focused on the `doctor` diagnostic tool. Behavior-preserving on prod paths — every new seam defaults to the live runner.

- **`doctor/index` `runDoctor`** — `RunDoctorDependencies` seam (system / android / ios / autoMobile runners), resolved once via `resolveDoctorRunners`, so the orchestration (section gating, summary math, version resolution) is unit-tested without real ADB / socket / iOS I/O. The resolver is extracted to keep `runDoctor` under the complexity ratchet.
- **`doctor/checks/system` `checkRuntime`** — `detectBunVersion` seam makes the Node.js arm testable (`globalThis.Bun` is non-configurable and can't be deleted in a test).
- **`doctor/checks/automobile`** — `checkCtrlProxy` / `checkWorkProfileAccessibility` DI seams so the Android branch avoids real CtrlProxy / ADB I/O.

163 doctor tests pass; full `typecheck` + `lint` green.

## Coverage note

Lands the verified findings completed so far; remaining [#4185](https://github.com/kaeawc/auto-mobile/issues/4185) findings tracked in a follow-up so the milestone burn-down stays green rather than blocked on one large slice.

Part of the Unit Test Quality Audit milestone.
