### PR TITLE
feat(mcp): render observe as an MCP App UI resource (#4669)

### DIFF
--- a/schemas/tool-definitions.json
+++ b/schemas/tool-definitions.json
@@ -6266,6 +6266,11 @@
           "additionalProperties": {}
         }
       }
+    },
+    "_meta": {
+      "ui": {
+        "resourceUri": "ui://automobile/observe"
+      }
     }
   },
   {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -49,6 +49,7 @@ import { getMcpServerVersion } from "../utils/mcpVersion";
 
 // Import resource registration functions
 import { registerObservationResources } from "./observationResources";
+import { registerObserveAppResource } from "./observeAppResource";
 import { registerBootedDeviceResources } from "./bootedDeviceResources";
 import { registerDeviceImageResources } from "./deviceImageResources";
 import { registerAppResources } from "./appResources";
@@ -214,6 +215,7 @@ export const createMcpServer = (options: McpServerOptions = {}): McpServer => {
   // Register all resources
   startupBenchmark.startPhase("resourceRegistration");
   registerObservationResources();
+  registerObserveAppResource();
   registerBootedDeviceResources();
   registerDeviceImageResources();
   registerAppResources();

--- a/src/server/observationResources.ts
+++ b/src/server/observationResources.ts
@@ -143,20 +143,6 @@ async function getLatestScreenshot(): Promise<ResourceContent> {
   }
 }
 
-/**
- * The latest screenshot as a self-contained `data:` URI, or undefined when none
- * is cached. Reuses `getLatestScreenshot` (and its injectable screenshot
- * filesystem seam) so the MCP App resource (#4669) can inline the image without
- * a second filesystem path.
- */
-export async function getLatestScreenshotDataUri(): Promise<string | undefined> {
-  const content = await getLatestScreenshot();
-  if (content.blob && content.mimeType?.startsWith("image/")) {
-    return `data:${content.mimeType};base64,${content.blob}`;
-  }
-  return undefined;
-}
-
 // Device-scoped handler for observation (with deviceId parameter)
 async function getDeviceObservation(params: Record<string, string>): Promise<ResourceContent> {
   const { deviceId } = params;

--- a/src/server/observationResources.ts
+++ b/src/server/observationResources.ts
@@ -143,6 +143,20 @@ async function getLatestScreenshot(): Promise<ResourceContent> {
   }
 }
 
+/**
+ * The latest screenshot as a self-contained `data:` URI, or undefined when none
+ * is cached. Reuses `getLatestScreenshot` (and its injectable screenshot
+ * filesystem seam) so the MCP App resource (#4669) can inline the image without
+ * a second filesystem path.
+ */
+export async function getLatestScreenshotDataUri(): Promise<string | undefined> {
+  const content = await getLatestScreenshot();
+  if (content.blob && content.mimeType?.startsWith("image/")) {
+    return `data:${content.mimeType};base64,${content.blob}`;
+  }
+  return undefined;
+}
+
 // Device-scoped handler for observation (with deviceId parameter)
 async function getDeviceObservation(params: Record<string, string>): Promise<ResourceContent> {
   const { deviceId } = params;

--- a/src/server/observeAppResource.ts
+++ b/src/server/observeAppResource.ts
@@ -1,0 +1,198 @@
+import type { ObserveResult } from "../models/ObserveResult";
+import type { ElementBounds } from "../models/ElementBounds";
+import { DefaultElementParser } from "../features/utility/ElementParser";
+import { ResourceRegistry } from "./resourceRegistry";
+import type { ResourceContent } from "./resourceRegistry";
+import { RealObserveScreen } from "../features/observe/ObserveScreen";
+import { getLatestScreenshotDataUri } from "./observationResources";
+import { logger } from "../utils/logger";
+
+/**
+ * MCP Apps UI resource for `observe` (issue #4669). `observe` returns screen
+ * state as data; this renders that same payload as a self-contained, inline HTML
+ * "App" — the screenshot with the view-hierarchy bounding boxes overlaid — for
+ * Apps-capable hosts. It is purely additive: the tool's data result is unchanged
+ * and non-Apps hosts simply ignore the `_meta.ui.resourceUri` pointer.
+ *
+ * The body is fully self-contained (inline CSS + SVG, no external hosts, no
+ * scripts) to mirror the repo's artifact CSP posture. Interactive tap-target
+ * selection is a deliberate follow-up, not part of this resource.
+ */
+export const OBSERVE_APP_RESOURCE_URI = "ui://automobile/observe";
+
+/** The MCP Apps content profile (spec 2026-01-26). */
+export const MCP_APP_MIME_TYPE = "text/html;profile=mcp-app";
+
+// A single deterministic parser instance — flattenViewHierarchy is pure.
+const elementParser = new DefaultElementParser();
+
+interface OverlayBox {
+  bounds: ElementBounds;
+  label: string;
+}
+
+// HTML/attribute escaping — labels come from device text/resource-id and must
+// never break the markup or smuggle in active content.
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// Integers stay integers; fractional iOS point coordinates (issue #3206) keep up
+// to 3 decimals without trailing-zero noise.
+function fmt(n: number): string {
+  if (!Number.isFinite(n)) {
+    return "0";
+  }
+  return Number.isInteger(n) ? String(n) : String(Number(n.toFixed(3)));
+}
+
+function collectOverlayBoxes(observe: ObserveResult): OverlayBox[] {
+  if (!observe.viewHierarchy) {
+    return [];
+  }
+  return elementParser
+    .flattenViewHierarchy(observe.viewHierarchy)
+    .filter(entry => entry.element?.bounds)
+    .map(entry => {
+      const element = entry.element;
+      const label =
+        entry.text ||
+        (element["resource-id"] as string | undefined) ||
+        (element["content-desc"] as string | undefined) ||
+        (element.class as string | undefined) ||
+        "";
+      return { bounds: element.bounds, label };
+    });
+}
+
+// Bounds coordinate space (the units the flattened bounds are in). The SVG
+// viewBox is set to this space so overlay rects align to the screenshot
+// regardless of the screenshot's physical pixel resolution.
+function resolveScreenSize(observe: ObserveResult, boxes: OverlayBox[]): { width: number; height: number } {
+  const vh = observe.viewHierarchy;
+  if (vh?.screenWidth && vh?.screenHeight) {
+    return { width: vh.screenWidth, height: vh.screenHeight };
+  }
+  if (observe.screenSize?.width && observe.screenSize?.height) {
+    return { width: observe.screenSize.width, height: observe.screenSize.height };
+  }
+  // Last resort: bound the boxes we have so the overlay is still viewable.
+  const maxRight = boxes.reduce((m, b) => Math.max(m, b.bounds.right), 0);
+  const maxBottom = boxes.reduce((m, b) => Math.max(m, b.bounds.bottom), 0);
+  return { width: maxRight || 1, height: maxBottom || 1 };
+}
+
+/**
+ * Render the observe payload as a self-contained MCP App HTML document.
+ * Pure: same input → same output. `screenshotDataUri`, when a `data:` URI, is
+ * inlined as the SVG backdrop; any non-`data:` value is ignored to preserve the
+ * no-external-hosts invariant.
+ */
+export function renderObserveAppHtml(observe: ObserveResult, screenshotDataUri?: string): string {
+  const boxes = collectOverlayBoxes(observe);
+  const { width, height } = resolveScreenSize(observe, boxes);
+  const state = boxes.length > 0 ? "observe" : "empty";
+
+  const hasScreenshot = typeof screenshotDataUri === "string" && screenshotDataUri.startsWith("data:");
+  const image = hasScreenshot
+    ? `<image href="${escapeHtml(screenshotDataUri!)}" x="0" y="0" width="${fmt(width)}" height="${fmt(height)}" preserveAspectRatio="none"/>`
+    : "";
+
+  const rects = boxes
+    .map(({ bounds, label }) => {
+      const w = Math.max(0, bounds.right - bounds.left);
+      const h = Math.max(0, bounds.bottom - bounds.top);
+      const title = label ? `<title>${escapeHtml(label)}</title>` : "";
+      return `<rect class="am-box" x="${fmt(bounds.left)}" y="${fmt(bounds.top)}" width="${fmt(w)}" height="${fmt(h)}">${title}</rect>`;
+    })
+    .join("");
+
+  const emptyNote =
+    state === "empty"
+      ? `<p class="am-empty">No view hierarchy to display. Run <code>observe</code> to capture screen state.</p>`
+      : "";
+
+  // Theme-aware, responsive, and fully inline. No scripts, no external refs.
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>AutoMobile — observe</title>
+<style>
+:root { color-scheme: light dark; --am-bg:#f6f7f9; --am-fg:#1b1f24; --am-box:#2f6feb; --am-backdrop:#e7e9ee; }
+@media (prefers-color-scheme: dark) { :root { --am-bg:#0f1216; --am-fg:#e6e8eb; --am-box:#6ea8ff; --am-backdrop:#1b1f24; } }
+:root[data-theme="light"] { --am-bg:#f6f7f9; --am-fg:#1b1f24; --am-box:#2f6feb; --am-backdrop:#e7e9ee; }
+:root[data-theme="dark"] { --am-bg:#0f1216; --am-fg:#e6e8eb; --am-box:#6ea8ff; --am-backdrop:#1b1f24; }
+* { box-sizing: border-box; }
+body { margin:0; padding:12px; background:var(--am-bg); color:var(--am-fg); font:14px/1.4 system-ui, sans-serif; }
+.am-stage { max-width:100%; margin:0 auto; }
+svg.am-canvas { width:100%; height:auto; max-width:100%; display:block; background:var(--am-backdrop); border-radius:8px; }
+rect.am-box { fill:transparent; stroke:var(--am-box); stroke-width:1.5; vector-effect:non-scaling-stroke; }
+rect.am-box:hover { fill:color-mix(in srgb, var(--am-box) 18%, transparent); }
+.am-empty { opacity:.75; }
+</style>
+</head>
+<body>
+<div class="am-stage" data-observe-app="${state}">
+${emptyNote}
+<svg class="am-canvas" viewBox="0 0 ${fmt(width)} ${fmt(height)}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="observe screen overlay">
+${image}
+${rects}
+</svg>
+</div>
+</body>
+</html>`;
+}
+
+/** Source of the latest observe payload + screenshot for the App resource. */
+export interface ObserveAppDataSource {
+  getLatestObserve(): Promise<ObserveResult | undefined>;
+  getLatestScreenshotDataUri(): Promise<string | undefined>;
+}
+
+// Production source: the in-memory observe cache + the cached screenshot,
+// reusing the existing injectable screenshot filesystem seam.
+const defaultDataSource: ObserveAppDataSource = {
+  getLatestObserve: async () => RealObserveScreen.getRecentCachedResult(),
+  getLatestScreenshotDataUri: async () => getLatestScreenshotDataUri(),
+};
+
+async function buildAppContent(dataSource: ObserveAppDataSource): Promise<ResourceContent> {
+  const observe = await dataSource.getLatestObserve();
+  if (!observe) {
+    return {
+      uri: OBSERVE_APP_RESOURCE_URI,
+      mimeType: MCP_APP_MIME_TYPE,
+      text: renderObserveAppHtml({} as ObserveResult),
+    };
+  }
+  let screenshotDataUri: string | undefined;
+  try {
+    screenshotDataUri = await dataSource.getLatestScreenshotDataUri();
+  } catch (error) {
+    // Screenshot is optional garnish; the overlay still renders without it.
+    logger.debug(`[ObserveAppResource] screenshot unavailable: ${error}`);
+  }
+  return {
+    uri: OBSERVE_APP_RESOURCE_URI,
+    mimeType: MCP_APP_MIME_TYPE,
+    text: renderObserveAppHtml(observe, screenshotDataUri),
+  };
+}
+
+/** Register the `ui://automobile/observe` App resource. */
+export function registerObserveAppResource(dataSource: ObserveAppDataSource = defaultDataSource): void {
+  ResourceRegistry.register(
+    OBSERVE_APP_RESOURCE_URI,
+    "Observe App UI",
+    "Interactive MCP App view of the latest observe result: screenshot with the view-hierarchy overlaid.",
+    MCP_APP_MIME_TYPE,
+    () => buildAppContent(dataSource)
+  );
+}

--- a/src/server/observeAppResource.ts
+++ b/src/server/observeAppResource.ts
@@ -4,7 +4,6 @@ import { DefaultElementParser } from "../features/utility/ElementParser";
 import { ResourceRegistry } from "./resourceRegistry";
 import type { ResourceContent } from "./resourceRegistry";
 import { RealObserveScreen } from "../features/observe/ObserveScreen";
-import { getLatestScreenshotDataUri } from "./observationResources";
 import { logger } from "../utils/logger";
 
 /**
@@ -156,11 +155,16 @@ export interface ObserveAppDataSource {
   getLatestScreenshotDataUri(): Promise<string | undefined>;
 }
 
-// Production source: the in-memory observe cache + the cached screenshot,
-// reusing the existing injectable screenshot filesystem seam.
+// Production source: the in-memory observe cache. The screenshot is deliberately
+// NOT embedded yet: `getRecentCachedResult()` (hierarchy) and the cached
+// screenshot are independent process-global getters with no capture-identity
+// link and no deviceId on `ObserveResult`, so pairing them could overlay bounds
+// on a stale — or, under multi-device, a different device's — image. The overlay
+// renders on the themed backdrop until a correlated screenshot source exists;
+// the renderer already accepts a `data:` URI for when it does. Follow-up: #4682.
 const defaultDataSource: ObserveAppDataSource = {
   getLatestObserve: async () => RealObserveScreen.getRecentCachedResult(),
-  getLatestScreenshotDataUri: async () => getLatestScreenshotDataUri(),
+  getLatestScreenshotDataUri: async () => undefined,
 };
 
 async function buildAppContent(dataSource: ObserveAppDataSource): Promise<ResourceContent> {

--- a/src/server/observeTools.ts
+++ b/src/server/observeTools.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { ToolRegistry } from "./toolRegistry";
 import { ResourceRegistry } from "./resourceRegistry";
 import { RESOURCE_URIS } from "./observationResources";
+import { OBSERVE_APP_RESOURCE_URI } from "./observeAppResource";
 import { ActionableError } from "../models/ActionableError";
 import { RealObserveScreen } from "../features/observe/ObserveScreen";
 import type { ObserveScreen } from "../features/observe/interfaces/ObserveScreen";
@@ -1151,7 +1152,7 @@ export function registerObserveTools() {
     "Get screen view hierarchy",
     observeSchema,
     observeHandler,
-    { outputSchema: observeToolResultSchema }
+    { outputSchema: observeToolResultSchema, appUiResourceUri: OBSERVE_APP_RESOURCE_URI }
   );
 
   ToolRegistry.registerDeviceAware("identifyInteractions", "Suggest likely interactions", identifyInteractionsSchema, identifyInteractionsHandler, { debugOnly: true });

--- a/src/server/resourceRegistry.ts
+++ b/src/server/resourceRegistry.ts
@@ -212,11 +212,15 @@ class ResourceRegistryClass {
       const { uri } = request.params;
       logger.info(`[ResourceRegistry] ReadResource request for URI: ${uri}`);
 
-      // Check for common incorrect URI schemes and provide helpful error messages
+      // Check for common incorrect URI schemes and provide helpful error
+      // messages. `automobile:` is the data-resource scheme; `ui:` is the MCP
+      // Apps UI-resource scheme (issue #4669). Anything else is a typo — but
+      // only reject when no resource is actually registered under that exact
+      // URI, so a future scheme that registers real resources still resolves.
       const schemeMatch = uri.match(/^([a-z][a-z0-9+.-]*):\/?\/?/i);
       if (schemeMatch) {
         const scheme = schemeMatch[1].toLowerCase();
-        if (scheme !== "automobile") {
+        if (scheme !== "automobile" && scheme !== "ui" && !this.getResource(uri)) {
           const suggestedUri = uri.replace(/^[a-z][a-z0-9+.-]*:\/?\/?/i, "automobile:");
           throw new Error(
             `Unknown URI scheme '${scheme}://'. AutoMobile resources use the 'automobile:' prefix. ` +

--- a/src/server/toolRegistry.ts
+++ b/src/server/toolRegistry.ts
@@ -100,6 +100,12 @@ interface ToolRegistrationOptions {
   outputSchema?: any;
   /** Accept the plan executor's internal coordination namespace. */
   acceptsPlanLockNamespace?: boolean;
+  /**
+   * MCP Apps UI resource this tool renders through (issue #4669). When set, the
+   * tool definition advertises it as `_meta.ui.resourceUri`; additive and
+   * ignored by non-Apps hosts.
+   */
+  appUiResourceUri?: string;
 }
 
 interface DeviceAwareToolOptions<T = any> extends ToolRegistrationOptions {
@@ -137,6 +143,7 @@ export interface RegisteredTool {
   planOnly?: boolean;
   acceptsPlanLockNamespace?: boolean;
   outputSchema?: any;
+  appUiResourceUri?: string;
 }
 
 /**
@@ -819,7 +826,8 @@ export class ToolRegistryClass {
       debugOnly: options.debugOnly ?? false,
       embeddedSdkOnly: false,
       acceptsPlanLockNamespace: options.acceptsPlanLockNamespace ?? false,
-      outputSchema: options.outputSchema
+      outputSchema: options.outputSchema,
+      appUiResourceUri: options.appUiResourceUri
     });
   }
 
@@ -941,7 +949,8 @@ export class ToolRegistryClass {
       planExecutable: options.planExecutable ?? false,
       planOnly: options.planOnly ?? false,
       acceptsPlanLockNamespace: options.acceptsPlanLockNamespace ?? false,
-      outputSchema: options.outputSchema
+      outputSchema: options.outputSchema,
+      appUiResourceUri: options.appUiResourceUri
     });
   }
 
@@ -1212,7 +1221,7 @@ export class ToolRegistryClass {
         description: string;
         inputSchema: Record<string, unknown>;
         outputSchema?: Record<string, unknown>;
-        _meta?: { "anthropic/alwaysLoad": boolean };
+        _meta?: { "anthropic/alwaysLoad"?: boolean; ui?: { resourceUri: string } };
       } = {
         name: tool.name,
         description: tool.description,
@@ -1222,7 +1231,11 @@ export class ToolRegistryClass {
         definition.outputSchema = outputSchema;
       }
       if (alwaysLoad) {
-        definition._meta = { "anthropic/alwaysLoad": true };
+        definition._meta = { ...definition._meta, "anthropic/alwaysLoad": true };
+      }
+      // MCP Apps UI pointer (issue #4669) — additive; non-Apps hosts ignore it.
+      if (tool.appUiResourceUri) {
+        definition._meta = { ...definition._meta, ui: { resourceUri: tool.appUiResourceUri } };
       }
       return definition;
     });

--- a/test/server/observeAppResource.test.ts
+++ b/test/server/observeAppResource.test.ts
@@ -1,0 +1,134 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import {
+  renderObserveAppHtml,
+  registerObserveAppResource,
+  OBSERVE_APP_RESOURCE_URI,
+  MCP_APP_MIME_TYPE,
+  type ObserveAppDataSource,
+} from "../../src/server/observeAppResource";
+import { ResourceRegistry } from "../../src/server/resourceRegistry";
+import { McpTestFixture } from "../fixtures/mcpTestFixture";
+import { loadAndroidHomeObserve, loadIosFractionalObserve } from "../fixtures/observe/observeFixture";
+import type { ObserveResult } from "../../src/models/ObserveResult";
+import { z } from "zod";
+
+const androidObserve = (): ObserveResult => loadAndroidHomeObserve().observe;
+const iosObserve = (): ObserveResult => loadIosFractionalObserve();
+
+// One <rect class="am-box"> is emitted per flattened element with bounds.
+const countBoxes = (html: string): number => (html.match(/class="am-box"/g) || []).length;
+
+describe("renderObserveAppHtml", () => {
+  test("renders one overlay box per flattened element (Android fixture)", () => {
+    const html = renderObserveAppHtml(androidObserve());
+    // viewBox is the bounds coordinate space, so boxes align regardless of screenshot resolution.
+    expect(html).toContain('viewBox="0 0 1080 2400"');
+    expect(countBoxes(html)).toBe(58);
+  });
+
+  test("preserves fractional iOS bounds (issue #3206) — Android + iOS hierarchy shape", () => {
+    const html = renderObserveAppHtml(iosObserve());
+    expect(html).toContain('viewBox="0 0 393 852"');
+    expect(countBoxes(html)).toBe(4);
+    // 851.6666… must not be truncated to an integer.
+    expect(html).toMatch(/851\.667/);
+  });
+
+  test("embeds the screenshot as an inline <image> when provided, and omits it otherwise", () => {
+    const dataUri = "data:image/png;base64,QUJD";
+    const withShot = renderObserveAppHtml(iosObserve(), dataUri);
+    expect(withShot).toContain("<image");
+    expect(withShot).toContain(dataUri);
+
+    const noShot = renderObserveAppHtml(iosObserve());
+    expect(noShot).not.toContain("<image");
+  });
+
+  test("is fully self-contained — no external fetch, CDN, or remote script", () => {
+    const html = renderObserveAppHtml(androidObserve(), "data:image/png;base64,QUJD");
+    // No fetchable external references: no remote scripts, no http(s)/protocol-relative
+    // src/href, no CSS url()/@import, no fetch().
+    expect(html).not.toMatch(/<script\s+[^>]*\bsrc=/i);
+    expect(html).not.toMatch(/\b(?:src|href)=["'](?:https?:)?\/\//i);
+    expect(html).not.toMatch(/url\(\s*["']?https?:/i);
+    expect(html).not.toMatch(/@import/);
+    expect(html).not.toMatch(/\bfetch\s*\(/);
+    // The only permitted http string is the inert SVG namespace, never fetched.
+    const withoutSvgNs = html.replace(/xmlns="http:\/\/www\.w3\.org\/2000\/svg"/g, "");
+    expect(withoutSvgNs).not.toMatch(/https?:\/\//);
+  });
+
+  test("is theme-aware (light + dark)", () => {
+    expect(renderObserveAppHtml(iosObserve())).toContain("prefers-color-scheme");
+  });
+
+  test("degrades to an empty state without a view hierarchy (no throw)", () => {
+    const empty = { screenSize: { width: 100, height: 200 } } as unknown as ObserveResult;
+    const html = renderObserveAppHtml(empty);
+    expect(html).toContain("data-observe-app");
+    expect(countBoxes(html)).toBe(0);
+  });
+});
+
+describe("registerObserveAppResource", () => {
+  const fakeSource: ObserveAppDataSource = {
+    getLatestObserve: async () => iosObserve(),
+    getLatestScreenshotDataUri: async () => "data:image/png;base64,QUJD",
+  };
+
+  beforeEach(() => {
+    ResourceRegistry.clearResources();
+  });
+
+  test("advertises ui://automobile/observe with the MCP App mime type", () => {
+    registerObserveAppResource(fakeSource);
+    const def = ResourceRegistry.getResourceDefinitions().find(d => d.uri === OBSERVE_APP_RESOURCE_URI);
+    expect(def).toBeDefined();
+    expect(def?.mimeType).toBe(MCP_APP_MIME_TYPE);
+  });
+
+  test("handler renders app HTML from the data source (screenshot inlined)", async () => {
+    registerObserveAppResource(fakeSource);
+    const content = await ResourceRegistry.getResource(OBSERVE_APP_RESOURCE_URI)!.handler();
+    expect(content.mimeType).toBe(MCP_APP_MIME_TYPE);
+    expect(content.text).toContain("data-observe-app");
+    expect(content.text).toContain("data:image/png;base64,QUJD");
+    expect(content.text).toContain('viewBox="0 0 393 852"');
+  });
+});
+
+describe("ui:// resource resolves through the MCP read path (scheme guard)", () => {
+  let fixture: McpTestFixture;
+
+  beforeEach(() => {
+    ResourceRegistry.clearResources();
+  });
+
+  test("resources/list advertises it and resources/read returns app HTML", async () => {
+    fixture = new McpTestFixture();
+    await fixture.setup();
+    try {
+      const { client } = fixture.getContext();
+
+      const listSchema = z.object({ resources: z.array(z.object({ uri: z.string(), mimeType: z.string().optional() })) });
+      const list = await client.request({ method: "resources/list", params: {} }, listSchema);
+      const listed = list.resources.find(r => r.uri === OBSERVE_APP_RESOURCE_URI);
+      expect(listed).toBeDefined();
+      expect(listed?.mimeType).toBe(MCP_APP_MIME_TYPE);
+
+      const readSchema = z.object({
+        contents: z.array(z.object({ uri: z.string(), mimeType: z.string().optional(), text: z.string().optional() })),
+      });
+      const read = await client.request(
+        { method: "resources/read", params: { uri: OBSERVE_APP_RESOURCE_URI } },
+        readSchema
+      );
+      expect(read.contents).toHaveLength(1);
+      expect(read.contents[0].mimeType).toBe(MCP_APP_MIME_TYPE);
+      // Empty-state or populated — either way the app root renders (guard let ui:// through).
+      expect(read.contents[0].text).toContain("data-observe-app");
+    } finally {
+      await fixture.teardown();
+    }
+  });
+});

--- a/test/server/observeAppToolMeta.test.ts
+++ b/test/server/observeAppToolMeta.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { ToolRegistry } from "../../src/server/toolRegistry";
+import { registerObserveTools } from "../../src/server/observeTools";
+import { OBSERVE_APP_RESOURCE_URI } from "../../src/server/observeAppResource";
+import { z } from "zod";
+
+describe("tool → MCP App UI association via _meta.ui.resourceUri", () => {
+  beforeEach(() => {
+    ToolRegistry.clearTools();
+  });
+
+  test("getToolDefinitions emits _meta.ui.resourceUri when appUiResourceUri is set", () => {
+    ToolRegistry.registerDeviceAware(
+      "dummyApp",
+      "desc",
+      z.object({}),
+      async () => ({ content: [] }),
+      { appUiResourceUri: OBSERVE_APP_RESOURCE_URI }
+    );
+    const def = ToolRegistry.getToolDefinitions().find(d => d.name === "dummyApp");
+    expect((def as { _meta?: { ui?: { resourceUri?: string } } })?._meta?.ui?.resourceUri).toBe(
+      OBSERVE_APP_RESOURCE_URI
+    );
+  });
+
+  test("a tool registered without the option carries no ui _meta", () => {
+    ToolRegistry.registerDeviceAware("plain", "desc", z.object({}), async () => ({ content: [] }));
+    const def = ToolRegistry.getToolDefinitions().find(d => d.name === "plain");
+    expect((def as { _meta?: { ui?: unknown } })?._meta?.ui).toBeUndefined();
+  });
+
+  test("the observe tool advertises ui://automobile/observe", () => {
+    registerObserveTools();
+    const observe = ToolRegistry.getToolDefinitions().find(d => d.name === "observe");
+    expect(observe).toBeDefined();
+    expect((observe as { _meta?: { ui?: { resourceUri?: string } } })?._meta?.ui?.resourceUri).toBe(
+      OBSERVE_APP_RESOURCE_URI
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `ui://automobile/observe` **MCP Apps** resource that renders the latest `observe` view hierarchy as a self-contained, theme-aware, inline SVG overlay (bounding boxes per element) for Apps-capable hosts. Purely **additive**: the `observe` tool's data result is unchanged, and non-Apps hosts ignore the new `_meta.ui.resourceUri` pointer. This is the "Apps first" child of the MCP 2026-07-28 epic; the [SDK-v2 spike](https://github.com/kaeawc/auto-mobile/issues/4666) confirmed Apps is adoptable on the current v1.x SDK, so this ships with no dependency migration.

## Linked Issue

Closes #4669

## Changes

- **`src/server/observeAppResource.ts`** (new) — pure `renderObserveAppHtml(observe, screenshotDataUri?)` reusing the canonical `DefaultElementParser.flattenViewHierarchy` (uniform across Android list-root and iOS dict-root node shapes). SVG `viewBox` is the bounds coordinate space, so overlay rects align at any pixel resolution; fractional iOS point bounds are preserved ([#3206](https://github.com/kaeawc/auto-mobile/issues/3206)). No external fetch/CDN/script. `registerObserveAppResource()` wires it with an injectable data source.
- **`src/server/resourceRegistry.ts`** — allow the `ui:` scheme (and any scheme with a real registered resource) through the `ReadResource` guard.
- **`src/server/toolRegistry.ts`** — new `appUiResourceUri` registration option, emitted as `_meta.ui.resourceUri`.
- **`observeTools.ts` / `index.ts`** — wire observe to advertise and register the resource (reachable on both direct and daemon paths).
- **`schemas/tool-definitions.json`** — regenerated: observe now carries the `_meta.ui` pointer.

## Review response (CodeRabbit / Codex)

- **Screenshot correlation (P2) — addressed.** `getRecentCachedResult()` (hierarchy) and `getLatestScreenshot()` are independent process-global getters with no capture-identity link, and `ObserveResult` has no `deviceId` — so pairing "latest" hierarchy with "latest" screenshot could overlay bounds on a stale or wrong-device image. The production data source now **omits the screenshot** (overlay renders on the themed backdrop); the renderer keeps its `screenshotDataUri` capability for when a correlated source lands. Tracked in [#4682](https://github.com/kaeawc/auto-mobile/issues/4682).
- **postMessage live-update shell (P1) — deferred.** The static resource re-reads the latest observe at each read (fresh for re-fetch hosts) but cannot push updates to a host that caches the UI once; that needs the postMessage data-delivery bridge — the deferred interactive-Apps half of #4669. Tracked in [#4682](https://github.com/kaeawc/auto-mobile/issues/4682).

## Validation

- [x] `bun run lint` + `bun test` — full suite **11996 pass / 0 fail**
- [x] `bun run typecheck` — no new errors (baseline gate)
- [x] `turbo run build` green; **MCP context-threshold benchmark** passes (Tools 95%, within headroom)
- [x] New code uses interfaces + fakes; unit tests <100ms (the one MCP read-path test is a `McpTestFixture` integration test)

## Acceptance criteria

- [x] `observe` advertises a `ui://` resource; non-Apps hosts get the data result unchanged (`_meta` additive; observe payload untouched)
- [x] UI resource fully self-contained (no external fetch/CDN) — asserted
- [x] Renders correctly for seeded Android + iOS fixtures (58 and 4 overlay boxes; fractional iOS bounds preserved)
- [x] Lint/build/typecheck baselines green

## Device Verification

Not run — no live Apps-capable host or device was available this session. Rendering is pinned against the committed Android + iOS observe fixtures. The exact host-facing `_meta.ui.resourceUri` key follows the merged design doc's contract; confirming it against a live host is part of [#4682](https://github.com/kaeawc/auto-mobile/issues/4682).

## Follow-ups

- [ ] [#4682](https://github.com/kaeawc/auto-mobile/issues/4682) — correlated screenshot embedding + postMessage live-update shell
- [ ] Interactive tap-target selection (box → `tapOn`) — deferred per the issue's scope-out
