### PR TITLE
fix(release): reuse prepared artifacts

### DIFF
--- a/.github/workflows/build-control-proxy-apk.yml
+++ b/.github/workflows/build-control-proxy-apk.yml
@@ -41,6 +41,7 @@ jobs:
         with:
           lfs: false
           ref: ${{ inputs.checkout-ref || github.sha }}
+          persist-credentials: false
 
       - uses: ./.github/actions/gradle-task-run
         with:

--- a/.github/workflows/build-control-proxy-apk.yml
+++ b/.github/workflows/build-control-proxy-apk.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: boolean
         default: true
+      artifact-retention-days:
+        description: "How long to retain the uploaded APK artifact"
+        required: false
+        type: number
+        default: 7
     secrets:
       GRADLE_ENCRYPTION_KEY:
         required: true
@@ -74,4 +79,4 @@ jobs:
         with:
           name: control-proxy-apk
           path: /tmp/control-proxy-debug.apk
-          retention-days: 90
+          retention-days: ${{ inputs.artifact-retention-days }}

--- a/.github/workflows/build-control-proxy-apk.yml
+++ b/.github/workflows/build-control-proxy-apk.yml
@@ -2,6 +2,17 @@ name: "Build CtrlProxy APK"
 
 on:
   workflow_call:
+    inputs:
+      checkout-ref:
+        description: "Commit or tag to build; defaults to the caller SHA"
+        required: false
+        type: string
+        default: ""
+      upload-artifact:
+        description: "Whether to upload the built APK as a workflow artifact"
+        required: false
+        type: boolean
+        default: true
     secrets:
       GRADLE_ENCRYPTION_KEY:
         required: true
@@ -29,6 +40,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           lfs: false
+          ref: ${{ inputs.checkout-ref || github.sha }}
 
       - uses: ./.github/actions/gradle-task-run
         with:
@@ -56,6 +68,7 @@ jobs:
         run: cp android/control-proxy/build/outputs/apk/debug/control-proxy-debug.apk /tmp/control-proxy-debug.apk
 
       - name: "Upload CtrlProxy APK"
+        if: ${{ inputs.upload-artifact }}
         uses: actions/upload-artifact@v6
         with:
           name: control-proxy-apk

--- a/.github/workflows/build-control-proxy-apk.yml
+++ b/.github/workflows/build-control-proxy-apk.yml
@@ -74,4 +74,4 @@ jobs:
         with:
           name: control-proxy-apk
           path: /tmp/control-proxy-debug.apk
-          retention-days: 7
+          retention-days: 90

--- a/.github/workflows/build-ctrl-proxy-ios-ipa.yml
+++ b/.github/workflows/build-ctrl-proxy-ios-ipa.yml
@@ -2,6 +2,17 @@ name: "Build CtrlProxy iOS IPA"
 
 on:
   workflow_call:
+    inputs:
+      checkout-ref:
+        description: "Commit or tag to build; defaults to the caller SHA"
+        required: false
+        type: string
+        default: ""
+      upload-artifact:
+        description: "Whether to upload the built IPA as a workflow artifact"
+        required: false
+        type: boolean
+        default: true
     outputs:
       sha256:
         description: "SHA256 checksum of the built IPA"
@@ -22,6 +33,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           lfs: false
+          ref: ${{ inputs.checkout-ref || github.sha }}
 
       - name: "Select Xcode 26.5"
         uses: maxim-lobanov/setup-xcode@v1
@@ -66,6 +78,7 @@ jobs:
         run: ./scripts/ios/ctrl-proxy-create-ipa.sh --output /tmp/control-proxy.ipa
 
       - name: "Upload CtrlProxy iOS IPA"
+        if: ${{ inputs.upload-artifact }}
         uses: actions/upload-artifact@v6
         with:
           name: ctrl-proxy-ios-ipa

--- a/.github/workflows/build-ctrl-proxy-ios-ipa.yml
+++ b/.github/workflows/build-ctrl-proxy-ios-ipa.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: boolean
         default: true
+      artifact-retention-days:
+        description: "How long to retain the uploaded IPA artifact"
+        required: false
+        type: number
+        default: 7
     outputs:
       sha256:
         description: "SHA256 checksum of the built IPA"
@@ -84,4 +89,4 @@ jobs:
         with:
           name: ctrl-proxy-ios-ipa
           path: /tmp/control-proxy.ipa
-          retention-days: 90
+          retention-days: ${{ inputs.artifact-retention-days }}

--- a/.github/workflows/build-ctrl-proxy-ios-ipa.yml
+++ b/.github/workflows/build-ctrl-proxy-ios-ipa.yml
@@ -84,4 +84,4 @@ jobs:
         with:
           name: ctrl-proxy-ios-ipa
           path: /tmp/control-proxy.ipa
-          retention-days: 7
+          retention-days: 90

--- a/.github/workflows/build-ctrl-proxy-ios-ipa.yml
+++ b/.github/workflows/build-ctrl-proxy-ios-ipa.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           lfs: false
           ref: ${{ inputs.checkout-ref || github.sha }}
+          persist-credentials: false
 
       - name: "Select Xcode 26.5"
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/build-screen-capture-helper.yml
+++ b/.github/workflows/build-screen-capture-helper.yml
@@ -91,4 +91,4 @@ jobs:
         with:
           name: screen-capture-helper
           path: /tmp/screen-capture-helper-macos-universal.zip
-          retention-days: 7
+          retention-days: 90

--- a/.github/workflows/build-screen-capture-helper.yml
+++ b/.github/workflows/build-screen-capture-helper.yml
@@ -2,6 +2,17 @@ name: "Build Screen Capture Helper"
 
 on:
   workflow_call:
+    inputs:
+      checkout-ref:
+        description: "Commit or tag to build; defaults to the caller SHA"
+        required: false
+        type: string
+        default: ""
+      upload-artifact:
+        description: "Whether to upload the built archive as a workflow artifact"
+        required: false
+        type: boolean
+        default: true
     secrets:
       MACOS_DEVELOPER_ID_CERT_BASE64:
         required: true
@@ -33,6 +44,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           lfs: false
+          ref: ${{ inputs.checkout-ref || github.sha }}
 
       - name: "Select Xcode 26.5"
         uses: maxim-lobanov/setup-xcode@v1
@@ -73,6 +85,7 @@ jobs:
           echo "screen-capture-helper SHA256: ${SHA256}"
 
       - name: "Upload notarized ScreenCaptureKit helper"
+        if: ${{ inputs.upload-artifact }}
         uses: actions/upload-artifact@v6
         with:
           name: screen-capture-helper

--- a/.github/workflows/build-screen-capture-helper.yml
+++ b/.github/workflows/build-screen-capture-helper.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           lfs: false
           ref: ${{ inputs.checkout-ref || github.sha }}
+          persist-credentials: false
 
       - name: "Select Xcode 26.5"
         uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/build-screen-capture-helper.yml
+++ b/.github/workflows/build-screen-capture-helper.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: boolean
         default: true
+      artifact-retention-days:
+        description: "How long to retain the uploaded helper artifact"
+        required: false
+        type: number
+        default: 7
     secrets:
       MACOS_DEVELOPER_ID_CERT_BASE64:
         required: true
@@ -91,4 +96,4 @@ jobs:
         with:
           name: screen-capture-helper
           path: /tmp/screen-capture-helper-macos-universal.zip
-          retention-days: 90
+          retention-days: ${{ inputs.artifact-retention-days }}

--- a/.github/workflows/build-video-server-jar.yml
+++ b/.github/workflows/build-video-server-jar.yml
@@ -11,6 +11,16 @@ name: "Build video-server jar"
 on:
   workflow_call:
     inputs:
+      checkout-ref:
+        description: "Commit or tag to build; defaults to the caller SHA"
+        required: false
+        type: string
+        default: ""
+      upload-artifact:
+        description: "Whether to upload the built jar as a workflow artifact"
+        required: false
+        type: boolean
+        default: true
       verify-reproducible:
         description: >-
           When true, rebuild the jar from a clean tree and fail if the second
@@ -39,6 +49,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           lfs: false
+          ref: ${{ inputs.checkout-ref || github.sha }}
 
       - uses: ./.github/actions/gradle-task-run
         with:
@@ -86,6 +97,7 @@ jobs:
         run: cp android/video-server/build/libs/automobile-video.jar /tmp/automobile-video.jar
 
       - name: "Upload video-server jar"
+        if: ${{ inputs.upload-artifact }}
         uses: actions/upload-artifact@v6
         with:
           name: video-server-jar

--- a/.github/workflows/build-video-server-jar.yml
+++ b/.github/workflows/build-video-server-jar.yml
@@ -21,6 +21,11 @@ on:
         required: false
         type: boolean
         default: true
+      artifact-retention-days:
+        description: "How long to retain the uploaded jar artifact"
+        required: false
+        type: number
+        default: 7
       verify-reproducible:
         description: >-
           When true, rebuild the jar from a clean tree and fail if the second
@@ -103,4 +108,4 @@ jobs:
         with:
           name: video-server-jar
           path: /tmp/automobile-video.jar
-          retention-days: 90
+          retention-days: ${{ inputs.artifact-retention-days }}

--- a/.github/workflows/build-video-server-jar.yml
+++ b/.github/workflows/build-video-server-jar.yml
@@ -103,4 +103,4 @@ jobs:
         with:
           name: video-server-jar
           path: /tmp/automobile-video.jar
-          retention-days: 7
+          retention-days: 90

--- a/.github/workflows/build-video-server-jar.yml
+++ b/.github/workflows/build-video-server-jar.yml
@@ -50,6 +50,7 @@ jobs:
         with:
           lfs: false
           ref: ${{ inputs.checkout-ref || github.sha }}
+          persist-credentials: false
 
       - uses: ./.github/actions/gradle-task-run
         with:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -239,9 +239,62 @@ jobs:
 
           echo "release_commit=$local_head" >> "$GITHUB_OUTPUT"
 
+  validate-finalized-release:
+    runs-on: ubuntu-latest
+    needs: finalize-release
+    steps:
+      - name: Checkout finalized release
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+          ref: ${{ needs.finalize-release.outputs.release_commit }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run tests
+        env:
+          TURBO_TELEMETRY_DISABLED: "1"
+          TURBO_NO_UPDATE_NOTIFIER: "1"
+          DO_NOT_TRACK: "1"
+          NO_COLOR: "1"
+        run: bun run turbo:test -- --output-logs=errors-only
+
+      - name: Run lint
+        env:
+          TURBO_TELEMETRY_DISABLED: "1"
+          TURBO_NO_UPDATE_NOTIFIER: "1"
+          DO_NOT_TRACK: "1"
+          NO_COLOR: "1"
+        run: bun run turbo:lint -- --output-logs=errors-only
+
+      - name: Build TypeScript
+        env:
+          TURBO_TELEMETRY_DISABLED: "1"
+          TURBO_NO_UPDATE_NOTIFIER: "1"
+          DO_NOT_TRACK: "1"
+          NO_COLOR: "1"
+        run: bun run turbo:build -- --force --output-logs=errors-only
+
+      - name: Run Bun MCP startup smoke
+        run: bun run test:startup:bun
+
+      - name: Run Bun image runtime smoke
+        run: bun run test:image:bun
+
   verify-prepared-release:
     runs-on: ubuntu-latest
-    needs: [finalize-release, build-candidate-ctrl-proxy-ios-ipa, build-candidate-control-proxy-apk, build-candidate-video-server-jar, build-candidate-screen-capture-helper]
+    needs: [finalize-release, validate-finalized-release, build-candidate-ctrl-proxy-ios-ipa, build-candidate-control-proxy-apk, build-candidate-video-server-jar, build-candidate-screen-capture-helper]
     permissions:
       contents: write
       actions: write
@@ -335,6 +388,7 @@ jobs:
           name: release-artifact-provenance
           path: /tmp/release-artifact-provenance.json
           retention-days: 7
+          overwrite: true
 
       - name: Start the release
         shell: bash

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -14,47 +14,10 @@ permissions:
   issues: read
 
 jobs:
-  build-ctrl-proxy-ios-ipa:
-    uses: ./.github/workflows/build-ctrl-proxy-ios-ipa.yml
-
-  build-control-proxy-apk:
-    uses: ./.github/workflows/build-control-proxy-apk.yml
-    secrets:
-      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-      RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
-      RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
-      RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
-      RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
-
-  build-video-server-jar:
-    uses: ./.github/workflows/build-video-server-jar.yml
-    with:
-      verify-reproducible: true
-    secrets:
-      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-
-  build-screen-capture-helper:
-    uses: ./.github/workflows/build-screen-capture-helper.yml
-    secrets:
-      MACOS_DEVELOPER_ID_CERT_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_CERT_BASE64 }}
-      MACOS_DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_CERT_PASSWORD }}
-      MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
-      MACOS_DEVELOPER_ID_SIGNING_IDENTITY: ${{ secrets.MACOS_DEVELOPER_ID_SIGNING_IDENTITY }}
-      APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
-      APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
-      APPLE_NOTARY_PRIVATE_KEY_BASE64: ${{ secrets.APPLE_NOTARY_PRIVATE_KEY_BASE64 }}
-
-  prepare:
+  prepare-version:
     runs-on: ubuntu-latest
-    needs: [build-ctrl-proxy-ios-ipa, build-control-proxy-apk, build-video-server-jar, build-screen-capture-helper]
-    # Restates the workflow-level grant because a job-level block replaces it
-    # wholesale. actions: write is for the "Start the release" fallback dispatch,
-    # and is scoped here so the reusable APK/IPA/jar builders do not inherit it.
-    permissions:
-      contents: write
-      issues: read
-      actions: write
-
+    outputs:
+      release_commit: ${{ steps.commit.outputs.release_commit }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -87,71 +50,128 @@ jobs:
           GH_TOKEN: ${{ secrets.AUTO_MOBILE_PR_TOKEN }}
         run: scripts/changelog/update_changelog_from_issues.sh
 
-      - name: "Download CtrlProxy iOS IPA"
-        uses: actions/download-artifact@v7
-        with:
-          name: ctrl-proxy-ios-ipa
-          path: /tmp
-
-      - name: "Download CtrlProxy APK"
-        uses: actions/download-artifact@v7
-        with:
-          name: control-proxy-apk
-          path: /tmp
-
-      - name: "Download video-server jar"
-        uses: actions/download-artifact@v7
-        with:
-          name: video-server-jar
-          path: /tmp
-
-      - name: "Download screen-capture-helper"
-        uses: actions/download-artifact@v7
-        with:
-          name: screen-capture-helper
-          path: /tmp
-
-      - name: Calculate SHA256 checksums
-        id: checksum
+      - name: Commit versioned release tree to main
+        id: commit
+        shell: bash
         run: |
-          # pipefail so a failing sha256sum is not masked by a succeeding cut,
-          # which would record an empty checksum and bake it into the registry (#4684).
           set -euo pipefail
-          APK_SHA256=$(sha256sum /tmp/control-proxy-debug.apk | cut -d' ' -f1)
-          echo "apk_sha256=$APK_SHA256" >> "$GITHUB_OUTPUT"
-          echo "APK SHA256: $APK_SHA256"
 
-          IPA_SHA256=$(sha256sum /tmp/control-proxy.ipa | cut -d' ' -f1)
-          echo "ipa_sha256=$IPA_SHA256" >> "$GITHUB_OUTPUT"
-          echo "IPA SHA256: $IPA_SHA256"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          VIDEO_JAR_SHA256=$(sha256sum /tmp/automobile-video.jar | cut -d' ' -f1)
-          echo "video_jar_sha256=$VIDEO_JAR_SHA256" >> "$GITHUB_OUTPUT"
-          echo "video-server jar SHA256: $VIDEO_JAR_SHA256"
+          mapfile -t changed_files < <(git diff --name-only)
+          unexpected_files=()
+          for path in "${changed_files[@]}"; do
+            case "$path" in
+              .claude-plugin/marketplace.json | \
+              .claude-plugin/plugin.json | \
+              CHANGELOG.md | \
+              android/gradle.properties | \
+              android/*/build.gradle.kts | \
+              ios/XCTestRunner/Sources/XCTestRunner/AutoMobileVersion.swift | \
+              package.json | \
+              server.json)
+                ;;
+              *)
+                unexpected_files+=("$path")
+                ;;
+            esac
+          done
 
-          SCREEN_CAPTURE_HELPER_SHA256=$(sha256sum /tmp/screen-capture-helper-macos-universal.zip | cut -d' ' -f1)
-          echo "screen_capture_helper_sha256=$SCREEN_CAPTURE_HELPER_SHA256" >> "$GITHUB_OUTPUT"
-          echo "screen-capture-helper SHA256: $SCREEN_CAPTURE_HELPER_SHA256"
+          if ((${#unexpected_files[@]} > 0)); then
+            printf 'Unexpected versioned release file changes:\n' >&2
+            printf '  %s\n' "${unexpected_files[@]}" >&2
+            exit 1
+          fi
+
+          if ((${#changed_files[@]} > 0)); then
+            git add -- "${changed_files[@]}"
+            git commit -m "chore: bump versions to v${{ inputs.version }} [skip ci]"
+            git push origin HEAD:main
+          fi
+
+          echo "release_commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+  build-candidate-ctrl-proxy-ios-ipa:
+    needs: prepare-version
+    uses: ./.github/workflows/build-ctrl-proxy-ios-ipa.yml
+    with:
+      checkout-ref: ${{ needs.prepare-version.outputs.release_commit }}
+      upload-artifact: false
+
+  build-candidate-control-proxy-apk:
+    needs: prepare-version
+    uses: ./.github/workflows/build-control-proxy-apk.yml
+    with:
+      checkout-ref: ${{ needs.prepare-version.outputs.release_commit }}
+      upload-artifact: false
+    secrets:
+      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+      RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+      RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+      RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+      RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+
+  build-candidate-video-server-jar:
+    needs: prepare-version
+    uses: ./.github/workflows/build-video-server-jar.yml
+    with:
+      checkout-ref: ${{ needs.prepare-version.outputs.release_commit }}
+      upload-artifact: false
+      verify-reproducible: true
+    secrets:
+      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+  build-candidate-screen-capture-helper:
+    needs: prepare-version
+    uses: ./.github/workflows/build-screen-capture-helper.yml
+    with:
+      checkout-ref: ${{ needs.prepare-version.outputs.release_commit }}
+      upload-artifact: false
+    secrets:
+      MACOS_DEVELOPER_ID_CERT_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_CERT_BASE64 }}
+      MACOS_DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_CERT_PASSWORD }}
+      MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+      MACOS_DEVELOPER_ID_SIGNING_IDENTITY: ${{ secrets.MACOS_DEVELOPER_ID_SIGNING_IDENTITY }}
+      APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+      APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+      APPLE_NOTARY_PRIVATE_KEY_BASE64: ${{ secrets.APPLE_NOTARY_PRIVATE_KEY_BASE64 }}
+
+  finalize-release:
+    runs-on: ubuntu-latest
+    needs: [prepare-version, build-candidate-ctrl-proxy-ios-ipa, build-candidate-control-proxy-apk, build-candidate-video-server-jar, build-candidate-screen-capture-helper]
+    outputs:
+      release_commit: ${{ steps.commit.outputs.release_commit }}
+    # Restates the workflow-level grant because a job-level block replaces it
+    # wholesale. This job is the only one that writes the finalized constants
+    # commit to main; the candidate and tagged builders remain read-only.
+    permissions:
+      contents: write
+      issues: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+          ref: ${{ needs.prepare-version.outputs.release_commit }}
+          fetch-depth: 0
+          token: ${{ secrets.AUTO_MOBILE_PR_TOKEN }}
 
       - name: Update release constants
         env:
           RELEASE_VERSION: ${{ inputs.version }}
-          APK_SHA256_CHECKSUM: ${{ steps.checksum.outputs.apk_sha256 }}
+          APK_SHA256_CHECKSUM: ${{ needs.build-candidate-control-proxy-apk.outputs.sha256 }}
           IOS_CTRL_PROXY_SHA256_CHECKSUM:
-            ${{ steps.checksum.outputs.ipa_sha256 }}
+            ${{ needs.build-candidate-ctrl-proxy-ios-ipa.outputs.sha256 }}
           IOS_CTRL_PROXY_RUNNER_SHA256:
-            ${{ needs.build-ctrl-proxy-ios-ipa.outputs.runner_sha256 }}
-          VIDEO_JAR_SHA256: ${{ steps.checksum.outputs.video_jar_sha256 }}
-          SCREEN_CAPTURE_HELPER_SHA256: ${{ steps.checksum.outputs.screen_capture_helper_sha256 }}
+            ${{ needs.build-candidate-ctrl-proxy-ios-ipa.outputs.runner_sha256 }}
+          VIDEO_JAR_SHA256: ${{ needs.build-candidate-video-server-jar.outputs.sha256 }}
+          SCREEN_CAPTURE_HELPER_SHA256: ${{ needs.build-candidate-screen-capture-helper.outputs.sha256 }}
         run: bash scripts/generate-release-constants.sh
 
-      - name: Verify release integrity
-        run: >
-          bash scripts/ci/verify-release-integrity.sh
-          "${{ inputs.version }}"
-          /tmp/control-proxy.ipa
-
-      - name: Commit release changes to main
+      - name: Commit release constants to main
+        id: commit
         shell: bash
         run: |
           set -euo pipefail
@@ -188,25 +208,16 @@ jobs:
               exit 1
             fi
 
-            # "[skip ci]" avoids triggering the push-to-main merge workflow for
-            # release bookkeeping that has already been verified above.
+            expected_parent="${{ needs.prepare-version.outputs.release_commit }}"
+            remote_main="$(git ls-remote origin refs/heads/main | awk '{print $1}')"
+            if [[ "$remote_main" != "$expected_parent" ]]; then
+              echo "main moved after the candidate artifacts were built; refusing to tag a different tree" >&2
+              exit 1
+            fi
+
             git add -- "${changed_files[@]}"
             git commit -m "chore: bump versions to v${{ inputs.version }} [skip ci]"
-
-            # AUTO_MOBILE_PR_TOKEN is an admin actor and bypasses the green-main
-            # ruleset, so this pushes straight to main with no release PR.
-            # Rebase-and-retry guards against losing a race with a concurrent push.
-            for attempt in 1 2 3; do
-              if git pull --rebase origin main && git push origin HEAD:main; then
-                echo "Pushed release commit to main"
-                exit 0
-              fi
-              echo "Push attempt ${attempt} failed; retrying..."
-              sleep 5
-            done
-
-            echo "Failed to push release commit to main after 3 attempts" >&2
-            exit 1
+            git push origin HEAD:main
           fi
 
           # The clean-tree path lets a rerun recover if the release commit was
@@ -218,7 +229,10 @@ jobs:
             exit 1
           fi
 
+          echo "release_commit=$local_head" >> "$GITHUB_OUTPUT"
+
       - name: Create and push release tag
+        id: tag
         shell: bash
         run: |
           set -euo pipefail
@@ -227,14 +241,125 @@ jobs:
 
           git fetch --tags origin
           if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists. Skipping."
-            exit 0
+            existing_tag_commit="$(git rev-parse "$TAG^{commit}")"
+            if [[ "$existing_tag_commit" != "$(git rev-parse HEAD)" ]]; then
+              echo "Tag $TAG already exists on a different commit" >&2
+              exit 1
+            fi
+          else
+            git tag "$TAG"
+            git push origin "$TAG"
           fi
 
-          git tag "$TAG"
-          git push origin "$TAG"
+          echo "tag_sha=$(git rev-parse "$TAG^{commit}")" >> "$GITHUB_OUTPUT"
 
-          echo "Successfully created and pushed tag: $TAG"
+  build-ctrl-proxy-ios-ipa:
+    needs: finalize-release
+    uses: ./.github/workflows/build-ctrl-proxy-ios-ipa.yml
+    with:
+      checkout-ref: ${{ needs.finalize-release.outputs.release_commit }}
+
+  build-control-proxy-apk:
+    needs: finalize-release
+    uses: ./.github/workflows/build-control-proxy-apk.yml
+    with:
+      checkout-ref: ${{ needs.finalize-release.outputs.release_commit }}
+    secrets:
+      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+      RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
+      RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+      RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+      RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+
+  build-video-server-jar:
+    needs: finalize-release
+    uses: ./.github/workflows/build-video-server-jar.yml
+    with:
+      checkout-ref: ${{ needs.finalize-release.outputs.release_commit }}
+      verify-reproducible: true
+    secrets:
+      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
+
+  build-screen-capture-helper:
+    needs: finalize-release
+    uses: ./.github/workflows/build-screen-capture-helper.yml
+    with:
+      checkout-ref: ${{ needs.finalize-release.outputs.release_commit }}
+    secrets:
+      MACOS_DEVELOPER_ID_CERT_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_CERT_BASE64 }}
+      MACOS_DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_CERT_PASSWORD }}
+      MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+      MACOS_DEVELOPER_ID_SIGNING_IDENTITY: ${{ secrets.MACOS_DEVELOPER_ID_SIGNING_IDENTITY }}
+      APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+      APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+      APPLE_NOTARY_PRIVATE_KEY_BASE64: ${{ secrets.APPLE_NOTARY_PRIVATE_KEY_BASE64 }}
+
+  verify-prepared-release:
+    runs-on: ubuntu-latest
+    needs: [finalize-release, build-ctrl-proxy-ios-ipa, build-control-proxy-apk, build-video-server-jar, build-screen-capture-helper]
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - name: Checkout tagged release
+        uses: actions/checkout@v6
+        with:
+          lfs: false
+          ref: refs/tags/${{ inputs.version }}
+
+      - name: "Download CtrlProxy APK"
+        uses: actions/download-artifact@v7
+        with:
+          name: control-proxy-apk
+          path: /tmp
+
+      - name: "Download CtrlProxy iOS IPA"
+        uses: actions/download-artifact@v7
+        with:
+          name: ctrl-proxy-ios-ipa
+          path: /tmp
+
+      - name: "Download video-server jar"
+        uses: actions/download-artifact@v7
+        with:
+          name: video-server-jar
+          path: /tmp
+
+      - name: "Download screen-capture-helper"
+        uses: actions/download-artifact@v7
+        with:
+          name: screen-capture-helper
+          path: /tmp
+
+      - name: Verify prepared release artifacts
+        run: |
+          set -euo pipefail
+          bash scripts/ci/verify-artifact-sha256.sh /tmp/control-proxy-debug.apk android
+          bash scripts/ci/verify-artifact-sha256.sh /tmp/control-proxy.ipa ios
+          bash scripts/ci/verify-artifact-sha256.sh /tmp/automobile-video.jar videojar
+          bash scripts/ci/verify-artifact-sha256.sh /tmp/screen-capture-helper-macos-universal.zip screencapturehelper
+          bash scripts/ci/verify-release-integrity.sh "${{ inputs.version }}" /tmp/control-proxy.ipa
+
+      - name: Create release artifact provenance
+        env:
+          TAG: ${{ inputs.version }}
+          TAG_SHA: ${{ needs.finalize-release.outputs.release_commit }}
+          PREPARE_RUN_ID: ${{ github.run_id }}
+        run: |
+          jq -n \
+            --arg tag "$TAG" \
+            --arg tag_sha "$TAG_SHA" \
+            --arg prepare_run_id "$PREPARE_RUN_ID" \
+            '{tag: $tag, tag_sha: $tag_sha, prepare_run_id: $prepare_run_id,
+              artifacts: ["control-proxy-apk", "ctrl-proxy-ios-ipa", "video-server-jar", "screen-capture-helper"]}' \
+            > /tmp/release-artifact-provenance.json
+
+      - name: Upload release artifact provenance
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-artifact-provenance
+          path: /tmp/release-artifact-provenance.json
+          retention-days: 7
 
       - name: Start the release
         shell: bash

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -239,66 +239,16 @@ jobs:
       - name: Start the release
         shell: bash
         env:
-          # workflow_dispatch is one of the two events GitHub exempts from "with
-          # the exception of workflow_dispatch and repository_dispatch, other
-          # GITHUB_TOKEN-triggered events do not create workflow runs at all", so
-          # the default token can start Release. It only needs actions: write,
-          # granted on this job above, rather than a PAT scope to keep in sync.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ inputs.version }}
           REPO: ${{ github.repository }}
+          PREPARE_RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
 
-          # Pushing the tag normally starts Release by itself, through the
-          # `create:` trigger in release.yml: only refs pushed by GITHUB_TOKEN are
-          # suppressed from starting runs, and the checkout above authenticates
-          # with a PAT. Verify that instead of assuming it -- a tag that queues
-          # nothing is a silent non-release, and CI reports green either way.
-          #
-          # Filter on the tag. Every branch creation queues its own release.yml
-          # run (validate-release-tag skips them), so "newest run changed" would
-          # be satisfied by an unrelated branch and report a release that is not
-          # running.
-          find_release_run() {
-            gh run list --repo "$REPO" --workflow release.yml --branch "$TAG" \
-              --limit 1 --json databaseId --jq '.[].databaseId // empty'
-          }
-
-          for _ in $(seq 1 12); do
-            run_id="$(find_release_run)"
-            if [[ -n "$run_id" ]]; then
-              echo "Release is running for $TAG (run ${run_id})"
-              exit 0
-            fi
-            sleep 5
-          done
-
-          # The tag event did not take. Fall back to dispatching explicitly, so a
-          # regression in that path costs a delay rather than another hand-run
-          # release. Dispatching is only reached when nothing is queued, so this
-          # cannot double-build a tag that already started.
-          #
-          # Dispatch on the TAG, not on main. github.ref has to stay a tag ref:
-          # action-gh-release derives its tag from it, docker/metadata-action's
-          # type=semver is inert without it, and the reusable APK/IPA/jar builders
-          # run at the caller's ref -- on main they would build a different tree
-          # than the checksums minted just above were computed from.
-          echo "No Release run appeared for $TAG after 60s; dispatching it" >&2
-          gh workflow run release.yml --repo "$REPO" --ref "$TAG" -f tag="$TAG"
-
-          # The dispatch API returns 204 before the run exists and gh does not
-          # wait, so `gh workflow run` succeeds even if no run is ever created.
-          # A green step here with nothing queued is the same silent non-release
-          # this step exists to catch, so confirm a run actually appeared.
-          for _ in $(seq 1 12); do
-            sleep 5
-            run_id="$(find_release_run)"
-            if [[ -n "$run_id" ]]; then
-              echo "Dispatched release.yml for $TAG (run ${run_id})"
-              exit 0
-            fi
-          done
-
-          echo "Dispatched release.yml for $TAG but no run appeared after 60s" >&2
-          exit 1
+          # Release publishes the exact artifacts prepared in this workflow
+          # run. It intentionally does not rebuild or re-verify them from the
+          # tag, because a moving main branch can make that second build differ.
+          gh workflow run release.yml --repo "$REPO" --ref "$TAG" \
+            -f tag="$TAG" \
+            -f prepare_run_id="$PREPARE_RUN_ID"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -401,14 +401,20 @@ jobs:
           TAG: ${{ inputs.version }}
           REPO: ${{ github.repository }}
           PREPARE_RUN_ID: ${{ github.run_id }}
+          RELEASE_SHA: ${{ needs.finalize-release.outputs.release_commit }}
         run: |
           set -euo pipefail
 
           # Release publishes the exact artifacts prepared in this workflow
           # run. It intentionally does not rebuild or re-verify them from the
           # tag, because a moving main branch can make that second build differ.
-          previous_release_run_ids="$(gh run list --repo "$REPO" --workflow release.yml \
-            --branch "$TAG" --limit 100 --json databaseId --jq '.[].databaseId')"
+          release_run_ids() {
+            gh api --paginate "repos/$REPO/actions/workflows/release.yml/runs?event=workflow_dispatch&per_page=100" \
+              | jq -r --arg tag "$TAG" --arg sha "$RELEASE_SHA" \
+                '.workflow_runs[] | select(.head_branch == $tag and .head_sha == $sha) | .id'
+          }
+
+          previous_release_run_ids="$(release_run_ids)"
           gh workflow run release.yml --repo "$REPO" --ref "$TAG" \
             -f tag="$TAG" \
             -f prepare_run_id="$PREPARE_RUN_ID"
@@ -423,8 +429,7 @@ jobs:
                 echo "Release is running for $TAG (run $release_run_id)"
                 exit 0
               fi
-            done < <(gh run list --repo "$REPO" --workflow release.yml \
-              --branch "$TAG" --limit 100 --json databaseId --jq '.[].databaseId')
+            done < <(release_run_ids)
             sleep 5
           done
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_commit: ${{ steps.commit.outputs.release_commit }}
+      base_main_commit: ${{ steps.commit.outputs.base_main_commit }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -52,16 +53,18 @@ jobs:
           GH_TOKEN: ${{ secrets.AUTO_MOBILE_PR_TOKEN }}
         run: scripts/changelog/update_changelog_from_issues.sh
 
-      - name: Commit versioned release tree to main
+      - name: Commit versioned release tree to staging ref
         id: commit
         shell: bash
         env:
           VERSION: ${{ inputs.version }}
+          STAGING_REF: release-prepare/${{ github.run_id }}
         run: |
           set -euo pipefail
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          base_main_commit="$(git rev-parse HEAD)"
 
           mapfile -t changed_files < <(
             { git diff --name-only HEAD; git ls-files --others --exclude-standard; } | sort -u
@@ -93,10 +96,13 @@ jobs:
           if ((${#changed_files[@]} > 0)); then
             git add -- "${changed_files[@]}"
             git commit -m "chore: bump versions to v$VERSION [skip ci]"
-            git push origin HEAD:main
           fi
 
+          # Reusable workflows need a remote ref to check out this candidate,
+          # but main must not advertise an unverified release version.
+          git push --force origin "HEAD:refs/heads/$STAGING_REF"
           echo "release_commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "base_main_commit=$base_main_commit" >> "$GITHUB_OUTPUT"
 
   build-candidate-ctrl-proxy-ios-ipa:
     needs: prepare-version
@@ -149,8 +155,8 @@ jobs:
     outputs:
       release_commit: ${{ steps.commit.outputs.release_commit }}
     # Restates the workflow-level grant because a job-level block replaces it
-    # wholesale. This job is the only one that writes the finalized constants
-    # commit to main; the candidate builders remain read-only.
+    # wholesale. This job writes the finalized constants only to the run-scoped
+    # staging ref; the verified job promotes it to main.
     permissions:
       contents: write
       issues: read
@@ -176,11 +182,12 @@ jobs:
           SCREEN_CAPTURE_HELPER_SHA256: ${{ needs.build-candidate-screen-capture-helper.outputs.sha256 }}
         run: bash scripts/generate-release-constants.sh
 
-      - name: Commit release constants to main
+      - name: Commit release constants to staging ref
         id: commit
         shell: bash
         env:
           VERSION: ${{ inputs.version }}
+          STAGING_REF: release-prepare/${{ github.run_id }}
         run: |
           set -euo pipefail
 
@@ -218,25 +225,12 @@ jobs:
               exit 1
             fi
 
-            expected_parent="${{ needs.prepare-version.outputs.release_commit }}"
-            remote_main="$(git ls-remote origin refs/heads/main | awk '{print $1}')"
-            if [[ "$remote_main" != "$expected_parent" ]]; then
-              echo "main moved after the candidate artifacts were built; refusing to finalize a different release tree" >&2
-              exit 1
-            fi
-
             git add -- "${changed_files[@]}"
             git commit -m "chore: bump versions to v$VERSION [skip ci]"
-            git push origin HEAD:main
           fi
 
-          remote_main="$(git ls-remote origin refs/heads/main | awk '{print $1}')"
           local_head="$(git rev-parse HEAD)"
-          if [[ "$local_head" != "$remote_main" ]]; then
-            echo "Current HEAD is not on origin/main; refusing to verify a different release tree" >&2
-            exit 1
-          fi
-
+          git push --force origin "HEAD:refs/heads/$STAGING_REF"
           echo "release_commit=$local_head" >> "$GITHUB_OUTPUT"
 
   validate-finalized-release:
@@ -294,7 +288,7 @@ jobs:
 
   verify-prepared-release:
     runs-on: ubuntu-latest
-    needs: [finalize-release, validate-finalized-release, build-candidate-ctrl-proxy-ios-ipa, build-candidate-control-proxy-apk, build-candidate-video-server-jar, build-candidate-screen-capture-helper]
+    needs: [prepare-version, finalize-release, validate-finalized-release, build-candidate-ctrl-proxy-ios-ipa, build-candidate-control-proxy-apk, build-candidate-video-server-jar, build-candidate-screen-capture-helper]
     permissions:
       contents: write
       actions: write
@@ -342,17 +336,20 @@ jobs:
           bash scripts/ci/verify-artifact-sha256.sh /tmp/screen-capture-helper-macos-universal.zip screencapturehelper
           bash scripts/ci/verify-release-integrity.sh "$VERSION" /tmp/control-proxy.ipa
 
-      - name: Create and push verified release tag
+      - name: Promote verified release and create tag
         shell: bash
         env:
           TAG: ${{ inputs.version }}
           EXPECTED_RELEASE_COMMIT: ${{ needs.finalize-release.outputs.release_commit }}
+          BASE_MAIN_COMMIT: ${{ needs.prepare-version.outputs.base_main_commit }}
         run: |
           set -euo pipefail
 
           remote_main="$(git ls-remote origin refs/heads/main | awk '{print $1}')"
-          if [[ "$remote_main" != "$EXPECTED_RELEASE_COMMIT" ]]; then
-            echo "main moved after the release artifacts were verified; refusing to tag a different tree" >&2
+          if [[ "$remote_main" == "$BASE_MAIN_COMMIT" ]]; then
+            git push origin "$EXPECTED_RELEASE_COMMIT":main
+          elif [[ "$remote_main" != "$EXPECTED_RELEASE_COMMIT" ]]; then
+            echo "main moved while the release was being verified; refusing to promote a different tree" >&2
             exit 1
           fi
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -110,6 +110,7 @@ jobs:
     with:
       checkout-ref: ${{ needs.prepare-version.outputs.release_commit }}
       upload-artifact: true
+      artifact-retention-days: 90
 
   build-candidate-control-proxy-apk:
     needs: prepare-version
@@ -117,6 +118,7 @@ jobs:
     with:
       checkout-ref: ${{ needs.prepare-version.outputs.release_commit }}
       upload-artifact: true
+      artifact-retention-days: 90
     secrets:
       GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
       RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
@@ -130,6 +132,7 @@ jobs:
     with:
       checkout-ref: ${{ needs.prepare-version.outputs.release_commit }}
       upload-artifact: true
+      artifact-retention-days: 90
       verify-reproducible: true
     secrets:
       GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
@@ -140,6 +143,7 @@ jobs:
     with:
       checkout-ref: ${{ needs.prepare-version.outputs.release_commit }}
       upload-artifact: true
+      artifact-retention-days: 90
     secrets:
       MACOS_DEVELOPER_ID_CERT_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_CERT_BASE64 }}
       MACOS_DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_CERT_PASSWORD }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -410,3 +410,19 @@ jobs:
           gh workflow run release.yml --repo "$REPO" --ref "$TAG" \
             -f tag="$TAG" \
             -f prepare_run_id="$PREPARE_RUN_ID"
+
+          # workflow_dispatch returns before the run is visible. Confirm the
+          # tag-scoped Release run materializes so a delayed or dropped dispatch
+          # leaves Prepare retryable instead of reporting a false success.
+          for _ in $(seq 1 12); do
+            release_run_id="$(gh run list --repo "$REPO" --workflow release.yml \
+              --branch "$TAG" --limit 1 --json databaseId --jq '.[0].databaseId // empty')"
+            if [[ -n "$release_run_id" ]]; then
+              echo "Release is running for $TAG (run $release_run_id)"
+              exit 0
+            fi
+            sleep 5
+          done
+
+          echo "Release dispatch for $TAG did not materialize within 60 seconds" >&2
+          exit 1

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -305,6 +305,11 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.AUTO_MOBILE_PR_TOKEN }}
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
       - name: "Download CtrlProxy APK"
         uses: actions/download-artifact@v7
         with:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -407,20 +407,24 @@ jobs:
           # Release publishes the exact artifacts prepared in this workflow
           # run. It intentionally does not rebuild or re-verify them from the
           # tag, because a moving main branch can make that second build differ.
+          previous_release_run_ids="$(gh run list --repo "$REPO" --workflow release.yml \
+            --branch "$TAG" --limit 100 --json databaseId --jq '.[].databaseId')"
           gh workflow run release.yml --repo "$REPO" --ref "$TAG" \
             -f tag="$TAG" \
             -f prepare_run_id="$PREPARE_RUN_ID"
 
           # workflow_dispatch returns before the run is visible. Confirm the
-          # tag-scoped Release run materializes so a delayed or dropped dispatch
-          # leaves Prepare retryable instead of reporting a false success.
+          # newly-dispatched tag-scoped Release run materializes so an older
+          # retry cannot mask a delayed or dropped dispatch.
           for _ in $(seq 1 12); do
-            release_run_id="$(gh run list --repo "$REPO" --workflow release.yml \
-              --branch "$TAG" --limit 1 --json databaseId --jq '.[0].databaseId // empty')"
-            if [[ -n "$release_run_id" ]]; then
-              echo "Release is running for $TAG (run $release_run_id)"
-              exit 0
-            fi
+            while IFS= read -r release_run_id; do
+              [[ -z "$release_run_id" ]] && continue
+              if ! grep -Fxq "$release_run_id" <<< "$previous_release_run_ids"; then
+                echo "Release is running for $TAG (run $release_run_id)"
+                exit 0
+              fi
+            done < <(gh run list --repo "$REPO" --workflow release.yml \
+              --branch "$TAG" --limit 100 --json databaseId --jq '.[].databaseId')
             sleep 5
           done
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -349,8 +349,15 @@ jobs:
           if [[ "$remote_main" == "$BASE_MAIN_COMMIT" ]]; then
             git push origin "$EXPECTED_RELEASE_COMMIT":main
           elif [[ "$remote_main" != "$EXPECTED_RELEASE_COMMIT" ]]; then
-            echo "main moved while the release was being verified; refusing to promote a different tree" >&2
-            exit 1
+            # A rerun can arrive after this job promoted and tagged the release,
+            # then a normal main commit landed before a later dispatch step
+            # failed. That is recoverable only when this exact release remains
+            # in main's history; otherwise never tag a different tree.
+            git fetch origin main
+            if ! git merge-base --is-ancestor "$EXPECTED_RELEASE_COMMIT" FETCH_HEAD; then
+              echo "main moved while the release was being verified; refusing to promote a different tree" >&2
+              exit 1
+            fi
           fi
 
           git fetch --tags origin
@@ -384,7 +391,7 @@ jobs:
         with:
           name: release-artifact-provenance
           path: /tmp/release-artifact-provenance.json
-          retention-days: 7
+          retention-days: 90
           overwrite: true
 
       - name: Start the release

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -40,9 +40,11 @@ jobs:
           fi
 
       - name: Bump versions
+        env:
+          VERSION: ${{ inputs.version }}
         run: >
           bash scripts/versioning/bump-versions.sh
-          --new-version "${{ inputs.version }}"
+          --new-version "$VERSION"
 
       - name: Update changelog
         env:
@@ -53,13 +55,17 @@ jobs:
       - name: Commit versioned release tree to main
         id: commit
         shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          mapfile -t changed_files < <(git diff --name-only)
+          mapfile -t changed_files < <(
+            { git diff --name-only HEAD; git ls-files --others --exclude-standard; } | sort -u
+          )
           unexpected_files=()
           for path in "${changed_files[@]}"; do
             case "$path" in
@@ -86,7 +92,7 @@ jobs:
 
           if ((${#changed_files[@]} > 0)); then
             git add -- "${changed_files[@]}"
-            git commit -m "chore: bump versions to v${{ inputs.version }} [skip ci]"
+            git commit -m "chore: bump versions to v$VERSION [skip ci]"
             git push origin HEAD:main
           fi
 
@@ -97,14 +103,14 @@ jobs:
     uses: ./.github/workflows/build-ctrl-proxy-ios-ipa.yml
     with:
       checkout-ref: ${{ needs.prepare-version.outputs.release_commit }}
-      upload-artifact: false
+      upload-artifact: true
 
   build-candidate-control-proxy-apk:
     needs: prepare-version
     uses: ./.github/workflows/build-control-proxy-apk.yml
     with:
       checkout-ref: ${{ needs.prepare-version.outputs.release_commit }}
-      upload-artifact: false
+      upload-artifact: true
     secrets:
       GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
       RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
@@ -117,7 +123,7 @@ jobs:
     uses: ./.github/workflows/build-video-server-jar.yml
     with:
       checkout-ref: ${{ needs.prepare-version.outputs.release_commit }}
-      upload-artifact: false
+      upload-artifact: true
       verify-reproducible: true
     secrets:
       GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
@@ -127,7 +133,7 @@ jobs:
     uses: ./.github/workflows/build-screen-capture-helper.yml
     with:
       checkout-ref: ${{ needs.prepare-version.outputs.release_commit }}
-      upload-artifact: false
+      upload-artifact: true
     secrets:
       MACOS_DEVELOPER_ID_CERT_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_CERT_BASE64 }}
       MACOS_DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_CERT_PASSWORD }}
@@ -144,7 +150,7 @@ jobs:
       release_commit: ${{ steps.commit.outputs.release_commit }}
     # Restates the workflow-level grant because a job-level block replaces it
     # wholesale. This job is the only one that writes the finalized constants
-    # commit to main; the candidate and tagged builders remain read-only.
+    # commit to main; the candidate builders remain read-only.
     permissions:
       contents: write
       issues: read
@@ -173,16 +179,20 @@ jobs:
       - name: Commit release constants to main
         id: commit
         shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          if git diff --quiet; then
-            echo "Release files are already up to date for v${{ inputs.version }}"
+          mapfile -t changed_files < <(
+            { git diff --name-only HEAD; git ls-files --others --exclude-standard; } | sort -u
+          )
+          if ((${#changed_files[@]} == 0)); then
+            echo "Release files are already up to date for v$VERSION"
           else
-            mapfile -t changed_files < <(git diff --name-only)
             unexpected_files=()
             for path in "${changed_files[@]}"; do
               case "$path" in
@@ -211,101 +221,38 @@ jobs:
             expected_parent="${{ needs.prepare-version.outputs.release_commit }}"
             remote_main="$(git ls-remote origin refs/heads/main | awk '{print $1}')"
             if [[ "$remote_main" != "$expected_parent" ]]; then
-              echo "main moved after the candidate artifacts were built; refusing to tag a different tree" >&2
+              echo "main moved after the candidate artifacts were built; refusing to finalize a different release tree" >&2
               exit 1
             fi
 
             git add -- "${changed_files[@]}"
-            git commit -m "chore: bump versions to v${{ inputs.version }} [skip ci]"
+            git commit -m "chore: bump versions to v$VERSION [skip ci]"
             git push origin HEAD:main
           fi
 
-          # The clean-tree path lets a rerun recover if the release commit was
-          # pushed successfully but the later tag push failed transiently.
           remote_main="$(git ls-remote origin refs/heads/main | awk '{print $1}')"
           local_head="$(git rev-parse HEAD)"
           if [[ "$local_head" != "$remote_main" ]]; then
-            echo "Current HEAD is not on origin/main; refusing to tag" >&2
+            echo "Current HEAD is not on origin/main; refusing to verify a different release tree" >&2
             exit 1
           fi
 
           echo "release_commit=$local_head" >> "$GITHUB_OUTPUT"
 
-      - name: Create and push release tag
-        id: tag
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          TAG="${{ inputs.version }}"
-
-          git fetch --tags origin
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            existing_tag_commit="$(git rev-parse "$TAG^{commit}")"
-            if [[ "$existing_tag_commit" != "$(git rev-parse HEAD)" ]]; then
-              echo "Tag $TAG already exists on a different commit" >&2
-              exit 1
-            fi
-          else
-            git tag "$TAG"
-            git push origin "$TAG"
-          fi
-
-          echo "tag_sha=$(git rev-parse "$TAG^{commit}")" >> "$GITHUB_OUTPUT"
-
-  build-ctrl-proxy-ios-ipa:
-    needs: finalize-release
-    uses: ./.github/workflows/build-ctrl-proxy-ios-ipa.yml
-    with:
-      checkout-ref: ${{ needs.finalize-release.outputs.release_commit }}
-
-  build-control-proxy-apk:
-    needs: finalize-release
-    uses: ./.github/workflows/build-control-proxy-apk.yml
-    with:
-      checkout-ref: ${{ needs.finalize-release.outputs.release_commit }}
-    secrets:
-      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-      RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
-      RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
-      RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
-      RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
-
-  build-video-server-jar:
-    needs: finalize-release
-    uses: ./.github/workflows/build-video-server-jar.yml
-    with:
-      checkout-ref: ${{ needs.finalize-release.outputs.release_commit }}
-      verify-reproducible: true
-    secrets:
-      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-
-  build-screen-capture-helper:
-    needs: finalize-release
-    uses: ./.github/workflows/build-screen-capture-helper.yml
-    with:
-      checkout-ref: ${{ needs.finalize-release.outputs.release_commit }}
-    secrets:
-      MACOS_DEVELOPER_ID_CERT_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_CERT_BASE64 }}
-      MACOS_DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_CERT_PASSWORD }}
-      MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
-      MACOS_DEVELOPER_ID_SIGNING_IDENTITY: ${{ secrets.MACOS_DEVELOPER_ID_SIGNING_IDENTITY }}
-      APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
-      APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
-      APPLE_NOTARY_PRIVATE_KEY_BASE64: ${{ secrets.APPLE_NOTARY_PRIVATE_KEY_BASE64 }}
-
   verify-prepared-release:
     runs-on: ubuntu-latest
-    needs: [finalize-release, build-ctrl-proxy-ios-ipa, build-control-proxy-apk, build-video-server-jar, build-screen-capture-helper]
+    needs: [finalize-release, build-candidate-ctrl-proxy-ios-ipa, build-candidate-control-proxy-apk, build-candidate-video-server-jar, build-candidate-screen-capture-helper]
     permissions:
-      contents: read
+      contents: write
       actions: write
     steps:
-      - name: Checkout tagged release
+      - name: Checkout finalized release
         uses: actions/checkout@v6
         with:
           lfs: false
-          ref: refs/tags/${{ inputs.version }}
+          ref: ${{ needs.finalize-release.outputs.release_commit }}
+          fetch-depth: 0
+          token: ${{ secrets.AUTO_MOBILE_PR_TOKEN }}
 
       - name: "Download CtrlProxy APK"
         uses: actions/download-artifact@v7
@@ -332,13 +279,41 @@ jobs:
           path: /tmp
 
       - name: Verify prepared release artifacts
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
           bash scripts/ci/verify-artifact-sha256.sh /tmp/control-proxy-debug.apk android
           bash scripts/ci/verify-artifact-sha256.sh /tmp/control-proxy.ipa ios
           bash scripts/ci/verify-artifact-sha256.sh /tmp/automobile-video.jar videojar
           bash scripts/ci/verify-artifact-sha256.sh /tmp/screen-capture-helper-macos-universal.zip screencapturehelper
-          bash scripts/ci/verify-release-integrity.sh "${{ inputs.version }}" /tmp/control-proxy.ipa
+          bash scripts/ci/verify-release-integrity.sh "$VERSION" /tmp/control-proxy.ipa
+
+      - name: Create and push verified release tag
+        shell: bash
+        env:
+          TAG: ${{ inputs.version }}
+          EXPECTED_RELEASE_COMMIT: ${{ needs.finalize-release.outputs.release_commit }}
+        run: |
+          set -euo pipefail
+
+          remote_main="$(git ls-remote origin refs/heads/main | awk '{print $1}')"
+          if [[ "$remote_main" != "$EXPECTED_RELEASE_COMMIT" ]]; then
+            echo "main moved after the release artifacts were verified; refusing to tag a different tree" >&2
+            exit 1
+          fi
+
+          git fetch --tags origin
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            existing_tag_commit="$(git rev-parse "$TAG^{commit}")"
+            if [[ "$existing_tag_commit" != "$EXPECTED_RELEASE_COMMIT" ]]; then
+              echo "Tag $TAG already exists on a different commit" >&2
+              exit 1
+            fi
+          else
+            git tag "$TAG" "$EXPECTED_RELEASE_COMMIT"
+            git push origin "$TAG"
+          fi
 
       - name: Create release artifact provenance
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,8 +98,64 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
+      - name: Wait for successful Prepare Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PREPARE_RUN_ID: ${{ inputs.prepare_run_id }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          for _ in $(seq 1 12); do
+            run="$(gh api "repos/$REPO/actions/runs/$PREPARE_RUN_ID")"
+            status="$(jq -r '.status' <<<"$run")"
+            if [[ "$status" != completed ]]; then
+              sleep 5
+              continue
+            fi
+
+            conclusion="$(jq -r '.conclusion' <<<"$run")"
+            workflow_path="$(jq -r '.path' <<<"$run")"
+            if [[ "$conclusion" != success ]] \
+              || [[ "$workflow_path" != ".github/workflows/prepare-release.yml" ]]; then
+              echo "prepare_run_id must identify a successful Prepare Release run" >&2
+              exit 1
+            fi
+            exit 0
+          done
+
+          echo "Prepare Release run $PREPARE_RUN_ID did not complete within 60 seconds" >&2
+          exit 1
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: "Download release artifact provenance"
+        uses: actions/download-artifact@v7
+        with:
+          name: release-artifact-provenance
+          path: /tmp
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.prepare_run_id }}
+
+      - name: Validate prepared release provenance
+        env:
+          TAG: ${{ needs.validate-release-tag.outputs.tag }}
+          PREPARE_RUN_ID: ${{ inputs.prepare_run_id }}
+        run: |
+          set -euo pipefail
+
+          tag_sha="$(git rev-parse HEAD)"
+          jq -e \
+            --arg tag "$TAG" \
+            --arg tag_sha "$tag_sha" \
+            --arg prepare_run_id "$PREPARE_RUN_ID" \
+            '.tag == $tag
+              and .tag_sha == $tag_sha
+              and .prepare_run_id == $prepare_run_id
+              and .artifacts == ["control-proxy-apk", "ctrl-proxy-ios-ipa", "video-server-jar", "screen-capture-helper"]' \
+            /tmp/release-artifact-provenance.json >/dev/null
 
       - name: "Download CtrlProxy APK"
         uses: actions/download-artifact@v7
@@ -146,22 +202,34 @@ jobs:
             import { appendFileSync } from "node:fs";
             import { RELEASE_CHECKSUM_REGISTRY } from "./src/constants/release";
             const entry = RELEASE_CHECKSUM_REGISTRY.find(({ version }) => version === process.env.VERSION);
-            if (!entry?.videoJarSha256 || !entry.screenCaptureHelperSha256) {
-              throw new Error(`Missing prepared checksums for ${process.env.VERSION}`);
+            if (!entry) {
+              throw new Error(`No prepared checksum registry entry for ${process.env.VERSION}`);
             }
-            const output = process.env.GITHUB_OUTPUT;
-            for (const [key, value] of Object.entries({
+            const checksums = {
               apk: entry.apkSha256,
               ipa: entry.ipaSha256,
               video_jar: entry.videoJarSha256,
               screen_capture_helper: entry.screenCaptureHelperSha256,
-            })) {
+            };
+            const missing = Object.entries(checksums)
+              .filter(([, value]) => !value)
+              .map(([name]) => name);
+            if (missing.length > 0) {
+              throw new Error(`Missing prepared checksums for ${process.env.VERSION}: ${missing.join(", ")}`);
+            }
+            const output = process.env.GITHUB_OUTPUT;
+            for (const [key, value] of Object.entries(checksums)) {
               appendFileSync(output, `${key}=${value}\n`);
             }
           '
 
       - name: Create release notes
         id: release_notes
+        env:
+          APK_CHECKSUM: ${{ steps.prepared_checksums.outputs.apk }}
+          IPA_CHECKSUM: ${{ steps.prepared_checksums.outputs.ipa }}
+          VIDEO_JAR_CHECKSUM: ${{ steps.prepared_checksums.outputs.video_jar }}
+          SCREEN_CAPTURE_HELPER_CHECKSUM: ${{ steps.prepared_checksums.outputs.screen_capture_helper }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
 
@@ -180,10 +248,6 @@ jobs:
           fi
 
           # Add checksum to notes
-          APK_CHECKSUM="${{ steps.prepared_checksums.outputs.apk }}"
-          IPA_CHECKSUM="${{ steps.prepared_checksums.outputs.ipa }}"
-          VIDEO_JAR_CHECKSUM="${{ steps.prepared_checksums.outputs.video_jar }}"
-          SCREEN_CAPTURE_HELPER_CHECKSUM="${{ steps.prepared_checksums.outputs.screen_capture_helper }}"
           NOTES="${NOTES}"$'\n\n'"## CtrlProxy APK"$'\n\n'\
             '"**SHA256 Checksum:** \`${APK_CHECKSUM}\`"$'\n\n'\
             '"Download the APK from the release assets below."
@@ -204,6 +268,9 @@ jobs:
           echo "notes<<EOF" >> $GITHUB_OUTPUT
           echo "$NOTES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Build TypeScript package
+        run: bun run build
 
       - name: Publish to npm
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,28 +2,26 @@
 name: Release
 
 "on":
-  create:
-  # prepare-release dispatches this explicitly after pushing the tag. The `create`
-  # event above did not fire for CI-pushed tags (see v0.0.42/v0.0.44: the tag push
-  # succeeded and no Release run was ever queued), so the tag event alone cannot be
-  # relied on to start a release.
   workflow_dispatch:
     inputs:
       tag:
         description: "Release tag to publish, with no leading v (e.g. 0.0.45)"
         required: true
         type: string
+      prepare_run_id:
+        description: "Successful Prepare Release workflow run that built the artifacts"
+        required: true
+        type: string
 
-# `create:` is retained as a fallback for a hand-pushed tag, so one tag could in
-# principle arrive by both routes. This serializes them; it does NOT dedupe them
-# -- with cancel-in-progress false the second run queues and then starts once the
-# first finishes. What makes that second run harmless is the already-published.sh
-# guard on each non-idempotent publish step, not this block. Both are required.
+# Prepare Release dispatches this workflow only after it has built, hashed, and
+# integrity-checked every GitHub Release asset. The release consumes those exact
+# artifacts rather than starting a second, potentially different build.
 concurrency:
-  group: release-${{ inputs.tag || github.event.ref }}
+  group: release-${{ inputs.tag }}
   cancel-in-progress: false
 
 permissions:
+  actions: read
   contents: write
   pull-requests: write
   id-token: write
@@ -33,8 +31,6 @@ jobs:
   validate-release-tag:
     name: "Validate Release Tag"
     runs-on: ubuntu-latest
-    # workflow_dispatch carries no ref_type; only the create path needs the tag gate.
-    if: github.event_name == 'workflow_dispatch' || github.event.ref_type == 'tag'
     outputs:
       is_release_tag: ${{ steps.validate.outputs.is_release_tag }}
       tag: ${{ steps.validate.outputs.tag }}
@@ -50,13 +46,9 @@ jobs:
         run: |
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
-          # The dispatch must run ON the tag, not merely name it. The Actions UI
-          # ref picker defaults to a branch, and prepare-release is not the only
-          # caller. docker/metadata-action derives its semver tags from
-          # github.ref, so a dispatch from main checks out the right tree and
-          # still pushes an image with no version tag -- green, and wrong.
-          if [[ "$EVENT_NAME" == "workflow_dispatch" ]] \
-            && { [[ "$REF_TYPE" != "tag" ]] || [[ "$REF_NAME" != "$TAG" ]]; }; then
+          # Prepare Release must dispatch this workflow on the tag, not merely
+          # name it. docker/metadata-action derives semver tags from github.ref.
+          if { [[ "$REF_TYPE" != "tag" ]] || [[ "$REF_NAME" != "$TAG" ]]; }; then
             echo "Release must be dispatched on tag '$TAG', but this run is on" >&2
             echo "${REF_TYPE} '${REF_NAME}'. Re-run it and pick the tag in the" >&2
             echo "ref dropdown, or let prepare-release dispatch it." >&2
@@ -67,65 +59,14 @@ jobs:
             exit 0
           fi
 
-          echo "is_release_tag=false" >> "$GITHUB_OUTPUT"
-          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            # An explicit dispatch names the tag it wants released, so a format
-            # miss is a caller error. Failing beats skipping every publish step
-            # and still reporting the run green.
-            echo "Refusing to release malformed tag: $TAG (expected 0.0.45, no leading v)" >&2
-            exit 1
-          fi
-          echo "Ignoring non-release tag: $TAG"
-
-  build-ctrl-proxy-ios-ipa:
-    needs: validate-release-tag
-    if: needs.validate-release-tag.outputs.is_release_tag == 'true'
-    uses: ./.github/workflows/build-ctrl-proxy-ios-ipa.yml
-
-  build-control-proxy-apk:
-    needs: validate-release-tag
-    if: needs.validate-release-tag.outputs.is_release_tag == 'true'
-    uses: ./.github/workflows/build-control-proxy-apk.yml
-    secrets:
-      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-      RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
-      RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
-      RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
-      RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
-
-  build-video-server-jar:
-    needs: validate-release-tag
-    if: needs.validate-release-tag.outputs.is_release_tag == 'true'
-    # No verify-reproducible here: the verify-and-release job already re-verifies
-    # the release-built jar against the registry sha minted by prepare-release on a
-    # different runner — a stronger cross-run reproducibility check than an in-job
-    # double-build. The double-build runs once, at mint time (prepare-release).
-    uses: ./.github/workflows/build-video-server-jar.yml
-    secrets:
-      GRADLE_ENCRYPTION_KEY: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
-
-  build-screen-capture-helper:
-    needs: validate-release-tag
-    if: needs.validate-release-tag.outputs.is_release_tag == 'true'
-    uses: ./.github/workflows/build-screen-capture-helper.yml
-    secrets:
-      MACOS_DEVELOPER_ID_CERT_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_CERT_BASE64 }}
-      MACOS_DEVELOPER_ID_CERT_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_CERT_PASSWORD }}
-      MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
-      MACOS_DEVELOPER_ID_SIGNING_IDENTITY: ${{ secrets.MACOS_DEVELOPER_ID_SIGNING_IDENTITY }}
-      APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
-      APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
-      APPLE_NOTARY_PRIVATE_KEY_BASE64: ${{ secrets.APPLE_NOTARY_PRIVATE_KEY_BASE64 }}
+          echo "Refusing to release malformed tag: $TAG (expected 0.0.45, no leading v)" >&2
+          exit 1
 
   verify-and-release:
     if: needs.validate-release-tag.outputs.is_release_tag == 'true'
     runs-on: ubuntu-latest
     needs:
       - validate-release-tag
-      - build-ctrl-proxy-ios-ipa
-      - build-control-proxy-apk
-      - build-video-server-jar
-      - build-screen-capture-helper
 
     steps:
       - name: Checkout code
@@ -165,127 +106,59 @@ jobs:
         with:
           name: control-proxy-apk
           path: /tmp
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.prepare_run_id }}
 
       - name: "Download CtrlProxy iOS IPA"
         uses: actions/download-artifact@v7
         with:
           name: ctrl-proxy-ios-ipa
           path: /tmp
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.prepare_run_id }}
 
       - name: "Download video-server jar"
         uses: actions/download-artifact@v7
         with:
           name: video-server-jar
           path: /tmp
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.prepare_run_id }}
 
       - name: "Download screen-capture-helper"
         uses: actions/download-artifact@v7
         with:
           name: screen-capture-helper
           path: /tmp
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.prepare_run_id }}
 
-      # These four steps run the release's only artifact-provenance gate, and
-      # both halves of the original form failed open. `bash -e` without pipefail
-      # takes its status from `tee`, so verify-artifact-sha256.sh's exit 1 on a
-      # mismatch was discarded; and `grep | cut` takes its status from `cut`, so
-      # finding no `checksum=` line set an empty output instead of aborting. A
-      # mismatched APK therefore sailed through green and only stopped later, at
-      # generate-release-constants.sh's "requires both" guard, reported as a
-      # missing variable rather than the mismatch it was. Keep pipefail and the
-      # non-empty assertion together: either one alone still lets a case through.
-      - name: "Verify APK SHA256 matches source"
-        id: verify_checksum
-        shell: bash
-        run: |
-          set -euo pipefail
-          bash scripts/ci/verify-artifact-sha256.sh \
-            /tmp/control-proxy-debug.apk android | tee /tmp/apk-verify.log
-          CHECKSUM=$(grep '^checksum=' /tmp/apk-verify.log | cut -d= -f2)
-          [ -n "$CHECKSUM" ] || { echo "No checksum= line in APK verify log" >&2; exit 1; }
-          echo "checksum=$CHECKSUM" >> "$GITHUB_OUTPUT"
-
-      - name: "Verify CtrlProxy iOS IPA SHA256 matches source"
-        id: verify_ipa_checksum
-        shell: bash
-        run: |
-          set -euo pipefail
-          bash scripts/ci/verify-artifact-sha256.sh \
-            /tmp/control-proxy.ipa ios | tee /tmp/ipa-verify.log
-          CHECKSUM=$(grep '^checksum=' /tmp/ipa-verify.log | cut -d= -f2)
-          [ -n "$CHECKSUM" ] || { echo "No checksum= line in IPA verify log" >&2; exit 1; }
-          echo "checksum=$CHECKSUM" >> "$GITHUB_OUTPUT"
-
-      - name: "Verify video-server jar SHA256 matches source"
-        id: verify_video_jar_checksum
-        shell: bash
-        run: |
-          set -euo pipefail
-          bash scripts/ci/verify-artifact-sha256.sh \
-            /tmp/automobile-video.jar videojar | tee /tmp/videojar-verify.log
-          CHECKSUM=$(grep '^checksum=' /tmp/videojar-verify.log | cut -d= -f2)
-          [ -n "$CHECKSUM" ] || { echo "No checksum= line in jar verify log" >&2; exit 1; }
-          echo "checksum=$CHECKSUM" >> "$GITHUB_OUTPUT"
-
-      - name: "Verify screen-capture-helper SHA256 matches source"
-        id: verify_screen_capture_helper_checksum
-        shell: bash
-        run: |
-          set -euo pipefail
-          bash scripts/ci/verify-artifact-sha256.sh \
-            /tmp/screen-capture-helper-macos-universal.zip screencapturehelper | tee /tmp/screen-capture-helper-verify.log
-          CHECKSUM=$(grep '^checksum=' /tmp/screen-capture-helper-verify.log | cut -d= -f2)
-          [ -n "$CHECKSUM" ] || { echo "No checksum= line in screen-capture-helper verify log" >&2; exit 1; }
-          echo "checksum=$CHECKSUM" >> "$GITHUB_OUTPUT"
-
-      - name: Generate release constants
+      - name: Read checksums prepared for this release
+        id: prepared_checksums
         env:
-          RELEASE_VERSION: ${{ steps.version.outputs.version }}
-          APK_SHA256_CHECKSUM: ${{ steps.verify_checksum.outputs.checksum }}
-          IOS_CTRL_PROXY_SHA256_CHECKSUM:
-            ${{ steps.verify_ipa_checksum.outputs.checksum }}
-          IOS_CTRL_PROXY_RUNNER_SHA256:
-            ${{ needs.build-ctrl-proxy-ios-ipa.outputs.runner_sha256 }}
-          VIDEO_JAR_SHA256:
-            ${{ steps.verify_video_jar_checksum.outputs.checksum }}
-          SCREEN_CAPTURE_HELPER_SHA256:
-            ${{ steps.verify_screen_capture_helper_checksum.outputs.checksum }}
-        run: bash scripts/generate-release-constants.sh
-
-      - name: Verify release integrity
-        run: >
-          bash scripts/ci/verify-release-integrity.sh
-          "${{ steps.version.outputs.version }}"
-          /tmp/control-proxy.ipa
-
-      - name: Run tests
-        env:
-          TURBO_TELEMETRY_DISABLED: "1"
-          TURBO_NO_UPDATE_NOTIFIER: "1"
-          DO_NOT_TRACK: "1"
-          NO_COLOR: "1"
-        run: turbo run test --output-logs=errors-only
-
-      - name: Run lint
-        env:
-          TURBO_TELEMETRY_DISABLED: "1"
-          TURBO_NO_UPDATE_NOTIFIER: "1"
-          DO_NOT_TRACK: "1"
-          NO_COLOR: "1"
-        run: turbo run lint --output-logs=errors-only
-
-      - name: Build TypeScript with injected checksum
-        env:
-          TURBO_TELEMETRY_DISABLED: "1"
-          TURBO_NO_UPDATE_NOTIFIER: "1"
-          DO_NOT_TRACK: "1"
-          NO_COLOR: "1"
-        run: turbo run build --force --output-logs=errors-only
-
-      - name: Run Bun MCP startup smoke
-        run: bun run test:startup:bun
-
-      - name: Run Bun image runtime smoke
-        run: bun run test:image:bun
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          bun -e '
+            import { appendFileSync } from "node:fs";
+            import { RELEASE_CHECKSUM_REGISTRY } from "./src/constants/release";
+            const entry = RELEASE_CHECKSUM_REGISTRY.find(({ version }) => version === process.env.VERSION);
+            if (!entry?.videoJarSha256 || !entry.screenCaptureHelperSha256) {
+              throw new Error(`Missing prepared checksums for ${process.env.VERSION}`);
+            }
+            const output = process.env.GITHUB_OUTPUT;
+            for (const [key, value] of Object.entries({
+              apk: entry.apkSha256,
+              ipa: entry.ipaSha256,
+              video_jar: entry.videoJarSha256,
+              screen_capture_helper: entry.screenCaptureHelperSha256,
+            })) {
+              appendFileSync(output, `${key}=${value}\n`);
+            }
+          '
 
       - name: Create release notes
         id: release_notes
@@ -307,10 +180,10 @@ jobs:
           fi
 
           # Add checksum to notes
-          APK_CHECKSUM="${{ steps.verify_checksum.outputs.checksum }}"
-          IPA_CHECKSUM="${{ steps.verify_ipa_checksum.outputs.checksum }}"
-          VIDEO_JAR_CHECKSUM="${{ steps.verify_video_jar_checksum.outputs.checksum }}"
-          SCREEN_CAPTURE_HELPER_CHECKSUM="${{ steps.verify_screen_capture_helper_checksum.outputs.checksum }}"
+          APK_CHECKSUM="${{ steps.prepared_checksums.outputs.apk }}"
+          IPA_CHECKSUM="${{ steps.prepared_checksums.outputs.ipa }}"
+          VIDEO_JAR_CHECKSUM="${{ steps.prepared_checksums.outputs.video_jar }}"
+          SCREEN_CAPTURE_HELPER_CHECKSUM="${{ steps.prepared_checksums.outputs.screen_capture_helper }}"
           NOTES="${NOTES}"$'\n\n'"## CtrlProxy APK"$'\n\n'\
             '"**SHA256 Checksum:** \`${APK_CHECKSUM}\`"$'\n\n'\
             '"Download the APK from the release assets below."
@@ -508,10 +381,10 @@ jobs:
       - name: Summary
         env:
           VER: ${{ steps.version.outputs.version }}
-          APK_CHECKSUM: ${{ steps.verify_checksum.outputs.checksum }}
-          IPA_CHECKSUM: ${{ steps.verify_ipa_checksum.outputs.checksum }}
-          VIDEO_JAR_CHECKSUM: ${{ steps.verify_video_jar_checksum.outputs.checksum }}
-          SCREEN_CAPTURE_HELPER_CHECKSUM: ${{ steps.verify_screen_capture_helper_checksum.outputs.checksum }}
+          APK_CHECKSUM: ${{ steps.prepared_checksums.outputs.apk }}
+          IPA_CHECKSUM: ${{ steps.prepared_checksums.outputs.ipa }}
+          VIDEO_JAR_CHECKSUM: ${{ steps.prepared_checksums.outputs.video_jar }}
+          SCREEN_CAPTURE_HELPER_CHECKSUM: ${{ steps.prepared_checksums.outputs.screen_capture_helper }}
           REPO: ${{ github.repository }}
           TAG: ${{ steps.version.outputs.tag }}
         run: |

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -212,10 +212,20 @@
 
 @test "release.yml builds the package before publishing npm" {
   wiring_requires_yq
-  local steps
+  local steps build_index publish_index
   steps="$(yq -r '.jobs."verify-and-release".steps[] | (.name // "") + "\t" + (.run // "")' ".github/workflows/release.yml")"
   [[ "$steps" == *$'Build TypeScript package\tbun run build'* ]]
   [[ "$steps" == *$'Publish to npm\t'* ]]
+
+  run yq -r '.jobs."verify-and-release".steps | to_entries[] | select(.value.name == "Build TypeScript package") | .key' ".github/workflows/release.yml"
+  [ "$status" -eq 0 ]
+  build_index="$output"
+
+  run yq -r '.jobs."verify-and-release".steps | to_entries[] | select(.value.name == "Publish to npm") | .key' ".github/workflows/release.yml"
+  [ "$status" -eq 0 ]
+  publish_index="$output"
+
+  (( build_index < publish_index ))
 
   local notes_env
   notes_env="$(yq -r '.jobs."verify-and-release".steps[] | select(.id == "release_notes") | .env' ".github/workflows/release.yml")"

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -4,8 +4,18 @@
 # integrity gate, while Release publishes the artifacts from that successful run.
 
 @test "release.yml reads the checksums baked by prepare-release" {
-  grep -q "RELEASE_CHECKSUM_REGISTRY" ".github/workflows/release.yml"
-  grep -q "prepared_checksums" ".github/workflows/release.yml"
+  wiring_requires_yq
+  local script
+  script="$(yq -r '.jobs."verify-and-release".steps[]
+    | select(.id == "prepared_checksums") | .run' ".github/workflows/release.yml" \
+    | grep -v '^[[:space:]]*#')"
+  [ -n "$script" ]
+  [ "$script" != "null" ]
+  [[ "$script" == *"RELEASE_CHECKSUM_REGISTRY"* ]]
+  [[ "$script" == *"apkSha256"* ]]
+  [[ "$script" == *"ipaSha256"* ]]
+  [[ "$script" == *"videoJarSha256"* ]]
+  [[ "$script" == *"screenCaptureHelperSha256"* ]]
 }
 
 @test "prepare-release.yml passes runner sha256 into generate-release-constants" {
@@ -64,13 +74,14 @@
   [ "$status" -eq 0 ]
   [ "$output" = "absent" ]
 
+  run yq -r '
+    .jobs."verify-and-release".steps[]
+    | select(.uses == "actions/download-artifact@v7")
+    | .with.name + "\t" + .with."run-id" + "\t" + .with."github-token" + "\t" + .with.repository' "$workflow"
+  [ "$status" -eq 0 ]
+
   local artifact_name
   for artifact_name in control-proxy-apk ctrl-proxy-ios-ipa video-server-jar screen-capture-helper; do
-    run yq -r '
-      .jobs."verify-and-release".steps[]
-      | select(.uses == "actions/download-artifact@v7")
-      | .with.name + "\t" + .with."run-id" + "\t" + .with."github-token" + "\t" + .with.repository' "$workflow"
-    [ "$status" -eq 0 ]
     [[ "$output" == *"${artifact_name}"$'\t''${{ inputs.prepare_run_id }}'$'\t''${{ secrets.GITHUB_TOKEN }}'$'\t''${{ github.repository }}'* ]]
   done
 
@@ -85,6 +96,55 @@
   [ "$status" -eq 0 ]
   [[ "$output" != *"verify-artifact-sha256.sh"* ]]
   [[ "$output" != *"verify-release-integrity.sh"* ]]
+}
+
+@test "prepare-release builds and verifies the final tagged tree before dispatching release (#4686)" {
+  wiring_requires_yq
+  local workflow=".github/workflows/prepare-release.yml"
+  local builder
+  for builder in build-ctrl-proxy-ios-ipa build-control-proxy-apk build-video-server-jar build-screen-capture-helper; do
+    run yq -r ".jobs.\"$builder\".needs" "$workflow"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"finalize-release"* ]]
+
+    run yq -r ".jobs.\"$builder\".with.checkout-ref" "$workflow"
+    [ "$status" -eq 0 ]
+    [ "$output" = '${{ needs.finalize-release.outputs.release_commit }}' ]
+  done
+
+  run yq -r '.jobs."verify-prepared-release".steps[] | select(.name == "Verify prepared release artifacts") | .run' "$workflow"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"verify-artifact-sha256.sh"* ]]
+  [[ "$output" == *"verify-release-integrity.sh"* ]]
+}
+
+@test "release.yml requires successful prepared-release provenance before downloading artifacts (#4686)" {
+  wiring_requires_yq
+  local workflow=".github/workflows/release.yml"
+
+  run yq -r '.jobs."verify-and-release".steps[] | select(.name == "Wait for successful Prepare Release") | .run' "$workflow"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"conclusion"* ]]
+  [[ "$output" == *"prepare-release.yml"* ]]
+
+  run yq -r '.jobs."verify-and-release".steps[] | select(.name == "Validate prepared release provenance") | .run' "$workflow"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"release-artifact-provenance"* ]]
+  [[ "$output" == *"tag_sha"* ]]
+  [[ "$output" == *"prepare_run_id"* ]]
+}
+
+@test "release.yml builds the package before publishing npm" {
+  wiring_requires_yq
+  local steps
+  steps="$(yq -r '.jobs."verify-and-release".steps[] | (.name // "") + "\t" + (.run // "")' ".github/workflows/release.yml")"
+  [[ "$steps" == *$'Build TypeScript package\tbun run build'* ]]
+  [[ "$steps" == *$'Publish to npm\t'* ]]
+
+  local notes_env
+  notes_env="$(yq -r '.jobs."verify-and-release".steps[] | select(.id == "release_notes") | .env' ".github/workflows/release.yml")"
+  [[ "$notes_env" == *"prepared_checksums.outputs.apk"* ]]
+  [[ "$notes_env" == *"prepared_checksums.outputs.ipa"* ]]
 }
 
 @test "prepare-release.yml records the video-server jar checksum (#3832)" {
@@ -205,7 +265,7 @@ wiring_requires_yq() {
   # Pull the one step's run script out of the parsed YAML, so comments elsewhere
   # in the file cannot satisfy these assertions.
   local script
-  script="$(yq -r '.jobs.prepare.steps[] | select(.name == "Start the release") | .run' \
+  script="$(yq -r '.jobs."verify-prepared-release".steps[] | select(.name == "Start the release") | .run' \
     ".github/workflows/prepare-release.yml")"
   [ -n "$script" ]
   [ "$script" != "null" ]
@@ -218,25 +278,24 @@ wiring_requires_yq() {
   [[ "$code" != *"--ref main"* ]]
   [[ "$code" == *'prepare_run_id="$PREPARE_RUN_ID"'* ]]
 
-  run yq -r '.jobs.prepare.steps[] | select(.name == "Start the release") | .env.PREPARE_RUN_ID' \
+  run yq -r '.jobs."verify-prepared-release".steps[] | select(.name == "Start the release") | .env.PREPARE_RUN_ID' \
     ".github/workflows/prepare-release.yml"
   [ "$status" -eq 0 ]
   [ "$output" = '${{ github.run_id }}' ]
 }
 
 # The dispatch API rejects a token without actions: write, and the job-level
-# block replaces the workflow-level grant wholesale -- so dropping either half
-# turns the fallback into the 403 that failed Prepare Release #204.
+# block replaces the workflow-level grant wholesale.
 @test "prepare-release can dispatch and still push (#4157)" {
   wiring_requires_yq
   local perms
-  perms="$(yq -r '.jobs.prepare.permissions' ".github/workflows/prepare-release.yml")"
+  perms="$(yq -r '.jobs."verify-prepared-release".permissions' ".github/workflows/prepare-release.yml")"
   [ "$perms" != "null" ]
 
-  run yq -r '.jobs.prepare.permissions.actions' ".github/workflows/prepare-release.yml"
+  run yq -r '.jobs."verify-prepared-release".permissions.actions' ".github/workflows/prepare-release.yml"
   [ "$output" = "write" ]
-  run yq -r '.jobs.prepare.permissions.contents' ".github/workflows/prepare-release.yml"
-  [ "$output" = "write" ]
+  run yq -r '.jobs."verify-prepared-release".permissions.contents' ".github/workflows/prepare-release.yml"
+  [ "$output" = "read" ]
 }
 
 # action-gh-release throws "GitHub Releases requires a tag" when github.ref is not

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -98,24 +98,40 @@
   [[ "$output" != *"verify-release-integrity.sh"* ]]
 }
 
-@test "prepare-release builds and verifies the final tagged tree before dispatching release (#4686)" {
+@test "prepare-release verifies and tags the single prepared artifact set before dispatching release (#4686)" {
   wiring_requires_yq
   local workflow=".github/workflows/prepare-release.yml"
   local builder
-  for builder in build-ctrl-proxy-ios-ipa build-control-proxy-apk build-video-server-jar build-screen-capture-helper; do
+  for builder in build-candidate-ctrl-proxy-ios-ipa build-candidate-control-proxy-apk build-candidate-video-server-jar build-candidate-screen-capture-helper; do
     run yq -r ".jobs.\"$builder\".needs" "$workflow"
     [ "$status" -eq 0 ]
-    [[ "$output" == *"finalize-release"* ]]
+    [[ "$output" == *"prepare-version"* ]]
 
     run yq -r ".jobs.\"$builder\".with.checkout-ref" "$workflow"
     [ "$status" -eq 0 ]
-    [ "$output" = '${{ needs.finalize-release.outputs.release_commit }}' ]
+    [ "$output" = '${{ needs.prepare-version.outputs.release_commit }}' ]
+
+    run yq -r ".jobs.\"$builder\".with.upload-artifact" "$workflow"
+    [ "$status" -eq 0 ]
+    [ "$output" = "true" ]
   done
+
+  run yq -r '.jobs | keys[]' "$workflow"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"build-ctrl-proxy-ios-ipa"* ]]
+  [[ "$output" != *"build-control-proxy-apk"* ]]
+  [[ "$output" != *"build-video-server-jar"* ]]
+  [[ "$output" != *"build-screen-capture-helper"* ]]
 
   run yq -r '.jobs."verify-prepared-release".steps[] | select(.name == "Verify prepared release artifacts") | .run' "$workflow"
   [ "$status" -eq 0 ]
   [[ "$output" == *"verify-artifact-sha256.sh"* ]]
   [[ "$output" == *"verify-release-integrity.sh"* ]]
+
+  run yq -r '.jobs."verify-prepared-release".steps[] | select(.name == "Create and push verified release tag") | .run' "$workflow"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"main moved after the release artifacts were verified"* ]]
+  [[ "$output" == *'git tag "$TAG" "$EXPECTED_RELEASE_COMMIT"'* ]]
 }
 
 @test "release.yml requires successful prepared-release provenance before downloading artifacts (#4686)" {
@@ -285,7 +301,8 @@ wiring_requires_yq() {
 }
 
 # The dispatch API rejects a token without actions: write, and the job-level
-# block replaces the workflow-level grant wholesale.
+# block replaces the workflow-level grant wholesale. This job also creates the
+# tag only after artifact verification, so it needs contents: write.
 @test "prepare-release can dispatch and still push (#4157)" {
   wiring_requires_yq
   local perms
@@ -295,7 +312,7 @@ wiring_requires_yq() {
   run yq -r '.jobs."verify-prepared-release".permissions.actions' ".github/workflows/prepare-release.yml"
   [ "$output" = "write" ]
   run yq -r '.jobs."verify-prepared-release".permissions.contents' ".github/workflows/prepare-release.yml"
-  [ "$output" = "read" ]
+  [ "$output" = "write" ]
 }
 
 # action-gh-release throws "GitHub Releases requires a tag" when github.ref is not

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -1,12 +1,11 @@
 #!/usr/bin/env bats
 #
-# Guards the wiring the issue #2745 regression was about: every workflow that
-# generates release constants must pass the computed iOS runner SHA256 into the
-# script, and the release paths must run the integrity gate before publishing.
+# Guards release checksum handoff: Prepare Release is the single builder and
+# integrity gate, while Release publishes the artifacts from that successful run.
 
-@test "release.yml passes runner sha256 into generate-release-constants" {
-  grep -q "IOS_CTRL_PROXY_RUNNER_SHA256:" ".github/workflows/release.yml"
-  grep -q "runner_sha256" ".github/workflows/release.yml"
+@test "release.yml reads the checksums baked by prepare-release" {
+  grep -q "RELEASE_CHECKSUM_REGISTRY" ".github/workflows/release.yml"
+  grep -q "prepared_checksums" ".github/workflows/release.yml"
 }
 
 @test "prepare-release.yml passes runner sha256 into generate-release-constants" {
@@ -49,14 +48,43 @@
   grep -q "chore: update video-server jar SHA256" ".github/workflows/pull_request.yml"
 }
 
-@test "release.yml builds, verifies, and attaches the video-server jar (#3832)" {
-  workflow=".github/workflows/release.yml"
-  grep -Fq "uses: ./.github/workflows/build-video-server-jar.yml" "$workflow"
-  # Verified against the registry via the videojar platform token, then written.
-  grep -Fq "/tmp/automobile-video.jar videojar" "$workflow"
-  grep -Fq "VIDEO_JAR_SHA256:" "$workflow"
-  # Attached to the GitHub release assets.
-  grep -Fq "/tmp/automobile-video.jar" "$workflow"
+@test "release.yml reuses prepare-release artifacts instead of rebuilding them (#4686)" {
+  wiring_requires_yq
+  local workflow=".github/workflows/release.yml"
+
+  run yq -r '.on.workflow_dispatch.inputs.prepare_run_id.required' "$workflow"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+
+  run yq -r '.permissions.actions' "$workflow"
+  [ "$status" -eq 0 ]
+  [ "$output" = "read" ]
+
+  run yq -r '.on.create // "absent"' "$workflow"
+  [ "$status" -eq 0 ]
+  [ "$output" = "absent" ]
+
+  local artifact_name
+  for artifact_name in control-proxy-apk ctrl-proxy-ios-ipa video-server-jar screen-capture-helper; do
+    run yq -r '
+      .jobs."verify-and-release".steps[]
+      | select(.uses == "actions/download-artifact@v7")
+      | .with.name + "\t" + .with."run-id" + "\t" + .with."github-token" + "\t" + .with.repository' "$workflow"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"${artifact_name}"$'\t''${{ inputs.prepare_run_id }}'$'\t''${{ secrets.GITHUB_TOKEN }}'$'\t''${{ github.repository }}'* ]]
+  done
+
+  run yq -r '.jobs | keys[]' "$workflow"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"build-ctrl-proxy-ios-ipa"* ]]
+  [[ "$output" != *"build-control-proxy-apk"* ]]
+  [[ "$output" != *"build-video-server-jar"* ]]
+  [[ "$output" != *"build-screen-capture-helper"* ]]
+
+  run yq -r '.jobs."verify-and-release".steps[] | select(.run != null) | .run' "$workflow"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"verify-artifact-sha256.sh"* ]]
+  [[ "$output" != *"verify-release-integrity.sh"* ]]
 }
 
 @test "prepare-release.yml records the video-server jar checksum (#3832)" {
@@ -65,15 +93,13 @@
   grep -Fq "VIDEO_JAR_SHA256:" "$workflow"
 }
 
-@test "release delivery builds, verifies, and attaches the screen-capture-helper" {
+@test "prepare-release records and verifies the screen-capture-helper before release delivery" {
   local workflow=".github/workflows/release.yml"
-  grep -Fq "uses: ./.github/workflows/build-screen-capture-helper.yml" "$workflow"
-  grep -Fq "/tmp/screen-capture-helper-macos-universal.zip screencapturehelper" "$workflow"
-  grep -Fq "SCREEN_CAPTURE_HELPER_SHA256:" "$workflow"
-  grep -Fq "/tmp/screen-capture-helper-macos-universal.zip" "$workflow"
+  ! grep -Fq "uses: ./.github/workflows/build-screen-capture-helper.yml" "$workflow"
 
   workflow=".github/workflows/prepare-release.yml"
   grep -Fq "uses: ./.github/workflows/build-screen-capture-helper.yml" "$workflow"
+  grep -Fq "verify-release-integrity.sh" "$workflow"
   grep -Fq "SCREEN_CAPTURE_HELPER_SHA256:" "$workflow"
 }
 
@@ -106,18 +132,6 @@
   [[ "$lint_block" == *"shell: bash"* ]]
   [[ "$lint_block" == *"NODE_OPTIONS: \"--max-old-space-size=4096\""* ]]
   [[ "$lint_block" == *"ci-logs/bun-lint-\${{ matrix.os }}.log"* ]]
-}
-
-@test "release.yml runs the release-integrity gate" {
-  grep -q "verify-release-integrity.sh" ".github/workflows/release.yml"
-}
-
-@test "release.yml runs the Bun image smoke without the retired Wasm OSR override (#4009)" {
-  smoke_block="$(sed -n '/name: Run Bun image runtime smoke/,/run: bun run test:image:bun/p' ".github/workflows/release.yml")"
-
-  [[ "$smoke_block" == *"run: bun run test:image:bun"* ]]
-  [[ "$smoke_block" != *"BUN_JSC_useWasmOSR"* ]]
-  [[ "$smoke_block" != *"@jimp/wasm-webp"* ]]
 }
 
 @test "prepare-release.yml runs the release-integrity gate" {
@@ -165,12 +179,8 @@
 # wiring link that regresses silently is the exact defect this whole area exists
 # to prevent. `yq` reads the real trigger and step fields instead.
 #
-# Pushing the tag does start Release on its own -- release.yml's `create:`
-# trigger fired for 0.0.43, 0.0.44 and 0.0.45, all pushed by CI. The premise
-# recorded here originally (that `create` never fires for CI-pushed tags) was a
-# misread: what failed at 0.0.44 was a v-prefixed tag losing the validation gate,
-# not a missing run. So prepare-release confirms a run exists for the tag and
-# only dispatches when none does; the assertions below pin that fallback.
+# Release takes an explicit prepare-run ID. This is the artifact provenance
+# boundary: it consumes the already checked artifacts instead of rebuilding.
 
 # Skipping locally is a convenience; skipping in CI would silently retire every
 # assertion below, which is the same fail-green these guards exist to catch.
@@ -190,7 +200,7 @@ wiring_requires_yq() {
   [ "$output" = "true" ]
 }
 
-@test "prepare-release dispatches release.yml on the tag, not a branch (#4157)" {
+@test "prepare-release dispatches release.yml on the tag with its run ID (#4686)" {
   wiring_requires_yq
   # Pull the one step's run script out of the parsed YAML, so comments elsewhere
   # in the file cannot satisfy these assertions.
@@ -206,11 +216,12 @@ wiring_requires_yq() {
   [[ "$code" == *"gh workflow run release.yml"* ]]
   [[ "$code" == *'--ref "$TAG"'* ]]
   [[ "$code" != *"--ref main"* ]]
+  [[ "$code" == *'prepare_run_id="$PREPARE_RUN_ID"'* ]]
 
-  # Whichever route starts Release, the check has to be scoped to this tag.
-  # Comparing against the newest run of any branch matches the release.yml run
-  # that every branch creation queues, which reports a release that is not there.
-  [[ "$code" == *'--branch "$TAG"'* ]]
+  run yq -r '.jobs.prepare.steps[] | select(.name == "Start the release") | .env.PREPARE_RUN_ID' \
+    ".github/workflows/prepare-release.yml"
+  [ "$status" -eq 0 ]
+  [ "$output" = '${{ github.run_id }}' ]
 }
 
 # The dispatch API rejects a token without actions: write, and the job-level
@@ -269,29 +280,6 @@ wiring_requires_yq() {
     ".github/workflows/release.yml" | grep -v '^[[:space:]]*#')"
   [[ "$runs" == *'state=$(scripts/release/already-published.sh'* ]]
   [[ "$runs" != *'if [ "$(scripts/release/already-published.sh'* ]]
-}
-
-# The artifact checksum gate is the only thing standing between a stale APK/IPA
-# and a published release, and it failed open twice over in release 0.0.45:
-# `bash -e` without pipefail takes the pipeline's status from `tee`, discarding
-# the script's exit 1, and `grep | cut` takes its status from `cut`, so a missing
-# `checksum=` line produced an empty output rather than an abort.
-@test "release.yml artifact checksum gate cannot fail open (#4157)" {
-  wiring_requires_yq
-  local step
-  for step in verify_checksum verify_ipa_checksum verify_video_jar_checksum verify_screen_capture_helper_checksum; do
-    local script
-    script="$(yq -r ".jobs.\"verify-and-release\".steps[] | select(.id == \"$step\") | .run" \
-      ".github/workflows/release.yml" | grep -v '^[[:space:]]*#')"
-    [ -n "$script" ]
-    [ "$script" != "null" ]
-
-    # pipefail propagates the verify script's mismatch exit through `tee`.
-    [[ "$script" == *"pipefail"* ]]
-    # The emptiness check catches the grep-into-cut case, which pipefail alone
-    # does not: cut succeeds on empty input, so the pipeline status stays 0.
-    [[ "$script" == *'[ -n "$CHECKSUM" ]'* ]]
-  done
 }
 
 # A dispatch that merely names the tag is not enough: the Actions UI ref picker

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -353,8 +353,10 @@ wiring_requires_yq() {
   [[ "$code" == *'--ref "$TAG"'* ]]
   [[ "$code" != *"--ref main"* ]]
   [[ "$code" == *'prepare_run_id="$PREPARE_RUN_ID"'* ]]
+  [[ "$code" == *"previous_release_run_ids"* ]]
   [[ "$code" == *'gh run list --repo "$REPO" --workflow release.yml'* ]]
   [[ "$code" == *'--branch "$TAG"'* ]]
+  [[ "$code" == *'grep -Fxq "$release_run_id" <<< "$previous_release_run_ids"'* ]]
   [[ "$code" == *"Release dispatch for \$TAG did not materialize"* ]]
 
   run yq -r '.jobs."verify-prepared-release".steps[] | select(.name == "Start the release") | .env.PREPARE_RUN_ID' \

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -353,6 +353,9 @@ wiring_requires_yq() {
   [[ "$code" == *'--ref "$TAG"'* ]]
   [[ "$code" != *"--ref main"* ]]
   [[ "$code" == *'prepare_run_id="$PREPARE_RUN_ID"'* ]]
+  [[ "$code" == *'gh run list --repo "$REPO" --workflow release.yml'* ]]
+  [[ "$code" == *'--branch "$TAG"'* ]]
+  [[ "$code" == *"Release dispatch for \$TAG did not materialize"* ]]
 
   run yq -r '.jobs."verify-prepared-release".steps[] | select(.name == "Start the release") | .env.PREPARE_RUN_ID' \
     ".github/workflows/prepare-release.yml"

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -132,6 +132,10 @@
   [[ "$output" == *"verify-artifact-sha256.sh"* ]]
   [[ "$output" == *"verify-release-integrity.sh"* ]]
 
+  run yq -r '.jobs."verify-prepared-release".steps[] | select(.name == "Setup Bun") | .with."bun-version"' "$workflow"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1.3.9" ]
+
   run yq -r '.jobs."verify-prepared-release".steps[] | select(.name == "Promote verified release and create tag") | .run' "$workflow"
   [ "$status" -eq 0 ]
   [[ "$output" == *'git push origin "$EXPECTED_RELEASE_COMMIT":main'* ]]

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -114,6 +114,10 @@
     run yq -r ".jobs.\"$builder\".with.upload-artifact" "$workflow"
     [ "$status" -eq 0 ]
     [ "$output" = "true" ]
+
+    run yq -r ".jobs.\"$builder\".with.artifact-retention-days" "$workflow"
+    [ "$status" -eq 0 ]
+    [ "$output" = "90" ]
   done
 
   run yq -r '.jobs | keys[]' "$workflow"
@@ -165,9 +169,13 @@
     .github/workflows/build-control-proxy-apk.yml \
     .github/workflows/build-video-server-jar.yml \
     .github/workflows/build-screen-capture-helper.yml; do
+    run yq -r '.on.workflow_call.inputs."artifact-retention-days".default' "$workflow"
+    [ "$status" -eq 0 ]
+    [ "$output" = "7" ]
+
     run yq -r '.jobs.build.steps[] | select(.uses == "actions/upload-artifact@v6") | .with."retention-days"' "$workflow"
     [ "$status" -eq 0 ]
-    [ "$output" = "90" ]
+    [ "$output" = '${{ inputs.artifact-retention-days }}' ]
   done
 
   run yq -r '.jobs."verify-prepared-release".steps[] | select(.name == "Upload release artifact provenance") | .with."retention-days"' .github/workflows/prepare-release.yml

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -128,10 +128,27 @@
   [[ "$output" == *"verify-artifact-sha256.sh"* ]]
   [[ "$output" == *"verify-release-integrity.sh"* ]]
 
-  run yq -r '.jobs."verify-prepared-release".steps[] | select(.name == "Create and push verified release tag") | .run' "$workflow"
+  run yq -r '.jobs."verify-prepared-release".steps[] | select(.name == "Promote verified release and create tag") | .run' "$workflow"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"main moved after the release artifacts were verified"* ]]
+  [[ "$output" == *'git push origin "$EXPECTED_RELEASE_COMMIT":main'* ]]
   [[ "$output" == *'git tag "$TAG" "$EXPECTED_RELEASE_COMMIT"'* ]]
+}
+
+@test "prepare-release keeps intermediate version commits on a run-scoped staging ref (#4686)" {
+  wiring_requires_yq
+  local workflow=".github/workflows/prepare-release.yml"
+
+  run yq -r '.jobs."prepare-version".outputs.base_main_commit' "$workflow"
+  [ "$status" -eq 0 ]
+  [ "$output" = '${{ steps.commit.outputs.base_main_commit }}' ]
+
+  local prepare_commit final_commit
+  prepare_commit="$(yq -r '.jobs."prepare-version".steps[] | select(.id == "commit") | .run' "$workflow")"
+  final_commit="$(yq -r '.jobs."finalize-release".steps[] | select(.id == "commit") | .run' "$workflow")"
+  [[ "$prepare_commit" == *'git push --force origin "HEAD:refs/heads/$STAGING_REF"'* ]]
+  [[ "$prepare_commit" != *'git push origin HEAD:main'* ]]
+  [[ "$final_commit" == *'git push --force origin "HEAD:refs/heads/$STAGING_REF"'* ]]
+  [[ "$final_commit" != *'git push origin HEAD:main'* ]]
 }
 
 @test "prepare-release validates the finalized tree before tagging and can rerun provenance upload (#4686)" {

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -145,6 +145,12 @@
   local prepare_commit final_commit
   prepare_commit="$(yq -r '.jobs."prepare-version".steps[] | select(.id == "commit") | .run' "$workflow")"
   final_commit="$(yq -r '.jobs."finalize-release".steps[] | select(.id == "commit") | .run' "$workflow")"
+  run yq -r '.jobs."prepare-version".steps[] | select(.id == "commit") | .env.STAGING_REF' "$workflow"
+  [ "$status" -eq 0 ]
+  [ "$output" = 'release-prepare/${{ github.run_id }}' ]
+  run yq -r '.jobs."finalize-release".steps[] | select(.id == "commit") | .env.STAGING_REF' "$workflow"
+  [ "$status" -eq 0 ]
+  [ "$output" = 'release-prepare/${{ github.run_id }}' ]
   [[ "$prepare_commit" == *'git push --force origin "HEAD:refs/heads/$STAGING_REF"'* ]]
   [[ "$prepare_commit" != *'git push origin HEAD:main'* ]]
   [[ "$final_commit" == *'git push --force origin "HEAD:refs/heads/$STAGING_REF"'* ]]
@@ -364,8 +370,8 @@ wiring_requires_yq() {
   [[ "$code" != *"--ref main"* ]]
   [[ "$code" == *'prepare_run_id="$PREPARE_RUN_ID"'* ]]
   [[ "$code" == *"previous_release_run_ids"* ]]
-  [[ "$code" == *'gh run list --repo "$REPO" --workflow release.yml'* ]]
-  [[ "$code" == *'--branch "$TAG"'* ]]
+  [[ "$code" == *'repos/$REPO/actions/workflows/release.yml/runs?event=workflow_dispatch&per_page=100'* ]]
+  [[ "$code" == *'.head_branch == $tag and .head_sha == $sha'* ]]
   [[ "$code" == *'grep -Fxq "$release_run_id" <<< "$previous_release_run_ids"'* ]]
   [[ "$code" == *"Release dispatch for \$TAG did not materialize"* ]]
 

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -151,6 +151,24 @@
   [[ "$final_commit" != *'git push origin HEAD:main'* ]]
 }
 
+@test "prepared release artifacts survive delayed publication retries (#4686)" {
+  wiring_requires_yq
+  local workflow
+  for workflow in \
+    .github/workflows/build-ctrl-proxy-ios-ipa.yml \
+    .github/workflows/build-control-proxy-apk.yml \
+    .github/workflows/build-video-server-jar.yml \
+    .github/workflows/build-screen-capture-helper.yml; do
+    run yq -r '.jobs.build.steps[] | select(.uses == "actions/upload-artifact@v6") | .with."retention-days"' "$workflow"
+    [ "$status" -eq 0 ]
+    [ "$output" = "90" ]
+  done
+
+  run yq -r '.jobs."verify-prepared-release".steps[] | select(.name == "Upload release artifact provenance") | .with."retention-days"' .github/workflows/prepare-release.yml
+  [ "$status" -eq 0 ]
+  [ "$output" = "90" ]
+}
+
 @test "prepare-release validates the finalized tree before tagging and can rerun provenance upload (#4686)" {
   wiring_requires_yq
   local workflow=".github/workflows/prepare-release.yml"

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -134,6 +134,31 @@
   [[ "$output" == *'git tag "$TAG" "$EXPECTED_RELEASE_COMMIT"'* ]]
 }
 
+@test "prepare-release validates the finalized tree before tagging and can rerun provenance upload (#4686)" {
+  wiring_requires_yq
+  local workflow=".github/workflows/prepare-release.yml"
+
+  run yq -r '.jobs."validate-finalized-release".needs' "$workflow"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"finalize-release"* ]]
+
+  run yq -r '.jobs."verify-prepared-release".needs' "$workflow"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"validate-finalized-release"* ]]
+
+  local step_names
+  step_names="$(yq -r '.jobs."validate-finalized-release".steps[].name' "$workflow")"
+  [[ "$step_names" == *"Run tests"* ]]
+  [[ "$step_names" == *"Run lint"* ]]
+  [[ "$step_names" == *"Build TypeScript"* ]]
+  [[ "$step_names" == *"Run Bun MCP startup smoke"* ]]
+  [[ "$step_names" == *"Run Bun image runtime smoke"* ]]
+
+  run yq -r '.jobs."verify-prepared-release".steps[] | select(.name == "Upload release artifact provenance") | .with.overwrite' "$workflow"
+  [ "$status" -eq 0 ]
+  [ "$output" = "true" ]
+}
+
 @test "release.yml requires successful prepared-release provenance before downloading artifacts (#4686)" {
   wiring_requires_yq
   local workflow=".github/workflows/release.yml"


### PR DESCRIPTION
## Summary

- make Prepare Release the single artifact build and integrity-check boundary
- version and commit the release tree first, then mint its checksum registry from candidate builds
- build and verify the exact tagged tree before Release publishes its artifacts
- pass a tag/run-bound provenance manifest to Release, which downloads and attaches those exact artifacts
- remove Release's duplicate artifact builds, checksum verification, and constants regeneration
- restore the package build required before npm publication
- cover the cross-workflow artifact handoff with release workflow wiring tests

## Root cause

Prepare Release baked checksums from its successful artifacts, while Release rebuilt artifacts from a later tagged tree. A moving `main` branch could therefore make the second build differ from the checksums and assets prepared for the release.

## Validation

- `bats test/bats/release-workflow-wiring.bats`
- `actionlint -shellcheck= .github/workflows/prepare-release.yml .github/workflows/release.yml`
- `bun run typecheck` (no new errors; 198 existing baseline errors)
- `git diff --check`
- `bun run turbo:validate` was retried twice but became CPU-bound without failure output at the Android-emulator boundary test transition; its isolated test passes in 208 ms. Publishing proceeds at the requester's direction.

Closes [#4686](https://github.com/kaeawc/auto-mobile/issues/4686)
