### PR TITLE
fix(ci): diagnose installer startup timeouts

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -522,10 +522,22 @@ jobs:
         with:
           lfs: false
 
+      - name: "Build source CLI for installer diagnostics"
+        uses: ./.github/actions/setup-auto-mobile-npm-package
+        with:
+          install-global: "false"
+
       - name: "Run Installer (development)"
         id: run-installer-development
         shell: bash
         continue-on-error: true
+        env:
+          # Keep this disabled-job definition aligned with the PR installer lane.
+          AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS: "30000"
+          AUTOMOBILE_STARTUP_BENCHMARK: "1"
+          AUTOMOBILE_STARTUP_BENCHMARK_OUTPUT: "${{ github.workspace }}/ci-logs/installer-daemon-startup.json"
+          AUTOMOBILE_STARTUP_BENCHMARK_LABEL: "installer-development-${{ matrix.os }}"
+          AUTOMOBILE_CLI_PATH: "${{ github.workspace }}/dist/src/index.js"
         run: |
           set -uo pipefail
           mkdir -p ci-logs
@@ -533,6 +545,18 @@ jobs:
           bash ./scripts/install.sh --contributor --preset development --non-interactive 2>&1 | tee ci-logs/installer.log
           install_status=${PIPESTATUS[0]}
           set -e
+          mkdir -p ci-logs/daemon-logs
+          if [[ -d "${HOME}/.auto-mobile/logs" ]]; then
+            cp -R "${HOME}/.auto-mobile/logs/." ci-logs/daemon-logs/ || true
+          else
+            echo "No daemon logs directory was created" > ci-logs/daemon-logs/README.txt
+          fi
+          : > ci-logs/ctrl-proxy-cache-state.txt
+          for cache_path in "${TMPDIR:-/tmp}"/auto-mobile-prefetch-* "${HOME}/.automobile/ctrl-proxy-ios"; do
+            [[ -e "${cache_path}" ]] || continue
+            printf '%s\n' "=== ${cache_path} ===" >> ci-logs/ctrl-proxy-cache-state.txt
+            find "${cache_path}" -maxdepth 2 -mindepth 0 -print >> ci-logs/ctrl-proxy-cache-state.txt 2>&1 || true
+          done
           echo "INSTALL_EXIT_CODE=${install_status}" >> "$GITHUB_ENV"
           echo "install_exit_code=${install_status}" >> "$GITHUB_OUTPUT"
           exit 0

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -998,11 +998,25 @@ jobs:
         with:
           lfs: false
 
+      - name: "Build source CLI for installer diagnostics"
+        if: env.RUN_INSTALLER == 'true'
+        uses: ./.github/actions/setup-auto-mobile-npm-package
+        with:
+          install-global: "false"
+
       - name: "Run Installer (development)"
         id: run-installer-development
         if: env.RUN_INSTALLER == 'true'
         shell: bash
         continue-on-error: true
+        env:
+          # The default 10s daemon budget is lower than cold hosted macOS
+          # startup variance. Keep this aligned with ensure-daemon-ready.sh.
+          AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS: "30000"
+          AUTOMOBILE_STARTUP_BENCHMARK: "1"
+          AUTOMOBILE_STARTUP_BENCHMARK_OUTPUT: "${{ github.workspace }}/ci-logs/installer-daemon-startup.json"
+          AUTOMOBILE_STARTUP_BENCHMARK_LABEL: "installer-development-${{ matrix.os }}"
+          AUTOMOBILE_CLI_PATH: "${{ github.workspace }}/dist/src/index.js"
         run: |
           set -uo pipefail
           mkdir -p ci-logs
@@ -1010,6 +1024,18 @@ jobs:
           bash ./scripts/install.sh --contributor --preset development --non-interactive 2>&1 | tee ci-logs/installer.log
           install_status=${PIPESTATUS[0]}
           set -e
+          mkdir -p ci-logs/daemon-logs
+          if [[ -d "${HOME}/.auto-mobile/logs" ]]; then
+            cp -R "${HOME}/.auto-mobile/logs/." ci-logs/daemon-logs/ || true
+          else
+            echo "No daemon logs directory was created" > ci-logs/daemon-logs/README.txt
+          fi
+          : > ci-logs/ctrl-proxy-cache-state.txt
+          for cache_path in "${TMPDIR:-/tmp}"/auto-mobile-prefetch-* "${HOME}/.automobile/ctrl-proxy-ios"; do
+            [[ -e "${cache_path}" ]] || continue
+            printf '%s\n' "=== ${cache_path} ===" >> ci-logs/ctrl-proxy-cache-state.txt
+            find "${cache_path}" -maxdepth 2 -mindepth 0 -print >> ci-logs/ctrl-proxy-cache-state.txt 2>&1 || true
+          done
           echo "INSTALL_EXIT_CODE=${install_status}" >> "$GITHUB_ENV"
           echo "install_exit_code=${install_status}" >> "$GITHUB_OUTPUT"
           exit 0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2752,6 +2752,15 @@ detect_ide_plugins_dir() {
 }
 
 resolve_auto_mobile_command() {
+    if [[ -n "${AUTOMOBILE_CLI_PATH:-}" ]]; then
+        if [[ ! -x "${AUTOMOBILE_CLI_PATH}" ]]; then
+            log_error "AUTOMOBILE_CLI_PATH must point to an executable AutoMobile CLI: ${AUTOMOBILE_CLI_PATH}"
+            return 1
+        fi
+        AUTO_MOBILE_CMD=("${AUTOMOBILE_CLI_PATH}")
+        return 0
+    fi
+
     if command_exists bunx; then
         AUTO_MOBILE_CMD=("bunx" "@kaeawc/auto-mobile@latest")
         return 0

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -313,10 +313,12 @@ export class Daemon {
     // isolated-path launch during our own multi-second startup window, instead
     // of failing closed on an unknown path. The ordering lives behind
     // runStartupPrologue() so it can be asserted with fakes (issue #2871).
-    await runStartupPrologue({
-      writeEarlyOwnerRecord: () => this.writeEarlyOwnerRecord(),
-      initializeDatabase: () => this.initializeDatabase(),
-    });
+    await startupBenchmark.runPhase("daemonDatabaseInitialization", () =>
+      runStartupPrologue({
+        writeEarlyOwnerRecord: () => this.writeEarlyOwnerRecord(),
+        initializeDatabase: () => this.initializeDatabase(),
+      })
+    );
 
     // Find an available port
     this.port = await this.findAvailablePort(this.port);
@@ -336,7 +338,7 @@ export class Daemon {
 
     // Initialize iOS CtrlProxy iOS connections for discovered iOS devices
     // This establishes WebSocket connections early so observe calls are fast
-    await this.initializeIosServices();
+    await startupBenchmark.runPhase("iosServices", () => this.initializeIosServices());
 
     // Start Unix socket server AFTER device pool is ready
     logger.info(`Daemon host: "${this.host}", port: ${this.port}`);
@@ -356,6 +358,7 @@ export class Daemon {
     startupBenchmark.endPhase("socketServerStart");
     logger.info("Unix socket server started");
 
+    startupBenchmark.startPhase("auxiliarySocketServerStart");
     await startVideoRecordingSocketServer();
     await startTestRecordingSocketServer();
     await startDeviceSnapshotSocketServer();
@@ -368,6 +371,7 @@ export class Daemon {
     await startTelemetryPushSocketServer();
     await startWebRtcStreamSocketServer();
     await startVideoStreamSocketServer();
+    startupBenchmark.endPhase("auxiliarySocketServerStart");
 
     // Wire up callback to establish WebSocket connections when IDE plugins subscribe
     this.setupDeviceDataStreamCallback();
@@ -393,6 +397,8 @@ export class Daemon {
       port: this.port,
       socketPath: SOCKET_PATH,
       deviceCount: this.devicePool.getTotalDeviceCount(),
+      mcpHttpListenerBound: this.httpServer?.listening ?? false,
+      daemonSocketListenerBound: this.socketServer?.isListening() ?? false,
     });
 
     logger.info(

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -961,15 +961,23 @@ export class DaemonManager implements DaemonManagerLike {
   async waitForReady(timeout: number, signal?: AbortSignal): Promise<boolean> {
     const startTime = this.timer.now();
     const pollInterval = 100; // Poll every 100ms
+    let pollCount = 0;
+    let socketObserved = false;
 
     while (this.timer.now() - startTime < timeout) {
       if (signal?.aborted) {
         return false;
       }
+      pollCount++;
       if (existsSync(this.socketPath)) {
+        socketObserved = true;
         const status = await this.status();
         if (status.running) {
           if (await this.verifyDaemonConnection()) {
+            stderrLog(
+              `Daemon readiness probe succeeded after ${this.timer.now() - startTime}ms ` +
+              `(${pollCount} polls; socket observed)`
+            );
             return true;
           }
           if (signal?.aborted) {
@@ -982,6 +990,10 @@ export class DaemonManager implements DaemonManagerLike {
       await this.sleepUnlessAborted(pollInterval, signal);
     }
 
+    stderrLog(
+      `Daemon readiness probe timed out after ${this.timer.now() - startTime}ms ` +
+      `(${pollCount} polls; socket ${socketObserved ? "observed" : "not observed"})`
+    );
     return false;
   }
 

--- a/src/features/toolCapabilities/toolCapabilityMap.ts
+++ b/src/features/toolCapabilities/toolCapabilityMap.ts
@@ -1,13 +1,13 @@
 import type { ToolCapability } from "./SessionToolProfileService";
 
 const groups: Record<ToolCapability, readonly string[]> = {
-  clipboard: ["clipboard", "selectAllText"],
+  "clipboard": ["clipboard", "selectAllText"],
   "advanced-interaction": ["openLink", "imeAction", "dragAndDrop", "pinchOn", "shake", "rotate"],
   "app-permissions": ["getAppPermissions", "setAppPermissions"],
   "device-settings": ["changeLocalization", "getDeviceState", "setDeviceState"],
   "app-data-interop": ["putAppFile", "getPreference", "setPreference", "sqlQuery", "setKeyValue", "removeKeyValue", "clearKeyValueFile"],
-  notifications: ["systemTray", "postNotification", "getNotificationPolicy", "setNotificationPolicy"],
-  telephony: ["phoneCall", "sendSms"],
+  "notifications": ["systemTray", "postNotification", "getNotificationPolicy", "setNotificationPolicy"],
+  "telephony": ["phoneCall", "sendSms"],
   "accessibility-tools": ["accessibility", "accessibilityFocus"],
   "screen-artifacts": ["videoRecording", "deviceSnapshot", "highlight"],
   "test-authoring": ["executePlan", "startTestRecording", "exportPlan", "recordSteps", "barrier", "criticalSection"],

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,9 @@ setFatalProcessHandler(event => {
 });
 
 async function main() {
+  startupBenchmark.mark("processEntry");
+  startupBenchmark.startPhase("moduleImports");
+
   const rawArgs = process.argv.slice(2);
   const bootDeviceIndex = rawArgs.indexOf("--boot-device");
   if (bootDeviceIndex >= 0) {
@@ -82,6 +85,7 @@ async function main() {
     // import and startup side effect: no database, daemon, CtrlProxy, or media
     // cache work is needed to launch and await a device.
     const { runBootDeviceCommand } = await import("./cli/bootDevice");
+    startupBenchmark.endPhase("moduleImports");
     await runBootDeviceCommand(rawArgs.slice(bootDeviceIndex + 1));
     // Android launch owns a live emulator child; the one-shot caller only
     // needs the already-flushed JSON result, not that child as its own event
@@ -110,8 +114,7 @@ async function main() {
   const { AndroidCtrlProxyManager } = await import("./utils/CtrlProxyManager");
   const { IOSCtrlProxyBuilder } = await import("./utils/IOSCtrlProxyBuilder");
   const { IOSCtrlProxyManager } = await import("./utils/IOSCtrlProxyManager");
-
-  startupBenchmark.mark("processEntry");
+  startupBenchmark.endPhase("moduleImports");
 
   const { startVideoRecordingSocketServer, stopVideoRecordingSocketServer } = videoRecordingSocketServer;
   const { startTestRecordingSocketServer, stopTestRecordingSocketServer } = testRecordingSocketServer;
@@ -192,10 +195,14 @@ async function main() {
     });
     if (skipCtrlProxyDownload) {
       logger.info(`CtrlProxy downloads disabled (${SKIP_CTRL_PROXY_DOWNLOAD_FLAG} or ${SKIP_CTRL_PROXY_DOWNLOAD_ENV})`);
+      startupBenchmark.recordPhase("androidCtrlProxyPrefetch", 0);
     } else {
       // Start prefetching the accessibility service APK in the background
       // This runs asynchronously and will be ready when first device connects
-      AndroidCtrlProxyManager.prefetchApk();
+      startupBenchmark.startPhase("androidCtrlProxyPrefetch");
+      void AndroidCtrlProxyManager.prefetchApk().then(() => {
+        startupBenchmark.endPhase("androidCtrlProxyPrefetch");
+      });
     }
 
     // Start the iOS build prefetch asynchronously so it can be ready for first
@@ -203,8 +210,12 @@ async function main() {
     if (process.platform === "darwin") {
       if (skipCtrlProxyDownload) {
         logger.info(`CtrlProxy iOS prefetch disabled (${SKIP_CTRL_PROXY_DOWNLOAD_FLAG} or ${SKIP_CTRL_PROXY_DOWNLOAD_ENV})`);
+        startupBenchmark.recordPhase("iosCtrlProxyPrefetch", 0);
       } else {
-        IOSCtrlProxyBuilder.prefetchBuild();
+        startupBenchmark.startPhase("iosCtrlProxyPrefetch");
+        void IOSCtrlProxyBuilder.prefetchBuild().then(() => {
+          startupBenchmark.endPhase("iosCtrlProxyPrefetch");
+        });
       }
     }
 
@@ -282,31 +293,33 @@ async function main() {
       }
     };
 
-    if (daemonMode) {
-      await guardDatabaseStartup(async () => {
-        await new DefaultDatabaseInitializer().initialize();
-        await applyFeatureFlagStartup();
-      });
-    } else {
-      // Direct mode (--no-proxy/--direct) opens the shared SQLite DB in-process
-      // with no cross-process lock. Refuse BEFORE the first DB touch (feature-flag
-      // startup opens the DB and runs migrations) if a live daemon already owns
-      // the SAME resolved DB file, to avoid two writers on one sqlite file
-      // (SQLITE_BUSY stalls, competing migrations, aux-socket bind conflicts).
-      // File-scoped, so an isolated AUTOMOBILE_DB_PATH still starts normally. #2795
-      // The ordering (guard before the DB touch, only under noProxy) lives behind
-      // runDirectModeStartup() so it can be unit-tested with fakes (issue #2871).
-      const { runDirectModeStartup } = await import("./daemon/directModeStartup");
-      await runDirectModeStartup({
-        noProxy,
-        assertDbOwnership: async () => {
-          const { assertDirectModeDbOwnership, createDefaultDirectModeGuardDeps } =
-            await import("./daemon/directModeGuard");
-          assertDirectModeDbOwnership(createDefaultDirectModeGuardDeps());
-        },
-        applyFeatureFlagStartup,
-      });
-    }
+    await startupBenchmark.runPhase("databasePreflight", async () => {
+      if (daemonMode) {
+        await guardDatabaseStartup(async () => {
+          await new DefaultDatabaseInitializer().initialize();
+          await applyFeatureFlagStartup();
+        });
+      } else {
+        // Direct mode (--no-proxy/--direct) opens the shared SQLite DB in-process
+        // with no cross-process lock. Refuse BEFORE the first DB touch (feature-flag
+        // startup opens the DB and runs migrations) if a live daemon already owns
+        // the SAME resolved DB file, to avoid two writers on one sqlite file
+        // (SQLITE_BUSY stalls, competing migrations, aux-socket bind conflicts).
+        // File-scoped, so an isolated AUTOMOBILE_DB_PATH still starts normally. #2795
+        // The ordering (guard before the DB touch, only under noProxy) lives behind
+        // runDirectModeStartup() so it can be unit-tested with fakes (issue #2871).
+        const { runDirectModeStartup } = await import("./daemon/directModeStartup");
+        await runDirectModeStartup({
+          noProxy,
+          assertDbOwnership: async () => {
+            const { assertDirectModeDbOwnership, createDefaultDirectModeGuardDeps } =
+              await import("./daemon/directModeGuard");
+            assertDirectModeDbOwnership(createDefaultDirectModeGuardDeps());
+          },
+          applyFeatureFlagStartup,
+        });
+      }
+    });
 
     if (noWaitForPollingOverhead) {
       serverConfig.setWaitForPollingOverheadEnabled(false);

--- a/src/utils/CtrlProxyManager.ts
+++ b/src/utils/CtrlProxyManager.ts
@@ -202,18 +202,18 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
    * Call this at server startup to warm the cache before first device connection.
    * This is a no-op if prefetch is already in progress or completed.
    */
-  public static prefetchApk(): void {
+  public static prefetchApk(): Promise<string | null> {
     // Skip if already prefetching or prefetched
     if (AndroidCtrlProxyManager.prefetchPromise !== null) {
       logger.info("[CTRL_PROXY] APK prefetch already initiated, skipping");
-      return;
+      return AndroidCtrlProxyManager.prefetchPromise;
     }
 
     // Skip if there's an override path (local APK)
     const overridePath = process.env.AUTOMOBILE_CTRL_PROXY_APK_PATH?.trim();
     if (overridePath && overridePath.length > 0) {
       logger.info("[CTRL_PROXY] Using local APK override, skipping prefetch");
-      return;
+      return Promise.resolve(null);
     }
 
     logger.info("[CTRL_PROXY] Starting APK prefetch");
@@ -238,6 +238,7 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
         AndroidCtrlProxyManager.prefetchPromise = null;
         return null;
       });
+    return AndroidCtrlProxyManager.prefetchPromise;
   }
 
   /**
@@ -1744,7 +1745,7 @@ export class AndroidCtrlProxyManager implements CtrlProxyManager {
     if (this.fileDownloader !== AndroidCtrlProxyManager.defaultFileDownloader) {
       return;
     }
-    AndroidCtrlProxyManager.prefetchApk();
+    void AndroidCtrlProxyManager.prefetchApk();
   }
 
   private isNetworkError(message: string): boolean {

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -538,16 +538,16 @@ export class IOSCtrlProxyBuilder {
   /**
    * Prefetch download at startup (background, non-blocking)
    */
-  public static prefetchBuild(): void {
+  public static prefetchBuild(): Promise<CtrlProxyIosBuildResult | null> {
     // Only run on macOS
     if (process.platform !== "darwin") {
       logger.info("[IOSCtrlProxyBuilder] Prefetch skipped (not macOS)");
-      return;
+      return Promise.resolve(null);
     }
 
     if (IOSCtrlProxyBuilder.prefetchPromise !== null) {
       logger.info("[IOSCtrlProxyBuilder] Prefetch already initiated, skipping");
-      return;
+      return IOSCtrlProxyBuilder.prefetchPromise;
     }
 
     logger.info("[IOSCtrlProxyBuilder] Starting download prefetch");
@@ -576,6 +576,7 @@ export class IOSCtrlProxyBuilder {
         });
         return null;
       });
+    return IOSCtrlProxyBuilder.prefetchPromise;
   }
 
   /**

--- a/src/utils/startupBenchmark.ts
+++ b/src/utils/startupBenchmark.ts
@@ -1,31 +1,41 @@
 import { performance } from "node:perf_hooks";
 import fs from "node:fs";
 import path from "node:path";
+import { resolvePathFromDaemonLaunchWorkingDirectory } from "./workingDirectory";
 
 const STARTUP_BENCHMARK_PREFIX = "STARTUP_BENCHMARK";
 
 interface StartupBenchmarkReport {
   type: string;
+  state: "in_progress" | "ready";
   timestamp: string;
   pid: number;
   label?: string;
   marks: Record<string, number>;
   phases: Record<string, number>;
+  activePhases: string[];
   memoryUsage: NodeJS.MemoryUsage;
   meta: Record<string, unknown>;
 }
 
-const envEnabledRaw =
-  process.env.AUTOMOBILE_STARTUP_BENCHMARK ??
-  process.env.AUTO_MOBILE_STARTUP_BENCHMARK ??
-  "";
+export function isStartupBenchmarkEnabled(
+  args: readonly string[],
+  environment: Readonly<Record<string, string | undefined>>
+): boolean {
+  if (args.includes("--startup-benchmark")) {
+    return true;
+  }
 
-const envEnabled = envEnabledRaw.toLowerCase();
-const enabled =
-  process.argv.includes("--startup-benchmark") ||
-  envEnabled === "1" ||
-  envEnabled === "true" ||
-  envEnabled === "yes";
+  const envEnabled = (
+    environment.AUTOMOBILE_STARTUP_BENCHMARK ??
+    environment.AUTO_MOBILE_STARTUP_BENCHMARK ??
+    ""
+  ).toLowerCase();
+  return args.includes("--daemon-mode") &&
+    (envEnabled === "1" || envEnabled === "true" || envEnabled === "yes");
+}
+
+const enabled = isStartupBenchmarkEnabled(process.argv, process.env);
 
 const outputPath =
   process.env.AUTOMOBILE_STARTUP_BENCHMARK_OUTPUT ??
@@ -35,15 +45,39 @@ const label =
   process.env.AUTOMOBILE_STARTUP_BENCHMARK_LABEL ??
   process.env.AUTO_MOBILE_STARTUP_BENCHMARK_LABEL;
 
-class StartupBenchmark {
+export interface StartupBenchmarkOptions {
+  outputPath?: string;
+  label?: string;
+  now?: () => number;
+  fileSystem?: StartupBenchmarkFileSystem;
+}
+
+export type StartupBenchmarkFileSystem = Pick<
+  typeof fs,
+  "existsSync" | "mkdirSync" | "renameSync" | "writeFileSync"
+>;
+
+export class StartupBenchmark {
   private marks = new Map<string, number>();
   private phaseStarts = new Map<string, number>();
   private phases = new Map<string, number>();
   private emitted = false;
+  private emittedReport: { type: string; meta: Record<string, unknown> } | undefined;
   private readonly enabled: boolean;
+  private readonly outputPath: string | undefined;
+  private readonly label: string | undefined;
+  private readonly now: () => number;
+  private readonly fileSystem: StartupBenchmarkFileSystem;
 
-  constructor(isEnabled: boolean) {
+  constructor(isEnabled: boolean, options: StartupBenchmarkOptions = {}) {
     this.enabled = isEnabled;
+    const rawOutputPath = options.outputPath ?? outputPath;
+    this.outputPath = rawOutputPath
+      ? resolvePathFromDaemonLaunchWorkingDirectory(rawOutputPath)
+      : undefined;
+    this.label = options.label ?? label;
+    this.now = options.now ?? performance.now;
+    this.fileSystem = options.fileSystem ?? fs;
   }
 
   isEnabled(): boolean {
@@ -54,14 +88,23 @@ class StartupBenchmark {
     if (!this.enabled || this.marks.has(name)) {
       return;
     }
-    this.marks.set(name, performance.now());
+    this.marks.set(name, this.now());
+    this.persistCheckpoint();
   }
 
   startPhase(name: string): void {
     if (!this.enabled || this.phases.has(name) || this.phaseStarts.has(name)) {
       return;
     }
-    this.phaseStarts.set(name, performance.now());
+    this.phaseStarts.set(name, this.now());
+    this.persistCheckpoint();
+  }
+
+  async runPhase<T>(name: string, work: () => Promise<T>): Promise<T> {
+    this.startPhase(name);
+    const result = await work();
+    this.endPhase(name);
+    return result;
   }
 
   endPhase(name: string): void {
@@ -72,7 +115,9 @@ class StartupBenchmark {
     if (start === undefined) {
       return;
     }
-    this.phases.set(name, performance.now() - start);
+    this.phases.set(name, this.now() - start);
+    this.phaseStarts.delete(name);
+    this.persistCheckpoint();
   }
 
   recordPhase(name: string, durationMs: number): void {
@@ -80,6 +125,7 @@ class StartupBenchmark {
       return;
     }
     this.phases.set(name, durationMs);
+    this.persistCheckpoint();
   }
 
   emit(type: string, meta: Record<string, unknown> = {}): void {
@@ -87,36 +133,58 @@ class StartupBenchmark {
       return;
     }
     this.emitted = true;
+    this.emittedReport = { type, meta };
 
+    const report = this.createReport(type, "ready", meta);
+    const payload = JSON.stringify(report);
+
+    this.writeReport(payload);
+    process.stderr.write(`${STARTUP_BENCHMARK_PREFIX} ${payload}\n`);
+  }
+
+  private persistCheckpoint(): void {
+    if (!this.enabled) {
+      return;
+    }
+    const report = this.emittedReport
+      ? this.createReport(this.emittedReport.type, "ready", this.emittedReport.meta)
+      : this.createReport("startup-checkpoint", "in_progress");
+    this.writeReport(JSON.stringify(report));
+  }
+
+  private createReport(
+    type: string,
+    state: StartupBenchmarkReport["state"],
+    meta: Record<string, unknown> = {}
+  ): StartupBenchmarkReport {
     const marks = Object.fromEntries(this.marks.entries());
     const phases = Object.fromEntries(this.phases.entries());
 
-    if (marks.processEntry !== undefined && phases.moduleImports === undefined) {
-      phases.moduleImports = marks.processEntry;
-    }
-
-    const report: StartupBenchmarkReport = {
+    return {
       type,
+      state,
       timestamp: new Date().toISOString(),
       pid: process.pid,
-      label,
+      label: this.label,
       marks,
       phases,
+      activePhases: [...this.phaseStarts.keys()],
       memoryUsage: process.memoryUsage(),
-      meta
+      meta,
     };
+  }
 
-    const payload = JSON.stringify(report);
-
-    if (outputPath) {
-      const dir = path.dirname(outputPath);
-      if (!fs.existsSync(dir)) {
-        fs.mkdirSync(dir, { recursive: true });
-      }
-      fs.writeFileSync(outputPath, payload, "utf-8");
+  private writeReport(payload: string): void {
+    if (!this.outputPath) {
+      return;
     }
-
-    process.stderr.write(`${STARTUP_BENCHMARK_PREFIX} ${payload}\n`);
+    const dir = path.dirname(this.outputPath);
+    if (!this.fileSystem.existsSync(dir)) {
+      this.fileSystem.mkdirSync(dir, { recursive: true });
+    }
+    const temporaryPath = `${this.outputPath}.${process.pid}.tmp`;
+    this.fileSystem.writeFileSync(temporaryPath, payload, "utf-8");
+    this.fileSystem.renameSync(temporaryPath, this.outputPath);
   }
 }
 

--- a/test/bats/install-cli-override.bats
+++ b/test/bats/install-cli-override.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+
+SCRIPT="${BATS_TEST_DIRNAME}/../../scripts/install.sh"
+
+setup() {
+  TEST_ROOT="$(mktemp -d)"
+  CLI_PATH="${TEST_ROOT}/auto-mobile"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "${CLI_PATH}"
+  chmod +x "${CLI_PATH}"
+}
+
+teardown() {
+  rm -rf "${TEST_ROOT}"
+}
+
+@test "uses the executable source CLI override for daemon lifecycle commands" {
+  run env INSTALL_SH_SOURCE_ONLY=true AUTOMOBILE_CLI_PATH="${CLI_PATH}" SCRIPT="${SCRIPT}" bash -c '
+    source "${SCRIPT}"
+    command_exists() { return 1; }
+    resolve_auto_mobile_command
+    printf "%s\n" "${AUTO_MOBILE_CMD[@]}"
+  '
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "${CLI_PATH}" ]
+}
+
+@test "rejects a non-executable source CLI override" {
+  chmod -x "${CLI_PATH}"
+
+  run env INSTALL_SH_SOURCE_ONLY=true AUTOMOBILE_CLI_PATH="${CLI_PATH}" SCRIPT="${SCRIPT}" bash -c '
+    source "${SCRIPT}"
+    command_exists() { return 1; }
+    if resolve_auto_mobile_command; then
+      exit 1
+    fi
+  '
+
+  [ "$status" -eq 0 ]
+}

--- a/test/daemon/daemonManagerReadiness.test.ts
+++ b/test/daemon/daemonManagerReadiness.test.ts
@@ -278,6 +278,30 @@ describe("DaemonManager readiness", () => {
     expect(clients).toHaveLength(0);
   });
 
+  test("reports elapsed readiness timing when no daemon socket appears", async () => {
+    const { lockPath, pidPath, socketPath } = createPaths();
+    const fakeTimer = new FakeTimer();
+    fakeTimer.enableAutoAdvance();
+    const stderr = spyOn(process.stderr, "write").mockImplementation(() => true);
+    const manager = new DaemonManager(
+      undefined,
+      undefined,
+      fakeTimer,
+      lockPath,
+      pidPath,
+      socketPath
+    );
+
+    try {
+      await expect(manager.waitForReady(200)).resolves.toBe(false);
+      expect(stderr).toHaveBeenCalledWith(
+        "Daemon readiness probe timed out after 200ms (2 polls; socket not observed)\n"
+      );
+    } finally {
+      stderr.mockRestore();
+    }
+  });
+
   test("startup timeout includes bounded daemon log context", async () => {
     const { lockPath, pidPath, socketPath } = createPaths();
     const fakeTimer = new FakeTimer();

--- a/test/scripts/installerStartupDiagnostics.test.ts
+++ b/test/scripts/installerStartupDiagnostics.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { load } from "js-yaml";
+
+interface WorkflowStep {
+  name?: string;
+  env?: Record<string, string>;
+  run?: string;
+  uses?: string;
+  with?: Record<string, string>;
+}
+
+interface WorkflowDocument {
+  jobs?: Record<string, { steps?: WorkflowStep[] }>;
+}
+
+const workflows = [
+  ".github/workflows/pull_request.yml",
+  ".github/workflows/merge.yml",
+];
+const entrypointSource = readFileSync("src/index.ts", "utf8");
+const daemonSource = readFileSync("src/daemon/daemon.ts", "utf8");
+
+function installerDevelopmentSteps(path: string): WorkflowStep[] {
+  const workflow = load(readFileSync(path, "utf8")) as WorkflowDocument;
+  return workflow.jobs?.["installer-development"]?.steps ?? [];
+}
+
+describe("#4631 installer startup diagnostics", () => {
+  test("records module loading before the first awaited startup import", () => {
+    const mainStart = entrypointSource.indexOf("async function main()");
+    const processEntryMark = entrypointSource.indexOf(
+      'startupBenchmark.mark("processEntry")',
+      mainStart
+    );
+    const moduleImportsStart = entrypointSource.indexOf(
+      'startupBenchmark.startPhase("moduleImports")',
+      mainStart
+    );
+    const firstDynamicImport = entrypointSource.indexOf("await import(", mainStart);
+    const moduleImportsEnd = entrypointSource.indexOf(
+      'startupBenchmark.endPhase("moduleImports")',
+      firstDynamicImport
+    );
+
+    expect(mainStart).toBeGreaterThanOrEqual(0);
+    expect(processEntryMark).toBeGreaterThan(mainStart);
+    expect(moduleImportsStart).toBeGreaterThan(processEntryMark);
+    expect(firstDynamicImport).toBeGreaterThan(moduleImportsStart);
+    expect(moduleImportsEnd).toBeGreaterThan(firstDynamicImport);
+  });
+
+  test("keeps auxiliary socket startup active until every server is ready", () => {
+    const socketStartsBegin = daemonSource.indexOf("await startVideoRecordingSocketServer()");
+    const socketStartsEnd = daemonSource.indexOf("await startVideoStreamSocketServer()");
+    const phaseStart = daemonSource.lastIndexOf(
+      'startupBenchmark.startPhase("auxiliarySocketServerStart")',
+      socketStartsBegin
+    );
+    const phaseEnd = daemonSource.indexOf(
+      'startupBenchmark.endPhase("auxiliarySocketServerStart")',
+      socketStartsEnd
+    );
+
+    expect(socketStartsBegin).toBeGreaterThanOrEqual(0);
+    expect(socketStartsEnd).toBeGreaterThan(socketStartsBegin);
+    expect(phaseStart).toBeGreaterThanOrEqual(0);
+    expect(phaseStart).toBeLessThan(socketStartsBegin);
+    expect(phaseEnd).toBeGreaterThan(socketStartsEnd);
+  });
+
+  for (const workflowPath of workflows) {
+    test(`${workflowPath} gives the development installer a bounded cold-start policy and preserves diagnostics`, () => {
+      const steps = installerDevelopmentSteps(workflowPath);
+      expect(steps.length).toBeGreaterThan(0);
+
+      const sourceCli = steps.find(step => step.name === "Build source CLI for installer diagnostics");
+      expect(sourceCli).toMatchObject({
+        uses: "./.github/actions/setup-auto-mobile-npm-package",
+        with: { "install-global": "false" },
+      });
+
+      const installer = steps.find(step => step.name === "Run Installer (development)");
+      expect(installer?.env).toMatchObject({
+        AUTOMOBILE_DAEMON_STARTUP_TIMEOUT_MS: "30000",
+        AUTOMOBILE_STARTUP_BENCHMARK: "1",
+        AUTOMOBILE_STARTUP_BENCHMARK_OUTPUT:
+          "${{ github.workspace }}/ci-logs/installer-daemon-startup.json",
+        AUTOMOBILE_CLI_PATH: "${{ github.workspace }}/dist/src/index.js",
+      });
+      expect(installer?.run).toContain("ci-logs/daemon-logs");
+      expect(installer?.run).toContain("ci-logs/ctrl-proxy-cache-state.txt");
+
+      const upload = steps.find(step => step.name === "Upload Logs");
+      expect(upload?.with?.path).toBe("ci-logs/");
+    });
+  }
+});

--- a/test/utils/startupBenchmark.test.ts
+++ b/test/utils/startupBenchmark.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
+import {
+  isStartupBenchmarkEnabled,
+  StartupBenchmark,
+  type StartupBenchmarkFileSystem,
+} from "../../src/utils/startupBenchmark";
+
+describe("StartupBenchmark checkpoints", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+  });
+
+  test("persists active startup phases until daemon readiness completes", () => {
+    const dir = mkdtempSync(join(tmpdir(), "startup-benchmark-"));
+    tempDirs.push(dir);
+    const outputPath = join(dir, "startup.json");
+    let now = 100;
+    const benchmark = new StartupBenchmark(true, {
+      outputPath,
+      label: "installer-development",
+      now: () => now,
+    });
+
+    benchmark.mark("processEntry");
+    benchmark.startPhase("androidCtrlProxyPrefetch");
+
+    expect(JSON.parse(readFileSync(outputPath, "utf8"))).toMatchObject({
+      type: "startup-checkpoint",
+      state: "in_progress",
+      label: "installer-development",
+      marks: { processEntry: 100 },
+      phases: {},
+      activePhases: ["androidCtrlProxyPrefetch"],
+    });
+
+    now = 375;
+    benchmark.endPhase("androidCtrlProxyPrefetch");
+    benchmark.emit("daemon", { listenerBound: true });
+
+    expect(JSON.parse(readFileSync(outputPath, "utf8"))).toMatchObject({
+      type: "daemon",
+      state: "ready",
+      phases: { androidCtrlProxyPrefetch: 275 },
+      activePhases: [],
+      meta: { listenerBound: true },
+    });
+  });
+
+  test("persists module loading as the active phase before imports complete", () => {
+    const dir = mkdtempSync(join(tmpdir(), "startup-benchmark-"));
+    tempDirs.push(dir);
+    const outputPath = join(dir, "startup.json");
+    const benchmark = new StartupBenchmark(true, { outputPath });
+
+    benchmark.mark("processEntry");
+    benchmark.startPhase("moduleImports");
+
+    expect(JSON.parse(readFileSync(outputPath, "utf8"))).toMatchObject({
+      type: "startup-checkpoint",
+      state: "in_progress",
+      marks: { processEntry: expect.any(Number) },
+      phases: {},
+      activePhases: ["moduleImports"],
+    });
+  });
+
+  test("preserves the ready report when a background phase settles after readiness", () => {
+    const dir = mkdtempSync(join(tmpdir(), "startup-benchmark-"));
+    tempDirs.push(dir);
+    const outputPath = join(dir, "startup.json");
+    let now = 100;
+    const benchmark = new StartupBenchmark(true, {
+      outputPath,
+      now: () => now,
+    });
+
+    benchmark.startPhase("iosCtrlProxyPrefetch");
+    benchmark.emit("daemon", { daemonSocketListenerBound: true });
+
+    now = 325;
+    benchmark.endPhase("iosCtrlProxyPrefetch");
+
+    expect(JSON.parse(readFileSync(outputPath, "utf8"))).toMatchObject({
+      type: "daemon",
+      state: "ready",
+      phases: { iosCtrlProxyPrefetch: 225 },
+      activePhases: [],
+      meta: { daemonSocketListenerBound: true },
+    });
+  });
+
+  test("atomically replaces checkpoint files", () => {
+    const dir = mkdtempSync(join(tmpdir(), "startup-benchmark-"));
+    tempDirs.push(dir);
+    const outputPath = join(dir, "startup.json");
+    const renameCalls: Array<[string, string]> = [];
+    const fileSystem: StartupBenchmarkFileSystem = {
+      existsSync: fs.existsSync,
+      mkdirSync: fs.mkdirSync,
+      writeFileSync: fs.writeFileSync,
+      renameSync: (from, to) => {
+        renameCalls.push([from.toString(), to.toString()]);
+        fs.renameSync(from, to);
+      },
+    };
+
+    new StartupBenchmark(true, { outputPath, fileSystem }).mark("processEntry");
+
+    expect(renameCalls).toEqual([[`${outputPath}.${process.pid}.tmp`, outputPath]]);
+  });
+
+  test("resolves relative output paths from the daemon launch working directory", () => {
+    const launchCwd = mkdtempSync(join(tmpdir(), "startup-benchmark-launch-cwd-"));
+    tempDirs.push(launchCwd);
+    const originalLaunchCwd = process.env[DAEMON_LAUNCH_CWD_ENV];
+    const writes: string[] = [];
+    const renames: Array<[string, string]> = [];
+    const fileSystem: StartupBenchmarkFileSystem = {
+      existsSync: () => true,
+      mkdirSync: () => undefined,
+      writeFileSync: filePath => {
+        writes.push(filePath.toString());
+      },
+      renameSync: (from, to) => {
+        renames.push([from.toString(), to.toString()]);
+      },
+    };
+
+    process.env[DAEMON_LAUNCH_CWD_ENV] = launchCwd;
+    try {
+      new StartupBenchmark(true, {
+        outputPath: join("ci-logs", "installer-daemon-startup.json"),
+        fileSystem,
+      }).mark("processEntry");
+
+      const outputPath = join(launchCwd, "ci-logs", "installer-daemon-startup.json");
+      expect(writes).toEqual([`${outputPath}.${process.pid}.tmp`]);
+      expect(renames).toEqual([[`${outputPath}.${process.pid}.tmp`, outputPath]]);
+    } finally {
+      if (originalLaunchCwd === undefined) {
+        delete process.env[DAEMON_LAUNCH_CWD_ENV];
+      } else {
+        process.env[DAEMON_LAUNCH_CWD_ENV] = originalLaunchCwd;
+      }
+    }
+  });
+
+  test("keeps a failed phase active in its checkpoint", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "startup-benchmark-"));
+    tempDirs.push(dir);
+    const outputPath = join(dir, "startup.json");
+    const benchmark = new StartupBenchmark(true, { outputPath });
+    const failure = new Error("database unavailable");
+
+    await expect(
+      benchmark.runPhase("databasePreflight", async () => {
+        throw failure;
+      })
+    ).rejects.toBe(failure);
+
+    expect(JSON.parse(readFileSync(outputPath, "utf8"))).toMatchObject({
+      type: "startup-checkpoint",
+      state: "in_progress",
+      phases: {},
+      activePhases: ["databasePreflight"],
+    });
+  });
+});
+
+describe("isStartupBenchmarkEnabled", () => {
+  test("limits environment-driven reports to the detached daemon process", () => {
+    const environment = { AUTOMOBILE_STARTUP_BENCHMARK: "1" };
+
+    expect(isStartupBenchmarkEnabled(["bun", "index.ts", "--daemon-mode"], environment)).toBe(true);
+    expect(isStartupBenchmarkEnabled(["auto-mobile", "--daemon", "start"], environment)).toBe(false);
+    expect(isStartupBenchmarkEnabled(["auto-mobile", "--daemon", "health"], environment)).toBe(false);
+  });
+
+  test("keeps the explicit benchmark flag available outside daemon mode", () => {
+    expect(isStartupBenchmarkEnabled(["bun", "index.ts", "--startup-benchmark"], {})).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds persistent startup benchmark checkpoints so installer failures identify active startup phases, including Android and iOS CtrlProxy prefetches and listener-bound state.

Raises the development installer daemon readiness budget from 10 to 30 seconds and preserves daemon logs, benchmark output, and CtrlProxy cache state in CI artifacts.

## Linked Issue

Closes [#4631](https://github.com/kaeawc/auto-mobile/issues/4631)

## Bug / Regression Context

- **Prior attempts:** The macOS installer lane failed on [#4627](https://github.com/kaeawc/auto-mobile/pull/4627) and passed on rerun without a source change.
- **Observed symptom:** The installer reported `Daemon failed to start within 10000ms` after CtrlProxy prefetch logs, with no readiness or terminal daemon evidence.
- **Repro steps / conditions:** Cold hosted macOS development installer startup.

## Validation

- [x] `TMPDIR=/private/tmp AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-4631-data bun run turbo:validate`
- [x] `bun run typecheck` reports no new errors over the existing baseline
- [x] `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-4631-data bun run validate:yaml`
- [x] Focused Bun and BATS coverage for startup checkpoints, readiness diagnostics, and workflow configuration
- [x] New TypeScript behavior has deterministic test seams
- [x] No new dependencies or generic helpers added
- [x] Based on current `main`
