### PR TITLE
Add device frame-context input validation

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -84,6 +84,9 @@ import dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.security.MessageDigest
+import java.util.Collections
+import java.util.IdentityHashMap
+import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.coroutines.resume
 import kotlin.math.max
@@ -350,6 +353,15 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
    * Changes immediately on a native UI event; capture and input share this device-owned context.
    */
   private val frameContext = AtomicLong(0)
+  /** Fresh for every service process, preventing a restarted runner from reusing an old token. */
+  private val frameContextEpoch = UUID.randomUUID().toString()
+
+  private fun currentFrameContext(): String = "$frameContextEpoch:${frameContext.get()}"
+
+  // A hierarchy has object identity for its short trip from extraction to broadcast. Retaining the
+  // extraction-time token lets broadcast fail closed if an accessibility event intervenes.
+  private val extractedHierarchyFrameContexts =
+    Collections.synchronizedMap(IdentityHashMap<ViewHierarchy, String>())
 
   @Volatile private var isRecording: Boolean = false
 
@@ -975,6 +987,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
                 if (broadcastThrottler.shouldBroadcast()) {
                   broadcastHierarchyUpdate(result.hierarchy)
                 } else {
+                  extractedHierarchyFrameContexts.remove(result.hierarchy)
                   Log.d(
                     TAG,
                     "Throttled event-driven broadcast (${broadcastThrottler.timeSinceLastBroadcastMs()}ms since last)",
@@ -989,6 +1002,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
                 if (broadcastThrottler.shouldBroadcast()) {
                   broadcastHierarchyUpdate(result.hierarchy)
                 } else {
+                  extractedHierarchyFrameContexts.remove(result.hierarchy)
                   Log.d(
                     TAG,
                     "Throttled event-driven broadcast (${broadcastThrottler.timeSinceLastBroadcastMs()}ms since last)",
@@ -1245,7 +1259,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     expected: String?,
     action: String,
   ): Boolean {
-    if (expected == null || expected == frameContext.get().toString()) return false
+    if (expected == null || expected == currentFrameContext()) return false
     val error = "Stale frame context for input/$action; observe a fresh frame before retrying"
     launchRequestScope(requestId) {
       when (action) {
@@ -2093,6 +2107,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
    * all visible windows to capture popups, toolbars, etc.
    */
   private fun extractHierarchyDirect(disableAllFiltering: Boolean = false): ViewHierarchy? {
+    val contextAtExtractionStart = currentFrameContext()
     // Get all windows to capture popups, toolbars, and other floating windows
     val allWindows = windows
     val rootNode = rootInActiveWindow
@@ -2154,7 +2169,11 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         deviceModel = Build.MODEL,
         isEmulator = getIsEmulator(),
       )
-    return withScaleMetadata(enriched, screenDimensions)
+    val hierarchyWithScaleMetadata = withScaleMetadata(enriched, screenDimensions)
+    if (hierarchyWithScaleMetadata != null && contextAtExtractionStart == currentFrameContext()) {
+      extractedHierarchyFrameContexts[hierarchyWithScaleMetadata] = contextAtExtractionStart
+    }
+    return hierarchyWithScaleMetadata
   }
 
   /**
@@ -2268,6 +2287,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     textFilter: String? = null,
     disableAllFiltering: Boolean = false,
   ): ViewHierarchy? {
+    val contextAtExtractionStart = currentFrameContext()
     val allWindows = windows
     val rootNode = rootInActiveWindow
     val screenDimensions = getScreenDimensions()
@@ -2303,7 +2323,11 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       }
     // The ADB EXTRACT_HIERARCHY route must carry the #4548 scale metadata too (this route does not
     // add the other device metadata, but the daemon retains scale metadata off any route).
-    return withScaleMetadata(hierarchy, screenDimensions)
+    val hierarchyWithScaleMetadata = withScaleMetadata(hierarchy, screenDimensions)
+    if (hierarchyWithScaleMetadata != null && contextAtExtractionStart == currentFrameContext()) {
+      extractedHierarchyFrameContexts[hierarchyWithScaleMetadata] = contextAtExtractionStart
+    }
+    return hierarchyWithScaleMetadata
   }
 
   private fun sendResult(success: Boolean, data: String? = null, error: String? = null) {
@@ -2351,13 +2375,13 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
    *   ordering.
    */
   private suspend fun broadcastHierarchyUpdate(hierarchy: ViewHierarchy, sync: Boolean = false) {
+    val contextAtExtraction = extractedHierarchyFrameContexts.remove(hierarchy)
     if (!::webSocketServer.isInitialized || !webSocketServer.isRunning()) {
       Log.d(TAG, "WebSocket server not running, skipping broadcast")
       return
     }
 
     try {
-      val contextAtBroadcastStart = frameContext.get()
       val jsonString =
         perfProvider.track("serializeHierarchy") { jsonCompact.encodeToString(hierarchy) }
 
@@ -2374,8 +2398,8 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           append(
             """{"type":"hierarchy_update","timestamp":${System.currentTimeMillis()},"data":$jsonString"""
           )
-          if (contextAtBroadcastStart == frameContext.get()) {
-            append(""","frameContext":"$contextAtBroadcastStart"""")
+          if (contextAtExtraction != null && contextAtExtraction == currentFrameContext()) {
+            append(""","frameContext":"$contextAtExtraction"""")
           }
           if (perfTiming != null) {
             append(""","perfTiming":$perfTiming""")
@@ -5232,9 +5256,9 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     // otherwise be logged-and-swallowed here, emitting neither `screenshot` nor `screenshot_error`
     // and hanging the awaiting client until timeout (issue #3023).
     asyncActionRunner.launch(requestId, "screenshot") {
-      val contextBeforeCapture = frameContext.get()
+      val contextBeforeCapture = currentFrameContext()
       val screenshot = takeScreenshotAsync()
-      val stableContext = contextBeforeCapture.takeIf { it == frameContext.get() }
+      val stableContext = contextBeforeCapture.takeIf { it == currentFrameContext() }
       if (screenshot != null) {
         webSocketServer.broadcast(
           ProtocolScreenshotResult(

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -1574,7 +1574,10 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
             recordInteractionEvent(event, "inputText")
           }
         }
-        AccessibilityEvent.TYPE_VIEW_SCROLLED -> recordDebouncedScroll(event)
+        AccessibilityEvent.TYPE_VIEW_SCROLLED -> {
+          frameContext.incrementAndGet()
+          recordDebouncedScroll(event)
+        }
       }
 
       // Delegate to the smart debouncer for content/window changes
@@ -2354,6 +2357,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     }
 
     try {
+      val contextAtBroadcastStart = frameContext.get()
       val jsonString =
         perfProvider.track("serializeHierarchy") { jsonCompact.encodeToString(hierarchy) }
 
@@ -2370,7 +2374,9 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           append(
             """{"type":"hierarchy_update","timestamp":${System.currentTimeMillis()},"data":$jsonString"""
           )
-          append(""",\"frameContext\":\"${frameContext.get()}\"""")
+          if (contextAtBroadcastStart == frameContext.get()) {
+            append(""","frameContext":"$contextAtBroadcastStart"""")
+          }
           if (perfTiming != null) {
             append(""","perfTiming":$perfTiming""")
           }

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -26,7 +26,6 @@ import android.view.Display
 import android.view.WindowManager
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
-import java.util.concurrent.atomic.AtomicLong
 import dev.jasonpearson.automobile.ctrlproxy.models.ElementBounds
 import dev.jasonpearson.automobile.ctrlproxy.models.HighlightShape
 import dev.jasonpearson.automobile.ctrlproxy.models.InteractionElement
@@ -85,6 +84,7 @@ import dev.jasonpearson.automobile.sdk.network.NetworkMockRuleStore
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.security.MessageDigest
+import java.util.concurrent.atomic.AtomicLong
 import kotlin.coroutines.resume
 import kotlin.math.max
 import kotlinx.coroutines.CancellationException
@@ -346,7 +346,9 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     ComponentName(this, AutoMobileDeviceAdminReceiver::class.java)
   }
   @Volatile private var lastWindowClassName: String? = null
-  /** Changes immediately on a native UI event; capture and input share this device-owned context. */
+  /**
+   * Changes immediately on a native UI event; capture and input share this device-owned context.
+   */
   private val frameContext = AtomicLong(0)
 
   @Volatile private var isRecording: Boolean = false
@@ -1173,7 +1175,13 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
   ) = performSwipe(requestId, x1, y1, x2, y2, duration)
 
   override fun requestSwipe(
-    requestId: String?, x1: Double, y1: Double, x2: Double, y2: Double, duration: Long, frameContext: String?,
+    requestId: String?,
+    x1: Double,
+    y1: Double,
+    x2: Double,
+    y2: Double,
+    duration: Long,
+    frameContext: String?,
   ) {
     if (rejectStaleFrameContext(requestId, frameContext, "swipe")) return
     performSwipe(requestId, x1, y1, x2, y2, duration)
@@ -1182,7 +1190,13 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
   override fun requestTapCoordinates(requestId: String?, x: Double, y: Double, duration: Long) =
     performTapCoordinates(requestId, x, y, duration)
 
-  override fun requestTapCoordinates(requestId: String?, x: Double, y: Double, duration: Long, frameContext: String?) {
+  override fun requestTapCoordinates(
+    requestId: String?,
+    x: Double,
+    y: Double,
+    duration: Long,
+    frameContext: String?,
+  ) {
     if (rejectStaleFrameContext(requestId, frameContext, "tap")) return
     performTapCoordinates(requestId, x, y, duration)
   }
@@ -1209,15 +1223,28 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
   ) = performDrag(requestId, x1, y1, x2, y2, pressDurationMs, dragDurationMs, holdDurationMs)
 
   override fun requestDrag(
-    requestId: String?, x1: Double, y1: Double, x2: Double, y2: Double, pressDurationMs: Long,
-    dragDurationMs: Long, holdDurationMs: Long, frameContext: String?,
+    requestId: String?,
+    x1: Double,
+    y1: Double,
+    x2: Double,
+    y2: Double,
+    pressDurationMs: Long,
+    dragDurationMs: Long,
+    holdDurationMs: Long,
+    frameContext: String?,
   ) {
     if (rejectStaleFrameContext(requestId, frameContext, "drag")) return
     performDrag(requestId, x1, y1, x2, y2, pressDurationMs, dragDurationMs, holdDurationMs)
   }
 
-  /** Rejects an input that was mapped through a screen state the service has since observed change. */
-  private fun rejectStaleFrameContext(requestId: String?, expected: String?, action: String): Boolean {
+  /**
+   * Rejects an input that was mapped through a screen state the service has since observed change.
+   */
+  private fun rejectStaleFrameContext(
+    requestId: String?,
+    expected: String?,
+    action: String,
+  ): Boolean {
     if (expected == null || expected == frameContext.get().toString()) return false
     val error = "Stale frame context for input/$action; observe a fresh frame before retrying"
     launchRequestScope(requestId) {

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -26,6 +26,7 @@ import android.view.Display
 import android.view.WindowManager
 import android.view.accessibility.AccessibilityEvent
 import android.view.accessibility.AccessibilityNodeInfo
+import java.util.concurrent.atomic.AtomicLong
 import dev.jasonpearson.automobile.ctrlproxy.models.ElementBounds
 import dev.jasonpearson.automobile.ctrlproxy.models.HighlightShape
 import dev.jasonpearson.automobile.ctrlproxy.models.InteractionElement
@@ -345,6 +346,8 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     ComponentName(this, AutoMobileDeviceAdminReceiver::class.java)
   }
   @Volatile private var lastWindowClassName: String? = null
+  /** Changes immediately on a native UI event; capture and input share this device-owned context. */
+  private val frameContext = AtomicLong(0)
 
   @Volatile private var isRecording: Boolean = false
 
@@ -1169,8 +1172,20 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     duration: Long,
   ) = performSwipe(requestId, x1, y1, x2, y2, duration)
 
+  override fun requestSwipe(
+    requestId: String?, x1: Double, y1: Double, x2: Double, y2: Double, duration: Long, frameContext: String?,
+  ) {
+    if (rejectStaleFrameContext(requestId, frameContext, "swipe")) return
+    performSwipe(requestId, x1, y1, x2, y2, duration)
+  }
+
   override fun requestTapCoordinates(requestId: String?, x: Double, y: Double, duration: Long) =
     performTapCoordinates(requestId, x, y, duration)
+
+  override fun requestTapCoordinates(requestId: String?, x: Double, y: Double, duration: Long, frameContext: String?) {
+    if (rejectStaleFrameContext(requestId, frameContext, "tap")) return
+    performTapCoordinates(requestId, x, y, duration)
+  }
 
   override fun requestTwoFingerSwipe(
     requestId: String?,
@@ -1192,6 +1207,28 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     dragDurationMs: Long,
     holdDurationMs: Long,
   ) = performDrag(requestId, x1, y1, x2, y2, pressDurationMs, dragDurationMs, holdDurationMs)
+
+  override fun requestDrag(
+    requestId: String?, x1: Double, y1: Double, x2: Double, y2: Double, pressDurationMs: Long,
+    dragDurationMs: Long, holdDurationMs: Long, frameContext: String?,
+  ) {
+    if (rejectStaleFrameContext(requestId, frameContext, "drag")) return
+    performDrag(requestId, x1, y1, x2, y2, pressDurationMs, dragDurationMs, holdDurationMs)
+  }
+
+  /** Rejects an input that was mapped through a screen state the service has since observed change. */
+  private fun rejectStaleFrameContext(requestId: String?, expected: String?, action: String): Boolean {
+    if (expected == null || expected == frameContext.get().toString()) return false
+    val error = "Stale frame context for input/$action; observe a fresh frame before retrying"
+    launchRequestScope(requestId) {
+      when (action) {
+        "tap" -> broadcastTapCoordinatesResult(requestId, false, error, 0)
+        "swipe" -> broadcastSwipeResult(requestId, false, error, 0, null)
+        "drag" -> broadcastDragResult(requestId, false, error, 0, null)
+      }
+    }
+    return true
+  }
 
   override fun requestPinch(
     requestId: String?,
@@ -1519,6 +1556,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         event.eventType == AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED ||
           event.eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED
       ) {
+        frameContext.incrementAndGet()
         if (::hierarchyDebouncer.isInitialized) {
           hierarchyDebouncer.onAccessibilityEvent()
         }
@@ -2305,6 +2343,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           append(
             """{"type":"hierarchy_update","timestamp":${System.currentTimeMillis()},"data":$jsonString"""
           )
+          append(""",\"frameContext\":\"${frameContext.get()}\"""")
           if (perfTiming != null) {
             append(""","perfTiming":$perfTiming""")
           }
@@ -5160,7 +5199,9 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     // otherwise be logged-and-swallowed here, emitting neither `screenshot` nor `screenshot_error`
     // and hanging the awaiting client until timeout (issue #3023).
     asyncActionRunner.launch(requestId, "screenshot") {
+      val contextBeforeCapture = frameContext.get()
       val screenshot = takeScreenshotAsync()
+      val stableContext = contextBeforeCapture.takeIf { it == frameContext.get() }
       if (screenshot != null) {
         webSocketServer.broadcast(
           ProtocolScreenshotResult(
@@ -5172,6 +5213,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
             screenshotEncodeDurationMs = screenshot.encodeDurationMs,
             screenshotByteLength = screenshot.byteLength,
             screenshotBase64Length = screenshot.base64Length,
+            frameContext = stableContext?.toString(),
           )
         )
         Log.d(TAG, "Broadcasted screenshot to ${webSocketServer.getConnectionCount()} clients")

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -1598,7 +1598,8 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       // The debouncer uses structural hash comparison to detect animation vs real changes
       if (
         event.eventType == AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED ||
-          event.eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED
+          event.eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED ||
+          event.eventType == AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED
       ) {
         frameContext.incrementAndGet()
         if (::hierarchyDebouncer.isInitialized) {

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyActions.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyActions.kt
@@ -37,13 +37,24 @@ interface CtrlProxyActions {
   )
 
   fun requestSwipe(
-    requestId: String?, x1: Double, y1: Double, x2: Double, y2: Double, duration: Long, frameContext: String?,
+    requestId: String?,
+    x1: Double,
+    y1: Double,
+    x2: Double,
+    y2: Double,
+    duration: Long,
+    frameContext: String?,
   ) = requestSwipe(requestId, x1, y1, x2, y2, duration)
 
   fun requestTapCoordinates(requestId: String?, x: Double, y: Double, duration: Long)
 
-  fun requestTapCoordinates(requestId: String?, x: Double, y: Double, duration: Long, frameContext: String?) =
-    requestTapCoordinates(requestId, x, y, duration)
+  fun requestTapCoordinates(
+    requestId: String?,
+    x: Double,
+    y: Double,
+    duration: Long,
+    frameContext: String?,
+  ) = requestTapCoordinates(requestId, x, y, duration)
 
   fun requestTwoFingerSwipe(
     requestId: String?,
@@ -67,8 +78,15 @@ interface CtrlProxyActions {
   )
 
   fun requestDrag(
-    requestId: String?, x1: Double, y1: Double, x2: Double, y2: Double, pressDurationMs: Long,
-    dragDurationMs: Long, holdDurationMs: Long, frameContext: String?,
+    requestId: String?,
+    x1: Double,
+    y1: Double,
+    x2: Double,
+    y2: Double,
+    pressDurationMs: Long,
+    dragDurationMs: Long,
+    holdDurationMs: Long,
+    frameContext: String?,
   ) = requestDrag(requestId, x1, y1, x2, y2, pressDurationMs, dragDurationMs, holdDurationMs)
 
   fun requestPinch(

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyActions.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyActions.kt
@@ -36,7 +36,14 @@ interface CtrlProxyActions {
     duration: Long,
   )
 
+  fun requestSwipe(
+    requestId: String?, x1: Double, y1: Double, x2: Double, y2: Double, duration: Long, frameContext: String?,
+  ) = requestSwipe(requestId, x1, y1, x2, y2, duration)
+
   fun requestTapCoordinates(requestId: String?, x: Double, y: Double, duration: Long)
+
+  fun requestTapCoordinates(requestId: String?, x: Double, y: Double, duration: Long, frameContext: String?) =
+    requestTapCoordinates(requestId, x, y, duration)
 
   fun requestTwoFingerSwipe(
     requestId: String?,
@@ -58,6 +65,11 @@ interface CtrlProxyActions {
     dragDurationMs: Long,
     holdDurationMs: Long,
   )
+
+  fun requestDrag(
+    requestId: String?, x1: Double, y1: Double, x2: Double, y2: Double, pressDurationMs: Long,
+    dragDurationMs: Long, holdDurationMs: Long, frameContext: String?,
+  ) = requestDrag(requestId, x1, y1, x2, y2, pressDurationMs, dragDurationMs, holdDurationMs)
 
   fun requestPinch(
     requestId: String?,

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandler.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandler.kt
@@ -109,6 +109,7 @@ class CtrlProxyMessageHandler(
           request.x2,
           request.y2,
           request.duration,
+          request.frameContext,
         )
       }
       is RequestTapCoordinates -> {
@@ -121,7 +122,7 @@ class CtrlProxyMessageHandler(
             error = nonFiniteError(field, value),
           )
         }
-        actions.requestTapCoordinates(request.requestId, request.x, request.y, request.duration)
+        actions.requestTapCoordinates(request.requestId, request.x, request.y, request.duration, request.frameContext)
       }
       is RequestTwoFingerSwipe -> {
         // Two-finger swipe shares the swipe_result response type. `offset` is an Int (a pixel gap),
@@ -170,6 +171,7 @@ class CtrlProxyMessageHandler(
           request.resolvedPressDurationMs,
           request.resolvedDragDurationMs,
           request.holdDurationMs,
+          request.frameContext,
         )
       }
       is RequestPinch -> {

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandler.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandler.kt
@@ -122,7 +122,13 @@ class CtrlProxyMessageHandler(
             error = nonFiniteError(field, value),
           )
         }
-        actions.requestTapCoordinates(request.requestId, request.x, request.y, request.duration, request.frameContext)
+        actions.requestTapCoordinates(
+          request.requestId,
+          request.x,
+          request.y,
+          request.duration,
+          request.frameContext,
+        )
       }
       is RequestTwoFingerSwipe -> {
         // Two-finger swipe shares the swipe_result response type. `offset` is an Int (a pixel gap),

--- a/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequest.kt
+++ b/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequest.kt
@@ -65,6 +65,7 @@ data class RequestTapCoordinates(
   val x: Double,
   val y: Double,
   val duration: Long = 10L,
+  val frameContext: String? = null,
 ) : WebSocketRequest()
 
 @Serializable
@@ -76,6 +77,7 @@ data class RequestSwipe(
   val x2: Double,
   val y2: Double,
   val duration: Long = 300L,
+  val frameContext: String? = null,
 ) : WebSocketRequest()
 
 @Serializable
@@ -101,6 +103,7 @@ data class RequestDrag(
   val pressDurationMs: Long = 600L,
   val dragDurationMs: Long = 300L,
   val holdDurationMs: Long = 100L,
+  val frameContext: String? = null,
   // Legacy field names for backward compatibility
   val holdTime: Long? = null,
   val duration: Long? = null,

--- a/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketResponse.kt
+++ b/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketResponse.kt
@@ -285,6 +285,7 @@ data class ScreenshotResult(
   val format: String = "jpeg",
   val width: Int? = null,
   val height: Int? = null,
+  val frameContext: String? = null,
   val screenshotCaptureDurationMs: Long? = null,
   val screenshotEncodeDurationMs: Long? = null,
   val screenshotByteLength: Int? = null,

--- a/docs/design-docs/mcp/daemon/client-frame-snapshot.md
+++ b/docs/design-docs/mcp/daemon/client-frame-snapshot.md
@@ -21,8 +21,8 @@ several sources that update independently:
 
 | Source | Carries | Updates |
 | --- | --- | --- |
-| observation stream `screenshot_update` | pixels, reported screen size, `captureSequence`, `coordinateSpace` | continuously while subscribed |
-| observation stream `hierarchy_update` | element tree with `bounds`, `captureSequence`, `coordinateSpace` | continuously, usually debounced client-side |
+| observation stream `screenshot_update` | pixels, reported screen size, `captureSequence`, `coordinateSpace`, device `frameContext` | continuously while subscribed |
+| observation stream `hierarchy_update` | element tree with `bounds`, `captureSequence`, `coordinateSpace`, device `frameContext` | continuously, usually debounced client-side |
 | live mirror relay (optional) | decoded video frames | at the mirror's frame rate |
 | daemon connection state | transport liveness | on connect/disconnect |
 | device selection | which device the user chose | on user action |
@@ -52,6 +52,7 @@ DeviceFrameSnapshot(
   deviceId,             // the one device every contributing source agreed on
   sequence,             // monotonic; orders snapshots against each other (see below)
   captureSequence,      // the daemon capture identity screenshot and hierarchy agreed on
+  frameContext,         // device-authored identity screenshot and hierarchy agreed on
   capturedAtMs,         // client clock, for recency
   source,               // Screenshot | LiveVideo — which pixels are displayed
   frameWidth/Height,    // the displayed frame's dimensions
@@ -96,6 +97,7 @@ and unit-testable without a device.
 | A screenshot **and** a hierarchy have been applied | Mapping needs both |
 | Every source's device id equals the selection | After a device switch the previous device's frame lingers |
 | `screenshot.captureSequence == hierarchy.captureSequence` | **Shared capture identity** — this is what catches the equal-aspect resolution change |
+| `screenshot.frameContext == hierarchy.frameContext`, both non-null | **Device capture identity** — this catches same-size navigation between request and pixel capture |
 | Both messages carry a `captureSequence` at all | Older daemons do not stamp one; control fails closed rather than guessing |
 | `now - screenshot.receivedAt <= 5000 ms` | The daemon may stop pushing without disconnecting |
 | `now - liveFrame.receivedAt <= 1000 ms` (when a live frame is displayed) | **Recency** — this is what catches the stalled mirror |
@@ -145,7 +147,7 @@ mis-scaled tap one level down. So the daemon measures the frame's header and
 refuses to stamp on mismatch. It also publishes the *measured* dimensions, so a
 client falling back to them maps through the pixels it is actually rendering.
 
-### Residual: request-send is not device-capture
+### Device capture identity
 
 Identity is bound when the client **sends** the screenshot request, not when the
 device actually captures the pixels. The device captures some time later, so if
@@ -154,11 +156,12 @@ carry screen A's identity and pair with screen A's hierarchy. No client-side
 signal distinguishes this: the dimensions are identical, and the client has no
 visibility into what was on screen at capture time.
 
-Closing it requires the device to report the hierarchy or UI state it captured
-against — a CtrlProxy protocol change plus an APK/IPA re-cut — so it is out of
-scope for the client-side consolidation. It is tracked with the daemon-side
-frame-context validation work in
-[#4505](https://github.com/kaeawc/auto-mobile/issues/4505).
+Current CtrlProxy runners report an opaque `frameContext` with each hierarchy and
+with a screenshot only when it can prove the hierarchy stayed unchanged across
+pixel capture. A control client requires matching, non-null contexts alongside
+`captureSequence`, then echoes that exact value on `input/*`. The daemon rejects
+a stale or unavailable echo before executing the request. The token is opaque,
+device-specific, and must never be synthesized or compared across reconnects.
 
 The identity source is monotonic for the daemon process's lifetime and is never
 reset, so an id cannot be reused after a device reconnect and collide with a

--- a/docs/design-docs/mcp/daemon/unix-socket-api.md
+++ b/docs/design-docs/mcp/daemon/unix-socket-api.md
@@ -410,6 +410,24 @@ The socket returns exactly one response per request. If the request times out,
 the envelope has `success: false`; treat that response as authoritative and
 re-observe device state before assuming the input landed.
 
+### Frame-context safety
+
+Every `input/*` request may include an optional `frameContext` string copied from both the
+`screenshot_update` and `hierarchy_update` that describe the exact rendered frame. Omit it to
+retain the legacy behavior byte-for-byte.
+
+When supplied, the daemon compares it with the newest device-authored observation context and
+rejects a mismatch before executing the action with an actionable `observe a fresh frame before
+retrying` error. Current Android and iOS CtrlProxy runners also validate context-bearing gestures
+at the device boundary. iOS derives the opaque value from the captured hierarchy before and after
+a screenshot; if the UI changes during capture, the screenshot intentionally has no context and a
+client must not invent one. This protects same-size navigation as well as rotations and resolution
+changes.
+
+The value is opaque, device-specific, and must only be echoed unchanged. It is not a timestamp,
+not portable across devices or runner restarts, and a client must fail closed when the screenshot
+and hierarchy contexts are absent or unequal.
+
 ### `input/tap`
 
 Taps an absolute device-screen coordinate. Coordinates are physical pixels in

--- a/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
+++ b/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
@@ -25,12 +25,14 @@
 		2CFEE57D3D518C352BAB2937 /* SdkHierarchyModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E0B84D4CA225ECB1E09064 /* SdkHierarchyModels.swift */; };
 		2DD69FF84C0520EED9B77AFF /* ObjCExceptionBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D776AE5CF32E6E89AEF7A5 /* ObjCExceptionBridge.swift */; };
 		31606D9CB665D76FBF91C86C /* MultiFingerSwipeDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB532F74A3F3A670BD526CC /* MultiFingerSwipeDiagnostics.swift */; };
+		37667E0852D846E2C5D1DA4A /* FrameContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4BE559FB2C03A096815C9F /* FrameContext.swift */; };
 		3841CE71EF7F67B82441E6E3 /* DisplayLinkFPSMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1044F2C47DD6B836C1E32F1C /* DisplayLinkFPSMonitor.swift */; };
 		416E49D98E779D4D7D060F16 /* ObjCExceptionBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D776AE5CF32E6E89AEF7A5 /* ObjCExceptionBridge.swift */; };
 		42E706C81F51E89DEBD9C1A9 /* CtrlProxy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 056D5DCA8003C7DFA37244C4 /* CtrlProxy.framework */; };
 		4413FD9E4C8BF4071C74D482 /* HierarchyDebouncerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5AAA4E2861D92C17F39B14 /* HierarchyDebouncerTests.swift */; };
 		45B926178972D1A358CFF284 /* HierarchyMerger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAAF8CEA9B9A28B052E57E0A /* HierarchyMerger.swift */; };
 		47A050F2D8153251E395B7B9 /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F9D7B74C318EE243B225B95 /* Protocols.swift */; };
+		4917F959900833F074F22C34 /* FrameContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD4BE559FB2C03A096815C9F /* FrameContext.swift */; };
 		4A0FBEF6FAEF437AA17B20EA /* PerfProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A284B6FFBE969931BB03A2FF /* PerfProvider.swift */; };
 		51172531044918A0248559AE /* ObjCExceptionCatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = D219492B8663B05AFF608428 /* ObjCExceptionCatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5278294A4F04317461A1FBE4 /* ObjCExceptionCatcher.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFAE974582B8CDFFBA64AFB5 /* ObjCExceptionCatcher.framework */; };
@@ -221,6 +223,7 @@
 		B4CB9272A186932D89EB1072 /* WebSocketServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketServer.swift; sourceTree = "<group>"; };
 		B7BE98EA2924A42A6CD22993 /* ElementLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementLocatorTests.swift; sourceTree = "<group>"; };
 		CCAAB1439B71724CA0BF2401 /* GesturePerformerSymbolsUnavailableWiringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GesturePerformerSymbolsUnavailableWiringTests.swift; sourceTree = "<group>"; };
+		CD4BE559FB2C03A096815C9F /* FrameContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameContext.swift; sourceTree = "<group>"; };
 		D219492B8663B05AFF608428 /* ObjCExceptionCatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ObjCExceptionCatcher.h; sourceTree = "<group>"; };
 		D81453AD074F2A392251CFC3 /* Models.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models.swift; sourceTree = "<group>"; };
 		DBA97A6C3A1240A055D9876C /* OSLogReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSLogReader.swift; sourceTree = "<group>"; };
@@ -369,6 +372,7 @@
 				1044F2C47DD6B836C1E32F1C /* DisplayLinkFPSMonitor.swift */,
 				95565999DC108319DEED894A /* ElementLocator.swift */,
 				9A1B2931E58B158EE51C5F4F /* Fakes.swift */,
+				CD4BE559FB2C03A096815C9F /* FrameContext.swift */,
 				F2144B84CD70DB35A1030624 /* GesturePerformer.swift */,
 				034DC5B8A3A4FCE46CD89568 /* HierarchyDebouncer.swift */,
 				FAAF8CEA9B9A28B052E57E0A /* HierarchyMerger.swift */,
@@ -591,6 +595,7 @@
 				F469E7EF16C59A99DBD519DA /* DisplayLinkFPSMonitor.swift in Sources */,
 				9FE4564D1819768FEFD62606 /* ElementLocator.swift in Sources */,
 				A603343B94D35DDF48F7AA4D /* Fakes.swift in Sources */,
+				4917F959900833F074F22C34 /* FrameContext.swift in Sources */,
 				D9EF3A486E53F97C1CCB7A3B /* GesturePerformer.swift in Sources */,
 				EA65C486C9E6DBB5BFE9CA41 /* HierarchyDebouncer.swift in Sources */,
 				158C6F3B528C02BE92AA6132 /* HierarchyMerger.swift in Sources */,
@@ -657,6 +662,7 @@
 				CDEF0C911EA979C4E9C54B0B /* DefaultStorageInspecting.swift in Sources */,
 				3841CE71EF7F67B82441E6E3 /* DisplayLinkFPSMonitor.swift in Sources */,
 				1F968B5EDB744057F51321EF /* ElementLocator.swift in Sources */,
+				37667E0852D846E2C5D1DA4A /* FrameContext.swift in Sources */,
 				5FDF9AE29841625DD7EFB7EC /* GesturePerformer.swift in Sources */,
 				5458E55CB48475D2487A49C3 /* HierarchyDebouncer.swift in Sources */,
 				45B926178972D1A358CFF284 /* HierarchyMerger.swift in Sources */,

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -311,7 +311,8 @@ public class CommandHandler: CommandHandling {
         return HierarchyUpdateResponse(
             requestId: request.requestId,
             data: enriched,
-            perfTiming: perfTimings?.first
+            perfTiming: perfTimings?.first,
+            frameContext: FrameContext.forHierarchy(enriched)
         )
     }
 
@@ -393,14 +394,34 @@ public class CommandHandler: CommandHandling {
     }
 
     private func handleRequestScreenshot(_ request: RequestEnvelope, startTime _: Date) throws -> ScreenshotResponse {
+        // Read the hierarchy on both sides of the pixel capture. A change during capture leaves
+        // the context absent, which makes a context-aware client fail closed instead of pairing
+        // pixels from one screen with the identity of another.
+        let before = currentFrameContext()
         let data = try gesturePerformer.getScreenshot()
+        let after = currentFrameContext()
         let base64 = data.base64EncodedString()
 
         return ScreenshotResponse(
             requestId: request.requestId,
             data: base64,
-            format: "png"
+            format: "png",
+            frameContext: before == after ? before : nil
         )
+    }
+
+    private func currentFrameContext() -> String? {
+        guard let hierarchy = try? elementLocator.getViewHierarchy(disableAllFiltering: false) else {
+            return nil
+        }
+        return FrameContext.forHierarchy(enrichWithMatchingSdkHierarchy(hierarchy))
+    }
+
+    private func requireCurrentFrameContext(_ expected: String?) throws {
+        guard let expected else { return }
+        guard currentFrameContext() == expected else {
+            throw CommandError.executionFailed("Stale frame context; observe a fresh frame before retrying")
+        }
     }
 
     // MARK: - Gestures
@@ -427,6 +448,7 @@ public class CommandHandler: CommandHandling {
     }
 
     private func handleTapCoordinates(_ request: RequestTapCoordinates, startTime: Date) throws -> WebSocketResponse {
+        try requireCurrentFrameContext(request.frameContext)
         try requireFinite(request.x, field: "x")
         try requireFinite(request.y, field: "y")
         let duration = request.duration ?? 0
@@ -440,6 +462,7 @@ public class CommandHandler: CommandHandling {
     }
 
     private func handleSwipe(_ request: RequestSwipe, startTime: Date) throws -> WebSocketResponse {
+        try requireCurrentFrameContext(request.frameContext)
         try requireFinite(request.x1, field: "x1")
         try requireFinite(request.y1, field: "y1")
         try requireFinite(request.x2, field: "x2")
@@ -496,6 +519,7 @@ public class CommandHandler: CommandHandling {
     }
 
     private func handleDrag(_ request: RequestDrag, startTime: Date) throws -> WebSocketResponse {
+        try requireCurrentFrameContext(request.frameContext)
         try requireFinite(request.x1, field: "x1")
         try requireFinite(request.y1, field: "y1")
         try requireFinite(request.x2, field: "x2")

--- a/ios/control-proxy/Sources/CtrlProxy/FrameContext.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/FrameContext.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// Stable, opaque identity for a device hierarchy. It deliberately hashes the encoded hierarchy
+/// rather than dimensions: same-size navigation must still invalidate a mirrored frame.
+enum FrameContext {
+    static func forHierarchy(_ hierarchy: ViewHierarchy) -> String? {
+        // `updatedAt` is assigned for every extraction, so including it would reject an unchanged
+        // screen merely because validation sampled it a millisecond later. Hash only semantic
+        // screen state, with sorted keys for deterministic dictionary encoding.
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        guard let data = try? encoder.encode(SemanticHierarchy(hierarchy)) else { return nil }
+        var hash: UInt64 = 0xcbf29ce484222325
+        for byte in data {
+            hash ^= UInt64(byte)
+            hash &*= 0x100000001b3
+        }
+        return String(hash, radix: 16)
+    }
+}
+
+private struct SemanticHierarchy: Encodable {
+    let packageName: String?
+    let hierarchy: UIElementInfo?
+    let windowInfo: WindowInfo?
+    let windows: [WindowInfo]?
+    let screenScale: Float?
+    let screenWidth: Int?
+    let screenHeight: Int?
+    let systemInsets: EdgeInsetsInfo?
+    let insets: ObservationInsetsInfo
+    let error: String?
+    let fallbackToSpringboard: Bool?
+
+    init(_ value: ViewHierarchy) {
+        packageName = value.packageName
+        hierarchy = value.hierarchy
+        windowInfo = value.windowInfo
+        windows = value.windows
+        screenScale = value.screenScale
+        screenWidth = value.screenWidth
+        screenHeight = value.screenHeight
+        systemInsets = value.systemInsets
+        insets = value.insets
+        error = value.error
+        fallbackToSpringboard = value.fallbackToSpringboard
+    }
+}

--- a/ios/control-proxy/Sources/CtrlProxy/FrameContext.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/FrameContext.swift
@@ -3,7 +3,27 @@ import Foundation
 /// Stable, opaque identity for a device hierarchy. It deliberately hashes the encoded hierarchy
 /// rather than dimensions: same-size navigation must still invalidate a mirrored frame.
 enum FrameContext {
+    private static let lock = NSLock()
+    private static var generation: UInt64 = 0
+
+    /// Each pushed hierarchy advances a process-local generation. This detects an A→B→A change
+    /// while a screenshot is in flight even when its semantic hash returns to the same value.
+    static func recordHierarchy(_ hierarchy: ViewHierarchy) -> String? {
+        lock.lock()
+        generation &+= 1
+        let currentGeneration = generation
+        lock.unlock()
+        return semanticHash(hierarchy).map { "\(currentGeneration):\($0)" }
+    }
+
     static func forHierarchy(_ hierarchy: ViewHierarchy) -> String? {
+        lock.lock()
+        let currentGeneration = generation
+        lock.unlock()
+        return semanticHash(hierarchy).map { "\(currentGeneration):\($0)" }
+    }
+
+    private static func semanticHash(_ hierarchy: ViewHierarchy) -> String? {
         // `updatedAt` is assigned for every extraction, so including it would reject an unchanged
         // screen merely because validation sampled it a millisecond later. Hash only semantic
         // screen state, with sorted keys for deterministic dictionary encoding.

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -55,6 +55,7 @@ public struct RequestTapCoordinates: Decodable {
     public var x: Double
     public var y: Double
     public var duration: Int?
+    public var frameContext: String?
 }
 
 public struct RequestSwipe: Decodable {
@@ -64,6 +65,7 @@ public struct RequestSwipe: Decodable {
     public var x2: Double
     public var y2: Double
     public var duration: Int?
+    public var frameContext: String?
 }
 
 public struct RequestMultiFingerSwipe: Decodable {
@@ -87,6 +89,7 @@ public struct RequestDrag: Decodable {
     public var dragDurationMs: Int?
     public var holdDurationMs: Int?
     public var holdTime: Int?
+    public var frameContext: String?
 }
 
 public struct RequestPinch: Decodable {
@@ -851,12 +854,15 @@ public struct HierarchyUpdateResponse: Codable {
     public let data: ViewHierarchy?
     public let perfTiming: PerfTiming?
     public let error: String?
+    /// Opaque identity calculated from the exact hierarchy captured on device.
+    public let frameContext: String?
 
     public init(
         requestId: String? = nil,
         data: ViewHierarchy? = nil,
         perfTiming: PerfTiming? = nil,
-        error: String? = nil
+        error: String? = nil,
+        frameContext: String? = nil
     ) {
         type = "hierarchy_update"
         timestamp = Int64(Date().timeIntervalSince1970 * 1000)
@@ -864,6 +870,7 @@ public struct HierarchyUpdateResponse: Codable {
         self.data = data
         self.perfTiming = perfTiming
         self.error = error
+        self.frameContext = frameContext
     }
 }
 
@@ -1194,13 +1201,15 @@ public struct ScreenshotResponse: Codable {
     public let requestId: String?
     public let format: String
     public let data: String // Base64 encoded
+    public let frameContext: String?
 
-    public init(requestId: String?, data: String, format: String = "png") {
+    public init(requestId: String?, data: String, format: String = "png", frameContext: String? = nil) {
         type = "screenshot"
         timestamp = Int64(Date().timeIntervalSince1970 * 1000)
         self.requestId = requestId
         self.format = format
         self.data = data
+        self.frameContext = frameContext
     }
 }
 

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -281,7 +281,8 @@ public class WebSocketServer: WebSocketServing {
                     requestId: hierarchyResponse.requestId,
                     data: hierarchyResponse.data,
                     perfTiming: perfTiming,
-                    error: hierarchyResponse.error
+                    error: hierarchyResponse.error,
+                    frameContext: hierarchyResponse.frameContext
                 )
             }
             return try encoder.encode(hierarchyResponse)
@@ -306,7 +307,8 @@ public class WebSocketServer: WebSocketServing {
         let response = HierarchyUpdateResponse(
             requestId: nil, // No requestId for push updates
             data: hierarchy,
-            perfTiming: nil
+            perfTiming: nil,
+            frameContext: FrameContext.forHierarchy(hierarchy)
         )
 
         do {

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -308,7 +308,7 @@ public class WebSocketServer: WebSocketServing {
             requestId: nil, // No requestId for push updates
             data: hierarchy,
             perfTiming: nil,
-            frameContext: FrameContext.forHierarchy(hierarchy)
+            frameContext: FrameContext.recordHierarchy(hierarchy)
         )
 
         do {

--- a/ios/control-proxy/Tests/CtrlProxyTests/ModelsTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ModelsTests.swift
@@ -2,6 +2,23 @@
 import XCTest
 
 final class ModelsTests: XCTestCase {
+    func testFrameContextGenerationInvalidatesAnABAReturnToTheSameHierarchy() {
+        let screenA = ViewHierarchy(
+            packageName: "com.example.a",
+            hierarchy: UIElementInfo(text: "A")
+        )
+        let screenB = ViewHierarchy(
+            packageName: "com.example.b",
+            hierarchy: UIElementInfo(text: "B")
+        )
+
+        let firstScreenAContext = FrameContext.recordHierarchy(screenA)
+        _ = FrameContext.recordHierarchy(screenB)
+        let returnedScreenAContext = FrameContext.recordHierarchy(screenA)
+
+        XCTAssertNotEqual(firstScreenAContext, returnedScreenAContext)
+    }
+
     // MARK: - PerfTiming Tests
 
     func testPerfTimingEncoding() throws {

--- a/scripts/ios/navigation-graph-sdk-event-integration.sh
+++ b/scripts/ios/navigation-graph-sdk-event-integration.sh
@@ -10,6 +10,10 @@ timestamp_ms="$(($(date +%s) * 1000))"
 bundle_id="dev.jasonpearson.automobile.issue4460"
 home_screen="Issue4460Home"
 detail_screen="Issue4460Detail"
+# Keep the runner's SDK-event consumer and the public graph query in one session. Each CLI
+# invocation otherwise receives a distinct MCP session, which can route the injected events to a
+# different session-scoped NavigationGraphManager than getNavigationGraph reads.
+session_uuid="44600000-0000-4000-8000-000000000000"
 
 require_command() {
   command -v "$1" >/dev/null 2>&1 || {
@@ -76,12 +80,12 @@ curl --fail --silent --show-error --max-time 5 \
 # relying on its background poll leaves a race on a busy Simulator runner.
 # Query through the public, daemon-backed tool until the batched events appear.
 for attempt in 1 2 3 4 5; do
-  if ! auto-mobile --debug --cli observe --platform ios --deviceId "${device_id}" >/dev/null; then
+  if ! auto-mobile --debug --cli --session-uuid "${session_uuid}" observe --platform ios --deviceId "${device_id}" >/dev/null; then
     echo "observe refresh attempt ${attempt} failed; retrying in 2s..." >&2
     sleep 2
     continue
   fi
-  if ! graph="$(auto-mobile --debug --cli getNavigationGraph --platform ios --deviceId "${device_id}")"; then
+  if ! graph="$(auto-mobile --debug --cli --session-uuid "${session_uuid}" getNavigationGraph --platform ios --deviceId "${device_id}")"; then
     echo "getNavigationGraph attempt ${attempt} failed; retrying in 2s..." >&2
     sleep 2
     continue

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -465,10 +465,6 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       screenshotByteLength,
       screenshotBase64Length,
     };
-    if (options.frameContext !== undefined) {
-      this.currentFrameContexts.set(deviceId, options.frameContext);
-    }
-
     const sentCount = this.pushToSubscribers({ message, targetDeviceId: deviceId });
     if (sentCount > 0) {
       logger.debug(`[DeviceDataStream] Pushed screenshot_update to ${sentCount} subscribers (device: ${deviceId})`);

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -350,6 +350,10 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
   pushHierarchyUpdate(deviceId: string, hierarchy: ViewHierarchyResult, frameContext?: string): number | null {
     if (frameContext !== undefined) {
       this.currentFrameContexts.set(deviceId, frameContext);
+    } else {
+      // The device could not prove which UI the hierarchy describes. Its previous token is no
+      // longer authoritative: keeping it would let stale non-gesture input pass the daemon gate.
+      this.currentFrameContexts.delete(deviceId);
     }
     // Skip the diff clone+walk when nobody is listening (the layout inspector is
     // usually closed): the frame would reach zero subscribers anyway. Drop the

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -127,6 +127,8 @@ interface DeviceDataStreamMessage extends ScreenshotMetadata {
    * checks) can tell converted frames from a pre-#4548 runner's and fall back accordingly.
    */
   coordinateSpace?: CoordinateSpace;
+  /** Opaque device-authored UI identity used by input validation. */
+  frameContext?: string;
 }
 
 /**
@@ -184,6 +186,7 @@ interface PushScreenshotOptions {
    * omitted for a pre-#4548 runner, keeping the frame legacy point-space.
    */
   coordinateSpace?: CoordinateSpace;
+  frameContext?: string;
 }
 
 /**
@@ -272,6 +275,13 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
   DeviceDataFilter,
   DeviceDataPush
 > {
+  /** Most recent device-authored identity received for each device. Kept even when no IDE is
+   * subscribed: daemon-side input validation must not depend on an inspector being open. */
+  private readonly currentFrameContexts = new Map<string, string>();
+
+  getCurrentFrameContext(deviceId: string): string | undefined {
+    return this.currentFrameContexts.get(deviceId);
+  }
   private onSubscriberConnected: OnSubscriberConnectedCallback | null = null;
   private onScreenshotCadenceChanged: OnScreenshotCadenceChangedCallback | null = null;
   private onHierarchyCadenceChanged: OnHierarchyCadenceChangedCallback | null = null;
@@ -337,7 +347,10 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
   /**
    * Push a hierarchy update to all subscribers interested in this device.
    */
-  pushHierarchyUpdate(deviceId: string, hierarchy: ViewHierarchyResult): number | null {
+  pushHierarchyUpdate(deviceId: string, hierarchy: ViewHierarchyResult, frameContext?: string): number | null {
+    if (frameContext !== undefined) {
+      this.currentFrameContexts.set(deviceId, frameContext);
+    }
     // Skip the diff clone+walk when nobody is listening (the layout inspector is
     // usually closed): the frame would reach zero subscribers anyway. Drop the
     // baseline too so a later re-subscribe diffs from a fresh frame, not a tree
@@ -381,6 +394,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       hierarchyDiff: summary,
       captureSequence,
       ...(scaleMetadata ? { coordinateSpace: COORDINATE_SPACE_PX } : {}),
+      frameContext,
     };
 
     const sentCount = this.pushToSubscribers({ message, targetDeviceId: deviceId });
@@ -440,6 +454,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       // against mapping bounds that may not describe these pixels.
       captureSequence: claimMatchesPixels ? options.captureSequence : undefined,
       ...(options.coordinateSpace ? { coordinateSpace: options.coordinateSpace } : {}),
+      frameContext: options.frameContext,
       screenshotMimeType,
       screenshotFormat,
       screenshotCaptureSource,
@@ -450,6 +465,9 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       screenshotByteLength,
       screenshotBase64Length,
     };
+    if (options.frameContext !== undefined) {
+      this.currentFrameContexts.set(deviceId, options.frameContext);
+    }
 
     const sentCount = this.pushToSubscribers({ message, targetDeviceId: deviceId });
     if (sentCount > 0) {
@@ -607,6 +625,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
     // Drop the diff baseline: the next hierarchy after a reconnect is a fresh
     // full frame, not a delta from the tree captured before the connection dropped.
     this.previousHierarchyByDevice.delete(deviceId);
+    this.currentFrameContexts.delete(deviceId);
     // Nothing to reset for capture identity: ids are never reused (the source is monotonic for the
     // process), and clients drop their own bindings when the connection goes away.
 

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1025,7 +1025,6 @@ export class UnixSocketServer {
       }
 
       if (args.platform === "android") {
-      if (args.platform === "android") {
         const client = AndroidCtrlProxyClient.getInstance(targetDevice, defaultAdbClientFactory);
         return args.frameContext === undefined
           ? await client.requestTapCoordinates(args.x, args.y, args.duration, remainingTimeoutMs)

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -65,6 +65,7 @@ import {
 import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
 import { canonicalPixelsToPoints } from "./canonicalPixels";
 import { ActionableError, toActionableError } from "../models/ActionableError";
+import { getDeviceDataStreamServer } from "./deviceDataStreamSocketServer";
 import type { KeyValueType } from "../features/storage/storageTypes";
 import type { BootedDevice, ImeAction } from "../models";
 import type { DeviceService } from "../features/observe/DeviceService";
@@ -1011,6 +1012,7 @@ export class UnixSocketServer {
       "input/tap"
     );
     const gestureResult = await this.runKeyedMcpForward(`device:${targetDevice.deviceId}`, async () => {
+      this.requireCurrentFrameContext(targetDevice.deviceId, args.frameContext, "input/tap");
       const queueWaitMs = this.timer.now() - queueEnterMs;
       const remainingTimeoutMs = totalTimeoutMs - queueWaitMs;
       if (remainingTimeoutMs <= 0) {
@@ -1023,9 +1025,11 @@ export class UnixSocketServer {
       }
 
       if (args.platform === "android") {
-        return await AndroidCtrlProxyClient
-          .getInstance(targetDevice, defaultAdbClientFactory)
-          .requestTapCoordinates(args.x, args.y, args.duration, remainingTimeoutMs);
+      if (args.platform === "android") {
+        const client = AndroidCtrlProxyClient.getInstance(targetDevice, defaultAdbClientFactory);
+        return args.frameContext === undefined
+          ? await client.requestTapCoordinates(args.x, args.y, args.duration, remainingTimeoutMs)
+          : await client.requestTapCoordinates(args.x, args.y, args.duration, remainingTimeoutMs, undefined, args.frameContext);
       }
       const iosClient = IOSCtrlProxyClient.getInstance(targetDevice);
       const [x, y] = await this.toIosRunnerCoordinates(
@@ -1035,7 +1039,9 @@ export class UnixSocketServer {
         remainingTimeoutMs
       );
       const gestureTimeoutMs = this.remainingBudgetAfterProbe(queueEnterMs, totalTimeoutMs, request.method, "handleInputTap");
-      return await iosClient.requestTapCoordinates(x, y, args.duration, gestureTimeoutMs);
+      return args.frameContext === undefined
+        ? await iosClient.requestTapCoordinates(x, y, args.duration, gestureTimeoutMs)
+        : await iosClient.requestTapCoordinates(x, y, args.duration, gestureTimeoutMs, undefined, args.frameContext);
     });
 
     if (!gestureResult.success) {
@@ -1065,6 +1071,7 @@ export class UnixSocketServer {
       "input/swipe"
     );
     const gestureResult = await this.runKeyedMcpForward(`device:${targetDevice.deviceId}`, async () => {
+      this.requireCurrentFrameContext(targetDevice.deviceId, args.frameContext, "input/swipe");
       const queueWaitMs = this.timer.now() - queueEnterMs;
       const remainingTimeoutMs = totalTimeoutMs - queueWaitMs;
       if (remainingTimeoutMs <= 0) {
@@ -1077,19 +1084,41 @@ export class UnixSocketServer {
       }
 
       if (args.platform === "android") {
-        return await AndroidCtrlProxyClient
-          .getInstance(targetDevice, defaultAdbClientFactory)
-          .requestSwipe(args.startX, args.startY, args.endX, args.endY, args.durationMs, remainingTimeoutMs);
+        const client = AndroidCtrlProxyClient.getInstance(targetDevice, defaultAdbClientFactory);
+        return args.frameContext === undefined
+          ? await client.requestSwipe(args.startX, args.startY, args.endX, args.endY, args.durationMs, remainingTimeoutMs)
+          : await client.requestSwipe(
+            args.startX,
+            args.startY,
+            args.endX,
+            args.endY,
+            args.durationMs,
+            remainingTimeoutMs,
+            undefined,
+            args.frameContext
+          );
       }
-      const iosClient = IOSCtrlProxyClient.getInstance(targetDevice);
+      const client = IOSCtrlProxyClient.getInstance(targetDevice);
       const [startX, startY, endX, endY] = await this.toIosRunnerCoordinates(
-        iosClient,
+        client,
         targetDevice.deviceId,
         [args.startX, args.startY, args.endX, args.endY],
         remainingTimeoutMs
       );
       const gestureTimeoutMs = this.remainingBudgetAfterProbe(queueEnterMs, totalTimeoutMs, request.method, "handleInputSwipe");
-      return await iosClient.requestDrag(startX, startY, endX, endY, 0, args.durationMs, 0, gestureTimeoutMs);
+      return args.frameContext === undefined
+        ? await client.requestDrag(startX, startY, endX, endY, 0, args.durationMs, 0, gestureTimeoutMs)
+        : await client.requestDrag(
+          startX,
+          startY,
+          endX,
+          endY,
+          0,
+          args.durationMs,
+          0,
+          gestureTimeoutMs,
+          args.frameContext
+        );
     });
 
     if (!gestureResult.success) {
@@ -1135,6 +1164,7 @@ export class UnixSocketServer {
           true
         )
         : targetDevice;
+      this.requireCurrentFrameContext(targetDevice.deviceId, args.frameContext, "input/typeText");
       const queueWaitMs = this.timer.now() - queueEnterMs;
       const remainingTimeoutMs = totalTimeoutMs - queueWaitMs;
       if (remainingTimeoutMs <= 0) {
@@ -1205,6 +1235,7 @@ export class UnixSocketServer {
       "input/pressButton"
     );
     const buttonResult = await this.runKeyedMcpForward(`device:${targetDevice.deviceId}`, async () => {
+      this.requireCurrentFrameContext(targetDevice.deviceId, args.frameContext, "input/pressButton");
       const queueWaitMs = this.timer.now() - queueEnterMs;
       const remainingTimeoutMs = totalTimeoutMs - queueWaitMs;
       if (remainingTimeoutMs <= 0) {
@@ -1249,6 +1280,7 @@ export class UnixSocketServer {
       "input/key"
     );
     const keyResult = await this.runKeyedMcpForward(`device:${targetDevice.deviceId}`, async () => {
+      this.requireCurrentFrameContext(targetDevice.deviceId, args.frameContext, "input/key");
       const queueWaitMs = this.timer.now() - queueEnterMs;
       const remainingTimeoutMs = totalTimeoutMs - queueWaitMs;
       if (remainingTimeoutMs <= 0) {
@@ -1420,6 +1452,7 @@ export class UnixSocketServer {
     x: number;
     y: number;
     duration?: number;
+    frameContext?: string;
   } {
     if (!params || typeof params !== "object" || Array.isArray(params)) {
       throw new Error("input/tap requires params object");
@@ -1445,6 +1478,12 @@ export class UnixSocketServer {
     if (args.deviceId !== undefined && typeof args.deviceId !== "string") {
       throw new Error("input/tap deviceId must be a string when provided");
     }
+    if (
+      args.frameContext !== undefined &&
+      (typeof args.frameContext !== "string" || args.frameContext.length === 0)
+    ) {
+      throw new Error("input/tap frameContext must be a non-empty string when provided");
+    }
 
     return {
       platform: args.platform,
@@ -1452,6 +1491,7 @@ export class UnixSocketServer {
       x: args.x,
       y: args.y,
       duration: args.duration,
+      frameContext: args.frameContext,
     };
   }
 
@@ -1463,6 +1503,7 @@ export class UnixSocketServer {
     endX: number;
     endY: number;
     durationMs: number;
+    frameContext?: string;
   } {
     if (!params || typeof params !== "object" || Array.isArray(params)) {
       throw new Error("input/swipe requires params object");
@@ -1498,6 +1539,12 @@ export class UnixSocketServer {
     if (args.deviceId !== undefined && typeof args.deviceId !== "string") {
       throw new Error("input/swipe deviceId must be a string when provided");
     }
+    if (
+      args.frameContext !== undefined &&
+      (typeof args.frameContext !== "string" || args.frameContext.length === 0)
+    ) {
+      throw new Error("input/swipe frameContext must be a non-empty string when provided");
+    }
 
     return {
       platform: args.platform,
@@ -1507,6 +1554,7 @@ export class UnixSocketServer {
       endX: args.endX,
       endY: args.endY,
       durationMs: args.durationMs ?? 300,
+      frameContext: args.frameContext,
     };
   }
 
@@ -1516,13 +1564,14 @@ export class UnixSocketServer {
     text: string;
     submit: boolean;
     append: boolean;
+    frameContext?: string;
   } {
     if (!params || typeof params !== "object" || Array.isArray(params)) {
       throw new Error("input/typeText requires params object");
     }
 
     const args = params as Record<string, unknown>;
-    const supportedParams = new Set(["platform", "deviceId", "text", "submit", "mode"]);
+    const supportedParams = new Set(["platform", "deviceId", "text", "submit", "mode", "frameContext"]);
     const unsupportedParams = Object.keys(args).filter(key => !supportedParams.has(key));
     if (unsupportedParams.length > 0) {
       throw new Error(`input/typeText unsupported params: ${unsupportedParams.join(", ")}`);
@@ -1539,6 +1588,7 @@ export class UnixSocketServer {
     if (args.deviceId !== undefined && typeof args.deviceId !== "string") {
       throw new Error("input/typeText deviceId must be a string when provided");
     }
+    this.validateFrameContextParam(args.frameContext, "input/typeText");
     // "append" adds to the focused field instead of replacing it, which is what
     // an interactive client mirroring one keystroke at a time needs: the default
     // replace semantics would leave only the last character typed (#3351).
@@ -1551,6 +1601,7 @@ export class UnixSocketServer {
       text: args.text,
       submit: args.submit ?? false,
       append: args.mode === "append",
+      frameContext: args.frameContext as string | undefined,
     };
   }
 
@@ -1559,6 +1610,7 @@ export class UnixSocketServer {
     deviceId?: string;
     button: string;
     responseButton: string;
+    frameContext?: string;
   } {
     if (!params || typeof params !== "object" || Array.isArray(params)) {
       throw new Error("input/pressButton requires params object");
@@ -1578,6 +1630,7 @@ export class UnixSocketServer {
     if (args.deviceId !== undefined && typeof args.deviceId !== "string") {
       throw new Error("input/pressButton deviceId must be a string when provided");
     }
+    this.validateFrameContextParam(args.frameContext, "input/pressButton");
     const button = args.button === "app_switch" ? "recent" : args.button;
 
     return {
@@ -1585,6 +1638,7 @@ export class UnixSocketServer {
       deviceId: args.deviceId,
       button,
       responseButton: args.button,
+      frameContext: args.frameContext as string | undefined,
     };
   }
 
@@ -1592,13 +1646,14 @@ export class UnixSocketServer {
     platform: "android" | "ios";
     deviceId?: string;
     key: InputKeyName;
+    frameContext?: string;
   } {
     if (!params || typeof params !== "object" || Array.isArray(params)) {
       throw new Error("input/key requires params object");
     }
 
     const args = params as Record<string, unknown>;
-    const supportedParams = new Set(["platform", "deviceId", "key"]);
+    const supportedParams = new Set(["platform", "deviceId", "key", "frameContext"]);
     const unsupportedParams = Object.keys(args).filter(key => !supportedParams.has(key));
     if (unsupportedParams.length > 0) {
       throw new Error(`input/key unsupported params: ${unsupportedParams.join(", ")}`);
@@ -1615,12 +1670,33 @@ export class UnixSocketServer {
     if (args.deviceId !== undefined && typeof args.deviceId !== "string") {
       throw new Error("input/key deviceId must be a string when provided");
     }
+    this.validateFrameContextParam(args.frameContext, "input/key");
 
     return {
       platform: args.platform,
       deviceId: args.deviceId,
       key: args.key,
+      frameContext: args.frameContext as string | undefined,
     };
+  }
+
+  private validateFrameContextParam(frameContext: unknown, action: string): void {
+    if (frameContext !== undefined && (typeof frameContext !== "string" || frameContext.length === 0)) {
+      throw new Error(`${action} frameContext must be a non-empty string when provided`);
+    }
+  }
+
+  /**
+   * Input that carries a device-authored context is safe only if the newest observation from that
+   * device still reports that exact context. Missing context fails closed: a caller can re-observe
+   * and retry, whereas executing against an unproven screen could actuate the wrong UI.
+   */
+  private requireCurrentFrameContext(deviceId: string, frameContext: string | undefined, action: string): void {
+    if (frameContext === undefined) {return;}
+    const current = getDeviceDataStreamServer()?.getCurrentFrameContext(deviceId);
+    if (current !== frameContext) {
+      throw new Error(`${action} frameContext is stale or unavailable; observe a fresh frame before retrying`);
+    }
   }
 
   private async resolveInputTargetDevice(

--- a/src/features/observe/ScreenshotBackoffScheduler.ts
+++ b/src/features/observe/ScreenshotBackoffScheduler.ts
@@ -19,6 +19,8 @@ export interface ScreenshotCaptureResult extends ScreenshotMetadata {
    * was in flight. Absent when there was no forwarded capture to bind.
    */
   captureBinding?: ScreenGeometryBinding;
+  /** Device-authored identity captured with the pixels, if the native runner could prove it. */
+  frameContext?: string;
 }
 
 /**

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -2359,6 +2359,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
           data: message.data,
           format: message.format || "jpeg",
           timestamp: message.timestamp,
+          frameContext: message.frameContext,
           ...screenshotPerformanceMetadataFrom(message),
         });
       }
@@ -3034,7 +3035,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
         },
         (result: ScreenshotCaptureResult) => {
           if (result.data) {
-            this.pushScreenshotToObservationStream(result.data, result, result.captureBinding);
+            this.pushScreenshotToObservationStream(result.data, result, result.captureBinding, result.frameContext);
           }
         },
         {
@@ -3111,6 +3112,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
         data: result.data,
         checksum,
         captureBinding,
+        frameContext: result.frameContext,
         ...metadataForScreenshotFormat(ANDROID_CTRLPROXY_SCREENSHOT_METADATA, result.format),
         ...screenshotPerformanceMetadataFrom(result),
       };

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -227,6 +227,7 @@ interface WsHierarchyUpdateMessage extends WsMessageBase {
   type: "hierarchy_update";
   data: AccessibilityHierarchy;
   perfTiming?: AndroidPerfTiming[];
+  frameContext?: string;
 }
 
 interface WsScreenshotMessage extends WsMessageBase, ScreenshotPerformanceMetadata {
@@ -234,6 +235,7 @@ interface WsScreenshotMessage extends WsMessageBase, ScreenshotPerformanceMetada
   requestId: string;
   data: string;
   format?: string;
+  frameContext?: string;
 }
 
 interface WsScreenshotErrorMessage extends WsMessageBase {
@@ -750,12 +752,17 @@ export interface AndroidCtrlProxy extends CtrlProxyClient {
 
   requestSwipe(
     x1: number, y1: number, x2: number, y2: number,
-    duration?: number, timeoutMs?: number, perf?: PerformanceTracker
+    duration?: number, timeoutMs?: number, perf?: PerformanceTracker, frameContext?: string
   ): Promise<A11ySwipeResult>;
+
+  requestTapCoordinates(
+    x: number, y: number,
+    duration?: number, timeoutMs?: number, perf?: PerformanceTracker, frameContext?: string
+  ): Promise<A11yTapCoordinatesResult>;
 
   requestDrag(
     x1: number, y1: number, x2: number, y2: number,
-    pressDurationMs: number, dragDurationMs: number, holdDurationMs: number, timeoutMs: number
+    pressDurationMs: number, dragDurationMs: number, holdDurationMs: number, timeoutMs: number, frameContext?: string
   ): Promise<A11yDragResult>;
 
   requestPinch(
@@ -1443,15 +1450,15 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
 
   async requestSwipe(
     x1: number, y1: number, x2: number, y2: number,
-    duration: number = 300, timeoutMs: number = 5000, perf: PerformanceTracker = new NoOpPerformanceTracker()
+    duration: number = 300, timeoutMs: number = 5000, perf: PerformanceTracker = new NoOpPerformanceTracker(), frameContext?: string
   ): Promise<A11ySwipeResult> {
-    return this.gestures.requestSwipe(x1, y1, x2, y2, duration, timeoutMs, perf);
+    return this.gestures.requestSwipe(x1, y1, x2, y2, duration, timeoutMs, perf, frameContext);
   }
 
   async requestTapCoordinates(
-    x: number, y: number, duration: number = 10, timeoutMs: number = 5000, perf: PerformanceTracker = new NoOpPerformanceTracker()
+    x: number, y: number, duration: number = 10, timeoutMs: number = 5000, perf: PerformanceTracker = new NoOpPerformanceTracker(), frameContext?: string
   ): Promise<A11yTapCoordinatesResult> {
-    return this.gestures.requestTapCoordinates(x, y, duration, timeoutMs, perf);
+    return this.gestures.requestTapCoordinates(x, y, duration, timeoutMs, perf, frameContext);
   }
 
   async requestTwoFingerSwipe(
@@ -1463,9 +1470,9 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
 
   async requestDrag(
     x1: number, y1: number, x2: number, y2: number,
-    pressDurationMs: number, dragDurationMs: number, holdDurationMs: number, timeoutMs: number
+    pressDurationMs: number, dragDurationMs: number, holdDurationMs: number, timeoutMs: number, frameContext?: string
   ): Promise<A11yDragResult> {
-    return this.gestures.requestDrag(x1, y1, x2, y2, pressDurationMs, dragDurationMs, holdDurationMs, timeoutMs);
+    return this.gestures.requestDrag(x1, y1, x2, y2, pressDurationMs, dragDurationMs, holdDurationMs, timeoutMs, frameContext);
   }
 
   async requestPinch(
@@ -2325,7 +2332,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       }
 
       if (message.type === "hierarchy_update" && message.data) {
-        this.handleHierarchyUpdate(message.data, message.perfTiming);
+        this.handleHierarchyUpdate(message.data, message.perfTiming, message.frameContext);
       }
 
       // Handle screenshot response
@@ -2341,7 +2348,8 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
           this.pushScreenshotToObservationStream(
             message.data,
             metadata,
-            binding
+            binding,
+            message.frameContext,
           );
         } else {
           logger.debug("[CTRL_PROXY] Suppressed screenshot observation stream push for explicit initial-frame request");
@@ -2816,7 +2824,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     }
   }
 
-  private handleHierarchyUpdate(data: AccessibilityHierarchy, perfTiming?: AndroidPerfTiming[]): void {
+  private handleHierarchyUpdate(data: AccessibilityHierarchy, perfTiming?: AndroidPerfTiming[], frameContext?: string): void {
     const now = this.timer.now();
     logger.debug(`[CTRL_PROXY] Received hierarchy update (updatedAt: ${data.updatedAt}, receivedAt: ${now})`);
 
@@ -2844,7 +2852,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     }
     if (!suppressObservationStreamPush) {
       // Push to observation stream
-      this.pushHierarchyToObservationStream(data);
+      this.pushHierarchyToObservationStream(data, frameContext);
 
       // Start screenshot backoff
       this.startScreenshotBackoff();
@@ -2911,14 +2919,14 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     return !this.sdkNavigationAppIds.has(packageName);
   }
 
-  private pushHierarchyToObservationStream(hierarchy: ViewHierarchyResult): void {
+  private pushHierarchyToObservationStream(hierarchy: ViewHierarchyResult, frameContext?: string): void {
     const server = getDeviceDataStreamServer();
     if (!server) {
       return;
     }
 
     try {
-      const captureSequence = server.pushHierarchyUpdate(this.device.deviceId, hierarchy);
+      const captureSequence = server.pushHierarchyUpdate(this.device.deviceId, hierarchy, frameContext);
       // Record the identity the daemon assigned, so screenshot requests initiated from here on are
       // bound to it. A null return (no subscribers), a throw, or a missing server all leave the
       // geometry untracked, and the daemon then omits the identity so a control client fails closed.
@@ -2933,7 +2941,8 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   private pushScreenshotToObservationStream(
     screenshotBase64: string,
     metadata: ScreenshotMetadata = ANDROID_CTRLPROXY_SCREENSHOT_METADATA,
-    binding?: ScreenGeometryBinding
+    binding?: ScreenGeometryBinding,
+    frameContext?: string,
   ): void {
     const server = getDeviceDataStreamServer();
     if (!server) {
@@ -2954,7 +2963,10 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       // carries that declaration so a mid-flight metadata flip cannot relabel the frame.
       server.pushScreenshotUpdate(
         this.device.deviceId, screenshotBase64, screenWidth, screenHeight, metadata,
-        screenshotBindingPushOptions(binding)
+        {
+          ...screenshotBindingPushOptions(binding),
+          ...(frameContext !== undefined ? { frameContext } : {}),
+        }
       );
     } catch (error) {
       logger.debug(`[CTRL_PROXY] Failed to push screenshot to observation stream: ${error}`);

--- a/src/features/observe/android/types.ts
+++ b/src/features/observe/android/types.ts
@@ -198,6 +198,7 @@ export interface ScreenshotResult extends ScreenshotPerformanceMetadata {
   format?: string;
   timestamp?: number;
   error?: string;
+  frameContext?: string;
 }
 
 /** Swipe result from accessibility service */

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -205,16 +205,16 @@ export interface IOSCtrlProxy extends CtrlProxyClient {
 
   requestSwipe(
     x1: number, y1: number, x2: number, y2: number,
-    duration?: number, timeoutMs?: number, perf?: PerformanceTracker
+    duration?: number, timeoutMs?: number, perf?: PerformanceTracker, frameContext?: string
   ): Promise<CtrlProxySwipeResult>;
 
   requestTapCoordinates(
-    x: number, y: number, duration?: number, timeoutMs?: number, perf?: PerformanceTracker
+    x: number, y: number, duration?: number, timeoutMs?: number, perf?: PerformanceTracker, frameContext?: string
   ): Promise<CtrlProxyTapResult>;
 
   requestDrag(
     x1: number, y1: number, x2: number, y2: number,
-    pressDurationMs: number, dragDurationMs: number, holdDurationMs: number, timeoutMs: number
+    pressDurationMs: number, dragDurationMs: number, holdDurationMs: number, timeoutMs: number, frameContext?: string
   ): Promise<CtrlProxyDragResult>;
 
   requestPinch(
@@ -1461,7 +1461,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       if (requestId) {
         const suppressObservationStreamPush = this.consumeHierarchyObservationStreamSuppression(requestId);
         if (!suppressObservationStreamPush) {
-          this.pushHierarchyToObservationStream(converted, message.data as XCTestHierarchy);
+          this.pushHierarchyToObservationStream(converted, message.data as XCTestHierarchy, message.frameContext);
         } else {
           logger.debug("[IOSCtrlProxyClient] Suppressed hierarchy observation stream push for explicit initial-frame request");
         }
@@ -1495,7 +1495,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
 
       // Convert and push to observation stream for IDE plugins
       const viewHierarchyResult = this.convertToViewHierarchyResult(message.data);
-      this.pushHierarchyToObservationStream(viewHierarchyResult, message.data as XCTestHierarchy);
+      this.pushHierarchyToObservationStream(viewHierarchyResult, message.data as XCTestHierarchy, message.frameContext);
 
       // Start screenshot backoff sequence for real-time screenshot streaming
       this.startScreenshotBackoff();
@@ -1705,23 +1705,23 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   // ===========================================================================
 
   async requestTapCoordinates(
-    x: number, y: number, duration: number = 0, timeoutMs: number = 5000, perf?: PerformanceTracker
+    x: number, y: number, duration: number = 0, timeoutMs: number = 5000, perf?: PerformanceTracker, frameContext?: string
   ): Promise<CtrlProxyTapResult> {
-    return this.gestures.requestTapCoordinates(x, y, duration, timeoutMs, perf);
+    return this.gestures.requestTapCoordinates(x, y, duration, timeoutMs, perf, frameContext);
   }
 
   async requestSwipe(
     x1: number, y1: number, x2: number, y2: number,
-    duration: number = 300, timeoutMs: number = 5000, perf?: PerformanceTracker
+    duration: number = 300, timeoutMs: number = 5000, perf?: PerformanceTracker, frameContext?: string
   ): Promise<CtrlProxySwipeResult> {
-    return this.gestures.requestSwipe(x1, y1, x2, y2, duration, timeoutMs, perf);
+    return this.gestures.requestSwipe(x1, y1, x2, y2, duration, timeoutMs, perf, frameContext);
   }
 
   async requestDrag(
     x1: number, y1: number, x2: number, y2: number,
-    pressDurationMs: number, dragDurationMs: number, holdDurationMs: number, timeoutMs: number
+    pressDurationMs: number, dragDurationMs: number, holdDurationMs: number, timeoutMs: number, frameContext?: string
   ): Promise<CtrlProxyDragResult> {
-    return this.gestures.requestDrag(x1, y1, x2, y2, pressDurationMs, dragDurationMs, holdDurationMs, timeoutMs);
+    return this.gestures.requestDrag(x1, y1, x2, y2, pressDurationMs, dragDurationMs, holdDurationMs, timeoutMs, frameContext);
   }
 
   async requestPinch(
@@ -2051,7 +2051,8 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
    */
   private pushHierarchyToObservationStream(
     hierarchy: ViewHierarchyResult,
-    source: XCTestHierarchy | undefined
+    source: XCTestHierarchy | undefined,
+    frameContext?: string,
   ): void {
     const server = getDeviceDataStreamServer();
     if (!server) {
@@ -2068,7 +2069,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       // all on the first response). A resolution-changing response would then associate its capture
       // id with the old dimensions and screenshots could not pair until another hierarchy arrived.
       this.updateScreenGeometryFrom(source);
-      const captureSequence = server.pushHierarchyUpdate(this.device.deviceId, hierarchy);
+      const captureSequence = server.pushHierarchyUpdate(this.device.deviceId, hierarchy, frameContext);
       // Record the identity the daemon assigned, so screenshot requests initiated from here on are
       // bound to it. A null return (no subscribers), a throw, or a missing server all leave the
       // geometry untracked, and the daemon then omits the identity so a control client fails closed.
@@ -2089,7 +2090,8 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     screenHeight: number,
     metadata: ScreenshotMetadata = IOS_CTRLPROXY_SCREENSHOT_METADATA,
     captureSequence?: number,
-    coordinateSpace?: CoordinateSpace
+    coordinateSpace?: CoordinateSpace,
+    frameContext?: string,
   ): void {
     const server = getDeviceDataStreamServer();
     if (!server) {
@@ -2106,6 +2108,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       server.pushScreenshotUpdate(this.device.deviceId, screenshotBase64, screenWidth, screenHeight, metadata, {
         captureSequence,
         ...(coordinateSpace ? { coordinateSpace } : {}),
+        frameContext,
       });
     } catch (error) {
       logger.debug(`[IOSCtrlProxyClient] Failed to push screenshot to observation stream: ${error}`);
@@ -2154,7 +2157,8 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
             screenHeight,
             result,
             binding?.captureSequence,
-            binding?.coordinateSpace
+            binding?.coordinateSpace,
+            result.frameContext
           );
         },
         {
@@ -2194,6 +2198,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
         success: true,
         data: result.data,
         captureBinding,
+        frameContext: result.frameContext,
         ...metadataForScreenshotFormat(IOS_CTRLPROXY_SCREENSHOT_METADATA, result.format),
       };
     } catch (error) {

--- a/src/features/observe/ios/decodeCtrlProxyMessage.ts
+++ b/src/features/observe/ios/decodeCtrlProxyMessage.ts
@@ -50,6 +50,7 @@ export function decodeCtrlProxyMessage(message: WebSocketMessage): DecodedCtrlPr
       result = {
         hierarchy: message.data,
         perfTiming: message.perfTiming,
+        frameContext: message.frameContext,
       };
       break;
 
@@ -59,6 +60,7 @@ export function decodeCtrlProxyMessage(message: WebSocketMessage): DecodedCtrlPr
         data: message.data,
         format: message.format ?? "png",
         timestamp: message.timestamp,
+        frameContext: message.frameContext,
       };
       break;
 

--- a/src/features/observe/ios/types.ts
+++ b/src/features/observe/ios/types.ts
@@ -143,6 +143,8 @@ export interface WebSocketMessage {
   // synthesis, honors center) or "element-anchored" (public fallback, center-less).
   // See issue #2910.
   pinchPath?: string;
+  /** Opaque device-authored identity for the hierarchy/pixels in this message. */
+  frameContext?: string;
 }
 
 /**
@@ -154,6 +156,7 @@ export interface CtrlProxyScreenshotResult {
   format?: string;
   timestamp?: number;
   error?: string;
+  frameContext?: string;
 }
 
 /** Swipe result from CtrlProxy iOS */

--- a/src/features/observe/shared/SharedGestureDelegate.ts
+++ b/src/features/observe/shared/SharedGestureDelegate.ts
@@ -41,13 +41,14 @@ export class SharedGestureDelegate {
     y: number,
     duration: number = 0,
     timeoutMs: number = 5000,
-    perf?: PerformanceTracker
+    perf?: PerformanceTracker,
+    frameContext?: string,
   ): Promise<BaseResult> {
     return sendCommand<BaseResult>(this.context, {
       idPrefix: "tap",
       responseType: "tap_coordinates",
       messageType: "request_tap_coordinates",
-      params: { x: this.coord(x), y: this.coord(y), duration },
+      params: { x: this.coord(x), y: this.coord(y), duration, frameContext },
       timeoutMs,
       perf,
       errorLabel: "Tap",
@@ -61,7 +62,8 @@ export class SharedGestureDelegate {
     y2: number,
     duration: number = 300,
     timeoutMs: number = 5000,
-    perf?: PerformanceTracker
+    perf?: PerformanceTracker,
+    frameContext?: string,
   ): Promise<GestureTimingResult> {
     return sendCommand<GestureTimingResult>(this.context, {
       idPrefix: "swipe",
@@ -73,6 +75,7 @@ export class SharedGestureDelegate {
         x2: this.coord(x2),
         y2: this.coord(y2),
         duration,
+        frameContext,
       },
       timeoutMs,
       perf,
@@ -88,7 +91,8 @@ export class SharedGestureDelegate {
     pressDurationMs: number,
     dragDurationMs: number,
     holdDurationMs: number,
-    timeoutMs: number
+    timeoutMs: number,
+    frameContext?: string,
   ): Promise<GestureTimingResult> {
     return sendCommand<GestureTimingResult>(this.context, {
       idPrefix: "drag",
@@ -102,6 +106,7 @@ export class SharedGestureDelegate {
         pressDurationMs,
         dragDurationMs,
         holdDurationMs,
+        frameContext,
       },
       timeoutMs,
       errorLabel: "Drag",

--- a/test/bats/navigation-graph-sdk-event-integration.bats
+++ b/test/bats/navigation-graph-sdk-event-integration.bats
@@ -45,7 +45,7 @@ if [ "$1" = "--cli" ] && [ "$2" = "doctor" ]; then
   printf "{\"ios\":{\"checks\":[]}}\\n"
   exit 0
 fi
-if [ "$1" = "--debug" ] && [ "$2" = "--cli" ] && [ "$3" = "getNavigationGraph" ]; then
+if [ "$1" = "--debug" ] && [ "$2" = "--cli" ] && [ "$3" = "--session-uuid" ] && [ "$5" = "getNavigationGraph" ]; then
   attempts=0
   [ -f "$GRAPH_ATTEMPTS_FILE" ] && attempts="$(cat "$GRAPH_ATTEMPTS_FILE")"
   attempts=$((attempts + 1))

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -80,6 +80,18 @@ describe("DeviceDataStreamSocketServer", () => {
     expect(server.getCurrentFrameContext("device-1")).toBe("frame-A");
   });
 
+  it("clears a device frame context when a hierarchy has no proven context", () => {
+    const hierarchy = {
+      updatedAt: 123,
+      packageName: "com.example.app",
+      hierarchy: { text: "Home" },
+    } as any;
+    server.pushHierarchyUpdate("device-1", hierarchy, "frame-A");
+    server.pushHierarchyUpdate("device-1", hierarchy);
+
+    expect(server.getCurrentFrameContext("device-1")).toBeUndefined();
+  });
+
   describe("request_observation", () => {
     const requestedObservation = (deviceId: string): RequestedObservation => ({
       deviceId,

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -70,6 +70,16 @@ describe("DeviceDataStreamSocketServer", () => {
     await server.startFake();
   });
 
+  it("records a device-authored frame context even without an IDE subscriber", () => {
+    server.pushHierarchyUpdate("device-1", {
+      updatedAt: 123,
+      packageName: "com.example.app",
+      hierarchy: { text: "Home" },
+    } as any, "frame-A");
+
+    expect(server.getCurrentFrameContext("device-1")).toBe("frame-A");
+  });
+
   describe("request_observation", () => {
     const requestedObservation = (deviceId: string): RequestedObservation => ({
       deviceId,
@@ -593,6 +603,13 @@ describe("DeviceDataStreamSocketServer", () => {
       const messages = socket.getWrittenMessages<any>();
       const hierarchyMessages = messages.filter(m => m.type === "hierarchy_update");
       expect(hierarchyMessages[hierarchyMessages.length - 1].hierarchyDiff.hasBaseline).toBe(false);
+    });
+
+    it("forgets a device frame context when the connection is lost", () => {
+      server.pushHierarchyUpdate("device-1", frame("a"), "frame-A");
+      server.onDeviceConnectionLost("device-1");
+
+      expect(server.getCurrentFrameContext("device-1")).toBeUndefined();
     });
 
     it("stamps a monotonic capture identity on each hierarchy and echoes it on matching screenshots", () => {

--- a/test/daemon/socketServerInputTap.test.ts
+++ b/test/daemon/socketServerInputTap.test.ts
@@ -110,6 +110,28 @@ describe("UnixSocketServer input/tap", () => {
     expect(requestTapCoordinates).toHaveBeenCalledWith(20, 30, undefined, 30_000);
   });
 
+  test("rejects an Android frameContext without a matching device observation", async () => {
+    const requestTapCoordinates = mock(async () => ({ success: true }));
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      requestTapCoordinates,
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/tap", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      x: 12.5,
+      y: 34.25,
+      frameContext: "screen-A",
+    });
+
+    expect(response.success).toBe(false);
+    expect(response.error).toContain("stale or unavailable");
+    expect(requestTapCoordinates).not.toHaveBeenCalled();
+  });
+
   test("iOS tap: a confirmed-legacy device probes only ONCE across consecutive taps (#4549 D)", async () => {
     const requestTapCoordinates = mock(async () => ({ success: true }));
     const fetchHierarchy = mock(async () => ({ hierarchy: {} })); // success, no metadata => legacy
@@ -275,6 +297,22 @@ describe("UnixSocketServer input/tap", () => {
     expect(fetchHierarchy).toHaveBeenCalledTimes(1);
     // 600/3 = 200, 900/3 = 300 — NOT dispatched as 600/900 points (which would tap at 1/3 scale).
     expect(requestTapCoordinates).toHaveBeenCalledWith(200, 300, undefined, 30_000);
+  });
+
+  test("rejects an iOS frameContext without a matching device observation", async () => {
+    const requestTapCoordinates = mock(async () => ({ success: true }));
+    IOSCtrlProxyClient.getInstance = mock(() => ({ requestTapCoordinates })) as unknown as typeof IOSCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([iosDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/tap", {
+      platform: "ios", deviceId: "ios-sim-1", x: 20, y: 30, frameContext: "7",
+    });
+
+    expect(response.success).toBe(false);
+    expect(response.error).toContain("stale or unavailable");
+    expect(requestTapCoordinates).not.toHaveBeenCalled();
   });
 
   test("uses the socket autolock device when deviceId is omitted", async () => {
@@ -476,5 +514,17 @@ describe("UnixSocketServer input/tap", () => {
       y: 10,
       duration: 200,
     });
+  });
+
+  test("accepts optional frameContext on every non-pointer input contract", () => {
+    const target = server as unknown as {
+      parseInputTypeTextParams(value: unknown): { frameContext?: string };
+      parseInputPressButtonParams(value: unknown): { frameContext?: string };
+      parseInputKeyParams(value: unknown): { frameContext?: string };
+    };
+
+    expect(target.parseInputTypeTextParams({ platform: "android", text: "x", frameContext: "frame-A" }).frameContext).toBe("frame-A");
+    expect(target.parseInputPressButtonParams({ platform: "android", button: "home", frameContext: "frame-A" }).frameContext).toBe("frame-A");
+    expect(target.parseInputKeyParams({ platform: "android", key: "enter", frameContext: "frame-A" }).frameContext).toBe("frame-A");
   });
 });

--- a/test/scripts/xcodegenDriftCheck.test.ts
+++ b/test/scripts/xcodegenDriftCheck.test.ts
@@ -227,7 +227,7 @@ describe("xcodegen drift check", () => {
 
     expectExitStatus(result, 1);
     expect(result.stdout + result.stderr).toContain("XcodeGen project files are out of date");
-  });
+  }, 15_000);
 
   test("ctrl-proxy scope fails when the regenerated CtrlProxy project is untracked after deletion", () => {
     const repoDir = createTempRepo();
@@ -247,7 +247,7 @@ describe("xcodegen drift check", () => {
     expectExitStatus(result, 1);
     expect(result.stdout + result.stderr).toContain("XcodeGen project files are out of date");
     expect(result.stdout + result.stderr).toContain("?? ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj");
-  });
+  }, 15_000);
 
   test("ctrl-proxy scope refuses to generate with a skewed XcodeGen version", () => {
     // Regression guard for #3975: generating with a version other than the pin


### PR DESCRIPTION
## Summary

Implements the device-origin frame-context protocol for [issue #4505](https://github.com/kaeawc/auto-mobile/issues/4505).

- Android and iOS CtrlProxy observations attach an opaque frame context to hierarchy and screenshot frames.
- All Unix-socket `input/*` contracts accept the optional value and reject stale or unavailable contexts before dispatch.
- iOS validates context-bearing gestures from a stable semantic hierarchy fingerprint; Android validates them against its accessibility generation.
- The observation-stream and third-party client contracts now document pairing and echoing the value. Contexts are cleared on device disconnect.

## Why

The daemon previously had no durable way to reject a click aimed at pixels captured after a same-size UI transition. The device now vouches for the hierarchy state associated with the frame, allowing clients to turn a potential mis-tap into a re-observe-and-retry error.

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run turbo:validate`
- `bun test test/daemon/socketServerInputTap.test.ts test/daemon/deviceDataStreamSocketServer.test.ts`
- `(cd android && ./gradlew :protocol:compileKotlin :control-proxy:compileDebugKotlin)`
- `(cd ios/control-proxy && swift test)` — 426 tests

## Release follow-through

This changes both CtrlProxy runners. Before this is considered ready to merge, the signed Android APK and iOS IPA must be re-cut through the release workflow and their generated checksums recorded; the daemon otherwise downloads the previously pinned runners.
