### PR TITLE
fix(desktop): enforce frame-context control

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -160,7 +160,6 @@ import dev.jasonpearson.automobile.desktop.core.video.toImageBitmap
 import dev.jasonpearson.automobile.desktop.domain.DeviceControlDecision
 import dev.jasonpearson.automobile.desktop.domain.DeviceControlInputs
 import dev.jasonpearson.automobile.desktop.domain.DeviceScreenControlMode
-import dev.jasonpearson.automobile.desktop.domain.LiveFrameFacts
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.launch
@@ -551,10 +550,10 @@ fun AutoMobileContent(
       }
     }
   val liveVideoFrame = rememberLiveVideoFrame(liveVideoSource, activeDeviceId, MONOTONIC_NOW_MS)
-  // Forces the control-availability decision to be re-evaluated on a timer, not only when a source
-  // produces an update (issue #3348). A stalled relay produces nothing at all — its staleness is
-  // visible only as time passing — so without this a frozen mirror would stay clickable until some
-  // unrelated recomposition happened to run.
+  // Forces the control-availability decision to be re-evaluated on a timer, not only when an
+  // observation source produces an update (issue #3348). A stalled observation stream produces
+  // nothing at all — its staleness is visible only as time passing — so without this a frozen
+  // screenshot would stay clickable until some unrelated recomposition happened to run.
   val controlFreshnessTick = rememberControlFreshnessTick(enableDeviceControl && isLiveLayoutMode)
 
   // Pending failure ID for deep linking from notifications
@@ -1655,8 +1654,9 @@ fun AutoMobileContent(
           // view then maps clicks through that snapshot and hands it back with each tap, so a
           // snapshot swap between click and dispatch cannot change what the daemon receives.
           //
-          // Re-evaluated on a slow ticker as well as on source updates, because a stalled live
-          // relay produces no updates at all — its staleness is only visible as time passing.
+          // Re-evaluated on a slow ticker as well as on source updates, because a stalled
+          // observation stream produces no updates at all — its staleness is only visible as time
+          // passing.
           controlFreshnessTick
           val deviceControlDecision =
             deviceControlSession.evaluate(
@@ -1670,17 +1670,10 @@ fun AutoMobileContent(
                   layoutInspectorState.connectionStatus == ConnectionStatus.Connected,
                 screenshot = layoutInspectorState.screenshotFacts,
                 hierarchy = layoutInspectorState.hierarchyFacts,
-                liveFrame =
-                  liveVideoFrame?.let { frame ->
-                    LiveFrameFacts(
-                      deviceId = activeDeviceId,
-                      sequence = frame.sequence,
-                      receivedAtMs = frame.receivedAtMs,
-                      width = frame.bitmap.width,
-                      height = frame.bitmap.height,
-                      rotation = frame.rotation,
-                    )
-                  },
+                // Control maps and renders the paired observation screenshot. WebRTC has no
+                // capture identity, so it is only an Inspector-mode rendering source and must not
+                // decide whether the independently paired screenshot is actionable.
+                liveFrame = null,
               )
             )
           // What a CLICK acts through. While a post-input refresh is pending this is the retained

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -952,6 +952,7 @@ fun AutoMobileContent(
             // resolution change can never supply the bounds a tap is mapped through — however few
             // milliseconds behind it is (issue #3348).
             captureSequence = update.captureSequence,
+            frameContext = update.frameContext,
             // The unit this update's bounds are in, as the daemon declared it. Carried per update
             // rather than per session because the declaration is per message, and the control
             // policy only compares dimensions exactly when the paired screenshot declared the same
@@ -1002,6 +1003,7 @@ fun AutoMobileContent(
           generation = generation,
           // Pairs by equality against the hierarchy's id; see the hierarchy collector above.
           captureSequence = update.captureSequence,
+          frameContext = update.frameContext,
           // Same reasoning as the hierarchy collector: the declared unit travels with the frame
           // (issue #4550).
           coordinateSpace = update.coordinateSpace,

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/AutoMobileContent.kt
@@ -914,6 +914,10 @@ fun AutoMobileContent(
     liveStreamClient.resetLayoutReplayCache()
     liveStreamClient.hierarchyUpdates.collect { update ->
       if (!isActiveDeviceStreamFrame(update.deviceId, activeDeviceId)) return@collect
+      deviceControlSession.onObservationFrameContextDeclared(
+        update.frameContext,
+        update.captureSequence,
+      )
       // AT RECEIPT, before the parse below and before the layout state's debounce: the daemon has
       // already switched to interpreting input under the new scale metadata by the time it
       // publishes a new declaration, so a flip has to invalidate control NOW. Detecting it from
@@ -971,6 +975,10 @@ fun AutoMobileContent(
     liveStreamClient.resetLayoutReplayCache()
     liveStreamClient.screenshotUpdates.collect { update ->
       if (!isActiveDeviceStreamFrame(update.deviceId, activeDeviceId)) return@collect
+      deviceControlSession.onObservationFrameContextDeclared(
+        update.frameContext,
+        update.captureSequence,
+      )
       // Same receipt-time gate as the hierarchy collector; see its comment (issue #4550).
       deviceControlSession.onObservationSpaceDeclared(
         update.coordinateSpace,
@@ -1695,7 +1703,10 @@ fun AutoMobileContent(
             DeviceScreenView(
               screenshotData =
                 renderSnapshot?.screenshotData ?: layoutInspectorState.screenshotData,
-              liveFrame = liveVideoFrame?.bitmap,
+              // WebRTC frames have no capture identity. In control mode render the paired
+              // observation screenshot instead, so the pixels the user clicks carry the same
+              // frameContext as the hierarchy and input request.
+              liveFrame = if (controlSnapshot == null) liveVideoFrame?.bitmap else null,
               screenWidth = renderSnapshot?.deviceWidth ?: layoutInspectorState.screenWidth,
               screenHeight = renderSnapshot?.deviceHeight ?: layoutInspectorState.screenHeight,
               rotation = layoutInspectorState.rotation,

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlInputDispatcher.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlInputDispatcher.kt
@@ -175,12 +175,14 @@ class DeviceControlInputDispatcher(
    * current command publishes the rejection, so retained commands can be put back in FIFO order
    * before it reads the queue again.
    */
-  fun discardFrameContext(frameContext: String) {
+  fun discardFrameContext(frameContext: String): Long? {
     val retained = mutableListOf<DeviceControlInputCommand>()
+    var newestDiscardedToken: Long? = null
     while (true) {
       val command = commands.tryReceive().getOrNull() ?: break
       if (command.snapshot.frameContext == frameContext) {
         command.client?.close()
+        newestDiscardedToken = maxOf(newestDiscardedToken ?: Long.MIN_VALUE, command.token)
       } else {
         retained += command
       }
@@ -190,6 +192,7 @@ class DeviceControlInputDispatcher(
         "A retained device-control command did not fit back into its drained queue"
       }
     }
+    return newestDiscardedToken
   }
 
   companion object {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlInputDispatcher.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlInputDispatcher.kt
@@ -166,6 +166,32 @@ class DeviceControlInputDispatcher(
     }
   }
 
+  /**
+   * Drop pending inputs bound to [frameContext], preserving inputs the user made through a newer
+   * paired frame. A stale-context response proves only its own snapshot unsafe; clearing every
+   * pending command here would silently discard an already queued gesture for a newer snapshot.
+   *
+   * Like [reset], this runs on the session's UI context. The consumer is suspended while its
+   * current command publishes the rejection, so retained commands can be put back in FIFO order
+   * before it reads the queue again.
+   */
+  fun discardFrameContext(frameContext: String) {
+    val retained = mutableListOf<DeviceControlInputCommand>()
+    while (true) {
+      val command = commands.tryReceive().getOrNull() ?: break
+      if (command.snapshot.frameContext == frameContext) {
+        command.client?.close()
+      } else {
+        retained += command
+      }
+    }
+    retained.forEach { command ->
+      check(commands.trySend(command).isSuccess) {
+        "A retained device-control command did not fit back into its drained queue"
+      }
+    }
+  }
+
   companion object {
     /**
      * Bounded queue depth. Small: a human cannot out-gesture a working daemon by more than a few

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlInputForwarder.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlInputForwarder.kt
@@ -42,6 +42,7 @@ class DeviceControlInputForwarder {
    * @param client the daemon client to tap through, snapshotted at click time; null drops the tap.
    * @param platform the daemon platform string for the tapped device ("android" / "ios").
    * @param deviceId the target device id, or null to let the daemon pick its active device.
+   * @param frameContext opaque identity from the snapshot this input was mapped through.
    * @param onError invoked with the daemon's actionable error message (or an exception message)
    *   when the tap fails. Never called for an out-of-bounds point or a successful tap.
    */
@@ -51,6 +52,7 @@ class DeviceControlInputForwarder {
     platform: String,
     deviceId: String?,
     onError: (String) -> Unit,
+    frameContext: String,
   ) {
     // Out of bounds: the mapping never clamps, so a click outside the device screen produces an
     // off-screen coordinate. Dropping it honors the screen-control-mapping contract (the daemon
@@ -66,6 +68,7 @@ class DeviceControlInputForwarder {
         y = point.y.toDouble(),
         platform = platform,
         deviceId = deviceId,
+        frameContext = frameContext,
       )
     }
   }
@@ -88,6 +91,7 @@ class DeviceControlInputForwarder {
     platform: String,
     deviceId: String?,
     onError: (String) -> Unit,
+    frameContext: String,
   ) {
     // Either endpoint off-screen makes the whole gesture malformed: the daemon interpolates
     // between the two, so a bad end is as damaging as a bad start.
@@ -104,6 +108,7 @@ class DeviceControlInputForwarder {
         platform = platform,
         deviceId = deviceId,
         durationMs = durationMs,
+        frameContext = frameContext,
       )
     }
   }
@@ -123,10 +128,16 @@ class DeviceControlInputForwarder {
     platform: String,
     deviceId: String?,
     onError: (String) -> Unit,
+    frameContext: String,
   ) {
     if (client == null) return
     forward(onError) {
-      client.inputPressButton(button = button, platform = platform, deviceId = deviceId)
+      client.inputPressButton(
+        button = button,
+        platform = platform,
+        deviceId = deviceId,
+        frameContext = frameContext,
+      )
     }
   }
 
@@ -153,6 +164,7 @@ class DeviceControlInputForwarder {
     platform: String,
     deviceId: String?,
     onError: (String) -> Unit,
+    frameContext: String,
   ) {
     if (text.isEmpty()) return
     if (client == null) return
@@ -162,6 +174,7 @@ class DeviceControlInputForwarder {
         platform = platform,
         deviceId = deviceId,
         append = true,
+        frameContext = frameContext,
       )
     }
   }
@@ -179,9 +192,17 @@ class DeviceControlInputForwarder {
     platform: String,
     deviceId: String?,
     onError: (String) -> Unit,
+    frameContext: String,
   ) {
     if (client == null) return
-    forward(onError) { client.inputKey(key = key, platform = platform, deviceId = deviceId) }
+    forward(onError) {
+      client.inputKey(
+        key = key,
+        platform = platform,
+        deviceId = deviceId,
+        frameContext = frameContext,
+      )
+    }
   }
 
   /**

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSession.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSession.kt
@@ -621,10 +621,19 @@ class DeviceControlSession(
         // Failure: the device did not change, so nothing on screen is stale and nothing is cleared.
         refreshTracker.onInputFailed()
         if (isStaleFrameContextError(message)) {
-          staleContextRejectedCaptureSequence = command.snapshot.captureSequence
-          // Inputs already queued against the rejected snapshot must not become implicit retries.
-          dispatcher.reset()
-          interactionSnapshot = null
+          // Inputs already queued against the rejected snapshot must not become implicit retries,
+          // but a user can receive a newer paired frame and enqueue a valid command while this
+          // one is in flight. Reject only this context so that newer command stays in gesture
+          // order and can still reach the device.
+          dispatcher.discardFrameContext(command.snapshot.frameContext)
+          if (!hasNewerInteractionSnapshotThan(command.snapshot)) {
+            staleContextRejectedCaptureSequence =
+              maxOf(
+                staleContextRejectedCaptureSequence ?: Long.MIN_VALUE,
+                command.snapshot.captureSequence,
+              )
+            interactionSnapshot = null
+          }
         }
         // Serialize the claim check with the banner write on the UI context so a superseded
         // attempt's stale error cannot resurrect a banner a newer attempt already cleared.
@@ -688,6 +697,9 @@ class DeviceControlSession(
         )
     }
   }
+
+  private fun hasNewerInteractionSnapshotThan(snapshot: DeviceFrameSnapshot): Boolean =
+    interactionSnapshot?.captureSequence?.let { it > snapshot.captureSequence } == true
 
   companion object {
     private fun isStaleFrameContextError(message: String): Boolean =

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSession.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSession.kt
@@ -123,15 +123,42 @@ class DeviceControlSession(
     }
   }
 
+  /** Records the newest frame context observed from the stream. */
+  private class FrameContextTracker {
+    private var seen: Boolean = false
+    private var last: String? = null
+
+    fun observe(frameContext: String?): Boolean {
+      val changed = seen && frameContext != last
+      seen = true
+      last = frameContext
+      return changed
+    }
+
+    fun matches(frameContext: String): Boolean = !seen || frameContext == last
+
+    fun forget() {
+      seen = false
+      last = null
+    }
+  }
+
   // The declaration seen at STREAM RECEIPT — the earliest point in the pipeline, ahead of hierarchy
   // parsing and the layout state's debounce. This is the one that matters (see
   // [onObservationSpaceDeclared]).
   private val streamSpace = SpaceTracker()
 
+  // Like [streamSpace], but carries the device-authored identity that makes input actionable.
+  private val streamFrameContext = FrameContextTracker()
+
   // Newest capture identity whose coordinate space has been observed at receipt, so a late frame
   // carrying an older binding cannot roll the tracked space backward (see
   // [onObservationSpaceDeclared]).
   private var lastObservedSpaceCapture: Long? = null
+
+  // A delayed screenshot may carry the context it had when capture began, so receipt-time context
+  // observations must use the same capture ordering as coordinate-space observations.
+  private var lastObservedFrameContextCapture: Long? = null
 
   // Newest device rotation any source has proven, for the dispatch-time gate. Null until one is
   // observed, which is why a session that has seen no rotation accepts every snapshot.
@@ -355,6 +382,20 @@ class DeviceControlSession(
   }
 
   /**
+   * Note the frame context declared by an observation message at stream receipt.
+   *
+   * Frame application can be delayed by hierarchy parsing and debounce, but the runner begins
+   * rejecting the previous context as soon as it publishes the new one. Retiring control here keeps
+   * the old pixels and queued inputs from remaining actionable in that window.
+   */
+  fun onObservationFrameContextDeclared(frameContext: String?, captureSequence: Long?) {
+    val lastSeen = lastObservedFrameContextCapture
+    if (captureSequence != null && lastSeen != null && captureSequence <= lastSeen) return
+    if (captureSequence != null) lastObservedFrameContextCapture = captureSequence
+    if (streamFrameContext.observe(frameContext)) resetPreservingSpaceBaseline()
+  }
+
+  /**
    * Whether [snapshot]'s coordinates can still be sent to the device: its declared
    * [CoordinateSpace] AND its capture rotation are both the ones the device is currently reporting
    * (issues #4550, #4502).
@@ -379,6 +420,7 @@ class DeviceControlSession(
   private fun coordinatesAreStillDispatchable(snapshot: DeviceFrameSnapshot): Boolean =
     staleContextRejectedCaptureSequence == null &&
       streamSpace.matches(snapshot.coordinateSpace) &&
+      streamFrameContext.matches(snapshot.frameContext) &&
       lastProvenRotation.let { it == null || it == snapshot.rotation }
 
   /**
@@ -583,6 +625,8 @@ class DeviceControlSession(
     screenshotFactSpace.forget()
     hierarchyFactSpace.forget()
     lastObservedSpaceCapture = null
+    streamFrameContext.forget()
+    lastObservedFrameContextCapture = null
     lastProvenRotation = null
   }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSession.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSession.kt
@@ -193,6 +193,13 @@ class DeviceControlSession(
     private set
 
   /**
+   * Capture identity of a snapshot the daemon rejected as stale. The rendered snapshot remains
+   * useful for inspection, but its coordinates are no longer actionable until a later paired
+   * capture arrives.
+   */
+  private var staleContextRejectedCaptureSequence: Long? = null
+
+  /**
    * Evaluate control availability for [inputs] and, on the way, offer the resulting snapshot to the
    * refresh tracker so a pending post-input wait settles on the first superseding snapshot.
    *
@@ -208,6 +215,11 @@ class DeviceControlSession(
     inputs.newestProvenRotation()?.let { lastProvenRotation = it }
     val decision = DeviceControlPolicy.evaluate(inputs, now)
     val live = decision.snapshotOrNull
+    staleContextRejectedCaptureSequence?.let { rejectedCapture ->
+      if (live != null && live.captureSequence > rejectedCapture) {
+        staleContextRejectedCaptureSequence = null
+      }
+    }
     if (refreshTracker.state == PostInputRefreshState.AwaitingSnapshot) {
       // Hold the clicked snapshot on screen until something supersedes it (or the wait times out).
       val settled =
@@ -228,7 +240,9 @@ class DeviceControlSession(
     // view in Control for the rest of the 3s wait, and each successful tap restarts that wait, so
     // stale content could stay actionable indefinitely.
     interactionSnapshot =
-      if (refreshTracker.state == PostInputRefreshState.AwaitingSnapshot) {
+      if (staleContextRejectedCaptureSequence != null) {
+        null
+      } else if (refreshTracker.state == PostInputRefreshState.AwaitingSnapshot) {
         retainedIfStillActionable(decision, inputs, now)
       } else {
         live
@@ -363,7 +377,8 @@ class DeviceControlSession(
    * nothing to contradict.
    */
   private fun coordinatesAreStillDispatchable(snapshot: DeviceFrameSnapshot): Boolean =
-    streamSpace.matches(snapshot.coordinateSpace) &&
+    staleContextRejectedCaptureSequence == null &&
+      streamSpace.matches(snapshot.coordinateSpace) &&
       lastProvenRotation.let { it == null || it == snapshot.rotation }
 
   /**
@@ -472,6 +487,7 @@ class DeviceControlSession(
    * view received while focused and in control mode.
    */
   fun key(snapshot: DeviceFrameSnapshot, stroke: DeviceKeyStroke): Boolean {
+    if (!coordinatesAreStillDispatchable(snapshot)) return false
     when (val decision = decide(stroke)) {
       is DeviceKeyboardDecision.PressButton ->
         enqueue { client, platformName, token ->
@@ -582,6 +598,7 @@ class DeviceControlSession(
     dispatcher.reset()
     errorToken.incrementAndGet()
     refreshTracker.reset()
+    staleContextRejectedCaptureSequence = null
     renderSnapshot = null
     interactionSnapshot = null
     publishError(null)
@@ -603,6 +620,12 @@ class DeviceControlSession(
       } else {
         // Failure: the device did not change, so nothing on screen is stale and nothing is cleared.
         refreshTracker.onInputFailed()
+        if (isStaleFrameContextError(message)) {
+          staleContextRejectedCaptureSequence = command.snapshot.captureSequence
+          // Inputs already queued against the rejected snapshot must not become implicit retries.
+          dispatcher.reset()
+          interactionSnapshot = null
+        }
         // Serialize the claim check with the banner write on the UI context so a superseded
         // attempt's stale error cannot resurrect a banner a newer attempt already cleared.
         if (command.token == errorToken.get()) publishError(message)
@@ -622,6 +645,7 @@ class DeviceControlSession(
           client = command.client,
           platform = command.platform,
           deviceId = command.snapshot.deviceId,
+          frameContext = command.snapshot.frameContext,
           onError = onError,
         )
       is DeviceControlInputCommand.Swipe ->
@@ -632,6 +656,7 @@ class DeviceControlSession(
           client = command.client,
           platform = command.platform,
           deviceId = command.snapshot.deviceId,
+          frameContext = command.snapshot.frameContext,
           onError = onError,
         )
       is DeviceControlInputCommand.PressButton ->
@@ -640,6 +665,7 @@ class DeviceControlSession(
           client = command.client,
           platform = command.platform,
           deviceId = command.snapshot.deviceId,
+          frameContext = command.snapshot.frameContext,
           onError = onError,
         )
       is DeviceControlInputCommand.TypeText ->
@@ -648,6 +674,7 @@ class DeviceControlSession(
           client = command.client,
           platform = command.platform,
           deviceId = command.snapshot.deviceId,
+          frameContext = command.snapshot.frameContext,
           onError = onError,
         )
       is DeviceControlInputCommand.SendKey ->
@@ -656,12 +683,17 @@ class DeviceControlSession(
           client = command.client,
           platform = command.platform,
           deviceId = command.snapshot.deviceId,
+          frameContext = command.snapshot.frameContext,
           onError = onError,
         )
     }
   }
 
   companion object {
+    private fun isStaleFrameContextError(message: String): Boolean =
+      message.contains("frameContext", ignoreCase = true) &&
+        message.contains("stale or unavailable", ignoreCase = true)
+
     /**
      * Shown when the bounded dispatch queue rejects an input because the daemon is not draining it.
      */

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSession.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSession.kt
@@ -691,8 +691,9 @@ class DeviceControlSession(
 
   companion object {
     private fun isStaleFrameContextError(message: String): Boolean =
-      message.contains("frameContext", ignoreCase = true) &&
-        message.contains("stale or unavailable", ignoreCase = true)
+      message.contains("stale frame context", ignoreCase = true) ||
+        (message.contains("frameContext", ignoreCase = true) &&
+          message.contains("stale or unavailable", ignoreCase = true))
 
     /**
      * Shown when the bounded dispatch queue rejects an input because the daemon is not draining it.

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSession.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSession.kt
@@ -220,11 +220,11 @@ class DeviceControlSession(
     private set
 
   /**
-   * Capture identity of a snapshot the daemon rejected as stale. The rendered snapshot remains
-   * useful for inspection, but its coordinates are no longer actionable until a later paired
-   * capture arrives.
+   * Frame context of a snapshot the daemon rejected as stale. The rendered snapshot remains useful
+   * for inspection, but its coordinates are no longer actionable until the device reports a
+   * different context.
    */
-  private var staleContextRejectedCaptureSequence: Long? = null
+  private var staleContextRejectedFrameContext: String? = null
 
   /**
    * Evaluate control availability for [inputs] and, on the way, offer the resulting snapshot to the
@@ -242,9 +242,9 @@ class DeviceControlSession(
     inputs.newestProvenRotation()?.let { lastProvenRotation = it }
     val decision = DeviceControlPolicy.evaluate(inputs, now)
     val live = decision.snapshotOrNull
-    staleContextRejectedCaptureSequence?.let { rejectedCapture ->
-      if (live != null && live.captureSequence > rejectedCapture) {
-        staleContextRejectedCaptureSequence = null
+    staleContextRejectedFrameContext?.let { rejectedContext ->
+      if (live != null && live.frameContext != rejectedContext) {
+        staleContextRejectedFrameContext = null
       }
     }
     if (refreshTracker.state == PostInputRefreshState.AwaitingSnapshot) {
@@ -267,7 +267,7 @@ class DeviceControlSession(
     // view in Control for the rest of the 3s wait, and each successful tap restarts that wait, so
     // stale content could stay actionable indefinitely.
     interactionSnapshot =
-      if (staleContextRejectedCaptureSequence != null) {
+      if (staleContextRejectedFrameContext != null) {
         null
       } else if (refreshTracker.state == PostInputRefreshState.AwaitingSnapshot) {
         retainedIfStillActionable(decision, inputs, now)
@@ -418,7 +418,7 @@ class DeviceControlSession(
    * nothing to contradict.
    */
   private fun coordinatesAreStillDispatchable(snapshot: DeviceFrameSnapshot): Boolean =
-    staleContextRejectedCaptureSequence == null &&
+    staleContextRejectedFrameContext == null &&
       streamSpace.matches(snapshot.coordinateSpace) &&
       streamFrameContext.matches(snapshot.frameContext) &&
       lastProvenRotation.let { it == null || it == snapshot.rotation }
@@ -642,7 +642,7 @@ class DeviceControlSession(
     dispatcher.reset()
     errorToken.incrementAndGet()
     refreshTracker.reset()
-    staleContextRejectedCaptureSequence = null
+    staleContextRejectedFrameContext = null
     renderSnapshot = null
     interactionSnapshot = null
     publishError(null)
@@ -669,13 +669,14 @@ class DeviceControlSession(
           // but a user can receive a newer paired frame and enqueue a valid command while this
           // one is in flight. Reject only this context so that newer command stays in gesture
           // order and can still reach the device.
-          dispatcher.discardFrameContext(command.snapshot.frameContext)
-          if (!hasNewerInteractionSnapshotThan(command.snapshot)) {
-            staleContextRejectedCaptureSequence =
-              maxOf(
-                staleContextRejectedCaptureSequence ?: Long.MIN_VALUE,
-                command.snapshot.captureSequence,
-              )
+          val newestDiscardedToken = dispatcher.discardFrameContext(command.snapshot.frameContext)
+          if (newestDiscardedToken == errorToken.get()) {
+            // A discarded retry owned the current claim. Its removal must not also suppress the
+            // stale rejection that explains why control is unavailable.
+            errorToken.set(command.token)
+          }
+          if (!hasDifferentInteractionFrameContextThan(command.snapshot)) {
+            staleContextRejectedFrameContext = command.snapshot.frameContext
             interactionSnapshot = null
           }
         }
@@ -742,8 +743,8 @@ class DeviceControlSession(
     }
   }
 
-  private fun hasNewerInteractionSnapshotThan(snapshot: DeviceFrameSnapshot): Boolean =
-    interactionSnapshot?.captureSequence?.let { it > snapshot.captureSequence } == true
+  private fun hasDifferentInteractionFrameContextThan(snapshot: DeviceFrameSnapshot): Boolean =
+    interactionSnapshot?.frameContext?.let { it != snapshot.frameContext } == true
 
   companion object {
     private fun isStaleFrameContextError(message: String): Boolean =

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSession.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSession.kt
@@ -270,9 +270,11 @@ class DeviceControlSession(
       if (staleContextRejectedFrameContext != null) {
         null
       } else if (refreshTracker.state == PostInputRefreshState.AwaitingSnapshot) {
-        retainedIfStillActionable(decision, inputs, now)
+        retainedIfStillActionable(decision, inputs, now)?.takeIf {
+          streamFrameContext.matches(it.frameContext)
+        }
       } else {
-        live
+        live?.takeIf { streamFrameContext.matches(it.frameContext) }
       }
     return decision
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AutoMobileClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/AutoMobileClient.kt
@@ -82,6 +82,7 @@ interface AutoMobileClient {
     platform: String = "android",
     deviceId: String? = null,
     duration: Int? = null,
+    frameContext: String? = null,
   ): InputActionResult
 
   fun inputSwipe(
@@ -92,12 +93,14 @@ interface AutoMobileClient {
     platform: String = "android",
     deviceId: String? = null,
     durationMs: Int? = null,
+    frameContext: String? = null,
   ): InputActionResult
 
   fun inputPressButton(
     button: String,
     platform: String = "android",
     deviceId: String? = null,
+    frameContext: String? = null,
   ): InputActionResult
 
   /**
@@ -113,12 +116,14 @@ interface AutoMobileClient {
     deviceId: String? = null,
     submit: Boolean? = null,
     append: Boolean = false,
+    frameContext: String? = null,
   ): InputActionResult
 
   fun inputKey(
     key: String,
     platform: String = "android",
     deviceId: String? = null,
+    frameContext: String? = null,
   ): InputActionResult
 
   fun setKeyValue(

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClient.kt
@@ -296,6 +296,7 @@ class McpDaemonClient(
     platform: String,
     deviceId: String?,
     duration: Int?,
+    frameContext: String?,
   ): InputActionResult {
     return sendInputRequest(
       "input/tap",
@@ -305,6 +306,7 @@ class McpDaemonClient(
         put("x", JsonPrimitive(x))
         put("y", JsonPrimitive(y))
         putOptionalInt("duration", duration)
+        putOptionalString("frameContext", frameContext)
       },
     )
   }
@@ -317,6 +319,7 @@ class McpDaemonClient(
     platform: String,
     deviceId: String?,
     durationMs: Int?,
+    frameContext: String?,
   ): InputActionResult {
     return sendInputRequest(
       "input/swipe",
@@ -328,6 +331,7 @@ class McpDaemonClient(
         put("endX", JsonPrimitive(endX))
         put("endY", JsonPrimitive(endY))
         putOptionalInt("durationMs", durationMs)
+        putOptionalString("frameContext", frameContext)
       },
     )
   }
@@ -336,6 +340,7 @@ class McpDaemonClient(
     button: String,
     platform: String,
     deviceId: String?,
+    frameContext: String?,
   ): InputActionResult {
     return sendInputRequest(
       "input/pressButton",
@@ -343,6 +348,7 @@ class McpDaemonClient(
         put("platform", JsonPrimitive(platform))
         putOptionalString("deviceId", deviceId)
         put("button", JsonPrimitive(button))
+        putOptionalString("frameContext", frameContext)
       },
     )
   }
@@ -353,6 +359,7 @@ class McpDaemonClient(
     deviceId: String?,
     submit: Boolean?,
     append: Boolean,
+    frameContext: String?,
   ): InputActionResult {
     val appendSupportError = if (append) inputTypeTextAppendSupportError() else null
     if (appendSupportError != null) {
@@ -370,6 +377,7 @@ class McpDaemonClient(
             putOptionalString("deviceId", deviceId)
             put("text", JsonPrimitive(text))
             putOptionalBoolean("submit", submit)
+            putOptionalString("frameContext", frameContext)
             // Omitted entirely when false: the daemon rejects unknown/!append values, and older
             // daemons reject the param outright.
             if (append) put("mode", JsonPrimitive("append"))
@@ -393,6 +401,7 @@ class McpDaemonClient(
     key: String,
     platform: String,
     deviceId: String?,
+    frameContext: String?,
   ): InputActionResult {
     return sendInputRequest(
       "input/key",
@@ -400,6 +409,7 @@ class McpDaemonClient(
         put("platform", JsonPrimitive(platform))
         putOptionalString("deviceId", deviceId)
         put("key", JsonPrimitive(key))
+        putOptionalString("frameContext", frameContext)
       },
     )
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpHttpClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpHttpClient.kt
@@ -362,6 +362,7 @@ class McpHttpClient(
     platform: String,
     deviceId: String?,
     duration: Int?,
+    frameContext: String?,
   ): InputActionResult = unsupportedInputAction(transportName, "input/tap")
 
   override fun inputSwipe(
@@ -372,12 +373,14 @@ class McpHttpClient(
     platform: String,
     deviceId: String?,
     durationMs: Int?,
+    frameContext: String?,
   ): InputActionResult = unsupportedInputAction(transportName, "input/swipe")
 
   override fun inputPressButton(
     button: String,
     platform: String,
     deviceId: String?,
+    frameContext: String?,
   ): InputActionResult = unsupportedInputAction(transportName, "input/pressButton")
 
   override fun inputTypeText(
@@ -386,12 +389,14 @@ class McpHttpClient(
     deviceId: String?,
     submit: Boolean?,
     append: Boolean,
+    frameContext: String?,
   ): InputActionResult = unsupportedInputAction(transportName, "input/typeText")
 
   override fun inputKey(
     key: String,
     platform: String,
     deviceId: String?,
+    frameContext: String?,
   ): InputActionResult = unsupportedInputAction(transportName, "input/key")
 
   override fun callTool(name: String, arguments: JsonObject): JsonElement {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpStdioClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpStdioClient.kt
@@ -353,6 +353,7 @@ class McpStdioClient(
     platform: String,
     deviceId: String?,
     duration: Int?,
+    frameContext: String?,
   ): InputActionResult = unsupportedInputAction(transportName, "input/tap")
 
   override fun inputSwipe(
@@ -363,12 +364,14 @@ class McpStdioClient(
     platform: String,
     deviceId: String?,
     durationMs: Int?,
+    frameContext: String?,
   ): InputActionResult = unsupportedInputAction(transportName, "input/swipe")
 
   override fun inputPressButton(
     button: String,
     platform: String,
     deviceId: String?,
+    frameContext: String?,
   ): InputActionResult = unsupportedInputAction(transportName, "input/pressButton")
 
   override fun inputTypeText(
@@ -377,12 +380,14 @@ class McpStdioClient(
     deviceId: String?,
     submit: Boolean?,
     append: Boolean,
+    frameContext: String?,
   ): InputActionResult = unsupportedInputAction(transportName, "input/typeText")
 
   override fun inputKey(
     key: String,
     platform: String,
     deviceId: String?,
+    frameContext: String?,
   ): InputActionResult = unsupportedInputAction(transportName, "input/key")
 
   override fun callTool(name: String, arguments: JsonObject): JsonElement {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
@@ -317,6 +317,7 @@ class ObservationStreamClient {
             packageName = packageName,
             diff = response.hierarchyDiff,
             captureSequence = response.captureSequence,
+            frameContext = response.frameContext,
             coordinateSpace = CoordinateSpace.fromWire(response.coordinateSpace),
             rotation = response.rotation,
           )
@@ -344,6 +345,7 @@ class ObservationStreamClient {
             screenshotByteLength = response.screenshotByteLength,
             screenshotBase64Length = response.screenshotBase64Length,
             captureSequence = response.captureSequence,
+            frameContext = response.frameContext,
             coordinateSpace = CoordinateSpace.fromWire(response.coordinateSpace),
             rotation = response.rotation,
           )
@@ -579,6 +581,8 @@ data class StreamResponse(
    * reports geometry derived from that hierarchy. Null on daemons that predate it.
    */
   val captureSequence: Long? = null,
+  /** Opaque device-authored identity for the UI state this message describes. */
+  val frameContext: String? = null,
   /**
    * Declared coordinate space of this message's geometry — `"px"` for canonical physical pixels
    * (issue #4549). Absent on a legacy frame. Kept as the raw wire [String] here so an unknown
@@ -671,6 +675,8 @@ data class HierarchyStreamUpdate(
   val diff: HierarchyDiffSummary? = null,
   /** Shared capture identity; see [StreamResponse.captureSequence]. */
   val captureSequence: Long? = null,
+  /** Opaque device-authored identity; see [StreamResponse.frameContext]. */
+  val frameContext: String? = null,
   /**
    * Declared coordinate space of this update's element `bounds`; see
    * [StreamResponse.coordinateSpace]. Null means the daemon declared none (legacy point-space).
@@ -697,6 +703,8 @@ data class ScreenshotStreamUpdate(
   val screenshotBase64Length: Int? = null,
   /** Shared capture identity; see [StreamResponse.captureSequence]. */
   val captureSequence: Long? = null,
+  /** Opaque device-authored identity; see [StreamResponse.frameContext]. */
+  val frameContext: String? = null,
   /**
    * Declared coordinate space of this frame's [screenWidth]/[screenHeight]; see
    * [StreamResponse.coordinateSpace]. Null means the daemon declared none (legacy point-space).

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceControlBlockedNotice.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceControlBlockedNotice.kt
@@ -51,6 +51,10 @@ internal fun deviceControlBlockReasonText(reason: DeviceControlBlockReason): Str
       "Device control paused: waiting for screenshot and layout to sync"
     DeviceControlBlockReason.CaptureIdentityUnavailable ->
       "Device control unavailable: daemon does not report capture identity"
+    DeviceControlBlockReason.FrameContextUnavailable ->
+      "Device control unavailable: runner does not report frame context"
+    DeviceControlBlockReason.FrameContextMismatch ->
+      "Device control paused: screenshot and layout frame contexts disagree"
     // A permanent, actionable condition rather than a transient one: the daemon is newer than this
     // client, so the wording points at the fix (update) instead of implying it will resolve itself.
     DeviceControlBlockReason.UnsupportedCoordinateSpace ->

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorState.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorState.kt
@@ -265,6 +265,7 @@ class LayoutInspectorState(
     deviceId: String? = null,
     generation: Long? = null,
     captureSequence: Long? = null,
+    frameContext: String? = null,
     coordinateSpace: CoordinateSpace? = null,
     rotation: Int? = null,
   ) {
@@ -284,6 +285,7 @@ class LayoutInspectorState(
         deviceId = deviceId,
         sequence = nextSourceSequence(),
         captureSequence = captureSequence,
+        frameContext = frameContext,
         receivedAtMs = nowMs(),
         width = width,
         height = height,
@@ -305,6 +307,7 @@ class LayoutInspectorState(
     newRotation: Int = 0,
     deviceId: String? = null,
     captureSequence: Long? = null,
+    frameContext: String? = null,
     coordinateSpace: CoordinateSpace? = null,
     captureRotation: Int? = null,
   ) {
@@ -319,6 +322,7 @@ class LayoutInspectorState(
       changedIds,
       deviceId,
       captureSequence,
+      frameContext,
       coordinateSpace,
       captureRotation,
     )
@@ -338,6 +342,7 @@ class LayoutInspectorState(
     deviceId: String? = null,
     generation: Long? = null,
     captureSequence: Long? = null,
+    frameContext: String? = null,
     coordinateSpace: CoordinateSpace? = null,
     captureRotation: Int? = null,
   ) {
@@ -352,6 +357,7 @@ class LayoutInspectorState(
         changedIds,
         deviceId,
         captureSequence,
+        frameContext,
         coordinateSpace,
         captureRotation,
       )
@@ -368,6 +374,7 @@ class LayoutInspectorState(
     changedIds: Set<String>,
     deviceId: String? = null,
     captureSequence: Long? = null,
+    frameContext: String? = null,
     coordinateSpace: CoordinateSpace? = null,
     captureRotation: Int? = null,
   ) {
@@ -380,6 +387,7 @@ class LayoutInspectorState(
         deviceId = deviceId,
         sequence = nextSourceSequence(),
         captureSequence = captureSequence,
+        frameContext = frameContext,
         receivedAtMs = nowMs(),
         hierarchy = parsed,
         // The root commonly reports (0,0,0,0) on Android (accessibility service); 0 tells the

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/testing/FakeAutoMobileClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/testing/FakeAutoMobileClient.kt
@@ -134,6 +134,7 @@ class FakeAutoMobileClient : AutoMobileClient {
     val platform: String,
     val deviceId: String?,
     val duration: Int?,
+    val frameContext: String? = null,
   )
 
   data class InputSwipeCall(
@@ -144,12 +145,14 @@ class FakeAutoMobileClient : AutoMobileClient {
     val platform: String,
     val deviceId: String?,
     val durationMs: Int?,
+    val frameContext: String? = null,
   )
 
   data class InputPressButtonCall(
     val button: String,
     val platform: String,
     val deviceId: String?,
+    val frameContext: String? = null,
   )
 
   data class InputTypeTextCall(
@@ -158,12 +161,14 @@ class FakeAutoMobileClient : AutoMobileClient {
     val deviceId: String?,
     val submit: Boolean?,
     val append: Boolean = false,
+    val frameContext: String? = null,
   )
 
   data class InputKeyCall(
     val key: String,
     val platform: String,
     val deviceId: String?,
+    val frameContext: String? = null,
   )
 
   val setKeyValueCalls = mutableListOf<SetKeyValueCall>()
@@ -298,9 +303,10 @@ class FakeAutoMobileClient : AutoMobileClient {
     platform: String,
     deviceId: String?,
     duration: Int?,
+    frameContext: String?,
   ): InputActionResult {
     calls.add("inputTap")
-    inputTapCalls.add(InputTapCall(x, y, platform, deviceId, duration))
+    inputTapCalls.add(InputTapCall(x, y, platform, deviceId, duration, frameContext))
     return inputTapResult
   }
 
@@ -312,9 +318,12 @@ class FakeAutoMobileClient : AutoMobileClient {
     platform: String,
     deviceId: String?,
     durationMs: Int?,
+    frameContext: String?,
   ): InputActionResult {
     calls.add("inputSwipe")
-    inputSwipeCalls.add(InputSwipeCall(startX, startY, endX, endY, platform, deviceId, durationMs))
+    inputSwipeCalls.add(
+      InputSwipeCall(startX, startY, endX, endY, platform, deviceId, durationMs, frameContext)
+    )
     return inputSwipeResult
   }
 
@@ -322,9 +331,10 @@ class FakeAutoMobileClient : AutoMobileClient {
     button: String,
     platform: String,
     deviceId: String?,
+    frameContext: String?,
   ): InputActionResult {
     calls.add("inputPressButton")
-    inputPressButtonCalls.add(InputPressButtonCall(button, platform, deviceId))
+    inputPressButtonCalls.add(InputPressButtonCall(button, platform, deviceId, frameContext))
     return inputPressButtonResult
   }
 
@@ -334,9 +344,12 @@ class FakeAutoMobileClient : AutoMobileClient {
     deviceId: String?,
     submit: Boolean?,
     append: Boolean,
+    frameContext: String?,
   ): InputActionResult {
     calls.add("inputTypeText")
-    inputTypeTextCalls.add(InputTypeTextCall(text, platform, deviceId, submit, append))
+    inputTypeTextCalls.add(
+      InputTypeTextCall(text, platform, deviceId, submit, append, frameContext)
+    )
     return inputTypeTextResult
   }
 
@@ -344,9 +357,10 @@ class FakeAutoMobileClient : AutoMobileClient {
     key: String,
     platform: String,
     deviceId: String?,
+    frameContext: String?,
   ): InputActionResult {
     calls.add("inputKey")
-    inputKeyCalls.add(InputKeyCall(key, platform, deviceId))
+    inputKeyCalls.add(InputKeyCall(key, platform, deviceId, frameContext))
     return inputKeyResult
   }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlInputDispatcherTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlInputDispatcherTest.kt
@@ -2,6 +2,7 @@ package dev.jasonpearson.automobile.desktop.core.control
 
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
 import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
+import dev.jasonpearson.automobile.desktop.domain.DeviceFrameSnapshot
 import dev.jasonpearson.automobile.desktop.domain.DevicePoint
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -20,12 +21,16 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class DeviceControlInputDispatcherTest {
 
-  private fun command(token: Long = 0L, client: AutoMobileClient? = null) =
+  private fun command(
+    token: Long = 0L,
+    client: AutoMobileClient? = null,
+    snapshot: DeviceFrameSnapshot = testSnapshot(),
+  ) =
     DeviceControlInputCommand.Tap(
       point = DevicePoint(x = 0, y = 0, inBounds = true),
       client = client,
       platform = "android",
-      snapshot = testSnapshot(),
+      snapshot = snapshot,
       token = token,
     )
 
@@ -116,6 +121,34 @@ class DeviceControlInputDispatcherTest {
       "the in-flight tap's client is left to its own finally",
     )
     assertEquals(emptyList(), forwarded, "no pending tap forwards after reset")
+    scope.cancel()
+  }
+
+  @Test
+  fun `discarding a stale frame context preserves newer pending commands`() = runTest {
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val stall = CompletableDeferred<Unit>()
+    val forwarded = mutableListOf<Long>()
+    val dispatcher =
+      DeviceControlInputDispatcher(scope) { cmd ->
+        if (cmd.token == 0L) stall.await() else forwarded += cmd.token
+      }
+    val staleSnapshot = testSnapshot(sequence = 7L)
+    val freshSnapshot = testSnapshot(sequence = 8L)
+    val staleClient = FakeAutoMobileClient()
+    val freshClient = FakeAutoMobileClient()
+
+    dispatcher.enqueue(command(token = 0L))
+    dispatcher.enqueue(command(token = 1L, client = staleClient, snapshot = staleSnapshot))
+    dispatcher.enqueue(command(token = 2L, client = freshClient, snapshot = freshSnapshot))
+
+    dispatcher.discardFrameContext(staleSnapshot.frameContext)
+    stall.complete(Unit)
+    advanceUntilIdle()
+
+    assertTrue("close" in staleClient.calls, "stale pending command must be closed")
+    assertFalse("close" in freshClient.calls, "newer pending command must stay queued")
+    assertEquals(listOf(2L), forwarded)
     scope.cancel()
   }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlInputDispatcherTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlInputDispatcherTest.kt
@@ -142,7 +142,7 @@ class DeviceControlInputDispatcherTest {
     dispatcher.enqueue(command(token = 1L, client = staleClient, snapshot = staleSnapshot))
     dispatcher.enqueue(command(token = 2L, client = freshClient, snapshot = freshSnapshot))
 
-    dispatcher.discardFrameContext(staleSnapshot.frameContext)
+    assertEquals(1L, dispatcher.discardFrameContext(staleSnapshot.frameContext))
     stall.complete(Unit)
     advanceUntilIdle()
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlInputForwarderTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlInputForwarderTest.kt
@@ -20,13 +20,18 @@ class DeviceControlInputForwarderTest {
 
   private val forwarder = DeviceControlInputForwarder()
 
+  private companion object {
+    const val TEST_FRAME_CONTEXT = "android:44"
+  }
+
   private fun forward(
     point: DevicePoint,
     client: AutoMobileClient?,
     platform: String = "android",
     deviceId: String? = "emulator-5554",
     onError: (String) -> Unit = { error("unexpected error: $it") },
-  ) = forwarder.forwardTap(point, client, platform, deviceId, onError)
+    frameContext: String = TEST_FRAME_CONTEXT,
+  ) = forwarder.forwardTap(point, client, platform, deviceId, onError, frameContext)
 
   @Test
   fun `in-bounds tap forwards mapped device coordinates to inputTap`() {
@@ -50,6 +55,7 @@ class DeviceControlInputForwarderTest {
           platform = "android",
           deviceId = "emulator-5554",
           duration = null,
+          frameContext = TEST_FRAME_CONTEXT,
         )
       ),
       fake.inputTapCalls,
@@ -110,6 +116,7 @@ class DeviceControlInputForwarderTest {
           platform: String,
           deviceId: String?,
           duration: Int?,
+          frameContext: String?,
         ): InputActionResult = throw IllegalStateException("daemon socket closed")
       }
     var error: String? = null
@@ -144,6 +151,7 @@ class DeviceControlInputForwarderTest {
       platform = "ios",
       deviceId = "sim-udid",
       onError = { error("unexpected error: $it") },
+      frameContext = TEST_FRAME_CONTEXT,
     )
 
     assertEquals(
@@ -156,6 +164,7 @@ class DeviceControlInputForwarderTest {
           platform = "ios",
           deviceId = "sim-udid",
           durationMs = 300,
+          frameContext = TEST_FRAME_CONTEXT,
         )
       ),
       fake.inputSwipeCalls,
@@ -176,6 +185,7 @@ class DeviceControlInputForwarderTest {
       platform = "android",
       deviceId = "emulator-5554",
       onError = { error = it },
+      frameContext = TEST_FRAME_CONTEXT,
     )
     forwarder.forwardSwipe(
       start = DevicePoint(x = -4, y = 10, inBounds = false),
@@ -185,6 +195,7 @@ class DeviceControlInputForwarderTest {
       platform = "android",
       deviceId = "emulator-5554",
       onError = { error = it },
+      frameContext = TEST_FRAME_CONTEXT,
     )
 
     assertTrue(fake.inputSwipeCalls.isEmpty(), "an off-screen endpoint must not be sent")
@@ -213,6 +224,7 @@ class DeviceControlInputForwarderTest {
       platform = "android",
       deviceId = null,
       onError = { error = it },
+      frameContext = TEST_FRAME_CONTEXT,
     )
 
     assertEquals("No active android device to swipe", error)
@@ -230,6 +242,7 @@ class DeviceControlInputForwarderTest {
           platform: String,
           deviceId: String?,
           durationMs: Int?,
+          frameContext: String?,
         ): InputActionResult = throw IllegalStateException("daemon socket closed")
       }
     var error: String? = null
@@ -242,6 +255,7 @@ class DeviceControlInputForwarderTest {
       platform = "android",
       deviceId = null,
       onError = { error = it },
+      frameContext = TEST_FRAME_CONTEXT,
     )
 
     assertEquals("daemon socket closed", error)
@@ -259,6 +273,7 @@ class DeviceControlInputForwarderTest {
       platform = "android",
       deviceId = null,
       onError = { error = it },
+      frameContext = TEST_FRAME_CONTEXT,
     )
 
     assertNull(error)
@@ -276,6 +291,7 @@ class DeviceControlInputForwarderTest {
       platform = "android",
       deviceId = "emulator-5554",
       onError = { fail("empty text must not be an error, it must be a no-op: $it") },
+      frameContext = TEST_FRAME_CONTEXT,
     )
 
     assertEquals(emptyList(), client.inputTypeTextCalls)
@@ -286,9 +302,9 @@ class DeviceControlInputForwarderTest {
     var error: String? = null
     val onError: (String) -> Unit = { error = it }
 
-    forwarder.forwardPressButton("back", null, "android", null, onError)
-    forwarder.forwardTypeText("a", null, "android", null, onError)
-    forwarder.forwardKey("enter", null, "android", null, onError)
+    forwarder.forwardPressButton("back", null, "android", null, onError, TEST_FRAME_CONTEXT)
+    forwarder.forwardTypeText("a", null, "android", null, onError, TEST_FRAME_CONTEXT)
+    forwarder.forwardKey("enter", null, "android", null, onError, TEST_FRAME_CONTEXT)
 
     assertNull(error)
   }
@@ -300,8 +316,71 @@ class DeviceControlInputForwarderTest {
       InputActionResult(action = "input/key", success = false, error = "unsupported on ios")
     var error: String? = null
 
-    forwarder.forwardKey("enter", client, "ios", "iphone-1", onError = { error = it })
+    forwarder.forwardKey(
+      "enter",
+      client,
+      "ios",
+      "iphone-1",
+      onError = { error = it },
+      frameContext = TEST_FRAME_CONTEXT,
+    )
 
     assertEquals("unsupported on ios", error)
+  }
+
+  @Test
+  fun `every desktop input helper echoes the paired frame context`() {
+    val client = FakeAutoMobileClient()
+    val context = TEST_FRAME_CONTEXT
+    val onError: (String) -> Unit = { fail("unexpected error: $it") }
+
+    forwarder.forwardTap(
+      point = DevicePoint(x = 1, y = 2, inBounds = true),
+      client = client,
+      platform = "android",
+      deviceId = "emulator-5554",
+      frameContext = context,
+      onError = onError,
+    )
+    forwarder.forwardSwipe(
+      start = DevicePoint(x = 1, y = 2, inBounds = true),
+      end = DevicePoint(x = 3, y = 4, inBounds = true),
+      durationMs = 300,
+      client = client,
+      platform = "android",
+      deviceId = "emulator-5554",
+      frameContext = context,
+      onError = onError,
+    )
+    forwarder.forwardPressButton(
+      button = "back",
+      client = client,
+      platform = "android",
+      deviceId = "emulator-5554",
+      frameContext = context,
+      onError = onError,
+    )
+    forwarder.forwardTypeText(
+      text = "a",
+      client = client,
+      platform = "android",
+      deviceId = "emulator-5554",
+      frameContext = context,
+      onError = onError,
+    )
+    forwarder.forwardKey(
+      key = "enter",
+      client = client,
+      platform = "android",
+      deviceId = "emulator-5554",
+      frameContext = context,
+      onError = onError,
+    )
+
+    assertEquals(context, client.inputTapCalls.single().frameContext)
+    assertEquals(context, client.inputSwipeCalls.single().frameContext)
+    assertEquals(context, client.inputPressButtonCalls.single().frameContext)
+    assertEquals(context, client.inputTypeTextCalls.single().frameContext)
+    assertEquals(context, client.inputKeyCalls.single().frameContext)
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlPolicyTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlPolicyTest.kt
@@ -67,6 +67,7 @@ class DeviceControlPolicyTest {
         width = 1080,
         height = 2340,
         data = null,
+        frameContext = "epoch:7",
         rotation = 0,
       ),
     hierarchy: HierarchyFrameFacts? =
@@ -78,6 +79,7 @@ class DeviceControlPolicyTest {
         hierarchy = hierarchyOf(1080, 2340),
         rootWidth = 1080,
         rootHeight = 2340,
+        frameContext = "epoch:7",
         rotation = 0,
       ),
     liveFrame: LiveFrameFacts? = null,
@@ -106,6 +108,7 @@ class DeviceControlPolicyTest {
     assertEquals(DeviceFrameSource.Screenshot, snapshot.source)
     assertEquals(1080, snapshot.deviceWidth)
     assertEquals(2340, snapshot.deviceHeight)
+    assertEquals("epoch:7", snapshot.frameContext)
     // Monotonic ordering: the newest contributing source sequence.
     assertEquals(11L, snapshot.sequence)
   }
@@ -207,6 +210,7 @@ class DeviceControlPolicyTest {
               width = 720,
               height = 1560,
               data = null,
+              frameContext = "epoch:pair",
               rotation = 0,
             ),
           hierarchy =
@@ -218,6 +222,7 @@ class DeviceControlPolicyTest {
               hierarchy = hierarchyOf(1080, 2340),
               rootWidth = 1080,
               rootHeight = 2340,
+              frameContext = "epoch:pair",
               rotation = 0,
             ),
         ),
@@ -248,8 +253,30 @@ class DeviceControlPolicyTest {
               hierarchy = hierarchyOf(720, 1560),
               rootWidth = 720,
               rootHeight = 1560,
+              frameContext = "epoch:7",
               rotation = 0,
             )
+        )
+      ),
+    )
+  }
+
+  @Test
+  fun `missing frame context keeps the client in inspector mode`() {
+    assertEquals(
+      DeviceControlBlockReason.FrameContextUnavailable,
+      blockedReason(inputs(screenshot = inputs().screenshot?.copy(frameContext = null))),
+    )
+  }
+
+  @Test
+  fun `mismatched frame contexts keep the client in inspector mode`() {
+    assertEquals(
+      DeviceControlBlockReason.FrameContextMismatch,
+      blockedReason(
+        inputs(
+          screenshot = inputs().screenshot?.copy(frameContext = "epoch:7"),
+          hierarchy = inputs().hierarchy?.copy(frameContext = "epoch:8"),
         )
       ),
     )
@@ -273,6 +300,7 @@ class DeviceControlPolicyTest {
               width = 2340,
               height = 1080,
               data = null,
+              frameContext = "epoch:7",
               rotation = 1,
             ),
           hierarchy =
@@ -284,6 +312,7 @@ class DeviceControlPolicyTest {
               hierarchy = hierarchyOf(1080, 2340),
               rootWidth = 1080,
               rootHeight = 2340,
+              frameContext = "epoch:7",
               rotation = 0,
             ),
         )
@@ -306,6 +335,7 @@ class DeviceControlPolicyTest {
               width = 1080,
               height = 2340,
               data = null,
+              frameContext = "epoch:7",
               rotation = 4,
             ),
           hierarchy =
@@ -317,6 +347,7 @@ class DeviceControlPolicyTest {
               hierarchy = hierarchyOf(1080, 2340),
               rootWidth = 1080,
               rootHeight = 2340,
+              frameContext = "epoch:7",
               rotation = 4,
             ),
         )
@@ -341,6 +372,7 @@ class DeviceControlPolicyTest {
                 width = 1170,
                 height = 2532,
                 data = null,
+                frameContext = "epoch:7",
                 rotation = 1,
               ),
             hierarchy =
@@ -352,6 +384,7 @@ class DeviceControlPolicyTest {
                 hierarchy = hierarchyOf(2532, 1170),
                 rootWidth = 2532,
                 rootHeight = 1170,
+                frameContext = "epoch:7",
                 rotation = 1,
               ),
           ),
@@ -499,6 +532,7 @@ class DeviceControlPolicyTest {
         width = 1080,
         height = 2340,
         data = null,
+        frameContext = "epoch:7",
         rotation = 0,
       )
     assertEquals(DeviceControlBlockReason.StaleFrame, blockedReason(inputs(screenshot = stale)))
@@ -613,6 +647,7 @@ class DeviceControlPolicyTest {
                   hierarchy = hierarchyOf(0, 0),
                   rootWidth = 0,
                   rootHeight = 0,
+                  frameContext = "epoch:7",
                   rotation = 0,
                 )
             ),
@@ -636,6 +671,7 @@ class DeviceControlPolicyTest {
       height = height,
       data = null,
       coordinateSpace = coordinateSpace,
+      frameContext = "epoch:7",
       // Proven rotation so the #4502 gate passes and these tests isolate the COORDINATE-SPACE
       // behavior they were written for. Rotation has its own dedicated tests.
       rotation = 0,
@@ -651,6 +687,7 @@ class DeviceControlPolicyTest {
       rootWidth = width,
       rootHeight = height,
       coordinateSpace = coordinateSpace,
+      frameContext = "epoch:7",
       rotation = 0,
     )
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionTest.kt
@@ -892,6 +892,9 @@ class DeviceControlSessionTest {
     // asynchronous application. This receipt-time hook closes that interval.
     session.onObservationFrameContextDeclared("epoch:8", captureSequence = 8L)
 
+    // The old paired facts are still available, but evaluating them must not restore the snapshot
+    // that receipt-time invalidation just retired.
+    assertNotNull(session.evaluate(current).snapshotOrNull)
     assertNull(session.interactionSnapshot)
     assertFalse(session.tap(clickedBeforeChange, point))
     advanceUntilIdle()

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionTest.kt
@@ -71,6 +71,7 @@ class DeviceControlSessionTest {
     // The snapshot is the authority for the target device, so a selection change racing the
     // dispatch cannot redirect this tap.
     assertEquals("emulator-5554", call.deviceId)
+    assertEquals("epoch:5", call.frameContext)
     scope.cancel()
   }
 
@@ -125,6 +126,80 @@ class DeviceControlSessionTest {
     // what must never happen is a *stale* error outliving a newer clear.
     assertEquals("stale failure", banner)
     assertEquals(2, client.inputTapCalls.size)
+    scope.cancel()
+  }
+
+  @Test
+  fun `a stale frame-context rejection preserves rendering but blocks retry until a newer pair`() =
+    runTest {
+      val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+      val client =
+        FakeAutoMobileClient().apply {
+          inputTapResult =
+            InputActionResult(
+              action = "input/tap",
+              success = false,
+              error =
+                "input/tap frameContext is stale or unavailable; observe a fresh frame before retrying",
+            )
+        }
+      val session = session(scope, client)
+      val initial = paired(captureSequence = 7L, sourceSequence = 10L)
+      val rejected = assertNotNull(session.evaluate(initial).snapshotOrNull)
+
+      session.tap(rejected, point)
+      advanceUntilIdle()
+      session.evaluate(initial)
+
+      assertEquals(rejected, session.renderSnapshot)
+      assertNull(session.interactionSnapshot)
+      assertFalse(
+        session.tap(rejected, point),
+        "the rejected snapshot must not retry automatically",
+      )
+
+      val fresh = paired(captureSequence = 8L, sourceSequence = 12L)
+      val freshSnapshot = assertNotNull(session.evaluate(fresh).snapshotOrNull)
+
+      assertEquals(freshSnapshot, session.interactionSnapshot)
+      scope.cancel()
+    }
+
+  @Test
+  fun `a stale frame-context rejection drops queued retries`() = runTest {
+    val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+    val client =
+      FakeAutoMobileClient().apply {
+        inputTapResult =
+          InputActionResult(
+            action = "input/tap",
+            success = false,
+            error =
+              "input/tap frameContext is stale or unavailable; observe a fresh frame before retrying",
+          )
+      }
+    val session =
+      DeviceControlSession(
+        scope = scope,
+        clientProvider = { client },
+        platform = { "android" },
+        nowMs = { 1_000L },
+        publishError = {},
+        uiContext = StandardTestDispatcher(testScheduler),
+        ioDispatcher = StandardTestDispatcher(testScheduler),
+      )
+    val snapshot = testSnapshot(sequence = 7L)
+
+    session.tap(snapshot, point)
+    session.tap(snapshot, point)
+    advanceUntilIdle()
+
+    assertEquals(
+      1,
+      client.inputTapCalls.size,
+      "the queued gesture must not retry stale coordinates",
+    )
+    assertNull(session.interactionSnapshot)
     scope.cancel()
   }
 
@@ -1100,6 +1175,7 @@ class DeviceControlSessionTest {
           height = height,
           data = data,
           coordinateSpace = coordinateSpace,
+          frameContext = "epoch:$captureSequence",
           rotation = 0,
         ),
       hierarchy =
@@ -1112,6 +1188,7 @@ class DeviceControlSessionTest {
           rootWidth = width,
           rootHeight = height,
           coordinateSpace = coordinateSpace,
+          frameContext = "epoch:$captureSequence",
           rotation = 0,
         ),
       liveFrame = null,

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionTest.kt
@@ -864,6 +864,28 @@ class DeviceControlSessionTest {
   }
 
   @Test
+  fun `a frame-context change retires control at stream receipt`() = runTest {
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val client = FakeAutoMobileClient()
+    val session = session(scope, client)
+    val current = paired(captureSequence = 7L, sourceSequence = 10L)
+
+    session.onObservationFrameContextDeclared("epoch:7", captureSequence = 7L)
+    assertNotNull(session.evaluate(current).snapshotOrNull)
+    val clickedBeforeChange = assertNotNull(session.interactionSnapshot)
+
+    // The new context has arrived, but the hierarchy/screenshot facts may still be awaiting their
+    // asynchronous application. This receipt-time hook closes that interval.
+    session.onObservationFrameContextDeclared("epoch:8", captureSequence = 8L)
+
+    assertNull(session.interactionSnapshot)
+    assertFalse(session.tap(clickedBeforeChange, point))
+    advanceUntilIdle()
+    assertTrue(client.inputTapCalls.isEmpty())
+    scope.cancel()
+  }
+
+  @Test
   fun `the receipt-time retirement invalidates Compose readers of the interaction snapshot`() =
     runTest {
       // Half (a) of the receipt fix. Retiring the snapshot early is only useful if the VIEW

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionTest.kt
@@ -130,7 +130,7 @@ class DeviceControlSessionTest {
   }
 
   @Test
-  fun `a stale frame-context rejection preserves rendering but blocks retry until a newer pair`() =
+  fun `a stale frame-context rejection preserves rendering but blocks retry until context changes`() =
     runTest {
       val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
       val client =
@@ -157,7 +157,15 @@ class DeviceControlSessionTest {
         "the rejected snapshot must not retry automatically",
       )
 
-      val fresh = paired(captureSequence = 8L, sourceSequence = 12L)
+      val delayedSameContext =
+        paired(captureSequence = 8L, sourceSequence = 12L, frameContext = rejected.frameContext)
+      assertNotNull(session.evaluate(delayedSameContext).snapshotOrNull)
+      assertNull(
+        session.interactionSnapshot,
+        "a later capture under the rejected context must not restore control",
+      )
+
+      val fresh = paired(captureSequence = 9L, sourceSequence = 13L)
       val freshSnapshot = assertNotNull(session.evaluate(fresh).snapshotOrNull)
 
       assertEquals(freshSnapshot, session.interactionSnapshot)
@@ -165,7 +173,7 @@ class DeviceControlSessionTest {
     }
 
   @Test
-  fun `a stale frame-context rejection drops queued retries`() = runTest {
+  fun `a stale frame-context rejection drops queued retries and publishes its error`() = runTest {
     val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
     val client =
       FakeAutoMobileClient().apply {
@@ -177,13 +185,14 @@ class DeviceControlSessionTest {
               "input/tap frameContext is stale or unavailable; observe a fresh frame before retrying",
           )
       }
+    val published = mutableListOf<String?>()
     val session =
       DeviceControlSession(
         scope = scope,
         clientProvider = { client },
         platform = { "android" },
         nowMs = { 1_000L },
-        publishError = {},
+        publishError = { published += it },
         uiContext = StandardTestDispatcher(testScheduler),
         ioDispatcher = StandardTestDispatcher(testScheduler),
       )
@@ -197,6 +206,11 @@ class DeviceControlSessionTest {
       1,
       client.inputTapCalls.size,
       "the queued gesture must not retry stale coordinates",
+    )
+    assertEquals(
+      "input/tap frameContext is stale or unavailable; observe a fresh frame before retrying",
+      published.last(),
+      "the discarded retry cannot suppress the rejection that removed it",
     )
     assertNull(session.interactionSnapshot)
     scope.cancel()
@@ -1224,6 +1238,7 @@ class DeviceControlSessionTest {
     data: ByteArray? = null,
     receivedAtMs: Long = 1_000L,
     coordinateSpace: CoordinateSpace? = null,
+    frameContext: String = "epoch:$captureSequence",
   ) =
     DeviceControlInputs(
       enabled = true,
@@ -1241,7 +1256,7 @@ class DeviceControlSessionTest {
           height = height,
           data = data,
           coordinateSpace = coordinateSpace,
-          frameContext = "epoch:$captureSequence",
+          frameContext = frameContext,
           rotation = 0,
         ),
       hierarchy =
@@ -1254,7 +1269,7 @@ class DeviceControlSessionTest {
           rootWidth = width,
           rootHeight = height,
           coordinateSpace = coordinateSpace,
-          frameContext = "epoch:$captureSequence",
+          frameContext = frameContext,
           rotation = 0,
         ),
       liveFrame = null,

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionTest.kt
@@ -139,8 +139,7 @@ class DeviceControlSessionTest {
             InputActionResult(
               action = "input/tap",
               success = false,
-              error =
-                "input/tap frameContext is stale or unavailable; observe a fresh frame before retrying",
+              error = "Stale frame context for input/tap; observe a fresh frame before retrying",
             )
         }
       val session = session(scope, client)

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionTest.kt
@@ -203,6 +203,51 @@ class DeviceControlSessionTest {
   }
 
   @Test
+  fun `a stale rejection preserves a queued input from a newer paired frame`() = runTest {
+    val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+    val staleClient =
+      FakeAutoMobileClient().apply {
+        inputTapResult =
+          InputActionResult(
+            action = "input/tap",
+            success = false,
+            error =
+              "input/tap frameContext is stale or unavailable; observe a fresh frame before retrying",
+          )
+      }
+    val freshClient = FakeAutoMobileClient()
+    val clients = listOf(staleClient, freshClient)
+    var clientIndex = 0
+    val session =
+      DeviceControlSession(
+        scope = scope,
+        clientProvider = { clients[clientIndex++] },
+        platform = { "android" },
+        nowMs = { 1_000L },
+        publishError = {},
+        uiContext = StandardTestDispatcher(testScheduler),
+        ioDispatcher = StandardTestDispatcher(testScheduler),
+      )
+    val staleSnapshot =
+      assertNotNull(
+        session.evaluate(paired(captureSequence = 7L, sourceSequence = 10L)).snapshotOrNull
+      )
+    assertTrue(session.tap(staleSnapshot, point))
+    val freshSnapshot =
+      assertNotNull(
+        session.evaluate(paired(captureSequence = 8L, sourceSequence = 12L)).snapshotOrNull
+      )
+
+    assertTrue(session.tap(freshSnapshot, point))
+    advanceUntilIdle()
+
+    assertEquals(1, staleClient.inputTapCalls.size)
+    assertEquals(1, freshClient.inputTapCalls.size, "newer-frame input must survive stale cleanup")
+    assertEquals(freshSnapshot, session.interactionSnapshot)
+    scope.cancel()
+  }
+
+  @Test
   fun `reset clears the banner and drops a pending refresh wait`() = runTest {
     val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
     var banner: String? = "something"

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/PostInputRefreshTrackerTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/PostInputRefreshTrackerTest.kt
@@ -34,6 +34,7 @@ class PostInputRefreshTrackerTest {
       hierarchy = null,
       coordinateSpace = null,
       captureSequence = captureSequence,
+      frameContext = "epoch:$captureSequence",
       screenshotSequence = sourceSequence,
       hierarchySequence = sourceSequence,
       liveFrameSequence = null,

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/TestSnapshots.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/TestSnapshots.kt
@@ -11,6 +11,7 @@ internal fun testSnapshot(
   deviceWidth: Int = 1080,
   deviceHeight: Int = 2340,
   coordinateSpace: CoordinateSpace? = null,
+  frameContext: String = "epoch:$sequence",
 ): DeviceFrameSnapshot =
   DeviceFrameSnapshot(
     deviceId = deviceId,
@@ -25,6 +26,7 @@ internal fun testSnapshot(
     hierarchy = null,
     coordinateSpace = coordinateSpace,
     captureSequence = sequence,
+    frameContext = frameContext,
     screenshotSequence = sequence,
     hierarchySequence = sequence,
     liveFrameSequence = null,

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
@@ -20,6 +20,7 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 
 class McpDaemonClientInputTest {
   private val json = Json { ignoreUnknownKeys = true }
@@ -97,6 +98,16 @@ class McpDaemonClientInputTest {
     )
     assertEquals(true, result.response.success)
     assertEquals(InputCoordinates(x = 240.5, y = 640.25), result.response.coordinates)
+  }
+
+  @Test
+  fun `an input without a frame context omits the param for legacy daemons`() {
+    val result =
+      captureInputRequest("""{ "action": "input/tap", "success": true }""") { client ->
+        client.inputTap(x = 1.0, y = 2.0)
+      }
+
+    assertFalse("frameContext" in result.request.params)
   }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/McpDaemonClientInputTest.kt
@@ -79,6 +79,7 @@ class McpDaemonClientInputTest {
           platform = "android",
           deviceId = "emulator-5554",
           duration = 50,
+          frameContext = "android:41",
         )
       }
 
@@ -90,6 +91,7 @@ class McpDaemonClientInputTest {
         "x" to JsonPrimitive(240.5),
         "y" to JsonPrimitive(640.25),
         "duration" to JsonPrimitive(50),
+        "frameContext" to JsonPrimitive("android:41"),
       ),
       result.request.params,
     )
@@ -123,6 +125,7 @@ class McpDaemonClientInputTest {
           platform = "android",
           deviceId = "emulator-5554",
           durationMs = 350,
+          frameContext = "android:42",
         )
       }
 
@@ -136,6 +139,7 @@ class McpDaemonClientInputTest {
         "endX" to JsonPrimitive(520.25),
         "endY" to JsonPrimitive(500.5),
         "durationMs" to JsonPrimitive(350),
+        "frameContext" to JsonPrimitive("android:42"),
       ),
       result.request.params,
     )
@@ -151,18 +155,34 @@ class McpDaemonClientInputTest {
       captureInputRequest(
         """{ "action": "input/pressButton", "success": true, "button": "back" }"""
       ) { client ->
-        client.inputPressButton(button = "back", platform = "android", deviceId = "device-1")
+        client.inputPressButton(
+          button = "back",
+          platform = "android",
+          deviceId = "device-1",
+          frameContext = "android:43",
+        )
       }
     val typeText =
       captureInputRequest(
         """{ "action": "input/typeText", "success": true, "textLength": 5, "submitted": true }"""
       ) { client ->
-        client.inputTypeText(text = "hello", platform = "ios", deviceId = "device-2", submit = true)
+        client.inputTypeText(
+          text = "hello",
+          platform = "ios",
+          deviceId = "device-2",
+          submit = true,
+          frameContext = "ios:43",
+        )
       }
     val key =
       captureInputRequest("""{ "action": "input/key", "success": true, "key": "enter" }""") { client
         ->
-        client.inputKey(key = "enter", platform = "android", deviceId = "device-3")
+        client.inputKey(
+          key = "enter",
+          platform = "android",
+          deviceId = "device-3",
+          frameContext = "android:44",
+        )
       }
 
     assertEquals("input/pressButton", pressButton.request.method)
@@ -171,6 +191,7 @@ class McpDaemonClientInputTest {
         "platform" to JsonPrimitive("android"),
         "deviceId" to JsonPrimitive("device-1"),
         "button" to JsonPrimitive("back"),
+        "frameContext" to JsonPrimitive("android:43"),
       ),
       pressButton.request.params,
     )
@@ -183,6 +204,7 @@ class McpDaemonClientInputTest {
         "deviceId" to JsonPrimitive("device-2"),
         "text" to JsonPrimitive("hello"),
         "submit" to JsonPrimitive(true),
+        "frameContext" to JsonPrimitive("ios:43"),
       ),
       typeText.request.params,
     )
@@ -195,6 +217,7 @@ class McpDaemonClientInputTest {
         "platform" to JsonPrimitive("android"),
         "deviceId" to JsonPrimitive("device-3"),
         "key" to JsonPrimitive("enter"),
+        "frameContext" to JsonPrimitive("android:44"),
       ),
       key.request.params,
     )

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClientTest.kt
@@ -125,12 +125,15 @@ class ObservationStreamClientTest {
           "screenshotBase64": "aW1hZ2U=",
           "screenWidth": 1170,
           "screenHeight": 2532,
-          "coordinateSpace": "px"
+          "coordinateSpace": "px",
+          "frameContext": "ios:41"
         }
         """
           .trimIndent()
       )
-      assertEquals(CoordinateSpace.Pixels, awaitItem().coordinateSpace)
+      val update = awaitItem()
+      assertEquals(CoordinateSpace.Pixels, update.coordinateSpace)
+      assertEquals("ios:41", update.frameContext)
     }
 
     client.hierarchyUpdates.test {
@@ -141,12 +144,15 @@ class ObservationStreamClientTest {
           "deviceId": "emulator-5554",
           "timestamp": 2000,
           "data": { "packageName": "com.example" },
-          "coordinateSpace": "px"
+          "coordinateSpace": "px",
+          "frameContext": "ios:41"
         }
         """
           .trimIndent()
       )
-      assertEquals(CoordinateSpace.Pixels, awaitItem().coordinateSpace)
+      val update = awaitItem()
+      assertEquals(CoordinateSpace.Pixels, update.coordinateSpace)
+      assertEquals("ios:41", update.frameContext)
     }
   }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceScreenViewControlTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceScreenViewControlTest.kt
@@ -490,6 +490,7 @@ class DeviceScreenViewControlTest {
       hierarchy = null,
       coordinateSpace = null,
       captureSequence = sequence,
+      frameContext = "epoch:$sequence",
       screenshotSequence = sequence,
       hierarchySequence = sequence,
       liveFrameSequence = null,

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceScreenViewKeyboardTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/DeviceScreenViewKeyboardTest.kt
@@ -507,6 +507,7 @@ class DeviceScreenViewKeyboardTest {
       hierarchy = null,
       coordinateSpace = null,
       captureSequence = sequence,
+      frameContext = "epoch:$sequence",
       screenshotSequence = sequence,
       hierarchySequence = sequence,
       liveFrameSequence = null,

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorStateFrameGenerationTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorStateFrameGenerationTest.kt
@@ -140,12 +140,14 @@ class LayoutInspectorStateFrameGenerationTest {
       deviceId = device,
       generation = state.frameGeneration,
       captureSequence = 1L,
+      frameContext = "epoch:1",
       rotation = 0,
     )
     state.updateHierarchy(
       rootBounds(),
       deviceId = device,
       captureSequence = 1L,
+      frameContext = "epoch:1",
       captureRotation = 0,
     )
     state.updateConnectionStatus(ConnectionStatus.Connected)
@@ -165,12 +167,14 @@ class LayoutInspectorStateFrameGenerationTest {
       deviceId = device,
       generation = state.frameGeneration,
       captureSequence = 2L,
+      frameContext = "epoch:2",
       rotation = 0,
     )
     state.updateHierarchy(
       rootBounds(),
       deviceId = device,
       captureSequence = 2L,
+      frameContext = "epoch:2",
       captureRotation = 0,
     )
     state.updateConnectionStatus(ConnectionStatus.Connected)

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationScreenshotLoaderTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationScreenshotLoaderTest.kt
@@ -437,6 +437,7 @@ class FakeAutoMobileClient : AutoMobileClient {
     platform: String,
     deviceId: String?,
     duration: Int?,
+    frameContext: String?,
   ) = notImplemented()
 
   override fun inputSwipe(
@@ -447,12 +448,14 @@ class FakeAutoMobileClient : AutoMobileClient {
     platform: String,
     deviceId: String?,
     durationMs: Int?,
+    frameContext: String?,
   ) = notImplemented()
 
   override fun inputPressButton(
     button: String,
     platform: String,
     deviceId: String?,
+    frameContext: String?,
   ) = notImplemented()
 
   override fun inputTypeText(
@@ -461,12 +464,14 @@ class FakeAutoMobileClient : AutoMobileClient {
     deviceId: String?,
     submit: Boolean?,
     append: Boolean,
+    frameContext: String?,
   ) = notImplemented()
 
   override fun inputKey(
     key: String,
     platform: String,
     deviceId: String?,
+    frameContext: String?,
   ) = notImplemented()
 
   override fun setKeyValue(

--- a/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/DeviceControlPolicy.kt
+++ b/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/DeviceControlPolicy.kt
@@ -33,6 +33,13 @@ public enum class DeviceControlBlockReason {
    */
   CaptureIdentityUnavailable,
   /**
+   * One or both contributing messages omitted the device-authored frame context. Older runners
+   * remain inspector-only rather than allowing control with an unprovable UI identity.
+   */
+  FrameContextUnavailable,
+  /** Screenshot and hierarchy frame contexts differ, so they cannot describe one UI state. */
+  FrameContextMismatch,
+  /**
    * A contributing message declared a [CoordinateSpace] this client does not implement
    * (issue #4550).
    *
@@ -217,6 +224,13 @@ public object DeviceControlPolicy {
     if (captureSequence == null || hierarchy.captureSequence == null) {
       return blocked(DeviceControlBlockReason.CaptureIdentityUnavailable)
     }
+    val frameContext = screenshot.frameContext
+    if (frameContext == null || hierarchy.frameContext == null) {
+      return blocked(DeviceControlBlockReason.FrameContextUnavailable)
+    }
+    if (frameContext != hierarchy.frameContext) {
+      return blocked(DeviceControlBlockReason.FrameContextMismatch)
+    }
 
     // Rotation is capture-time provenance, distinct from pixel orientation. iOS can deliver
     // native-portrait screenshot pixels for a landscape device, so geometry intentionally accepts
@@ -335,6 +349,7 @@ public object DeviceControlPolicy {
         // coordinates are in must travel with it rather than be re-derived at dispatch time.
         coordinateSpace = pairedSpace,
         captureSequence = captureSequence,
+        frameContext = frameContext,
         rotation = screenshotRotation,
         screenshotSequence = screenshot.sequence,
         hierarchySequence = hierarchy.sequence,

--- a/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/DeviceFrameSnapshot.kt
+++ b/android/desktop-domain/src/main/kotlin/dev/jasonpearson/automobile/desktop/domain/DeviceFrameSnapshot.kt
@@ -39,6 +39,8 @@ public enum class DeviceFrameSource {
  *   (issue #4550). [CoordinateSpace.Pixels] when the message carried `coordinateSpace: "px"`; null
  *   for a legacy frame that declared nothing. Travels per message rather than per session because
  *   the declaration is per message: a runner can start reporting scale metadata mid-stream.
+ * @param frameContext opaque device-authored identity for the UI state that produced these pixels.
+ *   A controllable snapshot requires this to agree with [HierarchyFrameFacts.frameContext].
  */
 public data class ScreenshotFrameFacts(
   val deviceId: String?,
@@ -49,6 +51,7 @@ public data class ScreenshotFrameFacts(
   val height: Int,
   val data: ByteArray?,
   val coordinateSpace: CoordinateSpace? = null,
+  val frameContext: String? = null,
   /** Device display rotation reported for this capture; null means legacy/unproven provenance. */
   val rotation: Int? = null,
 ) {
@@ -63,6 +66,7 @@ public data class ScreenshotFrameFacts(
       sequence == other.sequence &&
       captureSequence == other.captureSequence &&
       receivedAtMs == other.receivedAtMs &&
+      frameContext == other.frameContext &&
       width == other.width &&
       height == other.height &&
       rotation == other.rotation &&
@@ -75,6 +79,7 @@ public data class ScreenshotFrameFacts(
     result = 31 * result + sequence.hashCode()
     result = 31 * result + (captureSequence?.hashCode() ?: 0)
     result = 31 * result + receivedAtMs.hashCode()
+    result = 31 * result + (frameContext?.hashCode() ?: 0)
     result = 31 * result + width
     result = 31 * result + height
     result = 31 * result + (rotation ?: 0)
@@ -99,6 +104,7 @@ public data class ScreenshotFrameFacts(
  *   [ScreenshotFrameFacts.coordinateSpace][ScreenshotFrameFacts]. Only when this AND the paired
  *   screenshot both declare [CoordinateSpace.Pixels] do the two describe one unit, which is the
  *   precondition [DeviceControlPolicy] requires before comparing absolute dimensions.
+ * @param frameContext opaque device-authored identity for this hierarchy capture.
  */
 public data class HierarchyFrameFacts(
   val deviceId: String?,
@@ -109,6 +115,7 @@ public data class HierarchyFrameFacts(
   val rootWidth: Int,
   val rootHeight: Int,
   val coordinateSpace: CoordinateSpace? = null,
+  val frameContext: String? = null,
   /** Device display rotation reported for this hierarchy capture. */
   val rotation: Int? = null,
 )
@@ -173,6 +180,7 @@ public data class LiveFrameFacts(
  *   the wrong physical place. Carrying the space lets the session notice the transition and fail
  *   closed; see `DeviceControlSession`.
  * @param captureSequence the daemon capture identity the screenshot and hierarchy agreed on.
+ * @param frameContext the device-authored UI identity the screenshot and hierarchy agreed on.
  * @param rotation the device rotation the contributing sources agreed on when this snapshot was
  *   captured. Retention compares later source observations against this value so a partially
  *   received rotation update cannot leave old coordinate bounds clickable.
@@ -193,6 +201,7 @@ public data class DeviceFrameSnapshot(
   val hierarchy: ParsedHierarchy?,
   val coordinateSpace: CoordinateSpace?,
   val captureSequence: Long,
+  val frameContext: String,
   val rotation: Int = 0,
   val screenshotSequence: Long,
   val hierarchySequence: Long,
@@ -223,6 +232,7 @@ public data class DeviceFrameSnapshot(
     return deviceId == other.deviceId &&
       sequence == other.sequence &&
       captureSequence == other.captureSequence &&
+      frameContext == other.frameContext &&
       rotation == other.rotation &&
       screenshotSequence == other.screenshotSequence &&
       hierarchySequence == other.hierarchySequence &&
@@ -234,6 +244,7 @@ public data class DeviceFrameSnapshot(
     var result = deviceId.hashCode()
     result = 31 * result + sequence.hashCode()
     result = 31 * result + captureSequence.hashCode()
+    result = 31 * result + frameContext.hashCode()
     result = 31 * result + rotation
     result = 31 * result + screenshotSequence.hashCode()
     result = 31 * result + hierarchySequence.hashCode()

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -801,8 +801,11 @@ public class CommandHandler: CommandHandling {
         perfProvider.serial("handlePressButton")
         defer { perfProvider.end() }
 
-        try perfProvider.track("pressButton") {
-            try gesturePerformer.pressButton(button)
+        try requireCurrentFrameContext(request.frameContext)
+        try performContextCheckedGesture(expected: request.frameContext) {
+            try perfProvider.track("pressButton") {
+                try gesturePerformer.pressButton(button)
+            }
         }
 
         if button.lowercased() == "home" || button.lowercased() == "recent" {
@@ -825,8 +828,11 @@ public class CommandHandler: CommandHandling {
         perfProvider.serial("handlePressHome")
         defer { perfProvider.end() }
 
-        try perfProvider.track("pressHome") {
-            try gesturePerformer.pressHome()
+        try requireCurrentFrameContext(request.frameContext)
+        try performContextCheckedGesture(expected: request.frameContext) {
+            try perfProvider.track("pressHome") {
+                try gesturePerformer.pressHome()
+            }
         }
 
         // Explicit state transition: home screen means springboard is now foreground
@@ -848,8 +854,11 @@ public class CommandHandler: CommandHandling {
         perfProvider.serial("handlePressBack")
         defer { perfProvider.end() }
 
-        try perfProvider.track("pressBack") {
-            try gesturePerformer.pressBack()
+        try requireCurrentFrameContext(request.frameContext)
+        try performContextCheckedGesture(expected: request.frameContext) {
+            try perfProvider.track("pressBack") {
+                try gesturePerformer.pressBack()
+            }
         }
 
         return WebSocketResponse.success(
@@ -878,8 +887,11 @@ public class CommandHandler: CommandHandling {
         perfProvider.serial("handleRecentApps")
         defer { perfProvider.end() }
 
-        let didOpen = try perfProvider.track("openRecentApps") {
-            try gesturePerformer.openRecentApps()
+        try requireCurrentFrameContext(request.frameContext)
+        let didOpen = try performContextCheckedGesture(expected: request.frameContext) {
+            try perfProvider.track("openRecentApps") {
+                try gesturePerformer.openRecentApps()
+            }
         }
 
         guard didOpen else {

--- a/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/CommandHandler.swift
@@ -612,13 +612,16 @@ public class CommandHandler: CommandHandling {
             )
 
         do {
-            if let resourceId = resourceId {
-                try perfProvider.track("setText.byResourceId") {
-                    try gesturePerformer.setText(resourceId: resourceId, text: text)
-                }
-            } else {
-                try perfProvider.track("typeText") {
-                    try gesturePerformer.typeText(text: text)
+            try requireCurrentFrameContext(request.frameContext)
+            try performContextCheckedGesture(expected: request.frameContext) {
+                if let resourceId = resourceId {
+                    try perfProvider.track("setText.byResourceId") {
+                        try gesturePerformer.setText(resourceId: resourceId, text: text)
+                    }
+                } else {
+                    try perfProvider.track("typeText") {
+                        try gesturePerformer.typeText(text: text)
+                    }
                 }
             }
         } catch {
@@ -646,8 +649,11 @@ public class CommandHandler: CommandHandling {
         perfProvider.serial("handleAppendText")
         defer { perfProvider.end() }
 
-        try perfProvider.track("appendText") {
-            try gesturePerformer.appendText(text: request.text)
+        try requireCurrentFrameContext(request.frameContext)
+        try performContextCheckedGesture(expected: request.frameContext) {
+            try perfProvider.track("appendText") {
+                try gesturePerformer.appendText(text: request.text)
+            }
         }
 
         return WebSocketResponse.success(

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -108,11 +108,13 @@ public struct RequestSetText: Decodable {
     public var requestId: String?
     public var text: String
     public var resourceId: String?
+    public var frameContext: String?
 }
 
 public struct RequestAppendText: Decodable {
     public var requestId: String?
     public var text: String
+    public var frameContext: String?
 }
 
 public struct RequestClearText: Decodable {

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -24,6 +24,7 @@ import Foundation
 /// Payload for commands that carry no parameters beyond the request id.
 public struct RequestEnvelope: Decodable {
     public var requestId: String?
+    public var frameContext: String? = nil
 }
 
 // MARK: View hierarchy
@@ -135,6 +136,7 @@ public struct RequestKeyboard: Decodable {
 public struct RequestPressButton: Decodable {
     public var requestId: String?
     public var action: String
+    public var frameContext: String? = nil
 }
 
 // MARK: Actions

--- a/ios/control-proxy/Tests/CtrlProxyTests/FrameContextSafetyTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/FrameContextSafetyTests.swift
@@ -71,6 +71,11 @@ final class FrameContextSafetyTests: XCTestCase {
                 y2: 40,
                 frameContext: expected
             )),
+            .appendText(RequestAppendText(
+                requestId: "append",
+                text: "a",
+                frameContext: expected
+            )),
         ]
 
         for request in requests {
@@ -86,6 +91,7 @@ final class FrameContextSafetyTests: XCTestCase {
         XCTAssertTrue(fakeGesturePerformer.getTapHistory().isEmpty)
         XCTAssertTrue(fakeGesturePerformer.getSwipeHistory().isEmpty)
         XCTAssertTrue(fakeGesturePerformer.getDragHistory().isEmpty)
+        XCTAssertTrue(fakeGesturePerformer.getAppendTextHistory().isEmpty)
     }
 
     private func makeHierarchy(text: String) -> ViewHierarchy {

--- a/ios/control-proxy/Tests/CtrlProxyTests/FrameContextSafetyTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/FrameContextSafetyTests.swift
@@ -76,11 +76,31 @@ final class FrameContextSafetyTests: XCTestCase {
                 text: "a",
                 frameContext: expected
             )),
+            .pressButton(RequestPressButton(
+                requestId: "button",
+                action: "volume_up",
+                frameContext: expected
+            )),
+            .pressHome(RequestEnvelope(
+                requestId: "home",
+                frameContext: expected
+            )),
+            .pressBack(RequestEnvelope(
+                requestId: "back",
+                frameContext: expected
+            )),
+            .recentApps(RequestEnvelope(
+                requestId: "recent",
+                frameContext: expected
+            )),
         ]
 
         for request in requests {
             fakeElementLocator.setHierarchy(screenA)
             fakeElementLocator.onHierarchyRead = { [fakeElementLocator] in
+                // FakeElementLocator invokes this after returning the first hierarchy, so the
+                // initial requireCurrentFrameContext sees A and the serialized execution check
+                // sees B.
                 fakeElementLocator?.setHierarchy(screenB)
                 fakeElementLocator?.onHierarchyRead = nil
             }
@@ -92,6 +112,10 @@ final class FrameContextSafetyTests: XCTestCase {
         XCTAssertTrue(fakeGesturePerformer.getSwipeHistory().isEmpty)
         XCTAssertTrue(fakeGesturePerformer.getDragHistory().isEmpty)
         XCTAssertTrue(fakeGesturePerformer.getAppendTextHistory().isEmpty)
+        XCTAssertTrue(fakeGesturePerformer.getPressButtonHistory().isEmpty)
+        XCTAssertEqual(fakeGesturePerformer.getPressHomeCallCount(), 0)
+        XCTAssertEqual(fakeGesturePerformer.getPressBackCallCount(), 0)
+        XCTAssertEqual(fakeGesturePerformer.getOpenRecentAppsCallCount(), 0)
     }
 
     private func makeHierarchy(text: String) -> ViewHierarchy {

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -1452,7 +1452,7 @@ export class UnixSocketServer {
       appendCharsSent = textResult.charsSent;
     } else {
       const textResult = append
-        ? await (client as IOSCtrlProxyClient).requestAppendText(text, timeoutMs)
+        ? await (client as IOSCtrlProxyClient).requestAppendText(text, timeoutMs, undefined, frameContext)
         : await client.requestSetText(text, { timeoutMs, frameContext });
       if (!textResult.success) {
         return { success: false, error: textResult.error };

--- a/src/features/action/PressButton.ts
+++ b/src/features/action/PressButton.ts
@@ -61,7 +61,7 @@ export class PressButton extends BaseVisualChange {
         case "android":
           return await this.executeAndroidButtonPress(button, timeoutMs, frameContext);
         case "ios":
-          return await this.executeiOSButtonPress(button, timeoutMs);
+          return await this.executeiOSButtonPress(button, timeoutMs, frameContext);
         default:
           throw new Error(`Unsupported platform: ${this.device.platform}`);
       }
@@ -237,11 +237,20 @@ export class PressButton extends BaseVisualChange {
    * @param button - Button name to press
    * @returns Result of the button press operation
    */
-  private async executeiOSButtonPress(button: string, timeoutMs?: number): Promise<PressButtonResult> {
+  private async executeiOSButtonPress(
+    button: string,
+    timeoutMs?: number,
+    frameContext?: string
+  ): Promise<PressButtonResult> {
     const normalizedButton = button.toLowerCase();
     if (PressButton.IOS_NAVIGATION_BUTTONS.has(normalizedButton)) {
       const client = IOSCtrlProxyClient.getInstance(this.device);
-      const result = await this.executeiOSNavigationButton(client, normalizedButton, timeoutMs);
+      const result = await this.executeiOSNavigationButton(
+        client,
+        normalizedButton,
+        timeoutMs,
+        frameContext
+      );
 
       if (!result.success) {
         return {
@@ -270,7 +279,7 @@ export class PressButton extends BaseVisualChange {
       }
 
       const client = IOSCtrlProxyClient.getInstance(this.device);
-      const result = await client.requestPressButton(normalizedButton, timeoutMs);
+      const result = await client.requestPressButton(normalizedButton, timeoutMs, undefined, frameContext);
 
       if (!result.success) {
         return {
@@ -304,15 +313,16 @@ export class PressButton extends BaseVisualChange {
   private async executeiOSNavigationButton(
     client: IOSCtrlProxyClient,
     button: string,
-    timeoutMs?: number
+    timeoutMs?: number,
+    frameContext?: string
   ): Promise<{ success: boolean; error?: string }> {
     switch (button) {
       case "home":
-        return client.requestPressHome(timeoutMs);
+        return client.requestPressHome(timeoutMs, undefined, frameContext);
       case "back":
-        return client.requestPressBack(timeoutMs);
+        return client.requestPressBack(timeoutMs, undefined, frameContext);
       case "recent":
-        return client.requestRecentApps(timeoutMs);
+        return client.requestRecentApps(timeoutMs, undefined, frameContext);
       default:
         return { success: false, error: `Unsupported iOS button: ${button}` };
     }

--- a/src/features/observe/ios/CtrlProxyNavigation.ts
+++ b/src/features/observe/ios/CtrlProxyNavigation.ts
@@ -33,12 +33,14 @@ export class CtrlProxyNavigation {
    */
   async requestPressHome(
     timeoutMs: number = 5000,
-    perf?: PerformanceTracker
+    perf?: PerformanceTracker,
+    frameContext?: string
   ): Promise<CtrlProxyPressHomeResult> {
     return sendCommand<CtrlProxyPressHomeResult>(this.context, {
       idPrefix: "pressHome",
       responseType: "press_home",
       messageType: "request_press_home",
+      params: frameContext === undefined ? undefined : { frameContext },
       timeoutMs,
       perf,
       cancelScreenshotBackoff: false,
@@ -52,12 +54,14 @@ export class CtrlProxyNavigation {
    */
   async requestPressBack(
     timeoutMs: number = 5000,
-    perf?: PerformanceTracker
+    perf?: PerformanceTracker,
+    frameContext?: string
   ): Promise<CtrlProxyPressBackResult> {
     return sendCommand<CtrlProxyPressBackResult>(this.context, {
       idPrefix: "pressBack",
       responseType: "press_back",
       messageType: "request_press_back",
+      params: frameContext === undefined ? undefined : { frameContext },
       timeoutMs,
       perf,
       cancelScreenshotBackoff: false,
@@ -91,13 +95,14 @@ export class CtrlProxyNavigation {
   async requestPressButton(
     button: string,
     timeoutMs: number = 5000,
-    perf?: PerformanceTracker
+    perf?: PerformanceTracker,
+    frameContext?: string
   ): Promise<CtrlProxyPressButtonResult> {
     return sendCommand<CtrlProxyPressButtonResult>(this.context, {
       idPrefix: "pressButton",
       responseType: "press_button",
       messageType: "request_press_button",
-      params: { action: button },
+      params: frameContext === undefined ? { action: button } : { action: button, frameContext },
       timeoutMs,
       perf,
       cancelScreenshotBackoff: false,
@@ -179,12 +184,14 @@ export class CtrlProxyNavigation {
    */
   async requestRecentApps(
     timeoutMs: number = 5000,
-    perf?: PerformanceTracker
+    perf?: PerformanceTracker,
+    frameContext?: string
   ): Promise<CtrlProxyRecentAppsResult> {
     return sendCommand<CtrlProxyRecentAppsResult>(this.context, {
       idPrefix: "recentApps",
       responseType: "recent_apps",
       messageType: "request_recent_apps",
+      params: frameContext === undefined ? undefined : { frameContext },
       timeoutMs,
       perf,
       cancelScreenshotBackoff: false,

--- a/src/features/observe/ios/CtrlProxyText.ts
+++ b/src/features/observe/ios/CtrlProxyText.ts
@@ -24,7 +24,8 @@ export class CtrlProxyText extends SharedTextDelegate {
   async requestAppendText(
     text: string,
     timeoutMs: number = 5000,
-    perf?: PerformanceTracker
+    perf?: PerformanceTracker,
+    frameContext?: string
   ): Promise<BaseResult> {
     // Older released runners predate request_append_text, but their untargeted
     // request_set_text path already uses XCUITest typeText at the focused caret.
@@ -35,14 +36,18 @@ export class CtrlProxyText extends SharedTextDelegate {
       (supportedCommands !== undefined && !supportedCommands.includes("request_append_text")) ||
       (supportedCommands === undefined && this.context.isCommandSupported?.("request_append_text") === false)
     ) {
-      return this.requestSetText(text, { timeoutMs, perf });
+      return this.requestSetText(text, { timeoutMs, perf, frameContext });
     }
 
+    const params: Record<string, unknown> = { text };
+    if (frameContext !== undefined) {
+      params.frameContext = frameContext;
+    }
     return sendCommand<BaseResult>(this.context, {
       idPrefix: "appendText",
       responseType: "append_text",
       messageType: "request_append_text",
-      params: { text },
+      params,
       timeoutMs,
       perf,
       errorLabel: "Append text",

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -228,7 +228,7 @@ export interface IOSCtrlProxy extends CtrlProxyClient {
   ): Promise<CtrlProxySetTextResult>;
 
   requestAppendText(
-    text: string, timeoutMs?: number, perf?: PerformanceTracker
+    text: string, timeoutMs?: number, perf?: PerformanceTracker, frameContext?: string
   ): Promise<CtrlProxySetTextResult>;
 
   requestClearText(
@@ -1747,9 +1747,9 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   }
 
   async requestAppendText(
-    text: string, timeoutMs: number = 5000, perf?: PerformanceTracker
+    text: string, timeoutMs: number = 5000, perf?: PerformanceTracker, frameContext?: string
   ): Promise<CtrlProxySetTextResult> {
-    return this.text.requestAppendText(text, timeoutMs, perf);
+    return this.text.requestAppendText(text, timeoutMs, perf, frameContext);
   }
 
   async requestClearText(

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -255,11 +255,11 @@ export interface IOSCtrlProxy extends CtrlProxyClient {
   ): Promise<CtrlProxyClipboardResult>;
 
   requestPressHome(
-    timeoutMs?: number, perf?: PerformanceTracker
+    timeoutMs?: number, perf?: PerformanceTracker, frameContext?: string
   ): Promise<CtrlProxyPressHomeResult>;
 
   requestPressBack(
-    timeoutMs?: number, perf?: PerformanceTracker
+    timeoutMs?: number, perf?: PerformanceTracker, frameContext?: string
   ): Promise<CtrlProxyPressBackResult>;
 
   requestShake(
@@ -267,11 +267,11 @@ export interface IOSCtrlProxy extends CtrlProxyClient {
   ): Promise<CtrlProxyShakeResult>;
 
   requestPressButton(
-    button: string, timeoutMs?: number, perf?: PerformanceTracker
+    button: string, timeoutMs?: number, perf?: PerformanceTracker, frameContext?: string
   ): Promise<CtrlProxyPressButtonResult>;
 
   requestRecentApps(
-    timeoutMs?: number, perf?: PerformanceTracker
+    timeoutMs?: number, perf?: PerformanceTracker, frameContext?: string
   ): Promise<CtrlProxyRecentAppsResult>;
 
   requestRotate(
@@ -1784,15 +1784,15 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   // ===========================================================================
 
   async requestPressHome(
-    timeoutMs: number = 5000, perf?: PerformanceTracker
+    timeoutMs: number = 5000, perf?: PerformanceTracker, frameContext?: string
   ): Promise<CtrlProxyPressHomeResult> {
-    return this.navigation.requestPressHome(timeoutMs, perf);
+    return this.navigation.requestPressHome(timeoutMs, perf, frameContext);
   }
 
   async requestPressBack(
-    timeoutMs: number = 5000, perf?: PerformanceTracker
+    timeoutMs: number = 5000, perf?: PerformanceTracker, frameContext?: string
   ): Promise<CtrlProxyPressBackResult> {
-    return this.navigation.requestPressBack(timeoutMs, perf);
+    return this.navigation.requestPressBack(timeoutMs, perf, frameContext);
   }
 
   async requestShake(
@@ -1802,15 +1802,15 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   }
 
   async requestPressButton(
-    button: string, timeoutMs: number = 5000, perf?: PerformanceTracker
+    button: string, timeoutMs: number = 5000, perf?: PerformanceTracker, frameContext?: string
   ): Promise<CtrlProxyPressButtonResult> {
-    return this.navigation.requestPressButton(button, timeoutMs, perf);
+    return this.navigation.requestPressButton(button, timeoutMs, perf, frameContext);
   }
 
   async requestRecentApps(
-    timeoutMs: number = 5000, perf?: PerformanceTracker
+    timeoutMs: number = 5000, perf?: PerformanceTracker, frameContext?: string
   ): Promise<CtrlProxyRecentAppsResult> {
-    return this.navigation.requestRecentApps(timeoutMs, perf);
+    return this.navigation.requestRecentApps(timeoutMs, perf, frameContext);
   }
 
   async requestRotate(

--- a/test/daemon/socketServerInputTypeText.test.ts
+++ b/test/daemon/socketServerInputTypeText.test.ts
@@ -841,6 +841,28 @@ describe("UnixSocketServer input/typeText", () => {
     expect(requestSetText).not.toHaveBeenCalled();
   });
 
+  test("forwards an iOS frame context to the CtrlProxy append primitive", async () => {
+    const requestAppendText = mock(async () => ({ success: true, totalTimeMs: 1 }));
+    IOSCtrlProxyClient.getInstance = mock(() => ({
+      requestAppendText,
+    })) as unknown as typeof IOSCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([iosDevice]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    (server as unknown as { requireCurrentFrameContext: () => void }).requireCurrentFrameContext = () => {};
+    await server.start();
+
+    const response = await sendRequest(socketPath, "input/typeText", {
+      platform: "ios",
+      deviceId: "ios-sim-1",
+      text: "a",
+      mode: "append",
+      frameContext: "ios:7",
+    });
+
+    expect(response.success).toBe(true);
+    expect(requestAppendText).toHaveBeenCalledWith("a", 30_000, undefined, "ios:7");
+  });
+
   test("uses the socket autolock device when deviceId is omitted", async () => {
     const requestSetText = mock(async () => ({ success: true, totalTimeMs: 1 }));
     const requestImeAction = mock(async () => ({ success: true, totalTimeMs: 1 }));

--- a/test/features/action/PressButton.test.ts
+++ b/test/features/action/PressButton.test.ts
@@ -96,6 +96,45 @@ describe("PressButton", () => {
     }
   });
 
+  test("ios button presses retain their desktop frame context through the runner request", async () => {
+    const contexts: string[] = [];
+    const getInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+      requestPressBack: async (_timeoutMs?: number, _perf?: unknown, frameContext?: string) => {
+        contexts.push(frameContext ?? "");
+        return { success: true, totalTimeMs: 5 };
+      },
+      requestPressHome: async (_timeoutMs?: number, _perf?: unknown, frameContext?: string) => {
+        contexts.push(frameContext ?? "");
+        return { success: true, totalTimeMs: 5 };
+      },
+      requestRecentApps: async (_timeoutMs?: number, _perf?: unknown, frameContext?: string) => {
+        contexts.push(frameContext ?? "");
+        return { success: true, totalTimeMs: 5 };
+      },
+      requestPressButton: async (
+        _button: string,
+        _timeoutMs?: number,
+        _perf?: unknown,
+        frameContext?: string
+      ) => {
+        contexts.push(frameContext ?? "");
+        return { success: true, totalTimeMs: 5 };
+      }
+    } as any);
+
+    try {
+      const pressButton = new PressButton(iosDevice);
+      await pressButton.press("home", undefined, "desktop-frame");
+      await pressButton.press("back", undefined, "desktop-frame");
+      await pressButton.press("recent", undefined, "desktop-frame");
+      await pressButton.press("volume_up", undefined, "desktop-frame");
+
+      expect(contexts).toEqual(["desktop-frame", "desktop-frame", "desktop-frame", "desktop-frame"]);
+    } finally {
+      getInstanceSpy.mockRestore();
+    }
+  });
+
   test("android ADB keyevent honors the caller timeout budget", async () => {
     const androidDevice: BootedDevice = {
       deviceId: "android-device",

--- a/test/features/observe/ios/CtrlProxyText.test.ts
+++ b/test/features/observe/ios/CtrlProxyText.test.ts
@@ -16,6 +16,20 @@ describe("CtrlProxyText requestAppendText", () => {
     await expect(pending).resolves.toEqual({ success: true, totalTimeMs: 1 });
   });
 
+  test("includes a frame context when supplied", async () => {
+    const harness = createIosDelegateHarness({ supportedCommands: ["request_append_text"] });
+    const pending = new CtrlProxyText(harness.context).requestAppendText("a", 5000, undefined, "ios:7");
+    await flush();
+
+    expect(harness.sentMessages[0]).toMatchObject({
+      type: "request_append_text",
+      text: "a",
+      frameContext: "ios:7",
+    });
+    expect(harness.resolveLast({ success: true, totalTimeMs: 1 })).toBe(true);
+    await expect(pending).resolves.toEqual({ success: true, totalTimeMs: 1 });
+  });
+
   test("falls back to focused-field typeText on a runner that predates append", async () => {
     const harness = createIosDelegateHarness({ supportedCommands: ["request_set_text"] });
     const pending = new CtrlProxyText(harness.context).requestAppendText("a");

--- a/test/features/observe/ios/ctrlProxyRequestSnapshots.test.ts
+++ b/test/features/observe/ios/ctrlProxyRequestSnapshots.test.ts
@@ -195,17 +195,17 @@ const SNAPSHOT_SPECS: SnapshotSpec[] = [
   {
     name: "request_press_button",
     builder: "CtrlProxyNavigation.requestPressButton",
-    invoke: h => new CtrlProxyNavigation(h.context).requestPressButton("volume_up"),
+    invoke: h => new CtrlProxyNavigation(h.context).requestPressButton("volume_up", 5000, undefined, "frame-context"),
   },
   {
     name: "request_press_home",
     builder: "CtrlProxyNavigation.requestPressHome",
-    invoke: h => new CtrlProxyNavigation(h.context).requestPressHome(),
+    invoke: h => new CtrlProxyNavigation(h.context).requestPressHome(5000, undefined, "frame-context"),
   },
   {
     name: "request_press_back",
     builder: "CtrlProxyNavigation.requestPressBack",
-    invoke: h => new CtrlProxyNavigation(h.context).requestPressBack(),
+    invoke: h => new CtrlProxyNavigation(h.context).requestPressBack(5000, undefined, "frame-context"),
   },
   {
     name: "request_shake",
@@ -215,7 +215,7 @@ const SNAPSHOT_SPECS: SnapshotSpec[] = [
   {
     name: "request_recent_apps",
     builder: "CtrlProxyNavigation.requestRecentApps",
-    invoke: h => new CtrlProxyNavigation(h.context).requestRecentApps(),
+    invoke: h => new CtrlProxyNavigation(h.context).requestRecentApps(5000, undefined, "frame-context"),
   },
   {
     name: "request_action",

--- a/test/features/observe/ios/ctrlProxyRequestSnapshots.test.ts
+++ b/test/features/observe/ios/ctrlProxyRequestSnapshots.test.ts
@@ -170,7 +170,7 @@ const SNAPSHOT_SPECS: SnapshotSpec[] = [
   {
     name: "request_append_text",
     builder: "CtrlProxyText.requestAppendText",
-    invoke: h => new CtrlProxyText(h.context).requestAppendText("a"),
+    invoke: h => new CtrlProxyText(h.context).requestAppendText("a", 5000, undefined, "frame-context"),
   },
   {
     name: "request_clear_text",

--- a/test/fixtures/ios-ctrlproxy-request-snapshots.json
+++ b/test/fixtures/ios-ctrlproxy-request-snapshots.json
@@ -167,7 +167,8 @@
       "wire": {
         "type": "request_press_button",
         "requestId": "fixture-request-id",
-        "action": "volume_up"
+        "action": "volume_up",
+        "frameContext": "frame-context"
       }
     },
     {
@@ -175,7 +176,8 @@
       "builder": "CtrlProxyNavigation.requestPressHome",
       "wire": {
         "type": "request_press_home",
-        "requestId": "fixture-request-id"
+        "requestId": "fixture-request-id",
+        "frameContext": "frame-context"
       }
     },
     {
@@ -183,7 +185,8 @@
       "builder": "CtrlProxyNavigation.requestPressBack",
       "wire": {
         "type": "request_press_back",
-        "requestId": "fixture-request-id"
+        "requestId": "fixture-request-id",
+        "frameContext": "frame-context"
       }
     },
     {
@@ -199,7 +202,8 @@
       "builder": "CtrlProxyNavigation.requestRecentApps",
       "wire": {
         "type": "request_recent_apps",
-        "requestId": "fixture-request-id"
+        "requestId": "fixture-request-id",
+        "frameContext": "frame-context"
       }
     },
     {

--- a/test/fixtures/ios-ctrlproxy-request-snapshots.json
+++ b/test/fixtures/ios-ctrlproxy-request-snapshots.json
@@ -123,7 +123,8 @@
       "wire": {
         "type": "request_append_text",
         "requestId": "fixture-request-id",
-        "text": "a"
+        "text": "a",
+        "frameContext": "frame-context"
       }
     },
     {


### PR DESCRIPTION
## Summary

The desktop client now pairs the daemon-provided `frameContext` with matching screenshot and
hierarchy captures, echoes it through every desktop input method, and fails closed when the
context is absent, mismatched, or rejected as stale. A stale-context rejection keeps the frame
visible for inspection, clears queued retries, and blocks control until a newer paired capture
arrives.

No new helpers or dependencies were added.

## Linked Issue

Closes [#4596](https://github.com/kaeawc/auto-mobile/issues/4596)

## Bug / Regression Context

- **Prior attempts:** None.
- **Observed symptom:** Desktop control could not bind input to the exact observed UI frame.
- **Repro steps / conditions:** A legacy runner omits `frameContext`, screenshot and hierarchy
  contexts diverge, or the daemon rejects an input as stale.

## Validation

- [x] Focused desktop protocol, policy, session, forwarding, and socket tests
- [x] `./gradlew :desktop-core:test`
- [x] `ONLY_TOUCHED_FILES=true bash scripts/ktfmt/validate_ktfmt.sh`
- [x] `bun run typecheck`
- [ ] `bun run turbo:validate` is blocked by unrelated device-test port exhaustion:
  `No free host ports were found at or above 8765`
- [x] New code uses existing interfaces and fakes; no new direct dependency was added
- [x] Branch was created from current `origin/main`

## Kotlin Reuse Check

- [x] Checked existing desktop domain, session, and daemon contracts before adding code
- [x] No helper, wrapper, or dependency was added
