### PR TITLE
fix(ci): fail installer when ffmpeg installation fails

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3264,7 +3264,8 @@ _install_system_package() {
     if [[ "${NON_INTERACTIVE}" != "true" ]]; then
         if ! gum confirm "Install ${pkg}? (${description})"; then
             log_info "Skipped ${pkg} — install later with: ${skip_hint}"
-            return 1
+            # A user-declined interactive install is a successful no-op.
+            return 0
         fi
     fi
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3281,7 +3281,7 @@ _install_system_package() {
 install_runtime_deps() {
     # ffmpeg — required for video recording features
     if ! command_exists ffmpeg; then
-        _install_system_package "ffmpeg" "required for video recording" || true
+        _install_system_package "ffmpeg" "required for video recording"
     fi
 }
 

--- a/test/bats/install-runtime-deps.bats
+++ b/test/bats/install-runtime-deps.bats
@@ -38,3 +38,21 @@ setup() {
 
   [ "$status" -eq 0 ]
 }
+
+@test "allows an interactive user to decline ffmpeg installation" {
+  detect_os() {
+    printf 'linux\n'
+  }
+  command_exists() {
+    [[ "$1" == "apt-get" ]]
+  }
+  gum() {
+    [[ "$1" == "confirm" ]]
+    return 1
+  }
+  NON_INTERACTIVE=false
+
+  run install_runtime_deps
+
+  [ "$status" -eq 0 ]
+}

--- a/test/bats/install-runtime-deps.bats
+++ b/test/bats/install-runtime-deps.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+
+# Regression coverage for #4636: a required runtime dependency must not let
+# the installer report success when its package installation fails.
+
+setup() {
+  export INSTALL_SH_SOURCE_ONLY=true
+  # shellcheck source=/dev/null
+  source scripts/install.sh
+
+  log_info() { :; }
+  log_warn() { :; }
+}
+
+@test "fails when the required ffmpeg installation fails" {
+  command_exists() {
+    [[ "$1" != "ffmpeg" ]]
+  }
+  _install_system_package() {
+    [[ "$1" == "ffmpeg" ]]
+    return 1
+  }
+
+  run install_runtime_deps
+
+  [ "$status" -eq 1 ]
+}
+
+@test "succeeds when ffmpeg is already installed" {
+  command_exists() {
+    [[ "$1" == "ffmpeg" ]]
+  }
+  _install_system_package() {
+    return 1
+  }
+
+  run install_runtime_deps
+
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

The Ubuntu development installer now fails when it cannot install the required
`ffmpeg` runtime dependency. Previously, `install_runtime_deps` suppressed that
failure, allowing installation to report success before the runtime-dependency
verification step failed.

## Linked Issue

Closes [#4636](https://github.com/kaeawc/auto-mobile/issues/4636)

## Bug / Regression Context

- **Prior attempts:** None.
- **Observed symptom:** Ubuntu installer-development CI reported `INSTALL_EXIT_CODE=0`, then failed `scripts/ci/verify-runtime-deps.sh` because `ffmpeg` was missing.
- **Repro steps / conditions:** Make the required `ffmpeg` package installation fail during a non-interactive installer run; the old installer swallowed the failure and exited successfully.

## Validation

- [x] `bats test/bats/install-runtime-deps.bats test/bats/install-bounded-package-install.bats test/bats/verify-runtime-deps.bats`
- [x] `scripts/all_fast_validate_checks.sh --only shellcheck,shell-portability,shell-sete --no-parallel`
- [x] `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-issue-4636-20260728-090000/automobile-data bun run turbo:validate` (11,924 passed; 13 intentional integration skips)
- [x] `bun run typecheck` reports no new errors
- [x] Shell-only change; Android/iOS validation is not applicable
- [x] BATS coverage uses the installer's existing source-only seam and package-installer stub
- [x] No new generic helper or direct dependency was added
- [x] Branch created from the current `origin/main`
