### PR TITLE
docs: wire apple-signing-setup guide into MkDocs nav (fix orphaned-doc CI failure)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -208,6 +208,7 @@ nav:
   - 'Contributing':
       - 'Overview': contributing.md
       - 'Standard Library First': contributing/stdlib-first.md
+      - 'Apple Signing & Notarization': release/apple-signing-setup.md
       - 'Dependency Decisions':
           - 'fast-check': decisions/fast-check.md
       - 'Codex Automation Thread Report': codex-automation-thread-spam-report.md


### PR DESCRIPTION
## Summary

Base-health fix. #4664 added `docs/release/apple-signing-setup.md` but did not add it to the MkDocs nav, so `scripts/validate-mkdocs-nav.ts` flags it as **orphaned** and the `mkdocs-nav` check fails on **Fast Validation**, **BATS Shell Tests**, and **Shell Tests** for every open PR. `main`'s tip merged via `[skip ci]`, so it was never caught on `main`.

## Change

Add the guide to the nav under **Contributing** as "Apple Signing & Notarization".

## Testing

- `bash scripts/validate_mkdocs_nav.sh` → exit 0 (was exit 1: `Orphaned files: release/apple-signing-setup.md`).
- `bats test/bats/portability-cosmetic.bats -f "resolves the repository from its own path"` → `ok`.

Unblocks the desktop-workspace PR sequence (#4667) and any other open PR.
