### PR TITLE
refactor(db): de-duplicate event-repository getDb/cleanup + InstallApp user target

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -162,6 +162,11 @@
       "count": 1
     }
   },
+  "src/db/eventRepositoryBase.ts": {
+    "auto-mobile/no-unknown-cast": {
+      "count": 1
+    }
+  },
   "src/db/eventRetention.ts": {
     "auto-mobile/no-unknown-cast": {
       "count": 1
@@ -180,17 +185,11 @@
   "src/db/layoutEventRepository.ts": {
     "@typescript-eslint/no-floating-promises": {
       "count": 2
-    },
-    "auto-mobile/no-unknown-cast": {
-      "count": 1
     }
   },
   "src/db/logEventRepository.ts": {
     "@typescript-eslint/no-floating-promises": {
       "count": 2
-    },
-    "auto-mobile/no-unknown-cast": {
-      "count": 1
     }
   },
   "src/db/migrationLock.ts": {
@@ -206,9 +205,6 @@
   "src/db/navigationEventRepository.ts": {
     "@typescript-eslint/no-floating-promises": {
       "count": 2
-    },
-    "auto-mobile/no-unknown-cast": {
-      "count": 1
     }
   },
   "src/db/navigationRepository.ts": {
@@ -219,24 +215,15 @@
   "src/db/networkEventRepository.ts": {
     "@typescript-eslint/no-floating-promises": {
       "count": 1
-    },
-    "auto-mobile/no-unknown-cast": {
-      "count": 1
     }
   },
   "src/db/osEventRepository.ts": {
     "@typescript-eslint/no-floating-promises": {
       "count": 2
-    },
-    "auto-mobile/no-unknown-cast": {
-      "count": 1
     }
   },
   "src/db/storageEventRepository.ts": {
     "@typescript-eslint/no-floating-promises": {
-      "count": 1
-    },
-    "auto-mobile/no-unknown-cast": {
       "count": 1
     }
   },
@@ -372,14 +359,6 @@
       "count": 3
     }
   },
-  "src/features/action/PressButton.ts": {
-    "auto-mobile/catch-convention": {
-      "count": 1
-    },
-    "max-depth": {
-      "count": 1
-    }
-  },
   "src/features/action/RecentApps.ts": {
     "auto-mobile/catch-convention": {
       "count": 1
@@ -477,19 +456,13 @@
   },
   "src/features/navigation/DefaultUIStateSetup.ts": {
     "auto-mobile/catch-convention": {
-      "count": 2
+      "count": 1
     },
     "complexity": {
       "count": 2
-    },
-    "max-depth": {
-      "count": 3
     }
   },
   "src/features/navigation/Explore.ts": {
-    "auto-mobile/catch-convention": {
-      "count": 2
-    },
     "complexity": {
       "count": 3
     },
@@ -506,9 +479,6 @@
     }
   },
   "src/features/navigation/NavigateTo.ts": {
-    "auto-mobile/catch-convention": {
-      "count": 1
-    },
     "complexity": {
       "count": 1
     },
@@ -679,17 +649,11 @@
     }
   },
   "src/features/observe/ios/IOSCtrlProxyClient.ts": {
-    "@typescript-eslint/no-misused-promises": {
-      "count": 1
-    },
     "auto-mobile/catch-convention": {
       "count": 1
     },
     "complexity": {
-      "count": 3
-    },
-    "max-depth": {
-      "count": 1
+      "count": 2
     }
   },
   "src/features/observe/ios/IosScreenIdentity.ts": {
@@ -832,21 +796,11 @@
       "count": 1
     }
   },
-  "src/features/webrtc/PersistentEncoderH264Source.ts": {
-    "complexity": {
-      "count": 1
-    }
-  },
   "src/features/webrtc/VideoServerStreamParser.ts": {
     "complexity": {
       "count": 1
     },
     "max-depth": {
-      "count": 1
-    }
-  },
-  "src/features/webrtc/WebRtcPublisher.ts": {
-    "complexity": {
       "count": 1
     }
   },
@@ -908,7 +862,7 @@
       "count": 1
     },
     "max-depth": {
-      "count": 3
+      "count": 2
     }
   },
   "src/server/deviceImageResources.ts": {
@@ -931,7 +885,7 @@
       "count": 1
     },
     "auto-mobile/no-unknown-cast": {
-      "count": 3
+      "count": 2
     },
     "complexity": {
       "count": 3
@@ -1111,7 +1065,7 @@
       "count": 2
     },
     "complexity": {
-      "count": 8
+      "count": 7
     },
     "max-depth": {
       "count": 12

--- a/src/db/eventRepositoryBase.ts
+++ b/src/db/eventRepositoryBase.ts
@@ -1,0 +1,44 @@
+import type { Kysely } from "kysely";
+import type { Database } from "./types";
+import { getDatabase } from "./database";
+import {
+  pruneEventTableByCount,
+  type EventRetentionState,
+  type EventTableName,
+} from "./eventRetention";
+
+export type { EventRetentionState, EventTableName } from "./eventRetention";
+
+/**
+ * Resolve the Kysely handle for an event-repository call: a caller-supplied
+ * handle always wins (tests inject an in-memory DB and must never resolve the
+ * real file-backed database), otherwise fall back to the shared process
+ * database. Extracted from the six event repositories, which each carried a
+ * byte-identical copy (issue #3516).
+ */
+export function getDb(db?: Kysely<Database>): Kysely<Database> {
+  return db ?? (getDatabase() as unknown as Kysely<Database>);
+}
+
+/** A fresh, isolated retention counter for one event repository. */
+export function createEventRetentionState(): EventRetentionState {
+  return { cleanupInProgress: false, insertsSinceCleanup: 0 };
+}
+
+/**
+ * Parameterized retention wrapper shared by the six event repositories, whose
+ * per-table `cleanupIfNeeded` copies differed only by a table-name literal
+ * (issue #3516). Each repo binds its own table name + retention state and
+ * delegates here. Undefined `maxRows` / `checkInterval` / `inserted` fall
+ * through to `pruneEventTableByCount`'s defaults, preserving prior behavior.
+ */
+export async function cleanupEventTable(
+  table: EventTableName,
+  state: EventRetentionState,
+  db?: Kysely<Database>,
+  maxRows?: number,
+  checkInterval?: number,
+  inserted?: number
+): Promise<void> {
+  await pruneEventTableByCount(db, table, state, maxRows, checkInterval, inserted);
+}

--- a/src/db/layoutEventRepository.ts
+++ b/src/db/layoutEventRepository.ts
@@ -1,7 +1,6 @@
 import type { Kysely } from "kysely";
 import type { Database } from "./types";
-import { getDatabase } from "./database";
-import { pruneEventTableByCount, type EventRetentionState } from "./eventRetention";
+import { getDb, createEventRetentionState, cleanupEventTable } from "./eventRepositoryBase";
 
 export interface RecordLayoutEventInput {
   deviceId: string | null;
@@ -18,11 +17,7 @@ export interface RecordLayoutEventInput {
   screenName?: string | null;
 }
 
-const retentionState: EventRetentionState = { cleanupInProgress: false, insertsSinceCleanup: 0 };
-
-function getDb(db?: Kysely<Database>): Kysely<Database> {
-  return db ?? (getDatabase() as unknown as Kysely<Database>);
-}
+const retentionState = createEventRetentionState();
 
 function toLayoutRow(input: RecordLayoutEventInput) {
   return {
@@ -104,5 +99,5 @@ export async function cleanupIfNeeded(
   checkInterval?: number,
   inserted?: number
 ): Promise<void> {
-  await pruneEventTableByCount(db, "layout_events", retentionState, maxRows, checkInterval, inserted);
+  await cleanupEventTable("layout_events", retentionState, db, maxRows, checkInterval, inserted);
 }

--- a/src/db/logEventRepository.ts
+++ b/src/db/logEventRepository.ts
@@ -1,7 +1,6 @@
 import type { Kysely } from "kysely";
 import type { Database } from "./types";
-import { getDatabase } from "./database";
-import { pruneEventTableByCount, type EventRetentionState } from "./eventRetention";
+import { getDb, createEventRetentionState, cleanupEventTable } from "./eventRepositoryBase";
 
 export interface RecordLogEventInput {
   deviceId: string | null;
@@ -14,11 +13,7 @@ export interface RecordLogEventInput {
   filterName: string;
 }
 
-const retentionState: EventRetentionState = { cleanupInProgress: false, insertsSinceCleanup: 0 };
-
-function getDb(db?: Kysely<Database>): Kysely<Database> {
-  return db ?? (getDatabase() as unknown as Kysely<Database>);
-}
+const retentionState = createEventRetentionState();
 
 function toLogRow(input: RecordLogEventInput) {
   return {
@@ -96,5 +91,5 @@ export async function cleanupIfNeeded(
   checkInterval?: number,
   inserted?: number
 ): Promise<void> {
-  await pruneEventTableByCount(db, "log_events", retentionState, maxRows, checkInterval, inserted);
+  await cleanupEventTable("log_events", retentionState, db, maxRows, checkInterval, inserted);
 }

--- a/src/db/navigationEventRepository.ts
+++ b/src/db/navigationEventRepository.ts
@@ -1,7 +1,6 @@
 import type { Kysely } from "kysely";
 import type { Database } from "./types";
-import { getDatabase } from "./database";
-import { pruneEventTableByCount, type EventRetentionState } from "./eventRetention";
+import { getDb, createEventRetentionState, cleanupEventTable } from "./eventRepositoryBase";
 
 export interface RecordNavigationEventInput {
   deviceId: string | null;
@@ -14,11 +13,7 @@ export interface RecordNavigationEventInput {
   metadata: Record<string, string> | null;
 }
 
-const retentionState: EventRetentionState = { cleanupInProgress: false, insertsSinceCleanup: 0 };
-
-function getDb(db?: Kysely<Database>): Kysely<Database> {
-  return db ?? (getDatabase() as unknown as Kysely<Database>);
-}
+const retentionState = createEventRetentionState();
 
 function toNavigationRow(input: RecordNavigationEventInput) {
   return {
@@ -92,5 +87,5 @@ export async function cleanupIfNeeded(
   checkInterval?: number,
   inserted?: number
 ): Promise<void> {
-  await pruneEventTableByCount(db, "navigation_events", retentionState, maxRows, checkInterval, inserted);
+  await cleanupEventTable("navigation_events", retentionState, db, maxRows, checkInterval, inserted);
 }

--- a/src/db/networkEventRepository.ts
+++ b/src/db/networkEventRepository.ts
@@ -1,7 +1,6 @@
 import type { Kysely } from "kysely";
 import type { Database } from "./types";
-import { getDatabase } from "./database";
-import { pruneEventTableByCount, type EventRetentionState } from "./eventRetention";
+import { getDb, createEventRetentionState, cleanupEventTable } from "./eventRepositoryBase";
 import { truncateBodyText } from "../utils/truncateBodyText";
 
 export interface RecordNetworkEventInput {
@@ -26,11 +25,7 @@ export interface RecordNetworkEventInput {
   contentType?: string | null;
 }
 
-const retentionState: EventRetentionState = { cleanupInProgress: false, insertsSinceCleanup: 0 };
-
-function getDb(db?: Kysely<Database>): Kysely<Database> {
-  return db ?? (getDatabase() as unknown as Kysely<Database>);
-}
+const retentionState = createEventRetentionState();
 
 export async function recordNetworkEvent(
   input: RecordNetworkEventInput,
@@ -171,5 +166,5 @@ export async function cleanupIfNeeded(
   maxRows?: number,
   checkInterval?: number
 ): Promise<void> {
-  await pruneEventTableByCount(db, "network_events", retentionState, maxRows, checkInterval);
+  await cleanupEventTable("network_events", retentionState, db, maxRows, checkInterval);
 }

--- a/src/db/osEventRepository.ts
+++ b/src/db/osEventRepository.ts
@@ -1,7 +1,6 @@
 import type { Kysely } from "kysely";
 import type { Database } from "./types";
-import { getDatabase } from "./database";
-import { pruneEventTableByCount, type EventRetentionState } from "./eventRetention";
+import { getDb, createEventRetentionState, cleanupEventTable } from "./eventRepositoryBase";
 
 export interface RecordOsEventInput {
   deviceId: string | null;
@@ -13,11 +12,7 @@ export interface RecordOsEventInput {
   details: Record<string, string> | null;
 }
 
-const retentionState: EventRetentionState = { cleanupInProgress: false, insertsSinceCleanup: 0 };
-
-function getDb(db?: Kysely<Database>): Kysely<Database> {
-  return db ?? (getDatabase() as unknown as Kysely<Database>);
-}
+const retentionState = createEventRetentionState();
 
 function toOsRow(input: RecordOsEventInput) {
   return {
@@ -92,5 +87,5 @@ export async function cleanupIfNeeded(
   checkInterval?: number,
   inserted?: number
 ): Promise<void> {
-  await pruneEventTableByCount(db, "os_events", retentionState, maxRows, checkInterval, inserted);
+  await cleanupEventTable("os_events", retentionState, db, maxRows, checkInterval, inserted);
 }

--- a/src/db/storageEventRepository.ts
+++ b/src/db/storageEventRepository.ts
@@ -1,7 +1,6 @@
 import type { Kysely } from "kysely";
 import type { Database } from "./types";
-import { getDatabase } from "./database";
-import { pruneEventTableByCount, type EventRetentionState } from "./eventRetention";
+import { getDb, createEventRetentionState, cleanupEventTable } from "./eventRepositoryBase";
 import { logger } from "../utils/logger";
 
 export interface RecordStorageEventInput {
@@ -62,11 +61,7 @@ export function normalizeStorageEvent(input: PartialStorageEvent): RecordStorage
   };
 }
 
-const retentionState: EventRetentionState = { cleanupInProgress: false, insertsSinceCleanup: 0 };
-
-function getDb(db?: Kysely<Database>): Kysely<Database> {
-  return db ?? (getDatabase() as unknown as Kysely<Database>);
-}
+const retentionState = createEventRetentionState();
 
 export async function recordStorageEvent(
   rawInput: RecordStorageEventInput,
@@ -184,5 +179,5 @@ export async function cleanupIfNeeded(
   maxRows?: number,
   checkInterval?: number
 ): Promise<void> {
-  await pruneEventTableByCount(db, "storage_events", retentionState, maxRows, checkInterval);
+  await cleanupEventTable("storage_events", retentionState, db, maxRows, checkInterval);
 }

--- a/src/features/action/InstallApp.ts
+++ b/src/features/action/InstallApp.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import { AdbClientFactory, defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbExecutor } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import { AndroidUserTargetResolver } from "../../utils/android-cmdline-tools/AndroidUserTargetResolver";
 import { BootedDevice } from "../../models";
 import { createGlobalPerformanceTracker, type PerformanceTracker } from "../../utils/PerformanceTracker";
 import { DefaultHostCommandExecutor, type HostCommandExecutor } from "../../utils/HostCommandExecutor";
@@ -102,29 +103,11 @@ export class InstallApp {
 
     // Auto-detect target user if not specified
     const targetUserId = await perf.track("detectTargetUser", async () => {
-      if (userId !== undefined) {
-        return userId;
-      }
-
-      // Check if app is in foreground and get its user
-      if (packageName) {
-        const foregroundApp = await this.adb.getForegroundApp(signal);
-        if (foregroundApp && foregroundApp.packageName === packageName) {
-          return foregroundApp.userId;
-        }
-      }
-
-      // Get list of users and prefer work profile
-      const users = await this.adb.listUsers(signal);
-
-      // Find first work profile (flags 30 typically indicates managed/work profile)
-      const workProfile = users.find(u => u.userId > 0 && u.running);
-      if (workProfile) {
-        return workProfile.userId;
-      }
-
-      // Fall back to primary user
-      return 0;
+      return (await new AndroidUserTargetResolver(this.adb).resolve({
+        packageName,
+        explicitUserId: userId,
+        signal,
+      })).userId;
     });
 
     let isInstalled = false;

--- a/test/features/action/InstallApp.test.ts
+++ b/test/features/action/InstallApp.test.ts
@@ -123,8 +123,8 @@ describe("InstallApp", () => {
     fakeHost.setCommandResponse("aapt2", createExecResult("package: name='com.example.app' versionCode='1'"));
 
     fakeAdb.setUsers([
-      { userId: 0, name: "Owner", flags: 13, running: true },
-      { userId: 10, name: "Work", flags: 30, running: true }
+      { userId: 0, name: "Owner", flags: 0x13, running: true },
+      { userId: 10, name: "Work", flags: 0x30, running: true }
     ]);
     fakeAdb.setCommandResponse("shell pm list packages --user 10 -f com.example.app", createExecResult("0"));
     fakeAdb.setCommandResponse(`install --user 10 -r "${apkPath}"`, createExecResult("Success"));


### PR DESCRIPTION
## Summary

De-duplicates the copy-pasted helpers called out in [#3516](https://github.com/kaeawc/auto-mobile/issues/3516).

### Event repositories (`getDb` + `cleanupIfNeeded`)

Extracts the byte-identical `getDb` and the per-table `cleanupIfNeeded` boilerplate — previously copied across all six event repositories (navigation, log, layout, os, network, storage) — into a new shared `src/db/eventRepositoryBase.ts`:

- **`getDb(db?)`** — one source of the "caller handle wins, else fall back to the process DB" resolution. The test-injection seam is preserved exactly (callers still pass an in-memory DB; nothing resolves the real file-backed `getDatabase()` in tests).
- **`createEventRetentionState()`** — a fresh, isolated per-repo retention counter.
- **`cleanupEventTable(table, state, db?, maxRows?, checkInterval?, inserted?)`** — parameterized wrapper over the existing shared `pruneEventTableByCount`. Each repo binds its own table name + retention state. Undefined `maxRows` / `checkInterval` / `inserted` fall through to the same defaults, so behavior is identical, and network/storage keep their existing no-`inserted` `cleanupIfNeeded` signature.

Each repo keeps its exported `cleanupIfNeeded` (imported by `test/db/eventRetention.test.ts`) with an unchanged signature; it now delegates to `cleanupEventTable`.

### `detectTargetUser` block

Five of the six action files already used `AndroidUserTargetResolver`; this completes the de-duplication by migrating the last raw copy in `InstallApp` to it (passing `signal`, matching the prior abort behavior).

Note: the resolver keys a work profile on the managed-profile flag (`0x20`) rather than the older "any nonzero running user" heuristic — the same correction already applied to the five siblings ("a secondary user is never treated as managed solely because its ID is nonzero"). The `InstallApp` test's fake work profile is updated from `flags: 30` to a real managed-profile flag (`flags: 0x30`), matching the sibling `UninstallApp` test convention, so it still asserts a work profile at userId 10 is targeted.

## Validation

- `bun test test/db/` + the affected action tests (Install/Uninstall/Terminate) — 997 pass, 0 fail
- `bun test test/lint/` — 194 pass, 0 fail
- `bun run typecheck` — no new type errors
- `bun run lint` — clean (the forced `getDatabase() as unknown as Kysely` cast is baselined per repo convention on the new file; the six now-stale repo suppression entries were pruned)

Closes [#3516](https://github.com/kaeawc/auto-mobile/issues/3516)
