### PR TITLE
Desktop workspace: real facet content — Logs (per-device telemetry) + facet-content seam

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -12,13 +13,20 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import dev.jasonpearson.automobile.desktop.core.daemon.TelemetryPushClient
+import dev.jasonpearson.automobile.desktop.core.daemon.TelemetryPushSocketClient
+import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import dev.jasonpearson.automobile.desktop.core.mcp.DaemonMcpResourceClient
 import dev.jasonpearson.automobile.desktop.core.settings.SettingsProvider
 import dev.jasonpearson.automobile.desktop.core.shell.MenuBarActions
+import dev.jasonpearson.automobile.desktop.core.telemetry.TelemetryDashboard
+import dev.jasonpearson.automobile.desktop.core.workspace.DeviceColumn
+import dev.jasonpearson.automobile.desktop.core.workspace.Tool
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceAction
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceEffect
+import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceFacetPlaceholder
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceShell
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceViewModel
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePicker
@@ -107,8 +115,45 @@ fun AutoMobileDesktopApp(
           state = workspaceState,
           onAction = workspaceViewModel::onAction,
           onOpenPicker = workspaceViewModel::openPicker,
+          facetContent = { column, tool -> WorkspaceFacet(column, tool) },
         )
       }
     }
   }
+}
+
+/**
+ * Real docked-facet content for a pane. Only Logs is wired so far (per-device telemetry); every
+ * other tool falls back to the shared placeholder until its dashboard gains per-device targeting.
+ */
+@Composable
+private fun WorkspaceFacet(column: DeviceColumn, tool: Tool) {
+  when (tool) {
+    Tool.Logs -> LogsFacet(column)
+    else -> WorkspaceFacetPlaceholder(tool)
+  }
+}
+
+/**
+ * Logs facet: the telemetry dashboard scoped to this pane's device. A [TelemetryPushSocketClient]
+ * is connected per device while the facet is shown and disposed when it closes or the device
+ * changes.
+ */
+@Composable
+private fun LogsFacet(column: DeviceColumn) {
+  var client by remember(column.deviceId) { mutableStateOf<TelemetryPushClient?>(null) }
+  DisposableEffect(column.deviceId) {
+    val socket = TelemetryPushSocketClient()
+    socket.connect(deviceId = column.deviceId)
+    client = socket
+    onDispose {
+      socket.dispose()
+      client = null
+    }
+  }
+  TelemetryDashboard(
+    telemetryPushClient = client,
+    dataSourceMode = DataSourceMode.Real,
+    activeDeviceId = column.deviceId,
+  )
 }

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -13,16 +12,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import dev.jasonpearson.automobile.desktop.core.daemon.TelemetryPushClient
-import dev.jasonpearson.automobile.desktop.core.daemon.TelemetryPushSocketClient
-import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import dev.jasonpearson.automobile.desktop.core.mcp.DaemonMcpResourceClient
 import dev.jasonpearson.automobile.desktop.core.settings.SettingsProvider
 import dev.jasonpearson.automobile.desktop.core.shell.MenuBarActions
-import dev.jasonpearson.automobile.desktop.core.telemetry.TelemetryDashboard
 import dev.jasonpearson.automobile.desktop.core.workspace.DeviceColumn
+import dev.jasonpearson.automobile.desktop.core.workspace.LogsFacet
 import dev.jasonpearson.automobile.desktop.core.workspace.Tool
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceAction
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceEffect
@@ -123,8 +119,9 @@ fun AutoMobileDesktopApp(
 }
 
 /**
- * Real docked-facet content for a pane. Only Logs is wired so far (per-device telemetry); every
- * other tool falls back to the shared placeholder until its dashboard gains per-device targeting.
+ * Real docked-facet content for a pane. Only Logs is wired so far (per-device telemetry, via the
+ * testable [LogsFacet] in desktop-core); every other tool falls back to the shared placeholder
+ * until its dashboard gains per-device targeting.
  */
 @Composable
 private fun WorkspaceFacet(column: DeviceColumn, tool: Tool) {
@@ -132,28 +129,4 @@ private fun WorkspaceFacet(column: DeviceColumn, tool: Tool) {
     Tool.Logs -> LogsFacet(column)
     else -> WorkspaceFacetPlaceholder(tool)
   }
-}
-
-/**
- * Logs facet: the telemetry dashboard scoped to this pane's device. A [TelemetryPushSocketClient]
- * is connected per device while the facet is shown and disposed when it closes or the device
- * changes.
- */
-@Composable
-private fun LogsFacet(column: DeviceColumn) {
-  var client by remember(column.deviceId) { mutableStateOf<TelemetryPushClient?>(null) }
-  DisposableEffect(column.deviceId) {
-    val socket = TelemetryPushSocketClient()
-    socket.connect(deviceId = column.deviceId)
-    client = socket
-    onDispose {
-      socket.dispose()
-      client = null
-    }
-  }
-  TelemetryDashboard(
-    telemetryPushClient = client,
-    dataSourceMode = DataSourceMode.Real,
-    activeDeviceId = column.deviceId,
-  )
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/LogsFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/LogsFacet.kt
@@ -1,0 +1,43 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import dev.jasonpearson.automobile.desktop.core.daemon.TelemetryPushClient
+import dev.jasonpearson.automobile.desktop.core.daemon.TelemetryPushSocketClient
+import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
+import dev.jasonpearson.automobile.desktop.core.telemetry.TelemetryDashboard
+
+/**
+ * Docked-facet body for [Tool.Logs]: the telemetry dashboard scoped to a single pane's device. A
+ * [TelemetryPushClient] is created via [telemetryClientFactory] and connected to [column]'s device
+ * while the facet is shown, then disposed when it leaves composition or the device changes.
+ *
+ * [telemetryClientFactory] is injected (defaulting to a real per-device
+ * [TelemetryPushSocketClient]) so the per-device connect/dispose lifecycle can be verified with a
+ * fake instead of real socket I/O.
+ */
+@Composable
+fun LogsFacet(
+  column: DeviceColumn,
+  telemetryClientFactory: (String) -> TelemetryPushClient = { TelemetryPushSocketClient() },
+) {
+  var client by remember(column.deviceId) { mutableStateOf<TelemetryPushClient?>(null) }
+  DisposableEffect(column.deviceId) {
+    val connected =
+      telemetryClientFactory(column.deviceId).also { it.connect(deviceId = column.deviceId) }
+    client = connected
+    onDispose {
+      connected.dispose()
+      client = null
+    }
+  }
+  TelemetryDashboard(
+    telemetryPushClient = client,
+    dataSourceMode = DataSourceMode.Real,
+    activeDeviceId = column.deviceId,
+  )
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -46,6 +46,11 @@ fun WorkspaceShell(
   onOpenPicker: () -> Unit,
   status: WorkspaceStatus = WorkspaceStatus.Green,
   modifier: Modifier = Modifier,
+  // Renders the docked facet body for a pane's active tool. Hoisted so the host can supply real
+  // per-device dashboards; defaults to a placeholder so un-wired tools stay inert.
+  facetContent: @Composable (DeviceColumn, Tool) -> Unit = { _, tool ->
+    WorkspaceFacetPlaceholder(tool)
+  },
 ) {
   Column(modifier.fillMaxSize()) {
     TopBar(status = status, onOpenPicker = onOpenPicker)
@@ -58,6 +63,7 @@ fun WorkspaceShell(
               column = column,
               focused = column.deviceId == state.focusedDeviceId,
               onAction = onAction,
+              facetContent = facetContent,
               modifier = Modifier.weight(1f).fillMaxHeight(),
             )
           }
@@ -134,6 +140,7 @@ private fun DeviceColumnView(
   column: DeviceColumn,
   focused: Boolean,
   onAction: (WorkspaceAction) -> Unit,
+  facetContent: @Composable (DeviceColumn, Tool) -> Unit,
   modifier: Modifier,
 ) {
   Column(
@@ -152,7 +159,7 @@ private fun DeviceColumnView(
       // stream collapses to grow the facet.
       val facetFraction = facetHeightFraction(column.shrunk)
       StreamArea(column, onAction, Modifier.weight(1f - facetFraction))
-      DockedFacet(column, tool, onAction, Modifier.weight(facetFraction))
+      DockedFacet(column, tool, onAction, facetContent, Modifier.weight(facetFraction))
     }
   }
 }
@@ -182,14 +189,15 @@ private fun StreamArea(
 
 /**
  * The docked facet (tool window) for a pane's active [tool]: a header with the tool icon + label
- * and a ✕ that deselects the tool, over a placeholder body. Real per-tool dashboard content is
- * deferred — the existing dashboards target a single active device, not a per-pane one.
+ * and a ✕ that deselects the tool, over a body supplied by [facetContent]. The body is hoisted so
+ * the host can drop in real per-device dashboards; the default is [WorkspaceFacetPlaceholder].
  */
 @Composable
 private fun DockedFacet(
   column: DeviceColumn,
   tool: Tool,
   onAction: (WorkspaceAction) -> Unit,
+  facetContent: @Composable (DeviceColumn, Tool) -> Unit,
   modifier: Modifier,
 ) {
   Column(modifier.fillMaxWidth().background(MaterialTheme.colorScheme.surface)) {
@@ -216,9 +224,19 @@ private fun DockedFacet(
         onClick = { onAction(WorkspaceAction.SelectTool(column.deviceId, null)) },
       )
     }
-    Box(Modifier.weight(1f).fillMaxWidth(), contentAlignment = Alignment.Center) {
-      Text("${tool.label} — coming soon", color = MaterialTheme.colorScheme.outline)
-    }
+    Box(Modifier.weight(1f).fillMaxWidth()) { facetContent(column, tool) }
+  }
+}
+
+/**
+ * Default docked-facet body: a centered "coming soon" note for a tool with no wired dashboard.
+ * Public so a host that wires real content for only some tools can reuse it as the fallback for the
+ * rest (see [WorkspaceShell]'s `facetContent`).
+ */
+@Composable
+fun WorkspaceFacetPlaceholder(tool: Tool) {
+  Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    Text("${tool.label} — coming soon", color = MaterialTheme.colorScheme.outline)
   }
 }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -59,13 +60,17 @@ fun WorkspaceShell(
       is WorkspaceUiState.Content ->
         Row(Modifier.weight(1f).fillMaxWidth()) {
           state.columns.forEach { column ->
-            DeviceColumnView(
-              column = column,
-              focused = column.deviceId == state.focusedDeviceId,
-              onAction = onAction,
-              facetContent = facetContent,
-              modifier = Modifier.weight(1f).fillMaxHeight(),
-            )
+            // Key by deviceId so a surviving pane keeps its own remembered state + facet
+            // connection when another pane closes (unkeyed = positional identity churns survivors).
+            key(column.deviceId) {
+              DeviceColumnView(
+                column = column,
+                focused = column.deviceId == state.focusedDeviceId,
+                onAction = onAction,
+                facetContent = facetContent,
+                modifier = Modifier.weight(1f).fillMaxHeight(),
+              )
+            }
           }
         }
     }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/LogsFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/LogsFacetTest.kt
@@ -1,0 +1,44 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.daemon.FakeTelemetryPushClient
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class LogsFacetTest {
+
+  @Test
+  fun `connects the telemetry client to the pane device and disposes when removed`() =
+    runComposeUiTest {
+      val fake = FakeTelemetryPushClient()
+      val visible = mutableStateOf(true)
+      setContent {
+        MaterialTheme {
+          if (visible.value) {
+            LogsFacet(
+              column =
+                DeviceColumn(deviceId = "dev-1", name = "Pixel", platform = Platform.Android),
+              telemetryClientFactory = { fake },
+            )
+          }
+        }
+      }
+      waitForIdle()
+      // Connected exactly once, to this pane's device.
+      assertEquals("dev-1", fake.getLastDeviceId())
+      assertEquals(1, fake.getConnectCallCount())
+
+      // Leaving composition disposes the client (dispose → disconnect).
+      runOnIdle { visible.value = false }
+      waitForIdle()
+      assertTrue(
+        "expected the client to be disposed on removal",
+        fake.getDisconnectCallCount() >= 1,
+      )
+    }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.desktop.core.workspace
 
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -181,5 +182,41 @@ class WorkspaceShellUiTest {
     }
     onNodeWithContentDescription("Storage Pixel 8").performClick()
     assertEquals(WorkspaceAction.SelectTool("a", Tool.Storage), action)
+  }
+
+  @Test
+  fun `facet renders the injected facetContent for the active tool`() = runComposeUiTest {
+    var received: Pair<String, Tool>? = null
+    val state =
+      WorkspaceUiState.Content(
+        columns = listOf(col("a", "Pixel 8").copy(activeTool = Tool.Logs)),
+        focusedDeviceId = "a",
+      )
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(
+          state = state,
+          onAction = {},
+          onOpenPicker = {},
+          facetContent = { column, tool ->
+            received = column.deviceId to tool
+            Text("facet-slot:${tool.label}")
+          },
+        )
+      }
+    }
+    onNodeWithText("facet-slot:Logs").assertIsDisplayed()
+    assertEquals("a" to Tool.Logs, received)
+  }
+
+  @Test
+  fun `default facetContent shows the coming-soon placeholder`() = runComposeUiTest {
+    val state =
+      WorkspaceUiState.Content(
+        columns = listOf(col("a", "Pixel 8").copy(activeTool = Tool.Performance)),
+        focusedDeviceId = "a",
+      )
+    setContent { MaterialTheme { WorkspaceShell(state = state, onAction = {}, onOpenPicker = {}) } }
+    onNodeWithText("Performance — coming soon", substring = true).assertIsDisplayed()
   }
 }


### PR DESCRIPTION
## Summary

Renders **real facet content** in the workspace's docked facet, starting with **Logs** (per-device
telemetry), plus a reusable **facet-content seam** so the remaining tools plug in incrementally.
`WorkspaceShell` gains a hoisted `facetContent: @Composable (DeviceColumn, Tool) -> Unit` slot
(default: the shared `WorkspaceFacetPlaceholder`); `DockedFacet` renders it instead of a hardcoded
"coming soon". The `desktop-app` host supplies a `facetContent` that wires `Tool.Logs` to
`TelemetryDashboard` scoped to `column.deviceId` (per-device `TelemetryPushSocketClient`, lifecycle
via `DisposableEffect`); other tools fall back to the placeholder.

Continues [#4667](https://github.com/kaeawc/auto-mobile/pull/4667) / [#4679](https://github.com/kaeawc/auto-mobile/pull/4679) / [#4695](https://github.com/kaeawc/auto-mobile/pull/4695) / [#4700](https://github.com/kaeawc/auto-mobile/pull/4700).

## Why Logs first

An exploration found Logs is the only tool already fully per-device with **no daemon/data-source
change**: it takes `activeDeviceId` and its `TelemetryPushClient` connects per device, with a built-in
per-device cache. Storage is close (needs a per-pane `packageName`); Navigation/Layout/Performance/
Test/Failures are hardwired to the daemon's single active device; Network has no dashboard yet.

## Linked Issue

Closes #4703

## Validation

- [x] Android `:desktop-core:detektMain` + `:desktop-app:detektMain`, `:desktop-core:test` (full),
      `:desktop-app:compileKotlin`, ktfmt — all green.
- [x] New desktop-core Compose tests: the facet invokes the injected slot for the active tool; the
      default slot renders the placeholder.
- Host telemetry-socket wiring is not unit-tested (no live daemon); it mirrors the existing
  `AutoMobileContent` telemetry wiring and is pinned at the desktop-core seam boundary.

## Acceptance criteria

1. ✅ `DockedFacet` renders the injected `facetContent(column, tool)` for the active tool.
2. ✅ Default `facetContent` is the placeholder (un-wired tools unchanged).
3. ✅ Host wires `Tool.Logs` → `TelemetryDashboard` per `column.deviceId`, else placeholder.

## Follow-ups (in order)

Storage (per-pane app resolution) → Navigation (per-device observation-stream client) →
Performance / Layout / Test (add `deviceId` to resources + `DataSourceFactory`) →
Failures (device-filtered resource) → Network (net-new dashboard).