### PR TITLE
fix(release): add pipefail to mint-side checksum steps

### DIFF
--- a/.github/workflows/build-control-proxy-apk.yml
+++ b/.github/workflows/build-control-proxy-apk.yml
@@ -45,6 +45,8 @@ jobs:
       - name: "Calculate APK SHA256"
         id: checksum
         run: |
+          # pipefail so a failing sha256sum is not masked by a succeeding cut (#4684).
+          set -euo pipefail
           APK_PATH="android/control-proxy/build/outputs/apk/debug/control-proxy-debug.apk"
           SHA256=$(sha256sum "$APK_PATH" | cut -d' ' -f1)
           echo "sha256=$SHA256" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-screen-capture-helper.yml
+++ b/.github/workflows/build-screen-capture-helper.yml
@@ -66,6 +66,8 @@ jobs:
       - name: "Calculate helper archive SHA256"
         id: checksum
         run: |
+          # pipefail so a failing shasum is not masked by a succeeding cut (#4684).
+          set -euo pipefail
           SHA256=$(shasum -a 256 /tmp/screen-capture-helper-macos-universal.zip | cut -d' ' -f1)
           echo "sha256=${SHA256}" >> "${GITHUB_OUTPUT}"
           echo "screen-capture-helper SHA256: ${SHA256}"

--- a/.github/workflows/build-video-server-jar.yml
+++ b/.github/workflows/build-video-server-jar.yml
@@ -51,6 +51,8 @@ jobs:
       - name: "Calculate jar SHA256"
         id: checksum
         run: |
+          # pipefail so a failing sha256sum is not masked by a succeeding cut (#4684).
+          set -euo pipefail
           JAR_PATH="android/video-server/build/libs/automobile-video.jar"
           SHA256=$(sha256sum "$JAR_PATH" | cut -d' ' -f1)
           echo "sha256=$SHA256" >> $GITHUB_OUTPUT
@@ -59,6 +61,9 @@ jobs:
       - name: "Verify reproducible build"
         if: ${{ inputs.verify-reproducible }}
         run: |
+          # pipefail so a failing sha256sum is not masked by a succeeding cut — an
+          # empty SECOND_SHA would otherwise read as a reproducibility failure (#4684).
+          set -euo pipefail
           JAR_PATH="android/video-server/build/libs/automobile-video.jar"
           FIRST_SHA="${{ steps.checksum.outputs.sha256 }}"
           # Clean the module output and rebuild from scratch. A byte-identical

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -114,6 +114,9 @@ jobs:
       - name: Calculate SHA256 checksums
         id: checksum
         run: |
+          # pipefail so a failing sha256sum is not masked by a succeeding cut,
+          # which would record an empty checksum and bake it into the registry (#4684).
+          set -euo pipefail
           APK_SHA256=$(sha256sum /tmp/control-proxy-debug.apk | cut -d' ' -f1)
           echo "apk_sha256=$APK_SHA256" >> "$GITHUB_OUTPUT"
           echo "APK SHA256: $APK_SHA256"


### PR DESCRIPTION
## Summary

Checksum-minting steps piped `sha256sum`/`shasum` into `cut` without `pipefail`, so a failure in the
hash command was masked by a succeeding `cut` and the step recorded an **empty** checksum instead of
failing. [#4356](https://github.com/kaeawc/auto-mobile/pull/4356) fixed this class on the consumer
side; the mint side was never covered.

## Linked Issue

Closes #4684

## Bug / Regression Context

- **Prior attempts:** [#4356](https://github.com/kaeawc/auto-mobile/pull/4356) closed the consumer half only.
- **Observed symptom:** a silent mint-side failure bakes a wrong/empty checksum into `src/constants/release.ts`, which then either blocks the release at the verify gate or ships a registry entry no artifact matches. This is the shape of the 0.0.45 failure at "Generate release constants".
- **Repro conditions:** any `sha256sum` failure (missing/unreadable artifact) inside these steps — `cut` still exits 0, so the step succeeds with `SHA256=""`.

## Changes

`set -euo pipefail` added to the five affected `run:` blocks, matching the convention already used
elsewhere in these files (`prepare-release.yml:154`, `:221`, `:248`,
`build-screen-capture-helper.yml:53`):

- `.github/workflows/prepare-release.yml` — "Calculate SHA256 checksums" (covers all four hashes)
- `.github/workflows/build-control-proxy-apk.yml` — "Calculate APK SHA256"
- `.github/workflows/build-video-server-jar.yml` — "Calculate jar SHA256" **and** "Verify reproducible build" (a second unguarded `sha256sum`; an empty `SECOND_SHA` there would read as a reproducibility failure)
- `.github/workflows/build-screen-capture-helper.yml` — "Calculate helper archive SHA256"

Note `build-screen-capture-helper.yml:53` already had `set -euo pipefail`, but it belongs to a
*different* step ("Write App Store Connect API key"); the checksum step at `:66-71` was its own
unguarded block.

## Acceptance criteria

- [x] Every listed step fails loudly when its hash command fails, rather than producing an empty checksum
- [x] No shared helper introduced — none exists in `scripts/` (the `compute_sha256` functions in `scripts/ci/*.sh` are private per-script), so inline guards matching existing convention were preferred over inventing one
- [x] Logic is inline YAML, so no BATS coverage applies; verified by an audit script asserting every `sha256sum`/`shasum` step in these four files is pipefail-guarded (0 unguarded)

## Validation

- [x] `bunx turbo run lint build test` — 3/3 tasks, 12009 tests across 853 files, 0 failures
- [x] `bun run typecheck` — no new type errors (198 known in baseline)
- [x] All four workflow files parse as valid YAML
- [x] Audit: 5/5 checksum steps guarded, 0 unguarded
- [x] Branched from latest `main` (`fd15f5dd8`, which includes [#4691](https://github.com/kaeawc/auto-mobile/pull/4691))

## Context

Item 2 of the release-repair sequence tracked in [#4672](https://github.com/kaeawc/auto-mobile/issues/4672).
