### PR TITLE
perf(android-video): write inter frames directly from the codec ByteBuffer

### DIFF
--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
@@ -66,6 +66,14 @@ class VideoStreamWriter(
   private val packetCache = VideoPacketCache()
   private val reconnectWindow = ReconnectWindow(nowMs, CLIENT_RECONNECT_WINDOW_MS)
 
+  /**
+   * Growable scratch buffer reused across inter frames to move the payload out of the codec
+   * [ByteBuffer] without a per-frame heap allocation. Only ever touched under [lock] from the
+   * single encoder thread. Config/keyframe packets bypass it because they are copied for the cache
+   * anyway.
+   */
+  private var scratch = ByteArray(0)
+
   @Volatile private var stopped = false
 
   companion object {
@@ -187,22 +195,31 @@ class VideoStreamWriter(
   }
 
   /**
-   * Write one encoded video packet. It is cached before writing, allowing a later client to decode
-   * immediately even if this client fails mid-write.
+   * Write one encoded video packet directly from the codec [ByteBuffer].
+   *
+   * Config and keyframe packets are copied into an exact-size [ByteArray] and cached before
+   * writing, so a later client can decode immediately even if this client fails mid-write. Inter
+   * frames are not cached, so they are moved through a reused growable scratch buffer rather than a
+   * fresh per-frame allocation — the payload is fully written before the caller releases the output
+   * buffer, so the codec-owned bytes stay valid for the duration of this call.
    */
   fun writePacket(buffer: ByteBuffer, bufferInfo: MediaCodec.BufferInfo): Boolean {
-    val data = ByteArray(bufferInfo.size)
-    buffer.position(bufferInfo.offset)
-    buffer.get(data, 0, bufferInfo.size)
+    val size = bufferInfo.size
+    val isConfig = (bufferInfo.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0
+    val isKeyFrame = (bufferInfo.flags and MediaCodec.BUFFER_FLAG_KEY_FRAME) != 0
     val ptsAndFlags =
-      VideoStreamProtocol.ptsAndFlags(
-        bufferInfo.presentationTimeUs,
-        (bufferInfo.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0,
-        (bufferInfo.flags and MediaCodec.BUFFER_FLAG_KEY_FRAME) != 0,
-      )
+      VideoStreamProtocol.ptsAndFlags(bufferInfo.presentationTimeUs, isConfig, isKeyFrame)
+    buffer.position(bufferInfo.offset)
     synchronized(lock) {
-      packetCache.remember(CachedVideoPacket(ptsAndFlags, data))
-      return writePacketDataLocked(TRACK_ID_VIDEO, ptsAndFlags, data)
+      if (isConfig || isKeyFrame) {
+        val data = ByteArray(size)
+        buffer.get(data, 0, size)
+        packetCache.remember(CachedVideoPacket(ptsAndFlags, data))
+        return writePacketDataLocked(TRACK_ID_VIDEO, ptsAndFlags, data)
+      }
+      scratch = growScratch(scratch, size)
+      buffer.get(scratch, 0, size)
+      return writePacketDataLocked(TRACK_ID_VIDEO, ptsAndFlags, scratch, size)
     }
   }
 
@@ -243,15 +260,20 @@ class VideoStreamWriter(
     }
   }
 
-  private fun writePacketDataLocked(trackId: Int, ptsAndFlags: Long, data: ByteArray): Boolean {
+  private fun writePacketDataLocked(
+    trackId: Int,
+    ptsAndFlags: Long,
+    data: ByteArray,
+    length: Int = data.size,
+  ): Boolean {
     if (stopped) return false
 
     // Keep the encoder alive during local client recovery. Video data is cached;
     // audio resumes live when the replacement mux client attaches.
     val output = outputStream ?: return true
     try {
-      output.write(VideoStreamProtocol.packetHeader(audioEnabled, trackId, ptsAndFlags, data.size))
-      output.write(data)
+      output.write(VideoStreamProtocol.packetHeader(audioEnabled, trackId, ptsAndFlags, length))
+      output.write(data, 0, length)
       return true
     } catch (e: IOException) {
       println("Error writing packet: ${e.message}")
@@ -287,6 +309,14 @@ class VideoStreamWriter(
     serverSocket = null
   }
 }
+
+/**
+ * Returns a [ByteArray] of at least [size] bytes, reusing [scratch] whenever it already fits so
+ * inter frames avoid a per-frame allocation. Only the leading [size] bytes are ever written, so a
+ * larger reused buffer never leaks stale trailing bytes onto the wire.
+ */
+internal fun growScratch(scratch: ByteArray, size: Int): ByteArray =
+  if (scratch.size < size) ByteArray(size) else scratch
 
 /** Cached decoder setup and latest complete keyframe for a replacement client. */
 internal data class CachedVideoPacket(val ptsAndFlags: Long, val data: ByteArray) {

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriterTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriterTest.kt
@@ -1,10 +1,29 @@
 package dev.jasonpearson.automobile.video
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class VideoStreamWriterTest {
+  @Test
+  fun scratchBufferGrowsOnceAndIsReusedForSmallerFrames() {
+    // Inter frames reuse a growable scratch buffer instead of allocating per frame.
+    val first = growScratch(ByteArray(0), size = 1_024)
+    assertEquals(1_024, first.size)
+
+    // A smaller subsequent frame reuses the same array — no new allocation.
+    val reused = growScratch(first, size = 512)
+    assertSame(first, reused)
+
+    // Only a larger frame forces a single reallocation.
+    val grown = growScratch(reused, size = 2_048)
+    assertNotSame(reused, grown)
+    assertEquals(2_048, grown.size)
+  }
+
   @Test
   fun reconnectWindowUsesElapsedTimeDespiteWallClockJumps() {
     var elapsedRealtimeMs = 1_000L


### PR DESCRIPTION
Closes [#4745](https://github.com/kaeawc/auto-mobile/issues/4745)

## Summary

The socket write path in `VideoStreamWriter.writePacket` allocated a fresh `ByteArray` and copied the entire encoded frame out of the codec `ByteBuffer` on **every** frame, creating steady GC pressure on the device at 30-60fps. Only config and IDR packets are actually cached for replay to a replacement client, so only those need an owned copy.

This PR writes inter (non-config, non-keyframe) packets from the codec `ByteBuffer` through a **reused growable scratch buffer** instead of a fresh per-frame allocation:

- **Config / keyframe packets** keep their exact-size `ByteArray` copy — that copy is required for the replay cache anyway (`VideoPacketCache.remember(...)`), so it does double duty as the write source.
- **Inter frames** copy into a scratch buffer that grows only when a larger frame arrives (`growScratch`) and is reused otherwise. `writePacketDataLocked` now takes an explicit `length`, and writes exactly `length` bytes (`output.write(data, 0, length)`), so a larger reused buffer never leaks stale trailing bytes onto the wire.

Buffer lifetime is safe: `VideoServer`'s encoding loop calls `writePacket` fully synchronously **before** `encoder.releaseOutputBuffer(index)` ([VideoServer.kt:288-294](https://github.com/kaeawc/auto-mobile/blob/main/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt#L288-L294)), and the payload is fully written within `writePacket`, so the codec-owned `ByteBuffer` stays valid for the duration of the call. The scratch buffer is only ever touched under `lock` from the single encoder thread.

## Changes

- `VideoStreamWriter.kt` — reused `scratch` field; `writePacket` splits cached (exact copy) vs. inter (scratch) paths; `writePacketDataLocked` gains a defaulted `length` param and writes only `length` bytes; new pure `internal growScratch(...)` helper.
- `VideoStreamWriterTest.kt` — added `scratchBufferGrowsOnceAndIsReusedForSmallerFrames`, verifying the buffer grows once, is reused for smaller frames (no realloc), and grows again only for a larger frame.

A full end-to-end `writePacket` unit test isn't feasible in this JVM-only module — it depends on Android's `MediaCodec.BufferInfo` and a socket `OutputStream`, and the module has no Robolectric/MockK (JUnit only). Rather than add a dependency or a wider refactor (this file also has sibling PRs #4743 and #4754 in flight), the allocation-avoidance crux was extracted into the pure `growScratch` helper and tested deterministically.

## Validation

- `./gradlew :video-server:test` (JDK 21) — BUILD SUCCESSFUL, all tests pass (including the new test).
- ktfmt (`scripts/ktfmt/validate_ktfmt.sh`) — "All Kotlin source files are properly formatted."
- Diff kept surgical to minimize conflicts with sibling PRs #4743 / #4754 that also edit `VideoStreamWriter.kt`.
