### PR TITLE
fix(ios): prevent zombie ffmpeg/helper processes in capture teardown

### DIFF
--- a/src/features/screen-stream/IOSScreenCaptureHelper.ts
+++ b/src/features/screen-stream/IOSScreenCaptureHelper.ts
@@ -247,12 +247,22 @@ export class IOSScreenCaptureHelper extends EventEmitter {
       `[IOSScreenCaptureHelper] helper pid=${proc.pid ?? "?"} did not exit after SIGTERM; escalating to SIGKILL`
     );
     proc.kill("SIGKILL");
-    if (process.platform === "darwin" && proc.pid !== undefined) {
-      try {
-        this.processGroupKiller(proc.pid, "SIGKILL");
-      } catch (error) {
-        logger.debug(
-          `[IOSScreenCaptureHelper] process-group cleanup failed for pid=${proc.pid}: ${error}`
+    if (process.platform === "darwin") {
+      if (proc.pid !== undefined) {
+        try {
+          this.processGroupKiller(proc.pid, "SIGKILL");
+        } catch (error) {
+          // A surviving process group can leak detached ScreenCaptureKit XPC
+          // children, so surface the failure rather than swallowing it at debug.
+          logger.warn(
+            `[IOSScreenCaptureHelper] process-group cleanup failed for pid=${proc.pid}; detached children may leak: ${error}`
+          );
+        }
+      } else {
+        // Without a pid the detached process group cannot be targeted; the
+        // direct SIGKILL above is the only cleanup, so flag the potential leak.
+        logger.warn(
+          "[IOSScreenCaptureHelper] helper pid unknown after SIGKILL; cannot group-kill, detached children may leak"
         );
       }
     }

--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -66,6 +66,16 @@ const IOS_KEYFRAME_INTERVAL_SECONDS = 2;
  * `ANDROID_FORCED_KEYFRAME_MIN_INTERVAL_MS`.
  */
 export const IOS_FORCED_KEYFRAME_MIN_INTERVAL_MS = 3000;
+/**
+ * Grace window granted to an outgoing ffmpeg encoder to honour SIGTERM after a
+ * keyframe restart before it is escalated to SIGKILL. A slow or signal-ignoring
+ * `h264_videotoolbox` process left un-reaped lingers as a zombie holding the
+ * (scarce on hosted runners) hardware encoder, so the restart is not considered
+ * complete until the old encoder has exited or been force-killed. Mirrors the
+ * capture helper's SIGTERM→grace→SIGKILL discipline
+ * ({@link IOS_HELPER_STOP_GRACE_MS}).
+ */
+export const IOS_ENCODER_RESTART_GRACE_MS = 2_000;
 /** H.264 macroblock edge, in pixels. */
 const H264_MACROBLOCK_SIZE = 16;
 /** Smallest dimension ffmpeg can encode as 4:2:0 chroma-subsampled video. */
@@ -389,9 +399,48 @@ export class IosH264Source implements H264CaptureSource {
       this.writeFrameToEncoder(this.lastHelperFrame);
       this.writeFrameToEncoder(this.lastHelperFrame);
     }
-    oldEncoder.stdin.end();
-    oldEncoder.kill("SIGTERM");
+    // Reap the outgoing encoder on a bounded grace, escalating to SIGKILL, so a
+    // slow or signal-ignoring h264_videotoolbox cannot linger as a zombie
+    // holding the hardware encoder. Fire-and-forget: the replacement is already
+    // live and every old-encoder handler is guarded by `this.encoder === encoder`.
+    void this.reapOutgoingEncoder(oldEncoder);
     return true;
+  }
+
+  /**
+   * End the outgoing encoder's stdin, SIGTERM it, and await its exit within
+   * {@link IOS_ENCODER_RESTART_GRACE_MS}; if it has not exited by then, escalate
+   * to SIGKILL. Mirrors {@link IOSScreenCaptureHelper}'s shutdown discipline.
+   */
+  private async reapOutgoingEncoder(encoder: IosH264EncoderProcess): Promise<void> {
+    let exited = false;
+    const exitPromise = new Promise<void>(resolve => {
+      encoder.once("exit", () => {
+        exited = true;
+        resolve();
+      });
+    });
+    encoder.stdin.end();
+    encoder.kill("SIGTERM");
+
+    let timeout: NodeJS.Timeout | undefined;
+    const timedOut = new Promise<void>(resolve => {
+      timeout = this.timer.setTimeout(resolve, IOS_ENCODER_RESTART_GRACE_MS);
+    });
+    try {
+      await Promise.race([exitPromise, timedOut]);
+    } finally {
+      if (timeout) {
+        this.timer.clearTimeout(timeout);
+      }
+    }
+
+    if (!exited) {
+      logger.warn(
+        `[IosH264Source] outgoing ffmpeg encoder did not exit within ${IOS_ENCODER_RESTART_GRACE_MS}ms after SIGTERM; escalating to SIGKILL`
+      );
+      encoder.kill("SIGKILL");
+    }
   }
 
   private async resolveCaptureTarget(helperPath: string): Promise<CaptureTarget> {

--- a/test/features/screen-stream/IOSScreenCaptureHelper.test.ts
+++ b/test/features/screen-stream/IOSScreenCaptureHelper.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { FakeChildProcess } from "../../fakes/FakeChildProcess";
 import { FakeTimer } from "../../fakes/FakeTimer";
+import { logger } from "../../../src/utils/logger";
 import {
   encodeFrameHeader,
   IOS_HELPER_STOP_GRACE_MS,
@@ -362,6 +363,43 @@ describe("IOSScreenCaptureHelper", () => {
       expect(processGroupSignals).toEqual([]);
     }
   });
+
+  test.skipIf(process.platform !== "darwin")(
+    "logs at warn when process-group cleanup fails so a detached-child leak is visible",
+    async () => {
+      const timer = new FakeTimer();
+      const fake = new FakeChildProcess();
+      fake.kill = signal => {
+        // Ignore SIGTERM so stop() escalates to SIGKILL + process-group kill.
+        void signal;
+        fake.killed = true;
+        return true;
+      };
+      const helper = new IOSScreenCaptureHelper({
+        binaryPath: "/fake/screen-capture-helper",
+        target: { kind: "simulator", windowID: 1 },
+        spawner: () => fake as unknown as ChildProcessWithoutNullStreams,
+        timer,
+        processGroupKiller: () => {
+          throw new Error("kill: no such process group");
+        },
+      });
+      helper.start();
+      const warning = spyOn(logger, "warn").mockImplementation(() => {});
+
+      try {
+        const stopped = helper.stop();
+        timer.advanceTime(IOS_HELPER_STOP_GRACE_MS);
+        await stopped;
+
+        expect(warning).toHaveBeenCalledWith(
+          expect.stringContaining(`process-group cleanup failed for pid=${fake.pid}`)
+        );
+      } finally {
+        warning.mockRestore();
+      }
+    }
+  );
 
   test("bounds a concurrent stop after SIGTERM instead of awaiting exit forever", async () => {
     const timer = new FakeTimer();

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -12,6 +12,7 @@ import {
   IOS_WEBRTC_FFMPEG_ENV_ALIAS,
   IOS_WEBRTC_DEFAULT_BITS_PER_PIXEL,
   IOS_FORCED_KEYFRAME_MIN_INTERVAL_MS,
+  IOS_ENCODER_RESTART_GRACE_MS,
   IOS_SIMULATOR_TARGET_RESOLUTION_TIMEOUT_MS,
   IosH264Source,
   defaultIosBitrateBps,
@@ -1379,6 +1380,68 @@ describe("IosH264Source", () => {
     expect(chunks).toContainEqual(Buffer.from([0, 0, 0, 1, 0x65]));
     // The deliberate restart must not surface as a source failure.
     expect(errors).toEqual([]);
+  });
+
+  test("escalates the outgoing encoder to SIGKILL when it ignores SIGTERM within the grace window", async () => {
+    const timer = new FakeTimer();
+    const { source, helper, encoders } = createRestartHarness({ timer }, encoder => {
+      // A slow / signal-ignoring h264_videotoolbox never emits "exit" on SIGTERM.
+      const signals: NodeJS.Signals[] = [];
+      (encoder as unknown as { killSignals: NodeJS.Signals[] }).killSignals = signals;
+      encoder.kill = (signal?: NodeJS.Signals | number): boolean => {
+        signals.push((typeof signal === "number" ? "SIGTERM" : signal ?? "SIGTERM") as NodeJS.Signals);
+        encoder.killed = true;
+        return true;
+      };
+    });
+
+    await startWithFrame(source, helper, frame(2, 2, 0x11));
+    emitIdr(encoders[0]);
+    await flush();
+
+    expect(source.requestKeyFrame()).toBe(true);
+    const oldSignals = (encoders[0] as unknown as { killSignals: NodeJS.Signals[] }).killSignals;
+
+    // The restart SIGTERMs the outgoing encoder but must not force-kill it until
+    // the bounded grace window elapses without an exit.
+    expect(oldSignals).toEqual(["SIGTERM"]);
+
+    timer.advanceTime(IOS_ENCODER_RESTART_GRACE_MS);
+    await flush();
+
+    // A zombie that ignored SIGTERM past the grace window is escalated to SIGKILL
+    // so it cannot linger holding the hardware encoder.
+    expect(oldSignals).toEqual(["SIGTERM", "SIGKILL"]);
+  });
+
+  test("does not force-kill the outgoing encoder that exits within the grace window", async () => {
+    const timer = new FakeTimer();
+    const { source, helper, encoders } = createRestartHarness({ timer }, encoder => {
+      const signals: NodeJS.Signals[] = [];
+      (encoder as unknown as { killSignals: NodeJS.Signals[] }).killSignals = signals;
+      encoder.kill = (signal?: NodeJS.Signals | number): boolean => {
+        const name = (typeof signal === "number" ? "SIGTERM" : signal ?? "SIGTERM") as NodeJS.Signals;
+        signals.push(name);
+        encoder.killed = true;
+        if (name === "SIGTERM") {
+          // Honour SIGTERM promptly: exit before the grace window elapses.
+          encoder.emit("exit", null, "SIGTERM");
+        }
+        return true;
+      };
+    });
+
+    await startWithFrame(source, helper, frame(2, 2, 0x11));
+    emitIdr(encoders[0]);
+    await flush();
+
+    expect(source.requestKeyFrame()).toBe(true);
+    await flush();
+    timer.advanceTime(IOS_ENCODER_RESTART_GRACE_MS);
+    await flush();
+
+    const oldSignals = (encoders[0] as unknown as { killSignals: NodeJS.Signals[] }).killSignals;
+    expect(oldSignals).toEqual(["SIGTERM"]);
   });
 
   test("requestKeyFrame throttles a burst of PLIs to at most one restart per interval", async () => {


### PR DESCRIPTION
Closes [#4770](https://github.com/kaeawc/auto-mobile/issues/4770)

## Summary

Two process-lifecycle paths in the iOS capture pipeline could leak child
processes. This closes both.

### Problem 1 — encoder restart could orphan the old ffmpeg

`requestKeyFrame` (`src/features/webrtc/IosH264Source.ts`) spawned the
replacement encoder and then merely `stdin.end()` + `SIGTERM`-ed the outgoing
one, with no exit-await or SIGKILL escalation. A slow or signal-ignoring
`h264_videotoolbox` could linger as a zombie holding the (scarce on hosted
runners) hardware encoder.

Now the outgoing encoder is reaped through a new `reapOutgoingEncoder` helper
that mirrors `IOSScreenCaptureHelper`'s SIGTERM→grace→SIGKILL discipline: end
stdin, SIGTERM, await exit within a bounded grace
(`IOS_ENCODER_RESTART_GRACE_MS` = 2000ms), and escalate to SIGKILL (logged at
`warn`) if it does not exit. The reap is fire-and-forget so `requestKeyFrame`
stays synchronous; correctness of the live stream continues to rest on the
existing `this.encoder === encoder` handler guards.

### Problem 2 — helper process-group cleanup was best-effort and pid-gated

`IOSScreenCaptureHelper.stop()`
(`src/features/screen-stream/IOSScreenCaptureHelper.ts`) group-killed only when
`proc.pid !== undefined` and only `debug`-logged group-kill failures, so a leak
of detached ScreenCaptureKit children was invisible.

The group-kill failure log is raised to `warn`, and a new `warn` is emitted when
the pid is unknown (so the group cannot be targeted at all) — both call out that
detached children may leak.

## Acceptance criteria

- [x] A test proves the old encoder is escalated to SIGKILL if it does not exit
  within the grace window after a keyframe restart
  (`escalates the outgoing encoder to SIGKILL when it ignores SIGTERM within the
  grace window`), plus a companion test that it is *not* force-killed when it
  exits in time.
- [x] Group-kill failures are logged at `warn` (`logs at warn when process-group
  cleanup fails so a detached-child leak is visible`, darwin-gated).

## Validation

- `bun run typecheck` — no new type errors (198 known in baseline)
- `bun test` on both affected suites — 102 pass, 0 fail
- `turbo run lint build test`
