### PR TITLE
Desktop: WorkspaceShell scaffolding as the app root (device-column model + empty state)

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -4,17 +4,18 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import dev.jasonpearson.automobile.desktop.core.AutoMobileContent
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
-import dev.jasonpearson.automobile.desktop.core.platform.NoOpNotificationHandler
-import dev.jasonpearson.automobile.desktop.core.platform.SourceFileOpener
 import dev.jasonpearson.automobile.desktop.core.settings.SettingsProvider
 import dev.jasonpearson.automobile.desktop.core.shell.MenuBarActions
+import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceShell
+import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceViewModel
 import dev.jasonpearson.automobile.desktop.theme.AutoMobileTheme
 
 /**
@@ -33,31 +34,27 @@ private class ObservableSettingsProvider(private val delegate: SettingsProvider)
 }
 
 @Composable
-fun AutoMobileDesktopApp(menuBarActions: MenuBarActions = remember { MenuBarActions() }) {
+fun AutoMobileDesktopApp(
+  @Suppress("UNUSED_PARAMETER") menuBarActions: MenuBarActions = remember { MenuBarActions() }
+) {
   val graphSettings = LocalAutoMobileGraph.current.settingsProvider
   val settings = remember(graphSettings) { ObservableSettingsProvider(graphSettings) }
+  val scope = rememberCoroutineScope()
+  val workspaceViewModel = remember(scope) { WorkspaceViewModel(scope) }
+  val workspaceState by workspaceViewModel.state.collectAsState()
 
   AutoMobileTheme(themeMode = settings.themeMode) {
     Surface(
       modifier = Modifier.fillMaxSize(),
       color = MaterialTheme.colorScheme.background,
     ) {
-      AutoMobileContent(
-        settingsProvider = settings,
-        notificationHandler = NoOpNotificationHandler,
-        onOpenSource = { fileName, lineNumber, className ->
-          SourceFileOpener.open(
-            fileName,
-            lineNumber,
-            className,
-            settings.androidIde,
-            settings.iosIde,
-          )
-        },
-        menuBarActions = menuBarActions,
-        // The reference desktop client opts into device control (issue #3347): a click on the live
-        // layout screen taps the device via the daemon. The IDE plugin leaves this off.
-        enableDeviceControl = true,
+      // Device-tab workspace is the desktop app root (replaces ThreePaneShell). AutoMobileContent
+      // is retained and still used by the IDE plugin; dashboards return as workspace facets in
+      // follow-up PRs. menuBarActions is plumbed for later re-wiring once facets/panes exist.
+      WorkspaceShell(
+        state = workspaceState,
+        onAction = workspaceViewModel::onAction,
+        onOpenPicker = workspaceViewModel::openPicker,
       )
     }
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceModels.kt
@@ -1,0 +1,50 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+/** Platform of an observed device, with the emoji used in its column-header chip. */
+enum class Platform(val emoji: String) {
+  Android("🤖"), // 🤖
+  Ios("🍎"), // 🍎
+}
+
+/** Per-column interaction mode. The header toggle flips between the two (forgiving both ways). */
+enum class InteractionMode {
+  Input,
+  Inspect,
+}
+
+/**
+ * The per-device tools, shown as emoji in the column header. Emoji match the desktop app's sidebar
+ * facet vocabulary (see `AutoMobileContent`/`AppIcons`). There is no separate "Bug" tool — bug
+ * reporting lives inside [Failures].
+ */
+enum class Tool(val icon: String, val label: String) {
+  Navigation("🧭", "Navigation"), // 🧭
+  Logs("📄", "Logs"), // 📄
+  Storage("💾", "Storage"), // 💾
+  Network("🌐", "Network"), // 🌐
+  Test("🧪", "Test"), // 🧪
+  Failures("💥", "Failures"), // 💥
+  Performance("⚡", "Performance"), // ⚡
+}
+
+/** High-level health rollup shown as the single status dot in the top bar. */
+enum class WorkspaceStatus {
+  Green,
+  Yellow,
+  Red,
+}
+
+/**
+ * One observed device rendered as a column. Identity (name + platform) lives here — there is no
+ * separate device-tab bar. A device is either observed (present as a column) or not; there is no
+ * minimized state.
+ */
+data class DeviceColumn(
+  val deviceId: String,
+  val name: String,
+  val platform: Platform,
+  val mode: InteractionMode = InteractionMode.Input,
+  val activeTool: Tool? = null,
+  val shrunk: Boolean = false,
+  val locked: Boolean = false,
+)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -1,0 +1,244 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+private val StatusGreen = Color(0xFF40C057)
+private val StatusYellow = Color(0xFFF0C000)
+private val StatusRed = Color(0xFFFA5252)
+private val Accent = Color(0xFF4DABF7)
+
+/**
+ * Root of the device-tab workspace. Device identity lives in each column header (no top tab bar); a
+ * device is observed (a column) or not. This PR lands the shell, the empty state, and the column
+ * chrome; real streams, emulator controls, facets, and the picker arrive in later PRs.
+ */
+@Composable
+fun WorkspaceShell(
+  state: WorkspaceUiState,
+  onAction: (WorkspaceAction) -> Unit,
+  onOpenPicker: () -> Unit,
+  status: WorkspaceStatus = WorkspaceStatus.Green,
+  modifier: Modifier = Modifier,
+) {
+  Column(modifier.fillMaxSize()) {
+    TopBar(status = status, onOpenPicker = onOpenPicker)
+    when (state) {
+      is WorkspaceUiState.Empty -> EmptyState(onOpenPicker, Modifier.weight(1f).fillMaxWidth())
+      is WorkspaceUiState.Content ->
+        Row(Modifier.weight(1f).fillMaxWidth()) {
+          state.columns.forEach { column ->
+            DeviceColumnView(
+              column = column,
+              focused = column.deviceId == state.focusedDeviceId,
+              onAction = onAction,
+              modifier = Modifier.weight(1f).fillMaxHeight(),
+            )
+          }
+        }
+    }
+  }
+}
+
+@Composable
+private fun TopBar(status: WorkspaceStatus, onOpenPicker: () -> Unit) {
+  Row(
+    modifier =
+      Modifier.fillMaxWidth()
+        .height(40.dp)
+        .background(MaterialTheme.colorScheme.surfaceVariant)
+        .padding(horizontal = 12.dp),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Row(
+      modifier =
+        Modifier.clickable { onOpenPicker() }
+          .semantics { contentDescription = "Devices" }
+          .padding(horizontal = 8.dp, vertical = 4.dp),
+      verticalAlignment = Alignment.CenterVertically,
+    ) {
+      Text("Devices", style = MaterialTheme.typography.labelLarge)
+      Text("  +", color = Accent, fontWeight = FontWeight.Bold)
+    }
+    Spacer(Modifier.weight(1f))
+    Box(
+      modifier =
+        Modifier.size(12.dp).background(status.color(), CircleShape).semantics {
+          contentDescription = "Status: ${status.name}"
+        }
+    )
+  }
+}
+
+@Composable
+private fun EmptyState(onOpenPicker: () -> Unit, modifier: Modifier) {
+  Column(
+    modifier = modifier,
+    verticalArrangement = Arrangement.Center,
+    horizontalAlignment = Alignment.CenterHorizontally,
+  ) {
+    Text(
+      "No devices observed",
+      style = MaterialTheme.typography.headlineSmall,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Spacer(Modifier.height(12.dp))
+    Box(
+      modifier =
+        Modifier.clickable { onOpenPicker() }
+          .semantics { contentDescription = "Open Devices" }
+          .background(Accent, RoundedCornerShape(6.dp))
+          .padding(horizontal = 20.dp, vertical = 10.dp)
+    ) {
+      Text("Open Devices", color = Color.White)
+    }
+  }
+}
+
+@Composable
+private fun DeviceColumnView(
+  column: DeviceColumn,
+  focused: Boolean,
+  onAction: (WorkspaceAction) -> Unit,
+  modifier: Modifier,
+) {
+  Column(
+    modifier =
+      modifier.border(
+        width = if (focused) 2.dp else 1.dp,
+        color = if (focused) Accent else MaterialTheme.colorScheme.outlineVariant,
+      )
+  ) {
+    DeviceColumnHeader(column, onAction)
+    // placeholder stream area — real WebRTC stream + emulator controls land in a later PR
+    Box(
+      modifier =
+        Modifier.weight(1f).fillMaxWidth().background(MaterialTheme.colorScheme.surfaceVariant),
+      contentAlignment = Alignment.Center,
+    ) {
+      Text("stream", color = MaterialTheme.colorScheme.outline)
+    }
+  }
+}
+
+@Composable
+private fun DeviceColumnHeader(column: DeviceColumn, onAction: (WorkspaceAction) -> Unit) {
+  Row(
+    modifier =
+      Modifier.fillMaxWidth()
+        .height(34.dp)
+        .background(MaterialTheme.colorScheme.surface)
+        .padding(horizontal = 8.dp),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Text(column.platform.emoji)
+    Spacer(Modifier.width(6.dp))
+    Text(column.name, style = MaterialTheme.typography.labelLarge)
+    Spacer(Modifier.width(10.dp))
+    ModeToggle(column, onAction)
+    Spacer(Modifier.weight(1f))
+    Tool.entries.forEach { tool ->
+      Glyph(
+        text = tool.icon,
+        description = tool.label,
+        active = column.activeTool == tool,
+        onClick = { onAction(WorkspaceAction.SelectTool(column.deviceId, tool)) },
+      )
+    }
+    Spacer(Modifier.width(4.dp))
+    Glyph(
+      text = "⤡",
+      description = "Shrink ${column.name}",
+      active = column.shrunk,
+      onClick = { onAction(WorkspaceAction.ToggleShrink(column.deviceId)) },
+    )
+    Glyph(
+      text = "✕",
+      description = "Close ${column.name}",
+      active = false,
+      onClick = { onAction(WorkspaceAction.CloseDevice(column.deviceId)) },
+    )
+  }
+}
+
+@Composable
+private fun ModeToggle(column: DeviceColumn, onAction: (WorkspaceAction) -> Unit) {
+  Row {
+    ToggleCell(
+      text = "✋",
+      description = "Input mode",
+      active = column.mode == InteractionMode.Input,
+      onClick = { onAction(WorkspaceAction.SetMode(column.deviceId, InteractionMode.Input)) },
+    )
+    ToggleCell(
+      text = "🔍",
+      description = "Inspect mode",
+      active = column.mode == InteractionMode.Inspect,
+      onClick = { onAction(WorkspaceAction.SetMode(column.deviceId, InteractionMode.Inspect)) },
+    )
+  }
+}
+
+@Composable
+private fun ToggleCell(text: String, description: String, active: Boolean, onClick: () -> Unit) {
+  Box(
+    modifier =
+      Modifier.clickable(onClick = onClick)
+        .semantics { contentDescription = description }
+        .background(
+          if (active) Accent else Color.Transparent,
+          RoundedCornerShape(4.dp),
+        )
+        .padding(horizontal = 6.dp, vertical = 3.dp)
+  ) {
+    Text(text)
+  }
+}
+
+@Composable
+private fun Glyph(text: String, description: String, active: Boolean, onClick: () -> Unit) {
+  Box(
+    modifier =
+      Modifier.clickable(onClick = onClick)
+        .semantics { contentDescription = description }
+        .background(
+          if (active) Accent.copy(alpha = 0.35f) else Color.Transparent,
+          RoundedCornerShape(4.dp),
+        )
+        .padding(horizontal = 4.dp, vertical = 2.dp)
+  ) {
+    Text(text)
+  }
+}
+
+private fun WorkspaceStatus.color(): Color =
+  when (this) {
+    WorkspaceStatus.Green -> StatusGreen
+    WorkspaceStatus.Yellow -> StatusYellow
+    WorkspaceStatus.Red -> StatusRed
+  }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModel.kt
@@ -1,0 +1,116 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+private val LOG = LoggerFactory.getLogger("WorkspaceViewModel")
+
+/** UI state for the device-tab workspace. */
+sealed interface WorkspaceUiState {
+  /** No devices observed yet — the launch surface until the picker opens some. */
+  data object Empty : WorkspaceUiState
+
+  data class Content(
+    val columns: List<DeviceColumn>,
+    val focusedDeviceId: String?,
+  ) : WorkspaceUiState
+}
+
+/** Actions the workspace can dispatch. Downstream behavior (streams, facets) lands in later PRs. */
+sealed interface WorkspaceAction {
+  data class ObserveDevice(val column: DeviceColumn) : WorkspaceAction
+
+  data class CloseDevice(val deviceId: String) : WorkspaceAction
+
+  data class FocusDevice(val deviceId: String) : WorkspaceAction
+
+  data class SetMode(val deviceId: String, val mode: InteractionMode) : WorkspaceAction
+
+  data class ToggleShrink(val deviceId: String) : WorkspaceAction
+
+  data class SelectTool(val deviceId: String, val tool: Tool?) : WorkspaceAction
+}
+
+/** One-shot effects emitted by the workspace. */
+sealed interface WorkspaceEffect {
+  /** Open the device picker. Wired to a real screen in a later PR. */
+  data object OpenPicker : WorkspaceEffect
+}
+
+/**
+ * ViewModel for the device-tab workspace. Owns the set of observed device columns and which one is
+ * focused, independent of Compose. Mirrors the repo's sealed [WorkspaceUiState]/[WorkspaceAction]/
+ * [WorkspaceEffect] + [StateFlow]/[Channel] convention (cf. `NavigationViewModel`).
+ */
+class WorkspaceViewModel(private val scope: CoroutineScope) {
+  private val _state = MutableStateFlow<WorkspaceUiState>(WorkspaceUiState.Empty)
+  val state: StateFlow<WorkspaceUiState> = _state.asStateFlow()
+
+  private val _effect = Channel<WorkspaceEffect>(Channel.BUFFERED)
+  val effect = _effect.receiveAsFlow()
+
+  fun onAction(action: WorkspaceAction) {
+    when (action) {
+      is WorkspaceAction.ObserveDevice -> observe(action.column)
+      is WorkspaceAction.CloseDevice -> close(action.deviceId)
+      is WorkspaceAction.FocusDevice -> focus(action.deviceId)
+      is WorkspaceAction.SetMode -> mutate(action.deviceId) { it.copy(mode = action.mode) }
+      is WorkspaceAction.ToggleShrink -> mutate(action.deviceId) { it.copy(shrunk = !it.shrunk) }
+      is WorkspaceAction.SelectTool -> mutate(action.deviceId) { it.copy(activeTool = action.tool) }
+    }
+  }
+
+  /** Emit [WorkspaceEffect.OpenPicker]; the picker screen itself arrives in a later PR. */
+  fun openPicker() {
+    scope.launch { _effect.send(WorkspaceEffect.OpenPicker) }
+  }
+
+  private fun observe(column: DeviceColumn) {
+    _state.update { current ->
+      val columns = (current as? WorkspaceUiState.Content)?.columns ?: emptyList()
+      if (columns.any { it.deviceId == column.deviceId }) {
+        LOG.debug("Device ${column.deviceId} already observed; refocusing")
+        WorkspaceUiState.Content(columns, focusedDeviceId = column.deviceId)
+      } else {
+        WorkspaceUiState.Content(columns + column, focusedDeviceId = column.deviceId)
+      }
+    }
+  }
+
+  private fun close(deviceId: String) {
+    _state.update { current ->
+      val content = current as? WorkspaceUiState.Content ?: return@update current
+      val remaining = content.columns.filterNot { it.deviceId == deviceId }
+      if (remaining.isEmpty()) {
+        WorkspaceUiState.Empty
+      } else {
+        val focus =
+          if (content.focusedDeviceId == deviceId) remaining.first().deviceId
+          else content.focusedDeviceId
+        WorkspaceUiState.Content(remaining, focusedDeviceId = focus)
+      }
+    }
+  }
+
+  private fun focus(deviceId: String) {
+    _state.update { current ->
+      (current as? WorkspaceUiState.Content)?.copy(focusedDeviceId = deviceId) ?: current
+    }
+  }
+
+  private fun mutate(deviceId: String, transform: (DeviceColumn) -> DeviceColumn) {
+    _state.update { current ->
+      val content = current as? WorkspaceUiState.Content ?: return@update current
+      content.copy(
+        columns = content.columns.map { if (it.deviceId == deviceId) transform(it) else it }
+      )
+    }
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
@@ -1,0 +1,83 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class WorkspaceShellUiTest {
+
+  private fun col(id: String, name: String, platform: Platform = Platform.Android) =
+    DeviceColumn(deviceId = id, name = name, platform = platform)
+
+  @Test
+  fun `empty state prompts to open Devices`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(state = WorkspaceUiState.Empty, onAction = {}, onOpenPicker = {})
+      }
+    }
+    onNodeWithText("No devices observed", substring = true).assertIsDisplayed()
+    onNodeWithContentDescription("Open Devices").assertIsDisplayed()
+  }
+
+  @Test
+  fun `empty state Open Devices click invokes callback`() = runComposeUiTest {
+    var opened = false
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(
+          state = WorkspaceUiState.Empty,
+          onAction = {},
+          onOpenPicker = { opened = true },
+        )
+      }
+    }
+    onNodeWithContentDescription("Open Devices").performClick()
+    assertTrue(opened)
+  }
+
+  @Test
+  fun `content renders the device chip header with tools and close`() = runComposeUiTest {
+    val state =
+      WorkspaceUiState.Content(columns = listOf(col("a", "Pixel 8")), focusedDeviceId = "a")
+    setContent { MaterialTheme { WorkspaceShell(state = state, onAction = {}, onOpenPicker = {}) } }
+    onNodeWithText("Pixel 8").assertIsDisplayed()
+    onNodeWithContentDescription("Input mode").assertIsDisplayed()
+    onNodeWithContentDescription("Inspect mode").assertIsDisplayed()
+    onNodeWithContentDescription("Navigation").assertIsDisplayed()
+    onNodeWithContentDescription("Performance").assertIsDisplayed()
+    onNodeWithContentDescription("Close Pixel 8").assertIsDisplayed()
+  }
+
+  @Test
+  fun `clicking close emits CloseDevice for that column`() = runComposeUiTest {
+    var action: WorkspaceAction? = null
+    val state =
+      WorkspaceUiState.Content(columns = listOf(col("a", "Pixel 8")), focusedDeviceId = "a")
+    setContent {
+      MaterialTheme { WorkspaceShell(state = state, onAction = { action = it }, onOpenPicker = {}) }
+    }
+    onNodeWithContentDescription("Close Pixel 8").performClick()
+    assertEquals(WorkspaceAction.CloseDevice("a"), action)
+  }
+
+  @Test
+  fun `two devices render both chips`() = runComposeUiTest {
+    val state =
+      WorkspaceUiState.Content(
+        columns = listOf(col("a", "Pixel 8"), col("b", "iPhone 15", Platform.Ios)),
+        focusedDeviceId = "a",
+      )
+    setContent { MaterialTheme { WorkspaceShell(state = state, onAction = {}, onOpenPicker = {}) } }
+    onNodeWithText("Pixel 8").assertIsDisplayed()
+    onNodeWithText("iPhone 15").assertIsDisplayed()
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModelTest.kt
@@ -1,0 +1,109 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WorkspaceViewModelTest {
+
+  private val testDispatcher = UnconfinedTestDispatcher()
+  private val testScope = TestScope(testDispatcher)
+
+  private fun column(id: String, platform: Platform = Platform.Android) =
+    DeviceColumn(deviceId = id, name = "Device $id", platform = platform)
+
+  @Test
+  fun `initial state is Empty`() = testScope.runTest {
+    val vm = WorkspaceViewModel(this)
+    assertTrue(vm.state.value is WorkspaceUiState.Empty)
+  }
+
+  @Test
+  fun `observing a device transitions Empty to Content and focuses it`() = testScope.runTest {
+    val vm = WorkspaceViewModel(this)
+    vm.onAction(WorkspaceAction.ObserveDevice(column("a")))
+    val state = vm.state.value
+    assertTrue("Expected Content but was $state", state is WorkspaceUiState.Content)
+    state as WorkspaceUiState.Content
+    assertEquals(listOf("a"), state.columns.map { it.deviceId })
+    assertEquals("a", state.focusedDeviceId)
+  }
+
+  @Test
+  fun `observing a second device appends a column and focuses it`() = testScope.runTest {
+    val vm = WorkspaceViewModel(this)
+    vm.onAction(WorkspaceAction.ObserveDevice(column("a")))
+    vm.onAction(WorkspaceAction.ObserveDevice(column("b")))
+    val state = vm.state.value as WorkspaceUiState.Content
+    assertEquals(listOf("a", "b"), state.columns.map { it.deviceId })
+    assertEquals("b", state.focusedDeviceId)
+  }
+
+  @Test
+  fun `observing an already-observed device does not duplicate it but refocuses`() =
+    testScope.runTest {
+      val vm = WorkspaceViewModel(this)
+      vm.onAction(WorkspaceAction.ObserveDevice(column("a")))
+      vm.onAction(WorkspaceAction.ObserveDevice(column("b")))
+      vm.onAction(WorkspaceAction.ObserveDevice(column("a")))
+      val state = vm.state.value as WorkspaceUiState.Content
+      assertEquals(listOf("a", "b"), state.columns.map { it.deviceId })
+      assertEquals("a", state.focusedDeviceId)
+    }
+
+  @Test
+  fun `closing a column removes it and refocuses when the focused one closes`() =
+    testScope.runTest {
+      val vm = WorkspaceViewModel(this)
+      vm.onAction(WorkspaceAction.ObserveDevice(column("a")))
+      vm.onAction(WorkspaceAction.ObserveDevice(column("b")))
+      vm.onAction(WorkspaceAction.CloseDevice("b"))
+      val state = vm.state.value as WorkspaceUiState.Content
+      assertEquals(listOf("a"), state.columns.map { it.deviceId })
+      assertEquals("a", state.focusedDeviceId)
+    }
+
+  @Test
+  fun `closing the last column returns to Empty`() = testScope.runTest {
+    val vm = WorkspaceViewModel(this)
+    vm.onAction(WorkspaceAction.ObserveDevice(column("a")))
+    vm.onAction(WorkspaceAction.CloseDevice("a"))
+    assertTrue(vm.state.value is WorkspaceUiState.Empty)
+  }
+
+  @Test
+  fun `closing an unfocused column keeps the current focus`() = testScope.runTest {
+    val vm = WorkspaceViewModel(this)
+    vm.onAction(WorkspaceAction.ObserveDevice(column("a")))
+    vm.onAction(WorkspaceAction.ObserveDevice(column("b")))
+    vm.onAction(WorkspaceAction.FocusDevice("a"))
+    vm.onAction(WorkspaceAction.CloseDevice("b"))
+    val state = vm.state.value as WorkspaceUiState.Content
+    assertEquals("a", state.focusedDeviceId)
+  }
+
+  @Test
+  fun `setMode toggleShrink and selectTool mutate only the target column`() = testScope.runTest {
+    val vm = WorkspaceViewModel(this)
+    vm.onAction(WorkspaceAction.ObserveDevice(column("a")))
+    vm.onAction(WorkspaceAction.ObserveDevice(column("b")))
+    vm.onAction(WorkspaceAction.SetMode("a", InteractionMode.Inspect))
+    vm.onAction(WorkspaceAction.ToggleShrink("a"))
+    vm.onAction(WorkspaceAction.SelectTool("a", Tool.Logs))
+    val state = vm.state.value as WorkspaceUiState.Content
+    val a = state.columns.first { it.deviceId == "a" }
+    val b = state.columns.first { it.deviceId == "b" }
+    assertEquals(InteractionMode.Inspect, a.mode)
+    assertTrue(a.shrunk)
+    assertEquals(Tool.Logs, a.activeTool)
+    assertEquals(InteractionMode.Input, b.mode)
+    assertTrue(!b.shrunk)
+    assertNull(b.activeTool)
+  }
+}


### PR DESCRIPTION
## Summary

First PR of the device-tab workspace redesign. Replaces `ThreePaneShell` as the **desktop app root** with a new `WorkspaceShell` scaffold, per the wireframed UX. Scaffolding only — real streams, emulator controls, the device picker, interaction behavior, facets, and per-tool diff land in follow-up PRs.

`AutoMobileContent`, `ThreePaneShell`, and the dashboards are **retained unchanged** (the IDE plugin still uses `AutoMobileContent`) and will return as workspace facets in follow-ups.

## Changes

- **`core/workspace/WorkspaceModels.kt`** — `DeviceColumn`, `Platform` (🤖/🍎), `InteractionMode {Input, Inspect}`, `Tool` (emoji: 🧭📄💾🌐🧪💥⚡; no separate Bug tool — bug reporting will live in Failures), `WorkspaceStatus`.
- **`core/workspace/WorkspaceViewModel.kt`** — sealed `WorkspaceUiState {Empty | Content(columns, focusedDeviceId)}`, `WorkspaceAction`, `WorkspaceEffect {OpenPicker}`; `StateFlow` + `Channel`, injected `CoroutineScope` (mirrors `NavigationViewModel`).
- **`core/workspace/WorkspaceShell.kt`** — top chrome (inert Devices launcher + single status dot), columns-only layout, empty state, per-column header chip (platform + name + hand↔magnifier toggle + emoji tool row + `⤡` shrink + `✕` close) over a placeholder stream box. No `LIVE` labels; a device is observed or not (no minimize).
- **`AutoMobileDesktopApp.kt`** — renders `WorkspaceShell` instead of `AutoMobileContent`.

## Testing

- `WorkspaceViewModelTest` (8 cases): Empty→Content on observe, append+focus, no-duplicate refocus, close removes + refocuses, close last → Empty, close-unfocused keeps focus, per-column mutation isolation.
- `WorkspaceShellUiTest` (5 cases): empty-state prompt + `Open Devices` click; content renders chip/toggle/tools/close; close emits `CloseDevice`; two devices render both chips.
- `./android/gradlew -p android :desktop-core:test :desktop-app:test` green (full desktop-core suite, no regressions). `:desktop-app:compileKotlin` green. ktfmt validation green tree-wide.

## Acceptance criteria (issue #4663)

- [x] `WorkspaceShell` is the app root; launches to the empty state.
- [x] `WorkspaceViewModel` with sealed state/action/effect + injected scope.
- [x] Column header renders per design (chip, toggle, emoji tools, `⤡`, `✕`) from `DeviceColumn`.
- [x] Single status dot replaces per-service sidebar chips.
- [x] `ThreePaneShell` no longer the desktop-app root; its code + dashboards retained for reuse.
- [x] ViewModel unit tests + Compose UI tests for empty and content states.
- [x] ktfmt / build / desktop-core tests green.

## Notes / deliberate scope

The desktop app launches to an empty workspace (dashboards unreachable **there**) until the follow-up facet PRs; the IDE plugin is unaffected. The Devices launcher is intentionally inert this PR (picker is a later PR).

Closes #4663
