### PR TITLE
fix(ios): harden frame-context provenance

### DIFF
--- a/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
+++ b/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		8AC18133C075D1909F9D04E6 /* ObjCExceptionCatcher.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFAE974582B8CDFFBA64AFB5 /* ObjCExceptionCatcher.framework */; };
 		8D5933C825193DD5F0FDF354 /* ObjCExceptionCatcher.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FFAE974582B8CDFFBA64AFB5 /* ObjCExceptionCatcher.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		8E00E330C839DBF9AC5DCC8E /* ObjCExceptionCatcher.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FFAE974582B8CDFFBA64AFB5 /* ObjCExceptionCatcher.framework */; };
+		9344F9D095AA18CD7DAC3C91 /* FrameContextSafetyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7A827A4CDA083F75436C2A /* FrameContextSafetyTests.swift */; };
 		96ED92C8F268021CE148C4FF /* CtrlProxy.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 056D5DCA8003C7DFA37244C4 /* CtrlProxy.framework */; };
 		9E975A4E407F93A21BD80EB4 /* SdkDatabaseClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EDA90BC9E26458BCE47381F /* SdkDatabaseClient.swift */; };
 		9EFF1197D83979B0FC0E0BCE /* CommandPayloadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A702D259D2A37D9AA088EF8 /* CommandPayloadTests.swift */; };
@@ -183,6 +184,7 @@
 		034DC5B8A3A4FCE46CD89568 /* HierarchyDebouncer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HierarchyDebouncer.swift; sourceTree = "<group>"; };
 		043D2CA5107B76077BA6301C /* SdkHierarchyCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdkHierarchyCache.swift; sourceTree = "<group>"; };
 		056D5DCA8003C7DFA37244C4 /* CtrlProxy.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CtrlProxy.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0C7A827A4CDA083F75436C2A /* FrameContextSafetyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameContextSafetyTests.swift; sourceTree = "<group>"; };
 		0CDD96577EB9823B5FCF2585 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Assets.xcassets; path = CtrlProxyApp/Assets.xcassets; sourceTree = SOURCE_ROOT; };
 		0EDA90BC9E26458BCE47381F /* SdkDatabaseClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdkDatabaseClient.swift; sourceTree = "<group>"; };
 		0EE277596991C059142C485B /* CtrlProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CtrlProxy.swift; sourceTree = "<group>"; };
@@ -295,6 +297,7 @@
 				8A702D259D2A37D9AA088EF8 /* CommandPayloadTests.swift */,
 				B7BE98EA2924A42A6CD22993 /* ElementLocatorTests.swift */,
 				76DC5538569B4FCF89EA7547 /* ErrorResponseTypeTests.swift */,
+				0C7A827A4CDA083F75436C2A /* FrameContextSafetyTests.swift */,
 				CCAAB1439B71724CA0BF2401 /* GesturePerformerSymbolsUnavailableWiringTests.swift */,
 				3E5AAA4E2861D92C17F39B14 /* HierarchyDebouncerTests.swift */,
 				0F6E995191B4AF437EDB71CA /* HierarchyMergerTests.swift */,
@@ -639,6 +642,7 @@
 				9EFF1197D83979B0FC0E0BCE /* CommandPayloadTests.swift in Sources */,
 				E8B2051927387427E1F14EC2 /* ElementLocatorTests.swift in Sources */,
 				FBAA2ADC92863B6A10403BA1 /* ErrorResponseTypeTests.swift in Sources */,
+				9344F9D095AA18CD7DAC3C91 /* FrameContextSafetyTests.swift in Sources */,
 				671E243A2BD5CAF78FF48E1D /* GesturePerformerSymbolsUnavailableWiringTests.swift in Sources */,
 				4413FD9E4C8BF4071C74D482 /* HierarchyDebouncerTests.swift in Sources */,
 				CFCA362E1EF1F3251B19BC1B /* HierarchyMergerTests.swift in Sources */,

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -24,6 +24,7 @@ public class CommandHandler: CommandHandling {
     private let sdkDatabaseClient: (any SdkDatabaseFetching)?
     private let hierarchyDebouncer: (any HierarchyDebouncing)?
     private let voiceOverStateProvider: any VoiceOverStateProviding
+    private let frameContext: FrameContext
 
     public init(
         elementLocator: ElementLocating,
@@ -34,7 +35,8 @@ public class CommandHandler: CommandHandling {
         sdkHierarchyCache: (any SdkHierarchyCaching)? = nil,
         sdkDatabaseClient: (any SdkDatabaseFetching)? = nil,
         hierarchyDebouncer: (any HierarchyDebouncing)? = nil,
-        voiceOverStateProvider: any VoiceOverStateProviding = DefaultVoiceOverStateProvider()
+        voiceOverStateProvider: any VoiceOverStateProviding = DefaultVoiceOverStateProvider(),
+        frameContext: FrameContext = FrameContext()
     ) {
         self.elementLocator = elementLocator
         self.gesturePerformer = gesturePerformer
@@ -45,6 +47,7 @@ public class CommandHandler: CommandHandling {
         self.sdkDatabaseClient = sdkDatabaseClient
         self.hierarchyDebouncer = hierarchyDebouncer
         self.voiceOverStateProvider = voiceOverStateProvider
+        self.frameContext = frameContext
     }
 
     /// Factory for testing - allows injecting fakes
@@ -57,7 +60,8 @@ public class CommandHandler: CommandHandling {
         sdkHierarchyCache: (any SdkHierarchyCaching)? = nil,
         sdkDatabaseClient: (any SdkDatabaseFetching)? = nil,
         hierarchyDebouncer: (any HierarchyDebouncing)? = nil,
-        voiceOverStateProvider: any VoiceOverStateProviding = DefaultVoiceOverStateProvider()
+        voiceOverStateProvider: any VoiceOverStateProviding = DefaultVoiceOverStateProvider(),
+        frameContext: FrameContext = FrameContext()
     )
         -> CommandHandler
     {
@@ -70,7 +74,8 @@ public class CommandHandler: CommandHandling {
             sdkHierarchyCache: sdkHierarchyCache,
             sdkDatabaseClient: sdkDatabaseClient,
             hierarchyDebouncer: hierarchyDebouncer,
-            voiceOverStateProvider: voiceOverStateProvider
+            voiceOverStateProvider: voiceOverStateProvider,
+            frameContext: frameContext
         )
     }
 
@@ -312,7 +317,7 @@ public class CommandHandler: CommandHandling {
             requestId: request.requestId,
             data: enriched,
             perfTiming: perfTimings?.first,
-            frameContext: FrameContext.forHierarchy(enriched)
+            frameContext: frameContext.context(for: enriched)
         )
     }
 
@@ -415,7 +420,7 @@ public class CommandHandler: CommandHandling {
         guard let hierarchy = try? elementLocator.getViewHierarchy(disableAllFiltering: false) else {
             return nil
         }
-        return FrameContext.forHierarchy(enrichWithMatchingSdkHierarchy(hierarchy))
+        return frameContext.context(for: enrichWithMatchingSdkHierarchy(hierarchy))
     }
 
     private func requireCurrentFrameContext(_ expected: String?) throws {
@@ -423,6 +428,20 @@ public class CommandHandler: CommandHandling {
         guard currentFrameContext() == expected else {
             throw CommandError.executionFailed("Stale frame context; observe a fresh frame before retrying")
         }
+    }
+
+    private func performContextCheckedGesture<T>(
+        expected: String?,
+        operation: () throws -> T
+    )
+        throws -> T
+    {
+        let hierarchy = try? elementLocator.getViewHierarchy(disableAllFiltering: false)
+        return try frameContext.performIfCurrent(
+            expected: expected,
+            hierarchy: hierarchy.map(enrichWithMatchingSdkHierarchy),
+            operation: operation
+        )
     }
 
     // MARK: - Gestures
@@ -453,7 +472,9 @@ public class CommandHandler: CommandHandling {
         try requireFinite(request.x, field: "x")
         try requireFinite(request.y, field: "y")
         let duration = request.duration ?? 0
-        try gesturePerformer.tap(x: request.x, y: request.y, duration: TimeInterval(duration) / 1000.0)
+        try performContextCheckedGesture(expected: request.frameContext) {
+            try gesturePerformer.tap(x: request.x, y: request.y, duration: TimeInterval(duration) / 1000.0)
+        }
 
         return WebSocketResponse.success(
             type: ResponseType.tapCoordinatesResult.rawValue,
@@ -469,11 +490,13 @@ public class CommandHandler: CommandHandling {
         try requireFinite(request.x2, field: "x2")
         try requireFinite(request.y2, field: "y2")
         let duration = request.duration ?? 300
-        try gesturePerformer.swipe(
-            startX: request.x1, startY: request.y1,
-            endX: request.x2, endY: request.y2,
-            duration: TimeInterval(duration) / 1000.0
-        )
+        try performContextCheckedGesture(expected: request.frameContext) {
+            try gesturePerformer.swipe(
+                startX: request.x1, startY: request.y1,
+                endX: request.x2, endY: request.y2,
+                duration: TimeInterval(duration) / 1000.0
+            )
+        }
 
         return WebSocketResponse.success(
             type: ResponseType.swipeResult.rawValue,
@@ -529,13 +552,15 @@ public class CommandHandler: CommandHandling {
         let dragDuration = request.dragDurationMs ?? 300
         let holdDuration = request.holdDurationMs ?? 100
 
-        try gesturePerformer.drag(
-            startX: request.x1, startY: request.y1,
-            endX: request.x2, endY: request.y2,
-            pressDuration: TimeInterval(pressDuration) / 1000.0,
-            dragDuration: TimeInterval(dragDuration) / 1000.0,
-            holdDuration: TimeInterval(holdDuration) / 1000.0
-        )
+        try performContextCheckedGesture(expected: request.frameContext) {
+            try gesturePerformer.drag(
+                startX: request.x1, startY: request.y1,
+                endX: request.x2, endY: request.y2,
+                pressDuration: TimeInterval(pressDuration) / 1000.0,
+                dragDuration: TimeInterval(dragDuration) / 1000.0,
+                holdDuration: TimeInterval(holdDuration) / 1000.0
+            )
+        }
 
         return WebSocketResponse.success(
             type: ResponseType.dragResult.rawValue,

--- a/ios/control-proxy/Sources/CtrlProxy/CtrlProxy.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CtrlProxy.swift
@@ -15,6 +15,7 @@ public class CtrlProxy {
     private let hierarchyDebouncer: HierarchyDebouncer
     private let fpsMonitor: DisplayLinkFPSMonitor
     private let sdkHierarchyCache: SdkHierarchyCache
+    private let frameContext: FrameContext
     private let sdkHierarchyClient: SdkHierarchyClient
     private let sdkDatabaseClient: SdkDatabaseClient
     private let sdkHierarchyRefreshPublisher: SdkHierarchyRefreshPublisher
@@ -31,6 +32,7 @@ public class CtrlProxy {
     ) {
         elementLocator = ElementLocator()
         gesturePerformer = GesturePerformer(elementLocator: elementLocator)
+        frameContext = FrameContext()
         sdkHierarchyCache = SdkHierarchyCache()
         sdkHierarchyClient = SdkHierarchyClient()
         sdkDatabaseClient = SdkDatabaseClient()
@@ -42,9 +44,15 @@ public class CtrlProxy {
             sdkHierarchyClient: sdkHierarchyClient,
             sdkHierarchyCache: sdkHierarchyCache,
             sdkDatabaseClient: sdkDatabaseClient,
-            hierarchyDebouncer: hierarchyDebouncer
+            hierarchyDebouncer: hierarchyDebouncer,
+            frameContext: frameContext
         )
-        server = WebSocketServer(port: port, commandHandler: commandHandler, sdkHierarchyCache: sdkHierarchyCache)
+        server = WebSocketServer(
+            port: port,
+            commandHandler: commandHandler,
+            sdkHierarchyCache: sdkHierarchyCache,
+            frameContext: frameContext
+        )
         fpsMonitor = DisplayLinkFPSMonitor()
         sdkHierarchyRefreshPublisher = SdkHierarchyRefreshPublisher(
             hierarchyProvider: { [weak hierarchyDebouncer] in
@@ -59,6 +67,9 @@ public class CtrlProxy {
         )
         server.onSdkHierarchyUpdated = { [weak self] in
             self?.sdkHierarchyRefreshPublisher.publish()
+        }
+        hierarchyDebouncer.setOnTransition { [weak self] hierarchy in
+            self?.frameContext.recordTransition(to: hierarchy)
         }
     }
 

--- a/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Fakes.swift
@@ -9,6 +9,7 @@ public class FakeElementLocator: ElementLocating {
     private var hierarchyData: ViewHierarchy?
     private var elements: [String: Any] = [:]
     private var shouldThrow: Error?
+    public var onHierarchyRead: (() -> Void)?
 
     // MARK: - Call History
 
@@ -71,7 +72,7 @@ public class FakeElementLocator: ElementLocating {
             throw error
         }
 
-        return hierarchyData ?? ViewHierarchy(
+        let hierarchy = hierarchyData ?? ViewHierarchy(
             packageName: "com.test.app",
             hierarchy: UIElementInfo(
                 text: "Fake Root",
@@ -80,6 +81,8 @@ public class FakeElementLocator: ElementLocating {
             ),
             windowInfo: WindowInfo(id: 0, type: 1, isActive: true, isFocused: true)
         )
+        onHierarchyRead?()
+        return hierarchy
     }
 
     public func findElement(byResourceId resourceId: String) -> Any? {
@@ -134,6 +137,7 @@ public class FakeGesturePerformer: GesturePerforming {
 
     private var screenshotData: Data?
     private var screenshotCapture: ScreenshotCapture?
+    public var onScreenshot: (() -> Void)?
     private var currentOrientation = "portrait"
     private var failureMap: [String: Error] = [:]
 
@@ -569,12 +573,14 @@ public class FakeGesturePerformer: GesturePerforming {
     public func getScreenshot() throws -> Data {
         try checkFailure("screenshot")
         screenshotCallCount += 1
+        onScreenshot?()
         return screenshotData ?? Data()
     }
 
     public func getScreenshotCapture() throws -> ScreenshotCapture {
         try checkFailure("screenshot")
         screenshotCallCount += 1
+        onScreenshot?()
         return screenshotCapture ?? ScreenshotCapture(
             data: screenshotData ?? Data(),
             rotation: DeviceRotation.fromOrientationName(currentOrientation)

--- a/ios/control-proxy/Sources/CtrlProxy/FrameContext.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/FrameContext.swift
@@ -1,26 +1,49 @@
 import Foundation
 
-/// Stable, opaque identity for a device hierarchy. It deliberately hashes the encoded hierarchy
-/// rather than dimensions: same-size navigation must still invalidate a mirrored frame.
-enum FrameContext {
-    private static let lock = NSLock()
-    private static var generation: UInt64 = 0
+/// Stable, opaque identity for a device hierarchy. A tracker belongs to one CtrlProxy process,
+/// so a delayed context can never be reused after that process restarts.
+public final class FrameContext {
+    private let lock = NSLock()
+    private let epoch: UUID
+    private var generation: UInt64 = 0
 
-    /// Each pushed hierarchy advances a process-local generation. This detects an A→B→A change
-    /// while a screenshot is in flight even when its semantic hash returns to the same value.
-    static func recordHierarchy(_ hierarchy: ViewHierarchy) -> String? {
-        lock.lock()
-        generation &+= 1
-        let currentGeneration = generation
-        lock.unlock()
-        return semanticHash(hierarchy).map { "\(currentGeneration):\($0)" }
+    public init(epoch: UUID = UUID()) {
+        self.epoch = epoch
     }
 
-    static func forHierarchy(_ hierarchy: ViewHierarchy) -> String? {
+    /// Records a device-side UI transition, even when hierarchy publication is debounced.
+    public func recordTransition(to _: ViewHierarchy) {
+        lock.lock()
+        generation &+= 1
+        lock.unlock()
+    }
+
+    public func context(for hierarchy: ViewHierarchy) -> String? {
         lock.lock()
         let currentGeneration = generation
         lock.unlock()
-        return semanticHash(hierarchy).map { "\(currentGeneration):\($0)" }
+        return Self.semanticHash(hierarchy).map { "\(epoch.uuidString):\(currentGeneration):\($0)" }
+    }
+
+    /// Serializes transition recording with the final context check and gesture dispatch.
+    func performIfCurrent<T>(
+        expected: String?,
+        hierarchy: ViewHierarchy?,
+        operation: () throws -> T
+    )
+        throws -> T
+    {
+        guard let expected else { return try operation() }
+        guard let hierarchy else {
+            throw CommandError.executionFailed("Stale frame context; observe a fresh frame before retrying")
+        }
+
+        lock.lock()
+        defer { lock.unlock() }
+        guard Self.semanticHash(hierarchy).map({ "\(epoch.uuidString):\(generation):\($0)" }) == expected else {
+            throw CommandError.executionFailed("Stale frame context; observe a fresh frame before retrying")
+        }
+        return try operation()
     }
 
     private static func semanticHash(_ hierarchy: ViewHierarchy) -> String? {
@@ -30,10 +53,10 @@ enum FrameContext {
         let encoder = JSONEncoder()
         encoder.outputFormatting = .sortedKeys
         guard let data = try? encoder.encode(SemanticHierarchy(hierarchy)) else { return nil }
-        var hash: UInt64 = 0xcbf29ce484222325
+        var hash: UInt64 = 0xCBF2_9CE4_8422_2325
         for byte in data {
             hash ^= UInt64(byte)
-            hash &*= 0x100000001b3
+            hash &*= 0x1000_0000_01B3
         }
         return String(hash, radix: 16)
     }

--- a/ios/control-proxy/Sources/CtrlProxy/HierarchyDebouncer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/HierarchyDebouncer.swift
@@ -35,6 +35,9 @@ public protocol HierarchyDebouncing {
     /// Set callback for hierarchy results
     func setOnResult(_ callback: @escaping (HierarchyResult) -> Void)
 
+    /// Set callback for each newly observed structural UI state, including debounced changes.
+    func setOnTransition(_ callback: @escaping (ViewHierarchy) -> Void)
+
     /// Get the last extracted hierarchy without triggering a new extraction
     func getLastHierarchy() -> ViewHierarchy?
 
@@ -74,6 +77,7 @@ public class HierarchyDebouncer: HierarchyDebouncing {
     // MARK: - State
 
     private var lastStructuralHash = 0
+    private var lastObservedStructuralHash = 0
     private var inAnimationMode = false
     private var animationModeEndTime: Int64 = 0
     private var skippedPollCount = 0
@@ -85,6 +89,7 @@ public class HierarchyDebouncer: HierarchyDebouncing {
     private var pollScheduled = false
     private var pollGeneration = 0
     private var onResult: ((HierarchyResult) -> Void)?
+    private var onTransition: ((ViewHierarchy) -> Void)?
 
     public var isRunning: Bool {
         lock.lock()
@@ -110,6 +115,12 @@ public class HierarchyDebouncer: HierarchyDebouncing {
         lock.lock()
         defer { lock.unlock() }
         onResult = callback
+    }
+
+    public func setOnTransition(_ callback: @escaping (ViewHierarchy) -> Void) {
+        lock.lock()
+        defer { lock.unlock() }
+        onTransition = callback
     }
 
     public func setPollIntervalMs(_ intervalMs: Int64) {
@@ -192,6 +203,7 @@ public class HierarchyDebouncer: HierarchyDebouncing {
     public func reset() {
         lock.lock()
         lastStructuralHash = 0
+        lastObservedStructuralHash = 0
         inAnimationMode = false
         animationModeEndTime = 0
         skippedPollCount = 0
@@ -241,6 +253,7 @@ public class HierarchyDebouncer: HierarchyDebouncing {
 
             lock.lock()
             lastStructuralHash = hash
+            lastObservedStructuralHash = hash
             lastHierarchy = hierarchy
             lastBroadcastTime = timer.now()
             let callback = onResult
@@ -298,9 +311,18 @@ public class HierarchyDebouncer: HierarchyDebouncing {
 
             lock.lock()
             let oldHash = lastStructuralHash
+            let oldObservedHash = lastObservedStructuralHash
             let callback = onResult
+            let transitionCallback = onTransition
             let lastBroadcast = lastBroadcastTime
             lock.unlock()
+
+            if newHash != oldObservedHash {
+                lock.lock()
+                lastObservedStructuralHash = newHash
+                lock.unlock()
+                transitionCallback?(hierarchy)
+            }
 
             if newHash == oldHash {
                 // Structure unchanged - likely animation
@@ -440,6 +462,7 @@ public class FakeHierarchyDebouncer: HierarchyDebouncing {
     // State
     private var _isRunning = false
     private var onResult: ((HierarchyResult) -> Void)?
+    private var onTransition: ((ViewHierarchy) -> Void)?
     private var lastHierarchy: ViewHierarchy?
     private let lock = NSLock()
 
@@ -498,6 +521,12 @@ public class FakeHierarchyDebouncer: HierarchyDebouncing {
         lock.unlock()
     }
 
+    public func setOnTransition(_ callback: @escaping (ViewHierarchy) -> Void) {
+        lock.lock()
+        onTransition = callback
+        lock.unlock()
+    }
+
     public func getLastHierarchy() -> ViewHierarchy? {
         lock.lock()
         defer { lock.unlock() }
@@ -522,6 +551,9 @@ public class FakeHierarchyDebouncer: HierarchyDebouncing {
         }
         lock.unlock()
         callback?(result)
+        if case let .changed(hierarchy, _, _) = result {
+            onTransition?(hierarchy)
+        }
     }
 
     /// Reset all call counts for fresh test assertions

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -111,6 +111,7 @@ public class WebSocketServer: WebSocketServing {
     private let commandHandler: CommandHandler
     private let perfProvider: PerfProvider
     private let sdkHierarchyCache: SdkHierarchyCache?
+    private let frameContext: FrameContext
     private let queue = DispatchQueue(label: "com.ctrlproxy.server")
     var onSdkHierarchyUpdated: (() -> Void)?
 
@@ -122,12 +123,14 @@ public class WebSocketServer: WebSocketServing {
         port: UInt16 = 8765,
         commandHandler: CommandHandler,
         perfProvider: PerfProvider = PerfProvider.instance,
-        sdkHierarchyCache: SdkHierarchyCache? = nil
+        sdkHierarchyCache: SdkHierarchyCache? = nil,
+        frameContext: FrameContext = FrameContext()
     ) {
         self.port = port
         self.commandHandler = commandHandler
         self.perfProvider = perfProvider
         self.sdkHierarchyCache = sdkHierarchyCache
+        self.frameContext = frameContext
     }
 
     /// Starts the server
@@ -304,11 +307,12 @@ public class WebSocketServer: WebSocketServing {
 
     /// Broadcast a hierarchy update to all connected clients (push notification)
     public func broadcastHierarchyUpdate(_ hierarchy: ViewHierarchy) {
+        frameContext.recordTransition(to: hierarchy)
         let response = HierarchyUpdateResponse(
             requestId: nil, // No requestId for push updates
             data: hierarchy,
             perfTiming: nil,
-            frameContext: FrameContext.recordHierarchy(hierarchy)
+            frameContext: frameContext.context(for: hierarchy)
         )
 
         do {

--- a/ios/control-proxy/Tests/CtrlProxyTests/FrameContextSafetyTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/FrameContextSafetyTests.swift
@@ -1,0 +1,97 @@
+@testable import CtrlProxy
+import XCTest
+
+final class FrameContextSafetyTests: XCTestCase {
+    private var fakeElementLocator: FakeElementLocator!
+    private var fakeGesturePerformer: FakeGesturePerformer!
+    private var frameContext: FrameContext!
+    private var commandHandler: CommandHandler!
+
+    override func setUp() {
+        super.setUp()
+        fakeElementLocator = FakeElementLocator()
+        fakeGesturePerformer = FakeGesturePerformer()
+        frameContext = FrameContext()
+        commandHandler = CommandHandler.createForTesting(
+            elementLocator: fakeElementLocator,
+            gesturePerformer: fakeGesturePerformer,
+            perfProvider: PerfProvider.createForTesting(timeProvider: FakeTimeProvider(initialTime: 0)),
+            frameContext: frameContext
+        )
+    }
+
+    func testContextsFromSeparateProcessesCannotMatch() {
+        let hierarchy = makeHierarchy(text: "A")
+        let restartedProcess = FrameContext()
+
+        XCTAssertNotEqual(
+            frameContext.context(for: hierarchy),
+            restartedProcess.context(for: hierarchy)
+        )
+    }
+
+    func testScreenshotContextIsAbsentAfterABATransitionDuringCapture() {
+        let screenA = makeHierarchy(text: "A")
+        let screenB = makeHierarchy(text: "B")
+        fakeElementLocator.setHierarchy(screenA)
+        fakeGesturePerformer.onScreenshot = { [frameContext] in
+            frameContext?.recordTransition(to: screenB)
+            frameContext?.recordTransition(to: screenA)
+        }
+
+        let response = commandHandler.handle(.requestScreenshot(RequestEnvelope(requestId: "capture"))) as? ScreenshotResponse
+
+        XCTAssertNil(response?.frameContext)
+    }
+
+    func testContextBearingGesturesRevalidateAtDispatchBoundary() {
+        let screenA = makeHierarchy(text: "A")
+        let screenB = makeHierarchy(text: "B")
+        let expected = frameContext.context(for: screenA)
+        let requests: [WebSocketRequest] = [
+            .tapCoordinates(RequestTapCoordinates(
+                requestId: "tap",
+                x: 10,
+                y: 20,
+                frameContext: expected
+            )),
+            .swipe(RequestSwipe(
+                requestId: "swipe",
+                x1: 10,
+                y1: 20,
+                x2: 30,
+                y2: 40,
+                frameContext: expected
+            )),
+            .drag(RequestDrag(
+                requestId: "drag",
+                x1: 10,
+                y1: 20,
+                x2: 30,
+                y2: 40,
+                frameContext: expected
+            )),
+        ]
+
+        for request in requests {
+            fakeElementLocator.setHierarchy(screenA)
+            fakeElementLocator.onHierarchyRead = { [fakeElementLocator] in
+                fakeElementLocator?.setHierarchy(screenB)
+                fakeElementLocator?.onHierarchyRead = nil
+            }
+            let response = commandHandler.handle(request) as? WebSocketResponse
+            XCTAssertEqual(response?.success, false)
+        }
+
+        XCTAssertTrue(fakeGesturePerformer.getTapHistory().isEmpty)
+        XCTAssertTrue(fakeGesturePerformer.getSwipeHistory().isEmpty)
+        XCTAssertTrue(fakeGesturePerformer.getDragHistory().isEmpty)
+    }
+
+    private func makeHierarchy(text: String) -> ViewHierarchy {
+        ViewHierarchy(
+            packageName: "com.example.app",
+            hierarchy: UIElementInfo(text: text)
+        )
+    }
+}

--- a/ios/control-proxy/Tests/CtrlProxyTests/HierarchyDebouncerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/HierarchyDebouncerTests.swift
@@ -398,6 +398,29 @@ final class HierarchyDebouncerTests: XCTestCase {
         }
     }
 
+    func testReportsStructuralTransitionBeforeDebouncedBroadcast() {
+        let initial = ViewHierarchy(
+            packageName: "com.test.app",
+            hierarchy: UIElementInfo(text: "A")
+        )
+        let changed = ViewHierarchy(
+            packageName: "com.test.app",
+            hierarchy: UIElementInfo(text: "B")
+        )
+        fakeLocator.setHierarchy(initial)
+        let transitions = Box<[ViewHierarchy]>([])
+        debouncer.setOnTransition { hierarchy in
+            transitions.value.append(hierarchy)
+        }
+
+        debouncer.start()
+        fakeLocator.setHierarchy(changed)
+        fakeTimer.advance(by: 10)
+
+        XCTAssertEqual(transitions.value.count, 1)
+        XCTAssertEqual(transitions.value.first?.hierarchy?.text, "B")
+    }
+
     // MARK: - StructuralHasher Tests
 
     func testHashChangesWhenAlertNodesAdded() {

--- a/ios/control-proxy/Tests/CtrlProxyTests/ModelsTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ModelsTests.swift
@@ -12,9 +12,12 @@ final class ModelsTests: XCTestCase {
             hierarchy: UIElementInfo(text: "B")
         )
 
-        let firstScreenAContext = FrameContext.recordHierarchy(screenA)
-        _ = FrameContext.recordHierarchy(screenB)
-        let returnedScreenAContext = FrameContext.recordHierarchy(screenA)
+        let frameContext = FrameContext()
+        frameContext.recordTransition(to: screenA)
+        let firstScreenAContext = frameContext.context(for: screenA)
+        frameContext.recordTransition(to: screenB)
+        frameContext.recordTransition(to: screenA)
+        let returnedScreenAContext = frameContext.context(for: screenA)
 
         XCTAssertNotEqual(firstScreenAContext, returnedScreenAContext)
     }


### PR DESCRIPTION
## Summary

Closes [#4587](https://github.com/kaeawc/auto-mobile/issues/4587).

- Give each CtrlProxy process its own frame-context epoch and generation.
- Record hierarchy transitions before broadcast debounce, so a changed hierarchy invalidates stale context immediately.
- Revalidate the context atomically at tap, swipe, and drag dispatch.

## Root cause

Frame-context provenance previously relied on process-global state and accepted a context after asynchronous validation even when a hierarchy transition occurred before gesture dispatch.

## Validation

- `swift test -Xswiftc -warnings-as-errors` in `ios/control-proxy` (439 tests)
- Focused frame-context and hierarchy-debouncer tests
- `bun run typecheck`
- `ONLY_TOUCHED_FILES=true bash scripts/swiftlint/validate_swiftlint.sh`

`bun run turbo:validate` remains blocked by the sandbox's unwritable default data directory, shared test-port exhaustion, and an unrelated local ephemeral-server bind failure.
