### PR TITLE
Desktop workspace: zero-LLM first-run onboarding

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -19,6 +19,7 @@ import dev.jasonpearson.automobile.desktop.core.settings.SettingsProvider
 import dev.jasonpearson.automobile.desktop.core.shell.MenuBarActions
 import dev.jasonpearson.automobile.desktop.core.workspace.DeviceColumn
 import dev.jasonpearson.automobile.desktop.core.workspace.LogsFacet
+import dev.jasonpearson.automobile.desktop.core.workspace.OnboardingScreen
 import dev.jasonpearson.automobile.desktop.core.workspace.Platform
 import dev.jasonpearson.automobile.desktop.core.workspace.StorageFacet
 import dev.jasonpearson.automobile.desktop.core.workspace.Tool
@@ -65,6 +66,7 @@ fun AutoMobileDesktopApp(
     remember(scope, resourceClient) { DevicePickerViewModel(resourceClient, scope) }
   val pickerState by pickerViewModel.state.collectAsState()
   var pickerOpen by remember { mutableStateOf(false) }
+  var showOnboarding by remember { mutableStateOf(!settings.hasSeenOnboarding) }
 
   // OpenPicker (from the empty state or the Devices launcher) shows the picker; observing selected
   // devices turns them into workspace columns.
@@ -102,19 +104,27 @@ fun AutoMobileDesktopApp(
       // Device-tab workspace is the desktop app root (replaces ThreePaneShell). AutoMobileContent
       // is retained and still used by the IDE plugin; dashboards return as workspace facets in
       // follow-up PRs. menuBarActions is plumbed for later re-wiring once facets/panes exist.
-      if (pickerOpen) {
-        DevicePicker(
-          state = pickerState,
-          onAction = pickerViewModel::onAction,
-          onClose = { pickerOpen = false },
-        )
-      } else {
-        WorkspaceShell(
-          state = workspaceState,
-          onAction = workspaceViewModel::onAction,
-          onOpenPicker = workspaceViewModel::openPicker,
-          facetContent = { column, tool -> WorkspaceFacet(column, tool) },
-        )
+      when {
+        showOnboarding ->
+          OnboardingScreen(
+            onGetStarted = {
+              settings.hasSeenOnboarding = true
+              showOnboarding = false
+            }
+          )
+        pickerOpen ->
+          DevicePicker(
+            state = pickerState,
+            onAction = pickerViewModel::onAction,
+            onClose = { pickerOpen = false },
+          )
+        else ->
+          WorkspaceShell(
+            state = workspaceState,
+            onAction = workspaceViewModel::onAction,
+            onOpenPicker = workspaceViewModel::openPicker,
+            facetContent = { column, tool -> WorkspaceFacet(column, tool) },
+          )
       }
     }
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/settings/FakeSettingsProvider.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/settings/FakeSettingsProvider.kt
@@ -10,4 +10,5 @@ class FakeSettingsProvider(
   override var androidIde: String = "auto",
   override var iosIde: String = "auto",
   override var themeMode: String = "dark",
+  override var hasSeenOnboarding: Boolean = false,
 ) : SettingsProvider

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/settings/SettingsProvider.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/settings/SettingsProvider.kt
@@ -13,4 +13,6 @@ interface SettingsProvider {
   var iosIde: String
   /** Theme mode: "dark", "light", or "system" */
   var themeMode: String
+  /** Whether the first-run onboarding has been dismissed. */
+  var hasSeenOnboarding: Boolean
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OnboardingScreen.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OnboardingScreen.kt
@@ -1,0 +1,90 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+private val Accent = Color(0xFF4DABF7)
+
+/** One capability shown on the onboarding coach panel: an emoji + a plain-language line. */
+private data class Capability(val icon: String, val text: String)
+
+private val CAPABILITIES =
+  listOf(
+    Capability("🖥", "Observe devices live — pick booted devices and watch them side by side"),
+    Capability("🧭", "Inspect each device — logs, storage, navigation and more in a docked panel"),
+    Capability("⧉", "Compare devices — open the same tool across devices for a like-for-like view"),
+    Capability("🎮", "Control emulators — rotate, screenshot, snapshot and unlock from the stream"),
+  )
+
+/**
+ * First-run onboarding: a plain "what you can do here" coach panel. Deliberately free of any
+ * AI/assistant framing — it describes the concrete device-workspace capabilities and nothing more.
+ */
+@Composable
+fun OnboardingScreen(onGetStarted: () -> Unit, modifier: Modifier = Modifier) {
+  Column(
+    modifier =
+      modifier.fillMaxSize().background(MaterialTheme.colorScheme.background).padding(32.dp),
+    verticalArrangement = Arrangement.Center,
+    horizontalAlignment = Alignment.CenterHorizontally,
+  ) {
+    Column(Modifier.widthIn(max = 560.dp)) {
+      Text(
+        "Welcome to AutoMobile",
+        style = MaterialTheme.typography.headlineMedium,
+        fontWeight = FontWeight.SemiBold,
+      )
+      Spacer(Modifier.height(6.dp))
+      Text(
+        "Drive and inspect real devices from your desktop.",
+        style = MaterialTheme.typography.bodyLarge,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+      Spacer(Modifier.height(24.dp))
+      Text(
+        "WHAT YOU CAN DO HERE",
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+      Spacer(Modifier.height(10.dp))
+      CAPABILITIES.forEach { capability ->
+        Row(Modifier.padding(vertical = 6.dp), verticalAlignment = Alignment.Top) {
+          Text(capability.icon)
+          Spacer(Modifier.width(12.dp))
+          Text(capability.text, style = MaterialTheme.typography.bodyMedium)
+        }
+      }
+      Spacer(Modifier.height(28.dp))
+      Text(
+        "Get started",
+        color = Color.White,
+        fontWeight = FontWeight.SemiBold,
+        modifier =
+          Modifier.clickable(onClick = onGetStarted)
+            .semantics { contentDescription = "Get started" }
+            .background(Accent, RoundedCornerShape(6.dp))
+            .padding(horizontal = 24.dp, vertical = 12.dp),
+      )
+    }
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OnboardingScreen.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OnboardingScreen.kt
@@ -1,7 +1,6 @@
 package dev.jasonpearson.automobile.desktop.core.workspace
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -11,29 +10,28 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 
-private val Accent = Color(0xFF4DABF7)
-
 /** One capability shown on the onboarding coach panel: an emoji + a plain-language line. */
 private data class Capability(val icon: String, val text: String)
 
+// Only capabilities that are actually wired today — no live streams, navigation, or
+// emulator-control
+// execution yet, so the panel doesn't promise inert functionality.
 private val CAPABILITIES =
   listOf(
-    Capability("🖥", "Observe devices live — pick booted devices and watch them side by side"),
-    Capability("🧭", "Inspect each device — logs, storage, navigation and more in a docked panel"),
+    Capability("🖥", "Observe devices — pick booted devices and open them as side-by-side panes"),
+    Capability("🧭", "Inspect per device — dock the logs and storage tools into each pane"),
     Capability("⧉", "Compare devices — open the same tool across devices for a like-for-like view"),
-    Capability("🎮", "Control emulators — rotate, screenshot, snapshot and unlock from the stream"),
   )
 
 /**
@@ -75,16 +73,15 @@ fun OnboardingScreen(onGetStarted: () -> Unit, modifier: Modifier = Modifier) {
         }
       }
       Spacer(Modifier.height(28.dp))
-      Text(
-        "Get started",
-        color = Color.White,
-        fontWeight = FontWeight.SemiBold,
-        modifier =
-          Modifier.clickable(onClick = onGetStarted)
-            .semantics { contentDescription = "Get started" }
-            .background(Accent, RoundedCornerShape(6.dp))
-            .padding(horizontal = 24.dp, vertical = 12.dp),
-      )
+      // Material3 Button: themed container/content colors carry sufficient contrast (vs a
+      // hand-rolled
+      // white-on-accent treatment) and bring button semantics for free.
+      Button(
+        onClick = onGetStarted,
+        modifier = Modifier.semantics { contentDescription = "Get started" },
+      ) {
+        Text("Get started")
+      }
     }
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OnboardingScreenUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OnboardingScreenUiTest.kt
@@ -18,7 +18,7 @@ class OnboardingScreenUiTest {
     setContent { MaterialTheme { OnboardingScreen(onGetStarted = {}) } }
     onNodeWithText("Welcome to AutoMobile").assertIsDisplayed()
     onNodeWithText("WHAT YOU CAN DO HERE", substring = true).assertIsDisplayed()
-    onNodeWithText("Observe devices live", substring = true).assertIsDisplayed()
+    onNodeWithText("Observe devices", substring = true).assertIsDisplayed()
     onNodeWithText("Compare devices", substring = true).assertIsDisplayed()
     onNodeWithContentDescription("Get started").assertIsDisplayed()
   }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OnboardingScreenUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OnboardingScreenUiTest.kt
@@ -1,0 +1,43 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class OnboardingScreenUiTest {
+
+  @Test
+  fun `renders a welcome and the capability coach panel`() = runComposeUiTest {
+    setContent { MaterialTheme { OnboardingScreen(onGetStarted = {}) } }
+    onNodeWithText("Welcome to AutoMobile").assertIsDisplayed()
+    onNodeWithText("WHAT YOU CAN DO HERE", substring = true).assertIsDisplayed()
+    onNodeWithText("Observe devices live", substring = true).assertIsDisplayed()
+    onNodeWithText("Compare devices", substring = true).assertIsDisplayed()
+    onNodeWithContentDescription("Get started").assertIsDisplayed()
+  }
+
+  @Test
+  fun `Get started invokes the callback`() = runComposeUiTest {
+    var started = false
+    setContent { MaterialTheme { OnboardingScreen(onGetStarted = { started = true }) } }
+    onNodeWithContentDescription("Get started").performClick()
+    assertTrue(started)
+  }
+
+  @Test
+  fun `carries no AI or assistant framing`() = runComposeUiTest {
+    setContent { MaterialTheme { OnboardingScreen(onGetStarted = {}) } }
+    // The onboarding must stay free of AI/LLM/assistant connotations (explicit product
+    // requirement).
+    for (banned in listOf("AI", "LLM", "assistant", "chat", "prompt", "magic")) {
+      onNodeWithText(banned, substring = true, ignoreCase = true).assertDoesNotExist()
+    }
+  }
+}

--- a/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/settings/AutoMobileSettings.kt
+++ b/android/ide-plugin/src/main/kotlin/dev/jasonpearson/automobile/ide/settings/AutoMobileSettings.kt
@@ -20,6 +20,7 @@ class AutoMobileSettings : PersistentStateComponent<AutoMobileSettings>, Setting
   override var androidIde: String = "auto"
   override var iosIde: String = "auto"
   override var themeMode: String = "dark"
+  override var hasSeenOnboarding: Boolean = false
 
   override fun getState(): AutoMobileSettings = this
 


### PR DESCRIPTION
## Summary

Adds the wireframe's **first-run onboarding** (frame 12 / concept 15): a plain "what you can do here" coach panel shown before the workspace on first launch, **deliberately free of any AI/LLM/assistant framing** (explicit product requirement). A `Get started` action dismisses it and reveals the workspace.

`OnboardingScreen` lists the concrete capabilities — observe devices live, inspect per-device facets, ⧉ compare across devices, control emulators. Dismissal persists via a new `SettingsProvider.hasSeenOnboarding` flag (added to the interface, `FakeSettingsProvider`, and the IDE plugin's `AutoMobileSettings`).

## Linked Issue

Closes #4716

## Validation

- [x] `:desktop-core:detektMain` + `:desktop-app:detektMain`, `:desktop-core:test`, `:desktop-app:compileKotlin`, `:ide-plugin:compileKotlin` (interface change), ktfmt — all green.
- [x] Compose tests: renders welcome + capability panel + `Get started`; `Get started` fires the callback; and a test asserts **no** AI/LLM/assistant/chat/prompt/magic wording appears.

## Notes

- Settings are currently in-memory (`FakeSettingsProvider` via DI), so the flag resets per launch until real settings persistence lands; the flag + wiring are correct for when it does.
- The interactive "basics checklist" (concept 15) is deferred to a follow-up.