### PR TITLE
fix(ci): give validate-finalized-release full history for lint boundary checks

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -246,6 +246,11 @@ jobs:
         with:
           lfs: false
           ref: ${{ needs.finalize-release.outputs.release_commit }}
+          # Full history so origin/main resolves. `bun run lint` chains
+          # diff-based ratchet boundary scripts (check-host-shell-boundary.ts
+          # et al.) that require a base ref; a shallow single-ref checkout of
+          # the release commit lacks origin/main and makes them throw.
+          fetch-depth: 0
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Problem

The **Prepare Release** run [30507018450](https://github.com/kaeawc/auto-mobile/actions/runs/30507018450) failed in the `validate-finalized-release` job at the **Run lint** step:

```
error: Cannot check new host shell execution: base ref origin/main does not exist.
      at resolveBaseRef (scripts/check-host-shell-boundary.ts:43:17)
```

`bun run lint` chains ~11 diff-based *ratchet* boundary scripts after ESLint (`check-host-shell-boundary.ts` and friends). Each resolves a base ref to compute changed files — `origin/main` by default, or the PR base via `GITHUB_BASE_REF`. But:

- This is a `workflow_dispatch` run, so there is no `GITHUB_BASE_REF` fallback.
- `validate-finalized-release` checked out `release_commit` with a shallow, single-ref checkout (no `fetch-depth`), so `origin/main` was never fetched.

The first boundary script threw, lint exited 1, and `verify-prepared-release` was skipped.

## Fix

Add `fetch-depth: 0` to the `validate-finalized-release` checkout — the same pattern the sibling `verify-prepared-release` job already uses. With full history, `origin/main` resolves. `release_commit` is one version-bump commit atop `origin/main` (it is promoted to main only later, in `verify-prepared-release`), so the boundary scripts diff a trivial changeset and pass, while ESLint and the real lint gate still run in full.

## Validation

`scripts/all_fast_validate_checks.sh` — all 27 checks pass (exit 0).
