### PR TITLE
Desktop workspace: command palette / quick-jump (⌘K)

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.desktop
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -17,6 +18,7 @@ import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import dev.jasonpearson.automobile.desktop.core.mcp.DaemonMcpResourceClient
 import dev.jasonpearson.automobile.desktop.core.settings.SettingsProvider
 import dev.jasonpearson.automobile.desktop.core.shell.MenuBarActions
+import dev.jasonpearson.automobile.desktop.core.workspace.CommandPalette
 import dev.jasonpearson.automobile.desktop.core.workspace.DeviceColumn
 import dev.jasonpearson.automobile.desktop.core.workspace.LogsFacet
 import dev.jasonpearson.automobile.desktop.core.workspace.OnboardingScreen
@@ -28,6 +30,7 @@ import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceEffect
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceFacetPlaceholder
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceShell
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceViewModel
+import dev.jasonpearson.automobile.desktop.core.workspace.buildWorkspaceCommands
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePicker
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerAction
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerEffect
@@ -66,6 +69,7 @@ fun AutoMobileDesktopApp(
     remember(scope, resourceClient) { DevicePickerViewModel(resourceClient, scope) }
   val pickerState by pickerViewModel.state.collectAsState()
   var pickerOpen by remember { mutableStateOf(false) }
+  var paletteOpen by remember { mutableStateOf(false) }
   var showOnboarding by remember { mutableStateOf(!settings.hasSeenOnboarding) }
 
   // OpenPicker (from the empty state or the Devices launcher) shows the picker; observing selected
@@ -119,12 +123,26 @@ fun AutoMobileDesktopApp(
             onClose = { pickerOpen = false },
           )
         else ->
-          WorkspaceShell(
-            state = workspaceState,
-            onAction = workspaceViewModel::onAction,
-            onOpenPicker = workspaceViewModel::openPicker,
-            facetContent = { column, tool -> WorkspaceFacet(column, tool) },
-          )
+          Box(Modifier.fillMaxSize()) {
+            WorkspaceShell(
+              state = workspaceState,
+              onAction = workspaceViewModel::onAction,
+              onOpenPicker = workspaceViewModel::openPicker,
+              onOpenPalette = { paletteOpen = true },
+              facetContent = { column, tool -> WorkspaceFacet(column, tool) },
+            )
+            if (paletteOpen) {
+              CommandPalette(
+                commands =
+                  buildWorkspaceCommands(
+                    workspaceState,
+                    onOpenPicker = workspaceViewModel::openPicker,
+                    onAction = workspaceViewModel::onAction,
+                  ),
+                onDismiss = { paletteOpen = false },
+              )
+            }
+          }
       }
     }
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPalette.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPalette.kt
@@ -1,0 +1,150 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+
+/** A single command in the palette: a stable [id], a display [label], and its [run] action. */
+data class PaletteCommand(val id: String, val label: String, val run: () -> Unit)
+
+/** Commands matching [query] by case-insensitive substring; blank query returns all. Pure. */
+internal fun filterCommands(commands: List<PaletteCommand>, query: String): List<PaletteCommand> {
+  val q = query.trim()
+  return if (q.isEmpty()) commands else commands.filter { it.label.contains(q, ignoreCase = true) }
+}
+
+/**
+ * The commands available for the current workspace [state]: open the picker, focus/close each
+ * observed device, open any tool on the focused device, and (with >1 device) compare the focused
+ * device's active tool. Each command dispatches an existing workspace action, so the palette needs
+ * no new backend. Pure over its inputs for testability.
+ */
+fun buildWorkspaceCommands(
+  state: WorkspaceUiState,
+  onOpenPicker: () -> Unit,
+  onAction: (WorkspaceAction) -> Unit,
+): List<PaletteCommand> = buildList {
+  add(PaletteCommand("open-devices", "Open Devices", onOpenPicker))
+  val content = state as? WorkspaceUiState.Content ?: return@buildList
+  content.columns.forEach { column ->
+    add(
+      PaletteCommand("focus-${column.deviceId}", "Focus ${column.name}") {
+        onAction(WorkspaceAction.FocusDevice(column.deviceId))
+      }
+    )
+    add(
+      PaletteCommand("close-${column.deviceId}", "Close ${column.name}") {
+        onAction(WorkspaceAction.CloseDevice(column.deviceId))
+      }
+    )
+  }
+  val focused = content.columns.firstOrNull { it.deviceId == content.focusedDeviceId }
+  if (focused != null) {
+    Tool.entries.forEach { tool ->
+      add(
+        PaletteCommand("tool-${tool.name}", "Open ${tool.label} on ${focused.name}") {
+          onAction(WorkspaceAction.SelectTool(focused.deviceId, tool))
+        }
+      )
+    }
+    if (content.columns.size > 1) {
+      focused.activeTool?.let { active ->
+        add(
+          PaletteCommand("diff-${active.name}", "Compare ${active.label} across devices") {
+            onAction(WorkspaceAction.DiffTool(active))
+          }
+        )
+      }
+    }
+  }
+}
+
+/**
+ * Quick-jump command palette (⌘K): a search field over a filtered command list, on a dimmed shell.
+ * Selecting a command runs it and dismisses; clicking the scrim dismisses.
+ */
+@Composable
+fun CommandPalette(
+  commands: List<PaletteCommand>,
+  onDismiss: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  var query by remember { mutableStateOf("") }
+  val results = filterCommands(commands, query)
+  Box(
+    modifier =
+      modifier
+        .fillMaxSize()
+        .background(Color.Black.copy(alpha = 0.5f))
+        .clickable(
+          interactionSource = remember { MutableInteractionSource() },
+          indication = null,
+          onClick = onDismiss,
+        )
+        .semantics { contentDescription = "Command palette" },
+    contentAlignment = Alignment.TopCenter,
+  ) {
+    Column(
+      Modifier.padding(top = 80.dp)
+        .widthIn(max = 560.dp)
+        .fillMaxWidth(0.6f)
+        .background(MaterialTheme.colorScheme.surface, RoundedCornerShape(8.dp))
+        // Swallow clicks so interacting with the card doesn't dismiss via the scrim.
+        .clickable(
+          interactionSource = remember { MutableInteractionSource() },
+          indication = null,
+          onClick = {},
+        )
+        .padding(12.dp)
+    ) {
+      OutlinedTextField(
+        value = query,
+        onValueChange = { query = it },
+        singleLine = true,
+        label = { Text("Search commands") },
+        modifier = Modifier.fillMaxWidth().semantics { contentDescription = "Command search" },
+      )
+      Spacer(Modifier.height(8.dp))
+      LazyColumn(Modifier.heightIn(max = 360.dp)) {
+        items(results, key = { it.id }) { command ->
+          Text(
+            command.label,
+            modifier =
+              Modifier.fillMaxWidth()
+                .clickable {
+                  command.run()
+                  onDismiss()
+                }
+                .padding(vertical = 8.dp, horizontal = 4.dp),
+          )
+        }
+      }
+    }
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPalette.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPalette.kt
@@ -19,12 +19,15 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -97,6 +100,9 @@ fun CommandPalette(
 ) {
   var query by remember { mutableStateOf("") }
   val results = filterCommands(commands, query)
+  // Focus the search field as soon as the palette opens, so the user can type immediately.
+  val searchFocus = remember { FocusRequester() }
+  LaunchedEffect(Unit) { searchFocus.requestFocus() }
   Box(
     modifier =
       modifier
@@ -128,7 +134,10 @@ fun CommandPalette(
         onValueChange = { query = it },
         singleLine = true,
         label = { Text("Search commands") },
-        modifier = Modifier.fillMaxWidth().semantics { contentDescription = "Command search" },
+        modifier =
+          Modifier.fillMaxWidth().focusRequester(searchFocus).semantics {
+            contentDescription = "Command search"
+          },
       )
       Spacer(Modifier.height(8.dp))
       LazyColumn(Modifier.heightIn(max = 360.dp)) {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -46,6 +46,7 @@ fun WorkspaceShell(
   onAction: (WorkspaceAction) -> Unit,
   onOpenPicker: () -> Unit,
   status: WorkspaceStatus = WorkspaceStatus.Green,
+  onOpenPalette: () -> Unit = {},
   modifier: Modifier = Modifier,
   // Renders the docked facet body for a pane's active tool. Hoisted so the host can supply real
   // per-device dashboards; defaults to a placeholder so un-wired tools stay inert.
@@ -54,7 +55,7 @@ fun WorkspaceShell(
   },
 ) {
   Column(modifier.fillMaxSize()) {
-    TopBar(status = status, onOpenPicker = onOpenPicker)
+    TopBar(status = status, onOpenPicker = onOpenPicker, onOpenPalette = onOpenPalette)
     when (state) {
       is WorkspaceUiState.Empty -> EmptyState(onOpenPicker, Modifier.weight(1f).fillMaxWidth())
       is WorkspaceUiState.Content ->
@@ -80,7 +81,11 @@ fun WorkspaceShell(
 }
 
 @Composable
-private fun TopBar(status: WorkspaceStatus, onOpenPicker: () -> Unit) {
+private fun TopBar(
+  status: WorkspaceStatus,
+  onOpenPicker: () -> Unit,
+  onOpenPalette: () -> Unit,
+) {
   Row(
     modifier =
       Modifier.fillMaxWidth()
@@ -100,6 +105,17 @@ private fun TopBar(status: WorkspaceStatus, onOpenPicker: () -> Unit) {
       Text("  +", color = Accent, fontWeight = FontWeight.Bold)
     }
     Spacer(Modifier.weight(1f))
+    // Quick-jump command palette (⌘K).
+    Text(
+      "⌘K",
+      style = MaterialTheme.typography.labelMedium,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+      modifier =
+        Modifier.clickable { onOpenPalette() }
+          .semantics { contentDescription = "Open command palette" }
+          .padding(horizontal = 8.dp, vertical = 4.dp),
+    )
+    Spacer(Modifier.width(8.dp))
     Box(
       modifier =
         Modifier.size(12.dp).background(status.color(), CircleShape).semantics {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPaletteTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPaletteTest.kt
@@ -2,6 +2,7 @@ package dev.jasonpearson.automobile.desktop.core.workspace
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -82,6 +83,7 @@ class CommandPaletteTest {
         PaletteCommand("b", "Close Pixel") { ran = "b" },
       )
     setContent { MaterialTheme { CommandPalette(commands, onDismiss = { dismissed = true }) } }
+    onNodeWithContentDescription("Command search").assertIsFocused()
     onNodeWithContentDescription("Command search").performTextInput("close")
     onNodeWithText("Open Devices").assertDoesNotExist()
     onNodeWithText("Close Pixel").performClick()

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPaletteTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPaletteTest.kt
@@ -1,0 +1,91 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.runComposeUiTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class CommandPaletteTest {
+
+  private fun cmd(id: String, label: String) = PaletteCommand(id, label) {}
+
+  private fun column(id: String, name: String, activeTool: Tool? = null) =
+    DeviceColumn(deviceId = id, name = name, platform = Platform.Android, activeTool = activeTool)
+
+  @Test
+  fun `filter matches label substring case-insensitively and blank returns all`() {
+    val commands = listOf(cmd("a", "Open Devices"), cmd("b", "Close Pixel"), cmd("c", "Open Logs"))
+    assertEquals(listOf("a", "c"), filterCommands(commands, "OPEN").map { it.id })
+    assertEquals(3, filterCommands(commands, "   ").size)
+  }
+
+  @Test
+  fun `empty state offers only Open Devices`() {
+    val commands = buildWorkspaceCommands(WorkspaceUiState.Empty, onOpenPicker = {}, onAction = {})
+    assertEquals(listOf("Open Devices"), commands.map { it.label })
+  }
+
+  @Test
+  fun `content offers per-device and focused-tool commands that dispatch`() {
+    val dispatched = mutableListOf<WorkspaceAction>()
+    var openedPicker = false
+    val state =
+      WorkspaceUiState.Content(columns = listOf(column("a", "Pixel 8")), focusedDeviceId = "a")
+    val commands =
+      buildWorkspaceCommands(
+        state,
+        onOpenPicker = { openedPicker = true },
+        onAction = { dispatched.add(it) },
+      )
+    val labels = commands.map { it.label }
+    assertTrue(labels.containsAll(listOf("Open Devices", "Focus Pixel 8", "Close Pixel 8")))
+    assertTrue(labels.contains("Open Logs on Pixel 8"))
+
+    commands.first { it.label == "Open Logs on Pixel 8" }.run()
+    assertEquals(WorkspaceAction.SelectTool("a", Tool.Logs), dispatched.last())
+    commands.first { it.label == "Open Devices" }.run()
+    assertTrue(openedPicker)
+  }
+
+  @Test
+  fun `compare command appears only with multiple devices and an active tool`() {
+    val two =
+      WorkspaceUiState.Content(
+        columns = listOf(column("a", "Pixel", activeTool = Tool.Logs), column("b", "Tab")),
+        focusedDeviceId = "a",
+      )
+    assertTrue(
+      buildWorkspaceCommands(two, {}, {}).any { it.label == "Compare Logs across devices" }
+    )
+    val one =
+      WorkspaceUiState.Content(
+        columns = listOf(column("a", "Pixel", activeTool = Tool.Logs)),
+        focusedDeviceId = "a",
+      )
+    assertTrue(buildWorkspaceCommands(one, {}, {}).none { it.label.startsWith("Compare") })
+  }
+
+  @Test
+  fun `typing filters the list and selecting runs the command then dismisses`() = runComposeUiTest {
+    var ran: String? = null
+    var dismissed = false
+    val commands =
+      listOf(
+        PaletteCommand("a", "Open Devices") { ran = "a" },
+        PaletteCommand("b", "Close Pixel") { ran = "b" },
+      )
+    setContent { MaterialTheme { CommandPalette(commands, onDismiss = { dismissed = true }) } }
+    onNodeWithContentDescription("Command search").performTextInput("close")
+    onNodeWithText("Open Devices").assertDoesNotExist()
+    onNodeWithText("Close Pixel").performClick()
+    assertEquals("b", ran)
+    assertTrue(dismissed)
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
@@ -19,6 +19,23 @@ class WorkspaceShellUiTest {
     DeviceColumn(deviceId = id, name = name, platform = platform)
 
   @Test
+  fun `top bar exposes a command-palette trigger`() = runComposeUiTest {
+    var opened = false
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(
+          state = WorkspaceUiState.Empty,
+          onAction = {},
+          onOpenPicker = {},
+          onOpenPalette = { opened = true },
+        )
+      }
+    }
+    onNodeWithContentDescription("Open command palette").performClick()
+    assertTrue(opened)
+  }
+
+  @Test
   fun `empty state prompts to open Devices`() = runComposeUiTest {
     setContent {
       MaterialTheme {


### PR DESCRIPTION
Adds the wireframe's command palette (frame 11): a dimmed-shell search overlay whose commands map to existing workspace actions — fully functional today, no new backend.

Closes #4722

## Validation
- `:desktop-core:detektMain` + `:desktop-app:detektMain`, `:desktop-core:test`, `:desktop-app:compileKotlin`, ktfmt — green.
- Unit tests: `filterCommands` (substring/blank), `buildWorkspaceCommands` (command set + dispatch). Compose: type-to-filter + run-then-dismiss; TopBar ⌘K trigger.

## Notes
Commands: Open Devices; per observed device Focus/Close; open any tool on the focused device; compare the focused device's active tool (>1 device). The actual ⌘K key binding (Compose Desktop window key handling) is a follow-up — the visible ⌘K trigger opens it for now.