### PR TITLE
fix(ios): remove dead simctl recordVideo branch from PlatformVideoCaptureBackend

### DIFF
--- a/src/features/video/PlatformVideoCaptureBackend.ts
+++ b/src/features/video/PlatformVideoCaptureBackend.ts
@@ -1,20 +1,12 @@
-import path from "node:path";
-import { promises as fsPromises } from "node:fs";
-import { pathExists } from "../../utils/filesystem/DefaultFileSystem";
 import { ActionableError, BootedDevice } from "../../models";
 import { defaultTimer } from "../../utils/SystemTimer";
 import type { Timer } from "../../utils/SystemTimer";
 import { defaultAdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbClientFactory } from "../../utils/android-cmdline-tools/AdbClientFactory";
-import { SimCtlClient, type SimCtl } from "../../utils/ios-cmdline-tools/SimCtlClient";
 import { logger } from "../../utils/logger";
-import { DefaultFfmpegClient, type FfmpegClient } from "../../utils/media/FfmpegClient";
 import {
   createExitTracker,
   getFileSize,
-  PROCESS_EXIT_TIMEOUT_MS,
-  waitForExit,
-  waitForSpawn,
   type ProcessExitState,
   type TrackedChildProcess,
 } from "../../utils/ChildProcessTracker";
@@ -26,8 +18,6 @@ import type {
 } from "./VideoRecorderService";
 import { ANDROID_SCREENRECORD_MAX_SECONDS } from "./androidScreenrecord";
 
-const FFMPEG_SCALE_TIMEOUT_MS = 60_000;
-
 interface AndroidBackendHandle {
   kind: "android";
   process: TrackedChildProcess;
@@ -38,18 +28,7 @@ interface AndroidBackendHandle {
   deviceTempPath: string;
 }
 
-interface IosBackendHandle {
-  kind: "ios";
-  process: TrackedChildProcess;
-  exitState: ProcessExitState;
-  exitPromise: Promise<void>;
-  stderr: string[];
-  rawOutputPath: string;
-  outputPath: string;
-  resolution?: { width: number; height: number };
-}
-
-type BackendHandle = AndroidBackendHandle | IosBackendHandle;
+type BackendHandle = AndroidBackendHandle;
 
 export function clampBitrateKbps(config: VideoCaptureConfig): number {
   const maxBitrateKbps = Math.max(0, Math.floor(config.maxThroughputMbps * 1000));
@@ -60,12 +39,23 @@ export function clampBitrateKbps(config: VideoCaptureConfig): number {
   return Math.min(config.targetBitrateKbps, maxBitrateKbps);
 }
 
+/**
+ * Platform-native video capture backend.
+ *
+ * Android recordings use `adb shell screenrecord` on the device. iOS recordings
+ * are intentionally NOT handled here: {@link HybridVideoCaptureBackend} routes
+ * every iOS device to `FfmpegVideoProcessingBackend`, whose `startIos` drives
+ * `simctl … recordVideo` with the SIGINT + moov-atom flush + materialization wait
+ * that a robust iOS capture needs. The former platform-native `simctl recordVideo`
+ * branch here spawned the recorder with all stdio ignored, so a failed recording
+ * surfaced only an exit code with no stderr to diagnose it — and it was unreachable
+ * in production. It was removed rather than hardened (issue #4773); iOS callers are
+ * rejected explicitly so a future mis-wire fails loudly instead of silently.
+ */
 export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
   constructor(
     private readonly adbFactory: AdbClientFactory = defaultAdbClientFactory,
     private readonly timer: Timer = defaultTimer,
-    private readonly simctlFactory: (device: BootedDevice) => SimCtl = device => new SimCtlClient(device),
-    private readonly ffmpegClient: FfmpegClient = new DefaultFfmpegClient(),
   ) {}
 
   async start(config: VideoCaptureConfig): Promise<RecordingHandle> {
@@ -79,7 +69,10 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
     }
 
     if (device.platform === "ios") {
-      return this.startIos(device, config);
+      throw new ActionableError(
+        "iOS video recording is not handled by PlatformVideoCaptureBackend. " +
+          "Route iOS devices through FfmpegVideoProcessingBackend (HybridVideoCaptureBackend does this automatically)."
+      );
     }
 
     throw new ActionableError(`Unsupported platform for video recording: ${device.platform}`);
@@ -87,120 +80,107 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
 
   async stop(handle: RecordingHandle): Promise<RecordingResult> {
     const backendHandle = handle.backendHandle as BackendHandle | undefined;
-    if (!backendHandle) {
+    if (!backendHandle || backendHandle.kind !== "android") {
       throw new Error("Missing backend handle for video recording.");
     }
 
     logger.info(`[VideoCapture] Stopping recording ${handle.recordingId}`);
 
-    if (backendHandle.kind === "android") {
-      // Stop screenrecord on the *device* with SIGINT first. If we only SIGINT the host
-      // `adb shell screenrecord` process, ADB can drop the session before the device writes
-      // the MP4 moov atom — leading to tiny/corrupt files that show a single frozen frame.
-      // NOTE: pkill -2 signals *all* screenrecord processes on the device. This is fine for
-      // single-recording usage but would interfere with concurrent recordings on the same device.
-      const adbForStop = this.adbFactory.create(backendHandle.device);
-      try {
-        const pk = await adbForStop.executeCommand("shell pkill -2 screenrecord", 8000);
-        logger.info(
-          `[VideoCapture] Device pkill -2 screenrecord completed (out=${pk.stdout.trim().slice(0, 120)} err=${pk.stderr.trim().slice(0, 160)})`
-        );
-      } catch (error) {
-        logger.warn(
-          `[VideoCapture] Device-side pkill -2 screenrecord failed; will rely on host SIGINT: ${error instanceof Error ? error.message : String(error)}`
-        );
-      }
-
-      // Wait for the host adb process to exit now that remote screenrecord should have finalized
-      const gracefulExitTimeout = 10000;
-      let timeoutId: NodeJS.Timeout | undefined;
-      const timeoutPromise = new Promise<void>(resolve => {
-        timeoutId = this.timer.setTimeout(() => {
-          if (backendHandle.process.exitCode === null && !backendHandle.process.killed) {
-            logger.info(`[VideoCapture] Sending SIGINT to host adb after pkill wait`);
-            backendHandle.process.kill("SIGINT");
-          }
-          resolve();
-        }, gracefulExitTimeout);
-      });
-
-      await Promise.race([backendHandle.exitPromise, timeoutPromise]);
-      if (timeoutId) {
-        // Disarm through the injected timer, not the global clearTimeout. Once
-        // the host adb has exited the 10 s SIGINT callback is stale; leaving it
-        // armed (as global clearTimeout would, since the handle came from
-        // this.timer.setTimeout) fires a SIGINT after the recording finished
-        // (issue #4170).
-        this.timer.clearTimeout(timeoutId);
-      }
-
-      if (backendHandle.process.exitCode === null && !backendHandle.process.killed) {
-        logger.warn(`[VideoCapture] screenrecord still running after SIGINT; sending SIGKILL`);
-        backendHandle.process.kill("SIGKILL");
-        await backendHandle.exitPromise;
-      } else {
-        await backendHandle.exitPromise;
-      }
-
-      logger.info(`[VideoCapture] Process exited with code: ${backendHandle.exitState.exitCode}, signal: ${backendHandle.exitState.signal}`);
-
-      // Give screenrecord extra time to finalize the file on device
-      // Even though the process has exited, file writes may still be in progress
-      logger.info(`[VideoCapture] Waiting 1 second for file to finalize on device`);
-      await this.timer.sleep(1000);
-    } else {
-      await waitForExit(backendHandle.process, backendHandle.exitPromise, {
-        timeoutMs: PROCESS_EXIT_TIMEOUT_MS,
-      });
+    // Stop screenrecord on the *device* with SIGINT first. If we only SIGINT the host
+    // `adb shell screenrecord` process, ADB can drop the session before the device writes
+    // the MP4 moov atom — leading to tiny/corrupt files that show a single frozen frame.
+    // NOTE: pkill -2 signals *all* screenrecord processes on the device. This is fine for
+    // single-recording usage but would interfere with concurrent recordings on the same device.
+    const adbForStop = this.adbFactory.create(backendHandle.device);
+    try {
+      const pk = await adbForStop.executeCommand("shell pkill -2 screenrecord", 8000);
       logger.info(
-        `[VideoCapture] Process exited with code: ${backendHandle.exitState.exitCode}, signal: ${backendHandle.exitState.signal}`
+        `[VideoCapture] Device pkill -2 screenrecord completed (out=${pk.stdout.trim().slice(0, 120)} err=${pk.stderr.trim().slice(0, 160)})`
+      );
+    } catch (error) {
+      logger.warn(
+        `[VideoCapture] Device-side pkill -2 screenrecord failed; will rely on host SIGINT: ${error instanceof Error ? error.message : String(error)}`
       );
     }
 
-    if (backendHandle.kind === "android") {
-      // Pull the file from the device
-      logger.info(`[VideoCapture] Pulling file from device: ${backendHandle.deviceTempPath} -> ${handle.outputPath}`);
-      const adb = this.adbFactory.create(backendHandle.device);
-      const pullArgs = ["pull", backendHandle.deviceTempPath, handle.outputPath];
-      try {
-        const pullProcess = await adb.spawn(pullArgs);
-
-        await new Promise<void>((resolve, reject) => {
-          pullProcess.once("exit", code => {
-            if (code === 0) {
-              logger.info(`[VideoCapture] File pulled successfully`);
-              resolve();
-            } else {
-              reject(new Error(`adb pull failed with exit code ${code}`));
-            }
-          });
-          pullProcess.once("error", err => reject(err));
-        });
-      } finally {
-        // Always clean up the /sdcard temp file, even when the pull failed —
-        // otherwise a failed pull leaks the temp recording on the device on
-        // every stop (issue #4170).
-        logger.info(`[VideoCapture] Cleaning up temp file on device`);
-        const rmArgs = ["shell", "rm", backendHandle.deviceTempPath];
-        try {
-          const rmProcess = await adb.spawn(rmArgs);
-
-          await new Promise<void>(resolve => {
-            rmProcess.once("exit", () => {
-              logger.info(`[VideoCapture] Temp file cleaned up`);
-              resolve();
-            });
-            rmProcess.once("error", err => {
-              logger.warn(`[VideoCapture] Failed to clean up temp file: ${err}`);
-              resolve();
-            });
-          });
-        } catch (err) {
-          logger.warn(`[VideoCapture] Failed to clean up temp file: ${err}`);
+    // Wait for the host adb process to exit now that remote screenrecord should have finalized
+    const gracefulExitTimeout = 10000;
+    let timeoutId: NodeJS.Timeout | undefined;
+    const timeoutPromise = new Promise<void>(resolve => {
+      timeoutId = this.timer.setTimeout(() => {
+        if (backendHandle.process.exitCode === null && !backendHandle.process.killed) {
+          logger.info(`[VideoCapture] Sending SIGINT to host adb after pkill wait`);
+          backendHandle.process.kill("SIGINT");
         }
-      }
+        resolve();
+      }, gracefulExitTimeout);
+    });
+
+    await Promise.race([backendHandle.exitPromise, timeoutPromise]);
+    if (timeoutId) {
+      // Disarm through the injected timer, not the global clearTimeout. Once
+      // the host adb has exited the 10 s SIGINT callback is stale; leaving it
+      // armed (as global clearTimeout would, since the handle came from
+      // this.timer.setTimeout) fires a SIGINT after the recording finished
+      // (issue #4170).
+      this.timer.clearTimeout(timeoutId);
+    }
+
+    if (backendHandle.process.exitCode === null && !backendHandle.process.killed) {
+      logger.warn(`[VideoCapture] screenrecord still running after SIGINT; sending SIGKILL`);
+      backendHandle.process.kill("SIGKILL");
+      await backendHandle.exitPromise;
     } else {
-      await this.finalizeIosRecording(backendHandle);
+      await backendHandle.exitPromise;
+    }
+
+    logger.info(`[VideoCapture] Process exited with code: ${backendHandle.exitState.exitCode}, signal: ${backendHandle.exitState.signal}`);
+
+    // Give screenrecord extra time to finalize the file on device
+    // Even though the process has exited, file writes may still be in progress
+    logger.info(`[VideoCapture] Waiting 1 second for file to finalize on device`);
+    await this.timer.sleep(1000);
+
+    // Pull the file from the device
+    logger.info(`[VideoCapture] Pulling file from device: ${backendHandle.deviceTempPath} -> ${handle.outputPath}`);
+    const adb = this.adbFactory.create(backendHandle.device);
+    const pullArgs = ["pull", backendHandle.deviceTempPath, handle.outputPath];
+    try {
+      const pullProcess = await adb.spawn(pullArgs);
+
+      await new Promise<void>((resolve, reject) => {
+        pullProcess.once("exit", code => {
+          if (code === 0) {
+            logger.info(`[VideoCapture] File pulled successfully`);
+            resolve();
+          } else {
+            reject(new Error(`adb pull failed with exit code ${code}`));
+          }
+        });
+        pullProcess.once("error", err => reject(err));
+      });
+    } finally {
+      // Always clean up the /sdcard temp file, even when the pull failed —
+      // otherwise a failed pull leaks the temp recording on the device on
+      // every stop (issue #4170).
+      logger.info(`[VideoCapture] Cleaning up temp file on device`);
+      const rmArgs = ["shell", "rm", backendHandle.deviceTempPath];
+      try {
+        const rmProcess = await adb.spawn(rmArgs);
+
+        await new Promise<void>(resolve => {
+          rmProcess.once("exit", () => {
+            logger.info(`[VideoCapture] Temp file cleaned up`);
+            resolve();
+          });
+          rmProcess.once("error", err => {
+            logger.warn(`[VideoCapture] Failed to clean up temp file: ${err}`);
+            resolve();
+          });
+        });
+      } catch (err) {
+        logger.warn(`[VideoCapture] Failed to clean up temp file: ${err}`);
+      }
     }
 
     const sizeBytes = await getFileSize(handle.outputPath);
@@ -290,145 +270,11 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
     };
   }
 
-  private async startIos(
-    device: BootedDevice,
-    config: VideoCaptureConfig
-  ): Promise<RecordingHandle> {
-    const simctl = this.simctlFactory(device);
-    const available = await simctl.isAvailable();
-    if (!available) {
-      throw new ActionableError("simctl is not available. Install Xcode command line tools.");
-    }
-
-    const rawOutputPath = config.resolution
-      ? path.join(config.outputDirectory, `raw-${config.fileName}`)
-      : config.outputPath;
-
-    const args = [
-      "io",
-      device.deviceId,
-      "recordVideo",
-      "--codec",
-      "h264",
-      "--force",
-      rawOutputPath,
-    ];
-
-    const process = await simctl.startCommandArgs(args, { stdio: ["ignore", "ignore", "ignore"] });
-
-    try {
-      await waitForSpawn(process);
-    } catch (error) {
-      throw new ActionableError(`Failed to start iOS recording: ${error}`);
-    }
-
-    const stderr: string[] = [];
-    const { exitState, exitPromise } = createExitTracker(process, stderr);
-
-    const backendHandle: IosBackendHandle = {
-      kind: "ios",
-      process,
-      exitState,
-      exitPromise,
-      stderr,
-      rawOutputPath,
-      outputPath: config.outputPath,
-      resolution: config.resolution,
-    };
-
-    return {
-      recordingId: config.recordingId,
-      outputPath: config.outputPath,
-      startedAt: config.startedAt,
-      backendHandle,
-    };
-  }
-
   private resolveAndroidTimeLimit(maxDurationSeconds?: number): number {
     if (maxDurationSeconds && maxDurationSeconds > 0) {
       return Math.min(maxDurationSeconds, ANDROID_SCREENRECORD_MAX_SECONDS);
     }
 
     return ANDROID_SCREENRECORD_MAX_SECONDS;
-  }
-
-  private async finalizeIosRecording(handle: IosBackendHandle): Promise<void> {
-    const needsScale = Boolean(handle.resolution);
-    if (!needsScale) {
-      if (handle.rawOutputPath !== handle.outputPath) {
-        await this.replaceOutputFile(handle.rawOutputPath, handle.outputPath);
-      }
-      return;
-    }
-
-    const resolution = handle.resolution!;
-    const ffmpegAvailable = await this.isFfmpegAvailable();
-    if (!ffmpegAvailable) {
-      logger.warn("[VideoCapture] FFmpeg not available; keeping original iOS recording.");
-      await this.replaceOutputFile(handle.rawOutputPath, handle.outputPath);
-      return;
-    }
-
-    try {
-      await this.scaleWithFfmpeg(handle.rawOutputPath, handle.outputPath, resolution);
-      await fsPromises.rm(handle.rawOutputPath, { recursive: true, force: true });
-    } catch (error) {
-      logger.warn(`[VideoCapture] Failed to scale iOS recording: ${error}`);
-      await this.replaceOutputFile(handle.rawOutputPath, handle.outputPath);
-    }
-  }
-
-  private async replaceOutputFile(sourcePath: string, destinationPath: string): Promise<void> {
-    if (sourcePath === destinationPath) {
-      return;
-    }
-
-    const sourceExists = await pathExists(sourcePath);
-    if (!sourceExists) {
-      logger.warn(`[VideoCapture] Missing iOS recording at ${sourcePath}`);
-      return;
-    }
-
-    await fsPromises.rm(destinationPath, { recursive: true, force: true });
-    await fsPromises.rename(sourcePath, destinationPath);
-  }
-
-  private async isFfmpegAvailable(): Promise<boolean> {
-    try {
-      await this.ffmpegClient.probe();
-      return true;
-    } catch (error) {
-      logger.debug(`[PlatformVideoCaptureBackend] FFmpeg probe failed; preserving the original recording: ${error instanceof Error ? error.message : String(error)}`);
-      return false;
-    }
-  }
-
-  private async scaleWithFfmpeg(
-    inputPath: string,
-    outputPath: string,
-    resolution: { width: number; height: number }
-  ): Promise<void> {
-    const args = [
-      "-y",
-      "-i",
-      inputPath,
-      "-vf",
-      `scale=${resolution.width}:${resolution.height}`,
-      "-c:v",
-      "libx264",
-      "-preset",
-      "veryfast",
-      "-pix_fmt",
-      "yuv420p",
-      "-movflags",
-      "+faststart",
-      outputPath,
-    ];
-    await this.ffmpegClient.run({
-      args,
-      context: "iOS recording scale",
-      stdio: ["ignore", "pipe", "pipe"],
-      timeoutMs: FFMPEG_SCALE_TIMEOUT_MS,
-    });
   }
 }

--- a/test/features/video/PlatformVideoCaptureBackend.test.ts
+++ b/test/features/video/PlatformVideoCaptureBackend.test.ts
@@ -8,7 +8,6 @@ import type {
   VideoCaptureConfig,
 } from "../../../src/features/video/VideoRecorderService";
 import type { BootedDevice } from "../../../src/models";
-import type { SimCtl } from "../../../src/utils/ios-cmdline-tools/SimCtlClient";
 import { FakeAdbClientFactory } from "../../fakes/FakeAdbClientFactory";
 import { FakeChildProcess } from "../../fakes/FakeChildProcess";
 import { FakeTimer } from "../../fakes/FakeTimer";
@@ -16,26 +15,6 @@ import { FakeTimer } from "../../fakes/FakeTimer";
 describe("PlatformVideoCaptureBackend - Unit Tests", () => {
   let backend: PlatformVideoCaptureBackend;
   let tempDir: string;
-
-  test("gives iOS FFmpeg scaling a bounded media-processing timeout", async () => {
-    let request: { timeoutMs?: number } | undefined;
-    const ffmpegClient = {
-      run: async (value: { timeoutMs?: number }) => {
-        request = value;
-        return { stdout: "", stderr: "", exitCode: 0, signal: null };
-      },
-    };
-    const backend = new PlatformVideoCaptureBackend(
-      undefined,
-      undefined,
-      undefined,
-      ffmpegClient as any,
-    );
-
-    await (backend as any).scaleWithFfmpeg("/tmp/input.mov", "/tmp/output.mp4", { width: 1280, height: 720 });
-
-    expect(request?.timeoutMs).toBeGreaterThan(5_000);
-  });
 
   beforeEach(async () => {
     backend = new PlatformVideoCaptureBackend();
@@ -100,30 +79,22 @@ describe("PlatformVideoCaptureBackend - Unit Tests", () => {
     });
   });
 
-  test("starts iOS recording through the injected SimCtl argv boundary", async () => {
-    const process = new FakeChildProcess();
-    process.simulateSpawn();
-    let receivedArgs: string[] = [];
-    let receivedOptions: unknown;
-    const simctl = {
-      isAvailable: async () => true,
-      startCommandArgs: async (args: string[], options?: unknown) => {
-        receivedArgs = args;
-        receivedOptions = options;
-        return process as any;
-      },
-    } as SimCtl;
-    backend = new PlatformVideoCaptureBackend(undefined, undefined, () => simctl);
+  // The platform-native `simctl recordVideo` branch was unreachable dead code:
+  // HybridVideoCaptureBackend routes every iOS device to FfmpegVideoProcessingBackend.
+  // The dead branch spawned the recorder with all stdio ignored, so a failed capture
+  // surfaced only an exit code with no stderr to diagnose it. It was removed (issue
+  // #4773); iOS callers are now rejected explicitly so a future mis-wire fails loudly
+  // instead of silently, and the error points at the correct backend.
+  test("rejects iOS recording and points at the ffmpeg backend (issue #4773)", async () => {
     const device: BootedDevice = { platform: "ios", deviceId: "ios-platform-udid", name: "iPhone" };
 
-    await backend.start({
-      recordingId: "recording", outputDirectory: tempDir, outputPath: path.join(tempDir, "video.mp4"),
-      fileName: "video.mp4", startedAt: new Date().toISOString(), qualityPreset: "low", targetBitrateKbps: 1000,
-      maxThroughputMbps: 5, fps: 15, maxArchiveSizeMb: 2048, format: "mp4", device,
-    });
-
-    expect(receivedArgs).toEqual(["io", "ios-platform-udid", "recordVideo", "--codec", "h264", "--force", path.join(tempDir, "video.mp4")]);
-    expect(receivedOptions).toEqual({ stdio: ["ignore", "ignore", "ignore"] });
+    await expect(
+      backend.start({
+        recordingId: "recording", outputDirectory: tempDir, outputPath: path.join(tempDir, "video.mp4"),
+        fileName: "video.mp4", startedAt: new Date().toISOString(), qualityPreset: "low", targetBitrateKbps: 1000,
+        maxThroughputMbps: 5, fps: 15, maxArchiveSizeMb: 2048, format: "mp4", device,
+      })
+    ).rejects.toThrow(/FfmpegVideoProcessingBackend/);
   });
 
   describe("Stop Operation", () => {


### PR DESCRIPTION
Closes [#4773](https://github.com/kaeawc/auto-mobile/issues/4773)

## Dead-or-alive determination

The iOS branch of `PlatformVideoCaptureBackend` is **dead code at runtime**.

- The only runtime construction of `PlatformVideoCaptureBackend` is as the default
  `platformBackend` of `HybridVideoCaptureBackend`
  (`src/features/video/HybridVideoCaptureBackend.ts`).
- `HybridVideoCaptureBackend.selectBackend` routes **every** iOS device to
  `FfmpegVideoProcessingBackend` (the robust path: SIGINT + moov-atom flush +
  materialization wait). Android is the only platform ever handed to
  `PlatformVideoCaptureBackend`, and the Android-with-ffmpeg-pipe opt-in also goes
  to the ffmpeg backend.
- `VideoRecorderService` is backend-agnostic (it just delegates), and
  `videoRecordingManager` only ever builds a `HybridVideoCaptureBackend`.

So `PlatformVideoCaptureBackend.startIos` was reachable only from its own unit
tests — never from the MCP `startVideoRecording` tool. The live iOS implementation
is `FfmpegVideoProcessingBackend.startIos`.

## Change

Per the issue's preferred remedy for a confirmed-dead branch, I removed it rather
than hardening it:

- Deleted the iOS branch (`startIos`) and its iOS-only scaffolding that nothing else
  used: `finalizeIosRecording`, `scaleWithFfmpeg`, `isFfmpegAvailable`,
  `replaceOutputFile`, the `IosBackendHandle` type, and the now-unused
  `simctlFactory` / `ffmpegClient` constructor parameters (and their imports).
- `PlatformVideoCaptureBackend` is now Android-only. iOS callers are **rejected
  explicitly** with an `ActionableError` pointing at `FfmpegVideoProcessingBackend`,
  so a future mis-wire fails loudly instead of silently swallowing stderr behind
  `stdio: ["ignore","ignore","ignore"]`.
- iOS routing through the ffmpeg backend stays explicit in
  `HybridVideoCaptureBackend.selectBackend` (unchanged) and is covered by the
  existing `HybridVideoCaptureBackend` test "routes iOS recording to ffmpeg backend".

This also removes the diagnostic gap the issue describes: there is no longer a
path where a failed `recordVideo` yields only an exit code with no stderr.

## Tests

- Replaced the two tests that exercised the dead iOS path (the `simctl` argv
  boundary test and the `scaleWithFfmpeg` timeout test) with a test asserting
  `PlatformVideoCaptureBackend.start` rejects an iOS device and the error names the
  correct backend.
- All Android stop-sequence, clamp, and time-limit tests are unchanged and pass.

## Validation

- `bun run typecheck` — no new type errors (198 known baseline).
- `turbo run lint build test` — lint + build clean; 12082 pass / 0 fail / 13 skip.
