### PR TITLE
test(video-server): socket seam + recovery-path tests for VideoStreamWriter

### DIFF
--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
@@ -100,7 +100,7 @@ object VideoServer {
     }
   }
 
-  private fun parseQuality(args: Array<String>): QualityPreset {
+  internal fun parseQuality(args: Array<String>): QualityPreset {
     var i = 0
     while (i < args.size) {
       when (args[i]) {
@@ -128,7 +128,7 @@ object VideoServer {
   }
 
   /** Read the integer value following [flag], or null if absent/invalid. */
-  private fun parseIntFlag(args: Array<String>, flag: String): Int? {
+  internal fun parseIntFlag(args: Array<String>, flag: String): Int? {
     val index = args.indexOf(flag)
     if (index < 0 || index + 1 >= args.size) {
       return null
@@ -137,7 +137,7 @@ object VideoServer {
   }
 
   /** Parse `--size WxH` into an even-rounded (width, height) pair, or null. */
-  private fun parseSizeFlag(args: Array<String>): Pair<Int, Int>? {
+  internal fun parseSizeFlag(args: Array<String>): Pair<Int, Int>? {
     val index = args.indexOf("--size")
     if (index < 0 || index + 1 >= args.size) {
       return null

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServerSocketSeam.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServerSocketSeam.kt
@@ -1,0 +1,68 @@
+package dev.jasonpearson.automobile.video
+
+import android.net.LocalServerSocket
+import android.net.LocalSocket
+import java.io.InputStream
+import java.io.OutputStream
+
+/**
+ * Narrow seam over `android.net.LocalServerSocket` / `android.net.LocalSocket` so
+ * [VideoStreamWriter]'s accept / write / replay / command paths can be driven by fakes.
+ *
+ * The framework socket classes are only available inside `app_process`, so the concrete
+ * [LocalServerSocketAdapter] / [LocalSocketConnection] wrappers below are never loaded in a plain
+ * JVM unit test; tests inject their own [VideoServerSocketFactory] instead. This mirrors how
+ * `DisplayControl` wraps hidden framework display APIs behind a testable surface.
+ */
+fun interface VideoServerSocketFactory {
+  /** Bind an abstract local socket named [socketName] and return the listening server socket. */
+  fun create(socketName: String): VideoServerSocket
+}
+
+/** A bound, listening server socket. */
+interface VideoServerSocket {
+  /**
+   * Block until a client connects and return it, or `null` when there are no further clients and
+   * the acceptor loop should stop. Throws [java.io.IOException] when the socket is closed or the
+   * accept fails.
+   */
+  fun accept(): VideoClientConnection?
+
+  /** Close the listening socket, unblocking a pending [accept]. */
+  fun close()
+}
+
+/** A single bidirectional client connection exposing only the byte streams the writer needs. */
+interface VideoClientConnection {
+  val outputStream: OutputStream
+  val inputStream: InputStream
+
+  fun close()
+}
+
+/** Production factory that binds a real abstract-namespace `LocalServerSocket`. */
+internal object LocalServerSocketFactory : VideoServerSocketFactory {
+  override fun create(socketName: String): VideoServerSocket =
+    LocalServerSocketAdapter(LocalServerSocket(socketName))
+}
+
+internal class LocalServerSocketAdapter(private val serverSocket: LocalServerSocket) :
+  VideoServerSocket {
+  override fun accept(): VideoClientConnection = LocalSocketConnection(serverSocket.accept())
+
+  override fun close() {
+    serverSocket.close()
+  }
+}
+
+internal class LocalSocketConnection(private val socket: LocalSocket) : VideoClientConnection {
+  override val outputStream: OutputStream
+    get() = socket.outputStream
+
+  override val inputStream: InputStream
+    get() = socket.inputStream
+
+  override fun close() {
+    socket.close()
+  }
+}

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
@@ -1,8 +1,6 @@
 package dev.jasonpearson.automobile.video
 
 import android.media.MediaCodec
-import android.net.LocalServerSocket
-import android.net.LocalSocket
 import android.os.SystemClock
 import java.io.IOException
 import java.io.OutputStream
@@ -51,6 +49,7 @@ class VideoStreamWriter(
   private val height: Int,
   private val audioEnabled: Boolean = false,
   private val nowMs: () -> Long = { SystemClock.elapsedRealtime() },
+  private val socketFactory: VideoServerSocketFactory = LocalServerSocketFactory,
 ) {
   private data class CachedPacket(
     val trackId: Int,
@@ -58,10 +57,10 @@ class VideoStreamWriter(
     val data: ByteArray,
   )
 
-  private var serverSocket: LocalServerSocket? = null
+  private var serverSocket: VideoServerSocket? = null
   // @Volatile: stop() closes this without the lock to unblock a writer thread wedged in a
   // blocking socket write (the writer holds `lock` for the duration of that write).
-  @Volatile private var clientSocket: LocalSocket? = null
+  @Volatile private var clientSocket: VideoClientConnection? = null
   private var outputStream: OutputStream? = null
   private var commandHandler: ((Int) -> Unit)? = null
   private val lock = Any()
@@ -110,9 +109,7 @@ class VideoStreamWriter(
    * without delaying initial decoder setup.
    */
   fun start(onClientConnected: () -> Unit = {}) {
-    serverSocket = LocalServerSocket(socketName)
-    synchronized(lock) { reconnectWindow.start() }
-    println("Waiting for client connection on localabstract:$socketName")
+    bindServerSocket()
     writerThread =
       Thread({ drainToTransport() }, "video-transport-writer").apply {
         isDaemon = true
@@ -139,6 +136,17 @@ class VideoStreamWriter(
   }
 
   /**
+   * Bind the listening socket and arm the reconnect window without spawning the acceptor thread.
+   * Split out from [start] so unit tests can drive [acceptClients] synchronously on the test thread
+   * with an injected [socketFactory].
+   */
+  internal fun bindServerSocket() {
+    serverSocket = socketFactory.create(socketName)
+    synchronized(lock) { reconnectWindow.start() }
+    println("Waiting for client connection on localabstract:$socketName")
+  }
+
+  /**
    * Registers a callback for every current or future bidirectional client. The reader is
    * deliberately owned by the writer so reconnects do not lose the keyframe-request control
    * channel.
@@ -149,7 +157,7 @@ class VideoStreamWriter(
     }
   }
 
-  private fun acceptClients(onClientConnected: () -> Unit) {
+  internal fun acceptClients(onClientConnected: () -> Unit) {
     while (!stopped) {
       val client =
         try {
@@ -188,7 +196,7 @@ class VideoStreamWriter(
     }
   }
 
-  private fun startCommandReaderFor(client: LocalSocket) {
+  private fun startCommandReaderFor(client: VideoClientConnection) {
     val input = client.inputStream
     Thread(
         {
@@ -296,7 +304,7 @@ class VideoStreamWriter(
     }
   }
 
-  private fun isCurrentClient(client: LocalSocket): Boolean =
+  private fun isCurrentClient(client: VideoClientConnection): Boolean =
     synchronized(lock) { clientSocket === client }
 
   private fun closeClientLocked() {

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoServerArgumentsTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoServerArgumentsTest.kt
@@ -1,0 +1,166 @@
+package dev.jasonpearson.automobile.video
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+/**
+ * Direct unit coverage for the video server's pure command-line parsing and validation. These paths
+ * gate security-relevant inputs (socket name / session token) and the encoder's dimension
+ * requirements, and were previously untested.
+ */
+class VideoServerArgumentsTest {
+
+  // --- QualityPreset.fromString ---------------------------------------------------------------
+
+  @Test
+  fun qualityPresetFromStringIsCaseInsensitive() {
+    assertEquals(QualityPreset.LOW, QualityPreset.fromString("low"))
+    assertEquals(QualityPreset.MEDIUM, QualityPreset.fromString("MEDIUM"))
+    assertEquals(QualityPreset.HIGH, QualityPreset.fromString("High"))
+  }
+
+  @Test
+  fun qualityPresetFromStringRejectsUnknownValues() {
+    val error =
+      assertThrows(IllegalArgumentException::class.java) { QualityPreset.fromString("ultra") }
+    assertEquals("Unknown quality preset: ultra", error.message)
+  }
+
+  // --- VideoServer.parseQuality ---------------------------------------------------------------
+
+  @Test
+  fun parseQualityReadsLongAndShortFlags() {
+    assertEquals(QualityPreset.HIGH, VideoServer.parseQuality(arrayOf("--quality", "high")))
+    assertEquals(QualityPreset.LOW, VideoServer.parseQuality(arrayOf("-q", "low")))
+  }
+
+  @Test
+  fun parseQualityDefaultsToMediumWhenAbsentOrInvalid() {
+    assertEquals(QualityPreset.MEDIUM, VideoServer.parseQuality(arrayOf()))
+    // An invalid preset is reported to stderr and falls back to MEDIUM rather than crashing.
+    assertEquals(QualityPreset.MEDIUM, VideoServer.parseQuality(arrayOf("--quality", "bogus")))
+    // A trailing flag with no value is ignored.
+    assertEquals(QualityPreset.MEDIUM, VideoServer.parseQuality(arrayOf("--quality")))
+  }
+
+  // --- VideoServer.parseIntFlag ---------------------------------------------------------------
+
+  @Test
+  fun parseIntFlagReadsPositiveValuesAndRejectsTheRest() {
+    assertEquals(
+      2_500_000,
+      VideoServer.parseIntFlag(arrayOf("--bit-rate", "2500000"), "--bit-rate"),
+    )
+    assertNull(VideoServer.parseIntFlag(arrayOf("--bit-rate", "0"), "--bit-rate"))
+    assertNull(VideoServer.parseIntFlag(arrayOf("--bit-rate", "-5"), "--bit-rate"))
+    assertNull(VideoServer.parseIntFlag(arrayOf("--bit-rate", "abc"), "--bit-rate"))
+    assertNull(VideoServer.parseIntFlag(arrayOf("--bit-rate"), "--bit-rate"))
+    assertNull(VideoServer.parseIntFlag(arrayOf(), "--bit-rate"))
+  }
+
+  // --- VideoServer.parseSizeFlag --------------------------------------------------------------
+
+  @Test
+  fun parseSizeFlagParsesWidthHeightWithEitherSeparator() {
+    assertEquals(720 to 1280, VideoServer.parseSizeFlag(arrayOf("--size", "720x1280")))
+    assertEquals(720 to 1280, VideoServer.parseSizeFlag(arrayOf("--size", "720X1280")))
+  }
+
+  @Test
+  fun parseSizeFlagRoundsDownToEvenDimensions() {
+    // MediaCodec requires even dimensions; odd values round down by clearing the low bit.
+    assertEquals(720 to 1280, VideoServer.parseSizeFlag(arrayOf("--size", "721x1281")))
+  }
+
+  @Test
+  fun parseSizeFlagRejectsMalformedOrZeroCollapsingValues() {
+    assertNull(VideoServer.parseSizeFlag(arrayOf()))
+    assertNull(VideoServer.parseSizeFlag(arrayOf("--size")))
+    assertNull(VideoServer.parseSizeFlag(arrayOf("--size", "720")))
+    assertNull(VideoServer.parseSizeFlag(arrayOf("--size", "720x1280x60")))
+    assertNull(VideoServer.parseSizeFlag(arrayOf("--size", "axb")))
+    assertNull(VideoServer.parseSizeFlag(arrayOf("--size", "0x1280")))
+    assertNull(VideoServer.parseSizeFlag(arrayOf("--size", "-720x1280")))
+    // 1x1 rounds to 0x0, which would defer into an opaque encoder failure, so it is rejected.
+    assertNull(VideoServer.parseSizeFlag(arrayOf("--size", "1x1")))
+  }
+
+  // --- VideoSessionArguments.parse ------------------------------------------------------------
+
+  @Test
+  fun parseDefaultsSocketNameAndLeavesOptionalFieldsNull() {
+    val options = VideoSessionArguments.parse(arrayOf())
+    assertEquals("automobile_video", options.socketName)
+    assertNull(options.token)
+    assertNull(options.ownerPid)
+    assertNull(options.deviceSerial)
+    assertNull(options.forwardPort)
+  }
+
+  @Test
+  fun parseAcceptsFullyPopulatedValidArguments() {
+    val options =
+      VideoSessionArguments.parse(
+        arrayOf(
+          "--socket-name",
+          "automobile_video.session-1",
+          "--session-token",
+          "abcd-efgh-1234",
+          "--owner-pid",
+          "4321",
+          "--device-serial",
+          "emulator-5554",
+          "--forward-port",
+          "61234",
+        )
+      )
+    assertEquals("automobile_video.session-1", options.socketName)
+    assertEquals("abcd-efgh-1234", options.token)
+    assertEquals(4321L, options.ownerPid)
+    assertEquals("emulator-5554", options.deviceSerial)
+    assertEquals(61234, options.forwardPort)
+  }
+
+  @Test
+  fun parseRejectsSocketNamesOutsideTheSafeCharacterSet() {
+    assertThrows(IllegalArgumentException::class.java) {
+      VideoSessionArguments.parse(arrayOf("--socket-name", "bad name with spaces"))
+    }
+    assertThrows(IllegalArgumentException::class.java) {
+      VideoSessionArguments.parse(arrayOf("--socket-name", "../escape"))
+    }
+    assertThrows(IllegalArgumentException::class.java) {
+      // Empty violates the {1,100} length bound.
+      VideoSessionArguments.parse(arrayOf("--socket-name", ""))
+    }
+    assertThrows(IllegalArgumentException::class.java) {
+      // 101 characters exceeds the length bound.
+      VideoSessionArguments.parse(arrayOf("--socket-name", "a".repeat(101)))
+    }
+  }
+
+  @Test
+  fun parseRejectsTokensOutsideTheSafeCharacterSet() {
+    assertThrows(IllegalArgumentException::class.java) {
+      // Too short (< 8 characters).
+      VideoSessionArguments.parse(arrayOf("--session-token", "short"))
+    }
+    assertThrows(IllegalArgumentException::class.java) {
+      // Underscore is not in the token character class.
+      VideoSessionArguments.parse(arrayOf("--session-token", "has_underscore_1"))
+    }
+    assertThrows(IllegalArgumentException::class.java) {
+      // 81 characters exceeds the {8,80} bound.
+      VideoSessionArguments.parse(arrayOf("--session-token", "a".repeat(81)))
+    }
+  }
+
+  @Test
+  fun parseIgnoresNonPositiveOwnerPidAndForwardPort() {
+    val options = VideoSessionArguments.parse(arrayOf("--owner-pid", "0", "--forward-port", "-1"))
+    assertNull(options.ownerPid)
+    assertNull(options.forwardPort)
+  }
+}

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriterTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriterTest.kt
@@ -1,5 +1,14 @@
 package dev.jasonpearson.automobile.video
 
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -21,5 +30,248 @@ class VideoStreamWriterTest {
 
     elapsedRealtimeMs = 12_000L
     assertTrue(window.isExpired())
+  }
+
+  // --- socket/stream seam driven by fakes -----------------------------------------------------
+
+  /**
+   * An output stream that records writes but starts throwing [IOException] once its write count
+   * reaches [failFromWriteIndex]. `flush()` is exempt so a successful header still lands before a
+   * later packet write fails.
+   */
+  private class ScriptedOutputStream(private val failFromWriteIndex: Int = Int.MAX_VALUE) :
+    OutputStream() {
+    var writeCount = 0
+      private set
+
+    override fun write(b: Int) = recordWrite()
+
+    override fun write(b: ByteArray) = recordWrite()
+
+    override fun write(b: ByteArray, off: Int, len: Int) = recordWrite()
+
+    private fun recordWrite() {
+      if (writeCount >= failFromWriteIndex) {
+        throw IOException("scripted write failure at index $writeCount")
+      }
+      writeCount++
+    }
+  }
+
+  /** Blocks in `read()` until the owning connection is closed, then reports EOF. */
+  private class BlockingUntilClosedInputStream(private val closed: CountDownLatch) : InputStream() {
+    override fun read(): Int {
+      closed.await()
+      return -1
+    }
+  }
+
+  private class FakeClientConnection(
+    override val outputStream: OutputStream = ByteArrayOutputStream(),
+    input: InputStream? = null,
+  ) : VideoClientConnection {
+    @Volatile var closed = false
+    private val closedLatch = CountDownLatch(1)
+    override val inputStream: InputStream = input ?: BlockingUntilClosedInputStream(closedLatch)
+
+    override fun close() {
+      if (!closed) {
+        closed = true
+        closedLatch.countDown()
+      }
+    }
+  }
+
+  /**
+   * Drives [VideoStreamWriter.acceptClients] deterministically: each queued action produces the
+   * next `accept()` result (a connection, a thrown [IOException], or the end of the queue which
+   * returns `null` so the acceptor loop stops).
+   */
+  private class FakeServerSocket(actions: List<() -> VideoClientConnection?>) : VideoServerSocket {
+    private val queue = ArrayDeque(actions)
+    @Volatile var closed = false
+
+    override fun accept(): VideoClientConnection? {
+      val next = queue.removeFirstOrNull() ?: return null
+      return next()
+    }
+
+    override fun close() {
+      closed = true
+    }
+  }
+
+  private fun writer(
+    now: () -> Long,
+    serverSocket: VideoServerSocket,
+    audioEnabled: Boolean = false,
+  ): VideoStreamWriter =
+    VideoStreamWriter(
+      socketName = "test_socket",
+      width = 480,
+      height = 800,
+      audioEnabled = audioEnabled,
+      nowMs = now,
+      socketFactory = { serverSocket },
+    )
+
+  @Test
+  fun writeFailureDetachesClientButKeepsEncoderAlive() {
+    var now = 1_000L
+    // Header write (index 0) succeeds; the next packet write fails.
+    val connection =
+      FakeClientConnection(outputStream = ScriptedOutputStream(failFromWriteIndex = 1))
+    val attachCount = AtomicInteger()
+    val subject = writer({ now }, FakeServerSocket(listOf({ connection })))
+
+    subject.bindServerSocket()
+    subject.acceptClients { attachCount.incrementAndGet() }
+
+    assertEquals(1, attachCount.get())
+    assertFalse(connection.closed)
+
+    // The write fails mid-packet: the client is detached, but the contract returns true so the
+    // encode loop keeps producing (loop termination is owned by reconnectWindowExpired()).
+    val result = subject.writeAudioPacket(byteArrayOf(1, 2, 3), ptsUs = 0)
+    assertTrue("write failure must not signal loop termination", result)
+    assertTrue("failed write must detach the client", connection.closed)
+
+    // After detach the bounded reconnect window governs shutdown.
+    now = 1_000L + VideoStreamWriter.CLIENT_RECONNECT_WINDOW_MS
+    assertTrue(subject.reconnectWindowExpired())
+  }
+
+  @Test
+  fun attachRollsBackWhenStreamHeaderWriteThrows() {
+    var now = 1_000L
+    // Header write (index 0) throws, so attach must roll back.
+    val connection =
+      FakeClientConnection(outputStream = ScriptedOutputStream(failFromWriteIndex = 0))
+    val attachCount = AtomicInteger()
+    val subject = writer({ now }, FakeServerSocket(listOf({ connection })))
+
+    subject.bindServerSocket()
+    subject.acceptClients { attachCount.incrementAndGet() }
+
+    assertEquals("failed attach must not report a connected client", 0, attachCount.get())
+    assertTrue("rolled-back attach must close the client socket", connection.closed)
+
+    now = 1_000L + VideoStreamWriter.CLIENT_RECONNECT_WINDOW_MS
+    assertTrue("rolled-back attach must arm the reconnect window", subject.reconnectWindowExpired())
+  }
+
+  @Test
+  fun acceptFailureStopsAcceptorWithoutAttaching() {
+    var now = 1_000L
+    val attachCount = AtomicInteger()
+    val subject = writer({ now }, FakeServerSocket(listOf({ throw IOException("accept failed") })))
+
+    subject.bindServerSocket()
+    // Must not throw: the acceptor swallows the accept IOException and returns.
+    subject.acceptClients { attachCount.incrementAndGet() }
+
+    assertEquals(0, attachCount.get())
+    // Nothing ever attached, so the initial clientless window still governs shutdown.
+    now = 1_000L + VideoStreamWriter.CLIENT_RECONNECT_WINDOW_MS
+    assertTrue(subject.reconnectWindowExpired())
+  }
+
+  @Test
+  fun reconnectDisplacesPriorClientAndStaleReaderCannotDetachReplacement() {
+    var now = 1_000L
+    val first = FakeClientConnection()
+    val second = FakeClientConnection()
+    val attachCount = AtomicInteger()
+    val subject = writer({ now }, FakeServerSocket(listOf({ first }, { second })))
+
+    subject.bindServerSocket()
+    subject.acceptClients { attachCount.incrementAndGet() }
+
+    assertEquals("both clients attach in turn", 2, attachCount.get())
+    assertTrue("the replacement displaces and closes the first client", first.closed)
+    assertFalse("the replacement client stays open", second.closed)
+
+    // The first client's command reader wakes (its socket closed) only after the replacement is
+    // current, so its clientSocket === client guard is false and it must not detach the second
+    // client. The window therefore stays attached regardless of how far the clock advances.
+    now = 1_000_000L
+    assertFalse(
+      "a stale reader from the displaced client must not detach the replacement",
+      subject.reconnectWindowExpired(),
+    )
+
+    subject.stop()
+  }
+
+  @Test
+  fun commandReaderDispatchesClientCommandsAndDetachesOnEof() {
+    var now = 1_000L
+    val received = CountDownLatch(1)
+    val lastCommand = AtomicInteger(-1)
+    // One command byte then EOF; EOF breaks the read loop and detaches in finally.
+    val connection =
+      FakeClientConnection(
+        input =
+          ByteArrayInputStream(byteArrayOf(VideoStreamProtocol.COMMAND_REQUEST_KEY_FRAME.toByte()))
+      )
+    val subject = writer({ now }, FakeServerSocket(listOf({ connection })))
+
+    subject.startCommandReader { command ->
+      lastCommand.set(command)
+      received.countDown()
+    }
+    subject.bindServerSocket()
+    subject.acceptClients {}
+
+    assertTrue(
+      "command reader must dispatch the client's request byte",
+      received.await(2, TimeUnit.SECONDS),
+    )
+    assertEquals(VideoStreamProtocol.COMMAND_REQUEST_KEY_FRAME, lastCommand.get())
+  }
+
+  // --- writePacket success/failure contract (pinning the decision) ----------------------------
+
+  @Test
+  fun writeReturnsTrueWithNoClientSoWritesAreDroppedNotFailed() {
+    val subject = writer({ 0L }, FakeServerSocket(emptyList()))
+    subject.bindServerSocket()
+
+    // No client has attached: writes are silently dropped (cached, for the next client) and must
+    // report success so the encode loop is not torn down while waiting for a reconnect.
+    assertTrue(subject.writeAudioPacket(byteArrayOf(1, 2, 3), ptsUs = 0))
+  }
+
+  @Test
+  fun writeReturnsFalseOnlyAfterStop() {
+    val subject = writer({ 0L }, FakeServerSocket(emptyList()))
+    subject.bindServerSocket()
+    subject.stop()
+
+    // Once stopped the contract flips to false, the single condition the encode loop treats as
+    // terminal (VideoServer's `if (!success) break`).
+    assertFalse(subject.writeAudioPacket(byteArrayOf(1, 2, 3), ptsUs = 0))
+  }
+
+  @Test
+  fun stopClosesServerSocketAndClearsClient() {
+    val serverSocket = FakeServerSocket(listOf({ FakeClientConnection() }))
+    val subject = writer({ 0L }, serverSocket)
+    subject.bindServerSocket()
+    subject.acceptClients {}
+
+    subject.stop()
+
+    assertTrue(serverSocket.closed)
+  }
+
+  @Test
+  fun constructionWithDefaultFactoryDoesNotBindAFrameworkSocket() {
+    // The default socket factory must only be invoked by start()/bindServerSocket(), never during
+    // construction, so the writer is constructible under a plain JVM (no LocalServerSocket) and no
+    // client can be observed before bind. Not calling bindServerSocket() here, a write is a no-op
+    // that reports success (no client yet).
+    val subject = VideoStreamWriter(socketName = "s", width = 2, height = 2, nowMs = { 0L })
+    assertTrue(subject.writeAudioPacket(byteArrayOf(0), ptsUs = 0))
   }
 }


### PR DESCRIPTION
Closes [#4754](https://github.com/kaeawc/auto-mobile/issues/4754)

## Summary

`VideoStreamWriter` concentrated the video-server's write-failure, client-reconnect-race, and keyframe-command-channel recovery logic but had no tests reaching past its inner `ReconnectWindow`, because it constructed `LocalServerSocket` directly and exposed no injectable socket/stream seam. This PR adds that seam and the missing tests, without rewriting the write path itself (that is the scope of the sibling PRs also touching this file).

### Socket/stream seam (new `VideoServerSocketSeam.kt`)

A narrow, framework-free interface trio, mirroring how `DisplayControl` wraps hidden framework APIs behind a testable surface:

- `VideoServerSocketFactory` — `fun create(socketName): VideoServerSocket`
- `VideoServerSocket` — `accept(): VideoClientConnection?` / `close()`
- `VideoClientConnection` — `outputStream` / `inputStream` / `close()`

The production `LocalServerSocketFactory` / `LocalServerSocketAdapter` / `LocalSocketConnection` wrappers live behind these interfaces and are the only place `LocalServerSocket` / `LocalSocket` are referenced, so they are never loaded under a plain-JVM unit test. `VideoStreamWriter` now takes a `socketFactory` (defaulting to the production factory) and holds `VideoServerSocket?` / `VideoClientConnection?` instead of the concrete framework types. `start()` is split so `bindServerSocket()` arms the socket + reconnect window without spawning the acceptor thread, letting tests drive `acceptClients` synchronously with fakes.

The write path (`writePacketDataLocked`, `writeStreamHeaderLocked`, `replayCachedVideoLocked`) is unchanged — only the socket/connection field types.

### Tests

`VideoStreamWriterTest` (fake-driven recovery paths, all deterministic and sub-second):
- write-failure `IOException` -> `closeClientLocked()` + `onClientDetached()`
- attach rollback when the stream-header write throws
- accept-failure stops the acceptor without attaching
- reconnect displacement + the stale-reader `clientSocket === client` guard (the reconnect-race core)
- command-reader dispatch + EOF detach

`writePacket` contract is **pinned** (not altered): returns `true` with no client (writes dropped, not failed), `true` on a failed write (encoder kept alive; loop termination is owned by `reconnectWindowExpired()`), and `false` only after `stop()`. The existing `if (!success)` branch in `VideoServer.kt` is left in place as the deliberate terminal condition, documented by the pinning tests.

`VideoServerArgumentsTest` (pure logic, previously zero coverage):
- `QualityPreset.fromString` incl. the `IllegalArgumentException` branch
- `VideoServer.parseQuality` / `parseIntFlag` / `parseSizeFlag` (widened `private` -> `internal` for direct testing)
- `VideoSessionArguments.parse` — `SAFE_SOCKET_NAME` / `SAFE_TOKEN` regex + length validation and `require` rejections

## Validation

- `./gradlew :video-server:test` (JDK 21, local Android SDK) — **BUILD SUCCESSFUL**; 23 new tests (10 in `VideoStreamWriterTest`, 13 in `VideoServerArgumentsTest`), 0 failures / 0 errors, alongside the existing suites.
- `ktfmt --google-style` (pinned 0.64) applied to all touched files — clean.

## Acceptance criteria

- [x] Socket/stream seam exists for `VideoStreamWriter`; write-failure, attach-rollback, accept-failure, and reconnect-displacement paths have unit tests.
- [x] `writePacket`'s success/failure contract is pinned with tests (dead branch left as the intentional terminal condition, documented in tests).
- [x] Pure logic (`parseSizeFlag`, `parseIntFlag`, `parseQuality`, `QualityPreset.fromString`, `VideoSessionArguments.parse`) has direct unit tests.
