### PR TITLE
test(observe-output,platform-services): discriminate 4 named regressions (#4518)

### DIFF
--- a/test/features/featureFlags/FeatureFlagService.toolListChanged.test.ts
+++ b/test/features/featureFlags/FeatureFlagService.toolListChanged.test.ts
@@ -102,11 +102,15 @@ describe("FeatureFlagService tools/list_changed notifications", () => {
     expect(updated.enabled).toBe(true);
   });
 
-  test("keeps the flag committed even if a throwing notifier rejects setFlag", async () => {
-    // The notifier is documented as best-effort and unguarded (FeatureFlagService
-    // commits the flag BEFORE notifying). If a notifier violates that contract by
-    // throwing, the caller sees a rejection for a change that already happened —
-    // this pins that observable outcome so a regression can't silently swallow it.
+  test("commits the flag before notifying, so a throwing notifier can't roll it back", async () => {
+    // ToolListChangedNotifier is documented as best-effort: implementations MUST
+    // NOT throw. FeatureFlagService commits the flag BEFORE notifying, so even a
+    // contract-violating throw must not undo the committed change. We pin that
+    // defensive outcome — the flag stays enabled — WITHOUT over-specifying whether
+    // the illegal throw propagates back to the caller. Propagation is an
+    // unspecified implementation detail (the contract says the throw can't happen),
+    // and asserting `.rejects.toThrow` here would lock in that detail and red a
+    // future notifier-guarding improvement.
     const throwingNotifier: ToolListChangedNotifier = {
       notifyToolListChanged(): void {
         throw new Error("notifier boom");
@@ -120,8 +124,10 @@ describe("FeatureFlagService tools/list_changed notifications", () => {
     );
     await service.listFlags();
 
-    await expect(service.setFlag("debug", true)).rejects.toThrow("notifier boom");
-    // The flag is already persisted despite the rejection.
+    // Tolerate either resolution or rejection: the contract forbids the throw, so
+    // its propagation is not the behavior under test — the committed flag is.
+    await service.setFlag("debug", true).catch(() => undefined);
+
     expect(service.isEnabled("debug")).toBe(true);
   });
 });

--- a/test/features/observe/output/ObserveResultOutput.test.ts
+++ b/test/features/observe/output/ObserveResultOutput.test.ts
@@ -1207,9 +1207,17 @@ describe("sanitizeObserveResult", () => {
 
     const ROWS: ReductionRow[] = [
       {
+        // Isolate the perf-audit strip: reference is the fully-sanitized output
+        // with ONLY the raw `performanceAudit` restored, so the sole difference is
+        // stripPerformanceAudit's work. Comparing against the raw fixture instead
+        // (as before) stayed green on independent perfTiming-drop + node-trim even
+        // if the strip regressed to a no-op.
         label: "perf-audit strip",
         reduced: () => sanitizeObserveResult(loadAndroidHomeObserve().observe, DROP_NONE),
-        reference: () => loadAndroidHomeObserve().observe,
+        reference: () => {
+          const { observe } = loadAndroidHomeObserve();
+          return { ...sanitizeObserveResult(observe, DROP_NONE), performanceAudit: observe.performanceAudit };
+        },
         tokensToo: true,
       },
       {

--- a/test/features/observe/output/diffObserveResult.test.ts
+++ b/test/features/observe/output/diffObserveResult.test.ts
@@ -1722,6 +1722,64 @@ describe("diffObserveResult — iOS stable-identity boundaries (A9/P8)", () => {
     }
   });
 
+  // Competing-identifier precedence: a single-id row (above) leaves the order
+  // resource-id > accessibilityIdentifier > view-id unpinned — reversing it keeps
+  // every single-id row green. Here BOTH a higher- and a lower-priority id are
+  // present and DISAGREE across the edit, so the pairing outcome is decided purely
+  // by which id source wins. `Old`/`New` text still differs, so content-identity
+  // never re-pairs and the iOS stable-id pass alone decides.
+  const textEditAsym = (oldAttrs: Record<string, unknown>, newAttrs: Record<string, unknown>) => {
+    const node = (attrs: Record<string, unknown>, t: string) => ({
+      "className": "XCUIElementTypeTextField",
+      ...attrs,
+      "text": t,
+      "value": t,
+      "bounds": { ...REGION },
+    });
+    return diffObserveResult(iosObs(node(oldAttrs, "Old")), iosObs(node(newAttrs, "New")));
+  };
+
+  const COMPETING_PRECEDENCE_ROWS: ReadonlyArray<
+    readonly [string, Record<string, unknown>, Record<string, unknown>, boolean]
+  > = [
+    [
+      "resource-id wins over a differing accessibilityIdentifier",
+      { "resource-id": "Field", "accessibilityIdentifier": "a11y-old" },
+      { "resource-id": "Field", "accessibilityIdentifier": "a11y-new" },
+      true,
+    ],
+    [
+      "a differing resource-id is authoritative over a matching accessibilityIdentifier",
+      { "resource-id": "Field-old", "accessibilityIdentifier": "a11y" },
+      { "resource-id": "Field-new", "accessibilityIdentifier": "a11y" },
+      false,
+    ],
+    [
+      "accessibilityIdentifier wins over a differing view-id when no resource-id",
+      { "accessibilityIdentifier": "a11y", "view-id": "view-old" },
+      { "accessibilityIdentifier": "a11y", "view-id": "view-new" },
+      true,
+    ],
+    [
+      "a differing accessibilityIdentifier is authoritative over a matching view-id",
+      { "accessibilityIdentifier": "a11y-old", "view-id": "view" },
+      { "accessibilityIdentifier": "a11y-new", "view-id": "view" },
+      false,
+    ],
+  ];
+
+  test.each(COMPETING_PRECEDENCE_ROWS)("%s", (_label, oldAttrs, newAttrs, expectRepaired) => {
+    const diff = textEditAsym(oldAttrs, newAttrs);
+    if (expectRepaired) {
+      expect(diff.changed).toHaveLength(1);
+      expect(diff.changed[0].changes.text).toEqual({ from: "Old", to: "New" });
+    } else {
+      expect(diff.added).toHaveLength(1);
+      expect(diff.removed).toHaveLength(1);
+      expect(diff.changed).toEqual([]);
+    }
+  });
+
   test("an editable field with a list-cell class opts out of the repair", () => {
     const node = (t: string) => ({
       "className": "XCUIElementTypeCell",

--- a/test/features/telemetry/TelemetryEventBuffer.test.ts
+++ b/test/features/telemetry/TelemetryEventBuffer.test.ts
@@ -203,15 +203,25 @@ describe("TelemetryEventBuffer", () => {
     // Let the first flush snapshot ["first"] and park on the repository gate.
     await new Promise<void>(resolve => setImmediate(resolve));
 
-    // A second flush requested while the first is still blocked must queue behind it.
+    // A second flush requested while the first is still blocked must queue behind
+    // it — crucially, its buffer snapshot must not happen until the first flush
+    // completes.
     buffer.addLog(makeLog("second"));
     const secondFlush = buffer.flush();
+
+    // Added AFTER the second flush() call but BEFORE the first flush is released.
+    // Under serialization the second flush has not snapshotted the buffer yet, so
+    // "third" joins its batch. If the two flushes ran concurrently the second would
+    // have already snapshotted ["second"] and stranded "third" — so this row is
+    // what discriminates the serialization the test names (drop `flushChain` and it
+    // reds). The earlier single-shared-gate assertion held either way.
+    buffer.addLog(makeLog("third"));
 
     repository.releaseLogFlush();
     await Promise.all([firstFlush, secondFlush]);
 
     expect(repository.logBatches).toHaveLength(2);
     expect(repository.logBatches[0].map(r => r.message)).toEqual(["first"]);
-    expect(repository.logBatches[1].map(r => r.message)).toEqual(["second"]);
+    expect(repository.logBatches[1].map(r => r.message)).toEqual(["second", "third"]);
   });
 });


### PR DESCRIPTION
## Summary

Fix-forward from the Codex P2 review comments filed after [#4514](https://github.com/kaeawc/auto-mobile/pull/4514) (observe-output) and [#4515](https://github.com/kaeawc/auto-mobile/pull/4515) (platform-services) auto-merged. All are **test-strengthening only** — the shipped tests already pass and pin real behavior; these make four rows *discriminate* the specific regression each names. Every change is verified by mutation: inject the named regression, confirm the strengthened row reds where the old row stayed green, then revert.

| Finding | Change | Mutation proof |
|---|---|---|
| `diffObserveResult.test.ts` iOS id precedence | Single-id rows left `resource-id > accessibilityIdentifier > view-id` unpinned. Added **competing-identifier** rows (asymmetric old/new) so the pairing outcome depends on which id source wins. | Reversing `iosStableId` precedence reds the 2 new resource-id/accId rows; all 158 other rows stay green. |
| `ObserveResultOutput.test.ts` perf-audit strip | Row compared fully-sanitized vs the **raw** fixture, so independent `perfTiming`-drop + node-trim satisfied it even if the strip regressed. Reference is now sanitized-plus-raw-`performanceAudit`, isolating the strip. | No-op'ing `stripPerformanceAudit` reds this row; sibling reduction rows stay green. |
| `TelemetryEventBuffer.test.ts` overlapping flush | Single shared gate + two events passed with or without `flushChain`. Added a **third** event between the 2nd `flush()` and gate release, landing in batch 2 only under serialization. | Replacing `flush()` with `return this.doFlush()` (no `flushChain`) reds the test. |
| `FeatureFlagService.toolListChanged.test.ts` | Asserted `.rejects.toThrow` even though `ToolListChangedNotifier` implementations MUST NOT throw — over-specifying an impl detail. Now pins the **defensive outcome** (flag stays committed) and tolerates either resolution or rejection. | Reordering `setFlag` to notify **before** committing reds the test (`isEnabled` false). |

**Finding 2** (`ObserveResultOutput.test.ts:993` "text '0'") was **already satisfied on `main`** — the row is the string `"0"` (committed in [#4514](https://github.com/kaeawc/auto-mobile/pull/4514), never numeric `0` per `git blame`), and the `.toBe("0")` assertion already discriminates a drop of the legit string. No change.

## Linked Issue

Closes #4518

## Validation

- [x] `bun test` (full suite): 12081 pass / 0 fail
- [x] `bun run lint` (new-violation gate) + all boundary checks pass
- [x] `bun run typecheck` reports no new errors (baseline gate)
- [x] Test-only change; all four touched suites run <100ms per case with existing fakes/FakeTimer
- [x] Each strengthened row mutation-verified against the regression it names

## Follow-ups

- None. Finding 2 required no change (documented above).
