### PR TITLE
fix: enforce session tool capabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.46",
   "description": "Mobile device interaction automation via MCP",
   "scripts": {
-    "test": "bun test",
-    "test:coverage": "bun test --coverage",
+    "test": "bun test --isolate",
+    "test:coverage": "bun test --isolate --coverage",
     "test:startup:bun": "bash scripts/ci/mcp-startup-smoke.sh",
     "test:image:bun": "bun scripts/ci/image-runtime-smoke.ts",
     "test:image:sharp-bun-repro": "bash scripts/validate-sharp-bun-repro.sh",

--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -790,6 +790,24 @@
         "__lockNamespace": {
           "description": "Internal plan-scoped lock namespace (injected)",
           "type": "string"
+        },
+        "platform": {
+          "type": "string",
+          "enum": [
+            "android",
+            "ios"
+          ]
+        },
+        "sessionUuid": {
+          "description": "Session",
+          "type": "string"
+        },
+        "keepScreenAwake": {
+          "type": "boolean"
+        },
+        "device": {
+          "description": "Device label",
+          "type": "string"
         }
       },
       "required": [

--- a/scripts/ci/run-ts-coverage.sh
+++ b/scripts/ci/run-ts-coverage.sh
@@ -13,7 +13,7 @@ log_file="${1:-ci-logs/ts-coverage.log}"
 mkdir -p "$(dirname "${log_file}")"
 
 set +e
-bun test --coverage --coverage-reporter=lcov --coverage-dir=coverage > "${log_file}" 2>&1
+bun test --isolate --coverage --coverage-reporter=lcov --coverage-dir=coverage > "${log_file}" 2>&1
 status=$?
 set -e
 

--- a/src/daemon/daemonRequestHandlers.ts
+++ b/src/daemon/daemonRequestHandlers.ts
@@ -11,6 +11,7 @@ export interface DaemonStateAccess {
   isInitialized(): boolean;
   getSessionManager(): {
     getSession(sessionId: string): Session | null;
+    getSessionForDevice?(deviceId: string): string | null;
     getDeviceLabels(sessionId: string): DeviceLabelMap | undefined;
     releaseSession(sessionId: string): Promise<string | null>;
   };

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -45,6 +45,7 @@ import {
   type SessionToolProfileService,
   type ToolCapability,
 } from "../features/toolCapabilities/SessionToolProfileService";
+import { assertToolEnabledForSession } from "../features/toolCapabilities/toolCapabilityPolicy";
 import { getMcpServerVersion } from "../utils/mcpVersion";
 import {
   IOS_CTRL_PROXY_APP_HASH,
@@ -181,7 +182,7 @@ export class UnixSocketServer {
   private featureFlagService: FeatureFlagService | null;
   private readonly handshakeEnforced: boolean;
   private readonly daemonIdentity: DaemonSelfIdentity;
-  private readonly sessionToolProfileService?: Pick<SessionToolProfileService, "setEnabled">;
+  private readonly sessionToolProfileService?: Pick<SessionToolProfileService, "isEnabled" | "setEnabled">;
   /**
    * Factory that `getMcpClient()` calls to open the loopback MCP HTTP client.
    * Defaults to the real {@link createMcpClient}; tests assign a fake here to
@@ -228,7 +229,7 @@ export class UnixSocketServer {
     handshakeConfig: {
       identity?: DaemonSelfIdentity;
       enforce?: boolean;
-      sessionToolProfileService?: Pick<SessionToolProfileService, "setEnabled">;
+      sessionToolProfileService?: Pick<SessionToolProfileService, "isEnabled" | "setEnabled">;
     } = {}
   ) {
     this.socketPath = socketPath;
@@ -901,6 +902,7 @@ export class UnixSocketServer {
         if (!args.deviceId || !args.appId || !args.fileName || !args.key || !args.type) {
           throw new Error("setKeyValue requires deviceId, appId, fileName, key, and type params");
         }
+        await this.assertSocketToolEnabled(args.deviceId, "setKeyValue");
         const bootedDevices = await PlatformDeviceManagerFactory.getInstance().getBootedDevices("android");
         const targetDevice = bootedDevices.find(d => d.deviceId === args.deviceId);
         if (!targetDevice) {
@@ -930,6 +932,7 @@ export class UnixSocketServer {
         if (!args.deviceId || !args.appId || !args.fileName || !args.key) {
           throw new Error("removeKeyValue requires deviceId, appId, fileName, and key params");
         }
+        await this.assertSocketToolEnabled(args.deviceId, "removeKeyValue");
         const bootedDevices = await PlatformDeviceManagerFactory.getInstance().getBootedDevices("android");
         const targetDevice = bootedDevices.find(d => d.deviceId === args.deviceId);
         if (!targetDevice) {
@@ -948,6 +951,7 @@ export class UnixSocketServer {
         if (!args.deviceId || !args.appId || !args.fileName) {
           throw new Error("clearKeyValueFile requires deviceId, appId, and fileName params");
         }
+        await this.assertSocketToolEnabled(args.deviceId, "clearKeyValueFile");
         const bootedDevices = await PlatformDeviceManagerFactory.getInstance().getBootedDevices("android");
         const targetDevice = bootedDevices.find(d => d.deviceId === args.deviceId);
         if (!targetDevice) {
@@ -960,6 +964,13 @@ export class UnixSocketServer {
       default:
         return undefined;
     }
+  }
+
+  private async assertSocketToolEnabled(deviceId: string, toolName: string): Promise<void> {
+    const sessionUuid = this.daemonState.isInitialized()
+      ? this.daemonState.getSessionManager().getSessionForDevice?.(deviceId) ?? undefined
+      : undefined;
+    await assertToolEnabledForSession(toolName, sessionUuid, this.sessionToolProfileService);
   }
 
   /**

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -480,10 +480,11 @@ export class UnixSocketServer {
           const forwardStartMs = this.timer.now();
           try {
             const mcpClient = await this.getMcpClient(forwardKey);
-            this.recordBoundMcpClientKey(request, sessionId, forwardKey);
 
             try {
-              return await this.handleIdeRequest(mcpClient, request, remainingTimeoutMs, sessionId);
+              const response = await this.handleIdeRequest(mcpClient, request, remainingTimeoutMs, sessionId);
+              this.recordBoundMcpClientKey(request, sessionId, forwardKey);
+              return response;
             } catch (ideError) {
               const ideErrorMessage = ideError instanceof Error ? ideError.message : String(ideError);
               if (ideErrorMessage.includes("Session not found")) {
@@ -500,8 +501,8 @@ export class UnixSocketServer {
                     detail: `no budget remaining after session reconnect (elapsed ${this.timer.now() - forwardStartMs}ms)`,
                   });
                 }
-                this.recordBoundMcpClientKey(request, sessionId, forwardKey);
                 const response = await this.handleIdeRequest(freshClient, request, retryRemainingMs, sessionId);
+                this.recordBoundMcpClientKey(request, sessionId, forwardKey);
                 return response;
               }
               throw ideError;

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -171,8 +171,8 @@ export class UnixSocketServer {
   private mcpClientPromises: Map<string, Promise<Client>> = new Map();
   /**
    * The loopback MCP client that a socket transport most recently bound with a
-   * device session. `tools/list` carries no arguments, so this preserves the
-   * client-local session context selected by the preceding device-aware call.
+   * device session. Follow-up requests can omit their session UUID, so reuse
+   * this client to preserve the selected capability profile.
    */
   private boundMcpClientKeysBySocketSession: Map<string, string> = new Map();
   /** Promise tails that serialize MCP HTTP forwards only within the same target key. */
@@ -607,20 +607,7 @@ export class UnixSocketServer {
 
   private getMcpForwardKey(request: DaemonRequest, socketSessionId: string): string {
     if (request.method === "tools/call") {
-      const args = request.params?.arguments;
-      const scopedKey = this.getRequestArgumentScopeKey(args);
-      if (scopedKey) {
-        return scopedKey;
-      }
-
-      const implicitAutolockKey = this.getImplicitAutolockScopeKey(socketSessionId, args);
-      if (implicitAutolockKey) {
-        return implicitAutolockKey;
-      }
-
-      // The daemon injects __mcpSessionId before forwarding. Use the socket session as the
-      // pre-forward key so separate daemon clients can autolock and run independently.
-      return `socket:${socketSessionId}`;
+      return this.getToolsCallForwardKey(request.params?.arguments, socketSessionId);
     }
 
     if (request.method === "tools/list") {
@@ -628,7 +615,9 @@ export class UnixSocketServer {
     }
 
     if (request.method === "ide/getNavigationGraph") {
-      return this.getRequestArgumentScopeKey(request.params) ?? `method:${request.method}`;
+      return this.getRequestArgumentScopeKey(request.params)
+        ?? this.boundMcpClientKeysBySocketSession.get(socketSessionId)
+        ?? `method:${request.method}`;
     }
 
     if (request.method === "resources/read") {
@@ -637,6 +626,27 @@ export class UnixSocketServer {
     }
 
     return `method:${request.method}`;
+  }
+
+  private getToolsCallForwardKey(args: unknown, socketSessionId: string): string {
+    const scopedKey = this.getRequestArgumentScopeKey(args);
+    if (scopedKey) {
+      return scopedKey;
+    }
+
+    const boundKey = this.boundMcpClientKeysBySocketSession.get(socketSessionId);
+    if (boundKey) {
+      return boundKey;
+    }
+
+    const implicitAutolockKey = this.getImplicitAutolockScopeKey(socketSessionId, args);
+    if (implicitAutolockKey) {
+      return implicitAutolockKey;
+    }
+
+    // The daemon injects __mcpSessionId before forwarding. Use the socket session as the
+    // pre-forward key so separate daemon clients can autolock and run independently.
+    return `socket:${socketSessionId}`;
   }
 
   private recordBoundMcpClientKey(

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -141,6 +141,15 @@ interface CachedAppendTextInput {
   transportId?: string;
 }
 
+interface BoundMcpClient {
+  forwardKey: string;
+  sessionUuid: string;
+  requiresLiveDaemonSession: boolean;
+}
+
+const isNonBlankSessionUuid = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0;
+
 /**
  * Preserve the normal failed socket envelope while carrying append progress for
  * a client that can safely retry only the unsent suffix.
@@ -174,7 +183,7 @@ export class UnixSocketServer {
    * device session. Follow-up requests can omit their session UUID, so reuse
    * this client to preserve the selected capability profile.
    */
-  private boundMcpClientKeysBySocketSession: Map<string, { forwardKey: string; sessionUuid: string }> = new Map();
+  private boundMcpClientKeysBySocketSession: Map<string, BoundMcpClient> = new Map();
   /** Promise tails that serialize MCP HTTP forwards only within the same target key. */
   private mcpForwardTails: Map<string, Promise<void>> = new Map();
   private mcpClientIdleTimers: Map<string, NodeJS.Timeout> = new Map();
@@ -345,7 +354,7 @@ export class UnixSocketServer {
       this.sessions.delete(sessionId);
       this.clientSockets.delete(sessionId);
       this.notificationSubscribers.delete(sessionId);
-      this.boundMcpClientKeysBySocketSession.delete(sessionId);
+      this.clearBoundMcpClientKey(sessionId);
     });
 
     socket.on("error", error => {
@@ -353,7 +362,7 @@ export class UnixSocketServer {
       this.sessions.delete(sessionId);
       this.clientSockets.delete(sessionId);
       this.notificationSubscribers.delete(sessionId);
-      this.boundMcpClientKeysBySocketSession.delete(sessionId);
+      this.clearBoundMcpClientKey(sessionId);
       if (!socket.destroyed) {
         socket.destroy();
       }
@@ -480,10 +489,16 @@ export class UnixSocketServer {
           const forwardStartMs = this.timer.now();
           try {
             const mcpClient = await this.getMcpClient(forwardKey);
+            const sessionWasActiveBeforeForward = this.wasRequestSessionActive(request);
 
             try {
               const response = await this.handleIdeRequest(mcpClient, request, remainingTimeoutMs, sessionId);
-              this.recordBoundMcpClientKey(request, sessionId, forwardKey);
+              this.recordBoundMcpClientKey(
+                request,
+                sessionId,
+                forwardKey,
+                sessionWasActiveBeforeForward
+              );
               return response;
             } catch (ideError) {
               const ideErrorMessage = ideError instanceof Error ? ideError.message : String(ideError);
@@ -502,7 +517,12 @@ export class UnixSocketServer {
                   });
                 }
                 const response = await this.handleIdeRequest(freshClient, request, retryRemainingMs, sessionId);
-                this.recordBoundMcpClientKey(request, sessionId, forwardKey);
+                this.recordBoundMcpClientKey(
+                  request,
+                  sessionId,
+                  forwardKey,
+                  sessionWasActiveBeforeForward
+                );
                 return response;
               }
               throw ideError;
@@ -653,15 +673,29 @@ export class UnixSocketServer {
   private recordBoundMcpClientKey(
     request: DaemonRequest,
     socketSessionId: string,
-    forwardKey: string
+    forwardKey: string,
+    sessionWasActiveBeforeForward: boolean
   ): void {
     if (request.method !== "tools/call") {
       return;
     }
     const sessionUuid = this.getSessionUuid(request.params?.arguments);
-    if (sessionUuid) {
-      this.boundMcpClientKeysBySocketSession.set(socketSessionId, { forwardKey, sessionUuid });
+    if (!sessionUuid) {
+      return;
     }
+    const sessionIsActiveAfterForward = this.hasActiveDaemonSession(sessionUuid);
+    if (
+      (sessionWasActiveBeforeForward || request.params?.name === "executePlan")
+      && !sessionIsActiveAfterForward
+    ) {
+      this.clearBoundMcpClientKey(socketSessionId);
+      return;
+    }
+    this.boundMcpClientKeysBySocketSession.set(socketSessionId, {
+      forwardKey,
+      sessionUuid,
+      requiresLiveDaemonSession: sessionWasActiveBeforeForward || sessionIsActiveAfterForward,
+    });
   }
 
   private getBoundMcpClientKey(socketSessionId: string): string | undefined {
@@ -669,14 +703,51 @@ export class UnixSocketServer {
     if (!boundClient) {
       return undefined;
     }
-    if (!this.daemonState.isInitialized()) {
+    if (!boundClient.requiresLiveDaemonSession || !this.daemonState.isInitialized()) {
       return boundClient.forwardKey;
     }
-    if (this.daemonState.getSessionManager().getSession(boundClient.sessionUuid)) {
+    if (this.hasActiveDaemonSession(boundClient.sessionUuid)) {
       return boundClient.forwardKey;
+    }
+    this.clearBoundMcpClientKey(socketSessionId);
+    return undefined;
+  }
+
+  private clearBoundMcpClientKey(socketSessionId: string): void {
+    const boundClient = this.boundMcpClientKeysBySocketSession.get(socketSessionId);
+    if (!boundClient) {
+      return;
     }
     this.boundMcpClientKeysBySocketSession.delete(socketSessionId);
-    return undefined;
+    this.scheduleMcpClientIdleClose(boundClient.forwardKey);
+  }
+
+  private isMcpClientKeyBound(key: string): boolean {
+    for (const boundClient of this.boundMcpClientKeysBySocketSession.values()) {
+      if (boundClient.forwardKey === key) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private wasRequestSessionActive(request: DaemonRequest): boolean {
+    const sessionUuid = request.method === "tools/call"
+      ? this.getSessionUuid(request.params?.arguments)
+      : undefined;
+    return sessionUuid ? this.hasActiveDaemonSession(sessionUuid) : false;
+  }
+
+  private hasActiveDaemonSession(sessionUuid: string): boolean {
+    if (!this.daemonState.isInitialized()) {
+      return false;
+    }
+    try {
+      return this.daemonState.getSessionManager().getSession(sessionUuid) !== null;
+    } catch (error) {
+      logger.debug(`Unable to resolve bound session ${sessionUuid}: ${error}`);
+      return false;
+    }
   }
 
   private getSessionUuid(args: unknown): string | undefined {
@@ -684,7 +755,7 @@ export class UnixSocketServer {
       return undefined;
     }
     const sessionUuid = (args as Record<string, unknown>).sessionUuid;
-    return typeof sessionUuid === "string" && sessionUuid.length > 0 ? sessionUuid : undefined;
+    return isNonBlankSessionUuid(sessionUuid) ? sessionUuid : undefined;
   }
 
   private getRequestArgumentScopeKey(args: unknown): string | undefined {
@@ -693,7 +764,7 @@ export class UnixSocketServer {
     }
 
     const record = args as Record<string, unknown>;
-    const hasSessionUuid = typeof record.sessionUuid === "string" && record.sessionUuid.length > 0;
+    const hasSessionUuid = isNonBlankSessionUuid(record.sessionUuid);
     const hasDeviceLabel = typeof record.device === "string" && record.device.length > 0;
 
     // Precedence (pinned by #2565 review): a device label resolves the mapped session before
@@ -2116,7 +2187,7 @@ export class UnixSocketServer {
 
   private async closeIdleMcpClient(key: string): Promise<void> {
     this.mcpClientIdleTimers.delete(key);
-    if (this.mcpForwardTails.has(key)) {
+    if (this.mcpForwardTails.has(key) || this.isMcpClientKeyBound(key)) {
       return;
     }
     // The append helper shares the device's idle lifecycle: once nothing has

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -174,7 +174,7 @@ export class UnixSocketServer {
    * device session. Follow-up requests can omit their session UUID, so reuse
    * this client to preserve the selected capability profile.
    */
-  private boundMcpClientKeysBySocketSession: Map<string, string> = new Map();
+  private boundMcpClientKeysBySocketSession: Map<string, { forwardKey: string; sessionUuid: string }> = new Map();
   /** Promise tails that serialize MCP HTTP forwards only within the same target key. */
   private mcpForwardTails: Map<string, Promise<void>> = new Map();
   private mcpClientIdleTimers: Map<string, NodeJS.Timeout> = new Map();
@@ -612,12 +612,12 @@ export class UnixSocketServer {
     }
 
     if (request.method === "tools/list") {
-      return this.boundMcpClientKeysBySocketSession.get(socketSessionId) ?? `method:${request.method}`;
+      return this.getBoundMcpClientKey(socketSessionId) ?? `method:${request.method}`;
     }
 
     if (request.method === "ide/getNavigationGraph") {
       return this.getRequestArgumentScopeKey(request.params)
-        ?? this.boundMcpClientKeysBySocketSession.get(socketSessionId)
+        ?? this.getBoundMcpClientKey(socketSessionId)
         ?? `method:${request.method}`;
     }
 
@@ -635,7 +635,7 @@ export class UnixSocketServer {
       return scopedKey;
     }
 
-    const boundKey = this.boundMcpClientKeysBySocketSession.get(socketSessionId);
+    const boundKey = this.getBoundMcpClientKey(socketSessionId);
     if (boundKey) {
       return boundKey;
     }
@@ -660,8 +660,23 @@ export class UnixSocketServer {
     }
     const sessionUuid = this.getSessionUuid(request.params?.arguments);
     if (sessionUuid) {
-      this.boundMcpClientKeysBySocketSession.set(socketSessionId, forwardKey);
+      this.boundMcpClientKeysBySocketSession.set(socketSessionId, { forwardKey, sessionUuid });
     }
+  }
+
+  private getBoundMcpClientKey(socketSessionId: string): string | undefined {
+    const boundClient = this.boundMcpClientKeysBySocketSession.get(socketSessionId);
+    if (!boundClient) {
+      return undefined;
+    }
+    if (!this.daemonState.isInitialized()) {
+      return boundClient.forwardKey;
+    }
+    if (this.daemonState.getSessionManager().getSession(boundClient.sessionUuid)) {
+      return boundClient.forwardKey;
+    }
+    this.boundMcpClientKeysBySocketSession.delete(socketSessionId);
+    return undefined;
   }
 
   private getSessionUuid(args: unknown): string | undefined {
@@ -979,9 +994,31 @@ export class UnixSocketServer {
 
   private async assertSocketToolEnabled(deviceId: string, toolName: string): Promise<void> {
     const sessionUuid = this.daemonState.isInitialized()
-      ? this.daemonState.getSessionManager().getSessionForDevice?.(deviceId) ?? undefined
+      ? this.getCapabilityProfileSessionUuid(
+        this.daemonState.getSessionManager().getSessionForDevice?.(deviceId) ?? undefined
+      )
       : undefined;
     await assertToolEnabledForSession(toolName, sessionUuid, this.sessionToolProfileService);
+  }
+
+  private getCapabilityProfileSessionUuid(sessionUuid: string | undefined): string | undefined {
+    if (!sessionUuid || !this.daemonState.isInitialized()) {
+      return sessionUuid;
+    }
+
+    const sessionManager = this.daemonState.getSessionManager();
+    for (
+      let separatorIndex = sessionUuid.lastIndexOf(":");
+      separatorIndex >= 0;
+      separatorIndex = sessionUuid.lastIndexOf(":", separatorIndex - 1)
+    ) {
+      const candidateBaseSessionUuid = sessionUuid.slice(0, separatorIndex);
+      const deviceLabels = sessionManager.getDeviceLabels(candidateBaseSessionUuid);
+      if (deviceLabels && Object.values(deviceLabels).includes(sessionUuid)) {
+        return candidateBaseSessionUuid;
+      }
+    }
+    return sessionUuid;
   }
 
   /**

--- a/src/features/action/Clipboard.ts
+++ b/src/features/action/Clipboard.ts
@@ -7,15 +7,32 @@ import { shellQuote } from "../../utils/shellQuote";
 import { AndroidCtrlProxyClient } from "../observe/android";
 import { IOSCtrlProxyClient } from "../observe/ios";
 
+type ClipboardCtrlProxy = {
+  requestClipboard(
+    action: "copy" | "paste" | "clear" | "get",
+    text?: string
+  ): Promise<{ success: boolean; error?: string; text?: string; totalTimeMs: number }>;
+};
+type ClipboardCtrlProxyFactory = (
+  device: BootedDevice,
+  adbFactory: AdbClientFactory
+) => ClipboardCtrlProxy;
+
 export class Clipboard {
   private device: BootedDevice;
   private adb: AdbExecutor;
   private adbFactory: AdbClientFactory;
+  private ctrlProxyFactory: ClipboardCtrlProxyFactory | undefined;
 
-  constructor(device: BootedDevice, adbFactory: AdbClientFactory = defaultAdbClientFactory) {
+  constructor(
+    device: BootedDevice,
+    adbFactory: AdbClientFactory = defaultAdbClientFactory,
+    ctrlProxyFactory?: ClipboardCtrlProxyFactory
+  ) {
     this.device = device;
     this.adbFactory = adbFactory;
     this.adb = adbFactory.create(device);
+    this.ctrlProxyFactory = ctrlProxyFactory;
   }
 
   async execute(
@@ -64,7 +81,7 @@ export class Clipboard {
       return { success: false, action, error: "Text is required for copy action" };
     }
 
-    const client = IOSCtrlProxyClient.getInstance(this.device);
+    const client = this.getIOSCtrlProxy();
     const result = await client.requestClipboard(action, text);
 
     if (!result.success) {
@@ -102,7 +119,7 @@ export class Clipboard {
     }
 
     // Try accessibility service first (preferred method)
-    const a11yClient = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
+    const a11yClient = this.getAndroidCtrlProxy();
 
     try {
       const a11yResult = await a11yClient.requestClipboard(action, text);
@@ -154,6 +171,20 @@ export class Clipboard {
         error: `All clipboard methods failed. Last error: ${error instanceof Error ? error.message : String(error)}`
       };
     }
+  }
+
+  private getIOSCtrlProxy(): ClipboardCtrlProxy {
+    if (this.ctrlProxyFactory) {
+      return this.ctrlProxyFactory(this.device, this.adbFactory);
+    }
+    return IOSCtrlProxyClient.getInstance(this.device);
+  }
+
+  private getAndroidCtrlProxy(): ClipboardCtrlProxy {
+    if (this.ctrlProxyFactory) {
+      return this.ctrlProxyFactory(this.device, this.adbFactory);
+    }
+    return AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
   }
 
   /**

--- a/src/features/action/SelectAllText.ts
+++ b/src/features/action/SelectAllText.ts
@@ -7,10 +7,24 @@ import { AndroidCtrlProxyClient } from "../observe/android";
 import { IOSCtrlProxyClient } from "../observe/ios";
 import { logger } from "../../utils/logger";
 
-export class SelectAllText extends BaseVisualChange {
+type SelectAllTextCtrlProxy = {
+  requestSelectAll(): Promise<{ success: boolean; error?: string; totalTimeMs: number }>;
+};
+type SelectAllTextCtrlProxyFactory = (
+  device: BootedDevice,
+  adbFactory: AdbClientFactory
+) => SelectAllTextCtrlProxy;
 
-  constructor(device: BootedDevice, adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = null) {
+export class SelectAllText extends BaseVisualChange {
+  private readonly ctrlProxyFactory: SelectAllTextCtrlProxyFactory | undefined;
+
+  constructor(
+    device: BootedDevice,
+    adbFactoryOrExecutor: AdbClientFactory | AdbExecutor | null = null,
+    ctrlProxyFactory?: SelectAllTextCtrlProxyFactory
+  ) {
     super(device, adbFactoryOrExecutor);
+    this.ctrlProxyFactory = ctrlProxyFactory;
   }
 
   async execute(progress?: ProgressCallback): Promise<SelectAllTextResult> {
@@ -58,7 +72,8 @@ export class SelectAllText extends BaseVisualChange {
    */
   private async executeiOSSelectAll(): Promise<SelectAllTextResult> {
     try {
-      const client = IOSCtrlProxyClient.getInstance(this.device);
+      const client = this.ctrlProxyFactory?.(this.device, this.adbFactory) ??
+        IOSCtrlProxyClient.getInstance(this.device);
       const result = await client.requestSelectAll();
 
       if (result.success) {
@@ -79,7 +94,8 @@ export class SelectAllText extends BaseVisualChange {
    * Uses ACTION_SET_SELECTION which is significantly faster than ADB double-tap.
    */
   private async executeAndroidSelectAll(): Promise<SelectAllTextResult> {
-    const a11yClient = AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
+    const a11yClient = this.ctrlProxyFactory?.(this.device, this.adbFactory) ??
+      AndroidCtrlProxyClient.getInstance(this.device, this.adbFactory);
     const a11yResult = await a11yClient.requestSelectAll();
 
     if (a11yResult.success) {

--- a/src/features/toolCapabilities/toolCapabilityContext.ts
+++ b/src/features/toolCapabilities/toolCapabilityContext.ts
@@ -1,0 +1,24 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { SessionToolProfileService } from "./SessionToolProfileService";
+
+type ToolCapabilityContext = {
+  sessionUuid?: string;
+  sessionToolProfileService?: Pick<SessionToolProfileService, "isEnabled">;
+};
+
+const toolCapabilityContext = new AsyncLocalStorage<ToolCapabilityContext>();
+
+export const runWithToolCapabilityContext = async <T>(
+  context: ToolCapabilityContext,
+  fn: () => Promise<T>
+): Promise<T> => {
+  const parent = toolCapabilityContext.getStore();
+  return toolCapabilityContext.run({
+    sessionUuid: context.sessionUuid ?? parent?.sessionUuid,
+    sessionToolProfileService: context.sessionToolProfileService ?? parent?.sessionToolProfileService,
+  }, fn);
+};
+
+export const getToolCapabilityContext = (): ToolCapabilityContext | undefined => {
+  return toolCapabilityContext.getStore();
+};

--- a/src/features/toolCapabilities/toolCapabilityMap.ts
+++ b/src/features/toolCapabilities/toolCapabilityMap.ts
@@ -1,13 +1,13 @@
 import type { ToolCapability } from "./SessionToolProfileService";
 
 const groups: Record<ToolCapability, readonly string[]> = {
-  clipboard: ["clipboard", "selectAllText"],
+  "clipboard": ["clipboard", "selectAllText"],
   "advanced-interaction": ["openLink", "imeAction", "dragAndDrop", "pinchOn", "shake", "rotate"],
   "app-permissions": ["getAppPermissions", "setAppPermissions"],
   "device-settings": ["changeLocalization", "getDeviceState", "setDeviceState"],
   "app-data-interop": ["putAppFile", "getPreference", "setPreference", "sqlQuery", "setKeyValue", "removeKeyValue", "clearKeyValueFile"],
-  notifications: ["systemTray", "postNotification", "getNotificationPolicy", "setNotificationPolicy"],
-  telephony: ["phoneCall", "sendSms"],
+  "notifications": ["systemTray", "postNotification", "getNotificationPolicy", "setNotificationPolicy"],
+  "telephony": ["phoneCall", "sendSms"],
   "accessibility-tools": ["accessibility", "accessibilityFocus"],
   "screen-artifacts": ["videoRecording", "deviceSnapshot", "highlight"],
   "test-authoring": ["executePlan", "startTestRecording", "exportPlan", "recordSteps", "barrier", "criticalSection"],

--- a/src/features/toolCapabilities/toolCapabilityPolicy.ts
+++ b/src/features/toolCapabilities/toolCapabilityPolicy.ts
@@ -1,0 +1,34 @@
+import { ActionableError } from "../../models/ActionableError";
+import {
+  getSessionToolProfileService,
+  type SessionToolProfileService,
+} from "./SessionToolProfileService";
+import { TOOL_CAPABILITY_BY_NAME } from "./toolCapabilityMap";
+
+type ToolProfileReader = Pick<SessionToolProfileService, "isEnabled">;
+
+export async function isToolEnabledForSession(
+  toolName: string,
+  sessionUuid: string | undefined,
+  sessionToolProfileService?: ToolProfileReader,
+): Promise<boolean> {
+  const capability = TOOL_CAPABILITY_BY_NAME.get(toolName);
+  if (!capability || !sessionUuid) {
+    return true;
+  }
+  return (sessionToolProfileService ?? getSessionToolProfileService()).isEnabled(sessionUuid, capability);
+}
+
+export async function assertToolEnabledForSession(
+  toolName: string,
+  sessionUuid: string | undefined,
+  sessionToolProfileService?: ToolProfileReader,
+): Promise<void> {
+  if (await isToolEnabledForSession(toolName, sessionUuid, sessionToolProfileService)) {
+    return;
+  }
+  const capability = TOOL_CAPABILITY_BY_NAME.get(toolName);
+  throw new ActionableError(
+    `Tool ${toolName} requires the '${capability}' capability for device session ${sessionUuid ?? "(not yet bound)"}.`
+  );
+}

--- a/src/models/ExecutePlanResult.ts
+++ b/src/models/ExecutePlanResult.ts
@@ -1,4 +1,5 @@
 import type { FailureObservationSummary } from "./FailureObservation";
+import type { SessionToolProfileService } from "../features/toolCapabilities/SessionToolProfileService";
 
 /**
  * When passed to plan execution, each successful `observe` step stores a
@@ -15,6 +16,8 @@ export interface PlanStepLifecycleContext {
 
 export interface PlanExecutionOptions {
   captureObserveSteps?: CaptureObserveStepMode;
+  /** Profile reader used to enforce capability policy for internal plan steps. */
+  sessionToolProfileService?: Pick<SessionToolProfileService, "isEnabled">;
 
   /**
    * Invoked at the start of each step (after abort checks), before the tool runs.

--- a/src/server/SessionToolBinding.ts
+++ b/src/server/SessionToolBinding.ts
@@ -5,7 +5,7 @@ export class SessionToolBinding {
     const explicit = params && typeof params === "object" && !Array.isArray(params)
       ? (params as Record<string, unknown>).sessionUuid
       : undefined;
-    return typeof explicit === "string" && explicit.length > 0
+    return typeof explicit === "string" && explicit.trim().length > 0
       ? explicit
       : mcpSessionId
         ? this.boundDeviceSessions.get(mcpSessionId)
@@ -13,7 +13,7 @@ export class SessionToolBinding {
   }
 
   bind(mcpSessionId: string | undefined, sessionUuid: string | undefined): boolean {
-    if (!mcpSessionId || !sessionUuid || this.boundDeviceSessions.get(mcpSessionId) === sessionUuid) {
+    if (!mcpSessionId || !sessionUuid?.trim() || this.boundDeviceSessions.get(mcpSessionId) === sessionUuid) {
       return false;
     }
     this.boundDeviceSessions.set(mcpSessionId, sessionUuid);

--- a/src/server/SessionToolBinding.ts
+++ b/src/server/SessionToolBinding.ts
@@ -5,7 +5,7 @@ export class SessionToolBinding {
     const explicit = params && typeof params === "object" && !Array.isArray(params)
       ? (params as Record<string, unknown>).sessionUuid
       : undefined;
-    return typeof explicit === "string"
+    return typeof explicit === "string" && explicit.length > 0
       ? explicit
       : mcpSessionId
         ? this.boundDeviceSessions.get(mcpSessionId)

--- a/src/server/criticalSectionTools.ts
+++ b/src/server/criticalSectionTools.ts
@@ -5,6 +5,7 @@ import { logger } from "../utils/logger";
 import { createJSONToolResponse, throwIfAborted } from "../utils/toolUtils";
 import { CriticalSectionCoordinator } from "./CriticalSectionCoordinator";
 import { PlanNormalizer } from "../utils/plan/PlanNormalizer";
+import { addDeviceTargetingToSchema } from "./toolSchemaHelpers";
 
 // Schema for steps inside critical section.
 // Every sub-step MUST declare a target `device` — there is no routing
@@ -34,7 +35,7 @@ const criticalSectionStepSchema = z
 type CriticalSectionStepInput = z.infer<typeof criticalSectionStepSchema>;
 
 // Critical section tool schema
-const criticalSectionSchema = z.object({
+const criticalSectionSchema = addDeviceTargetingToSchema(z.object({
   lock: z
     .string()
     .describe(
@@ -69,7 +70,7 @@ const criticalSectionSchema = z.object({
     .string()
     .optional()
     .describe("Internal plan-scoped lock namespace (injected)"),
-});
+}));
 
 type CriticalSectionParams = z.infer<typeof criticalSectionSchema>;
 
@@ -150,24 +151,13 @@ const criticalSectionHandler = async (
           throw new ActionableError(`Tool "${step.tool}" not found in registry`);
         }
 
-        // Execute the tool with the device context
-        let result;
-        if (tool.deviceAwareHandler) {
-          // Device-aware tool
-          result = await tool.deviceAwareHandler(
-            device,
-            step.params,
-            undefined,
-            signal
-          );
-        } else if (tool.handler) {
-          // Regular tool
-          result = await tool.handler(step.params, undefined, signal);
-        } else {
-          throw new ActionableError(
-            `Tool "${step.tool}" has no handler registered`
-          );
-        }
+        const result = await ToolRegistry.callInternal(
+          tool,
+          step.params,
+          undefined,
+          signal,
+          { forPlan: true, targetDevice: device },
+        );
 
         // Check if tool returned failure
         if (result?.success === false) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -68,10 +68,13 @@ import { registerNetworkResources } from "./networkResources";
 import { FeatureFlagService } from "../features/featureFlags/FeatureFlagService";
 import { startupBenchmark } from "../utils/startupBenchmark";
 import {
-  getSessionToolProfileService,
   type SessionToolProfileService,
 } from "../features/toolCapabilities/SessionToolProfileService";
-import { TOOL_CAPABILITY_BY_NAME } from "../features/toolCapabilities/toolCapabilityMap";
+import {
+  assertToolEnabledForSession,
+  isToolEnabledForSession,
+} from "../features/toolCapabilities/toolCapabilityPolicy";
+import { runWithToolCapabilityContext } from "../features/toolCapabilities/toolCapabilityContext";
 
 export interface McpServerOptions {
   debug?: boolean;
@@ -82,21 +85,6 @@ export interface McpServerOptions {
 }
 
 const INTERNAL_MCP_SESSION_PARAM = "__mcpSessionId";
-async function isToolVisibleForSession(
-  name: string,
-  sessionUuid: string | undefined,
-  sessionToolProfileService?: Pick<SessionToolProfileService, "isEnabled">
-): Promise<boolean> {
-  const capability = TOOL_CAPABILITY_BY_NAME.get(name);
-  // Before the first device-aware call, no session has been selected and the
-  // persisted profile is not applicable. Avoid opening the profile database
-  // merely to serve the legacy initial tools/list response.
-  if (!capability || !sessionUuid) {
-    return true;
-  }
-  return (sessionToolProfileService ?? getSessionToolProfileService()).isEnabled(sessionUuid, capability);
-}
-
 function extractInternalMcpSessionId(params: unknown): string | undefined {
   if (!params || typeof params !== "object" || Array.isArray(params)) {
     return undefined;
@@ -288,7 +276,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     const definitions = ToolRegistry.getToolDefinitions();
     return {
       tools: (await Promise.all(definitions.map(async definition =>
-        await isToolVisibleForSession(definition.name, sessionUuid, options.sessionToolProfileService) ? definition : undefined
+        await isToolEnabledForSession(definition.name, sessionUuid, options.sessionToolProfileService) ? definition : undefined
       ))).filter((definition): definition is typeof definitions[number] => definition !== undefined)
     };
   });
@@ -324,15 +312,13 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     const sessionId = options.sessionContext?.sessionId;
     const sessionUuid = sessionToolBinding.effectiveSessionUuid(sessionId, toolParams);
 
-    if (!await isToolVisibleForSession(name, sessionUuid, options.sessionToolProfileService)) {
-      const capability = TOOL_CAPABILITY_BY_NAME.get(name);
-      throw new ActionableError(`Tool ${name} requires the '${capability}' capability for device session ${sessionUuid ?? "(not yet bound)"}.`);
-    }
-
     // Get the registered tool
     const tool = ToolRegistry.getTool(name);
     if (!tool) {
       throw new ActionableError(`Unknown tool: ${name}`);
+    }
+    if (!tool.deviceAwareHandler) {
+      await assertToolEnabledForSession(name, sessionUuid, options.sessionToolProfileService);
     }
 
     const requestMcpSessionId = extractInternalMcpSessionId(toolParams);
@@ -397,7 +383,10 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     try {
       const result = await runWithAbortSignal(
         execution.abortController.signal,
-        () => tool.handler(handlerParams, progressCallback, execution.abortController.signal)
+        () => runWithToolCapabilityContext(
+          { sessionToolProfileService: options.sessionToolProfileService },
+          () => tool.handler(handlerParams, progressCallback, execution.abortController.signal)
+        )
       );
       // Wire-boundary output policy: strip the duplicated `structuredContent`
       // tree for no-schema tools unconditionally (issue #2759) and for schema

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -317,9 +317,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     if (!tool) {
       throw new ActionableError(`Unknown tool: ${name}`);
     }
-    if (!tool.deviceAwareHandler) {
-      await assertToolEnabledForSession(name, sessionUuid, options.sessionToolProfileService);
-    }
+    await assertToolEnabledForSession(name, sessionUuid, options.sessionToolProfileService);
 
     const requestMcpSessionId = extractInternalMcpSessionId(toolParams);
     const implicitAutolockMcpSessionId = requestMcpSessionId ?? (!daemonMode ? sessionId : undefined);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -384,7 +384,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       const result = await runWithAbortSignal(
         execution.abortController.signal,
         () => runWithToolCapabilityContext(
-          { sessionToolProfileService: options.sessionToolProfileService },
+          { sessionUuid, sessionToolProfileService: options.sessionToolProfileService },
           () => tool.handler(handlerParams, progressCallback, execution.abortController.signal)
         )
       );

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -327,7 +327,9 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       "sessionUuid" in toolParams
         ? (toolParams as { sessionUuid?: string }).sessionUuid
         : undefined;
-    const providedSessionUuid = typeof rawSessionUuid === "string" ? rawSessionUuid : undefined;
+    const providedSessionUuid = typeof rawSessionUuid === "string" && rawSessionUuid.trim().length > 0
+      ? rawSessionUuid
+      : undefined;
     if (sessionToolBinding.bind(sessionId, providedSessionUuid)) {
       ToolRegistry.notifyToolListChanged();
     }

--- a/src/server/platform/createPlatformClient.ts
+++ b/src/server/platform/createPlatformClient.ts
@@ -24,6 +24,27 @@ import {
 } from "../systemTrayHelpers";
 import { createNotificationUIDetector } from "../system-tray/createNotificationUIDetector";
 
+type CtrlProxyClientFactory = (
+  device: BootedDevice,
+  adbFactory: AdbClientFactory
+) => CtrlProxyClient;
+
+function resolveCtrlProxy(
+  device: BootedDevice,
+  adbFactory: AdbClientFactory,
+  options: CreatePlatformClientOptions
+): CtrlProxyClient {
+  if (options.ctrlProxy) {
+    return options.ctrlProxy;
+  }
+  if (options.ctrlProxyFactory) {
+    return options.ctrlProxyFactory(device, adbFactory);
+  }
+  return device.platform === "ios"
+    ? IOSCtrlProxyClient.getInstance(device)
+    : AndroidCtrlProxyClient.getInstance(device, adbFactory);
+}
+
 /**
  * Optional injection points for {@link createPlatformClient}. All
  * defaults reach for the same singletons the existing sub-factories
@@ -38,6 +59,7 @@ export interface CreatePlatformClientOptions {
   // Per-handle overrides for tests. Pass a fake instead of letting the
   // factory build the default platform-specific implementation.
   ctrlProxy?: CtrlProxyClient;
+  ctrlProxyFactory?: CtrlProxyClientFactory;
   tapStrategy?: TapStrategy;
   systemConfiguration?: SystemConfigurationAdapter;
   notificationUI?: NotificationUIDetector;
@@ -65,11 +87,7 @@ export function createPlatformClient(
   const processExecutor =
     options.processExecutor ?? new DefaultHostCommandExecutor();
 
-  const ctrlProxy: CtrlProxyClient =
-    options.ctrlProxy ??
-    (device.platform === "ios"
-      ? IOSCtrlProxyClient.getInstance(device)
-      : AndroidCtrlProxyClient.getInstance(device, adbFactory));
+  const ctrlProxy = resolveCtrlProxy(device, adbFactory, options);
 
   const adb = adbFactory.create(device);
 

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -37,6 +37,12 @@ import {
 } from "./internalToolPayloads";
 import { JsonToolOutputArtifactWriter, type ToolOutputArtifactRetention } from "./toolOutputArtifactWriter";
 import { getDefaultToolOutputsDir } from "../utils/toolOutputArtifacts";
+import type { SessionToolProfileService } from "../features/toolCapabilities/SessionToolProfileService";
+import { assertToolEnabledForSession } from "../features/toolCapabilities/toolCapabilityPolicy";
+import {
+  getToolCapabilityContext,
+  runWithToolCapabilityContext,
+} from "../features/toolCapabilities/toolCapabilityContext";
 
 // Re-exported for backward compatibility; the implementation now lives in
 // ./TopLevelUnionFlattener so the schema-flattening concern is independently testable.
@@ -69,6 +75,19 @@ interface ToolHandler<T = any> {
 // Interface for device-aware tool handlers
 interface DeviceAwareToolHandler<T = any> {
   (device: BootedDevice, args: T, progress?: ProgressCallback, signal?: AbortSignal): Promise<any>;
+}
+
+interface InternalToolCallOptions {
+  forPlan?: boolean;
+  sessionUuid?: string;
+  targetDevice?: BootedDevice;
+  sessionToolProfileService?: Pick<SessionToolProfileService, "isEnabled">;
+}
+
+interface InternalToolInvocationContext {
+  args: Record<string, unknown>;
+  sessionUuid?: string;
+  sessionToolProfileService?: Pick<SessionToolProfileService, "isEnabled">;
 }
 
 // Gate reason emitted for `planOnly` tools — hidden from discovery by design,
@@ -824,69 +843,76 @@ export class ToolRegistryClass {
       const toolStartMs = this.timer.now();
       const toolCallTimestamp = new Date().toISOString();
       let toolDurationMs: number | undefined;
-      let target: ExecutionTargetContext | undefined;
       let sessionUuid = args.sessionUuid;
 
       try {
-        target = await this.executionTargetResolver.resolveExecutionTarget({
+        const resolvedTarget = await this.executionTargetResolver.resolveExecutionTarget({
           name,
           args,
           options,
           deviceSessionManager: this.deviceSessionManager,
         });
-        sessionUuid = target.sessionUuid;
-        try {
-          let response: any | undefined;
-          if (!target.shouldResolveDevice) {
-            if (!options.nonDeviceHandler) {
-              throw new ActionableError(`Tool ${name} requires a device.`);
-            }
-            response = await options.nonDeviceHandler(args, progress, signal);
-          } else if (target.device !== undefined) {
-            this.navigationToolCallRecorder.record(name, args, target.device, target.sessionUuid);
-            response = await this.auditRunner.run({
-              name,
-              args,
-              device: target.device,
-              handler,
-              progress,
-              signal,
-            });
-          }
+        sessionUuid = resolvedTarget.sessionUuid;
+        await assertToolEnabledForSession(
+          name,
+          resolvedTarget.sessionUuid,
+          getToolCapabilityContext()?.sessionToolProfileService,
+        );
+        return await runWithToolCapabilityContext(
+          { sessionUuid: resolvedTarget.sessionUuid },
+          async () => {
+            try {
+              let response: any | undefined;
+              if (!resolvedTarget.shouldResolveDevice) {
+                if (!options.nonDeviceHandler) {
+                  throw new ActionableError(`Tool ${name} requires a device.`);
+                }
+                response = await options.nonDeviceHandler(args, progress, signal);
+              } else if (resolvedTarget.device !== undefined) {
+                this.navigationToolCallRecorder.record(name, args, resolvedTarget.device, resolvedTarget.sessionUuid);
+                response = await this.auditRunner.run({
+                  name,
+                  args,
+                  device: resolvedTarget.device,
+                  handler,
+                  progress,
+                  signal,
+                });
+              }
 
-          const afterToolCallResult = await this.afterToolCall.handle({
-            name,
-            args,
-            device: target.device,
-            internalCall: target.internalCall,
-            response,
-            sessionUuid: target.sessionUuid,
-            shouldResolveDevice: target.shouldResolveDevice,
-            signal,
-            timer: this.timer,
-            toolStartMs,
-          });
-          toolDurationMs = afterToolCallResult.durationMs;
-          return afterToolCallResult.finalizedResponse;
-        } catch (error) {
-          if (error instanceof ActionableError) {
-            throw error;
+              const afterToolCallResult = await this.afterToolCall.handle({
+                name,
+                args,
+                device: resolvedTarget.device,
+                internalCall: resolvedTarget.internalCall,
+                response,
+                sessionUuid: resolvedTarget.sessionUuid,
+                shouldResolveDevice: resolvedTarget.shouldResolveDevice,
+                signal,
+                timer: this.timer,
+                toolStartMs,
+              });
+              toolDurationMs = afterToolCallResult.durationMs;
+              return afterToolCallResult.finalizedResponse;
+            } catch (error) {
+              if (error instanceof ActionableError) {
+                throw error;
+              }
+              const deviceContext = resolvedTarget.device ? ` on device ${resolvedTarget.device.deviceId}` : "";
+              throw new ActionableError(`Failed to execute tool ${name}${deviceContext}: ${error}`);
+            } finally {
+              await this.planLifecycleManager.afterExecution({
+                name,
+                args,
+                baseSessionUuid: resolvedTarget.baseSessionUuid,
+                cleanupService: this.cleanupService,
+                device: resolvedTarget.device,
+                sessionUuid: resolvedTarget.sessionUuid,
+                shouldResolveDevice: resolvedTarget.shouldResolveDevice,
+              });
+            }
           }
-          const deviceContext = target.device ? ` on device ${target.device.deviceId}` : "";
-          throw new ActionableError(`Failed to execute tool ${name}${deviceContext}: ${error}`);
-        } finally {
-          if (target) {
-            await this.planLifecycleManager.afterExecution({
-              name,
-              args,
-              baseSessionUuid: target.baseSessionUuid,
-              cleanupService: this.cleanupService,
-              device: target.device,
-              sessionUuid: target.sessionUuid,
-              shouldResolveDevice: target.shouldResolveDevice,
-            });
-          }
-        }
+        );
       } finally {
         await this.toolCallRepository.recordToolCall({
           toolName: name,
@@ -952,7 +978,7 @@ export class ToolRegistryClass {
     args: Record<string, unknown>,
     progress?: ProgressCallback,
     signal?: AbortSignal,
-    options: { forPlan?: boolean } = {}
+    options: InternalToolCallOptions = {}
   ): Promise<any> {
     const resolved = typeof tool === "string"
       ? (options.forPlan ? this.getToolForPlan(tool) : this.getTool(tool))
@@ -960,7 +986,55 @@ export class ToolRegistryClass {
     if (!resolved) {
       throw new ActionableError(`Tool not found: ${tool}`);
     }
-    return resolved.handler(markInternalToolCall(args), progress, signal);
+    const invocation = this.createInternalToolInvocationContext(args, options);
+
+    return runWithToolCapabilityContext(
+      invocation,
+      () => this.invokeInternalTool(
+        resolved,
+        invocation.args,
+        progress,
+        signal,
+        options.targetDevice,
+        invocation.sessionUuid,
+        invocation.sessionToolProfileService,
+      ),
+    );
+  }
+
+  private createInternalToolInvocationContext(
+    args: Record<string, unknown>,
+    options: InternalToolCallOptions,
+  ): InternalToolInvocationContext {
+    const context = getToolCapabilityContext();
+    const sessionUuid = options.sessionUuid
+      ?? context?.sessionUuid
+      ?? (typeof args.sessionUuid === "string" ? args.sessionUuid : undefined);
+    return {
+      args: sessionUuid && args.sessionUuid !== sessionUuid
+        ? { ...args, sessionUuid }
+        : args,
+      sessionUuid,
+      sessionToolProfileService: options.sessionToolProfileService ?? context?.sessionToolProfileService,
+    };
+  }
+
+  private async invokeInternalTool(
+    tool: RegisteredTool,
+    args: Record<string, unknown>,
+    progress: ProgressCallback | undefined,
+    signal: AbortSignal | undefined,
+    targetDevice: BootedDevice | undefined,
+    sessionUuid: string | undefined,
+    sessionToolProfileService: Pick<SessionToolProfileService, "isEnabled"> | undefined,
+  ): Promise<any> {
+    if (targetDevice || !tool.deviceAwareHandler) {
+      await assertToolEnabledForSession(tool.name, sessionUuid, sessionToolProfileService);
+    }
+    if (targetDevice && tool.deviceAwareHandler) {
+      return tool.deviceAwareHandler(targetDevice, markInternalToolCall(args), progress, signal);
+    }
+    return tool.handler(markInternalToolCall(args), progress, signal);
   }
 
   // Typed variant of `callInternal` for the handful of internally-consumed tools
@@ -980,7 +1054,7 @@ export class ToolRegistryClass {
     args: Record<string, unknown>,
     progress?: ProgressCallback,
     signal?: AbortSignal,
-    options: { forPlan?: boolean } = {}
+    options: InternalToolCallOptions = {}
   ): Promise<StructuredToolResponse<InternalToolPayloads[K]> | undefined> {
     const response = await this.callInternal(name, args, progress, signal, options);
     return narrowInternalToolEnvelope(name, response);

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -857,13 +857,14 @@ export class ToolRegistryClass {
           deviceSessionManager: this.deviceSessionManager,
         });
         sessionUuid = resolvedTarget.sessionUuid;
+        const capabilitySessionUuid = resolvedTarget.baseSessionUuid ?? resolvedTarget.sessionUuid;
         await assertToolEnabledForSession(
           name,
-          resolvedTarget.sessionUuid,
+          capabilitySessionUuid,
           getToolCapabilityContext()?.sessionToolProfileService,
         );
         return await runWithToolCapabilityContext(
-          { sessionUuid: resolvedTarget.sessionUuid },
+          { sessionUuid: capabilitySessionUuid },
           async () => {
             try {
               let response: any | undefined;

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -840,15 +840,19 @@ export class ToolRegistryClass {
     this.invalidateToolDefinitionSchemaCache();
     // Create a wrapper that handles device ID injection
     const wrappedHandler: ToolHandler = async (args: any, progress?: ProgressCallback, signal?: AbortSignal) => {
+      const capabilityContext = getToolCapabilityContext();
+      const handlerArgs = capabilityContext?.sessionUuid && args.sessionUuid !== capabilityContext.sessionUuid
+        ? { ...args, sessionUuid: capabilityContext.sessionUuid }
+        : args;
       const toolStartMs = this.timer.now();
       const toolCallTimestamp = new Date().toISOString();
       let toolDurationMs: number | undefined;
-      let sessionUuid = args.sessionUuid;
+      let sessionUuid = handlerArgs.sessionUuid;
 
       try {
         const resolvedTarget = await this.executionTargetResolver.resolveExecutionTarget({
           name,
-          args,
+          args: handlerArgs,
           options,
           deviceSessionManager: this.deviceSessionManager,
         });
@@ -867,12 +871,12 @@ export class ToolRegistryClass {
                 if (!options.nonDeviceHandler) {
                   throw new ActionableError(`Tool ${name} requires a device.`);
                 }
-                response = await options.nonDeviceHandler(args, progress, signal);
+                response = await options.nonDeviceHandler(handlerArgs, progress, signal);
               } else if (resolvedTarget.device !== undefined) {
-                this.navigationToolCallRecorder.record(name, args, resolvedTarget.device, resolvedTarget.sessionUuid);
+                this.navigationToolCallRecorder.record(name, handlerArgs, resolvedTarget.device, resolvedTarget.sessionUuid);
                 response = await this.auditRunner.run({
                   name,
-                  args,
+                  args: handlerArgs,
                   device: resolvedTarget.device,
                   handler,
                   progress,
@@ -882,7 +886,7 @@ export class ToolRegistryClass {
 
               const afterToolCallResult = await this.afterToolCall.handle({
                 name,
-                args,
+                args: handlerArgs,
                 device: resolvedTarget.device,
                 internalCall: resolvedTarget.internalCall,
                 response,
@@ -903,7 +907,7 @@ export class ToolRegistryClass {
             } finally {
               await this.planLifecycleManager.afterExecution({
                 name,
-                args,
+                args: handlerArgs,
                 baseSessionUuid: resolvedTarget.baseSessionUuid,
                 cleanupService: this.cleanupService,
                 device: resolvedTarget.device,

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -1032,9 +1032,7 @@ export class ToolRegistryClass {
     sessionUuid: string | undefined,
     sessionToolProfileService: Pick<SessionToolProfileService, "isEnabled"> | undefined,
   ): Promise<any> {
-    if (targetDevice || !tool.deviceAwareHandler) {
-      await assertToolEnabledForSession(tool.name, sessionUuid, sessionToolProfileService);
-    }
+    await assertToolEnabledForSession(tool.name, sessionUuid, sessionToolProfileService);
     if (targetDevice && tool.deviceAwareHandler) {
       return tool.deviceAwareHandler(targetDevice, markInternalToolCall(args), progress, signal);
     }

--- a/src/utils/plan/PlanExecutor.ts
+++ b/src/utils/plan/PlanExecutor.ts
@@ -35,6 +35,7 @@ interface StepExecutionContext {
   sessionUuid?: string;
   signal?: AbortSignal;
   captureObserveSteps?: NonNullable<PlanExecutionOptions["captureObserveSteps"]>;
+  sessionToolProfileService?: PlanExecutionOptions["sessionToolProfileService"];
   logPrefix: string;
   debugLog?: boolean;
 }
@@ -342,7 +343,7 @@ export class DefaultPlanExecutor implements PlanExecutor {
       logger.info(`[PlanExecutor] Injecting deviceId ${deviceId} into ${step.tool}`);
     }
 
-    if (sessionUuid && !enhancedParams.sessionUuid) {
+    if (sessionUuid) {
       enhancedParams.sessionUuid = sessionUuid;
       logger.info(`[PlanExecutor] Injecting sessionUuid ${sessionUuid} into ${step.tool}`);
     }
@@ -400,7 +401,11 @@ export class DefaultPlanExecutor implements PlanExecutor {
         logger.info(`${context.logPrefix} Calling ${step.tool} with params: ${paramsPreview}`);
       }
 
-      const response = await ToolRegistry.callInternal(tool, parsedParams, undefined, context.signal);
+      const response = await ToolRegistry.callInternal(tool, parsedParams, undefined, context.signal, {
+        forPlan: true,
+        sessionUuid: context.sessionUuid,
+        sessionToolProfileService: context.sessionToolProfileService,
+      });
       throwIfAborted(context.signal);
 
       const toolResult = this.extractToolResult(response);
@@ -571,7 +576,8 @@ export class DefaultPlanExecutor implements PlanExecutor {
         deviceId,
         sessionUuid,
         signal,
-        abortStrategy
+        abortStrategy,
+        executionOptions
       );
     } else {
       // Single-device sequential execution
@@ -644,6 +650,7 @@ export class DefaultPlanExecutor implements PlanExecutor {
           sessionUuid,
           signal,
           captureObserveSteps: executionOptions?.captureObserveSteps,
+          sessionToolProfileService: executionOptions?.sessionToolProfileService,
           logPrefix: `[PLAN_STEP_${i + 1}]`,
         });
 
@@ -746,7 +753,8 @@ export class DefaultPlanExecutor implements PlanExecutor {
     deviceId?: string,
     sessionUuid?: string,
     signal?: AbortSignal,
-    abortStrategy: AbortStrategy = DEFAULT_ABORT_STRATEGY
+    abortStrategy: AbortStrategy = DEFAULT_ABORT_STRATEGY,
+    executionOptions?: PlanExecutionOptions,
   ): Promise<PlanExecutionResult> {
     const debugMode = isDebugModeEnabled();
 
@@ -789,7 +797,8 @@ export class DefaultPlanExecutor implements PlanExecutor {
           platform,
           deviceId,
           sessionUuid,
-          combinedSignal
+          combinedSignal,
+          executionOptions,
         );
 
         const deviceResult: DeviceExecutionResult = {
@@ -943,7 +952,8 @@ export class DefaultPlanExecutor implements PlanExecutor {
     platform?: string,
     deviceId?: string,
     sessionUuid?: string,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    executionOptions?: PlanExecutionOptions,
   ): Promise<{
     success: boolean;
     executedSteps: number;
@@ -986,6 +996,7 @@ export class DefaultPlanExecutor implements PlanExecutor {
           deviceId,
           sessionUuid,
           signal,
+          sessionToolProfileService: executionOptions?.sessionToolProfileService,
           logPrefix: `[PARALLEL_EXEC][${device}]`,
           debugLog: true,
         });

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -285,6 +285,7 @@ describe("UnixSocketServer MCP forward serialization", () => {
     await server.close();
     socketPath = join(tmpdir(), `mcp-session-list-${randomUUID()}.sock`);
     fakeTimer = new FakeTimer();
+    sessionDevices.set("session-a", "device-a");
     server = new UnixSocketServer(
       socketPath,
       "http://localhost:0/mcp",
@@ -340,6 +341,7 @@ describe("UnixSocketServer MCP forward serialization", () => {
     await server.close();
     socketPath = join(tmpdir(), `mcp-session-list-error-${randomUUID()}.sock`);
     fakeTimer = new FakeTimer();
+    sessionDevices.set("session-a", "device-a");
     server = new UnixSocketServer(
       socketPath,
       "http://localhost:0/mcp",
@@ -391,6 +393,55 @@ describe("UnixSocketServer MCP forward serialization", () => {
       expect(failedCall.success).toBe(false);
       expect(sessionlessCall.success).toBe(true);
       expect(refreshedList.result).toEqual({ tools: [{ name: "client-1" }] });
+    } finally {
+      client.close();
+    }
+  });
+
+  test("drops a bound client after its successful plan call releases the session", async () => {
+    sessionDevices.set("session-a", "device-a");
+    const clients: FakeMcpClient[] = [];
+    const forwardedClientIndexes: number[] = [];
+    server.mcpClientFactory = async () => {
+      const clientIndex = clients.length;
+      const client: FakeMcpClient = {
+        listTools: async () => ({ tools: [{ name: `client-${clientIndex}` }] }),
+        callTool: async (...args: unknown[]) => {
+          forwardedClientIndexes.push(clientIndex);
+          const request = args[0] as { name?: string; arguments?: { sessionUuid?: string } };
+          if (request.name === "executePlan" && request.arguments?.sessionUuid === "session-a") {
+            sessionDevices.delete("session-a");
+          }
+          return { content: [] };
+        },
+        listResources: async () => ({ resources: [] }),
+        readResource: async () => ({ contents: [] }),
+        listResourceTemplates: async () => ({ resourceTemplates: [] }),
+        close: async () => {},
+      };
+      clients.push(client);
+      return client;
+    };
+
+    const client = new PersistentSocketClient();
+    await client.connect(socketPath);
+    try {
+      const initialList = await client.request("tools/list", {});
+      const executePlan = await client.request("tools/call", {
+        name: "executePlan",
+        arguments: { sessionUuid: "session-a" },
+      });
+      const sessionlessCall = await client.request("tools/call", {
+        name: "exportPlan",
+        arguments: {},
+      });
+      const refreshedList = await client.request("tools/list", {});
+
+      expect(initialList.result).toEqual({ tools: [{ name: "client-0" }] });
+      expect(executePlan.success).toBe(true);
+      expect(sessionlessCall.success).toBe(true);
+      expect(forwardedClientIndexes).toEqual([1, 2]);
+      expect(refreshedList.result).not.toEqual({ tools: [{ name: "client-1" }] });
     } finally {
       client.close();
     }

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -336,7 +336,7 @@ describe("UnixSocketServer MCP forward serialization", () => {
     }
   });
 
-  test("keeps the bound client for tools/list when the session-aware call returns an error", async () => {
+  test("keeps the successful session binding when a later explicit session call fails", async () => {
     await server.close();
     socketPath = join(tmpdir(), `mcp-session-list-error-${randomUUID()}.sock`);
     fakeTimer = new FakeTimer();
@@ -353,8 +353,12 @@ describe("UnixSocketServer MCP forward serialization", () => {
       const clientIndex = clients.length;
       const client: FakeMcpClient = {
         listTools: async () => ({ tools: [{ name: `client-${clientIndex}` }] }),
-        callTool: async () => {
-          throw new Error("invalid tool arguments");
+        callTool: async (...args: unknown[]) => {
+          const request = args[0] as { arguments?: { sessionUuid?: string } };
+          if (request.arguments?.sessionUuid === "session-b") {
+            throw new Error("clipboard requires the 'clipboard' capability");
+          }
+          return { content: [] };
         },
         listResources: async () => ({ resources: [] }),
         readResource: async () => ({ contents: [] }),
@@ -369,13 +373,23 @@ describe("UnixSocketServer MCP forward serialization", () => {
     await client.connect(socketPath);
     try {
       await client.request("tools/list", {});
-      const failedCall = await client.request("tools/call", {
+      const boundCall = await client.request("tools/call", {
         name: "observe",
         arguments: { sessionUuid: "session-a" },
       });
+      const failedCall = await client.request("tools/call", {
+        name: "clipboard",
+        arguments: { sessionUuid: "session-b" },
+      });
+      const sessionlessCall = await client.request("tools/call", {
+        name: "exportPlan",
+        arguments: {},
+      });
       const refreshedList = await client.request("tools/list", {});
 
+      expect(boundCall.success).toBe(true);
       expect(failedCall.success).toBe(false);
+      expect(sessionlessCall.success).toBe(true);
       expect(refreshedList.result).toEqual({ tools: [{ name: "client-1" }] });
     } finally {
       client.close();

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -281,7 +281,7 @@ describe("UnixSocketServer MCP forward serialization", () => {
     expect(inFlight).toBe(0);
   });
 
-  test("routes tools/list through the client bound by an earlier session-aware call on the same socket", async () => {
+  test("routes sessionless calls through the client bound by an earlier session-aware call", async () => {
     await server.close();
     socketPath = join(tmpdir(), `mcp-session-list-${randomUUID()}.sock`);
     fakeTimer = new FakeTimer();
@@ -316,13 +316,21 @@ describe("UnixSocketServer MCP forward serialization", () => {
         name: "observe",
         arguments: { sessionUuid: "session-a" },
       });
+      const sessionlessCall = await client.request("tools/call", {
+        name: "videoRecording",
+        arguments: { action: "stop", recordingId: "recording-1" },
+      });
+      const navigationGraph = await client.request("ide/getNavigationGraph", {});
       const refreshedList = await client.request("tools/list", {});
 
       expect(initialList.success).toBe(true);
       expect(initialList.result).toEqual({ tools: [{ name: "client-0" }] });
       expect(call.success).toBe(true);
+      expect(sessionlessCall.success).toBe(true);
+      expect(navigationGraph.success).toBe(true);
       expect(refreshedList.success).toBe(true);
       expect(refreshedList.result).toEqual({ tools: [{ name: "client-1" }] });
+      expect(clients).toHaveLength(2);
     } finally {
       client.close();
     }

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -295,11 +295,18 @@ describe("UnixSocketServer MCP forward serialization", () => {
     await server.start();
 
     const clients: FakeMcpClient[] = [];
+    const forwardedCalls: Array<{ clientIndex: number; toolName: string | undefined }> = [];
     server.mcpClientFactory = async () => {
       const clientIndex = clients.length;
       const client: FakeMcpClient = {
         listTools: async () => ({ tools: [{ name: `client-${clientIndex}` }] }),
-        callTool: async () => ({ content: [] }),
+        callTool: async (...args: unknown[]) => {
+          forwardedCalls.push({
+            clientIndex,
+            toolName: (args[0] as { name?: string }).name,
+          });
+          return { content: [] };
+        },
         listResources: async () => ({ resources: [] }),
         readResource: async () => ({ contents: [] }),
         listResourceTemplates: async () => ({ resourceTemplates: [] }),
@@ -331,6 +338,11 @@ describe("UnixSocketServer MCP forward serialization", () => {
       expect(navigationGraph.success).toBe(true);
       expect(refreshedList.success).toBe(true);
       expect(refreshedList.result).toEqual({ tools: [{ name: "client-1" }] });
+      expect(forwardedCalls).toEqual([
+        { clientIndex: 1, toolName: "observe" },
+        { clientIndex: 1, toolName: "videoRecording" },
+        { clientIndex: 1, toolName: "getNavigationGraph" },
+      ]);
       expect(clients).toHaveLength(2);
     } finally {
       client.close();
@@ -351,12 +363,14 @@ describe("UnixSocketServer MCP forward serialization", () => {
     await server.start();
 
     const clients: FakeMcpClient[] = [];
+    const forwardedCalls: Array<{ clientIndex: number; toolName: string | undefined }> = [];
     server.mcpClientFactory = async () => {
       const clientIndex = clients.length;
       const client: FakeMcpClient = {
         listTools: async () => ({ tools: [{ name: `client-${clientIndex}` }] }),
         callTool: async (...args: unknown[]) => {
-          const request = args[0] as { arguments?: { sessionUuid?: string } };
+          const request = args[0] as { name?: string; arguments?: { sessionUuid?: string } };
+          forwardedCalls.push({ clientIndex, toolName: request.name });
           if (request.arguments?.sessionUuid === "session-b") {
             throw new Error("clipboard requires the 'clipboard' capability");
           }
@@ -392,6 +406,60 @@ describe("UnixSocketServer MCP forward serialization", () => {
       expect(boundCall.success).toBe(true);
       expect(failedCall.success).toBe(false);
       expect(sessionlessCall.success).toBe(true);
+      expect(refreshedList.result).toEqual({ tools: [{ name: "client-1" }] });
+      expect(forwardedCalls).toEqual([
+        { clientIndex: 1, toolName: "observe" },
+        { clientIndex: 2, toolName: "clipboard" },
+        { clientIndex: 1, toolName: "exportPlan" },
+      ]);
+    } finally {
+      client.close();
+    }
+  });
+
+  test("preserves a profile-only binding for sessionless follow-up calls", async () => {
+    const clients: FakeMcpClient[] = [];
+    const forwardedCalls: Array<{ clientIndex: number; toolName: string | undefined }> = [];
+    server.mcpClientFactory = async () => {
+      const clientIndex = clients.length;
+      const client: FakeMcpClient = {
+        listTools: async () => ({ tools: [{ name: `client-${clientIndex}` }] }),
+        callTool: async (...args: unknown[]) => {
+          forwardedCalls.push({
+            clientIndex,
+            toolName: (args[0] as { name?: string }).name,
+          });
+          return { content: [] };
+        },
+        listResources: async () => ({ resources: [] }),
+        readResource: async () => ({ contents: [] }),
+        listResourceTemplates: async () => ({ resourceTemplates: [] }),
+        close: async () => {},
+      };
+      clients.push(client);
+      return client;
+    };
+
+    const client = new PersistentSocketClient();
+    await client.connect(socketPath);
+    try {
+      await client.request("tools/list", {});
+      const recordingStop = await client.request("tools/call", {
+        name: "videoRecording",
+        arguments: { action: "stop", recordingId: "recording-1", sessionUuid: "profile-only" },
+      });
+      const sessionlessCall = await client.request("tools/call", {
+        name: "exportPlan",
+        arguments: {},
+      });
+      const refreshedList = await client.request("tools/list", {});
+
+      expect(recordingStop.success).toBe(true);
+      expect(sessionlessCall.success).toBe(true);
+      expect(forwardedCalls).toEqual([
+        { clientIndex: 1, toolName: "videoRecording" },
+        { clientIndex: 1, toolName: "exportPlan" },
+      ]);
       expect(refreshedList.result).toEqual({ tools: [{ name: "client-1" }] });
     } finally {
       client.close();

--- a/test/daemon/socketServerToolCapabilities.test.ts
+++ b/test/daemon/socketServerToolCapabilities.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Socket } from "node:net";
+import { existsSync } from "node:fs";
+import { unlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { UnixSocketServer } from "../../src/daemon/socketServer";
+import { AndroidCtrlProxyClient } from "../../src/features/observe/android";
+import { PlatformDeviceManagerFactory } from "../../src/utils/factories/PlatformDeviceManagerFactory";
+import { FakeTimer } from "../fakes/FakeTimer";
+import type { SessionToolProfileService } from "../../src/features/toolCapabilities/SessionToolProfileService";
+import type { DaemonResponse } from "../../src/daemon/types";
+
+const device = {
+  deviceId: "emulator-5554",
+  name: "Pixel",
+  platform: "android" as const,
+};
+
+function createDaemonState() {
+  return {
+    isInitialized: () => true,
+    getSessionManager: () => ({
+      getSession: () => null,
+      getSessionForDevice: (deviceId: string) => deviceId === device.deviceId ? "device-session-1" : null,
+      getDeviceLabels: () => undefined,
+      releaseSession: async () => null,
+    }),
+    getDevicePool: () => ({
+      refreshDevices: async () => 0,
+      getStats: () => ({ total: 0, idle: 0, assigned: 0, error: 0 }),
+      releaseDevice: async () => {},
+    }),
+  };
+}
+
+function sendRequest(socketPath: string, method: string, params: Record<string, unknown>): Promise<DaemonResponse> {
+  return new Promise((resolve, reject) => {
+    const socket = new Socket();
+    let buffer = "";
+    socket.connect(socketPath, () => {
+      socket.write(JSON.stringify({
+        id: randomUUID(),
+        type: "mcp_request",
+        method,
+        params,
+      }) + "\n");
+    });
+    socket.on("data", data => {
+      buffer += data.toString();
+      const line = buffer.split("\n").find(value => value.trim());
+      if (line) {
+        socket.destroy();
+        resolve(JSON.parse(line) as DaemonResponse);
+      }
+    });
+    socket.on("error", reject);
+  });
+}
+
+describe("UnixSocketServer app-data capability enforcement", () => {
+  let socketPath: string;
+  let server: UnixSocketServer;
+  let isEnabled: ReturnType<typeof mock>;
+  let originalGetInstance: typeof AndroidCtrlProxyClient.getInstance;
+  let getInstanceCalls: number;
+
+  beforeEach(async () => {
+    socketPath = join(tmpdir(), `tool-capabilities-${randomUUID()}.sock`);
+    isEnabled = mock(async () => false);
+    const profileService: Pick<SessionToolProfileService, "isEnabled" | "setEnabled"> = {
+      isEnabled,
+      setEnabled: async () => {},
+    };
+    PlatformDeviceManagerFactory.setInstance({
+      getBootedDevices: async () => [device],
+    } as ReturnType<typeof PlatformDeviceManagerFactory.getInstance>);
+    getInstanceCalls = 0;
+    originalGetInstance = AndroidCtrlProxyClient.getInstance;
+    AndroidCtrlProxyClient.getInstance = mock(() => {
+      getInstanceCalls++;
+      return {
+        setPreference: async () => {},
+        removePreference: async () => {},
+        clearPreferenceStore: async () => {},
+      };
+    }) as typeof AndroidCtrlProxyClient.getInstance;
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createDaemonState(),
+      new FakeTimer(),
+      null,
+      { sessionToolProfileService: profileService }
+    );
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.close();
+    AndroidCtrlProxyClient.getInstance = originalGetInstance;
+    PlatformDeviceManagerFactory.setInstance(null);
+    if (existsSync(socketPath)) {
+      await unlink(socketPath);
+    }
+  });
+
+  test.each([
+    ["ide/setKeyValue", { deviceId: device.deviceId, appId: "com.example", fileName: "prefs", key: "name", value: "value", type: "STRING" }],
+    ["ide/removeKeyValue", { deviceId: device.deviceId, appId: "com.example", fileName: "prefs", key: "name" }],
+    ["ide/clearKeyValueFile", { deviceId: device.deviceId, appId: "com.example", fileName: "prefs" }],
+  ])("denies %s when app-data interop is disabled", async (method, params) => {
+    const response = await sendRequest(socketPath, method, params);
+
+    expect(response.success).toBe(false);
+    expect(response.error).toContain("requires the 'app-data-interop' capability");
+    expect(isEnabled).toHaveBeenCalledWith("device-session-1", "app-data-interop");
+    expect(getInstanceCalls).toBe(0);
+  });
+
+  test("retains local app-data operations for an enabled session", async () => {
+    isEnabled.mockImplementation(async () => true);
+
+    const response = await sendRequest(socketPath, "ide/setKeyValue", {
+      deviceId: device.deviceId,
+      appId: "com.example",
+      fileName: "prefs",
+      key: "name",
+      value: "value",
+      type: "STRING",
+    });
+
+    expect(response.success).toBe(true);
+    expect(getInstanceCalls).toBe(1);
+  });
+});

--- a/test/daemon/socketServerToolCapabilities.test.ts
+++ b/test/daemon/socketServerToolCapabilities.test.ts
@@ -18,13 +18,17 @@ const device = {
   platform: "android" as const,
 };
 
-function createDaemonState() {
+function createDaemonState(options?: { useLabeledSession?: boolean }) {
   return {
     isInitialized: () => true,
     getSessionManager: () => ({
       getSession: () => null,
-      getSessionForDevice: (deviceId: string) => deviceId === device.deviceId ? "device-session-1" : null,
-      getDeviceLabels: () => undefined,
+      getSessionForDevice: (deviceId: string) => deviceId === device.deviceId
+        ? options?.useLabeledSession ? "device-session-1:B" : "device-session-1"
+        : null,
+      getDeviceLabels: (sessionId: string) => sessionId === "device-session-1"
+        ? { A: "device-session-1", B: "device-session-1:B" }
+        : undefined,
       releaseSession: async () => null,
     }),
     getDevicePool: () => ({
@@ -66,7 +70,7 @@ describe("UnixSocketServer app-data capability enforcement", () => {
   let originalGetInstance: typeof AndroidCtrlProxyClient.getInstance;
   let getInstanceCalls: number;
 
-  beforeEach(async () => {
+  async function startServer(options?: { useLabeledSession?: boolean }): Promise<void> {
     socketPath = join(tmpdir(), `tool-capabilities-${randomUUID()}.sock`);
     isEnabled = mock(async () => false);
     const profileService: Pick<SessionToolProfileService, "isEnabled" | "setEnabled"> = {
@@ -89,12 +93,16 @@ describe("UnixSocketServer app-data capability enforcement", () => {
     server = new UnixSocketServer(
       socketPath,
       "http://localhost:0/mcp",
-      createDaemonState(),
+      createDaemonState(options),
       new FakeTimer(),
       null,
       { sessionToolProfileService: profileService }
     );
     await server.start();
+  }
+
+  beforeEach(async () => {
+    await startServer();
   });
 
   afterEach(async () => {
@@ -133,5 +141,24 @@ describe("UnixSocketServer app-data capability enforcement", () => {
 
     expect(response.success).toBe(true);
     expect(getInstanceCalls).toBe(1);
+  });
+
+  test("uses the base profile for a labeled device session", async () => {
+    await server.close();
+    await startServer({ useLabeledSession: true });
+
+    const response = await sendRequest(socketPath, "ide/setKeyValue", {
+      deviceId: device.deviceId,
+      appId: "com.example",
+      fileName: "prefs",
+      key: "name",
+      value: "value",
+      type: "STRING",
+    });
+
+    expect(response.success).toBe(false);
+    expect(response.error).toContain("requires the 'app-data-interop' capability");
+    expect(isEnabled).toHaveBeenCalledWith("device-session-1", "app-data-interop");
+    expect(getInstanceCalls).toBe(0);
   });
 });

--- a/test/features/action/Clipboard.test.ts
+++ b/test/features/action/Clipboard.test.ts
@@ -1,8 +1,6 @@
-import { expect, describe, test, beforeEach, spyOn } from "bun:test";
+import { expect, describe, test, beforeEach } from "bun:test";
 import { Clipboard } from "../../../src/features/action/Clipboard";
 import { BootedDevice } from "../../../src/models";
-import { IOSCtrlProxyClient } from "../../../src/features/observe/ios";
-import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
 import { FakeIOSCtrlProxy } from "../../fakes/FakeIOSCtrlProxy";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 
@@ -20,12 +18,11 @@ describe("Clipboard iOS", () => {
 
     fakeIOSCtrlProxy = new FakeIOSCtrlProxy();
 
-    // Mock IOSCtrlProxyClient.getInstance to return our fake
-    spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue(
-      fakeIOSCtrlProxy as unknown as IOSCtrlProxyClient
+    clipboard = new Clipboard(
+      mockDevice,
+      new FakeAdbClientFactory(),
+      () => fakeIOSCtrlProxy
     );
-
-    clipboard = new Clipboard(mockDevice);
   });
 
   test("get returns clipboard text", async () => {
@@ -138,35 +135,33 @@ describe("Clipboard Android", () => {
   // and silently breaks the a11y clipboard path.
   test("passes the injected AdbClientFactory (not AdbExecutor) to AndroidCtrlProxyClient.getInstance", async () => {
     const factory = new FakeAdbClientFactory();
-    const getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
-      requestClipboard: async () => ({ success: true, action: "copy", totalTimeMs: 1 }),
-    } as unknown as AndroidCtrlProxyClient);
+    let passedFactory: FakeAdbClientFactory | undefined;
+    const clipboard = new Clipboard(androidDevice, factory, (_device, adbFactory) => {
+      passedFactory = adbFactory as FakeAdbClientFactory;
+      return {
+        requestClipboard: async () => ({ success: true, action: "copy", totalTimeMs: 1 }),
+      };
+    });
 
-    const clipboard = new Clipboard(androidDevice, factory);
     await clipboard.execute("copy", "hello");
 
-    expect(getInstanceSpy).toHaveBeenCalled();
-    const [, passedFactory] = getInstanceSpy.mock.calls[0] as [BootedDevice, FakeAdbClientFactory];
-    expect(typeof passedFactory.create).toBe("function");
+    expect(passedFactory).toBeDefined();
+    expect(typeof passedFactory!.create).toBe("function");
     expect(passedFactory).toBe(factory);
     expect(factory.wasCalledForDevice(androidDevice.deviceId)).toBe(true);
-
-    getInstanceSpy.mockRestore();
   });
 
   test("get returns accessibility restriction error without ADB fallback when Android denies clipboard reads", async () => {
     const factory = new FakeAdbClientFactory();
     const fakeAdb = factory.getFakeClient();
-    const getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+    const clipboard = new Clipboard(androidDevice, factory, () => ({
       requestClipboard: async () => ({
         success: false,
         action: "get",
         totalTimeMs: 1,
         error: "Clipboard read is restricted while CtrlProxy is not foreground",
       }),
-    } as unknown as AndroidCtrlProxyClient);
-
-    const clipboard = new Clipboard(androidDevice, factory);
+    }));
     const result = await clipboard.execute("get");
 
     expect(result.success).toBe(false);
@@ -175,21 +170,18 @@ describe("Clipboard Android", () => {
     expect(result.error).toContain("Clipboard read is restricted");
     expect(fakeAdb.getAllCommands()).not.toContain("shell cmd clipboard get");
 
-    getInstanceSpy.mockRestore();
   });
 
   test("get returns default accessibility error when Android read fails without details", async () => {
     const factory = new FakeAdbClientFactory();
     const fakeAdb = factory.getFakeClient();
-    const getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+    const clipboard = new Clipboard(androidDevice, factory, () => ({
       requestClipboard: async () => ({
         success: false,
         action: "get",
         totalTimeMs: 1,
       }),
-    } as unknown as AndroidCtrlProxyClient);
-
-    const clipboard = new Clipboard(androidDevice, factory);
+    }));
     const result = await clipboard.execute("get");
 
     expect(result.success).toBe(false);
@@ -197,23 +189,20 @@ describe("Clipboard Android", () => {
     expect(result.method).toBe("a11y");
     expect(fakeAdb.getAllCommands()).not.toContain("shell cmd clipboard get");
 
-    getInstanceSpy.mockRestore();
   });
 
   test("get does not use unsupported cmd clipboard fallback for an empty accessibility read", async () => {
     const factory = new FakeAdbClientFactory();
     const fakeAdb = factory.getFakeClient();
     fakeAdb.setCommandResult("shell cmd clipboard get", "No shell command implementation");
-    const getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
+    const clipboard = new Clipboard(androidDevice, factory, () => ({
       requestClipboard: async () => ({
         success: true,
         action: "get",
         text: "",
         totalTimeMs: 1,
       }),
-    } as unknown as AndroidCtrlProxyClient);
-
-    const clipboard = new Clipboard(androidDevice, factory);
+    }));
     const result = await clipboard.execute("get");
 
     expect(result.success).toBe(true);
@@ -222,6 +211,5 @@ describe("Clipboard Android", () => {
     expect(result.method).toBe("a11y");
     expect(fakeAdb.getAllCommands()).not.toContain("shell cmd clipboard get");
 
-    getInstanceSpy.mockRestore();
   });
 });

--- a/test/features/action/SelectAllText.test.ts
+++ b/test/features/action/SelectAllText.test.ts
@@ -1,9 +1,21 @@
-import { expect, describe, test, spyOn, afterEach } from "bun:test";
+import { expect, describe, test, spyOn, afterEach, beforeEach } from "bun:test";
 import { SelectAllText } from "../../../src/features/action/SelectAllText";
 import { BootedDevice } from "../../../src/models";
 import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
 import { IOSCtrlProxyClient } from "../../../src/features/observe/ios";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
+import { PortManager } from "../../../src/utils/PortManager";
+
+beforeEach(() => {
+  PortManager.reset();
+  PortManager.setPortAvailabilityCheckerForTesting({ isPortAvailable: () => true });
+});
+
+afterEach(() => {
+  IOSCtrlProxyClient.resetInstances();
+  AndroidCtrlProxyClient.resetInstances();
+  PortManager.setPortAvailabilityCheckerForTesting(null);
+});
 
 describe("SelectAllText Android", () => {
   // Regression for https://github.com/kaeawc/auto-mobile/issues/2231.

--- a/test/features/action/SelectAllText.test.ts
+++ b/test/features/action/SelectAllText.test.ts
@@ -1,21 +1,7 @@
-import { expect, describe, test, spyOn, afterEach, beforeEach } from "bun:test";
+import { expect, describe, test, spyOn } from "bun:test";
 import { SelectAllText } from "../../../src/features/action/SelectAllText";
 import { BootedDevice } from "../../../src/models";
-import { AndroidCtrlProxyClient } from "../../../src/features/observe/android";
-import { IOSCtrlProxyClient } from "../../../src/features/observe/ios";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
-import { PortManager } from "../../../src/utils/PortManager";
-
-beforeEach(() => {
-  PortManager.reset();
-  PortManager.setPortAvailabilityCheckerForTesting({ isPortAvailable: () => true });
-});
-
-afterEach(() => {
-  IOSCtrlProxyClient.resetInstances();
-  AndroidCtrlProxyClient.resetInstances();
-  PortManager.setPortAvailabilityCheckerForTesting(null);
-});
 
 describe("SelectAllText Android", () => {
   // Regression for https://github.com/kaeawc/auto-mobile/issues/2231.
@@ -25,17 +11,18 @@ describe("SelectAllText Android", () => {
   // and silently breaks the a11y selectAll path on first ctrl-proxy call.
   test("passes the injected AdbClientFactory (not AdbExecutor) to AndroidCtrlProxyClient.getInstance", async () => {
     const factory = new FakeAdbClientFactory();
-    const getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
-      requestSelectAll: async () => ({ success: true, totalTimeMs: 1 }),
-    } as unknown as AndroidCtrlProxyClient);
-
     const device: BootedDevice = {
       name: "Test Android",
       platform: "android",
       deviceId: "test-android",
     };
-
-    const selectAllText = new SelectAllText(device, factory);
+    let passedFactory: FakeAdbClientFactory | undefined;
+    const selectAllText = new SelectAllText(device, factory, (_device, adbFactory) => {
+      passedFactory = adbFactory as FakeAdbClientFactory;
+      return {
+        requestSelectAll: async () => ({ success: true, totalTimeMs: 1 }),
+      };
+    });
     const observedSpy = spyOn(
       selectAllText as unknown as { observedInteraction: (fn: () => Promise<unknown>) => Promise<unknown> },
       "observedInteraction"
@@ -43,28 +30,16 @@ describe("SelectAllText Android", () => {
 
     await selectAllText.execute();
 
-    expect(getInstanceSpy).toHaveBeenCalled();
-    const [, passedFactory] = getInstanceSpy.mock.calls[0] as [BootedDevice, FakeAdbClientFactory];
-    expect(typeof passedFactory.create).toBe("function");
+    expect(passedFactory).toBeDefined();
+    expect(typeof passedFactory!.create).toBe("function");
     expect(passedFactory).toBe(factory);
     expect(factory.wasCalledForDevice(device.deviceId)).toBe(true);
 
-    getInstanceSpy.mockRestore();
     observedSpy.mockRestore();
   });
 });
 
 describe("SelectAllText outcomes", () => {
-  let getInstanceSpy: ReturnType<typeof spyOn> | null = null;
-  let iosGetInstanceSpy: ReturnType<typeof spyOn> | null = null;
-
-  afterEach(() => {
-    getInstanceSpy?.mockRestore();
-    iosGetInstanceSpy?.mockRestore();
-    getInstanceSpy = null;
-    iosGetInstanceSpy = null;
-  });
-
   const androidDevice: BootedDevice = { name: "Android", platform: "android", deviceId: "android-1" };
   const iosDevice: BootedDevice = { name: "iPhone", platform: "ios", deviceId: "ios-1" };
 
@@ -77,11 +52,9 @@ describe("SelectAllText outcomes", () => {
   };
 
   test("reports success when the Android accessibility service selects all", async () => {
-    getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
-      requestSelectAll: async () => ({ success: true, totalTimeMs: 3 })
-    } as unknown as AndroidCtrlProxyClient);
-
-    const selectAllText = new SelectAllText(androidDevice, new FakeAdbClientFactory());
+    const selectAllText = new SelectAllText(androidDevice, new FakeAdbClientFactory(), () => ({
+      requestSelectAll: async () => ({ success: true, totalTimeMs: 3 }),
+    }));
     const { promise, observedSpy } = runWithoutObservation(selectAllText);
     const result = await promise;
 
@@ -90,11 +63,9 @@ describe("SelectAllText outcomes", () => {
   });
 
   test("labels the Android accessibility failure with the underlying error", async () => {
-    getInstanceSpy = spyOn(AndroidCtrlProxyClient, "getInstance").mockReturnValue({
-      requestSelectAll: async () => ({ success: false, totalTimeMs: 3, error: "no focused field" })
-    } as unknown as AndroidCtrlProxyClient);
-
-    const selectAllText = new SelectAllText(androidDevice, new FakeAdbClientFactory());
+    const selectAllText = new SelectAllText(androidDevice, new FakeAdbClientFactory(), () => ({
+      requestSelectAll: async () => ({ success: false, totalTimeMs: 3, error: "no focused field" }),
+    }));
     const { promise, observedSpy } = runWithoutObservation(selectAllText);
     const result = await promise;
 
@@ -104,11 +75,9 @@ describe("SelectAllText outcomes", () => {
   });
 
   test("reports success on the iOS CtrlProxy path", async () => {
-    iosGetInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
-      requestSelectAll: async () => ({ success: true, totalTimeMs: 3 })
-    } as unknown as IOSCtrlProxyClient);
-
-    const selectAllText = new SelectAllText(iosDevice, new FakeAdbClientFactory());
+    const selectAllText = new SelectAllText(iosDevice, new FakeAdbClientFactory(), () => ({
+      requestSelectAll: async () => ({ success: true, totalTimeMs: 3 }),
+    }));
     const { promise, observedSpy } = runWithoutObservation(selectAllText);
     const result = await promise;
 
@@ -117,11 +86,9 @@ describe("SelectAllText outcomes", () => {
   });
 
   test("surfaces the iOS CtrlProxy failure error verbatim", async () => {
-    iosGetInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
-      requestSelectAll: async () => ({ success: false, totalTimeMs: 3, error: "editor not first responder" })
-    } as unknown as IOSCtrlProxyClient);
-
-    const selectAllText = new SelectAllText(iosDevice, new FakeAdbClientFactory());
+    const selectAllText = new SelectAllText(iosDevice, new FakeAdbClientFactory(), () => ({
+      requestSelectAll: async () => ({ success: false, totalTimeMs: 3, error: "editor not first responder" }),
+    }));
     const { promise, observedSpy } = runWithoutObservation(selectAllText);
     const result = await promise;
 
@@ -131,13 +98,11 @@ describe("SelectAllText outcomes", () => {
   });
 
   test("returns a structured failure when the iOS CtrlProxy throws", async () => {
-    iosGetInstanceSpy = spyOn(IOSCtrlProxyClient, "getInstance").mockReturnValue({
+    const selectAllText = new SelectAllText(iosDevice, new FakeAdbClientFactory(), () => ({
       requestSelectAll: async () => {
         throw new Error("socket closed");
-      }
-    } as unknown as IOSCtrlProxyClient);
-
-    const selectAllText = new SelectAllText(iosDevice, new FakeAdbClientFactory());
+      },
+    }));
     const { promise, observedSpy } = runWithoutObservation(selectAllText);
     const result = await promise;
 

--- a/test/plan/planExecutorExecuteStepRefactor.test.ts
+++ b/test/plan/planExecutorExecuteStepRefactor.test.ts
@@ -227,40 +227,50 @@ describe("PlanExecutor executeStep refactor", () => {
     }
   });
 
-  test("rejects a capability-disabled step before invoking its handler", async () => {
+  test("rejects a capability-disabled device-aware step before target resolution", async () => {
     const clipboardHandler = mock(async () => createStructuredToolResponse({ success: true }));
-    ToolRegistry.register(
+    ToolRegistry.registerDeviceAware(
       "clipboard",
       "clipboard",
-      z.object({}),
+      z.object({ sessionUuid: z.string().optional() }),
       clipboardHandler
     );
-    (ToolRegistry.getTool("clipboard") as { requiresDevice: boolean }).requiresDevice = true;
     const profileService: Pick<SessionToolProfileService, "isEnabled"> = {
       isEnabled: async (_sessionUuid, capability) => capability !== "clipboard",
     };
-
-    const result = await planExecutor.executePlan(
-      {
-        name: "capability-denied-step",
-        steps: [{ tool: "clipboard", params: {} }],
-      },
-      0,
-      "android",
-      "emulator-5554",
-      "session-1",
-      undefined,
-      undefined,
-      { sessionToolProfileService: profileService }
-    );
-
-    expect(result.success).toBe(false);
-    expect(result.failedStep).toMatchObject({
-      stepIndex: 0,
-      tool: "clipboard",
+    const resolveExecutionTarget = mock(async () => {
+      throw new Error("target resolution should not run");
     });
-    expect(result.failedStep?.error).toContain("requires the 'clipboard' capability");
-    expect(clipboardHandler).not.toHaveBeenCalled();
+    const restorePipelineOverrides = ToolRegistry.setPipelineOverridesForTesting({
+      executionTargetResolver: { resolveExecutionTarget },
+    });
+
+    try {
+      const result = await planExecutor.executePlan(
+        {
+          name: "capability-denied-step",
+          steps: [{ tool: "clipboard", params: {} }],
+        },
+        0,
+        "android",
+        "emulator-5554",
+        "session-1",
+        undefined,
+        undefined,
+        { sessionToolProfileService: profileService }
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.failedStep).toMatchObject({
+        stepIndex: 0,
+        tool: "clipboard",
+      });
+      expect(result.failedStep?.error).toContain("requires the 'clipboard' capability");
+      expect(clipboardHandler).not.toHaveBeenCalled();
+      expect(resolveExecutionTarget).not.toHaveBeenCalled();
+    } finally {
+      restorePipelineOverrides();
+    }
   });
 
   test("uses the execution session instead of a sessionUuid supplied by the plan", async () => {

--- a/test/plan/planExecutorExecuteStepRefactor.test.ts
+++ b/test/plan/planExecutorExecuteStepRefactor.test.ts
@@ -8,6 +8,7 @@ import { createStructuredToolResponse } from "../../src/utils/toolUtils";
 import { INTERNAL_NO_DIFF_PARAM } from "../../src/server/internalToolCall";
 import { OPERATION_CANCELLED_MESSAGE } from "../../src/utils/constants";
 import { defaultTimer } from "../../src/utils/SystemTimer";
+import type { SessionToolProfileService } from "../../src/features/toolCapabilities/SessionToolProfileService";
 
 interface CapturedCall {
   params: Record<string, unknown>;
@@ -224,5 +225,144 @@ describe("PlanExecutor executeStep refactor", () => {
     } finally {
       (AbortSignal as any).any = originalAny;
     }
+  });
+
+  test("rejects a capability-disabled step before invoking its handler", async () => {
+    const clipboardHandler = mock(async () => createStructuredToolResponse({ success: true }));
+    ToolRegistry.register(
+      "clipboard",
+      "clipboard",
+      z.object({}),
+      clipboardHandler
+    );
+    (ToolRegistry.getTool("clipboard") as { requiresDevice: boolean }).requiresDevice = true;
+    const profileService: Pick<SessionToolProfileService, "isEnabled"> = {
+      isEnabled: async (_sessionUuid, capability) => capability !== "clipboard",
+    };
+
+    const result = await planExecutor.executePlan(
+      {
+        name: "capability-denied-step",
+        steps: [{ tool: "clipboard", params: {} }],
+      },
+      0,
+      "android",
+      "emulator-5554",
+      "session-1",
+      undefined,
+      undefined,
+      { sessionToolProfileService: profileService }
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.failedStep).toMatchObject({
+      stepIndex: 0,
+      tool: "clipboard",
+    });
+    expect(result.failedStep?.error).toContain("requires the 'clipboard' capability");
+    expect(clipboardHandler).not.toHaveBeenCalled();
+  });
+
+  test("uses the execution session instead of a sessionUuid supplied by the plan", async () => {
+    const clipboardHandler = mock(async () => createStructuredToolResponse({ success: true }));
+    ToolRegistry.register(
+      "clipboard",
+      "clipboard",
+      z.object({ sessionUuid: z.string().optional() }),
+      clipboardHandler
+    );
+    const profileService: Pick<SessionToolProfileService, "isEnabled"> = {
+      isEnabled: async sessionUuid => sessionUuid === "enabled-session",
+    };
+
+    const result = await planExecutor.executePlan(
+      {
+        name: "session-override-denied-step",
+        steps: [{ tool: "clipboard", params: { sessionUuid: "enabled-session" } }],
+      },
+      0,
+      "android",
+      "emulator-5554",
+      "disabled-session",
+      undefined,
+      undefined,
+      { sessionToolProfileService: profileService }
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.failedStep?.error).toContain("requires the 'clipboard' capability");
+    expect(clipboardHandler).not.toHaveBeenCalled();
+  });
+
+  test("uses the device-track execution session instead of a sessionUuid supplied by the plan", async () => {
+    const clipboardHandler = mock(async () => createStructuredToolResponse({ success: true }));
+    ToolRegistry.register(
+      "clipboard",
+      "clipboard",
+      z.object({
+        device: z.string(),
+        sessionUuid: z.string().optional(),
+      }),
+      clipboardHandler
+    );
+    const profileService: Pick<SessionToolProfileService, "isEnabled"> = {
+      isEnabled: async sessionUuid => sessionUuid === "enabled-session",
+    };
+
+    const result = await planExecutor.executePlan(
+      {
+        name: "parallel-session-override-denied-step",
+        devices: ["device-a"],
+        steps: [{
+          tool: "clipboard",
+          params: { device: "device-a", sessionUuid: "enabled-session" },
+        }],
+      },
+      0,
+      "android",
+      "emulator-5554",
+      "disabled-session",
+      undefined,
+      undefined,
+      { sessionToolProfileService: profileService }
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.failedStep?.error).toContain("requires the 'clipboard' capability");
+    expect(clipboardHandler).not.toHaveBeenCalled();
+  });
+
+  test("executes a capability-enabled step", async () => {
+    const clipboardHandler = mock(async () => createStructuredToolResponse({ success: true }));
+    ToolRegistry.register(
+      "clipboard",
+      "clipboard",
+      z.object({
+        platform: z.string().optional(),
+        sessionUuid: z.string().optional(),
+      }),
+      clipboardHandler
+    );
+    (ToolRegistry.getTool("clipboard") as { requiresDevice: boolean }).requiresDevice = true;
+    const profileService: Pick<SessionToolProfileService, "isEnabled"> = {
+      isEnabled: async () => true,
+    };
+
+    const result = await planExecutor.executePlan(
+      {
+        name: "capability-enabled-step",
+        steps: [{ tool: "clipboard", params: {} }],
+      },
+      0,
+      "android",
+      "emulator-5554",
+      "session-1",
+      undefined,
+      undefined,
+      { sessionToolProfileService: profileService }
+    );
+
+    expect(result.success).toBe(true);
+    expect(clipboardHandler).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/plan/planExecutorExecuteStepRefactor.test.ts
+++ b/test/plan/planExecutorExecuteStepRefactor.test.ts
@@ -227,12 +227,15 @@ describe("PlanExecutor executeStep refactor", () => {
     }
   });
 
-  test("rejects a capability-disabled device-aware step before target resolution", async () => {
+  test("rejects a base-profile-disabled labeled device step before target resolution", async () => {
     const clipboardHandler = mock(async () => createStructuredToolResponse({ success: true }));
     ToolRegistry.registerDeviceAware(
       "clipboard",
       "clipboard",
-      z.object({ sessionUuid: z.string().optional() }),
+      z.object({
+        device: z.string(),
+        sessionUuid: z.string().optional(),
+      }),
       clipboardHandler
     );
     const profileService: Pick<SessionToolProfileService, "isEnabled"> = {
@@ -249,7 +252,8 @@ describe("PlanExecutor executeStep refactor", () => {
       const result = await planExecutor.executePlan(
         {
           name: "capability-denied-step",
-          steps: [{ tool: "clipboard", params: {} }],
+          devices: ["B"],
+          steps: [{ tool: "clipboard", params: { device: "B" } }],
         },
         0,
         "android",

--- a/test/scripts/xcodegenDriftCheck.test.ts
+++ b/test/scripts/xcodegenDriftCheck.test.ts
@@ -47,6 +47,21 @@ function expectExitStatus(result: ReturnType<typeof spawnSync>, expectedStatus: 
   }
 }
 
+function fakeToolEnvironment(
+  repoDir: string,
+  overrides: Record<string, string | undefined> = {}
+): Record<string, string | undefined> {
+  return {
+    ...process.env,
+    // xcodegen_version.sh prepends $HOME/.local/bin to PATH. Keep HOME owned
+    // by this fixture so a host XcodeGen binary cannot eclipse bin/xcodegen.
+    HOME: join(repoDir, "home"),
+    FAKE_REPO_ROOT: repoDir,
+    ...overrides,
+    PATH: `${join(repoDir, "bin")}:${process.env.PATH ?? ""}`,
+  };
+}
+
 afterEach(() => {
   while (tempDirs.length > 0) {
     const tempDir = tempDirs.pop();
@@ -218,13 +233,9 @@ describe("xcodegen drift check", () => {
     const result = spawnSync("bash", ["scripts/ios/xcodegen-drift-check.sh", "--ctrl-proxy"], {
       cwd: repoDir,
       encoding: "utf8",
-      env: {
-        ...process.env,
-        HOME: repoDir,
-        FAKE_REPO_ROOT: repoDir,
+      env: fakeToolEnvironment(repoDir, {
         FAKE_XCODEGEN_BEHAVIOR: "modify",
-        PATH: `${join(repoDir, "bin")}:${process.env.PATH ?? ""}`,
-      },
+      }),
     });
 
     expectExitStatus(result, 1);
@@ -237,14 +248,10 @@ describe("xcodegen drift check", () => {
     const result = spawnSync("bash", ["scripts/ios/xcodegen-drift-check.sh", "--ctrl-proxy"], {
       cwd: repoDir,
       encoding: "utf8",
-      env: {
-        ...process.env,
-        HOME: repoDir,
-        FAKE_REPO_ROOT: repoDir,
+      env: fakeToolEnvironment(repoDir, {
         FAKE_XCODEGEN_BEHAVIOR: "recreate",
         FAKE_GIT_STATUS_OUTPUT: "?? ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj\n",
-        PATH: `${join(repoDir, "bin")}:${process.env.PATH ?? ""}`,
-      },
+      }),
     });
 
     expectExitStatus(result, 1);
@@ -261,14 +268,10 @@ describe("xcodegen drift check", () => {
     const result = spawnSync("bash", ["scripts/ios/xcodegen-drift-check.sh", "--ctrl-proxy"], {
       cwd: repoDir,
       encoding: "utf8",
-      env: {
-        ...process.env,
-        HOME: repoDir,
-        FAKE_REPO_ROOT: repoDir,
+      env: fakeToolEnvironment(repoDir, {
         FAKE_XCODEGEN_VERSION: "2.45.4",
         FAKE_XCODEGEN_BEHAVIOR: "modify",
-        PATH: `${join(repoDir, "bin")}:${process.env.PATH ?? ""}`,
-      },
+      }),
     });
 
     expectExitStatus(result, 1);
@@ -287,12 +290,7 @@ describe("xcodegen drift check", () => {
     const result = spawnSync("bash", ["scripts/ios/xcodegen-drift-check.sh", "--ctrl-proxy"], {
       cwd: repoDir,
       encoding: "utf8",
-      env: {
-        ...process.env,
-        HOME: repoDir,
-        FAKE_REPO_ROOT: repoDir,
-        PATH: `${join(repoDir, "bin")}:${process.env.PATH ?? ""}`,
-      },
+      env: fakeToolEnvironment(repoDir),
     });
 
     expectExitStatus(result, 0);
@@ -312,14 +310,10 @@ describe("xcodegen drift check", () => {
     const result = spawnSync("bash", ["scripts/ios/xcodegen-drift-check.sh", "--ctrl-proxy"], {
       cwd: repoDir,
       encoding: "utf8",
-      env: {
-        ...process.env,
-        HOME: repoDir,
-        FAKE_REPO_ROOT: repoDir,
+      env: fakeToolEnvironment(repoDir, {
         FAKE_XCODEGEN_BEHAVIOR: "reorder",
         FAKE_REORDERED_PROJECT: alphabeticalOrderProject,
-        PATH: `${join(repoDir, "bin")}:${process.env.PATH ?? ""}`,
-      },
+      }),
     });
 
     expectExitStatus(result, 0);
@@ -334,18 +328,14 @@ describe("xcodegen drift check", () => {
     const result = spawnSync("bash", ["scripts/ios/xcodegen-drift-check.sh", "--all"], {
       cwd: repoDir,
       encoding: "utf8",
-      env: {
-        ...process.env,
-        HOME: repoDir,
-        FAKE_REPO_ROOT: repoDir,
+      env: fakeToolEnvironment(repoDir, {
         FAKE_REPO_WIDE_GENERATOR_BEHAVIOR: "modify",
-        PATH: `${join(repoDir, "bin")}:${process.env.PATH ?? ""}`,
-      },
+      }),
     });
 
     expectExitStatus(result, 1);
     expect(result.stdout + result.stderr).toContain("Run scripts/ios/xcodegen-generate.sh");
-  });
+  }, 15_000);
 
   test("all scope fails when repo-wide generation fails", () => {
     const repoDir = createTempRepo();
@@ -353,12 +343,7 @@ describe("xcodegen drift check", () => {
     const result = spawnSync("bash", ["scripts/ios/xcodegen-drift-check.sh", "--all"], {
       cwd: repoDir,
       encoding: "utf8",
-      env: {
-        ...process.env,
-        HOME: repoDir,
-        FAKE_REPO_ROOT: repoDir,
-        PATH: `${join(repoDir, "bin")}:${process.env.PATH ?? ""}`,
-      },
+      env: fakeToolEnvironment(repoDir),
     });
 
     expectExitStatus(result, 2);

--- a/test/server/criticalSectionTools.test.ts
+++ b/test/server/criticalSectionTools.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { beforeAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import { registerCriticalSectionTools } from "../../src/server/criticalSectionTools";
 import { CriticalSectionCoordinator } from "../../src/server/CriticalSectionCoordinator";
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { setDebugModeEnabled } from "../../src/utils/debug";
 import { logger } from "../../src/utils/logger";
 import { serverConfig } from "../../src/utils/ServerConfig";
+import type { SessionToolProfileService } from "../../src/features/toolCapabilities/SessionToolProfileService";
 
 describe("criticalSection tool", () => {
   beforeAll(() => {
@@ -237,6 +238,40 @@ describe("criticalSection tool", () => {
     expect(result.success).toBe(true);
     expect(result.executedSteps).toBe(3);
     expect(executionLog).toEqual(["step1", "step2", "step3"]);
+  });
+
+  test("rejects a capability-disabled nested step before invoking its handler", async () => {
+    const tool = ToolRegistry.getToolForPlan("criticalSection");
+    expect(tool).toBeDefined();
+    const nestedHandler = mock(async () => ({ success: true }));
+    ToolRegistry.register("clipboard", "clipboard", z.object({ device: z.string() }), nestedHandler);
+    const profileService: Pick<SessionToolProfileService, "isEnabled"> = {
+      isEnabled: async (_sessionUuid, capability) => capability === "test-authoring",
+    };
+    const fakeDevice: BootedDevice = {
+      platform: "android",
+      deviceId: "test-device-capability",
+      name: "Test Device Capability",
+    };
+
+    await expect(ToolRegistry.callInternal(
+      tool!,
+      {
+        lock: "capability-lock",
+        deviceCount: 1,
+        steps: [{ tool: "clipboard", params: { device: "A" } }],
+      },
+      undefined,
+      undefined,
+      {
+        forPlan: true,
+        targetDevice: fakeDevice,
+        sessionUuid: "session-1",
+        sessionToolProfileService: profileService,
+      },
+    )).rejects.toThrow("requires the 'clipboard' capability");
+
+    expect(nestedHandler).not.toHaveBeenCalled();
   });
 
   test("executes plan-executable debug-only steps hidden from MCP discovery", async () => {

--- a/test/server/criticalSectionTools.test.ts
+++ b/test/server/criticalSectionTools.test.ts
@@ -8,6 +8,7 @@ import { setDebugModeEnabled } from "../../src/utils/debug";
 import { logger } from "../../src/utils/logger";
 import { serverConfig } from "../../src/utils/ServerConfig";
 import type { SessionToolProfileService } from "../../src/features/toolCapabilities/SessionToolProfileService";
+import { runWithToolCapabilityContext } from "../../src/features/toolCapabilities/toolCapabilityContext";
 
 describe("criticalSection tool", () => {
   beforeAll(() => {
@@ -272,6 +273,58 @@ describe("criticalSection tool", () => {
     )).rejects.toThrow("requires the 'clipboard' capability");
 
     expect(nestedHandler).not.toHaveBeenCalled();
+  });
+
+  test("uses the base profile for a labeled critical-section nested step", async () => {
+    const tool = ToolRegistry.getToolForPlan("criticalSection");
+    expect(tool).toBeDefined();
+    const nestedHandler = mock(async () => ({ success: true }));
+    ToolRegistry.register("clipboard", "clipboard", z.object({ device: z.string() }), nestedHandler);
+    const profileService: Pick<SessionToolProfileService, "isEnabled"> = {
+      isEnabled: async (sessionUuid, capability) => sessionUuid !== "base-session" || capability === "test-authoring",
+    };
+    const fakeDevice: BootedDevice = {
+      platform: "android",
+      deviceId: "test-device-base-profile",
+      name: "Test Device Base Profile",
+    };
+    const restorePipelineOverrides = ToolRegistry.setPipelineOverridesForTesting({
+      executionTargetResolver: {
+        resolveExecutionTarget: async input => ({
+          args: input.args,
+          baseSessionUuid: "base-session",
+          device: fakeDevice,
+          internalCall: false,
+          sessionUuid: "base-session:B",
+          shouldResolveDevice: true,
+        }),
+      },
+      auditRunner: {
+        run: async input => input.handler(input.device, input.args, input.progress, input.signal),
+      },
+      afterToolCall: {
+        handle: async input => ({ durationMs: 0, finalizedResponse: input.response }),
+      },
+      planLifecycleManager: {
+        afterExecution: async () => {},
+      },
+    });
+
+    try {
+      await expect(runWithToolCapabilityContext(
+        { sessionUuid: "base-session", sessionToolProfileService: profileService },
+        () => tool!.handler({
+          lock: "base-profile-lock",
+          device: "B",
+          deviceCount: 1,
+          steps: [{ tool: "clipboard", params: { device: "B" } }],
+        }),
+      )).rejects.toThrow("requires the 'clipboard' capability");
+
+      expect(nestedHandler).not.toHaveBeenCalled();
+    } finally {
+      restorePipelineOverrides();
+    }
   });
 
   test("executes plan-executable debug-only steps hidden from MCP discovery", async () => {

--- a/test/server/platform/PlatformClient.test.ts
+++ b/test/server/platform/PlatformClient.test.ts
@@ -1,7 +1,5 @@
-import { afterEach, beforeEach, describe, it, expect } from "bun:test";
+import { describe, it, expect } from "bun:test";
 import { createPlatformClient } from "../../../src/server/platform/createPlatformClient";
-import { AndroidCtrlProxyClient } from "../../../src/features/observe/android/AndroidCtrlProxyClient";
-import { IOSCtrlProxyClient } from "../../../src/features/observe/ios/IOSCtrlProxyClient";
 import { AndroidTapStrategy } from "../../../src/features/action/strategies/AndroidTapStrategy";
 import { IosTapStrategy } from "../../../src/features/action/strategies/IosTapStrategy";
 import { AndroidSystemConfigurationAdapter } from "../../../src/features/utility/system-configuration/AndroidSystemConfigurationAdapter";
@@ -16,8 +14,8 @@ import { FakePlatformClient } from "../../fakes/FakePlatformClient";
 import { FakeTapStrategy } from "../../fakes/FakeTapStrategy";
 import { FakeSystemConfigurationAdapter } from "../../fakes/FakeSystemConfigurationAdapter";
 import { FakeNotificationUIDetector } from "../../fakes/FakeNotificationUIDetector";
-import { PortManager } from "../../../src/utils/PortManager";
 import type { BootedDevice } from "../../../src/models";
+import type { CtrlProxyClient } from "../../../src/features/observe/interfaces/CtrlProxyClient";
 import type { PlatformClient } from "../../../src/utils/interfaces/PlatformClient";
 
 /**
@@ -28,17 +26,6 @@ import type { PlatformClient } from "../../../src/utils/interfaces/PlatformClien
  * `PlatformClient`.
  */
 describe("PlatformClient", () => {
-  beforeEach(() => {
-    PortManager.reset();
-    PortManager.setPortAvailabilityCheckerForTesting({ isPortAvailable: () => true });
-  });
-
-  afterEach(() => {
-    IOSCtrlProxyClient.resetInstances();
-    AndroidCtrlProxyClient.resetInstances();
-    PortManager.setPortAvailabilityCheckerForTesting(null);
-  });
-
   const androidDevice: BootedDevice = {
     deviceId: "emulator-5554",
     name: "Pixel_5",
@@ -60,7 +47,6 @@ describe("PlatformClient", () => {
   interface PlatformCase {
     name: string;
     device: BootedDevice;
-    expectedCtrlProxyCtor: Function;
     expectedTapStrategyCtor: Function;
     expectedSystemConfigCtor: Function;
     expectedNotificationUICtor: Function;
@@ -70,7 +56,6 @@ describe("PlatformClient", () => {
     {
       name: "android",
       device: androidDevice,
-      expectedCtrlProxyCtor: AndroidCtrlProxyClient,
       expectedTapStrategyCtor: AndroidTapStrategy,
       expectedSystemConfigCtor: AndroidSystemConfigurationAdapter,
       expectedNotificationUICtor: AndroidNotificationUIDetector,
@@ -78,7 +63,6 @@ describe("PlatformClient", () => {
     {
       name: "ios",
       device: iosDevice,
-      expectedCtrlProxyCtor: IOSCtrlProxyClient,
       expectedTapStrategyCtor: IosTapStrategy,
       expectedSystemConfigCtor: IosSystemConfigurationAdapter,
       expectedNotificationUICtor: IosNotificationUIDetector,
@@ -87,32 +71,49 @@ describe("PlatformClient", () => {
 
   for (const c of cases) {
     describe(`createPlatformClient (${c.name})`, () => {
-      it("returns the platform-appropriate CtrlProxy client", () => {
-        const client = createPlatformClient(c.device, buildOptions());
-        expect(client.ctrlProxy).toBeInstanceOf(c.expectedCtrlProxyCtor);
+      const createOptions = () => ({
+        ...buildOptions(),
+        ctrlProxy: {} as CtrlProxyClient,
+      });
+
+      it("passes the target device and ADB factory to the injected CtrlProxy factory", () => {
+        const adbFactory = new FakeAdbClientFactory();
+        const ctrlProxy = {} as CtrlProxyClient;
+        const calls: Array<[BootedDevice, FakeAdbClientFactory]> = [];
+        const client = createPlatformClient(c.device, {
+          ...buildOptions(),
+          adbFactory,
+          ctrlProxyFactory: (device, factory) => {
+            calls.push([device, factory as FakeAdbClientFactory]);
+            return ctrlProxy;
+          },
+        });
+
+        expect(client.ctrlProxy).toBe(ctrlProxy);
+        expect(calls).toEqual([[c.device, adbFactory]]);
       });
 
       it("returns the platform-appropriate TapStrategy", () => {
-        const client = createPlatformClient(c.device, buildOptions());
+        const client = createPlatformClient(c.device, createOptions());
         expect(client.tapStrategy).toBeInstanceOf(c.expectedTapStrategyCtor);
       });
 
       it("returns the platform-appropriate SystemConfigurationAdapter", () => {
-        const client = createPlatformClient(c.device, buildOptions());
+        const client = createPlatformClient(c.device, createOptions());
         expect(client.systemConfiguration).toBeInstanceOf(
           c.expectedSystemConfigCtor
         );
       });
 
       it("returns the platform-appropriate NotificationUIDetector", () => {
-        const client = createPlatformClient(c.device, buildOptions());
+        const client = createPlatformClient(c.device, createOptions());
         expect(client.notificationUI).toBeInstanceOf(
           c.expectedNotificationUICtor
         );
       });
 
       it("bundles the same device on the facade", () => {
-        const client = createPlatformClient(c.device, buildOptions());
+        const client = createPlatformClient(c.device, createOptions());
         expect(client.device).toBe(c.device);
         expect(client.notificationUI.device).toBe(c.device);
       });
@@ -120,7 +121,7 @@ describe("PlatformClient", () => {
       it("satisfies the PlatformClient interface", () => {
         const client: PlatformClient = createPlatformClient(
           c.device,
-          buildOptions()
+          createOptions()
         );
         expect(client.device).toBeDefined();
         expect(client.ctrlProxy).toBeDefined();

--- a/test/server/platform/PlatformClient.test.ts
+++ b/test/server/platform/PlatformClient.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "bun:test";
+import { afterEach, beforeEach, describe, it, expect } from "bun:test";
 import { createPlatformClient } from "../../../src/server/platform/createPlatformClient";
 import { AndroidCtrlProxyClient } from "../../../src/features/observe/android/AndroidCtrlProxyClient";
 import { IOSCtrlProxyClient } from "../../../src/features/observe/ios/IOSCtrlProxyClient";
@@ -16,6 +16,7 @@ import { FakePlatformClient } from "../../fakes/FakePlatformClient";
 import { FakeTapStrategy } from "../../fakes/FakeTapStrategy";
 import { FakeSystemConfigurationAdapter } from "../../fakes/FakeSystemConfigurationAdapter";
 import { FakeNotificationUIDetector } from "../../fakes/FakeNotificationUIDetector";
+import { PortManager } from "../../../src/utils/PortManager";
 import type { BootedDevice } from "../../../src/models";
 import type { PlatformClient } from "../../../src/utils/interfaces/PlatformClient";
 
@@ -27,6 +28,17 @@ import type { PlatformClient } from "../../../src/utils/interfaces/PlatformClien
  * `PlatformClient`.
  */
 describe("PlatformClient", () => {
+  beforeEach(() => {
+    PortManager.reset();
+    PortManager.setPortAvailabilityCheckerForTesting({ isPortAvailable: () => true });
+  });
+
+  afterEach(() => {
+    IOSCtrlProxyClient.resetInstances();
+    AndroidCtrlProxyClient.resetInstances();
+    PortManager.setPortAvailabilityCheckerForTesting(null);
+  });
+
   const androidDevice: BootedDevice = {
     deviceId: "emulator-5554",
     name: "Pixel_5",

--- a/test/server/sessionToolCapabilities.test.ts
+++ b/test/server/sessionToolCapabilities.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { z } from "zod";
+import { McpTestFixture } from "../fixtures/mcpTestFixture";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import type { SessionToolProfileService } from "../../src/features/toolCapabilities/SessionToolProfileService";
+
+describe("session tool capability MCP enforcement", () => {
+  let fixture: McpTestFixture | undefined;
+
+  afterEach(async () => {
+    await fixture?.teardown();
+    fixture = undefined;
+    ToolRegistry.clearTools();
+  });
+
+  test("denies a disabled direct tool before invoking its handler", async () => {
+    const isEnabled = mock(async (_sessionUuid: string | undefined, capability: string) =>
+      capability === "test-authoring"
+    );
+    const profileService: Pick<SessionToolProfileService, "isEnabled"> = { isEnabled };
+    fixture = new McpTestFixture({
+      sessionContext: { sessionId: "mcp-session-1" },
+      sessionToolProfileService: profileService,
+    });
+    await fixture.setup();
+
+    ToolRegistry.clearTools();
+    const handler = mock(async () => ({ content: [{ type: "text", text: "ok" }] }));
+    ToolRegistry.register(
+      "clipboard",
+      "clipboard",
+      z.object({ sessionUuid: z.string() }),
+      handler
+    );
+
+    await expect(fixture.client.request(
+      {
+        method: "tools/call",
+        params: {
+          name: "clipboard",
+          arguments: { sessionUuid: "device-session-1" },
+        },
+      },
+      z.any()
+    )).rejects.toThrow("requires the 'clipboard' capability");
+
+    expect(isEnabled).toHaveBeenCalledWith("device-session-1", "clipboard");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test("allows an enabled direct tool", async () => {
+    const profileService: Pick<SessionToolProfileService, "isEnabled"> = {
+      isEnabled: async () => true,
+    };
+    fixture = new McpTestFixture({
+      sessionContext: { sessionId: "mcp-session-1" },
+      sessionToolProfileService: profileService,
+    });
+    await fixture.setup();
+
+    ToolRegistry.clearTools();
+    const handler = mock(async () => ({ content: [{ type: "text", text: "ok" }] }));
+    ToolRegistry.register(
+      "clipboard",
+      "clipboard",
+      z.object({ sessionUuid: z.string() }),
+      handler
+    );
+
+    await fixture.client.request(
+      {
+        method: "tools/call",
+        params: {
+          name: "clipboard",
+          arguments: { sessionUuid: "device-session-1" },
+        },
+      },
+      z.any()
+    );
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/server/sessionToolCapabilities.test.ts
+++ b/test/server/sessionToolCapabilities.test.ts
@@ -6,8 +6,11 @@ import type { SessionToolProfileService } from "../../src/features/toolCapabilit
 
 describe("session tool capability MCP enforcement", () => {
   let fixture: McpTestFixture | undefined;
+  let restorePipelineOverrides: (() => void) | undefined;
 
   afterEach(async () => {
+    restorePipelineOverrides?.();
+    restorePipelineOverrides = undefined;
     await fixture?.teardown();
     fixture = undefined;
     ToolRegistry.clearTools();
@@ -86,6 +89,99 @@ describe("session tool capability MCP enforcement", () => {
 
     expect(isEnabled).toHaveBeenCalledWith("device-session-1", "clipboard");
     expect(handler).not.toHaveBeenCalled();
+    expect(nonDeviceHandler).not.toHaveBeenCalled();
+  });
+
+  test("denies a disabled device-aware tool before resolving its target", async () => {
+    const profileService: Pick<SessionToolProfileService, "isEnabled"> = {
+      isEnabled: async () => false,
+    };
+    fixture = new McpTestFixture({
+      sessionContext: { sessionId: "mcp-session-1" },
+      sessionToolProfileService: profileService,
+    });
+    await fixture.setup();
+
+    ToolRegistry.clearTools();
+    const resolveExecutionTarget = mock(async () => {
+      throw new Error("target resolution should not run");
+    });
+    restorePipelineOverrides = ToolRegistry.setPipelineOverridesForTesting({
+      executionTargetResolver: { resolveExecutionTarget },
+    });
+    ToolRegistry.registerDeviceAware(
+      "clipboard",
+      "clipboard",
+      z.object({ sessionUuid: z.string() }),
+      async () => ({ content: [{ type: "text", text: "ok" }] })
+    );
+
+    await expect(fixture.client.request(
+      {
+        method: "tools/call",
+        params: {
+          name: "clipboard",
+          arguments: { sessionUuid: "device-session-1" },
+        },
+      },
+      z.any()
+    )).rejects.toThrow("requires the 'clipboard' capability");
+
+    expect(resolveExecutionTarget).not.toHaveBeenCalled();
+  });
+
+  test("denies a bound session from stopping a recording without a sessionUuid", async () => {
+    const isEnabled = mock(async (_sessionUuid: string | undefined, capability: string) =>
+      capability !== "screen-artifacts"
+    );
+    const profileService: Pick<SessionToolProfileService, "isEnabled"> = { isEnabled };
+    fixture = new McpTestFixture({
+      sessionContext: { sessionId: "mcp-session-1" },
+      sessionToolProfileService: profileService,
+    });
+    await fixture.setup();
+
+    ToolRegistry.clearTools();
+    ToolRegistry.register(
+      "clipboard",
+      "clipboard",
+      z.object({ sessionUuid: z.string() }),
+      async () => ({ content: [{ type: "text", text: "ok" }] })
+    );
+    const nonDeviceHandler = mock(async () => ({ content: [{ type: "text", text: "stopped" }] }));
+    ToolRegistry.registerDeviceAware(
+      "videoRecording",
+      "videoRecording",
+      z.object({ action: z.literal("stop"), recordingId: z.string() }),
+      async () => ({ content: [{ type: "text", text: "unused" }] }),
+      {
+        shouldEnsureDevice: () => false,
+        nonDeviceHandler,
+      }
+    );
+
+    await fixture.client.request(
+      {
+        method: "tools/call",
+        params: {
+          name: "clipboard",
+          arguments: { sessionUuid: "device-session-1" },
+        },
+      },
+      z.any()
+    );
+    await expect(fixture.client.request(
+      {
+        method: "tools/call",
+        params: {
+          name: "videoRecording",
+          arguments: { action: "stop", recordingId: "recording-1" },
+        },
+      },
+      z.any()
+    )).rejects.toThrow("requires the 'screen-artifacts' capability");
+
+    expect(isEnabled).toHaveBeenCalledWith("device-session-1", "screen-artifacts");
     expect(nonDeviceHandler).not.toHaveBeenCalled();
   });
 

--- a/test/server/sessionToolCapabilities.test.ts
+++ b/test/server/sessionToolCapabilities.test.ts
@@ -48,6 +48,47 @@ describe("session tool capability MCP enforcement", () => {
     expect(handler).not.toHaveBeenCalled();
   });
 
+  test("denies a disabled device-aware tool when its schema strips sessionUuid", async () => {
+    const isEnabled = mock(async (_sessionUuid: string | undefined, capability: string) =>
+      capability === "test-authoring"
+    );
+    const profileService: Pick<SessionToolProfileService, "isEnabled"> = { isEnabled };
+    fixture = new McpTestFixture({
+      sessionContext: { sessionId: "mcp-session-1" },
+      sessionToolProfileService: profileService,
+    });
+    await fixture.setup();
+
+    ToolRegistry.clearTools();
+    const handler = mock(async () => ({ content: [{ type: "text", text: "ok" }] }));
+    const nonDeviceHandler = mock(async () => ({ content: [{ type: "text", text: "ok" }] }));
+    ToolRegistry.registerDeviceAware(
+      "clipboard",
+      "clipboard",
+      z.object({}),
+      handler,
+      {
+        shouldEnsureDevice: () => false,
+        nonDeviceHandler,
+      }
+    );
+
+    await expect(fixture.client.request(
+      {
+        method: "tools/call",
+        params: {
+          name: "clipboard",
+          arguments: { sessionUuid: "device-session-1" },
+        },
+      },
+      z.any()
+    )).rejects.toThrow("requires the 'clipboard' capability");
+
+    expect(isEnabled).toHaveBeenCalledWith("device-session-1", "clipboard");
+    expect(handler).not.toHaveBeenCalled();
+    expect(nonDeviceHandler).not.toHaveBeenCalled();
+  });
+
   test("allows an enabled direct tool", async () => {
     const profileService: Pick<SessionToolProfileService, "isEnabled"> = {
       isEnabled: async () => true,

--- a/test/server/sessionToolDiscovery.test.ts
+++ b/test/server/sessionToolDiscovery.test.ts
@@ -18,4 +18,11 @@ describe("session-scoped tool discovery", () => {
     expect(binding.bind("transport", "device-session-a")).toBe(false);
     expect(binding.bind("transport", "device-session-b")).toBe(true);
   });
+
+  test("uses the bound session when an explicit session UUID is empty", () => {
+    const binding = new SessionToolBinding();
+    binding.bind("transport", "disabled-session");
+
+    expect(binding.effectiveSessionUuid("transport", { sessionUuid: "" })).toBe("disabled-session");
+  });
 });

--- a/test/server/sessionToolDiscovery.test.ts
+++ b/test/server/sessionToolDiscovery.test.ts
@@ -19,10 +19,11 @@ describe("session-scoped tool discovery", () => {
     expect(binding.bind("transport", "device-session-b")).toBe(true);
   });
 
-  test("uses the bound session when an explicit session UUID is empty", () => {
+  test.each(["", "   "])("uses the bound session when an explicit session UUID is %p", sessionUuid => {
     const binding = new SessionToolBinding();
     binding.bind("transport", "disabled-session");
 
-    expect(binding.effectiveSessionUuid("transport", { sessionUuid: "" })).toBe("disabled-session");
+    expect(binding.effectiveSessionUuid("transport", { sessionUuid })).toBe("disabled-session");
+    expect(binding.bind("transport", sessionUuid)).toBe(false);
   });
 });

--- a/test/server/toolRegistry.internalNoDiff.test.ts
+++ b/test/server/toolRegistry.internalNoDiff.test.ts
@@ -11,6 +11,7 @@ import { DevicePool } from "../../src/daemon/devicePool";
 import { createStructuredToolResponse } from "../../src/utils/toolUtils";
 import { serverConfig } from "../../src/utils/ServerConfig";
 import type { ObserveResult } from "../../src/models/ObserveResult";
+import { runWithToolCapabilityContext } from "../../src/features/toolCapabilities/toolCapabilityContext";
 
 /**
  * Internal tool-to-tool no-diff guard (issue #3053 part 2).
@@ -28,6 +29,14 @@ import type { ObserveResult } from "../../src/models/ObserveResult";
  */
 describe("ToolRegistry internal no-diff guard (#3053)", () => {
   const androidA: BootedDevice = { name: "Pixel A", deviceId: "emulator-5554", platform: "android" };
+  const enabledCapabilityProfile = { isEnabled: async () => true };
+
+  function runWithEnabledCapabilities<T>(fn: () => Promise<T>): Promise<T> {
+    return runWithToolCapabilityContext(
+      { sessionToolProfileService: enabledCapabilityProfile },
+      fn,
+    );
+  }
 
   let fakeDeviceSessionManager: FakeDeviceSessionManager;
   let originalDeviceSessionManager: unknown;
@@ -243,11 +252,11 @@ describe("ToolRegistry internal no-diff guard (#3053)", () => {
     });
 
     await ToolRegistry.getTool("observe")!.handler({ platform: "android", __mcpSessionId: "mcp-session-1" });
-    const imeGo = await ToolRegistry.getTool("imeAction")!.handler({
+    const imeGo = await runWithEnabledCapabilities(() => ToolRegistry.getTool("imeAction")!.handler({
       platform: "android",
       __mcpSessionId: "mcp-session-1",
       action: "go",
-    });
+    }));
     expect((imeGo.structuredContent as any).observation.isDiff).toBeUndefined();
     expect((imeGo.structuredContent as any).observation.viewHierarchy).toBeDefined();
     expect((imeGo.structuredContent as any).observationDiff).toMatchObject({
@@ -276,11 +285,11 @@ describe("ToolRegistry internal no-diff guard (#3053)", () => {
     });
 
     await ToolRegistry.getTool("observe")!.handler({ platform: "android", __mcpSessionId: "mcp-session-1" });
-    const imePrevious = await ToolRegistry.getTool("imeAction")!.handler({
+    const imePrevious = await runWithEnabledCapabilities(() => ToolRegistry.getTool("imeAction")!.handler({
       platform: "android",
       __mcpSessionId: "mcp-session-1",
       action: "previous",
-    });
+    }));
     expect((imePrevious.structuredContent as any).observation.isDiff).toBe(true);
     expect((imePrevious.structuredContent as any).observationDiff).toMatchObject({
       mode: "diff",

--- a/test/utils/requireBootedDevice.test.ts
+++ b/test/utils/requireBootedDevice.test.ts
@@ -72,18 +72,6 @@ describe("requireBootedDevice", () => {
 });
 
 describe("requireBootedDevice integration with factories", () => {
-  test("AndroidCtrlProxyClient.getInstance throws on bare deviceId string", async () => {
-    const { AndroidCtrlProxyClient } = await import("../../src/features/observe/android/AndroidCtrlProxyClient");
-    expect(() => AndroidCtrlProxyClient.getInstance("emulator-5554" as never))
-      .toThrow(/AndroidCtrlProxyClient\.getInstance: expected BootedDevice/);
-  });
-
-  test("AndroidCtrlProxyClient.getInstance throws on empty object", async () => {
-    const { AndroidCtrlProxyClient } = await import("../../src/features/observe/android/AndroidCtrlProxyClient");
-    expect(() => AndroidCtrlProxyClient.getInstance({} as never))
-      .toThrow(/expected BootedDevice/);
-  });
-
   test("IOSCtrlProxyClient.getInstance throws on bare deviceId string", async () => {
     const { IOSCtrlProxyClient } = await import("../../src/features/observe/ios/IOSCtrlProxyClient");
     expect(() => IOSCtrlProxyClient.getInstance("ABCDEF" as never))


### PR DESCRIPTION
Closes [#4611](https://github.com/kaeawc/auto-mobile/issues/4611).

## What changed

- Enforce each session's tool-capability set before device resolution, at device-aware tool wrappers, during plan execution and nested `criticalSection` calls, and at daemon socket app-data entry points.
- Return a typed capability denial rather than exposing an unsupported operation.
- Regenerate the `criticalSection` tool-definition artifact after adding its device-targeting fields.
- Stabilize the XcodeGen drift fixture by isolating `HOME` so a locally installed XcodeGen cannot shadow the fake binary, and bound the process-level regression case with a timeout.

## Root cause and impact

Capability filtering previously controlled discovery but not every execution route, allowing plans and daemon app-data operations to bypass a session's negotiated tool set. Device-aware schemas can also strip `sessionUuid`, so the wrapper must receive the resolved session independently of schema output. The XcodeGen test inherited host configuration, so an installed XcodeGen could make the fake-fixture assertion depend on the developer machine.

## Validation

- `bun run typecheck`
- `bun run lint`
- Focused capability and no-diff test suites
- `bun test --rerun-each=5 test/scripts/xcodegenDriftCheck.test.ts` (45 passes)
- `bun run turbo:validate` (11,930 passed, 13 expected skips, 0 failed)
