### PR TITLE
refactor(a11y): narrow WcagAudit baseline seam

### DIFF
--- a/src/features/accessibility/WcagAudit.ts
+++ b/src/features/accessibility/WcagAudit.ts
@@ -17,14 +17,20 @@ import { ContrastChecker } from "./ContrastChecker";
 import { BaselineManager } from "./BaselineManager";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 
+export interface WcagBaselineStore {
+  getBaseline(screenId: string): Promise<{ violations: Pick<WcagViolation, "fingerprint">[] } | null>;
+  saveBaseline(screenId: string, violations: WcagViolation[]): Promise<void>;
+  clearBaseline(screenId: string): Promise<void>;
+}
+
 export class WcagAudit {
   private contrastChecker: ContrastChecker;
-  private baselineManager: BaselineManager;
+  private baselineStore: WcagBaselineStore;
   private timer: Timer;
 
-  constructor(timer: Timer = defaultTimer, baselineManager: BaselineManager = new BaselineManager()) {
+  constructor(timer: Timer = defaultTimer, baselineStore: WcagBaselineStore = new BaselineManager()) {
     this.contrastChecker = new ContrastChecker({}, timer);
-    this.baselineManager = baselineManager;
+    this.baselineStore = baselineStore;
     this.timer = timer;
   }
 
@@ -71,7 +77,7 @@ export class WcagAudit {
     let baselinedCount = 0;
 
     if (config.useBaseline) {
-      const baseline = await this.baselineManager.getBaseline(screenId);
+      const baseline = await this.baselineStore.getBaseline(screenId);
       if (baseline) {
         const baselineFingerprints = new Set(baseline.violations.map(v => v.fingerprint));
         filteredViolations = violations.filter(v => !baselineFingerprints.has(v.fingerprint));
@@ -100,14 +106,14 @@ export class WcagAudit {
    * Save current violations as baseline
    */
   async saveBaseline(result: AccessibilityAuditResult): Promise<void> {
-    await this.baselineManager.saveBaseline(result.screenId, result.violations);
+    await this.baselineStore.saveBaseline(result.screenId, result.violations);
   }
 
   /**
    * Clear baseline for a screen
    */
   async clearBaseline(screenId: string): Promise<void> {
-    await this.baselineManager.clearBaseline(screenId);
+    await this.baselineStore.clearBaseline(screenId);
   }
 
   /**

--- a/test/features/accessibility/WcagAudit.test.ts
+++ b/test/features/accessibility/WcagAudit.test.ts
@@ -4,26 +4,26 @@
  */
 
 import { expect, describe, it, beforeEach } from "bun:test";
-import { WcagAudit } from "../../../src/features/accessibility/WcagAudit";
-import { BaselineManager } from "../../../src/features/accessibility/BaselineManager";
+import { WcagAudit, type WcagBaselineStore } from "../../../src/features/accessibility/WcagAudit";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import type { Element } from "../../../src/models/Element";
 import type { ViewHierarchyNode } from "../../../src/models/ViewHierarchyResult";
-import type { AccessibilityAuditConfig } from "../../../src/models/AccessibilityAudit";
+import type { AccessibilityAuditConfig, WcagViolation } from "../../../src/models/AccessibilityAudit";
 
 /**
- * BaselineManager double that returns a canned baseline without touching any
- * database. Construction alone never resolves the file-backed singleton (the DB
- * handle is resolved lazily), and getBaseline is overridden so the query path is
- * never reached (issue #3067).
+ * Baseline-store fake that returns a canned baseline without touching persistence.
  */
-class StubBaselineManager extends BaselineManager {
-  constructor(private readonly stub: Awaited<ReturnType<BaselineManager["getBaseline"]>>) {
-    super();
+class StubBaselineManager implements WcagBaselineStore {
+  constructor(private readonly stub: { violations: Pick<WcagViolation, "fingerprint">[] } | null) {
   }
-  async getBaseline(): Promise<Awaited<ReturnType<BaselineManager["getBaseline"]>>> {
+
+  async getBaseline(_screenId: string): Promise<{ violations: Pick<WcagViolation, "fingerprint">[] } | null> {
     return this.stub;
   }
+
+  async saveBaseline(_screenId: string, _violations: WcagViolation[]): Promise<void> {}
+
+  async clearBaseline(_screenId: string): Promise<void> {}
 }
 
 describe("WcagAudit", function() {
@@ -473,9 +473,7 @@ describe("WcagAudit", function() {
       const suppressed = seedResult.violations[0];
 
       const stub = new StubBaselineManager({
-        screenId: seedResult.screenId,
         violations: [suppressed],
-        updatedAt: new Date().toISOString(),
       });
       const withBaseline = new WcagAudit(new FakeTimer(), stub);
       const result = await withBaseline.audit(elements, hierarchy, undefined, "com.test", {
@@ -494,9 +492,7 @@ describe("WcagAudit", function() {
       const seedResult = await baselineAndFindings();
 
       const stub = new StubBaselineManager({
-        screenId: seedResult.screenId,
         violations: seedResult.violations,
-        updatedAt: new Date().toISOString(),
       });
       const withBaseline = new WcagAudit(new FakeTimer(), stub);
       const result = await withBaseline.audit(elements, hierarchy, undefined, "com.test", {


### PR DESCRIPTION
## Summary

- Add a narrow `WcagBaselineStore` interface at the `WcagAudit` consumer boundary.
- Keep `BaselineManager` as the unchanged default production implementation.
- Replace the suppression-test subclass with a plain interface fake.

## Why

`BaselineManager` has private persistence state, so TypeScript rejected lightweight fakes even though `WcagAudit` only needs baseline operations. The narrow seam keeps tests and alternate implementations independent of that persistence detail.

## Validation

- `AUTOMOBILE_DATA_DIR=/private/tmp/auto-mobile-issue-4510 bun test test/features/accessibility/WcagAudit.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun test --isolate --path-ignore-patterns='test/integration/webrtcDeviceCapture.integration.test.ts'` (`11974 pass, 11 skip, 0 fail`)
- `bun test test/integration/webrtcDeviceCapture.integration.test.ts` with the normal log path (`2 skip, 0 fail`)

`bun run turbo:validate` completed lint, build, and boundary tasks, but its test child stalled locally after the skipped WebRTC integration file. The full-suite command above and the excluded file both completed green.

Closes [#4510](https://github.com/kaeawc/auto-mobile/issues/4510)
