### PR TITLE
fix(android): device-clock domain for eventOnly fresh-focus fallback (#4617)

### DIFF
--- a/src/features/action/InputText.ts
+++ b/src/features/action/InputText.ts
@@ -658,9 +658,17 @@ export class InputText extends BaseVisualChange {
       return viewHierarchy;
     }
 
+    // Android interprets `minTimestamp` in the device-authored hierarchy clock
+    // domain. When the failed hierarchy carries an `updatedAt` we derive the
+    // lower bound from it (device clock, +1 for strictly-newer). When it does
+    // NOT, we must still stay in the device domain: falling back to the host
+    // clock (`this.timer.now()`) lets a device clock running ahead of the host
+    // accept an older cached focused hierarchy as fresh, defeating the freshness
+    // guarantee (issue #4617). Derive the fallback from the device clock via
+    // `getDeviceTimestampMs`, the same source the rest of the freshness logic uses.
     const minTimestamp = typeof viewHierarchy.updatedAt === "number"
       ? viewHierarchy.updatedAt + 1
-      : this.timer.now();
+      : await this.adb.getDeviceTimestampMs();
     const refreshedObserveResult = await this.observeScreen.execute({
       skipWaitForFresh: false,
       minTimestamp

--- a/test/fakes/FakeAdbClient.ts
+++ b/test/fakes/FakeAdbClient.ts
@@ -9,7 +9,7 @@ import { FakeAdbProcess } from "./FakeAdbProcess";
 
 type FakeAdbClientContract = Pick<
   AdbExecutor,
-  "execute" | "executeCommand" | "getForegroundApp" | "listUsers" | "spawn"
+  "execute" | "executeCommand" | "getForegroundApp" | "getDeviceTimestampMs" | "listUsers" | "spawn"
 >;
 
 /** How a spawned command should terminate, keyed by a substring of its argv. */
@@ -41,6 +41,7 @@ export class FakeAdbClient implements FakeAdbClientContract {
   private foregroundAppError: Error | null = null;
   private hangingCommandPatterns: string[] = [];
   private users: Array<{ userId: number; name: string; flags?: number; running?: boolean }> = [];
+  private deviceTimestampMs: number | null = null;
   private spawnCalls: string[][] = [];
   private spawnBehaviors: SpawnBehavior[] = [];
 
@@ -232,6 +233,22 @@ export class FakeAdbClient implements FakeAdbClientContract {
   }
 
   /**
+   * Configure the device clock returned by {@link getDeviceTimestampMs}. Pass a
+   * value ahead of the host FakeTimer to exercise device-vs-host clock skew.
+   */
+  setDeviceTimestampMs(timestampMs: number | null): void {
+    this.deviceTimestampMs = timestampMs;
+  }
+
+  /**
+   * Return the configured device time (device-authored clock domain), or the
+   * host wall clock when unset — mirrors {@link FakeAdbExecutor.getDeviceTimestampMs}.
+   */
+  async getDeviceTimestampMs(): Promise<number> {
+    return this.deviceTimestampMs ?? Date.now();
+  }
+
+  /**
    * Get all recorded command calls
    */
   getCommandCalls(): Array<{
@@ -294,6 +311,7 @@ export class FakeAdbClient implements FakeAdbClientContract {
     this.hangingCommandPatterns = [];
     this.spawnCalls = [];
     this.spawnBehaviors = [];
+    this.deviceTimestampMs = null;
   }
 
   /**

--- a/test/fakes/FakeAdbClient.ts
+++ b/test/fakes/FakeAdbClient.ts
@@ -241,11 +241,14 @@ export class FakeAdbClient implements FakeAdbClientContract {
   }
 
   /**
-   * Return the configured device time (device-authored clock domain), or the
-   * host wall clock when unset — mirrors {@link FakeAdbExecutor.getDeviceTimestampMs}.
+   * Return the configured device time (device-authored clock domain), or a
+   * deterministic `0` when unset. `0` is the faithful fake equivalent of the
+   * host FakeTimer's default epoch; use {@link setDeviceTimestampMs} to model
+   * device-vs-host clock skew. (No real-clock fallback here — fakes must stay
+   * deterministic; #4186 hygiene scan.)
    */
   async getDeviceTimestampMs(): Promise<number> {
-    return this.deviceTimestampMs ?? Date.now();
+    return this.deviceTimestampMs ?? 0;
   }
 
   /**

--- a/test/features/action/InputText.test.ts
+++ b/test/features/action/InputText.test.ts
@@ -6,6 +6,7 @@ import { FakeAdbExecutor } from "../../fakes/FakeAdbExecutor";
 import { FakeObserveScreen } from "../../fakes/FakeObserveScreen";
 import { FakeTimer } from "../../fakes/FakeTimer";
 import type { InputTextMode } from "../../../src/features/action/InputText";
+import type { ObserveScreen, ObserveScreenExecuteOptions } from "../../../src/features/observe/interfaces/ObserveScreen";
 import type { BootedDevice, ExecResult, ObserveResult } from "../../../src/models";
 import type { AdbClientFactory } from "../../../src/utils/android-cmdline-tools/AdbClientFactory";
 import { AdbClient, AdbCommandTimeoutError } from "../../../src/utils/android-cmdline-tools/AdbClient";
@@ -605,6 +606,70 @@ describe("InputText", () => {
       "shell input keyevent KEYCODE_X",
       "shell input keyevent KEYCODE_T"
     ]);
+  });
+
+  // Regression for https://github.com/kaeawc/auto-mobile/issues/4617.
+  // When the failed cached hierarchy carries no `updatedAt`, the refresh lower
+  // bound must be derived from the DEVICE clock (getDeviceTimestampMs), not the
+  // host FakeTimer/wall clock. Android interprets `minTimestamp` in the
+  // device-authored hierarchy clock domain, so a device clock running AHEAD of
+  // the host would let an older cached focused hierarchy satisfy a host-clock
+  // lower bound and be wrongly accepted as fresh — dispatching key events.
+  test("eventOnly derives the no-updatedAt refresh lower bound from the device clock, not the host", async () => {
+    const factory = new FakeAdbClientFactory();
+    factory.getFakeClient().setCommandResult("shell getprop ro.build.version.sdk", "31\n");
+    // Device clock is far ahead of the host FakeTimer (which starts at 0).
+    const deviceNowMs = 1_700_000_000_000;
+    factory.getFakeClient().setDeviceTimestampMs(deviceNowMs);
+    const hostTimer = new FakeTimer(); // now() === 0, strictly behind the device clock
+    const inputText = new InputText(androidDevice, factory as AdbClientFactory, undefined, hostTimer);
+
+    // A cached focused hierarchy captured EARLIER in device time than "now" —
+    // stale — but still newer than the host clock (0). Under the old host-clock
+    // fallback its timestamp satisfies minTimestamp and it is wrongly accepted.
+    const cachedFocusedDeviceTs = 1_699_999_999_000;
+    const observeExecuteOptions: ObserveScreenExecuteOptions[] = [];
+    const focused = observeResultWithFocusedText("old");
+    const observe = {
+      execute: async (options?: ObserveScreenExecuteOptions): Promise<ObserveResult> => {
+        observeExecuteOptions.push({ ...(options ?? {}) });
+        const lowerBound = options?.minTimestamp ?? 0;
+        return {
+          ...focused,
+          viewHierarchy: { ...focused.viewHierarchy, updatedAt: cachedFocusedDeviceTs },
+          freshness: {
+            requestedAfter: lowerBound,
+            actualTimestamp: cachedFocusedDeviceTs,
+            isFresh: cachedFocusedDeviceTs >= lowerBound,
+            staleDurationMs: Math.max(0, lowerBound - cachedFocusedDeviceTs),
+          },
+        } as ObserveResult;
+      },
+    };
+    inputText.observeScreen = observe as unknown as ObserveScreen;
+
+    // The cached hierarchy that FAILED the focused-editable check: no focus, no updatedAt.
+    const cachedUnfocused = {
+      viewHierarchy: {
+        hierarchy: { node: { class: "android.view.inputmethod.SoftInputWindow" } },
+      },
+    } as ObserveResult;
+
+    const result = await testInputText(inputText).executeAndroidTextInput(
+      "next",
+      undefined,
+      false,
+      "eventOnly",
+      cachedUnfocused
+    );
+
+    // Device-domain lower bound rejects the stale cached focused hierarchy: no
+    // key events are dispatched. The host-clock fallback (minTimestamp 0) would
+    // have accepted it and typed.
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("eventOnly requires a focused editable field");
+    expect(observeExecuteOptions[0]?.minTimestamp).toBe(deviceNowMs);
+    expect(inputCommands(factory)).toEqual([]);
   });
 
   test("eventOnly delegates keyboard dismissal to the keyboard closer", async () => {


### PR DESCRIPTION
## Summary

Completes the remaining #4617 gap left after [#4623](https://github.com/kaeawc/auto-mobile/pull/4623). In `refreshFocusedTextInputHierarchy`, when the failed hierarchy has no `updatedAt`, the refresh lower bound (`minTimestamp`) fell back to the **host** clock (`this.timer.now()`). Android interprets `minTimestamp` in the **device-authored** hierarchy clock domain, so a device clock running ahead of the host could accept an older cached focused hierarchy as fresh — defeating the eventOnly freshness guarantee for the no-`updatedAt` case.

Fix: derive the fallback lower bound from the device clock via `getDeviceTimestampMs()` — the same source the rest of the freshness logic (`BaseVisualChange`, `LaunchApp`) already uses — keeping the whole path in one clock domain.

## Linked Issue

Closes [#4617](https://github.com/kaeawc/auto-mobile/issues/4617)

## Changes
- `src/features/action/InputText.ts`: no-`updatedAt` fallback now uses `await this.adb.getDeviceTimestampMs()` instead of `this.timer.now()`.
- `test/fakes/FakeAdbClient.ts`: added `getDeviceTimestampMs()` + `setDeviceTimestampMs()` to keep the fake aligned with the `AdbExecutor` contract (mirrors `FakeAdbExecutor`).

## Validation
- [x] New regression test (no-`updatedAt` / device-clock-ahead-of-host → stale hierarchy rejected, no key events) — fails before, passes after
- [x] `bun test test/features/action/` — 1083 pass / 0 fail; `bun run typecheck` no new errors; `bun run lint` clean
