### PR TITLE
Desktop workspace: Navigation facet (per-device, stream-driven)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationDashboard.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationDashboard.kt
@@ -45,6 +45,11 @@ fun NavigationDashboard(
     null, // Screenshot loader (hoisted to parent so cache persists across toggles)
   settingsProvider: SettingsProvider =
     FakeSettingsProvider(), // Settings provider (caller injects real impl)
+  // When true (and a stream is provided), skip the initial active-device data-source fetch and
+  // drive the graph solely from the per-device [observationStreamClient]. This keeps per-device
+  // panes correct: the active-device fetch would otherwise briefly show the wrong device's graph
+  // until the first stream push. The default preserves the existing (non-facet) fetch behavior.
+  streamOnly: Boolean = false,
 ) {
   val graph = LocalAutoMobileGraph.current
   var currentSection by remember { mutableStateOf(NavigationSection.FlowMap) }
@@ -70,7 +75,15 @@ fun NavigationDashboard(
   var isLoading by remember { mutableStateOf(true) }
   var error by remember { mutableStateOf<String?>(null) }
 
-  LaunchedEffect(dataSourceMode, clientProvider, selectedAppId) {
+  val streamDriven = streamOnly && observationStreamClient != null
+
+  LaunchedEffect(dataSourceMode, clientProvider, selectedAppId, streamDriven) {
+    // Stream-only: skip the active-device data-source fetch so the graph is driven solely by this
+    // pane's per-device stream (avoids briefly showing the active device's graph).
+    if (streamDriven) {
+      isLoading = false
+      return@LaunchedEffect
+    }
     LOG.info(
       "Loading navigation data with mode: $dataSourceMode, appId: $selectedAppId, clientProvider=${if (clientProvider != null) "present" else "null"}"
     )

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationDashboard.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationDashboard.kt
@@ -45,8 +45,8 @@ fun NavigationDashboard(
     null, // Screenshot loader (hoisted to parent so cache persists across toggles)
   settingsProvider: SettingsProvider =
     FakeSettingsProvider(), // Settings provider (caller injects real impl)
-  // When true (and a stream is provided), skip the initial active-device data-source fetch and
-  // drive the graph solely from the per-device [observationStreamClient]. This keeps per-device
+  // When true, never run the initial active-device data-source fetch; the graph is driven solely by
+  // the per-device [observationStreamClient] (which the caller attaches). This keeps per-device
   // panes correct: the active-device fetch would otherwise briefly show the wrong device's graph
   // until the first stream push. The default preserves the existing (non-facet) fetch behavior.
   streamOnly: Boolean = false,
@@ -75,12 +75,13 @@ fun NavigationDashboard(
   var isLoading by remember { mutableStateOf(true) }
   var error by remember { mutableStateOf<String?>(null) }
 
-  val streamDriven = streamOnly && observationStreamClient != null
-
-  LaunchedEffect(dataSourceMode, clientProvider, selectedAppId, streamDriven) {
-    // Stream-only: skip the active-device data-source fetch so the graph is driven solely by this
-    // pane's per-device stream (avoids briefly showing the active device's graph).
-    if (streamDriven) {
+  LaunchedEffect(dataSourceMode, clientProvider, selectedAppId, streamOnly) {
+    // Stream-only: never run the active-device data-source fetch — the graph is driven solely by
+    // this pane's per-device stream. Gated on streamOnly directly (not stream presence): the facet
+    // attaches its stream via DisposableEffect AFTER first composition, so keying on the attached
+    // stream would still let the fetch fire once on mount and briefly show the wrong device's
+    // graph.
+    if (streamOnly) {
       isLoading = false
       return@LaunchedEffect
     }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationDashboard.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationDashboard.kt
@@ -11,7 +11,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
 import dev.jasonpearson.automobile.desktop.core.daemon.NavigationGraphStreamUpdate
-import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
+import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
 import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
 import dev.jasonpearson.automobile.desktop.core.datasource.NavigationGraph
 import dev.jasonpearson.automobile.desktop.core.datasource.Result
@@ -39,7 +39,7 @@ fun NavigationDashboard(
   dataSourceMode: DataSourceMode = DataSourceMode.Fake,
   clientProvider: (() -> AutoMobileClient)? = null, // MCP client for real data
   selectedAppId: String? = null, // App ID to filter navigation graph by (managed by parent)
-  observationStreamClient: ObservationStreamClient? =
+  observationStreamClient: ObservationStream? =
     null, // Real-time stream client for navigation updates
   screenshotLoader: ScreenshotLoader? =
     null, // Screenshot loader (hoisted to parent so cache persists across toggles)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
@@ -57,5 +57,8 @@ fun NavigationFacet(
     settingsProvider = graph.settingsProvider,
     selectedAppId = null,
     screenshotLoader = screenshotLoader,
+    // Drive the graph solely from this pane's per-device stream so a second pane on another device
+    // never shows the active device's graph.
+    streamOnly = true,
   )
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
@@ -1,0 +1,61 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
+import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
+import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
+import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
+import dev.jasonpearson.automobile.desktop.core.navigation.NavigationDashboard
+import dev.jasonpearson.automobile.desktop.core.navigation.NavigationScreenshotLoader
+
+/**
+ * Docked-facet body for [Tool.Navigation]: the navigation dashboard scoped to a single pane's
+ * device. An [ObservationStream] is created via [observationStreamFactory] and connected to
+ * [column]'s device while the facet is shown, then disposed when it leaves composition or the
+ * device changes — mirroring [LogsFacet]'s per-device connect/dispose lifecycle.
+ *
+ * [observationStreamFactory] is injected (defaulting to a real per-device
+ * [ObservationStreamClient]) so the connect/dispose/request lifecycle can be verified with
+ * [dev.jasonpearson.automobile.desktop .core.daemon.FakeObservationStream] instead of real socket
+ * I/O.
+ *
+ * [selectedAppId] is left null so the stream's foreground-app-change logic drives which app's graph
+ * is shown; no package needs to be pre-resolved. Navigation is platform-agnostic, so — unlike
+ * [StorageFacet] — no Android-only guard is required.
+ */
+@Composable
+fun NavigationFacet(
+  column: DeviceColumn,
+  observationStreamFactory: (String) -> ObservationStream = { ObservationStreamClient() },
+) {
+  val graph = LocalAutoMobileGraph.current
+  var stream by remember(column.deviceId) { mutableStateOf<ObservationStream?>(null) }
+  DisposableEffect(column.deviceId) {
+    val connected =
+      observationStreamFactory(column.deviceId).also { it.connect(deviceId = column.deviceId) }
+    stream = connected
+    onDispose {
+      connected.dispose()
+      stream = null
+    }
+  }
+  // Stable across recompositions so NavigationDashboard's data-source effect (keyed on the provider
+  // identity) doesn't relaunch and clobber stream-driven graph updates.
+  val clientProvider = remember { { graph.autoMobileClient } }
+  // Remembered per device so its LRU cache survives facet toggles.
+  val screenshotLoader =
+    remember(column.deviceId) { NavigationScreenshotLoader(clientProvider = clientProvider) }
+  NavigationDashboard(
+    observationStreamClient = stream,
+    dataSourceMode = DataSourceMode.Real,
+    clientProvider = clientProvider,
+    settingsProvider = graph.settingsProvider,
+    selectedAppId = null,
+    screenshotLoader = screenshotLoader,
+  )
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
@@ -95,8 +95,13 @@ class NavigationFacetTest {
         currentScreen = "Login",
       )
     )
-    waitForIdle()
 
+    // Poll rather than a single waitForIdle: the render depends on the async chain
+    // SharedFlow collect -> state update -> recompose -> canvas layout, which a lone waitForIdle
+    // does not deterministically await (flaked under CI load).
+    waitUntil(timeoutMillis = 5_000) {
+      onAllNodesWithText("Login").fetchSemanticsNodes().isNotEmpty()
+    }
     onAllNodesWithText("Login").onFirst().assertExists()
   }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
@@ -1,0 +1,129 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.daemon.FakeObservationStream
+import dev.jasonpearson.automobile.desktop.core.daemon.NavigationGraphStreamUpdate
+import dev.jasonpearson.automobile.desktop.core.daemon.NavigationNodeData
+import dev.jasonpearson.automobile.desktop.core.datasource.DefaultDataSourceFactory
+import dev.jasonpearson.automobile.desktop.core.di.AutoMobileGraphProvider
+import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
+import dev.jasonpearson.automobile.desktop.core.settings.FakeSettingsProvider
+import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class NavigationFacetTest {
+
+  /** In-memory graph so the dashboard's data-source load hits a fake client, never a socket. */
+  private fun testGraph(): AutoMobileGraphProvider {
+    val client = FakeAutoMobileClient()
+    return object : AutoMobileGraphProvider {
+      override val autoMobileClient = client
+      override val settingsProvider = FakeSettingsProvider()
+      override val dataSourceFactory = DefaultDataSourceFactory(client)
+    }
+  }
+
+  @Test
+  fun `connects the stream to the pane device, requests the graph, and disposes on removal`() =
+    runComposeUiTest {
+      val fake = FakeObservationStream()
+      val visible = mutableStateOf(true)
+      setContent {
+        CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+          MaterialTheme {
+            if (visible.value) {
+              NavigationFacet(
+                column =
+                  DeviceColumn(deviceId = "dev-1", name = "Pixel", platform = Platform.Android),
+                observationStreamFactory = { fake },
+              )
+            }
+          }
+        }
+      }
+      waitForIdle()
+
+      // (1) Connected exactly once, scoped to this pane's device.
+      assertEquals(1, fake.connectCallCount)
+      assertEquals("dev-1", fake.lastConnectedDeviceId)
+      // (2) The dashboard requested the navigation graph on entry.
+      assertTrue(
+        "expected requestNavigationGraph to be issued",
+        fake.navigationRequestCount >= 1,
+      )
+
+      // (4) Leaving composition disposes the stream (dispose -> disconnect).
+      runOnIdle { visible.value = false }
+      waitForIdle()
+      assertTrue(
+        "expected the stream to be disposed on removal",
+        fake.disconnectCallCount >= 1,
+      )
+    }
+
+  @Test
+  fun `renders screen nodes emitted on the navigation stream`() = runComposeUiTest {
+    val fake = FakeObservationStream()
+    setContent {
+      CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+        MaterialTheme {
+          NavigationFacet(
+            column = DeviceColumn(deviceId = "dev-1", name = "Pixel", platform = Platform.Android),
+            observationStreamFactory = { fake },
+          )
+        }
+      }
+    }
+    waitForIdle()
+
+    fake.emitNavigation(
+      NavigationGraphStreamUpdate(
+        timestamp = 1L,
+        appId = "com.example.app",
+        // Node labels render truncated to 12 chars on the canvas, so keep this short.
+        nodes = listOf(NavigationNodeData(id = 1, screenName = "Login", visitCount = 2)),
+        edges = emptyList(),
+        currentScreen = "Login",
+      )
+    )
+    waitForIdle()
+
+    onAllNodesWithText("Login").onFirst().assertExists()
+  }
+
+  @Test
+  fun `reconnects to a new device when the column device changes`() = runComposeUiTest {
+    val streams = mutableMapOf<String, FakeObservationStream>()
+    val deviceId = mutableStateOf("dev-1")
+    setContent {
+      CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+        MaterialTheme {
+          NavigationFacet(
+            column =
+              DeviceColumn(deviceId = deviceId.value, name = "Pixel", platform = Platform.Android),
+            observationStreamFactory = { id -> streams.getOrPut(id) { FakeObservationStream() } },
+          )
+        }
+      }
+    }
+    waitForIdle()
+    assertEquals(1, streams.getValue("dev-1").connectCallCount)
+
+    runOnIdle { deviceId.value = "dev-2" }
+    waitForIdle()
+
+    // Old stream disposed, new stream connected to the new device.
+    assertTrue(streams.getValue("dev-1").disconnectCallCount >= 1)
+    assertEquals(1, streams.getValue("dev-2").connectCallCount)
+    assertEquals("dev-2", streams.getValue("dev-2").lastConnectedDeviceId)
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
@@ -7,10 +7,14 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
 import dev.jasonpearson.automobile.desktop.core.daemon.FakeObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.NavigationGraphStreamUpdate
 import dev.jasonpearson.automobile.desktop.core.daemon.NavigationNodeData
+import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceFactory
+import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
 import dev.jasonpearson.automobile.desktop.core.datasource.DefaultDataSourceFactory
+import dev.jasonpearson.automobile.desktop.core.datasource.NavigationDataSource
 import dev.jasonpearson.automobile.desktop.core.di.AutoMobileGraphProvider
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
 import dev.jasonpearson.automobile.desktop.core.settings.FakeSettingsProvider
@@ -22,13 +26,34 @@ import org.junit.Test
 @OptIn(ExperimentalTestApi::class)
 class NavigationFacetTest {
 
+  /**
+   * [DataSourceFactory] that counts navigation-data-source creations, delegating everything else. A
+   * non-zero count means the dashboard ran its active-device fetch path — which a stream-only facet
+   * must never do.
+   */
+  private class CountingNavigationFactory(private val delegate: DataSourceFactory) :
+    DataSourceFactory by delegate {
+    var navigationDataSourceCreations = 0
+      private set
+
+    override fun createNavigationDataSource(
+      mode: DataSourceMode,
+      clientProvider: (() -> AutoMobileClient)?,
+      appId: String?,
+      cacheTtlMs: Long,
+    ): NavigationDataSource {
+      navigationDataSourceCreations++
+      return delegate.createNavigationDataSource(mode, clientProvider, appId, cacheTtlMs)
+    }
+  }
+
   /** In-memory graph so the dashboard's data-source load hits a fake client, never a socket. */
-  private fun testGraph(): AutoMobileGraphProvider {
+  private fun testGraph(factory: DataSourceFactory? = null): AutoMobileGraphProvider {
     val client = FakeAutoMobileClient()
     return object : AutoMobileGraphProvider {
       override val autoMobileClient = client
       override val settingsProvider = FakeSettingsProvider()
-      override val dataSourceFactory = DefaultDataSourceFactory(client)
+      override val dataSourceFactory = factory ?: DefaultDataSourceFactory(client)
     }
   }
 
@@ -131,4 +156,32 @@ class NavigationFacetTest {
     assertEquals(1, streams.getValue("dev-2").connectCallCount)
     assertEquals("dev-2", streams.getValue("dev-2").lastConnectedDeviceId)
   }
+
+  @Test
+  fun `never queries the active-device data source, even during the on-mount window`() =
+    runComposeUiTest {
+      val factory = CountingNavigationFactory(DefaultDataSourceFactory(FakeAutoMobileClient()))
+      setContent {
+        CompositionLocalProvider(LocalAutoMobileGraph provides testGraph(factory)) {
+          MaterialTheme {
+            NavigationFacet(
+              column =
+                DeviceColumn(deviceId = "dev-1", name = "Pixel", platform = Platform.Android),
+              observationStreamFactory = { FakeObservationStream() },
+            )
+          }
+        }
+      }
+      waitForIdle()
+
+      // The facet attaches its stream via DisposableEffect AFTER first composition, so on mount
+      // observationStreamClient is still null. A count > 0 would mean the dashboard fell back to
+      // the active-device fetch during that window (the old stream-presence gate) — briefly showing
+      // the wrong device's graph. Gating on streamOnly directly keeps this at 0.
+      assertEquals(
+        "stream-only facet must never create the active-device navigation data source",
+        0,
+        factory.navigationDataSourceCreations,
+      )
+    }
 }


### PR DESCRIPTION
Adds the 🧭 Navigation facet — a per-device docked tool window wrapping `NavigationDashboard`, driven per pane via an injected `ObservationStream` (`connect(deviceId)` + `requestNavigationGraph`), mirroring `LogsFacet`. Part of the facet build-out ([#4715](https://github.com/kaeawc/auto-mobile/issues/4715)); built in parallel with Performance/Layout.

## Changes
- `NavigationFacet.kt` (+ test) — per-device `ObservationStream` factory (default real), `DisposableEffect` connect/dispose, renders `NavigationDashboard` with a remembered `clientProvider`/`screenshotLoader` and `selectedAppId = null` (stream's foreground-app logic drives the graph).
- `NavigationDashboard.kt` — retyped `observationStreamClient` to the `ObservationStream` interface (mechanical; existing `AutoMobileContent` callers pass the concrete subtype, no cascade).

## Validation
- `:desktop-core:detektMain` + `:desktop-core:test` (3 Compose tests: connect+requestNavigationGraph per device, stream-emitted node renders, reconnect-on-device-change) + `compileKotlin` — green.

## Note
Host wiring lands in the combined host PR (Navigation/Performance/Layout) to avoid parallel conflicts on `WorkspaceFacet`.