### PR TITLE
Desktop workspace: Failures facet (cross-device)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/FailuresFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/FailuresFacet.kt
@@ -1,0 +1,33 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.runtime.Composable
+import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
+import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
+import dev.jasonpearson.automobile.desktop.core.failures.FailuresDashboard
+
+/**
+ * Docked-facet body for [Tool.Failures]: the failures dashboard (crashes, ANRs, tool-call failures,
+ * non-fatals).
+ *
+ * Unlike the per-device facets ([LogsFacet], [StorageFacet]), failures data is a **cross-device
+ * global aggregate**: the daemon's `automobile:failures` resource is not device-filtered, so every
+ * pane renders the same failures list regardless of which device [column] describes. This matches
+ * the wireframe, which treats 💥 Failures as "cross-device by design"; a per-device filter is a
+ * separate daemon follow-up. The [column] is accepted to keep a uniform facet signature with the
+ * host's tool→facet mapping.
+ *
+ * [dataSourceMode] is injected (defaulting to [DataSourceMode.Real]) so the dashboard can be
+ * rendered against fake data in tests without real MCP I/O. The client is read from the DI graph
+ * and only touched by the dashboard in [DataSourceMode.Real].
+ */
+@Composable
+fun FailuresFacet(
+  column: DeviceColumn,
+  dataSourceMode: DataSourceMode = DataSourceMode.Real,
+) {
+  val graph = LocalAutoMobileGraph.current
+  FailuresDashboard(
+    dataSourceMode = dataSourceMode,
+    clientProvider = { graph.autoMobileClient },
+  )
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/FailuresFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/FailuresFacetTest.kt
@@ -1,0 +1,45 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class FailuresFacetTest {
+
+  private fun column(platform: Platform) =
+    DeviceColumn(deviceId = "dev-1", name = "Pixel", platform = platform)
+
+  /** The dashboard chrome renders for an Android pane (Fake mode avoids real MCP I/O). */
+  @Test
+  fun `renders the failures dashboard for an android pane`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        FailuresFacet(column = column(Platform.Android), dataSourceMode = DataSourceMode.Fake)
+      }
+    }
+    waitForIdle()
+    // The Issues header and the All filter chip are the stable dashboard chrome.
+    onNodeWithText("Issues", substring = true).assertIsDisplayed()
+    onNodeWithText("All").assertIsDisplayed()
+  }
+
+  /**
+   * The same cross-device dashboard renders for an iOS pane — failures are a global aggregate, so
+   * the facet does not crash or diverge by platform.
+   */
+  @Test
+  fun `renders the failures dashboard for an ios pane`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        FailuresFacet(column = column(Platform.Ios), dataSourceMode = DataSourceMode.Fake)
+      }
+    }
+    waitForIdle()
+    onNodeWithText("Issues", substring = true).assertIsDisplayed()
+  }
+}


### PR DESCRIPTION
Adds the 💥 Failures facet — a docked tool window rendering `FailuresDashboard`. Part of the facet build-out ([#4715](https://github.com/kaeawc/auto-mobile/issues/4715)).

## Note on scope
`automobile:failures` is a **cross-device global aggregate** (no device-filtered resource), so every pane shows the same failures list — matching the wireframe (💥 is a per-device *tool*, but the data is global). A per-device-filtered failures resource is a daemon follow-up (see [#4715](https://github.com/kaeawc/auto-mobile/issues/4715)); documented in the facet KDoc.

## Changes
- `FailuresFacet.kt` (+ test) — renders `FailuresDashboard(dataSourceMode = Real, clientProvider = { graph.autoMobileClient })` via `LocalAutoMobileGraph.current`; `dataSourceMode` is injectable (defaults Real) so the test drives it in Fake mode.

## Validation
- `:desktop-core:detektMain` + `:desktop-core:test` (2 Compose tests, Android+iOS panes) + `compileKotlin` — green.

Host wiring lands in the combined `WorkspaceFacet` PR.