### PR TITLE
fix: validate stale Android input contexts

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -1198,7 +1198,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     frameContext: String?,
   ) {
     if (rejectStaleFrameContext(requestId, frameContext, "swipe")) return
-    performSwipe(requestId, x1, y1, x2, y2, duration)
+    performSwipe(requestId, x1, y1, x2, y2, duration, frameContext)
   }
 
   override fun requestTapCoordinates(requestId: String?, x: Double, y: Double, duration: Long) =
@@ -1212,7 +1212,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     frameContext: String?,
   ) {
     if (rejectStaleFrameContext(requestId, frameContext, "tap")) return
-    performTapCoordinates(requestId, x, y, duration)
+    performTapCoordinates(requestId, x, y, duration, frameContext)
   }
 
   override fun requestTwoFingerSwipe(
@@ -1248,7 +1248,17 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     frameContext: String?,
   ) {
     if (rejectStaleFrameContext(requestId, frameContext, "drag")) return
-    performDrag(requestId, x1, y1, x2, y2, pressDurationMs, dragDurationMs, holdDurationMs)
+    performDrag(
+      requestId,
+      x1,
+      y1,
+      x2,
+      y2,
+      pressDurationMs,
+      dragDurationMs,
+      holdDurationMs,
+      frameContext,
+    )
   }
 
   /**
@@ -1266,6 +1276,19 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         "tap" -> broadcastTapCoordinatesResult(requestId, false, error, 0)
         "swipe" -> broadcastSwipeResult(requestId, false, error, 0, null)
         "drag" -> broadcastDragResult(requestId, false, error, 0, null)
+        "set_text" -> broadcastSetTextResult(requestId, false, error, 0)
+        "ime_action" -> broadcastImeActionResult(requestId, action, false, error, 0)
+        "global_action" ->
+          webSocketServer.broadcast(
+            dev.jasonpearson.automobile.protocol.GlobalActionResult(
+              timestamp = System.currentTimeMillis(),
+              requestId = requestId,
+              success = false,
+              action = action,
+              totalTimeMs = 0,
+              error = error,
+            )
+          )
       }
     }
     return true
@@ -1297,8 +1320,24 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     dismissKeyboard: Boolean,
   ) = performSetText(requestId, text, resourceId, dismissKeyboard)
 
+  override fun requestSetText(
+    requestId: String?,
+    text: String,
+    resourceId: String?,
+    dismissKeyboard: Boolean,
+    frameContext: String?,
+  ) {
+    if (rejectStaleFrameContext(requestId, frameContext, "set_text")) return
+    performSetText(requestId, text, resourceId, dismissKeyboard)
+  }
+
   override fun requestImeAction(requestId: String?, action: String) =
     performImeAction(requestId, action)
+
+  override fun requestImeAction(requestId: String?, action: String, frameContext: String?) {
+    if (rejectStaleFrameContext(requestId, frameContext, "ime_action")) return
+    performImeAction(requestId, action)
+  }
 
   override fun requestSelectAll(requestId: String?) = performSelectAll(requestId)
 
@@ -1323,6 +1362,31 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
 
   override fun requestGlobalAction(requestId: String?, action: String) =
     performGlobalActionRequest(requestId, action)
+
+  override fun requestGlobalAction(requestId: String?, action: String, frameContext: String?) {
+    if (rejectStaleFrameContext(requestId, frameContext, "global_action")) return
+    performGlobalActionRequest(requestId, action)
+  }
+
+  override fun validateFrameContext(requestId: String?, frameContext: String) {
+    val matches = frameContext == currentFrameContext()
+    asyncActionRunner.launch(requestId, "validate_frame_context") {
+      webSocketServer?.broadcast(
+        dev.jasonpearson.automobile.protocol.FrameContextValidationResult(
+          timestamp = System.currentTimeMillis(),
+          requestId = requestId,
+          success = matches,
+          totalTimeMs = 0,
+          error =
+            if (matches) {
+              null
+            } else {
+              "Stale frame context for input/key; observe a fresh frame before retrying"
+            },
+        )
+      )
+    }
+  }
 
   override fun requestDeviceInfo(requestId: String?) = performDeviceInfoRequest(requestId)
 
@@ -1599,6 +1663,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       if (
         event.eventType == AccessibilityEvent.TYPE_WINDOW_CONTENT_CHANGED ||
           event.eventType == AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED ||
+          event.eventType == AccessibilityEvent.TYPE_WINDOWS_CHANGED ||
           event.eventType == AccessibilityEvent.TYPE_VIEW_TEXT_CHANGED
       ) {
         frameContext.incrementAndGet()
@@ -2557,6 +2622,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     requestId: String?,
     startTimeMs: Long,
     gestureBuiltTimeMs: Long,
+    frameContext: String? = null,
     beforeCompletedResult: () -> Unit = {},
     onResult: (GestureDispatchOutcome) -> Unit,
   ) {
@@ -2571,6 +2637,13 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       )
 
     lifecycle.startDispatch()
+    if (frameContext != null && frameContext != currentFrameContext()) {
+      lifecycle.failed(
+        IllegalStateException("Stale frame context; observe a fresh frame before retrying"),
+        onResult,
+      )
+      return
+    }
     val dispatched =
       try {
         dispatchGesture(
@@ -2609,6 +2682,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     x2: Double,
     y2: Double,
     duration: Long,
+    frameContext: String? = null,
   ) {
     val startTime = System.currentTimeMillis()
     Log.d(TAG, "performSwipe: ($x1, $y1) -> ($x2, $y2) duration=${duration}ms")
@@ -2633,7 +2707,14 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       val gestureBuiltTime = System.currentTimeMillis()
       Log.d(TAG, "Gesture built in ${gestureBuiltTime - startTime}ms")
 
-      dispatchGestureWithResult("performSwipe", gesture, requestId, startTime, gestureBuiltTime) {
+      dispatchGestureWithResult(
+        "performSwipe",
+        gesture,
+        requestId,
+        startTime,
+        gestureBuiltTime,
+        frameContext,
+      ) {
         outcome ->
         if (outcome.completed) {
           Log.d(
@@ -2687,6 +2768,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     pressDurationMs: Long,
     dragDurationMs: Long,
     holdDurationMs: Long,
+    frameContext: String? = null,
   ) {
     val startTime = System.currentTimeMillis()
     Log.d(
@@ -2821,7 +2903,14 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       val gestureBuiltTime = System.currentTimeMillis()
       Log.d(TAG, "Drag gesture built in ${gestureBuiltTime - startTime}ms")
 
-      dispatchGestureWithResult("performDrag", gesture, requestId, startTime, gestureBuiltTime) {
+      dispatchGestureWithResult(
+        "performDrag",
+        gesture,
+        requestId,
+        startTime,
+        gestureBuiltTime,
+        frameContext,
+      ) {
         outcome ->
         if (outcome.completed) {
           Log.d(
@@ -2863,7 +2952,13 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
    * @param y Y coordinate to tap
    * @param duration Duration of the tap in milliseconds (default 10ms for a quick tap)
    */
-  private fun performTapCoordinates(requestId: String?, x: Double, y: Double, duration: Long = 10) {
+  private fun performTapCoordinates(
+    requestId: String?,
+    x: Double,
+    y: Double,
+    duration: Long = 10,
+    frameContext: String? = null,
+  ) {
     val startTime = System.currentTimeMillis()
     Log.d(TAG, "performTapCoordinates: ($x, $y) duration=${duration}ms")
     perfProvider.serial("performTapCoordinates")
@@ -2889,6 +2984,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         requestId,
         startTime,
         gestureBuiltTime,
+        frameContext,
         beforeCompletedResult = {
           // Wait for UI to settle after tap, then extract fresh hierarchy.
           val freshHierarchy =

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -2714,8 +2714,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         startTime,
         gestureBuiltTime,
         frameContext,
-      ) {
-        outcome ->
+      ) { outcome ->
         if (outcome.completed) {
           Log.d(
             TAG,
@@ -2910,8 +2909,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         startTime,
         gestureBuiltTime,
         frameContext,
-      ) {
-        outcome ->
+      ) { outcome ->
         if (outcome.completed) {
           Log.d(
             TAG,

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyActions.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyActions.kt
@@ -106,7 +106,18 @@ interface CtrlProxyActions {
     dismissKeyboard: Boolean,
   )
 
+  fun requestSetText(
+    requestId: String?,
+    text: String,
+    resourceId: String?,
+    dismissKeyboard: Boolean,
+    frameContext: String?,
+  ) = requestSetText(requestId, text, resourceId, dismissKeyboard)
+
   fun requestImeAction(requestId: String?, action: String)
+
+  fun requestImeAction(requestId: String?, action: String, frameContext: String?) =
+    requestImeAction(requestId, action)
 
   fun requestSelectAll(requestId: String?)
 
@@ -126,6 +137,11 @@ interface CtrlProxyActions {
   fun removeCaCert(requestId: String?, alias: String?, certificate: String?)
 
   fun requestGlobalAction(requestId: String?, action: String)
+
+  fun requestGlobalAction(requestId: String?, action: String, frameContext: String?) =
+    requestGlobalAction(requestId, action)
+
+  fun validateFrameContext(requestId: String?, frameContext: String) = Unit
 
   fun requestDeviceInfo(requestId: String?)
 

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandler.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandler.kt
@@ -273,7 +273,8 @@ class CtrlProxyMessageHandler(
         } else {
           actions.requestGlobalAction(request.requestId, request.action, request.frameContext)
         }
-      is ValidateFrameContext -> actions.validateFrameContext(request.requestId, request.frameContext)
+      is ValidateFrameContext ->
+        actions.validateFrameContext(request.requestId, request.frameContext)
       is RequestDeviceInfo -> actions.requestDeviceInfo(request.requestId)
       is GetDeviceOwnerStatus -> actions.getDeviceOwnerStatus(request.requestId)
       is GetPermission ->

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandler.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandler.kt
@@ -51,6 +51,7 @@ import dev.jasonpearson.automobile.protocol.SubscribeStorage
 import dev.jasonpearson.automobile.protocol.SwipeResult
 import dev.jasonpearson.automobile.protocol.TapCoordinatesResult
 import dev.jasonpearson.automobile.protocol.UnsubscribeStorage
+import dev.jasonpearson.automobile.protocol.ValidateFrameContext
 import dev.jasonpearson.automobile.protocol.WebSocketMessageHandler
 import dev.jasonpearson.automobile.protocol.WebSocketRequest
 import dev.jasonpearson.automobile.protocol.WebSocketResponse
@@ -210,13 +211,28 @@ class CtrlProxyMessageHandler(
         )
       }
       is RequestSetText ->
-        actions.requestSetText(
-          request.requestId,
-          request.text,
-          request.resourceId,
-          request.dismissKeyboard,
-        )
-      is RequestImeAction -> actions.requestImeAction(request.requestId, request.action)
+        if (request.frameContext == null) {
+          actions.requestSetText(
+            request.requestId,
+            request.text,
+            request.resourceId,
+            request.dismissKeyboard,
+          )
+        } else {
+          actions.requestSetText(
+            request.requestId,
+            request.text,
+            request.resourceId,
+            request.dismissKeyboard,
+            request.frameContext,
+          )
+        }
+      is RequestImeAction ->
+        if (request.frameContext == null) {
+          actions.requestImeAction(request.requestId, request.action)
+        } else {
+          actions.requestImeAction(request.requestId, request.action, request.frameContext)
+        }
       is RequestSelectAll -> actions.requestSelectAll(request.requestId)
       is RequestAction ->
         actions.requestAction(
@@ -251,7 +267,13 @@ class CtrlProxyMessageHandler(
         } else {
           log("remove_ca_cert missing alias and certificate; ignoring")
         }
-      is RequestGlobalAction -> actions.requestGlobalAction(request.requestId, request.action)
+      is RequestGlobalAction ->
+        if (request.frameContext == null) {
+          actions.requestGlobalAction(request.requestId, request.action)
+        } else {
+          actions.requestGlobalAction(request.requestId, request.action, request.frameContext)
+        }
+      is ValidateFrameContext -> actions.validateFrameContext(request.requestId, request.frameContext)
       is RequestDeviceInfo -> actions.requestDeviceInfo(request.requestId)
       is GetDeviceOwnerStatus -> actions.getDeviceOwnerStatus(request.requestId)
       is GetPermission ->

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyActionsFakes.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyActionsFakes.kt
@@ -271,8 +271,19 @@ class RecordingCtrlProxyActions : CtrlProxyActions {
     dismissKeyboard: Boolean,
   ) = record("requestSetText", requestId, text, resourceId, dismissKeyboard)
 
+  override fun requestSetText(
+    requestId: String?,
+    text: String,
+    resourceId: String?,
+    dismissKeyboard: Boolean,
+    frameContext: String?,
+  ) = record("requestSetText", requestId, text, resourceId, dismissKeyboard, frameContext)
+
   override fun requestImeAction(requestId: String?, action: String) =
     record("requestImeAction", requestId, action)
+
+  override fun requestImeAction(requestId: String?, action: String, frameContext: String?) =
+    record("requestImeAction", requestId, action, frameContext)
 
   override fun requestSelectAll(requestId: String?) = record("requestSelectAll", requestId)
 
@@ -297,6 +308,12 @@ class RecordingCtrlProxyActions : CtrlProxyActions {
 
   override fun requestGlobalAction(requestId: String?, action: String) =
     record("requestGlobalAction", requestId, action)
+
+  override fun requestGlobalAction(requestId: String?, action: String, frameContext: String?) =
+    record("requestGlobalAction", requestId, action, frameContext)
+
+  override fun validateFrameContext(requestId: String?, frameContext: String) =
+    record("validateFrameContext", requestId, frameContext)
 
   override fun requestDeviceInfo(requestId: String?) = record("requestDeviceInfo", requestId)
 

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandlerTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandlerTest.kt
@@ -412,9 +412,23 @@ class CtrlProxyMessageHandlerTest {
   }
 
   @Test
+  fun `forwards frame context with request_set_text`() = runTest {
+    dispatch(
+      """{"type":"request_set_text","requestId":"txt1","text":"Hello","frameContext":"frame-1"}"""
+    )
+    assertEquals("requestSetText" to listOf<Any?>("txt1", "Hello", null, false, "frame-1"), lastCall)
+  }
+
+  @Test
   fun `dispatches request_ime_action`() = runTest {
     dispatch("""{"type":"request_ime_action","requestId":"i1","action":"search"}""")
     assertEquals("requestImeAction" to listOf<Any?>("i1", "search"), lastCall)
+  }
+
+  @Test
+  fun `forwards frame context with request_ime_action`() = runTest {
+    dispatch("""{"type":"request_ime_action","requestId":"i1","action":"search","frameContext":"frame-1"}""")
+    assertEquals("requestImeAction" to listOf<Any?>("i1", "search", "frame-1"), lastCall)
   }
 
   @Test
@@ -527,6 +541,18 @@ class CtrlProxyMessageHandlerTest {
   fun `dispatches request_global_action`() = runTest {
     dispatch("""{"type":"request_global_action","requestId":"g1","action":"back"}""")
     assertEquals("requestGlobalAction" to listOf<Any?>("g1", "back"), lastCall)
+  }
+
+  @Test
+  fun `dispatches validate_frame_context`() = runTest {
+    dispatch("""{"type":"validate_frame_context","requestId":"context-1","frameContext":"epoch:4"}""")
+    assertEquals("validateFrameContext" to listOf<Any?>("context-1", "epoch:4"), lastCall)
+  }
+
+  @Test
+  fun `forwards frame context with request_global_action`() = runTest {
+    dispatch("""{"type":"request_global_action","requestId":"g1","action":"back","frameContext":"frame-1"}""")
+    assertEquals("requestGlobalAction" to listOf<Any?>("g1", "back", "frame-1"), lastCall)
   }
 
   @Test

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandlerTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxyMessageHandlerTest.kt
@@ -416,7 +416,10 @@ class CtrlProxyMessageHandlerTest {
     dispatch(
       """{"type":"request_set_text","requestId":"txt1","text":"Hello","frameContext":"frame-1"}"""
     )
-    assertEquals("requestSetText" to listOf<Any?>("txt1", "Hello", null, false, "frame-1"), lastCall)
+    assertEquals(
+      "requestSetText" to listOf<Any?>("txt1", "Hello", null, false, "frame-1"),
+      lastCall,
+    )
   }
 
   @Test
@@ -427,7 +430,9 @@ class CtrlProxyMessageHandlerTest {
 
   @Test
   fun `forwards frame context with request_ime_action`() = runTest {
-    dispatch("""{"type":"request_ime_action","requestId":"i1","action":"search","frameContext":"frame-1"}""")
+    dispatch(
+      """{"type":"request_ime_action","requestId":"i1","action":"search","frameContext":"frame-1"}"""
+    )
     assertEquals("requestImeAction" to listOf<Any?>("i1", "search", "frame-1"), lastCall)
   }
 
@@ -545,13 +550,17 @@ class CtrlProxyMessageHandlerTest {
 
   @Test
   fun `dispatches validate_frame_context`() = runTest {
-    dispatch("""{"type":"validate_frame_context","requestId":"context-1","frameContext":"epoch:4"}""")
+    dispatch(
+      """{"type":"validate_frame_context","requestId":"context-1","frameContext":"epoch:4"}"""
+    )
     assertEquals("validateFrameContext" to listOf<Any?>("context-1", "epoch:4"), lastCall)
   }
 
   @Test
   fun `forwards frame context with request_global_action`() = runTest {
-    dispatch("""{"type":"request_global_action","requestId":"g1","action":"back","frameContext":"frame-1"}""")
+    dispatch(
+      """{"type":"request_global_action","requestId":"g1","action":"back","frameContext":"frame-1"}"""
+    )
     assertEquals("requestGlobalAction" to listOf<Any?>("g1", "back", "frame-1"), lastCall)
   }
 

--- a/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequest.kt
+++ b/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketRequest.kt
@@ -145,6 +145,7 @@ data class RequestSetText(
   val text: String,
   val resourceId: String? = null,
   val dismissKeyboard: Boolean = false,
+  val frameContext: String? = null,
 ) : WebSocketRequest()
 
 @Serializable
@@ -152,6 +153,7 @@ data class RequestSetText(
 data class RequestImeAction(
   override val requestId: String? = null,
   val action: String, // done, next, search, send, go, previous
+  val frameContext: String? = null,
 ) : WebSocketRequest()
 
 @Serializable
@@ -391,6 +393,14 @@ data class ClearPreferences(
 data class RequestGlobalAction(
   override val requestId: String? = null,
   val action: String, // back, home, recent, notifications, power_dialog, lock_screen
+  val frameContext: String? = null,
+) : WebSocketRequest()
+
+@Serializable
+@SerialName("validate_frame_context")
+data class ValidateFrameContext(
+  override val requestId: String? = null,
+  val frameContext: String,
 ) : WebSocketRequest()
 
 // =============================================================================

--- a/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketResponse.kt
+++ b/android/protocol/src/main/kotlin/dev/jasonpearson/automobile/protocol/WebSocketResponse.kt
@@ -536,6 +536,16 @@ data class GlobalActionResult(
   val error: String? = null,
 ) : WebSocketResponse()
 
+@Serializable
+@SerialName("frame_context_validation_result")
+data class FrameContextValidationResult(
+  override val timestamp: Long,
+  val requestId: String? = null,
+  val success: Boolean,
+  val totalTimeMs: Long,
+  val error: String? = null,
+) : WebSocketResponse()
+
 // =============================================================================
 // Device Info Result
 // =============================================================================

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1189,6 +1189,7 @@ export class UnixSocketServer {
             imeAction,
             remainingTimeoutMs,
             args.append,
+            args.frameContext,
             charsSent => {
               confirmedAppendCharsSent = charsSent;
             }
@@ -1246,7 +1247,10 @@ export class UnixSocketServer {
         });
       }
 
-      return await new PressButton(targetDevice).press(args.button, remainingTimeoutMs);
+      const pressButton = new PressButton(targetDevice);
+      return args.frameContext === undefined
+        ? await pressButton.press(args.button, remainingTimeoutMs)
+        : await pressButton.press(args.button, remainingTimeoutMs, args.frameContext);
     });
 
     if (!buttonResult.success) {
@@ -1291,7 +1295,10 @@ export class UnixSocketServer {
         });
       }
 
-      return await new InputKey(targetDevice).press(args.key, remainingTimeoutMs);
+      const inputKey = new InputKey(targetDevice);
+      return args.frameContext === undefined
+        ? await inputKey.press(args.key, remainingTimeoutMs)
+        : await inputKey.press(args.key, remainingTimeoutMs, args.frameContext);
     });
 
     if (!keyResult.success) {
@@ -1314,6 +1321,7 @@ export class UnixSocketServer {
     imeAction: ImeAction | undefined,
     timeoutMs: number,
     append: boolean = false,
+    frameContext?: string,
     onConfirmedAppendCharsSent?: (charsSent: number) => void
   ): Promise<{ success: boolean; error?: string; charsSent?: number }> {
     // Charge set-text and the optional submit/IME action against a single
@@ -1352,7 +1360,7 @@ export class UnixSocketServer {
     } else {
       const textResult = append
         ? await (client as IOSCtrlProxyClient).requestAppendText(text, timeoutMs)
-        : await client.requestSetText(text, { timeoutMs });
+        : await client.requestSetText(text, { timeoutMs, frameContext });
       if (!textResult.success) {
         return { success: false, error: textResult.error };
       }

--- a/src/features/action/InputKey.ts
+++ b/src/features/action/InputKey.ts
@@ -3,6 +3,7 @@ import type { AdbClientFactory } from "../../utils/android-cmdline-tools/AdbClie
 import { defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { logger } from "../../utils/logger";
+import { AndroidCtrlProxyClient } from "../observe/android";
 
 export const INPUT_KEY_CODE_MAP = {
   enter: "KEYCODE_ENTER",
@@ -34,19 +35,31 @@ export interface InputKeyResult {
   error?: string;
 }
 
+export interface FrameContextValidator {
+  validateFrameContext(
+    frameContext: string,
+    timeoutMs?: number
+  ): Promise<{ success: boolean; error?: string }>;
+}
+
 export class InputKey {
   private readonly device: BootedDevice;
   private readonly adb: AdbExecutor;
 
   constructor(
     device: BootedDevice,
-    adbFactory: AdbClientFactory = defaultAdbClientFactory
+    private readonly adbFactory: AdbClientFactory = defaultAdbClientFactory,
+    private readonly frameContextValidator?: FrameContextValidator
   ) {
     this.device = device;
     this.adb = adbFactory.create(device);
   }
 
-  async press(key: InputKeyName, timeoutMs?: number): Promise<InputKeyResult> {
+  async press(
+    key: InputKeyName,
+    timeoutMs?: number,
+    frameContext?: string
+  ): Promise<InputKeyResult> {
     if (this.device.platform !== "android") {
       return {
         success: false,
@@ -58,6 +71,19 @@ export class InputKey {
 
     const keyCode = INPUT_KEY_CODE_MAP[key];
     try {
+      if (frameContext !== undefined) {
+        const validator = this.frameContextValidator ??
+          AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
+        const validation = await validator.validateFrameContext(frameContext, timeoutMs);
+        if (!validation.success) {
+          return {
+            success: false,
+            key,
+            keyCode,
+            error: validation.error ?? "Frame context is stale or unavailable; observe a fresh frame before retrying",
+          };
+        }
+      }
       await this.adb.executeCommand(`shell input keyevent ${keyCode}`, timeoutMs, undefined, true);
       return {
         success: true,

--- a/src/features/action/PressButton.ts
+++ b/src/features/action/PressButton.ts
@@ -55,11 +55,11 @@ export class PressButton extends BaseVisualChange {
    *   per-transport hard-coded defaults. When omitted, the existing defaults
    *   apply.
    */
-  async press(button: string, timeoutMs?: number): Promise<PressButtonResult> {
+  async press(button: string, timeoutMs?: number, frameContext?: string): Promise<PressButtonResult> {
     try {
       switch (this.device.platform) {
         case "android":
-          return await this.executeAndroidButtonPress(button, timeoutMs);
+          return await this.executeAndroidButtonPress(button, timeoutMs, frameContext);
         case "ios":
           return await this.executeiOSButtonPress(button, timeoutMs);
         default:
@@ -89,7 +89,11 @@ export class PressButton extends BaseVisualChange {
   // before we fall back to ADB keyevent.
   private static readonly GLOBAL_ACTION_TIMEOUT_MS = 3000;
 
-  private async executeAndroidButtonPress(button: string, timeoutMs?: number): Promise<PressButtonResult> {
+  private async executeAndroidButtonPress(
+    button: string,
+    timeoutMs?: number,
+    frameContext?: string
+  ): Promise<PressButtonResult> {
     const normalized = button.toLowerCase();
     const keyCode = resolveAndroidKeyCode(normalized);
     if (keyCode === undefined) {
@@ -118,7 +122,12 @@ export class PressButton extends BaseVisualChange {
           : Math.min(PressButton.GLOBAL_ACTION_TIMEOUT_MS, budget);
         try {
           const client = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
-          const result = await client.requestGlobalAction(normalized, globalActionTimeout);
+          const result = await client.requestGlobalAction(
+            normalized,
+            globalActionTimeout,
+            undefined,
+            frameContext
+          );
           if (result.success) {
             logger.debug(`[PRESS_BUTTON] Used accessibility service for ${button}`);
             return { success: true, button, keyCode };

--- a/src/features/observe/DeviceService.ts
+++ b/src/features/observe/DeviceService.ts
@@ -50,6 +50,8 @@ export interface SetTextOptions {
    * setText. Ignored on iOS (no handler on the Swift side).
    */
   dismissKeyboard?: boolean;
+  /** Device-authored context paired with the observed Android frame. */
+  frameContext?: string;
 }
 
 /**

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -384,6 +384,13 @@ interface WsGlobalActionResultMessage extends WsMessageBase {
   totalTimeMs?: number;
 }
 
+interface WsFrameContextValidationResultMessage extends WsMessageBase {
+  type: "frame_context_validation_result";
+  requestId: string;
+  success?: boolean;
+  totalTimeMs?: number;
+}
+
 interface WsDeviceInfoResultMessage extends WsMessageBase {
   type: "device_info_result";
   requestId: string;
@@ -703,6 +710,7 @@ type WebSocketMessage =
   | WsInstalledPackagesResultMessage
   | WsPackageInfoResultMessage
   | WsLaunchIntentResultMessage
+  | WsFrameContextValidationResultMessage
   | WsNavigationEventMessage
   | WsPackageEventMessage
   | WsInteractionEventMessage
@@ -1873,7 +1881,8 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   async requestGlobalAction(
     action: string,
     timeoutMs: number = 5000,
-    perf: PerformanceTracker = new NoOpPerformanceTracker()
+    perf: PerformanceTracker = new NoOpPerformanceTracker(),
+    frameContext?: string
   ): Promise<{ success: boolean; action: string; totalTimeMs: number; error?: string }> {
     const startTime = this.timer.now();
     try {
@@ -1893,13 +1902,52 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
         throw new Error("WebSocket not connected");
       }
       this.ws.send(serializeCtrlProxyRequest(
-        ctrlProxyRequests.requestGlobalAction({ requestId, action })
+        ctrlProxyRequests.requestGlobalAction({ requestId, action, frameContext })
       ));
       logger.debug(`[CTRL_PROXY] Sent global action request (requestId: ${requestId}, action: ${action})`);
 
       return await promise;
     } catch (error) {
       return { success: false, action, totalTimeMs: this.timer.now() - startTime, error: `${error}` };
+    }
+  }
+
+  /**
+   * Verifies that an observed frame context still matches device state immediately before
+   * an ADB-only input action is issued.
+   */
+  async validateFrameContext(
+    frameContext: string,
+    timeoutMs: number = 5000
+  ): Promise<{ success: boolean; totalTimeMs: number; error?: string }> {
+    const startTime = this.timer.now();
+    try {
+      if (!this.isConnected()) {
+        return { success: false, totalTimeMs: this.timer.now() - startTime, error: "WebSocket not connected" };
+      }
+
+      const requestId = this.requestManager.generateId("validate_frame_context");
+      const promise = this.requestManager.register<{ success: boolean; totalTimeMs: number; error?: string }>(
+        requestId,
+        "validate_frame_context",
+        timeoutMs,
+        (_id, _type, timeout) => ({
+          success: false,
+          totalTimeMs: this.timer.now() - startTime,
+          error: `Frame context validation timeout after ${timeout}ms`,
+        })
+      );
+
+      if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+        throw new Error("WebSocket not connected");
+      }
+      this.ws.send(serializeCtrlProxyRequest(
+        ctrlProxyRequests.validateFrameContext({ requestId, frameContext })
+      ));
+
+      return await promise;
+    } catch (error) {
+      return { success: false, totalTimeMs: this.timer.now() - startTime, error: `${error}` };
     }
   }
 
@@ -2601,6 +2649,14 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
         this.requestManager.resolve(message.requestId, {
           success: message.success ?? false, action: message.action,
           totalTimeMs: message.totalTimeMs ?? 0, error: message.error
+        });
+      }
+
+      if (message.type === "frame_context_validation_result" && message.requestId) {
+        this.requestManager.resolve(message.requestId, {
+          success: message.success ?? false,
+          totalTimeMs: message.totalTimeMs ?? 0,
+          error: message.error,
         });
       }
 

--- a/src/features/observe/android/ctrlProxyProtocol.ts
+++ b/src/features/observe/android/ctrlProxyProtocol.ts
@@ -143,6 +143,7 @@ export interface RequestSetTextMessage {
   text: string;
   resourceId?: string;
   dismissKeyboard?: boolean;
+  frameContext?: string;
 }
 
 /** `@SerialName("request_ime_action")` → `RequestImeAction` */
@@ -150,6 +151,7 @@ export interface RequestImeActionMessage {
   type: "request_ime_action";
   requestId: string;
   action: ImeAction;
+  frameContext?: string;
 }
 
 /** `@SerialName("request_select_all")` → `RequestSelectAll` */
@@ -413,6 +415,14 @@ export interface RequestGlobalActionMessage {
   type: "request_global_action";
   requestId: string;
   action: string;
+  frameContext?: string;
+}
+
+/** `@SerialName("validate_frame_context")` → `ValidateFrameContext` */
+export interface ValidateFrameContextMessage {
+  type: "validate_frame_context";
+  requestId: string;
+  frameContext: string;
 }
 
 // =============================================================================
@@ -536,6 +546,7 @@ export type CtrlProxyRequest =
   | RemovePreferenceMessage
   | ClearPreferencesMessage
   | RequestGlobalActionMessage
+  | ValidateFrameContextMessage
   | SetRecompositionTrackingMessage
   | SetAccessibilityFlagsMessage
   | SetNetworkMockRulesMessage
@@ -599,6 +610,7 @@ const REQUEST_TYPE_REGISTRY: Record<CtrlProxyRequestType, true> = {
   remove_preference: true,
   clear_preferences: true,
   request_global_action: true,
+  validate_frame_context: true,
   set_recomposition_tracking: true,
   set_accessibility_flags: true,
   set_network_mock_rules: true,
@@ -847,8 +859,28 @@ export const ctrlProxyRequests = {
     };
   },
 
-  requestGlobalAction(args: { requestId: string; action: string }): RequestGlobalActionMessage {
-    return { type: "request_global_action", requestId: args.requestId, action: args.action };
+  requestGlobalAction(args: {
+    requestId: string;
+    action: string;
+    frameContext?: string;
+  }): RequestGlobalActionMessage {
+    return {
+      type: "request_global_action",
+      requestId: args.requestId,
+      action: args.action,
+      frameContext: args.frameContext,
+    };
+  },
+
+  validateFrameContext(args: {
+    requestId: string;
+    frameContext: string;
+  }): ValidateFrameContextMessage {
+    return {
+      type: "validate_frame_context",
+      requestId: args.requestId,
+      frameContext: args.frameContext,
+    };
   },
 
   setRecompositionTracking(args: { requestId: string; enabled: boolean }): SetRecompositionTrackingMessage {

--- a/src/features/observe/shared/SharedTextDelegate.ts
+++ b/src/features/observe/shared/SharedTextDelegate.ts
@@ -21,13 +21,16 @@ export class SharedTextDelegate {
     text: string,
     options: SetTextOptions = {}
   ): Promise<BaseResult> {
-    const { resourceId, timeoutMs = 5000, perf, dismissKeyboard = false } = options;
+    const { resourceId, timeoutMs = 5000, perf, dismissKeyboard = false, frameContext } = options;
     const params: Record<string, unknown> = { text };
     if (resourceId) {
       params.resourceId = resourceId;
     }
     if (dismissKeyboard) {
       params.dismissKeyboard = true;
+    }
+    if (frameContext !== undefined) {
+      params.frameContext = frameContext;
     }
 
     return sendCommand<BaseResult>(this.context, {

--- a/test/daemon/socketServerInputKey.test.ts
+++ b/test/daemon/socketServerInputKey.test.ts
@@ -161,6 +161,29 @@ describe("UnixSocketServer input/key", () => {
     expect(createMcpClient).not.toHaveBeenCalled();
   });
 
+  test("forwards an Android frame context to the key implementation", async () => {
+    const press = mock(async (key: InputKeyName): Promise<InputKeyResult> => ({
+      success: true,
+      key,
+      keyCode: "KEYCODE_ENTER",
+    }));
+    InputKey.prototype.press = press;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    (server as unknown as { requireCurrentFrameContext: () => void }).requireCurrentFrameContext = () => {};
+    await server.start();
+
+    const { response } = await sendRequest(socketPath, "input/key", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      key: "enter",
+      frameContext: "frame-1",
+    });
+
+    expect(response.success).toBe(true);
+    expect(press).toHaveBeenCalledWith("enter", 30_000, "frame-1");
+  });
+
   test("returns one clear unsupported-platform response for iOS", async () => {
     const press = mock(async (key: InputKeyName): Promise<InputKeyResult> => ({
       success: false,

--- a/test/daemon/socketServerInputPressButton.test.ts
+++ b/test/daemon/socketServerInputPressButton.test.ts
@@ -227,6 +227,29 @@ describe("UnixSocketServer input/pressButton", () => {
     expect(createMcpClient).not.toHaveBeenCalled();
   });
 
+  test("forwards an Android frame context to the button implementation", async () => {
+    const press = mock(async (button: string): Promise<PressButtonResult> => ({
+      success: true,
+      button,
+      keyCode: 4,
+    }));
+    PressButton.prototype.press = press;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    (server as unknown as { requireCurrentFrameContext: () => void }).requireCurrentFrameContext = () => {};
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/pressButton", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      button: "back",
+      frameContext: "frame-1",
+    });
+
+    expect(response.success).toBe(true);
+    expect(press).toHaveBeenCalledWith("back", 30_000, "frame-1");
+  });
+
   test("routes iOS button presses through the existing pressButton implementation", async () => {
     const press = mock(async (button: string): Promise<PressButtonResult> => ({
       success: true,

--- a/test/daemon/socketServerInputTypeText.test.ts
+++ b/test/daemon/socketServerInputTypeText.test.ts
@@ -878,6 +878,31 @@ describe("UnixSocketServer input/typeText", () => {
     expect(requestImeAction).not.toHaveBeenCalled();
   });
 
+  test("forwards an Android frame context to CtrlProxy text input", async () => {
+    const requestSetText = mock(async () => ({ success: true, totalTimeMs: 1 }));
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      requestSetText,
+      requestImeAction: mock(async () => ({ success: true, totalTimeMs: 1 })),
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    (server as unknown as { requireCurrentFrameContext: () => void }).requireCurrentFrameContext = () => {};
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/typeText", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      text: "context-bound",
+      frameContext: "frame-1",
+    });
+
+    expect(response.success).toBe(true);
+    expect(requestSetText).toHaveBeenCalledWith("context-bound", {
+      timeoutMs: 30_000,
+      frameContext: "frame-1",
+    });
+  });
+
   test("serializes concurrent typeText calls for the same device", async () => {
     let inFlight = 0;
     let maxInFlight = 0;

--- a/test/features/action/InputKey.test.ts
+++ b/test/features/action/InputKey.test.ts
@@ -77,6 +77,44 @@ describe("InputKey", () => {
     ]);
   });
 
+  test("does not issue an ADB keyevent when device validation rejects a frame context", async () => {
+    const fakeAdb = new FakeAdbExecutor();
+    const validator = {
+      validateFrameContext: async () => ({
+        success: false,
+        error: "Stale frame context for input/key; observe a fresh frame before retrying",
+      }),
+    };
+    const inputKey = new InputKey(androidDevice, createAdbFactory(fakeAdb), validator);
+
+    const result = await inputKey.press("enter", 1234, "epoch:2");
+
+    expect(result).toEqual({
+      success: false,
+      key: "enter",
+      keyCode: "KEYCODE_ENTER",
+      error: "Stale frame context for input/key; observe a fresh frame before retrying",
+    });
+    expect(fakeAdb.getExecutedCommands()).toEqual([]);
+  });
+
+  test("validates a supplied frame context before issuing an ADB keyevent", async () => {
+    const fakeAdb = new FakeAdbExecutor();
+    const calls: Array<[string, number | undefined]> = [];
+    const validator = {
+      validateFrameContext: async (frameContext: string, timeoutMs?: number) => {
+        calls.push([frameContext, timeoutMs]);
+        return { success: true };
+      },
+    };
+    const inputKey = new InputKey(androidDevice, createAdbFactory(fakeAdb), validator);
+
+    await inputKey.press("tab", 1234, "epoch:3");
+
+    expect(calls).toEqual([["epoch:3", 1234]]);
+    expect(fakeAdb.getExecutedCommands()).toEqual(["shell input keyevent KEYCODE_TAB"]);
+  });
+
   test("wraps an ADB keyevent failure in a stable error envelope", async () => {
     const fakeAdb = new FakeAdbExecutor();
     fakeAdb.setCommandError("KEYCODE_TAB", new Error("device offline"));

--- a/test/features/observe/android/ctrlProxyProtocol.test.ts
+++ b/test/features/observe/android/ctrlProxyProtocol.test.ts
@@ -58,6 +58,7 @@ const KOTLIN_SERIAL_NAMES = [
   "remove_preference",
   "clear_preferences",
   "request_global_action",
+  "validate_frame_context",
   "request_device_info",
   "set_recomposition_tracking",
   "set_accessibility_flags",
@@ -395,6 +396,14 @@ describe("ctrlProxyProtocol — builders serialize byte-identically", () => {
       expected: '{"type":"request_global_action","requestId":"ga-1","action":"back"}',
     },
     {
+      builder: "validateFrameContext",
+      name: "frame context",
+      actual: serializeCtrlProxyRequest(
+        ctrlProxyRequests.validateFrameContext({ requestId: "fc-1", frameContext: "epoch:5" })
+      ),
+      expected: '{"type":"validate_frame_context","requestId":"fc-1","frameContext":"epoch:5"}',
+    },
+    {
       builder: "setRecompositionTracking",
       name: "enabled flag",
       actual: serializeCtrlProxyRequest(ctrlProxyRequests.setRecompositionTracking({ requestId: "rt-1", enabled: true })),
@@ -475,12 +484,12 @@ describe("ctrlProxyProtocol — builders serialize byte-identically", () => {
   });
 
   // Completeness guard: every builder in the module must have at least one wire row above, and the
-  // total builder count is pinned. Ship builder #37 without a row and this fails — not a silently
+  // total builder count is pinned. Ship builder #38 without a row and this fails — not a silently
   // uncovered send site. `request_two_finger_swipe` has no builder here by design (it goes through
   // the shared sendCommand path, asserted in CtrlProxyGestures.test.ts), so it is not a builder key.
-  test("every ctrlProxyRequests builder has wire coverage and the count is pinned at 36", () => {
+  test("every ctrlProxyRequests builder has wire coverage and the count is pinned at 37", () => {
     const builderNames = Object.keys(ctrlProxyRequests);
-    expect(builderNames.length).toBe(36);
+    expect(builderNames.length).toBe(37);
     const covered = new Set(cases.map(row => row.builder));
     expect([...covered].sort()).toEqual([...builderNames].sort());
   });


### PR DESCRIPTION
## Summary

- reject context-bearing Android text, button, and key input after the device observes a new frame
- revalidate Android gestures at the dispatch boundary and refresh on `TYPE_WINDOWS_CHANGED`
- add a typed CtrlProxy frame-context validation request before ADB-only key events

## Root Cause

The daemon checked the most recently streamed context, but some Android input paths did not verify
that context against the accessibility service immediately before dispatch.

## Validation

- `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-4586 bun run turbo:validate`
- `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-4586 bun run typecheck`
- `android/gradlew :control-proxy:testDebugUnitTest --tests dev.jasonpearson.automobile.ctrlproxy.CtrlProxyMessageHandlerTest`

Closes [#4586](https://github.com/kaeawc/auto-mobile/issues/4586)
