### PR TITLE
Desktop workspace: per-pane docked facet (tool window) with shrink-to-grow

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceModels.kt
@@ -61,3 +61,11 @@ data class DeviceColumn(
   val shrunk: Boolean = false,
   val locked: Boolean = false,
 )
+
+/**
+ * Fraction of a pane's content height given to the docked facet when a tool is active. Shrinking
+ * the pane (⤡) collapses the stream to grow the facet, so the shrunk fraction is the larger one.
+ * The complement `1 - fraction` is the stream's share; both stay strictly within (0, 1) so they are
+ * valid Compose weights.
+ */
+internal fun facetHeightFraction(shrunk: Boolean): Float = if (shrunk) 0.8f else 0.35f

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceModels.kt
@@ -61,11 +61,3 @@ data class DeviceColumn(
   val shrunk: Boolean = false,
   val locked: Boolean = false,
 )
-
-/**
- * Fraction of a pane's content height given to the docked facet when a tool is active. Shrinking
- * the pane (⤡) collapses the stream to grow the facet, so the shrunk fraction is the larger one.
- * The complement `1 - fraction` is the stream's share; both stay strictly within (0, 1) so they are
- * valid Compose weights.
- */
-internal fun facetHeightFraction(shrunk: Boolean): Float = if (shrunk) 0.8f else 0.35f

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
 private val StatusGreen = Color(0xFF40C057)
@@ -120,6 +121,14 @@ private fun EmptyState(onOpenPicker: () -> Unit, modifier: Modifier) {
   }
 }
 
+/**
+ * Fraction of a pane's content height given to the docked facet when a tool is active. Shrinking
+ * the pane (⤡) collapses the stream to grow the facet, so the shrunk fraction is the larger one.
+ * The complement `1 - fraction` is the stream's share; both stay strictly within (0, 1) so they are
+ * valid Compose weights. `internal` (not `private`) so the same-module pure test can pin the ratio.
+ */
+internal fun facetHeightFraction(shrunk: Boolean): Float = if (shrunk) 0.8f else 0.35f
+
 @Composable
 private fun DeviceColumnView(
   column: DeviceColumn,
@@ -190,8 +199,16 @@ private fun DockedFacet(
     ) {
       Text(tool.icon)
       Spacer(Modifier.width(6.dp))
-      Text(tool.label, style = MaterialTheme.typography.labelLarge)
-      Spacer(Modifier.weight(1f))
+      // Weighted + ellipsized so a long label on a narrow pane yields space to the close control
+      // instead of pushing it off-screen.
+      Text(
+        tool.label,
+        style = MaterialTheme.typography.labelLarge,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        modifier = Modifier.weight(1f),
+      )
+      Spacer(Modifier.width(6.dp))
       Glyph(
         text = "✕",
         description = "Close ${tool.label} facet on ${column.name}",
@@ -252,7 +269,8 @@ private fun DeviceColumnHeader(column: DeviceColumn, onAction: (WorkspaceAction)
       val active = column.activeTool == tool
       Glyph(
         text = tool.icon,
-        description = tool.label,
+        // Device name disambiguates identical tool labels across panes for a11y / automation.
+        description = "${tool.label} ${column.name}",
         active = active,
         // Re-tapping the active tool closes its facet.
         onClick = {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -135,19 +135,72 @@ private fun DeviceColumnView(
       )
   ) {
     DeviceColumnHeader(column, onAction)
-    // placeholder stream area — the real WebRTC stream lands in a later PR; the emulator controls
-    // float over it now.
-    Box(
-      modifier =
-        Modifier.weight(1f).fillMaxWidth().background(MaterialTheme.colorScheme.surfaceVariant),
-      contentAlignment = Alignment.Center,
+    val tool = column.activeTool
+    if (tool == null) {
+      StreamArea(column, onAction, Modifier.weight(1f))
+    } else {
+      // With a tool active the pane splits stream + docked facet; ⤡ shrink flips the split so the
+      // stream collapses to grow the facet.
+      val facetFraction = facetHeightFraction(column.shrunk)
+      StreamArea(column, onAction, Modifier.weight(1f - facetFraction))
+      DockedFacet(column, tool, onAction, Modifier.weight(facetFraction))
+    }
+  }
+}
+
+/**
+ * Placeholder device stream with the emulator controls floating on it. The real WebRTC stream lands
+ * in a later PR.
+ */
+@Composable
+private fun StreamArea(
+  column: DeviceColumn,
+  onAction: (WorkspaceAction) -> Unit,
+  modifier: Modifier,
+) {
+  Box(
+    modifier = modifier.fillMaxWidth().background(MaterialTheme.colorScheme.surfaceVariant),
+    contentAlignment = Alignment.Center,
+  ) {
+    Text("stream", color = MaterialTheme.colorScheme.outline)
+    EmulatorControls(
+      column = column,
+      onAction = onAction,
+      modifier = Modifier.align(Alignment.TopCenter).padding(6.dp),
+    )
+  }
+}
+
+/**
+ * The docked facet (tool window) for a pane's active [tool]: a header with the tool icon + label
+ * and a ✕ that deselects the tool, over a placeholder body. Real per-tool dashboard content is
+ * deferred — the existing dashboards target a single active device, not a per-pane one.
+ */
+@Composable
+private fun DockedFacet(
+  column: DeviceColumn,
+  tool: Tool,
+  onAction: (WorkspaceAction) -> Unit,
+  modifier: Modifier,
+) {
+  Column(modifier.fillMaxWidth().background(MaterialTheme.colorScheme.surface)) {
+    Row(
+      modifier = Modifier.fillMaxWidth().height(30.dp).padding(horizontal = 8.dp),
+      verticalAlignment = Alignment.CenterVertically,
     ) {
-      Text("stream", color = MaterialTheme.colorScheme.outline)
-      EmulatorControls(
-        column = column,
-        onAction = onAction,
-        modifier = Modifier.align(Alignment.TopCenter).padding(6.dp),
+      Text(tool.icon)
+      Spacer(Modifier.width(6.dp))
+      Text(tool.label, style = MaterialTheme.typography.labelLarge)
+      Spacer(Modifier.weight(1f))
+      Glyph(
+        text = "✕",
+        description = "Close ${tool.label} facet on ${column.name}",
+        active = false,
+        onClick = { onAction(WorkspaceAction.SelectTool(column.deviceId, null)) },
       )
+    }
+    Box(Modifier.weight(1f).fillMaxWidth(), contentAlignment = Alignment.Center) {
+      Text("${tool.label} — coming soon", color = MaterialTheme.colorScheme.outline)
     }
   }
 }
@@ -196,11 +249,15 @@ private fun DeviceColumnHeader(column: DeviceColumn, onAction: (WorkspaceAction)
     ModeToggle(column, onAction)
     Spacer(Modifier.weight(1f))
     Tool.entries.forEach { tool ->
+      val active = column.activeTool == tool
       Glyph(
         text = tool.icon,
         description = tool.label,
-        active = column.activeTool == tool,
-        onClick = { onAction(WorkspaceAction.SelectTool(column.deviceId, tool)) },
+        active = active,
+        // Re-tapping the active tool closes its facet.
+        onClick = {
+          onAction(WorkspaceAction.SelectTool(column.deviceId, if (active) null else tool))
+        },
       )
     }
     Spacer(Modifier.width(4.dp))

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceLayoutTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceLayoutTest.kt
@@ -1,0 +1,20 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WorkspaceLayoutTest {
+
+  @Test
+  fun `facet grows when the stream is shrunk`() {
+    assertTrue(facetHeightFraction(shrunk = true) > facetHeightFraction(shrunk = false))
+  }
+
+  @Test
+  fun `facet fractions are valid split weights`() {
+    for (shrunk in listOf(true, false)) {
+      val fraction = facetHeightFraction(shrunk)
+      assertTrue("fraction must be in (0,1) but was $fraction", fraction > 0f && fraction < 1f)
+    }
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
@@ -121,4 +121,65 @@ class WorkspaceShellUiTest {
     onNodeWithContentDescription("Screenshot Pixel 8").performClick()
     assertEquals(WorkspaceAction.RunControl("a", EmulatorControl.Screenshot), action)
   }
+
+  @Test
+  fun `active tool renders a docked facet with a close control`() = runComposeUiTest {
+    val state =
+      WorkspaceUiState.Content(
+        columns = listOf(col("a", "Pixel 8").copy(activeTool = Tool.Logs)),
+        focusedDeviceId = "a",
+      )
+    setContent { MaterialTheme { WorkspaceShell(state = state, onAction = {}, onOpenPicker = {}) } }
+    onNodeWithContentDescription("Close Logs facet on Pixel 8").assertIsDisplayed()
+  }
+
+  @Test
+  fun `no active tool renders no facet`() = runComposeUiTest {
+    val state =
+      WorkspaceUiState.Content(columns = listOf(col("a", "Pixel 8")), focusedDeviceId = "a")
+    setContent { MaterialTheme { WorkspaceShell(state = state, onAction = {}, onOpenPicker = {}) } }
+    onNodeWithContentDescription("Close Logs facet on Pixel 8").assertDoesNotExist()
+  }
+
+  @Test
+  fun `facet close deselects the active tool`() = runComposeUiTest {
+    var action: WorkspaceAction? = null
+    val state =
+      WorkspaceUiState.Content(
+        columns = listOf(col("a", "Pixel 8").copy(activeTool = Tool.Logs)),
+        focusedDeviceId = "a",
+      )
+    setContent {
+      MaterialTheme { WorkspaceShell(state = state, onAction = { action = it }, onOpenPicker = {}) }
+    }
+    onNodeWithContentDescription("Close Logs facet on Pixel 8").performClick()
+    assertEquals(WorkspaceAction.SelectTool("a", null), action)
+  }
+
+  @Test
+  fun `re-tapping the active tool toggles it off`() = runComposeUiTest {
+    var action: WorkspaceAction? = null
+    val state =
+      WorkspaceUiState.Content(
+        columns = listOf(col("a", "Pixel 8").copy(activeTool = Tool.Logs)),
+        focusedDeviceId = "a",
+      )
+    setContent {
+      MaterialTheme { WorkspaceShell(state = state, onAction = { action = it }, onOpenPicker = {}) }
+    }
+    onNodeWithContentDescription("Logs").performClick()
+    assertEquals(WorkspaceAction.SelectTool("a", null), action)
+  }
+
+  @Test
+  fun `tapping an inactive tool selects it`() = runComposeUiTest {
+    var action: WorkspaceAction? = null
+    val state =
+      WorkspaceUiState.Content(columns = listOf(col("a", "Pixel 8")), focusedDeviceId = "a")
+    setContent {
+      MaterialTheme { WorkspaceShell(state = state, onAction = { action = it }, onOpenPicker = {}) }
+    }
+    onNodeWithContentDescription("Storage").performClick()
+    assertEquals(WorkspaceAction.SelectTool("a", Tool.Storage), action)
+  }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
@@ -52,8 +52,8 @@ class WorkspaceShellUiTest {
     onNodeWithText("Pixel 8").assertIsDisplayed()
     onNodeWithContentDescription("Input mode").assertIsDisplayed()
     onNodeWithContentDescription("Inspect mode").assertIsDisplayed()
-    onNodeWithContentDescription("Navigation").assertIsDisplayed()
-    onNodeWithContentDescription("Performance").assertIsDisplayed()
+    onNodeWithContentDescription("Navigation Pixel 8").assertIsDisplayed()
+    onNodeWithContentDescription("Performance Pixel 8").assertIsDisplayed()
     onNodeWithContentDescription("Close Pixel 8").assertIsDisplayed()
   }
 
@@ -167,7 +167,7 @@ class WorkspaceShellUiTest {
     setContent {
       MaterialTheme { WorkspaceShell(state = state, onAction = { action = it }, onOpenPicker = {}) }
     }
-    onNodeWithContentDescription("Logs").performClick()
+    onNodeWithContentDescription("Logs Pixel 8").performClick()
     assertEquals(WorkspaceAction.SelectTool("a", null), action)
   }
 
@@ -179,7 +179,7 @@ class WorkspaceShellUiTest {
     setContent {
       MaterialTheme { WorkspaceShell(state = state, onAction = { action = it }, onOpenPicker = {}) }
     }
-    onNodeWithContentDescription("Storage").performClick()
+    onNodeWithContentDescription("Storage Pixel 8").performClick()
     assertEquals(WorkspaceAction.SelectTool("a", Tool.Storage), action)
   }
 }


### PR DESCRIPTION
## Summary

Adds a **docked facet (tool window)** to each observed device pane in the Compose Desktop workspace.
Selecting a tool in the pane's emoji tool row now docks a facet panel inside that pane; re-tapping
the active tool (or the facet's ✕) closes it. With a tool active the pane splits into stream + facet,
and the ⤡ shrink toggle flips the split so the stream collapses to grow the facet — making the
previously-dead `DeviceColumn.shrunk` field functional.

Continues the desktop-app UX build-out after [#4667](https://github.com/kaeawc/auto-mobile/pull/4667)
(shell + pane chrome), [#4679](https://github.com/kaeawc/auto-mobile/pull/4679) (device picker), and
[#4695](https://github.com/kaeawc/auto-mobile/pull/4695) (emulator controls). Wireframe: "emoji tools
+ stream + docked facet"; "⤡ shrink collapses the stream and grows the active tool".

The facet body is a per-tool **placeholder**. Every `Tool` already has a real dashboard
(`NavigationDashboard`, `TelemetryDashboard`, …) reachable via `graph.dataSourceFactory`, but they
were built for the single-active-device `ThreePaneShell` — they target the daemon's active device and
need `selectedAppId`/stream wiring the workspace doesn't track per column. Rendering per-pane content
needs per-device data-source targeting that doesn't exist yet; that's a follow-up.

## Linked Issue

Closes #4699

## Changes

- `WorkspaceModels.kt` — pure `facetHeightFraction(shrunk)` split helper.
- `WorkspaceShell.kt` — extracted `StreamArea`; `DeviceColumnView` splits stream + `DockedFacet` when
  a tool is active; tool-row re-tap toggles the facet closed.

## Validation

- [x] Android `:desktop-core:detektMain` + `:desktop-core:test` (full suite) + `ktfmt` validate — green.
- [x] New code follows the repo's Compose/ViewModel conventions; UI tests via `runComposeUiTest`, the
      split helper via a pure JUnit test, all <100ms.
- [x] Kotlin reuse: reuses the existing `Glyph` composable and the `SelectTool` action/`shrunk` field;
      no new helpers or dependencies beyond one pure function.
- [x] Rebased onto latest `main`.
- Not applicable: TS `lint`/`typecheck` (no `src/` change); Device Verification (placeholder facet, no
  on-device behavior).

## Acceptance criteria

1. ✅ Active tool renders a docked facet (icon + label header) — `WorkspaceShellUiTest`.
2. ✅ Facet ✕ deselects the tool — `WorkspaceShellUiTest`.
3. ✅ Re-tapping the active tool toggles the facet closed; tapping an inactive tool selects it —
   `WorkspaceShellUiTest`.
4. ✅ Stream/facet split flips on shrink via a unit-tested pure helper — `WorkspaceLayoutTest`.
5. ✅ Placeholder facet body (real content deferred).

## Follow-ups

- [ ] Wire each real dashboard into the facet with per-device data-source targeting (own issue to file).
- [ ] ⧉ Diff button — open the same tool on the other observed device(s).
