### PR TITLE
test(utils-android): complete remaining audit coverage

### DIFF
--- a/test/utils/CtrlProxyManager.test.ts
+++ b/test/utils/CtrlProxyManager.test.ts
@@ -109,7 +109,7 @@ describe("CtrlProxyManager", function() {
       expect(result).toBe(false);
     });
 
-    test("should return false when the ADB command throws", async function() {
+    test("returns false when the ADB command throws", async function() {
       // ADD-10: exercise the catch path for real. Setting stderr on a resolved
       // response never entered the catch (isInstalled reads stdout only), so it
       // could not distinguish "return false" from any other catch behavior.
@@ -144,7 +144,7 @@ describe("CtrlProxyManager", function() {
       expect(result).toBe(false);
     });
 
-    test("should return false when ADB command fails", async function() {
+    test("returns false when the ADB command fails", async function() {
       fakeAdb.setCommandResponse("settings get secure", {
         stdout: "",
         stderr: "Error"

--- a/test/utils/android-cmdline-tools/AdbClient-listUsers.test.ts
+++ b/test/utils/android-cmdline-tools/AdbClient-listUsers.test.ts
@@ -1,429 +1,151 @@
-import { expect, describe, it, beforeEach } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { AdbClient } from "../../../src/utils/android-cmdline-tools/AdbClient";
-import type { ExecResult } from "../../../src/models";
+import type { AndroidUser, ExecResult } from "../../../src/models";
 
-describe("AdbClient.listUsers", () => {
-  let adbClient: AdbClient;
-  let mockExecAsync: (command: string) => Promise<ExecResult>;
-  let lastCommand: string;
+const owner: AndroidUser = { userId: 0, name: "Owner", flags: 0x4c13, running: true };
+const workProfile: AndroidUser = { userId: 10, name: "Work profile", flags: 0x30, running: true };
+const fallbackOwner: AndroidUser = { userId: 0, name: "Owner", flags: 0x13, running: true };
 
-  beforeEach(() => {
-    // Create a mock exec function that tracks the last command
-    mockExecAsync = (command: string): Promise<ExecResult> => {
-      lastCommand = command;
-      return Promise.resolve({
-        stdout: "",
-        stderr: "",
-        toString: () => "",
-        trim: () => "",
-        includes: () => false
-      });
-    };
+function execResult(stdout: string): ExecResult {
+  return {
+    stdout,
+    stderr: "",
+    toString: () => stdout,
+    trim: () => stdout.trim(),
+    includes: search => stdout.includes(search),
+  };
+}
 
-    adbClient = new AdbClient(null, mockExecAsync, null as any);
-  });
+type CommandOutcome = string | Error;
 
-  describe("parseUsersFromDumpsys", () => {
-    it("should parse single user from dumpsys output", async () => {
-      const dumpsysOutput = `Current user: 0
+interface ListUsersCase {
+  name: string;
+  outcomes: CommandOutcome[];
+  expectedUsers: AndroidUser[];
+  expectedCommandFragments: string[];
+}
 
-Users:
-  UserInfo{0:null:4c13} serialNo=0 isPrimary=true
-    Type: android.os.usertype.full.SYSTEM
-    Flags: 19475 (ADMIN|FULL|INITIALIZED|MAIN|PRIMARY|SYSTEM)
-    State: RUNNING_UNLOCKED
-    Created: <unknown>
-
-  Owner name: Owner`;
-
-      mockExecAsync = (command: string): Promise<ExecResult> => {
-        lastCommand = command;
-        return Promise.resolve({
-          stdout: dumpsysOutput,
-          stderr: "",
-          toString: () => dumpsysOutput,
-          trim: () => dumpsysOutput.trim(),
-          includes: (s: string) => dumpsysOutput.includes(s)
-        });
-      };
-
-      adbClient = new AdbClient(null, mockExecAsync, null as any);
-      const users = await adbClient.listUsers();
-
-      expect(users.length).toBe(1);
-      expect(users[0]).toEqual({
-        userId: 0,
-        name: "Owner",
-        flags: 0x4c13,
-        running: true
-      });
-      expect(lastCommand).toContain("dumpsys user");
-    });
-
-    it("should parse multiple users with work profile from dumpsys output", async () => {
-      const dumpsysOutput = `Current user: 0
+const cases: ListUsersCase[] = [
+  {
+    name: "parses a primary user from structured dumpsys output",
+    outcomes: [`Current user: 0
 
 Users:
   UserInfo{0:null:4c13} serialNo=0 isPrimary=true
     Type: android.os.usertype.full.SYSTEM
     Flags: 19475 (ADMIN|FULL|INITIALIZED|MAIN|PRIMARY|SYSTEM)
     State: RUNNING_UNLOCKED
-    Created: <unknown>
+
+  Owner name: Owner`],
+    expectedUsers: [owner],
+    expectedCommandFragments: ["shell dumpsys user"],
+  },
+  {
+    name: "parses a running work profile from structured dumpsys output",
+    outcomes: [`Current user: 0
+
+Users:
+  UserInfo{0:null:4c13} serialNo=0 isPrimary=true
+    Type: android.os.usertype.full.SYSTEM
+    State: RUNNING_UNLOCKED
 
   UserInfo{10:Work profile:30} serialNo=10 isPrimary=false parentId=0
     Type: android.os.usertype.profile.MANAGED
     Flags: 48 (MANAGED_PROFILE)
     State: RUNNING_UNLOCKED
-    Created: +2d5h32m18s445ms ago
 
-  Owner name: Owner`;
-
-      mockExecAsync = (command: string): Promise<ExecResult> => {
-        lastCommand = command;
-        return Promise.resolve({
-          stdout: dumpsysOutput,
-          stderr: "",
-          toString: () => dumpsysOutput,
-          trim: () => dumpsysOutput.trim(),
-          includes: (s: string) => dumpsysOutput.includes(s)
-        });
-      };
-
-      adbClient = new AdbClient(null, mockExecAsync, null as any);
-      const users = await adbClient.listUsers();
-
-      expect(users.length).toBe(2);
-      expect(users[0]).toEqual({
-        userId: 0,
-        name: "Owner",
-        flags: 0x4c13,
-        running: true
-      });
-      expect(users[1]).toEqual({
-        userId: 10,
-        name: "Work profile",
-        flags: 0x30,
-        running: true
-      });
-    });
-
-    it("should handle shutdown users correctly", async () => {
-      const dumpsysOutput = `Current user: 0
-
-Users:
+  Owner name: Owner`],
+    expectedUsers: [owner, workProfile],
+    expectedCommandFragments: ["shell dumpsys user"],
+  },
+  {
+    name: "marks a shutdown secondary user as not running",
+    outcomes: [`Users:
   UserInfo{0:null:4c13} serialNo=0 isPrimary=true
-    Type: android.os.usertype.full.SYSTEM
     State: RUNNING_UNLOCKED
 
   UserInfo{10:Secondary User:0} serialNo=10 isPrimary=false
-    Type: android.os.usertype.full.SECONDARY
     State: SHUTDOWN
 
-  Owner name: Owner`;
-
-      mockExecAsync = (command: string): Promise<ExecResult> => {
-        lastCommand = command;
-        return Promise.resolve({
-          stdout: dumpsysOutput,
-          stderr: "",
-          toString: () => dumpsysOutput,
-          trim: () => dumpsysOutput.trim(),
-          includes: (s: string) => dumpsysOutput.includes(s)
-        });
-      };
-
-      adbClient = new AdbClient(null, mockExecAsync, null as any);
-      const users = await adbClient.listUsers();
-
-      expect(users.length).toBe(2);
-      expect(users[0].running).toBe(true);
-      expect(users[1].running).toBe(false);
-    });
-
-    it("should handle RUNNING_LOCKED state as running", async () => {
-      const dumpsysOutput = `Current user: 0
-
-Users:
+  Owner name: Owner`],
+    expectedUsers: [owner, { userId: 10, name: "Secondary User", flags: 0, running: false }],
+    expectedCommandFragments: ["shell dumpsys user"],
+  },
+  {
+    name: "treats a locked user as running",
+    outcomes: [`Users:
   UserInfo{0:null:4c13} serialNo=0 isPrimary=true
-    Type: android.os.usertype.full.SYSTEM
     State: RUNNING_LOCKED
 
-  Owner name: Owner`;
-
-      mockExecAsync = (command: string): Promise<ExecResult> => {
-        lastCommand = command;
-        return Promise.resolve({
-          stdout: dumpsysOutput,
-          stderr: "",
-          toString: () => dumpsysOutput,
-          trim: () => dumpsysOutput.trim(),
-          includes: (s: string) => dumpsysOutput.includes(s)
-        });
-      };
-
-      adbClient = new AdbClient(null, mockExecAsync, null as any);
-      const users = await adbClient.listUsers();
-
-      expect(users.length).toBe(1);
-      expect(users[0].running).toBe(true);
-    });
-
-    it("should use default name for null username when no Owner name is found", async () => {
-      const dumpsysOutput = `Current user: 0
-
-Users:
+  Owner name: Owner`],
+    expectedUsers: [owner],
+    expectedCommandFragments: ["shell dumpsys user"],
+  },
+  {
+    name: "uses a user-ID fallback name when dumpsys omits it",
+    outcomes: [`Users:
   UserInfo{10:null:30} serialNo=10 isPrimary=false
-    Type: android.os.usertype.profile.MANAGED
-    State: RUNNING_UNLOCKED`;
-
-      mockExecAsync = (command: string): Promise<ExecResult> => {
-        lastCommand = command;
-        return Promise.resolve({
-          stdout: dumpsysOutput,
-          stderr: "",
-          toString: () => dumpsysOutput,
-          trim: () => dumpsysOutput.trim(),
-          includes: (s: string) => dumpsysOutput.includes(s)
-        });
-      };
-
-      adbClient = new AdbClient(null, mockExecAsync, null as any);
-      const users = await adbClient.listUsers();
-
-      expect(users.length).toBe(1);
-      expect(users[0].name).toBe("User 10");
-    });
-
-    it("should fall back to pm list users when dumpsys parsing fails", async () => {
-      const pmOutput = `Users:
+    State: RUNNING_UNLOCKED`],
+    expectedUsers: [{ userId: 10, name: "User 10", flags: 0x30, running: true }],
+    expectedCommandFragments: ["shell dumpsys user"],
+  },
+  {
+    name: "falls back to pm output when dumpsys has no users",
+    outcomes: ["Invalid output", `Users:
 \tUserInfo{0:Owner:4c13} running
-\tUserInfo{10:Work profile:30} running`;
-
-      let callCount = 0;
-      mockExecAsync = (command: string): Promise<ExecResult> => {
-        lastCommand = command;
-        callCount++;
-
-        if (callCount === 1) {
-          // First call to dumpsys returns invalid data
-          return Promise.resolve({
-            stdout: "Invalid output",
-            stderr: "",
-            toString: () => "Invalid output",
-            trim: () => "Invalid output",
-            includes: (s: string) => "Invalid output".includes(s)
-          });
-        } else {
-          // Second call to pm list users returns valid data
-          return Promise.resolve({
-            stdout: pmOutput,
-            stderr: "",
-            toString: () => pmOutput,
-            trim: () => pmOutput.trim(),
-            includes: (s: string) => pmOutput.includes(s)
-          });
-        }
-      };
-
-      adbClient = new AdbClient(null, mockExecAsync, null as any);
-      const users = await adbClient.listUsers();
-
-      expect(users.length).toBe(2);
-      expect(users[0]).toEqual({
-        userId: 0,
-        name: "Owner",
-        flags: 0x4c13,
-        running: true
-      });
-      expect(users[1]).toEqual({
-        userId: 10,
-        name: "Work profile",
-        flags: 0x30,
-        running: true
-      });
-      expect(lastCommand).toContain("pm list users");
-    });
-
-    it("should fall back to pm list users when dumpsys command fails", async () => {
-      const pmOutput = `Users:
-\tUserInfo{0:Owner:4c13} running`;
-
-      let callCount = 0;
-      mockExecAsync = (command: string): Promise<ExecResult> => {
-        lastCommand = command;
-        callCount++;
-
-        if (callCount === 1) {
-          // First call to dumpsys throws error
-          throw new Error("dumpsys user failed");
-        } else {
-          // Second call to pm list users succeeds
-          return Promise.resolve({
-            stdout: pmOutput,
-            stderr: "",
-            toString: () => pmOutput,
-            trim: () => pmOutput.trim(),
-            includes: (s: string) => pmOutput.includes(s)
-          });
-        }
-      };
-
-      adbClient = new AdbClient(null, mockExecAsync, null as any);
-      const users = await adbClient.listUsers();
-
-      expect(users.length).toBe(1);
-      expect(users[0]).toEqual({
-        userId: 0,
-        name: "Owner",
-        flags: 0x4c13,
-        running: true
-      });
-      expect(lastCommand).toContain("pm list users");
-    });
-  });
-
-  describe("listUsersLegacy (pm list users)", () => {
-    it("should parse users from pm list users output", async () => {
-      const pmOutput = `Users:
+\tUserInfo{10:Work profile:30} running`],
+    expectedUsers: [owner, workProfile],
+    expectedCommandFragments: ["shell dumpsys user", "shell pm list users"],
+  },
+  {
+    name: "falls back to pm output when dumpsys throws",
+    outcomes: [new Error("dumpsys user failed"), `Users:
+\tUserInfo{0:Owner:4c13} running`],
+    expectedUsers: [owner],
+    expectedCommandFragments: ["shell dumpsys user", "shell pm list users"],
+  },
+  {
+    name: "marks a pm user without running status as stopped",
+    outcomes: [new Error("dumpsys unavailable"), "Users:\n\tUserInfo{0:Owner:4c13}"],
+    expectedUsers: [{ ...owner, running: false }],
+    expectedCommandFragments: ["shell dumpsys user", "shell pm list users"],
+  },
+  {
+    name: "returns the primary fallback when both user commands fail",
+    outcomes: [new Error("dumpsys unavailable"), new Error("pm unavailable")],
+    expectedUsers: [fallbackOwner],
+    expectedCommandFragments: ["shell dumpsys user", "shell pm list users"],
+  },
+  {
+    name: "returns the primary fallback when neither parser finds a user",
+    outcomes: ["Some random output with no user info", "Still no user info"],
+    expectedUsers: [fallbackOwner],
+    expectedCommandFragments: ["shell dumpsys user", "shell pm list users"],
+  },
+  {
+    name: "parses hexadecimal flags from pm output",
+    outcomes: [new Error("dumpsys unavailable"), `Users:
 \tUserInfo{0:Owner:4c13} running
-\tUserInfo{10:Work profile:30} running`;
+\tUserInfo{10:Work:1a2b} running`],
+    expectedUsers: [owner, { userId: 10, name: "Work", flags: 0x1a2b, running: true }],
+    expectedCommandFragments: ["shell dumpsys user", "shell pm list users"],
+  },
+];
 
-      // Mock to simulate fallback: first dumpsys fails, then pm succeeds
-      let callCount = 0;
-      mockExecAsync = (command: string): Promise<ExecResult> => {
-        lastCommand = command;
-        callCount++;
-
-        if (callCount === 1) {
-          throw new Error("dumpsys not available");
-        } else {
-          return Promise.resolve({
-            stdout: pmOutput,
-            stderr: "",
-            toString: () => pmOutput,
-            trim: () => pmOutput.trim(),
-            includes: (s: string) => pmOutput.includes(s)
-          });
-        }
-      };
-
-      adbClient = new AdbClient(null, mockExecAsync, null as any);
-      const users = await adbClient.listUsers();
-
-      expect(users.length).toBe(2);
-      expect(users[0].userId).toBe(0);
-      expect(users[0].name).toBe("Owner");
-      expect(users[0].flags).toBe(0x4c13);
-      expect(users[0].running).toBe(true);
-
-      expect(users[1].userId).toBe(10);
-      expect(users[1].name).toBe("Work profile");
-      expect(users[1].flags).toBe(0x30);
-      expect(users[1].running).toBe(true);
+describe("AdbClient.listUsers", () => {
+  test.each(cases)("$name", async ({ outcomes, expectedUsers, expectedCommandFragments }) => {
+    const commands: string[] = [];
+    let outcomeIndex = 0;
+    const client = new AdbClient(null, async command => {
+      commands.push(command);
+      const outcome = outcomes[outcomeIndex++];
+      if (outcome instanceof Error) {
+        throw outcome;
+      }
+      return execResult(outcome);
     });
 
-    it("should handle users without running status", async () => {
-      const pmOutput = `Users:
-\tUserInfo{0:Owner:4c13}`;
-
-      let callCount = 0;
-      mockExecAsync = (command: string): Promise<ExecResult> => {
-        lastCommand = command;
-        callCount++;
-
-        if (callCount === 1) {
-          throw new Error("dumpsys not available");
-        } else {
-          return Promise.resolve({
-            stdout: pmOutput,
-            stderr: "",
-            toString: () => pmOutput,
-            trim: () => pmOutput.trim(),
-            includes: (s: string) => pmOutput.includes(s)
-          });
-        }
-      };
-
-      adbClient = new AdbClient(null, mockExecAsync, null as any);
-      const users = await adbClient.listUsers();
-
-      expect(users.length).toBe(1);
-      expect(users[0].running).toBe(false);
-    });
-
-    it("should return fallback user when both commands fail", async () => {
-      mockExecAsync = (): Promise<ExecResult> => {
-        throw new Error("All commands failed");
-      };
-
-      adbClient = new AdbClient(null, mockExecAsync, null as any);
-      const users = await adbClient.listUsers();
-
-      expect(users.length).toBe(1);
-      expect(users[0]).toEqual({
-        userId: 0,
-        name: "Owner",
-        flags: 0x13,
-        running: true
-      });
-    });
-
-    it("should return fallback user when parsing produces no results", async () => {
-      const invalidOutput = "Some random output with no user info";
-
-      mockExecAsync = (command: string): Promise<ExecResult> => {
-        lastCommand = command;
-
-        return Promise.resolve({
-          stdout: invalidOutput,
-          stderr: "",
-          toString: () => invalidOutput,
-          trim: () => invalidOutput.trim(),
-          includes: (s: string) => invalidOutput.includes(s)
-        });
-      };
-
-      adbClient = new AdbClient(null, mockExecAsync, null as any);
-      const users = await adbClient.listUsers();
-
-      expect(users.length).toBe(1);
-      expect(users[0]).toEqual({
-        userId: 0,
-        name: "Owner",
-        flags: 0x13,
-        running: true
-      });
-    });
-
-    it("should correctly parse hexadecimal flags", async () => {
-      const pmOutput = `Users:
-\tUserInfo{0:Owner:4c13} running
-\tUserInfo{10:Work:1a2b} running`;
-
-      let callCount = 0;
-      mockExecAsync = (command: string): Promise<ExecResult> => {
-        lastCommand = command;
-        callCount++;
-
-        if (callCount === 1) {
-          throw new Error("dumpsys not available");
-        } else {
-          return Promise.resolve({
-            stdout: pmOutput,
-            stderr: "",
-            toString: () => pmOutput,
-            trim: () => pmOutput.trim(),
-            includes: (s: string) => pmOutput.includes(s)
-          });
-        }
-      };
-
-      adbClient = new AdbClient(null, mockExecAsync, null as any);
-      const users = await adbClient.listUsers();
-
-      expect(users.length).toBe(2);
-      expect(users[0].flags).toBe(0x4c13); // 19475 in decimal
-      expect(users[1].flags).toBe(0x1a2b); // 6699 in decimal
-    });
+    await expect(client.listUsers()).resolves.toEqual(expectedUsers);
+    expect(commands.map(command => command.replace(/^.*\badb\s+/, ""))).toEqual(expectedCommandFragments);
   });
 });

--- a/test/utils/android-cmdline-tools/AndroidUserTargetResolver.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidUserTargetResolver.test.ts
@@ -1,35 +1,98 @@
 import { describe, expect, test } from "bun:test";
-import { AndroidUserTargetResolver } from "../../../src/utils/android-cmdline-tools/AndroidUserTargetResolver";
+import { AndroidUserTargetResolver, type ResolvedUserTarget, type UserTargetRequest } from "../../../src/utils/android-cmdline-tools/AndroidUserTargetResolver";
+import type { AndroidUser } from "../../../src/models";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 
-describe("AndroidUserTargetResolver", () => {
-  test("preserves an explicit primary user", async () => {
-    const resolver = new AndroidUserTargetResolver(new FakeAdbExecutor());
-    expect(await resolver.resolve({ explicitUserId: 0 })).toEqual({ userId: 0, source: "explicit" });
-  });
+const owner: AndroidUser = { userId: 0, name: "Owner", flags: 0x13, running: true };
+const pausedWork: AndroidUser = { userId: 11, name: "Paused work", flags: 0x30, running: false };
+const work: AndroidUser = { userId: 12, name: "Work", flags: 0x20, running: true };
+const otherWork: AndroidUser = { userId: 13, name: "Other work", flags: 0x30, running: true };
 
-  test("uses the package's foreground user before profile fallback", async () => {
-    const adb = new FakeAdbExecutor();
-    adb.setForegroundApp({ packageName: "com.example.app", userId: 12 });
-    const resolver = new AndroidUserTargetResolver(adb);
-    expect(await resolver.resolve({ packageName: "com.example.app" })).toEqual({ userId: 12, source: "foregroundPackage" });
-  });
+interface ResolveCase {
+  name: string;
+  request: UserTargetRequest;
+  users?: AndroidUser[];
+  foreground?: { packageName: string; userId: number } | null;
+  expected: ResolvedUserTarget;
+}
 
-  test("ignores a running non-managed secondary user", async () => {
-    const adb = new FakeAdbExecutor();
-    adb.setUsers([{ userId: 0, name: "Owner", flags: 13, running: true }, { userId: 10, name: "Secondary", flags: 0, running: true }]);
-    const resolver = new AndroidUserTargetResolver(adb);
-    expect(await resolver.resolve()).toEqual({ userId: 0, source: "primaryFallback" });
-  });
+const cases: ResolveCase[] = [
+  {
+    name: "uses explicit primary user zero before every other signal",
+    request: { explicitUserId: 0, packageName: "com.example.app" },
+    users: [work],
+    foreground: { packageName: "com.example.app", userId: 12 },
+    expected: { userId: 0, source: "explicit" },
+  },
+  {
+    name: "uses an explicit non-primary user before profile fallback",
+    request: { explicitUserId: 10 },
+    users: [work],
+    expected: { userId: 10, source: "explicit" },
+  },
+  {
+    name: "uses a matching foreground package before a managed profile",
+    request: { packageName: "com.example.app" },
+    users: [work],
+    foreground: { packageName: "com.example.app", userId: 10 },
+    expected: { userId: 10, source: "foregroundPackage" },
+  },
+  {
+    name: "uses a running managed profile when the foreground package differs",
+    request: { packageName: "com.example.app" },
+    users: [work],
+    foreground: { packageName: "com.example.other", userId: 10 },
+    expected: { userId: 12, source: "managedProfile" },
+  },
+  {
+    name: "uses a running managed profile when no foreground package is available",
+    request: { packageName: "com.example.app" },
+    users: [work],
+    foreground: null,
+    expected: { userId: 12, source: "managedProfile" },
+  },
+  {
+    name: "uses a managed profile when no package was requested",
+    request: {},
+    users: [work],
+    expected: { userId: 12, source: "managedProfile" },
+  },
+  {
+    name: "skips a paused managed profile and falls back to the primary user",
+    request: {},
+    users: [owner, pausedWork],
+    expected: { userId: 0, source: "primaryFallback" },
+  },
+  {
+    name: "does not treat a running secondary user as managed",
+    request: {},
+    users: [owner, { userId: 10, name: "Secondary", flags: 0, running: true }],
+    expected: { userId: 0, source: "primaryFallback" },
+  },
+  {
+    name: "selects the first running managed profile in device order",
+    request: {},
+    users: [pausedWork, work, otherWork],
+    expected: { userId: 12, source: "managedProfile" },
+  },
+  {
+    name: "falls back to the primary user when no users are reported",
+    request: {},
+    users: [],
+    expected: { userId: 0, source: "primaryFallback" },
+  },
+];
 
-  test("selects the first running managed profile and ignores paused profiles", async () => {
+describe("AndroidUserTargetResolver.resolve", () => {
+  test.each(cases)("$name", async ({ request, users, foreground, expected }) => {
     const adb = new FakeAdbExecutor();
-    adb.setUsers([
-      { userId: 11, name: "Paused work", flags: 0x30, running: false },
-      { userId: 12, name: "Work", flags: 0x20, running: true },
-      { userId: 13, name: "Other work", flags: 0x30, running: true },
-    ]);
-    const resolver = new AndroidUserTargetResolver(adb);
-    expect(await resolver.resolve()).toEqual({ userId: 12, source: "managedProfile" });
+    if (users) {
+      adb.setUsers(users);
+    }
+    if (foreground !== undefined) {
+      adb.setForegroundApp(foreground);
+    }
+
+    await expect(new AndroidUserTargetResolver(adb).resolve(request)).resolves.toEqual(expected);
   });
 });

--- a/test/utils/android-cmdline-tools/avdmanager.test.ts
+++ b/test/utils/android-cmdline-tools/avdmanager.test.ts
@@ -795,18 +795,6 @@ id: pixel_4
       expect(result.message).toContain("Tool installation functionality has been removed");
     });
 
-    test("should report manual install guidance when required tools are missing", async () => {
-      const mockDeps = createDependencies();
-
-      mockDeps.detectAndroidCommandLineTools = async () => [];
-      mockDeps.getBestAndroidToolsLocation = () => null;
-
-      const result = await avdmanager.acceptLicenses(mockDeps);
-
-      expect(result.success).toBe(false);
-      expect(result.message).toContain("Tool installation functionality has been removed");
-    });
-
     test("should handle missing executable files", async () => {
       const mockDeps = createDependencies();
 


### PR DESCRIPTION
## What

- Collapses `AdbClient.listUsers` coverage into an observable, table-driven contract for parsing and fallback behavior.
- Adds the full `AndroidUserTargetResolver.resolve` precedence matrix using `FakeAdbExecutor` state.
- Removes the duplicate missing-tools license test and completes the remaining behavior-first test names.

## Why

This completes the remaining concrete test-quality findings from the utils-android audit without changing production behavior.

## Validation

- `bun test test/utils/android-cmdline-tools/AdbClient-listUsers.test.ts test/utils/android-cmdline-tools/AndroidUserTargetResolver.test.ts test/utils/android-cmdline-tools/avdmanager.test.ts test/utils/CtrlProxyManager.test.ts test/utils/android-cmdline-tools/AndroidEmulatorClient-headless.test.ts test/utils/android-cmdline-tools/AndroidEmulatorClient-wakeAndUnlock.test.ts`
- `bun run lint`
- `bun run build`
- `bun run typecheck`
- `bun run turbo:validate`
- `git diff --check`

Closes [#4527](https://github.com/kaeawc/auto-mobile/issues/4527)
