### PR TITLE
fix(media): preserve pull errors during cleanup

### DIFF
--- a/src/features/video/PlatformVideoCaptureBackend.ts
+++ b/src/features/video/PlatformVideoCaptureBackend.ts
@@ -182,18 +182,22 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
         // every stop (issue #4170).
         logger.info(`[VideoCapture] Cleaning up temp file on device`);
         const rmArgs = ["shell", "rm", backendHandle.deviceTempPath];
-        const rmProcess = await adb.spawn(rmArgs);
+        try {
+          const rmProcess = await adb.spawn(rmArgs);
 
-        await new Promise<void>(resolve => {
-          rmProcess.once("exit", () => {
-            logger.info(`[VideoCapture] Temp file cleaned up`);
-            resolve();
+          await new Promise<void>(resolve => {
+            rmProcess.once("exit", () => {
+              logger.info(`[VideoCapture] Temp file cleaned up`);
+              resolve();
+            });
+            rmProcess.once("error", err => {
+              logger.warn(`[VideoCapture] Failed to clean up temp file: ${err}`);
+              resolve();
+            });
           });
-          rmProcess.once("error", err => {
-            logger.warn(`[VideoCapture] Failed to clean up temp file: ${err}`);
-            resolve(); // Don't fail the whole operation if cleanup fails
-          });
-        });
+        } catch (err) {
+          logger.warn(`[VideoCapture] Failed to clean up temp file: ${err}`);
+        }
       }
     } else {
       await this.finalizeIosRecording(backendHandle);

--- a/test/fakes/FakeAdbClient.ts
+++ b/test/fakes/FakeAdbClient.ts
@@ -15,7 +15,10 @@ type FakeAdbClientContract = Pick<
 /** How a spawned command should terminate, keyed by a substring of its argv. */
 interface SpawnBehavior {
   match: string;
-  outcome: { kind: "exit"; code: number } | { kind: "error"; error: Error };
+  outcome:
+    | { kind: "exit"; code: number }
+    | { kind: "error"; error: Error }
+    | { kind: "reject"; error: Error };
 }
 
 /**
@@ -116,7 +119,9 @@ export class FakeAdbClient implements FakeAdbClientContract {
     const proc = new FakeAdbProcess();
     const joined = args.join(" ");
     const behavior = this.spawnBehaviors.find(b => joined.includes(b.match));
-    if (behavior?.outcome.kind === "error") {
+    if (behavior?.outcome.kind === "reject") {
+      throw behavior.outcome.error;
+    } else if (behavior?.outcome.kind === "error") {
       proc.scheduleError(behavior.outcome.error);
     } else {
       proc.scheduleExit(behavior?.outcome.kind === "exit" ? behavior.outcome.code : 0);
@@ -134,6 +139,11 @@ export class FakeAdbClient implements FakeAdbClientContract {
 
   setSpawnError(match: string, error: Error): void {
     this.spawnBehaviors.push({ match, outcome: { kind: "error", error } });
+  }
+
+  /** Configure a spawned command to reject before a process is created. */
+  setSpawnRejection(match: string, error: Error): void {
+    this.spawnBehaviors.push({ match, outcome: { kind: "reject", error } });
   }
 
   /** All recorded spawn argv arrays, in order. */

--- a/test/features/record/McpCallRecorder.test.ts
+++ b/test/features/record/McpCallRecorder.test.ts
@@ -73,6 +73,19 @@ describe("McpCallRecorder", () => {
       expect(recorder.stepCount).toBe(7);
     });
 
+    test("records clearText and dragAndDrop as plan steps", () => {
+      const recorder = new McpCallRecorder();
+      recorder.start();
+
+      recorder.record("clearText", { id: "email" });
+      recorder.record("dragAndDrop", { from: "source", to: "destination" });
+
+      expect(recorder.stop()).toEqual([
+        { tool: "clearText", params: { id: "email" } },
+        { tool: "dragAndDrop", params: { from: "source", to: "destination" } },
+      ]);
+    });
+
     test("ignores infrastructure tools", () => {
       const recorder = new McpCallRecorder();
       recorder.start();

--- a/test/features/video/PlatformVideoCaptureBackend.test.ts
+++ b/test/features/video/PlatformVideoCaptureBackend.test.ts
@@ -349,6 +349,24 @@ describe("PlatformVideoCaptureBackend - Unit Tests", () => {
       // The finally block runs the cleanup even though the pull rejected.
       expect(fakeClient.wasSpawned("rm /sdcard/auto-mobile-test.mp4")).toBe(true);
     });
+
+    test("preserves the pull error when cleanup cannot start", async () => {
+      const fakeFactory = new FakeAdbClientFactory();
+      const fakeClient = fakeFactory.getFakeClient();
+      fakeClient.setSpawnExit("pull", 1);
+      fakeClient.setSpawnRejection("rm", new Error("cleanup spawn failed"));
+      const fakeTimer = new FakeTimer();
+      fakeTimer.enableAutoAdvance();
+
+      const backend = new PlatformVideoCaptureBackend(fakeFactory, fakeTimer);
+      const fakeProcess = new FakeChildProcess();
+      fakeProcess.exitCode = 0;
+      const handle = buildAndroidStopHandle(path.join(tempDir, "out.mp4"), fakeProcess);
+
+      await expect(backend.stop(handle)).rejects.toThrow(/adb pull failed/);
+
+      expect(fakeClient.wasSpawned("rm /sdcard/auto-mobile-test.mp4")).toBe(true);
+    });
   });
 
   describe("clampBitrateKbps", () => {


### PR DESCRIPTION
## Summary

- preserve the original Android `adb pull` failure when device-temp-file cleanup cannot start
- add deterministic fake ADB coverage for a spawn-time rejection
- verify representative recordable MCP tools are emitted as plan steps

## Root cause

`PlatformVideoCaptureBackend.stop()` cleaned up the Android temporary recording in a `finally` block. If `adb.spawn()` failed while starting that cleanup, its error replaced the failed pull error that caused the cleanup to run.

## Validation

- `bun test test/features/video/PlatformVideoCaptureBackend.test.ts test/features/record/McpCallRecorder.test.ts`
- `bun run turbo:validate`
- `bun run typecheck`
- `git diff --check`

Closes [issue #4523](https://github.com/kaeawc/auto-mobile/issues/4523)
