### PR TITLE
fix(ios): re-resolve the Simulator windowID on capture retry

### DIFF
--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -466,9 +466,10 @@ export class IosH264Source implements H264CaptureSource {
 
   private async startCaptureWithSimulatorRetry(helperPath: string, target: CaptureTarget): Promise<void> {
     const shouldRetryNoFirstFrame = target.kind === "simulator" && !this.options.createHelper;
+    let currentTarget = target;
     for (let attempt = 0; ; attempt++) {
       try {
-        await this.startCaptureAttempt(helperPath, target);
+        await this.startCaptureAttempt(helperPath, currentTarget);
         return;
       } catch (error) {
         if (!shouldRetryNoFirstFrame || !(error instanceof NoFirstFrameError)) {
@@ -489,10 +490,39 @@ export class IosH264Source implements H264CaptureSource {
         // The failed lease is invalidated above, so one new ScreenCaptureKit session
         // can recover a transient no-frame startup without surfacing a warning.
         logger.debug(
-          `[IosH264Source] no first frame from pooled Simulator helper for ${describeCaptureTarget(target)}; retrying once`
+          `[IosH264Source] no first frame from pooled Simulator helper for ${describeCaptureTarget(currentTarget)}; retrying once`
         );
+        // A Simulator relaunch/reboot/window-recreation between attempts changes the
+        // CGWindowID, so reusing the stale windowID would deterministically retry
+        // against a dead window. Re-resolve it under the same 2s deadline
+        // (IOS_SIMULATOR_TARGET_RESOLUTION_TIMEOUT_MS) so the retry targets the live
+        // window without consuming the whole startup budget.
+        currentTarget = await this.reresolveSimulatorTarget(helperPath, currentTarget);
       }
     }
+  }
+
+  private async reresolveSimulatorTarget(
+    helperPath: string,
+    target: CaptureTarget
+  ): Promise<CaptureTarget> {
+    if (target.kind !== "simulator") {
+      return target;
+    }
+    let windowID: number;
+    try {
+      windowID = await this.resolveSimulatorWindowIdWithDeadline(helperPath);
+    } catch (error) {
+      throw toActionableError(error, "Failed to re-resolve iOS Simulator window for capture retry");
+    }
+    if (windowID === target.windowID) {
+      return target;
+    }
+    logger.debug(
+      `[IosH264Source] Simulator windowID changed from ${target.windowID} to ${windowID} before retry; ` +
+      "targeting the freshly-resolved window"
+    );
+    return { ...target, windowID };
   }
 
   private async startCaptureAttempt(helperPath: string, target: CaptureTarget): Promise<void> {

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -420,6 +420,111 @@ describe("IosH264Source", () => {
     await pool.shutdown();
   });
 
+  test("re-resolves a changed Simulator windowID before the silent-capture retry", async () => {
+    const timer = new FakeTimer();
+    const helpers: FakeFrameCaptureHelper[] = [];
+    const helperTargets: CaptureTarget[] = [];
+    const pool = new IOSSimulatorCaptureHelperPool({
+      createHelper: options => {
+        helperTargets.push(options.target);
+        const helper = new FakeFrameCaptureHelper();
+        helpers.push(helper);
+        return helper;
+      },
+    });
+    const resolvedWindowIds = [42, 99];
+    let resolveCalls = 0;
+    const source = new IosH264Source({
+      device: IOS_SIMULATOR,
+      helperPath: FAKE_HELPER_PATH,
+      helperPathExists: fakeHelperPathExists,
+      onData: () => {},
+      firstFrameTimeoutMs: 1,
+      simulatorHelperPool: pool,
+      spawner: () => new FakeChildProcess() as unknown as ChildProcessWithoutNullStreams,
+      simulatorWindowResolver: async () => resolvedWindowIds[resolveCalls++] ?? 99,
+      commandRunner: successfulCommandRunner,
+      timer,
+    });
+
+    const started = source.start().then(
+      () => null,
+      error => error as Error
+    );
+    await flush();
+    timer.advanceTime(1);
+    await flush();
+
+    expect(helpers).toHaveLength(2);
+    helpers[1].emitFrame(frame(1, 1, 0x11));
+
+    expect(await started).toBeNull();
+    // First attempt targeted the initially-resolved window; the retry re-resolved
+    // to the recreated window's new CGWindowID rather than reusing the stale one.
+    expect(helperTargets).toEqual([
+      { kind: "simulator", windowID: 42, fps: WEBRTC_IOS_SIMULATOR_FPS_DEFAULT },
+      { kind: "simulator", windowID: 99, fps: WEBRTC_IOS_SIMULATOR_FPS_DEFAULT },
+    ]);
+    expect(resolveCalls).toBe(2);
+    expect(helpers[0].stopped).toBe(true);
+    expect(helpers[1].started).toBe(true);
+    await source.stop();
+    await pool.shutdown();
+  });
+
+  test("retries with the same windowID when the Simulator window is unchanged", async () => {
+    const timer = new FakeTimer();
+    const helpers: FakeFrameCaptureHelper[] = [];
+    const helperTargets: CaptureTarget[] = [];
+    const pool = new IOSSimulatorCaptureHelperPool({
+      createHelper: options => {
+        helperTargets.push(options.target);
+        const helper = new FakeFrameCaptureHelper();
+        helpers.push(helper);
+        return helper;
+      },
+    });
+    let resolveCalls = 0;
+    const source = new IosH264Source({
+      device: IOS_SIMULATOR,
+      helperPath: FAKE_HELPER_PATH,
+      helperPathExists: fakeHelperPathExists,
+      onData: () => {},
+      firstFrameTimeoutMs: 1,
+      simulatorHelperPool: pool,
+      spawner: () => new FakeChildProcess() as unknown as ChildProcessWithoutNullStreams,
+      simulatorWindowResolver: async () => {
+        resolveCalls++;
+        return 42;
+      },
+      commandRunner: successfulCommandRunner,
+      timer,
+    });
+
+    const started = source.start().then(
+      () => null,
+      error => error as Error
+    );
+    await flush();
+    timer.advanceTime(1);
+    await flush();
+
+    expect(helpers).toHaveLength(2);
+    helpers[1].emitFrame(frame(1, 1, 0x11));
+
+    expect(await started).toBeNull();
+    expect(helperTargets).toEqual([
+      { kind: "simulator", windowID: 42, fps: WEBRTC_IOS_SIMULATOR_FPS_DEFAULT },
+      { kind: "simulator", windowID: 42, fps: WEBRTC_IOS_SIMULATOR_FPS_DEFAULT },
+    ]);
+    // Re-resolution happens once on retry; the unchanged id preserves prior behavior.
+    expect(resolveCalls).toBe(2);
+    expect(helpers[0].stopped).toBe(true);
+    expect(helpers[1].started).toBe(true);
+    await source.stop();
+    await pool.shutdown();
+  });
+
   test("reports the existing no-frame error after a second silent pooled Simulator attempt", async () => {
     const helpers: FakeFrameCaptureHelper[] = [];
     const pool = new IOSSimulatorCaptureHelperPool({


### PR DESCRIPTION
Closes [#4767](https://github.com/kaeawc/auto-mobile/issues/4767)

## Summary

The silent-capture retry in `IosH264Source` (`startCaptureWithSimulatorRetry`)
reused the same `target.windowID` that `resolveCaptureTarget` resolved once at
start. If the Simulator window was recreated between the failed first attempt and
the retry (relaunch, device reboot, window close/reopen), the CGWindowID changes
and the retry deterministically targeted a dead window — defeating the recovery
that PR [#4424](https://github.com/kaeawc/auto-mobile/pull/4424) added.

## Changes

- `src/features/webrtc/IosH264Source.ts`: on the silent-no-first-frame Simulator
  retry, re-resolve the windowID via `resolveSimulatorWindowIdWithDeadline` (new
  `reresolveSimulatorTarget` helper) instead of reusing the stale
  `target.windowID`. The retry now targets the freshly-resolved window and builds
  a fresh `CaptureTarget` (preserving `fps`/`audio`). Re-resolution reuses the
  existing 2s deadline (`IOS_SIMULATOR_TARGET_RESOLUTION_TIMEOUT_MS`), so the
  retry cannot consume the whole startup budget. A re-resolution failure is
  wrapped in an `ActionableError`.
- `test/features/webrtc/IosH264Source.test.ts`: two tests —
  - windowID changes (42 -> 99) between the first attempt and the retry: the
    retry is acquired against the freshly-resolved id 99 and succeeds.
  - unchanged window: the retry re-resolves once and reuses the same id 42,
    preserving prior single-attempt-recovery behavior.

## Validation

- `bun run typecheck` — no new type errors (198 known baseline).
- `turbo run lint build test` — pass.
- `bun test test/features/webrtc/IosH264Source.test.ts` — 72 pass / 0 fail.
- Confirmed both new tests fail against the pre-fix source (2 fail), proving they
  exercise the change.
