### PR TITLE
fix: keep cleanup from blocking startup

### DIFF
--- a/scripts/ios/navigation-graph-sdk-event-integration.sh
+++ b/scripts/ios/navigation-graph-sdk-event-integration.sh
@@ -52,6 +52,14 @@ ctrl_proxy_port="$(jq -er --arg device_id "${device_id}" '
 
 curl --fail --silent --show-error --max-time 5 "http://127.0.0.1:${ctrl_proxy_port}/health" >/dev/null
 
+# `doctor` above may have started the shared CtrlProxy client while it was
+# unbound. Bind it to this graph session before posting events so its SDK-event
+# poller cannot consume them into the global NavigationGraphManager.
+if ! auto-mobile --debug --cli --session-uuid "${session_uuid}" observe --platform ios --deviceId "${device_id}" >/dev/null; then
+  echo "error: could not bind iOS SDK events to navigation graph session" >&2
+  exit 1
+fi
+
 event_payload() {
   local destination="$1"
   jq -cn \

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -710,6 +710,9 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   public override async ensureConnected(
     perf: PerformanceTracker = new NoOpPerformanceTracker()
   ): Promise<boolean> {
+    // Direct session tools connect here without passing through the manager.
+    await IOSCtrlProxyManager.awaitStartupOrphanRunnerReap();
+
     const connected = await super.ensureConnected(perf);
     if (connected) {
       return true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,7 +188,7 @@ async function main() {
     startStartupMaintenance({
       platform: process.platform,
       startAndroidSweep: () => AndroidCtrlProxyManager.sweepStalePrefetchDirsOnStartup(),
-      startIosReap: () => IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup(),
+      startIosReap: () => IOSCtrlProxyManager.startOrphanRunnerReapOnStartup(),
     });
     if (skipCtrlProxyDownload) {
       logger.info(`CtrlProxy downloads disabled (${SKIP_CTRL_PROXY_DOWNLOAD_FLAG} or ${SKIP_CTRL_PROXY_DOWNLOAD_ENV})`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ import {
   setFatalProcessHandler,
   setProcessShutdownHandler,
 } from "./processLifecycle";
+import { startStartupMaintenance } from "./utils/startupMaintenance";
 
 interface FatalLogger {
   error(...args: unknown[]): void;
@@ -181,10 +182,14 @@ async function main() {
     serverConfig.setNetworkMockableEnabled(networkMockable);
     serverConfig.setDismissKeyboardAfterInputEnabled(dismissKeyboardAfterInput);
     serverConfig.setEventAllMarkers(eventAllMarkers);
-    // Reclaim any auto-mobile-prefetch-* scratch dirs leaked by a previously
-    // crashed/killed daemon before its shutdown cleanup ran (#4334). Runs even
-    // when downloads are disabled, since leaked dirs still need reclaiming.
-    await AndroidCtrlProxyManager.sweepStalePrefetchDirsOnStartup();
+    // Reclaim artifacts leaked by previous daemons without gating stdio
+    // readiness. The sweeps are best-effort maintenance, not a prerequisite for
+    // serving a new client (issue #4581).
+    startStartupMaintenance({
+      platform: process.platform,
+      startAndroidSweep: () => AndroidCtrlProxyManager.sweepStalePrefetchDirsOnStartup(),
+      startIosReap: () => IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup(),
+    });
     if (skipCtrlProxyDownload) {
       logger.info(`CtrlProxy downloads disabled (${SKIP_CTRL_PROXY_DOWNLOAD_FLAG} or ${SKIP_CTRL_PROXY_DOWNLOAD_ENV})`);
     } else {
@@ -193,10 +198,9 @@ async function main() {
       AndroidCtrlProxyManager.prefetchApk();
     }
 
-    // Reap orphaned iOS runners before the daemon accepts iOS work, then start
-    // the build prefetch asynchronously so it can be ready for first use.
+    // Start the iOS build prefetch asynchronously so it can be ready for first
+    // use. Runner cleanup above is also asynchronous and bounded.
     if (process.platform === "darwin") {
-      await IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup();
       if (skipCtrlProxyDownload) {
         logger.info(`CtrlProxy iOS prefetch disabled (${SKIP_CTRL_PROXY_DOWNLOAD_FLAG} or ${SKIP_CTRL_PROXY_DOWNLOAD_ENV})`);
       } else {

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -262,6 +262,7 @@ export function registerDeviceTools() {
 
     perf.startOperation("ensureCtrlProxy");
     try {
+      await IOSCtrlProxyManager.awaitStartupOrphanRunnerReap();
       const manager = IOSCtrlProxyManager.getInstance(device);
       const xcTestClient = IOSCtrlProxyClient.getInstance(device, manager.getServicePort());
 

--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -29,6 +29,8 @@ import {
   DefaultAndroidPrerequisiteDetector
 } from "./android-cmdline-tools/AndroidPrerequisiteDetector";
 
+export const MAX_STALE_PREFETCH_DIRS_PER_STARTUP = 20;
+
 /**
  * Android-specific accessibility-service lifecycle, extending the
  * platform-agnostic {@link ProxyManager}.
@@ -424,24 +426,42 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       return;
     }
 
+    const candidates = entries.filter(
+      entry => entry.isDirectory() && entry.name.startsWith(AndroidCtrlProxyManager.PREFETCH_DIR_PREFIX)
+    );
     const now = timer.now();
-    let reclaimed = 0;
-    for (const entry of entries) {
-      if (!entry.isDirectory() || !entry.name.startsWith(AndroidCtrlProxyManager.PREFETCH_DIR_PREFIX)) {
-        continue;
-      }
+    const staleDirectories: string[] = [];
+    for (const entry of candidates) {
       const dir = path.join(tempRoot, entry.name);
       try {
         const stats = await fs.stat(dir);
-        if (now - stats.mtimeMs < AndroidCtrlProxyManager.STALE_PREFETCH_MAX_AGE_MS) {
-          continue;
+        if (now - stats.mtimeMs >= AndroidCtrlProxyManager.STALE_PREFETCH_MAX_AGE_MS) {
+          staleDirectories.push(dir);
         }
+      } catch (error) {
+        // Per-entry best-effort: a concurrent process may remove the same dir,
+        // or it may vanish mid-sweep. Skip it and keep going.
+        logger.debug(`[CTRL_PROXY] Failed to inspect stale prefetch dir ${dir}: ${error}`);
+      }
+    }
+
+    const skippedCandidateCount = Math.max(0, staleDirectories.length - MAX_STALE_PREFETCH_DIRS_PER_STARTUP);
+    if (skippedCandidateCount > 0) {
+      logger.warn(
+        `[CTRL_PROXY] Prefetch sweep skipped ${skippedCandidateCount} stale prefetch dir(s) after ` +
+        `reaching the ${MAX_STALE_PREFETCH_DIRS_PER_STARTUP}-directory startup cap`
+      );
+    }
+
+    let reclaimed = 0;
+    for (const dir of staleDirectories.slice(0, MAX_STALE_PREFETCH_DIRS_PER_STARTUP)) {
+      try {
         await fs.rm(dir, { recursive: true, force: true });
         reclaimed++;
       } catch (error) {
         // Per-entry best-effort: a concurrent process may remove the same dir,
         // or it may vanish mid-sweep. Skip it and keep going.
-        logger.debug(`[CTRL_PROXY] Failed to sweep stale prefetch dir ${dir}: ${error}`);
+        logger.debug(`[CTRL_PROXY] Failed to remove stale prefetch dir ${dir}: ${error}`);
       }
     }
 

--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -30,6 +30,7 @@ import {
 } from "./android-cmdline-tools/AndroidPrerequisiteDetector";
 
 export const MAX_STALE_PREFETCH_DIRS_PER_STARTUP = 20;
+export const STALE_PREFETCH_SWEEP_DEADLINE_MS = 5_000;
 
 /**
  * Android-specific accessibility-service lifecycle, extending the
@@ -430,43 +431,71 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
       entry => entry.isDirectory() && entry.name.startsWith(AndroidCtrlProxyManager.PREFETCH_DIR_PREFIX)
     );
     const now = timer.now();
-    const staleDirectories: string[] = [];
-    for (const entry of candidates) {
-      const dir = path.join(tempRoot, entry.name);
-      try {
-        const stats = await fs.stat(dir);
-        if (now - stats.mtimeMs >= AndroidCtrlProxyManager.STALE_PREFETCH_MAX_AGE_MS) {
-          staleDirectories.push(dir);
-        }
-      } catch (error) {
-        // Per-entry best-effort: a concurrent process may remove the same dir,
-        // or it may vanish mid-sweep. Skip it and keep going.
-        logger.debug(`[CTRL_PROXY] Failed to inspect stale prefetch dir ${dir}: ${error}`);
-      }
-    }
-
-    const skippedCandidateCount = Math.max(0, staleDirectories.length - MAX_STALE_PREFETCH_DIRS_PER_STARTUP);
-    if (skippedCandidateCount > 0) {
-      logger.warn(
-        `[CTRL_PROXY] Prefetch sweep skipped ${skippedCandidateCount} stale prefetch dir(s) after ` +
-        `reaching the ${MAX_STALE_PREFETCH_DIRS_PER_STARTUP}-directory startup cap`
-      );
-    }
-
+    const deadline = now + STALE_PREFETCH_SWEEP_DEADLINE_MS;
     let reclaimed = 0;
-    for (const dir of staleDirectories.slice(0, MAX_STALE_PREFETCH_DIRS_PER_STARTUP)) {
-      try {
-        await fs.rm(dir, { recursive: true, force: true });
-        reclaimed++;
-      } catch (error) {
-        // Per-entry best-effort: a concurrent process may remove the same dir,
-        // or it may vanish mid-sweep. Skip it and keep going.
-        logger.debug(`[CTRL_PROXY] Failed to remove stale prefetch dir ${dir}: ${error}`);
+    for (const [index, entry] of candidates.entries()) {
+      if (timer.now() >= deadline) {
+        AndroidCtrlProxyManager.logPrefetchSweepDeadline();
+        return;
+      }
+      const dir = path.join(tempRoot, entry.name);
+      const result = await AndroidCtrlProxyManager.reclaimStalePrefetchDir(dir, now, deadline, timer);
+      if (result === "deadline_exhausted") {
+        AndroidCtrlProxyManager.logPrefetchSweepDeadline();
+        return;
+      }
+      if (result !== "reclaimed") {
+        continue;
+      }
+      reclaimed++;
+      if (reclaimed === MAX_STALE_PREFETCH_DIRS_PER_STARTUP) {
+        AndroidCtrlProxyManager.logSkippedPrefetchCandidates(candidates.length - index - 1);
+        break;
       }
     }
 
     if (reclaimed > 0) {
       logger.info(`[CTRL_PROXY] Swept ${reclaimed} stale prefetch dir(s) from ${tempRoot}`);
+    }
+  }
+
+  private static async reclaimStalePrefetchDir(
+    dir: string,
+    now: number,
+    deadline: number,
+    timer: Timer
+  ): Promise<"reclaimed" | "not_stale" | "deadline_exhausted"> {
+    try {
+      const stats = await fs.stat(dir);
+      if (timer.now() >= deadline) {
+        return "deadline_exhausted";
+      }
+      if (now - stats.mtimeMs < AndroidCtrlProxyManager.STALE_PREFETCH_MAX_AGE_MS) {
+        return "not_stale";
+      }
+      await fs.rm(dir, { recursive: true, force: true });
+      return "reclaimed";
+    } catch (error) {
+      // Per-entry best-effort: a concurrent process may remove the same dir,
+      // or it may vanish mid-sweep. Skip it and keep going.
+      logger.debug(`[CTRL_PROXY] Failed to inspect stale prefetch dir ${dir}: ${error}`);
+      return "not_stale";
+    }
+  }
+
+  private static logPrefetchSweepDeadline(): void {
+    logger.warn(
+      `[CTRL_PROXY] Prefetch sweep timed out after ${STALE_PREFETCH_SWEEP_DEADLINE_MS}ms ` +
+      `while inspecting stale prefetch directories`
+    );
+  }
+
+  private static logSkippedPrefetchCandidates(skippedCandidateCount: number): void {
+    if (skippedCandidateCount > 0) {
+      logger.warn(
+        `[CTRL_PROXY] Prefetch sweep skipped ${skippedCandidateCount} uninspected prefetch dir candidate(s) after ` +
+        `reaching the ${MAX_STALE_PREFETCH_DIRS_PER_STARTUP}-directory startup cap`
+      );
     }
   }
 

--- a/src/utils/DeviceSessionManager.ts
+++ b/src/utils/DeviceSessionManager.ts
@@ -717,6 +717,7 @@ export class DeviceSessionManager implements DeviceSessionManager {
     try {
       const skipCtrlProxyIOSSetup = options?.skipCtrlProxyDownload ?? options?.skipAccessibilityDownload ?? options?.skipAccessibilitySetup;
 
+      await IOSCtrlProxyManager.awaitStartupOrphanRunnerReap();
       const manager = this.provider.getIOSCtrlProxyManager(device);
       const xcTestClient = this.provider.getIOSCtrlProxyClient(device, manager.getServicePort());
 

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -388,12 +388,19 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    * Starts orphan reaping during daemon initialization while retaining the
    * promise so the first simulator request cannot adopt a runner being reaped.
    */
-  public static startOrphanRunnerReapOnStartup(): Promise<void> {
-    const work = IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup();
-    IOSCtrlProxyManager.startupOrphanRunnerReap = work.catch(error => {
+  public static startOrphanRunnerReapOnStartup(
+    processClient: IOSCtrlProxyProcessClient = new IOSCtrlProxyProcessClient(),
+    timer: Timer = defaultTimer
+  ): Promise<void> {
+    const work = IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup(processClient, timer);
+    const completedWork = work.catch(error => {
       logger.debug(`[IOSCtrlProxy] Startup orphan runner sweep failed: ${error}`);
     });
-    return work;
+    IOSCtrlProxyManager.startupOrphanRunnerReap = IOSCtrlProxyManager.completeWithinStartupReapDeadline(
+      completedWork,
+      timer
+    );
+    return IOSCtrlProxyManager.startupOrphanRunnerReap;
   }
 
   /**
@@ -407,7 +414,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     const deadline = timer.now() + STARTUP_ORPHAN_RUNNER_REAP_DEADLINE_MS;
     let pids: number[] = [];
     try {
-      pids = await processClient.findStartupCandidatePids();
+      pids = await processClient.findStartupCandidatePids(deadline);
     } catch (error) {
       logger.debug(`[IOSCtrlProxy] Failed to enumerate CtrlProxy iOS processes during startup sweep: ${error}`);
       return;
@@ -416,36 +423,59 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     const reapedRootPids = new Set<number>();
     for (const pid of pids) {
       if (timer.now() >= deadline) {
-        logger.warn(
-          `[IOSCtrlProxy] startup CtrlProxy runner sweep timed out after ${STARTUP_ORPHAN_RUNNER_REAP_DEADLINE_MS}ms`
-        );
+        IOSCtrlProxyManager.logStartupOrphanRunnerReapDeadline();
         return;
       }
       try {
-        const root = await IOSCtrlProxyManager.findStartupOrphanRunnerRoot(processClient, pid, deadline, timer);
-        if (root.kind === "deadline_exhausted" || timer.now() >= deadline) {
-          logger.warn(
-            `[IOSCtrlProxy] startup CtrlProxy runner sweep timed out after ${STARTUP_ORPHAN_RUNNER_REAP_DEADLINE_MS}ms`
-          );
+        if (!await IOSCtrlProxyManager.reapStartupOrphanRunnerCandidate(
+          processClient,
+          pid,
+          deadline,
+          timer,
+          reapedRootPids
+        )) {
           return;
         }
-        if (root.kind !== "root" || reapedRootPids.has(root.pid)) {
-          continue;
-        }
-        if (reapedRootPids.size >= MAX_STARTUP_ORPHAN_RUNNER_CANDIDATES) {
-          logger.warn(
-            `[IOSCtrlProxy] startup sweep skipped 1 startup CtrlProxy runner candidate after ` +
-            `reaching the ${MAX_STARTUP_ORPHAN_RUNNER_CANDIDATES}-candidate cap`
-          );
-          return;
-        }
-        reapedRootPids.add(root.pid);
-        logger.info(`[IOSCtrlProxy] Reaping orphaned CtrlProxy iOS process tree rooted at ${root.pid}`);
-        await processClient.terminateProcessTree(root.pid);
       } catch (error) {
         logger.debug(`[IOSCtrlProxy] Failed to reap orphaned CtrlProxy iOS process ${pid}: ${error}`);
+        if (timer.now() >= deadline) {
+          IOSCtrlProxyManager.logStartupOrphanRunnerReapDeadline();
+          return;
+        }
       }
     }
+  }
+
+  private static async reapStartupOrphanRunnerCandidate(
+    processClient: IOSCtrlProxyProcessClient,
+    pid: number,
+    deadline: number,
+    timer: Timer,
+    reapedRootPids: Set<number>
+  ): Promise<boolean> {
+    const root = await IOSCtrlProxyManager.findStartupOrphanRunnerRoot(processClient, pid, deadline, timer);
+    if (root.kind === "deadline_exhausted" || timer.now() >= deadline) {
+      IOSCtrlProxyManager.logStartupOrphanRunnerReapDeadline();
+      return false;
+    }
+    if (root.kind !== "root" || reapedRootPids.has(root.pid)) {
+      return true;
+    }
+    if (reapedRootPids.size >= MAX_STARTUP_ORPHAN_RUNNER_CANDIDATES) {
+      logger.warn(
+        `[IOSCtrlProxy] startup sweep skipped 1 startup CtrlProxy runner candidate after ` +
+        `reaching the ${MAX_STARTUP_ORPHAN_RUNNER_CANDIDATES}-candidate cap`
+      );
+      return false;
+    }
+    reapedRootPids.add(root.pid);
+    logger.info(`[IOSCtrlProxy] Reaping orphaned CtrlProxy iOS process tree rooted at ${root.pid}`);
+    await processClient.terminateProcessTree(root.pid, deadline);
+    if (timer.now() >= deadline) {
+      IOSCtrlProxyManager.logStartupOrphanRunnerReapDeadline();
+      return false;
+    }
+    return true;
   }
 
   private static async findStartupOrphanRunnerRoot(
@@ -454,7 +484,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     deadline: number,
     timer: Timer
   ): Promise<DaemonManagedRunnerTreeRoot> {
-    const processInfo = await processClient.getProcessInfo(pid);
+    const processInfo = await processClient.getProcessInfo(pid, deadline);
     if (!processInfo || !processClient.isCtrlProxyRunnerCommand(processInfo.command)) {
       return { kind: "not_daemon_managed" };
     }
@@ -470,6 +500,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       {
         requireOrphanedRoot: true,
         shouldContinue: () => timer.now() < deadline,
+        deadline,
       }
     );
   }
@@ -1774,7 +1805,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   private static async findDaemonManagedRunnerTreeRoot(
     processClient: IOSCtrlProxyProcessClient,
     process: ListeningProcess,
-    options: { requireOrphanedRoot?: boolean; shouldContinue?: () => boolean } = {}
+    options: { requireOrphanedRoot?: boolean; shouldContinue?: () => boolean; deadline?: number } = {}
   ): Promise<DaemonManagedRunnerTreeRoot> {
     if (!IOSCtrlProxyManager.isCtrlProxyRunnerCommand(process.command)) {
       return { kind: "not_daemon_managed" };
@@ -1793,11 +1824,11 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     }
 
     while (parentPid !== undefined && parentPid > 1 && !visitedPids.has(parentPid)) {
-      if (options.shouldContinue && !options.shouldContinue()) {
+      if (!IOSCtrlProxyManager.shouldContinueStartupOrphanRunnerTraversal(options)) {
         return { kind: "deadline_exhausted" };
       }
       visitedPids.add(parentPid);
-      const parentInfo = await processClient.getProcessInfo(parentPid);
+      const parentInfo = await processClient.getProcessInfo(parentPid, options.deadline);
       if (!parentInfo) {
         break;
       }
@@ -1826,8 +1857,40 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     }
   }
 
-  private static async awaitStartupOrphanRunnerReap(): Promise<void> {
+  public static async awaitStartupOrphanRunnerReap(): Promise<void> {
     await IOSCtrlProxyManager.startupOrphanRunnerReap;
+  }
+
+  private static async completeWithinStartupReapDeadline(work: Promise<void>, timer: Timer): Promise<void> {
+    let timeout: NodeJS.Timeout | undefined;
+    try {
+      await Promise.race([
+        work,
+        new Promise<void>(resolve => {
+          timeout = timer.setTimeout(() => {
+            IOSCtrlProxyManager.logStartupOrphanRunnerReapDeadline();
+            resolve();
+          }, STARTUP_ORPHAN_RUNNER_REAP_DEADLINE_MS);
+          (timeout as { unref?: () => void }).unref?.();
+        }),
+      ]);
+    } finally {
+      if (timeout) {
+        timer.clearTimeout(timeout);
+      }
+    }
+  }
+
+  private static logStartupOrphanRunnerReapDeadline(): void {
+    logger.warn(
+      `[IOSCtrlProxy] startup CtrlProxy runner sweep timed out after ${STARTUP_ORPHAN_RUNNER_REAP_DEADLINE_MS}ms`
+    );
+  }
+
+  private static shouldContinueStartupOrphanRunnerTraversal(
+    options: { shouldContinue?: () => boolean }
+  ): boolean {
+    return options.shouldContinue?.() ?? true;
   }
 
   private static daemonManagedParentRoot(

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -24,6 +24,9 @@ import { IOSCtrlProxyHealthClient, isValidCtrlProxyPort } from "./ios/IOSCtrlPro
 import { IOSCtrlProxyProcessClient } from "./ios/IOSCtrlProxyProcessClient";
 import type { ProxyManager, ProxySetupResult } from "./interfaces/ProxyManager";
 
+export const MAX_STARTUP_ORPHAN_RUNNER_CANDIDATES = 20;
+export const STARTUP_ORPHAN_RUNNER_REAP_DEADLINE_MS = 5_000;
+
 /**
  * iOS-specific setup result; carries the build result alongside the
  * platform-agnostic fields.
@@ -377,6 +380,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     processClient: IOSCtrlProxyProcessClient = new IOSCtrlProxyProcessClient(),
     timer: Timer = defaultTimer
   ): Promise<void> {
+    const deadline = timer.now() + STARTUP_ORPHAN_RUNNER_REAP_DEADLINE_MS;
     let pids: number[] = [];
     try {
       pids = await processClient.findStartupCandidatePids();
@@ -385,7 +389,22 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       return;
     }
 
-    for (const pid of pids) {
+    const candidates = pids.slice(0, MAX_STARTUP_ORPHAN_RUNNER_CANDIDATES);
+    const skippedCandidateCount = pids.length - candidates.length;
+    if (skippedCandidateCount > 0) {
+      logger.warn(
+        `[IOSCtrlProxy] startup sweep skipped ${skippedCandidateCount} startup CtrlProxy runner candidate(s) after ` +
+        `reaching the ${MAX_STARTUP_ORPHAN_RUNNER_CANDIDATES}-candidate cap`
+      );
+    }
+
+    for (const pid of candidates) {
+      if (timer.now() >= deadline) {
+        logger.warn(
+          `[IOSCtrlProxy] startup CtrlProxy runner sweep timed out after ${STARTUP_ORPHAN_RUNNER_REAP_DEADLINE_MS}ms`
+        );
+        return;
+      }
       try {
         const processInfo = await processClient.getProcessInfo(pid);
         if (!processInfo || !processClient.isCtrlProxyRunnerCommand(processInfo.command)) {
@@ -400,8 +419,17 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
             environment: processInfo.environment,
             ppid: processInfo.ppid,
           },
-          { requireOrphanedRoot: true }
+          {
+            requireOrphanedRoot: true,
+            shouldContinue: () => timer.now() < deadline,
+          }
         );
+        if (timer.now() >= deadline) {
+          logger.warn(
+            `[IOSCtrlProxy] startup CtrlProxy runner sweep timed out after ${STARTUP_ORPHAN_RUNNER_REAP_DEADLINE_MS}ms`
+          );
+          return;
+        }
         if (rootPid === null) {
           continue;
         }
@@ -1711,7 +1739,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   private static async findDaemonManagedRunnerTreeRoot(
     processClient: IOSCtrlProxyProcessClient,
     process: ListeningProcess,
-    options: { requireOrphanedRoot?: boolean } = {}
+    options: { requireOrphanedRoot?: boolean; shouldContinue?: () => boolean } = {}
   ): Promise<number | null> {
     if (!IOSCtrlProxyManager.isCtrlProxyRunnerCommand(process.command)) {
       return null;
@@ -1726,6 +1754,9 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     }
 
     while (parentPid !== undefined && parentPid > 1 && !visitedPids.has(parentPid)) {
+      if (options.shouldContinue && !options.shouldContinue()) {
+        return null;
+      }
       visitedPids.add(parentPid);
       const parentInfo = await processClient.getProcessInfo(parentPid);
       if (!parentInfo) {

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -104,6 +104,16 @@ interface ListeningProcess {
   ppid?: number;
 }
 
+type DaemonManagedRunnerTreeRoot =
+  | { readonly kind: "root"; readonly pid: number }
+  | { readonly kind: "not_daemon_managed" }
+  | { readonly kind: "deadline_exhausted" };
+
+interface DaemonManagedRunnerParentRoot {
+  readonly rootPid: number | null;
+  readonly terminal: boolean;
+}
+
 // Re-exported from the extracted collaborator (issue #3218) so existing
 // consumers/tests keep importing it from this facade module.
 export type { HostPortAvailabilityChecker };
@@ -146,6 +156,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
 
   // Singleton instances per device
   private static instances: Map<string, IOSCtrlProxyManager> = new Map();
+  private static startupOrphanRunnerReap: Promise<void> | null = null;
 
   // Cache for status checks
   private cachedAvailability: { isAvailable: boolean; timestamp: number } | null = null;
@@ -361,6 +372,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
    */
   public static resetInstances(): void {
     IOSCtrlProxyManager.instances.clear();
+    IOSCtrlProxyManager.startupOrphanRunnerReap = null;
   }
 
   /**
@@ -370,6 +382,18 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
     const instances = Array.from(IOSCtrlProxyManager.instances.values());
     await Promise.all(instances.map(instance => instance.stop()));
     IOSCtrlProxyManager.instances.clear();
+  }
+
+  /**
+   * Starts orphan reaping during daemon initialization while retaining the
+   * promise so the first simulator request cannot adopt a runner being reaped.
+   */
+  public static startOrphanRunnerReapOnStartup(): Promise<void> {
+    const work = IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup();
+    IOSCtrlProxyManager.startupOrphanRunnerReap = work.catch(error => {
+      logger.debug(`[IOSCtrlProxy] Startup orphan runner sweep failed: ${error}`);
+    });
+    return work;
   }
 
   /**
@@ -389,16 +413,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       return;
     }
 
-    const candidates = pids.slice(0, MAX_STARTUP_ORPHAN_RUNNER_CANDIDATES);
-    const skippedCandidateCount = pids.length - candidates.length;
-    if (skippedCandidateCount > 0) {
-      logger.warn(
-        `[IOSCtrlProxy] startup sweep skipped ${skippedCandidateCount} startup CtrlProxy runner candidate(s) after ` +
-        `reaching the ${MAX_STARTUP_ORPHAN_RUNNER_CANDIDATES}-candidate cap`
-      );
-    }
-
-    for (const pid of candidates) {
+    const reapedRootPids = new Set<number>();
+    for (const pid of pids) {
       if (timer.now() >= deadline) {
         logger.warn(
           `[IOSCtrlProxy] startup CtrlProxy runner sweep timed out after ${STARTUP_ORPHAN_RUNNER_REAP_DEADLINE_MS}ms`
@@ -406,39 +422,56 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         return;
       }
       try {
-        const processInfo = await processClient.getProcessInfo(pid);
-        if (!processInfo || !processClient.isCtrlProxyRunnerCommand(processInfo.command)) {
-          continue;
-        }
-        const rootPid = await IOSCtrlProxyManager.findDaemonManagedRunnerTreeRoot(
-          processClient,
-          {
-            pid,
-            port: IOSCtrlProxyManager.DEFAULT_PORT,
-            command: processInfo.command,
-            environment: processInfo.environment,
-            ppid: processInfo.ppid,
-          },
-          {
-            requireOrphanedRoot: true,
-            shouldContinue: () => timer.now() < deadline,
-          }
-        );
-        if (timer.now() >= deadline) {
+        const root = await IOSCtrlProxyManager.findStartupOrphanRunnerRoot(processClient, pid, deadline, timer);
+        if (root.kind === "deadline_exhausted" || timer.now() >= deadline) {
           logger.warn(
             `[IOSCtrlProxy] startup CtrlProxy runner sweep timed out after ${STARTUP_ORPHAN_RUNNER_REAP_DEADLINE_MS}ms`
           );
           return;
         }
-        if (rootPid === null) {
+        if (root.kind !== "root" || reapedRootPids.has(root.pid)) {
           continue;
         }
-        logger.info(`[IOSCtrlProxy] Reaping orphaned CtrlProxy iOS process tree rooted at ${rootPid}`);
-        await processClient.terminateProcessTree(rootPid);
+        if (reapedRootPids.size >= MAX_STARTUP_ORPHAN_RUNNER_CANDIDATES) {
+          logger.warn(
+            `[IOSCtrlProxy] startup sweep skipped 1 startup CtrlProxy runner candidate after ` +
+            `reaching the ${MAX_STARTUP_ORPHAN_RUNNER_CANDIDATES}-candidate cap`
+          );
+          return;
+        }
+        reapedRootPids.add(root.pid);
+        logger.info(`[IOSCtrlProxy] Reaping orphaned CtrlProxy iOS process tree rooted at ${root.pid}`);
+        await processClient.terminateProcessTree(root.pid);
       } catch (error) {
         logger.debug(`[IOSCtrlProxy] Failed to reap orphaned CtrlProxy iOS process ${pid}: ${error}`);
       }
     }
+  }
+
+  private static async findStartupOrphanRunnerRoot(
+    processClient: IOSCtrlProxyProcessClient,
+    pid: number,
+    deadline: number,
+    timer: Timer
+  ): Promise<DaemonManagedRunnerTreeRoot> {
+    const processInfo = await processClient.getProcessInfo(pid);
+    if (!processInfo || !processClient.isCtrlProxyRunnerCommand(processInfo.command)) {
+      return { kind: "not_daemon_managed" };
+    }
+    return IOSCtrlProxyManager.findDaemonManagedRunnerTreeRoot(
+      processClient,
+      {
+        pid,
+        port: IOSCtrlProxyManager.DEFAULT_PORT,
+        command: processInfo.command,
+        environment: processInfo.environment,
+        ppid: processInfo.ppid,
+      },
+      {
+        requireOrphanedRoot: true,
+        shouldContinue: () => timer.now() < deadline,
+      }
+    );
   }
 
   /**
@@ -657,6 +690,8 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         `AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_PATH / _IPA_PATH is set but unusable: ${iosOverride.reason}`
       );
     }
+
+    await this.awaitStartupOrphanRunnerReap();
 
     logger.info("[IOSCtrlProxy] Starting CtrlProxy");
     this.isStopping = false;
@@ -1600,7 +1635,7 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
           this.processClient,
           process
         );
-        if (daemonManagedRoot !== null && daemonManagedRoot !== process.pid) {
+        if (daemonManagedRoot.kind === "root" && daemonManagedRoot.pid !== process.pid) {
           continue;
         }
         if (!await this.processAncestryContainsDeviceId(process)) {
@@ -1732,30 +1767,34 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
   }
 
   private async findDaemonManagedRunnerTreeRoot(process: ListeningProcess): Promise<number> {
-    return (await IOSCtrlProxyManager.findDaemonManagedRunnerTreeRoot(this.processClient, process)) ??
-      process.pid;
+    const result = await IOSCtrlProxyManager.findDaemonManagedRunnerTreeRoot(this.processClient, process);
+    return result.kind === "root" ? result.pid : process.pid;
   }
 
   private static async findDaemonManagedRunnerTreeRoot(
     processClient: IOSCtrlProxyProcessClient,
     process: ListeningProcess,
     options: { requireOrphanedRoot?: boolean; shouldContinue?: () => boolean } = {}
-  ): Promise<number | null> {
+  ): Promise<DaemonManagedRunnerTreeRoot> {
     if (!IOSCtrlProxyManager.isCtrlProxyRunnerCommand(process.command)) {
-      return null;
+      return { kind: "not_daemon_managed" };
     }
 
-    let rootPid: number | null = process.ppid === 1 ? process.pid : null;
+    let rootPid = process.ppid === 1 ? process.pid : null;
     let parentPid = process.ppid;
     const visitedPids = new Set<number>([process.pid]);
 
     if (IOSCtrlProxyManager.isDaemonManagedSimulatorXcodebuildCommandShape(process.command)) {
-      rootPid = options.requireOrphanedRoot && process.ppid !== 1 ? null : process.pid;
+      rootPid = IOSCtrlProxyManager.rootPidForDaemonManagedProcess(
+        process.pid,
+        process.ppid,
+        options.requireOrphanedRoot
+      );
     }
 
     while (parentPid !== undefined && parentPid > 1 && !visitedPids.has(parentPid)) {
       if (options.shouldContinue && !options.shouldContinue()) {
-        return null;
+        return { kind: "deadline_exhausted" };
       }
       visitedPids.add(parentPid);
       const parentInfo = await processClient.getProcessInfo(parentPid);
@@ -1763,21 +1802,60 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
         break;
       }
 
-      if (
-        IOSCtrlProxyManager.isShellCommand(parentInfo.command) &&
-        IOSCtrlProxyManager.isDaemonManagedSimulatorXcodebuildCommandShape(parentInfo.command)
-      ) {
-        return options.requireOrphanedRoot && parentInfo.ppid !== 1 ? null : parentPid;
-      }
-
-      if (IOSCtrlProxyManager.isDaemonManagedSimulatorXcodebuildCommandShape(parentInfo.command)) {
-        rootPid = options.requireOrphanedRoot && parentInfo.ppid !== 1 ? null : parentPid;
+      const parentRoot = IOSCtrlProxyManager.daemonManagedParentRoot(
+        parentInfo,
+        parentPid,
+        options.requireOrphanedRoot
+      );
+      if (parentRoot) {
+        if (parentRoot.terminal) {
+          return IOSCtrlProxyManager.toDaemonManagedRunnerTreeRoot(parentRoot.rootPid);
+        }
+        rootPid = parentRoot.rootPid;
       }
 
       parentPid = parentInfo.ppid;
     }
 
-    return rootPid;
+    return IOSCtrlProxyManager.toDaemonManagedRunnerTreeRoot(rootPid);
+  }
+
+  private async awaitStartupOrphanRunnerReap(): Promise<void> {
+    if (this.isSimulator()) {
+      await IOSCtrlProxyManager.awaitStartupOrphanRunnerReap();
+    }
+  }
+
+  private static async awaitStartupOrphanRunnerReap(): Promise<void> {
+    await IOSCtrlProxyManager.startupOrphanRunnerReap;
+  }
+
+  private static daemonManagedParentRoot(
+    process: { command: string; ppid?: number },
+    pid: number,
+    requireOrphanedRoot: boolean | undefined
+  ): DaemonManagedRunnerParentRoot | null {
+    if (!IOSCtrlProxyManager.isDaemonManagedSimulatorXcodebuildCommandShape(process.command)) {
+      return null;
+    }
+    return {
+      rootPid: IOSCtrlProxyManager.rootPidForDaemonManagedProcess(pid, process.ppid, requireOrphanedRoot),
+      terminal: IOSCtrlProxyManager.isShellCommand(process.command),
+    };
+  }
+
+  private static rootPidForDaemonManagedProcess(
+    pid: number,
+    ppid: number | undefined,
+    requireOrphanedRoot: boolean | undefined
+  ): number | null {
+    return requireOrphanedRoot && ppid !== 1 ? null : pid;
+  }
+
+  private static toDaemonManagedRunnerTreeRoot(rootPid: number | null): DaemonManagedRunnerTreeRoot {
+    return rootPid === null
+      ? { kind: "not_daemon_managed" }
+      : { kind: "root", pid: rootPid };
   }
 
   private formatListeningProcesses(processes: ListeningProcess[]): string {

--- a/src/utils/ios/IOSCtrlProxyProcessClient.ts
+++ b/src/utils/ios/IOSCtrlProxyProcessClient.ts
@@ -113,6 +113,10 @@ export class IOSCtrlProxyProcessClient {
       const result = await this.executeCommand("kill", ["-0", String(pid)], deadline);
       return !/operation not permitted|permission denied/i.test(result.stderr);
     } catch (error) {
+      // A command error means the process is unavailable only while the
+      // caller's cleanup budget remains. Do not turn deadline expiry into a
+      // successful exit observation.
+      this.remainingTimeoutMs(deadline);
       logger.debug(`[IOSCtrlProxy] Failed to check PID ${pid}: ${error}`);
       return false;
     }

--- a/src/utils/ios/IOSCtrlProxyProcessClient.ts
+++ b/src/utils/ios/IOSCtrlProxyProcessClient.ts
@@ -64,11 +64,11 @@ export class IOSCtrlProxyProcessClient {
     return null;
   }
 
-  async findStartupCandidatePids(): Promise<number[]> {
+  async findStartupCandidatePids(deadline?: number): Promise<number[]> {
     // The startup sweep caps inspection, so discover only CtrlProxy-shaped
     // commands before the cap rather than letting unrelated xcodebuild work
     // consume it.
-    return this.findPids("CtrlProxy", false);
+    return this.findPids("CtrlProxy", false, deadline);
   }
 
   async findXcodebuildPids(): Promise<number[]> {
@@ -88,14 +88,18 @@ export class IOSCtrlProxyProcessClient {
     }
   }
 
-  async getProcessInfo(pid: number): Promise<CtrlProxyProcessInfo | null> {
+  async getProcessInfo(pid: number, deadline?: number): Promise<CtrlProxyProcessInfo | null> {
     try {
-      const { stdout } = await this.host.executeCommand("ps", ["-p", String(pid), "-o", "ppid=", "-o", "args="]);
+      const { stdout } = await this.executeCommand(
+        "ps",
+        ["-p", String(pid), "-o", "ppid=", "-o", "args="],
+        deadline
+      );
       const output = stdout.trim();
       if (!output) {
         return null;
       }
-      const environment = await this.getProcessEnvironment(pid);
+      const environment = await this.getProcessEnvironment(pid, deadline);
       const match = output.match(/^(\d+)\s+([\s\S]+)$/);
       return match ? { ppid: Number.parseInt(match[1], 10), command: match[2], environment } : { command: output, environment };
     } catch (error) {
@@ -104,9 +108,9 @@ export class IOSCtrlProxyProcessClient {
     }
   }
 
-  async isRunning(pid: number): Promise<boolean> {
+  async isRunning(pid: number, deadline?: number): Promise<boolean> {
     try {
-      const result = await this.host.executeCommand("kill", ["-0", String(pid)]);
+      const result = await this.executeCommand("kill", ["-0", String(pid)], deadline);
       return !/operation not permitted|permission denied/i.test(result.stderr);
     } catch (error) {
       logger.debug(`[IOSCtrlProxy] Failed to check PID ${pid}: ${error}`);
@@ -123,9 +127,9 @@ export class IOSCtrlProxyProcessClient {
       this.hasDeviceIdentity(`${process.command} ${process.environment ?? ""}`, deviceId);
   }
 
-  async findDescendantProcessIds(rootPid: number): Promise<number[]> {
+  async findDescendantProcessIds(rootPid: number, deadline?: number): Promise<number[]> {
     try {
-      const { stdout } = await this.host.executeCommand("ps", ["-axo", "pid=,ppid="]);
+      const { stdout } = await this.executeCommand("ps", ["-axo", "pid=,ppid="], deadline);
       const children = new Map<number, number[]>();
       for (const line of stdout.trim().split("\n")) {
         const match = line.trim().match(/^(\d+)\s+(\d+)$/);
@@ -151,15 +155,15 @@ export class IOSCtrlProxyProcessClient {
     }
   }
 
-  async terminateProcessTree(pid: number): Promise<void> {
-    const descendants = await this.findDescendantProcessIds(pid);
+  async terminateProcessTree(pid: number, deadline?: number): Promise<void> {
+    const descendants = await this.findDescendantProcessIds(pid, deadline);
     const targets = [...descendants].reverse().concat(pid);
-    await this.signalGroup(pid, "TERM");
-    await this.signalPids(targets, "TERM");
-    if (await this.waitForExit([pid, ...descendants])) {return;}
-    await this.signalGroup(pid, "KILL");
-    await this.signalPids(targets, "KILL");
-    await this.waitForExit([pid, ...descendants]);
+    await this.signalGroup(pid, "TERM", deadline);
+    await this.signalPids(targets, "TERM", deadline);
+    if (await this.waitForExit([pid, ...descendants], deadline)) {return;}
+    await this.signalGroup(pid, "KILL", deadline);
+    await this.signalPids(targets, "KILL", deadline);
+    await this.waitForExit([pid, ...descendants], deadline);
   }
 
   async terminateProcess(pid: number): Promise<void> {
@@ -187,9 +191,9 @@ export class IOSCtrlProxyProcessClient {
     return shape && (process.ppid === 1 || !this.hasExternalXcodebuildIdentity(process.environment ?? ""));
   }
 
-  private async findPids(pattern: string, exact: boolean): Promise<number[]> {
+  private async findPids(pattern: string, exact: boolean, deadline?: number): Promise<number[]> {
     try {
-      const { stdout } = await this.host.executeCommand("pgrep", [exact ? "-x" : "-f", pattern]);
+      const { stdout } = await this.executeCommand("pgrep", [exact ? "-x" : "-f", pattern], deadline);
       return stdout.trim().split("\n").flatMap(line => {
         const pid = Number.parseInt(line, 10);
         return Number.isNaN(pid) ? [] : [pid];
@@ -200,9 +204,13 @@ export class IOSCtrlProxyProcessClient {
     }
   }
 
-  private async getProcessEnvironment(pid: number): Promise<string | undefined> {
+  private async getProcessEnvironment(pid: number, deadline?: number): Promise<string | undefined> {
     try {
-      const { stdout } = await this.host.executeCommand("ps", ["eww", "-p", String(pid), "-o", "command="]);
+      const { stdout } = await this.executeCommand(
+        "ps",
+        ["eww", "-p", String(pid), "-o", "command="],
+        deadline
+      );
       return stdout.trim() || undefined;
     } catch (error) {
       logger.debug(`[IOSCtrlProxy] Failed to inspect environment for PID ${pid}: ${error}`);
@@ -219,36 +227,57 @@ export class IOSCtrlProxyProcessClient {
     return environment.includes("CTRL_PROXY_IOS_PORT=") || environment.includes("AUTOMOBILE_DEVICE_ID=") || environment.includes("SIMCTL_CHILD_AUTOMOBILE_DEVICE_ID=");
   }
 
-  private async signalGroup(pid: number, signal: "TERM" | "KILL"): Promise<void> {
+  private async signalGroup(pid: number, signal: "TERM" | "KILL", deadline?: number): Promise<void> {
     try {
-      await this.host.executeCommand("kill", [`-${signal}`, "--", `-${pid}`]);
+      await this.executeCommand("kill", [`-${signal}`, "--", `-${pid}`], deadline);
     } catch (error) {
       logger.debug(`[IOSCtrlProxy] PID ${pid} is not a signalable process group: ${error}`);
     }
   }
 
-  private async signalPids(pids: number[], signal: "TERM" | "KILL"): Promise<void> {
+  private async signalPids(pids: number[], signal: "TERM" | "KILL", deadline?: number): Promise<void> {
     for (const pid of pids) {
       try {
-        await this.host.executeCommand("kill", [`-${signal}`, String(pid)]);
+        await this.executeCommand("kill", [`-${signal}`, String(pid)], deadline);
       } catch (error) {
         logger.debug(`[IOSCtrlProxy] PID ${pid} exited before ${signal}: ${error}`);
       }
     }
   }
 
-  private async waitForExit(pids: number[]): Promise<boolean> {
+  private async waitForExit(pids: number[], deadline?: number): Promise<boolean> {
     for (let attempt = 0; attempt < this.releaseAttempts; attempt++) {
-      if (await this.haveExited(pids)) {return true;}
-      await this.timer.sleep(this.releaseGraceMs);
+      if (await this.haveExited(pids, deadline)) {return true;}
+      const delayMs = this.remainingTimeoutMs(deadline);
+      await this.timer.sleep(delayMs === undefined ? this.releaseGraceMs : Math.min(this.releaseGraceMs, delayMs));
     }
-    return this.haveExited(pids);
+    return this.haveExited(pids, deadline);
   }
 
-  private async haveExited(pids: number[]): Promise<boolean> {
+  private async haveExited(pids: number[], deadline?: number): Promise<boolean> {
     for (const pid of pids) {
-      if (await this.isRunning(pid)) {return false;}
+      if (await this.isRunning(pid, deadline)) {return false;}
     }
     return true;
+  }
+
+  private async executeCommand(
+    file: string,
+    args: string[],
+    deadline?: number
+  ): Promise<Awaited<ReturnType<HostCommandExecutor["executeCommand"]>>> {
+    const timeoutMs = this.remainingTimeoutMs(deadline);
+    return this.host.executeCommand(file, args, timeoutMs === undefined ? undefined : { timeoutMs });
+  }
+
+  private remainingTimeoutMs(deadline: number | undefined): number | undefined {
+    if (deadline === undefined) {
+      return undefined;
+    }
+    const remainingMs = deadline - this.timer.now();
+    if (remainingMs <= 0) {
+      throw new Error("Startup CtrlProxy runner sweep deadline elapsed");
+    }
+    return remainingMs;
   }
 }

--- a/src/utils/ios/IOSCtrlProxyProcessClient.ts
+++ b/src/utils/ios/IOSCtrlProxyProcessClient.ts
@@ -65,13 +65,10 @@ export class IOSCtrlProxyProcessClient {
   }
 
   async findStartupCandidatePids(): Promise<number[]> {
-    const pids = new Set<number>();
-    for (const [pattern, exact] of [["xcodebuild", true], ["CtrlProxyUITests-Runner", false]] as const) {
-      for (const pid of await this.findPids(pattern, exact)) {
-        pids.add(pid);
-      }
-    }
-    return [...pids];
+    // The startup sweep caps inspection, so discover only CtrlProxy-shaped
+    // commands before the cap rather than letting unrelated xcodebuild work
+    // consume it.
+    return this.findPids("CtrlProxy", false);
   }
 
   async findXcodebuildPids(): Promise<number[]> {

--- a/src/utils/startupMaintenance.ts
+++ b/src/utils/startupMaintenance.ts
@@ -1,7 +1,7 @@
 import { defaultTimer, type Timer } from "./SystemTimer";
 import { logger, type Logger } from "./logger";
 
-export const STARTUP_MAINTENANCE_TIMEOUT_MS = 5_000;
+export const STARTUP_MAINTENANCE_SLOW_WARNING_MS = 5_000;
 
 export interface StartupMaintenanceDependencies {
   readonly platform: NodeJS.Platform;
@@ -51,9 +51,9 @@ function startBackgroundCleanup(
 
   const timeout = timer.setTimeout(() => {
     log.warn(
-      `[STARTUP_MAINTENANCE] ${label} exceeded ${STARTUP_MAINTENANCE_TIMEOUT_MS}ms; continuing startup`
+      `[STARTUP_MAINTENANCE] ${label} exceeded ${STARTUP_MAINTENANCE_SLOW_WARNING_MS}ms; continuing startup`
     );
-  }, STARTUP_MAINTENANCE_TIMEOUT_MS);
+  }, STARTUP_MAINTENANCE_SLOW_WARNING_MS);
   (timeout as { unref?: () => void }).unref?.();
 
   void work

--- a/src/utils/startupMaintenance.ts
+++ b/src/utils/startupMaintenance.ts
@@ -1,0 +1,70 @@
+import { defaultTimer, type Timer } from "./SystemTimer";
+import { logger, type Logger } from "./logger";
+
+export const STARTUP_MAINTENANCE_TIMEOUT_MS = 5_000;
+
+export interface StartupMaintenanceDependencies {
+  readonly platform: NodeJS.Platform;
+  readonly startAndroidSweep: () => Promise<void>;
+  readonly startIosReap: () => Promise<void>;
+  readonly timer?: Timer;
+  readonly logger?: Logger;
+}
+
+/**
+ * Starts cleanup leaked by previous daemon processes without delaying JSON-RPC
+ * readiness. The work remains best-effort after the caller's bounded window.
+ */
+export function startStartupMaintenance(dependencies: StartupMaintenanceDependencies): void {
+  const timer = dependencies.timer ?? defaultTimer;
+  const log = dependencies.logger ?? logger;
+
+  startBackgroundCleanup(
+    "Android CtrlProxy prefetch cleanup",
+    dependencies.startAndroidSweep,
+    timer,
+    log
+  );
+  if (dependencies.platform === "darwin") {
+    startBackgroundCleanup(
+      "iOS CtrlProxy runner cleanup",
+      dependencies.startIosReap,
+      timer,
+      log
+    );
+  }
+}
+
+function startBackgroundCleanup(
+  label: string,
+  cleanup: () => Promise<void>,
+  timer: Timer,
+  log: Logger
+): void {
+  let work: Promise<void>;
+  try {
+    work = cleanup();
+  } catch (error) {
+    log.warn(`[STARTUP_MAINTENANCE] ${label} failed: ${formatError(error)}`);
+    return;
+  }
+
+  const timeout = timer.setTimeout(() => {
+    log.warn(
+      `[STARTUP_MAINTENANCE] ${label} exceeded ${STARTUP_MAINTENANCE_TIMEOUT_MS}ms; continuing startup`
+    );
+  }, STARTUP_MAINTENANCE_TIMEOUT_MS);
+  (timeout as { unref?: () => void }).unref?.();
+
+  void work
+    .catch(error => {
+      log.warn(`[STARTUP_MAINTENANCE] ${label} failed: ${formatError(error)}`);
+    })
+    .finally(() => {
+      timer.clearTimeout(timeout);
+    });
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/test/bats/navigation-graph-sdk-event-integration.bats
+++ b/test/bats/navigation-graph-sdk-event-integration.bats
@@ -7,6 +7,7 @@ setup() {
   ORIG_PATH="$PATH"
   export GRAPH_ATTEMPTS_FILE="${MOCK_BIN}/graph-attempts"
   export CURL_URL_FILE="${MOCK_BIN}/curl-urls"
+  export SESSION_OBSERVE_FILE="${MOCK_BIN}/session-observe"
 }
 
 teardown() {
@@ -26,7 +27,14 @@ SCRIPT
 
 @test "retries getNavigationGraph after an initial CLI failure" {
   make_mock xcrun 'exit 0'
-  make_mock curl 'printf "%s\\n" "${!#}" >> "$CURL_URL_FILE"'
+  make_mock curl '
+url="${!#}"
+if [[ "$url" == */sdk-events ]] && [[ ! -f "$SESSION_OBSERVE_FILE" ]]; then
+  echo "SDK events were posted before the graph session was bound" >&2
+  exit 1
+fi
+printf "%s\\n" "$url" >> "$CURL_URL_FILE"
+'
   make_mock base64 'cat'
   make_mock sleep 'exit 0'
   make_mock jq '
@@ -43,6 +51,10 @@ exit 0
   make_mock auto-mobile '
 if [ "$1" = "--cli" ] && [ "$2" = "doctor" ]; then
   printf "{\"ios\":{\"checks\":[]}}\\n"
+  exit 0
+fi
+if [ "$1" = "--debug" ] && [ "$2" = "--cli" ] && [ "$3" = "--session-uuid" ] && [ "$5" = "observe" ]; then
+  touch "$SESSION_OBSERVE_FILE"
   exit 0
 fi
 if [ "$1" = "--debug" ] && [ "$2" = "--cli" ] && [ "$3" = "--session-uuid" ] && [ "$5" = "getNavigationGraph" ]; then

--- a/test/features/observe/ios/CtrlProxyClientAutoSetup.test.ts
+++ b/test/features/observe/ios/CtrlProxyClientAutoSetup.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { IOSCtrlProxyClient } from "../../../../src/features/observe/ios";
 import { BootedDevice } from "../../../../src/models";
 import {
@@ -8,6 +8,15 @@ import {
 import { FakeTimer } from "../../../fakes/FakeTimer";
 import { FakeIOSCtrlProxyManager } from "../../../fakes/FakeIOSCtrlProxyManager";
 import type { ServiceManagerFactory, BootedDeviceLister } from "../../../../src/features/observe/ios/IOSCtrlProxyClient";
+import { IOSCtrlProxyManager } from "../../../../src/utils/IOSCtrlProxyManager";
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>(done => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
 
 describe("IOSCtrlProxyClient auto-setup", function() {
   let testDevice: BootedDevice;
@@ -170,6 +179,42 @@ describe("IOSCtrlProxyClient auto-setup", function() {
     expect(fakeManager.wasMethodCalled("setup:force=true")).toBe(false);
 
     await client.close();
+  });
+
+  test("waits for startup reaping before connecting directly to an existing runner", async function() {
+    const reaping = deferred();
+    const reapSpy = spyOn(
+      IOSCtrlProxyManager,
+      "reapOrphanedRunnerProcessesOnStartup"
+    ).mockImplementation(() => reaping.promise);
+    const urls: string[] = [];
+    const client = IOSCtrlProxyClient.createForTesting(
+      testDevice,
+      serverPort,
+      url => {
+        urls.push(url);
+        return createSuccessWebSocketFactory(fakeTimer)(url);
+      },
+      fakeTimer,
+      createManagerFactory()
+    );
+
+    try {
+      IOSCtrlProxyManager.startOrphanRunnerReapOnStartup();
+      const connecting = client.ensureConnected();
+      await Promise.resolve();
+
+      expect(urls).toEqual([]);
+
+      reaping.resolve();
+      await expect(connecting).resolves.toBe(true);
+      expect(urls).toEqual(["ws://localhost:8765/ws"]);
+    } finally {
+      reaping.resolve();
+      await client.close();
+      reapSpy.mockRestore();
+      IOSCtrlProxyManager.resetInstances();
+    }
   });
 
   test("setup failure handled gracefully", async function() {

--- a/test/utils/CtrlProxyManager.test.ts
+++ b/test/utils/CtrlProxyManager.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import {
   AndroidCtrlProxyManager,
   MAX_STALE_PREFETCH_DIRS_PER_STARTUP,
+  STALE_PREFETCH_SWEEP_DEADLINE_MS,
 } from "../../src/utils/CtrlProxyManager";
 import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
 import { AdbClient } from "../../src/utils/android-cmdline-tools/AdbClient";
@@ -2445,7 +2446,7 @@ describe("CtrlProxyManager", function() {
         const remaining = await Promise.all(staleDirs.map(exists));
         expect(remaining.filter(Boolean)).toHaveLength(1);
         expect(warnSpy).toHaveBeenCalledWith(
-          expect.stringContaining("skipped 1 stale prefetch dir")
+          expect.stringContaining("skipped 1 uninspected prefetch dir candidate")
         );
       } finally {
         warnSpy.mockRestore();
@@ -2476,6 +2477,35 @@ describe("CtrlProxyManager", function() {
         );
       } finally {
         readdirSpy.mockRestore();
+      }
+    });
+
+    test("stops inspection when the stale-prefetch deadline expires", async function() {
+      const first = await makeAgedDir("auto-mobile-prefetch-first", 2 * HOUR_MS);
+      const second = await makeAgedDir("auto-mobile-prefetch-second", 2 * HOUR_MS);
+      const originalStat = fs.stat;
+      let statCount = 0;
+      const statSpy = spyOn(fs, "stat").mockImplementation(async (...args) => {
+        statCount++;
+        if (statCount === 1) {
+          sweepTimer.advanceTime(STALE_PREFETCH_SWEEP_DEADLINE_MS);
+        }
+        return originalStat(...args);
+      });
+      const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+
+      try {
+        await AndroidCtrlProxyManager.sweepStalePrefetchDirsOnStartup(scratchRoot, sweepTimer);
+
+        expect(statCount).toBe(1);
+        expect(await exists(first)).toBe(true);
+        expect(await exists(second)).toBe(true);
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining("Prefetch sweep timed out")
+        );
+      } finally {
+        warnSpy.mockRestore();
+        statSpy.mockRestore();
       }
     });
   });

--- a/test/utils/CtrlProxyManager.test.ts
+++ b/test/utils/CtrlProxyManager.test.ts
@@ -1,10 +1,14 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { AndroidCtrlProxyManager } from "../../src/utils/CtrlProxyManager";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import {
+  AndroidCtrlProxyManager,
+  MAX_STALE_PREFETCH_DIRS_PER_STARTUP,
+} from "../../src/utils/CtrlProxyManager";
 import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
 import { AdbClient } from "../../src/utils/android-cmdline-tools/AdbClient";
 import type { AdbClientFactory } from "../../src/utils/android-cmdline-tools/AdbClientFactory";
 import { BootedDevice } from "../../src/models";
 import * as fs from "fs/promises";
+import type { Dirent } from "fs";
 import * as path from "path";
 import crypto from "crypto";
 import os from "os";
@@ -13,6 +17,7 @@ import AdmZip from "adm-zip";
 import { FakeAccessibilityDetector } from "../fakes/FakeAccessibilityDetector";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
+import { logger } from "../../src/utils/logger";
 
 describe("CtrlProxyManager", function() {
   let accessibilityServiceClient: AndroidCtrlProxyManager;
@@ -2423,6 +2428,55 @@ describe("CtrlProxyManager", function() {
       await expect(
         AndroidCtrlProxyManager.sweepStalePrefetchDirsOnStartup(missing, sweepTimer)
       ).resolves.toBeUndefined();
+    });
+
+    test("caps stale directory work and warns about the skipped remainder", async function() {
+      const staleDirs = await Promise.all(
+        Array.from(
+          { length: MAX_STALE_PREFETCH_DIRS_PER_STARTUP + 1 },
+          (_, index) => makeAgedDir(`auto-mobile-prefetch-cap-${String(index).padStart(3, "0")}`, 2 * HOUR_MS)
+        )
+      );
+      const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+
+      try {
+        await AndroidCtrlProxyManager.sweepStalePrefetchDirsOnStartup(scratchRoot, sweepTimer);
+
+        const remaining = await Promise.all(staleDirs.map(exists));
+        expect(remaining.filter(Boolean)).toHaveLength(1);
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining("skipped 1 stale prefetch dir")
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    test("does not let fresh directories consume the stale cleanup cap", async function() {
+      const freshDirs = await Promise.all(
+        Array.from(
+          { length: MAX_STALE_PREFETCH_DIRS_PER_STARTUP },
+          (_, index) => makeAgedDir(`auto-mobile-prefetch-a-fresh-${index}`, 60 * 1000)
+        )
+      );
+      const stale = await makeAgedDir("auto-mobile-prefetch-z-stale", 2 * HOUR_MS);
+      const readdirSpy = spyOn(fs, "readdir").mockResolvedValue(
+        [...freshDirs, stale].map(dir => ({
+          name: path.basename(dir),
+          isDirectory: () => true,
+        })) as unknown as Dirent[]
+      );
+
+      try {
+        await AndroidCtrlProxyManager.sweepStalePrefetchDirsOnStartup(scratchRoot, sweepTimer);
+
+        expect(await exists(stale)).toBe(false);
+        await expect(Promise.all(freshDirs.map(exists))).resolves.toEqual(
+          Array(MAX_STALE_PREFETCH_DIRS_PER_STARTUP).fill(true)
+        );
+      } finally {
+        readdirSpy.mockRestore();
+      }
     });
   });
 });

--- a/test/utils/DeviceSessionManager.test.ts
+++ b/test/utils/DeviceSessionManager.test.ts
@@ -1,6 +1,7 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { EventEmitter } from "events";
 import { DeviceSessionManager } from "../../src/utils/DeviceSessionManager";
+import { IOSCtrlProxyManager } from "../../src/utils/IOSCtrlProxyManager";
 import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 import { FakeDeviceClientProvider } from "../fakes/FakeDeviceClientProvider";
@@ -36,6 +37,14 @@ function stubAndroidCtrlProxy(overrides: Partial<AndroidCtrlProxy>): AndroidCtrl
 
 function stubIOSCtrlProxy(overrides: Partial<IOSCtrlProxy>): IOSCtrlProxy {
   return overrides as unknown as IOSCtrlProxy;
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>(done => {
+    resolve = done;
+  });
+  return { promise, resolve };
 }
 
 function makeReadyWindow(): FakeWindow {
@@ -381,6 +390,56 @@ describe("DeviceSessionManager iOS push-update cache invalidation", () => {
 
     expect(observeCache.wasClearedFor("ios-push-1")).toBe(true);
     expect(observeCache.getClearedDevices()).toEqual(["ios-push-1"]);
+  });
+
+  test("waits for startup reaping before confirming a connected iOS runner is ready", async () => {
+    const reaping = deferred();
+    const reapSpy = spyOn(
+      IOSCtrlProxyManager,
+      "reapOrphanedRunnerProcessesOnStartup"
+    ).mockImplementation(() => reaping.promise);
+    const fakeSimctl = new FakeSimCtlClient();
+    fakeSimctl.setDeviceInfo("ios-push-1", {
+      udid: "ios-push-1",
+      name: "iPhone 15",
+      state: "Booted",
+      isAvailable: true,
+    });
+
+    const iosManager = new FakeIOSCtrlProxyManager();
+    const verifyServiceReady = spyOn(
+      new FakeIOSCtrlProxy(),
+      "verifyServiceReady"
+    ).mockResolvedValue(true);
+    const iosClient = {
+      isConnected: () => true,
+      verifyServiceReady,
+      onPushUpdate: () => () => {},
+    } as unknown as IOSCtrlProxy;
+    const provider = new FakeDeviceClientProvider(
+      fakeAdb,
+      fakeDeviceUtils,
+      fakeSimctl as any,
+      {
+        iosCtrlProxyManager: iosManager,
+        iosCtrlProxyClient: iosClient,
+      }
+    );
+    const manager = DeviceSessionManager.createInstance(provider);
+
+    try {
+      IOSCtrlProxyManager.startOrphanRunnerReapOnStartup();
+      const verify = manager.verifyIosDevice("ios-push-1");
+      await new Promise<void>(resolve => setImmediate(resolve));
+
+      expect(verifyServiceReady).not.toHaveBeenCalled();
+      reaping.resolve();
+      await verify;
+      expect(verifyServiceReady).toHaveBeenCalled();
+    } finally {
+      reapSpy.mockRestore();
+      IOSCtrlProxyManager.resetInstances();
+    }
   });
 });
 

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -2542,6 +2542,38 @@ describe("IOSCtrlProxyManager", function() {
       }
     });
 
+    test("startup reaping releases simulator start after its deadline when process cleanup hangs", async function() {
+      const reaping = deferred();
+      const reapSpy = spyOn(
+        IOSCtrlProxyManager,
+        "reapOrphanedRunnerProcessesOnStartup"
+      ).mockImplementation(() => reaping.promise);
+      const fakeExecutor = new FakeProcessExecutor();
+      fakeExecutor.setCommandResponse("curl -s", createExecResult("ok", ""));
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor
+      );
+
+      try {
+        IOSCtrlProxyManager.startOrphanRunnerReapOnStartup(undefined, fakeTimer);
+        const start = manager.start();
+        await Promise.resolve();
+
+        expect(fakeExecutor.wasCommandExecuted("curl -s")).toBe(false);
+        fakeTimer.advanceTime(STARTUP_ORPHAN_RUNNER_REAP_DEADLINE_MS);
+        await new Promise<void>(resolve => setImmediate(resolve));
+        expect(fakeExecutor.wasCommandExecuted("curl -s")).toBe(true);
+
+        reaping.resolve();
+        await fakeTimer.resolvePromise(start);
+      } finally {
+        reapSpy.mockRestore();
+      }
+    });
+
     test("start() reports the bound PID and command when owned port cleanup cannot free the port", async function() {
       const stuckProcess: FakeListeningProcess = {
         pid: 5555,

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -34,6 +34,14 @@ interface FakeListeningProcess {
   ignoreKill?: boolean;
 }
 
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>(done => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
 /**
  * A minimal format-version-1 xctestrun with a single UI-test bundle, used by the
  * boundary test to model what the in-simulator runner actually reads.
@@ -2378,6 +2386,41 @@ describe("IOSCtrlProxyManager", function() {
       expect(unrelatedXcodebuilds.every(process => process.alive)).toBe(true);
     });
 
+    test("startup orphan reaping inspects past live CtrlProxy runners before applying its cap", async function() {
+      const liveRunners: FakeListeningProcess[] = Array.from(
+        { length: MAX_STARTUP_ORPHAN_RUNNER_CANDIDATES },
+        (_, index) => ({
+          pid: 6700 + index,
+          port: 0,
+          ppid: 8000 + index,
+          command: `/tmp/CtrlProxyUITests-Runner.app/CtrlProxyUITests-Runner live-${index}`,
+          alive: true,
+        })
+      );
+      const orphanedRunner: FakeListeningProcess = {
+        pid: 6800,
+        port: 0,
+        ppid: 1,
+        command: "/tmp/CtrlProxyUITests-Runner.app/CtrlProxyUITests-Runner orphan",
+        alive: true,
+      };
+      const fakeExecutor = new FakeProcessExecutor();
+      installListeningProcessFakes(fakeExecutor, [...liveRunners, orphanedRunner]);
+      fakeExecutor.setCommandResponse(
+        "pgrep -f 'CtrlProxy'",
+        createExecResult([...liveRunners, orphanedRunner].map(process => String(process.pid)).join("\n"), "")
+      );
+      fakeTimer.enableAutoAdvance();
+
+      await IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup(
+        new IOSCtrlProxyProcessClient(fakeExecutor, fakeTimer),
+        fakeTimer
+      );
+
+      expect(orphanedRunner.alive).toBe(false);
+      expect(liveRunners.every(process => process.alive)).toBe(true);
+    });
+
     test("startup orphan reaping stops at its fake-clock deadline", async function() {
       const candidates: FakeListeningProcess[] = [0, 1].map(index => ({
         pid: 7000 + index,
@@ -2415,6 +2458,87 @@ describe("IOSCtrlProxyManager", function() {
         );
       } finally {
         warnSpy.mockRestore();
+      }
+    });
+
+    test("startup orphan reaping does not terminate a tree when ancestry traversal exhausts its deadline", async function() {
+      const shell: FakeListeningProcess = {
+        pid: 7101,
+        port: 0,
+        ppid: 1,
+        command: "/bin/sh -c xcodebuild",
+        alive: true,
+      };
+      const xcodebuild: FakeListeningProcess = {
+        pid: 7102,
+        port: 0,
+        ppid: shell.pid,
+        command: `xcodebuild test-without-building -xctestrun /tmp/CtrlProxy.xctestrun ` +
+          `-destination platform=iOS Simulator,id=${testDevice.deviceId} ` +
+          "-only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService",
+        alive: true,
+      };
+      const runner: FakeListeningProcess = {
+        pid: 7103,
+        port: 0,
+        ppid: xcodebuild.pid,
+        command: "/tmp/CtrlProxyUITests-Runner.app/CtrlProxyUITests-Runner",
+        alive: true,
+      };
+      const fakeExecutor = new FakeProcessExecutor();
+      installListeningProcessFakes(fakeExecutor, [shell, xcodebuild, runner]);
+      fakeExecutor.setCommandResponse("pgrep -f 'CtrlProxy'", createExecResult(`${runner.pid}\n`, ""));
+      const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+      let nowCallCount = 0;
+      const nowSpy = spyOn(fakeTimer, "now").mockImplementation(() => {
+        nowCallCount++;
+        return nowCallCount >= 4 ? STARTUP_ORPHAN_RUNNER_REAP_DEADLINE_MS : 0;
+      });
+
+      try {
+        await IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup(
+          new IOSCtrlProxyProcessClient(fakeExecutor, fakeTimer),
+          fakeTimer
+        );
+
+        expect(runner.alive).toBe(true);
+        expect(xcodebuild.alive).toBe(true);
+        expect(fakeExecutor.wasCommandExecuted("kill -TERM -- -7101")).toBe(false);
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining("startup CtrlProxy runner sweep timed out")
+        );
+      } finally {
+        nowSpy.mockRestore();
+        warnSpy.mockRestore();
+      }
+    });
+
+    test("start waits for startup orphan reaping before probing a simulator runner", async function() {
+      const reaping = deferred();
+      const reapSpy = spyOn(
+        IOSCtrlProxyManager,
+        "reapOrphanedRunnerProcessesOnStartup"
+      ).mockImplementation(() => reaping.promise);
+      const fakeExecutor = new FakeProcessExecutor();
+      fakeExecutor.setCommandResponse("curl -s", createExecResult("ok", ""));
+      const manager = IOSCtrlProxyManager.createForTestingWithDeps(
+        testDevice,
+        fakeTimer,
+        createFakeBuilder(),
+        fakeExecutor
+      );
+
+      try {
+        IOSCtrlProxyManager.startOrphanRunnerReapOnStartup();
+        const start = manager.start();
+        await Promise.resolve();
+
+        expect(fakeExecutor.wasCommandExecuted("curl -s")).toBe(false);
+        reaping.resolve();
+        await start;
+        expect(fakeExecutor.wasCommandExecuted("curl -s")).toBe(true);
+      } finally {
+        reapSpy.mockRestore();
       }
     });
 

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -1,6 +1,10 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import type { ChildProcess } from "node:child_process";
-import { IOSCtrlProxyManager } from "../../src/utils/IOSCtrlProxyManager";
+import {
+  IOSCtrlProxyManager,
+  STARTUP_ORPHAN_RUNNER_REAP_DEADLINE_MS,
+  MAX_STARTUP_ORPHAN_RUNNER_CANDIDATES,
+} from "../../src/utils/IOSCtrlProxyManager";
 import { BootedDevice } from "../../src/models";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeProcessExecutor } from "../fakes/FakeProcessExecutor";
@@ -9,6 +13,7 @@ import { createExecResult } from "../../src/utils/execResult";
 import { PortManager } from "../../src/utils/PortManager";
 import { IOSCtrlProxyBuilder } from "../../src/utils/IOSCtrlProxyBuilder";
 import { IOSCtrlProxyProcessClient } from "../../src/utils/ios/IOSCtrlProxyProcessClient";
+import { logger } from "../../src/utils/logger";
 import type { Xcodebuild } from "../../src/utils/ios-cmdline-tools/XcodebuildClient";
 import type { DeviceAppManager } from "../../src/utils/ios-cmdline-tools/DeviceAppManager";
 import { parsePlist } from "../../src/utils/ios-cmdline-tools/XctestrunPlist";
@@ -2204,7 +2209,7 @@ describe("IOSCtrlProxyManager", function() {
         alive: true,
       };
       installListeningProcessFakes(fakeExecutor, [orphanProcess]);
-      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("4444\n", ""));
+      fakeExecutor.setCommandResponse("pgrep -f 'CtrlProxy'", createExecResult("4444\n", ""));
       fakeTimer.enableAutoAdvance();
 
       await IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup(new IOSCtrlProxyProcessClient(fakeExecutor, fakeTimer), fakeTimer);
@@ -2222,8 +2227,7 @@ describe("IOSCtrlProxyManager", function() {
         alive: true,
       };
       installListeningProcessFakes(fakeExecutor, [orphanProcess]);
-      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("", ""));
-      fakeExecutor.setCommandResponse("pgrep -f 'CtrlProxyUITests-Runner'", createExecResult("4445\n", ""));
+      fakeExecutor.setCommandResponse("pgrep -f 'CtrlProxy'", createExecResult("4445\n", ""));
       fakeTimer.enableAutoAdvance();
 
       await IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup(new IOSCtrlProxyProcessClient(fakeExecutor, fakeTimer), fakeTimer);
@@ -2260,8 +2264,7 @@ describe("IOSCtrlProxyManager", function() {
         alive: true,
       };
       installListeningProcessFakes(fakeExecutor, [orphanedRunner, orphanedXcodebuild, orphanedShell]);
-      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("4447\n", ""));
-      fakeExecutor.setCommandResponse("pgrep -f 'CtrlProxyUITests-Runner'", createExecResult("4448\n", ""));
+      fakeExecutor.setCommandResponse("pgrep -f 'CtrlProxy'", createExecResult("4447\n4448\n", ""));
       fakeTimer.enableAutoAdvance();
 
       await IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup(new IOSCtrlProxyProcessClient(fakeExecutor, fakeTimer), fakeTimer);
@@ -2293,8 +2296,7 @@ describe("IOSCtrlProxyManager", function() {
         ignoreKill: true,
       };
       installListeningProcessFakes(fakeExecutor, [liveParent, liveXcodebuild]);
-      fakeExecutor.setCommandResponse("pgrep -x xcodebuild", createExecResult("4451\n", ""));
-      fakeExecutor.setCommandResponse("pgrep -f 'CtrlProxyUITests-Runner'", createExecResult("", ""));
+      fakeExecutor.setCommandResponse("pgrep -f 'CtrlProxy'", createExecResult("4451\n", ""));
       fakeTimer.enableAutoAdvance();
 
       await IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup(new IOSCtrlProxyProcessClient(fakeExecutor, fakeTimer), fakeTimer);
@@ -2302,6 +2304,118 @@ describe("IOSCtrlProxyManager", function() {
       expect(fakeExecutor.wasCommandExecuted("kill -TERM -- -4451")).toBe(false);
       expect(fakeExecutor.wasCommandExecuted("kill -TERM 4451")).toBe(false);
       expect(liveXcodebuild.alive).toBe(true);
+    });
+
+    test("startup orphan reaping caps candidate process work and logs skipped candidates", async function() {
+      const candidates: FakeListeningProcess[] = Array.from(
+        { length: MAX_STARTUP_ORPHAN_RUNNER_CANDIDATES + 1 },
+        (_, index) => ({
+          pid: 6000 + index,
+          port: 0,
+          ppid: 1,
+          command: `xcodebuild test-without-building -xctestrun /tmp/CtrlProxy-${index}.xctestrun ` +
+            `-destination platform=iOS Simulator,id=${testDevice.deviceId} ` +
+            `-only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService`,
+          alive: true,
+        })
+      );
+      const fakeExecutor = new FakeProcessExecutor();
+      installListeningProcessFakes(fakeExecutor, candidates);
+      fakeExecutor.setCommandResponse(
+        "pgrep -f 'CtrlProxy'",
+        createExecResult(candidates.map(candidate => String(candidate.pid)).join("\n"), "")
+      );
+      fakeTimer.enableAutoAdvance();
+      const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+
+      try {
+        await IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup(
+          new IOSCtrlProxyProcessClient(fakeExecutor, fakeTimer),
+          fakeTimer
+        );
+
+        expect(candidates.filter(candidate => candidate.alive)).toHaveLength(1);
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining("skipped 1 startup CtrlProxy runner candidate")
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    test("startup orphan reaping filters unrelated xcodebuild candidates before applying its cap", async function() {
+      const unrelatedXcodebuilds: FakeListeningProcess[] = Array.from(
+        { length: MAX_STARTUP_ORPHAN_RUNNER_CANDIDATES },
+        (_, index) => ({
+          pid: 6500 + index,
+          port: 0,
+          ppid: 1,
+          command: `xcodebuild test-without-building -xctestrun /tmp/Unrelated-${index}.xctestrun`,
+          alive: true,
+        })
+      );
+      const orphanedRunner: FakeListeningProcess = {
+        pid: 6600,
+        port: 0,
+        ppid: 1,
+        command: "/tmp/CtrlProxyUITests-Runner.app/CtrlProxyUITests-Runner",
+        alive: true,
+      };
+      const fakeExecutor = new FakeProcessExecutor();
+      installListeningProcessFakes(fakeExecutor, [...unrelatedXcodebuilds, orphanedRunner]);
+      fakeExecutor.setCommandResponse(
+        "pgrep -f 'CtrlProxy'",
+        createExecResult(`${orphanedRunner.pid}\n`, "")
+      );
+      fakeTimer.enableAutoAdvance();
+
+      await IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup(
+        new IOSCtrlProxyProcessClient(fakeExecutor, fakeTimer),
+        fakeTimer
+      );
+
+      expect(orphanedRunner.alive).toBe(false);
+      expect(unrelatedXcodebuilds.every(process => process.alive)).toBe(true);
+    });
+
+    test("startup orphan reaping stops at its fake-clock deadline", async function() {
+      const candidates: FakeListeningProcess[] = [0, 1].map(index => ({
+        pid: 7000 + index,
+        port: 0,
+        ppid: 1,
+        command: `xcodebuild test-without-building -xctestrun /tmp/CtrlProxy-${index}.xctestrun ` +
+          `-destination platform=iOS Simulator,id=${testDevice.deviceId} ` +
+          `-only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService`,
+        alive: true,
+      }));
+      const fakeExecutor = new FakeProcessExecutor();
+      fakeExecutor.setCommandHandler("ps -p", command => {
+        const pid = Number(command.match(/ps -p\s+(\d+)/)?.[1]);
+        const process = candidates.find(candidate => candidate.pid === pid && candidate.alive);
+        fakeTimer.advanceTime(STARTUP_ORPHAN_RUNNER_REAP_DEADLINE_MS);
+        return createExecResult(process ? `${process.ppid} ${process.command}` : "", "");
+      });
+      installListeningProcessFakes(fakeExecutor, candidates);
+      fakeExecutor.setCommandResponse(
+        "pgrep -f 'CtrlProxy'",
+        createExecResult(candidates.map(candidate => String(candidate.pid)).join("\n"), "")
+      );
+      fakeTimer.enableAutoAdvance();
+      const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+
+      try {
+        await IOSCtrlProxyManager.reapOrphanedRunnerProcessesOnStartup(
+          new IOSCtrlProxyProcessClient(fakeExecutor, fakeTimer),
+          fakeTimer
+        );
+
+        expect(candidates.filter(candidate => candidate.alive)).toHaveLength(2);
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining("startup CtrlProxy runner sweep timed out")
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
 
     test("start() reports the bound PID and command when owned port cleanup cannot free the port", async function() {

--- a/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
+++ b/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { IOSCtrlProxyProcessClient } from "../../../src/utils/ios/IOSCtrlProxyProcessClient";
+import type { HostCommandExecutor, HostCommandOptions } from "../../../src/utils/HostCommandExecutor";
 import { FakeHostCommandExecutor } from "../../fakes/FakeHostCommandExecutor";
 import { FakeTimer } from "../../fakes/FakeTimer";
 
@@ -8,6 +9,22 @@ function result(stdout = "", stderr = "") {
 }
 
 describe("IOSCtrlProxyProcessClient", () => {
+  test("bounds startup candidate discovery by the supplied deadline", async () => {
+    const timer = new FakeTimer();
+    const options: Array<HostCommandOptions | undefined> = [];
+    const host: HostCommandExecutor = {
+      async executeCommand(_file, _args, commandOptions) {
+        options.push(commandOptions);
+        return result();
+      },
+    };
+    const client = new IOSCtrlProxyProcessClient(host, timer);
+
+    await client.findStartupCandidatePids(100);
+
+    expect(options).toEqual([{ timeoutMs: 100 }]);
+  });
+
   test("uses argv for PID lookup and preserves device identity validation", async () => {
     const host = new FakeHostCommandExecutor();
     host.setCommandResponse("pgrep -x xcodebuild", result("42\n"));

--- a/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
+++ b/test/utils/ios/IOSCtrlProxyProcessClient.test.ts
@@ -65,6 +65,27 @@ describe("IOSCtrlProxyProcessClient", () => {
     ]));
   });
 
+  test("propagates deadline expiry while waiting for a process tree to exit", async () => {
+    const timer = new FakeTimer();
+    const host: HostCommandExecutor = {
+      async executeCommand(file, args) {
+        if (file === "ps") {
+          return result("42 1\n");
+        }
+        if (file === "kill" && args[0] === "-0") {
+          timer.advanceTime(100);
+          throw new Error("kill -0 timed out");
+        }
+        return result();
+      },
+    };
+    const client = new IOSCtrlProxyProcessClient(host, timer, { releaseAttempts: 1, releaseGraceMs: 1 });
+
+    await expect(client.terminateProcessTree(42, 100)).rejects.toThrow(
+      "Startup CtrlProxy runner sweep deadline elapsed"
+    );
+  });
+
   test("treats permission failures as an unavailable PID rather than signaling it", async () => {
     const host = new FakeHostCommandExecutor();
     host.setCommandResponse("kill -0 77", result("", "Operation not permitted"));

--- a/test/utils/startupMaintenance.test.ts
+++ b/test/utils/startupMaintenance.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import {
+  STARTUP_MAINTENANCE_TIMEOUT_MS,
+  startStartupMaintenance,
+} from "../../src/utils/startupMaintenance";
+import { FakeLogger } from "../fakes/FakeLogger";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+function pendingPromise(): Promise<void> {
+  return new Promise<void>(() => {});
+}
+
+describe("startStartupMaintenance", () => {
+  test("returns while Android and iOS cleanup remain pending so request readiness is not delayed", async () => {
+    const timer = new FakeTimer();
+    const log = new FakeLogger();
+    let androidStarted = false;
+    let iosStarted = false;
+
+    startStartupMaintenance({
+      platform: "darwin",
+      startAndroidSweep: () => {
+        androidStarted = true;
+        return pendingPromise();
+      },
+      startIosReap: () => {
+        iosStarted = true;
+        return pendingPromise();
+      },
+      timer,
+      logger: log,
+    });
+
+    await expect(Promise.resolve("request-ready")).resolves.toBe("request-ready");
+    expect(androidStarted).toBe(true);
+    expect(iosStarted).toBe(true);
+  });
+
+  test("logs cleanup rejection without surfacing it to startup", async () => {
+    const timer = new FakeTimer();
+    const log = new FakeLogger();
+
+    startStartupMaintenance({
+      platform: "linux",
+      startAndroidSweep: async () => {
+        throw new Error("temp directory unavailable");
+      },
+      startIosReap: () => pendingPromise(),
+      timer,
+      logger: log,
+    });
+
+    await Promise.resolve();
+
+    expect(log.at("warn").map(message => message.message)).toEqual([
+      expect.stringContaining("Android CtrlProxy prefetch cleanup failed"),
+    ]);
+  });
+
+  test("logs a timeout while allowing the unfinished cleanup to stay backgrounded", () => {
+    const timer = new FakeTimer();
+    const log = new FakeLogger();
+
+    startStartupMaintenance({
+      platform: "linux",
+      startAndroidSweep: () => pendingPromise(),
+      startIosReap: () => pendingPromise(),
+      timer,
+      logger: log,
+    });
+    timer.advanceTime(STARTUP_MAINTENANCE_TIMEOUT_MS);
+
+    expect(log.at("warn").map(message => message.message)).toEqual([
+      expect.stringContaining("Android CtrlProxy prefetch cleanup exceeded"),
+    ]);
+  });
+});

--- a/test/utils/startupMaintenance.test.ts
+++ b/test/utils/startupMaintenance.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
-  STARTUP_MAINTENANCE_TIMEOUT_MS,
+  STARTUP_MAINTENANCE_SLOW_WARNING_MS,
   startStartupMaintenance,
 } from "../../src/utils/startupMaintenance";
 import { FakeLogger } from "../fakes/FakeLogger";
@@ -31,7 +31,6 @@ describe("startStartupMaintenance", () => {
       logger: log,
     });
 
-    await expect(Promise.resolve("request-ready")).resolves.toBe("request-ready");
     expect(androidStarted).toBe(true);
     expect(iosStarted).toBe(true);
   });
@@ -68,7 +67,7 @@ describe("startStartupMaintenance", () => {
       timer,
       logger: log,
     });
-    timer.advanceTime(STARTUP_MAINTENANCE_TIMEOUT_MS);
+    timer.advanceTime(STARTUP_MAINTENANCE_SLOW_WARNING_MS);
 
     expect(log.at("warn").map(message => message.message)).toEqual([
       expect.stringContaining("Android CtrlProxy prefetch cleanup exceeded"),


### PR DESCRIPTION
## Summary

- Start Android stale-prefetch cleanup and macOS iOS-runner cleanup in the background so they cannot delay stdio JSON-RPC readiness.
- Log cleanup failures and five-second timeout observations without failing startup.
- Cap Android prefetch candidates and iOS runner candidates at 20 per startup; bound iOS tree discovery with a fake-clock deadline.

## Root Cause

`src/index.ts` awaited unbounded best-effort cleanup before connecting the MCP server to stdio. Accumulated temp directories or a busy process table could therefore leave a healthy subprocess unable to answer `initialize`.

## Validation

- `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-4581-green bun test test/utils/startupMaintenance.test.ts test/utils/CtrlProxyManager.test.ts test/utils/IOSCtrlProxyManager.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run turbo:validate`

Closes #4581
