### PR TITLE
Desktop workspace: Performance facet (per-device live metrics)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/performance/PerformanceDashboard.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/performance/PerformanceDashboard.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.jasonpearson.automobile.desktop.core.components.Link
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
-import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
+import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
 import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
@@ -55,8 +55,10 @@ fun PerformanceDashboard(
   onNavigateToTest: (String) -> Unit = {}, // Navigate to a test
   dataSourceMode: DataSourceMode = DataSourceMode.Fake,
   clientProvider: (() -> AutoMobileClient)? = null, // MCP client for real data
-  observationStreamClient: ObservationStreamClient? =
-    null, // Shared stream client for real-time updates
+  observationStreamClient: ObservationStream? = null, // Per-device stream for real-time updates
+  // Device this dashboard is scoped to; when set, cross-device stream updates are dropped so panes
+  // in a multi-device workspace can't contaminate each other's live metrics. Null = no filtering.
+  deviceId: String? = null,
   // Initial metrics from parent to avoid empty state flicker when opening
   initialFps: Float? = null,
   initialFrameTimeMs: Float? = null,
@@ -201,6 +203,11 @@ fun PerformanceDashboard(
 
     LOG.info("Starting performance updates collection from stream client")
     observationStreamClient.performanceUpdates.collect { update ->
+      // The stream may be server-scoped to one device, but guard against cross-device updates so a
+      // multi-device workspace can't contaminate this pane's metrics.
+      if (deviceId != null && update.deviceId != null && update.deviceId != deviceId) {
+        return@collect
+      }
       LOG.info(
         "Received performance update - fps=${update.fps}, jankFrames=${update.jankFrames}, touchLatencyMs=${update.touchLatencyMs}, ttiMs=${update.timeToInteractiveMs}, screenName=${update.screenName}"
       )

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/PerformanceFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/PerformanceFacet.kt
@@ -1,0 +1,54 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
+import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
+import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
+import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
+import dev.jasonpearson.automobile.desktop.core.performance.PerformanceDashboard
+
+/**
+ * Docked-facet body for [Tool.Performance]: the performance dashboard scoped to a single pane's
+ * device. A per-pane [ObservationStream] is created via [observationStreamFactory] and connected to
+ * [column]'s device while the facet is shown, then disposed when it leaves composition or the
+ * device changes. The dashboard's live metrics (fps, frame time, jank, memory, …) are pushed from
+ * that stream and filtered to [column]'s device, so panes in a multi-device workspace stay
+ * isolated.
+ *
+ * [observationStreamFactory] is injected (defaulting to a real per-device
+ * [ObservationStreamClient]) so the per-device connect/dispose lifecycle can be verified with a
+ * [FakeObservationStream] instead of real socket I/O.
+ *
+ * Note: only the LIVE metrics here are per-device (the stream carries a deviceId). The dashboard's
+ * audit-history fallback still reads via the DI graph's active-device client — device-scoping that
+ * path is a separate follow-up (thread deviceId through listPerformanceAuditResults), not fixed
+ * here.
+ */
+@Composable
+fun PerformanceFacet(
+  column: DeviceColumn,
+  observationStreamFactory: (String) -> ObservationStream = { ObservationStreamClient() },
+) {
+  val graph = LocalAutoMobileGraph.current
+  var stream by remember(column.deviceId) { mutableStateOf<ObservationStream?>(null) }
+  DisposableEffect(column.deviceId) {
+    val connected =
+      observationStreamFactory(column.deviceId).also { it.connect(deviceId = column.deviceId) }
+    stream = connected
+    onDispose {
+      connected.dispose()
+      stream = null
+    }
+  }
+  PerformanceDashboard(
+    dataSourceMode = DataSourceMode.Real,
+    clientProvider = { graph.autoMobileClient },
+    observationStreamClient = stream,
+    deviceId = column.deviceId,
+  )
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/PerformanceFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/PerformanceFacetTest.kt
@@ -1,0 +1,148 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.daemon.FakeObservationStream
+import dev.jasonpearson.automobile.desktop.core.daemon.PerformanceStreamUpdate
+import dev.jasonpearson.automobile.desktop.core.datasource.DefaultDataSourceFactory
+import dev.jasonpearson.automobile.desktop.core.di.AutoMobileGraphProvider
+import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
+import dev.jasonpearson.automobile.desktop.core.settings.FakeSettingsProvider
+import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class PerformanceFacetTest {
+
+  /**
+   * A DI graph backed by a [FakeAutoMobileClient] so the dashboard's audit-history fallback
+   * resolves to an empty run (no socket), keeping these tests deterministic. The live-metrics path
+   * under test comes from the injected [FakeObservationStream], not this client.
+   */
+  private fun fakeGraph(): AutoMobileGraphProvider {
+    val client = FakeAutoMobileClient()
+    return object : AutoMobileGraphProvider {
+      override val autoMobileClient = client
+      override val settingsProvider = FakeSettingsProvider()
+      override val dataSourceFactory = DefaultDataSourceFactory(client)
+    }
+  }
+
+  private fun perfUpdate(deviceId: String?, fps: Float) =
+    PerformanceStreamUpdate(
+      deviceId = deviceId,
+      timestamp = 1_000L,
+      fps = fps,
+      frameTimeMs = 16f,
+      jankFrames = 0,
+      droppedFrames = 0,
+      memoryUsageMb = 100f,
+      cpuUsagePercent = 10f,
+      touchLatencyMs = null,
+      timeToInteractiveMs = null,
+      screenName = null,
+      isResponsive = true,
+      recompositionCount = null,
+      recompositionRate = null,
+    )
+
+  @Test
+  fun `connects the stream to the pane device and disposes when removed`() = runComposeUiTest {
+    val fake = FakeObservationStream()
+    val visible = mutableStateOf(true)
+    setContent {
+      CompositionLocalProvider(LocalAutoMobileGraph provides fakeGraph()) {
+        MaterialTheme {
+          if (visible.value) {
+            PerformanceFacet(
+              column =
+                DeviceColumn(deviceId = "dev-1", name = "Pixel", platform = Platform.Android),
+              observationStreamFactory = { fake },
+            )
+          }
+        }
+      }
+    }
+    waitForIdle()
+    // Connected exactly once, to this pane's device.
+    assertEquals("dev-1", fake.lastConnectedDeviceId)
+    assertEquals(1, fake.connectCallCount)
+
+    // Leaving composition disposes the stream (dispose → disconnect).
+    runOnIdle { visible.value = false }
+    waitForIdle()
+    assertTrue("expected the stream to be disposed on removal", fake.disconnectCallCount >= 1)
+  }
+
+  @Test
+  fun `reconnects to the new device when the pane device changes`() = runComposeUiTest {
+    val fake = FakeObservationStream()
+    val deviceId = mutableStateOf("dev-1")
+    setContent {
+      CompositionLocalProvider(LocalAutoMobileGraph provides fakeGraph()) {
+        MaterialTheme {
+          PerformanceFacet(
+            column =
+              DeviceColumn(deviceId = deviceId.value, name = "Pixel", platform = Platform.Android),
+            observationStreamFactory = { fake },
+          )
+        }
+      }
+    }
+    waitForIdle()
+    assertEquals(1, fake.connectCallCount)
+
+    runOnIdle { deviceId.value = "dev-2" }
+    waitForIdle()
+    // The old subscription is disposed and a new connect targets the new device.
+    assertEquals("dev-2", fake.lastConnectedDeviceId)
+    assertEquals(2, fake.connectCallCount)
+    assertTrue(fake.disconnectCallCount >= 1)
+  }
+
+  @Test
+  fun `renders a live metric from a stream update for this device`() = runComposeUiTest {
+    val fake = FakeObservationStream()
+    setContent {
+      CompositionLocalProvider(LocalAutoMobileGraph provides fakeGraph()) {
+        MaterialTheme {
+          PerformanceFacet(
+            column = DeviceColumn(deviceId = "dev-1", name = "Pixel", platform = Platform.Android),
+            observationStreamFactory = { fake },
+          )
+        }
+      }
+    }
+    waitForIdle()
+    runOnIdle { fake.emitPerformance(perfUpdate(deviceId = "dev-1", fps = 30f)) }
+    waitForIdle()
+    onNodeWithText("Frame Rate").assertIsDisplayed()
+  }
+
+  @Test
+  fun `ignores a stream update for another device`() = runComposeUiTest {
+    val fake = FakeObservationStream()
+    setContent {
+      CompositionLocalProvider(LocalAutoMobileGraph provides fakeGraph()) {
+        MaterialTheme {
+          PerformanceFacet(
+            column = DeviceColumn(deviceId = "dev-1", name = "Pixel", platform = Platform.Android),
+            observationStreamFactory = { fake },
+          )
+        }
+      }
+    }
+    waitForIdle()
+    runOnIdle { fake.emitPerformance(perfUpdate(deviceId = "other", fps = 30f)) }
+    waitForIdle()
+    // Filtered out: no metric cards render, only the empty "waiting" state.
+    onNodeWithText("Waiting for performance data...").assertIsDisplayed()
+  }
+}


### PR DESCRIPTION
Adds the ⚡ Performance facet — a per-device docked tool window wrapping `PerformanceDashboard`, driven per pane via an injected `ObservationStream` (live metrics filtered by `deviceId`), mirroring `LogsFacet`'s connect/dispose lifecycle. Part of the facet build-out ([#4715](https://github.com/kaeawc/auto-mobile/issues/4715)); built in parallel with Navigation/Layout.

## Changes
- `PerformanceFacet.kt` (+ test) — per-device `ObservationStream` factory (default real), `DisposableEffect` connect/dispose, renders `PerformanceDashboard` scoped to the pane's device.
- `PerformanceDashboard.kt` — retyped `observationStreamClient` to the `ObservationStream` interface; added a `deviceId` filter on `performanceUpdates` to prevent cross-pane contamination (both params defaulted, legacy caller unaffected).

## Validation
- `:desktop-core:detektMain` + `:desktop-core:test` (4 new Compose tests: connect-once-per-device, dispose-on-removal, reconnect-on-device-change, cross-device filter) + `:desktop-core:/:desktop-app:compileKotlin` — all green.

## Note
Host wiring (`Tool.Performance -> PerformanceFacet` in `WorkspaceFacet`) lands in a single follow-up host PR that wires Navigation/Performance/Layout together, to avoid parallel conflicts on that shared file. The facet's test is its consumer until then. Audit-history remains active-device (separate follow-up).