### PR TITLE
fix(observe): retain gated scope metadata in skeleton responses

### DIFF
--- a/src/server/finalizeToolResponse.ts
+++ b/src/server/finalizeToolResponse.ts
@@ -299,6 +299,16 @@ export function finalizeToolResponse<T>(response: T, ctx: FinalizeToolResponseCo
     let served: ObserveResult = sanitized;
     if (resolveObserveProjection(ctx.args) === "skeleton") {
       served = sanitizeObserveResult(observeResult, { ...cfg, project: "skeleton" });
+      // Skeleton replaces the hierarchy, so scope's structural transforms cannot
+      // run afterward. Preserve only the requested dimensions withheld by flags.
+      if ((scopeConfig.gatedOff?.length ?? 0) > 0) {
+        served = applyObserveScopeExperiments(served, {
+          focus: false,
+          overview: false,
+          region: false,
+          gatedOff: scopeConfig.gatedOff,
+        });
+      }
     } else if (scopeActive) {
       served = applyObserveScopeExperiments(sanitized, scopeConfig);
     }

--- a/test/server/finalizeToolResponse.test.ts
+++ b/test/server/finalizeToolResponse.test.ts
@@ -1776,7 +1776,11 @@ describe("finalizeToolResponse", () => {
  * sanitized tree) intact and never touch internal tool-to-tool calls.
  */
 describe("finalizeToolResponse observe scope experiments (#4344)", () => {
+  let originalSkeleton: boolean;
+
   beforeEach(() => {
+    originalSkeleton = serverConfig.isObserveResultProjectSkeletonEnabled();
+    serverConfig.setObserveResultProjectSkeletonEnabled(false);
     serverConfig.setObserveFocusScopeEnabled(false);
     serverConfig.setObserveOverviewEnabled(false);
     serverConfig.setObserveRegionEnabled(false);
@@ -1784,6 +1788,7 @@ describe("finalizeToolResponse observe scope experiments (#4344)", () => {
   });
 
   afterEach(() => {
+    serverConfig.setObserveResultProjectSkeletonEnabled(originalSkeleton);
     serverConfig.setObserveFocusScopeEnabled(false);
     serverConfig.setObserveOverviewEnabled(false);
     serverConfig.setObserveRegionEnabled(false);
@@ -1855,6 +1860,44 @@ describe("finalizeToolResponse observe scope experiments (#4344)", () => {
     expect(out.observeScope?.applied).toContain("focus");
     expect(out.observeScope!.nodesAfter).toBeLessThan(out.observeScope!.nodesBefore);
     // text mirror agrees with structuredContent.
+    expect(finalized.content[0].text).toBe(stringifyToolResponse(finalized.structuredContent));
+  });
+
+  test("explicit skeleton projection preserves all-gated scope metadata without a scope transform", () => {
+    const finalized = finalizeToolResponse(createStructuredToolResponse(chromeObserve()), {
+      name: "observe",
+      args: {
+        project: "skeleton",
+        scope: { focus: true, region: true, overview: true },
+      },
+    });
+
+    const out = finalized.structuredContent as ObserveResult;
+    expect(out.skeleton).toEqual([]);
+    expect(out.viewHierarchy).toBeUndefined();
+    expect(out.elements).toBeUndefined();
+    expect(out.observeScope).toMatchObject({
+      applied: [],
+      gatedOff: ["focus", "region", "overview"],
+    });
+    expect(finalized.content[0].text).toBe(stringifyToolResponse(finalized.structuredContent));
+  });
+
+  test("flag-enabled skeleton preserves gated metadata without applying enabled scope transforms", () => {
+    serverConfig.setObserveResultProjectSkeletonEnabled(true);
+    serverConfig.setObserveFocusScopeEnabled(true);
+    const finalized = finalizeToolResponse(createStructuredToolResponse(chromeObserve()), {
+      name: "observe",
+      args: { scope: { focus: true, region: true } },
+    });
+
+    const out = finalized.structuredContent as ObserveResult;
+    expect(out.skeleton).toEqual([]);
+    expect(out.viewHierarchy).toBeUndefined();
+    expect(out.observeScope).toMatchObject({
+      applied: [],
+      gatedOff: ["region"],
+    });
     expect(finalized.content[0].text).toBe(stringifyToolResponse(finalized.structuredContent));
   });
 

--- a/test/server/observeOutputSchema.test.ts
+++ b/test/server/observeOutputSchema.test.ts
@@ -243,7 +243,14 @@ describe("observeResultSchema: parses real captures (#3025)", () => {
   });
 
   test("advertises requested scope dimensions gated off by server flags", () => {
-    expect(JSON.stringify(flattenTopLevelUnion(toJSONSchema(observeResultSchema)))).toContain("\"gatedOff\"");
+    const schema = flattenTopLevelUnion(toJSONSchema(observeResultSchema));
+    const properties = schema.properties as Record<string, unknown>;
+    const observeScope = properties.observeScope as { properties: Record<string, unknown> };
+    const gatedOff = observeScope.properties.gatedOff as {
+      items: { enum: string[] };
+    };
+
+    expect(gatedOff.items.enum).toEqual(["focus", "region", "overview"]);
   });
 });
 


### PR DESCRIPTION
## Summary

- Preserve `observeScope.gatedOff` when skeleton projection wins.
- Keep skeleton projection structurally unchanged by applying no focus, region, or overview transforms afterward.
- Cover explicit and flag-enabled skeleton projection, and validate the generated schema enum for `gatedOff`.

## Root Cause

`finalizeToolResponse` returned from the skeleton projection path before the scope experiment transform attached gated-off metadata. This made a deliberately gated request indistinguishable from an unscoped skeleton response.

Closes [#4616](https://github.com/kaeawc/auto-mobile/issues/4616)

## Validation

- `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-issue-4616 bun test test/server/finalizeToolResponse.test.ts test/server/observeOutputSchema.test.ts` (119 passing)
- `bun run typecheck` (no new errors)
- `bun run turbo:validate` completed lint, build, and boundary checks; its full test phase has five existing `xcodegenDriftCheck` fixture failures because the temporary test repository omits `ios/control-proxy/project.yml`. Publishing with this known unrelated failure was explicitly approved.
