### PR TITLE
fix(debug): name invalid highlight bounds

### DIFF
--- a/src/features/debug/VisualHighlight.ts
+++ b/src/features/debug/VisualHighlight.ts
@@ -37,8 +37,8 @@ const normalizeNullableString = (value: string | null | undefined): string | und
 const highlightBoundsSchema: z.ZodType<HighlightBounds> = z.object({
   x: z.number().int(),
   y: z.number().int(),
-  width: z.number().int().positive(),
-  height: z.number().int().positive(),
+  width: z.number().int().positive("bounds.width must be a positive integer"),
+  height: z.number().int().positive("bounds.height must be a positive integer"),
   sourceWidth: z.number().int().positive().nullable().optional(),
   sourceHeight: z.number().int().positive().nullable().optional()
 }).superRefine((value, ctx) => {

--- a/test/features/debug/VisualHighlight.test.ts
+++ b/test/features/debug/VisualHighlight.test.ts
@@ -94,17 +94,25 @@ describe("VisualHighlight", () => {
     ]);
   });
 
-  test("addHighlight rejects an invalid shape with the zod validation message before contacting the client", async () => {
-    const invalidShape: HighlightShape = {
-      type: "box",
-      bounds: {
-        x: 10,
-        y: 20,
-        width: 0,
-        height: 80
+  test.each([
+    {
+      dimension: "width",
+      invalidShape: {
+        type: "box" as const,
+        bounds: { x: 10, y: 20, width: 0, height: 80 }
       }
-    };
-
+    },
+    {
+      dimension: "height",
+      invalidShape: {
+        type: "box" as const,
+        bounds: { x: 10, y: 20, width: 100, height: 0 }
+      }
+    }
+  ])("addHighlight names the invalid bounds $dimension before contacting the client", async ({
+    dimension,
+    invalidShape
+  }) => {
     let requests = 0;
     const fakeClient = {
       requestAddHighlight: async () => {
@@ -117,9 +125,7 @@ describe("VisualHighlight", () => {
     const error = await highlight.addHighlight("highlight-1", invalidShape).catch(caught => caught);
 
     expect(error).toBeInstanceOf(ActionableError);
-    // The zod message reports the constraint but NOT the offending field name.
-    expect((error as Error).message).toContain("Too small: expected number to be >0");
-    // Validation happens before the wire call, so the client is never contacted.
+    expect((error as Error).message).toContain(`bounds.${dimension}`);
     expect(requests).toBe(0);
   });
 


### PR DESCRIPTION
## Summary

- Name invalid highlight `bounds.width` and `bounds.height` values in validation errors.
- Cover both dimensions and preserve the no-request validation boundary.

## Root Cause

Zod's default positive-number message omitted the path, leaving callers unable to tell whether width or height was invalid.

## Validation

- `bun test test/features/debug/VisualHighlight.test.ts`
- `bun run typecheck`
- `bun run turbo:validate -- --env-mode=loose`

Closes [#4516](https://github.com/kaeawc/auto-mobile/issues/4516)
