### PR TITLE
refactor(server): consolidate ID generation onto IdGenerator seam

### DIFF
--- a/src/server/appFileService.ts
+++ b/src/server/appFileService.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import { promises as nodeFs } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, posix, relative } from "node:path";
@@ -17,6 +16,7 @@ import {
 } from "./appFileContract";
 import { ActionableError, BootedDevice, Platform, type ExecResult } from "../models";
 import { defaultAdbClientFactory, type AdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
+import { defaultIdGenerator, type IdGenerator } from "../utils/IdGenerator";
 import type { AdbExecutor } from "../utils/android-cmdline-tools/interfaces/AdbExecutor";
 import { SimCtlClient } from "../utils/ios-cmdline-tools/SimCtlClient";
 import { isIosSimulatorUdid } from "../utils/ios-cmdline-tools/iosDeviceType";
@@ -97,6 +97,7 @@ export interface AppFileServiceDependencies {
   fileSystem?: AppFileFileSystem;
   providers?: AppFileProvider[];
   deviceResolver?: (deviceId: string) => Promise<BootedDevice>;
+  idGenerator?: IdGenerator;
 }
 
 const nodeAppFileFileSystem: AppFileFileSystem = {
@@ -157,17 +158,18 @@ export function createAppFileServiceForTesting(deps: AppFileServiceDependencies 
     deviceResolver: deps.deviceResolver ?? defaultDependencies.deviceResolver,
   };
   return new DefaultAppFileService(
-    deps.providers ?? createDefaultProviders(resolvedDeps),
+    deps.providers ?? createDefaultProviders(resolvedDeps, deps.idGenerator ?? defaultIdGenerator),
     resolvedDeps.deviceResolver,
     resolvedDeps.fileSystem
   );
 }
 
 function createDefaultProviders(
-  deps: Required<Pick<AppFileServiceDependencies, "adbFactory" | "simctlFactory" | "fileSystem">>
+  deps: Required<Pick<AppFileServiceDependencies, "adbFactory" | "simctlFactory" | "fileSystem">>,
+  idGenerator: IdGenerator = defaultIdGenerator
 ): AppFileProvider[] {
   return [
-    new AndroidAppFileProvider(deps.adbFactory),
+    new AndroidAppFileProvider(deps.adbFactory, idGenerator),
     new IosSimulatorAppFileProvider(deps.simctlFactory, deps.fileSystem),
   ];
 }
@@ -284,7 +286,10 @@ class DefaultAppFileService implements AppFileService {
 class AndroidAppFileProvider implements AppFileProvider {
   readonly platform = "android" as const;
 
-  constructor(private readonly adbFactory: AdbClientFactory) {}
+  constructor(
+    private readonly adbFactory: AdbClientFactory,
+    private readonly idGenerator: IdGenerator = defaultIdGenerator
+  ) {}
 
   async putFile(request: PutAppFileProviderRequest): Promise<void> {
     const adb = this.adbFactory.create(request.device);
@@ -309,7 +314,7 @@ class AndroidAppFileProvider implements AppFileProvider {
       return;
     }
 
-    const tempDevicePath = `/data/local/tmp/automobile-${randomUUID()}-${posix.basename(request.destinationPath)}`;
+    const tempDevicePath = `/data/local/tmp/automobile-${this.idGenerator.next()}-${posix.basename(request.destinationPath)}`;
     await executeAndroidAppFileCommand(
       adb,
       `push ${shellQuote(request.sourcePath)} ${shellQuote(tempDevicePath)}`,

--- a/src/server/deviceTools.ts
+++ b/src/server/deviceTools.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { randomUUID } from "node:crypto";
+import { defaultIdGenerator, type IdGenerator } from "../utils/IdGenerator";
 import { ToolRegistry, ProgressCallback } from "./toolRegistry";
 import { MultiPlatformDeviceManager, PlatformDeviceManager } from "../utils/deviceUtils";
 import { createJSONToolResponse } from "../utils/toolUtils";
@@ -111,6 +111,7 @@ export interface DeviceToolsDependencies {
   ensureCtrlProxyReady?: (device: BootedDevice, perf: ReturnType<typeof createPerformanceTracker>) => Promise<void>;
   deviceCreationGateFactory: () => DeviceCreationGate;
   deviceProvisionerFactory: () => DeviceProvisioner;
+  idGenerator: IdGenerator;
 }
 
 async function defaultNotifyResourcesChanged(): Promise<void> {
@@ -129,6 +130,7 @@ function getDeviceToolsDependencies(): DeviceToolsDependencies {
       notifyResourcesChanged: defaultNotifyResourcesChanged,
       deviceCreationGateFactory: () => getDeviceCreationGate(),
       deviceProvisionerFactory: () => createDefaultDeviceProvisioner(),
+      idGenerator: defaultIdGenerator,
     };
   }
   return moduleDependencies;
@@ -143,6 +145,7 @@ export function setDeviceToolsDependencies(deps: Partial<DeviceToolsDependencies
     ensureCtrlProxyReady: deps.ensureCtrlProxyReady ?? currentDeps.ensureCtrlProxyReady,
     deviceCreationGateFactory: deps.deviceCreationGateFactory ?? currentDeps.deviceCreationGateFactory,
     deviceProvisionerFactory: deps.deviceProvisionerFactory ?? currentDeps.deviceProvisionerFactory,
+    idGenerator: deps.idGenerator ?? currentDeps.idGenerator,
   };
 }
 
@@ -321,7 +324,7 @@ export function registerDeviceTools() {
         .autolockDevice(device.deviceId, device.platform, args.__mcpSessionId);
     }
     if (!sessionId) {
-      sessionId = randomUUID();
+      sessionId = deps.idGenerator.next();
       if (DaemonState.getInstance().isInitialized()) {
         sessionId = await DaemonState.getInstance()
           .getDevicePool()

--- a/src/server/highlightTools.ts
+++ b/src/server/highlightTools.ts
@@ -13,7 +13,7 @@ import {
   ViewHierarchyResult
 } from "../models";
 import { highlightShapeSchema, VisualHighlightClient } from "../features/debug/VisualHighlight";
-import { recordVideoRecordingHighlightAdded } from "./videoRecordingManager";
+import { generateHighlightId, recordVideoRecordingHighlightAdded } from "./videoRecordingManager";
 import { defaultAdbClientFactory } from "../utils/android-cmdline-tools/AdbClientFactory";
 import { AndroidCtrlProxyClient } from "../features/observe/android";
 import { IOSCtrlProxyClient } from "../features/observe/ios";
@@ -21,8 +21,6 @@ import { DefaultElementSelector } from "../features/utility/DefaultElementSelect
 import { DefaultElementFinder } from "../features/utility/ElementFinder";
 import { DefaultElementParser } from "../features/utility/ElementParser";
 import { NoOpPerformanceTracker, type PerformanceTracker } from "../utils/PerformanceTracker";
-import { defaultTimer, type Timer } from "../utils/SystemTimer";
-import { createTimestampedId } from "../utils/IdGenerator";
 import {
   elementContainerSchema,
   elementIdTextFieldsSchema,
@@ -30,10 +28,6 @@ import {
   validateElementIdTextSelector
 } from "./elementSelectorSchemas";
 import { boundsEqual } from "../utils/bounds";
-
-const generateHighlightId = (timer: Timer = defaultTimer): string => {
-  return createTimestampedId("highlight", timer);
-};
 
 const highlightBaseSchema = z.object({
   platform: platformSchema,

--- a/src/server/testRecordingManager.ts
+++ b/src/server/testRecordingManager.ts
@@ -1,10 +1,10 @@
-import { randomUUID } from "node:crypto";
 import * as yaml from "js-yaml";
 import { BootedDevice, Plan, PlanStep } from "../models";
 import { logger } from "../utils/logger";
 import { getMcpServerVersion, releaseVersion } from "../utils/mcpVersion";
 import { PlanValidator } from "../utils/plan/PlanValidator";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
+import { defaultIdGenerator, type IdGenerator } from "../utils/IdGenerator";
 import { DualTrackRecorder } from "../features/record/android";
 
 interface TestRecordingStartResult {
@@ -110,7 +110,11 @@ const formatPlanName = (planName?: string): string => {
   return `recorded-plan-${timestamp}`;
 };
 
-export async function startTestRecording(device: BootedDevice, timer: Timer = defaultTimer): Promise<TestRecordingStartResult> {
+export async function startTestRecording(
+  device: BootedDevice,
+  timer: Timer = defaultTimer,
+  idGenerator: IdGenerator = defaultIdGenerator
+): Promise<TestRecordingStartResult> {
   if (activeRecording) {
     if (activeRecording.deviceId !== device.deviceId) {
       throw new Error(
@@ -131,7 +135,7 @@ export async function startTestRecording(device: BootedDevice, timer: Timer = de
     throw new Error(`Test recording is only supported on Android right now (got ${device.platform}).`);
   }
 
-  const recordingId = randomUUID();
+  const recordingId = idGenerator.next();
   const startedAt = timer.now();
 
   const recorder = new DualTrackRecorder(device);

--- a/src/server/videoRecordingManager.ts
+++ b/src/server/videoRecordingManager.ts
@@ -332,7 +332,12 @@ function highlightAnimationDurationMs(platform: BootedDevice["platform"]): numbe
     : ANDROID_HIGHLIGHT_ANIMATION_DURATION_MS;
 }
 
-function generateHighlightId(timer: Timer = defaultTimer): string {
+/**
+ * Canonical highlight-id factory. Formats an operator-visible `highlight_<ts>_<uuid>`
+ * whose uniqueness comes from the injected {@link createTimestampedId} primitive.
+ * Exported so `highlightTools` shares this one path rather than re-inlining it.
+ */
+export function generateHighlightId(timer: Timer = defaultTimer): string {
   return createTimestampedId("highlight", timer);
 }
 

--- a/test/server/appFileService.test.ts
+++ b/test/server/appFileService.test.ts
@@ -10,6 +10,7 @@ import {
 import type { BootedDevice } from "../../src/models";
 import type { AdbClientFactory } from "../../src/utils/android-cmdline-tools/AdbClientFactory";
 import { DAEMON_LAUNCH_CWD_ENV } from "../../src/utils/workingDirectory";
+import { CountingIdGenerator } from "../../src/utils/IdGenerator";
 import { FakeAdbClientFactory } from "../fakes/FakeAdbClientFactory";
 import { FakeAdbExecutor } from "../fakes/FakeAdbExecutor";
 import { FakeSimCtlClient } from "../fakes/FakeSimCtlClient";
@@ -169,6 +170,35 @@ describe("AppFileService", () => {
     expect(commands[1]).toContain("/data/local/tmp/automobile-");
     expect(commands[1]).toContain("files/fixtures/welcome file.txt");
     expect(commands[2]).toContain("shell rm -f '/data/local/tmp/automobile-");
+  });
+
+  test("sources the run-as temp path token from the injected IdGenerator", async () => {
+    const adbFactory = new FakeAdbClientFactory();
+    const service = createAppFileServiceForTesting({
+      adbFactory,
+      idGenerator: new CountingIdGenerator("tmp"),
+      simctlFactory: () => {
+        throw new Error("simctl not used");
+      },
+    });
+    const device: BootedDevice = {
+      deviceId: "emulator-5554",
+      name: "Pixel",
+      platform: "android",
+    };
+
+    await service.putFile({
+      device,
+      appId: "com.example.app",
+      container: "documents",
+      contentText: "hello",
+      destinationPath: "fixtures/welcome.txt",
+    });
+
+    const commands = adbFactory.getFakeClient().getAllCommands();
+    // Deterministic token proves randomUUID() was routed onto the IdGenerator seam (issue #3511).
+    expect(commands[0]).toContain("/data/local/tmp/automobile-tmp-1-welcome.txt");
+    expect(commands[2]).toContain("/data/local/tmp/automobile-tmp-1-welcome.txt");
   });
 
   test("lists missing Android containers as empty instead of failing find", async () => {

--- a/test/server/deviceTools.startDevice.test.ts
+++ b/test/server/deviceTools.startDevice.test.ts
@@ -8,6 +8,7 @@ import { DaemonState } from "../../src/daemon/daemonState";
 import { SessionManager } from "../../src/daemon/sessionManager";
 import { DevicePool } from "../../src/daemon/devicePool";
 import { FakeTimer } from "../fakes/FakeTimer";
+import { CountingIdGenerator } from "../../src/utils/IdGenerator";
 import { DEFAULT_DEVICE_READY_TIMEOUT_MS } from "../../src/utils/deviceUtils";
 import * as os from "os";
 
@@ -99,6 +100,21 @@ describe("startDevice handler", () => {
     expect(result.osVersion).toBe("14");
     expect(result.sessionId).toBeDefined();
     expect(typeof result.sessionId).toBe("string");
+  });
+
+  it("sources the fallback sessionId from the injected IdGenerator", async () => {
+    // Daemon is not initialized here, so the session UUID is minted directly by
+    // the injected generator rather than the pool — proving the randomUUID() call
+    // was routed onto the IdGenerator seam (issue #3511).
+    setDeviceToolsDependencies({ idGenerator: new CountingIdGenerator("session") });
+    registerDeviceTools();
+
+    fakeDeviceUtils.setBootedDevices("android", [androidDevice]);
+    fakeMatcher.setBootedResult(androidDevice);
+
+    const result = await callStartDevice({ platform: "android" });
+
+    expect(result.sessionId).toBe("session-1");
   });
 
   it("fails closed on an unusable iOS runner override, before touching the cached runner (#4221)", async () => {


### PR DESCRIPTION
## Summary

Partial fix for [#3511](https://github.com/kaeawc/auto-mobile/issues/3511) — aligns the **server layer** with CLAUDE.md's "one canonical primitive per concern: UUIDs come from `IdGenerator`". The daemon layer is deferred (see Remaining).

- **De-duplicate `generateHighlightId`.** The helper was verbatim-copied in `highlightTools.ts` and `videoRecordingManager.ts`. Export the single canonical one from `videoRecordingManager` and import it into `highlightTools`, deleting the duplicate and its now-unused `Timer`/`createTimestampedId` imports.
- **Route the server-layer `randomUUID()` sites through the injected `IdGenerator`:**
  - `deviceTools` — added `idGenerator` to `DeviceToolsDependencies`; the fallback session UUID now comes from `deps.idGenerator.next()`.
  - `testRecordingManager.startTestRecording` — added an `idGenerator` default param mirroring the existing `timer` seam, for the recording id.
  - `appFileService` — threaded `idGenerator` through `AppFileServiceDependencies` into `AndroidAppFileProvider` for the run-as temp-path token.

Behavior is preserved: the default `NodeIdGenerator` still calls `randomUUID()`. The value is an injectable, testable seam. The `Math.random()`/`slice` variants the issue lists (`highlightTools`, `videoRecordingManager`, `ScreenshotJobTracker`) had already been migrated onto `createTimestampedId` on `main`.

## Tests

- New unit tests inject a `CountingIdGenerator` to prove the routing:
  - `deviceTools.startDevice` — the fallback `sessionId` is `session-1`.
  - `appFileService` — the run-as temp path token is deterministic (`automobile-tmp-1-…`).
- Existing `highlightTools` / `videoRecordingManager` tests cover the de-dup.

## Remaining (follow-up)

The daemon-layer `randomUUID()` sites are **not** in this PR — their constructors are heavily overloaded and core to daemon bring-up, so they warrant their own reviewed change:

- `src/daemon/client.ts` (2 sites — request ids)
- `src/daemon/socketServer.ts` (session id)
- `src/daemon/devicePool.ts` (session id)

The issue's third checkbox — a lint rule banning raw `randomUUID()`/`Math.random()` in `src/` outside the primitives — should land only once those daemon sites are converted, otherwise the rule fails immediately.

## Validation

- `bun test test/server/` — 1556 pass
- `bun test test/lint/` — 194 pass
- `bun run typecheck` — no new type errors
- `bun run lint` — clean

Refs [#3511](https://github.com/kaeawc/auto-mobile/issues/3511)
