### PR TITLE
ci(release): trigger on tag pushes only, not every branch creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,14 @@ jobs:
     name: "Validate Release Tag"
     runs-on: ubuntu-latest
     # The push trigger is already tag-filtered, so any push event here is a tag;
-    # workflow_dispatch is the explicit release path. Both should run.
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
+    # workflow_dispatch is the explicit release path. Both should run. A tag
+    # *deletion* also arrives as a push (github.event.deleted == true) with the
+    # deleted tag still in github.ref_name, which would otherwise pass validation
+    # and start the build/publish jobs against a tag that no longer exists -- the
+    # former create: trigger never fired on deletion, so guard it explicitly.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && github.event.deleted == false)
     outputs:
       is_release_tag: ${{ steps.validate.outputs.is_release_tag }}
       tag: ${{ steps.validate.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,18 @@
 name: Release
 
 "on":
-  create:
-  # prepare-release dispatches this explicitly after pushing the tag. The `create`
-  # event above did not fire for CI-pushed tags (see v0.0.42/v0.0.44: the tag push
-  # succeeded and no Release run was ever queued), so the tag event alone cannot be
-  # relied on to start a release.
+  # Tag pushes only. Replaces the former `create:` trigger, which also fired on
+  # every branch creation and queued a Release run that immediately skipped
+  # (ref_type != tag) -- noise on the Actions list. `push.tags` fires only for
+  # tag refs, so no branch-creation runs are ever queued.
+  push:
+    tags:
+      - "*"
+  # prepare-release dispatches this explicitly after pushing the tag. A tag pushed
+  # by CI with GITHUB_TOKEN does not trigger the `push` event above (Actions does
+  # not re-trigger workflows from the default token; see v0.0.42/v0.0.44, where the
+  # tag push queued no Release run), so the push trigger alone cannot be relied on
+  # to start a release. The push trigger is the fallback for a hand-pushed tag.
   workflow_dispatch:
     inputs:
       tag:
@@ -14,13 +21,16 @@ name: Release
         required: true
         type: string
 
-# `create:` is retained as a fallback for a hand-pushed tag, so one tag could in
-# principle arrive by both routes. This serializes them; it does NOT dedupe them
-# -- with cancel-in-progress false the second run queues and then starts once the
-# first finishes. What makes that second run harmless is the already-published.sh
-# guard on each non-idempotent publish step, not this block. Both are required.
+# A hand-pushed tag can arrive by both `push` and a subsequent dispatch, so one
+# tag could start two runs. This serializes them; it does NOT dedupe them -- with
+# cancel-in-progress false the second run queues and then starts once the first
+# finishes. What makes that second run harmless is the already-published.sh guard
+# on each non-idempotent publish step, not this block. Both are required.
+# github.ref_name (not github.event.ref) is used so the push path -- where
+# github.event.ref is the full "refs/tags/X" -- lands in the same group as the
+# dispatch path, which keys on the short tag from inputs.tag.
 concurrency:
-  group: release-${{ inputs.tag || github.event.ref }}
+  group: release-${{ inputs.tag || github.ref_name }}
   cancel-in-progress: false
 
 permissions:
@@ -33,8 +43,9 @@ jobs:
   validate-release-tag:
     name: "Validate Release Tag"
     runs-on: ubuntu-latest
-    # workflow_dispatch carries no ref_type; only the create path needs the tag gate.
-    if: github.event_name == 'workflow_dispatch' || github.event.ref_type == 'tag'
+    # The push trigger is already tag-filtered, so any push event here is a tag;
+    # workflow_dispatch is the explicit release path. Both should run.
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
     outputs:
       is_release_tag: ${{ steps.validate.outputs.is_release_tag }}
       tag: ${{ steps.validate.outputs.tag }}
@@ -43,7 +54,7 @@ jobs:
         id: validate
         shell: bash
         env:
-          TAG: ${{ inputs.tag || github.event.ref }}
+          TAG: ${{ inputs.tag || github.ref_name }}
           EVENT_NAME: ${{ github.event_name }}
           REF_TYPE: ${{ github.ref_type }}
           REF_NAME: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

`release.yml` triggers on `create:`, which GitHub fires on **branch and tag** creation. Every new
branch (every `work/…`, `fix/…`, `dependabot/…` push) therefore queues a Release run that immediately
skips at the job gate (`github.event.ref_type == 'tag'` is false). The Actions "Release" list is mostly
1–2s skipped runs, one per branch created.

## Proposed change

Replace the `create:` trigger with a tag-filtered `push:`:

```yaml
"on":
  push:
    tags:
      - "*"
  workflow_dispatch:
    inputs:
      tag: { ... }
```

`push.tags` fires only for tag refs, so no branch-creation run is ever queued. This is a strict
improvement over `create` for the fallback purpose: `create` fired on branches (noise) and only once
per ref; `push.tags` fires exactly on tag pushes.

## Correctness notes

- The primary release path is unchanged: prepare-release dispatches `release.yml` via
  `workflow_dispatch`. A CI tag push with `GITHUB_TOKEN` does not trigger `push` (same reason it did not
  trigger `create` — Actions does not re-trigger from the default token), so the event trigger remains a
  fallback for a **hand-pushed** tag, exactly as before.
- `github.event.ref` is the short name (`0.0.47`) on `create` but the full ref (`refs/tags/0.0.47`) on
  `push`. Both usages (the concurrency group key and the validate step's `TAG`) switch to
  `github.ref_name`, which is short on both and is short-circuited by `inputs.tag` on the dispatch path —
  keeping the two routes in the same concurrency group and the semver regex intact.
- The job gate becomes `event_name == 'workflow_dispatch' || event_name == 'push'`; since `push` is
  tag-filtered, every push event is a tag.

## Acceptance criteria

1. No Release run is queued on branch creation.
2. A dispatched release (prepare-release path) still runs and validates identically.
3. A hand-pushed release tag still triggers a run.
4. `actionlint` introduces no new findings.

## Context

Cosmetic cleanup surfaced while preparing the 0.0.47 re-cut ([#4672](https://github.com/kaeawc/auto-mobile/issues/4672)). Not a release blocker.
