### PR TITLE
fix(desktop): reject conflicting proven rotations

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSession.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSession.kt
@@ -654,6 +654,15 @@ class DeviceControlSession(
   }
 
   private suspend fun execute(command: DeviceControlInputCommand) {
+    // A command can wait behind another input while the sources rotate. Recheck at the FIFO
+    // consumer boundary so a coordinate captured before disagreement cannot reach the daemon.
+    if (
+      (command is DeviceControlInputCommand.Tap || command is DeviceControlInputCommand.Swipe) &&
+        !coordinatesAreStillDispatchable(command.snapshot)
+    ) {
+      command.client?.close()
+      return
+    }
     var error: String? = null
     try {
       withContext(ioDispatcher) { forward(command) { message -> error = message } }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSession.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSession.kt
@@ -161,7 +161,8 @@ class DeviceControlSession(
   private var lastObservedFrameContextCapture: Long? = null
 
   // The latest proven device rotations, for the dispatch-time gate. Null until one is observed,
-  // one value when every proving source agrees, and multiple values during a disagreement.
+  // one value when every proving source agrees, and multiple values latched during a disagreement
+  // until currently reported sources prove they agree again.
   @Volatile private var lastProvenRotations: Set<Int>? = null
 
   // Backstop trackers on the frame FACTS, for updates that never came through the stream collectors
@@ -236,10 +237,7 @@ class DeviceControlSession(
   fun evaluate(inputs: DeviceControlInputs): DeviceControlDecision {
     val now = nowMs()
     resetOnCoordinateSpaceTransition(inputs)
-    // Keep all current PROVEN rotations so dispatch can reject a snapshot the device has since
-    // rotated away from, or any input while sources disagree (issues #4502, #4550, #4604). Only
-    // recorded — the retirement decisions themselves stay where each fix put them.
-    inputs.provenRotations().takeIf { it.isNotEmpty() }?.let { lastProvenRotations = it }
+    updateProvenRotations(inputs)
     val decision = DeviceControlPolicy.evaluate(inputs, now)
     val live = decision.snapshotOrNull
     staleContextRejectedFrameContext?.let { rejectedContext ->
@@ -446,6 +444,24 @@ class DeviceControlSession(
     listOfNotNull(screenshot?.rotation, hierarchy?.rotation, liveFrame?.rotation)
       .filter { it in 0..3 }
       .toSet()
+
+  /**
+   * Keep a proven disagreement until every currently reported source can prove an agreeing
+   * rotation. A missing or malformed value cannot prove the device returned to the prior rotation.
+   */
+  private fun updateProvenRotations(inputs: DeviceControlInputs) {
+    val rotations = inputs.provenRotations()
+    if (rotations.isEmpty()) return
+    if ((lastProvenRotations?.size ?: 0) > 1 && inputs.hasUnprovenReportedRotation()) return
+    lastProvenRotations = rotations
+  }
+
+  private fun DeviceControlInputs.hasUnprovenReportedRotation(): Boolean =
+    screenshot?.let { !it.rotation.isProvenRotation() } == true ||
+      hierarchy?.let { !it.rotation.isProvenRotation() } == true ||
+      liveFrame?.let { !it.rotation.isProvenRotation() } == true
+
+  private fun Int?.isProvenRotation(): Boolean = this != null && this in 0..3
 
   /**
    * Enqueue a tap on [snapshot] at the mapped device coordinate [point], in click order.

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSession.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSession.kt
@@ -162,7 +162,7 @@ class DeviceControlSession(
 
   // The latest proven device rotations, for the dispatch-time gate. Null until one is observed,
   // one value when every proving source agrees, and multiple values during a disagreement.
-  private var lastProvenRotations: Set<Int>? = null
+  @Volatile private var lastProvenRotations: Set<Int>? = null
 
   // Backstop trackers on the frame FACTS, for updates that never came through the stream collectors
   // (see [resetOnCoordinateSpaceTransition]).
@@ -424,9 +424,12 @@ class DeviceControlSession(
     staleContextRejectedFrameContext == null &&
       streamSpace.matches(snapshot.coordinateSpace) &&
       streamFrameContext.matches(snapshot.frameContext) &&
-      lastProvenRotations.let { rotations ->
-        rotations == null || (rotations.size == 1 && snapshot.rotation in rotations)
-      }
+      rotationIsStillDispatchable(snapshot)
+
+  private fun rotationIsStillDispatchable(snapshot: DeviceFrameSnapshot): Boolean =
+    lastProvenRotations.let { rotations ->
+      rotations == null || (rotations.size == 1 && snapshot.rotation in rotations)
+    }
 
   /**
    * A source can arrive before it pairs with its counterpart during a rotation. That unpaired
@@ -664,11 +667,26 @@ class DeviceControlSession(
       return
     }
     var error: String? = null
-    try {
-      withContext(ioDispatcher) { forward(command) { message -> error = message } }
-    } finally {
-      command.client?.close()
-    }
+    val forwarded =
+      try {
+        withContext(ioDispatcher) {
+          // The main-to-IO dispatcher hop admits another observation before the daemon call.
+          // This volatile read is the final rotation gate before coordinates leave the process.
+          if (
+            (command is DeviceControlInputCommand.Tap ||
+              command is DeviceControlInputCommand.Swipe) &&
+              !rotationIsStillDispatchable(command.snapshot)
+          ) {
+            false
+          } else {
+            forward(command) { message -> error = message }
+            true
+          }
+        }
+      } finally {
+        command.client?.close()
+      }
+    if (!forwarded) return
     val message = error
     withContext(uiContext) {
       if (message == null) {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSession.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSession.kt
@@ -160,9 +160,9 @@ class DeviceControlSession(
   // observations must use the same capture ordering as coordinate-space observations.
   private var lastObservedFrameContextCapture: Long? = null
 
-  // Newest device rotation any source has proven, for the dispatch-time gate. Null until one is
-  // observed, which is why a session that has seen no rotation accepts every snapshot.
-  private var lastProvenRotation: Int? = null
+  // The latest proven device rotations, for the dispatch-time gate. Null until one is observed,
+  // one value when every proving source agrees, and multiple values during a disagreement.
+  private var lastProvenRotations: Set<Int>? = null
 
   // Backstop trackers on the frame FACTS, for updates that never came through the stream collectors
   // (see [resetOnCoordinateSpaceTransition]).
@@ -236,10 +236,10 @@ class DeviceControlSession(
   fun evaluate(inputs: DeviceControlInputs): DeviceControlDecision {
     val now = nowMs()
     resetOnCoordinateSpaceTransition(inputs)
-    // Newest PROVEN rotation, kept so dispatch can reject a snapshot the device has since rotated
-    // away from (issue #4502 + #4550). Only recorded — the retirement decisions themselves stay
-    // where each fix put them.
-    inputs.newestProvenRotation()?.let { lastProvenRotation = it }
+    // Keep all current PROVEN rotations so dispatch can reject a snapshot the device has since
+    // rotated away from, or any input while sources disagree (issues #4502, #4550, #4604). Only
+    // recorded — the retirement decisions themselves stay where each fix put them.
+    inputs.provenRotations().takeIf { it.isNotEmpty() }?.let { lastProvenRotations = it }
     val decision = DeviceControlPolicy.evaluate(inputs, now)
     val live = decision.snapshotOrNull
     staleContextRejectedFrameContext?.let { rejectedContext ->
@@ -416,7 +416,7 @@ class DeviceControlSession(
    * Both properties are checked because both can invalidate a coordinate independently: a space
    * flip changes the UNIT the numbers are in, a rotation changes the AXES they are measured on, and
    * a frame is dispatchable only when both are current. Each reuses the value its own fix already
-   * records — the stream space tracker and the newest proven rotation — rather than introducing a
+   * records — the stream space tracker and the proven source rotations — rather than introducing a
    * third notion of "current". A session that has observed neither accepts everything: there is
    * nothing to contradict.
    */
@@ -424,7 +424,9 @@ class DeviceControlSession(
     staleContextRejectedFrameContext == null &&
       streamSpace.matches(snapshot.coordinateSpace) &&
       streamFrameContext.matches(snapshot.frameContext) &&
-      lastProvenRotation.let { it == null || it == snapshot.rotation }
+      lastProvenRotations.let { rotations ->
+        rotations == null || (rotations.size == 1 && snapshot.rotation in rotations)
+      }
 
   /**
    * A source can arrive before it pairs with its counterpart during a rotation. That unpaired
@@ -436,11 +438,11 @@ class DeviceControlSession(
       it in 0..3 && it != retainedRotation
     }
 
-  /** The newest rotation any source has PROVEN (a value in `0..3`), or null if none has yet. */
-  private fun DeviceControlInputs.newestProvenRotation(): Int? =
-    listOfNotNull(screenshot?.rotation, hierarchy?.rotation, liveFrame?.rotation).lastOrNull {
-      it in 0..3
-    }
+  /** All rotations any source has PROVEN (values in `0..3`), independent of source order. */
+  private fun DeviceControlInputs.provenRotations(): Set<Int> =
+    listOfNotNull(screenshot?.rotation, hierarchy?.rotation, liveFrame?.rotation)
+      .filter { it in 0..3 }
+      .toSet()
 
   /**
    * Enqueue a tap on [snapshot] at the mapped device coordinate [point], in click order.
@@ -630,7 +632,7 @@ class DeviceControlSession(
     lastObservedSpaceCapture = null
     streamFrameContext.forget()
     lastObservedFrameContextCapture = null
-    lastProvenRotation = null
+    lastProvenRotations = null
   }
 
   /**

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionTest.kt
@@ -1304,6 +1304,92 @@ class DeviceControlSessionTest {
     scope.cancel()
   }
 
+  @Test
+  fun `a screenshot-first rotation with a stale hierarchy blocks dispatch`() = runTest {
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val client = FakeAutoMobileClient()
+    val session = session(scope, client)
+    val base = paired(captureSequence = 8L, sourceSequence = 11L)
+    val conflictingRotations = base.copy(screenshot = base.screenshot?.copy(rotation = 1))
+
+    session.evaluate(conflictingRotations)
+
+    assertFalse(
+      session.tap(testSnapshot().copy(rotation = 0), point),
+      "the stale hierarchy cannot make the disagreement dispatchable",
+    )
+    advanceUntilIdle()
+    assertTrue(client.inputTapCalls.isEmpty(), "nothing reaches the device during disagreement")
+    scope.cancel()
+  }
+
+  @Test
+  fun `a hierarchy-first rotation with a stale screenshot blocks dispatch`() = runTest {
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val client = FakeAutoMobileClient()
+    val session = session(scope, client)
+    val base = paired(captureSequence = 8L, sourceSequence = 11L)
+    val conflictingRotations = base.copy(hierarchy = base.hierarchy?.copy(rotation = 1))
+
+    session.evaluate(conflictingRotations)
+
+    assertFalse(
+      session.tap(testSnapshot().copy(rotation = 1), point),
+      "the newer hierarchy cannot make the disagreement dispatchable",
+    )
+    advanceUntilIdle()
+    assertTrue(client.inputTapCalls.isEmpty(), "nothing reaches the device during disagreement")
+    scope.cancel()
+  }
+
+  @Test
+  fun `a pointer captured before a rotation disagreement is not dispatched`() = runTest {
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val client = FakeAutoMobileClient()
+    val session = session(scope, client)
+    val initial = paired(captureSequence = 7L, sourceSequence = 10L)
+    val clicked = assertNotNull(session.evaluate(initial).snapshotOrNull)
+    val conflictingRotations =
+      initial.copy(screenshot = initial.screenshot?.copy(sequence = 11L, rotation = 1))
+
+    session.evaluate(conflictingRotations)
+
+    assertFalse(session.tap(clicked, point), "the in-flight pointer must fail closed")
+    advanceUntilIdle()
+    assertTrue(client.inputTapCalls.isEmpty(), "the captured pointer never reaches the device")
+    scope.cancel()
+  }
+
+  @Test
+  fun `single and unanimous proven rotations remain dispatchable`() = runTest {
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val client = FakeAutoMobileClient()
+    val session = session(scope, client)
+    val singleSourceBase = paired(captureSequence = 8L, sourceSequence = 11L)
+    val singleSource =
+      singleSourceBase.copy(
+        screenshot = singleSourceBase.screenshot?.copy(rotation = 1),
+        hierarchy = singleSourceBase.hierarchy?.copy(rotation = null),
+      )
+
+    session.evaluate(singleSource)
+    assertTrue(session.tap(testSnapshot().copy(rotation = 1), point))
+    advanceUntilIdle()
+
+    val unanimousBase = paired(captureSequence = 9L, sourceSequence = 12L)
+    val unanimous =
+      unanimousBase.copy(
+        screenshot = unanimousBase.screenshot?.copy(rotation = 2),
+        hierarchy = unanimousBase.hierarchy?.copy(rotation = 2),
+      )
+    session.evaluate(unanimous)
+    assertTrue(session.tap(testSnapshot().copy(rotation = 2), point))
+    advanceUntilIdle()
+
+    assertEquals(2, client.inputTapCalls.size)
+    scope.cancel()
+  }
+
   /** A coherent, freshly-received screenshot+hierarchy pair sharing one capture identity. */
   private fun paired(
     captureSequence: Long,

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionTest.kt
@@ -1361,6 +1361,47 @@ class DeviceControlSessionTest {
   }
 
   @Test
+  fun `queued coordinate commands are discarded after a rotation disagreement`() = runTest {
+    val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+    val clients = mutableListOf<FakeAutoMobileClient>()
+    val session =
+      DeviceControlSession(
+        scope = scope,
+        clientProvider = { FakeAutoMobileClient().also { clients += it } },
+        platform = { "android" },
+        nowMs = { 1_000L },
+        publishError = {},
+        uiContext = StandardTestDispatcher(testScheduler),
+        ioDispatcher = StandardTestDispatcher(testScheduler),
+      )
+    val initial = paired(captureSequence = 7L, sourceSequence = 10L)
+    val snapshot = assertNotNull(session.evaluate(initial).snapshotOrNull)
+
+    assertTrue(session.tap(snapshot, point))
+    assertTrue(
+      session.swipe(
+        snapshot,
+        DevicePoint(x = 540, y = 1800, inBounds = true),
+        DevicePoint(x = 540, y = 400, inBounds = true),
+      )
+    )
+    assertEquals(2, clients.size, "each queued command captures its client")
+
+    session.evaluate(
+      initial.copy(screenshot = initial.screenshot?.copy(sequence = 11L, rotation = 1))
+    )
+    advanceUntilIdle()
+
+    clients.forEach { client ->
+      assertTrue(client.inputTapCalls.isEmpty(), "a queued tap cannot survive disagreement")
+      assertTrue(client.inputSwipeCalls.isEmpty(), "a queued swipe cannot survive disagreement")
+      assertTrue("close" in client.calls, "a discarded command closes its captured client")
+    }
+    assertEquals(PostInputRefreshState.Idle, session.refreshState)
+    scope.cancel()
+  }
+
+  @Test
   fun `single and unanimous proven rotations remain dispatchable`() = runTest {
     val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
     val client = FakeAutoMobileClient()

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionTest.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -1397,6 +1398,43 @@ class DeviceControlSessionTest {
       assertTrue(client.inputSwipeCalls.isEmpty(), "a queued swipe cannot survive disagreement")
       assertTrue("close" in client.calls, "a discarded command closes its captured client")
     }
+    assertEquals(PostInputRefreshState.Idle, session.refreshState)
+    scope.cancel()
+  }
+
+  @Test
+  fun `coordinate commands revalidate rotations after dispatching to io`() = runTest {
+    val ioScheduler = TestCoroutineScheduler()
+    val scope = CoroutineScope(StandardTestDispatcher(testScheduler))
+    val client = FakeAutoMobileClient()
+    val session =
+      DeviceControlSession(
+        scope = scope,
+        clientProvider = { client },
+        platform = { "android" },
+        nowMs = { 1_000L },
+        publishError = {},
+        uiContext = StandardTestDispatcher(testScheduler),
+        ioDispatcher = StandardTestDispatcher(ioScheduler),
+      )
+    val initial = paired(captureSequence = 7L, sourceSequence = 10L)
+    val snapshot = assertNotNull(session.evaluate(initial).snapshotOrNull)
+
+    assertTrue(session.tap(snapshot, point))
+    advanceUntilIdle()
+
+    // The consumer passed its pre-IO check but is suspended before the daemon call.
+    session.evaluate(
+      initial.copy(screenshot = initial.screenshot?.copy(sequence = 11L, rotation = 1))
+    )
+    ioScheduler.advanceUntilIdle()
+    advanceUntilIdle()
+
+    assertTrue(
+      client.inputTapCalls.isEmpty(),
+      "the IO-boundary check must reject stale coordinates",
+    )
+    assertTrue("close" in client.calls, "the discarded command closes its captured client")
     assertEquals(PostInputRefreshState.Idle, session.refreshState)
     scope.cancel()
   }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/control/DeviceControlSessionTest.kt
@@ -1403,6 +1403,42 @@ class DeviceControlSessionTest {
   }
 
   @Test
+  fun `an unproven update cannot clear a rotation disagreement`() = runTest {
+    val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
+    val client = FakeAutoMobileClient()
+    val session = session(scope, client)
+    val initial = paired(captureSequence = 7L, sourceSequence = 10L)
+    val snapshot = assertNotNull(session.evaluate(initial).snapshotOrNull)
+    val disagreement =
+      initial.copy(screenshot = initial.screenshot?.copy(sequence = 11L, rotation = 1))
+
+    session.evaluate(disagreement)
+    val unproven =
+      disagreement.copy(screenshot = disagreement.screenshot?.copy(sequence = 12L, rotation = null))
+    assertEquals(
+      DeviceControlBlockReason.RotationMismatch,
+      (session.evaluate(unproven) as DeviceControlDecision.Blocked).reason,
+    )
+
+    assertFalse(
+      session.tap(snapshot, point),
+      "an unproven screenshot cannot prove that the earlier conflict resolved",
+    )
+    assertTrue(client.inputTapCalls.isEmpty())
+
+    val agreement =
+      unproven.copy(
+        screenshot = unproven.screenshot?.copy(sequence = 13L, rotation = 0),
+        hierarchy = unproven.hierarchy?.copy(sequence = 13L, rotation = 0),
+      )
+    val agreedSnapshot = assertNotNull(session.evaluate(agreement).snapshotOrNull)
+    assertTrue(session.tap(agreedSnapshot, point), "valid agreement restores coordinate dispatch")
+    advanceUntilIdle()
+    assertEquals(1, client.inputTapCalls.size)
+    scope.cancel()
+  }
+
+  @Test
   fun `coordinate commands revalidate rotations after dispatching to io`() = runTest {
     val ioScheduler = TestCoroutineScheduler()
     val scope = CoroutineScope(StandardTestDispatcher(testScheduler))


### PR DESCRIPTION
## Summary

Track every valid rotation currently proven by the desktop screenshot, hierarchy, and live-frame sources. Coordinate input now fails closed when those sources disagree instead of selecting the last value in a hard-coded source list. Single-source and unanimous rotation evidence retain the existing dispatch behavior.

## Linked Issue

Closes [#4604](https://github.com/kaeawc/auto-mobile/issues/4604).

## Bug / Regression Context

- **Prior attempts:** The dispatch-time rotation guard was added during the client-screen-control work and the source-order flaw was identified in review of [#4580](https://github.com/kaeawc/auto-mobile/pull/4580).
- **Observed symptom:** A screenshot reporting a new rotation could be overridden by a stale hierarchy solely because hierarchy appeared later in `listOfNotNull(...)`, allowing stale pointer coordinates to reach the device.
- **Repro steps / conditions:** Evaluate a coherent portrait snapshot, evaluate a screenshot-first or hierarchy-first rotation disagreement, then dispatch a pointer captured before the disagreement.

## Validation

- [x] `bun run turbo:validate` passes: 11,968 tests passed, 13 skipped, 0 failed
- [x] `bun run typecheck` reports no new errors
- [x] `./gradlew :desktop-core:test --tests '*DeviceControlSessionTest'`
- [x] `./gradlew :desktop-core:test`
- [x] `./gradlew :desktop-core:detektMain :desktop-core:detektTest`
- [x] `scripts/all_fast_validate_checks.sh --only ktfmt`
- [x] New tests use the existing injected client and fake coroutine dispatchers
- [x] Rebased onto latest `main`, conflicts resolved

## Kotlin Reuse Check

- [x] Checked Kotlin stdlib, existing desktop-core patterns, and project dependencies; used `Set<Int>` and collection operations from the standard library
- [x] No helper, wrapper, or dependency was added

## Follow-ups

None identified.
