### PR TITLE
fix: preserve frame context in explicit observations

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -929,7 +929,12 @@ export class Daemon {
       getLatestHierarchy: (...args) => client.getLatestHierarchy(...args),
       requestHierarchySyncWithoutObservationStreamPush: async (...args) => {
         const result = await client.requestHierarchySyncWithoutObservationStreamPush(...args);
-        return result ? { hierarchy: result.hierarchy } : null;
+        return result
+          ? {
+            hierarchy: result.hierarchy,
+            ...(result.frameContext === undefined ? {} : { frameContext: result.frameContext }),
+          }
+          : null;
       },
       convertToViewHierarchyResult: hierarchy =>
         client.convertToViewHierarchyResult(hierarchy as never),

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -282,6 +282,8 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
   /** Most recent device-authored identity received for each device. Kept even when no IDE is
    * subscribed: daemon-side input validation must not depend on an inspector being open. */
   private readonly currentFrameContexts = new Map<string, string>();
+  /** Incremented for every hierarchy accepted from a device, including contextless frames. */
+  private readonly frameContextGenerations = new Map<string, number>();
 
   getCurrentFrameContext(deviceId: string): string | undefined {
     return this.currentFrameContexts.get(deviceId);
@@ -352,6 +354,10 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
    * Push a hierarchy update to all subscribers interested in this device.
    */
   pushHierarchyUpdate(deviceId: string, hierarchy: ViewHierarchyResult, frameContext?: string): number | null {
+    this.frameContextGenerations.set(
+      deviceId,
+      (this.frameContextGenerations.get(deviceId) ?? 0) + 1
+    );
     if (frameContext !== undefined) {
       this.currentFrameContexts.set(deviceId, frameContext);
     } else {
@@ -897,6 +903,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
     }
 
     try {
+      const frameContextGenerationsAtStart = new Map(this.frameContextGenerations);
       const observations = await this.requestObservationWithTimeout({
         deviceId: request.deviceId ?? null,
         requestId: request.id,
@@ -914,6 +921,15 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
         const hierarchy = observation.viewHierarchy;
         if (!hierarchy) {
           failures.push(this.describeMissingHierarchy(deviceId, observation));
+          continue;
+        }
+        if (
+          (this.frameContextGenerations.get(deviceId) ?? 0)
+          !== (frameContextGenerationsAtStart.get(deviceId) ?? 0)
+        ) {
+          logger.debug(
+            `[DeviceDataStream] Skipped stale explicit observation for ${deviceId}; a newer hierarchy arrived`
+          );
           continue;
         }
         this.pushHierarchyUpdate(deviceId, hierarchy, hierarchy.frameContext);

--- a/src/daemon/deviceDataStreamSocketServer.ts
+++ b/src/daemon/deviceDataStreamSocketServer.ts
@@ -916,7 +916,7 @@ export class DeviceDataStreamSocketServer extends PushSubscriptionSocketServer<
           failures.push(this.describeMissingHierarchy(deviceId, observation));
           continue;
         }
-        this.pushHierarchyUpdate(deviceId, hierarchy);
+        this.pushHierarchyUpdate(deviceId, hierarchy, hierarchy.frameContext);
       }
 
       if (failures.length > 0) {

--- a/src/daemon/observationInitialFrame.ts
+++ b/src/daemon/observationInitialFrame.ts
@@ -47,7 +47,7 @@ export interface ObservationStreamAndroidClient {
     disableAllFiltering?: boolean,
     signal?: AbortSignal,
     timeoutMs?: number
-  ): Promise<{ hierarchy: AccessibilityHierarchy } | null>;
+  ): Promise<{ hierarchy: AccessibilityHierarchy; frameContext?: string } | null>;
   convertToViewHierarchyResult(hierarchy: AccessibilityHierarchy): ViewHierarchyResult;
   captureScreenshotForObservationStream(): Promise<ScreenshotCaptureResult>;
 }
@@ -66,7 +66,7 @@ export interface ObservationStreamIosClient {
     disableAllFiltering?: boolean,
     signal?: AbortSignal,
     timeoutMs?: number
-  ): Promise<{ hierarchy: unknown } | null>;
+  ): Promise<{ hierarchy: unknown; frameContext?: string } | null>;
   convertToViewHierarchyResult(hierarchy: unknown): ViewHierarchyResult;
   requestScreenshotWithoutObservationStreamPush(timeoutMs?: number, perf?: PerformanceTracker): Promise<CtrlProxyScreenshotResult>;
 }
@@ -128,14 +128,15 @@ async function pushAndroidInitialObservationFrame(
 
   logger.info(`[Daemon] WebSocket connected to ${device.deviceId} for observation stream`);
 
-  const hierarchy = await getAndroidInitialHierarchy(client);
-  if (!hierarchy) {
+  const initialHierarchy = await getAndroidInitialHierarchy(client);
+  if (!initialHierarchy) {
     logger.warn(`[Daemon] No hierarchy available for initial observation frame on ${device.deviceId}`);
     return;
   }
 
-  const viewHierarchy = client.convertToViewHierarchyResult(hierarchy);
-  dependencies.streamServer.pushHierarchyUpdate(device.deviceId, viewHierarchy);
+  const viewHierarchy = client.convertToViewHierarchyResult(initialHierarchy.hierarchy);
+  const frameContext = initialHierarchy.frameContext ?? viewHierarchy.frameContext;
+  dependencies.streamServer.pushHierarchyUpdate(device.deviceId, viewHierarchy, frameContext);
 
   await pushAndroidInitialScreenshot(device.deviceId, client, dependencies.streamServer, viewHierarchy);
 }
@@ -155,7 +156,11 @@ async function pushAndroidInitialScreenshot(
       dimensions.width,
       dimensions.height,
       pickScreenshotMetadata(screenshot),
-      { ...canonicalPixelScreenshotOptions(viewHierarchy), rotation: screenshot.rotation }
+      {
+        ...canonicalPixelScreenshotOptions(viewHierarchy),
+        rotation: screenshot.rotation,
+        ...(screenshot.frameContext === undefined ? {} : { frameContext: screenshot.frameContext }),
+      }
     );
   }
 }
@@ -173,7 +178,7 @@ function canonicalPixelScreenshotOptions(
 
 async function getAndroidInitialHierarchy(
   client: ObservationStreamAndroidClient
-): Promise<AccessibilityHierarchy | null> {
+): Promise<{ hierarchy: AccessibilityHierarchy; frameContext?: string } | null> {
   const hierarchyResponse = await client.getLatestHierarchy(
     false,
     INITIAL_FRAME_HIERARCHY_TIMEOUT_MS,
@@ -181,7 +186,10 @@ async function getAndroidInitialHierarchy(
     true
   );
   if (hierarchyResponse.hierarchy && hierarchyResponse.fresh) {
-    return hierarchyResponse.hierarchy;
+    return {
+      hierarchy: hierarchyResponse.hierarchy,
+      frameContext: hierarchyResponse.frameContext,
+    };
   }
 
   const syncHierarchy = await client.requestHierarchySyncWithoutObservationStreamPush(
@@ -190,7 +198,9 @@ async function getAndroidInitialHierarchy(
     undefined,
     INITIAL_FRAME_HIERARCHY_TIMEOUT_MS
   );
-  return syncHierarchy?.hierarchy ?? null;
+  return syncHierarchy
+    ? { hierarchy: syncHierarchy.hierarchy, frameContext: syncHierarchy.frameContext }
+    : null;
 }
 
 async function pushIosInitialObservationFrame(
@@ -206,14 +216,15 @@ async function pushIosInitialObservationFrame(
 
   logger.info(`[Daemon] CtrlProxy iOS connected to ${device.deviceId} for observation stream`);
 
-  const hierarchy = await getIosInitialHierarchy(client);
-  if (!hierarchy) {
+  const initialHierarchy = await getIosInitialHierarchy(client);
+  if (!initialHierarchy) {
     logger.warn(`[Daemon] No hierarchy available for initial observation frame on ${device.deviceId}`);
     return;
   }
 
-  const viewHierarchy = client.convertToViewHierarchyResult(hierarchy);
-  dependencies.streamServer.pushHierarchyUpdate(device.deviceId, viewHierarchy);
+  const viewHierarchy = client.convertToViewHierarchyResult(initialHierarchy.hierarchy);
+  const frameContext = initialHierarchy.frameContext ?? viewHierarchy.frameContext;
+  dependencies.streamServer.pushHierarchyUpdate(device.deviceId, viewHierarchy, frameContext);
 
   const screenshot = await client.requestScreenshotWithoutObservationStreamPush(INITIAL_FRAME_SCREENSHOT_TIMEOUT_MS);
   if (screenshot.success && screenshot.data) {
@@ -224,14 +235,18 @@ async function pushIosInitialObservationFrame(
       dimensions.width,
       dimensions.height,
       metadataForScreenshotFormat(IOS_CTRLPROXY_SCREENSHOT_METADATA, screenshot.format),
-      { ...canonicalPixelScreenshotOptions(viewHierarchy), rotation: screenshot.rotation }
+      {
+        ...canonicalPixelScreenshotOptions(viewHierarchy),
+        rotation: screenshot.rotation,
+        ...(screenshot.frameContext === undefined ? {} : { frameContext: screenshot.frameContext }),
+      }
     );
   }
 }
 
 async function getIosInitialHierarchy(
   client: ObservationStreamIosClient
-): Promise<CtrlProxyHierarchy | null> {
+): Promise<{ hierarchy: CtrlProxyHierarchy; frameContext?: string } | null> {
   const hierarchyResponse = await client.getLatestHierarchy(
     false,
     INITIAL_FRAME_HIERARCHY_TIMEOUT_MS,
@@ -239,7 +254,10 @@ async function getIosInitialHierarchy(
     true
   );
   if (hierarchyResponse.hierarchy && hierarchyResponse.fresh) {
-    return hierarchyResponse.hierarchy;
+    return {
+      hierarchy: hierarchyResponse.hierarchy,
+      frameContext: hierarchyResponse.frameContext,
+    };
   }
 
   const syncHierarchy = await client.requestHierarchySyncWithoutObservationStreamPush(
@@ -248,7 +266,9 @@ async function getIosInitialHierarchy(
     undefined,
     INITIAL_FRAME_HIERARCHY_TIMEOUT_MS
   );
-  return syncHierarchy ? syncHierarchy.hierarchy as CtrlProxyHierarchy : null;
+  return syncHierarchy
+    ? { hierarchy: syncHierarchy.hierarchy as CtrlProxyHierarchy, frameContext: syncHierarchy.frameContext }
+    : null;
 }
 
 function getAndroidScreenshotDimensions(hierarchy: ViewHierarchyResult): { width: number; height: number } {

--- a/src/features/observe/ViewHierarchy.ts
+++ b/src/features/observe/ViewHierarchy.ts
@@ -152,7 +152,12 @@ export class ViewHierarchy implements ViewHierarchyInterface {
       }
 
       // Convert XCTestHierarchy to ViewHierarchyResult format
-      return this.convertXCTestHierarchy(result.hierarchy, result.updatedAt, result.reconnectStatus);
+      return this.convertXCTestHierarchy(
+        result.hierarchy,
+        result.updatedAt,
+        result.reconnectStatus,
+        result.frameContext
+      );
     });
 
     perf.end();
@@ -165,7 +170,12 @@ export class ViewHierarchy implements ViewHierarchyInterface {
   /**
    * Convert XCTestHierarchy to ViewHierarchyResult format
    */
-  private convertXCTestHierarchy(hierarchy: any, updatedAt?: number, ctrlProxyReconnect?: ViewHierarchyResult["ctrlProxyReconnect"]): ViewHierarchyResult {
+  private convertXCTestHierarchy(
+    hierarchy: any,
+    updatedAt?: number,
+    ctrlProxyReconnect?: ViewHierarchyResult["ctrlProxyReconnect"],
+    frameContext?: string
+  ): ViewHierarchyResult {
     const cleanedHierarchy = cleanupIosXCTestHierarchy(hierarchy);
     const result = {
       ...cleanedHierarchy,
@@ -173,6 +183,9 @@ export class ViewHierarchy implements ViewHierarchyInterface {
     };
     if (ctrlProxyReconnect) {
       result.ctrlProxyReconnect = ctrlProxyReconnect;
+    }
+    if (frameContext !== undefined) {
+      result.frameContext = frameContext;
     }
     return result;
   }

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -740,14 +740,14 @@ export interface AndroidCtrlProxy extends CtrlProxyClient {
     signal?: AbortSignal,
     timeoutMs?: number,
     diagnostics?: HierarchySyncDiagnostics
-  ): Promise<{ hierarchy: AccessibilityHierarchy; perfTiming?: AndroidPerfTiming[] } | null>;
+  ): Promise<{ hierarchy: AccessibilityHierarchy; perfTiming?: AndroidPerfTiming[]; frameContext?: string } | null>;
 
   requestHierarchySyncWithoutObservationStreamPush(
     perf?: PerformanceTracker,
     disableAllFiltering?: boolean,
     signal?: AbortSignal,
     timeoutMs?: number
-  ): Promise<{ hierarchy: AccessibilityHierarchy; perfTiming?: AndroidPerfTiming[] } | null>;
+  ): Promise<{ hierarchy: AccessibilityHierarchy; perfTiming?: AndroidPerfTiming[]; frameContext?: string } | null>;
 
   convertToViewHierarchyResult(accessibilityHierarchy: AccessibilityHierarchy): ViewHierarchyResult;
 
@@ -2842,7 +2842,8 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
       hierarchy: data,
       receivedAt: now,
       fresh: true,
-      perfTiming
+      perfTiming,
+      frameContext,
     };
 
     // Update cached screen dimensions

--- a/src/features/observe/android/CtrlProxyHierarchy.ts
+++ b/src/features/observe/android/CtrlProxyHierarchy.ts
@@ -182,7 +182,8 @@ export class CtrlProxyHierarchy {
               hierarchy: cachedHierarchy.hierarchy,
               fresh: isFresh,
               updatedAt: updatedAt,
-              perfTiming: cachedHierarchy.perfTiming
+              perfTiming: cachedHierarchy.perfTiming,
+              frameContext: cachedHierarchy.frameContext,
             };
           }
         } else {
@@ -195,7 +196,8 @@ export class CtrlProxyHierarchy {
             hierarchy: cachedHierarchy.hierarchy,
             fresh: isFresh,
             updatedAt: updatedAt,
-            perfTiming: cachedHierarchy.perfTiming
+            perfTiming: cachedHierarchy.perfTiming,
+            frameContext: cachedHierarchy.frameContext,
           };
         }
       }
@@ -224,7 +226,8 @@ export class CtrlProxyHierarchy {
             hierarchy: freshData.hierarchy,
             fresh: true,
             updatedAt: freshData.hierarchy.updatedAt,
-            perfTiming: freshData.perfTiming
+            perfTiming: freshData.perfTiming,
+            frameContext: freshData.frameContext,
           };
         } else {
           // Record timeout so we skip WebSocket wait for a while
@@ -247,7 +250,8 @@ export class CtrlProxyHierarchy {
               hierarchy: currentCache.hierarchy,
               fresh: false,
               updatedAt: currentCache.hierarchy.updatedAt,
-              perfTiming: currentCache.perfTiming
+              perfTiming: currentCache.perfTiming,
+              frameContext: currentCache.frameContext,
             };
           }
         }
@@ -322,6 +326,7 @@ export class CtrlProxyHierarchy {
       let hierarchyData = response.hierarchy;
       let isFresh = response.fresh;
       let androidPerfTiming = response.perfTiming;
+      let frameContext = response.frameContext;
 
       // If no hierarchy from WebSocket or data is stale, sync to get fresh data
       const needsSync = !hierarchyData || !isFresh;
@@ -343,6 +348,7 @@ export class CtrlProxyHierarchy {
           if (syncResult.perfTiming) {
             androidPerfTiming = syncResult.perfTiming;
           }
+          frameContext = syncResult.frameContext;
           isFresh = true;
           if (hierarchyData.packageName) {
             this.lastKnownPackageName = hierarchyData.packageName;
@@ -368,6 +374,9 @@ export class CtrlProxyHierarchy {
       // Add the device timestamp to the result
       if (hierarchyData!.updatedAt) {
         convertedHierarchy.updatedAt = hierarchyData!.updatedAt;
+      }
+      if (frameContext !== undefined) {
+        convertedHierarchy.frameContext = frameContext;
       }
 
       // Merge Android-side performance timing
@@ -400,7 +409,7 @@ export class CtrlProxyHierarchy {
     signal?: AbortSignal,
     timeoutMs: number = 10000,
     diagnostics?: HierarchySyncDiagnostics
-  ): Promise<{ hierarchy: AccessibilityHierarchy; perfTiming?: AndroidPerfTiming[] } | null> {
+  ): Promise<{ hierarchy: AccessibilityHierarchy; perfTiming?: AndroidPerfTiming[]; frameContext?: string } | null> {
     const startTime = this.context.timer.now();
     const effectiveTimeoutMs = Math.max(0, timeoutMs);
 
@@ -456,7 +465,8 @@ export class CtrlProxyHierarchy {
         logger.debug(`[CTRL_PROXY] Sync complete: ${duration}ms (updatedAt: ${freshData.hierarchy.updatedAt})`);
         return {
           hierarchy: freshData.hierarchy,
-          perfTiming: freshData.perfTiming
+          perfTiming: freshData.perfTiming,
+          frameContext: freshData.frameContext,
         };
       }
 

--- a/src/features/observe/android/types.ts
+++ b/src/features/observe/android/types.ts
@@ -177,6 +177,7 @@ export interface CachedHierarchy {
   receivedAt: number;
   fresh: boolean;
   perfTiming?: AndroidPerfTiming[];
+  frameContext?: string;
 }
 
 /**
@@ -187,6 +188,7 @@ export interface AccessibilityHierarchyResponse {
   fresh: boolean;
   updatedAt?: number; // Timestamp from device (only present when hierarchy data exists)
   perfTiming?: AndroidPerfTiming[]; // Android-side performance timing data
+  frameContext?: string;
 }
 
 /**

--- a/src/features/observe/ios/CtrlProxyHierarchy.ts
+++ b/src/features/observe/ios/CtrlProxyHierarchy.ts
@@ -87,7 +87,11 @@ export class CtrlProxyHierarchy {
       return null;
     }
 
-    return this.convertToViewHierarchyResult(response.hierarchy);
+    const converted = this.convertToViewHierarchyResult(response.hierarchy);
+    if (response.frameContext !== undefined) {
+      converted.frameContext = response.frameContext;
+    }
+    return converted;
   }
 
   /**
@@ -117,7 +121,8 @@ export class CtrlProxyHierarchy {
           hierarchy: cachedHierarchy.hierarchy,
           fresh: true,
           updatedAt: cachedHierarchy.hierarchy.updatedAt,
-          perfTiming: cachedHierarchy.perfTiming
+          perfTiming: cachedHierarchy.perfTiming,
+          frameContext: cachedHierarchy.frameContext,
         };
       }
     }
@@ -142,7 +147,8 @@ export class CtrlProxyHierarchy {
           hierarchy: result.hierarchy,
           fresh: true,
           updatedAt: result.hierarchy.updatedAt,
-          perfTiming: result.perfTiming
+          perfTiming: result.perfTiming,
+          frameContext: result.frameContext,
         };
       }
 
@@ -173,6 +179,7 @@ export class CtrlProxyHierarchy {
         fresh: false,
         updatedAt: fallbackHierarchy.hierarchy.updatedAt,
         perfTiming: fallbackHierarchy.perfTiming,
+        frameContext: fallbackHierarchy.frameContext,
         reconnectStatus,
         reconnectMessage: reconnectStatus
           ? this.buildReconnectMessage(reconnectStatus.retryAfterSeconds)
@@ -205,7 +212,7 @@ export class CtrlProxyHierarchy {
     signal?: AbortSignal,
     timeoutMs: number = 5000,
     suppressObservationStreamPush: boolean = false
-  ): Promise<{ hierarchy: XCTestHierarchy; perfTiming?: CtrlProxyPerfTiming } | null> {
+  ): Promise<{ hierarchy: XCTestHierarchy; perfTiming?: CtrlProxyPerfTiming; frameContext?: string } | null> {
     if (!await this.context.ensureConnected(perf)) {
       return null;
     }
@@ -214,7 +221,11 @@ export class CtrlProxyHierarchy {
     if (suppressObservationStreamPush) {
       this.context.suppressHierarchyObservationStreamPush?.(requestId, timeoutMs);
     }
-    const promise = this.context.requestManager.register<{ hierarchy?: XCTestHierarchy; perfTiming?: CtrlProxyPerfTiming }>(
+    const promise = this.context.requestManager.register<{
+      hierarchy?: XCTestHierarchy;
+      perfTiming?: CtrlProxyPerfTiming;
+      frameContext?: string;
+    }>(
       requestId,
       "hierarchy",
       timeoutMs,
@@ -238,13 +249,15 @@ export class CtrlProxyHierarchy {
         hierarchy: result.hierarchy,
         receivedAt: this.context.timer.now(),
         fresh: true,
-        perfTiming: result.perfTiming
+        perfTiming: result.perfTiming,
+        frameContext: result.frameContext,
       };
       this.context.setCachedHierarchy(newCache);
 
       return {
         hierarchy: result.hierarchy,
-        perfTiming: result.perfTiming
+        perfTiming: result.perfTiming,
+        frameContext: result.frameContext,
       };
     }
 

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -1646,7 +1646,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     disableAllFiltering?: boolean,
     signal?: AbortSignal,
     timeoutMs: number = 5000
-  ): Promise<{ hierarchy: XCTestHierarchy; perfTiming?: CtrlProxyPerfTiming } | null> {
+  ): Promise<{ hierarchy: XCTestHierarchy; perfTiming?: CtrlProxyPerfTiming; frameContext?: string } | null> {
     return this.hierarchy.requestHierarchySync(perf, disableAllFiltering, signal, timeoutMs, true);
   }
 

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -180,7 +180,7 @@ export interface IOSCtrlProxy extends CtrlProxyClient {
     disableAllFiltering?: boolean,
     signal?: AbortSignal,
     timeoutMs?: number
-  ): Promise<{ hierarchy: XCTestHierarchy; perfTiming?: CtrlProxyPerfTiming } | null>;
+  ): Promise<{ hierarchy: XCTestHierarchy; perfTiming?: CtrlProxyPerfTiming; frameContext?: string } | null>;
   requestAddHighlight(
     id: string,
     shape: HighlightShape,
@@ -199,7 +199,7 @@ export interface IOSCtrlProxy extends CtrlProxyClient {
     disableAllFiltering?: boolean,
     signal?: AbortSignal,
     timeoutMs?: number
-  ): Promise<{ hierarchy: XCTestHierarchy; perfTiming?: CtrlProxyPerfTiming } | null>;
+  ): Promise<{ hierarchy: XCTestHierarchy; perfTiming?: CtrlProxyPerfTiming; frameContext?: string } | null>;
 
   convertToViewHierarchyResult(hierarchy: XCTestHierarchy): ViewHierarchyResult;
 
@@ -1489,7 +1489,8 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
         hierarchy: message.data,
         receivedAt: now,
         fresh: true,
-        perfTiming: message.perfTiming as CtrlProxyPerfTiming | undefined
+        perfTiming: message.perfTiming as CtrlProxyPerfTiming | undefined,
+        frameContext: message.frameContext,
       };
       logger.info(`[IOSCtrlProxyClient] Received hierarchy push update - UI changed`);
 

--- a/src/features/observe/ios/types.ts
+++ b/src/features/observe/ios/types.ts
@@ -254,6 +254,7 @@ export interface CtrlProxyCachedHierarchy {
   receivedAt: number;
   fresh: boolean;
   perfTiming?: CtrlProxyPerfTiming;
+  frameContext?: string;
 }
 
 export type CachedHierarchy = CtrlProxyCachedHierarchy;
@@ -266,6 +267,7 @@ export interface CtrlProxyHierarchyResponse {
   fresh: boolean;
   updatedAt?: number;
   perfTiming?: CtrlProxyPerfTiming;
+  frameContext?: string;
   reconnectStatus?: CtrlProxyReconnectStatus;
   reconnectMessage?: string;
 }

--- a/src/models/ViewHierarchyResult.ts
+++ b/src/models/ViewHierarchyResult.ts
@@ -15,6 +15,8 @@ export interface ViewHierarchyResult {
   hierarchy: Hierarchy;
   /** Timestamp from the device when the hierarchy was captured (milliseconds since epoch) */
   updatedAt?: number;
+  /** Opaque device-authored identity for the UI state captured in this hierarchy. */
+  frameContext?: string;
   /** Package name of the foreground app (from accessibility service) */
   packageName?: string;
   /** Optional window metadata from the accessibility service */

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -173,6 +173,35 @@ describe("DeviceDataStreamSocketServer", () => {
       expect(server.getCurrentFrameContext("emulator-5554")).toBeUndefined();
     });
 
+    it("does not let a completed explicit observation replace a newer live frame context", async () => {
+      let resolveObservation: ((observations: RequestedObservation[]) => void) | undefined;
+      server.setOnObservationRequested(() => new Promise(resolve => {
+        resolveObservation = resolve;
+      }));
+      const { socket } = server.simulateSubscription({ deviceId: "emulator-5554" });
+
+      const request = server.processLineForTest(socket, JSON.stringify({
+        id: "obs-race",
+        command: "request_observation",
+        deviceId: "emulator-5554",
+      }));
+      await Promise.resolve();
+      expect(resolveObservation).toBeDefined();
+
+      server.pushHierarchyUpdate(
+        "emulator-5554",
+        requestedObservation("emulator-5554", "frame-B").observation.viewHierarchy!,
+        "frame-B"
+      );
+      resolveObservation!([requestedObservation("emulator-5554", "frame-A")]);
+      await request;
+
+      expect(server.getCurrentFrameContext("emulator-5554")).toBe("frame-B");
+      expect(socket.getWrittenMessages<{ type: string }>().filter(message =>
+        message.type === "hierarchy_update"
+      )).toHaveLength(1);
+    });
+
     it("returns error when no observation callback is configured", async () => {
       const socket = new FakeSocket();
 

--- a/test/daemon/deviceDataStreamSocketServer.test.ts
+++ b/test/daemon/deviceDataStreamSocketServer.test.ts
@@ -93,7 +93,7 @@ describe("DeviceDataStreamSocketServer", () => {
   });
 
   describe("request_observation", () => {
-    const requestedObservation = (deviceId: string): RequestedObservation => ({
+    const requestedObservation = (deviceId: string, frameContext?: string): RequestedObservation => ({
       deviceId,
       observation: {
         updatedAt: "2026-06-24T00:00:00.000Z",
@@ -103,6 +103,7 @@ describe("DeviceDataStreamSocketServer", () => {
           updatedAt: 123,
           packageName: "com.example.app",
           hierarchy: { text: "Home" },
+          ...(frameContext === undefined ? {} : { frameContext }),
         } as any,
       },
     });
@@ -139,6 +140,37 @@ describe("DeviceDataStreamSocketServer", () => {
       expect(msgs[1].type).toBe("subscription_response");
       expect(msgs[1].id).toBe("obs-1");
       expect(msgs[1].success).toBe(true);
+    });
+
+    it("forwards proven frame context and clears it when an explicit observation lacks provenance", async () => {
+      server.setOnObservationRequested(async request => [
+        requestedObservation(request.deviceId ?? "emulator-5554", "frame-A"),
+      ]);
+      const { socket } = server.simulateSubscription({ deviceId: "emulator-5554" });
+
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "obs-context",
+        command: "request_observation",
+        deviceId: "emulator-5554",
+      }));
+
+      const firstMessages = socket.getWrittenMessages<{
+        type: string;
+        frameContext?: string;
+      }>();
+      expect(firstMessages[0].frameContext).toBe("frame-A");
+      expect(server.getCurrentFrameContext("emulator-5554")).toBe("frame-A");
+
+      server.setOnObservationRequested(async request => [
+        requestedObservation(request.deviceId ?? "emulator-5554"),
+      ]);
+      await server.processLineForTest(socket, JSON.stringify({
+        id: "obs-contextless",
+        command: "request_observation",
+        deviceId: "emulator-5554",
+      }));
+
+      expect(server.getCurrentFrameContext("emulator-5554")).toBeUndefined();
     });
 
     it("returns error when no observation callback is configured", async () => {

--- a/test/daemon/observationInitialFrame.test.ts
+++ b/test/daemon/observationInitialFrame.test.ts
@@ -600,6 +600,33 @@ describe("pushInitialObservationFramesForSubscriber", () => {
     });
   });
 
+  it("forwards the synchronous iOS hierarchy context when the initial cache is empty", async () => {
+    const streamServer = new FakeObservationStreamServer();
+    const iosClient = new FakeIosInitialFrameClient(
+      true,
+      null,
+      {
+        updatedAt: 789,
+        packageName: "com.example",
+        screenWidth: 390,
+        screenHeight: 844,
+        screenScale: 3,
+        hierarchy: { text: "Cold start" },
+        frameContext: "ios-sync",
+      } as any
+    );
+
+    await pushInitialObservationFramesForSubscriber(iosDevice.id, [iosDevice], {
+      streamServer,
+      androidClientFactory: () => {
+        throw new Error("unexpected Android client");
+      },
+      iosClientFactory: () => iosClient,
+    });
+
+    expect(streamServer.hierarchyUpdates[0].frameContext).toBe("ios-sync");
+  });
+
   it("does not seed iOS subscribers from stale cached hierarchy", async () => {
     const streamServer = new FakeObservationStreamServer();
     const iosClient = new FakeIosInitialFrameClient(

--- a/test/daemon/observationInitialFrame.test.ts
+++ b/test/daemon/observationInitialFrame.test.ts
@@ -19,11 +19,19 @@ import type {
 import { loadCoordinateMappingVectors } from "../parity/coordinateMappingGoldenVectors";
 
 class FakeObservationStreamServer {
-  readonly hierarchyUpdates: Array<{ deviceId: string; hierarchy: ViewHierarchyResult }> = [];
+  readonly hierarchyUpdates: Array<{
+    deviceId: string;
+    hierarchy: ViewHierarchyResult;
+    frameContext?: string;
+  }> = [];
   readonly screenshotUpdates: ScreenshotUpdate[] = [];
 
-  pushHierarchyUpdate(deviceId: string, hierarchy: ViewHierarchyResult): void {
-    this.hierarchyUpdates.push({ deviceId, hierarchy });
+  pushHierarchyUpdate(deviceId: string, hierarchy: ViewHierarchyResult, frameContext?: string): void {
+    this.hierarchyUpdates.push({
+      deviceId,
+      hierarchy,
+      ...(frameContext === undefined ? {} : { frameContext }),
+    });
   }
 
   pushScreenshotUpdate(
@@ -32,7 +40,12 @@ class FakeObservationStreamServer {
     screenWidth: number,
     screenHeight: number,
     metadata?: Record<string, unknown>,
-    options?: { captureSequence?: number; coordinateSpace?: "px"; rotation?: number }
+    options?: {
+      captureSequence?: number;
+      coordinateSpace?: "px";
+      frameContext?: string;
+      rotation?: number;
+    }
   ): void {
     const screenshotOptions = options?.captureSequence === undefined && options?.rotation === undefined
       ? undefined
@@ -45,6 +58,7 @@ class FakeObservationStreamServer {
       ...(metadata === undefined ? {} : { metadata }),
       ...(options?.coordinateSpace === undefined ? {} : { coordinateSpace: options.coordinateSpace }),
       ...(screenshotOptions === undefined ? {} : { options: screenshotOptions }),
+      ...(options?.frameContext === undefined ? {} : { frameContext: options.frameContext }),
     });
   }
 }
@@ -57,6 +71,7 @@ interface ScreenshotUpdate {
   metadata?: Record<string, unknown>;
   coordinateSpace?: "px";
   options?: { captureSequence?: number; rotation?: number };
+  frameContext?: string;
 }
 
 class FakeAndroidInitialFrameClient implements ObservationStreamAndroidClient {
@@ -118,6 +133,9 @@ class FakeAndroidInitialFrameClient implements ObservationStreamAndroidClient {
       updatedAt: hierarchy.updatedAt,
       screenWidth: hierarchy.screenWidth,
       screenHeight: hierarchy.screenHeight,
+      ...("frameContext" in hierarchy && typeof hierarchy.frameContext === "string"
+        ? { frameContext: hierarchy.frameContext }
+        : {}),
     };
   }
 
@@ -191,6 +209,9 @@ class FakeIosInitialFrameClient implements ObservationStreamIosClient {
       ...(typedHierarchy.pixelWidth === undefined ? {} : { pixelWidth: typedHierarchy.pixelWidth }),
       ...(typedHierarchy.pixelHeight === undefined ? {} : { pixelHeight: typedHierarchy.pixelHeight }),
       rotation: typedHierarchy.rotation,
+      ...("frameContext" in typedHierarchy && typeof typedHierarchy.frameContext === "string"
+        ? { frameContext: typedHierarchy.frameContext }
+        : {}),
     };
   }
 
@@ -265,6 +286,39 @@ describe("pushInitialObservationFramesForSubscriber", () => {
     ]);
     expect(androidClient.suppressedSyncHierarchyCalls).toHaveLength(0);
     expect(androidClient.observationScreenshotCallCount).toBe(1);
+  });
+
+  it("forwards proven Android initial-frame contexts", async () => {
+    const streamServer = new FakeObservationStreamServer();
+    const androidClient = new FakeAndroidInitialFrameClient(
+      true,
+      {
+        updatedAt: 123,
+        packageName: "com.example",
+        screenWidth: 1440,
+        screenHeight: 3120,
+        hierarchy: { text: "Home" },
+        frameContext: "android-hierarchy",
+      } as any,
+      undefined,
+      true,
+      {
+        success: true,
+        data: "android-shot",
+        frameContext: "android-screenshot",
+      }
+    );
+
+    await pushInitialObservationFramesForSubscriber(androidDevice.id, [androidDevice], {
+      streamServer,
+      androidClientFactory: () => androidClient,
+      iosClientFactory: () => {
+        throw new Error("unexpected iOS client");
+      },
+    });
+
+    expect(streamServer.hierarchyUpdates[0].frameContext).toBe("android-hierarchy");
+    expect(streamServer.screenshotUpdates[0].frameContext).toBe("android-screenshot");
   });
 
   it("pushes Android initial ADB fallback screenshots with fallback metadata", async () => {
@@ -481,6 +535,35 @@ describe("pushInitialObservationFramesForSubscriber", () => {
     expect(iosClient.syncHierarchyCalls).toHaveLength(0);
     expect(iosClient.suppressedSyncHierarchyCalls).toHaveLength(0);
     expect(iosClient.suppressedScreenshotCalls).toEqual([{ timeoutMs: 3000 }]);
+  });
+
+  it("forwards proven iOS initial-frame contexts", async () => {
+    const streamServer = new FakeObservationStreamServer();
+    const iosClient = new FakeIosInitialFrameClient(
+      true,
+      {
+        updatedAt: 456,
+        packageName: "com.example.ios",
+        screenWidth: 390,
+        screenHeight: 844,
+        screenScale: 3,
+        hierarchy: { text: "Home" },
+        frameContext: "ios-hierarchy",
+      } as any,
+      undefined,
+      { success: true, data: "ios-shot", format: "png", frameContext: "ios-screenshot" }
+    );
+
+    await pushInitialObservationFramesForSubscriber(iosDevice.id, [iosDevice], {
+      streamServer,
+      androidClientFactory: () => {
+        throw new Error("unexpected Android client");
+      },
+      iosClientFactory: () => iosClient,
+    });
+
+    expect(streamServer.hierarchyUpdates[0].frameContext).toBe("ios-hierarchy");
+    expect(streamServer.screenshotUpdates[0].frameContext).toBe("ios-screenshot");
   });
 
   it("captures iOS hierarchy synchronously when the initial cache is empty", async () => {


### PR DESCRIPTION
## Summary

Preserves device-authored `frameContext` values through explicit observation and initial observation frames.

- Carry hierarchy context through Android and iOS CtrlProxy cache and synchronous observation paths.
- Include proven hierarchy and screenshot contexts in Android and iOS initial stream frames.
- Keep contextless legacy and raced frames fail-closed: they omit the token and clear the daemon's authoritative context.

## Root Cause

Explicit `request_observation` and initial-frame paths rebuilt stream frames after the native clients had received their contexts, but did not forward the values into the device-data stream. The daemon therefore cleared the context needed for validated `input/*` calls.

## Validation

- `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-issue-4585-data bun test test/daemon/deviceDataStreamSocketServer.test.ts test/daemon/observationInitialFrame.test.ts`
- `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-issue-4585-data bun test test/features/observe/CtrlProxyClient.test.ts test/features/observe/ios/IOSCtrlProxyClient.test.ts`
- `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-issue-4585-data bun run typecheck`
- `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-issue-4585-data bun run turbo:validate`

Closes #4585
