### PR TITLE
Desktop workspace: Layout facet (per-device, stream-driven)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorDashboard.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/LayoutInspectorDashboard.kt
@@ -22,9 +22,9 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
 import dev.jasonpearson.automobile.desktop.core.daemon.DeviceStreamEvent
+import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
 import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
-import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
 import dev.jasonpearson.automobile.desktop.core.tabs.PanelHeader
 import dev.jasonpearson.automobile.desktop.core.tabs.VerticalCollapsibleTab
 import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
@@ -40,11 +40,11 @@ fun LayoutInspectorDashboard(
   modifier: Modifier = Modifier,
   dataSourceMode: DataSourceMode = DataSourceMode.Fake,
   clientProvider: (() -> AutoMobileClient)? = null, // MCP client for real data
-  observationStreamClient: ObservationStreamClient, // Shared stream client (managed at app level)
+  observationStream: ObservationStream, // Per-device stream (owned by the pane's facet)
+  deviceId: String? = null, // Pane's device; tags applied frames and scopes the initial request
   platform: String = "android", // Device platform ("android" or "ios")
   onRestartDaemon: (() -> Unit)? = null,
 ) {
-  val graph = LocalAutoMobileGraph.current
   val state = rememberLayoutInspectorState()
   val colors = SharedTheme.globalColors
 
@@ -54,7 +54,7 @@ fun LayoutInspectorDashboard(
       "LayoutInspectorDashboard"
     )
 
-  val streamClient = observationStreamClient
+  val streamClient = observationStream
 
   // Collect hierarchy updates from the stream
   LaunchedEffect(streamClient) {
@@ -79,7 +79,11 @@ fun LayoutInspectorDashboard(
             "Parsed hierarchy: root=${result.first.root.className}, children=${result.first.root.children.size}"
           )
           state.updateConnectionStatus(ConnectionStatus.Connected)
-          state.applyHierarchyUpdate(result.first, result.second)
+          state.applyHierarchyUpdate(
+            result.first,
+            result.second,
+            deviceId = update.deviceId ?: deviceId,
+          )
           dashboardLog.info("Updated state with new hierarchy")
         } else {
           dashboardLog.warn("Failed to parse hierarchy from JSON")
@@ -114,6 +118,7 @@ fun LayoutInspectorDashboard(
           fallbackReason = update.screenshotFallbackReason,
           format = update.screenshotFormat,
           captureSource = update.screenshotCaptureSource,
+          deviceId = update.deviceId ?: deviceId,
         )
         dashboardLog.info("Updated state with new screenshot")
       }
@@ -170,37 +175,11 @@ fun LayoutInspectorDashboard(
     }
   }
 
-  // Initial fetch as fallback (in case stream hasn't pushed yet)
-  LaunchedEffect(dataSourceMode, clientProvider) {
-    kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
-      try {
-        val dataSource =
-          graph.dataSourceFactory.createLayoutDataSource(dataSourceMode, clientProvider, platform)
-        when (val result = dataSource.getObservation()) {
-          is dev.jasonpearson.automobile.desktop.core.datasource.Result.Success -> {
-            val observation = result.data
-            state.updateHierarchy(observation.hierarchy, observation.rotation)
-            observation.screenshotData?.let { screenshot ->
-              state.updateScreenshot(
-                data = screenshot,
-                width = observation.screenWidth,
-                height = observation.screenHeight,
-                timestamp = observation.timestamp,
-              )
-            }
-          }
-          is dev.jasonpearson.automobile.desktop.core.datasource.Result.Error -> {
-            // Keep current state or show error
-          }
-          is dev.jasonpearson.automobile.desktop.core.datasource.Result.Loading -> {
-            // Keep loading state
-          }
-        }
-      } catch (e: Exception) {
-        // Keep current state or show error
-      }
-    }
-  }
+  // Prime the stream with a one-off observation for THIS pane's device, in case it hasn't pushed
+  // yet. Scoped to [deviceId] rather than the previous active-device REST fallback, so a per-device
+  // facet never renders another device's frame. The result flows back through
+  // hierarchyUpdates/screenshotUpdates above.
+  LaunchedEffect(observationStream, deviceId) { observationStream.requestObservation(deviceId) }
 
   // Panel collapse states - default to collapsed, remember user preference
   // TODO: Persist these to IDE preferences for remembering across sessions

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/LayoutFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/LayoutFacet.kt
@@ -1,0 +1,47 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
+import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
+import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
+import dev.jasonpearson.automobile.desktop.core.layout.LayoutInspectorDashboard
+
+/**
+ * Docked-facet body for the Layout Inspector, scoped to a single pane's device. An
+ * [ObservationStream] is created via [observationStreamFactory] and connected to [column]'s device
+ * while the facet is shown, then disposed when it leaves composition or the device changes — the
+ * same per-device connect/dispose lifecycle as [LogsFacet]. Each pane therefore drives its own
+ * stream and mirror, rather than following the app's active device.
+ *
+ * [observationStreamFactory] is injected (defaulting to a real per-device
+ * [ObservationStreamClient]) so the connect/dispose lifecycle can be verified with a
+ * [FakeObservationStream] instead of real socket I/O.
+ */
+@Composable
+fun LayoutFacet(
+  column: DeviceColumn,
+  observationStreamFactory: () -> ObservationStream = { ObservationStreamClient() },
+) {
+  var stream by remember(column.deviceId) { mutableStateOf<ObservationStream?>(null) }
+  DisposableEffect(column.deviceId) {
+    val connected = observationStreamFactory().also { it.connect(deviceId = column.deviceId) }
+    stream = connected
+    onDispose {
+      connected.dispose()
+      stream = null
+    }
+  }
+  stream?.let { activeStream ->
+    LayoutInspectorDashboard(
+      dataSourceMode = DataSourceMode.Real,
+      observationStream = activeStream,
+      deviceId = column.deviceId,
+      platform = if (column.platform == Platform.Ios) "ios" else "android",
+    )
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/LayoutFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/LayoutFacetTest.kt
@@ -1,0 +1,103 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.daemon.FakeObservationStream
+import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class LayoutFacetTest {
+
+  /** A factory that hands out a fresh [FakeObservationStream] per call and records each one. */
+  private class RecordingStreamFactory : () -> ObservationStream {
+    val created = mutableListOf<FakeObservationStream>()
+
+    override fun invoke(): ObservationStream = FakeObservationStream().also { created += it }
+  }
+
+  @Test
+  fun `connects the stream to the pane device and disposes when removed`() = runComposeUiTest {
+    val fake = FakeObservationStream()
+    val visible = mutableStateOf(true)
+    setContent {
+      MaterialTheme {
+        if (visible.value) {
+          LayoutFacet(
+            column = DeviceColumn(deviceId = "dev-1", name = "Pixel", platform = Platform.Android),
+            observationStreamFactory = { fake },
+          )
+        }
+      }
+    }
+    waitForIdle()
+    // Connected exactly once, to this pane's device.
+    assertEquals("dev-1", fake.lastConnectedDeviceId)
+    assertEquals(1, fake.connectCallCount)
+
+    // Leaving composition disposes the stream (dispose → disconnect).
+    runOnIdle { visible.value = false }
+    waitForIdle()
+    assertTrue("expected the stream to be disposed on removal", fake.disconnectCallCount >= 1)
+  }
+
+  @Test
+  fun `re-keys to a new stream scoped to the new device when the pane device changes`() =
+    runComposeUiTest {
+      val factory = RecordingStreamFactory()
+      val deviceId = mutableStateOf("dev-1")
+      setContent {
+        MaterialTheme {
+          LayoutFacet(
+            column =
+              DeviceColumn(deviceId = deviceId.value, name = "Pixel", platform = Platform.Android),
+            observationStreamFactory = factory,
+          )
+        }
+      }
+      waitForIdle()
+      assertEquals(1, factory.created.size)
+      assertEquals("dev-1", factory.created[0].lastConnectedDeviceId)
+      assertEquals(1, factory.created[0].connectCallCount)
+
+      // Changing the pane's device disposes the old stream and connects a fresh one to the new id.
+      runOnIdle { deviceId.value = "dev-2" }
+      waitForIdle()
+      assertEquals(2, factory.created.size)
+      assertTrue(
+        "expected the previous device's stream to be disposed on re-key",
+        factory.created[0].disconnectCallCount >= 1,
+      )
+      assertEquals("dev-2", factory.created[1].lastConnectedDeviceId)
+      assertEquals(1, factory.created[1].connectCallCount)
+    }
+
+  @Test
+  fun `two panes get two independent streams each scoped to its own device`() = runComposeUiTest {
+    val factory = RecordingStreamFactory()
+    setContent {
+      MaterialTheme {
+        Column {
+          LayoutFacet(
+            column = DeviceColumn(deviceId = "dev-1", name = "Pixel", platform = Platform.Android),
+            observationStreamFactory = factory,
+          )
+          LayoutFacet(
+            column = DeviceColumn(deviceId = "dev-2", name = "iPhone", platform = Platform.Ios),
+            observationStreamFactory = factory,
+          )
+        }
+      }
+    }
+    waitForIdle()
+    // One distinct stream per pane, each connected exactly once to its own device.
+    assertEquals(2, factory.created.size)
+    assertEquals(setOf("dev-1", "dev-2"), factory.created.map { it.lastConnectedDeviceId }.toSet())
+    assertTrue(factory.created.all { it.connectCallCount == 1 })
+  }
+}


### PR DESCRIPTION
Adds the Layout-inspector facet — a per-device docked tool window wrapping `LayoutInspectorDashboard`, driven per pane via an injected `ObservationStream` (`connect(deviceId)` + `requestObservation(deviceId)`), mirroring `LogsFacet`. Part of the facet build-out ([#4715](https://github.com/kaeawc/auto-mobile/issues/4715)); built in parallel with Navigation/Performance.

## Changes
- `LayoutFacet.kt` (+ test) — per-device `ObservationStream` factory (default real), `DisposableEffect` connect/dispose, renders `LayoutInspectorDashboard` scoped to the pane's device + platform.
- `LayoutInspectorDashboard.kt` — retyped the stream param to the `ObservationStream` interface (renamed `observationStream`), added a `deviceId` that tags applied frames, and replaced the active-device REST fallback with a device-scoped `requestObservation(deviceId)` so a pane never renders another device's frame. **No production regression: `LayoutInspectorDashboard` had no callers on main** (the facet is its first consumer).

## Validation
- `:desktop-core:detektMain` + `:desktop-core:test` (3 Compose tests: connect/dispose per device, reconnect-on-device-change, two-pane isolation) + `compileKotlin` — green.

## Notes
- `clientProvider`/`platform` params on `LayoutInspectorDashboard` are now unused (kept for signature stability); can prune in a follow-up.
- Host wiring lands in the combined `WorkspaceFacet` PR (Navigation/Performance/Layout).