### PR TITLE
fix(docs): sync daemon docs to default CtrlProxy version 0.0.47

### DIFF
--- a/docs/design-docs/mcp/daemon/client-frame-snapshot.md
+++ b/docs/design-docs/mcp/daemon/client-frame-snapshot.md
@@ -205,7 +205,7 @@ non-null contexts alongside `captureSequence`, then echoes that exact value on
 request. The token is opaque, device-specific, and must never be synthesized or
 compared across reconnects.
 
-The default `0.0.46` CtrlProxy artifacts predate this protocol. A client must
+The default `0.0.47` CtrlProxy artifacts predate this protocol. A client must
 treat those artifacts as legacy and remain in inspector mode until its runner
 publishes `frameContext`.
 

--- a/docs/design-docs/mcp/daemon/client-screen-control.md
+++ b/docs/design-docs/mcp/daemon/client-screen-control.md
@@ -224,7 +224,7 @@ also what lets the retained-frame rule below notice a transition *into* an unkno
   snapshot. Keep its mirror in inspector mode rather than omitting `frameContext` from an input
   request and guessing. The optional field remains compatible with generic, non-screen-control
   socket clients that do not have an observation snapshot.
-- **Release availability:** the default `0.0.46` CtrlProxy artifacts predate `frameContext`
+- **Release availability:** the default `0.0.47` CtrlProxy artifacts predate `frameContext`
   support. Use runners built from a revision that publishes the field before enabling this control
   flow; otherwise treat the runner as legacy and keep the mirror in inspector mode.
 - **Active device:** every message's `deviceId` identifies its device. Subscribe with the selected

--- a/docs/design-docs/mcp/daemon/unix-socket-api.md
+++ b/docs/design-docs/mcp/daemon/unix-socket-api.md
@@ -379,7 +379,7 @@ after the response frame is printed. A screen-control client must replace
 `android-generation-42` with the opaque `frameContext` from its paired screenshot
 and hierarchy; it is illustrative and cannot be reused for another frame.
 These `frameContext` examples require a runner that publishes the field; the
-default `0.0.46` CtrlProxy artifacts are legacy and cannot supply one.
+default `0.0.47` CtrlProxy artifacts are legacy and cannot supply one.
 
 ```bash
 export AUTOMOBILE_DAEMON_SOCKET_PATH="${AUTOMOBILE_DAEMON_SOCKET_PATH:-/tmp/auto-mobile-daemon-$(id -u).sock}"


### PR DESCRIPTION
## Summary

Main is red: the `v0.0.47` `[skip ci]` version bump (commit 46537b2f5) prepended a
`RELEASE_CHECKSUM_REGISTRY` entry, so `registry[0].version` is now `0.0.47`.
`test/docs/daemonInputApiExamples.test.ts` derives `defaultReleaseVersion` from that and asserts the
three daemon docs reference it — but they still said `0.0.46`. Because the bump skipped CI, the
breakage went unreported on `main` until surfaced by an unrelated PR's merge-ref CI.

This updates the three "default \`0.0.46\` CtrlProxy artifacts …" references to `0.0.47` (the
statements remain true — the released runner still predates `frameContext`, tracked in
[#4596](https://github.com/kaeawc/auto-mobile/issues/4596) / [#4586](https://github.com/kaeawc/auto-mobile/issues/4586)).

## Changes

- `docs/design-docs/mcp/daemon/client-screen-control.md`, `client-frame-snapshot.md`,
  `unix-socket-api.md` — `0.0.46` → `0.0.47`.

## Validation

- [x] `bun test test/docs/daemonInputApiExamples.test.ts` — 7/7 pass (was failing on `main`).

## Note

This recurs on every tagged release bump because the docs positionally track
`RELEASE_CHECKSUM_REGISTRY[0].version` while the bump commit skips CI. Out of scope here; the durable
fix would be to update these docs as part of the bump, or make the assertion tolerate the lag.