### PR TITLE
fix(observe): report scope dimensions gated off

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -6152,6 +6152,17 @@
                 ]
               }
             },
+            "gatedOff": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "focus",
+                  "region",
+                  "overview"
+                ]
+              }
+            },
             "nodesBefore": {
               "type": "integer",
               "minimum": 0,

--- a/src/features/observe/output/ObserveScopeExperiments.ts
+++ b/src/features/observe/output/ObserveScopeExperiments.ts
@@ -55,6 +55,8 @@ export type {
 export interface ObserveScopeConfig {
   /** FOCUS on. */
   focus: boolean;
+  /** Requested dimensions withheld because their server experiment flags are off. */
+  gatedOff?: ObserveScopeKind[];
   /** Optional FOCUS anchor; when absent, FOCUS scopes to the foreground app. */
   focusAnchor?: FocusAnchor;
   /** OVERVIEW on. */
@@ -553,12 +555,19 @@ function runOverviewStage(run: ScopeRun): void {
   run.applied.push("overview");
 }
 
-function buildScopeMetadata(run: ScopeRun, nodesBefore: number): ObserveScopeMetadata {
+function buildScopeMetadata(
+  run: ScopeRun,
+  nodesBefore: number,
+  gatedOff: ObserveScopeKind[]
+): ObserveScopeMetadata {
   const metadata: ObserveScopeMetadata = {
     applied: run.applied,
     nodesBefore,
     nodesAfter: countNodes(rootNodes(run.current)),
   };
+  if (gatedOff.length > 0) {
+    metadata.gatedOff = gatedOff;
+  }
   if (run.regionPx) {
     metadata.regionPx = run.regionPx;
   }
@@ -570,14 +579,17 @@ function buildScopeMetadata(run: ScopeRun, nodesBefore: number): ObserveScopeMet
 
 /**
  * Apply the enabled scope transforms in order (focus -> region -> overview) and
- * annotate `observeScope`. Pure: the input is never mutated. When nothing is
- * enabled, returns the input unchanged (no clone, no metadata).
+ * annotate `observeScope`. Pure: the input is never mutated. Requested
+ * dimensions gated off by server flags are recorded without changing the tree.
+ * When no transform is enabled and nothing was gated off, returns the input
+ * unchanged (no clone, no metadata).
  */
 export function applyObserveScopeExperiments(
   input: ObserveResult,
   cfg: ObserveScopeConfig
 ): ObserveResult {
-  if (!cfg.focus && !cfg.region && !cfg.overview) {
+  const gatedOff = cfg.gatedOff ?? [];
+  if (!cfg.focus && !cfg.region && !cfg.overview && gatedOff.length === 0) {
     return input;
   }
 
@@ -597,7 +609,7 @@ export function applyObserveScopeExperiments(
   // Every stage returns a fresh clone, so `run.current` is never the input here;
   // guard the theoretically-unreachable no-op case anyway.
   const out = run.current === input ? clone(input) : run.current;
-  out.observeScope = buildScopeMetadata({ ...run, current: out }, nodesBefore);
+  out.observeScope = buildScopeMetadata({ ...run, current: out }, nodesBefore, gatedOff);
   return out;
 }
 
@@ -611,6 +623,23 @@ export interface ObserveScopeFlags {
 /** A dimension is requested when the call set it to `true` or an object (not `false`/absent). */
 function isDimensionRequested(dim: boolean | object | undefined): boolean {
   return dim !== undefined && dim !== false;
+}
+
+function gatedOffDimensions(
+  flags: ObserveScopeFlags,
+  scope: ObserveScopeInput | undefined
+): ObserveScopeKind[] {
+  const gatedOff: ObserveScopeKind[] = [];
+  if (!flags.focus && isDimensionRequested(scope?.focus)) {
+    gatedOff.push("focus");
+  }
+  if (!flags.region && isDimensionRequested(scope?.region)) {
+    gatedOff.push("region");
+  }
+  if (!flags.overview && scope?.overview === true) {
+    gatedOff.push("overview");
+  }
+  return gatedOff;
 }
 
 /** The anchor object of a `focus` request, or undefined for the `true` (foreground) form. */
@@ -640,5 +669,6 @@ export function buildObserveScopeConfig(
     overview: flags.overview && scope?.overview === true,
     region: flags.region && isDimensionRequested(scope?.region),
     regionBox: regionBoxOf(scope?.region),
+    gatedOff: gatedOffDimensions(flags, scope),
   };
 }

--- a/src/models/ObserveResult.ts
+++ b/src/models/ObserveResult.ts
@@ -330,8 +330,9 @@ export interface ObserveResult {
   /**
    * Progressive-disclosure scoping metadata (issue #4344), present only when an
    * `--observe-focus-scope` / `--observe-overview` / `--observe-region`
-   * experiment scoped this observe payload. Records which transforms ran and the
-   * node-count reduction so the experiment is measurable on the wire. See
+   * experiment scoped this observe payload, or withheld a requested dimension.
+   * Records which transforms ran and the node-count reduction so the experiment
+   * is measurable on the wire. See
    * `features/observe/output/ObserveScopeExperiments.ts`.
    */
   observeScope?: ObserveScopeMetadata;

--- a/src/models/ObserveScope.ts
+++ b/src/models/ObserveScope.ts
@@ -45,6 +45,8 @@ export type ObserveScopeKind = "focus" | "region" | "overview";
 export interface ObserveScopeMetadata {
   /** Transforms that actually changed the tree, in application order. */
   applied: ObserveScopeKind[];
+  /** Requested dimensions withheld because their server experiment flags are off. */
+  gatedOff?: ObserveScopeKind[];
   /** Hierarchy node count before any scoping. */
   nodesBefore: number;
   /** Hierarchy node count after all scoping. */

--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -253,7 +253,16 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
     overview: serverConfig.isObserveOverviewEnabled(),
     region: serverConfig.isObserveRegionEnabled(),
   };
-  const scopeActive = !ctx.internal && (scopeFlags.focus || scopeFlags.overview || scopeFlags.region);
+  const scopeConfig = buildObserveScopeConfig(
+    scopeFlags,
+    ctx.args?.scope as ObserveScopeInput | undefined
+  );
+  const scopeActive = !ctx.internal && (
+    scopeFlags.focus ||
+    scopeFlags.overview ||
+    scopeFlags.region ||
+    (scopeConfig.gatedOff?.length ?? 0) > 0
+  );
 
   // Internal tool-to-tool calls (#3053) always get the full sanitized observation:
   // the diff/strip transforms are for the agent-facing wire only, so an internal
@@ -291,10 +300,7 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
     if (resolveObserveProjection(ctx.args) === "skeleton") {
       served = sanitizeObserveResult(observeResult, { ...cfg, project: "skeleton" });
     } else if (scopeActive) {
-      served = applyObserveScopeExperiments(
-        sanitized,
-        buildObserveScopeConfig(scopeFlags, ctx.args?.scope as ObserveScopeInput | undefined)
-      );
+      served = applyObserveScopeExperiments(sanitized, scopeConfig);
     }
     sanitizedPayload = served as unknown as Record<string, unknown>;
     hasArtifactableObservation = true;

--- a/src/server/toolOutputSchemas.ts
+++ b/src/server/toolOutputSchemas.ts
@@ -451,6 +451,7 @@ export const skeletonElementSchema = z.object({
  */
 export const observeScopeMetadataSchema = z.object({
   applied: z.array(z.enum(["focus", "region", "overview"])),
+  gatedOff: z.array(z.enum(["focus", "region", "overview"])).optional(),
   nodesBefore: z.number().int().nonnegative(),
   nodesAfter: z.number().int().nonnegative(),
   regionPx: elementBoundsSchema.optional(),

--- a/test/features/observe/output/ObserveScopeExperiments.test.ts
+++ b/test/features/observe/output/ObserveScopeExperiments.test.ts
@@ -205,6 +205,7 @@ describe("buildObserveScopeConfig", () => {
     expect(cfg.focus).toBe(false);
     expect(cfg.region).toBe(false);
     expect(cfg.overview).toBe(false);
+    expect(cfg.gatedOff).toEqual(["focus", "region", "overview"]);
   });
 
   test("no scope input yields an all-off config", () => {

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -1814,12 +1814,29 @@ describe("finalizeToolResponse observe scope experiments (#4344)", () => {
     } as ObserveResult;
   }
 
-  test("no scope flags: observe payload is untouched even when the call requests scope", () => {
+  test("no scope flags: reports requested dimensions gated off", () => {
     const finalized = finalizeToolResponse(createStructuredToolResponse(chromeObserve()), {
       name: "observe",
-      args: { scope: { focus: true } },
+      args: { scope: { focus: true, region: true, overview: true } },
     });
-    expect((finalized.structuredContent as ObserveResult).observeScope).toBeUndefined();
+    const out = finalized.structuredContent as ObserveResult;
+    expect(out.observeScope).toMatchObject({
+      applied: [],
+      gatedOff: ["focus", "region", "overview"],
+    });
+    expect(out.observeScope!.nodesAfter).toBe(out.observeScope!.nodesBefore);
+  });
+
+  test("reports a disabled requested dimension alongside enabled scope transforms", () => {
+    serverConfig.setObserveFocusScopeEnabled(true);
+    const finalized = finalizeToolResponse(createStructuredToolResponse(chromeObserve()), {
+      name: "observe",
+      args: { scope: { focus: true, region: true } },
+    });
+    expect((finalized.structuredContent as ObserveResult).observeScope).toMatchObject({
+      applied: ["focus"],
+      gatedOff: ["region"],
+    });
   });
 
   test("flag on but no scope in the call: payload is untouched", () => {

--- a/test/server/observeOutputSchema.test.ts
+++ b/test/server/observeOutputSchema.test.ts
@@ -241,6 +241,10 @@ describe("observeResultSchema: parses real captures (#3025)", () => {
       observeResultSchema.parse({ deviceLock: { locked: "yes", keyguardShowing: true } })
     ).toThrow();
   });
+
+  test("advertises requested scope dimensions gated off by server flags", () => {
+    expect(JSON.stringify(flattenTopLevelUnion(toJSONSchema(observeResultSchema)))).toContain("\"gatedOff\"");
+  });
 });
 
 describe("observeToolResultSchema: artifact metadata (#3480)", () => {


### PR DESCRIPTION
## Summary

`observe` now reports requested scope dimensions that are withheld because their server experiment flags are disabled. The additive `observeScope.gatedOff` field distinguishes a full unscoped result from a request that was deliberately gated off, while preserving the existing flag-gating behavior.

## Linked Issue

Closes [#4591](https://github.com/kaeawc/auto-mobile/issues/4591)

## Bug / Regression Context

- **Prior attempts:** Scope transforms landed in [#4390](https://github.com/kaeawc/auto-mobile/pull/4390) with dark-launch flags intentionally defaulting to off.
- **Observed symptom:** A caller requesting disabled scope dimensions received an indistinguishable full result with no `observeScope` metadata.
- **Repro steps / conditions:** Call `observe` with `scope` dimensions on a daemon without their corresponding `--observe-focus-scope`, `--observe-region`, or `--observe-overview` flag.

## Validation

- [x] Focused scope, response-finalization, and output-schema tests: 159 passing
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Regenerated `schemas/tool-definitions.json`
- [x] New code is pure and focused unit tests run in under 100ms
- [x] Branch created from current `origin/main`
- [ ] `bun run turbo:validate` completed lint/build but its full suite had five unrelated `xcodegenDriftCheck` fixture failures: temporary repositories lack `ios/control-proxy/project.yml`

