### PR TITLE
fix(release): refresh apk/ipa checksums for an already-registered version

### DIFF
--- a/scripts/generate-release-constants.sh
+++ b/scripts/generate-release-constants.sh
@@ -163,11 +163,12 @@ if [ -n "$release_version" ]; then
 
   if grep -q "version: \"${release_version}\"" "$constants_path"; then
     # Version already registered — do NOT duplicate the entry, but fall through
-    # to the per-entry runner-sha update below. The release
+    # to the per-entry checksum refresh below. The release
     # job re-runs this after prepare-release already added the entry; skipping
     # entirely would leave runnerSha256 empty (verification disabled) whenever
-    # prepare-release predates the runner-sha wiring.
-    echo "INFO: Version ${release_version} already in registry — refreshing scalar constants only"
+    # prepare-release predates the runner-sha wiring, and would keep stale
+    # apk/ipa checksums from the earlier prepare run (#4683).
+    echo "INFO: Version ${release_version} already in registry — refreshing artifact checksums"
   else
     new_entry="  {
     version: \"${release_version}\",
@@ -261,6 +262,26 @@ fi
 if [ -n "$ios_app_hash" ]; then
   sed_inplace_extended "s/^export const IOS_CTRL_PROXY_APP_HASH: string = \".*\";/export const IOS_CTRL_PROXY_APP_HASH: string = \"${ios_app_hash}\";/" "$tmp_file"
   echo "   iOS app hash: ${ios_app_hash}"
+fi
+
+# Refresh the artifact checksums for an already-registered version (#4683).
+# prepare-release adds the entry, then the release job re-runs this script for the
+# same version; without these the entry keeps the apk/ipa values from the earlier
+# prepare run and release.yml's "Verify APK SHA256 matches source" gate can never
+# pass. The new-entry template above already writes both, so these only matter on
+# the already-registered path — mirroring how runnerSha256 is refreshed below.
+if [ -n "$apk_checksum" ]; then
+  if [ -n "$release_version" ]; then
+    update_registry_field "$tmp_file" "$release_version" "apkSha256" "$apk_checksum"
+  fi
+  echo "   APK SHA256: ${apk_checksum}"
+fi
+
+if [ -n "$ios_checksum" ]; then
+  if [ -n "$release_version" ]; then
+    update_registry_field "$tmp_file" "$release_version" "ipaSha256" "$ios_checksum"
+  fi
+  echo "   iOS CtrlProxy SHA256: ${ios_checksum}"
 fi
 
 if [ -n "$ios_runner_sha256" ]; then

--- a/test/bats/generate-release-constants.bats
+++ b/test/bats/generate-release-constants.bats
@@ -386,3 +386,40 @@ PY
   [ "$status" -ne 0 ]
   [[ "$output" == *"SCREEN_CAPTURE_HELPER_SHA256 must be a valid SHA256"* ]]
 }
+
+# Regression guard for #4683. prepare-release adds the registry entry first, then
+# the release job re-runs this script for the same version. That already-registered
+# path refreshed only runnerSha256/videoJarSha256/screenCaptureHelperSha256, so
+# apkSha256/ipaSha256 kept stale values from an earlier prepare run and the release
+# job's "Verify APK SHA256 matches source" gate could never pass.
+@test "refreshes apkSha256 and ipaSha256 for an already-registered version" {
+  local constants="${TEST_ROOT}/src/constants/release.ts"
+
+  apk_before="$(read_field_for_version 0.0.46 apkSha256 "$constants")"
+  ipa_before="$(read_field_for_version 0.0.46 ipaSha256 "$constants")"
+  [ -n "$apk_before" ]
+  [ -n "$ipa_before" ]
+  # Guard the guard: the fixture must not already hold the values we write.
+  [ "$apk_before" != "$APK_SHA" ]
+  [ "$ipa_before" != "$IPA_SHA" ]
+
+  run env \
+    RELEASE_VERSION="0.0.46" \
+    APK_SHA256_CHECKSUM="$APK_SHA" \
+    IOS_CTRL_PROXY_SHA256_CHECKSUM="$IPA_SHA" \
+    IOS_CTRL_PROXY_RUNNER_SHA256="$RUNNER_SHA" \
+    VIDEO_JAR_SHA256="$VIDEO_JAR_SHA" \
+    SCREEN_CAPTURE_HELPER_SHA256="$HELPER_SHA" \
+    bash "${TEST_ROOT}/scripts/generate-release-constants.sh"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"already in registry"* ]]
+
+  [ "$(read_field_for_version 0.0.46 apkSha256 "$constants")" = "$APK_SHA" ]
+  [ "$(read_field_for_version 0.0.46 ipaSha256 "$constants")" = "$IPA_SHA" ]
+
+  # The three fields that already worked must keep working.
+  [ "$(read_field_for_version 0.0.46 runnerSha256 "$constants")" = "$RUNNER_SHA" ]
+  [ "$(read_field_for_version 0.0.46 videoJarSha256 "$constants")" = "$VIDEO_JAR_SHA" ]
+  [ "$(read_field_for_version 0.0.46 screenCaptureHelperSha256 "$constants")" = "$HELPER_SHA" ]
+}


### PR DESCRIPTION
## Summary

`scripts/generate-release-constants.sh` refreshed only three of the five per-version artifact
checksums when the release version was **already registered** in `RELEASE_CHECKSUM_REGISTRY`.
`apkSha256` and `ipaSha256` were never rewritten, so they survived as stale carry-overs from an
earlier prepare run — which is why `release.yml`'s "Verify APK SHA256 matches source" gate could
never pass and the release workflow has not completed since 0.0.44.

This adds the two missing refresh blocks, mirroring the existing `runnerSha256` /
`videoJarSha256` / `screenCaptureHelperSha256` pattern.

## Linked Issue

Closes #4683

## Bug / Regression Context

- **Prior attempts:** [#4356](https://github.com/kaeawc/auto-mobile/pull/4356) fixed the consumer half of the checksum gate failing open; the mint-side write-skip was never covered.
- **Observed symptom:** published 0.0.46 assets mismatch the pinned registry values, so a fresh install hard-fails checksum verification and cannot install the CtrlProxy APK (`observe` returns an empty hierarchy). Tracked in [#4672](https://github.com/kaeawc/auto-mobile/issues/4672).
- **Repro steps / conditions:** `prepare-release` adds the registry entry, then the release job re-runs this script for the same version. Directly visible in the 0.0.46 bump commit — `git show 787aa2bfb -- src/constants/release.ts` updates `screenCaptureHelperSha256`, `runnerSha256` and `videoJarSha256` but leaves `apkSha256`/`ipaSha256` untouched.

## Changes

- `scripts/generate-release-constants.sh`: refresh `apkSha256` and `ipaSha256` for an
  already-registered version via the existing `update_registry_field` helper, guarded on a
  non-empty checksum and a non-empty `RELEASE_VERSION` — the same shape as the three fields that
  already worked. The new-entry and `nightly` paths are untouched (`nightly` already updated
  apk/ipa).
- Corrected the now-inaccurate `INFO: … refreshing scalar constants only` log line.
- `test/bats/generate-release-constants.bats`: regression test for the already-registered path.

## Acceptance criteria

- [x] Running for a version already in the registry refreshes all five fields plus `runnerSha256Target`
- [x] BATS coverage that fails before the fix and passes after — confirmed red at the `apkSha256` assertion, then green
- [x] No behaviour change to the new-entry or `nightly` paths (all 17 pre-existing tests stay green)

## Validation

- [x] `bunx turbo run lint build test` — 3/3 tasks, 12009 tests across 853 files, green
- [x] `bun run typecheck` — no new type errors (198 known in baseline)
- [x] `bats test/bats/generate-release-constants.bats` — 18/18
- [x] `shellcheck scripts/generate-release-constants.sh` — clean
- [x] Branched from latest `main`

## Scope note

This makes the bake correct **for whatever tree it is given**. It does not guarantee that tree is the
tagged one — `prepare-release.yml` still builds and hashes a pre-bump tree it may not tag, tracked
separately in [#4686](https://github.com/kaeawc/auto-mobile/issues/4686). Both are needed for a
reliable release.
