### PR TITLE
fix(android): enforce frame context at ADB dispatch

### DIFF
--- a/scripts/typecheck-baseline.txt
+++ b/scripts/typecheck-baseline.txt
@@ -69,16 +69,10 @@ src/features/accessibility/WcagAudit.ts: error TS2339: Property 'class' does not
 src/features/accessibility/WcagAudit.ts: error TS2352: Conversion of type 'ViewHierarchyNode[]' to type 'ViewHierarchyNode' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 src/features/accessibility/WcagAudit.ts: error TS7053: Element implicitly has an 'any' type because expression of type '"resource-id"' can't be used to index type 'ViewHierarchyNode'.
 src/features/action/BaseVisualChange.ts: error TS2322: Type '{ warning: string; requestedAfter?: number; actualTimestamp?: number; isFresh?: boolean | undefined; staleDurationMs?: number; }' is not assignable to type '{ requestedAfter?: number | undefined; actualTimestamp?: number | undefined; isFresh: boolean; staleDurationMs?: number | undefined; warning?: string | undefined; }'.
-src/features/action/BaseVisualChange.ts: error TS2339: Property 'getDeviceTimestampMs' does not exist on type 'AdbExecutor'.
-src/features/action/BaseVisualChange.ts: error TS2339: Property 'getDeviceTimestampMs' does not exist on type 'AdbExecutor'.
 src/features/action/BaseVisualChange.ts: error TS2339: Property 'signal' does not exist on type '{ changeExpected: boolean; tolerancePercent?: number | undefined; queryOptions?: ViewHierarchyQueryOptions | undefined; gfxMetrics?: GfxMetrics | null | undefined; perf?: PerformanceTracker | undefined; actionStartTime?: number | undefined; predictionContext?: PredictionActionContext | undefined; }'.
 src/features/action/BaseVisualChange.ts: error TS2339: Property 'signal' does not exist on type '{ changeExpected: boolean; tolerancePercent?: number | undefined; queryOptions?: ViewHierarchyQueryOptions | undefined; gfxMetrics?: GfxMetrics | null | undefined; perf?: PerformanceTracker | undefined; actionStartTime?: number | undefined; predictionContext?: PredictionActionContext | undefined; }'.
 src/features/action/IosSimulatorPermissions.ts: error TS2352: Conversion of type 'TccPermissionRow' to type 'Record<string, null | number | string>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 src/features/action/LaunchApp.ts: error TS2322: Type 'boolean | null' is not assignable to type 'boolean'.
-src/features/action/LaunchApp.ts: error TS2322: Type 'unknown' is not assignable to type 'number'.
-src/features/action/LaunchApp.ts: error TS2339: Property 'getDeviceTimestampMs' does not exist on type 'AdbExecutor'.
-src/features/action/LaunchApp.ts: error TS2339: Property 'getDeviceTimestampMs' does not exist on type 'AdbExecutor'.
-src/features/action/LaunchApp.ts: error TS2339: Property 'getDeviceTimestampMs' does not exist on type 'AdbExecutor'.
 src/features/action/OpenURL.ts: error TS2345: Argument of type 'AdbExecutor' is not assignable to parameter of type 'AdbClient'.
 src/features/action/SetUIState.ts: error TS2554: Expected 0-1 arguments, but got 5.
 src/features/action/SetUIState.ts: error TS2554: Expected 0-1 arguments, but got 5.
@@ -187,8 +181,6 @@ src/server/observeTools.ts: error TS2322: Type 'TimingData' is not assignable to
 src/server/observeTools.ts: error TS2339: Property 'sessionUuid' does not exist on type 'IdentifyInteractionsOptions'.
 src/server/observeTools.ts: error TS2339: Property 'sessionUuid' does not exist on type 'IdentifyInteractionsOptions'.
 src/server/observeTools.ts: error TS2488: Type 'TimingData' must have a '[Symbol.iterator]()' method that returns an iterator.
-src/server/systemTrayHelpers.ts: error TS2322: Type 'SystemTrayDependencies | null' is not assignable to type 'SystemTrayDependencies'.
-src/server/systemTrayHelpers.ts: error TS2741: Property 'getDeviceTimestampMs' is missing in type 'AdbExecutor' but required in type 'SystemTrayAdb'.
 src/server/testRunResources.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type '"latestOnly" | "limit" | "lookbackDays" | "orderDirection" | "testClass" | "testMethod"'.
 src/server/testTimingResources.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type '"appVersion" | "deviceId" | "deviceName" | "devicePlatform" | "deviceType" | "gitCommit" | "jdkVersion" | "limit" | "sessionUuid" | "targetSdk" | "testClass" | "testMethod" | ... 6 more ... | "orderDirection"'.
 src/utils/Backoff.ts: error TS2322: Type 'BackoffPolicy | readonly number[]' is not assignable to type 'BackoffPolicy'.
@@ -211,7 +203,6 @@ src/utils/plan/PlanSchemaValidator.ts: error TS1343: The 'import.meta' meta-prop
 # swap-fp: 11 :: src/daemon/SocketServerRegistry.ts: error TS2345: Argument of type 'Promise<BaseSocketServer | void>' is not assignable to parameter of type 'Promise<void>'.
 # swap-fp: 11 :: src/daemon/socketServer.ts: error TS2322: Type 'unknown' is not assignable to type '{ [x: string]: unknown; } | undefined'.
 # swap-fp: 11 :: src/db/failureAnalyticsRepository.ts: error TS2322: Type 'FailureType' is not assignable to type '"anr" | "crash" | "tool_failure"'.
-# swap-fp: 11 :: src/features/action/LaunchApp.ts: error TS2322: Type 'unknown' is not assignable to type 'number'.
 # swap-fp: 11 :: src/features/action/TapAnyElement.ts: error TS2416: Property 'hashViewHierarchy' in type 'TapAnyElement' is not assignable to the same property in base type 'BaseVisualChange'.
 # swap-fp: 11 :: src/features/action/TapOnElement.ts: error TS2416: Property 'hashViewHierarchy' in type 'TapOnElement' is not assignable to the same property in base type 'BaseVisualChange'.
 # swap-fp: 11 :: src/features/action/swipeon/ScrollUntilVisible.ts: error TS2322: Type 'ViewHierarchyResult | undefined' is not assignable to type 'ViewHierarchyResult | null'.
@@ -242,19 +233,15 @@ src/utils/plan/PlanSchemaValidator.ts: error TS1343: The 'import.meta' meta-prop
 # swap-fp: 21,28 :: src/db/migrator.ts: error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
 # swap-fp: 23 :: src/features/accessibility/ContrastChecker.ts: error TS2345: Argument of type 'Map<string, number>' is not assignable to parameter of type 'Map<string, { timestamp: number; }>'.
 # swap-fp: 24 :: src/utils/ios-cmdline-tools/XcodeSigning.ts: error TS2322: Type 'Promise<string | undefined>' is not assignable to type 'Promise<void>'.
-# swap-fp: 24,28,49 :: src/features/action/LaunchApp.ts: error TS2339: Property 'getDeviceTimestampMs' does not exist on type 'AdbExecutor'.
 # swap-fp: 25 :: src/daemon/client.ts: error TS2345: Argument of type 'NonSharedBuffer | string' is not assignable to parameter of type 'Buffer<ArrayBufferLike>'.
-# swap-fp: 25,27 :: src/features/action/BaseVisualChange.ts: error TS2339: Property 'getDeviceTimestampMs' does not exist on type 'AdbExecutor'.
 # swap-fp: 27 :: src/db/migrator.ts: error TS7006: Parameter 'index' implicitly has an 'any' type.
 # swap-fp: 27,45 :: src/db/database.ts: error TS2307: Cannot find module 'bun:sqlite' or its corresponding type declarations.
 # swap-fp: 28 :: src/db/migrations/2026_01_30_000_performance_live_metrics.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type 'DataTypeExpression'.
-# swap-fp: 29 :: src/server/systemTrayHelpers.ts: error TS2741: Property 'getDeviceTimestampMs' is missing in type 'AdbExecutor' but required in type 'SystemTrayAdb'.
 # swap-fp: 3 :: src/daemon/failuresStreamSocketServer.ts: error TS2559: Type 'FailuresStreamSocketRequest' has no properties in common with type 'SocketRequest'.
 # swap-fp: 3 :: src/daemon/performanceStreamSocketServer.ts: error TS2559: Type 'PerformanceStreamSocketRequest' has no properties in common with type 'SocketRequest'.
 # swap-fp: 3 :: src/daemon/testRecordingSocketServer.ts: error TS2559: Type 'TestRecordingCommand' has no properties in common with type 'SocketRequest'.
 # swap-fp: 3 :: src/db/logEventRepository.ts: error TS2322: Type '{ deviceId: null | string; timestamp: number; applicationId: null | string; sessionId: null | string; level: number; tag: string; message: string; filterName: null | string; }[]' is not assignable to type 'RecordLogEventInput[]'.
 # swap-fp: 3 :: src/features/navigation/NavigateTo.ts: error TS2459: Module '"./NavigationGraphManager"' declares 'ToolCallInteraction' locally, but it is not exported.
-# swap-fp: 3 :: src/server/systemTrayHelpers.ts: error TS2322: Type 'SystemTrayDependencies | null' is not assignable to type 'SystemTrayDependencies'.
 # swap-fp: 3 :: src/utils/Backoff.ts: error TS2322: Type 'BackoffPolicy | readonly number[]' is not assignable to type 'BackoffPolicy'.
 # swap-fp: 30 :: src/features/action/IosSimulatorPermissions.ts: error TS2352: Conversion of type 'TccPermissionRow' to type 'Record<string, null | number | string>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 # swap-fp: 30 :: src/server/appResources.ts: error TS2345: Argument of type 'string[]' is not assignable to parameter of type 'readonly ("deviceId" | "platform" | "profile" | "search" | "type")[]'.
@@ -293,6 +280,7 @@ src/utils/plan/PlanSchemaValidator.ts: error TS1343: The 'import.meta' meta-prop
 # swap-fp: 46 :: src/daemon/telemetryPushSocketServer.ts: error TS2345: Argument of type '"anr" | "crash" | "nonfatal"' is not assignable to parameter of type 'OperandValueExpressionOrList<Database, "failure_groups" | "failure_occurrences", "failure_groups.type">'.
 # swap-fp: 46 :: src/db/bunSqliteDialect.ts: error TS2307: Cannot find module 'bun:sqlite' or its corresponding type declarations.
 # swap-fp: 46 :: src/server/observeTools.ts: error TS2488: Type 'TimingData' must have a '[Symbol.iterator]()' method that returns an iterator.
+# swap-fp: 47 :: src/features/navigation/NavigateTo.ts: error TS2345: Argument of type 'AdbExecutor' is not assignable to parameter of type 'AdbClient'.
 # swap-fp: 47 :: src/features/observe/HierarchyPlatformValidator.ts: error TS2339: Property 'startsWith' does not exist on type '{}'.
 # swap-fp: 47 :: src/server/formTools.ts: error TS2345: Argument of type 'AdbExecutor | null' is not assignable to parameter of type 'AdbClient | null | undefined'.
 # swap-fp: 47,64 :: src/features/preferences/AppPreferences.ts: error TS2345: Argument of type 'PreferenceResultValue | null' is not assignable to parameter of type 'PreferenceValue | null'.
@@ -335,7 +323,6 @@ src/utils/plan/PlanSchemaValidator.ts: error TS1343: The 'import.meta' meta-prop
 # swap-fp: 7,7,7,7,9,9,9,9 :: src/index.ts: error TS2322: Type 'number | string | undefined' is not assignable to type 'number | undefined'.
 # swap-fp: 74 :: src/features/utility/ElementParser.ts: error TS2339: Property 'hierarchy' does not exist on type '{ windowLayer: number; }'.
 # swap-fp: 74,75,76,77,77 :: src/features/action/SetUIState.ts: error TS2554: Expected 0-1 arguments, but got 5.
-# swap-fp: 78 :: src/features/navigation/NavigateTo.ts: error TS2345: Argument of type 'AdbExecutor' is not assignable to parameter of type 'AdbClient'.
 # swap-fp: 8,8 :: src/db/migrations/2026_01_30_000_performance_live_metrics.ts: error TS2339: Property 'raw' does not exist on type 'Kysely<unknown>'.
 # swap-fp: 85 :: src/daemon/socketServer.ts: error TS2554: Expected 1-2 arguments, but got 3.
 # swap-fp: 88 :: src/server/testRunResources.ts: error TS2345: Argument of type 'string' is not assignable to parameter of type '"latestOnly" | "limit" | "lookbackDays" | "orderDirection" | "testClass" | "testMethod"'.

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1380,7 +1380,14 @@ export class UnixSocketServer {
     // input for this device, not just this one request.
     let appendCharsSent: number | undefined;
     if (append && platform === "android") {
-      const textResult = await this.getAppendTextInput(targetDevice).appendText(text, timeoutMs);
+      const textResult = await this.executeAndroidAppendText(
+        targetDevice,
+        text,
+        deadline,
+        timeoutMs,
+        frameContext,
+        client as AndroidCtrlProxyClient
+      );
       if (textResult.charsSent !== undefined) {
         onConfirmedAppendCharsSent?.(textResult.charsSent);
       }
@@ -1401,6 +1408,40 @@ export class UnixSocketServer {
       }
     }
     return await this.runImeActionWithinBudget(client, imeAction, deadline, timeoutMs, appendCharsSent);
+  }
+
+  private async executeAndroidAppendText(
+    targetDevice: BootedDevice,
+    text: string,
+    deadline: number,
+    totalTimeoutMs: number,
+    frameContext: string | undefined,
+    client: AndroidCtrlProxyClient
+  ): Promise<{ success: boolean; error?: string; charsSent?: number }> {
+    if (frameContext !== undefined) {
+      const validationTimeoutMs = deadline - this.timer.now();
+      if (validationTimeoutMs <= 0) {
+        return {
+          success: false,
+          error: `input/typeText exceeded ${totalTimeoutMs}ms budget before append frame context validation`,
+        };
+      }
+      const validation = await client.validateFrameContext(frameContext, validationTimeoutMs);
+      if (!validation.success) {
+        return {
+          success: false,
+          error: validation.error ?? "Frame context is stale or unavailable; observe a fresh frame before retrying",
+        };
+      }
+    }
+    const appendTimeoutMs = deadline - this.timer.now();
+    if (appendTimeoutMs <= 0) {
+      return {
+        success: false,
+        error: `input/typeText exceeded ${totalTimeoutMs}ms budget before append key events`,
+      };
+    }
+    return await this.getAppendTextInput(targetDevice).appendText(text, appendTimeoutMs);
   }
 
   private async runImeActionWithinBudget(

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -32,7 +32,7 @@ import {
   extractClientHandshake,
   type DaemonSelfIdentity,
 } from "./daemonHandshake";
-import { InputText } from "../features/action/InputText";
+import { InputText, type AppendKeyEventValidator } from "../features/action/InputText";
 import { getCurrentBuildIdentity } from "./buildIdentity";
 import { DaemonState } from "./daemonState";
 import { DaemonStateAccess, handleDaemonRequest } from "./daemonRequestHandlers";
@@ -125,7 +125,8 @@ export type McpClientFactory = () => Promise<Client>;
 export interface AppendTextInput {
   appendText(
     text: string,
-    timeoutMs?: number
+    timeoutMs?: number,
+    beforeKeyEvent?: AppendKeyEventValidator
   ): Promise<{ success: boolean; error?: string; charsSent?: number }>;
 }
 
@@ -1418,22 +1419,6 @@ export class UnixSocketServer {
     frameContext: string | undefined,
     client: AndroidCtrlProxyClient
   ): Promise<{ success: boolean; error?: string; charsSent?: number }> {
-    if (frameContext !== undefined) {
-      const validationTimeoutMs = deadline - this.timer.now();
-      if (validationTimeoutMs <= 0) {
-        return {
-          success: false,
-          error: `input/typeText exceeded ${totalTimeoutMs}ms budget before append frame context validation`,
-        };
-      }
-      const validation = await client.validateFrameContext(frameContext, validationTimeoutMs);
-      if (!validation.success) {
-        return {
-          success: false,
-          error: validation.error ?? "Frame context is stale or unavailable; observe a fresh frame before retrying",
-        };
-      }
-    }
     const appendTimeoutMs = deadline - this.timer.now();
     if (appendTimeoutMs <= 0) {
       return {
@@ -1441,7 +1426,35 @@ export class UnixSocketServer {
         error: `input/typeText exceeded ${totalTimeoutMs}ms budget before append key events`,
       };
     }
-    return await this.getAppendTextInput(targetDevice).appendText(text, appendTimeoutMs);
+    return await this.getAppendTextInput(targetDevice).appendText(
+      text,
+      appendTimeoutMs,
+      frameContext === undefined
+        ? undefined
+        : () => this.validateAppendFrameContext(client, frameContext, deadline, totalTimeoutMs)
+    );
+  }
+
+  private async validateAppendFrameContext(
+    client: AndroidCtrlProxyClient,
+    frameContext: string,
+    deadline: number,
+    totalTimeoutMs: number
+  ): Promise<{ success: boolean; error?: string }> {
+    const validationTimeoutMs = deadline - this.timer.now();
+    if (validationTimeoutMs <= 0) {
+      return {
+        success: false,
+        error: `input/typeText exceeded ${totalTimeoutMs}ms budget before append frame context validation`,
+      };
+    }
+    const validation = await client.validateFrameContext(frameContext, validationTimeoutMs);
+    return validation.success
+      ? { success: true }
+      : {
+        success: false,
+        error: validation.error ?? "Frame context is stale or unavailable; observe a fresh frame before retrying",
+      };
   }
 
   private async runImeActionWithinBudget(

--- a/src/features/action/InputKey.ts
+++ b/src/features/action/InputKey.ts
@@ -74,10 +74,6 @@ export class InputKey {
     const keyCode = INPUT_KEY_CODE_MAP[key];
     try {
       const deadlineMs = timeoutMs !== undefined ? this.timer.now() + timeoutMs : undefined;
-      const validationFailure = await this.validateFrameContext(key, keyCode, frameContext, deadlineMs);
-      if (validationFailure) {
-        return validationFailure;
-      }
       const adbTimeoutMs = this.remainingMs(deadlineMs);
       if (adbTimeoutMs !== undefined && adbTimeoutMs <= 0) {
         return {
@@ -87,7 +83,39 @@ export class InputKey {
           error: "input/key deadline exhausted before ADB keyevent",
         };
       }
-      await this.adb.executeCommand(`shell input keyevent ${keyCode}`, adbTimeoutMs, undefined, true);
+      let validationFailure: InputKeyResult | undefined;
+      try {
+        await this.adb.execute(
+          ["shell", "input", "keyevent", keyCode],
+          {
+            timeoutMs: adbTimeoutMs,
+            noRetry: true,
+            beforeDispatch: frameContext === undefined
+              ? undefined
+              : async () => {
+                validationFailure = await this.validateFrameContext(key, keyCode, frameContext, deadlineMs);
+                if (validationFailure) {
+                  throw new Error(validationFailure.error);
+                }
+                const remainingMs = this.remainingMs(deadlineMs);
+                if (remainingMs !== undefined && remainingMs <= 0) {
+                  validationFailure = {
+                    success: false,
+                    key,
+                    keyCode,
+                    error: "input/key deadline exhausted before ADB keyevent",
+                  };
+                  throw new Error(validationFailure.error);
+                }
+              },
+          }
+        );
+      } catch (error) {
+        if (validationFailure) {
+          return validationFailure;
+        }
+        throw error;
+      }
       return {
         success: true,
         key,

--- a/src/features/action/InputKey.ts
+++ b/src/features/action/InputKey.ts
@@ -4,6 +4,7 @@ import { defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbCl
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { logger } from "../../utils/logger";
 import { AndroidCtrlProxyClient } from "../observe/android";
+import { defaultTimer, type Timer } from "../../utils/SystemTimer";
 
 export const INPUT_KEY_CODE_MAP = {
   enter: "KEYCODE_ENTER",
@@ -49,7 +50,8 @@ export class InputKey {
   constructor(
     device: BootedDevice,
     private readonly adbFactory: AdbClientFactory = defaultAdbClientFactory,
-    private readonly frameContextValidator?: FrameContextValidator
+    private readonly frameContextValidator?: FrameContextValidator,
+    private readonly timer: Timer = defaultTimer
   ) {
     this.device = device;
     this.adb = adbFactory.create(device);
@@ -71,20 +73,21 @@ export class InputKey {
 
     const keyCode = INPUT_KEY_CODE_MAP[key];
     try {
-      if (frameContext !== undefined) {
-        const validator = this.frameContextValidator ??
-          AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
-        const validation = await validator.validateFrameContext(frameContext, timeoutMs);
-        if (!validation.success) {
-          return {
-            success: false,
-            key,
-            keyCode,
-            error: validation.error ?? "Frame context is stale or unavailable; observe a fresh frame before retrying",
-          };
-        }
+      const deadlineMs = timeoutMs !== undefined ? this.timer.now() + timeoutMs : undefined;
+      const validationFailure = await this.validateFrameContext(key, keyCode, frameContext, deadlineMs);
+      if (validationFailure) {
+        return validationFailure;
       }
-      await this.adb.executeCommand(`shell input keyevent ${keyCode}`, timeoutMs, undefined, true);
+      const adbTimeoutMs = this.remainingMs(deadlineMs);
+      if (adbTimeoutMs !== undefined && adbTimeoutMs <= 0) {
+        return {
+          success: false,
+          key,
+          keyCode,
+          error: "input/key deadline exhausted before ADB keyevent",
+        };
+      }
+      await this.adb.executeCommand(`shell input keyevent ${keyCode}`, adbTimeoutMs, undefined, true);
       return {
         success: true,
         key,
@@ -100,5 +103,41 @@ export class InputKey {
         error: `Failed to press key "${key}": ${message}`,
       };
     }
+  }
+
+  private async validateFrameContext(
+    key: InputKeyName,
+    keyCode: string,
+    frameContext: string | undefined,
+    deadlineMs: number | undefined
+  ): Promise<InputKeyResult | undefined> {
+    if (frameContext === undefined) {
+      return undefined;
+    }
+    const validationTimeoutMs = this.remainingMs(deadlineMs);
+    if (validationTimeoutMs !== undefined && validationTimeoutMs <= 0) {
+      return {
+        success: false,
+        key,
+        keyCode,
+        error: "input/key deadline exhausted before frame context validation",
+      };
+    }
+    const validator = this.frameContextValidator ??
+      AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
+    const validation = await validator.validateFrameContext(frameContext, validationTimeoutMs);
+    if (validation.success) {
+      return undefined;
+    }
+    return {
+      success: false,
+      key,
+      keyCode,
+      error: validation.error ?? "Frame context is stale or unavailable; observe a fresh frame before retrying",
+    };
+  }
+
+  private remainingMs(deadlineMs: number | undefined): number | undefined {
+    return deadlineMs === undefined ? undefined : deadlineMs - this.timer.now();
   }
 }

--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -29,6 +29,8 @@ import { Keyboard } from "./Keyboard";
 
 export type InputTextMode = "a11y" | "eventLast" | "eventAll" | "eventOnly" | "append";
 
+export type AppendKeyEventValidator = () => Promise<{ success: boolean; error?: string }>;
+
 interface KeyboardCloser {
   close(): Promise<KeyboardResult>;
 }
@@ -338,9 +340,10 @@ export class InputText extends BaseVisualChange {
    */
   async appendText(
     text: string,
-    timeoutMs?: number
+    timeoutMs?: number,
+    beforeKeyEvent?: AppendKeyEventValidator
   ): Promise<SendTextResult & { method?: InputTextMode }> {
-    return this.executeAndroidAppendTextInput(text, undefined, false, timeoutMs);
+    return this.executeAndroidAppendTextInput(text, undefined, false, timeoutMs, beforeKeyEvent);
   }
 
   /**
@@ -370,7 +373,8 @@ export class InputText extends BaseVisualChange {
     text: string,
     imeAction?: ImeAction,
     dismissKeyboard: boolean = false,
-    timeoutMs?: number
+    timeoutMs?: number,
+    beforeKeyEvent?: AppendKeyEventValidator
   ): Promise<SendTextResult & { method?: InputTextMode }> {
     const remaining = this.createBudget(timeoutMs);
     const planned = await this.planAppendKeyEvents(text, remaining, timeoutMs);
@@ -379,7 +383,7 @@ export class InputText extends BaseVisualChange {
       return this.appendFailure(text, planned.error, 0);
     }
 
-    const typed = await this.typeAppendKeyEvents(planned.plans, remaining, timeoutMs);
+    const typed = await this.typeAppendKeyEvents(planned.plans, remaining, timeoutMs, beforeKeyEvent);
     if (typed.error) {
       // A non-timeout failure leaves an exact confirmed prefix, while a timed-out
       // key event is ambiguous: Android may have accepted it before adb was killed.
@@ -470,10 +474,29 @@ export class InputText extends BaseVisualChange {
   private async typeAppendKeyEvents(
     plans: KeyEventPlan[],
     remaining: () => number | undefined,
-    timeoutMs: number | undefined
+    timeoutMs: number | undefined,
+    beforeKeyEvent?: AppendKeyEventValidator
   ): Promise<{ charsSent?: number; error?: string }> {
     let charsSent = 0;
     for (const plan of plans) {
+      if (beforeKeyEvent) {
+        let validation: { success: boolean; error?: string };
+        try {
+          validation = await beforeKeyEvent();
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return {
+            charsSent,
+            error: `append frame context validation failed: ${message}`
+          };
+        }
+        if (!validation.success) {
+          return {
+            charsSent,
+            error: validation.error ?? "Frame context is stale or unavailable; observe a fresh frame before retrying"
+          };
+        }
+      }
       const budget = remaining();
       if (budget !== undefined && budget <= 0) {
         return { charsSent, error: this.appendBudgetExceeded(timeoutMs, "typing") };

--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -29,7 +29,7 @@ import { Keyboard } from "./Keyboard";
 
 export type InputTextMode = "a11y" | "eventLast" | "eventAll" | "eventOnly" | "append";
 
-export type AppendKeyEventValidator = () => Promise<{ success: boolean; error?: string }>;
+export type AppendKeyEventValidator = (timeoutMs?: number) => Promise<{ success: boolean; error?: string }>;
 
 interface KeyboardCloser {
   close(): Promise<KeyboardResult>;
@@ -341,9 +341,9 @@ export class InputText extends BaseVisualChange {
   async appendText(
     text: string,
     timeoutMs?: number,
-    beforeKeyEvent?: AppendKeyEventValidator
+    beforeKeyEvents?: AppendKeyEventValidator
   ): Promise<SendTextResult & { method?: InputTextMode }> {
-    return this.executeAndroidAppendTextInput(text, undefined, false, timeoutMs, beforeKeyEvent);
+    return this.executeAndroidAppendTextInput(text, undefined, false, timeoutMs, beforeKeyEvents);
   }
 
   /**
@@ -374,7 +374,7 @@ export class InputText extends BaseVisualChange {
     imeAction?: ImeAction,
     dismissKeyboard: boolean = false,
     timeoutMs?: number,
-    beforeKeyEvent?: AppendKeyEventValidator
+    beforeKeyEvents?: AppendKeyEventValidator
   ): Promise<SendTextResult & { method?: InputTextMode }> {
     const remaining = this.createBudget(timeoutMs);
     const planned = await this.planAppendKeyEvents(text, remaining, timeoutMs);
@@ -383,7 +383,7 @@ export class InputText extends BaseVisualChange {
       return this.appendFailure(text, planned.error, 0);
     }
 
-    const typed = await this.typeAppendKeyEvents(planned.plans, remaining, timeoutMs, beforeKeyEvent);
+    const typed = await this.typeAppendKeyEvents(planned.plans, remaining, timeoutMs, beforeKeyEvents);
     if (typed.error) {
       // A non-timeout failure leaves an exact confirmed prefix, while a timed-out
       // key event is ambiguous: Android may have accepted it before adb was killed.
@@ -475,32 +475,36 @@ export class InputText extends BaseVisualChange {
     plans: KeyEventPlan[],
     remaining: () => number | undefined,
     timeoutMs: number | undefined,
-    beforeKeyEvent?: AppendKeyEventValidator
+    beforeKeyEvents?: AppendKeyEventValidator
   ): Promise<{ charsSent?: number; error?: string }> {
     let charsSent = 0;
     for (const plan of plans) {
-      if (beforeKeyEvent) {
-        let validation: { success: boolean; error?: string };
-        try {
-          validation = await beforeKeyEvent();
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          return {
-            charsSent,
-            error: `append frame context validation failed: ${message}`
-          };
-        }
-        if (!validation.success) {
-          return {
-            charsSent,
-            error: validation.error ?? "Frame context is stale or unavailable; observe a fresh frame before retrying"
-          };
-        }
-      }
       const budget = remaining();
       if (budget !== undefined && budget <= 0) {
         return { charsSent, error: this.appendBudgetExceeded(timeoutMs, "typing") };
       }
+      let validationError: string | undefined;
+      const beforeDispatch = charsSent === 0 && beforeKeyEvents
+        ? async (remainingTimeoutMs?: number) => {
+          try {
+            const validation = await beforeKeyEvents(remainingTimeoutMs);
+            if (!validation.success) {
+              validationError = validation.error ??
+                "Frame context is stale or unavailable; observe a fresh frame before retrying";
+            }
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            validationError = `append frame context validation failed: ${message}`;
+          }
+          const budgetAfterValidation = remaining();
+          if (validationError === undefined && budgetAfterValidation !== undefined && budgetAfterValidation <= 0) {
+            validationError = this.appendBudgetExceeded(timeoutMs, "typing");
+          }
+          if (validationError) {
+            throw new Error(validationError);
+          }
+        }
+        : undefined;
       try {
         // noRetry: production AdbClient retries a timed-out command up to 4 total
         // attempts, each charged the SAME budget — and runInputOperationWithTimeout
@@ -508,8 +512,16 @@ export class InputText extends BaseVisualChange {
         // stalled key event would otherwise hold the queue for ~4x the request
         // deadline. A single attempt keeps this append's device operations within
         // one budget, including shared ADB-path discovery.
-        await this.executeKeyEventPlan(plan, budget, true);
+        await this.executeKeyEventPlan(
+          plan,
+          budget,
+          true,
+          beforeDispatch
+        );
       } catch (error) {
+        if (validationError) {
+          return { charsSent, error: validationError };
+        }
         const message = error instanceof Error ? error.message : String(error);
         logger.warn(`[InputText] append key event failed after ${charsSent} char(s): ${message}`, error);
         // An adb timeout kills the host child but cannot establish whether Android
@@ -736,10 +748,15 @@ export class InputText extends BaseVisualChange {
   private async executeKeyEventPlan(
     plan: KeyEventPlan,
     timeoutMs?: number,
-    noRetry: boolean = false
+    noRetry: boolean = false,
+    beforeDispatch?: (remainingTimeoutMs?: number) => Promise<void>
   ): Promise<void> {
-    for (const command of plan.commands) {
-      await this.adb.executeCommand(command, timeoutMs, undefined, noRetry);
+    for (const [index, command] of plan.commands.entries()) {
+      await this.adb.execute(command.split(" "), {
+        timeoutMs,
+        noRetry,
+        beforeDispatch: index === 0 ? beforeDispatch : undefined,
+      });
     }
   }
 

--- a/src/features/action/PressButton.ts
+++ b/src/features/action/PressButton.ts
@@ -133,7 +133,7 @@ export class PressButton extends BaseVisualChange {
       };
     }
 
-    await this.adb.executeCommand(`shell input keyevent ${keyCode}`, adbBudget);
+    await this.adb.executeCommand(`shell input keyevent ${keyCode}`, adbBudget, undefined, true);
     return { success: true, button, keyCode };
   }
 
@@ -162,8 +162,9 @@ export class PressButton extends BaseVisualChange {
         return { success: true, button, keyCode };
       }
       logger.debug(`[PRESS_BUTTON] Global action failed (${result.error}), falling back to ADB`);
-    } catch {
-      // Fall through to the validated ADB keyevent.
+    } catch (error) {
+      // The validated ADB fallback remains safe when the global-action RPC fails.
+      logger.debug(`[PRESS_BUTTON] Global action threw for ${button}, falling back to ADB: ${error}`);
     }
     return undefined;
   }

--- a/src/features/action/PressButton.ts
+++ b/src/features/action/PressButton.ts
@@ -114,11 +114,6 @@ export class PressButton extends BaseVisualChange {
       return globalActionResult;
     }
 
-    const validationFailure = await this.validateFrameContextBeforeAdb(button, keyCode, deadlineMs, frameContext);
-    if (validationFailure) {
-      return validationFailure;
-    }
-
     // Fail fast if the (optional) deadline was fully consumed by the global-action
     // attempt or frame-context validation above. Passing 0 to executeCommand would arm NO timeout (the
     // `if (timeoutMs)` check treats 0 as falsy), leaving the ADB keyevent
@@ -133,7 +128,39 @@ export class PressButton extends BaseVisualChange {
       };
     }
 
-    await this.adb.executeCommand(`shell input keyevent ${keyCode}`, adbBudget, undefined, true);
+    let validationFailure: PressButtonResult | undefined;
+    try {
+      await this.adb.execute(
+        ["shell", "input", "keyevent", String(keyCode)],
+        {
+          timeoutMs: adbBudget,
+          noRetry: true,
+          beforeDispatch: frameContext === undefined
+            ? undefined
+            : async () => {
+              validationFailure = await this.validateFrameContextBeforeAdb(button, keyCode, deadlineMs, frameContext);
+              if (validationFailure) {
+                throw new Error(validationFailure.error);
+              }
+              const remainingMs = this.remainingMs(deadlineMs);
+              if (remainingMs !== undefined && remainingMs <= 0) {
+                validationFailure = {
+                  success: false,
+                  button,
+                  keyCode: -1,
+                  error: `Button press deadline exhausted before ADB keyevent for ${button}`
+                };
+                throw new Error(validationFailure.error);
+              }
+            },
+        }
+      );
+    } catch (error) {
+      if (validationFailure) {
+        return validationFailure;
+      }
+      throw error;
+    }
     return { success: true, button, keyCode };
   }
 

--- a/src/features/action/PressButton.ts
+++ b/src/features/action/PressButton.ts
@@ -109,41 +109,21 @@ export class PressButton extends BaseVisualChange {
     // the (optional) global-action attempt and the ADB fallback so the caller's
     // timeout is not exceeded by the sum of the two per-transport defaults.
     const deadlineMs = timeoutMs !== undefined ? this.timer.now() + timeoutMs : undefined;
-    const remainingMs = (): number | undefined =>
-      deadlineMs !== undefined ? deadlineMs - this.timer.now() : undefined;
+    const globalActionResult = await this.tryAndroidGlobalAction(button, normalized, keyCode, deadlineMs, frameContext);
+    if (globalActionResult) {
+      return globalActionResult;
+    }
 
-    // Try accessibility service global action for supported buttons
-    if (PressButton.GLOBAL_ACTION_BUTTONS.has(normalized)) {
-      const budget = remainingMs();
-      // Skip straight to ADB if the deadline is already exhausted.
-      if (budget === undefined || budget > 0) {
-        const globalActionTimeout = budget === undefined
-          ? PressButton.GLOBAL_ACTION_TIMEOUT_MS
-          : Math.min(PressButton.GLOBAL_ACTION_TIMEOUT_MS, budget);
-        try {
-          const client = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
-          const result = await client.requestGlobalAction(
-            normalized,
-            globalActionTimeout,
-            undefined,
-            frameContext
-          );
-          if (result.success) {
-            logger.debug(`[PRESS_BUTTON] Used accessibility service for ${button}`);
-            return { success: true, button, keyCode };
-          }
-          logger.debug(`[PRESS_BUTTON] Global action failed (${result.error}), falling back to ADB`);
-        } catch {
-          // Fall through to ADB
-        }
-      }
+    const validationFailure = await this.validateFrameContextBeforeAdb(button, keyCode, deadlineMs, frameContext);
+    if (validationFailure) {
+      return validationFailure;
     }
 
     // Fail fast if the (optional) deadline was fully consumed by the global-action
-    // attempt above. Passing 0 to executeCommand would arm NO timeout (the
+    // attempt or frame-context validation above. Passing 0 to executeCommand would arm NO timeout (the
     // `if (timeoutMs)` check treats 0 as falsy), leaving the ADB keyevent
     // unbounded — the exact overrun this budget threading exists to prevent.
-    const adbBudget = remainingMs();
+    const adbBudget = this.remainingMs(deadlineMs);
     if (adbBudget !== undefined && adbBudget <= 0) {
       return {
         success: false,
@@ -155,6 +135,73 @@ export class PressButton extends BaseVisualChange {
 
     await this.adb.executeCommand(`shell input keyevent ${keyCode}`, adbBudget);
     return { success: true, button, keyCode };
+  }
+
+  private async tryAndroidGlobalAction(
+    button: string,
+    normalized: string,
+    keyCode: number,
+    deadlineMs: number | undefined,
+    frameContext: string | undefined
+  ): Promise<PressButtonResult | undefined> {
+    if (!PressButton.GLOBAL_ACTION_BUTTONS.has(normalized)) {
+      return undefined;
+    }
+    const budget = this.remainingMs(deadlineMs);
+    if (budget !== undefined && budget <= 0) {
+      return undefined;
+    }
+    const globalActionTimeout = budget === undefined
+      ? PressButton.GLOBAL_ACTION_TIMEOUT_MS
+      : Math.min(PressButton.GLOBAL_ACTION_TIMEOUT_MS, budget);
+    try {
+      const client = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
+      const result = await client.requestGlobalAction(normalized, globalActionTimeout, undefined, frameContext);
+      if (result.success) {
+        logger.debug(`[PRESS_BUTTON] Used accessibility service for ${button}`);
+        return { success: true, button, keyCode };
+      }
+      logger.debug(`[PRESS_BUTTON] Global action failed (${result.error}), falling back to ADB`);
+    } catch {
+      // Fall through to the validated ADB keyevent.
+    }
+    return undefined;
+  }
+
+  private async validateFrameContextBeforeAdb(
+    button: string,
+    keyCode: number,
+    deadlineMs: number | undefined,
+    frameContext: string | undefined
+  ): Promise<PressButtonResult | undefined> {
+    if (frameContext === undefined) {
+      return undefined;
+    }
+    const validationBudget = this.remainingMs(deadlineMs);
+    if (validationBudget !== undefined && validationBudget <= 0) {
+      return {
+        success: false,
+        button,
+        keyCode: -1,
+        error: `Button press deadline exhausted before frame context validation for ${button}`
+      };
+    }
+
+    const client = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
+    const validation = await client.validateFrameContext(frameContext, validationBudget);
+    if (validation.success) {
+      return undefined;
+    }
+    return {
+      success: false,
+      button,
+      keyCode: -1,
+      error: validation.error ?? "Frame context is stale or unavailable; observe a fresh frame before retrying"
+    };
+  }
+
+  private remainingMs(deadlineMs: number | undefined): number | undefined {
+    return deadlineMs === undefined ? undefined : deadlineMs - this.timer.now();
   }
 
   /**

--- a/src/utils/android-cmdline-tools/AdbClient.ts
+++ b/src/utils/android-cmdline-tools/AdbClient.ts
@@ -456,9 +456,9 @@ export class AdbClient implements AdbExecutor {
   }
 
   async execute(args: string[], options: AdbExecuteOptions = {}): Promise<ExecResult> {
-    const { timeoutMs, maxBuffer, noRetry, signal } = options;
+    const { timeoutMs, maxBuffer, noRetry, signal, beforeDispatch } = options;
     const startTime = this.timer.now();
-    const result = await this.executeArgsImpl(args, timeoutMs, maxBuffer, noRetry, signal);
+    const result = await this.executeArgsImpl(args, timeoutMs, maxBuffer, noRetry, signal, beforeDispatch);
     const duration = this.timer.now() - startTime;
     const command = args.join(" ");
 
@@ -692,7 +692,8 @@ export class AdbClient implements AdbExecutor {
     timeoutMs?: number,
     maxBuffer?: number,
     noRetry?: boolean,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    beforeDispatch?: (remainingTimeoutMs?: number) => Promise<void>
   ): Promise<ExecResult> {
     const startTime = this.timer.now();
     const resolvedSignal = signal ?? getAbortSignal();
@@ -707,6 +708,7 @@ export class AdbClient implements AdbExecutor {
     if (noRetry) {
       // No retry - just execute once
       try {
+        await beforeDispatch?.(this.getRemainingTimeoutMs(timeoutMs, startTime, command));
         const result = await this.execWithSignal(
           adbPath,
           fullArgs,
@@ -737,6 +739,7 @@ export class AdbClient implements AdbExecutor {
         if (resolvedSignal?.aborted) {
           throw this.getAbortError(resolvedSignal);
         }
+        await beforeDispatch?.(this.getRemainingTimeoutMs(timeoutMs, startTime, command));
         const result = await this.execWithSignal(
           adbPath,
           fullArgs,

--- a/src/utils/android-cmdline-tools/interfaces/AdbExecutor.ts
+++ b/src/utils/android-cmdline-tools/interfaces/AdbExecutor.ts
@@ -61,6 +61,12 @@ export interface AdbExecutor {
   ): Promise<ExecResult>;
 
   /**
+   * Get the device time in milliseconds since the Unix epoch.
+   * Falls back to the host time when device time cannot be retrieved.
+   */
+  getDeviceTimestampMs(): Promise<number>;
+
+  /**
    * Get the list of booted Android devices
    * @returns Promise with array of booted devices
    */

--- a/src/utils/android-cmdline-tools/interfaces/AdbExecutor.ts
+++ b/src/utils/android-cmdline-tools/interfaces/AdbExecutor.ts
@@ -27,6 +27,11 @@ export interface AdbExecuteOptions {
   maxBuffer?: number;
   noRetry?: boolean;
   signal?: AbortSignal;
+  /**
+   * Runs after ADB path resolution and immediately before a subprocess dispatch.
+   * Receives the remaining command budget, if one was supplied.
+   */
+  beforeDispatch?: (remainingTimeoutMs?: number) => Promise<void>;
 }
 
 export interface AdbSpawnOptions {

--- a/test/daemon/socketServerInputTypeText.test.ts
+++ b/test/daemon/socketServerInputTypeText.test.ts
@@ -903,8 +903,8 @@ describe("UnixSocketServer input/typeText", () => {
     });
   });
 
-  test("rejects stale context before append mode emits Android key events", async () => {
-    const appendText = mock(async () => ({ success: true, charsSent: 1 }));
+  test("rejects stale context after append capability discovery and before key events", async () => {
+    const adb = new ProductionShapedAdbExecutor(fakeTimer, { probeApiLevel: 31 });
     const validateFrameContext = mock(async () => ({
       success: false,
       error: "Stale frame context; observe a fresh frame before retrying",
@@ -915,7 +915,38 @@ describe("UnixSocketServer input/typeText", () => {
     })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
     PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
     server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
-    server.appendTextFactory = () => ({ appendText });
+    server.appendTextFactory = device => createAppendTextInput(device, adb, fakeTimer);
+    (server as unknown as { requireCurrentFrameContext: () => void }).requireCurrentFrameContext = () => {};
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/typeText", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      text: "A",
+      mode: "append",
+      frameContext: "epoch:2",
+    });
+
+    expect(response.success).toBe(false);
+    expect(response.error).toContain("Stale frame context");
+    expect(validateFrameContext).toHaveBeenCalledWith("epoch:2", 30_000);
+    expect(adb.probeCalls).toEqual([30_000]);
+    expect(adb.inputCommands()).toEqual([]);
+  });
+
+  test("does not emit append key events when validation exhausts the shared deadline", async () => {
+    const adb = new ScriptedAdbExecutor(fakeTimer);
+    const validateFrameContext = mock(async () => {
+      fakeTimer.advanceTime(30_000);
+      return { success: true };
+    });
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      validateFrameContext,
+      requestImeAction: mock(async () => ({ success: true, totalTimeMs: 1 })),
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    server.appendTextFactory = device => createAppendTextInput(device, adb, fakeTimer);
     (server as unknown as { requireCurrentFrameContext: () => void }).requireCurrentFrameContext = () => {};
     await server.start();
 
@@ -924,13 +955,49 @@ describe("UnixSocketServer input/typeText", () => {
       deviceId: "emulator-5554",
       text: "a",
       mode: "append",
-      frameContext: "epoch:2",
+      frameContext: "epoch:3",
     });
 
     expect(response.success).toBe(false);
-    expect(response.error).toContain("Stale frame context");
-    expect(validateFrameContext).toHaveBeenCalledWith("epoch:2", 30_000);
-    expect(appendText).not.toHaveBeenCalled();
+    expect(response.error).toContain("input/typeText exceeded 30000ms");
+    expect(validateFrameContext).toHaveBeenCalledWith("epoch:3", 30_000);
+    expect(adb.inputCommands()).toEqual([]);
+  });
+
+  test("reports confirmed append progress when later frame validation throws", async () => {
+    const adb = new ScriptedAdbExecutor(fakeTimer);
+    let validationCount = 0;
+    const validateFrameContext = mock(async () => {
+      validationCount += 1;
+      if (validationCount === 2) {
+        throw new Error("CtrlProxy disconnected");
+      }
+      return { success: true };
+    });
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      validateFrameContext,
+      requestImeAction: mock(async () => ({ success: true, totalTimeMs: 1 })),
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    server.appendTextFactory = device => createAppendTextInput(device, adb, fakeTimer);
+    (server as unknown as { requireCurrentFrameContext: () => void }).requireCurrentFrameContext = () => {};
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/typeText", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      text: "ab",
+      mode: "append",
+      frameContext: "epoch:4",
+    });
+
+    expect(response).toMatchObject({
+      success: false,
+      error: "append frame context validation failed: CtrlProxy disconnected",
+      charsSent: 1,
+    });
+    expect(adb.inputCommands()).toEqual(["shell input keyevent KEYCODE_A"]);
   });
 
   test("serializes concurrent typeText calls for the same device", async () => {

--- a/test/daemon/socketServerInputTypeText.test.ts
+++ b/test/daemon/socketServerInputTypeText.test.ts
@@ -903,6 +903,36 @@ describe("UnixSocketServer input/typeText", () => {
     });
   });
 
+  test("rejects stale context before append mode emits Android key events", async () => {
+    const appendText = mock(async () => ({ success: true, charsSent: 1 }));
+    const validateFrameContext = mock(async () => ({
+      success: false,
+      error: "Stale frame context; observe a fresh frame before retrying",
+    }));
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      validateFrameContext,
+      requestImeAction: mock(async () => ({ success: true, totalTimeMs: 1 })),
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([androidDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    server.appendTextFactory = () => ({ appendText });
+    (server as unknown as { requireCurrentFrameContext: () => void }).requireCurrentFrameContext = () => {};
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/typeText", {
+      platform: "android",
+      deviceId: "emulator-5554",
+      text: "a",
+      mode: "append",
+      frameContext: "epoch:2",
+    });
+
+    expect(response.success).toBe(false);
+    expect(response.error).toContain("Stale frame context");
+    expect(validateFrameContext).toHaveBeenCalledWith("epoch:2", 30_000);
+    expect(appendText).not.toHaveBeenCalled();
+  });
+
   test("serializes concurrent typeText calls for the same device", async () => {
     let inFlight = 0;
     let maxInFlight = 0;

--- a/test/daemon/socketServerInputTypeText.test.ts
+++ b/test/daemon/socketServerInputTypeText.test.ts
@@ -7,7 +7,7 @@ import { join } from "node:path";
 import { UnixSocketServer } from "../../src/daemon/socketServer";
 import { InputText } from "../../src/features/action/InputText";
 import type { BootedDevice, ExecResult } from "../../src/models";
-import type { AdbExecutor } from "../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
+import type { AdbExecuteOptions, AdbExecutor } from "../../src/utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { AdbCommandTimeoutError } from "../../src/utils/android-cmdline-tools/AdbClient";
 import { defaultTimer } from "../../src/utils/SystemTimer";
 import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
@@ -57,6 +57,11 @@ class ScriptedAdbExecutor {
       trim: () => stdout.trim(),
       includes: (search: string) => stdout.includes(search),
     } as unknown as ExecResult;
+  }
+
+  async execute(args: string[], options: AdbExecuteOptions = {}): Promise<ExecResult> {
+    await options.beforeDispatch?.(options.timeoutMs);
+    return this.executeCommand(args.join(" "), options.timeoutMs);
   }
 
   /**
@@ -964,14 +969,11 @@ describe("UnixSocketServer input/typeText", () => {
     expect(adb.inputCommands()).toEqual([]);
   });
 
-  test("reports confirmed append progress when later frame validation throws", async () => {
+  test("validates a multi-character append once before the first key event", async () => {
     const adb = new ScriptedAdbExecutor(fakeTimer);
     let validationCount = 0;
     const validateFrameContext = mock(async () => {
       validationCount += 1;
-      if (validationCount === 2) {
-        throw new Error("CtrlProxy disconnected");
-      }
       return { success: true };
     });
     AndroidCtrlProxyClient.getInstance = mock(() => ({
@@ -993,11 +995,14 @@ describe("UnixSocketServer input/typeText", () => {
     });
 
     expect(response).toMatchObject({
-      success: false,
-      error: "append frame context validation failed: CtrlProxy disconnected",
-      charsSent: 1,
+      success: true,
+      result: { success: true, textLength: 2 },
     });
-    expect(adb.inputCommands()).toEqual(["shell input keyevent KEYCODE_A"]);
+    expect(validationCount).toBe(1);
+    expect(adb.inputCommands()).toEqual([
+      "shell input keyevent KEYCODE_A",
+      "shell input keyevent KEYCODE_B",
+    ]);
   });
 
   test("serializes concurrent typeText calls for the same device", async () => {

--- a/test/fakes/FakeAdbClient.ts
+++ b/test/fakes/FakeAdbClient.ts
@@ -98,6 +98,7 @@ export class FakeAdbClient implements FakeAdbClientContract {
    * a test can configure a result via {@link setCommandResult}.
    */
   async execute(args: string[], options?: AdbExecuteOptions): Promise<ExecResult> {
+    await options?.beforeDispatch?.(options.timeoutMs);
     const command = args.join(" ");
     return this.executeCommand(
       command,

--- a/test/fakes/FakeAdbExecutor.ts
+++ b/test/fakes/FakeAdbExecutor.ts
@@ -220,6 +220,7 @@ export class FakeAdbExecutor implements AdbExecutor {
    * command history so existing pattern-based stubs keep matching.
    */
   async execute(args: string[], options: AdbExecuteOptions = {}): Promise<ExecResult> {
+    await options.beforeDispatch?.(options.timeoutMs);
     this.executedArgv.push([...args]);
     return this.executeCommand(
       args.join(" "),

--- a/test/features/action/InputKey.test.ts
+++ b/test/features/action/InputKey.test.ts
@@ -3,6 +3,7 @@ import { InputKey } from "../../../src/features/action/InputKey";
 import type { BootedDevice } from "../../../src/models";
 import type { AdbClientFactory } from "../../../src/utils/android-cmdline-tools/AdbClientFactory";
 import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
+import { FakeTimer } from "../../fakes/FakeTimer";
 
 const androidDevice: BootedDevice = {
   deviceId: "emulator-5554",
@@ -113,6 +114,52 @@ describe("InputKey", () => {
 
     expect(calls).toEqual([["epoch:3", 1234]]);
     expect(fakeAdb.getExecutedCommands()).toEqual(["shell input keyevent KEYCODE_TAB"]);
+  });
+
+  test("shares one deadline between frame validation and the ADB keyevent", async () => {
+    const fakeAdb = new FakeAdbExecutor();
+    const timer = new FakeTimer();
+    const validationTimeouts: number[] = [];
+    const validator = {
+      validateFrameContext: async (_frameContext: string, timeoutMs?: number) => {
+        validationTimeouts.push(timeoutMs ?? -1);
+        timer.advanceTime(400);
+        return { success: true };
+      },
+    };
+    const inputKey = new InputKey(androidDevice, createAdbFactory(fakeAdb), validator, timer);
+
+    const result = await inputKey.press("tab", 1_000, "epoch:4");
+
+    expect(result.success).toBe(true);
+    expect(validationTimeouts).toEqual([1_000]);
+    expect(fakeAdb.getCommandCalls()).toEqual([
+      {
+        command: "shell input keyevent KEYCODE_TAB",
+        timeoutMs: 600,
+        maxBuffer: undefined,
+        noRetry: true,
+        signal: undefined,
+      },
+    ]);
+  });
+
+  test("does not issue an ADB keyevent after validation exhausts the shared deadline", async () => {
+    const fakeAdb = new FakeAdbExecutor();
+    const timer = new FakeTimer();
+    const validator = {
+      validateFrameContext: async () => {
+        timer.advanceTime(1_000);
+        return { success: true };
+      },
+    };
+    const inputKey = new InputKey(androidDevice, createAdbFactory(fakeAdb), validator, timer);
+
+    const result = await inputKey.press("tab", 1_000, "epoch:5");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("deadline exhausted");
+    expect(fakeAdb.getExecutedCommands()).toEqual([]);
   });
 
   test("wraps an ADB keyevent failure in a stable error envelope", async () => {

--- a/test/features/action/InputKey.test.ts
+++ b/test/features/action/InputKey.test.ts
@@ -86,7 +86,7 @@ describe("InputKey", () => {
         error: "Stale frame context for input/key; observe a fresh frame before retrying",
       }),
     };
-    const inputKey = new InputKey(androidDevice, createAdbFactory(fakeAdb), validator);
+    const inputKey = new InputKey(androidDevice, createAdbFactory(fakeAdb), validator, new FakeTimer());
 
     const result = await inputKey.press("enter", 1234, "epoch:2");
 
@@ -108,7 +108,7 @@ describe("InputKey", () => {
         return { success: true };
       },
     };
-    const inputKey = new InputKey(androidDevice, createAdbFactory(fakeAdb), validator);
+    const inputKey = new InputKey(androidDevice, createAdbFactory(fakeAdb), validator, new FakeTimer());
 
     await inputKey.press("tab", 1234, "epoch:3");
 
@@ -136,7 +136,7 @@ describe("InputKey", () => {
     expect(fakeAdb.getCommandCalls()).toEqual([
       {
         command: "shell input keyevent KEYCODE_TAB",
-        timeoutMs: 600,
+        timeoutMs: 1_000,
         maxBuffer: undefined,
         noRetry: true,
         signal: undefined,

--- a/test/features/action/PressButton.android.test.ts
+++ b/test/features/action/PressButton.android.test.ts
@@ -44,6 +44,15 @@ describe("PressButton Android keycode dispatch", () => {
 
     expect(result).toEqual({ success: true, button, keyCode });
     expect(fakeAdb.getExecutedCommands()).toEqual([`shell input keyevent ${keyCode}`]);
+    expect(fakeAdb.getCommandCalls()).toEqual([
+      {
+        command: `shell input keyevent ${keyCode}`,
+        timeoutMs: undefined,
+        maxBuffer: undefined,
+        noRetry: true,
+        signal: undefined,
+      },
+    ]);
   });
 
   test("normalizes the button name case before resolving the keycode", async () => {

--- a/test/features/action/PressButton.android.test.ts
+++ b/test/features/action/PressButton.android.test.ts
@@ -81,4 +81,37 @@ describe("PressButton Android keycode dispatch", () => {
     expect(result).toEqual({ success: true, button, keyCode });
     expect(fakeAdb.getExecutedCommands()).toEqual([`shell input keyevent ${keyCode}`]);
   });
+
+  test("rejects a stale context instead of falling back from a failed global action to ADB", async () => {
+    getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+      requestGlobalAction: async () => ({ success: false, error: "global action unavailable" }),
+      validateFrameContext: async () => ({
+        success: false,
+        error: "Stale frame context; observe a fresh frame before retrying",
+      }),
+    } as unknown as AndroidCtrlProxyClient);
+
+    const pressButton = new PressButton(androidDevice, fakeAdb);
+    const result = await (pressButton as any).executeAndroidButtonPress("back", 500, "epoch:2");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Stale frame context");
+    expect(fakeAdb.getExecutedCommands()).toEqual([]);
+  });
+
+  test("validates a context before dispatching an ADB-only hardware button", async () => {
+    getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+      validateFrameContext: async () => ({
+        success: false,
+        error: "Stale frame context; observe a fresh frame before retrying",
+      }),
+    } as unknown as AndroidCtrlProxyClient);
+
+    const pressButton = new PressButton(androidDevice, fakeAdb);
+    const result = await (pressButton as any).executeAndroidButtonPress("volume_up", 500, "epoch:3");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Stale frame context");
+    expect(fakeAdb.getExecutedCommands()).toEqual([]);
+  });
 });

--- a/test/features/action/PressButton.test.ts
+++ b/test/features/action/PressButton.test.ts
@@ -106,8 +106,8 @@ describe("PressButton", () => {
     const fakeTimer = new FakeTimer();
     const capturedTimeouts: (number | undefined)[] = [];
     const fakeAdb = {
-      executeCommand: async (_command: string, timeoutMs?: number) => {
-        capturedTimeouts.push(timeoutMs);
+      execute: async (_args: string[], options?: { timeoutMs?: number }) => {
+        capturedTimeouts.push(options?.timeoutMs);
         return { stdout: "", stderr: "", toString: () => "", trim: () => "", includes: () => false };
       }
     } as any;
@@ -130,8 +130,8 @@ describe("PressButton", () => {
 
     const capturedTimeouts: (number | undefined)[] = [];
     const fakeAdb = {
-      executeCommand: async (_command: string, timeoutMs?: number) => {
-        capturedTimeouts.push(timeoutMs);
+      execute: async (_args: string[], options?: { timeoutMs?: number }) => {
+        capturedTimeouts.push(options?.timeoutMs);
         return { stdout: "", stderr: "", toString: () => "", trim: () => "", includes: () => false };
       }
     } as any;
@@ -165,8 +165,8 @@ describe("PressButton", () => {
     } as any);
 
     const fakeAdb = {
-      executeCommand: async (_command: string, timeoutMs?: number) => {
-        adbTimeouts.push(timeoutMs);
+      execute: async (_args: string[], options?: { timeoutMs?: number }) => {
+        adbTimeouts.push(options?.timeoutMs);
         return { stdout: "", stderr: "", toString: () => "", trim: () => "", includes: () => false };
       }
     } as any;

--- a/test/features/navigation/Explore.test.ts
+++ b/test/features/navigation/Explore.test.ts
@@ -486,8 +486,8 @@ describe("Explore", () => {
     test("uses injected Android recovery dependencies without nested progress", async () => {
       const commands: string[] = [];
       const adb = {
-        executeCommand: async (command: string) => {
-          commands.push(command);
+        execute: async (args: string[]) => {
+          commands.push(args.join(" "));
           return "";
         }
       } as AdbClient;
@@ -526,7 +526,7 @@ describe("Explore", () => {
         requestGlobalAction: async () => ({ success: false, error: "unavailable" })
       } as never);
       const adb = {
-        executeCommand: async () => { throw new Error("Back navigation was rejected"); }
+        execute: async () => { throw new Error("Back navigation was rejected"); }
       } as AdbClient;
       explore = new Explore(device, adb, fakeTimer, fakeGraph);
 
@@ -546,7 +546,7 @@ describe("Explore", () => {
         requestGlobalAction: async () => ({ success: false, error: "unavailable" })
       } as never);
       const adb = {
-        executeCommand: async () => { throw new Error("Home navigation was rejected"); }
+        execute: async () => { throw new Error("Home navigation was rejected"); }
       } as AdbClient;
       explore = new Explore(device, adb, fakeTimer, fakeGraph);
 
@@ -566,7 +566,7 @@ describe("Explore", () => {
         requestGlobalAction: async () => ({ success: false, error: "unavailable" })
       } as never);
       const adb = {
-        executeCommand: async () => { throw new Error("Back navigation was rejected"); }
+        execute: async () => { throw new Error("Back navigation was rejected"); }
       } as AdbClient;
       explore = new Explore(device, adb, fakeTimer, fakeGraph);
       (explore as any).observeScreen = {

--- a/test/utils/AccessibilityDetector.test.ts
+++ b/test/utils/AccessibilityDetector.test.ts
@@ -60,6 +60,10 @@ class FakeAdbExecutor implements AdbExecutor {
     return null;
   }
 
+  async getDeviceTimestampMs(): Promise<number> {
+    return 0;
+  }
+
   async getAdbPathOnly(): Promise<string> {
     return "adb";
   }

--- a/test/utils/android-cmdline-tools/AdbClient-executionContract.test.ts
+++ b/test/utils/android-cmdline-tools/AdbClient-executionContract.test.ts
@@ -23,6 +23,62 @@ function ok(stdout: string): ExecResult {
 }
 
 describe("AdbClient retry contract", () => {
+  test("runs beforeDispatch after path resolution and before the ADB subprocess", async () => {
+    const events: string[] = [];
+    const client = new AdbClient(
+      DEVICE,
+      async () => {
+        events.push("dispatch");
+        return ok("");
+      },
+      null,
+      defaultRetryExecutor,
+      new FakeTimer()
+    );
+    const internals = client as unknown as {
+      getBaseCommandParts: () => Promise<{ adbPath: string; baseArgs: string[] }>;
+    };
+    internals.getBaseCommandParts = async () => {
+      events.push("path-resolved");
+      return { adbPath: "adb", baseArgs: [] };
+    };
+
+    await client.execute(["shell", "input", "keyevent", "KEYCODE_TAB"], {
+      timeoutMs: 1234,
+      noRetry: true,
+      beforeDispatch: async timeoutMs => {
+        events.push(`validated:${timeoutMs}`);
+      },
+    });
+
+    expect(events).toEqual(["path-resolved", "validated:1234", "dispatch"]);
+  });
+
+  test("does not dispatch when beforeDispatch rejects", async () => {
+    let dispatches = 0;
+    const client = new AdbClient(
+      DEVICE,
+      async () => {
+        dispatches += 1;
+        return ok("");
+      },
+      null,
+      defaultRetryExecutor,
+      new FakeTimer()
+    );
+
+    await expect(
+      client.execute(["shell", "input", "keyevent", "KEYCODE_TAB"], {
+        noRetry: true,
+        beforeDispatch: async () => {
+          throw new Error("stale frame context");
+        },
+      })
+    ).rejects.toThrow("stale frame context");
+
+    expect(dispatches).toBe(0);
+  });
+
   test("retries a transient failure and succeeds within MAX_ADB_RETRIES", async () => {
     let calls = 0;
     const exec = (): Promise<ExecResult> => {


### PR DESCRIPTION
## Summary

- validate Android frame context immediately before every ADB button dispatch
- validate append-mode socket text inside the per-device keyed execution path
- share the `input/key` deadline between frame validation and the ADB keyevent

## Root Cause

The prior frame-context work validated global actions and daemon cache state, but an unsuccessful global action could fall through to an unvalidated ADB keyevent. Direct hardware buttons and append-mode text also reached ADB without a device-side context check. `input/key` granted validation and ADB separate full timeout budgets.

## Validation

- `bun test test/features/action/PressButton.android.test.ts test/features/action/PressButton.test.ts`
- `bun test test/features/action/InputKey.test.ts test/daemon/socketServerInputKey.test.ts`
- `bun test test/daemon/socketServerInputTypeText.test.ts test/daemon/socketServerInputPressButton.test.ts`
- `bun run lint`
- `bun run build`
- `./gradlew :control-proxy:testDebugUnitTest --tests dev.jasonpearson.automobile.ctrlproxy.CtrlProxyMessageHandlerTest`

Known unrelated validation failures on current `main`:

- `bun run typecheck` reports two existing `InputText.ts` errors for `AdbExecutor.getDeviceTimestampMs`.
- `bun run turbo:validate` runs 11,885 tests successfully, but five xcodegen-drift scenarios fail because their temporary fixture lacks `ios/control-proxy/project.yml`.

Closes [#4618](https://github.com/kaeawc/auto-mobile/issues/4618)
