### PR TITLE
refactor(observe): stop CtrlProxy facades restating delegate defaults

### DIFF
--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1457,22 +1457,30 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   // Delegated Public Methods - Gestures
   // ===========================================================================
 
+  // These are thin pass-throughs. They deliberately DO NOT restate the delegate's
+  // default parameter values: omitted args forward as `undefined`, so the delegate
+  // (the single source of truth) applies its own defaults. This makes the two-copies
+  // drift class from issue #3505 unrepresentable.
   async requestSwipe(
     x1: number, y1: number, x2: number, y2: number,
-    duration: number = 300, timeoutMs: number = 5000, perf: PerformanceTracker = new NoOpPerformanceTracker(), frameContext?: string
+    duration?: number, timeoutMs?: number, perf?: PerformanceTracker, frameContext?: string
   ): Promise<A11ySwipeResult> {
     return this.gestures.requestSwipe(x1, y1, x2, y2, duration, timeoutMs, perf, frameContext);
   }
 
   async requestTapCoordinates(
-    x: number, y: number, duration: number = 10, timeoutMs: number = 5000, perf: PerformanceTracker = new NoOpPerformanceTracker(), frameContext?: string
+    x: number, y: number,
+    // Deliberate Android-specific override: taps default to a 10ms press, not the
+    // delegate's cross-platform 0ms default. This is the one intentional divergence,
+    // not restated drift — see issue #3505.
+    duration: number = 10, timeoutMs?: number, perf?: PerformanceTracker, frameContext?: string
   ): Promise<A11yTapCoordinatesResult> {
     return this.gestures.requestTapCoordinates(x, y, duration, timeoutMs, perf, frameContext);
   }
 
   async requestTwoFingerSwipe(
     x1: number, y1: number, x2: number, y2: number,
-    duration: number = 300, offset: number = 100, timeoutMs: number = 5000, perf: PerformanceTracker = new NoOpPerformanceTracker()
+    duration?: number, offset?: number, timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<A11ySwipeResult> {
     return this.gestures.requestTwoFingerSwipe(x1, y1, x2, y2, duration, offset, timeoutMs, perf);
   }
@@ -1487,7 +1495,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   async requestPinch(
     centerX: number, centerY: number,
     distanceStart: number, distanceEnd: number, rotationDegrees: number,
-    duration: number = 300, timeoutMs: number = 5000, perf: PerformanceTracker = new NoOpPerformanceTracker()
+    duration?: number, timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<A11yPinchResult> {
     return this.gestures.requestPinch(centerX, centerY, distanceStart, distanceEnd, rotationDegrees, duration, timeoutMs, perf);
   }
@@ -1503,20 +1511,20 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   }
 
   async requestClearText(
-    resourceId?: string, timeoutMs: number = 5000, perf: PerformanceTracker = new NoOpPerformanceTracker()
+    resourceId?: string, timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<A11ySetTextResult> {
     return this.text.requestClearText(resourceId, timeoutMs, perf);
   }
 
   async requestImeAction(
     action: ImeAction,
-    timeoutMs: number = 5000, perf: PerformanceTracker = new NoOpPerformanceTracker()
+    timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<A11yImeActionResult> {
     return this.text.requestImeAction(action, timeoutMs, perf);
   }
 
   async requestSelectAll(
-    timeoutMs: number = 5000, perf: PerformanceTracker = new NoOpPerformanceTracker()
+    timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<A11ySelectAllResult> {
     return this.text.requestSelectAll(timeoutMs, perf);
   }
@@ -1526,31 +1534,31 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   // ===========================================================================
 
   async requestInstallCaCertificate(
-    certificate: string, timeoutMs: number = 10000, perf: PerformanceTracker = new NoOpPerformanceTracker()
+    certificate: string, timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<A11yCaCertResult> {
     return this.certificates.requestInstallCaCertificate(certificate, timeoutMs, perf);
   }
 
   async requestInstallCaCertificateFromFile(
-    certificatePath: string, timeoutMs: number = 10000, perf: PerformanceTracker = new NoOpPerformanceTracker()
+    certificatePath: string, timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<A11yCaCertResult> {
     return this.certificates.requestInstallCaCertificateFromFile(certificatePath, timeoutMs, perf);
   }
 
   async requestRemoveCaCertificate(
-    alias: string, timeoutMs: number = 10000, perf: PerformanceTracker = new NoOpPerformanceTracker()
+    alias: string, timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<A11yCaCertResult> {
     return this.certificates.requestRemoveCaCertificate(alias, timeoutMs, perf);
   }
 
   async requestDeviceOwnerStatus(
-    timeoutMs: number = 5000, perf: PerformanceTracker = new NoOpPerformanceTracker()
+    timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<A11yDeviceOwnerStatusResult> {
     return this.certificates.requestDeviceOwnerStatus(timeoutMs, perf);
   }
 
   async requestPermission(
-    permission: string, requestPermission: boolean = true, timeoutMs: number = 5000, perf: PerformanceTracker = new NoOpPerformanceTracker()
+    permission: string, requestPermission?: boolean, timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<A11yPermissionResult> {
     return this.certificates.requestPermission(permission, requestPermission, timeoutMs, perf);
   }
@@ -1559,35 +1567,35 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   // Delegated Public Methods - Storage
   // ===========================================================================
 
-  async listPreferenceFiles(packageName: string, timeoutMs: number = 5000): Promise<PreferenceFile[]> {
+  async listPreferenceFiles(packageName: string, timeoutMs?: number): Promise<PreferenceFile[]> {
     return this.storage.listPreferenceFiles(packageName, timeoutMs);
   }
 
-  async getPreferenceEntries(packageName: string, fileName: string, timeoutMs: number = 5000): Promise<KeyValueEntry[]> {
+  async getPreferenceEntries(packageName: string, fileName: string, timeoutMs?: number): Promise<KeyValueEntry[]> {
     return this.storage.getPreferenceEntries(packageName, fileName, timeoutMs);
   }
 
-  async getPreference(packageName: string, fileName: string, key: string, timeoutMs: number = 5000): Promise<KeyValueEntry | null> {
+  async getPreference(packageName: string, fileName: string, key: string, timeoutMs?: number): Promise<KeyValueEntry | null> {
     return this.storage.getPreference(packageName, fileName, key, timeoutMs);
   }
 
-  async setPreference(packageName: string, fileName: string, key: string, value: string | null, type: KeyValueType, timeoutMs: number = 5000): Promise<void> {
+  async setPreference(packageName: string, fileName: string, key: string, value: string | null, type: KeyValueType, timeoutMs?: number): Promise<void> {
     return this.storage.setPreference(packageName, fileName, key, value, type, timeoutMs);
   }
 
-  async removePreference(packageName: string, fileName: string, key: string, timeoutMs: number = 5000): Promise<void> {
+  async removePreference(packageName: string, fileName: string, key: string, timeoutMs?: number): Promise<void> {
     return this.storage.removePreference(packageName, fileName, key, timeoutMs);
   }
 
-  async clearPreferenceStore(packageName: string, fileName: string, timeoutMs: number = 5000): Promise<void> {
+  async clearPreferenceStore(packageName: string, fileName: string, timeoutMs?: number): Promise<void> {
     return this.storage.clearPreferenceStore(packageName, fileName, timeoutMs);
   }
 
-  async subscribeStorage(packageName: string, fileName: string, timeoutMs: number = 5000): Promise<StorageSubscription> {
+  async subscribeStorage(packageName: string, fileName: string, timeoutMs?: number): Promise<StorageSubscription> {
     return this.storage.subscribeStorage(packageName, fileName, timeoutMs);
   }
 
-  async unsubscribeStorage(subscriptionId: string, timeoutMs: number = 5000): Promise<void> {
+  async unsubscribeStorage(subscriptionId: string, timeoutMs?: number): Promise<void> {
     return this.storage.unsubscribeStorage(subscriptionId, timeoutMs);
   }
 
@@ -1600,25 +1608,25 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   // ===========================================================================
 
   async clearAccessibilityFocus(
-    resourceId: string, timeoutMs: number = 5000, perf: PerformanceTracker = new NoOpPerformanceTracker()
+    resourceId: string, timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<void> {
     return this.focus.clearAccessibilityFocus(resourceId, timeoutMs, perf);
   }
 
   async setAccessibilityFocus(
-    resourceId: string, timeoutMs: number = 5000, perf: PerformanceTracker = new NoOpPerformanceTracker()
+    resourceId: string, timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<void> {
     return this.focus.setAccessibilityFocus(resourceId, timeoutMs, perf);
   }
 
   async requestCurrentFocus(
-    timeoutMs: number = 5000, perf: PerformanceTracker = new NoOpPerformanceTracker()
+    timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<CurrentFocusResult> {
     return this.focus.requestCurrentFocus(timeoutMs, perf);
   }
 
   async requestTraversalOrder(
-    timeoutMs: number = 5000, perf: PerformanceTracker = new NoOpPerformanceTracker()
+    timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<TraversalOrderResult> {
     return this.focus.requestTraversalOrder(timeoutMs, perf);
   }
@@ -1628,7 +1636,7 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   // ===========================================================================
 
   async requestAddHighlight(
-    id: string, shape: HighlightShape, timeoutMs: number = 5000, perf: PerformanceTracker = new NoOpPerformanceTracker()
+    id: string, shape: HighlightShape, timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<HighlightOperationResult> {
     return this.highlights.requestAddHighlight(id, shape, timeoutMs, perf);
   }

--- a/src/features/observe/android/AndroidCtrlProxyClient.ts
+++ b/src/features/observe/android/AndroidCtrlProxyClient.ts
@@ -1389,38 +1389,42 @@ export class AndroidCtrlProxyClient extends DeviceServiceClient implements Andro
   // Delegated Public Methods - Hierarchy
   // ===========================================================================
 
+  // Thin pass-throughs: like the gesture/text/etc. delegates below, these do NOT
+  // restate the delegate's default parameter values. Omitted args forward as
+  // `undefined`, so CtrlProxyHierarchy (the single source of truth) applies its own
+  // defaults — keeping the two-copies drift class from issue #3505 unrepresentable.
   async getAccessibilityHierarchy(
     queryOptions?: ViewHierarchyQueryOptions,
-    perf: PerformanceTracker = new NoOpPerformanceTracker(),
-    skipWaitForFresh: boolean = false,
-    minTimestamp: number = 0,
-    disableAllFiltering: boolean = false,
+    perf?: PerformanceTracker,
+    skipWaitForFresh?: boolean,
+    minTimestamp?: number,
+    disableAllFiltering?: boolean,
     signal?: AbortSignal,
     timeoutMs?: number
   ): Promise<ViewHierarchyResult | null> {
     return this.hierarchy.getAccessibilityHierarchy(queryOptions, perf, skipWaitForFresh, minTimestamp, disableAllFiltering, signal, timeoutMs);
   }
 
-  async setRecompositionTrackingEnabled(enabled: boolean, perf: PerformanceTracker = new NoOpPerformanceTracker()): Promise<void> {
+  async setRecompositionTrackingEnabled(enabled: boolean, perf?: PerformanceTracker): Promise<void> {
     return this.hierarchy.setRecompositionTrackingEnabled(enabled, perf);
   }
 
   async getLatestHierarchy(
-    waitForFresh: boolean = false,
+    waitForFresh?: boolean,
     timeout?: number,
-    perf: PerformanceTracker = new NoOpPerformanceTracker(),
-    skipWaitForFresh: boolean = false,
-    minTimestamp: number = 0,
+    perf?: PerformanceTracker,
+    skipWaitForFresh?: boolean,
+    minTimestamp?: number,
     signal?: AbortSignal
   ): Promise<AccessibilityHierarchyResponse> {
-    return this.hierarchy.getLatestHierarchy(waitForFresh, timeout!, perf, skipWaitForFresh, minTimestamp, signal);
+    return this.hierarchy.getLatestHierarchy(waitForFresh, timeout, perf, skipWaitForFresh, minTimestamp, signal);
   }
 
   async requestHierarchySync(
-    perf: PerformanceTracker = new NoOpPerformanceTracker(),
-    disableAllFiltering: boolean = false,
+    perf?: PerformanceTracker,
+    disableAllFiltering?: boolean,
     signal?: AbortSignal,
-    timeoutMs: number = 10000,
+    timeoutMs?: number,
     diagnostics?: HierarchySyncDiagnostics
   ): Promise<{ hierarchy: AccessibilityHierarchy; perfTiming?: AndroidPerfTiming[] } | null> {
     return this.hierarchy.requestHierarchySync(perf, disableAllFiltering, signal, timeoutMs, diagnostics);

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -1673,11 +1673,15 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   // Delegated Public Methods - Highlights
   // ===========================================================================
 
+  // Thin pass-throughs below deliberately DO NOT restate the delegate's default
+  // parameter values: omitted args forward as `undefined` so the delegate (the
+  // single source of truth) applies its own defaults, making the two-copies drift
+  // class from issue #3505 unrepresentable.
   async requestAddHighlight(
     id: string,
     shape: HighlightShape,
-    timeoutMs: number = 5000,
-    perf: PerformanceTracker = new NoOpPerformanceTracker()
+    timeoutMs?: number,
+    perf?: PerformanceTracker
   ): Promise<CtrlProxyHighlightResult> {
     return this.highlights.requestAddHighlight(id, shape, timeoutMs, perf);
   }
@@ -1709,14 +1713,14 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   // ===========================================================================
 
   async requestTapCoordinates(
-    x: number, y: number, duration: number = 0, timeoutMs: number = 5000, perf?: PerformanceTracker, frameContext?: string
+    x: number, y: number, duration?: number, timeoutMs?: number, perf?: PerformanceTracker, frameContext?: string
   ): Promise<CtrlProxyTapResult> {
     return this.gestures.requestTapCoordinates(x, y, duration, timeoutMs, perf, frameContext);
   }
 
   async requestSwipe(
     x1: number, y1: number, x2: number, y2: number,
-    duration: number = 300, timeoutMs: number = 5000, perf?: PerformanceTracker, frameContext?: string
+    duration?: number, timeoutMs?: number, perf?: PerformanceTracker, frameContext?: string
   ): Promise<CtrlProxySwipeResult> {
     return this.gestures.requestSwipe(x1, y1, x2, y2, duration, timeoutMs, perf, frameContext);
   }
@@ -1731,7 +1735,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   async requestPinch(
     centerX: number, centerY: number,
     distanceStart: number, distanceEnd: number, rotationDegrees: number,
-    duration: number = 300, timeoutMs: number = 5000, perf?: PerformanceTracker
+    duration?: number, timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<CtrlProxyPinchResult> {
     return this.gestures.requestPinch(centerX, centerY, distanceStart, distanceEnd, rotationDegrees, duration, timeoutMs, perf);
   }
@@ -1747,33 +1751,33 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   }
 
   async requestAppendText(
-    text: string, timeoutMs: number = 5000, perf?: PerformanceTracker, frameContext?: string
+    text: string, timeoutMs?: number, perf?: PerformanceTracker, frameContext?: string
   ): Promise<CtrlProxySetTextResult> {
     return this.text.requestAppendText(text, timeoutMs, perf, frameContext);
   }
 
   async requestClearText(
-    resourceId?: string, timeoutMs: number = 5000, perf?: PerformanceTracker
+    resourceId?: string, timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<CtrlProxySetTextResult> {
     return this.text.requestClearText(resourceId, timeoutMs, perf);
   }
 
   async requestImeAction(
     action: ImeAction,
-    timeoutMs: number = 5000, perf?: PerformanceTracker
+    timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<CtrlProxyImeActionResult> {
     return this.text.requestImeAction(action, timeoutMs, perf);
   }
 
   async requestSelectAll(
-    timeoutMs: number = 5000, perf?: PerformanceTracker
+    timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<CtrlProxySelectAllResult> {
     return this.text.requestSelectAll(timeoutMs, perf);
   }
 
   async requestKeyboard(
     action: "open" | "close" | "detect",
-    timeoutMs: number = 5000,
+    timeoutMs?: number,
     perf?: PerformanceTracker
   ): Promise<CtrlProxyKeyboardResult> {
     return this.keyboard.requestKeyboard(action, timeoutMs, perf);
@@ -1784,43 +1788,43 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   // ===========================================================================
 
   async requestPressHome(
-    timeoutMs: number = 5000, perf?: PerformanceTracker, frameContext?: string
+    timeoutMs?: number, perf?: PerformanceTracker, frameContext?: string
   ): Promise<CtrlProxyPressHomeResult> {
     return this.navigation.requestPressHome(timeoutMs, perf, frameContext);
   }
 
   async requestPressBack(
-    timeoutMs: number = 5000, perf?: PerformanceTracker, frameContext?: string
+    timeoutMs?: number, perf?: PerformanceTracker, frameContext?: string
   ): Promise<CtrlProxyPressBackResult> {
     return this.navigation.requestPressBack(timeoutMs, perf, frameContext);
   }
 
   async requestShake(
-    timeoutMs: number = 5000, perf?: PerformanceTracker
+    timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<CtrlProxyShakeResult> {
     return this.navigation.requestShake(timeoutMs, perf);
   }
 
   async requestPressButton(
-    button: string, timeoutMs: number = 5000, perf?: PerformanceTracker, frameContext?: string
+    button: string, timeoutMs?: number, perf?: PerformanceTracker, frameContext?: string
   ): Promise<CtrlProxyPressButtonResult> {
     return this.navigation.requestPressButton(button, timeoutMs, perf, frameContext);
   }
 
   async requestRecentApps(
-    timeoutMs: number = 5000, perf?: PerformanceTracker, frameContext?: string
+    timeoutMs?: number, perf?: PerformanceTracker, frameContext?: string
   ): Promise<CtrlProxyRecentAppsResult> {
     return this.navigation.requestRecentApps(timeoutMs, perf, frameContext);
   }
 
   async requestRotate(
-    orientation: string, timeoutMs: number = 5000, perf?: PerformanceTracker
+    orientation: string, timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<CtrlProxyRotateResult> {
     return this.navigation.requestRotate(orientation, timeoutMs, perf);
   }
 
   async requestLaunchApp(
-    bundleId: string, timeoutMs: number = 10000, perf?: PerformanceTracker, coldBoot: boolean = false
+    bundleId: string, timeoutMs?: number, perf?: PerformanceTracker, coldBoot?: boolean
   ): Promise<CtrlProxyLaunchAppResult> {
     return this.navigation.requestLaunchApp(bundleId, timeoutMs, perf, coldBoot);
   }
@@ -1830,7 +1834,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   // ===========================================================================
 
   async requestResetPermissions(
-    bundleId: string, permissions: string[], timeoutMs: number = 5000, perf?: PerformanceTracker
+    bundleId: string, permissions: string[], timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<CtrlProxyResetPermissionsResult> {
     return this.permissions.requestResetPermissions(bundleId, permissions, timeoutMs, perf);
   }
@@ -1842,7 +1846,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   async requestClipboard(
     action: "copy" | "paste" | "clear" | "get",
     text?: string,
-    timeoutMs: number = 5000,
+    timeoutMs?: number,
     perf?: PerformanceTracker
   ): Promise<CtrlProxyClipboardResult> {
     return this.clipboard.requestClipboard(action, text, timeoutMs, perf);
@@ -1853,13 +1857,13 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   // ===========================================================================
 
   async requestScreenshot(
-    timeoutMs: number = 5000, perf?: PerformanceTracker
+    timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<CtrlProxyScreenshotResult> {
     return this.screenshot.requestScreenshot(timeoutMs, perf);
   }
 
   async requestScreenshotWithoutObservationStreamPush(
-    timeoutMs: number = 5000, perf?: PerformanceTracker
+    timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<CtrlProxyScreenshotResult> {
     return this.requestScreenshot(timeoutMs, perf);
   }
@@ -1869,7 +1873,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   // ===========================================================================
 
   async requestVoiceOverState(
-    timeoutMs: number = 5000, perf?: PerformanceTracker
+    timeoutMs?: number, perf?: PerformanceTracker
   ): Promise<CtrlProxyVoiceOverResult> {
     return this.voiceOver.requestVoiceOverState(timeoutMs, perf);
   }
@@ -1877,7 +1881,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   async requestVoiceOverActivate(
     label: string,
     action: "activate" | "long_press",
-    timeoutMs: number = 5000,
+    timeoutMs?: number,
     perf?: PerformanceTracker
   ): Promise<CtrlProxyActionResult> {
     return this.voiceOver.requestVoiceOverActivate(label, action, timeoutMs, perf);
@@ -1887,7 +1891,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     action: string,
     resourceId?: string,
     label?: string,
-    timeoutMs: number = 5000,
+    timeoutMs?: number,
     perf?: PerformanceTracker
   ): Promise<CtrlProxyActionResult> {
     return this.voiceOver.requestAction(action, resourceId, label, timeoutMs, perf);
@@ -1896,8 +1900,8 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   async requestMultiFingerSwipe(
     x1: number, y1: number, x2: number, y2: number,
     fingerCount: number,
-    duration: number = 300,
-    timeoutMs: number = 5000,
+    duration?: number,
+    timeoutMs?: number,
     perf?: PerformanceTracker,
     fingerSpacing?: number
   ): Promise<CtrlProxySwipeResult> {
@@ -1908,27 +1912,27 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
   // Delegated Public Methods - Storage (UserDefaults)
   // ===========================================================================
 
-  async listPreferenceFiles(packageName: string, timeoutMs: number = 5000): Promise<import("../../storage/storageTypes").PreferenceFile[]> {
+  async listPreferenceFiles(packageName: string, timeoutMs?: number): Promise<import("../../storage/storageTypes").PreferenceFile[]> {
     return this.storage.listPreferenceFiles(packageName, timeoutMs);
   }
 
-  async getPreferenceEntries(packageName: string, fileName: string, timeoutMs: number = 5000): Promise<import("../../storage/storageTypes").KeyValueEntry[]> {
+  async getPreferenceEntries(packageName: string, fileName: string, timeoutMs?: number): Promise<import("../../storage/storageTypes").KeyValueEntry[]> {
     return this.storage.getPreferenceEntries(packageName, fileName, timeoutMs);
   }
 
-  async getPreference(packageName: string, fileName: string, key: string, timeoutMs: number = 5000): Promise<import("../../storage/storageTypes").KeyValueEntry | null> {
+  async getPreference(packageName: string, fileName: string, key: string, timeoutMs?: number): Promise<import("../../storage/storageTypes").KeyValueEntry | null> {
     return this.storage.getPreference(packageName, fileName, key, timeoutMs);
   }
 
-  async setPreference(packageName: string, fileName: string, key: string, value: string | null, type: import("../../storage/storageTypes").KeyValueType, timeoutMs: number = 5000): Promise<void> {
+  async setPreference(packageName: string, fileName: string, key: string, value: string | null, type: import("../../storage/storageTypes").KeyValueType, timeoutMs?: number): Promise<void> {
     return this.storage.setPreference(packageName, fileName, key, value, type, timeoutMs);
   }
 
-  async removePreference(packageName: string, fileName: string, key: string, timeoutMs: number = 5000): Promise<void> {
+  async removePreference(packageName: string, fileName: string, key: string, timeoutMs?: number): Promise<void> {
     return this.storage.removePreference(packageName, fileName, key, timeoutMs);
   }
 
-  async clearPreferenceStore(packageName: string, fileName: string, timeoutMs: number = 5000): Promise<void> {
+  async clearPreferenceStore(packageName: string, fileName: string, timeoutMs?: number): Promise<void> {
     return this.storage.clearPreferenceStore(packageName, fileName, timeoutMs);
   }
 
@@ -1940,19 +1944,19 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     appId: string,
     databasePath: string,
     query: string,
-    timeoutMs: number = 5000
+    timeoutMs?: number
   ): Promise<import("../../database/DatabaseInspector").SQLResult> {
     return this.database.executeSQL(appId, databasePath, query, timeoutMs);
   }
 
   async listDatabasesForIos(
     appId: string,
-    timeoutMs: number = 5000
+    timeoutMs?: number
   ): Promise<import("../../database/DatabaseInspector").DatabaseInfo[]> {
     return this.database.listDatabases(appId, timeoutMs);
   }
 
-  async listTablesForIos(appId: string, databasePath: string, timeoutMs: number = 5000): Promise<string[]> {
+  async listTablesForIos(appId: string, databasePath: string, timeoutMs?: number): Promise<string[]> {
     return this.database.listTables(appId, databasePath, timeoutMs);
   }
 
@@ -1960,9 +1964,9 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     appId: string,
     databasePath: string,
     table: string,
-    limit: number = 50,
-    offset: number = 0,
-    timeoutMs: number = 5000
+    limit?: number,
+    offset?: number,
+    timeoutMs?: number
   ): Promise<import("../../database/DatabaseInspector").TableDataResult> {
     return this.database.getTableData(appId, databasePath, table, limit, offset, timeoutMs);
   }
@@ -1971,7 +1975,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     appId: string,
     databasePath: string,
     table: string,
-    timeoutMs: number = 5000
+    timeoutMs?: number
   ): Promise<import("../../database/DatabaseInspector").TableStructureResult> {
     return this.database.getTableStructure(appId, databasePath, table, timeoutMs);
   }

--- a/src/features/observe/ios/IOSCtrlProxyClient.ts
+++ b/src/features/observe/ios/IOSCtrlProxyClient.ts
@@ -1625,12 +1625,16 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     return this.hierarchy.getAccessibilityHierarchy(queryOptions, perf, skipWaitForFresh, minTimestamp, disableAllFiltering);
   }
 
+  // Thin pass-throughs: like the delegated methods below, these do NOT restate the
+  // delegate's default parameter values. Omitted args forward as `undefined`, so
+  // CtrlProxyHierarchy (the single source of truth) applies its own defaults —
+  // keeping the two-copies drift class from issue #3505 unrepresentable.
   async getLatestHierarchy(
-    waitForFresh: boolean = false,
-    timeout: number = 15000,
+    waitForFresh?: boolean,
+    timeout?: number,
     perf?: PerformanceTracker,
-    skipWaitForFresh: boolean = false,
-    minTimestamp: number = 0
+    skipWaitForFresh?: boolean,
+    minTimestamp?: number
   ): Promise<CtrlProxyHierarchyResponse> {
     return this.hierarchy.getLatestHierarchy(waitForFresh, timeout, perf, skipWaitForFresh, minTimestamp);
   }
@@ -1639,7 +1643,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     perf?: PerformanceTracker,
     disableAllFiltering?: boolean,
     signal?: AbortSignal,
-    timeoutMs: number = 5000
+    timeoutMs?: number
   ): Promise<{ hierarchy: XCTestHierarchy; perfTiming?: CtrlProxyPerfTiming } | null> {
     return this.hierarchy.requestHierarchySync(perf, disableAllFiltering, signal, timeoutMs);
   }
@@ -1648,7 +1652,7 @@ export class IOSCtrlProxyClient extends DeviceServiceClient implements IOSCtrlPr
     perf?: PerformanceTracker,
     disableAllFiltering?: boolean,
     signal?: AbortSignal,
-    timeoutMs: number = 5000
+    timeoutMs?: number
   ): Promise<{ hierarchy: XCTestHierarchy; perfTiming?: CtrlProxyPerfTiming; frameContext?: string } | null> {
     return this.hierarchy.requestHierarchySync(perf, disableAllFiltering, signal, timeoutMs, true);
   }


### PR DESCRIPTION
## Summary

The CtrlProxy facades (`AndroidCtrlProxyClient`, `IOSCtrlProxyClient`) re-declared the default parameter values that already live in the shared delegates, so the defaults existed in two independently-editable places and could silently drift ([#3505](https://github.com/kaeawc/auto-mobile/issues/3505)).

This makes the delegate the single source of truth: each pass-through now declares its optional params with `?` and forwards `undefined`, letting the delegate apply its own default. Passing `undefined` to a parameter that has a default triggers that default, so behavior is unchanged. `sendCommand` already treats `perf` as optional (`options.perf ? ... : ...`), so an omitted tracker is behaviorally identical to a `NoOpPerformanceTracker`.

## One documented divergence

While doing this I found genuine live drift: the Android facade `requestTapCoordinates` restated `duration = 10`, but the shared `SharedGestureDelegate` defaults `duration = 0` (the iOS facade restated `0`, matching). Callers that omit the duration (e.g. `systemTrayHelpers`) currently get Android's 10ms press. Blindly forwarding `undefined` there would silently change Android tap behavior (10ms to 0ms), and the shared delegate can only hold one value for both platforms. So the Android `duration = 10` is **preserved** and now carries an inline comment marking it a deliberate platform override rather than restated drift.

## Validation

- `bun run typecheck` — passes (no new errors; ran `bun install --frozen-lockfile` in the worktree first)
- `bun run lint` — clean (including all boundary checks)
- `bun test` over `test/features/observe/`, `test/features/action/`, `test/server/system-tray/` and the CtrlProxy/delegate suites — 3153 pass, 0 fail

## Acceptance criteria
- [x] Facade pass-throughs no longer restate default values
- [x] Delegates remain the only place defaults are defined (the one intentional Android tap override is documented, not silent)
- [x] Existing CtrlProxy tests green (no behavioral change)

Closes [#3505](https://github.com/kaeawc/auto-mobile/issues/3505)
