### PR TITLE
test: add cross-language golden vectors for coordinate mapping (#4547)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -206,6 +206,14 @@ jobs:
           filters: |
             desktop_core:
               - 'android/desktop-core/**'
+              # desktop-core depends on desktop-domain (api(project(":desktop-domain"))),
+              # and the desktop-domain mapper's golden/unit tests LIVE in desktop-core
+              # (e.g. CoordinateMappingGoldenVectorTest for issue #4547). Without this
+              # entry a desktop-domain-only change skipped desktop-core-unit-tests and
+              # the drift guard never executed (pre-existing gap; #4547 made it
+              # load-bearing). ide-plugin and desktop-app jobs OR on this output, so
+              # they pick up desktop-domain changes through it as well.
+              - 'android/desktop-domain/**'
               - 'android/protocol/**'
               - 'android/test-plan-validation/**'
               - 'android/gradle.properties'

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/CoordinateMappingGoldenVectorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/CoordinateMappingGoldenVectorTest.kt
@@ -147,8 +147,10 @@ class CoordinateMappingGoldenVectorTest {
       FitScaleVector(300f, 600f, 800f, 1200f, 32f, 1f),
       // Frame far larger than viewport: clamps to the 0.3 floor.
       FitScaleVector(5000f, 5000f, 400f, 400f, 32f, 0.3f),
-      // Mid-range: 736+64=800 padded frame in a 400-wide viewport.
+      // Mid-range: 736+64=800 padded frame in a 400-wide viewport (WIDTH candidate decisive).
       FitScaleVector(736f, 736f, 400f, 800f, 32f, 0.5f),
+      // HEIGHT candidate decisive mid-range: 400/(736+64)=0.5 binds; width candidate is 2.0.
+      FitScaleVector(336f, 736f, 800f, 400f, 32f, 0.5f),
     )
 
   private data class ScreenshotRotationVector(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/CoordinateMappingGoldenVectorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/CoordinateMappingGoldenVectorTest.kt
@@ -74,6 +74,9 @@ class CoordinateMappingGoldenVectorTest {
       ViewportToDeviceVector(375f, 667f, 1f, 0f, 0f, 375, 667, 100.4f, 200.6f, 100, 201, 1),
       // iOS Display Zoom-like device (320x693 zoomed points at 3x); changes under #4549.
       ViewportToDeviceVector(320f, 693f, 1f, 0f, 0f, 320, 693, 160f, 346.5f, 160, 347, 1),
+      // Width-derived-ratio invariant: aspect-MISMATCHED frame (width ratio 2, height ratio
+      // 4). Pins that BOTH axes scale by deviceWidth/frameWidthPx (height-derived y = 800).
+      ViewportToDeviceVector(500f, 500f, 1f, 0f, 0f, 1000, 2000, 100f, 200f, 200, 400, 1),
     )
 
   private data class DeviceToViewportVector(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/CoordinateMappingGoldenVectorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/CoordinateMappingGoldenVectorTest.kt
@@ -1,0 +1,266 @@
+package dev.jasonpearson.automobile.desktop.core.layout
+
+import dev.jasonpearson.automobile.desktop.domain.DeviceScreenCoordinateMapper
+import dev.jasonpearson.automobile.desktop.domain.DeviceScreenGeometry
+import dev.jasonpearson.automobile.desktop.domain.ViewportPoint
+import kotlin.test.assertEquals
+import org.junit.Test
+
+/**
+ * Cross-language golden vectors for viewport <-> device coordinate mapping (issue #4547, B0 of the
+ * canonical-pixel campaign #4547 -> #4548 -> #4549 -> #4550).
+ *
+ * The canonical single source is `test/fixtures/coordinate-mapping-golden-vectors.json` at the repo
+ * root. The inline tables below are a committed copy of its five [DeviceScreenCoordinateMapper]
+ * sections; `test/parity/coordinateMappingGoldenVectorParity.test.ts` parses these literals out of
+ * this file's source and verifies them against the JSON (the same drift-guard mechanism as
+ * `PinchGeometryTest.kt` / `pinch-golden-vectors.json`), so a one-sided edit of either side fails
+ * `bun test`.
+ *
+ * KEEP THE TABLES PURELY NUMERIC: no string literals and no booleans inside the `listOf(...)`
+ * regions (booleans are encoded as 0/1) — the TypeScript parser extracts numbers positionally. Row
+ * order must match the JSON.
+ *
+ * These vectors PIN CURRENT BEHAVIOR. The iOS point-space rows (flagged
+ * willChangeUnderCanonicalPixels in the JSON) MUST change when #4549 converts hierarchy bounds to
+ * canonical pixels; update the JSON and every consumer together in that PR.
+ */
+class CoordinateMappingGoldenVectorTest {
+
+  private val mapper = DeviceScreenCoordinateMapper
+
+  private data class ViewportToDeviceVector(
+    val frameWidthPx: Float,
+    val frameHeightPx: Float,
+    val scale: Float,
+    val offsetX: Float,
+    val offsetY: Float,
+    val deviceWidth: Int,
+    val deviceHeight: Int,
+    val viewportX: Float,
+    val viewportY: Float,
+    val expectedX: Int,
+    val expectedY: Int,
+    val expectedInBounds: Int,
+  )
+
+  private val viewportToDeviceVectors =
+    listOf(
+      // Android 1080x2340 portrait, frame at half device size: frame center -> device center.
+      ViewportToDeviceVector(540f, 1170f, 1f, 0f, 0f, 1080, 2340, 270f, 585f, 540, 1170, 1),
+      // Zoom removal: at scale 2 a viewport point twice as far maps to the same device point.
+      ViewportToDeviceVector(540f, 1170f, 2f, 0f, 0f, 1080, 2340, 540f, 1170f, 540, 1170, 1),
+      // Pan removal: device origin sits at the pan offset.
+      ViewportToDeviceVector(540f, 1170f, 1f, 100f, 50f, 1080, 2340, 100f, 50f, 0, 0, 1),
+      // Pan + zoom combined.
+      ViewportToDeviceVector(540f, 1170f, 2f, 100f, 50f, 1080, 2340, 370f, 635f, 270, 585, 1),
+      // Rounding boundary: device 0.5 rounds half-up to 1.
+      ViewportToDeviceVector(540f, 1170f, 1f, 0f, 0f, 1080, 2340, 0.25f, 0f, 1, 0, 1),
+      // Negative rounding boundary: device -0.5 rounds toward positive infinity to 0.
+      ViewportToDeviceVector(540f, 1170f, 1f, 0f, 0f, 1080, 2340, -0.25f, 0f, 0, 0, 1),
+      // Out of bounds at exactly deviceWidth: bounds are exclusive, no clamping.
+      ViewportToDeviceVector(540f, 1170f, 1f, 0f, 0f, 1080, 2340, 540f, 585f, 1080, 1170, 0),
+      // Negative out of bounds: raw coordinates returned, never clamped.
+      ViewportToDeviceVector(540f, 1170f, 1f, 0f, 0f, 1080, 2340, -10f, -10f, -20, -20, 0),
+      // Far past the bottom-right edge.
+      ViewportToDeviceVector(540f, 1170f, 1f, 0f, 0f, 1080, 2340, 1000f, 2000f, 2000, 4000, 0),
+      // Landscape device space (rotation-aligned upstream).
+      ViewportToDeviceVector(1170f, 540f, 1f, 0f, 0f, 2340, 1080, 585f, 270f, 1170, 540, 1),
+      // Degenerate zero frame width: frame-to-device ratio falls back to 1.
+      ViewportToDeviceVector(0f, 0f, 1f, 0f, 0f, 1080, 2340, 12.5f, 7f, 13, 7, 1),
+      // iOS 3x device (390x844): device space is POINTS today; changes under #4549.
+      ViewportToDeviceVector(390f, 844f, 1f, 0f, 0f, 390, 844, 195f, 422f, 195, 422, 1),
+      // iOS 2x device (375x667) with fractional viewport input; changes under #4549.
+      ViewportToDeviceVector(375f, 667f, 1f, 0f, 0f, 375, 667, 100.4f, 200.6f, 100, 201, 1),
+      // iOS Display Zoom-like device (320x693 zoomed points at 3x); changes under #4549.
+      ViewportToDeviceVector(320f, 693f, 1f, 0f, 0f, 320, 693, 160f, 346.5f, 160, 347, 1),
+    )
+
+  private data class DeviceToViewportVector(
+    val deviceX: Int,
+    val deviceY: Int,
+    val frameWidthPx: Float,
+    val frameHeightPx: Float,
+    val scale: Float,
+    val offsetX: Float,
+    val offsetY: Float,
+    val deviceWidth: Int,
+    val deviceHeight: Int,
+    val expectedX: Float,
+    val expectedY: Float,
+  )
+
+  private val deviceToViewportVectors =
+    listOf(
+      // Inverse of the identity half-frame case: device center back to frame center.
+      DeviceToViewportVector(540, 1170, 540f, 1170f, 1f, 0f, 0f, 1080, 2340, 270f, 585f),
+      // Inverse with pan + zoom.
+      DeviceToViewportVector(270, 585, 540f, 1170f, 2f, 100f, 50f, 1080, 2340, 370f, 635f),
+      // Degenerate zero device width: device-to-frame ratio falls back to 1.
+      DeviceToViewportVector(7, 9, 540f, 1170f, 1f, 10f, 20f, 0, 2340, 17f, 29f),
+      // iOS 3x point-space inverse; changes under #4549.
+      DeviceToViewportVector(195, 422, 390f, 844f, 1f, 0f, 0f, 390, 844, 195f, 422f),
+    )
+
+  private data class FitToViewportVector(
+    val imageWidth: Int,
+    val imageHeight: Int,
+    val viewportWidth: Float,
+    val viewportHeight: Float,
+    val padding: Float,
+    val expectedWidthPx: Float,
+    val expectedHeightPx: Float,
+  )
+
+  private val fitToViewportVectors =
+    listOf(
+      // Height-constrained: 1080x2160 (aspect 2.0) in 800x800 with 32 padding.
+      FitToViewportVector(1080, 2160, 800f, 800f, 32f, 368f, 736f),
+      // Width-constrained: narrow tall viewport.
+      FitToViewportVector(1080, 2160, 400f, 2000f, 32f, 336f, 672f),
+      // Landscape image (aspect 0.5): width-constrained.
+      FitToViewportVector(2160, 1080, 1200f, 1200f, 32f, 1136f, 568f),
+      // Unknown image width falls back to aspect ratio 2.16.
+      FitToViewportVector(0, 0, 800f, 800f, 32f, 340.7407f, 736f),
+      // Tiny viewport: max frame sides coerce to the 1px floor.
+      FitToViewportVector(1080, 2160, 10f, 10f, 32f, 0.5f, 1f),
+    )
+
+  private data class FitScaleVector(
+    val frameWidthPx: Float,
+    val frameHeightPx: Float,
+    val viewportWidth: Float,
+    val viewportHeight: Float,
+    val padding: Float,
+    val expected: Float,
+  )
+
+  private val fitScaleVectors =
+    listOf(
+      // Frame fits comfortably: scale caps at 1.0.
+      FitScaleVector(300f, 600f, 800f, 1200f, 32f, 1f),
+      // Frame far larger than viewport: clamps to the 0.3 floor.
+      FitScaleVector(5000f, 5000f, 400f, 400f, 32f, 0.3f),
+      // Mid-range: 736+64=800 padded frame in a 400-wide viewport.
+      FitScaleVector(736f, 736f, 400f, 800f, 32f, 0.5f),
+    )
+
+  private data class ScreenshotRotationVector(
+    val imageWidth: Int,
+    val imageHeight: Int,
+    val rootWidth: Int,
+    val rootHeight: Int,
+    val expected: Int,
+  )
+
+  private val screenshotRotationVectors =
+    listOf(
+      // Portrait image, portrait bounds: no rotation.
+      ScreenshotRotationVector(1080, 2340, 1080, 2340, 0),
+      // Landscape image, landscape bounds: no rotation.
+      ScreenshotRotationVector(2340, 1080, 2340, 1080, 0),
+      // Portrait image, landscape bounds: rotate 90 CW.
+      ScreenshotRotationVector(1080, 2340, 2340, 1080, 3),
+      // Landscape image, portrait bounds: rotate 270 CW.
+      ScreenshotRotationVector(2340, 1080, 1080, 2340, 1),
+      // Non-positive image width: no rotation inferred.
+      ScreenshotRotationVector(0, 2340, 1080, 2340, 0),
+      // Non-positive root dimensions: no rotation inferred.
+      ScreenshotRotationVector(1080, 2340, 0, 0, 0),
+      // iOS pixel screenshot vs point-space root: orientations agree across units.
+      ScreenshotRotationVector(1170, 2532, 390, 844, 0),
+      // Square image counts as landscape against portrait bounds.
+      ScreenshotRotationVector(1000, 1000, 1080, 2340, 1),
+    )
+
+  private fun geometry(vector: ViewportToDeviceVector) =
+    DeviceScreenGeometry(
+      frameWidthPx = vector.frameWidthPx,
+      frameHeightPx = vector.frameHeightPx,
+      scale = vector.scale,
+      offsetX = vector.offsetX,
+      offsetY = vector.offsetY,
+      deviceWidth = vector.deviceWidth,
+      deviceHeight = vector.deviceHeight,
+    )
+
+  private fun geometry(vector: DeviceToViewportVector) =
+    DeviceScreenGeometry(
+      frameWidthPx = vector.frameWidthPx,
+      frameHeightPx = vector.frameHeightPx,
+      scale = vector.scale,
+      offsetX = vector.offsetX,
+      offsetY = vector.offsetY,
+      deviceWidth = vector.deviceWidth,
+      deviceHeight = vector.deviceHeight,
+    )
+
+  @Test
+  fun `viewportToDevice matches the golden vectors`() {
+    for ((index, vector) in viewportToDeviceVectors.withIndex()) {
+      val point =
+        mapper.viewportToDevice(ViewportPoint(vector.viewportX, vector.viewportY), geometry(vector))
+      assertEquals(vector.expectedX, point.x, "row $index x")
+      assertEquals(vector.expectedY, point.y, "row $index y")
+      assertEquals(vector.expectedInBounds == 1, point.inBounds, "row $index inBounds")
+    }
+  }
+
+  @Test
+  fun `deviceToViewport matches the golden vectors`() {
+    for ((index, vector) in deviceToViewportVectors.withIndex()) {
+      val point = mapper.deviceToViewport(vector.deviceX, vector.deviceY, geometry(vector))
+      assertEquals(vector.expectedX, point.x, TOLERANCE, "row $index x")
+      assertEquals(vector.expectedY, point.y, TOLERANCE, "row $index y")
+    }
+  }
+
+  @Test
+  fun `fitToViewport matches the golden vectors`() {
+    for ((index, vector) in fitToViewportVectors.withIndex()) {
+      val frame =
+        mapper.fitToViewport(
+          vector.imageWidth,
+          vector.imageHeight,
+          vector.viewportWidth,
+          vector.viewportHeight,
+          vector.padding,
+        )
+      assertEquals(vector.expectedWidthPx, frame.widthPx, TOLERANCE, "row $index width")
+      assertEquals(vector.expectedHeightPx, frame.heightPx, TOLERANCE, "row $index height")
+    }
+  }
+
+  @Test
+  fun `fitScale matches the golden vectors`() {
+    for ((index, vector) in fitScaleVectors.withIndex()) {
+      val scale =
+        mapper.fitScale(
+          vector.frameWidthPx,
+          vector.frameHeightPx,
+          vector.viewportWidth,
+          vector.viewportHeight,
+          vector.padding,
+        )
+      assertEquals(vector.expected, scale, TOLERANCE, "row $index")
+    }
+  }
+
+  @Test
+  fun `detectScreenshotRotation matches the golden vectors`() {
+    for ((index, vector) in screenshotRotationVectors.withIndex()) {
+      val rotation =
+        mapper.detectScreenshotRotation(
+          vector.imageWidth,
+          vector.imageHeight,
+          vector.rootWidth,
+          vector.rootHeight,
+        )
+      assertEquals(vector.expected, rotation, "row $index")
+    }
+  }
+
+  private companion object {
+    const val TOLERANCE = 0.001f
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/CoordinateMappingGoldenVectorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/CoordinateMappingGoldenVectorTest.kt
@@ -62,6 +62,10 @@ class CoordinateMappingGoldenVectorTest {
       ViewportToDeviceVector(540f, 1170f, 1f, 0f, 0f, 1080, 2340, 540f, 585f, 1080, 1170, 0),
       // Negative out of bounds: raw coordinates returned, never clamped.
       ViewportToDeviceVector(540f, 1170f, 1f, 0f, 0f, 1080, 2340, -10f, -10f, -20, -20, 0),
+      // x-only negative out of bounds: y inside (pins the x lower bound independently).
+      ViewportToDeviceVector(540f, 1170f, 1f, 0f, 0f, 1080, 2340, -10f, 585f, -20, 1170, 0),
+      // y-only negative out of bounds: x inside (pins the y lower bound independently).
+      ViewportToDeviceVector(540f, 1170f, 1f, 0f, 0f, 1080, 2340, 270f, -10f, 540, -20, 0),
       // y-only out of bounds: x inside, y exactly at deviceHeight (exclusive).
       ViewportToDeviceVector(540f, 1170f, 1f, 0f, 0f, 1080, 2340, 270f, 1170f, 540, 2340, 0),
       // Far past the bottom-right edge.

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/CoordinateMappingGoldenVectorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/CoordinateMappingGoldenVectorTest.kt
@@ -103,6 +103,9 @@ class CoordinateMappingGoldenVectorTest {
       DeviceToViewportVector(7, 9, 540f, 1170f, 1f, 10f, 20f, 0, 2340, 17f, 29f),
       // iOS 3x point-space inverse; changes under #4549.
       DeviceToViewportVector(195, 422, 390f, 844f, 1f, 0f, 0f, 390, 844, 195f, 422f),
+      // Width-derived-ratio invariant (inverse): aspect-MISMATCHED frame (width ratio 0.5,
+      // height ratio 0.25). Pins BOTH axes scale by frameWidthPx/deviceWidth (height y = 100).
+      DeviceToViewportVector(200, 400, 500f, 500f, 1f, 0f, 0f, 1000, 2000, 100f, 200f),
     )
 
   private data class FitToViewportVector(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/CoordinateMappingGoldenVectorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/CoordinateMappingGoldenVectorTest.kt
@@ -62,6 +62,8 @@ class CoordinateMappingGoldenVectorTest {
       ViewportToDeviceVector(540f, 1170f, 1f, 0f, 0f, 1080, 2340, 540f, 585f, 1080, 1170, 0),
       // Negative out of bounds: raw coordinates returned, never clamped.
       ViewportToDeviceVector(540f, 1170f, 1f, 0f, 0f, 1080, 2340, -10f, -10f, -20, -20, 0),
+      // y-only out of bounds: x inside, y exactly at deviceHeight (exclusive).
+      ViewportToDeviceVector(540f, 1170f, 1f, 0f, 0f, 1080, 2340, 270f, 1170f, 540, 2340, 0),
       // Far past the bottom-right edge.
       ViewportToDeviceVector(540f, 1170f, 1f, 0f, 0f, 1080, 2340, 1000f, 2000f, 2000, 4000, 0),
       // Landscape device space (rotation-aligned upstream).
@@ -128,6 +130,8 @@ class CoordinateMappingGoldenVectorTest {
       FitToViewportVector(2160, 1080, 1200f, 1200f, 32f, 1136f, 568f),
       // Unknown image width falls back to aspect ratio 2.16.
       FitToViewportVector(0, 0, 800f, 800f, 32f, 340.7407f, 736f),
+      // Non-default padding 10: height-constrained 390x780 (default padding would give 368x736).
+      FitToViewportVector(1080, 2160, 800f, 800f, 10f, 390f, 780f),
       // Tiny viewport: max frame sides coerce to the 1px floor.
       FitToViewportVector(1080, 2160, 10f, 10f, 32f, 0.5f, 1f),
     )
@@ -151,6 +155,8 @@ class CoordinateMappingGoldenVectorTest {
       FitScaleVector(736f, 736f, 400f, 800f, 32f, 0.5f),
       // HEIGHT candidate decisive mid-range: 400/(736+64)=0.5 binds; width candidate is 2.0.
       FitScaleVector(336f, 736f, 800f, 400f, 32f, 0.5f),
+      // Non-default padding 20: 400/(760+40)=0.5 (default padding would give 400/824=0.4854).
+      FitScaleVector(760f, 760f, 400f, 800f, 20f, 0.5f),
     )
 
   private data class ScreenshotRotationVector(
@@ -179,6 +185,16 @@ class CoordinateMappingGoldenVectorTest {
       ScreenshotRotationVector(1170, 2532, 390, 844, 0),
       // Square image counts as landscape against portrait bounds.
       ScreenshotRotationVector(1000, 1000, 1080, 2340, 1),
+      // Square ROOT bounds count as landscape against a portrait screenshot (strict >).
+      ScreenshotRotationVector(1080, 2340, 1000, 1000, 3),
+      // Decisive zero imageWidth: orientations would mismatch without the guard.
+      ScreenshotRotationVector(0, 2340, 2340, 1080, 0),
+      // Decisive zero imageHeight alone.
+      ScreenshotRotationVector(2340, 0, 1080, 2340, 0),
+      // Decisive zero rootWidth alone.
+      ScreenshotRotationVector(2340, 1080, 0, 2340, 0),
+      // Decisive zero rootHeight alone.
+      ScreenshotRotationVector(1080, 2340, 1080, 0, 0),
     )
 
   private fun geometry(vector: ViewportToDeviceVector) =

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../../src/daemon/deviceDataStreamSocketServer";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeSocket } from "../fakes/FakeNetServer";
+import { loadCoordinateMappingVectors } from "../parity/coordinateMappingGoldenVectors";
 
 /**
  * Test helper that wraps DeviceDataStreamSocketServer to allow injecting fake sockets
@@ -542,18 +543,18 @@ describe("DeviceDataStreamSocketServer", () => {
     });
   });
 
-  describe("hierarchy diff annotation", () => {
-    /** A minimal PNG whose IHDR declares the given pixel size, base64-encoded as CtrlProxy sends it. */
-    const pngFrame = (width: number, height: number): string => {
-      const buffer = Buffer.alloc(24);
-      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(buffer, 0);
-      buffer.writeUInt32BE(13, 8); // IHDR data length, fixed by the PNG spec
-      buffer.write("IHDR", 12, "ascii");
-      buffer.writeUInt32BE(width, 16);
-      buffer.writeUInt32BE(height, 20);
-      return buffer.toString("base64");
-    };
+  /** A minimal PNG whose IHDR declares the given pixel size, base64-encoded as CtrlProxy sends it. */
+  const pngFrame = (width: number, height: number): string => {
+    const buffer = Buffer.alloc(24);
+    Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(buffer, 0);
+    buffer.writeUInt32BE(13, 8); // IHDR data length, fixed by the PNG spec
+    buffer.write("IHDR", 12, "ascii");
+    buffer.writeUInt32BE(width, 16);
+    buffer.writeUInt32BE(height, 20);
+    return buffer.toString("base64");
+  };
 
+  describe("hierarchy diff annotation", () => {
     const frame = (text: string) =>
       ({ hierarchy: { node: { $: { class: "Root" }, node: [{ $: { class: "Child", text } }] } } }) as any;
 
@@ -1292,5 +1293,45 @@ describe("DeviceDataStreamSocketServer", () => {
 
       expect(socket.getWrittenMessages()).toHaveLength(0);
     });
+  });
+
+  describe("coordinate-mapping golden vectors: geometry pairing (issue #4547)", () => {
+    // Cross-language golden suite, B0 of the canonical-pixel campaign (#4547 -> #4549). Each
+    // vector drives the daemon's REAL header-measurement pairing (pixelsMatchClaimedGeometry via
+    // pushScreenshotUpdate): the capture identity is echoed on the screenshot exactly when the
+    // frame's measured pixels are consistent with the claimed geometry (exact match or swapped
+    // orientation — never a scale change, never an unmeasurable frame).
+    const goldenFrame = (text: string) =>
+      ({ hierarchy: { node: { $: { class: "Root" }, node: [{ $: { class: "Child", text } }] } } }) as any;
+
+    const vectors = loadCoordinateMappingVectors().geometryPairing;
+
+    for (const [index, vector] of vectors.entries()) {
+      it(`row ${index}: measured ${vector.measuredWidth}x${vector.measuredHeight} vs claimed ${vector.claimedWidth}x${vector.claimedHeight} -> ${vector.expectedMatch === 1 ? "paired" : "not paired"}`, () => {
+        const { socket } = server.simulateSubscription({ deviceId: "device-golden" });
+
+        const captureSequence = server.pushHierarchyUpdate("device-golden", goldenFrame("a"));
+        // measuredWidth/Height of -1 encodes an unmeasurable frame (not a decodable PNG header).
+        const screenshotBase64 =
+          vector.measuredWidth < 0
+            ? Buffer.from("not-an-image").toString("base64")
+            : pngFrame(vector.measuredWidth, vector.measuredHeight);
+        server.pushScreenshotUpdate(
+          "device-golden",
+          screenshotBase64,
+          vector.claimedWidth,
+          vector.claimedHeight,
+          {},
+          { captureSequence: captureSequence ?? undefined }
+        );
+
+        const screenshot = socket.getWrittenMessages<any>().find(m => m.type === "screenshot_update");
+        if (vector.expectedMatch === 1) {
+          expect(screenshot.captureSequence).toBe(captureSequence);
+        } else {
+          expect(screenshot.captureSequence).toBeUndefined();
+        }
+      });
+    }
   });
 });

--- a/test/daemon/observationInitialFrame.test.ts
+++ b/test/daemon/observationInitialFrame.test.ts
@@ -16,6 +16,7 @@ import type {
   CtrlProxyHierarchyResponse,
   CtrlProxyScreenshotResult,
 } from "../../src/features/observe/ios/types";
+import { loadCoordinateMappingVectors } from "../parity/coordinateMappingGoldenVectors";
 
 class FakeObservationStreamServer {
   readonly hierarchyUpdates: Array<{ deviceId: string; hierarchy: ViewHierarchyResult }> = [];
@@ -554,6 +555,45 @@ describe("pushInitialObservationFramesForSubscriber", () => {
 
     expect(streamServer.hierarchyUpdates.map(update => update.deviceId)).toEqual([androidDevice.id]);
     expect(streamServer.screenshotUpdates.map(update => update.deviceId)).toEqual([androidDevice.id]);
+  });
+
+  describe("coordinate-mapping golden vectors: iOS point->pixel (issue #4547)", () => {
+    // Cross-language golden suite, B0 of the canonical-pixel campaign (#4547 -> #4549). Each
+    // vector drives the daemon's REAL iOS point->pixel conversion (getIosScreenshotDimensions via
+    // pushInitialObservationFramesForSubscriber): screenshot geometry is published as
+    // round(points * screenScale), defaulting the multiplier to 1 when the hierarchy carries no
+    // scale (encoded as scale=0 in the fixture). Every row is flagged
+    // willChangeUnderCanonicalPixels: once #4549 delivers pixel-space hierarchies, this
+    // daemon-side multiply must disappear and these vectors must be updated deliberately.
+    const vectors = loadCoordinateMappingVectors().iosPointToPixel;
+
+    for (const [index, vector] of vectors.entries()) {
+      it(`row ${index}: ${vector.pointWidth}x${vector.pointHeight} points at scale ${vector.scale || "absent"} -> ${vector.expectedPixelWidth}x${vector.expectedPixelHeight} pixels`, async () => {
+        const streamServer = new FakeObservationStreamServer();
+        const iosClient = new FakeIosInitialFrameClient(true, {
+          updatedAt: 1,
+          packageName: "com.example.ios",
+          screenWidth: vector.pointWidth,
+          screenHeight: vector.pointHeight,
+          ...(vector.scale === 0 ? {} : { screenScale: vector.scale }),
+          hierarchy: { text: "Golden" },
+        });
+
+        await pushInitialObservationFramesForSubscriber(iosDevice.id, [iosDevice], {
+          streamServer,
+          androidClientFactory: () => {
+            throw new Error("unexpected Android client");
+          },
+          iosClientFactory: () => iosClient,
+        });
+
+        expect(streamServer.screenshotUpdates[0]).toMatchObject({
+          deviceId: iosDevice.id,
+          screenWidth: vector.expectedPixelWidth,
+          screenHeight: vector.expectedPixelHeight,
+        });
+      });
+    }
   });
 
   it("does not push an initial frame when connection fails", async () => {

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -13,6 +13,7 @@ import { FakeTimer } from "../../../fakes/FakeTimer";
 import { FakeScreenshotBackoffScheduler } from "../../../../src/features/observe/ScreenshotBackoffScheduler";
 import type { DeviceConnectionLostNotifier } from "../../../../src/features/observe/DeviceConnectionLostNotifier";
 import { FakeIosSdkEventIngestor } from "../../../fakes/FakeIosSdkEventIngestor";
+import { loadCoordinateMappingVectors } from "../../../parity/coordinateMappingGoldenVectors";
 import {
   startDeviceDataStreamSocketServer,
   stopDeviceDataStreamSocketServer,
@@ -2800,6 +2801,34 @@ describe("IOSCtrlProxyClient", function() {
       setStaleCache(390, 844, 3);
       (ctrlProxyClient as any).pushHierarchyToObservationStream({ hierarchy: {} } as any, {} as any);
       expect(geometry.bind()).toBeNull();
+    });
+
+    describe("coordinate-mapping golden vectors: LIVE iOS point->pixel (issue #4547)", function() {
+      // The bootstrap path (observationInitialFrame's getIosScreenshotDimensions) and this LIVE
+      // hierarchy-update path (updateScreenGeometryFrom) are SEPARATE implementations of the same
+      // points * screenScale conversion. Both consume the shared golden vectors independently, so
+      // a #4549 canonical-pixel change (or any drift) in either path fails its own consumer —
+      // green tests on one path can never vouch for the other.
+      const vectors = loadCoordinateMappingVectors().iosPointToPixel;
+
+      for (const [index, vector] of vectors.entries()) {
+        test(`row ${index}: ${vector.pointWidth}x${vector.pointHeight} points at scale ${vector.scale || "absent"} -> ${vector.expectedPixelWidth}x${vector.expectedPixelHeight} pixels`, async function() {
+          await startStreamServer();
+          const geometry = (ctrlProxyClient as any).screenGeometry;
+
+          // scale === 0 encodes "hierarchy carried no screenScale" (the live path defaults to 1).
+          (ctrlProxyClient as any).pushHierarchyToObservationStream({ hierarchy: {} } as any, {
+            screenWidth: vector.pointWidth,
+            screenHeight: vector.pointHeight,
+            ...(vector.scale === 0 ? {} : { screenScale: vector.scale }),
+          });
+
+          const bound = geometry.bind();
+          expect(bound).not.toBeNull();
+          expect(bound.width).toBe(vector.expectedPixelWidth);
+          expect(bound.height).toBe(vector.expectedPixelHeight);
+        });
+      }
     });
   });
 });

--- a/test/fixtures/coordinate-mapping-golden-vectors.json
+++ b/test/fixtures/coordinate-mapping-golden-vectors.json
@@ -77,6 +77,18 @@
       "expectedX": -20, "expectedY": -20, "expectedInBounds": 0
     },
     {
+      "comment": "x-only negative out of bounds: y well inside — pins the x lower-bound predicate independently (deleting x >= 0 flips only this row)",
+      "frameWidthPx": 540, "frameHeightPx": 1170, "scale": 1, "offsetX": 0, "offsetY": 0,
+      "deviceWidth": 1080, "deviceHeight": 2340, "viewportX": -10, "viewportY": 585,
+      "expectedX": -20, "expectedY": 1170, "expectedInBounds": 0
+    },
+    {
+      "comment": "y-only negative out of bounds: x well inside — pins the y lower-bound predicate independently (deleting y >= 0 flips only this row)",
+      "frameWidthPx": 540, "frameHeightPx": 1170, "scale": 1, "offsetX": 0, "offsetY": 0,
+      "deviceWidth": 1080, "deviceHeight": 2340, "viewportX": 270, "viewportY": -10,
+      "expectedX": 540, "expectedY": -20, "expectedInBounds": 0
+    },
+    {
       "comment": "y-only out of bounds: x well inside, y exactly at deviceHeight (exclusive) — pins the y bounds predicate independently of x",
       "frameWidthPx": 540, "frameHeightPx": 1170, "scale": 1, "offsetX": 0, "offsetY": 0,
       "deviceWidth": 1080, "deviceHeight": 2340, "viewportX": 270, "viewportY": 1170,
@@ -313,6 +325,11 @@
     {
       "comment": "single-axis off-by-one rejected: the check is exact, not approximate",
       "measuredWidth": 1080, "measuredHeight": 2339, "claimedWidth": 1080, "claimedHeight": 2340,
+      "expectedMatch": 0
+    },
+    {
+      "comment": "ONE-axis swap rejected: measured.width == claimedHeight (1170) but measured.height != claimedWidth (2532 vs 2500) — the swap acceptance is a conjunction, so a frame matching only one opposite axis must never receive a capture identity",
+      "measuredWidth": 1170, "measuredHeight": 2532, "claimedWidth": 2500, "claimedHeight": 1170,
       "expectedMatch": 0
     }
   ],

--- a/test/fixtures/coordinate-mapping-golden-vectors.json
+++ b/test/fixtures/coordinate-mapping-golden-vectors.json
@@ -1,0 +1,298 @@
+{
+  "comment": [
+    "Cross-language golden vectors for viewport<->device coordinate mapping (issue #4547, B0 of the",
+    "canonical-pixel campaign #4547 -> #4548 -> #4549 -> #4550). This file is the single source of",
+    "truth, mirroring test/fixtures/pinch-golden-vectors.json.",
+    "",
+    "Consumers:",
+    "- Kotlin: android/desktop-core .../layout/CoordinateMappingGoldenVectorTest.kt holds inline",
+    "  copies of the five mapper sections and drives DeviceScreenCoordinateMapper against them.",
+    "  test/parity/coordinateMappingGoldenVectorParity.test.ts parses those inline literals out of",
+    "  the Kotlin source and verifies them against this file (the pinch drift-guard mechanism).",
+    "- TypeScript: test/daemon/deviceDataStreamSocketServer.test.ts drives the daemon's",
+    "  pixelsMatchClaimedGeometry pairing from the geometryPairing section, and",
+    "  test/daemon/observationInitialFrame.test.ts drives the daemon's iOS point->pixel conversion",
+    "  from the iosPointToPixel section, both reading this file directly.",
+    "- Swift: deliberately NO consumer. The iOS runner (ios/control-proxy) performs no",
+    "  viewport<->device mapping; it reports point-space bounds plus screenScale",
+    "  (ElementLocator.swift) and the point->pixel conversion happens daemon-side in TypeScript",
+    "  (IOSCtrlProxyClient.updateScreenGeometryFrom / observationInitialFrame). The runner's only",
+    "  coordinate math, pinch endpoint geometry, is already pinned by pinch-golden-vectors.json.",
+    "",
+    "These vectors PIN CURRENT BEHAVIOR. Rows with willChangeUnderCanonicalPixels=true document",
+    "iOS point-space cases whose expected values MUST change when #4549 converts hierarchy bounds",
+    "to canonical pixels — a green suite across that change means the conversion silently drifted.",
+    "",
+    "Booleans are encoded as 0/1 so the Kotlin inline tables stay purely numeric for the positional",
+    "source parser. In geometryPairing, measuredWidth=measuredHeight=-1 means an unmeasurable frame.",
+    "In iosPointToPixel, scale=0 means the hierarchy carried no screenScale (daemon defaults to 1)."
+  ],
+  "viewportToDevice": [
+    {
+      "comment": "Android 1080x2340 portrait, frame at half device size: frame center maps to device center",
+      "frameWidthPx": 540, "frameHeightPx": 1170, "scale": 1, "offsetX": 0, "offsetY": 0,
+      "deviceWidth": 1080, "deviceHeight": 2340, "viewportX": 270, "viewportY": 585,
+      "expectedX": 540, "expectedY": 1170, "expectedInBounds": 1
+    },
+    {
+      "comment": "zoom removal: at scale 2 a viewport point twice as far maps to the same device point",
+      "frameWidthPx": 540, "frameHeightPx": 1170, "scale": 2, "offsetX": 0, "offsetY": 0,
+      "deviceWidth": 1080, "deviceHeight": 2340, "viewportX": 540, "viewportY": 1170,
+      "expectedX": 540, "expectedY": 1170, "expectedInBounds": 1
+    },
+    {
+      "comment": "pan removal: device origin sits at the pan offset",
+      "frameWidthPx": 540, "frameHeightPx": 1170, "scale": 1, "offsetX": 100, "offsetY": 50,
+      "deviceWidth": 1080, "deviceHeight": 2340, "viewportX": 100, "viewportY": 50,
+      "expectedX": 0, "expectedY": 0, "expectedInBounds": 1
+    },
+    {
+      "comment": "pan + zoom combined: (370-100)/2=135 -> device 270; (635-50)/2=292.5 -> device 585",
+      "frameWidthPx": 540, "frameHeightPx": 1170, "scale": 2, "offsetX": 100, "offsetY": 50,
+      "deviceWidth": 1080, "deviceHeight": 2340, "viewportX": 370, "viewportY": 635,
+      "expectedX": 270, "expectedY": 585, "expectedInBounds": 1
+    },
+    {
+      "comment": "rounding boundary: viewport 0.25 * ratio 2 = device 0.5, halves round UP to 1",
+      "frameWidthPx": 540, "frameHeightPx": 1170, "scale": 1, "offsetX": 0, "offsetY": 0,
+      "deviceWidth": 1080, "deviceHeight": 2340, "viewportX": 0.25, "viewportY": 0,
+      "expectedX": 1, "expectedY": 0, "expectedInBounds": 1
+    },
+    {
+      "comment": "negative rounding boundary: device -0.5 rounds toward positive infinity to 0 (Kotlin roundToInt tie rule)",
+      "frameWidthPx": 540, "frameHeightPx": 1170, "scale": 1, "offsetX": 0, "offsetY": 0,
+      "deviceWidth": 1080, "deviceHeight": 2340, "viewportX": -0.25, "viewportY": 0,
+      "expectedX": 0, "expectedY": 0, "expectedInBounds": 1
+    },
+    {
+      "comment": "out of bounds at exactly deviceWidth: bounds are exclusive, no clamping",
+      "frameWidthPx": 540, "frameHeightPx": 1170, "scale": 1, "offsetX": 0, "offsetY": 0,
+      "deviceWidth": 1080, "deviceHeight": 2340, "viewportX": 540, "viewportY": 585,
+      "expectedX": 1080, "expectedY": 1170, "expectedInBounds": 0
+    },
+    {
+      "comment": "negative out of bounds: raw negative coordinates are returned, never clamped",
+      "frameWidthPx": 540, "frameHeightPx": 1170, "scale": 1, "offsetX": 0, "offsetY": 0,
+      "deviceWidth": 1080, "deviceHeight": 2340, "viewportX": -10, "viewportY": -10,
+      "expectedX": -20, "expectedY": -20, "expectedInBounds": 0
+    },
+    {
+      "comment": "far past the bottom-right edge: raw coordinates preserved, flagged out of bounds",
+      "frameWidthPx": 540, "frameHeightPx": 1170, "scale": 1, "offsetX": 0, "offsetY": 0,
+      "deviceWidth": 1080, "deviceHeight": 2340, "viewportX": 1000, "viewportY": 2000,
+      "expectedX": 2000, "expectedY": 4000, "expectedInBounds": 0
+    },
+    {
+      "comment": "landscape device space (rotation-aligned upstream): 2340x1080 with a landscape frame",
+      "frameWidthPx": 1170, "frameHeightPx": 540, "scale": 1, "offsetX": 0, "offsetY": 0,
+      "deviceWidth": 2340, "deviceHeight": 1080, "viewportX": 585, "viewportY": 270,
+      "expectedX": 1170, "expectedY": 540, "expectedInBounds": 1
+    },
+    {
+      "comment": "degenerate zero frame width: frame-to-device ratio falls back to 1 (identity)",
+      "frameWidthPx": 0, "frameHeightPx": 0, "scale": 1, "offsetX": 0, "offsetY": 0,
+      "deviceWidth": 1080, "deviceHeight": 2340, "viewportX": 12.5, "viewportY": 7,
+      "expectedX": 13, "expectedY": 7, "expectedInBounds": 1
+    },
+    {
+      "comment": "iOS 3x device (iPhone-class 390x844): device space is POINTS today, so a 390pt-wide frame maps 1:1. Under #4549 (canonical pixels) deviceWidth/deviceHeight become 1170x2532 and expectedX/expectedY become 585/1266.",
+      "willChangeUnderCanonicalPixels": true,
+      "frameWidthPx": 390, "frameHeightPx": 844, "scale": 1, "offsetX": 0, "offsetY": 0,
+      "deviceWidth": 390, "deviceHeight": 844, "viewportX": 195, "viewportY": 422,
+      "expectedX": 195, "expectedY": 422, "expectedInBounds": 1
+    },
+    {
+      "comment": "iOS 2x device (375x667 points) with fractional viewport input. Under #4549 the device space becomes 750x1334 pixels and the expected coordinates double (modulo rounding).",
+      "willChangeUnderCanonicalPixels": true,
+      "frameWidthPx": 375, "frameHeightPx": 667, "scale": 1, "offsetX": 0, "offsetY": 0,
+      "deviceWidth": 375, "deviceHeight": 667, "viewportX": 100.4, "viewportY": 200.6,
+      "expectedX": 100, "expectedY": 201, "expectedInBounds": 1
+    },
+    {
+      "comment": "iOS Display Zoom-like device (320x693 zoomed points at 3x). Under #4549 the device space becomes 960x2079 pixels.",
+      "willChangeUnderCanonicalPixels": true,
+      "frameWidthPx": 320, "frameHeightPx": 693, "scale": 1, "offsetX": 0, "offsetY": 0,
+      "deviceWidth": 320, "deviceHeight": 693, "viewportX": 160, "viewportY": 346.5,
+      "expectedX": 160, "expectedY": 347, "expectedInBounds": 1
+    }
+  ],
+  "deviceToViewport": [
+    {
+      "comment": "inverse of the identity half-frame case: device center back to frame center",
+      "deviceX": 540, "deviceY": 1170, "frameWidthPx": 540, "frameHeightPx": 1170, "scale": 1,
+      "offsetX": 0, "offsetY": 0, "deviceWidth": 1080, "deviceHeight": 2340,
+      "expectedX": 270, "expectedY": 585
+    },
+    {
+      "comment": "inverse with pan + zoom: device (270,585) -> frame (135,292.5) -> viewport (370,635)",
+      "deviceX": 270, "deviceY": 585, "frameWidthPx": 540, "frameHeightPx": 1170, "scale": 2,
+      "offsetX": 100, "offsetY": 50, "deviceWidth": 1080, "deviceHeight": 2340,
+      "expectedX": 370, "expectedY": 635
+    },
+    {
+      "comment": "degenerate zero device width: device-to-frame ratio falls back to 1 (identity + offset)",
+      "deviceX": 7, "deviceY": 9, "frameWidthPx": 540, "frameHeightPx": 1170, "scale": 1,
+      "offsetX": 10, "offsetY": 20, "deviceWidth": 0, "deviceHeight": 2340,
+      "expectedX": 17, "expectedY": 29
+    },
+    {
+      "comment": "iOS 3x point-space inverse. Under #4549 deviceWidth/deviceHeight become 1170x2532 pixels, so the same device point lands at a different viewport position.",
+      "willChangeUnderCanonicalPixels": true,
+      "deviceX": 195, "deviceY": 422, "frameWidthPx": 390, "frameHeightPx": 844, "scale": 1,
+      "offsetX": 0, "offsetY": 0, "deviceWidth": 390, "deviceHeight": 844,
+      "expectedX": 195, "expectedY": 422
+    }
+  ],
+  "fitToViewport": [
+    {
+      "comment": "height-constrained: 1080x2160 (aspect 2.0) in 800x800 with 32 padding -> 368x736",
+      "imageWidth": 1080, "imageHeight": 2160, "viewportWidth": 800, "viewportHeight": 800,
+      "padding": 32, "expectedWidthPx": 368, "expectedHeightPx": 736
+    },
+    {
+      "comment": "width-constrained: 1080x2160 in a narrow 400x2000 viewport -> 336x672",
+      "imageWidth": 1080, "imageHeight": 2160, "viewportWidth": 400, "viewportHeight": 2000,
+      "padding": 32, "expectedWidthPx": 336, "expectedHeightPx": 672
+    },
+    {
+      "comment": "landscape image 2160x1080 (aspect 0.5) in 1200x1200 -> width-constrained 1136x568",
+      "imageWidth": 2160, "imageHeight": 1080, "viewportWidth": 1200, "viewportHeight": 1200,
+      "padding": 32, "expectedWidthPx": 1136, "expectedHeightPx": 568
+    },
+    {
+      "comment": "unknown image width falls back to aspect ratio 2.16 -> height-constrained 340.7407x736",
+      "imageWidth": 0, "imageHeight": 0, "viewportWidth": 800, "viewportHeight": 800,
+      "padding": 32, "expectedWidthPx": 340.7407, "expectedHeightPx": 736
+    },
+    {
+      "comment": "tiny viewport: max frame sides coerce to the 1px floor -> 0.5x1",
+      "imageWidth": 1080, "imageHeight": 2160, "viewportWidth": 10, "viewportHeight": 10,
+      "padding": 32, "expectedWidthPx": 0.5, "expectedHeightPx": 1
+    }
+  ],
+  "fitScale": [
+    {
+      "comment": "frame fits comfortably: scale caps at 1.0 (never enlarges)",
+      "frameWidthPx": 300, "frameHeightPx": 600, "viewportWidth": 800, "viewportHeight": 1200,
+      "padding": 32, "expected": 1
+    },
+    {
+      "comment": "frame far larger than viewport: clamps to the 0.3 floor",
+      "frameWidthPx": 5000, "frameHeightPx": 5000, "viewportWidth": 400, "viewportHeight": 400,
+      "padding": 32, "expected": 0.3
+    },
+    {
+      "comment": "mid-range: 736+64=800 padded frame in a 400-wide viewport -> exactly 0.5",
+      "frameWidthPx": 736, "frameHeightPx": 736, "viewportWidth": 400, "viewportHeight": 800,
+      "padding": 32, "expected": 0.5
+    }
+  ],
+  "screenshotRotation": [
+    {
+      "comment": "portrait image, portrait bounds: no rotation",
+      "imageWidth": 1080, "imageHeight": 2340, "rootWidth": 1080, "rootHeight": 2340, "expected": 0
+    },
+    {
+      "comment": "landscape image, landscape bounds: no rotation",
+      "imageWidth": 2340, "imageHeight": 1080, "rootWidth": 2340, "rootHeight": 1080, "expected": 0
+    },
+    {
+      "comment": "portrait image, landscape bounds: rotate 90 CW (code 3)",
+      "imageWidth": 1080, "imageHeight": 2340, "rootWidth": 2340, "rootHeight": 1080, "expected": 3
+    },
+    {
+      "comment": "landscape image, portrait bounds: rotate 270 CW (code 1)",
+      "imageWidth": 2340, "imageHeight": 1080, "rootWidth": 1080, "rootHeight": 2340, "expected": 1
+    },
+    {
+      "comment": "non-positive image width: no rotation inferred",
+      "imageWidth": 0, "imageHeight": 2340, "rootWidth": 1080, "rootHeight": 2340, "expected": 0
+    },
+    {
+      "comment": "non-positive root dimensions: no rotation inferred",
+      "imageWidth": 1080, "imageHeight": 2340, "rootWidth": 0, "rootHeight": 0, "expected": 0
+    },
+    {
+      "comment": "iOS pixel screenshot (1170x2532) vs point-space root (390x844): orientations agree across units, so no rotation. Output survives #4549 but the cross-unit comparison it pins does not.",
+      "imageWidth": 1170, "imageHeight": 2532, "rootWidth": 390, "rootHeight": 844, "expected": 0
+    },
+    {
+      "comment": "square image counts as landscape (height > width is false) against portrait bounds -> code 1",
+      "imageWidth": 1000, "imageHeight": 1000, "rootWidth": 1080, "rootHeight": 2340, "expected": 1
+    }
+  ],
+  "geometryPairing": [
+    {
+      "comment": "exact match: measured pixels equal the claimed geometry",
+      "measuredWidth": 1080, "measuredHeight": 2340, "claimedWidth": 1080, "claimedHeight": 2340,
+      "expectedMatch": 1
+    },
+    {
+      "comment": "orientation swap accepted: iOS landscape claim (2532x1170) with native-portrait pixels",
+      "measuredWidth": 1170, "measuredHeight": 2532, "claimedWidth": 2532, "claimedHeight": 1170,
+      "expectedMatch": 1
+    },
+    {
+      "comment": "aspect-preserving scale change rejected: 720x1560 pixels against a 1080x2340 claim",
+      "measuredWidth": 720, "measuredHeight": 1560, "claimedWidth": 1080, "claimedHeight": 2340,
+      "expectedMatch": 0
+    },
+    {
+      "comment": "unrelated dimensions rejected",
+      "measuredWidth": 800, "measuredHeight": 600, "claimedWidth": 1080, "claimedHeight": 2340,
+      "expectedMatch": 0
+    },
+    {
+      "comment": "unmeasurable frame (-1/-1 sentinel) never matches",
+      "measuredWidth": -1, "measuredHeight": -1, "claimedWidth": 1080, "claimedHeight": 2340,
+      "expectedMatch": 0
+    },
+    {
+      "comment": "iOS exact pixel match (claims are already pixel-space today via the daemon's point*scale conversion)",
+      "measuredWidth": 1170, "measuredHeight": 2532, "claimedWidth": 1170, "claimedHeight": 2532,
+      "expectedMatch": 1
+    },
+    {
+      "comment": "square frame: same-orientation and swapped checks coincide, accepted",
+      "measuredWidth": 1000, "measuredHeight": 1000, "claimedWidth": 1000, "claimedHeight": 1000,
+      "expectedMatch": 1
+    },
+    {
+      "comment": "single-axis off-by-one rejected: the check is exact, not approximate",
+      "measuredWidth": 1080, "measuredHeight": 2339, "claimedWidth": 1080, "claimedHeight": 2340,
+      "expectedMatch": 0
+    }
+  ],
+  "iosPointToPixel": [
+    {
+      "comment": "2x device: 375x667 points -> 750x1334 pixels. Under #4549 the hierarchy arrives in canonical pixels and this daemon-side multiply disappears (or becomes identity).",
+      "willChangeUnderCanonicalPixels": true,
+      "pointWidth": 375, "pointHeight": 667, "scale": 2,
+      "expectedPixelWidth": 750, "expectedPixelHeight": 1334
+    },
+    {
+      "comment": "3x device: 390x844 points -> 1170x2532 pixels",
+      "willChangeUnderCanonicalPixels": true,
+      "pointWidth": 390, "pointHeight": 844, "scale": 3,
+      "expectedPixelWidth": 1170, "expectedPixelHeight": 2532
+    },
+    {
+      "comment": "Display Zoom-like: zoomed 320x693 points at 3x -> 960x2079 pixels",
+      "willChangeUnderCanonicalPixels": true,
+      "pointWidth": 320, "pointHeight": 693, "scale": 3,
+      "expectedPixelWidth": 960, "expectedPixelHeight": 2079
+    },
+    {
+      "comment": "fractional scale rounding boundary: 375*2.5 = 937.5 rounds half-up to 938",
+      "willChangeUnderCanonicalPixels": true,
+      "pointWidth": 375, "pointHeight": 812, "scale": 2.5,
+      "expectedPixelWidth": 938, "expectedPixelHeight": 2030
+    },
+    {
+      "comment": "absent screenScale (0 sentinel): daemon defaults the multiplier to 1",
+      "willChangeUnderCanonicalPixels": true,
+      "pointWidth": 390, "pointHeight": 844, "scale": 0,
+      "expectedPixelWidth": 390, "expectedPixelHeight": 844
+    }
+  ]
+}

--- a/test/fixtures/coordinate-mapping-golden-vectors.json
+++ b/test/fixtures/coordinate-mapping-golden-vectors.json
@@ -194,8 +194,13 @@
       "padding": 32, "expected": 0.3
     },
     {
-      "comment": "mid-range: 736+64=800 padded frame in a 400-wide viewport -> exactly 0.5",
+      "comment": "mid-range: 736+64=800 padded frame in a 400-wide viewport -> exactly 0.5 (WIDTH candidate decisive)",
       "frameWidthPx": 736, "frameHeightPx": 736, "viewportWidth": 400, "viewportHeight": 800,
+      "padding": 32, "expected": 0.5
+    },
+    {
+      "comment": "HEIGHT candidate decisive mid-range: height ratio 400/(736+64)=0.5 binds while the width ratio is 800/(336+64)=2.0 — pins that the height term participates in the min",
+      "frameWidthPx": 336, "frameHeightPx": 736, "viewportWidth": 800, "viewportHeight": 400,
       "padding": 32, "expected": 0.5
     }
   ],
@@ -305,6 +310,12 @@
       "willChangeUnderCanonicalPixels": true,
       "pointWidth": 390, "pointHeight": 844, "scale": 0,
       "expectedPixelWidth": 390, "expectedPixelHeight": 844
+    },
+    {
+      "comment": "fractional HEIGHT product isolated: 667*2.5 = 1667.5 rounds half-up to 1668 while the width product (400*2.5=1000) is integral — a height-axis-only rounding regression cannot hide behind the width case",
+      "willChangeUnderCanonicalPixels": true,
+      "pointWidth": 400, "pointHeight": 667, "scale": 2.5,
+      "expectedPixelWidth": 1000, "expectedPixelHeight": 1668
     }
   ]
 }

--- a/test/fixtures/coordinate-mapping-golden-vectors.json
+++ b/test/fixtures/coordinate-mapping-golden-vectors.json
@@ -77,6 +77,12 @@
       "expectedX": -20, "expectedY": -20, "expectedInBounds": 0
     },
     {
+      "comment": "y-only out of bounds: x well inside, y exactly at deviceHeight (exclusive) — pins the y bounds predicate independently of x",
+      "frameWidthPx": 540, "frameHeightPx": 1170, "scale": 1, "offsetX": 0, "offsetY": 0,
+      "deviceWidth": 1080, "deviceHeight": 2340, "viewportX": 270, "viewportY": 1170,
+      "expectedX": 540, "expectedY": 2340, "expectedInBounds": 0
+    },
+    {
       "comment": "far past the bottom-right edge: raw coordinates preserved, flagged out of bounds",
       "frameWidthPx": 540, "frameHeightPx": 1170, "scale": 1, "offsetX": 0, "offsetY": 0,
       "deviceWidth": 1080, "deviceHeight": 2340, "viewportX": 1000, "viewportY": 2000,
@@ -177,6 +183,11 @@
       "padding": 32, "expectedWidthPx": 340.7407, "expectedHeightPx": 736
     },
     {
+      "comment": "non-default padding 10 (not the 32 default): max sides 780, height-constrained 390x780 — substituting DEFAULT_PADDING would give 368x736",
+      "imageWidth": 1080, "imageHeight": 2160, "viewportWidth": 800, "viewportHeight": 800,
+      "padding": 10, "expectedWidthPx": 390, "expectedHeightPx": 780
+    },
+    {
       "comment": "tiny viewport: max frame sides coerce to the 1px floor -> 0.5x1",
       "imageWidth": 1080, "imageHeight": 2160, "viewportWidth": 10, "viewportHeight": 10,
       "padding": 32, "expectedWidthPx": 0.5, "expectedHeightPx": 1
@@ -202,6 +213,11 @@
       "comment": "HEIGHT candidate decisive mid-range: height ratio 400/(736+64)=0.5 binds while the width ratio is 800/(336+64)=2.0 — pins that the height term participates in the min",
       "frameWidthPx": 336, "frameHeightPx": 736, "viewportWidth": 800, "viewportHeight": 400,
       "padding": 32, "expected": 0.5
+    },
+    {
+      "comment": "non-default padding 20 (not the 32 default): padded sides 800, width candidate 400/800=0.5 — substituting DEFAULT_PADDING would give 400/824=0.4854",
+      "frameWidthPx": 760, "frameHeightPx": 760, "viewportWidth": 400, "viewportHeight": 800,
+      "padding": 20, "expected": 0.5
     }
   ],
   "screenshotRotation": [
@@ -236,6 +252,26 @@
     {
       "comment": "square image counts as landscape (height > width is false) against portrait bounds -> code 1",
       "imageWidth": 1000, "imageHeight": 1000, "rootWidth": 1080, "rootHeight": 2340, "expected": 1
+    },
+    {
+      "comment": "square ROOT bounds count as landscape against a portrait screenshot -> code 3: pins strict rootHeight > rootWidth (a >= mutation flips this to 0)",
+      "imageWidth": 1080, "imageHeight": 2340, "rootWidth": 1000, "rootHeight": 1000, "expected": 3
+    },
+    {
+      "comment": "DECISIVE zero imageWidth: orientations would MISMATCH (portrait-by-height image, landscape bounds), so deleting the imageWidth guard clause changes the result to 3",
+      "imageWidth": 0, "imageHeight": 2340, "rootWidth": 2340, "rootHeight": 1080, "expected": 0
+    },
+    {
+      "comment": "DECISIVE zero imageHeight alone: landscape-by-default image vs portrait bounds, so deleting the imageHeight guard clause changes the result to 1",
+      "imageWidth": 2340, "imageHeight": 0, "rootWidth": 1080, "rootHeight": 2340, "expected": 0
+    },
+    {
+      "comment": "DECISIVE zero rootWidth alone: portrait-by-height bounds vs landscape image, so deleting the rootWidth guard clause changes the result to 1",
+      "imageWidth": 2340, "imageHeight": 1080, "rootWidth": 0, "rootHeight": 2340, "expected": 0
+    },
+    {
+      "comment": "DECISIVE zero rootHeight alone: landscape-by-default bounds vs portrait image, so deleting the rootHeight guard clause changes the result to 3",
+      "imageWidth": 1080, "imageHeight": 2340, "rootWidth": 1080, "rootHeight": 0, "expected": 0
     }
   ],
   "geometryPairing": [

--- a/test/fixtures/coordinate-mapping-golden-vectors.json
+++ b/test/fixtures/coordinate-mapping-golden-vectors.json
@@ -114,6 +114,12 @@
       "frameWidthPx": 320, "frameHeightPx": 693, "scale": 1, "offsetX": 0, "offsetY": 0,
       "deviceWidth": 320, "deviceHeight": 693, "viewportX": 160, "viewportY": 346.5,
       "expectedX": 160, "expectedY": 347, "expectedInBounds": 1
+    },
+    {
+      "comment": "width-derived-ratio invariant: deliberately aspect-MISMATCHED frame (500x500 frame, 1000x2000 device; width ratio 2, height ratio 4). Not a realistic aspect-fitted frame — the pipeline pre-aligns rotation and fits to the device aspect — but it pins the documented rule that BOTH axes scale by deviceWidth/frameWidthPx: a height-derived y would give 800, not 400.",
+      "frameWidthPx": 500, "frameHeightPx": 500, "scale": 1, "offsetX": 0, "offsetY": 0,
+      "deviceWidth": 1000, "deviceHeight": 2000, "viewportX": 100, "viewportY": 200,
+      "expectedX": 200, "expectedY": 400, "expectedInBounds": 1
     }
   ],
   "deviceToViewport": [

--- a/test/fixtures/coordinate-mapping-golden-vectors.json
+++ b/test/fixtures/coordinate-mapping-golden-vectors.json
@@ -147,6 +147,12 @@
       "deviceX": 195, "deviceY": 422, "frameWidthPx": 390, "frameHeightPx": 844, "scale": 1,
       "offsetX": 0, "offsetY": 0, "deviceWidth": 390, "deviceHeight": 844,
       "expectedX": 195, "expectedY": 422
+    },
+    {
+      "comment": "width-derived-ratio invariant (inverse): deliberately aspect-MISMATCHED frame (500x500 frame, 1000x2000 device; width ratio 0.5, height ratio 0.25). Not a realistic aspect-fitted frame — it pins the documented rule that BOTH axes scale by frameWidthPx/deviceWidth: a height-derived y would give 100, not 200.",
+      "deviceX": 200, "deviceY": 400, "frameWidthPx": 500, "frameHeightPx": 500, "scale": 1,
+      "offsetX": 0, "offsetY": 0, "deviceWidth": 1000, "deviceHeight": 2000,
+      "expectedX": 100, "expectedY": 200
     }
   ],
   "fitToViewport": [

--- a/test/lint/turboTestInputsCoverNativeSources.test.ts
+++ b/test/lint/turboTestInputsCoverNativeSources.test.ts
@@ -66,6 +66,18 @@ describe("turbo test inputs cover native sources a guard reads (issue #4351)", (
     return JSON.parse(readFileSync(join(ROOT, "turbo.json"), "utf8")) as TurboConfig;
   }
 
+  /**
+   * Repo-relative form of an absolute path, ALWAYS forward-slashed (#4367 hazard class: Windows
+   * `path.join` produces backslashed absolutes, and every comparison downstream — the owner-file
+   * exclusion, glob coverage, exemption keys, reporting — is forward-slash-sensitive). Without
+   * this single choke-point normalization the owner exclusion fails on Windows, the scanner reads
+   * its own source, and the join-segment example in the scan's comment self-flags as a referenced
+   * native path.
+   */
+  function repoRelative(abs: string): string {
+    return abs.slice(ROOT.length + 1).replace(/\\/g, "/");
+  }
+
   for (const taskName of CACHED_TASKS) {
     describe(`tasks.${taskName}.inputs`, () => {
       test("declares every native source tree a guard reads", () => {
@@ -100,7 +112,7 @@ describe("turbo test inputs cover native sources a guard reads (issue #4351)", (
         if (entry.isDirectory()) {
           walk(abs);
         } else if (entry.name.endsWith(".ts")) {
-          const rel = abs.slice(ROOT.length + 1);
+          const rel = repoRelative(abs);
           // Skip this guard itself: its REQUIRED_NATIVE_GLOBS and
           // NOT_READ_EXEMPTIONS literals would otherwise make every entry
           // trivially "referenced" by its own definition, so the stale-exemption
@@ -134,6 +146,9 @@ describe("turbo test inputs cover native sources a guard reads (issue #4351)", (
           // initially slipped past this lint (issue #4547 follow-up). Single-
           // segment reconstructions ("ios" alone) are skipped: they are always
           // temp-dir fixtures or prose, and the bare repo dir is never a read.
+          // Known regex miss cases (nested calls in join args, template
+          // literals, computed segments) are tracked in #4568 (AST promotion);
+          // REQUIRED_NATIVE_GLOBS still enforces every declared read meanwhile.
           for (const call of source.matchAll(/\bjoin\(([^)]*)\)/gs)) {
             const literals = [...call[1].matchAll(/"([^"]+)"/g)].map(m => m[1]);
             const start = literals.findIndex(l => l === "android" || l === "ios");
@@ -182,6 +197,22 @@ describe("turbo test inputs cover native sources a guard reads (issue #4351)", (
       `Native paths referenced by tests but neither a declared test input nor exempted:\n${uncovered.join("\n")}\n` +
         `Add a narrow glob to REQUIRED_NATIVE_GLOBS (and turbo.json) if a test reads it, or a NOT_READ_EXEMPTIONS entry if it does not.`
     ).toEqual([]);
+  });
+
+  test("#4367 hazard: a win32 backslashed absolute normalizes to the forward-slash owner path", () => {
+    // Deterministic reproduction of the Windows CI failure shape: path.join on win32 yields
+    // `ROOT\test\lint\...`, and without normalization `rel === GUARD_PATH` is false, so the
+    // scanner reads its own source and self-flags the join-segment example in its comments.
+    const winAbs = `${ROOT}\\test\\lint\\turboTestInputsCoverNativeSources.test.ts`;
+    expect(repoRelative(winAbs)).toBe(GUARD_PATH);
+  });
+
+  test("the scan never attributes a native path to its own owner file", () => {
+    // Belt to the normalization above: whatever the platform separator, the owner exclusion must
+    // hold — the guard's own comments deliberately contain scan-pattern examples.
+    for (const [path, tests] of referencedNativePaths()) {
+      expect([...tests], `${path} attributed to the scanner itself`).not.toContain(GUARD_PATH);
+    }
   });
 
   test("no not-read exemption is stale", () => {

--- a/test/lint/turboTestInputsCoverNativeSources.test.ts
+++ b/test/lint/turboTestInputsCoverNativeSources.test.ts
@@ -49,6 +49,13 @@ describe("turbo test inputs cover native sources a guard reads (issue #4351)", (
     "android/protocol/src/main/kotlin/**",
     // webrtcDeviceCaptureLatency.test.ts mirrors QualityPreset.MEDIUM.fps.
     "android/video-server/src/main/kotlin/**",
+    // pinchGoldenVectorParity.test.ts parses the inline golden tables out of
+    // PinchGeometryTest.kt / PinchGeometryTests.swift (issue #2997).
+    "android/control-proxy/src/test/kotlin/**",
+    "ios/control-proxy/Tests/**",
+    // coordinateMappingGoldenVectorParity.test.ts parses the inline golden
+    // tables out of CoordinateMappingGoldenVectorTest.kt (issue #4547).
+    "android/desktop-core/src/test/kotlin/**",
   ] as const;
 
   interface TurboConfig {
@@ -102,20 +109,37 @@ describe("turbo test inputs cover native sources a guard reads (issue #4351)", (
             continue;
           }
           const source = readFileSync(abs, "utf8");
-          for (const match of source.matchAll(/(?<![A-Za-z0-9_.-])(android|ios)\/[A-Za-z0-9._/-]+/g)) {
-            const path = match[0].replace(/\/+$/, "");
-            // SwiftPM's generated output can exist after a local native build
-            // but is never a source input for a TypeScript unit test.
-            if (path.split("/").includes(".build")) {
-              continue;
+          const record = (path: string): void => {
+            // SwiftPM's `.build` and Gradle's `build` outputs can exist after a
+            // local native build but are never source inputs for a TS unit test.
+            const segments = path.split("/");
+            if (segments.includes(".build") || segments.includes("build")) {
+              return;
             }
             if (!existsSync(join(ROOT, path))) {
-              continue;
+              return;
             }
             if (!found.has(path)) {
               found.set(path, new Set());
             }
             found.get(path)!.add(rel);
+          };
+          for (const match of source.matchAll(/(?<![A-Za-z0-9_.-])(android|ios)\/[A-Za-z0-9._/-]+/g)) {
+            record(match[0].replace(/\/+$/, ""));
+          }
+          // ALSO reconstruct `join(..., "android", "desktop-core", ...)`-style
+          // segmented paths: the golden-vector parity guards build their Kotlin/
+          // Swift read targets this way, which the literal regex above cannot
+          // see — exactly how the coordinate-mapping guard's cross-tree read
+          // initially slipped past this lint (issue #4547 follow-up). Single-
+          // segment reconstructions ("ios" alone) are skipped: they are always
+          // temp-dir fixtures or prose, and the bare repo dir is never a read.
+          for (const call of source.matchAll(/\bjoin\(([^)]*)\)/gs)) {
+            const literals = [...call[1].matchAll(/"([^"]+)"/g)].map(m => m[1]);
+            const start = literals.findIndex(l => l === "android" || l === "ios");
+            if (start >= 0 && literals.length - start >= 2) {
+              record(literals.slice(start).join("/"));
+            }
           }
         }
       }

--- a/test/parity/coordinateMappingGoldenVectorParity.test.ts
+++ b/test/parity/coordinateMappingGoldenVectorParity.test.ts
@@ -37,6 +37,7 @@ import {
   referenceIosPointToPixel,
   referenceViewportToDevice,
   SCREENSHOT_ROTATION_FIELDS,
+  validateCoordinateMappingVectors,
   VIEWPORT_TO_DEVICE_FIELDS,
 } from "./coordinateMappingGoldenVectors";
 
@@ -119,6 +120,26 @@ describe("coordinate-mapping golden vector parity (issue #4547)", function() {
         diffs.some(d => d.includes("row 0 field offsetX") && d.includes("missing or non-numeric")),
       ).toBe(true);
     }
+  });
+
+  test("AC2: daemon-only sections are strictly validated at load time", function() {
+    // The Kotlin-backed sections get a second layer via diffNumericRows, but geometryPairing and
+    // iosPointToPixel are consumed directly by the daemon tests, where JS coercion hides
+    // corruption: `"375" * 2 === 750`, so a string-typed pointWidth would pass BOTH the reference
+    // recalculation and the real daemon path. The loader must reject it with the location named.
+    const corrupted = structuredClone(canonical);
+    (corrupted.iosPointToPixel[0] as Record<string, unknown>).pointWidth = "375";
+    expect(() => validateCoordinateMappingVectors(corrupted, "fixture.json")).toThrow(
+      /fixture\.json: section iosPointToPixel row 0 field pointWidth: missing or non-numeric value \("375"\)/,
+    );
+    // A deleted expected field in a daemon-only section must also fail (no silent unmatch).
+    const missing = structuredClone(canonical);
+    delete (missing.geometryPairing[2] as Partial<(typeof missing.geometryPairing)[number]>).expectedMatch;
+    expect(() => validateCoordinateMappingVectors(missing, "fixture.json")).toThrow(
+      /section geometryPairing row 2 field expectedMatch/,
+    );
+    // And the shipped fixture passes (already exercised by loadCoordinateMappingVectors above).
+    expect(() => validateCoordinateMappingVectors(canonical, "fixture.json")).not.toThrow();
   });
 
   test("the Kotlin runtime golden loops still drive the real mapper", function() {

--- a/test/parity/coordinateMappingGoldenVectorParity.test.ts
+++ b/test/parity/coordinateMappingGoldenVectorParity.test.ts
@@ -103,7 +103,22 @@ describe("coordinate-mapping golden vector parity (issue #4547)", function() {
     const tampered = kotlinViewportToDevice.map(row => ({ ...row }));
     delete (tampered[3] as Partial<(typeof tampered)[number]>).expectedY;
     const diffs = diffNumericRows(tampered, canonical.viewportToDevice, VIEWPORT_TO_DEVICE_FIELDS);
-    expect(diffs.some(d => d.includes("row 3 field expectedY") && d.includes("missing or non-finite"))).toBe(true);
+    expect(diffs.some(d => d.includes("row 3 field expectedY") && d.includes("missing or non-numeric"))).toBe(true);
+  });
+
+  test("AC2: the guard rejects a coercible non-numeric field, not just a missing one", function() {
+    // `Number(null)`, `Number(false)`, and `Number("0")` all coerce to 0, so a ZERO-valued
+    // canonical input (offsetX is 0 in most rows) corrupted to one of those would pass a
+    // coercing comparison — the raw value must be validated as a genuine finite number.
+    for (const corrupted of [null, false, "0"]) {
+      const tampered = canonical.viewportToDevice.map(row => ({ ...row }));
+      expect(tampered[0].offsetX).toBe(0); // the coercion-equivalent target the guard must catch
+      (tampered[0] as Record<string, unknown>).offsetX = corrupted;
+      const diffs = diffNumericRows(kotlinViewportToDevice, tampered, VIEWPORT_TO_DEVICE_FIELDS);
+      expect(
+        diffs.some(d => d.includes("row 0 field offsetX") && d.includes("missing or non-numeric")),
+      ).toBe(true);
+    }
   });
 
   test("the Kotlin runtime golden loops still drive the real mapper", function() {

--- a/test/parity/coordinateMappingGoldenVectorParity.test.ts
+++ b/test/parity/coordinateMappingGoldenVectorParity.test.ts
@@ -96,6 +96,16 @@ describe("coordinate-mapping golden vector parity (issue #4547)", function() {
     expect(diffs.some(d => d.includes("rootWidth"))).toBe(true);
   });
 
+  test("AC2: the guard fails CLOSED on a missing field, not open", function() {
+    // `Number(undefined)` is NaN and NaN compares as "not different" under any tolerance check,
+    // so a malformed row (deleted field, typo'd key) must be reported as drift — silently
+    // passing would neuter the guard exactly when the fixture is broken.
+    const tampered = kotlinViewportToDevice.map(row => ({ ...row }));
+    delete (tampered[3] as Partial<(typeof tampered)[number]>).expectedY;
+    const diffs = diffNumericRows(tampered, canonical.viewportToDevice, VIEWPORT_TO_DEVICE_FIELDS);
+    expect(diffs.some(d => d.includes("row 3 field expectedY") && d.includes("missing or non-finite"))).toBe(true);
+  });
+
   test("the Kotlin runtime golden loops still drive the real mapper", function() {
     // This guard only proves literals <-> JSON. The math <-> literals half lives in the Kotlin
     // test's runtime loops. If someone deleted those loops but kept the tables, this parity suite

--- a/test/parity/coordinateMappingGoldenVectorParity.test.ts
+++ b/test/parity/coordinateMappingGoldenVectorParity.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Drift guard for the cross-language coordinate-mapping golden vectors (issue #4547, B0 of the
+ * canonical-pixel campaign #4547 -> #4548 -> #4549 -> #4550).
+ *
+ * Single source of truth: `test/fixtures/coordinate-mapping-golden-vectors.json`. The Kotlin
+ * consumer (`CoordinateMappingGoldenVectorTest.kt`, desktop-core) holds committed inline copies of
+ * the five `DeviceScreenCoordinateMapper` sections; this suite parses those literals out of the
+ * Kotlin source and asserts they match the JSON, so a coordinated one-sided edit (change the
+ * mapper's math AND its golden literals without updating the JSON, or vice versa) fails here —
+ * the same mechanism as `pinchGoldenVectorParity.test.ts`.
+ *
+ * The JSON is also a DERIVED source, not a hand-copy: float32-exact reference ports of the Kotlin
+ * mapper (and of the daemon's pairing / point->pixel logic) recompute every row's expected outputs
+ * from its inputs. The daemon sections (`geometryPairing`, `iosPointToPixel`) are additionally
+ * consumed against the REAL daemon code in `test/daemon/deviceDataStreamSocketServer.test.ts` and
+ * `test/daemon/observationInitialFrame.test.ts`.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import {
+  COORDINATE_KOTLIN_TEST_PATH,
+  DEVICE_TO_VIEWPORT_FIELDS,
+  diffNumericRows,
+  FIT_SCALE_FIELDS,
+  FIT_TO_VIEWPORT_FIELDS,
+  loadCoordinateMappingVectors,
+  parseKotlinDeviceToViewportTable,
+  parseKotlinFitScaleTable,
+  parseKotlinFitToViewportTable,
+  parseKotlinScreenshotRotationTable,
+  parseKotlinViewportToDeviceTable,
+  referenceDetectScreenshotRotation,
+  referenceDeviceToViewport,
+  referenceFitScale,
+  referenceFitToViewport,
+  referenceGeometryPairing,
+  referenceIosPointToPixel,
+  referenceViewportToDevice,
+  SCREENSHOT_ROTATION_FIELDS,
+  VIEWPORT_TO_DEVICE_FIELDS,
+} from "./coordinateMappingGoldenVectors";
+
+describe("coordinate-mapping golden vector parity (issue #4547)", function() {
+  const canonical = loadCoordinateMappingVectors();
+  const kotlinViewportToDevice = parseKotlinViewportToDeviceTable();
+  const kotlinDeviceToViewport = parseKotlinDeviceToViewportTable();
+  const kotlinFitToViewport = parseKotlinFitToViewportTable();
+  const kotlinFitScale = parseKotlinFitScaleTable();
+  const kotlinScreenshotRotation = parseKotlinScreenshotRotationTable();
+
+  test("canonical JSON exposes non-trivial tables for every section", function() {
+    // Guards against an empty/renamed fixture silently making every parity assertion vacuous.
+    expect(canonical.viewportToDevice.length).toBeGreaterThanOrEqual(10);
+    expect(canonical.deviceToViewport.length).toBeGreaterThanOrEqual(3);
+    expect(canonical.fitToViewport.length).toBeGreaterThanOrEqual(4);
+    expect(canonical.fitScale.length).toBeGreaterThanOrEqual(3);
+    expect(canonical.screenshotRotation.length).toBeGreaterThanOrEqual(6);
+    expect(canonical.geometryPairing.length).toBeGreaterThanOrEqual(6);
+    expect(canonical.iosPointToPixel.length).toBeGreaterThanOrEqual(4);
+  });
+
+  test("AC1: Kotlin viewportToDevice literals are verified against the single source", function() {
+    expect(diffNumericRows(kotlinViewportToDevice, canonical.viewportToDevice, VIEWPORT_TO_DEVICE_FIELDS)).toEqual([]);
+  });
+
+  test("AC1: Kotlin deviceToViewport literals are verified against the single source", function() {
+    expect(diffNumericRows(kotlinDeviceToViewport, canonical.deviceToViewport, DEVICE_TO_VIEWPORT_FIELDS)).toEqual([]);
+  });
+
+  test("AC1: Kotlin fitToViewport literals are verified against the single source", function() {
+    expect(diffNumericRows(kotlinFitToViewport, canonical.fitToViewport, FIT_TO_VIEWPORT_FIELDS)).toEqual([]);
+  });
+
+  test("AC1: Kotlin fitScale literals are verified against the single source", function() {
+    expect(diffNumericRows(kotlinFitScale, canonical.fitScale, FIT_SCALE_FIELDS)).toEqual([]);
+  });
+
+  test("AC1: Kotlin screenshotRotation literals are verified against the single source", function() {
+    expect(diffNumericRows(kotlinScreenshotRotation, canonical.screenshotRotation, SCREENSHOT_ROTATION_FIELDS)).toEqual([]);
+  });
+
+  test("AC2: a coordinated one-sided edit of the Kotlin table is detected", function() {
+    // Simulate the failure mode the guard exists for: someone changes the Kotlin mapper's rounding
+    // AND updates only the Kotlin golden literals. The untouched JSON no longer matches.
+    const tampered = kotlinViewportToDevice.map(row => ({ ...row }));
+    tampered[0] = { ...tampered[0], expectedX: tampered[0].expectedX + 5 };
+    const diffs = diffNumericRows(tampered, canonical.viewportToDevice, VIEWPORT_TO_DEVICE_FIELDS);
+    expect(diffs.length).toBeGreaterThan(0);
+    expect(diffs.some(d => d.includes("row 0 field expectedX"))).toBe(true);
+  });
+
+  test("AC2: an input-tuple divergence is also detected", function() {
+    const tampered = kotlinScreenshotRotation.map(row => ({ ...row }));
+    tampered[2] = { ...tampered[2], rootWidth: tampered[2].rootWidth + 1 };
+    const diffs = diffNumericRows(tampered, canonical.screenshotRotation, SCREENSHOT_ROTATION_FIELDS);
+    expect(diffs.some(d => d.includes("rootWidth"))).toBe(true);
+  });
+
+  test("the Kotlin runtime golden loops still drive the real mapper", function() {
+    // This guard only proves literals <-> JSON. The math <-> literals half lives in the Kotlin
+    // test's runtime loops. If someone deleted those loops but kept the tables, this parity suite
+    // would still pass while the mapper drifted — assert the assertion-driving symbols exist.
+    const kotlinSource = readFileSync(COORDINATE_KOTLIN_TEST_PATH, "utf8");
+    for (const symbol of [
+      "viewportToDevice(",
+      "deviceToViewport(",
+      "fitToViewport(",
+      "fitScale(",
+      "detectScreenshotRotation(",
+      "assertEquals",
+    ]) {
+      expect(kotlinSource).toContain(symbol);
+    }
+  });
+
+  test("every viewportToDevice row's expected outputs are DERIVABLE from its inputs", function() {
+    for (let i = 0; i < canonical.viewportToDevice.length; i++) {
+      const row = canonical.viewportToDevice[i];
+      const computed = referenceViewportToDevice(row);
+      expect(`${i}:${computed.x},${computed.y},${computed.inBounds ? 1 : 0}`)
+        .toBe(`${i}:${row.expectedX},${row.expectedY},${row.expectedInBounds}`);
+    }
+  });
+
+  test("every deviceToViewport row's expected outputs are DERIVABLE from its inputs", function() {
+    for (let i = 0; i < canonical.deviceToViewport.length; i++) {
+      const row = canonical.deviceToViewport[i];
+      const computed = referenceDeviceToViewport(row);
+      expect(Math.abs(computed.x - row.expectedX)).toBeLessThanOrEqual(1e-3);
+      expect(Math.abs(computed.y - row.expectedY)).toBeLessThanOrEqual(1e-3);
+    }
+  });
+
+  test("every fitToViewport row's expected outputs are DERIVABLE from its inputs", function() {
+    for (let i = 0; i < canonical.fitToViewport.length; i++) {
+      const row = canonical.fitToViewport[i];
+      const computed = referenceFitToViewport(row);
+      expect(Math.abs(computed.widthPx - row.expectedWidthPx)).toBeLessThanOrEqual(1e-3);
+      expect(Math.abs(computed.heightPx - row.expectedHeightPx)).toBeLessThanOrEqual(1e-3);
+    }
+  });
+
+  test("every fitScale row's expected output is DERIVABLE from its inputs", function() {
+    for (let i = 0; i < canonical.fitScale.length; i++) {
+      const row = canonical.fitScale[i];
+      expect(Math.abs(referenceFitScale(row) - row.expected)).toBeLessThanOrEqual(1e-3);
+    }
+  });
+
+  test("every screenshotRotation row's expected code is DERIVABLE from its inputs", function() {
+    for (let i = 0; i < canonical.screenshotRotation.length; i++) {
+      const row = canonical.screenshotRotation[i];
+      expect(`${i}:${referenceDetectScreenshotRotation(row)}`).toBe(`${i}:${row.expected}`);
+    }
+  });
+
+  test("every geometryPairing row's expected match is DERIVABLE from its inputs", function() {
+    for (let i = 0; i < canonical.geometryPairing.length; i++) {
+      const row = canonical.geometryPairing[i];
+      expect(`${i}:${referenceGeometryPairing(row) ? 1 : 0}`).toBe(`${i}:${row.expectedMatch}`);
+    }
+  });
+
+  test("every iosPointToPixel row's expected pixels are DERIVABLE from its inputs", function() {
+    for (let i = 0; i < canonical.iosPointToPixel.length; i++) {
+      const row = canonical.iosPointToPixel[i];
+      const computed = referenceIosPointToPixel(row);
+      expect(`${i}:${computed.width}x${computed.height}`)
+        .toBe(`${i}:${row.expectedPixelWidth}x${row.expectedPixelHeight}`);
+    }
+  });
+
+  test("the reference math catches a corrupted expected value in the source", function() {
+    // Negative control: a mis-typed expected endpoint must trip the derivation check.
+    const row = canonical.viewportToDevice[0];
+    const computed = referenceViewportToDevice(row);
+    expect(computed.x).not.toBe(row.expectedX + 7);
+  });
+
+  test("AC3: iOS point-space rows are explicitly flagged as changing under canonical pixels", function() {
+    // The proof the suite will catch the #4549 conversion: at least one row in each affected
+    // section is documented as MUST-change, so that PR has to touch this fixture deliberately.
+    expect(canonical.viewportToDevice.some(row => row.willChangeUnderCanonicalPixels === true)).toBe(true);
+    expect(canonical.deviceToViewport.some(row => row.willChangeUnderCanonicalPixels === true)).toBe(true);
+    expect(canonical.iosPointToPixel.every(row => row.willChangeUnderCanonicalPixels === true)).toBe(true);
+    // And the flagged viewportToDevice rows are exactly the point-space ones (deviceWidth equals
+    // the frame width at scale 1 with an iOS point-class dimension, not an Android pixel one).
+    for (const row of canonical.viewportToDevice) {
+      if (row.willChangeUnderCanonicalPixels) {
+        expect(row.deviceWidth).toBeLessThan(1000);
+      }
+    }
+  });
+});

--- a/test/parity/coordinateMappingGoldenVectors.ts
+++ b/test/parity/coordinateMappingGoldenVectors.ts
@@ -371,6 +371,16 @@ export function diffNumericRows<T extends Record<string, number | boolean | unde
     for (const field of fields) {
       const a = Number(actual[i][field]);
       const e = Number(expected[i][field]);
+      // Fail CLOSED on a missing or non-numeric field: `Number(undefined)` is NaN and every
+      // NaN comparison is false, so a malformed fixture/table row would otherwise sail through
+      // the tolerance check as "not different" and neuter the drift guard.
+      if (!Number.isFinite(a) || !Number.isFinite(e)) {
+        diffs.push(
+          `row ${i} field ${field}: missing or non-finite value ` +
+            `(actual=${String(actual[i][field])}, expected=${String(expected[i][field])})`,
+        );
+        continue;
+      }
       if (Math.abs(a - e) > tolerance) {
         diffs.push(`row ${i} field ${field}: ${a} !== ${e}`);
       }

--- a/test/parity/coordinateMappingGoldenVectors.ts
+++ b/test/parity/coordinateMappingGoldenVectors.ts
@@ -369,15 +369,20 @@ export function diffNumericRows<T extends Record<string, number | boolean | unde
   }
   for (let i = 0; i < expected.length; i++) {
     for (const field of fields) {
-      const a = Number(actual[i][field]);
-      const e = Number(expected[i][field]);
-      // Fail CLOSED on a missing or non-numeric field: `Number(undefined)` is NaN and every
-      // NaN comparison is false, so a malformed fixture/table row would otherwise sail through
-      // the tolerance check as "not different" and neuter the drift guard.
-      if (!Number.isFinite(a) || !Number.isFinite(e)) {
+      const a = actual[i][field];
+      const e = expected[i][field];
+      // Fail CLOSED on a missing, non-numeric, or non-finite field — validating the RAW value,
+      // never a coerced one. `Number(undefined)` is NaN (silently "not different" under any
+      // tolerance), and `Number(null)` / `Number(false)` / `Number("0")` all coerce to 0, so a
+      // zero-valued canonical input corrupted to one of those would pass a coercing comparison
+      // and neuter the drift guard exactly when the fixture is broken.
+      if (
+        typeof a !== "number" || !Number.isFinite(a) ||
+        typeof e !== "number" || !Number.isFinite(e)
+      ) {
         diffs.push(
-          `row ${i} field ${field}: missing or non-finite value ` +
-            `(actual=${String(actual[i][field])}, expected=${String(expected[i][field])})`,
+          `row ${i} field ${field}: missing or non-numeric value ` +
+            `(actual=${JSON.stringify(a)}, expected=${JSON.stringify(e)})`,
         );
         continue;
       }

--- a/test/parity/coordinateMappingGoldenVectors.ts
+++ b/test/parity/coordinateMappingGoldenVectors.ts
@@ -150,14 +150,43 @@ export function loadCoordinateMappingVectors(): CoordinateMappingGoldenVectors {
   const parsed = JSON.parse(
     readFileSync(COORDINATE_CANONICAL_JSON_PATH, "utf8"),
   ) as CoordinateMappingGoldenVectors;
+  validateCoordinateMappingVectors(parsed, COORDINATE_CANONICAL_JSON_PATH);
+  return parsed;
+}
+
+/**
+ * Strict structural validation of the canonical fixture, applied at LOAD time so every consumer
+ * (Kotlin parity, daemon geometry-pairing, daemon point->pixel) fails closed on a malformed file.
+ *
+ * The Kotlin-backed sections are additionally guarded by `diffNumericRows`, but the daemon-only
+ * sections (`geometryPairing`, `iosPointToPixel`) are consumed directly, where JS coercion would
+ * hide corruption: `"375" * 2` is `750`, so a string-typed `pointWidth` passes BOTH the reference
+ * recalculation and the real daemon path. Every declared numeric field must therefore be a raw,
+ * finite `number` — a missing field (`undefined`) or a coercible impostor (`"375"`, `null`,
+ * `false`) fails with the section, row, and field named. This also guarantees no expected field
+ * is silently unmatched by a typo'd key: the canonical field list drives the check, not the row.
+ */
+export function validateCoordinateMappingVectors(
+  parsed: CoordinateMappingGoldenVectors,
+  source: string = COORDINATE_CANONICAL_JSON_PATH,
+): void {
   for (const section of SECTION_NAMES) {
     if (!Array.isArray(parsed[section]) || parsed[section].length === 0) {
-      throw new Error(
-        `${COORDINATE_CANONICAL_JSON_PATH}: missing non-empty "${section}" array`,
-      );
+      throw new Error(`${source}: missing non-empty "${section}" array`);
     }
+    const fields = SECTION_NUMERIC_FIELDS[section];
+    parsed[section].forEach((row, index) => {
+      for (const field of fields) {
+        const value = (row as Record<string, unknown>)[field];
+        if (typeof value !== "number" || !Number.isFinite(value)) {
+          throw new Error(
+            `${source}: section ${section} row ${index} field ${field}: ` +
+              `missing or non-numeric value (${JSON.stringify(value)})`,
+          );
+        }
+      }
+    });
   }
-  return parsed;
 }
 
 /** Chunk a flat number sequence into fixed-width rows, failing closed on misalignment. */
@@ -449,3 +478,30 @@ export const SCREENSHOT_ROTATION_FIELDS = [
   "rootHeight",
   "expected",
 ] as const;
+
+export const GEOMETRY_PAIRING_FIELDS = [
+  "measuredWidth",
+  "measuredHeight",
+  "claimedWidth",
+  "claimedHeight",
+  "expectedMatch",
+] as const;
+
+export const IOS_POINT_TO_PIXEL_FIELDS = [
+  "pointWidth",
+  "pointHeight",
+  "scale",
+  "expectedPixelWidth",
+  "expectedPixelHeight",
+] as const;
+
+/** Per-section canonical numeric field lists driving the load-time strict validation. */
+const SECTION_NUMERIC_FIELDS: Record<(typeof SECTION_NAMES)[number], readonly string[]> = {
+  viewportToDevice: VIEWPORT_TO_DEVICE_FIELDS,
+  deviceToViewport: DEVICE_TO_VIEWPORT_FIELDS,
+  fitToViewport: FIT_TO_VIEWPORT_FIELDS,
+  fitScale: FIT_SCALE_FIELDS,
+  screenshotRotation: SCREENSHOT_ROTATION_FIELDS,
+  geometryPairing: GEOMETRY_PAIRING_FIELDS,
+  iosPointToPixel: IOS_POINT_TO_PIXEL_FIELDS,
+};

--- a/test/parity/coordinateMappingGoldenVectors.ts
+++ b/test/parity/coordinateMappingGoldenVectors.ts
@@ -1,0 +1,436 @@
+/**
+ * Single-source drift-guard helpers for the cross-language coordinate-mapping golden vectors
+ * (issue #4547, B0 of the canonical-pixel campaign #4547 -> #4548 -> #4549 -> #4550).
+ *
+ * Canonical source: `test/fixtures/coordinate-mapping-golden-vectors.json`. Consumers:
+ * - Kotlin `CoordinateMappingGoldenVectorTest.kt` (desktop-core) holds inline copies of the five
+ *   `DeviceScreenCoordinateMapper` sections; this module parses those committed literals out of
+ *   the Kotlin source (the pinch-vector mechanism, see `pinchGoldenVectors.ts`) and the parity
+ *   test verifies them against the JSON.
+ * - TypeScript daemon tests read the JSON directly: `geometryPairing` drives the daemon's
+ *   `pixelsMatchClaimedGeometry` pairing (`test/daemon/deviceDataStreamSocketServer.test.ts`) and
+ *   `iosPointToPixel` drives the iOS point->pixel conversion
+ *   (`test/daemon/observationInitialFrame.test.ts`).
+ * - Swift: deliberately no consumer — the iOS runner performs no viewport<->device mapping (see
+ *   the JSON header comment for the evidence trail).
+ *
+ * The reference implementations below mirror the Kotlin mapper opcode for opcode, with
+ * `Math.fround` after each arithmetic step to reproduce Kotlin `Float` (32-bit) semantics exactly,
+ * so the JSON is a *derived* source: a test recomputes every row's expected outputs from its
+ * inputs and a bad hand-edit is caught at the root. `Math.round` matches Kotlin `roundToInt`
+ * (both round ties toward positive infinity).
+ */
+import { readFileSync } from "fs";
+import { join } from "path";
+import { extractNumbers, extractNumericTableRegion, REPO_ROOT } from "./pinchGoldenVectors";
+
+export const COORDINATE_CANONICAL_JSON_PATH = join(
+  REPO_ROOT,
+  "test",
+  "fixtures",
+  "coordinate-mapping-golden-vectors.json",
+);
+
+export const COORDINATE_KOTLIN_TEST_PATH = join(
+  REPO_ROOT,
+  "android",
+  "desktop-core",
+  "src",
+  "test",
+  "kotlin",
+  "dev",
+  "jasonpearson",
+  "automobile",
+  "desktop",
+  "core",
+  "layout",
+  "CoordinateMappingGoldenVectorTest.kt",
+);
+
+export interface ViewportToDeviceVector {
+  frameWidthPx: number;
+  frameHeightPx: number;
+  scale: number;
+  offsetX: number;
+  offsetY: number;
+  deviceWidth: number;
+  deviceHeight: number;
+  viewportX: number;
+  viewportY: number;
+  expectedX: number;
+  expectedY: number;
+  /** 1 = in bounds, 0 = out of bounds (kept numeric so the Kotlin table stays purely numeric). */
+  expectedInBounds: number;
+  willChangeUnderCanonicalPixels?: boolean;
+}
+
+export interface DeviceToViewportVector {
+  deviceX: number;
+  deviceY: number;
+  frameWidthPx: number;
+  frameHeightPx: number;
+  scale: number;
+  offsetX: number;
+  offsetY: number;
+  deviceWidth: number;
+  deviceHeight: number;
+  expectedX: number;
+  expectedY: number;
+  willChangeUnderCanonicalPixels?: boolean;
+}
+
+export interface FitToViewportVector {
+  imageWidth: number;
+  imageHeight: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  padding: number;
+  expectedWidthPx: number;
+  expectedHeightPx: number;
+}
+
+export interface FitScaleVector {
+  frameWidthPx: number;
+  frameHeightPx: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  padding: number;
+  expected: number;
+}
+
+export interface ScreenshotRotationVector {
+  imageWidth: number;
+  imageHeight: number;
+  rootWidth: number;
+  rootHeight: number;
+  expected: number;
+}
+
+export interface GeometryPairingVector {
+  /** -1 together with measuredHeight = -1 means the frame is unmeasurable. */
+  measuredWidth: number;
+  measuredHeight: number;
+  claimedWidth: number;
+  claimedHeight: number;
+  /** 1 = the daemon pairs the screenshot with the claimed geometry, 0 = it must not. */
+  expectedMatch: number;
+}
+
+export interface IosPointToPixelVector {
+  pointWidth: number;
+  pointHeight: number;
+  /** 0 means the hierarchy carried no screenScale (the daemon defaults the multiplier to 1). */
+  scale: number;
+  expectedPixelWidth: number;
+  expectedPixelHeight: number;
+  willChangeUnderCanonicalPixels?: boolean;
+}
+
+export interface CoordinateMappingGoldenVectors {
+  viewportToDevice: ViewportToDeviceVector[];
+  deviceToViewport: DeviceToViewportVector[];
+  fitToViewport: FitToViewportVector[];
+  fitScale: FitScaleVector[];
+  screenshotRotation: ScreenshotRotationVector[];
+  geometryPairing: GeometryPairingVector[];
+  iosPointToPixel: IosPointToPixelVector[];
+}
+
+const SECTION_NAMES = [
+  "viewportToDevice",
+  "deviceToViewport",
+  "fitToViewport",
+  "fitScale",
+  "screenshotRotation",
+  "geometryPairing",
+  "iosPointToPixel",
+] as const;
+
+export function loadCoordinateMappingVectors(): CoordinateMappingGoldenVectors {
+  const parsed = JSON.parse(
+    readFileSync(COORDINATE_CANONICAL_JSON_PATH, "utf8"),
+  ) as CoordinateMappingGoldenVectors;
+  for (const section of SECTION_NAMES) {
+    if (!Array.isArray(parsed[section]) || parsed[section].length === 0) {
+      throw new Error(
+        `${COORDINATE_CANONICAL_JSON_PATH}: missing non-empty "${section}" array`,
+      );
+    }
+  }
+  return parsed;
+}
+
+/** Chunk a flat number sequence into fixed-width rows, failing closed on misalignment. */
+function chunkRows(numbers: number[], width: number, label: string): number[][] {
+  if (numbers.length === 0 || numbers.length % width !== 0) {
+    throw new Error(
+      `${label}: expected a positive multiple of ${width} numbers, got ${numbers.length}`,
+    );
+  }
+  const rows: number[][] = [];
+  for (let i = 0; i < numbers.length; i += width) {
+    rows.push(numbers.slice(i, i + width));
+  }
+  return rows;
+}
+
+/** Parse one Kotlin inline table (a `val <marker> = listOf(...)` literal) into fixed-width rows. */
+function parseKotlinSection(marker: string, rowWidth: number): number[][] {
+  const region = extractNumericTableRegion(COORDINATE_KOTLIN_TEST_PATH, marker, "(", ")");
+  return chunkRows(
+    extractNumbers(region),
+    rowWidth,
+    `${COORDINATE_KOTLIN_TEST_PATH} (${marker.trim()})`,
+  );
+}
+
+export function parseKotlinViewportToDeviceTable(): ViewportToDeviceVector[] {
+  return parseKotlinSection("val viewportToDeviceVectors =", 12).map(row => ({
+    frameWidthPx: row[0],
+    frameHeightPx: row[1],
+    scale: row[2],
+    offsetX: row[3],
+    offsetY: row[4],
+    deviceWidth: row[5],
+    deviceHeight: row[6],
+    viewportX: row[7],
+    viewportY: row[8],
+    expectedX: row[9],
+    expectedY: row[10],
+    expectedInBounds: row[11],
+  }));
+}
+
+export function parseKotlinDeviceToViewportTable(): DeviceToViewportVector[] {
+  return parseKotlinSection("val deviceToViewportVectors =", 11).map(row => ({
+    deviceX: row[0],
+    deviceY: row[1],
+    frameWidthPx: row[2],
+    frameHeightPx: row[3],
+    scale: row[4],
+    offsetX: row[5],
+    offsetY: row[6],
+    deviceWidth: row[7],
+    deviceHeight: row[8],
+    expectedX: row[9],
+    expectedY: row[10],
+  }));
+}
+
+export function parseKotlinFitToViewportTable(): FitToViewportVector[] {
+  return parseKotlinSection("val fitToViewportVectors =", 7).map(row => ({
+    imageWidth: row[0],
+    imageHeight: row[1],
+    viewportWidth: row[2],
+    viewportHeight: row[3],
+    padding: row[4],
+    expectedWidthPx: row[5],
+    expectedHeightPx: row[6],
+  }));
+}
+
+export function parseKotlinFitScaleTable(): FitScaleVector[] {
+  return parseKotlinSection("val fitScaleVectors =", 6).map(row => ({
+    frameWidthPx: row[0],
+    frameHeightPx: row[1],
+    viewportWidth: row[2],
+    viewportHeight: row[3],
+    padding: row[4],
+    expected: row[5],
+  }));
+}
+
+export function parseKotlinScreenshotRotationTable(): ScreenshotRotationVector[] {
+  return parseKotlinSection("val screenshotRotationVectors =", 5).map(row => ({
+    imageWidth: row[0],
+    imageHeight: row[1],
+    rootWidth: row[2],
+    rootHeight: row[3],
+    expected: row[4],
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Reference implementations (float32-exact ports of DeviceScreenCoordinateMapper)
+// ---------------------------------------------------------------------------
+
+const f = Math.fround;
+
+/** Fallback aspect ratio for unknown image width — mirrors `FALLBACK_ASPECT_RATIO = 2.16f`. */
+const FALLBACK_ASPECT_RATIO = f(2.16);
+
+export function referenceViewportToDevice(
+  vector: ViewportToDeviceVector,
+): { x: number; y: number; inBounds: boolean } {
+  const frameX = f(f(vector.viewportX - vector.offsetX) / vector.scale);
+  const frameY = f(f(vector.viewportY - vector.offsetY) / vector.scale);
+  const frameToDevice =
+    vector.frameWidthPx > 0 ? f(vector.deviceWidth / vector.frameWidthPx) : 1;
+  const x = Math.round(f(frameX * frameToDevice));
+  const y = Math.round(f(frameY * frameToDevice));
+  const inBounds =
+    x >= 0 && x < vector.deviceWidth && y >= 0 && y < vector.deviceHeight;
+  return { x, y, inBounds };
+}
+
+export function referenceDeviceToViewport(
+  vector: DeviceToViewportVector,
+): { x: number; y: number } {
+  const deviceToFrame =
+    vector.deviceWidth > 0 ? f(vector.frameWidthPx / vector.deviceWidth) : 1;
+  const frameX = f(vector.deviceX * deviceToFrame);
+  const frameY = f(vector.deviceY * deviceToFrame);
+  return {
+    x: f(f(frameX * vector.scale) + vector.offsetX),
+    y: f(f(frameY * vector.scale) + vector.offsetY),
+  };
+}
+
+export function referenceFitToViewport(
+  vector: FitToViewportVector,
+): { widthPx: number; heightPx: number } {
+  const aspect =
+    vector.imageWidth > 0 ? f(vector.imageHeight / vector.imageWidth) : FALLBACK_ASPECT_RATIO;
+  const maxFrameWidth = Math.max(f(vector.viewportWidth - f(vector.padding * 2)), 1);
+  const maxFrameHeight = Math.max(f(vector.viewportHeight - f(vector.padding * 2)), 1);
+  if (f(maxFrameWidth * aspect) <= maxFrameHeight) {
+    return { widthPx: maxFrameWidth, heightPx: f(maxFrameWidth * aspect) };
+  }
+  return { widthPx: f(maxFrameHeight / aspect), heightPx: maxFrameHeight };
+}
+
+export function referenceFitScale(vector: FitScaleVector): number {
+  const paddedWidth = f(vector.frameWidthPx + f(vector.padding * 2));
+  const paddedHeight = f(vector.frameHeightPx + f(vector.padding * 2));
+  const raw = Math.min(
+    f(vector.viewportWidth / paddedWidth),
+    f(vector.viewportHeight / paddedHeight),
+    1,
+  );
+  return Math.min(Math.max(raw, f(0.3)), 1);
+}
+
+export function referenceDetectScreenshotRotation(vector: ScreenshotRotationVector): number {
+  const { imageWidth, imageHeight, rootWidth, rootHeight } = vector;
+  if (imageWidth <= 0 || imageHeight <= 0 || rootWidth <= 0 || rootHeight <= 0) {
+    return 0;
+  }
+  const imageIsPortrait = imageHeight > imageWidth;
+  const boundsIsPortrait = rootHeight > rootWidth;
+  if (imageIsPortrait && !boundsIsPortrait) {
+    return 3;
+  }
+  if (!imageIsPortrait && boundsIsPortrait) {
+    return 1;
+  }
+  return 0;
+}
+
+/** Mirrors the daemon's `pixelsMatchClaimedGeometry` (exact match OR swapped WxH, never scale). */
+export function referenceGeometryPairing(vector: GeometryPairingVector): boolean {
+  if (vector.measuredWidth < 0 || vector.measuredHeight < 0) {
+    return false;
+  }
+  const sameOrientation =
+    vector.measuredWidth === vector.claimedWidth &&
+    vector.measuredHeight === vector.claimedHeight;
+  const swappedOrientation =
+    vector.measuredWidth === vector.claimedHeight &&
+    vector.measuredHeight === vector.claimedWidth;
+  return sameOrientation || swappedOrientation;
+}
+
+/** Mirrors the daemon's iOS point->pixel conversion: `Math.round(points * (scale || 1))`. */
+export function referenceIosPointToPixel(
+  vector: IosPointToPixelVector,
+): { width: number; height: number } {
+  const scale = vector.scale === 0 ? 1 : vector.scale;
+  return {
+    width: Math.round(vector.pointWidth * scale),
+    height: Math.round(vector.pointHeight * scale),
+  };
+}
+
+/**
+ * Compare two same-shape numeric row arrays and return human-readable mismatch strings (empty
+ * array === identical). This is the drift detector for the Kotlin inline tables: feed it a table
+ * with a one-sided edit and it reports exactly which row and field diverged.
+ */
+export function diffNumericRows<T extends Record<string, number | boolean | undefined>>(
+  actual: T[],
+  expected: T[],
+  fields: ReadonlyArray<keyof T & string>,
+  tolerance = 1e-3,
+): string[] {
+  const diffs: string[] = [];
+  if (actual.length !== expected.length) {
+    diffs.push(`row count ${actual.length} !== ${expected.length}`);
+    return diffs;
+  }
+  for (let i = 0; i < expected.length; i++) {
+    for (const field of fields) {
+      const a = Number(actual[i][field]);
+      const e = Number(expected[i][field]);
+      if (Math.abs(a - e) > tolerance) {
+        diffs.push(`row ${i} field ${field}: ${a} !== ${e}`);
+      }
+    }
+  }
+  return diffs;
+}
+
+export const VIEWPORT_TO_DEVICE_FIELDS = [
+  "frameWidthPx",
+  "frameHeightPx",
+  "scale",
+  "offsetX",
+  "offsetY",
+  "deviceWidth",
+  "deviceHeight",
+  "viewportX",
+  "viewportY",
+  "expectedX",
+  "expectedY",
+  "expectedInBounds",
+] as const;
+
+export const DEVICE_TO_VIEWPORT_FIELDS = [
+  "deviceX",
+  "deviceY",
+  "frameWidthPx",
+  "frameHeightPx",
+  "scale",
+  "offsetX",
+  "offsetY",
+  "deviceWidth",
+  "deviceHeight",
+  "expectedX",
+  "expectedY",
+] as const;
+
+export const FIT_TO_VIEWPORT_FIELDS = [
+  "imageWidth",
+  "imageHeight",
+  "viewportWidth",
+  "viewportHeight",
+  "padding",
+  "expectedWidthPx",
+  "expectedHeightPx",
+] as const;
+
+export const FIT_SCALE_FIELDS = [
+  "frameWidthPx",
+  "frameHeightPx",
+  "viewportWidth",
+  "viewportHeight",
+  "padding",
+  "expected",
+] as const;
+
+export const SCREENSHOT_ROTATION_FIELDS = [
+  "imageWidth",
+  "imageHeight",
+  "rootWidth",
+  "rootHeight",
+  "expected",
+] as const;

--- a/test/parity/pinchGoldenVectors.ts
+++ b/test/parity/pinchGoldenVectors.ts
@@ -120,11 +120,46 @@ function extractBalanced(
  *  and trailing type suffixes (`0f` -> `0`, `433.9f` -> `433.9`), which is every form the golden
  *  tables use. Exotic forms the tables never contain (exponent `2e2`, underscore `6_0`, hex
  *  `0x10`) are deliberately NOT parsed specially: they split into extra tokens and trip the
- *  `NUMBERS_PER_ROW` alignment check in `rowsFromNumbers`, which fails closed rather than silently
- *  mis-parsing. */
-function extractNumbers(source: string): number[] {
+ *  per-row alignment check in `rowsFromNumbers` (or a sibling suite's chunker), which fails
+ *  closed rather than silently mis-parsing. Exported for the coordinate-mapping golden-vector
+ *  suite (issue #4547), which reuses this exact parsing pipeline for its own tables. */
+export function extractNumbers(source: string): number[] {
   const matches = source.match(/-?\d+(?:\.\d+)?/g) ?? [];
   return matches.map(Number);
+}
+
+/**
+ * Shared front half of the golden-table parsing pipeline: read a platform test file, strip
+ * comments, carve out the balanced table literal after `assignmentMarker`, and assert it contains
+ * no string literals. Returns the raw table region text; callers extract and chunk the numbers
+ * according to their own row shapes. Extracted so the coordinate-mapping golden-vector suite
+ * (issue #4547) reuses the exact same drift-guard mechanics as the pinch suite.
+ */
+export function extractNumericTableRegion(
+  filePath: string,
+  assignmentMarker: string,
+  open: string,
+  close: string,
+): string {
+  // Strip comments BEFORE the balanced-delimiter scan so a stray `[`/`]`/`(`/`)` inside a comment
+  // between the marker and the literal (or within it) can never mis-terminate the walk.
+  const source = stripComments(readFileSync(filePath, "utf8"));
+  const markerIndex = source.indexOf(assignmentMarker);
+  if (markerIndex < 0) {
+    throw new Error(`marker '${assignmentMarker}' not found in ${filePath}`);
+  }
+  // Start after the marker so a type annotation in the marker (e.g. Swift's `[Vector]`) is not
+  // mistaken for the opening delimiter of the literal.
+  const region = extractBalanced(
+    source,
+    markerIndex + assignmentMarker.length,
+    open,
+    close,
+  );
+  // Fail loudly if a string literal ever appears inside the table region so a digit-bearing label
+  // can never silently corrupt positional number extraction (Item 2, issue #3021).
+  assertNoStringLiterals(region, filePath);
+  return region;
 }
 
 /** Chunk a flat number sequence into golden rows, asserting a clean multiple of the row width. */
@@ -165,24 +200,7 @@ export function parseGoldenTable(
   open: string,
   close: string,
 ): GoldenVector[] {
-  // Strip comments BEFORE the balanced-delimiter scan so a stray `[`/`]`/`(`/`)` inside a comment
-  // between the marker and the literal (or within it) can never mis-terminate the walk.
-  const source = stripComments(readFileSync(filePath, "utf8"));
-  const markerIndex = source.indexOf(assignmentMarker);
-  if (markerIndex < 0) {
-    throw new Error(`marker '${assignmentMarker}' not found in ${filePath}`);
-  }
-  // Start after the marker so a type annotation in the marker (e.g. Swift's `[Vector]`) is not
-  // mistaken for the opening delimiter of the literal.
-  const region = extractBalanced(
-    source,
-    markerIndex + assignmentMarker.length,
-    open,
-    close,
-  );
-  // Item 2 (#3021): fail loudly if a string literal ever appears inside the table region so a
-  // digit-bearing label can never silently corrupt positional number extraction.
-  assertNoStringLiterals(region, filePath);
+  const region = extractNumericTableRegion(filePath, assignmentMarker, open, close);
   const numbers = extractNumbers(region);
   return rowsFromNumbers(numbers, filePath);
 }

--- a/turbo.json
+++ b/turbo.json
@@ -38,7 +38,7 @@
       "passThroughEnv": ["CI", "GITHUB_ACTIONS"]
     },
     "test": {
-      "description": "Run Bun test suite. The android/** and ios/** globs below are read off disk by cross-language source-scan guards no TS import can reach (registrationTeardownGuard, ctrlProxyProtocol, ctrlProxyWireParity, webrtcDeviceCaptureLatency); without them a Kotlin/Swift-only diff replays a cached result and the guard never runs. turbo.json is an input so editing test:coverage's list cannot leave this hash stale. Do not narrow or drop these without updating test/lint/turboTestInputsCoverNativeSources.test.ts (issue #4351).",
+      "description": "Run Bun test suite. The android/** and ios/** globs below are read off disk by cross-language source-scan guards no TS import can reach (registrationTeardownGuard, ctrlProxyProtocol, ctrlProxyWireParity, webrtcDeviceCaptureLatency, pinchGoldenVectorParity, coordinateMappingGoldenVectorParity); without them a Kotlin/Swift-only diff replays a cached result and the guard never runs. turbo.json is an input so editing test:coverage's list cannot leave this hash stale. Do not narrow or drop these without updating test/lint/turboTestInputsCoverNativeSources.test.ts (issue #4351).",
       "inputs": [
         "src/**",
         "test/**",
@@ -50,10 +50,13 @@
         "turbo.json",
         "android/auto-mobile-sdk/src/main/kotlin/**",
         "android/control-proxy/src/main/kotlin/**",
+        "android/control-proxy/src/test/kotlin/**",
+        "android/desktop-core/src/test/kotlin/**",
         "android/protocol/src/main/kotlin/**",
         "android/video-server/src/main/kotlin/**",
         "ios/auto-mobile-sdk/Sources/**",
-        "ios/control-proxy/Sources/**"
+        "ios/control-proxy/Sources/**",
+        "ios/control-proxy/Tests/**"
       ],
       "outputs": [],
       "outputLogs": "new-only",
@@ -99,10 +102,13 @@
         "turbo.json",
         "android/auto-mobile-sdk/src/main/kotlin/**",
         "android/control-proxy/src/main/kotlin/**",
+        "android/control-proxy/src/test/kotlin/**",
+        "android/desktop-core/src/test/kotlin/**",
         "android/protocol/src/main/kotlin/**",
         "android/video-server/src/main/kotlin/**",
         "ios/auto-mobile-sdk/Sources/**",
-        "ios/control-proxy/Sources/**"
+        "ios/control-proxy/Sources/**",
+        "ios/control-proxy/Tests/**"
       ],
       "outputs": ["coverage/**"],
       "outputLogs": "new-only",


### PR DESCRIPTION
## Summary

Adds the cross-language golden-vector suite for viewport<->device coordinate mapping — B0 of the canonical-pixel campaign ([#4547](https://github.com/kaeawc/auto-mobile/issues/4547) → [#4548](https://github.com/kaeawc/auto-mobile/issues/4548) → [#4549](https://github.com/kaeawc/auto-mobile/issues/4549) → [#4550](https://github.com/kaeawc/auto-mobile/issues/4550)). It PINS CURRENT BEHAVIOR so the later unit conversion ([#4549](https://github.com/kaeawc/auto-mobile/issues/4549)) must land as a deliberate golden update, never silent drift. Mirrors the `pinch-golden-vectors.json` single-source pattern exactly.

Closes [#4547](https://github.com/kaeawc/auto-mobile/issues/4547)

## Single source + consumers

- **Canonical file:** `test/fixtures/coordinate-mapping-golden-vectors.json` (7 sections, 64 vectors), strictly validated at load time: every declared numeric field must be a raw finite `number`, so a corrupted daemon-only field (`"375"` would coerce through `*` in both the reference and the real daemon path) or a deleted field fails every consumer with the section/row/field named.
- **Kotlin:** `android/desktop-core/.../layout/CoordinateMappingGoldenVectorTest.kt` holds inline copies of the five `DeviceScreenCoordinateMapper` sections and drives the real mapper against them (5 runtime golden loops).
- **TypeScript (daemon, real code):**
  - `test/daemon/deviceDataStreamSocketServer.test.ts` drives `pixelsMatchClaimedGeometry` through `pushScreenshotUpdate` (real IHDR-measured PNGs vs claimed geometry) from the `geometryPairing` section.
  - `test/daemon/observationInitialFrame.test.ts` drives the daemon's BOOTSTRAP iOS point→pixel conversion (`getIosScreenshotDimensions`) through `pushInitialObservationFramesForSubscriber`, and `test/features/observe/ios/IOSCtrlProxyClient.test.ts` drives the SEPARATE LIVE-hierarchy conversion (`updateScreenGeometryFrom`, real client + fakes) — both from the `iosPointToPixel` section, so the two production paths are independently pinned and cannot vouch for each other during the #4549 conversion.
- **Drift guard:** `test/parity/coordinateMappingGoldenVectorParity.test.ts` parses the Kotlin inline literals out of source (reusing the pinch parsing pipeline, now exported from `test/parity/pinchGoldenVectors.ts`) and verifies them against the JSON; float32-exact TS reference ports additionally re-derive every row's expected outputs from its inputs, so the JSON is a derived source, not a third hand-copy. Symbol checks pin that the Kotlin runtime loops still drive the real mapper.
- **Swift: deliberately no consumer.** The iOS runner performs no viewport<->device mapping: it reports point-space bounds plus `screenScale` (`ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift`), and the point→pixel conversion happens daemon-side in TypeScript (`IOSCtrlProxyClient.updateScreenGeometryFrom`, `observationInitialFrame.ts`). The runner's only coordinate math — pinch endpoint geometry — is already pinned by `pinch-golden-vectors.json`. Inventing a Swift consumer would test a port that does not ship.

## CI gating fix (pre-existing gap the golden suite made load-bearing)

The `desktop_core` path filter in `.github/workflows/pull_request.yml` did not include `android/desktop-domain/**`, so a PR changing only `DeviceScreenCoordinateMapper` (which lives in desktop-domain) skipped `desktop-core-unit-tests` — the exact job that runs the new golden test. The filter now lists `android/desktop-domain/**`; a desktop-domain-only diff triggers `build-desktop-core`, `desktop-core-unit-tests`, `build-ide-plugin`, `ide-plugin-unit-tests`, `build-desktop-app` (3-OS matrix), and `desktop-app-unit-tests` (the ide-plugin/desktop-app jobs OR on `desktop_core_changed`). detekt and the emulator jobs were already covered by the broader `kotlin` (`android/**/*.kt`) and `android` (`android/**`) filters.

The scheduled job feeds a REQUIRED check directly: the active `green-main` ruleset requires the contexts `Build Desktop Core Module` and `Run Desktop Core Unit Tests` (and `Run Desktop App Unit Tests`) by their stable job display names — the roll-up gates (`iOS Build`, `IDE Plugin`, `Shell Tests`, ...) exist only for matrix jobs with unstable expanded names or deliberately-advisory legs. Chain for a desktop-domain-only diff: `filter-desktop-core` matches → `desktop_core_changed=true` → `build-desktop-core` → `desktop-core-unit-tests` runs `:desktop-core:test` (includes the golden test) → a red run reddens the required `Run Desktop Core Unit Tests` context and blocks merge.

## Vector coverage

| Section | Rows | Covers |
|---|---|---|
| `viewportToDevice` | 18 | Android 1080x2340 identity/zoom/pan/pan+zoom; half-up rounding at ±0.5; out-of-bounds at-edge/negative/past-edge (exclusive bounds, no clamping); landscape (rotated) device space; axis-isolated out-of-bounds rows (x-only negative, y-only negative, y-only past-edge — every inBounds predicate pinned independently); degenerate zero frame width; iOS 2x/3x/Display-Zoom point spaces; aspect-MISMATCHED frame pinning the width-derived-ratio invariant (both axes scale by `deviceWidth/frameWidthPx`) |
| `deviceToViewport` | 5 | inverse identity; inverse pan+zoom; degenerate zero device width; iOS 3x point space; aspect-MISMATCHED frame pinning the width-derived-ratio invariant on the inverse |
| `fitToViewport` | 6 | height- and width-constrained aspect fit; landscape; 2.16 fallback aspect; non-default padding (decisive vs DEFAULT_PADDING); 1px floor coercion |
| `fitScale` | 5 | 1.0 cap, 0.3 floor, exact width-decisive mid-range, height-decisive mid-range (pins the height term in the min), non-default padding (decisive vs DEFAULT_PADDING) |
| `screenshotRotation` | 13 | codes 0/1/3; iOS pixels-vs-points orientation agreement; square-image and square-root-bounds edges (strict > pinned both ways); one DECISIVE row per non-positive-dimension guard clause (each clause deletion flips exactly its row) |
| `geometryPairing` | 9 | exact match; iOS landscape swap accepted; aspect-preserving scale rejected; unrelated dims; unmeasurable frame; square; single-axis off-by-one; ONE-axis swap rejected (the swap acceptance is a conjunction) |
| `iosPointToPixel` | 6 | 2x, 3x, Display Zoom (320x693@3x), fractional WIDTH product (937.5→938), fractional HEIGHT product isolated (1667.5→1668 with integral width), absent-scale default 1 |

## Flagged as will-change under [#4549](https://github.com/kaeawc/auto-mobile/issues/4549)

`willChangeUnderCanonicalPixels: true` on: the 3 iOS point-space `viewportToDevice` rows, the iOS `deviceToViewport` row, and **all 5** `iosPointToPixel` rows (once hierarchies arrive in canonical pixels the daemon-side `points * screenScale` multiply must disappear). The parity suite asserts these flags exist, so [#4549](https://github.com/kaeawc/auto-mobile/issues/4549) cannot land without touching this fixture deliberately.

## Validation

- `bun test`: 11708 pass / 0 fail (839 files); new parity suite 18 tests, daemon golden rows 8 + 5.
- `bun run lint` exit 0; `bun run typecheck` 0 new errors (206 baseline).
- `./gradlew :desktop-core:test :desktop-domain:test --rerun-tasks` BUILD SUCCESSFUL (golden test 5/5).
- `./gradlew :desktop-core:detektMain :desktop-core:detektTest :desktop-domain:detektMain :desktop-domain:detektTest :desktop-app:compileKotlin :ide-plugin:compileKotlin --rerun-tasks` BUILD SUCCESSFUL.
- ktfmt 0.64 `--google-style --dry-run` clean on the new Kotlin file.
- No `ide-plugin` source changes; no Xcode project changes (no Swift files added).

## Mutation checks (all restored)

- Kotlin mapper `roundToInt` → `toInt`: `viewportToDevice matches the golden vectors` FAILED.
- Daemon pairing `sameOrientation || swapped` → `&&`: 6 TS failures including golden rows.
- Daemon iOS scale multiply dropped (`scale = 1`): 6 TS failures including 4 golden rows.
- One-sided Kotlin table literal edit: parity AC1 FAILED.
- Corrupted JSON expected value: both the derivation check and the Kotlin-vs-JSON diff FAILED.
- Fail-closed guard neutered (bare `Number()` comparison, `NaN` treated as "not different"): the malformed-row test (`AC2: the guard fails CLOSED on a missing field`) FAILED.
- Coercion re-introduced (`Number(...)` on raw fields, so `null`/`false`/`"0"` coerce to 0): the coercible-field test FAILED.
- Kotlin mapper y-axis switched to a height-derived ratio: `row 14 y expected:<400> but was:<800>` — only the new aspect-mismatched vector catches it.
- TS reference port y-axis switched to a height-derived ratio: the viewportToDevice derivation test FAILED on the same vector.
- Kotlin mapper INVERSE y-axis switched to a height-derived ratio: `row 4 y Expected <200.0> actual <100.0>` — only the new aspect-mismatched inverse vector catches the pure ratio swap.
- TS reference port inverse y-axis switched likewise: the deviceToViewport derivation test FAILED.
- Load-time strictness reverted to coercion (`Number.isFinite(Number(value))`): the daemon-section validation test FAILED.
- Removed `android/desktop-core/src/test/kotlin/**` from `turbo.json`: the turbo-inputs lint guard FAILED on both layers (required-glob list AND the new join-segment scan).
- Live path's scale multiply dropped (`scale = 1` in `updateScreenGeometryFrom`): the LIVE consumer failed on 5 golden rows while the bootstrap consumer stayed fully green — the two paths are independently pinned.
- Height candidate dropped from `fitScale`'s `minOf` (Kotlin): only the new height-decisive row failed (`row 3 Expected <0.5> actual <1.0>`); same for the TS reference port.
- Bootstrap height rounding `Math.round`→`Math.trunc`: only the new fractional-height row failed (1667.5→1667).
- y upper-bound predicate dropped from `inBounds`: only the y-only OOB row failed.
- Each of the four `detectScreenshotRotation` guard clauses deleted individually: exactly its decisive row failed (0→3, 0→1, 0→1, 0→3 respectively).
- `boundsIsPortrait` `>` → `>=`: only the square-root-bounds row failed (3→0).
- `fitToViewport` / `fitScale` bodies substituting `DEFAULT_PADDING` for the padding parameter: exactly the non-default-padding row of each failed.
- Windows-normalization removed from the turbo-inputs scan: the win32-shape reproduction test failed.
- x / y lower-bound predicates deleted individually from `inBounds`: exactly the x-only-negative / y-only-negative row failed respectively.
- Swap acceptance `&&`→`||` in the daemon's `pixelsMatchClaimedGeometry`: exactly the one-axis-swap row failed (identity would have been stamped on incompatible geometry); same single-row failure in the TS reference.

## Turbo cache-key correctness ([known hazard class](https://github.com/kaeawc/auto-mobile/issues/4351))

The parity guard reads Kotlin/Swift test files off disk, but those trees were not `turbo.json` `test`/`test:coverage` inputs — CI could replay a cached green Bun result after a Kotlin-only golden-table change, silently skipping the drift guard. Added `android/desktop-core/src/test/kotlin/**` plus the SAME pre-existing gap for the pinch guard (`android/control-proxy/src/test/kotlin/**`, `ios/control-proxy/Tests/**`) to both tasks: the turbo hash now includes those trees, so any change there busts the cache and the parity suites actually run. The gap evaded `turboTestInputsCoverNativeSources.test.ts` because its scan only matched `android/...` path LITERALS while the parity modules build paths from `join(..., "android", ...)` segments — the lint guard now also reconstructs join-segmented paths, so the next cross-tree read cannot repeat this. All scanned relative paths are normalized to forward slashes at a single choke point (the [#4367](https://github.com/kaeawc/auto-mobile/issues/4367) Windows hazard class: backslashed relatives broke the owner-file exclusion, so the scanner self-flagged its own comment examples on windows-latest), with a deterministic win32-shape reproduction test. Known regex miss cases (nested calls, template literals, computed segments) are filed as [#4568](https://github.com/kaeawc/auto-mobile/issues/4568) (AST promotion, precedent [#3103](https://github.com/kaeawc/auto-mobile/issues/3103)); the REQUIRED_NATIVE_GLOBS layer still enforces declared globs meanwhile.

Future coverage suggestions collect in [#4569](https://github.com/kaeawc/auto-mobile/issues/4569) rather than blocking campaign PRs.

Part of [#1099](https://github.com/kaeawc/auto-mobile/issues/1099). Follow-ups: [#4548](https://github.com/kaeawc/auto-mobile/issues/4548), [#4549](https://github.com/kaeawc/auto-mobile/issues/4549), [#4550](https://github.com/kaeawc/auto-mobile/issues/4550).
