### PR TITLE
fix(android): prove CtrlProxy rotation changes

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -334,6 +334,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
   private val timeProvider: TimeProvider = SystemTimeProvider()
   private lateinit var webSocketServer: WebSocketServer
   private lateinit var hierarchyDebouncer: HierarchyDebouncer
+  private lateinit var rotationProvenance: RotationProvenanceTracker
   private var hierarchyBroadcastThrottler: BroadcastThrottler? = null
   private val navigationEventAccumulator = NavigationEventAccumulator()
   private lateinit var overlayManager: OverlayManager
@@ -829,6 +830,12 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     }
 
     try {
+      rotationProvenance =
+        RotationProvenanceTracker(
+          DisplayRotationChangeSignal(
+            getSystemService(Context.DISPLAY_SERVICE) as? android.hardware.display.DisplayManager
+          )
+        )
       overlayDrawer = OverlayDrawer(screenDimensionsProvider = { getScreenDimensions() })
       overlayManager =
         OverlayManager(this, viewFactory = { HighlightOverlayView(it, overlayDrawer) })
@@ -1119,6 +1126,10 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
       unregisterReceiver(screenStateReceiver)
     } catch (e: Exception) {
       Log.e(TAG, "Error unregistering screen state receiver", e)
+    }
+
+    if (::rotationProvenance.isInitialized) {
+      rotationProvenance.close()
     }
 
     // Stop logcat reader
@@ -2188,7 +2199,8 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     val contextAtExtractionStart = currentFrameContext()
     // Bracket every input acquisition and the extraction itself. If rotation changes anywhere in
     // that interval, hierarchy geometry cannot be proven to match a single display orientation.
-    val rotationBeforeExtraction = getRotationOrNull()
+    val rotationCapture = rotationProvenance.beginCapture()
+    val rotationAtCaptureStart = getRotationOrNull()
     // Get all windows to capture popups, toolbars, and other floating windows
     val allWindows = windows
     val rootNode = rootInActiveWindow
@@ -2231,9 +2243,12 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         )
       }
 
-    val rotationAfterExtraction = getRotationOrNull()
     val rotation =
-      if (rotationBeforeExtraction == rotationAfterExtraction) rotationAfterExtraction else null
+      rotationProvenance.rotationIfUnchanged(
+        rotationCapture,
+        rotationAtCaptureStart,
+        getRotationOrNull(),
+      )
 
     // Add device metadata to the hierarchy (eliminates need for dumpsys calls on client)
     val wakefulness = getWakefulness()
@@ -2375,7 +2390,8 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     // This is the synchronous ADB-broadcast fallback, not the debounced direct route above. It
     // must bracket the same inputs and extraction so the fallback never publishes a hierarchy
     // whose geometry and rotation came from different display states.
-    val rotationBeforeExtraction = getRotationOrNull()
+    val rotationCapture = rotationProvenance.beginCapture()
+    val rotationAtCaptureStart = getRotationOrNull()
     val allWindows = windows
     val rootNode = rootInActiveWindow
     val screenDimensions = getScreenDimensions()
@@ -2409,9 +2425,12 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
           disableAllFiltering,
         )
       }
-    val rotationAfterExtraction = getRotationOrNull()
     val rotation =
-      if (rotationBeforeExtraction == rotationAfterExtraction) rotationAfterExtraction else null
+      rotationProvenance.rotationIfUnchanged(
+        rotationCapture,
+        rotationAtCaptureStart,
+        getRotationOrNull(),
+      )
     // The ADB EXTRACT_HIERARCHY route must carry the #4548 scale metadata too (this route does not
     // add the other device metadata, but the daemon retains scale metadata off any route).
     val hierarchyWithScaleMetadata =
@@ -2565,7 +2584,8 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
         val startTime = System.currentTimeMillis()
 
         // Use suspendCancellableCoroutine to bridge callback-based API
-        val rotationBeforeCapture = getRotationOrNull()
+        val rotationCapture = rotationProvenance.beginCapture()
+        val rotationAtCaptureStart = getRotationOrNull()
         val captured =
           suspendCancellableCoroutine<Pair<Bitmap, Int?>?> { continuation ->
             takeScreenshot(
@@ -2583,12 +2603,14 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
                     continuation.resume(null)
                     return
                   }
-                  val rotationAfterCapture = getRotationOrNull()
-                  // A changed rotation makes the pixels' orientation ambiguous. Preserve that
+                  // A display change makes the pixels' orientation ambiguous. Preserve that
                   // ambiguity as null so desktop control fails closed rather than guessing.
                   val rotation =
-                    if (rotationBeforeCapture == rotationAfterCapture) rotationAfterCapture
-                    else null
+                    rotationProvenance.rotationIfUnchanged(
+                      rotationCapture,
+                      rotationAtCaptureStart,
+                      getRotationOrNull(),
+                    )
                   continuation.resume(hardwareBitmap to rotation)
                 }
 

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/RotationProvenanceTracker.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/RotationProvenanceTracker.kt
@@ -1,13 +1,22 @@
 package dev.jasonpearson.automobile.ctrlproxy
 
 import android.hardware.display.DisplayManager
+import android.os.Handler
+import android.os.HandlerThread
 import android.view.Display
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 
 /** Delivers changes that can invalidate the rotation proven for an in-flight capture. */
 internal interface RotationChangeSignal {
   /** Returns false when the platform cannot provide the required change notifications. */
   fun register(listener: () -> Unit): Boolean
+
+  /**
+   * Drains notifications observed before this barrier, returning false if that cannot be proven.
+   */
+  fun synchronize(): Boolean
 
   fun unregister()
 }
@@ -19,10 +28,14 @@ internal interface RotationChangeSignal {
 internal class DisplayRotationChangeSignal(private val displayManager: DisplayManager?) :
   RotationChangeSignal {
   private var displayListener: DisplayManager.DisplayListener? = null
+  private var callbackHandler: Handler? = null
+  private var callbackThread: HandlerThread? = null
 
   override fun register(listener: () -> Unit): Boolean {
     check(displayListener == null) { "Display change listener is already registered" }
     val manager = displayManager ?: return false
+    val thread = HandlerThread("CtrlProxyRotationChanges").apply { start() }
+    val handler = Handler(thread.looper)
     val registeredListener =
       object : DisplayManager.DisplayListener {
         override fun onDisplayAdded(displayId: Int) = Unit
@@ -35,15 +48,36 @@ internal class DisplayRotationChangeSignal(private val displayManager: DisplayMa
 
         override fun onDisplayRemoved(displayId: Int) = Unit
       }
-    manager.registerDisplayListener(registeredListener, null)
+    try {
+      manager.registerDisplayListener(registeredListener, handler)
+    } catch (e: Exception) {
+      thread.quitSafely()
+      throw e
+    }
     displayListener = registeredListener
+    callbackHandler = handler
+    callbackThread = thread
     return true
+  }
+
+  override fun synchronize(): Boolean {
+    val handler = callbackHandler ?: return false
+    val barrier = CountDownLatch(1)
+    if (!handler.post { barrier.countDown() }) return false
+    return barrier.await(CALLBACK_DRAIN_TIMEOUT_MS, TimeUnit.MILLISECONDS)
   }
 
   override fun unregister() {
     val listener = displayListener ?: return
     displayManager?.unregisterDisplayListener(listener)
     displayListener = null
+    callbackHandler = null
+    callbackThread?.quitSafely()
+    callbackThread = null
+  }
+
+  private companion object {
+    const val CALLBACK_DRAIN_TIMEOUT_MS = 1_000L
   }
 }
 
@@ -69,16 +103,16 @@ internal class RotationProvenanceTracker(private val changeSignal: RotationChang
     captureGeneration: Long,
     rotationAtCaptureStart: Int?,
     rotationAtCaptureEnd: Int?,
-  ): Int? =
-    if (
-      isRegistered &&
-        captureGeneration == generation.get() &&
-        rotationAtCaptureStart == rotationAtCaptureEnd
+  ): Int? {
+    if (!isRegistered || !changeSignal.synchronize()) return null
+    return if (
+      captureGeneration == generation.get() && rotationAtCaptureStart == rotationAtCaptureEnd
     ) {
       rotationAtCaptureEnd
     } else {
       null
     }
+  }
 
   override fun close() {
     changeSignal.unregister()

--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/RotationProvenanceTracker.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/RotationProvenanceTracker.kt
@@ -1,0 +1,87 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import android.hardware.display.DisplayManager
+import android.view.Display
+import java.util.concurrent.atomic.AtomicLong
+
+/** Delivers changes that can invalidate the rotation proven for an in-flight capture. */
+internal interface RotationChangeSignal {
+  /** Returns false when the platform cannot provide the required change notifications. */
+  fun register(listener: () -> Unit): Boolean
+
+  fun unregister()
+}
+
+/**
+ * Android's default-display callback. Any display change advances provenance because a capture
+ * cannot safely distinguish which display state produced its pixels or hierarchy.
+ */
+internal class DisplayRotationChangeSignal(private val displayManager: DisplayManager?) :
+  RotationChangeSignal {
+  private var displayListener: DisplayManager.DisplayListener? = null
+
+  override fun register(listener: () -> Unit): Boolean {
+    check(displayListener == null) { "Display change listener is already registered" }
+    val manager = displayManager ?: return false
+    val registeredListener =
+      object : DisplayManager.DisplayListener {
+        override fun onDisplayAdded(displayId: Int) = Unit
+
+        override fun onDisplayChanged(displayId: Int) {
+          if (displayId == Display.DEFAULT_DISPLAY) {
+            listener()
+          }
+        }
+
+        override fun onDisplayRemoved(displayId: Int) = Unit
+      }
+    manager.registerDisplayListener(registeredListener, null)
+    displayListener = registeredListener
+    return true
+  }
+
+  override fun unregister() {
+    val listener = displayListener ?: return
+    displayManager?.unregisterDisplayListener(listener)
+    displayListener = null
+  }
+}
+
+/**
+ * Associates a rotation sample with a display-change generation.
+ *
+ * Endpoint rotation equality catches a transition when its display callback has not yet run, but it
+ * misses A -> B -> A. The default-display callback increments [generation] for every change, so a
+ * matching end rotation is only trusted if neither guard observed a transition.
+ */
+internal class RotationProvenanceTracker(private val changeSignal: RotationChangeSignal) :
+  AutoCloseable {
+  private val generation = AtomicLong(0)
+  @Volatile private var isRegistered = false
+
+  init {
+    isRegistered = changeSignal.register { generation.incrementAndGet() }
+  }
+
+  fun beginCapture(): Long = generation.get()
+
+  fun rotationIfUnchanged(
+    captureGeneration: Long,
+    rotationAtCaptureStart: Int?,
+    rotationAtCaptureEnd: Int?,
+  ): Int? =
+    if (
+      isRegistered &&
+        captureGeneration == generation.get() &&
+        rotationAtCaptureStart == rotationAtCaptureEnd
+    ) {
+      rotationAtCaptureEnd
+    } else {
+      null
+    }
+
+  override fun close() {
+    changeSignal.unregister()
+    isRegistered = false
+  }
+}

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/RotationProvenanceTrackerTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/RotationProvenanceTrackerTest.kt
@@ -1,0 +1,152 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+class RotationProvenanceTrackerTest {
+
+  @Test
+  fun `A to B to A display changes make the capture rotation unproven`() {
+    val changes = FakeRotationChangeSignal()
+    val provenance = RotationProvenanceTracker(changes)
+
+    val capture = provenance.beginCapture()
+    changes.emitRotationChanged(1)
+    changes.emitRotationChanged(0)
+
+    assertNull(
+      provenance.rotationIfUnchanged(
+        capture,
+        rotationAtCaptureStart = 0,
+        rotationAtCaptureEnd = changes.rotation,
+      )
+    )
+  }
+
+  @Test
+  fun `a capture without a display change keeps its rotation`() {
+    val provenance = RotationProvenanceTracker(FakeRotationChangeSignal())
+
+    val capture = provenance.beginCapture()
+
+    assertEquals(
+      1,
+      provenance.rotationIfUnchanged(
+        capture,
+        rotationAtCaptureStart = 1,
+        rotationAtCaptureEnd = 1,
+      ),
+    )
+  }
+
+  @Test
+  fun `a changed rotation is unproven before its callback is delivered`() {
+    val provenance = RotationProvenanceTracker(FakeRotationChangeSignal())
+
+    val capture = provenance.beginCapture()
+
+    assertNull(
+      provenance.rotationIfUnchanged(
+        capture,
+        rotationAtCaptureStart = 0,
+        rotationAtCaptureEnd = 1,
+      )
+    )
+  }
+
+  @Test
+  fun `closing unregisters the display change callback`() {
+    val changes = FakeRotationChangeSignal()
+    val provenance = RotationProvenanceTracker(changes)
+
+    assertTrue(changes.isRegistered)
+
+    provenance.close()
+
+    assertFalse(changes.isRegistered)
+  }
+
+  @Test
+  fun `all capture routes use rotation provenance instead of endpoint equality`() {
+    val source = KotlinSourceScan.maskLiteralsAndComments(locateCtrlProxySource().readText())
+
+    for (route in
+      listOf(
+        "private fun extractHierarchyDirect",
+        "private fun extractHierarchy(",
+        "private suspend fun takeScreenshotAsync",
+      )) {
+      val start = source.indexOf(route)
+      assertTrue("$route not found in CtrlProxy.kt", start >= 0)
+      val bodyOpen = source.indexOf('{', start)
+      val body = source.substring(bodyOpen, KotlinSourceScan.matchBrace(source, bodyOpen))
+      assertTrue(
+        "$route must capture the display-change generation before acquiring capture inputs",
+        "rotationProvenance.beginCapture()" in body,
+      )
+      assertTrue(
+        "$route must retain rotation only when the display-change generation is stable",
+        "rotationProvenance.rotationIfUnchanged(" in body,
+      )
+      assertTrue(
+        "$route must retain the previous endpoint rotation guard until display callbacks arrive",
+        "rotationAtCaptureStart" in body,
+      )
+      assertFalse(
+        "$route must not rely on endpoint rotation equality, which misses A -> B -> A",
+        "rotationBefore" in body,
+      )
+    }
+  }
+
+  private class FakeRotationChangeSignal : RotationChangeSignal {
+    private var listener: (() -> Unit)? = null
+    var rotation: Int = 0
+      private set
+
+    val isRegistered: Boolean
+      get() = listener != null
+
+    override fun register(listener: () -> Unit): Boolean {
+      this.listener = listener
+      return true
+    }
+
+    override fun unregister() {
+      listener = null
+    }
+
+    fun emitRotationChanged(rotation: Int) {
+      this.rotation = rotation
+      requireNotNull(listener).invoke()
+    }
+  }
+
+  private fun locateCtrlProxySource(): File {
+    val rel = "src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt"
+    val direct =
+      listOf(File(rel), File("control-proxy/$rel"), File("android/control-proxy/$rel"))
+        .firstOrNull { it.isFile }
+    if (direct != null) return direct
+
+    var directory: File? = File(System.getProperty("user.dir") ?: ".").absoluteFile
+    while (directory != null) {
+      for (candidate in
+        listOf(
+          File(directory, rel),
+          File(directory, "control-proxy/$rel"),
+          File(directory, "android/control-proxy/$rel"),
+        )) {
+        if (candidate.isFile) return candidate
+      }
+      directory = directory.parentFile
+    }
+    fail("Could not locate CtrlProxy.kt from user.dir=${System.getProperty("user.dir")}")
+    error("unreachable")
+  }
+}

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/RotationProvenanceTrackerTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/RotationProvenanceTrackerTest.kt
@@ -11,7 +11,7 @@ import org.junit.Test
 class RotationProvenanceTrackerTest {
 
   @Test
-  fun `A to B to A display changes make the capture rotation unproven`() {
+  fun `queued A to B to A display changes make the capture rotation unproven`() {
     val changes = FakeRotationChangeSignal()
     val provenance = RotationProvenanceTracker(changes)
 
@@ -19,6 +19,7 @@ class RotationProvenanceTrackerTest {
     changes.emitRotationChanged(1)
     changes.emitRotationChanged(0)
 
+    assertEquals(2, changes.pendingChangeCount)
     assertNull(
       provenance.rotationIfUnchanged(
         capture,
@@ -26,6 +27,7 @@ class RotationProvenanceTrackerTest {
         rotationAtCaptureEnd = changes.rotation,
       )
     )
+    assertEquals(0, changes.pendingChangeCount)
   }
 
   @Test
@@ -55,6 +57,21 @@ class RotationProvenanceTrackerTest {
         capture,
         rotationAtCaptureStart = 0,
         rotationAtCaptureEnd = 1,
+      )
+    )
+  }
+
+  @Test
+  fun `a capture is unproven when its callback queue cannot be drained`() {
+    val provenance = RotationProvenanceTracker(FakeRotationChangeSignal(synchronizeResult = false))
+
+    val capture = provenance.beginCapture()
+
+    assertNull(
+      provenance.rotationIfUnchanged(
+        capture,
+        rotationAtCaptureStart = 0,
+        rotationAtCaptureEnd = 0,
       )
     )
   }
@@ -104,26 +121,40 @@ class RotationProvenanceTrackerTest {
     }
   }
 
-  private class FakeRotationChangeSignal : RotationChangeSignal {
+  private class FakeRotationChangeSignal(private val synchronizeResult: Boolean = true) :
+    RotationChangeSignal {
     private var listener: (() -> Unit)? = null
+    private val pendingListeners = mutableListOf<() -> Unit>()
     var rotation: Int = 0
       private set
 
     val isRegistered: Boolean
       get() = listener != null
 
+    val pendingChangeCount: Int
+      get() = pendingListeners.size
+
     override fun register(listener: () -> Unit): Boolean {
       this.listener = listener
       return true
     }
 
+    override fun synchronize(): Boolean {
+      if (!synchronizeResult) return false
+      val queuedListeners = pendingListeners.toList()
+      pendingListeners.clear()
+      queuedListeners.forEach { it.invoke() }
+      return true
+    }
+
     override fun unregister() {
       listener = null
+      pendingListeners.clear()
     }
 
     fun emitRotationChanged(rotation: Int) {
       this.rotation = rotation
-      requireNotNull(listener).invoke()
+      pendingListeners += requireNotNull(listener)
     }
   }
 

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyScaleMetadataTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/ViewHierarchyScaleMetadataTest.kt
@@ -135,12 +135,16 @@ class ViewHierarchyScaleMetadataTest {
     val body = source.substring(bodyOpen, KotlinSourceScan.matchBrace(source, bodyOpen))
 
     assertTrue(
-      "ADB fallback must sample rotation before hierarchy inputs",
-      "val rotationBeforeExtraction = getRotationOrNull()" in body,
+      "ADB fallback must capture the display-change generation before hierarchy inputs",
+      "val rotationCapture = rotationProvenance.beginCapture()" in body,
     )
     assertTrue(
-      "ADB fallback must sample rotation after hierarchy extraction",
-      "val rotationAfterExtraction = getRotationOrNull()" in body,
+      "ADB fallback must retain rotation only when the display-change generation is stable",
+      "rotationProvenance.rotationIfUnchanged(" in body,
+    )
+    assertTrue(
+      "ADB fallback must retain the prior endpoint guard until display callbacks arrive",
+      "rotationAtCaptureStart" in body,
     )
     assertTrue(
       "ADB fallback must stamp only a stable rotation onto its hierarchy",


### PR DESCRIPTION
## Summary

Replace endpoint-only rotation sampling with a lifecycle-managed `DisplayManager` change signal and monotonic provenance generation across screenshot capture plus both hierarchy routes. The callback runs on a dedicated handler that is drained before rotation validation, and endpoint equality remains an additional guard.

## Linked Issue

Addresses [#4605](https://github.com/kaeawc/auto-mobile/issues/4605). The issue remains open until the next tagged release publishes a CtrlProxy APK containing this change.

## Bug / Regression Context

- **Prior attempts:** Capture routes sampled rotation only before and after acquisition.
- **Observed symptom:** An A -> B -> A rotation could stamp A onto B-oriented pixels when the endpoint samples matched.
- **Repro steps / conditions:** Rotate the default display from A to B and back to A while a screenshot or hierarchy capture is in flight.

## Validation

- [x] `GRADLE_USER_HOME=/private/tmp/auto-mobile-issue-4605-20260728/.gradle-home android/gradlew :control-proxy:testDebugUnitTest --tests dev.jasonpearson.automobile.ctrlproxy.RotationProvenanceTrackerTest --tests dev.jasonpearson.automobile.ctrlproxy.ViewHierarchyScaleMetadataTest`
- [x] `ktfmt --google-style --dry-run --set-exit-if-changed` on all four changed Kotlin files
- [x] `bun run typecheck` reports no new errors against the existing baseline
- [ ] `bun run turbo:validate` was blocked by the environment: inherited log-path permissions, then unavailable host ports beginning at `8765`
- [x] New code uses a fake change-signal seam; tests cover stable, delayed-callback, and A -> B -> A captures
- [x] Rebased onto current `main`

## Kotlin Reuse Check

- [x] Used Kotlin/JDK `AtomicLong` and Android `DisplayManager`; no dependency, generic helper, wrapper, or utility was added

## Device Verification

- [ ] Not run: no Android device was connected in this worktree

## Follow-ups

- [ ] A tagged release must build and publish the updated CtrlProxy APK before [#4605](https://github.com/kaeawc/auto-mobile/issues/4605) can be closed
