### PR TITLE
test(server-runtime): collapse a11y/platform loops, add serverSetup schema checks (#4528)

### DIFF
--- a/test/server/accessibilityTools.test.ts
+++ b/test/server/accessibilityTools.test.ts
@@ -50,40 +50,33 @@ describe("accessibilityTools", () => {
   });
 
   describe("schema validation", () => {
-    test("accepts talkback: true", () => {
-      expect(() => accessibilitySchema.parse({ talkback: true })).not.toThrow();
-    });
+    // Collapsed from 8 hand-rolled siblings into a single table so a failing
+    // row is named, plus the boundary rows the siblings never specified: null,
+    // explicit undefined, and an unknown key (issue #4183 item 18).
+    const cases: ReadonlyArray<{ name: string; input: unknown; valid: boolean }> = [
+      { name: "talkback: true", input: { talkback: true }, valid: true },
+      { name: "talkback: false", input: { talkback: false }, valid: true },
+      { name: "empty object (all params optional)", input: {}, valid: true },
+      { name: "talkback as a string", input: { talkback: "yes" }, valid: false },
+      { name: "talkback as a number", input: { talkback: 1 }, valid: false },
+      { name: "talkback as null", input: { talkback: null }, valid: false },
+      { name: "talkback explicitly undefined", input: { talkback: undefined }, valid: true },
+      { name: "voiceover: true", input: { voiceover: true }, valid: true },
+      { name: "voiceover: false", input: { voiceover: false }, valid: true },
+      { name: "voiceover as a string", input: { voiceover: "yes" }, valid: false },
+      { name: "voiceover as a number", input: { voiceover: 1 }, valid: false },
+      { name: "voiceover as null", input: { voiceover: null }, valid: false },
+      // z.object strips unknown keys rather than rejecting them, so an
+      // unknown key is accepted (verified: accepted, issue #4183 item 18).
+      { name: "an unknown key", input: { unknownKey: true }, valid: true },
+    ];
 
-    test("accepts talkback: false", () => {
-      expect(() => accessibilitySchema.parse({ talkback: false })).not.toThrow();
-    });
-
-    test("accepts empty object (all params optional)", () => {
-      expect(() => accessibilitySchema.parse({})).not.toThrow();
-    });
-
-    test("rejects talkback as a string", () => {
-      expect(() => accessibilitySchema.parse({ talkback: "yes" })).toThrow();
-    });
-
-    test("rejects talkback as a number", () => {
-      expect(() => accessibilitySchema.parse({ talkback: 1 })).toThrow();
-    });
-
-    test("accepts voiceover: true", () => {
-      expect(() => accessibilitySchema.parse({ voiceover: true })).not.toThrow();
-    });
-
-    test("accepts voiceover: false", () => {
-      expect(() => accessibilitySchema.parse({ voiceover: false })).not.toThrow();
-    });
-
-    test("rejects voiceover as a string", () => {
-      expect(() => accessibilitySchema.parse({ voiceover: "yes" })).toThrow();
-    });
-
-    test("rejects voiceover as a number", () => {
-      expect(() => accessibilitySchema.parse({ voiceover: 1 })).toThrow();
+    test.each(cases)("$valid for $name", ({ input, valid }) => {
+      if (valid) {
+        expect(() => accessibilitySchema.parse(input)).not.toThrow();
+      } else {
+        expect(() => accessibilitySchema.parse(input)).toThrow();
+      }
     });
   });
 });

--- a/test/server/platform/PlatformClient.test.ts
+++ b/test/server/platform/PlatformClient.test.ts
@@ -69,70 +69,68 @@ describe("PlatformClient", () => {
     },
   ];
 
-  for (const c of cases) {
-    describe(`createPlatformClient (${c.name})`, () => {
-      const createOptions = () => ({
-        ...buildOptions(),
-        ctrlProxy: {} as CtrlProxyClient,
-      });
-
-      it("passes the target device and ADB factory to the injected CtrlProxy factory", () => {
-        const adbFactory = new FakeAdbClientFactory();
-        const ctrlProxy = {} as CtrlProxyClient;
-        const calls: Array<[BootedDevice, FakeAdbClientFactory]> = [];
-        const client = createPlatformClient(c.device, {
-          ...buildOptions(),
-          adbFactory,
-          ctrlProxyFactory: (device, factory) => {
-            calls.push([device, factory as FakeAdbClientFactory]);
-            return ctrlProxy;
-          },
-        });
-
-        expect(client.ctrlProxy).toBe(ctrlProxy);
-        expect(calls).toEqual([[c.device, adbFactory]]);
-      });
-
-      it("returns the platform-appropriate TapStrategy", () => {
-        const client = createPlatformClient(c.device, createOptions());
-        expect(client.tapStrategy).toBeInstanceOf(c.expectedTapStrategyCtor);
-      });
-
-      it("returns the platform-appropriate SystemConfigurationAdapter", () => {
-        const client = createPlatformClient(c.device, createOptions());
-        expect(client.systemConfiguration).toBeInstanceOf(
-          c.expectedSystemConfigCtor
-        );
-      });
-
-      it("returns the platform-appropriate NotificationUIDetector", () => {
-        const client = createPlatformClient(c.device, createOptions());
-        expect(client.notificationUI).toBeInstanceOf(
-          c.expectedNotificationUICtor
-        );
-      });
-
-      it("bundles the same device on the facade", () => {
-        const client = createPlatformClient(c.device, createOptions());
-        expect(client.device).toBe(c.device);
-        expect(client.notificationUI.device).toBe(c.device);
-      });
-
-      it("satisfies the PlatformClient interface", () => {
-        const client: PlatformClient = createPlatformClient(
-          c.device,
-          createOptions()
-        );
-        expect(client.device).toBeDefined();
-        expect(client.ctrlProxy).toBeDefined();
-        expect(typeof client.tapStrategy.isAccessibilityServiceEnabled).toBe(
-          "function"
-        );
-        expect(typeof client.systemConfiguration.setLocale).toBe("function");
-        expect(typeof client.notificationUI.isTrayOpen).toBe("function");
-      });
+  describe.each(cases)("createPlatformClient ($name)", c => {
+    const createOptions = () => ({
+      ...buildOptions(),
+      ctrlProxy: {} as CtrlProxyClient,
     });
-  }
+
+    it("passes the target device and ADB factory to the injected CtrlProxy factory", () => {
+      const adbFactory = new FakeAdbClientFactory();
+      const ctrlProxy = {} as CtrlProxyClient;
+      const calls: Array<[BootedDevice, FakeAdbClientFactory]> = [];
+      const client = createPlatformClient(c.device, {
+        ...buildOptions(),
+        adbFactory,
+        ctrlProxyFactory: (device, factory) => {
+          calls.push([device, factory as FakeAdbClientFactory]);
+          return ctrlProxy;
+        },
+      });
+
+      expect(client.ctrlProxy).toBe(ctrlProxy);
+      expect(calls).toEqual([[c.device, adbFactory]]);
+    });
+
+    it("returns the platform-appropriate TapStrategy", () => {
+      const client = createPlatformClient(c.device, createOptions());
+      expect(client.tapStrategy).toBeInstanceOf(c.expectedTapStrategyCtor);
+    });
+
+    it("returns the platform-appropriate SystemConfigurationAdapter", () => {
+      const client = createPlatformClient(c.device, createOptions());
+      expect(client.systemConfiguration).toBeInstanceOf(
+        c.expectedSystemConfigCtor
+      );
+    });
+
+    it("returns the platform-appropriate NotificationUIDetector", () => {
+      const client = createPlatformClient(c.device, createOptions());
+      expect(client.notificationUI).toBeInstanceOf(
+        c.expectedNotificationUICtor
+      );
+    });
+
+    it("bundles the same device on the facade", () => {
+      const client = createPlatformClient(c.device, createOptions());
+      expect(client.device).toBe(c.device);
+      expect(client.notificationUI.device).toBe(c.device);
+    });
+
+    it("satisfies the PlatformClient interface", () => {
+      const client: PlatformClient = createPlatformClient(
+        c.device,
+        createOptions()
+      );
+      expect(client.device).toBeDefined();
+      expect(client.ctrlProxy).toBeDefined();
+      expect(typeof client.tapStrategy.isAccessibilityServiceEnabled).toBe(
+        "function"
+      );
+      expect(typeof client.systemConfiguration.setLocale).toBe("function");
+      expect(typeof client.notificationUI.isTrayOpen).toBe("function");
+    });
+  });
 
   describe("createPlatformClient overrides", () => {
     it("uses the injected ctrlProxy without constructing a platform client", () => {

--- a/test/server/toolRegistration.test.ts
+++ b/test/server/toolRegistration.test.ts
@@ -91,6 +91,33 @@ describe("Tool Registration Validation (Integration Tests)", () => {
     expect(() => compileJsonSchema(observe!.outputSchema)).not.toThrow();
   });
 
+  // R11 (issue #4183): the observe-only check above compiled a single schema.
+  // Every committed input/output schema must be compilable by strict clients,
+  // or a hand-edited schema slips through until a client rejects it at runtime.
+  test("should keep every committed tool schema compilable by strict clients", async () => {
+    const fs = await import("fs/promises");
+    const path = await import("path");
+    const schemaPath = path.join(process.cwd(), "schemas", "tool-definitions.json");
+
+    const content = await fs.readFile(schemaPath, "utf-8");
+    const schemas = JSON.parse(content) as ToolSchemaDefinition[];
+    expect(schemas.length).toBeGreaterThan(0);
+
+    for (const schema of schemas) {
+      expect(() => compileJsonSchema(schema.inputSchema), `${schema.name} inputSchema`).not.toThrow();
+      if (schema.outputSchema !== undefined) {
+        expect(() => compileJsonSchema(schema.outputSchema), `${schema.name} outputSchema`).not.toThrow();
+      }
+    }
+  });
+
+  // R9 (issue #4183): a negative assertion so the compile check cannot silently
+  // pass on anything — a structurally-invalid schema (`type` not an allowed
+  // keyword) must be rejected, proving compileJsonSchema is a real gate.
+  test("compileJsonSchema rejects a structurally invalid schema", () => {
+    expect(() => compileJsonSchema({ type: "not-a-json-schema-type" })).toThrow();
+  });
+
   // A5 (issue #4181, rank 6): the previous test compared only NAMES, and only
   // in the served->committed direction. This checks BOTH directions and the
   // body/description bytes:


### PR DESCRIPTION
## What

Implements the well-specified findings of [#4661](https://github.com/kaeawc/auto-mobile/issues/4661) (a [#4528](https://github.com/kaeawc/auto-mobile/issues/4528) child; [#4183](https://github.com/kaeawc/auto-mobile/issues/4183) items 18, 19, R9-R11). Test-only, low-risk.

- **accessibilityTools.test.ts (item 18, P7 CONFIRMED):** collapse the 8 hand-rolled schema-validation siblings into one `test.each` table and add the boundary rows they never specified — `null`, explicit `undefined`, and an unknown key (verified accepted: `z.object` strips unknown keys).
- **platform/PlatformClient.test.ts (item 19, P8):** convert the hand-rolled `for (const c of cases)` into `describe.each` so a failing row names the platform. There is no dead `collaborators` line in current code — the P8 "delete the dead line" fix targeted a proposal snippet that never landed; current code uses a typed `PlatformCase[]`.
- **toolRegistration.test.ts (R9/R11 CONFIRMED):** add a schema-validation test that compiles **every** committed input/output schema (not just `observe`), plus an R9 **negative** assertion proving `compileJsonSchema` rejects a structurally invalid schema (so the compile check cannot silently pass on anything).

`serverSetup.test.ts` was deleted in [#4181](https://github.com/kaeawc/auto-mobile/issues/4181), so the R10 anchor is folded into the `toolRegistration` suite, which already imports `compileJsonSchema`.

## Not actioned

- **Item 21 (D1-D9 tautology deletes):** the referenced "DELETE table" is absent from [#4183](https://github.com/kaeawc/auto-mobile/issues/4183)'s body/comment, [#4528](https://github.com/kaeawc/auto-mobile/issues/4528), and [#4661](https://github.com/kaeawc/auto-mobile/issues/4661). Every in-repo tautology-removal marker (`toolRegistration.test.ts`, `ping.test.ts`, `observeOutputSchema.test.ts`) cites the sibling [#4181](https://github.com/kaeawc/auto-mobile/issues/4181) audit (landed in [#4495](https://github.com/kaeawc/auto-mobile/pull/4495)), so those shape tests appear already removed. Not guess-deleted.

## Validation

- `bun test` on the 3 touched files: 40 pass.
- `bun test test/lint/`: 194 pass.
- `bun run typecheck`: no new type errors.
- `bun run lint`: clean.

Part of the Unit Test Quality Audit milestone.

Closes #4661
