### PR TITLE
test: extend coordinate mapping golden vectors

### DIFF
--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/CoordinateMappingGoldenVectorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/CoordinateMappingGoldenVectorTest.kt
@@ -250,6 +250,7 @@ class CoordinateMappingGoldenVectorTest {
       ScaleReportingVector(375.0, 812.0, 3.144, 1179, 2553),
       ScaleReportingVector(414.0, 736.0, 2.608696, 1080, 1920),
       ScaleReportingVector(320.0, 568.0, 2.0, 640, 1136),
+      ScaleReportingVector(450.0, 750.0, 2.61, 1175, 1958),
       // Exact-half dimensions use the same round-half-away-from-zero rule as the iOS runner.
       ScaleReportingVector(375.0, 811.0, 3.5, 1313, 2839),
       // Android's production contract is the scale-1 identity: it has no point-to-pixel conversion.

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/CoordinateMappingGoldenVectorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/CoordinateMappingGoldenVectorTest.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.desktop.core.layout
 
+import dev.jasonpearson.automobile.desktop.domain.DevicePoint
 import dev.jasonpearson.automobile.desktop.domain.DeviceScreenCoordinateMapper
 import dev.jasonpearson.automobile.desktop.domain.DeviceScreenGeometry
 import dev.jasonpearson.automobile.desktop.domain.ViewportPoint
@@ -13,7 +14,7 @@ import org.junit.Test
  *
  * The canonical single source is `test/fixtures/coordinate-mapping-golden-vectors.json` at the repo
  * root. The inline tables below are committed copies of its five [DeviceScreenCoordinateMapper]
- * sections plus the shared scale-reporting contract;
+ * sections, [DevicePoint.clampedTo], and the shared scale-reporting contract;
  * `test/parity/coordinateMappingGoldenVectorParity.test.ts` parses these literals out of this
  * file's source and verifies them against the JSON (the same drift-guard mechanism as
  * `PinchGeometryTest.kt` / `pinch-golden-vectors.json`), so a one-sided edit of either side fails
@@ -117,6 +118,31 @@ class CoordinateMappingGoldenVectorTest {
       // Width-derived-ratio invariant (inverse): aspect-MISMATCHED frame (width ratio 0.5,
       // height ratio 0.25). Pins BOTH axes scale by frameWidthPx/deviceWidth (height y = 100).
       DeviceToViewportVector(200, 400, 500f, 500f, 1f, 0f, 0f, 1000, 2000, 100f, 200f),
+      // Degenerate zero device width still applies the current pan and zoom after the identity
+      // fallback.
+      DeviceToViewportVector(7, 9, 540f, 1170f, 2f, 10f, 20f, 0, 2340, 24f, 38f),
+    )
+
+  private data class ClampedToVector(
+    val x: Int,
+    val y: Int,
+    val width: Int,
+    val height: Int,
+    val expectedX: Int,
+    val expectedY: Int,
+    val expectedInBounds: Int,
+  )
+
+  private val clampedToVectors =
+    listOf(
+      // Negative x and past-bottom y pin independently to the first and last addressable pixels.
+      ClampedToVector(-5, 102, 100, 100, 0, 99, 1),
+      // Past-right x and negative y pin independently to the opposite two edges.
+      ClampedToVector(200, -5, 100, 100, 99, 0, 1),
+      // A zero-width screen has no addressable point, even though the non-zero axis still clamps.
+      ClampedToVector(5, 5, 0, 100, 0, 5, 0),
+      // The mirror zero-height screen preserves the same empty-rect contract.
+      ClampedToVector(5, 5, 100, 0, 5, 0, 0),
     )
 
   private data class FitToViewportVector(
@@ -166,6 +192,10 @@ class CoordinateMappingGoldenVectorTest {
       FitScaleVector(336f, 736f, 800f, 400f, 32f, 0.5f),
       // Non-default padding 20: 400/(760+40)=0.5 (default padding would give 400/824=0.4854).
       FitScaleVector(760f, 760f, 400f, 800f, 20f, 0.5f),
+      // Exact cap boundary: both padded dimensions equal the viewport, so raw scale is exactly 1.
+      FitScaleVector(736f, 736f, 800f, 800f, 32f, 1f),
+      // Exact floor boundary: width candidate is exactly 240/(736+64)=0.3.
+      FitScaleVector(736f, 736f, 240f, 800f, 32f, 0.3f),
     )
 
   private data class ScreenshotRotationVector(
@@ -265,6 +295,17 @@ class CoordinateMappingGoldenVectorTest {
       val point = mapper.deviceToViewport(vector.deviceX, vector.deviceY, geometry(vector))
       assertEquals(vector.expectedX, point.x, TOLERANCE, "row $index x")
       assertEquals(vector.expectedY, point.y, TOLERANCE, "row $index y")
+    }
+  }
+
+  @Test
+  fun `clampedTo matches the golden vectors`() {
+    for ((index, vector) in clampedToVectors.withIndex()) {
+      val point =
+        DevicePoint(vector.x, vector.y, inBounds = false).clampedTo(vector.width, vector.height)
+      assertEquals(vector.expectedX, point.x, "row $index x")
+      assertEquals(vector.expectedY, point.y, "row $index y")
+      assertEquals(vector.expectedInBounds == 1, point.inBounds, "row $index inBounds")
     }
   }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/CoordinateMappingGoldenVectorTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/CoordinateMappingGoldenVectorTest.kt
@@ -336,7 +336,7 @@ class CoordinateMappingGoldenVectorTest {
           vector.viewportHeight,
           vector.padding,
         )
-      assertEquals(vector.expected, scale, TOLERANCE, "row $index")
+      assertEquals(vector.expected, scale, FIT_SCALE_TOLERANCE, "row $index")
     }
   }
 
@@ -372,5 +372,6 @@ class CoordinateMappingGoldenVectorTest {
 
   private companion object {
     const val TOLERANCE = 0.001f
+    const val FIT_SCALE_TOLERANCE = 0f
   }
 }

--- a/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/ElementLocator.swift
@@ -121,7 +121,7 @@ final class ForegroundTracker {
 public class ElementLocator: ElementLocating {
     private struct ScreenMetrics {
         let scale: Float
-        let nativeScale: Float
+        let nativeScale: Double
         let fallbackWidth: Int
         let fallbackHeight: Int
         let rotation: Int?
@@ -560,7 +560,7 @@ public class ElementLocator: ElementLocating {
                         capture.value.2,
                         ScreenMetrics(
                             scale: Float(UIScreen.main.scale),
-                            nativeScale: Float(UIScreen.main.nativeScale),
+                            nativeScale: Double(UIScreen.main.nativeScale),
                             fallbackWidth: Int(capture.value.3.width),
                             fallbackHeight: Int(capture.value.3.height),
                             rotation: capture.rotation
@@ -672,7 +672,7 @@ public class ElementLocator: ElementLocating {
             let (currentScreenMetrics, afterHierarchyCapture): (ScreenMetrics, RotationCaptureSample) =
                 try runOnMainThread {
                     let scale = Float(UIScreen.main.scale)
-                    let nativeScale = Float(UIScreen.main.nativeScale)
+                    let nativeScale = Double(UIScreen.main.nativeScale)
                     let bounds = UIScreen.main.bounds
                     let captureSample = DeviceRotation.captureSample()
                     return (
@@ -709,7 +709,7 @@ public class ElementLocator: ElementLocating {
             let pixelDimensions = ElementLocator.computePixelDimensions(
                 pointWidth: screenWidth,
                 pointHeight: screenHeight,
-                nativeScale: Double(currentScreenMetrics.nativeScale)
+                nativeScale: currentScreenMetrics.nativeScale
             )
 
             return ViewHierarchy(

--- a/ios/control-proxy/Sources/CtrlProxy/Models.swift
+++ b/ios/control-proxy/Sources/CtrlProxy/Models.swift
@@ -948,7 +948,7 @@ public struct ViewHierarchy: Codable {
     /// (`UIScreen.scale`): Display Zoom changes `nativeScale` but not `scale`, and
     /// `XCUIScreenshot.pngRepresentation` is rendered at native scale, so this is the
     /// value that actually converts reported bounds to screenshot pixels (#4548).
-    public let nativeScale: Float?
+    public let nativeScale: Double?
     /// Physical screenshot pixel width: `round(screenWidth * nativeScale)` (#4548).
     public let pixelWidth: Int?
     /// Physical screenshot pixel height: `round(screenHeight * nativeScale)` (#4548).
@@ -969,7 +969,7 @@ public struct ViewHierarchy: Codable {
         screenScale: Float? = nil,
         screenWidth: Int? = nil,
         screenHeight: Int? = nil,
-        nativeScale: Float? = nil,
+        nativeScale: Double? = nil,
         pixelWidth: Int? = nil,
         pixelHeight: Int? = nil,
         rotation: Int? = nil,

--- a/ios/control-proxy/Tests/CtrlProxyTests/ElementLocatorTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ElementLocatorTests.swift
@@ -967,13 +967,15 @@ final class ElementLocatorTests: XCTestCase {
         // Row 2 is the Display Zoom case: nativeScale 3.144 while UIScreen.scale stays 3.0 —
         // using scale would report 2436 instead of the screenshot's true 2553 pixels.
         // Row 3 is the iPhone Plus downsampling case: scale 3.0 but nativeScale 2.608696.
-        // Row 5 pins the .5 rounding tie (round half away from zero == JS Math.round here,
-        // all values positive). Row 6 is the Android identity contract (nativeScale 1).
+        // Row 5 pins the Float-vs-Double precision boundary at 2.61. Row 6 pins the .5
+        // rounding tie (round half away from zero == JS Math.round here, all values positive).
+        // Row 7 is the Android identity contract (nativeScale 1).
         let scaleReportingVectors: [[Double]] = [
             [393, 852, 3.0, 1179, 2556],
             [375, 812, 3.144, 1179, 2553],
             [414, 736, 2.608696, 1080, 1920],
             [320, 568, 2.0, 640, 1136],
+            [450, 750, 2.61, 1175, 1958],
             [375, 811, 3.5, 1313, 2839],
             [1080, 2340, 1.0, 1080, 2340],
         ]

--- a/ios/control-proxy/Tests/CtrlProxyTests/ModelsTests.swift
+++ b/ios/control-proxy/Tests/CtrlProxyTests/ModelsTests.swift
@@ -106,6 +106,20 @@ final class ModelsTests: XCTestCase {
         XCTAssertFalse(encodedWithout.contains("pixelHeight"))
     }
 
+    func testViewHierarchyRetainsNativeScaleDoublePrecision() throws {
+        let hierarchy = ViewHierarchy(
+            updatedAt: 1,
+            screenWidth: 450,
+            screenHeight: 750,
+            nativeScale: 2.61,
+            pixelWidth: 1175,
+            pixelHeight: 1958
+        )
+
+        let nativeScale = try XCTUnwrap(hierarchy.nativeScale)
+        XCTAssertEqual(Double(nativeScale), 2.61, accuracy: 0)
+    }
+
     // MARK: - WebSocketRequest Tests
 
     func testWebSocketRequestDecoding() throws {

--- a/test/fixtures/coordinate-mapping-golden-vectors.json
+++ b/test/fixtures/coordinate-mapping-golden-vectors.json
@@ -428,7 +428,7 @@
       "expectedPixelWidth": 938, "expectedPixelHeight": 2030
     },
     {
-      "comment": "iPhone Plus-like nativeScale precision: 450*2.61 = 1174.5 -> 1175 and 750*2.61 = 1957.5 -> 1958, pinning the daemon's float64 multiply at a non-integer scale",
+      "comment": "iPhone Plus-like nativeScale precision: runner-reported Float metadata is widened to float64 in the daemon, then 450*2.61 = 1174.5 -> 1175 and 750*2.61 = 1957.5 -> 1958",
       "willChangeUnderCanonicalPixels": true,
       "pointWidth": 450, "pointHeight": 750, "scale": 2.61,
       "expectedPixelWidth": 1175, "expectedPixelHeight": 1958
@@ -472,6 +472,11 @@
       "comment": "2x device: 320x568 points -> 640x1136 pixels",
       "pointWidth": 320, "pointHeight": 568, "nativeScale": 2.0,
       "expectedPixelWidth": 640, "expectedPixelHeight": 1136
+    },
+    {
+      "comment": "iPhone Plus-like nativeScale precision: retaining 2.61 as a Double gives 450*2.61 = 1174.5 -> 1175 and 750*2.61 = 1957.5 -> 1958; a Float narrowing would produce 1174x1957",
+      "pointWidth": 450, "pointHeight": 750, "nativeScale": 2.61,
+      "expectedPixelWidth": 1175, "expectedPixelHeight": 1958
     },
     {
       "comment": "rounding tie on both axes: 375*3.5=1312.5 and 811*3.5=2838.5 round half away from zero (== JS Math.round for positive values)",

--- a/test/fixtures/coordinate-mapping-golden-vectors.json
+++ b/test/fixtures/coordinate-mapping-golden-vectors.json
@@ -6,7 +6,8 @@
     "",
     "Consumers:",
     "- Kotlin: android/desktop-core .../layout/CoordinateMappingGoldenVectorTest.kt holds inline",
-    "  copies of the five mapper sections and drives DeviceScreenCoordinateMapper against them.",
+    "  copies of the five mapper sections, DevicePoint.clampedTo, and scale reporting, then drives",
+    "  the production methods against them.",
     "  test/parity/coordinateMappingGoldenVectorParity.test.ts parses those inline literals out of",
     "  the Kotlin source and verifies them against this file (the pinch drift-guard mechanism).",
     "- TypeScript: test/daemon/deviceDataStreamSocketServer.test.ts drives the daemon's",
@@ -191,6 +192,34 @@
       "deviceX": 200, "deviceY": 400, "frameWidthPx": 500, "frameHeightPx": 500, "scale": 1,
       "offsetX": 0, "offsetY": 0, "deviceWidth": 1000, "deviceHeight": 2000,
       "expectedX": 100, "expectedY": 200
+    },
+    {
+      "comment": "zero deviceWidth with pan + zoom: the ratio falls back to identity first, then the normal viewport transform still applies (7*2+10, 9*2+20)",
+      "deviceX": 7, "deviceY": 9, "frameWidthPx": 540, "frameHeightPx": 1170, "scale": 2,
+      "offsetX": 10, "offsetY": 20, "deviceWidth": 0, "deviceHeight": 2340,
+      "expectedX": 24, "expectedY": 38
+    }
+  ],
+  "clampedTo": [
+    {
+      "comment": "negative x and past-bottom y clamp independently to the first and last addressable pixels",
+      "x": -5, "y": 102, "width": 100, "height": 100,
+      "expectedX": 0, "expectedY": 99, "expectedInBounds": 1
+    },
+    {
+      "comment": "past-right x and negative y clamp independently to the opposite two edges",
+      "x": 200, "y": -5, "width": 100, "height": 100,
+      "expectedX": 99, "expectedY": 0, "expectedInBounds": 1
+    },
+    {
+      "comment": "zero-width screen: the non-zero axis still clamps, but no point is in bounds",
+      "x": 5, "y": 5, "width": 0, "height": 100,
+      "expectedX": 0, "expectedY": 5, "expectedInBounds": 0
+    },
+    {
+      "comment": "zero-height screen: mirror of the zero-width contract",
+      "x": 5, "y": 5, "width": 100, "height": 0,
+      "expectedX": 5, "expectedY": 0, "expectedInBounds": 0
     }
   ],
   "fitToViewport": [
@@ -250,6 +279,16 @@
       "comment": "non-default padding 20 (not the 32 default): padded sides 800, width candidate 400/800=0.5 — substituting DEFAULT_PADDING would give 400/824=0.4854",
       "frameWidthPx": 760, "frameHeightPx": 760, "viewportWidth": 400, "viewportHeight": 800,
       "padding": 20, "expected": 0.5
+    },
+    {
+      "comment": "exact cap boundary: padded frame is exactly 800x800 in an 800x800 viewport, so raw scale is exactly 1.0",
+      "frameWidthPx": 736, "frameHeightPx": 736, "viewportWidth": 800, "viewportHeight": 800,
+      "padding": 32, "expected": 1
+    },
+    {
+      "comment": "exact floor boundary: width candidate is exactly 240/(736+64)=0.3 while height candidate is 1.0",
+      "frameWidthPx": 736, "frameHeightPx": 736, "viewportWidth": 240, "viewportHeight": 800,
+      "padding": 32, "expected": 0.3
     }
   ],
   "screenshotRotation": [
@@ -356,6 +395,11 @@
       "comment": "ONE-axis swap rejected: measured.width == claimedHeight (1170) but measured.height != claimedWidth (2532 vs 2500) — the swap acceptance is a conjunction, so a frame matching only one opposite axis must never receive a capture identity",
       "measuredWidth": 1170, "measuredHeight": 2532, "claimedWidth": 2500, "claimedHeight": 1170,
       "expectedMatch": 0
+    },
+    {
+      "comment": "mirror ONE-axis swap rejected: measured.height == claimedWidth (1170) but measured.width != claimedHeight (2532 vs 2500), so the swapped orientation conjunction remains false",
+      "measuredWidth": 2532, "measuredHeight": 1170, "claimedWidth": 1170, "claimedHeight": 2500,
+      "expectedMatch": 0
     }
   ],
   "iosPointToPixel": [
@@ -382,6 +426,12 @@
       "willChangeUnderCanonicalPixels": true,
       "pointWidth": 375, "pointHeight": 812, "scale": 2.5,
       "expectedPixelWidth": 938, "expectedPixelHeight": 2030
+    },
+    {
+      "comment": "iPhone Plus-like nativeScale precision: 450*2.61 = 1174.5 -> 1175 and 750*2.61 = 1957.5 -> 1958, pinning the daemon's float64 multiply at a non-integer scale",
+      "willChangeUnderCanonicalPixels": true,
+      "pointWidth": 450, "pointHeight": 750, "scale": 2.61,
+      "expectedPixelWidth": 1175, "expectedPixelHeight": 1958
     },
     {
       "comment": "no runner metadata (0 sentinel = pre-#4548 runner): the daemon does NOT convert — bounds stay point-space and the frame is not stamped coordinateSpace:px (legacy fallback), so the identity 390x844 is preserved",

--- a/test/parity/coordinateMappingGoldenVectorParity.test.ts
+++ b/test/parity/coordinateMappingGoldenVectorParity.test.ts
@@ -18,12 +18,14 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "fs";
 import {
+  CLAMPED_TO_FIELDS,
   COORDINATE_KOTLIN_TEST_PATH,
   DEVICE_TO_VIEWPORT_FIELDS,
   diffNumericRows,
   FIT_SCALE_FIELDS,
   FIT_TO_VIEWPORT_FIELDS,
   loadCoordinateMappingVectors,
+  parseKotlinClampedToTable,
   parseSwiftScaleReportingTable,
   parseKotlinDeviceToViewportTable,
   parseKotlinFitScaleTable,
@@ -32,6 +34,7 @@ import {
   parseKotlinScreenshotRotationTable,
   parseKotlinViewportToDeviceTable,
   referenceDetectScreenshotRotation,
+  referenceClampedTo,
   referenceDeviceToViewport,
   referenceFitScale,
   referenceFitToViewport,
@@ -50,6 +53,7 @@ describe("coordinate-mapping golden vector parity (issue #4547)", function() {
   const canonical = loadCoordinateMappingVectors();
   const kotlinViewportToDevice = parseKotlinViewportToDeviceTable();
   const kotlinDeviceToViewport = parseKotlinDeviceToViewportTable();
+  const kotlinClampedTo = parseKotlinClampedToTable();
   const kotlinFitToViewport = parseKotlinFitToViewportTable();
   const kotlinFitScale = parseKotlinFitScaleTable();
   const kotlinScreenshotRotation = parseKotlinScreenshotRotationTable();
@@ -60,12 +64,75 @@ describe("coordinate-mapping golden vector parity (issue #4547)", function() {
     // Guards against an empty/renamed fixture silently making every parity assertion vacuous.
     expect(canonical.viewportToDevice.length).toBeGreaterThanOrEqual(10);
     expect(canonical.deviceToViewport.length).toBeGreaterThanOrEqual(3);
+    expect(canonical.clampedTo.length).toBeGreaterThanOrEqual(4);
     expect(canonical.fitToViewport.length).toBeGreaterThanOrEqual(4);
     expect(canonical.fitScale.length).toBeGreaterThanOrEqual(3);
     expect(canonical.screenshotRotation.length).toBeGreaterThanOrEqual(6);
     expect(canonical.geometryPairing.length).toBeGreaterThanOrEqual(6);
     expect(canonical.iosPointToPixel.length).toBeGreaterThanOrEqual(4);
     expect(canonical.scaleReporting.length).toBeGreaterThanOrEqual(5);
+  });
+
+  test("issue #4569: the canonical source covers the deferred coordinate-mapping gaps", function() {
+    expect(
+      canonical.clampedTo.some(row =>
+        row.x === -5 &&
+        row.y === 102 &&
+        row.width === 100 &&
+        row.height === 100 &&
+        row.expectedX === 0 &&
+        row.expectedY === 99 &&
+        row.expectedInBounds === 1
+      ),
+    ).toBe(true);
+    expect(
+      canonical.clampedTo.some(row =>
+        row.x === 5 &&
+        row.y === 5 &&
+        row.width === 0 &&
+        row.height === 100 &&
+        row.expectedX === 0 &&
+        row.expectedY === 5 &&
+        row.expectedInBounds === 0
+      ),
+    ).toBe(true);
+    expect(
+      canonical.geometryPairing.some(row =>
+        row.measuredHeight === row.claimedWidth &&
+        row.measuredWidth !== row.claimedHeight &&
+        row.expectedMatch === 0
+      ),
+    ).toBe(true);
+    expect(
+      canonical.fitScale.some(row =>
+        row.viewportWidth === row.frameWidthPx + row.padding * 2 &&
+        row.viewportHeight === row.frameHeightPx + row.padding * 2 &&
+        row.expected === 1
+      ),
+    ).toBe(true);
+    expect(
+      canonical.fitScale.some(row =>
+        row.viewportWidth / (row.frameWidthPx + row.padding * 2) === 0.3 &&
+        row.expected === 0.3
+      ),
+    ).toBe(true);
+    expect(
+      canonical.iosPointToPixel.some(row =>
+        row.pointWidth === 450 &&
+        row.pointHeight === 750 &&
+        row.scale === 2.61 &&
+        row.expectedPixelWidth === 1175 &&
+        row.expectedPixelHeight === 1958
+      ),
+    ).toBe(true);
+    expect(
+      canonical.deviceToViewport.some(row =>
+        row.deviceWidth === 0 &&
+        row.scale === 2 &&
+        row.offsetX === 10 &&
+        row.offsetY === 20
+      ),
+    ).toBe(true);
   });
 
   test("B1: Swift scaleReporting literals are verified against the single source (issue #4548)", function() {
@@ -110,6 +177,10 @@ describe("coordinate-mapping golden vector parity (issue #4547)", function() {
 
   test("AC1: Kotlin deviceToViewport literals are verified against the single source", function() {
     expect(diffNumericRows(kotlinDeviceToViewport, canonical.deviceToViewport, DEVICE_TO_VIEWPORT_FIELDS)).toEqual([]);
+  });
+
+  test("AC1: Kotlin clampedTo literals are verified against the single source", function() {
+    expect(diffNumericRows(kotlinClampedTo, canonical.clampedTo, CLAMPED_TO_FIELDS)).toEqual([]);
   });
 
   test("AC1: Kotlin fitToViewport literals are verified against the single source", function() {
@@ -201,6 +272,19 @@ describe("coordinate-mapping golden vector parity (issue #4547)", function() {
     ]) {
       expect(kotlinSource).toContain(symbol);
     }
+    for (const methodName of [
+      "viewportToDevice matches the golden vectors",
+      "deviceToViewport matches the golden vectors",
+      "clampedTo matches the golden vectors",
+      "fitToViewport matches the golden vectors",
+      "fitScale matches the golden vectors",
+      "detectScreenshotRotation matches the golden vectors",
+      "scale reporting matches the golden vectors",
+    ]) {
+      expect(kotlinSource).toMatch(
+        new RegExp(String.raw`@Test\s+fun \`${methodName}\`\(\)`),
+      );
+    }
   });
 
   test("every viewportToDevice row's expected outputs are DERIVABLE from its inputs", function() {
@@ -218,6 +302,15 @@ describe("coordinate-mapping golden vector parity (issue #4547)", function() {
       const computed = referenceDeviceToViewport(row);
       expect(Math.abs(computed.x - row.expectedX)).toBeLessThanOrEqual(1e-3);
       expect(Math.abs(computed.y - row.expectedY)).toBeLessThanOrEqual(1e-3);
+    }
+  });
+
+  test("every clampedTo row's expected output is DERIVABLE from its inputs", function() {
+    for (let i = 0; i < canonical.clampedTo.length; i++) {
+      const row = canonical.clampedTo[i];
+      const computed = referenceClampedTo(row);
+      expect(`${i}:${computed.x},${computed.y},${computed.inBounds}`)
+        .toBe(`${i}:${row.expectedX},${row.expectedY},${row.expectedInBounds}`);
     }
   });
 

--- a/test/parity/coordinateMappingGoldenVectorParity.test.ts
+++ b/test/parity/coordinateMappingGoldenVectorParity.test.ts
@@ -126,6 +126,15 @@ describe("coordinate-mapping golden vector parity (issue #4547)", function() {
       ),
     ).toBe(true);
     expect(
+      canonical.scaleReporting.some(row =>
+        row.pointWidth === 450 &&
+        row.pointHeight === 750 &&
+        row.nativeScale === 2.61 &&
+        row.expectedPixelWidth === 1175 &&
+        row.expectedPixelHeight === 1958
+      ),
+    ).toBe(true);
+    expect(
       canonical.deviceToViewport.some(row =>
         row.deviceWidth === 0 &&
         row.scale === 2 &&
@@ -265,6 +274,7 @@ describe("coordinate-mapping golden vector parity (issue #4547)", function() {
     for (const symbol of [
       "viewportToDevice(",
       "deviceToViewport(",
+      "clampedTo(",
       "fitToViewport(",
       "fitScale(",
       "detectScreenshotRotation(",
@@ -284,6 +294,23 @@ describe("coordinate-mapping golden vector parity (issue #4547)", function() {
       expect(kotlinSource).toMatch(
         new RegExp(String.raw`@Test\s+fun \`${methodName}\`\(\)`),
       );
+    }
+    for (const [methodName, productionCall] of [
+      ["viewportToDevice matches the golden vectors", "mapper.viewportToDevice("],
+      ["deviceToViewport matches the golden vectors", "mapper.deviceToViewport("],
+      ["clampedTo matches the golden vectors", "DevicePoint(vector.x, vector.y, inBounds = false).clampedTo("],
+      ["fitToViewport matches the golden vectors", "mapper.fitToViewport("],
+      ["fitScale matches the golden vectors", "mapper.fitScale("],
+      ["detectScreenshotRotation matches the golden vectors", "mapper.detectScreenshotRotation("],
+      ["scale reporting matches the golden vectors", "(vector.pointWidth * vector.nativeScale).roundToInt()"],
+    ]) {
+      const methodStart = kotlinSource.indexOf(`fun \`${methodName}\`()`);
+      const bodyStart = kotlinSource.indexOf("{", methodStart);
+      const nextTest = kotlinSource.indexOf("\n  @Test", bodyStart);
+      const body = kotlinSource.slice(bodyStart, nextTest === -1 ? kotlinSource.length : nextTest);
+      expect(methodStart).toBeGreaterThanOrEqual(0);
+      expect(body).toContain(productionCall);
+      expect(body).toContain("assertEquals(");
     }
   });
 

--- a/test/parity/coordinateMappingGoldenVectorParity.test.ts
+++ b/test/parity/coordinateMappingGoldenVectorParity.test.ts
@@ -326,7 +326,7 @@ describe("coordinate-mapping golden vector parity (issue #4547)", function() {
   test("every fitScale row's expected output is DERIVABLE from its inputs", function() {
     for (let i = 0; i < canonical.fitScale.length; i++) {
       const row = canonical.fitScale[i];
-      expect(Math.abs(referenceFitScale(row) - row.expected)).toBeLessThanOrEqual(1e-3);
+      expect(referenceFitScale(row)).toBe(Math.fround(row.expected));
     }
   });
 

--- a/test/parity/coordinateMappingGoldenVectors.ts
+++ b/test/parity/coordinateMappingGoldenVectors.ts
@@ -4,9 +4,10 @@
  *
  * Canonical source: `test/fixtures/coordinate-mapping-golden-vectors.json`. Consumers:
  * - Kotlin `CoordinateMappingGoldenVectorTest.kt` (desktop-core) holds inline copies of the five
- *   `DeviceScreenCoordinateMapper` sections plus the scale-reporting contract; this module parses those committed literals out of
- *   the Kotlin source (the pinch-vector mechanism, see `pinchGoldenVectors.ts`) and the parity
- *   test verifies them against the JSON.
+ *   `DeviceScreenCoordinateMapper` sections, `DevicePoint.clampedTo`, and the scale-reporting
+ *   contract; this module parses those committed literals out of the Kotlin source (the
+ *   pinch-vector mechanism, see `pinchGoldenVectors.ts`) and the parity test verifies them against
+ *   the JSON.
  * - TypeScript daemon tests read the JSON directly: `geometryPairing` drives the daemon's
  *   `pixelsMatchClaimedGeometry` pairing (`test/daemon/deviceDataStreamSocketServer.test.ts`) and
  *   `iosPointToPixel` drives the iOS point->pixel conversion
@@ -88,6 +89,16 @@ export interface DeviceToViewportVector {
   willChangeUnderCanonicalPixels?: boolean;
 }
 
+export interface ClampedToVector {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  expectedX: number;
+  expectedY: number;
+  expectedInBounds: number;
+}
+
 export interface FitToViewportVector {
   imageWidth: number;
   imageHeight: number;
@@ -152,6 +163,7 @@ export interface ScaleReportingVector {
 export interface CoordinateMappingGoldenVectors {
   viewportToDevice: ViewportToDeviceVector[];
   deviceToViewport: DeviceToViewportVector[];
+  clampedTo: ClampedToVector[];
   fitToViewport: FitToViewportVector[];
   fitScale: FitScaleVector[];
   screenshotRotation: ScreenshotRotationVector[];
@@ -163,6 +175,7 @@ export interface CoordinateMappingGoldenVectors {
 const SECTION_NAMES = [
   "viewportToDevice",
   "deviceToViewport",
+  "clampedTo",
   "fitToViewport",
   "fitScale",
   "screenshotRotation",
@@ -296,6 +309,18 @@ export function parseKotlinDeviceToViewportTable(): DeviceToViewportVector[] {
   }));
 }
 
+export function parseKotlinClampedToTable(): ClampedToVector[] {
+  return parseKotlinSection("val clampedToVectors =", 7).map(row => ({
+    x: row[0],
+    y: row[1],
+    width: row[2],
+    height: row[3],
+    expectedX: row[4],
+    expectedY: row[5],
+    expectedInBounds: row[6],
+  }));
+}
+
 export function parseKotlinFitToViewportTable(): FitToViewportVector[] {
   return parseKotlinSection("val fitToViewportVectors =", 7).map(row => ({
     imageWidth: row[0],
@@ -372,6 +397,17 @@ export function referenceDeviceToViewport(
   return {
     x: f(f(frameX * vector.scale) + vector.offsetX),
     y: f(f(frameY * vector.scale) + vector.offsetY),
+  };
+}
+
+/** Mirrors `DevicePoint.clampedTo`: pin to an addressable edge without inventing a point in an empty rect. */
+export function referenceClampedTo(
+  vector: ClampedToVector,
+): { x: number; y: number; inBounds: number } {
+  return {
+    x: Math.min(Math.max(vector.x, 0), Math.max(vector.width - 1, 0)),
+    y: Math.min(Math.max(vector.y, 0), Math.max(vector.height - 1, 0)),
+    inBounds: vector.width > 0 && vector.height > 0 ? 1 : 0,
   };
 }
 
@@ -527,6 +563,16 @@ export const DEVICE_TO_VIEWPORT_FIELDS = [
   "expectedY",
 ] as const;
 
+export const CLAMPED_TO_FIELDS = [
+  "x",
+  "y",
+  "width",
+  "height",
+  "expectedX",
+  "expectedY",
+  "expectedInBounds",
+] as const;
+
 export const FIT_TO_VIEWPORT_FIELDS = [
   "imageWidth",
   "imageHeight",
@@ -582,6 +628,7 @@ export const SCALE_REPORTING_FIELDS = [
 const SECTION_NUMERIC_FIELDS: Record<(typeof SECTION_NAMES)[number], readonly string[]> = {
   viewportToDevice: VIEWPORT_TO_DEVICE_FIELDS,
   deviceToViewport: DEVICE_TO_VIEWPORT_FIELDS,
+  clampedTo: CLAMPED_TO_FIELDS,
   fitToViewport: FIT_TO_VIEWPORT_FIELDS,
   fitScale: FIT_SCALE_FIELDS,
   screenshotRotation: SCREENSHOT_ROTATION_FIELDS,


### PR DESCRIPTION
## Summary

Extends the coordinate-mapping golden-vector suite with the deferred coverage rows from [#4569](https://github.com/kaeawc/auto-mobile/issues/4569).

- Adds `DevicePoint.clampedTo` cross-language vectors and Kotlin runtime coverage, including edge clamping and zero-dimension screens.
- Pins the mirror one-axis geometry-pairing rejection, exact `fitScale` floor/cap boundaries, iOS `2.61` scale rounding, and zero-width `deviceToViewport` pan/zoom behavior.
- Strengthens the Kotlin/fixture parity guard so every golden-vector loop is directly annotated with `@Test`.
- Retains iOS `nativeScale` as `Double` through the runner, so a `2.61` native scale reports pixel dimensions consistent with the daemon's canonical-pixel conversion.

## Why

The original coordinate-mapping vectors covered the documented mapper rules but intentionally deferred these incremental mutation cases. The new `2.61` row also exposed an iOS producer mismatch: narrowing `UIScreen.nativeScale` to `Float` changed a half-pixel product before the runner reported its dimensions. These changes keep the runner and daemon on the same double-precision contract.

## Validation

- `bun test test/parity/coordinateMappingGoldenVectorParity.test.ts`
- `(cd android && ./gradlew :desktop-core:test --tests '*CoordinateMappingGoldenVectorTest')`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run turbo:validate`
- `bash scripts/ios/swift-test.sh`

Closes [#4569](https://github.com/kaeawc/auto-mobile/issues/4569).
