### PR TITLE
perf(android-video): decouple encode loop from transport via drop-oldest handoff

### DIFF
--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/FrameHandoff.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/FrameHandoff.kt
@@ -1,0 +1,116 @@
+package dev.jasonpearson.automobile.video
+
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+/** One encoded H.264 access unit copied out of the MediaCodec output buffer. */
+class EncodedVideoFrame(val ptsAndFlags: Long, val data: ByteArray) {
+  /** SPS/PPS codec configuration (bit 63). */
+  val isConfig: Boolean
+    get() = (ptsAndFlags and VideoStreamProtocol.PACKET_FLAG_CONFIG) != 0L
+
+  /** IDR / sync frame (bit 62). */
+  val isKeyFrame: Boolean
+    get() = (ptsAndFlags and VideoStreamProtocol.PACKET_FLAG_KEY_FRAME) != 0L
+
+  /**
+   * Config and keyframes are decoder-essential: a delta frame is undecodable without the reference
+   * IDR (and the IDR without its SPS/PPS), so these must not be silently discarded from the live
+   * path.
+   */
+  val isCritical: Boolean
+    get() = isConfig || isKeyFrame
+}
+
+/**
+ * A single-slot, drop-oldest handoff that decouples the MediaCodec encode loop from the transport
+ * writer thread (issue #4749).
+ *
+ * The encode loop must never block on a slow or stalled socket reader. A synchronous `dequeue ->
+ * blocking write -> release` loop lets transport back-pressure the encoder: unreleased output
+ * buffers stall MediaCodec's Surface input, so frames are delayed instead of dropped. This handoff
+ * holds at most one pending packet. A newer delta replaces an unsent older one (latest-frame-wins)
+ * so the reader always advances toward the live edge rather than draining a stale backlog.
+ *
+ * ## Keyframe / config protection
+ *
+ * A slotted config or keyframe is **sticky**: while one occupies the slot every subsequent offer is
+ * dropped until the writer takes it. This guarantees that any decoder-essential packet that reaches
+ * the slot is delivered intact and in order (SPS/PPS before its IDR), and can never be buried by a
+ * later delta that the decoder could not use anyway. Criticals arrive when the slot is idle (config
+ * at startup; IDRs on the 2s GOP boundary or a keyframe request), so stickiness costs nothing in
+ * the steady state. The reconnect cache in [VideoStreamWriter] independently retains SPS/PPS + the
+ * latest IDR for replacement-client replay, so nothing the handoff drops compromises reconnect.
+ *
+ * Pure JVM: no Android framework, no wall-clock or real timers, so the drop policy unit-tests
+ * deterministically.
+ */
+class FrameHandoff {
+  private val lock = ReentrantLock()
+  private val available = lock.newCondition()
+  private var slot: EncodedVideoFrame? = null
+  private var closed = false
+  private var dropped = 0L
+
+  /**
+   * Offer an encoded packet to the writer. Never blocks the caller (the encode loop).
+   *
+   * @return false once the handoff is [close]d (the producer should stop), true otherwise.
+   */
+  fun offer(frame: EncodedVideoFrame): Boolean = lock.withLock {
+    if (closed) {
+      return false
+    }
+    val existing = slot
+    when {
+      existing == null -> slot = frame
+      existing.isCritical -> {
+        // Sticky critical: never overwrite an unsent config/keyframe. Drop the newcomer;
+        // the encoder re-emits an IDR on the next GOP boundary or keyframe request.
+        dropped++
+        return true
+      }
+      else -> {
+        // Slot holds a delta; the newer packet supersedes it (drop-oldest / latest-wins).
+        dropped++
+        slot = frame
+      }
+    }
+    available.signalAll()
+    true
+  }
+
+  /**
+   * Block until a packet is available or the handoff is closed, then remove and return it. Returns
+   * null only when the handoff is closed and drained, signalling the writer thread to exit.
+   */
+  fun take(): EncodedVideoFrame? = lock.withLock {
+    while (slot == null && !closed) {
+      available.await()
+    }
+    val frame = slot
+    slot = null
+    frame
+  }
+
+  /** Non-blocking variant of [take]; returns null when the slot is empty. */
+  fun poll(): EncodedVideoFrame? = lock.withLock {
+    val frame = slot
+    slot = null
+    frame
+  }
+
+  /** Close the handoff, waking any blocked [take] so the writer thread can exit. */
+  fun close() {
+    lock.withLock {
+      closed = true
+      available.signalAll()
+    }
+  }
+
+  /** Total packets discarded by the drop-oldest policy since construction. */
+  fun droppedCount(): Long = lock.withLock { dropped }
+
+  /** The currently-slotted packet without removing it; for tests and diagnostics. */
+  fun peek(): EncodedVideoFrame? = lock.withLock { slot }
+}

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
@@ -59,18 +59,30 @@ class VideoStreamWriter(
   )
 
   private var serverSocket: LocalServerSocket? = null
-  private var clientSocket: LocalSocket? = null
+  // @Volatile: stop() closes this without the lock to unblock a writer thread wedged in a
+  // blocking socket write (the writer holds `lock` for the duration of that write).
+  @Volatile private var clientSocket: LocalSocket? = null
   private var outputStream: OutputStream? = null
   private var commandHandler: ((Int) -> Unit)? = null
   private val lock = Any()
   private val packetCache = VideoPacketCache()
   private val reconnectWindow = ReconnectWindow(nowMs, CLIENT_RECONNECT_WINDOW_MS)
 
+  // Decouple encode from transport (#4749): the encode loop offers to a drop-oldest single-slot
+  // handoff and returns immediately; this dedicated thread drains it into the socket, so a stalled
+  // reader can never back-pressure MediaCodec's Surface input.
+  private val handoff = FrameHandoff()
+  // @Volatile: assigned on the thread that calls start(), read by stop() on the shutdown hook.
+  @Volatile private var writerThread: Thread? = null
+
   @Volatile private var stopped = false
 
   companion object {
     /** Keep capture warm long enough for ADB/daemon local-socket recovery. */
     const val CLIENT_RECONNECT_WINDOW_MS = 5_000L
+
+    /** Upper bound on how long [stop] waits for the transport writer thread to unwind. */
+    const val WRITER_JOIN_TIMEOUT_MS = 200L
 
     /** "h264" as big-endian int: 0x68323634 */
     const val CODEC_ID_H264 = VideoStreamProtocol.CODEC_ID_H264
@@ -101,12 +113,29 @@ class VideoStreamWriter(
     serverSocket = LocalServerSocket(socketName)
     synchronized(lock) { reconnectWindow.start() }
     println("Waiting for client connection on localabstract:$socketName")
+    writerThread =
+      Thread({ drainToTransport() }, "video-transport-writer").apply {
+        isDaemon = true
+        start()
+      }
     Thread(
         { acceptClients(onClientConnected) },
         "video-client-acceptor",
       )
       .apply { isDaemon = true }
       .start()
+  }
+
+  /**
+   * The single consumer of [handoff]: blocks for the next encoded packet and writes it to the
+   * current client. Isolating the blocking transport write on this thread is what keeps a slow or
+   * stalled reader from back-pressuring the encode loop.
+   */
+  private fun drainToTransport() {
+    while (!stopped) {
+      val frame = handoff.take() ?: break
+      synchronized(lock) { writePacketDataLocked(TRACK_ID_VIDEO, frame.ptsAndFlags, frame.data) }
+    }
   }
 
   /**
@@ -187,8 +216,14 @@ class VideoStreamWriter(
   }
 
   /**
-   * Write one encoded video packet. It is cached before writing, allowing a later client to decode
-   * immediately even if this client fails mid-write.
+   * Hand one encoded video packet off to the transport writer. Copies the buffer, caches decoder
+   * state, then offers to the drop-oldest [handoff] — all non-blocking, so the caller may release
+   * the MediaCodec output buffer immediately without waiting on the socket.
+   *
+   * Caching happens here on the producer side, before the handoff can drop anything, so a dropped
+   * live packet never removes SPS/PPS or the latest IDR from the reconnect replay cache.
+   *
+   * @return false once the writer has been [stop]ped, signalling the encode loop to exit.
    */
   fun writePacket(buffer: ByteBuffer, bufferInfo: MediaCodec.BufferInfo): Boolean {
     val data = ByteArray(bufferInfo.size)
@@ -200,10 +235,8 @@ class VideoStreamWriter(
         (bufferInfo.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0,
         (bufferInfo.flags and MediaCodec.BUFFER_FLAG_KEY_FRAME) != 0,
       )
-    synchronized(lock) {
-      packetCache.remember(CachedVideoPacket(ptsAndFlags, data))
-      return writePacketDataLocked(TRACK_ID_VIDEO, ptsAndFlags, data)
-    }
+    synchronized(lock) { packetCache.remember(CachedVideoPacket(ptsAndFlags, data)) }
+    return handoff.offer(EncodedVideoFrame(ptsAndFlags, data))
   }
 
   fun writeAudioPacket(data: ByteArray, ptsUs: Long): Boolean =
@@ -278,6 +311,22 @@ class VideoStreamWriter(
   /** Stop the stream writer and close all sockets. */
   fun stop() {
     stopped = true
+    handoff.close()
+    // Unblock the writer thread if it is wedged in a blocking socket write (it holds `lock` for the
+    // duration, so we must NOT take `lock` here). Closing the socket makes that write throw.
+    try {
+      clientSocket?.close()
+    } catch (_: IOException) {}
+    writerThread?.let {
+      try {
+        // Bounded: the socket close above unblocks a wedged write promptly; the join only lets the
+        // writer thread unwind cleanly and must never hang shutdown.
+        it.join(WRITER_JOIN_TIMEOUT_MS)
+      } catch (_: InterruptedException) {
+        Thread.currentThread().interrupt()
+      }
+    }
+    writerThread = null
     synchronized(lock) {
       closeClientLocked()
     }

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/FrameHandoffTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/FrameHandoffTest.kt
@@ -1,0 +1,154 @@
+package dev.jasonpearson.automobile.video
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pins the encode/transport decoupling contract for issue #4749. The encode loop must never block
+ * on a slow reader, so [FrameHandoff] holds a single slot with a drop-oldest policy: newer deltas
+ * supersede unsent older ones, while decoder-essential config/keyframes are protected. The policy
+ * is pure and deterministic — no real threads, sockets, or timers are exercised here.
+ */
+class FrameHandoffTest {
+  private var pts = 0L
+
+  private fun delta(): EncodedVideoFrame =
+    EncodedVideoFrame(
+      VideoStreamProtocol.ptsAndFlags(pts++, isConfig = false, isKeyFrame = false),
+      byteArrayOf(1),
+    )
+
+  private fun keyFrame(): EncodedVideoFrame =
+    EncodedVideoFrame(
+      VideoStreamProtocol.ptsAndFlags(pts++, isConfig = false, isKeyFrame = true),
+      byteArrayOf(2),
+    )
+
+  private fun config(): EncodedVideoFrame =
+    EncodedVideoFrame(
+      VideoStreamProtocol.ptsAndFlags(pts++, isConfig = true, isKeyFrame = false),
+      byteArrayOf(3),
+    )
+
+  @Test
+  fun singlePacketRoundTrips() {
+    val handoff = FrameHandoff()
+    val frame = delta()
+
+    assertTrue(handoff.offer(frame))
+    assertSame(frame, handoff.take())
+    assertEquals(0L, handoff.droppedCount())
+    assertNull(handoff.poll())
+  }
+
+  @Test
+  fun newerDeltaReplacesUnsentOlderDelta() {
+    val handoff = FrameHandoff()
+    val stale = delta()
+    val fresh = delta()
+
+    handoff.offer(stale)
+    handoff.offer(fresh)
+
+    // Latest-frame-wins: the reader advances toward the live edge, not through a backlog.
+    assertSame(fresh, handoff.peek())
+    assertEquals(1L, handoff.droppedCount())
+    assertSame(fresh, handoff.take())
+  }
+
+  @Test
+  fun deltaNeverEvictsUnsentKeyFrame() {
+    val handoff = FrameHandoff()
+    val idr = keyFrame()
+
+    handoff.offer(idr)
+    handoff.offer(delta())
+    handoff.offer(delta())
+
+    // A delta is undecodable without its reference IDR: the keyframe is sticky, the deltas drop.
+    assertSame(idr, handoff.peek())
+    assertEquals(2L, handoff.droppedCount())
+  }
+
+  @Test
+  fun deltaNeverEvictsUnsentConfig() {
+    val handoff = FrameHandoff()
+    val sps = config()
+
+    handoff.offer(sps)
+    handoff.offer(delta())
+
+    assertSame(sps, handoff.peek())
+    assertEquals(1L, handoff.droppedCount())
+  }
+
+  @Test
+  fun keyFrameEvictsAStaleDelta() {
+    val handoff = FrameHandoff()
+    val stale = delta()
+    val idr = keyFrame()
+
+    handoff.offer(stale)
+    handoff.offer(idr)
+
+    // A keyframe is strictly more useful than an unsent delta: it wins the slot.
+    assertSame(idr, handoff.peek())
+    assertEquals(1L, handoff.droppedCount())
+  }
+
+  @Test
+  fun slottedCriticalIsStickyAgainstLaterCritical() {
+    val handoff = FrameHandoff()
+    val sps = config()
+
+    // Guarantees SPS/PPS reaches the writer before its IDR: a single slot cannot hold both, so the
+    // first-arriving critical is delivered intact and the encoder re-emits the IDR next GOP.
+    handoff.offer(sps)
+    handoff.offer(keyFrame())
+
+    assertSame(sps, handoff.peek())
+    assertEquals(1L, handoff.droppedCount())
+  }
+
+  @Test
+  fun takingAStickyCriticalFreesTheSlotForLivePackets() {
+    val handoff = FrameHandoff()
+    val idr = keyFrame()
+
+    handoff.offer(idr)
+    handoff.offer(delta()) // dropped: idr sticky
+    assertSame(idr, handoff.take())
+
+    val live = delta()
+    assertTrue(handoff.offer(live))
+    assertSame(live, handoff.peek())
+    assertEquals(1L, handoff.droppedCount())
+  }
+
+  @Test
+  fun offerReturnsFalseOnceClosed() {
+    val handoff = FrameHandoff()
+    handoff.close()
+
+    assertFalse(handoff.offer(delta()))
+    // A closed, drained handoff returns null so the writer thread exits its loop.
+    assertNull(handoff.take())
+  }
+
+  @Test
+  fun closeDrainsRemainingPacketBeforeSignallingExit() {
+    val handoff = FrameHandoff()
+    val pending = delta()
+    handoff.offer(pending)
+
+    handoff.close()
+
+    // The last accepted packet is still delivered; only then does take() report closure.
+    assertSame(pending, handoff.take())
+    assertNull(handoff.take())
+  }
+}


### PR DESCRIPTION
Closes [#4749](https://github.com/kaeawc/auto-mobile/issues/4749)

## Summary

The on-device encode loop dequeued a MediaCodec output buffer, wrote it to the
LocalSocket **synchronously**, then released the buffer, all on one thread. A slow
or stalled host reader blocked the write, so the encoder's output buffers (and in
turn its Surface input) backed up and frames were **delayed rather than
dropped-latest** — there was no latest-frame-wins policy on the device side.

This decouples encode from transport:

- **New `FrameHandoff`** (`android/video-server/.../video/FrameHandoff.kt`) — a
  bounded, single-slot, **drop-oldest** handoff. A newer delta replaces an unsent
  older one (latest-frame-wins), so the reader advances toward the live edge
  instead of draining a stale backlog. Pure JVM: no Android framework, no real
  timers, so the drop policy unit-tests deterministically.
- **Dedicated `video-transport-writer` thread** in `VideoStreamWriter` drains the
  handoff into the socket. `writePacket` now copies the buffer, caches decoder
  state, and offers to the handoff — all non-blocking — so the encode loop
  releases the output buffer immediately and a transport stall can no longer
  back-pressure MediaCodec. `VideoServer.kt`'s encode loop is unchanged (its
  `writePacket` call is simply non-blocking now), keeping this diff off the file
  that sibling PR [#4748](https://github.com/kaeawc/auto-mobile/pull/4748) touches.

### Invariants preserved

- **Cached SPS/PPS + IDR replay** — caching happens on the producer side, *before*
  the handoff can drop anything, so a dropped live packet never removes config or
  the latest IDR from the reconnect replay cache.
- **Keyframe integrity on the live path** — a slotted config/keyframe is *sticky*:
  it is never buried by a later delta (which a decoder could not use without it).
  A newer keyframe still evicts a stale delta.
- **Reconnect window** — `ReconnectWindow` behavior is untouched; the writer thread
  writes through the same lock and `writePacketDataLocked` disconnect handling.
- **Keyframe-command reader semantics** — the command-reader thread and
  `onClientConnected` IDR request are unchanged.
- **Clean shutdown** — `stop()` closes the handoff and the client socket (the
  latter without taking the lock) to unblock a wedged write, then bounded-joins the
  writer thread so shutdown can never hang.

## Validation

Ran locally on the Android toolchain (JDK 21, `sdk.dir` set):

- `./gradlew :video-server:test` — **BUILD SUCCESSFUL**; `FrameHandoffTest` = 9
  tests, 0 failures (0.01s), all module tests green.
- `ktfmt --google-style` on the changed files — clean (exit 0).

New `FrameHandoffTest` covers: single-packet round-trip, newer-delta-replaces-delta
(drop count), delta never evicts an unsent keyframe or config, keyframe evicts a
stale delta, sticky-critical vs a later critical, slot freed after taking a sticky
critical, and closed-handoff / drain-on-close signalling.
