### PR TITLE
Desktop workspace: emulator controls on each device pane (rotate · screenshot · snapshot + contextual Unlock)

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import dev.jasonpearson.automobile.desktop.core.mcp.DaemonMcpResourceClient
 import dev.jasonpearson.automobile.desktop.core.settings.SettingsProvider
 import dev.jasonpearson.automobile.desktop.core.shell.MenuBarActions
@@ -25,6 +26,8 @@ import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerAct
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerEffect
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerViewModel
 import dev.jasonpearson.automobile.desktop.theme.AutoMobileTheme
+
+private val LOG = LoggerFactory.getLogger("AutoMobileDesktopApp")
 
 /**
  * Wraps a [SettingsProvider] so that [themeMode] is backed by Compose snapshot state, enabling
@@ -61,9 +64,18 @@ fun AutoMobileDesktopApp(
   // devices turns them into workspace columns.
   LaunchedEffect(workspaceViewModel) {
     workspaceViewModel.effect.collect { effect ->
-      if (effect is WorkspaceEffect.OpenPicker) {
-        pickerViewModel.onAction(DevicePickerAction.Refresh)
-        pickerOpen = true
+      when (effect) {
+        is WorkspaceEffect.OpenPicker -> {
+          pickerViewModel.onAction(DevicePickerAction.Refresh)
+          pickerOpen = true
+        }
+        // Emulator-control execution is deferred to #4694; drain + log the intent for now so the
+        // effect channel doesn't back up. The control UI + intent contract ships in this PR.
+        is WorkspaceEffect.RunControl ->
+          LOG.info(
+            "Emulator control ${effect.control} requested for ${effect.deviceId} " +
+              "(${effect.platform}); execution deferred to #4694"
+          )
       }
     }
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceModels.kt
@@ -27,6 +27,19 @@ enum class Tool(val icon: String, val label: String) {
   Performance("⚡", "Performance"), // ⚡
 }
 
+/**
+ * Emulator controls that float on each device stream. These are one-shot device actions: the
+ * workspace emits an intent and the host runs it against the device. [Unlock] is contextual — shown
+ * only when the column is `locked`. The non-one-shot `locale` (needs a target picker) and `more`
+ * (overflow menu) controls are a follow-up.
+ */
+enum class EmulatorControl(val icon: String, val label: String) {
+  Rotate("🔄", "Rotate"), // 🔄
+  Screenshot("📸", "Screenshot"), // 📸
+  Snapshot("🗂", "Snapshot"), // 🗂
+  Unlock("🔓", "Unlock"), // 🔓
+}
+
 /** High-level health rollup shown as the single status dot in the top bar. */
 enum class WorkspaceStatus {
   Green,

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -163,6 +163,9 @@ private fun EmulatorControls(
   modifier: Modifier,
 ) {
   Row(modifier, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+    // Unlock is gated on the pane's lock state; rotate/screenshot/snapshot always show. Production
+    // does not yet feed DeviceColumn.locked (that needs device-state plumbing), so Unlock only
+    // becomes reachable once #4694 wires the observed lock state in.
     EmulatorControl.entries
       .filter { it != EmulatorControl.Unlock || column.locked }
       .forEach { control ->

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -135,14 +135,44 @@ private fun DeviceColumnView(
       )
   ) {
     DeviceColumnHeader(column, onAction)
-    // placeholder stream area — real WebRTC stream + emulator controls land in a later PR
+    // placeholder stream area — the real WebRTC stream lands in a later PR; the emulator controls
+    // float over it now.
     Box(
       modifier =
         Modifier.weight(1f).fillMaxWidth().background(MaterialTheme.colorScheme.surfaceVariant),
       contentAlignment = Alignment.Center,
     ) {
       Text("stream", color = MaterialTheme.colorScheme.outline)
+      EmulatorControls(
+        column = column,
+        onAction = onAction,
+        modifier = Modifier.align(Alignment.TopCenter).padding(6.dp),
+      )
     }
+  }
+}
+
+/**
+ * Emulator controls floating on a device stream: rotate · screenshot · snapshot, plus a contextual
+ * 🔓 Unlock shown only when the device is locked. Each is a one-shot [WorkspaceAction.RunControl].
+ */
+@Composable
+private fun EmulatorControls(
+  column: DeviceColumn,
+  onAction: (WorkspaceAction) -> Unit,
+  modifier: Modifier,
+) {
+  Row(modifier, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+    EmulatorControl.entries
+      .filter { it != EmulatorControl.Unlock || column.locked }
+      .forEach { control ->
+        Glyph(
+          text = control.icon,
+          description = "${control.label} ${column.name}",
+          active = false,
+          onClick = { onAction(WorkspaceAction.RunControl(column.deviceId, control)) },
+        )
+      }
   }
 }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModel.kt
@@ -36,12 +36,25 @@ sealed interface WorkspaceAction {
   data class ToggleShrink(val deviceId: String) : WorkspaceAction
 
   data class SelectTool(val deviceId: String, val tool: Tool?) : WorkspaceAction
+
+  /** Run an emulator control against a device pane (rotate, screenshot, snapshot, unlock). */
+  data class RunControl(val deviceId: String, val control: EmulatorControl) : WorkspaceAction
 }
 
 /** One-shot effects emitted by the workspace. */
 sealed interface WorkspaceEffect {
   /** Open the device picker. Wired to a real screen in a later PR. */
   data object OpenPicker : WorkspaceEffect
+
+  /**
+   * Run an emulator [control] against the device. Carries the resolved [platform] so the host can
+   * dispatch the right device call without re-reading workspace state.
+   */
+  data class RunControl(
+    val deviceId: String,
+    val platform: Platform,
+    val control: EmulatorControl,
+  ) : WorkspaceEffect
 }
 
 /**
@@ -64,6 +77,7 @@ class WorkspaceViewModel(private val scope: CoroutineScope) {
       is WorkspaceAction.SetMode -> mutate(action.deviceId) { it.copy(mode = action.mode) }
       is WorkspaceAction.ToggleShrink -> mutate(action.deviceId) { it.copy(shrunk = !it.shrunk) }
       is WorkspaceAction.SelectTool -> mutate(action.deviceId) { it.copy(activeTool = action.tool) }
+      is WorkspaceAction.RunControl -> runControl(action.deviceId, action.control)
     }
   }
 
@@ -97,6 +111,13 @@ class WorkspaceViewModel(private val scope: CoroutineScope) {
         WorkspaceUiState.Content(remaining, focusedDeviceId = focus)
       }
     }
+  }
+
+  /** Emit a [WorkspaceEffect.RunControl] for the targeted column; unknown ids are a no-op. */
+  private fun runControl(deviceId: String, control: EmulatorControl) {
+    val content = _state.value as? WorkspaceUiState.Content ?: return
+    val column = content.columns.firstOrNull { it.deviceId == deviceId } ?: return
+    scope.launch { _effect.send(WorkspaceEffect.RunControl(deviceId, column.platform, control)) }
   }
 
   private fun focus(deviceId: String) {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
@@ -80,4 +80,45 @@ class WorkspaceShellUiTest {
     onNodeWithText("Pixel 8").assertIsDisplayed()
     onNodeWithText("iPhone 15").assertIsDisplayed()
   }
+
+  @Test
+  fun `pane renders rotate screenshot and snapshot controls`() = runComposeUiTest {
+    val state =
+      WorkspaceUiState.Content(columns = listOf(col("a", "Pixel 8")), focusedDeviceId = "a")
+    setContent { MaterialTheme { WorkspaceShell(state = state, onAction = {}, onOpenPicker = {}) } }
+    onNodeWithContentDescription("Rotate Pixel 8").assertIsDisplayed()
+    onNodeWithContentDescription("Screenshot Pixel 8").assertIsDisplayed()
+    onNodeWithContentDescription("Snapshot Pixel 8").assertIsDisplayed()
+  }
+
+  @Test
+  fun `Unlock control appears only when the device is locked`() = runComposeUiTest {
+    val state =
+      WorkspaceUiState.Content(
+        columns = listOf(col("a", "Pixel 8").copy(locked = true)),
+        focusedDeviceId = "a",
+      )
+    setContent { MaterialTheme { WorkspaceShell(state = state, onAction = {}, onOpenPicker = {}) } }
+    onNodeWithContentDescription("Unlock Pixel 8").assertIsDisplayed()
+  }
+
+  @Test
+  fun `Unlock control is absent when the device is unlocked`() = runComposeUiTest {
+    val state =
+      WorkspaceUiState.Content(columns = listOf(col("a", "Pixel 8")), focusedDeviceId = "a")
+    setContent { MaterialTheme { WorkspaceShell(state = state, onAction = {}, onOpenPicker = {}) } }
+    onNodeWithContentDescription("Unlock Pixel 8").assertDoesNotExist()
+  }
+
+  @Test
+  fun `clicking a control dispatches RunControl for that column`() = runComposeUiTest {
+    var action: WorkspaceAction? = null
+    val state =
+      WorkspaceUiState.Content(columns = listOf(col("a", "Pixel 8")), focusedDeviceId = "a")
+    setContent {
+      MaterialTheme { WorkspaceShell(state = state, onAction = { action = it }, onOpenPicker = {}) }
+    }
+    onNodeWithContentDescription("Screenshot Pixel 8").performClick()
+    assertEquals(WorkspaceAction.RunControl("a", EmulatorControl.Screenshot), action)
+  }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModelTest.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.desktop.core.workspace
 
+import app.cash.turbine.test
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -105,5 +106,32 @@ class WorkspaceViewModelTest {
     assertEquals(InteractionMode.Input, b.mode)
     assertTrue(!b.shrunk)
     assertNull(b.activeTool)
+  }
+
+  @Test
+  fun `RunControl emits an effect carrying the target device platform`() = testScope.runTest {
+    val vm = WorkspaceViewModel(this)
+    vm.onAction(WorkspaceAction.ObserveDevice(column("a", Platform.Ios)))
+    vm.effect.test {
+      vm.onAction(WorkspaceAction.RunControl("a", EmulatorControl.Rotate))
+      val effect = awaitItem()
+      assertTrue("Expected RunControl but was $effect", effect is WorkspaceEffect.RunControl)
+      effect as WorkspaceEffect.RunControl
+      assertEquals("a", effect.deviceId)
+      assertEquals(Platform.Ios, effect.platform)
+      assertEquals(EmulatorControl.Rotate, effect.control)
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
+
+  @Test
+  fun `RunControl for an unknown device emits nothing`() = testScope.runTest {
+    val vm = WorkspaceViewModel(this)
+    vm.onAction(WorkspaceAction.ObserveDevice(column("a")))
+    vm.effect.test {
+      vm.onAction(WorkspaceAction.RunControl("nope", EmulatorControl.Screenshot))
+      expectNoEvents()
+      cancelAndIgnoreRemainingEvents()
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adds the wireframe's **emulator controls** to each observed device pane in the Compose Desktop
workspace: a control cluster floating on each device stream — **🔄 rotate · 📸 screenshot · 🗂
snapshot** — plus a contextual **🔓 Unlock** that appears only when the device is `locked`. Each
control is a one-shot `WorkspaceAction.RunControl` intent; the `WorkspaceViewModel` resolves the
target column and emits a `WorkspaceEffect.RunControl(deviceId, platform, control)`.

Real device execution is intentionally deferred to a follow-up (see below) — this PR ships the
tested control UI + intent/effect, mirroring how [#4667](https://github.com/kaeawc/auto-mobile/pull/4667)
shipped the emoji tool row, ✋↔🔍 mode toggle, and shrink as UI + state with device behavior deferred.
The host observes the new effect and drains + logs it. Continues the desktop-app UX build-out after
[#4667](https://github.com/kaeawc/auto-mobile/pull/4667) (shell + pane chrome) and
[#4679](https://github.com/kaeawc/auto-mobile/pull/4679) (device picker).

Wireframe spec (`docs/design-docs/plat/android/desktop-app-wireframes/README.md`, W1–W8):
"Emulator controls float on each stream … with a contextual Unlock when the device is locked."

## Linked Issue

Closes #4690

## Changes

- `WorkspaceModels.kt` — new `EmulatorControl` enum (Rotate · Screenshot · Snapshot · Unlock).
- `WorkspaceViewModel.kt` — `WorkspaceAction.RunControl` + `WorkspaceEffect.RunControl`; `runControl`
  resolves the column and emits the effect (unknown id = no-op).
- `WorkspaceShell.kt` — `EmulatorControls` composable floating on the pane stream; Unlock gated on
  `DeviceColumn.locked`.
- `AutoMobileDesktopApp.kt` — host observes `RunControl` and logs it (execution deferred to #4694).

## Validation

- [x] Android: `:desktop-core:detektMain` + `:desktop-app:detektMain`, `:desktop-core:test` (full
      suite), `:desktop-app:compileKotlin`, and `scripts/ktfmt/apply_ktfmt.sh` — all green locally.
- [x] New code uses the repo's ViewModel convention (sealed state/action/effect + StateFlow/Channel);
      unit tests are TestScope + Turbine and Compose `runComposeUiTest`, all <100ms.
- [x] Kotlin reuse: reuses the existing `Glyph` composable, `EmulatorControl.entries`, and the
      established effect-collector seam in the host — no new helpers or dependencies.
- [x] Rebased onto latest `main`.
- Not applicable: TS `lint`/`typecheck` (no `src/` change); Device Verification (no on-device behavior
  ships — execution is deferred).

## Acceptance criteria

1. ✅ Each pane renders rotate · screenshot · snapshot controls — `WorkspaceShellUiTest`.
2. ✅ Unlock appears only when `locked` — `WorkspaceShellUiTest` (present/absent cases).
3. ✅ Triggering a control emits an effect carrying the device's id + platform; unknown id emits
   nothing — `WorkspaceViewModelTest` (Turbine).
4. ✅ (revised) Host drains + logs the effect; real device execution is #4694.

## Follow-ups

- [x] #4694 — execute the control intents against the real device (rotate needs per-column
  orientation state; there is no `screenshot` MCP tool; `deviceSnapshot`/`wakeAndUnlock` map cleanly).
  Also folds in the deferred `locale` + `more` controls.
