### PR TITLE
Desktop workspace: Storage facet (per-device, auto-resolved app)

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -19,6 +19,7 @@ import dev.jasonpearson.automobile.desktop.core.settings.SettingsProvider
 import dev.jasonpearson.automobile.desktop.core.shell.MenuBarActions
 import dev.jasonpearson.automobile.desktop.core.workspace.DeviceColumn
 import dev.jasonpearson.automobile.desktop.core.workspace.LogsFacet
+import dev.jasonpearson.automobile.desktop.core.workspace.StorageFacet
 import dev.jasonpearson.automobile.desktop.core.workspace.Tool
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceAction
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceEffect
@@ -119,14 +120,15 @@ fun AutoMobileDesktopApp(
 }
 
 /**
- * Real docked-facet content for a pane. Only Logs is wired so far (per-device telemetry, via the
- * testable [LogsFacet] in desktop-core); every other tool falls back to the shared placeholder
- * until its dashboard gains per-device targeting.
+ * Real docked-facet content for a pane. Logs (per-device telemetry) and Storage (per-device,
+ * auto-resolved app) are wired via their testable facets in desktop-core; every other tool falls
+ * back to the shared placeholder until its dashboard gains per-device targeting.
  */
 @Composable
 private fun WorkspaceFacet(column: DeviceColumn, tool: Tool) {
   when (tool) {
     Tool.Logs -> LogsFacet(column)
+    Tool.Storage -> StorageFacet(column)
     else -> WorkspaceFacetPlaceholder(tool)
   }
 }

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -19,6 +19,7 @@ import dev.jasonpearson.automobile.desktop.core.settings.SettingsProvider
 import dev.jasonpearson.automobile.desktop.core.shell.MenuBarActions
 import dev.jasonpearson.automobile.desktop.core.workspace.DeviceColumn
 import dev.jasonpearson.automobile.desktop.core.workspace.LogsFacet
+import dev.jasonpearson.automobile.desktop.core.workspace.Platform
 import dev.jasonpearson.automobile.desktop.core.workspace.StorageFacet
 import dev.jasonpearson.automobile.desktop.core.workspace.Tool
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceAction
@@ -128,7 +129,11 @@ fun AutoMobileDesktopApp(
 private fun WorkspaceFacet(column: DeviceColumn, tool: Tool) {
   when (tool) {
     Tool.Logs -> LogsFacet(column)
-    Tool.Storage -> StorageFacet(column)
+    // Storage is Android-only for now: iOS key-value mutations misroute to Android-only daemon
+    // handlers (#4708). iOS panes fall back to the placeholder until that lands.
+    Tool.Storage ->
+      if (column.platform == Platform.Android) StorageFacet(column)
+      else WorkspaceFacetPlaceholder(tool)
     else -> WorkspaceFacetPlaceholder(tool)
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/StorageFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/StorageFacet.kt
@@ -1,7 +1,11 @@
 package dev.jasonpearson.automobile.desktop.core.workspace
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -12,6 +16,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
 import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
 import dev.jasonpearson.automobile.desktop.core.datasource.InstalledApp
 import dev.jasonpearson.automobile.desktop.core.datasource.Result
@@ -30,47 +37,62 @@ internal fun resolveStoragePackage(apps: List<InstalledApp>): String? =
 internal fun Platform.toStoragePlatform(): StoragePlatform =
   if (this == Platform.Ios) StoragePlatform.iOS else StoragePlatform.Android
 
+private sealed interface StorageFacetState {
+  data object Loading : StorageFacetState
+
+  data object NoApp : StorageFacetState
+
+  data class Error(val message: String) : StorageFacetState
+
+  data class Resolved(val packageName: String) : StorageFacetState
+}
+
 /**
  * Docked-facet body for [Tool.Storage]: the storage dashboard scoped to a pane's device and its
  * resolved app. The app is auto-resolved (foreground, else first installed) via
- * [loadInstalledApps], which is injected so the resolution and its loading/empty states are
+ * [loadInstalledApps], which is injected so resolution and its loading/error/empty states are
  * testable without real MCP; the default reads the device's installed-app list through the DI
- * graph.
+ * graph. An app-list failure surfaces a retryable error rather than being masked as "no app".
  */
 @Composable
 fun StorageFacet(
   column: DeviceColumn,
-  loadInstalledApps: (suspend (String) -> List<InstalledApp>)? = null,
+  loadInstalledApps: (suspend (String) -> Result<List<InstalledApp>>)? = null,
 ) {
   val graph = LocalAutoMobileGraph.current
-  val loader: suspend (String) -> List<InstalledApp> =
+  val loader: suspend (String) -> Result<List<InstalledApp>> =
     loadInstalledApps
       ?: { deviceId ->
-        val source =
-          graph.dataSourceFactory.createAppListDataSource(
-            DataSourceMode.Real,
-            { graph.autoMobileClient },
-            deviceId,
-          )
-        (source.getInstalledApps() as? Result.Success)?.data ?: emptyList()
+        graph.dataSourceFactory
+          .createAppListDataSource(DataSourceMode.Real, { graph.autoMobileClient }, deviceId)
+          .getInstalledApps()
       }
-  var resolvedPackage by remember(column.deviceId) { mutableStateOf<String?>(null) }
-  var resolving by remember(column.deviceId) { mutableStateOf(true) }
-  LaunchedEffect(column.deviceId) {
-    resolving = true
-    resolvedPackage = resolveStoragePackage(loader(column.deviceId))
-    resolving = false
+  var attempt by remember(column.deviceId) { mutableStateOf(0) }
+  var state by
+    remember(column.deviceId, attempt) {
+      mutableStateOf<StorageFacetState>(StorageFacetState.Loading)
+    }
+  LaunchedEffect(column.deviceId, attempt) {
+    state =
+      when (val result = loader(column.deviceId)) {
+        is Result.Success ->
+          resolveStoragePackage(result.data)?.let { StorageFacetState.Resolved(it) }
+            ?: StorageFacetState.NoApp
+        is Result.Error ->
+          StorageFacetState.Error(result.message ?: "Failed to load the device's apps")
+        Result.Loading -> StorageFacetState.Loading
+      }
   }
-  val packageName = resolvedPackage
-  when {
-    resolving -> FacetNote("Resolving app…")
-    packageName == null -> FacetNote("No app found on this device")
-    else ->
+  when (val current = state) {
+    StorageFacetState.Loading -> FacetNote("Resolving app…")
+    StorageFacetState.NoApp -> FacetNote("No app found on this device")
+    is StorageFacetState.Error -> FacetError(current.message) { attempt++ }
+    is StorageFacetState.Resolved ->
       StorageDashboard(
         dataSourceMode = DataSourceMode.Real,
         clientProvider = { graph.autoMobileClient },
         deviceId = column.deviceId,
-        packageName = packageName,
+        packageName = current.packageName,
         platform = column.platform.toStoragePlatform(),
       )
   }
@@ -81,5 +103,25 @@ fun StorageFacet(
 private fun FacetNote(text: String) {
   Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
     Text(text, color = MaterialTheme.colorScheme.outline)
+  }
+}
+
+/** Error state with a Retry affordance that re-runs the app-list load. */
+@Composable
+private fun FacetError(message: String, onRetry: () -> Unit) {
+  Column(
+    Modifier.fillMaxSize(),
+    verticalArrangement = Arrangement.Center,
+    horizontalAlignment = Alignment.CenterHorizontally,
+  ) {
+    Text(message, color = MaterialTheme.colorScheme.error)
+    Text(
+      "Retry",
+      color = MaterialTheme.colorScheme.primary,
+      modifier =
+        Modifier.padding(top = 8.dp).clickable(onClick = onRetry).semantics {
+          contentDescription = "Retry loading apps"
+        },
+    )
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/StorageFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/StorageFacet.kt
@@ -1,0 +1,85 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
+import dev.jasonpearson.automobile.desktop.core.datasource.InstalledApp
+import dev.jasonpearson.automobile.desktop.core.datasource.Result
+import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
+import dev.jasonpearson.automobile.desktop.core.storage.StorageDashboard
+import dev.jasonpearson.automobile.desktop.core.storage.StoragePlatform
+
+/**
+ * The package whose storage a pane inspects: the device's foreground app, else its first installed
+ * app, else none. Pure so the choice is unit-testable.
+ */
+internal fun resolveStoragePackage(apps: List<InstalledApp>): String? =
+  apps.firstOrNull { it.isForeground }?.packageName ?: apps.firstOrNull()?.packageName
+
+/** Map the workspace [Platform] to the storage layer's [StoragePlatform]. */
+internal fun Platform.toStoragePlatform(): StoragePlatform =
+  if (this == Platform.Ios) StoragePlatform.iOS else StoragePlatform.Android
+
+/**
+ * Docked-facet body for [Tool.Storage]: the storage dashboard scoped to a pane's device and its
+ * resolved app. The app is auto-resolved (foreground, else first installed) via
+ * [loadInstalledApps], which is injected so the resolution and its loading/empty states are
+ * testable without real MCP; the default reads the device's installed-app list through the DI
+ * graph.
+ */
+@Composable
+fun StorageFacet(
+  column: DeviceColumn,
+  loadInstalledApps: (suspend (String) -> List<InstalledApp>)? = null,
+) {
+  val graph = LocalAutoMobileGraph.current
+  val loader: suspend (String) -> List<InstalledApp> =
+    loadInstalledApps
+      ?: { deviceId ->
+        val source =
+          graph.dataSourceFactory.createAppListDataSource(
+            DataSourceMode.Real,
+            { graph.autoMobileClient },
+            deviceId,
+          )
+        (source.getInstalledApps() as? Result.Success)?.data ?: emptyList()
+      }
+  var resolvedPackage by remember(column.deviceId) { mutableStateOf<String?>(null) }
+  var resolving by remember(column.deviceId) { mutableStateOf(true) }
+  LaunchedEffect(column.deviceId) {
+    resolving = true
+    resolvedPackage = resolveStoragePackage(loader(column.deviceId))
+    resolving = false
+  }
+  val packageName = resolvedPackage
+  when {
+    resolving -> FacetNote("Resolving app…")
+    packageName == null -> FacetNote("No app found on this device")
+    else ->
+      StorageDashboard(
+        dataSourceMode = DataSourceMode.Real,
+        clientProvider = { graph.autoMobileClient },
+        deviceId = column.deviceId,
+        packageName = packageName,
+        platform = column.platform.toStoragePlatform(),
+      )
+  }
+}
+
+/** Centered single-line note for a facet's transient (resolving) or empty states. */
+@Composable
+private fun FacetNote(text: String) {
+  Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    Text(text, color = MaterialTheme.colorScheme.outline)
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/StorageFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/StorageFacetTest.kt
@@ -3,9 +3,11 @@ package dev.jasonpearson.automobile.desktop.core.workspace
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runComposeUiTest
 import dev.jasonpearson.automobile.desktop.core.datasource.InstalledApp
+import dev.jasonpearson.automobile.desktop.core.datasource.Result
 import dev.jasonpearson.automobile.desktop.core.storage.StoragePlatform
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -45,11 +47,26 @@ class StorageFacetTest {
       MaterialTheme {
         StorageFacet(
           column = DeviceColumn(deviceId = "d", name = "Pixel", platform = Platform.Android),
-          loadInstalledApps = { emptyList() },
+          loadInstalledApps = { Result.Success(emptyList()) },
         )
       }
     }
     waitForIdle()
     onNodeWithText("No app found", substring = true).assertIsDisplayed()
+  }
+
+  @Test
+  fun `surfaces a retryable error when the app list fails to load`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        StorageFacet(
+          column = DeviceColumn(deviceId = "d", name = "Pixel", platform = Platform.Android),
+          loadInstalledApps = { Result.Error(RuntimeException("daemon down")) },
+        )
+      }
+    }
+    waitForIdle()
+    onNodeWithText("daemon down", substring = true).assertIsDisplayed()
+    onNodeWithContentDescription("Retry loading apps").assertIsDisplayed()
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/StorageFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/StorageFacetTest.kt
@@ -1,0 +1,55 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.datasource.InstalledApp
+import dev.jasonpearson.automobile.desktop.core.storage.StoragePlatform
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class StorageFacetTest {
+
+  private fun app(pkg: String, foreground: Boolean = false) =
+    InstalledApp(packageName = pkg, displayName = pkg, isForeground = foreground)
+
+  @Test
+  fun `resolves the foreground app package`() {
+    val apps = listOf(app("com.a"), app("com.b", foreground = true), app("com.c"))
+    assertEquals("com.b", resolveStoragePackage(apps))
+  }
+
+  @Test
+  fun `falls back to the first app when none is foreground`() {
+    assertEquals("com.a", resolveStoragePackage(listOf(app("com.a"), app("com.b"))))
+  }
+
+  @Test
+  fun `resolves null when the device has no apps`() {
+    assertNull(resolveStoragePackage(emptyList()))
+  }
+
+  @Test
+  fun `maps workspace platform to storage platform`() {
+    assertEquals(StoragePlatform.iOS, Platform.Ios.toStoragePlatform())
+    assertEquals(StoragePlatform.Android, Platform.Android.toStoragePlatform())
+  }
+
+  @Test
+  fun `shows the no-app state when the device has no apps`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        StorageFacet(
+          column = DeviceColumn(deviceId = "d", name = "Pixel", platform = Platform.Android),
+          loadInstalledApps = { emptyList() },
+        )
+      }
+    }
+    waitForIdle()
+    onNodeWithText("No app found", substring = true).assertIsDisplayed()
+  }
+}


### PR DESCRIPTION
## Summary

Wires the workspace **Storage facet** to real per-device content (next facet after Logs, [#4703](https://github.com/kaeawc/auto-mobile/pull/4704)). `StorageDashboard` is already `deviceId`-parameterized but real mode requires a `packageName`, which `DeviceColumn` doesn't carry — so `StorageFacet` **auto-resolves** the pane device's app (foreground, else first installed) via the existing `createAppListDataSource` and a pure `resolveStoragePackage`, maps `Platform`→`StoragePlatform`, and renders `StorageDashboard` scoped to the device + package. Mirrors `LogsFacet`'s injected-seam pattern.

## Linked Issue

Closes #4706

## Validation

- [x] `:desktop-core:detektMain` + `:desktop-app:detektMain`, `:desktop-core:test` (full), `:desktop-app:compileKotlin`, ktfmt — all green.
- [x] Pure unit tests: `resolveStoragePackage` (foreground / first / empty) and `Platform.toStoragePlatform`. Compose test: the "no app found" state when the device has no apps. `loadInstalledApps` is injected so resolution is tested without real MCP.
- Host `StorageDashboard` render (real MCP) is the untested seam, consistent with `LogsFacet`.

## Acceptance criteria

1. ✅ `resolveStoragePackage` → foreground, else first, else null.
2. ✅ `Platform.toStoragePlatform()` maps Ios→iOS, Android→Android.
3. ✅ Resolving/no-app states; otherwise renders `StorageDashboard` for the device + resolved package.
4. ✅ Host wires `Tool.Storage` → `StorageFacet`.

## Follow-ups

Manual app override (per-pane app picker, reusing the currently-unused `AppSelectorDropdown`).
Remaining facets: Navigation → Performance → Layout → Test → Failures → Network.