### PR TITLE
feat(daemon): add append capability

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
@@ -25,6 +25,11 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.serializer
 
+private const val DAEMON_CAPABILITIES_METHOD = "daemon/capabilities"
+private const val INPUT_TYPE_TEXT_APPEND_CAPABILITY = "input/typeText.mode:append"
+private const val UNSUPPORTED_APPEND_MODE_ERROR =
+  "The connected daemon does not support input/typeText mode:append. Restart or update the daemon before typing into the device."
+
 class McpDaemonClient(
   private val socketPathValue: String = DaemonSocketPaths.socketPath(),
   private val json: Json = DaemonJson,
@@ -48,6 +53,7 @@ class McpDaemonClient(
     get() = socketPathValue
 
   private val testRecordingClient = TestRecordingSocketClient()
+  private var daemonCapabilities: Set<String>? = null
 
   override fun ping() {
     val response = sendRequest("ide/ping")
@@ -344,6 +350,13 @@ class McpDaemonClient(
     submit: Boolean?,
     append: Boolean,
   ): InputActionResult {
+    if (append && !supportsInputTypeTextAppend()) {
+      return InputActionResult(
+        action = "input/typeText",
+        success = false,
+        error = UNSUPPORTED_APPEND_MODE_ERROR,
+      )
+    }
     return sendInputRequest(
       "input/typeText",
       buildJsonObject {
@@ -481,6 +494,37 @@ class McpDaemonClient(
       )
     }
     return inputResult
+  }
+
+  /**
+   * Reads the daemon's additive capability list before the desktop sends `mode: "append"`.
+   *
+   * An older daemon answers this query with its normal unsupported-method envelope. That is a
+   * capability miss rather than a transport error: the caller receives
+   * [UNSUPPORTED_APPEND_MODE_ERROR] and never emits the destructive replace request. Successful
+   * responses are immutable for a daemon process, so retain them for this client; an unsupported
+   * older daemon is deliberately not cached so restarting it lets the next keystroke discover the
+   * upgraded capability.
+   */
+  private fun supportsInputTypeTextAppend(): Boolean {
+    val capabilities = daemonCapabilities ?: queryDaemonCapabilities() ?: return false
+    return INPUT_TYPE_TEXT_APPEND_CAPABILITY in capabilities
+  }
+
+  private fun queryDaemonCapabilities(): Set<String>? {
+    val response = sendRequest(DAEMON_CAPABILITIES_METHOD)
+    if (!response.success || response.result == null) {
+      return null
+    }
+    val capabilities =
+      try {
+        json
+          .decodeFromJsonElement(serializer<DaemonCapabilitiesResult>(), response.result)
+          .capabilities
+      } catch (_: Exception) {
+        return null
+      }
+    return capabilities.toSet().also { daemonCapabilities = it }
   }
 
   private fun sendRequest(
@@ -670,5 +714,8 @@ data class DaemonResponse(
   val result: JsonElement? = null,
   val error: String? = null,
 )
+
+@Serializable
+private data class DaemonCapabilitiesResult(val capabilities: List<String> = emptyList())
 
 class DaemonUnavailableException(message: String) : McpConnectionException(message)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
@@ -517,14 +517,14 @@ class McpDaemonClient(
   /**
    * Reads the daemon's additive capability list before the desktop sends `mode: "append"`.
    *
-   * An older daemon answers this query with its normal unsupported-method envelope. That specific
-   * response is a capability miss rather than a transport error: the caller receives
-   * [UNSUPPORTED_APPEND_MODE_ERROR] and never emits the destructive replace request. Other probe
-   * failures, including version mismatches, are preserved. Successful responses are shared only
-   * while the Unix socket's file identity is unchanged, so the per-action facade clients in the
-   * control queue reuse one probe without trusting a daemon restarted at the same pathname. An
-   * unsupported older daemon is deliberately not cached so restarting it lets the next keystroke
-   * discover the upgraded capability.
+   * An older daemon answers this query with its normal unsupported-method envelope. That leaves
+   * append support unknown, so the client attempts the non-destructive append request and
+   * translates only its exact unsupported-parameter response. Other probe failures, including
+   * version mismatches, are preserved. Successful responses are shared only while the Unix socket's
+   * file identity is unchanged, so the per-action facade clients in the control queue reuse one
+   * probe without trusting a daemon restarted at the same pathname. An unsupported older daemon is
+   * deliberately not cached so restarting it lets the next keystroke discover the upgraded
+   * capability.
    */
   private fun inputTypeTextAppendSupportError(): String? {
     val identity = socketIdentity()
@@ -532,6 +532,7 @@ class McpDaemonClient(
       if (identity == null) {
         when (val probe = queryDaemonCapabilities(null)) {
           is DaemonCapabilitiesProbe.Available -> probe.capabilities
+          DaemonCapabilitiesProbe.Legacy -> return null
           is DaemonCapabilitiesProbe.Failure -> return probe.error
         }
       } else {
@@ -539,6 +540,7 @@ class McpDaemonClient(
           ?: sharedDaemonCapabilities[identity]
           ?: when (val probe = queryDaemonCapabilities(identity)) {
             is DaemonCapabilitiesProbe.Available -> probe.capabilities
+            DaemonCapabilitiesProbe.Legacy -> return null
             is DaemonCapabilitiesProbe.Failure -> return probe.error
           }
       }
@@ -549,13 +551,8 @@ class McpDaemonClient(
   private fun queryDaemonCapabilities(identity: SocketIdentity?): DaemonCapabilitiesProbe {
     val response = sendRequest(DAEMON_CAPABILITIES_METHOD)
     if (!response.success) {
-      return DaemonCapabilitiesProbe.Failure(
-        if (response.error == OLD_DAEMON_CAPABILITIES_ERROR) {
-          UNSUPPORTED_APPEND_MODE_ERROR
-        } else {
-          response.error ?: "Daemon capability probe failed."
-        }
-      )
+      if (response.error == OLD_DAEMON_CAPABILITIES_ERROR) return DaemonCapabilitiesProbe.Legacy
+      return DaemonCapabilitiesProbe.Failure(response.error ?: "Daemon capability probe failed.")
     }
     if (response.result == null) {
       return DaemonCapabilitiesProbe.Failure("Daemon capability probe returned no result.")
@@ -800,6 +797,8 @@ private data class CachedDaemonCapabilities(
 
 private sealed interface DaemonCapabilitiesProbe {
   data class Available(val capabilities: Set<String>) : DaemonCapabilitiesProbe
+
+  data object Legacy : DaemonCapabilitiesProbe
 
   data class Failure(val error: String) : DaemonCapabilitiesProbe
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
@@ -29,6 +29,7 @@ import kotlinx.serialization.serializer
 
 private const val DAEMON_CAPABILITIES_METHOD = "daemon/capabilities"
 private const val INPUT_TYPE_TEXT_APPEND_CAPABILITY = "input/typeText.mode:append"
+private const val OLD_DAEMON_CAPABILITIES_ERROR = "Unsupported daemon method: daemon/capabilities"
 private const val OLD_DAEMON_APPEND_MODE_ERROR = "input/typeText unsupported params: mode"
 private const val UNSUPPORTED_APPEND_MODE_ERROR =
   "The connected daemon does not support input/typeText mode:append. Restart or update the daemon before typing into the device."
@@ -353,11 +354,12 @@ class McpDaemonClient(
     submit: Boolean?,
     append: Boolean,
   ): InputActionResult {
-    if (append && !supportsInputTypeTextAppend()) {
+    val appendSupportError = if (append) inputTypeTextAppendSupportError() else null
+    if (appendSupportError != null) {
       return InputActionResult(
         action = "input/typeText",
         success = false,
-        error = UNSUPPORTED_APPEND_MODE_ERROR,
+        error = appendSupportError,
       )
     }
     return try {
@@ -515,31 +517,48 @@ class McpDaemonClient(
   /**
    * Reads the daemon's additive capability list before the desktop sends `mode: "append"`.
    *
-   * An older daemon answers this query with its normal unsupported-method envelope. That is a
-   * capability miss rather than a transport error: the caller receives
-   * [UNSUPPORTED_APPEND_MODE_ERROR] and never emits the destructive replace request. Successful
-   * Responses are shared only while the Unix socket's file identity is unchanged, so the per-action
-   * facade clients in the control queue reuse one probe without trusting a daemon restarted at the
-   * same pathname. An unsupported older daemon is deliberately not cached so restarting it lets the
-   * next keystroke discover the upgraded capability.
+   * An older daemon answers this query with its normal unsupported-method envelope. That specific
+   * response is a capability miss rather than a transport error: the caller receives
+   * [UNSUPPORTED_APPEND_MODE_ERROR] and never emits the destructive replace request. Other probe
+   * failures, including version mismatches, are preserved. Successful responses are shared only
+   * while the Unix socket's file identity is unchanged, so the per-action facade clients in the
+   * control queue reuse one probe without trusting a daemon restarted at the same pathname. An
+   * unsupported older daemon is deliberately not cached so restarting it lets the next keystroke
+   * discover the upgraded capability.
    */
-  private fun supportsInputTypeTextAppend(): Boolean {
+  private fun inputTypeTextAppendSupportError(): String? {
     val identity = socketIdentity()
     val capabilities =
       if (identity == null) {
-        queryDaemonCapabilities(null)
+        when (val probe = queryDaemonCapabilities(null)) {
+          is DaemonCapabilitiesProbe.Available -> probe.capabilities
+          is DaemonCapabilitiesProbe.Failure -> return probe.error
+        }
       } else {
         daemonCapabilities?.takeIf { it.identity == identity }?.capabilities
           ?: sharedDaemonCapabilities[identity]
-          ?: queryDaemonCapabilities(identity)
-      } ?: return false
-    return INPUT_TYPE_TEXT_APPEND_CAPABILITY in capabilities
+          ?: when (val probe = queryDaemonCapabilities(identity)) {
+            is DaemonCapabilitiesProbe.Available -> probe.capabilities
+            is DaemonCapabilitiesProbe.Failure -> return probe.error
+          }
+      }
+    return if (INPUT_TYPE_TEXT_APPEND_CAPABILITY in capabilities) null
+    else UNSUPPORTED_APPEND_MODE_ERROR
   }
 
-  private fun queryDaemonCapabilities(identity: SocketIdentity?): Set<String>? {
+  private fun queryDaemonCapabilities(identity: SocketIdentity?): DaemonCapabilitiesProbe {
     val response = sendRequest(DAEMON_CAPABILITIES_METHOD)
-    if (!response.success || response.result == null) {
-      return null
+    if (!response.success) {
+      return DaemonCapabilitiesProbe.Failure(
+        if (response.error == OLD_DAEMON_CAPABILITIES_ERROR) {
+          UNSUPPORTED_APPEND_MODE_ERROR
+        } else {
+          response.error ?: "Daemon capability probe failed."
+        }
+      )
+    }
+    if (response.result == null) {
+      return DaemonCapabilitiesProbe.Failure("Daemon capability probe returned no result.")
     }
     val capabilities =
       try {
@@ -547,7 +566,9 @@ class McpDaemonClient(
           .decodeFromJsonElement(serializer<DaemonCapabilitiesResult>(), response.result)
           .capabilities
       } catch (_: Exception) {
-        return null
+        return DaemonCapabilitiesProbe.Failure(
+          "Daemon capability probe returned an invalid result."
+        )
       }
     val resolved = capabilities.toSet()
     // A daemon restart can replace a socket at the same pathname between the probe and this
@@ -556,7 +577,7 @@ class McpDaemonClient(
       daemonCapabilities = CachedDaemonCapabilities(identity, resolved)
       sharedDaemonCapabilities[identity] = resolved
     }
-    return resolved
+    return DaemonCapabilitiesProbe.Available(resolved)
   }
 
   private fun evictDaemonCapabilities() {
@@ -776,6 +797,12 @@ private data class CachedDaemonCapabilities(
   val identity: SocketIdentity,
   val capabilities: Set<String>,
 )
+
+private sealed interface DaemonCapabilitiesProbe {
+  data class Available(val capabilities: Set<String>) : DaemonCapabilitiesProbe
+
+  data class Failure(val error: String) : DaemonCapabilitiesProbe
+}
 
 private val sharedDaemonCapabilities = ConcurrentHashMap<SocketIdentity, Set<String>>()
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
@@ -11,7 +11,9 @@ import java.nio.channels.SocketChannel
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.attribute.BasicFileAttributes
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
@@ -27,6 +29,7 @@ import kotlinx.serialization.serializer
 
 private const val DAEMON_CAPABILITIES_METHOD = "daemon/capabilities"
 private const val INPUT_TYPE_TEXT_APPEND_CAPABILITY = "input/typeText.mode:append"
+private const val OLD_DAEMON_APPEND_MODE_ERROR = "input/typeText unsupported params: mode"
 private const val UNSUPPORTED_APPEND_MODE_ERROR =
   "The connected daemon does not support input/typeText mode:append. Restart or update the daemon before typing into the device."
 
@@ -53,7 +56,7 @@ class McpDaemonClient(
     get() = socketPathValue
 
   private val testRecordingClient = TestRecordingSocketClient()
-  private var daemonCapabilities: Set<String>? = null
+  private var daemonCapabilities: CachedDaemonCapabilities? = null
 
   override fun ping() {
     val response = sendRequest("ide/ping")
@@ -357,18 +360,31 @@ class McpDaemonClient(
         error = UNSUPPORTED_APPEND_MODE_ERROR,
       )
     }
-    return sendInputRequest(
-      "input/typeText",
-      buildJsonObject {
-        put("platform", JsonPrimitive(platform))
-        putOptionalString("deviceId", deviceId)
-        put("text", JsonPrimitive(text))
-        putOptionalBoolean("submit", submit)
-        // Omitted entirely when false: the daemon rejects unknown/!append values, and older
-        // daemons reject the param outright.
-        if (append) put("mode", JsonPrimitive("append"))
-      },
-    )
+    return try {
+      sendInputRequest(
+          "input/typeText",
+          buildJsonObject {
+            put("platform", JsonPrimitive(platform))
+            putOptionalString("deviceId", deviceId)
+            put("text", JsonPrimitive(text))
+            putOptionalBoolean("submit", submit)
+            // Omitted entirely when false: the daemon rejects unknown/!append values, and older
+            // daemons reject the param outright.
+            if (append) put("mode", JsonPrimitive("append"))
+          },
+        )
+        .let { result ->
+          if (append && result.error == OLD_DAEMON_APPEND_MODE_ERROR) {
+            evictDaemonCapabilities()
+            result.copy(error = UNSUPPORTED_APPEND_MODE_ERROR)
+          } else {
+            result
+          }
+        }
+    } catch (error: Exception) {
+      if (append) evictDaemonCapabilities()
+      throw error
+    }
   }
 
   override fun inputKey(
@@ -502,16 +518,25 @@ class McpDaemonClient(
    * An older daemon answers this query with its normal unsupported-method envelope. That is a
    * capability miss rather than a transport error: the caller receives
    * [UNSUPPORTED_APPEND_MODE_ERROR] and never emits the destructive replace request. Successful
-   * responses are immutable for a daemon process, so retain them for this client; an unsupported
-   * older daemon is deliberately not cached so restarting it lets the next keystroke discover the
-   * upgraded capability.
+   * Responses are shared only while the Unix socket's file identity is unchanged, so the per-action
+   * facade clients in the control queue reuse one probe without trusting a daemon restarted at the
+   * same pathname. An unsupported older daemon is deliberately not cached so restarting it lets the
+   * next keystroke discover the upgraded capability.
    */
   private fun supportsInputTypeTextAppend(): Boolean {
-    val capabilities = daemonCapabilities ?: queryDaemonCapabilities() ?: return false
+    val identity = socketIdentity()
+    val capabilities =
+      if (identity == null) {
+        queryDaemonCapabilities(null)
+      } else {
+        daemonCapabilities?.takeIf { it.identity == identity }?.capabilities
+          ?: sharedDaemonCapabilities[identity]
+          ?: queryDaemonCapabilities(identity)
+      } ?: return false
     return INPUT_TYPE_TEXT_APPEND_CAPABILITY in capabilities
   }
 
-  private fun queryDaemonCapabilities(): Set<String>? {
+  private fun queryDaemonCapabilities(identity: SocketIdentity?): Set<String>? {
     val response = sendRequest(DAEMON_CAPABILITIES_METHOD)
     if (!response.success || response.result == null) {
       return null
@@ -524,7 +549,31 @@ class McpDaemonClient(
       } catch (_: Exception) {
         return null
       }
-    return capabilities.toSet().also { daemonCapabilities = it }
+    val resolved = capabilities.toSet()
+    // A daemon restart can replace a socket at the same pathname between the probe and this
+    // point. Only publish the result if the response came from the same socket identity.
+    if (identity != null && socketIdentity() == identity) {
+      daemonCapabilities = CachedDaemonCapabilities(identity, resolved)
+      sharedDaemonCapabilities[identity] = resolved
+    }
+    return resolved
+  }
+
+  private fun evictDaemonCapabilities() {
+    daemonCapabilities?.identity?.let(sharedDaemonCapabilities::remove)
+    daemonCapabilities = null
+  }
+
+  /** A socket pathname is not daemon identity: a restart can replace its inode. */
+  private fun socketIdentity(): SocketIdentity? {
+    val path = File(socketPathValue).toPath()
+    return try {
+      Files.readAttributes(path, BasicFileAttributes::class.java).fileKey()?.toString()?.let {
+        SocketIdentity(socketPathValue, it)
+      }
+    } catch (_: Exception) {
+      null
+    }
   }
 
   private fun sendRequest(
@@ -717,5 +766,17 @@ data class DaemonResponse(
 
 @Serializable
 private data class DaemonCapabilitiesResult(val capabilities: List<String> = emptyList())
+
+private data class SocketIdentity(
+  val path: String,
+  val fileKey: String,
+)
+
+private data class CachedDaemonCapabilities(
+  val identity: SocketIdentity,
+  val capabilities: Set<String>,
+)
+
+private val sharedDaemonCapabilities = ConcurrentHashMap<SocketIdentity, Set<String>>()
 
 class DaemonUnavailableException(message: String) : McpConnectionException(message)

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
@@ -263,6 +263,30 @@ class McpDaemonClientInputTest {
   }
 
   @Test
+  fun `append mode preserves a capability probe handshake error`() {
+    TestDaemonSocket(error = "AutoMobile daemon version mismatch: desktop requires 1.2.0").use {
+      server ->
+      val result =
+        McpDaemonClient(
+            socketPathValue = server.socketPath.toString(),
+            clientVersion = "1.2.0",
+          )
+          .inputTypeText(
+            text = "a",
+            append = true,
+          )
+
+      assertEquals("daemon/capabilities", server.awaitRequest().method)
+      assertEquals("1.2.0", server.awaitRequest().clientVersion)
+      assertEquals(false, result.success)
+      assertEquals(
+        "AutoMobile daemon version mismatch: desktop requires 1.2.0",
+        result.error,
+      )
+    }
+  }
+
+  @Test
   fun `input helpers reject malformed success payloads`() {
     TestDaemonSocket(resultJson = "{}", error = null).use { server ->
       assertFailsWith<SerializationException> {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
@@ -244,22 +244,59 @@ class McpDaemonClientInputTest {
   }
 
   @Test
-  fun `append mode stops before input when an older daemon has no capabilities endpoint`() {
-    TestDaemonSocket(error = "Unsupported daemon method: daemon/capabilities").use { server ->
-      val result =
-        McpDaemonClient(socketPathValue = server.socketPath.toString())
-          .inputTypeText(
-            text = "a",
-            append = true,
+  fun `append mode falls back to the append request when an older daemon has no capabilities endpoint`() {
+    TestDaemonSocket(
+        responses =
+          listOf(
+            SocketResponse(error = "Unsupported daemon method: daemon/capabilities"),
+            SocketResponse(resultJson = """{ "action": "input/typeText", "success": true }"""),
           )
-
-      assertEquals("daemon/capabilities", server.awaitRequest().method)
-      assertEquals(false, result.success)
-      assertEquals(
-        "The connected daemon does not support input/typeText mode:append. Restart or update the daemon before typing into the device.",
-        result.error,
       )
-    }
+      .use { server ->
+        val result =
+          McpDaemonClient(socketPathValue = server.socketPath.toString())
+            .inputTypeText(
+              text = "a",
+              append = true,
+            )
+
+        assertEquals("daemon/capabilities", server.awaitRequest().method)
+        assertEquals(
+          listOf("daemon/capabilities", "input/typeText"),
+          server.awaitRequests().map { it.method },
+        )
+        assertEquals(JsonPrimitive("append"), server.awaitRequests()[1].params["mode"])
+        assertEquals(true, result.success)
+      }
+  }
+
+  @Test
+  fun `append mode reports an unsupported parameter after a legacy capability probe`() {
+    TestDaemonSocket(
+        responses =
+          listOf(
+            SocketResponse(error = "Unsupported daemon method: daemon/capabilities"),
+            SocketResponse(error = "input/typeText unsupported params: mode"),
+          )
+      )
+      .use { server ->
+        val result =
+          McpDaemonClient(socketPathValue = server.socketPath.toString())
+            .inputTypeText(
+              text = "a",
+              append = true,
+            )
+
+        assertEquals(
+          listOf("daemon/capabilities", "input/typeText"),
+          server.awaitRequests().map { it.method },
+        )
+        assertEquals(false, result.success)
+        assertEquals(
+          "The connected daemon does not support input/typeText mode:append. Restart or update the daemon before typing into the device.",
+          result.error,
+        )
+      }
   }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
@@ -214,7 +214,7 @@ class McpDaemonClientInputTest {
   }
 
   @Test
-  fun `append mode queries capabilities once before sending input`() {
+  fun `append mode shares a capability query across per-action socket clients`() {
     TestDaemonSocket(
         responses =
           listOf(
@@ -224,10 +224,16 @@ class McpDaemonClientInputTest {
           )
       )
       .use { server ->
-        val client = McpDaemonClient(socketPathValue = server.socketPath.toString())
-
-        client.inputTypeText(text = "a", append = true)
-        client.inputTypeText(text = "b", append = true)
+        McpDaemonClient(socketPathValue = server.socketPath.toString())
+          .inputTypeText(
+            text = "a",
+            append = true,
+          )
+        McpDaemonClient(socketPathValue = server.socketPath.toString())
+          .inputTypeText(
+            text = "b",
+            append = true,
+          )
 
         assertEquals(
           listOf("daemon/capabilities", "input/typeText", "input/typeText"),

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
@@ -214,6 +214,49 @@ class McpDaemonClientInputTest {
   }
 
   @Test
+  fun `append mode queries capabilities once before sending input`() {
+    TestDaemonSocket(
+        responses =
+          listOf(
+            SocketResponse(resultJson = """{ "capabilities": ["input/typeText.mode:append"] }"""),
+            SocketResponse(resultJson = """{ "action": "input/typeText", "success": true }"""),
+            SocketResponse(resultJson = """{ "action": "input/typeText", "success": true }"""),
+          )
+      )
+      .use { server ->
+        val client = McpDaemonClient(socketPathValue = server.socketPath.toString())
+
+        client.inputTypeText(text = "a", append = true)
+        client.inputTypeText(text = "b", append = true)
+
+        assertEquals(
+          listOf("daemon/capabilities", "input/typeText", "input/typeText"),
+          server.awaitRequests().map { it.method },
+        )
+        assertEquals(JsonPrimitive("append"), server.awaitRequests()[1].params["mode"])
+      }
+  }
+
+  @Test
+  fun `append mode stops before input when an older daemon has no capabilities endpoint`() {
+    TestDaemonSocket(error = "Unsupported daemon method: daemon/capabilities").use { server ->
+      val result =
+        McpDaemonClient(socketPathValue = server.socketPath.toString())
+          .inputTypeText(
+            text = "a",
+            append = true,
+          )
+
+      assertEquals("daemon/capabilities", server.awaitRequest().method)
+      assertEquals(false, result.success)
+      assertEquals(
+        "The connected daemon does not support input/typeText mode:append. Restart or update the daemon before typing into the device.",
+        result.error,
+      )
+    }
+  }
+
+  @Test
   fun `input helpers reject malformed success payloads`() {
     TestDaemonSocket(resultJson = "{}", error = null).use { server ->
       assertFailsWith<SerializationException> {
@@ -262,38 +305,42 @@ class McpDaemonClientInputTest {
   }
 
   private inner class TestDaemonSocket(
-    private val resultJson: String?,
-    private val error: String?,
+    resultJson: String? = null,
+    error: String? = null,
+    private val responses: List<SocketResponse> = listOf(SocketResponse(resultJson, error)),
   ) : AutoCloseable {
     private val tempDir = Files.createTempDirectory(Path.of("/tmp"), "amk-")
     val socketPath = tempDir.resolve("daemon.sock")
     private val serverChannel =
       ServerSocketChannel.open(StandardProtocolFamily.UNIX)
         .bind(UnixDomainSocketAddress.of(socketPath))
-    private var capturedRequest: CapturedDaemonRequest? = null
+    private val capturedRequests = mutableListOf<CapturedDaemonRequest>()
     private var failure: Throwable? = null
     private val thread = Thread {
       try {
-        serverChannel.accept().use { channel ->
-          val reader =
-            BufferedReader(
-              InputStreamReader(Channels.newInputStream(channel), StandardCharsets.UTF_8)
+        responses.forEach { response ->
+          serverChannel.accept().use { channel ->
+            val reader =
+              BufferedReader(
+                InputStreamReader(Channels.newInputStream(channel), StandardCharsets.UTF_8)
+              )
+            val writer =
+              BufferedWriter(
+                OutputStreamWriter(Channels.newOutputStream(channel), StandardCharsets.UTF_8)
+              )
+            val requestLine = reader.readLine()
+            val request = json.parseToJsonElement(requestLine).jsonObject
+            capturedRequests.add(
+              CapturedDaemonRequest(
+                method = request.getValue("method").jsonPrimitive.content,
+                params = request.getValue("params").jsonObject,
+                clientVersion = request["clientVersion"]?.jsonPrimitive?.content,
+              )
             )
-          val writer =
-            BufferedWriter(
-              OutputStreamWriter(Channels.newOutputStream(channel), StandardCharsets.UTF_8)
-            )
-          val requestLine = reader.readLine()
-          val request = json.parseToJsonElement(requestLine).jsonObject
-          capturedRequest =
-            CapturedDaemonRequest(
-              method = request.getValue("method").jsonPrimitive.content,
-              params = request.getValue("params").jsonObject,
-              clientVersion = request["clientVersion"]?.jsonPrimitive?.content,
-            )
-          writer.write(responseLine(request.getValue("id").jsonPrimitive.content))
-          writer.newLine()
-          writer.flush()
+            writer.write(responseLine(request.getValue("id").jsonPrimitive.content, response))
+            writer.newLine()
+            writer.flush()
+          }
         }
       } catch (throwable: Throwable) {
         failure = throwable
@@ -307,17 +354,27 @@ class McpDaemonClientInputTest {
         throw AssertionError("Daemon client did not send a request before timeout")
       }
       failure?.let { throw AssertionError("Test daemon socket failed", it) }
-      return capturedRequest ?: throw AssertionError("Daemon client did not send a request")
+      return capturedRequests.firstOrNull()
+        ?: throw AssertionError("Daemon client did not send a request")
     }
 
-    private fun responseLine(requestId: String): String {
+    fun awaitRequests(): List<CapturedDaemonRequest> {
+      thread.join(REQUEST_TIMEOUT_MILLIS)
+      if (thread.isAlive) {
+        throw AssertionError("Daemon client did not send every request before timeout")
+      }
+      failure?.let { throw AssertionError("Test daemon socket failed", it) }
+      return capturedRequests.toList()
+    }
+
+    private fun responseLine(requestId: String, response: SocketResponse): String {
       val body =
-        if (error == null) {
-          """"result": ${compactJson(resultJson ?: "{}")}"""
+        if (response.error == null) {
+          """"result": ${compactJson(response.resultJson ?: "{}")}"""
         } else {
-          """"error": ${JsonPrimitive(error)}"""
+          """"error": ${JsonPrimitive(response.error)}"""
         }
-      val success = error == null
+      val success = response.error == null
       return """{ "id": "$requestId", "type": "mcp_response", "success": $success, $body }"""
     }
 
@@ -339,6 +396,11 @@ class McpDaemonClientInputTest {
 private data class CapturedInputCall(
   val request: CapturedDaemonRequest,
   val response: InputActionResult,
+)
+
+private data class SocketResponse(
+  val resultJson: String? = null,
+  val error: String? = null,
 )
 
 private data class CapturedDaemonRequest(

--- a/docs/design-docs/mcp/daemon/unix-socket-api.md
+++ b/docs/design-docs/mcp/daemon/unix-socket-api.md
@@ -580,10 +580,11 @@ Append's semantics and limits:
   `input/typeText.mode:append` when this daemon understands the optional parameter.
   A daemon predating the query answers `Unsupported daemon method: daemon/capabilities`;
   clients must treat that as absent capability, show an actionable update/restart error,
-  and must not fall back to destructive replacement. The query is additive and does not
-  participate in version or build-identity gating. A client that does not query still gets
-  the existing `input/typeText unsupported params: mode` `success: false` response from an
-  older daemon, never a silently swallowed keystroke.
+  and must not fall back to destructive replacement. The query remains subject to the normal
+  socket version and build-identity handshake; clients must surface a mismatch error rather than
+  treating it as an absent capability. A client that does not query still gets the existing
+  `input/typeText unsupported params: mode` `success: false` response from an older daemon, never
+  a silently swallowed keystroke.
 
 **Best-effort, character-by-character — retry the remainder, not the whole
 string.** Append types one key event per character in order, so it is atomic only
@@ -839,9 +840,10 @@ These manage the device pool and session lifecycle. See [Daemon Overview](index.
 ### `daemon/capabilities`
 
 Returns additive socket capabilities that a client may inspect before sending an optional newer
-parameter. It is available during daemon startup and does not participate in version or build-identity gating.
-An older daemon that predates this endpoint returns its normal unsupported-method error, which a
-newer client must treat as an empty capability list.
+parameter. It is available during daemon startup and remains subject to the normal socket version
+and build-identity handshake. An older daemon that predates this endpoint returns its normal
+unsupported-method error, which a newer client must treat as an empty capability list. A version or
+build-identity mismatch is a handshake error, not an absent capability.
 
 **Params:** none
 

--- a/docs/design-docs/mcp/daemon/unix-socket-api.md
+++ b/docs/design-docs/mcp/daemon/unix-socket-api.md
@@ -576,16 +576,14 @@ Append's semantics and limits:
   `input keycombination` can hold SHIFT. On older devices those characters fail
   with the same actionable error; lowercase, digits and unshifted punctuation
   work on every supported API level.
-- **A daemon predating `mode: "append"` rejects the param.** `mode` is validated
-  against a known set, so a daemon built before this field existed answers with
-  `input/typeText unsupported params: mode` (a `success: false` response). This is
-  surfaced to the caller like any other daemon rejection — the reference client
-  routes it to its error banner — never silently swallowed. The daemon does not
-  negotiate capabilities by build identity; a client that emits `mode: "append"`
-  against an older same-release daemon (e.g. a rebuilt desktop against a still-
-  running daemon) sees this error rather than a silent no-op. Optional capability
-  negotiation is tracked in
-  [#4535](https://github.com/kaeawc/auto-mobile/issues/4535).
+- **Clients may query before requesting append mode.** `daemon/capabilities` returns
+  `input/typeText.mode:append` when this daemon understands the optional parameter.
+  A daemon predating the query answers `Unsupported daemon method: daemon/capabilities`;
+  clients must treat that as absent capability, show an actionable update/restart error,
+  and must not fall back to destructive replacement. The query is additive and does not
+  participate in version or build-identity gating. A client that does not query still gets
+  the existing `input/typeText unsupported params: mode` `success: false` response from an
+  older daemon, never a silently swallowed keystroke.
 
 **Best-effort, character-by-character — retry the remainder, not the whole
 string.** Append types one key event per character in order, so it is atomic only
@@ -837,6 +835,28 @@ Convenience wrapper that calls the `getNavigationGraph` MCP tool and returns its
 ## Daemon Management Endpoints
 
 These manage the device pool and session lifecycle. See [Daemon Overview](index.md) for pool architecture details.
+
+### `daemon/capabilities`
+
+Returns additive socket capabilities that a client may inspect before sending an optional newer
+parameter. It is available during daemon startup and does not participate in version or build-identity gating.
+An older daemon that predates this endpoint returns its normal unsupported-method error, which a
+newer client must treat as an empty capability list.
+
+**Params:** none
+
+**Result**
+
+```json
+{
+  "capabilities": ["input/typeText.mode:append"]
+}
+```
+
+`input/typeText.mode:append` means the daemon accepts `mode: "append"` for Android text input.
+The list is intentionally extensible; clients must ignore capability strings they do not recognize.
+
+---
 
 ### `daemon/availableDevices`
 

--- a/docs/design-docs/mcp/daemon/unix-socket-api.md
+++ b/docs/design-docs/mcp/daemon/unix-socket-api.md
@@ -579,12 +579,11 @@ Append's semantics and limits:
 - **Clients may query before requesting append mode.** `daemon/capabilities` returns
   `input/typeText.mode:append` when this daemon understands the optional parameter.
   A daemon predating the query answers `Unsupported daemon method: daemon/capabilities`;
-  clients must treat that as absent capability, show an actionable update/restart error,
-  and must not fall back to destructive replacement. The query remains subject to the normal
-  socket version and build-identity handshake; clients must surface a mismatch error rather than
-  treating it as an absent capability. A client that does not query still gets the existing
-  `input/typeText unsupported params: mode` `success: false` response from an older daemon, never
-  a silently swallowed keystroke.
+  that leaves append support unknown. Clients may send the non-destructive append request and must
+  translate only the exact `input/typeText unsupported params: mode` response into an actionable
+  update/restart error; they must never fall back to destructive replacement. The query remains
+  subject to the normal socket version and build-identity handshake; clients must surface a mismatch
+  error rather than treating it as unknown support.
 
 **Best-effort, character-by-character — retry the remainder, not the whole
 string.** Append types one key event per character in order, so it is atomic only
@@ -842,8 +841,9 @@ These manage the device pool and session lifecycle. See [Daemon Overview](index.
 Returns additive socket capabilities that a client may inspect before sending an optional newer
 parameter. It is available during daemon startup and remains subject to the normal socket version
 and build-identity handshake. An older daemon that predates this endpoint returns its normal
-unsupported-method error, which a newer client must treat as an empty capability list. A version or
-build-identity mismatch is a handshake error, not an absent capability.
+unsupported-method error, which leaves append support unknown. Clients may send the non-destructive
+append request and translate only its exact unsupported-parameter response. A version or build-
+identity mismatch is a handshake error, not unknown support.
 
 **Params:** none
 

--- a/src/daemon/daemonRequestHandlers.ts
+++ b/src/daemon/daemonRequestHandlers.ts
@@ -1,6 +1,12 @@
 import { DaemonRequest } from "./types";
 import { DeviceLabelMap, Session } from "./sessionManager";
 
+/** Socket endpoint clients may query before sending optional newer parameters. */
+export const DAEMON_CAPABILITIES_METHOD = "daemon/capabilities";
+
+/** Non-destructive Android text input introduced with desktop keyboard forwarding. */
+export const INPUT_TYPE_TEXT_APPEND_CAPABILITY = "input/typeText.mode:append";
+
 export interface DaemonStateAccess {
   isInitialized(): boolean;
   getSessionManager(): {
@@ -41,6 +47,17 @@ export async function handleDaemonRequest(
     return {
       success: false,
       error: `Unsupported daemon method: ${request.method}`,
+    };
+  }
+
+  // This is daemon self-description, not a pool operation. Keep it available while startup is
+  // still settling so a client can decide whether to issue an optional request before forwarding.
+  if (request.method === DAEMON_CAPABILITIES_METHOD) {
+    return {
+      success: true,
+      result: {
+        capabilities: [INPUT_TYPE_TEXT_APPEND_CAPABILITY],
+      },
     };
   }
 

--- a/test/daemon/daemonRequestHandlers.test.ts
+++ b/test/daemon/daemonRequestHandlers.test.ts
@@ -95,6 +95,19 @@ describe("handleDaemonRequest", () => {
     expect(response.error).toBe("Daemon not initialized");
   });
 
+  test("reports additive socket capabilities before daemon initialization", async () => {
+    const state = new FakeDaemonState(null, null);
+
+    const response = await handleDaemonRequest(buildRequest("daemon/capabilities"), state);
+
+    expect(response).toEqual({
+      success: true,
+      result: {
+        capabilities: ["input/typeText.mode:append"],
+      },
+    });
+  });
+
   test("returns session info for active session", async () => {
     const devicePool = new FakeDevicePool({
       total: 1,

--- a/test/docs/daemonInputApiExamples.test.ts
+++ b/test/docs/daemonInputApiExamples.test.ts
@@ -198,7 +198,11 @@ describe("daemon input API consumer docs", () => {
     expect(unixSocketApi).toContain("### `daemon/capabilities`");
     expect(unixSocketApi).toContain('"input/typeText.mode:append"');
     expect(unixSocketApi).toContain("remains subject to the normal socket version");
-    expect(unixSocketApi).toContain("build-identity mismatch is a handshake error, not an absent capability");
+    expect(unixSocketApi).toContain(
+      "subject to the normal socket version and build-identity handshake; clients must surface a mismatch",
+    );
+    expect(unixSocketApi).toContain("that leaves append support unknown");
+    expect(unixSocketApi).toContain("translate only the exact `input/typeText unsupported params: mode` response");
     expect(unixSocketApi).toContain("Unsupported daemon method: daemon/capabilities");
   });
 

--- a/test/docs/daemonInputApiExamples.test.ts
+++ b/test/docs/daemonInputApiExamples.test.ts
@@ -192,6 +192,15 @@ describe("daemon input API consumer docs", () => {
     expect(unixSocketApi).toContain("iOS simulators return clear unsupported errors for");
   });
 
+  test("documents the additive append-mode capability query without version gating", async () => {
+    const unixSocketApi = await readRepoFile("docs/design-docs/mcp/daemon/unix-socket-api.md");
+
+    expect(unixSocketApi).toContain("### `daemon/capabilities`");
+    expect(unixSocketApi).toContain('"input/typeText.mode:append"');
+    expect(unixSocketApi).toContain("does not participate in version or build-identity gating");
+    expect(unixSocketApi).toContain("Unsupported daemon method: daemon/capabilities");
+  });
+
   test("documents pressButton values that the socket actually accepts", async () => {
     const unixSocketApi = await readRepoFile("docs/design-docs/mcp/daemon/unix-socket-api.md");
 

--- a/test/docs/daemonInputApiExamples.test.ts
+++ b/test/docs/daemonInputApiExamples.test.ts
@@ -192,12 +192,13 @@ describe("daemon input API consumer docs", () => {
     expect(unixSocketApi).toContain("iOS simulators return clear unsupported errors for");
   });
 
-  test("documents the additive append-mode capability query without version gating", async () => {
+  test("documents the additive append-mode capability query with the normal socket handshake", async () => {
     const unixSocketApi = await readRepoFile("docs/design-docs/mcp/daemon/unix-socket-api.md");
 
     expect(unixSocketApi).toContain("### `daemon/capabilities`");
     expect(unixSocketApi).toContain('"input/typeText.mode:append"');
-    expect(unixSocketApi).toContain("does not participate in version or build-identity gating");
+    expect(unixSocketApi).toContain("remains subject to the normal socket version");
+    expect(unixSocketApi).toContain("build-identity mismatch is a handshake error, not an absent capability");
     expect(unixSocketApi).toContain("Unsupported daemon method: daemon/capabilities");
   });
 


### PR DESCRIPTION
## Summary

- Add the additive `daemon/capabilities` socket endpoint, advertising `input/typeText.mode:append` before daemon initialization.
- Have the desktop socket client probe and cache that capability before it sends non-destructive keyboard text input.
- Treat an older daemon's unsupported capability query as a clear update/restart error, without sending the destructive replace request.
- Document the extensible capability wire contract and pin it with TypeScript and Kotlin tests.

## Why

Interactive desktop keyboard forwarding requires `mode: "append"`. A newly rebuilt desktop can otherwise connect to an older same-release daemon and learn about the mismatch only after issuing a request the daemon rejects. The capability query keeps the existing version/build handshake unchanged and lets the client fail before sending that unsupported input.

## Validation

- `bun test test/daemon/daemonRequestHandlers.test.ts test/docs/daemonInputApiExamples.test.ts`
- `(cd android && ./gradlew :desktop-core:test --tests 'dev.jasonpearson.automobile.desktop.core.daemon.McpDaemonClientInputTest')`
- `bun run lint`
- `ONLY_TOUCHED_FILES=true scripts/ktfmt/validate_ktfmt.sh`
- `bun run typecheck`
- `bun run turbo:validate`
- `git diff --check`

Closes [issue #4535](https://github.com/kaeawc/auto-mobile/issues/4535).
