### PR TITLE
refactor(desktop): extract ObservationStream interface + FakeObservationStream

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FakeObservationStream.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FakeObservationStream.kt
@@ -1,0 +1,101 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * In-memory [ObservationStream] for UI tests: records subscription lifecycle (connect/disconnect/
+ * dispose, requested navigation graph) and lets tests emit updates onto each flow, with no socket.
+ */
+class FakeObservationStream : ObservationStream {
+  private fun <T> flow() =
+    MutableSharedFlow<T>(
+      replay = 1,
+      extraBufferCapacity = 16,
+      onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+  private val _hierarchyUpdates = flow<HierarchyStreamUpdate>()
+  override val hierarchyUpdates: SharedFlow<HierarchyStreamUpdate> =
+    _hierarchyUpdates.asSharedFlow()
+  private val _screenshotUpdates = flow<ScreenshotStreamUpdate>()
+  override val screenshotUpdates: SharedFlow<ScreenshotStreamUpdate> =
+    _screenshotUpdates.asSharedFlow()
+  private val _navigationUpdates = flow<NavigationGraphStreamUpdate>()
+  override val navigationUpdates: SharedFlow<NavigationGraphStreamUpdate> =
+    _navigationUpdates.asSharedFlow()
+  private val _performanceUpdates = flow<PerformanceStreamUpdate>()
+  override val performanceUpdates: SharedFlow<PerformanceStreamUpdate> =
+    _performanceUpdates.asSharedFlow()
+  private val _storageUpdates = flow<StorageStreamUpdate>()
+  override val storageUpdates: SharedFlow<StorageStreamUpdate> = _storageUpdates.asSharedFlow()
+  private val _deviceEvents = flow<DeviceStreamEvent>()
+  override val deviceEvents: SharedFlow<DeviceStreamEvent> = _deviceEvents.asSharedFlow()
+
+  private val _connectionState = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected())
+  override val connectionState: StateFlow<ConnectionState> = _connectionState.asStateFlow()
+
+  private var connected = false
+
+  var connectCallCount = 0
+    private set
+
+  var disconnectCallCount = 0
+    private set
+
+  var lastConnectedDeviceId: String? = null
+    private set
+
+  var navigationRequestCount = 0
+    private set
+
+  var lastNavigationAppId: String? = null
+    private set
+
+  override fun connect(deviceId: String?) {
+    connectCallCount++
+    lastConnectedDeviceId = deviceId
+    connected = true
+    _connectionState.value = ConnectionState.Connected()
+  }
+
+  override fun disconnect() {
+    disconnectCallCount++
+    connected = false
+    _connectionState.value = ConnectionState.Disconnected()
+  }
+
+  override fun isConnected(): Boolean = connected
+
+  override fun dispose() {
+    disconnect()
+  }
+
+  override fun setCadence(screenshotIntervalMs: Long?, hierarchyIntervalMs: Long?) = Unit
+
+  override fun resetLayoutReplayCache() = Unit
+
+  override fun requestNavigationGraph(appId: String?) {
+    navigationRequestCount++
+    lastNavigationAppId = appId
+  }
+
+  override fun requestObservation(deviceId: String?) = Unit
+
+  // -- Test helpers: push updates onto the flows --
+  fun emitNavigation(update: NavigationGraphStreamUpdate): Boolean =
+    _navigationUpdates.tryEmit(update)
+
+  fun emitPerformance(update: PerformanceStreamUpdate): Boolean =
+    _performanceUpdates.tryEmit(update)
+
+  fun emitStorage(update: StorageStreamUpdate): Boolean = _storageUpdates.tryEmit(update)
+
+  fun emitHierarchy(update: HierarchyStreamUpdate): Boolean = _hierarchyUpdates.tryEmit(update)
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStream.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStream.kt
@@ -1,0 +1,42 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * The observation-stream contract: per-device real-time updates (hierarchy, screenshot, navigation
+ * graph, performance, storage, device events) plus subscription lifecycle. Extracted so consumers
+ * (e.g. the workspace facets) can depend on the interface and be tested with
+ * [FakeObservationStream] instead of the socket-backed [ObservationStreamClient].
+ */
+interface ObservationStream {
+  val hierarchyUpdates: SharedFlow<HierarchyStreamUpdate>
+  val screenshotUpdates: SharedFlow<ScreenshotStreamUpdate>
+  val navigationUpdates: SharedFlow<NavigationGraphStreamUpdate>
+  val performanceUpdates: SharedFlow<PerformanceStreamUpdate>
+  val storageUpdates: SharedFlow<StorageStreamUpdate>
+  val deviceEvents: SharedFlow<DeviceStreamEvent>
+  val connectionState: StateFlow<ConnectionState>
+
+  /** Subscribe to the stream, optionally filtered server-side to [deviceId]. */
+  fun connect(deviceId: String? = null)
+
+  /** Unsubscribe and close the connection; the instance may be reconnected. */
+  fun disconnect()
+
+  fun isConnected(): Boolean
+
+  /** Disconnect and release all resources; do not reuse after calling. */
+  fun dispose()
+
+  fun setCadence(screenshotIntervalMs: Long? = null, hierarchyIntervalMs: Long? = null)
+
+  fun resetLayoutReplayCache()
+
+  /** Request the navigation graph for the subscribed device (optionally scoped to [appId]). */
+  fun requestNavigationGraph(appId: String? = null)
+
+  /** Request a one-off observation for [deviceId] (or the subscribed device when null). */
+  fun requestObservation(deviceId: String? = null)
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/ObservationStreamClient.kt
@@ -41,7 +41,7 @@ import kotlinx.serialization.serializer
  *
  * Socket path: ~/.auto-mobile/observation-stream.sock
  */
-class ObservationStreamClient {
+class ObservationStreamClient : ObservationStream {
   companion object {
     internal fun getSocketPath(): String =
       AutoMobileSocketPaths.socketPath("observation-stream.sock")
@@ -59,15 +59,18 @@ class ObservationStreamClient {
 
   // Flow for hierarchy updates
   private val _hierarchyUpdates = MutableSharedFlow<HierarchyStreamUpdate>(replay = 1)
-  val hierarchyUpdates: SharedFlow<HierarchyStreamUpdate> = _hierarchyUpdates.asSharedFlow()
+  override val hierarchyUpdates: SharedFlow<HierarchyStreamUpdate> =
+    _hierarchyUpdates.asSharedFlow()
 
   // Flow for screenshot updates
   private val _screenshotUpdates = MutableSharedFlow<ScreenshotStreamUpdate>(replay = 1)
-  val screenshotUpdates: SharedFlow<ScreenshotStreamUpdate> = _screenshotUpdates.asSharedFlow()
+  override val screenshotUpdates: SharedFlow<ScreenshotStreamUpdate> =
+    _screenshotUpdates.asSharedFlow()
 
   // Flow for navigation graph updates
   private val _navigationUpdates = MutableSharedFlow<NavigationGraphStreamUpdate>(replay = 1)
-  val navigationUpdates: SharedFlow<NavigationGraphStreamUpdate> = _navigationUpdates.asSharedFlow()
+  override val navigationUpdates: SharedFlow<NavigationGraphStreamUpdate> =
+    _navigationUpdates.asSharedFlow()
 
   // Flow for performance metrics updates (use extraBufferCapacity + DROP_OLDEST to avoid blocking)
   private val _performanceUpdates =
@@ -76,7 +79,8 @@ class ObservationStreamClient {
       extraBufferCapacity = 10,
       onBufferOverflow = kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST,
     )
-  val performanceUpdates: SharedFlow<PerformanceStreamUpdate> = _performanceUpdates.asSharedFlow()
+  override val performanceUpdates: SharedFlow<PerformanceStreamUpdate> =
+    _performanceUpdates.asSharedFlow()
 
   // Flow for live key/value storage changes. Storage writes can burst (a screen that persists
   // several preferences at once), so this follows the performance flow's non-blocking policy
@@ -87,15 +91,15 @@ class ObservationStreamClient {
       extraBufferCapacity = 32,
       onBufferOverflow = kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST,
     )
-  val storageUpdates: SharedFlow<StorageStreamUpdate> = _storageUpdates.asSharedFlow()
+  override val storageUpdates: SharedFlow<StorageStreamUpdate> = _storageUpdates.asSharedFlow()
 
   // Flow for device-level stream events such as control connection loss.
   private val _deviceEvents = MutableSharedFlow<DeviceStreamEvent>(replay = 1)
-  val deviceEvents: SharedFlow<DeviceStreamEvent> = _deviceEvents.asSharedFlow()
+  override val deviceEvents: SharedFlow<DeviceStreamEvent> = _deviceEvents.asSharedFlow()
 
   // Flow for connection state
   private val _connectionState = MutableStateFlow<ConnectionState>(ConnectionState.Disconnected())
-  val connectionState: StateFlow<ConnectionState> = _connectionState.asStateFlow()
+  override val connectionState: StateFlow<ConnectionState> = _connectionState.asStateFlow()
 
   // Requested observation cadence, remembered so it is re-applied on every (re)subscribe (so the
   // cadence survives reconnects). Managed via setCadence(); null means "use the daemon's default".
@@ -109,7 +113,7 @@ class ObservationStreamClient {
    *
    * @param deviceId Optional device ID to subscribe to. If null, subscribes to all devices.
    */
-  fun connect(deviceId: String? = null) {
+  override fun connect(deviceId: String?) {
     if (_connectionState.value.isConnected) {
       log.info("Already connected to observation stream")
       return
@@ -156,7 +160,7 @@ class ObservationStreamClient {
     }
   }
 
-  fun disconnect() {
+  override fun disconnect() {
     if (!_connectionState.value.isConnected) return
 
     val previousState = _connectionState.value
@@ -183,13 +187,13 @@ class ObservationStreamClient {
     _connectionState.update { ConnectionState.Disconnected() }
   }
 
-  fun isConnected(): Boolean = _connectionState.value.isConnected
+  override fun isConnected(): Boolean = _connectionState.value.isConnected
 
   /**
    * Disconnect and cancel the internal coroutine scope. After calling dispose(), this client
    * instance should not be reused.
    */
-  fun dispose() {
+  override fun dispose() {
     disconnect()
     scope.coroutineContext[Job]?.cancel()
   }
@@ -223,7 +227,7 @@ class ObservationStreamClient {
    * null for a field to fall back to the daemon's per-platform default. No-op when the cadence is
    * unchanged, so callers can invoke this on every focus change without spamming the socket.
    */
-  fun setCadence(screenshotIntervalMs: Long? = null, hierarchyIntervalMs: Long? = null) {
+  override fun setCadence(screenshotIntervalMs: Long?, hierarchyIntervalMs: Long?) {
     if (
       requestedScreenshotIntervalMs == screenshotIntervalMs &&
         requestedHierarchyIntervalMs == hierarchyIntervalMs
@@ -472,7 +476,7 @@ class ObservationStreamClient {
    * already done on a device-connection-lost event.
    */
   @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
-  fun resetLayoutReplayCache() {
+  override fun resetLayoutReplayCache() {
     _screenshotUpdates.resetReplayCache()
     _hierarchyUpdates.resetReplayCache()
   }
@@ -484,7 +488,7 @@ class ObservationStreamClient {
    * @param appId Optional app ID to request the graph for a specific app. If null, the server
    *   returns the graph for the current foreground app.
    */
-  fun requestNavigationGraph(appId: String? = null) {
+  override fun requestNavigationGraph(appId: String?) {
     if (!_connectionState.value.isConnected) return
 
     val request =
@@ -504,7 +508,7 @@ class ObservationStreamClient {
    *
    * @param deviceId Capture just this device; null captures every subscribed device.
    */
-  fun requestObservation(deviceId: String? = null) {
+  override fun requestObservation(deviceId: String?) {
     if (!_connectionState.value.isConnected) return
 
     val request =

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FakeObservationStreamTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FakeObservationStreamTest.kt
@@ -1,0 +1,32 @@
+package dev.jasonpearson.automobile.desktop.core.daemon
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FakeObservationStreamTest {
+
+  @Test
+  fun `connect records the device and count, dispose disconnects`() {
+    val stream = FakeObservationStream()
+    assertFalse(stream.isConnected())
+
+    stream.connect("dev-1")
+    assertTrue(stream.isConnected())
+    assertEquals(1, stream.connectCallCount)
+    assertEquals("dev-1", stream.lastConnectedDeviceId)
+
+    stream.dispose()
+    assertFalse(stream.isConnected())
+    assertEquals(1, stream.disconnectCallCount)
+  }
+
+  @Test
+  fun `requestNavigationGraph records the appId and count`() {
+    val stream = FakeObservationStream()
+    stream.requestNavigationGraph("com.example.app")
+    assertEquals(1, stream.navigationRequestCount)
+    assertEquals("com.example.app", stream.lastNavigationAppId)
+  }
+}


### PR DESCRIPTION
## Summary

Extracts an `ObservationStream` interface from the socket-backed `ObservationStreamClient` and adds `FakeObservationStream`, so the per-device workspace facets can be unit-tested without a real socket. Item 1 of the facet-infrastructure issue ([#4715](https://github.com/kaeawc/auto-mobile/issues/4715)); directly enables the **Navigation** and **Performance** facets (drivable per-device via `connect(deviceId)` + `requestNavigationGraph` / live-metrics, no daemon-resource change).

## Changes
- `ObservationStream` interface: 7 update flows + `connectionState` + `connect`/`disconnect`/`isConnected`/`dispose`/`setCadence`/`resetLayoutReplayCache`/`requestNavigationGraph`/`requestObservation`.
- `ObservationStreamClient : ObservationStream` — `override`s only; **no** rename, so all existing constructions, the companion `socketExists()`, and the 16 existing test sites are untouched (behavior-neutral).
- `FakeObservationStream` — records connect/dispose + navigation-graph requests, emits onto each flow.

## Validation
- `:desktop-core:detektMain` + `:desktop-core:test` (incl. the existing `ObservationStreamClientTest`/`ObservationStreamStorageTest` + new `FakeObservationStreamTest`) + ktfmt — green.

Consumers (Navigation facet retyping `NavigationDashboard`'s `observationStreamClient` param to the interface) land in the immediate follow-up PR.