### PR TITLE
fix(adb): bound path discovery deadline

### DIFF
--- a/docs/design-docs/mcp/daemon/client-screen-control.md
+++ b/docs/design-docs/mcp/daemon/client-screen-control.md
@@ -293,7 +293,6 @@ tracked back to [#1099](https://github.com/kaeawc/auto-mobile/issues/1099):
 | [#4502](https://github.com/kaeawc/auto-mobile/issues/4502) | Close the same-device rotation window in the client control-tap gate. |
 | [#4505](https://github.com/kaeawc/auto-mobile/issues/4505) | Daemon-side frame-context validation so the *daemon* rejects stale-context input (protects clients that will not reimplement the client-side snapshot rules). |
 | [#4519](https://github.com/kaeawc/auto-mobile/issues/4519) | iOS non-destructive text append for keyboard forwarding. |
-| [#4533](https://github.com/kaeawc/auto-mobile/issues/4533) | Bound `ensureAdbPath` discovery so a cold cache cannot wedge the per-device input queue. |
 | [#4534](https://github.com/kaeawc/auto-mobile/issues/4534) | Evict the append cache on rapid same-serial device reuse (needs a device-connect signal). |
 | [#4535](https://github.com/kaeawc/auto-mobile/issues/4535) | Optional daemon capability signal for newer input params (e.g. `input/typeText mode:append`). |
 | [#4536](https://github.com/kaeawc/auto-mobile/issues/4536) | Prefer a reliable native AltGraph signal over the `ctrl && alt` heuristic. |

--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -325,12 +325,8 @@ export class InputText extends BaseVisualChange {
    *   Omitting it leaves the subprocesses unbounded, which is only safe for a caller
    *   that owns its own lifetime.
    *
-   *   Caveat: the budget bounds only the operations this method issues. It does NOT
-   *   bound `AdbClient`'s shared ADB-path discovery (`ensureAdbPath`), which runs
-   *   inside `executeArgsImpl` BEFORE the per-command timeout applies. On a cold or
-   *   expired 60s path cache a stalled discovery probe can still wedge the queue —
-   *   a property of the shared adb primitive every input path uses, tracked in
-   *   #4533, not fixable here.
+   *   `AdbClient` charges its shared ADB-path discovery against the same command
+   *   deadline, so a cold or expired path cache cannot escape this request budget.
    */
   async appendText(
     text: string,
@@ -479,9 +475,8 @@ export class InputText extends BaseVisualChange {
         // attempts, each charged the SAME budget — and runInputOperationWithTimeout
         // awaits the losing operation before releasing the per-device queue, so a
         // stalled key event would otherwise hold the queue for ~4x the request
-        // deadline. A single attempt keeps this append's own device ops within one
-        // budget (the shared ensureAdbPath discovery is the one exception — see the
-        // appendText caveat and issue #4533).
+        // deadline. A single attempt keeps this append's device operations within
+        // one budget, including shared ADB-path discovery.
         await this.executeKeyEventPlan(plan, budget, true);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -2,7 +2,11 @@ import { execFile, spawn, type ChildProcess } from "child_process";
 import { promisify } from "util";
 import { logger } from "../logger";
 import { BootedDevice, ExecResult, AndroidUser, DeviceLockState } from "../../models";
-import { detectAndroidCommandLineTools, getBestAndroidToolsLocation } from "./detection";
+import {
+  AndroidToolsDetectionTimeoutError,
+  detectAndroidCommandLineTools,
+  getBestAndroidToolsLocation,
+} from "./detection";
 import {
   AdbExecutor,
   type AdbExecuteOptions,
@@ -16,6 +20,7 @@ import { TTLCache } from "../cache/Cache";
 import { Timer, defaultTimer } from "../SystemTimer";
 import { wrapCommandError } from "../CommandError";
 import { isAdbMissingDeviceError, notifyAdbMissingDevice } from "./AdbDeviceHealth";
+import { DefaultSystemDetection, type SystemDetection } from "../system/SystemDetection";
 
 type ExecFileAsync = (file: string, args: string[], maxBuffer?: number) => Promise<ExecResult>;
 
@@ -194,35 +199,40 @@ export class AdbClient implements AdbExecutor {
   /**
    * Get the ADB path asynchronously via detection
    */
-  private async getAdbPath(): Promise<string> {
+  private async getAdbPath(timeoutMs?: number, signal?: AbortSignal): Promise<string> {
+    const deadlineMs = timeoutMs === undefined ? undefined : this.timer.now() + timeoutMs;
     // 1. Try environment variables first (fastest path)
     const envPath = this.getFallbackAdbPath();
     if (envPath !== "adb") {
       // We got a path from environment variables, verify it exists
       try {
-        await this.execAsync(envPath, ["version"]);
+        await this.executeAdbPathProbe(envPath, ["version"], deadlineMs, signal);
         logger.debug(`Using ADB from environment: ${envPath}`);
         return envPath;
-      } catch {
+      } catch (error) {
+        this.throwIfAdbPathTimeout(error);
         logger.debug(`ADB path from environment not working: ${envPath}`);
       }
     }
 
     // 2. Try to find via `which adb` (works in CI environments where adb is in PATH)
     try {
-      const whichResult = await this.execAsync("which", ["adb"]);
+      const whichResult = await this.executeAdbPathProbe("which", ["adb"], deadlineMs, signal);
       const adbFromPath = whichResult.stdout.trim();
       if (adbFromPath) {
         logger.debug(`Found ADB via which: ${adbFromPath}`);
         return adbFromPath;
       }
-    } catch {
+    } catch (error) {
+      this.throwIfAdbPathTimeout(error);
       logger.debug("ADB not found via 'which adb'");
     }
 
     // 3. Try Android command line tools detection (slower, more comprehensive)
     try {
-      const locations = await detectAndroidCommandLineTools();
+      const locations = await detectAndroidCommandLineTools(
+        this.createDeadlineBoundSystemDetection(deadlineMs, signal)
+      );
       const bestLocation = getBestAndroidToolsLocation(locations);
 
       if (bestLocation) {
@@ -238,12 +248,72 @@ export class AdbClient implements AdbExecutor {
         return `${sdkRoot}/platform-tools/adb`;
       }
     } catch (error) {
+      if (error instanceof AndroidToolsDetectionTimeoutError) {
+        throw new AdbCommandTimeoutError(error.message);
+      }
       logger.debug(`Failed to detect ADB path via Android tools detection: ${error}`);
     }
 
     // 4. Final fallback - just use "adb" and hope it's in PATH
     logger.debug("Using fallback ADB path: adb");
     return "adb";
+  }
+
+  private async executeAdbPathProbe(
+    file: string,
+    args: string[],
+    deadlineMs: number | undefined,
+    signal?: AbortSignal
+  ): Promise<ExecResult> {
+    const timeoutMs = deadlineMs === undefined ? undefined : deadlineMs - this.timer.now();
+    if (timeoutMs !== undefined && timeoutMs <= 0) {
+      throw new AdbCommandTimeoutError(`Command timed out before ADB path discovery: ${file} ${args.join(" ")}`);
+    }
+    return this.execWithSignal(file, args, undefined, timeoutMs, signal);
+  }
+
+  private createDeadlineBoundSystemDetection(
+    deadlineMs: number | undefined,
+    signal?: AbortSignal
+  ): SystemDetection {
+    const defaults = new DefaultSystemDetection();
+    return {
+      getCurrentPlatform: () => defaults.getCurrentPlatform(),
+      getHomeDir: () => defaults.getHomeDir(),
+      getEnvVar: name => defaults.getEnvVar(name),
+      fileExistsSync: path => defaults.fileExistsSync(path),
+      fileExists: path => defaults.fileExists(path),
+      executeCommand: async (file, args = []) => {
+        try {
+          return await this.executeAdbPathProbe(file, args, deadlineMs, signal);
+        } catch (error) {
+          if (error instanceof AdbCommandTimeoutError) {
+            throw new AndroidToolsDetectionTimeoutError(error.message);
+          }
+          throw error;
+        }
+      },
+    };
+  }
+
+  private throwIfAdbPathTimeout(error: unknown, signal?: AbortSignal): void {
+    if (error instanceof AdbCommandTimeoutError) {
+      throw error;
+    }
+    if (signal?.aborted) {
+      throw this.getAbortError(signal);
+    }
+  }
+
+  private getRemainingTimeoutMs(timeoutMs: number | undefined, startTime: number, command: string): number | undefined {
+    if (timeoutMs === undefined) {
+      return undefined;
+    }
+    const remainingMs = timeoutMs - (this.timer.now() - startTime);
+    if (remainingMs <= 0) {
+      throw new AdbCommandTimeoutError(`Command timed out after ${timeoutMs}ms before execution: ${command}`);
+    }
+    return remainingMs;
   }
 
   /**
@@ -257,7 +327,7 @@ export class AdbClient implements AdbExecutor {
   /**
    * Ensure ADB path is properly detected and cached
    */
-  private async ensureAdbPath(): Promise<string> {
+  private async ensureAdbPath(timeoutMs?: number, signal?: AbortSignal): Promise<string> {
     // In test mode, skip detection and use fallback (usually "adb")
     if (this.isTestMode) {
       return this.adbPath;
@@ -272,7 +342,7 @@ export class AdbClient implements AdbExecutor {
     }
 
     // Detect and cache the path
-    const detectedPath = await this.getAdbPath();
+    const detectedPath = await this.getAdbPath(timeoutMs, signal);
     cache.set("adbPath", detectedPath);
     this.adbPath = detectedPath;
     return this.adbPath;
@@ -287,9 +357,9 @@ export class AdbClient implements AdbExecutor {
     return [adbPath, ...baseArgs].join(" ");
   }
 
-  async getBaseCommandParts(): Promise<{ adbPath: string; baseArgs: string[] }> {
+  async getBaseCommandParts(timeoutMs?: number, signal?: AbortSignal): Promise<{ adbPath: string; baseArgs: string[] }> {
     const deviceId = this.device?.deviceId;
-    const adbPath = await this.ensureAdbPath();
+    const adbPath = await this.ensureAdbPath(timeoutMs, signal);
     const baseArgs: string[] = [];
 
     if (deviceId) {
@@ -565,11 +635,11 @@ export class AdbClient implements AdbExecutor {
     noRetry?: boolean,
     signal?: AbortSignal
   ): Promise<ExecResult> {
-    const { adbPath, baseArgs } = await this.getBaseCommandParts();
-    const fullArgs = [...baseArgs, ...commandArgs];
-    const command = commandArgs.join(" ");
     const startTime = this.timer.now();
     const resolvedSignal = signal ?? getAbortSignal();
+    const { adbPath, baseArgs } = await this.getBaseCommandParts(timeoutMs, resolvedSignal);
+    const fullArgs = [...baseArgs, ...commandArgs];
+    const command = commandArgs.join(" ");
 
     // Log which device is receiving this command for parallel execution debugging
     const deviceInfo = this.device ? `[DEVICE:${this.device.deviceId}]` : "[NO-DEVICE]";
@@ -578,7 +648,13 @@ export class AdbClient implements AdbExecutor {
     if (noRetry) {
       // No retry - just execute once
       try {
-        const result = await this.execWithSignal(adbPath, fullArgs, maxBuffer, timeoutMs, resolvedSignal);
+        const result = await this.execWithSignal(
+          adbPath,
+          fullArgs,
+          maxBuffer,
+          this.getRemainingTimeoutMs(timeoutMs, startTime, command),
+          resolvedSignal
+        );
         return result;
       } catch (error) {
         if (resolvedSignal?.aborted) {
@@ -602,7 +678,13 @@ export class AdbClient implements AdbExecutor {
         if (resolvedSignal?.aborted) {
           throw this.getAbortError(resolvedSignal);
         }
-        const result = await this.execWithSignal(adbPath, fullArgs, maxBuffer, timeoutMs, resolvedSignal);
+        const result = await this.execWithSignal(
+          adbPath,
+          fullArgs,
+          maxBuffer,
+          this.getRemainingTimeoutMs(timeoutMs, startTime, command),
+          resolvedSignal
+        );
         return result;
       },
       {

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -135,7 +135,8 @@ export class AdbClient implements AdbExecutor {
     execAsyncFn: ((command: string, maxBuffer?: number) => Promise<ExecResult>) | ExecFileAsync | null = null,
     spawnFn: typeof spawn | null = null,
     retryExecutor: RetryExecutor = defaultRetryExecutor,
-    timer: Timer = defaultTimer
+    timer: Timer = defaultTimer,
+    private readonly systemDetectionFactory: () => SystemDetection = () => new DefaultSystemDetection()
   ) {
     this.device = device;
     // Test mode if: custom execAsync provided OR global test mode flag is set
@@ -280,13 +281,13 @@ export class AdbClient implements AdbExecutor {
     deadlineMs: number | undefined,
     signal?: AbortSignal
   ): SystemDetection {
-    const defaults = new DefaultSystemDetection();
+    const defaults = this.systemDetectionFactory();
     return {
       getCurrentPlatform: () => defaults.getCurrentPlatform(),
       getHomeDir: () => defaults.getHomeDir(),
       getEnvVar: name => defaults.getEnvVar(name),
       fileExistsSync: path => defaults.fileExistsSync(path),
-      fileExists: path => defaults.fileExists(path),
+      fileExists: path => this.executeDetectionFileProbe(defaults, path, deadlineMs, signal),
       executeCommand: async (file, args = []) => {
         try {
           return await this.executeAdbPathProbe(file, args, deadlineMs, signal);
@@ -301,6 +302,57 @@ export class AdbClient implements AdbExecutor {
         }
       },
     };
+  }
+
+  private async executeDetectionFileProbe(
+    systemDetection: SystemDetection,
+    path: string,
+    deadlineMs: number | undefined,
+    signal?: AbortSignal
+  ): Promise<boolean> {
+    if (signal?.aborted) {
+      throw new AndroidToolsDetectionAbortError(this.getAbortError(signal));
+    }
+
+    const timeoutMs = deadlineMs === undefined ? undefined : deadlineMs - this.timer.now();
+    if (timeoutMs !== undefined && timeoutMs <= 0) {
+      throw new AndroidToolsDetectionTimeoutError(`Command timed out before ADB path discovery: ${path}`);
+    }
+    if (timeoutMs === undefined && !signal) {
+      return systemDetection.fileExists(path);
+    }
+
+    return new Promise<boolean>((resolve, reject) => {
+      let settled = false;
+      let timeoutHandle: NodeJS.Timeout | undefined;
+      const cleanup = () => {
+        if (timeoutHandle) {
+          this.timer.clearTimeout(timeoutHandle);
+        }
+        signal?.removeEventListener("abort", onAbort);
+      };
+      const settle = (callback: () => void) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        callback();
+      };
+      const onAbort = () => settle(() => reject(new AndroidToolsDetectionAbortError(this.getAbortError(signal!))));
+
+      if (timeoutMs !== undefined) {
+        timeoutHandle = this.timer.setTimeout(
+          () => settle(() => reject(new AndroidToolsDetectionTimeoutError(`Command timed out before ADB path discovery: ${path}`))),
+          timeoutMs
+        );
+      }
+      signal?.addEventListener("abort", onAbort, { once: true });
+      void systemDetection.fileExists(path).then(
+        exists => settle(() => resolve(exists)),
+        error => settle(() => reject(error))
+      );
+    });
   }
 
   private throwIfAdbPathTimeout(error: unknown, signal?: AbortSignal): void {

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -3,6 +3,7 @@ import { promisify } from "util";
 import { logger } from "../logger";
 import { BootedDevice, ExecResult, AndroidUser, DeviceLockState } from "../../models";
 import {
+  AndroidToolsDetectionAbortError,
   AndroidToolsDetectionTimeoutError,
   detectAndroidCommandLineTools,
   getBestAndroidToolsLocation,
@@ -251,6 +252,9 @@ export class AdbClient implements AdbExecutor {
       if (error instanceof AndroidToolsDetectionTimeoutError) {
         throw new AdbCommandTimeoutError(error.message);
       }
+      if (error instanceof AndroidToolsDetectionAbortError) {
+        throw error.abortError;
+      }
       logger.debug(`Failed to detect ADB path via Android tools detection: ${error}`);
     }
 
@@ -289,6 +293,9 @@ export class AdbClient implements AdbExecutor {
         } catch (error) {
           if (error instanceof AdbCommandTimeoutError) {
             throw new AndroidToolsDetectionTimeoutError(error.message);
+          }
+          if (signal?.aborted) {
+            throw new AndroidToolsDetectionAbortError(this.getAbortError(signal));
           }
           throw error;
         }

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -210,7 +210,7 @@ export class AdbClient implements AdbExecutor {
         logger.debug(`Using ADB from environment: ${envPath}`);
         return envPath;
       } catch (error) {
-        this.throwIfAdbPathTimeout(error);
+        this.throwIfAdbPathTimeout(error, signal);
         logger.debug(`ADB path from environment not working: ${envPath}`);
       }
     }
@@ -224,7 +224,7 @@ export class AdbClient implements AdbExecutor {
         return adbFromPath;
       }
     } catch (error) {
-      this.throwIfAdbPathTimeout(error);
+      this.throwIfAdbPathTimeout(error, signal);
       logger.debug("ADB not found via 'which adb'");
     }
 

--- a/src/utils/android-cmdline-tools/detection.ts
+++ b/src/utils/android-cmdline-tools/detection.ts
@@ -2,6 +2,18 @@ import { join, dirname } from "path";
 import { logger } from "../logger";
 import { SystemDetection, DefaultSystemDetection } from "../system/SystemDetection";
 
+/**
+ * Signals that a caller-owned deadline expired while this module was probing
+ * the host. Discovery normally treats missing commands as a negative result;
+ * a deadline expiry must instead reach that caller unchanged.
+ */
+export class AndroidToolsDetectionTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AndroidToolsDetectionTimeoutError";
+  }
+}
+
 export type AndroidToolsSource = "homebrew" | "android_home" | "android_sdk_root" | "path" | "manual" | "typical";
 
 export interface AndroidToolsLocation {
@@ -202,6 +214,9 @@ export async function isToolInPath(toolName: string, systemDetection = createDef
     await systemDetection.executeCommand(command, [toolName]);
     return true;
   } catch (error) {
+    if (error instanceof AndroidToolsDetectionTimeoutError) {
+      throw error;
+    }
     // which/where exits non-zero when the tool isn't on PATH; that's a normal "not found", not a fault.
     logger.debug(`src/utils/android-cmdline-tools/detection.ts fallback failed: ${error}`, error);
     return false;
@@ -218,6 +233,9 @@ export async function getToolPathFromPath(toolName: string, systemDetection = cr
     const path = result.stdout.trim().split("\n")[0]; // Take first result if multiple
     return path || null;
   } catch (error) {
+    if (error instanceof AndroidToolsDetectionTimeoutError) {
+      throw error;
+    }
     // which/where exits non-zero when the tool isn't on PATH; null tells the caller to keep searching.
     logger.debug(`src/utils/android-cmdline-tools/detection.ts fallback failed: ${error}`, error);
     return null;
@@ -410,6 +428,9 @@ export async function detectAndroidCommandLineTools(systemDetection = createDefa
       logger.debug(`Found Android tools in PATH: ${pathLocation.available_tools.join(", ")}`);
     }
   } catch (error) {
+    if (error instanceof AndroidToolsDetectionTimeoutError) {
+      throw error;
+    }
     logger.warn(`Error detecting Android tools in PATH: ${(error as Error).message}`);
   }
 

--- a/src/utils/android-cmdline-tools/detection.ts
+++ b/src/utils/android-cmdline-tools/detection.ts
@@ -14,6 +14,20 @@ export class AndroidToolsDetectionTimeoutError extends Error {
   }
 }
 
+/** Preserves caller cancellation through discovery's normal miss handling. */
+export class AndroidToolsDetectionAbortError extends Error {
+  constructor(readonly abortError: Error) {
+    super(abortError.message);
+    this.name = "AndroidToolsDetectionAbortError";
+  }
+}
+
+function isAndroidToolsDetectionControlError(
+  error: unknown
+): error is AndroidToolsDetectionTimeoutError | AndroidToolsDetectionAbortError {
+  return error instanceof AndroidToolsDetectionTimeoutError || error instanceof AndroidToolsDetectionAbortError;
+}
+
 export type AndroidToolsSource = "homebrew" | "android_home" | "android_sdk_root" | "path" | "manual" | "typical";
 
 export interface AndroidToolsLocation {
@@ -214,7 +228,7 @@ export async function isToolInPath(toolName: string, systemDetection = createDef
     await systemDetection.executeCommand(command, [toolName]);
     return true;
   } catch (error) {
-    if (error instanceof AndroidToolsDetectionTimeoutError) {
+    if (isAndroidToolsDetectionControlError(error)) {
       throw error;
     }
     // which/where exits non-zero when the tool isn't on PATH; that's a normal "not found", not a fault.
@@ -233,7 +247,7 @@ export async function getToolPathFromPath(toolName: string, systemDetection = cr
     const path = result.stdout.trim().split("\n")[0]; // Take first result if multiple
     return path || null;
   } catch (error) {
-    if (error instanceof AndroidToolsDetectionTimeoutError) {
+    if (isAndroidToolsDetectionControlError(error)) {
       throw error;
     }
     // which/where exits non-zero when the tool isn't on PATH; null tells the caller to keep searching.
@@ -428,7 +442,7 @@ export async function detectAndroidCommandLineTools(systemDetection = createDefa
       logger.debug(`Found Android tools in PATH: ${pathLocation.available_tools.join(", ")}`);
     }
   } catch (error) {
-    if (error instanceof AndroidToolsDetectionTimeoutError) {
+    if (isAndroidToolsDetectionControlError(error)) {
       throw error;
     }
     logger.warn(`Error detecting Android tools in PATH: ${(error as Error).message}`);

--- a/src/utils/android-cmdline-tools/detection.ts
+++ b/src/utils/android-cmdline-tools/detection.ts
@@ -28,6 +28,12 @@ function isAndroidToolsDetectionControlError(
   return error instanceof AndroidToolsDetectionTimeoutError || error instanceof AndroidToolsDetectionAbortError;
 }
 
+function rethrowAndroidToolsDetectionControlError(error: unknown): void {
+  if (isAndroidToolsDetectionControlError(error)) {
+    throw error;
+  }
+}
+
 export type AndroidToolsSource = "homebrew" | "android_home" | "android_sdk_root" | "path" | "manual" | "typical";
 
 export interface AndroidToolsLocation {
@@ -201,6 +207,27 @@ export function getHomebrewAndroidToolsPath(systemDetection = createDefaultSyste
   return null;
 }
 
+async function getHomebrewAndroidToolsPathAsync(
+  systemDetection: SystemDetection
+): Promise<string | null> {
+  if (systemDetection.getCurrentPlatform() !== "darwin") {
+    return null;
+  }
+
+  const homebrewPaths = [
+    "/opt/homebrew/share/android-commandlinetools/cmdline-tools/latest",
+    "/usr/local/share/android-commandlinetools/cmdline-tools/latest"
+  ];
+
+  for (const homebrewPath of homebrewPaths) {
+    if (await systemDetection.fileExists(homebrewPath)) {
+      return homebrewPath;
+    }
+  }
+
+  return null;
+}
+
 /**
  * Get Android SDK path from environment variables
  */
@@ -219,6 +246,22 @@ export function getAndroidSdkFromEnvironment(systemDetection = createDefaultSyst
   return null;
 }
 
+async function getAndroidSdkFromEnvironmentAsync(
+  systemDetection: SystemDetection
+): Promise<string | null> {
+  const androidHome = systemDetection.getEnvVar("ANDROID_HOME");
+  if (androidHome && await systemDetection.fileExists(androidHome)) {
+    return androidHome;
+  }
+
+  const androidSdkRoot = systemDetection.getEnvVar("ANDROID_SDK_ROOT");
+  if (androidSdkRoot && await systemDetection.fileExists(androidSdkRoot)) {
+    return androidSdkRoot;
+  }
+
+  return null;
+}
+
 /**
  * Check if a tool is available in the system PATH
  */
@@ -228,9 +271,7 @@ export async function isToolInPath(toolName: string, systemDetection = createDef
     await systemDetection.executeCommand(command, [toolName]);
     return true;
   } catch (error) {
-    if (isAndroidToolsDetectionControlError(error)) {
-      throw error;
-    }
+    rethrowAndroidToolsDetectionControlError(error);
     // which/where exits non-zero when the tool isn't on PATH; that's a normal "not found", not a fault.
     logger.debug(`src/utils/android-cmdline-tools/detection.ts fallback failed: ${error}`, error);
     return false;
@@ -247,9 +288,7 @@ export async function getToolPathFromPath(toolName: string, systemDetection = cr
     const path = result.stdout.trim().split("\n")[0]; // Take first result if multiple
     return path || null;
   } catch (error) {
-    if (isAndroidToolsDetectionControlError(error)) {
-      throw error;
-    }
+    rethrowAndroidToolsDetectionControlError(error);
     // which/where exits non-zero when the tool isn't on PATH; null tells the caller to keep searching.
     logger.debug(`src/utils/android-cmdline-tools/detection.ts fallback failed: ${error}`, error);
     return null;
@@ -285,16 +324,41 @@ export function getAvailableToolsInDirectory(toolsDir: string, systemDetection =
   return availableTools;
 }
 
+async function getAvailableToolsInDirectoryAsync(
+  toolsDir: string,
+  systemDetection: SystemDetection
+): Promise<string[]> {
+  if (!await systemDetection.fileExists(toolsDir)) {
+    return [];
+  }
+
+  const availableTools: string[] = [];
+  const binDir = join(toolsDir, "bin");
+  if (!await systemDetection.fileExists(binDir)) {
+    return [];
+  }
+
+  for (const toolName of Object.keys(ANDROID_TOOLS)) {
+    const toolPath = join(binDir, toolName);
+    const toolPathWithExt = join(binDir, `${toolName}.bat`);
+    if (await systemDetection.fileExists(toolPath) || await systemDetection.fileExists(toolPathWithExt)) {
+      availableTools.push(toolName);
+    }
+  }
+
+  return availableTools;
+}
+
 /**
  * Detect Android command line tools installation from Homebrew (macOS only)
  */
 export async function detectHomebrewAndroidTools(systemDetection = createDefaultSystemDetection()): Promise<AndroidToolsLocation | null> {
-  const homebrewPath = getHomebrewAndroidToolsPath(systemDetection);
+  const homebrewPath = await getHomebrewAndroidToolsPathAsync(systemDetection);
   if (!homebrewPath) {
     return null;
   }
 
-  const availableTools = getAvailableToolsInDirectory(homebrewPath, systemDetection);
+  const availableTools = await getAvailableToolsInDirectoryAsync(homebrewPath, systemDetection);
   if (availableTools.length === 0) {
     return null;
   }
@@ -314,10 +378,10 @@ export async function detectAndroidSdkTools(systemDetection = createDefaultSyste
   logger.debug("Looking for Android SDK tools");
 
   // Check environment variables
-  const sdkPath = getAndroidSdkFromEnvironment(systemDetection);
+  const sdkPath = await getAndroidSdkFromEnvironmentAsync(systemDetection);
   if (sdkPath) {
     const cmdlineToolsPath = join(sdkPath, "cmdline-tools", "latest");
-    const availableTools = getAvailableToolsInDirectory(cmdlineToolsPath, systemDetection);
+    const availableTools = await getAvailableToolsInDirectoryAsync(cmdlineToolsPath, systemDetection);
 
     if (availableTools.length > 0) {
       const source = systemDetection.getEnvVar("ANDROID_HOME") ? "android_home" : "android_sdk_root";
@@ -342,7 +406,7 @@ export async function detectAndroidSdkTools(systemDetection = createDefaultSyste
     }
 
     const cmdlineToolsPath = join(sdkPath, "cmdline-tools", "latest");
-    const availableTools = getAvailableToolsInDirectory(cmdlineToolsPath, systemDetection);
+    const availableTools = await getAvailableToolsInDirectoryAsync(cmdlineToolsPath, systemDetection);
 
     if (availableTools.length > 0) {
       locations.push({
@@ -420,6 +484,7 @@ export async function detectAndroidCommandLineTools(systemDetection = createDefa
       logger.debug(`Found Homebrew Android tools at: ${homebrewLocation.path}`);
     }
   } catch (error) {
+    rethrowAndroidToolsDetectionControlError(error);
     logger.warn(`Error detecting Homebrew Android tools: ${(error as Error).message}`);
   }
 
@@ -431,6 +496,7 @@ export async function detectAndroidCommandLineTools(systemDetection = createDefa
       logger.debug(`Found Android SDK tools at: ${location.path} (source: ${location.source})`);
     }
   } catch (error) {
+    rethrowAndroidToolsDetectionControlError(error);
     logger.warn(`Error detecting Android SDK tools: ${(error as Error).message}`);
   }
 
@@ -442,9 +508,7 @@ export async function detectAndroidCommandLineTools(systemDetection = createDefa
       logger.debug(`Found Android tools in PATH: ${pathLocation.available_tools.join(", ")}`);
     }
   } catch (error) {
-    if (isAndroidToolsDetectionControlError(error)) {
-      throw error;
-    }
+    rethrowAndroidToolsDetectionControlError(error);
     logger.warn(`Error detecting Android tools in PATH: ${(error as Error).message}`);
   }
 

--- a/src/utils/system/SystemDetection.ts
+++ b/src/utils/system/SystemDetection.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "fs";
+import { access } from "fs/promises";
 import { homedir, platform } from "os";
 import { execFile } from "child_process";
 import { promisify } from "util";
@@ -58,7 +59,10 @@ export class DefaultSystemDetection implements SystemDetection {
   }
 
   async fileExists(path: string): Promise<boolean> {
-    return existsSync(path);
+    return access(path).then(
+      () => true,
+      () => false
+    );
   }
 
   async executeCommand(file: string, args: string[] = []): Promise<{ stdout: string; stderr: string }> {

--- a/test/utils/android-cmdline-tools/AdbClientPathDiscoveryTimeout.test.ts
+++ b/test/utils/android-cmdline-tools/AdbClientPathDiscoveryTimeout.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  AdbClient,
+  AdbCommandTimeoutError,
+  resetAdbClientCaches,
+} from "../../../src/utils/android-cmdline-tools/AdbClient";
+import { clearDetectionCache } from "../../../src/utils/android-cmdline-tools/detection";
+import { defaultRetryExecutor } from "../../../src/utils/retry/RetryExecutor";
+import { FakeTimer } from "../../fakes/FakeTimer";
+import type { ExecResult } from "../../../src/models";
+
+const ANDROID_ENV_NAMES = ["ANDROID_HOME", "ANDROID_SDK_ROOT", "ANDROID_SDK_HOME"] as const;
+const savedAndroidEnvironment = new Map(
+  ANDROID_ENV_NAMES.map(name => [name, process.env[name]])
+);
+
+type AdbClientInternals = {
+  isTestMode: boolean;
+  execAsync: (file: string, args: string[], maxBuffer?: number) => Promise<ExecResult>;
+  execWithSignal: (
+    file: string,
+    args: string[],
+    maxBuffer?: number,
+    timeoutMs?: number,
+    signal?: AbortSignal
+  ) => Promise<ExecResult>;
+};
+
+function ok(stdout = ""): ExecResult {
+  return {
+    stdout,
+    stderr: "",
+    toString: () => stdout,
+    trim: () => stdout.trim(),
+    includes: (value: string) => stdout.includes(value),
+  };
+}
+
+describe("AdbClient ADB-path discovery deadline", () => {
+  beforeEach(() => {
+    resetAdbClientCaches();
+    clearDetectionCache();
+    for (const name of ANDROID_ENV_NAMES) {
+      delete process.env[name];
+    }
+  });
+
+  afterEach(() => {
+    resetAdbClientCaches();
+    clearDetectionCache();
+    for (const name of ANDROID_ENV_NAMES) {
+      const value = savedAndroidEnvironment.get(name);
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+  });
+
+  test("fails the request budget when a cold-cache path probe stalls", async () => {
+    const timer = new FakeTimer();
+    const client = new AdbClient(null, null, null, defaultRetryExecutor, timer);
+    const internals = client as unknown as AdbClientInternals;
+    internals.isTestMode = false;
+    internals.execAsync = async () => new Promise<ExecResult>(() => {});
+    internals.execWithSignal = async (_file, _args, _maxBuffer, timeoutMs) =>
+      new Promise<ExecResult>((_resolve, reject) => {
+        timer.setTimeout(
+          () => reject(new AdbCommandTimeoutError(`Command timed out after ${timeoutMs}ms`)),
+          timeoutMs
+        );
+      });
+
+    let settled: unknown = undefined;
+    void client.execute(["shell", "true"], { timeoutMs: 20, noRetry: true })
+      .then(() => { settled = new Error("expected discovery to time out"); })
+      .catch(error => { settled = error; });
+
+    await Promise.resolve();
+    timer.advanceTime(20);
+    await new Promise<void>(resolve => setImmediate(resolve));
+
+    expect(settled).toBeInstanceOf(AdbCommandTimeoutError);
+  });
+
+  test("passes only the remaining request budget to the command after discovery", async () => {
+    const timer = new FakeTimer();
+    const client = new AdbClient(null, null, null, defaultRetryExecutor, timer);
+    const internals = client as unknown as AdbClientInternals;
+    internals.isTestMode = false;
+    internals.execAsync = async (file, args) => {
+      expect([file, ...args]).toEqual(["which", "adb"]);
+      timer.advanceTime(7);
+      return ok("/sdk/platform-tools/adb\n");
+    };
+
+    const commandTimeouts: number[] = [];
+    internals.execWithSignal = async (file, args, _maxBuffer, timeoutMs) => {
+      if (file === "which" && args[0] === "adb") {
+        timer.advanceTime(7);
+        return ok("/sdk/platform-tools/adb\n");
+      }
+      if (file.endsWith("/adb") && args[0] === "shell") {
+        commandTimeouts.push(timeoutMs ?? -1);
+      }
+      return ok();
+    };
+
+    await client.execute(["shell", "true"], { timeoutMs: 20, noRetry: true });
+
+    expect(commandTimeouts).toEqual([13]);
+  });
+
+  test("propagates a fallback-detection timeout and does not cache an incomplete resolution", async () => {
+    const timer = new FakeTimer();
+    const client = new AdbClient(null, null, null, defaultRetryExecutor, timer);
+    const internals = client as unknown as AdbClientInternals;
+    internals.isTestMode = false;
+    let recover = false;
+    let adbPathProbeCalls = 0;
+    const executedCommands: string[] = [];
+    internals.execWithSignal = async (file, args, _maxBuffer, timeoutMs) => {
+      const command = [file, ...args].join(" ");
+      executedCommands.push(command);
+      if (command === "which adb") {
+        adbPathProbeCalls += 1;
+        return recover ? ok("/sdk/platform-tools/adb\n") : ok("");
+      }
+      if (file.endsWith("/adb")) {
+        return ok();
+      }
+      return new Promise<ExecResult>((_resolve, reject) => {
+        timer.setTimeout(
+          () => reject(new AdbCommandTimeoutError(`Command timed out after ${timeoutMs}ms`)),
+          timeoutMs
+        );
+      });
+    };
+
+    let firstFailure: unknown = undefined;
+    void client.execute(["shell", "true"], { timeoutMs: 20, noRetry: true })
+      .catch(error => { firstFailure = error; });
+    await Promise.resolve();
+    timer.advanceTime(20);
+    await new Promise<void>(resolve => setImmediate(resolve));
+
+    expect(firstFailure).toBeInstanceOf(AdbCommandTimeoutError);
+    expect(executedCommands).not.toContain("adb shell true");
+
+    recover = true;
+    await client.execute(["shell", "true"], { timeoutMs: 20, noRetry: true });
+
+    expect(adbPathProbeCalls).toBe(2);
+  });
+});

--- a/test/utils/android-cmdline-tools/AdbClientPathDiscoveryTimeout.test.ts
+++ b/test/utils/android-cmdline-tools/AdbClientPathDiscoveryTimeout.test.ts
@@ -8,6 +8,7 @@ import { clearDetectionCache } from "../../../src/utils/android-cmdline-tools/de
 import { defaultRetryExecutor } from "../../../src/utils/retry/RetryExecutor";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import type { ExecResult } from "../../../src/models";
+import type { SystemDetection } from "../../../src/utils/system/SystemDetection";
 
 const ANDROID_ENV_NAMES = ["ANDROID_HOME", "ANDROID_SDK_ROOT", "ANDROID_SDK_HOME"] as const;
 const savedAndroidEnvironment = new Map(
@@ -229,5 +230,54 @@ describe("AdbClient ADB-path discovery deadline", () => {
 
     expect(adbPathProbeCalls).toBe(2);
     expect(commandFiles).toEqual(["/sdk/platform-tools/adb"]);
+  });
+
+  test("times out instead of blocking on a stalled fallback filesystem probe", async () => {
+    const timer = new FakeTimer();
+    let fileProbeStarted = false;
+    const commandFiles: string[] = [];
+    const stalledSystemDetection: SystemDetection = {
+      getCurrentPlatform: () => "darwin",
+      getHomeDir: () => "/Users/test",
+      getEnvVar: () => undefined,
+      fileExistsSync: () => false,
+      fileExists: async () => {
+        fileProbeStarted = true;
+        return new Promise<boolean>(() => {});
+      },
+      executeCommand: async () => {
+        throw new Error("command not found");
+      },
+    };
+    const client = new AdbClient(
+      null,
+      null,
+      null,
+      defaultRetryExecutor,
+      timer,
+      () => stalledSystemDetection
+    );
+    const internals = client as unknown as AdbClientInternals;
+    internals.isTestMode = false;
+    internals.execWithSignal = async (file, args) => {
+      if (file === "which" && args[0] === "adb") {
+        return ok("");
+      }
+      if (args[0] === "shell") {
+        commandFiles.push(file);
+      }
+      return ok();
+    };
+
+    let settled: unknown = undefined;
+    void client.execute(["shell", "true"], { timeoutMs: 20, noRetry: true })
+      .catch(error => { settled = error; });
+    await new Promise<void>(resolve => setImmediate(resolve));
+    expect(fileProbeStarted).toBe(true);
+    timer.advanceTime(20);
+    await new Promise<void>(resolve => setImmediate(resolve));
+
+    expect(settled).toBeInstanceOf(AdbCommandTimeoutError);
+    expect(commandFiles).toEqual([]);
   });
 });

--- a/test/utils/android-cmdline-tools/AdbClientPathDiscoveryTimeout.test.ts
+++ b/test/utils/android-cmdline-tools/AdbClientPathDiscoveryTimeout.test.ts
@@ -192,4 +192,42 @@ describe("AdbClient ADB-path discovery deadline", () => {
     expect(commandFiles).toEqual(["/sdk/platform-tools/adb"]);
     expect(versionProbeCalls).toBe(2);
   });
+
+  test("does not cache the fallback path when a later tool-discovery probe is aborted", async () => {
+    const client = new AdbClient(null, null, null, defaultRetryExecutor, new FakeTimer());
+    const internals = client as unknown as AdbClientInternals;
+    internals.isTestMode = false;
+    let adbPathProbeCalls = 0;
+    const commandFiles: string[] = [];
+    internals.execWithSignal = async (file, args, _maxBuffer, _timeoutMs, signal) => {
+      if (signal?.aborted) {
+        throw new Error("probe aborted");
+      }
+      if (file === "which" && args[0] === "adb") {
+        adbPathProbeCalls += 1;
+        return adbPathProbeCalls === 1 ? ok("") : ok("/sdk/platform-tools/adb\n");
+      }
+      if (file === "which") {
+        return new Promise<ExecResult>((_resolve, reject) => {
+          signal?.addEventListener("abort", () => reject(new Error("probe aborted")), { once: true });
+        });
+      }
+      if (args[0] === "shell") {
+        commandFiles.push(file);
+      }
+      return ok();
+    };
+
+    const controller = new AbortController();
+    const aborted = client.execute(["shell", "true"], { noRetry: true, signal: controller.signal });
+    await Promise.resolve();
+    controller.abort();
+
+    await expect(aborted).rejects.toThrow("Operation cancelled");
+
+    await client.execute(["shell", "true"], { noRetry: true });
+
+    expect(adbPathProbeCalls).toBe(2);
+    expect(commandFiles).toEqual(["/sdk/platform-tools/adb"]);
+  });
 });

--- a/test/utils/android-cmdline-tools/AdbClientPathDiscoveryTimeout.test.ts
+++ b/test/utils/android-cmdline-tools/AdbClientPathDiscoveryTimeout.test.ts
@@ -153,4 +153,43 @@ describe("AdbClient ADB-path discovery deadline", () => {
 
     expect(adbPathProbeCalls).toBe(2);
   });
+
+  test("does not cache the fallback path when an environment probe is aborted", async () => {
+    process.env.ANDROID_HOME = "/sdk";
+    const client = new AdbClient(null, null, null, defaultRetryExecutor, new FakeTimer());
+    const internals = client as unknown as AdbClientInternals;
+    internals.isTestMode = false;
+    let versionProbeCalls = 0;
+    const commandFiles: string[] = [];
+    internals.execWithSignal = async (file, args, _maxBuffer, _timeoutMs, signal) => {
+      if (signal?.aborted) {
+        throw new Error("probe aborted");
+      }
+      if (file === "/sdk/platform-tools/adb" && args[0] === "version") {
+        versionProbeCalls += 1;
+        if (versionProbeCalls === 1) {
+          return new Promise<ExecResult>((_resolve, reject) => {
+            signal?.addEventListener("abort", () => reject(new Error("probe aborted")), { once: true });
+          });
+        }
+        return ok();
+      }
+      if (args[0] === "shell") {
+        commandFiles.push(file);
+      }
+      return ok();
+    };
+
+    const controller = new AbortController();
+    const aborted = client.execute(["shell", "true"], { noRetry: true, signal: controller.signal });
+    await Promise.resolve();
+    controller.abort();
+
+    await expect(aborted).rejects.toThrow("Operation cancelled");
+
+    await client.execute(["shell", "true"], { noRetry: true });
+
+    expect(commandFiles).toEqual(["/sdk/platform-tools/adb"]);
+    expect(versionProbeCalls).toBe(2);
+  });
 });


### PR DESCRIPTION
## Summary

- Charge ADB executable-path discovery and command-line-tools fallback probes against each caller's command deadline.
- Pass only the remaining deadline to the resolved ADB command and subsequent retries.
- Keep path-discovery timeouts distinct from ordinary "not found" detection failures, so incomplete discovery is never cached.

## Root cause and impact

`AdbClient.executeArgsImpl` resolved the ADB executable before applying `timeoutMs` to the actual command. A stalled `adb version`, `which adb`, or fallback tool probe could therefore outlive an input request and hold the daemon's per-device queue. The shared resolver now uses the same deadline as the command.

## Validation

- `bun test test/features/action/InputText.test.ts test/utils/android-cmdline-tools/AdbClientPathDiscoveryTimeout.test.ts test/utils/android-cmdline-tools/detection.test.ts`
- `bun run turbo:validate`
- `bun run typecheck`
- `git diff --check`

Closes [#4533](https://github.com/kaeawc/auto-mobile/issues/4533)
