### PR TITLE
test(misc): complete remaining test-quality findings

### DIFF
--- a/scripts/ios/navigation-graph-sdk-event-integration.sh
+++ b/scripts/ios/navigation-graph-sdk-event-integration.sh
@@ -71,9 +71,16 @@ curl --fail --silent --show-error --max-time 5 \
   --data "${batch}" \
   "http://127.0.0.1:${ctrl_proxy_port}/sdk-events" >/dev/null
 
-# CtrlProxy polls its SDK endpoint every two seconds after the warm-up observe.
+# Refresh the connected CtrlProxy client after injection. `getNavigationGraph`
+# reads the daemon's persisted graph but does not itself drain `/sdk-events`, so
+# relying on its background poll leaves a race on a busy Simulator runner.
 # Query through the public, daemon-backed tool until the batched events appear.
 for attempt in 1 2 3 4 5; do
+  if ! auto-mobile --debug --cli observe --platform ios --deviceId "${device_id}" >/dev/null; then
+    echo "observe refresh attempt ${attempt} failed; retrying in 2s..." >&2
+    sleep 2
+    continue
+  fi
   if ! graph="$(auto-mobile --debug --cli getNavigationGraph --platform ios --deviceId "${device_id}")"; then
     echo "getNavigationGraph attempt ${attempt} failed; retrying in 2s..." >&2
     sleep 2

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -804,6 +804,12 @@ export class ToolRegistryClass {
     });
   }
 
+  /** Remove one test-only or dynamically registered tool without disturbing the registry. */
+  unregister(name: string): void {
+    this.invalidateToolDefinitionSchemaCache();
+    this.tools.delete(name);
+  }
+
   // Register a device-aware tool
   registerDeviceAware(
     name: string,

--- a/src/utils/plan/PlanSchemaValidator.ts
+++ b/src/utils/plan/PlanSchemaValidator.ts
@@ -180,6 +180,16 @@ export class PlanSchemaValidator {
    * @returns Validation result
    */
   async validateFile(filePath: string): Promise<PlanValidationResult> {
+    if (!this.schemaLoaded) {
+      return {
+        valid: false,
+        errors: [{
+          field: "schema",
+          message: "Schema not loaded. Call loadSchema() first."
+        }]
+      };
+    }
+
     try {
       const content = await fs.readFile(filePath, "utf-8");
       return this.validateYaml(content);

--- a/src/vision/ClaudeVisionClient.ts
+++ b/src/vision/ClaudeVisionClient.ts
@@ -16,6 +16,89 @@ import type { Timer } from "../utils/SystemTimer";
 import { defaultTimer } from "../utils/SystemTimer";
 import { logger } from "../utils/logger";
 
+export function parseClaudeResponse(response: Anthropic.Message): ClaudeVisionAnalysis {
+  let responseText = "";
+  for (const block of response.content) {
+    if (block.type === "text") {
+      responseText += block.text;
+    }
+  }
+
+  const jsonMatch = responseText.match(/```json\n([\s\S]*?)\n```/) || responseText.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) {
+    throw new Error("Failed to parse JSON from Claude response");
+  }
+
+  let parsed: any;
+  try {
+    parsed = JSON.parse(jsonMatch[1] || jsonMatch[0]);
+  } catch (error) {
+    throw new Error(`Failed to parse JSON from Claude response: ${(error as Error).message}`);
+  }
+
+  return {
+    elementFound: parsed.elementFound || false,
+    elementLocation: parsed.elementLocation || undefined,
+    suggestedText: parsed.suggestedText || undefined,
+    suggestedResourceId: parsed.suggestedResourceId || undefined,
+    navigationRequired: parsed.navigationRequired || false,
+    steps: parsed.steps || undefined,
+    visualDescription: parsed.visualDescription || "",
+    similarElements: parsed.similarElements || [],
+    confidence: parsed.confidence || 0,
+    reasoning: parsed.reasoning || "",
+  };
+}
+
+export function calculateClaudeCost(inputTokens: number, outputTokens: number): number {
+  return (inputTokens / 1_000_000) * 3 + (outputTokens / 1_000_000) * 15;
+}
+
+export function toClaudeVisionFallbackResult(
+  analysis: ClaudeVisionAnalysis,
+  costUsd: number,
+  durationMs: number,
+  screenshotPath: string
+): VisionFallbackResult {
+  const confidence: VisionFallbackResult["confidence"] =
+    analysis.confidence >= 0.9 ? "high" : analysis.confidence >= 0.7 ? "medium" : "low";
+  const navigationSteps: NavigationStep[] | undefined = analysis.steps?.map(step => ({
+    action: mapClaudeAction(step.action),
+    target: step.target,
+    description: step.reasoning,
+  }));
+  const alternativeSelectors: AlternativeSelector[] = [];
+  if (analysis.suggestedText) {
+    alternativeSelectors.push({ type: "text", value: analysis.suggestedText, confidence: analysis.confidence, reasoning: "Claude suggested this text as alternative" });
+  }
+  if (analysis.suggestedResourceId) {
+    alternativeSelectors.push({ type: "resourceId", value: analysis.suggestedResourceId, confidence: analysis.confidence, reasoning: "Claude suggested this resource ID as alternative" });
+  }
+
+  return {
+    found: analysis.elementFound,
+    confidence,
+    navigationSteps: navigationSteps?.length ? navigationSteps : undefined,
+    alternativeSelectors: alternativeSelectors.length ? alternativeSelectors : undefined,
+    reason: analysis.elementFound ? undefined : analysis.reasoning,
+    similarElements: analysis.similarElements,
+    costUsd,
+    durationMs,
+    screenshotPath,
+    provider: "claude",
+  };
+}
+
+function mapClaudeAction(action: string): NavigationStep["action"] {
+  const normalized = action.toLowerCase();
+  if (normalized.includes("tap") || normalized.includes("click")) { return "tap"; }
+  if (normalized.includes("swipe")) { return "swipe"; }
+  if (normalized.includes("scroll")) { return "scroll"; }
+  if (normalized.includes("input") || normalized.includes("type")) { return "input"; }
+  if (normalized.includes("wait")) { return "wait"; }
+  return "tap";
+}
+
 export class ClaudeVisionClient {
   private client: Anthropic;
   private model: string;
@@ -70,17 +153,17 @@ export class ClaudeVisionClient {
       });
 
       // Parse response
-      const analysis = this.parseClaudeResponse(response);
+      const analysis = parseClaudeResponse(response);
 
       // Calculate cost (approximate)
       const inputTokens = response.usage.input_tokens;
       const outputTokens = response.usage.output_tokens;
-      const costUsd = this.calculateCost(inputTokens, outputTokens);
+      const costUsd = calculateClaudeCost(inputTokens, outputTokens);
 
       const durationMs = this.timer.now() - startTime;
 
       // Convert analysis to VisionFallbackResult
-      return this.convertToFallbackResult(
+      return toClaudeVisionFallbackResult(
         analysis,
         costUsd,
         durationMs,
@@ -171,113 +254,4 @@ export class ClaudeVisionClient {
     return parts.join("\n");
   }
 
-  private parseClaudeResponse(response: Anthropic.Message): ClaudeVisionAnalysis {
-    // Extract text from response
-    let responseText = "";
-    for (const block of response.content) {
-      if (block.type === "text") {
-        responseText += block.text;
-      }
-    }
-
-    // Try to extract JSON from the response
-    const jsonMatch = responseText.match(/```json\n([\s\S]*?)\n```/) || responseText.match(/\{[\s\S]*\}/);
-
-    if (!jsonMatch) {
-      throw new Error("Failed to parse JSON from Claude response");
-    }
-
-    const jsonStr = jsonMatch[1] || jsonMatch[0];
-    let parsed: any;
-    try {
-      parsed = JSON.parse(jsonStr);
-    } catch (err) {
-      throw new Error(
-        `Failed to parse JSON from Claude response: ${(err as Error).message}`
-      );
-    }
-
-    return {
-      elementFound: parsed.elementFound || false,
-      elementLocation: parsed.elementLocation || undefined,
-      suggestedText: parsed.suggestedText || undefined,
-      suggestedResourceId: parsed.suggestedResourceId || undefined,
-      navigationRequired: parsed.navigationRequired || false,
-      steps: parsed.steps || undefined,
-      visualDescription: parsed.visualDescription || "",
-      similarElements: parsed.similarElements || [],
-      confidence: parsed.confidence || 0,
-      reasoning: parsed.reasoning || "",
-    };
-  }
-
-  private convertToFallbackResult(
-    analysis: ClaudeVisionAnalysis,
-    costUsd: number,
-    durationMs: number,
-    screenshotPath: string
-  ): VisionFallbackResult {
-    // Determine confidence level
-    const confidenceLevel: "high" | "medium" | "low" =
-      analysis.confidence >= 0.9 ? "high" :
-        analysis.confidence >= 0.7 ? "medium" : "low";
-
-    // Build navigation steps if provided
-    const navigationSteps: NavigationStep[] | undefined = analysis.steps?.map(step => ({
-      action: this.mapAction(step.action),
-      target: step.target,
-      description: step.reasoning,
-    }));
-
-    // Build alternative selectors
-    const alternativeSelectors: AlternativeSelector[] = [];
-    if (analysis.suggestedText) {
-      alternativeSelectors.push({
-        type: "text",
-        value: analysis.suggestedText,
-        confidence: analysis.confidence,
-        reasoning: "Claude suggested this text as alternative",
-      });
-    }
-    if (analysis.suggestedResourceId) {
-      alternativeSelectors.push({
-        type: "resourceId",
-        value: analysis.suggestedResourceId,
-        confidence: analysis.confidence,
-        reasoning: "Claude suggested this resource ID as alternative",
-      });
-    }
-
-    return {
-      found: analysis.elementFound,
-      confidence: confidenceLevel,
-      navigationSteps: navigationSteps && navigationSteps.length > 0 ? navigationSteps : undefined,
-      alternativeSelectors: alternativeSelectors.length > 0 ? alternativeSelectors : undefined,
-      reason: !analysis.elementFound ? analysis.reasoning : undefined,
-      similarElements: analysis.similarElements,
-      costUsd,
-      durationMs,
-      screenshotPath,
-      provider: "claude",
-    };
-  }
-
-  private mapAction(action: string): NavigationStep["action"] {
-    const normalized = action.toLowerCase();
-    if (normalized.includes("tap") || normalized.includes("click")) {return "tap";}
-    if (normalized.includes("swipe")) {return "swipe";}
-    if (normalized.includes("scroll")) {return "scroll";}
-    if (normalized.includes("input") || normalized.includes("type")) {return "input";}
-    if (normalized.includes("wait")) {return "wait";}
-    return "tap"; // Default
-  }
-
-  private calculateCost(inputTokens: number, outputTokens: number): number {
-    // Claude Sonnet 4.5 pricing (as of 2025)
-    // Input: $3 per million tokens
-    // Output: $15 per million tokens
-    const inputCost = (inputTokens / 1_000_000) * 3.0;
-    const outputCost = (outputTokens / 1_000_000) * 15.0;
-    return inputCost + outputCost;
-  }
 }

--- a/test/constants/release.test.ts
+++ b/test/constants/release.test.ts
@@ -386,6 +386,7 @@ describe("resolveVideoJarChecksum (video-server jar delivery, #3830)", function(
   });
 
   test("registry entries carry empty or well-formed 64-char videoJarSha256 values", function() {
+    expect(RELEASE_CHECKSUM_REGISTRY.length).toBeGreaterThan(0);
     for (const entry of RELEASE_CHECKSUM_REGISTRY) {
       const jar = entry.videoJarSha256 ?? "";
       expect(jar === "" || /^[a-f0-9]{64}$/.test(jar)).toBe(true);
@@ -420,6 +421,7 @@ describe("screen-capture-helper release delivery", function() {
   });
 
   test("registry helper checksums are empty or SHA-256 values", function() {
+    expect(RELEASE_CHECKSUM_REGISTRY.length).toBeGreaterThan(0);
     for (const entry of RELEASE_CHECKSUM_REGISTRY) {
       const checksum = entry.screenCaptureHelperSha256 ?? "";
       expect(checksum === "" || /^[a-f0-9]{64}$/.test(checksum)).toBe(true);
@@ -529,13 +531,16 @@ describe("package.json as canonical version source", function() {
     readFileSync(join(import.meta.dir, "../../package.json"), "utf8")
   ) as { version: string };
 
-  test("resolveLatestVersion() equals package.json version", function() {
+  test("keeps a non-empty newest registry entry coherent with package.json", function() {
+    expect(RELEASE_CHECKSUM_REGISTRY.length).toBeGreaterThan(0);
+    expect(RELEASE_CHECKSUM_REGISTRY[0].version).toBe(pkg.version);
     expect(resolveLatestVersion()).toBe(pkg.version);
   });
 });
 
 describe("iOS runner-binary checksum", function() {
   test("registry entries carry empty or well-formed 64-char runner sha256 values", function() {
+    expect(RELEASE_CHECKSUM_REGISTRY.length).toBeGreaterThan(0);
     for (const entry of RELEASE_CHECKSUM_REGISTRY) {
       expect(entry.runnerSha256 === "" || /^[a-f0-9]{64}$/.test(entry.runnerSha256)).toBe(true);
     }

--- a/test/contracts/ChecksumCalculatorContract.ts
+++ b/test/contracts/ChecksumCalculatorContract.ts
@@ -7,6 +7,7 @@ import type { ChecksumCalculator } from "../../src/utils/ChecksumCalculator";
 
 export interface ChecksumCalculatorContractFactory {
   make(expectedChecksum: string): ChecksumCalculator;
+  makeFailure(): ChecksumCalculator;
 }
 
 export const runChecksumCalculatorContract = (
@@ -29,6 +30,11 @@ export const runChecksumCalculatorContract = (
       } finally {
         await fs.rm(tempDir, { recursive: true, force: true });
       }
+    });
+
+    test("rejects a missing file instead of fabricating a checksum", async function() {
+      await expect(factory.makeFailure().computeFileSha256("/missing-contract-file.bin"))
+        .rejects.toThrow();
     });
   });
 };

--- a/test/contracts/FileDownloaderContract.ts
+++ b/test/contracts/FileDownloaderContract.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import fs from "node:fs/promises";
 import http from "node:http";
+import os from "node:os";
 import path from "node:path";
 import type { FileDownloader } from "../../src/utils/FileDownloader";
 
@@ -20,7 +21,7 @@ export const runFileDownloaderContract = (
 
     test("writes the downloaded payload to the requested destination", async function() {
       const payload = Buffer.from("download contract payload");
-      tempDir = await makeScratchTempDir("download-contract-");
+      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "auto-mobile-download-contract-"));
       const destination = path.join(tempDir, "nested", "payload.txt");
       const downloader = makeDownloader(payload);
       const server = await createPayloadServer(payload);
@@ -32,13 +33,18 @@ export const runFileDownloaderContract = (
         await server.close();
       }
     });
-  });
-};
 
-const makeScratchTempDir = async (prefix: string): Promise<string> => {
-  const scratchDir = path.join(process.cwd(), "scratch");
-  await fs.mkdir(scratchDir, { recursive: true });
-  return fs.mkdtemp(path.join(scratchDir, prefix));
+    test("rejects an already-aborted download without writing a destination", async function() {
+      const controller = new AbortController();
+      controller.abort();
+      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "auto-mobile-download-contract-"));
+      const destination = path.join(tempDir, "payload.txt");
+
+      await expect(makeDownloader(Buffer.from("payload")).download("https://example.invalid/payload", destination, controller.signal))
+        .rejects.toThrow(/aborted/i);
+      expect(await fs.stat(destination).catch(() => undefined)).toBeUndefined();
+    });
+  });
 };
 
 const createPayloadServer = async (

--- a/test/contracts/FileDownloaderContract.ts
+++ b/test/contracts/FileDownloaderContract.ts
@@ -44,6 +44,19 @@ export const runFileDownloaderContract = (
         .rejects.toThrow(/aborted/i);
       expect(await fs.stat(destination).catch(() => undefined)).toBeUndefined();
     });
+
+    test("rejects a download aborted after it starts without writing a destination", async function() {
+      const controller = new AbortController();
+      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "auto-mobile-download-contract-"));
+      const destination = path.join(tempDir, "payload.txt");
+      const download = makeDownloader(Buffer.from("payload"))
+        .download("https://example.invalid/payload", destination, controller.signal);
+
+      controller.abort();
+
+      await expect(download).rejects.toThrow(/aborted/i);
+      expect(await fs.stat(destination).catch(() => undefined)).toBeUndefined();
+    });
   });
 };
 

--- a/test/contracts/TimerContract.ts
+++ b/test/contracts/TimerContract.ts
@@ -90,6 +90,19 @@ export const runTimerContract = (
 
       expect(calls).toBe(0);
     });
+
+    test("setInterval keeps firing until it is cancelled", async function() {
+      const timer = makeTimer();
+      let calls = 0;
+      const handle = timer.setInterval(() => {
+        calls++;
+      }, capabilities.realTime ? 1 : 10);
+
+      await timer.sleep(capabilities.realTime ? 15 : 25);
+      timer.clearInterval(handle);
+
+      expect(calls).toBeGreaterThan(1);
+    });
   });
 };
 

--- a/test/contracts/TimerContract.ts
+++ b/test/contracts/TimerContract.ts
@@ -91,18 +91,20 @@ export const runTimerContract = (
       expect(calls).toBe(0);
     });
 
-    test("setInterval keeps firing until it is cancelled", async function() {
-      const timer = makeTimer();
-      let calls = 0;
-      const handle = timer.setInterval(() => {
-        calls++;
-      }, capabilities.realTime ? 1 : 10);
+    if (!capabilities.realTime) {
+      test("setInterval keeps firing until it is cancelled", async function() {
+        const timer = makeTimer();
+        let calls = 0;
+        const handle = timer.setInterval(() => {
+          calls++;
+        }, 10);
 
-      await timer.sleep(capabilities.realTime ? 15 : 25);
-      timer.clearInterval(handle);
+        await timer.sleep(25);
+        timer.clearInterval(handle);
 
-      expect(calls).toBeGreaterThan(1);
-    });
+        expect(calls).toBeGreaterThan(1);
+      });
+    }
   });
 };
 

--- a/test/contracts/TimerContract.ts
+++ b/test/contracts/TimerContract.ts
@@ -42,9 +42,9 @@ export const runTimerContract = (
 
       timer.setTimeout(() => {
         fired = true;
-      }, capabilities.realTime ? 5 : 10);
+      }, capabilities.realTime ? 1 : 10);
 
-      await timer.sleep(capabilities.realTime ? 20 : 20);
+      await timer.sleep(capabilities.realTime ? 15 : 20);
 
       expect(fired).toBe(true);
     });
@@ -53,10 +53,10 @@ export const runTimerContract = (
       const timer = makeTimer();
       const calls: string[] = [];
 
-      timer.setTimeout(() => calls.push("late"), capabilities.realTime ? 20 : 100);
-      timer.setTimeout(() => calls.push("early"), capabilities.realTime ? 5 : 10);
+      timer.setTimeout(() => calls.push("late"), capabilities.realTime ? 5 : 100);
+      timer.setTimeout(() => calls.push("early"), capabilities.realTime ? 1 : 10);
 
-      await timer.sleep(capabilities.realTime ? 40 : 101);
+      await timer.sleep(capabilities.realTime ? 15 : 101);
 
       expect(calls).toEqual(["early", "late"]);
     });
@@ -67,11 +67,11 @@ export const runTimerContract = (
 
       const handle = timer.setTimeout(() => {
         fired = true;
-      }, capabilities.realTime ? 20 : 10);
+      }, capabilities.realTime ? 5 : 10);
       timer.clearTimeout(handle);
 
       if (capabilities.realTime) {
-        await timer.sleep(30);
+        await timer.sleep(15);
       }
 
       expect(fired).toBe(false);
@@ -86,7 +86,7 @@ export const runTimerContract = (
       }, capabilities.realTime ? 1 : 10);
       timer.clearInterval(handle);
 
-      await timer.sleep(capabilities.realTime ? 10 : 0);
+      await timer.sleep(capabilities.realTime ? 15 : 0);
 
       expect(calls).toBe(0);
     });

--- a/test/contracts/runAll.test.ts
+++ b/test/contracts/runAll.test.ts
@@ -55,14 +55,20 @@ runFileSystemContract("FakeFileSystem", () => new FakeFileSystem(), {
 });
 
 runChecksumCalculatorContract("DefaultChecksumCalculator", {
-  make: () => new DefaultChecksumCalculator()
+  make: () => new DefaultChecksumCalculator(),
+  makeFailure: () => new DefaultChecksumCalculator(),
 });
 runChecksumCalculatorContract("FakeChecksumCalculator", {
   make: expectedChecksum => {
     const calculator = new FakeChecksumCalculator();
     calculator.checksum = expectedChecksum;
     return calculator;
-  }
+  },
+  makeFailure: () => {
+    const calculator = new FakeChecksumCalculator();
+    calculator.shouldThrow = new Error("missing contract file");
+    return calculator;
+  },
 });
 
 runFileDownloaderContract("DefaultFileDownloader", () => new DefaultFileDownloader());

--- a/test/doctor/checks/daemonConnectivity.test.ts
+++ b/test/doctor/checks/daemonConnectivity.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { checkDaemonConnectivity } from "../../../src/doctor/checks/automobile";
+import type { DaemonHealthReport } from "../../../src/daemon/debugTools";
+
+const healthReport = (overrides: Partial<DaemonHealthReport> = {}): DaemonHealthReport => ({
+  timestamp: "2026-07-27T00:00:00.000Z",
+  daemonRunning: true,
+  socketExists: true,
+  socketAccessible: true,
+  pidFileExists: true,
+  pidFileValid: true,
+  socketConnectable: true,
+  recommendations: [],
+  ...overrides,
+});
+
+describe("checkDaemonConnectivity", () => {
+  test.each([
+    {
+      name: "reports pass when the daemon socket accepts connections",
+      report: healthReport(),
+      expected: { status: "pass", message: "Daemon is responsive" },
+    },
+    {
+      name: "reports skip when no daemon is running",
+      report: healthReport({ daemonRunning: false, socketConnectable: false }),
+      expected: { status: "skip", message: "Daemon is not running" },
+    },
+    {
+      name: "reports the daemon recommendation when a running daemon is hung",
+      report: healthReport({ socketConnectable: false, recommendations: ["Remove stale socket", "Restart daemon"] }),
+      expected: { status: "warn", message: "Daemon running but not responding", recommendation: "Remove stale socket; Restart daemon" },
+    },
+    {
+      name: "falls back to the restart recommendation when a hung daemon gives none",
+      report: healthReport({ socketConnectable: false }),
+      expected: { status: "warn", message: "Daemon running but not responding" },
+      recommendationContains: "--daemon restart",
+    },
+  ])("$name", async ({ report, expected, recommendationContains }) => {
+    const result = await checkDaemonConnectivity(async () => report);
+
+    expect(result).toMatchObject(expected);
+    if (recommendationContains) {
+      expect(result.recommendation).toContain(recommendationContains);
+      expect(result.recommendation).not.toContain("@latest");
+    } else if (!("recommendation" in expected)) {
+      expect(result.recommendation).toBeUndefined();
+    }
+  });
+
+  test("returns a warning when the health probe throws", async () => {
+    const result = await checkDaemonConnectivity(async () => {
+      throw new Error("socket unavailable");
+    });
+
+    expect(result).toMatchObject({
+      name: "Daemon Connectivity",
+      status: "warn",
+      message: "Connectivity check failed: socket unavailable",
+    });
+  });
+});

--- a/test/doctor/checks/workProfileAccessibility.test.ts
+++ b/test/doctor/checks/workProfileAccessibility.test.ts
@@ -132,6 +132,48 @@ describe("checkWorkProfileAccessibility", () => {
     expect(result.message).toBe("No work profiles detected");
   });
 
+  test.each([
+    {
+      name: "a running secondary user without the managed-profile flag",
+      users: [
+        { userId: 0, name: "Owner", flags: 0x13, running: true },
+        { userId: 10, name: "Personal secondary", flags: 0x10, running: true },
+      ],
+      expected: { status: "pass", message: "No work profiles detected" },
+    },
+    {
+      name: "a stopped managed profile",
+      users: [
+        { userId: 0, name: "Owner", flags: 0x13, running: true },
+        { userId: 10, name: "Stopped work", flags: 0x30, running: false },
+      ],
+      expected: { status: "pass", message: "No work profiles detected" },
+    },
+  ])("does not warn for $name", async ({ users, expected }) => {
+    fakeAdb.setDevices([{ name: "emulator-5554", platform: "android", deviceId: "emulator-5554" }]);
+    fakeAdb.setUsers(users);
+
+    const result = await checkWorkProfileAccessibility(fakeFactory);
+
+    expect(result).toMatchObject(expected);
+  });
+
+  test("returns the ADB failure cause when profile discovery throws", async () => {
+    fakeAdb.setDevices([{ name: "emulator-5554", platform: "android", deviceId: "emulator-5554" }]);
+    fakeAdb.setUsers([
+      { userId: 0, name: "Owner", flags: 0x13, running: true },
+      { userId: 10, name: "Work profile", flags: 0x30, running: true },
+    ]);
+    fakeAdb.setCommandError("enabled_accessibility_services", new Error("adb server not running"));
+
+    const result = await checkWorkProfileAccessibility(fakeFactory);
+
+    expect(result).toMatchObject({
+      status: "skip",
+      message: "Could not check: adb server not running",
+    });
+  });
+
   test("handles multiple work profiles with mixed accessibility status", async () => {
     const device: BootedDevice = {
       name: "emulator-5554",

--- a/test/fakes/FakeFileDownloader.ts
+++ b/test/fakes/FakeFileDownloader.ts
@@ -19,6 +19,9 @@ export class FakeFileDownloader implements FileDownloader {
     this.downloadedUrls.push(url);
     this.downloadedDestinations.push(destination);
     await fs.mkdir(path.dirname(destination), { recursive: true });
+    if (signal?.aborted) {
+      throw new Error(`Download aborted while writing: ${url}`);
+    }
     await fs.writeFile(destination, this.payload);
     this.lastWrittenPath = destination;
   }

--- a/test/fakes/FakeFileDownloader.ts
+++ b/test/fakes/FakeFileDownloader.ts
@@ -9,7 +9,10 @@ export class FakeFileDownloader implements FileDownloader {
   public shouldThrow: Error | null = null;
   public lastWrittenPath: string | null = null;
 
-  public async download(url: string, destination: string): Promise<void> {
+  public async download(url: string, destination: string, signal?: AbortSignal): Promise<void> {
+    if (signal?.aborted) {
+      throw new Error(`Download aborted before starting: ${url}`);
+    }
     if (this.shouldThrow) {
       throw this.shouldThrow;
     }

--- a/test/fakes/FakeTimer.test.ts
+++ b/test/fakes/FakeTimer.test.ts
@@ -37,6 +37,22 @@ describe("FakeTimer auto-advance", function() {
 
     expect(events).toEqual(["first", "second"]);
   });
+
+  test("reset during an interval callback prevents recurrence", async function() {
+    const timer = new FakeTimer();
+    timer.enableAutoAdvance();
+    let calls = 0;
+
+    timer.setInterval(() => {
+      calls++;
+      timer.reset();
+    }, 1);
+
+    await timer.sleep(10);
+    await new Promise<void>(resolve => setImmediate(resolve));
+
+    expect(calls).toBe(1);
+  });
 });
 
 describe("FakeTimer async manual advancement", function() {

--- a/test/fakes/FakeTimer.ts
+++ b/test/fakes/FakeTimer.ts
@@ -69,6 +69,8 @@ export class FakeTimer implements Timer {
   private pendingAutoAdvanceTasks: PendingAutoAdvanceTask[] = [];
   private nextAutoAdvanceTaskOrder: number = 1;
   private autoAdvanceDispatchScheduled: boolean = false;
+  // Invalidates auto-advance callbacks that were scheduled before reset().
+  private autoAdvanceGeneration: number = 0;
   // Monotonic registration counter so manual advanceTime() can break equal
   // due-time ties by FIFO registration order across sleeps/timeouts/intervals.
   private nextEventSeq: number = 1;
@@ -307,6 +309,7 @@ export class FakeTimer implements Timer {
    * Reset all state (clears pending sleeps, timeouts, intervals, history, and time).
    */
   reset(): void {
+    this.autoAdvanceGeneration++;
     // Resolve all pending sleeps before clearing to avoid hanging promises
     this.resolveAll();
     this.sleepHistory = [];
@@ -380,15 +383,18 @@ export class FakeTimer implements Timer {
     this.nextIntervalId++;
     if (this.autoAdvance) {
       const period = ms > 0 ? ms : 1;
+      const generation = this.autoAdvanceGeneration;
       const scheduleNext = (): void => this.enqueueAutoAdvanceTask(() => {
-        if (!this.cancelledIntervalIds.has(numericId)) {
+        if (generation === this.autoAdvanceGeneration && !this.cancelledIntervalIds.has(numericId)) {
           callback();
-          if (!this.cancelledIntervalIds.has(numericId)) {
+          if (generation === this.autoAdvanceGeneration && !this.cancelledIntervalIds.has(numericId)) {
             scheduleNext();
             return;
           }
         }
-        this.cancelledIntervalIds.delete(numericId);
+        if (generation === this.autoAdvanceGeneration) {
+          this.cancelledIntervalIds.delete(numericId);
+        }
       }, period);
       scheduleNext();
       return id;

--- a/test/fakes/FakeTimer.ts
+++ b/test/fakes/FakeTimer.ts
@@ -372,19 +372,25 @@ export class FakeTimer implements Timer {
   /**
    * Schedule a callback to be executed repeatedly at a specified interval.
    * In normal mode: fires each time advanceTime() moves past the interval.
-   * In auto-advance mode: fires once at its scheduled fake time (intervals should not repeat in tests).
+   * In auto-advance mode: reschedules itself at each fake interval until cancelled.
    */
   setInterval(callback: () => void, ms: number): NodeJS.Timeout {
     const id = this.nextIntervalId as unknown as NodeJS.Timeout;
     const numericId = this.nextIntervalId;
     this.nextIntervalId++;
     if (this.autoAdvance) {
-      this.enqueueAutoAdvanceTask(() => {
+      const period = ms > 0 ? ms : 1;
+      const scheduleNext = (): void => this.enqueueAutoAdvanceTask(() => {
         if (!this.cancelledIntervalIds.has(numericId)) {
           callback();
+          if (!this.cancelledIntervalIds.has(numericId)) {
+            scheduleNext();
+            return;
+          }
         }
         this.cancelledIntervalIds.delete(numericId);
-      }, ms);
+      }, period);
+      scheduleNext();
       return id;
     }
     this.pendingIntervals.push({

--- a/test/helpers/withTemporaryTool.ts
+++ b/test/helpers/withTemporaryTool.ts
@@ -1,0 +1,14 @@
+import { ToolRegistry } from "../../src/server/toolRegistry";
+
+export async function withTemporaryTool<T>(
+  name: string,
+  register: () => void,
+  run: () => Promise<T>
+): Promise<T> {
+  register();
+  try {
+    return await run();
+  } finally {
+    ToolRegistry.unregister(name);
+  }
+}

--- a/test/plan/PlanSchemaValidator.test.ts
+++ b/test/plan/PlanSchemaValidator.test.ts
@@ -663,3 +663,16 @@ steps:
     });
   });
 });
+
+describe("PlanSchemaValidator.validateFile", () => {
+  it("returns the schema-loading error before attempting to read a missing file", async () => {
+    const validator = new PlanSchemaValidator();
+
+    const result = await validator.validateFile("/definitely-missing-plan.yaml");
+
+    expect(result).toEqual({
+      valid: false,
+      errors: [{ field: "schema", message: "Schema not loaded. Call loadSchema() first." }],
+    });
+  });
+});

--- a/test/plan/planExecutorAbortAfterStep.test.ts
+++ b/test/plan/planExecutorAbortAfterStep.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, test, beforeEach } from "bun:test";
 import { DefaultPlanExecutor } from "../../src/utils/plan/PlanExecutor";
-import { Plan } from "../../src/models/Plan";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import { z } from "zod";
 import { OPERATION_CANCELLED_MESSAGE } from "../../src/utils/constants";
+import { withTemporaryTool } from "../helpers/withTemporaryTool";
 
-
-const toolName = `abortTest_${Date.now()}`;
+const toolName = "abortTest";
 
 const toolSchema = z.object({
   platform: z.string().optional(),
@@ -26,83 +25,52 @@ describe("PlanExecutor - abort signal checked after each step", () => {
   test("aborts immediately after tool returns when signal fired during execution", async () => {
     const abortController = new AbortController();
 
-    ToolRegistry.register(
-      toolName,
-      "Tool that aborts the signal mid-execution on step 1",
-      toolSchema,
-      async () => {
+    await withTemporaryTool(toolName, () => {
+      ToolRegistry.register(toolName, "Tool that aborts the signal mid-execution on step 1", toolSchema, async () => {
         toolCallCount++;
         if (toolCallCount === 1) {
           abortController.abort();
         }
         return { success: true };
-      },
-    );
+      });
+      (ToolRegistry.getTool(toolName) as any).requiresDevice = false;
+    }, async () => {
+      const result = await planExecutor.executePlan({
+        name: "Abort After Step",
+        mcpVersion: "1.0",
+        steps: [{ tool: toolName, params: {} }, { tool: toolName, params: {} }, { tool: toolName, params: {} }],
+      }, 0, "android", undefined, undefined, abortController.signal);
 
-    const tool = ToolRegistry.getTool(toolName)!;
-    (tool as any).requiresDevice = false;
+      expect(toolCallCount).toBe(1);
+      expect(result.success).toBe(false);
+      expect(result.failedStep?.error).toInclude(OPERATION_CANCELLED_MESSAGE);
+    });
 
-    const plan: Plan = {
-      name: "Abort After Step",
-      mcpVersion: "1.0",
-      steps: [
-        { tool: toolName, params: {} },
-        { tool: toolName, params: {} },
-        { tool: toolName, params: {} },
-      ],
-    };
-
-    const result = await planExecutor.executePlan(
-      plan,
-      0,
-      "android",
-      undefined,
-      undefined,
-      abortController.signal,
-    );
-
-    expect(toolCallCount).toBe(1);
-    expect(result.success).toBe(false);
-    expect(result.failedStep?.error).toInclude(OPERATION_CANCELLED_MESSAGE);
+    expect(ToolRegistry.getTool(toolName)).toBeUndefined();
   });
 
   test("completes normally when signal is never aborted", async () => {
-    const completionToolName = `abortTestComplete_${Date.now()}`;
+    const completionToolName = "abortTestComplete";
     const abortController = new AbortController();
 
-    ToolRegistry.register(
-      completionToolName,
-      "Tool that never aborts",
-      toolSchema,
-      async () => {
+    await withTemporaryTool(completionToolName, () => {
+      ToolRegistry.register(completionToolName, "Tool that never aborts", toolSchema, async () => {
         toolCallCount++;
         return { success: true };
-      },
-    );
+      });
+      (ToolRegistry.getTool(completionToolName) as any).requiresDevice = false;
+    }, async () => {
+      const result = await planExecutor.executePlan({
+        name: "No Abort",
+        mcpVersion: "1.0",
+        steps: [{ tool: completionToolName, params: {} }, { tool: completionToolName, params: {} }],
+      }, 0, "android", undefined, undefined, abortController.signal);
 
-    const tool = ToolRegistry.getTool(completionToolName)!;
-    (tool as any).requiresDevice = false;
+      expect(toolCallCount).toBe(2);
+      expect(result.success).toBe(true);
+      expect(result.executedSteps).toBe(2);
+    });
 
-    const plan: Plan = {
-      name: "No Abort",
-      mcpVersion: "1.0",
-      steps: [
-        { tool: completionToolName, params: {} },
-        { tool: completionToolName, params: {} },
-      ],
-    };
-
-    const result = await planExecutor.executePlan(
-      plan,
-      0,
-      "android",
-      undefined,
-      undefined,
-      abortController.signal,
-    );
-
-    expect(toolCallCount).toBe(2);
-    expect(result.success).toBe(true);
-    expect(result.executedSteps).toBe(2);
+    expect(ToolRegistry.getTool(completionToolName)).toBeUndefined();
   });
 });

--- a/test/scripts/gradleTaskRunAction.test.ts
+++ b/test/scripts/gradleTaskRunAction.test.ts
@@ -6,7 +6,14 @@ import { load } from "js-yaml";
 const actionPath = join(import.meta.dir, "../../.github/actions/gradle-task-run/action.yml");
 
 interface CompositeAction {
-  runs?: { using?: string; steps?: Array<{ uses?: string }> };
+  runs?: { using?: string; steps?: CompositeActionStep[] };
+}
+
+interface CompositeActionStep {
+  id?: string;
+  name?: string;
+  run?: string;
+  uses?: string;
 }
 
 function usesRefs(action: CompositeAction): string[] {
@@ -40,5 +47,12 @@ describe("gradle-task-run action", () => {
     }
 
     expect(refs.some(ref => ref.startsWith("pplanel/hash-calculator-action@"))).toBe(false);
+
+    const evalGradle = action.runs?.steps?.find(step => step.id === "eval_gradle");
+    expect(evalGradle?.run).toContain('echo "version=$(cat /tmp/gradle_version.txt)" >> "$GITHUB_OUTPUT"');
+    expect(evalGradle?.run).toContain('echo "version=${{ inputs.gradle-version }}" >> "$GITHUB_OUTPUT"');
+
+    const hashGradleTasks = action.runs?.steps?.find(step => step.name === "Hash Gradle Tasks");
+    expect(hashGradleTasks?.run).toContain('echo "digest=$digest" >> "$GITHUB_OUTPUT"');
   });
 });

--- a/test/scripts/gradleTaskRunAction.test.ts
+++ b/test/scripts/gradleTaskRunAction.test.ts
@@ -1,26 +1,40 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { load } from "js-yaml";
 
-const repoRoot = join(import.meta.dir, "../..");
-const actionPath = join(repoRoot, ".github/actions/gradle-task-run/action.yml");
+const actionPath = join(import.meta.dir, "../../.github/actions/gradle-task-run/action.yml");
+
+interface CompositeAction {
+  runs?: { using?: string; steps?: Array<{ uses?: string }> };
+}
+
+function usesRefs(action: CompositeAction): string[] {
+  return (action.runs?.steps ?? []).flatMap(step => step.uses ? [step.uses] : []);
+}
+
+function majorVersion(ref: string): number | undefined {
+  const match = /@v(\d+)(?:\.|$)/.exec(ref);
+  return match ? Number(match[1]) : undefined;
+}
 
 describe("gradle-task-run action", () => {
-  test("does not reference GitHub actions pinned to Node 20 runtimes", () => {
-    const action = readFileSync(actionPath, "utf8");
+  test("uses action versions at or above the supported Node runtime floor", () => {
+    const action = load(readFileSync(actionPath, "utf8")) as CompositeAction;
+    const refs = usesRefs(action);
+    const minimumMajorByAction: Record<string, number> = {
+      "actions/setup-java": 5,
+      "gradle/actions/setup-gradle": 5,
+      "actions/cache/restore": 5,
+      "actions/cache/save": 5,
+      "actions/upload-artifact": 7,
+    };
 
-    expect(action).not.toContain("pplanel/hash-calculator-action");
-    expect(action).not.toContain("actions/cache/restore@v4");
-    expect(action).not.toContain("actions/cache/save@v4");
-    expect(action).not.toContain("actions/upload-artifact@v4.4.0");
-    expect(action).not.toContain("gradle/actions/setup-gradle@v4");
-
-    expect(action).toContain("gradle/actions/setup-gradle@v5.0.2");
-    expect(action).toContain("actions/cache/restore@v5.1.0");
-    expect(action).toContain("actions/cache/save@v5.1.0");
-    expect(action).toContain("actions/upload-artifact@v7.0.1");
-    expect(action).toContain('echo "digest=$digest" >> "$GITHUB_OUTPUT"');
-    expect(action).toContain('echo "version=$(cat /tmp/gradle_version.txt)" >> "$GITHUB_OUTPUT"');
-    expect(action).toContain('echo "version=${{ inputs.gradle-version }}" >> "$GITHUB_OUTPUT"');
+    expect(action.runs?.using).toBe("composite");
+    for (const [actionName, minimumMajor] of Object.entries(minimumMajorByAction)) {
+      const ref = refs.find(candidate => candidate.startsWith(`${actionName}@`));
+      expect(ref).toBeDefined();
+      expect(majorVersion(ref!)).toBeGreaterThanOrEqual(minimumMajor);
+    }
   });
 });

--- a/test/scripts/gradleTaskRunAction.test.ts
+++ b/test/scripts/gradleTaskRunAction.test.ts
@@ -32,9 +32,13 @@ describe("gradle-task-run action", () => {
 
     expect(action.runs?.using).toBe("composite");
     for (const [actionName, minimumMajor] of Object.entries(minimumMajorByAction)) {
-      const ref = refs.find(candidate => candidate.startsWith(`${actionName}@`));
-      expect(ref).toBeDefined();
-      expect(majorVersion(ref!)).toBeGreaterThanOrEqual(minimumMajor);
+      const matchingRefs = refs.filter(candidate => candidate.startsWith(`${actionName}@`));
+      expect(matchingRefs.length).toBeGreaterThan(0);
+      for (const ref of matchingRefs) {
+        expect(majorVersion(ref)).toBeGreaterThanOrEqual(minimumMajor);
+      }
     }
+
+    expect(refs.some(ref => ref.startsWith("pplanel/hash-calculator-action@"))).toBe(false);
   });
 });

--- a/test/scripts/xcodegenDriftCheck.test.ts
+++ b/test/scripts/xcodegenDriftCheck.test.ts
@@ -3,12 +3,12 @@ import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rm
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
+import { loadJobSteps } from "../helpers/workflowSteps";
 
 const repoRoot = join(import.meta.dir, "../..");
 const driftCheckScript = join(repoRoot, "scripts/ios/xcodegen-drift-check.sh");
 const versionScript = join(repoRoot, "scripts/ios/xcodegen_version.sh");
 const normalizeScript = join(repoRoot, "scripts/ios/pbxproj_normalize.sh");
-const workflowPath = join(repoRoot, ".github/workflows/pull_request.yml");
 const tempDirs: string[] = [];
 
 // A minimal PBXProject `targets = (...)` block in two of the orders XcodeGen
@@ -358,19 +358,21 @@ describe("xcodegen drift check", () => {
   });
 
   test("pull request workflow gates both Xcode project jobs on the drift check", () => {
-    const workflow = readFileSync(workflowPath, "utf8");
-    const xcodeBuildJob = workflow.indexOf("ios-xcode-build:");
-    const xctestRunnerJob = workflow.indexOf("ios-xctest-runner-simulator-tests:");
-    const xcodeBuildDriftCheck = workflow.indexOf("./scripts/ios/xcodegen-drift-check.sh --all", xcodeBuildJob);
-    const xcodeBuild = workflow.indexOf("./scripts/ios/xcode-build.sh", xcodeBuildJob);
-    const xctestRunnerDriftCheck = workflow.indexOf("./scripts/ios/xcodegen-drift-check.sh --ctrl-proxy", xctestRunnerJob);
-    const xctestRunnerBuild = workflow.indexOf("./scripts/ios/ctrl-proxy-build-for-testing.sh", xctestRunnerJob);
+    const xcodeBuildSteps = loadJobSteps(".github/workflows/pull_request.yml", "ios-xcode-build");
+    const xctestRunnerSteps = loadJobSteps(".github/workflows/pull_request.yml", "ios-xctest-runner-simulator-tests");
+    const indexOfRun = (steps: typeof xcodeBuildSteps, command: string) =>
+      steps.findIndex(step => step.run?.includes(command));
 
-    expect(xcodeBuildJob).toBeGreaterThan(-1);
-    expect(xctestRunnerJob).toBeGreaterThan(-1);
-    expect(xcodeBuildDriftCheck).toBeGreaterThan(xcodeBuildJob);
+    const xcodeBuildDriftCheck = indexOfRun(xcodeBuildSteps, "./scripts/ios/xcodegen-drift-check.sh --all");
+    const xcodeBuild = indexOfRun(xcodeBuildSteps, "./scripts/ios/xcode-build.sh");
+    const xctestRunnerDriftCheck = indexOfRun(xctestRunnerSteps, "./scripts/ios/xcodegen-drift-check.sh --ctrl-proxy");
+    const xctestRunnerBuild = indexOfRun(xctestRunnerSteps, "./scripts/ios/ctrl-proxy-build-for-testing.sh");
+
+    expect(xcodeBuildSteps.length).toBeGreaterThan(0);
+    expect(xctestRunnerSteps.length).toBeGreaterThan(0);
+    expect(xcodeBuildDriftCheck).toBeGreaterThanOrEqual(0);
     expect(xcodeBuildDriftCheck).toBeLessThan(xcodeBuild);
-    expect(xctestRunnerDriftCheck).toBeGreaterThan(xctestRunnerJob);
+    expect(xctestRunnerDriftCheck).toBeGreaterThanOrEqual(0);
     expect(xctestRunnerDriftCheck).toBeLessThan(xctestRunnerBuild);
   });
 });

--- a/test/vision/ClaudeVisionClient.test.ts
+++ b/test/vision/ClaudeVisionClient.test.ts
@@ -1,74 +1,67 @@
 import { describe, expect, test } from "bun:test";
-import { ClaudeVisionClient } from "../../src/vision/ClaudeVisionClient";
+import {
+  calculateClaudeCost,
+  parseClaudeResponse,
+  toClaudeVisionFallbackResult,
+} from "../../src/vision/ClaudeVisionClient";
+import type { ClaudeVisionAnalysis } from "../../src/vision/VisionTypes";
 
-const makeClient = () => new ClaudeVisionClient("test-key-not-used");
+const makeResponse = (text: string) => ({ content: [{ type: "text", text }] } as any);
 
-const callCalculateCost = (
-  client: ClaudeVisionClient,
-  inputTokens: number,
-  outputTokens: number
-): number => (client as any).calculateCost(inputTokens, outputTokens);
+const analysis = (overrides: Partial<ClaudeVisionAnalysis> = {}): ClaudeVisionAnalysis => ({
+  elementFound: true,
+  navigationRequired: false,
+  visualDescription: "Login screen",
+  similarElements: [],
+  confidence: 0.9,
+  reasoning: "visible",
+  ...overrides,
+});
 
-const makeResponse = (text: string) =>
-  ({ content: [{ type: "text", text }] } as any);
-
-const callParse = (client: ClaudeVisionClient, response: unknown) =>
-  (client as any).parseClaudeResponse(response);
-
-describe("ClaudeVisionClient.parseClaudeResponse", () => {
-  test("throws a controlled error when JSON inside a code block is malformed", () => {
-    const client = makeClient();
-    const response = makeResponse("```json\n{ \"elementFound\": tr,\n```");
-
-    expect(() => callParse(client, response)).toThrow(
-      /Failed to parse JSON from Claude response/
-    );
+describe("parseClaudeResponse", () => {
+  test.each([
+    ["a malformed fenced JSON response", "```json\n{ \"elementFound\": tr,\n```"],
+    ["a malformed inline JSON response", "here is a result: { not valid json at all }"],
+    ["a prose-only response", "Claude returned only prose, no JSON here."],
+  ])("throws a controlled error for %s", (_name, responseText) => {
+    expect(() => parseClaudeResponse(makeResponse(responseText))).toThrow(/Failed to parse JSON from Claude response/);
   });
 
-  test("throws a controlled error when JSON outside a code block is malformed", () => {
-    const client = makeClient();
-    const response = makeResponse("here is a result: { not valid json at all }");
-
-    expect(() => callParse(client, response)).toThrow(
-      /Failed to parse JSON from Claude response/
-    );
-  });
-
-  test("throws when no JSON match is present in the response", () => {
-    const client = makeClient();
-    const response = makeResponse("Claude returned only prose, no JSON here.");
-
-    expect(() => callParse(client, response)).toThrow(
-      /Failed to parse JSON from Claude response/
-    );
-  });
-
-  test("parses well-formed JSON inside a fenced code block", () => {
-    const client = makeClient();
-    const response = makeResponse(
+  test("returns analysis fields from a well-formed fenced response", () => {
+    const parsed = parseClaudeResponse(makeResponse(
       "```json\n{\"elementFound\": true, \"confidence\": 0.95, \"reasoning\": \"ok\"}\n```"
-    );
+    ));
 
-    const parsed = callParse(client, response);
-
-    expect(parsed.elementFound).toBe(true);
-    expect(parsed.confidence).toBe(0.95);
-    expect(parsed.reasoning).toBe("ok");
+    expect(parsed).toMatchObject({ elementFound: true, confidence: 0.95, reasoning: "ok" });
   });
 });
 
-describe("ClaudeVisionClient.calculateCost", () => {
-  // Sonnet pricing: $3 / Mtok input, $15 / Mtok output.
+describe("calculateClaudeCost", () => {
   test("prices input and output tokens at $3 and $15 per million", () => {
-    const client = makeClient();
-    // 1M input = $3, 1M output = $15 → $18 total.
-    expect(callCalculateCost(client, 1_000_000, 1_000_000)).toBeCloseTo(18.0, 6);
+    expect(calculateClaudeCost(1_000_000, 1_000_000)).toBeCloseTo(18, 6);
+    expect(calculateClaudeCost(500_000, 100_000)).toBeCloseTo(3, 6);
+    expect(calculateClaudeCost(0, 0)).toBe(0);
+  });
+});
+
+describe("toClaudeVisionFallbackResult", () => {
+  test.each([
+    [0.9, "high"],
+    [0.7, "medium"],
+    [0.699, "low"],
+  ] as const)("uses %p as the %s confidence boundary", (confidence, expectedConfidence) => {
+    const result = toClaudeVisionFallbackResult(analysis({ confidence }), 0.01, 12, "/screen.png");
+
+    expect(result.confidence).toBe(expectedConfidence);
   });
 
-  test("is zero for zero tokens and scales linearly", () => {
-    const client = makeClient();
-    expect(callCalculateCost(client, 0, 0)).toBe(0);
-    // 500k input ($1.50) + 100k output ($1.50) = $3.00.
-    expect(callCalculateCost(client, 500_000, 100_000)).toBeCloseTo(3.0, 6);
+  test("defaults an unknown navigation action to tap while preserving its target", () => {
+    const result = toClaudeVisionFallbackResult(analysis({
+      steps: [{ action: "open details", target: "Settings", reasoning: "next screen" }],
+    }), 0.01, 12, "/screen.png");
+
+    expect(result.navigationSteps).toEqual([
+      { action: "tap", target: "Settings", description: "next screen" },
+    ]);
   });
 });

--- a/test/vision/VisionFallback.test.ts
+++ b/test/vision/VisionFallback.test.ts
@@ -73,6 +73,13 @@ describe("VisionFallback orchestrator", () => {
     ).rejects.toThrow(/not enabled/);
   });
 
+  test("rejects an unsupported provider before attempting a paid analysis", async () => {
+    const fallback = new VisionFallback(config({ provider: "unsupported" as any }), timer, undefined, checksums);
+
+    await expect(fallback.analyzeAndSuggest("/s.png", HIERARCHY, criteria("Login")))
+      .rejects.toThrow("Unsupported vision provider: unsupported");
+  });
+
   test("caches a result: an identical query hits the analyzer only once", async () => {
     const fb = new VisionFallback(config(), timer, undefined, checksums);
     const count = stubAnalyzer(fb, result());
@@ -95,8 +102,12 @@ describe("VisionFallback orchestrator", () => {
     await fb.analyzeAndSuggest("/s.png", HIERARCHY, criteria("Login"));
     expect(count()).toBe(1);
 
-    // Past the TTL: the stale entry is evicted and the analyzer runs again.
-    timer.advanceTime(2 * 60 * 1000);
+    // The exact TTL remains a cache hit; expiry starts one millisecond later.
+    timer.advanceTime(1 * 60 * 1000);
+    await fb.analyzeAndSuggest("/s.png", HIERARCHY, criteria("Login"));
+    expect(count()).toBe(1);
+
+    timer.advanceTime(1);
     await fb.analyzeAndSuggest("/s.png", HIERARCHY, criteria("Login"));
     expect(count()).toBe(2);
   });


### PR DESCRIPTION
## What

Completes the actionable remaining test-quality findings from [#4529](https://github.com/kaeawc/auto-mobile/issues/4529).

- Covers daemon connectivity outcomes and work-profile error/boundary cases through injected fakes.
- Makes Claude vision parsing, cost calculation, confidence boundaries, and navigation mapping pure and directly testable; covers vision-cache TTL and unsupported-provider behavior.
- Strengthens timer, checksum, and downloader contracts, including fake abort/error parity and OS temporary directories.
- Returns a structured result when plan schema validation is attempted before loading the schema, and adds scoped tool-registration cleanup for plan tests.
- Replaces brittle workflow/action string checks with parsed structural and runtime-floor assertions; makes release-registry loops non-vacuous.

## Why

Several existing suites asserted only happy paths or implementation details, leaving failure paths, boundaries, and test isolation unpinned. These changes make the observable behavior explicit while preserving production defaults.

## Validation

- `bun run lint`
- `bun run turbo:validate`
- `bun run typecheck`
- `git diff --check`

Closes [#4529](https://github.com/kaeawc/auto-mobile/issues/4529).
