### PR TITLE
Desktop workspace: ⧉ Diff — open the same tool across observed devices

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -59,6 +59,7 @@ fun WorkspaceShell(
       is WorkspaceUiState.Empty -> EmptyState(onOpenPicker, Modifier.weight(1f).fillMaxWidth())
       is WorkspaceUiState.Content ->
         Row(Modifier.weight(1f).fillMaxWidth()) {
+          val canDiff = state.columns.size > 1
           state.columns.forEach { column ->
             // Key by deviceId so a surviving pane keeps its own remembered state + facet
             // connection when another pane closes (unkeyed = positional identity churns survivors).
@@ -68,6 +69,7 @@ fun WorkspaceShell(
                 focused = column.deviceId == state.focusedDeviceId,
                 onAction = onAction,
                 facetContent = facetContent,
+                canDiff = canDiff,
                 modifier = Modifier.weight(1f).fillMaxHeight(),
               )
             }
@@ -146,6 +148,7 @@ private fun DeviceColumnView(
   focused: Boolean,
   onAction: (WorkspaceAction) -> Unit,
   facetContent: @Composable (DeviceColumn, Tool) -> Unit,
+  canDiff: Boolean,
   modifier: Modifier,
 ) {
   Column(
@@ -164,7 +167,7 @@ private fun DeviceColumnView(
       // stream collapses to grow the facet.
       val facetFraction = facetHeightFraction(column.shrunk)
       StreamArea(column, onAction, Modifier.weight(1f - facetFraction))
-      DockedFacet(column, tool, onAction, facetContent, Modifier.weight(facetFraction))
+      DockedFacet(column, tool, onAction, facetContent, canDiff, Modifier.weight(facetFraction))
     }
   }
 }
@@ -203,6 +206,7 @@ private fun DockedFacet(
   tool: Tool,
   onAction: (WorkspaceAction) -> Unit,
   facetContent: @Composable (DeviceColumn, Tool) -> Unit,
+  canDiff: Boolean,
   modifier: Modifier,
 ) {
   Column(modifier.fillMaxWidth().background(MaterialTheme.colorScheme.surface)) {
@@ -212,8 +216,9 @@ private fun DockedFacet(
     ) {
       Text(tool.icon)
       Spacer(Modifier.width(6.dp))
-      // Weighted + ellipsized so a long label on a narrow pane yields space to the close control
-      // instead of pushing it off-screen.
+      // Weighted + ellipsized so a long label on a narrow pane yields space to the trailing
+      // controls
+      // instead of pushing them off-screen.
       Text(
         tool.label,
         style = MaterialTheme.typography.labelLarge,
@@ -222,6 +227,16 @@ private fun DockedFacet(
         modifier = Modifier.weight(1f),
       )
       Spacer(Modifier.width(6.dp))
+      // ⧉ Diff opens the same tool on the other observed devices; only meaningful with >1 device.
+      if (canDiff) {
+        Glyph(
+          text = "⧉",
+          description = "Open ${tool.label} on all devices",
+          active = false,
+          onClick = { onAction(WorkspaceAction.DiffTool(tool)) },
+        )
+        Spacer(Modifier.width(6.dp))
+      }
       Glyph(
         text = "✕",
         description = "Close ${tool.label} facet on ${column.name}",

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModel.kt
@@ -39,6 +39,9 @@ sealed interface WorkspaceAction {
 
   /** Run an emulator control against a device pane (rotate, screenshot, snapshot, unlock). */
   data class RunControl(val deviceId: String, val control: EmulatorControl) : WorkspaceAction
+
+  /** Open [tool] on every observed pane for like-for-like comparison (the facet ⧉ Diff control). */
+  data class DiffTool(val tool: Tool) : WorkspaceAction
 }
 
 /** One-shot effects emitted by the workspace. */
@@ -78,6 +81,15 @@ class WorkspaceViewModel(private val scope: CoroutineScope) {
       is WorkspaceAction.ToggleShrink -> mutate(action.deviceId) { it.copy(shrunk = !it.shrunk) }
       is WorkspaceAction.SelectTool -> mutate(action.deviceId) { it.copy(activeTool = action.tool) }
       is WorkspaceAction.RunControl -> runControl(action.deviceId, action.control)
+      is WorkspaceAction.DiffTool -> diffTool(action.tool)
+    }
+  }
+
+  /** Open [tool] on every observed column so all panes show the same facet side by side. */
+  private fun diffTool(tool: Tool) {
+    _state.update { current ->
+      val content = current as? WorkspaceUiState.Content ?: return@update current
+      content.copy(columns = content.columns.map { it.copy(activeTool = tool) })
     }
   }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
@@ -210,6 +210,51 @@ class WorkspaceShellUiTest {
   }
 
   @Test
+  fun `diff control appears in a facet only with multiple devices`() = runComposeUiTest {
+    val state =
+      WorkspaceUiState.Content(
+        columns =
+          listOf(
+            col("a", "Pixel 8").copy(activeTool = Tool.Logs),
+            col("b", "iPhone 15", Platform.Ios),
+          ),
+        focusedDeviceId = "a",
+      )
+    setContent { MaterialTheme { WorkspaceShell(state = state, onAction = {}, onOpenPicker = {}) } }
+    onNodeWithContentDescription("Open Logs on all devices").assertIsDisplayed()
+  }
+
+  @Test
+  fun `diff control is absent with a single device`() = runComposeUiTest {
+    val state =
+      WorkspaceUiState.Content(
+        columns = listOf(col("a", "Pixel 8").copy(activeTool = Tool.Logs)),
+        focusedDeviceId = "a",
+      )
+    setContent { MaterialTheme { WorkspaceShell(state = state, onAction = {}, onOpenPicker = {}) } }
+    onNodeWithContentDescription("Open Logs on all devices").assertDoesNotExist()
+  }
+
+  @Test
+  fun `clicking diff dispatches DiffTool for the facet's tool`() = runComposeUiTest {
+    var action: WorkspaceAction? = null
+    val state =
+      WorkspaceUiState.Content(
+        columns =
+          listOf(
+            col("a", "Pixel 8").copy(activeTool = Tool.Logs),
+            col("b", "iPhone 15", Platform.Ios),
+          ),
+        focusedDeviceId = "a",
+      )
+    setContent {
+      MaterialTheme { WorkspaceShell(state = state, onAction = { action = it }, onOpenPicker = {}) }
+    }
+    onNodeWithContentDescription("Open Logs on all devices").performClick()
+    assertEquals(WorkspaceAction.DiffTool(Tool.Logs), action)
+  }
+
+  @Test
   fun `default facetContent shows the coming-soon placeholder`() = runComposeUiTest {
     val state =
       WorkspaceUiState.Content(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceViewModelTest.kt
@@ -125,6 +125,20 @@ class WorkspaceViewModelTest {
   }
 
   @Test
+  fun `DiffTool opens the tool on every observed column`() = testScope.runTest {
+    val vm = WorkspaceViewModel(this)
+    vm.onAction(WorkspaceAction.ObserveDevice(column("a")))
+    vm.onAction(WorkspaceAction.ObserveDevice(column("b")))
+    vm.onAction(WorkspaceAction.SelectTool("a", Tool.Storage))
+    vm.onAction(WorkspaceAction.DiffTool(Tool.Logs))
+    val state = vm.state.value as WorkspaceUiState.Content
+    assertTrue(
+      "every column should show the diffed tool",
+      state.columns.all { it.activeTool == Tool.Logs },
+    )
+  }
+
+  @Test
   fun `RunControl for an unknown device emits nothing`() = testScope.runTest {
     val vm = WorkspaceViewModel(this)
     vm.onAction(WorkspaceAction.ObserveDevice(column("a")))


### PR DESCRIPTION
## Summary

Adds the wireframe's **⧉ Diff** control to each docked-facet header — it opens the **same tool on the other observed devices** for like-for-like comparison (the wireframe's "high investment in comparing/diffing two devices"). Deferred from the docked-facet PR ([#4700](https://github.com/kaeawc/auto-mobile/pull/4700)).

`WorkspaceAction.DiffTool(tool)` sets `activeTool = tool` on every observed column so all panes show the same facet side by side. Self-contained workspace logic — no daemon change. The control shows only when >1 device is observed (`canDiff` threaded from `WorkspaceShell`).

## Linked Issue

Closes #4713

## Validation

- [x] `:desktop-core:detektMain` + `:desktop-core:test` + ktfmt — green.
- [x] ViewModel test: `DiffTool` sets the tool on all columns. Compose tests: ⧉ present only with >1 device, absent with one, and click dispatches `DiffTool(activeTool)`.

## Acceptance criteria

1. ✅ `DiffTool(tool)` opens the tool on all observed columns.
2. ✅ ⧉ appears only with multiple devices.
3. ✅ Clicking ⧉ dispatches `DiffTool` for the facet's tool.

## Out of scope

A deeper "diff strip"/difference-highlighting compare view — this broadcasts the tool selection so panes render side by side.