### PR TITLE
fix(desktop): preserve sequenced coordinate space

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSession.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSession.kt
@@ -370,14 +370,15 @@ class DeviceControlSession(
    * already seen is ignored outright: it neither records nor resets.
    *
    * `captureSequence` is the ordering signal because it is already bound to each frame and is
-   * monotonic per device (issue #3348) — no new clock, no third notion of "current". It is absent
-   * only on frames the policy already refuses to pair, and on those there is nothing to order
-   * against, so they are observed as before. The hierarchy path is unaffected: the daemon assigns
-   * the id on every hierarchy push, so a hierarchy's id is always the newest at the time it is sent
-   * and can never be rejected here.
+   * monotonic per device (issue #3348) — no new clock, no third notion of "current". A session that
+   * has never received one still observes unsequenced legacy frames as before. Once a sequenced
+   * observation establishes the current space, an unsequenced frame cannot prove it is newer and is
+   * ignored. The hierarchy path is unaffected: the daemon assigns the id on every hierarchy push,
+   * so a hierarchy's id is always the newest at the time it is sent and can never be rejected here.
    */
   fun onObservationSpaceDeclared(coordinateSpace: CoordinateSpace?, captureSequence: Long?) {
     val lastSeen = lastObservedSpaceCapture
+    if (captureSequence == null && lastSeen != null) return
     if (captureSequence != null && lastSeen != null && captureSequence <= lastSeen) return
     if (captureSequence != null) lastObservedSpaceCapture = captureSequence
     if (streamSpace.observe(coordinateSpace)) resetPreservingSpaceBaseline()

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionTest.kt
@@ -994,6 +994,78 @@ class DeviceControlSessionTest {
     }
 
   @Test
+  fun `an unsequenced screenshot cannot roll back a sequenced coordinate space`() = runTest {
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val client = FakeAutoMobileClient()
+    val session = session(scope, client)
+
+    session.onObservationSpaceDeclared(CoordinateSpace.Pixels, captureSequence = 8L)
+
+    // A screenshot whose declared dimensions do not match its PNG keeps this old binding but has
+    // its capture identity stripped before delivery. It cannot prove that the current stream space
+    // changed after the sequenced observation.
+    session.onObservationSpaceDeclared(null, captureSequence = null)
+
+    assertTrue(
+      session.tap(testSnapshot(coordinateSpace = CoordinateSpace.Pixels), point),
+      "the sequenced coordinate space remains current",
+    )
+    advanceUntilIdle()
+    assertFalse(
+      session.tap(testSnapshot(coordinateSpace = null), point),
+      "an unsequenced legacy declaration cannot resurrect the old space",
+    )
+    advanceUntilIdle()
+    assertEquals(1, client.inputTapCalls.size, "only the pixel-space tap reached the device")
+    scope.cancel()
+  }
+
+  @Test
+  fun `an unsequenced rollback cannot dispatch a pointer captured before a space flip`() = runTest {
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val client = FakeAutoMobileClient()
+    val session = session(scope, client)
+
+    session.onObservationSpaceDeclared(null, captureSequence = 7L)
+    assertNotNull(
+      session.evaluate(paired(captureSequence = 7L, sourceSequence = 10L)).snapshotOrNull
+    )
+    val clickedBeforeFlip = assertNotNull(session.interactionSnapshot)
+
+    session.onObservationSpaceDeclared(CoordinateSpace.Pixels, captureSequence = 8L)
+    session.onObservationSpaceDeclared(null, captureSequence = null)
+
+    assertFalse(
+      session.tap(clickedBeforeFlip, point),
+      "a pre-flip legacy pointer must stay rejected after an unsequenced old-space screenshot",
+    )
+    advanceUntilIdle()
+    assertTrue(client.inputTapCalls.isEmpty(), "nothing reached the device")
+    scope.cancel()
+  }
+
+  @Test
+  fun `unsequenced-only sessions retain coordinate-space tracking`() = runTest {
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val client = FakeAutoMobileClient()
+    val session = session(scope, client)
+
+    session.onObservationSpaceDeclared(null, captureSequence = null)
+    assertTrue(session.tap(testSnapshot(coordinateSpace = null), point))
+    advanceUntilIdle()
+
+    // Legacy runners never provide a capture sequence, so their later declaration must still
+    // advance the stream space and retire the previous coordinate unit.
+    session.onObservationSpaceDeclared(CoordinateSpace.Pixels, captureSequence = null)
+    assertTrue(session.tap(testSnapshot(coordinateSpace = CoordinateSpace.Pixels), point))
+    assertFalse(session.tap(testSnapshot(coordinateSpace = null), point))
+    advanceUntilIdle()
+
+    assertEquals(2, client.inputTapCalls.size)
+    scope.cancel()
+  }
+
+  @Test
   fun `a tap or swipe carrying a retired snapshot is rejected at dispatch`() = runTest {
     // Half (b): defence in depth. Even with the observable retirement, a pointer event that
     // CAPTURED the snapshot before the flip can reach dispatch after it — the view cannot


### PR DESCRIPTION
## Summary

Preserve the coordinate space established by a sequenced desktop observation. An unsequenced screenshot can retain its declared space after the daemon strips its capture identity, but it can no longer roll the stream backward once sequenced ordering has become available. Never-sequenced legacy sessions keep their existing behavior.

## Linked Issue

Closes [#4603](https://github.com/kaeawc/auto-mobile/issues/4603)

## Bug / Regression Context

- **Prior attempts:** Sequenced stale captures are already rejected; this closes the unsequenced branch raised during review of [#4580](https://github.com/kaeawc/auto-mobile/pull/4580).
- **Observed symptom:** A delayed old-space screenshot without a capture identity rewrote `streamSpace`, allowing an input captured before the real space flip to be dispatched with the wrong unit.
- **Repro steps / conditions:** Receive a sequenced legacy-space observation, then a sequenced pixel-space observation. Deliver a delayed legacy screenshot whose capture identity was stripped because its measured pixels did not match its geometry.

## Validation

- [x] `:desktop-core:test` passes.
- [x] `bun run typecheck` reports no new errors.
- [x] `scripts/ktfmt/apply_ktfmt.sh` formats the touched Kotlin files.
- [x] Deterministic `DeviceControlSessionTest` coverage verifies sequenced rollback resistance, dispatch rejection across the attempted rollback, and never-sequenced legacy behavior.
- [x] Fresh worktree created from current `origin/main`.
- [ ] `bun run turbo:validate`: lint, build, and all boundary checks pass; its TypeScript test task is blocked locally by shared-host port exhaustion (841 unrelated failures).

## Kotlin Reuse Check

- [x] Used the existing `DeviceControlSession` ordering state and test fakes; no helper, wrapper, or dependency was added.
