### PR TITLE
feat(daemon): publish canonical pixel geometry and convert input coordinates for iOS (#4549)

### DIFF
--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/CoordinateMappingGoldenVectorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/CoordinateMappingGoldenVectorTest.kt
@@ -21,9 +21,10 @@ import org.junit.Test
  * regions (booleans are encoded as 0/1) — the TypeScript parser extracts numbers positionally. Row
  * order must match the JSON.
  *
- * These vectors PIN CURRENT BEHAVIOR. The iOS point-space rows (flagged
- * willChangeUnderCanonicalPixels in the JSON) MUST change when #4549 converts hierarchy bounds to
- * canonical pixels; update the JSON and every consumer together in that PR.
+ * The iOS rows flagged willChangeUnderCanonicalPixels in the JSON were converted to canonical
+ * pixels in #4549 (device dimensions are now physical pixels); the mapper CODE is unchanged — it
+ * simply receives px device dims from the daemon now. Keep these literals in lockstep with the JSON
+ * (the parity suite parses them out of this source).
  */
 class CoordinateMappingGoldenVectorTest {
 
@@ -74,12 +75,13 @@ class CoordinateMappingGoldenVectorTest {
       ViewportToDeviceVector(1170f, 540f, 1f, 0f, 0f, 2340, 1080, 585f, 270f, 1170, 540, 1),
       // Degenerate zero frame width: frame-to-device ratio falls back to 1.
       ViewportToDeviceVector(0f, 0f, 1f, 0f, 0f, 1080, 2340, 12.5f, 7f, 13, 7, 1),
-      // iOS 3x device (390x844): device space is POINTS today; changes under #4549.
-      ViewportToDeviceVector(390f, 844f, 1f, 0f, 0f, 390, 844, 195f, 422f, 195, 422, 1),
-      // iOS 2x device (375x667) with fractional viewport input; changes under #4549.
-      ViewportToDeviceVector(375f, 667f, 1f, 0f, 0f, 375, 667, 100.4f, 200.6f, 100, 201, 1),
-      // iOS Display Zoom-like device (320x693 zoomed points at 3x); changes under #4549.
-      ViewportToDeviceVector(320f, 693f, 1f, 0f, 0f, 320, 693, 160f, 346.5f, 160, 347, 1),
+      // iOS 3x device (390x844): CANONICAL PIXELS (#4549) — device dims are now physical pixels
+      // (390pt x nativeScale 3 = 1170x2532), so expected outputs scale by 3.
+      ViewportToDeviceVector(390f, 844f, 1f, 0f, 0f, 1170, 2532, 195f, 422f, 585, 1266, 1),
+      // iOS 2x device (375x667) with fractional viewport input: CANONICAL PIXELS (#4549), 750x1334.
+      ViewportToDeviceVector(375f, 667f, 1f, 0f, 0f, 750, 1334, 100.4f, 200.6f, 201, 401, 1),
+      // iOS Display Zoom-like device (320x693 at 3x): CANONICAL PIXELS (#4549), 960x2079.
+      ViewportToDeviceVector(320f, 693f, 1f, 0f, 0f, 960, 2079, 160f, 346.5f, 480, 1040, 1),
       // Width-derived-ratio invariant: aspect-MISMATCHED frame (width ratio 2, height ratio
       // 4). Pins that BOTH axes scale by deviceWidth/frameWidthPx (height-derived y = 800).
       ViewportToDeviceVector(500f, 500f, 1f, 0f, 0f, 1000, 2000, 100f, 200f, 200, 400, 1),
@@ -107,8 +109,9 @@ class CoordinateMappingGoldenVectorTest {
       DeviceToViewportVector(270, 585, 540f, 1170f, 2f, 100f, 50f, 1080, 2340, 370f, 635f),
       // Degenerate zero device width: device-to-frame ratio falls back to 1.
       DeviceToViewportVector(7, 9, 540f, 1170f, 1f, 10f, 20f, 0, 2340, 17f, 29f),
-      // iOS 3x point-space inverse; changes under #4549.
-      DeviceToViewportVector(195, 422, 390f, 844f, 1f, 0f, 0f, 390, 844, 195f, 422f),
+      // iOS 3x inverse: CANONICAL PIXELS (#4549) — device dims 1170x2532, so the same device point
+      // (195,422) now in px maps back through ratio 390/1170 = 1/3 to viewport (65, 140.66667).
+      DeviceToViewportVector(195, 422, 390f, 844f, 1f, 0f, 0f, 1170, 2532, 65f, 140.66667f),
       // Width-derived-ratio invariant (inverse): aspect-MISMATCHED frame (width ratio 0.5,
       // height ratio 0.25). Pins BOTH axes scale by frameWidthPx/deviceWidth (height y = 100).
       DeviceToViewportVector(200, 400, 500f, 500f, 1f, 0f, 0f, 1000, 2000, 100f, 200f),

--- a/docs/design-docs/mcp/daemon/client-frame-snapshot.md
+++ b/docs/design-docs/mcp/daemon/client-frame-snapshot.md
@@ -21,8 +21,8 @@ several sources that update independently:
 
 | Source | Carries | Updates |
 | --- | --- | --- |
-| observation stream `screenshot_update` | pixels, reported screen size, `captureSequence` | continuously while subscribed |
-| observation stream `hierarchy_update` | element tree with `bounds`, `captureSequence` | continuously, usually debounced client-side |
+| observation stream `screenshot_update` | pixels, reported screen size, `captureSequence`, `coordinateSpace` | continuously while subscribed |
+| observation stream `hierarchy_update` | element tree with `bounds`, `captureSequence`, `coordinateSpace` | continuously, usually debounced client-side |
 | live mirror relay (optional) | decoded video frames | at the mirror's frame rate |
 | daemon connection state | transport liveness | on connect/disconnect |
 | device selection | which device the user chose | on user action |
@@ -99,8 +99,31 @@ and unit-testable without a device.
 | Both messages carry a `captureSequence` at all | Older daemons do not stamp one; control fails closed rather than guessing |
 | `now - screenshot.receivedAt <= 5000 ms` | The daemon may stop pushing without disconnecting |
 | `now - liveFrame.receivedAt <= 1000 ms` (when a live frame is displayed) | **Recency** — this is what catches the stalled mirror |
-| Displayed **screenshot** and mapping bounds agree in aspect (rotation-tolerant) | A screenshot may be a downscale, and iOS reports pixels against point-space bounds |
+| Displayed **screenshot** and mapping bounds agree in aspect (rotation-tolerant) | A screenshot may be a downscale, and a legacy (no `coordinateSpace`) frame reports iOS pixels against point-space bounds — see [Coordinate space](#coordinate-space-canonical-pixels) |
 | Displayed **live mirror frame** matches the mapping bounds EXACTLY | See below — an aspect check would accept a scale change |
+
+### Coordinate space: canonical pixels
+
+Every geometry-bearing message declares its coordinate space with a
+`coordinateSpace` field. `"px"` means the message's element `bounds` and screen
+`screenWidth`/`screenHeight` are **canonical physical pixels** — the daemon
+converted the runner's logical points using the runner-reported `nativeScale`
+(issue [#4548](https://github.com/kaeawc/auto-mobile/issues/4548)), so a screenshot
+and the hierarchy that describes it share one unit and compare **exactly** (the
+rotation W/H swap for native-portrait screenshots is still accepted). Android
+bounds are already physical pixels (`nativeScale` 1), so it declares `"px"` too.
+
+The field is **absent** when the runner supplied no scale metadata (a pre-#4548
+runner). That is the **legacy fallback**: `bounds` stay in logical points while
+the screenshot is pixels — the mixed-unit state that predates canonical pixels —
+and a client keeps its aspect-only (±tolerance) geometry check. A client that
+sees no `coordinateSpace` must not assume pixels; a client that sees `"px"` can
+compare absolute dimensions exactly. On the input side, a client that renders a
+`"px"` frame sends `input/*` coordinates in **pixels**; the daemon divides by
+`nativeScale` before dispatching to the iOS runner (which addresses the screen in
+points), so the physical tap location is unchanged. (The desktop client's
+migration to exact px checks is issue
+[#4550](https://github.com/kaeawc/auto-mobile/issues/4550); #4549 ships the field.)
 
 ### Pairing is identity, never elapsed time
 

--- a/docs/design-docs/mcp/daemon/client-frame-snapshot.md
+++ b/docs/design-docs/mcp/daemon/client-frame-snapshot.md
@@ -120,8 +120,9 @@ and a client keeps its aspect-only (±tolerance) geometry check. A client that
 sees no `coordinateSpace` must not assume pixels; a client that sees `"px"` can
 compare absolute dimensions exactly. On the input side, a client that renders a
 `"px"` frame sends `input/*` coordinates in **pixels**; the daemon divides by
-`nativeScale` before dispatching to the iOS runner (which addresses the screen in
-points), so the physical tap location is unchanged. (The desktop client's
+`nativeScale` (an exact fractional quotient — the runner takes `Double` points)
+before dispatching to the iOS runner, so the physical tap location is unchanged.
+(The desktop client's
 migration to exact px checks is issue
 [#4550](https://github.com/kaeawc/auto-mobile/issues/4550); #4549 ships the field.)
 

--- a/docs/design-docs/mcp/daemon/unix-socket-api.md
+++ b/docs/design-docs/mcp/daemon/unix-socket-api.md
@@ -311,6 +311,25 @@ they return the action result only. Callers that need post-input state should
 call `observe` through the MCP proxy or subscribe to the observation stream after
 the input response returns.
 
+#### Coordinate space (canonical pixels)
+
+Coordinates are **canonical physical pixels** in the current device orientation —
+the same space the observation stream publishes element `bounds` and screen
+dimensions in when a message carries `coordinateSpace: "px"` (issue
+[#4549](https://github.com/kaeawc/auto-mobile/issues/4549)). A client maps a tap
+from the frame it is rendering straight into these `input/*` coordinates with no
+unit conversion of its own.
+
+The daemon performs any runner-specific conversion internally: the iOS XCUITest
+runner addresses the screen in **logical points**, so for iOS the daemon divides
+each incoming pixel coordinate by the runner-reported `nativeScale` (round-half-
+even) before dispatch. Android runners already take physical pixels, so nothing
+is converted. If the iOS runner supplied no scale metadata (a pre-#4548 runner,
+so its frames were never published as `coordinateSpace: "px"`), the daemon leaves
+the coordinates untouched — the legacy point-space fallback, in which the client
+was already working in points. See
+[Client Frame Snapshot: coordinate space](client-frame-snapshot.md#coordinate-space-canonical-pixels).
+
 ### Implementation status
 
 | Method | Android | iOS | Notes |

--- a/docs/design-docs/mcp/daemon/unix-socket-api.md
+++ b/docs/design-docs/mcp/daemon/unix-socket-api.md
@@ -322,12 +322,17 @@ unit conversion of its own.
 
 The daemon performs any runner-specific conversion internally: the iOS XCUITest
 runner addresses the screen in **logical points**, so for iOS the daemon divides
-each incoming pixel coordinate by the runner-reported `nativeScale` (round-half-
-even) before dispatch. Android runners already take physical pixels, so nothing
-is converted. If the iOS runner supplied no scale metadata (a pre-#4548 runner,
-so its frames were never published as `coordinateSpace: "px"`), the daemon leaves
-the coordinates untouched — the legacy point-space fallback, in which the client
-was already working in points. See
+each incoming pixel coordinate by the runner-reported `nativeScale` before
+dispatch. That divide is an **exact fractional quotient** — it is NOT rounded —
+because XCUITest accepts fractional (`Double`) points and quantizing would discard
+sub-point precision. (Round-half-even applies only on the publish side, where
+points are converted to integer physical pixels; the input divide is its exact
+inverse, so the round-trip carries only that single publish-side quantization.)
+Android runners already take physical pixels, so nothing is converted. If the iOS
+runner supplied no scale metadata (a pre-#4548 runner, so its frames were never
+published as `coordinateSpace: "px"`), the daemon leaves the coordinates
+untouched — the legacy point-space fallback, in which the client was already
+working in points. See
 [Client Frame Snapshot: coordinate space](client-frame-snapshot.md#coordinate-space-canonical-pixels).
 
 ### Implementation status

--- a/src/daemon/canonicalPixels.ts
+++ b/src/daemon/canonicalPixels.ts
@@ -136,15 +136,16 @@ function scaleWindowBounds(window: ViewHierarchyWindowInfo, nativeScale: number)
 }
 
 /**
- * Scale EVERY bounds-bearing field a hierarchy result carries to the wire, so a message stamped
+ * Scale EVERY geometry field a hierarchy result carries to the wire, so a message stamped
  * `coordinateSpace:"px"` is entirely pixels — no field is left in points. Enumerated from
  * `CtrlProxyHierarchy.convertToViewHierarchyResult` (iOS) and the Android converter: the root node
  * tree, the iOS root `hierarchy.bounds`, each `windows[*]` frame bounds and its nested node tree,
- * `contentHiddenRegions[*].bounds`, and the `accessibility-focused-element` node.
+ * `contentHiddenRegions[*].bounds`, the `accessibility-focused-element` node, and the `systemInsets`
+ * alias (a compatibility field with NO units discriminator, so it must follow `coordinateSpace`).
  *
- * NOT scaled here: `insets` / `systemInsets`. `ObservationInsets` carries its own `units` field
- * ("points" | "physical-pixels"), so it is self-describing independent of `coordinateSpace`; those
- * are inset offsets, not element bounds, and stay as the runner reported them.
+ * NOT scaled: the typed `insets` (`ObservationInsets`). It carries its own `units` field
+ * ("points" | "physical-pixels"), so it is self-describing independent of `coordinateSpace` and
+ * stays exactly as the runner reported it.
  */
 function scaleAllBounds(hierarchy: ViewHierarchyResult, nativeScale: number): void {
   if (hierarchy.hierarchy?.node) {
@@ -169,6 +170,19 @@ function scaleAllBounds(hierarchy: ViewHierarchyResult, nativeScale: number): vo
       if (regionBounds) {
         scaleBoundsInPlace(regionBounds, nativeScale);
       }
+    }
+  }
+  if (hierarchy.systemInsets) {
+    scaleEdgeInsetsInPlace(hierarchy.systemInsets, nativeScale);
+  }
+}
+
+/** Scale a `{top,right,bottom,left}` inset alias in place by `nativeScale`, round-half-even. */
+function scaleEdgeInsetsInPlace(insets: Record<string, unknown>, nativeScale: number): void {
+  for (const edge of ["top", "right", "bottom", "left"]) {
+    const value = insets[edge];
+    if (typeof value === "number") {
+      insets[edge] = roundHalfEven(value * nativeScale);
     }
   }
 }

--- a/src/daemon/canonicalPixels.ts
+++ b/src/daemon/canonicalPixels.ts
@@ -1,0 +1,201 @@
+/**
+ * Canonical-pixel conversion for the observation-stream wire (issue #4549, B2 of the
+ * canonical-pixel campaign #4547 -> #4548 -> #4549 -> #4550).
+ *
+ * The daemon publishes iOS hierarchy element bounds and screen dimensions in canonical PHYSICAL
+ * pixels — converted from the runner's logical points via the runner-reported `nativeScale`
+ * (#4548's `ScreenScaleMetadata`, NOT the old `screenScale`). Android bounds are already physical
+ * pixels (nativeScale === 1), so its conversion is the numeric identity; both platforms declare the
+ * space with `coordinateSpace: "px"`.
+ *
+ * The change is DECLARED, never silent: a message carries `coordinateSpace: "px"` only when the
+ * runner supplied complete scale metadata. A hierarchy from a pre-#4548 runner has no metadata, is
+ * left untouched (point-space), and is NOT stamped — so old runners and new daemons degrade to
+ * exactly today's semantics (the legacy fallback #4550 keys its aspect-only tolerance on).
+ *
+ * Rounding is round-half-even (banker's rounding) so the point -> pixel -> point round-trip the
+ * input path performs (`input/*` divides by nativeScale for the XCUITest runner, which wants
+ * points) lands back within the same point at .5 boundaries instead of biasing away from zero.
+ */
+import type { ScreenScaleMetadata } from "../models/ScreenScaleMetadata";
+import type {
+  ViewHierarchyNode,
+  ViewHierarchyResult,
+  ViewHierarchyWindowInfo,
+  ContentHiddenRegion,
+} from "../models/ViewHierarchyResult";
+
+/** The wire field value declaring a message's coordinates are canonical physical pixels. */
+export const COORDINATE_SPACE_PX = "px" as const;
+
+/** Coordinate space a geometry-bearing message is expressed in. Absent === legacy point-space. */
+export type CoordinateSpace = typeof COORDINATE_SPACE_PX;
+
+/**
+ * Round to the nearest integer, ties to even (banker's rounding). Unlike `Math.round` (ties toward
+ * +Infinity) this is symmetric about zero, so converting a coordinate to pixels and back to points
+ * cannot accumulate a directional bias at exact half-values — the property the round-trip goldens
+ * pin. `-0` is normalized to `0`.
+ */
+export function roundHalfEven(value: number): number {
+  if (!Number.isFinite(value)) {
+    return value;
+  }
+  const floor = Math.floor(value);
+  const remainder = value - floor;
+  let result: number;
+  if (remainder < 0.5) {
+    result = floor;
+  } else if (remainder > 0.5) {
+    result = floor + 1;
+  } else {
+    // Exactly halfway: pick the even neighbour.
+    result = floor % 2 === 0 ? floor : floor + 1;
+  }
+  return result === 0 ? 0 : result;
+}
+
+/**
+ * Convert a canonical-pixel coordinate back to the runner's logical points by dividing out
+ * `nativeScale`. Used by the `input/*` handlers before dispatching to the iOS XCUITest runner,
+ * which addresses the screen in points. A `nativeScale` of 1 (Android, or a non-positive/degenerate
+ * value) is the identity, so a caller can apply this unconditionally.
+ *
+ * The quotient is EXACT — deliberately NOT rounded. The iOS request models and gesture engine
+ * accept fractional `Double` points (they feed `CGVector`), so quantizing here would discard
+ * sub-point precision (401px @ 2x is 200.5pt, not 200; 1px @ 3x is 0.333pt, not 0) and would add a
+ * second rounding to the point->pixel->point round-trip. Pixels are already integer coordinates
+ * (round-half-even on the publish/multiply side); keeping the divide exact means the round-trip
+ * carries only the single publish-side quantization.
+ */
+export function canonicalPixelsToPoints(pixels: number, nativeScale: number): number {
+  if (!Number.isFinite(nativeScale) || nativeScale <= 0 || nativeScale === 1) {
+    return pixels;
+  }
+  return pixels / nativeScale;
+}
+
+const BOUNDS_EDGES = ["left", "top", "right", "bottom"] as const;
+
+/** Scale one bounds object in place by `nativeScale`, round-half-even. Non-numeric edges are left. */
+function scaleBoundsInPlace(bounds: Record<string, unknown>, nativeScale: number): void {
+  for (const edge of BOUNDS_EDGES) {
+    const value = bounds[edge];
+    if (typeof value === "number") {
+      bounds[edge] = roundHalfEven(value * nativeScale);
+    }
+  }
+}
+
+/**
+ * An object-form bounds ({left,top,right,bottom} with at least one numeric edge), returned as a
+ * mutable record. iOS element bounds ride the wire as this object under `node.$.bounds`; the
+ * string/array forms some Android capture sources use are left untouched (Android is
+ * nativeScale === 1, so its conversion is the identity and there is nothing to scale).
+ */
+function asScalableBounds(value: unknown): Record<string, unknown> | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const candidate = value as Record<string, unknown>;
+  const hasNumericEdge = BOUNDS_EDGES.some(edge => typeof candidate[edge] === "number");
+  return hasNumericEdge ? candidate : null;
+}
+
+/** Scale a node's bounds (both the typed `bounds` and the `$.bounds` attribute forms) in place. */
+function scaleNodeBounds(node: ViewHierarchyNode, nativeScale: number): void {
+  const typed = asScalableBounds(node.bounds);
+  if (typed) {
+    scaleBoundsInPlace(typed, nativeScale);
+  }
+  const attr = node.$ ? asScalableBounds(node.$["bounds"]) : null;
+  if (attr) {
+    scaleBoundsInPlace(attr, nativeScale);
+  }
+}
+
+/** Depth-first scale every node's bounds under [node] in place. */
+function scaleTreeBounds(node: ViewHierarchyNode, nativeScale: number): void {
+  scaleNodeBounds(node, nativeScale);
+  if (node.node) {
+    for (const child of node.node) {
+      scaleTreeBounds(child, nativeScale);
+    }
+  }
+}
+
+/** Scale a `windows[*]` entry: its own frame bounds plus the node tree it nests. */
+function scaleWindowBounds(window: ViewHierarchyWindowInfo, nativeScale: number): void {
+  const windowBounds = asScalableBounds(window.bounds);
+  if (windowBounds) {
+    scaleBoundsInPlace(windowBounds, nativeScale);
+  }
+  if (window.hierarchy) {
+    scaleTreeBounds(window.hierarchy, nativeScale);
+  }
+}
+
+/**
+ * Scale EVERY bounds-bearing field a hierarchy result carries to the wire, so a message stamped
+ * `coordinateSpace:"px"` is entirely pixels — no field is left in points. Enumerated from
+ * `CtrlProxyHierarchy.convertToViewHierarchyResult` (iOS) and the Android converter: the root node
+ * tree, the iOS root `hierarchy.bounds`, each `windows[*]` frame bounds and its nested node tree,
+ * `contentHiddenRegions[*].bounds`, and the `accessibility-focused-element` node.
+ *
+ * NOT scaled here: `insets` / `systemInsets`. `ObservationInsets` carries its own `units` field
+ * ("points" | "physical-pixels"), so it is self-describing independent of `coordinateSpace`; those
+ * are inset offsets, not element bounds, and stay as the runner reported them.
+ */
+function scaleAllBounds(hierarchy: ViewHierarchyResult, nativeScale: number): void {
+  if (hierarchy.hierarchy?.node) {
+    scaleTreeBounds(hierarchy.hierarchy.node, nativeScale);
+  }
+  const rootBounds = asScalableBounds(hierarchy.hierarchy?.bounds);
+  if (rootBounds) {
+    scaleBoundsInPlace(rootBounds, nativeScale);
+  }
+  const focused = hierarchy["accessibility-focused-element"];
+  if (focused) {
+    scaleTreeBounds(focused, nativeScale);
+  }
+  if (hierarchy.windows) {
+    for (const window of hierarchy.windows) {
+      scaleWindowBounds(window, nativeScale);
+    }
+  }
+  if (hierarchy.contentHiddenRegions) {
+    for (const region of hierarchy.contentHiddenRegions as ContentHiddenRegion[]) {
+      const regionBounds = asScalableBounds(region.bounds);
+      if (regionBounds) {
+        scaleBoundsInPlace(regionBounds, nativeScale);
+      }
+    }
+  }
+}
+
+/**
+ * Convert a hierarchy result to canonical pixels IN PLACE using runner scale metadata: every
+ * element bound and the screen dimensions become physical pixels. Screen dimensions adopt the
+ * runner-reported `pixelWidth`/`pixelHeight` directly (the runner already derived them at native
+ * scale in #4548), so the daemon no longer multiplies points by a screen scale for them. Element
+ * bounds — which the runner reports per-node in points — are scaled by `nativeScale`.
+ *
+ * Callers MUST pass a hierarchy they own (e.g. the diff clone the observation stream pushes), never
+ * a shared instance: MCP `observe` continues to serve point-space bounds. Idempotence is NOT
+ * guaranteed; convert once.
+ */
+export function convertHierarchyToCanonicalPixels(
+  hierarchy: ViewHierarchyResult,
+  metadata: ScreenScaleMetadata
+): void {
+  const { nativeScale, pixelWidth, pixelHeight } = metadata;
+
+  hierarchy.screenWidth = pixelWidth;
+  hierarchy.screenHeight = pixelHeight;
+
+  // Android bounds are already physical pixels (nativeScale === 1): the screen dims above suffice
+  // and scaling by 1 is a no-op, so skip the walk entirely.
+  if (nativeScale !== 1) {
+    scaleAllBounds(hierarchy, nativeScale);
+  }
+}

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -12,6 +12,12 @@ import { DEVICE_DATA_STREAM_SOCKET_CONFIG } from "./daemonFiles";
 import type { ScreenshotMetadata } from "../features/observe/ScreenshotMetadata";
 import { annotateHierarchyDiff, type HierarchyDiffSummary } from "./hierarchyStreamDiff";
 import { readImageHeaderDimensions } from "../utils/screenshot/imageHeaderDimensions";
+import { readScreenScaleMetadata } from "../models/ScreenScaleMetadata";
+import {
+  COORDINATE_SPACE_PX,
+  convertHierarchyToCanonicalPixels,
+  type CoordinateSpace,
+} from "./canonicalPixels";
 
 /**
  * Navigation graph summary for streaming to IDE plugins.
@@ -114,6 +120,13 @@ interface DeviceDataStreamMessage extends ScreenshotMetadata {
    * instant the geometry does, at any delta.
    */
   captureSequence?: number;
+  /**
+   * Coordinate space of this message's geometry (element bounds, screen dimensions) — `"px"` for
+   * canonical physical pixels (issue #4549). Present only when the runner supplied complete scale
+   * metadata; ABSENT means legacy point-space, so a control client (and #4550's exact geometry
+   * checks) can tell converted frames from a pre-#4548 runner's and fall back accordingly.
+   */
+  coordinateSpace?: CoordinateSpace;
 }
 
 /**
@@ -164,6 +177,13 @@ interface PushScreenshotOptions {
    * fails closed instead of pairing them with an unrelated hierarchy.
    */
   captureSequence?: number;
+  /**
+   * Set to `"px"` when the caller's device is publishing canonical physical pixels (issue #4549) —
+   * i.e. the runner supplied complete scale metadata. Stamps `coordinateSpace: "px"` on the
+   * screenshot so a control client reads the published `screenWidth`/`screenHeight` as pixels;
+   * omitted for a pre-#4548 runner, keeping the frame legacy point-space.
+   */
+  coordinateSpace?: CoordinateSpace;
 }
 
 /**
@@ -334,7 +354,17 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
     // as the next baseline.
     const previous = this.previousHierarchyByDevice.get(deviceId) ?? null;
     const { hierarchy: annotated, summary } = annotateHierarchyDiff(previous, hierarchy);
+    // Baseline the UN-annotated, UN-converted original so the next frame's diff is computed in the
+    // same (point) space the runner reports — the diff must not see the canonical-pixel rewrite.
     this.previousHierarchyByDevice.set(deviceId, hierarchy);
+
+    // Convert to canonical pixels on the clone we own (never the caller's hierarchy or the baseline,
+    // so MCP observe keeps serving point-space bounds). Only when the runner supplied complete scale
+    // metadata; otherwise the frame stays point-space and is not stamped (legacy fallback).
+    const scaleMetadata = readScreenScaleMetadata(hierarchy);
+    if (scaleMetadata) {
+      convertHierarchyToCanonicalPixels(annotated, scaleMetadata);
+    }
 
     // Assign this capture's shared identity and RETURN it, so the caller can bind it to the
     // screenshot requests it initiates while this hierarchy is current.
@@ -350,6 +380,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       data: annotated,
       hierarchyDiff: summary,
       captureSequence,
+      ...(scaleMetadata ? { coordinateSpace: COORDINATE_SPACE_PX } : {}),
     };
 
     const sentCount = this.pushToSubscribers({ message, targetDeviceId: deviceId });
@@ -408,6 +439,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
       // other case the field is omitted and the control client fails closed rather than pairing
       // against mapping bounds that may not describe these pixels.
       captureSequence: claimMatchesPixels ? options.captureSequence : undefined,
+      ...(options.coordinateSpace ? { coordinateSpace: options.coordinateSpace } : {}),
       screenshotMimeType,
       screenshotFormat,
       screenshotCaptureSource,

--- a/src/daemon/observationInitialFrame.ts
+++ b/src/daemon/observationInitialFrame.ts
@@ -17,6 +17,8 @@ import {
   metadataForScreenshotFormat,
   pickScreenshotMetadata,
 } from "../features/observe/ScreenshotMetadata";
+import { readScreenScaleMetadata } from "../models/ScreenScaleMetadata";
+import { COORDINATE_SPACE_PX } from "./canonicalPixels";
 
 const INITIAL_FRAME_HIERARCHY_TIMEOUT_MS = 3_000;
 const INITIAL_FRAME_SCREENSHOT_TIMEOUT_MS = 3_000;
@@ -152,9 +154,21 @@ async function pushAndroidInitialScreenshot(
       screenshot.data,
       dimensions.width,
       dimensions.height,
-      pickScreenshotMetadata(screenshot)
+      pickScreenshotMetadata(screenshot),
+      canonicalPixelScreenshotOptions(viewHierarchy)
     );
   }
+}
+
+/**
+ * Declare `coordinateSpace: "px"` on the screenshot when — and only when — the runner supplied
+ * complete scale metadata (#4549), matching the stamp `pushHierarchyUpdate` applies to the paired
+ * hierarchy. A pre-#4548 runner has no metadata, so the frame stays legacy point-space.
+ */
+function canonicalPixelScreenshotOptions(
+  hierarchy: ViewHierarchyResult
+): { coordinateSpace: typeof COORDINATE_SPACE_PX } | Record<string, never> {
+  return readScreenScaleMetadata(hierarchy) ? { coordinateSpace: COORDINATE_SPACE_PX } : {};
 }
 
 async function getAndroidInitialHierarchy(
@@ -209,7 +223,8 @@ async function pushIosInitialObservationFrame(
       screenshot.data,
       dimensions.width,
       dimensions.height,
-      metadataForScreenshotFormat(IOS_CTRLPROXY_SCREENSHOT_METADATA, screenshot.format)
+      metadataForScreenshotFormat(IOS_CTRLPROXY_SCREENSHOT_METADATA, screenshot.format),
+      canonicalPixelScreenshotOptions(viewHierarchy)
     );
   }
 }
@@ -244,6 +259,14 @@ function getAndroidScreenshotDimensions(hierarchy: ViewHierarchyResult): { width
 }
 
 function getIosScreenshotDimensions(hierarchy: ViewHierarchyResult): { width: number; height: number } {
+  // Canonical pixels (#4549): when the runner supplied complete scale metadata, the physical
+  // screenshot pixel dimensions are the runner-reported `pixelWidth`/`pixelHeight` — the daemon no
+  // longer multiplies points by a screen scale for them. A pre-#4548 runner has no metadata, so
+  // fall back to the legacy `round(points * screenScale)` claim, byte-identical to before.
+  const metadata = readScreenScaleMetadata(hierarchy);
+  if (metadata) {
+    return { width: metadata.pixelWidth, height: metadata.pixelHeight };
+  }
   const scale = hierarchy.screenScale ?? 1;
   return {
     width: hierarchy.screenWidth ? Math.round(hierarchy.screenWidth * scale) : IOS_DEFAULT_SCREEN_WIDTH,

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -63,6 +63,7 @@ import {
   type InputKeyName,
 } from "../features/action/InputKey";
 import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
+import { canonicalPixelsToPoints } from "./canonicalPixels";
 import type { KeyValueType } from "../features/storage/storageTypes";
 import type { BootedDevice, ImeAction } from "../models";
 import type { DeviceService } from "../features/observe/DeviceService";
@@ -876,6 +877,39 @@ export class UnixSocketServer {
     }
   }
 
+  /**
+   * Convert incoming `input/*` coordinates to the units the iOS XCUITest runner expects (points).
+   *
+   * A control client that renders a canonical-pixel observation frame (#4549) sends taps/swipes in
+   * PIXELS, so divide by the runner-reported `nativeScale` before dispatch — the inverse of the
+   * daemon's publish-side point->pixel conversion, so the tap lands at the same physical location.
+   * The divide is EXACT (fractional points; XCUITest accepts them), so the round-trip carries only
+   * the single publish-side quantization.
+   *
+   * The scale metadata is populated by #4548 on hierarchy RECEIPT, which has not happened yet if a
+   * control client sends its first input before the daemon has received any hierarchy for this
+   * device — dispatching those pixels as points would land a 3x tap at 1/3 scale. So when the
+   * metadata is null we fetch one hierarchy first (no observation-stream push) to populate it, then
+   * decide. If it is STILL null (a pre-#4548 legacy runner), the control client never received px
+   * bounds either, so it is sending point-space coordinates and we pass them through unchanged.
+   */
+  private async toIosRunnerCoordinates(
+    client: IOSCtrlProxyClient,
+    coordinates: number[],
+    timeoutMs: number
+  ): Promise<number[]> {
+    let nativeScale = client.getScreenScaleMetadata()?.nativeScale;
+    if (nativeScale === undefined) {
+      await client.requestHierarchySyncWithoutObservationStreamPush(undefined, false, undefined, timeoutMs);
+      nativeScale = client.getScreenScaleMetadata()?.nativeScale;
+    }
+    if (nativeScale === undefined) {
+      return coordinates;
+    }
+    const scale = nativeScale;
+    return coordinates.map(coordinate => canonicalPixelsToPoints(coordinate, scale));
+  }
+
   private async handleInputTap(
     request: DaemonRequest,
     socketSessionId?: string
@@ -901,13 +935,14 @@ export class UnixSocketServer {
         });
       }
 
-      return args.platform === "android"
-        ? await AndroidCtrlProxyClient
+      if (args.platform === "android") {
+        return await AndroidCtrlProxyClient
           .getInstance(targetDevice, defaultAdbClientFactory)
-          .requestTapCoordinates(args.x, args.y, args.duration, remainingTimeoutMs)
-        : await IOSCtrlProxyClient
-          .getInstance(targetDevice)
           .requestTapCoordinates(args.x, args.y, args.duration, remainingTimeoutMs);
+      }
+      const iosClient = IOSCtrlProxyClient.getInstance(targetDevice);
+      const [x, y] = await this.toIosRunnerCoordinates(iosClient, [args.x, args.y], remainingTimeoutMs);
+      return await iosClient.requestTapCoordinates(x, y, args.duration, remainingTimeoutMs);
     });
 
     if (!gestureResult.success) {
@@ -948,13 +983,18 @@ export class UnixSocketServer {
         });
       }
 
-      return args.platform === "android"
-        ? await AndroidCtrlProxyClient
+      if (args.platform === "android") {
+        return await AndroidCtrlProxyClient
           .getInstance(targetDevice, defaultAdbClientFactory)
-          .requestSwipe(args.startX, args.startY, args.endX, args.endY, args.durationMs, remainingTimeoutMs)
-        : await IOSCtrlProxyClient
-          .getInstance(targetDevice)
-          .requestDrag(args.startX, args.startY, args.endX, args.endY, 0, args.durationMs, 0, remainingTimeoutMs);
+          .requestSwipe(args.startX, args.startY, args.endX, args.endY, args.durationMs, remainingTimeoutMs);
+      }
+      const iosClient = IOSCtrlProxyClient.getInstance(targetDevice);
+      const [startX, startY, endX, endY] = await this.toIosRunnerCoordinates(
+        iosClient,
+        [args.startX, args.startY, args.endX, args.endY],
+        remainingTimeoutMs
+      );
+      return await iosClient.requestDrag(startX, startY, endX, endY, 0, args.durationMs, 0, remainingTimeoutMs);
     });
 
     if (!gestureResult.success) {

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -64,6 +64,7 @@ import {
 } from "../features/action/InputKey";
 import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
 import { canonicalPixelsToPoints } from "./canonicalPixels";
+import { ActionableError, toActionableError } from "../models/ActionableError";
 import type { KeyValueType } from "../features/storage/storageTypes";
 import type { BootedDevice, ImeAction } from "../models";
 import type { DeviceService } from "../features/observe/DeviceService";
@@ -180,6 +181,14 @@ export class UnixSocketServer {
    * same id with a different image re-probes rather than trusting a stale API level.
    */
   private appendTextInputs: Map<string, CachedAppendTextInput> = new Map();
+
+  /**
+   * Device ids whose iOS runner a scale probe CONFIRMED report no scale metadata (a genuine
+   * pre-#4548 runner). Cached so subsequent legacy taps skip the hierarchy-sync round trip (#4549).
+   * A probe FAILURE is never cached (it must re-probe); the entry is dropped the moment metadata
+   * appears, so a runner upgrade is not pinned to the stale legacy verdict.
+   */
+  private confirmedLegacyScaleDevices: Set<string> = new Set();
 
   constructor(
     socketPath: string = SOCKET_PATH,
@@ -889,25 +898,88 @@ export class UnixSocketServer {
    * The scale metadata is populated by #4548 on hierarchy RECEIPT, which has not happened yet if a
    * control client sends its first input before the daemon has received any hierarchy for this
    * device — dispatching those pixels as points would land a 3x tap at 1/3 scale. So when the
-   * metadata is null we fetch one hierarchy first (no observation-stream push) to populate it, then
-   * decide. If it is STILL null (a pre-#4548 legacy runner), the control client never received px
-   * bounds either, so it is sending point-space coordinates and we pass them through unchanged.
+   * metadata is null we fetch one hierarchy first (no observation-stream push, bounded by
+   * `probeTimeoutMs`) to populate it, then decide:
+   *  - probe FAILS (throws, or returns no hierarchy — not connected / timed out): fail closed with
+   *    an actionable error rather than mis-dispatching; do NOT cache (the next input re-probes).
+   *  - probe SUCCEEDS but the runner carries no metadata: a genuine pre-#4548 legacy runner, whose
+   *    control client sends point-space coordinates — pass through, and cache the verdict so
+   *    subsequent legacy taps skip the round trip. The cache entry is dropped the moment metadata
+   *    appears, so a runner upgrade is not pinned to the legacy verdict.
+   *
+   * The caller must charge the probe's elapsed time against the gesture budget (recompute the
+   * remaining timeout after this resolves) so probe + gesture never exceed one request budget.
    */
+  /**
+   * The gesture budget remaining after the iOS scale probe (if any) ran, charging its elapsed
+   * wall-time against the request's total budget so probe + gesture never exceed one budget (#3351).
+   * Throws a timeout when the probe already consumed the budget, rather than starting a full-budget
+   * gesture on top of it. On the common path (metadata already known) the probe is synchronous, so
+   * the elapsed time is just the queue wait and this returns ~the full remaining budget.
+   */
+  private remainingBudgetAfterProbe(
+    queueEnterMs: number,
+    totalTimeoutMs: number,
+    toolName: string,
+    origin: string
+  ): number {
+    const remaining = totalTimeoutMs - (this.timer.now() - queueEnterMs);
+    if (remaining <= 0) {
+      throw new McpTimeoutError({
+        toolName,
+        timeoutMs: totalTimeoutMs,
+        origin: `UnixSocketServer.${origin}`,
+        detail: "iOS screen-scale probe consumed the request budget",
+      });
+    }
+    return remaining;
+  }
+
   private async toIosRunnerCoordinates(
     client: IOSCtrlProxyClient,
+    deviceId: string,
     coordinates: number[],
-    timeoutMs: number
+    probeTimeoutMs: number
   ): Promise<number[]> {
-    let nativeScale = client.getScreenScaleMetadata()?.nativeScale;
-    if (nativeScale === undefined) {
-      await client.requestHierarchySyncWithoutObservationStreamPush(undefined, false, undefined, timeoutMs);
-      nativeScale = client.getScreenScaleMetadata()?.nativeScale;
+    const knownScale = client.getScreenScaleMetadata()?.nativeScale;
+    if (knownScale !== undefined) {
+      // Metadata present: a runner upgrade drops any stale confirmed-legacy verdict for this device.
+      this.confirmedLegacyScaleDevices.delete(deviceId);
+      return coordinates.map(coordinate => canonicalPixelsToPoints(coordinate, knownScale));
     }
-    if (nativeScale === undefined) {
+    if (this.confirmedLegacyScaleDevices.has(deviceId)) {
+      // A prior probe SUCCEEDED with no metadata: a confirmed legacy runner. Skip the round trip.
       return coordinates;
     }
-    const scale = nativeScale;
-    return coordinates.map(coordinate => canonicalPixelsToPoints(coordinate, scale));
+
+    // Startup window: no hierarchy received yet, so #4548 receipt-based retention has not run. Fetch
+    // one (without an observation-stream push) so the scale is known before we decide the space.
+    let probed: unknown;
+    try {
+      probed = await client.requestHierarchySyncWithoutObservationStreamPush(undefined, false, undefined, probeTimeoutMs);
+    } catch (error) {
+      // Probe threw: a transient failure, NOT evidence of a legacy runner. Fail closed rather than
+      // mis-dispatching pixels as points.
+      throw toActionableError(error, `Could not determine iOS screen scale for ${deviceId}; the input coordinate scale probe failed`);
+    }
+    if (!probed) {
+      // Probe returned no hierarchy (not connected / timed out): a FAILURE, distinct from a runner
+      // that answered with no metadata. Fail closed and do NOT cache — the next input re-probes.
+      throw new ActionableError(
+        `Could not determine iOS screen scale for ${deviceId}: the hierarchy probe returned no data. ` +
+        `Retry once the device has produced a hierarchy.`
+      );
+    }
+
+    const probedScale = client.getScreenScaleMetadata()?.nativeScale;
+    if (probedScale === undefined) {
+      // Probe SUCCEEDED but the runner reported no scale metadata: a genuine pre-#4548 legacy
+      // runner. The control client never received px bounds, so it sends points — pass through, and
+      // cache the verdict so subsequent legacy taps skip the probe.
+      this.confirmedLegacyScaleDevices.add(deviceId);
+      return coordinates;
+    }
+    return coordinates.map(coordinate => canonicalPixelsToPoints(coordinate, probedScale));
   }
 
   private async handleInputTap(
@@ -941,8 +1013,14 @@ export class UnixSocketServer {
           .requestTapCoordinates(args.x, args.y, args.duration, remainingTimeoutMs);
       }
       const iosClient = IOSCtrlProxyClient.getInstance(targetDevice);
-      const [x, y] = await this.toIosRunnerCoordinates(iosClient, [args.x, args.y], remainingTimeoutMs);
-      return await iosClient.requestTapCoordinates(x, y, args.duration, remainingTimeoutMs);
+      const [x, y] = await this.toIosRunnerCoordinates(
+        iosClient,
+        targetDevice.deviceId,
+        [args.x, args.y],
+        remainingTimeoutMs
+      );
+      const gestureTimeoutMs = this.remainingBudgetAfterProbe(queueEnterMs, totalTimeoutMs, request.method, "handleInputTap");
+      return await iosClient.requestTapCoordinates(x, y, args.duration, gestureTimeoutMs);
     });
 
     if (!gestureResult.success) {
@@ -991,10 +1069,12 @@ export class UnixSocketServer {
       const iosClient = IOSCtrlProxyClient.getInstance(targetDevice);
       const [startX, startY, endX, endY] = await this.toIosRunnerCoordinates(
         iosClient,
+        targetDevice.deviceId,
         [args.startX, args.startY, args.endX, args.endY],
         remainingTimeoutMs
       );
-      return await iosClient.requestDrag(startX, startY, endX, endY, 0, args.durationMs, 0, remainingTimeoutMs);
+      const gestureTimeoutMs = this.remainingBudgetAfterProbe(queueEnterMs, totalTimeoutMs, request.method, "handleInputSwipe");
+      return await iosClient.requestDrag(startX, startY, endX, endY, 0, args.durationMs, 0, gestureTimeoutMs);
     });
 
     if (!gestureResult.success) {

--- a/src/features/observe/TrackedScreenGeometry.ts
+++ b/src/features/observe/TrackedScreenGeometry.ts
@@ -17,19 +17,47 @@
  * Both the Android and iOS clients own one of these, so the rule is identical on both platforms by
  * construction rather than by two parallel implementations agreeing.
  */
+import type { CoordinateSpace } from "../../daemon/canonicalPixels";
+
 /**
  * The geometry and capture identity a screenshot request was initiated under. Captured at
  * request-send time and used when the response is pushed, so an intervening hierarchy cannot
  * relabel the in-flight frame with a capture it does not belong to.
+ *
+ * `coordinateSpace` travels with the binding for the same reason as the dimensions (#4549): whether
+ * this frame's geometry is canonical pixels is fixed the moment the request is initiated, so an
+ * intervening hierarchy that flips the client's latest scale metadata (legacy<->canonical) cannot
+ * stamp the in-flight frame with a space its geometry does not describe.
  */
 export interface ScreenGeometryBinding {
   captureSequence: number;
   width: number;
   height: number;
+  coordinateSpace?: CoordinateSpace;
+}
+
+/**
+ * The `pushScreenshotUpdate` options a screenshot inherits from the binding taken at request
+ * initiation: the capture identity AND (from #4549) the coordinate space it was captured under.
+ * Kept as a free function so both platform clients derive them the same way and neither method has
+ * to inline the optional-field spreads.
+ */
+export function screenshotBindingPushOptions(
+  binding: ScreenGeometryBinding | undefined
+): { captureSequence?: number; coordinateSpace?: CoordinateSpace } {
+  return {
+    captureSequence: binding?.captureSequence,
+    ...(binding?.coordinateSpace ? { coordinateSpace: binding.coordinateSpace } : {}),
+  };
 }
 
 export class TrackedScreenGeometry {
-  private current: { width: number; height: number; captureSequence: number | null } | null = null;
+  private current: {
+    width: number;
+    height: number;
+    captureSequence: number | null;
+    coordinateSpace?: CoordinateSpace;
+  } | null = null;
 
   /** Current width, or null when no hierarchy has produced dimensions yet. */
   get width(): number | null {
@@ -75,6 +103,7 @@ export class TrackedScreenGeometry {
       captureSequence: current.captureSequence,
       width: current.width,
       height: current.height,
+      ...(current.coordinateSpace ? { coordinateSpace: current.coordinateSpace } : {}),
     };
   }
 
@@ -83,7 +112,7 @@ export class TrackedScreenGeometry {
    * already established; a change replaces the entry as NOT forwarded, because the daemon has not
    * yet seen a hierarchy carrying the new geometry.
    */
-  update(width: number, height: number): void {
+  update(width: number, height: number, coordinateSpace?: CoordinateSpace): void {
     // Unusable geometry CLEARS rather than leaving the previous entry intact: keeping stale
     // forwarded dimensions here would let a later hierarchy push vouch for geometry that no longer
     // describes the device. Non-finite values are rejected for the same reason — they can only come
@@ -92,10 +121,18 @@ export class TrackedScreenGeometry {
       this.clear();
       return;
     }
-    if (this.current?.width === width && this.current.height === height) {
+    // The coordinate space is part of the identity: a change to it (canonical<->legacy) is a change
+    // even when the numeric dimensions coincide — on a non-Display-Zoom device points*screenScale
+    // and points*nativeScale are equal, so a metadata appearance/disappearance that does not move
+    // the pixels must still reset provenance rather than be deduplicated away.
+    if (
+      this.current?.width === width &&
+      this.current.height === height &&
+      this.current.coordinateSpace === coordinateSpace
+    ) {
       return;
     }
-    this.current = { width, height, captureSequence: null };
+    this.current = { width, height, captureSequence: null, coordinateSpace };
   }
 
   /**

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -44,7 +44,7 @@ import { getDbWriteBarrier } from "../../../db/dbWriteBarrier";
 import { DefaultWorkProfileMonitor, WorkProfileMonitor } from "../../../utils/WorkProfileMonitor";
 import { IOS_CTRL_PROXY_RESERVED_PORTS, PortManager } from "../../../utils/PortManager";
 import { requireBootedDevice } from "../../../utils/requireBootedDevice";
-import { TrackedScreenGeometry, type ScreenGeometryBinding } from "../TrackedScreenGeometry";
+import { TrackedScreenGeometry, screenshotBindingPushOptions, type ScreenGeometryBinding } from "../TrackedScreenGeometry";
 import { getDeviceDataStreamServer } from "../../../daemon/deviceDataStreamSocketServer";
 import { COORDINATE_SPACE_PX } from "../../../daemon/canonicalPixels";
 import {
@@ -2947,15 +2947,15 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     const screenHeight = binding?.height ?? this.screenGeometry.height ?? 2340;
 
     try {
-      // The identity travels with the frame from the moment it was requested (issue #3348). The
-      // daemon still verifies these declared dimensions against the frame's real pixels before
-      // stamping it, which catches a geometry change between binding and delivery.
-      server.pushScreenshotUpdate(this.device.deviceId, screenshotBase64, screenWidth, screenHeight, metadata, {
-        captureSequence: binding?.captureSequence,
-        // Android bounds are already physical pixels (nativeScale === 1), so a post-#4548 runner's
-        // frame is canonical pixels as-is — declare it so the client reads px uniformly (#4549).
-        ...(this.getScreenScaleMetadata() ? { coordinateSpace: COORDINATE_SPACE_PX } : {}),
-      });
+      // The identity AND the coordinate space travel with the frame from the moment it was
+      // requested (issues #3348, #4549) — both from the binding taken at initiation, never the
+      // client's LATEST metadata at delivery. Android bounds are already physical pixels
+      // (nativeScale === 1), so a post-#4548 runner's frame is canonical pixels as-is; the binding
+      // carries that declaration so a mid-flight metadata flip cannot relabel the frame.
+      server.pushScreenshotUpdate(
+        this.device.deviceId, screenshotBase64, screenWidth, screenHeight, metadata,
+        screenshotBindingPushOptions(binding)
+      );
     } catch (error) {
       logger.debug(`[CTRL_PROXY] Failed to push screenshot to observation stream: ${error}`);
     }
@@ -2990,8 +2990,14 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     if (bestDimensions) {
       // A change clears the identity: it becomes capture-tracked only once the hierarchy carrying
       // it reaches the daemon (see pushHierarchyToObservationStream) — which will NOT happen when
-      // this hierarchy is suppressed, or when there is no stream server.
-      this.screenGeometry.update(bestDimensions.width, bestDimensions.height);
+      // this hierarchy is suppressed, or when there is no stream server. The coordinate space is
+      // bound here (#4549) from the metadata present for THIS hierarchy, so a later metadata flip
+      // cannot restamp a frame whose request was bound now.
+      this.screenGeometry.update(
+        bestDimensions.width,
+        bestDimensions.height,
+        this.reportedScaleMetadata ? COORDINATE_SPACE_PX : undefined
+      );
     } else {
       // No usable window bounds in this hierarchy. Clearing (rather than keeping the previous
       // entry) stops a later push from vouching for dimensions this hierarchy cannot confirm.

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -46,6 +46,7 @@ import { IOS_CTRL_PROXY_RESERVED_PORTS, PortManager } from "../../../utils/PortM
 import { requireBootedDevice } from "../../../utils/requireBootedDevice";
 import { TrackedScreenGeometry, type ScreenGeometryBinding } from "../TrackedScreenGeometry";
 import { getDeviceDataStreamServer } from "../../../daemon/deviceDataStreamSocketServer";
+import { COORDINATE_SPACE_PX } from "../../../daemon/canonicalPixels";
 import {
   ScreenshotBackoffScheduler,
   DefaultScreenshotBackoffScheduler,
@@ -2951,6 +2952,9 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       // stamping it, which catches a geometry change between binding and delivery.
       server.pushScreenshotUpdate(this.device.deviceId, screenshotBase64, screenWidth, screenHeight, metadata, {
         captureSequence: binding?.captureSequence,
+        // Android bounds are already physical pixels (nativeScale === 1), so a post-#4548 runner's
+        // frame is canonical pixels as-is — declare it so the client reads px uniformly (#4549).
+        ...(this.getScreenScaleMetadata() ? { coordinateSpace: COORDINATE_SPACE_PX } : {}),
       });
     } catch (error) {
       logger.debug(`[CTRL_PROXY] Failed to push screenshot to observation stream: ${error}`);

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -56,6 +56,7 @@ import type { SimulatedErrorType } from "../../../server/NetworkState";
 import type { CtrlProxyClient } from "../interfaces/CtrlProxyClient";
 import { TrackedScreenGeometry } from "../TrackedScreenGeometry";
 import { getDeviceDataStreamServer, PerformanceStreamData } from "../../../daemon/deviceDataStreamSocketServer";
+import { COORDINATE_SPACE_PX } from "../../../daemon/canonicalPixels";
 import { getPerformanceMonitor } from "../../performance/PerformanceMonitor";
 import {
   ScreenshotBackoffScheduler,
@@ -2085,8 +2086,13 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       // The identity travels with the frame from the moment it was requested (issue #3348). The
       // daemon still verifies these declared dimensions against the frame's real pixels before
       // stamping it, which catches a geometry change between binding and delivery.
+      //
+      // Declare canonical pixels (#4549) when the runner supplied complete scale metadata — the
+      // published screenWidth/screenHeight are then native-scale pixels, matching the hierarchy
+      // stamp. A pre-#4548 runner has no metadata, so the frame stays legacy point-space.
       server.pushScreenshotUpdate(this.device.deviceId, screenshotBase64, screenWidth, screenHeight, metadata, {
         captureSequence,
+        ...(this.getScreenScaleMetadata() ? { coordinateSpace: COORDINATE_SPACE_PX } : {}),
       });
     } catch (error) {
       logger.debug(`[IOSCtrlProxyClient] Failed to push screenshot to observation stream: ${error}`);
@@ -2202,16 +2208,22 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       this.screenGeometry.clear();
       return;
     }
-    // screenWidth/screenHeight are in iOS points — multiply by screenScale to get pixels,
-    // matching the screenshot image resolution and the TakeScreenshot path (which reads PNG header pixels).
-    const scale = hierarchy.screenScale ?? 1;
+    // Canonical pixels (#4549): the capture-identity claim must equal the screenshot's real pixels,
+    // which XCUIScreenshot renders at NATIVE scale. When the runner supplied complete scale
+    // metadata, use its reported pixelWidth/pixelHeight (derived at nativeScale in #4548) directly —
+    // NOT points * screenScale, which diverges from the PNG under Display Zoom. A pre-#4548 runner
+    // has no metadata, so fall back to the legacy points * screenScale claim, byte-identical.
+    const metadata = readScreenScaleMetadata(hierarchy);
+    const [pixelWidth, pixelHeight] = metadata
+      ? [metadata.pixelWidth, metadata.pixelHeight]
+      : [
+        Math.round(hierarchy.screenWidth * (hierarchy.screenScale ?? 1)),
+        Math.round(hierarchy.screenHeight * (hierarchy.screenScale ?? 1)),
+      ];
     // A change clears the forwarded flag: the geometry becomes capture-tracked only once a
     // hierarchy carrying it is forwarded (see pushHierarchyToObservationStream) — which will NOT
     // happen while hierarchy pushes are suppressed, or when there is no stream server.
-    this.screenGeometry.update(
-      Math.round(hierarchy.screenWidth * scale),
-      Math.round(hierarchy.screenHeight * scale)
-    );
+    this.screenGeometry.update(pixelWidth, pixelHeight);
   }
 
   /**

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -56,7 +56,7 @@ import type { SimulatedErrorType } from "../../../server/NetworkState";
 import type { CtrlProxyClient } from "../interfaces/CtrlProxyClient";
 import { TrackedScreenGeometry } from "../TrackedScreenGeometry";
 import { getDeviceDataStreamServer, PerformanceStreamData } from "../../../daemon/deviceDataStreamSocketServer";
-import { COORDINATE_SPACE_PX } from "../../../daemon/canonicalPixels";
+import { COORDINATE_SPACE_PX, type CoordinateSpace } from "../../../daemon/canonicalPixels";
 import { getPerformanceMonitor } from "../../performance/PerformanceMonitor";
 import {
   ScreenshotBackoffScheduler,
@@ -2075,7 +2075,8 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     screenWidth: number,
     screenHeight: number,
     metadata: ScreenshotMetadata = IOS_CTRLPROXY_SCREENSHOT_METADATA,
-    captureSequence?: number
+    captureSequence?: number,
+    coordinateSpace?: CoordinateSpace
   ): void {
     const server = getDeviceDataStreamServer();
     if (!server) {
@@ -2083,16 +2084,15 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     }
 
     try {
-      // The identity travels with the frame from the moment it was requested (issue #3348). The
-      // daemon still verifies these declared dimensions against the frame's real pixels before
-      // stamping it, which catches a geometry change between binding and delivery.
-      //
-      // Declare canonical pixels (#4549) when the runner supplied complete scale metadata — the
-      // published screenWidth/screenHeight are then native-scale pixels, matching the hierarchy
-      // stamp. A pre-#4548 runner has no metadata, so the frame stays legacy point-space.
+      // The identity AND the coordinate space travel with the frame from the moment it was
+      // requested (issues #3348, #4549) — both are read from the binding taken at request
+      // initiation, NEVER from the client's LATEST scale metadata at delivery time. A hierarchy
+      // that flips the metadata (canonical<->legacy) while this frame is in flight must not
+      // relabel it: the declared space must match the geometry the frame was captured under. The
+      // daemon still verifies the declared dimensions against the frame's real pixels.
       server.pushScreenshotUpdate(this.device.deviceId, screenshotBase64, screenWidth, screenHeight, metadata, {
         captureSequence,
-        ...(this.getScreenScaleMetadata() ? { coordinateSpace: COORDINATE_SPACE_PX } : {}),
+        ...(coordinateSpace ? { coordinateSpace } : {}),
       });
     } catch (error) {
       logger.debug(`[IOSCtrlProxyClient] Failed to push screenshot to observation stream: ${error}`);
@@ -2140,7 +2140,8 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
             screenWidth,
             screenHeight,
             result,
-            binding?.captureSequence
+            binding?.captureSequence,
+            binding?.coordinateSpace
           );
         },
         {
@@ -2222,8 +2223,10 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
       ];
     // A change clears the forwarded flag: the geometry becomes capture-tracked only once a
     // hierarchy carrying it is forwarded (see pushHierarchyToObservationStream) — which will NOT
-    // happen while hierarchy pushes are suppressed, or when there is no stream server.
-    this.screenGeometry.update(pixelWidth, pixelHeight);
+    // happen while hierarchy pushes are suppressed, or when there is no stream server. The
+    // coordinate space is bound here too (#4549), from the metadata present for THIS hierarchy, so
+    // a later metadata flip cannot restamp a frame whose request was bound now.
+    this.screenGeometry.update(pixelWidth, pixelHeight, metadata ? COORDINATE_SPACE_PX : undefined);
   }
 
   /**

--- a/test/daemon/canonicalPixels.test.ts
+++ b/test/daemon/canonicalPixels.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "bun:test";
+import {
+  COORDINATE_SPACE_PX,
+  canonicalPixelsToPoints,
+  convertHierarchyToCanonicalPixels,
+  roundHalfEven,
+} from "../../src/daemon/canonicalPixels";
+import type { ViewHierarchyResult } from "../../src/models";
+import { loadCoordinateMappingVectors } from "../parity/coordinateMappingGoldenVectors";
+
+describe("roundHalfEven", () => {
+  it("rounds ties to the even neighbour (not away from zero like Math.round)", () => {
+    expect(roundHalfEven(0.5)).toBe(0);
+    expect(roundHalfEven(1.5)).toBe(2);
+    expect(roundHalfEven(2.5)).toBe(2);
+    expect(roundHalfEven(3.5)).toBe(4);
+    expect(roundHalfEven(-0.5)).toBe(0);
+    expect(roundHalfEven(-1.5)).toBe(-2);
+    expect(roundHalfEven(-2.5)).toBe(-2);
+  });
+
+  it("rounds non-ties to the nearest integer", () => {
+    expect(roundHalfEven(0.49)).toBe(0);
+    expect(roundHalfEven(0.51)).toBe(1);
+    expect(roundHalfEven(937.5)).toBe(938); // floor 937 (odd) -> up to even 938
+    expect(roundHalfEven(1667.5)).toBe(1668); // floor 1667 (odd) -> up to even 1668
+    expect(roundHalfEven(-937.4)).toBe(-937);
+  });
+
+  it("normalizes -0 to 0 and passes non-finite values through", () => {
+    expect(Object.is(roundHalfEven(-0.4), 0)).toBe(true);
+    expect(roundHalfEven(Number.NaN)).toBeNaN();
+    expect(roundHalfEven(Number.POSITIVE_INFINITY)).toBe(Number.POSITIVE_INFINITY);
+  });
+});
+
+describe("canonicalPixelsToPoints", () => {
+  it("divides pixels by nativeScale EXACTLY, preserving fractional points for the runner", () => {
+    expect(canonicalPixelsToPoints(1170, 3)).toBe(390);
+    expect(canonicalPixelsToPoints(750, 2)).toBe(375);
+    // The runner accepts fractional Double points, so the divide must NOT quantize.
+    expect(canonicalPixelsToPoints(401, 2)).toBe(200.5); // not 200
+    expect(canonicalPixelsToPoints(1, 3)).toBeCloseTo(1 / 3, 12); // not 0
+    expect(canonicalPixelsToPoints(938, 2.5)).toBe(375.2); // not 375
+  });
+
+  it("is the identity for nativeScale 1 or a degenerate scale", () => {
+    expect(canonicalPixelsToPoints(585, 1)).toBe(585);
+    expect(canonicalPixelsToPoints(585, 0)).toBe(585);
+    expect(canonicalPixelsToPoints(585, -3)).toBe(585);
+    expect(canonicalPixelsToPoints(585, Number.NaN)).toBe(585);
+  });
+});
+
+describe("convertHierarchyToCanonicalPixels", () => {
+  const baseHierarchy = (): ViewHierarchyResult => ({
+    hierarchy: {
+      bounds: { left: 0, top: 0, right: 390, bottom: 844 },
+      node: {
+        $: { bounds: { left: 10, top: 20, right: 100, bottom: 60 } },
+        node: [
+          { $: { bounds: { left: 5, top: 5, right: 15, bottom: 25 } } },
+        ],
+      },
+    },
+    screenWidth: 390,
+    screenHeight: 844,
+  });
+
+  it("scales element bounds by nativeScale and adopts reported pixel screen dims (iOS 3x)", () => {
+    const hierarchy = baseHierarchy();
+    convertHierarchyToCanonicalPixels(hierarchy, { nativeScale: 3, pixelWidth: 1170, pixelHeight: 2532 });
+
+    expect(hierarchy.screenWidth).toBe(1170);
+    expect(hierarchy.screenHeight).toBe(2532);
+    expect(hierarchy.hierarchy.node!.$["bounds"]).toEqual({ left: 30, top: 60, right: 300, bottom: 180 });
+    expect(hierarchy.hierarchy.node!.node![0].$["bounds"]).toEqual({ left: 15, top: 15, right: 45, bottom: 75 });
+    expect(hierarchy.hierarchy.bounds).toEqual({ left: 0, top: 0, right: 1170, bottom: 2532 });
+  });
+
+  it("uses round-half-even for fractional nativeScale (Display Zoom / Plus downsampling)", () => {
+    const hierarchy: ViewHierarchyResult = {
+      hierarchy: { node: { $: { bounds: { left: 0, top: 0, right: 375, bottom: 812 } } } },
+      screenWidth: 375,
+      screenHeight: 812,
+    };
+    convertHierarchyToCanonicalPixels(hierarchy, { nativeScale: 2.5, pixelWidth: 938, pixelHeight: 2030 });
+    // 375*2.5 = 937.5 -> 938 (even); 812*2.5 = 2030 (integral)
+    expect(hierarchy.hierarchy.node!.$["bounds"]).toEqual({ left: 0, top: 0, right: 938, bottom: 2030 });
+  });
+
+  it("leaves element bounds untouched at nativeScale 1 (Android) but still adopts reported screen dims", () => {
+    const hierarchy = baseHierarchy();
+    convertHierarchyToCanonicalPixels(hierarchy, { nativeScale: 1, pixelWidth: 390, pixelHeight: 844 });
+    expect(hierarchy.hierarchy.node!.$["bounds"]).toEqual({ left: 10, top: 20, right: 100, bottom: 60 });
+    expect(hierarchy.screenWidth).toBe(390);
+    expect(hierarchy.screenHeight).toBe(844);
+  });
+
+  it("does not corrupt non-object bounds forms (string/array)", () => {
+    const hierarchy: ViewHierarchyResult = {
+      hierarchy: { node: { $: { bounds: "[0,0][100,200]" } } as any },
+      screenWidth: 100,
+      screenHeight: 200,
+    };
+    convertHierarchyToCanonicalPixels(hierarchy, { nativeScale: 3, pixelWidth: 300, pixelHeight: 600 });
+    expect(hierarchy.hierarchy.node!.$["bounds"]).toBe("[0,0][100,200]");
+  });
+
+  describe("golden iosPointToPixel: element bounds point->pixel conversion", () => {
+    // Each flagged golden row is a (pointWidth x pointHeight) rect converted to canonical pixels via
+    // the runner-reported nativeScale. scale=0 encodes a pre-#4548 runner (no metadata), so the
+    // daemon leaves bounds untouched — the caller never invokes this conversion (see the
+    // legacy-fallback pushHierarchyUpdate test); we assert that identity here for completeness.
+    const vectors = loadCoordinateMappingVectors().iosPointToPixel;
+    for (const [index, vector] of vectors.entries()) {
+      it(`row ${index}: ${vector.pointWidth}x${vector.pointHeight} @ ${vector.scale || "no-metadata"} -> ${vector.expectedPixelWidth}x${vector.expectedPixelHeight}`, () => {
+        const hierarchy: ViewHierarchyResult = {
+          hierarchy: { node: { $: { bounds: { left: 0, top: 0, right: vector.pointWidth, bottom: vector.pointHeight } } } },
+          screenWidth: vector.pointWidth,
+          screenHeight: vector.pointHeight,
+        };
+        if (vector.scale === 0) {
+          // No metadata: the daemon never converts; bounds stay point-space (identity).
+          expect(vector.expectedPixelWidth).toBe(vector.pointWidth);
+          expect(vector.expectedPixelHeight).toBe(vector.pointHeight);
+          return;
+        }
+        convertHierarchyToCanonicalPixels(hierarchy, {
+          nativeScale: vector.scale,
+          pixelWidth: vector.expectedPixelWidth,
+          pixelHeight: vector.expectedPixelHeight,
+        });
+        expect(hierarchy.hierarchy.node!.$["bounds"]).toEqual({
+          left: 0,
+          top: 0,
+          right: vector.expectedPixelWidth,
+          bottom: vector.expectedPixelHeight,
+        });
+      });
+    }
+  });
+
+  describe("golden iosPointToPixel: point -> pixel -> point round-trip", () => {
+    // The publish path converts a point bound to pixels (roundHalfEven(point * nativeScale), integer
+    // pixel coords); the input path converts a client pixel coordinate back to points by an EXACT
+    // divide (/ nativeScale). Because the divide adds no rounding, the round-trip error is only the
+    // single publish-side integer-pixel quantization: at most 0.5/nativeScale <= 0.5 of a point.
+    const vectors = loadCoordinateMappingVectors().iosPointToPixel;
+    for (const [index, vector] of vectors.entries()) {
+      if (vector.scale === 0) { continue; }
+      it(`row ${index}: nativeScale ${vector.scale}`, () => {
+        for (const point of [0, 1, vector.pointWidth / 2, vector.pointWidth - 1, vector.pointWidth]) {
+          const pixels = roundHalfEven(point * vector.scale);
+          const back = canonicalPixelsToPoints(pixels, vector.scale);
+          expect(Math.abs(back - point)).toBeLessThanOrEqual(0.5 / vector.scale);
+        }
+      });
+    }
+
+    it("is EXACT when the pixel product is integral (no divide-side rounding)", () => {
+      // 390pt @ 3x -> 1170px -> 390.000pt exactly; 375pt @ 2x -> 750px -> 375pt exactly.
+      expect(canonicalPixelsToPoints(roundHalfEven(390 * 3), 3)).toBe(390);
+      expect(canonicalPixelsToPoints(roundHalfEven(375 * 2), 2)).toBe(375);
+    });
+  });
+
+  describe("scaleAllBounds: every bounds-bearing wire field is converted", () => {
+    // A pre-#4549 gap left windows[*].bounds (and other non-node-tree bounds) in points while the
+    // node tree was pixels — a self-inconsistent px-stamped message. Convert them all.
+    it("converts window bounds, nested window node trees, content-hidden regions, and the focused node", () => {
+      const hierarchy: ViewHierarchyResult = {
+        "hierarchy": { node: { $: { bounds: { left: 0, top: 0, right: 10, bottom: 20 } } } },
+        "screenWidth": 390,
+        "screenHeight": 844,
+        "windows": [
+          {
+            bounds: { left: 0, top: 0, right: 390, bottom: 844 },
+            hierarchy: { $: { bounds: { left: 5, top: 5, right: 15, bottom: 25 } } },
+          },
+        ],
+        "contentHiddenRegions": [
+          { bounds: { left: 1, top: 2, right: 3, bottom: 4 }, reason: "x", areaPercent: 1 },
+        ],
+        "accessibility-focused-element": { $: { bounds: { left: 2, top: 4, right: 6, bottom: 8 } } },
+      };
+      convertHierarchyToCanonicalPixels(hierarchy, { nativeScale: 3, pixelWidth: 1170, pixelHeight: 2532 });
+
+      expect(hierarchy.windows![0].bounds).toEqual({ left: 0, top: 0, right: 1170, bottom: 2532 });
+      expect(hierarchy.windows![0].hierarchy!.$["bounds"]).toEqual({ left: 15, top: 15, right: 45, bottom: 75 });
+      expect(hierarchy.contentHiddenRegions![0].bounds).toEqual({ left: 3, top: 6, right: 9, bottom: 12 });
+      expect(hierarchy["accessibility-focused-element"]!.$["bounds"]).toEqual({ left: 6, top: 12, right: 18, bottom: 24 });
+    });
+
+    it("leaves insets untouched (they carry their own self-describing units field)", () => {
+      const hierarchy: ViewHierarchyResult = {
+        hierarchy: { node: { $: { bounds: { left: 0, top: 0, right: 10, bottom: 20 } } } },
+        screenWidth: 390,
+        screenHeight: 844,
+        systemInsets: { top: 47, right: 0, bottom: 34, left: 0 },
+      };
+      convertHierarchyToCanonicalPixels(hierarchy, { nativeScale: 3, pixelWidth: 1170, pixelHeight: 2532 });
+      expect(hierarchy.systemInsets).toEqual({ top: 47, right: 0, bottom: 34, left: 0 });
+    });
+  });
+});
+
+describe("COORDINATE_SPACE_PX", () => {
+  it('is the literal "px"', () => {
+    expect(COORDINATE_SPACE_PX).toBe("px");
+  });
+});

--- a/test/daemon/canonicalPixels.test.ts
+++ b/test/daemon/canonicalPixels.test.ts
@@ -192,15 +192,20 @@ describe("convertHierarchyToCanonicalPixels", () => {
       expect(hierarchy["accessibility-focused-element"]!.$["bounds"]).toEqual({ left: 6, top: 12, right: 18, bottom: 24 });
     });
 
-    it("leaves insets untouched (they carry their own self-describing units field)", () => {
+    it("converts the systemInsets alias (no units field) but leaves typed insets alone", () => {
       const hierarchy: ViewHierarchyResult = {
         hierarchy: { node: { $: { bounds: { left: 0, top: 0, right: 10, bottom: 20 } } } },
         screenWidth: 390,
         screenHeight: 844,
         systemInsets: { top: 47, right: 0, bottom: 34, left: 0 },
+        // Typed insets self-describe via `units`, so they are NOT touched by the coordinateSpace stamp.
+        insets: { available: true, source: "ios-sdk-safe-area", units: "points", safeArea: { top: 47, right: 0, bottom: 34, left: 0 } },
       };
       convertHierarchyToCanonicalPixels(hierarchy, { nativeScale: 3, pixelWidth: 1170, pixelHeight: 2532 });
-      expect(hierarchy.systemInsets).toEqual({ top: 47, right: 0, bottom: 34, left: 0 });
+      // systemInsets follows coordinateSpace -> pixels.
+      expect(hierarchy.systemInsets).toEqual({ top: 141, right: 0, bottom: 102, left: 0 });
+      // Typed insets untouched (points, self-describing).
+      expect(hierarchy.insets).toEqual({ available: true, source: "ios-sdk-safe-area", units: "points", safeArea: { top: 47, right: 0, bottom: 34, left: 0 } });
     });
   });
 });

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -1295,6 +1295,101 @@ describe("DeviceDataStreamSocketServer", () => {
     });
   });
 
+  describe("canonical-pixel conversion at the wire (issue #4549)", () => {
+    // A hierarchy carrying the #4548 runner scale metadata: iOS points + nativeScale + reported
+    // physical pixel dims. Element bounds live under $.bounds as {left,top,right,bottom}.
+    const iosFrame = () =>
+      ({
+        hierarchy: {
+          bounds: { left: 0, top: 0, right: 390, bottom: 844 },
+          node: {
+            $: { class: "UIWindow", bounds: { left: 0, top: 0, right: 390, bottom: 844 } },
+            node: [{ $: { class: "UIButton", text: "Go", bounds: { left: 10, top: 20, right: 100, bottom: 60 } } }],
+          },
+        },
+        screenWidth: 390,
+        screenHeight: 844,
+        screenScale: 3,
+        nativeScale: 3,
+        pixelWidth: 1170,
+        pixelHeight: 2532,
+      }) as any;
+
+    it("publishes iOS element bounds and screen dims in pixels and stamps coordinateSpace:px", () => {
+      const { socket } = server.simulateSubscription({ deviceId: "ios-1" });
+      server.pushHierarchyUpdate("ios-1", iosFrame());
+
+      const [message] = socket.getWrittenMessages<any>();
+      expect(message.type).toBe("hierarchy_update");
+      expect(message.coordinateSpace).toBe("px");
+      expect(message.data.screenWidth).toBe(1170);
+      expect(message.data.screenHeight).toBe(2532);
+      expect(message.data.hierarchy.node.$.bounds).toEqual({ left: 0, top: 0, right: 1170, bottom: 2532 });
+      expect(message.data.hierarchy.node.node[0].$.bounds).toEqual({ left: 30, top: 60, right: 300, bottom: 180 });
+      expect(message.data.hierarchy.bounds).toEqual({ left: 0, top: 0, right: 1170, bottom: 2532 });
+    });
+
+    it("does not mutate the caller's hierarchy (MCP observe keeps point-space bounds)", () => {
+      server.simulateSubscription({ deviceId: "ios-1" });
+      const input = iosFrame();
+      server.pushHierarchyUpdate("ios-1", input);
+      // The push converts a clone; the object the caller (and MCP observe) holds is untouched.
+      expect(input.data ?? input.hierarchy.node.$.bounds).toEqual({ left: 0, top: 0, right: 390, bottom: 844 });
+      expect(input.screenWidth).toBe(390);
+    });
+
+    it("LEGACY: a hierarchy without runner metadata is byte-identical (points, no px stamp)", () => {
+      const { socket } = server.simulateSubscription({ deviceId: "ios-legacy" });
+      const legacy = iosFrame();
+      delete legacy.nativeScale;
+      delete legacy.pixelWidth;
+      delete legacy.pixelHeight;
+      server.pushHierarchyUpdate("ios-legacy", legacy);
+
+      const [message] = socket.getWrittenMessages<any>();
+      expect(message.coordinateSpace).toBeUndefined();
+      // Point-space bounds and dims pass through unchanged.
+      expect(message.data.screenWidth).toBe(390);
+      expect(message.data.hierarchy.node.node[0].$.bounds).toEqual({ left: 10, top: 20, right: 100, bottom: 60 });
+    });
+
+    it("Android (nativeScale 1) leaves bounds numerically identical but still declares px", () => {
+      const { socket } = server.simulateSubscription({ deviceId: "android-1" });
+      const androidFrame = {
+        hierarchy: { node: { $: { class: "FrameLayout", bounds: { left: 0, top: 0, right: 1080, bottom: 2340 } } } },
+        screenWidth: 1080,
+        screenHeight: 2340,
+        nativeScale: 1,
+        pixelWidth: 1080,
+        pixelHeight: 2340,
+      } as any;
+      server.pushHierarchyUpdate("android-1", androidFrame);
+
+      const [message] = socket.getWrittenMessages<any>();
+      expect(message.coordinateSpace).toBe("px");
+      expect(message.data.hierarchy.node.$.bounds).toEqual({ left: 0, top: 0, right: 1080, bottom: 2340 });
+    });
+
+    it("stamps coordinateSpace:px on a screenshot when the caller declares px", () => {
+      const { socket } = server.simulateSubscription({ deviceId: "ios-1" });
+      const seq = server.pushHierarchyUpdate("ios-1", iosFrame());
+      server.pushScreenshotUpdate("ios-1", pngFrame(1170, 2532), 1170, 2532, {}, {
+        captureSequence: seq ?? undefined,
+        coordinateSpace: "px",
+      });
+      const shot = socket.getWrittenMessages<any>().find(m => m.type === "screenshot_update");
+      expect(shot.coordinateSpace).toBe("px");
+      expect(shot.captureSequence).toBe(seq);
+    });
+
+    it("omits coordinateSpace on a screenshot from a legacy (non-px) caller", () => {
+      const { socket } = server.simulateSubscription({ deviceId: "ios-legacy" });
+      server.pushScreenshotUpdate("ios-legacy", pngFrame(1170, 2532), 1170, 2532, {}, {});
+      const shot = socket.getWrittenMessages<any>().find(m => m.type === "screenshot_update");
+      expect(shot.coordinateSpace).toBeUndefined();
+    });
+  });
+
   describe("coordinate-mapping golden vectors: geometry pairing (issue #4547)", () => {
     // Cross-language golden suite, B0 of the canonical-pixel campaign (#4547 -> #4549). Each
     // vector drives the daemon's REAL header-measurement pairing (pixelsMatchClaimedGeometry via

--- a/test/daemon/observationInitialFrame.test.ts
+++ b/test/daemon/observationInitialFrame.test.ts
@@ -31,7 +31,8 @@ class FakeObservationStreamServer {
     screenshotBase64: string,
     screenWidth: number,
     screenHeight: number,
-    metadata?: Record<string, unknown>
+    metadata?: Record<string, unknown>,
+    options?: { coordinateSpace?: "px" }
   ): void {
     this.screenshotUpdates.push({
       deviceId,
@@ -39,6 +40,7 @@ class FakeObservationStreamServer {
       screenWidth,
       screenHeight,
       ...(metadata === undefined ? {} : { metadata }),
+      ...(options?.coordinateSpace === undefined ? {} : { coordinateSpace: options.coordinateSpace }),
     });
   }
 }
@@ -49,6 +51,7 @@ interface ScreenshotUpdate {
   screenWidth: number;
   screenHeight: number;
   metadata?: Record<string, unknown>;
+  coordinateSpace?: "px";
 }
 
 class FakeAndroidInitialFrameClient implements ObservationStreamAndroidClient {
@@ -165,7 +168,11 @@ class FakeIosInitialFrameClient implements ObservationStreamIosClient {
   }
 
   convertToViewHierarchyResult(hierarchy: unknown): ViewHierarchyResult {
-    const typedHierarchy = hierarchy as CtrlProxyHierarchy;
+    const typedHierarchy = hierarchy as CtrlProxyHierarchy & {
+      nativeScale?: number;
+      pixelWidth?: number;
+      pixelHeight?: number;
+    };
     return {
       hierarchy: { node: { $: { text: typedHierarchy.hierarchy.text } } },
       packageName: typedHierarchy.packageName,
@@ -173,6 +180,11 @@ class FakeIosInitialFrameClient implements ObservationStreamIosClient {
       screenWidth: typedHierarchy.screenWidth,
       screenHeight: typedHierarchy.screenHeight,
       screenScale: typedHierarchy.screenScale,
+      // Additive #4548 scale metadata, mirroring the real converter's spread — so the daemon's
+      // canonical-pixel path (#4549) is exercised when the runner supplied it.
+      ...(typedHierarchy.nativeScale === undefined ? {} : { nativeScale: typedHierarchy.nativeScale }),
+      ...(typedHierarchy.pixelWidth === undefined ? {} : { pixelWidth: typedHierarchy.pixelWidth }),
+      ...(typedHierarchy.pixelHeight === undefined ? {} : { pixelHeight: typedHierarchy.pixelHeight }),
     };
   }
 
@@ -558,26 +570,38 @@ describe("pushInitialObservationFramesForSubscriber", () => {
   });
 
   describe("coordinate-mapping golden vectors: iOS point->pixel (issue #4547)", () => {
-    // Cross-language golden suite, B0 of the canonical-pixel campaign (#4547 -> #4549). Each
-    // vector drives the daemon's REAL iOS point->pixel conversion (getIosScreenshotDimensions via
-    // pushInitialObservationFramesForSubscriber): screenshot geometry is published as
-    // round(points * screenScale), defaulting the multiplier to 1 when the hierarchy carries no
-    // scale (encoded as scale=0 in the fixture). Every row is flagged
-    // willChangeUnderCanonicalPixels: once #4549 delivers pixel-space hierarchies, this
-    // daemon-side multiply must disappear and these vectors must be updated deliberately.
+    // Cross-language golden suite, B0/B2 of the canonical-pixel campaign (#4547 -> #4549). Each
+    // vector drives the daemon's REAL iOS screenshot-dimension publishing (getIosScreenshotDimensions
+    // via pushInitialObservationFramesForSubscriber). Under #4549, when the runner supplies complete
+    // scale metadata (nativeScale + reported pixelWidth/pixelHeight), the daemon publishes those
+    // physical pixel dimensions DIRECTLY — the old points*screenScale multiply disappears — and
+    // stamps coordinateSpace:"px". A row with scale=0 encodes a pre-#4548 runner (no metadata): the
+    // daemon falls back to the legacy round(points * 1) point-space claim and does NOT stamp px.
+    // (The per-element point->pixel bounds conversion these same vectors drive lives in
+    // test/daemon/canonicalPixels.test.ts.)
     const vectors = loadCoordinateMappingVectors().iosPointToPixel;
 
     for (const [index, vector] of vectors.entries()) {
-      it(`row ${index}: ${vector.pointWidth}x${vector.pointHeight} points at scale ${vector.scale || "absent"} -> ${vector.expectedPixelWidth}x${vector.expectedPixelHeight} pixels`, async () => {
+      const hasMetadata = vector.scale !== 0;
+      it(`row ${index}: ${vector.pointWidth}x${vector.pointHeight} @ ${vector.scale || "no-metadata"} -> ${vector.expectedPixelWidth}x${vector.expectedPixelHeight} px${hasMetadata ? " (px-stamped)" : " (legacy)"}`, async () => {
         const streamServer = new FakeObservationStreamServer();
         const iosClient = new FakeIosInitialFrameClient(true, {
           updatedAt: 1,
           packageName: "com.example.ios",
           screenWidth: vector.pointWidth,
           screenHeight: vector.pointHeight,
-          ...(vector.scale === 0 ? {} : { screenScale: vector.scale }),
+          // A real runner reports nativeScale + the derived pixel dims. scale=0 == pre-#4548 runner:
+          // no metadata, so the daemon takes the legacy path and never stamps px.
+          ...(hasMetadata
+            ? {
+              screenScale: vector.scale,
+              nativeScale: vector.scale,
+              pixelWidth: vector.expectedPixelWidth,
+              pixelHeight: vector.expectedPixelHeight,
+            }
+            : {}),
           hierarchy: { text: "Golden" },
-        });
+        } as any);
 
         await pushInitialObservationFramesForSubscriber(iosDevice.id, [iosDevice], {
           streamServer,
@@ -592,6 +616,9 @@ describe("pushInitialObservationFramesForSubscriber", () => {
           screenWidth: vector.expectedPixelWidth,
           screenHeight: vector.expectedPixelHeight,
         });
+        // The px declaration is gated on runner metadata: present == canonical pixels declared,
+        // absent (legacy runner) == no field so the client keeps its point-space fallback.
+        expect(streamServer.screenshotUpdates[0].coordinateSpace).toBe(hasMetadata ? "px" : undefined);
       });
     }
   });

--- a/test/daemon/socketServerInputSwipe.test.ts
+++ b/test/daemon/socketServerInputSwipe.test.ts
@@ -87,10 +87,13 @@ describe("UnixSocketServer input/swipe", () => {
     expect(createMcpClient).not.toHaveBeenCalled();
   });
 
-  test("routes iOS coordinate swipes through the duration-aware iOS drag gesture", async () => {
+  test("LEGACY iOS swipe (no runner scale metadata) passes coordinates through unchanged", async () => {
     const requestDrag = mock(async () => ({ success: true }));
+    const fetchHierarchy = mock(async () => null);
     IOSCtrlProxyClient.getInstance = mock(() => ({
       requestDrag,
+      getScreenScaleMetadata: () => null,
+      requestHierarchySyncWithoutObservationStreamPush: fetchHierarchy,
     })) as unknown as typeof IOSCtrlProxyClient.getInstance;
     PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([iosDevice]));
     server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
@@ -117,6 +120,33 @@ describe("UnixSocketServer input/swipe", () => {
       durationMs: 750,
     });
     expect(requestDrag).toHaveBeenCalledWith(20, 30, 80, 90, 0, 750, 0, 30_000);
+  });
+
+  test("canonical-pixel iOS swipe divides each endpoint by nativeScale before dispatch", async () => {
+    // px frame (#4549): endpoints arrive in pixels, divided by nativeScale=3 to runner points.
+    const requestDrag = mock(async () => ({ success: true }));
+    IOSCtrlProxyClient.getInstance = mock(() => ({
+      requestDrag,
+      getScreenScaleMetadata: () => ({ nativeScale: 3, pixelWidth: 1170, pixelHeight: 2532 }),
+    })) as unknown as typeof IOSCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([iosDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/swipe", {
+      platform: "ios",
+      deviceId: "ios-sim-1",
+      startX: 300,
+      startY: 600,
+      endX: 900,
+      endY: 1500,
+      durationMs: 750,
+    });
+
+    expect(response.success).toBe(true);
+    // Echoed endpoints stay in the client's px space; only the runner dispatch is converted.
+    expect(response.result).toMatchObject({ start: { x: 300, y: 600 }, end: { x: 900, y: 1500 } });
+    expect(requestDrag).toHaveBeenCalledWith(100, 200, 300, 500, 0, 750, 0, 30_000);
   });
 
   test("uses the socket autolock device when deviceId is omitted", async () => {

--- a/test/daemon/socketServerInputSwipe.test.ts
+++ b/test/daemon/socketServerInputSwipe.test.ts
@@ -89,7 +89,7 @@ describe("UnixSocketServer input/swipe", () => {
 
   test("LEGACY iOS swipe (no runner scale metadata) passes coordinates through unchanged", async () => {
     const requestDrag = mock(async () => ({ success: true }));
-    const fetchHierarchy = mock(async () => null);
+    const fetchHierarchy = mock(async () => ({ hierarchy: {} })); // success, no metadata => legacy
     IOSCtrlProxyClient.getInstance = mock(() => ({
       requestDrag,
       getScreenScaleMetadata: () => null,

--- a/test/daemon/socketServerInputTap.test.ts
+++ b/test/daemon/socketServerInputTap.test.ts
@@ -83,11 +83,11 @@ describe("UnixSocketServer input/tap", () => {
     expect(createMcpClient).not.toHaveBeenCalled();
   });
 
-  test("LEGACY iOS tap (no runner scale metadata) passes pixel coordinates through unchanged", async () => {
-    // No metadata even after fetching a hierarchy: a pre-#4548 runner. The control client never got
-    // px bounds, so it is sending point-space coordinates — pass through, no division.
+  test("LEGACY iOS tap: probe SUCCEEDS with no metadata -> pass through unchanged", async () => {
+    // The probe returns a hierarchy (success) but it carries no scale metadata: a genuine pre-#4548
+    // runner. The control client never got px bounds, so it sends points — pass through, no divide.
     const requestTapCoordinates = mock(async () => ({ success: true }));
-    const fetchHierarchy = mock(async () => null);
+    const fetchHierarchy = mock(async () => ({ hierarchy: {} }));
     IOSCtrlProxyClient.getInstance = mock(() => ({
       requestTapCoordinates,
       getScreenScaleMetadata: () => null,
@@ -105,15 +105,114 @@ describe("UnixSocketServer input/tap", () => {
     });
 
     expect(response.success).toBe(true);
-    expect(response.result).toMatchObject({
-      action: "input/tap",
-      platform: "ios",
-      deviceId: "ios-sim-1",
-      success: true,
-      coordinates: { x: 20, y: 30 },
-    });
-    expect(fetchHierarchy).toHaveBeenCalledTimes(1); // it tried to learn the scale first
+    expect(response.result).toMatchObject({ coordinates: { x: 20, y: 30 } });
+    expect(fetchHierarchy).toHaveBeenCalledTimes(1); // it probed to learn the scale first
     expect(requestTapCoordinates).toHaveBeenCalledWith(20, 30, undefined, 30_000);
+  });
+
+  test("iOS tap: a confirmed-legacy device probes only ONCE across consecutive taps (#4549 D)", async () => {
+    const requestTapCoordinates = mock(async () => ({ success: true }));
+    const fetchHierarchy = mock(async () => ({ hierarchy: {} })); // success, no metadata => legacy
+    IOSCtrlProxyClient.getInstance = mock(() => ({
+      requestTapCoordinates,
+      getScreenScaleMetadata: () => null,
+      requestHierarchySyncWithoutObservationStreamPush: fetchHierarchy,
+    })) as unknown as typeof IOSCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([iosDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    await sendRequest(socketPath, "input/tap", { platform: "ios", deviceId: "ios-sim-1", x: 20, y: 30 });
+    await sendRequest(socketPath, "input/tap", { platform: "ios", deviceId: "ios-sim-1", x: 40, y: 50 });
+
+    expect(fetchHierarchy).toHaveBeenCalledTimes(1); // cached after the first confirms legacy
+    expect(requestTapCoordinates).toHaveBeenCalledTimes(2);
+  });
+
+  test("iOS tap: a FAILED probe (no hierarchy) rejects the input instead of assuming legacy (#4549 C)", async () => {
+    const requestTapCoordinates = mock(async () => ({ success: true }));
+    const fetchHierarchy = mock(async () => null); // not connected / timed out -> FAILURE
+    IOSCtrlProxyClient.getInstance = mock(() => ({
+      requestTapCoordinates,
+      getScreenScaleMetadata: () => null,
+      requestHierarchySyncWithoutObservationStreamPush: fetchHierarchy,
+    })) as unknown as typeof IOSCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([iosDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/tap", { platform: "ios", deviceId: "ios-sim-1", x: 600, y: 900 });
+
+    expect(response.success).toBe(false);
+    expect(response.error).toContain("Could not determine iOS screen scale");
+    expect(requestTapCoordinates).not.toHaveBeenCalled(); // fail closed, no mis-dispatch
+  });
+
+  test("iOS tap: a THROWN probe rejects the input (#4549 C)", async () => {
+    const requestTapCoordinates = mock(async () => ({ success: true }));
+    const fetchHierarchy = mock(async () => { throw new Error("ws disconnected"); });
+    IOSCtrlProxyClient.getInstance = mock(() => ({
+      requestTapCoordinates,
+      getScreenScaleMetadata: () => null,
+      requestHierarchySyncWithoutObservationStreamPush: fetchHierarchy,
+    })) as unknown as typeof IOSCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([iosDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/tap", { platform: "ios", deviceId: "ios-sim-1", x: 600, y: 900 });
+
+    expect(response.success).toBe(false);
+    expect(response.error).toContain("scale probe failed");
+    expect(requestTapCoordinates).not.toHaveBeenCalled();
+  });
+
+  test("iOS tap: the scale probe is charged against the gesture budget (#4549 B)", async () => {
+    // The probe consumes 20s of the 30s budget; the gesture must get only the ~10s remainder, not a
+    // fresh 30s (which would let probe + gesture run ~2x the declared budget).
+    const requestTapCoordinates = mock(async () => ({ success: true }));
+    let scale: { nativeScale: number; pixelWidth: number; pixelHeight: number } | null = null;
+    const fetchHierarchy = mock(async () => {
+      fakeTimer.advanceTime(20_000);
+      scale = { nativeScale: 3, pixelWidth: 1170, pixelHeight: 2532 };
+      return { hierarchy: {} };
+    });
+    IOSCtrlProxyClient.getInstance = mock(() => ({
+      requestTapCoordinates,
+      getScreenScaleMetadata: () => scale,
+      requestHierarchySyncWithoutObservationStreamPush: fetchHierarchy,
+    })) as unknown as typeof IOSCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([iosDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/tap", { platform: "ios", deviceId: "ios-sim-1", x: 600, y: 900 });
+
+    expect(response.success).toBe(true);
+    expect(requestTapCoordinates).toHaveBeenCalledWith(200, 300, undefined, 10_000);
+  });
+
+  test("iOS tap: a probe that consumes the whole budget fails with a timeout, not a full-budget gesture (#4549 B)", async () => {
+    const requestTapCoordinates = mock(async () => ({ success: true }));
+    let scale: { nativeScale: number } | null = null;
+    const fetchHierarchy = mock(async () => {
+      fakeTimer.advanceTime(31_000); // exceeds the 30s budget
+      scale = { nativeScale: 3 };
+      return { hierarchy: {} };
+    });
+    IOSCtrlProxyClient.getInstance = mock(() => ({
+      requestTapCoordinates,
+      getScreenScaleMetadata: () => scale,
+      requestHierarchySyncWithoutObservationStreamPush: fetchHierarchy,
+    })) as unknown as typeof IOSCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([iosDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/tap", { platform: "ios", deviceId: "ios-sim-1", x: 600, y: 900 });
+
+    expect(response.success).toBe(false);
+    expect(requestTapCoordinates).not.toHaveBeenCalled();
   });
 
   test("canonical-pixel iOS tap divides by nativeScale (exact) before dispatch to the points-based runner", async () => {
@@ -151,9 +250,10 @@ describe("UnixSocketServer input/tap", () => {
     const requestTapCoordinates = mock(async () => ({ success: true }));
     let scale: { nativeScale: number; pixelWidth: number; pixelHeight: number } | null = null;
     const fetchHierarchy = mock(async () => {
-      // Simulate #4548 receipt-based retention populating the scale during the fetch.
+      // Simulate #4548 receipt-based retention populating the scale during the fetch. The probe
+      // SUCCEEDS (returns a hierarchy); the scale is now known.
       scale = { nativeScale: 3, pixelWidth: 1170, pixelHeight: 2532 };
-      return null;
+      return { hierarchy: {} };
     });
     IOSCtrlProxyClient.getInstance = mock(() => ({
       requestTapCoordinates,

--- a/test/daemon/socketServerInputTap.test.ts
+++ b/test/daemon/socketServerInputTap.test.ts
@@ -83,10 +83,15 @@ describe("UnixSocketServer input/tap", () => {
     expect(createMcpClient).not.toHaveBeenCalled();
   });
 
-  test("routes iOS coordinate taps through the iOS gesture client", async () => {
+  test("LEGACY iOS tap (no runner scale metadata) passes pixel coordinates through unchanged", async () => {
+    // No metadata even after fetching a hierarchy: a pre-#4548 runner. The control client never got
+    // px bounds, so it is sending point-space coordinates — pass through, no division.
     const requestTapCoordinates = mock(async () => ({ success: true }));
+    const fetchHierarchy = mock(async () => null);
     IOSCtrlProxyClient.getInstance = mock(() => ({
       requestTapCoordinates,
+      getScreenScaleMetadata: () => null,
+      requestHierarchySyncWithoutObservationStreamPush: fetchHierarchy,
     })) as unknown as typeof IOSCtrlProxyClient.getInstance;
     PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([iosDevice]));
     server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
@@ -107,7 +112,69 @@ describe("UnixSocketServer input/tap", () => {
       success: true,
       coordinates: { x: 20, y: 30 },
     });
+    expect(fetchHierarchy).toHaveBeenCalledTimes(1); // it tried to learn the scale first
     expect(requestTapCoordinates).toHaveBeenCalledWith(20, 30, undefined, 30_000);
+  });
+
+  test("canonical-pixel iOS tap divides by nativeScale (exact) before dispatch to the points-based runner", async () => {
+    // The control client renders a px frame (#4549) and sends the tap in PIXELS; the daemon divides
+    // EXACTLY by nativeScale so the XCUITest runner receives (fractional) points and the tap lands
+    // at the same physical location. 1170/3 = 390, 2533/3 = 844.333...
+    const requestTapCoordinates = mock(async () => ({ success: true }));
+    IOSCtrlProxyClient.getInstance = mock(() => ({
+      requestTapCoordinates,
+      getScreenScaleMetadata: () => ({ nativeScale: 3, pixelWidth: 1170, pixelHeight: 2532 }),
+    })) as unknown as typeof IOSCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([iosDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/tap", {
+      platform: "ios",
+      deviceId: "ios-sim-1",
+      x: 1170,
+      y: 2533,
+    });
+
+    expect(response.success).toBe(true);
+    // The echoed coordinates stay in the client's px space; only the runner dispatch is converted.
+    expect(response.result).toMatchObject({ coordinates: { x: 1170, y: 2533 } });
+    const [x, y] = requestTapCoordinates.mock.calls[0];
+    expect(x).toBe(390);
+    expect(y).toBeCloseTo(2533 / 3, 10); // fractional point preserved, not quantized to 844
+  });
+
+  test("iOS tap before ANY hierarchy fetches one first, then divides by the learned nativeScale", async () => {
+    // Startup window: the control client's first tap arrives before the daemon received any
+    // hierarchy, so #4548 receipt-based retention has not run and getScreenScaleMetadata() is null.
+    // The daemon fetches a hierarchy (populating the scale via receipt), then converts.
+    const requestTapCoordinates = mock(async () => ({ success: true }));
+    let scale: { nativeScale: number; pixelWidth: number; pixelHeight: number } | null = null;
+    const fetchHierarchy = mock(async () => {
+      // Simulate #4548 receipt-based retention populating the scale during the fetch.
+      scale = { nativeScale: 3, pixelWidth: 1170, pixelHeight: 2532 };
+      return null;
+    });
+    IOSCtrlProxyClient.getInstance = mock(() => ({
+      requestTapCoordinates,
+      getScreenScaleMetadata: () => scale,
+      requestHierarchySyncWithoutObservationStreamPush: fetchHierarchy,
+    })) as unknown as typeof IOSCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([iosDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/tap", {
+      platform: "ios",
+      deviceId: "ios-sim-1",
+      x: 600,
+      y: 900,
+    });
+
+    expect(response.success).toBe(true);
+    expect(fetchHierarchy).toHaveBeenCalledTimes(1);
+    // 600/3 = 200, 900/3 = 300 — NOT dispatched as 600/900 points (which would tap at 1/3 scale).
+    expect(requestTapCoordinates).toHaveBeenCalledWith(200, 300, undefined, 30_000);
   });
 
   test("uses the socket autolock device when deviceId is omitted", async () => {

--- a/test/features/observe/TrackedScreenGeometry.test.ts
+++ b/test/features/observe/TrackedScreenGeometry.test.ts
@@ -102,4 +102,32 @@ describe("TrackedScreenGeometry", () => {
     expect(geometry.width).toBeNull();
     expect(geometry.isForwarded).toBe(false);
   });
+
+  it("carries the coordinate space bound at update time through markForwarded and bind (#4549)", () => {
+    const geometry = new TrackedScreenGeometry();
+    geometry.update(1170, 2532, "px");
+    geometry.markForwarded(9);
+    expect(geometry.bind()).toEqual({ captureSequence: 9, width: 1170, height: 2532, coordinateSpace: "px" });
+  });
+
+  it("omits coordinateSpace from the binding when the geometry was bound in legacy point-space", () => {
+    const geometry = new TrackedScreenGeometry();
+    geometry.update(1170, 2532); // no space => legacy
+    geometry.markForwarded(9);
+    expect(geometry.bind()).toEqual({ captureSequence: 9, width: 1170, height: 2532 });
+  });
+
+  it("resets provenance on a coordinate-space flip even when the numeric dimensions coincide", () => {
+    // On a non-Display-Zoom device points*screenScale == points*nativeScale, so metadata
+    // appearing (legacy -> px) does not move the pixels. The space change must still reset the
+    // forwarded flag, or a later push would vouch a px identity for a legacy-bound capture.
+    const geometry = new TrackedScreenGeometry();
+    geometry.update(1170, 2532); // legacy
+    geometry.markForwarded(9);
+    expect(geometry.isForwarded).toBe(true);
+
+    geometry.update(1170, 2532, "px"); // same dims, space flips
+    expect(geometry.isForwarded).toBe(false);
+    expect(geometry.bind()).toBeNull();
+  });
 });

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -2852,18 +2852,21 @@ describe("IOSCtrlProxyClient", function() {
         expect(ctrlProxyClient.getScreenScaleMetadata()).toEqual(expectedFull);
       });
 
-      test("retention on receipt does NOT change the tracked geometry computation", async function() {
+      test("canonical pixels (#4549): the tracked geometry claim uses nativeScale pixel dims", async function() {
         await startStreamServer();
         const geometry = (ctrlProxyClient as any).screenGeometry;
 
-        // Display Zoom values chosen so the two computations DISAGREE: the tracked geometry stays
-        // points * screenScale (375*3=1125, 812*3=2436) while the reported pixel dims are
-        // points * nativeScale (1179x2553). #4549 flips geometry; this PR must not.
+        // Display Zoom values chosen so the two computations DISAGREE: points * screenScale
+        // (375*3=1125, 812*3=2436) vs the runner-reported pixel dims points * nativeScale
+        // (1179x2553). Under #4549 the capture-identity claim must equal the screenshot's real
+        // pixels, which XCUIScreenshot renders at NATIVE scale — so the claim is 1179x2553, NOT the
+        // old screenScale computation. This is what makes the daemon's exact pixel pairing work
+        // under Display Zoom.
         receiveHierarchy(fullMetadata);
         expect(ctrlProxyClient.getScreenScaleMetadata()).toEqual(expectedFull);
         const bound = geometry.bind();
-        expect(bound.width).toBe(1125);
-        expect(bound.height).toBe(2436);
+        expect(bound.width).toBe(1179);
+        expect(bound.height).toBe(2553);
       });
 
       test("legacy hierarchy without the fields: metadata is null", function() {

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -2918,6 +2918,46 @@ describe("IOSCtrlProxyClient", function() {
           });
         }
       });
+
+      test("stamps the screenshot's coordinateSpace from the request-time binding, not later metadata (#4549)", async function() {
+        const socket = await startStreamServer();
+        const geometry = (ctrlProxyClient as any).screenGeometry;
+
+        // Bind a CANONICAL-PIXEL capture: forward a hierarchy carrying complete #4548 scale metadata.
+        (ctrlProxyClient as any).pushHierarchyToObservationStream({ hierarchy: {} } as any, {
+          screenWidth: 375, screenHeight: 812, screenScale: 3,
+          nativeScale: 3, pixelWidth: 1125, pixelHeight: 2436,
+        });
+        const boundPx = geometry.bind();
+        expect(boundPx.coordinateSpace).toBe("px");
+
+        // A legacy hierarchy arrives while the frame is in flight, flipping the LATEST metadata to
+        // null. Reading it at delivery would DROP the px declaration from a canonical-bound frame.
+        (ctrlProxyClient as any).reportedScaleMetadata = null;
+        socket.reset();
+
+        (ctrlProxyClient as any).pushScreenshotToObservationStream(
+          "c2hvdA==", boundPx.width, boundPx.height, undefined, boundPx.captureSequence, boundPx.coordinateSpace
+        );
+        const pxShot = socket.getWrittenMessages<any>().find(m => m.type === "screenshot_update");
+        expect(pxShot.coordinateSpace).toBe("px"); // the bound value, NOT the flipped-to-null metadata
+
+        // Reverse: a LEGACY-bound capture must not gain px just because metadata later appeared.
+        (ctrlProxyClient as any).pushHierarchyToObservationStream({ hierarchy: {} } as any, {
+          screenWidth: 320, screenHeight: 693, screenScale: 3, // no nativeScale => legacy binding
+        });
+        const boundLegacy = geometry.bind();
+        expect(boundLegacy.coordinateSpace).toBeUndefined();
+
+        (ctrlProxyClient as any).reportedScaleMetadata = { nativeScale: 3, pixelWidth: 960, pixelHeight: 2079 };
+        socket.reset();
+
+        (ctrlProxyClient as any).pushScreenshotToObservationStream(
+          "c2hvdA==", boundLegacy.width, boundLegacy.height, undefined, boundLegacy.captureSequence, boundLegacy.coordinateSpace
+        );
+        const legacyShot = socket.getWrittenMessages<any>().find(m => m.type === "screenshot_update");
+        expect(legacyShot.coordinateSpace).toBeUndefined(); // bound legacy, NOT the flipped-to-px metadata
+      });
     });
 
     describe("coordinate-mapping golden vectors: LIVE iOS point->pixel (issue #4547)", function() {

--- a/test/fixtures/coordinate-mapping-golden-vectors.json
+++ b/test/fixtures/coordinate-mapping-golden-vectors.json
@@ -10,25 +10,35 @@
     "  test/parity/coordinateMappingGoldenVectorParity.test.ts parses those inline literals out of",
     "  the Kotlin source and verifies them against this file (the pinch drift-guard mechanism).",
     "- TypeScript: test/daemon/deviceDataStreamSocketServer.test.ts drives the daemon's",
-    "  pixelsMatchClaimedGeometry pairing from the geometryPairing section, and",
-    "  test/daemon/observationInitialFrame.test.ts drives the daemon's iOS point->pixel conversion",
-    "  from the iosPointToPixel section, both reading this file directly.",
+    "  pixelsMatchClaimedGeometry pairing from the geometryPairing section; the iosPointToPixel",
+    "  section drives BOTH the daemon's canonical-pixel element-bounds conversion",
+    "  (test/daemon/canonicalPixels.test.ts, roundHalfEven(point*nativeScale) + the round-trip proof)",
+    "  and its screenshot-dimension publishing (test/daemon/observationInitialFrame.test.ts, which",
+    "  now publishes the runner-reported pixel dimensions and stamps coordinateSpace:px).",
     "- Swift: ONE consumer, the scaleReporting section. Since #4548 the iOS runner derives the",
     "  physical screenshot pixel dimensions it reports (ElementLocator.computePixelDimensions,",
     "  points * UIScreen.nativeScale); ElementLocatorTests.swift holds an inline copy of the",
     "  scaleReporting rows and the parity suite parses it out of the source. The runner still",
-    "  performs no viewport<->device mapping: point-space bounds plus screenScale cross the wire",
-    "  and the point->pixel conversion for geometry pairing happens daemon-side in TypeScript",
-    "  (IOSCtrlProxyClient.updateScreenGeometryFrom / observationInitialFrame). The runner's other",
+    "  performs no viewport<->device mapping: point-space bounds plus nativeScale metadata cross the",
+    "  wire and the point->pixel conversion happens daemon-side in TypeScript (#4549:",
+    "  deviceDataStreamSocketServer.pushHierarchyUpdate -> convertHierarchyToCanonicalPixels,",
+    "  IOSCtrlProxyClient.updateScreenGeometryFrom, observationInitialFrame). The runner's other",
     "  coordinate math, pinch endpoint geometry, is pinned by pinch-golden-vectors.json.",
     "",
-    "These vectors PIN CURRENT BEHAVIOR. Rows with willChangeUnderCanonicalPixels=true document",
-    "iOS point-space cases whose expected values MUST change when #4549 converts hierarchy bounds",
-    "to canonical pixels — a green suite across that change means the conversion silently drifted.",
+    "Rows with willChangeUnderCanonicalPixels=true are the iOS cases the #4549 conversion touched",
+    "and were UPDATED in that PR to post-conversion (canonical-pixel) values. In viewportToDevice /",
+    "deviceToViewport the device dimensions became physical pixels (deviceWidth *= nativeScale) and",
+    "the expected mapper outputs scaled accordingly; the client mapper CODE is unchanged (it simply",
+    "receives px device dims now). In iosPointToPixel `scale` is now the runner-reported nativeScale",
+    "and the rows pin the daemon's point->pixel bounds/dimension conversion (a value coincides with",
+    "the old point*screenScale publish on non-Display-Zoom device classes, where screenScale ==",
+    "nativeScale — the semantic change there is the nativeScale source and the coordinateSpace:px",
+    "declaration, not the number). A green suite across a FUTURE conversion change still means drift.",
     "",
     "Booleans are encoded as 0/1 so the Kotlin inline tables stay purely numeric for the positional",
     "source parser. In geometryPairing, measuredWidth=measuredHeight=-1 means an unmeasurable frame.",
-    "In iosPointToPixel, scale=0 means the hierarchy carried no screenScale (daemon defaults to 1).",
+    "In iosPointToPixel, scale=0 means no runner scale metadata (pre-#4548 runner): the daemon does",
+    "not convert and does not stamp coordinateSpace:px (legacy point-space fallback).",
     "",
     "scaleReporting (#4548, B1) pins the RUNNER-side derivation of the reported physical pixel",
     "dimensions: pixel = round(point * nativeScale), where nativeScale is UIScreen.nativeScale on",
@@ -123,25 +133,25 @@
       "expectedX": 13, "expectedY": 7, "expectedInBounds": 1
     },
     {
-      "comment": "iOS 3x device (iPhone-class 390x844): device space is POINTS today, so a 390pt-wide frame maps 1:1. Under #4549 (canonical pixels) deviceWidth/deviceHeight become 1170x2532 and expectedX/expectedY become 585/1266.",
+      "comment": "iOS 3x device (iPhone-class 390x844): CANONICAL PIXELS (#4549). The daemon now publishes device dimensions in physical pixels (390pt x nativeScale 3 = 1170x2532), so a frame still displayed at 390px maps up by deviceWidth/frameWidthPx = 3. The input path divides the returned pixel coordinate back by nativeScale, so the physical tap is unchanged (585/3 = 195).",
       "willChangeUnderCanonicalPixels": true,
       "frameWidthPx": 390, "frameHeightPx": 844, "scale": 1, "offsetX": 0, "offsetY": 0,
-      "deviceWidth": 390, "deviceHeight": 844, "viewportX": 195, "viewportY": 422,
-      "expectedX": 195, "expectedY": 422, "expectedInBounds": 1
+      "deviceWidth": 1170, "deviceHeight": 2532, "viewportX": 195, "viewportY": 422,
+      "expectedX": 585, "expectedY": 1266, "expectedInBounds": 1
     },
     {
-      "comment": "iOS 2x device (375x667 points) with fractional viewport input. Under #4549 the device space becomes 750x1334 pixels and the expected coordinates double (modulo rounding).",
+      "comment": "iOS 2x device (375x667 points) with fractional viewport input: CANONICAL PIXELS (#4549). Device dimensions become 750x1334 (nativeScale 2), so the expected coordinates roughly double modulo float32 rounding (100.4 -> 201, 200.6 -> 401).",
       "willChangeUnderCanonicalPixels": true,
       "frameWidthPx": 375, "frameHeightPx": 667, "scale": 1, "offsetX": 0, "offsetY": 0,
-      "deviceWidth": 375, "deviceHeight": 667, "viewportX": 100.4, "viewportY": 200.6,
-      "expectedX": 100, "expectedY": 201, "expectedInBounds": 1
+      "deviceWidth": 750, "deviceHeight": 1334, "viewportX": 100.4, "viewportY": 200.6,
+      "expectedX": 201, "expectedY": 401, "expectedInBounds": 1
     },
     {
-      "comment": "iOS Display Zoom-like device (320x693 zoomed points at 3x). Under #4549 the device space becomes 960x2079 pixels.",
+      "comment": "iOS Display Zoom-like device (320x693 zoomed points at 3x): CANONICAL PIXELS (#4549). Device dimensions become 960x2079, so the frame-to-device ratio is 3 and the expected coordinates scale up (160 -> 480, 346.5 -> 1040).",
       "willChangeUnderCanonicalPixels": true,
       "frameWidthPx": 320, "frameHeightPx": 693, "scale": 1, "offsetX": 0, "offsetY": 0,
-      "deviceWidth": 320, "deviceHeight": 693, "viewportX": 160, "viewportY": 346.5,
-      "expectedX": 160, "expectedY": 347, "expectedInBounds": 1
+      "deviceWidth": 960, "deviceHeight": 2079, "viewportX": 160, "viewportY": 346.5,
+      "expectedX": 480, "expectedY": 1040, "expectedInBounds": 1
     },
     {
       "comment": "width-derived-ratio invariant: deliberately aspect-MISMATCHED frame (500x500 frame, 1000x2000 device; width ratio 2, height ratio 4). Not a realistic aspect-fitted frame — the pipeline pre-aligns rotation and fits to the device aspect — but it pins the documented rule that BOTH axes scale by deviceWidth/frameWidthPx: a height-derived y would give 800, not 400.",
@@ -170,11 +180,11 @@
       "expectedX": 17, "expectedY": 29
     },
     {
-      "comment": "iOS 3x point-space inverse. Under #4549 deviceWidth/deviceHeight become 1170x2532 pixels, so the same device point lands at a different viewport position.",
+      "comment": "iOS 3x inverse: CANONICAL PIXELS (#4549). deviceWidth/deviceHeight become 1170x2532, so the SAME device point (195,422) — now interpreted in physical pixels near the top-left — maps back to a different viewport position (device-to-frame ratio 390/1170 = 1/3): 195 -> 65, 422 -> 140.667.",
       "willChangeUnderCanonicalPixels": true,
       "deviceX": 195, "deviceY": 422, "frameWidthPx": 390, "frameHeightPx": 844, "scale": 1,
-      "offsetX": 0, "offsetY": 0, "deviceWidth": 390, "deviceHeight": 844,
-      "expectedX": 195, "expectedY": 422
+      "offsetX": 0, "offsetY": 0, "deviceWidth": 1170, "deviceHeight": 2532,
+      "expectedX": 65, "expectedY": 140.66667
     },
     {
       "comment": "width-derived-ratio invariant (inverse): deliberately aspect-MISMATCHED frame (500x500 frame, 1000x2000 device; width ratio 0.5, height ratio 0.25). Not a realistic aspect-fitted frame — it pins the documented rule that BOTH axes scale by frameWidthPx/deviceWidth: a height-derived y would give 100, not 200.",
@@ -345,37 +355,37 @@
   ],
   "iosPointToPixel": [
     {
-      "comment": "2x device: 375x667 points -> 750x1334 pixels. Under #4549 the hierarchy arrives in canonical pixels and this daemon-side multiply disappears (or becomes identity).",
+      "comment": "2x device: a 375x667 point rect converts to 750x1334 canonical pixels. Under #4549 `scale` is the runner-reported nativeScale (#4548): the daemon converts iOS element bounds points->pixels (roundHalfEven(point*nativeScale), test/daemon/canonicalPixels.test.ts) and publishes screenshot dims from the reported pixel dimensions — the old getIosScreenshotDimensions points*screenScale multiply disappears. Numeric value is unchanged on a non-Display-Zoom 2x device (nativeScale == screenScale == 2); what changed is the source (nativeScale, authoritative under Display Zoom) and the coordinateSpace:px declaration.",
       "willChangeUnderCanonicalPixels": true,
       "pointWidth": 375, "pointHeight": 667, "scale": 2,
       "expectedPixelWidth": 750, "expectedPixelHeight": 1334
     },
     {
-      "comment": "3x device: 390x844 points -> 1170x2532 pixels",
+      "comment": "3x device: 390x844 point rect -> 1170x2532 canonical pixels via nativeScale 3",
       "willChangeUnderCanonicalPixels": true,
       "pointWidth": 390, "pointHeight": 844, "scale": 3,
       "expectedPixelWidth": 1170, "expectedPixelHeight": 2532
     },
     {
-      "comment": "Display Zoom-like: zoomed 320x693 points at 3x -> 960x2079 pixels",
+      "comment": "Display Zoom-like: 320x693 point rect -> 960x2079 canonical pixels via nativeScale 3",
       "willChangeUnderCanonicalPixels": true,
       "pointWidth": 320, "pointHeight": 693, "scale": 3,
       "expectedPixelWidth": 960, "expectedPixelHeight": 2079
     },
     {
-      "comment": "fractional scale rounding boundary: 375*2.5 = 937.5 rounds half-up to 938",
+      "comment": "fractional nativeScale rounding boundary: 375*2.5 = 937.5 -> 938 (round-half-even: 938 is even; coincides with round-half-up here)",
       "willChangeUnderCanonicalPixels": true,
       "pointWidth": 375, "pointHeight": 812, "scale": 2.5,
       "expectedPixelWidth": 938, "expectedPixelHeight": 2030
     },
     {
-      "comment": "absent screenScale (0 sentinel): daemon defaults the multiplier to 1",
+      "comment": "no runner metadata (0 sentinel = pre-#4548 runner): the daemon does NOT convert — bounds stay point-space and the frame is not stamped coordinateSpace:px (legacy fallback), so the identity 390x844 is preserved",
       "willChangeUnderCanonicalPixels": true,
       "pointWidth": 390, "pointHeight": 844, "scale": 0,
       "expectedPixelWidth": 390, "expectedPixelHeight": 844
     },
     {
-      "comment": "fractional HEIGHT product isolated: 667*2.5 = 1667.5 rounds half-up to 1668 while the width product (400*2.5=1000) is integral — a height-axis-only rounding regression cannot hide behind the width case",
+      "comment": "fractional HEIGHT product isolated: 667*2.5 = 1667.5 -> 1668 (round-half-even) while the width product (400*2.5=1000) is integral — a height-axis-only rounding regression cannot hide behind the width case",
       "willChangeUnderCanonicalPixels": true,
       "pointWidth": 400, "pointHeight": 667, "scale": 2.5,
       "expectedPixelWidth": 1000, "expectedPixelHeight": 1668

--- a/test/parity/coordinateMappingGoldenVectorParity.test.ts
+++ b/test/parity/coordinateMappingGoldenVectorParity.test.ts
@@ -261,17 +261,19 @@ describe("coordinate-mapping golden vector parity (issue #4547)", function() {
     expect(computed.x).not.toBe(row.expectedX + 7);
   });
 
-  test("AC3: iOS point-space rows are explicitly flagged as changing under canonical pixels", function() {
-    // The proof the suite will catch the #4549 conversion: at least one row in each affected
-    // section is documented as MUST-change, so that PR has to touch this fixture deliberately.
+  test("AC3: the iOS rows were converted to canonical pixels under #4549", function() {
+    // The flags are the campaign's cross-language marker; #4549 UPDATED these rows to their
+    // post-conversion (canonical-pixel) values (the review artifact is this fixture's diff). The
+    // flags are retained so a FUTURE conversion change still has to touch the fixture deliberately.
     expect(canonical.viewportToDevice.some(row => row.willChangeUnderCanonicalPixels === true)).toBe(true);
     expect(canonical.deviceToViewport.some(row => row.willChangeUnderCanonicalPixels === true)).toBe(true);
     expect(canonical.iosPointToPixel.every(row => row.willChangeUnderCanonicalPixels === true)).toBe(true);
-    // And the flagged viewportToDevice rows are exactly the point-space ones (deviceWidth equals
-    // the frame width at scale 1 with an iOS point-class dimension, not an Android pixel one).
+    // Post-#4549 the flagged viewportToDevice rows are in PHYSICAL-PIXEL device space, which upscales
+    // the point-space display frame: deviceWidth = frameWidthPx * nativeScale, strictly greater than
+    // the frame width (an iOS point-class device dim equal to the frame width was the pre-#4549 state).
     for (const row of canonical.viewportToDevice) {
       if (row.willChangeUnderCanonicalPixels) {
-        expect(row.deviceWidth).toBeLessThan(1000);
+        expect(row.deviceWidth).toBeGreaterThan(row.frameWidthPx);
       }
     }
   });


### PR DESCRIPTION
## Summary

B2 of the canonical-pixel campaign ([#4547](https://github.com/kaeawc/auto-mobile/issues/4547) → [#4548](https://github.com/kaeawc/auto-mobile/issues/4548) → [#4549](https://github.com/kaeawc/auto-mobile/issues/4549) → [#4550](https://github.com/kaeawc/auto-mobile/issues/4550)) — the semantic pivot. The daemon now publishes iOS hierarchy **element bounds and screen dimensions in canonical physical pixels** on the observation-stream wire, and converts `input/*` pixel coordinates back to points for the iOS XCUITest runner. The change is **declared, never silent**: every geometry-bearing message gains `coordinateSpace: "px"`, and a message without it means legacy point-space.

Closes [#4549](https://github.com/kaeawc/auto-mobile/issues/4549).

Keyed on the runner-reported `nativeScale` from [#4548](https://github.com/kaeawc/auto-mobile/issues/4548) (**NOT** the old `screenScale` — they diverge under Display Zoom, and screenshots render at native scale). MCP `observe`/`tapOn` are untouched (still points); only the observation-stream wire and the `input/*` socket endpoints convert. Zero desktop-client and zero ide-plugin code changes — [#4550](https://github.com/kaeawc/auto-mobile/issues/4550) consumes the field for the client's exact-geometry migration.

## The `coordinateSpace` field + conversion math

New wire field on `hierarchy_update` and `screenshot_update`: `coordinateSpace?: "px"`. Present only when the runner supplied complete `ScreenScaleMetadata`; absent = legacy point-space.

**Publish (points → pixels), `src/daemon/canonicalPixels.ts` + `deviceDataStreamSocketServer.pushHierarchyUpdate`:**
- element bounds: `roundHalfEven(point * nativeScale)`
- screen dimensions: the runner-reported `pixelWidth`/`pixelHeight` directly (the old `getIosScreenshotDimensions` `points * screenScale` multiply disappears)
- converted on the diff **clone** the wire owns, so MCP `observe` keeps serving point-space bounds
- `screenshot_update` dims are the measured PNG pixels (already px); it is px-stamped when the caller declares px

**Capture identity (`IOSCtrlProxyClient.updateScreenGeometryFrom`):** the claim now uses the native-scale pixel dims, so the daemon's exact pixel pairing works under Display Zoom (the rotation W/H swap acceptance is kept).

**Input (pixels → points), `socketServer.handleInputTap`/`handleInputSwipe` → `toIosRunnerCoordinates`:** for iOS, `roundHalfEven(pixels / nativeScale)` before dispatch (XCUITest addresses the screen in points). Android is unchanged (already pixels).

## `coordinateSpace` gating — every branch, and the legacy path

| Site | px-mode (metadata present) | Legacy (no metadata, pre-#4548 runner) |
|---|---|---|
| `pushHierarchyUpdate` | convert bounds + dims, stamp `px` | no conversion, no stamp (byte-identical) |
| `pushScreenshotUpdate` | stamp `px` when caller declares it | no stamp |
| `getIosScreenshotDimensions` | reported `pixelWidth`/`pixelHeight` | legacy `round(points * screenScale)` |
| `updateScreenGeometryFrom` | native-scale pixel claim | legacy `round(points * screenScale)` |
| `input/tap`, `input/swipe` (iOS) | divide by `nativeScale` | pass through unchanged |

The legacy path is tested end-to-end: a hierarchy without runner metadata is not converted and not stamped (`deviceDataStreamSocketServer.test.ts`), the `scale=0` golden row asserts identity + no stamp, and the legacy iOS tap/swipe tests assert pass-through.

## Golden-vector diff (the review artifact)

All 10 flagged rows in `test/fixtures/coordinate-mapping-golden-vectors.json` were updated deliberately; **no unflagged row changed**. Drift guard, strict validation, TS/Kotlin consumers all green.

- **`viewportToDevice` (3 flagged)** — device dims became physical pixels (`deviceWidth *= nativeScale`), expected mapper outputs scaled accordingly. iOS 3x `390→1170`, expected `195/422 → 585/1266`; iOS 2x `375→750`, `→ 201/401`; Display-Zoom-like `320→960`, `→ 480/1040`.
- **`deviceToViewport` (1 flagged)** — iOS 3x inverse: device dims `390x844 → 1170x2532`, so the same device point `(195,422)` now in px maps back through ratio `1/3` to `(65, 140.667)`.
- **`iosPointToPixel` (6 flagged)** — `scale` is now the runner-reported `nativeScale`; the rows pin the daemon's point→pixel bounds/dimension conversion (`test/daemon/canonicalPixels.test.ts` drives the real converter; `observationInitialFrame.test.ts` drives the screenshot-dim publish + `px` stamp). **Numeric values are unchanged for these device classes** (the fixture's scales are integer/simple, where `screenScale == nativeScale`, and px-is-px for screen dims) — see the note below.
- The client mapper CODE (`DeviceScreenCoordinateMapper`) is **unchanged**; it simply receives px device dims now. `AC3` in the parity test was updated (flagged `viewportToDevice` rows are now physical-pixel device space, `deviceWidth > frameWidthPx`).

### Note on `iosPointToPixel` values (per the "same value" check)

For the non-Display-Zoom rows the numeric pixel value did **not** change, and this is correct, not a papered-over flag: screen **dimensions** were already published in pixels pre-#4549 (`round(points * screenScale)`), and on these device classes `screenScale == nativeScale`, so the number coincides. The genuine per-row change is (a) the **source** is now `nativeScale` — authoritative under Display Zoom, proven by the retained `IOSCtrlProxyClient` test where `nativeScale 3.144 ≠ screenScale 3` flips the capture claim `1125x2436 → 1179x2553`, and (b) the new `coordinateSpace:"px"` declaration. The genuinely all-device numeric change is in element **bounds** (points → pixels), newly pinned in `canonicalPixels.test.ts`. Flags are retained as the campaign's cross-language marker.

## Round-trip rounding proof

`roundHalfEven` (banker's rounding) both directions keeps the point → pixel → point round-trip within a single point at `.5` boundaries (no directional bias like `Math.round`). Pinned in `canonicalPixels.test.ts` across the golden rows: `|canonicalPixelsToPoints(roundHalfEven(point * nativeScale), nativeScale) - round(point)| <= 1`. So a tap sent in pixels lands at the same physical location as before.

## Validation

- **TypeScript:** `bun install --frozen-lockfile`; full `bun test` **11804 pass / 0 fail** (13 skip); `bun run lint` clean; `bun run typecheck` gate green (no new type errors). Mutation-checked the new module and both integration seams (round-half-even, screen-dim source, input divide, wire conversion, input conversion).
- **Kotlin:** `:desktop-core:test --tests CoordinateMappingGoldenVectorTest` BUILD SUCCESSFUL (JDK 21); ktfmt clean on the touched file.
- **Swift:** untouched — `scaleReporting` and `ElementLocatorTests.swift` are unchanged, so no re-cut and no `swift test` needed.
- Golden drift guard + strict validation + all three cross-language consumers green.

## Scope

B2 of the canonical-pixel campaign; [#4550](https://github.com/kaeawc/auto-mobile/issues/4550) consumes `coordinateSpace:"px"` for the client's exact-geometry checks. Zero desktop-client behavior change and zero ide-plugin changes here.
