### PR TITLE
test(action): isolate Android permission tracker

### DIFF
--- a/src/features/action/GrantAndroidPermissions.ts
+++ b/src/features/action/GrantAndroidPermissions.ts
@@ -3,7 +3,7 @@ import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/A
 import { AndroidUserTargetResolver } from "../../utils/android-cmdline-tools/AndroidUserTargetResolver";
 import { BootedDevice, GrantAndroidPermissionItemResult, GrantAndroidPermissionsResult } from "../../models";
 import { logger } from "../../utils/logger";
-import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
+import { createGlobalPerformanceTracker, type PerformanceTracker } from "../../utils/PerformanceTracker";
 import { outputLooksLikeShellFailure } from "../../utils/android-cmdline-tools/shellOutputHeuristics";
 import { shellQuote } from "../../utils/shellQuote";
 
@@ -22,13 +22,20 @@ export class GrantAndroidPermissions {
 
   private adb: AdbExecutor;
 
-  constructor(device: BootedDevice, adbFactory: AdbClientFactory = defaultAdbClientFactory) {
+  private createPerformanceTracker: () => PerformanceTracker;
+
+  constructor(
+    device: BootedDevice,
+    adbFactory: AdbClientFactory = defaultAdbClientFactory,
+    performanceTrackerFactory: () => PerformanceTracker = createGlobalPerformanceTracker
+  ) {
     this.device = device;
     this.adb = adbFactory.create(device);
+    this.createPerformanceTracker = performanceTrackerFactory;
   }
 
   async execute(packageName: string, input: GrantAndroidPermissionsInput): Promise<GrantAndroidPermissionsResult> {
-    const perf = createGlobalPerformanceTracker();
+    const perf = this.createPerformanceTracker();
     perf.serial("changeAndroidPermissions");
 
     const permissions = input.permissions ?? [];
@@ -57,7 +64,7 @@ export class GrantAndroidPermissions {
     permissions: string[],
     userId: number | undefined,
     action: Exclude<AndroidPermissionChangeAction, "reset">,
-    perf: ReturnType<typeof createGlobalPerformanceTracker>
+    perf: PerformanceTracker
   ): Promise<GrantAndroidPermissionsResult> {
     if (permissions.length === 0) {
       perf.end();
@@ -163,7 +170,7 @@ export class GrantAndroidPermissions {
     packageName: string,
     permissions: string[],
     userId: number | undefined,
-    perf: ReturnType<typeof createGlobalPerformanceTracker>
+    perf: PerformanceTracker
   ): Promise<GrantAndroidPermissionsResult> {
     const resetPermissions = permissions;
     if (userId !== undefined) {

--- a/test/features/action/GrantAndroidPermissions.test.ts
+++ b/test/features/action/GrantAndroidPermissions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { BootedDevice } from "../../../src/models";
 import { GrantAndroidPermissions } from "../../../src/features/action/GrantAndroidPermissions";
+import { NoOpPerformanceTracker } from "../../../src/utils/PerformanceTracker";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 
 const androidDevice: BootedDevice = {
@@ -258,14 +259,31 @@ describe("GrantAndroidPermissions", () => {
     expect(result.error).toBe("Failed step(s): pm_grant:(empty)");
   });
 
-  // NOTE: the "aggregates failed step operationIds into the error message" test was
-  // removed here — it passed locally (bun/turbo/coverage/isolation, 15x) but failed
-  // deterministically on ubuntu+macos+windows CI, unreproducible locally. The action's
-  // execute() drives its work through a process-wide createGlobalPerformanceTracker()
-  // singleton, so the failure is cross-test-order coupling that only surfaces under CI's
-  // file scheduling. Re-adding it needs a perf-tracker injection seam (a production
-  // change) — tracked in the follow-up. The `Failed step(s): …` aggregate is still
-  // partially exercised by the reset-permissions failure path elsewhere in this file.
+  test.each([
+    ["grant", "android.permission.SEND_SMS"],
+    ["revoke", "android.permission.CAMERA"],
+  ] as const)("reports the failed %s operation ID when setting a permission fails", async (actionType, permission) => {
+    const factory = new FakeAdbClientFactory();
+    const client = factory.getFakeClient();
+    client.setCommandError(
+      `shell pm ${actionType} --user 0 'com.example.app' '${permission}'`,
+      new Error("java.lang.SecurityException: Permission denial")
+    );
+
+    const action = new GrantAndroidPermissions(
+      androidDevice,
+      factory,
+      () => new NoOpPerformanceTracker()
+    );
+    const result = await action.execute("com.example.app", {
+      action: actionType,
+      permissions: [permission],
+      userId: 0,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe(`Failed step(s): pm_${actionType}:${permission}`);
+  });
 
   test("non-Android device returns structured failure without adb", async () => {
     const factory = new FakeAdbClientFactory();


### PR DESCRIPTION
## Summary

Inject a performance-tracker factory into `GrantAndroidPermissions`, retaining
the global tracker as the production default. The unit test now uses its own
`NoOpPerformanceTracker` and verifies the aggregate failed-operation message
for both permission-setting actions: `grant` and `revoke`.

## Linked Issue

Closes [issue #4492](https://github.com/kaeawc/auto-mobile/issues/4492)

## Bug / Regression Context

- **Prior attempt:** [PR #4489](https://github.com/kaeawc/auto-mobile/pull/4489) removed the aggregate-error test after it failed deterministically only in CI.
- **Observed symptom:** the test's configured failed `pm` command was reported as successful under CI file scheduling, despite repeated local runs passing.
- **Root-cause hypothesis:** process-wide debug-performance state could couple test files. This change gives the test an isolated tracker without changing production tracking.

## Validation

- [x] `bun test test/features/action/GrantAndroidPermissions.test.ts` — 14 passing tests; the new cases cover `grant` and `revoke` and each ran in under 1 ms.
- [x] Mutation proof: changing emitted operation IDs made both new cases fail; restored behavior passes.
- [x] `bun run turbo:validate`
- [x] `bun run typecheck` — no new errors against the repository baseline.
- [x] `git diff --check`
- [x] Rebased on the fetched current `main` before implementation.
