### PR TITLE
fix(desktop): strip unsigned ffmpeg/ffprobe programs so DMG notarization passes

### DIFF
--- a/.github/workflows/build-desktop-app-installers.yml
+++ b/.github/workflows/build-desktop-app-installers.yml
@@ -167,11 +167,31 @@ jobs:
             exit 1
           fi
           echo "Notarizing $DMG"
-          xcrun notarytool submit "$DMG" \
+          # `notarytool submit --wait` exits 0 even when Apple's verdict is
+          # Invalid, which previously let the step run on to `stapler staple`
+          # and die with an opaque "Record not found" error 65. Parse the JSON
+          # result instead: anything but Accepted fails the step, after dumping
+          # the notary log so the per-file rejection reasons land in CI output.
+          SUBMISSION_JSON=$(xcrun notarytool submit "$DMG" \
             --key "$APPLE_NOTARY_KEY_PATH" \
             --key-id "$APPLE_NOTARY_KEY_ID" \
             --issuer "$APPLE_NOTARY_ISSUER_ID" \
-            --wait
+            --wait \
+            --output-format json)
+          echo "$SUBMISSION_JSON"
+          SUBMISSION_ID=$(jq -r '.id // empty' <<<"$SUBMISSION_JSON")
+          STATUS=$(jq -r '.status // empty' <<<"$SUBMISSION_JSON")
+          if [ "$STATUS" != "Accepted" ]; then
+            echo "Notarization verdict: ${STATUS:-unknown} (submission ${SUBMISSION_ID:-unknown})" >&2
+            if [ -n "$SUBMISSION_ID" ]; then
+              # Best-effort: the log service can lag right after the verdict.
+              xcrun notarytool log "$SUBMISSION_ID" \
+                --key "$APPLE_NOTARY_KEY_PATH" \
+                --key-id "$APPLE_NOTARY_KEY_ID" \
+                --issuer "$APPLE_NOTARY_ISSUER_ID" >&2 || true
+            fi
+            exit 1
+          fi
           xcrun stapler staple "$DMG"
           xcrun stapler validate "$DMG"
 

--- a/android/desktop-app/build.gradle.kts
+++ b/android/desktop-app/build.gradle.kts
@@ -1,3 +1,10 @@
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+import java.util.zip.ZipOutputStream
+import org.gradle.api.artifacts.transform.InputArtifact
+import org.gradle.api.artifacts.transform.TransformAction
+import org.gradle.api.artifacts.transform.TransformOutputs
+import org.gradle.api.artifacts.transform.TransformParameters
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 import org.jetbrains.compose.reload.gradle.ComposeHotRun
 
@@ -56,6 +63,75 @@ val desktopMacPackageVersion: String =
   normalizeSemver(desktopReleaseVersion).let { (major, minor, patch) ->
     "${if (major == 0) 1 else major}.$minor.$patch"
   }
+
+// --- Strip bundled ffmpeg/ffprobe program executables --------------------------
+// The org.bytedeco:ffmpeg:<ver>:<platform> classifier jar ships the ffmpeg and
+// ffprobe CLI programs alongside the libav*/libjni* JNI libraries. The desktop
+// app only uses the JNI bindings (H264Decoder in :desktop-core), so the programs
+// are dead weight — and on macOS they break notarization: Compose's signer
+// re-signs *.dylib/*.jnilib entries inside jars during packaging, but not
+// extensionless Mach-O executables, so Apple's notary service finds the
+// ad-hoc-signed ffmpeg/ffprobe binaries and rejects the DMG as Invalid.
+// Filtering is applied to all platforms uniformly so the shipped runtime
+// classpath does not vary by OS.
+val ffmpegProgramsStripped: Attribute<Boolean> =
+  Attribute.of(
+    "dev.jasonpearson.automobile.desktop.ffmpegProgramsStripped",
+    Boolean::class.javaObjectType,
+  )
+
+abstract class StripFfmpegProgramsTransform : TransformAction<TransformParameters.None> {
+  @get:InputArtifact abstract val inputArtifact: Provider<FileSystemLocation>
+
+  override fun transform(outputs: TransformOutputs) {
+    val input = inputArtifact.get().asFile
+    if (!input.name.startsWith("ffmpeg-")) {
+      outputs.file(input)
+      return
+    }
+    val output = outputs.file("${input.nameWithoutExtension}-no-programs.jar")
+    ZipFile(input).use { zip ->
+      ZipOutputStream(output.outputStream().buffered()).use { out ->
+        for (entry in zip.entries()) {
+          if (isFfmpegProgram(entry)) continue
+          out.putNextEntry(ZipEntry(entry.name).apply { time = entry.time })
+          if (!entry.isDirectory) {
+            zip.getInputStream(entry).use { it.copyTo(out) }
+          }
+          out.closeEntry()
+        }
+      }
+    }
+  }
+
+  private fun isFfmpegProgram(entry: ZipEntry): Boolean {
+    if (entry.isDirectory || !entry.name.startsWith("org/bytedeco/ffmpeg/")) {
+      return false
+    }
+    val fileName = entry.name.substringAfterLast('/')
+    return fileName == "ffmpeg" ||
+      fileName == "ffprobe" ||
+      fileName == "ffmpeg.exe" ||
+      fileName == "ffprobe.exe"
+  }
+}
+
+dependencies {
+  attributesSchema { attribute(ffmpegProgramsStripped) }
+  artifactTypes.named("jar") { attributes.attribute(ffmpegProgramsStripped, false) }
+  registerTransform(StripFfmpegProgramsTransform::class) {
+    from
+      .attribute(ffmpegProgramsStripped, false)
+      .attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, "jar")
+    to
+      .attribute(ffmpegProgramsStripped, true)
+      .attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, "jar")
+  }
+}
+
+configurations.named("runtimeClasspath") {
+  attributes.attribute(ffmpegProgramsStripped, true)
+}
 
 dependencies {
   // Shared module (UX, unix socket architecture, settings, data sources)


### PR DESCRIPTION
## Problem

The Prepare Release run [30511560482](https://github.com/kaeawc/auto-mobile/actions/runs/30511560482) failed in `Package dmg (macos-latest)` at **Notarize and staple DMG** (exit 65). Apple's notary service returned **status: Invalid** for the DMG.

The notary log for submission `746ee508-4ecf-45ca-9110-443a2ec8d893` (verified locally with the App Store Connect API key) lists exactly six errors — all against the **`ffmpeg` and `ffprobe` CLI programs inside the `org.bytedeco:ffmpeg` `macosx-arm64` classifier jar**:

- "The binary is not signed with a valid Developer ID certificate."
- "The signature does not include a secure timestamp."
- "The executable does not have the hardened runtime enabled."

(× each of `ffmpeg`, `ffprobe`.) Nothing else in the DMG was flagged.

**Root cause:** Compose's packaging signer re-signs `*.dylib`/`*.jnilib` entries inside jars (the 15 libav*/libjni* dylibs in the same jar come out correctly signed), but not extensionless Mach-O executables — so the two ad-hoc linker-signed programs shipped exactly as bytedeco built them, and Apple's notary scans jar contents.

## Fix

1. **`android/desktop-app/build.gradle.kts`** — an artifact transform on the desktop-app runtime classpath strips `ffmpeg`/`ffprobe`(`.exe`) program entries from the bytedeco ffmpeg jar for all platforms. The desktop app only uses the JNI bindings (`H264Decoder` in `:desktop-core`); the CLI programs are dead weight.
2. **`.github/workflows/build-desktop-app-installers.yml`** — `notarytool submit --wait` exits 0 even when the verdict is Invalid, which let the step run on to `stapler` and die with an opaque "Record not found" error 65. The step now parses the JSON result, dumps `notarytool log` into CI output on any non-Accepted verdict, and fails before stapling — so any future rejection is self-diagnosing.

## Validation

- Rebuilt the distributable locally with the transform: `ffmpeg`/`ffprobe` gone from the packaged jar, all 15 JNI dylibs retained; a Mach-O scan across all 69 packaged jars finds no remaining non-dylib binaries.
- `:desktop-app:test :desktop-app:createDistributable` green.
- `scripts/all_fast_validate_checks.sh` — all 27 checks pass (includes workflow + ktfmt validation).
