### PR TITLE
fix(android): refresh eventOnly focus hierarchy

### DIFF
--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -623,7 +623,13 @@ export class InputText extends BaseVisualChange {
       return viewHierarchy;
     }
 
-    const refreshedObserveResult = await this.observeScreen.execute({ skipWaitForFresh: false });
+    const minTimestamp = typeof this.adb.getDeviceTimestampMs === "function"
+      ? await this.adb.getDeviceTimestampMs()
+      : this.timer.now();
+    const refreshedObserveResult = await this.observeScreen.execute({
+      skipWaitForFresh: false,
+      minTimestamp
+    });
     const refreshedViewHierarchy = refreshedObserveResult.viewHierarchy;
     return refreshedViewHierarchy && hasFocusedTextInput(refreshedViewHierarchy)
       ? refreshedViewHierarchy

--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -1,5 +1,12 @@
 import { BaseVisualChange } from "./BaseVisualChange";
-import { BootedDevice, ImeAction, KeyboardResult, ObserveResult, SendTextResult } from "../../models";
+import {
+  BootedDevice,
+  ImeAction,
+  KeyboardResult,
+  ObserveResult,
+  SendTextResult,
+  ViewHierarchyResult
+} from "../../models";
 import { logger } from "../../utils/logger";
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { AndroidCtrlProxyClient } from "../observe/android";
@@ -568,7 +575,8 @@ export class InputText extends BaseVisualChange {
       };
     }
 
-    if (!hasFocusedTextInput(viewHierarchy)) {
+    const focusedViewHierarchy = await this.refreshFocusedTextInputHierarchy(viewHierarchy);
+    if (!focusedViewHierarchy) {
       return {
         success: false,
         text,
@@ -577,7 +585,7 @@ export class InputText extends BaseVisualChange {
       };
     }
 
-    await clearTextWithKeyEvents(this.adb, getFocusedTextLength(viewHierarchy));
+    await clearTextWithKeyEvents(this.adb, getFocusedTextLength(focusedViewHierarchy));
     for (const keyEventPlan of keyEventPlans) {
       await this.executeKeyEventPlan(keyEventPlan);
     }
@@ -606,6 +614,20 @@ export class InputText extends BaseVisualChange {
       imeAction,
       method: "eventOnly"
     };
+  }
+
+  private async refreshFocusedTextInputHierarchy(
+    viewHierarchy: ViewHierarchyResult
+  ): Promise<ViewHierarchyResult | undefined> {
+    if (hasFocusedTextInput(viewHierarchy)) {
+      return viewHierarchy;
+    }
+
+    const refreshedObserveResult = await this.observeScreen.execute({ skipWaitForFresh: false });
+    const refreshedViewHierarchy = refreshedObserveResult.viewHierarchy;
+    return refreshedViewHierarchy && hasFocusedTextInput(refreshedViewHierarchy)
+      ? refreshedViewHierarchy
+      : undefined;
   }
 
   /**

--- a/test/features/action/InputText.test.ts
+++ b/test/features/action/InputText.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { InputText } from "../../../src/features/action/InputText";
 import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
+import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { FakeObserveScreen } from "../../fakes/FakeObserveScreen";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import type { InputTextMode } from "../../../src/features/action/InputText";
@@ -487,8 +488,9 @@ describe("InputText", () => {
   });
 
   test("eventOnly rejects after a refreshed hierarchy still lacks a focused editable field", async () => {
-    const factory = new FakeAdbClientFactory();
-    const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+    const adb = new FakeAdbExecutor();
+    adb.setDeviceTimestampMs(42);
+    const inputText = new InputText(androidDevice, adb);
     const observeScreen = new FakeObserveScreen();
     const unfocused = {
       viewHierarchy: {
@@ -514,7 +516,7 @@ describe("InputText", () => {
     expect(result.error).toBe("eventOnly requires a focused editable field");
     expect(observeScreen.getExecuteCallCount()).toBe(1);
     expect(observeScreen.getExecuteOptions()[0]?.skipWaitForFresh).toBe(false);
-    expect(inputCommands(factory)).toEqual([]);
+    expect(observeScreen.getExecuteOptions()[0]?.minTimestamp).toBe(42);
   });
 
   test("eventOnly delegates keyboard dismissal to the keyboard closer", async () => {

--- a/test/features/action/InputText.test.ts
+++ b/test/features/action/InputText.test.ts
@@ -473,6 +473,7 @@ describe("InputText", () => {
     expect(result.method).toBe("eventOnly");
     expect(observeScreen.getGetMostRecentCachedObserveResultCallCount()).toBe(1);
     expect(observeScreen.getExecuteCallCount()).toBe(2);
+    expect(observeScreen.getExecuteOptions()[0]?.skipWaitForFresh).toBe(false);
     expect(inputCommands(factory)).toEqual([
       "shell input keyevent KEYCODE_MOVE_END",
       "shell input keyevent KEYCODE_DEL",

--- a/test/features/action/InputText.test.ts
+++ b/test/features/action/InputText.test.ts
@@ -513,6 +513,7 @@ describe("InputText", () => {
     expect(result.success).toBe(false);
     expect(result.error).toBe("eventOnly requires a focused editable field");
     expect(observeScreen.getExecuteCallCount()).toBe(1);
+    expect(observeScreen.getExecuteOptions()[0]?.skipWaitForFresh).toBe(false);
     expect(inputCommands(factory)).toEqual([]);
   });
 

--- a/test/features/action/InputText.test.ts
+++ b/test/features/action/InputText.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { InputText } from "../../../src/features/action/InputText";
 import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
+import { FakeObserveScreen } from "../../fakes/FakeObserveScreen";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import type { InputTextMode } from "../../../src/features/action/InputText";
 import type { BootedDevice, ExecResult, ObserveResult } from "../../../src/models";
@@ -428,18 +429,89 @@ describe("InputText", () => {
   ])("eventOnly rejects %s before sending input events", async (_description, properties) => {
     const factory = new FakeAdbClientFactory();
     const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+    const observeResult = observeResultWithFocusedText("existing", properties);
+    const observeScreen = new FakeObserveScreen();
+    observeScreen.setObserveResult(observeResult);
+    inputText.observeScreen = observeScreen;
 
     const result = await testInputText(inputText).executeAndroidTextInput(
       "next",
       undefined,
       false,
       "eventOnly",
-      observeResultWithFocusedText("existing", properties)
+      observeResult
     );
 
     expect(result.success).toBe(false);
     expect(result.method).toBe("eventOnly");
     expect(result.error).toBe("eventOnly requires a focused editable field");
+    expect(observeScreen.getExecuteCallCount()).toBe(1);
+    expect(inputCommands(factory)).toEqual([]);
+  });
+
+  test("eventOnly refreshes a stale cached hierarchy before rejecting the focused-field precondition", async () => {
+    const factory = new FakeAdbClientFactory();
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+    const observeScreen = new FakeObserveScreen();
+    observeScreen.setObserveSequence([
+      {
+        viewHierarchy: {
+          hierarchy: {
+            node: {
+              class: "android.view.inputmethod.SoftInputWindow"
+            }
+          }
+        }
+      } as ObserveResult,
+      observeResultWithFocusedText("old")
+    ]);
+    inputText.observeScreen = observeScreen;
+
+    const result = await inputText.execute("next", undefined, false, "eventOnly");
+
+    expect(result.success).toBe(true);
+    expect(result.method).toBe("eventOnly");
+    expect(observeScreen.getGetMostRecentCachedObserveResultCallCount()).toBe(1);
+    expect(observeScreen.getExecuteCallCount()).toBe(2);
+    expect(inputCommands(factory)).toEqual([
+      "shell input keyevent KEYCODE_MOVE_END",
+      "shell input keyevent KEYCODE_DEL",
+      "shell input keyevent KEYCODE_DEL",
+      "shell input keyevent KEYCODE_DEL",
+      "shell input keyevent KEYCODE_N",
+      "shell input keyevent KEYCODE_E",
+      "shell input keyevent KEYCODE_X",
+      "shell input keyevent KEYCODE_T"
+    ]);
+  });
+
+  test("eventOnly rejects after a refreshed hierarchy still lacks a focused editable field", async () => {
+    const factory = new FakeAdbClientFactory();
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+    const observeScreen = new FakeObserveScreen();
+    const unfocused = {
+      viewHierarchy: {
+        hierarchy: {
+          node: {
+            class: "android.view.inputmethod.SoftInputWindow"
+          }
+        }
+      }
+    } as ObserveResult;
+    observeScreen.setObserveSequence([unfocused, unfocused]);
+    inputText.observeScreen = observeScreen;
+
+    const result = await testInputText(inputText).executeAndroidTextInput(
+      "next",
+      undefined,
+      false,
+      "eventOnly",
+      unfocused
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("eventOnly requires a focused editable field");
+    expect(observeScreen.getExecuteCallCount()).toBe(1);
     expect(inputCommands(factory)).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary

Refresh the Android `eventOnly` focused-field hierarchy once when the cached hierarchy is stale before rejecting the request. This preserves the existing error after a refreshed hierarchy also lacks a focused editable field.

## Linked Issue

Closes [#4594](https://github.com/kaeawc/auto-mobile/issues/4594)

## Bug / Regression Context

- **Prior attempts:** None.
- **Observed symptom:** `inputText --mode eventOnly` intermittently returned `eventOnly requires a focused editable field` immediately after `tapOn` focused a field.
- **Repro steps / conditions:** The cached hierarchy contains the IME `SoftInputWindow` while a fresh hierarchy contains the focused host-app `EditText`.

## Validation

- [x] `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-4594 bun test test/features/action/InputText.test.ts` passes: 37 tests.
- [x] `bun run lint` passes.
- [x] `bun run typecheck` reports no new errors against the 206-error baseline.
- [x] Unit coverage uses the existing `FakeObserveScreen`; the new cases run in under 10 ms.
- [x] No new dependency or generic helper was added.
- [x] Branch was created from the latest fetched `main`.
- [ ] `bun run turbo:validate` is blocked by five pre-existing failures in `test/scripts/xcodegenDriftCheck.test.ts`: its temporary CtrlProxy fixture omits `ios/control-proxy/project.yml`, which the unchanged drift-check script now requires. The run otherwise passed lint, build, all boundary checks, and 11,836 tests.
