### PR TITLE
fix(ios): prevent frame-context races

### DIFF
--- a/ios/control-proxy/Sources/CtrlProxy/FrameContext.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/FrameContext.swift
@@ -1,25 +1,46 @@
 import Foundation
 
+protocol FrameContextMainExecuting: AnyObject {
+    func perform<T>(_ operation: () throws -> T) throws -> T
+}
+
+private final class MainThreadFrameContextExecutor: FrameContextMainExecuting {
+    func perform<T>(_ operation: () throws -> T) throws -> T {
+        try withoutActuallyEscaping(operation) { operation in
+            try runOnMainThread(operation)
+        }
+    }
+}
+
 /// Stable, opaque identity for a device hierarchy. A tracker belongs to one CtrlProxy process,
 /// so a delayed context can never be reused after that process restarts.
 public final class FrameContext {
     private let lock = NSLock()
     private let epoch: UUID
+    private let mainThreadExecutor: FrameContextMainExecuting
     private var generation: UInt64 = 0
 
     public init(epoch: UUID = UUID()) {
         self.epoch = epoch
+        mainThreadExecutor = MainThreadFrameContextExecutor()
+    }
+
+    init(epoch: UUID, mainThreadExecutor: FrameContextMainExecuting) {
+        self.epoch = epoch
+        self.mainThreadExecutor = mainThreadExecutor
     }
 
     /// Records a device-side UI transition and returns the context for that exact generation.
     @discardableResult
     public func recordTransition(to hierarchy: ViewHierarchy) -> String? {
-        let hash = Self.semanticHash(hierarchy)
-        lock.lock()
-        generation &+= 1
-        let context = hash.map { "\(epoch.uuidString):\(generation):\($0)" }
-        lock.unlock()
-        return context
+        try? mainThreadExecutor.perform { [self] in
+            let hash = Self.semanticHash(hierarchy)
+            self.lock.lock()
+            self.generation &+= 1
+            let context = hash.map { "\(self.epoch.uuidString):\(self.generation):\($0)" }
+            self.lock.unlock()
+            return context
+        }
     }
 
     public func context(for hierarchy: ViewHierarchy) -> String? {
@@ -29,7 +50,7 @@ public final class FrameContext {
         return Self.semanticHash(hierarchy).map { "\(epoch.uuidString):\(currentGeneration):\($0)" }
     }
 
-    /// Validates a context against the current hierarchy before dispatching a gesture.
+    /// Validates a context and dispatches its gesture on the transition executor.
     func performIfCurrent<T>(
         expected: String?,
         hierarchy: ViewHierarchy?,
@@ -37,20 +58,22 @@ public final class FrameContext {
     )
         throws -> T
     {
-        guard let expected else { return try operation() }
-        guard let hierarchy else {
-            throw CommandError.executionFailed("Stale frame context; observe a fresh frame before retrying")
-        }
+        try mainThreadExecutor.perform { [self] in
+            guard let expected else { return try operation() }
+            guard let hierarchy else {
+                throw CommandError.executionFailed("Stale frame context; observe a fresh frame before retrying")
+            }
 
-        let hash = Self.semanticHash(hierarchy)
-        lock.lock()
-        let isCurrent = hash.map { "\(epoch.uuidString):\(generation):\($0)" } == expected
-        lock.unlock()
+            let hash = Self.semanticHash(hierarchy)
+            self.lock.lock()
+            let isCurrent = hash.map { "\(self.epoch.uuidString):\(self.generation):\($0)" } == expected
+            self.lock.unlock()
 
-        guard isCurrent else {
-            throw CommandError.executionFailed("Stale frame context; observe a fresh frame before retrying")
+            guard isCurrent else {
+                throw CommandError.executionFailed("Stale frame context; observe a fresh frame before retrying")
+            }
+            return try operation()
         }
-        return try operation()
     }
 
     private static func semanticHash(_ hierarchy: ViewHierarchy) -> String? {

--- a/ios/control-proxy/Sources/CtrlProxy/FrameContext.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/FrameContext.swift
@@ -11,11 +11,15 @@ public final class FrameContext {
         self.epoch = epoch
     }
 
-    /// Records a device-side UI transition, even when hierarchy publication is debounced.
-    public func recordTransition(to _: ViewHierarchy) {
+    /// Records a device-side UI transition and returns the context for that exact generation.
+    @discardableResult
+    public func recordTransition(to hierarchy: ViewHierarchy) -> String? {
+        let hash = Self.semanticHash(hierarchy)
         lock.lock()
         generation &+= 1
+        let context = hash.map { "\(epoch.uuidString):\(generation):\($0)" }
         lock.unlock()
+        return context
     }
 
     public func context(for hierarchy: ViewHierarchy) -> String? {
@@ -25,7 +29,7 @@ public final class FrameContext {
         return Self.semanticHash(hierarchy).map { "\(epoch.uuidString):\(currentGeneration):\($0)" }
     }
 
-    /// Serializes transition recording with the final context check and gesture dispatch.
+    /// Validates a context against the current hierarchy before dispatching a gesture.
     func performIfCurrent<T>(
         expected: String?,
         hierarchy: ViewHierarchy?,
@@ -38,9 +42,12 @@ public final class FrameContext {
             throw CommandError.executionFailed("Stale frame context; observe a fresh frame before retrying")
         }
 
+        let hash = Self.semanticHash(hierarchy)
         lock.lock()
-        defer { lock.unlock() }
-        guard Self.semanticHash(hierarchy).map({ "\(epoch.uuidString):\(generation):\($0)" }) == expected else {
+        let isCurrent = hash.map { "\(epoch.uuidString):\(generation):\($0)" } == expected
+        lock.unlock()
+
+        guard isCurrent else {
             throw CommandError.executionFailed("Stale frame context; observe a fresh frame before retrying")
         }
         return try operation()

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -307,12 +307,12 @@ public class WebSocketServer: WebSocketServing {
 
     /// Broadcast a hierarchy update to all connected clients (push notification)
     public func broadcastHierarchyUpdate(_ hierarchy: ViewHierarchy) {
-        frameContext.recordTransition(to: hierarchy)
+        let context = frameContext.recordTransition(to: hierarchy)
         let response = HierarchyUpdateResponse(
             requestId: nil, // No requestId for push updates
             data: hierarchy,
             perfTiming: nil,
-            frameContext: frameContext.context(for: hierarchy)
+            frameContext: context
         )
 
         do {

--- a/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/WebSocketServer.swift
@@ -112,6 +112,7 @@ public class WebSocketServer: WebSocketServing {
     private let perfProvider: PerfProvider
     private let sdkHierarchyCache: SdkHierarchyCache?
     private let frameContext: FrameContext
+    private let broadcastSink: ((Data) -> Void)?
     private let queue = DispatchQueue(label: "com.ctrlproxy.server")
     var onSdkHierarchyUpdated: (() -> Void)?
 
@@ -131,6 +132,23 @@ public class WebSocketServer: WebSocketServing {
         self.perfProvider = perfProvider
         self.sdkHierarchyCache = sdkHierarchyCache
         self.frameContext = frameContext
+        broadcastSink = nil
+    }
+
+    init(
+        port: UInt16,
+        commandHandler: CommandHandler,
+        perfProvider: PerfProvider,
+        sdkHierarchyCache: SdkHierarchyCache?,
+        frameContext: FrameContext,
+        broadcastSink: ((Data) -> Void)?
+    ) {
+        self.port = port
+        self.commandHandler = commandHandler
+        self.perfProvider = perfProvider
+        self.sdkHierarchyCache = sdkHierarchyCache
+        self.frameContext = frameContext
+        self.broadcastSink = broadcastSink
     }
 
     /// Starts the server
@@ -300,6 +318,10 @@ public class WebSocketServer: WebSocketServing {
 
     /// Broadcast a message to all connected clients
     public func broadcast(_ data: Data) {
+        if let broadcastSink {
+            broadcastSink(data)
+            return
+        }
         for connection in connections.values() {
             connection.send(data)
         }

--- a/ios/control-proxy/Tests/CtrlProxyTests/FrameContextSafetyTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/FrameContextSafetyTests.swift
@@ -118,6 +118,40 @@ final class FrameContextSafetyTests: XCTestCase {
         XCTAssertEqual(fakeGesturePerformer.getOpenRecentAppsCallCount(), 0)
     }
 
+    func testValidatedGestureAllowsMainQueueTransitionBeforeSynchronousGestureHop() {
+        let screenA = makeHierarchy(text: "A")
+        let screenB = makeHierarchy(text: "B")
+        let expected = frameContext.context(for: screenA)
+        let operationFinished = DispatchSemaphore(value: 0)
+        let mainQueue = DispatchQueue(label: "FrameContextSafetyTests.main")
+
+        DispatchQueue.global().async { [frameContext] in
+            _ = try? frameContext?.performIfCurrent(
+                expected: expected,
+                hierarchy: screenA
+            ) {
+                mainQueue.async {
+                    frameContext?.recordTransition(to: screenB)
+                }
+                mainQueue.sync {}
+                operationFinished.signal()
+            }
+        }
+
+        XCTAssertEqual(operationFinished.wait(timeout: .now() + 0.05), .success)
+    }
+
+    func testTransitionContextKeepsItsOriginalGenerationAfterDelayedBroadcast() {
+        let screenA = makeHierarchy(text: "A")
+        let screenB = makeHierarchy(text: "B")
+        let delayedBroadcastContext = frameContext.recordTransition(to: screenA)
+
+        frameContext.recordTransition(to: screenB)
+        frameContext.recordTransition(to: screenA)
+
+        XCTAssertNotEqual(delayedBroadcastContext, frameContext.context(for: screenA))
+    }
+
     private func makeHierarchy(text: String) -> ViewHierarchy {
         ViewHierarchy(
             packageName: "com.example.app",

--- a/ios/control-proxy/Tests/CtrlProxyTests/FrameContextSafetyTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/FrameContextSafetyTests.swift
@@ -118,27 +118,28 @@ final class FrameContextSafetyTests: XCTestCase {
         XCTAssertEqual(fakeGesturePerformer.getOpenRecentAppsCallCount(), 0)
     }
 
-    func testValidatedGestureAllowsMainQueueTransitionBeforeSynchronousGestureHop() {
+    func testTransitionQueuedBeforeGestureExecutionRejectsStaleContext() {
         let screenA = makeHierarchy(text: "A")
         let screenB = makeHierarchy(text: "B")
+        let executor = TestFrameContextMainExecutor()
+        let frameContext = FrameContext(epoch: UUID(), mainThreadExecutor: executor)
         let expected = frameContext.context(for: screenA)
-        let operationFinished = DispatchSemaphore(value: 0)
-        let mainQueue = DispatchQueue(label: "FrameContextSafetyTests.main")
+        var operationCalled = false
 
-        DispatchQueue.global().async { [frameContext] in
-            _ = try? frameContext?.performIfCurrent(
+        executor.enqueue {
+            frameContext.recordTransition(to: screenB)
+        }
+
+        XCTAssertThrowsError(
+            try frameContext.performIfCurrent(
                 expected: expected,
                 hierarchy: screenA
             ) {
-                mainQueue.async {
-                    frameContext?.recordTransition(to: screenB)
-                }
-                mainQueue.sync {}
-                operationFinished.signal()
+                operationCalled = true
             }
-        }
-
-        XCTAssertEqual(operationFinished.wait(timeout: .now() + 0.05), .success)
+        )
+        XCTAssertFalse(operationCalled)
+        executor.drain()
     }
 
     func testTransitionContextKeepsItsOriginalGenerationAfterDelayedBroadcast() {
@@ -157,5 +158,40 @@ final class FrameContextSafetyTests: XCTestCase {
             packageName: "com.example.app",
             hierarchy: UIElementInfo(text: text)
         )
+    }
+}
+
+private final class TestFrameContextMainExecutor: FrameContextMainExecuting {
+    private let queue = DispatchQueue(label: "FrameContextSafetyTests.main")
+    private let key = DispatchSpecificKey<UUID>()
+    private let identifier = UUID()
+
+    init() {
+        queue.setSpecific(key: key, value: identifier)
+    }
+
+    func perform<T>(_ operation: () throws -> T) throws -> T {
+        if DispatchQueue.getSpecific(key: key) == identifier {
+            return try operation()
+        }
+
+        var result: Result<T, Error>?
+        withoutActuallyEscaping(operation) { operation in
+            queue.sync {
+                result = Result { try operation() }
+            }
+        }
+        guard let result else {
+            preconditionFailure("Frame-context executor did not return a result")
+        }
+        return try result.get()
+    }
+
+    func enqueue(_ operation: @escaping () -> Void) {
+        queue.async(execute: operation)
+    }
+
+    func drain() {
+        queue.sync {}
     }
 }

--- a/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/WebSocketServerTests.swift
@@ -21,6 +21,18 @@ final class WebSocketServerTests: XCTestCase {
         }
     }
 
+    private final class TransitionInjectingExecutor: FrameContextMainExecuting {
+        var afterNextPerform: (() -> Void)?
+
+        func perform<T>(_ operation: () throws -> T) throws -> T {
+            let result = try operation()
+            let callback = afterNextPerform
+            afterNextPerform = nil
+            callback?()
+            return result
+        }
+    }
+
     private var perfProvider: PerfProvider!
 
     override func tearDown() {
@@ -31,7 +43,12 @@ final class WebSocketServerTests: XCTestCase {
 
     /// A `WebSocketServer` wired to fakes, with a test perf provider so the
     /// singleton is untouched.
-    private func makeServer() -> WebSocketServer {
+    private func makeServer(
+        frameContext: FrameContext = FrameContext(),
+        broadcastSink: ((Data) -> Void)? = nil
+    )
+        -> WebSocketServer
+    {
         let fakeTimeProvider = FakeTimeProvider(initialTime: 1000)
         perfProvider = PerfProvider.createForTesting(timeProvider: fakeTimeProvider)
         let handler = CommandHandler.createForTesting(
@@ -39,7 +56,14 @@ final class WebSocketServerTests: XCTestCase {
             gesturePerformer: FakeGesturePerformer(),
             perfProvider: perfProvider
         )
-        return WebSocketServer(commandHandler: handler, perfProvider: perfProvider)
+        return WebSocketServer(
+            port: 8765,
+            commandHandler: handler,
+            perfProvider: perfProvider,
+            sdkHierarchyCache: nil,
+            frameContext: frameContext,
+            broadcastSink: broadcastSink
+        )
     }
 
     /// Drive a raw command through the real `handleMessage` and return the single
@@ -91,6 +115,38 @@ final class WebSocketServerTests: XCTestCase {
             file: file,
             line: line
         )
+    }
+
+    func testBroadcastHierarchyUpdateRetainsCapturedTransitionContext() throws {
+        let screenA = ViewHierarchy(
+            packageName: "com.example.app",
+            hierarchy: UIElementInfo(text: "A")
+        )
+        let screenB = ViewHierarchy(
+            packageName: "com.example.app",
+            hierarchy: UIElementInfo(text: "B")
+        )
+        let epoch = UUID()
+        let expectedContext = FrameContext(epoch: epoch).recordTransition(to: screenA)
+        let executor = TransitionInjectingExecutor()
+        let frameContext = FrameContext(epoch: epoch, mainThreadExecutor: executor)
+        var broadcasts: [Data] = []
+        let server = makeServer(
+            frameContext: frameContext,
+            broadcastSink: { broadcasts.append($0) }
+        )
+
+        executor.afterNextPerform = {
+            frameContext.recordTransition(to: screenB)
+            frameContext.recordTransition(to: screenA)
+        }
+
+        server.broadcastHierarchyUpdate(screenA)
+
+        XCTAssertEqual(broadcasts.count, 1)
+        let response = try JSONDecoder().decode(HierarchyUpdateResponse.self, from: broadcasts[0])
+        XCTAssertEqual(response.frameContext, expectedContext)
+        XCTAssertNotEqual(response.frameContext, frameContext.context(for: screenA))
     }
 
     // MARK: - Decode-failure → error envelope (real handleMessage path)


### PR DESCRIPTION
## Summary

- capture the exact frame-context generation for each hierarchy broadcast
- release the frame-context lock before gesture execution synchronously hops to the main queue
- add deterministic regressions for the deadlock, delayed-broadcast relabeling, and broadcast-wire-context races

## Root cause

Frame-context transition recording could relabel a queued hierarchy update with a newer generation. Gesture validation also held the frame-context lock while the gesture performed a synchronous main-thread hop, allowing a main-thread transition to deadlock with the background gesture request.

## Validation

- `swift test -Xswiftc -warnings-as-errors`
- `swift build -Xswiftc -warnings-as-errors`
- `ONLY_TOUCHED_FILES=true bash scripts/swiftlint/validate_swiftlint.sh`
- `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-issue-4620-data bun run turbo:validate`

## Delivery

This changes the iOS CtrlProxy runner source. Default installs still resolve the released runner. A tagged release must rebuild and publish `control-proxy.ipa` and update the release checksum registry before delivery is complete.

Related issue: [#4620](https://github.com/kaeawc/auto-mobile/issues/4620)
