### PR TITLE
feat(desktop): polish and sign off client screen control (#3352)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceScreenView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceScreenView.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameMillis
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
@@ -81,10 +82,18 @@ import dev.jasonpearson.automobile.desktop.domain.DevicePoint
 import dev.jasonpearson.automobile.desktop.domain.DeviceScreenControlMode
 import dev.jasonpearson.automobile.desktop.domain.DeviceScreenCoordinateMapper
 import dev.jasonpearson.automobile.desktop.domain.DeviceScreenGeometry
+import dev.jasonpearson.automobile.desktop.domain.TouchFeedbackModel
 import dev.jasonpearson.automobile.desktop.domain.ViewportPoint
 import org.jetbrains.skia.Image
 
 private val IS_MAC = System.getProperty("os.name", "").contains("Mac", ignoreCase = true)
+
+/**
+ * Base radius, in frame pixels at zoom 1.0, of the transient control-tap feedback pulse
+ * (issue #3352). Scaled up with the device frame by the same `boundsToFrameScale` the element
+ * overlays use, and grown further as the pulse fades.
+ */
+private const val TOUCH_PULSE_BASE_RADIUS_PX = 12f
 
 /**
  * Transform element bounds from the original (unrotated) hierarchy coordinate system to the rotated
@@ -399,6 +408,34 @@ fun DeviceScreenView(
       onElementSelected(null)
     }
   }
+
+  // Transient touch-point feedback for a forwarded control-mode tap (issue #3352). A control-mode
+  // tap otherwise produces no on-canvas confirmation until the device redraws, so a brief pulse at
+  // the tapped device coordinate tells the user the click registered and was forwarded. The fade
+  // math is the pure, unit-tested TouchFeedbackModel; this composable only owns the clock and the
+  // per-frame tick that drives the fade. Inert in inspector mode, so the IDE plugin is unaffected.
+  val touchFeedback = remember { TouchFeedbackModel() }
+  var touchFeedbackNow by remember { mutableStateOf(0L) }
+  // Bumped on each recorded pulse so the tick effect (re)launches; the loop exits on its own once
+  // nothing is left to fade, so it never spins while the screen is idle.
+  var touchFeedbackGeneration by remember { mutableStateOf(0) }
+  LaunchedEffect(controlMode) {
+    if (controlMode != DeviceScreenControlMode.Control) touchFeedback.reset()
+  }
+  LaunchedEffect(touchFeedbackGeneration, controlMode) {
+    if (controlMode != DeviceScreenControlMode.Control) return@LaunchedEffect
+    while (touchFeedback.hasActive(System.currentTimeMillis())) {
+      withFrameMillis { touchFeedbackNow = System.currentTimeMillis() }
+    }
+  }
+  // Resolved during composition (a pure read) so the draw closure never mutates state; reading
+  // touchFeedbackNow here is what re-composes the overlay each frame while a pulse is fading.
+  val activeTouchFeedback =
+    if (controlMode == DeviceScreenControlMode.Control) {
+      touchFeedback.active(touchFeedbackNow)
+    } else {
+      emptyList()
+    }
 
   // Zoom and pan state
   var scale by remember { mutableFloatStateOf(1f) }
@@ -784,6 +821,14 @@ fun DeviceScreenView(
                           geometry,
                         )
                       currentOnControlTap?.invoke(snapshot, point)
+                      // Pulse where the tap landed, but only for a point the session will actually
+                      // forward: an out-of-bounds tap is dropped per the coordinate-mapping
+                      // contract, so showing a marker for it would be misleading feedback.
+                      if (point.inBounds) {
+                        touchFeedback.record(point.x, point.y, System.currentTimeMillis())
+                        touchFeedbackNow = System.currentTimeMillis()
+                        touchFeedbackGeneration++
+                      }
                     }
                   }
                   // Inspector mode: select the deepest element under the click (unchanged
@@ -943,6 +988,29 @@ fun DeviceScreenView(
                         size = Size(r[2], r[3]),
                       )
                     }
+                  }
+
+                  // Transient touch-point feedback (issue #3352): a blue pulse at each forwarded
+                  // control tap, fading and expanding over its lifetime. Marker coordinates are in
+                  // device (== hierarchy bounds) space, so they scale to frame pixels the same way
+                  // element overlays do. Empty in inspector mode.
+                  for (feedback in activeTouchFeedback) {
+                    val cx = feedback.marker.x * boundsToFrameScale
+                    val cy = feedback.marker.y * boundsToFrameScale
+                    val alpha = (1f - feedback.progress).coerceIn(0f, 1f)
+                    val radius = TOUCH_PULSE_BASE_RADIUS_PX * (0.7f + 0.6f * feedback.progress)
+                    val pulseColor = Color(0xFF2196F3)
+                    drawCircle(
+                      color = pulseColor.copy(alpha = alpha * 0.25f),
+                      radius = radius,
+                      center = Offset(cx, cy),
+                    )
+                    drawCircle(
+                      color = pulseColor.copy(alpha = alpha),
+                      radius = radius,
+                      center = Offset(cx, cy),
+                      style = Stroke(width = 2f),
+                    )
                   }
                 },
             )

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceScreenView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceScreenView.kt
@@ -90,8 +90,8 @@ private val IS_MAC = System.getProperty("os.name", "").contains("Mac", ignoreCas
 
 /**
  * Base radius, in frame pixels at zoom 1.0, of the transient control-tap feedback pulse
- * (issue #3352). Scaled up with the device frame by the same `boundsToFrameScale` the element
- * overlays use, and grown further as the pulse fades.
+ * (issue #3352). Placed via the marker's captured `frameOffset`, and grown further as the pulse
+ * fades.
  */
 private const val TOUCH_PULSE_BASE_RADIUS_PX = 12f
 
@@ -343,8 +343,13 @@ fun DeviceScreenView(
    * same frame: a snapshot swap between the click and the caller's dispatch cannot change the
    * mapping this point was produced with. The point carries [DevicePoint.inBounds]; a null default
    * makes control mode inert until a caller wires it. No-op in inspector mode.
+   *
+   * Returns whether the tap was actually **forwarded** — dispatched to the device AND accepted by
+   * the caller's input queue (false for an off-screen point or a full queue). The view uses that
+   * answer to decide whether to show the transient touch pulse (issue #3352), so a tap that never
+   * reached the device shows no success feedback. The inert null default counts as not forwarded.
    */
-  onControlTap: ((DeviceFrameSnapshot, DevicePoint) -> Unit)? = null,
+  onControlTap: ((DeviceFrameSnapshot, DevicePoint) -> Boolean)? = null,
   /**
    * Called in [DeviceScreenControlMode.Control] when a pointer drag completes, with the snapshot
    * the drag began on and the raw mapped start/end device coordinates (issue #3350). Both endpoints
@@ -820,12 +825,24 @@ fun DeviceScreenView(
                           ViewportPoint(offset.x, offset.y),
                           geometry,
                         )
-                      currentOnControlTap?.invoke(snapshot, point)
-                      // Pulse where the tap landed, but only for a point the session will actually
-                      // forward: an out-of-bounds tap is dropped per the coordinate-mapping
-                      // contract, so showing a marker for it would be misleading feedback.
-                      if (point.inBounds) {
-                        touchFeedback.record(point.x, point.y, System.currentTimeMillis())
+                      // Pulse ONLY when the tap was actually forwarded and accepted (issue
+                      // #3352): the callback answers dispatched-and-accepted, false for an
+                      // off-screen point, a full queue, or an unwired (null) control view. Showing
+                      // a
+                      // marker for anything else would claim a success that never reached the
+                      // device. The marker captures the snapshot's mapping bounds so it renders
+                      // back
+                      // through the same geometry the tap used and cannot drift mid-fade.
+                      val forwarded = currentOnControlTap?.invoke(snapshot, point) ?: false
+                      touchFeedback.recordIfForwarded(
+                        forwarded = forwarded,
+                        x = point.x,
+                        y = point.y,
+                        deviceWidth = snapshot.deviceWidth,
+                        deviceHeight = snapshot.deviceHeight,
+                        nowMs = System.currentTimeMillis(),
+                      )
+                      if (forwarded) {
                         touchFeedbackNow = System.currentTimeMillis()
                         touchFeedbackGeneration++
                       }
@@ -991,24 +1008,24 @@ fun DeviceScreenView(
                   }
 
                   // Transient touch-point feedback (issue #3352): a blue pulse at each forwarded
-                  // control tap, fading and expanding over its lifetime. Marker coordinates are in
-                  // device (== hierarchy bounds) space, so they scale to frame pixels the same way
-                  // element overlays do. Empty in inspector mode.
+                  // control tap, fading and expanding over its lifetime. Each marker is placed
+                  // through its OWN captured snapshot bounds (frameOffset), not the live
+                  // boundsToFrameScale — so it lands where the tap mapped and does not drift if a
+                  // resolution/rotation change arrives mid-fade. Empty in inspector mode.
                   for (feedback in activeTouchFeedback) {
-                    val cx = feedback.marker.x * boundsToFrameScale
-                    val cy = feedback.marker.y * boundsToFrameScale
+                    val center = feedback.frameOffset(size.width)
                     val alpha = (1f - feedback.progress).coerceIn(0f, 1f)
                     val radius = TOUCH_PULSE_BASE_RADIUS_PX * (0.7f + 0.6f * feedback.progress)
                     val pulseColor = Color(0xFF2196F3)
                     drawCircle(
                       color = pulseColor.copy(alpha = alpha * 0.25f),
                       radius = radius,
-                      center = Offset(cx, cy),
+                      center = Offset(center.x, center.y),
                     )
                     drawCircle(
                       color = pulseColor.copy(alpha = alpha),
                       radius = radius,
-                      center = Offset(cx, cy),
+                      center = Offset(center.x, center.y),
                       style = Stroke(width = 2f),
                     )
                   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceScreenView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceScreenView.kt
@@ -74,6 +74,7 @@ import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import dev.jasonpearson.automobile.desktop.core.MONOTONIC_NOW_MS
 import dev.jasonpearson.automobile.desktop.core.control.DeviceKeyboardEventTranslator
 import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
 import dev.jasonpearson.automobile.desktop.domain.DeviceFrameSnapshot
@@ -417,10 +418,15 @@ fun DeviceScreenView(
   // Transient touch-point feedback for a forwarded control-mode tap (issue #3352). A control-mode
   // tap otherwise produces no on-canvas confirmation until the device redraws, so a brief pulse at
   // the tapped device coordinate tells the user the click registered and was forwarded. The fade
-  // math is the pure, unit-tested TouchFeedbackModel; this composable only owns the clock and the
-  // per-frame tick that drives the fade. Inert in inspector mode, so the IDE plugin is unaffected.
-  val touchFeedback = remember { TouchFeedbackModel() }
-  var touchFeedbackNow by remember { mutableStateOf(0L) }
+  // math is the pure, unit-tested TouchFeedbackModel; this composable only owns the per-frame tick
+  // that drives the fade. Inert in inspector mode, so the IDE plugin is unaffected.
+  //
+  // The model ages markers on MONOTONIC_NOW_MS (#3348's monotonic source), NOT the wall clock: a
+  // wall-clock step backward would clamp elapsed to 0 and spin this recompose loop every frame
+  // until real time caught up (a stuck pulse + sustained CPU). The tick below advances on the same
+  // monotonic source so recompose time and aging time agree.
+  val touchFeedback = remember { TouchFeedbackModel(nowMs = MONOTONIC_NOW_MS) }
+  var touchFeedbackTick by remember { mutableStateOf(0L) }
   // Bumped on each recorded pulse so the tick effect (re)launches; the loop exits on its own once
   // nothing is left to fade, so it never spins while the screen is idle.
   var touchFeedbackGeneration by remember { mutableStateOf(0) }
@@ -429,15 +435,16 @@ fun DeviceScreenView(
   }
   LaunchedEffect(touchFeedbackGeneration, controlMode) {
     if (controlMode != DeviceScreenControlMode.Control) return@LaunchedEffect
-    while (touchFeedback.hasActive(System.currentTimeMillis())) {
-      withFrameMillis { touchFeedbackNow = System.currentTimeMillis() }
+    while (touchFeedback.hasActive()) {
+      withFrameMillis { touchFeedbackTick = MONOTONIC_NOW_MS() }
     }
   }
-  // Resolved during composition (a pure read) so the draw closure never mutates state; reading
-  // touchFeedbackNow here is what re-composes the overlay each frame while a pulse is fading.
+  // Resolved during composition (a pure read) so the draw closure never mutates state. Reading
+  // touchFeedbackTick here subscribes the overlay to the per-frame tick so it re-composes while a
+  // pulse is fading; the model resolves the fade against its own monotonic clock, not this value.
   val activeTouchFeedback =
     if (controlMode == DeviceScreenControlMode.Control) {
-      touchFeedback.active(touchFeedbackNow)
+      touchFeedbackTick.let { touchFeedback.active() }
     } else {
       emptyList()
     }
@@ -840,10 +847,9 @@ fun DeviceScreenView(
                         y = point.y,
                         deviceWidth = snapshot.deviceWidth,
                         deviceHeight = snapshot.deviceHeight,
-                        nowMs = System.currentTimeMillis(),
                       )
                       if (forwarded) {
-                        touchFeedbackNow = System.currentTimeMillis()
+                        touchFeedbackTick = MONOTONIC_NOW_MS()
                         touchFeedbackGeneration++
                       }
                     }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceScreenView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceScreenView.kt
@@ -433,6 +433,15 @@ fun DeviceScreenView(
   LaunchedEffect(controlMode) {
     if (controlMode != DeviceScreenControlMode.Control) touchFeedback.reset()
   }
+  // Drop pulses when the device rotates mid-fade (issue #3352): a marker is placed by scaling its
+  // captured device point through its captured bounds, which only holds within the orientation it
+  // was captured in — after a portrait<->landscape flip the same point maps into a differently
+  // shaped frame and would land outside the clipped canvas. Keying on the orientation flag fires
+  // this only on an actual flip, so a same-orientation resolution change keeps its pulses.
+  val controlSnapshotLandscape = controlSnapshot?.let { it.deviceWidth > it.deviceHeight }
+  LaunchedEffect(controlSnapshotLandscape) {
+    controlSnapshot?.let { touchFeedback.retainOnlyOrientation(it.deviceWidth, it.deviceHeight) }
+  }
   LaunchedEffect(touchFeedbackGeneration, controlMode) {
     if (controlMode != DeviceScreenControlMode.Control) return@LaunchedEffect
     while (touchFeedback.hasActive()) {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/TouchFeedbackModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/TouchFeedbackModelTest.kt
@@ -1,5 +1,7 @@
 package dev.jasonpearson.automobile.desktop.core.control
 
+import dev.jasonpearson.automobile.desktop.domain.ActiveTouchFeedback
+import dev.jasonpearson.automobile.desktop.domain.TouchFeedbackMarker
 import dev.jasonpearson.automobile.desktop.domain.TouchFeedbackModel
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -8,19 +10,24 @@ import kotlin.test.assertTrue
 
 /**
  * The pure transient touch-feedback model (issue #3352). All time is fed in, so the fade
- * transitions run with no timer — record, age partway, age out, cap, and reset — the same way the
- * other `desktop-domain` policies are tested.
+ * transitions run with no timer — record, age partway, age out, cap, reset, the dispatch gate, and
+ * the captured-geometry rendering — the same way the other `desktop-domain` policies are tested.
  */
 class TouchFeedbackModelTest {
 
   private val duration = 600L
+  private val w = 1080
+  private val h = 2340
 
   private fun model() = TouchFeedbackModel(durationMs = duration)
+
+  private fun TouchFeedbackModel.recordAt(x: Int, y: Int, nowMs: Long) =
+    record(x = x, y = y, deviceWidth = w, deviceHeight = h, nowMs = nowMs)
 
   @Test
   fun `a freshly recorded pulse is active at full strength`() {
     val model = model()
-    model.record(x = 100, y = 200, nowMs = 1_000L)
+    model.recordAt(x = 100, y = 200, nowMs = 1_000L)
 
     val active = model.active(1_000L)
     assertEquals(1, active.size)
@@ -34,7 +41,7 @@ class TouchFeedbackModelTest {
   @Test
   fun `progress rises as the pulse ages but stays visible until the duration elapses`() {
     val model = model()
-    model.record(x = 10, y = 20, nowMs = 0L)
+    model.recordAt(x = 10, y = 20, nowMs = 0L)
 
     // Halfway through: still visible, progress 0.5.
     assertEquals(0.5f, model.active(300L).single().progress)
@@ -47,7 +54,7 @@ class TouchFeedbackModelTest {
   @Test
   fun `a pulse expires exactly at the duration boundary`() {
     val model = model()
-    model.record(x = 10, y = 20, nowMs = 0L)
+    model.recordAt(x = 10, y = 20, nowMs = 0L)
 
     // progress >= 1 at the boundary means fully faded: not returned, not counted active.
     assertTrue(model.active(600L).isEmpty())
@@ -58,8 +65,8 @@ class TouchFeedbackModelTest {
   @Test
   fun `multiple concurrent pulses are all reported`() {
     val model = model()
-    model.record(x = 1, y = 1, nowMs = 0L)
-    model.record(x = 2, y = 2, nowMs = 100L)
+    model.recordAt(x = 1, y = 1, nowMs = 0L)
+    model.recordAt(x = 2, y = 2, nowMs = 100L)
 
     val active = model.active(200L)
     assertEquals(2, active.size)
@@ -68,9 +75,9 @@ class TouchFeedbackModelTest {
   @Test
   fun `recording prunes fully faded pulses so the list does not accumulate`() {
     val model = model()
-    model.record(x = 1, y = 1, nowMs = 0L)
+    model.recordAt(x = 1, y = 1, nowMs = 0L)
     // A new record long after the first has faded drops the dead one.
-    model.record(x = 2, y = 2, nowMs = 5_000L)
+    model.recordAt(x = 2, y = 2, nowMs = 5_000L)
 
     val active = model.active(5_000L)
     assertEquals(1, active.size)
@@ -81,7 +88,7 @@ class TouchFeedbackModelTest {
   fun `the number of retained pulses is capped, dropping the oldest first`() {
     val model = model()
     // All recorded at the same instant so none fades; only the cap can bound them.
-    repeat(TouchFeedbackModel.MAX_MARKERS + 3) { i -> model.record(x = i, y = i, nowMs = 0L) }
+    repeat(TouchFeedbackModel.MAX_MARKERS + 3) { i -> model.recordAt(x = i, y = i, nowMs = 0L) }
 
     val active = model.active(0L)
     assertEquals(TouchFeedbackModel.MAX_MARKERS, active.size)
@@ -93,7 +100,7 @@ class TouchFeedbackModelTest {
   @Test
   fun `reset drops every pulse`() {
     val model = model()
-    model.record(x = 1, y = 1, nowMs = 0L)
+    model.recordAt(x = 1, y = 1, nowMs = 0L)
     model.reset()
 
     assertTrue(model.active(0L).isEmpty())
@@ -103,7 +110,7 @@ class TouchFeedbackModelTest {
   @Test
   fun `a backwards clock step never makes a pulse negative or invisible`() {
     val model = model()
-    model.record(x = 1, y = 1, nowMs = 1_000L)
+    model.recordAt(x = 1, y = 1, nowMs = 1_000L)
 
     // Clock stepped back below the record instant: clamp progress to 0, stay visible.
     val active = model.active(900L)
@@ -114,9 +121,80 @@ class TouchFeedbackModelTest {
   @Test
   fun `a non-positive duration disables feedback`() {
     val model = TouchFeedbackModel(durationMs = 0L)
-    model.record(x = 1, y = 1, nowMs = 0L)
+    model.recordAt(x = 1, y = 1, nowMs = 0L)
 
     assertTrue(model.active(0L).isEmpty())
     assertFalse(model.hasActive(0L))
+  }
+
+  // --- Dispatch gate (issue #3352, finding A): a pulse must signal only a forwarded tap. ---
+
+  @Test
+  fun `recordIfForwarded records nothing when the tap was not forwarded`() {
+    val model = model()
+    model.recordIfForwarded(
+      forwarded = false,
+      x = 100,
+      y = 200,
+      deviceWidth = w,
+      deviceHeight = h,
+      nowMs = 0L,
+    )
+
+    assertTrue(model.active(0L).isEmpty())
+    assertFalse(model.hasActive(0L))
+  }
+
+  @Test
+  fun `recordIfForwarded records a pulse when the tap was forwarded`() {
+    val model = model()
+    model.recordIfForwarded(
+      forwarded = true,
+      x = 100,
+      y = 200,
+      deviceWidth = w,
+      deviceHeight = h,
+      nowMs = 0L,
+    )
+
+    assertEquals(1, model.active(0L).size)
+  }
+
+  // --- Captured geometry (issue #3352, finding B): the pulse renders through the snapshot bounds
+  // it was captured with, not a later/live geometry. ---
+
+  @Test
+  fun `frameOffset scales through the marker's captured device width, not a live one`() {
+    // A center tap captured against a 1080-wide snapshot.
+    val marker =
+      TouchFeedbackMarker(
+        x = 540,
+        y = 1170,
+        deviceWidth = 1080,
+        deviceHeight = 2340,
+        startedAtMs = 0L,
+      )
+    val active = ActiveTouchFeedback(marker = marker, progress = 0f)
+
+    // Rendered into a 540px-wide frame: exactly half device -> the frame center x.
+    val offset = active.frameOffset(frameWidthPx = 540f)
+    assertEquals(270f, offset.x)
+    assertEquals(585f, offset.y)
+
+    // The SAME device point captured against a different (e.g. post-resolution-change) snapshot
+    // width lands at a DIFFERENT frame offset for the same frame — proving the captured width, not
+    // a live dimension, drives placement.
+    val staleWidthMarker = marker.copy(deviceWidth = 720)
+    val staleOffset = ActiveTouchFeedback(staleWidthMarker, 0f).frameOffset(540f)
+    assertEquals(405f, staleOffset.x)
+  }
+
+  @Test
+  fun `frameOffset yields the origin for a degenerate zero-width snapshot`() {
+    val marker =
+      TouchFeedbackMarker(x = 5, y = 9, deviceWidth = 0, deviceHeight = 0, startedAtMs = 0L)
+    val offset = ActiveTouchFeedback(marker, 0f).frameOffset(540f)
+    assertEquals(0f, offset.x)
+    assertEquals(0f, offset.y)
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/TouchFeedbackModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/TouchFeedbackModelTest.kt
@@ -223,4 +223,32 @@ class TouchFeedbackModelTest {
     assertEquals(0f, offset.x)
     assertEquals(0f, offset.y)
   }
+
+  // --- Orientation (issue #3352): a rotation mid-pulse drops stale-oriented markers. ---
+
+  @Test
+  fun `retainOnlyOrientation drops pulses after a portrait to landscape flip`() {
+    val model = model()
+    now = 0L
+    // Captured in portrait (w < h).
+    model.record(x = 540, y = 1170, deviceWidth = 1080, deviceHeight = 2340)
+    assertEquals(1, model.active().size)
+
+    // Device rotates to landscape (w > h): the portrait marker no longer maps into the frame.
+    model.retainOnlyOrientation(deviceWidth = 2340, deviceHeight = 1080)
+    assertTrue(model.active().isEmpty())
+  }
+
+  @Test
+  fun `retainOnlyOrientation keeps pulses on a same-orientation resolution change`() {
+    val model = model()
+    now = 0L
+    // Captured in portrait 1080x2340.
+    model.record(x = 540, y = 1170, deviceWidth = 1080, deviceHeight = 2340)
+
+    // A same-orientation resolution change (still portrait) must NOT drop the pulse — the captured
+    // bounds already place it correctly.
+    model.retainOnlyOrientation(deviceWidth = 720, deviceHeight = 1560)
+    assertEquals(1, model.active().size)
+  }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/TouchFeedbackModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/TouchFeedbackModelTest.kt
@@ -1,0 +1,122 @@
+package dev.jasonpearson.automobile.desktop.core.control
+
+import dev.jasonpearson.automobile.desktop.domain.TouchFeedbackModel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The pure transient touch-feedback model (issue #3352). All time is fed in, so the fade
+ * transitions run with no timer — record, age partway, age out, cap, and reset — the same way the
+ * other `desktop-domain` policies are tested.
+ */
+class TouchFeedbackModelTest {
+
+  private val duration = 600L
+
+  private fun model() = TouchFeedbackModel(durationMs = duration)
+
+  @Test
+  fun `a freshly recorded pulse is active at full strength`() {
+    val model = model()
+    model.record(x = 100, y = 200, nowMs = 1_000L)
+
+    val active = model.active(1_000L)
+    assertEquals(1, active.size)
+    assertEquals(100, active[0].marker.x)
+    assertEquals(200, active[0].marker.y)
+    // progress 0 at the instant it was recorded -> the UI renders it at full alpha.
+    assertEquals(0f, active[0].progress)
+    assertTrue(model.hasActive(1_000L))
+  }
+
+  @Test
+  fun `progress rises as the pulse ages but stays visible until the duration elapses`() {
+    val model = model()
+    model.record(x = 10, y = 20, nowMs = 0L)
+
+    // Halfway through: still visible, progress 0.5.
+    assertEquals(0.5f, model.active(300L).single().progress)
+    assertTrue(model.hasActive(300L))
+
+    // Just before the end: still visible.
+    assertTrue(model.hasActive(599L))
+  }
+
+  @Test
+  fun `a pulse expires exactly at the duration boundary`() {
+    val model = model()
+    model.record(x = 10, y = 20, nowMs = 0L)
+
+    // progress >= 1 at the boundary means fully faded: not returned, not counted active.
+    assertTrue(model.active(600L).isEmpty())
+    assertFalse(model.hasActive(600L))
+    assertTrue(model.active(10_000L).isEmpty())
+  }
+
+  @Test
+  fun `multiple concurrent pulses are all reported`() {
+    val model = model()
+    model.record(x = 1, y = 1, nowMs = 0L)
+    model.record(x = 2, y = 2, nowMs = 100L)
+
+    val active = model.active(200L)
+    assertEquals(2, active.size)
+  }
+
+  @Test
+  fun `recording prunes fully faded pulses so the list does not accumulate`() {
+    val model = model()
+    model.record(x = 1, y = 1, nowMs = 0L)
+    // A new record long after the first has faded drops the dead one.
+    model.record(x = 2, y = 2, nowMs = 5_000L)
+
+    val active = model.active(5_000L)
+    assertEquals(1, active.size)
+    assertEquals(2, active.single().marker.x)
+  }
+
+  @Test
+  fun `the number of retained pulses is capped, dropping the oldest first`() {
+    val model = model()
+    // All recorded at the same instant so none fades; only the cap can bound them.
+    repeat(TouchFeedbackModel.MAX_MARKERS + 3) { i -> model.record(x = i, y = i, nowMs = 0L) }
+
+    val active = model.active(0L)
+    assertEquals(TouchFeedbackModel.MAX_MARKERS, active.size)
+    // The three oldest (x = 0,1,2) were evicted; the newest survive.
+    assertFalse(active.any { it.marker.x < 3 })
+    assertTrue(active.any { it.marker.x == TouchFeedbackModel.MAX_MARKERS + 2 })
+  }
+
+  @Test
+  fun `reset drops every pulse`() {
+    val model = model()
+    model.record(x = 1, y = 1, nowMs = 0L)
+    model.reset()
+
+    assertTrue(model.active(0L).isEmpty())
+    assertFalse(model.hasActive(0L))
+  }
+
+  @Test
+  fun `a backwards clock step never makes a pulse negative or invisible`() {
+    val model = model()
+    model.record(x = 1, y = 1, nowMs = 1_000L)
+
+    // Clock stepped back below the record instant: clamp progress to 0, stay visible.
+    val active = model.active(900L)
+    assertEquals(0f, active.single().progress)
+    assertTrue(model.hasActive(900L))
+  }
+
+  @Test
+  fun `a non-positive duration disables feedback`() {
+    val model = TouchFeedbackModel(durationMs = 0L)
+    model.record(x = 1, y = 1, nowMs = 0L)
+
+    assertTrue(model.active(0L).isEmpty())
+    assertFalse(model.hasActive(0L))
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/TouchFeedbackModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/TouchFeedbackModelTest.kt
@@ -9,9 +9,11 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
- * The pure transient touch-feedback model (issue #3352). All time is fed in, so the fade
- * transitions run with no timer — record, age partway, age out, cap, reset, the dispatch gate, and
- * the captured-geometry rendering — the same way the other `desktop-domain` policies are tested.
+ * The pure transient touch-feedback model (issue #3352). The clock is injected — a mutable
+ * monotonic fake — so the fade transitions run with no timer: record, age partway, age out, cap,
+ * reset, the dispatch gate, monotonic aging, and the captured-geometry rendering, the same way the
+ * other `desktop-domain` policies are tested. Aging reads the injected clock, so a model that read
+ * a real clock instead would leave a pulse un-aged under the fed clock (see the monotonic test).
  */
 class TouchFeedbackModelTest {
 
@@ -19,67 +21,94 @@ class TouchFeedbackModelTest {
   private val w = 1080
   private val h = 2340
 
-  private fun model() = TouchFeedbackModel(durationMs = duration)
+  /** A controllable monotonic clock: the test advances [now] and the model reads it. */
+  private var now = 0L
 
-  private fun TouchFeedbackModel.recordAt(x: Int, y: Int, nowMs: Long) =
-    record(x = x, y = y, deviceWidth = w, deviceHeight = h, nowMs = nowMs)
+  private fun model() = TouchFeedbackModel(durationMs = duration, nowMs = { now })
+
+  private fun TouchFeedbackModel.recordAt(x: Int, y: Int, atMs: Long) {
+    now = atMs
+    record(x = x, y = y, deviceWidth = w, deviceHeight = h)
+  }
 
   @Test
   fun `a freshly recorded pulse is active at full strength`() {
     val model = model()
-    model.recordAt(x = 100, y = 200, nowMs = 1_000L)
+    model.recordAt(x = 100, y = 200, atMs = 1_000L)
 
-    val active = model.active(1_000L)
+    val active = model.active()
     assertEquals(1, active.size)
     assertEquals(100, active[0].marker.x)
     assertEquals(200, active[0].marker.y)
     // progress 0 at the instant it was recorded -> the UI renders it at full alpha.
     assertEquals(0f, active[0].progress)
-    assertTrue(model.hasActive(1_000L))
+    assertTrue(model.hasActive())
   }
 
   @Test
   fun `progress rises as the pulse ages but stays visible until the duration elapses`() {
     val model = model()
-    model.recordAt(x = 10, y = 20, nowMs = 0L)
+    model.recordAt(x = 10, y = 20, atMs = 0L)
 
     // Halfway through: still visible, progress 0.5.
-    assertEquals(0.5f, model.active(300L).single().progress)
-    assertTrue(model.hasActive(300L))
+    now = 300L
+    assertEquals(0.5f, model.active().single().progress)
+    assertTrue(model.hasActive())
 
     // Just before the end: still visible.
-    assertTrue(model.hasActive(599L))
+    now = 599L
+    assertTrue(model.hasActive())
   }
 
   @Test
   fun `a pulse expires exactly at the duration boundary`() {
     val model = model()
-    model.recordAt(x = 10, y = 20, nowMs = 0L)
+    model.recordAt(x = 10, y = 20, atMs = 0L)
 
     // progress >= 1 at the boundary means fully faded: not returned, not counted active.
-    assertTrue(model.active(600L).isEmpty())
-    assertFalse(model.hasActive(600L))
-    assertTrue(model.active(10_000L).isEmpty())
+    now = 600L
+    assertTrue(model.active().isEmpty())
+    assertFalse(model.hasActive())
+    now = 10_000L
+    assertTrue(model.active().isEmpty())
+  }
+
+  @Test
+  fun `a pulse ages and expires on the injected monotonic clock`() {
+    // Guards the wall-clock defect: the model MUST age against its injected clock, not a real one.
+    // Recorded at t=0; advancing the injected clock past the duration must expire it. A model that
+    // read System.currentTimeMillis() instead would see ~0 elapsed here and leave the pulse active.
+    val model = model()
+    model.recordAt(x = 1, y = 1, atMs = 0L)
+
+    now = 100L
+    assertTrue(model.hasActive())
+
+    now = duration + 1L
+    assertTrue(model.active().isEmpty())
+    assertFalse(model.hasActive())
   }
 
   @Test
   fun `multiple concurrent pulses are all reported`() {
     val model = model()
-    model.recordAt(x = 1, y = 1, nowMs = 0L)
-    model.recordAt(x = 2, y = 2, nowMs = 100L)
+    model.recordAt(x = 1, y = 1, atMs = 0L)
+    model.recordAt(x = 2, y = 2, atMs = 100L)
 
-    val active = model.active(200L)
+    now = 200L
+    val active = model.active()
     assertEquals(2, active.size)
   }
 
   @Test
   fun `recording prunes fully faded pulses so the list does not accumulate`() {
     val model = model()
-    model.recordAt(x = 1, y = 1, nowMs = 0L)
+    model.recordAt(x = 1, y = 1, atMs = 0L)
     // A new record long after the first has faded drops the dead one.
-    model.recordAt(x = 2, y = 2, nowMs = 5_000L)
+    model.recordAt(x = 2, y = 2, atMs = 5_000L)
 
-    val active = model.active(5_000L)
+    now = 5_000L
+    val active = model.active()
     assertEquals(1, active.size)
     assertEquals(2, active.single().marker.x)
   }
@@ -88,43 +117,52 @@ class TouchFeedbackModelTest {
   fun `the number of retained pulses is capped, dropping the oldest first`() {
     val model = model()
     // All recorded at the same instant so none fades; only the cap can bound them.
-    repeat(TouchFeedbackModel.MAX_MARKERS + 3) { i -> model.recordAt(x = i, y = i, nowMs = 0L) }
+    now = 0L
+    repeat(TouchFeedbackModel.MAX_MARKERS + 3) { i ->
+      record(model = model, x = i, y = i)
+    }
 
-    val active = model.active(0L)
+    val active = model.active()
     assertEquals(TouchFeedbackModel.MAX_MARKERS, active.size)
     // The three oldest (x = 0,1,2) were evicted; the newest survive.
     assertFalse(active.any { it.marker.x < 3 })
     assertTrue(active.any { it.marker.x == TouchFeedbackModel.MAX_MARKERS + 2 })
   }
 
+  private fun record(model: TouchFeedbackModel, x: Int, y: Int) =
+    model.record(x = x, y = y, deviceWidth = w, deviceHeight = h)
+
   @Test
   fun `reset drops every pulse`() {
     val model = model()
-    model.recordAt(x = 1, y = 1, nowMs = 0L)
+    model.recordAt(x = 1, y = 1, atMs = 0L)
     model.reset()
 
-    assertTrue(model.active(0L).isEmpty())
-    assertFalse(model.hasActive(0L))
+    assertTrue(model.active().isEmpty())
+    assertFalse(model.hasActive())
   }
 
   @Test
-  fun `a backwards clock step never makes a pulse negative or invisible`() {
+  fun `a non-monotonic clock reading below the record instant clamps to full strength, never negative`() {
+    // Monotonic time never regresses, so this only exercises the defensive clamp: a clock reading
+    // below a marker's record instant must keep the pulse at progress 0, not go negative/invisible.
     val model = model()
-    model.recordAt(x = 1, y = 1, nowMs = 1_000L)
+    model.recordAt(x = 1, y = 1, atMs = 1_000L)
 
-    // Clock stepped back below the record instant: clamp progress to 0, stay visible.
-    val active = model.active(900L)
+    now = 900L
+    val active = model.active()
     assertEquals(0f, active.single().progress)
-    assertTrue(model.hasActive(900L))
+    assertTrue(model.hasActive())
   }
 
   @Test
   fun `a non-positive duration disables feedback`() {
-    val model = TouchFeedbackModel(durationMs = 0L)
-    model.recordAt(x = 1, y = 1, nowMs = 0L)
+    val disabled = TouchFeedbackModel(durationMs = 0L, nowMs = { now })
+    now = 0L
+    disabled.record(x = 1, y = 1, deviceWidth = w, deviceHeight = h)
 
-    assertTrue(model.active(0L).isEmpty())
-    assertFalse(model.hasActive(0L))
+    assertTrue(disabled.active().isEmpty())
+    assertFalse(disabled.hasActive())
   }
 
   // --- Dispatch gate (issue #3352, finding A): a pulse must signal only a forwarded tap. ---
@@ -132,32 +170,20 @@ class TouchFeedbackModelTest {
   @Test
   fun `recordIfForwarded records nothing when the tap was not forwarded`() {
     val model = model()
-    model.recordIfForwarded(
-      forwarded = false,
-      x = 100,
-      y = 200,
-      deviceWidth = w,
-      deviceHeight = h,
-      nowMs = 0L,
-    )
+    now = 0L
+    model.recordIfForwarded(forwarded = false, x = 100, y = 200, deviceWidth = w, deviceHeight = h)
 
-    assertTrue(model.active(0L).isEmpty())
-    assertFalse(model.hasActive(0L))
+    assertTrue(model.active().isEmpty())
+    assertFalse(model.hasActive())
   }
 
   @Test
   fun `recordIfForwarded records a pulse when the tap was forwarded`() {
     val model = model()
-    model.recordIfForwarded(
-      forwarded = true,
-      x = 100,
-      y = 200,
-      deviceWidth = w,
-      deviceHeight = h,
-      nowMs = 0L,
-    )
+    now = 0L
+    model.recordIfForwarded(forwarded = true, x = 100, y = 200, deviceWidth = w, deviceHeight = h)
 
-    assertEquals(1, model.active(0L).size)
+    assertEquals(1, model.active().size)
   }
 
   // --- Captured geometry (issue #3352, finding B): the pulse renders through the snapshot bounds

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceScreenViewControlTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceScreenViewControlTest.kt
@@ -206,7 +206,7 @@ class DeviceScreenViewControlTest {
             elementMap = mapOf("root" to root),
             controlMode = DeviceScreenControlMode.Control,
             controlSnapshot = current,
-            onControlTap = { _, _ -> },
+            onControlTap = { _, _ -> true },
             onControlSwipe = { s, a, b -> reported = Triple(s, a, b) },
           )
         }
@@ -276,7 +276,10 @@ class DeviceScreenViewControlTest {
             elementMap = mapOf("root" to root),
             controlMode = mode,
             controlSnapshot = snapshot(1080, 2340),
-            onControlTap = { _, point -> probed = point },
+            onControlTap = { _, point ->
+              probed = point
+              true
+            },
           )
         }
       }
@@ -362,7 +365,10 @@ class DeviceScreenViewControlTest {
             elementMap = mapOf("root" to root),
             controlMode = mode,
             controlSnapshot = snapshot(1080, 2340),
-            onControlTap = { _, point -> fineGrained = point },
+            onControlTap = { _, point ->
+              fineGrained = point
+              true
+            },
           )
         }
       }
@@ -462,7 +468,10 @@ class DeviceScreenViewControlTest {
       elementMap = mapOf("root" to root),
       controlMode = mode,
       controlSnapshot = snapshot(1080, 2340, sequence = 42L),
-      onControlTap = { _, point -> onTap(point) },
+      onControlTap = { _, point ->
+        onTap(point)
+        true
+      },
       onControlSwipe = onSwipe,
     )
   }
@@ -508,7 +517,10 @@ class DeviceScreenViewControlTest {
             elementMap = mapOf("root" to root),
             controlMode = DeviceScreenControlMode.Control,
             controlSnapshot = snapshot(deviceWidth, deviceHeight),
-            onControlTap = { _, point -> tap = point },
+            onControlTap = { _, point ->
+              tap = point
+              true
+            },
           )
         }
       }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceScreenViewKeyboardTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceScreenViewKeyboardTest.kt
@@ -129,7 +129,7 @@ class DeviceScreenViewKeyboardTest {
         elementMap = mapOf("root" to root),
         controlMode = DeviceScreenControlMode.Control,
         controlSnapshot = snapshot(),
-        onControlTap = { _, _ -> },
+        onControlTap = { _, _ -> true },
         onControlKey = { _, stroke ->
           observed.forwarded.add(stroke)
           true
@@ -247,7 +247,7 @@ class DeviceScreenViewKeyboardTest {
             elementMap = mapOf("root" to root),
             controlMode = DeviceScreenControlMode.Control,
             controlSnapshot = snapshot(),
-            onControlTap = { _, _ -> },
+            onControlTap = { _, _ -> true },
             onControlKey = { _, _ -> true },
             onControlFocusChanged = { focusStates.add(it) },
           )
@@ -294,7 +294,7 @@ class DeviceScreenViewKeyboardTest {
         elementMap = mapOf("root" to root),
         controlMode = mode,
         controlSnapshot = snapshot,
-        onControlTap = { _, _ -> },
+        onControlTap = { _, _ -> true },
         onControlKey = { _, stroke ->
           observed.forwarded.add(stroke)
           forwardsEverything

--- a/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/TouchFeedback.kt
+++ b/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/TouchFeedback.kt
@@ -47,17 +47,26 @@ public data class ActiveTouchFeedback(val marker: TouchFeedbackMarker, val progr
 
 /**
  * Holds the transient touch-feedback pulses for a mirrored device screen and resolves which are
- * still visible at a given client-clock instant (issue #3352).
+ * still visible right now (issue #3352).
  *
- * Pure and clock-free: every method takes `nowMs`, so the fade transitions are unit-tested with a
- * fed clock and no timer, exactly like the other `desktop-domain` policies. The reads
- * ([active]/[hasActive]) never mutate, so a UI layer may call them during composition or draw; the
- * list only shrinks in [record] (which prunes fully-faded markers first) and [reset].
+ * The clock is **injected and must be monotonic** ([nowMs]) — production passes
+ * `System.nanoTime()`-based millis, the same source #3348 introduced for frame-age aging. Both the
+ * record timestamp and the aging read come from this one clock, so a wall-clock step backward (NTP
+ * correction, manual change, a VM/laptop resume) can neither strand a pulse visible nor spin the
+ * host's recompose loop: monotonic time never regresses, so elapsed only grows and a pulse always
+ * reaches expiry. Injecting it also keeps the fade transitions unit-testable with a fed clock and
+ * no timer, exactly like the other `desktop-domain` policies.
+ *
+ * The reads ([active]/[hasActive]) never mutate, so a UI layer may call them during composition or
+ * draw; the list only shrinks in [record] (which prunes fully-faded markers first) and [reset].
  *
  * Feedback is deliberately capped at [MAX_MARKERS]: rapid tapping cannot grow the list without
  * bound, and the oldest pulse is dropped first since it is closest to fading anyway.
  */
-public class TouchFeedbackModel(private val durationMs: Long = DURATION_MS) {
+public class TouchFeedbackModel(
+  private val durationMs: Long = DURATION_MS,
+  private val nowMs: () -> Long = MONOTONIC_NOW_MS,
+) {
   private val markers = ArrayDeque<TouchFeedbackMarker>()
 
   /**
@@ -72,33 +81,39 @@ public class TouchFeedbackModel(private val durationMs: Long = DURATION_MS) {
     y: Int,
     deviceWidth: Int,
     deviceHeight: Int,
-    nowMs: Long,
   ) {
-    if (forwarded) record(x, y, deviceWidth, deviceHeight, nowMs)
+    if (forwarded) record(x, y, deviceWidth, deviceHeight)
   }
 
   /**
    * Record a forwarded input at device coordinate ([x], [y]) — mapped through a snapshot whose
-   * bounds are [deviceWidth] x [deviceHeight] — as of [nowMs], starting a fresh pulse. Fully-faded
-   * markers are pruned first, and the oldest live one is dropped if this would exceed
-   * [MAX_MARKERS].
+   * bounds are [deviceWidth] x [deviceHeight] — stamped with the monotonic clock, starting a fresh
+   * pulse. Fully-faded markers are pruned first, and the oldest live one is dropped if this would
+   * exceed [MAX_MARKERS].
    */
-  public fun record(x: Int, y: Int, deviceWidth: Int, deviceHeight: Int, nowMs: Long) {
-    markers.removeAll { progress(it, nowMs) >= 1f }
-    markers.addLast(TouchFeedbackMarker(x, y, deviceWidth, deviceHeight, nowMs))
+  public fun record(x: Int, y: Int, deviceWidth: Int, deviceHeight: Int) {
+    val now = nowMs()
+    markers.removeAll { progress(it, now) >= 1f }
+    markers.addLast(TouchFeedbackMarker(x, y, deviceWidth, deviceHeight, now))
     while (markers.size > MAX_MARKERS) {
       markers.removeFirst()
     }
   }
 
-  /** The pulses still visible at [nowMs], each with its resolved [ActiveTouchFeedback.progress]. */
-  public fun active(nowMs: Long): List<ActiveTouchFeedback> = markers.mapNotNull { marker ->
-    val p = progress(marker, nowMs)
-    if (p >= 1f) null else ActiveTouchFeedback(marker, p)
+  /** The pulses still visible now, each with its resolved [ActiveTouchFeedback.progress]. */
+  public fun active(): List<ActiveTouchFeedback> {
+    val now = nowMs()
+    return markers.mapNotNull { marker ->
+      val p = progress(marker, now)
+      if (p >= 1f) null else ActiveTouchFeedback(marker, p)
+    }
   }
 
-  /** Whether any pulse is still visible at [nowMs]; drives whether a UI layer keeps ticking. */
-  public fun hasActive(nowMs: Long): Boolean = markers.any { progress(it, nowMs) < 1f }
+  /** Whether any pulse is still visible now; drives whether a UI layer keeps ticking. */
+  public fun hasActive(): Boolean {
+    val now = nowMs()
+    return markers.any { progress(it, now) < 1f }
+  }
 
   /** Drop every pulse. Called when control mode exits, so a stale pulse never lingers. */
   public fun reset() {
@@ -106,17 +121,25 @@ public class TouchFeedbackModel(private val durationMs: Long = DURATION_MS) {
   }
 
   /**
-   * Fade progress of [marker] at [nowMs]: `0.0` when just recorded, `1.0` once [durationMs] has
-   * elapsed. A non-positive [durationMs] makes every marker immediately expired (feedback off), and
-   * a backwards clock step clamps to `0.0` rather than going negative.
+   * Fade progress of [marker] at [now]: `0.0` when just recorded, `1.0` once [durationMs] has
+   * elapsed. A non-positive [durationMs] makes every marker immediately expired (feedback off).
+   * Elapsed is clamped at `0.0` defensively; a monotonic clock never produces a negative elapsed,
+   * so this only guards a misconfigured (non-monotonic) injected clock.
    */
-  private fun progress(marker: TouchFeedbackMarker, nowMs: Long): Float {
+  private fun progress(marker: TouchFeedbackMarker, now: Long): Float {
     if (durationMs <= 0L) return 1f
-    val elapsed = nowMs - marker.startedAtMs
+    val elapsed = now - marker.startedAtMs
     return (elapsed.toFloat() / durationMs.toFloat()).coerceIn(0f, 1f)
   }
 
   public companion object {
+    /**
+     * Default monotonic clock: `System.nanoTime()` in milliseconds. Mirrors desktop-core's
+     * `MONOTONIC_NOW_MS` (#3348) so aging never rides the wall clock; unlike `currentTimeMillis()`
+     * it cannot step backward.
+     */
+    public val MONOTONIC_NOW_MS: () -> Long = { System.nanoTime() / 1_000_000L }
+
     /** How long, in milliseconds, a touch pulse stays visible before fully fading. */
     public const val DURATION_MS: Long = 600L
 

--- a/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/TouchFeedback.kt
+++ b/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/TouchFeedback.kt
@@ -2,19 +2,25 @@ package dev.jasonpearson.automobile.desktop.domain
 
 /**
  * A transient marker for a control-mode input the client actually forwarded, used to draw a brief
- * touch pulse where a tap landed (issue
- * [#3352](https://github.com/kaeawc/auto-mobile/issues/3352)).
+ * touch pulse where a tap landed (issue #3352).
  *
- * Pure model: device coordinates (the same space as hierarchy `bounds` and [DevicePoint]) plus the
- * client-clock instant the input was forwarded. A UI layer maps [x]/[y] back to viewport pixels
- * through the same geometry the tap was mapped with, and fades the pulse out over
- * [TouchFeedbackModel.DURATION_MS].
- *
- * The marker is recorded only for an input that reached the daemon dispatch queue — never for a
- * dropped one (an off-screen point, or a keystroke the policy declined) — so the pulse is honest
- * feedback rather than noise. Deciding that is the caller's job; this type only carries a point.
+ * The point is in device coordinates (the same space as hierarchy `bounds` and [DevicePoint]), and
+ * [deviceWidth]/[deviceHeight] are the mapping bounds of the frame snapshot the tap was mapped
+ * through — captured with the marker so the pulse renders back through the SAME geometry the tap
+ * used. Binding the mapping bounds to the marker is what keeps the pulse from drifting if a
+ * resolution or rotation change arrives during its fade, and what makes it land where the tap went
+ * rather than where the live (possibly stale) hierarchy would put it.
  */
-public data class TouchFeedbackMarker(val x: Int, val y: Int, val startedAtMs: Long)
+public data class TouchFeedbackMarker(
+  val x: Int,
+  val y: Int,
+  val deviceWidth: Int,
+  val deviceHeight: Int,
+  val startedAtMs: Long,
+)
+
+/** Frame-pixel center of a pulse, produced by [ActiveTouchFeedback.frameOffset]. */
+public data class TouchFeedbackFrameOffset(val x: Float, val y: Float)
 
 /**
  * A [TouchFeedbackMarker] still visible at a given instant, with its fade resolved.
@@ -23,12 +29,25 @@ public data class TouchFeedbackMarker(val x: Int, val y: Int, val startedAtMs: L
  * pulse fully expires, so a UI layer derives alpha (`1 - progress`) and an expanding radius from it
  * without repeating the clock math.
  */
-public data class ActiveTouchFeedback(val marker: TouchFeedbackMarker, val progress: Float)
+public data class ActiveTouchFeedback(val marker: TouchFeedbackMarker, val progress: Float) {
+  /**
+   * The pulse's center in frame pixels, for a device frame [frameWidthPx] wide.
+   *
+   * Scaled through the marker's OWN captured [TouchFeedbackMarker.deviceWidth] — a single
+   * width-based ratio for both axes, the exact inverse of the width-based viewport→device mapping —
+   * so the pulse lands where the tap did and cannot drift when the live frame geometry changes
+   * mid-fade. A non-positive captured width yields the origin (a degenerate snapshot has no
+   * addressable pixel to place a pulse at).
+   */
+  public fun frameOffset(frameWidthPx: Float): TouchFeedbackFrameOffset {
+    val scale = if (marker.deviceWidth > 0) frameWidthPx / marker.deviceWidth else 0f
+    return TouchFeedbackFrameOffset(marker.x * scale, marker.y * scale)
+  }
+}
 
 /**
  * Holds the transient touch-feedback pulses for a mirrored device screen and resolves which are
- * still visible at a given client-clock instant (issue
- * [#3352](https://github.com/kaeawc/auto-mobile/issues/3352)).
+ * still visible at a given client-clock instant (issue #3352).
  *
  * Pure and clock-free: every method takes `nowMs`, so the fade transitions are unit-tested with a
  * fed clock and no timer, exactly like the other `desktop-domain` policies. The reads
@@ -42,13 +61,31 @@ public class TouchFeedbackModel(private val durationMs: Long = DURATION_MS) {
   private val markers = ArrayDeque<TouchFeedbackMarker>()
 
   /**
-   * Record a forwarded input at device coordinate ([x], [y]) as of [nowMs], starting a fresh pulse.
-   * Fully-faded markers are pruned first, and the oldest live one is dropped if this would exceed
+   * Record a pulse only when the input was actually [forwarded] to the device — i.e. the client's
+   * dispatch accepted it. A tap that was dropped (off-screen, a full bounded queue) or never
+   * dispatched (control unwired) must NOT pulse, or the indicator would claim a success that never
+   * happened. This is the gate; [record] itself is unconditional.
+   */
+  public fun recordIfForwarded(
+    forwarded: Boolean,
+    x: Int,
+    y: Int,
+    deviceWidth: Int,
+    deviceHeight: Int,
+    nowMs: Long,
+  ) {
+    if (forwarded) record(x, y, deviceWidth, deviceHeight, nowMs)
+  }
+
+  /**
+   * Record a forwarded input at device coordinate ([x], [y]) — mapped through a snapshot whose
+   * bounds are [deviceWidth] x [deviceHeight] — as of [nowMs], starting a fresh pulse. Fully-faded
+   * markers are pruned first, and the oldest live one is dropped if this would exceed
    * [MAX_MARKERS].
    */
-  public fun record(x: Int, y: Int, nowMs: Long) {
+  public fun record(x: Int, y: Int, deviceWidth: Int, deviceHeight: Int, nowMs: Long) {
     markers.removeAll { progress(it, nowMs) >= 1f }
-    markers.addLast(TouchFeedbackMarker(x, y, nowMs))
+    markers.addLast(TouchFeedbackMarker(x, y, deviceWidth, deviceHeight, nowMs))
     while (markers.size > MAX_MARKERS) {
       markers.removeFirst()
     }
@@ -60,9 +97,7 @@ public class TouchFeedbackModel(private val durationMs: Long = DURATION_MS) {
     if (p >= 1f) null else ActiveTouchFeedback(marker, p)
   }
 
-  /**
-   * Whether any pulse is still visible at [nowMs]; drives whether a UI layer needs to keep ticking.
-   */
+  /** Whether any pulse is still visible at [nowMs]; drives whether a UI layer keeps ticking. */
   public fun hasActive(nowMs: Long): Boolean = markers.any { progress(it, nowMs) < 1f }
 
   /** Drop every pulse. Called when control mode exits, so a stale pulse never lingers. */

--- a/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/TouchFeedback.kt
+++ b/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/TouchFeedback.kt
@@ -121,6 +121,23 @@ public class TouchFeedbackModel(
   }
 
   /**
+   * Drop pulses whose captured orientation no longer matches the current [deviceWidth] x
+   * [deviceHeight] (issue #3352).
+   *
+   * A marker is placed by scaling its captured device point through its captured bounds
+   * ([ActiveTouchFeedback.frameOffset]), which is exact only within the orientation it was captured
+   * in. If the device rotates during a pulse (portrait↔landscape — the width/height aspect flips),
+   * the same device point maps into a differently-shaped frame and the pulse would land outside the
+   * clipped canvas. A transient 600ms marker is not worth transforming across a rotation, and a
+   * stale-oriented pulse is worse than none — so it is simply dropped. Same-orientation resolution
+   * changes are unaffected (that is what the captured bounds already handle).
+   */
+  public fun retainOnlyOrientation(deviceWidth: Int, deviceHeight: Int) {
+    val landscape = deviceWidth > deviceHeight
+    markers.removeAll { (it.deviceWidth > it.deviceHeight) != landscape }
+  }
+
+  /**
    * Fade progress of [marker] at [now]: `0.0` when just recorded, `1.0` once [durationMs] has
    * elapsed. A non-positive [durationMs] makes every marker immediately expired (feedback off).
    * Elapsed is clamped at `0.0` defensively; a monotonic clock never produces a negative elapsed,

--- a/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/TouchFeedback.kt
+++ b/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/TouchFeedback.kt
@@ -1,0 +1,91 @@
+package dev.jasonpearson.automobile.desktop.domain
+
+/**
+ * A transient marker for a control-mode input the client actually forwarded, used to draw a brief
+ * touch pulse where a tap landed (issue
+ * [#3352](https://github.com/kaeawc/auto-mobile/issues/3352)).
+ *
+ * Pure model: device coordinates (the same space as hierarchy `bounds` and [DevicePoint]) plus the
+ * client-clock instant the input was forwarded. A UI layer maps [x]/[y] back to viewport pixels
+ * through the same geometry the tap was mapped with, and fades the pulse out over
+ * [TouchFeedbackModel.DURATION_MS].
+ *
+ * The marker is recorded only for an input that reached the daemon dispatch queue — never for a
+ * dropped one (an off-screen point, or a keystroke the policy declined) — so the pulse is honest
+ * feedback rather than noise. Deciding that is the caller's job; this type only carries a point.
+ */
+public data class TouchFeedbackMarker(val x: Int, val y: Int, val startedAtMs: Long)
+
+/**
+ * A [TouchFeedbackMarker] still visible at a given instant, with its fade resolved.
+ *
+ * [progress] runs from `0.0` at the instant the input was forwarded to `1.0` at the moment the
+ * pulse fully expires, so a UI layer derives alpha (`1 - progress`) and an expanding radius from it
+ * without repeating the clock math.
+ */
+public data class ActiveTouchFeedback(val marker: TouchFeedbackMarker, val progress: Float)
+
+/**
+ * Holds the transient touch-feedback pulses for a mirrored device screen and resolves which are
+ * still visible at a given client-clock instant (issue
+ * [#3352](https://github.com/kaeawc/auto-mobile/issues/3352)).
+ *
+ * Pure and clock-free: every method takes `nowMs`, so the fade transitions are unit-tested with a
+ * fed clock and no timer, exactly like the other `desktop-domain` policies. The reads
+ * ([active]/[hasActive]) never mutate, so a UI layer may call them during composition or draw; the
+ * list only shrinks in [record] (which prunes fully-faded markers first) and [reset].
+ *
+ * Feedback is deliberately capped at [MAX_MARKERS]: rapid tapping cannot grow the list without
+ * bound, and the oldest pulse is dropped first since it is closest to fading anyway.
+ */
+public class TouchFeedbackModel(private val durationMs: Long = DURATION_MS) {
+  private val markers = ArrayDeque<TouchFeedbackMarker>()
+
+  /**
+   * Record a forwarded input at device coordinate ([x], [y]) as of [nowMs], starting a fresh pulse.
+   * Fully-faded markers are pruned first, and the oldest live one is dropped if this would exceed
+   * [MAX_MARKERS].
+   */
+  public fun record(x: Int, y: Int, nowMs: Long) {
+    markers.removeAll { progress(it, nowMs) >= 1f }
+    markers.addLast(TouchFeedbackMarker(x, y, nowMs))
+    while (markers.size > MAX_MARKERS) {
+      markers.removeFirst()
+    }
+  }
+
+  /** The pulses still visible at [nowMs], each with its resolved [ActiveTouchFeedback.progress]. */
+  public fun active(nowMs: Long): List<ActiveTouchFeedback> = markers.mapNotNull { marker ->
+    val p = progress(marker, nowMs)
+    if (p >= 1f) null else ActiveTouchFeedback(marker, p)
+  }
+
+  /**
+   * Whether any pulse is still visible at [nowMs]; drives whether a UI layer needs to keep ticking.
+   */
+  public fun hasActive(nowMs: Long): Boolean = markers.any { progress(it, nowMs) < 1f }
+
+  /** Drop every pulse. Called when control mode exits, so a stale pulse never lingers. */
+  public fun reset() {
+    markers.clear()
+  }
+
+  /**
+   * Fade progress of [marker] at [nowMs]: `0.0` when just recorded, `1.0` once [durationMs] has
+   * elapsed. A non-positive [durationMs] makes every marker immediately expired (feedback off), and
+   * a backwards clock step clamps to `0.0` rather than going negative.
+   */
+  private fun progress(marker: TouchFeedbackMarker, nowMs: Long): Float {
+    if (durationMs <= 0L) return 1f
+    val elapsed = nowMs - marker.startedAtMs
+    return (elapsed.toFloat() / durationMs.toFloat()).coerceIn(0f, 1f)
+  }
+
+  public companion object {
+    /** How long, in milliseconds, a touch pulse stays visible before fully fading. */
+    public const val DURATION_MS: Long = 600L
+
+    /** Upper bound on simultaneously-retained pulses; the oldest is dropped past this. */
+    public const val MAX_MARKERS: Int = 8
+  }
+}

--- a/docs/design-docs/mcp/daemon/client-frame-snapshot.md
+++ b/docs/design-docs/mcp/daemon/client-frame-snapshot.md
@@ -1,9 +1,11 @@
 # Client Screen Control: frame snapshots and post-input refresh
 
-<kbd>🚧 In progress</kbd>
+<kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd>
 
 Part of milestone 28 (Client Screen Control), parent [#1099](https://github.com/kaeawc/auto-mobile/issues/1099).
 Shipped by [#3348](https://github.com/kaeawc/auto-mobile/issues/3348).
+New to screen control? Start at the
+[third-party client guide](client-screen-control.md) for the end-to-end picture.
 
 [Screen Control Mapping](screen-control-mapping.md) specifies how a viewport pixel
 becomes a device coordinate. This document specifies the other half a control

--- a/docs/design-docs/mcp/daemon/client-screen-control.md
+++ b/docs/design-docs/mcp/daemon/client-screen-control.md
@@ -12,7 +12,7 @@ device key.
 The contract is deliberately published rather than kept as private UI detail, because the
 **desktop app is not the only consumer**: any client that speaks the daemon's Unix-socket
 `input/*` protocol can implement the same control surface. Everything a third-party author needs
-is on this page or in the four documents it links; **you do not need to read any Compose or
+is on this page or in the documents it links; **you do not need to read any Compose or
 Kotlin source to implement a correct client.** The desktop inspector is merely the reference
 implementation.
 
@@ -38,10 +38,10 @@ the normative spec for its piece.
 | # | Contract | Where it lives |
 | --- | --- | --- |
 | 1 | The `input/*` socket endpoints (tap, swipe, pressButton, typeText, key) | [Unix Socket API → Input API](unix-socket-api.md#input-api) |
-| 2 | Viewport→device **coordinate mapping** (#3346) | [Screen Control Mapping](screen-control-mapping.md#viewport--device-mapping) |
-| 3 | **Drag-to-swipe** threshold and cancellation (#3350) | [Screen Control Mapping → Drag-to-swipe policy](screen-control-mapping.md#drag-to-swipe-policy) |
-| 4 | **Key-forwarding** and host-shortcut policy (#3351) | [Screen Control Mapping → Keyboard forwarding policy](screen-control-mapping.md#keyboard-forwarding-policy) |
-| 5 | **Frame snapshot** pairing + **post-input refresh** (#3348) | [Client Frame Snapshot](client-frame-snapshot.md) |
+| 2 | Viewport→device **coordinate mapping** ([#3346](https://github.com/kaeawc/auto-mobile/issues/3346)) | [Screen Control Mapping](screen-control-mapping.md#viewport--device-mapping) |
+| 3 | **Drag-to-swipe** threshold and cancellation ([#3350](https://github.com/kaeawc/auto-mobile/issues/3350)) | [Screen Control Mapping → Drag-to-swipe policy](screen-control-mapping.md#drag-to-swipe-policy) |
+| 4 | **Key-forwarding** and host-shortcut policy ([#3351](https://github.com/kaeawc/auto-mobile/issues/3351)) | [Screen Control Mapping → Keyboard forwarding policy](screen-control-mapping.md#keyboard-forwarding-policy) |
+| 5 | **Frame snapshot** pairing + **post-input refresh** ([#3348](https://github.com/kaeawc/auto-mobile/issues/3348)) | [Client Frame Snapshot](client-frame-snapshot.md) |
 
 ## Implementing a client, end to end
 

--- a/docs/design-docs/mcp/daemon/client-screen-control.md
+++ b/docs/design-docs/mcp/daemon/client-screen-control.md
@@ -1,0 +1,212 @@
+# Client Screen Control: third-party client guide
+
+<kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd>
+
+Milestone 28 (Client Screen Control), parent
+[#1099](https://github.com/kaeawc/auto-mobile/issues/1099). This is the **single entry
+point** for building a screen-control surface against the AutoMobile daemon. Screen control
+lets a client that mirrors a device screen turn pointer and keyboard input on the mirror into
+real device input — a click becomes a tap, a drag becomes a swipe, a keystroke becomes text or a
+device key.
+
+The contract is deliberately published rather than kept as private UI detail, because the
+**desktop app is not the only consumer**: any client that speaks the daemon's Unix-socket
+`input/*` protocol can implement the same control surface. Everything a third-party author needs
+is on this page or in the four documents it links; **you do not need to read any Compose or
+Kotlin source to implement a correct client.** The desktop inspector is merely the reference
+implementation.
+
+## What talks to the daemon (and what does not)
+
+| Consumer | Uses screen control? |
+| --- | --- |
+| Desktop app (`android/desktop-app`) | **Yes** — the reference control client. |
+| Third-party daemon clients | **Yes** — the audience for this document. |
+| IntelliJ / Android Studio plugin (`android/ide-plugin`) | **No — inspector only.** |
+
+The IDE plugin shares the `desktop-core` rendering code but **never enables control mode**. It
+is an inspector: it selects elements and highlights them, and forwards no device input of any
+kind. Control mode is opt-in and default-off, so a host that does not enable it gets exactly
+today's inspector behavior with no source change. Read the absence of control in the IDE plugin
+as a deliberate scope decision, not a dropped feature.
+
+## The five contracts
+
+Screen control is five separate contracts. This page ties them together; each linked document is
+the normative spec for its piece.
+
+| # | Contract | Where it lives |
+| --- | --- | --- |
+| 1 | The `input/*` socket endpoints (tap, swipe, pressButton, typeText, key) | [Unix Socket API → Input API](unix-socket-api.md#input-api) |
+| 2 | Viewport→device **coordinate mapping** (#3346) | [Screen Control Mapping](screen-control-mapping.md#viewport--device-mapping) |
+| 3 | **Drag-to-swipe** threshold and cancellation (#3350) | [Screen Control Mapping → Drag-to-swipe policy](screen-control-mapping.md#drag-to-swipe-policy) |
+| 4 | **Key-forwarding** and host-shortcut policy (#3351) | [Screen Control Mapping → Keyboard forwarding policy](screen-control-mapping.md#keyboard-forwarding-policy) |
+| 5 | **Frame snapshot** pairing + **post-input refresh** (#3348) | [Client Frame Snapshot](client-frame-snapshot.md) |
+
+## Implementing a client, end to end
+
+A control client is a loop: assemble a frame, map an input against it, forward it, wait for the
+picture to catch up. Do these in order.
+
+### 1. Subscribe and assemble a frame snapshot
+
+Subscribe to the daemon observation stream and consume `screenshot_update` and `hierarchy_update`
+messages. **Do not** act on either message alone. Assemble an immutable
+[frame snapshot](client-frame-snapshot.md#the-snapshot) that binds together, for one device:
+
+- the displayed pixels and their real dimensions,
+- the element hierarchy with its `bounds`,
+- the shared **capture identity** — a screenshot and a hierarchy belong to the same snapshot only
+  when `screenshot.captureSequence == hierarchy.captureSequence`.
+
+Control is available **only when a snapshot exists**. If any
+[availability rule](client-frame-snapshot.md#availability-rules) fails — no device selected, stream
+disconnected, screenshot older than 5 s, screenshot and hierarchy capture identities disagree, no
+`captureSequence` stamped at all — the client must **fail closed** to inspector behavior and
+forward nothing. There is no partial control state.
+
+This is the load-bearing safety rule of the whole feature: mapping a click through a stale or
+mismatched frame taps the wrong pixel on real hardware. Pairing is **identity, never elapsed
+time** — see [Pairing is identity](client-frame-snapshot.md#pairing-is-identity-never-elapsed-time).
+
+### 2. Map a pointer point to a device coordinate
+
+When the user clicks the mirror, map the viewport pixel to a device coordinate with the formulas
+in [Viewport → device mapping](screen-control-mapping.md#viewport--device-mapping). The device
+coordinate space is the snapshot's `deviceWidth`/`deviceHeight`, **not** whatever your view last
+rendered. Key rules:
+
+- A single width-based ratio scales both axes (the frame is aspect-fitted).
+- The mapping **never clamps**; it returns the raw coordinate plus an `inBounds` flag.
+- A control client **must not tap an out-of-bounds point** — drop it. (An out-of-bounds *drag
+  end* is the one exception; see below.)
+
+Map the point through **exactly the snapshot the user clicked**, and keep that snapshot bound to
+the input all the way to the request. A snapshot swap between click and send must not change the
+mapping or the target device.
+
+### 3. Decide what the gesture actually is
+
+Not every pointer or key event becomes input. These are **client-side** policies — the daemon
+executes whatever it is handed, so convergence on one policy is what keeps clients consistent.
+
+- **Tap** — an in-bounds click → one [`input/tap`](unix-socket-api.md#inputtap) at the mapped
+  coordinate.
+- **Drag → swipe** — a drag is a swipe only if it travels **≥ 24 device coordinates** (measured
+  after the end is clamped). Below that, send **nothing** — not a swipe and *not* a tap. Map both
+  endpoints through the **one** snapshot pinned when the drag began. A drag that *started*
+  off-screen is dropped; a drag that *ended* off-screen is clamped to the last addressable pixel.
+  Use a fixed **300 ms** duration, not the pointer velocity. Full rules:
+  [Drag-to-swipe policy](screen-control-mapping.md#drag-to-swipe-policy).
+- **Keyboard** — forward only while the mirror view **holds keyboard focus** and is in control
+  mode. A keystroke carrying **Ctrl/Alt/Meta** belongs to the host and is not forwarded (with one
+  documented AltGr/Option composition exception). `Escape` → `input/pressButton back`;
+  Enter/Tab/Backspace/Delete/arrows (unshifted) → [`input/key`](unix-socket-api.md#inputkey); a
+  printable ASCII character → [`input/typeText`](unix-socket-api.md#inputtypetext) with
+  `mode: "append"`. A declined keystroke must be left **unconsumed** so it reaches the host's own
+  shortcuts. Full rules:
+  [Keyboard forwarding policy](screen-control-mapping.md#keyboard-forwarding-policy).
+
+### 4. Forward over the socket
+
+Send the corresponding `input/*` request. See
+[Copy-paste raw socket examples](unix-socket-api.md#copy-paste-raw-socket-examples) for
+one-liners you can pipe straight into the socket. The device id must come from the snapshot the
+input was mapped through, never from a device selection resolved at send time.
+
+Forward all inputs through **one ordered, bounded queue** so a tap-then-swipe-then-type sequence
+reaches the device in the order the user made it. If the queue is full (a stalled daemon), surface
+an overload error rather than dropping silently.
+
+### 5. Refresh from the stream, do not poll
+
+The `input/*` responses return the action result only; they do **not** carry a fresh observation
+and do **not** trigger one. After a successful input, **consume the next superseding snapshot from
+the stream you are already subscribed to — do not poll and do not issue a separate `observe`
+call.** Hold the pre-input snapshot on screen (still clickable) until a snapshot with a strictly
+greater capture identity arrives, or a 3 s timeout releases it. A failed or ignored input changes
+nothing on the device, so it clears nothing. Full state machine:
+[Post-input refresh policy](client-frame-snapshot.md#post-input-refresh-policy).
+
+## User feedback
+
+A client should give the user clear, non-noisy feedback:
+
+- **Success** — a brief transient indicator that an input was forwarded (the reference client
+  pulses a marker where a tap landed) plus the eventual stream refresh. Keep it transient.
+- **Failure** — surface the daemon's actionable error (e.g. an iOS `input/key` rejection, or an
+  older device that cannot type an uppercase character) through a dismissible banner.
+- **Blocked** — when control is unavailable, optionally explain why (device disconnected, frame
+  stale, capture identity unavailable). Debounce it so transient blips during normal streaming do
+  not flicker.
+
+None of this is required by the daemon; it is client UX guidance so control surfaces feel
+consistent.
+
+## Android vs iOS support matrix
+
+| Input | Android | iOS |
+| --- | --- | --- |
+| Tap (`input/tap`) | ✅ Supported | ✅ Supported |
+| Swipe / drag (`input/swipe`) | ✅ Supported | ✅ Supported |
+| Device buttons (`input/pressButton`) | ✅ Supported | ⚠️ Supported with platform gaps (unsupported buttons fail rather than being ignored) |
+| Discrete keys (`input/key`: Enter, Tab, arrows, …) | ✅ Supported | ❌ Unsupported — CtrlProxy exposes no discrete key events; the daemon returns an actionable error |
+| Printable text (`input/typeText`) | ✅ Supported via non-destructive `mode: "append"` | ❌ **Not forwarded by control clients** |
+
+**Why iOS text is disabled.** `input/typeText`'s default path *replaces* the focused field's
+contents, so typing one character per keystroke would wipe the field on every key. The
+non-destructive `mode: "append"` (real key events, adds to the field) is **Android-only** — iOS's
+control proxy has only the destructive set-text primitive, and the daemon rejects `mode: "append"`
+on iOS rather than silently replacing. A control client targeting iOS must therefore **not forward
+printable text at all**; a disabled typing path is strictly better than one that erases the field.
+Buttons and taps/swipes are unaffected, so control mode stays useful on iOS. Lifting this needs an
+iOS-side non-destructive insert primitive, tracked in
+[#4519](https://github.com/kaeawc/auto-mobile/issues/4519).
+
+Uppercase/shifted characters on Android need `input keycombination`, available only on API 31+. A
+client cannot see the device API level, so it forwards them anyway; an older device answers with an
+actionable error the client surfaces — a reported failure, not a silent loss.
+
+## Manual smoke plan
+
+No automated end-to-end coverage drives a real device screen from a mirror, so control is
+smoke-tested by hand. Run this after any change to the control path, on each platform, with the
+desktop app (or your client) connected to the daemon and a device/simulator streaming.
+
+**Android** (emulator or device):
+
+1. Enter control mode (open the Live Layout view on a real, selected device with a live frame).
+2. **Tap** a button; confirm the device actuates it and the touch pulse appears where you clicked.
+3. **Swipe** to scroll a list; confirm the list scrolls and a sub-24px nudge does nothing.
+4. **Button** — press `Esc`; confirm the device navigates back.
+5. **Text/keys** — focus a text field, type ASCII text (confirm it *appends*, not replaces),
+   press Enter/Tab/arrows/Backspace; confirm each maps to the device.
+6. Trigger a failure (e.g. overload the queue) and confirm the error banner shows and clears.
+
+**iOS** (simulator):
+
+1. Enter control mode as above.
+2. **Tap** and **swipe** — confirm both actuate.
+3. **Button** — `Esc` → back; confirm.
+4. **Text/keys** — confirm printable text is **not** forwarded (no field wipe) and `input/key`
+   presses surface an actionable error rather than being silently dropped.
+
+> **Status:** this plan is written but **manual execution is pending** — the sign-off environment
+> had no attached Android device or iOS simulator. Record pass/fail per step when a device fleet
+> is available.
+
+## Milestone sign-off and known deferrals
+
+The Client Screen Control milestone is complete. The following are intentionally deferred and
+tracked back to [#1099](https://github.com/kaeawc/auto-mobile/issues/1099):
+
+| Issue | Deferred item |
+| --- | --- |
+| [#4502](https://github.com/kaeawc/auto-mobile/issues/4502) | Close the same-device rotation window in the client control-tap gate. |
+| [#4505](https://github.com/kaeawc/auto-mobile/issues/4505) | Daemon-side frame-context validation so the *daemon* rejects stale-context input (protects clients that will not reimplement the client-side snapshot rules). |
+| [#4519](https://github.com/kaeawc/auto-mobile/issues/4519) | iOS non-destructive text append for keyboard forwarding. |
+| [#4533](https://github.com/kaeawc/auto-mobile/issues/4533) | Bound `ensureAdbPath` discovery so a cold cache cannot wedge the per-device input queue. |
+| [#4534](https://github.com/kaeawc/auto-mobile/issues/4534) | Evict the append cache on rapid same-serial device reuse (needs a device-connect signal). |
+| [#4535](https://github.com/kaeawc/auto-mobile/issues/4535) | Optional daemon capability signal for newer input params (e.g. `input/typeText mode:append`). |
+| [#4536](https://github.com/kaeawc/auto-mobile/issues/4536) | Prefer a reliable native AltGraph signal over the `ctrl && alt` heuristic. |
+| [#4537](https://github.com/kaeawc/auto-mobile/issues/4537) | Surface partial-progress (`charsSent`) on a failed multi-character `input/typeText` append over the wire. |

--- a/docs/design-docs/mcp/daemon/client-screen-control.md
+++ b/docs/design-docs/mcp/daemon/client-screen-control.md
@@ -43,6 +43,93 @@ the normative spec for its piece.
 | 4 | **Key-forwarding** and host-shortcut policy ([#3351](https://github.com/kaeawc/auto-mobile/issues/3351)) | [Screen Control Mapping → Keyboard forwarding policy](screen-control-mapping.md#keyboard-forwarding-policy) |
 | 5 | **Frame snapshot** pairing + **post-input refresh** ([#3348](https://github.com/kaeawc/auto-mobile/issues/3348)) | [Client Frame Snapshot](client-frame-snapshot.md) |
 
+## Observation stream protocol
+
+The frame snapshot in step 1 is assembled from the daemon's **observation stream**, a separate Unix
+socket from the request/response `input/*` API. This is the wire contract a client needs to connect;
+it is authoritative to `src/daemon/deviceDataStreamSocketServer.ts`.
+
+### Socket and framing
+
+- **Path:** `~/.auto-mobile/observation-stream.sock` (`$HOME/.auto-mobile/observation-stream.sock`).
+- **Framing:** newline-delimited JSON. Each request and each pushed message is a single JSON object
+  on its own line (`\n`-terminated). There is no length prefix.
+
+### Subscribe handshake
+
+Send a `subscribe` command; the daemon replies once, then pushes update messages until you
+`unsubscribe` or disconnect.
+
+```json
+// client -> daemon
+{ "id": "1", "command": "subscribe", "deviceId": "emulator-5554" }
+// daemon -> client
+{ "id": "1", "type": "subscription_response", "success": true }
+```
+
+- `deviceId` is **optional**: omit it (or send `null`) to receive frames for **all** devices; pass a
+  specific id to receive only that device's frames. A control client should subscribe to the one
+  device the user selected.
+- Optional `screenshotIntervalMs` / `hierarchyIntervalMs` on the `subscribe` request set the capture
+  cadence (daemon defaults: screenshot 3000 ms, hierarchy 1000 ms; minimum 250 ms). To change
+  cadence in place later, send `{ "command": "update_cadence", "screenshotIntervalMs": …,
+  "hierarchyIntervalMs": … }`; to stop, send `{ "command": "unsubscribe" }`. An older daemon that
+  does not know a command replies with a benign error and keeps its default cadence.
+
+### Pushed messages
+
+Every push carries a `type`, the `deviceId` it belongs to, and a display-only `timestamp`. Pair
+frames **only** across messages with the same `deviceId`.
+
+**`hierarchy_update`** — the element tree. Carries a `captureSequence` on **every** message.
+
+```json
+{
+  "type": "hierarchy_update",
+  "deviceId": "emulator-5554",
+  "timestamp": 1737942000123,
+  "data": { "hierarchy": { "…": "ViewHierarchyResult with element bounds" } },
+  "hierarchyDiff": { "…": "optional per-frame diff summary" },
+  "captureSequence": 42
+}
+```
+
+**`screenshot_update`** — the pixels. Carries a `captureSequence` **only when** the daemon verified
+that the frame's real pixel dimensions match the geometry its capture client claimed; otherwise the
+field is **absent** and a control client must fail closed for that frame.
+
+```json
+{
+  "type": "screenshot_update",
+  "deviceId": "emulator-5554",
+  "timestamp": 1737942000456,
+  "screenshotBase64": "<PNG bytes, base64>",
+  "screenWidth": 1080,
+  "screenHeight": 2340,
+  "captureSequence": 42
+}
+```
+
+**`error`** — a device-side problem (e.g. connection lost):
+`{ "type": "error", "deviceId": "…", "timestamp": …, "error": "device connection lost" }`.
+
+(The stream also pushes `navigation_update`, `performance_update`, and `storage_update`; a control
+client ignores them.)
+
+### Pairing and the active device
+
+- **Pair on `captureSequence`, never on `timestamp`.** A screenshot and a hierarchy describe the
+  same captured device state only when their `captureSequence` values are **equal**. `timestamp` is
+  display-only and mixes two clocks (a hierarchy's is the device wall clock, a screenshot's is the
+  daemon's), so it must not gate pairing. `captureSequence` is monotonic and never reset for the
+  daemon process lifetime, so an id cannot be reused across a device reconnect. A `screenshot_update`
+  with **no** `captureSequence` cannot be paired — fail closed. The full rationale and the rest of
+  the availability rules are in [Client Frame Snapshot](client-frame-snapshot.md).
+- **Active device:** every message's `deviceId` identifies its device. Subscribe with the selected
+  device's id (rather than the all-devices `null`) so you only receive its frames, and still confirm
+  each message's `deviceId` matches the selection before pairing — a lingering frame from a
+  previously-selected device must not pair with the new one.
+
 ## Implementing a client, end to end
 
 A control client is a loop: assemble a frame, map an input against it, forward it, wait for the
@@ -50,8 +137,9 @@ picture to catch up. Do these in order.
 
 ### 1. Subscribe and assemble a frame snapshot
 
-Subscribe to the daemon observation stream and consume `screenshot_update` and `hierarchy_update`
-messages. **Do not** act on either message alone. Assemble an immutable
+Subscribe to the daemon observation stream (wire protocol below:
+[Observation stream protocol](#observation-stream-protocol)) and consume `screenshot_update` and
+`hierarchy_update` messages. **Do not** act on either message alone. Assemble an immutable
 [frame snapshot](client-frame-snapshot.md#the-snapshot) that binds together, for one device:
 
 - the displayed pixels and their real dimensions,

--- a/docs/design-docs/mcp/daemon/screen-control-mapping.md
+++ b/docs/design-docs/mcp/daemon/screen-control-mapping.md
@@ -1,8 +1,11 @@
 # Client Screen Control: coordinate mapping contract
 
-<kbd>🚧 In progress</kbd>
+<kbd>✅ Implemented</kbd> <kbd>🧪 Tested</kbd>
 
 Part of milestone 28 (Client Screen Control), parent [#1099](https://github.com/kaeawc/auto-mobile/issues/1099).
+New to screen control? Start at the
+[third-party client guide](client-screen-control.md), which ties this document together with the
+`input/*` endpoints, the frame-snapshot rules, and the post-input refresh policy.
 This document specifies how a mirrored device screen converts a **viewport point**
 (a pixel the user clicked/dragged on the rendered canvas) into a **device
 coordinate** suitable for the typed daemon input helpers (`inputTap`,

--- a/docs/design-docs/plat/android/desktop-app.md
+++ b/docs/design-docs/plat/android/desktop-app.md
@@ -279,8 +279,31 @@ Tests live under `android/desktop-core/src/test/kotlin/` and cover:
 
 All fakes and test utilities follow the interface + fake pattern mandated by the project, with injectable time/clock for deterministic behavior.
 
+## Device Screen Control
+
+The Layout dashboard's device mirror is interactive in the desktop app: in *control mode* a click
+becomes a device tap, a drag becomes a swipe, and (on Android) keystrokes forward to the focused
+field. This is milestone 28 (parent [#1099](https://github.com/kaeawc/auto-mobile/issues/1099)),
+implemented across `desktop-domain` (pure policies) and `desktop-core` (the
+`DeviceControlSession` seam and `DeviceScreenView` wiring).
+
+- **Opt-in, default-off.** `AutoMobileContent(enableDeviceControl = ...)` gates it. The desktop app
+  passes `true`; `desktop-core`'s default is `false`.
+- **The IDE plugin is inspector-only.** It shares `desktop-core` but leaves `enableDeviceControl`
+  false, so it selects and highlights elements and **never forwards device input**. This is a
+  deliberate scope decision, not a dropped feature — control mode is a desktop-app (and third-party
+  daemon client) feature.
+- **Input goes over the daemon `input/*` socket endpoints**, not a bespoke protocol, so any client
+  can implement the same surface. The client-facing contracts (coordinate mapping, drag-to-swipe,
+  keyboard policy, frame-snapshot pairing, post-input refresh) are published for third-party
+  authors.
+
+User-facing docs: [Controlling a Device from the Desktop App](../../../using/screen-control.md).
+Client-author docs: [third-party client guide](../../mcp/daemon/client-screen-control.md).
+
 ## See Also
 
 - [Android Overview](index.md)
 - [Observe](observe.md) -- observation pipeline that feeds the Layout dashboard
 - [IDE Plugin](ide-plugin/) -- IntelliJ plugin that shares `desktop-core`
+- [Client Screen Control (third-party guide)](../../mcp/daemon/client-screen-control.md)

--- a/docs/using/screen-control.md
+++ b/docs/using/screen-control.md
@@ -18,13 +18,17 @@ AutoMobile daemon, see the
 3. When a live, paired frame is available for the selected real device, the mirror becomes
    **interactive automatically** — that is control mode. Until then it stays a read-only inspector.
 
-To **exit**, turn the **Live** toggle off, close the panel, or press **Escape** when the mirror is
-not focused. Leaving control mode returns the view to the ordinary inspector (click-to-select,
-hover-to-highlight).
+To **exit**, turn the **Live** toggle off or close the Layout panel. (Pressing **Escape** does not
+exit control mode: while the mirror is focused, Escape is forwarded to the device as the Back
+button; while it is unfocused, Escape only deselects/closes the inspector pane.) Leaving control
+mode returns the view to the ordinary inspector (click-to-select, hover-to-highlight).
 
-Control mode is **opt-in and only in the desktop app**. It never turns on for mock/demo data, for a
-device that is not explicitly selected, or when the stream is disconnected — in every one of those
-cases the mirror falls back to the plain inspector.
+Control mode is **opt-in**. Among AutoMobile's own surfaces only the desktop app enables it — the
+IDE plugin stays inspector-only — though any third-party client built on the daemon can offer the
+same control surface (see the
+[third-party client guide](../design-docs/mcp/daemon/client-screen-control.md)). It never turns on
+for mock/demo data, for a device that is not explicitly selected, or when the stream is
+disconnected — in every one of those cases the mirror falls back to the plain inspector.
 
 ## Supported interactions
 
@@ -45,8 +49,12 @@ A few details worth knowing:
   this stops pointer jitter from actuating the device.
 - **Keyboard needs focus.** Click the mirror first so it holds keyboard focus; only then do
   keystrokes forward. Clicking the mirror always re-focuses it.
-- **App/window shortcuts still work.** Any shortcut with Ctrl, Alt, or Cmd/Win stays with the
-  desktop app and is not sent to the device, so your menus and window shortcuts are unaffected.
+- **App/window shortcuts still work.** A shortcut with Ctrl, Alt, or Cmd/Win generally stays with
+  the desktop app and is not sent to the device, so your menus and window shortcuts are unaffected.
+  The one exception is character composition — AltGr on Windows/Linux, Option on macOS — which
+  still types the composed character; see the
+  [keyboard forwarding policy](../design-docs/mcp/daemon/screen-control-mapping.md#keyboard-forwarding-policy)
+  for the exact rule.
 
 ## Feedback
 

--- a/docs/using/screen-control.md
+++ b/docs/using/screen-control.md
@@ -1,0 +1,81 @@
+# Controlling a Device from the Desktop App
+
+The AutoMobile desktop app can mirror a connected device's screen **and drive it**. In *control
+mode* the mirrored screen becomes interactive: clicking taps the device, dragging swipes it, and —
+on Android — typing forwards to the focused field. This turns the Layout inspector from a
+read-only view into a hands-on remote for the device under test.
+
+This page is for people **using the desktop app**. If you are building your own client against the
+AutoMobile daemon, see the
+[third-party client guide](../design-docs/mcp/daemon/client-screen-control.md) instead.
+
+## Entering and exiting control mode
+
+1. Connect a device or simulator and make sure AutoMobile is observing it (the device is selected
+   in the left sidebar and its screen is streaming in the Layout inspector).
+2. Open the **Layout** inspector panel and turn on its **Live** toggle. The mirror starts showing
+   the live screen.
+3. When a live, paired frame is available for the selected real device, the mirror becomes
+   **interactive automatically** — that is control mode. Until then it stays a read-only inspector.
+
+To **exit**, turn the **Live** toggle off, close the panel, or press **Escape** when the mirror is
+not focused. Leaving control mode returns the view to the ordinary inspector (click-to-select,
+hover-to-highlight).
+
+Control mode is **opt-in and only in the desktop app**. It never turns on for mock/demo data, for a
+device that is not explicitly selected, or when the stream is disconnected — in every one of those
+cases the mirror falls back to the plain inspector.
+
+## Supported interactions
+
+| You do | The device gets |
+| --- | --- |
+| **Click** the mirror | A tap at that point |
+| **Drag** across the mirror | A swipe from where you pressed to where you released |
+| **`Esc`** (mirror focused) | The Back button |
+| **Enter / Tab / Backspace / Delete / arrow keys** | The matching key press (Android) |
+| **Type ASCII text** | The text, appended to the focused field (Android) |
+
+A few details worth knowing:
+
+- **Panning while in control mode.** A plain drag is a *swipe*, so to pan/scroll the mirror view
+  itself hold the zoom modifier (**Cmd** on macOS, **Ctrl** elsewhere) while dragging. Zoom with
+  the same modifier + scroll wheel, or the on-screen zoom buttons.
+- **Tiny drags do nothing.** A drag shorter than a small threshold is neither a swipe nor a tap —
+  this stops pointer jitter from actuating the device.
+- **Keyboard needs focus.** Click the mirror first so it holds keyboard focus; only then do
+  keystrokes forward. Clicking the mirror always re-focuses it.
+- **App/window shortcuts still work.** Any shortcut with Ctrl, Alt, or Cmd/Win stays with the
+  desktop app and is not sent to the device, so your menus and window shortcuts are unaffected.
+
+## Feedback
+
+- **Success** — a brief blue pulse appears where you tapped, confirming the input was forwarded.
+  Shortly after, the mirror refreshes to show the device's new state.
+- **Failure** — if an input fails (for example a key the device cannot accept), a dismissible error
+  banner explains what happened.
+- **Unavailable** — if control cannot be offered (device disconnected, frame stale), the mirror
+  quietly falls back to the read-only inspector, and a small notice may explain why.
+
+## Android vs iOS
+
+| Interaction | Android | iOS (simulator) |
+| --- | --- | --- |
+| Tap | ✅ | ✅ |
+| Drag → swipe | ✅ | ✅ |
+| Back button (`Esc`) | ✅ | ✅ |
+| Discrete keys (Enter, Tab, arrows) | ✅ | ❌ not available |
+| Typing text | ✅ (appended to the field) | ❌ **disabled** |
+
+**Why typing is disabled on iOS.** Forwarding text to iOS could only *replace* the whole field on
+every keystroke, wiping what is there. Rather than corrupt the field, control mode does not forward
+printable text to iOS at all. Tapping, swiping, and the Back button all work on iOS. Non-destructive
+iOS typing is a tracked follow-up
+([#4519](https://github.com/kaeawc/auto-mobile/issues/4519)).
+
+## The IDE plugin is inspector-only
+
+The IntelliJ / Android Studio plugin shares the same layout-inspector view but **does not offer
+control mode**. It selects and highlights elements only, and never sends input to the device. This
+is intentional — screen control is a desktop-app (and third-party client) feature, not an IDE
+plugin feature.

--- a/docs/using/screen-control.md
+++ b/docs/using/screen-control.md
@@ -51,8 +51,11 @@ A few details worth knowing:
   keystrokes forward. Clicking the mirror always re-focuses it.
 - **App/window shortcuts still work.** A shortcut with Ctrl, Alt, or Cmd/Win generally stays with
   the desktop app and is not sent to the device, so your menus and window shortcuts are unaffected.
-  The one exception is character composition — AltGr on Windows/Linux, Option on macOS — which
-  still types the composed character; see the
+  The one exception is character composition — AltGr on Windows/Linux, Option on macOS — but only
+  when it produces a **printable ASCII** character (`U+0020`–`U+007E`): that types on the device. A
+  composed non-ASCII character (`€`, `ß`, an accented letter) is **not** forwarded and stays with
+  the desktop app, the same ASCII-only limit that applies to typing in general (see
+  [#4519](https://github.com/kaeawc/auto-mobile/issues/4519)). See the
   [keyboard forwarding policy](../design-docs/mcp/daemon/screen-control-mapping.md#keyboard-forwarding-policy)
   for the exact rule.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,7 @@ nav:
           - 'Startup': using/perf-analysis/startup.md
           - 'Screen Transition': using/perf-analysis/screen-transition.md
           - 'Scroll Framerate': using/perf-analysis/scroll-framerate.md
+      - 'Device Screen Control': using/screen-control.md
       - 'Accessibility': using/a11y.md
       - 'TalkBack Testing': using/talkback.md
       - 'VoiceOver Testing': using/voiceover.md
@@ -122,6 +123,7 @@ nav:
              - 'Critical Section': design-docs/mcp/daemon/critical-section.md
              - 'Multi-Agent Filesystem Contract': design-docs/mcp/daemon/multi-agent-filesystem-contract.md
              - 'Unix Socket API': design-docs/mcp/daemon/unix-socket-api.md
+             - 'Client Screen Control (3rd-party guide)': design-docs/mcp/daemon/client-screen-control.md
              - 'Screen Control Mapping': design-docs/mcp/daemon/screen-control-mapping.md
              - 'Client Frame Snapshot': design-docs/mcp/daemon/client-frame-snapshot.md
           - 'Multi-device': design-docs/mcp/multi-device.md


### PR DESCRIPTION
## Summary

Polish, documentation, and sign-off for **Client Screen Control** — item **6/6** of milestone 28
(parent [#1099](https://github.com/kaeawc/auto-mobile/issues/1099)). The core input interactions
already shipped; this finishes the milestone by adding the one missing feedback surface,
consolidating the third-party client contract into a single entry point, adding desktop user docs,
and recording the deferrals.

Closes #3352

## What changed

### Light UI feedback (the one missing surface)

Error and block-reason feedback already existed (`DeviceControlTapErrorBanner`,
`DeviceControlBlockedNotice` from [#3351](https://github.com/kaeawc/auto-mobile/issues/3351) /
[#4531](https://github.com/kaeawc/auto-mobile/issues/4531)); **positive success feedback did not**.

- Added a pure, injected-clock `TouchFeedbackModel` in `desktop-domain` that holds transient
  touch-point pulses and resolves which are visible at a given instant.
- `DeviceScreenView` renders a brief fading/expanding blue pulse where a forwarded control tap
  landed. It is recorded **only for an in-bounds (actually forwarded) tap**, so it is honest and
  non-noisy, and is **inert in inspector mode** — zero `ide-plugin` impact.

### Documentation

- **New third-party client guide** — `docs/design-docs/mcp/daemon/client-screen-control.md`. A
  single entry point that ties together the `input/*` endpoints, coordinate mapping
  ([#3346](https://github.com/kaeawc/auto-mobile/issues/3346)), drag-to-swipe
  ([#3350](https://github.com/kaeawc/auto-mobile/issues/3350)), keyboard policy
  ([#3351](https://github.com/kaeawc/auto-mobile/issues/3351)), and frame-snapshot/refresh
  ([#3348](https://github.com/kaeawc/auto-mobile/issues/3348)) into an end-to-end walkthrough. A
  client author can implement screen control **from the docs alone**, without reading Compose code.
- **New desktop user doc** — `docs/using/screen-control.md`. How to enter/exit control mode,
  supported interactions (tap, drag→swipe, keyboard/text/buttons), feedback, and the Android vs iOS
  differences.
- Flipped `screen-control-mapping.md` and `client-frame-snapshot.md` status chips to
  Implemented/Tested and cross-linked the new guide.
- Documented in `desktop-app.md` (and the new docs) that the **IDE plugin is inspector-only** and
  never a control consumer — a deliberate scope decision, not a dropped feature.
- Wired both new pages into `mkdocs.yml` nav (`Using AutoMobile → Device Screen Control`; `Daemon →
  Client Screen Control (3rd-party guide)`).

### Manual smoke plan

A manual smoke plan covering tap/swipe/button/text/key for Android and iOS is written into the
third-party guide. **Manual execution is pending** — the sign-off environment had no attached
Android device or iOS simulator; pass/fail should be recorded per step when a fleet is available.

## Milestone 28 sign-off — Client Screen Control

| Issue | PR |
| --- | --- |
| [#3346 — control mode + coordinate mapping](https://github.com/kaeawc/auto-mobile/issues/3346) | [#4456](https://github.com/kaeawc/auto-mobile/pull/4456) |
| [#3347 — click-to-tap](https://github.com/kaeawc/auto-mobile/issues/3347) | [#4475](https://github.com/kaeawc/auto-mobile/pull/4475) |
| [#3348 — atomic frame snapshot + post-input refresh](https://github.com/kaeawc/auto-mobile/issues/3348) | [#4506](https://github.com/kaeawc/auto-mobile/pull/4506) |
| [#3350 — drag-to-swipe](https://github.com/kaeawc/auto-mobile/issues/3350) | [#4507](https://github.com/kaeawc/auto-mobile/pull/4507) |
| [#3351 — keyboard, text and button forwarding](https://github.com/kaeawc/auto-mobile/issues/3351) | [#4513](https://github.com/kaeawc/auto-mobile/pull/4513) |
| [#3352 — polish and sign off](https://github.com/kaeawc/auto-mobile/issues/3352) | this PR |

## Android vs iOS support matrix

| Input | Android | iOS |
| --- | --- | --- |
| Tap (`input/tap`) | ✅ | ✅ |
| Swipe / drag (`input/swipe`) | ✅ | ✅ |
| Device buttons (`input/pressButton`) | ✅ | ⚠️ platform gaps (unsupported buttons fail rather than being ignored) |
| Discrete keys (`input/key`) | ✅ | ❌ CtrlProxy exposes no discrete key events |
| Printable text (`input/typeText`) | ✅ non-destructive `mode: "append"` | ❌ not forwarded (only a destructive set-text primitive exists — see [#4519](https://github.com/kaeawc/auto-mobile/issues/4519)) |

## Deferred follow-ups (linked to [#1099](https://github.com/kaeawc/auto-mobile/issues/1099))

Already filed; captured here as the milestone's known deferrals — none duplicated:

- [#4502](https://github.com/kaeawc/auto-mobile/issues/4502) — close the same-device rotation window in the client control-tap gate.
- [#4505](https://github.com/kaeawc/auto-mobile/issues/4505) — daemon-side frame-context validation (stale-frame rejection; the durable cross-client fix).
- [#4519](https://github.com/kaeawc/auto-mobile/issues/4519) — iOS non-destructive text append.
- [#4533](https://github.com/kaeawc/auto-mobile/issues/4533) — bound `ensureAdbPath` discovery.
- [#4534](https://github.com/kaeawc/auto-mobile/issues/4534) — evict append cache on rapid same-serial reuse.
- [#4535](https://github.com/kaeawc/auto-mobile/issues/4535) — daemon capability signal for newer input params.
- [#4536](https://github.com/kaeawc/auto-mobile/issues/4536) — reliable native AltGraph signal.
- [#4537](https://github.com/kaeawc/auto-mobile/issues/4537) — surface partial-progress (`charsSent`) on a failed multi-character append.

## Validation

- `desktop-domain` + `desktop-core` compile clean (forced with `--rerun-tasks`).
- detekt (`detektMain` + `detektTest`) green on both modules.
- `desktop-core` tests: **791 passed, 0 failed** (6 pre-existing skips), including 9 new
  `TouchFeedbackModelTest` cases and the 13 existing `DeviceScreenViewControlTest` cases.
- Mutation check: flipping the pulse-expiry boundary (`>= 1f` → `> 1f`) fails
  `a pulse expires exactly at the duration boundary` (and the non-positive-duration case), confirming
  the tests pin the behavior.
- ktfmt applied; `mkdocs` nav validation passes.
- **Zero `ide-plugin` changes**; no `src/` (TypeScript) changes.

Do not enable auto-merge.
