### PR TITLE
fix(ios): include typed inputs in hierarchy

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1758,7 +1758,8 @@ jobs:
             -xctestrun "${XCTESTRUN}" \
             -destination "id=${SIMULATOR_UDID}" \
             -only-testing:CtrlProxyUITests/PrivacyResourceMappingTests \
-            -only-testing:CtrlProxyTests/RotationChangeGenerationTests/testGestureOrientationKeepsLandscapeSceneWhenDeviceIsFaceUp
+            -only-testing:CtrlProxyTests/RotationChangeGenerationTests/testGestureOrientationKeepsLandscapeSceneWhenDeviceIsFaceUp \
+            -only-testing:CtrlProxyUITests/CtrlProxyUITests/testHierarchyIncludesTypedTextInputsMissingFromSnapshotTree
 
       # Re-sync the backgrounded ffmpeg install before its only consumer. With the
       # install hoisted out, this step's 10-minute cap now covers the test alone.

--- a/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
+++ b/ios/control-proxy/CtrlProxy.xcodeproj/project.pbxproj
@@ -754,7 +754,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = dev.jasonpearson.automobile.ctrlproxy;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.jasonpearson.automobile.ctrlproxy.framework;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -868,7 +868,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = dev.jasonpearson.automobile.ctrlproxy;
+				PRODUCT_BUNDLE_IDENTIFIER = dev.jasonpearson.automobile.ctrlproxy.framework;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/ios/control-proxy/CtrlProxyApp/AppDelegate.swift
+++ b/ios/control-proxy/CtrlProxyApp/AppDelegate.swift
@@ -11,9 +11,77 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         -> Bool
     {
         window = UIWindow(frame: UIScreen.main.bounds)
-        window?.rootViewController = UIViewController()
+        if ProcessInfo.processInfo.environment["CTRL_PROXY_SNAPSHOT_GAP_TEST_MODE"] == "1" {
+            window?.rootViewController = SnapshotGapViewController()
+        } else {
+            window?.rootViewController = UIViewController()
+        }
         window?.rootViewController?.view.backgroundColor = .systemBackground
         window?.makeKeyAndVisible()
         return true
+    }
+}
+
+private final class SnapshotGapViewController: UIViewController {
+    private let composerGroup = UIView()
+    private let messageTextView = UITextView()
+    private let standardTextField = UITextField()
+    private let secureTextField = UITextField()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        composerGroup.accessibilityContainerType = .semanticGroup
+        composerGroup.accessibilityLabel = "Composer"
+        composerGroup.translatesAutoresizingMaskIntoConstraints = false
+
+        messageTextView.isAccessibilityElement = true
+        messageTextView.accessibilityLabel = "Message #sample"
+        messageTextView.font = .preferredFont(forTextStyle: .body)
+        messageTextView.backgroundColor = .secondarySystemBackground
+        messageTextView.layer.cornerRadius = 8
+        messageTextView.translatesAutoresizingMaskIntoConstraints = false
+
+        standardTextField.isAccessibilityElement = true
+        standardTextField.accessibilityLabel = "Standard field"
+        standardTextField.accessibilityIdentifier = "standard-field"
+        standardTextField.placeholder = "Standard field"
+        standardTextField.borderStyle = .roundedRect
+        standardTextField.translatesAutoresizingMaskIntoConstraints = false
+
+        secureTextField.isAccessibilityElement = true
+        secureTextField.accessibilityLabel = "Password"
+        secureTextField.accessibilityIdentifier = "secure-field"
+        secureTextField.placeholder = "Password"
+        secureTextField.isSecureTextEntry = true
+        secureTextField.borderStyle = .roundedRect
+        secureTextField.translatesAutoresizingMaskIntoConstraints = false
+
+        composerGroup.addSubview(messageTextView)
+        view.addSubview(composerGroup)
+        view.addSubview(standardTextField)
+        view.addSubview(secureTextField)
+
+        NSLayoutConstraint.activate([
+            composerGroup.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            composerGroup.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
+            composerGroup.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 40),
+
+            messageTextView.leadingAnchor.constraint(equalTo: composerGroup.leadingAnchor),
+            messageTextView.trailingAnchor.constraint(equalTo: composerGroup.trailingAnchor),
+            messageTextView.topAnchor.constraint(equalTo: composerGroup.topAnchor),
+            messageTextView.heightAnchor.constraint(equalToConstant: 88),
+            messageTextView.bottomAnchor.constraint(equalTo: composerGroup.bottomAnchor),
+
+            standardTextField.leadingAnchor.constraint(equalTo: composerGroup.leadingAnchor),
+            standardTextField.trailingAnchor.constraint(equalTo: composerGroup.trailingAnchor),
+            standardTextField.topAnchor.constraint(equalTo: composerGroup.bottomAnchor, constant: 24),
+            standardTextField.heightAnchor.constraint(equalToConstant: 44),
+
+            secureTextField.leadingAnchor.constraint(equalTo: composerGroup.leadingAnchor),
+            secureTextField.trailingAnchor.constraint(equalTo: composerGroup.trailingAnchor),
+            secureTextField.topAnchor.constraint(equalTo: standardTextField.bottomAnchor, constant: 16),
+            secureTextField.heightAnchor.constraint(equalToConstant: 44),
+        ])
     }
 }

--- a/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
@@ -143,7 +143,7 @@ public class ElementLocator: ElementLocating {
         /// Element types whose internal UIKit subviews produce same-type nested children
         /// in the XCUITest accessibility tree. These are collapsed during hierarchy building
         /// to avoid exposing non-interactive internal subviews (e.g. _UITextFieldRoundedRectBackgroundViewNeue).
-        private static let textInputElementTypes: Set<XCUIElement.ElementType> = [
+        private static let textInputElementTypes: [XCUIElement.ElementType] = [
             .textField,        // UITextField internal subviews
             .secureTextField,  // Same internals as UITextField with isSecureTextEntry
             .textView,         // TextKit 2 internal views (_UITextLayoutCanvasView)
@@ -538,11 +538,12 @@ public class ElementLocator: ElementLocating {
             // IMPORTANT: Create a FRESH XCUIApplication instance for each snapshot to avoid
             // stale accessibility cache. Cached instances may not reflect system-presented
             // alerts like permission dialogs.
-            let (snapshot, keyboardFocusFrame, screenMetrics) = try perfProvider.track("snapshot") {
+            let (snapshot, typedTextInputSnapshots, keyboardFocusFrame, screenMetrics) = try perfProvider.track("snapshot") {
                 try runOnMainThread {
                     let capture = try DeviceRotation.capture {
                         let freshApp = XCUIApplication(bundleIdentifier: bundleId)
                         let snap = try freshApp.snapshot()
+                        let typedInputs = Self.visibleHittableTextInputSnapshots(in: freshApp)
 
                         // Query keyboard focus via predicate — snapshot.hasFocus reflects
                         // UIKit focus (tvOS/iPad), not keyboard input focus on iPhone.
@@ -550,17 +551,18 @@ public class ElementLocator: ElementLocating {
                             .matching(NSPredicate(format: "hasKeyboardFocus == true"))
                             .firstMatch
                         let focusFrame: CGRect? = focused.exists ? focused.frame : nil
-                        return (snap, focusFrame, UIScreen.main.bounds)
+                        return (snap, typedInputs, focusFrame, UIScreen.main.bounds)
                     }
 
                     return (
                         capture.value.0,
                         capture.value.1,
+                        capture.value.2,
                         ScreenMetrics(
                             scale: Float(UIScreen.main.scale),
                             nativeScale: Float(UIScreen.main.nativeScale),
-                            fallbackWidth: Int(capture.value.2.width),
-                            fallbackHeight: Int(capture.value.2.height),
+                            fallbackWidth: Int(capture.value.3.width),
+                            fallbackHeight: Int(capture.value.3.height),
                             rotation: capture.rotation
                         )
                     )
@@ -581,15 +583,33 @@ public class ElementLocator: ElementLocating {
                 )
             }
 
+            let hierarchyWithTypedTextInputs = perfProvider.track("mergeTypedTextInputs") {
+                let candidates = typedTextInputSnapshots.enumerated().map { index, textInputSnapshot in
+                    buildElementInfoFromSnapshot(
+                        textInputSnapshot,
+                        depth: 1,
+                        screenBounds: screenBounds,
+                        parentPath: "typed-text-input",
+                        childIndex: index,
+                        keyboardFocusFrame: keyboardFocusFrame,
+                        disableAllFiltering: disableAllFiltering
+                    )
+                }
+                return ElementLocator.mergeMissingTextInputCandidates(
+                    into: rawElement,
+                    candidates: candidates
+                )
+            }
+
             // Apply optimization - flatten structural wrappers and filter empty nodes
             // Skip optimization when disableAllFiltering is true (for raw hierarchy debugging)
             let rootElement: UIElementInfo
             if disableAllFiltering {
-                rootElement = rawElement
+                rootElement = hierarchyWithTypedTextInputs
             } else {
                 rootElement = perfProvider.track("optimize") {
-                    let optimizedElements = optimizeHierarchy(rawElement, isRoot: true)
-                    return optimizedElements.first ?? rawElement
+                    let optimizedElements = optimizeHierarchy(hierarchyWithTypedTextInputs, isRoot: true)
+                    return optimizedElements.first ?? hierarchyWithTypedTextInputs
                 }
             }
 
@@ -706,6 +726,28 @@ public class ElementLocator: ElementLocating {
                 rotation: hierarchyRotation,
                 fallbackToSpringboard: tracker.didFallbackToSpringboard ? true : nil
             )
+        }
+
+        /// Snapshot the text inputs whose typed XCTest queries can expose controls
+        /// absent from the application's recursive snapshot tree.
+        private static func visibleHittableTextInputSnapshots(in app: XCUIApplication) -> [XCUIElementSnapshot] {
+            var snapshots: [XCUIElementSnapshot] = []
+
+            for type in textInputElementTypes {
+                let candidates = app.descendants(matching: type).allElementsBoundByIndex
+                for candidate in candidates {
+                    guard candidate.exists,
+                          candidate.isHittable,
+                          !candidate.frame.isEmpty,
+                          let snapshot = try? candidate.snapshot()
+                    else {
+                        continue
+                    }
+                    snapshots.append(snapshot)
+                }
+            }
+
+            return snapshots
         }
 
         /// Get system alerts from the app snapshot and springboard.
@@ -929,6 +971,7 @@ public class ElementLocator: ElementLocating {
                 let isTextInput = snapshot.elementType == .textField
                     || snapshot.elementType == .textView
                     || snapshot.elementType == .secureTextField
+                    || snapshot.elementType == .searchField
                 hasFocus = framesMatch && isTextInput
             } else {
                 hasFocus = snapshot.hasFocus
@@ -938,7 +981,7 @@ public class ElementLocator: ElementLocating {
             // Only include actions for text input elements (click is implied by clickable)
             var actions: [String]?
             if isEnabled && (snapshot.elementType == .textField || snapshot.elementType == .textView ||
-                snapshot.elementType == .secureTextField)
+                snapshot.elementType == .secureTextField || snapshot.elementType == .searchField)
             {
                 actions = ["set_text", "clear_text"]
             }
@@ -1178,7 +1221,7 @@ public class ElementLocator: ElementLocating {
             case .checkBox: return "checkbox"
             case .radioButton: return "radio"
             case .slider: return "slider"
-            case .textField, .textView, .secureTextField: return "textfield"
+            case .textField, .textView, .secureTextField, .searchField: return "textfield"
             case .image: return "image"
             case .staticText: return "text"
             case .table, .collectionView: return "list"
@@ -1464,6 +1507,80 @@ public class ElementLocator: ElementLocating {
         "UITextView",
         "UISearchBar",
     ]
+
+    /// Adds typed XCTest text-input candidates that the recursive application
+    /// snapshot did not contain. Fallback nodes are leaves below the application
+    /// root because XCTest does not expose a reliable parent for this path.
+    static func mergeMissingTextInputCandidates(
+        into root: UIElementInfo,
+        candidates: [UIElementInfo]
+    ) -> UIElementInfo {
+        var existing = allNodes(in: root)
+        var rootChildren = root.node ?? []
+
+        for candidate in candidates {
+            guard !existing.contains(where: { isSameTextInput($0, candidate) }) else {
+                continue
+            }
+
+            let leaf = copying(candidate, node: nil)
+            rootChildren.append(leaf)
+            existing.append(leaf)
+        }
+
+        return copying(root, node: rootChildren.isEmpty ? nil : rootChildren)
+    }
+
+    private static func allNodes(in element: UIElementInfo) -> [UIElementInfo] {
+        [element] + (element.node ?? []).flatMap(allNodes)
+    }
+
+    private static func isSameTextInput(_ lhs: UIElementInfo, _ rhs: UIElementInfo) -> Bool {
+        guard lhs.resourceId == rhs.resourceId,
+              lhs.className == rhs.className,
+              let lhsBounds = lhs.bounds,
+              let rhsBounds = rhs.bounds
+        else {
+            return false
+        }
+
+        return lhsBounds.left == rhsBounds.left
+            && lhsBounds.top == rhsBounds.top
+            && lhsBounds.right == rhsBounds.right
+            && lhsBounds.bottom == rhsBounds.bottom
+    }
+
+    private static func copying(_ element: UIElementInfo, node: [UIElementInfo]?) -> UIElementInfo {
+        UIElementInfo(
+            text: element.text,
+            value: element.value,
+            textSize: element.textSize,
+            contentDesc: element.contentDesc,
+            resourceId: element.resourceId,
+            className: element.className,
+            bounds: element.bounds,
+            clickable: element.clickable,
+            enabled: element.enabled,
+            focusable: element.focusable,
+            focused: element.focused,
+            accessibilityFocused: element.accessibilityFocused,
+            scrollable: element.scrollable,
+            password: element.password,
+            checkable: element.checkable,
+            checked: element.checked,
+            selected: element.selected,
+            longClickable: element.longClickable,
+            testTag: element.testTag,
+            role: element.role,
+            stateDescription: element.stateDescription,
+            errorMessage: element.errorMessage,
+            hintText: element.hintText,
+            viewId: element.viewId,
+            extras: element.extras,
+            actions: element.actions,
+            node: node
+        )
+    }
 
     /// Check whether a UIElementInfo carries any unique identifying information
     /// (text, resourceId, contentDesc, hintText). Elements without these are

--- a/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
@@ -736,14 +736,18 @@ public class ElementLocator: ElementLocating {
             for type in textInputElementTypes {
                 let candidates = app.descendants(matching: type).allElementsBoundByIndex
                 for candidate in candidates {
-                    guard candidate.exists,
-                          candidate.isHittable,
-                          !candidate.frame.isEmpty,
-                          let snapshot = try? candidate.snapshot()
-                    else {
-                        continue
+                    let snapshot: XCUIElementSnapshot? = runOnMainThreadNonThrowing({
+                        guard candidate.exists,
+                              candidate.isHittable,
+                              !candidate.frame.isEmpty
+                        else {
+                            return nil
+                        }
+                        return try? candidate.snapshot()
+                    }, fallback: nil)
+                    if let snapshot {
+                        snapshots.append(snapshot)
                     }
-                    snapshots.append(snapshot)
                 }
             }
 

--- a/ios/control-proxy/Tests/CtrlProxyTests/ElementLocatorTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ElementLocatorTests.swift
@@ -827,6 +827,108 @@ final class ElementLocatorTests: XCTestCase {
         _ = cache.count
     }
 
+    // MARK: - Typed text input fallback (#4644)
+
+    func testMergeMissingTextInputCandidates_appendsIdentifierlessTextViewWithNativeFields() {
+        let root = UIElementInfo(
+            className: "XCUIApplication",
+            bounds: ElementBounds(left: 0, top: 0, right: 393, bottom: 852),
+            node: [
+                UIElementInfo(
+                    resourceId: "standard-field",
+                    className: "UITextField",
+                    bounds: ElementBounds(left: 20, top: 100, right: 373, bottom: 144),
+                    clickable: "true",
+                    role: "textfield"
+                ),
+            ]
+        )
+        let missingTextView = UIElementInfo(
+            text: "Message #sample",
+            value: "draft",
+            className: "UITextView",
+            bounds: ElementBounds(left: 20, top: 180, right: 373, bottom: 260),
+            clickable: "true",
+            focused: "true",
+            role: "textfield",
+            hintText: "Write a message",
+            viewId: "generated-view-id",
+            actions: ["set_text", "clear_text"]
+        )
+
+        let result = ElementLocator.mergeMissingTextInputCandidates(
+            into: root,
+            candidates: [missingTextView]
+        )
+
+        let appended = result.node?.last
+        XCTAssertEqual(result.node?.count, 2)
+        XCTAssertEqual(appended?.resourceId, nil)
+        XCTAssertEqual(appended?.className, "UITextView")
+        XCTAssertEqual(appended?.bounds?.left, 20)
+        XCTAssertEqual(appended?.bounds?.top, 180)
+        XCTAssertEqual(appended?.bounds?.right, 373)
+        XCTAssertEqual(appended?.bounds?.bottom, 260)
+        XCTAssertEqual(appended?.clickable, "true")
+        XCTAssertEqual(appended?.focused, "true")
+        XCTAssertEqual(appended?.role, "textfield")
+        XCTAssertEqual(appended?.hintText, "Write a message")
+        XCTAssertEqual(appended?.value, "draft")
+        XCTAssertEqual(appended?.actions, ["set_text", "clear_text"])
+    }
+
+    func testMergeMissingTextInputCandidates_doesNotDuplicateExistingStandardTextField() {
+        let standardField = UIElementInfo(
+            resourceId: "standard-field",
+            className: "UITextField",
+            bounds: ElementBounds(left: 20, top: 100, right: 373, bottom: 144),
+            clickable: "true",
+            role: "textfield"
+        )
+        let root = UIElementInfo(
+            className: "XCUIApplication",
+            bounds: ElementBounds(left: 0, top: 0, right: 393, bottom: 852),
+            node: [standardField]
+        )
+
+        let result = ElementLocator.mergeMissingTextInputCandidates(
+            into: root,
+            candidates: [standardField]
+        )
+
+        XCTAssertEqual(result.node?.count, 1)
+        XCTAssertEqual(result.node?.first?.resourceId, "standard-field")
+    }
+
+    func testMergeMissingTextInputCandidates_preservesMaskedSecureValue() {
+        let maskedValue = String(repeating: "\u{2022}", count: 6)
+        let secureField = UIElementInfo(
+            text: "Password",
+            value: maskedValue,
+            resourceId: "password-field",
+            className: "UISecureTextField",
+            bounds: ElementBounds(left: 20, top: 280, right: 373, bottom: 324),
+            clickable: "true",
+            password: "true",
+            role: "textfield",
+            actions: ["set_text", "clear_text"]
+        )
+        let root = UIElementInfo(
+            className: "XCUIApplication",
+            bounds: ElementBounds(left: 0, top: 0, right: 393, bottom: 852)
+        )
+
+        let result = ElementLocator.mergeMissingTextInputCandidates(
+            into: root,
+            candidates: [secureField]
+        )
+
+        let appended = result.node?.first
+        XCTAssertEqual(appended?.value, maskedValue)
+        XCTAssertNotEqual(appended?.value, "secret")
+        XCTAssertEqual(appended?.password, "true")
+    }
+
     // MARK: - ForegroundTracker (#3614)
 
     func testForegroundTrackerSetAndSwitch() {

--- a/ios/control-proxy/Tests/CtrlProxyUITests/CtrlProxyUITests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyUITests/CtrlProxyUITests.swift
@@ -94,6 +94,59 @@ final class CtrlProxyUITests: XCTestCase {
         XCTAssertEqual(result, .timedOut, "Expected service to run until timeout")
     }
 
+    func testHierarchyIncludesTypedTextInputsMissingFromSnapshotTree() throws {
+        let app = XCUIApplication()
+        app.launchEnvironment["CTRL_PROXY_SNAPSHOT_GAP_TEST_MODE"] = "1"
+        app.launch()
+
+        let messageTextView = app.descendants(matching: .textView)
+            .matching(NSPredicate(format: "label == %@", "Message #sample"))
+            .firstMatch
+        XCTAssertTrue(messageTextView.waitForExistence(timeout: 5))
+        XCTAssertTrue(messageTextView.isHittable)
+        XCTAssertTrue(messageTextView.identifier.isEmpty)
+
+        let locator = ElementLocator(application: app)
+        locator.setApplication(app, bundleId: "dev.jasonpearson.automobile.ctrlproxy")
+
+        let initialHierarchy = try locator.getViewHierarchy(disableAllFiltering: false)
+        let initialNodes = hierarchyNodes(in: try XCTUnwrap(initialHierarchy.hierarchy))
+        let messageNodes = initialNodes.filter {
+            $0.className == "UITextView" && $0.text == "Message #sample"
+        }
+        let messageNode = try XCTUnwrap(messageNodes.first)
+        XCTAssertEqual(messageNodes.count, 1)
+        XCTAssertNil(messageNode.resourceId)
+        XCTAssertEqual(messageNode.role, "textfield")
+        XCTAssertEqual(messageNode.clickable, "true")
+        XCTAssertEqual(messageNode.actions, ["set_text", "clear_text"])
+        XCTAssertEqual(messageNode.bounds?.left, Int(messageTextView.frame.minX))
+        XCTAssertEqual(messageNode.bounds?.top, Int(messageTextView.frame.minY))
+        XCTAssertEqual(messageNode.bounds?.right, Int(messageTextView.frame.maxX))
+        XCTAssertEqual(messageNode.bounds?.bottom, Int(messageTextView.frame.maxY))
+
+        let standardFieldNodes = initialNodes.filter {
+            $0.className == "UITextField" && $0.resourceId == "standard-field"
+        }
+        XCTAssertEqual(standardFieldNodes.count, 1)
+
+        let gestures = GesturePerformer(application: app, elementLocator: locator)
+        try gestures.performAction("tap", label: "Message #sample")
+        try gestures.typeText(text: "hello")
+        XCTAssertEqual(messageTextView.value as? String, "hello")
+
+        let secureField = app.secureTextFields["secure-field"]
+        secureField.tap()
+        secureField.typeText("secret")
+
+        let finalHierarchy = try locator.getViewHierarchy(disableAllFiltering: false)
+        let secureNode = hierarchyNodes(in: try XCTUnwrap(finalHierarchy.hierarchy)).first {
+            $0.className == "UISecureTextField" && $0.resourceId == "secure-field"
+        }
+        XCTAssertEqual(secureNode?.value, String(repeating: "\u{2022}", count: 6))
+        XCTAssertEqual(secureNode?.password, "true")
+    }
+
     // MARK: - Configuration Helpers
 
     private func getPort() -> UInt16 {
@@ -116,5 +169,9 @@ final class CtrlProxyUITests: XCTestCase {
             return timeout
         }
         return nil
+    }
+
+    private func hierarchyNodes(in element: UIElementInfo) -> [UIElementInfo] {
+        [element] + (element.node ?? []).flatMap { hierarchyNodes(in: $0) }
     }
 }

--- a/ios/control-proxy/project.yml
+++ b/ios/control-proxy/project.yml
@@ -60,7 +60,7 @@ targets:
         embed: false
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: dev.jasonpearson.automobile.ctrlproxy
+        PRODUCT_BUNDLE_IDENTIFIER: dev.jasonpearson.automobile.ctrlproxy.framework
         DEFINES_MODULE: YES
         CODE_SIGN_STYLE: Automatic
         GENERATE_INFOPLIST_FILE: YES


### PR DESCRIPTION
## Summary

`observe()` now supplements the recursive XCTest snapshot with visible, hittable
native text inputs found through typed XCTest queries. Missing candidates are
added as root-level leaves only when their identifier, element type, and bounds
are not already present.

The fallback preserves labels, values, placeholders, roles, bounds, focus state,
text actions, and secure-value masking for text fields, secure text fields,
text views, and search fields. It adds focused unit and UI regression coverage,
and runs the UI test in the existing CtrlProxy simulator job.

## Linked Issue

Closes https://github.com/kaeawc/auto-mobile/issues/4644

## Bug / Regression Context

- **Observed symptom:** a visible, hittable iOS text input found by a typed
  XCTest query could be absent from `observe()`, leaving no semantic target for
  `tapOn` before text entry.
- **Repro conditions:** UIKit `UITextView` in a semantic group with an empty
  accessibility identifier.

## Release Delivery

The existing Prepare Release workflow rebuilds the iOS IPA from `main` and
generates its checksum registry entry. This runner fix ships with the next
tagged release; it intentionally does not mutate the immutable `0.0.46`
release entry.

## Validation

- `swift test --filter ElementLocatorTests`
- `xcodebuild build-for-testing` for all CtrlProxy targets
- `scripts/ios/xcodegen-drift-check.sh --ctrl-proxy`
- `bun run turbo:validate`
- `bun run typecheck`

The local CoreSimulatorService was unavailable, so the iOS UI test could not
run here. The target compiles and is included in the existing Xcode 26.5 PR
simulator job.
