### PR TITLE
fix(daemon): evict append cache on device ready

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -203,7 +203,7 @@ export class Daemon {
       this.deviceSessionRepository,
       undefined,
       (sessionId, _deviceId, releaseReason) => this.cancelAndReleaseSession(sessionId, releaseReason),
-      device => this.socketServer?.evictDeviceInputCache(device.deviceId)
+      deviceId => this.socketServer?.evictDeviceInputCache(deviceId)
     );
     // Initialize singleton for daemon state access
     DaemonState.getInstance().initialize(this.sessionManager, this.devicePool);
@@ -1197,8 +1197,8 @@ export class Daemon {
           // serial does not inherit the previous one's cached API-level capability
           // (issue #3351): an API 31+/pre-31 mismatch mis-handles SHIFT/uppercase.
           // This fires only on a CONFIRMED disappearance; a fast same-serial restart
-          // that never confirms is not caught here (the 5-min idle close is the
-          // backstop until a device-connect signal exists — issue #4534).
+          // that never confirms is handled by the device-ready callback; the 5-min
+          // idle close remains a fallback.
           this.socketServer?.evictDeviceInputCache(deviceId);
           if (this.devicePool.getDevice(deviceId)) {
             deviceCleanupSucceeded = false;

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -202,7 +202,8 @@ export class Daemon {
       undefined,
       this.deviceSessionRepository,
       undefined,
-      (sessionId, _deviceId, releaseReason) => this.cancelAndReleaseSession(sessionId, releaseReason)
+      (sessionId, _deviceId, releaseReason) => this.cancelAndReleaseSession(sessionId, releaseReason),
+      device => this.socketServer?.evictDeviceInputCache(device.deviceId)
     );
     // Initialize singleton for daemon state access
     DaemonState.getInstance().initialize(this.sessionManager, this.devicePool);

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -76,7 +76,7 @@ interface DeviceDisconnectSessionReleaser {
 }
 
 interface DeviceReadyListener {
-  (device: BootedDevice): void;
+  (deviceId: string): void;
 }
 
 /**
@@ -253,6 +253,7 @@ export class DevicePool {
           pooledDevice.platform = device.platform;
           pooledDevice.iosVersion = device.iosVersion;
         }
+        this.notifyDeviceReady(device.deviceId);
       }
       perf.endOperation("poolUpdate");
 
@@ -276,6 +277,14 @@ export class DevicePool {
         logger.error(`Stack trace: ${error.stack}`);
       }
       return 0;
+    }
+  }
+
+  private notifyDeviceReady(deviceId: string): void {
+    try {
+      this.onDeviceReady?.(deviceId);
+    } catch (error) {
+      logger.warn(`[DevicePool] Device-ready listener failed for ${deviceId}: ${error}`);
     }
   }
 
@@ -319,11 +328,7 @@ export class DevicePool {
       logger.info(`Added device ${device.deviceId} to pool`);
     }
 
-    try {
-      this.onDeviceReady?.(device);
-    } catch (error) {
-      logger.warn(`[DevicePool] Device-ready listener failed for ${device.deviceId}: ${error}`);
-    }
+    this.notifyDeviceReady(device.deviceId);
   }
 
   /**
@@ -1397,7 +1402,8 @@ export class DevicePool {
    */
   async bindOrReuseDeviceSession(sessionId: string, deviceId: string, platform: Platform): Promise<string> {
     return await this.assignmentMutex.runExclusive(async () => {
-      if (!this.devices.has(deviceId)) {
+      const alreadyPooled = this.devices.has(deviceId);
+      if (!alreadyPooled) {
         const bootedDevices = await this.deviceManager.getBootedDevices(platform);
         const booted = bootedDevices.find(d => d.deviceId === deviceId);
         if (booted) {
@@ -1416,6 +1422,10 @@ export class DevicePool {
           `Device '${deviceId}' is not available in the device pool. ` +
           "It may have been shut down or disconnected."
         );
+      }
+
+      if (alreadyPooled) {
+        this.notifyDeviceReady(deviceId);
       }
 
       if (device.sessionId) {
@@ -1472,7 +1482,8 @@ export class DevicePool {
     const sessionId = randomUUID();
 
     // Ensure device is in the pool (it may have been freshly booted)
-    if (!this.devices.has(deviceId)) {
+    const alreadyPooled = this.devices.has(deviceId);
+    if (!alreadyPooled) {
       const bootedDevices = await this.deviceManager.getBootedDevices(platform);
       const booted = bootedDevices.find(d => d.deviceId === deviceId);
       if (booted) {
@@ -1507,6 +1518,10 @@ export class DevicePool {
         `  - Use 'startDevice' with deviceId to restart this specific device\n` +
         `  - Use 'listDevices' to see currently available devices`
       );
+    }
+
+    if (alreadyPooled) {
+      this.notifyDeviceReady(deviceId);
     }
 
     device.sessionId = sessionId;

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -75,6 +75,10 @@ interface DeviceDisconnectSessionReleaser {
   (sessionId: string, deviceId: string, releaseReason: string): Promise<void>;
 }
 
+interface DeviceReadyListener {
+  (device: BootedDevice): void;
+}
+
 /**
  * Device Pool
  *
@@ -103,6 +107,7 @@ export class DevicePool {
   private readonly deviceSessionRepository: DeviceSessionRepository;
   private readonly criteriaMatcher: DeviceCriteriaMatcher;
   private readonly releaseSessionForDisconnectedDevice: DeviceDisconnectSessionReleaser;
+  private readonly onDeviceReady: DeviceReadyListener | undefined;
 
   // Max consecutive errors before marking device as failed
   private readonly MAX_DEVICE_ERRORS = 5;
@@ -121,7 +126,8 @@ export class DevicePool {
     retryExecutor: RetryExecutor = defaultRetryExecutor,
     deviceSessionRepository: DeviceSessionRepository = new DeviceSessionRepository(),
     criteriaMatcher: DeviceCriteriaMatcher = new DeviceCriteriaMatcher(),
-    releaseSessionForDisconnectedDevice?: DeviceDisconnectSessionReleaser
+    releaseSessionForDisconnectedDevice?: DeviceDisconnectSessionReleaser,
+    onDeviceReady?: DeviceReadyListener
   ) {
     this.sessionManager = sessionManager;
     this.daemonSessionId = daemonSessionId;
@@ -131,6 +137,7 @@ export class DevicePool {
     this.retryExecutor = retryExecutor;
     this.deviceSessionRepository = deviceSessionRepository;
     this.criteriaMatcher = criteriaMatcher;
+    this.onDeviceReady = onDeviceReady;
     this.releaseSessionForDisconnectedDevice = releaseSessionForDisconnectedDevice ?? (async (
       sessionId,
       _deviceId,
@@ -288,30 +295,35 @@ export class DevicePool {
         existing.simulatorType = this.criteriaMatcher.getBootedDeviceSimulatorType(device) ?? existing.simulatorType;
         existing.lastUsedAt = this.seedLastUsedAt(this.timer.now());
         logger.info(`Recovered errored device ${device.deviceId} after successful boot`);
-        return;
+      } else {
+        logger.warn(`Device ${device.deviceId} already in pool`);
       }
-      logger.warn(`Device ${device.deviceId} already in pool`);
-      return;
+    } else {
+      const now = this.seedLastUsedAt(this.timer.now());
+      this.devices.set(device.deviceId, {
+        id: device.deviceId,
+        name: device.name,
+        platform: device.platform,
+        sessionId: null,
+        status: "idle",
+        lastUsedAt: now,
+        assignmentCount: 0,
+        errorCount: 0,
+        iosVersion: device.iosVersion,
+        simulatorType: this.criteriaMatcher.getBootedDeviceSimulatorType(device),
+      });
+      this.deviceSessionStarts.set(device.deviceId, now);
+      this.refreshMissingDeviceMisses.delete(device.deviceId);
+      await this.setDeviceSessionTracking(device.deviceId, now);
+
+      logger.info(`Added device ${device.deviceId} to pool`);
     }
 
-    const now = this.seedLastUsedAt(this.timer.now());
-    this.devices.set(device.deviceId, {
-      id: device.deviceId,
-      name: device.name,
-      platform: device.platform,
-      sessionId: null,
-      status: "idle",
-      lastUsedAt: now,
-      assignmentCount: 0,
-      errorCount: 0,
-      iosVersion: device.iosVersion,
-      simulatorType: this.criteriaMatcher.getBootedDeviceSimulatorType(device),
-    });
-    this.deviceSessionStarts.set(device.deviceId, now);
-    this.refreshMissingDeviceMisses.delete(device.deviceId);
-    await this.setDeviceSessionTracking(device.deviceId, now);
-
-    logger.info(`Added device ${device.deviceId} to pool`);
+    try {
+      this.onDeviceReady?.(device);
+    } catch (error) {
+      logger.warn(`[DevicePool] Device-ready listener failed for ${device.deviceId}: ${error}`);
+    }
   }
 
   /**

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -1403,6 +1403,9 @@ export class DevicePool {
   async bindOrReuseDeviceSession(sessionId: string, deviceId: string, platform: Platform): Promise<string> {
     return await this.assignmentMutex.runExclusive(async () => {
       const alreadyPooled = this.devices.has(deviceId);
+      if (alreadyPooled) {
+        this.notifyDeviceReady(deviceId);
+      }
       if (!alreadyPooled) {
         const bootedDevices = await this.deviceManager.getBootedDevices(platform);
         const booted = bootedDevices.find(d => d.deviceId === deviceId);
@@ -1422,10 +1425,6 @@ export class DevicePool {
           `Device '${deviceId}' is not available in the device pool. ` +
           "It may have been shut down or disconnected."
         );
-      }
-
-      if (alreadyPooled) {
-        this.notifyDeviceReady(deviceId);
       }
 
       if (device.sessionId) {
@@ -1483,6 +1482,9 @@ export class DevicePool {
 
     // Ensure device is in the pool (it may have been freshly booted)
     const alreadyPooled = this.devices.has(deviceId);
+    if (alreadyPooled) {
+      this.notifyDeviceReady(deviceId);
+    }
     if (!alreadyPooled) {
       const bootedDevices = await this.deviceManager.getBootedDevices(platform);
       const booted = bootedDevices.find(d => d.deviceId === deviceId);
@@ -1518,10 +1520,6 @@ export class DevicePool {
         `  - Use 'startDevice' with deviceId to restart this specific device\n` +
         `  - Use 'listDevices' to see currently available devices`
       );
-    }
-
-    if (alreadyPooled) {
-      this.notifyDeviceReady(deviceId);
     }
 
     device.sessionId = sessionId;

--- a/src/daemon/devicePool.ts
+++ b/src/daemon/devicePool.ts
@@ -280,7 +280,8 @@ export class DevicePool {
     }
   }
 
-  private notifyDeviceReady(deviceId: string): void {
+  /** Notify consumers that a device has reached a boot-ready connection boundary. */
+  notifyDeviceReady(deviceId: string): void {
     try {
       this.onDeviceReady?.(deviceId);
     } catch (error) {

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -987,6 +987,18 @@ export class UnixSocketServer {
       args.append
     );
     const inputResult = await this.runKeyedMcpForward(`device:${targetDevice.deviceId}`, async () => {
+      // A same-serial emulator may reconnect while this request waits behind an
+      // earlier input. Re-read its ADB transport inside the keyed callback so the
+      // append-helper lookup cannot reuse a capability from that older instance.
+      const executionTargetDevice = args.append && args.platform === "android"
+        ? await this.resolveInputTargetDevice(
+          args.platform,
+          targetDevice.deviceId,
+          socketSessionId,
+          "input/typeText",
+          true
+        )
+        : targetDevice;
       const queueWaitMs = this.timer.now() - queueEnterMs;
       const remainingTimeoutMs = totalTimeoutMs - queueWaitMs;
       if (remainingTimeoutMs <= 0) {
@@ -1007,7 +1019,7 @@ export class UnixSocketServer {
         () =>
           this.executeInputTypeText(
             args.platform,
-            targetDevice,
+            executionTargetDevice,
             args.text,
             imeAction,
             remainingTimeoutMs,

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1645,9 +1645,10 @@ export class UnixSocketServer {
    * close. If an emulator is replaced under a reused serial (`emulator-5554`)
    * before then, the next device would inherit the previous one's cached API-level
    * capability — an API 31+ / pre-31 mismatch that mis-handles SHIFT and uppercase.
-   * The device pool calls this as soon as a boot-ready device is added or re-added,
-   * including a rapid same-serial replacement that the disconnect monitor never
-   * observes as absent. The confirmed-disconnect monitor also calls it as a backstop.
+   * The device pool calls this after it adds a device, rediscovers it during a
+   * refresh, or binds it after startDevice. That covers rapid same-serial
+   * replacements that the disconnect monitor never observes as absent. The
+   * confirmed-disconnect monitor also calls it as a backstop.
    * Idempotent; safe for an unknown id.
    */
   evictDeviceInputCache(deviceId: string): void {

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -125,6 +125,11 @@ export interface AppendTextInput {
   ): Promise<{ success: boolean; error?: string; charsSent?: number }>;
 }
 
+interface CachedAppendTextInput {
+  input: AppendTextInput;
+  transportId?: string;
+}
+
 export class UnixSocketServer {
   private server: NetServer | null = null;
   private socketFileIdentity: SocketFileIdentity | null = null;
@@ -173,7 +178,7 @@ export class UnixSocketServer {
    * same per-device key, same idle window), so a device that re-appears under the
    * same id with a different image re-probes rather than trusting a stale API level.
    */
-  private appendTextInputs: Map<string, AppendTextInput> = new Map();
+  private appendTextInputs: Map<string, CachedAppendTextInput> = new Map();
 
   constructor(
     socketPath: string = SOCKET_PATH,
@@ -1646,9 +1651,9 @@ export class UnixSocketServer {
    * before then, the next device would inherit the previous one's cached API-level
    * capability — an API 31+ / pre-31 mismatch that mis-handles SHIFT and uppercase.
    * The device pool calls this after it adds a device, rediscovers it during a
-   * refresh, or binds it after startDevice. That covers rapid same-serial
-   * replacements that the disconnect monitor never observes as absent. The
-   * confirmed-disconnect monitor also calls it as a backstop.
+   * refresh, or binds it after startDevice. Direct socket discovery also rebuilds
+   * a helper when ADB reports a changed transport id for the same serial. The
+   * confirmed-disconnect monitor remains a backstop.
    * Idempotent; safe for an unknown id.
    */
   evictDeviceInputCache(deviceId: string): void {
@@ -1660,11 +1665,20 @@ export class UnixSocketServer {
   /** Cached-per-device accessor for the append helper; see {@link appendTextInputs}. */
   private getAppendTextInput(device: BootedDevice): AppendTextInput {
     const existing = this.appendTextInputs.get(device.deviceId);
+    if (
+      existing &&
+      (existing.transportId === undefined || device.transportId === undefined || existing.transportId === device.transportId)
+    ) {
+      return existing.input;
+    }
     if (existing) {
-      return existing;
+      logger.debug(
+        `[UnixSocketServer] Rebuilding cached append helper for ${device.deviceId}: ` +
+        `ADB transport changed from ${existing.transportId} to ${device.transportId}`
+      );
     }
     const created = this.appendTextFactory(device);
-    this.appendTextInputs.set(device.deviceId, created);
+    this.appendTextInputs.set(device.deviceId, { input: created, transportId: device.transportId });
     return created;
   }
 

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1639,18 +1639,20 @@ export class UnixSocketServer {
   }
 
   /**
-   * Drop the cached append helper for a device that has disconnected (issue #3351).
+   * Drop the cached append helper after a device lifecycle change (issue #3351).
    *
    * The cache is keyed by deviceId and otherwise lives until the 5-minute idle
    * close. If an emulator is replaced under a reused serial (`emulator-5554`)
    * before then, the next device would inherit the previous one's cached API-level
    * capability — an API 31+ / pre-31 mismatch that mis-handles SHIFT and uppercase.
-   * The daemon's device-disconnect monitor calls this on a confirmed disconnect so
-   * the replacement re-probes from scratch. Idempotent; safe for an unknown id.
+   * The device pool calls this as soon as a boot-ready device is added or re-added,
+   * including a rapid same-serial replacement that the disconnect monitor never
+   * observes as absent. The confirmed-disconnect monitor also calls it as a backstop.
+   * Idempotent; safe for an unknown id.
    */
   evictDeviceInputCache(deviceId: string): void {
     if (this.appendTextInputs.delete(deviceId)) {
-      logger.debug(`[UnixSocketServer] Evicted cached append helper for disconnected device ${deviceId}`);
+      logger.debug(`[UnixSocketServer] Evicted cached append helper for device ${deviceId}`);
     }
   }
 

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -983,7 +983,8 @@ export class UnixSocketServer {
       args.platform,
       args.deviceId,
       socketSessionId,
-      "input/typeText"
+      "input/typeText",
+      args.append
     );
     const inputResult = await this.runKeyedMcpForward(`device:${targetDevice.deviceId}`, async () => {
       const queueWaitMs = this.timer.now() - queueEnterMs;
@@ -1437,13 +1438,14 @@ export class UnixSocketServer {
     platform: "android" | "ios",
     deviceId: string | undefined,
     socketSessionId: string | undefined,
-    action: "input/tap" | "input/swipe" | "input/typeText" | "input/pressButton" | "input/key"
+    action: "input/tap" | "input/swipe" | "input/typeText" | "input/pressButton" | "input/key",
+    bypassAndroidDeviceListCache: boolean = false
   ): Promise<BootedDevice> {
-    const discovery = await PlatformDeviceManagerFactory.getInstance().getBootedDevicesDetailed(platform);
-    if (!discovery.succeededPlatforms.has(platform)) {
-      throw new Error(`Unable to discover booted ${platform} devices for ${action}`);
-    }
-    const bootedDevices = discovery.devices;
+    const bootedDevices = await this.discoverInputTargetDevices(
+      platform,
+      action,
+      bypassAndroidDeviceListCache
+    );
     if (deviceId) {
       const targetDevice = bootedDevices.find(device => device.deviceId === deviceId);
       if (!targetDevice) {
@@ -1475,6 +1477,20 @@ export class UnixSocketServer {
       throw new Error(`No booted ${platform} devices found for ${action}`);
     }
     throw new Error(`${action} requires deviceId when multiple ${platform} devices are booted`);
+  }
+
+  private async discoverInputTargetDevices(
+    platform: "android" | "ios",
+    action: "input/tap" | "input/swipe" | "input/typeText" | "input/pressButton" | "input/key",
+    bypassAndroidDeviceListCache: boolean
+  ): Promise<BootedDevice[]> {
+    const discovery = await PlatformDeviceManagerFactory.getInstance().getBootedDevicesDetailed(platform, {
+      bypassAndroidDeviceListCache,
+    });
+    if (!discovery.succeededPlatforms.has(platform)) {
+      throw new Error(`Unable to discover booted ${platform} devices for ${action}`);
+    }
+    return discovery.devices;
   }
 
   private async handleIdeRequest(
@@ -1666,8 +1682,8 @@ export class UnixSocketServer {
   private getAppendTextInput(device: BootedDevice): AppendTextInput {
     const existing = this.appendTextInputs.get(device.deviceId);
     if (
-      existing &&
-      (existing.transportId === undefined || device.transportId === undefined || existing.transportId === device.transportId)
+      existing?.transportId !== undefined &&
+      device.transportId === existing.transportId
     ) {
       return existing.input;
     }

--- a/src/models/DeviceInfo.ts
+++ b/src/models/DeviceInfo.ts
@@ -27,6 +27,8 @@ export interface BootedDevice {
   name: string;
   platform: Platform;
   deviceId: string;
+  /** ADB transport identity, which changes when a serial reconnects. */
+  transportId?: string;
   source?: "local";
   iosVersion?: string;
   osVersion?: string;

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -217,6 +217,12 @@ export function registerDeviceTools() {
       const boot = await bootService.boot(args, progress ? { report: progress } : undefined);
       perf.endOperation("bootDevice");
 
+      // A ready device may reuse an existing serial. Invalidate daemon-side
+      // per-device state before any later await lets socket traffic reach it.
+      if (DaemonState.getInstance().isInitialized()) {
+        DaemonState.getInstance().getDevicePool().notifyDeviceReady(boot.device.deviceId);
+      }
+
       if (boot.source === "cold-boot" || boot.provisioned) {
         perf.startOperation("notifyResources");
         await deps.notifyResourcesChanged();

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -780,14 +780,14 @@ export class AdbClient implements AdbExecutor {
    * Get the list of connected devices
    * @returns Promise with an array of device IDs
    */
-  async getBootedAndroidDevices(): Promise<BootedDevice[]> {
+  async getBootedAndroidDevices(options: { bypassCache?: boolean } = {}): Promise<BootedDevice[]> {
     if (this.shouldSkipMissingAdbProbe()) {
       return [];
     }
 
     // Check cache first - TTLCache handles expiration automatically
     const cache = getDeviceListCache();
-    const cachedDevices = cache.get("devices");
+    const cachedDevices = options.bypassCache ? undefined : cache.get("devices");
     if (cachedDevices) {
       logger.debug("Getting list of connected devices (cached)");
       return cachedDevices;

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -797,7 +797,7 @@ export class AdbClient implements AdbExecutor {
     let result: ExecResult;
     try {
       result = await this.executeCommand(
-        "devices",
+        "devices -l",
         AdbClient.DEVICE_LIST_TIMEOUT_MS,
         undefined,
         true
@@ -814,13 +814,19 @@ export class AdbClient implements AdbExecutor {
     const devices = lines
       .filter(line => line.trim().length > 0)
       .flatMap(line => {
-        const parts = line.split("\t");
-        const deviceId = parts[0]?.trim();
-        const state = parts[1]?.trim();
+        const [deviceId, state, ...details] = line.trim().split(/\s+/);
         if (!deviceId || state !== "device") {
           return [];
         }
-        return [{ name: deviceId, platform: "android", deviceId } as BootedDevice];
+        const transportId = details
+          .find(detail => detail.startsWith("transport_id:"))
+          ?.slice("transport_id:".length);
+        return [{
+          name: deviceId,
+          platform: "android",
+          deviceId,
+          ...(transportId ? { transportId } : {}),
+        } satisfies BootedDevice];
       });
 
     // Cache the result

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -805,6 +805,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           logger.debug(`AVD name detection for ${deviceId}: raw="${result.stdout}" (${result.stdout.length} chars), cleaned="${avdName}"`);
 
           runningDevices.push({
+            ...device,
             name: avdName || this.unknownEmulatorName(deviceId),
             platform: "android",
             deviceId: deviceId,
@@ -853,6 +854,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
         }
 
         runningDevices.push({
+          ...device,
           name: deviceName,
           platform: "android",
           deviceId: device.deviceId,

--- a/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
+++ b/src/utils/android-cmdline-tools/AndroidEmulatorClient.ts
@@ -779,12 +779,15 @@ export class AndroidEmulatorClient implements AndroidEmulator {
    * must distinguish "no emulators are booted" from "adb discovery failed"
    * should use this.
    */
-  async getBootedDevicesChecked(onlyEmulators: boolean = false): Promise<BootedDevice[]> {
+  async getBootedDevicesChecked(
+    onlyEmulators: boolean = false,
+    options: { bypassDeviceListCache?: boolean } = {}
+  ): Promise<BootedDevice[]> {
     const perf = createGlobalPerformanceTracker();
     {
       const adb = this.adbFactory.create(null);
       perf.startOperation("adbDeviceScan");
-      const devices = await adb.getBootedAndroidDevices();
+      const devices = await adb.getBootedAndroidDevices({ bypassCache: options.bypassDeviceListCache });
       perf.endOperation("adbDeviceScan");
       const runningDevices: BootedDevice[] = [];
 
@@ -815,6 +818,7 @@ export class AndroidEmulatorClient implements AndroidEmulator {
           // If we can't get the AVD name, just use the device ID
           logger.debug(`Failed to get AVD name for ${deviceId}: ${error}`);
           runningDevices.push({
+            ...device,
             name: this.unknownEmulatorName(deviceId),
             platform: "android",
             deviceId: deviceId,

--- a/src/utils/android-cmdline-tools/interfaces/AdbExecutor.ts
+++ b/src/utils/android-cmdline-tools/interfaces/AdbExecutor.ts
@@ -64,7 +64,7 @@ export interface AdbExecutor {
    * Get the list of booted Android devices
    * @returns Promise with array of booted devices
    */
-  getBootedAndroidDevices(): Promise<BootedDevice[]>;
+  getBootedAndroidDevices(options?: { bypassCache?: boolean }): Promise<BootedDevice[]>;
 
   /**
    * Check if the device screen is currently on

--- a/src/utils/deviceUtils.ts
+++ b/src/utils/deviceUtils.ts
@@ -22,6 +22,11 @@ export interface BootedDeviceDiscovery {
   succeededPlatforms: Set<Platform>;
 }
 
+export interface BootedDeviceDiscoveryOptions {
+  /** Bypass Android's short device-list cache to verify ADB transport identity. */
+  bypassAndroidDeviceListCache?: boolean;
+}
+
 /**
  * Interface for device utility operations
  * Provides platform-agnostic device management for Android emulators and iOS simulators
@@ -56,7 +61,10 @@ export interface PlatformDeviceManager {
    * pruning devices on a transient/partial discovery failure.
    * @param platform - Target platform ("android", "ios", or "either" for both)
    */
-  getBootedDevicesDetailed(platform: SomePlatform): Promise<BootedDeviceDiscovery>;
+  getBootedDevicesDetailed(
+    platform: SomePlatform,
+    options?: BootedDeviceDiscoveryOptions
+  ): Promise<BootedDeviceDiscovery>;
 
   /**
    * Start a device (emulator or simulator)
@@ -241,13 +249,18 @@ export class MultiPlatformDeviceManager implements PlatformDeviceManager {
     }
   }
 
-  async getBootedDevicesDetailed(platform: SomePlatform): Promise<BootedDeviceDiscovery> {
+  async getBootedDevicesDetailed(
+    platform: SomePlatform,
+    options: BootedDeviceDiscoveryOptions = {}
+  ): Promise<BootedDeviceDiscovery> {
     const devices: BootedDevice[] = [];
     const succeededPlatforms = new Set<Platform>();
 
     if (platform === "android" || platform === "either") {
       try {
-        const emulators = await this.emulator.getBootedDevicesChecked();
+        const emulators = await this.emulator.getBootedDevicesChecked(false, {
+          bypassDeviceListCache: options.bypassAndroidDeviceListCache,
+        });
         devices.push(...emulators);
         succeededPlatforms.add("android");
       } catch (error) {

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -6,7 +6,7 @@ import { SessionManager } from "../../src/daemon/sessionManager";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeInstalledAppsRepository } from "../fakes/FakeInstalledAppsRepository";
 import { FakeDeviceManager } from "../fakes/FakeDeviceManager";
-import { BootedDevice, DeviceInfo, Platform } from "../../src/models";
+import { BootedDevice, DeviceInfo, Platform, SomePlatform } from "../../src/models";
 import { DefaultRetryExecutor } from "../../src/utils/retry/RetryExecutor";
 import { MultiPlatformDeviceManager } from "../../src/utils/deviceUtils";
 import { DEFAULT_DEVICE_READY_TIMEOUT_MS } from "../../src/utils/deviceTimeouts";
@@ -72,6 +72,37 @@ describe("DevicePool", () => {
     async getBootedDevicesDetailed(platform: "android" | "ios" | "either") {
       this.detailedBootedCalls++;
       return super.getBootedDevicesDetailed(platform);
+    }
+  }
+
+  class DeferredDiscoveryFakeDeviceManager extends FakeDeviceManager {
+    private readonly discoveryStartedPromise: Promise<void>;
+    private readonly discoveryReleasePromise: Promise<void>;
+    private resolveDiscoveryStarted!: () => void;
+    private resolveDiscoveryRelease!: () => void;
+
+    constructor() {
+      super();
+      this.discoveryStartedPromise = new Promise(resolve => {
+        this.resolveDiscoveryStarted = resolve;
+      });
+      this.discoveryReleasePromise = new Promise(resolve => {
+        this.resolveDiscoveryRelease = resolve;
+      });
+    }
+
+    async getBootedDevicesDetailed(platform: SomePlatform) {
+      this.resolveDiscoveryStarted();
+      await this.discoveryReleasePromise;
+      return await super.getBootedDevicesDetailed(platform);
+    }
+
+    async waitForDiscoveryStart(): Promise<void> {
+      await this.discoveryStartedPromise;
+    }
+
+    releaseDiscovery(): void {
+      this.resolveDiscoveryRelease();
     }
   }
 
@@ -221,14 +252,15 @@ describe("DevicePool", () => {
       expect(connectedDeviceIds).toEqual(["emulator-5554"]);
     });
 
-    test("notifies when start-device binding reuses an existing serial", async () => {
+    test("notifies before binding validates an existing serial", async () => {
       const connectedDeviceIds: string[] = [];
+      const deferredDeviceManager = new DeferredDiscoveryFakeDeviceManager();
       devicePool = new DevicePool(
         sessionManager,
         "test-daemon-session-id",
         fakeTimer,
         fakeAppsRepo,
-        fakeDeviceManager,
+        deferredDeviceManager,
         new DefaultRetryExecutor(fakeTimer),
         undefined,
         undefined,
@@ -237,9 +269,57 @@ describe("DevicePool", () => {
       );
       const device = createBootedDevice("emulator-5554");
       await devicePool.initializeWithDevices([device]);
-      fakeDeviceManager.bootedDevices = [device];
+      deferredDeviceManager.bootedDevices = [device];
 
-      await devicePool.bindOrReuseDeviceSession("session-1", "emulator-5554", "android");
+      const binding = devicePool.bindOrReuseDeviceSession("session-1", "emulator-5554", "android");
+      await deferredDeviceManager.waitForDiscoveryStart();
+      try {
+        expect(connectedDeviceIds).toEqual(["emulator-5554"]);
+      } finally {
+        deferredDeviceManager.releaseDiscovery();
+        await binding;
+      }
+
+      expect(connectedDeviceIds).toEqual(["emulator-5554"]);
+    });
+
+    test("notifies before autolock validates an existing serial", async () => {
+      const originalAutolock = process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+      const connectedDeviceIds: string[] = [];
+      const deferredDeviceManager = new DeferredDiscoveryFakeDeviceManager();
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        deferredDeviceManager,
+        new DefaultRetryExecutor(fakeTimer),
+        undefined,
+        undefined,
+        undefined,
+        deviceId => connectedDeviceIds.push(deviceId)
+      );
+      const device = createBootedDevice("emulator-5554");
+      await devicePool.initializeWithDevices([device]);
+      deferredDeviceManager.bootedDevices = [device];
+      process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = "1";
+
+      try {
+        const binding = devicePool.autolockDevice("emulator-5554", "android", "mcp-session-1");
+        await deferredDeviceManager.waitForDiscoveryStart();
+        try {
+          expect(connectedDeviceIds).toEqual(["emulator-5554"]);
+        } finally {
+          deferredDeviceManager.releaseDiscovery();
+          await binding;
+        }
+      } finally {
+        if (originalAutolock === undefined) {
+          delete process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK;
+        } else {
+          process.env.AUTOMOBILE_DEVICE_POOL_AUTOLOCK = originalAutolock;
+        }
+      }
 
       expect(connectedDeviceIds).toEqual(["emulator-5554"]);
     });

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -174,6 +174,31 @@ describe("DevicePool", () => {
     });
   });
 
+  describe("device-ready notifications", () => {
+    test("notifies when a boot-ready device reuses an existing serial", async () => {
+      const connectedDeviceIds: string[] = [];
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        fakeDeviceManager,
+        new DefaultRetryExecutor(fakeTimer),
+        undefined,
+        undefined,
+        undefined,
+        device => connectedDeviceIds.push(device.deviceId)
+      );
+      await devicePool.initializeWithDevices([createBootedDevice("emulator-5554")]);
+
+      await devicePool.addDevice(createBootedDevice("emulator-5554"));
+
+      expect(connectedDeviceIds).toEqual(["emulator-5554"]);
+      expect(devicePool.getTotalDeviceCount()).toBe(1);
+      expect(devicePool.getDevice("emulator-5554")?.sessionId).toBeNull();
+    });
+  });
+
   describe("refreshDevices", () => {
     test("does not query simctl during Linux Android-only refresh", async () => {
       await withProcessPlatform("linux", async () => {

--- a/test/daemon/devicePool.test.ts
+++ b/test/daemon/devicePool.test.ts
@@ -187,7 +187,7 @@ describe("DevicePool", () => {
         undefined,
         undefined,
         undefined,
-        device => connectedDeviceIds.push(device.deviceId)
+        deviceId => connectedDeviceIds.push(deviceId)
       );
       await devicePool.initializeWithDevices([createBootedDevice("emulator-5554")]);
 
@@ -196,6 +196,52 @@ describe("DevicePool", () => {
       expect(connectedDeviceIds).toEqual(["emulator-5554"]);
       expect(devicePool.getTotalDeviceCount()).toBe(1);
       expect(devicePool.getDevice("emulator-5554")?.sessionId).toBeNull();
+    });
+
+    test("notifies when refresh rediscovers an existing serial", async () => {
+      const connectedDeviceIds: string[] = [];
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        fakeDeviceManager,
+        new DefaultRetryExecutor(fakeTimer),
+        undefined,
+        undefined,
+        undefined,
+        deviceId => connectedDeviceIds.push(deviceId)
+      );
+      const device = createBootedDevice("emulator-5554");
+      await devicePool.initializeWithDevices([device]);
+      fakeDeviceManager.bootedDevices = [device];
+
+      await devicePool.refreshDevices();
+
+      expect(connectedDeviceIds).toEqual(["emulator-5554"]);
+    });
+
+    test("notifies when start-device binding reuses an existing serial", async () => {
+      const connectedDeviceIds: string[] = [];
+      devicePool = new DevicePool(
+        sessionManager,
+        "test-daemon-session-id",
+        fakeTimer,
+        fakeAppsRepo,
+        fakeDeviceManager,
+        new DefaultRetryExecutor(fakeTimer),
+        undefined,
+        undefined,
+        undefined,
+        deviceId => connectedDeviceIds.push(deviceId)
+      );
+      const device = createBootedDevice("emulator-5554");
+      await devicePool.initializeWithDevices([device]);
+      fakeDeviceManager.bootedDevices = [device];
+
+      await devicePool.bindOrReuseDeviceSession("session-1", "emulator-5554", "android");
+
+      expect(connectedDeviceIds).toEqual(["emulator-5554"]);
     });
   });
 

--- a/test/daemon/socketServerInputTypeText.test.ts
+++ b/test/daemon/socketServerInputTypeText.test.ts
@@ -436,6 +436,50 @@ describe("UnixSocketServer input/typeText", () => {
     expect(adb.probeCalls.length).toBe(2);
   });
 
+  test("re-probes append input when direct discovery reports a new connection incarnation", async () => {
+    const requestSetText = mock(async () => ({ success: true, totalTimeMs: 1 }));
+    const requestImeAction = mock(async () => ({ success: true, totalTimeMs: 1 }));
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      requestSetText,
+      requestImeAction,
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    let discoveredDevice = {
+      ...androidDevice,
+      transportId: "1",
+    } as BootedDevice;
+    PlatformDeviceManagerFactory.setInstance({
+      getBootedDevicesDetailed: async () => ({
+        devices: [discoveredDevice],
+        succeededPlatforms: new Set(["android"]),
+      }),
+    } as ReturnType<typeof PlatformDeviceManagerFactory.getInstance>);
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    const adb = new ProductionShapedAdbExecutor(fakeTimer);
+    let factoryCalls = 0;
+    server.appendTextFactory = device => {
+      factoryCalls++;
+      return createAppendTextInput(device, adb, fakeTimer);
+    };
+    await server.start();
+
+    const append = () => sendRequest(socketPath, "input/typeText", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      text: "A",
+      mode: "append",
+    }, 1234);
+
+    expect((await append()).success).toBe(true);
+    discoveredDevice = {
+      ...androidDevice,
+      transportId: "2",
+    } as BootedDevice;
+    expect((await append()).success).toBe(true);
+
+    expect(factoryCalls).toBe(2);
+    expect(adb.probeCalls.length).toBe(2);
+  });
+
   // The client forwards every printable ASCII character, but uppercase and shifted
   // symbols need `input keycombination` (API 31+) and the client cannot see the API
   // level. The daemon therefore has to REPORT the failure; a silent success that

--- a/test/daemon/socketServerInputTypeText.test.ts
+++ b/test/daemon/socketServerInputTypeText.test.ts
@@ -485,6 +485,68 @@ describe("UnixSocketServer input/typeText", () => {
     expect(bypassedAndroidDeviceListCache).toBe(true);
   });
 
+  test("revalidates append transport identity after waiting behind same-device input", async () => {
+    const requestSetText = mock(async () => ({ success: true, totalTimeMs: 1 }));
+    const requestImeAction = mock(async () => ({ success: true, totalTimeMs: 1 }));
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      requestSetText,
+      requestImeAction,
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    let discoveredDevice = { ...androidDevice, transportId: "1" } as BootedDevice;
+    let discoveryCalls = 0;
+    PlatformDeviceManagerFactory.setInstance({
+      getBootedDevicesDetailed: async () => {
+        discoveryCalls++;
+        return {
+          devices: [discoveredDevice],
+          succeededPlatforms: new Set(["android"]),
+        };
+      },
+    } as ReturnType<typeof PlatformDeviceManagerFactory.getInstance>);
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    let releaseFirstAppend: (() => void) | undefined;
+    const firstAppendReleased = new Promise<void>(resolve => { releaseFirstAppend = resolve; });
+    let signalFirstAppendStarted: (() => void) | undefined;
+    const firstAppendStarted = new Promise<void>(resolve => { signalFirstAppendStarted = resolve; });
+    const createdForTransportIds: Array<string | undefined> = [];
+    server.appendTextFactory = device => {
+      createdForTransportIds.push(device.transportId);
+      return {
+        appendText: async () => {
+          if (createdForTransportIds.length === 1) {
+            signalFirstAppendStarted?.();
+            await firstAppendReleased;
+          }
+          return { success: true };
+        },
+      } as InputText;
+    };
+    await server.start();
+
+    const append = () => sendRequest(socketPath, "input/typeText", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      text: "A",
+      mode: "append",
+    }, 1234);
+
+    const first = append();
+    await firstAppendStarted;
+    const second = append();
+    await flushMicrotasks();
+    expect(discoveryCalls).toBe(3);
+
+    // The second request was resolved before the replacement, then waited in
+    // the same-device queue. Its queued revalidation must see the new transport.
+    discoveredDevice = { ...androidDevice, transportId: "2" } as BootedDevice;
+    releaseFirstAppend?.();
+
+    expect((await first).success).toBe(true);
+    expect((await second).success).toBe(true);
+    expect(createdForTransportIds).toEqual(["1", "2"]);
+    expect(discoveryCalls).toBe(4);
+  });
+
   test("does not reuse append input when direct discovery omits transport identity", async () => {
     const requestSetText = mock(async () => ({ success: true, totalTimeMs: 1 }));
     const requestImeAction = mock(async () => ({ success: true, totalTimeMs: 1 }));

--- a/test/daemon/socketServerInputTypeText.test.ts
+++ b/test/daemon/socketServerInputTypeText.test.ts
@@ -358,7 +358,7 @@ describe("UnixSocketServer input/typeText", () => {
       requestSetText,
       requestImeAction,
     })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
-    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([{ ...androidDevice, transportId: "1" }]));
     server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
     const adb = new ProductionShapedAdbExecutor(fakeTimer);
     let factoryCalls = 0;
@@ -447,11 +447,15 @@ describe("UnixSocketServer input/typeText", () => {
       ...androidDevice,
       transportId: "1",
     } as BootedDevice;
+    let bypassedAndroidDeviceListCache = false;
     PlatformDeviceManagerFactory.setInstance({
-      getBootedDevicesDetailed: async () => ({
-        devices: [discoveredDevice],
-        succeededPlatforms: new Set(["android"]),
-      }),
+      getBootedDevicesDetailed: async (_platform, options?: { bypassAndroidDeviceListCache?: boolean }) => {
+        bypassedAndroidDeviceListCache ||= options?.bypassAndroidDeviceListCache === true;
+        return {
+          devices: [discoveredDevice],
+          succeededPlatforms: new Set(["android"]),
+        };
+      },
     } as ReturnType<typeof PlatformDeviceManagerFactory.getInstance>);
     server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
     const adb = new ProductionShapedAdbExecutor(fakeTimer);
@@ -474,6 +478,38 @@ describe("UnixSocketServer input/typeText", () => {
       ...androidDevice,
       transportId: "2",
     } as BootedDevice;
+    expect((await append()).success).toBe(true);
+
+    expect(factoryCalls).toBe(2);
+    expect(adb.probeCalls.length).toBe(2);
+    expect(bypassedAndroidDeviceListCache).toBe(true);
+  });
+
+  test("does not reuse append input when direct discovery omits transport identity", async () => {
+    const requestSetText = mock(async () => ({ success: true, totalTimeMs: 1 }));
+    const requestImeAction = mock(async () => ({ success: true, totalTimeMs: 1 }));
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      requestSetText,
+      requestImeAction,
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    const adb = new ProductionShapedAdbExecutor(fakeTimer);
+    let factoryCalls = 0;
+    server.appendTextFactory = device => {
+      factoryCalls++;
+      return createAppendTextInput(device, adb, fakeTimer);
+    };
+    await server.start();
+
+    const append = () => sendRequest(socketPath, "input/typeText", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      text: "A",
+      mode: "append",
+    }, 1234);
+
+    expect((await append()).success).toBe(true);
     expect((await append()).success).toBe(true);
 
     expect(factoryCalls).toBe(2);

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -157,6 +157,54 @@ describe("startDevice handler", () => {
     expect(fakeDeviceUtils.wasMethodCalled("startDevice")).toBe(true);
   });
 
+  it("evicts the pooled device cache before cold-boot resource notifications", async () => {
+    const timer = new FakeTimer();
+    daemonSessionManager = new SessionManager(timer);
+    const readyDeviceIds: string[] = [];
+    const pool = new DevicePool(
+      daemonSessionManager,
+      "daemon-session",
+      timer,
+      undefined,
+      fakeDeviceUtils,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      deviceId => readyDeviceIds.push(deviceId)
+    );
+    DaemonState.getInstance().initialize(daemonSessionManager, pool);
+
+    const coldBootImage = { ...androidImage, deviceId: androidDevice.deviceId };
+    fakeDeviceUtils.setDeviceImages("android", [coldBootImage]);
+    fakeMatcher.setBootedResult(null);
+    fakeMatcher.setImageResult(coldBootImage);
+
+    let releaseResources!: () => void;
+    const resourcesStarted = new Promise<void>(resolve => {
+      releaseResources = resolve;
+    });
+    let signalResourcesStarted!: () => void;
+    const waitForResources = new Promise<void>(resolve => {
+      signalResourcesStarted = resolve;
+    });
+    setDeviceToolsDependencies({
+      notifyResourcesChanged: async () => {
+        signalResourcesStarted();
+        await resourcesStarted;
+      },
+    });
+
+    const start = callStartDevice({ platform: "android" });
+    await waitForResources;
+    try {
+      expect(readyDeviceIds).toEqual(["emulator-5554"]);
+    } finally {
+      releaseResources();
+      await start;
+    }
+  });
+
   it("cold-boots without a process handle (adopted device: startDevice returns null)", async () => {
     fakeDeviceUtils.setBootedDevices("android", []);
     fakeDeviceUtils.setDeviceImages("android", [androidImage]);

--- a/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
+++ b/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
@@ -29,7 +29,7 @@ describe("AdbClient.getBootedAndroidDevices", () => {
       if (command.includes("adb devices")) {
         return createExecResult([
           "List of devices attached",
-          "emulator-5554\tdevice",
+          "emulator-5554\tdevice product:sdk_gphone64_arm64 transport_id:42",
           "emulator-5556\tbooting",
           "emulator-5558\toffline",
           "emulator-5560\tunauthorized",
@@ -43,7 +43,12 @@ describe("AdbClient.getBootedAndroidDevices", () => {
     const devices = await adb.getBootedAndroidDevices();
 
     expect(devices).toEqual([
-      { name: "emulator-5554", platform: "android", deviceId: "emulator-5554" },
+      {
+        name: "emulator-5554",
+        platform: "android",
+        deviceId: "emulator-5554",
+        transportId: "42",
+      },
     ]);
   });
 

--- a/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
+++ b/test/utils/android-cmdline-tools/AdbClient-getBootedAndroidDevices.test.ts
@@ -52,6 +52,25 @@ describe("AdbClient.getBootedAndroidDevices", () => {
     ]);
   });
 
+  test("bypasses the device-list cache when checking a connection incarnation", async () => {
+    let calls = 0;
+    const adb = new AdbClient(null, async (command: string): Promise<ExecResult> => {
+      if (!command.includes("adb devices")) {
+        return createExecResult("");
+      }
+      calls++;
+      return createExecResult([
+        "List of devices attached",
+        `emulator-5554\tdevice transport_id:${calls}`,
+        "",
+      ].join("\n"));
+    });
+
+    expect(await adb.getBootedAndroidDevices()).toMatchObject([{ transportId: "1" }]);
+    expect(await adb.getBootedAndroidDevices({ bypassCache: true })).toMatchObject([{ transportId: "2" }]);
+    expect(calls).toBe(2);
+  });
+
   test("does not retry commands when adb reports the target serial is gone", async () => {
     let calls = 0;
     const execAsync = async (): Promise<ExecResult> => {

--- a/test/utils/android-cmdline-tools/AndroidEmulatorClient-getBootedDevices.test.ts
+++ b/test/utils/android-cmdline-tools/AndroidEmulatorClient-getBootedDevices.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { AndroidEmulatorClient } from "../../../src/utils/android-cmdline-tools/AndroidEmulatorClient";
+import type { BootedDevice } from "../../../src/models";
+import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeTimer } from "../../fakes/FakeTimer";
+
+describe("AndroidEmulatorClient.getBootedDevicesChecked", () => {
+  test("preserves transport identity when AVD-name lookup fails", async () => {
+    const adb = new FakeAdbExecutor();
+    adb.setDevices([{
+      name: "ignored",
+      platform: "android",
+      deviceId: "emulator-5554",
+      transportId: "42",
+    } satisfies BootedDevice]);
+    adb.setCommandError("emu avd name", new Error("emulator console unavailable"));
+    const client = new AndroidEmulatorClient(null, null, new FakeTimer(), new FakeAdbClientFactory(adb));
+
+    await expect(client.getBootedDevicesChecked()).resolves.toEqual([{
+      name: "Unknown (emulator-5554)",
+      platform: "android",
+      deviceId: "emulator-5554",
+      transportId: "42",
+      source: "local",
+    }]);
+  });
+});


### PR DESCRIPTION
## Summary

- emit a device-ready callback whenever `DevicePool` adds or re-adds a boot-ready device
- evict the daemon append-input helper through that callback, before a same-serial replacement can reuse the prior device's API-level cache
- retain confirmed-disconnect eviction as the lifecycle backstop

## Root cause

The disconnect monitor only evicted after it observed a confirmed absence. A fast replacement under the same Android serial could re-enter ready state before a poll observed that absence, leaving the prior `InputText` instance cached for five minutes.

## Validation

- `bun test test/daemon/devicePool.test.ts test/daemon/socketServerInputTypeText.test.ts`
- `bun run lint`
- `bun run turbo:validate`
- `bun run typecheck` (no new errors; one pre-existing baseline swap-guard warning)

Closes [#4534](https://github.com/kaeawc/auto-mobile/issues/4534).
