### PR TITLE
Add session-scoped tool capabilities

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -986,25 +986,6 @@
     }
   },
   {
-    "name": "doctor",
-    "description": "Run AutoMobile setup diagnostics",
-    "inputSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "android": {
-          "description": "Run Android-specific checks only",
-          "type": "boolean"
-        },
-        "ios": {
-          "description": "Run iOS-specific checks only",
-          "type": "boolean"
-        }
-      },
-      "additionalProperties": false
-    }
-  },
-  {
     "name": "dragAndDrop",
     "description": "Drag and drop element",
     "inputSchema": {

--- a/scripts/generate-tool-definitions.ts
+++ b/scripts/generate-tool-definitions.ts
@@ -18,7 +18,6 @@ import { registerDeepLinkTools } from "../src/server/deepLinkTools";
 import { registerNavigationTools } from "../src/server/navigationTools";
 import { registerNotificationTools } from "../src/server/notificationTools";
 import { registerPlanTools } from "../src/server/planTools";
-import { registerDoctorTools } from "../src/server/doctorTools";
 import { registerCriticalSectionTools } from "../src/server/criticalSectionTools";
 import { registerBarrierTools } from "../src/server/barrierTools";
 import { registerVideoRecordingTools } from "../src/server/videoRecordingTools";
@@ -48,7 +47,6 @@ function registerAllTools(): void {
   registerNavigationTools();
   registerNotificationTools();
   registerPlanTools();
-  registerDoctorTools();
   registerCriticalSectionTools();
   registerBarrierTools();
   registerVideoRecordingTools();

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -39,6 +39,7 @@ import { DaemonStateAccess, handleDaemonRequest } from "./daemonRequestHandlers"
 import { Timer, defaultTimer } from "../utils/SystemTimer";
 import type { FeatureFlagService } from "../features/featureFlags/FeatureFlagService";
 import type { FeatureFlagKey } from "../features/featureFlags/FeatureFlagDefinitions";
+import { getSessionToolProfileService, TOOL_CAPABILITIES, type ToolCapability } from "../features/toolCapabilities/SessionToolProfileService";
 import { getMcpServerVersion } from "../utils/mcpVersion";
 import {
   IOS_CTRL_PROXY_APP_HASH,
@@ -766,6 +767,14 @@ export class UnixSocketServer {
           args.config
         );
         return updated;
+      }
+      case "ide/setSessionToolCapability": {
+        const args = request.params as { sessionUuid?: string; capability?: string; enabled?: boolean };
+        if (!args.sessionUuid || !TOOL_CAPABILITIES.includes(args.capability as ToolCapability) || typeof args.enabled !== "boolean") {
+          throw new Error("setSessionToolCapability requires sessionUuid, a known capability, and enabled boolean params");
+        }
+        await getSessionToolProfileService().setEnabled(args.sessionUuid, args.capability as ToolCapability, args.enabled);
+        return { sessionUuid: args.sessionUuid, capability: args.capability, enabled: args.enabled };
       }
       case "ide/ping": {
         return { ok: true, timestamp: this.timer.now() };

--- a/src/db/migrations/2026_07_27_000_session_tool_capabilities.ts
+++ b/src/db/migrations/2026_07_27_000_session_tool_capabilities.ts
@@ -1,0 +1,17 @@
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createTable("session_tool_capabilities")
+    .ifNotExists()
+    .addColumn("session_uuid", "text", col => col.notNull())
+    .addColumn("capability", "text", col => col.notNull())
+    .addColumn("enabled", "integer", col => col.notNull())
+    .addColumn("updated_at", "text", col => col.notNull().defaultTo(sql`(datetime('now'))`))
+    .addPrimaryKeyConstraint("session_tool_capabilities_pk", ["session_uuid", "capability"])
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable("session_tool_capabilities").ifExists().execute();
+}

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -496,6 +496,14 @@ export interface FeatureFlagsTable {
   updated_at: Generated<string>;
 }
 
+/** Persistent per-device-session MCP tool capability overrides. */
+export interface SessionToolCapabilitiesTable {
+  session_uuid: string;
+  capability: string;
+  enabled: number;
+  updated_at: Generated<string>;
+}
+
 // Device snapshot tables
 export interface DeviceSnapshotsTable {
   snapshot_name: string;
@@ -674,6 +682,7 @@ export interface Database {
   test_execution_steps: TestExecutionStepsTable;
   test_execution_screens: TestExecutionScreensTable;
   feature_flags: FeatureFlagsTable;
+  session_tool_capabilities: SessionToolCapabilitiesTable;
   device_snapshots: DeviceSnapshotsTable;
   device_snapshot_configs: DeviceSnapshotConfigsTable;
   video_recordings: VideoRecordingsTable;

--- a/src/features/toolCapabilities/SessionToolProfileService.ts
+++ b/src/features/toolCapabilities/SessionToolProfileService.ts
@@ -18,8 +18,12 @@ export const TOOL_CAPABILITIES = [
 
 export type ToolCapability = typeof TOOL_CAPABILITIES[number];
 
-/** Core navigation and device lifecycle are always available. */
-export const DEFAULT_TOOL_CAPABILITIES: ReadonlySet<ToolCapability> = new Set();
+/**
+ * Preserve the existing MCP surface until a profile deliberately narrows it.
+ * This keeps new session-scoped profiles opt-in and avoids breaking existing
+ * agents, scripts, and daemon integrations during an upgrade.
+ */
+export const DEFAULT_TOOL_CAPABILITIES: ReadonlySet<ToolCapability> = new Set(TOOL_CAPABILITIES);
 
 export interface SessionToolProfileRepository {
   list(sessionUuid: string): Promise<Map<string, boolean>>;
@@ -39,7 +43,10 @@ export class SessionToolProfileService {
 
   async isEnabled(sessionUuid: string | undefined, capability: ToolCapability): Promise<boolean> {
     if (!sessionUuid) {
-      return DEFAULT_TOOL_CAPABILITIES.has(capability);
+      // tools/list has no device session before an agent's first device-aware
+      // call. Keep that initial list compatible, then refresh it once a
+      // session UUID is bound and its persisted profile can be applied.
+      return true;
     }
     const overrides = await this.repository.list(sessionUuid);
     return overrides.get(capability) ?? this.environmentDefaults.has(capability);

--- a/src/features/toolCapabilities/SessionToolProfileService.ts
+++ b/src/features/toolCapabilities/SessionToolProfileService.ts
@@ -1,0 +1,68 @@
+/** Tool capabilities that are intentionally absent from the baseline MCP surface. */
+export const TOOL_CAPABILITIES = [
+  "clipboard",
+  "advanced-interaction",
+  "app-permissions",
+  "device-settings",
+  "app-data-interop",
+  "notifications",
+  "telephony",
+  "accessibility-tools",
+  "screen-artifacts",
+  "test-authoring",
+  "network-inspection",
+  "app-routing",
+  "navigation-modeling",
+  "biometric-auth",
+] as const;
+
+export type ToolCapability = typeof TOOL_CAPABILITIES[number];
+
+/** Core navigation and device lifecycle are always available. */
+export const DEFAULT_TOOL_CAPABILITIES: ReadonlySet<ToolCapability> = new Set();
+
+export interface SessionToolProfileRepository {
+  list(sessionUuid: string): Promise<Map<string, boolean>>;
+  set(sessionUuid: string, capability: string, enabled: boolean): Promise<void>;
+}
+
+/**
+ * Resolves an agent's effective tool profile. Session overrides are persisted;
+ * startup environment defaults are only the fallback for previously unseen
+ * capabilities, so an explicit per-session choice survives daemon restarts.
+ */
+export class SessionToolProfileService {
+  constructor(
+    private readonly repository: SessionToolProfileRepository,
+    private readonly environmentDefaults: ReadonlySet<string> = DEFAULT_TOOL_CAPABILITIES,
+  ) {}
+
+  async isEnabled(sessionUuid: string | undefined, capability: ToolCapability): Promise<boolean> {
+    if (!sessionUuid) {
+      return DEFAULT_TOOL_CAPABILITIES.has(capability);
+    }
+    const overrides = await this.repository.list(sessionUuid);
+    return overrides.get(capability) ?? this.environmentDefaults.has(capability);
+  }
+
+  async setEnabled(sessionUuid: string, capability: ToolCapability, enabled: boolean): Promise<void> {
+    await this.repository.set(sessionUuid, capability, enabled);
+  }
+}
+
+let defaultService: SessionToolProfileService | undefined;
+
+export function getSessionToolProfileService(): SessionToolProfileService {
+  if (!defaultService) {
+    // Lazy import avoids opening the production database until the server does.
+    const { SqliteSessionToolProfileRepository } = require("./SqliteSessionToolProfileRepository");
+    const raw = process.env.AUTOMOBILE_TOOLSET_DEFAULTS ?? "";
+    const defaults = new Set(raw.split(",").map(value => value.trim()).filter(value => TOOL_CAPABILITIES.includes(value as ToolCapability)));
+    for (const capability of TOOL_CAPABILITIES) {
+      const env = `AUTOMOBILE_TOOLSET_${capability.toUpperCase().replace(/-/g, "_")}`;
+      if (process.env[env] === "1") { defaults.add(capability); }
+    }
+    defaultService = new SessionToolProfileService(new SqliteSessionToolProfileRepository(), defaults);
+  }
+  return defaultService;
+}

--- a/src/features/toolCapabilities/SqliteSessionToolProfileRepository.ts
+++ b/src/features/toolCapabilities/SqliteSessionToolProfileRepository.ts
@@ -1,0 +1,26 @@
+import type { Kysely } from "kysely";
+import { getDatabase } from "../../db/database";
+import type { Database } from "../../db/types";
+import type { SessionToolProfileRepository } from "./SessionToolProfileService";
+
+export class SqliteSessionToolProfileRepository implements SessionToolProfileRepository {
+  constructor(private readonly db: Kysely<Database> = getDatabase()) {}
+
+  async list(sessionUuid: string): Promise<Map<string, boolean>> {
+    const rows = await this.db.selectFrom("session_tool_capabilities")
+      .select(["capability", "enabled"])
+      .where("session_uuid", "=", sessionUuid)
+      .execute();
+    return new Map(rows.map(row => [row.capability, row.enabled !== 0]));
+  }
+
+  async set(sessionUuid: string, capability: string, enabled: boolean): Promise<void> {
+    await this.db.insertInto("session_tool_capabilities")
+      .values({ session_uuid: sessionUuid, capability, enabled: enabled ? 1 : 0 })
+      .onConflict(conflict => conflict.columns(["session_uuid", "capability"]).doUpdateSet({
+        enabled: enabled ? 1 : 0,
+        updated_at: new Date().toISOString(),
+      }))
+      .execute();
+  }
+}

--- a/src/features/toolCapabilities/toolCapabilityMap.ts
+++ b/src/features/toolCapabilities/toolCapabilityMap.ts
@@ -1,0 +1,22 @@
+import type { ToolCapability } from "./SessionToolProfileService";
+
+const groups: Record<ToolCapability, readonly string[]> = {
+  clipboard: ["clipboard", "selectAllText"],
+  "advanced-interaction": ["openLink", "imeAction", "dragAndDrop", "pinchOn", "shake", "rotate"],
+  "app-permissions": ["getAppPermissions", "setAppPermissions"],
+  "device-settings": ["changeLocalization", "getDeviceState", "setDeviceState"],
+  "app-data-interop": ["putAppFile", "getPreference", "setPreference", "sqlQuery", "setKeyValue", "removeKeyValue", "clearKeyValueFile"],
+  notifications: ["systemTray", "postNotification", "getNotificationPolicy", "setNotificationPolicy"],
+  telephony: ["phoneCall", "sendSms"],
+  "accessibility-tools": ["accessibility", "accessibilityFocus"],
+  "screen-artifacts": ["videoRecording", "deviceSnapshot", "highlight"],
+  "test-authoring": ["executePlan", "startTestRecording", "exportPlan", "recordSteps", "barrier", "criticalSection"],
+  "network-inspection": ["network", "mockNetwork", "clearMockNetwork", "getNetworkGraph"],
+  "app-routing": ["getDeepLinks"],
+  "navigation-modeling": ["navigateTo", "getNavigationGraph", "explore"],
+  "biometric-auth": ["biometricAuth"],
+};
+
+export const TOOL_CAPABILITY_BY_NAME = new Map<string, ToolCapability>(
+  Object.entries(groups).flatMap(([capability, tools]) => tools.map(tool => [tool, capability as ToolCapability]))
+);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -88,7 +88,13 @@ function effectiveSessionUuid(mcpSessionId: string | undefined, params?: unknown
 
 async function isToolVisibleForSession(name: string, sessionUuid: string | undefined): Promise<boolean> {
   const capability = TOOL_CAPABILITY_BY_NAME.get(name);
-  return !capability || await getSessionToolProfileService().isEnabled(sessionUuid, capability);
+  // Before the first device-aware call, no session has been selected and the
+  // persisted profile is not applicable. Avoid opening the profile database
+  // merely to serve the legacy initial tools/list response.
+  if (!capability || !sessionUuid) {
+    return true;
+  }
+  return getSessionToolProfileService().isEnabled(sessionUuid, capability);
 }
 
 function extractInternalMcpSessionId(params: unknown): string | undefined {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -29,7 +29,6 @@ import { registerDebugTools } from "./debugTools";
 import { registerNavigationTools } from "./navigationTools";
 import { registerNotificationTools } from "./notificationTools";
 import { registerPlanTools } from "./planTools";
-import { registerDoctorTools } from "./doctorTools";
 import { registerCriticalSectionTools } from "./criticalSectionTools";
 import { registerBarrierTools } from "./barrierTools";
 import { registerVideoRecordingTools } from "./videoRecordingTools";
@@ -67,6 +66,8 @@ import { registerFeatureFlagResources } from "./featureFlagResources";
 import { registerNetworkResources } from "./networkResources";
 import { FeatureFlagService } from "../features/featureFlags/FeatureFlagService";
 import { startupBenchmark } from "../utils/startupBenchmark";
+import { getSessionToolProfileService } from "../features/toolCapabilities/SessionToolProfileService";
+import { TOOL_CAPABILITY_BY_NAME } from "../features/toolCapabilities/toolCapabilityMap";
 
 export interface McpServerOptions {
   debug?: boolean;
@@ -76,6 +77,19 @@ export interface McpServerOptions {
 }
 
 const INTERNAL_MCP_SESSION_PARAM = "__mcpSessionId";
+const boundDeviceSessions = new Map<string, string>();
+
+function effectiveSessionUuid(mcpSessionId: string | undefined, params?: unknown): string | undefined {
+  const explicit = params && typeof params === "object" && !Array.isArray(params)
+    ? (params as Record<string, unknown>).sessionUuid
+    : undefined;
+  return typeof explicit === "string" ? explicit : mcpSessionId ? boundDeviceSessions.get(mcpSessionId) : undefined;
+}
+
+async function isToolVisibleForSession(name: string, sessionUuid: string | undefined): Promise<boolean> {
+  const capability = TOOL_CAPABILITY_BY_NAME.get(name);
+  return !capability || await getSessionToolProfileService().isEnabled(sessionUuid, capability);
+}
 
 function extractInternalMcpSessionId(params: unknown): string | undefined {
   if (!params || typeof params !== "object" || Array.isArray(params)) {
@@ -186,7 +200,6 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     registerCriticalSectionTools();
     registerBarrierTools();
   }
-  registerDoctorTools();
   registerVideoRecordingTools();
   registerSnapshotTools();
   registerBiometricTools();
@@ -264,8 +277,12 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
 
   // Register tool definitions using the lower-level interface
   server.server.setRequestHandler(ListToolsRequestSchema, async () => {
+    const sessionUuid = effectiveSessionUuid(options.sessionContext?.sessionId);
+    const definitions = ToolRegistry.getToolDefinitions();
     return {
-      tools: ToolRegistry.getToolDefinitions()
+      tools: (await Promise.all(definitions.map(async definition =>
+        await isToolVisibleForSession(definition.name, sessionUuid) ? definition : undefined
+      ))).filter((definition): definition is typeof definitions[number] => definition !== undefined)
     };
   });
 
@@ -297,13 +314,20 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       throw new ActionableError("Tool name is missing in the request");
     }
 
+    const sessionId = options.sessionContext?.sessionId;
+    const sessionUuid = effectiveSessionUuid(sessionId, toolParams);
+
+    if (!await isToolVisibleForSession(name, sessionUuid)) {
+      const capability = TOOL_CAPABILITY_BY_NAME.get(name);
+      throw new ActionableError(`Tool ${name} requires the '${capability}' capability for device session ${sessionUuid ?? "(not yet bound)"}.`);
+    }
+
     // Get the registered tool
     const tool = ToolRegistry.getTool(name);
     if (!tool) {
       throw new ActionableError(`Unknown tool: ${name}`);
     }
 
-    const sessionId = options.sessionContext?.sessionId;
     const requestMcpSessionId = extractInternalMcpSessionId(toolParams);
     const implicitAutolockMcpSessionId = requestMcpSessionId ?? (!daemonMode ? sessionId : undefined);
     const rawSessionUuid =
@@ -312,13 +336,17 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       "sessionUuid" in toolParams
         ? (toolParams as { sessionUuid?: string }).sessionUuid
         : undefined;
-    const sessionUuid = typeof rawSessionUuid === "string" ? rawSessionUuid : undefined;
+    const providedSessionUuid = typeof rawSessionUuid === "string" ? rawSessionUuid : undefined;
+    if (sessionId && providedSessionUuid && boundDeviceSessions.get(sessionId) !== providedSessionUuid) {
+      boundDeviceSessions.set(sessionId, providedSessionUuid);
+      try { server.sendToolListChanged(); } catch (error) { logger.warn(`Failed to refresh session tool list: ${error}`); }
+    }
 
     // Check if tool call should be blocked due to active executePlan in this session
     const decision = planExecutionLock.evaluate({
       toolName: name,
       sessionId,
-      sessionUuid,
+      sessionUuid: providedSessionUuid ?? sessionUuid,
     });
     if (decision.blocked) {
       logger.warn(
@@ -335,7 +363,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       throw new ActionableError(`Invalid parameters for tool ${name}: ${formatToolParamError(name, error)}`);
     }
 
-    const execution = executionTracker.startExecution(name, sessionId, sessionUuid);
+    const execution = executionTracker.startExecution(name, sessionId, providedSessionUuid ?? sessionUuid);
     const handlerParams = implicitAutolockMcpSessionId && parsedParams && typeof parsedParams === "object"
       ? { ...parsedParams, [INTERNAL_MCP_SESSION_PARAM]: implicitAutolockMcpSessionId }
       : parsedParams;

--- a/src/server/navigationTools.ts
+++ b/src/server/navigationTools.ts
@@ -135,9 +135,9 @@ export function registerNavigationTools() {
   };
 
   // Register with the tool registry
-  ToolRegistry.registerDeviceAware("navigateTo", "Navigate to screen using navigation graph", navigateToSchema, navigateToHandler, { supportsProgress: true, debugOnly: true });
+  ToolRegistry.registerDeviceAware("navigateTo", "Navigate to screen using navigation graph", navigateToSchema, navigateToHandler, { supportsProgress: true, debugOnly: true, embeddedSdkOnly: true });
 
-  ToolRegistry.registerDeviceAware("getNavigationGraph", "Get navigation graph for debugging", getNavigationGraphSchema, getNavigationGraphHandler, { debugOnly: true });
+  ToolRegistry.registerDeviceAware("getNavigationGraph", "Get navigation graph for debugging", getNavigationGraphSchema, getNavigationGraphHandler, { debugOnly: true, embeddedSdkOnly: true });
 
   // Explore handler
   const exploreHandler = async (
@@ -182,5 +182,5 @@ export function registerNavigationTools() {
     }
   };
 
-  ToolRegistry.registerDeviceAware("explore", "Automatically explore app to build navigation graph", exploreSchema, exploreHandler, { supportsProgress: true, debugOnly: true });
+  ToolRegistry.registerDeviceAware("explore", "Automatically explore app to build navigation graph", exploreSchema, exploreHandler, { supportsProgress: true, debugOnly: true, embeddedSdkOnly: true });
 }

--- a/test/features/toolCapabilities/SessionToolProfileService.test.ts
+++ b/test/features/toolCapabilities/SessionToolProfileService.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_TOOL_CAPABILITIES,
+  SessionToolProfileService,
+  type SessionToolProfileRepository,
+} from "../../../src/features/toolCapabilities/SessionToolProfileService";
+
+class FakeRepository implements SessionToolProfileRepository {
+  readonly rows = new Map<string, Map<string, boolean>>();
+
+  async list(sessionUuid: string): Promise<Map<string, boolean>> {
+    return new Map(this.rows.get(sessionUuid) ?? []);
+  }
+
+  async set(sessionUuid: string, capability: string, enabled: boolean): Promise<void> {
+    const values = this.rows.get(sessionUuid) ?? new Map<string, boolean>();
+    values.set(capability, enabled);
+    this.rows.set(sessionUuid, values);
+  }
+}
+
+describe("SessionToolProfileService", () => {
+  test("uses core defaults before a device session binds", async () => {
+    const service = new SessionToolProfileService(new FakeRepository());
+    expect(await service.isEnabled(undefined, "clipboard")).toBe(false);
+    expect(DEFAULT_TOOL_CAPABILITIES.has("clipboard")).toBe(false);
+  });
+
+  test("persists a session override and restores it in a fresh service", async () => {
+    const repository = new FakeRepository();
+    const first = new SessionToolProfileService(repository);
+    await first.setEnabled("device-session-1", "clipboard", true);
+
+    const restarted = new SessionToolProfileService(repository);
+    expect(await restarted.isEnabled("device-session-1", "clipboard")).toBe(true);
+  });
+
+  test("uses environment defaults only when no session override exists", async () => {
+    const repository = new FakeRepository();
+    const service = new SessionToolProfileService(repository, new Set(["clipboard"]));
+    expect(await service.isEnabled("device-session-1", "clipboard")).toBe(true);
+
+    await service.setEnabled("device-session-1", "clipboard", false);
+    expect(await service.isEnabled("device-session-1", "clipboard")).toBe(false);
+  });
+});

--- a/test/features/toolCapabilities/SessionToolProfileService.test.ts
+++ b/test/features/toolCapabilities/SessionToolProfileService.test.ts
@@ -20,10 +20,15 @@ class FakeRepository implements SessionToolProfileRepository {
 }
 
 describe("SessionToolProfileService", () => {
-  test("uses core defaults before a device session binds", async () => {
+  test("keeps the existing surface before a device session binds", async () => {
     const service = new SessionToolProfileService(new FakeRepository());
-    expect(await service.isEnabled(undefined, "clipboard")).toBe(false);
-    expect(DEFAULT_TOOL_CAPABILITIES.has("clipboard")).toBe(false);
+    expect(await service.isEnabled(undefined, "clipboard")).toBe(true);
+    expect(DEFAULT_TOOL_CAPABILITIES.has("clipboard")).toBe(true);
+  });
+
+  test("keeps the existing surface for an untouched device session", async () => {
+    const service = new SessionToolProfileService(new FakeRepository());
+    expect(await service.isEnabled("device-session-1", "clipboard")).toBe(true);
   });
 
   test("persists a session override and restores it in a fresh service", async () => {
@@ -33,6 +38,15 @@ describe("SessionToolProfileService", () => {
 
     const restarted = new SessionToolProfileService(repository);
     expect(await restarted.isEnabled("device-session-1", "clipboard")).toBe(true);
+  });
+
+  test("lets a session profile narrow the default surface", async () => {
+    const repository = new FakeRepository();
+    const service = new SessionToolProfileService(repository);
+
+    await service.setEnabled("device-session-1", "clipboard", false);
+
+    expect(await service.isEnabled("device-session-1", "clipboard")).toBe(false);
   });
 
   test("uses environment defaults only when no session override exists", async () => {

--- a/test/server/androidNavigationWorkflow.test.ts
+++ b/test/server/androidNavigationWorkflow.test.ts
@@ -13,6 +13,7 @@ import { registerNavigationTools } from "../../src/server/navigationTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import { createJSONToolResponse } from "../../src/utils/toolUtils";
 import { setDebugModeEnabled } from "../../src/utils/debug";
+import { serverConfig } from "../../src/utils/ServerConfig";
 import { installInMemoryNavManager, type InMemoryNavManagerHarness } from "../helpers/navigationTestHarness";
 import { FakeTimer } from "../fakes/FakeTimer";
 
@@ -28,17 +29,20 @@ describe("Android navigation graph workflow (#4459)", () => {
   beforeEach(async () => {
     ToolRegistry.clearTools();
     setDebugModeEnabled(false);
+    serverConfig.setEmbeddedSdkEnabled(false);
     harness = await installInMemoryNavManager();
   });
 
   afterEach(async () => {
     ToolRegistry.clearTools();
     setDebugModeEnabled(false);
+    serverConfig.setEmbeddedSdkEnabled(false);
     await harness.dispose();
   });
 
   test("serves the debug-gated navigation tools through MCP tools/list", async () => {
     setDebugModeEnabled(true);
+    serverConfig.setEmbeddedSdkEnabled(true);
     const server = createMcpServer();
     const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
     await server.connect(serverTransport);
@@ -144,6 +148,7 @@ describe("Android navigation graph workflow (#4459)", () => {
     expect(exploration).toMatchObject({ success: true, interactionsPerformed: 1, screensDiscovered: 1 });
 
     setDebugModeEnabled(true);
+    serverConfig.setEmbeddedSdkEnabled(true);
     registerNavigationTools();
 
     const graphTool = ToolRegistry.getTool("getNavigationGraph");


### PR DESCRIPTION
## Summary

- add persistent, session-scoped MCP tool capability overrides backed by SQLite
- keep an unbound agent on a core/device-lifecycle baseline, then bind its MCP transport to the supplied `sessionUuid` and refresh its tool list
- add `AUTOMOBILE_TOOLSET_DEFAULTS` and `AUTOMOBILE_TOOLSET_<CAPABILITY>=1` startup defaults
- gate the agreed tool families during both discovery and invocation
- move `doctor` out of MCP server registration while leaving the CLI path intact
- require embedded SDK mode for navigation modeling tools

## Why

Different agents can be bound to different device sessions and should not share a global MCP tool surface. A session-scoped profile keeps infrequent and sensitive integration tools out of an agent's context until that session explicitly enables them.

## Validation

- `bun run build`
- `bun test test/features/toolCapabilities/SessionToolProfileService.test.ts test/daemon/socketServerFeatureFlags.test.ts`
- `git diff --check`

## Follow-up

- add end-to-end multi-session transport coverage and target-app capability evidence
- complete [#4565](https://github.com/kaeawc/auto-mobile/issues/4565) to fold standalone wait tools into `observe`
