### PR TITLE
fix(daemon): validate capability probe contracts

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
@@ -782,8 +782,7 @@ data class DaemonResponse(
   val error: String? = null,
 )
 
-@Serializable
-private data class DaemonCapabilitiesResult(val capabilities: List<String> = emptyList())
+@Serializable private data class DaemonCapabilitiesResult(val capabilities: List<String>)
 
 private data class SocketIdentity(
   val path: String,

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
@@ -324,6 +324,22 @@ class McpDaemonClientInputTest {
   }
 
   @Test
+  fun `append mode rejects a successful capability probe without capabilities`() {
+    TestDaemonSocket(resultJson = "{}").use { server ->
+      val result =
+        McpDaemonClient(socketPathValue = server.socketPath.toString())
+          .inputTypeText(
+            text = "a",
+            append = true,
+          )
+
+      assertEquals(listOf("daemon/capabilities"), server.awaitRequests().map { it.method })
+      assertEquals(false, result.success)
+      assertEquals("Daemon capability probe returned an invalid result.", result.error)
+    }
+  }
+
+  @Test
   fun `input helpers reject malformed success payloads`() {
     TestDaemonSocket(resultJson = "{}", error = null).use { server ->
       assertFailsWith<SerializationException> {

--- a/docs/design-docs/mcp/daemon/unix-socket-api.md
+++ b/docs/design-docs/mcp/daemon/unix-socket-api.md
@@ -31,7 +31,10 @@ All messages are newline-delimited JSON sent over the Unix socket. Each request 
   "type": "mcp_request",
   "method": "ide/ping",
   "params": {},
-  "timeoutMs": 30000
+  "timeoutMs": 30000,
+  "clientVersion": "1.2.3",
+  "clientBuildId": "sha256:...",
+  "clientEntryScript": "/absolute/path/to/client-entry.js"
 }
 ```
 
@@ -42,6 +45,9 @@ All messages are newline-delimited JSON sent over the Unix socket. Each request 
 | `method` | `string` | Yes | Endpoint name (e.g. `ide/ping`, `daemon/availableDevices`) |
 | `params` | `object` | Yes | Method-specific parameters; pass `{}` when none are needed |
 | `timeoutMs` | `number` | No | Per-request timeout in milliseconds (default: 30 000). Long-running `tools/call` requests may be raised to a tool-specific minimum timeout by the daemon (see [Tool-specific timeout floors](#tool-specific-timeout-floors)). |
+| `clientVersion` | `string` | No | Client package/release version. Supply it to opt into version mismatch detection; clients that omit every handshake field are treated as legacy and bypass the handshake. |
+| `clientBuildId` | `string` | No | Content hash of the client entry script. TypeScript clients should supply this together with `clientEntryScript` for build-identity detection. |
+| `clientEntryScript` | `string` | No | Absolute path to the client entry script. Supply it with `clientBuildId`; Kotlin and Swift clients use `clientVersion` only. |
 
 **Response**
 

--- a/test/docs/daemonInputApiExamples.test.ts
+++ b/test/docs/daemonInputApiExamples.test.ts
@@ -204,6 +204,9 @@ describe("daemon input API consumer docs", () => {
     expect(unixSocketApi).toContain("that leaves append support unknown");
     expect(unixSocketApi).toContain("translate only the exact `input/typeText unsupported params: mode` response");
     expect(unixSocketApi).toContain("Unsupported daemon method: daemon/capabilities");
+    expect(unixSocketApi).toContain('"clientVersion": "1.2.3"');
+    expect(unixSocketApi).toContain('"clientBuildId": "sha256:..."');
+    expect(unixSocketApi).toContain('"clientEntryScript": "/absolute/path/to/client-entry.js"');
   });
 
   test("documents pressButton values that the socket actually accepts", async () => {


### PR DESCRIPTION
## Summary

Follow up on two findings from merged [PR #4557](https://github.com/kaeawc/auto-mobile/pull/4557):

- document the socket request handshake fields, including the full TypeScript build-identity pair;
- reject successful capability responses that omit `capabilities` instead of caching them as an empty list.

## Impact

Third-party capability clients can now opt into the version/build mismatch gate using the documented request schema. Malformed capability responses return an explicit invalid-result error instead of being mistaken for unsupported append mode.

## Validation

- `./gradlew :desktop-core:test --tests 'dev.jasonpearson.automobile.desktop.core.daemon.McpDaemonClientInputTest'`
- `bun test ./test/docs/daemonInputApiExamples.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run turbo:validate`
- `ONLY_TOUCHED_FILES=true scripts/ktfmt/validate_ktfmt.sh`
- `git diff --check`
