### PR TITLE
test(action): deflake InputKey caller-timeout test with a FakeTimer

### DIFF
--- a/test/features/action/InputKey.test.ts
+++ b/test/features/action/InputKey.test.ts
@@ -26,7 +26,9 @@ function createAdbFactory(fakeAdb: FakeAdbExecutor): AdbClientFactory {
 describe("InputKey", () => {
   test("sends supported Android keys through ADB keyevent with the caller timeout", async () => {
     const fakeAdb = new FakeAdbExecutor();
-    const inputKey = new InputKey(androidDevice, createAdbFactory(fakeAdb));
+    // Inject a FakeTimer so `now()` is constant: with the real timer, a 1ms tick between the two
+    // `timer.now()` calls in press() intermittently made the forwarded timeout 1233 not 1234 (#4696).
+    const inputKey = new InputKey(androidDevice, createAdbFactory(fakeAdb), undefined, new FakeTimer());
 
     const result = await inputKey.press("enter", 1234);
 


### PR DESCRIPTION
## Summary

Deflakes `InputKey > sends supported Android keys through ADB keyevent with the caller timeout`
(`test/features/action/InputKey.test.ts`), which has intermittently reddened the post-merge
**TypeScript Code Coverage** suite on unrelated (Kotlin) changes.

**Root cause:** `press()` computes `adbTimeoutMs = remainingMs(deadline) = (timer.now() + timeoutMs) - timer.now()`. With the default **real** timer, a 1ms tick between the two `now()` calls occasionally makes the forwarded timeout `1233` instead of the asserted `1234` — a timing-dependent `toEqual` mismatch. The sibling tests already inject a `FakeTimer`; this one didn't.

**Fix:** inject a `FakeTimer` (constant `now()`) so the forwarded timeout is deterministically `1234`.

## Linked Issue

Closes #4696

## Validation

- [x] `bun test test/features/action/InputKey.test.ts` — 8/8 pass, 3 consecutive runs (was intermittent).
- [x] `bun run typecheck` — no new type errors.

Test-only change; no production behavior affected.