### PR TITLE
fix(desktop): fix forward client screen control signoff review findings (#4546)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceScreenView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceScreenView.kt
@@ -91,8 +91,8 @@ private val IS_MAC = System.getProperty("os.name", "").contains("Mac", ignoreCas
 
 /**
  * Base radius, in frame pixels at zoom 1.0, of the transient control-tap feedback pulse
- * (issue #3352). Placed via the marker's captured `frameOffset`, and grown further as the pulse
- * fades.
+ * (issue #3352). Placed via `touchFeedbackCenter` (the canonical mapper through the marker's
+ * captured bounds, #4546), and grown further as the pulse fades.
  */
 private const val TOUCH_PULSE_BASE_RADIUS_PX = 12f
 
@@ -433,14 +433,16 @@ fun DeviceScreenView(
   LaunchedEffect(controlMode) {
     if (controlMode != DeviceScreenControlMode.Control) touchFeedback.reset()
   }
-  // Drop pulses when the device rotates mid-fade (issue #3352): a marker is placed by scaling its
-  // captured device point through its captured bounds, which only holds within the orientation it
-  // was captured in — after a portrait<->landscape flip the same point maps into a differently
-  // shaped frame and would land outside the clipped canvas. Keying on the orientation flag fires
-  // this only on an actual flip, so a same-orientation resolution change keeps its pulses.
-  val controlSnapshotLandscape = controlSnapshot?.let { it.deviceWidth > it.deviceHeight }
-  LaunchedEffect(controlSnapshotLandscape) {
-    controlSnapshot?.let { touchFeedback.retainOnlyOrientation(it.deviceWidth, it.deviceHeight) }
+  // Drop pulses when the device frame changes shape mid-fade (issues #3352, #4546): a marker is
+  // placed by mapping its captured device point through its captured bounds, which only holds
+  // while the frame keeps the aspect it was captured against. Both a portrait<->landscape flip AND
+  // a same-orientation aspect change (1080x2340 -> 1080x1920) reshape the frame, so keying on the
+  // snapshot dimensions fires the cleanup on any dimension change; the model's aspect-tolerance
+  // rule then retains equal-aspect pulses (a plain resolution change keeps them) and drops the
+  // reshaped ones.
+  val controlSnapshotDims = controlSnapshot?.let { it.deviceWidth to it.deviceHeight }
+  LaunchedEffect(controlSnapshotDims) {
+    controlSnapshot?.let { touchFeedback.retainOnlyMatchingAspect(it.deviceWidth, it.deviceHeight) }
   }
   LaunchedEffect(touchFeedbackGeneration, controlMode) {
     if (controlMode != DeviceScreenControlMode.Control) return@LaunchedEffect
@@ -1023,12 +1025,14 @@ fun DeviceScreenView(
                   }
 
                   // Transient touch-point feedback (issue #3352): a blue pulse at each forwarded
-                  // control tap, fading and expanding over its lifetime. Each marker is placed
-                  // through its OWN captured snapshot bounds (frameOffset), not the live
+                  // control tap, fading and expanding over its lifetime. Each marker is placed by
+                  // the canonical mapper through its OWN captured snapshot bounds
+                  // (touchFeedbackCenter -> deviceToViewport, #4546), not the live
                   // boundsToFrameScale — so it lands where the tap mapped and does not drift if a
                   // resolution/rotation change arrives mid-fade. Empty in inspector mode.
                   for (feedback in activeTouchFeedback) {
-                    val center = feedback.frameOffset(size.width)
+                    val center =
+                      touchFeedbackCenter(feedback.marker, size.width, size.height) ?: continue
                     val alpha = (1f - feedback.progress).coerceIn(0f, 1f)
                     val radius = TOUCH_PULSE_BASE_RADIUS_PX * (0.7f + 0.6f * feedback.progress)
                     val pulseColor = Color(0xFF2196F3)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/TouchFeedbackPlacement.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/TouchFeedbackPlacement.kt
@@ -1,0 +1,39 @@
+package dev.jasonpearson.automobile.desktop.core.layout
+
+import dev.jasonpearson.automobile.desktop.domain.DeviceScreenCoordinateMapper
+import dev.jasonpearson.automobile.desktop.domain.DeviceScreenGeometry
+import dev.jasonpearson.automobile.desktop.domain.TouchFeedbackMarker
+import dev.jasonpearson.automobile.desktop.domain.ViewportPoint
+
+/**
+ * The center, in frame pixels, at which to draw the touch pulse for [marker] on a frame canvas of
+ * [frameWidthPx] x [frameHeightPx] (issues #3352, #4546).
+ *
+ * Routes through the canonical [DeviceScreenCoordinateMapper.deviceToViewport] rather than a
+ * private inverse transform, so pulse placement can never drift from the mapper the tap itself was
+ * mapped with. The geometry is built from the marker's OWN captured snapshot bounds — not the live
+ * device dimensions — so the pulse lands where the tap mapped and does not move if a resolution or
+ * rotation change arrives mid-fade. The pulse is drawn inside the frame's own draw scope (the
+ * zoom/pan `graphicsLayer` already transforms the canvas), so scale is 1 and pan is 0 here.
+ *
+ * Returns `null` for a degenerate non-positive captured width: such a snapshot has no addressable
+ * pixel to place a pulse at, so no pulse is drawn.
+ */
+internal fun touchFeedbackCenter(
+  marker: TouchFeedbackMarker,
+  frameWidthPx: Float,
+  frameHeightPx: Float,
+): ViewportPoint? {
+  if (marker.deviceWidth <= 0) return null
+  val geometry =
+    DeviceScreenGeometry(
+      frameWidthPx = frameWidthPx,
+      frameHeightPx = frameHeightPx,
+      scale = 1f,
+      offsetX = 0f,
+      offsetY = 0f,
+      deviceWidth = marker.deviceWidth,
+      deviceHeight = marker.deviceHeight,
+    )
+  return DeviceScreenCoordinateMapper.deviceToViewport(marker.x, marker.y, geometry)
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/TouchFeedbackModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/TouchFeedbackModelTest.kt
@@ -1,7 +1,5 @@
 package dev.jasonpearson.automobile.desktop.core.control
 
-import dev.jasonpearson.automobile.desktop.domain.ActiveTouchFeedback
-import dev.jasonpearson.automobile.desktop.domain.TouchFeedbackMarker
 import dev.jasonpearson.automobile.desktop.domain.TouchFeedbackModel
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -11,9 +9,11 @@ import kotlin.test.assertTrue
 /**
  * The pure transient touch-feedback model (issue #3352). The clock is injected — a mutable
  * monotonic fake — so the fade transitions run with no timer: record, age partway, age out, cap,
- * reset, the dispatch gate, monotonic aging, and the captured-geometry rendering, the same way the
- * other `desktop-domain` policies are tested. Aging reads the injected clock, so a model that read
- * a real clock instead would leave a pulse un-aged under the fed clock (see the monotonic test).
+ * reset, the dispatch gate, monotonic aging, and the aspect-based geometry retention, the same way
+ * the other `desktop-domain` policies are tested. Aging reads the injected clock, so a model that
+ * read a real clock instead would leave a pulse un-aged under the fed clock (see the monotonic
+ * test). Placement itself is covered in `TouchFeedbackPlacementTest`, which pins the render path to
+ * the canonical [dev.jasonpearson.automobile.desktop.domain.DeviceScreenCoordinateMapper].
  */
 class TouchFeedbackModelTest {
 
@@ -186,48 +186,11 @@ class TouchFeedbackModelTest {
     assertEquals(1, model.active().size)
   }
 
-  // --- Captured geometry (issue #3352, finding B): the pulse renders through the snapshot bounds
-  // it was captured with, not a later/live geometry. ---
+  // --- Geometry retention (issues #3352, #4546): a mid-pulse frame reshape drops stale markers.
+  // The rule is aspect-based, so it catches both rotations and same-orientation aspect changes. ---
 
   @Test
-  fun `frameOffset scales through the marker's captured device width, not a live one`() {
-    // A center tap captured against a 1080-wide snapshot.
-    val marker =
-      TouchFeedbackMarker(
-        x = 540,
-        y = 1170,
-        deviceWidth = 1080,
-        deviceHeight = 2340,
-        startedAtMs = 0L,
-      )
-    val active = ActiveTouchFeedback(marker = marker, progress = 0f)
-
-    // Rendered into a 540px-wide frame: exactly half device -> the frame center x.
-    val offset = active.frameOffset(frameWidthPx = 540f)
-    assertEquals(270f, offset.x)
-    assertEquals(585f, offset.y)
-
-    // The SAME device point captured against a different (e.g. post-resolution-change) snapshot
-    // width lands at a DIFFERENT frame offset for the same frame — proving the captured width, not
-    // a live dimension, drives placement.
-    val staleWidthMarker = marker.copy(deviceWidth = 720)
-    val staleOffset = ActiveTouchFeedback(staleWidthMarker, 0f).frameOffset(540f)
-    assertEquals(405f, staleOffset.x)
-  }
-
-  @Test
-  fun `frameOffset yields the origin for a degenerate zero-width snapshot`() {
-    val marker =
-      TouchFeedbackMarker(x = 5, y = 9, deviceWidth = 0, deviceHeight = 0, startedAtMs = 0L)
-    val offset = ActiveTouchFeedback(marker, 0f).frameOffset(540f)
-    assertEquals(0f, offset.x)
-    assertEquals(0f, offset.y)
-  }
-
-  // --- Orientation (issue #3352): a rotation mid-pulse drops stale-oriented markers. ---
-
-  @Test
-  fun `retainOnlyOrientation drops pulses after a portrait to landscape flip`() {
+  fun `retainOnlyMatchingAspect drops pulses after a portrait to landscape flip`() {
     val model = model()
     now = 0L
     // Captured in portrait (w < h).
@@ -235,20 +198,57 @@ class TouchFeedbackModelTest {
     assertEquals(1, model.active().size)
 
     // Device rotates to landscape (w > h): the portrait marker no longer maps into the frame.
-    model.retainOnlyOrientation(deviceWidth = 2340, deviceHeight = 1080)
+    model.retainOnlyMatchingAspect(deviceWidth = 2340, deviceHeight = 1080)
     assertTrue(model.active().isEmpty())
   }
 
   @Test
-  fun `retainOnlyOrientation keeps pulses on a same-orientation resolution change`() {
+  fun `retainOnlyMatchingAspect keeps pulses on an equal-aspect resolution change`() {
     val model = model()
     now = 0L
     // Captured in portrait 1080x2340.
     model.record(x = 540, y = 1170, deviceWidth = 1080, deviceHeight = 2340)
 
-    // A same-orientation resolution change (still portrait) must NOT drop the pulse — the captured
-    // bounds already place it correctly.
-    model.retainOnlyOrientation(deviceWidth = 720, deviceHeight = 1560)
+    // An equal-aspect resolution change (720x1560 has the same 13:6 aspect) must NOT drop the
+    // pulse — the captured bounds already place it correctly in the same-shaped frame.
+    model.retainOnlyMatchingAspect(deviceWidth = 720, deviceHeight = 1560)
     assertEquals(1, model.active().size)
+  }
+
+  @Test
+  fun `retainOnlyMatchingAspect drops pulses on a same-orientation aspect change`() {
+    // The finding behind #4546: an orientation-keyed rule kept this marker even though a
+    // portrait -> portrait resolution change (1080x2340 -> 1080x1920) reshapes the frame, leaving
+    // a marker near the old bottom edge mapped below the new frame.
+    val model = model()
+    now = 0L
+    model.record(x = 540, y = 2200, deviceWidth = 1080, deviceHeight = 2340)
+    assertEquals(1, model.active().size)
+
+    model.retainOnlyMatchingAspect(deviceWidth = 1080, deviceHeight = 1920)
+    assertTrue(model.active().isEmpty())
+  }
+
+  @Test
+  fun `retainOnlyMatchingAspect keeps pulses within the geometry tolerance`() {
+    // Aspect within DeviceControlPolicy's 5% relative geometry tolerance is "the same shape":
+    // 1080x2340 (2.1667) vs 1080x2300 (2.1296) differ by ~1.7%, so the pulse is retained.
+    val model = model()
+    now = 0L
+    model.record(x = 540, y = 1170, deviceWidth = 1080, deviceHeight = 2340)
+
+    model.retainOnlyMatchingAspect(deviceWidth = 1080, deviceHeight = 2300)
+    assertEquals(1, model.active().size)
+  }
+
+  @Test
+  fun `retainOnlyMatchingAspect drops every pulse for a degenerate current dimension`() {
+    // Non-positive current dimensions describe no drawable frame, so nothing can be vouched for.
+    val model = model()
+    now = 0L
+    model.record(x = 540, y = 1170, deviceWidth = 1080, deviceHeight = 2340)
+
+    model.retainOnlyMatchingAspect(deviceWidth = 0, deviceHeight = 2340)
+    assertTrue(model.active().isEmpty())
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/TouchFeedbackPlacementTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/TouchFeedbackPlacementTest.kt
@@ -1,0 +1,77 @@
+package dev.jasonpearson.automobile.desktop.core.layout
+
+import dev.jasonpearson.automobile.desktop.domain.DeviceScreenCoordinateMapper
+import dev.jasonpearson.automobile.desktop.domain.DeviceScreenGeometry
+import dev.jasonpearson.automobile.desktop.domain.TouchFeedbackMarker
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Pulse placement must be the canonical mapper's inverse transform, not a private re-derivation
+ * (issue #4546): `touchFeedbackCenter` builds a [DeviceScreenGeometry] from the marker's own
+ * captured snapshot bounds and delegates to [DeviceScreenCoordinateMapper.deviceToViewport]. These
+ * tests pin both the delegation (any drift from the mapper's output fails) and the concrete values
+ * the old width-based transform produced, so the API move is behavior-preserving.
+ */
+class TouchFeedbackPlacementTest {
+
+  private fun marker(x: Int, y: Int, w: Int, h: Int) =
+    TouchFeedbackMarker(x = x, y = y, deviceWidth = w, deviceHeight = h, startedAtMs = 0L)
+
+  @Test
+  fun `placement scales through the marker's captured device width, not a live one`() {
+    // A center tap captured against a 1080-wide snapshot, rendered into a 540px-wide frame:
+    // exactly half device -> the frame center x. Same values the pre-#4546 transform produced.
+    val center = touchFeedbackCenter(marker(540, 1170, 1080, 2340), 540f, 1170f)
+    assertNotNull(center)
+    assertEquals(270f, center.x)
+    assertEquals(585f, center.y)
+
+    // The SAME device point captured against a different (e.g. post-resolution-change) snapshot
+    // width lands at a DIFFERENT frame offset for the same frame — proving the captured width,
+    // not a live dimension, drives placement.
+    val stale = touchFeedbackCenter(marker(540, 1170, 720, 1560), 540f, 1170f)
+    assertNotNull(stale)
+    assertEquals(405f, stale.x)
+  }
+
+  @Test
+  fun `placement equals the canonical mapper's deviceToViewport for the marker geometry`() {
+    // Delegation pin: for a spread of markers and frame sizes, the placement is byte-identical to
+    // calling the canonical mapper with the frame-local geometry (scale 1, no pan, captured
+    // bounds). A placement path that re-derives its own transform diverges here as soon as the
+    // mapper changes — which is the drift #4546 exists to prevent.
+    val cases =
+      listOf(
+        Triple(marker(0, 0, 1080, 2340), 540f, 1170f),
+        Triple(marker(1079, 2339, 1080, 2340), 540f, 1170f),
+        Triple(marker(333, 777, 720, 1560), 411f, 890.5f),
+        Triple(marker(100, 200, 2340, 1080), 900f, 415.4f),
+      )
+    for ((m, frameW, frameH) in cases) {
+      val expected =
+        DeviceScreenCoordinateMapper.deviceToViewport(
+          m.x,
+          m.y,
+          DeviceScreenGeometry(
+            frameWidthPx = frameW,
+            frameHeightPx = frameH,
+            scale = 1f,
+            offsetX = 0f,
+            offsetY = 0f,
+            deviceWidth = m.deviceWidth,
+            deviceHeight = m.deviceHeight,
+          ),
+        )
+      assertEquals(expected, touchFeedbackCenter(m, frameW, frameH))
+    }
+  }
+
+  @Test
+  fun `a degenerate zero-width snapshot places no pulse`() {
+    // No addressable pixel to place a pulse at -> nothing is drawn (the draw loop skips it).
+    assertNull(touchFeedbackCenter(marker(5, 9, 0, 0), 540f, 1170f))
+  }
+}

--- a/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/TouchFeedback.kt
+++ b/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/TouchFeedback.kt
@@ -1,5 +1,7 @@
 package dev.jasonpearson.automobile.desktop.domain
 
+import kotlin.math.abs
+
 /**
  * A transient marker for a control-mode input the client actually forwarded, used to draw a brief
  * touch pulse where a tap landed (issue #3352).
@@ -19,31 +21,19 @@ public data class TouchFeedbackMarker(
   val startedAtMs: Long,
 )
 
-/** Frame-pixel center of a pulse, produced by [ActiveTouchFeedback.frameOffset]. */
-public data class TouchFeedbackFrameOffset(val x: Float, val y: Float)
-
 /**
  * A [TouchFeedbackMarker] still visible at a given instant, with its fade resolved.
  *
  * [progress] runs from `0.0` at the instant the input was forwarded to `1.0` at the moment the
  * pulse fully expires, so a UI layer derives alpha (`1 - progress`) and an expanding radius from it
  * without repeating the clock math.
+ *
+ * Placement is NOT resolved here: a renderer maps [marker]'s device point back to frame pixels by
+ * building a [DeviceScreenGeometry] from the marker's own captured bounds and calling the canonical
+ * [DeviceScreenCoordinateMapper.deviceToViewport] — one inverse transform for the whole module, so
+ * a mapper fix can never leave pulse placement behind (issue #4546).
  */
-public data class ActiveTouchFeedback(val marker: TouchFeedbackMarker, val progress: Float) {
-  /**
-   * The pulse's center in frame pixels, for a device frame [frameWidthPx] wide.
-   *
-   * Scaled through the marker's OWN captured [TouchFeedbackMarker.deviceWidth] — a single
-   * width-based ratio for both axes, the exact inverse of the width-based viewport→device mapping —
-   * so the pulse lands where the tap did and cannot drift when the live frame geometry changes
-   * mid-fade. A non-positive captured width yields the origin (a degenerate snapshot has no
-   * addressable pixel to place a pulse at).
-   */
-  public fun frameOffset(frameWidthPx: Float): TouchFeedbackFrameOffset {
-    val scale = if (marker.deviceWidth > 0) frameWidthPx / marker.deviceWidth else 0f
-    return TouchFeedbackFrameOffset(marker.x * scale, marker.y * scale)
-  }
-}
+public data class ActiveTouchFeedback(val marker: TouchFeedbackMarker, val progress: Float)
 
 /**
  * Holds the transient touch-feedback pulses for a mirrored device screen and resolves which are
@@ -121,20 +111,37 @@ public class TouchFeedbackModel(
   }
 
   /**
-   * Drop pulses whose captured orientation no longer matches the current [deviceWidth] x
-   * [deviceHeight] (issue #3352).
+   * Drop pulses whose captured aspect ratio no longer matches the current [deviceWidth] x
+   * [deviceHeight] (issues #3352, #4546).
    *
-   * A marker is placed by scaling its captured device point through its captured bounds
-   * ([ActiveTouchFeedback.frameOffset]), which is exact only within the orientation it was captured
-   * in. If the device rotates during a pulse (portrait↔landscape — the width/height aspect flips),
-   * the same device point maps into a differently-shaped frame and the pulse would land outside the
-   * clipped canvas. A transient 600ms marker is not worth transforming across a rotation, and a
-   * stale-oriented pulse is worse than none — so it is simply dropped. Same-orientation resolution
-   * changes are unaffected (that is what the captured bounds already handle).
+   * A marker is placed by mapping its captured device point through its captured bounds (via
+   * [DeviceScreenCoordinateMapper.deviceToViewport]), which is exact only while the frame keeps the
+   * shape it was captured against. Two changes break that:
+   * - a **rotation** (portrait↔landscape) flips the aspect, so the same device point maps into a
+   *   differently-shaped frame and the pulse lands outside the clipped canvas;
+   * - a **same-orientation aspect change** (1080x2340 -> 1080x1920) reshapes the frame the same way
+   *   — a marker near the old bottom edge maps below the new frame.
+   *
+   * Both are caught by one rule: retain a marker only while its captured aspect matches the current
+   * aspect within [ASPECT_TOLERANCE] (relative, matching [DeviceControlPolicy]'s
+   * geometry-consistency tolerance). An equal-aspect resolution change (1080x2340 -> 720x1560)
+   * passes and keeps its pulses — that is exactly what the captured bounds already handle. A
+   * transient 600ms marker is not worth transforming across a reshape, and a stale-shaped pulse is
+   * worse than none — so it is simply dropped. Non-positive current dimensions describe no drawable
+   * frame, so every pulse is dropped.
    */
-  public fun retainOnlyOrientation(deviceWidth: Int, deviceHeight: Int) {
-    val landscape = deviceWidth > deviceHeight
-    markers.removeAll { (it.deviceWidth > it.deviceHeight) != landscape }
+  public fun retainOnlyMatchingAspect(deviceWidth: Int, deviceHeight: Int) {
+    if (deviceWidth <= 0 || deviceHeight <= 0) {
+      markers.clear()
+      return
+    }
+    val currentAspect = deviceHeight.toFloat() / deviceWidth.toFloat()
+    markers.removeAll { marker ->
+      marker.deviceWidth <= 0 ||
+        marker.deviceHeight <= 0 ||
+        abs(marker.deviceHeight.toFloat() / marker.deviceWidth.toFloat() - currentAspect) >
+          ASPECT_TOLERANCE * currentAspect
+    }
   }
 
   /**
@@ -162,5 +169,13 @@ public class TouchFeedbackModel(
 
     /** Upper bound on simultaneously-retained pulses; the oldest is dropped past this. */
     public const val MAX_MARKERS: Int = 8
+
+    /**
+     * Relative aspect-ratio tolerance for [retainOnlyMatchingAspect]. Matches
+     * `DeviceControlPolicy.GEOMETRY_ASPECT_TOLERANCE` (5%), so "the frame still has the shape the
+     * marker was captured against" means the same thing here as it does for the control gate's
+     * geometry-consistency check.
+     */
+    public const val ASPECT_TOLERANCE: Float = 0.05f
   }
 }

--- a/docs/design-docs/mcp/daemon/client-screen-control.md
+++ b/docs/design-docs/mcp/daemon/client-screen-control.md
@@ -78,10 +78,12 @@ Send a `subscribe` command; the daemon replies once, then pushes update messages
 
 ### Keepalive (ping/pong) — required to stay connected
 
-The daemon actively reaps subscribers it considers dead. Every **10 s** it sends each subscriber a
-ping push, and any subscriber whose activity has not been refreshed within the last **30 s** has its
-socket **destroyed** and its subscription removed. A client that subscribes but never answers pings
-is disconnected roughly 30 s after connecting — even while it is happily receiving frames.
+The daemon actively reaps subscribers it considers dead. Every **10 s** a keepalive sweep sends
+each subscriber a ping push and destroys any subscriber whose activity has not been refreshed for
+**more than 30 s**, removing its subscription. Because reaping happens only on those 10 s sweep
+boundaries, the effective disconnect lands **between just over 30 s and just under 40 s** of
+inactivity, depending on how the subscription aligns with the sweep. A client that subscribes but
+never answers pings is disconnected in that window — even while it is happily receiving frames.
 
 ```json
 // daemon -> client, every 10 s
@@ -96,9 +98,9 @@ is disconnected roughly 30 s after connecting — even while it is happily recei
 - The ping's `timestamp` is the daemon's clock in epoch milliseconds; it is informational.
 - **Receiving pushed frames does not count as activity.** The daemon deliberately does not refresh
   liveness on its own successful outbound writes — otherwise the frame stream itself would keep a
-  hung client "alive" forever. A client that consumes `screenshot_update`s but never pongs times
-  out at 30 s. Liveness is refreshed by your `pong`, the initial `subscribe`, and one narrow
-  exception below.
+  hung client "alive" forever. A client that consumes `screenshot_update`s but never pongs is
+  reaped by the first sweep after 30 s of inactivity. Liveness is refreshed by your `pong`, the
+  initial `subscribe`, and one narrow exception below.
 - **The one exception — backpressure `drain` — is not something to rely on.** If a push overflows
   the daemon-side socket buffer (the write crosses the high-water mark), the daemon listens for the
   socket's `drain` event, and that drain — proof the peer actually read the backlog — refreshes the

--- a/docs/design-docs/mcp/daemon/client-screen-control.md
+++ b/docs/design-docs/mcp/daemon/client-screen-control.md
@@ -76,6 +76,32 @@ Send a `subscribe` command; the daemon replies once, then pushes update messages
   "hierarchyIntervalMs": … }`; to stop, send `{ "command": "unsubscribe" }`. An older daemon that
   does not know a command replies with a benign error and keeps its default cadence.
 
+### Keepalive (ping/pong) — required to stay connected
+
+The daemon actively reaps subscribers it considers dead. Every **10 s** it sends each subscriber a
+ping push, and any subscriber whose activity has not been refreshed within the last **30 s** has its
+socket **destroyed** and its subscription removed. A client that subscribes but never answers pings
+is disconnected roughly 30 s after connecting — even while it is happily receiving frames.
+
+```json
+// daemon -> client, every 10 s
+{ "type": "ping", "timestamp": 1737942000789 }
+// client -> daemon, in reply
+{ "command": "pong" }
+```
+
+- Reply to each `ping` with `{ "command": "pong" }` on the same connection (newline-terminated,
+  like every request). No `id` is needed, and the daemon sends **no response** to a pong — it only
+  refreshes your subscription's activity timestamp.
+- The ping's `timestamp` is the daemon's clock in epoch milliseconds; it is informational.
+- **Receiving pushed frames does not count as activity.** The daemon deliberately refreshes
+  liveness only on inbound traffic (your `pong`, or the initial `subscribe`), never on its own
+  outbound writes — otherwise the frame stream itself would keep a hung client "alive" forever. A
+  client that consumes `screenshot_update`s but never pongs still times out at 30 s.
+- Simplest compliant implementation: on any received line with `"type": "ping"`, immediately write
+  `{"command":"pong"}\n`. There is no harm in an unsolicited pong; an unknown command, by contrast,
+  gets an `error` response.
+
 ### Pushed messages
 
 Every push carries a `type`, the `deviceId` it belongs to, and a display-only `timestamp`. Pair

--- a/docs/design-docs/mcp/daemon/client-screen-control.md
+++ b/docs/design-docs/mcp/daemon/client-screen-control.md
@@ -94,10 +94,17 @@ is disconnected roughly 30 s after connecting — even while it is happily recei
   like every request). No `id` is needed, and the daemon sends **no response** to a pong — it only
   refreshes your subscription's activity timestamp.
 - The ping's `timestamp` is the daemon's clock in epoch milliseconds; it is informational.
-- **Receiving pushed frames does not count as activity.** The daemon deliberately refreshes
-  liveness only on inbound traffic (your `pong`, or the initial `subscribe`), never on its own
-  outbound writes — otherwise the frame stream itself would keep a hung client "alive" forever. A
-  client that consumes `screenshot_update`s but never pongs still times out at 30 s.
+- **Receiving pushed frames does not count as activity.** The daemon deliberately does not refresh
+  liveness on its own successful outbound writes — otherwise the frame stream itself would keep a
+  hung client "alive" forever. A client that consumes `screenshot_update`s but never pongs times
+  out at 30 s. Liveness is refreshed by your `pong`, the initial `subscribe`, and one narrow
+  exception below.
+- **The one exception — backpressure `drain` — is not something to rely on.** If a push overflows
+  the daemon-side socket buffer (the write crosses the high-water mark), the daemon listens for the
+  socket's `drain` event, and that drain — proof the peer actually read the backlog — refreshes the
+  activity timestamp. A slow reader that repeatedly triggers backpressure can therefore incidentally
+  survive past 30 s without ponging. Do **not** design a client around this: a healthy reader never
+  fills the buffer, so no drain events fire, and only pongs keep it alive.
 - Simplest compliant implementation: on any received line with `"type": "ping"`, immediately write
   `{"command":"pong"}\n`. There is no harm in an unsolicited pong; an unknown command, by contrast,
   gets an `error` response.

--- a/test/docs/observationStreamKeepaliveDoc.test.ts
+++ b/test/docs/observationStreamKeepaliveDoc.test.ts
@@ -131,4 +131,35 @@ describe("observation stream keepalive doc (client-screen-control.md)", () => {
     server.triggerKeepalive();
     expect(server.getSubscriberCount()).toBe(1);
   });
+
+  test("the documented backpressure-drain exception refreshes liveness without a pong", async () => {
+    // The doc's one exception to "outbound writes are not activity": a write that crosses the
+    // high-water mark arms a drain listener, and the peer's later drain — proof it actually read
+    // the backlog — refreshes lastActivity (PushSubscriptionSocketServer.armDrainListener; also
+    // pinned by PushSubscriptionSocketServer.test.ts's backpressure suite). The doc must describe
+    // it, and the server must still behave that way.
+    const section = await readKeepaliveSection();
+    expect(section).toContain("`drain`");
+
+    const timer = new FakeTimer();
+    const server = new DocPinPushServer(timer);
+    const socket = new FakeSocket();
+    const subscriptionId = server.addSubscriber(socket);
+
+    // Backpressure: every write reports a full buffer, so the keepalive ping's own send arms the
+    // drain listener (checkKeepalive: sendJson -> false -> armDrainListener).
+    socket.write = () => false;
+    timer.advanceTimersByTime(DEFAULT_KEEPALIVE_CONFIG.intervalMs);
+    server.triggerKeepalive();
+
+    // Just short of the reap deadline the peer finally drains — no pong ever sent.
+    timer.advanceTimersByTime(DEFAULT_KEEPALIVE_CONFIG.timeoutMs - DEFAULT_KEEPALIVE_CONFIG.intervalMs - 1_000);
+    socket.emit("drain");
+    expect(server.lastActivityOf(subscriptionId)).toBe(timer.now());
+
+    // The drain-refreshed subscriber survives a sweep past the original deadline.
+    timer.advanceTimersByTime(2_000);
+    server.triggerKeepalive();
+    expect(server.getSubscriberCount()).toBe(1);
+  });
 });

--- a/test/docs/observationStreamKeepaliveDoc.test.ts
+++ b/test/docs/observationStreamKeepaliveDoc.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { Socket } from "node:net";
+import { PushSubscriptionSocketServer } from "../../src/daemon/socketServer/PushSubscriptionSocketServer";
+import { DEFAULT_KEEPALIVE_CONFIG } from "../../src/daemon/socketServer/SocketServerTypes";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeSocket } from "../fakes/FakeNetServer";
+
+// Doc-pin for the keepalive section added by #4546: the third-party client guide's
+// documented ping/pong exchange must stay true to the real
+// PushSubscriptionSocketServer, or a client author implementing from the doc alone
+// gets reaped at the activity timeout. The doc's literal JSON examples are parsed
+// out of the markdown and driven through the real server: the documented ping shape
+// is compared against what checkKeepalive actually writes, and the documented pong
+// line is fed verbatim through processLine to prove it refreshes liveness.
+
+const DOC_PATH = "docs/design-docs/mcp/daemon/client-screen-control.md";
+const repoRoot = join(import.meta.dir, "../..");
+
+async function readKeepaliveSection(): Promise<string> {
+  const markdown = await readFile(join(repoRoot, DOC_PATH), "utf-8");
+  const start = markdown.indexOf("### Keepalive (ping/pong)");
+  const end = markdown.indexOf("### Pushed messages", start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return markdown.slice(start, end);
+}
+
+/** The JSON example lines inside the section's fenced code block, in order. */
+function parseExampleLines(section: string): Array<Record<string, unknown>> {
+  return section
+    .split("\n")
+    .filter(line => line.trimStart().startsWith("{"))
+    .map(line => JSON.parse(line) as Record<string, unknown>);
+}
+
+class DocPinPushServer extends PushSubscriptionSocketServer<null, never> {
+  constructor(timer: FakeTimer) {
+    super("/fake/path/keepalive-doc.sock", timer, "KeepaliveDocPin");
+  }
+
+  addSubscriber(socket: FakeSocket): string {
+    const subscriptionId = "keepalive-doc-1";
+    this.subscribers.set(subscriptionId, {
+      socket: socket as unknown as Socket,
+      subscriptionId,
+      lastActivity: this.timer.now(),
+      filter: null,
+      backfilling: false,
+      drainPending: false,
+    });
+    return subscriptionId;
+  }
+
+  lastActivityOf(subscriptionId: string): number | undefined {
+    return this.subscribers.get(subscriptionId)?.lastActivity;
+  }
+
+  triggerKeepalive(): void {
+    this.checkKeepalive();
+  }
+
+  async feedLine(socket: FakeSocket, line: string): Promise<void> {
+    await this.processLine(socket as unknown as Socket, line);
+  }
+
+  protected parseSubscriptionFilter(): null {
+    return null;
+  }
+
+  protected matchesFilter(): boolean {
+    return false;
+  }
+
+  protected createPushMessage(): unknown {
+    return {};
+  }
+}
+
+describe("observation stream keepalive doc (client-screen-control.md)", () => {
+  test("documents the daemon's real ping shape and cadence", async () => {
+    const section = await readKeepaliveSection();
+    const [docPing] = parseExampleLines(section);
+
+    const timer = new FakeTimer();
+    const server = new DocPinPushServer(timer);
+    const socket = new FakeSocket();
+    server.addSubscriber(socket);
+
+    timer.advanceTimersByTime(DEFAULT_KEEPALIVE_CONFIG.intervalMs);
+    server.triggerKeepalive();
+
+    const [realPing] = socket.getWrittenMessages<Record<string, unknown>>();
+    expect(realPing).toBeDefined();
+    // Same keys, same type discriminator; the timestamp value is clock-dependent.
+    expect(Object.keys(docPing).sort()).toEqual(Object.keys(realPing).sort());
+    expect(docPing.type).toBe("ping");
+    expect(realPing.type).toBe("ping");
+    expect(typeof docPing.timestamp).toBe("number");
+    expect(typeof realPing.timestamp).toBe("number");
+
+    // The documented cadence and activity window are the server's real config.
+    expect(DEFAULT_KEEPALIVE_CONFIG.intervalMs).toBe(10_000);
+    expect(DEFAULT_KEEPALIVE_CONFIG.timeoutMs).toBe(30_000);
+    expect(section).toContain("**10 s**");
+    expect(section).toContain("**30 s**");
+  });
+
+  test("the documented pong line, fed verbatim, refreshes liveness with no response", async () => {
+    const section = await readKeepaliveSection();
+    const examples = parseExampleLines(section);
+    const docPong = examples.find(example => example.command === "pong");
+    expect(docPong).toEqual({ command: "pong" });
+
+    const timer = new FakeTimer();
+    const server = new DocPinPushServer(timer);
+    const socket = new FakeSocket();
+    const subscriptionId = server.addSubscriber(socket);
+
+    // Nearly at the reap deadline; the doc's exact pong line must refresh activity.
+    timer.advanceTimersByTime(DEFAULT_KEEPALIVE_CONFIG.timeoutMs - 1_000);
+    await server.feedLine(socket, JSON.stringify(docPong));
+    expect(server.lastActivityOf(subscriptionId)).toBe(timer.now());
+
+    // The doc says the daemon sends no response to a pong.
+    expect(socket.getWrittenMessages()).toEqual([]);
+
+    // And the refreshed subscriber survives the sweep that would otherwise reap it.
+    timer.advanceTimersByTime(2_000);
+    server.triggerKeepalive();
+    expect(server.getSubscriberCount()).toBe(1);
+  });
+});

--- a/test/docs/observationStreamKeepaliveDoc.test.ts
+++ b/test/docs/observationStreamKeepaliveDoc.test.ts
@@ -104,7 +104,10 @@ describe("observation stream keepalive doc (client-screen-control.md)", () => {
     expect(DEFAULT_KEEPALIVE_CONFIG.intervalMs).toBe(10_000);
     expect(DEFAULT_KEEPALIVE_CONFIG.timeoutMs).toBe(30_000);
     expect(section).toContain("**10 s**");
-    expect(section).toContain("**30 s**");
+    expect(section).toContain("**more than 30 s**");
+    // Reaping happens only on sweep boundaries, so the doc must state the effective
+    // disconnect window rather than a hard 30 s cliff (#4546 review).
+    expect(section).toContain("between just over 30 s and just under 40 s");
   });
 
   test("the documented pong line, fed verbatim, refreshes liveness with no response", async () => {


### PR DESCRIPTION
## Summary

Fix-forward (S0) for the three post-merge review findings on [#4538](https://github.com/kaeawc/auto-mobile/pull/4538) (client screen control signoff). This precedes the canonical-pixel coordinate campaign ([#4547](https://github.com/kaeawc/auto-mobile/issues/4547)–[#4550](https://github.com/kaeawc/auto-mobile/issues/4550)).

Closes [#4546](https://github.com/kaeawc/auto-mobile/issues/4546)

### 1. Keepalive handshake documented (P1)

`docs/design-docs/mcp/daemon/client-screen-control.md` gains a "Keepalive (ping/pong) — required to stay connected" section in the observation-stream protocol, verified against `PushSubscriptionSocketServer`:

- daemon sends `{ "type": "ping", "timestamp": <epoch ms> }` to every subscriber every **10 s** (`DEFAULT_KEEPALIVE_CONFIG.intervalMs`);
- client must reply `{ "command": "pong" }` (newline-terminated, no `id`, no response sent back);
- a subscriber whose activity is not refreshed within **30 s** (`timeoutMs`) has its socket destroyed;
- pushed frames deliberately do **not** count as activity — a client that consumes frames but never pongs is still reaped.

A new doc-pin test (`test/docs/observationStreamKeepaliveDoc.test.ts`) parses the doc's literal JSON examples and drives them through the real `PushSubscriptionSocketServer` with a `FakeTimer`: the documented ping shape is compared against what `checkKeepalive` actually writes, and the documented pong line is fed verbatim through `processLine` to prove it refreshes liveness and survives the reap sweep.

### 2. Pulse placement through the canonical mapper (P1)

`ActiveTouchFeedback.frameOffset` and `TouchFeedbackFrameOffset` — the second public width-based inverse transform with one consumer — are **deleted** from `desktop-domain`. Pulse placement now goes through `DeviceScreenCoordinateMapper.deviceToViewport`: an internal helper (`touchFeedbackCenter`, adjacent to its only consumer in `desktop-core/layout`) builds a `DeviceScreenGeometry` from the marker's own captured snapshot bounds (scale 1 / no pan, since the pulse draws inside the frame's already-transformed draw scope) and delegates to the mapper. Behavior is identical for real geometry; a degenerate zero-width snapshot now draws no pulse instead of a pulse at the origin.

### 3. Pulses cleared on aspect-ratio change (P2)

`retainOnlyOrientation` (landscape-boolean keyed) is replaced by `retainOnlyMatchingAspect`: a marker is retained only while its captured aspect matches the current snapshot aspect within a **5% relative tolerance**, matching `DeviceControlPolicy.GEOMETRY_ASPECT_TOLERANCE`. Orientation flips and same-orientation aspect changes (1080x2340 → 1080x1920) both clear; equal-aspect resolution changes (1080x2340 → 720x1560) retain. The `DeviceScreenView` cleanup effect now keys on the snapshot `deviceWidth to deviceHeight` pair instead of the landscape flag, so the cleanup actually runs on aspect changes.

## Tested

- `:desktop-core:test`, `:desktop-domain:test`, detekt main+test for both modules, `:desktop-app:compileKotlin`, `:ide-plugin:compileKotlin` — all `--rerun-tasks`, green. Zero `ide-plugin` source changes.
- ktfmt `--google-style` clean on all touched Kotlin files.
- `bun run typecheck` (no new errors), `bun run lint` (exit 0), `bun test test/docs/ test/daemon/socketServer/` (54 pass).
- **Mutation checks** (revert behavior → test fails → restore):
  - doc-pin: mutating the doc's pong example and separately the server's ping `type` each failed the doc test;
  - placement: replacing the mapper delegation with a height-based re-derivation failed the delegation-pin test;
  - retention: reverting to the orientation-only rule failed the same-orientation aspect-change and degenerate-dimension tests.
