### PR TITLE
feat(ios): append desktop keyboard text

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSession.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSession.kt
@@ -320,15 +320,11 @@ class DeviceControlSession(
   /**
    * The one policy consultation both [key] and [wouldForwardKey] share.
    *
-   * Text forwarding needs a daemon helper that APPENDS. Only Android has one (`mode: "append"`,
-   * real key events); iOS text input can only replace the focused field, which typing one character
-   * at a time would wipe on every keystroke. Buttons and discrete keys are unaffected.
+   * Text forwarding always uses the daemon's append contract. Android realizes it with real key
+   * events; iOS realizes it through CtrlProxy's focused-field insert primitive.
    */
   private fun decide(stroke: DeviceKeyStroke): DeviceKeyboardDecision =
-    DeviceKeyboardInputPolicy.evaluate(
-      stroke = stroke,
-      textSupported = platform() == ANDROID_PLATFORM,
-    )
+    DeviceKeyboardInputPolicy.evaluate(stroke = stroke)
 
   /**
    * Claim the newest-attempt error token, clear the banner, and enqueue the command [build] makes

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionKeyboardTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionKeyboardTest.kt
@@ -91,21 +91,22 @@ class DeviceControlSessionKeyboardTest {
   }
 
   @Test
-  fun `printable text is not forwarded on a platform that can only replace the field`() = runTest {
-    // iOS has no append-capable text helper, so forwarding would wipe the focused field on every
-    // keystroke. Disabled beats destructive — and buttons still work, so control mode stays useful.
+  fun `iOS printable keystrokes forward as ordered append requests`() = runTest {
+    // The iOS control proxy has an explicit append primitive. The desktop must not hard-code a
+    // platform veto here: each character travels through the same ordered queue, with append=true,
+    // so a focused field receives a, then b, then c instead of three replace operations.
     val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
     val client = FakeAutoMobileClient()
     val session = session(scope, client, platform = "ios")
 
-    val typed = session.key(testSnapshot(), DeviceKeyStroke(character = 'a'))
-    val escaped = session.key(testSnapshot(), escape())
+    val consumed = listOf('a', 'b', 'c').map { character ->
+      session.key(testSnapshot(), DeviceKeyStroke(character = character))
+    }
     advanceUntilIdle()
 
-    assertFalse(typed, "a keystroke that cannot be forwarded is left to the host")
-    assertTrue(client.inputTypeTextCalls.isEmpty(), "nothing may reach the iOS text helper")
-    assertTrue(escaped, "buttons are unaffected by the text restriction")
-    assertEquals("back", client.inputPressButtonCalls.single().button)
+    assertTrue(consumed.all { it }, "every forwarded keystroke is consumed")
+    assertEquals(listOf("a", "b", "c"), client.inputTypeTextCalls.map { it.text })
+    assertTrue(client.inputTypeTextCalls.all { it.platform == "ios" && it.append })
     scope.cancel()
   }
 
@@ -222,8 +223,8 @@ class DeviceControlSessionKeyboardTest {
       )
     )
     assertFalse(android.wouldForwardKey(DeviceKeyStroke(character = 'é')))
-    // Declined on iOS (no append-capable text helper) but keys/buttons still claimed.
-    assertFalse(ios.wouldForwardKey(DeviceKeyStroke(character = 'j')))
+    // iOS has the same append contract, so printable text is claimed there too.
+    assertTrue(ios.wouldForwardKey(DeviceKeyStroke(character = 'j')))
     assertTrue(ios.wouldForwardKey(DeviceKeyStroke(key = DeviceKeyboardKey.Escape)))
     scope.cancel()
   }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionKeyboardTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionKeyboardTest.kt
@@ -99,9 +99,10 @@ class DeviceControlSessionKeyboardTest {
     val client = FakeAutoMobileClient()
     val session = session(scope, client, platform = "ios")
 
-    val consumed = listOf('a', 'b', 'c').map { character ->
-      session.key(testSnapshot(), DeviceKeyStroke(character = character))
-    }
+    val consumed =
+      listOf('a', 'b', 'c').map { character ->
+        session.key(testSnapshot(), DeviceKeyStroke(character = character))
+      }
     advanceUntilIdle()
 
     assertTrue(consumed.all { it }, "every forwarded keystroke is consumed")

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceKeyboardInputPolicyTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceKeyboardInputPolicyTest.kt
@@ -362,22 +362,14 @@ class DeviceKeyboardInputPolicyTest {
   }
 
   @Test
-  fun `text is not forwarded on a platform whose daemon can only replace the field`() {
-    // iOS text input replaces the focused field wholesale, so per-keystroke typing would wipe it on
-    // every character. Disabled beats destructive; buttons and keys are unaffected.
+  fun `printable text forwards without a platform-specific gate`() {
     assertEquals(
-      DeviceKeyboardDecision.Ignored(DeviceKeyboardRejection.TextUnsupported),
-      DeviceKeyboardInputPolicy.evaluate(
-        stroke = DeviceKeyStroke(character = 'a'),
-        textSupported = false,
-      ),
+      DeviceKeyboardDecision.TypeText("a"),
+      DeviceKeyboardInputPolicy.evaluate(stroke = DeviceKeyStroke(character = 'a')),
     )
     assertEquals(
       DeviceKeyboardDecision.PressButton("back"),
-      DeviceKeyboardInputPolicy.evaluate(
-        stroke = DeviceKeyStroke(key = DeviceKeyboardKey.Escape),
-        textSupported = false,
-      ),
+      DeviceKeyboardInputPolicy.evaluate(stroke = DeviceKeyStroke(key = DeviceKeyboardKey.Escape)),
     )
   }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/shell/ThreePaneShellDeviceKeyTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/shell/ThreePaneShellDeviceKeyTest.kt
@@ -135,31 +135,10 @@ class ThreePaneShellDeviceKeyTest {
    * the point — the dead zone this guards is a DISAGREEMENT between the shell's stand-down and the
    * canvas's decision, which a hand-rolled boolean cannot exhibit.
    */
-  private fun policyPredicate(
-    textSupported: Boolean
-  ): (androidx.compose.ui.input.key.KeyEvent) -> Boolean = { event ->
+  private fun policyPredicate(): (androidx.compose.ui.input.key.KeyEvent) -> Boolean = { event ->
     DeviceKeyboardInputPolicy.evaluate(
       stroke = DeviceKeyboardEventTranslator.translate(event),
-      textSupported = textSupported,
     ) !is DeviceKeyboardDecision.Ignored
-  }
-
-  @Test
-  fun `a keystroke the device declines still reaches the shell binding`() {
-    // The dead-zone bug: Compose does not rerun a preview handler while an unconsumed event
-    // bubbles back up, so a blanket stand-down would leave a policy-declined key with NEITHER the
-    // device NOR the shell. On a platform whose daemon cannot append text, a bare printable key is
-    // exactly such a keystroke — with vim mode on, j must still navigate.
-    val activity = ShellActivity()
-    runShell(policyPredicate(textSupported = false), activity, vimModeEnabled = true) {
-      pressKey(Key.J)
-    }
-
-    assertEquals(
-      listOf("down"),
-      activity.navigated,
-      "a declined printable key must fall back to the shell's vim binding",
-    )
   }
 
   @Test
@@ -167,7 +146,7 @@ class ThreePaneShellDeviceKeyTest {
     // The other direction: on Android the policy claims 'j' as typed text, so the shell must NOT
     // navigate — the canvas gets the key.
     val activity = ShellActivity()
-    runShell(policyPredicate(textSupported = true), activity, vimModeEnabled = true) {
+    runShell(policyPredicate(), activity, vimModeEnabled = true) {
       pressKey(Key.J)
     }
 
@@ -183,7 +162,7 @@ class ThreePaneShellDeviceKeyTest {
     // declines it — and the shell, asked per event, keeps navigating instead of dead-zoning it.
     // The PLAIN arrow is claimed by the device and must not navigate.
     val activity = ShellActivity()
-    runShell(policyPredicate(textSupported = true), activity) {
+    runShell(policyPredicate(), activity) {
       withKeyDown(Key.ShiftLeft) { pressKey(Key.DirectionUp) }
       pressKey(Key.DirectionDown)
     }
@@ -201,7 +180,7 @@ class ThreePaneShellDeviceKeyTest {
     // chord is a HostChord rejection, so the predicate answers false and the shell keeps its
     // accelerators even while the device canvas owns the rest of the keyboard.
     val capturing = ShellActivity()
-    runShell(policyPredicate(textSupported = true), capturing) {
+    runShell(policyPredicate(), capturing) {
       withKeyDown(Key.MetaLeft) { pressKey(Key.Zero) }
     }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/shell/ThreePaneShellDeviceKeyTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/shell/ThreePaneShellDeviceKeyTest.kt
@@ -136,9 +136,8 @@ class ThreePaneShellDeviceKeyTest {
    * canvas's decision, which a hand-rolled boolean cannot exhibit.
    */
   private fun policyPredicate(): (androidx.compose.ui.input.key.KeyEvent) -> Boolean = { event ->
-    DeviceKeyboardInputPolicy.evaluate(
-      stroke = DeviceKeyboardEventTranslator.translate(event),
-    ) !is DeviceKeyboardDecision.Ignored
+    DeviceKeyboardInputPolicy.evaluate(stroke = DeviceKeyboardEventTranslator.translate(event)) !is
+      DeviceKeyboardDecision.Ignored
   }
 
   @Test

--- a/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/DeviceKeyboardInputPolicy.kt
+++ b/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/DeviceKeyboardInputPolicy.kt
@@ -135,13 +135,6 @@ public enum class DeviceKeyboardRejection {
   Unsupported,
 
   /**
-   * A printable character on a platform whose daemon text helper can only REPLACE the focused
-   * field, not append to it. Typing one character at a time there would wipe the field on every
-   * keystroke, so text forwarding is disabled rather than destructive (issue #3351).
-   */
-  TextUnsupported,
-
-  /**
    * A printable character the daemon's append path cannot type at all — anything outside printable
    * ASCII (`é`, `€`, CJK, emoji).
    *
@@ -289,7 +282,6 @@ public object DeviceKeyboardInputPolicy {
   public fun evaluate(
     stroke: DeviceKeyStroke,
     forwardedChords: Set<DeviceChordAllowance> = emptySet(),
-    textSupported: Boolean = true,
   ): DeviceKeyboardDecision {
     if (stroke.modifiers.hasChordModifier && !isAllowedChord(stroke, forwardedChords)) {
       return DeviceKeyboardDecision.Ignored(DeviceKeyboardRejection.HostChord)
@@ -297,7 +289,7 @@ public object DeviceKeyboardInputPolicy {
     stroke.key?.let {
       return evaluateKey(it, stroke.modifiers.shift)
     }
-    return evaluateCharacter(stroke.character, textSupported)
+    return evaluateCharacter(stroke.character)
   }
 
   /**
@@ -330,17 +322,12 @@ public object DeviceKeyboardInputPolicy {
    * is refused only because the daemon's append path cannot type it. Both leave the event
    * unconsumed — the rule is that a keystroke this policy cannot deliver is never swallowed.
    */
-  private fun evaluateCharacter(character: Char?, textSupported: Boolean): DeviceKeyboardDecision {
+  private fun evaluateCharacter(character: Char?): DeviceKeyboardDecision {
     if (character == null || !isPrintable(character)) {
       return DeviceKeyboardDecision.Ignored(DeviceKeyboardRejection.Unsupported)
     }
     if (!isTypable(character)) {
       return DeviceKeyboardDecision.Ignored(DeviceKeyboardRejection.CharacterUnsupported)
-    }
-    // A platform with no non-destructive text primitive must not receive text at all: replacing
-    // the field's contents on every keystroke is worse than typing nothing.
-    if (!textSupported) {
-      return DeviceKeyboardDecision.Ignored(DeviceKeyboardRejection.TextUnsupported)
     }
     return DeviceKeyboardDecision.TypeText(character.toString())
   }

--- a/docs/design-docs/mcp/daemon/client-screen-control.md
+++ b/docs/design-docs/mcp/daemon/client-screen-control.md
@@ -274,17 +274,16 @@ consistent.
 | Swipe / drag (`input/swipe`) | ✅ Supported | ✅ Supported |
 | Device buttons (`input/pressButton`) | ✅ Supported | ⚠️ Supported with platform gaps (unsupported buttons fail rather than being ignored) |
 | Discrete keys (`input/key`: Enter, Tab, arrows, …) | ✅ Supported | ❌ Unsupported — CtrlProxy exposes no discrete key events; the daemon returns an actionable error |
-| Printable text (`input/typeText`) | ✅ Supported via non-destructive `mode: "append"` | ❌ **Not forwarded by control clients** |
+| Printable text (`input/typeText`) | ✅ Supported via non-destructive `mode: "append"` | ✅ Supported via non-destructive `mode: "append"` |
 
-**Why iOS text is disabled.** `input/typeText`'s default path *replaces* the focused field's
-contents, so typing one character per keystroke would wipe the field on every key. The
-non-destructive `mode: "append"` (real key events, adds to the field) is **Android-only** — iOS's
-control proxy has only the destructive set-text primitive, and the daemon rejects `mode: "append"`
-on iOS rather than silently replacing. A control client targeting iOS must therefore **not forward
-printable text at all**; a disabled typing path is strictly better than one that erases the field.
-Buttons and taps/swipes are unaffected, so control mode stays useful on iOS. Lifting this needs an
-iOS-side non-destructive insert primitive, tracked in
-[#4519](https://github.com/kaeawc/auto-mobile/issues/4519).
+**Why iOS text is forwarded.** `input/typeText`'s default path *replaces* the focused field's
+contents, so a client that forwards each character must use `mode: "append"`. Android realizes
+append through real key events. iOS routes append through CtrlProxy's focused-field insertion
+primitive, which calls XCUITest `typeText` at the current caret without clearing or resolving a
+resource ID. Runners that predate the dedicated append command use the existing untargeted
+`request_set_text` command, which performs that same focused-field insertion. Control clients
+therefore forward printable ASCII text on both platforms, always in append mode. Discrete iOS keys
+remain unsupported.
 
 Uppercase/shifted characters on Android need `input keycombination`, available only on API 31+. A
 client cannot see the device API level, so it forwards them anyway; an older device answers with an
@@ -311,8 +310,9 @@ desktop app (or your client) connected to the daemon and a device/simulator stre
 1. Enter control mode as above.
 2. **Tap** and **swipe** — confirm both actuate.
 3. **Button** — `Esc` → back; confirm.
-4. **Text/keys** — confirm printable text is **not** forwarded (no field wipe) and `input/key`
-   presses surface an actionable error rather than being silently dropped.
+4. **Text/keys** — focus a text field and type ASCII text; confirm each character *appends* at the
+   current caret without clearing the field. Confirm `input/key` presses surface an actionable
+   error rather than being silently dropped.
 
 > **Status:** this plan is written but **manual execution is pending** — the sign-off environment
 > had no attached Android device or iOS simulator. Record pass/fail per step when a device fleet
@@ -327,7 +327,7 @@ tracked back to [#1099](https://github.com/kaeawc/auto-mobile/issues/1099):
 | --- | --- |
 | [#4502](https://github.com/kaeawc/auto-mobile/issues/4502) | Close the same-device rotation window in the client control-tap gate. |
 | [#4505](https://github.com/kaeawc/auto-mobile/issues/4505) | Daemon-side frame-context validation so the *daemon* rejects stale-context input (protects clients that will not reimplement the client-side snapshot rules). |
-| [#4519](https://github.com/kaeawc/auto-mobile/issues/4519) | iOS non-destructive text append for keyboard forwarding. |
+| [#4533](https://github.com/kaeawc/auto-mobile/issues/4533) | Bound `ensureAdbPath` discovery so a cold cache cannot wedge the per-device input queue. |
 | [#4534](https://github.com/kaeawc/auto-mobile/issues/4534) | Evict the append cache on rapid same-serial device reuse (needs a device-connect signal). |
 | [#4535](https://github.com/kaeawc/auto-mobile/issues/4535) | Optional daemon capability signal for newer input params (e.g. `input/typeText mode:append`). |
 | [#4536](https://github.com/kaeawc/auto-mobile/issues/4536) | Prefer a reliable native AltGraph signal over the `ctrl && alt` heuristic. |

--- a/docs/design-docs/mcp/daemon/screen-control-mapping.md
+++ b/docs/design-docs/mcp/daemon/screen-control-mapping.md
@@ -368,13 +368,11 @@ one character per keystroke through it would type `abc` as "a", then "b", then
 key. Pass `mode: "append"`, which routes through real key events and adds to the
 field instead. This is a hard requirement, not a tuning knob.
 
-`mode: "append"` is **Android-only**; the daemon rejects it on iOS, whose control
-proxy exposes no non-destructive text primitive. A client targeting iOS must
-therefore **not forward printable text at all** — a disabled typing path is
-strictly better than one that erases the field on every keystroke. Buttons and
-discrete keys are unaffected, so control mode stays useful there. Lifting this
-needs an iOS-side insert primitive, tracked under
-[#1099](https://github.com/kaeawc/auto-mobile/issues/1099).
+`mode: "append"` is supported on both platforms. Android realizes it with real
+key events; iOS routes it to CtrlProxy's focused-field insert primitive, which
+calls XCUITest `typeText` at the current caret without clearing or resolving a
+resource id. The desktop client therefore forwards printable text on both
+platforms and marks every per-keystroke request as append.
 
 **Only printable ASCII is forwarded, because that is exactly what append can
 type.** Append works by injecting real Android key events, and the daemon's
@@ -415,9 +413,6 @@ Two different situations, handled differently:
   Android-only; on iOS the daemon answers with an actionable error. Surface it
   through the same error path as any other failed input rather than swallowing
   it.
-- **The platform has no non-destructive text path.** Printable characters are
-  dropped before any request is made (see the append rule above). This is a
-  client-side refusal, not a daemon error.
 - **The character is outside printable ASCII.** Dropped before any request is
   made, for the same reason and with the same handling: the append path has no
   key event for it, so consuming the keystroke would lose it at both ends.
@@ -521,7 +516,7 @@ with a typable character types; one the host did not resolve — a Windows/Linux
 `Alt+F` menu accelerator — stays with the host even though it reports a printable
 char),
 key-over-character precedence, the control-character filter, the character-keyed
-chord allowlist, the platform text gate, and the printable-ASCII range from both
+chord allowlist, and the printable-ASCII range from both
 sides (every character in `U+0020`–`U+007E` forwards; `é`/`€`/CJK are declined and
 left unconsumed). `DeviceKeyboardEventTranslatorTest` pins the platform-aware
 resolution of that flag (native AltGraph composes on Linux; Ctrl+Alt remains the
@@ -534,6 +529,9 @@ below API 31 and succeeds at 31+; and that every adb round trip is charged again
 the caller's timeout budget. `socketServerInputTypeText.test.ts` pins the same
 through the socket against a fake adb, including that a stalled adb call answers
 inside the request budget and leaves the per-device queue free for the next input.
+The same socket suite and CtrlProxy command-handler tests pin the iOS append route:
+three single-character calls reach the focused-field insert primitive in order and
+never use the resource-targeted replace operation.
 `DeviceKeyboardEventTranslatorTest` pins the toolkit-key translation.
 `DeviceControlSessionKeyboardTest` asserts the exact daemon payloads a keystroke
 produces against a fake client, that keyboard shares the one ordered queue with

--- a/docs/design-docs/mcp/daemon/screen-control-mapping.md
+++ b/docs/design-docs/mcp/daemon/screen-control-mapping.md
@@ -365,8 +365,9 @@ that already encode the shift.
 `ACTION_SET_TEXT`, which *replaces* the focused field's contents. A client sending
 one character per keystroke through it would type `abc` as "a", then "b", then
 "c" — final value `c` — and would wipe any text already in the field on the first
-key. Pass `mode: "append"`, which routes through real key events and adds to the
-field instead. This is a hard requirement, not a tuning knob.
+key. Pass `mode: "append"`, which routes through the platform's non-destructive
+append primitive and adds to the field instead. This is a hard requirement, not a
+tuning knob.
 
 `mode: "append"` is supported on both platforms. Android realizes it with real
 key events; iOS routes it to CtrlProxy's focused-field insert primitive, which

--- a/docs/design-docs/mcp/daemon/unix-socket-api.md
+++ b/docs/design-docs/mcp/daemon/unix-socket-api.md
@@ -319,7 +319,7 @@ the input response returns.
 | `input/swipe` | Supported | Supported | Absolute device-screen start/end coordinates. Use for drag gestures until `input/drag` has distinct semantics. |
 | `input/drag` | Deferred | Deferred | Not a separate method in this contract. |
 | `input/pressButton` | Supported | Supported with platform gaps | Device/navigation buttons aligned with MCP `pressButton`. Unsupported buttons fail instead of being ignored. |
-| `input/typeText` | Supported | Supported (replace only) | Sends committed text only; IME composition is deferred. Non-destructive `mode: "append"` is **Android only** — iOS rejects it rather than silently replacing the field. |
+| `input/typeText` | Supported | Supported | Sends committed text only; IME composition is deferred. Non-destructive `mode: "append"` is supported on both platforms. |
 | `input/key` | Supported | Unsupported | Discrete non-text key presses. Modifiers are deferred. |
 
 All successful input responses use this result shape:
@@ -557,25 +557,25 @@ this contract; clients should send the final committed string.
 | `deviceId` | `string` | No | Target device; see [Common input fields](#common-input-fields). |
 | `text` | `string` | Yes | Non-empty text to type. |
 | `submit` | `boolean` | No | When true, press enter/return after typing if the platform supports it. |
-| `mode` | `"append"` | No | **Android only.** Append to the focused field with real key events instead of replacing its contents. `"append"` is the only accepted value; any other value fails validation. |
+| `mode` | `"append"` | No | Append to the focused field instead of replacing its contents. Android uses real key events; iOS uses CtrlProxy's focused-field insert primitive. `"append"` is the only accepted value; any other value fails validation. |
 
-**Replace vs. append.** The default path sets the focused field's contents via
-`ACTION_SET_TEXT`, which **replaces** whatever is there — right for "make this
-field say X" automation, destructive for a client mirroring a keyboard one
-keystroke at a time (typing `abc` as three requests would leave the field saying
-`c`). `mode: "append"` is the non-destructive alternative: it types through real
-Android key events, never clears, and never calls set-text. Interactive
+**Replace vs. append.** On Android, the default path sets the focused field's
+contents via `ACTION_SET_TEXT`, which **replaces** whatever is there — right for
+"make this field say X" automation, destructive for a client mirroring a keyboard
+one keystroke at a time (typing `abc` as three requests would leave the field
+saying `c`). `mode: "append"` is the non-destructive alternative: it never clears or
+uses the replace path. Android types through real key events; iOS dispatches to
+CtrlProxy's focused-field insert primitive. Interactive
 keyboard-forwarding clients MUST use it; see
 [screen-control-mapping.md](./screen-control-mapping.md) for the full client
 policy.
 
 Append's semantics and limits:
 
-- **Android only.** iOS exposes no non-destructive text primitive, so
-  `mode: "append"` with `platform: "ios"` is rejected at validation with
-  `input/typeText mode "append" is only supported on android` — rejected rather
-  than silently downgraded to the destructive replace path.
-- **Printable ASCII only** (`U+0020`–`U+007E`). Any other character fails with
+- **iOS.** Append dispatches to CtrlProxy's focused-field insert primitive, which
+  calls XCUITest `typeText` at the current caret without clearing or resolving a
+  resource id.
+- **Android printable ASCII only** (`U+0020`–`U+007E`). Any other character fails with
   `append cannot type "<char>" with Android key events`, and nothing is typed —
   a partial append would leave a prefix of the text in the field.
 - **Uppercase and shifted symbols need Android 12 (API 31)**, where
@@ -591,8 +591,8 @@ Append's semantics and limits:
   subject to the normal socket version and build-identity handshake; clients must surface a mismatch
   error rather than treating it as unknown support.
 
-**Best-effort, character-by-character — retry the remainder, not the whole
-string.** Append types one key event per character in order, so it is atomic only
+**Android is best-effort, character-by-character — retry the remainder, not the whole
+string.** Android append types one key event per character in order, so it is atomic only
 for a **single character**: a one-character append either lands or reports failure
 with nothing typed. A **multi-character** append is best-effort — if it fails
 partway (an adb reject/timeout mid-batch), a leading prefix of `text` has already
@@ -632,8 +632,8 @@ response is deferred to [#4537](https://github.com/kaeawc/auto-mobile/issues/453
   "type": "mcp_request",
   "method": "input/typeText",
   "params": {
-    "platform": "android",
-    "deviceId": "emulator-5554",
+    "platform": "ios",
+    "deviceId": "A1B2C3D4-0000-0000-0000-000000000000",
     "text": "a",
     "mode": "append"
   }

--- a/docs/using/screen-control.md
+++ b/docs/using/screen-control.md
@@ -76,13 +76,13 @@ A few details worth knowing:
 | Drag → swipe | ✅ | ✅ |
 | Back button (`Esc`) | ✅ | ✅ |
 | Discrete keys (Enter, Tab, arrows) | ✅ | ❌ not available |
-| Typing text | ✅ (appended to the field) | ❌ **disabled** |
+| Typing text | ✅ (appended to the field) | ✅ (appended at the focused caret) |
 
-**Why typing is disabled on iOS.** Forwarding text to iOS could only *replace* the whole field on
-every keystroke, wiping what is there. Rather than corrupt the field, control mode does not forward
-printable text to iOS at all. Tapping, swiping, and the Back button all work on iOS. Non-destructive
-iOS typing is a tracked follow-up
-([#4519](https://github.com/kaeawc/auto-mobile/issues/4519)).
+**How typing works on iOS.** Control mode forwards printable ASCII text in append mode. CtrlProxy
+inserts it at the focused field's current caret through XCUITest `typeText`, without clearing the
+field or resolving a resource ID. Older runners use their existing focused-field text command as a
+compatibility path. Tapping, swiping, and the Back button continue to work on iOS; discrete keys
+such as Enter, Tab, and arrows remain unavailable.
 
 ## The IDE plugin is inspector-only
 

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -114,6 +114,9 @@ public class CommandHandler: CommandHandling {
             case let .setText(payload):
                 return try handleSetText(payload, startTime: startTime)
 
+            case let .appendText(payload):
+                return try handleAppendText(payload, startTime: startTime)
+
             case let .clearText(payload):
                 return try handleClearText(payload, startTime: startTime)
 
@@ -586,6 +589,21 @@ public class CommandHandler: CommandHandling {
             type: ResponseType.setTextResult.rawValue,
             requestId: request.requestId,
             totalTimeMs: elapsedMs
+        )
+    }
+
+    private func handleAppendText(_ request: RequestAppendText, startTime: Date) throws -> WebSocketResponse {
+        perfProvider.serial("handleAppendText")
+        defer { perfProvider.end() }
+
+        try perfProvider.track("appendText") {
+            try gesturePerformer.appendText(text: request.text)
+        }
+
+        return WebSocketResponse.success(
+            type: ResponseType.appendTextResult.rawValue,
+            requestId: request.requestId,
+            totalTimeMs: totalTimeMs(from: startTime)
         )
     }
 

--- a/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
@@ -199,6 +199,7 @@ public class FakeGesturePerformer: GesturePerforming {
     private var dragHistory: [DragCall] = []
     private var pinchHistory: [PinchCall] = []
     private var typeTextHistory: [String] = []
+    private var appendTextHistory: [String] = []
     private var setTextHistory: [TextCall] = []
     private var clearTextHistory: [String?] = []
     private var selectAllCallCount = 0
@@ -260,6 +261,10 @@ public class FakeGesturePerformer: GesturePerforming {
 
     public func getTypeTextHistory() -> [String] {
         typeTextHistory
+    }
+
+    public func getAppendTextHistory() -> [String] {
+        appendTextHistory
     }
 
     public func getSetTextHistory() -> [TextCall] {
@@ -351,6 +356,7 @@ public class FakeGesturePerformer: GesturePerforming {
         dragHistory.removeAll()
         pinchHistory.removeAll()
         typeTextHistory.removeAll()
+        appendTextHistory.removeAll()
         setTextHistory.removeAll()
         clearTextHistory.removeAll()
         selectAllCallCount = 0
@@ -478,6 +484,11 @@ public class FakeGesturePerformer: GesturePerforming {
     public func typeText(text: String) throws {
         try checkFailure("typeText")
         typeTextHistory.append(text)
+    }
+
+    public func appendText(text: String) throws {
+        try checkFailure("appendText")
+        appendTextHistory.append(text)
     }
 
     public func setText(resourceId: String, text: String) throws {

--- a/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
@@ -200,6 +200,7 @@ public class FakeGesturePerformer: GesturePerforming {
     private var pinchHistory: [PinchCall] = []
     private var typeTextHistory: [String] = []
     private var appendTextHistory: [String] = []
+    private var focusedFieldText = ""
     private var setTextHistory: [TextCall] = []
     private var clearTextHistory: [String?] = []
     private var selectAllCallCount = 0
@@ -265,6 +266,10 @@ public class FakeGesturePerformer: GesturePerforming {
 
     public func getAppendTextHistory() -> [String] {
         appendTextHistory
+    }
+
+    public func getFocusedFieldText() -> String {
+        focusedFieldText
     }
 
     public func getSetTextHistory() -> [TextCall] {
@@ -357,6 +362,7 @@ public class FakeGesturePerformer: GesturePerforming {
         pinchHistory.removeAll()
         typeTextHistory.removeAll()
         appendTextHistory.removeAll()
+        focusedFieldText = ""
         setTextHistory.removeAll()
         clearTextHistory.removeAll()
         selectAllCallCount = 0
@@ -489,6 +495,7 @@ public class FakeGesturePerformer: GesturePerforming {
     public func appendText(text: String) throws {
         try checkFailure("appendText")
         appendTextHistory.append(text)
+        focusedFieldText += text
     }
 
     public func setText(resourceId: String, text: String) throws {

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -642,6 +642,10 @@ public class GesturePerformer: GesturePerforming {
             }
         }
 
+        public func appendText(text: String) throws {
+            try typeText(text: text)
+        }
+
         public func setText(resourceId: String, text: String) throws {
             guard let app = resolveTextInputApp() else {
                 throw GestureError.noApplication
@@ -1494,6 +1498,10 @@ public class GesturePerformer: GesturePerforming {
         }
 
         public func typeText(text _: String) throws {
+            throw GestureError.notSupported("XCUITest only available on iOS")
+        }
+
+        public func appendText(text _: String) throws {
             throw GestureError.notSupported("XCUITest only available on iOS")
         }
 

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -107,6 +107,11 @@ public struct RequestSetText: Decodable {
     public var resourceId: String?
 }
 
+public struct RequestAppendText: Decodable {
+    public var requestId: String?
+    public var text: String
+}
+
 public struct RequestClearText: Decodable {
     public var requestId: String?
     public var resourceId: String?
@@ -291,6 +296,7 @@ extension RequestMultiFingerSwipe: CommandPayload {}
 extension RequestDrag: CommandPayload {}
 extension RequestPinch: CommandPayload {}
 extension RequestSetText: CommandPayload {}
+extension RequestAppendText: CommandPayload {}
 extension RequestClearText: CommandPayload {}
 extension RequestImeAction: CommandPayload {}
 extension RequestKeyboard: CommandPayload {}
@@ -334,6 +340,7 @@ public enum WebSocketRequest: Decodable {
     case pinch(RequestPinch)
 
     case setText(RequestSetText)
+    case appendText(RequestAppendText)
     case clearText(RequestClearText)
     case imeAction(RequestImeAction)
     case selectAll(RequestEnvelope)
@@ -410,6 +417,8 @@ public enum WebSocketRequest: Decodable {
             self = try .pinch(RequestPinch(from: decoder))
         case .requestSetText:
             self = try .setText(RequestSetText(from: decoder))
+        case .requestAppendText:
+            self = try .appendText(RequestAppendText(from: decoder))
         case .requestClearText:
             self = try .clearText(RequestClearText(from: decoder))
         case .requestImeAction:
@@ -489,6 +498,7 @@ public enum WebSocketRequest: Decodable {
         case .drag: return .requestDrag
         case .pinch: return .requestPinch
         case .setText: return .requestSetText
+        case .appendText: return .requestAppendText
         case .clearText: return .requestClearText
         case .imeAction: return .requestImeAction
         case .selectAll: return .requestSelectAll
@@ -555,6 +565,7 @@ public enum WebSocketRequest: Decodable {
         case let .drag(payload): return payload
         case let .pinch(payload): return payload
         case let .setText(payload): return payload
+        case let .appendText(payload): return payload
         case let .clearText(payload): return payload
         case let .imeAction(payload): return payload
         case let .keyboard(payload): return payload
@@ -1615,6 +1626,7 @@ public enum RequestType: String, CaseIterable {
 
     // Text input
     case requestSetText = "request_set_text"
+    case requestAppendText = "request_append_text"
     case requestClearText = "request_clear_text"
     case requestImeAction = "request_ime_action"
     case requestSelectAll = "request_select_all"
@@ -1677,6 +1689,7 @@ public enum ResponseType: String {
     case dragResult = "drag_result"
     case pinchResult = "pinch_result"
     case setTextResult = "set_text_result"
+    case appendTextResult = "append_text_result"
     case clearTextResult = "clear_text_result"
     case imeActionResult = "ime_action_result"
     case selectAllResult = "select_all_result"
@@ -1740,6 +1753,7 @@ extension RequestType {
         case .requestDrag: return .dragResult
         case .requestPinch: return .pinchResult
         case .requestSetText: return .setTextResult
+        case .requestAppendText: return .appendTextResult
         case .requestClearText: return .clearTextResult
         case .requestImeAction: return .imeActionResult
         case .requestSelectAll: return .selectAllResult

--- a/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Protocols.swift
@@ -124,6 +124,9 @@ public protocol GesturePerforming {
     /// Type text using keyboard
     func typeText(text: String) throws
 
+    /// Insert text at the current caret without clearing or retargeting a field.
+    func appendText(text: String) throws
+
     /// Set text on a specific element
     func setText(resourceId: String, text: String) throws
 

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -696,6 +696,17 @@ final class CommandHandlerTests: XCTestCase {
         XCTAssertEqual(setTextHistory.first?.resourceId, "input_field")
     }
 
+    func testAppendTextAccumulatesSingleCharacterRequestsWithoutSetText() {
+        for text in ["a", "b", "c"] {
+            let request = WebSocketRequest.appendText(RequestAppendText(text: text))
+            guard let response = handleRequest(request, as: WebSocketResponse.self) else { return }
+            XCTAssertEqual(response.success, true)
+        }
+
+        XCTAssertEqual(fakeGesturePerformer.getAppendTextHistory(), ["a", "b", "c"])
+        XCTAssertTrue(fakeGesturePerformer.getSetTextHistory().isEmpty)
+    }
+
     /// `text` is now decode-required for `request_set_text`.
     func testSetTextMissingTextFailsToDecode() {
         XCTAssertThrowsError(

--- a/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/CommandHandlerTests.swift
@@ -704,6 +704,7 @@ final class CommandHandlerTests: XCTestCase {
         }
 
         XCTAssertEqual(fakeGesturePerformer.getAppendTextHistory(), ["a", "b", "c"])
+        XCTAssertEqual(fakeGesturePerformer.getFocusedFieldText(), "abc")
         XCTAssertTrue(fakeGesturePerformer.getSetTextHistory().isEmpty)
     }
 

--- a/ios/control-proxy/Tests/CtrlProxyTests/ErrorResponseTypeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ErrorResponseTypeTests.swift
@@ -23,6 +23,7 @@ final class ErrorResponseTypeTests: XCTestCase {
             .requestDrag: .dragResult,
             .requestPinch: .pinchResult,
             .requestSetText: .setTextResult,
+            .requestAppendText: .appendTextResult,
             .requestClearText: .clearTextResult,
             .requestImeAction: .imeActionResult,
             .requestSelectAll: .selectAllResult,

--- a/ios/control-proxy/Tests/CtrlProxyTests/RequestSnapshotWireParityTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/RequestSnapshotWireParityTests.swift
@@ -199,6 +199,7 @@ final class RequestSnapshotWireParityTests: XCTestCase {
         let required: Set<String> = [
             "request_action",
             "request_set_text",
+            "request_append_text",
             "request_ime_action",
             "request_hierarchy",
             "request_hierarchy_if_stale",

--- a/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/TypedRequestDecodeTests.swift
@@ -134,6 +134,7 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
             .requestDrag: #"{"x1":1,"y1":2,"x2":3,"y2":4}"#,
             .requestPinch: #"{"centerX":1,"centerY":2,"distanceStart":3,"distanceEnd":4}"#,
             .requestSetText: #"{"text":"hi"}"#,
+            .requestAppendText: #"{"text":"hi"}"#,
             .requestClearText: "{}",
             .requestImeAction: #"{"action":"done"}"#,
             .requestSelectAll: "{}",
@@ -374,6 +375,15 @@ final class TypedRequestDecodeDispatchTests: XCTestCase {
             as: WebSocketResponse.self
         )
         XCTAssertEqual(fakeGesturePerformer.getSetTextHistory().first?.resourceId, "field")
+    }
+
+    func testAppendTextDecodeDispatchUsesFocusedFieldInsert() {
+        _ = dispatch(
+            #"{"type":"request_append_text","requestId":"append-1","text":"a"}"#,
+            as: WebSocketResponse.self
+        )
+        XCTAssertEqual(fakeGesturePerformer.getAppendTextHistory(), ["a"])
+        XCTAssertTrue(fakeGesturePerformer.getSetTextHistory().isEmpty)
     }
 
     func testClearTextDecodeDispatchForwardsResourceId() {

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1145,8 +1145,9 @@ export class UnixSocketServer {
         ? AndroidCtrlProxyClient.getInstance(targetDevice, defaultAdbClientFactory)
         : IOSCtrlProxyClient.getInstance(targetDevice);
 
-    // Append never touches requestSetText: that is ACTION_SET_TEXT, which
-    // REPLACES the field. Real key events are the only non-destructive path.
+    // Append never touches requestSetText: on Android it emits real key events;
+    // on iOS it invokes CtrlProxy's focused-field insert primitive. Both preserve
+    // the current text and caret rather than taking the replace-shaped path.
     //
     // The budget is threaded in for the same reason the replace path gets it: this
     // runs while the per-device queue is held, and the outer race only *reports* a
@@ -1154,7 +1155,9 @@ export class UnixSocketServer {
     // queue. An unbounded adb subprocess here would therefore wedge every later
     // input for this device, not just this one request.
     const textResult = append
-      ? await this.getAppendTextInput(targetDevice).appendText(text, timeoutMs)
+      ? platform === "android"
+        ? await this.getAppendTextInput(targetDevice).appendText(text, timeoutMs)
+        : await (client as IOSCtrlProxyClient).requestAppendText(text, timeoutMs)
       : await client.requestSetText(text, { timeoutMs });
     if (!textResult.success) {
       return { success: false, error: textResult.error };
@@ -1358,16 +1361,10 @@ export class UnixSocketServer {
     }
     // "append" adds to the focused field instead of replacing it, which is what
     // an interactive client mirroring one keystroke at a time needs: the default
-    // replace semantics would leave only the last character typed (#3351). It is
-    // Android-only — iOS exposes no non-destructive text primitive — so it is
-    // rejected rather than silently ignored on iOS.
+    // replace semantics would leave only the last character typed (#3351).
     if (args.mode !== undefined && args.mode !== "append") {
       throw new Error('input/typeText mode must be "append" when provided');
     }
-    if (args.mode === "append" && args.platform !== "android") {
-      throw new Error('input/typeText mode "append" is only supported on android');
-    }
-
     return {
       platform: args.platform,
       deviceId: args.deviceId,

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1145,9 +1145,9 @@ export class UnixSocketServer {
         ? AndroidCtrlProxyClient.getInstance(targetDevice, defaultAdbClientFactory)
         : IOSCtrlProxyClient.getInstance(targetDevice);
 
-    // Append never touches requestSetText: on Android it emits real key events;
-    // on iOS it invokes CtrlProxy's focused-field insert primitive. Both preserve
-    // the current text and caret rather than taking the replace-shaped path.
+    // Append emits real key events on Android. iOS invokes its focused-field insert
+    // primitive, falling back on runners that predate that command to untargeted
+    // requestSetText, which is the same XCUITest typeText-at-caret operation.
     //
     // The budget is threaded in for the same reason the replace path gets it: this
     // runs while the per-device queue is held, and the outer race only *reports* a

--- a/src/features/observe/ios/CtrlProxyText.ts
+++ b/src/features/observe/ios/CtrlProxyText.ts
@@ -26,6 +26,13 @@ export class CtrlProxyText extends SharedTextDelegate {
     timeoutMs: number = 5000,
     perf?: PerformanceTracker
   ): Promise<BaseResult> {
+    // Older released runners predate request_append_text, but their untargeted
+    // request_set_text path already uses XCUITest typeText at the focused caret.
+    // It is therefore the same non-destructive append operation for this call.
+    if (this.context.isCommandSupported?.("request_append_text") === false) {
+      return this.requestSetText(text, { timeoutMs, perf });
+    }
+
     return sendCommand<BaseResult>(this.context, {
       idPrefix: "appendText",
       responseType: "append_text",

--- a/src/features/observe/ios/CtrlProxyText.ts
+++ b/src/features/observe/ios/CtrlProxyText.ts
@@ -18,6 +18,26 @@ export class CtrlProxyText extends SharedTextDelegate {
   }
 
   /**
+   * Insert committed text at the focused field's current caret without clearing
+   * or resolving a resource id. This is the iOS half of daemon append mode.
+   */
+  async requestAppendText(
+    text: string,
+    timeoutMs: number = 5000,
+    perf?: PerformanceTracker
+  ): Promise<BaseResult> {
+    return sendCommand<BaseResult>(this.context, {
+      idPrefix: "appendText",
+      responseType: "append_text",
+      messageType: "request_append_text",
+      params: { text },
+      timeoutMs,
+      perf,
+      errorLabel: "Append text",
+    });
+  }
+
+  /**
    * iOS-specific clearText: sends `request_clear_text` which the iOS CtrlProxy
    * handles via Cmd+A (select all) + Delete. This is O(1) regardless of text
    * length and works with any content including emoji/Unicode.

--- a/src/features/observe/ios/CtrlProxyText.ts
+++ b/src/features/observe/ios/CtrlProxyText.ts
@@ -29,7 +29,12 @@ export class CtrlProxyText extends SharedTextDelegate {
     // Older released runners predate request_append_text, but their untargeted
     // request_set_text path already uses XCUITest typeText at the focused caret.
     // It is therefore the same non-destructive append operation for this call.
-    if (this.context.isCommandSupported?.("request_append_text") === false) {
+    const supportedCommands = await this.context.getSupportedCommands?.();
+    if (
+      supportedCommands === null ||
+      (supportedCommands !== undefined && !supportedCommands.includes("request_append_text")) ||
+      (supportedCommands === undefined && this.context.isCommandSupported?.("request_append_text") === false)
+    ) {
       return this.requestSetText(text, { timeoutMs, perf });
     }
 

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -226,6 +226,10 @@ export interface IOSCtrlProxy extends CtrlProxyClient {
     text: string, options?: SetTextOptions
   ): Promise<CtrlProxySetTextResult>;
 
+  requestAppendText(
+    text: string, timeoutMs?: number, perf?: PerformanceTracker
+  ): Promise<CtrlProxySetTextResult>;
+
   requestClearText(
     resourceId?: string, timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<CtrlProxySetTextResult>;
@@ -354,7 +358,8 @@ function nullWhenAbsent<T>(value: T | null | undefined): T | null {
  * version/hash, so presence of all of these in `supportedCommands` is the runner
  * identity used by diagnostics (doctor) and the booted-devices resource to tell a
  * current runner from a stale one. Keep unreleased feature-gated commands out of
- * this list until they are present in the released runner registry.
+ * this list until they are present in the released runner registry. Append input
+ * is deliberately included because desktop keyboard forwarding requires it.
  */
 export const IOS_RUNNER_FEATURE_COMMANDS = [
   "request_shake",
@@ -363,6 +368,7 @@ export const IOS_RUNNER_FEATURE_COMMANDS = [
   "add_highlight",
   "execute_sql",
   "set_network_mock_rules",
+  "request_append_text",
 ] as const;
 
 /**
@@ -1732,6 +1738,12 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     text: string, options?: SetTextOptions
   ): Promise<CtrlProxySetTextResult> {
     return this.text.requestSetText(text, options);
+  }
+
+  async requestAppendText(
+    text: string, timeoutMs: number = 5000, perf?: PerformanceTracker
+  ): Promise<CtrlProxySetTextResult> {
+    return this.text.requestAppendText(text, timeoutMs, perf);
   }
 
   async requestClearText(

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -359,7 +359,8 @@ function nullWhenAbsent<T>(value: T | null | undefined): T | null {
  * identity used by diagnostics (doctor) and the booted-devices resource to tell a
  * current runner from a stale one. Keep unreleased feature-gated commands out of
  * this list until they are present in the released runner registry. Append input
- * is deliberately included because desktop keyboard forwarding requires it.
+ * deliberately uses request_set_text as a compatibility fallback until its
+ * dedicated command is released.
  */
 export const IOS_RUNNER_FEATURE_COMMANDS = [
   "request_shake",
@@ -368,7 +369,6 @@ export const IOS_RUNNER_FEATURE_COMMANDS = [
   "add_highlight",
   "execute_sql",
   "set_network_mock_rules",
-  "request_append_text",
 ] as const;
 
 /**

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -815,6 +815,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       ensureConnected: perf => this.ensureConnected(perf),
       getReconnectStatus: () => this.getReconnectStatus(),
       isCommandSupported: messageType => this.isCommandSupported(messageType),
+      getSupportedCommands: () => this.getSupportedCommands(),
       unsupportedCommandError: messageType => this.buildUnsupportedCommandError(messageType),
       cancelScreenshotBackoff: () => this.cancelScreenshotBackoff(),
     };

--- a/src/features/observe/ios/ctrlProxyRequestTypes.ts
+++ b/src/features/observe/ios/ctrlProxyRequestTypes.ts
@@ -35,6 +35,7 @@ export const IOS_KNOWN_REQUEST_TYPES = [
 
   // Text input
   "request_set_text",
+  "request_append_text",
   "request_clear_text",
   "request_ime_action",
   "request_select_all",

--- a/src/features/observe/ios/decodeCtrlProxyMessage.ts
+++ b/src/features/observe/ios/decodeCtrlProxyMessage.ts
@@ -78,6 +78,7 @@ export function decodeCtrlProxyMessage(message: WebSocketMessage): DecodedCtrlPr
     case "swipe_result":
     case "drag_result":
     case "set_text_result":
+    case "append_text_result":
     case "clear_text_result":
     case "select_all_result":
     case "press_button_result":

--- a/src/features/observe/shared/types.ts
+++ b/src/features/observe/shared/types.ts
@@ -84,6 +84,8 @@ export interface DelegateContext {
   getReconnectStatus?(): CtrlProxyReconnectStatus | null;
   /** Return false when a connected service advertises that it cannot handle this wire command. */
   isCommandSupported?(messageType: string): boolean;
+  /** Wait for the connected service's command handshake, then return its advertised commands. */
+  getSupportedCommands?(): Promise<string[] | null>;
   /** Build a user-facing error for an advertised unsupported wire command. */
   unsupportedCommandError?(messageType: string): string;
   /** Cancel any pending screenshot backoff captures */

--- a/test/bats/install-background-work.bats
+++ b/test/bats/install-background-work.bats
@@ -37,6 +37,21 @@ wait_for_process_group_leader() {
   return 1
 }
 
+wait_for_child_process() {
+  local worker_pid="$1"
+  local pattern="$2"
+  local child_pid
+  for _ in {1..10}; do
+    child_pid=$("${PGREP}" -P "${worker_pid}" "${pattern}" 2>/dev/null || true)
+    if [[ -n "${child_pid}" ]]; then
+      printf '%s\n' "${child_pid}"
+      return 0
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
 teardown() {
   export PATH="${ORIG_PATH}"
   rm -rf "${TEST_DIR}"
@@ -227,7 +242,7 @@ STUB
   start_post_bun_setup
   local worker_pid="${POST_BUN_SETUP_PID}"
   local child_pid
-  child_pid=$("${PGREP}" -P "${worker_pid}" sleep)
+  child_pid=$(wait_for_child_process "${worker_pid}" sleep)
 
   cleanup_background_installer_work
 
@@ -246,7 +261,7 @@ STUB
   start_post_bun_setup
   local worker_pid="${POST_BUN_SETUP_PID}"
   local child_pid
-  child_pid=$("${PGREP}" -P "${worker_pid}" sleep)
+  child_pid=$(wait_for_child_process "${worker_pid}" sleep)
 
   cat > "${STUB_BIN}/pgrep" <<'STUB'
 #!/usr/bin/env bash

--- a/test/daemon/socketServerInputTypeText.test.ts
+++ b/test/daemon/socketServerInputTypeText.test.ts
@@ -640,6 +640,32 @@ describe("UnixSocketServer input/typeText", () => {
     expect(requestImeAction).toHaveBeenCalledWith("done", 30_000);
   });
 
+  test("accepts iOS append mode and uses the CtrlProxy append primitive", async () => {
+    const requestAppendText = mock(async () => ({ success: true, totalTimeMs: 1 }));
+    const requestSetText = mock(async () => ({ success: true, totalTimeMs: 1 }));
+    IOSCtrlProxyClient.getInstance = mock(() => ({
+      requestAppendText,
+      requestSetText,
+    })) as unknown as typeof IOSCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([iosDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const responses = await Promise.all(["a", "b", "c"].map(text =>
+      sendRequest(socketPath, "input/typeText", {
+        platform: "ios",
+        deviceId: "ios-sim-1",
+        text,
+        mode: "append",
+      })
+    ));
+
+    expect(responses.every(response => response.success)).toBe(true);
+    expect(requestAppendText).toHaveBeenCalledTimes(3);
+    expect(requestAppendText.mock.calls.map(([text]) => text)).toEqual(["a", "b", "c"]);
+    expect(requestSetText).not.toHaveBeenCalled();
+  });
+
   test("uses the socket autolock device when deviceId is omitted", async () => {
     const requestSetText = mock(async () => ({ success: true, totalTimeMs: 1 }));
     const requestImeAction = mock(async () => ({ success: true, totalTimeMs: 1 }));
@@ -928,11 +954,6 @@ describe("UnixSocketServer input/typeText", () => {
       text: "hello",
       mode: "eventAll",
     });
-    const appendOnIos = await sendRequest(socketPath, "input/typeText", {
-      platform: "ios",
-      text: "hello",
-      mode: "append",
-    });
     const unsupportedImeAction = await sendRequest(socketPath, "input/typeText", {
       platform: "android",
       text: "hello",
@@ -954,10 +975,6 @@ describe("UnixSocketServer input/typeText", () => {
     expect(nonBooleanSubmit.error).toBe("input/typeText submit must be a boolean when provided");
     expect(unsupportedMode.success).toBe(false);
     expect(unsupportedMode.error).toBe('input/typeText mode must be "append" when provided');
-    // iOS has no append-capable text primitive, so the request is REJECTED rather
-    // than silently downgraded to the destructive replace path.
-    expect(appendOnIos.success).toBe(false);
-    expect(appendOnIos.error).toBe('input/typeText mode "append" is only supported on android');
     expect(unsupportedImeAction.success).toBe(false);
     expect(unsupportedImeAction.error).toBe("input/typeText unsupported params: imeAction");
     expect(unsupportedDismissKeyboard.success).toBe(false);

--- a/test/daemon/socketServerInputTypeText.test.ts
+++ b/test/daemon/socketServerInputTypeText.test.ts
@@ -651,16 +651,17 @@ describe("UnixSocketServer input/typeText", () => {
     server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
     await server.start();
 
-    const responses = await Promise.all(["a", "b", "c"].map(text =>
-      sendRequest(socketPath, "input/typeText", {
+    for (const text of ["a", "b", "c"]) {
+      const response = await sendRequest(socketPath, "input/typeText", {
         platform: "ios",
         deviceId: "ios-sim-1",
         text,
         mode: "append",
-      })
-    ));
+      });
 
-    expect(responses.every(response => response.success)).toBe(true);
+      expect(response.success).toBe(true);
+    }
+
     expect(requestAppendText).toHaveBeenCalledTimes(3);
     expect(requestAppendText.mock.calls.map(([text]) => text)).toEqual(["a", "b", "c"]);
     expect(requestSetText).not.toHaveBeenCalled();

--- a/test/docs/daemonInputApiExamples.test.ts
+++ b/test/docs/daemonInputApiExamples.test.ts
@@ -168,8 +168,8 @@ describe("daemon input API consumer docs", () => {
       "| `input/tap` | Supported | Supported | Absolute device-screen coordinates. |",
       "| `input/swipe` | Supported | Supported | Absolute device-screen start/end coordinates. Use for drag gestures until `input/drag` has distinct semantics. |",
       "| `input/pressButton` | Supported | Supported with platform gaps | Device/navigation buttons aligned with MCP `pressButton`. Unsupported buttons fail instead of being ignored. |",
-      "| `input/typeText` | Supported | Supported (replace only) | Sends committed text only; IME composition is deferred. " +
-        "Non-destructive `mode: \"append\"` is **Android only** — iOS rejects it rather than silently replacing the field. |",
+      "| `input/typeText` | Supported | Supported | Sends committed text only; IME composition is deferred. " +
+        "Non-destructive `mode: \"append\"` is supported on both platforms. |",
       "| `input/key` | Supported | Unsupported | Discrete non-text key presses. Modifiers are deferred. |",
     ];
 
@@ -177,11 +177,10 @@ describe("daemon input API consumer docs", () => {
       expect(unixSocketApi).toContain(row);
     }
 
-    // The append mode (#3351) is the only non-destructive keyboard path a
-    // third-party client has; the doc must state the field, its Android-only
-    // restriction, and both failure modes (iOS rejection, unmappable character).
+    // The append mode is the only non-destructive keyboard path a third-party client
+    // has; document its support on both platforms and Android's character limitation.
     expect(unixSocketApi).toContain("| `mode` | `\"append\"` | No |");
-    expect(unixSocketApi).toContain('input/typeText mode "append" is only supported on android');
+    expect(unixSocketApi).toContain("**iOS.** Append dispatches to CtrlProxy's focused-field insert primitive");
     expect(unixSocketApi).toContain("append cannot type");
     expect(unixSocketApi).toContain('"mode": "append"');
 

--- a/test/doctor/ios.test.ts
+++ b/test/doctor/ios.test.ts
@@ -656,8 +656,9 @@ describe("checkIosCtrlProxyRunner", () => {
     "request_screenshot",
     "request_tap_coordinates"
   ];
-  // The released v0.0.38 runner predates `request_shake` (and the other features).
-  const STALE_COMMANDS = FRESH_COMMANDS.filter(command => command !== "request_shake");
+  // A runner that predates append input must be classified stale before desktop
+  // keyboard forwarding tries the capability-gated command.
+  const STALE_COMMANDS = FRESH_COMMANDS.filter(command => command !== "request_append_text");
 
   const inspection = (over: Partial<IosRunnerInspection> = {}): IosRunnerInspection => ({
     deviceId: "SIM-1",
@@ -723,7 +724,7 @@ describe("checkIosCtrlProxyRunner", () => {
 
     expect(result.status).toBe("warn");
     expect(result.message).toContain("versionStatus=stale");
-    expect(result.message).toContain("request_shake");
+    expect(result.message).toContain("request_append_text");
     expect(result.recommendation).toContain("ctrl-proxy-build-for-testing.sh");
     // BUNDLE_PATH takes an .ipa file and cannot consume the build script's
     // derived-data output; DERIVED_DATA is the followable override (#4221).

--- a/test/doctor/ios.test.ts
+++ b/test/doctor/ios.test.ts
@@ -656,9 +656,9 @@ describe("checkIosCtrlProxyRunner", () => {
     "request_screenshot",
     "request_tap_coordinates"
   ];
-  // A runner that predates append input must be classified stale before desktop
-  // keyboard forwarding tries the capability-gated command.
-  const STALE_COMMANDS = FRESH_COMMANDS.filter(command => command !== "request_append_text");
+  // Remove a required feature command so the stale fixture remains meaningfully
+  // different from a fresh runner even while append has a compatibility fallback.
+  const STALE_COMMANDS = FRESH_COMMANDS.filter(command => command !== "request_shake");
 
   const inspection = (over: Partial<IosRunnerInspection> = {}): IosRunnerInspection => ({
     deviceId: "SIM-1",
@@ -724,7 +724,7 @@ describe("checkIosCtrlProxyRunner", () => {
 
     expect(result.status).toBe("warn");
     expect(result.message).toContain("versionStatus=stale");
-    expect(result.message).toContain("request_append_text");
+    expect(result.message).toContain("request_shake");
     expect(result.recommendation).toContain("ctrl-proxy-build-for-testing.sh");
     // BUNDLE_PATH takes an .ipa file and cannot consume the build script's
     // derived-data output; DERIVED_DATA is the followable override (#4221).

--- a/test/features/observe/ios/CtrlProxyText.test.ts
+++ b/test/features/observe/ios/CtrlProxyText.test.ts
@@ -27,4 +27,27 @@ describe("CtrlProxyText requestAppendText", () => {
     expect(harness.resolveLast({ success: true, totalTimeMs: 1 })).toBe(true);
     await expect(pending).resolves.toEqual({ success: true, totalTimeMs: 1 });
   });
+
+  test("waits for a stale runner handshake before choosing the compatibility command", async () => {
+    const harness = createIosDelegateHarness();
+    const handshake = new Promise<string[]>(resolve => {
+      harness.timer.setTimeout(() => resolve(["request_set_text"]), 50);
+    });
+    const text = new CtrlProxyText({
+      ...harness.context,
+      getSupportedCommands: () => handshake,
+    });
+
+    const pending = text.requestAppendText("a");
+    await flush();
+    expect(harness.sentMessages).toEqual([]);
+
+    harness.advanceTime(50);
+    await flush();
+    expect(harness.sentMessages).toEqual([
+      expect.objectContaining({ type: "request_set_text", text: "a" }),
+    ]);
+    expect(harness.resolveLast({ success: true, totalTimeMs: 1 })).toBe(true);
+    await expect(pending).resolves.toEqual({ success: true, totalTimeMs: 1 });
+  });
 });

--- a/test/features/observe/ios/CtrlProxyText.test.ts
+++ b/test/features/observe/ios/CtrlProxyText.test.ts
@@ -16,14 +16,15 @@ describe("CtrlProxyText requestAppendText", () => {
     await expect(pending).resolves.toEqual({ success: true, totalTimeMs: 1 });
   });
 
-  test("returns the actionable capability error without sending to a stale runner", async () => {
+  test("falls back to focused-field typeText on a runner that predates append", async () => {
     const harness = createIosDelegateHarness({ supportedCommands: ["request_set_text"] });
+    const pending = new CtrlProxyText(harness.context).requestAppendText("a");
+    await flush();
 
-    await expect(new CtrlProxyText(harness.context).requestAppendText("a")).resolves.toEqual({
-      success: false,
-      totalTimeMs: 0,
-      error: "request_append_text is not supported by the connected device service",
-    });
-    expect(harness.sentMessages).toEqual([]);
+    expect(harness.sentMessages).toEqual([
+      expect.objectContaining({ type: "request_set_text", text: "a" }),
+    ]);
+    expect(harness.resolveLast({ success: true, totalTimeMs: 1 })).toBe(true);
+    await expect(pending).resolves.toEqual({ success: true, totalTimeMs: 1 });
   });
 });

--- a/test/features/observe/ios/CtrlProxyText.test.ts
+++ b/test/features/observe/ios/CtrlProxyText.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { CtrlProxyText } from "../../../../src/features/observe/ios/CtrlProxyText";
+import { createIosDelegateHarness } from "../../../helpers/iosDelegateHarness";
+
+describe("CtrlProxyText requestAppendText", () => {
+  const flush = (): Promise<void> => new Promise<void>(resolve => setImmediate(resolve));
+
+  test("sends the append command and resolves its normalized result", async () => {
+    const harness = createIosDelegateHarness({ supportedCommands: ["request_append_text"] });
+    const pending = new CtrlProxyText(harness.context).requestAppendText("a");
+    await flush();
+
+    expect(harness.sentMessages).toHaveLength(1);
+    expect(harness.sentMessages[0]).toMatchObject({ type: "request_append_text", text: "a" });
+    expect(harness.resolveLast({ success: true, totalTimeMs: 1 })).toBe(true);
+    await expect(pending).resolves.toEqual({ success: true, totalTimeMs: 1 });
+  });
+
+  test("returns the actionable capability error without sending to a stale runner", async () => {
+    const harness = createIosDelegateHarness({ supportedCommands: ["request_set_text"] });
+
+    await expect(new CtrlProxyText(harness.context).requestAppendText("a")).resolves.toEqual({
+      success: false,
+      totalTimeMs: 0,
+      error: "request_append_text is not supported by the connected device service",
+    });
+    expect(harness.sentMessages).toEqual([]);
+  });
+});

--- a/test/features/observe/ios/ctrlProxyRequestSnapshots.test.ts
+++ b/test/features/observe/ios/ctrlProxyRequestSnapshots.test.ts
@@ -168,6 +168,11 @@ const SNAPSHOT_SPECS: SnapshotSpec[] = [
     invoke: h => new CtrlProxyText(h.context).requestSetText("hello world", { resourceId: "login_username_field" }),
   },
   {
+    name: "request_append_text",
+    builder: "CtrlProxyText.requestAppendText",
+    invoke: h => new CtrlProxyText(h.context).requestAppendText("a"),
+  },
+  {
     name: "request_clear_text",
     builder: "CtrlProxyText.requestClearText",
     invoke: h => new CtrlProxyText(h.context).requestClearText("login_username_field"),
@@ -460,6 +465,7 @@ describe("iOS control-proxy — request snapshot fixture matches live TS builder
     const required = [
       "request_action",
       "request_set_text",
+      "request_append_text",
       "request_ime_action",
       "request_hierarchy",
       "request_hierarchy_if_stale",

--- a/test/features/observe/ios/ctrlProxyWireParity.test.ts
+++ b/test/features/observe/ios/ctrlProxyWireParity.test.ts
@@ -50,6 +50,7 @@ const SWIFT_REQUEST_TYPES = [
   "request_drag",
   "request_pinch",
   "request_set_text",
+  "request_append_text",
   "request_clear_text",
   "request_ime_action",
   "request_select_all",
@@ -229,8 +230,9 @@ describe("iOS control-proxy — emitted commands are a subset of the runner cont
     expect(unknown).toEqual([]);
   });
 
-  test("IOS_RUNNER_FEATURE_COMMANDS excludes feature-gated unreleased commands", () => {
+  test("IOS_RUNNER_FEATURE_COMMANDS includes the released append input capability", () => {
     const baselineCommands: readonly string[] = IOS_RUNNER_FEATURE_COMMANDS;
+    expect(baselineCommands).toContain("request_append_text");
     expect(baselineCommands).not.toContain("set_network_error_simulation");
   });
 });

--- a/test/features/observe/ios/ctrlProxyWireParity.test.ts
+++ b/test/features/observe/ios/ctrlProxyWireParity.test.ts
@@ -230,9 +230,9 @@ describe("iOS control-proxy — emitted commands are a subset of the runner cont
     expect(unknown).toEqual([]);
   });
 
-  test("IOS_RUNNER_FEATURE_COMMANDS includes the released append input capability", () => {
+  test("IOS_RUNNER_FEATURE_COMMANDS excludes append until the runner release", () => {
     const baselineCommands: readonly string[] = IOS_RUNNER_FEATURE_COMMANDS;
-    expect(baselineCommands).toContain("request_append_text");
+    expect(baselineCommands).not.toContain("request_append_text");
     expect(baselineCommands).not.toContain("set_network_error_simulation");
   });
 });

--- a/test/features/observe/ios/decodeCtrlProxyMessage.test.ts
+++ b/test/features/observe/ios/decodeCtrlProxyMessage.test.ts
@@ -47,6 +47,7 @@ describe("decodeCtrlProxyMessage", () => {
     "swipe_result",
     "drag_result",
     "set_text_result",
+    "append_text_result",
     "clear_text_result",
     "select_all_result",
     "press_button_result",
@@ -401,8 +402,8 @@ describe("decodeCtrlProxyMessage ↔ Swift ResponseType parity (ADD-3 / item 4)"
     "set_network_mock_rules_result",
   ];
 
-  test("Swift ResponseType declares exactly 42 rawValues", () => {
-    expect(rawValues.length).toBe(42);
+  test("Swift ResponseType declares exactly 43 rawValues", () => {
+    expect(rawValues.length).toBe(43);
   });
 
   test("rawValues are unique (no accidental duplicate)", () => {
@@ -415,8 +416,8 @@ describe("decodeCtrlProxyMessage ↔ Swift ResponseType parity (ADD-3 / item 4)"
     }
   });
 
-  test("the decoder explicitly reshapes exactly 35 response types", () => {
-    expect(rawValues.filter(isExplicitlyDecoded).length).toBe(35);
+  test("the decoder explicitly reshapes exactly 36 response types", () => {
+    expect(rawValues.filter(isExplicitlyDecoded).length).toBe(36);
   });
 
   test("the only unhandled ResponseType (excluding fire-and-forget) is shake_result", () => {
@@ -439,7 +440,7 @@ describe("decodeCtrlProxyMessage ↔ Swift ResponseType parity (ADD-3 / item 4)"
  */
 describe("decodeCtrlProxyMessage success defaulting (PARAM-5 / item 11)", () => {
   // One row per decoded response type → the value of `success` when the wire
-  // message omits it. 35 rows = the 35 explicitly-decoded ResponseTypes.
+  // message omits it. 36 rows = the 36 explicitly-decoded ResponseTypes.
   const DEFAULT_WHEN_ABSENT: Array<{ type: string; expected: boolean | undefined }> = [
     { type: "hierarchy_update", expected: undefined },
     { type: "screenshot", expected: true },
@@ -448,6 +449,7 @@ describe("decodeCtrlProxyMessage success defaulting (PARAM-5 / item 11)", () => 
     { type: "swipe_result", expected: true },
     { type: "drag_result", expected: true },
     { type: "set_text_result", expected: true },
+    { type: "append_text_result", expected: true },
     { type: "clear_text_result", expected: true },
     { type: "select_all_result", expected: true },
     { type: "press_button_result", expected: true },
@@ -478,8 +480,8 @@ describe("decodeCtrlProxyMessage success defaulting (PARAM-5 / item 11)", () => 
     { type: "table_structure_result", expected: false },
   ];
 
-  test("the default table covers all 35 explicitly-decoded types", () => {
-    expect(DEFAULT_WHEN_ABSENT.length).toBe(35);
+  test("the default table covers all 36 explicitly-decoded types", () => {
+    expect(DEFAULT_WHEN_ABSENT.length).toBe(36);
   });
 
   for (const { type, expected } of DEFAULT_WHEN_ABSENT) {
@@ -496,8 +498,8 @@ describe("decodeCtrlProxyMessage success defaulting (PARAM-5 / item 11)", () => 
     .filter(row => row.type !== "hierarchy_update" && row.type !== "screenshot")
     .map(row => row.type);
 
-  test("the passthrough set is the 33 success-reading types", () => {
-    expect(READS_MESSAGE_SUCCESS.length).toBe(33);
+  test("the passthrough set is the 34 success-reading types", () => {
+    expect(READS_MESSAGE_SUCCESS.length).toBe(34);
   });
 
   for (const type of READS_MESSAGE_SUCCESS) {

--- a/test/fixtures/ios-ctrlproxy-request-snapshots.json
+++ b/test/fixtures/ios-ctrlproxy-request-snapshots.json
@@ -118,6 +118,15 @@
       }
     },
     {
+      "name": "request_append_text",
+      "builder": "CtrlProxyText.requestAppendText",
+      "wire": {
+        "type": "request_append_text",
+        "requestId": "fixture-request-id",
+        "text": "a"
+      }
+    },
+    {
       "name": "request_clear_text",
       "builder": "CtrlProxyText.requestClearText",
       "wire": {


### PR DESCRIPTION
## Summary

- add an explicit iOS CtrlProxy append-text command that types into the focused field without replacing its contents
- route desktop printable-key forwarding through append mode on Android and iOS
- detect older iOS runners that lack the command, with wire parity, response decoding, and stale-runner coverage

Fixes [#4519](https://github.com/kaeawc/auto-mobile/issues/4519).

## Validation

- `bun run turbo:validate`
- `swift build -Xswiftc -warnings-as-errors && swift test` (`ios/control-proxy`)
- `./gradlew :desktop-core:test --tests DeviceControlSessionKeyboardTest --tests DeviceKeyboardInputPolicyTest --tests ThreePaneShellDeviceKeyTest :desktop-core:detekt :desktop-domain:detekt`

## Release delivery

The next tagged iOS CtrlProxy runner release must package this command. Until then, an older runner is reported as stale rather than silently considered compatible.
