### PR TITLE
fix: correct dead code detector false positives

### DIFF
--- a/scripts/detect-dead-code-ts.sh
+++ b/scripts/detect-dead-code-ts.sh
@@ -87,6 +87,13 @@ if [ $TS_PRUNE_EXIT -eq 0 ] || [ -s "$TS_PRUNE_OUTPUT" ]; then
             continue
         fi
 
+        # ts-prune marks exports referenced within their own module separately;
+        # they are not dead-code candidates. Keep this aligned with
+        # dead-code:ts:prune in package.json.
+        if [[ "$line" == *" (used in module)" ]]; then
+            continue
+        fi
+
         # Parse: src/file.ts:123 - exportName (used in module)
         if [[ "$line" =~ ^(.+):([0-9]+)[[:space:]]*-[[:space:]]*(.+)$ ]]; then
             file="${BASH_REMATCH[1]}"

--- a/test/bats/portability-cosmetic.bats
+++ b/test/bats/portability-cosmetic.bats
@@ -33,6 +33,39 @@ teardown() {
   [[ "$output" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+Z$ ]]
 }
 
+@test "dead-code detection excludes ts-prune exports used in their module" {
+  local detector
+  detector="$(cd scripts && pwd)/detect-dead-code-ts.sh"
+  local bin="$WORK_DIR/bin"
+  local report="$WORK_DIR/report"
+  mkdir -p "$bin" "$WORK_DIR/scripts"
+  : > "$WORK_DIR/scripts/fixture.sh"
+
+  cat > "$bin/bunx" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1" = "ts-prune" ]; then
+  printf '%s\n' \
+    'src/example.ts:1 - UsedExport (used in module)' \
+    'src/example.ts:2 - DeadExport'
+  exit 1
+fi
+
+if [ "$1" = "knip" ]; then
+  printf '%s\n' '{}'
+  exit 0
+fi
+
+exit 2
+EOF
+  chmod +x "$bin/bunx"
+
+  run env PATH="$bin:$PATH" bash -c 'cd "$1" && "$2" --json --output-dir="$3" --threshold=1' _ "$WORK_DIR" "$detector" "$report"
+
+  [ "$status" -eq 0 ]
+  [ "$(jq '.totalIssues' "$report/dead-code-report.json")" -eq 1 ]
+  [ "$(jq -r '.issues[0].name' "$report/dead-code-report.json")" = "DeadExport" ]
+}
+
 # --- B ---------------------------------------------------------------------
 @test "shell/xml validators do not use a bare -P \"\$(nproc)\"" {
   for s in scripts/shellcheck/validate_shell_scripts.sh scripts/xml/validate_xml.sh; do


### PR DESCRIPTION
## Summary

- Exclude `ts-prune` exports reported as "used in module" from the dead-code report.
- Add a regression test that preserves genuinely unused exports in the report.

## Root cause

`dead-code:ts` parsed `ts-prune`'s informational "used in module" entries as unused exports, unlike the existing `dead-code:ts:prune` command. This inflated the report from 7 actionable candidates to 331 and exceeded the configured threshold.

## Validation

- `bats test/bats/portability-cosmetic.bats`
- `bash scripts/all_fast_validate_checks.sh --group shell --no-parallel`
- `bun run dead-code:ts --output-dir=scratch/dead-code-after-4532 --threshold=10` (7 candidates; passes threshold)
- `bun run turbo:validate` (11,615 passed; 13 skipped)
- `bun run typecheck` (no new errors; 206 known baseline errors)

Closes [#4532](https://github.com/kaeawc/auto-mobile/issues/4532)
