### PR TITLE
feat(ios): classify the first-frame timeout by last capture startup stage

### DIFF
--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -9,6 +9,7 @@ import type {
   FrameQueueMetrics,
   IosScreenCaptureHelperOptions,
   IosScreenCaptureReadiness,
+  IosScreenCaptureReadinessPhase,
   MalformedFrameError,
   NativeFrameMetrics,
 } from "../screen-stream";
@@ -246,6 +247,7 @@ export class IosH264Source implements H264CaptureSource {
   private cancelFirstAudioWait: (() => void) | null = null;
   private rejectFirstAudioWait: ((error: Error) => void) | null = null;
   private lastHelperStderr: string | null = null;
+  private lastReadinessPhase: IosScreenCaptureReadinessPhase | null = null;
   private lastEncoderStderr: string | null = null;
   private lastForcedKeyFrameMs = Number.NEGATIVE_INFINITY;
   private lastOutputWriteDurationMs: number | null = null;
@@ -308,6 +310,7 @@ export class IosH264Source implements H264CaptureSource {
     await this.teardownPromise;
     this.phase = "starting";
     this.lastHelperStderr = null;
+    this.lastReadinessPhase = null;
     this.helperFrameMetrics = null;
     this.nativeFrameMetrics = null;
     this.lastHelperFrame = null;
@@ -497,6 +500,7 @@ export class IosH264Source implements H264CaptureSource {
 
   private async startCaptureAttempt(helperPath: string, target: CaptureTarget): Promise<void> {
     logger.info(`[IosH264Source] starting screen-capture-helper for ${describeCaptureTarget(target)}`);
+    this.lastReadinessPhase = null;
     const helper = this.createCaptureHelper({ binaryPath: helperPath, target });
     this.helper = helper;
     this.wireHelperFrames(helper);
@@ -525,7 +529,7 @@ export class IosH264Source implements H264CaptureSource {
         finish(resolve);
       };
       const timeout = this.timer.setTimeout(() => {
-        finish(() => reject(makeNoFramesError(target)));
+        finish(() => reject(makeNoFramesError(target, this.lastReadinessPhase)));
       }, this.firstFrameTimeoutMs);
       this.cancelFirstFrameWait = cancel;
 
@@ -542,7 +546,7 @@ export class IosH264Source implements H264CaptureSource {
           return;
         }
         if (isNoFramesPermissionWarning(line)) {
-          finish(() => reject(makeNoFramesError(target)));
+          finish(() => reject(makeNoFramesError(target, this.lastReadinessPhase)));
         } else if (isHelperError(line)) {
           finish(() => reject(new Error(`screen-capture-helper reported an error: ${line}`)));
         }
@@ -651,6 +655,11 @@ export class IosH264Source implements H264CaptureSource {
       }
     });
     helper.on("readiness", status => {
+      if (this.helper === helper && this.isActive()) {
+        // Track the furthest startup stage reached so a first-frame timeout can
+        // name exactly where capture stalled (issue #4766).
+        this.lastReadinessPhase = status.phase;
+      }
       logger.debug(
         `[IosH264Source] capture readiness phase=${status.phase} atMs=${status.atMs}${status.detail ? ` detail=${status.detail}` : ""}`
       );
@@ -1051,11 +1060,47 @@ function clampMacroblockAxis(value: number): number {
   return Math.min(WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME, Math.max(1, value));
 }
 
-function makeNoFramesError(target: CaptureTarget): NoFirstFrameError {
-  const hint = target.kind === "simulator"
-    ? " Grant Screen Recording permission to your terminal/IDE in System Settings > Privacy & Security > Screen Recording."
-    : "";
-  return new NoFirstFrameError(`iOS screen capture did not produce a first frame.${hint}`);
+function makeNoFramesError(
+  target: CaptureTarget,
+  lastPhase: IosScreenCaptureReadinessPhase | null
+): NoFirstFrameError {
+  const stage = lastPhase === null ? "" : ` (last stage: ${lastPhase})`;
+  const hint = hintForNoFrames(target, lastPhase);
+  return new NoFirstFrameError(
+    `iOS screen capture did not produce a first frame${stage}.${hint}`
+  );
+}
+
+// Map the furthest startup stage reached to a targeted hint so the surfaced
+// error distinguishes a permission stall from window discovery vs a hung start
+// (issue #4766).
+function hintForNoFrames(
+  target: CaptureTarget,
+  lastPhase: IosScreenCaptureReadinessPhase | null
+): string {
+  const permissionHint =
+    " Grant Screen Recording permission to your terminal/IDE in System Settings > Privacy & Security > Screen Recording.";
+  switch (lastPhase) {
+    case null:
+    case "helper-executable-found":
+    case "helper-process-spawned":
+      // The helper never confirmed permission; the likeliest cause is a missing
+      // Screen Recording grant.
+      return target.kind === "simulator" ? permissionHint : "";
+    case "permission-ready":
+      // Permission is granted but the target Simulator window never resolved.
+      return " The Simulator window could not be resolved; ensure the Simulator is booted and visible.";
+    case "target-resolved":
+      // The window resolved but ScreenCaptureKit never confirmed the session
+      // started — a hung start (see issue #4350).
+      return " Capture never started after the window resolved (hung start); retry or restart the Simulator.";
+    case "capture-started":
+      // The session started but delivered no frames — usually a permission gate
+      // that lets the session begin without producing pixels.
+      return target.kind === "simulator" ? permissionHint : "";
+    case "first-frame":
+      return "";
+  }
 }
 
 function isNoFramesPermissionWarning(line: string): boolean {

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -69,6 +69,10 @@ class FakeFrameCaptureHelper extends EventEmitter implements IosFrameCaptureHelp
   emitStderr(line: string): void {
     this.emit("stderr", line);
   }
+
+  emitReadiness(phase: string, atMs = 0, detail?: string): void {
+    this.emit("readiness", { phase, atMs, detail });
+  }
 }
 
 class DelayedStopFrameCaptureHelper extends FakeFrameCaptureHelper {
@@ -697,6 +701,73 @@ describe("IosH264Source", () => {
     expect(error?.message).toBe("iOS screen capture did not produce a first frame.");
     expect(helpers).toHaveLength(1);
     expect(helpers[0].stopped).toBe(true);
+  });
+
+  test("names the last capture startup stage in the first-frame timeout error", async () => {
+    const timer = new FakeTimer();
+    const helper = new FakeFrameCaptureHelper();
+    const source = new IosH264Source({
+      device: IOS_DEVICE,
+      helperPath: FAKE_HELPER_PATH,
+      helperPathExists: fakeHelperPathExists,
+      firstFrameTimeoutMs: 1,
+      timer,
+      onData: () => {},
+      createHelper: () => helper,
+      spawner: () => new FakeChildProcess() as unknown as ChildProcessWithoutNullStreams,
+      commandRunner: successfulCommandRunner,
+    });
+
+    const started = source.start().then(
+      () => null,
+      error => error as Error
+    );
+    await flush();
+    // The furthest stage reached wins: capture-started is later than the
+    // earlier permission/resolve markers.
+    helper.emitReadiness("permission-ready");
+    helper.emitReadiness("target-resolved");
+    helper.emitReadiness("capture-started");
+    timer.advanceTime(1);
+
+    const error = await started;
+    expect(error).toBeInstanceOf(Error);
+    expect(error?.message).toBe(
+      "iOS screen capture did not produce a first frame (last stage: capture-started)."
+    );
+  });
+
+  test("adds a hung-start hint when a simulator resolves its window but never starts", async () => {
+    const timer = new FakeTimer();
+    const helper = new FakeFrameCaptureHelper();
+    const source = new IosH264Source({
+      device: IOS_SIMULATOR,
+      helperPath: FAKE_HELPER_PATH,
+      helperPathExists: fakeHelperPathExists,
+      firstFrameTimeoutMs: 1,
+      timer,
+      onData: () => {},
+      createHelper: () => helper,
+      simulatorWindowResolver: async () => 42,
+      spawner: () => new FakeChildProcess() as unknown as ChildProcessWithoutNullStreams,
+      commandRunner: successfulCommandRunner,
+    });
+
+    const started = source.start().then(
+      () => null,
+      error => error as Error
+    );
+    await flush();
+    helper.emitReadiness("permission-ready");
+    helper.emitReadiness("target-resolved");
+    timer.advanceTime(1);
+
+    const error = await started;
+    expect(error).toBeInstanceOf(Error);
+    expect(error?.message).toBe(
+      "iOS screen capture did not produce a first frame (last stage: target-resolved). " +
+        "Capture never started after the window resolved (hung start); retry or restart the Simulator."
+    );
   });
 
   test("requests simulator audio and forwards its PCM16LE chunks unchanged", async () => {


### PR DESCRIPTION
Closes [#4766](https://github.com/kaeawc/auto-mobile/issues/4766)

## Summary

The iOS capture helper emits rich startup-stage markers
(`permission-ready` -> `target-resolved` -> `capture-started` ->
`first-frame`) that `IOSScreenCaptureHelper` forwards to `IosH264Source`
as `readiness` events, but the source only debug-logged them and threw a
generic "did not produce a first frame" on timeout, discarding the exact
stage that stalled.

This change makes every capture-startup failure self-diagnosing:

- Track the last-observed `IosScreenCaptureReadiness` phase per capture
  attempt in `IosH264Source` (reset at the start of each attempt and when
  a source (re)starts).
- Include it in the no-first-frame / timeout error message, e.g.
  `iOS screen capture did not produce a first frame (last stage: capture-started).`
- Map each terminal stage to a targeted hint that distinguishes the root
  causes called out in the issue: missing permission vs unresolved window
  vs hung start (see [#4350](https://github.com/kaeawc/auto-mobile/issues/4350)).

When no readiness event was observed (e.g. physical device), the message
is unchanged, preserving existing behavior.

## Changes

- `src/features/webrtc/IosH264Source.ts` - new `lastReadinessPhase` field,
  reset in `start()` and `startCaptureAttempt()`; readiness handler records
  the phase; `makeNoFramesError(target, lastPhase)` appends the stage and a
  stage-specific `hintForNoFrames(...)`.
- `test/features/webrtc/IosH264Source.test.ts` - `emitReadiness` helper on
  the fake, plus two tests: one asserting the timeout message names the last
  readiness event delivered before the timeout, one asserting the hung-start
  hint for a Simulator that resolves its window but never starts.

## Validation

- `bun run typecheck` - no new type errors (198 baseline).
- `bunx turbo run lint build` - pass.
- `bunx turbo run test` - 12085 pass, 13 skip, 0 fail (12098 tests).
