### PR TITLE
refactor(image): centralize WebP codec execution behind WebpBinaryResolver

### DIFF
--- a/src/utils/image/webp/CliWebpCodec.ts
+++ b/src/utils/image/webp/CliWebpCodec.ts
@@ -1,7 +1,4 @@
-import type { ChildProcess } from "node:child_process";
-import type { Writable } from "node:stream";
 import { ActionableError } from "../../../models/ActionableError";
-import { DefaultHostCommandExecutor, type HostProcessExecutor } from "../../HostCommandExecutor";
 import { WebpBinaryResolver, type WebpBinaryProvider } from "./WebpBinaryResolver";
 
 export interface CliWebpEncodeOptions {
@@ -16,16 +13,20 @@ export function isWebpBuffer(buffer: Buffer): boolean {
     buffer.subarray(8, 12).toString("ascii") === "WEBP";
 }
 
+/**
+ * Image-transformation semantics for the WebP leg: build cwebp/dwebp argv from
+ * options and sniff the resulting buffers. All process resolution and lifecycle
+ * is delegated to the injected {@link WebpBinaryProvider}, the single owner that
+ * resolves and executes the libwebp tools.
+ */
 export class CliWebpCodec {
   constructor(
-    private readonly binaryResolver: WebpBinaryProvider = new WebpBinaryResolver(),
-    private readonly processExecutor: HostProcessExecutor = new DefaultHostCommandExecutor()
+    private readonly binaryResolver: WebpBinaryProvider = new WebpBinaryResolver()
   ) {}
 
   async encode(pngBuffer: Buffer, options: CliWebpEncodeOptions = {}): Promise<Buffer> {
-    const cwebp = await this.binaryResolver.resolveCwebp();
     const args = [...buildCwebpOptionArgs(options), "-o", "-", "--", "-"];
-    const output = await this.runCodecProcess("cwebp", cwebp, args, pngBuffer, "AUTOMOBILE_CWEBP_PATH");
+    const output = await this.binaryResolver.runCwebp(args, pngBuffer);
     if (!isWebpBuffer(output)) {
       throw new ActionableError("cwebp did not produce a WebP RIFF buffer. Set AUTOMOBILE_CWEBP_PATH to a working cwebp binary.");
     }
@@ -37,36 +38,7 @@ export class CliWebpCodec {
       throw new ActionableError("CliWebpCodec.decode expected a WebP RIFF buffer.");
     }
 
-    const dwebp = await this.binaryResolver.resolveDwebp();
-    return this.runCodecProcess("dwebp", dwebp, ["-o", "-", "--", "-"], webpBuffer, "AUTOMOBILE_DWEBP_PATH");
-  }
-
-  private async runCodecProcess(
-    toolName: "cwebp" | "dwebp",
-    command: string,
-    args: string[],
-    input: Buffer,
-    envVar: string
-  ): Promise<Buffer> {
-    const child = this.processExecutor.spawn(command, args, { stdio: ["pipe", "pipe", "pipe"] });
-    const stdout: Buffer[] = [];
-    const stderr: Buffer[] = [];
-
-    if (!child.stdin || !child.stdout || !child.stderr) {
-      throw new ActionableError(`${toolName} was spawned without piped stdio. Set ${envVar} to a working ${toolName} binary.`);
-    }
-
-    child.stdout.on("data", data => stdout.push(Buffer.isBuffer(data) ? data : Buffer.from(data)));
-    child.stderr.on("data", data => stderr.push(Buffer.isBuffer(data) ? data : Buffer.from(data)));
-    const completion = waitForCompletion(child, child.stdin, toolName, envVar, stderr);
-    try {
-      child.stdin.end(input);
-    } catch (error) {
-      throw actionableProcessError(toolName, envVar, `stdin write failed: ${errorMessage(error)}`);
-    }
-
-    await completion;
-    return Buffer.concat(stdout);
+    return this.binaryResolver.runDwebp(["-o", "-", "--", "-"], webpBuffer);
   }
 }
 
@@ -82,38 +54,4 @@ function buildCwebpOptionArgs(options: CliWebpEncodeOptions): string[] {
     return ["-q", String(quality)];
   }
   return [];
-}
-
-async function waitForCompletion(
-  child: ChildProcess,
-  stdin: Writable,
-  toolName: "cwebp" | "dwebp",
-  envVar: string,
-  stderr: Buffer[]
-): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    child.once("error", error => {
-      reject(actionableProcessError(toolName, envVar, error.message));
-    });
-    stdin.once("error", error => {
-      reject(actionableProcessError(toolName, envVar, `stdin write failed: ${errorMessage(error)}`));
-    });
-    child.once("close", (code, signal) => {
-      if (code === 0) {
-        resolve();
-        return;
-      }
-      const detail = Buffer.concat(stderr).toString("utf8").trim();
-      const suffix = detail ? `: ${detail}` : "";
-      reject(actionableProcessError(toolName, envVar, `exited with code ${code ?? "null"} signal ${signal ?? "null"}${suffix}`));
-    });
-  });
-}
-
-function actionableProcessError(toolName: "cwebp" | "dwebp", envVar: string, detail: string): ActionableError {
-  return new ActionableError(`${toolName} failed (${detail}). Set ${envVar} to a working ${toolName} binary.`);
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
 }

--- a/src/utils/image/webp/WebpBinaryResolver.ts
+++ b/src/utils/image/webp/WebpBinaryResolver.ts
@@ -1,12 +1,14 @@
+import type { ChildProcess } from "node:child_process";
 import { constants as fsConstants, existsSync } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import process from "node:process";
+import type { Writable } from "node:stream";
 import { ActionableError } from "../../../models/ActionableError";
 import { type ChecksumCalculator, DefaultChecksumCalculator } from "../../ChecksumCalculator";
 import { DefaultFileDownloader, type FileDownloader } from "../../FileDownloader";
-import { DefaultHostCommandExecutor, type HostCommandExecutor } from "../../HostCommandExecutor";
+import { DefaultHostCommandExecutor, type HostProcessExecutor } from "../../HostCommandExecutor";
 import { logger } from "../../logger";
 
 const LIBWEBP_VERSION = "1.6.0";
@@ -28,7 +30,7 @@ export interface WebpBinaryResolverOptions {
   arch?: NodeJS.Architecture;
   env?: NodeJS.ProcessEnv;
   fileDownloader?: FileDownloader;
-  processExecutor?: HostCommandExecutor;
+  processExecutor?: HostProcessExecutor;
   checksumCalculator?: ChecksumCalculator;
 }
 
@@ -37,9 +39,18 @@ export interface ResolvedWebpBinaries {
   dwebp: string;
 }
 
+/**
+ * The single injected boundary that both resolves and executes the libwebp
+ * CLI tools. Consumers pass argv structurally (never shell-interpolated) and
+ * receive the codec output buffer; the owner defines availability, process
+ * lifecycle, child cleanup, and actionable errors. Keep image-transformation
+ * semantics (argv construction, buffer sniffing) in the codec layer.
+ */
 export interface WebpBinaryProvider {
   resolveCwebp(): Promise<string>;
   resolveDwebp(): Promise<string>;
+  runCwebp(args: string[], input: Buffer): Promise<Buffer>;
+  runDwebp(args: string[], input: Buffer): Promise<Buffer>;
 }
 
 export class WebpBinaryResolver implements WebpBinaryProvider {
@@ -49,7 +60,7 @@ export class WebpBinaryResolver implements WebpBinaryProvider {
   private readonly arch: NodeJS.Architecture;
   private readonly env: NodeJS.ProcessEnv;
   private readonly fileDownloader: FileDownloader;
-  private readonly processExecutor: HostCommandExecutor;
+  private readonly processExecutor: HostProcessExecutor;
   private readonly checksumCalculator: ChecksumCalculator;
 
   constructor(options: WebpBinaryResolverOptions = {}) {
@@ -74,6 +85,44 @@ export class WebpBinaryResolver implements WebpBinaryProvider {
 
   async resolveDwebp(): Promise<string> {
     return this.resolveBinary("dwebp", "AUTOMOBILE_DWEBP_PATH");
+  }
+
+  async runCwebp(args: string[], input: Buffer): Promise<Buffer> {
+    const command = await this.resolveCwebp();
+    return this.runCodecProcess("cwebp", command, args, input, "AUTOMOBILE_CWEBP_PATH");
+  }
+
+  async runDwebp(args: string[], input: Buffer): Promise<Buffer> {
+    const command = await this.resolveDwebp();
+    return this.runCodecProcess("dwebp", command, args, input, "AUTOMOBILE_DWEBP_PATH");
+  }
+
+  private async runCodecProcess(
+    toolName: WebpBinary,
+    command: string,
+    args: string[],
+    input: Buffer,
+    envVar: string
+  ): Promise<Buffer> {
+    const child = this.processExecutor.spawn(command, args, { stdio: ["pipe", "pipe", "pipe"] });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+
+    if (!child.stdin || !child.stdout || !child.stderr) {
+      throw new ActionableError(`${toolName} was spawned without piped stdio. Set ${envVar} to a working ${toolName} binary.`);
+    }
+
+    child.stdout.on("data", data => stdout.push(Buffer.isBuffer(data) ? data : Buffer.from(data)));
+    child.stderr.on("data", data => stderr.push(Buffer.isBuffer(data) ? data : Buffer.from(data)));
+    const completion = waitForCompletion(child, child.stdin, toolName, envVar, stderr);
+    try {
+      child.stdin.end(input);
+    } catch (error) {
+      throw actionableProcessError(toolName, envVar, `stdin write failed: ${errorMessage(error)}`);
+    }
+
+    await completion;
+    return Buffer.concat(stdout);
   }
 
   private async resolveBinary(binary: WebpBinary, envVar: string): Promise<string> {
@@ -260,6 +309,36 @@ async function isExecutableFile(filePath: string, platform: NodeJS.Platform): Pr
   }
 }
 
+
+async function waitForCompletion(
+  child: ChildProcess,
+  stdin: Writable,
+  toolName: WebpBinary,
+  envVar: string,
+  stderr: Buffer[]
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    child.once("error", error => {
+      reject(actionableProcessError(toolName, envVar, error.message));
+    });
+    stdin.once("error", error => {
+      reject(actionableProcessError(toolName, envVar, `stdin write failed: ${errorMessage(error)}`));
+    });
+    child.once("close", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      const detail = Buffer.concat(stderr).toString("utf8").trim();
+      const suffix = detail ? `: ${detail}` : "";
+      reject(actionableProcessError(toolName, envVar, `exited with code ${code ?? "null"} signal ${signal ?? "null"}${suffix}`));
+    });
+  });
+}
+
+function actionableProcessError(toolName: WebpBinary, envVar: string, detail: string): ActionableError {
+  return new ActionableError(`${toolName} failed (${detail}). Set ${envVar} to a working ${toolName} binary.`);
+}
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);

--- a/test/lint/webpExecutionBoundary.test.ts
+++ b/test/lint/webpExecutionBoundary.test.ts
@@ -8,24 +8,35 @@ const BINARY = "(?:cwebp|dwebp|webpmux)";
 
 /**
  * A production file "directly executes" a libwebp tool when it launches the
- * binary itself — a literal cwebp/dwebp/webpmux name handed to a process API, or
- * a path resolved from the owner's resolveCwebp/resolveDwebp then spawned. The
- * blessed path is `WebpBinaryProvider.runCwebp` / `runDwebp` on the owner, which
- * this heuristic deliberately does not flag.
+ * binary itself — a literal cwebp/dwebp/webpmux name handed to a process API
+ * (including the *Sync spellings and a shell `-c` command string), or a path
+ * resolved from the owner's resolveCwebp/resolveDwebp then spawned. The blessed
+ * path is `WebpBinaryProvider.runCwebp` / `runDwebp` on the owner, which this
+ * heuristic deliberately does not flag.
+ *
+ * Residual limit (bounded to concrete evasions): the binary name must appear as
+ * a literal inside a single string token. A name assembled from a variable or
+ * string concatenation, or one hidden past same-quote nesting inside a shell
+ * string, is not detected — those are out of scope for this guard.
  */
 function directlyExecutesWebp(source: string): boolean {
-  const launchApis = "(?:spawn|spawnSync|exec|execFile|execFileSync)";
+  const launchApis = "(?:spawn|spawnSync|exec|execSync|execFile|execFileSync)";
+  // A launcher whose first string argument itself contains the binary, e.g.
+  // spawn("cwebp", ...) or execSync("cwebp -o - -").
   const directLiteral = new RegExp(`\\b${launchApis}\\s*\\(\\s*["'\`][^"'\`]*${BINARY}`, "i");
-  const bunSpawnLiteral = new RegExp(`Bun\\.spawn\\s*\\(\\s*\\[\\s*["'\`][^"'\`]*${BINARY}`, "i");
+  const bunSpawnLiteral = new RegExp(`Bun\\.spawn(?:Sync)?\\s*\\(\\s*\\[\\s*["'\`][^"'\`]*${BINARY}`, "i");
+  // A shell launcher that smuggles the binary through a `-c` command string,
+  // e.g. spawn("/bin/sh", ["-c", "cwebp -o -"]) or Bun.spawn(["bash", "-c", "dwebp ..."]).
+  const shellCommandString = new RegExp(`["'\`]-c["'\`]\\s*,\\s*["'\`][^"'\`]*${BINARY}`, "i");
 
   const resolverVarNames = [
     ...source.matchAll(/\b(?:const|let|var)\s+(\w+)\s*=\s*(?:await\s+)?[^;]*\.(?:resolveCwebp|resolveDwebp)\s*\([^;]*;/g)
   ].map(match => match[1]);
   const resolverVarLaunch = resolverVarNames.some(name =>
-    new RegExp(`\\b${launchApis}\\s*\\(\\s*${name}\\b|Bun\\.spawn\\s*\\(\\s*\\[\\s*${name}\\b|\\.spawn\\s*\\(\\s*${name}\\b`).test(source)
+    new RegExp(`\\b${launchApis}\\s*\\(\\s*${name}\\b|Bun\\.spawn(?:Sync)?\\s*\\(\\s*\\[\\s*${name}\\b|\\.spawn\\s*\\(\\s*${name}\\b`).test(source)
   );
 
-  return directLiteral.test(source) || bunSpawnLiteral.test(source) || resolverVarLaunch;
+  return directLiteral.test(source) || bunSpawnLiteral.test(source) || shellCommandString.test(source) || resolverVarLaunch;
 }
 
 function sourceFiles(directory: string): string[] {
@@ -75,6 +86,13 @@ describe("webp codec execution boundary (issue #4064)", () => {
     expect(directlyExecutesWebp(
       "const bin = await resolver.resolveDwebp(); execFile(bin, args);"
     )).toBe(true);
+  });
+
+  test("flags shell-string and *Sync launcher evasions", () => {
+    expect(directlyExecutesWebp('execSync("cwebp -o - -");')).toBe(true);
+    expect(directlyExecutesWebp('spawn("/bin/sh", ["-c", "cwebp -o -"]);')).toBe(true);
+    expect(directlyExecutesWebp('Bun.spawn(["bash", "-c", "dwebp -o - --"]);')).toBe(true);
+    expect(directlyExecutesWebp('spawnSync("webpmux", ["-info", file]);')).toBe(true);
   });
 
   test("does not flag the blessed runCwebp/runDwebp delegation", () => {

--- a/test/lint/webpExecutionBoundary.test.ts
+++ b/test/lint/webpExecutionBoundary.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const ROOT = join(import.meta.dir, "..", "..");
+const OWNER = "src/utils/image/webp/WebpBinaryResolver.ts";
+const BINARY = "(?:cwebp|dwebp|webpmux)";
+
+/**
+ * A production file "directly executes" a libwebp tool when it launches the
+ * binary itself — a literal cwebp/dwebp/webpmux name handed to a process API, or
+ * a path resolved from the owner's resolveCwebp/resolveDwebp then spawned. The
+ * blessed path is `WebpBinaryProvider.runCwebp` / `runDwebp` on the owner, which
+ * this heuristic deliberately does not flag.
+ */
+function directlyExecutesWebp(source: string): boolean {
+  const launchApis = "(?:spawn|spawnSync|exec|execFile|execFileSync)";
+  const directLiteral = new RegExp(`\\b${launchApis}\\s*\\(\\s*["'\`][^"'\`]*${BINARY}`, "i");
+  const bunSpawnLiteral = new RegExp(`Bun\\.spawn\\s*\\(\\s*\\[\\s*["'\`][^"'\`]*${BINARY}`, "i");
+
+  const resolverVarNames = [
+    ...source.matchAll(/\b(?:const|let|var)\s+(\w+)\s*=\s*(?:await\s+)?[^;]*\.(?:resolveCwebp|resolveDwebp)\s*\([^;]*;/g)
+  ].map(match => match[1]);
+  const resolverVarLaunch = resolverVarNames.some(name =>
+    new RegExp(`\\b${launchApis}\\s*\\(\\s*${name}\\b|Bun\\.spawn\\s*\\(\\s*\\[\\s*${name}\\b|\\.spawn\\s*\\(\\s*${name}\\b`).test(source)
+  );
+
+  return directLiteral.test(source) || bunSpawnLiteral.test(source) || resolverVarLaunch;
+}
+
+function sourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) {return sourceFiles(path);}
+    return entry.name.endsWith(".ts") ? [path] : [];
+  });
+}
+
+describe("webp codec execution boundary (issue #4064)", () => {
+  test("only WebpBinaryResolver directly executes cwebp/dwebp/webpmux", () => {
+    const exceptions = new Map<string, string>([
+      // Diagnostic-only references are allowed only with a concrete reason here.
+    ]);
+    const offenders = sourceFiles(join(ROOT, "src")).flatMap(file => {
+      const repoPath = relative(ROOT, file).split("\\").join("/");
+      if (repoPath === OWNER || exceptions.has(repoPath)) {return [];}
+      const source = readFileSync(file, "utf8");
+      return directlyExecutesWebp(source)
+        ? [`${repoPath} directly executes a libwebp tool; route it through ${OWNER} (WebpBinaryProvider.runCwebp/runDwebp) instead.`]
+        : [];
+    });
+
+    expect(offenders, offenders.join("\n")).toEqual([]);
+  });
+
+  test("the owner is the single production boundary that resolves and executes the tools", () => {
+    const owner = readFileSync(join(ROOT, OWNER), "utf8");
+    expect(owner).toContain("async runCwebp(");
+    expect(owner).toContain("async runDwebp(");
+    expect(owner).toContain("this.processExecutor.spawn(");
+
+    const codec = readFileSync(join(ROOT, "src/utils/image/webp/CliWebpCodec.ts"), "utf8");
+    expect(codec).not.toContain(".spawn(");
+    expect(codec).toContain("this.binaryResolver.runCwebp(");
+    expect(codec).toContain("this.binaryResolver.runDwebp(");
+  });
+
+  test("flags literal binary names and resolved paths passed to launch APIs", () => {
+    expect(directlyExecutesWebp('spawn("cwebp", ["-o", "-"]);')).toBe(true);
+    expect(directlyExecutesWebp('execFile("dwebp", args);')).toBe(true);
+    expect(directlyExecutesWebp('Bun.spawn(["webpmux", "-info", file]);')).toBe(true);
+    expect(directlyExecutesWebp(
+      "const command = await this.binaryResolver.resolveCwebp(); this.executor.spawn(command, args);"
+    )).toBe(true);
+    expect(directlyExecutesWebp(
+      "const bin = await resolver.resolveDwebp(); execFile(bin, args);"
+    )).toBe(true);
+  });
+
+  test("does not flag the blessed runCwebp/runDwebp delegation", () => {
+    expect(directlyExecutesWebp("const output = await this.binaryResolver.runCwebp(args, pngBuffer);")).toBe(false);
+    expect(directlyExecutesWebp('return this.binaryResolver.runDwebp(["-o", "-", "--", "-"], webpBuffer);')).toBe(false);
+    expect(directlyExecutesWebp("const binaries = await new WebpBinaryResolver().resolve();")).toBe(false);
+  });
+
+  test("every documented exception still exists", () => {
+    const exceptions = new Map<string, string>([
+      // Keep this list empty unless a production diagnostic cannot use the owner.
+    ]);
+    expect(
+      [...exceptions.keys()].filter(path => !sourceFiles(join(ROOT, "src")).some(file => relative(ROOT, file).split("\\").join("/") === path))
+    ).toEqual([]);
+  });
+});

--- a/test/utils/image/webp/CliWebpCodec.test.ts
+++ b/test/utils/image/webp/CliWebpCodec.test.ts
@@ -1,22 +1,48 @@
 import { describe, expect, test } from "bun:test";
 import { ActionableError } from "../../../../src/models/ActionableError";
 import { CliWebpCodec, isWebpBuffer } from "../../../../src/utils/image/webp/CliWebpCodec";
-import { defaultTimer } from "../../../../src/utils/SystemTimer";
-import { FakeChildProcess } from "../../../fakes/FakeChildProcess";
-import { FakeProcessExecutor } from "../../../fakes/FakeProcessExecutor";
+import type { WebpBinaryProvider } from "../../../../src/utils/image/webp/WebpBinaryResolver";
 
-class FakeWebpBinaryResolver {
+interface RecordedRun {
+  binary: "cwebp" | "dwebp";
+  args: string[];
+  input: Buffer;
+}
+
+/**
+ * Fake owner: records argv/input and returns a canned buffer (or throws) so the
+ * codec's argv construction and buffer sniffing can be tested without spawning.
+ */
+class FakeWebpBinaryProvider implements WebpBinaryProvider {
+  readonly runs: RecordedRun[] = [];
+
   constructor(
-    private readonly cwebpPath = "/tools/cwebp",
-    private readonly dwebpPath = "/tools/dwebp"
+    private readonly cwebpOutput: Buffer | Error = Buffer.from("RIFFxxxxWEBPencoded"),
+    private readonly dwebpOutput: Buffer | Error = Buffer.from("png-output")
   ) {}
 
   async resolveCwebp(): Promise<string> {
-    return this.cwebpPath;
+    return "/tools/cwebp";
   }
 
   async resolveDwebp(): Promise<string> {
-    return this.dwebpPath;
+    return "/tools/dwebp";
+  }
+
+  async runCwebp(args: string[], input: Buffer): Promise<Buffer> {
+    this.runs.push({ binary: "cwebp", args, input });
+    if (this.cwebpOutput instanceof Error) {
+      throw this.cwebpOutput;
+    }
+    return this.cwebpOutput;
+  }
+
+  async runDwebp(args: string[], input: Buffer): Promise<Buffer> {
+    this.runs.push({ binary: "dwebp", args, input });
+    if (this.dwebpOutput instanceof Error) {
+      throw this.dwebpOutput;
+    }
+    return this.dwebpOutput;
   }
 }
 
@@ -29,132 +55,72 @@ describe("isWebpBuffer", () => {
 });
 
 describe("CliWebpCodec", () => {
-  test("encodes PNG input through cwebp stdin/stdout with quality flags", async () => {
-    const processExecutor = new FakeProcessExecutor();
-    const child = new FakeChildProcess();
-    child.addStdoutData(Buffer.from("RIFFxxxxWEBPencoded"));
-    processExecutor.setNextSpawnProcess(child);
-    const codec = new CliWebpCodec(new FakeWebpBinaryResolver(), processExecutor);
+  test("encodes PNG input through the resolver with quality flags", async () => {
+    const provider = new FakeWebpBinaryProvider();
+    const codec = new CliWebpCodec(provider);
     const input = Buffer.from("png-data");
 
-    const encodedPromise = codec.encode(input, { quality: 60 });
-    child.simulateSpawn();
-    child.simulateExit(0);
-    const encoded = await encodedPromise;
+    const encoded = await codec.encode(input, { quality: 60 });
 
     expect(encoded.toString()).toBe("RIFFxxxxWEBPencoded");
-    expect(child.getStdinData()).toEqual(input);
-    expect(processExecutor.getSpawnedProcesses()).toMatchObject([
-      {
-        command: "/tools/cwebp",
-        args: ["-q", "60", "-o", "-", "--", "-"]
-      }
+    expect(provider.runs).toEqual([
+      { binary: "cwebp", args: ["-q", "60", "-o", "-", "--", "-"], input }
     ]);
   });
 
   test("maps lossless and near-lossless cwebp flags", async () => {
-    const processExecutor = new FakeProcessExecutor();
-    for (const options of [{ lossless: true, quality: 75 }, { nearLossless: true, quality: 40 }]) {
-      const child = new FakeChildProcess();
-      child.addStdoutData(Buffer.from("RIFFxxxxWEBPencoded"));
-      processExecutor.setNextSpawnProcess(child);
-      const promise = new CliWebpCodec(new FakeWebpBinaryResolver(), processExecutor).encode(Buffer.from("png"), options);
-      child.simulateSpawn();
-      child.simulateExit(0);
-      await promise;
-    }
+    const provider = new FakeWebpBinaryProvider();
+    const codec = new CliWebpCodec(provider);
 
-    const spawns = processExecutor.getSpawnedProcesses();
-    expect(spawns[0].args).toEqual(["-lossless", "-q", "75", "-o", "-", "--", "-"]);
-    expect(spawns[1].args).toEqual(["-near_lossless", "40", "-o", "-", "--", "-"]);
+    await codec.encode(Buffer.from("png"), { lossless: true, quality: 75 });
+    await codec.encode(Buffer.from("png"), { nearLossless: true, quality: 40 });
+
+    expect(provider.runs[0].args).toEqual(["-lossless", "-q", "75", "-o", "-", "--", "-"]);
+    expect(provider.runs[1].args).toEqual(["-near_lossless", "40", "-o", "-", "--", "-"]);
   });
 
-  test("decodes WebP input through dwebp stdin/stdout", async () => {
-    const processExecutor = new FakeProcessExecutor();
-    const child = new FakeChildProcess();
-    child.addStdoutData(Buffer.from("png-output"));
-    processExecutor.setNextSpawnProcess(child);
-    const codec = new CliWebpCodec(new FakeWebpBinaryResolver(), processExecutor);
+  test("decodes WebP input through the resolver", async () => {
+    const provider = new FakeWebpBinaryProvider();
+    const codec = new CliWebpCodec(provider);
     const input = Buffer.from("RIFFxxxxWEBPdata");
 
-    const decodedPromise = codec.decode(input);
-    child.simulateSpawn();
-    child.simulateExit(0);
-    const decoded = await decodedPromise;
+    const decoded = await codec.decode(input);
 
     expect(decoded.toString()).toBe("png-output");
-    expect(child.getStdinData()).toEqual(input);
-    expect(processExecutor.getSpawnedProcesses()).toMatchObject([
-      {
-        command: "/tools/dwebp",
-        args: ["-o", "-", "--", "-"]
-      }
+    expect(provider.runs).toEqual([
+      { binary: "dwebp", args: ["-o", "-", "--", "-"], input }
     ]);
   });
 
-  test("waits for stdio close before reading codec stdout", async () => {
-    const processExecutor = new FakeProcessExecutor();
-    const child = new FakeChildProcess();
-    processExecutor.setNextSpawnProcess(child);
-    const codec = new CliWebpCodec(new FakeWebpBinaryResolver(), processExecutor);
+  test("rejects encode output that is not WebP", async () => {
+    const provider = new FakeWebpBinaryProvider(Buffer.from("not-webp"));
+    const codec = new CliWebpCodec(provider);
 
-    const encodedPromise = codec.encode(Buffer.from("png"));
-    child.simulateSpawn();
-    defaultTimer.setTimeout(() => {
-      child.exitCode = 0;
-      child.emit("exit", 0, null);
-      child.stdout.push(Buffer.from("RIFFxxxxWEBPencoded"));
-      child.stdout.push(null);
-      child.stderr.push(null);
-      child.emit("close", 0, null);
-    }, 0);
-    const encoded = await encodedPromise;
+    const thrown = await codec.encode(Buffer.from("png")).catch(error => error);
 
-    expect(encoded.toString()).toBe("RIFFxxxxWEBPencoded");
+    expect(thrown).toBeInstanceOf(ActionableError);
+    expect(thrown.message).toContain("WebP");
+    expect(thrown.message).toContain("AUTOMOBILE_CWEBP_PATH");
   });
 
-  test("rejects decode input that is not WebP", async () => {
-    const codec = new CliWebpCodec(new FakeWebpBinaryResolver(), new FakeProcessExecutor());
+  test("rejects decode input that is not WebP before spawning", async () => {
+    const provider = new FakeWebpBinaryProvider();
+    const codec = new CliWebpCodec(provider);
 
     const thrown = await codec.decode(Buffer.from("not-webp")).catch(error => error);
 
     expect(thrown).toBeInstanceOf(ActionableError);
     expect(thrown.message).toContain("WebP");
+    expect(provider.runs).toEqual([]);
   });
 
-  test("surfaces subprocess failures as actionable errors", async () => {
-    const processExecutor = new FakeProcessExecutor();
-    const child = new FakeChildProcess();
-    child.addStderrData("bad webp");
-    processExecutor.setNextSpawnProcess(child);
-    const codec = new CliWebpCodec(new FakeWebpBinaryResolver(), processExecutor);
+  test("propagates resolver execution failures unchanged", async () => {
+    const failure = new ActionableError("cwebp failed (exited with code 1: bad webp). Set AUTOMOBILE_CWEBP_PATH to a working cwebp binary.");
+    const provider = new FakeWebpBinaryProvider(failure);
+    const codec = new CliWebpCodec(provider);
 
-    const encodedPromise = codec.encode(Buffer.from("png"));
-    child.simulateSpawn();
-    child.simulateExit(1);
-    const thrown = await encodedPromise.catch(error => error);
+    const thrown = await codec.encode(Buffer.from("png")).catch(error => error);
 
-    expect(thrown).toBeInstanceOf(ActionableError);
-    expect(thrown.message).toContain("cwebp");
-    expect(thrown.message).toContain("AUTOMOBILE_CWEBP_PATH");
-    expect(thrown.message).toContain("bad webp");
-  });
-
-  test("surfaces stdin write failures as actionable errors", async () => {
-    const processExecutor = new FakeProcessExecutor();
-    const child = new FakeChildProcess();
-    child.setStdinError("write EPIPE");
-    processExecutor.setNextSpawnProcess(child);
-    const codec = new CliWebpCodec(new FakeWebpBinaryResolver(), processExecutor);
-
-    const encodedPromise = codec.encode(Buffer.from("png"));
-    child.simulateSpawn();
-    child.simulateExit(1);
-    const thrown = await encodedPromise.catch(error => error);
-
-    expect(thrown).toBeInstanceOf(ActionableError);
-    expect(thrown.message).toContain("cwebp");
-    expect(thrown.message).toContain("AUTOMOBILE_CWEBP_PATH");
-    expect(thrown.message).toContain("write EPIPE");
+    expect(thrown).toBe(failure);
   });
 });

--- a/test/utils/image/webp/WebpBinaryResolver.test.ts
+++ b/test/utils/image/webp/WebpBinaryResolver.test.ts
@@ -7,6 +7,7 @@ import type { FileDownloader } from "../../../../src/utils/FileDownloader";
 import { WebpBinaryResolver } from "../../../../src/utils/image/webp/WebpBinaryResolver";
 import { defaultTimer } from "../../../../src/utils/SystemTimer";
 import { FakeChecksumCalculator } from "../../../fakes/FakeChecksumCalculator";
+import { FakeChildProcess } from "../../../fakes/FakeChildProcess";
 import { FakeFileDownloader } from "../../../fakes/FakeFileDownloader";
 import { FakeProcessExecutor } from "../../../fakes/FakeProcessExecutor";
 
@@ -327,5 +328,131 @@ describe("WebpBinaryResolver", () => {
     expect(thrown).toBeInstanceOf(ActionableError);
     expect(thrown.message).toContain("AUTOMOBILE_CWEBP_PATH");
     expect(thrown.message).toContain("cwebp");
+  });
+});
+
+/**
+ * Drive a FakeChildProcess once the codec has written stdin and attached its
+ * listeners. Keying off `stdin` finish makes ordering deterministic regardless
+ * of how long the real filesystem resolution ahead of the spawn takes. Data is
+ * pushed synchronously; `close` fires on a later macrotask so the readable
+ * `data` events flush first.
+ */
+function driveChild(
+  child: FakeChildProcess,
+  { stdout = Buffer.alloc(0), stderr = "", exitCode = 0 }: { stdout?: Buffer; stderr?: string; exitCode?: number } = {}
+): void {
+  child.stdin.on("finish", () => {
+    if (stdout.length > 0) {
+      child.stdout.push(stdout);
+    }
+    child.stdout.push(null);
+    if (stderr) {
+      child.stderr.push(Buffer.from(stderr));
+    }
+    child.stderr.push(null);
+    defaultTimer.setTimeout(() => {
+      child.exitCode = exitCode;
+      child.emit("exit", exitCode, null);
+      child.emit("close", exitCode, null);
+    }, 0);
+  });
+}
+
+async function resolverWithExecutable(
+  binary: "cwebp" | "dwebp",
+  processExecutor: FakeProcessExecutor
+): Promise<WebpBinaryResolver> {
+  const root = await makeTempDir();
+  const binaryPath = path.join(root, "bin", binary);
+  await writeExecutable(binaryPath);
+  const envVar = binary === "cwebp" ? "AUTOMOBILE_CWEBP_PATH" : "AUTOMOBILE_DWEBP_PATH";
+  return new WebpBinaryResolver({
+    projectRoot: root,
+    platform: "darwin",
+    arch: "arm64",
+    env: { [envVar]: binaryPath, PATH: "" },
+    processExecutor
+  });
+}
+
+describe("WebpBinaryResolver codec execution", () => {
+  test("resolves cwebp then spawns it with structural argv over stdin/stdout", async () => {
+    const processExecutor = new FakeProcessExecutor();
+    const child = new FakeChildProcess();
+    driveChild(child, { stdout: Buffer.from("RIFFxxxxWEBPencoded") });
+    processExecutor.setNextSpawnProcess(child);
+    const resolver = await resolverWithExecutable("cwebp", processExecutor);
+    const input = Buffer.from("png-data");
+
+    const output = await resolver.runCwebp(["-q", "60", "-o", "-", "--", "-"], input);
+
+    expect(output.toString()).toBe("RIFFxxxxWEBPencoded");
+    expect(child.getStdinData()).toEqual(input);
+    const spawned = processExecutor.getSpawnedProcesses();
+    expect(spawned).toHaveLength(1);
+    expect(spawned[0].args).toEqual(["-q", "60", "-o", "-", "--", "-"]);
+    expect(spawned[0].command).toContain("cwebp");
+  });
+
+  test("runDwebp spawns the resolved dwebp binary", async () => {
+    const processExecutor = new FakeProcessExecutor();
+    const child = new FakeChildProcess();
+    driveChild(child, { stdout: Buffer.from("png-output") });
+    processExecutor.setNextSpawnProcess(child);
+    const resolver = await resolverWithExecutable("dwebp", processExecutor);
+
+    const output = await resolver.runDwebp(["-o", "-", "--", "-"], Buffer.from("RIFFxxxxWEBPdata"));
+
+    expect(output.toString()).toBe("png-output");
+    expect(processExecutor.getSpawnedProcesses()[0].command).toContain("dwebp");
+  });
+
+  test("surfaces non-zero exit with stderr detail as an actionable error", async () => {
+    const processExecutor = new FakeProcessExecutor();
+    const child = new FakeChildProcess();
+    driveChild(child, { stderr: "bad webp", exitCode: 1 });
+    processExecutor.setNextSpawnProcess(child);
+    const resolver = await resolverWithExecutable("cwebp", processExecutor);
+
+    const thrown = await resolver.runCwebp(["-o", "-", "--", "-"], Buffer.from("png")).catch(error => error);
+
+    expect(thrown).toBeInstanceOf(ActionableError);
+    expect(thrown.message).toContain("cwebp");
+    expect(thrown.message).toContain("AUTOMOBILE_CWEBP_PATH");
+    expect(thrown.message).toContain("bad webp");
+  });
+
+  test("surfaces stdin write failures as actionable errors", async () => {
+    const processExecutor = new FakeProcessExecutor();
+    const child = new FakeChildProcess();
+    child.setStdinError("write EPIPE");
+    processExecutor.setNextSpawnProcess(child);
+    const resolver = await resolverWithExecutable("cwebp", processExecutor);
+
+    const thrown = await resolver.runCwebp(["-o", "-", "--", "-"], Buffer.from("png")).catch(error => error);
+
+    expect(thrown).toBeInstanceOf(ActionableError);
+    expect(thrown.message).toContain("cwebp");
+    expect(thrown.message).toContain("AUTOMOBILE_CWEBP_PATH");
+    expect(thrown.message).toContain("write EPIPE");
+  });
+
+  test("propagates missing-binary resolution failures before spawning", async () => {
+    const root = await makeTempDir();
+    const processExecutor = new FakeProcessExecutor();
+    const resolver = new WebpBinaryResolver({
+      projectRoot: root,
+      platform: "win32",
+      arch: "x64",
+      env: { PATH: "" },
+      processExecutor
+    });
+
+    const thrown = await resolver.runCwebp(["-o", "-", "--", "-"], Buffer.from("png")).catch(error => error);
+
+    expect(thrown).toBeInstanceOf(ActionableError);
+    expect(thrown.message).toContain("AUTOMOBILE_CWEBP_PATH");
+    expect(processExecutor.getSpawnedProcesses()).toEqual([]);
   });
 });


### PR DESCRIPTION
## Problem

External WebP codec process launching was split between two concerns:
`WebpBinaryResolver` resolved cwebp/dwebp paths while `CliWebpCodec` owned the
argv invocation and process lifecycle (spawn, stdin/stdout piping, close/error
handling). There was no owner boundary for execution and no static guard against
new direct invocations.

## Change

- `WebpBinaryResolver` is now the single injected owner that both **resolves and
  executes** the libwebp tools. New `runCwebp(args, input)` / `runDwebp(args, input)`
  methods on `WebpBinaryProvider` own the spawn, structural argv, child stdio,
  close/cancellation handling, and actionable errors.
- `CliWebpCodec` keeps only image-transformation semantics — building cwebp argv
  from options and sniffing WebP RIFF buffers — and delegates all execution to the
  injected owner. It no longer takes a `HostProcessExecutor`.
- Dynamic values (paths, argv) are passed structurally via argv, never
  shell-interpolated.
- New focused static guard `test/lint/webpExecutionBoundary.test.ts` blocks new
  direct `cwebp`/`dwebp`/`webpmux` invocations outside the owner, mirroring the
  existing execution-boundary guards. Documented (currently empty) exception map.
- Windows `cwebp` + off-platform download/extract behavior is preserved.

## Tests

Fakes only, all fast:
- Resolver codec-execution tests cover missing binaries, structural argv,
  codec-failure stderr, and stdin write failures.
- Codec tests cover argv construction, buffer sniffing (rejecting non-WebP input
  before spawn), and error propagation.
- Validation: affected image/doctor suites, `bun test test/lint/`,
  `bun run typecheck`, `bun run lint`, `bun run build` all green.

Closes [#4064](https://github.com/kaeawc/auto-mobile/issues/4064)
