### PR TITLE
test(action): seam Android launch lifecycle coverage

### DIFF
--- a/src/features/action/LaunchApp.ts
+++ b/src/features/action/LaunchApp.ts
@@ -1,7 +1,7 @@
 import { AdbClient } from "../../utils/android-cmdline-tools/AdbClient";
 import { AndroidUserTargetResolver } from "../../utils/android-cmdline-tools/AndroidUserTargetResolver";
 import { BaseVisualChange } from "./BaseVisualChange";
-import { BootedDevice, ClearAppDataResult, LaunchAppResult, ObserveResult } from "../../models";
+import { BootedDevice, ClearAppDataResult, LaunchAppResult, ObserveResult, TerminateAppResult } from "../../models";
 import { ActionableError } from "../../models";
 import { TerminateApp } from "./TerminateApp";
 import { ClearAppData } from "./ClearAppData";
@@ -35,6 +35,17 @@ export interface IosClearAppDataRunner {
   execute(bundleId: string): Promise<ClearAppDataResult>;
 }
 
+export interface AndroidClearAppDataAction {
+  execute(packageName: string, userId?: number): Promise<ClearAppDataResult>;
+}
+
+export interface AndroidColdBootAction {
+  execute(
+    packageName: string,
+    options?: { skipObservation?: boolean; userId?: number }
+  ): Promise<TerminateAppResult>;
+}
+
 /**
  * Launch an app on a physical iOS device via devicectl. Narrow injection point
  * so tests never shell out; parallels `DeviceAppUninstaller` in UninstallApp.
@@ -56,6 +67,8 @@ interface LaunchAppDependencies {
   performanceTrackerFactory?: () => PerformanceTracker;
   deviceAppLauncher?: DeviceAppLauncher;
   clearAppDataFactory?: (device: BootedDevice, simctl: SimCtlClient) => IosClearAppDataRunner;
+  createAndroidClearAppData?: (device: BootedDevice) => AndroidClearAppDataAction;
+  createAndroidColdBoot?: (device: BootedDevice) => AndroidColdBootAction;
 }
 
 export class LaunchApp extends BaseVisualChange {
@@ -66,6 +79,8 @@ export class LaunchApp extends BaseVisualChange {
   private installedAppsProvider: InstalledAppsProvider;
   private performanceTrackerFactory: () => PerformanceTracker;
   private clearAppDataFactory: (device: BootedDevice, simctl: SimCtlClient) => IosClearAppDataRunner;
+  private createAndroidClearAppData: (device: BootedDevice) => AndroidClearAppDataAction;
+  private createAndroidColdBoot: (device: BootedDevice) => AndroidColdBootAction;
   /**
    * Create an LaunchApp instance
    * @param device - Optional device
@@ -93,6 +108,20 @@ export class LaunchApp extends BaseVisualChange {
     this.clearAppDataFactory = dependencies.clearAppDataFactory ?? (
       (device, simctl) => new ClearAppDataIos(device, simctl)
     );
+    this.createAndroidClearAppData = this.resolveAndroidClearAppDataFactory(dependencies.createAndroidClearAppData);
+    this.createAndroidColdBoot = this.resolveAndroidColdBootFactory(dependencies.createAndroidColdBoot);
+  }
+
+  private resolveAndroidClearAppDataFactory(
+    factory: ((device: BootedDevice) => AndroidClearAppDataAction) | undefined
+  ): (device: BootedDevice) => AndroidClearAppDataAction {
+    return factory ?? (device => new ClearAppData(device));
+  }
+
+  private resolveAndroidColdBootFactory(
+    factory: ((device: BootedDevice) => AndroidColdBootAction) | undefined
+  ): (device: BootedDevice) => AndroidColdBootAction {
+    return factory ?? (device => new TerminateApp(device));
   }
 
   /**
@@ -605,12 +634,12 @@ export class LaunchApp extends BaseVisualChange {
     if (isRunning) {
       if (clearAppData) {
         await perf.track("clearAppData", async () => {
-          return new ClearAppData(this.device).execute(packageName, targetUserId);
+          return this.createAndroidClearAppData(this.device).execute(packageName, targetUserId);
         });
         didTerminateOrClear = true;
       } else if (coldBoot) {
         await perf.track("terminateApp", async () => {
-          return new TerminateApp(this.device).execute(packageName, { skipObservation: true, userId: targetUserId });
+          return this.createAndroidColdBoot(this.device).execute(packageName, { skipObservation: true, userId: targetUserId });
         });
         didTerminateOrClear = true;
       }
@@ -633,7 +662,7 @@ export class LaunchApp extends BaseVisualChange {
     } else {
       if (clearAppData) {
         await perf.track("clearAppData", async () => {
-          return new ClearAppData(this.device).execute(packageName, targetUserId);
+          return this.createAndroidClearAppData(this.device).execute(packageName, targetUserId);
         });
         didTerminateOrClear = true;
       }

--- a/test/features/action/ClearAppData.test.ts
+++ b/test/features/action/ClearAppData.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { ClearAppData } from "../../../src/features/action/ClearAppData";
+import { BootedDevice } from "../../../src/models";
+import type { AdbClientFactory } from "../../../src/utils/android-cmdline-tools/AdbClientFactory";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+
+const device: BootedDevice = {
+  name: "test-device",
+  platform: "android",
+  deviceId: "device-123",
+};
+
+function adbFactoryFor(adb: FakeAdbExecutor): AdbClientFactory {
+  return { create: () => adb };
+}
+
+describe("ClearAppData", () => {
+  test("clears the explicitly requested Android user", async () => {
+    const adb = new FakeAdbExecutor();
+    const clearAppData = new ClearAppData(device, adbFactoryFor(adb));
+
+    const result = await clearAppData.execute("com.example.app", 10);
+
+    expect(result).toEqual({ success: true, packageName: "com.example.app", userId: 10 });
+    expect(adb.getExecutedCommands()).toEqual(["shell pm clear --user 10 com.example.app"]);
+  });
+
+  test("uses the package foreground user when no user is explicitly requested", async () => {
+    const adb = new FakeAdbExecutor();
+    adb.setForegroundApp({ packageName: "com.example.app", userId: 11 });
+    const clearAppData = new ClearAppData(device, adbFactoryFor(adb));
+
+    const result = await clearAppData.execute("com.example.app");
+
+    expect(result).toEqual({ success: true, packageName: "com.example.app", userId: 11 });
+    expect(adb.getExecutedCommands()).toEqual(["shell pm clear --user 11 com.example.app"]);
+  });
+
+  test("returns a stable failure result when pm clear fails", async () => {
+    const adb = new FakeAdbExecutor();
+    adb.setCommandError("shell pm clear --user 10 com.example.app", new Error("adb failed"));
+    const clearAppData = new ClearAppData(device, adbFactoryFor(adb));
+
+    const result = await clearAppData.execute("com.example.app", 10);
+
+    expect(result).toEqual({
+      success: false,
+      packageName: "com.example.app",
+      userId: 10,
+      error: "Failed to clear application data",
+    });
+  });
+});

--- a/test/features/action/LaunchApp.test.ts
+++ b/test/features/action/LaunchApp.test.ts
@@ -117,6 +117,31 @@ describe("LaunchApp", () => {
     expect(fakeAdb.wasCommandExecuted(`shell monkey -p ${packageName} --user 0 1`)).toBe(true);
   });
 
+  test("clears Android app data through the injected action before relaunch when not running", async () => {
+    fakeTimer.enableAutoAdvance();
+    fakeAdb.setForegroundApp({ packageName, userId: 0 });
+    fakeAdb.setCommandResponse(`shell ps | grep ${packageName}`, { stdout: "0\n", stderr: "" });
+
+    const clearCalls: Array<{ device: BootedDevice; packageName: string; userId: number | undefined }> = [];
+    const lifecycleLaunchApp = new LaunchApp(device, fakeAdb as unknown as any, null, fakeTimer, {
+      createAndroidClearAppData: clearDevice => ({
+        execute: async (clearPackageName: string, userId?: number) => {
+          clearCalls.push({ device: clearDevice, packageName: clearPackageName, userId });
+          return { success: true, packageName: clearPackageName, userId };
+        },
+      }),
+    });
+    (lifecycleLaunchApp as any).awaitIdle = fakeAwaitIdle;
+    (lifecycleLaunchApp as any).observeScreen = fakeObserveScreen;
+    (lifecycleLaunchApp as any).window = fakeWindow;
+
+    const result = await lifecycleLaunchApp.execute(packageName, true, false);
+
+    expect(result.success).toBe(true);
+    expect(clearCalls).toEqual([{ device, packageName, userId: 0 }]);
+    expect(fakeAdb.wasCommandExecuted(`shell monkey -p ${packageName} --user 0 1`)).toBe(true);
+  });
+
   test("cold boots Android through the injected action before relaunch", async () => {
     fakeTimer.enableAutoAdvance();
     fakeAdb.setForegroundApp({ packageName, userId: 0 });

--- a/test/features/action/LaunchApp.test.ts
+++ b/test/features/action/LaunchApp.test.ts
@@ -77,6 +77,90 @@ describe("LaunchApp", () => {
     expect(fakeAwaitIdle.wasMethodCalled("initializeUiStabilityTracking")).toBe(true);
   });
 
+  test("clears Android app data through the injected action before relaunch", async () => {
+    fakeTimer.enableAutoAdvance();
+    fakeAdb.setForegroundApp({ packageName, userId: 0 });
+    fakeAdb.setCommandResponse(`shell ps | grep ${packageName}`, { stdout: "1\n", stderr: "" });
+
+    const clearCalls: Array<{ device: BootedDevice; packageName: string; userId: number | undefined }> = [];
+    const coldBootCalls: Array<{ packageName: string; options: unknown }> = [];
+    const lifecycleLaunchApp = new LaunchApp(device, fakeAdb as unknown as any, null, fakeTimer, {
+      createAndroidClearAppData: clearDevice => ({
+        execute: async (clearPackageName: string, userId?: number) => {
+          clearCalls.push({ device: clearDevice, packageName: clearPackageName, userId });
+          return { success: true, packageName: clearPackageName, userId };
+        },
+      }),
+      createAndroidColdBoot: () => ({
+        execute: async (coldBootPackageName: string, options?: unknown) => {
+          coldBootCalls.push({ packageName: coldBootPackageName, options });
+          return {
+            success: true,
+            packageName: coldBootPackageName,
+            wasInstalled: true,
+            wasRunning: true,
+            wasForeground: false,
+            userId: 0,
+          };
+        },
+      }),
+    });
+    (lifecycleLaunchApp as any).awaitIdle = fakeAwaitIdle;
+    (lifecycleLaunchApp as any).observeScreen = fakeObserveScreen;
+    (lifecycleLaunchApp as any).window = fakeWindow;
+
+    const result = await lifecycleLaunchApp.execute(packageName, true, false);
+
+    expect(result.success).toBe(true);
+    expect(clearCalls).toEqual([{ device, packageName, userId: 0 }]);
+    expect(coldBootCalls).toEqual([]);
+    expect(fakeAdb.wasCommandExecuted(`shell monkey -p ${packageName} --user 0 1`)).toBe(true);
+  });
+
+  test("cold boots Android through the injected action before relaunch", async () => {
+    fakeTimer.enableAutoAdvance();
+    fakeAdb.setForegroundApp({ packageName, userId: 0 });
+    fakeAdb.setCommandResponse(`shell ps | grep ${packageName}`, { stdout: "1\n", stderr: "" });
+
+    const clearCalls: string[] = [];
+    const coldBootCalls: Array<{ device: BootedDevice; packageName: string; options: unknown }> = [];
+    const lifecycleLaunchApp = new LaunchApp(device, fakeAdb as unknown as any, null, fakeTimer, {
+      createAndroidClearAppData: () => ({
+        execute: async (clearPackageName: string) => {
+          clearCalls.push(clearPackageName);
+          return { success: true, packageName: clearPackageName };
+        },
+      }),
+      createAndroidColdBoot: coldBootDevice => ({
+        execute: async (coldBootPackageName: string, options?: unknown) => {
+          coldBootCalls.push({ device: coldBootDevice, packageName: coldBootPackageName, options });
+          return {
+            success: true,
+            packageName: coldBootPackageName,
+            wasInstalled: true,
+            wasRunning: true,
+            wasForeground: false,
+            userId: 0,
+          };
+        },
+      }),
+    });
+    (lifecycleLaunchApp as any).awaitIdle = fakeAwaitIdle;
+    (lifecycleLaunchApp as any).observeScreen = fakeObserveScreen;
+    (lifecycleLaunchApp as any).window = fakeWindow;
+
+    const result = await lifecycleLaunchApp.execute(packageName, false, true);
+
+    expect(result.success).toBe(true);
+    expect(clearCalls).toEqual([]);
+    expect(coldBootCalls).toEqual([{
+      device,
+      packageName,
+      options: { skipObservation: true, userId: 0 },
+    }]);
+    expect(fakeAdb.wasCommandExecuted(`shell monkey -p ${packageName} --user 0 1`)).toBe(true);
+  });
+
   test("waits for foreground before returning observation", async () => {
     fakeAdb.setForegroundApp(null);
     fakeAdb.setCommandResponse(`shell ps | grep ${packageName}`, { stdout: "0\n", stderr: "" });

--- a/test/features/action/LaunchApp.test.ts
+++ b/test/features/action/LaunchApp.test.ts
@@ -44,6 +44,10 @@ describe("LaunchApp", () => {
     fakeAdb.setCommandResponse("shell pm list packages -s --user 0", { stdout: "", stderr: "" });
   };
 
+  const hasStartedAppLaunch = () => fakeAdb.getExecutedCommands().some(command =>
+    command.includes("shell am start --user 0") || command.includes(`shell monkey -p ${packageName}`)
+  );
+
   beforeEach(() => {
     device = { name: "test-device", platform: "android", deviceId: "device-123" };
     fakeAdb = new FakeAdbExecutor();
@@ -87,12 +91,14 @@ describe("LaunchApp", () => {
     const lifecycleLaunchApp = new LaunchApp(device, fakeAdb as unknown as any, null, fakeTimer, {
       createAndroidClearAppData: clearDevice => ({
         execute: async (clearPackageName: string, userId?: number) => {
+          expect(hasStartedAppLaunch()).toBe(false);
           clearCalls.push({ device: clearDevice, packageName: clearPackageName, userId });
           return { success: true, packageName: clearPackageName, userId };
         },
       }),
       createAndroidColdBoot: () => ({
         execute: async (coldBootPackageName: string, options?: unknown) => {
+          expect(hasStartedAppLaunch()).toBe(false);
           coldBootCalls.push({ packageName: coldBootPackageName, options });
           return {
             success: true,
@@ -126,6 +132,7 @@ describe("LaunchApp", () => {
     const lifecycleLaunchApp = new LaunchApp(device, fakeAdb as unknown as any, null, fakeTimer, {
       createAndroidClearAppData: clearDevice => ({
         execute: async (clearPackageName: string, userId?: number) => {
+          expect(hasStartedAppLaunch()).toBe(false);
           clearCalls.push({ device: clearDevice, packageName: clearPackageName, userId });
           return { success: true, packageName: clearPackageName, userId };
         },
@@ -158,6 +165,7 @@ describe("LaunchApp", () => {
       }),
       createAndroidColdBoot: coldBootDevice => ({
         execute: async (coldBootPackageName: string, options?: unknown) => {
+          expect(hasStartedAppLaunch()).toBe(false);
           coldBootCalls.push({ device: coldBootDevice, packageName: coldBootPackageName, options });
           return {
             success: true,


### PR DESCRIPTION
## Summary

- Inject Android clear-data and cold-boot actions into `LaunchApp` while retaining the existing production defaults.
- Cover both running-app lifecycle branches with deterministic fake actions and `FakeTimer`.
- Add `ClearAppData` unit coverage for explicit and inferred users plus the stable failure result.

## Why

`LaunchApp` constructed its Android collaborators directly, so the `clearAppData` and `coldBoot` paths could not be exercised at unit level. This adds the narrow constructor seams needed to guard their routing without changing device behavior.

## Validation

- `bun test test/features/action/LaunchApp.test.ts test/features/action/ClearAppData.test.ts`
- `bun run lint`
- `bun run turbo:validate`
- `bun run typecheck` (no new errors; existing baseline unchanged)
- `git diff --check`
- Mutation checks: bypassing each injected lifecycle action or replacing `pm clear` made its focused test fail.

Closes [#4486](https://github.com/kaeawc/auto-mobile/issues/4486)
