### PR TITLE
feat(desktop-core): surface device-control block reason in live layout view (#4531)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -1702,27 +1702,33 @@ fun AutoMobileContent(
               modifier = Modifier.align(Alignment.TopStart).padding(8.dp),
             )
 
-            // Why control is unavailable (issue #3490). The policy's reason is surfaced only when
-            // no interaction snapshot exists — while a post-input refresh retains one, clicks
-            // still actuate the device, so a "blocked" notice would contradict what the user
-            // experiences. The notice itself debounces, so the transient reasons that come and go
-            // during normal streaming never flicker into view.
-            DeviceControlBlockedNotice(
-              reason =
-                if (controlSnapshot == null) {
-                  (deviceControlDecision as? DeviceControlDecision.Blocked)?.reason
-                } else {
-                  null
-                },
-              modifier = Modifier.align(Alignment.BottomStart).padding(8.dp),
-            )
-
-            deviceControlTapError?.let { message ->
-              DeviceControlTapErrorBanner(
-                message = message,
-                onDismiss = { deviceControlTapError = null },
-                modifier = Modifier.align(Alignment.BottomCenter).padding(16.dp),
+            // Bottom notices share one Column so they stack instead of overlapping when both are
+            // visible (a lingering tap-error banner plus a block that outlasts the debounce).
+            Column(
+              modifier = Modifier.align(Alignment.BottomCenter).padding(16.dp),
+              horizontalAlignment = Alignment.CenterHorizontally,
+              verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+              // Why control is unavailable (issue #4531). The policy's reason is surfaced only
+              // when no interaction snapshot exists — while a post-input refresh retains one,
+              // clicks still actuate the device, so a "blocked" notice would contradict what the
+              // user experiences. The notice itself debounces, so the transient reasons that come
+              // and go during normal streaming never flicker into view.
+              DeviceControlBlockedNotice(
+                reason =
+                  if (controlSnapshot == null) {
+                    (deviceControlDecision as? DeviceControlDecision.Blocked)?.reason
+                  } else {
+                    null
+                  }
               )
+
+              deviceControlTapError?.let { message ->
+                DeviceControlTapErrorBanner(
+                  message = message,
+                  onDismiss = { deviceControlTapError = null },
+                )
+              }
             }
           }
         } else {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -99,6 +99,7 @@ import dev.jasonpearson.automobile.desktop.core.failures.McpFailuresDataSource
 import dev.jasonpearson.automobile.desktop.core.failures.StreamingFailuresDataSource
 import dev.jasonpearson.automobile.desktop.core.failures.TimeAggregation
 import dev.jasonpearson.automobile.desktop.core.layout.ConnectionStatus
+import dev.jasonpearson.automobile.desktop.core.layout.DeviceControlBlockedNotice
 import dev.jasonpearson.automobile.desktop.core.layout.DeviceControlTapErrorBanner
 import dev.jasonpearson.automobile.desktop.core.layout.DeviceScreenView
 import dev.jasonpearson.automobile.desktop.core.layout.ScreenshotMetadataOverlay
@@ -155,6 +156,7 @@ import dev.jasonpearson.automobile.desktop.core.video.VideoStreamClient
 import dev.jasonpearson.automobile.desktop.core.video.VideoStreamSource
 import dev.jasonpearson.automobile.desktop.core.video.VideoStreamState
 import dev.jasonpearson.automobile.desktop.core.video.toImageBitmap
+import dev.jasonpearson.automobile.desktop.domain.DeviceControlDecision
 import dev.jasonpearson.automobile.desktop.domain.DeviceControlInputs
 import dev.jasonpearson.automobile.desktop.domain.DeviceScreenControlMode
 import dev.jasonpearson.automobile.desktop.domain.LiveFrameFacts
@@ -1698,6 +1700,21 @@ fun AutoMobileContent(
               format = layoutInspectorState.screenshotFormat,
               captureSource = layoutInspectorState.screenshotCaptureSource,
               modifier = Modifier.align(Alignment.TopStart).padding(8.dp),
+            )
+
+            // Why control is unavailable (issue #3490). The policy's reason is surfaced only when
+            // no interaction snapshot exists — while a post-input refresh retains one, clicks
+            // still actuate the device, so a "blocked" notice would contradict what the user
+            // experiences. The notice itself debounces, so the transient reasons that come and go
+            // during normal streaming never flicker into view.
+            DeviceControlBlockedNotice(
+              reason =
+                if (controlSnapshot == null) {
+                  (deviceControlDecision as? DeviceControlDecision.Blocked)?.reason
+                } else {
+                  null
+                },
+              modifier = Modifier.align(Alignment.BottomStart).padding(8.dp),
             )
 
             deviceControlTapError?.let { message ->

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceControlBlockedNotice.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceControlBlockedNotice.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.jasonpearson.automobile.desktop.domain.DeviceControlBlockReason
@@ -28,7 +29,7 @@ internal const val DEVICE_CONTROL_BLOCK_NOTICE_HOLD_MS: Long = 1_500L
 
 /**
  * The user-facing explanation for [reason], or null for reasons that are a deliberate host
- * configuration rather than a condition the user can observe or wait out (issue #3490).
+ * configuration rather than a condition the user can observe or wait out (issue #4531).
  *
  * NotEnabled is null because the host opted out of device control entirely — the IDE plugin is
  * permanently inspector-only, and a notice there would be a constant fixture, not information.
@@ -59,7 +60,7 @@ internal fun deviceControlBlockReasonText(reason: DeviceControlBlockReason): Str
 
 /**
  * Small non-intrusive badge explaining why client device control is currently unavailable
- * (issue #3490). [DeviceControlPolicy][dev.jasonpearson.automobile.desktop.domain.DeviceControlPolicy]
+ * (issue #4531). [DeviceControlPolicy][dev.jasonpearson.automobile.desktop.domain.DeviceControlPolicy]
  * names exactly why control is blocked; without this the view silently falls back to inspector mode
  * and a click simply stops actuating the device with no explanation.
  *
@@ -75,15 +76,20 @@ fun DeviceControlBlockedNotice(
   holdMs: Long = DEVICE_CONTROL_BLOCK_NOTICE_HOLD_MS,
 ) {
   val text = reason?.let { deviceControlBlockReasonText(it) }
-  var held by remember { mutableStateOf(false) }
+  // Only text the hold effect has COMMITTED is ever rendered. Rendering `text` directly under a
+  // remembered `held` flag leaves a one-frame window on a reason A -> B change where B's text
+  // composes against A's still-true flag before the restarted effect resets it — B would flash
+  // for a frame and then wait out its hold. A cleared reason still hides immediately: the
+  // composition guard below checks the LIVE text, not the committed one.
+  var shownText by remember { mutableStateOf<String?>(null) }
   LaunchedEffect(text, holdMs) {
-    held = false
+    shownText = null
     if (text != null) {
       delay(holdMs)
-      held = true
+      shownText = text
     }
   }
-  if (text == null || !held) return
+  if (text == null || shownText != text) return
 
   Row(
     modifier =
@@ -96,6 +102,7 @@ fun DeviceControlBlockedNotice(
       color = Color.White.copy(alpha = 0.85f),
       fontSize = 10.sp,
       maxLines = 1,
+      overflow = TextOverflow.Ellipsis,
     )
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceControlBlockedNotice.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceControlBlockedNotice.kt
@@ -1,0 +1,101 @@
+package dev.jasonpearson.automobile.desktop.core.layout
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import dev.jasonpearson.automobile.desktop.domain.DeviceControlBlockReason
+import kotlinx.coroutines.delay
+
+/**
+ * How long a block reason must hold before [DeviceControlBlockedNotice] shows it. During normal
+ * streaming the transient reasons (UnpairedHierarchy while a fresh hierarchy is in flight,
+ * StaleFrame across a capture hiccup) come and go within a frame or two; only a reason that
+ * persists is worth telling the user about, so the notice never flickers in steady state.
+ */
+internal const val DEVICE_CONTROL_BLOCK_NOTICE_HOLD_MS: Long = 1_500L
+
+/**
+ * The user-facing explanation for [reason], or null for reasons that are a deliberate host
+ * configuration rather than a condition the user can observe or wait out (issue #3490).
+ *
+ * NotEnabled is null because the host opted out of device control entirely — the IDE plugin is
+ * permanently inspector-only, and a notice there would be a constant fixture, not information.
+ * NotRealDeviceMode is null for the same shape of reason: mock data is a mode the user chose.
+ */
+internal fun deviceControlBlockReasonText(reason: DeviceControlBlockReason): String? =
+  when (reason) {
+    DeviceControlBlockReason.NotEnabled -> null
+    DeviceControlBlockReason.NotRealDeviceMode -> null
+    DeviceControlBlockReason.NoDeviceSelected -> "Device control needs a device selected"
+    DeviceControlBlockReason.TransportCannotCarryInput ->
+      "Device control unavailable: this connection cannot carry input"
+    DeviceControlBlockReason.ObservationStreamDisconnected ->
+      "Device control paused: observation stream disconnected"
+    DeviceControlBlockReason.NoFrame -> "Device control waiting for the first frame"
+    DeviceControlBlockReason.DeviceMismatch ->
+      "Device control paused: displayed frame is from a different device"
+    DeviceControlBlockReason.UnpairedHierarchy ->
+      "Device control paused: waiting for screenshot and layout to sync"
+    DeviceControlBlockReason.CaptureIdentityUnavailable ->
+      "Device control unavailable: daemon does not report capture identity"
+    DeviceControlBlockReason.StaleFrame -> "Device control paused: frame is stale"
+    DeviceControlBlockReason.GeometryMismatch ->
+      "Device control paused: screenshot and layout geometry disagree"
+    DeviceControlBlockReason.LiveFrameGeometryUnverifiable ->
+      "Device control paused: live mirror resolution does not match the device"
+  }
+
+/**
+ * Small non-intrusive badge explaining why client device control is currently unavailable
+ * (issue #3490). [DeviceControlPolicy][dev.jasonpearson.automobile.desktop.domain.DeviceControlPolicy]
+ * names exactly why control is blocked; without this the view silently falls back to inspector mode
+ * and a click simply stops actuating the device with no explanation.
+ *
+ * Renders nothing until [reason] has held unchanged for [holdMs] (see
+ * [DEVICE_CONTROL_BLOCK_NOTICE_HOLD_MS]), and nothing at all for reasons
+ * [deviceControlBlockReasonText] maps to null, so hosts that never enable control (the IDE plugin)
+ * are unaffected.
+ */
+@Composable
+fun DeviceControlBlockedNotice(
+  reason: DeviceControlBlockReason?,
+  modifier: Modifier = Modifier,
+  holdMs: Long = DEVICE_CONTROL_BLOCK_NOTICE_HOLD_MS,
+) {
+  val text = reason?.let { deviceControlBlockReasonText(it) }
+  var held by remember { mutableStateOf(false) }
+  LaunchedEffect(text, holdMs) {
+    held = false
+    if (text != null) {
+      delay(holdMs)
+      held = true
+    }
+  }
+  if (text == null || !held) return
+
+  Row(
+    modifier =
+      modifier
+        .background(Color.Black.copy(alpha = 0.55f), RoundedCornerShape(4.dp))
+        .padding(horizontal = 8.dp, vertical = 4.dp)
+  ) {
+    Text(
+      text = text,
+      color = Color.White.copy(alpha = 0.85f),
+      fontSize = 10.sp,
+      maxLines = 1,
+    )
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceControlBlockedNoticeUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceControlBlockedNoticeUiTest.kt
@@ -73,6 +73,29 @@ class DeviceControlBlockedNoticeUiTest {
   }
 
   @Test
+  fun `a reason change after the notice is visible re-debounces the new reason`() =
+    runComposeUiTest {
+      mainClock.autoAdvance = false
+      var reason by mutableStateOf<DeviceControlBlockReason?>(DeviceControlBlockReason.StaleFrame)
+      setContent { MaterialTheme { DeviceControlBlockedNotice(reason = reason) } }
+      val staleText = deviceControlBlockReasonText(DeviceControlBlockReason.StaleFrame)!!
+      val unpairedText = deviceControlBlockReasonText(DeviceControlBlockReason.UnpairedHierarchy)!!
+
+      mainClock.advanceTimeBy(holdMs * 2)
+      onNodeWithText(staleText).assertIsDisplayed()
+
+      // The replacement must not inherit the shown reason's completed hold: only text the hold
+      // effect committed is rendered, so the new reason waits out its own full hold.
+      reason = DeviceControlBlockReason.UnpairedHierarchy
+      mainClock.advanceTimeBy(holdMs / 2)
+      onNodeWithText(staleText).assertDoesNotExist()
+      onNodeWithText(unpairedText).assertDoesNotExist()
+
+      mainClock.advanceTimeBy(holdMs)
+      onNodeWithText(unpairedText).assertIsDisplayed()
+    }
+
+  @Test
   fun `notice hides as soon as the reason clears`() = runComposeUiTest {
     mainClock.autoAdvance = false
     var reason by mutableStateOf<DeviceControlBlockReason?>(DeviceControlBlockReason.StaleFrame)

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceControlBlockedNoticeUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceControlBlockedNoticeUiTest.kt
@@ -46,10 +46,14 @@ class DeviceControlBlockedNoticeUiTest {
     }
     val text = deviceControlBlockReasonText(DeviceControlBlockReason.StaleFrame)!!
 
-    mainClock.advanceTimeBy(holdMs / 2)
+    // Exact boundary: absent through holdMs - 1, present at exactly holdMs. ignoreFrameDuration
+    // keeps advanceTimeBy from rounding up to a frame multiple, which would overshoot the bound.
+    mainClock.advanceTimeBy(holdMs - 1, ignoreFrameDuration = true)
     onNodeWithText(text).assertDoesNotExist()
 
-    mainClock.advanceTimeBy(holdMs)
+    mainClock.advanceTimeBy(1, ignoreFrameDuration = true)
+    mainClock
+      .advanceTimeByFrame() // dispatch the resumed hold coroutine; the deadline already passed
     onNodeWithText(text).assertIsDisplayed()
   }
 
@@ -63,12 +67,19 @@ class DeviceControlBlockedNoticeUiTest {
 
     mainClock.advanceTimeBy(holdMs / 2)
     reason = DeviceControlBlockReason.UnpairedHierarchy
-    mainClock.advanceTimeBy(holdMs / 2 + 1)
-    // Neither reason held for the full window yet: the first was replaced, the second is young.
+    // Pump one frame so the recomposition applies and the restarted hold anchors HERE — with a
+    // frozen clock, recomposition waits for a frame, and letting it happen inside the next
+    // advance would shift the anchor and blur the exact boundary below.
+    mainClock.advanceTimeByFrame()
+
+    mainClock.advanceTimeBy(holdMs - 1, ignoreFrameDuration = true)
+    // Neither reason held for the full window yet: the first was replaced, the second is 1ms shy.
     onNodeWithText(staleText).assertDoesNotExist()
     onNodeWithText(unpairedText).assertDoesNotExist()
 
-    mainClock.advanceTimeBy(holdMs)
+    mainClock.advanceTimeBy(1, ignoreFrameDuration = true)
+    mainClock
+      .advanceTimeByFrame() // dispatch the resumed hold coroutine; the deadline already passed
     onNodeWithText(unpairedText).assertIsDisplayed()
   }
 
@@ -85,13 +96,17 @@ class DeviceControlBlockedNoticeUiTest {
       onNodeWithText(staleText).assertIsDisplayed()
 
       // The replacement must not inherit the shown reason's completed hold: only text the hold
-      // effect committed is rendered, so the new reason waits out its own full hold.
+      // effect committed is rendered, so the new reason waits out its own full, exact hold.
       reason = DeviceControlBlockReason.UnpairedHierarchy
-      mainClock.advanceTimeBy(holdMs / 2)
+      mainClock.advanceTimeByFrame() // apply the recomposition so the fresh hold anchors here
+
+      mainClock.advanceTimeBy(holdMs - 1, ignoreFrameDuration = true)
       onNodeWithText(staleText).assertDoesNotExist()
       onNodeWithText(unpairedText).assertDoesNotExist()
 
-      mainClock.advanceTimeBy(holdMs)
+      mainClock.advanceTimeBy(1, ignoreFrameDuration = true)
+      mainClock
+        .advanceTimeByFrame() // dispatch the resumed hold coroutine; the deadline already passed
       onNodeWithText(unpairedText).assertIsDisplayed()
     }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceControlBlockedNoticeUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceControlBlockedNoticeUiTest.kt
@@ -1,0 +1,107 @@
+package dev.jasonpearson.automobile.desktop.core.layout
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.domain.DeviceControlBlockReason
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class DeviceControlBlockedNoticeUiTest {
+
+  private val holdMs = DEVICE_CONTROL_BLOCK_NOTICE_HOLD_MS
+
+  @Test
+  fun `host configuration reasons map to no text`() {
+    // NotEnabled is the IDE plugin's permanent state; NotRealDeviceMode is a mode the user chose.
+    // A notice for either would be a constant fixture, not information.
+    assertNull(deviceControlBlockReasonText(DeviceControlBlockReason.NotEnabled))
+    assertNull(deviceControlBlockReasonText(DeviceControlBlockReason.NotRealDeviceMode))
+  }
+
+  @Test
+  fun `every observable reason maps to distinct text`() {
+    val observable =
+      DeviceControlBlockReason.entries.filterNot {
+        it == DeviceControlBlockReason.NotEnabled ||
+          it == DeviceControlBlockReason.NotRealDeviceMode
+      }
+    val texts = observable.map { assertNotNull(deviceControlBlockReasonText(it), it.name) }
+    assertEquals(texts.size, texts.toSet().size, "block reason texts must be distinct")
+  }
+
+  @Test
+  fun `notice appears only after the reason has held`() = runComposeUiTest {
+    mainClock.autoAdvance = false
+    setContent {
+      MaterialTheme { DeviceControlBlockedNotice(reason = DeviceControlBlockReason.StaleFrame) }
+    }
+    val text = deviceControlBlockReasonText(DeviceControlBlockReason.StaleFrame)!!
+
+    mainClock.advanceTimeBy(holdMs / 2)
+    onNodeWithText(text).assertDoesNotExist()
+
+    mainClock.advanceTimeBy(holdMs)
+    onNodeWithText(text).assertIsDisplayed()
+  }
+
+  @Test
+  fun `a reason change restarts the hold`() = runComposeUiTest {
+    mainClock.autoAdvance = false
+    var reason by mutableStateOf<DeviceControlBlockReason?>(DeviceControlBlockReason.StaleFrame)
+    setContent { MaterialTheme { DeviceControlBlockedNotice(reason = reason) } }
+    val staleText = deviceControlBlockReasonText(DeviceControlBlockReason.StaleFrame)!!
+    val unpairedText = deviceControlBlockReasonText(DeviceControlBlockReason.UnpairedHierarchy)!!
+
+    mainClock.advanceTimeBy(holdMs / 2)
+    reason = DeviceControlBlockReason.UnpairedHierarchy
+    mainClock.advanceTimeBy(holdMs / 2 + 1)
+    // Neither reason held for the full window yet: the first was replaced, the second is young.
+    onNodeWithText(staleText).assertDoesNotExist()
+    onNodeWithText(unpairedText).assertDoesNotExist()
+
+    mainClock.advanceTimeBy(holdMs)
+    onNodeWithText(unpairedText).assertIsDisplayed()
+  }
+
+  @Test
+  fun `notice hides as soon as the reason clears`() = runComposeUiTest {
+    mainClock.autoAdvance = false
+    var reason by mutableStateOf<DeviceControlBlockReason?>(DeviceControlBlockReason.StaleFrame)
+    setContent { MaterialTheme { DeviceControlBlockedNotice(reason = reason) } }
+    val text = deviceControlBlockReasonText(DeviceControlBlockReason.StaleFrame)!!
+
+    mainClock.advanceTimeBy(holdMs * 2)
+    onNodeWithText(text).assertIsDisplayed()
+
+    reason = null
+    mainClock.advanceTimeBy(1)
+    onNodeWithText(text).assertDoesNotExist()
+  }
+
+  @Test
+  fun `renders nothing for NotEnabled no matter how long it holds`() = runComposeUiTest {
+    mainClock.autoAdvance = false
+    setContent {
+      MaterialTheme { DeviceControlBlockedNotice(reason = DeviceControlBlockReason.NotEnabled) }
+    }
+    mainClock.advanceTimeBy(holdMs * 10)
+    onNodeWithText("Device control", substring = true).assertDoesNotExist()
+  }
+
+  @Test
+  fun `renders nothing for a null reason`() = runComposeUiTest {
+    mainClock.autoAdvance = false
+    setContent { MaterialTheme { DeviceControlBlockedNotice(reason = null) } }
+    mainClock.advanceTimeBy(holdMs * 10)
+    onNodeWithText("Device control", substring = true).assertDoesNotExist()
+  }
+}


### PR DESCRIPTION
## Summary

[PR #4506](https://github.com/kaeawc/auto-mobile/pull/4506) introduced `DeviceControlPolicy`, which names exactly why client device control is unavailable (`DeviceControlBlockReason`), but the live layout view in `AutoMobileContent.kt` discarded the reason and silently rendered inspector mode — a click simply stopped actuating the device with no explanation, which is especially confusing for the transient reasons (`UnpairedHierarchy` while the hierarchy catches up, `StaleFrame` on a stalled mirror).

This adds `DeviceControlBlockedNotice`, a small badge in the same overlay `Box` as `ScreenshotMetadataOverlay` (top-start) and `DeviceControlTapErrorBanner` (bottom-center), aligned bottom-start to avoid both:

- **Debounced**: the reason must hold unchanged for 1.5 s (`DEVICE_CONTROL_BLOCK_NOTICE_HOLD_MS`) before anything renders, so transient blips during normal streaming never flicker into view. A reason change restarts the hold; a cleared reason hides it immediately.
- **Exhaustive text mapping**: `deviceControlBlockReasonText` is an exhaustive `when` (no `else`), so a new enum entry forces a display decision. `NotEnabled` and `NotRealDeviceMode` deliberately map to **null** — those are host configuration (the IDE plugin is permanently inspector-only; mock mode is user-chosen), so a notice there would be a constant fixture, not information. This is what keeps the IDE plugin unaffected with zero ide-plugin changes.
- **Suppressed while clicks still work**: the reason is passed only when no retained interaction snapshot exists — during a post-input refresh, clicks still actuate the device through the retained snapshot, so a "blocked" notice would contradict what the user experiences.

## Linked Issue

Closes [#4531](https://github.com/kaeawc/auto-mobile/issues/4531)

## Validation

- [x] Android changes: `:desktop-core:detektMain`, `:desktop-core:detektTest`, `:desktop-core:test` (full suite, new class 7/7), `:desktop-app:compileKotlin` all pass; touched Kotlin formatted with ktfmt `--google-style` 0.64
- [x] New code keeps the decision pure (`deviceControlBlockReasonText` is a pure function; debounce is tested deterministically via Compose `mainClock`, no real timers)
- [x] Rebased onto latest `main`, conflicts resolved

## Kotlin Reuse Check

- [x] Checked Kotlin stdlib/JDK/AndroidX, existing module dependencies, and dependency-compatible AutoMobile modules before adding helpers — the badge reuses the visual style of the existing `ScreenshotSourceLabel`; no new dependencies

## Reviewer notes

- Desktop-core only; the ide-plugin stays inspector-only by construction (it never enables control, `NotEnabled` renders nothing).
- The debounce keys on the mapped text (equivalently, the reason): alternating transient reasons each restart the hold, which is the intended "quiet in steady-state streaming" behavior.
