### PR TITLE
refactor+test(server-runtime): inject Timer seam into CriticalSectionCoordinator

### DIFF
--- a/src/server/CriticalSectionCoordinator.ts
+++ b/src/server/CriticalSectionCoordinator.ts
@@ -1,6 +1,6 @@
 import { Mutex } from "async-mutex";
 import { logger } from "../utils/logger";
-import { defaultTimer } from "../utils/SystemTimer";
+import { defaultTimer, Timer } from "../utils/SystemTimer";
 
 /**
  * Coordinates critical sections across multiple devices using global locks.
@@ -22,7 +22,14 @@ export class CriticalSectionCoordinator {
   // session UUID, so `namespace + SEP + lock` is collision-free.
   private static readonly NAMESPACE_SEPARATOR = "\u0000";
 
-  private constructor() {
+  // Injected timer seam (interface + fake per repo convention). Production uses
+  // the real `defaultTimer`; tests inject a FakeTimer via createForTesting() so
+  // barrier timeouts and cleanup delays are deterministic without global
+  // setTimeout/Date.now patching.
+  private readonly timer: Timer;
+
+  private constructor(timer: Timer = defaultTimer) {
+    this.timer = timer;
     this.locks = new Map();
     this.barrierCounts = new Map();
     this.expectedDeviceCounts = new Map();
@@ -35,6 +42,15 @@ export class CriticalSectionCoordinator {
       CriticalSectionCoordinator.instance = new CriticalSectionCoordinator();
     }
     return CriticalSectionCoordinator.instance;
+  }
+
+  /**
+   * Create an isolated instance with an injected timer (for testing). Bypasses
+   * the process-wide singleton so each test gets its own barrier state and its
+   * own FakeTimer.
+   */
+  public static createForTesting(timer: Timer): CriticalSectionCoordinator {
+    return new CriticalSectionCoordinator(timer);
   }
 
   /**
@@ -81,7 +97,7 @@ export class CriticalSectionCoordinator {
 
     const existingTimer = this.cleanupTimers.get(key);
     if (existingTimer) {
-      defaultTimer.clearTimeout(existingTimer);
+      this.timer.clearTimeout(existingTimer);
       this.cleanupTimers.delete(key);
     }
   }
@@ -216,7 +232,7 @@ export class CriticalSectionCoordinator {
       this.barrierResolvers.set(key, resolvers);
 
       // Set timeout
-      const timer = defaultTimer.setTimeout(() => {
+      const timer = this.timer.setTimeout(() => {
         // Remove this resolver
         const currentResolvers = this.barrierResolvers.get(key) || [];
         const index = currentResolvers.indexOf(resolve);
@@ -237,7 +253,7 @@ export class CriticalSectionCoordinator {
       // Store the timeout so we can clear it if resolved normally
       const originalResolve = resolve;
       const wrappedResolve = () => {
-        defaultTimer.clearTimeout(timer);
+        this.timer.clearTimeout(timer);
         originalResolve();
       };
 
@@ -256,11 +272,11 @@ export class CriticalSectionCoordinator {
   private scheduleCleanup(key: string): void {
     const existingTimer = this.cleanupTimers.get(key);
     if (existingTimer) {
-      defaultTimer.clearTimeout(existingTimer);
+      this.timer.clearTimeout(existingTimer);
     }
 
     // Schedule new cleanup
-    const timer = defaultTimer.setTimeout(() => {
+    const timer = this.timer.setTimeout(() => {
       logger.debug(`Cleaning up lock resources for "${key}"`);
       this.locks.delete(key);
       this.barrierCounts.delete(key);
@@ -284,7 +300,7 @@ export class CriticalSectionCoordinator {
 
     const existingTimer = this.cleanupTimers.get(key);
     if (existingTimer) {
-      defaultTimer.clearTimeout(existingTimer);
+      this.timer.clearTimeout(existingTimer);
     }
 
     this.locks.delete(key);
@@ -299,7 +315,7 @@ export class CriticalSectionCoordinator {
 	 */
   public reset(): void {
     for (const timer of this.cleanupTimers.values()) {
-      defaultTimer.clearTimeout(timer);
+      this.timer.clearTimeout(timer);
     }
 
     this.locks.clear();

--- a/test/server/CriticalSectionCoordinator.test.ts
+++ b/test/server/CriticalSectionCoordinator.test.ts
@@ -1,59 +1,47 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { CriticalSectionCoordinator } from "../../src/server/CriticalSectionCoordinator";
 import { FakeTimer } from "../fakes/FakeTimer";
-import { defaultTimer } from "../../src/utils/SystemTimer";
 
 describe("CriticalSectionCoordinator", () => {
   let coordinator: CriticalSectionCoordinator;
   let fakeTimer: FakeTimer;
-  let originalSetTimeout: typeof global.setTimeout;
-  let originalClearTimeout: typeof global.clearTimeout;
-  let originalDateNow: typeof Date.now;
 
   beforeEach(() => {
+    // Inject a FakeTimer via the createForTesting seam so barrier timeouts,
+    // cleanup delays, and now() are deterministic — no global setTimeout /
+    // clearTimeout / Date.now patching (#4183 item 14).
     fakeTimer = new FakeTimer();
-
-    originalSetTimeout = global.setTimeout;
-    originalClearTimeout = global.clearTimeout;
-    originalDateNow = Date.now;
-
-    global.setTimeout = ((callback: (...args: any[]) => void, ms?: number, ...args: any[]) => {
-      return fakeTimer.setTimeout(() => callback(...args), ms ?? 0);
-    }) as typeof global.setTimeout;
-    global.clearTimeout = ((handle: NodeJS.Timeout) => {
-      fakeTimer.clearTimeout(handle);
-    }) as typeof global.clearTimeout;
-    Date.now = () => fakeTimer.now();
-
-    coordinator = CriticalSectionCoordinator.getInstance();
-    coordinator.reset();
+    coordinator = CriticalSectionCoordinator.createForTesting(fakeTimer);
   });
 
   afterEach(() => {
-    Date.now = originalDateNow;
-    global.setTimeout = originalSetTimeout;
-    global.clearTimeout = originalClearTimeout;
+    coordinator.reset();
     fakeTimer.reset();
   });
 
+  // Coordination tests never need to control time explicitly: the barrier lifts
+  // synchronously when the last device arrives, and work/staggering sleeps just
+  // need to resolve so concurrent promises make progress. Auto-advance resolves
+  // those sleeps asynchronously while preserving deadline order, so a
+  // still-held mutex's blocked work does not deadlock the test.
   const wait = async (ms: number): Promise<void> => {
-    const promise = defaultTimer.sleep(ms);
-    fakeTimer.advanceTime(ms);
-    await promise;
+    await fakeTimer.sleep(ms);
   };
 
   test("allows single device to immediately enter critical section", async () => {
+    fakeTimer.enableAutoAdvance();
     coordinator.registerExpectedDevices("lock-1", 1);
 
-    const start = Date.now();
+    const start = fakeTimer.now();
     const release = await coordinator.enterCriticalSection("lock-1", "device-1");
-    const elapsed = Date.now() - start;
+    const elapsed = fakeTimer.now() - start;
 
     expect(elapsed).toBeLessThan(100); // Should not wait
     release();
   });
 
   test("waits for all devices to arrive at barrier before releasing any", async () => {
+    fakeTimer.enableAutoAdvance();
     const lockName = "lock-2";
     const deviceCount = 3;
     coordinator.registerExpectedDevices(lockName, deviceCount);
@@ -66,13 +54,13 @@ describe("CriticalSectionCoordinator", () => {
       async (deviceId, index) => {
         // Stagger arrivals slightly
         await wait(index * 10);
-        arrivals.push({ deviceId, arrivedAt: Date.now() });
+        arrivals.push({ deviceId, arrivedAt: fakeTimer.now() });
 
         const release = await coordinator.enterCriticalSection(
           lockName,
           deviceId
         );
-        releases.push({ deviceId, releasedAt: Date.now() });
+        releases.push({ deviceId, releasedAt: fakeTimer.now() });
 
         release();
       }
@@ -93,6 +81,7 @@ describe("CriticalSectionCoordinator", () => {
   });
 
   test("executes steps serially within critical section", async () => {
+    fakeTimer.enableAutoAdvance();
     const lockName = "lock-3";
     const deviceCount = 2;
     coordinator.registerExpectedDevices(lockName, deviceCount);
@@ -103,9 +92,9 @@ describe("CriticalSectionCoordinator", () => {
     const deviceWork = async (deviceId: string) => {
       const release = await coordinator.enterCriticalSection(lockName, deviceId);
 
-      executionLog.push({ deviceId, event: "start", time: Date.now() });
+      executionLog.push({ deviceId, event: "start", time: fakeTimer.now() });
       await wait(20);
-      executionLog.push({ deviceId, event: "end", time: Date.now() });
+      executionLog.push({ deviceId, event: "end", time: fakeTimer.now() });
 
       release();
     };
@@ -202,6 +191,7 @@ describe("CriticalSectionCoordinator", () => {
   });
 
   test("schedules cleanup after devices finish", async () => {
+    fakeTimer.enableAutoAdvance();
     const lockName = "lock-8";
     coordinator.registerExpectedDevices(lockName, 2);
 
@@ -229,6 +219,7 @@ describe("CriticalSectionCoordinator", () => {
   });
 
   test("supports multiple independent locks concurrently", async () => {
+    fakeTimer.enableAutoAdvance();
     coordinator.registerExpectedDevices("lock-A", 2);
     coordinator.registerExpectedDevices("lock-B", 2);
 
@@ -285,7 +276,8 @@ describe("CriticalSectionCoordinator", () => {
     const lockName = "lock-timeout-clear";
     coordinator.registerExpectedDevices(lockName, 2);
 
-    // Both devices enter concurrently and release immediately
+    // Both devices enter concurrently and release immediately. The barrier lifts
+    // synchronously when the second device arrives, so no time advance is needed.
     await Promise.all([
       (async () => {
         const release = await coordinator.enterCriticalSection(lockName, "device-1", 30000);
@@ -306,6 +298,7 @@ describe("CriticalSectionCoordinator", () => {
   });
 
   test("allows lock reuse after all devices complete", async () => {
+    fakeTimer.enableAutoAdvance();
     const lockName = "lock-reuse";
 
     // First round
@@ -339,6 +332,7 @@ describe("CriticalSectionCoordinator", () => {
   });
 
   test("handles reregistration of same lock after cleanup", async () => {
+    fakeTimer.enableAutoAdvance();
     const lockName = "lock-10";
 
     // First round


### PR DESCRIPTION
## Summary

Child of [#4528](https://github.com/kaeawc/auto-mobile/issues/4528) / [#4183](https://github.com/kaeawc/auto-mobile/issues/4183) item 14 (R7/R8). Introduces an injected `Timer` seam on `CriticalSectionCoordinator` and rewrites its tests to use a `FakeTimer` instead of global `setTimeout` / `clearTimeout` / `Date.now` patching.

## Source change (seam landed first)
- `CriticalSectionCoordinator` now holds an injected `private readonly timer: Timer`, defaulting to the real `defaultTimer`. All internal `defaultTimer.setTimeout` / `clearTimeout` calls route through `this.timer`.
- Added `CriticalSectionCoordinator.createForTesting(timer)` (matches the repo's `createForTesting` convention, e.g. `FailureRecorder`, `NavigationGraphManager`) so tests get an isolated instance with a `FakeTimer`.
- `getInstance()` (used by `barrierTools`/`criticalSectionTools`/`PlanExecutor`) is unchanged — production keeps the real timer.

## Test change
- Removed all global timer/`Date.now` patching. Tests inject a `FakeTimer` via `createForTesting`.
- Timeout tests advance fake time explicitly (`advanceTime`); coordination tests enable `enableAutoAdvance()` so barrier work/staggering sleeps resolve deterministically without a real clock. Time is read via `fakeTimer.now()` (no new `Date.now()`).

## Acceptance criteria
- [x] `CriticalSectionCoordinator` takes an injected `Timer` (real default, fake in tests).
- [x] No global timer patching remains in its tests.
- [x] Deterministic, <100ms.

## Validation
- `bun test test/server/CriticalSectionCoordinator.test.ts` — 18 pass
- `bun test test/lint/` — 194 pass
- `bun test test/server/` — 1554 pass
- `bun run typecheck` — no new type errors
- `bun run lint` — clean

Closes [#4658](https://github.com/kaeawc/auto-mobile/issues/4658)
