### PR TITLE
Fix session tool capability defaults

### DIFF
--- a/src/features/toolCapabilities/SessionToolProfileService.ts
+++ b/src/features/toolCapabilities/SessionToolProfileService.ts
@@ -59,17 +59,28 @@ export class SessionToolProfileService {
 
 let defaultService: SessionToolProfileService | undefined;
 
+export function getEnvironmentDefaultToolCapabilities(
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+): ReadonlySet<ToolCapability> {
+  const raw = environment.AUTOMOBILE_TOOLSET_DEFAULTS?.trim();
+  const defaults = raw
+    ? new Set(raw.split(",").map(value => value.trim()).filter((value): value is ToolCapability => TOOL_CAPABILITIES.includes(value as ToolCapability)))
+    : new Set(DEFAULT_TOOL_CAPABILITIES);
+  for (const capability of TOOL_CAPABILITIES) {
+    const env = `AUTOMOBILE_TOOLSET_${capability.toUpperCase().replace(/-/g, "_")}`;
+    if (environment[env] === "1") { defaults.add(capability); }
+  }
+  return defaults;
+}
+
 export function getSessionToolProfileService(): SessionToolProfileService {
   if (!defaultService) {
     // Lazy import avoids opening the production database until the server does.
     const { SqliteSessionToolProfileRepository } = require("./SqliteSessionToolProfileRepository");
-    const raw = process.env.AUTOMOBILE_TOOLSET_DEFAULTS ?? "";
-    const defaults = new Set(raw.split(",").map(value => value.trim()).filter(value => TOOL_CAPABILITIES.includes(value as ToolCapability)));
-    for (const capability of TOOL_CAPABILITIES) {
-      const env = `AUTOMOBILE_TOOLSET_${capability.toUpperCase().replace(/-/g, "_")}`;
-      if (process.env[env] === "1") { defaults.add(capability); }
-    }
-    defaultService = new SessionToolProfileService(new SqliteSessionToolProfileRepository(), defaults);
+    defaultService = new SessionToolProfileService(
+      new SqliteSessionToolProfileRepository(),
+      getEnvironmentDefaultToolCapabilities(),
+    );
   }
   return defaultService;
 }

--- a/src/utils/android-cmdline-tools/interfaces/AdbExecutor.ts
+++ b/src/utils/android-cmdline-tools/interfaces/AdbExecutor.ts
@@ -97,6 +97,9 @@ export interface AdbExecutor {
    */
   getForegroundApp(signal?: AbortSignal): Promise<{ packageName: string; userId: number } | null>;
 
+  /** Get device time in milliseconds. */
+  getDeviceTimestampMs(): Promise<number>;
+
   /**
    * Resolve and return the path to the `adb` binary without executing a command.
    * Used by diagnostics (doctor) to surface the detected path.

--- a/test/features/toolCapabilities/SessionToolProfileService.test.ts
+++ b/test/features/toolCapabilities/SessionToolProfileService.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   DEFAULT_TOOL_CAPABILITIES,
+  getEnvironmentDefaultToolCapabilities,
   SessionToolProfileService,
   type SessionToolProfileRepository,
 } from "../../../src/features/toolCapabilities/SessionToolProfileService";
@@ -31,13 +32,31 @@ describe("SessionToolProfileService", () => {
     expect(await service.isEnabled("device-session-1", "clipboard")).toBe(true);
   });
 
-  test("persists a session override and restores it in a fresh service", async () => {
-    const repository = new FakeRepository();
-    const first = new SessionToolProfileService(repository);
-    await first.setEnabled("device-session-1", "clipboard", true);
+  test.each([
+    ["unset", {}],
+    ["empty", { AUTOMOBILE_TOOLSET_DEFAULTS: "  " }],
+  ])("uses the declared baseline when defaults are %s", (_description, environment) => {
+    expect(getEnvironmentDefaultToolCapabilities(environment)).toEqual(DEFAULT_TOOL_CAPABILITIES);
+  });
 
-    const restarted = new SessionToolProfileService(repository);
-    expect(await restarted.isEnabled("device-session-1", "clipboard")).toBe(true);
+  test("replaces the baseline with explicit defaults before adding individual capabilities", () => {
+    const defaults = getEnvironmentDefaultToolCapabilities({
+      AUTOMOBILE_TOOLSET_DEFAULTS: "clipboard",
+      AUTOMOBILE_TOOLSET_ADVANCED_INTERACTION: "1",
+    });
+
+    expect(defaults).toEqual(new Set(["clipboard", "advanced-interaction"]));
+    expect(defaults.has("device-settings")).toBe(false);
+  });
+
+  test("persists a disabled session override and restores it in a fresh service", async () => {
+    const repository = new FakeRepository();
+    const environmentDefaults = new Set(["clipboard"]);
+    const first = new SessionToolProfileService(repository, environmentDefaults);
+    await first.setEnabled("device-session-1", "clipboard", false);
+
+    const restarted = new SessionToolProfileService(repository, environmentDefaults);
+    expect(await restarted.isEnabled("device-session-1", "clipboard")).toBe(false);
   });
 
   test("lets a session profile narrow the default surface", async () => {

--- a/test/utils/AccessibilityDetector.test.ts
+++ b/test/utils/AccessibilityDetector.test.ts
@@ -13,6 +13,10 @@ class FakeAdbExecutor implements AdbExecutor {
   private callCount = 0;
   private shouldError = false;
 
+  async getDeviceTimestampMs(): Promise<number> {
+    return 0;
+  }
+
   setResponse(output: string): void {
     this.responses.set("default", output);
   }


### PR DESCRIPTION
## Summary

- Use `DEFAULT_TOOL_CAPABILITIES` when `AUTOMOBILE_TOOLSET_DEFAULTS` is unset or blank.
- Preserve explicit default-list replacement followed by individual capability additions.
- Verify a persisted disabled override wins after a fresh session-profile service instance.

The startup parser previously treated an absent defaults variable as an empty set, unintentionally narrowing newly bound sessions. This restores the declared baseline unless configuration explicitly replaces it.

Closes [#4612](https://github.com/kaeawc/auto-mobile/issues/4612).

## Validation

- `bun test test/features/toolCapabilities/SessionToolProfileService.test.ts`
- `env HOME=/private/tmp/auto-mobile-4612-test-home bun run turbo:validate`
- `bun run typecheck`
