### PR TITLE
fix(ios): bound Simulator startCapture() and arm the no-frames watchdog before it

### DIFF
--- a/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
@@ -51,6 +51,14 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
     var audioEnabled = false
     var windowID: UInt32 = 0
 
+    /// Upper bound on `stream.startCapture()`. ScreenCaptureKit cold-start on
+    /// hosted `macos26` runners is slow-but-finite (measured 2.6–13s); this
+    /// deadline sits above that healthy window yet below the parent supervisor's
+    /// 15s first-frame SIGTERM (`IOS_FIRST_FRAME_TIMEOUT_MS`), so a genuinely
+    /// hung start is surfaced as a specific `error:` line rather than silent
+    /// frame starvation. See issues #4350 / #4764.
+    static let startCaptureDeadlineSeconds: TimeInterval = 14.0
+
     init(
         writer: FrameWriter,
         makeStream: @escaping StreamFactory = { filter, config, delegate in
@@ -88,8 +96,40 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
         if audio {
             try stream.addStreamOutput(self, type: .audio, sampleHandlerQueue: queue)
         }
-        try await stream.startCapture()
+        try await SimulatorCaptureSession.startCapture(stream)
         self.stream = stream
+    }
+
+    /// Races `stream.startCapture()` against `startCaptureDeadlineSeconds`.
+    ///
+    /// A hung `startCapture()` does not honor Swift task cancellation, so a
+    /// structured `withThrowingTaskGroup` would block on teardown awaiting the
+    /// very task we are trying to abandon. Instead the two arms run as
+    /// unstructured tasks and the first to finish wins; on timeout the stalled
+    /// capture task is left to be reaped by process exit, which the parent
+    /// triggers immediately after seeing the `error:` diagnostic.
+    private static func startCapture(_ stream: CaptureStream) async throws {
+        let race = StartRaceState()
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            let capture = Task {
+                do {
+                    try await stream.startCapture()
+                    if race.finish() { continuation.resume() }
+                } catch {
+                    if race.finish() { continuation.resume(throwing: error) }
+                }
+            }
+            Task {
+                let deadlineNanos = UInt64(startCaptureDeadlineSeconds * 1_000_000_000)
+                try? await Task.sleep(nanoseconds: deadlineNanos)
+                if race.finish() {
+                    capture.cancel()
+                    continuation.resume(
+                        throwing: StartCaptureTimeoutError(deadlineSeconds: startCaptureDeadlineSeconds)
+                    )
+                }
+            }
+        }
     }
 
     func stop() async {
@@ -229,6 +269,36 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
             return nil
         }
         return status
+    }
+}
+
+/// Thrown when `SimulatorCaptureSession` gives up waiting on `startCapture()`.
+/// Conforms to `CustomStringConvertible` so `main.swift`'s `error:` line names
+/// the stalled startup stage (`starting-capture` seen, `capture-started`
+/// absent), letting the parent supervisor fail fast with a specific cause
+/// instead of frame starvation. See issues #4350 / #4764.
+struct StartCaptureTimeoutError: Error, CustomStringConvertible {
+    let deadlineSeconds: TimeInterval
+
+    var description: String {
+        "startCapture() exceeded \(deadlineSeconds)s deadline "
+            + "(stage: starting-capture seen, capture-started absent)"
+    }
+}
+
+/// Single-winner guard for the `startCapture()` deadline race. `finish()`
+/// returns `true` exactly once, so the checked continuation is resumed by
+/// whichever arm — capture or timeout — completes first.
+final class StartRaceState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var finished = false
+
+    func finish() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if finished { return false }
+        finished = true
+        return true
     }
 }
 

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
@@ -189,9 +189,31 @@ case .captureSimulator(let windowID, let fps, let audio):
     }
     let firstFrameSignal = simSession.firstFrameSignal
 
+    // ScreenCaptureKit silently emits no frames when the host process lacks
+    // Screen Recording permission — there's no error to surface. Emit a hint on
+    // stderr if nothing arrives within the deadline; this leaves stdout (the
+    // frame channel) untouched. The timer lives on a dedicated queue — never the
+    // main run loop — so a main-actor-blocked start cannot starve it (issue
+    // #4764). It is *armed* only once capture has started so the measured
+    // 2.6–13s slow-start window cannot trip a false "no frames" warning; a start
+    // that never reaches capture-started is bounded and surfaced by the start
+    // deadline inside SimulatorCaptureSession instead.
+    let permissionHintQueue = DispatchQueue(label: "automobile.simulator-capture.permission-hint")
+    let permissionHintTimer = DispatchSource.makeTimerSource(queue: permissionHintQueue)
+    permissionHintTimer.setEventHandler {
+        if !firstFrameSignal.hasReceivedFrame {
+            logError(
+                "warn: no frames received within \(simulatorPermissionTimeoutSeconds)s. "
+                + "Grant 'Screen Recording' to your terminal/IDE in "
+                + "System Settings → Privacy & Security → Screen Recording."
+            )
+        }
+    }
+
     logError(CaptureStartupMarker.line(.startingCapture(windowID: windowID, fps: fps)))
     installShutdownHandlers {
         metricsReporter.stop()
+        permissionHintTimer.cancel()
         Task { @MainActor in
             await simSession.stop()
             exit(0)
@@ -202,19 +224,10 @@ case .captureSimulator(let windowID, let fps, let audio):
             try await simSession.start(window: window, fps: fps, audio: audio)
             logError(CaptureStartupMarker.line(.captureStarted(windowID: windowID)))
 
-            // ScreenCaptureKit silently emits no frames when the host process
-            // lacks Screen Recording permission — there's no error to surface.
-            // Emit a hint on stderr if nothing arrives within the deadline; this
-            // leaves stdout (the frame channel) untouched.
-            _ = Timer.scheduledTimer(withTimeInterval: simulatorPermissionTimeoutSeconds, repeats: false) { _ in
-                if !firstFrameSignal.hasReceivedFrame {
-                    logError(
-                        "warn: no frames received within \(simulatorPermissionTimeoutSeconds)s. "
-                        + "Grant 'Screen Recording' to your terminal/IDE in "
-                        + "System Settings → Privacy & Security → Screen Recording."
-                    )
-                }
-            }
+            // Measure the no-frames window from capture-started, not from launch,
+            // so the slow-start tail never counts against it.
+            permissionHintTimer.schedule(deadline: .now() + simulatorPermissionTimeoutSeconds)
+            permissionHintTimer.resume()
         } catch {
             logError("error: failed to start simulator capture: \(error)")
             exit(1)


### PR DESCRIPTION
Closes [#4764](https://github.com/kaeawc/auto-mobile/issues/4764)

## Summary

Localized root-cause fix for the intermittent no-H.264-frames flake in [#4350](https://github.com/kaeawc/auto-mobile/issues/4350), where the iOS Simulator capture helper could hang inside `SCStream.startCapture()` with no timeout and no diagnostic until the parent's 15s SIGTERM.

Two changes, both in `ios/screen-capture/Sources/ScreenCaptureHelper/`:

1. **Bound `startCapture()` with a deadline** (`SimulatorCaptureSession.swift`). `start()` now races `stream.startCapture()` against a 14s deadline. On timeout it throws a `StartCaptureTimeoutError` whose `description` names the stalled stage (`starting-capture` seen, `capture-started` absent). `main.swift` logs that as an `error:`-prefixed stderr line, which the parent supervisor (`IosH264Source.isHelperError`) treats as a fatal helper error, so the parent fails fast with a specific cause instead of frame starvation.
   - The race uses two unstructured tasks guarded by a single-winner `StartRaceState` rather than `withThrowingTaskGroup`. A hung `startCapture()` is a system call that does not honor Swift task cancellation, so a structured group would block on teardown awaiting the very task we want to abandon. The deadline runs off the generic executor, so a main-actor-blocked start cannot starve it, and the losing capture arm is left to be reaped by the process exit that follows the diagnostic.
   - `14.0s` sits above the measured 2.6-13s healthy slow-start window yet below the parent's 15s `IOS_FIRST_FRAME_TIMEOUT_MS` SIGTERM.

2. **Arm the no-frames / permission-hint watchdog off the main run loop** (`main.swift`). Replaced the `Timer.scheduledTimer` (main run loop, and previously created only *after* `start()` returned, so a hung start never created it) with a `DispatchSourceTimer` on a dedicated background queue that a blocked main-actor start cannot starve. It is *armed* (scheduled + resumed) only after `capture-started`, measuring its window from that point, so the healthy slow-start tail cannot trip a false "no frames" warning. The hung-start case is now bounded and diagnosed by (1) instead.

### Acceptance criteria

- A hung `startCapture()` now produces a distinct, greppable `error:`-prefixed stderr diagnostic within ~14s (before the parent's 15s SIGTERM) rather than hanging silently.
- A diagnostic always fires when `start()` would otherwise never return: the deadline bounds `start()` so it always resolves (throwing the specific error); the no-frames hint fires on a starvation-proof queue for the started-but-silent case.
- Healthy path unchanged: no premature timeout within the measured 2.6-13s slow-start window, and the no-frames hint is still measured from `capture-started`.

Kept focused on the start-deadline + watchdog-ordering logic per the note about sibling PR #4771's test seam on `SimulatorCaptureSession`.

## Validation

Run locally in this worktree (Swift toolchain available):

- `./scripts/ios/swift-build.sh` - build complete, no warnings.
- `./scripts/ios/swift-test.sh` - all packages pass (screen-capture: 44 tests, 0 failures).
- `swiftlint lint` - clean on both changed files (no new `force_unwrapping`; none added).

## Shipping note

This change lives in the prebuilt, checksum-pinned screen-capture helper. It requires a **helper re-cut** (rebuild + re-checksum) to reach released clients. This PR does not attempt the re-cut.
