### PR TITLE
Desktop workspace: full-screen device picker (filter rail + fuzzy search + multi-select observe)

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -12,10 +13,17 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
+import dev.jasonpearson.automobile.desktop.core.mcp.DaemonMcpResourceClient
 import dev.jasonpearson.automobile.desktop.core.settings.SettingsProvider
 import dev.jasonpearson.automobile.desktop.core.shell.MenuBarActions
+import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceAction
+import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceEffect
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceShell
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceViewModel
+import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePicker
+import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerAction
+import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerEffect
+import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerViewModel
 import dev.jasonpearson.automobile.desktop.theme.AutoMobileTheme
 
 /**
@@ -37,11 +45,36 @@ private class ObservableSettingsProvider(private val delegate: SettingsProvider)
 fun AutoMobileDesktopApp(
   @Suppress("UNUSED_PARAMETER") menuBarActions: MenuBarActions = remember { MenuBarActions() }
 ) {
-  val graphSettings = LocalAutoMobileGraph.current.settingsProvider
-  val settings = remember(graphSettings) { ObservableSettingsProvider(graphSettings) }
+  val graph = LocalAutoMobileGraph.current
+  val settings = remember(graph) { ObservableSettingsProvider(graph.settingsProvider) }
   val scope = rememberCoroutineScope()
   val workspaceViewModel = remember(scope) { WorkspaceViewModel(scope) }
   val workspaceState by workspaceViewModel.state.collectAsState()
+
+  val resourceClient = remember(graph) { DaemonMcpResourceClient(graph.autoMobileClient) }
+  val pickerViewModel =
+    remember(scope, resourceClient) { DevicePickerViewModel(resourceClient, scope) }
+  val pickerState by pickerViewModel.state.collectAsState()
+  var pickerOpen by remember { mutableStateOf(false) }
+
+  // OpenPicker (from the empty state or the Devices launcher) shows the picker; observing selected
+  // devices turns them into workspace columns.
+  LaunchedEffect(workspaceViewModel) {
+    workspaceViewModel.effect.collect { effect ->
+      if (effect is WorkspaceEffect.OpenPicker) {
+        pickerViewModel.onAction(DevicePickerAction.Refresh)
+        pickerOpen = true
+      }
+    }
+  }
+  LaunchedEffect(pickerViewModel) {
+    pickerViewModel.effect.collect { effect ->
+      if (effect is DevicePickerEffect.Observe) {
+        effect.columns.forEach { workspaceViewModel.onAction(WorkspaceAction.ObserveDevice(it)) }
+        pickerOpen = false
+      }
+    }
+  }
 
   AutoMobileTheme(themeMode = settings.themeMode) {
     Surface(
@@ -51,11 +84,19 @@ fun AutoMobileDesktopApp(
       // Device-tab workspace is the desktop app root (replaces ThreePaneShell). AutoMobileContent
       // is retained and still used by the IDE plugin; dashboards return as workspace facets in
       // follow-up PRs. menuBarActions is plumbed for later re-wiring once facets/panes exist.
-      WorkspaceShell(
-        state = workspaceState,
-        onAction = workspaceViewModel::onAction,
-        onOpenPicker = workspaceViewModel::openPicker,
-      )
+      if (pickerOpen) {
+        DevicePicker(
+          state = pickerState,
+          onAction = pickerViewModel::onAction,
+          onClose = { pickerOpen = false },
+        )
+      } else {
+        WorkspaceShell(
+          state = workspaceState,
+          onAction = workspaceViewModel::onAction,
+          onOpenPicker = workspaceViewModel::openPicker,
+        )
+      }
     }
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/DeviceModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/mcp/DeviceModels.kt
@@ -84,6 +84,9 @@ data class DeviceImageInfo(
   val isAvailable: Boolean? = null,
   val iosVersion: String? = null,
   val deviceType: String? = null,
+  // CPU architecture (e.g. "arm64", "x86_64"). Already emitted by the iOS images resource;
+  // Android abi is not yet plumbed through the daemon (tracked as a follow-up).
+  val architecture: String? = null,
 )
 
 /** Parser for device resource responses */

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePicker.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePicker.kt
@@ -1,0 +1,299 @@
+package dev.jasonpearson.automobile.desktop.core.workspace.picker
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import dev.jasonpearson.automobile.desktop.core.workspace.Platform
+
+private val Accent = Color(0xFF4DABF7)
+
+/**
+ * Full-screen device picker. Stateless over [DevicePickerUiState] with hoisted [onAction]; the
+ * workspace hosts it and turns the Observe effect into columns.
+ */
+@Composable
+fun DevicePicker(
+  state: DevicePickerUiState,
+  onAction: (DevicePickerAction) -> Unit,
+  onClose: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  Column(modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
+    when (state) {
+      is DevicePickerUiState.Loading -> Centered("Loading devices…")
+      is DevicePickerUiState.Error ->
+        Centered("Couldn't load devices: ${state.message}") {
+          Button(onClick = { onAction(DevicePickerAction.Refresh) }) { Text("Retry") }
+        }
+      is DevicePickerUiState.Content -> Content(state, onAction, onClose)
+    }
+  }
+}
+
+@Composable
+private fun Centered(message: String, extra: @Composable (() -> Unit)? = null) {
+  Column(
+    Modifier.fillMaxSize(),
+    verticalArrangement = Arrangement.Center,
+    horizontalAlignment = Alignment.CenterHorizontally,
+  ) {
+    Text(message, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    if (extra != null) {
+      Spacer(Modifier.height(12.dp))
+      extra()
+    }
+  }
+}
+
+@Composable
+private fun Content(
+  content: DevicePickerUiState.Content,
+  onAction: (DevicePickerAction) -> Unit,
+  onClose: () -> Unit,
+) {
+  Row(Modifier.fillMaxSize()) {
+    FilterRail(content, onAction)
+    Column(Modifier.weight(1f).fillMaxHeight()) {
+      HeaderRow(content, onAction, onClose)
+      ActiveChips(content.filters, onAction)
+      DeviceGrid(content, onAction)
+    }
+  }
+}
+
+@Composable
+private fun FilterRail(
+  content: DevicePickerUiState.Content,
+  onAction: (DevicePickerAction) -> Unit,
+) {
+  Column(
+    Modifier.width(240.dp)
+      .fillMaxHeight()
+      .background(MaterialTheme.colorScheme.surfaceVariant)
+      .padding(12.dp)
+  ) {
+    OutlinedTextField(
+      value = content.filters.query,
+      onValueChange = { onAction(DevicePickerAction.SetQuery(it)) },
+      label = { Text("Filter") },
+      singleLine = true,
+      modifier = Modifier.fillMaxWidth().semantics { contentDescription = "Filter search" },
+    )
+    Spacer(Modifier.height(8.dp))
+    LazyColumn(Modifier.fillMaxSize()) {
+      for (dimension in FilterDimension.entries) {
+        val opts = options(content.devices, content.filters, dimension)
+        if (opts.isEmpty()) continue
+        item(key = "hdr-${dimension.name}") {
+          Text(
+            dimension.title.uppercase(),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = 10.dp, bottom = 4.dp),
+          )
+        }
+        items(opts, key = { "${dimension.name}-${it.value}" }) { opt ->
+          OptionRow(opt) { toggle(dimension, opt.value, onAction) }
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun OptionRow(opt: FilterOption, onClick: () -> Unit) {
+  Row(
+    modifier =
+      Modifier.fillMaxWidth()
+        .clickable(onClick = onClick)
+        .semantics {
+          contentDescription = "${if (opt.selected) "Deselect" else "Select"} filter ${opt.label}"
+        }
+        .padding(vertical = 4.dp),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Box(
+      Modifier.width(16.dp)
+        .height(16.dp)
+        .background(
+          if (opt.selected) Accent else MaterialTheme.colorScheme.surface,
+          RoundedCornerShape(3.dp),
+        )
+    ) {
+      if (opt.selected) Text("✓", color = Color.White, style = MaterialTheme.typography.labelSmall)
+    }
+    Spacer(Modifier.width(8.dp))
+    Text(opt.label, modifier = Modifier.weight(1f), style = MaterialTheme.typography.bodyMedium)
+    Text(opt.count.toString(), color = MaterialTheme.colorScheme.onSurfaceVariant)
+  }
+}
+
+@Composable
+private fun ActiveChips(filters: PickerFilters, onAction: (DevicePickerAction) -> Unit) {
+  val chips = buildList {
+    filters.states.forEach { add(it.label() to { onAction(DevicePickerAction.ToggleState(it)) }) }
+    filters.platforms.forEach {
+      add(it.label() to { onAction(DevicePickerAction.TogglePlatform(it)) })
+    }
+    filters.osKeys.forEach { add(it to { onAction(DevicePickerAction.ToggleOs(it)) }) }
+    filters.architectures.forEach { add(it to { onAction(DevicePickerAction.ToggleArch(it)) }) }
+  }
+  if (chips.isEmpty()) return
+  Row(Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)) {
+    chips.forEach { (label, remove) ->
+      Row(
+        modifier =
+          Modifier.padding(end = 8.dp)
+            .clickable(onClick = remove)
+            .semantics { contentDescription = "Remove filter $label" }
+            .background(Accent, RoundedCornerShape(4.dp))
+            .padding(horizontal = 10.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+      ) {
+        Text(label, color = Color.White)
+        Text("  ✕", color = Color.White)
+      }
+    }
+  }
+}
+
+@Composable
+private fun HeaderRow(
+  content: DevicePickerUiState.Content,
+  onAction: (DevicePickerAction) -> Unit,
+  onClose: () -> Unit,
+) {
+  val count = content.selectedIds.size
+  Row(
+    modifier = Modifier.fillMaxWidth().padding(16.dp),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Text(
+      "Choose devices to observe",
+      style = MaterialTheme.typography.titleMedium,
+      fontWeight = FontWeight.SemiBold,
+    )
+    Spacer(Modifier.weight(1f))
+    Button(
+      onClick = { onAction(DevicePickerAction.ObserveSelected) },
+      enabled = count > 0,
+      modifier = Modifier.semantics { contentDescription = "Observe selected" },
+    ) {
+      Text(if (count > 0) "Observe ($count)" else "Observe")
+    }
+    Spacer(Modifier.width(8.dp))
+    Text(
+      "Close",
+      color = Accent,
+      modifier =
+        Modifier.clickable(onClick = onClose).semantics { contentDescription = "Close picker" },
+    )
+  }
+}
+
+@Composable
+private fun DeviceGrid(
+  content: DevicePickerUiState.Content,
+  onAction: (DevicePickerAction) -> Unit,
+) {
+  val devices = filteredDevices(content.devices, content.filters)
+  LazyVerticalGrid(
+    columns = GridCells.Adaptive(220.dp),
+    modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
+    horizontalArrangement = Arrangement.spacedBy(12.dp),
+    verticalArrangement = Arrangement.spacedBy(12.dp),
+  ) {
+    items(devices, key = { it.id }) { device ->
+      DeviceCard(
+        device = device,
+        selected = device.id in content.selectedIds,
+        onClick = { onAction(DevicePickerAction.ToggleSelect(device.id)) },
+      )
+    }
+  }
+}
+
+@Composable
+private fun DeviceCard(device: PickerDevice, selected: Boolean, onClick: () -> Unit) {
+  val booted = device.state == DeviceState.Booted
+  Column(
+    modifier =
+      Modifier.fillMaxWidth()
+        .border(
+          width = if (selected) 2.dp else 1.dp,
+          color = if (selected) Accent else MaterialTheme.colorScheme.outlineVariant,
+          shape = RoundedCornerShape(6.dp),
+        )
+        .then(if (booted) Modifier.clickable(onClick = onClick) else Modifier)
+        .semantics {
+          contentDescription =
+            if (booted) "Select ${device.name}" else "${device.name} (not booted)"
+        }
+        .padding(12.dp)
+  ) {
+    Text("${device.platform.emoji}  ${device.name}", style = MaterialTheme.typography.bodyLarge)
+    Spacer(Modifier.height(4.dp))
+    val meta =
+      listOfNotNull(
+          if (device.platform == Platform.Ios) "iOS" else "Android",
+          device.osLabel,
+          device.architecture,
+          if (booted) "booted" else "shutdown",
+        )
+        .joinToString(" · ")
+    Text(
+      meta,
+      style = MaterialTheme.typography.bodySmall,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    if (!booted) {
+      Text(
+        "Boot to observe (soon)",
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.outline,
+      )
+    }
+  }
+}
+
+private fun toggle(
+  dimension: FilterDimension,
+  value: String,
+  onAction: (DevicePickerAction) -> Unit,
+) {
+  when (dimension) {
+    FilterDimension.State -> onAction(DevicePickerAction.ToggleState(DeviceState.valueOf(value)))
+    FilterDimension.Platform -> onAction(DevicePickerAction.TogglePlatform(Platform.valueOf(value)))
+    FilterDimension.OsVersion -> onAction(DevicePickerAction.ToggleOs(value))
+    FilterDimension.Architecture -> onAction(DevicePickerAction.ToggleArch(value))
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
@@ -6,7 +6,9 @@ import dev.jasonpearson.automobile.desktop.core.mcp.McpResourceClient
 import dev.jasonpearson.automobile.desktop.core.mcp.ResourceReadResult
 import dev.jasonpearson.automobile.desktop.core.workspace.DeviceColumn
 import dev.jasonpearson.automobile.desktop.core.workspace.Platform
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -14,6 +16,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 private val LOG = LoggerFactory.getLogger("DevicePickerViewModel")
 private const val BOOTED_URI = "automobile:devices/booted"
@@ -66,6 +69,7 @@ sealed interface DevicePickerEffect {
 class DevicePickerViewModel(
   private val resourceClient: McpResourceClient,
   private val scope: CoroutineScope,
+  private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
   private val _state = MutableStateFlow<DevicePickerUiState>(DevicePickerUiState.Loading)
   val state: StateFlow<DevicePickerUiState> = _state.asStateFlow()
@@ -100,16 +104,20 @@ class DevicePickerViewModel(
     _state.value = DevicePickerUiState.Loading
     scope.launch {
       try {
-        val booted =
-          (resourceClient.readResource(BOOTED_URI) as? ResourceReadResult.Success)?.let {
-            DeviceResourceParser.parseBootedDevices(it.content)?.devices
-          } ?: emptyList()
-        val images =
-          (resourceClient.readResource(IMAGES_URI) as? ResourceReadResult.Success)?.let {
-            DeviceResourceParser.parseDeviceImages(it.content)?.images
-          } ?: emptyList()
-        val devices = buildPickerDevices(booted, images)
-        LOG.info("Picker loaded ${devices.size} devices (${booted.size} booted)")
+        // Resource reads hit the daemon (blocking) — keep them off the UI thread.
+        val devices =
+          withContext(ioDispatcher) {
+            val booted =
+              (resourceClient.readResource(BOOTED_URI) as? ResourceReadResult.Success)?.let {
+                DeviceResourceParser.parseBootedDevices(it.content)?.devices
+              } ?: emptyList()
+            val images =
+              (resourceClient.readResource(IMAGES_URI) as? ResourceReadResult.Success)?.let {
+                DeviceResourceParser.parseDeviceImages(it.content)?.images
+              } ?: emptyList()
+            buildPickerDevices(booted, images)
+          }
+        LOG.info("Picker loaded ${devices.size} devices")
         _state.value = DevicePickerUiState.Content(devices)
       } catch (e: Exception) {
         LOG.warn("Failed to load picker devices: ${e.message}", e)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
@@ -1,0 +1,165 @@
+package dev.jasonpearson.automobile.desktop.core.workspace.picker
+
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import dev.jasonpearson.automobile.desktop.core.mcp.DeviceResourceParser
+import dev.jasonpearson.automobile.desktop.core.mcp.McpResourceClient
+import dev.jasonpearson.automobile.desktop.core.mcp.ResourceReadResult
+import dev.jasonpearson.automobile.desktop.core.workspace.DeviceColumn
+import dev.jasonpearson.automobile.desktop.core.workspace.Platform
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+private val LOG = LoggerFactory.getLogger("DevicePickerViewModel")
+private const val BOOTED_URI = "automobile:devices/booted"
+private const val IMAGES_URI = "automobile:devices/images"
+
+sealed interface DevicePickerUiState {
+  data object Loading : DevicePickerUiState
+
+  data class Content(
+    val devices: List<PickerDevice>,
+    val filters: PickerFilters = PickerFilters(),
+    val selectedIds: Set<String> = emptySet(),
+  ) : DevicePickerUiState
+
+  data class Error(val message: String) : DevicePickerUiState
+}
+
+sealed interface DevicePickerAction {
+  data class ToggleState(val state: DeviceState) : DevicePickerAction
+
+  data class TogglePlatform(val platform: Platform) : DevicePickerAction
+
+  data class ToggleOs(val osKey: String) : DevicePickerAction
+
+  data class ToggleArch(val arch: String) : DevicePickerAction
+
+  data class SetQuery(val query: String) : DevicePickerAction
+
+  data class ClearFilter(val dimension: FilterDimension) : DevicePickerAction
+
+  data class ToggleSelect(val deviceId: String) : DevicePickerAction
+
+  data object ClearSelection : DevicePickerAction
+
+  data object ObserveSelected : DevicePickerAction
+
+  data object Refresh : DevicePickerAction
+}
+
+sealed interface DevicePickerEffect {
+  /** Observe the selected (booted) devices — the workspace turns these into columns. */
+  data class Observe(val columns: List<DeviceColumn>) : DevicePickerEffect
+}
+
+/**
+ * ViewModel for the device picker. Reads the booted-devices + device-images MCP resources through
+ * the shared [McpResourceClient], unifies them into [PickerDevice]s, and owns the filter/selection
+ * state. Only **booted** devices can be observed (a non-booted selection is ignored).
+ */
+class DevicePickerViewModel(
+  private val resourceClient: McpResourceClient,
+  private val scope: CoroutineScope,
+) {
+  private val _state = MutableStateFlow<DevicePickerUiState>(DevicePickerUiState.Loading)
+  val state: StateFlow<DevicePickerUiState> = _state.asStateFlow()
+
+  private val _effect = Channel<DevicePickerEffect>(Channel.BUFFERED)
+  val effect = _effect.receiveAsFlow()
+
+  init {
+    load()
+  }
+
+  fun onAction(action: DevicePickerAction) {
+    when (action) {
+      is DevicePickerAction.ToggleState ->
+        updateFilters { it.copy(states = it.states.toggle(action.state)) }
+      is DevicePickerAction.TogglePlatform ->
+        updateFilters { it.copy(platforms = it.platforms.toggle(action.platform)) }
+      is DevicePickerAction.ToggleOs ->
+        updateFilters { it.copy(osKeys = it.osKeys.toggle(action.osKey)) }
+      is DevicePickerAction.ToggleArch ->
+        updateFilters { it.copy(architectures = it.architectures.toggle(action.arch)) }
+      is DevicePickerAction.SetQuery -> updateFilters { it.copy(query = action.query) }
+      is DevicePickerAction.ClearFilter -> clearFilter(action.dimension)
+      is DevicePickerAction.ToggleSelect -> toggleSelect(action.deviceId)
+      is DevicePickerAction.ClearSelection -> updateContent { it.copy(selectedIds = emptySet()) }
+      is DevicePickerAction.ObserveSelected -> observeSelected()
+      is DevicePickerAction.Refresh -> load()
+    }
+  }
+
+  private fun load() {
+    _state.value = DevicePickerUiState.Loading
+    scope.launch {
+      try {
+        val booted =
+          (resourceClient.readResource(BOOTED_URI) as? ResourceReadResult.Success)?.let {
+            DeviceResourceParser.parseBootedDevices(it.content)?.devices
+          } ?: emptyList()
+        val images =
+          (resourceClient.readResource(IMAGES_URI) as? ResourceReadResult.Success)?.let {
+            DeviceResourceParser.parseDeviceImages(it.content)?.images
+          } ?: emptyList()
+        val devices = buildPickerDevices(booted, images)
+        LOG.info("Picker loaded ${devices.size} devices (${booted.size} booted)")
+        _state.value = DevicePickerUiState.Content(devices)
+      } catch (e: Exception) {
+        LOG.warn("Failed to load picker devices: ${e.message}", e)
+        _state.value = DevicePickerUiState.Error(e.message ?: "Failed to load devices")
+      }
+    }
+  }
+
+  private fun toggleSelect(deviceId: String) {
+    updateContent { content ->
+      // Booted-only: ignore selection of non-booted devices.
+      val device = content.devices.firstOrNull { it.id == deviceId } ?: return@updateContent content
+      if (device.state != DeviceState.Booted) return@updateContent content
+      content.copy(selectedIds = content.selectedIds.toggle(deviceId))
+    }
+  }
+
+  private fun observeSelected() {
+    val content = _state.value as? DevicePickerUiState.Content ?: return
+    val columns =
+      content.devices
+        .filter { it.id in content.selectedIds && it.state == DeviceState.Booted }
+        .map { DeviceColumn(deviceId = it.id, name = it.name, platform = it.platform) }
+    if (columns.isNotEmpty()) {
+      scope.launch { _effect.send(DevicePickerEffect.Observe(columns)) }
+    }
+  }
+
+  private fun clearFilter(dimension: FilterDimension) {
+    updateFilters {
+      when (dimension) {
+        FilterDimension.State -> it.copy(states = emptySet())
+        FilterDimension.Platform -> it.copy(platforms = emptySet(), osKeys = emptySet())
+        FilterDimension.OsVersion -> it.copy(osKeys = emptySet())
+        FilterDimension.Architecture -> it.copy(architectures = emptySet())
+      }
+    }
+  }
+
+  private fun updateFilters(transform: (PickerFilters) -> PickerFilters) {
+    updateContent { it.copy(filters = transform(it.filters)) }
+  }
+
+  private fun updateContent(
+    transform: (DevicePickerUiState.Content) -> DevicePickerUiState.Content
+  ) {
+    _state.update { current ->
+      (current as? DevicePickerUiState.Content)?.let(transform) ?: current
+    }
+  }
+}
+
+private fun <T> Set<T>.toggle(value: T): Set<T> = if (value in this) this - value else this + value

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerFilters.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerFilters.kt
@@ -1,0 +1,119 @@
+package dev.jasonpearson.automobile.desktop.core.workspace.picker
+
+import dev.jasonpearson.automobile.desktop.core.workspace.Platform
+
+/** The filter dimensions shown in the picker rail. */
+enum class FilterDimension(val title: String) {
+  State("State"),
+  Platform("Platform"),
+  OsVersion("OS version"),
+  Architecture("Architecture"),
+}
+
+/** Active filter selections + the rail search query. Empty set for a dimension = no constraint. */
+data class PickerFilters(
+  val states: Set<DeviceState> = emptySet(),
+  val platforms: Set<Platform> = emptySet(),
+  val osKeys: Set<String> = emptySet(),
+  val architectures: Set<String> = emptySet(),
+  val query: String = "",
+)
+
+/** One selectable option in the rail, with its live count under the current sibling filters. */
+data class FilterOption(
+  val value: String,
+  val label: String,
+  val count: Int,
+  val selected: Boolean,
+)
+
+internal fun Platform.label(): String = if (this == Platform.Ios) "iOS" else "Android"
+
+internal fun DeviceState.label(): String = if (this == DeviceState.Booted) "Booted" else "Shutdown"
+
+/** Match a device against every active dimension except [ignore] (for faceted counting). */
+private fun matches(d: PickerDevice, f: PickerFilters, ignore: FilterDimension?): Boolean {
+  if (ignore != FilterDimension.State && f.states.isNotEmpty() && d.state !in f.states) return false
+  if (ignore != FilterDimension.Platform && f.platforms.isNotEmpty() && d.platform !in f.platforms)
+    return false
+  if (
+    ignore != FilterDimension.OsVersion &&
+      f.osKeys.isNotEmpty() &&
+      (d.osKey == null || d.osKey !in f.osKeys)
+  )
+    return false
+  if (
+    ignore != FilterDimension.Architecture &&
+      f.architectures.isNotEmpty() &&
+      (d.architecture == null || d.architecture !in f.architectures)
+  )
+    return false
+  return true
+}
+
+/** Devices matching the intersection of all active filters (the grid contents). */
+fun filteredDevices(devices: List<PickerDevice>, f: PickerFilters): List<PickerDevice> =
+  devices.filter {
+    matches(it, f, ignore = null)
+  }
+
+private fun matchesQuery(label: String, query: String): Boolean =
+  query.isBlank() || label.contains(query.trim(), ignoreCase = true)
+
+/**
+ * Options for one dimension, each with a live count computed under the OTHER active filters. The
+ * OS-version dimension is gated: it returns no options until a platform filter is active. The rail
+ * [PickerFilters.query] fuzzy-filters which option labels are shown.
+ */
+fun options(
+  devices: List<PickerDevice>,
+  f: PickerFilters,
+  dimension: FilterDimension,
+): List<FilterOption> {
+  val visible = devices.filter { matches(it, f, ignore = dimension) }
+  val raw: List<FilterOption> =
+    when (dimension) {
+      FilterDimension.State ->
+        DeviceState.entries.map { state ->
+          FilterOption(
+            state.name,
+            state.label(),
+            visible.count { it.state == state },
+            state in f.states,
+          )
+        }
+      FilterDimension.Platform ->
+        Platform.entries.map { platform ->
+          FilterOption(
+            platform.name,
+            platform.label(),
+            visible.count { it.platform == platform },
+            platform in f.platforms,
+          )
+        }
+      FilterDimension.OsVersion -> {
+        if (f.platforms.isEmpty()) return emptyList()
+        visible
+          .filter { it.osKey != null }
+          .groupBy { it.osKey!! }
+          .toSortedMap(compareByDescending { it.toIntOrNull() ?: 0 })
+          .map { (key, group) ->
+            FilterOption(key, group.first().osLabel ?: key, group.size, key in f.osKeys)
+          }
+      }
+      FilterDimension.Architecture ->
+        visible
+          .mapNotNull { it.architecture }
+          .distinct()
+          .sorted()
+          .map { arch ->
+            FilterOption(
+              arch,
+              arch,
+              visible.count { it.architecture == arch },
+              arch in f.architectures,
+            )
+          }
+    }
+  return raw.filter { it.count > 0 || it.selected }.filter { matchesQuery(it.label, f.query) }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerFilters.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerFilters.kt
@@ -93,10 +93,13 @@ fun options(
         }
       FilterDimension.OsVersion -> {
         if (f.platforms.isEmpty()) return emptyList()
-        visible
-          .filter { it.osKey != null }
-          .groupBy { it.osKey!! }
-          .toSortedMap(compareByDescending { it.toIntOrNull() ?: 0 })
+        val grouped = LinkedHashMap<String, MutableList<PickerDevice>>()
+        for (device in visible) {
+          val key = device.osKey ?: continue
+          grouped.getOrPut(key) { mutableListOf() }.add(device)
+        }
+        grouped.entries
+          .sortedByDescending { it.key.toIntOrNull() ?: 0 }
           .map { (key, group) ->
             FilterOption(key, group.first().osLabel ?: key, group.size, key in f.osKeys)
           }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerModels.kt
@@ -1,0 +1,99 @@
+package dev.jasonpearson.automobile.desktop.core.workspace.picker
+
+import dev.jasonpearson.automobile.desktop.core.mcp.BootedDeviceInfo
+import dev.jasonpearson.automobile.desktop.core.mcp.DeviceImageInfo
+import dev.jasonpearson.automobile.desktop.core.workspace.Platform
+
+/**
+ * State of a device in the picker. A "booting" state is intentionally absent — the daemon device
+ * resources do not model it (only booted vs available), so it is deferred to a follow-up.
+ */
+enum class DeviceState {
+  Booted,
+  Shutdown,
+}
+
+/**
+ * A device row in the picker, unified from the booted-devices and device-images MCP resources. Only
+ * booted devices can be observed in this PR.
+ */
+data class PickerDevice(
+  val id: String,
+  val name: String,
+  val platform: Platform,
+  val state: DeviceState,
+  /** Normalized OS key for filtering/grouping: Android API level ("34") or iOS major ("17"). */
+  val osKey: String? = null,
+  /** Human label: "API 34" / "iOS 17". */
+  val osLabel: String? = null,
+  /** CPU architecture ("arm64"/"x86_64"); only iOS images currently carry it. */
+  val architecture: String? = null,
+)
+
+private val ANDROID_TARGET = Regex("android-(\\d+)")
+private val API_IN_NAME = Regex("API (\\d+)")
+
+internal fun platformOf(raw: String): Platform =
+  if (raw.equals("ios", ignoreCase = true)) Platform.Ios else Platform.Android
+
+private fun androidApiFromName(name: String): String? =
+  API_IN_NAME.find(name)?.groupValues?.getOrNull(1)
+
+private fun osOfImage(image: DeviceImageInfo): Pair<String?, String?> =
+  when {
+    image.platform.equals("ios", ignoreCase = true) -> {
+      val major = image.iosVersion?.substringBefore(".")?.takeIf { it.isNotBlank() }
+      major to major?.let { "iOS $it" }
+    }
+    else -> {
+      val api =
+        ANDROID_TARGET.find(image.target ?: "")?.groupValues?.getOrNull(1)
+          ?: androidApiFromName(image.name)
+      api to api?.let { "API $it" }
+    }
+  }
+
+/**
+ * Merge the booted-devices and device-images resources into one picker list. Booted devices win
+ * over their image entry (deduped by id and by name). Booted devices carry no OS/architecture from
+ * the daemon today, so Android API is best-effort parsed from the name.
+ */
+fun buildPickerDevices(
+  booted: List<BootedDeviceInfo>,
+  images: List<DeviceImageInfo>,
+): List<PickerDevice> {
+  val bootedIds = booted.map { it.deviceId }.toSet()
+  val bootedNames = booted.map { it.name }.toSet()
+
+  val bootedDevices = booted.map { device ->
+    val api =
+      androidApiFromName(device.name).takeIf { platformOf(device.platform) == Platform.Android }
+    PickerDevice(
+      id = device.deviceId,
+      name = device.name,
+      platform = platformOf(device.platform),
+      state = DeviceState.Booted,
+      osKey = api,
+      osLabel = api?.let { "API $it" },
+      architecture = null,
+    )
+  }
+
+  val shutdownDevices =
+    images
+      .filter { (it.deviceId ?: it.name) !in bootedIds && it.name !in bootedNames }
+      .map { image ->
+        val (osKey, osLabel) = osOfImage(image)
+        PickerDevice(
+          id = image.deviceId ?: image.name,
+          name = image.name,
+          platform = platformOf(image.platform),
+          state = DeviceState.Shutdown,
+          osKey = osKey,
+          osLabel = osLabel,
+          architecture = image.architecture,
+        )
+      }
+
+  return (bootedDevices + shutdownDevices).distinctBy { it.id }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerUiTest.kt
@@ -1,0 +1,87 @@
+package dev.jasonpearson.automobile.desktop.core.workspace.picker
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.workspace.Platform
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class DevicePickerUiTest {
+
+  private val devices =
+    listOf(
+      PickerDevice("p8", "Pixel 8", Platform.Android, DeviceState.Booted, "34", "API 34"),
+      PickerDevice("i15", "iPhone 15", Platform.Ios, DeviceState.Shutdown, "17", "iOS 17", "arm64"),
+    )
+
+  private fun content(selected: Set<String> = emptySet()) =
+    DevicePickerUiState.Content(devices, PickerFilters(), selected)
+
+  @Test
+  fun `renders rail options and device cards`() = runComposeUiTest {
+    setContent { MaterialTheme { DevicePicker(content(), onAction = {}, onClose = {}) } }
+    onNodeWithContentDescription("Select filter Booted").assertIsDisplayed()
+    onNodeWithContentDescription("Select filter Android").assertIsDisplayed()
+    onNodeWithText("Pixel 8", substring = true).assertIsDisplayed()
+    onNodeWithContentDescription("Select Pixel 8").assertIsDisplayed()
+    onNodeWithContentDescription("iPhone 15 (not booted)").assertIsDisplayed()
+  }
+
+  @Test
+  fun `clicking a filter option dispatches its toggle`() = runComposeUiTest {
+    var action: DevicePickerAction? = null
+    setContent {
+      MaterialTheme { DevicePicker(content(), onAction = { action = it }, onClose = {}) }
+    }
+    onNodeWithContentDescription("Select filter Android").performClick()
+    assertEquals(DevicePickerAction.TogglePlatform(Platform.Android), action)
+  }
+
+  @Test
+  fun `clicking a booted card dispatches ToggleSelect`() = runComposeUiTest {
+    var action: DevicePickerAction? = null
+    setContent {
+      MaterialTheme { DevicePicker(content(), onAction = { action = it }, onClose = {}) }
+    }
+    onNodeWithContentDescription("Select Pixel 8").performClick()
+    assertEquals(DevicePickerAction.ToggleSelect("p8"), action)
+  }
+
+  @Test
+  fun `observe is disabled with no selection and enabled + dispatches with a selection`() =
+    runComposeUiTest {
+      var action: DevicePickerAction? = null
+      setContent {
+        MaterialTheme {
+          DevicePicker(content(selected = setOf("p8")), onAction = { action = it }, onClose = {})
+        }
+      }
+      onNodeWithContentDescription("Observe selected").assertIsEnabled().performClick()
+      assertEquals(DevicePickerAction.ObserveSelected, action)
+    }
+
+  @Test
+  fun `observe is disabled when nothing is selected`() = runComposeUiTest {
+    setContent { MaterialTheme { DevicePicker(content(), onAction = {}, onClose = {}) } }
+    onNodeWithContentDescription("Observe selected").assertIsNotEnabled()
+  }
+
+  @Test
+  fun `close invokes onClose`() = runComposeUiTest {
+    var closed = false
+    setContent {
+      MaterialTheme { DevicePicker(content(), onAction = {}, onClose = { closed = true }) }
+    }
+    onNodeWithContentDescription("Close picker").performClick()
+    assertTrue(closed)
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
@@ -42,7 +42,7 @@ class DevicePickerViewModelTest {
 
   @Test
   fun `loads and unifies booted + images with dedupe and iOS architecture`() = testScope.runTest {
-    val vm = DevicePickerViewModel(fake(), this)
+    val vm = DevicePickerViewModel(fake(), this, UnconfinedTestDispatcher())
     val c = content(vm)
     assertEquals(listOf("emulator-5554", "Pixel_6_API_33", "iphone-15"), c.devices.map { it.id })
     val pixel8 = c.devices.first { it.id == "emulator-5554" }
@@ -56,7 +56,7 @@ class DevicePickerViewModelTest {
 
   @Test
   fun `toggling a platform updates the filters`() = testScope.runTest {
-    val vm = DevicePickerViewModel(fake(), this)
+    val vm = DevicePickerViewModel(fake(), this, UnconfinedTestDispatcher())
     vm.onAction(DevicePickerAction.TogglePlatform(Platform.Ios))
     assertEquals(setOf(Platform.Ios), content(vm).filters.platforms)
     vm.onAction(DevicePickerAction.TogglePlatform(Platform.Ios))
@@ -65,7 +65,7 @@ class DevicePickerViewModelTest {
 
   @Test
   fun `only booted devices can be selected`() = testScope.runTest {
-    val vm = DevicePickerViewModel(fake(), this)
+    val vm = DevicePickerViewModel(fake(), this, UnconfinedTestDispatcher())
     vm.onAction(DevicePickerAction.ToggleSelect("iphone-15")) // shutdown — ignored
     assertTrue(content(vm).selectedIds.isEmpty())
     vm.onAction(DevicePickerAction.ToggleSelect("emulator-5554")) // booted
@@ -74,7 +74,7 @@ class DevicePickerViewModelTest {
 
   @Test
   fun `observe selected emits one column per selected booted device`() = testScope.runTest {
-    val vm = DevicePickerViewModel(fake(), this)
+    val vm = DevicePickerViewModel(fake(), this, UnconfinedTestDispatcher())
     vm.effect.test {
       vm.onAction(DevicePickerAction.ToggleSelect("emulator-5554"))
       vm.onAction(DevicePickerAction.ObserveSelected)
@@ -89,7 +89,7 @@ class DevicePickerViewModelTest {
 
   @Test
   fun `clear filter resets that dimension`() = testScope.runTest {
-    val vm = DevicePickerViewModel(fake(), this)
+    val vm = DevicePickerViewModel(fake(), this, UnconfinedTestDispatcher())
     vm.onAction(DevicePickerAction.TogglePlatform(Platform.Android))
     vm.onAction(DevicePickerAction.ToggleOs("35"))
     vm.onAction(DevicePickerAction.ClearFilter(FilterDimension.Platform))

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
@@ -1,0 +1,101 @@
+package dev.jasonpearson.automobile.desktop.core.workspace.picker
+
+import app.cash.turbine.test
+import dev.jasonpearson.automobile.desktop.core.mcp.FakeMcpResourceClient
+import dev.jasonpearson.automobile.desktop.core.workspace.Platform
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DevicePickerViewModelTest {
+
+  private val testScope = TestScope(UnconfinedTestDispatcher())
+
+  private fun fake(): FakeMcpResourceClient =
+    FakeMcpResourceClient().apply {
+      bootedDevicesResponse =
+        """
+        {"totalCount":1,"androidCount":1,"iosCount":0,"virtualCount":1,"physicalCount":0,
+         "lastUpdated":"x","devices":[
+           {"name":"Pixel 8 API 35","platform":"android","deviceId":"emulator-5554",
+            "source":"local","isVirtual":true,"status":"booted"}]}
+        """
+          .trimIndent()
+      deviceImagesResponse =
+        """
+        {"totalCount":3,"androidCount":2,"iosCount":1,"lastUpdated":"x","images":[
+          {"name":"Pixel 8 API 35","platform":"android","deviceId":"Pixel_8_API_35","target":"android-35"},
+          {"name":"Pixel 6 API 33","platform":"android","deviceId":"Pixel_6_API_33","target":"android-33"},
+          {"name":"iPhone 15","platform":"ios","deviceId":"iphone-15","iosVersion":"17.2",
+           "architecture":"arm64","state":"Shutdown"}]}
+        """
+          .trimIndent()
+    }
+
+  private fun content(vm: DevicePickerViewModel) = vm.state.value as DevicePickerUiState.Content
+
+  @Test
+  fun `loads and unifies booted + images with dedupe and iOS architecture`() = testScope.runTest {
+    val vm = DevicePickerViewModel(fake(), this)
+    val c = content(vm)
+    assertEquals(listOf("emulator-5554", "Pixel_6_API_33", "iphone-15"), c.devices.map { it.id })
+    val pixel8 = c.devices.first { it.id == "emulator-5554" }
+    assertEquals(DeviceState.Booted, pixel8.state)
+    assertEquals("35", pixel8.osKey) // parsed from the name
+    val iphone = c.devices.first { it.id == "iphone-15" }
+    assertEquals(DeviceState.Shutdown, iphone.state)
+    assertEquals("arm64", iphone.architecture)
+    assertEquals("17", iphone.osKey)
+  }
+
+  @Test
+  fun `toggling a platform updates the filters`() = testScope.runTest {
+    val vm = DevicePickerViewModel(fake(), this)
+    vm.onAction(DevicePickerAction.TogglePlatform(Platform.Ios))
+    assertEquals(setOf(Platform.Ios), content(vm).filters.platforms)
+    vm.onAction(DevicePickerAction.TogglePlatform(Platform.Ios))
+    assertTrue(content(vm).filters.platforms.isEmpty())
+  }
+
+  @Test
+  fun `only booted devices can be selected`() = testScope.runTest {
+    val vm = DevicePickerViewModel(fake(), this)
+    vm.onAction(DevicePickerAction.ToggleSelect("iphone-15")) // shutdown — ignored
+    assertTrue(content(vm).selectedIds.isEmpty())
+    vm.onAction(DevicePickerAction.ToggleSelect("emulator-5554")) // booted
+    assertEquals(setOf("emulator-5554"), content(vm).selectedIds)
+  }
+
+  @Test
+  fun `observe selected emits one column per selected booted device`() = testScope.runTest {
+    val vm = DevicePickerViewModel(fake(), this)
+    vm.effect.test {
+      vm.onAction(DevicePickerAction.ToggleSelect("emulator-5554"))
+      vm.onAction(DevicePickerAction.ObserveSelected)
+      val effect = awaitItem()
+      assertTrue(effect is DevicePickerEffect.Observe)
+      val columns = (effect as DevicePickerEffect.Observe).columns
+      assertEquals(listOf("emulator-5554"), columns.map { it.deviceId })
+      assertEquals(Platform.Android, columns.first().platform)
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun `clear filter resets that dimension`() = testScope.runTest {
+    val vm = DevicePickerViewModel(fake(), this)
+    vm.onAction(DevicePickerAction.TogglePlatform(Platform.Android))
+    vm.onAction(DevicePickerAction.ToggleOs("35"))
+    vm.onAction(DevicePickerAction.ClearFilter(FilterDimension.Platform))
+    val f = content(vm).filters
+    assertTrue(f.platforms.isEmpty())
+    assertTrue(f.osKeys.isEmpty()) // clearing platform also clears the gated OS selection
+    assertNull(f.states.firstOrNull())
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerFiltersTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerFiltersTest.kt
@@ -1,0 +1,95 @@
+package dev.jasonpearson.automobile.desktop.core.workspace.picker
+
+import dev.jasonpearson.automobile.desktop.core.workspace.Platform
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PickerFiltersTest {
+
+  private fun dev(
+    id: String,
+    platform: Platform,
+    state: DeviceState,
+    osKey: String? = null,
+    osLabel: String? = null,
+    arch: String? = null,
+  ) = PickerDevice(id, "name-$id", platform, state, osKey, osLabel, arch)
+
+  private val devices =
+    listOf(
+      dev("a", Platform.Android, DeviceState.Booted, "34", "API 34"),
+      dev("b", Platform.Android, DeviceState.Shutdown, "33", "API 33"),
+      dev("c", Platform.Ios, DeviceState.Booted, "17", "iOS 17", "arm64"),
+      dev("d", Platform.Ios, DeviceState.Shutdown, "16", "iOS 16", "x86_64"),
+    )
+
+  @Test
+  fun `filteredDevices intersects active dimensions`() {
+    assertEquals(
+      listOf("a", "b"),
+      filteredDevices(devices, PickerFilters(platforms = setOf(Platform.Android))).map { it.id },
+    )
+    assertEquals(
+      listOf("a"),
+      filteredDevices(
+          devices,
+          PickerFilters(platforms = setOf(Platform.Android), states = setOf(DeviceState.Booted)),
+        )
+        .map { it.id },
+    )
+  }
+
+  @Test
+  fun `state options carry counts under sibling filters`() {
+    val all =
+      options(devices, PickerFilters(), FilterDimension.State).associate { it.value to it.count }
+    assertEquals(2, all["Booted"]) // a, c
+    assertEquals(2, all["Shutdown"]) // b, d
+    // Once Android is selected, state counts reflect only Android.
+    val android =
+      options(devices, PickerFilters(platforms = setOf(Platform.Android)), FilterDimension.State)
+        .associate { it.value to it.count }
+    assertEquals(1, android["Booted"]) // a
+    assertEquals(1, android["Shutdown"]) // b
+  }
+
+  @Test
+  fun `os version options are gated on a platform selection`() {
+    assertTrue(options(devices, PickerFilters(), FilterDimension.OsVersion).isEmpty())
+    val android =
+      options(
+        devices,
+        PickerFilters(platforms = setOf(Platform.Android)),
+        FilterDimension.OsVersion,
+      )
+    assertEquals(listOf("API 34", "API 33"), android.map { it.label }) // sorted desc
+    assertTrue(android.all { it.count == 1 })
+  }
+
+  @Test
+  fun `architecture options come from devices that carry one`() {
+    val arch = options(devices, PickerFilters(), FilterDimension.Architecture)
+    assertEquals(listOf("arm64", "x86_64"), arch.map { it.value })
+    assertTrue(arch.all { it.count == 1 })
+  }
+
+  @Test
+  fun `query fuzzy-filters option labels`() {
+    val android = PickerFilters(platforms = setOf(Platform.Android), query = "34")
+    assertEquals(
+      listOf("API 34"),
+      options(devices, android, FilterDimension.OsVersion).map { it.label },
+    )
+    val ios = PickerFilters(query = "ios")
+    assertEquals(listOf("iOS"), options(devices, ios, FilterDimension.Platform).map { it.label })
+  }
+
+  @Test
+  fun `selected option is kept even when its count drops to zero`() {
+    // Selecting iOS leaves no Android devices, but the Android option stays visible (selected).
+    val f = PickerFilters(platforms = setOf(Platform.Ios))
+    val platformOpts = options(devices, f, FilterDimension.Platform)
+    assertTrue(platformOpts.any { it.value == Platform.Ios.name && it.selected })
+  }
+}


### PR DESCRIPTION
## Summary

Second PR of the device-tab workspace (follows #4667). Adds the **full-screen device picker** that turns selected devices into workspace columns, replacing the inert Devices launcher.

**Reuses** the existing device data source — the `automobile:devices/booted` + `automobile:devices/images` MCP resources read via `McpResourceClient` — no second discovery path.

## Changes

- `core/workspace/picker/PickerModels.kt` — `PickerDevice` + `DeviceState`; `buildPickerDevices()` unifies the two resources (booted wins over its image entry; Android API best-effort parsed from the name).
- `core/workspace/picker/PickerFilters.kt` — pure filter logic: intersection filtering, **faceted per-option counts**, **platform-gated** OS-version group, fuzzy option search.
- `core/workspace/picker/DevicePickerViewModel.kt` — sealed `UiState`/`Action`/`Effect` + `StateFlow`/`Channel` (mirrors `WorkspaceViewModel`); loads via the resource client; **booted-only** selection; `Observe` effect → columns.
- `core/workspace/picker/DevicePicker.kt` — stateless full-screen composable: filter rail (search + counts), removable chips, results grid, multi-select, Observe.
- `AutoMobileDesktopApp.kt` — hosts the picker on `WorkspaceEffect.OpenPicker`; maps its `Observe` effect to `WorkspaceAction.ObserveDevice` per selected booted device.
- `DeviceModels.kt` — add `architecture` to `DeviceImageInfo` (already emitted on the iOS images wire).

## Filter dimensions

Shipped with real data: **Platform**, **OS version** (Android API / iOS, platform-gated), **State** (booted/shutdown), **Architecture** (iOS). Deferred to a daemon-plumbing follow-up (no source on the desktop today): **form factor** (both platforms; "foldable" unmodeled upstream), **Android architecture**, and a real **"booting"** state.

## Testing

- `PickerFiltersTest` — intersection, faceted counts, OS platform-gating, architecture options, fuzzy query, selected-option retention.
- `DevicePickerViewModelTest` (`FakeMcpResourceClient` + Turbine) — load/unify/dedupe + iOS arch, filter toggles, **booted-only** selection, Observe emits one column per selected booted device, clear-filter.
- `DevicePickerUiTest` — rail options, cards, filter-click dispatch, booted-card select dispatch, Observe enable/disable + dispatch, close.
- `:desktop-core:test :desktop-app:test` green (full suite, no regressions); `:desktop-app:compileKotlin` green; ktfmt clean tree-wide.

## Acceptance criteria (#4676)

- [x] Full-screen picker reachable from the empty state + Devices launcher (`OpenPicker` wired).
- [x] Filter rail with live per-option counts.
- [x] OS-version group only after a platform is selected.
- [x] Fuzzy search filters options.
- [x] Removable filter chips update results + counts.
- [x] Grid = intersection; multi-select; **Observe** dispatches `ObserveDevice` per selected **booted** device.
- [x] Non-booted devices shown but not observable (booted-only).
- [x] Reuses the existing device data source; `architecture` added with a real (iOS) source; form-factor/Android-arch/booting captured as a follow-up.
- [x] ViewModel + UI tests; ktfmt/build/tests green.

## Follow-up

Daemon plumbing for form factor + Android architecture + a real "booting" state (I'll file it).

Closes #4676
