### PR TITLE
test(server-runtime): pin resource-read/registry guidance + ScreenshotJobTracker.clear (#4659)

### DIFF
--- a/test/server/resources/read.test.ts
+++ b/test/server/resources/read.test.ts
@@ -228,27 +228,56 @@ describe("MCP Resources Read", () => {
     expect(content.blob!.length).toBeGreaterThan(0);
   });
 
-  test("reading non-existent resource should throw error", async function() {
+  const readResourceResponseSchema = z.object({
+    contents: z.array(z.object({
+      uri: z.string(),
+      mimeType: z.string().optional(),
+      text: z.string().optional(),
+      blob: z.string().optional()
+    }))
+  });
+
+  // Capture the message of the error a resources/read request rejects with, so
+  // the recovery-guidance strings can be pinned by value rather than presence
+  // (issue #4659; #4183 item 10 + R5).
+  const readResourceError = async (uri: string): Promise<string> => {
     const { client } = fixture.getContext();
-
-    // Send resources/read request for non-existent resource
-    const readResourceResponseSchema = z.object({
-      contents: z.array(z.object({
-        uri: z.string(),
-        mimeType: z.string().optional(),
-        text: z.string().optional(),
-        blob: z.string().optional()
-      }))
-    });
-
-    // Expect this to throw an error
-    await expect(async () => {
+    let caught: unknown;
+    try {
       await client.request({
         method: "resources/read",
-        params: {
-          uri: "automobile:observation/invalid"
-        }
+        params: { uri }
       }, readResourceResponseSchema);
-    }).toThrow();
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    return (caught as Error).message;
+  };
+
+  test("reading non-existent resource throws not-found guidance pinned by value", async function() {
+    // The registry's "Resource not found" recovery guidance (R5) is the
+    // agent-facing hint for a mistyped resource path; assert every pattern line
+    // by value so a src rewrite that drops one is caught.
+    const message = await readResourceError("automobile:observation/invalid");
+
+    expect(message).toContain("Resource not found: automobile:observation/invalid");
+    expect(message).toContain("Available resource patterns:");
+    expect(message).toContain("automobile:devices/booted - List all booted devices");
+    expect(message).toContain("automobile:devices/booted/{platform} - List devices by platform (android|ios)");
+    expect(message).toContain("automobile:devices/{deviceId}/apps - List apps for a device");
+    expect(message).toContain("automobile:apps?deviceId={deviceId} - Query apps with filters");
+    expect(message).toContain("automobile:observation/latest - Latest screen observation");
+    expect(message).toContain("Use the listApps tool for detailed guidance on listing apps.");
+  });
+
+  test("reading a resource with an unknown URI scheme throws scheme-correction guidance", async function() {
+    // A mistyped scheme (here 'automoble') is rewritten to 'automobile:' in the
+    // recovery hint; pin the exact wording and the corrected suggestion.
+    const message = await readResourceError("automoble:devices/booted");
+
+    expect(message).toContain("Unknown URI scheme 'automoble://'.");
+    expect(message).toContain("AutoMobile resources use the 'automobile:' prefix.");
+    expect(message).toContain("Try: automobile:devices/booted");
   });
 });

--- a/test/server/resources/read.test.ts
+++ b/test/server/resources/read.test.ts
@@ -237,10 +237,13 @@ describe("MCP Resources Read", () => {
     }))
   });
 
-  // Capture the message of the error a resources/read request rejects with, so
-  // the recovery-guidance strings can be pinned by value rather than presence
-  // (issue #4659; #4183 item 10 + R5).
-  const readResourceError = async (uri: string): Promise<string> => {
+  // Capture the recovery-guidance message a resources/read request rejects with,
+  // stripped of the JSON-RPC transport wrapper ("MCP error -32603: ") so the
+  // guidance itself can be pinned as one complete string rather than a set of
+  // independent substring checks (issue #4659; #4183 item 10 + R5). Asserting
+  // the whole message by equality catches a reordered, duplicated, or
+  // contradictory rewrite that a `toContain` per line would let through.
+  const readResourceGuidance = async (uri: string): Promise<string> => {
     const { client } = fixture.getContext();
     let caught: unknown;
     try {
@@ -252,32 +255,36 @@ describe("MCP Resources Read", () => {
       caught = error;
     }
     expect(caught).toBeInstanceOf(Error);
-    return (caught as Error).message;
+    return (caught as Error).message.replace(/^MCP error -?\d+: /, "");
   };
 
-  test("reading non-existent resource throws not-found guidance pinned by value", async function() {
+  test("reading non-existent resource throws the complete not-found guidance", async function() {
     // The registry's "Resource not found" recovery guidance (R5) is the
-    // agent-facing hint for a mistyped resource path; assert every pattern line
-    // by value so a src rewrite that drops one is caught.
-    const message = await readResourceError("automobile:observation/invalid");
+    // agent-facing hint for a mistyped resource path; pin the entire message so
+    // any dropped, reordered, or duplicated pattern line fails the test.
+    const guidance = await readResourceGuidance("automobile:observation/invalid");
 
-    expect(message).toContain("Resource not found: automobile:observation/invalid");
-    expect(message).toContain("Available resource patterns:");
-    expect(message).toContain("automobile:devices/booted - List all booted devices");
-    expect(message).toContain("automobile:devices/booted/{platform} - List devices by platform (android|ios)");
-    expect(message).toContain("automobile:devices/{deviceId}/apps - List apps for a device");
-    expect(message).toContain("automobile:apps?deviceId={deviceId} - Query apps with filters");
-    expect(message).toContain("automobile:observation/latest - Latest screen observation");
-    expect(message).toContain("Use the listApps tool for detailed guidance on listing apps.");
+    expect(guidance).toBe(
+      "Resource not found: automobile:observation/invalid\n\n" +
+      "Available resource patterns:\n" +
+      "  - automobile:devices/booted - List all booted devices\n" +
+      "  - automobile:devices/booted/{platform} - List devices by platform (android|ios)\n" +
+      "  - automobile:devices/{deviceId}/apps - List apps for a device\n" +
+      "  - automobile:apps?deviceId={deviceId} - Query apps with filters\n" +
+      "  - automobile:observation/latest - Latest screen observation\n\n" +
+      "Use the listApps tool for detailed guidance on listing apps."
+    );
   });
 
-  test("reading a resource with an unknown URI scheme throws scheme-correction guidance", async function() {
+  test("reading a resource with an unknown URI scheme throws the complete scheme-correction guidance", async function() {
     // A mistyped scheme (here 'automoble') is rewritten to 'automobile:' in the
-    // recovery hint; pin the exact wording and the corrected suggestion.
-    const message = await readResourceError("automoble:devices/booted");
+    // recovery hint; pin the entire message, wording and corrected suggestion.
+    const guidance = await readResourceGuidance("automoble:devices/booted");
 
-    expect(message).toContain("Unknown URI scheme 'automoble://'.");
-    expect(message).toContain("AutoMobile resources use the 'automobile:' prefix.");
-    expect(message).toContain("Try: automobile:devices/booted");
+    expect(guidance).toBe(
+      "Unknown URI scheme 'automoble://'. " +
+      "AutoMobile resources use the 'automobile:' prefix. " +
+      "Try: automobile:devices/booted"
+    );
   });
 });

--- a/test/utils/ScreenshotJobTracker.test.ts
+++ b/test/utils/ScreenshotJobTracker.test.ts
@@ -292,6 +292,54 @@ describe("ScreenshotJobTracker", () => {
     expect(ScreenshotJobTracker.getMostRecentPendingDeviceId()).toBe("device-2");
   });
 
+  test("clear aborts every pending job, removes their parent-signal listeners, and empties the tracker", async () => {
+    const listeners = new Set<EventListenerOrEventListenerObject>();
+    const parentSignal = {
+      aborted: false,
+      addEventListener: (_type: string, cb: EventListenerOrEventListenerObject) => {
+        listeners.add(cb);
+      },
+      removeEventListener: (_type: string, cb: EventListenerOrEventListenerObject) => {
+        listeners.delete(cb);
+      }
+    } as unknown as AbortSignal;
+
+    const hang = (signal: AbortSignal) => new Promise<{ success: boolean; error?: string }>(resolve => {
+      signal.addEventListener("abort", () => {
+        resolve({ success: false, error: OPERATION_CANCELLED_MESSAGE });
+      }, { once: true });
+    });
+
+    const jobA = ScreenshotJobTracker.startJob("device-1", hang);
+    const jobB = ScreenshotJobTracker.startJob("device-2", hang, { parentSignal });
+    // Let both runners attach their abort listeners before clearing.
+    await Promise.resolve();
+
+    expect(ScreenshotJobTracker.isPending("device-1")).toBe(true);
+    expect(ScreenshotJobTracker.isPending("device-2")).toBe(true);
+    // The parent-signal-backed job holds exactly one abort listener while live.
+    expect(listeners.size).toBe(1);
+
+    ScreenshotJobTracker.clear();
+
+    // Every in-flight job is aborted synchronously...
+    expect(jobA.signal.aborted).toBe(true);
+    expect(jobB.signal.aborted).toBe(true);
+    // ...the tracker is emptied immediately, before the runners settle...
+    expect(ScreenshotJobTracker.isPending("device-1")).toBe(false);
+    expect(ScreenshotJobTracker.isPending("device-2")).toBe(false);
+    expect(ScreenshotJobTracker.getMostRecentPendingDeviceId()).toBeUndefined();
+    // ...and the long-lived parent-signal listener is removed to prevent leaks.
+    expect(listeners.size).toBe(0);
+
+    // The aborted runners still resolve with the cancellation result.
+    const [rA, rB] = await Promise.all([jobA.promise, jobB.promise]);
+    expect(rA.success).toBe(false);
+    expect(rA.error).toContain(OPERATION_CANCELLED_MESSAGE);
+    expect(rB.success).toBe(false);
+    expect(rB.error).toContain(OPERATION_CANCELLED_MESSAGE);
+  });
+
   test("waitForCompletion returns null when the job times out", async () => {
     ScreenshotJobTracker.startJob("device-2", async signal => {
       return new Promise(resolve => {


### PR DESCRIPTION
Child of [#4528](https://github.com/kaeawc/auto-mobile/issues/4528). Implements [#4659](https://github.com/kaeawc/auto-mobile/issues/4659) ([#4183](https://github.com/kaeawc/auto-mobile/issues/4183) item 10: A5/R5/R6).

## What
Test-only. Pins agent-facing recovery-guidance strings **by value** rather than merely asserting a throw, and covers `ScreenshotJobTracker.clear()`.

- `test/server/resources/read.test.ts`: replaced the bare `.toThrow()` non-existent-resource test with two value-pinned tests:
  - **Not-found guidance (R5):** asserts `Resource not found: ...` plus every "Available resource patterns" line and the `listApps` hint.
  - **Unknown-scheme guidance:** asserts the `Unknown URI scheme 'automoble://'` wording and the corrected `Try: automobile:...` suggestion.
  - Extracted a small `readResourceError` helper to capture the rejection message.
- `test/utils/ScreenshotJobTracker.test.ts`: added a `clear()` test (R6) pinning that it aborts every pending job, removes long-lived parent-signal listeners (leak guard), and empties the tracker synchronously, while aborted runners still resolve with the cancellation result.

Re-confirmed against `main`; no REFUTED items implemented; no src changes.

## Validation
- `bun test test/utils/ScreenshotJobTracker.test.ts test/server/resources/read.test.ts` — 18 pass
- `bun test test/lint/` — 194 pass
- `bun run typecheck` — no new errors
- `bun run lint` — clean

Closes [#4659](https://github.com/kaeawc/auto-mobile/issues/4659)
