### PR TITLE
feat(daemon): expose append progress on failures

### DIFF
--- a/docs/design-docs/mcp/daemon/client-screen-control.md
+++ b/docs/design-docs/mcp/daemon/client-screen-control.md
@@ -331,4 +331,3 @@ tracked back to [#1099](https://github.com/kaeawc/auto-mobile/issues/1099):
 | [#4534](https://github.com/kaeawc/auto-mobile/issues/4534) | Evict the append cache on rapid same-serial device reuse (needs a device-connect signal). |
 | [#4535](https://github.com/kaeawc/auto-mobile/issues/4535) | Optional daemon capability signal for newer input params (e.g. `input/typeText mode:append`). |
 | [#4536](https://github.com/kaeawc/auto-mobile/issues/4536) | Prefer a reliable native AltGraph signal over the `ctrl && alt` heuristic. |
-| [#4537](https://github.com/kaeawc/auto-mobile/issues/4537) | Surface partial-progress (`charsSent`) on a failed multi-character `input/typeText` append over the wire. |

--- a/docs/design-docs/mcp/daemon/unix-socket-api.md
+++ b/docs/design-docs/mcp/daemon/unix-socket-api.md
@@ -596,17 +596,27 @@ string.** Android append types one key event per character in order, so it is at
 for a **single character**: a one-character append either lands or reports failure
 with nothing typed. A **multi-character** append is best-effort — if it fails
 partway (an adb reject/timeout mid-batch), a leading prefix of `text` has already
-been typed into the field. The failure is reported the same way as any other input
-error (a `success: false` response with a message; the daemon does **not** return a
-structured partial-progress count on the wire — see
-[#4537](https://github.com/kaeawc/auto-mobile/issues/4537)). Therefore a client
-that batches multiple characters into one request **must not blindly retry the
-whole string** on failure — re-sending `"ab"` after `"a"` already landed produces
-`"aab"`. A client that needs per-character atomicity must send **one character per
-`input/typeText` request**, which is exactly what the reference desktop client does
-(one request per keystroke). The in-process primitive already tracks how many
-characters landed (`SendTextResult.charsSent`); surfacing that on a failed wire
-response is deferred to [#4537](https://github.com/kaeawc/auto-mobile/issues/4537).
+been typed into the field. Its failed socket envelope includes `charsSent`, the
+number of leading characters that landed; retry only `text.slice(charsSent)`, not
+the whole string. For example, if `"ab"` fails after `"a"`, the response has
+`"charsSent": 1` and the client retries `"b"`, avoiding `"aab"`. `charsSent: 0`
+means retry the full text; a full-length value means all text landed and only a
+later part of the operation (such as submit) failed. The field is omitted for
+non-append failures. A client that needs per-character atomicity can still send
+**one character per `input/typeText` request**, which is exactly what the
+reference desktop client does (one request per keystroke).
+
+**Partial append failure response**
+
+```json
+{
+  "id": "type-3",
+  "type": "mcp_response",
+  "success": false,
+  "error": "append key event failed: adb rejected KEYCODE_B",
+  "charsSent": 1
+}
+```
 
 **Request**
 

--- a/docs/design-docs/mcp/daemon/unix-socket-api.md
+++ b/docs/design-docs/mcp/daemon/unix-socket-api.md
@@ -594,17 +594,24 @@ Append's semantics and limits:
 **Android is best-effort, character-by-character — retry the remainder, not the whole
 string.** Android append types one key event per character in order, so it is atomic only
 for a **single character**: a one-character append either lands or reports failure
-with nothing typed. A **multi-character** append is best-effort — if it fails
-partway (an adb reject/timeout mid-batch), a leading prefix of `text` has already
-been typed into the field. Its failed socket envelope includes `charsSent`, the
-number of leading characters that landed; retry only `text.slice(charsSent)`, not
-the whole string. For example, if `"ab"` fails after `"a"`, the response has
-`"charsSent": 1` and the client retries `"b"`, avoiding `"aab"`. `charsSent: 0`
-means retry the full text; a full-length value means all text landed and only a
-later part of the operation (such as submit) failed. The field is omitted for
-non-append failures. A client that needs per-character atomicity can still send
-**one character per `input/typeText` request**, which is exactly what the
-reference desktop client does (one request per keystroke).
+with nothing typed. A **multi-character** append is best-effort — if a definitive
+ADB rejection occurs partway, a leading prefix of `text` has already been typed
+into the field. Its failed socket envelope includes `charsSent`, the number of
+leading characters confirmed as sent; retry only `text.slice(charsSent)`, not the
+whole string. For example, if `"ab"` fails after confirmed delivery of `"a"`, the
+response has `"charsSent": 1` and the client retries `"b"`, avoiding `"aab"`.
+`charsSent: 0` means retry the full text; a full-length value means all text landed
+and only a later part of the operation (such as submit) failed. The field is
+omitted for non-append failures.
+
+**Timeouts are ambiguous.** If the ADB child times out while issuing a key event,
+Android may have accepted that current character before the host kills the child.
+The failed response therefore omits `charsSent`, even when earlier characters were
+confirmed, because retrying a suffix at that boundary could duplicate the timed-out
+character. Re-observe the field before deciding how to recover. A client that
+needs per-character atomicity can still send **one character per
+`input/typeText` request**, which is exactly what the reference desktop client
+does (one request per keystroke).
 
 **Partial append failure response**
 

--- a/docs/design-docs/mcp/daemon/unix-socket-api.md
+++ b/docs/design-docs/mcp/daemon/unix-socket-api.md
@@ -608,10 +608,10 @@ omitted for non-append failures.
 Android may have accepted that current character before the host kills the child.
 The failed response therefore omits `charsSent`, even when earlier characters were
 confirmed, because retrying a suffix at that boundary could duplicate the timed-out
-character. Re-observe the field before deciding how to recover. A client that
-needs per-character atomicity can still send **one character per
-`input/typeText` request**, which is exactly what the reference desktop client
-does (one request per keystroke).
+character. Re-observe the field before deciding how to recover, including when
+the request contained only one character. Sending one character per request makes
+definitive failure recovery simple, and is what the reference desktop client does,
+but it does not make a timed-out key event atomic.
 
 **Partial append failure response**
 

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -130,6 +130,20 @@ interface CachedAppendTextInput {
   transportId?: string;
 }
 
+/**
+ * Preserve the normal failed socket envelope while carrying append progress for
+ * a client that can safely retry only the unsent suffix.
+ */
+class InputTypeTextAppendError extends Error {
+  constructor(
+    message: string,
+    readonly charsSent: number
+  ) {
+    super(message);
+    this.name = "InputTypeTextAppendError";
+  }
+}
+
 export class UnixSocketServer {
   private server: NetServer | null = null;
   private socketFileIdentity: SocketFileIdentity | null = null;
@@ -480,6 +494,7 @@ export class UnixSocketServer {
           type: "mcp_response",
           success: false,
           error: errorMessage,
+          ...(error instanceof InputTypeTextAppendError ? { charsSent: error.charsSent } : {}),
         };
       }
     });
@@ -1029,6 +1044,12 @@ export class UnixSocketServer {
     });
 
     if (!inputResult.success) {
+      if (args.append && inputResult.charsSent !== undefined) {
+        throw new InputTypeTextAppendError(
+          inputResult.error ?? `input/typeText failed on ${args.platform}`,
+          inputResult.charsSent
+        );
+      }
       throw new Error(inputResult.error ?? `input/typeText failed on ${args.platform}`);
     }
 
@@ -1134,7 +1155,7 @@ export class UnixSocketServer {
     imeAction: ImeAction | undefined,
     timeoutMs: number,
     append: boolean = false
-  ): Promise<{ success: boolean; error?: string }> {
+  ): Promise<{ success: boolean; error?: string; charsSent?: number }> {
     // Charge set-text and the optional submit/IME action against a single
     // shared budget. Otherwise submit:true would hand each request the full
     // timeout, letting the combined operation run up to 2x the caller's
@@ -1154,18 +1175,34 @@ export class UnixSocketServer {
     // timeout — it still waits for the operation to settle before releasing the
     // queue. An unbounded adb subprocess here would therefore wedge every later
     // input for this device, not just this one request.
-    const textResult = append
-      ? platform === "android"
-        ? await this.getAppendTextInput(targetDevice).appendText(text, timeoutMs)
-        : await (client as IOSCtrlProxyClient).requestAppendText(text, timeoutMs)
-      : await client.requestSetText(text, { timeoutMs });
-    if (!textResult.success) {
-      return { success: false, error: textResult.error };
+    let appendCharsSent: number | undefined;
+    if (append && platform === "android") {
+      const textResult = await this.getAppendTextInput(targetDevice).appendText(text, timeoutMs);
+      if (!textResult.success) {
+        return {
+          success: false,
+          error: textResult.error,
+          ...(textResult.charsSent !== undefined ? { charsSent: textResult.charsSent } : {}),
+        };
+      }
+      appendCharsSent = textResult.charsSent;
+    } else {
+      const textResult = append
+        ? await (client as IOSCtrlProxyClient).requestAppendText(text, timeoutMs)
+        : await client.requestSetText(text, { timeoutMs });
+      if (!textResult.success) {
+        return { success: false, error: textResult.error };
+      }
     }
     if (!imeAction) {
-      return { success: true };
+      return appendCharsSent !== undefined
+        ? { success: true, charsSent: appendCharsSent }
+        : { success: true };
     }
-    return await this.runImeActionWithinBudget(client, imeAction, deadline, timeoutMs);
+    const imeResult = await this.runImeActionWithinBudget(client, imeAction, deadline, timeoutMs);
+    return appendCharsSent !== undefined
+      ? { ...imeResult, charsSent: appendCharsSent }
+      : imeResult;
   }
 
   private async runImeActionWithinBudget(

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1001,6 +1001,7 @@ export class UnixSocketServer {
       "input/typeText",
       args.append
     );
+    let confirmedAppendCharsSent: number | undefined;
     const inputResult = await this.runKeyedMcpForward(`device:${targetDevice.deviceId}`, async () => {
       // A same-serial emulator may reconnect while this request waits behind an
       // earlier input. Re-read its ADB transport inside the keyed callback so the
@@ -1038,8 +1039,15 @@ export class UnixSocketServer {
             args.text,
             imeAction,
             remainingTimeoutMs,
-            args.append
-          )
+            args.append,
+            charsSent => {
+              confirmedAppendCharsSent = charsSent;
+            }
+          ),
+        timeoutError =>
+          args.append && confirmedAppendCharsSent !== undefined
+            ? new InputTypeTextAppendError(timeoutError.message, confirmedAppendCharsSent)
+            : undefined
       );
     });
 
@@ -1154,7 +1162,8 @@ export class UnixSocketServer {
     text: string,
     imeAction: ImeAction | undefined,
     timeoutMs: number,
-    append: boolean = false
+    append: boolean = false,
+    onConfirmedAppendCharsSent?: (charsSent: number) => void
   ): Promise<{ success: boolean; error?: string; charsSent?: number }> {
     // Charge set-text and the optional submit/IME action against a single
     // shared budget. Otherwise submit:true would hand each request the full
@@ -1178,6 +1187,9 @@ export class UnixSocketServer {
     let appendCharsSent: number | undefined;
     if (append && platform === "android") {
       const textResult = await this.getAppendTextInput(targetDevice).appendText(text, timeoutMs);
+      if (textResult.charsSent !== undefined) {
+        onConfirmedAppendCharsSent?.(textResult.charsSent);
+      }
       if (!textResult.success) {
         return {
           success: false,
@@ -1229,7 +1241,8 @@ export class UnixSocketServer {
     totalTimeoutMs: number,
     remainingTimeoutMs: number,
     origin: string,
-    operation: () => Promise<T>
+    operation: () => Promise<T>,
+    timeoutError?: (timeout: McpTimeoutError) => Error | undefined
   ): Promise<T> {
     let timeoutHandle: NodeJS.Timeout | undefined;
     let timedOut = false;
@@ -1247,12 +1260,13 @@ export class UnixSocketServer {
         return result;
       }
 
-      throw new McpTimeoutError({
+      const error = new McpTimeoutError({
         toolName,
         timeoutMs: totalTimeoutMs,
         origin,
         detail: `operation exceeded remaining budget ${remainingTimeoutMs}ms`,
       });
+      throw timeoutError?.(error) ?? error;
     } finally {
       if (timeoutHandle) {
         this.timer.clearTimeout(timeoutHandle);

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1206,23 +1206,21 @@ export class UnixSocketServer {
         return { success: false, error: textResult.error };
       }
     }
-    if (!imeAction) {
-      return appendCharsSent !== undefined
-        ? { success: true, charsSent: appendCharsSent }
-        : { success: true };
-    }
     return await this.runImeActionWithinBudget(client, imeAction, deadline, timeoutMs, appendCharsSent);
   }
 
   private async runImeActionWithinBudget(
     client: Pick<DeviceService, "requestImeAction">,
-    imeAction: ImeAction,
+    imeAction: ImeAction | undefined,
     deadline: number,
     totalTimeoutMs: number,
     appendCharsSent?: number
   ): Promise<{ success: boolean; error?: string; charsSent?: number }> {
     const withAppendProgress = (result: { success: boolean; error?: string }) =>
       appendCharsSent !== undefined ? { ...result, charsSent: appendCharsSent } : result;
+    if (!imeAction) {
+      return withAppendProgress({ success: true });
+    }
     const remainingTimeoutMs = deadline - this.timer.now();
     if (remainingTimeoutMs <= 0) {
       // Defensive: in practice the outer Promise.race timeout fires first, so

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1211,29 +1211,40 @@ export class UnixSocketServer {
         ? { success: true, charsSent: appendCharsSent }
         : { success: true };
     }
-    const imeResult = await this.runImeActionWithinBudget(client, imeAction, deadline, timeoutMs);
-    return appendCharsSent !== undefined
-      ? { ...imeResult, charsSent: appendCharsSent }
-      : imeResult;
+    return await this.runImeActionWithinBudget(client, imeAction, deadline, timeoutMs, appendCharsSent);
   }
 
   private async runImeActionWithinBudget(
     client: Pick<DeviceService, "requestImeAction">,
     imeAction: ImeAction,
     deadline: number,
-    totalTimeoutMs: number
-  ): Promise<{ success: boolean; error?: string }> {
+    totalTimeoutMs: number,
+    appendCharsSent?: number
+  ): Promise<{ success: boolean; error?: string; charsSent?: number }> {
+    const withAppendProgress = (result: { success: boolean; error?: string }) =>
+      appendCharsSent !== undefined ? { ...result, charsSent: appendCharsSent } : result;
     const remainingTimeoutMs = deadline - this.timer.now();
     if (remainingTimeoutMs <= 0) {
       // Defensive: in practice the outer Promise.race timeout fires first, so
       // this path is only reached if set-text spends the entire budget before
       // the submit action starts.
-      return {
+      return withAppendProgress({
         success: false,
         error: `input/typeText exceeded ${totalTimeoutMs}ms budget before submit`,
+      });
+    }
+    try {
+      return withAppendProgress(await client.requestImeAction(imeAction, remainingTimeoutMs));
+    } catch (error) {
+      if (appendCharsSent === undefined) {
+        throw error;
+      }
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+        charsSent: appendCharsSent,
       };
     }
-    return await client.requestImeAction(imeAction, remainingTimeoutMs);
   }
 
   private async runInputOperationWithTimeout<T>(

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -41,6 +41,12 @@ export interface DaemonResponse {
   result?: any;
   /** Error message if unsuccessful */
   error?: string;
+  /**
+   * Number of leading characters delivered by a failed Android
+   * `input/typeText` append request. Present only when the append operation
+   * reached the device before failing, or explicitly reports zero progress.
+   */
+  charsSent?: number;
 }
 
 /**

--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -8,6 +8,7 @@ import { defaultTimer, type Timer } from "../../utils/SystemTimer";
 import { readAndroidDeviceApiLevel } from "../../utils/android-cmdline-tools/readAndroidDeviceApiLevel";
 import type { AdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import { AdbCommandTimeoutError } from "../../utils/android-cmdline-tools/AdbClient";
 import { resolveAutoInputMode } from "./resolveAutoInputMode";
 import { serverConfig } from "../../utils/ServerConfig";
 import { clearTextWithKeyEvents, getFocusedTextLength, hasFocusedTextInput } from "./ClearText";
@@ -373,8 +374,8 @@ export class InputText extends BaseVisualChange {
 
     const typed = await this.typeAppendKeyEvents(planned.plans, remaining, timeoutMs);
     if (typed.error) {
-      // Partial failure: `charsSent` characters already landed on the device. The
-      // caller must retry only `text.slice(charsSent)`, never the whole string.
+      // A non-timeout failure leaves an exact confirmed prefix, while a timed-out
+      // key event is ambiguous: Android may have accepted it before adb was killed.
       return this.appendFailure(text, typed.error, typed.charsSent);
     }
 
@@ -463,7 +464,7 @@ export class InputText extends BaseVisualChange {
     plans: KeyEventPlan[],
     remaining: () => number | undefined,
     timeoutMs: number | undefined
-  ): Promise<{ charsSent: number; error?: string }> {
+  ): Promise<{ charsSent?: number; error?: string }> {
     let charsSent = 0;
     for (const plan of plans) {
       const budget = remaining();
@@ -481,7 +482,13 @@ export class InputText extends BaseVisualChange {
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         logger.warn(`[InputText] append key event failed after ${charsSent} char(s): ${message}`, error);
-        return { charsSent, error: `append key event failed: ${message}` };
+        // An adb timeout kills the host child but cannot establish whether Android
+        // accepted the current key event. Reporting the earlier prefix as an exact
+        // retry boundary would let a caller duplicate this ambiguous character.
+        return {
+          ...(error instanceof AdbCommandTimeoutError ? {} : { charsSent }),
+          error: `append key event failed: ${message}`,
+        };
       }
       charsSent += 1;
     }
@@ -520,9 +527,15 @@ export class InputText extends BaseVisualChange {
   private appendFailure(
     text: string,
     error: string,
-    charsSent: number
+    charsSent?: number
   ): SendTextResult & { method?: InputTextMode } {
-    return { success: false, text, error, method: "append", charsSent };
+    return {
+      success: false,
+      text,
+      error,
+      method: "append",
+      ...(charsSent !== undefined ? { charsSent } : {}),
+    };
   }
 
   private async executeAndroidEventOnlyTextInput(

--- a/src/models/SendTextResult.ts
+++ b/src/models/SendTextResult.ts
@@ -8,12 +8,13 @@ export interface SendTextResult extends BaseActionResult {
   imeAction?: string;
   /**
    * For the Android `append` mode only: how many leading characters of `text`
-   * were actually sent to the device as key events. Append is best-effort and
-   * char-by-char, so on a partial failure (an adb reject/timeout mid-batch) this
-   * is the length of the prefix that landed — a caller must retry only
-   * `text.slice(charsSent)`, never the whole string, or it doubles the prefix
-   * (issue #3351). Present on both success (== full length) and partial-failure
-   * results; omitted by the non-append modes.
+   * were confirmed by adb as sent to the device as key events. Append is
+   * best-effort and char-by-char, so after a definitive partial failure this is
+   * the safe retry boundary: retry only `text.slice(charsSent)`, never the whole
+   * string, or it doubles the prefix (issue #3351). Omitted if an in-flight key
+   * event times out because adb cannot establish whether Android accepted it;
+   * callers must re-observe before retrying in that case. Present on success
+   * (== full length) and some failed append results; omitted by non-append modes.
    */
   charsSent?: number;
 }

--- a/test/daemon/socketServerInputTypeText.test.ts
+++ b/test/daemon/socketServerInputTypeText.test.ts
@@ -306,6 +306,48 @@ describe("UnixSocketServer input/typeText", () => {
     expect(requestImeAction).toHaveBeenCalledWith("done", 30_000);
   });
 
+  test("append preserves full progress when submit reaches the shared deadline", async () => {
+    const requestImeAction = mock(
+      () =>
+        new Promise(resolve => {
+          fakeTimer.setTimeout(
+            () => resolve({ success: false, error: "enter key unavailable", totalTimeMs: 1 }),
+            100
+          );
+        })
+    );
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      requestImeAction,
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    server.appendTextFactory = () => ({
+      appendText: async () => ({ success: true, charsSent: 2 }),
+    });
+    await server.start();
+
+    const responsePromise = sendRequest(socketPath, "input/typeText", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      text: "ab",
+      mode: "append",
+      submit: true,
+    }, 100);
+
+    await flushMicrotasks();
+    expect(requestImeAction).toHaveBeenCalledWith("done", 100);
+    fakeTimer.advanceTime(100);
+    await flushMicrotasks();
+
+    const response = await withWedgeGuard(
+      responsePromise,
+      "the timed-out submit did not release the per-device queue"
+    );
+    expect(response.success).toBe(false);
+    expect(response.error).toContain("input/typeText exceeded 100ms");
+    expect(response.charsSent).toBe(2);
+  });
+
   // The review's Critical + P1 finding, which share one root cause: the append path
   // used to receive no timeout at all. `runInputOperationWithTimeout` detects the
   // socket deadline but then AWAITS the in-flight operation before releasing the

--- a/test/daemon/socketServerInputTypeText.test.ts
+++ b/test/daemon/socketServerInputTypeText.test.ts
@@ -246,6 +246,33 @@ describe("UnixSocketServer input/typeText", () => {
     }
   });
 
+  test("failed multi-character append reports the landed prefix on the error envelope", async () => {
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    server.appendTextFactory = () => ({
+      appendText: async () => ({
+        success: false,
+        error: "append key event failed: adb rejected KEYCODE_B",
+        charsSent: 1,
+      }),
+    });
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/typeText", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      text: "ab",
+      mode: "append",
+    });
+
+    expect(response).toMatchObject({
+      success: false,
+      error: "append key event failed: adb rejected KEYCODE_B",
+      charsSent: 1,
+    });
+    expect(response.result).toBeUndefined();
+  });
+
   // The review's Critical + P1 finding, which share one root cause: the append path
   // used to receive no timeout at all. `runInputOperationWithTimeout` detects the
   // socket deadline but then AWAITS the in-flight operation before releasing the
@@ -883,6 +910,7 @@ describe("UnixSocketServer input/typeText", () => {
 
     expect(response.success).toBe(false);
     expect(response.error).toBe("return key unavailable");
+    expect(response.charsSent).toBeUndefined();
     expect(requestSetText).toHaveBeenCalledWith("hi there", { timeoutMs: 30_000 });
     expect(requestImeAction).toHaveBeenCalledWith("done", 30_000);
   });

--- a/test/daemon/socketServerInputTypeText.test.ts
+++ b/test/daemon/socketServerInputTypeText.test.ts
@@ -306,6 +306,36 @@ describe("UnixSocketServer input/typeText", () => {
     expect(requestImeAction).toHaveBeenCalledWith("done", 30_000);
   });
 
+  test("append reports full progress when submit throws after all text lands", async () => {
+    const requestImeAction = mock(async () => {
+      throw new Error("CtrlProxy send failed");
+    });
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      requestImeAction,
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    server.appendTextFactory = () => ({
+      appendText: async () => ({ success: true, charsSent: 2 }),
+    });
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/typeText", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      text: "ab",
+      mode: "append",
+      submit: true,
+    });
+
+    expect(response).toMatchObject({
+      success: false,
+      error: "CtrlProxy send failed",
+      charsSent: 2,
+    });
+    expect(requestImeAction).toHaveBeenCalledWith("done", 30_000);
+  });
+
   test("append preserves full progress when submit reaches the shared deadline", async () => {
     const requestImeAction = mock(
       () =>

--- a/test/daemon/socketServerInputTypeText.test.ts
+++ b/test/daemon/socketServerInputTypeText.test.ts
@@ -273,6 +273,38 @@ describe("UnixSocketServer input/typeText", () => {
     expect(response.result).toBeUndefined();
   });
 
+  test("append reports full progress when submit fails after all text lands", async () => {
+    const requestImeAction = mock(async () => ({
+      success: false,
+      error: "enter key unavailable",
+      totalTimeMs: 1,
+    }));
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      requestImeAction,
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    server.appendTextFactory = () => ({
+      appendText: async () => ({ success: true, charsSent: 2 }),
+    });
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/typeText", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      text: "ab",
+      mode: "append",
+      submit: true,
+    });
+
+    expect(response).toMatchObject({
+      success: false,
+      error: "enter key unavailable",
+      charsSent: 2,
+    });
+    expect(requestImeAction).toHaveBeenCalledWith("done", 30_000);
+  });
+
   // The review's Critical + P1 finding, which share one root cause: the append path
   // used to receive no timeout at all. `runInputOperationWithTimeout` detects the
   // socket deadline but then AWAITS the in-flight operation before releasing the
@@ -631,6 +663,7 @@ describe("UnixSocketServer input/typeText", () => {
 
     expect(response.success).toBe(false);
     expect(String(response.error)).toContain("append cannot type \"A\"");
+    expect(response.charsSent).toBe(0);
     // Not silently repaired by the replace path, which would wipe the field.
     expect(requestSetText).not.toHaveBeenCalled();
     expect(adb.inputCommands()).toEqual([]);

--- a/test/daemon/socketServerInputTypeText.test.ts
+++ b/test/daemon/socketServerInputTypeText.test.ts
@@ -8,6 +8,7 @@ import { UnixSocketServer } from "../../src/daemon/socketServer";
 import { InputText } from "../../src/features/action/InputText";
 import type { BootedDevice, ExecResult } from "../../src/models";
 import type { AdbExecutor } from "../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
+import { AdbCommandTimeoutError } from "../../src/utils/android-cmdline-tools/AdbClient";
 import { defaultTimer } from "../../src/utils/SystemTimer";
 import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
 import { IOSCtrlProxyClient } from "../../src/features/observe/ios";
@@ -70,7 +71,7 @@ class ScriptedAdbExecutor {
         return;
       }
       this.timer.setTimeout(
-        () => reject(new Error(`adb command timed out after ${timeoutMs}ms: ${label}`)),
+        () => reject(new AdbCommandTimeoutError(`adb command timed out after ${timeoutMs}ms: ${label}`)),
         timeoutMs
       );
     });
@@ -352,6 +353,42 @@ describe("UnixSocketServer input/typeText", () => {
     );
     expect(next.success).toBe(true);
     expect(requestSetText).toHaveBeenCalledWith("next", { timeoutMs: 30_000 });
+  });
+
+  test("a timed-out later append key omits an unsafe retry boundary", async () => {
+    const requestSetText = mock(async () => ({ success: true, totalTimeMs: 1 }));
+    const requestImeAction = mock(async () => ({ success: true, totalTimeMs: 1 }));
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      requestSetText,
+      requestImeAction,
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    const adb = new ScriptedAdbExecutor(fakeTimer, "KEYCODE_B");
+    server.appendTextFactory = device => createAppendTextInput(device, adb, fakeTimer);
+    await server.start();
+
+    const responsePromise = sendRequest(socketPath, "input/typeText", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      text: "ab",
+      mode: "append",
+    }, 100);
+
+    await flushMicrotasks();
+    fakeTimer.advanceTime(100);
+    await flushMicrotasks();
+
+    const response = await withWedgeGuard(
+      responsePromise,
+      "the timed-out append did not release the per-device queue"
+    );
+    expect(response.success).toBe(false);
+    expect(response.charsSent).toBeUndefined();
+    expect(adb.inputCommands()).toEqual([
+      "shell input keyevent KEYCODE_A",
+      "shell input keyevent KEYCODE_B",
+    ]);
   });
 
   // The first wedge fix bounded only the getprop FALLBACK. Production AdbClient

--- a/test/features/action/InputText.test.ts
+++ b/test/features/action/InputText.test.ts
@@ -832,8 +832,30 @@ describe("InputText", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain("append key event failed");
+    expect(result.charsSent).toBeUndefined();
     // Exactly one attempt: the deadline is not multiplied by the retry count.
     expect(keyEventCalls).toBe(1);
+  });
+
+  test("a timed-out later append key leaves the retry boundary ambiguous", async () => {
+    const exec = (command: string): Promise<ExecResult> => {
+      if (command.includes("input keyevent KEYCODE_B")) {
+        return Promise.reject(
+          new AdbCommandTimeoutError("Command timed out after 5ms: adb shell input keyevent KEYCODE_B")
+        );
+      }
+      return Promise.resolve(execResult(""));
+    };
+    const adb = new AdbClient(androidDevice, exec, null, undefined, new FakeTimer());
+    const inputText = new InputText(androidDevice, adb, undefined, new FakeTimer());
+
+    const result = await inputText.appendText("ab", 5000);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("append key event failed");
+    // KEYCODE_A was confirmed, but Android may have accepted KEYCODE_B before
+    // adb timed out, so `1` would be an unsafe retry boundary.
+    expect(result.charsSent).toBeUndefined();
   });
 
   test("append charges the API probe and every key event against the caller's budget", async () => {


### PR DESCRIPTION
## Summary

- Add `charsSent` to failed Android `input/typeText` append socket responses.
- Preserve the existing failed envelope (`success: false` and string `error`) so sibling input methods retain their behavior.
- Document retrying only `text.slice(charsSent)` and cover both partial append and non-append failures.

## Why

Multi-character append requests can deliver a leading prefix before an ADB failure. The daemon previously discarded the already-tracked prefix length, leaving a third-party client unable to resume safely without duplicating text.

## Validation

- `bun test test/daemon/socketServerInputTypeText.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run turbo:validate`
- `git diff --check`

Closes [#4537](https://github.com/kaeawc/auto-mobile/issues/4537)
