### PR TITLE
perf(android-video): add p50/p95 throughput/latency baseline gate for the Android video server

### DIFF
--- a/benchmark/webrtc/android-video-baseline.json
+++ b/benchmark/webrtc/android-video-baseline.json
@@ -1,0 +1,41 @@
+{
+  "version": "1.0.0",
+  "fpsTarget": 60,
+  "fpsTargetTolerance": 0.5,
+  "metrics": {
+    "encodeFps": {
+      "baseline": 45,
+      "tolerance": 0.2,
+      "direction": "higher-is-better",
+      "percentile": "p50"
+    },
+    "egressKbps": {
+      "baseline": 4000,
+      "tolerance": 0.3,
+      "direction": "higher-is-better",
+      "percentile": "p50"
+    },
+    "captureToFirstFrameMs": {
+      "baseline": 2000,
+      "tolerance": 0.3,
+      "direction": "lower-is-better",
+      "percentile": "p95"
+    },
+    "captureToBrowserMs": {
+      "baseline": 5000,
+      "tolerance": 0.3,
+      "direction": "lower-is-better",
+      "percentile": "p95"
+    },
+    "keyframeRecoveryMs": {
+      "baseline": 3000,
+      "tolerance": 0.35,
+      "direction": "lower-is-better",
+      "percentile": "p95"
+    }
+  },
+  "metadata": {
+    "generatedAt": "2026-07-29T00:00:00.000Z",
+    "description": "Android video-server p50/p95 throughput/latency baseline (#4758). Values mirror the QualityPreset.MEDIUM operating point (720p @ 4 Mbps @ 60fps) plus a hosted-runner buffer, and are PROVISIONAL targets pending several accumulated device-lane runs — the same posture the iOS aggregator (#4387) took by not committing a number until samples calibrated it. Ratchet down toward observed p50/p95 once the device lane has accumulated samples."
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:memory-leaks": "bun --expose-gc scripts/detect-memory-leaks.ts",
     "test:integration:webrtc-mediamtx": "bash scripts/webrtc/run-mediamtx-publisher-integration.sh",
     "test:integration:webrtc-device": "bash scripts/webrtc/run-mediamtx-device-integration.sh",
+    "gate:android-video-baseline": "bun scripts/webrtc/android-video-baseline-gate.ts",
     "lint": "eslint . --fix --pass-on-unpruned-suppressions && bun scripts/check-host-shell-boundary.ts && bash scripts/check-no-new-direct-simctl.sh && bun scripts/check-no-direct-plutil.ts && bash scripts/check-no-new-direct-xcodebuild.sh && bash scripts/check-no-new-direct-security.sh && bash scripts/check-no-new-direct-git-metadata.sh && bash scripts/check-no-local-shell-quote.sh && bash scripts/check-app-bundle-metadata-boundary.sh && bash scripts/check-ffmpeg-execution-boundary.sh && bash scripts/check-simulator-tcc-sqlite-boundary.sh && bash scripts/check-daemon-launcher-boundary.sh",
     "lint:prune": "eslint . --prune-suppressions",
     "lint:baseline": "eslint . --suppress-rule max-depth --suppress-rule complexity --suppress-rule max-nested-callbacks --suppress-rule auto-mobile/no-accumulator-foreach",

--- a/scripts/webrtc/android-video-baseline-gate.ts
+++ b/scripts/webrtc/android-video-baseline-gate.ts
@@ -1,0 +1,72 @@
+#!/usr/bin/env bun
+
+/**
+ * Android video-server throughput/latency baseline gate (#4758).
+ *
+ * Reads the device lane's accumulated `stage-latency.json` records out of an
+ * artifacts directory, reduces the Android samples to p50/p95, and fails the
+ * process when any metric regressed past the tolerance committed in
+ * `benchmark/webrtc/android-video-baseline.json` — the ratchet the fps/VBR/GOP
+ * tuning issues gate on. This is the Android counterpart to the iOS *reporting*
+ * script (`aggregate-egress-baseline.ts`, #4387); unlike that reporting-only
+ * tool, this one exits non-zero on regression, mirroring the typecheck/lint
+ * baseline gates.
+ *
+ * Usage:
+ *   bun scripts/webrtc/android-video-baseline-gate.ts <artifacts-dir> [baseline.json]
+ */
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { readCaptureStageRecords } from "./aggregate-egress-baseline";
+import {
+  evaluateAndroidVideoBaseline,
+  extractAndroidVideoMetrics,
+  formatAndroidVideoGateResult,
+  isAndroidVideoBaseline,
+  type AndroidVideoBaseline,
+} from "../../test/helpers/androidVideoBaseline";
+
+const DEFAULT_BASELINE_PATH = path.join(
+  import.meta.dir,
+  "..",
+  "..",
+  "benchmark",
+  "webrtc",
+  "android-video-baseline.json"
+);
+
+/** Read and structurally validate the committed baseline JSON. */
+export async function readAndroidVideoBaseline(file: string): Promise<AndroidVideoBaseline> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(file, "utf8"));
+  } catch (error) {
+    throw new Error(
+      `Failed to read Android video baseline at ${file}: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+  if (!isAndroidVideoBaseline(parsed)) {
+    throw new Error(`Malformed Android video baseline at ${file}: missing required version/fpsTarget/metrics fields`);
+  }
+  return parsed;
+}
+
+async function main(): Promise<void> {
+  const [dir, baselinePath] = process.argv.slice(2);
+  if (!dir) {
+    throw new Error("Usage: bun scripts/webrtc/android-video-baseline-gate.ts <artifacts-dir> [baseline.json]");
+  }
+  const baseline = await readAndroidVideoBaseline(baselinePath ?? DEFAULT_BASELINE_PATH);
+  const records = await readCaptureStageRecords(dir);
+  const metrics = extractAndroidVideoMetrics(records);
+  const result = evaluateAndroidVideoBaseline(metrics, baseline);
+  process.stdout.write(`${formatAndroidVideoGateResult(result)}\n`);
+  if (!result.passed) {
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/test/helpers/androidVideoBaseline.ts
+++ b/test/helpers/androidVideoBaseline.ts
@@ -1,0 +1,317 @@
+import { computePercentile } from "../../src/utils/percentile";
+import type { CaptureStageRecord } from "./captureStageTimeline";
+
+/**
+ * Android video-server throughput/latency baseline gate (#4758).
+ *
+ * The iOS device lane already reports a p50/p95 egress baseline
+ * (`aggregateCaptureStageRecords`, #4387) but asserts *no* threshold, so every
+ * encoder/transport tuning change on Android is currently unmeasured. This is
+ * the Android port plus the missing half: a regression gate that fails when an
+ * accumulated set of device-lane records regresses past a committed tolerance,
+ * mirroring the typecheck/lint baseline ratchet.
+ *
+ * All source values already live on {@link CaptureStageRecord}; this module only
+ * *reduces and compares* them, so it stays hermetic and needs no device lane to
+ * exercise. Where the device lane cannot run locally, the fixture-backed unit
+ * tests are the deliverable the sibling fps/VBR/GOP issues gate on.
+ */
+
+/** The five metrics the gate records and asserts, per the issue's acceptance criteria. */
+export const ANDROID_VIDEO_METRIC_KEYS = [
+  "encodeFps",
+  "egressKbps",
+  "captureToFirstFrameMs",
+  "captureToBrowserMs",
+  "keyframeRecoveryMs",
+] as const;
+
+export type AndroidVideoMetricKey = (typeof ANDROID_VIDEO_METRIC_KEYS)[number];
+
+/**
+ * The phase name the device lane records late-viewer keyframe recovery under
+ * (`timeline.runPhase("keyframeRecovery", ...)`), and the capture stage whose
+ * elapsed-from-origin is the capture → first-encoded-frame latency.
+ */
+export const KEYFRAME_RECOVERY_PHASE = "keyframeRecovery";
+export const FIRST_FRAME_STAGE = "firstEncodedFrame";
+
+/** p50/p95 of one metric over the samples that carried it. */
+export interface PercentilePair {
+  count: number;
+  p50: number;
+  p95: number;
+}
+
+/**
+ * The Android metric percentiles reduced from a set of records, plus the fps
+ * target the records configured. A metric no record carried is `null` — never
+ * coerced to zero — so "no samples" is distinguishable from "a real zero".
+ */
+export interface AndroidVideoMetrics {
+  /** Records considered after filtering to the Android platform. */
+  sampleCount: number;
+  /**
+   * Configured encode-fps target the records requested, when they agreed on
+   * one; null when no record carried a target or they disagreed. This is the
+   * "vs. target" reference the encode-fps assertion reads.
+   */
+  fpsTarget: number | null;
+  encodeFps: PercentilePair | null;
+  egressKbps: PercentilePair | null;
+  captureToFirstFrameMs: PercentilePair | null;
+  captureToBrowserMs: PercentilePair | null;
+  keyframeRecoveryMs: PercentilePair | null;
+}
+
+/** p50/p95 over the finite values only; an all-empty set yields null. */
+function percentilePair(values: Array<number | null | undefined>): PercentilePair | null {
+  const finite = values.filter((value): value is number => typeof value === "number" && Number.isFinite(value));
+  if (finite.length === 0) {
+    return null;
+  }
+  const sorted = [...finite].sort((a, b) => a - b);
+  return {
+    count: sorted.length,
+    p50: computePercentile(sorted, 50),
+    p95: computePercentile(sorted, 95),
+  };
+}
+
+/** The single fps target the records agree on, or null when absent or in conflict. */
+function resolveFpsTarget(records: CaptureStageRecord[]): number | null {
+  const targets = new Set(
+    records
+      .map(record => record.configuredFps)
+      .filter((value): value is number => typeof value === "number" && Number.isFinite(value))
+  );
+  return targets.size === 1 ? [...targets][0] : null;
+}
+
+function firstFrameElapsedMs(record: CaptureStageRecord): number | null {
+  return record.stages.find(stage => stage.stage === FIRST_FRAME_STAGE)?.elapsedMs ?? null;
+}
+
+function keyframeRecoveryElapsedMs(record: CaptureStageRecord): number | null {
+  return record.phases.find(phase => phase.phase === KEYFRAME_RECOVERY_PHASE)?.elapsedMs ?? null;
+}
+
+/**
+ * Reduce device-lane records to the Android metric percentiles (#4758). Filters
+ * to `platform` (default `"android"`) so an aggregated multi-platform artifact
+ * directory yields the Android view without contaminating it with iOS samples.
+ */
+export function extractAndroidVideoMetrics(
+  records: CaptureStageRecord[],
+  options: { platform?: string } = {}
+): AndroidVideoMetrics {
+  const platform = options.platform ?? "android";
+  const considered = records.filter(record => record.platform === platform);
+  return {
+    sampleCount: considered.length,
+    fpsTarget: resolveFpsTarget(considered),
+    encodeFps: percentilePair(considered.map(record => record.decodedFps)),
+    egressKbps: percentilePair(considered.map(record => record.egressKbps)),
+    captureToFirstFrameMs: percentilePair(considered.map(firstFrameElapsedMs)),
+    captureToBrowserMs: percentilePair(considered.map(record => record.captureToBrowserMs)),
+    keyframeRecoveryMs: percentilePair(considered.map(keyframeRecoveryElapsedMs)),
+  };
+}
+
+/** Whether a larger observed value is better (throughput/fps) or worse (latency). */
+export type MetricDirection = "higher-is-better" | "lower-is-better";
+
+/** Which percentile the gate compares against the baseline for a metric. */
+export type GatedPercentile = "p50" | "p95";
+
+/** One metric's committed baseline: the reference value and the tolerance around it. */
+export interface MetricThreshold {
+  /** The committed reference value the ratchet holds the lane to. */
+  baseline: number;
+  /** Fractional slack before a move counts as a regression (0.15 = 15%). */
+  tolerance: number;
+  direction: MetricDirection;
+  /** Which percentile is gated: central (p50) for rates, tail (p95) for latencies. */
+  percentile: GatedPercentile;
+}
+
+/** The committed Android video baseline — the ratchet artifact, mirroring `startup-baseline.json`. */
+export interface AndroidVideoBaseline {
+  version: string;
+  /**
+   * Encode-fps target the lane must sustain, and the fractional shortfall
+   * tolerated below it, independent of the ratchet in `metrics.encodeFps`.
+   */
+  fpsTarget: number;
+  fpsTargetTolerance: number;
+  metrics: Record<AndroidVideoMetricKey, MetricThreshold>;
+  metadata?: { generatedAt?: string; description?: string };
+}
+
+export type MetricStatus = "ok" | "regressed" | "missing";
+
+/** The gate's verdict for one metric. */
+export interface MetricEvaluation {
+  metric: AndroidVideoMetricKey;
+  status: MetricStatus;
+  direction: MetricDirection;
+  percentile: GatedPercentile;
+  /** The gated percentile of the observed samples, or null when none carried the metric. */
+  observed: number | null;
+  baseline: number;
+  /** The worst value that still passes: `baseline·(1±tolerance)` per direction. */
+  allowed: number;
+  /** Non-null only for `encodeFps`: the observed p50 against the configured target. */
+  targetCheck?: { target: number; allowed: number; status: MetricStatus };
+  message: string;
+}
+
+/** The whole-gate verdict. */
+export interface AndroidVideoGateResult {
+  passed: boolean;
+  sampleCount: number;
+  evaluations: MetricEvaluation[];
+}
+
+function allowedBound(threshold: MetricThreshold): number {
+  return threshold.direction === "higher-is-better"
+    ? threshold.baseline * (1 - threshold.tolerance)
+    : threshold.baseline * (1 + threshold.tolerance);
+}
+
+function isRegression(observed: number, allowed: number, direction: MetricDirection): boolean {
+  return direction === "higher-is-better" ? observed < allowed : observed > allowed;
+}
+
+function pick(pair: PercentilePair | null, percentile: GatedPercentile): number | null {
+  if (pair === null) {
+    return null;
+  }
+  return percentile === "p50" ? pair.p50 : pair.p95;
+}
+
+function unitFor(metric: AndroidVideoMetricKey): string {
+  if (metric === "encodeFps") {
+    return "fps";
+  }
+  return metric === "egressKbps" ? "kbps" : "ms";
+}
+
+function round(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+/** Evaluate the encode-fps "vs. target" check that rides alongside its ratchet. */
+function evaluateTargetCheck(
+  observedP50: number | null,
+  baseline: AndroidVideoBaseline
+): MetricEvaluation["targetCheck"] {
+  const allowed = baseline.fpsTarget * (1 - baseline.fpsTargetTolerance);
+  let status: MetricStatus;
+  if (observedP50 === null) {
+    status = "missing";
+  } else {
+    status = observedP50 < allowed ? "regressed" : "ok";
+  }
+  return { target: baseline.fpsTarget, allowed, status };
+}
+
+function evaluateMetric(
+  metric: AndroidVideoMetricKey,
+  metrics: AndroidVideoMetrics,
+  baseline: AndroidVideoBaseline
+): MetricEvaluation {
+  const threshold = baseline.metrics[metric];
+  const observed = pick(metrics[metric], threshold.percentile);
+  const allowed = allowedBound(threshold);
+  const unit = unitFor(metric);
+  const targetCheck = metric === "encodeFps" ? evaluateTargetCheck(observed, baseline) : undefined;
+
+  if (observed === null) {
+    return {
+      metric,
+      status: "missing",
+      direction: threshold.direction,
+      percentile: threshold.percentile,
+      observed: null,
+      baseline: threshold.baseline,
+      allowed,
+      targetCheck,
+      message: `${metric}: no samples carried this metric — cannot prove no regression`,
+    };
+  }
+
+  const regressed = isRegression(observed, allowed, threshold.direction) || targetCheck?.status === "regressed";
+  const comparator = threshold.direction === "higher-is-better" ? ">=" : "<=";
+  const targetSuffix =
+    targetCheck && targetCheck.status !== "ok"
+      ? ` (below target ${round(targetCheck.allowed)}${unit} of ${baseline.fpsTarget}${unit})`
+      : "";
+  return {
+    metric,
+    status: regressed ? "regressed" : "ok",
+    direction: threshold.direction,
+    percentile: threshold.percentile,
+    observed,
+    baseline: threshold.baseline,
+    allowed,
+    targetCheck,
+    message: `${metric} ${threshold.percentile}=${round(observed)}${unit} ${
+      regressed ? "REGRESSED" : "ok"
+    } (need ${comparator} ${round(allowed)}${unit}, baseline ${threshold.baseline}${unit})${targetSuffix}`,
+  };
+}
+
+/**
+ * Evaluate the Android metrics against the committed baseline (#4758). The gate
+ * fails on any metric that regressed past its tolerance, and — mirroring the
+ * unit-test real-DB guard's stance that a silent pass is the worst outcome — on
+ * any metric no sample carried, since an absent metric cannot prove a lane did
+ * not regress.
+ */
+export function evaluateAndroidVideoBaseline(
+  metrics: AndroidVideoMetrics,
+  baseline: AndroidVideoBaseline
+): AndroidVideoGateResult {
+  const evaluations = ANDROID_VIDEO_METRIC_KEYS.map(metric => evaluateMetric(metric, metrics, baseline));
+  return {
+    passed: evaluations.every(evaluation => evaluation.status === "ok"),
+    sampleCount: metrics.sampleCount,
+    evaluations,
+  };
+}
+
+/** Human-readable rendering of a gate result for a CI job log. */
+export function formatAndroidVideoGateResult(result: AndroidVideoGateResult): string {
+  const header = `Android video baseline gate: ${result.passed ? "PASS" : "FAIL"} (samples=${result.sampleCount})`;
+  return [header, ...result.evaluations.map(evaluation => `  ${evaluation.message}`)].join("\n");
+}
+
+/** Structural check that a parsed JSON value is an {@link AndroidVideoBaseline}. */
+export function isAndroidVideoBaseline(value: unknown): value is AndroidVideoBaseline {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  if (
+    typeof candidate.version !== "string" ||
+    typeof candidate.fpsTarget !== "number" ||
+    typeof candidate.fpsTargetTolerance !== "number" ||
+    typeof candidate.metrics !== "object" ||
+    candidate.metrics === null
+  ) {
+    return false;
+  }
+  const metrics = candidate.metrics as Record<string, unknown>;
+  return ANDROID_VIDEO_METRIC_KEYS.every(key => {
+    const threshold = metrics[key] as Record<string, unknown> | undefined;
+    return (
+      typeof threshold === "object" &&
+      threshold !== null &&
+      typeof threshold.baseline === "number" &&
+      typeof threshold.tolerance === "number" &&
+      (threshold.direction === "higher-is-better" || threshold.direction === "lower-is-better") &&
+      (threshold.percentile === "p50" || threshold.percentile === "p95")
+    );
+  });
+}

--- a/test/scripts/androidVideoBaselineGate.test.ts
+++ b/test/scripts/androidVideoBaselineGate.test.ts
@@ -1,0 +1,259 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { readFileSync } from "node:fs";
+import {
+  ANDROID_VIDEO_METRIC_KEYS,
+  evaluateAndroidVideoBaseline,
+  extractAndroidVideoMetrics,
+  formatAndroidVideoGateResult,
+  isAndroidVideoBaseline,
+  type AndroidVideoBaseline,
+} from "../helpers/androidVideoBaseline";
+import type { CaptureStageRecord } from "../helpers/captureStageTimeline";
+import { readAndroidVideoBaseline } from "../../scripts/webrtc/android-video-baseline-gate";
+import { readCaptureStageRecords } from "../../scripts/webrtc/aggregate-egress-baseline";
+
+const repoRoot = path.join(import.meta.dir, "..", "..");
+
+/**
+ * A device-lane record with the metric-carrying fields set. Stage/phase elapsed
+ * values are the source of the two latency metrics and keyframe recovery time.
+ */
+function androidRecord(overrides: {
+  platform?: string;
+  configuredFps?: number | null;
+  decodedFps?: number | null;
+  egressKbps?: number | null;
+  firstEncodedFrameMs?: number | null;
+  captureToBrowserMs?: number | null;
+  keyframeRecoveryMs?: number | null;
+} = {}): CaptureStageRecord {
+  const {
+    platform = "android",
+    configuredFps = 60,
+    decodedFps = 50,
+    egressKbps = 4200,
+    firstEncodedFrameMs = 1500,
+    captureToBrowserMs = 4000,
+    keyframeRecoveryMs = 2500,
+  } = overrides;
+  return {
+    platform,
+    streamId: "device-capture-android",
+    outcome: "passed",
+    sourceSize: null,
+    configuredFps,
+    decodedSize: null,
+    egressKbps,
+    decodedFps,
+    run: {
+      runId: "1",
+      runAttempt: "1",
+      commitSha: "abc",
+      runnerOs: "Linux",
+      runnerImage: "ubuntu",
+      startedAtIso: "2026-07-29T00:00:00.000Z",
+    },
+    samplingIntervalsMs: {},
+    schemaVersion: 3,
+    stages:
+      firstEncodedFrameMs === null
+        ? []
+        : [{ stage: "firstEncodedFrame", elapsedMs: firstEncodedFrameMs, deltaMs: firstEncodedFrameMs }],
+    phases:
+      keyframeRecoveryMs === null
+        ? []
+        : [{ phase: "keyframeRecovery", elapsedMs: keyframeRecoveryMs, status: "ok" }],
+    missingStages: [],
+    captureToBrowserMs,
+  };
+}
+
+function baseline(overrides: Partial<AndroidVideoBaseline> = {}): AndroidVideoBaseline {
+  return {
+    version: "1.0.0",
+    fpsTarget: 60,
+    fpsTargetTolerance: 0.5,
+    metrics: {
+      encodeFps: { baseline: 45, tolerance: 0.2, direction: "higher-is-better", percentile: "p50" },
+      egressKbps: { baseline: 4000, tolerance: 0.3, direction: "higher-is-better", percentile: "p50" },
+      captureToFirstFrameMs: { baseline: 2000, tolerance: 0.3, direction: "lower-is-better", percentile: "p95" },
+      captureToBrowserMs: { baseline: 5000, tolerance: 0.3, direction: "lower-is-better", percentile: "p95" },
+      keyframeRecoveryMs: { baseline: 3000, tolerance: 0.35, direction: "lower-is-better", percentile: "p95" },
+    },
+    ...overrides,
+  };
+}
+
+describe("#4758 extractAndroidVideoMetrics", () => {
+  test("reduces every metric to p50/p95 over the Android samples only", () => {
+    const metrics = extractAndroidVideoMetrics([
+      androidRecord({ decodedFps: 40, egressKbps: 4000, firstEncodedFrameMs: 1000, keyframeRecoveryMs: 2000 }),
+      androidRecord({ decodedFps: 60, egressKbps: 5000, firstEncodedFrameMs: 2000, keyframeRecoveryMs: 3000 }),
+      androidRecord({ platform: "ios", decodedFps: 5, egressKbps: 1 }),
+    ]);
+
+    expect(metrics.sampleCount).toBe(2);
+    expect(metrics.fpsTarget).toBe(60);
+    expect(metrics.encodeFps).toEqual({ count: 2, p50: 50, p95: 59 });
+    expect(metrics.egressKbps).toEqual({ count: 2, p50: 4500, p95: 4950 });
+    expect(metrics.captureToFirstFrameMs).toEqual({ count: 2, p50: 1500, p95: 1950 });
+    expect(metrics.keyframeRecoveryMs).toEqual({ count: 2, p50: 2500, p95: 2950 });
+  });
+
+  test("returns null for a metric no record carried, never a coerced zero", () => {
+    const metrics = extractAndroidVideoMetrics([
+      androidRecord({ egressKbps: null, keyframeRecoveryMs: null }),
+    ]);
+    expect(metrics.egressKbps).toBeNull();
+    expect(metrics.keyframeRecoveryMs).toBeNull();
+    // Other metrics on the same record are still summarized.
+    expect(metrics.encodeFps).not.toBeNull();
+  });
+
+  test("reports a null fps target when records disagree on the configured fps", () => {
+    const metrics = extractAndroidVideoMetrics([
+      androidRecord({ configuredFps: 60 }),
+      androidRecord({ configuredFps: 30 }),
+    ]);
+    expect(metrics.fpsTarget).toBeNull();
+  });
+});
+
+describe("#4758 evaluateAndroidVideoBaseline", () => {
+  test("passes when every metric is within tolerance", () => {
+    const metrics = extractAndroidVideoMetrics([androidRecord()]);
+    const result = evaluateAndroidVideoBaseline(metrics, baseline());
+    expect(result.passed).toBe(true);
+    expect(result.evaluations.every(e => e.status === "ok")).toBe(true);
+  });
+
+  test("fails when a higher-is-better metric drops past tolerance (fps collapse)", () => {
+    // 45 baseline, 20% tolerance -> floor 36. p50 of 30 regresses.
+    const metrics = extractAndroidVideoMetrics([androidRecord({ decodedFps: 30 })]);
+    const result = evaluateAndroidVideoBaseline(metrics, baseline());
+    expect(result.passed).toBe(false);
+    const encode = result.evaluations.find(e => e.metric === "encodeFps");
+    expect(encode?.status).toBe("regressed");
+    expect(encode?.allowed).toBeCloseTo(36, 5);
+  });
+
+  test("fails when a lower-is-better latency rises past tolerance", () => {
+    // captureToBrowser baseline 5000, 30% -> ceiling 6500. 8000 regresses.
+    const metrics = extractAndroidVideoMetrics([androidRecord({ captureToBrowserMs: 8000 })]);
+    const result = evaluateAndroidVideoBaseline(metrics, baseline());
+    expect(result.passed).toBe(false);
+    const latency = result.evaluations.find(e => e.metric === "captureToBrowserMs");
+    expect(latency?.status).toBe("regressed");
+    expect(latency?.allowed).toBeCloseTo(6500, 5);
+  });
+
+  test("holds the line exactly at the tolerance boundary", () => {
+    // keyframeRecovery baseline 3000, 35% -> ceiling 4050; exactly 4050 still passes.
+    const metrics = extractAndroidVideoMetrics([androidRecord({ keyframeRecoveryMs: 4050 })]);
+    const result = evaluateAndroidVideoBaseline(metrics, baseline());
+    const recovery = result.evaluations.find(e => e.metric === "keyframeRecoveryMs");
+    expect(recovery?.status).toBe("ok");
+  });
+
+  test("fails a metric no sample carried — an absent metric cannot prove no regression", () => {
+    const metrics = extractAndroidVideoMetrics([androidRecord({ keyframeRecoveryMs: null })]);
+    const result = evaluateAndroidVideoBaseline(metrics, baseline());
+    expect(result.passed).toBe(false);
+    const recovery = result.evaluations.find(e => e.metric === "keyframeRecoveryMs");
+    expect(recovery?.status).toBe("missing");
+    expect(recovery?.observed).toBeNull();
+  });
+
+  test("fails encode fps when it clears the ratchet but falls below the configured target", () => {
+    // Target 60, 50% tolerance -> target floor 30. Ratchet floor is 36.
+    // p50 of 33 clears... no. Use a baseline whose ratchet is loose but target is the binding check.
+    const metrics = extractAndroidVideoMetrics([androidRecord({ decodedFps: 25 })]);
+    const loose = baseline({
+      metrics: {
+        ...baseline().metrics,
+        encodeFps: { baseline: 20, tolerance: 0.5, direction: "higher-is-better", percentile: "p50" },
+      },
+      fpsTargetTolerance: 0.5,
+    });
+    // ratchet floor = 20*0.5 = 10 (25 clears); target floor = 60*0.5 = 30 (25 fails).
+    const result = evaluateAndroidVideoBaseline(metrics, loose);
+    const encode = result.evaluations.find(e => e.metric === "encodeFps");
+    expect(encode?.status).toBe("regressed");
+    expect(encode?.targetCheck?.status).toBe("regressed");
+    expect(result.passed).toBe(false);
+  });
+
+  test("formats a readable PASS/FAIL summary line per metric", () => {
+    const metrics = extractAndroidVideoMetrics([androidRecord({ decodedFps: 30 })]);
+    const text = formatAndroidVideoGateResult(evaluateAndroidVideoBaseline(metrics, baseline()));
+    expect(text).toContain("FAIL");
+    expect(text).toContain("encodeFps");
+    for (const key of ANDROID_VIDEO_METRIC_KEYS) {
+      expect(text).toContain(key);
+    }
+  });
+});
+
+describe("#4758 committed baseline JSON + reader", () => {
+  test("the committed benchmark/webrtc/android-video-baseline.json is structurally valid", () => {
+    const parsed = JSON.parse(
+      readFileSync(path.join(repoRoot, "benchmark/webrtc/android-video-baseline.json"), "utf8")
+    );
+    expect(isAndroidVideoBaseline(parsed)).toBe(true);
+  });
+
+  test("readAndroidVideoBaseline loads the committed baseline", async () => {
+    const loaded = await readAndroidVideoBaseline(
+      path.join(repoRoot, "benchmark/webrtc/android-video-baseline.json")
+    );
+    expect(loaded.fpsTarget).toBe(60);
+    expect(loaded.metrics.encodeFps.direction).toBe("higher-is-better");
+  });
+
+  test("readAndroidVideoBaseline rejects a malformed baseline", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "android-baseline-"));
+    try {
+      const bad = path.join(dir, "bad.json");
+      writeFileSync(bad, JSON.stringify({ version: "1", metrics: {} }));
+      await expect(readAndroidVideoBaseline(bad)).rejects.toThrow(/Malformed/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("isAndroidVideoBaseline rejects a threshold missing its direction", () => {
+    const b = baseline();
+    // Structurally corrupt one threshold.
+    const corrupt = { ...b, metrics: { ...b.metrics, egressKbps: { baseline: 1, tolerance: 0.1, percentile: "p50" } } };
+    expect(isAndroidVideoBaseline(corrupt)).toBe(false);
+  });
+});
+
+describe("#4758 gate over a fixture artifacts directory", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "android-gate-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("reads records recursively and evaluates the whole set", async () => {
+    writeFileSync(path.join(dir, "stage-latency.json"), JSON.stringify(androidRecord({ decodedFps: 55 })));
+    const nested = path.join(dir, "run-2");
+    mkdirSync(nested);
+    writeFileSync(path.join(nested, "stage-latency.json"), JSON.stringify(androidRecord({ decodedFps: 48 })));
+    // An unrelated artifact JSON must be ignored, not fail the run.
+    writeFileSync(path.join(dir, "unrelated.json"), JSON.stringify({ hello: "world" }));
+
+    // Exercised via extract+evaluate the way the CLI wires them.
+    const records = await readCaptureStageRecords(dir);
+    expect(records).toHaveLength(2);
+    const result = evaluateAndroidVideoBaseline(extractAndroidVideoMetrics(records), baseline());
+    expect(result.sampleCount).toBe(2);
+    expect(result.passed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Ports the iOS p50/p95 egress baseline aggregator ([#4387](https://github.com/kaeawc/auto-mobile/pull/4387)) to the Android video device lane and adds the piece iOS never had: a **regression gate** that fails when accumulated device-lane records regress past a committed tolerance, mirroring the typecheck/lint baseline ratchet.

The five metrics from the acceptance criteria are recorded and asserted:

| Metric | Source on `CaptureStageRecord` | Direction | Gated |
| --- | --- | --- | --- |
| encode fps (vs. target) | `decodedFps` (sustained) vs. `configuredFps` (target) | higher-is-better | p50 |
| egress bitrate | `egressKbps` | higher-is-better | p50 |
| capture -> first frame | `firstEncodedFrame` stage `elapsedMs` | lower-is-better | p95 |
| capture -> browser | `captureToBrowserMs` | lower-is-better | p95 |
| late-viewer keyframe recovery | `keyframeRecovery` phase `elapsedMs` | lower-is-better | p95 |

Every source value already lives on `CaptureStageRecord`, so the aggregator + gate stay hermetic and need no device lane to exercise — the fixture-backed unit tests are the deliverable the sibling fps/VBR/GOP tuning issues gate on.

## Changes

- `test/helpers/androidVideoBaseline.ts` — core logic: `extractAndroidVideoMetrics` (records -> p50/p95, Android-filtered), `evaluateAndroidVideoBaseline` (per-metric tolerance check with direction + gated percentile; an **absent** metric fails, since it cannot prove no-regression — the same stance as the unit-test real-DB guard), a formatter, and a structural baseline validator.
- `scripts/webrtc/android-video-baseline-gate.ts` — CLI counterpart to `aggregate-egress-baseline.ts`; reads the artifacts dir (reusing `readCaptureStageRecords`), evaluates against the committed baseline, and exits non-zero on regression.
- `benchmark/webrtc/android-video-baseline.json` — the committed ratchet artifact. Values mirror the `QualityPreset.MEDIUM` operating point (720p @ 4 Mbps @ 60fps) plus a hosted-runner buffer and are **provisional** pending accumulated device-lane samples — the same posture [#4387](https://github.com/kaeawc/auto-mobile/pull/4387) took by not committing a number until samples calibrated it.
- `test/scripts/androidVideoBaselineGate.test.ts` — 15 unit tests over fixture records: extraction, per-direction regression, tolerance boundary, missing-metric failure, encode-fps-vs-target, committed-baseline validity, and a fixture-directory end-to-end pass.
- `package.json` — `gate:android-video-baseline` script.

## Validation

- `bun test test/scripts/androidVideoBaselineGate.test.ts` -> 15 pass / 0 fail
- Sibling suites unaffected: `aggregateEgressBaseline.test.ts` + `captureStageTimeline.test.ts` -> 37 pass / 0 fail
- `bun run typecheck` -> no new type errors (198 known in baseline)
- `bun run lint` -> clean (all boundary checks pass)
- `bun run build` -> success
- CLI smoke test over fixtures: pass case exits 0, regression case exits 1 with per-metric detail.

## Unverifiable here (device-lane only)

The Android device lane needs a real emulator + browser and cannot run locally, so the gate's baseline numbers are provisional and the gate is not yet wired as a required CI check — it is exposed as `bun run gate:android-video-baseline <artifacts-dir>` for the device-lane workflow to call once samples accumulate, then ratcheted toward observed p50/p95. This matches the issue's fallback: the aggregator + gate logic and its tests are the deliverable.

Closes [#4758](https://github.com/kaeawc/auto-mobile/issues/4758)
