### PR TITLE
fix(android): redact system tray notification diagnostics

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,7 @@ async function main() {
   const { StdioServerTransport } = await import("@modelcontextprotocol/sdk/server/stdio.js");
   const { createMcpServer } = await import("./server");
   const { createProxyMcpServer } = await import("./server/proxyServer");
-  const { logger } = await import("./utils/logger");
+  const { logger, LogLevel } = await import("./utils/logger");
   fatalLogger = logger;
   const { runCliCommand } = await import("./cli");
   const { runDaemonCommand } = await import("./daemon/manager");
@@ -176,6 +176,10 @@ async function main() {
       outputReduction,
       toolOutputsDir,
     } = parseArgs(process.argv.slice(2), logger);
+
+    if (debug) {
+      logger.setLogLevel(LogLevel.DEBUG);
+    }
 
     serverConfig.setPlanExecutionLockScope(planExecutionLockScope);
     serverConfig.setVideoRecordingDefaults(videoRecordingDefaults);

--- a/src/server/systemTrayHelpers.ts
+++ b/src/server/systemTrayHelpers.ts
@@ -1083,15 +1083,19 @@ const collectNotificationSubtreeTexts = (node: any): string[] => {
   return texts;
 };
 
+type UnmatchedNotificationDiagnostics = {
+  info: string;
+  debug: string;
+};
+
 // Diagnostic: when the shade is open but no notification matched the criteria,
-// summarize every notification-row candidate and the text found inside each so a
-// failing run reveals whether the target text is present-but-unmatched vs. absent
-// from the captured hierarchy (issue: persistent-push notification "not found").
+// keep the state summary safe for default logs and place notification payloads
+// in the debug-only detail.
 const buildUnmatchedNotificationDiagnostics = (
   viewHierarchy: ViewHierarchyResult,
   criteria: SystemTrayNotificationArgs,
   appMatchTexts: string[]
-): string => {
+): UnmatchedNotificationDiagnostics => {
   const candidates = collectNotificationCandidates(viewHierarchy);
   const lines: string[] = [];
   for (let index = 0; index < candidates.length; index++) {
@@ -1108,13 +1112,15 @@ const buildUnmatchedNotificationDiagnostics = (
     appId: criteria.appId,
     tapActionLabel: criteria.tapActionLabel
   });
-  const header =
+  const info =
     `[systemTray][diag] shade open but no notification matched. ` +
-    `criteria=${criteriaSummary} appMatchTexts=${JSON.stringify(appMatchTexts)} ` +
     `candidateCount=${candidates.length}`;
-  return candidates.length > 0
-    ? `${header}\n${lines.join("\n")}`
-    : `${header} (no notification-row candidates detected in the open shade)`;
+  const debug =
+    `${info} criteria=${criteriaSummary} appMatchTexts=${JSON.stringify(appMatchTexts)}` +
+    (candidates.length > 0
+      ? `\n${lines.join("\n")}`
+      : " (no notification-row candidates detected in the open shade)");
+  return { info, debug };
 };
 
 export const waitForNotificationMatch = async (
@@ -1143,7 +1149,8 @@ export const waitForNotificationMatch = async (
     observation = await observeScreen.execute({ skipWaitForFresh: false, minTimestamp });
   }
 
-  let lastDiagSignature = "";
+  let lastInfoDiagSignature = "";
+  let lastDebugDiagSignature = "";
   let lastReexpandAtMs = timer.now();
   while (true) {
     const viewHierarchy = observation.viewHierarchy;
@@ -1155,9 +1162,13 @@ export const waitForNotificationMatch = async (
       // Diagnostic: log the candidate breakdown when the shade is open but nothing
       // matched, deduped so a 120s poll loop does not emit identical lines each tick.
       const diagnostics = buildUnmatchedNotificationDiagnostics(viewHierarchy, criteria, appMatchTexts);
-      if (diagnostics !== lastDiagSignature) {
-        lastDiagSignature = diagnostics;
-        logger.info(diagnostics);
+      if (diagnostics.info !== lastInfoDiagSignature) {
+        lastInfoDiagSignature = diagnostics.info;
+        logger.info(diagnostics.info);
+      }
+      if (diagnostics.debug !== lastDebugDiagSignature) {
+        lastDebugDiagSignature = diagnostics.debug;
+        logger.debug(diagnostics.debug);
       }
     } else {
       // The shade is not open. ensureSystemTrayOpen expanded it once, but a
@@ -1176,10 +1187,11 @@ export const waitForNotificationMatch = async (
       const trayDiag =
         `[systemTray][diag] shade NOT detected open during notification wait ` +
         `(hasHierarchy=${Boolean(observation.viewHierarchy)})`;
-      if (trayDiag !== lastDiagSignature) {
-        lastDiagSignature = trayDiag;
+      if (trayDiag !== lastInfoDiagSignature) {
+        lastInfoDiagSignature = trayDiag;
         logger.info(trayDiag);
       }
+      lastDebugDiagSignature = "";
     }
 
     if (timer.now() >= deadlineMs) {

--- a/test/server/systemTray.test.ts
+++ b/test/server/systemTray.test.ts
@@ -19,7 +19,7 @@ import type { SystemTrayIosClient } from "../../src/server/systemTrayHelpers";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
 import { FakeObserveScreen } from "../fakes/FakeObserveScreen";
-import { logger } from "../../src/utils/logger";
+import { logger, LogLevel } from "../../src/utils/logger";
 import type { BootedDevice, Element, ObserveResult, ViewHierarchyResult } from "../../src/models";
 
 const POLL_INTERVAL_MS = 250;
@@ -490,30 +490,43 @@ describe("systemTray unmatched-notification diagnostics", () => {
     resetSystemTrayDependencies();
   });
 
-  test("keeps the candidate count at info and sends notification previews to debug", async () => {
-    const fakeTimer = new FakeTimer();
-    const fakeAdb = new SequencedFakeAdbExecutor([1000, 2000]);
+  test("keeps payload-bearing diagnostics out of the INFO sink and emits them at DEBUG", async () => {
     const notificationPreview = "Alice: Project secret";
-    const fakeObserveScreen = new SequencedObserveScreen([
-      createObservation(createTrayHierarchy(notificationPreview)),
-      createObservation(createTrayHierarchy(notificationPreview)),
-      createObservation(createTrayHierarchy(notificationPreview)),
-      createObservation(createTrayHierarchy("Target Notification"))
-    ]);
+    const criteria = {
+      title: "Alice private target",
+      body: "Confidential body",
+      tapActionLabel: "Open Alice private target"
+    };
+    const appMatchTexts = ["Alice work profile"];
+    const payloads = [
+      notificationPreview,
+      criteria.title,
+      criteria.body,
+      criteria.tapActionLabel,
+      appMatchTexts[0]
+    ];
+    const waitForTarget = async (): Promise<void> => {
+      const fakeTimer = new FakeTimer();
+      const fakeAdb = new SequencedFakeAdbExecutor([1000, 2000]);
+      const fakeObserveScreen = new SequencedObserveScreen([
+        createObservation(createTrayHierarchy(notificationPreview)),
+        createObservation(createTrayHierarchy(notificationPreview)),
+        createObservation(createTrayHierarchy(notificationPreview)),
+        createObservation(createTrayHierarchy(
+          `${criteria.title} ${criteria.body} ${criteria.tapActionLabel}`
+        ))
+      ]);
 
-    setSystemTrayDependencies({
-      timer: fakeTimer,
-      adbFactory: () => fakeAdb,
-      observeScreenFactory: () => fakeObserveScreen
-    });
+      setSystemTrayDependencies({
+        timer: fakeTimer,
+        adbFactory: () => fakeAdb,
+        observeScreenFactory: () => fakeObserveScreen
+      });
 
-    const infoSpy = spyOn(logger, "info").mockImplementation(() => {});
-    const debugSpy = spyOn(logger, "debug").mockImplementation(() => {});
-    try {
       const resultPromise = waitForNotificationMatch(
         device,
-        { title: "Target Notification" },
-        [],
+        criteria,
+        appMatchTexts,
         5000
       );
 
@@ -522,20 +535,52 @@ describe("systemTray unmatched-notification diagnostics", () => {
       const result = await resultPromise;
 
       expect(result.match).not.toBeNull();
-      const diagLogs = infoSpy.mock.calls.filter(call =>
-        String(call[0]).includes("[systemTray][diag] shade open but no notification matched")
-      );
-      expect(diagLogs.length).toBe(1);
-      expect(String(diagLogs[0][0])).toContain("candidateCount=1");
-      expect(String(diagLogs[0][0])).not.toContain(notificationPreview);
-      const debugDiagLogs = debugSpy.mock.calls.filter(call =>
-        String(call[0]).includes("[systemTray][diag] shade open but no notification matched")
-      );
-      expect(debugDiagLogs.length).toBe(1);
-      expect(String(debugDiagLogs[0][0])).toContain(notificationPreview);
+      expect(result.match!.match.matches.title?.text).toBe(criteria.title);
+    };
+
+    const previousLevel = logger.getLogLevel();
+    const stdoutSpy = spyOn(process.stdout, "write").mockImplementation(() => true);
+    logger.enableStdoutLogging();
+    try {
+      // The singleton logger may still have writes queued by earlier tests.
+      // Drain them before this test begins counting its own sink output.
+      await logger.flush();
+      stdoutSpy.mockClear();
+      logger.setLogLevel(LogLevel.INFO);
+      await waitForTarget();
+
+      // Prove the asynchronous sink is live at INFO so the absence checks cannot
+      // pass merely because logger output was never flushed.
+      const infoSentinel = "__system_tray_info_sink_4614__";
+      logger.info(infoSentinel);
+      await logger.flush();
+      expect(stdoutSpy.mock.calls.some(call => String(call[0] ?? "").includes(infoSentinel))).toBe(true);
+
+      const infoDiagnostics = stdoutSpy.mock.calls
+        .map(call => String(call[0] ?? ""))
+        .filter(line => line.includes("[INFO] [systemTray][diag] shade open but no notification matched"));
+      expect(infoDiagnostics).toHaveLength(1);
+      expect(infoDiagnostics[0]).toContain("candidateCount=1");
+      for (const payload of payloads) {
+        expect(infoDiagnostics[0]).not.toContain(payload);
+      }
+
+      stdoutSpy.mockClear();
+      logger.setLogLevel(LogLevel.DEBUG);
+      await waitForTarget();
+      await logger.flush();
+
+      const debugDiagnostics = stdoutSpy.mock.calls
+        .map(call => String(call[0] ?? ""))
+        .filter(line => line.includes("[DEBUG] [systemTray][diag] shade open but no notification matched"));
+      expect(debugDiagnostics).toHaveLength(1);
+      for (const payload of payloads) {
+        expect(debugDiagnostics[0]).toContain(payload);
+      }
     } finally {
-      infoSpy.mockRestore();
-      debugSpy.mockRestore();
+      logger.setLogLevel(previousLevel);
+      logger.disableStdoutLogging();
+      stdoutSpy.mockRestore();
     }
   });
 

--- a/test/server/systemTray.test.ts
+++ b/test/server/systemTray.test.ts
@@ -360,6 +360,48 @@ describe("systemTray re-expand on closed shade during wait", () => {
     ).toBe(1);
   });
 
+  test("re-expands again after a second throttle interval while the shade remains closed", async () => {
+    const fakeTimer = new FakeTimer();
+    const fakeAdb = new SequencedFakeAdbExecutor([1000, 2000]);
+    const fakeObserveScreen = new SequencedObserveScreen([
+      createObservation(createTrayHierarchy("Other Notification")),
+      createObservation(createClosedHierarchy()),
+      createObservation(createClosedHierarchy()),
+      createObservation(createClosedHierarchy()),
+      createObservation(createClosedHierarchy()),
+      createObservation(createClosedHierarchy()),
+      createObservation(createClosedHierarchy()),
+      createObservation(createClosedHierarchy()),
+      createObservation(createClosedHierarchy()),
+      createObservation(createTrayHierarchy("Target Notification"))
+    ]);
+
+    setSystemTrayDependencies({
+      timer: fakeTimer,
+      adbFactory: () => fakeAdb,
+      observeScreenFactory: () => fakeObserveScreen
+    });
+
+    const resultPromise = waitForNotificationMatch(
+      device,
+      { title: "Target Notification" },
+      [],
+      REEXPAND_INTERVAL_MS * 5
+    );
+
+    // At t=1000 and t=2000, the closed shade crosses the re-expand throttle
+    // interval. The target appears after the second best-effort retry.
+    await advancePendingSleeps(fakeTimer, 9);
+
+    const result = await resultPromise;
+
+    expect(result.match).not.toBeNull();
+    expect(result.match!.match.matches.title?.text).toBe("Target Notification");
+    expect(
+      fakeAdb.getExecutedCommands().filter(cmd => cmd.includes("expand-notifications")).length
+    ).toBe(2);
+  });
+
   test("does not re-expand before a full throttle interval has elapsed", async () => {
     const fakeTimer = new FakeTimer();
     const fakeAdb = new SequencedFakeAdbExecutor([1000, 2000]);
@@ -448,13 +490,14 @@ describe("systemTray unmatched-notification diagnostics", () => {
     resetSystemTrayDependencies();
   });
 
-  test("logs the open-but-unmatched candidate breakdown once, deduped across identical polls", async () => {
+  test("keeps the candidate count at info and sends notification previews to debug", async () => {
     const fakeTimer = new FakeTimer();
     const fakeAdb = new SequencedFakeAdbExecutor([1000, 2000]);
+    const notificationPreview = "Alice: Project secret";
     const fakeObserveScreen = new SequencedObserveScreen([
-      createObservation(createTrayHierarchy("Other Notification")),
-      createObservation(createTrayHierarchy("Other Notification")),
-      createObservation(createTrayHierarchy("Other Notification")),
+      createObservation(createTrayHierarchy(notificationPreview)),
+      createObservation(createTrayHierarchy(notificationPreview)),
+      createObservation(createTrayHierarchy(notificationPreview)),
       createObservation(createTrayHierarchy("Target Notification"))
     ]);
 
@@ -465,6 +508,7 @@ describe("systemTray unmatched-notification diagnostics", () => {
     });
 
     const infoSpy = spyOn(logger, "info").mockImplementation(() => {});
+    const debugSpy = spyOn(logger, "debug").mockImplementation(() => {});
     try {
       const resultPromise = waitForNotificationMatch(
         device,
@@ -482,9 +526,16 @@ describe("systemTray unmatched-notification diagnostics", () => {
         String(call[0]).includes("[systemTray][diag] shade open but no notification matched")
       );
       expect(diagLogs.length).toBe(1);
-      expect(String(diagLogs[0][0])).toContain("Other Notification");
+      expect(String(diagLogs[0][0])).toContain("candidateCount=1");
+      expect(String(diagLogs[0][0])).not.toContain(notificationPreview);
+      const debugDiagLogs = debugSpy.mock.calls.filter(call =>
+        String(call[0]).includes("[systemTray][diag] shade open but no notification matched")
+      );
+      expect(debugDiagLogs.length).toBe(1);
+      expect(String(debugDiagLogs[0][0])).toContain(notificationPreview);
     } finally {
       infoSpy.mockRestore();
+      debugSpy.mockRestore();
     }
   });
 


### PR DESCRIPTION
## Summary

Moves payload-bearing unmatched-notification diagnostics to debug logging while retaining safe shade-state and candidate-count summaries at info. Adds FakeTimer coverage showing that a closed shade is re-expanded across two throttle intervals.

## Linked Issue

Closes [#4614](https://github.com/kaeawc/auto-mobile/issues/4614)

## Bug / Regression Context

- **Prior attempts:** [PR #4630](https://github.com/kaeawc/auto-mobile/pull/4630) added the re-expansion behavior and unmatched-notification diagnostics.
- **Observed symptom:** Default info logs could persist notification row text and content descriptions, including message previews and sender content.
- **Repro steps / conditions:** Wait for a non-matching notification while the system tray is open.

## Validation

- [x] `bun test test/server/systemTray.test.ts`
- [x] `bun run typecheck` reports no new errors
- [x] New coverage uses injected dependencies, fakes, and `FakeTimer`
- [x] Rebased onto current `main`
- [ ] `bun run turbo:validate` could not complete its full test leg because unrelated CtrlProxy-heavy tests cannot allocate host ports in the managed sandbox. Lint, build, and boundary checks passed before the port-allocation failures.
