### PR TITLE
fix(android): prevent stale frame response timeouts

### DIFF
--- a/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
+++ b/android/control-proxy/src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt
@@ -1209,7 +1209,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     duration: Long,
     frameContext: String?,
   ) {
-    if (rejectStaleFrameContext(requestId, frameContext, "swipe")) return
+    if (rejectStaleFrameContext(requestId, frameContext, StaleFrameContextAction.SWIPE)) return
     performSwipe(requestId, x1, y1, x2, y2, duration, frameContext)
   }
 
@@ -1223,7 +1223,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     duration: Long,
     frameContext: String?,
   ) {
-    if (rejectStaleFrameContext(requestId, frameContext, "tap")) return
+    if (rejectStaleFrameContext(requestId, frameContext, StaleFrameContextAction.TAP)) return
     performTapCoordinates(requestId, x, y, duration, frameContext)
   }
 
@@ -1259,7 +1259,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     holdDurationMs: Long,
     frameContext: String?,
   ) {
-    if (rejectStaleFrameContext(requestId, frameContext, "drag")) return
+    if (rejectStaleFrameContext(requestId, frameContext, StaleFrameContextAction.DRAG)) return
     performDrag(
       requestId,
       x1,
@@ -1273,30 +1273,41 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     )
   }
 
+  private enum class StaleFrameContextAction(val wireName: String) {
+    TAP("tap"),
+    SWIPE("swipe"),
+    DRAG("drag"),
+    SET_TEXT("set_text"),
+    IME_ACTION("ime_action"),
+    GLOBAL_ACTION("global_action"),
+  }
+
   /**
    * Rejects an input that was mapped through a screen state the service has since observed change.
    */
   private fun rejectStaleFrameContext(
     requestId: String?,
     expected: String?,
-    action: String,
+    action: StaleFrameContextAction,
   ): Boolean {
     if (expected == null || expected == currentFrameContext()) return false
-    val error = "Stale frame context for input/$action; observe a fresh frame before retrying"
+    val error =
+      "Stale frame context for input/${action.wireName}; observe a fresh frame before retrying"
     launchRequestScope(requestId) {
       when (action) {
-        "tap" -> broadcastTapCoordinatesResult(requestId, false, error, 0)
-        "swipe" -> broadcastSwipeResult(requestId, false, error, 0, null)
-        "drag" -> broadcastDragResult(requestId, false, error, 0, null)
-        "set_text" -> broadcastSetTextResult(requestId, false, error, 0)
-        "ime_action" -> broadcastImeActionResult(requestId, action, false, error, 0)
-        "global_action" ->
+        StaleFrameContextAction.TAP -> broadcastTapCoordinatesResult(requestId, false, error, 0)
+        StaleFrameContextAction.SWIPE -> broadcastSwipeResult(requestId, false, error, 0, null)
+        StaleFrameContextAction.DRAG -> broadcastDragResult(requestId, false, error, 0, null)
+        StaleFrameContextAction.SET_TEXT -> broadcastSetTextResult(requestId, false, error, 0)
+        StaleFrameContextAction.IME_ACTION ->
+          broadcastImeActionResult(requestId, action.wireName, false, error, 0)
+        StaleFrameContextAction.GLOBAL_ACTION ->
           webSocketServer.broadcast(
             dev.jasonpearson.automobile.protocol.GlobalActionResult(
               timestamp = System.currentTimeMillis(),
               requestId = requestId,
               success = false,
-              action = action,
+              action = action.wireName,
               totalTimeMs = 0,
               error = error,
             )
@@ -1339,7 +1350,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     dismissKeyboard: Boolean,
     frameContext: String?,
   ) {
-    if (rejectStaleFrameContext(requestId, frameContext, "set_text")) return
+    if (rejectStaleFrameContext(requestId, frameContext, StaleFrameContextAction.SET_TEXT)) return
     performSetText(requestId, text, resourceId, dismissKeyboard)
   }
 
@@ -1347,7 +1358,7 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     performImeAction(requestId, action)
 
   override fun requestImeAction(requestId: String?, action: String, frameContext: String?) {
-    if (rejectStaleFrameContext(requestId, frameContext, "ime_action")) return
+    if (rejectStaleFrameContext(requestId, frameContext, StaleFrameContextAction.IME_ACTION)) return
     performImeAction(requestId, action)
   }
 
@@ -1376,7 +1387,8 @@ class CtrlProxy : AccessibilityService(), CtrlProxyActions {
     performGlobalActionRequest(requestId, action)
 
   override fun requestGlobalAction(requestId: String?, action: String, frameContext: String?) {
-    if (rejectStaleFrameContext(requestId, frameContext, "global_action")) return
+    if (rejectStaleFrameContext(requestId, frameContext, StaleFrameContextAction.GLOBAL_ACTION))
+      return
     performGlobalActionRequest(requestId, action)
   }
 

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/StaleFrameContextRejectionWiringTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/StaleFrameContextRejectionWiringTest.kt
@@ -1,0 +1,108 @@
+package dev.jasonpearson.automobile.ctrlproxy
+
+import java.io.File
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * Structural regression guard for issue #4577.
+ *
+ * CtrlProxy is an AccessibilityService and cannot be constructed in a fast unit test. This source
+ * test instead verifies that every stale-frame rejection routes through a closed action set, and
+ * that the dispatch remains exhaustive without a silent fallback branch.
+ */
+class StaleFrameContextRejectionWiringTest {
+
+  private val staleFrameActions =
+    setOf("TAP", "SWIPE", "DRAG", "SET_TEXT", "IME_ACTION", "GLOBAL_ACTION")
+
+  @Test
+  fun `stale frame rejection accepts a typed action and dispatches every action`() {
+    val source = KotlinSourceScan.maskLiteralsAndComments(readCtrlProxySource())
+    val signature = rejectionSignature(source)
+    val body = rejectionBody(source)
+
+    assertTrue(
+      "rejectStaleFrameContext must accept StaleFrameContextAction rather than a raw String",
+      "action: StaleFrameContextAction" in signature,
+    )
+    assertFalse(
+      "the typed dispatch must stay exhaustive rather than silently ignoring a future action",
+      Regex("""\belse\s*->""").containsMatchIn(body),
+    )
+    assertEquals(
+      "every stale-frame action must retain an explicit correlated response envelope",
+      staleFrameActions,
+      routedActions(body),
+    )
+  }
+
+  @Test
+  fun `every frame context request selects a typed stale frame action`() {
+    val source = KotlinSourceScan.maskLiteralsAndComments(readCtrlProxySource())
+
+    assertEquals(
+      "a raw action string could enter the stale rejection dispatcher without a response",
+      staleFrameActions,
+      typedActionCallSites(source),
+    )
+  }
+
+  private fun rejectionSignature(source: String): String {
+    val start = source.indexOf("private fun rejectStaleFrameContext(")
+    assertTrue("rejectStaleFrameContext not found in CtrlProxy.kt", start >= 0)
+    val bodyOpen = source.indexOf('{', start)
+    assertTrue("rejectStaleFrameContext body not found in CtrlProxy.kt", bodyOpen >= 0)
+    return source.substring(start, bodyOpen)
+  }
+
+  private fun rejectionBody(source: String): String {
+    val start = source.indexOf("private fun rejectStaleFrameContext(")
+    assertTrue("rejectStaleFrameContext not found in CtrlProxy.kt", start >= 0)
+    val bodyOpen = source.indexOf('{', start)
+    assertTrue("rejectStaleFrameContext body not found in CtrlProxy.kt", bodyOpen >= 0)
+    return source.substring(bodyOpen, KotlinSourceScan.matchBrace(source, bodyOpen))
+  }
+
+  private fun routedActions(body: String): Set<String> =
+    Regex("""StaleFrameContextAction\.([A-Z_]+)\s*->""")
+      .findAll(body)
+      .map { it.groupValues[1] }
+      .toSet()
+
+  private fun typedActionCallSites(source: String): Set<String> =
+    Regex(
+        """rejectStaleFrameContext\(\s*requestId\s*,\s*frameContext\s*,\s*StaleFrameContextAction\.([A-Z_]+)\s*\)"""
+      )
+      .findAll(source)
+      .map { it.groupValues[1] }
+      .toSet()
+
+  private fun readCtrlProxySource(): String = locateCtrlProxySource().readText()
+
+  private fun locateCtrlProxySource(): File {
+    val rel = "src/main/kotlin/dev/jasonpearson/automobile/ctrlproxy/CtrlProxy.kt"
+    val direct =
+      listOf(File(rel), File("control-proxy/$rel"), File("android/control-proxy/$rel"))
+        .firstOrNull { it.isFile }
+    if (direct != null) return direct
+
+    var dir: File? = File(System.getProperty("user.dir") ?: ".").absoluteFile
+    while (dir != null) {
+      for (candidate in
+        listOf(
+          File(dir, rel),
+          File(dir, "control-proxy/$rel"),
+          File(dir, "android/control-proxy/$rel"),
+        )) {
+        if (candidate.isFile) return candidate
+      }
+      dir = dir.parentFile
+    }
+    fail("Could not locate CtrlProxy.kt from user.dir=${System.getProperty("user.dir")}")
+    error("unreachable")
+  }
+}

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/StaleFrameContextRejectionWiringTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/StaleFrameContextRejectionWiringTest.kt
@@ -19,6 +19,16 @@ class StaleFrameContextRejectionWiringTest {
   private val staleFrameActions =
     setOf("TAP", "SWIPE", "DRAG", "SET_TEXT", "IME_ACTION", "GLOBAL_ACTION")
 
+  private val responseEmitterByAction =
+    mapOf(
+      "TAP" to "broadcastTapCoordinatesResult",
+      "SWIPE" to "broadcastSwipeResult",
+      "DRAG" to "broadcastDragResult",
+      "SET_TEXT" to "broadcastSetTextResult",
+      "IME_ACTION" to "broadcastImeActionResult",
+      "GLOBAL_ACTION" to "GlobalActionResult",
+    )
+
   @Test
   fun `stale frame rejection accepts a typed action and dispatches every action`() {
     val source = KotlinSourceScan.maskLiteralsAndComments(readCtrlProxySource())
@@ -38,6 +48,12 @@ class StaleFrameContextRejectionWiringTest {
       staleFrameActions,
       routedActions(body),
     )
+    responseEmitterByAction.forEach { (action, emitter) ->
+      assertTrue(
+        "$action must emit its established correlated stale-frame response",
+        emitter in actionBranch(body, action),
+      )
+    }
   }
 
   @Test
@@ -72,6 +88,14 @@ class StaleFrameContextRejectionWiringTest {
       .findAll(body)
       .map { it.groupValues[1] }
       .toSet()
+
+  private fun actionBranch(body: String, action: String): String {
+    val marker = "StaleFrameContextAction.$action ->"
+    val start = body.indexOf(marker)
+    if (start < 0) return ""
+    val next = body.indexOf("StaleFrameContextAction.", start + marker.length)
+    return body.substring(start, if (next >= 0) next else body.length)
+  }
 
   private fun typedActionCallSites(source: String): Set<String> =
     Regex(

--- a/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/StaleFrameContextRejectionWiringTest.kt
+++ b/android/control-proxy/src/test/kotlin/dev/jasonpearson/automobile/ctrlproxy/StaleFrameContextRejectionWiringTest.kt
@@ -19,14 +19,30 @@ class StaleFrameContextRejectionWiringTest {
   private val staleFrameActions =
     setOf("TAP", "SWIPE", "DRAG", "SET_TEXT", "IME_ACTION", "GLOBAL_ACTION")
 
-  private val responseEmitterByAction =
+  private val correlatedResponsePatternByAction =
     mapOf(
-      "TAP" to "broadcastTapCoordinatesResult",
-      "SWIPE" to "broadcastSwipeResult",
-      "DRAG" to "broadcastDragResult",
-      "SET_TEXT" to "broadcastSetTextResult",
-      "IME_ACTION" to "broadcastImeActionResult",
-      "GLOBAL_ACTION" to "GlobalActionResult",
+      "TAP" to
+        Regex(
+          """broadcastTapCoordinatesResult\(\s*requestId\s*,\s*false\s*,\s*error\s*,\s*0\s*\)"""
+        ),
+      "SWIPE" to
+        Regex(
+          """broadcastSwipeResult\(\s*requestId\s*,\s*false\s*,\s*error\s*,\s*0\s*,\s*null\s*\)"""
+        ),
+      "DRAG" to
+        Regex(
+          """broadcastDragResult\(\s*requestId\s*,\s*false\s*,\s*error\s*,\s*0\s*,\s*null\s*\)"""
+        ),
+      "SET_TEXT" to
+        Regex("""broadcastSetTextResult\(\s*requestId\s*,\s*false\s*,\s*error\s*,\s*0\s*\)"""),
+      "IME_ACTION" to
+        Regex(
+          """broadcastImeActionResult\(\s*requestId\s*,\s*action\.wireName\s*,\s*false\s*,\s*error\s*,\s*0\s*\)"""
+        ),
+      "GLOBAL_ACTION" to
+        Regex(
+          """(?s)GlobalActionResult\(\s*timestamp\s*=\s*System\.currentTimeMillis\(\)\s*,\s*requestId\s*=\s*requestId\s*,\s*success\s*=\s*false\s*,.*?\berror\s*=\s*error\s*,"""
+        ),
     )
 
   @Test
@@ -48,10 +64,10 @@ class StaleFrameContextRejectionWiringTest {
       staleFrameActions,
       routedActions(body),
     )
-    responseEmitterByAction.forEach { (action, emitter) ->
+    correlatedResponsePatternByAction.forEach { (action, responsePattern) ->
       assertTrue(
-        "$action must emit its established correlated stale-frame response",
-        emitter in actionBranch(body, action),
+        "$action must retain its established correlated stale-frame response",
+        responsePattern.containsMatchIn(actionBranch(body, action)),
       )
     }
   }


### PR DESCRIPTION
## Summary

- Replace the raw stale-frame action string with a closed Android CtrlProxy action enum.
- Preserve the existing response envelopes for tap, swipe, drag, text, IME, and global actions.
- Add a fast source-wiring regression test that requires typed, exhaustive stale-frame dispatch.

## Root Cause

`rejectStaleFrameContext` returned after scheduling a `when` over a raw string. An unrecognized future action would match no branch, leaving its caller without a correlated response frame until timeout.

## Validation

- `./gradlew :control-proxy:testDebugUnitTest --tests dev.jasonpearson.automobile.ctrlproxy.StaleFrameContextRejectionWiringTest`
- `bun run typecheck`
- `bun run turbo:validate`

## Delivery Follow-Through

This changes the downloadable Android CtrlProxy runner. Before [#4577](https://github.com/kaeawc/auto-mobile/issues/4577) can be closed, cut and publish a new signed APK release and record its checksum in the tagged release registry. The nightly checksum entry is drift tracking only and is not a downloadable release artifact.

Tracks [#4577](https://github.com/kaeawc/auto-mobile/issues/4577)
