### PR TITLE
perf(android-video): frame packet header+payload into one socket write

### DIFF
--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamProtocol.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamProtocol.kt
@@ -70,4 +70,22 @@ object VideoStreamProtocol {
     } else {
       ByteBuffer.allocate(12).putLong(ptsAndFlags).putInt(size).array()
     }
+
+  /**
+   * Assemble the packet header and payload into a single contiguous buffer so each packet can be
+   * emitted with one `write` syscall and its header is never split from its payload across TCP
+   * segments (issue #4743).
+   */
+  fun framedPacket(
+    audioEnabled: Boolean,
+    trackId: Int,
+    ptsAndFlags: Long,
+    data: ByteArray,
+  ): ByteArray {
+    val header = packetHeader(audioEnabled, trackId, ptsAndFlags, data.size)
+    val framed = ByteArray(header.size + data.size)
+    System.arraycopy(header, 0, framed, 0, header.size)
+    System.arraycopy(data, 0, framed, header.size, data.size)
+    return framed
+  }
 }

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
@@ -283,8 +283,10 @@ class VideoStreamWriter(
     // audio resumes live when the replacement mux client attaches.
     val output = outputStream ?: return true
     try {
-      output.write(VideoStreamProtocol.packetHeader(audioEnabled, trackId, ptsAndFlags, data.size))
-      output.write(data)
+      // One write per packet: header + payload are framed into a single buffer so each packet
+      // costs one syscall instead of two and the header is never split from its payload across
+      // TCP segments (issue #4743).
+      output.write(VideoStreamProtocol.framedPacket(audioEnabled, trackId, ptsAndFlags, data))
       return true
     } catch (e: IOException) {
       println("Error writing packet: ${e.message}")

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamProtocolTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamProtocolTest.kt
@@ -151,6 +151,55 @@ class VideoStreamProtocolTest {
   }
 
   @Test
+  fun framedPacketConcatenatesHeaderThenPayloadInOneBuffer() {
+    val ptsAndFlags =
+      VideoStreamProtocol.ptsAndFlags(
+        presentationTimeUs = 123,
+        isConfig = true,
+        isKeyFrame = true,
+      )
+    val payload = byteArrayOf(0x0a, 0x0b, 0x0c)
+
+    val framed =
+      VideoStreamProtocol.framedPacket(
+        audioEnabled = false,
+        trackId = VideoStreamProtocol.TRACK_ID_VIDEO,
+        ptsAndFlags = ptsAndFlags,
+        data = payload,
+      )
+
+    // Header (12 bytes for legacy) + payload assembled into a single write buffer (issue #4743),
+    // byte-identical to header ++ payload so on-wire framing is unchanged.
+    val header =
+      VideoStreamProtocol.packetHeader(
+        audioEnabled = false,
+        trackId = VideoStreamProtocol.TRACK_ID_VIDEO,
+        ptsAndFlags = ptsAndFlags,
+        size = payload.size,
+      )
+    assertEquals(header.size + payload.size, framed.size)
+    assertArrayEquals(header, framed.copyOfRange(0, header.size))
+    assertArrayEquals(payload, framed.copyOfRange(header.size, framed.size))
+  }
+
+  @Test
+  fun framedPacketUsesLargerMuxHeaderWhenAudioEnabled() {
+    val payload = byteArrayOf(0x01, 0x02)
+
+    val framed =
+      VideoStreamProtocol.framedPacket(
+        audioEnabled = true,
+        trackId = VideoStreamProtocol.TRACK_ID_VIDEO,
+        ptsAndFlags = 5L,
+        data = payload,
+      )
+
+    // Mux packet header is 16 bytes; framed buffer is header ++ payload.
+    assertEquals(16 + payload.size, framed.size)
+    assertArrayEquals(payload, framed.copyOfRange(16, framed.size))
+  }
+
+  @Test
   fun replayedPacketFlagPreservesTheOriginalFlagsAndPts() {
     val original =
       VideoStreamProtocol.ptsAndFlags(


### PR DESCRIPTION
Closes [#4743](https://github.com/kaeawc/auto-mobile/issues/4743)

## Summary

Each encoded video/audio packet was written to the `LocalSocket` as two separate
`write()` calls — the framing header, then the payload — on the raw, unbuffered
`LocalSocket.outputStream`. At 30-60fps that is 60-120+ write syscalls/second and
lets TCP segmentation split each frame's small header away from its payload (the
classic small-header pessimization).

This change assembles the header and payload into a single contiguous buffer and
issues **one** `write` per packet. Combining the write also tightens on-wire
framing (header is never split from its payload across segments).

## Changes

- `VideoStreamProtocol.framedPacket(audioEnabled, trackId, ptsAndFlags, data)` — new
  pure helper that concatenates `packetHeader(...)` and the payload into one
  `ByteArray`. Pure and side-effect free, so the framing is directly unit-testable
  without a socket seam.
- `VideoStreamWriter.writePacketDataLocked(...)` — the two `output.write(...)` calls
  in the hot write path are replaced by a single `output.write(framedPacket(...))`.
  This is the only behavioral change to the writer.

The diff is deliberately kept to the write path only, to minimize conflicts with
sibling PRs #4745 and #4754 that also touch `VideoStreamWriter.kt`.

### Preserved invariants

- **Per-client cleanup** — the `IOException` handler (close client + mark the
  reconnect window detached) is unchanged.
- **Config/IDR replay path** — `replayCachedVideoLocked()` still routes through
  `writePacketDataLocked`, so replayed config + keyframe packets now also benefit
  from the single-write framing. The stream header (`writeStreamHeaderLocked`) is
  untouched.

## Validation

Ran locally with JDK 21 (Zulu 21.0.9) and `android/local.properties` (sdk.dir) set:

- `./gradlew :video-server:test` — BUILD SUCCESSFUL (includes two new
  `framedPacket` tests asserting header++payload concatenation for legacy and mux
  packet forms).
- `scripts/ktfmt/validate_ktfmt.sh` (touched files) — all Kotlin source properly
  formatted.
