### PR TITLE
fix(navigation): select target app graph

### DIFF
--- a/scripts/ios/navigation-graph-sdk-event-integration.sh
+++ b/scripts/ios/navigation-graph-sdk-event-integration.sh
@@ -55,7 +55,7 @@ curl --fail --silent --show-error --max-time 5 "http://127.0.0.1:${ctrl_proxy_po
 # `doctor` above may have started the shared CtrlProxy client while it was
 # unbound. Bind it to this graph session before posting events so its SDK-event
 # poller cannot consume them into the global NavigationGraphManager.
-if ! auto-mobile --debug --cli --session-uuid "${session_uuid}" observe --platform ios --deviceId "${device_id}" >/dev/null; then
+if ! auto-mobile --debug --embedded-sdk --cli --session-uuid "${session_uuid}" observe --platform ios --deviceId "${device_id}" >/dev/null; then
   echo "error: could not bind iOS SDK events to navigation graph session" >&2
   exit 1
 fi
@@ -88,12 +88,12 @@ curl --fail --silent --show-error --max-time 5 \
 # relying on its background poll leaves a race on a busy Simulator runner.
 # Query through the public, daemon-backed tool until the batched events appear.
 for attempt in 1 2 3 4 5; do
-  if ! auto-mobile --debug --cli --session-uuid "${session_uuid}" observe --platform ios --deviceId "${device_id}" >/dev/null; then
+  if ! auto-mobile --debug --embedded-sdk --cli --session-uuid "${session_uuid}" observe --platform ios --deviceId "${device_id}" >/dev/null; then
     echo "observe refresh attempt ${attempt} failed; retrying in 2s..." >&2
     sleep 2
     continue
   fi
-  if ! graph="$(auto-mobile --debug --cli --session-uuid "${session_uuid}" getNavigationGraph --platform ios --deviceId "${device_id}")"; then
+  if ! graph="$(auto-mobile --debug --embedded-sdk --cli --session-uuid "${session_uuid}" getNavigationGraph --platform ios --deviceId "${device_id}")"; then
     echo "getNavigationGraph attempt ${attempt} failed; retrying in 2s..." >&2
     sleep 2
     continue

--- a/scripts/ios/navigation-graph-sdk-event-integration.sh
+++ b/scripts/ios/navigation-graph-sdk-event-integration.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 device_id="${1:?usage: navigation-graph-sdk-event-integration.sh <simulator-udid>}"
 timestamp_ms="$(($(date +%s) * 1000))"
-bundle_id="dev.jasonpearson.automobile.issue4460"
+bundle_id="com.apple.reminders"
 home_screen="Issue4460Home"
 detail_screen="Issue4460Detail"
 # Keep the runner's SDK-event consumer and the public graph query in one session. Each CLI
@@ -56,6 +56,14 @@ ctrl_proxy_port_for_device() {
 ctrl_proxy_port="$(ctrl_proxy_port_for_device)"
 
 curl --fail --silent --show-error --max-time 5 "http://127.0.0.1:${ctrl_proxy_port}/health" >/dev/null
+
+# The graph query selects the target device's latest observed foreground app.
+# Keep the injected SDK events and the following observations scoped to the
+# same installed app instead of letting a SpringBoard observation hide them.
+if ! auto-mobile --debug --embedded-sdk --cli --session-uuid "${session_uuid}" launchApp --platform ios --appId "${bundle_id}" --deviceId "${device_id}" >/dev/null; then
+  echo "error: could not launch iOS graph target app" >&2
+  exit 1
+fi
 
 # `doctor` above may have started the shared CtrlProxy client while it was
 # unbound. Bind it to this graph session before posting events so its SDK-event

--- a/scripts/ios/navigation-graph-sdk-event-integration.sh
+++ b/scripts/ios/navigation-graph-sdk-event-integration.sh
@@ -30,22 +30,26 @@ require_command xcrun
 
 xcrun simctl getenv "${device_id}" HOME >/dev/null
 
-# CtrlProxy allocates a per-device host port; 8765 is only its preferred default
-# and may already belong to another local service. Ask the daemon that warmed the
-# runner for the selected simulator's reported port instead of probing a stale
-# default. `doctor` can exit non-zero for unrelated diagnostics, but still emits
-# the JSON report that contains this ready runner's round-trip result.
-doctor_report="$(auto-mobile --cli doctor --ios --json || true)"
-ctrl_proxy_port="$(jq -er --arg device_id "${device_id}" '
-  .ios.checks[]
-  | select(.name == "iOS Observe Round Trip")
-  | .message
-  | split(" | ")
-  | map(select(contains("device=" + $device_id + ";")))
-  | .[0]
-  | capture("runnerPort=(?<port>[0-9]+)")
-  | .port
-' <<<"${doctor_report}")" || {
+ctrl_proxy_port_for_device() {
+  # CtrlProxy allocates a per-device host port; 8765 is only its preferred
+  # default and may already belong to another local service. `doctor` can exit
+  # non-zero for unrelated diagnostics, but still emits the JSON round-trip
+  # report that contains this ready runner's port.
+  local doctor_report
+  doctor_report="$(auto-mobile --cli doctor --ios --json || true)"
+  jq -er --arg device_id "${device_id}" '
+    .ios.checks[]
+    | select(.name == "iOS Observe Round Trip")
+    | .message
+    | split(" | ")
+    | map(select(contains("device=" + $device_id + ";")))
+    | .[0]
+    | capture("runnerPort=(?<port>[0-9]+)")
+    | .port
+  ' <<<"${doctor_report}"
+}
+
+ctrl_proxy_port="$(ctrl_proxy_port_for_device)" || {
   echo "error: could not determine CtrlProxy port for simulator ${device_id}" >&2
   exit 1
 }
@@ -59,6 +63,14 @@ if ! auto-mobile --debug --embedded-sdk --cli --session-uuid "${session_uuid}" o
   echo "error: could not bind iOS SDK events to navigation graph session" >&2
   exit 1
 fi
+
+# Requesting debug and embedded-SDK tools can restart the daemon. That restart
+# creates a new CtrlProxy client, so the prior daemon's reported port is stale.
+ctrl_proxy_port="$(ctrl_proxy_port_for_device)" || {
+  echo "error: could not determine CtrlProxy port after daemon restart for simulator ${device_id}" >&2
+  exit 1
+}
+curl --fail --silent --show-error --max-time 5 "http://127.0.0.1:${ctrl_proxy_port}/health" >/dev/null
 
 event_payload() {
   local destination="$1"

--- a/scripts/ios/navigation-graph-sdk-event-integration.sh
+++ b/scripts/ios/navigation-graph-sdk-event-integration.sh
@@ -35,24 +35,25 @@ ctrl_proxy_port_for_device() {
   # default and may already belong to another local service. `doctor` can exit
   # non-zero for unrelated diagnostics, but still emits the JSON round-trip
   # report that contains this ready runner's port.
-  local doctor_report
+  local doctor_report ctrl_proxy_port
   doctor_report="$(auto-mobile --cli doctor --ios --json || true)"
-  jq -er --arg device_id "${device_id}" '
-    .ios.checks[]
-    | select(.name == "iOS Observe Round Trip")
-    | .message
-    | split(" | ")
-    | map(select(contains("device=" + $device_id + ";")))
-    | .[0]
-    | capture("runnerPort=(?<port>[0-9]+)")
-    | .port
-  ' <<<"${doctor_report}"
+  if ! ctrl_proxy_port="$(jq -er --arg device_id "${device_id}" '
+      .ios.checks[]
+      | select(.name == "iOS Observe Round Trip")
+      | .message
+      | split(" | ")
+      | map(select(contains("device=" + $device_id + ";")))
+      | .[0]
+      | capture("runnerPort=(?<port>[0-9]+)")
+      | .port
+    ' <<<"${doctor_report}")"; then
+    echo "error: could not determine CtrlProxy port for simulator ${device_id}" >&2
+    return 1
+  fi
+  printf '%s\n' "${ctrl_proxy_port}"
 }
 
-ctrl_proxy_port="$(ctrl_proxy_port_for_device)" || {
-  echo "error: could not determine CtrlProxy port for simulator ${device_id}" >&2
-  exit 1
-}
+ctrl_proxy_port="$(ctrl_proxy_port_for_device)"
 
 curl --fail --silent --show-error --max-time 5 "http://127.0.0.1:${ctrl_proxy_port}/health" >/dev/null
 
@@ -66,10 +67,7 @@ fi
 
 # Requesting debug and embedded-SDK tools can restart the daemon. That restart
 # creates a new CtrlProxy client, so the prior daemon's reported port is stale.
-ctrl_proxy_port="$(ctrl_proxy_port_for_device)" || {
-  echo "error: could not determine CtrlProxy port after daemon restart for simulator ${device_id}" >&2
-  exit 1
-}
+ctrl_proxy_port="$(ctrl_proxy_port_for_device)"
 curl --fail --silent --show-error --max-time 5 "http://127.0.0.1:${ctrl_proxy_port}/health" >/dev/null
 
 event_payload() {

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -207,12 +207,12 @@ export interface ProxiedResourceTemplate {
 
 /**
  * The daemon startup options that change its observable MCP behavior and so must
- * match before a running daemon can be reused: `embeddedSdk`, `networkMockable`,
+ * match before a running daemon can be reused: `debug`, `embeddedSdk`, `networkMockable`,
  * marker-based eventAll promotion config, plus every output-reduction flag. A
  * same-build MCP client that requests one of these against an already-running
  * daemon started without it (or vice versa) would otherwise silently get the
  * wrong tool-output or inputText behavior until a manual restart (issue #2759 —
- * the `toolResultsNoStructuredContent` case). `embeddedSdk` and `networkMockable`
+ * the `toolResultsNoStructuredContent` case). `debug`, `embeddedSdk`, and `networkMockable`
  * additionally gate whole tool families out of the registry, so reusing a daemon
  * that lacks the requested flag makes those tools unreachable (issue #4247). The
  * output-reduction fields are derived from `OUTPUT_REDUCTION_FLAG_SPECS` (whose
@@ -220,6 +220,7 @@ export interface ProxiedResourceTemplate {
  * automatically.
  */
 export const REUSE_CRITICAL_OPTION_KEYS: (keyof DaemonOptions)[] = [
+  "debug",
   "embeddedSdk",
   "networkMockable",
   "safeAreaWarnings",

--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -1197,7 +1197,14 @@ export class NavigationGraphManager implements NavigationGraphService {
    * Get graph statistics for debugging.
    */
   public async getStats(): Promise<NavigationGraphStats> {
-    if (!this.currentAppId) {
+    return this.getStatsForApp(this.currentAppId);
+  }
+
+  /**
+   * Get graph statistics for a specific app without changing the active graph.
+   */
+  public async getStatsForApp(appId: string | null): Promise<NavigationGraphStats> {
+    if (!appId) {
       return {
         nodeCount: 0,
         edgeCount: 0,
@@ -1208,15 +1215,16 @@ export class NavigationGraphManager implements NavigationGraphService {
       };
     }
 
-    const stats = await this.repository.getStats(this.currentAppId);
+    const stats = await this.repository.getStats(appId);
+    const isCurrentApp = appId === this.currentAppId;
 
     return {
       nodeCount: stats.nodeCount,
       edgeCount: stats.edgeCount,
-      currentScreen: this.currentScreen,
+      currentScreen: isCurrentApp ? this.currentScreen : null,
       knownEdgeCount: stats.toolEdgeCount,
       unknownEdgeCount: stats.unknownEdgeCount,
-      toolCallHistorySize: this.toolCallHistory.length,
+      toolCallHistorySize: isCurrentApp ? this.toolCallHistory.length : 0,
     };
   }
 
@@ -1249,7 +1257,14 @@ export class NavigationGraphManager implements NavigationGraphService {
    * Export the current graph for debugging/visualization.
    */
   public async exportGraph(): Promise<ExportedGraph> {
-    if (!this.currentAppId) {
+    return this.exportGraphForApp(this.currentAppId);
+  }
+
+  /**
+   * Export a specific app's graph without changing the active graph.
+   */
+  public async exportGraphForApp(appId: string | null): Promise<ExportedGraph> {
+    if (!appId) {
       return {
         appId: null,
         nodes: [],
@@ -1258,8 +1273,8 @@ export class NavigationGraphManager implements NavigationGraphService {
       };
     }
 
-    const dbNodes = await this.repository.getNodes(this.currentAppId);
-    const dbEdges = await this.repository.getEdges(this.currentAppId);
+    const dbNodes = await this.repository.getNodes(appId);
+    const dbEdges = await this.repository.getEdges(appId);
 
     const nodes: NavigationNode[] = [];
     for (const dbNode of dbNodes) {
@@ -1282,10 +1297,10 @@ export class NavigationGraphManager implements NavigationGraphService {
     const edges = await this.convertDBEdgesToNavigationEdges(dbEdges);
 
     return {
-      appId: this.currentAppId,
+      appId,
       nodes,
       edges,
-      currentScreen: this.currentScreen,
+      currentScreen: appId === this.currentAppId ? this.currentScreen : null,
     };
   }
 

--- a/src/server/navigationTools.ts
+++ b/src/server/navigationTools.ts
@@ -106,10 +106,10 @@ export function registerNavigationTools() {
   ) => {
     try {
       const manager = getNavigationManager(args.sessionUuid);
-      const stats = await manager.getStats();
-      const graph = await manager.exportGraph();
       const observation = RealObserveScreen.getRecentCachedResultForDevice(device.deviceId);
       const appId = observation?.viewHierarchy?.packageName ?? observation?.activeWindow?.appId;
+      const stats = await manager.getStatsForApp(appId ?? null);
+      const graph = await manager.exportGraphForApp(appId ?? null);
 
       return createJSONToolResponse({
         message: `Navigation graph for app: ${appId || "none"}`,

--- a/test/bats/navigation-graph-sdk-event-integration.bats
+++ b/test/bats/navigation-graph-sdk-event-integration.bats
@@ -9,6 +9,8 @@ setup() {
   export CURL_URL_FILE="${MOCK_BIN}/curl-urls"
   export SESSION_OBSERVE_FILE="${MOCK_BIN}/session-observe"
   export DOCTOR_CALLS_FILE="${MOCK_BIN}/doctor-calls"
+  export TARGET_APP_LAUNCHED_FILE="${MOCK_BIN}/target-app-launched"
+  export INVOCATION_FILE="${MOCK_BIN}/invocations"
 }
 
 teardown() {
@@ -55,6 +57,7 @@ fi
 exit 0
 '
   make_mock auto-mobile '
+printf "%s\n" "$*" >> "$INVOCATION_FILE"
 if [ "$1" = "--cli" ] && [ "$2" = "doctor" ]; then
   doctor_calls=0
   [ -f "$DOCTOR_CALLS_FILE" ] && doctor_calls="$(cat "$DOCTOR_CALLS_FILE")"
@@ -62,7 +65,19 @@ if [ "$1" = "--cli" ] && [ "$2" = "doctor" ]; then
   printf "{\"ios\":{\"checks\":[]}}\\n"
   exit 0
 fi
+if [ "$1" = "--debug" ] && [ "$2" = "--embedded-sdk" ] && [ "$3" = "--cli" ] && [ "$4" = "--session-uuid" ] && [ "$6" = "launchApp" ]; then
+  if [ "$7" != "--platform" ] || [ "$8" != "ios" ] || [ "$9" != "--appId" ] || [ "${10}" != "com.apple.reminders" ] || [ "${11}" != "--deviceId" ] || [ "${12}" != "simulator-udid" ]; then
+    echo "unexpected target app launch arguments: $*" >&2
+    exit 1
+  fi
+  touch "$TARGET_APP_LAUNCHED_FILE"
+  exit 0
+fi
 if [ "$1" = "--debug" ] && [ "$2" = "--embedded-sdk" ] && [ "$3" = "--cli" ] && [ "$4" = "--session-uuid" ] && [ "$6" = "observe" ]; then
+  if [ ! -f "$TARGET_APP_LAUNCHED_FILE" ]; then
+    echo "graph session was bound before its target app launched" >&2
+    exit 1
+  fi
   touch "$SESSION_OBSERVE_FILE"
   exit 0
 fi
@@ -83,7 +98,11 @@ fi
   [ "$status" -eq 0 ]
   [ "$(cat "$GRAPH_ATTEMPTS_FILE")" = "2" ]
   [ "$(cat "$DOCTOR_CALLS_FILE")" = "2" ]
+  [ -f "$TARGET_APP_LAUNCHED_FILE" ]
   [[ "$output" == *"getNavigationGraph attempt 1 failed"* ]]
+  launch_line="$(grep -n -- "launchApp --platform ios --appId com.apple.reminders --deviceId simulator-udid" "$INVOCATION_FILE" | head -n 1 | cut -d: -f1)"
+  observe_line="$(grep -n -- "observe --platform ios --deviceId simulator-udid" "$INVOCATION_FILE" | head -n 1 | cut -d: -f1)"
+  [ "$launch_line" -lt "$observe_line" ]
   grep -qx "http://127.0.0.1:8769/health" "$CURL_URL_FILE"
   grep -qx "http://127.0.0.1:8769/sdk-events" "$CURL_URL_FILE"
 }

--- a/test/bats/navigation-graph-sdk-event-integration.bats
+++ b/test/bats/navigation-graph-sdk-event-integration.bats
@@ -8,6 +8,7 @@ setup() {
   export GRAPH_ATTEMPTS_FILE="${MOCK_BIN}/graph-attempts"
   export CURL_URL_FILE="${MOCK_BIN}/curl-urls"
   export SESSION_OBSERVE_FILE="${MOCK_BIN}/session-observe"
+  export DOCTOR_CALLS_FILE="${MOCK_BIN}/doctor-calls"
 }
 
 teardown() {
@@ -43,13 +44,21 @@ if [ "$1" = "-cn" ]; then
   exit 0
 fi
 if [ "$1" = "-er" ]; then
-  printf "8768\\n"
+  doctor_calls="$(cat "$DOCTOR_CALLS_FILE")"
+  if [ "$doctor_calls" -eq 1 ]; then
+    printf "8768\\n"
+  else
+    printf "8769\\n"
+  fi
   exit 0
 fi
 exit 0
 '
   make_mock auto-mobile '
 if [ "$1" = "--cli" ] && [ "$2" = "doctor" ]; then
+  doctor_calls=0
+  [ -f "$DOCTOR_CALLS_FILE" ] && doctor_calls="$(cat "$DOCTOR_CALLS_FILE")"
+  printf "%s\\n" "$((doctor_calls + 1))" > "$DOCTOR_CALLS_FILE"
   printf "{\"ios\":{\"checks\":[]}}\\n"
   exit 0
 fi
@@ -73,7 +82,8 @@ fi
 
   [ "$status" -eq 0 ]
   [ "$(cat "$GRAPH_ATTEMPTS_FILE")" = "2" ]
+  [ "$(cat "$DOCTOR_CALLS_FILE")" = "2" ]
   [[ "$output" == *"getNavigationGraph attempt 1 failed"* ]]
-  grep -qx "http://127.0.0.1:8768/health" "$CURL_URL_FILE"
-  grep -qx "http://127.0.0.1:8768/sdk-events" "$CURL_URL_FILE"
+  grep -qx "http://127.0.0.1:8769/health" "$CURL_URL_FILE"
+  grep -qx "http://127.0.0.1:8769/sdk-events" "$CURL_URL_FILE"
 }

--- a/test/bats/navigation-graph-sdk-event-integration.bats
+++ b/test/bats/navigation-graph-sdk-event-integration.bats
@@ -53,11 +53,11 @@ if [ "$1" = "--cli" ] && [ "$2" = "doctor" ]; then
   printf "{\"ios\":{\"checks\":[]}}\\n"
   exit 0
 fi
-if [ "$1" = "--debug" ] && [ "$2" = "--cli" ] && [ "$3" = "--session-uuid" ] && [ "$5" = "observe" ]; then
+if [ "$1" = "--debug" ] && [ "$2" = "--embedded-sdk" ] && [ "$3" = "--cli" ] && [ "$4" = "--session-uuid" ] && [ "$6" = "observe" ]; then
   touch "$SESSION_OBSERVE_FILE"
   exit 0
 fi
-if [ "$1" = "--debug" ] && [ "$2" = "--cli" ] && [ "$3" = "--session-uuid" ] && [ "$5" = "getNavigationGraph" ]; then
+if [ "$1" = "--debug" ] && [ "$2" = "--embedded-sdk" ] && [ "$3" = "--cli" ] && [ "$4" = "--session-uuid" ] && [ "$6" = "getNavigationGraph" ]; then
   attempts=0
   [ -f "$GRAPH_ATTEMPTS_FILE" ] && attempts="$(cat "$GRAPH_ATTEMPTS_FILE")"
   attempts=$((attempts + 1))

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -185,13 +185,17 @@ describe("DaemonMcpProxy", () => {
           ...(opts.daemonEntryScript !== undefined ? { entryScript: opts.daemonEntryScript } : {}),
         };
         fakeManager.statusResult = initialStatus;
+        const restartedStatus = {
+          ...initialStatus,
+          version: opts.statusAfterRestartVersion ?? CLIENT_VERSION,
+          startedAt: timer.now(),
+          ...(opts.daemonOptions !== undefined ? { options: opts.daemonOptions } : {}),
+        };
         fakeManager.statusResults = [
           initialStatus,
-          {
-            ...initialStatus,
-            version: opts.statusAfterRestartVersion ?? CLIENT_VERSION,
-            startedAt: timer.now(),
-          },
+          restartedStatus,
+          restartedStatus,
+          restartedStatus,
         ];
         if (opts.waitForReadyResult !== undefined) {
           fakeManager.waitForReadyResult = opts.waitForReadyResult;
@@ -479,6 +483,7 @@ describe("DaemonMcpProxy", () => {
 
     describe("startup option mismatch handling", () => {
       function runningStatus(options: {
+        debug?: boolean;
         embeddedSdk?: boolean;
         networkMockable?: boolean;
         safeAreaWarnings?: boolean;
@@ -520,6 +525,34 @@ describe("DaemonMcpProxy", () => {
           await proxy.listTools();
           expect(fakeManager.restartCalled).toBe(true);
           expect(fakeManager.restartOptions).toEqual({ embeddedSdk: true });
+        } finally {
+          isAvailableSpy.mockRestore();
+          await proxy.close();
+        }
+      });
+
+      test("restarts daemon when debug mode differs", async () => {
+        const fakeClient = new FakeDaemonClient({
+          daemonMethodResults: new Map([["tools/list", { tools: [] }]]),
+        });
+        const fakeManager = new FakeDaemonManager();
+        fakeManager.statusResults = [
+          runningStatus({ debug: false }), // ensureVersionMatches
+          runningStatus({ debug: false }), // ensureBuildMatches
+          runningStatus({ debug: false }), // ensureStartupOptionsMatch (mismatch)
+          runningStatus({ debug: true }), // post-restart verify
+        ];
+        const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+        const proxy = new DaemonMcpProxy({
+          clientFactory: () => fakeClient,
+          daemonManager: fakeManager,
+          daemonOptions: { debug: true },
+        });
+
+        try {
+          await proxy.listTools();
+          expect(fakeManager.restartCalled).toBe(true);
+          expect(fakeManager.restartOptions).toEqual({ debug: true });
         } finally {
           isAvailableSpy.mockRestore();
           await proxy.close();

--- a/test/features/navigation/NavigationGraphManager.test.ts
+++ b/test/features/navigation/NavigationGraphManager.test.ts
@@ -481,6 +481,32 @@ describe("NavigationGraphManager", () => {
       expect(stats.knownEdgeCount).toBe(1);
       expect(stats.unknownEdgeCount).toBe(0);
     });
+
+    test("returns stats for a requested non-current app without its active screen", async () => {
+      await manager.setCurrentApp("com.apple.Preferences");
+      await manager.recordNavigationEvent(createEvent("iOS Settings", 1000));
+      await manager.recordNavigationEvent(createEvent("iOS General", 2000));
+
+      await manager.setCurrentApp("com.google.android.settings");
+      await manager.recordNavigationEvent(createEvent("Android Settings", 3000));
+
+      expect(await manager.getStatsForApp("com.apple.Preferences")).toEqual({
+        nodeCount: 2,
+        edgeCount: 1,
+        currentScreen: null,
+        knownEdgeCount: 0,
+        unknownEdgeCount: 1,
+        toolCallHistorySize: 0,
+      });
+      expect(await manager.getStatsForApp(null)).toEqual({
+        nodeCount: 0,
+        edgeCount: 0,
+        currentScreen: null,
+        knownEdgeCount: 0,
+        unknownEdgeCount: 0,
+        toolCallHistorySize: 0,
+      });
+    });
   });
 
   describe("exportGraph", () => {
@@ -505,6 +531,33 @@ describe("NavigationGraphManager", () => {
       const homeNode = exported.nodes.find(n => n.screenName === "Home");
       expect(homeNode).toBeDefined();
       expect(homeNode!.visitCount).toBe(1);
+    });
+
+    test("exports only the requested non-current app graph", async () => {
+      await manager.setCurrentApp("com.apple.Preferences");
+      await manager.recordNavigationEvent(createEvent("iOS Settings", 1000));
+      await manager.recordNavigationEvent(createEvent("iOS General", 2000));
+
+      await manager.setCurrentApp("com.google.android.settings");
+      await manager.recordNavigationEvent(createEvent("Android Settings", 3000));
+
+      const exported = await manager.exportGraphForApp("com.apple.Preferences");
+
+      expect(exported.appId).toBe("com.apple.Preferences");
+      expect(exported.currentScreen).toBeNull();
+      expect(exported.nodes.map(node => node.screenName)).toEqual([
+        "iOS General",
+        "iOS Settings",
+      ]);
+      expect(exported.edges.map(edge => [edge.from, edge.to])).toEqual([
+        ["iOS Settings", "iOS General"],
+      ]);
+      expect(await manager.exportGraphForApp(null)).toEqual({
+        appId: null,
+        nodes: [],
+        edges: [],
+        currentScreen: null,
+      });
     });
   });
 

--- a/test/server/androidNavigationWorkflow.test.ts
+++ b/test/server/androidNavigationWorkflow.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { z } from "zod";
@@ -6,6 +6,7 @@ import type { BootedDevice } from "../../src/models";
 import { Explore } from "../../src/features/navigation/Explore";
 import { NavigationGraphManager } from "../../src/features/navigation/NavigationGraphManager";
 import { DefaultPathOptimizer } from "../../src/features/navigation/DefaultPathOptimizer";
+import { RealObserveScreen } from "../../src/features/observe/ObserveScreen";
 import { NavigationRepository } from "../../src/db/navigationRepository";
 import { TestCoverageRepository } from "../../src/db/testCoverageRepository";
 import { createMcpServer } from "../../src/server/index";
@@ -153,7 +154,16 @@ describe("Android navigation graph workflow (#4459)", () => {
 
     const graphTool = ToolRegistry.getTool("getNavigationGraph");
     expect(graphTool).toBeDefined();
-    const graphResponse = await graphTool!.deviceAwareHandler!(device, { platform: "android", sessionUuid });
+    const observationSpy = spyOn(RealObserveScreen, "getRecentCachedResultForDevice").mockReturnValue({
+      viewHierarchy: { packageName: appId },
+    } as never);
+    const graphResponse = await (async () => {
+      try {
+        return await graphTool!.deviceAwareHandler!(device, { platform: "android", sessionUuid });
+      } finally {
+        observationSpy.mockRestore();
+      }
+    })();
     const graph = JSON.parse(graphResponse.content[0].text);
     expect(graph).toMatchObject({
       currentScreen: "Settings",

--- a/test/server/navigationTools.test.ts
+++ b/test/server/navigationTools.test.ts
@@ -6,6 +6,7 @@ import { RealObserveScreen } from "../../src/features/observe/ObserveScreen";
 import { registerNavigationTools } from "../../src/server/navigationTools";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import { setDebugModeEnabled } from "../../src/utils/debug";
+import { PortManager } from "../../src/utils/PortManager";
 import type { BootedDevice } from "../../src/models";
 import { FakeNavigationGraphManager } from "../fakes/FakeNavigationGraphManager";
 
@@ -33,6 +34,9 @@ describe("navigation tool session graph selection", () => {
     const usedSessions: unknown[] = [];
     const sessionManagerSpy = spyOn(NavigationGraphManager, "getInstanceForSession")
       .mockReturnValue(sessionGraph as unknown as NavigationGraphManager);
+    PortManager.setPortAvailabilityCheckerForTesting({
+      isPortAvailable: () => true,
+    });
     const navigateExecuteSpy = spyOn(NavigateTo.prototype, "execute").mockImplementation(async function() {
       usedManagers.push((this as unknown as { navigationManager: unknown }).navigationManager);
       usedSessions.push((this as unknown as { sessionUuid: unknown }).sessionUuid);
@@ -85,12 +89,57 @@ describe("navigation tool session graph selection", () => {
       sessionManagerSpy.mockRestore();
       navigateExecuteSpy.mockRestore();
       exploreExecuteSpy.mockRestore();
+      PortManager.reset();
+      PortManager.setPortAvailabilityCheckerForTesting(null);
     }
   });
 
   test("reports the target iOS device's observed app instead of a stale graph app", async () => {
     const staleGraph = new FakeNavigationGraphManager();
     staleGraph.setCurrentAppId("com.google.android.settings.intelligence");
+    staleGraph.addNode({
+      screenName: "Android Settings",
+      firstSeenAt: 1,
+      lastSeenAt: 1,
+      visitCount: 1,
+    });
+    staleGraph.addEdge({
+      from: "Android Settings",
+      to: "Android Accessibility",
+      timestamp: 1,
+      edgeType: "unknown",
+    });
+    Object.assign(staleGraph, {
+      getStatsForApp: async (appId: string | null) => {
+        expect(appId).toBe("com.apple.Preferences");
+        return {
+          nodeCount: 2,
+          edgeCount: 1,
+          currentScreen: null,
+          knownEdgeCount: 1,
+          unknownEdgeCount: 0,
+          toolCallHistorySize: 0,
+        };
+      },
+      exportGraphForApp: async (appId: string | null) => {
+        expect(appId).toBe("com.apple.Preferences");
+        return {
+          appId,
+          currentScreen: null,
+          nodes: [
+            { screenName: "iOS Settings", firstSeenAt: 1, lastSeenAt: 2, visitCount: 3 },
+            { screenName: "iOS General", firstSeenAt: 2, lastSeenAt: 3, visitCount: 1 },
+          ],
+          edges: [{
+            from: "iOS Settings",
+            to: "iOS General",
+            timestamp: 3,
+            edgeType: "tool" as const,
+            interaction: { toolName: "tapOn", args: { text: "General" }, timestamp: 3 },
+          }],
+        };
+      },
+    });
     const managerSpy = spyOn(NavigationGraphManager, "getInstance").mockReturnValue(
       staleGraph as unknown as NavigationGraphManager
     );
@@ -105,9 +154,28 @@ describe("navigation tool session graph selection", () => {
 
       const response = await handler!(device, { platform: "ios" });
 
-      expect(JSON.parse(response.content[0].text).message).toBe(
+      const result = JSON.parse(response.content[0].text);
+      expect(result.message).toBe(
         "Navigation graph for app: com.apple.Preferences"
       );
+      expect(result).toMatchObject({
+        currentScreen: null,
+        nodeCount: 2,
+        edgeCount: 1,
+        knownEdges: 1,
+        unknownEdges: 0,
+        screens: [
+          { name: "iOS Settings", visitCount: 3 },
+          { name: "iOS General", visitCount: 1 },
+        ],
+        transitions: [{
+          from: "iOS Settings",
+          to: "iOS General",
+          type: "tool",
+          tool: "tapOn",
+          args: { text: "General" },
+        }],
+      });
     } finally {
       observationSpy.mockRestore();
       managerSpy.mockRestore();
@@ -117,6 +185,29 @@ describe("navigation tool session graph selection", () => {
   test("reports none when the target device has no cached observation", async () => {
     const staleGraph = new FakeNavigationGraphManager();
     staleGraph.setCurrentAppId("com.google.android.settings.intelligence");
+    staleGraph.addNode({
+      screenName: "Android Settings",
+      firstSeenAt: 1,
+      lastSeenAt: 1,
+      visitCount: 1,
+    });
+    Object.assign(staleGraph, {
+      getStatsForApp: async (appId: string | null) => {
+        expect(appId).toBeNull();
+        return {
+          nodeCount: 0,
+          edgeCount: 0,
+          currentScreen: null,
+          knownEdgeCount: 0,
+          unknownEdgeCount: 0,
+          toolCallHistorySize: 0,
+        };
+      },
+      exportGraphForApp: async (appId: string | null) => {
+        expect(appId).toBeNull();
+        return { appId, currentScreen: null, nodes: [], edges: [] };
+      },
+    });
     const managerSpy = spyOn(NavigationGraphManager, "getInstance").mockReturnValue(
       staleGraph as unknown as NavigationGraphManager
     );
@@ -129,7 +220,76 @@ describe("navigation tool session graph selection", () => {
 
       const response = await handler!(device, { platform: "ios" });
 
-      expect(JSON.parse(response.content[0].text).message).toBe("Navigation graph for app: none");
+      expect(JSON.parse(response.content[0].text)).toEqual({
+        message: "Navigation graph for app: none",
+        currentScreen: null,
+        nodeCount: 0,
+        edgeCount: 0,
+        knownEdges: 0,
+        unknownEdges: 0,
+        screens: [],
+        transitions: [],
+      });
+    } finally {
+      observationSpy.mockRestore();
+      managerSpy.mockRestore();
+    }
+  });
+
+  test("keeps the current graph response unchanged when it matches the target observation", async () => {
+    const graph = new FakeNavigationGraphManager();
+    graph.setCurrentAppId("com.apple.Preferences");
+    graph.setCurrentScreenValue("iOS Settings");
+    graph.addNode({
+      screenName: "iOS Settings",
+      firstSeenAt: 1,
+      lastSeenAt: 2,
+      visitCount: 3,
+    });
+    Object.assign(graph, {
+      getStatsForApp: async (appId: string | null) => {
+        expect(appId).toBe("com.apple.Preferences");
+        return {
+          nodeCount: 1,
+          edgeCount: 0,
+          currentScreen: "iOS Settings",
+          knownEdgeCount: 0,
+          unknownEdgeCount: 0,
+          toolCallHistorySize: 0,
+        };
+      },
+      exportGraphForApp: async (appId: string | null) => {
+        expect(appId).toBe("com.apple.Preferences");
+        return {
+          appId,
+          currentScreen: "iOS Settings",
+          nodes: [{ screenName: "iOS Settings", firstSeenAt: 1, lastSeenAt: 2, visitCount: 3 }],
+          edges: [],
+        };
+      },
+    });
+    const managerSpy = spyOn(NavigationGraphManager, "getInstance").mockReturnValue(
+      graph as unknown as NavigationGraphManager
+    );
+    const observationSpy = spyOn(RealObserveScreen, "getRecentCachedResultForDevice").mockReturnValue({
+      viewHierarchy: { packageName: "com.apple.Preferences" }
+    } as never);
+
+    try {
+      const handler = (ToolRegistry as unknown as {
+        tools: Map<string, { deviceAwareHandler?: (device: BootedDevice, args: any) => Promise<any> }>;
+      }).tools.get("getNavigationGraph")?.deviceAwareHandler;
+
+      const response = await handler!(device, { platform: "ios" });
+
+      expect(JSON.parse(response.content[0].text)).toMatchObject({
+        message: "Navigation graph for app: com.apple.Preferences",
+        currentScreen: "iOS Settings",
+        nodeCount: 1,
+        edgeCount: 0,
+        screens: [{ name: "iOS Settings", visitCount: 3 }],
+        transitions: [],
+      });
     } finally {
       observationSpy.mockRestore();
       managerSpy.mockRestore();


### PR DESCRIPTION
## Summary

- Select navigation graph stats and detail data using the target device's cached observation app ID.
- Return an empty graph when the target device has no cached observation, rather than exposing another device's graph.
- Add regression coverage for cross-platform graph selection, no-observation behavior, and the Android navigation workflow.

## Root Cause

`getNavigationGraph` reported the target device's app in its message but still called the navigation manager's current-app export methods. In a mixed Android/iOS session, that could return an Android graph with an iOS app label.

## Validation

- `HOME=/private/tmp/auto-mobile-4619-home bun run turbo:validate`
- `HOME=/private/tmp/auto-mobile-4619-home bun run typecheck`

Closes #4619
