### PR TITLE
fix(server): trim device version bounds

### DIFF
--- a/src/utils/deviceMatcher.ts
+++ b/src/utils/deviceMatcher.ts
@@ -14,7 +14,7 @@ interface ParsedDeviceVersion {
 }
 
 function parseDeviceVersion(version: string): ParsedDeviceVersion | null {
-  const match = /^(\d+(?:\.\d+)*)(?:-QPR(\d+))?$/i.exec(version);
+  const match = /^(\d+(?:\.\d+)*)(?:-QPR(\d+))?$/i.exec(version.trim());
   if (!match) {
     return null;
   }

--- a/test/server/deviceMatcher.test.ts
+++ b/test/server/deviceMatcher.test.ts
@@ -315,6 +315,21 @@ describe("DefaultDeviceMatcher.matchBootedDevice", () => {
     expect(result?.deviceId).toBe("qpr2");
   });
 
+  it("trims surrounding whitespace from version bounds", () => {
+    const devices = [
+      bootedDevice({ deviceId: "13", osVersion: "13" }),
+      bootedDevice({ deviceId: "14", osVersion: "14" }),
+      bootedDevice({ deviceId: "15", osVersion: "15" }),
+    ];
+
+    const result = matcher.matchBootedDevice(
+      { platform: "android", minOsVersion: " 14 ", maxOsVersion: "\t14\n" },
+      devices,
+      "LATEST"
+    );
+    expect(result?.deviceId).toBe("14");
+  });
+
   it("does not let a codename satisfy a numeric minimum or outrank a numeric release", () => {
     const devices = [
       bootedDevice({ deviceId: "codename", osVersion: "Tiramisu" }),


### PR DESCRIPTION
## Summary

- Trim surrounding whitespace before parsing device-matcher version inputs.
- Keep the daemon's strict numeric version comparator unchanged.
- Cover whitespace-wrapped minimum and maximum bounds.

## Root cause

The device matcher passed bounds through to an anchored version parser. Bounds such as `" 14 "` therefore failed numeric parsing and excluded otherwise matching devices.

## Validation

- `bun test test/server/deviceMatcher.test.ts`
- `bun run turbo:validate`
- `bun run typecheck`
