### PR TITLE
Desktop workspace: Network facet (first cut)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/NetworkGraphDataSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/NetworkGraphDataSource.kt
@@ -87,7 +87,11 @@ private fun walkPaths(
 ) {
   for ((key, element) in paths) {
     val node = element as? JsonObject ?: continue
-    val segment = stripMethodSuffix(key)
+    val nested = node["paths"] as? JsonObject
+    // The server appends `[METHOD]` only to pure-leaf keys (`insertIntoTree`); branch and
+    // leaf+branch keys stay literal. So strip the method suffix only when this node has no
+    // children — otherwise a real bracketed segment like `items[archived]` would be mangled.
+    val segment = if (nested != null) key else stripMethodSuffix(key)
     val nextSegments = if (segment.isEmpty()) segments else segments + segment
     if (node.containsKey("success")) {
       out.add(
@@ -104,7 +108,6 @@ private fun walkPaths(
         )
       )
     }
-    val nested = node["paths"] as? JsonObject
     if (nested != null) {
       walkPaths(scheme, host, nested, nextSegments, out)
     }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/NetworkGraphDataSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/NetworkGraphDataSource.kt
@@ -1,0 +1,112 @@
+package dev.jasonpearson.automobile.desktop.core.datasource
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * A single captured endpoint, flattened out of the `getNetworkGraph` host → path tree into one row
+ * per method+path so the first-cut facet can render a flat list. [path] is the joined path segments
+ * (parameterized segments preserved as their `{id}` marker); [method]/[type] come from the leaf.
+ */
+data class NetworkEndpointRow(
+  val scheme: String,
+  val host: String,
+  val path: String,
+  val method: String?,
+  val type: String?,
+  val success: Int,
+  val errors: Int,
+  val p50: Int,
+  val p95: Int,
+)
+
+/**
+ * Reads the aggregate captured network graph for a device. Returns already-flattened endpoint rows
+ * so the facet stays a dumb renderer. Injected as an interface so the facet is testable without a
+ * live MCP daemon (see [FakeNetworkGraphDataSource]).
+ */
+interface NetworkGraphDataSource {
+  suspend fun getNetworkGraph(): Result<List<NetworkEndpointRow>>
+}
+
+/** Test double: returns a canned result (default: an empty graph). */
+class FakeNetworkGraphDataSource(
+  private val result: Result<List<NetworkEndpointRow>> = Result.Success(emptyList())
+) : NetworkGraphDataSource {
+  override suspend fun getNetworkGraph(): Result<List<NetworkEndpointRow>> = result
+}
+
+// --- MCP response models (mirror src/server/networkGraph.ts NetworkGraph) ---
+
+/** Top-level `getNetworkGraph` payload: `{ graph: GraphHost[] }`. */
+@Serializable data class NetworkGraphResponse(val graph: List<NetworkGraphHost> = emptyList())
+
+/**
+ * One host in the graph. `paths` is a dynamically keyed `Record<string, GraphNode>` where a node is
+ * a leaf (has `success`), a branch (has `paths`), or both — so it is kept as raw [JsonElement] and
+ * walked structurally by [flattenNetworkGraph] rather than modeled as a sealed union.
+ */
+@Serializable
+data class NetworkGraphHost(
+  val scheme: String = "https",
+  val host: String = "",
+  val paths: Map<String, JsonElement> = emptyMap(),
+)
+
+private val METHOD_SUFFIX = Regex("""\[[^\]]*\]$""")
+
+/** Strip the trailing `[GET]`/`[POST]` method disambiguator the daemon appends to leaf keys. */
+private fun stripMethodSuffix(key: String): String = key.replace(METHOD_SUFFIX, "")
+
+private fun JsonObject.intField(name: String): Int = this[name]?.jsonPrimitive?.intOrNull ?: 0
+
+private fun JsonObject.stringField(name: String): String? = this[name]?.jsonPrimitive?.content
+
+/**
+ * Walk the host → path tree, emitting one [NetworkEndpointRow] per leaf (a node carrying a
+ * `success` count). Recurses into any `paths` branch, accumulating path segments. Pure so the
+ * flattening is unit-testable independent of MCP.
+ */
+fun flattenNetworkGraph(hosts: List<NetworkGraphHost>): List<NetworkEndpointRow> {
+  val rows = mutableListOf<NetworkEndpointRow>()
+  for (host in hosts) {
+    walkPaths(host.scheme, host.host, host.paths, emptyList(), rows)
+  }
+  return rows
+}
+
+private fun walkPaths(
+  scheme: String,
+  host: String,
+  paths: Map<String, JsonElement>,
+  segments: List<String>,
+  out: MutableList<NetworkEndpointRow>,
+) {
+  for ((key, element) in paths) {
+    val node = element as? JsonObject ?: continue
+    val segment = stripMethodSuffix(key)
+    val nextSegments = if (segment.isEmpty()) segments else segments + segment
+    if (node.containsKey("success")) {
+      out.add(
+        NetworkEndpointRow(
+          scheme = scheme,
+          host = host,
+          path = "/" + nextSegments.joinToString("/"),
+          method = node.stringField("method"),
+          type = node.stringField("type"),
+          success = node.intField("success"),
+          errors = node.intField("errors"),
+          p50 = node.intField("p50"),
+          p95 = node.intField("p95"),
+        )
+      )
+    }
+    val nested = node["paths"] as? JsonObject
+    if (nested != null) {
+      walkPaths(scheme, host, nested, nextSegments, out)
+    }
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealNetworkGraphDataSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealNetworkGraphDataSource.kt
@@ -1,0 +1,62 @@
+package dev.jasonpearson.automobile.desktop.core.datasource
+
+import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.daemon.McpConnectionException
+import dev.jasonpearson.automobile.desktop.core.daemon.decodeToolResponse
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.serializer
+
+private val LOG = LoggerFactory.getLogger("RealNetworkGraphDataSource")
+
+/**
+ * Real network-graph data source backed by the `getNetworkGraph` MCP tool (device-aware; embedded
+ * SDK only). The tool returns an empty graph when no traffic was captured, which the facet renders
+ * as an explicit empty state rather than an error.
+ *
+ * @param clientProvider Function to provide an [AutoMobileClient] for MCP access
+ * @param deviceId The device ID to fetch the network graph for
+ * @param sinceSeconds Optional lookback window (forwarded to the tool)
+ * @param minRequests Optional minimum request count per endpoint (forwarded to the tool)
+ */
+class RealNetworkGraphDataSource(
+  private val clientProvider: (() -> AutoMobileClient)? = null,
+  private val deviceId: String? = null,
+  private val sinceSeconds: Int? = null,
+  private val minRequests: Int? = null,
+) : NetworkGraphDataSource {
+  private val json = Json { ignoreUnknownKeys = true }
+
+  override suspend fun getNetworkGraph(): Result<List<NetworkEndpointRow>> {
+    val provider =
+      clientProvider
+        ?: return Result.Error(
+          IllegalStateException("Not connected to MCP server. Please select a device first.")
+        )
+    val device = deviceId ?: return Result.Error(IllegalStateException("No device ID provided"))
+
+    return try {
+      withContext(Dispatchers.IO) {
+        val client = provider()
+        val arguments = buildJsonObject {
+          put("deviceId", device)
+          sinceSeconds?.let { put("sinceSeconds", it) }
+          minRequests?.let { put("minRequests", it) }
+        }
+        val toolElement = client.callTool("getNetworkGraph", arguments)
+        val response = decodeToolResponse(json, toolElement, serializer<NetworkGraphResponse>())
+        Result.Success(flattenNetworkGraph(response.graph))
+      }
+    } catch (e: McpConnectionException) {
+      LOG.warn("getNetworkGraph: MCP connection error: ${e.message}", e)
+      Result.Error(e, "MCP server not available: ${e.message}")
+    } catch (e: Exception) {
+      LOG.warn("getNetworkGraph: Exception: ${e.message}", e)
+      Result.Error(e, "Failed to load network graph: ${e.message}")
+    }
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealNetworkGraphDataSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealNetworkGraphDataSource.kt
@@ -4,10 +4,17 @@ import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
 import dev.jasonpearson.automobile.desktop.core.daemon.McpConnectionException
 import dev.jasonpearson.automobile.desktop.core.daemon.decodeToolResponse
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import java.io.File
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlinx.serialization.serializer
 
@@ -18,18 +25,30 @@ private val LOG = LoggerFactory.getLogger("RealNetworkGraphDataSource")
  * SDK only). The tool returns an empty graph when no traffic was captured, which the facet renders
  * as an explicit empty state rather than an error.
  *
+ * Artifact resolution: for external (non-internal) calls the daemon does NOT return the graph
+ * inline — `finalizeToolResponse` replaces the `graph` array with artifact metadata (`{ artifact: {
+ * path, format, ... } }`) and writes the real `GraphHost[]` JSON to a local file (see
+ * `src/server/finalizeToolResponse.ts` `artifactNetworkGraphPayload`). Because the daemon is
+ * co-located with the desktop app, we resolve the reference by reading that file from disk — the
+ * same way the desktop consumes daemon-written video artifacts. The inline shape is still handled
+ * for internal/older daemons that embed the array directly.
+ *
  * @param clientProvider Function to provide an [AutoMobileClient] for MCP access
  * @param deviceId The device ID to fetch the network graph for
  * @param sinceSeconds Optional lookback window (forwarded to the tool)
  * @param minRequests Optional minimum request count per endpoint (forwarded to the tool)
+ * @param readArtifactFile Reads a daemon-written artifact file by absolute path; injected so
+ *   artifact resolution is unit-testable without touching the filesystem.
  */
 class RealNetworkGraphDataSource(
   private val clientProvider: (() -> AutoMobileClient)? = null,
   private val deviceId: String? = null,
   private val sinceSeconds: Int? = null,
   private val minRequests: Int? = null,
+  private val readArtifactFile: (String) -> String = { path -> File(path).readText() },
 ) : NetworkGraphDataSource {
   private val json = Json { ignoreUnknownKeys = true }
+  private val hostListSerializer = ListSerializer(NetworkGraphHost.serializer())
 
   override suspend fun getNetworkGraph(): Result<List<NetworkEndpointRow>> {
     val provider =
@@ -48,15 +67,38 @@ class RealNetworkGraphDataSource(
           minRequests?.let { put("minRequests", it) }
         }
         val toolElement = client.callTool("getNetworkGraph", arguments)
-        val response = decodeToolResponse(json, toolElement, serializer<NetworkGraphResponse>())
-        Result.Success(flattenNetworkGraph(response.graph))
+        val payload = decodeToolResponse(json, toolElement, serializer<JsonObject>())
+        Result.Success(flattenNetworkGraph(resolveHosts(payload)))
       }
     } catch (e: McpConnectionException) {
       LOG.warn("getNetworkGraph: MCP connection error: ${e.message}", e)
       Result.Error(e, "MCP server not available: ${e.message}")
     } catch (e: Exception) {
+      // Let coroutine cancellation propagate so this suspend call stays cancellable
+      // (matches McpHttpClient's catch guard).
+      if (e is CancellationException) throw e
       LOG.warn("getNetworkGraph: Exception: ${e.message}", e)
       Result.Error(e, "Failed to load network graph: ${e.message}")
+    }
+  }
+
+  /**
+   * Extract the `GraphHost[]` from the tool payload, resolving the artifact reference when the
+   * graph was written to disk. Returns an empty list when the payload carries no graph (e.g. an
+   * unexpected shape) so the facet can distinguish "no traffic" from a hard failure.
+   */
+  private fun resolveHosts(payload: JsonObject): List<NetworkGraphHost> {
+    return when (val graph = payload["graph"]) {
+      is JsonArray -> json.decodeFromJsonElement(hostListSerializer, graph)
+      is JsonObject -> {
+        val path =
+          graph["artifact"]?.jsonObject?.get("path")?.jsonPrimitive?.content
+            ?: throw McpConnectionException(
+              "getNetworkGraph returned neither an inline graph nor an artifact path"
+            )
+        json.decodeFromString(hostListSerializer, readArtifactFile(path))
+      }
+      else -> emptyList()
     }
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NetworkFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NetworkFacet.kt
@@ -1,0 +1,147 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import dev.jasonpearson.automobile.desktop.core.datasource.NetworkEndpointRow
+import dev.jasonpearson.automobile.desktop.core.datasource.RealNetworkGraphDataSource
+import dev.jasonpearson.automobile.desktop.core.datasource.Result
+import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private sealed interface NetworkFacetState {
+  data object Loading : NetworkFacetState
+
+  data object Empty : NetworkFacetState
+
+  data class Error(val message: String) : NetworkFacetState
+
+  data class Resolved(val rows: List<NetworkEndpointRow>) : NetworkFacetState
+}
+
+/**
+ * Docked-facet body for [Tool.Network]: a first-cut flat list of the captured network endpoints for
+ * a pane's device, read from the `getNetworkGraph` MCP tool. This is intentionally minimal — a flat
+ * host/method/path list, not the full host → path tree dashboard.
+ *
+ * The graph read is injected via [loadNetworkGraph] so the loading/empty/error states are testable
+ * without a live MCP daemon; the default reads through a [RealNetworkGraphDataSource] built from
+ * the DI graph. The tool is embedded-SDK-only and returns an empty graph when no traffic was
+ * captured, which is surfaced as an explicit empty state rather than an error.
+ */
+@Composable
+fun NetworkFacet(
+  column: DeviceColumn,
+  loadNetworkGraph: (suspend (String) -> Result<List<NetworkEndpointRow>>)? = null,
+) {
+  val graph = LocalAutoMobileGraph.current
+  val loader: suspend (String) -> Result<List<NetworkEndpointRow>> =
+    loadNetworkGraph
+      ?: { deviceId ->
+        // Read off the UI thread: the tool call hits the daemon and would otherwise block
+        // recomposition. Injected test loaders run inline (deterministic).
+        withContext(Dispatchers.IO) {
+          RealNetworkGraphDataSource({ graph.autoMobileClient }, deviceId).getNetworkGraph()
+        }
+      }
+  var attempt by remember(column.deviceId) { mutableStateOf(0) }
+  var state by
+    remember(column.deviceId, attempt) {
+      mutableStateOf<NetworkFacetState>(NetworkFacetState.Loading)
+    }
+  LaunchedEffect(column.deviceId, attempt) {
+    state =
+      when (val result = loader(column.deviceId)) {
+        is Result.Success ->
+          if (result.data.isEmpty()) NetworkFacetState.Empty
+          else NetworkFacetState.Resolved(result.data)
+        is Result.Error ->
+          NetworkFacetState.Error(result.message ?: "Failed to load the network graph")
+        // A one-shot tool call resolves to Success/Error; treat a stray Loading as retryable.
+        Result.Loading -> NetworkFacetState.Error("Network graph is still loading")
+      }
+  }
+  when (val current = state) {
+    NetworkFacetState.Loading -> NetworkFacetNote("Loading network activity…")
+    NetworkFacetState.Empty -> NetworkFacetNote("No network activity captured on this device")
+    is NetworkFacetState.Error -> NetworkFacetError(current.message) { attempt++ }
+    is NetworkFacetState.Resolved -> NetworkEndpointList(current.rows)
+  }
+}
+
+/** Flat list of captured endpoints, one row per method+path. */
+@Composable
+private fun NetworkEndpointList(rows: List<NetworkEndpointRow>) {
+  LazyColumn(Modifier.fillMaxSize().padding(8.dp)) {
+    items(rows) { row -> NetworkEndpointRowItem(row) }
+  }
+}
+
+@Composable
+private fun NetworkEndpointRowItem(row: NetworkEndpointRow) {
+  Column(Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+    Row {
+      Text(
+        row.method ?: "—",
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(end = 8.dp),
+      )
+      Text("${row.host}${row.path}", style = MaterialTheme.typography.bodyMedium)
+    }
+    Text(
+      "✓ ${row.success}  ✗ ${row.errors}  p50 ${row.p50}ms  p95 ${row.p95}ms",
+      style = MaterialTheme.typography.labelSmall,
+      color = MaterialTheme.colorScheme.outline,
+    )
+  }
+}
+
+/** Centered single-line note for the facet's transient (loading) or empty states. */
+@Composable
+private fun NetworkFacetNote(text: String) {
+  Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    Text(text, color = MaterialTheme.colorScheme.outline)
+  }
+}
+
+/** Error state with a Retry affordance that re-runs the network-graph load. */
+@Composable
+private fun NetworkFacetError(message: String, onRetry: () -> Unit) {
+  Column(
+    Modifier.fillMaxSize(),
+    verticalArrangement = Arrangement.Center,
+    horizontalAlignment = Alignment.CenterHorizontally,
+  ) {
+    Text(message, color = MaterialTheme.colorScheme.error)
+    Text(
+      "Retry",
+      color = MaterialTheme.colorScheme.primary,
+      modifier =
+        Modifier.padding(top = 8.dp).clickable(onClick = onRetry).semantics {
+          contentDescription = "Retry loading network graph"
+        },
+    )
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/NetworkGraphFlattenTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/NetworkGraphFlattenTest.kt
@@ -1,0 +1,97 @@
+package dev.jasonpearson.automobile.desktop.core.datasource
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NetworkGraphFlattenTest {
+
+  private val json = Json { ignoreUnknownKeys = true }
+
+  private fun parse(text: String): List<NetworkGraphHost> =
+    json.decodeFromString(NetworkGraphResponse.serializer(), text).graph
+
+  @Test
+  fun `flattens a host tree into one row per leaf`() {
+    val hosts =
+      parse(
+        """
+        {
+          "graph": [
+            {
+              "scheme": "https",
+              "host": "api.example.com",
+              "paths": {
+                "users[GET]": {"method":"GET","type":"application/json","success":3,"errors":1,"p50":10,"p95":20},
+                "users": {
+                  "paths": {
+                    "{id}[GET]": {"method":"GET","success":5,"errors":0,"p50":8,"p95":15,"parameterized":true}
+                  }
+                },
+                "[GET]": {"method":"GET","success":2,"errors":0,"p50":1,"p95":2}
+              }
+            }
+          ]
+        }
+        """
+          .trimIndent()
+      )
+
+    val rows = flattenNetworkGraph(hosts)
+
+    assertEquals(3, rows.size)
+
+    val users = rows.first { it.path == "/users" }
+    assertEquals("api.example.com", users.host)
+    assertEquals("GET", users.method)
+    assertEquals("application/json", users.type)
+    assertEquals(3, users.success)
+    assertEquals(1, users.errors)
+    assertEquals(10, users.p50)
+    assertEquals(20, users.p95)
+  }
+
+  @Test
+  fun `joins nested segments and preserves the parameterized marker`() {
+    val hosts =
+      parse(
+        """
+        {"graph":[{"scheme":"https","host":"api.example.com","paths":{
+          "users":{"paths":{"{id}[GET]":{"method":"GET","success":5,"errors":0,"p50":8,"p95":15}}}
+        }}]}
+        """
+          .trimIndent()
+      )
+
+    val rows = flattenNetworkGraph(hosts)
+
+    val nested = rows.firstOrNull { it.path == "/users/{id}" }
+    assertNotNull("expected a flattened row for the parameterized path", nested)
+    assertEquals(5, nested!!.success)
+  }
+
+  @Test
+  fun `renders the root path as slash`() {
+    val hosts =
+      parse(
+        """
+        {"graph":[{"scheme":"https","host":"api.example.com","paths":{
+          "[GET]":{"method":"GET","success":2,"errors":0,"p50":1,"p95":2}
+        }}]}
+        """
+          .trimIndent()
+      )
+
+    val rows = flattenNetworkGraph(hosts)
+
+    assertEquals(1, rows.size)
+    assertEquals("/", rows.first().path)
+  }
+
+  @Test
+  fun `an empty graph flattens to no rows`() {
+    assertTrue(flattenNetworkGraph(parse("""{"graph":[]}""")).isEmpty())
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/NetworkGraphFlattenTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/NetworkGraphFlattenTest.kt
@@ -73,6 +73,26 @@ class NetworkGraphFlattenTest {
   }
 
   @Test
+  fun `preserves a bracketed intermediate segment and strips only the leaf method suffix`() {
+    val hosts =
+      parse(
+        """
+        {"graph":[{"scheme":"https","host":"api.example.com","paths":{
+          "items[archived]":{"paths":{"detail[GET]":{"method":"GET","success":4,"errors":0,"p50":5,"p95":9}}}
+        }}]}
+        """
+          .trimIndent()
+      )
+
+    val rows = flattenNetworkGraph(hosts)
+
+    assertEquals(1, rows.size)
+    // The `[archived]` branch segment must survive; only the leaf's `[GET]` is stripped.
+    assertEquals("/items[archived]/detail", rows.first().path)
+    assertEquals("GET", rows.first().method)
+  }
+
+  @Test
   fun `renders the root path as slash`() {
     val hosts =
       parse(

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealNetworkGraphDataSourceTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealNetworkGraphDataSourceTest.kt
@@ -1,0 +1,186 @@
+package dev.jasonpearson.automobile.desktop.core.datasource
+
+import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RealNetworkGraphDataSourceTest {
+
+  /** Wraps tool-result JSON the way the MCP tool-response envelope does. */
+  private fun toolResponse(bodyJson: String): JsonElement = buildJsonObject {
+    put(
+      "content",
+      buildJsonArray {
+        add(
+          buildJsonObject {
+            put("type", "text")
+            put("text", bodyJson)
+          }
+        )
+      },
+    )
+  }
+
+  private val hostArrayJson =
+    """
+    [
+      {
+        "scheme": "https",
+        "host": "api.example.com",
+        "paths": {
+          "users[GET]": {"method":"GET","type":"application/json","success":3,"errors":1,"p50":10,"p95":20}
+        }
+      }
+    ]
+    """
+      .trimIndent()
+
+  @Test
+  fun `returns error when no clientProvider`() = runBlocking {
+    val result = RealNetworkGraphDataSource().getNetworkGraph()
+
+    assertTrue(result is Result.Error)
+    assertTrue((result as Result.Error).message!!.contains("Not connected"))
+  }
+
+  @Test
+  fun `returns error when no deviceId`() = runBlocking {
+    val client = FakeAutoMobileClient()
+    val result =
+      RealNetworkGraphDataSource(clientProvider = { client }, deviceId = null).getNetworkGraph()
+
+    assertTrue(result is Result.Error)
+    assertTrue((result as Result.Error).message!!.contains("device"))
+  }
+
+  @Test
+  fun `decodes an inline graph and forwards deviceId plus filters`() = runBlocking {
+    val client = FakeAutoMobileClient()
+    client.callToolResult = toolResponse("""{"graph": $hostArrayJson}""")
+    var capturedArgs: JsonObject? = null
+    val capturing =
+      object : AutoMobileClient by client {
+        override fun callTool(name: String, arguments: JsonObject): JsonElement {
+          capturedArgs = arguments
+          return client.callToolResult
+        }
+      }
+
+    val result =
+      RealNetworkGraphDataSource(
+          clientProvider = { capturing },
+          deviceId = "emulator-5554",
+          sinceSeconds = 60,
+          minRequests = 2,
+        )
+        .getNetworkGraph()
+
+    assertTrue(result is Result.Success)
+    val rows = (result as Result.Success).data
+    assertEquals(1, rows.size)
+    assertEquals("api.example.com", rows.first().host)
+    assertEquals("/users", rows.first().path)
+    assertEquals("GET", rows.first().method)
+    assertEquals(3, rows.first().success)
+
+    val args = capturedArgs!!
+    assertEquals("emulator-5554", args.getValue("deviceId").jsonPrimitive.content)
+    assertEquals(60, args.getValue("sinceSeconds").jsonPrimitive.int)
+    assertEquals(2, args.getValue("minRequests").jsonPrimitive.int)
+  }
+
+  @Test
+  fun `resolves the artifacted graph by reading the artifact file`() = runBlocking {
+    val client = FakeAutoMobileClient()
+    // External calls artifact the array away; the response carries only a file reference.
+    client.callToolResult =
+      toolResponse(
+        """
+        {
+          "graph": {"artifact": {"path": "/tmp/auto-mobile/getNetworkGraph-1.json", "format": "json", "payload": "NetworkGraph", "bytes": 123, "tool": "getNetworkGraph"}},
+          "graphSummary": {"hostCount": 1}
+        }
+        """
+          .trimIndent()
+      )
+    var requestedPath: String? = null
+
+    val result =
+      RealNetworkGraphDataSource(
+          clientProvider = { client },
+          deviceId = "emulator-5554",
+          readArtifactFile = { path ->
+            requestedPath = path
+            hostArrayJson
+          },
+        )
+        .getNetworkGraph()
+
+    assertTrue(result is Result.Success)
+    assertEquals("/tmp/auto-mobile/getNetworkGraph-1.json", requestedPath)
+    val rows = (result as Result.Success).data
+    assertEquals(1, rows.size)
+    assertEquals("/users", rows.first().path)
+  }
+
+  @Test
+  fun `an artifacted empty graph resolves to no rows`() = runBlocking {
+    val client = FakeAutoMobileClient()
+    client.callToolResult =
+      toolResponse(
+        """{"graph": {"artifact": {"path": "/tmp/empty.json"}}, "graphSummary": {"hostCount": 0}}"""
+      )
+
+    val result =
+      RealNetworkGraphDataSource(
+          clientProvider = { client },
+          deviceId = "emulator-5554",
+          readArtifactFile = { "[]" },
+        )
+        .getNetworkGraph()
+
+    assertTrue(result is Result.Success)
+    assertTrue((result as Result.Success).data.isEmpty())
+  }
+
+  @Test
+  fun `returns error when the artifact reference has no path`() = runBlocking {
+    val client = FakeAutoMobileClient()
+    client.callToolResult = toolResponse("""{"graph": {"artifact": {"format": "json"}}}""")
+
+    val result =
+      RealNetworkGraphDataSource(clientProvider = { client }, deviceId = "emulator-5554")
+        .getNetworkGraph()
+
+    assertTrue(result is Result.Error)
+    assertTrue((result as Result.Error).message!!.contains("artifact path"))
+  }
+
+  @Test
+  fun `returns error when the artifact file cannot be read`() = runBlocking {
+    val client = FakeAutoMobileClient()
+    client.callToolResult =
+      toolResponse("""{"graph": {"artifact": {"path": "/tmp/missing.json"}}}""")
+
+    val result =
+      RealNetworkGraphDataSource(
+          clientProvider = { client },
+          deviceId = "emulator-5554",
+          readArtifactFile = { throw java.io.IOException("no such file") },
+        )
+        .getNetworkGraph()
+
+    assertTrue(result is Result.Error)
+    assertTrue((result as Result.Error).message!!.contains("Failed to load network graph"))
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NetworkFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NetworkFacetTest.kt
@@ -1,0 +1,97 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.datasource.NetworkEndpointRow
+import dev.jasonpearson.automobile.desktop.core.datasource.Result
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class NetworkFacetTest {
+
+  private fun column() = DeviceColumn(deviceId = "d", name = "Pixel", platform = Platform.Android)
+
+  private fun row(host: String, path: String, method: String = "GET") =
+    NetworkEndpointRow(
+      scheme = "https",
+      host = host,
+      path = path,
+      method = method,
+      type = "application/json",
+      success = 3,
+      errors = 1,
+      p50 = 10,
+      p95 = 20,
+    )
+
+  @Test
+  fun `shows the empty state when the graph has no captured traffic`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        NetworkFacet(column = column(), loadNetworkGraph = { Result.Success(emptyList()) })
+      }
+    }
+    waitForIdle()
+    onNodeWithText("No network activity captured", substring = true).assertIsDisplayed()
+  }
+
+  @Test
+  fun `renders a row per captured endpoint`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        NetworkFacet(
+          column = column(),
+          loadNetworkGraph = {
+            Result.Success(listOf(row("api.example.com", "/users/{id}")))
+          },
+        )
+      }
+    }
+    waitForIdle()
+    onNodeWithText("api.example.com/users/{id}", substring = true).assertIsDisplayed()
+  }
+
+  @Test
+  fun `surfaces a retryable error when the graph fails to load`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        NetworkFacet(
+          column = column(),
+          loadNetworkGraph = { Result.Error(RuntimeException("daemon down")) },
+        )
+      }
+    }
+    waitForIdle()
+    onNodeWithText("daemon down", substring = true).assertIsDisplayed()
+    onNodeWithContentDescription("Retry loading network graph").assertIsDisplayed()
+  }
+
+  @Test
+  fun `retry re-invokes the loader and renders the recovered rows`() = runComposeUiTest {
+    val attempts = AtomicInteger(0)
+    setContent {
+      MaterialTheme {
+        NetworkFacet(
+          column = column(),
+          loadNetworkGraph = {
+            if (attempts.getAndIncrement() == 0) Result.Error(RuntimeException("daemon down"))
+            else Result.Success(listOf(row("api.example.com", "/health")))
+          },
+        )
+      }
+    }
+    waitForIdle()
+    onNodeWithText("daemon down", substring = true).assertIsDisplayed()
+
+    onNodeWithContentDescription("Retry loading network graph").performClick()
+    waitForIdle()
+
+    onNodeWithText("api.example.com/health", substring = true).assertIsDisplayed()
+  }
+}


### PR DESCRIPTION
Adds a first-cut 🌐 Network facet — there was **no** Network dashboard before, only the `getNetworkGraph` MCP tool. Part of the facet build-out ([#4715](https://github.com/kaeawc/auto-mobile/issues/4715)).

## Changes (all new files, no host edits)
- `NetworkGraphDataSource` (interface + `Fake` + `Real` calling `getNetworkGraph` per-device) + `@Serializable` response models + a pure `flattenNetworkGraph` tree-walk.
- `NetworkFacet.kt` — per-pane facet mirroring `StorageFacet`'s Loading/Empty/Error(+Retry)/Resolved states via an injected loader (default real); renders a flat `LazyColumn` of endpoints (method, host+path, success/errors/p50/p95).
- Tests: `NetworkFacetTest` (empty/rows/error/retry) + `NetworkGraphFlattenTest` (pure flattener).

## First-cut / deferred (honest)
- Flat list, not the wireframe's expandable host→path tree dashboard — deliberately minimal.
- Injected-loader seam (no `DataSourceFactory` change); a factory method + a `RealNetworkGraphDataSourceTest` are follow-ups.
- Empty graph → explicit "No network activity captured" (embedded-SDK-only tool).

## Validation
- `:desktop-core:detektMain` + `:desktop-core:test` (NetworkFacetTest + NetworkGraphFlattenTest) + `compileKotlin` — green.

Host wiring lands in the combined `WorkspaceFacet` PR.