### PR TITLE
fix(ios): clear poisoned capture-pool entries on next attach

### DIFF
--- a/src/features/screen-stream/IOSSimulatorCaptureHelperPool.ts
+++ b/src/features/screen-stream/IOSSimulatorCaptureHelperPool.ts
@@ -105,6 +105,16 @@ export class IOSSimulatorCaptureHelperPool {
       }
       const targetKey = helperTargetKey(lease.options.target, lease.options.binaryPath);
       let entry = this.entries.get(targetKey);
+      if (entry?.failedStopFailed) {
+        // A previous helper.stop() threw and left this entry poisoned. The
+        // failure was already surfaced once (to the awaiting invalidate/best-
+        // effort cleanup). Drop the entry now so this attach can build a fresh
+        // helper instead of re-throwing the same error forever — bounded retry,
+        // not permanent poison of the window target.
+        this.clearEntryIdleTimer(entry);
+        this.entries.delete(targetKey);
+        entry = undefined;
+      }
       if (!entry) {
         // A new CGWindowID proves a reboot/window recreation. Evict any idle
         // session now rather than letting it occupy ScreenCaptureKit resources
@@ -133,9 +143,6 @@ export class IOSSimulatorCaptureHelperPool {
         this.wireHelper(entry);
       }
 
-      if (entry.failedStopFailed) {
-        throw entry.failedStopError;
-      }
       this.clearEntryIdleTimer(entry);
       entry.leases.add(lease);
       lease.entryKey = targetKey;
@@ -258,6 +265,11 @@ export class IOSSimulatorCaptureHelperPool {
     try {
       await entry.helper.stop();
     } catch (error) {
+      // Surface the stop failure to this caller, but record it so it is only
+      // re-thrown to concurrent cleanup of the SAME failed entry — never to a
+      // future attach. attach() drops a failedStopFailed entry and builds a
+      // fresh helper instead, so the failure cannot permanently poison the
+      // window target.
       entry.failedStopFailed = true;
       entry.failedStopError = error;
       throw error;
@@ -276,6 +288,15 @@ export class IOSSimulatorCaptureHelperPool {
     await entry.helper.stop();
   }
 
+  // All pool mutations serialize through one global chain rather than a
+  // per-target queue. attach() mutates cross-target state — it evicts idle
+  // entries belonging to *other* window keys before creating a new helper — so
+  // a per-key queue could stop an entry that a concurrent attach on that key is
+  // adopting. A slow helper.stop() therefore does delay an attach on an
+  // unrelated simulator; that is an accepted trade for the eviction invariant,
+  // since concurrent multi-simulator streaming is rare and the stops are
+  // TTL-bounded best-effort work. Revisit with per-key serialization only after
+  // decoupling the cross-target eviction from attach.
   private enqueue(action: () => Promise<void>): Promise<void> {
     const next = this.transition.then(action, action);
     this.transition = next.catch(() => undefined);

--- a/test/features/screen-stream/IOSSimulatorCaptureHelperPool.test.ts
+++ b/test/features/screen-stream/IOSSimulatorCaptureHelperPool.test.ts
@@ -194,6 +194,49 @@ describe("IOSSimulatorCaptureHelperPool", () => {
     }
   });
 
+  test("drops a poisoned entry after a failed stop so the next attach gets a fresh helper", async () => {
+    const helpers: FakeSimulatorHelper[] = [];
+    const pool = new IOSSimulatorCaptureHelperPool({
+      createHelper: () => {
+        const helper = new FakeSimulatorHelper();
+        helpers.push(helper);
+        return helper;
+      },
+    });
+    const first = pool.acquire(simulatorOptions(42));
+    first.on("error", () => {});
+    await first.start();
+    // The next stop() throws exactly once, then the fake reports as stopped.
+    helpers[0].stopError = new Error("stop failed");
+    const warning = spyOn(logger, "warn").mockImplementation(() => {});
+
+    try {
+      helpers[0].emit("error", new Error("capture failed"));
+      await flushMicrotasks();
+
+      // Failed cleanup surfaced its error, and the poisoned entry was dropped.
+      expect(warning).toHaveBeenCalledWith(
+        expect.stringContaining("failed helper stop failed: Error: stop failed")
+      );
+      expect(helpers[0].stops).toBe(1);
+
+      // A later attach to the SAME window key must create a fresh helper rather
+      // than re-throwing the sticky stop failure forever.
+      helpers[0].stopError = null;
+      const second = pool.acquire(simulatorOptions(42));
+      await second.start();
+
+      expect(helpers).toHaveLength(2);
+      expect(helpers[1].starts).toBe(1);
+      expect(second.isStarted).toBe(true);
+      await second.stop();
+    } finally {
+      warning.mockRestore();
+      await first.stop();
+      await pool.shutdown();
+    }
+  });
+
   test("does not create a helper when a lease stops before its queued attachment", async () => {
     const timer = new FakeTimer();
     const helpers: FakeSimulatorHelper[] = [];


### PR DESCRIPTION
Closes [#4769](https://github.com/kaeawc/auto-mobile/issues/4769)

## Summary

Fixes Problem 1 from the issue: a failed-stop entry in the warm iOS Simulator
capture-helper pool (`IOSSimulatorCaptureHelperPool`) permanently poisoned its
target window key.

When a failed entry's `helper.stop()` threw, the pool recorded a sticky
`failedStopFailed` / `failedStopError` and `attach()` re-threw it on *every*
future attach to the same window key, never dropping the entry. A single stuck
stop permanently poisoned that Simulator window target until the daemon
restarted — no new capture of that window could ever start.

### Change

- `attach()` now **drops** a `failedStopFailed` entry and builds a fresh helper
  instead of re-throwing forever — bounded retry, not permanent poison
  (`src/features/screen-stream/IOSSimulatorCaptureHelperPool.ts`).
- `stopFailedEntry()` still surfaces the stop failure **once** to the awaiting
  cleanup path (`invalidate` / best-effort). That recorded error now serves
  only concurrent cleanup of the same failed entry; it is no longer consulted
  by a future `attach`. This preserves `IosH264Source`'s fail-closed behavior
  when a silent-helper teardown's `stop()` fails.

### Problem 2 (global serialization) — documented, not changed

The issue lists per-target serialization as optional. `attach()` performs
cross-target work — it evicts idle entries belonging to *other* window keys
before creating a new helper — so a naive per-key queue could stop an entry
that a concurrent attach on that key is adopting. The global `transition` chain
is load-bearing for that eviction invariant, so it is retained with an
explanatory comment rather than replaced. A slow `stop()` therefore still
delays an attach on an unrelated simulator; that is an accepted trade-off,
since concurrent multi-simulator streaming is rare and the stops are
TTL-bounded best-effort work.

## Tests

Adds a regression test to `IOSSimulatorCaptureHelperPool.test.ts`:
`stop()` throws once → a later `attach` to the same key succeeds with a fresh
helper, and the failure is surfaced once via the best-effort cleanup log.

## Validation

All run inline on the branch head:

- `bun run typecheck` — pass (no new type errors; 198 known baseline errors).
- `bunx turbo run lint build` — pass (2 successful).
- `bun test` (full suite) — **12084 pass, 13 skip, 0 fail** (12097 tests, 859 files).
