### PR TITLE
refactor(host): centralize host defaults execution behind HostDefaultsClient

### DIFF
--- a/src/utils/HostDefaultsClient.ts
+++ b/src/utils/HostDefaultsClient.ts
@@ -1,0 +1,82 @@
+import { DefaultHostCommandExecutor, type HostCommandExecutor } from "./HostCommandExecutor";
+import { logger } from "./logger";
+
+/**
+ * The macOS host `defaults` binary. This client is the single production owner
+ * that resolves and executes it for host-only reads (issue #4062). Simulator
+ * `defaults` commands run inside a booted simulator via `xcrun simctl spawn` and
+ * belong to `SimCtlClient`; they are intentionally not routed through here.
+ */
+const DEFAULTS_BINARY = "defaults";
+const GLOBAL_DOMAIN_FLAG = "-g";
+
+/** `defaults read` is a trivial host lookup; keep the ceiling short. */
+const DEFAULT_READ_TIMEOUT_MS = 2000;
+
+export interface HostDefaultsReadOptions {
+  /** Override the read timeout. Defaults to {@link DEFAULT_READ_TIMEOUT_MS}. */
+  timeoutMs?: number;
+  /** Cancellation signal propagated to the underlying exec seam. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Host-only reads of the macOS `defaults` CLI. Returns the trimmed scalar value,
+ * or `null` when the key is unset, the value is empty, the CLI is absent, or the
+ * host is not macOS. Callers treat `null` as "unknown" and fall back.
+ */
+export interface HostDefaultsClient {
+  /** Whether host `defaults` is available on this platform (macOS only). */
+  isSupported(): boolean;
+  /** Read a key from the global (`-g`) domain. */
+  readGlobal(key: string, options?: HostDefaultsReadOptions): Promise<string | null>;
+}
+
+export interface HostDefaultsClientDependencies {
+  executor: HostCommandExecutor;
+  platform: NodeJS.Platform;
+  logger: Pick<typeof logger, "debug">;
+}
+
+function defaultDependencies(): HostDefaultsClientDependencies {
+  return {
+    executor: new DefaultHostCommandExecutor(),
+    platform: process.platform,
+    logger,
+  };
+}
+
+export class DefaultHostDefaultsClient implements HostDefaultsClient {
+  constructor(
+    private readonly dependencies: HostDefaultsClientDependencies = defaultDependencies()
+  ) {}
+
+  isSupported(): boolean {
+    return this.dependencies.platform === "darwin";
+  }
+
+  async readGlobal(key: string, options: HostDefaultsReadOptions = {}): Promise<string | null> {
+    if (!this.isSupported()) {
+      return null;
+    }
+
+    try {
+      const result = await this.dependencies.executor.executeCommand(
+        DEFAULTS_BINARY,
+        ["read", GLOBAL_DOMAIN_FLAG, key],
+        {
+          timeoutMs: options.timeoutMs ?? DEFAULT_READ_TIMEOUT_MS,
+          signal: options.signal,
+        }
+      );
+      const value = result.stdout.trim();
+      return value.length > 0 ? value : null;
+    } catch (error) {
+      // `defaults read -g <key>` exits non-zero when the key has never been set
+      // (e.g. no AppleInterfaceStyle in light mode) or the CLI is missing. Both
+      // mean "unknown", so null lets callers fall back to their default.
+      this.dependencies.logger.debug(`host defaults read -g ${key} failed: ${error}`, error);
+      return null;
+    }
+  }
+}

--- a/src/utils/hostAppearance.ts
+++ b/src/utils/hostAppearance.ts
@@ -1,6 +1,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import type { AppearanceMode } from "../models";
+import { DefaultHostDefaultsClient, type HostDefaultsClient } from "./HostDefaultsClient";
 import { logger } from "./logger";
 
 const execFileAsync = promisify(execFile);
@@ -31,13 +32,12 @@ function isDarkThemeValue(value: string): boolean {
   return normalized.includes("dark") || normalized.includes("prefer-dark");
 }
 
-export async function detectHostAppearance(): Promise<AppearanceMode> {
-  if (process.platform === "darwin") {
-    const result = await runCommand("defaults", ["read", "-g", "AppleInterfaceStyle"]);
-    if (result && result.stdout.trim().toLowerCase() === "dark") {
-      return "dark";
-    }
-    return "light";
+export async function detectHostAppearance(
+  hostDefaults: HostDefaultsClient = new DefaultHostDefaultsClient()
+): Promise<AppearanceMode> {
+  if (hostDefaults.isSupported()) {
+    const style = await hostDefaults.readGlobal("AppleInterfaceStyle");
+    return style?.toLowerCase() === "dark" ? "dark" : "light";
   }
 
   if (process.platform === "linux") {

--- a/test/lint/hostDefaultsExecutionBoundary.test.ts
+++ b/test/lint/hostDefaultsExecutionBoundary.test.ts
@@ -5,6 +5,36 @@ import { join, relative } from "node:path";
 const ROOT = join(import.meta.dir, "..", "..");
 const OWNER = "src/utils/HostDefaultsClient.ts";
 
+// child_process launch primitives, plus the executor-seam method the repo uses
+// (`HostCommandExecutor.executeCommand`). Callers that promisify or otherwise
+// alias one of these are recovered separately via `wrapperNames`.
+const LAUNCHER_NAMES = "spawn|spawnSync|spawnCommand|exec|execSync|execFile|execFileSync|executeCommand";
+// Opening string-literal quote: single, double, or backtick.
+const QUOTE = "[\"'`]";
+
+/**
+ * Names bound to a promisified/aliased `child_process` launcher, e.g.
+ * `const execFileAsync = promisify(execFile);` or `const run = execFile;`. Such
+ * a name invoked with a leading `"defaults"` literal is the same violation as a
+ * direct launcher call — the guard must recognize the launch semantically, not
+ * only the literal `execFile("defaults"` spelling.
+ *
+ * Bounded by design: this covers the concrete promisify/alias evasions the repo
+ * actually uses (see `src/utils/hostAppearance.ts`, `HostCommandExecutor.ts`).
+ * A launcher smuggled through a data structure, a computed member, or a
+ * cross-module indirection is out of scope for this regex detector; a new
+ * production `defaults` path in those exotic forms would need a manual review
+ * catch, and this comment marks the deliberate limit.
+ */
+function wrapperNames(source: string): string[] {
+  // const <name> = promisify(execFile) | util.promisify(exec) | execFile;
+  const pattern = new RegExp(
+    String.raw`\b(?:const|let|var)\s+(\w+)\s*=\s*(?:(?:\w+\.)?promisify\s*\(\s*(?:${LAUNCHER_NAMES})\s*\)|(?:${LAUNCHER_NAMES}))\s*;`,
+    "g"
+  );
+  return [...source.matchAll(pattern)].map(match => match[1]);
+}
+
 /**
  * Detects direct production execution of the host `defaults` binary (issue
  * #4062). Only the first-argument form is a violation: simulator `defaults`
@@ -14,12 +44,20 @@ const OWNER = "src/utils/HostDefaultsClient.ts";
  */
 export function directlyExecutesHostDefaults(source: string): boolean {
   // execFile("defaults", ...) / spawn("defaults", ...) / executeCommand("defaults", ...)
-  const literalFirstArg = /\b(?:spawn|spawnSync|spawnCommand|exec|execSync|execFile|execFileSync|executeCommand)\s*\(\s*["'`]defaults["'`]/;
+  const literalFirstArg = new RegExp(String.raw`\b(?:${LAUNCHER_NAMES})\s*\(\s*${QUOTE}defaults${QUOTE}`);
   // exec("defaults read -g ...") — shell string whose command word is `defaults`.
-  const shellString = /\b(?:exec|execSync)\s*\(\s*["'`]defaults\s/;
+  const shellString = new RegExp(String.raw`\b(?:exec|execSync)\s*\(\s*${QUOTE}defaults\s`);
   // Bun.spawn(["defaults", ...]) — argv array whose first element is the binary.
-  const bunSpawn = /\bBun\.spawn\s*\(\s*\[\s*["'`]defaults["'`]/;
-  return literalFirstArg.test(source) || shellString.test(source) || bunSpawn.test(source);
+  const bunSpawn = new RegExp(String.raw`\bBun\.spawn\s*\(\s*\[\s*${QUOTE}defaults${QUOTE}`);
+  if (literalFirstArg.test(source) || shellString.test(source) || bunSpawn.test(source)) {
+    return true;
+  }
+
+  // A promisified/aliased launcher invoked as `<name>("defaults", ...)`, where
+  // `<name>` is a launcher captured by `wrapperNames` (e.g. `execFileAsync`).
+  return wrapperNames(source).some(name =>
+    new RegExp(String.raw`\b${name}\s*\(\s*${QUOTE}defaults[\s${QUOTE.slice(1, -1)}]`).test(source)
+  );
 }
 
 function sourceFiles(directory: string): string[] {
@@ -57,6 +95,19 @@ describe("host defaults execution boundary (issue #4062)", () => {
     expect(directlyExecutesHostDefaults('await executor.executeCommand("defaults", ["read", "-g", key]);')).toBe(true);
     expect(directlyExecutesHostDefaults('exec("defaults read -g AppleInterfaceStyle");')).toBe(true);
     expect(directlyExecutesHostDefaults('Bun.spawn(["defaults", "read", "-g", key]);')).toBe(true);
+  });
+
+  test("flags a promisified or aliased launcher invoked with defaults", () => {
+    // The original hostAppearance.ts evasion: promisify(execFile) then call the wrapper.
+    expect(directlyExecutesHostDefaults(
+      'const execFileAsync = promisify(execFile); await execFileAsync("defaults", ["read", "-g", key]);'
+    )).toBe(true);
+    expect(directlyExecutesHostDefaults(
+      'const run = util.promisify(exec); await run("defaults read -g AppleInterfaceStyle");'
+    )).toBe(true);
+    expect(directlyExecutesHostDefaults(
+      'const launch = execFile; launch("defaults", ["read", "-g", key]);'
+    )).toBe(true);
   });
 
   test("does not flag simulator defaults routed through a simctl argv", () => {

--- a/test/lint/hostDefaultsExecutionBoundary.test.ts
+++ b/test/lint/hostDefaultsExecutionBoundary.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const ROOT = join(import.meta.dir, "..", "..");
+const OWNER = "src/utils/HostDefaultsClient.ts";
+
+/**
+ * Detects direct production execution of the host `defaults` binary (issue
+ * #4062). Only the first-argument form is a violation: simulator `defaults`
+ * commands pass `"defaults"` as a later element of a `simctl spawn` argv (e.g.
+ * `["spawn", udid, "defaults", ...]`), so keying on the launch call's *first*
+ * argument leaves those SimCtlClient paths untouched.
+ */
+export function directlyExecutesHostDefaults(source: string): boolean {
+  // execFile("defaults", ...) / spawn("defaults", ...) / executeCommand("defaults", ...)
+  const literalFirstArg = /\b(?:spawn|spawnSync|spawnCommand|exec|execSync|execFile|execFileSync|executeCommand)\s*\(\s*["'`]defaults["'`]/;
+  // exec("defaults read -g ...") — shell string whose command word is `defaults`.
+  const shellString = /\b(?:exec|execSync)\s*\(\s*["'`]defaults\s/;
+  // Bun.spawn(["defaults", ...]) — argv array whose first element is the binary.
+  const bunSpawn = /\bBun\.spawn\s*\(\s*\[\s*["'`]defaults["'`]/;
+  return literalFirstArg.test(source) || shellString.test(source) || bunSpawn.test(source);
+}
+
+function sourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {return sourceFiles(path);}
+    return entry.name.endsWith(".ts") ? [path] : [];
+  });
+}
+
+describe("host defaults execution boundary (issue #4062)", () => {
+  test("only HostDefaultsClient directly executes the host defaults binary", () => {
+    const exceptions = new Map<string, string>([
+      // Diagnostic-only references are allowed only with a concrete reason here.
+    ]);
+    const files = sourceFiles(join(ROOT, "src"));
+    // A silently-empty scan yields zero offenders and passes green while checking nothing.
+    expect(files.length).toBeGreaterThan(100);
+
+    const offenders = files.flatMap(file => {
+      const repoPath = relative(ROOT, file).split("\\").join("/");
+      if (repoPath === OWNER || exceptions.has(repoPath)) {return [];}
+      const source = readFileSync(file, "utf8");
+      return directlyExecutesHostDefaults(source)
+        ? [`${repoPath} directly executes host defaults; route it through ${OWNER} instead.`]
+        : [];
+    });
+
+    expect(offenders, offenders.join("\n")).toEqual([]);
+  });
+
+  test("flags direct launcher invocations of defaults", () => {
+    expect(directlyExecutesHostDefaults('execFile("defaults", ["read", "-g", key]);')).toBe(true);
+    expect(directlyExecutesHostDefaults('spawn("defaults", ["read", "-g", "AppleInterfaceStyle"]);')).toBe(true);
+    expect(directlyExecutesHostDefaults('await executor.executeCommand("defaults", ["read", "-g", key]);')).toBe(true);
+    expect(directlyExecutesHostDefaults('exec("defaults read -g AppleInterfaceStyle");')).toBe(true);
+    expect(directlyExecutesHostDefaults('Bun.spawn(["defaults", "read", "-g", key]);')).toBe(true);
+  });
+
+  test("does not flag simulator defaults routed through a simctl argv", () => {
+    expect(directlyExecutesHostDefaults('simctl.executeCommandArgs(["spawn", udid, "defaults", "read", domain, key]);')).toBe(false);
+    expect(directlyExecutesHostDefaults('spawn("xcrun", ["simctl", "spawn", udid, "defaults", "read"]);')).toBe(false);
+  });
+
+  test("every documented exception still exists", () => {
+    const exceptions = new Map<string, string>([
+      // Keep this list empty unless a production diagnostic cannot use the client.
+    ]);
+    const files = sourceFiles(join(ROOT, "src"));
+    expect([...exceptions.keys()].filter(path => !files.some(file => relative(ROOT, file).split("\\").join("/") === path))).toEqual([]);
+  });
+});

--- a/test/utils/HostDefaultsClient.test.ts
+++ b/test/utils/HostDefaultsClient.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DefaultHostDefaultsClient,
+  type HostDefaultsClientDependencies,
+} from "../../src/utils/HostDefaultsClient";
+import type { HostCommandExecutor, HostCommandOptions } from "../../src/utils/HostCommandExecutor";
+import type { ExecResult } from "../../src/models";
+
+function execResult(stdout: string, stderr = ""): ExecResult {
+  return {
+    stdout,
+    stderr,
+    toString: () => stdout,
+    trim: () => stdout.trim(),
+    includes: (search: string) => stdout.includes(search),
+  };
+}
+
+interface RecordedCall {
+  file: string;
+  args: string[];
+  options?: HostCommandOptions;
+}
+
+function recordingExecutor(
+  respond: (file: string, args: string[]) => ExecResult | Promise<ExecResult>
+): { executor: HostCommandExecutor; calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  const executor: HostCommandExecutor = {
+    async executeCommand(file, args = [], options) {
+      calls.push({ file, args, options });
+      return respond(file, args);
+    },
+  };
+  return { executor, calls };
+}
+
+function deps(
+  overrides: Partial<HostDefaultsClientDependencies> & Pick<HostDefaultsClientDependencies, "executor">
+): HostDefaultsClientDependencies {
+  return {
+    platform: "darwin",
+    logger: { debug: () => {} },
+    ...overrides,
+  };
+}
+
+describe("HostDefaultsClient", () => {
+  test("reports macOS support only on darwin", () => {
+    const { executor } = recordingExecutor(() => execResult(""));
+    expect(new DefaultHostDefaultsClient(deps({ executor, platform: "darwin" })).isSupported()).toBe(true);
+    expect(new DefaultHostDefaultsClient(deps({ executor, platform: "linux" })).isSupported()).toBe(false);
+    expect(new DefaultHostDefaultsClient(deps({ executor, platform: "win32" })).isSupported()).toBe(false);
+  });
+
+  test("returns the trimmed dark value via argv against the global domain", async () => {
+    const { executor, calls } = recordingExecutor(() => execResult("Dark\n"));
+    const client = new DefaultHostDefaultsClient(deps({ executor }));
+
+    expect(await client.readGlobal("AppleInterfaceStyle")).toBe("Dark");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].file).toBe("defaults");
+    expect(calls[0].args).toEqual(["read", "-g", "AppleInterfaceStyle"]);
+    expect(calls[0].options?.timeoutMs).toBe(2000);
+  });
+
+  test("returns the trimmed light value", async () => {
+    const { executor } = recordingExecutor(() => execResult("Light"));
+    const client = new DefaultHostDefaultsClient(deps({ executor }));
+    expect(await client.readGlobal("AppleInterfaceStyle")).toBe("Light");
+  });
+
+  test("treats an empty value as unset (null)", async () => {
+    const { executor } = recordingExecutor(() => execResult("   \n"));
+    const client = new DefaultHostDefaultsClient(deps({ executor }));
+    expect(await client.readGlobal("AppleInterfaceStyle")).toBeNull();
+  });
+
+  test("returns null and logs when the command fails (unset key or absent CLI)", async () => {
+    const messages: string[] = [];
+    const executor: HostCommandExecutor = {
+      async executeCommand() {
+        throw new Error("The domain/default pair does not exist");
+      },
+    };
+    const client = new DefaultHostDefaultsClient(
+      deps({ executor, logger: { debug: (message: string) => messages.push(message) } })
+    );
+
+    expect(await client.readGlobal("AppleInterfaceStyle")).toBeNull();
+    expect(messages.some(message => message.includes("AppleInterfaceStyle"))).toBe(true);
+  });
+
+  test("does not execute anything on non-macOS hosts", async () => {
+    const { executor, calls } = recordingExecutor(() => execResult("Dark"));
+    const client = new DefaultHostDefaultsClient(deps({ executor, platform: "linux" }));
+
+    expect(await client.readGlobal("AppleInterfaceStyle")).toBeNull();
+    expect(calls).toHaveLength(0);
+  });
+
+  test("forwards an explicit timeout and abort signal", async () => {
+    const { executor, calls } = recordingExecutor(() => execResult("Dark"));
+    const client = new DefaultHostDefaultsClient(deps({ executor }));
+    const controller = new AbortController();
+
+    await client.readGlobal("AppleInterfaceStyle", { timeoutMs: 500, signal: controller.signal });
+    expect(calls[0].options?.timeoutMs).toBe(500);
+    expect(calls[0].options?.signal).toBe(controller.signal);
+  });
+});

--- a/test/utils/hostAppearance.test.ts
+++ b/test/utils/hostAppearance.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { detectHostAppearance } from "../../src/utils/hostAppearance";
+import type { HostDefaultsClient } from "../../src/utils/HostDefaultsClient";
+
+function fakeHostDefaults(supported: boolean, value: string | null): HostDefaultsClient {
+  return {
+    isSupported: () => supported,
+    readGlobal: async () => value,
+  };
+}
+
+describe("detectHostAppearance", () => {
+  test("resolves dark when the injected host client reports Dark", async () => {
+    expect(await detectHostAppearance(fakeHostDefaults(true, "Dark"))).toBe("dark");
+  });
+
+  test("resolves light when the value is unset (null) on a supported host", async () => {
+    expect(await detectHostAppearance(fakeHostDefaults(true, null))).toBe("light");
+  });
+
+  test("resolves light for any non-dark value", async () => {
+    expect(await detectHostAppearance(fakeHostDefaults(true, "Light"))).toBe("light");
+  });
+});


### PR DESCRIPTION
## Summary

Host appearance detection executed the macOS `defaults` CLI directly via `execFile`. This routes it through a single injected, typed owner — `HostDefaultsClient` — mirroring the repo's existing execution-boundary pattern (`ffmpeg-execution-boundary`, `daemon-launcher-boundary`, `simulator-tcc-sqlite-boundary`, `avdmanager`/`sdkmanager`).

## What changed

- **`src/utils/HostDefaultsClient.ts`** (new owner): `HostDefaultsClient` interface + `DefaultHostDefaultsClient`. Host-only `defaults` reads that are argv-first (`["read", "-g", key]`), platform-gated to macOS (`isSupported()`), execute through the injected `HostCommandExecutor` seam (reusing the shared `runExecSeam`/`createExecResult` helpers — no re-inlined exec), carry a short timeout and cancellation signal, and return `null` on unset/empty/absent-CLI/non-macOS.
- **`src/utils/hostAppearance.ts`**: `detectHostAppearance` now takes an injectable `HostDefaultsClient` (default `DefaultHostDefaultsClient`) and delegates the macOS branch to it. Behavior preserved; Linux `gsettings`/KDE branches untouched.
- **`test/lint/hostDefaultsExecutionBoundary.test.ts`** (new static check): blocks new direct production execution of the host `defaults` binary outside the owner. Keyed on the launch call's *first* argument, so simulator `defaults` routed through a `simctl spawn` argv (`["spawn", udid, "defaults", ...]`) is intentionally not flagged.

Simulator `defaults` commands remain with `SimCtlClient` — intentionally out of scope per the issue.

## Tests

- `HostDefaultsClient`: dark / light / unset-empty / command-failure (unset key or absent CLI) / non-macOS no-exec / timeout+signal forwarding.
- `detectHostAppearance`: dark, unset→light, non-dark→light via injected fake.
- Boundary guard: positive launcher forms, negative simctl-argv forms, non-empty scan, exception-existence.

## Validation

- `bun test test/lint/` — 198 pass
- New + appearance tests — pass
- `bun run typecheck` — no new errors
- `bun run lint` — clean (all boundary guards pass)
- `bun run build` — success

Closes [#4062](https://github.com/kaeawc/auto-mobile/issues/4062)
