### PR TITLE
test(server-runtime): executionTracker session lifecycle on cancel + planExecutionLock rejection

### DIFF
--- a/src/server/executionTracker.ts
+++ b/src/server/executionTracker.ts
@@ -18,9 +18,9 @@ interface ActiveExecution {
   cancelReason?: Error;
 }
 
-type ExecutionScope = "session" | "global";
+export type ExecutionScope = "session" | "global";
 
-interface ExecutionScopeOptions {
+export interface ExecutionScopeOptions {
   scope: ExecutionScope;
   sessionId?: string;
   sessionUuid?: string;

--- a/test/server/executionTracker.test.ts
+++ b/test/server/executionTracker.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { ExecutionTracker } from "../../src/server/executionTracker";
+import { ExecutionTracker, type ExecutionScopeOptions } from "../../src/server/executionTracker";
 import { FakeIdGenerator } from "../fakes/FakeIdGenerator";
 import { FakeTimer } from "../fakes/FakeTimer";
 
@@ -42,5 +42,57 @@ describe("ExecutionTracker", function() {
 
     expect(execution.abortController.signal.reason).not.toEqual(new Error("streamable_http_onclose"));
     expect(execution.cancelReason).toBeUndefined();
+  });
+
+  // #4183 item 5 (A2): src-behavior assertion refiled from the old "cancel leaves session
+  // active" test. Cancelling aborts the in-flight AbortController but must NOT remove the
+  // execution from the tracker — only endExecution() tears down the session bookkeeping.
+  // So the session remains "active" after a cancel, which is what lets a fresh execution
+  // still observe an active session until it is explicitly ended.
+  test("cancellation aborts but leaves the session's execution active", async function() {
+    const tracker = new ExecutionTracker(new FakeTimer(), new FakeIdGenerator(["execution-1"]));
+    const execution = tracker.startExecution("tapOn", undefined, "session-uuid");
+
+    const cancelled = await tracker.cancelSessionUuidExecutions(
+      "session-uuid",
+      "device-disconnected:emulator-5554"
+    );
+
+    expect(cancelled).toBe(1);
+    expect(execution.abortController.signal.aborted).toBe(true);
+    // The session is not torn down by cancellation.
+    expect(tracker.hasActiveSessionUuidExecutions("session-uuid")).toBe(true);
+
+    // Only endExecution() clears the session bookkeeping.
+    tracker.endExecution(execution.id);
+    expect(tracker.hasActiveSessionUuidExecutions("session-uuid")).toBe(false);
+  });
+
+  // #4183 item 6 (A3): the scope fallback in hasActiveToolExecution (executionTracker.ts)
+  // had no table coverage. The scope order is: explicit "global" → sessionUuid map →
+  // sessionId map → global fallback when neither key is provided.
+  describe("hasActiveToolExecution scope fallback", function() {
+    const makeTracker = function(): ExecutionTracker {
+      const tracker = new ExecutionTracker(new FakeTimer(), new FakeIdGenerator(["execution-1"]));
+      tracker.startExecution("executePlan", "session-id", "session-uuid");
+      return tracker;
+    };
+
+    test.each<[string, ExecutionScopeOptions, boolean]>([
+      ["global scope matches regardless of session keys", { scope: "global" }, true],
+      ["session scope matches on sessionUuid", { scope: "session", sessionUuid: "session-uuid" }, true],
+      ["session scope misses on non-matching sessionUuid", { scope: "session", sessionUuid: "other-uuid" }, false],
+      ["session scope falls back to sessionId when no uuid", { scope: "session", sessionId: "session-id" }, true],
+      ["session scope misses on non-matching sessionId", { scope: "session", sessionId: "other-id" }, false],
+      ["session scope with neither key falls back to global", { scope: "session" }, true],
+    ])("%s", function(_name, options, expected) {
+      const tracker = makeTracker();
+      expect(tracker.hasActiveToolExecution("executePlan", options)).toBe(expected);
+    });
+
+    test("global scope does not match a different tool name", function() {
+      const tracker = makeTracker();
+      expect(tracker.hasActiveToolExecution("tapOn", { scope: "global" })).toBe(false);
+    });
   });
 });

--- a/test/server/executionTracker.test.ts
+++ b/test/server/executionTracker.test.ts
@@ -79,7 +79,7 @@ describe("ExecutionTracker", function() {
     };
 
     test.each<[string, ExecutionScopeOptions, boolean]>([
-      ["global scope matches regardless of session keys", { scope: "global" }, true],
+      ["global scope matches regardless of present non-matching session keys", { scope: "global", sessionId: "other-id", sessionUuid: "other-uuid" }, true],
       ["session scope matches on sessionUuid", { scope: "session", sessionUuid: "session-uuid" }, true],
       ["session scope misses on non-matching sessionUuid", { scope: "session", sessionUuid: "other-uuid" }, false],
       ["session scope falls back to sessionId when no uuid", { scope: "session", sessionId: "session-id" }, true],

--- a/test/server/planExecutionLock.test.ts
+++ b/test/server/planExecutionLock.test.ts
@@ -64,19 +64,16 @@ describe("Plan execution lock", () => {
       reason: "plan execution in progress",
     });
 
-    try {
-      const { client } = fixture.getContext();
-      await client.request({
+    const { client } = fixture.getContext();
+    await expect(
+      client.request({
         method: "tools/call",
         params: {
           name: "listDeviceImages",
           arguments: { platform: "android" },
         },
-      }, z.any());
-      expect.fail("Expected tool call to be rejected");
-    } catch (error: any) {
-      expect(error.message).toContain("plan execution in progress");
-    }
+      }, z.any())
+    ).rejects.toThrow("plan execution in progress");
   });
 
   test("allows MCP tool calls when no plan is executing", async () => {


### PR DESCRIPTION
Child of [#4528](https://github.com/kaeawc/auto-mobile/issues/4528). Addresses three [#4183](https://github.com/kaeawc/auto-mobile/issues/4183) findings, re-confirmed against current `main`.

## Changes
- **#4183 item 5 (A2, NEEDS-FIX):** refiled the "cancel leaves session active" case as a src-behavior assertion in `test/server/executionTracker.test.ts`. Cancellation aborts the `AbortController` but does **not** remove the execution — `hasActiveSessionUuidExecutions` stays `true` until `endExecution()` clears the bookkeeping. Kept the existing cancel-reason tests 2 & 3.
- **#4183 item 6 (A3, CONFIRMED):** added a `test.each` scope table for `hasActiveToolExecution` (`executionTracker.ts:114-128`), covering explicit `global`, `sessionUuid` match/miss, `sessionId` fallback match/miss, and the neither-key global fallback, plus a wrong-tool-name miss.
- **#4183 item 20 (R4, CONFIRMED):** converted the `planExecutionLock` rejection test from try/catch to `await expect(...).rejects.toThrow("plan execution in progress")`. (The historical `:106` try/catch referenced in the finding no longer exists on `main`; only one try/catch remained.)
- Exported `ExecutionScope`/`ExecutionScopeOptions` from `executionTracker.ts` so the scope table is typed without an extra src seam.

## Validation
- `bun test test/server/executionTracker.test.ts test/server/planExecutionLock.test.ts` — 14 pass / 0 fail
- `bun test test/lint/` — 194 pass / 0 fail
- `bun run typecheck` — no new errors (198 baseline)
- `bun run lint` — no new violations

Closes [#4657](https://github.com/kaeawc/auto-mobile/issues/4657)