### PR TITLE
refactor(ios): centralize xcrun devicectl execution behind DeviceAppManager

### DIFF
--- a/src/server/appResources.ts
+++ b/src/server/appResources.ts
@@ -3,15 +3,10 @@ import { PlatformDeviceManagerFactory } from "../utils/factories/PlatformDeviceM
 import { ListInstalledApps } from "../features/observe/ListInstalledApps";
 import { GetAppMetadata, IosAppMetadataSource } from "../features/observe/GetAppMetadata";
 import { SimCtlClient } from "../utils/ios-cmdline-tools/SimCtlClient";
-import { findBundleEntry } from "../utils/ios-cmdline-tools/DeviceAppManager";
+import { DeviceAppManager } from "../utils/ios-cmdline-tools/DeviceAppManager";
 import { BootedDevice, InstalledApp, InstalledAppsByProfile, Platform, SystemInstalledApp } from "../models";
 import { logger } from "../utils/logger";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
-import { promises as nodeFs } from "fs";
-import { tmpdir as nodeTmpdir } from "os";
-import { join as nodeJoin } from "path";
-import { execFile as nodeExecFile } from "child_process";
-import { promisify } from "util";
 
 // Resource URI templates
 export const APP_RESOURCE_TEMPLATES = {
@@ -748,37 +743,15 @@ function metadataCacheKey(deviceId: string, appId: string): string {
   return `${deviceId}:${appId}`;
 }
 
-const execFileAsync = promisify(nodeExecFile);
-
 function createIosMetadataSource(device: BootedDevice): IosAppMetadataSource {
   const simctl = new SimCtlClient(device);
+  // Physical-device app metadata resolves through DeviceAppManager, the single
+  // typed devicectl boundary (issue #4053) — no direct xcrun composition here.
+  const deviceAppManager = new DeviceAppManager();
   return {
     listApps: (deviceId?: string) => simctl.listApps(deviceId),
-    getPhysicalDeviceAppInfo: async (deviceId: string, bundleId: string) => {
-      // devicectl requires macOS; match DeviceAppManager's platform guard.
-      if (process.platform !== "darwin") {
-        return null;
-      }
-      const tempDir = await nodeFs.mkdtemp(nodeJoin(nodeTmpdir(), "automobile-metadata-"));
-      const jsonPath = nodeJoin(tempDir, "apps.json");
-      try {
-        await execFileAsync("xcrun", [
-          "devicectl", "device", "info", "apps",
-          "--device", deviceId,
-          "--bundle-id", bundleId,
-          "--json-output", jsonPath,
-          "--quiet"
-        ]);
-        const raw = await nodeFs.readFile(jsonPath, "utf-8");
-        const data = JSON.parse(raw);
-        return findBundleEntry(data, bundleId);
-      } catch (error) {
-        logger.warn(`[AppResources] Failed to get physical device app info for ${bundleId}: ${error}`);
-        return null;
-      } finally {
-        await nodeFs.rm(tempDir, { recursive: true, force: true });
-      }
-    }
+    getPhysicalDeviceAppInfo: (deviceId: string, bundleId: string) =>
+      deviceAppManager.getInstalledAppInfo(deviceId, bundleId)
   };
 }
 

--- a/src/utils/ios-cmdline-tools/DeviceAppManager.ts
+++ b/src/utils/ios-cmdline-tools/DeviceAppManager.ts
@@ -746,13 +746,14 @@ export class DeviceAppManager implements DeviceUrlLauncher {
   }
 
   /**
-   * Resolve the on-device installed bundle path for `bundleId` via
-   * `devicectl device info apps --bundle-id`. Returns null when the app isn't
-   * installed (no matching bundle entry / no resolvable path); devicectl exec or
-   * JSON-read failures propagate so a broken devicectl surfaces rather than
-   * masquerading as "not installed". macOS-only (callers guard the platform).
+   * Query the on-device `devicectl device info apps --bundle-id` payload and
+   * return the matching bundle entry (raw devicectl record), or null when the
+   * app isn't installed. devicectl exec / JSON-read failures PROPAGATE so a
+   * broken devicectl surfaces rather than masquerading as "not installed".
+   * macOS-only (callers guard the platform). Shared core behind
+   * {@link resolveInstalledBundlePathOnDevice} and {@link getInstalledAppInfo}.
    */
-  private async resolveInstalledBundlePathOnDevice(deviceUdid: string, bundleId: string): Promise<string | null> {
+  private async queryInstalledAppEntry(deviceUdid: string, bundleId: string): Promise<Record<string, unknown> | null> {
     const tempDir = await this.deps.mkdtemp(join(this.deps.tmpdir(), "automobile-devicectl-"));
     const jsonPath = join(tempDir, "apps.json");
     try {
@@ -770,14 +771,45 @@ export class DeviceAppManager implements DeviceUrlLauncher {
 
       const raw = await this.deps.readFile(jsonPath);
       const data = JSON.parse(raw) as unknown;
-      const entry = findBundleEntry(data, bundleId);
-      if (!entry) {
-        return null;
-      }
-      return extractBundlePath(entry);
+      return findBundleEntry(data, bundleId);
     } finally {
       await this.deps.rm(tempDir);
     }
+  }
+
+  /**
+   * Best-effort metadata read: return the on-device `devicectl device info apps`
+   * bundle entry for `bundleId`, or null. Unlike {@link queryInstalledAppEntry},
+   * this is non-throwing — it returns null off macOS (no devicectl) and logs a
+   * warning then returns null on any devicectl/JSON failure, matching the
+   * diagnostic contract of the app-metadata resource that consumes it (a lookup
+   * failure degrades to "no metadata" rather than surfacing as an error).
+   */
+  public async getInstalledAppInfo(deviceUdid: string, bundleId: string): Promise<Record<string, unknown> | null> {
+    if (this.deps.platform() !== "darwin") {
+      return null;
+    }
+    try {
+      return await this.queryInstalledAppEntry(deviceUdid, bundleId);
+    } catch (error) {
+      this.deps.logger.warn(`[DeviceAppManager] Failed to get physical device app info for ${bundleId}: ${getErrorMessage(error)}`);
+      return null;
+    }
+  }
+
+  /**
+   * Resolve the on-device installed bundle path for `bundleId` via
+   * `devicectl device info apps --bundle-id`. Returns null when the app isn't
+   * installed (no matching bundle entry / no resolvable path); devicectl exec or
+   * JSON-read failures propagate so a broken devicectl surfaces rather than
+   * masquerading as "not installed". macOS-only (callers guard the platform).
+   */
+  private async resolveInstalledBundlePathOnDevice(deviceUdid: string, bundleId: string): Promise<string | null> {
+    const entry = await this.queryInstalledAppEntry(deviceUdid, bundleId);
+    if (!entry) {
+      return null;
+    }
+    return extractBundlePath(entry);
   }
 
   /**

--- a/test/lint/devicectlExecutionBoundary.test.ts
+++ b/test/lint/devicectlExecutionBoundary.test.ts
@@ -6,19 +6,39 @@ const ROOT = join(import.meta.dir, "..", "..");
 const OWNER = "src/utils/ios-cmdline-tools/DeviceAppManager.ts";
 
 /**
- * True when `source` hands `devicectl` to a process launcher directly — i.e. a
- * production call that bypasses the single {@link OWNER} boundary. We look for a
- * launcher primitive (exec/execFile/spawn family, promisified or not, plus
- * `Bun.spawn`) whose argument list contains a `devicectl` string literal.
+ * True when `source` hands `devicectl` to a subprocess directly — i.e. a
+ * production call that bypasses the single {@link OWNER} boundary. Two shapes
+ * are caught:
+ *
+ * 1. A launcher primitive (exec/execFile/spawn family, promisified or not, plus
+ *    `Bun.spawn`) whose argument list contains a `devicectl` string literal.
+ * 2. An INDIRECT launch through the repo's own exec seam —
+ *    `HostCommandExecutor.executeCommand("xcrun", ["devicectl", ...])` or a
+ *    direct `runExecSeam(...)` — i.e. an `executeCommand`/`runExecSeam` call
+ *    whose argv carries both the `xcrun` file and a `devicectl` verb literal.
+ *    Requiring the `xcrun` literal keeps benign `executeCommand("adb", ...)` /
+ *    `executeCommand("xcrun", ["simctl", ...])` calls off the offender list.
+ *
  * DeviceAppManager itself never trips this: it routes every invocation through
- * its injected `execute` seam, not a launcher primitive.
+ * its injected `execute` seam with the `file`/`args` VARIABLES (no `xcrun` /
+ * `devicectl` literal at the call site), and it is the exempt {@link OWNER}.
+ *
+ * Residual limit: the seam regex scans across a single statement (no `;`), so it
+ * would miss a `devicectl` literal hidden behind a block-bodied
+ * `runExecSeam(() => { ...; })` callback. That indirection does not exist in the
+ * repo (the only seam is `executeCommand`, whose argv is a flat literal array),
+ * and any such rewrite would still surface through the launcher-primitive branch.
  */
 function directlyExecutesDevicectl(source: string): boolean {
   const launcherWithDevicectl =
     /\b(?:exec|execSync|execFile|execFileSync|execFileAsync|spawn|spawnSync|spawnCommand)\s*\([^;]*?["'`][^"'`]*\bdevicectl\b/;
   const bunSpawnWithDevicectl =
     /Bun\.spawn\s*\(\s*\[[^\]]*?["'`][^"'`]*\bdevicectl\b/;
-  return launcherWithDevicectl.test(source) || bunSpawnWithDevicectl.test(source);
+  const seamXcrunDevicectl =
+    /\b(?:executeCommand|runExecSeam)\s*\([^;]*?["'`]xcrun["'`][^;]*?\bdevicectl\b/;
+  return launcherWithDevicectl.test(source)
+    || bunSpawnWithDevicectl.test(source)
+    || seamXcrunDevicectl.test(source);
 }
 
 function sourceFiles(directory: string): string[] {
@@ -64,10 +84,32 @@ describe("devicectl execution boundary (issue #4053)", () => {
     )).toBe(true);
   });
 
-  test("does not flag the injected execute seam or comments", () => {
-    // DeviceAppManager routes through this.execute(...), not a launcher primitive.
+  test("detects INDIRECT devicectl launches through the repo exec seam", () => {
+    // HostCommandExecutor.executeCommand("xcrun", ["devicectl", ...]) bypasses
+    // the owner just as surely as a raw execFile would.
+    expect(directlyExecutesDevicectl(
+      'await this.processExecutor.executeCommand("xcrun", ["devicectl", "device", "info", "apps"]);'
+    )).toBe(true);
+    expect(directlyExecutesDevicectl(
+      'await executeCommand("xcrun", [\n  "devicectl", "device", "install", "app"\n]);'
+    )).toBe(true);
+    expect(directlyExecutesDevicectl(
+      'runExecSeam(cb, opts, { command: "xcrun", args: ["devicectl", "--version"] });'
+    )).toBe(true);
+  });
+
+  test("does not flag the injected execute seam, sibling tools, or comments", () => {
+    // DeviceAppManager's injected `execute(file, args)` dep is not a launcher.
     expect(directlyExecutesDevicectl(
       'await this.execute("xcrun", ["devicectl", "device", "uninstall", "app"]);'
+    )).toBe(false);
+    // The owner's default dep routes VARIABLES through the seam — no literals.
+    expect(directlyExecutesDevicectl(
+      "return new DefaultHostCommandExecutor().executeCommand(file, args);"
+    )).toBe(false);
+    // A sibling xcrun tool (simctl) through the same seam is not a devicectl call.
+    expect(directlyExecutesDevicectl(
+      'await this.processExecutor.executeCommand("xcrun", ["simctl", "list", "devices"]);'
     )).toBe(false);
     // Prose mentioning devicectl must not be a violation.
     expect(directlyExecutesDevicectl(

--- a/test/lint/devicectlExecutionBoundary.test.ts
+++ b/test/lint/devicectlExecutionBoundary.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const ROOT = join(import.meta.dir, "..", "..");
+const OWNER = "src/utils/ios-cmdline-tools/DeviceAppManager.ts";
+
+/**
+ * True when `source` hands `devicectl` to a process launcher directly — i.e. a
+ * production call that bypasses the single {@link OWNER} boundary. We look for a
+ * launcher primitive (exec/execFile/spawn family, promisified or not, plus
+ * `Bun.spawn`) whose argument list contains a `devicectl` string literal.
+ * DeviceAppManager itself never trips this: it routes every invocation through
+ * its injected `execute` seam, not a launcher primitive.
+ */
+function directlyExecutesDevicectl(source: string): boolean {
+  const launcherWithDevicectl =
+    /\b(?:exec|execSync|execFile|execFileSync|execFileAsync|spawn|spawnSync|spawnCommand)\s*\([^;]*?["'`][^"'`]*\bdevicectl\b/;
+  const bunSpawnWithDevicectl =
+    /Bun\.spawn\s*\(\s*\[[^\]]*?["'`][^"'`]*\bdevicectl\b/;
+  return launcherWithDevicectl.test(source) || bunSpawnWithDevicectl.test(source);
+}
+
+function sourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {return sourceFiles(path);}
+    return entry.name.endsWith(".ts") ? [path] : [];
+  });
+}
+
+describe("devicectl execution boundary (issue #4053)", () => {
+  test("only DeviceAppManager directly executes xcrun devicectl", () => {
+    const exceptions = new Map<string, string>([
+      // Diagnostic-only references are allowed only with a concrete reason here.
+    ]);
+    const offenders = sourceFiles(join(ROOT, "src")).flatMap(file => {
+      const repoPath = relative(ROOT, file);
+      if (repoPath === OWNER || exceptions.has(repoPath)) {return [];}
+      const source = readFileSync(file, "utf8");
+      return directlyExecutesDevicectl(source)
+        ? [`${repoPath} directly executes devicectl; route it through ${OWNER} instead.`]
+        : [];
+    });
+
+    expect(offenders, offenders.join("\n")).toEqual([]);
+  });
+
+  test("detects execFile-style devicectl launches", () => {
+    expect(directlyExecutesDevicectl(
+      'execFileAsync("xcrun", ["devicectl", "device", "info", "apps"]);'
+    )).toBe(true);
+    expect(directlyExecutesDevicectl(
+      'execFile("xcrun", [\n  "devicectl", "device", "install", "app"\n]);'
+    )).toBe(true);
+    expect(directlyExecutesDevicectl(
+      'spawnSync("xcrun", ["devicectl", "--version"]);'
+    )).toBe(true);
+  });
+
+  test("detects Bun.spawn devicectl launches", () => {
+    expect(directlyExecutesDevicectl(
+      'Bun.spawn(["xcrun", "devicectl", "device", "info", "processes"]);'
+    )).toBe(true);
+  });
+
+  test("does not flag the injected execute seam or comments", () => {
+    // DeviceAppManager routes through this.execute(...), not a launcher primitive.
+    expect(directlyExecutesDevicectl(
+      'await this.execute("xcrun", ["devicectl", "device", "uninstall", "app"]);'
+    )).toBe(false);
+    // Prose mentioning devicectl must not be a violation.
+    expect(directlyExecutesDevicectl(
+      "// route physical-device app queries through devicectl behind DeviceAppManager"
+    )).toBe(false);
+  });
+
+  test("every documented exception still exists", () => {
+    const exceptions = new Map<string, string>([
+      // Keep this list empty unless a production diagnostic cannot use the owner.
+    ]);
+    expect([...exceptions.keys()].filter(path => !sourceFiles(join(ROOT, "src")).some(file => relative(ROOT, file) === path))).toEqual([]);
+  });
+});

--- a/test/utils/ios-cmdline-tools/DeviceAppManager.test.ts
+++ b/test/utils/ios-cmdline-tools/DeviceAppManager.test.ts
@@ -1081,6 +1081,123 @@ describe("DeviceAppManager terminate (devicectl)", () => {
   });
 });
 
+describe("DeviceAppManager getInstalledAppInfo (devicectl)", () => {
+  const bundlePath = "/private/var/containers/Bundle/Application/ABC/CtrlProxyApp.app";
+  const makeExecResult = (stdout = "") => ({
+    stdout,
+    stderr: "",
+    toString() { return this.stdout; },
+    trim() { return this.stdout.trim(); },
+    includes(searchString: string) { return this.stdout.includes(searchString); }
+  });
+
+  const createInspector = (opts: {
+    platform?: NodeJS.Platform;
+    exec: (command: string) => Promise<ReturnType<typeof makeExecResult>>;
+    logger?: ReturnType<typeof createFakeLogger>;
+  }) => new DeviceAppManager({
+    platform: () => opts.platform ?? "darwin",
+    execute: (file, args) => opts.exec([file, ...args].join(" ")),
+    readFile: async path => fs.readFile(path, "utf-8"),
+    mkdtemp: async prefix => fs.mkdtemp(prefix),
+    rm: async path => fs.rm(path, { recursive: true, force: true }),
+    readdir: async path => fs.readdir(path),
+    stat: async path => fs.stat(path),
+    tmpdir,
+    logger: opts.logger ?? createFakeLogger()
+  });
+
+  test("issues `device info apps --bundle-id --json-output --quiet` with exact UDID/bundle argv and returns the parsed entry", async () => {
+    const commands: string[] = [];
+    const exec = async (command: string) => {
+      commands.push(command);
+      if (command.includes("device info apps")) {
+        const jsonPath = parseDevicectlJsonOutputPath(command);
+        if (jsonPath) {
+          await fs.writeFile(jsonPath, JSON.stringify({
+            apps: [{ bundleIdentifier: bundleId, bundleURL: `file://${bundlePath}`, version: "1.2.3" }]
+          }), "utf-8");
+        }
+      }
+      return makeExecResult();
+    };
+
+    const inspector = createInspector({ exec });
+    const entry = await inspector.getInstalledAppInfo("device-udid", bundleId);
+
+    expect(entry).not.toBeNull();
+    expect(entry!.bundleIdentifier).toBe(bundleId);
+    expect(entry!.version).toBe("1.2.3");
+    const infoCommand = commands.find(c => c.includes("device info apps"))!;
+    expect(infoCommand).toContain("xcrun devicectl device info apps");
+    expect(infoCommand).toContain("--device device-udid");
+    expect(infoCommand).toContain(`--bundle-id ${bundleId}`);
+    expect(infoCommand).toContain("--json-output");
+    expect(infoCommand).toContain("--quiet");
+    // Metadata read must never touch the simulator tool.
+    expect(commands.every(c => !c.includes("simctl"))).toBe(true);
+  });
+
+  test("returns null (no shell-out) off macOS", async () => {
+    const commands: string[] = [];
+    const exec = async (command: string) => { commands.push(command); return makeExecResult(); };
+    const inspector = createInspector({ platform: "linux", exec });
+
+    expect(await inspector.getInstalledAppInfo("device-udid", bundleId)).toBeNull();
+    expect(commands).toEqual([]);
+  });
+
+  test("returns null for an uninstalled bundle", async () => {
+    const exec = async (command: string) => {
+      if (command.includes("device info apps")) {
+        const jsonPath = parseDevicectlJsonOutputPath(command);
+        if (jsonPath) {
+          await fs.writeFile(jsonPath, JSON.stringify({ apps: [] }), "utf-8");
+        }
+      }
+      return makeExecResult();
+    };
+    const inspector = createInspector({ exec });
+    expect(await inspector.getInstalledAppInfo("device-udid", bundleId)).toBeNull();
+  });
+
+  test("degrades a devicectl failure to null and warns (best-effort metadata contract)", async () => {
+    const logger = createFakeLogger();
+    const exec = async () => { throw new Error("xcrun: devicectl not available"); };
+    const inspector = createInspector({ exec, logger });
+
+    expect(await inspector.getInstalledAppInfo("device-udid", bundleId)).toBeNull();
+    expect(logger.warnMessages.some(m => m.includes(bundleId))).toBe(true);
+  });
+
+  test("cleans up the temp json dir after the query", async () => {
+    const removed: string[] = [];
+    const exec = async (command: string) => {
+      if (command.includes("device info apps")) {
+        const jsonPath = parseDevicectlJsonOutputPath(command);
+        if (jsonPath) {
+          await fs.writeFile(jsonPath, JSON.stringify({ apps: [{ bundleIdentifier: bundleId }] }), "utf-8");
+        }
+      }
+      return makeExecResult();
+    };
+    const inspector = new DeviceAppManager({
+      platform: () => "darwin",
+      execute: (file, args) => exec([file, ...args].join(" ")),
+      readFile: async path => fs.readFile(path, "utf-8"),
+      mkdtemp: async prefix => fs.mkdtemp(prefix),
+      rm: async path => { removed.push(path); await fs.rm(path, { recursive: true, force: true }); },
+      readdir: async path => fs.readdir(path),
+      stat: async path => fs.stat(path),
+      tmpdir,
+      logger: createFakeLogger()
+    });
+
+    await inspector.getInstalledAppInfo("device-udid", bundleId);
+    expect(removed.length).toBe(1);
+  });
+});
+
 describe("isDevicectlProcessGoneError", () => {
   test("matches ESRCH / already-exited devicectl phrasings (case-insensitive)", () => {
     expect(isDevicectlProcessGoneError("The operation couldn’t be completed. No such process (NSPOSIXErrorDomain error 3.)")).toBe(true);


### PR DESCRIPTION
## Problem

`DeviceAppManager` is the physical-device semantic client, but the app-metadata
resource (`src/server/appResources.ts`) composed its own `xcrun devicectl device
info apps` invocation via `execFileAsync`, bypassing that boundary.

## Change

- Add `DeviceAppManager.getInstalledAppInfo(deviceUdid, bundleId)` — a
  best-effort, non-throwing `device info apps --bundle-id --json-output --quiet`
  query returning the parsed bundle entry or `null` (null off macOS, warn+null on
  devicectl/JSON failure), matching the metadata resource's diagnostic contract.
- Extract a shared private `queryInstalledAppEntry` core; `resolveInstalledBundlePathOnDevice`
  now reuses it (still error-propagating for the terminate path).
- Route `createIosMetadataSource` through `DeviceAppManager`, deleting the inline
  `execFileAsync`/temp-file/JSON plumbing and now-unused `fs`/`os`/`path`/`child_process` imports.
- Add `test/lint/devicectlExecutionBoundary.test.ts`, mirroring the avdmanager
  boundary guard ([#4051](https://github.com/kaeawc/auto-mobile/issues/4051)):
  blocks new direct production `xcrun devicectl` launches outside the owner.

## Preserved behaviors

- No launch/terminate/open-URL path changed. `info processes` still exposes no
  `bundleIdentifier` ([#2487](https://github.com/kaeawc/auto-mobile/issues/2487));
  physical-device open-URL branching on `isIosSimulatorUdid` is untouched.
- All dynamic values (UDID/bundle id/path) are passed as argv, never shell-interpolated.

## Validation

- `bun test` DeviceAppManager + GetAppMetadata + new boundary test: 68 pass
- `bun test test/lint/`: 199 pass · `bun test test/server/`: 1554 pass
- `bun run typecheck`: no new errors · `bun run lint`: clean · `bun run build`: ok

Closes [#4053](https://github.com/kaeawc/auto-mobile/issues/4053)
