### PR TITLE
test: strengthen observe-output/platform-services rows to discriminate regressions (#4518)

### DIFF
--- a/test/features/featureFlags/FeatureFlagService.toolListChanged.test.ts
+++ b/test/features/featureFlags/FeatureFlagService.toolListChanged.test.ts
@@ -102,11 +102,17 @@ describe("FeatureFlagService tools/list_changed notifications", () => {
     expect(updated.enabled).toBe(true);
   });
 
-  test("keeps the flag committed even if a throwing notifier rejects setFlag", async () => {
-    // The notifier is documented as best-effort and unguarded (FeatureFlagService
-    // commits the flag BEFORE notifying). If a notifier violates that contract by
-    // throwing, the caller sees a rejection for a change that already happened —
-    // this pins that observable outcome so a regression can't silently swallow it.
+  test("keeps the flag committed even when a misbehaving notifier throws", async () => {
+    // `ToolListChangedNotifier`'s contract says implementations MUST NOT throw,
+    // and `FeatureFlagService` commits the flag BEFORE notifying. The guarantee
+    // under test is the DEFENSIVE one: a contract-violating notifier that throws
+    // can never leave the flag half-applied. We deliberately do NOT pin whether
+    // the throw propagates out of `setFlag` — that would over-specify behavior
+    // the service is free to guard against (a try/catch around the notifier is a
+    // valid, arguably better, implementation); the earlier assertion that the
+    // rejection surfaces made the test red on that legitimate hardening. Only the
+    // commit-survives-notifier-failure outcome is the real contract, so that is
+    // all we assert.
     const throwingNotifier: ToolListChangedNotifier = {
       notifyToolListChanged(): void {
         throw new Error("notifier boom");
@@ -120,8 +126,10 @@ describe("FeatureFlagService tools/list_changed notifications", () => {
     );
     await service.listFlags();
 
-    await expect(service.setFlag("debug", true)).rejects.toThrow("notifier boom");
-    // The flag is already persisted despite the rejection.
+    // Tolerate either outcome (throw surfaced OR guarded/swallowed): the flag
+    // must be committed regardless. This reds only if the notifier failure
+    // actually corrupts state — e.g. the notify moves BEFORE the commit.
+    await service.setFlag("debug", true).catch(() => undefined);
     expect(service.isEnabled("debug")).toBe(true);
   });
 });

--- a/test/features/featureFlags/FeatureFlagService.toolListChanged.test.ts
+++ b/test/features/featureFlags/FeatureFlagService.toolListChanged.test.ts
@@ -118,8 +118,9 @@ describe("FeatureFlagService tools/list_changed notifications", () => {
         throw new Error("notifier boom");
       },
     };
+    const repository = new FakeFeatureFlagRepository();
     const service = new FeatureFlagService(
-      new FakeFeatureFlagRepository(),
+      repository,
       new FakeFeatureFlagApplier(),
       TEST_DEFINITIONS,
       throwingNotifier
@@ -131,5 +132,13 @@ describe("FeatureFlagService tools/list_changed notifications", () => {
     // actually corrupts state — e.g. the notify moves BEFORE the commit.
     await service.setFlag("debug", true).catch(() => undefined);
     expect(service.isEnabled("debug")).toBe(true);
+
+    // Assert PERSISTENCE, not only the in-memory flag: if `setFlag` were
+    // reordered to notify before it persists, a throwing notifier would skip
+    // `upsertFlag` while `isEnabled()` (in-memory) still passed. Reading the
+    // repository record makes the row red on that notify-before-persist ordering
+    // too, not just notify-before-in-memory-commit.
+    const persisted = (await repository.listFlags()).find(record => record.key === "debug");
+    expect(persisted?.enabled).toBe(true);
   });
 });

--- a/test/features/observe/output/ObserveResultOutput.test.ts
+++ b/test/features/observe/output/ObserveResultOutput.test.ts
@@ -1209,7 +1209,17 @@ describe("sanitizeObserveResult", () => {
       {
         label: "perf-audit strip",
         reduced: () => sanitizeObserveResult(loadAndroidHomeObserve().observe, DROP_NONE),
-        reference: () => loadAndroidHomeObserve().observe,
+        // Reference = fully sanitized EXCEPT the perf-audit strip: re-attach the
+        // raw (un-stripped) `performanceAudit` onto an otherwise-sanitized copy so
+        // the only delta between `reduced` and `reference` is `stripPerformanceAudit`.
+        // Comparing against the raw fixture instead would let the always-on
+        // perfTiming drop + node trim satisfy the row even if this specific strip
+        // regressed; isolating it means the row reds iff the perf-audit strip stops
+        // shrinking the payload.
+        reference: () => {
+          const { observe } = loadAndroidHomeObserve();
+          return { ...sanitizeObserveResult(observe, DROP_NONE), performanceAudit: observe.performanceAudit };
+        },
         tokensToo: true,
       },
       {

--- a/test/features/observe/output/diffObserveResult.test.ts
+++ b/test/features/observe/output/diffObserveResult.test.ts
@@ -1722,6 +1722,46 @@ describe("diffObserveResult — iOS stable-identity boundaries (A9/P8)", () => {
     }
   });
 
+  // Competing-identifier precedence. Each row supplies TWO identifiers that
+  // DISAGREE across the edit: the higher-priority slot holds a stable value on
+  // both sides while a lower-priority slot changes. Under the documented
+  // precedence (resource-id > accessibilityIdentifier > non-UUID view-id) the
+  // stable higher-priority id is chosen → both sides share an iOS key → the pair
+  // re-pairs as `changed`. If the precedence were inverted, the *changing*
+  // lower-priority id would be selected → the keys diverge → the pair splits into
+  // add+remove. The single-identifier PRECEDENCE_ROWS above cannot catch that
+  // inversion (they stay green either way); these rows red it.
+  const textEditAsym = (oldIds: Record<string, unknown>, newIds: Record<string, unknown>) => {
+    const node = (ids: Record<string, unknown>, t: string) => ({
+      "className": "XCUIElementTypeTextField",
+      ...ids,
+      "text": t,
+      "value": t,
+      "bounds": { ...REGION },
+    });
+    return diffObserveResult(iosObs(node(oldIds, "Old")), iosObs(node(newIds, "New")));
+  };
+
+  const COMPETING_ROWS: ReadonlyArray<readonly [string, Record<string, unknown>, Record<string, unknown>]> = [
+    ["resource-id outranks a changing accessibilityIdentifier",
+      { "resource-id": "TitleField", "accessibilityIdentifier": "before" },
+      { "resource-id": "TitleField", "accessibilityIdentifier": "after" }],
+    ["resource-id outranks a changing (non-UUID) view-id",
+      { "resource-id": "TitleField", "view-id": "before" },
+      { "resource-id": "TitleField", "view-id": "after" }],
+    ["accessibilityIdentifier outranks a changing (non-UUID) view-id",
+      { "accessibilityIdentifier": "title", "view-id": "before" },
+      { "accessibilityIdentifier": "title", "view-id": "after" }],
+  ];
+
+  test.each(COMPETING_ROWS)("%s → re-pairs on the higher-priority id", (_label, oldIds, newIds) => {
+    const diff = textEditAsym(oldIds, newIds);
+    expect(diff.changed).toHaveLength(1);
+    expect(diff.changed[0].changes.text).toEqual({ from: "Old", to: "New" });
+    expect(diff.added).toEqual([]);
+    expect(diff.removed).toEqual([]);
+  });
+
   test("an editable field with a list-cell class opts out of the repair", () => {
     const node = (t: string) => ({
       "className": "XCUIElementTypeCell",

--- a/test/features/telemetry/TelemetryEventBuffer.test.ts
+++ b/test/features/telemetry/TelemetryEventBuffer.test.ts
@@ -22,25 +22,41 @@ class FakeBatchTelemetryRepository implements BatchTelemetryRepository {
 
   rejectLogsWith: Error | null = null;
 
-  private pendingLogGate: Promise<void> | null = null;
-  private releaseLogGate: (() => void) | null = null;
+  // Per-invocation gates (issue #4518): each blocked recordLogEvents parks on its
+  // OWN resolver rather than a single shared promise. A shared gate released
+  // all-at-once let two overlapping flushes resume together, so the serialization
+  // test passed whether or not `flush()` chains — it couldn't distinguish serial
+  // from concurrent. With one gate per invocation, concurrently-blocked flushes
+  // are individually observable and can be released newest-first, which surfaces
+  // any non-serialized commit ordering in `logBatches`.
+  private blockLogFlushes = false;
+  private logGateResolvers: Array<() => void> = [];
 
-  /** Make the next recordLogEvents block until releaseLogFlush() is called. */
+  /** Block EVERY subsequent recordLogEvents on its own gate until released. */
   holdNextLogFlush(): void {
-    this.pendingLogGate = new Promise<void>(resolve => {
-      this.releaseLogGate = resolve;
-    });
+    this.blockLogFlushes = true;
   }
 
+  /**
+   * Stop blocking and release every currently-parked flush NEWEST-FIRST. If
+   * flushes run concurrently this lets a later flush commit before an earlier
+   * one, so a lost serialization guarantee shows up as reordered `logBatches`.
+   * When flushes are serialized only one flush is ever parked here at a time, so
+   * newest-first and oldest-first coincide and ordering is preserved.
+   */
   releaseLogFlush(): void {
-    this.releaseLogGate?.();
-    this.releaseLogGate = null;
-    this.pendingLogGate = null;
+    this.blockLogFlushes = false;
+    const resolvers = this.logGateResolvers.splice(0).reverse();
+    for (const resolve of resolvers) {
+      resolve();
+    }
   }
 
   async recordLogEvents(inputs: RecordLogEventInput[]): Promise<void> {
-    if (this.pendingLogGate) {
-      await this.pendingLogGate;
+    if (this.blockLogFlushes) {
+      await new Promise<void>(resolve => {
+        this.logGateResolvers.push(resolve);
+      });
     }
     if (this.rejectLogsWith) {
       throw this.rejectLogsWith;


### PR DESCRIPTION
## Summary

Strengthen 5 observe-output / platform-services test rows so that reversing the behavior each claims to guard actually makes it FAIL. Several previously passed even when the guarded behavior was inverted, so they didn't discriminate their named regressions. Test-only; no source changes.

## Linked Issue

Closes [#4518](https://github.com/kaeawc/auto-mobile/issues/4518)

## Per-row
- **Row 1** `diffObserveResult.test.ts`: added `COMPETING_ROWS` with two *disagreeing* identifiers so the documented id-precedence (`resource-id > accessibilityIdentifier > non-UUID view-id`) actually decides re-pairing. Fails if precedence is inverted; single-identifier rows couldn't catch that.
- **Row 2** `ObserveResultOutput.test.ts:993`: left unchanged — already correctly asserts the string `"0"` survives.
- **Row 3** `ObserveResultOutput.test.ts` perf-audit strip: reference now re-attaches raw `performanceAudit` onto an otherwise fully-sanitized copy, isolating `stripPerformanceAudit` as the only delta. Fails only if that strip regresses.
- **Row 4** `TelemetryEventBuffer.test.ts`: fake now uses per-invocation gates (queue) released newest-first, so concurrent flushes can genuinely interleave — the row fails if `flushChain` serialization is removed.
- **Row 5** `FeatureFlagService.toolListChanged.test.ts`: stop over-asserting that a contract-violating (throwing) notifier's rejection propagates; assert the real contract — the flag stays committed despite notifier failure. A legitimate try/catch hardening now keeps the test green instead of wrongly red-flagging it.

Each strengthened row was verified fail-before / pass-after by inverting the guarded source behavior.

## Validation
- [x] 4 touched test files: 318 pass / 0 fail
- [x] `test/lint/` (fake-hygiene etc.): 194 pass / 0 fail
- [x] `bun run typecheck` no new errors; `bun run lint` clean
