### PR TITLE
fix(desktop): prefer native AltGraph on Linux

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceKeyboardEventTranslator.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceKeyboardEventTranslator.kt
@@ -15,6 +15,28 @@ import dev.jasonpearson.automobile.desktop.domain.DeviceKeyboardKey
 /** Whether this host is macOS. Resolved once; the composition rule below branches on it. */
 private val IS_MAC = System.getProperty("os.name", "").contains("Mac", ignoreCase = true)
 
+/** Whether this host is Linux, where AWT's native AltGraph signal is reliable. */
+private val IS_LINUX = System.getProperty("os.name", "").contains("Linux", ignoreCase = true)
+
+/** Compose Desktop's public key-event wrapper retains its AWT event behind an internal carrier. */
+private val COMPOSE_NATIVE_EVENT_GETTER = runCatching {
+  Class.forName("androidx.compose.ui.input.key.InternalKeyEvent").getMethod("getNativeEvent")
+}
+  .getOrNull()
+
+/**
+ * Returns AWT's AltGraph state when Compose Desktop exposes its retained native event.
+ *
+ * Compose 1.11.1 makes the carrier type internal, so this narrowly uses its public JVM getter. A
+ * missing or changed carrier returns null so the caller can retain the Ctrl+Alt fallback rather
+ * than regressing AltGr input.
+ */
+private fun KeyEvent.nativeAltGraphDown(): Boolean? = runCatching {
+  COMPOSE_NATIVE_EVENT_GETTER?.invoke(nativeKeyEvent) as? java.awt.event.KeyEvent
+}
+  .getOrNull()
+  ?.isAltGraphDown
+
 /**
  * Translates a Compose key event into the Compose-free [DeviceKeyStroke] that
  * [dev.jasonpearson.automobile.desktop.domain.DeviceKeyboardInputPolicy] decides on (issue #3351).
@@ -52,8 +74,12 @@ object DeviceKeyboardEventTranslator {
       Key.DirectionRight to DeviceKeyboardKey.ArrowRight,
     )
 
-  /** Translate a live Compose [event]. */
-  fun translate(event: KeyEvent): DeviceKeyStroke =
+  /** Translate a live Compose [event]. Platform inputs are injectable for the native-event test. */
+  fun translate(
+    event: KeyEvent,
+    isMac: Boolean = IS_MAC,
+    isLinux: Boolean = IS_LINUX,
+  ): DeviceKeyStroke =
     translate(
       key = event.key,
       utf16CodePoint = event.utf16CodePoint,
@@ -64,6 +90,9 @@ object DeviceKeyboardEventTranslator {
           meta = event.isMetaPressed,
           shift = event.isShiftPressed,
         ),
+      isMac = isMac,
+      isLinux = isLinux,
+      isAltGraphDown = event.nativeAltGraphDown(),
     )
 
   /**
@@ -75,21 +104,27 @@ object DeviceKeyboardEventTranslator {
    * point yields a null character, so the policy ignores the keystroke rather than mangling it —
    * multi-unit input is IME territory, explicitly out of scope for #3351.
    *
-   * @param isMac the host platform, injectable so the composition rule below is unit-testable
+   * @param isMac whether the host is macOS, injectable so the composition rule is unit-testable
    *   without a real `os.name`; defaults to this host.
+   * @param isLinux whether the host is Linux, where native AltGraph is reliable; defaults to this
+   *   host.
+   * @param isAltGraphDown AWT's native AltGraph state, or null when the toolkit cannot expose it.
+   *   It is injectable because primitive translation tests do not construct an AWT event.
    */
   fun translate(
     key: Key,
     utf16CodePoint: Int,
     modifiers: DeviceKeyModifiers,
     isMac: Boolean = IS_MAC,
+    isLinux: Boolean = IS_LINUX,
+    isAltGraphDown: Boolean? = null,
   ): DeviceKeyStroke =
     DeviceKeyStroke(
       key = DEVICE_KEYS[key],
       character =
         utf16CodePoint.takeIf { it in Char.MIN_VALUE.code..Char.MAX_VALUE.code }?.toChar(),
       modifiers = modifiers,
-      altComposesText = resolvesAltComposition(modifiers, isMac),
+      altComposesText = resolvesAltComposition(modifiers, isMac, isLinux, isAltGraphDown),
     )
 
   /**
@@ -97,32 +132,34 @@ object DeviceKeyboardEventTranslator {
    * than a menu/window accelerator. This is the platform decision the pure policy cannot make; it
    * lives here because only the toolkit adapter sees the host OS and AWT's modifier masks.
    *
-   * - **Windows/Linux:** composition is AltGr, which AWT surfaces as **Ctrl+Alt**. A plain `Alt`
-   *   (no Ctrl) is a menu accelerator (`Alt+F` → File) — and AWT still reports a printable keyChar
-   *   for it — so it must NOT count as composition or the canvas would swallow the host's mnemonic.
+   * - **Linux:** composition is native AltGraph. A genuine Ctrl+Alt host shortcut has the native
+   *   AltGraph state unset, so it stays with the host.
+   * - **Windows:** composition is AltGr, which many JDKs expose only as **Ctrl+Alt**. The native
+   *   AltGraph state is not reliable there, so the Ctrl+Alt fallback remains. A plain `Alt` (no
+   *   Ctrl) is a menu accelerator (`Alt+F` → File) and must NOT count as composition or the canvas
+   *   would swallow the host's mnemonic.
    * - **macOS:** composition is the **Option** key (plain Alt, no Ctrl) — Option+L = `@` — and
    *   macOS menus use Cmd/Meta, never Alt, so plain Alt is safe to treat as composition there.
    *
    * Meta always disqualifies: `Cmd`/`Meta` shortcuts never compose characters, so Meta-held is the
    * reliable "shortcut, not typing" signal on every platform.
    *
-   * KNOWN LIMITATION (Windows/Linux): the `ctrl && alt` test is a heuristic, not a true AltGraph
-   * detector. AWT does expose an AltGraph signal — the native
-   * [java.awt.event.KeyEvent.isAltGraphDown] behind
-   * [androidx.compose.ui.input.key.KeyEvent.nativeKeyEvent], mirrored by Compose's
-   * `PointerKeyboardModifiers.isAltGraphPressed` — but it is NOT reliable on the platform that
-   * needs it: many Windows JDKs report a real AltGr keystroke as plain Ctrl+Alt with the ALT_GRAPH
-   * mask UNSET, so AltGr and a genuine Ctrl+Alt host shortcut are indistinguishable there.
-   * Requiring the mask would therefore regress AltGr typing (`@`, `€`, `{`) on those JDKs —
-   * breaking the common case the exception exists for — to fix only the rare
-   * genuine-Ctrl+Alt-shortcut-with-a-printable- char case. So the heuristic stays: a Ctrl+Alt host
-   * shortcut that happens to produce a printable character on some Windows/Linux layout is
-   * forwarded to the device rather than reaching the host. Tracked in #4536; if a reliable
-   * per-platform AltGraph signal becomes available, thread it in alongside `isMac` and prefer it
-   * over `ctrl && alt`.
+   * KNOWN LIMITATION (Windows): many Windows JDKs report a real AltGr keystroke as plain Ctrl+Alt
+   * with the native ALT_GRAPH mask unset. Therefore Windows keeps the Ctrl+Alt heuristic: a genuine
+   * Ctrl+Alt host shortcut that produces a printable character can still be forwarded to the
+   * device. Linux uses the reliable native signal instead. Tracked in #4536.
    */
-  private fun resolvesAltComposition(modifiers: DeviceKeyModifiers, isMac: Boolean): Boolean {
+  private fun resolvesAltComposition(
+    modifiers: DeviceKeyModifiers,
+    isMac: Boolean,
+    isLinux: Boolean,
+    isAltGraphDown: Boolean?,
+  ): Boolean {
     if (modifiers.meta || !modifiers.alt) return false
-    return isMac || modifiers.ctrl
+    return when {
+      isMac -> true
+      isLinux && isAltGraphDown != null -> isAltGraphDown
+      else -> modifiers.ctrl
+    }
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceKeyboardEventTranslator.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceKeyboardEventTranslator.kt
@@ -147,7 +147,7 @@ object DeviceKeyboardEventTranslator {
    * KNOWN LIMITATION (Windows): many Windows JDKs report a real AltGr keystroke as plain Ctrl+Alt
    * with the native ALT_GRAPH mask unset. Therefore Windows keeps the Ctrl+Alt heuristic: a genuine
    * Ctrl+Alt host shortcut that produces a printable character can still be forwarded to the
-   * device. Linux uses the reliable native signal instead. Tracked in #4536.
+   * device. Linux uses the reliable native signal instead.
    */
   private fun resolvesAltComposition(
     modifiers: DeviceKeyModifiers,

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceKeyboardEventTranslatorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceKeyboardEventTranslatorTest.kt
@@ -126,8 +126,8 @@ class DeviceKeyboardEventTranslatorTest {
   }
 
   @Test
-  fun `live Linux event reads native AltGraph through Compose`() {
-    val awtEvent =
+  fun `live Linux events read native AltGraph through Compose`() {
+    val altGraphEvent =
       AwtKeyEvent(
         Canvas(),
         AwtKeyEvent.KEY_PRESSED,
@@ -139,11 +139,31 @@ class DeviceKeyboardEventTranslatorTest {
 
     assertTrue(
       DeviceKeyboardEventTranslator.translate(
-          composeEvent(awtEvent),
+          composeEvent(altGraphEvent),
           isMac = false,
           isLinux = true,
         )
         .altComposesText
+    )
+
+    val ctrlAltShortcut =
+      AwtKeyEvent(
+        Canvas(),
+        AwtKeyEvent.KEY_PRESSED,
+        0L,
+        InputEvent.CTRL_DOWN_MASK or InputEvent.ALT_DOWN_MASK,
+        AwtKeyEvent.VK_F,
+        'f',
+      )
+    assertEquals(
+      DeviceKeyboardDecision.Ignored(DeviceKeyboardRejection.HostChord),
+      DeviceKeyboardInputPolicy.evaluate(
+        DeviceKeyboardEventTranslator.translate(
+          composeEvent(ctrlAltShortcut),
+          isMac = false,
+          isLinux = true,
+        )
+      ),
     )
   }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceKeyboardEventTranslatorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceKeyboardEventTranslatorTest.kt
@@ -7,6 +7,9 @@ import dev.jasonpearson.automobile.desktop.domain.DeviceKeyboardDecision
 import dev.jasonpearson.automobile.desktop.domain.DeviceKeyboardInputPolicy
 import dev.jasonpearson.automobile.desktop.domain.DeviceKeyboardKey
 import dev.jasonpearson.automobile.desktop.domain.DeviceKeyboardRejection
+import java.awt.Canvas
+import java.awt.event.InputEvent
+import java.awt.event.KeyEvent as AwtKeyEvent
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -18,6 +21,16 @@ import kotlin.test.assertTrue
  * meaning, and which code points survive as a typable character.
  */
 class DeviceKeyboardEventTranslatorTest {
+
+  private fun composeEvent(event: AwtKeyEvent): androidx.compose.ui.input.key.KeyEvent {
+    val nativeEvent =
+      Class.forName("androidx.compose.ui.input.key.KeyEvent_desktopKt")
+        .getMethod("toComposeEvent", AwtKeyEvent::class.java)
+        .invoke(null, event)
+    return (Class.forName("androidx.compose.ui.input.key.KeyEvent")
+      .getMethod("box-impl", Any::class.java)
+      .invoke(null, nativeEvent) as androidx.compose.ui.input.key.KeyEvent)
+  }
 
   private fun translate(key: Key, codePoint: Int = 0) =
     DeviceKeyboardEventTranslator.translate(key, codePoint, DeviceKeyModifiers())
@@ -70,20 +83,67 @@ class DeviceKeyboardEventTranslatorTest {
   // character or is a menu accelerator. `alt && printable` alone cannot tell them apart, because on
   // Windows/Linux AWT reports a printable keyChar for a plain Alt+F accelerator too.
 
-  private fun resolvedAltComposition(modifiers: DeviceKeyModifiers, isMac: Boolean): Boolean =
-    DeviceKeyboardEventTranslator.translate(Key.A, 'x'.code, modifiers, isMac).altComposesText
+  private fun resolvedAltComposition(
+    modifiers: DeviceKeyModifiers,
+    isMac: Boolean = false,
+    isLinux: Boolean = false,
+    isAltGraphDown: Boolean = false,
+  ): Boolean =
+    DeviceKeyboardEventTranslator.translate(
+        Key.A,
+        'x'.code,
+        modifiers,
+        isMac,
+        isLinux,
+        isAltGraphDown,
+      )
+      .altComposesText
 
   @Test
-  fun `on Windows or Linux only Ctrl+Alt is composition, plain Alt is a menu accelerator`() {
-    // Restores the original AltGr shape: AltGr surfaces as Ctrl+Alt, so that composes; a plain Alt
-    // is Alt+F-style menu access and must NOT be treated as composition.
+  fun `on Windows Ctrl+Alt is composition and plain Alt is a menu accelerator`() {
+    // Windows JDKs do not reliably set the native AltGraph mask, so its Ctrl+Alt fallback stays.
     assertTrue(
       resolvedAltComposition(DeviceKeyModifiers(ctrl = true, alt = true), isMac = false),
-      "AltGr (Ctrl+Alt) composes on Windows/Linux",
+      "AltGr (Ctrl+Alt) composes on Windows",
     )
     assertFalse(
       resolvedAltComposition(DeviceKeyModifiers(alt = true), isMac = false),
       "plain Alt is a menu accelerator on Windows/Linux, not composition",
+    )
+  }
+
+  @Test
+  fun `on Linux only native AltGraph is composition`() {
+    val modifiers = DeviceKeyModifiers(ctrl = true, alt = true)
+    assertTrue(
+      resolvedAltComposition(modifiers, isLinux = true, isAltGraphDown = true),
+      "native AltGraph composes on Linux",
+    )
+    assertFalse(
+      resolvedAltComposition(modifiers, isLinux = true, isAltGraphDown = false),
+      "a genuine Linux Ctrl+Alt shortcut stays with the host",
+    )
+  }
+
+  @Test
+  fun `live Linux event reads native AltGraph through Compose`() {
+    val awtEvent =
+      AwtKeyEvent(
+        Canvas(),
+        AwtKeyEvent.KEY_PRESSED,
+        0L,
+        InputEvent.CTRL_DOWN_MASK or InputEvent.ALT_DOWN_MASK or InputEvent.ALT_GRAPH_DOWN_MASK,
+        AwtKeyEvent.VK_A,
+        '@',
+      )
+
+    assertTrue(
+      DeviceKeyboardEventTranslator.translate(
+          composeEvent(awtEvent),
+          isMac = false,
+          isLinux = true,
+        )
+        .altComposesText
     )
   }
 
@@ -113,10 +173,19 @@ class DeviceKeyboardEventTranslatorTest {
   private fun decideForChar(
     codePoint: Int,
     modifiers: DeviceKeyModifiers,
-    isMac: Boolean,
+    isMac: Boolean = false,
+    isLinux: Boolean = false,
+    isAltGraphDown: Boolean = false,
   ): DeviceKeyboardDecision {
     val stroke: DeviceKeyStroke =
-      DeviceKeyboardEventTranslator.translate(Key.A, codePoint, modifiers, isMac)
+      DeviceKeyboardEventTranslator.translate(
+        Key.A,
+        codePoint,
+        modifiers,
+        isMac,
+        isLinux,
+        isAltGraphDown,
+      )
     return DeviceKeyboardInputPolicy.evaluate(stroke)
   }
 
@@ -135,6 +204,19 @@ class DeviceKeyboardEventTranslatorTest {
     assertEquals(
       DeviceKeyboardDecision.TypeText("@"),
       decideForChar('@'.code, DeviceKeyModifiers(ctrl = true, alt = true), isMac = false),
+    )
+  }
+
+  @Test
+  fun `Linux native AltGraph types while Ctrl+Alt shortcut stays with the host`() {
+    val modifiers = DeviceKeyModifiers(ctrl = true, alt = true)
+    assertEquals(
+      DeviceKeyboardDecision.TypeText("@"),
+      decideForChar('@'.code, modifiers, isLinux = true, isAltGraphDown = true),
+    )
+    assertEquals(
+      DeviceKeyboardDecision.Ignored(DeviceKeyboardRejection.HostChord),
+      decideForChar('f'.code, modifiers, isLinux = true),
     )
   }
 

--- a/docs/design-docs/mcp/daemon/screen-control-mapping.md
+++ b/docs/design-docs/mcp/daemon/screen-control-mapping.md
@@ -266,15 +266,22 @@ and macOS Option — and it is **platform-dependent**, so the host (not the pure
 policy) must resolve it. The rule is:
 
 ```text
-altComposesText = printable && !meta && ( isMac ? alt : (ctrl && alt) )
+altComposesText = printable && !meta && when {
+  isMac -> alt
+  isLinux && nativeAltGraph != null -> alt && nativeAltGraph
+  else -> ctrl && alt
+}
 ```
 
-- **Windows/Linux:** composition is **AltGr**, which AWT/Compose surfaces as
-  **Ctrl+Alt** (`@`, `€`, `{`, `\`). A *plain* Alt (no Ctrl) is a **menu
-  accelerator** — `Alt+F` opens File — and, crucially, AWT reports a printable
-  `keyChar` for it too. So `alt && printable` cannot tell them apart; treating
-  plain Alt as composition would **swallow the host's menu shortcut** and type the
-  letter into the device instead. Only Ctrl+Alt composes here.
+- **Linux:** composition is **AltGr**, identified by AWT's native
+  `isAltGraphDown()` signal. A genuine Ctrl+Alt shortcut has AltGraph unset, so
+  it stays with the host rather than typing its printable character into the
+  device.
+- **Windows:** composition is **AltGr**, but many JDKs surface it only as
+  **Ctrl+Alt** (`@`, `€`, `{`, `\`) and leave the native AltGraph flag unset. The
+  Ctrl+Alt fallback is therefore retained. A *plain* Alt (no Ctrl) is a **menu
+  accelerator** — `Alt+F` opens File — and AWT reports a printable `keyChar` for
+  it too, so it must not count as composition.
 - **macOS:** composition is the **Option** key, which is plain **Alt** (Option+L =
   `@`, Option+5 = `[`), and macOS menus use **Cmd/Meta, never Alt** — so plain Alt
   is safe to treat as composition on macOS only.
@@ -292,18 +299,15 @@ when it also produced a **typable ASCII** character. A porting client on another
 host must make the same platform-aware decision rather than inferring composition
 from `alt && printable`.
 
-**Known limitation (Windows/Linux).** The `ctrl && alt` test above is a heuristic,
-not a true AltGraph detector. AWT does expose an AltGraph signal (the native
+**Known limitation (Windows).** The `ctrl && alt` fallback is a heuristic, not a
+true AltGraph detector. AWT exposes an AltGraph signal (the native
 `java.awt.event.KeyEvent.isAltGraphDown()` behind Compose's `KeyEvent.nativeKeyEvent`,
-mirrored by `PointerKeyboardModifiers.isAltGraphPressed`), but it is unreliable on
-the platform that needs it: many Windows JDKs report a real AltGr keystroke as plain
-Ctrl+Alt with the `ALT_GRAPH` mask **unset**, making AltGr and a genuine Ctrl+Alt
-host shortcut indistinguishable there. Requiring the mask would regress AltGr typing
-(`@`, `€`, `{`) on those JDKs — the common case this exception exists for — to fix
-only the rare case of a Ctrl+Alt host shortcut that happens to carry a printable
-character. So the heuristic stays, with the accepted consequence that **such a
-Ctrl+Alt host shortcut may be forwarded to the device rather than reaching the host**
-on some Windows/Linux layouts. Tracked for a reliable-signal fix in
+mirrored by `PointerKeyboardModifiers.isAltGraphPressed`), but many Windows JDKs
+report a real AltGr keystroke as plain Ctrl+Alt with the `ALT_GRAPH` mask **unset**.
+Requiring the mask would regress common AltGr typing (`@`, `€`, `{`) on those JDKs.
+The accepted consequence is that **a genuine Ctrl+Alt host shortcut that produces a
+printable character may still be forwarded to the device rather than reaching the
+host** on Windows. Linux uses the reliable native signal. Tracked in
 [#4536](https://github.com/kaeawc/auto-mobile/issues/4536).
 
 A client that knows its own host leaves a particular chord unclaimed may opt it in
@@ -518,9 +522,10 @@ key-over-character precedence, the control-character filter, the character-keyed
 chord allowlist, the platform text gate, and the printable-ASCII range from both
 sides (every character in `U+0020`–`U+007E` forwards; `é`/`€`/CJK are declined and
 left unconsumed). `DeviceKeyboardEventTranslatorTest` pins the platform-aware
-resolution of that flag (Ctrl+Alt composes on Windows/Linux and plain Alt does
-not; plain Alt composes on macOS; Meta never does) end-to-end through the policy,
-parameterized by an injected `isMac` so both platforms are deterministic. `InputText.test.ts` pins the daemon append mode itself: it
+resolution of that flag (native AltGraph composes on Linux; Ctrl+Alt remains the
+Windows fallback; plain Alt composes on macOS; Meta never does) end-to-end through
+the policy, parameterized by injected platform and AltGraph inputs so every branch
+is deterministic. `InputText.test.ts` pins the daemon append mode itself: it
 issues key events and makes **no** `ACTION_SET_TEXT` call and **no** clear, so N
 single-character calls accumulate; that uppercase fails with an actionable error
 below API 31 and succeeds at 31+; and that every adb round trip is charged against

--- a/docs/design-docs/mcp/daemon/screen-control-mapping.md
+++ b/docs/design-docs/mcp/daemon/screen-control-mapping.md
@@ -307,8 +307,7 @@ report a real AltGr keystroke as plain Ctrl+Alt with the `ALT_GRAPH` mask **unse
 Requiring the mask would regress common AltGr typing (`@`, `€`, `{`) on those JDKs.
 The accepted consequence is that **a genuine Ctrl+Alt host shortcut that produces a
 printable character may still be forwarded to the device rather than reaching the
-host** on Windows. Linux uses the reliable native signal. Tracked in
-[#4536](https://github.com/kaeawc/auto-mobile/issues/4536).
+host** on Windows. Linux uses the reliable native signal.
 
 A client that knows its own host leaves a particular chord unclaimed may opt it in
 explicitly (`forwardedChords`). The default list is **empty**. Entries match


### PR DESCRIPTION
## Summary

- Prefer AWT's native AltGraph state for Linux keyboard forwarding.
- Keep the Ctrl+Alt fallback on Windows, where JDKs may omit the AltGraph mask.
- Pin Linux native-event routing, Linux Ctrl+Alt shortcut preservation, and the existing macOS/Windows behavior.

## Why

The prior Ctrl+Alt heuristic could forward a genuine Linux host shortcut that carried a printable character. Compose Desktop retains the AWT event in an internal carrier, so the translator reads its public JVM getter and falls back to the existing heuristic if a future toolkit cannot expose that carrier.

## Impact

Linux AltGr still types on the device, while Ctrl+Alt without native AltGraph remains available to the host. Windows compatibility and macOS Option behavior are unchanged.

Closes [#4536](https://github.com/kaeawc/auto-mobile/issues/4536).

## Validation

- `./gradlew :desktop-core:test --tests dev.jasonpearson.automobile.desktop.core.control.DeviceKeyboardEventTranslatorTest :desktop-core:detekt`
- `./gradlew :desktop-core:test`
- `scripts/all_fast_validate_checks.sh --only ktfmt --max-parallel 1`
- `bun run turbo:validate`
- `bun run typecheck`
