### PR TITLE
fix(daemon): session capability isolation, enforcement, and lifecycle

### DIFF
--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -139,8 +139,8 @@ export const DAEMON_SESSION_TOOL_BINDING_HEADER = "x-auto-mobile-session-uuid";
  * How long the proxy will keep replaying a remembered session binding on
  * sessionless calls before treating it as retired (issue #4610). It mirrors the
  * daemon's session idle timeout (`SessionManager.SESSION_TIMEOUT_MS`, 30 min):
- * once this window elapses with no explicit-`sessionUuid` call refreshing the
- * binding, the daemon session has certainly idle/heartbeat-expired, and
+ * once this window elapses with no forwarded call (explicit or implicit)
+ * refreshing the binding, the daemon session has certainly idle/heartbeat-expired, and
  * replaying its UUID would silently recreate the released session and reacquire
  * a device without the caller asking for it.
  */

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -136,6 +136,17 @@ export const MCP_STREAMABLE_PATH = "/auto-mobile/streamable";
 export const DAEMON_SESSION_TOOL_BINDING_HEADER = "x-auto-mobile-session-uuid";
 
 /**
+ * How long the proxy will keep replaying a remembered session binding on
+ * sessionless calls before treating it as retired (issue #4610). It mirrors the
+ * daemon's session idle timeout (`SessionManager.SESSION_TIMEOUT_MS`, 30 min):
+ * once this window elapses with no explicit-`sessionUuid` call refreshing the
+ * binding, the daemon session has certainly idle/heartbeat-expired, and
+ * replaying its UUID would silently recreate the released session and reacquire
+ * a device without the caller asking for it.
+ */
+export const DAEMON_BOUND_SESSION_REPLAY_TTL_MS = 30 * 60 * 1000;
+
+/**
  * Control-socket method a client sends to opt in to server-pushed
  * `DaemonNotification` frames (tools/resources list_changed forwarding,
  * issue #3223). Opt-in keeps the push invisible to Kotlin/Swift/legacy

--- a/src/daemon/constants.ts
+++ b/src/daemon/constants.ts
@@ -130,6 +130,12 @@ export const READINESS_PROBE_BACKOFF_MS = 150;
 export const MCP_STREAMABLE_PATH = "/auto-mobile/streamable";
 
 /**
+ * Internal loopback header used to restore a daemon socket's capability
+ * profile when its Streamable HTTP MCP transport is recreated.
+ */
+export const DAEMON_SESSION_TOOL_BINDING_HEADER = "x-auto-mobile-session-uuid";
+
+/**
  * Control-socket method a client sends to opt in to server-pushed
  * `DaemonNotification` frames (tools/resources list_changed forwarding,
  * issue #3223). Opt-in keeps the push invisible to Kotlin/Swift/legacy

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -23,6 +23,7 @@ import { PID_FILE_PATH, DAEMON_VERSION } from "./constants";
 import { getCurrentBuildIdentity } from "./buildIdentity";
 import { cleanupDaemonFiles, cleanupDaemonFilesSync, readPidFileDataSync } from "./daemonFiles";
 import { executionTracker } from "../server/executionTracker";
+import { SessionReleaseBroadcaster } from "../server/sessionReleaseBroadcast";
 import {
   awaitInFlightMigrations,
   closeDatabase,
@@ -192,6 +193,14 @@ export class Daemon {
     this.sessionManager.onSessionRelease((sessionId, deviceId) => {
       NavigationGraphManager.releaseSession(sessionId);
       RealObserveScreen.clearCache(deviceId);
+    });
+    // Emit a real "session released" signal so a connected DaemonMcpProxy clears
+    // its remembered session binding the moment the daemon releases the session
+    // (heartbeat / idle / plan), rather than guessing with the replay TTL. Fires
+    // for every released key — base and derived `${base}:${label}` alike; the
+    // proxy matches its bound (base) UUID by exact equality (issue #4610).
+    this.sessionManager.onSessionRelease(sessionId => {
+      SessionReleaseBroadcaster.emit(sessionId);
     });
     this.installedAppsRepository = installedAppsRepository ?? new InstalledAppsRepository();
     this.devicePool = new DevicePool(

--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_DAEMON_PORT,
   SOCKET_PATH,
   MCP_STREAMABLE_PATH,
+  DAEMON_SESSION_TOOL_BINDING_HEADER,
   DAEMON_PORT_RANGE_START,
   DAEMON_PORT_RANGE_END,
 } from "./constants";
@@ -608,7 +609,12 @@ export class Daemon {
           streamableTransport = this.transports.get(sessionId)!;
         } else if (isInitializeRequest || !sessionId) {
           // Create new transport for initialization or when no session ID
-          const sessionContext: { sessionId?: string } = {};
+          const boundSessionUuid = req.headers[DAEMON_SESSION_TOOL_BINDING_HEADER];
+          const sessionContext: { sessionId?: string; initialSessionToolBinding?: string } = {
+            ...(typeof boundSessionUuid === "string" && boundSessionUuid.trim().length > 0
+              ? { initialSessionToolBinding: boundSessionUuid }
+              : {}),
+          };
           streamableTransport = new StreamableHTTPServerTransport({
             sessionIdGenerator: () => this.idGenerator.next(),
             onsessioninitialized: newSessionId => {

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -998,7 +998,7 @@ export class DaemonMcpProxy {
 
     try {
       const result = await this.withRecoverableReconnect(() =>
-        this.client!.callDaemonMethod("resources/list", {})
+        this.client!.callDaemonMethod("resources/list", this.withBoundSessionUuid({}))
       );
       const resources = result?.resources ?? [];
       this.cachedResources = resources;
@@ -1020,7 +1020,7 @@ export class DaemonMcpProxy {
 
     try {
       const result = await this.withRecoverableReconnect(() =>
-        this.client!.callDaemonMethod("resources/list-templates", {})
+        this.client!.callDaemonMethod("resources/list-templates", this.withBoundSessionUuid({}))
       );
       const templates = result?.resourceTemplates ?? [];
       this.cachedResourceTemplates = templates;

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -881,6 +881,14 @@ export class DaemonMcpProxy {
       this.rememberSessionUuid(name, forwardedArgs);
       return result;
     } catch (error) {
+      if (name === "executePlan") {
+        // A rejected executePlan still triggers the daemon-side session release in
+        // DefaultPlanLifecycleManager.afterExecution()'s finally, so the remembered
+        // binding is stale whether the plan resolved or threw. The success path
+        // clears it via rememberSessionUuid; clear it on failure too so a later
+        // sessionless call cannot resurrect the released session (issue #4610).
+        this.clearBoundSessionUuid();
+      }
       // withRecoverableReconnect already reconciled build identity and retried once.
       // A still-"Unknown tool" failure means the daemon genuinely cannot provide a
       // tool this frontend advertises — surface an actionable error naming both

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -348,6 +348,13 @@ export class DaemonMcpProxy {
   // refreshing it, the remembered UUID is treated as retired so a sessionless
   // call is not rewritten to a released session (issue #4610).
   private boundSessionUuidAt: number | undefined;
+  // Monotonic counter bumped every time the binding is cleared — including a
+  // mid-flight release/heartbeat clear via handleDaemonNotification (issue #4611).
+  // A callTool captures this at forward time; if it has advanced by the time the
+  // call completes, a release for the bound UUID landed WHILE the call was in
+  // flight, so the post-call remember/refresh must NOT resurrect the released
+  // UUID (which would let the next sessionless call recreate the freed session).
+  private bindingGeneration: number = 0;
 
   // Cached definitions from daemon
   private cachedTools: ProxiedToolDefinition[] | null = null;
@@ -893,6 +900,11 @@ export class DaemonMcpProxy {
     args: Record<string, unknown>
   ): Promise<any> {
     const forwardedArgs = this.withBoundSessionUuid(args);
+    // Snapshot the binding generation at forward time. If a session-released
+    // signal (or any other clear) lands WHILE this call is in flight, the
+    // generation advances and the completion path below declines to resurrect the
+    // released UUID (issue #4611).
+    const callBindingGeneration = this.bindingGeneration;
     try {
       const result = await this.withRecoverableReconnect(() => this.client!.callTool(name, forwardedArgs));
       // Remember what was actually forwarded, not the caller's raw args. An
@@ -901,7 +913,7 @@ export class DaemonMcpProxy {
       // replay lease off forwardedArgs keeps continuous implicit activity from
       // being mistaken for idleness, so a later reconnect re-seeds the still-live
       // session instead of creating an unseeded transport (issue #4610).
-      this.rememberSessionUuid(name, forwardedArgs);
+      this.rememberSessionUuid(name, forwardedArgs, callBindingGeneration);
       return result;
     } catch (error) {
       // The success-only rememberSessionUuid above never runs when the handler
@@ -910,7 +922,7 @@ export class DaemonMcpProxy {
       // refreshing the replay lease here too, repeated admitted-but-failed calls
       // let the proxy lease silently expire while the daemon session stays alive,
       // so a later reconnect can no longer replay it (issue #4610).
-      this.refreshReplayLeaseAfterAdmittedFailure(name, forwardedArgs, error);
+      this.refreshReplayLeaseAfterAdmittedFailure(name, forwardedArgs, error, callBindingGeneration);
       // Do NOT clear the binding on a rejected executePlan. A plan can reject
       // *before* the handler runs — capability enforcement or schema parsing in
       // src/server/index.ts — in which case DefaultPlanLifecycleManager
@@ -962,15 +974,31 @@ export class DaemonMcpProxy {
   private clearBoundSessionUuid(): void {
     this.boundSessionUuid = undefined;
     this.boundSessionUuidAt = undefined;
+    // Advance the generation so any callTool that captured the prior value before
+    // this clear (e.g. a release observed mid-flight) declines to re-establish the
+    // now-released UUID on completion (issue #4611).
+    this.bindingGeneration += 1;
   }
 
   // Called with the FORWARDED args (post-withBoundSessionUuid), so an implicit
   // sessionless call that had the bound UUID injected refreshes the replay lease
   // just like an explicit-sessionUuid call, matching the daemon session it just
   // extended (issue #4610).
-  private rememberSessionUuid(name: string, forwardedArgs: Record<string, unknown>): void {
+  private rememberSessionUuid(
+    name: string,
+    forwardedArgs: Record<string, unknown>,
+    callBindingGeneration: number,
+  ): void {
     if (name === "executePlan") {
       this.clearBoundSessionUuid();
+      return;
+    }
+    // A release for the bound UUID observed WHILE this call was in flight already
+    // cleared the binding (handleDaemonNotification). Re-remembering the forwarded
+    // UUID now would resurrect the freed session and let the next sessionless call
+    // recreate it (issue #4611). The generation advancing since forward time is the
+    // signal; a later explicit call re-binds normally.
+    if (this.bindingGeneration !== callBindingGeneration) {
       return;
     }
     if (typeof forwardedArgs.sessionUuid === "string" && forwardedArgs.sessionUuid.trim().length > 0) {
@@ -993,9 +1021,17 @@ export class DaemonMcpProxy {
   private refreshReplayLeaseAfterAdmittedFailure(
     name: string,
     forwardedArgs: Record<string, unknown>,
-    error: unknown
+    error: unknown,
+    callBindingGeneration: number,
   ): void {
     if (name === "executePlan" || this.isRecoverableDaemonSessionError(error)) {
+      return;
+    }
+    // As in rememberSessionUuid: a release observed mid-flight already cleared the
+    // binding, so an admitted-then-rejected call must not re-refresh the released
+    // UUID's lease (issue #4611). The session is gone; resurrecting the lease would
+    // replay it on the next sessionless call.
+    if (this.bindingGeneration !== callBindingGeneration) {
       return;
     }
     if (typeof forwardedArgs.sessionUuid === "string" && forwardedArgs.sessionUuid.trim().length > 0) {

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -867,8 +867,14 @@ export class DaemonMcpProxy {
     }
 
     try {
+      // Bind discovery to the session like callTool does. Without this, a
+      // recoverable reconnect INSIDE withRecoverableReconnect retries tools/list
+      // with empty params against the fresh UNSEEDED transport, which returns the
+      // full unfiltered tool list instead of the session-scoped one. Computing the
+      // forwarded params inside the operation closure re-seeds the retry after a
+      // reconnect (issue #4610).
       const result = await this.withRecoverableReconnect(() =>
-        this.client!.callDaemonMethod("tools/list", {})
+        this.client!.callDaemonMethod("tools/list", this.withBoundSessionUuid({}))
       );
       const tools = result?.tools ?? [];
       this.cachedTools = tools;

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -872,7 +872,13 @@ export class DaemonMcpProxy {
     try {
       const forwardedArgs = this.withBoundSessionUuid(args);
       const result = await this.withRecoverableReconnect(() => this.client!.callTool(name, forwardedArgs));
-      this.rememberSessionUuid(name, args);
+      // Remember what was actually forwarded, not the caller's raw args. An
+      // implicit sessionless call injects the bound UUID into forwardedArgs and
+      // extends the live daemon session in getOrCreateSession(); refreshing the
+      // replay lease off forwardedArgs keeps continuous implicit activity from
+      // being mistaken for idleness, so a later reconnect re-seeds the still-live
+      // session instead of creating an unseeded transport (issue #4610).
+      this.rememberSessionUuid(name, forwardedArgs);
       return result;
     } catch (error) {
       // withRecoverableReconnect already reconciled build identity and retried once.
@@ -891,7 +897,8 @@ export class DaemonMcpProxy {
     // remembered binding dangling; replaying its UUID on a later sessionless call
     // would silently recreate the session and reacquire a device without the
     // caller asking for it (issue #4610). Once the replay window has elapsed with
-    // no explicit-sessionUuid call refreshing the binding, treat it as retired.
+    // no forwarded call (explicit or implicit) refreshing the binding, treat it
+    // as retired.
     if (this.isBoundSessionReplayExpired()) {
       this.clearBoundSessionUuid();
     }
@@ -919,13 +926,17 @@ export class DaemonMcpProxy {
     this.boundSessionUuidAt = undefined;
   }
 
-  private rememberSessionUuid(name: string, args: Record<string, unknown>): void {
+  // Called with the FORWARDED args (post-withBoundSessionUuid), so an implicit
+  // sessionless call that had the bound UUID injected refreshes the replay lease
+  // just like an explicit-sessionUuid call, matching the daemon session it just
+  // extended (issue #4610).
+  private rememberSessionUuid(name: string, forwardedArgs: Record<string, unknown>): void {
     if (name === "executePlan") {
       this.clearBoundSessionUuid();
       return;
     }
-    if (typeof args.sessionUuid === "string" && args.sessionUuid.trim().length > 0) {
-      this.boundSessionUuid = args.sessionUuid;
+    if (typeof forwardedArgs.sessionUuid === "string" && forwardedArgs.sessionUuid.trim().length > 0) {
+      this.boundSessionUuid = forwardedArgs.sessionUuid;
       this.boundSessionUuidAt = this.timer.now();
     }
   }

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -4,6 +4,7 @@ import { logger } from "../utils/logger";
 import { SOCKET_PATH, DAEMON_STARTUP_TIMEOUT_MS, CONNECTION_TIMEOUT_MS, DAEMON_VERSION, DAEMON_VERSION_RESTART_COOLDOWN_MS, DAEMON_BOUND_SESSION_REPLAY_TTL_MS } from "./constants";
 import type { DaemonNotification, DaemonOptions } from "./types";
 import { listChangedKindForMethod, type ListChangedKind } from "../server/listChangedBroadcast";
+import { SESSION_RELEASED_NOTIFICATION_METHOD } from "../server/sessionReleaseBroadcast";
 import { OUTPUT_REDUCTION_FLAG_SPECS } from "../utils/outputReductionFlags";
 import { compareStrictNumericVersions } from "../server/deviceMatcher";
 import { releaseVersion } from "../utils/mcpVersion";
@@ -472,6 +473,22 @@ export class DaemonMcpProxy {
   }
 
   private handleDaemonNotification(notification: DaemonNotification): void {
+    if (notification.method === SESSION_RELEASED_NOTIFICATION_METHOD) {
+      // The daemon actually released a session. If it is the one this proxy
+      // remembers, drop the binding NOW so a later sessionless call is not
+      // rewritten to the retired UUID (issue #4610). A non-matching key —
+      // including a derived `${base}:${label}` release when we hold the base —
+      // leaves the binding intact. The replay TTL stays as a dropped-frame
+      // backstop for when this signal never arrives.
+      if (
+        this.boundSessionUuid !== undefined &&
+        notification.sessionId === this.boundSessionUuid
+      ) {
+        this.clearBoundSessionUuid();
+      }
+      return;
+    }
+
     const kind = listChangedKindForMethod(notification.method);
     if (kind === undefined) {
       // Unknown pushed methods are expected as the daemon grows new

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -1,7 +1,7 @@
 import { DaemonClient, DaemonUnavailableError, type DaemonClientLike, type DaemonClientFactory } from "./client";
 import { DaemonManager, type DaemonManagerLike } from "./manager";
 import { logger } from "../utils/logger";
-import { SOCKET_PATH, DAEMON_STARTUP_TIMEOUT_MS, CONNECTION_TIMEOUT_MS, DAEMON_VERSION, DAEMON_VERSION_RESTART_COOLDOWN_MS } from "./constants";
+import { SOCKET_PATH, DAEMON_STARTUP_TIMEOUT_MS, CONNECTION_TIMEOUT_MS, DAEMON_VERSION, DAEMON_VERSION_RESTART_COOLDOWN_MS, DAEMON_BOUND_SESSION_REPLAY_TTL_MS } from "./constants";
 import type { DaemonNotification, DaemonOptions } from "./types";
 import { listChangedKindForMethod, type ListChangedKind } from "../server/listChangedBroadcast";
 import { OUTPUT_REDUCTION_FLAG_SPECS } from "../utils/outputReductionFlags";
@@ -342,6 +342,11 @@ export class DaemonMcpProxy {
   // proxy's successful explicit binding so subsequent sessionless calls can seed
   // a replacement socket without sharing the binding with other proxies.
   private boundSessionUuid: string | undefined;
+  // When the binding above was last set/refreshed, on the injected clock. Once
+  // the daemon's session idle window elapses with no explicit-sessionUuid call
+  // refreshing it, the remembered UUID is treated as retired so a sessionless
+  // call is not rewritten to a released session (issue #4610).
+  private boundSessionUuidAt: number | undefined;
 
   // Cached definitions from daemon
   private cachedTools: ProxiedToolDefinition[] | null = null;
@@ -882,23 +887,46 @@ export class DaemonMcpProxy {
   }
 
   private withBoundSessionUuid(args: Record<string, unknown>): Record<string, unknown> {
+    // A daemon session released by ordinary heartbeat/idle expiry leaves this
+    // remembered binding dangling; replaying its UUID on a later sessionless call
+    // would silently recreate the session and reacquire a device without the
+    // caller asking for it (issue #4610). Once the replay window has elapsed with
+    // no explicit-sessionUuid call refreshing the binding, treat it as retired.
+    if (this.isBoundSessionReplayExpired()) {
+      this.clearBoundSessionUuid();
+    }
+    // Only a caller-provided NON-EMPTY STRING sessionUuid counts as an explicit
+    // session selection that bypasses the retained binding. A blank/null/number/
+    // object sessionUuid is not explicit, so the bound UUID is still injected.
     if (
       !this.boundSessionUuid ||
-      (args.sessionUuid !== undefined &&
-        (typeof args.sessionUuid !== "string" || args.sessionUuid.trim().length > 0))
+      (typeof args.sessionUuid === "string" && args.sessionUuid.trim().length > 0)
     ) {
       return args;
     }
     return { ...args, sessionUuid: this.boundSessionUuid };
   }
 
+  private isBoundSessionReplayExpired(): boolean {
+    if (this.boundSessionUuid === undefined || this.boundSessionUuidAt === undefined) {
+      return false;
+    }
+    return this.timer.now() - this.boundSessionUuidAt >= DAEMON_BOUND_SESSION_REPLAY_TTL_MS;
+  }
+
+  private clearBoundSessionUuid(): void {
+    this.boundSessionUuid = undefined;
+    this.boundSessionUuidAt = undefined;
+  }
+
   private rememberSessionUuid(name: string, args: Record<string, unknown>): void {
     if (name === "executePlan") {
-      this.boundSessionUuid = undefined;
+      this.clearBoundSessionUuid();
       return;
     }
     if (typeof args.sessionUuid === "string" && args.sessionUuid.trim().length > 0) {
       this.boundSessionUuid = args.sessionUuid;
+      this.boundSessionUuidAt = this.timer.now();
     }
   }
 
@@ -995,7 +1023,7 @@ export class DaemonMcpProxy {
     this.notificationUnsubscribe?.();
     this.notificationUnsubscribe = null;
     this.connected = false;
-    this.boundSessionUuid = undefined;
+    this.clearBoundSessionUuid();
     this.invalidateCache();
     logger.debug("[DaemonMcpProxy] Disconnected from daemon");
   }

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -338,6 +338,10 @@ export class DaemonMcpProxy {
   private readonly clientAssetVersion: string | null;
   private connecting: Promise<void> | null = null;
   private connected: boolean = false;
+  // The daemon clears socket-local state when its RPC connection drops. Keep this
+  // proxy's successful explicit binding so subsequent sessionless calls can seed
+  // a replacement socket without sharing the binding with other proxies.
+  private boundSessionUuid: string | undefined;
 
   // Cached definitions from daemon
   private cachedTools: ProxiedToolDefinition[] | null = null;
@@ -861,7 +865,10 @@ export class DaemonMcpProxy {
     args: Record<string, unknown>
   ): Promise<any> {
     try {
-      return await this.withRecoverableReconnect(() => this.client!.callTool(name, args));
+      const forwardedArgs = this.withBoundSessionUuid(args);
+      const result = await this.withRecoverableReconnect(() => this.client!.callTool(name, forwardedArgs));
+      this.rememberSessionUuid(args);
+      return result;
     } catch (error) {
       // withRecoverableReconnect already reconciled build identity and retried once.
       // A still-"Unknown tool" failure means the daemon genuinely cannot provide a
@@ -871,6 +878,23 @@ export class DaemonMcpProxy {
         throw await this.toolUnavailableError(name);
       }
       throw error;
+    }
+  }
+
+  private withBoundSessionUuid(args: Record<string, unknown>): Record<string, unknown> {
+    if (
+      !this.boundSessionUuid ||
+      (args.sessionUuid !== undefined &&
+        (typeof args.sessionUuid !== "string" || args.sessionUuid.trim().length > 0))
+    ) {
+      return args;
+    }
+    return { ...args, sessionUuid: this.boundSessionUuid };
+  }
+
+  private rememberSessionUuid(args: Record<string, unknown>): void {
+    if (typeof args.sessionUuid === "string" && args.sessionUuid.trim().length > 0) {
+      this.boundSessionUuid = args.sessionUuid;
     }
   }
 
@@ -967,6 +991,7 @@ export class DaemonMcpProxy {
     this.notificationUnsubscribe?.();
     this.notificationUnsubscribe = null;
     this.connected = false;
+    this.boundSessionUuid = undefined;
     this.invalidateCache();
     logger.debug("[DaemonMcpProxy] Disconnected from daemon");
   }

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -892,8 +892,8 @@ export class DaemonMcpProxy {
     name: string,
     args: Record<string, unknown>
   ): Promise<any> {
+    const forwardedArgs = this.withBoundSessionUuid(args);
     try {
-      const forwardedArgs = this.withBoundSessionUuid(args);
       const result = await this.withRecoverableReconnect(() => this.client!.callTool(name, forwardedArgs));
       // Remember what was actually forwarded, not the caller's raw args. An
       // implicit sessionless call injects the bound UUID into forwardedArgs and
@@ -904,6 +904,13 @@ export class DaemonMcpProxy {
       this.rememberSessionUuid(name, forwardedArgs);
       return result;
     } catch (error) {
+      // The success-only rememberSessionUuid above never runs when the handler
+      // rejects, but an admitted-then-rejected call still reached
+      // getOrCreateSession() and refreshed the LIVE daemon session. Without
+      // refreshing the replay lease here too, repeated admitted-but-failed calls
+      // let the proxy lease silently expire while the daemon session stays alive,
+      // so a later reconnect can no longer replay it (issue #4610).
+      this.refreshReplayLeaseAfterAdmittedFailure(name, forwardedArgs, error);
       // Do NOT clear the binding on a rejected executePlan. A plan can reject
       // *before* the handler runs — capability enforcement or schema parsing in
       // src/server/index.ts — in which case DefaultPlanLifecycleManager
@@ -964,6 +971,31 @@ export class DaemonMcpProxy {
   private rememberSessionUuid(name: string, forwardedArgs: Record<string, unknown>): void {
     if (name === "executePlan") {
       this.clearBoundSessionUuid();
+      return;
+    }
+    if (typeof forwardedArgs.sessionUuid === "string" && forwardedArgs.sessionUuid.trim().length > 0) {
+      this.boundSessionUuid = forwardedArgs.sessionUuid;
+      this.boundSessionUuidAt = this.timer.now();
+    }
+  }
+
+  // Refresh the replay lease for a call that was ADMITTED and forwarded to the
+  // daemon handler but then REJECTED. getOrCreateSession() already refreshed the
+  // live daemon session before the handler ran, so the proxy lease must track
+  // that liveness even on failure — otherwise repeated admitted-but-failed calls
+  // retire a still-live session and a reconnect seeds an unbound transport
+  // (issue #4610). Excluded, because none of them refreshed a live session:
+  //   - executePlan owns its own binding lifecycle via the release signal; leave
+  //     it untouched so a pre-handler plan rejection does not strand the binding.
+  //   - a recoverable error (DaemonUnavailableError transport/connect failure,
+  //     "Session not found", or an unknown-tool build-skew) never reached the
+  //     handler with a live session, so the lease must be allowed to expire.
+  private refreshReplayLeaseAfterAdmittedFailure(
+    name: string,
+    forwardedArgs: Record<string, unknown>,
+    error: unknown
+  ): void {
+    if (name === "executePlan" || this.isRecoverableDaemonSessionError(error)) {
       return;
     }
     if (typeof forwardedArgs.sessionUuid === "string" && forwardedArgs.sessionUuid.trim().length > 0) {

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -867,7 +867,7 @@ export class DaemonMcpProxy {
     try {
       const forwardedArgs = this.withBoundSessionUuid(args);
       const result = await this.withRecoverableReconnect(() => this.client!.callTool(name, forwardedArgs));
-      this.rememberSessionUuid(args);
+      this.rememberSessionUuid(name, args);
       return result;
     } catch (error) {
       // withRecoverableReconnect already reconciled build identity and retried once.
@@ -892,7 +892,11 @@ export class DaemonMcpProxy {
     return { ...args, sessionUuid: this.boundSessionUuid };
   }
 
-  private rememberSessionUuid(args: Record<string, unknown>): void {
+  private rememberSessionUuid(name: string, args: Record<string, unknown>): void {
+    if (name === "executePlan") {
+      this.boundSessionUuid = undefined;
+      return;
+    }
     if (typeof args.sessionUuid === "string" && args.sessionUuid.trim().length > 0) {
       this.boundSessionUuid = args.sessionUuid;
     }

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -348,13 +348,25 @@ export class DaemonMcpProxy {
   // refreshing it, the remembered UUID is treated as retired so a sessionless
   // call is not rewritten to a released session (issue #4610).
   private boundSessionUuidAt: number | undefined;
-  // Monotonic counter bumped every time the binding is cleared — including a
-  // mid-flight release/heartbeat clear via handleDaemonNotification (issue #4611).
-  // A callTool captures this at forward time; if it has advanced by the time the
-  // call completes, a release for the bound UUID landed WHILE the call was in
-  // flight, so the post-call remember/refresh must NOT resurrect the released
-  // UUID (which would let the next sessionless call recreate the freed session).
-  private bindingGeneration: number = 0;
+  // Monotonic release-epoch counter, bumped every time the daemon signals that a
+  // session was released (via handleDaemonNotification). `releasedSessionEpochs`
+  // records, per released UUID, the epoch at which it was last released. A
+  // callTool captures the epoch at forward time; on completion the post-call
+  // remember/refresh asks "was the SPECIFIC UUID I forwarded released at a later
+  // epoch?" and, if so, declines to resurrect it. Scoping the guard to the
+  // forwarded UUID (issue #4655) — rather than a single global generation bumped
+  // by ANY binding change (issue #4611's first cut) — means the release of an
+  // UNRELATED session mid-call no longer blocks remembering the session THIS call
+  // actually forwarded, while a release of the forwarded UUID still preserves.
+  private releaseEpoch: number = 0;
+  private readonly releasedSessionEpochs = new Map<string, number>();
+  // Monotonic counter bumped whenever a daemon push invalidates a discovery cache
+  // or the session binding mid-flight (list_changed nulls a cache; a bound-session
+  // release changes the session scope). A `tools/list` / `resources/list` captures
+  // this at forward time and, if it has advanced by completion, declines to store
+  // the now-stale response into the cache the invalidation just cleared — the next
+  // discovery refetches under the current scope (issue #4655).
+  private discoveryEpoch: number = 0;
 
   // Cached definitions from daemon
   private cachedTools: ProxiedToolDefinition[] | null = null;
@@ -481,16 +493,25 @@ export class DaemonMcpProxy {
 
   private handleDaemonNotification(notification: DaemonNotification): void {
     if (notification.method === SESSION_RELEASED_NOTIFICATION_METHOD) {
-      // The daemon actually released a session. If it is the one this proxy
-      // remembers, drop the binding NOW so a later sessionless call is not
+      // The daemon actually released a session. Record the release against the
+      // SPECIFIC UUID (issue #4655) so an in-flight call that forwarded exactly
+      // this session declines to re-remember it on completion — regardless of
+      // whether it is the currently-bound session. If it IS the one this proxy
+      // remembers, also drop the binding NOW so a later sessionless call is not
       // rewritten to the retired UUID (issue #4610). A non-matching key —
       // including a derived `${base}:${label}` release when we hold the base —
       // leaves the binding intact. The replay TTL stays as a dropped-frame
       // backstop for when this signal never arrives.
+      if (typeof notification.sessionId === "string" && notification.sessionId.length > 0) {
+        this.recordSessionReleased(notification.sessionId);
+      }
       if (
         this.boundSessionUuid !== undefined &&
         notification.sessionId === this.boundSessionUuid
       ) {
+        // A bound-session release changes the scope of any in-flight discovery
+        // forwarded with that UUID, so invalidate pending discovery too (#4655).
+        this.discoveryEpoch += 1;
         this.clearBoundSessionUuid();
       }
       return;
@@ -504,6 +525,10 @@ export class DaemonMcpProxy {
       return;
     }
 
+    // Bump the discovery epoch so a discovery request whose response is still in
+    // flight declines to repopulate the cache this invalidation just cleared
+    // (issue #4655).
+    this.discoveryEpoch += 1;
     if (kind === "tools") {
       this.cachedTools = null;
     } else {
@@ -880,11 +905,19 @@ export class DaemonMcpProxy {
       // full unfiltered tool list instead of the session-scoped one. Computing the
       // forwarded params inside the operation closure re-seeds the retry after a
       // reconnect (issue #4610).
+      const discoveryEpoch = this.discoveryEpoch;
       const result = await this.withRecoverableReconnect(() =>
         this.client!.callDaemonMethod("tools/list", this.withBoundSessionUuid({}))
       );
       const tools = result?.tools ?? [];
-      this.cachedTools = tools;
+      // If a list_changed or bound-session release invalidated this cache WHILE the
+      // response was in flight, the response is scoped to the now-stale binding.
+      // Return it to THIS caller but leave the cache empty so the next listTools()
+      // refetches under the current scope, instead of resurrecting the list the
+      // invalidation just cleared (issue #4655).
+      if (this.discoveryEpoch === discoveryEpoch) {
+        this.cachedTools = tools;
+      }
       return tools;
     } catch (error) {
       logger.error(`[DaemonMcpProxy] Failed to list tools: ${error}`);
@@ -900,11 +933,13 @@ export class DaemonMcpProxy {
     args: Record<string, unknown>
   ): Promise<any> {
     const forwardedArgs = this.withBoundSessionUuid(args);
-    // Snapshot the binding generation at forward time. If a session-released
-    // signal (or any other clear) lands WHILE this call is in flight, the
-    // generation advances and the completion path below declines to resurrect the
-    // released UUID (issue #4611).
-    const callBindingGeneration = this.bindingGeneration;
+    // Snapshot the release epoch at forward time. If a session-released signal for
+    // the SPECIFIC forwarded UUID lands WHILE this call is in flight, that UUID's
+    // recorded epoch advances past this snapshot and the completion path below
+    // declines to resurrect the released UUID (issue #4611/#4655). A release of an
+    // UNRELATED session bumps the global epoch but not the forwarded UUID's entry,
+    // so it does not block remembering the session this call forwarded.
+    const callReleaseEpoch = this.releaseEpoch;
     try {
       const result = await this.withRecoverableReconnect(() => this.client!.callTool(name, forwardedArgs));
       // Remember what was actually forwarded, not the caller's raw args. An
@@ -913,7 +948,7 @@ export class DaemonMcpProxy {
       // replay lease off forwardedArgs keeps continuous implicit activity from
       // being mistaken for idleness, so a later reconnect re-seeds the still-live
       // session instead of creating an unseeded transport (issue #4610).
-      this.rememberSessionUuid(name, forwardedArgs, callBindingGeneration);
+      this.rememberSessionUuid(name, forwardedArgs, callReleaseEpoch);
       return result;
     } catch (error) {
       // The success-only rememberSessionUuid above never runs when the handler
@@ -922,7 +957,7 @@ export class DaemonMcpProxy {
       // refreshing the replay lease here too, repeated admitted-but-failed calls
       // let the proxy lease silently expire while the daemon session stays alive,
       // so a later reconnect can no longer replay it (issue #4610).
-      this.refreshReplayLeaseAfterAdmittedFailure(name, forwardedArgs, error, callBindingGeneration);
+      this.refreshReplayLeaseAfterAdmittedFailure(name, forwardedArgs, error, callReleaseEpoch);
       // Do NOT clear the binding on a rejected executePlan. A plan can reject
       // *before* the handler runs — capability enforcement or schema parsing in
       // src/server/index.ts — in which case DefaultPlanLifecycleManager
@@ -974,10 +1009,35 @@ export class DaemonMcpProxy {
   private clearBoundSessionUuid(): void {
     this.boundSessionUuid = undefined;
     this.boundSessionUuidAt = undefined;
-    // Advance the generation so any callTool that captured the prior value before
-    // this clear (e.g. a release observed mid-flight) declines to re-establish the
-    // now-released UUID on completion (issue #4611).
-    this.bindingGeneration += 1;
+  }
+
+  // Record that the daemon released a specific session UUID, advancing the global
+  // release epoch. An in-flight call that forwarded this exact UUID compares its
+  // captured epoch against this entry and declines to resurrect the released
+  // session on completion (issue #4655). Scoping the record to the UUID — not a
+  // global counter — is what lets an unrelated session's release NOT block
+  // remembering the session another in-flight call forwarded.
+  private recordSessionReleased(sessionUuid: string): void {
+    this.releaseEpoch += 1;
+    this.releasedSessionEpochs.set(sessionUuid, this.releaseEpoch);
+  }
+
+  // True when the session THIS call forwarded was released at a later epoch than
+  // the one captured at forward time — i.e. a release for the forwarded UUID
+  // landed WHILE the call was in flight. A release of any OTHER session advances
+  // the global epoch but leaves the forwarded UUID's entry untouched, so this
+  // stays false for it (issue #4655).
+  private wasForwardedSessionReleasedSince(
+    forwardedArgs: Record<string, unknown>,
+    forwardEpoch: number,
+  ): boolean {
+    const forwardedUuid = typeof forwardedArgs.sessionUuid === "string"
+      ? forwardedArgs.sessionUuid
+      : undefined;
+    if (forwardedUuid === undefined || forwardedUuid.trim().length === 0) {
+      return false;
+    }
+    return (this.releasedSessionEpochs.get(forwardedUuid) ?? 0) > forwardEpoch;
   }
 
   // Called with the FORWARDED args (post-withBoundSessionUuid), so an implicit
@@ -987,18 +1047,19 @@ export class DaemonMcpProxy {
   private rememberSessionUuid(
     name: string,
     forwardedArgs: Record<string, unknown>,
-    callBindingGeneration: number,
+    callReleaseEpoch: number,
   ): void {
     if (name === "executePlan") {
       this.clearBoundSessionUuid();
       return;
     }
-    // A release for the bound UUID observed WHILE this call was in flight already
-    // cleared the binding (handleDaemonNotification). Re-remembering the forwarded
-    // UUID now would resurrect the freed session and let the next sessionless call
-    // recreate it (issue #4611). The generation advancing since forward time is the
-    // signal; a later explicit call re-binds normally.
-    if (this.bindingGeneration !== callBindingGeneration) {
+    // A release for the FORWARDED UUID observed WHILE this call was in flight
+    // already recorded that UUID's release (handleDaemonNotification).
+    // Re-remembering it now would resurrect the freed session and let the next
+    // sessionless call recreate it (issue #4611). Scoped to the forwarded UUID so
+    // an unrelated session's mid-call release does NOT block this remember (issue
+    // #4655); a later explicit call re-binds normally.
+    if (this.wasForwardedSessionReleasedSince(forwardedArgs, callReleaseEpoch)) {
       return;
     }
     if (typeof forwardedArgs.sessionUuid === "string" && forwardedArgs.sessionUuid.trim().length > 0) {
@@ -1022,16 +1083,16 @@ export class DaemonMcpProxy {
     name: string,
     forwardedArgs: Record<string, unknown>,
     error: unknown,
-    callBindingGeneration: number,
+    callReleaseEpoch: number,
   ): void {
     if (name === "executePlan" || this.isRecoverableDaemonSessionError(error)) {
       return;
     }
-    // As in rememberSessionUuid: a release observed mid-flight already cleared the
-    // binding, so an admitted-then-rejected call must not re-refresh the released
-    // UUID's lease (issue #4611). The session is gone; resurrecting the lease would
-    // replay it on the next sessionless call.
-    if (this.bindingGeneration !== callBindingGeneration) {
+    // As in rememberSessionUuid: a release of the forwarded UUID observed
+    // mid-flight already recorded it, so an admitted-then-rejected call must not
+    // re-refresh the released UUID's lease (issue #4611/#4655). The session is
+    // gone; resurrecting the lease would replay it on the next sessionless call.
+    if (this.wasForwardedSessionReleasedSince(forwardedArgs, callReleaseEpoch)) {
       return;
     }
     if (typeof forwardedArgs.sessionUuid === "string" && forwardedArgs.sessionUuid.trim().length > 0) {
@@ -1065,11 +1126,16 @@ export class DaemonMcpProxy {
     }
 
     try {
+      const discoveryEpoch = this.discoveryEpoch;
       const result = await this.withRecoverableReconnect(() =>
         this.client!.callDaemonMethod("resources/list", this.withBoundSessionUuid({}))
       );
       const resources = result?.resources ?? [];
-      this.cachedResources = resources;
+      // Discard a response invalidated mid-flight rather than caching the stale
+      // scope (issue #4655); the next listResources() refetches.
+      if (this.discoveryEpoch === discoveryEpoch) {
+        this.cachedResources = resources;
+      }
       return resources;
     } catch (error) {
       logger.error(`[DaemonMcpProxy] Failed to list resources: ${error}`);
@@ -1087,11 +1153,16 @@ export class DaemonMcpProxy {
     }
 
     try {
+      const discoveryEpoch = this.discoveryEpoch;
       const result = await this.withRecoverableReconnect(() =>
         this.client!.callDaemonMethod("resources/list-templates", this.withBoundSessionUuid({}))
       );
       const templates = result?.resourceTemplates ?? [];
-      this.cachedResourceTemplates = templates;
+      // Discard a response invalidated mid-flight rather than caching the stale
+      // scope (issue #4655); the next listResourceTemplates() refetches.
+      if (this.discoveryEpoch === discoveryEpoch) {
+        this.cachedResourceTemplates = templates;
+      }
       return templates;
     } catch (error) {
       logger.error(`[DaemonMcpProxy] Failed to list resource templates: ${error}`);

--- a/src/daemon/daemonMcpProxy.ts
+++ b/src/daemon/daemonMcpProxy.ts
@@ -904,14 +904,14 @@ export class DaemonMcpProxy {
       this.rememberSessionUuid(name, forwardedArgs);
       return result;
     } catch (error) {
-      if (name === "executePlan") {
-        // A rejected executePlan still triggers the daemon-side session release in
-        // DefaultPlanLifecycleManager.afterExecution()'s finally, so the remembered
-        // binding is stale whether the plan resolved or threw. The success path
-        // clears it via rememberSessionUuid; clear it on failure too so a later
-        // sessionless call cannot resurrect the released session (issue #4610).
-        this.clearBoundSessionUuid();
-      }
+      // Do NOT clear the binding on a rejected executePlan. A plan can reject
+      // *before* the handler runs — capability enforcement or schema parsing in
+      // src/server/index.ts — in which case DefaultPlanLifecycleManager
+      // .afterExecution() never runs and the daemon session stays LIVE. Forgetting
+      // it here would strand a still-live session after a reconnect. The binding is
+      // now cleared authoritatively by the daemon's session-released signal
+      // (handleDaemonNotification) whenever the session is *actually* released —
+      // whether the plan succeeded or failed inside the handler (issue #4610).
       // withRecoverableReconnect already reconciled build identity and retried once.
       // A still-"Unknown tool" failure means the daemon genuinely cannot provide a
       // tool this frontend advertises — surface an actionable error naming both

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -739,14 +739,7 @@ export class UnixSocketServer {
     }
 
     if (request.method === "ide/getNavigationGraph") {
-      const executionKey = this.getRequestArgumentScopeKey(request.params);
-      if (executionKey) {
-        if (boundRoute) {
-          return { ...boundRoute, executionKey };
-        }
-        return this.sharedMcpForwardRoute(executionKey);
-      }
-      return boundRoute ?? this.sharedMcpForwardRoute(`method:${request.method}`);
+      return this.getNavigationGraphForwardRoute(request, socketSessionId, boundRoute);
     }
 
     if (request.method === "resources/read") {
@@ -757,15 +750,33 @@ export class UnixSocketServer {
     return this.sharedMcpForwardRoute(`method:${request.method}`);
   }
 
+  private getNavigationGraphForwardRoute(
+    request: DaemonRequest,
+    socketSessionId: string,
+    boundRoute: McpForwardRoute | undefined
+  ): McpForwardRoute {
+    const sessionUuid = this.getSessionUuid(request.params);
+    const executionKey = this.getRequestArgumentScopeKey(request.params);
+    if (sessionUuid) {
+      // An explicit read session routes to its OWN session-specific client so a
+      // cross-session IDE read never repurposes the socket's bound transport. If
+      // it reused the bound client, the loopback SessionToolBinding would be
+      // rebound to this UUID while recordBoundMcpClientKey early-returns for
+      // non-tools/call methods, leaving the daemon route labeled the bound
+      // session and the transport filtering by a different profile (issue #4610).
+      return this.sessionScopedForwardRoute(socketSessionId, sessionUuid, executionKey);
+    }
+    if (executionKey) {
+      return boundRoute ? { ...boundRoute, executionKey } : this.sharedMcpForwardRoute(executionKey);
+    }
+    return boundRoute ?? this.sharedMcpForwardRoute(`method:${request.method}`);
+  }
+
   private getToolsCallForwardRoute(args: unknown, socketSessionId: string): McpForwardRoute {
     const scopedKey = this.getRequestArgumentScopeKey(args);
     const sessionUuid = this.getSessionUuid(args);
     if (sessionUuid) {
-      return {
-        executionKey: scopedKey ?? `session:${sessionUuid}`,
-        clientKey: this.sessionMcpClientKey(socketSessionId, sessionUuid),
-        sessionUuid,
-      };
+      return this.sessionScopedForwardRoute(socketSessionId, sessionUuid, scopedKey);
     }
 
     const boundRoute = this.getBoundMcpClientRoute(socketSessionId);
@@ -796,6 +807,21 @@ export class UnixSocketServer {
 
   private sessionMcpClientKey(socketSessionId: string, sessionUuid: string): string {
     return `socket:${socketSessionId}:session:${sessionUuid}`;
+  }
+
+  // Route an explicit-session request (tools/call or an IDE read) to its OWN
+  // session-specific loopback client so it never repurposes the socket's bound
+  // transport to a different session (issue #4610).
+  private sessionScopedForwardRoute(
+    socketSessionId: string,
+    sessionUuid: string,
+    scopedKey: string | undefined
+  ): McpForwardRoute {
+    return {
+      executionKey: scopedKey ?? `session:${sessionUuid}`,
+      clientKey: this.sessionMcpClientKey(socketSessionId, sessionUuid),
+      sessionUuid,
+    };
   }
 
   private recordBoundMcpClientKey(

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -197,6 +197,8 @@ export class UnixSocketServer {
   private boundMcpClientKeysBySocketSession: Map<string, BoundMcpClient> = new Map();
   /** Promise tails that serialize MCP HTTP forwards only within the same execution target. */
   private mcpForwardTails: Map<string, Promise<void>> = new Map();
+  /** Active forwards by loopback MCP client, which can differ from the execution target. */
+  private activeMcpClientForwardCounts: Map<string, number> = new Map();
   private mcpClientIdleTimers: Map<string, NodeJS.Timeout> = new Map();
   private timer: Timer;
   private featureFlagService: FeatureFlagService | null;
@@ -596,9 +598,8 @@ export class UnixSocketServer {
   }
 
   /**
-   * Run one MCP forward at a time for a single target key. Each key owns a separate MCP client,
-   * so calls for different devices or sessions can proceed concurrently without sharing one
-   * Streamable HTTP session.
+   * Run one MCP forward at a time for a single execution target. Calls for different devices or
+   * sessions can proceed concurrently while their loopback transports remain session-local.
    */
   private runKeyedMcpForward<T>(executionKey: string, fn: () => Promise<T>): Promise<T> {
     const previous = this.mcpForwardTails.get(executionKey) ?? Promise.resolve();
@@ -618,6 +619,24 @@ export class UnixSocketServer {
     return run;
   }
 
+  private async runWithActiveMcpClient<T>(clientKey: string, fn: () => Promise<T>): Promise<T> {
+    this.clearMcpClientIdleTimer(clientKey);
+    this.activeMcpClientForwardCounts.set(
+      clientKey,
+      (this.activeMcpClientForwardCounts.get(clientKey) ?? 0) + 1
+    );
+    try {
+      return await fn();
+    } finally {
+      const remainingForClient = (this.activeMcpClientForwardCounts.get(clientKey) ?? 1) - 1;
+      if (remainingForClient === 0) {
+        this.activeMcpClientForwardCounts.delete(clientKey);
+      } else {
+        this.activeMcpClientForwardCounts.set(clientKey, remainingForClient);
+      }
+    }
+  }
+
   private runMcpForwardForCurrentRoute<T>(
     initialRoute: McpForwardRoute,
     request: DaemonRequest,
@@ -632,7 +651,7 @@ export class UnixSocketServer {
         );
         return await this.runMcpForwardForCurrentRoute(currentRoute, request, socketSessionId, fn);
       }
-      return await fn(currentRoute);
+      return await this.runWithActiveMcpClient(currentRoute.clientKey, () => fn(currentRoute));
     });
   }
 
@@ -2239,7 +2258,11 @@ export class UnixSocketServer {
 
   private async closeIdleMcpClient(key: string): Promise<void> {
     this.mcpClientIdleTimers.delete(key);
-    if (this.mcpForwardTails.has(key) || this.isMcpClientKeyBound(key)) {
+    if (
+      this.mcpForwardTails.has(key)
+      || this.activeMcpClientForwardCounts.has(key)
+      || this.isMcpClientKeyBound(key)
+    ) {
       return;
     }
     // The append helper shares the device's idle lifecycle: once nothing has

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -50,7 +50,8 @@ import {
   type SessionToolProfileService,
   type ToolCapability,
 } from "../features/toolCapabilities/SessionToolProfileService";
-import { assertToolEnabledForSession } from "../features/toolCapabilities/toolCapabilityPolicy";
+import { assertToolEnabledForAnySession } from "../features/toolCapabilities/toolCapabilityPolicy";
+import { resolveCapabilityBaseSessionUuid } from "../features/toolCapabilities/capabilitySessionResolver";
 import { getMcpServerVersion } from "../utils/mcpVersion";
 import {
   IOS_CTRL_PROXY_APP_HASH,
@@ -1204,32 +1205,22 @@ export class UnixSocketServer {
   }
 
   private async assertSocketToolEnabled(deviceId: string, toolName: string): Promise<void> {
-    const sessionUuid = this.daemonState.isInitialized()
-      ? this.getCapabilityProfileSessionUuid(
-        this.daemonState.getSessionManager().getSessionForDevice?.(deviceId) ?? undefined
-      )
-      : undefined;
-    await assertToolEnabledForSession(toolName, sessionUuid, this.sessionToolProfileService);
-  }
-
-  private getCapabilityProfileSessionUuid(sessionUuid: string | undefined): string | undefined {
-    if (!sessionUuid || !this.daemonState.isInitialized()) {
-      return sessionUuid;
+    if (!this.daemonState.isInitialized()) {
+      await assertToolEnabledForAnySession(toolName, [undefined], this.sessionToolProfileService);
+      return;
     }
-
     const sessionManager = this.daemonState.getSessionManager();
-    for (
-      let separatorIndex = sessionUuid.lastIndexOf(":");
-      separatorIndex >= 0;
-      separatorIndex = sessionUuid.lastIndexOf(":", separatorIndex - 1)
-    ) {
-      const candidateBaseSessionUuid = sessionUuid.slice(0, separatorIndex);
-      const deviceLabels = sessionManager.getDeviceLabels(candidateBaseSessionUuid);
-      if (deviceLabels && Object.values(deviceLabels).includes(sessionUuid)) {
-        return candidateBaseSessionUuid;
-      }
-    }
-    return sessionUuid;
+    // The device's owning session may be a derived `${base}:${label}` label
+    // session. Enforce the UNION of base + derived (issue #4611 Gap B, product
+    // decision) so a tool is enabled when EITHER grants it — symmetric with the
+    // MCP `registerDeviceAware` path. The shared helper resolves the base.
+    const derivedSessionUuid = sessionManager.getSessionForDevice?.(deviceId) ?? undefined;
+    const baseSessionUuid = resolveCapabilityBaseSessionUuid(derivedSessionUuid, sessionManager);
+    await assertToolEnabledForAnySession(
+      toolName,
+      [baseSessionUuid, derivedSessionUuid],
+      this.sessionToolProfileService,
+    );
   }
 
   /**

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -20,6 +20,7 @@ import {
   SOCKET_PATH,
   DAEMON_HANDSHAKE_ENABLED,
   DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD,
+  DAEMON_SESSION_TOOL_BINDING_HEADER,
   DAEMON_VERSION,
 } from "./constants";
 import {
@@ -119,7 +120,7 @@ interface SocketFileIdentity {
  * by name (a name-based patch silently no-ops if the internal creator is renamed,
  * leaving forwarding dead but the suite green).
  */
-export type McpClientFactory = () => Promise<Client>;
+export type McpClientFactory = (boundSessionUuid?: string) => Promise<Client>;
 
 /**
  * The narrow append-text surface `input/typeText mode:"append"` needs.
@@ -142,9 +143,19 @@ interface CachedAppendTextInput {
 }
 
 interface BoundMcpClient {
-  forwardKey: string;
+  clientKey: string;
+  executionKey: string;
   sessionUuid: string;
   requiresLiveDaemonSession: boolean;
+}
+
+interface McpForwardRoute {
+  /** Serializes work that targets the same physical device or session. */
+  executionKey: string;
+  /** Owns the loopback MCP transport and its session-local capability profile. */
+  clientKey: string;
+  /** Replayed when this transport needs to establish a fresh MCP session. */
+  sessionUuid?: string;
 }
 
 const isNonBlankSessionUuid = (value: unknown): value is string =>
@@ -184,7 +195,7 @@ export class UnixSocketServer {
    * this client to preserve the selected capability profile.
    */
   private boundMcpClientKeysBySocketSession: Map<string, BoundMcpClient> = new Map();
-  /** Promise tails that serialize MCP HTTP forwards only within the same target key. */
+  /** Promise tails that serialize MCP HTTP forwards only within the same execution target. */
   private mcpForwardTails: Map<string, Promise<void>> = new Map();
   private mcpClientIdleTimers: Map<string, NodeJS.Timeout> = new Map();
   private timer: Timer;
@@ -197,7 +208,7 @@ export class UnixSocketServer {
    * Defaults to the real {@link createMcpClient}; tests assign a fake here to
    * exercise forwarding without a live HTTP endpoint.
    */
-  mcpClientFactory: McpClientFactory = () => this.createMcpClient();
+  mcpClientFactory: McpClientFactory = sessionUuid => this.createMcpClient(sessionUuid);
 
   /**
    * Factory for the Android append-text helper behind `input/typeText mode:"append"`.
@@ -466,14 +477,14 @@ export class UnixSocketServer {
 
         const queueEnterMs = this.timer.now();
         const totalTimeoutMs = resolveMcpRequestTimeoutMs(request);
-        const initialForwardKey = this.getMcpForwardKey(request, sessionId);
+        const initialRoute = this.getMcpForwardRoute(request, sessionId);
 
-        const result = await this.runMcpForwardForCurrentKey(initialForwardKey, request, sessionId, async forwardKey => {
+        const result = await this.runMcpForwardForCurrentRoute(initialRoute, request, sessionId, async route => {
           const queueWaitMs = this.timer.now() - queueEnterMs;
           const remainingTimeoutMs = totalTimeoutMs - queueWaitMs;
           const forwardLabel = UnixSocketServer.describeMcpForwardRequest(request);
           logger.debug(
-            `[McpForward] start key=${forwardKey} socketSession=${sessionId} requestId=${request.id} ${forwardLabel} queueWaitMs=${queueWaitMs} remainingTimeoutMs=${remainingTimeoutMs}`
+            `[McpForward] start executionKey=${route.executionKey} clientKey=${route.clientKey} socketSession=${sessionId} requestId=${request.id} ${forwardLabel} queueWaitMs=${queueWaitMs} remainingTimeoutMs=${remainingTimeoutMs}`
           );
 
           if (remainingTimeoutMs <= 0) {
@@ -488,7 +499,7 @@ export class UnixSocketServer {
 
           const forwardStartMs = this.timer.now();
           try {
-            const mcpClient = await this.getMcpClient(forwardKey);
+            const mcpClient = await this.getMcpClient(route.clientKey, route.sessionUuid);
             const sessionWasActiveBeforeForward = this.wasRequestSessionActive(request);
 
             try {
@@ -496,7 +507,7 @@ export class UnixSocketServer {
               this.recordBoundMcpClientKey(
                 request,
                 sessionId,
-                forwardKey,
+                route,
                 sessionWasActiveBeforeForward
               );
               return response;
@@ -504,8 +515,8 @@ export class UnixSocketServer {
               const ideErrorMessage = ideError instanceof Error ? ideError.message : String(ideError);
               if (ideErrorMessage.includes("Session not found")) {
                 logger.warn("MCP client session expired, reconnecting and retrying...");
-                await this.resetMcpClient(forwardKey);
-                const freshClient = await this.getMcpClient(forwardKey);
+                await this.resetMcpClient(route.clientKey);
+                const freshClient = await this.getMcpClient(route.clientKey, route.sessionUuid);
                 const retryRemainingMs = remainingTimeoutMs - (this.timer.now() - forwardStartMs);
                 if (retryRemainingMs <= 0) {
                   const toolName = request.method === "tools/call" ? request.params?.name ?? request.method : request.method;
@@ -520,7 +531,7 @@ export class UnixSocketServer {
                 this.recordBoundMcpClientKey(
                   request,
                   sessionId,
-                  forwardKey,
+                  route,
                   sessionWasActiveBeforeForward
                 );
                 return response;
@@ -529,8 +540,9 @@ export class UnixSocketServer {
             }
           } finally {
             logger.debug(
-              `[McpForward] end key=${forwardKey} socketSession=${sessionId} requestId=${request.id} ${forwardLabel} forwardMs=${this.timer.now() - forwardStartMs}`
+              `[McpForward] end executionKey=${route.executionKey} clientKey=${route.clientKey} socketSession=${sessionId} requestId=${request.id} ${forwardLabel} forwardMs=${this.timer.now() - forwardStartMs}`
             );
+            this.scheduleMcpClientIdleClose(route.clientKey);
           }
         });
 
@@ -588,92 +600,110 @@ export class UnixSocketServer {
    * so calls for different devices or sessions can proceed concurrently without sharing one
    * Streamable HTTP session.
    */
-  private runKeyedMcpForward<T>(key: string, fn: () => Promise<T>): Promise<T> {
-    const previous = this.mcpForwardTails.get(key) ?? Promise.resolve();
+  private runKeyedMcpForward<T>(executionKey: string, fn: () => Promise<T>): Promise<T> {
+    const previous = this.mcpForwardTails.get(executionKey) ?? Promise.resolve();
     const run = previous.then(() => {
-      this.clearMcpClientIdleTimer(key);
       return fn();
     });
     const tail = run.then(
       () => undefined,
       () => undefined
     );
-    this.mcpForwardTails.set(key, tail);
+    this.mcpForwardTails.set(executionKey, tail);
     void tail.finally(() => {
-      if (this.mcpForwardTails.get(key) === tail) {
-        this.mcpForwardTails.delete(key);
-        this.scheduleMcpClientIdleClose(key);
+      if (this.mcpForwardTails.get(executionKey) === tail) {
+        this.mcpForwardTails.delete(executionKey);
       }
     });
     return run;
   }
 
-  private runMcpForwardForCurrentKey<T>(
-    initialKey: string,
+  private runMcpForwardForCurrentRoute<T>(
+    initialRoute: McpForwardRoute,
     request: DaemonRequest,
     socketSessionId: string,
-    fn: (forwardKey: string) => Promise<T>
+    fn: (route: McpForwardRoute) => Promise<T>
   ): Promise<T> {
-    return this.runKeyedMcpForward(initialKey, async () => {
-      const currentKey = this.getMcpForwardKey(request, socketSessionId);
-      if (currentKey !== initialKey) {
+    return this.runKeyedMcpForward(initialRoute.executionKey, async () => {
+      const currentRoute = this.getMcpForwardRoute(request, socketSessionId);
+      if (currentRoute.executionKey !== initialRoute.executionKey) {
         logger.debug(
-          `[McpForward] rekey requestId=${request.id} initialKey=${initialKey} currentKey=${currentKey}`
+          `[McpForward] rekey requestId=${request.id} initialExecutionKey=${initialRoute.executionKey} currentExecutionKey=${currentRoute.executionKey}`
         );
-        return await this.runMcpForwardForCurrentKey(currentKey, request, socketSessionId, fn);
+        return await this.runMcpForwardForCurrentRoute(currentRoute, request, socketSessionId, fn);
       }
-      return await fn(currentKey);
+      return await fn(currentRoute);
     });
   }
 
-  private getMcpForwardKey(request: DaemonRequest, socketSessionId: string): string {
+  private getMcpForwardRoute(request: DaemonRequest, socketSessionId: string): McpForwardRoute {
     if (request.method === "tools/call") {
-      return this.getToolsCallForwardKey(request.params?.arguments, socketSessionId);
+      return this.getToolsCallForwardRoute(request.params?.arguments, socketSessionId);
     }
 
+    const boundRoute = this.getBoundMcpClientRoute(socketSessionId);
     if (request.method === "tools/list") {
-      return this.getBoundMcpClientKey(socketSessionId) ?? `method:${request.method}`;
+      return boundRoute ?? this.sharedMcpForwardRoute(`method:${request.method}`);
     }
 
     if (request.method === "ide/getNavigationGraph") {
-      return this.getRequestArgumentScopeKey(request.params)
-        ?? this.getBoundMcpClientKey(socketSessionId)
-        ?? `method:${request.method}`;
+      const executionKey = this.getRequestArgumentScopeKey(request.params);
+      if (executionKey) {
+        return this.sharedMcpForwardRoute(executionKey);
+      }
+      return boundRoute ?? this.sharedMcpForwardRoute(`method:${request.method}`);
     }
 
     if (request.method === "resources/read") {
       const uri = request.params?.uri;
-      return typeof uri === "string" ? `resource:${uri}` : "resource:unknown";
+      return this.sharedMcpForwardRoute(typeof uri === "string" ? `resource:${uri}` : "resource:unknown");
     }
 
-    return `method:${request.method}`;
+    return this.sharedMcpForwardRoute(`method:${request.method}`);
   }
 
-  private getToolsCallForwardKey(args: unknown, socketSessionId: string): string {
+  private getToolsCallForwardRoute(args: unknown, socketSessionId: string): McpForwardRoute {
     const scopedKey = this.getRequestArgumentScopeKey(args);
-    if (scopedKey) {
-      return scopedKey;
+    const sessionUuid = this.getSessionUuid(args);
+    if (sessionUuid) {
+      return {
+        executionKey: scopedKey ?? `session:${sessionUuid}`,
+        clientKey: this.sessionMcpClientKey(socketSessionId, sessionUuid),
+        sessionUuid,
+      };
     }
 
-    const boundKey = this.getBoundMcpClientKey(socketSessionId);
-    if (boundKey) {
-      return boundKey;
+    if (scopedKey) {
+      return this.sharedMcpForwardRoute(scopedKey);
+    }
+
+    const boundRoute = this.getBoundMcpClientRoute(socketSessionId);
+    if (boundRoute) {
+      return boundRoute;
     }
 
     const implicitAutolockKey = this.getImplicitAutolockScopeKey(socketSessionId, args);
     if (implicitAutolockKey) {
-      return implicitAutolockKey;
+      return this.sharedMcpForwardRoute(implicitAutolockKey);
     }
 
     // The daemon injects __mcpSessionId before forwarding. Use the socket session as the
     // pre-forward key so separate daemon clients can autolock and run independently.
-    return `socket:${socketSessionId}`;
+    return this.sharedMcpForwardRoute(`socket:${socketSessionId}`);
+  }
+
+  private sharedMcpForwardRoute(key: string): McpForwardRoute {
+    return { executionKey: key, clientKey: key };
+  }
+
+  private sessionMcpClientKey(socketSessionId: string, sessionUuid: string): string {
+    return `socket:${socketSessionId}:session:${sessionUuid}`;
   }
 
   private recordBoundMcpClientKey(
     request: DaemonRequest,
     socketSessionId: string,
-    forwardKey: string,
+    route: McpForwardRoute,
     sessionWasActiveBeforeForward: boolean
   ): void {
     if (request.method !== "tools/call") {
@@ -691,23 +721,36 @@ export class UnixSocketServer {
       this.clearBoundMcpClientKey(socketSessionId);
       return;
     }
+    const previousBinding = this.boundMcpClientKeysBySocketSession.get(socketSessionId);
     this.boundMcpClientKeysBySocketSession.set(socketSessionId, {
-      forwardKey,
+      clientKey: route.clientKey,
+      executionKey: route.executionKey,
       sessionUuid,
       requiresLiveDaemonSession: sessionWasActiveBeforeForward || sessionIsActiveAfterForward,
     });
+    if (previousBinding && previousBinding.clientKey !== route.clientKey) {
+      this.scheduleMcpClientIdleClose(previousBinding.clientKey);
+    }
   }
 
-  private getBoundMcpClientKey(socketSessionId: string): string | undefined {
+  private getBoundMcpClientRoute(socketSessionId: string): McpForwardRoute | undefined {
     const boundClient = this.boundMcpClientKeysBySocketSession.get(socketSessionId);
     if (!boundClient) {
       return undefined;
     }
     if (!boundClient.requiresLiveDaemonSession || !this.daemonState.isInitialized()) {
-      return boundClient.forwardKey;
+      return {
+        clientKey: boundClient.clientKey,
+        executionKey: boundClient.executionKey,
+        sessionUuid: boundClient.sessionUuid,
+      };
     }
     if (this.hasActiveDaemonSession(boundClient.sessionUuid)) {
-      return boundClient.forwardKey;
+      return {
+        clientKey: boundClient.clientKey,
+        executionKey: boundClient.executionKey,
+        sessionUuid: boundClient.sessionUuid,
+      };
     }
     this.clearBoundMcpClientKey(socketSessionId);
     return undefined;
@@ -719,12 +762,12 @@ export class UnixSocketServer {
       return;
     }
     this.boundMcpClientKeysBySocketSession.delete(socketSessionId);
-    this.scheduleMcpClientIdleClose(boundClient.forwardKey);
+    this.scheduleMcpClientIdleClose(boundClient.clientKey);
   }
 
   private isMcpClientKeyBound(key: string): boolean {
     for (const boundClient of this.boundMcpClientKeysBySocketSession.values()) {
-      if (boundClient.forwardKey === key) {
+      if (boundClient.clientKey === key) {
         return true;
       }
     }
@@ -2093,7 +2136,7 @@ export class UnixSocketServer {
   /**
    * Create an MCP client connected to the HTTP server
    */
-  private async createMcpClient(): Promise<Client> {
+  private async createMcpClient(boundSessionUuid?: string): Promise<Client> {
     logger.info(`Creating MCP client with endpoint: "${this.mcpEndpoint}"`);
     if (!this.mcpEndpoint) {
       logger.error(`ERROR: mcpEndpoint is empty or undefined when creating client!`);
@@ -2103,6 +2146,15 @@ export class UnixSocketServer {
       new URL(this.mcpEndpoint),
       {
         reconnectionOptions: DAEMON_LOOPBACK_STREAMABLE_HTTP_RECONNECTION,
+        ...(boundSessionUuid
+          ? {
+            requestInit: {
+              headers: {
+                [DAEMON_SESSION_TOOL_BINDING_HEADER]: boundSessionUuid,
+              },
+            },
+          }
+          : {}),
       }
     );
 
@@ -2125,7 +2177,7 @@ export class UnixSocketServer {
   /**
    * Get or create the MCP client for a target key.
    */
-  private async getMcpClient(key: string): Promise<Client> {
+  private async getMcpClient(key: string, boundSessionUuid?: string): Promise<Client> {
     this.clearMcpClientIdleTimer(key);
 
     const existingClient = this.mcpClients.get(key);
@@ -2138,7 +2190,7 @@ export class UnixSocketServer {
       return existingPromise;
     }
 
-    const clientPromise = this.mcpClientFactory()
+    const clientPromise = this.mcpClientFactory(boundSessionUuid)
       .then(client => {
         this.mcpClients.set(key, client);
         this.mcpClientPromises.delete(key);

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -724,6 +724,27 @@ export class UnixSocketServer {
       // that would run the admitted tool with no capability profile. Only the
       // execution target may be re-resolved, never the admitted client/session
       // (issue #4610).
+      //
+      // Exception: when the admitted route was seeded for a specific daemon
+      // session and that session was RELEASED while this request waited in the
+      // queue, invoking the stale session-scoped client would re-seed the released
+      // UUID and RESURRECT the session (getOrCreateSession recreates it and
+      // reacquires a device the caller never asked for). A mid-flight socket
+      // disconnect, by contrast, leaves the daemon session live — so the daemon
+      // session still being active is exactly what distinguishes a disconnect
+      // (keep the admitted client, preserving the capability profile above) from a
+      // real release (re-resolve to the current, unseeded route). Only re-resolve
+      // when the recompute actually points somewhere else (issue #4610).
+      if (
+        initialRoute.sessionUuid !== undefined &&
+        currentRoute.clientKey !== initialRoute.clientKey &&
+        !this.hasActiveDaemonSession(initialRoute.sessionUuid)
+      ) {
+        logger.debug(
+          `[McpForward] released-session re-resolve requestId=${request.id} releasedSession=${initialRoute.sessionUuid} clientKey=${initialRoute.clientKey} -> ${currentRoute.clientKey}`
+        );
+        return await this.runWithActiveMcpClient(currentRoute.clientKey, () => fn(currentRoute));
+      }
       return await this.runWithActiveMcpClient(initialRoute.clientKey, () => fn(initialRoute));
     });
   }
@@ -735,6 +756,16 @@ export class UnixSocketServer {
 
     const boundRoute = this.getBoundMcpClientRoute(socketSessionId);
     if (request.method === "tools/list") {
+      // A reconnected restricted discovery re-sends `{sessionUuid}` (see
+      // daemonMcpProxy.listTools). A fresh socket has no boundRoute, so without
+      // honoring the request's session the shared UNSEEDED client would return the
+      // full, unfiltered tool list. Route to the session-scoped client so the
+      // seeded loopback transport advertises the session-scoped list, completing
+      // the proxy-side reconnect seeding (issue #4610).
+      const listSessionUuid = this.getSessionUuid(request.params);
+      if (listSessionUuid) {
+        return this.sessionScopedForwardRoute(socketSessionId, listSessionUuid, undefined);
+      }
       return boundRoute ?? this.sharedMcpForwardRoute(`method:${request.method}`);
     }
 

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -546,7 +546,9 @@ export class UnixSocketServer {
             logger.debug(
               `[McpForward] end executionKey=${route.executionKey} clientKey=${route.clientKey} socketSession=${sessionId} requestId=${request.id} ${forwardLabel} forwardMs=${this.timer.now() - forwardStartMs}`
             );
-            this.scheduleMcpClientIdleClose(route.clientKey);
+            // The idle close is scheduled by runWithActiveMcpClient's wrapper once
+            // this client's active-forward count reaches zero, so it is re-armed
+            // even when a forward throws before reaching this finally (issue #4610).
           }
         });
 
@@ -650,6 +652,13 @@ export class UnixSocketServer {
       const remainingForClient = (this.activeMcpClientForwardCounts.get(clientKey) ?? 1) - 1;
       if (remainingForClient === 0) {
         this.activeMcpClientForwardCounts.delete(clientKey);
+        // Re-arm the idle close around the whole active-client wrapper. A forward
+        // can throw before its own cleanup runs (e.g. the pre-forward queue
+        // timeout deadline throws before the forward-body finally), and this
+        // wrapper cleared the client's idle timer on entry. Without this re-arm
+        // the inactive transport would stay cached until another request or
+        // daemon shutdown (issue #4610).
+        this.scheduleMcpClientIdleClose(clientKey);
       } else {
         this.activeMcpClientForwardCounts.set(clientKey, remainingForClient);
       }
@@ -670,7 +679,14 @@ export class UnixSocketServer {
         );
         return await this.runMcpForwardForCurrentRoute(currentRoute, request, socketSessionId, fn);
       }
-      return await this.runWithActiveMcpClient(currentRoute.clientKey, () => fn(currentRoute));
+      // The execution target is unchanged, so this request keeps the client and
+      // session it was admitted with. Re-resolving may replace a session-specific
+      // clientKey with the shared unbound client (e.g. a mid-flight disconnect
+      // cleared the binding before this recompute) under the same executionKey;
+      // that would run the admitted tool with no capability profile. Only the
+      // execution target may be re-resolved, never the admitted client/session
+      // (issue #4610).
+      return await this.runWithActiveMcpClient(initialRoute.clientKey, () => fn(initialRoute));
     });
   }
 

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -197,6 +197,8 @@ export class UnixSocketServer {
   private boundMcpClientKeysBySocketSession: Map<string, BoundMcpClient> = new Map();
   /** Promise tails that serialize MCP HTTP forwards only within the same execution target. */
   private mcpForwardTails: Map<string, Promise<void>> = new Map();
+  /** Direct device forwards that need cleanup after every successor tail has settled. */
+  private mcpForwardIdleCloseKeys: Map<string, Set<string>> = new Map();
   /** Active forwards by loopback MCP client, which can differ from the execution target. */
   private activeMcpClientForwardCounts: Map<string, number> = new Map();
   private mcpClientIdleTimers: Map<string, NodeJS.Timeout> = new Map();
@@ -606,6 +608,11 @@ export class UnixSocketServer {
     fn: () => Promise<T>,
     idleCloseKey?: string
   ): Promise<T> {
+    if (idleCloseKey) {
+      const idleCloseKeys = this.mcpForwardIdleCloseKeys.get(executionKey) ?? new Set<string>();
+      idleCloseKeys.add(idleCloseKey);
+      this.mcpForwardIdleCloseKeys.set(executionKey, idleCloseKeys);
+    }
     const previous = this.mcpForwardTails.get(executionKey) ?? Promise.resolve();
     const run = previous.then(() => {
       if (idleCloseKey) {
@@ -621,8 +628,10 @@ export class UnixSocketServer {
     void tail.finally(() => {
       if (this.mcpForwardTails.get(executionKey) === tail) {
         this.mcpForwardTails.delete(executionKey);
-        if (idleCloseKey) {
-          this.scheduleMcpClientIdleClose(idleCloseKey);
+        const idleCloseKeys = this.mcpForwardIdleCloseKeys.get(executionKey);
+        this.mcpForwardIdleCloseKeys.delete(executionKey);
+        for (const key of idleCloseKeys ?? []) {
+          this.scheduleMcpClientIdleClose(key);
         }
       }
     });
@@ -678,6 +687,9 @@ export class UnixSocketServer {
     if (request.method === "ide/getNavigationGraph") {
       const executionKey = this.getRequestArgumentScopeKey(request.params);
       if (executionKey) {
+        if (boundRoute) {
+          return { ...boundRoute, executionKey };
+        }
         return this.sharedMcpForwardRoute(executionKey);
       }
       return boundRoute ?? this.sharedMcpForwardRoute(`method:${request.method}`);
@@ -2407,6 +2419,7 @@ export class UnixSocketServer {
       }
     }
     this.mcpForwardTails.clear();
+    this.mcpForwardIdleCloseKeys.clear();
     this.appendTextInputs.clear();
 
     // Clear sessions

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -29,6 +29,10 @@ import {
   type ListChangedKind,
 } from "../server/listChangedBroadcast";
 import {
+  SessionReleaseBroadcaster,
+  SESSION_RELEASED_NOTIFICATION_METHOD,
+} from "../server/sessionReleaseBroadcast";
+import {
   evaluateClientHandshake,
   extractClientHandshake,
   type DaemonSelfIdentity,
@@ -184,6 +188,7 @@ export class UnixSocketServer {
   /** Socket sessions that opted in to server-pushed notifications. */
   private notificationSubscribers: Set<string> = new Set();
   private listChangedUnsubscribe: (() => void) | null = null;
+  private sessionReleaseUnsubscribe: (() => void) | null = null;
   private socketPath: string;
   private mcpEndpoint: string;
   private daemonState: DaemonStateAccess;
@@ -294,6 +299,15 @@ export class UnixSocketServer {
       this.broadcastListChanged(kind);
     });
 
+    // Fan session-release events out to subscribed proxy clients (issue #4610),
+    // so a proxy clears its remembered binding on a real release instead of the
+    // replay-TTL guess. Subscribed here (not in the daemon) for the same
+    // recovery-rewire reason as list-changed; close() unsubscribes symmetrically.
+    this.sessionReleaseUnsubscribe?.();
+    this.sessionReleaseUnsubscribe = SessionReleaseBroadcaster.subscribe(sessionId => {
+      this.broadcastSessionReleased(sessionId);
+    });
+
     return new Promise((resolve, reject) => {
       this.server!.listen(this.socketPath, () => {
         this.socketFileIdentity = this.readSocketFileIdentity();
@@ -393,6 +407,29 @@ export class UnixSocketServer {
     const notification: DaemonNotification = {
       type: "daemon_notification",
       method: LIST_CHANGED_NOTIFICATION_METHODS[kind],
+    };
+    for (const sessionId of this.notificationSubscribers) {
+      const socket = this.clientSockets.get(sessionId);
+      if (!socket) {
+        continue;
+      }
+      this.writeFrame(socket, sessionId, notification);
+    }
+  }
+
+  /**
+   * Push a session-released notification frame to every subscribed client socket
+   * (issue #4610). `releasedSessionId` is the daemon session key that was just
+   * released (base or derived `${base}:${label}`); the proxy matches it against
+   * its bound UUID by exact equality. Best-effort per socket, like
+   * {@link broadcastListChanged}. Note `sessionId` here is the socket-client id,
+   * distinct from the released daemon session carried in the frame.
+   */
+  private broadcastSessionReleased(releasedSessionId: string): void {
+    const notification: DaemonNotification = {
+      type: "daemon_notification",
+      method: SESSION_RELEASED_NOTIFICATION_METHOD,
+      sessionId: releasedSessionId,
     };
     for (const sessionId of this.notificationSubscribers) {
       const socket = this.clientSockets.get(sessionId);
@@ -2417,6 +2454,10 @@ export class UnixSocketServer {
     // Stop receiving list-changed events (mirrors the subscribe in start()).
     this.listChangedUnsubscribe?.();
     this.listChangedUnsubscribe = null;
+
+    // Stop receiving session-release events (mirrors the subscribe in start()).
+    this.sessionReleaseUnsubscribe?.();
+    this.sessionReleaseUnsubscribe = null;
 
     // Close MCP clients
     const clients = Array.from(this.mcpClients.entries());

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -692,11 +692,14 @@ export class UnixSocketServer {
       };
     }
 
+    const boundRoute = this.getBoundMcpClientRoute(socketSessionId);
     if (scopedKey) {
+      if (boundRoute) {
+        return { ...boundRoute, executionKey: scopedKey };
+      }
       return this.sharedMcpForwardRoute(scopedKey);
     }
 
-    const boundRoute = this.getBoundMcpClientRoute(socketSessionId);
     if (boundRoute) {
       return boundRoute;
     }

--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -601,9 +601,16 @@ export class UnixSocketServer {
    * Run one MCP forward at a time for a single execution target. Calls for different devices or
    * sessions can proceed concurrently while their loopback transports remain session-local.
    */
-  private runKeyedMcpForward<T>(executionKey: string, fn: () => Promise<T>): Promise<T> {
+  private runKeyedMcpForward<T>(
+    executionKey: string,
+    fn: () => Promise<T>,
+    idleCloseKey?: string
+  ): Promise<T> {
     const previous = this.mcpForwardTails.get(executionKey) ?? Promise.resolve();
     const run = previous.then(() => {
+      if (idleCloseKey) {
+        this.clearMcpClientIdleTimer(idleCloseKey);
+      }
       return fn();
     });
     const tail = run.then(
@@ -614,6 +621,9 @@ export class UnixSocketServer {
     void tail.finally(() => {
       if (this.mcpForwardTails.get(executionKey) === tail) {
         this.mcpForwardTails.delete(executionKey);
+        if (idleCloseKey) {
+          this.scheduleMcpClientIdleClose(idleCloseKey);
+        }
       }
     });
     return run;
@@ -1322,7 +1332,7 @@ export class UnixSocketServer {
       return args.frameContext === undefined
         ? await iosClient.requestTapCoordinates(x, y, args.duration, gestureTimeoutMs)
         : await iosClient.requestTapCoordinates(x, y, args.duration, gestureTimeoutMs, undefined, args.frameContext);
-    });
+    }, `device:${targetDevice.deviceId}`);
 
     if (!gestureResult.success) {
       throw new Error(gestureResult.error ?? `input/tap failed on ${args.platform}`);
@@ -1399,7 +1409,7 @@ export class UnixSocketServer {
           gestureTimeoutMs,
           args.frameContext
         );
-    });
+    }, `device:${targetDevice.deviceId}`);
 
     if (!gestureResult.success) {
       throw new Error(gestureResult.error ?? `input/swipe failed on ${args.platform}`);
@@ -1480,7 +1490,7 @@ export class UnixSocketServer {
             ? new InputTypeTextAppendError(timeoutError.message, confirmedAppendCharsSent)
             : undefined
       );
-    });
+    }, `device:${targetDevice.deviceId}`);
 
     if (!inputResult.success) {
       if (args.append && inputResult.charsSent !== undefined) {
@@ -1532,7 +1542,7 @@ export class UnixSocketServer {
       return args.frameContext === undefined
         ? await pressButton.press(args.button, remainingTimeoutMs)
         : await pressButton.press(args.button, remainingTimeoutMs, args.frameContext);
-    });
+    }, `device:${targetDevice.deviceId}`);
 
     if (!buttonResult.success) {
       throw new Error(buttonResult.error ?? `input/pressButton failed on ${args.platform}`);
@@ -1580,7 +1590,7 @@ export class UnixSocketServer {
       return args.frameContext === undefined
         ? await inputKey.press(args.key, remainingTimeoutMs)
         : await inputKey.press(args.key, remainingTimeoutMs, args.frameContext);
-    });
+    }, `device:${targetDevice.deviceId}`);
 
     if (!keyResult.success) {
       throw new Error(keyResult.error ?? `input/key failed on ${args.platform}`);

--- a/src/daemon/types.ts
+++ b/src/daemon/types.ts
@@ -60,6 +60,12 @@ export interface DaemonNotification {
   type: "daemon_notification";
   /** MCP notification method, e.g. "notifications/tools/list_changed". */
   method: string;
+  /**
+   * Released session key for `notifications/session/released` frames (issue
+   * #4610). Absent for list-changed frames. The proxy clears its remembered
+   * binding only when this exactly equals its bound (base) session UUID.
+   */
+  sessionId?: string;
 }
 
 /** Discriminates a daemon socket frame as a server-pushed notification. */

--- a/src/features/toolCapabilities/capabilitySessionResolver.ts
+++ b/src/features/toolCapabilities/capabilitySessionResolver.ts
@@ -1,0 +1,42 @@
+/**
+ * Minimal session-manager surface the capability resolver needs. Kept narrow
+ * (YAGNI) so both the MCP tool registry and the daemon socket server can share
+ * one base-session resolution without depending on the full SessionManager.
+ */
+export interface CapabilitySessionManager {
+  getDeviceLabels(sessionUuid: string): Record<string, string> | undefined;
+}
+
+/**
+ * Given a session UUID that may be a derived `${base}:${label}` device-label
+ * session, return the BASE session UUID whose persisted tool profile governs
+ * capability enforcement. Returns the input unchanged when it is already a base
+ * session, when no session-manager is available, or when the label cannot be
+ * resolved.
+ *
+ * Lifted from the daemon socket server's former
+ * `getCapabilityProfileSessionUuid` (issue #4611 Gap A) so the MCP path
+ * (`toolRegistry`) and the socket path (`assertSocketToolEnabled`) resolve the
+ * base session identically instead of one path silently skipping enforcement.
+ */
+export function resolveCapabilityBaseSessionUuid(
+  sessionUuid: string | undefined,
+  sessionManager: CapabilitySessionManager | undefined,
+): string | undefined {
+  if (!sessionUuid || !sessionManager) {
+    return sessionUuid;
+  }
+
+  for (
+    let separatorIndex = sessionUuid.lastIndexOf(":");
+    separatorIndex >= 0;
+    separatorIndex = sessionUuid.lastIndexOf(":", separatorIndex - 1)
+  ) {
+    const candidateBaseSessionUuid = sessionUuid.slice(0, separatorIndex);
+    const deviceLabels = sessionManager.getDeviceLabels(candidateBaseSessionUuid);
+    if (deviceLabels && Object.values(deviceLabels).includes(sessionUuid)) {
+      return candidateBaseSessionUuid;
+    }
+  }
+  return sessionUuid;
+}

--- a/src/features/toolCapabilities/toolCapabilityContext.ts
+++ b/src/features/toolCapabilities/toolCapabilityContext.ts
@@ -1,8 +1,19 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import type { SessionToolProfileService } from "./SessionToolProfileService";
 
+/**
+ * Ambient context threaded through a tool invocation.
+ *
+ * `routingSessionUuid` is the ROUTING session — the derived/label session a
+ * device-aware call resolved to (issue #4611 Gap C). Nested device-aware and
+ * internal calls re-inject it so a `${base}:${label}` label session keeps its
+ * device/routing identity instead of collapsing back onto the base session.
+ * Capability enforcement is computed SEPARATELY at each assert call (union of
+ * base + derived, Gap B) and is intentionally NOT carried here, so routing and
+ * capability can no longer be re-conflated.
+ */
 type ToolCapabilityContext = {
-  sessionUuid?: string;
+  routingSessionUuid?: string;
   sessionToolProfileService?: Pick<SessionToolProfileService, "isEnabled">;
 };
 
@@ -14,7 +25,7 @@ export const runWithToolCapabilityContext = async <T>(
 ): Promise<T> => {
   const parent = toolCapabilityContext.getStore();
   return toolCapabilityContext.run({
-    sessionUuid: context.sessionUuid ?? parent?.sessionUuid,
+    routingSessionUuid: context.routingSessionUuid ?? parent?.routingSessionUuid,
     sessionToolProfileService: context.sessionToolProfileService ?? parent?.sessionToolProfileService,
   }, fn);
 };

--- a/src/features/toolCapabilities/toolCapabilityPolicy.ts
+++ b/src/features/toolCapabilities/toolCapabilityPolicy.ts
@@ -32,3 +32,57 @@ export async function assertToolEnabledForSession(
     `Tool ${toolName} requires the '${capability}' capability for device session ${sessionUuid ?? "(not yet bound)"}.`
   );
 }
+
+/**
+ * UNION capability semantics for a derived device-label session (issue #4611
+ * Gap B, product decision). A tool is enabled when EITHER the base OR the
+ * derived (`${base}:${label}`) session grants the capability. This is
+ * deliberately permissive: a derived label may re-enable a tool that the base
+ * session narrowed away. Sessions that collapse to the same UUID (a plain base
+ * session, or a deviceId whose owning session has no label) reduce to a single
+ * check.
+ *
+ * When no candidate session is bound yet, the initial surface is preserved
+ * (returns `true`), matching `isToolEnabledForSession`'s undefined-session
+ * behavior — otherwise `tools/list` before a device session binds would filter
+ * incorrectly.
+ */
+export async function isToolEnabledForAnySession(
+  toolName: string,
+  sessionUuids: ReadonlyArray<string | undefined>,
+  sessionToolProfileService?: ToolProfileReader,
+): Promise<boolean> {
+  const capability = TOOL_CAPABILITY_BY_NAME.get(toolName);
+  if (!capability) {
+    return true;
+  }
+  const candidates = Array.from(
+    new Set(sessionUuids.filter((uuid): uuid is string => Boolean(uuid)))
+  );
+  if (candidates.length === 0) {
+    return true;
+  }
+  const service = sessionToolProfileService ?? getSessionToolProfileService();
+  for (const sessionUuid of candidates) {
+    if (await service.isEnabled(sessionUuid, capability)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export async function assertToolEnabledForAnySession(
+  toolName: string,
+  sessionUuids: ReadonlyArray<string | undefined>,
+  sessionToolProfileService?: ToolProfileReader,
+): Promise<void> {
+  if (await isToolEnabledForAnySession(toolName, sessionUuids, sessionToolProfileService)) {
+    return;
+  }
+  const capability = TOOL_CAPABILITY_BY_NAME.get(toolName);
+  const target = Array.from(new Set(sessionUuids.filter((uuid): uuid is string => Boolean(uuid)))).join(" / ")
+    || "(not yet bound)";
+  throw new ActionableError(
+    `Tool ${toolName} requires the '${capability}' capability for device session ${target}.`
+  );
+}

--- a/src/server/SessionToolBinding.ts
+++ b/src/server/SessionToolBinding.ts
@@ -1,7 +1,10 @@
 export class SessionToolBinding {
   private readonly boundDeviceSessions = new Map<string, string>();
+  private initialSessionUuid?: string;
 
-  constructor(private readonly initialSessionUuid?: string) {}
+  constructor(initialSessionUuid?: string) {
+    this.initialSessionUuid = initialSessionUuid;
+  }
 
   effectiveSessionUuid(mcpSessionId: string | undefined, params?: unknown): string | undefined {
     const explicit = params && typeof params === "object" && !Array.isArray(params)
@@ -24,5 +27,36 @@ export class SessionToolBinding {
     }
     this.boundDeviceSessions.set(mcpSessionId, sessionUuid);
     return true;
+  }
+
+  /**
+   * Drop every binding whose effective session is the just-released
+   * `sessionUuid` (issue #4611 Gap D). After an executePlan (or a heartbeat/idle)
+   * release frees a daemon session, the per-transport binding must be torn down
+   * so a later sessionless `tools/list`/`tools/call` on the SAME MCP transport
+   * stops enforcing the released session's (now stale) capability profile.
+   *
+   * Both binding origins are cleared: any per-transport map entry pointing at the
+   * session AND a seeded `initialSessionUuid` fallback that `effectiveSessionUuid`
+   * would otherwise still return. Idempotent — returns whether anything was
+   * actually removed, so callers can skip a redundant list-changed notification
+   * when a duplicate release signal arrives.
+   */
+  unbindSession(sessionUuid: string): boolean {
+    if (!sessionUuid) {
+      return false;
+    }
+    let removed = false;
+    for (const [mcpSessionId, boundSessionUuid] of this.boundDeviceSessions) {
+      if (boundSessionUuid === sessionUuid) {
+        this.boundDeviceSessions.delete(mcpSessionId);
+        removed = true;
+      }
+    }
+    if (this.initialSessionUuid === sessionUuid) {
+      this.initialSessionUuid = undefined;
+      removed = true;
+    }
+    return removed;
   }
 }

--- a/src/server/SessionToolBinding.ts
+++ b/src/server/SessionToolBinding.ts
@@ -15,7 +15,11 @@ export class SessionToolBinding {
   }
 
   bind(mcpSessionId: string | undefined, sessionUuid: string | undefined): boolean {
-    if (!mcpSessionId || !sessionUuid?.trim() || this.effectiveSessionUuid(mcpSessionId) === sessionUuid) {
+    if (
+      !mcpSessionId
+      || !sessionUuid?.trim()
+      || this.boundDeviceSessions.get(mcpSessionId) === sessionUuid
+    ) {
       return false;
     }
     this.boundDeviceSessions.set(mcpSessionId, sessionUuid);

--- a/src/server/SessionToolBinding.ts
+++ b/src/server/SessionToolBinding.ts
@@ -1,6 +1,8 @@
 export class SessionToolBinding {
   private readonly boundDeviceSessions = new Map<string, string>();
 
+  constructor(private readonly initialSessionUuid?: string) {}
+
   effectiveSessionUuid(mcpSessionId: string | undefined, params?: unknown): string | undefined {
     const explicit = params && typeof params === "object" && !Array.isArray(params)
       ? (params as Record<string, unknown>).sessionUuid
@@ -8,12 +10,12 @@ export class SessionToolBinding {
     return typeof explicit === "string" && explicit.trim().length > 0
       ? explicit
       : mcpSessionId
-        ? this.boundDeviceSessions.get(mcpSessionId)
+        ? this.boundDeviceSessions.get(mcpSessionId) ?? this.initialSessionUuid
         : undefined;
   }
 
   bind(mcpSessionId: string | undefined, sessionUuid: string | undefined): boolean {
-    if (!mcpSessionId || !sessionUuid?.trim() || this.boundDeviceSessions.get(mcpSessionId) === sessionUuid) {
+    if (!mcpSessionId || !sessionUuid?.trim() || this.effectiveSessionUuid(mcpSessionId) === sessionUuid) {
       return false;
     }
     this.boundDeviceSessions.set(mcpSessionId, sessionUuid);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -73,7 +73,7 @@ import {
 } from "../features/toolCapabilities/SessionToolProfileService";
 import {
   assertToolEnabledForAnySession,
-  isToolEnabledForSession,
+  isToolEnabledForAnySession,
 } from "../features/toolCapabilities/toolCapabilityPolicy";
 import { getDeviceLabelMap } from "./deviceLabelMapping";
 import { runWithToolCapabilityContext } from "../features/toolCapabilities/toolCapabilityContext";
@@ -306,9 +306,20 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   server.server.setRequestHandler(ListToolsRequestSchema, async () => {
     const sessionUuid = sessionToolBinding.effectiveSessionUuid(options.sessionContext?.sessionId);
     const definitions = ToolRegistry.getToolDefinitions();
+    // Advertise a tool when EITHER the bound base session OR any of its derived
+    // `${base}:${label}` device-label sessions enables it — the same UNION the
+    // `tools/call` gate applies (issue #4611). The call-gate accepts a
+    // `{ sessionUuid: base, device: label }` call whenever a label re-enables a
+    // tool the base narrowed away; filtering discovery on the base alone would
+    // then leave that tool callable but never discovered. The base's label map is
+    // a read-only lookup (no device allocation); a session with no labels collapses
+    // to the base, preserving prior single-session filtering.
+    const candidateSessions = sessionUuid
+      ? [sessionUuid, ...Object.values(getDeviceLabelMap(sessionUuid) ?? {})]
+      : [sessionUuid];
     return {
       tools: (await Promise.all(definitions.map(async definition =>
-        await isToolEnabledForSession(definition.name, sessionUuid, options.sessionToolProfileService) ? definition : undefined
+        await isToolEnabledForAnySession(definition.name, candidateSessions, options.sessionToolProfileService) ? definition : undefined
       ))).filter((definition): definition is typeof definitions[number] => definition !== undefined)
     };
   });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -72,9 +72,10 @@ import {
   type SessionToolProfileService,
 } from "../features/toolCapabilities/SessionToolProfileService";
 import {
-  assertToolEnabledForSession,
+  assertToolEnabledForAnySession,
   isToolEnabledForSession,
 } from "../features/toolCapabilities/toolCapabilityPolicy";
+import { getDeviceLabelMap } from "./deviceLabelMapping";
 import { runWithToolCapabilityContext } from "../features/toolCapabilities/toolCapabilityContext";
 
 export interface McpServerOptions {
@@ -348,7 +349,28 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     if (!tool) {
       throw new ActionableError(`Unknown tool: ${name}`);
     }
-    await assertToolEnabledForSession(name, sessionUuid, options.sessionToolProfileService);
+    // Capability enforcement honors the UNION of the base and the derived
+    // `${base}:${label}` device-label sessions (issue #4611): a tool is enabled
+    // when EITHER grants it. This public MCP boundary is an EARLIER gate than the
+    // authoritative union in `registerDeviceAware` (which rejects a
+    // capability-denied tool before allocating a device), so it must apply the
+    // same union — otherwise a base session that narrowed a tool away would
+    // reject a `{ sessionUuid: base, device: label }` call here before the deeper
+    // gate could observe that `base:label` re-enables it. Resolve the derived
+    // label candidate from the base session's label map (a read-only lookup, no
+    // device allocation). Non-labeled and non-device-aware calls collapse to the
+    // base, preserving prior single-session behavior and `tools/list` filtering.
+    const requestedDeviceLabel = typeof (toolParams as Record<string, unknown>).device === "string"
+      ? (toolParams as Record<string, unknown>).device as string
+      : undefined;
+    const derivedLabelSessionUuid = requestedDeviceLabel && sessionUuid
+      ? getDeviceLabelMap(sessionUuid)?.[requestedDeviceLabel]
+      : undefined;
+    await assertToolEnabledForAnySession(
+      name,
+      [sessionUuid, derivedLabelSessionUuid],
+      options.sessionToolProfileService,
+    );
 
     const requestMcpSessionId = extractInternalMcpSessionId(toolParams);
     const implicitAutolockMcpSessionId = requestMcpSessionId ?? (!daemonMode ? sessionId : undefined);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -11,6 +11,7 @@ import { executionTracker } from "./executionTracker";
 import { runWithAbortSignal } from "../utils/AbortContext";
 import { createDefaultPlanExecutionLock, type PlanExecutionLock } from "./PlanExecutionLock";
 import { SessionToolBinding } from "./SessionToolBinding";
+import { SessionReleaseBroadcaster } from "./sessionReleaseBroadcast";
 
 // Import the tool registry
 import { ToolRegistry, toolHasOutputSchema } from "./toolRegistry";
@@ -269,6 +270,36 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
 
   // Register all resources with the server
   ResourceRegistry.registerWithServer(server);
+
+  // Tear down this transport's server-side SessionToolBinding when the daemon
+  // actually releases a session (issue #4611 Gap D). Two release sources funnel
+  // through the same idempotent `unbindSession`:
+  //   - the plan-release path, via ToolRegistry's injected teardown handler
+  //     (executePlan auto-release, deterministic, works in stdio mode too); and
+  //   - heartbeat/idle/explicit releases, via the process-wide
+  //     SessionReleaseBroadcaster (issue #4610), active in daemon mode.
+  // Clearing the binding stops a later sessionless tools/list or tools/call on
+  // this same MCP transport from enforcing the released session's stale profile.
+  // A list-changed notification is emitted only when a binding actually changed,
+  // so a duplicate release signal for the same session is a no-op.
+  const clearReleasedSessionBinding = (sessionUuid: string): void => {
+    if (sessionToolBinding.unbindSession(sessionUuid)) {
+      ToolRegistry.notifyToolListChanged();
+    }
+  };
+  const unregisterSessionBindingRelease = ToolRegistry.registerSessionBindingReleaseHandler({
+    onSessionReleased: clearReleasedSessionBinding,
+  });
+  const unsubscribeSessionReleaseBroadcast = SessionReleaseBroadcaster.subscribe(clearReleasedSessionBinding);
+  // Chain onto the existing onclose (set by ToolRegistry.registerWithServer's
+  // server tracking) so the per-transport teardown subscriptions are dropped when
+  // the transport closes, and no other lifecycle hook is clobbered.
+  const existingServerOnClose = server.server.onclose;
+  server.server.onclose = () => {
+    unregisterSessionBindingRelease();
+    unsubscribeSessionReleaseBroadcast();
+    existingServerOnClose?.();
+  };
 
   // Register tool definitions using the lower-level interface
   server.server.setRequestHandler(ListToolsRequestSchema, async () => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -384,7 +384,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
       const result = await runWithAbortSignal(
         execution.abortController.signal,
         () => runWithToolCapabilityContext(
-          { sessionUuid, sessionToolProfileService: options.sessionToolProfileService },
+          { routingSessionUuid: sessionUuid, sessionToolProfileService: options.sessionToolProfileService },
           () => tool.handler(handlerParams, progressCallback, execution.abortController.signal)
         )
       );

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -78,7 +78,7 @@ import { runWithToolCapabilityContext } from "../features/toolCapabilities/toolC
 
 export interface McpServerOptions {
   debug?: boolean;
-  sessionContext?: { sessionId?: string };
+  sessionContext?: { sessionId?: string; initialSessionToolBinding?: string };
   planExecutionLock?: PlanExecutionLock;
   daemonMode?: boolean;
   sessionToolProfileService?: Pick<SessionToolProfileService, "isEnabled">;
@@ -163,7 +163,7 @@ export function formatToolParamError(toolName: string, error: unknown): string {
 }
 
 export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
-  const sessionToolBinding = new SessionToolBinding();
+  const sessionToolBinding = new SessionToolBinding(options.sessionContext?.initialSessionToolBinding);
   // Plan execution lock with per-session scope to prevent interference during executePlan
   // Each test thread gets its own sessionUuid, enabling parallel execution on different devices
   const planExecutionLock = options.planExecutionLock ?? createDefaultPlanExecutionLock();

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -314,13 +314,23 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     // then leave that tool callable but never discovered. The base's label map is
     // a read-only lookup (no device allocation); a session with no labels collapses
     // to the base, preserving prior single-session filtering.
-    const candidateSessions = sessionUuid
-      ? [sessionUuid, ...Object.values(getDeviceLabelMap(sessionUuid) ?? {})]
-      : [sessionUuid];
+    //
+    // The union is per-tool and DEVICE-AWARE only, mirroring the call gate: a
+    // plain (non-`requiresDevice`) tool runs under the base session regardless of
+    // any `device` argument, so its discovery must be base-only. Advertising a
+    // plain tool that only a label enables would leave it listed but rejected by
+    // the base-only call gate — a label-only grant must not surface a plain tool.
+    const labelSessionUuids = sessionUuid
+      ? Object.values(getDeviceLabelMap(sessionUuid) ?? {})
+      : [];
     return {
-      tools: (await Promise.all(definitions.map(async definition =>
-        await isToolEnabledForAnySession(definition.name, candidateSessions, options.sessionToolProfileService) ? definition : undefined
-      ))).filter((definition): definition is typeof definitions[number] => definition !== undefined)
+      tools: (await Promise.all(definitions.map(async definition => {
+        const deviceAware = ToolRegistry.getTool(definition.name)?.requiresDevice ?? false;
+        const candidateSessions = deviceAware
+          ? [sessionUuid, ...labelSessionUuids]
+          : [sessionUuid];
+        return await isToolEnabledForAnySession(definition.name, candidateSessions, options.sessionToolProfileService) ? definition : undefined;
+      }))).filter((definition): definition is typeof definitions[number] => definition !== undefined)
     };
   });
 
@@ -371,10 +381,18 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
     // label candidate from the base session's label map (a read-only lookup, no
     // device allocation). Non-labeled and non-device-aware calls collapse to the
     // base, preserving prior single-session behavior and `tools/list` filtering.
+    //
+    // Gate the derived-label candidate to DEVICE-AWARE tools only. A plain tool
+    // (registered via `register`, not `registerDeviceAware`) strips the `device`
+    // field via its `z.object` schema and always executes under the base session,
+    // so it never runs on the labeled device — consulting `base:label`'s profile
+    // would let a caller borrow the label's grants for a base-disabled plain tool
+    // with `{ sessionUuid: base, device: label }`. For a plain tool, enforcement
+    // is base-only; only a `requiresDevice` tool actually uses the device field.
     const requestedDeviceLabel = typeof (toolParams as Record<string, unknown>).device === "string"
       ? (toolParams as Record<string, unknown>).device as string
       : undefined;
-    const derivedLabelSessionUuid = requestedDeviceLabel && sessionUuid
+    const derivedLabelSessionUuid = tool.requiresDevice && requestedDeviceLabel && sessionUuid
       ? getDeviceLabelMap(sessionUuid)?.[requestedDeviceLabel]
       : undefined;
     await assertToolEnabledForAnySession(

--- a/src/server/sessionReleaseBroadcast.ts
+++ b/src/server/sessionReleaseBroadcast.ts
@@ -1,0 +1,59 @@
+import { logger } from "../utils/logger";
+
+/**
+ * MCP-style wire method for the daemon's "a session was released" push
+ * (issue #4610). Unlike the list-changed families there is only one method, so
+ * this is a single named constant rather than a kind↔method map. Shared by the
+ * daemon socket broadcast (emit → frame) and the proxy's inbound dispatch
+ * (frame → clear bound binding) so the two ends can never drift.
+ */
+export const SESSION_RELEASED_NOTIFICATION_METHOD = "notifications/session/released";
+
+export interface SessionReleaseListener {
+  (sessionId: string): void;
+}
+
+/**
+ * Process-wide fan-out for session-release events, decoupled from any single
+ * MCP server/transport (issue #4610). The daemon's centralized release callback
+ * (`SessionManager.onSessionRelease`) emits every released session key here —
+ * base and derived `${base}:${label}` alike — and the Unix socket server
+ * subscribes so it can push a `notifications/session/released` frame to
+ * connected `DaemonMcpProxy` clients. That lets a proxy clear a remembered
+ * session binding the moment the daemon actually releases it (heartbeat / idle /
+ * plan), instead of guessing with the replay TTL. Emission is best-effort: a
+ * throwing listener is logged and never breaks the release that triggered it.
+ *
+ * Mirrors {@link ListChangedBroadcaster} in `listChangedBroadcast.ts`.
+ */
+class SessionReleaseBroadcasterClass {
+  private readonly listeners = new Set<SessionReleaseListener>();
+
+  /** Register a listener; returns an unsubscribe function. */
+  subscribe(listener: SessionReleaseListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  emit(sessionId: string): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(sessionId);
+      } catch (error) {
+        // Best-effort fan-out: one broken sink must not block the others or the
+        // session release that triggered the emit.
+        logger.warn(`[SessionReleaseBroadcaster] listener failed for released ${sessionId}: ${error}`);
+      }
+    }
+  }
+
+  /** Test-only: drop all listeners so suites sharing the singleton stay hermetic. */
+  clearForTesting(): void {
+    this.listeners.clear();
+  }
+}
+
+// Singleton: one process-wide broadcast channel, mirroring ListChangedBroadcaster.
+export const SessionReleaseBroadcaster = new SessionReleaseBroadcasterClass();

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -38,7 +38,11 @@ import {
 import { JsonToolOutputArtifactWriter, type ToolOutputArtifactRetention } from "./toolOutputArtifactWriter";
 import { getDefaultToolOutputsDir } from "../utils/toolOutputArtifacts";
 import type { SessionToolProfileService } from "../features/toolCapabilities/SessionToolProfileService";
-import { assertToolEnabledForSession } from "../features/toolCapabilities/toolCapabilityPolicy";
+import {
+  assertToolEnabledForAnySession,
+  assertToolEnabledForSession,
+} from "../features/toolCapabilities/toolCapabilityPolicy";
+import { resolveCapabilityBaseSessionUuid } from "../features/toolCapabilities/capabilitySessionResolver";
 import {
   getToolCapabilityContext,
   runWithToolCapabilityContext,
@@ -86,7 +90,7 @@ interface InternalToolCallOptions {
 
 interface InternalToolInvocationContext {
   args: Record<string, unknown>;
-  sessionUuid?: string;
+  routingSessionUuid?: string;
   sessionToolProfileService?: Pick<SessionToolProfileService, "isEnabled">;
 }
 
@@ -161,6 +165,13 @@ interface ExecutionTargetInput {
 interface ExecutionTargetContext {
   args: any;
   baseSessionUuid: string | undefined;
+  // Capability enforcement session (issue #4611 Gap A). Distinct from the
+  // routing `sessionUuid`: for a deviceId-only call there is no routing session,
+  // so this is derived from the device's owning session and enforcement still
+  // applies. May be a derived `${base}:${label}` label session. Optional so
+  // test pipeline overrides need not set it (the assert falls back to
+  // `sessionUuid`).
+  capabilitySessionUuid?: string | undefined;
   device: BootedDevice | undefined;
   internalCall: boolean;
   sessionUuid: string | undefined;
@@ -386,9 +397,25 @@ class DefaultExecutionTargetResolver implements ExecutionTargetResolver {
       }
     }
 
+    // Capability enforcement session (issue #4611 Gap A). A deviceId-only call
+    // has no routing sessionUuid, so a narrowed profile on the device's owning
+    // session would otherwise be silently bypassed (the policy treats an
+    // undefined session as fully enabled). When a routing session exists it IS
+    // the capability session (possibly a derived `${base}:${label}` label
+    // session); otherwise derive the device's owning session so enforcement
+    // still applies. Guarded on an initialized daemon — outside the daemon
+    // there is no session registry to consult. This mirrors the socket path,
+    // which already resolves deviceId -> session before enforcing.
+    let capabilitySessionUuid = sessionUuid;
+    if (!capabilitySessionUuid && device && DaemonState.getInstance().isInitialized()) {
+      capabilitySessionUuid =
+        DaemonState.getInstance().getSessionManager().getSessionForDevice?.(device.deviceId) ?? undefined;
+    }
+
     return {
       args,
       baseSessionUuid,
+      capabilitySessionUuid,
       device,
       internalCall,
       sessionUuid,
@@ -841,8 +868,11 @@ export class ToolRegistryClass {
     // Create a wrapper that handles device ID injection
     const wrappedHandler: ToolHandler = async (args: any, progress?: ProgressCallback, signal?: AbortSignal) => {
       const capabilityContext = getToolCapabilityContext();
-      const handlerArgs = capabilityContext?.sessionUuid && args.sessionUuid !== capabilityContext.sessionUuid
-        ? { ...args, sessionUuid: capabilityContext.sessionUuid }
+      // Re-inject the ambient ROUTING session (issue #4611 Gap C) so a nested
+      // device-aware call keeps the outer call's derived/label routing identity
+      // rather than reverting to the base session.
+      const handlerArgs = capabilityContext?.routingSessionUuid && args.sessionUuid !== capabilityContext.routingSessionUuid
+        ? { ...args, sessionUuid: capabilityContext.routingSessionUuid }
         : args;
       const toolStartMs = this.timer.now();
       const toolCallTimestamp = new Date().toISOString();
@@ -857,14 +887,28 @@ export class ToolRegistryClass {
           deviceSessionManager: this.deviceSessionManager,
         });
         sessionUuid = resolvedTarget.sessionUuid;
-        const capabilitySessionUuid = resolvedTarget.baseSessionUuid ?? resolvedTarget.sessionUuid;
-        await assertToolEnabledForSession(
+        // Capability enforcement is resolved independently of the routing
+        // session (issue #4611 Gaps A/B/C). The derived capability session is
+        // the resolver-derived device session (Gap A) or the routing session;
+        // the base is the caller-supplied base or the label's base resolved via
+        // the shared helper. Enforcement is the UNION of base + derived (Gap B,
+        // product decision): a tool is enabled if EITHER grants it, so a derived
+        // label may re-enable a tool the base narrowed away.
+        const capabilityDerivedSessionUuid = resolvedTarget.capabilitySessionUuid ?? resolvedTarget.sessionUuid;
+        const capabilitySessionManager = DaemonState.getInstance().isInitialized()
+          ? DaemonState.getInstance().getSessionManager()
+          : undefined;
+        const capabilityBaseSessionUuid = resolvedTarget.baseSessionUuid
+          ?? resolveCapabilityBaseSessionUuid(capabilityDerivedSessionUuid, capabilitySessionManager);
+        await assertToolEnabledForAnySession(
           name,
-          capabilitySessionUuid,
+          [capabilityBaseSessionUuid, capabilityDerivedSessionUuid],
           getToolCapabilityContext()?.sessionToolProfileService,
         );
         return await runWithToolCapabilityContext(
-          { sessionUuid: capabilitySessionUuid },
+          // Bind the ROUTING session (Gap C), not the base/capability session, so
+          // nested calls re-inject the correct derived routing UUID.
+          { routingSessionUuid: resolvedTarget.sessionUuid },
           async () => {
             try {
               let response: any | undefined;
@@ -1001,7 +1045,7 @@ export class ToolRegistryClass {
         progress,
         signal,
         options.targetDevice,
-        invocation.sessionUuid,
+        invocation.routingSessionUuid,
         invocation.sessionToolProfileService,
       ),
     );
@@ -1012,14 +1056,17 @@ export class ToolRegistryClass {
     options: InternalToolCallOptions,
   ): InternalToolInvocationContext {
     const context = getToolCapabilityContext();
+    // An internal call inherits the ambient ROUTING session (issue #4611 Gap C)
+    // so a plan step or navigation replay routes to the same derived/label
+    // session the outer call resolved to, not the base session.
     const sessionUuid = options.sessionUuid
-      ?? context?.sessionUuid
+      ?? context?.routingSessionUuid
       ?? (typeof args.sessionUuid === "string" ? args.sessionUuid : undefined);
     return {
       args: sessionUuid && args.sessionUuid !== sessionUuid
         ? { ...args, sessionUuid }
         : args,
-      sessionUuid,
+      routingSessionUuid: sessionUuid,
       sessionToolProfileService: options.sessionToolProfileService ?? context?.sessionToolProfileService,
     };
   }

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -40,7 +40,6 @@ import { getDefaultToolOutputsDir } from "../utils/toolOutputArtifacts";
 import type { SessionToolProfileService } from "../features/toolCapabilities/SessionToolProfileService";
 import {
   assertToolEnabledForAnySession,
-  assertToolEnabledForSession,
 } from "../features/toolCapabilities/toolCapabilityPolicy";
 import { resolveCapabilityBaseSessionUuid } from "../features/toolCapabilities/capabilitySessionResolver";
 import {
@@ -939,14 +938,10 @@ export class ToolRegistryClass {
         // product decision): a tool is enabled if EITHER grants it, so a derived
         // label may re-enable a tool the base narrowed away.
         const capabilityDerivedSessionUuid = resolvedTarget.capabilitySessionUuid ?? resolvedTarget.sessionUuid;
-        const capabilitySessionManager = DaemonState.getInstance().isInitialized()
-          ? DaemonState.getInstance().getSessionManager()
-          : undefined;
-        const capabilityBaseSessionUuid = resolvedTarget.baseSessionUuid
-          ?? resolveCapabilityBaseSessionUuid(capabilityDerivedSessionUuid, capabilitySessionManager);
-        await assertToolEnabledForAnySession(
+        await this.assertToolEnabledUnion(
           name,
-          [capabilityBaseSessionUuid, capabilityDerivedSessionUuid],
+          capabilityDerivedSessionUuid,
+          resolvedTarget.baseSessionUuid,
           getToolCapabilityContext()?.sessionToolProfileService,
         );
         return await runWithToolCapabilityContext(
@@ -1125,11 +1120,44 @@ export class ToolRegistryClass {
     sessionUuid: string | undefined,
     sessionToolProfileService: Pick<SessionToolProfileService, "isEnabled"> | undefined,
   ): Promise<any> {
-    await assertToolEnabledForSession(tool.name, sessionUuid, sessionToolProfileService);
+    // Honor the UNION of the base + derived `${base}:${label}` sessions here too
+    // (issue #4611). `sessionUuid` is the ambient ROUTING session — a derived
+    // label session for a labeled `criticalSection`/`executePlan` step — so a
+    // single-session assert would reject a tool the base enables but the label
+    // narrowed away. The `targetDevice` path below bypasses the device-aware
+    // wrapper's own union gate entirely, so this pre-gate is the ONLY enforcement
+    // point for it and must apply the union as well.
+    await this.assertToolEnabledUnion(tool.name, sessionUuid, undefined, sessionToolProfileService);
     if (targetDevice && tool.deviceAwareHandler) {
       return tool.deviceAwareHandler(targetDevice, markInternalToolCall(args), progress, signal);
     }
     return tool.handler(markInternalToolCall(args), progress, signal);
+  }
+
+  /**
+   * Assert a tool is enabled under UNION capability semantics (issue #4611): a
+   * tool is enabled when EITHER the base OR the derived `${base}:${label}`
+   * device-label session grants it. The base is resolved from the derived label
+   * session via the shared resolver unless the caller already knows it. Applied
+   * at every enforcement gate — the device-aware wrapper and the nested
+   * internal-call pre-gate — so no gate can reject a call the union should allow.
+   */
+  private async assertToolEnabledUnion(
+    toolName: string,
+    derivedSessionUuid: string | undefined,
+    explicitBaseSessionUuid: string | undefined,
+    sessionToolProfileService: Pick<SessionToolProfileService, "isEnabled"> | undefined,
+  ): Promise<void> {
+    const sessionManager = DaemonState.getInstance().isInitialized()
+      ? DaemonState.getInstance().getSessionManager()
+      : undefined;
+    const baseSessionUuid = explicitBaseSessionUuid
+      ?? resolveCapabilityBaseSessionUuid(derivedSessionUuid, sessionManager);
+    await assertToolEnabledForAnySession(
+      toolName,
+      [baseSessionUuid, derivedSessionUuid],
+      sessionToolProfileService,
+    );
   }
 
   // Typed variant of `callInternal` for the handful of internally-consumed tools

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -1137,10 +1137,19 @@ export class ToolRegistryClass {
   /**
    * Assert a tool is enabled under UNION capability semantics (issue #4611): a
    * tool is enabled when EITHER the base OR the derived `${base}:${label}`
-   * device-label session grants it. The base is resolved from the derived label
-   * session via the shared resolver unless the caller already knows it. Applied
-   * at every enforcement gate — the device-aware wrapper and the nested
-   * internal-call pre-gate — so no gate can reject a call the union should allow.
+   * device-label session grants it. Applied at every enforcement gate — the
+   * device-aware wrapper and the nested internal-call pre-gate — so no gate can
+   * reject a call the union should allow.
+   *
+   * The REAL base is always resolved through the shared resolver, even when the
+   * caller supplies `explicitBaseSessionUuid` (issue #4655). For an internal
+   * device-aware step whose routing session is already the derived `${base}:B`,
+   * the wrapper's resolver reports `baseSessionUuid = ${base}:B` — the derived
+   * value, not the true base. Trusting it verbatim would collapse the union to
+   * `[${base}:B, ${base}:B]` and lose the base grant. Passing the supplied base
+   * (or the derived session when none is supplied) back through
+   * `resolveCapabilityBaseSessionUuid` strips a `:label` when present and is a
+   * no-op for a genuine base, so the union is genuinely `[base, ${base}:B]`.
    */
   private async assertToolEnabledUnion(
     toolName: string,
@@ -1151,8 +1160,10 @@ export class ToolRegistryClass {
     const sessionManager = DaemonState.getInstance().isInitialized()
       ? DaemonState.getInstance().getSessionManager()
       : undefined;
-    const baseSessionUuid = explicitBaseSessionUuid
-      ?? resolveCapabilityBaseSessionUuid(derivedSessionUuid, sessionManager);
+    const baseSessionUuid = resolveCapabilityBaseSessionUuid(
+      explicitBaseSessionUuid ?? derivedSessionUuid,
+      sessionManager,
+    );
     await assertToolEnabledForAnySession(
       toolName,
       [baseSessionUuid, derivedSessionUuid],

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -233,6 +233,20 @@ const AUTOMATIC_TOOL_OUTPUT_RETENTION: ToolOutputArtifactRetention = {
   overflowMinAgeMs: 60 * 60 * 1000,
 };
 
+/**
+ * Server-side session-binding teardown seam (issue #4611 Gap D). A daemon
+ * session release (e.g. an executePlan auto-release) frees the session in the
+ * SessionManager/DevicePool but cannot, by itself, reach the per-transport
+ * `SessionToolBinding` held in `createMcpServer` (index.ts) — that binding still
+ * resolves the released session as the transport's effective session, so a later
+ * sessionless `tools/list`/`tools/call` keeps enforcing the released (stale)
+ * profile. `createMcpServer` registers a handler here (interface + fake per DI
+ * convention) so the actual release path can clear its transport binding.
+ */
+export interface SessionBindingReleaseHandler {
+  onSessionReleased(sessionUuid: string): void;
+}
+
 export interface PlanLifecycleInput {
   name: string;
   args: any;
@@ -241,6 +255,10 @@ export interface PlanLifecycleInput {
   device: BootedDevice | undefined;
   sessionUuid: string | undefined;
   shouldResolveDevice: boolean;
+  // Injected teardown for the server-side per-transport SessionToolBinding
+  // (issue #4611 Gap D). Invoked AFTER a real release for every session freed —
+  // base and derived label sessions alike — never optimistically.
+  sessionBindingReleaseHandler?: SessionBindingReleaseHandler;
 }
 
 interface PlanLifecycleManager {
@@ -744,7 +762,7 @@ export class DefaultAfterToolCallHandler implements AfterToolCallHandler {
 // executePlan cleanup and the auto-release guard without a live daemon session.
 export class DefaultPlanLifecycleManager implements PlanLifecycleManager {
   async afterExecution(input: PlanLifecycleInput): Promise<void> {
-    const { name, args, baseSessionUuid, cleanupService, device, sessionUuid, shouldResolveDevice } = input;
+    const { name, args, baseSessionUuid, cleanupService, device, sessionUuid, shouldResolveDevice, sessionBindingReleaseHandler } = input;
     if (device && name === "executePlan" && args?.cleanupAppId) {
       await cleanupService.cleanup(device, {
         appId: args.cleanupAppId,
@@ -757,8 +775,12 @@ export class DefaultPlanLifecycleManager implements PlanLifecycleManager {
         const sessionManager = DaemonState.getInstance().getSessionManager();
         const devicePool = DaemonState.getInstance().getDevicePool();
         const releaseSessionUuid = baseSessionUuid ?? sessionUuid;
+        // Track exactly which sessions this release actually frees so the
+        // server-side transport binding is torn down for each (issue #4611 Gap
+        // D) — coupled to the REAL release, never cleared optimistically.
+        const releasedSessionUuids: string[] = [];
         if (releaseSessionUuid) {
-          await releaseDeviceLabelSessions(releaseSessionUuid);
+          releasedSessionUuids.push(...await releaseDeviceLabelSessions(releaseSessionUuid));
         }
 
         const session = releaseSessionUuid ? sessionManager.getSession(releaseSessionUuid) : null;
@@ -768,7 +790,18 @@ export class DefaultPlanLifecycleManager implements PlanLifecycleManager {
           await devicePool.releaseDevice(deviceId);
           NavigationGraphManager.releaseSession(releaseSessionUuid);
           RealObserveScreen.clearCache(deviceId);
+          releasedSessionUuids.push(releaseSessionUuid);
           logger.info(`Auto-released session ${session.sessionId} and freed device ${deviceId} after executePlan`);
+        }
+
+        // Clear the per-transport SessionToolBinding for every freed session so a
+        // later sessionless tools/list or tools/call stops enforcing a released
+        // profile (issue #4611 Gap D). Best-effort: the handler swallows its own
+        // failures, but the release itself has already succeeded regardless.
+        if (sessionBindingReleaseHandler) {
+          for (const releasedUuid of releasedSessionUuids) {
+            sessionBindingReleaseHandler.onSessionReleased(releasedUuid);
+          }
         }
       } catch (releaseError) {
         logger.warn(`Failed to auto-release session ${sessionUuid}: ${releaseError}`);
@@ -786,6 +819,17 @@ export class ToolRegistryClass {
   // last-writer-wins (issue #3223). Entries are pruned via the underlying
   // server's onclose hook when a session's transport closes.
   private servers: Set<McpServer> = new Set();
+  // Per-transport server-side session-binding teardown handlers (issue #4611 Gap
+  // D). `createMcpServer` registers one per loopback transport; the plan-release
+  // path fans a released session UUID out to all of them so each transport's
+  // SessionToolBinding drops the stale session. Pruned via the returned
+  // unsubscribe on transport close, mirroring the `servers` set above.
+  private sessionBindingReleaseHandlers: Set<SessionBindingReleaseHandler> = new Set();
+  // Stable aggregate handed to the plan-lifecycle input so afterExecution can
+  // fan a released session out to every registered transport handler.
+  private readonly sessionBindingReleaseNotifier: SessionBindingReleaseHandler = {
+    onSessionReleased: sessionUuid => this.notifySessionBindingReleased(sessionUuid),
+  };
   private deviceSessionManager: DeviceSessionManager;
   private cleanupService: AppCleanupService;
   private toolCallRepository: ToolCallRepository;
@@ -958,6 +1002,7 @@ export class ToolRegistryClass {
                 device: resolvedTarget.device,
                 sessionUuid: resolvedTarget.sessionUuid,
                 shouldResolveDevice: resolvedTarget.shouldResolveDevice,
+                sessionBindingReleaseHandler: this.sessionBindingReleaseNotifier,
               });
             }
           }
@@ -1204,6 +1249,38 @@ export class ToolRegistryClass {
   // Test-only: drop tracked servers so suites sharing the singleton stay hermetic.
   clearServersForTesting(): void {
     this.servers.clear();
+  }
+
+  // Register a per-transport server-side session-binding teardown handler (issue
+  // #4611 Gap D) and return its unsubscribe. `createMcpServer` calls this once per
+  // loopback transport and drops it on transport close, so a released session's
+  // stale binding is cleared on every live transport but a closed transport's
+  // handler never lingers.
+  registerSessionBindingReleaseHandler(handler: SessionBindingReleaseHandler): () => void {
+    this.sessionBindingReleaseHandlers.add(handler);
+    return () => {
+      this.sessionBindingReleaseHandlers.delete(handler);
+    };
+  }
+
+  // Fan a released session UUID out to every registered transport handler. Called
+  // from the plan-release path (via the injected notifier) after a session is
+  // actually freed. Best-effort: one throwing handler never blocks the others or
+  // the release that triggered it.
+  notifySessionBindingReleased(sessionUuid: string): void {
+    for (const handler of this.sessionBindingReleaseHandlers) {
+      try {
+        handler.onSessionReleased(sessionUuid);
+      } catch (error) {
+        logger.warn(`[ToolRegistry] session-binding release handler failed for ${sessionUuid}: ${error}`);
+      }
+    }
+  }
+
+  // Test-only: drop registered session-binding release handlers so suites sharing
+  // the singleton stay hermetic.
+  clearSessionBindingReleaseHandlersForTesting(): void {
+    this.sessionBindingReleaseHandlers.clear();
   }
 
   // Emit notifications/tools/list_changed so caching clients re-fetch tools/list

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -7,7 +7,7 @@ import {
 } from "../../src/daemon/daemonMcpProxy";
 import { DaemonClient, DaemonUnavailableError, type DaemonClientLike } from "../../src/daemon/client";
 import { ActionableError } from "../../src/models";
-import { DAEMON_VERSION, DAEMON_VERSION_RESTART_COOLDOWN_MS } from "../../src/daemon/constants";
+import { DAEMON_VERSION, DAEMON_VERSION_RESTART_COOLDOWN_MS, DAEMON_BOUND_SESSION_REPLAY_TTL_MS } from "../../src/daemon/constants";
 import { logger } from "../../src/utils/logger";
 import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
 import { FakeDaemonClient } from "../fakes/FakeDaemonClient";
@@ -1378,6 +1378,98 @@ describe("DaemonMcpProxy", () => {
         expect(client.callToolCalls).toEqual([
           { toolName: "executePlan", params: { sessionUuid: "session-a", deviceId: "device-a" } },
           { toolName: "observe", params: { deviceId: "device-a" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("stops replaying a bound session after the daemon session idle window elapses", async () => {
+      // The daemon's heartbeat/idle cleanup can release an ordinary session while
+      // this proxy stays connected. Once the replay window elapses with no
+      // explicit-sessionUuid call refreshing the binding, a later device-aware
+      // call that omits sessionUuid must NOT be rewritten to the retired UUID —
+      // otherwise createToolExecutionContext silently recreates the session
+      // (issue [#4610](https://github.com/kaeawc/auto-mobile/issues/4610)).
+      const timer = new FakeTimer();
+      const client = new ScriptedDaemonClient({
+        toolResult: { content: [{ type: "text", text: "ok" }] },
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => client,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+        timer,
+      });
+
+      try {
+        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS);
+        await proxy.callTool("observe", { deviceId: "device-a" });
+
+        expect(client.callToolCalls).toEqual([
+          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "observe", params: { deviceId: "device-a" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("still replays a bound session before the idle window elapses", async () => {
+      const timer = new FakeTimer();
+      const client = new ScriptedDaemonClient({
+        toolResult: { content: [{ type: "text", text: "ok" }] },
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => client,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+        timer,
+      });
+
+      try {
+        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS - 1);
+        await proxy.callTool("observe", { deviceId: "device-a" });
+
+        expect(client.callToolCalls).toEqual([
+          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("injects the bound UUID when a later call carries a non-string sessionUuid", async () => {
+      // A null/number/object sessionUuid is not an explicit session selection, so
+      // the retained binding must still be injected rather than bypassed
+      // (issue [#4610](https://github.com/kaeawc/auto-mobile/issues/4610)).
+      const client = new ScriptedDaemonClient({
+        toolResult: { content: [{ type: "text", text: "ok" }] },
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => client,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        await proxy.callTool("observe", { deviceId: "device-a", sessionUuid: null as unknown as string });
+        await proxy.callTool("observe", { deviceId: "device-a", sessionUuid: 42 as unknown as string });
+
+        expect(client.callToolCalls).toEqual([
+          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
         ]);
       } finally {
         isAvailableSpy.mockRestore();

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -1366,6 +1366,49 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
+    test("listTools re-seeds the bound session on a reconnect so discovery stays session-scoped", async () => {
+      // listTools forwards to a shared transport. A reconnect mid-listTools would
+      // otherwise retry tools/list with empty params against the fresh unseeded
+      // transport, returning the full unfiltered tool list instead of the
+      // session-scoped one. Binding discovery like callTool re-seeds the retried
+      // tools/list so it returns the session-scoped list (issue #4610).
+      const staleClient = new ScriptedDaemonClient({
+        toolResult: { content: [{ type: "text", text: "bound" }] },
+        daemonMethodError: new Error("Session not found"),
+      });
+      const freshClient = new ScriptedDaemonClient({
+        daemonMethodResults: new Map([
+          ["tools/list", { tools: [{ name: "scopedTool", inputSchema: {} }] }],
+        ]),
+      });
+      const clients = [staleClient, freshClient];
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => clients.shift()!,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        // Bind the proxy to session-a via a successful tool call.
+        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+
+        const tools = await proxy.listTools();
+
+        expect(tools).toEqual([{ name: "scopedTool", inputSchema: {} }]);
+        // The stale attempt and the reconnect retry both carry the bound session.
+        expect(staleClient.callDaemonMethodCalls).toEqual([
+          { method: "tools/list", params: { sessionUuid: "session-a" } },
+        ]);
+        expect(freshClient.callDaemonMethodCalls).toEqual([
+          { method: "tools/list", params: { sessionUuid: "session-a" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
     test("does not replay an executePlan session after its successful release", async () => {
       const client = new ScriptedDaemonClient({
         toolResult: { content: [{ type: "text", text: "ok" }] },

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -1872,6 +1872,51 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
+    test("a release of an UNRELATED session mid-call does not block remembering the forwarded session (#4655)", async () => {
+      // Regression for the global-generation guard: the proxy is bound to
+      // session-a while an EXPLICIT session-b call is in flight; session-a (NOT
+      // the session this call forwarded) is released mid-flight. The old guard
+      // bumped one global counter on ANY binding clear, so the completing
+      // session-b call saw "a binding changed" and declined to remember session-b
+      // — even though session-b was never released. Scoped to the forwarded UUID,
+      // the release of the unrelated session-a must NOT block remembering
+      // session-b.
+      let callCount = 0;
+      const fakeClient: FakeDaemonClient = new FakeDaemonClient({
+        toolResult: { content: [{ type: "text", text: "ok" }] },
+        onCallTool: () => {
+          callCount += 1;
+          if (callCount === 2) {
+            fakeClient.emitNotification(SESSION_RELEASED_NOTIFICATION_METHOD, "session-a");
+          }
+        },
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        // Bind session-a.
+        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        // Explicit session-b call; the unrelated session-a is released mid-flight.
+        await proxy.callTool("observe", { sessionUuid: "session-b", deviceId: "device-b" });
+        // The next sessionless call must be rewritten to session-b (never released).
+        await proxy.callTool("observe", { deviceId: "device-b" });
+
+        expect(fakeClient.callToolCalls).toEqual([
+          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "observe", params: { sessionUuid: "session-b", deviceId: "device-b" } },
+          { toolName: "observe", params: { deviceId: "device-b", sessionUuid: "session-b" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
     test("a release during an admitted-then-rejected in-flight call is not undone by the refresh", async () => {
       let callCount = 0;
       const fakeClient: FakeDaemonClient = new FakeDaemonClient({
@@ -1969,6 +2014,71 @@ describe("DaemonMcpProxy", () => {
           { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
           { toolName: "observe", params: { deviceId: "device-a" } },
         ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("a tools/list invalidated mid-flight is not cached; the next listTools refetches (#4655)", async () => {
+      // A list_changed (or bound-session release) lands WHILE a session-scoped
+      // tools/list is pending. The handler nulls the cache immediately, but the
+      // eventual (now-stale) response used to repopulate cachedTools
+      // unconditionally, resurrecting the list the invalidation just cleared. The
+      // response must NOT be cached, so the next listTools() refetches.
+      let methodCallCount = 0;
+      const fakeClient: FakeDaemonClient = new FakeDaemonClient({
+        daemonMethodResults: new Map([
+          ["tools/list", { tools: [{ name: "t", inputSchema: {} }] }],
+        ]),
+        onCallDaemonMethod: method => {
+          if (method === "tools/list") {
+            methodCallCount += 1;
+            if (methodCallCount === 1) {
+              fakeClient.emitNotification("notifications/tools/list_changed");
+            }
+          }
+        },
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        const first = await proxy.listTools();
+        expect(first).toEqual([{ name: "t", inputSchema: {} }]);
+        // The mid-flight invalidation prevented caching, so a second call refetches.
+        const second = await proxy.listTools();
+        expect(second).toEqual([{ name: "t", inputSchema: {} }]);
+        expect(fakeClient.callDaemonMethodCalls).toHaveLength(2);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("a tools/list with NO mid-flight invalidation caches normally (positive control, #4655)", async () => {
+      // The discovery guard must not over-fire: with no push during the pending
+      // call, the response is cached and the second listTools() serves the cache.
+      const fakeClient = new FakeDaemonClient({
+        daemonMethodResults: new Map([
+          ["tools/list", { tools: [{ name: "t", inputSchema: {} }] }],
+        ]),
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await proxy.listTools();
+        await proxy.listTools();
+        expect(fakeClient.callDaemonMethodCalls).toHaveLength(1);
       } finally {
         isAvailableSpy.mockRestore();
         await proxy.close();

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -1360,6 +1360,31 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
+    test("does not replay an executePlan session after its successful release", async () => {
+      const client = new ScriptedDaemonClient({
+        toolResult: { content: [{ type: "text", text: "ok" }] },
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => client,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await proxy.callTool("executePlan", { sessionUuid: "session-a", deviceId: "device-a" });
+        await proxy.callTool("observe", { deviceId: "device-a" });
+
+        expect(client.callToolCalls).toEqual([
+          { toolName: "executePlan", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "observe", params: { deviceId: "device-a" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
     test("readResource recovers when a sibling's socket dropped", async () => {
       const recoveredResult = { contents: [{ uri: "automobile:devices/booted", text: "[]" }] };
       const staleClient = new ScriptedDaemonClient({

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -1434,12 +1434,15 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
-    test("clears the binding when an executePlan rejects, so its released session is not resurrected", async () => {
-      // A rejected executePlan still triggers daemon-side session release in
-      // DefaultPlanLifecycleManager.afterExecution()'s finally. The success-only
-      // clear is never reached on rejection, so without clearing on failure the
-      // stale UUID would be replayed on the next sessionless call and recreate the
-      // released session (issue [#4610](https://github.com/kaeawc/auto-mobile/issues/4610)).
+    test("preserves the binding when an executePlan rejects (a pre-handler rejection leaves the session live)", async () => {
+      // An executePlan can reject BEFORE the handler runs — capability enforcement
+      // or schema parsing in src/server/index.ts — in which case
+      // DefaultPlanLifecycleManager.afterExecution() never runs and the daemon
+      // session stays LIVE. The proxy must NOT forget the binding on rejection, or
+      // a later sessionless call after a reconnect would strand that still-live
+      // session. The binding is cleared only by the daemon's real session-released
+      // signal (see the release-signal tests), never by a bare plan rejection
+      // (issue [#4610](https://github.com/kaeawc/auto-mobile/issues/4610)).
       const client = new ScriptedDaemonClient({
         toolResult: { content: [{ type: "text", text: "ok" }] },
         toolErrorByName: new Map([["executePlan", new Error("plan boom")]]),
@@ -1456,10 +1459,12 @@ describe("DaemonMcpProxy", () => {
         await expect(proxy.callTool("executePlan", { deviceId: "device-a" })).rejects.toThrow("plan boom");
         await proxy.callTool("observe", { deviceId: "device-a" });
 
+        // The third call is still rewritten to session-a: the binding survived the
+        // rejection because nothing proved the session was released.
         expect(client.callToolCalls).toEqual([
           { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
           { toolName: "executePlan", params: { deviceId: "device-a", sessionUuid: "session-a" } },
-          { toolName: "observe", params: { deviceId: "device-a" } },
+          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
         ]);
       } finally {
         isAvailableSpy.mockRestore();

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -1573,6 +1573,85 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
+    test("refreshes the replay lease when an admitted bound call is rejected by the handler", async () => {
+      // An implicit sessionless call has the bound UUID injected and reaches the
+      // daemon, which refreshes the LIVE session in getOrCreateSession(). The
+      // handler then rejects (e.g. a tool failure), so the success-only
+      // rememberSessionUuid never runs. Without refreshing the lease in the catch
+      // path, crossing one TTL retires the still-live session and a later reconnect
+      // would seed an unbound transport (issue [#4610](https://github.com/kaeawc/auto-mobile/issues/4610)).
+      const timer = new FakeTimer();
+      const client = new ScriptedDaemonClient({
+        toolResult: { content: [{ type: "text", text: "ok" }] },
+        toolErrorByName: new Map([["tapOn", new ActionableError("tap failed after admission")]]),
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => client,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+        timer,
+      });
+
+      try {
+        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        // An admitted-then-rejected implicit call within the TTL. It must renew the
+        // lease off the injected UUID even though it throws.
+        timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS - 1);
+        await expect(proxy.callTool("tapOn", { deviceId: "device-a" })).rejects.toThrow("tap failed after admission");
+        // Cumulatively past one TTL from the initial bind; only the refreshed lease
+        // keeps the binding alive for this final implicit call.
+        timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS - 1);
+        await proxy.callTool("observe", { deviceId: "device-a" });
+
+        expect(client.callToolCalls).toEqual([
+          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "tapOn", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("does NOT refresh the replay lease when the failing call never reached the daemon", async () => {
+      // A transport/connect failure (DaemonUnavailableError) never reached the
+      // handler, so the live session was not refreshed. The lease must be allowed
+      // to expire — refreshing it would replay a UUID whose session may be gone
+      // (issue [#4610](https://github.com/kaeawc/auto-mobile/issues/4610)).
+      const timer = new FakeTimer();
+      const client = new ScriptedDaemonClient({
+        toolResult: { content: [{ type: "text", text: "ok" }] },
+        toolErrorByName: new Map([
+          ["tapOn", new DaemonUnavailableError("Daemon socket connection lost: connection closed")],
+        ]),
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => client,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+        timer,
+      });
+
+      try {
+        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS - 1);
+        await expect(proxy.callTool("tapOn", { deviceId: "device-a" })).rejects.toBeInstanceOf(DaemonUnavailableError);
+        timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS - 1);
+        await proxy.callTool("observe", { deviceId: "device-a" });
+
+        // The final implicit observe must NOT carry an injected sessionUuid: the
+        // lease expired because the transport failure did not refresh it.
+        const lastCall = client.callToolCalls[client.callToolCalls.length - 1];
+        expect(lastCall).toEqual({ toolName: "observe", params: { deviceId: "device-a" } });
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
     test("injects the bound UUID when a later call carries a non-string sessionUuid", async () => {
       // A null/number/object sessionUuid is not an explicit session selection, so
       // the retained binding must still be injected rather than bypassed

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -45,6 +45,7 @@ class ScriptedDaemonClient implements DaemonClientLike {
     private readonly behavior: {
       toolResult?: any;
       toolError?: Error;
+      toolErrorByName?: Map<string, Error>;
       resourceResult?: any;
       resourceError?: Error;
       daemonMethodResults?: Map<string, any>;
@@ -62,6 +63,10 @@ class ScriptedDaemonClient implements DaemonClientLike {
 
   async callTool(toolName: string, params: Record<string, any>): Promise<any> {
     this.callToolCalls.push({ toolName, params });
+    const perToolError = this.behavior.toolErrorByName?.get(toolName);
+    if (perToolError) {
+      throw perToolError;
+    }
     if (this.behavior.toolError) {
       throw this.behavior.toolError;
     }
@@ -1377,6 +1382,39 @@ describe("DaemonMcpProxy", () => {
 
         expect(client.callToolCalls).toEqual([
           { toolName: "executePlan", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "observe", params: { deviceId: "device-a" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("clears the binding when an executePlan rejects, so its released session is not resurrected", async () => {
+      // A rejected executePlan still triggers daemon-side session release in
+      // DefaultPlanLifecycleManager.afterExecution()'s finally. The success-only
+      // clear is never reached on rejection, so without clearing on failure the
+      // stale UUID would be replayed on the next sessionless call and recreate the
+      // released session (issue [#4610](https://github.com/kaeawc/auto-mobile/issues/4610)).
+      const client = new ScriptedDaemonClient({
+        toolResult: { content: [{ type: "text", text: "ok" }] },
+        toolErrorByName: new Map([["executePlan", new Error("plan boom")]]),
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => client,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        await expect(proxy.callTool("executePlan", { deviceId: "device-a" })).rejects.toThrow("plan boom");
+        await proxy.callTool("observe", { deviceId: "device-a" });
+
+        expect(client.callToolCalls).toEqual([
+          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "executePlan", params: { deviceId: "device-a", sessionUuid: "session-a" } },
           { toolName: "observe", params: { deviceId: "device-a" } },
         ]);
       } finally {

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -1830,6 +1830,121 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
+    // Issue #4611 (follow-up P1): a release observed WHILE a callTool is in flight
+    // must survive the call's completion. The in-flight call's post-call
+    // remember/refresh previously re-established the released UUID unconditionally,
+    // so the next sessionless call would inject it and recreate the freed session.
+    test("a release during a fulfilled in-flight call is not undone by the post-call remember", async () => {
+      let callCount = 0;
+      const fakeClient: FakeDaemonClient = new FakeDaemonClient({
+        toolResult: { content: [{ type: "text", text: "ok" }] },
+        onCallTool: () => {
+          callCount += 1;
+          // Fire the release DURING the second (sessionless, bound) call — after the
+          // bound UUID was injected into forwardedArgs but before the call resolves.
+          if (callCount === 2) {
+            fakeClient.emitNotification(SESSION_RELEASED_NOTIFICATION_METHOD, "session-a");
+          }
+        },
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        // Call 2 injects session-a, then the release lands mid-flight.
+        await proxy.callTool("observe", { deviceId: "device-a" });
+        // Call 3 must NOT be rewritten to the released UUID.
+        await proxy.callTool("observe", { deviceId: "device-a" });
+
+        expect(fakeClient.callToolCalls).toEqual([
+          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+          { toolName: "observe", params: { deviceId: "device-a" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("a release during an admitted-then-rejected in-flight call is not undone by the refresh", async () => {
+      let callCount = 0;
+      const fakeClient: FakeDaemonClient = new FakeDaemonClient({
+        toolResult: { content: [{ type: "text", text: "ok" }] },
+        onCallTool: () => {
+          callCount += 1;
+          if (callCount === 2) {
+            // Admitted (recorded + reached the daemon handler), then released
+            // mid-flight, then rejected by the handler (non-recoverable error).
+            fakeClient.emitNotification(SESSION_RELEASED_NOTIFICATION_METHOD, "session-a");
+            throw new Error("handler rejected the admitted call");
+          }
+        },
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        await expect(proxy.callTool("tapOn", { deviceId: "device-a" })).rejects.toThrow(
+          "handler rejected the admitted call"
+        );
+        // The admitted-failure refresh must not resurrect the released UUID's lease.
+        await proxy.callTool("observe", { deviceId: "device-a" });
+
+        expect(fakeClient.callToolCalls).toEqual([
+          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "tapOn", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+          { toolName: "observe", params: { deviceId: "device-a" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("with NO release mid-call, the in-flight call still remembers the binding normally", async () => {
+      // Positive control: the mid-flight guard must not over-fire. With the
+      // onCallTool seam present but emitting nothing, the binding persists and the
+      // next sessionless call is still rewritten (issue #4611).
+      let observed = 0;
+      const fakeClient = new FakeDaemonClient({
+        toolResult: { content: [{ type: "text", text: "ok" }] },
+        onCallTool: () => {
+          observed += 1;
+        },
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        await proxy.callTool("observe", { deviceId: "device-a" });
+
+        expect(fakeClient.callToolCalls).toEqual([
+          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+        ]);
+        expect(observed).toBe(2);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
     test("the TTL backstop still expires the binding when no signal arrives", async () => {
       // Dropped-frame path: no released signal is delivered, so the replay TTL
       // must still retire the binding on its own.

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -1447,6 +1447,45 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
+    test("keeps replaying a bound session across continuous implicit activity beyond one TTL", async () => {
+      // Continuous implicit (sessionless) calls forward the bound UUID and extend
+      // the live daemon session, so the replay lease must refresh off the forwarded
+      // args. Otherwise total elapsed time crossing one TTL retires a still-live
+      // session, and a later reconnect would seed an unbound transport that treats
+      // session-disabled capabilities as enabled
+      // (issue [#4610](https://github.com/kaeawc/auto-mobile/issues/4610)).
+      const timer = new FakeTimer();
+      const client = new ScriptedDaemonClient({
+        toolResult: { content: [{ type: "text", text: "ok" }] },
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => client,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+        timer,
+      });
+
+      try {
+        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        // Two implicit calls, each within the TTL, but cumulatively past it. Each
+        // forwarded implicit call must renew the lease so the binding survives.
+        timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS - 1);
+        await proxy.callTool("observe", { deviceId: "device-a" });
+        timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS - 1);
+        await proxy.callTool("observe", { deviceId: "device-a" });
+
+        expect(client.callToolCalls).toEqual([
+          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
     test("injects the bound UUID when a later call carries a non-string sessionUuid", async () => {
       // A null/number/object sessionUuid is not an explicit session selection, so
       // the retained binding must still be injected rather than bypassed

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -12,6 +12,7 @@ import { logger } from "../../src/utils/logger";
 import { FakeDaemonManager } from "../fakes/FakeDaemonManager";
 import { FakeDaemonClient } from "../fakes/FakeDaemonClient";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { SESSION_RELEASED_NOTIFICATION_METHOD } from "../../src/server/sessionReleaseBroadcast";
 
 const OLDER_VERSION = "0.0.1";
 const NEWER_VERSION = "9999.0.0";
@@ -1632,6 +1633,127 @@ describe("DaemonMcpProxy", () => {
         await expect(proxy.callTool("sendSms", {})).rejects.toThrow("ECONNREFUSED");
         expect(client.callToolCalls).toHaveLength(1);
         expect(client.closeCallCount).toBe(0);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+  });
+
+  describe("session-released signal (issue #4610)", () => {
+    // A real daemon->proxy "session released" push clears the remembered binding
+    // the moment the daemon releases the session (heartbeat / idle / plan),
+    // instead of waiting out the replay-TTL guess. The TTL stays as a
+    // dropped-frame backstop.
+
+    test("a released signal for the bound UUID clears the binding", async () => {
+      const fakeClient = new FakeDaemonClient({
+        toolResult: { content: [{ type: "text", text: "ok" }] },
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        // Bind session-a via an explicit call, then the daemon releases it.
+        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        fakeClient.emitNotification(SESSION_RELEASED_NOTIFICATION_METHOD, "session-a");
+        // The next sessionless call must NOT be rewritten to the retired UUID.
+        await proxy.callTool("observe", { deviceId: "device-a" });
+
+        expect(fakeClient.callToolCalls).toEqual([
+          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "observe", params: { deviceId: "device-a" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("a released signal for a different session leaves the binding intact", async () => {
+      const fakeClient = new FakeDaemonClient({
+        toolResult: { content: [{ type: "text", text: "ok" }] },
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        // A derived-only release (`${base}:${label}`) or an unrelated session key
+        // must NOT clear a base binding matched by exact equality.
+        fakeClient.emitNotification(SESSION_RELEASED_NOTIFICATION_METHOD, "session-a:device-a");
+        fakeClient.emitNotification(SESSION_RELEASED_NOTIFICATION_METHOD, "session-b");
+        await proxy.callTool("observe", { deviceId: "device-a" });
+
+        expect(fakeClient.callToolCalls).toEqual([
+          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("the TTL backstop still expires the binding when no signal arrives", async () => {
+      // Dropped-frame path: no released signal is delivered, so the replay TTL
+      // must still retire the binding on its own.
+      const timer = new FakeTimer();
+      const fakeClient = new FakeDaemonClient({
+        toolResult: { content: [{ type: "text", text: "ok" }] },
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+        timer,
+      });
+
+      try {
+        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        timer.advanceTime(DAEMON_BOUND_SESSION_REPLAY_TTL_MS);
+        await proxy.callTool("observe", { deviceId: "device-a" });
+
+        expect(fakeClient.callToolCalls).toEqual([
+          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "observe", params: { deviceId: "device-a" } },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
+    test("an unknown pushed method is still logged and ignored", async () => {
+      const fakeClient = new FakeDaemonClient({
+        toolResult: { content: [{ type: "text", text: "ok" }] },
+      });
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => fakeClient,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        // A future notification family must not touch the binding.
+        expect(() => fakeClient.emitNotification("notifications/some/future_thing")).not.toThrow();
+        await proxy.callTool("observe", { deviceId: "device-a" });
+
+        expect(fakeClient.callToolCalls).toEqual([
+          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          { toolName: "observe", params: { deviceId: "device-a", sessionUuid: "session-a" } },
+        ]);
       } finally {
         isAvailableSpy.mockRestore();
         await proxy.close();

--- a/test/daemon/daemonMcpProxy.test.ts
+++ b/test/daemon/daemonMcpProxy.test.ts
@@ -1299,6 +1299,67 @@ describe("DaemonMcpProxy", () => {
       }
     });
 
+    test("replays a successful session binding on later sessionless calls after reconnect", async () => {
+      const staleClient = new ScriptedDaemonClient({
+        toolResult: { content: [{ type: "text", text: "bound" }] },
+      });
+      const originalCallTool = staleClient.callTool.bind(staleClient);
+      staleClient.callTool = async (toolName, params) => {
+        if (staleClient.callToolCalls.length === 1) {
+          staleClient.callToolCalls.push({ toolName, params });
+          throw new DaemonUnavailableError("Daemon socket connection lost: connection closed");
+        }
+        return await originalCallTool(toolName, params);
+      };
+      const freshClient = new ScriptedDaemonClient({
+        toolResult: { content: [{ type: "text", text: "recovered" }] },
+      });
+      const clients = [staleClient, freshClient];
+      const isAvailableSpy = spyOn(DaemonClient, "isAvailable").mockResolvedValue(true);
+      const proxy = new DaemonMcpProxy({
+        clientFactory: () => clients.shift()!,
+        daemonManager: matchingDaemonManager(),
+        autoStartDaemon: false,
+      });
+
+      try {
+        await proxy.callTool("observe", { sessionUuid: "session-a", deviceId: "device-a" });
+        const result = await proxy.callTool("videoRecording", {
+          action: "stop",
+          deviceId: "device-a",
+          recordingId: "recording-a",
+        });
+
+        expect(result).toEqual({ content: [{ type: "text", text: "recovered" }] });
+        expect(staleClient.callToolCalls).toEqual([
+          { toolName: "observe", params: { sessionUuid: "session-a", deviceId: "device-a" } },
+          {
+            toolName: "videoRecording",
+            params: {
+              action: "stop",
+              deviceId: "device-a",
+              recordingId: "recording-a",
+              sessionUuid: "session-a",
+            },
+          },
+        ]);
+        expect(freshClient.callToolCalls).toEqual([
+          {
+            toolName: "videoRecording",
+            params: {
+              action: "stop",
+              deviceId: "device-a",
+              recordingId: "recording-a",
+              sessionUuid: "session-a",
+            },
+          },
+        ]);
+      } finally {
+        isAvailableSpy.mockRestore();
+        await proxy.close();
+      }
+    });
+
     test("readResource recovers when a sibling's socket dropped", async () => {
       const recoveredResult = { contents: [{ uri: "automobile:devices/booted", text: "[]" }] };
       const staleClient = new ScriptedDaemonClient({

--- a/test/daemon/daemonSessionReleaseSignal.test.ts
+++ b/test/daemon/daemonSessionReleaseSignal.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Daemon } from "../../src/daemon/daemon";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { SessionReleaseBroadcaster } from "../../src/server/sessionReleaseBroadcast";
+
+// Issue #4610: the daemon registers a release callback (next to the nav-graph /
+// observe-cache cleanup) that fans the released session key out to the
+// SessionReleaseBroadcaster, so a connected proxy learns of a real release
+// instead of guessing with the replay TTL.
+
+describe("Daemon session-release signal wiring", () => {
+  afterEach(() => {
+    SessionReleaseBroadcaster.clearForTesting();
+    // Constructing a Daemon initializes the global DaemonState singleton; reset
+    // it so this file does not leak initialized state into other suites.
+    if (DaemonState.getInstance().isInitialized()) {
+      DaemonState.getInstance().reset();
+    }
+  });
+
+  test("emits the released session key to the broadcaster on releaseSession", async () => {
+    const daemon = new Daemon({});
+    const sessionManager = daemon.getSessionManager();
+
+    const emitted: string[] = [];
+    const unsubscribe = SessionReleaseBroadcaster.subscribe(sessionId => {
+      emitted.push(sessionId);
+    });
+
+    try {
+      await sessionManager.createSession("session-release-signal", "emulator-5554", "android");
+      await sessionManager.releaseSession("session-release-signal");
+
+      expect(emitted).toEqual(["session-release-signal"]);
+    } finally {
+      unsubscribe();
+      sessionManager.stopCleanupTimer();
+    }
+  });
+});

--- a/test/daemon/daemonSessionReleaseSignal.test.ts
+++ b/test/daemon/daemonSessionReleaseSignal.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { Daemon } from "../../src/daemon/daemon";
 import { DaemonState } from "../../src/daemon/daemonState";
 import { SessionReleaseBroadcaster } from "../../src/server/sessionReleaseBroadcast";
+import { DeviceSessionRepository } from "../../src/db/deviceSessionRepository";
+import { createTestDatabase } from "../db/testDbHelper";
 
 // Issue #4610: the daemon registers a release callback (next to the nav-graph /
 // observe-cache cleanup) that fans the released session key out to the
@@ -19,7 +21,12 @@ describe("Daemon session-release signal wiring", () => {
   });
 
   test("emits the released session key to the broadcaster on releaseSession", async () => {
-    const daemon = new Daemon({});
+    // Inject an in-memory migrated DB so createSession/releaseSession persist
+    // through DeviceSessionRepository without resolving the real ~/.auto-mobile
+    // file DB (CLAUDE.md unit-test guard, issue #3067). The Daemon threads this
+    // repository straight into its SessionManager (daemon.ts).
+    const db = await createTestDatabase();
+    const daemon = new Daemon({}, undefined, undefined, new DeviceSessionRepository(db));
     const sessionManager = daemon.getSessionManager();
 
     const emitted: string[] = [];

--- a/test/daemon/socketServerIdeForwardRoute.test.ts
+++ b/test/daemon/socketServerIdeForwardRoute.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { UnixSocketServer } from "../../src/daemon/socketServer";
+import { FakeTimer } from "../fakes/FakeTimer";
+import type { DaemonRequest } from "../../src/daemon/types";
+import type { DeviceLabelMap, Session } from "../../src/daemon/sessionManager";
+
+function createFakeSession(sessionId: string, assignedDevice: string, deviceLabels?: DeviceLabelMap): Session {
+  return {
+    sessionId,
+    assignedDevice,
+    platform: "android",
+    createdAt: 0,
+    lastUsedAt: 0,
+    expiresAt: 60_000,
+    cacheData: { deviceLabels },
+    lastHeartbeat: 0,
+    sessionTimeoutMs: 60_000,
+    heartbeatTimeoutMs: 10_000,
+    heartbeatTimeoutSource: "default",
+    hasReceivedHeartbeat: false,
+  };
+}
+
+function createFakeDaemonState(sessionDevices: Map<string, string>) {
+  return {
+    isInitialized: () => true,
+    getSessionManager: () => ({
+      getSession: (sessionId: string) => {
+        const assignedDevice = sessionDevices.get(sessionId);
+        return assignedDevice ? createFakeSession(sessionId, assignedDevice) : null;
+      },
+      getDeviceLabels: () => undefined,
+      releaseSession: async () => null,
+    }),
+    getDevicePool: () => ({
+      refreshDevices: async () => 0,
+      getStats: () => ({ total: 0, idle: 0, assigned: 0, error: 0 }),
+      releaseDevice: async () => {},
+      resolveAutolockSessionForMcpSession: () => undefined,
+    }),
+  };
+}
+
+interface McpForwardRoute {
+  executionKey: string;
+  clientKey: string;
+  sessionUuid?: string;
+}
+
+interface BoundClientEntry {
+  clientKey: string;
+  executionKey: string;
+  sessionUuid: string;
+  requiresLiveDaemonSession: boolean;
+}
+
+function createServer(): UnixSocketServer {
+  const sessionDevices = new Map<string, string>();
+  // session-a is a live daemon session; session-b exists but is unbound to a device.
+  sessionDevices.set("session-a", "device-1");
+  sessionDevices.set("session-b", "");
+  return new UnixSocketServer(
+    join(tmpdir(), `ide-route-${randomUUID()}.sock`),
+    "http://localhost:0/mcp",
+    createFakeDaemonState(sessionDevices),
+    new FakeTimer(),
+  );
+}
+
+function bindSocketToSessionA(server: UnixSocketServer, socketSessionId: string): void {
+  const boundMap = (server as unknown as {
+    boundMcpClientKeysBySocketSession: Map<string, BoundClientEntry>;
+  }).boundMcpClientKeysBySocketSession;
+  boundMap.set(socketSessionId, {
+    clientKey: `socket:${socketSessionId}:session:session-a`,
+    executionKey: "device:device-1",
+    sessionUuid: "session-a",
+    requiresLiveDaemonSession: true,
+  });
+}
+
+function route(server: UnixSocketServer, request: DaemonRequest, socketSessionId: string): McpForwardRoute {
+  return (server as unknown as {
+    getMcpForwardRoute: (r: DaemonRequest, s: string) => McpForwardRoute;
+  }).getMcpForwardRoute(request, socketSessionId);
+}
+
+describe("UnixSocketServer ide/getNavigationGraph cross-session routing", () => {
+  test("an explicit sessionUuid B does not repurpose the socket's bound (session-a) client", () => {
+    const server = createServer();
+    const socketSessionId = "socket-A";
+    bindSocketToSessionA(server, socketSessionId);
+
+    const request: DaemonRequest = {
+      id: "1",
+      method: "ide/getNavigationGraph",
+      params: { sessionUuid: "session-b" },
+    };
+    const resolved = route(server, request, socketSessionId);
+
+    // The read must route to session-b's OWN client, never session-a's bound
+    // transport (whose SessionToolBinding would otherwise be rebound to B).
+    expect(resolved.clientKey).toBe(`socket:${socketSessionId}:session:session-b`);
+    expect(resolved.sessionUuid).toBe("session-b");
+    expect(resolved.executionKey).toBe("session:session-b");
+  });
+
+  test("no-sessionUuid getNavigationGraph still reuses the socket's bound client", () => {
+    const server = createServer();
+    const socketSessionId = "socket-A";
+    bindSocketToSessionA(server, socketSessionId);
+
+    const request: DaemonRequest = {
+      id: "2",
+      method: "ide/getNavigationGraph",
+      params: {},
+    };
+    const resolved = route(server, request, socketSessionId);
+
+    expect(resolved.clientKey).toBe(`socket:${socketSessionId}:session:session-a`);
+    expect(resolved.sessionUuid).toBe("session-a");
+  });
+
+  test("an explicit sessionUuid equal to the bound session keeps routing to that session", () => {
+    const server = createServer();
+    const socketSessionId = "socket-A";
+    bindSocketToSessionA(server, socketSessionId);
+
+    const request: DaemonRequest = {
+      id: "3",
+      method: "ide/getNavigationGraph",
+      params: { sessionUuid: "session-a" },
+    };
+    const resolved = route(server, request, socketSessionId);
+
+    expect(resolved.clientKey).toBe(`socket:${socketSessionId}:session:session-a`);
+    expect(resolved.sessionUuid).toBe("session-a");
+  });
+});

--- a/test/daemon/socketServerInputTypeText.test.ts
+++ b/test/daemon/socketServerInputTypeText.test.ts
@@ -564,6 +564,40 @@ describe("UnixSocketServer input/typeText", () => {
     ]);
   });
 
+  test("evicts the cached append helper after the direct device queue is idle", async () => {
+    const requestSetText = mock(async () => ({ success: true, totalTimeMs: 1 }));
+    const requestImeAction = mock(async () => ({ success: true, totalTimeMs: 1 }));
+    AndroidCtrlProxyClient.getInstance = mock(() => ({
+      requestSetText,
+      requestImeAction,
+    })) as unknown as typeof AndroidCtrlProxyClient.getInstance;
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([{ ...androidDevice, transportId: "1" }]));
+    server = new UnixSocketServer(socketPath, "http://localhost:0/mcp", createFakeDaemonState(), fakeTimer);
+    const adb = new ProductionShapedAdbExecutor(fakeTimer);
+    let factoryCalls = 0;
+    server.appendTextFactory = device => {
+      factoryCalls += 1;
+      return createAppendTextInput(device, adb, fakeTimer);
+    };
+    await server.start();
+
+    const append = (text: string) =>
+      sendRequest(socketPath, "input/typeText", {
+        platform: "android",
+        deviceId: "emulator-5554",
+        text,
+        mode: "append",
+      });
+
+    expect((await append("A")).success).toBe(true);
+    expect(factoryCalls).toBe(1);
+
+    await fakeTimer.advanceTimeAsync(5 * 60 * 1000);
+
+    expect((await append("B")).success).toBe(true);
+    expect(factoryCalls).toBe(2);
+  });
+
   // Issue #3351: an emulator replaced under a reused serial (emulator-5554) must not
   // inherit the previous device's cached API-level capability. The daemon's
   // disconnect monitor calls evictDeviceInputCache on a confirmed disconnect; after

--- a/test/daemon/socketServerInputTypeText.test.ts
+++ b/test/daemon/socketServerInputTypeText.test.ts
@@ -661,6 +661,12 @@ describe("UnixSocketServer input/typeText", () => {
     expect((await firstAppend).success).toBe(true);
     expect((await queuedMcpForward).success).toBe(true);
 
+    // The helper was built exactly once and is still cached: the queued session
+    // MCP forward has NOT evicted it yet. Asserting this before advancing time
+    // proves the later rebuild is caused by the idle-window eviction rather than
+    // the helper never being cached or being evicted immediately.
+    expect(factoryCalls).toBe(1);
+
     await fakeTimer.advanceTimeAsync(5 * 60 * 1000);
 
     expect((await append("B")).success).toBe(true);

--- a/test/daemon/socketServerInputTypeText.test.ts
+++ b/test/daemon/socketServerInputTypeText.test.ts
@@ -598,6 +598,75 @@ describe("UnixSocketServer input/typeText", () => {
     expect(factoryCalls).toBe(2);
   });
 
+  test("evicts the cached append helper after a session MCP forward succeeds it in the device queue", async () => {
+    PlatformDeviceManagerFactory.setInstance(createFakeDeviceManager([{ ...androidDevice, transportId: "1" }]));
+    const sessions = new Map([
+      ["session-a", createFakeSession("session-a", androidDevice.deviceId, "android")],
+    ]);
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createFakeDaemonState(sessions),
+      fakeTimer
+    );
+    let factoryCalls = 0;
+    let releaseAppend: () => void = () => {};
+    let signalAppendStarted: () => void = () => {};
+    const appendStarted = new Promise<void>(resolve => {
+      signalAppendStarted = resolve;
+    });
+    const appendReleased = new Promise<void>(resolve => {
+      releaseAppend = resolve;
+    });
+    server.appendTextFactory = () => {
+      factoryCalls += 1;
+      return {
+        appendText: async () => {
+          signalAppendStarted();
+          await appendReleased;
+          return { success: true, charsSent: 1 };
+        },
+      };
+    };
+    server.mcpClientFactory = async () => ({
+      callTool: async () => ({ content: [] }),
+      listTools: async () => ({ tools: [] }),
+      listResources: async () => ({ resources: [] }),
+      readResource: async () => ({ contents: [] }),
+      listResourceTemplates: async () => ({ resourceTemplates: [] }),
+      close: async () => {},
+    }) as any;
+    await server.start();
+
+    const append = (text: string) =>
+      sendRequest(socketPath, "input/typeText", {
+        platform: "android",
+        deviceId: androidDevice.deviceId,
+        text,
+        mode: "append",
+      });
+
+    const firstAppend = append("A");
+    await appendStarted;
+    const queuedMcpForward = sendRequest(socketPath, "tools/call", {
+      name: "observe",
+      arguments: {
+        sessionUuid: "session-a",
+        deviceId: androidDevice.deviceId,
+      },
+    });
+    await flushMicrotasks();
+    releaseAppend();
+
+    expect((await firstAppend).success).toBe(true);
+    expect((await queuedMcpForward).success).toBe(true);
+
+    await fakeTimer.advanceTimeAsync(5 * 60 * 1000);
+
+    expect((await append("B")).success).toBe(true);
+    expect(factoryCalls).toBe(2);
+  });
+
   // Issue #3351: an emulator replaced under a reused serial (emulator-5554) must not
   // inherit the previous device's cached API-level capability. The daemon's
   // disconnect monitor calls evictDeviceInputCache on a confirmed disconnect; after

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -457,6 +457,108 @@ describe("UnixSocketServer MCP forward serialization", () => {
     }
   });
 
+  test("re-resolves a queued sessionless device call when its bound session is RELEASED mid-queue", async () => {
+    // Mirror of the disconnect test above, but the admitted session is genuinely
+    // RELEASED (heartbeat/idle/explicit) while the sessionless device call is
+    // queued — not merely a socket disconnect. Invoking the stale session-scoped
+    // client would re-seed the released UUID and resurrect the session
+    // (getOrCreateSession recreates it and reacquires a device). The daemon
+    // session no longer being active is exactly what distinguishes this from the
+    // disconnect case, so the queued call must re-resolve to the shared, UNSEEDED
+    // client (created with `undefined`) instead of replaying session-a
+    // (issue #4610). The release is driven deterministically by removing the
+    // session from the fake session manager, the same observable state a real
+    // releaseSession produces.
+    await server.close();
+    socketPath = join(tmpdir(), `mcp-release-requeue-${randomUUID()}.sock`);
+    fakeTimer = new FakeTimer();
+    sessionDevices.set("session-a", "device-a");
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createFakeDaemonState(sessionDevices, sessionDeviceLabels, mcpAutolockSessions),
+      fakeTimer,
+    );
+    await server.start();
+
+    let releaseBlocker: () => void = () => {};
+    const blockerReleased = new Promise<void>(resolve => { releaseBlocker = resolve; });
+    let signalBlockerStarted: () => void = () => {};
+    const blockerStarted = new Promise<void>(resolve => { signalBlockerStarted = resolve; });
+
+    const forwardedCalls: Array<{ createdWith: string | undefined; toolName: string | undefined }> = [];
+    server.mcpClientFactory = async (createdWith?: string) => {
+      const client: FakeMcpClient = {
+        listTools: async () => ({ tools: [] }),
+        callTool: async (...args: unknown[]) => {
+          const request = args[0] as { name?: string };
+          if (request.name === "tapOn") {
+            signalBlockerStarted();
+            await blockerReleased;
+          }
+          forwardedCalls.push({ createdWith, toolName: request.name });
+          return { content: [] };
+        },
+        listResources: async () => ({ resources: [] }),
+        readResource: async () => ({ contents: [] }),
+        listResourceTemplates: async () => ({ resourceTemplates: [] }),
+        close: async () => {},
+      };
+      return client;
+    };
+
+    const socketB = new PersistentSocketClient();
+    const socketA = new PersistentSocketClient();
+    await Promise.all([socketB.connect(socketPath), socketA.connect(socketPath)]);
+    try {
+      // Socket B binds session-a → device-a (awaited so the binding is set).
+      const boundCall = await socketB.request("tools/call", {
+        name: "observe",
+        arguments: { sessionUuid: "session-a" },
+      });
+      expect(boundCall.success).toBe(true);
+
+      // Socket A's long-running SESSIONLESS op occupies the device:device-a queue.
+      const blockerCall = socketA.request("tools/call", {
+        name: "tapOn",
+        arguments: { deviceId: "device-a" },
+      });
+      await blockerStarted;
+
+      // Socket B's sessionless device-a call: admitted with B's bound client,
+      // queued behind socket A's op (same executionKey device:device-a).
+      const queuedCall = socketB.request("tools/call", {
+        name: "videoRecording",
+        arguments: { action: "stop", recordingId: "recording-1", deviceId: "device-a" },
+      });
+      // Let socket B read the frame and compute its initial (bound) route while
+      // session-a is still active.
+      for (let i = 0; i < 30; i++) {
+        await new Promise<void>(resolve => setImmediate(resolve));
+      }
+
+      // Release session-a while the sessionless call is still queued: the fake
+      // session manager now reports it gone, so hasActiveDaemonSession(session-a)
+      // is false when the queued route recomputes.
+      sessionDevices.delete("session-a");
+
+      // Release socket A's op so socket B's queued call runs post-release.
+      releaseBlocker();
+      await Promise.all([blockerCall, queuedCall]);
+
+      const queued = forwardedCalls.find(call => call.toolName === "videoRecording");
+      expect(queued).toBeDefined();
+      // The released session must NOT be replayed: the call re-resolves to the
+      // shared unbound client socket A created for device:device-a (created with
+      // undefined), never B's session-a bound client.
+      expect(queued?.createdWith).toBeUndefined();
+    } finally {
+      releaseBlocker();
+      socketB.close();
+      socketA.close();
+    }
+  });
+
   test("re-arms the idle close after a queued forward times out in the queue", async () => {
     // An unbound forward that waits behind another request for the same shared
     // route until its timeout budget is exhausted throws the pre-forward

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -446,6 +446,87 @@ describe("UnixSocketServer MCP forward serialization", () => {
     }
   });
 
+  test("retains a disconnected socket's transport while its device call is active", async () => {
+    await server.close();
+    socketPath = join(tmpdir(), `mcp-active-client-${randomUUID()}.sock`);
+    fakeTimer = new FakeTimer();
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createFakeDaemonState(sessionDevices, sessionDeviceLabels, mcpAutolockSessions),
+      fakeTimer,
+    );
+    await server.start();
+    sessionDevices.set("session-a", "device-a");
+    let closeCalls = 0;
+    let releaseLongCall: () => void = () => {};
+    let signalLongCallStarted: () => void = () => {};
+    let signalLongCallFinished: () => void = () => {};
+    const longCallStarted = new Promise<void>(resolve => {
+      signalLongCallStarted = resolve;
+    });
+    const longCallReleased = new Promise<void>(resolve => {
+      releaseLongCall = resolve;
+    });
+    const longCallFinished = new Promise<void>(resolve => {
+      signalLongCallFinished = resolve;
+    });
+    let callCount = 0;
+    server.mcpClientFactory = async () => ({
+      listTools: async () => ({ tools: [] }),
+      callTool: async () => {
+        callCount++;
+        if (callCount === 2) {
+          signalLongCallStarted();
+          await longCallReleased;
+          signalLongCallFinished();
+        }
+        return { content: [] };
+      },
+      listResources: async () => ({ resources: [] }),
+      readResource: async () => ({ contents: [] }),
+      listResourceTemplates: async () => ({ resourceTemplates: [] }),
+      close: async () => {
+        closeCalls++;
+      },
+    } as FakeMcpClient);
+
+    const client = new PersistentSocketClient();
+    await client.connect(socketPath);
+    try {
+      const boundCall = await client.request("tools/call", {
+        name: "observe",
+        arguments: { sessionUuid: "session-a" },
+      });
+      const longCall = client.request("tools/call", {
+        name: "executePlan",
+        arguments: { sessionUuid: "session-a" },
+      });
+      await longCallStarted;
+      const boundClientKeysBySocketSession = (server as unknown as {
+        boundMcpClientKeysBySocketSession: Map<string, unknown>;
+      }).boundMcpClientKeysBySocketSession;
+      const socketSessionId = boundClientKeysBySocketSession.keys().next().value;
+      expect(socketSessionId).toBeDefined();
+      (server as unknown as {
+        clearBoundMcpClientKey(socketSessionId: string): void;
+      }).clearBoundMcpClientKey(socketSessionId);
+      await fakeTimer.advanceTimeAsync(5 * 60 * 1000);
+
+      try {
+        expect(boundCall.success).toBe(true);
+        expect(closeCalls).toBe(0);
+      } finally {
+        releaseLongCall();
+        await longCallFinished;
+        await longCall;
+      }
+    } finally {
+      releaseLongCall();
+      client.close();
+    }
+  });
+
   test("keeps the successful session binding when a later explicit session call fails", async () => {
     await server.close();
     socketPath = join(tmpdir(), `mcp-session-list-error-${randomUUID()}.sock`);

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -326,7 +326,7 @@ describe("UnixSocketServer MCP forward serialization", () => {
       });
       const sessionlessCall = await client.request("tools/call", {
         name: "videoRecording",
-        arguments: { action: "stop", recordingId: "recording-1" },
+        arguments: { action: "stop", recordingId: "recording-1", deviceId: "device-a" },
       });
       const navigationGraph = await client.request("ide/getNavigationGraph", {});
       const refreshedList = await client.request("tools/list", {});

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -328,7 +328,7 @@ describe("UnixSocketServer MCP forward serialization", () => {
         name: "videoRecording",
         arguments: { action: "stop", recordingId: "recording-1", deviceId: "device-a" },
       });
-      const navigationGraph = await client.request("ide/getNavigationGraph", {});
+      const navigationGraph = await client.request("ide/getNavigationGraph", { deviceId: "device-a" });
       const refreshedList = await client.request("tools/list", {});
 
       expect(initialList.success).toBe(true);

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -349,6 +349,190 @@ describe("UnixSocketServer MCP forward serialization", () => {
     }
   });
 
+  test("keeps the admitted bound client when the socket disconnects before a queued sessionless device call runs", async () => {
+    // Socket B binds session-a → device-a, then submits a sessionless device-a
+    // call that queues behind socket A's long-running op on the same device
+    // (cross-socket, since one socket serializes its own frames). Socket B then
+    // disconnects, so its close handler clears the binding before the queued
+    // route is recomputed. The recompute keeps the same executionKey
+    // (device:device-a) but would otherwise swap B's session-specific client for
+    // the shared unbound client, running the admitted tool with no capability
+    // profile. The admitted client/session must be preserved (issue #4610). The
+    // disconnect is driven deterministically via the same clearBoundMcpClientKey
+    // seam the socket "close" handler uses.
+    await server.close();
+    socketPath = join(tmpdir(), `mcp-disconnect-admit-${randomUUID()}.sock`);
+    fakeTimer = new FakeTimer();
+    sessionDevices.set("session-a", "device-a");
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createFakeDaemonState(sessionDevices, sessionDeviceLabels, mcpAutolockSessions),
+      fakeTimer,
+    );
+    await server.start();
+
+    let releaseBlocker: () => void = () => {};
+    const blockerReleased = new Promise<void>(resolve => { releaseBlocker = resolve; });
+    let signalBlockerStarted: () => void = () => {};
+    const blockerStarted = new Promise<void>(resolve => { signalBlockerStarted = resolve; });
+
+    const forwardedCalls: Array<{ createdWith: string | undefined; toolName: string | undefined }> = [];
+    server.mcpClientFactory = async (createdWith?: string) => {
+      const client: FakeMcpClient = {
+        listTools: async () => ({ tools: [] }),
+        callTool: async (...args: unknown[]) => {
+          const request = args[0] as { name?: string };
+          // Socket A's blocker holds the device:device-a queue until released.
+          if (request.name === "tapOn") {
+            signalBlockerStarted();
+            await blockerReleased;
+          }
+          forwardedCalls.push({ createdWith, toolName: request.name });
+          return { content: [] };
+        },
+        listResources: async () => ({ resources: [] }),
+        readResource: async () => ({ contents: [] }),
+        listResourceTemplates: async () => ({ resourceTemplates: [] }),
+        close: async () => {},
+      };
+      return client;
+    };
+
+    const socketB = new PersistentSocketClient();
+    const socketA = new PersistentSocketClient();
+    await Promise.all([socketB.connect(socketPath), socketA.connect(socketPath)]);
+    try {
+      // Socket B binds session-a → device-a (awaited so the binding is set).
+      const boundCall = await socketB.request("tools/call", {
+        name: "observe",
+        arguments: { sessionUuid: "session-a" },
+      });
+      expect(boundCall.success).toBe(true);
+
+      // Socket A's long-running SESSIONLESS op occupies the device:device-a queue.
+      const blockerCall = socketA.request("tools/call", {
+        name: "tapOn",
+        arguments: { deviceId: "device-a" },
+      });
+      await blockerStarted;
+
+      // Socket B's sessionless device-a call: admitted with B's bound client,
+      // queued behind socket A's op (same executionKey device:device-a).
+      const queuedCall = socketB.request("tools/call", {
+        name: "videoRecording",
+        arguments: { action: "stop", recordingId: "recording-1", deviceId: "device-a" },
+      });
+      // Let socket B read the frame and compute its initial (bound) route while
+      // the binding still exists.
+      for (let i = 0; i < 30; i++) {
+        await new Promise<void>(resolve => setImmediate(resolve));
+      }
+
+      // Simulate socket B's "close" handler: clear its bound client key while the
+      // sessionless call is still queued behind socket A's op.
+      const boundClientKeysBySocketSession = (server as unknown as {
+        boundMcpClientKeysBySocketSession: Map<string, unknown>;
+      }).boundMcpClientKeysBySocketSession;
+      const socketSessionId = boundClientKeysBySocketSession.keys().next().value as string;
+      expect(socketSessionId).toBeDefined();
+      (server as unknown as {
+        clearBoundMcpClientKey(socketSessionId: string): void;
+      }).clearBoundMcpClientKey(socketSessionId);
+
+      // Release socket A's op so socket B's queued call runs post-disconnect.
+      releaseBlocker();
+      await Promise.all([blockerCall, queuedCall]);
+
+      const queued = forwardedCalls.find(call => call.toolName === "videoRecording");
+      expect(queued).toBeDefined();
+      // The admitted request must still run through B's session-a bound client
+      // (created with sessionUuid "session-a"), not the shared unbound client
+      // socket A created for device:device-a (created with undefined).
+      expect(queued?.createdWith).toBe("session-a");
+    } finally {
+      releaseBlocker();
+      socketB.close();
+      socketA.close();
+    }
+  });
+
+  test("re-arms the idle close after a queued forward times out in the queue", async () => {
+    // An unbound forward that waits behind another request for the same shared
+    // route until its timeout budget is exhausted throws the pre-forward
+    // deadline BEFORE the forward body's own cleanup. The active-client wrapper
+    // cleared the cached client's idle timer on entry, so without a re-arm the
+    // inactive transport would stay cached until another request or shutdown
+    // (issue #4610).
+    await server.close();
+    socketPath = join(tmpdir(), `mcp-queue-timeout-idle-${randomUUID()}.sock`);
+    fakeTimer = new FakeTimer();
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createFakeDaemonState(sessionDevices, sessionDeviceLabels, mcpAutolockSessions),
+      fakeTimer,
+    );
+    await server.start();
+
+    let callCount = 0;
+    let closeCalls = 0;
+    let releaseBlockingRequest: () => void = () => {};
+    const blockingPromise = new Promise<void>(resolve => { releaseBlockingRequest = resolve; });
+    server.mcpClientFactory = async () => ({
+      listTools: async () => ({ tools: [] }),
+      callTool: async () => {
+        callCount += 1;
+        if (callCount === 1) {
+          await blockingPromise;
+        }
+        return { content: [] };
+      },
+      listResources: async () => ({ resources: [] }),
+      readResource: async () => ({ contents: [] }),
+      listResourceTemplates: async () => ({ resourceTemplates: [] }),
+      close: async () => { closeCalls += 1; },
+    } as FakeMcpClient);
+
+    // First request blocks in callTool. tapOn has no per-tool timeout floor so
+    // the second request's short timeout is honored verbatim.
+    const first = sendToolsCallWithArgs(socketPath, "tapOn", { deviceId: "device-1" });
+    for (let i = 0; i < 10; i++) {
+      await new Promise<void>(resolve => setImmediate(resolve));
+    }
+
+    const second = sendRequest(socketPath, {
+      id: randomUUID(),
+      type: "mcp_request",
+      method: "tools/call",
+      params: { name: "tapOn", arguments: { deviceId: "device-1" } },
+      timeoutMs: 500,
+    });
+    for (let i = 0; i < 10; i++) {
+      await new Promise<void>(resolve => setImmediate(resolve));
+    }
+
+    // Advance past the queued request's timeout, then release the blocker.
+    fakeTimer.advanceTime(600);
+    releaseBlockingRequest();
+
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+    expect(firstResult.success).toBe(true);
+    expect(secondResult.success).toBe(false);
+    expect(secondResult.error).toContain("waiting in queue");
+
+    // Nothing has closed the shared transport yet.
+    expect(closeCalls).toBe(0);
+
+    // Advancing the idle window must close the cached transport — proving a
+    // replacement idle timer was scheduled after the queued-timeout throw.
+    await fakeTimer.advanceTimeAsync(5 * 60 * 1000);
+    for (let i = 0; i < 20 && closeCalls === 0; i++) {
+      await new Promise<void>(resolve => setImmediate(resolve));
+    }
+    expect(closeCalls).toBe(1);
+  });
+
   test("keeps tools/list isolated when two sockets bind different sessions on one device", async () => {
     sessionDevices.set("session-a", "device-a");
     sessionDevices.set("session-b", "device-a");

--- a/test/daemon/socketServerMcpForwardSerialization.test.ts
+++ b/test/daemon/socketServerMcpForwardSerialization.test.ts
@@ -349,6 +349,103 @@ describe("UnixSocketServer MCP forward serialization", () => {
     }
   });
 
+  test("keeps tools/list isolated when two sockets bind different sessions on one device", async () => {
+    sessionDevices.set("session-a", "device-a");
+    sessionDevices.set("session-b", "device-a");
+    const clients: FakeMcpClient[] = [];
+    server.mcpClientFactory = async () => {
+      let boundSessionUuid: string | undefined;
+      const client: FakeMcpClient = {
+        listTools: async () => ({
+          tools: [{ name: boundSessionUuid ?? "unbound" }],
+        }),
+        callTool: async (...args: unknown[]) => {
+          const request = args[0] as { arguments?: { sessionUuid?: string } };
+          boundSessionUuid = request.arguments?.sessionUuid;
+          return { content: [] };
+        },
+        listResources: async () => ({ resources: [] }),
+        readResource: async () => ({ contents: [] }),
+        listResourceTemplates: async () => ({ resourceTemplates: [] }),
+        close: async () => {},
+      };
+      clients.push(client);
+      return client;
+    };
+
+    const firstSocket = new PersistentSocketClient();
+    const secondSocket = new PersistentSocketClient();
+    await Promise.all([
+      firstSocket.connect(socketPath),
+      secondSocket.connect(socketPath),
+    ]);
+    try {
+      const firstBoundCall = await firstSocket.request("tools/call", {
+        name: "observe",
+        arguments: { sessionUuid: "session-a" },
+      });
+      const secondBoundCall = await secondSocket.request("tools/call", {
+        name: "observe",
+        arguments: { sessionUuid: "session-b" },
+      });
+      const [firstList, secondList] = await Promise.all([
+        firstSocket.request("tools/list", {}),
+        secondSocket.request("tools/list", {}),
+      ]);
+
+      expect(firstBoundCall.success).toBe(true);
+      expect(secondBoundCall.success).toBe(true);
+      expect(firstList.result).toEqual({ tools: [{ name: "session-a" }] });
+      expect(secondList.result).toEqual({ tools: [{ name: "session-b" }] });
+      expect(clients).toHaveLength(2);
+    } finally {
+      firstSocket.close();
+      secondSocket.close();
+    }
+  });
+
+  test("retains a bound socket transport past the idle client deadline", async () => {
+    sessionDevices.set("session-a", "device-a");
+    let closeCalls = 0;
+    server.mcpClientFactory = async () => {
+      let boundSessionUuid: string | undefined;
+      return {
+        listTools: async () => ({
+          tools: [{ name: boundSessionUuid ?? "unbound" }],
+        }),
+        callTool: async (...args: unknown[]) => {
+          const request = args[0] as { arguments?: { sessionUuid?: string } };
+          boundSessionUuid = request.arguments?.sessionUuid;
+          return { content: [] };
+        },
+        listResources: async () => ({ resources: [] }),
+        readResource: async () => ({ contents: [] }),
+        listResourceTemplates: async () => ({ resourceTemplates: [] }),
+        close: async () => {
+          closeCalls++;
+        },
+      } as FakeMcpClient;
+    };
+
+    const client = new PersistentSocketClient();
+    await client.connect(socketPath);
+    try {
+      const boundCall = await client.request("tools/call", {
+        name: "observe",
+        arguments: { sessionUuid: "session-a" },
+      });
+      fakeTimer.advanceTime(5 * 60 * 1000);
+      await Promise.resolve();
+      const list = await client.request("tools/list", {});
+
+      expect(boundCall.success).toBe(true);
+      expect(closeCalls).toBe(0);
+      expect(list.result).toEqual({ tools: [{ name: "session-a" }] });
+    } finally {
+      client.close();
+    }
+  });
+
   test("keeps the successful session binding when a later explicit session call fails", async () => {
     await server.close();
     socketPath = join(tmpdir(), `mcp-session-list-error-${randomUUID()}.sock`);

--- a/test/daemon/socketServerMcpReconnect.test.ts
+++ b/test/daemon/socketServerMcpReconnect.test.ts
@@ -87,6 +87,55 @@ function sendRequest(socketPath: string, method: string, params: Record<string, 
   });
 }
 
+class PersistentSocketClient {
+  private readonly socket = new Socket();
+  private buffer = "";
+  private readonly responses = new Map<string, DaemonResponse>();
+  private readonly waiters = new Map<string, (response: DaemonResponse) => void>();
+
+  async connect(socketPath: string): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      this.socket.connect(socketPath, resolve);
+      this.socket.on("error", reject);
+      this.socket.on("data", data => {
+        this.buffer += data.toString();
+        const lines = this.buffer.split("\n");
+        this.buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          if (!line.trim()) {
+            continue;
+          }
+          const response = JSON.parse(line) as DaemonResponse;
+          const waiter = this.waiters.get(response.id);
+          if (waiter) {
+            this.waiters.delete(response.id);
+            waiter(response);
+          } else {
+            this.responses.set(response.id, response);
+          }
+        }
+      });
+    });
+  }
+
+  request(method: string, params: Record<string, unknown>): Promise<DaemonResponse> {
+    const id = randomUUID();
+    this.socket.write(JSON.stringify({ id, type: "mcp_request", method, params }) + "\n");
+    const buffered = this.responses.get(id);
+    if (buffered) {
+      this.responses.delete(id);
+      return Promise.resolve(buffered);
+    }
+    return new Promise(resolve => {
+      this.waiters.set(id, resolve);
+    });
+  }
+
+  close(): void {
+    this.socket.destroy();
+  }
+}
+
 describe("UnixSocketServer MCP session reconnect", () => {
   let socketPath: string;
   let server: UnixSocketServer;
@@ -200,6 +249,38 @@ describe("UnixSocketServer MCP session reconnect", () => {
     const second = await sendRequest(socketPath, "tools/list");
     expect(second.success).toBe(true);
     expect(clientsCreated).toBe(2);
+  });
+
+  test("replays a bound session when tools/list reconnects its MCP client", async () => {
+    const clientBindings: Array<string | undefined> = [];
+    server.mcpClientFactory = async boundSessionUuid => {
+      clientBindings.push(boundSessionUuid);
+      const isFirstClient = clientBindings.length === 1;
+      return createFakeMcpClient({
+        listTools: async () => {
+          if (isFirstClient) {
+            throw new Error("Session not found");
+          }
+          return { tools: [{ name: boundSessionUuid ?? "unbound" }] };
+        },
+      });
+    };
+
+    const client = new PersistentSocketClient();
+    await client.connect(socketPath);
+    try {
+      const boundCall = await client.request("tools/call", {
+        name: "observe",
+        arguments: { sessionUuid: "session-a" },
+      });
+      const list = await client.request("tools/list", {});
+
+      expect(boundCall.success).toBe(true);
+      expect(clientBindings).toEqual(["session-a", "session-a"]);
+      expect(list.result).toEqual({ tools: [{ name: "session-a" }] });
+    } finally {
+      client.close();
+    }
   });
 
   test("closes idle per-key MCP clients after the idle timeout", async () => {

--- a/test/daemon/socketServerMcpReconnect.test.ts
+++ b/test/daemon/socketServerMcpReconnect.test.ts
@@ -283,6 +283,29 @@ describe("UnixSocketServer MCP session reconnect", () => {
     }
   });
 
+  test("seeds a session-scoped client for a reconnected tools/list carrying {sessionUuid}", async () => {
+    // After a reconnect the proxy re-sends `{sessionUuid}` on tools/list
+    // (daemonMcpProxy.listTools). A FRESH socket has no bound route, so the route
+    // must honor the request's session and build a SESSION-SEEDED client —
+    // otherwise the shared UNSEEDED client returns the full, unfiltered list
+    // instead of the session-scoped one (issue #4610).
+    const clientBindings: Array<string | undefined> = [];
+    server.mcpClientFactory = async boundSessionUuid => {
+      clientBindings.push(boundSessionUuid);
+      return createFakeMcpClient({
+        listTools: async () => ({ tools: [{ name: boundSessionUuid ?? "unbound" }] }),
+      });
+    };
+
+    const response = await sendRequest(socketPath, "tools/list", { sessionUuid: "session-a" });
+
+    expect(response.success).toBe(true);
+    // The loopback transport was seeded with the requested session, not left unbound.
+    expect(clientBindings).toEqual(["session-a"]);
+    const result = response.result as { tools: Array<{ name: string }> };
+    expect(result.tools).toEqual([{ name: "session-a" }]);
+  });
+
   test("closes idle per-key MCP clients after the idle timeout", async () => {
     let closeCalls = 0;
 

--- a/test/daemon/socketServerNotifications.test.ts
+++ b/test/daemon/socketServerNotifications.test.ts
@@ -7,6 +7,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { UnixSocketServer } from "../../src/daemon/socketServer";
 import { ListChangedBroadcaster } from "../../src/server/listChangedBroadcast";
+import {
+  SessionReleaseBroadcaster,
+  SESSION_RELEASED_NOTIFICATION_METHOD,
+} from "../../src/server/sessionReleaseBroadcast";
 import { DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD } from "../../src/daemon/constants";
 import { FakeTimer } from "../fakes/FakeTimer";
 import { defaultTimer } from "../../src/utils/SystemTimer";
@@ -148,6 +152,38 @@ describe("UnixSocketServer notification broadcast", () => {
       type: "daemon_notification",
       method: "notifications/resources/list_changed",
     });
+  });
+
+  test("pushes a session-released frame carrying the released session id to subscribers (issue #4610)", async () => {
+    const subscriber = await connectedClient();
+    subscriber.send(DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD);
+    await subscriber.waitForFrames(1);
+
+    // Emitted by the daemon's onSessionRelease callback in production; the socket
+    // server subscribes to the broadcaster in start().
+    SessionReleaseBroadcaster.emit("session-a");
+    await subscriber.waitForFrames(2);
+
+    expect(subscriber.frames[1]).toEqual({
+      type: "daemon_notification",
+      method: SESSION_RELEASED_NOTIFICATION_METHOD,
+      sessionId: "session-a",
+    });
+  });
+
+  test("close() unsubscribes from the session-release broadcaster too (issue #4610)", async () => {
+    const subscriber = await connectedClient();
+    subscriber.send(DAEMON_SUBSCRIBE_NOTIFICATIONS_METHOD);
+    await subscriber.waitForFrames(1);
+
+    subscriber.close();
+    await server.close();
+
+    expect(
+      (server as unknown as { sessionReleaseUnsubscribe: unknown }).sessionReleaseUnsubscribe
+    ).toBeNull();
+    expect(() => SessionReleaseBroadcaster.emit("session-a")).not.toThrow();
+    expect(subscriber.frames).toHaveLength(1);
   });
 
   test("close() unsubscribes from the broadcaster (no write to dead sockets)", async () => {

--- a/test/daemon/socketServerToolCapabilities.test.ts
+++ b/test/daemon/socketServerToolCapabilities.test.ts
@@ -143,7 +143,7 @@ describe("UnixSocketServer app-data capability enforcement", () => {
     expect(getInstanceCalls).toBe(1);
   });
 
-  test("uses the base profile for a labeled device session", async () => {
+  test("denies a labeled device session when both base and derived narrow the tool away", async () => {
     await server.close();
     await startServer({ useLabeledSession: true });
 
@@ -158,7 +158,30 @@ describe("UnixSocketServer app-data capability enforcement", () => {
 
     expect(response.success).toBe(false);
     expect(response.error).toContain("requires the 'app-data-interop' capability");
+    // UNION consults both the derived label session and its resolved base.
     expect(isEnabled).toHaveBeenCalledWith("device-session-1", "app-data-interop");
+    expect(isEnabled).toHaveBeenCalledWith("device-session-1:B", "app-data-interop");
     expect(getInstanceCalls).toBe(0);
+  });
+
+  test("allows a labeled device session when the derived label re-enables the tool (Gap B union symmetry)", async () => {
+    await server.close();
+    await startServer({ useLabeledSession: true });
+    // Base "device-session-1" narrows app-data-interop away; the derived
+    // "device-session-1:B" label grants it. Union => allowed, matching the MCP
+    // registerDeviceAware path.
+    isEnabled.mockImplementation(async (sessionUuid: string | undefined) => sessionUuid === "device-session-1:B");
+
+    const response = await sendRequest(socketPath, "ide/setKeyValue", {
+      deviceId: device.deviceId,
+      appId: "com.example",
+      fileName: "prefs",
+      key: "name",
+      value: "value",
+      type: "STRING",
+    });
+
+    expect(response.success).toBe(true);
+    expect(getInstanceCalls).toBe(1);
   });
 });

--- a/test/fakes/FakeDaemonClient.ts
+++ b/test/fakes/FakeDaemonClient.ts
@@ -11,6 +11,10 @@ export interface FakeDaemonClientOptions {
   // arriving WHILE the call is in flight. May throw to simulate an
   // admitted-then-rejected call.
   onCallTool?: (toolName: string, params: Record<string, any>) => void | Promise<void>;
+  // Same seam for callDaemonMethod (tools/list, resources/list, ...), so a test
+  // can simulate a list_changed / session-released push arriving WHILE a
+  // session-scoped discovery request is in flight (issue #4655).
+  onCallDaemonMethod?: (method: string, params: Record<string, any>) => void | Promise<void>;
 }
 
 export class FakeDaemonClient implements DaemonClientLike {
@@ -22,6 +26,7 @@ export class FakeDaemonClient implements DaemonClientLike {
   private resourceResult: any;
   private daemonMethodResults: Map<string, any>;
   private readonly onCallTool?: (toolName: string, params: Record<string, any>) => void | Promise<void>;
+  private readonly onCallDaemonMethod?: (method: string, params: Record<string, any>) => void | Promise<void>;
   private readonly notificationHandlers = new Set<(notification: DaemonNotification) => void>();
   subscribeToNotificationsCalls = 0;
   shouldFailConnect = false;
@@ -32,6 +37,7 @@ export class FakeDaemonClient implements DaemonClientLike {
     this.resourceResult = options.resourceResult ?? { contents: [{ uri: "test", text: "test" }] };
     this.daemonMethodResults = options.daemonMethodResults ?? new Map();
     this.onCallTool = options.onCallTool;
+    this.onCallDaemonMethod = options.onCallDaemonMethod;
   }
 
   async connect(): Promise<void> {
@@ -60,6 +66,9 @@ export class FakeDaemonClient implements DaemonClientLike {
 
   async callDaemonMethod(method: string, params: Record<string, any>): Promise<any> {
     this.callDaemonMethodCalls.push({ method, params });
+    if (this.onCallDaemonMethod) {
+      await this.onCallDaemonMethod(method, params);
+    }
     return this.daemonMethodResults.get(method) ?? {};
   }
 

--- a/test/fakes/FakeDaemonClient.ts
+++ b/test/fakes/FakeDaemonClient.ts
@@ -72,9 +72,13 @@ export class FakeDaemonClient implements DaemonClientLike {
   }
 
   /** Test hook: simulate a daemon-pushed notification frame. */
-  emitNotification(method: string): void {
+  emitNotification(method: string, sessionId?: string): void {
     for (const handler of this.notificationHandlers) {
-      handler({ type: "daemon_notification", method });
+      handler({
+        type: "daemon_notification",
+        method,
+        ...(sessionId !== undefined ? { sessionId } : {}),
+      });
     }
   }
 }

--- a/test/fakes/FakeDaemonClient.ts
+++ b/test/fakes/FakeDaemonClient.ts
@@ -6,6 +6,11 @@ export interface FakeDaemonClientOptions {
   toolResult?: any;
   resourceResult?: any;
   daemonMethodResults?: Map<string, any>;
+  // Invoked inside callTool AFTER the call is recorded but BEFORE it resolves, so
+  // a test can simulate a daemon push (e.g. a session-released notification)
+  // arriving WHILE the call is in flight. May throw to simulate an
+  // admitted-then-rejected call.
+  onCallTool?: (toolName: string, params: Record<string, any>) => void | Promise<void>;
 }
 
 export class FakeDaemonClient implements DaemonClientLike {
@@ -16,6 +21,7 @@ export class FakeDaemonClient implements DaemonClientLike {
   private toolResult: any;
   private resourceResult: any;
   private daemonMethodResults: Map<string, any>;
+  private readonly onCallTool?: (toolName: string, params: Record<string, any>) => void | Promise<void>;
   private readonly notificationHandlers = new Set<(notification: DaemonNotification) => void>();
   subscribeToNotificationsCalls = 0;
   shouldFailConnect = false;
@@ -25,6 +31,7 @@ export class FakeDaemonClient implements DaemonClientLike {
     this.toolResult = options.toolResult ?? { content: [{ type: "text", text: "success" }] };
     this.resourceResult = options.resourceResult ?? { contents: [{ uri: "test", text: "test" }] };
     this.daemonMethodResults = options.daemonMethodResults ?? new Map();
+    this.onCallTool = options.onCallTool;
   }
 
   async connect(): Promise<void> {
@@ -40,6 +47,9 @@ export class FakeDaemonClient implements DaemonClientLike {
 
   async callTool(toolName: string, params: Record<string, any>): Promise<any> {
     this.callToolCalls.push({ toolName, params });
+    if (this.onCallTool) {
+      await this.onCallTool(toolName, params);
+    }
     return this.toolResult;
   }
 

--- a/test/features/toolCapabilities/capabilitySessionResolver.test.ts
+++ b/test/features/toolCapabilities/capabilitySessionResolver.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import {
+  resolveCapabilityBaseSessionUuid,
+  type CapabilitySessionManager,
+} from "../../../src/features/toolCapabilities/capabilitySessionResolver";
+import {
+  assertToolEnabledForAnySession,
+  isToolEnabledForAnySession,
+} from "../../../src/features/toolCapabilities/toolCapabilityPolicy";
+import type { SessionToolProfileService } from "../../../src/features/toolCapabilities/SessionToolProfileService";
+
+const labeledSessionManager: CapabilitySessionManager = {
+  getDeviceLabels: sessionUuid =>
+    sessionUuid === "base-session"
+      ? { A: "base-session", B: "base-session:B" }
+      : undefined,
+};
+
+describe("resolveCapabilityBaseSessionUuid", () => {
+  test("returns a derived label session's base session", () => {
+    expect(resolveCapabilityBaseSessionUuid("base-session:B", labeledSessionManager)).toBe("base-session");
+  });
+
+  test("returns a plain base session unchanged", () => {
+    expect(resolveCapabilityBaseSessionUuid("base-session", labeledSessionManager)).toBe("base-session");
+  });
+
+  test("returns the input unchanged when the label cannot be resolved", () => {
+    expect(resolveCapabilityBaseSessionUuid("unknown:X", labeledSessionManager)).toBe("unknown:X");
+  });
+
+  test("passes through when no session manager is available", () => {
+    expect(resolveCapabilityBaseSessionUuid("base-session:B", undefined)).toBe("base-session:B");
+  });
+
+  test("passes through undefined", () => {
+    expect(resolveCapabilityBaseSessionUuid(undefined, labeledSessionManager)).toBeUndefined();
+  });
+});
+
+describe("isToolEnabledForAnySession (union semantics)", () => {
+  const only = (enabledSession: string): Pick<SessionToolProfileService, "isEnabled"> => ({
+    isEnabled: async sessionUuid => sessionUuid === enabledSession,
+  });
+
+  test("non-capability tools are always enabled", async () => {
+    expect(await isToolEnabledForAnySession("observe", [undefined], only("x"))).toBe(true);
+  });
+
+  test("keeps the initial surface when no session is bound", async () => {
+    expect(await isToolEnabledForAnySession("clipboard", [undefined, undefined], only("x"))).toBe(true);
+  });
+
+  test("enabled when only the base session grants it", async () => {
+    expect(await isToolEnabledForAnySession("clipboard", ["base", "base:B"], only("base"))).toBe(true);
+  });
+
+  test("enabled when only the derived session grants it", async () => {
+    expect(await isToolEnabledForAnySession("clipboard", ["base", "base:B"], only("base:B"))).toBe(true);
+  });
+
+  test("disabled only when neither base nor derived grants it", async () => {
+    const noneEnabled: Pick<SessionToolProfileService, "isEnabled"> = { isEnabled: async () => false };
+    expect(await isToolEnabledForAnySession("clipboard", ["base", "base:B"], noneEnabled)).toBe(false);
+  });
+});
+
+describe("assertToolEnabledForAnySession", () => {
+  test("throws naming the capability when both sessions narrow it away", async () => {
+    const noneEnabled: Pick<SessionToolProfileService, "isEnabled"> = { isEnabled: async () => false };
+    await expect(assertToolEnabledForAnySession("clipboard", ["base", "base:B"], noneEnabled))
+      .rejects.toThrow("requires the 'clipboard' capability");
+  });
+
+  test("resolves when either session grants the capability", async () => {
+    const derivedEnabled: Pick<SessionToolProfileService, "isEnabled"> = {
+      isEnabled: async sessionUuid => sessionUuid === "base:B",
+    };
+    await expect(assertToolEnabledForAnySession("clipboard", ["base", "base:B"], derivedEnabled))
+      .resolves.toBeUndefined();
+  });
+});

--- a/test/server/criticalSectionTools.test.ts
+++ b/test/server/criticalSectionTools.test.ts
@@ -275,11 +275,16 @@ describe("criticalSection tool", () => {
     expect(nestedHandler).not.toHaveBeenCalled();
   });
 
-  test("uses the base profile for a labeled critical-section nested step", async () => {
+  test("routes a labeled critical-section nested step with the derived session (union re-enables)", async () => {
+    // Issue #4611 Gaps B/C: a `${base}:${label}` label session carries its own
+    // routing identity into nested steps, and capability enforcement is the
+    // UNION of base + derived. Here the base narrows clipboard away but the
+    // derived label re-enables it, so the nested step must run AND route with
+    // the derived session (previously it collapsed to the base and was denied).
     const tool = ToolRegistry.getToolForPlan("criticalSection");
     expect(tool).toBeDefined();
     const nestedHandler = mock(async () => ({ success: true }));
-    ToolRegistry.register("clipboard", "clipboard", z.object({ device: z.string() }), nestedHandler);
+    ToolRegistry.register("clipboard", "clipboard", z.object({ device: z.string(), sessionUuid: z.string().optional() }), nestedHandler);
     const profileService: Pick<SessionToolProfileService, "isEnabled"> = {
       isEnabled: async (sessionUuid, capability) => sessionUuid !== "base-session" || capability === "test-authoring",
     };
@@ -311,10 +316,67 @@ describe("criticalSection tool", () => {
     });
 
     try {
-      await expect(runWithToolCapabilityContext(
-        { sessionUuid: "base-session", sessionToolProfileService: profileService },
+      await runWithToolCapabilityContext(
+        { routingSessionUuid: "base-session", sessionToolProfileService: profileService },
         () => tool!.handler({
           lock: "base-profile-lock",
+          device: "B",
+          deviceCount: 1,
+          steps: [{ tool: "clipboard", params: { device: "B" } }],
+        }),
+      );
+
+      expect(nestedHandler).toHaveBeenCalledTimes(1);
+      const nestedArgs = nestedHandler.mock.calls[0][0] as { sessionUuid?: string };
+      expect(nestedArgs.sessionUuid).toBe("base-session:B");
+    } finally {
+      restorePipelineOverrides();
+    }
+  });
+
+  test("denies a labeled critical-section nested step when base and derived both narrow it away", async () => {
+    // Union semantics remain restrictive when NEITHER session grants the
+    // capability (issue #4611 Gap B, the "both narrow" direction).
+    const tool = ToolRegistry.getToolForPlan("criticalSection");
+    expect(tool).toBeDefined();
+    const nestedHandler = mock(async () => ({ success: true }));
+    ToolRegistry.register("clipboard", "clipboard", z.object({ device: z.string(), sessionUuid: z.string().optional() }), nestedHandler);
+    const profileService: Pick<SessionToolProfileService, "isEnabled"> = {
+      // Only test-authoring is granted; clipboard is denied for every session.
+      isEnabled: async (_sessionUuid, capability) => capability === "test-authoring",
+    };
+    const fakeDevice: BootedDevice = {
+      platform: "android",
+      deviceId: "test-device-both-narrow",
+      name: "Test Device Both Narrow",
+    };
+    const restorePipelineOverrides = ToolRegistry.setPipelineOverridesForTesting({
+      executionTargetResolver: {
+        resolveExecutionTarget: async input => ({
+          args: input.args,
+          baseSessionUuid: "base-session",
+          device: fakeDevice,
+          internalCall: false,
+          sessionUuid: "base-session:B",
+          shouldResolveDevice: true,
+        }),
+      },
+      auditRunner: {
+        run: async input => input.handler(input.device, input.args, input.progress, input.signal),
+      },
+      afterToolCall: {
+        handle: async input => ({ durationMs: 0, finalizedResponse: input.response }),
+      },
+      planLifecycleManager: {
+        afterExecution: async () => {},
+      },
+    });
+
+    try {
+      await expect(runWithToolCapabilityContext(
+        { routingSessionUuid: "base-session", sessionToolProfileService: profileService },
+        () => tool!.handler({
+          lock: "both-narrow-lock",
           device: "B",
           deviceCount: 1,
           steps: [{ tool: "clipboard", params: { device: "B" } }],

--- a/test/server/planReleaseTransportBindingTeardown.test.ts
+++ b/test/server/planReleaseTransportBindingTeardown.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { McpTestFixture } from "../fixtures/mcpTestFixture";
+import { SessionReleaseBroadcaster } from "../../src/server/sessionReleaseBroadcast";
+import type { ToolCapability } from "../../src/features/toolCapabilities/SessionToolProfileService";
+
+// End-to-end coverage for the server-side SessionToolBinding teardown wired into
+// createMcpServer (issue #4611 Gap D). A transport seeded with a released-able
+// session enforces that session's narrowed profile in tools/list; once the
+// daemon actually releases the session (surfaced here via the process-wide
+// SessionReleaseBroadcaster, the same channel heartbeat/idle/plan releases use),
+// the transport binding is cleared and tools/list stops filtering.
+describe("createMcpServer server-side session-binding teardown (issue #4611 Gap D)", () => {
+  const RELEASED_SESSION = "session-S";
+  let fixture: McpTestFixture | undefined;
+
+  afterEach(async () => {
+    if (fixture) {
+      await fixture.teardown();
+      fixture = undefined;
+    }
+  });
+
+  // Narrow the released session so the whole "clipboard" capability is disabled
+  // for it; every other session (and the unbound state) keeps it enabled.
+  const profile = {
+    isEnabled: async (sessionUuid: string, capability: ToolCapability): Promise<boolean> =>
+      !(sessionUuid === RELEASED_SESSION && capability === "clipboard"),
+  };
+
+  test("a session release clears the transport binding so a later tools/list no longer enforces the released profile", async () => {
+    fixture = new McpTestFixture({
+      sessionContext: { sessionId: "transport-1", initialSessionToolBinding: RELEASED_SESSION },
+      sessionToolProfileService: profile,
+    });
+    await fixture.setup();
+    const { client } = fixture.getContext();
+
+    // While bound to the released session, the narrowed capability is filtered out.
+    const before = await client.listTools();
+    expect(before.tools.map(tool => tool.name)).not.toContain("clipboard");
+
+    // The daemon releases the session; the broadcaster reaches this transport.
+    SessionReleaseBroadcaster.emit(RELEASED_SESSION);
+
+    // The binding is gone, so tools/list reverts to the unbound (unfiltered) surface.
+    const after = await client.listTools();
+    expect(after.tools.map(tool => tool.name)).toContain("clipboard");
+  });
+
+  test("releasing an unrelated session leaves the bound profile intact", async () => {
+    fixture = new McpTestFixture({
+      sessionContext: { sessionId: "transport-2", initialSessionToolBinding: RELEASED_SESSION },
+      sessionToolProfileService: profile,
+    });
+    await fixture.setup();
+    const { client } = fixture.getContext();
+
+    SessionReleaseBroadcaster.emit("some-other-session");
+
+    const tools = await client.listTools();
+    // The still-bound released session keeps filtering the narrowed capability.
+    expect(tools.tools.map(tool => tool.name)).not.toContain("clipboard");
+  });
+});

--- a/test/server/sessionReleaseBroadcast.test.ts
+++ b/test/server/sessionReleaseBroadcast.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import {
+  SessionReleaseBroadcaster,
+  SESSION_RELEASED_NOTIFICATION_METHOD,
+} from "../../src/server/sessionReleaseBroadcast";
+
+describe("SESSION_RELEASED_NOTIFICATION_METHOD", () => {
+  test("is the stable session-released wire method", () => {
+    expect(SESSION_RELEASED_NOTIFICATION_METHOD).toBe("notifications/session/released");
+  });
+});
+
+describe("SessionReleaseBroadcaster", () => {
+  test("emit reaches all subscribers with the released session id; unsubscribe stops delivery", () => {
+    const first: string[] = [];
+    const second: string[] = [];
+    const unsubscribeFirst = SessionReleaseBroadcaster.subscribe(sessionId => {
+      first.push(sessionId);
+    });
+    const unsubscribeSecond = SessionReleaseBroadcaster.subscribe(sessionId => {
+      second.push(sessionId);
+    });
+
+    try {
+      SessionReleaseBroadcaster.emit("session-a");
+      unsubscribeFirst();
+      SessionReleaseBroadcaster.emit("session-a:device-a");
+
+      expect(first).toEqual(["session-a"]);
+      expect(second).toEqual(["session-a", "session-a:device-a"]);
+    } finally {
+      unsubscribeFirst();
+      unsubscribeSecond();
+    }
+  });
+
+  test("a throwing listener does not block sibling listeners", () => {
+    const received: string[] = [];
+    const unsubscribeThrowing = SessionReleaseBroadcaster.subscribe(() => {
+      throw new Error("listener boom");
+    });
+    const unsubscribeHealthy = SessionReleaseBroadcaster.subscribe(sessionId => {
+      received.push(sessionId);
+    });
+
+    try {
+      expect(() => SessionReleaseBroadcaster.emit("session-a")).not.toThrow();
+      expect(received).toEqual(["session-a"]);
+    } finally {
+      unsubscribeThrowing();
+      unsubscribeHealthy();
+    }
+  });
+});

--- a/test/server/sessionToolCapabilities.test.ts
+++ b/test/server/sessionToolCapabilities.test.ts
@@ -380,4 +380,96 @@ describe("capability union at the MCP boundary (#4611)", () => {
     const toolNames = await listToolsForBase(async () => false);
     expect(toolNames).not.toContain("clipboard");
   });
+
+  // Issue #4611 (follow-up P1): the derived-label union must be gated to
+  // DEVICE-AWARE tools only. A PLAIN tool (`register`, not `registerDeviceAware`)
+  // strips the `device` field via its schema and always runs under the base
+  // session, so it never runs on the labeled device — it must NOT borrow a
+  // label-only grant. `exportPlan` is a real plain tool and `startTestRecording`
+  // a real device-aware tool; both map to the `test-authoring` capability, so the
+  // ONLY difference exercised here is device-awareness.
+  const callPlainExportPlan = async (
+    isEnabled: (sessionUuid: string | undefined, capability: string) => Promise<boolean>,
+  ) => {
+    const profileService: Pick<SessionToolProfileService, "isEnabled"> = { isEnabled };
+    fixture = new McpTestFixture({
+      sessionContext: { sessionId: "mcp-session-1" },
+      sessionToolProfileService: profileService,
+    });
+    await fixture.setup();
+    ToolRegistry.clearTools();
+    const handler = mock(async () => ({ content: [{ type: "text", text: "ok" }] }));
+    // A plain tool: registered via `register`, its schema omits `device` (stripped
+    // for real plain tools). The raw `device: "B"` argument still reaches the
+    // call-gate, which must ignore it for a non-device-aware tool.
+    ToolRegistry.register(
+      "exportPlan",
+      "exportPlan",
+      z.object({ sessionUuid: z.string().optional() }),
+      handler,
+    );
+    const call = fixture.client.request(
+      {
+        method: "tools/call",
+        params: { name: "exportPlan", arguments: { sessionUuid: "base", device: "B" } },
+      },
+      z.any(),
+    );
+    return { call, handler };
+  };
+
+  test("plain tool: base disables, label enables -> REJECTED (no label borrowing)", async () => {
+    const { call, handler } = await callPlainExportPlan(
+      async (sessionUuid, capability) => capability === "test-authoring" && sessionUuid === "base:B",
+    );
+    await expect(call).rejects.toThrow("requires the 'test-authoring' capability");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test("plain tool: base enables -> allowed (base-only enforcement still works)", async () => {
+    const { call, handler } = await callPlainExportPlan(
+      async (sessionUuid, capability) => capability === "test-authoring" && sessionUuid === "base",
+    );
+    await call;
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  const listToolsForBasePlain = async (
+    isEnabled: (sessionUuid: string | undefined, capability: string) => Promise<boolean>,
+  ): Promise<string[]> => {
+    const profileService: Pick<SessionToolProfileService, "isEnabled"> = { isEnabled };
+    fixture = new McpTestFixture({
+      sessionContext: { sessionId: "mcp-session-1", initialSessionToolBinding: "base" },
+      sessionToolProfileService: profileService,
+    });
+    await fixture.setup();
+    ToolRegistry.clearTools();
+    ToolRegistry.register(
+      "exportPlan",
+      "exportPlan",
+      z.object({ sessionUuid: z.string().optional() }),
+      async () => ({ content: [{ type: "text", text: "ok" }] }),
+    );
+    const result = await fixture.client.request(
+      { method: "tools/list", params: {} },
+      z.any(),
+    );
+    return (result.tools as Array<{ name: string }>).map(tool => tool.name);
+  };
+
+  test("plain tool: only a label enables -> tool is NOT advertised (base-only discovery)", async () => {
+    // The base-only call gate would reject a plain-tool call, so discovery must not
+    // advertise a plain tool that only a label enables.
+    const toolNames = await listToolsForBasePlain(
+      async (sessionUuid, capability) => capability === "test-authoring" && sessionUuid === "base:B",
+    );
+    expect(toolNames).not.toContain("exportPlan");
+  });
+
+  test("plain tool: base enables -> tool IS advertised (base-only discovery)", async () => {
+    const toolNames = await listToolsForBasePlain(
+      async (sessionUuid, capability) => capability === "test-authoring" && sessionUuid === "base",
+    );
+    expect(toolNames).toContain("exportPlan");
+  });
 });

--- a/test/server/sessionToolCapabilities.test.ts
+++ b/test/server/sessionToolCapabilities.test.ts
@@ -338,4 +338,46 @@ describe("capability union at the MCP boundary (#4611)", () => {
     await expect(call).rejects.toThrow("requires the 'clipboard' capability");
     expect(handler).not.toHaveBeenCalled();
   });
+
+  const listToolsForBase = async (
+    isEnabled: (sessionUuid: string | undefined, capability: string) => Promise<boolean>,
+  ): Promise<string[]> => {
+    const profileService: Pick<SessionToolProfileService, "isEnabled"> = { isEnabled };
+    fixture = new McpTestFixture({
+      // Seed the transport binding to the base session so tools/list resolves the
+      // same base UUID (and its label map) the call-gate sees.
+      sessionContext: { sessionId: "mcp-session-1", initialSessionToolBinding: "base" },
+      sessionToolProfileService: profileService,
+    });
+    await fixture.setup();
+    ToolRegistry.clearTools();
+    ToolRegistry.registerDeviceAware(
+      "clipboard",
+      "clipboard",
+      z.object({ sessionUuid: z.string().optional(), device: z.string().optional() }),
+      async () => ({ content: [{ type: "text", text: "ok" }] }),
+    );
+    const result = await fixture.client.request(
+      { method: "tools/list", params: {} },
+      z.any(),
+    );
+    return (result.tools as Array<{ name: string }>).map(tool => tool.name);
+  };
+
+  test("base disables, derived label enables -> tool IS advertised (union discovery)", async () => {
+    // The call-gate accepts a `{ sessionUuid: base, device: B }` clipboard call
+    // because base:B re-enables it, so tools/list must advertise it too — otherwise
+    // the tool is callable but never discovered (issue #4611).
+    const toolNames = await listToolsForBase(
+      async (sessionUuid, capability) => capability === "clipboard" && sessionUuid === "base:B",
+    );
+    expect(toolNames).toContain("clipboard");
+  });
+
+  test("neither base nor any derived label enables -> tool is NOT advertised", async () => {
+    // Union discovery must not over-advertise: a tool no candidate session enables
+    // stays filtered out, matching the call-gate rejection.
+    const toolNames = await listToolsForBase(async () => false);
+    expect(toolNames).not.toContain("clipboard");
+  });
 });

--- a/test/server/sessionToolCapabilities.test.ts
+++ b/test/server/sessionToolCapabilities.test.ts
@@ -1,8 +1,14 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { z } from "zod";
 import { McpTestFixture } from "../fixtures/mcpTestFixture";
 import { ToolRegistry } from "../../src/server/toolRegistry";
 import type { SessionToolProfileService } from "../../src/features/toolCapabilities/SessionToolProfileService";
+import type { BootedDevice } from "../../src/models";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import { DevicePool } from "../../src/daemon/devicePool";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
 
 describe("session tool capability MCP enforcement", () => {
   let fixture: McpTestFixture | undefined;
@@ -216,5 +222,120 @@ describe("session tool capability MCP enforcement", () => {
     );
 
     expect(handler).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Issue #4611: capability enforcement must honor the UNION of the base and the
+// derived `${base}:${label}` device-label sessions at EVERY gate — a tool is
+// enabled when EITHER grants it. These tests drive the PUBLIC MCP `tools/call`
+// boundary (an earlier gate than the authoritative union in
+// `registerDeviceAware`) with a real `device: label` so the boundary must
+// resolve base + derived itself. Before the fix the boundary asserted the base
+// session only and rejected a labeled call that the label re-enabled.
+describe("capability union at the MCP boundary (#4611)", () => {
+  const device: BootedDevice = { name: "Pixel", deviceId: "emulator-5554", platform: "android" };
+  let fixture: McpTestFixture | undefined;
+  let restorePipelineOverrides: (() => void) | undefined;
+  let sessionManager: SessionManager | undefined;
+
+  const passthroughDerivedLabelPipeline = () => ToolRegistry.setPipelineOverridesForTesting({
+    executionTargetResolver: {
+      // Mirrors what DefaultExecutionTargetResolver returns for a
+      // `{ sessionUuid: "base", device: "B" }` call: base + derived label session.
+      resolveExecutionTarget: async (input: any) => ({
+        args: input.args,
+        baseSessionUuid: "base",
+        capabilitySessionUuid: "base:B",
+        device,
+        internalCall: false,
+        sessionUuid: "base:B",
+        shouldResolveDevice: true,
+      }),
+    },
+    auditRunner: {
+      run: async (input: any) => input.handler(input.device, input.args, input.progress, input.signal),
+    },
+    afterToolCall: {
+      handle: async (input: any) => ({ durationMs: 0, finalizedResponse: input.response }),
+    },
+    planLifecycleManager: {
+      afterExecution: async () => {},
+    },
+  });
+
+  beforeEach(async () => {
+    ToolRegistry.clearTools();
+    const timer = new FakeTimer();
+    sessionManager = new SessionManager(timer);
+    const fakeDeviceUtils = new FakeDeviceUtils();
+    fakeDeviceUtils.setBootedDevices("android", [device]);
+    const pool = new DevicePool(sessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);
+    await pool.initializeWithDevices([device]);
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    // Base session with a device-label map so the boundary can resolve the
+    // derived `base:B` label candidate via getDeviceLabelMap.
+    await sessionManager.createSession("base", device.deviceId, "android");
+    sessionManager.setDeviceLabels("base", { A: "base", B: "base:B" });
+  });
+
+  afterEach(async () => {
+    restorePipelineOverrides?.();
+    restorePipelineOverrides = undefined;
+    await fixture?.teardown();
+    fixture = undefined;
+    sessionManager?.stopCleanupTimer();
+    sessionManager = undefined;
+    ToolRegistry.clearTools();
+    DaemonState.getInstance().reset();
+  });
+
+  const callLabeledClipboard = async (
+    isEnabled: (sessionUuid: string | undefined, capability: string) => Promise<boolean>,
+  ) => {
+    const profileService: Pick<SessionToolProfileService, "isEnabled"> = { isEnabled };
+    fixture = new McpTestFixture({
+      sessionContext: { sessionId: "mcp-session-1" },
+      sessionToolProfileService: profileService,
+    });
+    await fixture.setup();
+    ToolRegistry.clearTools();
+    restorePipelineOverrides = passthroughDerivedLabelPipeline();
+    const handler = mock(async () => ({ content: [{ type: "text", text: "ok" }] }));
+    ToolRegistry.registerDeviceAware(
+      "clipboard",
+      "clipboard",
+      z.object({ sessionUuid: z.string().optional(), device: z.string().optional() }),
+      handler,
+    );
+    const call = fixture.client.request(
+      {
+        method: "tools/call",
+        params: { name: "clipboard", arguments: { sessionUuid: "base", device: "B" } },
+      },
+      z.any(),
+    );
+    return { call, handler };
+  };
+
+  test("base disables, derived label enables -> allowed end-to-end (union honored at the boundary)", async () => {
+    const { call, handler } = await callLabeledClipboard(
+      async (sessionUuid, capability) => capability === "clipboard" && sessionUuid === "base:B",
+    );
+    await call;
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test("base enables, derived label disables -> still allowed (union)", async () => {
+    const { call, handler } = await callLabeledClipboard(
+      async (sessionUuid, capability) => capability === "clipboard" && sessionUuid === "base",
+    );
+    await call;
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test("both base and derived label disable -> rejected", async () => {
+    const { call, handler } = await callLabeledClipboard(async () => false);
+    await expect(call).rejects.toThrow("requires the 'clipboard' capability");
+    expect(handler).not.toHaveBeenCalled();
   });
 });

--- a/test/server/sessionToolDiscovery.test.ts
+++ b/test/server/sessionToolDiscovery.test.ts
@@ -23,6 +23,7 @@ describe("session-scoped tool discovery", () => {
     const binding = new SessionToolBinding("device-session-a");
 
     expect(binding.effectiveSessionUuid("recreated-transport")).toBe("device-session-a");
+    expect(binding.bind("recreated-transport", "device-session-a")).toBe(true);
     expect(binding.bind("recreated-transport", "device-session-a")).toBe(false);
     expect(binding.bind("recreated-transport", "device-session-b")).toBe(true);
     expect(binding.effectiveSessionUuid("recreated-transport")).toBe("device-session-b");

--- a/test/server/sessionToolDiscovery.test.ts
+++ b/test/server/sessionToolDiscovery.test.ts
@@ -36,4 +36,36 @@ describe("session-scoped tool discovery", () => {
     expect(binding.effectiveSessionUuid("transport", { sessionUuid })).toBe("disabled-session");
     expect(binding.bind("transport", sessionUuid)).toBe(false);
   });
+
+  test("unbindSession drops every transport binding whose effective session was released (issue #4611 Gap D)", () => {
+    const binding = new SessionToolBinding();
+    binding.bind("transport-a", "session-1");
+    binding.bind("transport-b", "session-1");
+    binding.bind("transport-c", "session-2");
+
+    // A real release of session-1 removes both bindings pointed at it and leaves
+    // the unrelated session-2 binding intact.
+    expect(binding.unbindSession("session-1")).toBe(true);
+    expect(binding.effectiveSessionUuid("transport-a")).toBeUndefined();
+    expect(binding.effectiveSessionUuid("transport-b")).toBeUndefined();
+    expect(binding.effectiveSessionUuid("transport-c")).toBe("session-2");
+  });
+
+  test("unbindSession reports no change when nothing matches the released session", () => {
+    const binding = new SessionToolBinding();
+    binding.bind("transport", "session-1");
+
+    expect(binding.unbindSession("session-2")).toBe(false);
+    expect(binding.unbindSession("")).toBe(false);
+    expect(binding.effectiveSessionUuid("transport")).toBe("session-1");
+  });
+
+  test("unbindSession also clears a seeded initial binding for the released session", () => {
+    const binding = new SessionToolBinding("seeded-session");
+
+    expect(binding.effectiveSessionUuid("recreated-transport")).toBe("seeded-session");
+    expect(binding.unbindSession("seeded-session")).toBe(true);
+    // The seed fallback is gone, so a later sessionless call no longer enforces it.
+    expect(binding.effectiveSessionUuid("recreated-transport")).toBeUndefined();
+  });
 });

--- a/test/server/sessionToolDiscovery.test.ts
+++ b/test/server/sessionToolDiscovery.test.ts
@@ -19,6 +19,15 @@ describe("session-scoped tool discovery", () => {
     expect(binding.bind("transport", "device-session-b")).toBe(true);
   });
 
+  test("seeds only a recreated transport's initial session binding", () => {
+    const binding = new SessionToolBinding("device-session-a");
+
+    expect(binding.effectiveSessionUuid("recreated-transport")).toBe("device-session-a");
+    expect(binding.bind("recreated-transport", "device-session-a")).toBe(false);
+    expect(binding.bind("recreated-transport", "device-session-b")).toBe(true);
+    expect(binding.effectiveSessionUuid("recreated-transport")).toBe("device-session-b");
+  });
+
   test.each(["", "   "])("uses the bound session when an explicit session UUID is %p", sessionUuid => {
     const binding = new SessionToolBinding();
     binding.bind("transport", "disabled-session");

--- a/test/server/toolCapabilityRouting.test.ts
+++ b/test/server/toolCapabilityRouting.test.ts
@@ -262,6 +262,52 @@ describe("ToolRegistry capability routing and enforcement (#4611)", () => {
     }
   });
 
+  test("Gap B wrapper union (#4655): a device-aware internal step routed as the derived `base:B` is allowed when the base enables it", async () => {
+    // The device-aware wrapper's resolver reports `baseSessionUuid = args.sessionUuid`.
+    // For an internal step whose routing session is ALREADY the derived
+    // `base-session:B`, that is the DERIVED value, not the true base. A wrapper
+    // gate that trusted it verbatim as the union's base collapsed the union to
+    // `[base-session:B, base-session:B]` and lost the base grant. The wrapper must
+    // resolve the REAL base from the derived routing session so the union is
+    // genuinely `[base-session, base-session:B]`.
+    const sessionManager = await initializeDaemonWithLabeledBase();
+    try {
+      const isEnabled = mock(
+        async (sessionUuid: string | undefined, capability: string) =>
+          capability === "clipboard" && sessionUuid === "base-session",
+      );
+      const profileService: Pick<SessionToolProfileService, "isEnabled"> = { isEnabled };
+      const handler = mock(async () => ({ success: true }));
+      restorePipelineOverrides = passthroughPipeline(async input => ({
+        args: input.args,
+        // Simulates the resolver on a step already routed to the derived session.
+        baseSessionUuid: "base-session:B",
+        device,
+        internalCall: false,
+        sessionUuid: "base-session:B",
+        shouldResolveDevice: true,
+      }));
+      ToolRegistry.registerDeviceAware(
+        "clipboard",
+        "clipboard",
+        z.object({ sessionUuid: z.string().optional() }),
+        handler,
+      );
+
+      const response = await runWithToolCapabilityContext(
+        { routingSessionUuid: "base-session:B", sessionToolProfileService: profileService },
+        () => ToolRegistry.callInternal("clipboard", {}),
+      );
+
+      expect(response).toEqual({ success: true });
+      expect(handler).toHaveBeenCalledTimes(1);
+      // The wrapper gate resolved the REAL base from the derived routing session.
+      expect(isEnabled).toHaveBeenCalledWith("base-session", "clipboard");
+    } finally {
+      sessionManager.stopCleanupTimer();
+    }
+  });
+
   test("Gap B nested union: rejected only when both base and derived label disable the tool", async () => {
     const sessionManager = await initializeDaemonWithLabeledBase();
     try {

--- a/test/server/toolCapabilityRouting.test.ts
+++ b/test/server/toolCapabilityRouting.test.ts
@@ -193,4 +193,93 @@ describe("ToolRegistry capability routing and enforcement (#4611)", () => {
     expect(nestedHandler).toHaveBeenCalledTimes(1);
     expect(nestedSessionUuid).toBe("base-session:B");
   });
+
+  // Gap B union at the NESTED internal-call pre-gate (issue #4611). A labeled
+  // criticalSection/executePlan step routes through `callInternal` with the
+  // derived `${base}:${label}` session as the ambient routing session. Before
+  // the fix `invokeInternalTool` asserted that single derived session, rejecting
+  // a step the base session enables but the label narrowed away. The pre-gate
+  // must resolve the base from the derived label and apply the union — including
+  // on the `targetDevice` path, which bypasses the device-aware wrapper's own
+  // union gate entirely.
+  const initializeDaemonWithLabeledBase = async () => {
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer);
+    const fakeDeviceUtils = new FakeDeviceUtils();
+    fakeDeviceUtils.setBootedDevices("android", [device]);
+    const pool = new DevicePool(sessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);
+    await pool.initializeWithDevices([device]);
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    await sessionManager.createSession("base-session", device.deviceId, "android");
+    sessionManager.setDeviceLabels("base-session", { A: "base-session", B: "base-session:B" });
+    return sessionManager;
+  };
+
+  const baseEnabledDerivedDisabled = mock(
+    async (sessionUuid: string | undefined, capability: string) =>
+      capability === "clipboard" && sessionUuid === "base-session",
+  );
+
+  test("Gap B nested union: a labeled internal step is allowed when the base enables it but the derived label narrowed it away", async () => {
+    const sessionManager = await initializeDaemonWithLabeledBase();
+    try {
+      const profileService: Pick<SessionToolProfileService, "isEnabled"> = { isEnabled: baseEnabledDerivedDisabled };
+      const handler = mock(async () => ({ success: true }));
+      // A plain-registered tool: its handler is the raw handler with no wrapper
+      // union, so `invokeInternalTool`'s pre-gate is the ONLY enforcement point.
+      ToolRegistry.register("clipboard", "clipboard", z.object({}), handler);
+
+      const response = await runWithToolCapabilityContext(
+        { routingSessionUuid: "base-session:B", sessionToolProfileService: profileService },
+        () => ToolRegistry.callInternal("clipboard", {}),
+      );
+
+      expect(response).toEqual({ success: true });
+      expect(handler).toHaveBeenCalledTimes(1);
+    } finally {
+      sessionManager.stopCleanupTimer();
+    }
+  });
+
+  test("Gap B nested union: the targetDevice path also honors the union (bypasses the wrapper)", async () => {
+    const sessionManager = await initializeDaemonWithLabeledBase();
+    try {
+      const profileService: Pick<SessionToolProfileService, "isEnabled"> = { isEnabled: baseEnabledDerivedDisabled };
+      const deviceAwareHandler = mock(async () => ({ success: true }));
+      ToolRegistry.registerDeviceAware("clipboard", "clipboard", z.object({}), deviceAwareHandler);
+
+      const response = await runWithToolCapabilityContext(
+        { routingSessionUuid: "base-session:B", sessionToolProfileService: profileService },
+        () => ToolRegistry.callInternal("clipboard", {}, undefined, undefined, { targetDevice: device }),
+      );
+
+      expect(response).toEqual({ success: true });
+      // Invoked directly with the target device, bypassing the device-aware wrapper.
+      expect(deviceAwareHandler).toHaveBeenCalledTimes(1);
+      expect(deviceAwareHandler.mock.calls[0][0]).toEqual(device);
+    } finally {
+      sessionManager.stopCleanupTimer();
+    }
+  });
+
+  test("Gap B nested union: rejected only when both base and derived label disable the tool", async () => {
+    const sessionManager = await initializeDaemonWithLabeledBase();
+    try {
+      const isEnabled = mock(async () => false);
+      const profileService: Pick<SessionToolProfileService, "isEnabled"> = { isEnabled };
+      const handler = mock(async () => ({ success: true }));
+      ToolRegistry.register("clipboard", "clipboard", z.object({}), handler);
+
+      await expect(runWithToolCapabilityContext(
+        { routingSessionUuid: "base-session:B", sessionToolProfileService: profileService },
+        () => ToolRegistry.callInternal("clipboard", {}),
+      )).rejects.toThrow("requires the 'clipboard' capability");
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(isEnabled).toHaveBeenCalledWith("base-session", "clipboard");
+      expect(isEnabled).toHaveBeenCalledWith("base-session:B", "clipboard");
+    } finally {
+      sessionManager.stopCleanupTimer();
+    }
+  });
 });

--- a/test/server/toolCapabilityRouting.test.ts
+++ b/test/server/toolCapabilityRouting.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { z } from "zod";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import type { BootedDevice } from "../../src/models";
+import type { SessionToolProfileService } from "../../src/features/toolCapabilities/SessionToolProfileService";
+import { runWithToolCapabilityContext } from "../../src/features/toolCapabilities/toolCapabilityContext";
+import { DaemonState } from "../../src/daemon/daemonState";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import { DevicePool } from "../../src/daemon/devicePool";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
+import { FakeDeviceSessionManager } from "../fakes/FakeDeviceSessionManager";
+
+// Issue #4611 Gaps A/B/C — capability enforcement + routing/capability
+// un-conflation on the MCP device-aware path.
+describe("ToolRegistry capability routing and enforcement (#4611)", () => {
+  const device: BootedDevice = { name: "Pixel", deviceId: "emulator-5554", platform: "android" };
+
+  let restorePipelineOverrides: (() => void) | undefined;
+  let originalDeviceSessionManager: unknown;
+
+  const passthroughPipeline = (
+    resolveExecutionTarget: (input: any) => Promise<any>
+  ) => ToolRegistry.setPipelineOverridesForTesting({
+    executionTargetResolver: { resolveExecutionTarget },
+    auditRunner: {
+      run: async input => input.handler(input.device, input.args, input.progress, input.signal),
+    },
+    afterToolCall: {
+      handle: async input => ({ durationMs: 0, finalizedResponse: input.response }),
+    },
+    planLifecycleManager: {
+      afterExecution: async () => {},
+    },
+  });
+
+  beforeEach(() => {
+    ToolRegistry.clearTools();
+    originalDeviceSessionManager = (ToolRegistry as any).deviceSessionManager;
+  });
+
+  afterEach(() => {
+    restorePipelineOverrides?.();
+    restorePipelineOverrides = undefined;
+    (ToolRegistry as any).deviceSessionManager = originalDeviceSessionManager;
+    ToolRegistry.clearTools();
+    DaemonState.getInstance().reset();
+  });
+
+  test("Gap A: enforces the derived capability session of a deviceId-only call (assert consumes capabilitySessionUuid)", async () => {
+    const isEnabled = mock(async () => false);
+    const profileService: Pick<SessionToolProfileService, "isEnabled"> = { isEnabled };
+    const handler = mock(async () => ({ success: true }));
+    restorePipelineOverrides = passthroughPipeline(async input => ({
+      args: input.args,
+      baseSessionUuid: undefined,
+      // The resolver derives this from the device's owning session for a
+      // deviceId-only call. Without Gap A, enforcement saw only
+      // `baseSessionUuid ?? sessionUuid` (undefined) and silently allowed.
+      capabilitySessionUuid: "device-session-1",
+      device,
+      internalCall: false,
+      sessionUuid: undefined,
+      shouldResolveDevice: true,
+    }));
+    ToolRegistry.registerDeviceAware("clipboard", "clipboard", z.object({ deviceId: z.string() }), handler);
+
+    await expect(runWithToolCapabilityContext(
+      { sessionToolProfileService: profileService },
+      () => ToolRegistry.getTool("clipboard")!.handler({ deviceId: device.deviceId }),
+    )).rejects.toThrow("requires the 'clipboard' capability");
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(isEnabled).toHaveBeenCalledWith("device-session-1", "clipboard");
+  });
+
+  test("Gap A end-to-end: a real deviceId-only call enforces the device's owning session", async () => {
+    const timer = new FakeTimer();
+    const sessionManager = new SessionManager(timer);
+    const fakeDeviceUtils = new FakeDeviceUtils();
+    fakeDeviceUtils.setBootedDevices("android", [device]);
+    const pool = new DevicePool(sessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);
+    await pool.initializeWithDevices([device]);
+    DaemonState.getInstance().initialize(sessionManager, pool);
+    // Populates the device -> session reverse map read by getSessionForDevice.
+    // The DB write is best-effort and swallowed under the unit-test DB guard.
+    await sessionManager.createSession("owner-session", device.deviceId, "android");
+
+    const fakeDeviceSessionManager = new FakeDeviceSessionManager();
+    fakeDeviceSessionManager.setConnectedDevices([device]);
+    (ToolRegistry as any).deviceSessionManager = fakeDeviceSessionManager;
+
+    const isEnabled = mock(async () => false);
+    const profileService: Pick<SessionToolProfileService, "isEnabled"> = { isEnabled };
+    const handler = mock(async () => ({ success: true }));
+    ToolRegistry.registerDeviceAware(
+      "clipboard",
+      "clipboard",
+      z.object({ deviceId: z.string().optional(), platform: z.string().optional() }),
+      handler,
+    );
+
+    try {
+      await expect(runWithToolCapabilityContext(
+        { sessionToolProfileService: profileService },
+        () => ToolRegistry.getTool("clipboard")!.handler({ platform: "android", deviceId: device.deviceId }),
+      )).rejects.toThrow("requires the 'clipboard' capability");
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(isEnabled).toHaveBeenCalledWith("owner-session", "clipboard");
+    } finally {
+      sessionManager.stopCleanupTimer();
+    }
+  });
+
+  test("Gap B union: enabled when the derived label grants a tool the base narrowed away", async () => {
+    const isEnabled = mock(async (sessionUuid: string | undefined) => sessionUuid === "base-session:B");
+    const profileService: Pick<SessionToolProfileService, "isEnabled"> = { isEnabled };
+    const handler = mock(async () => ({ success: true }));
+    restorePipelineOverrides = passthroughPipeline(async input => ({
+      args: input.args,
+      baseSessionUuid: "base-session",
+      device,
+      internalCall: false,
+      sessionUuid: "base-session:B",
+      shouldResolveDevice: true,
+    }));
+    ToolRegistry.registerDeviceAware("clipboard", "clipboard", z.object({ sessionUuid: z.string().optional() }), handler);
+
+    const response = await runWithToolCapabilityContext(
+      { sessionToolProfileService: profileService },
+      () => ToolRegistry.getTool("clipboard")!.handler({ sessionUuid: "base-session" }),
+    );
+
+    expect(response).toEqual({ success: true });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test("Gap B union: denied only when both base and derived narrow the tool away", async () => {
+    const isEnabled = mock(async () => false);
+    const profileService: Pick<SessionToolProfileService, "isEnabled"> = { isEnabled };
+    const handler = mock(async () => ({ success: true }));
+    restorePipelineOverrides = passthroughPipeline(async input => ({
+      args: input.args,
+      baseSessionUuid: "base-session",
+      device,
+      internalCall: false,
+      sessionUuid: "base-session:B",
+      shouldResolveDevice: true,
+    }));
+    ToolRegistry.registerDeviceAware("clipboard", "clipboard", z.object({ sessionUuid: z.string().optional() }), handler);
+
+    await expect(runWithToolCapabilityContext(
+      { sessionToolProfileService: profileService },
+      () => ToolRegistry.getTool("clipboard")!.handler({ sessionUuid: "base-session" }),
+    )).rejects.toThrow("requires the 'clipboard' capability");
+
+    expect(handler).not.toHaveBeenCalled();
+    // Union consults both sessions before denying.
+    expect(isEnabled).toHaveBeenCalledWith("base-session", "clipboard");
+    expect(isEnabled).toHaveBeenCalledWith("base-session:B", "clipboard");
+  });
+
+  test("Gap C: a nested internal call routes with the outer call's derived session, not the base", async () => {
+    let nestedSessionUuid: unknown = "UNSET";
+    const nestedHandler = mock(async (args: { sessionUuid?: string }) => {
+      nestedSessionUuid = args.sessionUuid;
+      return { success: true };
+    });
+    ToolRegistry.register(
+      "nestedRoutingProbe",
+      "nested routing probe",
+      z.object({ sessionUuid: z.string().optional() }),
+      nestedHandler,
+    );
+    const outerHandler = mock(async () => {
+      await ToolRegistry.callInternal("nestedRoutingProbe", {});
+      return { success: true };
+    });
+    restorePipelineOverrides = passthroughPipeline(async input => ({
+      args: input.args,
+      baseSessionUuid: "base-session",
+      device,
+      internalCall: false,
+      sessionUuid: "base-session:B",
+      shouldResolveDevice: true,
+    }));
+    ToolRegistry.registerDeviceAware("outerRoutingProbe", "outer routing probe", z.object({ sessionUuid: z.string().optional() }), outerHandler);
+
+    await ToolRegistry.getTool("outerRoutingProbe")!.handler({ sessionUuid: "base-session" });
+
+    expect(outerHandler).toHaveBeenCalledTimes(1);
+    expect(nestedHandler).toHaveBeenCalledTimes(1);
+    expect(nestedSessionUuid).toBe("base-session:B");
+  });
+});

--- a/test/server/toolRegistry.collaborators.test.ts
+++ b/test/server/toolRegistry.collaborators.test.ts
@@ -12,6 +12,8 @@ import { serverConfig } from "../../src/utils/ServerConfig";
 import { defaultAdbClientFactory } from "../../src/utils/android-cmdline-tools/AdbClientFactory";
 import { DaemonState } from "../../src/daemon/daemonState";
 import { SessionManager } from "../../src/daemon/sessionManager";
+import { DeviceSessionRepository } from "../../src/db/deviceSessionRepository";
+import { createTestDatabase } from "../db/testDbHelper";
 import { DevicePool } from "../../src/daemon/devicePool";
 import { buildDeviceLabelMap } from "../../src/server/deviceLabelMapping";
 import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
@@ -282,7 +284,9 @@ describe("DefaultPlanLifecycleManager server-side binding teardown (issue #4611 
 
   beforeEach(async () => {
     const timer = new FakeTimer();
-    sessionManager = new SessionManager(timer);
+    // In-memory migrated DB so createSession persists without resolving the real
+    // ~/.auto-mobile file DB (CLAUDE.md unit-test guard, issue #3067).
+    sessionManager = new SessionManager(timer, new DeviceSessionRepository(await createTestDatabase()));
     const fakeDeviceUtils = new FakeDeviceUtils();
     fakeDeviceUtils.setBootedDevices("android", [androidDevice]);
     const pool = new DevicePool(sessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);

--- a/test/server/toolRegistry.collaborators.test.ts
+++ b/test/server/toolRegistry.collaborators.test.ts
@@ -7,10 +7,27 @@ import {
 } from "../../src/server/toolRegistry";
 import type { AppCleanupConfig, AppCleanupService } from "../../src/server/AppCleanupService";
 import type { BootedDevice } from "../../src/models";
+import type { SessionBindingReleaseHandler } from "../../src/server/toolRegistry";
 import { serverConfig } from "../../src/utils/ServerConfig";
 import { defaultAdbClientFactory } from "../../src/utils/android-cmdline-tools/AdbClientFactory";
 import { DaemonState } from "../../src/daemon/daemonState";
+import { SessionManager } from "../../src/daemon/sessionManager";
+import { DevicePool } from "../../src/daemon/devicePool";
+import { buildDeviceLabelMap } from "../../src/server/deviceLabelMapping";
+import { FakeDeviceUtils } from "../fakes/FakeDeviceUtils";
+import { FakeTimer } from "../fakes/FakeTimer";
 import { FakeLogger } from "../fakes/FakeLogger";
+
+// Deterministic fake for the injected server-side session-binding teardown seam
+// (issue #4611 Gap D). Records every released session UUID afterExecution reports
+// so the plan-release path can be asserted without a live MCP transport.
+class FakeSessionBindingReleaseHandler implements SessionBindingReleaseHandler {
+  released: string[] = [];
+
+  onSessionReleased(sessionUuid: string): void {
+    this.released.push(sessionUuid);
+  }
+}
 
 // Direct, fast unit coverage for the two ToolRegistry pipeline collaborators
 // called out in issue #3208. Both reach module-level singletons, so each test
@@ -238,6 +255,7 @@ describe("DefaultPlanLifecycleManager", () => {
 
     const cleanupService = new FakeAppCleanupService();
     const manager = new DefaultPlanLifecycleManager();
+    const releaseHandler = new FakeSessionBindingReleaseHandler();
 
     await manager.afterExecution(
       makeInput({
@@ -245,10 +263,83 @@ describe("DefaultPlanLifecycleManager", () => {
         sessionUuid: "session-1",
         baseSessionUuid: "session-1",
         args: {},
+        sessionBindingReleaseHandler: releaseHandler,
       })
     );
 
     // Cleanup path is independent of the release path and stays untouched here.
     expect(cleanupService.calls).toEqual([]);
+    // No real release happened, so the server-side binding teardown never fires.
+    expect(releaseHandler.released).toEqual([]);
+  });
+});
+
+// Exercises the REAL auto-release path (daemon initialized + live session) to
+// prove afterExecution clears the server-side SessionToolBinding for every
+// session it actually frees on an executePlan release (issue #4611 Gap D).
+describe("DefaultPlanLifecycleManager server-side binding teardown (issue #4611 Gap D)", () => {
+  let sessionManager: SessionManager;
+
+  beforeEach(async () => {
+    const timer = new FakeTimer();
+    sessionManager = new SessionManager(timer);
+    const fakeDeviceUtils = new FakeDeviceUtils();
+    fakeDeviceUtils.setBootedDevices("android", [androidDevice]);
+    const pool = new DevicePool(sessionManager, "daemon-session", timer, undefined, fakeDeviceUtils);
+    await pool.initializeWithDevices([androidDevice]);
+    DaemonState.getInstance().initialize(sessionManager, pool);
+  });
+
+  afterEach(() => {
+    DaemonState.getInstance().reset();
+    sessionManager.stopCleanupTimer();
+  });
+
+  test("notifies the release handler with the base session UUID after a plan auto-release", async () => {
+    await sessionManager.createSession("base", androidDevice.deviceId, "android");
+    const cleanupService = new FakeAppCleanupService();
+    const releaseHandler = new FakeSessionBindingReleaseHandler();
+    const manager = new DefaultPlanLifecycleManager();
+
+    await manager.afterExecution({
+      name: "executePlan",
+      args: {},
+      baseSessionUuid: "base",
+      cleanupService,
+      device: androidDevice,
+      sessionUuid: "base",
+      shouldResolveDevice: true,
+      sessionBindingReleaseHandler: releaseHandler,
+    });
+
+    // The base session is gone, and its transport binding was torn down.
+    expect(sessionManager.getSession("base")).toBeNull();
+    expect(releaseHandler.released).toEqual(["base"]);
+  });
+
+  test("notifies the release handler for every derived label session it releases", async () => {
+    await sessionManager.createSession("base", androidDevice.deviceId, "android");
+    await sessionManager.createSession("base:B", androidDevice.deviceId, "android");
+    sessionManager.setDeviceLabels("base", buildDeviceLabelMap(["A", "B"], "base"));
+
+    const cleanupService = new FakeAppCleanupService();
+    const releaseHandler = new FakeSessionBindingReleaseHandler();
+    const manager = new DefaultPlanLifecycleManager();
+
+    await manager.afterExecution({
+      name: "executePlan",
+      args: {},
+      baseSessionUuid: "base",
+      cleanupService,
+      device: androidDevice,
+      sessionUuid: "base",
+      shouldResolveDevice: true,
+      sessionBindingReleaseHandler: releaseHandler,
+    });
+
+    expect(releaseHandler.released).toContain("base");
+    expect(releaseHandler.released).toContain("base:B");
+    expect(sessionManager.getSession("base")).toBeNull();
+    expect(sessionManager.getSession("base:B")).toBeNull();
   });
 });

--- a/test/server/toolRegistryNotifyToolListChanged.test.ts
+++ b/test/server/toolRegistryNotifyToolListChanged.test.ts
@@ -120,3 +120,49 @@ describe("ToolRegistry.notifyToolListChanged", () => {
     }
   });
 });
+
+describe("ToolRegistry session-binding release fan-out (issue #4611 Gap D)", () => {
+  test("fans a released session UUID out to every registered handler and honors unsubscribe", () => {
+    const first: string[] = [];
+    const second: string[] = [];
+    const unsubscribeFirst = ToolRegistry.registerSessionBindingReleaseHandler({
+      onSessionReleased: uuid => first.push(uuid),
+    });
+    const unsubscribeSecond = ToolRegistry.registerSessionBindingReleaseHandler({
+      onSessionReleased: uuid => second.push(uuid),
+    });
+    try {
+      ToolRegistry.notifySessionBindingReleased("session-1");
+      expect(first).toEqual(["session-1"]);
+      expect(second).toEqual(["session-1"]);
+
+      unsubscribeFirst();
+      ToolRegistry.notifySessionBindingReleased("session-2");
+      // The unsubscribed handler stops receiving events; the survivor keeps going.
+      expect(first).toEqual(["session-1"]);
+      expect(second).toEqual(["session-1", "session-2"]);
+    } finally {
+      unsubscribeFirst();
+      unsubscribeSecond();
+    }
+  });
+
+  test("one throwing handler does not block sibling handlers", () => {
+    const healthy: string[] = [];
+    const unsubscribeThrowing = ToolRegistry.registerSessionBindingReleaseHandler({
+      onSessionReleased: () => {
+        throw new Error("teardown boom");
+      },
+    });
+    const unsubscribeHealthy = ToolRegistry.registerSessionBindingReleaseHandler({
+      onSessionReleased: uuid => healthy.push(uuid),
+    });
+    try {
+      expect(() => ToolRegistry.notifySessionBindingReleased("session-1")).not.toThrow();
+      expect(healthy).toEqual(["session-1"]);
+    } finally {
+      unsubscribeThrowing();
+      unsubscribeHealthy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Isolate and correctly manage each daemon-proxy socket's session-scoped MCP capability profile and session binding across its full lifecycle, while continuing to serialize tool execution by physical device or session. Expanded during review to cover the whole session-capability + lifecycle surface (subsumes #4611 and implements the release signal tracked in #4673).

## Linked Issues

Closes [#4610](https://github.com/kaeawc/auto-mobile/issues/4610)
Closes [#4611](https://github.com/kaeawc/auto-mobile/issues/4611)
Closes [#4673](https://github.com/kaeawc/auto-mobile/issues/4673)

## What changed

- **Real session-released signal (replaces the TTL guess).** All daemon session releases (heartbeat, idle, plan) fan out through one `SessionManager` choke point to a new `SessionReleaseBroadcaster`; the socket server pushes a `notifications/session/released` frame to connected proxies, and `DaemonMcpProxy` clears its remembered binding the moment the bound session is actually released. The 30-min replay TTL is now only a dropped-frame backstop.
- **Capability enforcement across every routing path (#4611).** The MCP path now derives a capability session from `deviceId` (closing the explicit-deviceId bypass); derived device-label sessions are enforced as the **union** of base + derived (a label can re-enable a tool the base narrowed away — deliberate product decision); and routing vs. capability session are un-conflated so nested navigation/replay keep their derived identity.
- **Plan-release binding teardown (#4611).** A released plan session no longer keeps enforcing its stale profile: an injected teardown seam (and the release broadcaster) clear the server-side `SessionToolBinding` on real release.
- **Transport seeding.** Explicit-session `ide/getNavigationGraph` reads route to their own client instead of repurposing the bound transport; `listTools`/`resources` bind the session so a reconnect mid-discovery stays session-scoped.
- **Binding lifecycle correctness.** Admitted requests keep their bound client on mid-flight disconnect; the replay lease refreshes on implicit forwarded calls; idle cleanup re-arms after a queued-forward timeout; and a pre-handler plan rejection preserves the (still-live) binding, leaving clearing to the real release signal.

## Validation

- [x] `bun run typecheck` reports no new errors
- [x] `bun run lint` clean (no new violations)
- [x] `bun test test/daemon/ test/server/ test/features/toolCapabilities/ test/plan/` — 2766+ pass, 0 fail
- [x] Each fix added a test that fails before / passes after
- [x] New tests use fakes and `FakeTimer`; no new dependency
- [x] Rebased onto latest `main`

## Follow-ups

- Union derived-session semantics is deliberately permissive; revisit if least-privilege is later preferred.
