### PR TITLE
Fix session-scoped tool discovery refresh

### DIFF
--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -478,11 +478,10 @@ export class UnixSocketServer {
           const forwardStartMs = this.timer.now();
           try {
             const mcpClient = await this.getMcpClient(forwardKey);
+            this.recordBoundMcpClientKey(request, sessionId, forwardKey);
 
             try {
-              const response = await this.handleIdeRequest(mcpClient, request, remainingTimeoutMs, sessionId);
-              this.recordBoundMcpClientKey(request, sessionId, forwardKey);
-              return response;
+              return await this.handleIdeRequest(mcpClient, request, remainingTimeoutMs, sessionId);
             } catch (ideError) {
               const ideErrorMessage = ideError instanceof Error ? ideError.message : String(ideError);
               if (ideErrorMessage.includes("Session not found")) {
@@ -499,8 +498,8 @@ export class UnixSocketServer {
                     detail: `no budget remaining after session reconnect (elapsed ${this.timer.now() - forwardStartMs}ms)`,
                   });
                 }
-                const response = await this.handleIdeRequest(freshClient, request, retryRemainingMs, sessionId);
                 this.recordBoundMcpClientKey(request, sessionId, forwardKey);
+                const response = await this.handleIdeRequest(freshClient, request, retryRemainingMs, sessionId);
                 return response;
               }
               throw ideError;

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -39,7 +39,12 @@ import { DaemonStateAccess, handleDaemonRequest } from "./daemonRequestHandlers"
 import { Timer, defaultTimer } from "../utils/SystemTimer";
 import type { FeatureFlagService } from "../features/featureFlags/FeatureFlagService";
 import type { FeatureFlagKey } from "../features/featureFlags/FeatureFlagDefinitions";
-import { getSessionToolProfileService, TOOL_CAPABILITIES, type ToolCapability } from "../features/toolCapabilities/SessionToolProfileService";
+import {
+  getSessionToolProfileService,
+  TOOL_CAPABILITIES,
+  type SessionToolProfileService,
+  type ToolCapability,
+} from "../features/toolCapabilities/SessionToolProfileService";
 import { getMcpServerVersion } from "../utils/mcpVersion";
 import {
   IOS_CTRL_PROXY_APP_HASH,
@@ -162,6 +167,12 @@ export class UnixSocketServer {
   private daemonState: DaemonStateAccess;
   private mcpClients: Map<string, Client> = new Map();
   private mcpClientPromises: Map<string, Promise<Client>> = new Map();
+  /**
+   * The loopback MCP client that a socket transport most recently bound with a
+   * device session. `tools/list` carries no arguments, so this preserves the
+   * client-local session context selected by the preceding device-aware call.
+   */
+  private boundMcpClientKeysBySocketSession: Map<string, string> = new Map();
   /** Promise tails that serialize MCP HTTP forwards only within the same target key. */
   private mcpForwardTails: Map<string, Promise<void>> = new Map();
   private mcpClientIdleTimers: Map<string, NodeJS.Timeout> = new Map();
@@ -169,6 +180,7 @@ export class UnixSocketServer {
   private featureFlagService: FeatureFlagService | null;
   private readonly handshakeEnforced: boolean;
   private readonly daemonIdentity: DaemonSelfIdentity;
+  private readonly sessionToolProfileService?: Pick<SessionToolProfileService, "setEnabled">;
   /**
    * Factory that `getMcpClient()` calls to open the loopback MCP HTTP client.
    * Defaults to the real {@link createMcpClient}; tests assign a fake here to
@@ -212,7 +224,11 @@ export class UnixSocketServer {
     daemonState: DaemonStateAccess = DaemonState.getInstance(),
     timer: Timer = defaultTimer,
     featureFlagService: FeatureFlagService | null = null,
-    handshakeConfig: { identity?: DaemonSelfIdentity; enforce?: boolean } = {}
+    handshakeConfig: {
+      identity?: DaemonSelfIdentity;
+      enforce?: boolean;
+      sessionToolProfileService?: Pick<SessionToolProfileService, "setEnabled">;
+    } = {}
   ) {
     this.socketPath = socketPath;
     this.mcpEndpoint = mcpEndpoint;
@@ -220,6 +236,7 @@ export class UnixSocketServer {
     this.timer = timer;
     this.featureFlagService = featureFlagService;
     this.handshakeEnforced = handshakeConfig.enforce ?? DAEMON_HANDSHAKE_ENABLED;
+    this.sessionToolProfileService = handshakeConfig.sessionToolProfileService;
     this.daemonIdentity = handshakeConfig.identity ?? {
       version: DAEMON_VERSION,
       build: getCurrentBuildIdentity(),
@@ -326,6 +343,7 @@ export class UnixSocketServer {
       this.sessions.delete(sessionId);
       this.clientSockets.delete(sessionId);
       this.notificationSubscribers.delete(sessionId);
+      this.boundMcpClientKeysBySocketSession.delete(sessionId);
     });
 
     socket.on("error", error => {
@@ -333,6 +351,7 @@ export class UnixSocketServer {
       this.sessions.delete(sessionId);
       this.clientSockets.delete(sessionId);
       this.notificationSubscribers.delete(sessionId);
+      this.boundMcpClientKeysBySocketSession.delete(sessionId);
       if (!socket.destroyed) {
         socket.destroy();
       }
@@ -461,7 +480,9 @@ export class UnixSocketServer {
             const mcpClient = await this.getMcpClient(forwardKey);
 
             try {
-              return await this.handleIdeRequest(mcpClient, request, remainingTimeoutMs, sessionId);
+              const response = await this.handleIdeRequest(mcpClient, request, remainingTimeoutMs, sessionId);
+              this.recordBoundMcpClientKey(request, sessionId, forwardKey);
+              return response;
             } catch (ideError) {
               const ideErrorMessage = ideError instanceof Error ? ideError.message : String(ideError);
               if (ideErrorMessage.includes("Session not found")) {
@@ -478,7 +499,9 @@ export class UnixSocketServer {
                     detail: `no budget remaining after session reconnect (elapsed ${this.timer.now() - forwardStartMs}ms)`,
                   });
                 }
-                return await this.handleIdeRequest(freshClient, request, retryRemainingMs, sessionId);
+                const response = await this.handleIdeRequest(freshClient, request, retryRemainingMs, sessionId);
+                this.recordBoundMcpClientKey(request, sessionId, forwardKey);
+                return response;
               }
               throw ideError;
             }
@@ -599,6 +622,10 @@ export class UnixSocketServer {
       return `socket:${socketSessionId}`;
     }
 
+    if (request.method === "tools/list") {
+      return this.boundMcpClientKeysBySocketSession.get(socketSessionId) ?? `method:${request.method}`;
+    }
+
     if (request.method === "ide/getNavigationGraph") {
       return this.getRequestArgumentScopeKey(request.params) ?? `method:${request.method}`;
     }
@@ -609,6 +636,28 @@ export class UnixSocketServer {
     }
 
     return `method:${request.method}`;
+  }
+
+  private recordBoundMcpClientKey(
+    request: DaemonRequest,
+    socketSessionId: string,
+    forwardKey: string
+  ): void {
+    if (request.method !== "tools/call") {
+      return;
+    }
+    const sessionUuid = this.getSessionUuid(request.params?.arguments);
+    if (sessionUuid) {
+      this.boundMcpClientKeysBySocketSession.set(socketSessionId, forwardKey);
+    }
+  }
+
+  private getSessionUuid(args: unknown): string | undefined {
+    if (!args || typeof args !== "object" || Array.isArray(args)) {
+      return undefined;
+    }
+    const sessionUuid = (args as Record<string, unknown>).sessionUuid;
+    return typeof sessionUuid === "string" && sessionUuid.length > 0 ? sessionUuid : undefined;
   }
 
   private getRequestArgumentScopeKey(args: unknown): string | undefined {
@@ -773,7 +822,9 @@ export class UnixSocketServer {
         if (!args.sessionUuid || !TOOL_CAPABILITIES.includes(args.capability as ToolCapability) || typeof args.enabled !== "boolean") {
           throw new Error("setSessionToolCapability requires sessionUuid, a known capability, and enabled boolean params");
         }
-        await getSessionToolProfileService().setEnabled(args.sessionUuid, args.capability as ToolCapability, args.enabled);
+        await (this.sessionToolProfileService ?? getSessionToolProfileService())
+          .setEnabled(args.sessionUuid, args.capability as ToolCapability, args.enabled);
+        ListChangedBroadcaster.emit("tools");
         return { sessionUuid: args.sessionUuid, capability: args.capability, enabled: args.enabled };
       }
       case "ide/ping": {
@@ -2072,6 +2123,7 @@ export class UnixSocketServer {
     const clients = Array.from(this.mcpClients.entries());
     this.mcpClients.clear();
     this.mcpClientPromises.clear();
+    this.boundMcpClientKeysBySocketSession.clear();
     for (const timer of this.mcpClientIdleTimers.values()) {
       this.timer.clearTimeout(timer);
     }

--- a/src/server/SessionToolBinding.ts
+++ b/src/server/SessionToolBinding.ts
@@ -1,0 +1,22 @@
+export class SessionToolBinding {
+  private readonly boundDeviceSessions = new Map<string, string>();
+
+  effectiveSessionUuid(mcpSessionId: string | undefined, params?: unknown): string | undefined {
+    const explicit = params && typeof params === "object" && !Array.isArray(params)
+      ? (params as Record<string, unknown>).sessionUuid
+      : undefined;
+    return typeof explicit === "string"
+      ? explicit
+      : mcpSessionId
+        ? this.boundDeviceSessions.get(mcpSessionId)
+        : undefined;
+  }
+
+  bind(mcpSessionId: string | undefined, sessionUuid: string | undefined): boolean {
+    if (!mcpSessionId || !sessionUuid || this.boundDeviceSessions.get(mcpSessionId) === sessionUuid) {
+      return false;
+    }
+    this.boundDeviceSessions.set(mcpSessionId, sessionUuid);
+    return true;
+  }
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -10,6 +10,7 @@ import { defaultTimer } from "../utils/SystemTimer";
 import { executionTracker } from "./executionTracker";
 import { runWithAbortSignal } from "../utils/AbortContext";
 import { createDefaultPlanExecutionLock, type PlanExecutionLock } from "./PlanExecutionLock";
+import { SessionToolBinding } from "./SessionToolBinding";
 
 // Import the tool registry
 import { ToolRegistry, toolHasOutputSchema } from "./toolRegistry";
@@ -66,7 +67,10 @@ import { registerFeatureFlagResources } from "./featureFlagResources";
 import { registerNetworkResources } from "./networkResources";
 import { FeatureFlagService } from "../features/featureFlags/FeatureFlagService";
 import { startupBenchmark } from "../utils/startupBenchmark";
-import { getSessionToolProfileService } from "../features/toolCapabilities/SessionToolProfileService";
+import {
+  getSessionToolProfileService,
+  type SessionToolProfileService,
+} from "../features/toolCapabilities/SessionToolProfileService";
 import { TOOL_CAPABILITY_BY_NAME } from "../features/toolCapabilities/toolCapabilityMap";
 
 export interface McpServerOptions {
@@ -74,19 +78,15 @@ export interface McpServerOptions {
   sessionContext?: { sessionId?: string };
   planExecutionLock?: PlanExecutionLock;
   daemonMode?: boolean;
+  sessionToolProfileService?: Pick<SessionToolProfileService, "isEnabled">;
 }
 
 const INTERNAL_MCP_SESSION_PARAM = "__mcpSessionId";
-const boundDeviceSessions = new Map<string, string>();
-
-function effectiveSessionUuid(mcpSessionId: string | undefined, params?: unknown): string | undefined {
-  const explicit = params && typeof params === "object" && !Array.isArray(params)
-    ? (params as Record<string, unknown>).sessionUuid
-    : undefined;
-  return typeof explicit === "string" ? explicit : mcpSessionId ? boundDeviceSessions.get(mcpSessionId) : undefined;
-}
-
-async function isToolVisibleForSession(name: string, sessionUuid: string | undefined): Promise<boolean> {
+async function isToolVisibleForSession(
+  name: string,
+  sessionUuid: string | undefined,
+  sessionToolProfileService?: Pick<SessionToolProfileService, "isEnabled">
+): Promise<boolean> {
   const capability = TOOL_CAPABILITY_BY_NAME.get(name);
   // Before the first device-aware call, no session has been selected and the
   // persisted profile is not applicable. Avoid opening the profile database
@@ -94,7 +94,7 @@ async function isToolVisibleForSession(name: string, sessionUuid: string | undef
   if (!capability || !sessionUuid) {
     return true;
   }
-  return getSessionToolProfileService().isEnabled(sessionUuid, capability);
+  return (sessionToolProfileService ?? getSessionToolProfileService()).isEnabled(sessionUuid, capability);
 }
 
 function extractInternalMcpSessionId(params: unknown): string | undefined {
@@ -175,6 +175,7 @@ export function formatToolParamError(toolName: string, error: unknown): string {
 }
 
 export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
+  const sessionToolBinding = new SessionToolBinding();
   // Plan execution lock with per-session scope to prevent interference during executePlan
   // Each test thread gets its own sessionUuid, enabling parallel execution on different devices
   const planExecutionLock = options.planExecutionLock ?? createDefaultPlanExecutionLock();
@@ -283,11 +284,11 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
 
   // Register tool definitions using the lower-level interface
   server.server.setRequestHandler(ListToolsRequestSchema, async () => {
-    const sessionUuid = effectiveSessionUuid(options.sessionContext?.sessionId);
+    const sessionUuid = sessionToolBinding.effectiveSessionUuid(options.sessionContext?.sessionId);
     const definitions = ToolRegistry.getToolDefinitions();
     return {
       tools: (await Promise.all(definitions.map(async definition =>
-        await isToolVisibleForSession(definition.name, sessionUuid) ? definition : undefined
+        await isToolVisibleForSession(definition.name, sessionUuid, options.sessionToolProfileService) ? definition : undefined
       ))).filter((definition): definition is typeof definitions[number] => definition !== undefined)
     };
   });
@@ -321,9 +322,9 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     }
 
     const sessionId = options.sessionContext?.sessionId;
-    const sessionUuid = effectiveSessionUuid(sessionId, toolParams);
+    const sessionUuid = sessionToolBinding.effectiveSessionUuid(sessionId, toolParams);
 
-    if (!await isToolVisibleForSession(name, sessionUuid)) {
+    if (!await isToolVisibleForSession(name, sessionUuid, options.sessionToolProfileService)) {
       const capability = TOOL_CAPABILITY_BY_NAME.get(name);
       throw new ActionableError(`Tool ${name} requires the '${capability}' capability for device session ${sessionUuid ?? "(not yet bound)"}.`);
     }
@@ -343,9 +344,8 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
         ? (toolParams as { sessionUuid?: string }).sessionUuid
         : undefined;
     const providedSessionUuid = typeof rawSessionUuid === "string" ? rawSessionUuid : undefined;
-    if (sessionId && providedSessionUuid && boundDeviceSessions.get(sessionId) !== providedSessionUuid) {
-      boundDeviceSessions.set(sessionId, providedSessionUuid);
-      try { server.sendToolListChanged(); } catch (error) { logger.warn(`Failed to refresh session tool list: ${error}`); }
+    if (sessionToolBinding.bind(sessionId, providedSessionUuid)) {
+      ToolRegistry.notifyToolListChanged();
     }
 
     // Check if tool call should be blocked due to active executePlan in this session

--- a/test/daemon/socketServerFeatureFlags.test.ts
+++ b/test/daemon/socketServerFeatureFlags.test.ts
@@ -11,6 +11,7 @@ import { FakeFeatureFlagRepository } from "../fakes/FakeFeatureFlagRepository";
 import { FakeFeatureFlagApplier } from "../fakes/FakeFeatureFlagApplier";
 import { FakeTimer } from "../fakes/FakeTimer";
 import type { DaemonResponse } from "../../src/daemon/types";
+import { ListChangedBroadcaster } from "../../src/server/listChangedBroadcast";
 
 function createTestService(): FeatureFlagService {
   return new FeatureFlagService(
@@ -149,5 +150,44 @@ describe("UnixSocketServer feature flag handlers", () => {
 
     expect(response.success).toBe(false);
     expect(response.error).toContain("Unknown feature flag");
+  });
+
+  test("ide/setSessionToolCapability persists then broadcasts a tools list refresh", async () => {
+    const writes: Array<{ sessionUuid: string; capability: string; enabled: boolean }> = [];
+    const profileService = {
+      setEnabled: async (sessionUuid: string, capability: string, enabled: boolean) => {
+        writes.push({ sessionUuid, capability, enabled });
+      },
+    };
+    await server.close();
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createFakeDaemonState(),
+      fakeTimer,
+      featureFlagService,
+      { sessionToolProfileService: profileService }
+    );
+    await server.start();
+
+    const emitted: string[] = [];
+    const unsubscribe = ListChangedBroadcaster.subscribe(kind => emitted.push(kind));
+    try {
+      const response = await sendRequest(socketPath, "ide/setSessionToolCapability", {
+        sessionUuid: "device-session-1",
+        capability: "clipboard",
+        enabled: false,
+      });
+
+      expect(response.success).toBe(true);
+      expect(writes).toEqual([{
+        sessionUuid: "device-session-1",
+        capability: "clipboard",
+        enabled: false,
+      }]);
+      expect(emitted).toEqual(["tools"]);
+    } finally {
+      unsubscribe();
+    }
   });
 });

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -166,6 +166,55 @@ function sendTwoToolsCallsOnOneSocket(socketPath: string, toolName: string): Pro
   });
 }
 
+class PersistentSocketClient {
+  private readonly socket = new Socket();
+  private buffer = "";
+  private readonly responses = new Map<string, DaemonResponse>();
+  private readonly waiters = new Map<string, (response: DaemonResponse) => void>();
+
+  async connect(socketPath: string): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      this.socket.connect(socketPath, resolve);
+      this.socket.on("error", reject);
+      this.socket.on("data", data => {
+        this.buffer += data.toString();
+        const lines = this.buffer.split("\n");
+        this.buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          if (!line.trim()) {
+            continue;
+          }
+          const response = JSON.parse(line) as DaemonResponse;
+          const waiter = this.waiters.get(response.id);
+          if (waiter) {
+            this.waiters.delete(response.id);
+            waiter(response);
+          } else {
+            this.responses.set(response.id, response);
+          }
+        }
+      });
+    });
+  }
+
+  request(method: string, params: Record<string, unknown>): Promise<DaemonResponse> {
+    const id = randomUUID();
+    this.socket.write(JSON.stringify({ id, type: "mcp_request", method, params }) + "\n");
+    const buffered = this.responses.get(id);
+    if (buffered) {
+      this.responses.delete(id);
+      return Promise.resolve(buffered);
+    }
+    return new Promise(resolve => {
+      this.waiters.set(id, resolve);
+    });
+  }
+
+  close(): void {
+    this.socket.destroy();
+  }
+}
+
 describe("UnixSocketServer MCP forward serialization", () => {
   let socketPath: string;
   let server: UnixSocketServer;
@@ -230,6 +279,53 @@ describe("UnixSocketServer MCP forward serialization", () => {
     expect(b.success).toBe(true);
     expect(maxInFlight).toBe(1);
     expect(inFlight).toBe(0);
+  });
+
+  test("routes tools/list through the client bound by an earlier session-aware call on the same socket", async () => {
+    await server.close();
+    socketPath = join(tmpdir(), `mcp-session-list-${randomUUID()}.sock`);
+    fakeTimer = new FakeTimer();
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createFakeDaemonState(sessionDevices, sessionDeviceLabels, mcpAutolockSessions),
+      fakeTimer,
+    );
+    await server.start();
+
+    const clients: FakeMcpClient[] = [];
+    server.mcpClientFactory = async () => {
+      const clientIndex = clients.length;
+      const client: FakeMcpClient = {
+        listTools: async () => ({ tools: [{ name: `client-${clientIndex}` }] }),
+        callTool: async () => ({ content: [] }),
+        listResources: async () => ({ resources: [] }),
+        readResource: async () => ({ contents: [] }),
+        listResourceTemplates: async () => ({ resourceTemplates: [] }),
+        close: async () => {},
+      };
+      clients.push(client);
+      return client;
+    };
+
+    const client = new PersistentSocketClient();
+    await client.connect(socketPath);
+    try {
+      const initialList = await client.request("tools/list", {});
+      const call = await client.request("tools/call", {
+        name: "observe",
+        arguments: { sessionUuid: "session-a" },
+      });
+      const refreshedList = await client.request("tools/list", {});
+
+      expect(initialList.success).toBe(true);
+      expect(initialList.result).toEqual({ tools: [{ name: "client-0" }] });
+      expect(call.success).toBe(true);
+      expect(refreshedList.success).toBe(true);
+      expect(refreshedList.result).toEqual({ tools: [{ name: "client-1" }] });
+    } finally {
+      client.close();
+    }
   });
 
   test("explicit device targets serialize even when session UUIDs differ", async () => {

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -328,6 +328,52 @@ describe("UnixSocketServer MCP forward serialization", () => {
     }
   });
 
+  test("keeps the bound client for tools/list when the session-aware call returns an error", async () => {
+    await server.close();
+    socketPath = join(tmpdir(), `mcp-session-list-error-${randomUUID()}.sock`);
+    fakeTimer = new FakeTimer();
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createFakeDaemonState(sessionDevices, sessionDeviceLabels, mcpAutolockSessions),
+      fakeTimer,
+    );
+    await server.start();
+
+    const clients: FakeMcpClient[] = [];
+    server.mcpClientFactory = async () => {
+      const clientIndex = clients.length;
+      const client: FakeMcpClient = {
+        listTools: async () => ({ tools: [{ name: `client-${clientIndex}` }] }),
+        callTool: async () => {
+          throw new Error("invalid tool arguments");
+        },
+        listResources: async () => ({ resources: [] }),
+        readResource: async () => ({ contents: [] }),
+        listResourceTemplates: async () => ({ resourceTemplates: [] }),
+        close: async () => {},
+      };
+      clients.push(client);
+      return client;
+    };
+
+    const client = new PersistentSocketClient();
+    await client.connect(socketPath);
+    try {
+      await client.request("tools/list", {});
+      const failedCall = await client.request("tools/call", {
+        name: "observe",
+        arguments: { sessionUuid: "session-a" },
+      });
+      const refreshedList = await client.request("tools/list", {});
+
+      expect(failedCall.success).toBe(false);
+      expect(refreshedList.result).toEqual({ tools: [{ name: "client-1" }] });
+    } finally {
+      client.close();
+    }
+  });
+
   test("explicit device targets serialize even when session UUIDs differ", async () => {
     let inFlight = 0;
     let maxInFlight = 0;

--- a/test/server/sessionToolDiscovery.test.ts
+++ b/test/server/sessionToolDiscovery.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { SessionToolBinding } from "../../src/server/SessionToolBinding";
+
+describe("session-scoped tool discovery", () => {
+  test("does not leak a bound session to another MCP server with the same transport session ID", async () => {
+    const serverA = new SessionToolBinding();
+    const serverB = new SessionToolBinding();
+
+    expect(serverA.bind("reused-transport-id", "device-session-a")).toBe(true);
+    expect(serverA.effectiveSessionUuid("reused-transport-id")).toBe("device-session-a");
+    expect(serverB.effectiveSessionUuid("reused-transport-id")).toBeUndefined();
+  });
+
+  test("only reports a refresh when a session binding changes", () => {
+    const binding = new SessionToolBinding();
+
+    expect(binding.bind("transport", "device-session-a")).toBe(true);
+    expect(binding.bind("transport", "device-session-a")).toBe(false);
+    expect(binding.bind("transport", "device-session-b")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Route a proxy transport's post-bind `tools/list` through its session-bound loopback MCP client. Bindings are now owned by each MCP server instance, and session capability updates broadcast `notifications/tools/list_changed` after persistence so connected proxies invalidate cached discovery results.

## Linked Issue

Closes [#4610](https://github.com/kaeawc/auto-mobile/issues/4610)

## Bug / Regression Context

- **Prior attempts:** [#4601](https://github.com/kaeawc/auto-mobile/pull/4601) added persisted session-scoped capabilities but left proxy `tools/list` on a shared unbound client.
- **Observed symptom:** A session-aware tool call could bind successfully while the next proxied tool list still advertised the unbound capability surface.
- **Repro steps / conditions:** Make a device-aware call with `sessionUuid`, then request `tools/list` through the same daemon proxy transport.

## Validation

- [x] Focused daemon proxy, notification, and binding-lifecycle tests
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run typecheck` with no new errors
- [ ] `bun run turbo:validate` is blocked by five existing XcodeGen fixture tests: their copied fixture is missing `ios/control-proxy/project.yml`, so generation cannot start
- [x] New code uses interfaces/fakes/FakeTimer; focused unit coverage is deterministic
- [ ] `main` advanced after branch creation with unrelated `InputText` changes; merge-base review found no validation or enforcement changes that require a rebase
