### PR TITLE
test(docs): sync device-boundary assertion to the corrected unix-socket-api doc

### DIFF
--- a/test/docs/daemonInputApiExamples.test.ts
+++ b/test/docs/daemonInputApiExamples.test.ts
@@ -193,7 +193,9 @@ describe("daemon input API consumer docs", () => {
     expect(unixSocketApi).toContain(
       `default \`${defaultReleaseVersion}\` CtrlProxy artifacts are legacy`,
     );
-    expect(unixSocketApi).toContain("device-boundary guarantee currently applies to `input/tap` and `input/swipe`");
+    expect(unixSocketApi).toContain(
+      "device-boundary guarantee applies to `input/tap`, `input/swipe`, `input/pressButton`",
+    );
     expect(unixSocketApi).toMatch(/"duration": 50,\r?\n    "frameContext": "android-generation-42"/);
     expect(unixSocketApi).toMatch(/"durationMs": 350,\r?\n    "frameContext": "android-generation-42"/);
     expect(unixSocketApi).toMatch(/"button": "back",\r?\n    "frameContext": "android-generation-42"/);


### PR DESCRIPTION
## Summary

Main is red: [#4724](https://github.com/kaeawc/auto-mobile/pull/4724) corrected the device-boundary paragraph in `docs/design-docs/mcp/daemon/unix-socket-api.md` but left `test/docs/daemonInputApiExamples.test.ts:196` asserting the old prose ("currently applies to `input/tap` and `input/swipe`"), so the TypeScript suite fails on all lanes for every PR (surfaced by #4723's merge-ref CI).

This syncs the assertion to the corrected wording ("applies to `input/tap`, `input/swipe`, `input/pressButton`").

## Validation
- [x] `bun test test/docs/daemonInputApiExamples.test.ts` — 7/7 pass (was failing on main).

Test-only; no production change. (Recurring hazard: this test hard-asserts exact doc substrings, so daemon-doc edits must update it in the same PR.)