### PR TITLE
test(ios): unit-test the ScreenCaptureHelper session lifecycle

### DIFF
--- a/ios/screen-capture/Package.swift
+++ b/ios/screen-capture/Package.swift
@@ -31,5 +31,10 @@ let package = Package(
             dependencies: ["ScreenCaptureCore"],
             path: "Tests/ScreenCaptureCoreTests"
         ),
+        .testTarget(
+            name: "ScreenCaptureHelperTests",
+            dependencies: ["ScreenCaptureHelper"],
+            path: "Tests/ScreenCaptureHelperTests"
+        ),
     ]
 )

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
@@ -4,24 +4,66 @@ import Foundation
 import ScreenCaptureKit
 import ScreenCaptureCore
 
+/// The subset of `SCStream` operations `SimulatorCaptureSession` drives. Wrapping
+/// them in a protocol is the seam that lets unit tests inject a fake stream and
+/// exercise the session's lifecycle paths (start/stop/reconfigure/fatal-error)
+/// without a real Simulator window or Screen Recording permission (issue #4771).
+/// The signatures match `SCStream`'s exactly so it conforms without adapters.
+protocol CaptureStream: AnyObject {
+    func addStreamOutput(
+        _ output: SCStreamOutput,
+        type: SCStreamOutputType,
+        sampleHandlerQueue: DispatchQueue?
+    ) throws
+    func removeStreamOutput(_ output: SCStreamOutput, type: SCStreamOutputType) throws
+    func startCapture() async throws
+    func stopCapture() async throws
+    func updateConfiguration(_ configuration: SCStreamConfiguration) async throws
+}
+
+extension SCStream: CaptureStream {}
+
 /// Streams BGRA frames from a single iOS Simulator window via ScreenCaptureKit.
 /// The frame rate is configurable (5–60); 5 is the default for typical MCP
 /// automation workloads. Size changes (e.g. device rotation) trigger a stream
 /// reconfiguration so frames don't get cropped.
 final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate {
+    /// Builds the concrete stream for a resolved window. Injected so tests can
+    /// substitute a fake `CaptureStream`; the default wires the real `SCStream`.
+    typealias StreamFactory = (SCContentFilter, SCStreamConfiguration, SCStreamDelegate) -> CaptureStream
+
     private let writer: FrameWriter
     private let onFatalError: (Error) -> Void
+    private let makeStream: StreamFactory
+    /// Diagnostic lines (first-frame marker, reconfigure warnings) go here so
+    /// tests can observe them; the default preserves the stderr behavior.
+    private let diagnosticSink: (String) -> Void
     private let queue = DispatchQueue(label: "automobile.simulator-capture.frames")
     let firstFrameSignal = FirstFrameSignal()
-    private var stream: SCStream?
-    private var configuredPixelWidth: Int = 0
-    private var configuredPixelHeight: Int = 0
-    private var fps: Int = CommandLineOptions.defaultSimulatorFPS
-    private var audioEnabled = false
-    private var windowID: UInt32 = 0
 
-    init(writer: FrameWriter, onFatalError: @escaping (Error) -> Void) {
+    // The following are `internal` (not `private`) so `@testable` tests can seed
+    // and inspect lifecycle state that `start()` would otherwise set only behind
+    // a real `SCWindow`. They are not part of the production API surface.
+    var stream: CaptureStream?
+    var configuredPixelWidth: Int = 0
+    var configuredPixelHeight: Int = 0
+    var fps: Int = CommandLineOptions.defaultSimulatorFPS
+    var audioEnabled = false
+    var windowID: UInt32 = 0
+
+    init(
+        writer: FrameWriter,
+        makeStream: @escaping StreamFactory = { filter, config, delegate in
+            SCStream(filter: filter, configuration: config, delegate: delegate)
+        },
+        diagnosticSink: @escaping (String) -> Void = { line in
+            FileHandle.standardError.write(Data(line.utf8))
+        },
+        onFatalError: @escaping (Error) -> Void
+    ) {
         self.writer = writer
+        self.makeStream = makeStream
+        self.diagnosticSink = diagnosticSink
         self.onFatalError = onFatalError
     }
 
@@ -34,7 +76,14 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
         configuredPixelWidth = config.width
         configuredPixelHeight = config.height
 
-        let stream = SCStream(filter: filter, configuration: config, delegate: self)
+        let stream = makeStream(filter, config, self)
+        try await beginCapture(with: stream, audio: audio)
+    }
+
+    /// Wires outputs onto an already-built stream and starts it. Split out from
+    /// `start()` so tests can drive it with a fake `CaptureStream` — the window
+    /// resolution and filter/config construction above need real SCK objects.
+    func beginCapture(with stream: CaptureStream, audio: Bool) async throws {
         try stream.addStreamOutput(self, type: .screen, sampleHandlerQueue: queue)
         if audio {
             try stream.addStreamOutput(self, type: .audio, sampleHandlerQueue: queue)
@@ -83,28 +132,52 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
         }
 
         if writer.write(sampleBuffer: sampleBuffer) {
-            if !firstFrameSignal.hasReceivedFrame {
-                // Emitted from the frame queue to confirm the source actually
-                // started delivering frames — the "captureStarted but no
-                // firstFrame" distinction issue #4350 needs.
-                let marker = CaptureStartupMarker.line(
-                    .firstFrame(windowID: windowID, width: actualWidth, height: actualHeight)
-                )
-                FileHandle.standardError.write(Data("\(marker)\n".utf8))
-            }
-            firstFrameSignal.markReceivedFrame()
+            noteFrameWritten(width: actualWidth, height: actualHeight)
         }
+    }
+
+    /// Emits the first-frame marker exactly once and records that frames are
+    /// flowing. Split out from the frame callback so tests can assert the
+    /// once-only marker emission without synthesizing a `CMSampleBuffer`.
+    func noteFrameWritten(width: Int, height: Int) {
+        if !firstFrameSignal.hasReceivedFrame {
+            // Emitted from the frame queue to confirm the source actually
+            // started delivering frames — the "captureStarted but no
+            // firstFrame" distinction issue #4350 needs.
+            let marker = CaptureStartupMarker.line(
+                .firstFrame(windowID: windowID, width: width, height: height)
+            )
+            diagnosticSink("\(marker)\n")
+        }
+        firstFrameSignal.markReceivedFrame()
     }
 
     // MARK: - SCStreamDelegate
 
     func stream(_ stream: SCStream, didStopWithError error: Error) {
+        handleFatalStop(error: error)
+    }
+
+    /// Routes a stream stop to the fatal-error handler. Split out from the
+    /// delegate callback so tests can drive it without a real `SCStream`.
+    func handleFatalStop(error: Error) {
         onFatalError(error)
     }
 
     // MARK: - Internals
 
     private func reconfigure(width: Int, height: Int) {
+        // Fire-and-forget: if the update fails we keep using the old config and
+        // either resync on the next size change or stop with a delegate error.
+        Task {
+            await performReconfiguration(width: width, height: height)
+        }
+    }
+
+    /// Applies a new capture size to the live stream. Split out from
+    /// `reconfigure`'s detached task so tests can `await` it deterministically
+    /// and assert both the success path and the swallowed-failure warning.
+    func performReconfiguration(width: Int, height: Int) async {
         guard let stream = stream else { return }
         configuredPixelWidth = width
         configuredPixelHeight = height
@@ -120,16 +193,10 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
         updated.sampleRate = 8_000
         updated.channelCount = 1
 
-        // Fire-and-forget: if the update fails we keep using the old config and
-        // either resync on the next size change or stop with a delegate error.
-        Task {
-            do {
-                try await stream.updateConfiguration(updated)
-            } catch {
-                FileHandle.standardError.write(
-                    Data("warn: failed to update stream configuration: \(error)\n".utf8)
-                )
-            }
+        do {
+            try await stream.updateConfiguration(updated)
+        } catch {
+            diagnosticSink("warn: failed to update stream configuration: \(error)\n")
         }
     }
 

--- a/ios/screen-capture/Tests/ScreenCaptureHelperTests/SimulatorCaptureSessionTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureHelperTests/SimulatorCaptureSessionTests.swift
@@ -1,0 +1,244 @@
+import CoreMedia
+import CoreVideo
+import Foundation
+import ScreenCaptureKit
+import XCTest
+@testable import ScreenCaptureCore
+@testable import ScreenCaptureHelper
+
+/// Deterministic coverage for `SimulatorCaptureSession`'s lifecycle paths.
+///
+/// These tests drive the session through its injected `CaptureStream` seam and
+/// diagnostic sink, so none of them require a real Simulator window, a live
+/// `SCStream`, or Screen Recording permission (issue #4771). They exercise the
+/// four behaviors called out on the issue: start/stop wiring, fatal-error
+/// handling, reconfigure success/failure, and once-only first-frame signalling.
+final class SimulatorCaptureSessionTests: XCTestCase {
+
+    // MARK: - Test doubles
+
+    /// In-memory `FrameSink` so a real `FrameWriter` can back the session.
+    private final class MemorySink: FrameSink {
+        private(set) var writes: [Data] = []
+        func write(_ data: Data) { writes.append(data) }
+    }
+
+    /// Records diagnostic lines the session would otherwise send to stderr.
+    private final class DiagnosticRecorder {
+        private(set) var lines: [String] = []
+        func record(_ line: String) { lines.append(line) }
+    }
+
+    /// Fake `CaptureStream` that records calls and can be told to fail specific
+    /// operations, standing in for a real `SCStream`.
+    private final class FakeCaptureStream: CaptureStream {
+        private(set) var addedScreenOutput = false
+        private(set) var addedAudioOutput = false
+        private(set) var startCaptureCallCount = 0
+        private(set) var stopCaptureCallCount = 0
+        private(set) var removedScreenOutput = false
+        private(set) var updatedConfigurations: [SCStreamConfiguration] = []
+
+        var startCaptureError: Error?
+        var updateConfigurationError: Error?
+
+        func addStreamOutput(
+            _ output: SCStreamOutput,
+            type: SCStreamOutputType,
+            sampleHandlerQueue: DispatchQueue?
+        ) throws {
+            if type == .screen { addedScreenOutput = true }
+            if type == .audio { addedAudioOutput = true }
+        }
+
+        func removeStreamOutput(_ output: SCStreamOutput, type: SCStreamOutputType) throws {
+            if type == .screen { removedScreenOutput = true }
+        }
+
+        func startCapture() async throws {
+            startCaptureCallCount += 1
+            if let error = startCaptureError { throw error }
+        }
+
+        func stopCapture() async throws {
+            stopCaptureCallCount += 1
+        }
+
+        func updateConfiguration(_ configuration: SCStreamConfiguration) async throws {
+            updatedConfigurations.append(configuration)
+            if let error = updateConfigurationError { throw error }
+        }
+    }
+
+    private struct StubError: Error, Equatable {
+        let id: Int
+    }
+
+    private func makeSession(
+        diagnostics: DiagnosticRecorder,
+        onFatalError: @escaping (Error) -> Void = { _ in }
+    ) -> SimulatorCaptureSession {
+        let writer = FrameWriter(sink: MemorySink())
+        return SimulatorCaptureSession(
+            writer: writer,
+            diagnosticSink: { diagnostics.record($0) },
+            onFatalError: onFatalError
+        )
+    }
+
+    // MARK: - Start / stop wiring
+
+    func testBeginCaptureAddsScreenOutputStartsAndStoresStream() async throws {
+        let diagnostics = DiagnosticRecorder()
+        let session = makeSession(diagnostics: diagnostics)
+        let fake = FakeCaptureStream()
+
+        try await session.beginCapture(with: fake, audio: false)
+
+        XCTAssertTrue(fake.addedScreenOutput)
+        XCTAssertFalse(fake.addedAudioOutput)
+        XCTAssertEqual(fake.startCaptureCallCount, 1)
+        XCTAssertTrue(session.stream === fake)
+    }
+
+    func testBeginCaptureAddsAudioOutputWhenEnabled() async throws {
+        let diagnostics = DiagnosticRecorder()
+        let session = makeSession(diagnostics: diagnostics)
+        let fake = FakeCaptureStream()
+
+        try await session.beginCapture(with: fake, audio: true)
+
+        XCTAssertTrue(fake.addedScreenOutput)
+        XCTAssertTrue(fake.addedAudioOutput)
+    }
+
+    func testBeginCapturePropagatesStartFailureAndLeavesStreamUnset() async {
+        let diagnostics = DiagnosticRecorder()
+        let session = makeSession(diagnostics: diagnostics)
+        let fake = FakeCaptureStream()
+        fake.startCaptureError = StubError(id: 7)
+
+        do {
+            try await session.beginCapture(with: fake, audio: false)
+            XCTFail("beginCapture should rethrow the startCapture failure")
+        } catch let error as StubError {
+            XCTAssertEqual(error, StubError(id: 7))
+        } catch {
+            XCTFail("unexpected error type: \(error)")
+        }
+
+        // A stream that never started must not be retained as the live stream.
+        XCTAssertNil(session.stream)
+    }
+
+    func testStopRemovesScreenOutputStopsAndClearsStream() async {
+        let diagnostics = DiagnosticRecorder()
+        let session = makeSession(diagnostics: diagnostics)
+        let fake = FakeCaptureStream()
+        session.stream = fake
+
+        await session.stop()
+
+        XCTAssertTrue(fake.removedScreenOutput)
+        XCTAssertEqual(fake.stopCaptureCallCount, 1)
+        XCTAssertNil(session.stream)
+    }
+
+    func testStopWithoutStreamIsNoop() async {
+        let diagnostics = DiagnosticRecorder()
+        let session = makeSession(diagnostics: diagnostics)
+
+        await session.stop()
+
+        XCTAssertNil(session.stream)
+    }
+
+    // MARK: - Fatal-error handling
+
+    func testFatalStopInvokesHandlerWithError() {
+        let diagnostics = DiagnosticRecorder()
+        var captured: Error?
+        let session = makeSession(diagnostics: diagnostics) { captured = $0 }
+
+        session.handleFatalStop(error: StubError(id: 42))
+
+        XCTAssertEqual(captured as? StubError, StubError(id: 42))
+    }
+
+    // MARK: - First-frame signalling + marker emission
+
+    func testFirstFrameEmitsMarkerOnceThenSuppresses() {
+        let diagnostics = DiagnosticRecorder()
+        let session = makeSession(diagnostics: diagnostics)
+        session.windowID = 91
+
+        XCTAssertFalse(session.firstFrameSignal.hasReceivedFrame)
+
+        session.noteFrameWritten(width: 804, height: 1748)
+        session.noteFrameWritten(width: 804, height: 1748)
+        session.noteFrameWritten(width: 402, height: 874)
+
+        XCTAssertTrue(session.firstFrameSignal.hasReceivedFrame)
+        XCTAssertEqual(diagnostics.lines, ["capture-phase: first-frame id=91 size=804x1748\n"])
+    }
+
+    // MARK: - Reconfigure success / failure
+
+    func testReconfigureSuccessUpdatesDimensionsAndPushesConfig() async {
+        let diagnostics = DiagnosticRecorder()
+        let session = makeSession(diagnostics: diagnostics)
+        let fake = FakeCaptureStream()
+        session.stream = fake
+        session.fps = 30
+        session.audioEnabled = true
+
+        await session.performReconfiguration(width: 900, height: 1900)
+
+        XCTAssertEqual(session.configuredPixelWidth, 900)
+        XCTAssertEqual(session.configuredPixelHeight, 1900)
+        XCTAssertEqual(fake.updatedConfigurations.count, 1)
+        let pushed = fake.updatedConfigurations.first
+        XCTAssertEqual(pushed?.width, 900)
+        XCTAssertEqual(pushed?.height, 1900)
+        XCTAssertEqual(pushed?.capturesAudio, true)
+        XCTAssertTrue(diagnostics.lines.isEmpty)
+    }
+
+    func testReconfigureFailureIsSwallowedWithWarningButDimensionsStick() async {
+        let diagnostics = DiagnosticRecorder()
+        let session = makeSession(diagnostics: diagnostics)
+        let fake = FakeCaptureStream()
+        fake.updateConfigurationError = StubError(id: 1)
+        session.stream = fake
+
+        await session.performReconfiguration(width: 640, height: 480)
+
+        // The new dimensions are recorded before the update is attempted, so a
+        // failed update does not resurrect the stale size.
+        XCTAssertEqual(session.configuredPixelWidth, 640)
+        XCTAssertEqual(session.configuredPixelHeight, 480)
+        XCTAssertEqual(diagnostics.lines.count, 1)
+        let warning = diagnostics.lines.first ?? ""
+        XCTAssertTrue(
+            warning.hasPrefix("warn: failed to update stream configuration:"),
+            "unexpected diagnostic line: \(warning)"
+        )
+    }
+
+    func testReconfigureWithoutStreamIsNoop() async {
+        let diagnostics = DiagnosticRecorder()
+        let session = makeSession(diagnostics: diagnostics)
+
+        await session.performReconfiguration(width: 100, height: 200)
+
+        // No stream means nothing to update and no dimension bookkeeping.
+        XCTAssertEqual(session.configuredPixelWidth, 0)
+        XCTAssertEqual(session.configuredPixelHeight, 0)
+        XCTAssertTrue(diagnostics.lines.isEmpty)
+    }
+
+    // NOTE: A bounded `startCapture()` timeout is not present on this branch
+    // (tracked separately as the #4350 hardening work). When it lands, add a
+    // case here that injects a `startCapture()` which never returns and asserts
+    // the session times out — the `CaptureStream` seam already supports it.
+}


### PR DESCRIPTION
Closes [#4771](https://github.com/kaeawc/auto-mobile/issues/4771)

## Summary

Adds the first deterministic Swift unit coverage for the `ScreenCaptureHelper`
session lifecycle. Previously only `ScreenCaptureCoreTests` (pure types) existed,
so every change to `SimulatorCaptureSession`'s start/stop/reconfigure/fatal paths
shipped unverified on the Swift side — exactly the [#4350](https://github.com/kaeawc/auto-mobile/issues/4350)
failure class.

### Seam

`SimulatorCaptureSession` drove a concrete `SCStream` directly, which cannot be
constructed in a test without a real Simulator window and Screen Recording
permission. This PR introduces a narrow `CaptureStream` protocol wrapping exactly
the operations the session uses (`addStreamOutput`, `removeStreamOutput`,
`startCapture`, `stopCapture`, `updateConfiguration`). `SCStream` conforms via a
zero-cost extension because the signatures match, so production behavior is
unchanged.

- The stream is now built through an injected `StreamFactory` (default wires the
  real `SCStream`), and a `diagnosticSink` closure captures the stderr diagnostic
  lines (default preserves the stderr write).
- The lifecycle branches were split into small, directly-drivable methods
  (`beginCapture`, `handleFatalStop`, `noteFrameWritten`, `performReconfiguration`)
  **without changing their logic**, keeping the seam out of the way of sibling
  PR [#4764](https://github.com/kaeawc/auto-mobile/pull/4764)'s start/watchdog
  rework and minimizing conflict surface.

### Tests

New `ScreenCaptureHelperTests` target (wired into `Package.swift`; runs via the
existing package-level `swift test` in `scripts/ios/swift-test.sh`, so no script
edit is needed) with 10 tests covering:

- **Start/stop wiring** — screen-only vs audio outputs, start-failure propagation
  leaving `stream` unset, stop removing the screen output + stopping + clearing.
- **Fatal-error handling** — `handleFatalStop` forwards the error to `onFatalError`.
- **First-frame signalling** — marker emitted exactly once with the correct
  `capture-phase: first-frame …` line, suppressed on subsequent frames.
- **Reconfigure** — success pushes an updated config with the new dimensions;
  failure is swallowed with a `warn:` diagnostic while the new dimensions stick;
  no-stream is a no-op.

A bounded `startCapture()` timeout is not present on this branch (it is part of
the separate #4350 hardening); a `NOTE` documents where to add that case once it
lands — the seam already supports it.

## Validation

- `./scripts/ios/swift-build.sh` — all packages built successfully.
- `./scripts/ios/swift-test.sh` — screen-capture passes; 10 new tests execute
  (`SimulatorCaptureSessionTests`, ~0.006s), full suite green.
- SwiftLint `--strict` clean on both changed files (force_unwrapping is an error;
  no force-unwraps introduced).
- Minimal diff; no SwiftFormat reformatting.
