### PR TITLE
fix(daemon): reject out-of-range input taps

### DIFF
--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -67,7 +67,7 @@ import { canonicalPixelsToPoints } from "./canonicalPixels";
 import { ActionableError, toActionableError } from "../models/ActionableError";
 import { getDeviceDataStreamServer } from "./deviceDataStreamSocketServer";
 import type { KeyValueType } from "../features/storage/storageTypes";
-import type { BootedDevice, ImeAction } from "../models";
+import type { BootedDevice, ImeAction, ScreenScaleMetadata } from "../models";
 import type { DeviceService } from "../features/observe/DeviceService";
 /** Must exceed the longest per-request MCP timeout (executePlan = 10 min), else long tool calls get killed mid-flight. */
 const DAEMON_RPC_SOCKET_IDLE_TIMEOUT_MS = MIN_EXECUTE_PLAN_MCP_TIMEOUT_MS + 5 * 60 * 1000;
@@ -955,13 +955,15 @@ export class UnixSocketServer {
     client: IOSCtrlProxyClient,
     deviceId: string,
     coordinates: number[],
-    probeTimeoutMs: number
+    probeTimeoutMs: number,
+    validateCanonicalCoordinates?: (geometry: ScreenScaleMetadata) => void
   ): Promise<number[]> {
-    const knownScale = client.getScreenScaleMetadata()?.nativeScale;
-    if (knownScale !== undefined) {
+    const knownMetadata = client.getScreenScaleMetadata();
+    if (knownMetadata) {
       // Metadata present: a runner upgrade drops any stale confirmed-legacy verdict for this device.
       this.confirmedLegacyScaleDevices.delete(deviceId);
-      return coordinates.map(coordinate => canonicalPixelsToPoints(coordinate, knownScale));
+      validateCanonicalCoordinates?.(knownMetadata);
+      return coordinates.map(coordinate => canonicalPixelsToPoints(coordinate, knownMetadata.nativeScale));
     }
     if (this.confirmedLegacyScaleDevices.has(deviceId)) {
       // A prior probe SUCCEEDED with no metadata: a confirmed legacy runner. Skip the round trip.
@@ -987,15 +989,37 @@ export class UnixSocketServer {
       );
     }
 
-    const probedScale = client.getScreenScaleMetadata()?.nativeScale;
-    if (probedScale === undefined) {
+    const probedMetadata = client.getScreenScaleMetadata();
+    if (!probedMetadata) {
       // Probe SUCCEEDED but the runner reported no scale metadata: a genuine pre-#4548 legacy
       // runner. The control client never received px bounds, so it sends points — pass through, and
       // cache the verdict so subsequent legacy taps skip the probe.
       this.confirmedLegacyScaleDevices.add(deviceId);
       return coordinates;
     }
-    return coordinates.map(coordinate => canonicalPixelsToPoints(coordinate, probedScale));
+    validateCanonicalCoordinates?.(probedMetadata);
+    return coordinates.map(coordinate => canonicalPixelsToPoints(coordinate, probedMetadata.nativeScale));
+  }
+
+  /**
+   * Canonical pixel bounds arrive with the complete runner metadata. A missing tuple is a legacy
+   * runner or an unseen hierarchy, where preserving the existing pass-through behavior is safer
+   * than guessing dimensions.
+   */
+  private requireCoordinatesWithinKnownScreenGeometry(
+    coordinates: readonly [number, number],
+    geometry: ScreenScaleMetadata | null
+  ): void {
+    if (!geometry) {
+      return;
+    }
+    const [x, y] = coordinates;
+    if (x < 0 || x > geometry.pixelWidth || y < 0 || y > geometry.pixelHeight) {
+      throw new Error(
+        `input/tap coordinates x=${x}, y=${y} are outside device canonical pixel bounds ` +
+        `x: 0..${geometry.pixelWidth}, y: 0..${geometry.pixelHeight}`
+      );
+    }
   }
 
   private async handleInputTap(
@@ -1026,6 +1050,7 @@ export class UnixSocketServer {
 
       if (args.platform === "android") {
         const client = AndroidCtrlProxyClient.getInstance(targetDevice, defaultAdbClientFactory);
+        this.requireCoordinatesWithinKnownScreenGeometry([args.x, args.y], client.getScreenScaleMetadata?.() ?? null);
         return args.frameContext === undefined
           ? await client.requestTapCoordinates(args.x, args.y, args.duration, remainingTimeoutMs)
           : await client.requestTapCoordinates(args.x, args.y, args.duration, remainingTimeoutMs, undefined, args.frameContext);
@@ -1035,7 +1060,8 @@ export class UnixSocketServer {
         iosClient,
         targetDevice.deviceId,
         [args.x, args.y],
-        remainingTimeoutMs
+        remainingTimeoutMs,
+        geometry => this.requireCoordinatesWithinKnownScreenGeometry([args.x, args.y], geometry)
       );
       const gestureTimeoutMs = this.remainingBudgetAfterProbe(queueEnterMs, totalTimeoutMs, request.method, "handleInputTap");
       return args.frameContext === undefined

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1014,10 +1014,10 @@ export class UnixSocketServer {
       return;
     }
     const [x, y] = coordinates;
-    if (x < 0 || x > geometry.pixelWidth || y < 0 || y > geometry.pixelHeight) {
+    if (x < 0 || x >= geometry.pixelWidth || y < 0 || y >= geometry.pixelHeight) {
       throw new Error(
         `input/tap coordinates x=${x}, y=${y} are outside device canonical pixel bounds ` +
-        `x: 0..${geometry.pixelWidth}, y: 0..${geometry.pixelHeight}`
+        `x: 0..${geometry.pixelWidth - 1}, y: 0..${geometry.pixelHeight - 1}`
       );
     }
   }

--- a/test/daemon/socketServerInputTap.test.ts
+++ b/test/daemon/socketServerInputTap.test.ts
@@ -103,15 +103,15 @@ describe("UnixSocketServer input/tap", () => {
       platform: "android",
       deviceId: "emulator-5554",
       x: 100,
-      y: 2341,
+      y: 2340,
     });
 
     expect(negative.success).toBe(false);
     expect(negative.error).toContain("x=-1, y=100");
-    expect(negative.error).toContain("x: 0..1080, y: 0..2340");
+    expect(negative.error).toContain("x: 0..1079, y: 0..2339");
     expect(oversized.success).toBe(false);
-    expect(oversized.error).toContain("x=100, y=2341");
-    expect(oversized.error).toContain("x: 0..1080, y: 0..2340");
+    expect(oversized.error).toContain("x=100, y=2340");
+    expect(oversized.error).toContain("x: 0..1079, y: 0..2339");
     expect(requestTapCoordinates).not.toHaveBeenCalled();
   });
 
@@ -272,7 +272,7 @@ describe("UnixSocketServer input/tap", () => {
   test("canonical-pixel iOS tap divides by nativeScale (exact) before dispatch to the points-based runner", async () => {
     // The control client renders a px frame (#4549) and sends the tap in PIXELS; the daemon divides
     // EXACTLY by nativeScale so the XCUITest runner receives (fractional) points and the tap lands
-    // at the same physical location. 1170/3 = 390, 2532/3 = 844.
+    // at the same physical location. 1169/3 = 389.666..., 2531/3 = 843.666....
     const requestTapCoordinates = mock(async () => ({ success: true }));
     IOSCtrlProxyClient.getInstance = mock(() => ({
       requestTapCoordinates,
@@ -285,16 +285,16 @@ describe("UnixSocketServer input/tap", () => {
     const response = await sendRequest(socketPath, "input/tap", {
       platform: "ios",
       deviceId: "ios-sim-1",
-      x: 1170,
-      y: 2532,
+      x: 1169,
+      y: 2531,
     });
 
     expect(response.success).toBe(true);
     // The echoed coordinates stay in the client's px space; only the runner dispatch is converted.
-    expect(response.result).toMatchObject({ coordinates: { x: 1170, y: 2532 } });
+    expect(response.result).toMatchObject({ coordinates: { x: 1169, y: 2531 } });
     const [x, y] = requestTapCoordinates.mock.calls[0];
-    expect(x).toBe(390);
-    expect(y).toBe(844);
+    expect(x).toBeCloseTo(1169 / 3, 10);
+    expect(y).toBeCloseTo(2531 / 3, 10);
   });
 
   test("iOS tap rejects coordinates outside bounds learned by the scale probe", async () => {
@@ -316,13 +316,13 @@ describe("UnixSocketServer input/tap", () => {
     const response = await sendRequest(socketPath, "input/tap", {
       platform: "ios",
       deviceId: "ios-sim-1",
-      x: 1171,
+      x: 1170,
       y: 100,
     });
 
     expect(response.success).toBe(false);
-    expect(response.error).toContain("x=1171, y=100");
-    expect(response.error).toContain("x: 0..1170, y: 0..2532");
+    expect(response.error).toContain("x=1170, y=100");
+    expect(response.error).toContain("x: 0..1169, y: 0..2531");
     expect(requestTapCoordinates).not.toHaveBeenCalled();
   });
 

--- a/test/daemon/socketServerInputTap.test.ts
+++ b/test/daemon/socketServerInputTap.test.ts
@@ -83,6 +83,38 @@ describe("UnixSocketServer input/tap", () => {
     expect(createMcpClient).not.toHaveBeenCalled();
   });
 
+  test("rejects Android tap coordinates outside known canonical pixel bounds", async () => {
+    const requestTapCoordinates = mock(async () => ({ success: true }));
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      requestTapCoordinates,
+      getScreenScaleMetadata: () => ({ nativeScale: 1, pixelWidth: 1080, pixelHeight: 2340 }),
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const negative = await sendRequest(socketPath, "input/tap", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      x: -1,
+      y: 100,
+    });
+    const oversized = await sendRequest(socketPath, "input/tap", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      x: 100,
+      y: 2341,
+    });
+
+    expect(negative.success).toBe(false);
+    expect(negative.error).toContain("x=-1, y=100");
+    expect(negative.error).toContain("x: 0..1080, y: 0..2340");
+    expect(oversized.success).toBe(false);
+    expect(oversized.error).toContain("x=100, y=2341");
+    expect(oversized.error).toContain("x: 0..1080, y: 0..2340");
+    expect(requestTapCoordinates).not.toHaveBeenCalled();
+  });
+
   test("LEGACY iOS tap: probe SUCCEEDS with no metadata -> pass through unchanged", async () => {
     // The probe returns a hierarchy (success) but it carries no scale metadata: a genuine pre-#4548
     // runner. The control client never got px bounds, so it sends points — pass through, no divide.
@@ -100,14 +132,14 @@ describe("UnixSocketServer input/tap", () => {
     const response = await sendRequest(socketPath, "input/tap", {
       platform: "ios",
       deviceId: "ios-sim-1",
-      x: 20,
-      y: 30,
+      x: -50,
+      y: 999999,
     });
 
     expect(response.success).toBe(true);
-    expect(response.result).toMatchObject({ coordinates: { x: 20, y: 30 } });
+    expect(response.result).toMatchObject({ coordinates: { x: -50, y: 999999 } });
     expect(fetchHierarchy).toHaveBeenCalledTimes(1); // it probed to learn the scale first
-    expect(requestTapCoordinates).toHaveBeenCalledWith(20, 30, undefined, 30_000);
+    expect(requestTapCoordinates).toHaveBeenCalledWith(-50, 999999, undefined, 30_000);
   });
 
   test("rejects an Android frameContext without a matching device observation", async () => {
@@ -240,7 +272,7 @@ describe("UnixSocketServer input/tap", () => {
   test("canonical-pixel iOS tap divides by nativeScale (exact) before dispatch to the points-based runner", async () => {
     // The control client renders a px frame (#4549) and sends the tap in PIXELS; the daemon divides
     // EXACTLY by nativeScale so the XCUITest runner receives (fractional) points and the tap lands
-    // at the same physical location. 1170/3 = 390, 2533/3 = 844.333...
+    // at the same physical location. 1170/3 = 390, 2532/3 = 844.
     const requestTapCoordinates = mock(async () => ({ success: true }));
     IOSCtrlProxyClient.getInstance = mock(() => ({
       requestTapCoordinates,
@@ -254,15 +286,44 @@ describe("UnixSocketServer input/tap", () => {
       platform: "ios",
       deviceId: "ios-sim-1",
       x: 1170,
-      y: 2533,
+      y: 2532,
     });
 
     expect(response.success).toBe(true);
     // The echoed coordinates stay in the client's px space; only the runner dispatch is converted.
-    expect(response.result).toMatchObject({ coordinates: { x: 1170, y: 2533 } });
+    expect(response.result).toMatchObject({ coordinates: { x: 1170, y: 2532 } });
     const [x, y] = requestTapCoordinates.mock.calls[0];
     expect(x).toBe(390);
-    expect(y).toBeCloseTo(2533 / 3, 10); // fractional point preserved, not quantized to 844
+    expect(y).toBe(844);
+  });
+
+  test("iOS tap rejects coordinates outside bounds learned by the scale probe", async () => {
+    const requestTapCoordinates = mock(async () => ({ success: true }));
+    let scale: { nativeScale: number; pixelWidth: number; pixelHeight: number } | null = null;
+    const fetchHierarchy = mock(async () => {
+      scale = { nativeScale: 3, pixelWidth: 1170, pixelHeight: 2532 };
+      return { hierarchy: {} };
+    });
+    IOSCtrlProxyClient.getInstance = mock(() => ({
+      requestTapCoordinates,
+      getScreenScaleMetadata: () => scale,
+      requestHierarchySyncWithoutObservationStreamPush: fetchHierarchy,
+    })) as unknown as typeof IOSCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([iosDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/tap", {
+      platform: "ios",
+      deviceId: "ios-sim-1",
+      x: 1171,
+      y: 100,
+    });
+
+    expect(response.success).toBe(false);
+    expect(response.error).toContain("x=1171, y=100");
+    expect(response.error).toContain("x: 0..1170, y: 0..2532");
+    expect(requestTapCoordinates).not.toHaveBeenCalled();
   });
 
   test("iOS tap before ANY hierarchy fetches one first, then divides by the learned nativeScale", async () => {


### PR DESCRIPTION
## Summary

- Reject `input/tap` coordinates outside known canonical pixel bounds on Android and iOS.
- Include the received coordinates and screen bounds in the rejection.
- Preserve inclusive screen-edge taps and existing legacy/unknown-geometry pass-through behavior.

## Root Cause

`input/tap` checked that coordinates were finite but never compared them with the runner-reported canonical pixel dimensions. A scale-conversion error could therefore dispatch an off-screen tap and report success.

Closes [#4593](https://github.com/kaeawc/auto-mobile/issues/4593).

## Validation

- `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-issue-4593 bun test test/daemon/socketServerInputTap.test.ts`
- `bun run typecheck` (no new errors; existing 206-error baseline)
- `bun run turbo:validate` (11,836 pass; 5 unrelated failures in `test/scripts/xcodegenDriftCheck.test.ts`)

The failing XcodeGen fixture omits `ios/control-proxy/project.yml`, which current `main`'s drift script requires. This PR does not modify that fixture or iOS project generation.
