### PR TITLE
fix(webrtc): bound blocking ADB and socket calls in the persistent video-server lifecycle

### DIFF
--- a/src/features/webrtc/PersistentEncoderH264Source.ts
+++ b/src/features/webrtc/PersistentEncoderH264Source.ts
@@ -40,6 +40,18 @@ export const VIDEO_SERVER_COMMAND_REQUEST_KEY_FRAME = 0x01;
 /** Retry a replaced local ADB socket without tearing down the device encoder. */
 export const DEFAULT_LOCAL_SOCKET_RECONNECT_WINDOW_MS = 5_000;
 export const DEFAULT_LOCAL_SOCKET_RECONNECT_RETRY_MS = 100;
+/**
+ * Bounded time for a blocking launch-path ADB/socket call (push, forward, spawn,
+ * initial connect). A wedged ADB/USB state must degrade to screenrecord, not hang
+ * the stream lifecycle forever.
+ */
+export const DEFAULT_LAUNCH_COMMAND_TIMEOUT_MS = 20_000;
+/**
+ * Bounded time for a blocking teardown/cleanup ADB call. Teardown is best-effort:
+ * a timeout is logged and skipped so `stop()` always settles and lease
+ * reconciliation handles any orphaned device resources.
+ */
+export const DEFAULT_TEARDOWN_COMMAND_TIMEOUT_MS = 5_000;
 
 /** Minimal socket surface the source needs, for injectable testing. */
 export interface StreamSocket {
@@ -125,6 +137,10 @@ export interface PersistentEncoderH264SourceOptions {
   timer?: Timer;
   /** How long to wait for the server to signal readiness (ms). */
   readyTimeoutMs?: number;
+  /** Bounded time for a blocking launch-path ADB/socket call (ms). */
+  commandTimeoutMs?: number;
+  /** Bounded time for a blocking teardown/cleanup ADB call (ms). */
+  teardownTimeoutMs?: number;
   /** Bounded time to reconnect a dropped local socket before failing the source. */
   localSocketReconnectWindowMs?: number;
   /** Spacing between local socket reconnect attempts. */
@@ -216,6 +232,8 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
   private readonly connector: SocketConnector;
   private readonly timer: Timer;
   private readonly readyTimeoutMs: number;
+  private readonly commandTimeoutMs: number;
+  private readonly teardownTimeoutMs: number;
   private readonly localSocketReconnectWindowMs: number;
   private readonly localSocketReconnectRetryMs: number;
   private readonly sessionTokenFactory: () => string;
@@ -250,6 +268,11 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     this.connector = options.connector ?? defaultConnector;
     this.timer = options.timer ?? defaultTimer;
     this.readyTimeoutMs = options.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS;
+    this.commandTimeoutMs = options.commandTimeoutMs ?? DEFAULT_LAUNCH_COMMAND_TIMEOUT_MS;
+    this.teardownTimeoutMs = options.teardownTimeoutMs ?? DEFAULT_TEARDOWN_COMMAND_TIMEOUT_MS;
+    if (this.commandTimeoutMs <= 0 || this.teardownTimeoutMs <= 0) {
+      throw new ActionableError("Video server command timeouts must be positive milliseconds.");
+    }
     this.localSocketReconnectWindowMs =
       options.localSocketReconnectWindowMs ?? DEFAULT_LOCAL_SOCKET_RECONNECT_WINDOW_MS;
     this.localSocketReconnectRetryMs =
@@ -336,6 +359,45 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     }
   }
 
+  /**
+   * Race `operation` against a deadline driven by the injected `Timer`, so a
+   * wedged ADB/USB state cannot block the persistent-encoder lifecycle forever.
+   * On timeout the returned promise rejects with an `ActionableError`; launch-path
+   * callers let it propagate (falling back to screenrecord) while teardown-path
+   * callers catch it and continue. Deterministic under `FakeTimer` in tests.
+   */
+  private withTimeout<T>(operation: Promise<T>, ms: number, label: string): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      let settled = false;
+      const timeout = this.timer.setTimeout(() => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        logger.warn(`[PersistentEncoderH264Source] ${label} timed out after ${ms}ms`);
+        reject(new ActionableError(`${label} did not complete within ${ms}ms`));
+      }, ms);
+      operation.then(
+        value => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          this.timer.clearTimeout(timeout);
+          resolve(value);
+        },
+        error => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          this.timer.clearTimeout(timeout);
+          reject(error instanceof Error ? error : new Error(String(error)));
+        }
+      );
+    });
+  }
+
   private async launch(): Promise<void> {
     const adb = this.adbFactory.create(this.options.device);
     const port = await this.prepareSession(adb);
@@ -356,10 +418,16 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     this.deviceProcessId = null;
     await this.reconcileExpiredLeases(adb);
     if (!this.running) {return null;}
-    await adb.executeCommand(`push "${this.options.jarPath}" ${VIDEO_SERVER_REMOTE_JAR_PATH}`);
+    await this.withTimeout(
+      adb.executeCommand(`push "${this.options.jarPath}" ${VIDEO_SERVER_REMOTE_JAR_PATH}`),
+      this.commandTimeoutMs,
+      "adb push video-server jar"
+    );
     if (!this.running) {return null;}
-    const forward = await adb.executeCommand(
-      `forward tcp:0 localabstract:${session.socketName}`
+    const forward = await this.withTimeout(
+      adb.executeCommand(`forward tcp:0 localabstract:${session.socketName}`),
+      this.commandTimeoutMs,
+      "adb forward video-server socket"
     );
     const port = Number.parseInt(forward.stdout.trim(), 10);
     if (!Number.isInteger(port) || port <= 0) {
@@ -378,7 +446,11 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
   private async spawnAndWaitForServer(
     adb: ReturnType<AdbClientFactory["create"]>
   ): Promise<AdbProcess | null> {
-    const server = await adb.spawn(this.buildServerArgs());
+    const server = await this.withTimeout(
+      adb.spawn(this.buildServerArgs()),
+      this.commandTimeoutMs,
+      "adb spawn video-server"
+    );
     if (!this.running) {
       server.kill("SIGINT");
       return null;
@@ -407,7 +479,12 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     // the marker in the gap between client connect and the later startup await.
     streamingStarted?.catch(() => {});
 
-    const connection = this.connector(port);
+    // Give the first connect the same deadline+abort treatment the reconnect path
+    // uses. A half-open forward with a live server would otherwise hang here
+    // forever (the race below only settles on server failure, not a stuck connect).
+    const connectController = new AbortController();
+    const connectDeadline = this.timer.now() + this.commandTimeoutMs;
+    const connection = this.connectBeforeDeadline(port, connectDeadline, connectController.signal);
     let connectionWon = false;
     let rejectServerFailure!: (error: Error) => void;
     const serverFailure = new Promise<never>((_, reject) => {
@@ -467,7 +544,10 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
       server.removeListener("exit", onServerExit);
       server.removeListener("error", onServerError);
       if (!connectionWon) {
-        void connection.then(socket => socket.destroy(), () => {});
+        // Server failure (or teardown) won the race: cancel the bounded connect
+        // so a late-resolving local socket is destroyed rather than leaked.
+        connectController.abort();
+        void connection.catch(() => {});
       }
       if (this.serverStartupInProgress === server) {
         this.serverStartupInProgress = null;
@@ -996,7 +1076,11 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
       const leaseListCommand =
         `for f in ${VIDEO_SERVER_LEASE_DIRECTORY}/*.json; do ` +
         '[ -f "$f" ] || continue; cat "$f"; printf "\\n"; done';
-      const result = await adb.executeCommand(`shell sh -c ${shellQuote(leaseListCommand)}`);
+      const result = await this.withTimeout(
+        adb.executeCommand(`shell sh -c ${shellQuote(leaseListCommand)}`),
+        this.teardownTimeoutMs,
+        "adb read video session leases"
+      );
       leases = parseLeases(result.stdout);
     } catch (error) {
       logger.debug(`[PersistentEncoderH264Source] unable to read video session leases: ${error}`);
@@ -1090,7 +1174,11 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     token: string
   ): Promise<VideoServerLease | null> {
     try {
-      const result = await adb.executeCommand(`shell cat ${VIDEO_SERVER_LEASE_DIRECTORY}/${token}.json`);
+      const result = await this.withTimeout(
+        adb.executeCommand(`shell cat ${VIDEO_SERVER_LEASE_DIRECTORY}/${token}.json`),
+        this.teardownTimeoutMs,
+        "adb read owned video session lease"
+      );
       return parseLeases(result.stdout).find(lease => lease.token === token) ?? null;
     } catch (error) {
       logger.debug(`[PersistentEncoderH264Source] unable to read owned video session lease: ${error}`);
@@ -1103,7 +1191,11 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     lease: VideoServerLease
   ): Promise<void> {
     try {
-      const commandLine = await adb.executeCommand(`shell cat /proc/${lease.pid}/cmdline`);
+      const commandLine = await this.withTimeout(
+        adb.executeCommand(`shell cat /proc/${lease.pid}/cmdline`),
+        this.teardownTimeoutMs,
+        "adb read video-server process cmdline"
+      );
       const argv = commandLine.stdout.split("\u0000");
       const ownsSession = argv.some(
         (argument, index) =>
@@ -1118,7 +1210,11 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
         );
         return;
       }
-      await adb.executeCommand(`shell kill -2 ${lease.pid}`);
+      await this.withTimeout(
+        adb.executeCommand(`shell kill -2 ${lease.pid}`),
+        this.teardownTimeoutMs,
+        "adb terminate video-server process"
+      );
     } catch (error) {
       logger.debug(
         `[PersistentEncoderH264Source] stale-session process cleanup skipped token=${lease.token}: ${error}`
@@ -1132,7 +1228,11 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     socketName: string
   ): Promise<void> {
     try {
-      const listed = await adb.executeCommand("forward --list");
+      const listed = await this.withTimeout(
+        adb.executeCommand("forward --list"),
+        this.teardownTimeoutMs,
+        "adb forward --list"
+      );
       const expectedPort = `tcp:${port}`;
       const expectedDestination = `localabstract:${socketName}`;
       const matches = listed.stdout.split(/\r?\n/).some(line => {
@@ -1145,7 +1245,11 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
         );
         return;
       }
-      await adb.executeCommand(`forward --remove tcp:${port}`);
+      await this.withTimeout(
+        adb.executeCommand(`forward --remove tcp:${port}`),
+        this.teardownTimeoutMs,
+        "adb forward --remove"
+      );
     } catch (error) {
       logger.debug(`[PersistentEncoderH264Source] forward --remove failed: ${error}`);
     }
@@ -1164,7 +1268,11 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
       return;
     }
     try {
-      await adb.executeCommand(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/${lease.token}.json`);
+      await this.withTimeout(
+        adb.executeCommand(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/${lease.token}.json`),
+        this.teardownTimeoutMs,
+        "adb remove video session lease"
+      );
     } catch (error) {
       logger.debug(`[PersistentEncoderH264Source] stale-session lease cleanup failed: ${error}`);
     }
@@ -1198,7 +1306,11 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     adb: ReturnType<AdbClientFactory["create"]>
   ): Promise<number | null> {
     try {
-      const result = await adb.executeCommand("shell cat /proc/uptime");
+      const result = await this.withTimeout(
+        adb.executeCommand("shell cat /proc/uptime"),
+        this.teardownTimeoutMs,
+        "adb read device uptime"
+      );
       const uptimeSeconds = Number.parseFloat(result.stdout.trim().split(/\s+/, 1)[0] ?? "");
       if (Number.isFinite(uptimeSeconds) && uptimeSeconds >= 0) {
         return Math.floor(uptimeSeconds * 1_000);

--- a/test/features/webrtc/PersistentEncoderH264Source.test.ts
+++ b/test/features/webrtc/PersistentEncoderH264Source.test.ts
@@ -130,43 +130,34 @@ function makeSource(overrides: Record<string, unknown> = {}) {
     (overrides.processCommandLine as string | undefined) ??
     `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--session-token\u0000stale-session`;
 
+  // Command substrings whose ADB call should hang forever, exercising the
+  // injected withTimeout bound under FakeTimer (never a real wait).
+  const hangCommands = (overrides.hangCommands as string[] | undefined) ?? [];
+  const neverResolves = <T>(): Promise<T> => new Promise<T>(() => {});
+
   const adbFactory: AdbClientFactory = {
     create() {
       return {
         getAdbPathOnly: async () => "adb",
-        executeCommand: async (command: string) => {
+        executeCommand: (command: string) => {
           commands.push(command);
+          if (hangCommands.some(sub => command.includes(sub))) {
+            return neverResolves<{ stdout: string; stderr: string; exitCode: number }>();
+          }
           if (command.startsWith("forward tcp:0")) {
             forwardedSocket = command.split("localabstract:")[1] ?? null;
             if (forwardResult) {
               return forwardResult;
             }
-            return { stdout: `${FORWARD_PORT}\n`, stderr: "", exitCode: 0 };
+            return Promise.resolve({ stdout: `${FORWARD_PORT}\n`, stderr: "", exitCode: 0 });
           }
-          if (command === "forward --list") {
-            const stdout =
-              (overrides.forwardListOutput as string | undefined) ??
-              (forwardedSocket
-                ? `${DEVICE.deviceId} tcp:${FORWARD_PORT} localabstract:${forwardedSocket}\n`
-                : "");
-            return { stdout, stderr: "", exitCode: 0 };
-          }
-          if (command.includes(`for f in ${VIDEO_SERVER_LEASE_DIRECTORY}/*.json`)) {
-            return { stdout: leaseOutput, stderr: "", exitCode: 0 };
-          }
-          if (command.startsWith(`shell cat ${VIDEO_SERVER_LEASE_DIRECTORY}/`)) {
-            return { stdout: leaseOutput, stderr: "", exitCode: 0 };
-          }
-          if (command === "shell cat /proc/uptime") {
-            return { stdout: `${deviceUptimeMs / 1000} 0.00\n`, stderr: "", exitCode: 0 };
-          }
-          if (command.startsWith("shell cat /proc/")) {
-            return { stdout: processCommandLine, stderr: "", exitCode: 0 };
-          }
-          return { stdout: "", stderr: "", exitCode: 0 };
+          return Promise.resolve(resolveCommand(command));
         },
         spawn: async (args: string[]) => {
           spawnArgs.push(args);
+          if (overrides.spawnHang === true) {
+            return neverResolves<FakeProcess>();
+          }
           const process = new FakeProcess();
           processes.push(process);
           return process;
@@ -174,6 +165,30 @@ function makeSource(overrides: Record<string, unknown> = {}) {
       } as unknown as ReturnType<AdbClientFactory["create"]>;
     },
   };
+
+  function resolveCommand(command: string): { stdout: string; stderr: string; exitCode: number } {
+    if (command === "forward --list") {
+      const stdout =
+        (overrides.forwardListOutput as string | undefined) ??
+        (forwardedSocket
+          ? `${DEVICE.deviceId} tcp:${FORWARD_PORT} localabstract:${forwardedSocket}\n`
+          : "");
+      return { stdout, stderr: "", exitCode: 0 };
+    }
+    if (command.includes(`for f in ${VIDEO_SERVER_LEASE_DIRECTORY}/*.json`)) {
+      return { stdout: leaseOutput, stderr: "", exitCode: 0 };
+    }
+    if (command.startsWith(`shell cat ${VIDEO_SERVER_LEASE_DIRECTORY}/`)) {
+      return { stdout: leaseOutput, stderr: "", exitCode: 0 };
+    }
+    if (command === "shell cat /proc/uptime") {
+      return { stdout: `${deviceUptimeMs / 1000} 0.00\n`, stderr: "", exitCode: 0 };
+    }
+    if (command.startsWith("shell cat /proc/")) {
+      return { stdout: processCommandLine, stderr: "", exitCode: 0 };
+    }
+    return { stdout: "", stderr: "", exitCode: 0 };
+  }
 
   const connector: SocketConnector = async () => {
     const socket = new FakeSocket();
@@ -1024,5 +1039,80 @@ describe("PersistentEncoderH264Source", () => {
 
     await first.source.stop();
     await second.source.stop();
+  });
+
+  describe("bounded ADB/socket timeouts", () => {
+    const COMMAND_TIMEOUT_MS = 20_000;
+    const TEARDOWN_TIMEOUT_MS = 5_000;
+
+    // Let the pending withTimeout promise register its FakeTimer setTimeout
+    // before advancing fake time, so the deadline actually fires.
+    async function fireTimeout(ctx: ReturnType<typeof makeSource>, ms: number): Promise<void> {
+      await tick();
+      ctx.timer.advanceTime(ms);
+      await tick();
+    }
+
+    async function expectStartRejects(overrides: Record<string, unknown>): Promise<Error> {
+      const ctx = makeSource(overrides);
+      const startPromise = ctx.source.start();
+      const settled = startPromise.then(() => null, error => error as Error);
+      await fireTimeout(ctx, COMMAND_TIMEOUT_MS);
+      const error = await settled;
+      expect(error).toBeInstanceOf(Error);
+      // The source tore itself down so the factory can fall back to screenrecord.
+      expect(ctx.source.isRunning).toBe(false);
+      return error as Error;
+    }
+
+    test("a hung adb push makes start() reject within the launch timeout", async () => {
+      const error = await expectStartRejects({ hangCommands: ["push \""] });
+      expect(error.message).toContain("adb push video-server jar");
+    });
+
+    test("a hung adb forward makes start() reject within the launch timeout", async () => {
+      const error = await expectStartRejects({ forwardResult: new Promise(() => {}) });
+      expect(error.message).toContain("adb forward video-server socket");
+    });
+
+    test("a hung adb spawn makes start() reject within the launch timeout", async () => {
+      const error = await expectStartRejects({ spawnHang: true });
+      expect(error.message).toContain("adb spawn video-server");
+    });
+
+    test("a hung initial socket connect makes start() reject within the launch timeout", async () => {
+      const ctx = makeSource({ connector: (() => new Promise(() => {})) as SocketConnector });
+      const startPromise = ctx.source.start();
+      const settled = startPromise.then(() => null, error => error as Error);
+      await tick(); // push + spawn
+      ctx.processes[0].ready();
+      await tick(); // ready resolves, forward + connect begins (and hangs)
+      ctx.timer.advanceTime(COMMAND_TIMEOUT_MS);
+      await tick();
+      const error = await settled;
+      expect(error).toBeInstanceOf(Error);
+      expect(ctx.source.isRunning).toBe(false);
+    });
+
+    test("a hung teardown command still lets stop() resolve within the timeout", async () => {
+      // readLease's `shell cat <lease>.json` is only hit during cleanup, so it
+      // hangs teardown without affecting the successful start.
+      const ctx = makeSource({
+        hangCommands: [`shell cat ${VIDEO_SERVER_LEASE_DIRECTORY}/${SESSION_TOKEN}.json`],
+      });
+      await startReady(ctx);
+
+      const stopPromise = ctx.source.stop();
+      const settled = stopPromise.then(() => "resolved", () => "rejected");
+      await fireTimeout(ctx, TEARDOWN_TIMEOUT_MS);
+      expect(await settled).toBe("resolved");
+      // stop() always winds the source down even when cleanup could not complete.
+      expect(ctx.source.isRunning).toBe(false);
+    });
+
+    test("rejects construction with a non-positive command timeout", () => {
+      expect(() => makeSource({ commandTimeoutMs: 0 })).toThrow();
+      expect(() => makeSource({ teardownTimeoutMs: -1 })).toThrow();
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes [#4741](https://github.com/kaeawc/auto-mobile/issues/4741).

The persistent on-device video-server path (`PersistentEncoderH264Source`) previously `await`ed blocking ADB and socket calls with **no timeout** on the launch path, the teardown path, and the initial socket connect. A wedged ADB/USB state turned a recoverable failure into an indefinite hang — the WebRTC stream never degraded to screenrecord, and on the stop path teardown wedged and leaked device processes, forward ports, and lease files.

This PR wraps every blocking ADB/socket call in the persistent-encoder lifecycle with an injected `withTimeout(promise, ms, label)` bound driven by the existing `Timer` seam, so the bounds are deterministic under `FakeTimer` in unit tests (no real waits).

## Changes

`src/features/webrtc/PersistentEncoderH264Source.ts`:

- New private `withTimeout<T>(operation, ms, label)` helper that races an operation against a `Timer.setTimeout` deadline. On timeout it logs a warning and rejects with an `ActionableError`.
- Two new (injectable) timeout budgets with sensible defaults: `commandTimeoutMs` (launch path, default 20s) and `teardownTimeoutMs` (teardown/cleanup, default 5s). Construction rejects non-positive values.
- **Launch path — throw on timeout** so the source factory falls back to screenrecord: `adb push` and `adb forward` (`prepareSession`), `adb.spawn` (`spawnAndWaitForServer`).
- **Initial socket connect** now reuses the reconnect path's `connectBeforeDeadline` (deadline + `AbortController`) instead of the unbounded `connector(port)`. A late-resolving socket is aborted/destroyed rather than leaked when server-failure or teardown wins the race.
- **Teardown / cleanup / lease-reconcile — log and continue** so `stop()` always settles: every `adb.executeCommand` in `teardown` -> `cleanupOwnedSession` (`readLease`, `forward --list`/`--remove`, `cat /proc/<pid>/cmdline`, `kill -2`, `rm`), plus the lease-list read and `cat /proc/uptime` in `reconcileExpiredLeases`. Timeouts surface as `ActionableError` into the existing best-effort catches, so orphaned resources are left to lease reconciliation.

`test/features/webrtc/PersistentEncoderH264Source.test.ts`:

- Added test hooks to `makeSource` (`hangCommands`, `spawnHang`) to simulate hung ADB calls, and refactored the fake `executeCommand` to keep it readable.
- New `bounded ADB/socket timeouts` suite: hung `adb push`/`forward`/`spawn` and a hung initial connect each make `start()` reject within the launch timeout (and the source tears itself down); a hung teardown command still lets `stop()` resolve within the teardown timeout; construction rejects a non-positive timeout. All drive time via `FakeTimer`.

## Acceptance criteria

- [x] No `adb`/socket call in the persistent-encoder lifecycle can block indefinitely; each has an injected, unit-tested timeout.
- [x] A simulated hung `adb push`/`forward`/`spawn` causes `start()` to reject within the timeout and fall back to screenrecord.
- [x] A simulated hung teardown command lets `stop()` resolve within the timeout.
- [x] Timeouts are driven by the injectable `Timer` so tests use fake time (no real waits).

## Validation

- `bun run typecheck` - pass (no new type errors; 198 known baseline errors).
- `bunx turbo run lint build test` - all 3 tasks successful. Tests: **12089 pass, 13 skip, 0 fail** (859 files, ~288s).
- Target suite `test/features/webrtc/PersistentEncoderH264Source.test.ts`: **42 pass, 0 fail** in ~160ms (6 new tests).
