### PR TITLE
fix(navigation): report target device app in graph

### DIFF
--- a/src/server/navigationTools.ts
+++ b/src/server/navigationTools.ts
@@ -5,6 +5,7 @@ import { NavigateTo, NavigateToOptions } from "../features/navigation/NavigateTo
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
 import { DefaultPathOptimizer } from "../features/navigation/DefaultPathOptimizer";
 import { Explore, ExploreOptions } from "../features/navigation/Explore";
+import { RealObserveScreen } from "../features/observe/ObserveScreen";
 import { createJSONToolResponse } from "../utils/toolUtils";
 import { Platform } from "../models";
 import { addDeviceTargetingToSchema, platformSchema } from "./toolSchemaHelpers";
@@ -107,9 +108,11 @@ export function registerNavigationTools() {
       const manager = getNavigationManager(args.sessionUuid);
       const stats = await manager.getStats();
       const graph = await manager.exportGraph();
+      const observation = RealObserveScreen.getRecentCachedResultForDevice(device.deviceId);
+      const appId = observation?.viewHierarchy?.packageName ?? observation?.activeWindow?.appId;
 
       return createJSONToolResponse({
-        message: `Navigation graph for app: ${graph.appId || "none"}`,
+        message: `Navigation graph for app: ${appId || "none"}`,
         currentScreen: stats.currentScreen,
         nodeCount: stats.nodeCount,
         edgeCount: stats.edgeCount,

--- a/test/server/navigationTools.test.ts
+++ b/test/server/navigationTools.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { Explore } from "../../src/features/navigation/Explore";
 import { NavigateTo } from "../../src/features/navigation/NavigateTo";
 import { NavigationGraphManager } from "../../src/features/navigation/NavigationGraphManager";
+import { RealObserveScreen } from "../../src/features/observe/ObserveScreen";
 import { registerNavigationTools } from "../../src/server/navigationTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import { setDebugModeEnabled } from "../../src/utils/debug";
@@ -84,6 +85,54 @@ describe("navigation tool session graph selection", () => {
       sessionManagerSpy.mockRestore();
       navigateExecuteSpy.mockRestore();
       exploreExecuteSpy.mockRestore();
+    }
+  });
+
+  test("reports the target iOS device's observed app instead of a stale graph app", async () => {
+    const staleGraph = new FakeNavigationGraphManager();
+    staleGraph.setCurrentAppId("com.google.android.settings.intelligence");
+    const managerSpy = spyOn(NavigationGraphManager, "getInstance").mockReturnValue(
+      staleGraph as unknown as NavigationGraphManager
+    );
+    const observationSpy = spyOn(RealObserveScreen, "getRecentCachedResultForDevice").mockReturnValue({
+      viewHierarchy: { packageName: "com.apple.Preferences" }
+    } as never);
+
+    try {
+      const handler = (ToolRegistry as unknown as {
+        tools: Map<string, { deviceAwareHandler?: (device: BootedDevice, args: any) => Promise<any> }>;
+      }).tools.get("getNavigationGraph")?.deviceAwareHandler;
+
+      const response = await handler!(device, { platform: "ios" });
+
+      expect(JSON.parse(response.content[0].text).message).toBe(
+        "Navigation graph for app: com.apple.Preferences"
+      );
+    } finally {
+      observationSpy.mockRestore();
+      managerSpy.mockRestore();
+    }
+  });
+
+  test("reports none when the target device has no cached observation", async () => {
+    const staleGraph = new FakeNavigationGraphManager();
+    staleGraph.setCurrentAppId("com.google.android.settings.intelligence");
+    const managerSpy = spyOn(NavigationGraphManager, "getInstance").mockReturnValue(
+      staleGraph as unknown as NavigationGraphManager
+    );
+    const observationSpy = spyOn(RealObserveScreen, "getRecentCachedResultForDevice").mockReturnValue(undefined);
+
+    try {
+      const handler = (ToolRegistry as unknown as {
+        tools: Map<string, { deviceAwareHandler?: (device: BootedDevice, args: any) => Promise<any> }>;
+      }).tools.get("getNavigationGraph")?.deviceAwareHandler;
+
+      const response = await handler!(device, { platform: "ios" });
+
+      expect(JSON.parse(response.content[0].text).message).toBe("Navigation graph for app: none");
+    } finally {
+      observationSpy.mockRestore();
+      managerSpy.mockRestore();
     }
   });
 });


### PR DESCRIPTION
## Summary

`getNavigationGraph` now formats its app name from the targeted device's latest cached observation. If that device has not yet been observed, it reports `none` instead of leaking the navigation manager's stale app ID from another platform.

## Linked Issue

Closes https://github.com/kaeawc/auto-mobile/issues/4592

## Bug / Regression Context

- **Prior attempts:** iOS navigation graph parity work landed in [#4468](https://github.com/kaeawc/auto-mobile/pull/4468).
- **Observed symptom:** the first iOS graph request after Android activity reported `com.google.android.settings.intelligence` while the iOS target was `com.apple.Preferences`.
- **Repro steps / conditions:** target an iOS simulator before it has an observation cached, after the daemon has served an Android device.

## Validation

- [x] Focused `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-4592 bun test test/server/navigationTools.test.ts`
- [x] `bun run typecheck` reported no new errors; it retained one existing baseline warning in `src/features/navigation/NavigateTo.ts`.
- [x] `bun run build`
- [x] `bun run lint`
- [x] `git diff --check`
- [ ] `bun test --bail` and `bun run turbo:validate` are blocked by five unchanged `test/scripts/xcodegenDriftCheck.test.ts` fixture failures. The test source matches `origin/main`; its temp fixture omits `ios/control-proxy/project.yml`.
- [x] The regression tests use existing navigation and observe-cache seams; no dependency or generic helper was added.
- [x] Branch starts from the latest fetched `main`.

## Device Verification

- [ ] Not run. The behavior is covered by deterministic handler tests using the targeted device observation cache.
