### PR TITLE
fix: bind initial observation frame captures

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -938,6 +938,8 @@ export class Daemon {
       },
       convertToViewHierarchyResult: hierarchy =>
         client.convertToViewHierarchyResult(hierarchy as never),
+      recordInitialObservationStreamHierarchy: (hierarchy, captureSequence) =>
+        client.recordInitialObservationStreamHierarchy(hierarchy, captureSequence),
       requestScreenshotWithoutObservationStreamPush: (...args) =>
         client.requestScreenshotWithoutObservationStreamPush(...args),
     };

--- a/src/daemon/observationInitialFrame.ts
+++ b/src/daemon/observationInitialFrame.ts
@@ -152,7 +152,8 @@ async function pushAndroidInitialObservationFrame(
     client,
     dependencies.streamServer,
     viewHierarchy,
-    captureSequence
+    captureSequence,
+    frameContext
   );
 }
 
@@ -161,7 +162,8 @@ async function pushAndroidInitialScreenshot(
   client: ObservationStreamAndroidClient,
   streamServer: Pick<DeviceDataStreamSocketServer, "pushScreenshotUpdate">,
   viewHierarchy: ViewHierarchyResult,
-  captureSequence: number | null
+  captureSequence: number | null,
+  hierarchyFrameContext: string | undefined
 ): Promise<void> {
   const screenshot = await client.captureScreenshotForObservationStream();
   if (screenshot.success && screenshot.data) {
@@ -173,7 +175,7 @@ async function pushAndroidInitialScreenshot(
       dimensions.height,
       pickScreenshotMetadata(screenshot),
       {
-        ...(captureSequence === null ? {} : { captureSequence }),
+        ...captureSequenceOptions(captureSequence, hierarchyFrameContext, screenshot.frameContext),
         ...canonicalPixelScreenshotOptions(viewHierarchy),
         rotation: screenshot.rotation,
         ...(screenshot.frameContext === undefined ? {} : { frameContext: screenshot.frameContext }),
@@ -191,6 +193,27 @@ function canonicalPixelScreenshotOptions(
   hierarchy: ViewHierarchyResult
 ): { coordinateSpace: typeof COORDINATE_SPACE_PX } | Record<string, never> {
   return readScreenScaleMetadata(hierarchy) ? { coordinateSpace: COORDINATE_SPACE_PX } : {};
+}
+
+/**
+ * A screenshot captured after the paired hierarchy may describe a same-size new screen. When
+ * both device-authored contexts are present, only an exact match proves the old identity still
+ * applies. Legacy runners omit one or both contexts, so they retain the existing identity rule.
+ */
+function captureSequenceOptions(
+  captureSequence: number | null,
+  hierarchyFrameContext: string | undefined,
+  screenshotFrameContext: string | undefined
+): { captureSequence?: number } {
+  if (
+    captureSequence === null ||
+    (hierarchyFrameContext !== undefined &&
+      screenshotFrameContext !== undefined &&
+      hierarchyFrameContext !== screenshotFrameContext)
+  ) {
+    return {};
+  }
+  return { captureSequence };
 }
 
 async function getAndroidInitialHierarchy(
@@ -254,7 +277,7 @@ async function pushIosInitialObservationFrame(
       dimensions.height,
       metadataForScreenshotFormat(IOS_CTRLPROXY_SCREENSHOT_METADATA, screenshot.format),
       {
-        ...(captureSequence === null ? {} : { captureSequence }),
+        ...captureSequenceOptions(captureSequence, frameContext, screenshot.frameContext),
         ...canonicalPixelScreenshotOptions(viewHierarchy),
         rotation: screenshot.rotation,
         ...(screenshot.frameContext === undefined ? {} : { frameContext: screenshot.frameContext }),

--- a/src/daemon/observationInitialFrame.ts
+++ b/src/daemon/observationInitialFrame.ts
@@ -49,6 +49,10 @@ export interface ObservationStreamAndroidClient {
     timeoutMs?: number
   ): Promise<{ hierarchy: AccessibilityHierarchy; frameContext?: string } | null>;
   convertToViewHierarchyResult(hierarchy: AccessibilityHierarchy): ViewHierarchyResult;
+  recordInitialObservationStreamHierarchy(
+    hierarchy: ViewHierarchyResult,
+    captureSequence: number | null
+  ): void;
   captureScreenshotForObservationStream(): Promise<ScreenshotCaptureResult>;
 }
 
@@ -68,6 +72,10 @@ export interface ObservationStreamIosClient {
     timeoutMs?: number
   ): Promise<{ hierarchy: unknown; frameContext?: string } | null>;
   convertToViewHierarchyResult(hierarchy: unknown): ViewHierarchyResult;
+  recordInitialObservationStreamHierarchy(
+    hierarchy: ViewHierarchyResult,
+    captureSequence: number | null
+  ): void;
   requestScreenshotWithoutObservationStreamPush(timeoutMs?: number, perf?: PerformanceTracker): Promise<CtrlProxyScreenshotResult>;
 }
 
@@ -136,16 +144,24 @@ async function pushAndroidInitialObservationFrame(
 
   const viewHierarchy = client.convertToViewHierarchyResult(initialHierarchy.hierarchy);
   const frameContext = initialHierarchy.frameContext ?? viewHierarchy.frameContext;
-  dependencies.streamServer.pushHierarchyUpdate(device.deviceId, viewHierarchy, frameContext);
+  const captureSequence = dependencies.streamServer.pushHierarchyUpdate(device.deviceId, viewHierarchy, frameContext);
+  client.recordInitialObservationStreamHierarchy(viewHierarchy, captureSequence);
 
-  await pushAndroidInitialScreenshot(device.deviceId, client, dependencies.streamServer, viewHierarchy);
+  await pushAndroidInitialScreenshot(
+    device.deviceId,
+    client,
+    dependencies.streamServer,
+    viewHierarchy,
+    captureSequence
+  );
 }
 
 async function pushAndroidInitialScreenshot(
   deviceId: string,
   client: ObservationStreamAndroidClient,
   streamServer: Pick<DeviceDataStreamSocketServer, "pushScreenshotUpdate">,
-  viewHierarchy: ViewHierarchyResult
+  viewHierarchy: ViewHierarchyResult,
+  captureSequence: number | null
 ): Promise<void> {
   const screenshot = await client.captureScreenshotForObservationStream();
   if (screenshot.success && screenshot.data) {
@@ -157,6 +173,7 @@ async function pushAndroidInitialScreenshot(
       dimensions.height,
       pickScreenshotMetadata(screenshot),
       {
+        ...(captureSequence === null ? {} : { captureSequence }),
         ...canonicalPixelScreenshotOptions(viewHierarchy),
         rotation: screenshot.rotation,
         ...(screenshot.frameContext === undefined ? {} : { frameContext: screenshot.frameContext }),
@@ -224,7 +241,8 @@ async function pushIosInitialObservationFrame(
 
   const viewHierarchy = client.convertToViewHierarchyResult(initialHierarchy.hierarchy);
   const frameContext = initialHierarchy.frameContext ?? viewHierarchy.frameContext;
-  dependencies.streamServer.pushHierarchyUpdate(device.deviceId, viewHierarchy, frameContext);
+  const captureSequence = dependencies.streamServer.pushHierarchyUpdate(device.deviceId, viewHierarchy, frameContext);
+  client.recordInitialObservationStreamHierarchy(viewHierarchy, captureSequence);
 
   const screenshot = await client.requestScreenshotWithoutObservationStreamPush(INITIAL_FRAME_SCREENSHOT_TIMEOUT_MS);
   if (screenshot.success && screenshot.data) {
@@ -236,6 +254,7 @@ async function pushIosInitialObservationFrame(
       dimensions.height,
       metadataForScreenshotFormat(IOS_CTRLPROXY_SCREENSHOT_METADATA, screenshot.format),
       {
+        ...(captureSequence === null ? {} : { captureSequence }),
         ...canonicalPixelScreenshotOptions(viewHierarchy),
         rotation: screenshot.rotation,
         ...(screenshot.frameContext === undefined ? {} : { frameContext: screenshot.frameContext }),

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -3002,7 +3002,8 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   /**
    * Bind the hierarchy explicitly forwarded by the daemon's subscriber bootstrap. The request
    * suppressed this client's normal stream push, so it must replace any prior provenance before
-   * accepting the identity assigned by that explicit push.
+   * accepting the identity assigned by that explicit push, then start keepalives for a static
+   * screen.
    */
   recordInitialObservationStreamHierarchy(
     hierarchy: ViewHierarchyResult,
@@ -3013,6 +3014,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     if (captureSequence !== null) {
       this.screenGeometry.markForwarded(captureSequence);
     }
+    this.startScreenshotBackoff();
   }
 
   private pushScreenshotToObservationStream(

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -2999,6 +2999,22 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
     }
   }
 
+  /**
+   * Bind the hierarchy explicitly forwarded by the daemon's subscriber bootstrap. The request
+   * suppressed this client's normal stream push, so it must replace any prior provenance before
+   * accepting the identity assigned by that explicit push.
+   */
+  recordInitialObservationStreamHierarchy(
+    hierarchy: ViewHierarchyResult,
+    captureSequence: number | null
+  ): void {
+    this.screenGeometry.clear();
+    this.updateCachedScreenDimensions(hierarchy);
+    if (captureSequence !== null) {
+      this.screenGeometry.markForwarded(captureSequence);
+    }
+  }
+
   private pushScreenshotToObservationStream(
     screenshotBase64: string,
     metadata: ScreenshotMetadata = ANDROID_CTRLPROXY_SCREENSHOT_METADATA,

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -2086,6 +2086,22 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   }
 
   /**
+   * Bind the hierarchy explicitly forwarded by the daemon's subscriber bootstrap. The request
+   * suppressed this client's normal stream push, so it must replace any prior provenance before
+   * accepting the identity assigned by that explicit push.
+   */
+  recordInitialObservationStreamHierarchy(
+    hierarchy: ViewHierarchyResult,
+    captureSequence: number | null
+  ): void {
+    this.screenGeometry.clear();
+    this.updateScreenGeometryFrom(hierarchy);
+    if (captureSequence !== null) {
+      this.screenGeometry.markForwarded(captureSequence);
+    }
+  }
+
+  /**
    * Push screenshot update to the device data stream for IDE plugins.
    */
   private pushScreenshotToObservationStream(

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -2088,7 +2088,8 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   /**
    * Bind the hierarchy explicitly forwarded by the daemon's subscriber bootstrap. The request
    * suppressed this client's normal stream push, so it must replace any prior provenance before
-   * accepting the identity assigned by that explicit push.
+   * accepting the identity assigned by that explicit push, then start keepalives for a static
+   * screen.
    */
   recordInitialObservationStreamHierarchy(
     hierarchy: ViewHierarchyResult,
@@ -2099,6 +2100,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     if (captureSequence !== null) {
       this.screenGeometry.markForwarded(captureSequence);
     }
+    this.startScreenshotBackoff();
   }
 
   /**

--- a/test/daemon/observationInitialFrame.test.ts
+++ b/test/daemon/observationInitialFrame.test.ts
@@ -19,6 +19,8 @@ import type {
 import { loadCoordinateMappingVectors } from "../parity/coordinateMappingGoldenVectors";
 
 class FakeObservationStreamServer {
+  constructor(private readonly captureSequence: number | null = null) {}
+
   readonly hierarchyUpdates: Array<{
     deviceId: string;
     hierarchy: ViewHierarchyResult;
@@ -26,12 +28,13 @@ class FakeObservationStreamServer {
   }> = [];
   readonly screenshotUpdates: ScreenshotUpdate[] = [];
 
-  pushHierarchyUpdate(deviceId: string, hierarchy: ViewHierarchyResult, frameContext?: string): void {
+  pushHierarchyUpdate(deviceId: string, hierarchy: ViewHierarchyResult, frameContext?: string): number | null {
     this.hierarchyUpdates.push({
       deviceId,
       hierarchy,
       ...(frameContext === undefined ? {} : { frameContext }),
     });
+    return this.captureSequence;
   }
 
   pushScreenshotUpdate(
@@ -81,6 +84,10 @@ class FakeAndroidInitialFrameClient implements ObservationStreamAndroidClient {
     skipWaitForFresh?: boolean;
   }> = [];
   readonly suppressedSyncHierarchyCalls: Array<{ timeoutMs?: number }> = [];
+  readonly forwardedInitialHierarchies: Array<{
+    hierarchy: ViewHierarchyResult;
+    captureSequence: number | null;
+  }> = [];
   observationScreenshotCallCount = 0;
 
   constructor(
@@ -139,6 +146,13 @@ class FakeAndroidInitialFrameClient implements ObservationStreamAndroidClient {
     };
   }
 
+  recordInitialObservationStreamHierarchy(
+    hierarchy: ViewHierarchyResult,
+    captureSequence: number | null
+  ): void {
+    this.forwardedInitialHierarchies.push({ hierarchy, captureSequence });
+  }
+
   async captureScreenshotForObservationStream(): Promise<ScreenshotCaptureResult> {
     this.observationScreenshotCallCount += 1;
     return this.screenshot;
@@ -149,6 +163,10 @@ class FakeIosInitialFrameClient implements ObservationStreamIosClient {
   readonly syncHierarchyCalls: Array<{ timeoutMs?: number }> = [];
   readonly suppressedSyncHierarchyCalls: Array<{ timeoutMs?: number }> = [];
   readonly suppressedScreenshotCalls: Array<{ timeoutMs?: number }> = [];
+  readonly forwardedInitialHierarchies: Array<{
+    hierarchy: ViewHierarchyResult;
+    captureSequence: number | null;
+  }> = [];
 
   constructor(
     private readonly connected: boolean,
@@ -213,6 +231,13 @@ class FakeIosInitialFrameClient implements ObservationStreamIosClient {
         ? { frameContext: typedHierarchy.frameContext }
         : {}),
     };
+  }
+
+  recordInitialObservationStreamHierarchy(
+    hierarchy: ViewHierarchyResult,
+    captureSequence: number | null
+  ): void {
+    this.forwardedInitialHierarchies.push({ hierarchy, captureSequence });
   }
 
   async requestScreenshot(): Promise<CtrlProxyScreenshotResult> {
@@ -286,6 +311,55 @@ describe("pushInitialObservationFramesForSubscriber", () => {
     ]);
     expect(androidClient.suppressedSyncHierarchyCalls).toHaveLength(0);
     expect(androidClient.observationScreenshotCallCount).toBe(1);
+  });
+
+  it("binds the Android initial screenshot and later keepalives to its forwarded hierarchy", async () => {
+    const streamServer = new FakeObservationStreamServer(41);
+    const androidClient = new FakeAndroidInitialFrameClient(true, {
+      updatedAt: 123,
+      packageName: "com.example",
+      screenWidth: 1440,
+      screenHeight: 3120,
+      hierarchy: { text: "Static screen" },
+    });
+
+    await pushInitialObservationFramesForSubscriber(androidDevice.id, [androidDevice], {
+      streamServer,
+      androidClientFactory: () => androidClient,
+      iosClientFactory: () => {
+        throw new Error("unexpected iOS client");
+      },
+    });
+
+    expect(streamServer.screenshotUpdates[0].options).toEqual({ captureSequence: 41 });
+    expect(androidClient.forwardedInitialHierarchies).toEqual([
+      {
+        hierarchy: streamServer.hierarchyUpdates[0].hierarchy,
+        captureSequence: 41,
+      },
+    ]);
+  });
+
+  it("keeps Android initial-frame geometry fail-closed when no identity is assigned", async () => {
+    const streamServer = new FakeObservationStreamServer(null);
+    const androidClient = new FakeAndroidInitialFrameClient(true, {
+      updatedAt: 123,
+      packageName: "com.example",
+      screenWidth: 1440,
+      screenHeight: 3120,
+      hierarchy: { text: "Legacy runner" },
+    });
+
+    await pushInitialObservationFramesForSubscriber(androidDevice.id, [androidDevice], {
+      streamServer,
+      androidClientFactory: () => androidClient,
+      iosClientFactory: () => {
+        throw new Error("unexpected iOS client");
+      },
+    });
+
+    expect(streamServer.screenshotUpdates[0].options).toBeUndefined();
+    expect(androidClient.forwardedInitialHierarchies[0].captureSequence).toBeNull();
   });
 
   it("forwards proven Android initial-frame contexts", async () => {
@@ -535,6 +609,57 @@ describe("pushInitialObservationFramesForSubscriber", () => {
     expect(iosClient.syncHierarchyCalls).toHaveLength(0);
     expect(iosClient.suppressedSyncHierarchyCalls).toHaveLength(0);
     expect(iosClient.suppressedScreenshotCalls).toEqual([{ timeoutMs: 3000 }]);
+  });
+
+  it("binds the iOS initial screenshot and later keepalives to its forwarded hierarchy", async () => {
+    const streamServer = new FakeObservationStreamServer(42);
+    const iosClient = new FakeIosInitialFrameClient(true, {
+      updatedAt: 456,
+      packageName: "com.example.ios",
+      screenWidth: 390,
+      screenHeight: 844,
+      screenScale: 3,
+      hierarchy: { text: "Static screen" },
+    });
+
+    await pushInitialObservationFramesForSubscriber(iosDevice.id, [iosDevice], {
+      streamServer,
+      androidClientFactory: () => {
+        throw new Error("unexpected Android client");
+      },
+      iosClientFactory: () => iosClient,
+    });
+
+    expect(streamServer.screenshotUpdates[0].options).toEqual({ captureSequence: 42 });
+    expect(iosClient.forwardedInitialHierarchies).toEqual([
+      {
+        hierarchy: streamServer.hierarchyUpdates[0].hierarchy,
+        captureSequence: 42,
+      },
+    ]);
+  });
+
+  it("keeps iOS initial-frame geometry fail-closed when no identity is assigned", async () => {
+    const streamServer = new FakeObservationStreamServer(null);
+    const iosClient = new FakeIosInitialFrameClient(true, {
+      updatedAt: 456,
+      packageName: "com.example.ios",
+      screenWidth: 390,
+      screenHeight: 844,
+      screenScale: 3,
+      hierarchy: { text: "Legacy runner" },
+    });
+
+    await pushInitialObservationFramesForSubscriber(iosDevice.id, [iosDevice], {
+      streamServer,
+      androidClientFactory: () => {
+        throw new Error("unexpected Android client");
+      },
+      iosClientFactory: () => iosClient,
+    });
+
+    expect(streamServer.screenshotUpdates[0].options).toBeUndefined();
+    expect(iosClient.forwardedInitialHierarchies[0].captureSequence).toBeNull();
   });
 
   it("forwards proven iOS initial-frame contexts", async () => {

--- a/test/daemon/observationInitialFrame.test.ts
+++ b/test/daemon/observationInitialFrame.test.ts
@@ -363,7 +363,7 @@ describe("pushInitialObservationFramesForSubscriber", () => {
   });
 
   it("forwards proven Android initial-frame contexts", async () => {
-    const streamServer = new FakeObservationStreamServer();
+    const streamServer = new FakeObservationStreamServer(43);
     const androidClient = new FakeAndroidInitialFrameClient(
       true,
       {
@@ -379,7 +379,7 @@ describe("pushInitialObservationFramesForSubscriber", () => {
       {
         success: true,
         data: "android-shot",
-        frameContext: "android-screenshot",
+        frameContext: "android-hierarchy",
       }
     );
 
@@ -392,7 +392,41 @@ describe("pushInitialObservationFramesForSubscriber", () => {
     });
 
     expect(streamServer.hierarchyUpdates[0].frameContext).toBe("android-hierarchy");
-    expect(streamServer.screenshotUpdates[0].frameContext).toBe("android-screenshot");
+    expect(streamServer.screenshotUpdates[0].frameContext).toBe("android-hierarchy");
+    expect(streamServer.screenshotUpdates[0].options).toMatchObject({ captureSequence: 43 });
+  });
+
+  it("omits the Android initial capture sequence when frame contexts conflict", async () => {
+    const streamServer = new FakeObservationStreamServer(43);
+    const androidClient = new FakeAndroidInitialFrameClient(
+      true,
+      {
+        updatedAt: 123,
+        packageName: "com.example",
+        screenWidth: 1440,
+        screenHeight: 3120,
+        hierarchy: { text: "Screen A" },
+        frameContext: "android-screen-a",
+      } as any,
+      undefined,
+      true,
+      {
+        success: true,
+        data: "android-shot",
+        frameContext: "android-screen-b",
+      }
+    );
+
+    await pushInitialObservationFramesForSubscriber(androidDevice.id, [androidDevice], {
+      streamServer,
+      androidClientFactory: () => androidClient,
+      iosClientFactory: () => {
+        throw new Error("unexpected iOS client");
+      },
+    });
+
+    expect(streamServer.screenshotUpdates[0].options).toBeUndefined();
+    expect(streamServer.screenshotUpdates[0].frameContext).toBe("android-screen-b");
   });
 
   it("pushes Android initial ADB fallback screenshots with fallback metadata", async () => {
@@ -663,7 +697,7 @@ describe("pushInitialObservationFramesForSubscriber", () => {
   });
 
   it("forwards proven iOS initial-frame contexts", async () => {
-    const streamServer = new FakeObservationStreamServer();
+    const streamServer = new FakeObservationStreamServer(44);
     const iosClient = new FakeIosInitialFrameClient(
       true,
       {
@@ -676,7 +710,7 @@ describe("pushInitialObservationFramesForSubscriber", () => {
         frameContext: "ios-hierarchy",
       } as any,
       undefined,
-      { success: true, data: "ios-shot", format: "png", frameContext: "ios-screenshot" }
+      { success: true, data: "ios-shot", format: "png", frameContext: "ios-hierarchy" }
     );
 
     await pushInitialObservationFramesForSubscriber(iosDevice.id, [iosDevice], {
@@ -688,7 +722,37 @@ describe("pushInitialObservationFramesForSubscriber", () => {
     });
 
     expect(streamServer.hierarchyUpdates[0].frameContext).toBe("ios-hierarchy");
-    expect(streamServer.screenshotUpdates[0].frameContext).toBe("ios-screenshot");
+    expect(streamServer.screenshotUpdates[0].frameContext).toBe("ios-hierarchy");
+    expect(streamServer.screenshotUpdates[0].options).toMatchObject({ captureSequence: 44 });
+  });
+
+  it("omits the iOS initial capture sequence when frame contexts conflict", async () => {
+    const streamServer = new FakeObservationStreamServer(44);
+    const iosClient = new FakeIosInitialFrameClient(
+      true,
+      {
+        updatedAt: 456,
+        packageName: "com.example.ios",
+        screenWidth: 390,
+        screenHeight: 844,
+        screenScale: 3,
+        hierarchy: { text: "Screen A" },
+        frameContext: "ios-screen-a",
+      } as any,
+      undefined,
+      { success: true, data: "ios-shot", format: "png", frameContext: "ios-screen-b" }
+    );
+
+    await pushInitialObservationFramesForSubscriber(iosDevice.id, [iosDevice], {
+      streamServer,
+      androidClientFactory: () => {
+        throw new Error("unexpected Android client");
+      },
+      iosClientFactory: () => iosClient,
+    });
+
+    expect(streamServer.screenshotUpdates[0].options).toBeUndefined();
+    expect(streamServer.screenshotUpdates[0].frameContext).toBe("ios-screen-b");
   });
 
   it("captures iOS hierarchy synchronously when the initial cache is empty", async () => {

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -3112,6 +3112,9 @@ describe("AndroidCtrlProxyClient", function() {
     // identity onto fresh pixels, and a control client would map a tap through stale bounds.
 
     test("binds an explicitly forwarded initial hierarchy for later static-screen screenshots", () => {
+      let backoffStarts = 0;
+      (accessibilityServiceClient as any).startScreenshotBackoff = () => { backoffStarts++; };
+
       accessibilityServiceClient.recordInitialObservationStreamHierarchy(
         hierarchyWithScreenSize(1080, 2340),
         41
@@ -3122,6 +3125,7 @@ describe("AndroidCtrlProxyClient", function() {
         width: 1080,
         height: 2340,
       });
+      expect(backoffStarts).toBe(1);
     });
 
     test("drops stale provenance when an initial hierarchy has no assigned identity", () => {

--- a/test/features/observe/CtrlProxyClient.test.ts
+++ b/test/features/observe/CtrlProxyClient.test.ts
@@ -3111,6 +3111,32 @@ describe("AndroidCtrlProxyClient", function() {
     // hierarchy carrying it. Claiming it otherwise lets the daemon stamp an older capture's
     // identity onto fresh pixels, and a control client would map a tap through stale bounds.
 
+    test("binds an explicitly forwarded initial hierarchy for later static-screen screenshots", () => {
+      accessibilityServiceClient.recordInitialObservationStreamHierarchy(
+        hierarchyWithScreenSize(1080, 2340),
+        41
+      );
+
+      expect((accessibilityServiceClient as any).screenGeometry.bind()).toEqual({
+        captureSequence: 41,
+        width: 1080,
+        height: 2340,
+      });
+    });
+
+    test("drops stale provenance when an initial hierarchy has no assigned identity", () => {
+      const geometry = (accessibilityServiceClient as any).screenGeometry;
+      geometry.update(1080, 2340);
+      geometry.markForwarded(40);
+
+      accessibilityServiceClient.recordInitialObservationStreamHierarchy(
+        hierarchyWithScreenSize(1080, 2340),
+        null
+      );
+
+      expect(geometry.bind()).toBeNull();
+    });
+
     test("claims provenance after a hierarchy is forwarded to the observation stream", async () => {
       const socket = await startStreamServerWithScreenshotSubscriber();
 

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -2727,6 +2727,36 @@ describe("IOSCtrlProxyClient", function() {
     // The iOS ordering rule: geometry must be derived from a hierarchy BEFORE it is pushed, so the
     // identity the daemon assigns is recorded against the geometry it actually describes.
 
+    test("binds an explicitly forwarded initial hierarchy for later static-screen screenshots", function() {
+      ctrlProxyClient.recordInitialObservationStreamHierarchy({
+        hierarchy: {},
+        screenWidth: 390,
+        screenHeight: 844,
+        screenScale: 3,
+      }, 42);
+
+      expect((ctrlProxyClient as any).screenGeometry.bind()).toEqual({
+        captureSequence: 42,
+        width: 1170,
+        height: 2532,
+      });
+    });
+
+    test("drops stale provenance when an initial hierarchy has no assigned identity", function() {
+      const geometry = (ctrlProxyClient as any).screenGeometry;
+      geometry.update(1170, 2532);
+      geometry.markForwarded(41);
+
+      ctrlProxyClient.recordInitialObservationStreamHierarchy({
+        hierarchy: {},
+        screenWidth: 390,
+        screenHeight: 844,
+        screenScale: 3,
+      }, null);
+
+      expect(geometry.bind()).toBeNull();
+    });
+
     const startStreamServer = async (): Promise<FakeSocket> => {
       await stopDeviceDataStreamSocketServer();
       const server = await startDeviceDataStreamSocketServer(fakeTimer);

--- a/test/features/observe/ios/IOSCtrlProxyClient.test.ts
+++ b/test/features/observe/ios/IOSCtrlProxyClient.test.ts
@@ -2728,6 +2728,9 @@ describe("IOSCtrlProxyClient", function() {
     // identity the daemon assigns is recorded against the geometry it actually describes.
 
     test("binds an explicitly forwarded initial hierarchy for later static-screen screenshots", function() {
+      let backoffStarts = 0;
+      (ctrlProxyClient as any).startScreenshotBackoff = () => { backoffStarts++; };
+
       ctrlProxyClient.recordInitialObservationStreamHierarchy({
         hierarchy: {},
         screenWidth: 390,
@@ -2740,6 +2743,7 @@ describe("IOSCtrlProxyClient", function() {
         width: 1170,
         height: 2532,
       });
+      expect(backoffStarts).toBe(1);
     });
 
     test("drops stale provenance when an initial hierarchy has no assigned identity", function() {


### PR DESCRIPTION
## Summary

Thread the capture sequence returned by an initial hierarchy update into its paired screenshot on Android and iOS. The bootstrap path now refreshes each client's tracked geometry binding after its suppressed hierarchy request, clearing stale provenance when the stream cannot assign an identity.

## Linked Issue

Closes [#4608](https://github.com/kaeawc/auto-mobile/issues/4608)

## Bug / Regression Context

- **Prior attempts:** The regular hierarchy forwarding paths already bind capture provenance, but the subscriber bootstrap intentionally suppresses those forwards.
- **Observed symptom:** A static screen receives an initial hierarchy followed by an unbound screenshot, so desktop control remains unavailable.
- **Repro steps / conditions:** Subscribe to the observation stream while a device screen does not subsequently emit another hierarchy update.

## Validation

- [x] Focused daemon, Android, and iOS provenance suites pass: 191 tests.
- [x] `bun run typecheck` reports no new errors.
- [x] New code uses existing interfaces, fakes, and FakeTimer-backed unit tests.
- [x] Rebased onto latest `main` before creating the isolated branch.
- [ ] `bun run turbo:validate` is blocked only by five existing XcodeGen drift-fixture tests. The fixtures omit `ios/control-proxy/project.yml`, so XcodeGen exits before each test's intended assertion. Lint, build, boundary checks, and the remaining 11,891 tests passed.

## Device Verification

- [ ] Not run. Coverage is limited to deterministic daemon and platform-client tests.
