### PR TITLE
fix(desktop): Storage-facet app resolution off UI thread + non-hanging Loading

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/StorageFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/StorageFacet.kt
@@ -25,6 +25,8 @@ import dev.jasonpearson.automobile.desktop.core.datasource.Result
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
 import dev.jasonpearson.automobile.desktop.core.storage.StorageDashboard
 import dev.jasonpearson.automobile.desktop.core.storage.StoragePlatform
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /**
  * The package whose storage a pane inspects: the device's foreground app, else its first installed
@@ -63,9 +65,13 @@ fun StorageFacet(
   val loader: suspend (String) -> Result<List<InstalledApp>> =
     loadInstalledApps
       ?: { deviceId ->
-        graph.dataSourceFactory
-          .createAppListDataSource(DataSourceMode.Real, { graph.autoMobileClient }, deviceId)
-          .getInstalledApps()
+        // Resolve off the UI thread: the app-list read hits the daemon and would otherwise block
+        // recomposition. Injected test loaders run inline (deterministic).
+        withContext(Dispatchers.IO) {
+          graph.dataSourceFactory
+            .createAppListDataSource(DataSourceMode.Real, { graph.autoMobileClient }, deviceId)
+            .getInstalledApps()
+        }
       }
   var attempt by remember(column.deviceId) { mutableStateOf(0) }
   var state by
@@ -80,7 +86,9 @@ fun StorageFacet(
             ?: StorageFacetState.NoApp
         is Result.Error ->
           StorageFacetState.Error(result.message ?: "Failed to load the device's apps")
-        Result.Loading -> StorageFacetState.Loading
+        // A one-shot app-list load resolves to Success/Error; treat a stray Loading as retryable
+        // rather than leaving the facet stuck on "Resolving app…".
+        Result.Loading -> StorageFacetState.Error("App list is still loading")
       }
   }
   when (val current = state) {


### PR DESCRIPTION
## Summary

Addresses two findings from the Storage-facet PR's review ([#4707](https://github.com/kaeawc/auto-mobile/pull/4707)) that landed **after** it auto-merged (the merge raced the late review comments):

1. **codex P1 — resolve off the UI thread.** `StorageFacet`'s default app-list load ran on the Compose UI thread (the daemon resource read can block recomposition). Wrapped the default loader's daemon call in `withContext(Dispatchers.IO)`. Injected test loaders run inline, so tests stay deterministic and no signature changes.
2. **CodeRabbit — don't leave `Result.Loading` permanently unresolved.** A stray `Result.Loading` mapped to the `Loading` state, which a one-shot loader never leaves. It now surfaces as a retryable error instead of hanging on "Resolving app…".

## Validation

- [x] `:desktop-core:detektMain` + `:desktop-core:test` (incl. `StorageFacetTest`) + ktfmt — green.

Follows up the merged review of #4707; iOS storage ([#4708](https://github.com/kaeawc/auto-mobile/issues/4708)) and live update ([#4709](https://github.com/kaeawc/auto-mobile/issues/4709)) remain separately tracked.