### PR TITLE
fix(android): re-expand notification shade on closed re-post during wait

### DIFF
--- a/src/server/systemTrayHelpers.ts
+++ b/src/server/systemTrayHelpers.ts
@@ -144,6 +144,11 @@ const NOTIFICATION_ROW_RESOURCE_ID_EXCLUDES = [
 ];
 const DEFAULT_SYSTEM_TRAY_AWAIT_TIMEOUT_MS = 5000;
 const SYSTEM_TRAY_POLL_INTERVAL_MS = 250;
+// When waiting for a notification, re-issue the shade expand (at most this often) if the
+// shade is found closed. A high-importance notification that re-posts (e.g. a persistent
+// connection push) re-fires a heads-up that can collapse the shade or race the initial
+// expand; without re-expanding, the poll loop would sit on a closed shade until timeout.
+const SYSTEM_TRAY_REEXPAND_INTERVAL_MS = 1000;
 export const SYSTEM_TRAY_CLEAR_MAX_ITERATIONS = 25;
 // Re-export shared constant so existing callers (interactionTools.ts) keep working.
 export const SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS = SYSTEM_TRAY_NOTIFICATION_SWIPE_DURATION_MS_FROM_HINTS;
@@ -212,6 +217,20 @@ const expandSystemTray = async (
   observation?: ObserveResult
 ): Promise<void> => {
   await detector.expandTray(observation);
+};
+
+// Re-expand the shade while waiting for a notification, swallowing failures: a
+// re-posting high-importance push can collapse the shade mid-wait, and the next
+// poll will re-observe and retry, so a single failed expand here is not fatal.
+const reexpandSystemTrayBestEffort = async (
+  detector: NotificationUIDetector,
+  observation?: ObserveResult
+): Promise<void> => {
+  try {
+    await expandSystemTray(detector, observation);
+  } catch (error) {
+    logger.debug(`[systemTray] re-expand while waiting for notification failed: ${error}`);
+  }
 };
 
 const collapseSystemTray = async (
@@ -1039,6 +1058,65 @@ export const ensureSystemTrayClosed = async (
   };
 };
 
+// Collect every text/content-desc string inside a candidate notification row's
+// subtree. Iterative (not recursive) to keep depth shallow for the lint ratchet.
+const collectNotificationSubtreeTexts = (node: any): string[] => {
+  const texts: string[] = [];
+  const stack: any[] = [node];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) {
+      continue;
+    }
+    for (const text of extractNodeTextCandidates(current)) {
+      texts.push(text);
+    }
+    const children = current.node;
+    if (Array.isArray(children)) {
+      for (const child of children) {
+        stack.push(child);
+      }
+    } else if (children && typeof children === "object") {
+      stack.push(children);
+    }
+  }
+  return texts;
+};
+
+// Diagnostic: when the shade is open but no notification matched the criteria,
+// summarize every notification-row candidate and the text found inside each so a
+// failing run reveals whether the target text is present-but-unmatched vs. absent
+// from the captured hierarchy (issue: persistent-push notification "not found").
+const buildUnmatchedNotificationDiagnostics = (
+  viewHierarchy: ViewHierarchyResult,
+  criteria: SystemTrayNotificationArgs,
+  appMatchTexts: string[]
+): string => {
+  const candidates = collectNotificationCandidates(viewHierarchy);
+  const lines: string[] = [];
+  for (let index = 0; index < candidates.length; index++) {
+    const candidate = candidates[index];
+    const texts = collectNotificationSubtreeTexts(candidate.node);
+    lines.push(
+      `  candidate#${index} depth=${candidate.depth} inGroup=${Boolean(candidate.groupNode)} ` +
+      `bounds=${JSON.stringify(candidate.element?.bounds ?? null)} texts=${JSON.stringify(texts)}`
+    );
+  }
+  const criteriaSummary = JSON.stringify({
+    title: criteria.title,
+    body: criteria.body,
+    appId: criteria.appId,
+    tapActionLabel: criteria.tapActionLabel
+  });
+  const header =
+    `[systemTray][diag] shade open but no notification matched. ` +
+    `criteria=${criteriaSummary} appMatchTexts=${JSON.stringify(appMatchTexts)} ` +
+    `candidateCount=${candidates.length}`;
+  return candidates.length > 0
+    ? `${header}\n${lines.join("\n")}`
+    : `${header} (no notification-row candidates detected in the open shade)`;
+};
+
 export const waitForNotificationMatch = async (
   device: BootedDevice,
   criteria: SystemTrayNotificationArgs,
@@ -1065,12 +1143,42 @@ export const waitForNotificationMatch = async (
     observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
   }
 
+  let lastDiagSignature = "";
+  let lastReexpandAtMs = timer.now();
   while (true) {
     const viewHierarchy = observation.viewHierarchy;
     if (viewHierarchy && detector.isTrayOpen(viewHierarchy)) {
       const match = findBestNotificationMatch(viewHierarchy, criteria, appMatchTexts);
       if (match) {
         return { observation, match };
+      }
+      // Diagnostic: log the candidate breakdown when the shade is open but nothing
+      // matched, deduped so a 120s poll loop does not emit identical lines each tick.
+      const diagnostics = buildUnmatchedNotificationDiagnostics(viewHierarchy, criteria, appMatchTexts);
+      if (diagnostics !== lastDiagSignature) {
+        lastDiagSignature = diagnostics;
+        logger.info(diagnostics);
+      }
+    } else {
+      // The shade is not open. ensureSystemTrayOpen expanded it once, but a
+      // high-importance notification that re-posts (e.g. a persistent connection
+      // push) re-fires a heads-up that can collapse the shade or race the initial
+      // expand. Without re-expanding, the loop would poll a closed shade until the
+      // (up to 120s) timeout and never match a notification that is genuinely there.
+      // Re-issue the expand, throttled, so a re-post can't leave the shade shut.
+      if (timer.now() - lastReexpandAtMs >= SYSTEM_TRAY_REEXPAND_INTERVAL_MS) {
+        lastReexpandAtMs = timer.now();
+        await reexpandSystemTrayBestEffort(detector, observation);
+      }
+      // Diagnostic: the shade is NOT detected as open (no hierarchy, a heads-up
+      // overlay, or the expand did not take). If this is all that appears for the
+      // whole wait, the failure is shade-open/detection, not notification matching.
+      const trayDiag =
+        `[systemTray][diag] shade NOT detected open during notification wait ` +
+        `(hasHierarchy=${Boolean(observation.viewHierarchy)})`;
+      if (trayDiag !== lastDiagSignature) {
+        lastDiagSignature = trayDiag;
+        logger.info(trayDiag);
       }
     }
 

--- a/test/server/systemTray.test.ts
+++ b/test/server/systemTray.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import {
   registerInteractionTools,
   resetSystemTrayDependencies,
@@ -19,9 +19,12 @@ import type { SystemTrayIosClient } from "../../src/server/systemTrayHelpers";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
 import { FakeObserveScreen } from "../fakes/FakeObserveScreen";
+import { logger } from "../../src/utils/logger";
 import type { BootedDevice, Element, ObserveResult, ViewHierarchyResult } from "../../src/models";
 
 const POLL_INTERVAL_MS = 250;
+// Mirrors the private SYSTEM_TRAY_REEXPAND_INTERVAL_MS in systemTrayHelpers.ts.
+const REEXPAND_INTERVAL_MS = 1000;
 const SYSTEM_TRAY_PACKAGE = "com.android.systemui";
 
 class SequencedFakeAdbExecutor extends FakeAdbExecutor {
@@ -305,6 +308,223 @@ describe("systemTray find", () => {
     expect(result.match).not.toBeNull();
     expect(result.match!.match.matches.title?.text).toBe("Target Notification");
     expect(fakeObserveScreen.getExecuteCallCount()).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// Issue #4614: a re-posting high-importance notification (e.g. a persistent
+// connection push) can collapse the shade mid-wait. waitForNotificationMatch
+// must re-issue the expand while polling, throttled to at most once per
+// REEXPAND_INTERVAL_MS, rather than sitting on a closed shade until timeout.
+describe("systemTray re-expand on closed shade during wait", () => {
+  afterEach(() => {
+    resetSystemTrayDependencies();
+  });
+
+  test("re-expands once the shade has been closed for a full throttle interval, then matches", async () => {
+    const fakeTimer = new FakeTimer();
+    const fakeAdb = new SequencedFakeAdbExecutor([1000, 2000]);
+    // Starts already open (ensureSystemTrayOpen takes the skip branch, so the
+    // only expand-notifications call possible here is our in-loop re-expand).
+    const fakeObserveScreen = new SequencedObserveScreen([
+      createObservation(createTrayHierarchy("Other Notification")),
+      createObservation(createClosedHierarchy()),
+      createObservation(createClosedHierarchy()),
+      createObservation(createClosedHierarchy()),
+      createObservation(createClosedHierarchy()),
+      createObservation(createTrayHierarchy("Target Notification"))
+    ]);
+
+    setSystemTrayDependencies({
+      timer: fakeTimer,
+      adbFactory: () => fakeAdb,
+      observeScreenFactory: () => fakeObserveScreen
+    });
+
+    const resultPromise = waitForNotificationMatch(
+      device,
+      { title: "Target Notification" },
+      [],
+      REEXPAND_INTERVAL_MS * 5
+    );
+
+    // 5 poll ticks: shade stays closed through t=250..1000, crossing the
+    // throttle interval on the 4th closed observation (t=1000), then reopens.
+    await advancePendingSleeps(fakeTimer, 5);
+
+    const result = await resultPromise;
+
+    expect(result.match).not.toBeNull();
+    expect(result.match!.match.matches.title?.text).toBe("Target Notification");
+    expect(
+      fakeAdb.getExecutedCommands().filter(cmd => cmd.includes("expand-notifications")).length
+    ).toBe(1);
+  });
+
+  test("does not re-expand before a full throttle interval has elapsed", async () => {
+    const fakeTimer = new FakeTimer();
+    const fakeAdb = new SequencedFakeAdbExecutor([1000, 2000]);
+    const fakeObserveScreen = new SequencedObserveScreen([
+      createObservation(createTrayHierarchy("Other Notification")),
+      createObservation(createClosedHierarchy()),
+      createObservation(createClosedHierarchy()),
+      createObservation(createClosedHierarchy())
+    ]);
+
+    setSystemTrayDependencies({
+      timer: fakeTimer,
+      adbFactory: () => fakeAdb,
+      observeScreenFactory: () => fakeObserveScreen
+    });
+
+    // Deadline elapses strictly before the shade has been closed for a full
+    // REEXPAND_INTERVAL_MS, so the loop should time out without ever
+    // re-issuing the expand.
+    const resultPromise = waitForNotificationMatch(
+      device,
+      { title: "Target Notification" },
+      [],
+      REEXPAND_INTERVAL_MS - 300
+    );
+
+    await advancePendingSleeps(fakeTimer, 3);
+
+    const result = await resultPromise;
+
+    expect(result.match).toBeNull();
+    expect(
+      fakeAdb.getExecutedCommands().filter(cmd => cmd.includes("expand-notifications")).length
+    ).toBe(0);
+  });
+
+  test("swallows a failed re-expand attempt and keeps polling until it matches", async () => {
+    const fakeTimer = new FakeTimer();
+    const fakeAdb = new SequencedFakeAdbExecutor([1000, 2000]);
+    fakeAdb.setCommandError("expand-notifications", new Error("boom"));
+    const fakeObserveScreen = new SequencedObserveScreen([
+      createObservation(createTrayHierarchy("Other Notification")),
+      createObservation(createClosedHierarchy()),
+      createObservation(createClosedHierarchy()),
+      createObservation(createClosedHierarchy()),
+      createObservation(createClosedHierarchy()),
+      createObservation(createTrayHierarchy("Target Notification"))
+    ]);
+
+    setSystemTrayDependencies({
+      timer: fakeTimer,
+      adbFactory: () => fakeAdb,
+      observeScreenFactory: () => fakeObserveScreen
+    });
+
+    const debugSpy = spyOn(logger, "debug").mockImplementation(() => {});
+    try {
+      const resultPromise = waitForNotificationMatch(
+        device,
+        { title: "Target Notification" },
+        [],
+        5000
+      );
+
+      await advancePendingSleeps(fakeTimer, 5);
+
+      const result = await resultPromise;
+
+      expect(result.match).not.toBeNull();
+      expect(result.match!.match.matches.title?.text).toBe("Target Notification");
+      const swallowedLogs = debugSpy.mock.calls.filter(call =>
+        String(call[0]).includes("re-expand while waiting for notification failed")
+      );
+      expect(swallowedLogs.length).toBe(1);
+    } finally {
+      debugSpy.mockRestore();
+    }
+  });
+});
+
+// Diagnostic logging added alongside the #4614 fix: when a wait fails to
+// match, the logs should reveal whether the shade was open-but-unmatched or
+// never detected as open, deduped so a long poll doesn't spam identical lines.
+describe("systemTray unmatched-notification diagnostics", () => {
+  afterEach(() => {
+    resetSystemTrayDependencies();
+  });
+
+  test("logs the open-but-unmatched candidate breakdown once, deduped across identical polls", async () => {
+    const fakeTimer = new FakeTimer();
+    const fakeAdb = new SequencedFakeAdbExecutor([1000, 2000]);
+    const fakeObserveScreen = new SequencedObserveScreen([
+      createObservation(createTrayHierarchy("Other Notification")),
+      createObservation(createTrayHierarchy("Other Notification")),
+      createObservation(createTrayHierarchy("Other Notification")),
+      createObservation(createTrayHierarchy("Target Notification"))
+    ]);
+
+    setSystemTrayDependencies({
+      timer: fakeTimer,
+      adbFactory: () => fakeAdb,
+      observeScreenFactory: () => fakeObserveScreen
+    });
+
+    const infoSpy = spyOn(logger, "info").mockImplementation(() => {});
+    try {
+      const resultPromise = waitForNotificationMatch(
+        device,
+        { title: "Target Notification" },
+        [],
+        5000
+      );
+
+      await advancePendingSleeps(fakeTimer, 3);
+
+      const result = await resultPromise;
+
+      expect(result.match).not.toBeNull();
+      const diagLogs = infoSpy.mock.calls.filter(call =>
+        String(call[0]).includes("[systemTray][diag] shade open but no notification matched")
+      );
+      expect(diagLogs.length).toBe(1);
+      expect(String(diagLogs[0][0])).toContain("Other Notification");
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+
+  test("logs the shade-not-open diagnostic once, deduped across identical closed polls", async () => {
+    const fakeTimer = new FakeTimer();
+    const fakeAdb = new SequencedFakeAdbExecutor([1000, 2000]);
+    const fakeObserveScreen = new SequencedObserveScreen([
+      createObservation(createTrayHierarchy("Other Notification")),
+      createObservation(createClosedHierarchy()),
+      createObservation(createClosedHierarchy()),
+      createObservation(createTrayHierarchy("Target Notification"))
+    ]);
+
+    setSystemTrayDependencies({
+      timer: fakeTimer,
+      adbFactory: () => fakeAdb,
+      observeScreenFactory: () => fakeObserveScreen
+    });
+
+    const infoSpy = spyOn(logger, "info").mockImplementation(() => {});
+    try {
+      const resultPromise = waitForNotificationMatch(
+        device,
+        { title: "Target Notification" },
+        [],
+        5000
+      );
+
+      await advancePendingSleeps(fakeTimer, 3);
+
+      const result = await resultPromise;
+
+      expect(result.match).not.toBeNull();
+      const diagLogs = infoSpy.mock.calls.filter(call =>
+        String(call[0]).includes("shade NOT detected open during notification wait")
+      );
+      expect(diagLogs.length).toBe(1);
+    } finally {
+      infoSpy.mockRestore();
+    }
   });
 });
 


### PR DESCRIPTION
Closes #4614

## Summary

`waitForNotificationMatch` expands the notification shade once up front (`ensureSystemTrayOpen`) and then polls for a matching notification, but never re-expands if the shade is later found closed. A re-posting high-importance notification (e.g. a persistent connection push retrying) can collapse the shade mid-wait via its heads-up transition, and the loop had no path back to an open shade before the deadline - it just times out with `match: null` even when the notification is genuinely there.

This re-issues the expand (throttled to once per second) whenever the shade is found closed during the wait, best-effort (a failed re-expand is logged and swallowed, not fatal - the next poll tick retries). Also adds diagnostic logging, deduped per unique message, that reports either the open-but-unmatched notification-row breakdown or that the shade was never detected open during the wait, so a future timeout points at the actual failure mode instead of a bare `match: null`.