### PR TITLE
fix(android): require fresh eventOnly focus hierarchy

### DIFF
--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -623,15 +623,16 @@ export class InputText extends BaseVisualChange {
       return viewHierarchy;
     }
 
-    const minTimestamp = typeof this.adb.getDeviceTimestampMs === "function"
-      ? await this.adb.getDeviceTimestampMs()
+    const minTimestamp = typeof viewHierarchy.updatedAt === "number"
+      ? viewHierarchy.updatedAt + 1
       : this.timer.now();
     const refreshedObserveResult = await this.observeScreen.execute({
       skipWaitForFresh: false,
       minTimestamp
     });
     const refreshedViewHierarchy = refreshedObserveResult.viewHierarchy;
-    return refreshedViewHierarchy && hasFocusedTextInput(refreshedViewHierarchy)
+    return refreshedObserveResult.freshness?.isFresh !== false &&
+      refreshedViewHierarchy && hasFocusedTextInput(refreshedViewHierarchy)
       ? refreshedViewHierarchy
       : undefined;
   }

--- a/test/features/action/InputText.test.ts
+++ b/test/features/action/InputText.test.ts
@@ -488,12 +488,11 @@ describe("InputText", () => {
   });
 
   test("eventOnly rejects after a refreshed hierarchy still lacks a focused editable field", async () => {
-    const adb = new FakeAdbExecutor();
-    adb.setDeviceTimestampMs(42);
-    const inputText = new InputText(androidDevice, adb);
+    const inputText = new InputText(androidDevice, new FakeAdbExecutor());
     const observeScreen = new FakeObserveScreen();
     const unfocused = {
       viewHierarchy: {
+        updatedAt: 42,
         hierarchy: {
           node: {
             class: "android.view.inputmethod.SoftInputWindow"
@@ -516,7 +515,96 @@ describe("InputText", () => {
     expect(result.error).toBe("eventOnly requires a focused editable field");
     expect(observeScreen.getExecuteCallCount()).toBe(1);
     expect(observeScreen.getExecuteOptions()[0]?.skipWaitForFresh).toBe(false);
-    expect(observeScreen.getExecuteOptions()[0]?.minTimestamp).toBe(42);
+    expect(observeScreen.getExecuteOptions()[0]?.minTimestamp).toBe(43);
+  });
+
+  test("eventOnly rejects a stale focused refresh from the same second without sending key events", async () => {
+    const factory = new FakeAdbClientFactory();
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+    const observeScreen = new FakeObserveScreen();
+    const staleCachedHierarchy = {
+      viewHierarchy: {
+        updatedAt: 1_700_000_000_500,
+        hierarchy: {
+          node: {
+            class: "android.view.inputmethod.SoftInputWindow"
+          }
+        }
+      }
+    } as ObserveResult;
+    observeScreen.setObserveSequence([
+      {
+        ...observeResultWithFocusedText("old"),
+        freshness: {
+          requestedAfter: 1_700_000_000_501,
+          actualTimestamp: 1_700_000_000_500,
+          isFresh: false,
+          staleDurationMs: 1
+        }
+      }
+    ]);
+    inputText.observeScreen = observeScreen;
+
+    const result = await testInputText(inputText).executeAndroidTextInput(
+      "next",
+      undefined,
+      false,
+      "eventOnly",
+      staleCachedHierarchy
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("eventOnly requires a focused editable field");
+    expect(observeScreen.getExecuteOptions()[0]?.minTimestamp).toBe(1_700_000_000_501);
+    expect(inputCommands(factory)).toEqual([]);
+  });
+
+  test("eventOnly accepts a newer fresh focused refresh", async () => {
+    const factory = new FakeAdbClientFactory();
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory);
+    const observeScreen = new FakeObserveScreen();
+    const staleCachedHierarchy = {
+      viewHierarchy: {
+        updatedAt: 1_700_000_000_500,
+        hierarchy: {
+          node: {
+            class: "android.view.inputmethod.SoftInputWindow"
+          }
+        }
+      }
+    } as ObserveResult;
+    observeScreen.setObserveSequence([
+      {
+        ...observeResultWithFocusedText("old"),
+        freshness: {
+          requestedAfter: 1_700_000_000_501,
+          actualTimestamp: 1_700_000_000_501,
+          isFresh: true
+        }
+      }
+    ]);
+    inputText.observeScreen = observeScreen;
+
+    const result = await testInputText(inputText).executeAndroidTextInput(
+      "next",
+      undefined,
+      false,
+      "eventOnly",
+      staleCachedHierarchy
+    );
+
+    expect(result.success).toBe(true);
+    expect(observeScreen.getExecuteOptions()[0]?.minTimestamp).toBe(1_700_000_000_501);
+    expect(inputCommands(factory)).toEqual([
+      "shell input keyevent KEYCODE_MOVE_END",
+      "shell input keyevent KEYCODE_DEL",
+      "shell input keyevent KEYCODE_DEL",
+      "shell input keyevent KEYCODE_DEL",
+      "shell input keyevent KEYCODE_N",
+      "shell input keyevent KEYCODE_E",
+      "shell input keyevent KEYCODE_X",
+      "shell input keyevent KEYCODE_T"
+    ]);
   });
 
   test("eventOnly delegates keyboard dismissal to the keyboard closer", async () => {


### PR DESCRIPTION
## Summary

Require Android `inputText` `eventOnly` retries to obtain a hierarchy strictly newer than the failed focused-field check. A refresh explicitly marked stale is rejected before any key events are dispatched.

## Linked Issue

Closes [#4617](https://github.com/kaeawc/auto-mobile/issues/4617)

## Bug / Regression Context

- **Prior attempts:** Follow-up to [PR #4600](https://github.com/kaeawc/auto-mobile/pull/4600).
- **Observed symptom:** A cached hierarchy from earlier in the same second could satisfy an inclusive timestamp retry, or a stale focused hierarchy could permit event-only input.
- **Repro steps / conditions:** A cached unfocused hierarchy fails the focused-editable check; a retry receives an earlier same-second or explicitly stale focused snapshot.

## Validation

- [x] `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-4617 bun test test/features/action/InputText.test.ts` passes: 39 tests.
- [x] `bun run lint` passes.
- [x] `bun run build` passes.
- [x] `bun run typecheck` reports no new errors against the 206-error baseline.
- [x] Tests use the existing `FakeObserveScreen` and `FakeAdbExecutor` seams.
- [x] No dependency or generic helper was added.
- [ ] `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-4617 bun run turbo:validate` is blocked by five failures in the unchanged `test/scripts/xcodegenDriftCheck.test.ts` fixture suite. The run otherwise passed lint, build, boundary checks, and 11,885 tests.
