### PR TITLE
docs(desktop): clarify AltGraph adapter contract

### DIFF
--- a/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/DeviceKeyboardInputPolicy.kt
+++ b/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/DeviceKeyboardInputPolicy.kt
@@ -56,14 +56,15 @@ public data class DeviceKeyModifiers(
  * @param altComposesText the host's platform-resolved verdict that this Alt-family keystroke is
  *   **composing a character** (AltGr on Windows/Linux, Option on macOS) rather than triggering a
  *   menu accelerator. The toolkit adapter that sees the host decides it: on Linux, use the native
- *   AltGraph state so a genuine Ctrl+Alt shortcut with AltGraph unset stays with the host; on
- *   Windows, use the Ctrl+Alt compatibility fallback when the JDK omits the native AltGraph mask
- *   for real AltGr; on macOS, Option (plain Alt) composes. A plain `Alt+F` accelerator can report a
- *   printable `keyChar`, so `alt && printable` would swallow it. The reference client resolves the
- *   verdict in `DeviceKeyboardEventTranslator` and passes the clean boolean in. The policy stays
- *   platform-agnostic and only forwards such a keystroke when it ALSO produced a typable
- *   character. Defaults false: absent a host verdict, an Alt-modified keystroke is a host chord,
- *   never swallowed.
+ *   AltGraph state when available so a genuine Ctrl+Alt shortcut with AltGraph false stays with the
+ *   host; if the signal is unavailable, fall back to Ctrl+Alt for AltGr. Windows uses the same
+ *   fallback when the JDK omits the native AltGraph mask for real AltGr; on macOS, Option (plain
+ *   Alt) composes. A plain `Alt+F` accelerator can report a printable `keyChar`, so `alt &&
+ *   printable` would swallow it. The reference client resolves the verdict in
+ *   `DeviceKeyboardEventTranslator` and passes the clean boolean in. The policy stays
+ *   platform-agnostic and only forwards such a keystroke when it ALSO produced a typable character.
+ *   Defaults false: absent a host verdict, an Alt-modified keystroke is a host chord, never
+ *   swallowed.
  */
 public data class DeviceKeyStroke(
   val key: DeviceKeyboardKey? = null,
@@ -198,11 +199,12 @@ public sealed interface DeviceKeyboardDecision {
  *    the desktop app has its own menu accelerators, and a third-party host has different ones
  *    again. Refusing every chord by default is the only rule correct for all of them. The one
  *    exception — composition — is **platform-dependent** and therefore cannot be decided here:
- *    Linux uses native AltGraph so a genuine Ctrl+Alt chord stays with the host; Windows falls back
- *    to Ctrl+Alt when the JDK omits that signal for real AltGr; and macOS uses Option (plain Alt),
- *    where menus use Cmd. The toolkit adapter that sees the host OS resolves the verdict and passes
- *    it in. Deciding it from `alt && printable` would swallow a plain `Alt+F` menu accelerator,
- *    which reports a printable char too.
+ *    Linux uses native AltGraph when available so a genuine Ctrl+Alt chord stays with the host, and
+ *    falls back to Ctrl+Alt when the signal is unavailable; Windows uses the same fallback when the
+ *    JDK omits the signal for real AltGr; and macOS uses Option (plain Alt), where menus use Cmd.
+ *    The toolkit adapter that sees the host OS resolves the verdict and passes it in. Deciding it
+ *    from `alt && printable` would swallow a plain `Alt+F` menu accelerator, which reports a
+ *    printable char too.
  * 2. **A device-meaningful key wins over the character it produced.** Enter, Tab and Backspace all
  *    report a control character; sending those as text would put a literal `\n` in a text field.
  *    But a device key with **Shift held is declined**: the daemon's `input/key` transmits no

--- a/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/DeviceKeyboardInputPolicy.kt
+++ b/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/DeviceKeyboardInputPolicy.kt
@@ -55,13 +55,15 @@ public data class DeviceKeyModifiers(
  * @param modifiers the modifiers held at the time.
  * @param altComposesText the host's platform-resolved verdict that this Alt-family keystroke is
  *   **composing a character** (AltGr on Windows/Linux, Option on macOS) rather than triggering a
- *   menu accelerator. The distinction cannot be made from modifiers alone — on Windows/Linux AWT
- *   reports a printable `keyChar` for a plain `Alt+F` menu accelerator, so `alt && printable` would
- *   swallow it — so the toolkit adapter that CAN see the platform (the reference client resolves it
- *   in `DeviceKeyboardEventTranslator`: `!meta && (isMac ? alt : ctrl && alt)`) decides and passes
- *   the clean boolean in. The policy stays platform-agnostic and only forwards such a keystroke
- *   when it ALSO produced a typable character. Defaults false: absent a host verdict, an
- *   Alt-modified keystroke is a host chord, never swallowed.
+ *   menu accelerator. The toolkit adapter that sees the host decides it: on Linux, use the native
+ *   AltGraph state so a genuine Ctrl+Alt shortcut with AltGraph unset stays with the host; on
+ *   Windows, use the Ctrl+Alt compatibility fallback when the JDK omits the native AltGraph mask
+ *   for real AltGr; on macOS, Option (plain Alt) composes. A plain `Alt+F` accelerator can report a
+ *   printable `keyChar`, so `alt && printable` would swallow it. The reference client resolves the
+ *   verdict in `DeviceKeyboardEventTranslator` and passes the clean boolean in. The policy stays
+ *   platform-agnostic and only forwards such a keystroke when it ALSO produced a typable
+ *   character. Defaults false: absent a host verdict, an Alt-modified keystroke is a host chord,
+ *   never swallowed.
  */
 public data class DeviceKeyStroke(
   val key: DeviceKeyboardKey? = null,
@@ -195,11 +197,12 @@ public sealed interface DeviceKeyboardDecision {
  *    of *modifiers*, not one host's keymap, precisely because the host is not knowable from here:
  *    the desktop app has its own menu accelerators, and a third-party host has different ones
  *    again. Refusing every chord by default is the only rule correct for all of them. The one
- *    exception — composition — is **platform-dependent** (AltGr is Ctrl+Alt on Windows/Linux;
- *    Option is plain Alt on macOS, where menus use Cmd) and therefore cannot be decided here: the
- *    toolkit adapter that sees the host OS resolves it and passes the verdict in. Deciding it from
- *    `alt && printable` would swallow a Windows/Linux `Alt+F` menu accelerator, which reports a
- *    printable char too.
+ *    exception — composition — is **platform-dependent** and therefore cannot be decided here:
+ *    Linux uses native AltGraph so a genuine Ctrl+Alt chord stays with the host; Windows falls back
+ *    to Ctrl+Alt when the JDK omits that signal for real AltGr; and macOS uses Option (plain Alt),
+ *    where menus use Cmd. The toolkit adapter that sees the host OS resolves the verdict and passes
+ *    it in. Deciding it from `alt && printable` would swallow a plain `Alt+F` menu accelerator,
+ *    which reports a printable char too.
  * 2. **A device-meaningful key wins over the character it produced.** Enter, Tab and Backspace all
  *    report a control character; sending those as text would put a literal `\n` in a text field.
  *    But a device key with **Shift held is declined**: the daemon's `input/key` transmits no


### PR DESCRIPTION
## Summary

- Update the public `DeviceKeyStroke.altComposesText` KDoc with Linux native-AltGraph routing.
- Document the Windows Ctrl+Alt compatibility fallback and macOS Option behavior for third-party toolkit adapters.

## Why

[PR #4545](https://github.com/kaeawc/auto-mobile/pull/4545) corrected the reference client but left the public adapter contract describing Linux AltGr as Ctrl+Alt. That could cause other clients to consume genuine Linux Ctrl+Alt host shortcuts.

## Validation

- `./gradlew :desktop-core:test --tests dev.jasonpearson.automobile.desktop.core.control.DeviceKeyboardInputPolicyTest --tests dev.jasonpearson.automobile.desktop.core.control.DeviceKeyboardEventTranslatorTest :desktop-domain:detekt :desktop-core:detekt`
- `git diff --check`
