### PR TITLE
fix(ios): harden rotation provenance

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1746,11 +1746,17 @@ jobs:
 
       - name: "Run selected CtrlProxy iOS tests (Xcode 26.5)"
         timeout-minutes: 5
+        env:
+          SIMULATOR_UDID: ${{ steps.ctrlproxy-simulator.outputs.simulator_udid }}
         run: |
+          if [[ ! "${SIMULATOR_UDID}" =~ ^[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$ ]]; then
+            echo "::error::Invalid simulator UDID" >&2
+            exit 1
+          fi
           XCTESTRUN=$(find /tmp/automobile-ctrl-proxy/Build/Products -name "*.xctestrun" | head -1)
           xcodebuild test-without-building \
             -xctestrun "${XCTESTRUN}" \
-            -destination "id=${{ steps.ctrlproxy-simulator.outputs.simulator_udid }}" \
+            -destination "id=${SIMULATOR_UDID}" \
             -only-testing:CtrlProxyUITests/PrivacyResourceMappingTests \
             -only-testing:CtrlProxyTests/RotationChangeGenerationTests/testGestureOrientationKeepsLandscapeSceneWhenDeviceIsFaceUp
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1744,14 +1744,15 @@ jobs:
       # booted sim's UDID.
       - wait: ctrlproxy-simulator
 
-      - name: "Run CtrlProxy privacy resource mapping UI test (Xcode 26.5)"
+      - name: "Run selected CtrlProxy iOS tests (Xcode 26.5)"
         timeout-minutes: 5
         run: |
           XCTESTRUN=$(find /tmp/automobile-ctrl-proxy/Build/Products -name "*.xctestrun" | head -1)
           xcodebuild test-without-building \
             -xctestrun "${XCTESTRUN}" \
             -destination "id=${{ steps.ctrlproxy-simulator.outputs.simulator_udid }}" \
-            -only-testing:CtrlProxyUITests/PrivacyResourceMappingTests
+            -only-testing:CtrlProxyUITests/PrivacyResourceMappingTests \
+            -only-testing:CtrlProxyTests/RotationChangeGenerationTests/testGestureOrientationKeepsLandscapeSceneWhenDeviceIsFaceUp
 
       # Re-sync the backgrounded ffmpeg install before its only consumer. With the
       # install hoisted out, this step's 10-minute cap now covers the test alone.

--- a/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
@@ -186,6 +186,7 @@ public class ElementLocator: ElementLocating {
             application: XCUIApplication? = nil,
             perfProvider: PerfProvider = PerfProvider.instance
         ) {
+            DeviceRotation.startMonitoring()
             tracker.setApplication(application, bundleId: nil, observe: false)
             self.perfProvider = perfProvider
         }

--- a/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
@@ -527,6 +527,11 @@ public class ElementLocator: ElementLocating {
             // Use the observed app's bundle identifier for packageName
             let bundleId = foregroundBundleId ?? "com.apple.springboard"
 
+            // Keep one monitor interval around every hierarchy-producing operation. The app and
+            // SpringBoard snapshots can each be internally stable while an A→B→A transition
+            // happens between them.
+            let beforeHierarchyCapture = try runOnMainThread { DeviceRotation.captureSample() }
+
             // Use snapshot() for fast hierarchy extraction - single IPC call captures everything
             // snapshot() captures all element data in ONE IPC call (fast!)
             // vs accessing properties individually which is extremely slow
@@ -644,26 +649,33 @@ public class ElementLocator: ElementLocating {
             // Display Zoom changes nativeScale while scale stays put, and
             // XCUIScreenshot.pngRepresentation renders at native scale (#4548). screenScale
             // (UIScreen.scale) is still reported unchanged for backward compatibility.
-            let currentScreenMetrics: ScreenMetrics = try runOnMainThread {
-                let scale = Float(UIScreen.main.scale)
-                let nativeScale = Float(UIScreen.main.nativeScale)
-                let bounds = UIScreen.main.bounds
-                return ScreenMetrics(
-                    scale: scale,
-                    nativeScale: nativeScale,
-                    fallbackWidth: Int(bounds.width),
-                    fallbackHeight: Int(bounds.height),
-                    rotation: DeviceRotation.current()
-                )
-            }
-            // SpringBoard contributes alert bounds through a second XCUI snapshot. Require its
-            // capture-time orientation and the final sample to agree with the app snapshot; this
-            // makes a rotation anywhere across either hierarchy-producing IPC fail closed.
-            let rotationAfterHierarchyCapture = try runOnMainThread { DeviceRotation.current() }
+            let (currentScreenMetrics, afterHierarchyCapture): (ScreenMetrics, RotationCaptureSample) =
+                try runOnMainThread {
+                    let scale = Float(UIScreen.main.scale)
+                    let nativeScale = Float(UIScreen.main.nativeScale)
+                    let bounds = UIScreen.main.bounds
+                    let captureSample = DeviceRotation.captureSample()
+                    return (
+                        ScreenMetrics(
+                            scale: scale,
+                            nativeScale: nativeScale,
+                            fallbackWidth: Int(bounds.width),
+                            fallbackHeight: Int(bounds.height),
+                            rotation: captureSample.rotation
+                        ),
+                        captureSample
+                    )
+                }
+            // SpringBoard contributes alert bounds through a second XCUI snapshot. Require each
+            // capture's rotation and the process-lifetime epoch to agree across the complete
+            // hierarchy assembly.
             let hierarchyRotation: Int?
             if screenMetrics.rotation == systemAlertCapture.rotation,
                screenMetrics.rotation == currentScreenMetrics.rotation,
-               screenMetrics.rotation == rotationAfterHierarchyCapture
+               screenMetrics.rotation == RotationCaptureSample.stableRotation(
+                   between: beforeHierarchyCapture,
+                   and: afterHierarchyCapture
+               )
             {
                 hierarchyRotation = screenMetrics.rotation
             } else {

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -3,8 +3,10 @@ import ObjCExceptionCatcher
 #if canImport(os)
     import os
 #endif
-#if canImport(XCTest) && os(iOS)
+#if os(iOS)
     import UIKit
+#endif
+#if canImport(XCTest) && os(iOS)
     import XCTest
 #endif
 
@@ -142,16 +144,6 @@ enum DeviceRotation {
                 default: return nil
                 }
             }
-
-            func currentGestureInterfaceOrientation() -> UIInterfaceOrientation {
-                switch XCUIDevice.shared.orientation {
-                case .portrait: return .portrait
-                case .landscapeLeft: return .landscapeLeft
-                case .portraitUpsideDown: return .portraitUpsideDown
-                case .landscapeRight: return .landscapeRight
-                default: return .portrait
-                }
-            }
         }
 
         private static let rotationSampler = XCUIDeviceRotationSampler()
@@ -175,8 +167,53 @@ enum DeviceRotation {
             rotationSampler.currentRotation()
         }
 
+    #endif
+
+    #if os(iOS)
         static func currentGestureInterfaceOrientation() -> UIInterfaceOrientation {
-            rotationSampler.currentGestureInterfaceOrientation()
+            let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+            let activeSceneOrientation = scenes.first(where: {
+                $0.activationState == .foregroundActive && isCardinalInterfaceOrientation($0.interfaceOrientation)
+            })?.interfaceOrientation
+            let sceneOrientation = scenes.first(where: {
+                isCardinalInterfaceOrientation($0.interfaceOrientation)
+            })?.interfaceOrientation
+
+            return gestureInterfaceOrientation(
+                activeSceneOrientation: activeSceneOrientation,
+                sceneOrientation: sceneOrientation,
+                deviceOrientation: UIDevice.current.orientation
+            )
+        }
+
+        static func gestureInterfaceOrientation(
+            activeSceneOrientation: UIInterfaceOrientation?,
+            sceneOrientation: UIInterfaceOrientation?,
+            deviceOrientation: UIDeviceOrientation
+        ) -> UIInterfaceOrientation {
+            if let activeSceneOrientation, isCardinalInterfaceOrientation(activeSceneOrientation) {
+                return activeSceneOrientation
+            }
+            if let sceneOrientation, isCardinalInterfaceOrientation(sceneOrientation) {
+                return sceneOrientation
+            }
+
+            switch deviceOrientation {
+            case .portrait: return .portrait
+            case .portraitUpsideDown: return .portraitUpsideDown
+            case .landscapeLeft: return .landscapeLeft
+            case .landscapeRight: return .landscapeRight
+            default: return .portrait
+            }
+        }
+
+        private static func isCardinalInterfaceOrientation(_ orientation: UIInterfaceOrientation) -> Bool {
+            switch orientation {
+            case .portrait, .landscapeLeft, .portraitUpsideDown, .landscapeRight:
+                return true
+            default:
+                return false
+            }
         }
     #endif
 }

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -69,13 +69,17 @@ final class RotationChangeMonitor {
         }
     }
 
+    func captureSample(using sampler: RotationSampling) -> RotationCaptureSample {
+        changeGeneration.captureSample(rotation: sampler.currentRotation())
+    }
+
     func capture<T>(
         using sampler: RotationSampling,
         _ operation: () throws -> T
     ) rethrows -> (value: T, rotation: Int?) {
-        let beforeCapture = changeGeneration.captureSample(rotation: sampler.currentRotation())
+        let beforeCapture = captureSample(using: sampler)
         let value = try operation()
-        let afterCapture = changeGeneration.captureSample(rotation: sampler.currentRotation())
+        let afterCapture = captureSample(using: sampler)
         return (
             value,
             RotationCaptureSample.stableRotation(between: beforeCapture, and: afterCapture)
@@ -161,6 +165,10 @@ enum DeviceRotation {
 
         static func capture<T>(_ operation: () throws -> T) rethrows -> (value: T, rotation: Int?) {
             try changeMonitor.capture(using: rotationSampler, operation)
+        }
+
+        static func captureSample() -> RotationCaptureSample {
+            changeMonitor.captureSample(using: rotationSampler)
         }
 
         static func current() -> Int? {

--- a/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/GesturePerformer.swift
@@ -49,6 +49,40 @@ final class RotationChangeGeneration {
     }
 }
 
+protocol RotationSampling {
+    func currentRotation() -> Int?
+}
+
+protocol RotationChangeSignaling: AnyObject {
+    func startObserving(_ handler: @escaping () -> Void)
+}
+
+/// Keeps a process-lifetime rotation epoch separate from synchronous XCUI capture work.
+final class RotationChangeMonitor {
+    private let changeGeneration = RotationChangeGeneration()
+    private let signal: RotationChangeSignaling
+
+    init(signal: RotationChangeSignaling) {
+        self.signal = signal
+        signal.startObserving { [weak self] in
+            self?.changeGeneration.recordOrientationChange()
+        }
+    }
+
+    func capture<T>(
+        using sampler: RotationSampling,
+        _ operation: () throws -> T
+    ) rethrows -> (value: T, rotation: Int?) {
+        let beforeCapture = changeGeneration.captureSample(rotation: sampler.currentRotation())
+        let value = try operation()
+        let afterCapture = changeGeneration.captureSample(rotation: sampler.currentRotation())
+        return (
+            value,
+            RotationCaptureSample.stableRotation(between: beforeCapture, and: afterCapture)
+        )
+    }
+}
+
 /// Maps platform orientation observations to the rotation epoch shared by hierarchy and screenshot
 /// frames. A value is intentionally absent when the platform cannot identify an interface rotation.
 enum DeviceRotation {
@@ -63,74 +97,78 @@ enum DeviceRotation {
     }
 
     #if canImport(XCTest) && os(iOS)
-        /// Captures a value while observing every orientation transition that occurs in the capture
-        /// interval. The observer is deliberately scoped to this operation: it detects an A→B→A
-        /// cycle without keeping a process-lifetime notification registration alive.
-        static func capture<T>(_ operation: () throws -> T) rethrows -> (value: T, rotation: Int?) {
-            let changeGeneration = RotationChangeGeneration()
-            UIDevice.current.beginGeneratingDeviceOrientationNotifications()
-            let orientationChangeObserver = NotificationCenter.default.addObserver(
-                forName: UIDevice.orientationDidChangeNotification,
-                object: UIDevice.current,
-                queue: nil
-            ) { _ in
-                changeGeneration.recordOrientationChange()
-            }
-            let beforeCapture = changeGeneration.captureSample(rotation: current())
-            defer {
-                NotificationCenter.default.removeObserver(orientationChangeObserver)
-                UIDevice.current.endGeneratingDeviceOrientationNotifications()
+        private final class DeviceOrientationChangeSignal: RotationChangeSignaling {
+            private let deliveryQueue: OperationQueue = {
+                let queue = OperationQueue()
+                queue.name = "dev.jasonpearson.automobile.ctrlproxy.device-orientation"
+                queue.maxConcurrentOperationCount = 1
+                return queue
+            }()
+            private var observer: NSObjectProtocol?
+
+            init() {
+                UIDevice.current.beginGeneratingDeviceOrientationNotifications()
             }
 
-            let value = try operation()
-            let afterCapture = changeGeneration.captureSample(rotation: current())
-            return (
-                value,
-                RotationCaptureSample.stableRotation(between: beforeCapture, and: afterCapture)
-            )
+            func startObserving(_ handler: @escaping () -> Void) {
+                observer = NotificationCenter.default.addObserver(
+                    forName: UIDevice.orientationDidChangeNotification,
+                    object: UIDevice.current,
+                    queue: deliveryQueue
+                ) { _ in
+                    handler()
+                }
+            }
+
+            deinit {
+                if let observer {
+                    NotificationCenter.default.removeObserver(observer)
+                }
+                UIDevice.current.endGeneratingDeviceOrientationNotifications()
+            }
+        }
+
+        private final class XCUIDeviceRotationSampler: RotationSampling {
+            func currentRotation() -> Int? {
+                switch XCUIDevice.shared.orientation {
+                case .portrait: return 0
+                case .landscapeLeft: return 1
+                case .portraitUpsideDown: return 2
+                case .landscapeRight: return 3
+                default: return nil
+                }
+            }
+
+            func currentGestureInterfaceOrientation() -> UIInterfaceOrientation {
+                switch XCUIDevice.shared.orientation {
+                case .portrait: return .portrait
+                case .landscapeLeft: return .landscapeLeft
+                case .portraitUpsideDown: return .portraitUpsideDown
+                case .landscapeRight: return .landscapeRight
+                default: return .portrait
+                }
+            }
+        }
+
+        private static let rotationSampler = XCUIDeviceRotationSampler()
+        private static let changeMonitor = RotationChangeMonitor(signal: DeviceOrientationChangeSignal())
+
+        /// Must be called while constructing the capture owners, before any synchronous XCUI work
+        /// can block the runner's main thread.
+        static func startMonitoring() {
+            _ = changeMonitor
+        }
+
+        static func capture<T>(_ operation: () throws -> T) rethrows -> (value: T, rotation: Int?) {
+            try changeMonitor.capture(using: rotationSampler, operation)
         }
 
         static func current() -> Int? {
-            fromInterfaceOrientation(currentInterfaceOrientation(fallback: .unknown))
-        }
-
-        static func fromInterfaceOrientation(_ orientation: UIInterfaceOrientation) -> Int? {
-            switch orientation {
-            case .portrait: return 0
-            case .landscapeLeft: return 1
-            case .portraitUpsideDown: return 2
-            case .landscapeRight: return 3
-            default: return nil
-            }
+            rotationSampler.currentRotation()
         }
 
         static func currentGestureInterfaceOrientation() -> UIInterfaceOrientation {
-            currentInterfaceOrientation(fallback: .portrait)
-        }
-
-        private static func currentInterfaceOrientation(fallback: UIInterfaceOrientation) -> UIInterfaceOrientation {
-            let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
-            if let activeScene = scenes.first(where: {
-                $0.activationState == .foregroundActive && fromInterfaceOrientation($0.interfaceOrientation) != nil
-            }) {
-                return activeScene.interfaceOrientation
-            }
-            if let scene = scenes.first(where: { fromInterfaceOrientation($0.interfaceOrientation) != nil }) {
-                return scene.interfaceOrientation
-            }
-
-            switch UIDevice.current.orientation {
-            case .portrait:
-                return .portrait
-            case .portraitUpsideDown:
-                return .portraitUpsideDown
-            case .landscapeLeft:
-                return .landscapeLeft
-            case .landscapeRight:
-                return .landscapeRight
-            default:
-                return fallback
-            }
+            rotationSampler.currentGestureInterfaceOrientation()
         }
     #endif
 }
@@ -251,6 +289,7 @@ public class GesturePerformer: GesturePerforming {
         private lazy var springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
 
         public init(application: XCUIApplication? = nil, elementLocator: ElementLocating) {
+            DeviceRotation.startMonitoring()
             self.application = application
             self.elementLocator = elementLocator
         }

--- a/ios/control-proxy/Tests/CtrlProxyTests/RotationChangeGenerationTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/RotationChangeGenerationTests.swift
@@ -1,6 +1,10 @@
 @testable import CtrlProxy
 import XCTest
 
+#if os(iOS)
+    import UIKit
+#endif
+
 private final class FakeRotationChangeSignal: RotationChangeSignaling {
     private var handler: (() -> Void)?
 
@@ -83,4 +87,16 @@ final class RotationChangeGenerationTests: XCTestCase {
 
         XCTAssertEqual(monitor.capture(using: sampler) { "capture" }.rotation, 3)
     }
+
+    #if os(iOS)
+        func testGestureOrientationKeepsLandscapeSceneWhenDeviceIsFaceUp() {
+            let orientation = DeviceRotation.gestureInterfaceOrientation(
+                activeSceneOrientation: .landscapeLeft,
+                sceneOrientation: .portrait,
+                deviceOrientation: .faceUp
+            )
+
+            XCTAssertEqual(orientation, .landscapeLeft)
+        }
+    #endif
 }

--- a/ios/control-proxy/Tests/CtrlProxyTests/RotationChangeGenerationTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/RotationChangeGenerationTests.swift
@@ -1,30 +1,64 @@
 @testable import CtrlProxy
 import XCTest
 
+private final class FakeRotationChangeSignal: RotationChangeSignaling {
+    private var handler: (() -> Void)?
+
+    func startObserving(_ handler: @escaping () -> Void) {
+        self.handler = handler
+    }
+
+    func sendOrientationChange() {
+        handler?()
+    }
+}
+
+private final class FakeRotationSampler: RotationSampling {
+    var rotation: Int?
+
+    init(rotation: Int?) {
+        self.rotation = rotation
+    }
+
+    func currentRotation() -> Int? {
+        rotation
+    }
+}
+
 final class RotationChangeGenerationTests: XCTestCase {
-    func testRejectsABARotationDuringCapture() {
-        let generation = RotationChangeGeneration()
-        let beforeCapture = generation.captureSample(rotation: 0)
+    func testUsesDeviceRotationSamplerInsteadOfAnyRunnerSceneValue() {
+        let signal = FakeRotationChangeSignal()
+        let sampler = FakeRotationSampler(rotation: 1)
+        let monitor = RotationChangeMonitor(signal: signal)
 
-        generation.recordOrientationChange()
-        generation.recordOrientationChange()
+        let capture = monitor.capture(using: sampler) { "capture" }
 
-        let afterCapture = generation.captureSample(rotation: 0)
+        XCTAssertEqual(capture.value, "capture")
+        XCTAssertEqual(capture.rotation, 1)
+    }
 
-        XCTAssertNil(
-            RotationCaptureSample.stableRotation(between: beforeCapture, and: afterCapture),
-            "A→B→A must invalidate capture rotation even when endpoint orientation returns to A"
-        )
+    func testRejectsABARotationWhenChangeSignalDeliversDuringCapture() {
+        let signal = FakeRotationChangeSignal()
+        let sampler = FakeRotationSampler(rotation: 0)
+        let monitor = RotationChangeMonitor(signal: signal)
+
+        let capture = monitor.capture(using: sampler) {
+            sampler.rotation = 1
+            signal.sendOrientationChange()
+            sampler.rotation = 0
+            signal.sendOrientationChange()
+            return "capture"
+        }
+
+        XCTAssertEqual(capture.value, "capture")
+        XCTAssertNil(capture.rotation, "A→B→A must invalidate capture rotation")
     }
 
     func testKeepsRotationWhenNoOrientationChangeOccursDuringCapture() {
-        let generation = RotationChangeGeneration()
-        let beforeCapture = generation.captureSample(rotation: 3)
-        let afterCapture = generation.captureSample(rotation: 3)
+        let signal = FakeRotationChangeSignal()
+        let sampler = FakeRotationSampler(rotation: 3)
+        let monitor = RotationChangeMonitor(signal: signal)
 
-        XCTAssertEqual(
-            RotationCaptureSample.stableRotation(between: beforeCapture, and: afterCapture),
-            3
-        )
+        XCTAssertEqual(monitor.capture(using: sampler) { "capture" }.rotation, 3)
     }
 }

--- a/ios/control-proxy/Tests/CtrlProxyTests/RotationChangeGenerationTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/RotationChangeGenerationTests.swift
@@ -26,7 +26,7 @@ private final class FakeRotationSampler: RotationSampling {
 }
 
 final class RotationChangeGenerationTests: XCTestCase {
-    func testUsesDeviceRotationSamplerInsteadOfAnyRunnerSceneValue() {
+    func testCapturesRotationUsingInjectedSampler() {
         let signal = FakeRotationChangeSignal()
         let sampler = FakeRotationSampler(rotation: 1)
         let monitor = RotationChangeMonitor(signal: signal)
@@ -52,6 +52,28 @@ final class RotationChangeGenerationTests: XCTestCase {
 
         XCTAssertEqual(capture.value, "capture")
         XCTAssertNil(capture.rotation, "A→B→A must invalidate capture rotation")
+    }
+
+    func testRejectsABARotationBetweenHierarchyCapturePhases() {
+        let signal = FakeRotationChangeSignal()
+        let sampler = FakeRotationSampler(rotation: 0)
+        let monitor = RotationChangeMonitor(signal: signal)
+
+        let beforeHierarchy = monitor.captureSample(using: sampler)
+        XCTAssertEqual(monitor.capture(using: sampler) { "app snapshot" }.rotation, 0)
+
+        sampler.rotation = 1
+        signal.sendOrientationChange()
+        sampler.rotation = 0
+        signal.sendOrientationChange()
+
+        XCTAssertEqual(monitor.capture(using: sampler) { "SpringBoard snapshot" }.rotation, 0)
+        let afterHierarchy = monitor.captureSample(using: sampler)
+
+        XCTAssertNil(
+            RotationCaptureSample.stableRotation(between: beforeHierarchy, and: afterHierarchy),
+            "A→B→A between the app and SpringBoard snapshots must invalidate hierarchy rotation"
+        )
     }
 
     func testKeepsRotationWhenNoOrientationChangeOccursDuringCapture() {


### PR DESCRIPTION
## Summary

Use `XCUIDevice.shared.orientation` rather than the runner scene to stamp iOS hierarchy and screenshot captures. A process-lifetime monitor now tracks device-orientation notifications on a dedicated queue and invalidates a capture when its rotation epoch changes, including A-to-B-to-A transitions. The hierarchy path retains that epoch across both the app and SpringBoard snapshots. The monitor exposes sampler and signal interfaces so the regression test drives signal delivery through fakes.

Publishing this behavior requires the next tagged CtrlProxy release. Nightly checksum updates are a drift record, not a downloadable runner artifact.

## Linked Issue

Tracks [#4606](https://github.com/kaeawc/auto-mobile/issues/4606). A future tagged-release pull request must carry the closing link after publishing the rebuilt runner.

## Bug / Regression Context

- **Prior attempts:** [#4562](https://github.com/kaeawc/auto-mobile/pull/4562) added capture-time rotation provenance.
- **Observed symptom:** a capture could be stamped with the test runner's scene orientation or remain trusted through a rotation while synchronous XCUI work blocked the main thread.
- **Repro steps / conditions:** rotate the automated app during hierarchy snapshot or screenshot capture, including a return to the original orientation before capture completes.

## Validation

- [x] `bun run turbo:validate` passes (11,968 tests passed; 13 expected integration skips)
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] iOS validation: focused rotation tests, full CtrlProxy Swift suite (447 tests), `xcodebuild build-for-testing`, and touched-file SwiftLint
- [x] New code uses interfaces and fakes; focused unit tests remain fast and deterministic
- [x] No new generic dependency or helper was added
- [x] Based on current `origin/main` at `217207cb87bab9e5cfb3ee738ed9dc1a9f280d1b`

## Device Verification

- [ ] Not run manually; the regression uses fake rotation sampling and signal delivery, and the iOS test bundles compile successfully.

## Follow-ups

- [x] No follow-up issue needed; Android tracking remains separate in [#4605](https://github.com/kaeawc/auto-mobile/issues/4605).
