### PR TITLE
perf(webrtc): rework VideoServerStreamParser buffering + cap frame/track size

### DIFF
--- a/src/features/screen-stream/frameProtocol.ts
+++ b/src/features/screen-stream/frameProtocol.ts
@@ -22,6 +22,8 @@
  * out of scope here (issue #4270 tracks the format-level follow-up).
  */
 
+import { BufferQueue } from "../../utils/BufferQueue";
+
 /** Sync marker as a little-endian UInt32; on the wire the bytes read "AMF1". */
 export const FRAME_MAGIC = 0x3146_4d41;
 /** The marker bytes as they appear on the wire (little-endian of FRAME_MAGIC). */
@@ -307,96 +309,6 @@ function fieldBoundsError(header: FrameHeader): MalformedFrameReason | null {
     return "header_payload_too_large";
   }
   return null;
-}
-
-/**
- * Chunked byte storage prevents repeated whole-frame `Buffer.concat` copies as
- * stdout arrives in pipe-sized pieces. Payload extraction performs one detached
- * copy, which is needed because decoded frames outlive their stdout chunks.
- */
-class BufferQueue {
-  private chunks: Buffer[] = [];
-  private headOffset = 0;
-  length = 0;
-
-  append(chunk: Buffer): void {
-    if (chunk.length === 0) {return;}
-    this.chunks.push(chunk);
-    this.length += chunk.length;
-  }
-
-  peek(length: number): Buffer {
-    if (length > this.length) {
-      throw new RangeError(`cannot peek ${length} bytes from ${this.length}-byte queue`);
-    }
-    const first = this.chunks[0];
-    const firstAvailable = first.length - this.headOffset;
-    if (firstAvailable >= length) {
-      return first.subarray(this.headOffset, this.headOffset + length);
-    }
-    const out = Buffer.allocUnsafe(length);
-    this.copyTo(out, length);
-    return out;
-  }
-
-  takeDetached(length: number): Buffer {
-    if (length > this.length) {
-      throw new RangeError(`cannot take ${length} bytes from ${this.length}-byte queue`);
-    }
-    const out = Buffer.allocUnsafe(length);
-    this.copyTo(out, length);
-    this.discard(length);
-    return out;
-  }
-
-  discard(length: number): void {
-    if (length > this.length) {
-      throw new RangeError(`cannot discard ${length} bytes from ${this.length}-byte queue`);
-    }
-    let remaining = length;
-    while (remaining > 0) {
-      const first = this.chunks[0];
-      const available = first.length - this.headOffset;
-      if (remaining < available) {
-        this.headOffset += remaining;
-        this.length -= remaining;
-        return;
-      }
-      this.chunks.shift();
-      this.headOffset = 0;
-      this.length -= available;
-      remaining -= available;
-    }
-  }
-
-  toBuffer(): Buffer {
-    if (this.length === 0) {return Buffer.alloc(0);}
-    const first = this.chunks[0];
-    if (this.chunks.length === 1) {
-      return first.subarray(this.headOffset);
-    }
-    const out = Buffer.allocUnsafe(this.length);
-    this.copyTo(out, this.length);
-    return out;
-  }
-
-  replace(bytes: Buffer): void {
-    this.chunks = bytes.length === 0 ? [] : [bytes];
-    this.headOffset = 0;
-    this.length = bytes.length;
-  }
-
-  private copyTo(destination: Buffer, length: number): void {
-    let copied = 0;
-    for (let index = 0; copied < length; index++) {
-      const chunk = this.chunks[index];
-      const start = index === 0 ? this.headOffset : 0;
-      const available = chunk.length - start;
-      const count = Math.min(available, length - copied);
-      chunk.copy(destination, copied, start, start + count);
-      copied += count;
-    }
-  }
 }
 
 /**

--- a/src/features/webrtc/PersistentEncoderH264Source.ts
+++ b/src/features/webrtc/PersistentEncoderH264Source.ts
@@ -762,7 +762,6 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
         }
       },
     });
-    socket.on("data", chunk => parser.push(chunk));
     let failed = false;
     const reportFailure = (error: Error): void => {
       if (failed || this.socket !== socket) {
@@ -771,6 +770,17 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
       failed = true;
       onSocketFailure(error);
     };
+    socket.on("data", chunk => {
+      try {
+        parser.push(chunk);
+      } catch (error) {
+        // A bounded parse error (over-cap size/trackCount, i.e. a framing
+        // desync) surfaces here instead of the parser buffering forever. Route
+        // it through the same failure path as a socket error so the source
+        // triggers its bounded reconnect/fallback.
+        reportFailure(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
     socket.on("error", reportFailure);
     socket.on("close", () => reportFailure(new Error("video-server socket closed")));
   }

--- a/src/features/webrtc/VideoServerStreamParser.ts
+++ b/src/features/webrtc/VideoServerStreamParser.ts
@@ -19,6 +19,9 @@
  * library-agnostic so it can be unit-tested without a device.
  */
 
+import { ActionableError } from "../../models/ActionableError";
+import { BufferQueue } from "../../utils/BufferQueue";
+
 /** "h264" as a big-endian int: 0x68323634. */
 export const VIDEO_SERVER_CODEC_ID_H264 = 0x68323634;
 /** "amux" as a big-endian int: multiplexed audio/video protocol marker. */
@@ -32,6 +35,24 @@ const STREAM_HEADER_BYTES = 12;
 const PACKET_HEADER_BYTES = 12;
 const MUX_TRACK_BYTES = 16;
 const MUX_PACKET_HEADER_BYTES = 16;
+
+/**
+ * Largest per-packet payload the parser will buffer. A single framing desync
+ * makes the 32-bit big-endian `size` field decode to an arbitrary value, so
+ * without a cap the parser buffers incoming bytes indefinitely while it waits
+ * for a bogus length — unbounded host-memory growth on a live 4-8 Mbps feed.
+ * 16 MiB sits comfortably above any real keyframe at the supported
+ * resolutions/bitrates, so legitimate maximum-size IDRs still parse while a
+ * corrupt length surfaces a bounded parse error instead.
+ */
+export const MAX_PACKET_BYTES = 16 * 1024 * 1024;
+
+/**
+ * Largest declared mux `trackCount`. The multiplexed protocol carries a handful
+ * of tracks (video + audio today); a bogus 32-bit count would otherwise make
+ * the header wait for `12 + trackCount * 16` bytes that never arrive.
+ */
+export const MAX_TRACK_COUNT = 16;
 const FLAG_CONFIG = 1n << 63n;
 const FLAG_KEY_FRAME = 1n << 62n;
 const FLAG_REPLAYED = 1n << 61n;
@@ -73,36 +94,53 @@ export interface VideoServerStreamParserCallbacks {
  * fully buffered. Bytes for a not-yet-complete packet are retained across calls.
  */
 export class VideoServerStreamParser {
-  private buffered: Buffer = Buffer.alloc(0);
+  private readonly buffered = new BufferQueue();
   private header: VideoServerStreamHeader | null = null;
   private muxTracks: Map<number, { codecId: number; param1: number; param2: number }> | null = null;
 
   constructor(private readonly callbacks: VideoServerStreamParserCallbacks) {}
 
+  /**
+   * Guard a size/track-count read against its cap. A declared length over the
+   * cap means a framing desync (or a corrupt stream): fail fast with a bounded
+   * parse error instead of buffering the bogus length forever. The socket
+   * wiring routes the throw to its reconnect/fallback path.
+   */
+  private assertWithinCap(value: number, cap: number, field: string): void {
+    if (value > cap) {
+      throw new ActionableError(
+        `video-server stream declared ${field}=${value}, exceeding the ${cap} cap; ` +
+          "the stream is likely corrupt or out of sync."
+      );
+    }
+  }
+
   push(chunk: Buffer): void {
-    this.buffered =
-      this.buffered.length === 0 ? chunk : Buffer.concat([this.buffered, chunk]);
+    this.buffered.append(chunk);
 
     if (!this.header && !this.muxTracks) {
       if (this.buffered.length < STREAM_HEADER_BYTES) {
         return;
       }
-      const codecOrMagic = this.buffered.readUInt32BE(0);
+      const streamHeader = this.buffered.peek(STREAM_HEADER_BYTES);
+      const codecOrMagic = streamHeader.readUInt32BE(0);
       if (codecOrMagic === VIDEO_SERVER_CODEC_ID_AMUX) {
-        const trackCount = this.buffered.readUInt32BE(8);
+        const trackCount = streamHeader.readUInt32BE(8);
+        this.assertWithinCap(trackCount, MAX_TRACK_COUNT, "trackCount");
         const headerBytes = STREAM_HEADER_BYTES + trackCount * MUX_TRACK_BYTES;
         if (this.buffered.length < headerBytes) {
           return;
         }
+        const fullHeader = this.buffered.peek(headerBytes);
         this.muxTracks = new Map();
         let videoHeader: Pick<VideoServerStreamHeader, "codecId" | "width" | "height"> | null = null;
         let hasPcmAudioTrack = false;
         for (let i = 0; i < trackCount; i++) {
           const offset = STREAM_HEADER_BYTES + i * MUX_TRACK_BYTES;
-          const trackId = this.buffered.readUInt32BE(offset);
-          const codecId = this.buffered.readUInt32BE(offset + 4);
-          const param1 = this.buffered.readUInt32BE(offset + 8);
-          const param2 = this.buffered.readUInt32BE(offset + 12);
+          const trackId = fullHeader.readUInt32BE(offset);
+          const codecId = fullHeader.readUInt32BE(offset + 4);
+          const param1 = fullHeader.readUInt32BE(offset + 8);
+          const param2 = fullHeader.readUInt32BE(offset + 12);
           this.muxTracks.set(trackId, { codecId, param1, param2 });
           if (codecId === VIDEO_SERVER_CODEC_ID_H264) {
             videoHeader = { codecId, width: param1, height: param2 };
@@ -114,14 +152,14 @@ export class VideoServerStreamParser {
           this.header = { ...videoHeader, muxed: true, audio: hasPcmAudioTrack };
           this.callbacks.onHeader?.(this.header);
         }
-        this.buffered = this.buffered.subarray(headerBytes);
+        this.buffered.discard(headerBytes);
       } else {
         this.header = {
           codecId: codecOrMagic,
-          width: this.buffered.readUInt32BE(4),
-          height: this.buffered.readUInt32BE(8),
+          width: streamHeader.readUInt32BE(4),
+          height: streamHeader.readUInt32BE(8),
         };
-        this.buffered = this.buffered.subarray(STREAM_HEADER_BYTES);
+        this.buffered.discard(STREAM_HEADER_BYTES);
         this.callbacks.onHeader?.(this.header);
       }
     }
@@ -132,15 +170,15 @@ export class VideoServerStreamParser {
     }
 
     while (this.buffered.length >= PACKET_HEADER_BYTES) {
-      const flags = this.buffered.readBigUInt64BE(0);
-      const size = this.buffered.readUInt32BE(8);
+      const packetHeader = this.buffered.peek(PACKET_HEADER_BYTES);
+      const flags = packetHeader.readBigUInt64BE(0);
+      const size = packetHeader.readUInt32BE(8);
+      this.assertWithinCap(size, MAX_PACKET_BYTES, "packet size");
       if (this.buffered.length < PACKET_HEADER_BYTES + size) {
         break; // wait for the rest of the payload
       }
-      const data = Buffer.from(
-        this.buffered.subarray(PACKET_HEADER_BYTES, PACKET_HEADER_BYTES + size)
-      );
-      this.buffered = this.buffered.subarray(PACKET_HEADER_BYTES + size);
+      this.buffered.discard(PACKET_HEADER_BYTES);
+      const data = this.buffered.takeDetached(size);
       this.callbacks.onPacket({
         trackId: VIDEO_SERVER_TRACK_ID_VIDEO,
         codecId: this.header?.codecId ?? VIDEO_SERVER_CODEC_ID_H264,
@@ -155,16 +193,16 @@ export class VideoServerStreamParser {
 
   private drainMuxPackets(): void {
     while (this.buffered.length >= MUX_PACKET_HEADER_BYTES) {
-      const trackId = this.buffered.readUInt32BE(0);
-      const flags = this.buffered.readBigUInt64BE(4);
-      const size = this.buffered.readUInt32BE(12);
+      const packetHeader = this.buffered.peek(MUX_PACKET_HEADER_BYTES);
+      const trackId = packetHeader.readUInt32BE(0);
+      const flags = packetHeader.readBigUInt64BE(4);
+      const size = packetHeader.readUInt32BE(12);
+      this.assertWithinCap(size, MAX_PACKET_BYTES, "packet size");
       if (this.buffered.length < MUX_PACKET_HEADER_BYTES + size) {
         break;
       }
-      const data = Buffer.from(
-        this.buffered.subarray(MUX_PACKET_HEADER_BYTES, MUX_PACKET_HEADER_BYTES + size)
-      );
-      this.buffered = this.buffered.subarray(MUX_PACKET_HEADER_BYTES + size);
+      this.buffered.discard(MUX_PACKET_HEADER_BYTES);
+      const data = this.buffered.takeDetached(size);
       const track = this.muxTracks?.get(trackId);
       if (!track) {
         continue;

--- a/src/utils/BufferQueue.ts
+++ b/src/utils/BufferQueue.ts
@@ -1,0 +1,95 @@
+/**
+ * Chunked byte storage for incremental stream parsers.
+ *
+ * Storing incoming chunks in a list and advancing a head offset avoids the
+ * repeated whole-buffer `Buffer.concat` copies that make per-chunk accumulation
+ * quadratic in payload size when a large frame arrives split across many small
+ * TCP/pipe segments. Reads over the head are contiguous views when they fit in a
+ * single chunk and copy only when they span a boundary; {@link takeDetached}
+ * performs the single detached copy needed when a decoded payload must outlive
+ * the chunks it was assembled from.
+ */
+export class BufferQueue {
+  private chunks: Buffer[] = [];
+  private headOffset = 0;
+  length = 0;
+
+  append(chunk: Buffer): void {
+    if (chunk.length === 0) {return;}
+    this.chunks.push(chunk);
+    this.length += chunk.length;
+  }
+
+  peek(length: number): Buffer {
+    if (length > this.length) {
+      throw new RangeError(`cannot peek ${length} bytes from ${this.length}-byte queue`);
+    }
+    const first = this.chunks[0];
+    const firstAvailable = first.length - this.headOffset;
+    if (firstAvailable >= length) {
+      return first.subarray(this.headOffset, this.headOffset + length);
+    }
+    const out = Buffer.allocUnsafe(length);
+    this.copyTo(out, length);
+    return out;
+  }
+
+  takeDetached(length: number): Buffer {
+    if (length > this.length) {
+      throw new RangeError(`cannot take ${length} bytes from ${this.length}-byte queue`);
+    }
+    const out = Buffer.allocUnsafe(length);
+    this.copyTo(out, length);
+    this.discard(length);
+    return out;
+  }
+
+  discard(length: number): void {
+    if (length > this.length) {
+      throw new RangeError(`cannot discard ${length} bytes from ${this.length}-byte queue`);
+    }
+    let remaining = length;
+    while (remaining > 0) {
+      const first = this.chunks[0];
+      const available = first.length - this.headOffset;
+      if (remaining < available) {
+        this.headOffset += remaining;
+        this.length -= remaining;
+        return;
+      }
+      this.chunks.shift();
+      this.headOffset = 0;
+      this.length -= available;
+      remaining -= available;
+    }
+  }
+
+  toBuffer(): Buffer {
+    if (this.length === 0) {return Buffer.alloc(0);}
+    const first = this.chunks[0];
+    if (this.chunks.length === 1) {
+      return first.subarray(this.headOffset);
+    }
+    const out = Buffer.allocUnsafe(this.length);
+    this.copyTo(out, this.length);
+    return out;
+  }
+
+  replace(bytes: Buffer): void {
+    this.chunks = bytes.length === 0 ? [] : [bytes];
+    this.headOffset = 0;
+    this.length = bytes.length;
+  }
+
+  private copyTo(destination: Buffer, length: number): void {
+    let copied = 0;
+    for (let index = 0; copied < length; index++) {
+      const chunk = this.chunks[index];
+      const start = index === 0 ? this.headOffset : 0;
+      const available = chunk.length - start;
+      const count = Math.min(available, length - copied);
+      chunk.copy(destination, copied, start, start + count);
+      copied += count;
+    }
+  }
+}

--- a/test/features/webrtc/VideoServerStreamParser.test.ts
+++ b/test/features/webrtc/VideoServerStreamParser.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { ActionableError } from "../../../src/models/ActionableError";
 import {
+  MAX_PACKET_BYTES,
+  MAX_TRACK_COUNT,
   VIDEO_SERVER_CODEC_ID_AMUX,
   VIDEO_SERVER_CODEC_ID_H264,
   VIDEO_SERVER_CODEC_ID_PCM16,
@@ -196,6 +199,78 @@ describe("VideoServerStreamParser", () => {
     expect(packets[0].data).toHaveLength(0);
     expect(packets[0].ptsUs).toBe(7);
     expect(packets[1].ptsUs).toBe(8);
+  });
+
+  test("throws a bounded parse error when a video packet declares a size over the cap", () => {
+    // A framing desync decodes an arbitrary 32-bit size. Rather than buffer the
+    // bogus length forever, the parser must fail fast so the socket wiring can
+    // reconnect. Only the 12-byte header is fed — no unbounded payload wait.
+    const { parser } = collect();
+    parser.push(streamHeader(1920, 1080));
+    const bogusHeader = Buffer.alloc(12);
+    bogusHeader.writeBigUInt64BE(0n, 0);
+    bogusHeader.writeUInt32BE(MAX_PACKET_BYTES + 1, 8);
+    expect(() => parser.push(bogusHeader)).toThrow(ActionableError);
+  });
+
+  test("throws a bounded parse error when a mux header declares a trackCount over the cap", () => {
+    const { parser } = collect();
+    const bogusMuxHeader = Buffer.alloc(12);
+    bogusMuxHeader.writeUInt32BE(VIDEO_SERVER_CODEC_ID_AMUX, 0);
+    bogusMuxHeader.writeUInt32BE(0, 4);
+    bogusMuxHeader.writeUInt32BE(MAX_TRACK_COUNT + 1, 8);
+    expect(() => parser.push(bogusMuxHeader)).toThrow(ActionableError);
+  });
+
+  test("throws a bounded parse error when a mux packet declares a size over the cap", () => {
+    const { parser } = collect();
+    parser.push(muxHeader());
+    const bogusMuxPacketHeader = Buffer.alloc(16);
+    bogusMuxPacketHeader.writeUInt32BE(VIDEO_SERVER_TRACK_ID_VIDEO, 0);
+    bogusMuxPacketHeader.writeBigUInt64BE(0n, 4);
+    bogusMuxPacketHeader.writeUInt32BE(MAX_PACKET_BYTES + 1, 12);
+    expect(() => parser.push(bogusMuxPacketHeader)).toThrow(ActionableError);
+  });
+
+  test("parses a legitimate maximum-size keyframe delivered in large chunks", () => {
+    // MAX_PACKET_BYTES must be comfortably above a real keyframe; the boundary
+    // itself must still parse, not trip the cap.
+    const { parser, packets } = collect();
+    parser.push(streamHeader(1920, 1080));
+    const payload = Buffer.alloc(MAX_PACKET_BYTES, 0x5a);
+    const framed = packet(payload, FLAG_KEY_FRAME, 99);
+    const CHUNK = 1024 * 1024;
+    for (let offset = 0; offset < framed.length; offset += CHUNK) {
+      parser.push(framed.subarray(offset, Math.min(offset + CHUNK, framed.length)));
+    }
+    expect(packets).toHaveLength(1);
+    expect(packets[0].data.length).toBe(MAX_PACKET_BYTES);
+    expect(packets[0].keyFrame).toBe(true);
+    expect(packets[0].ptsUs).toBe(99);
+  });
+
+  test("reassembles a large IDR split across many chunks and drains cleanly", () => {
+    // The chunk-list accumulator must not re-copy the whole partial buffer on
+    // every segment (the former O(n^2) Buffer.concat). Delivering a large frame
+    // one small segment at a time exercises the cursor/compaction path; a
+    // trailing packet proves the buffer reset once the frame drained.
+    const { parser, packets } = collect();
+    parser.push(streamHeader(1280, 720));
+    const idr = Buffer.alloc(512 * 1024, 0x41);
+    idr[0] = 0x00; idr[1] = 0x00; idr[2] = 0x00; idr[3] = 0x01; idr[4] = 0x65;
+    const framed = packet(idr, FLAG_KEY_FRAME, 4242);
+    const CHUNK = 1024;
+    for (let offset = 0; offset < framed.length; offset += CHUNK) {
+      parser.push(framed.subarray(offset, Math.min(offset + CHUNK, framed.length)));
+    }
+    expect(packets).toHaveLength(1);
+    expect(packets[0].data).toEqual(idr);
+
+    // Buffer state is clean after draining: a small trailing packet parses.
+    parser.push(packet(Buffer.from([0xbb]), 0n, 4243));
+    expect(packets).toHaveLength(2);
+    expect(packets[1].data).toEqual(Buffer.from([0xbb]));
+    expect(packets[1].ptsUs).toBe(4243);
   });
 
   test("a mux header declaring zero tracks yields no header and drops later packets", () => {


### PR DESCRIPTION
Closes [#4746](https://github.com/kaeawc/auto-mobile/issues/4746)

## Summary

`VideoServerStreamParser` had two coupled defects in the same accumulator region: a per-chunk `Buffer.concat` (O(n²) on large IDRs) and unbounded buffering when a framing desync decodes a bogus 32-bit `size`/`trackCount`. Both are fixed together, as the issue requests (it absorbs the former [#4747](https://github.com/kaeawc/auto-mobile/issues/4747)).

### Accumulator rework (drops the O(n²) `Buffer.concat`)
- The accumulator is now a chunk-list / read-cursor model instead of a `Buffer.concat` on every `push()`. Consumed bytes advance a head offset and fully-consumed chunks are dropped; a payload is materialized with a single detached copy when drained. A high-bitrate IDR split across many TCP segments no longer re-copies the whole partial accumulator per segment.
- This reuses the existing `BufferQueue` primitive that the screen-stream frame decoder already uses for exactly this purpose. I extracted it from `src/features/screen-stream/frameProtocol.ts` into `src/utils/BufferQueue.ts` so both parsers share one canonical implementation (per the "one canonical primitive per concern" guideline) rather than duplicating it. `frameProtocol.ts` now imports it; its behavior is unchanged.

### Memory-safety caps
- Added `MAX_PACKET_BYTES` (16 MiB, comfortably above any real keyframe at the supported resolutions/bitrates) and `MAX_TRACK_COUNT` (16) caps at the three size reads (video path, mux path, and mux `trackCount`).
- When a header declares a size/track-count over the cap, the parser throws a bounded `ActionableError` **before** waiting for the bogus length — so a corrupt stream fails fast instead of buffering forever.
- The socket wiring in `PersistentEncoderH264Source.wireSocket` now wraps `parser.push(chunk)` in a try/catch that routes the throw through the same `reportFailure` path as a socket error, so the source triggers its bounded reconnect/fallback.

## Acceptance criteria
- [x] A corrupt/over-large declared `size` or `trackCount` causes a bounded parse error, not unbounded buffering.
- [x] Legitimate maximum-size keyframes still parse (test feeds a payload of exactly `MAX_PACKET_BYTES`).
- [x] Large IDRs split across many chunks no longer trigger repeated whole-buffer copies; the accumulator compacts/resets once drained (test feeds a 512 KiB IDR in 1 KiB segments, then verifies a trailing packet parses cleanly).
- [x] `VideoServerStreamParser.test.ts` extended for both the over-cap/desync case (video size, mux size, and mux `trackCount`) and the split-chunk large-frame case.

## Validation
- `bun run typecheck` — pass, no new type errors (198 known baseline).
- `bun run lint` — pass (exit 0).
- `bun run build` — pass (exit 0).
- `bun test` on affected files (`VideoServerStreamParser`, `PersistentEncoderH264Source`, `frameProtocol`, `frameProtocol.property`) — 80 pass, 0 fail.
