### PR TITLE
feat(desktop): command-palette keyboard nav + device-label disambiguation

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPalette.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPalette.kt
@@ -51,25 +51,37 @@ internal fun filterCommands(commands: List<PaletteCommand>, query: String): List
 /**
  * Human-readable display names for [columns], keyed by device id. When two columns share a display
  * name (common for iOS simulators, which surface identical labels like "iPhone 15"), the colliding
- * ones get a short device-id suffix so palette labels stay distinguishable. Unique names are left
- * untouched. Command ids are already device-id-keyed, so this only affects the visible label. Pure.
+ * ones get a device-id suffix so palette labels stay distinguishable. The suffix is the *shortest*
+ * length that is unique within that duplicate-name group, so devices whose ids share a final run of
+ * characters still get labels that differ. Unique names are left untouched. Command ids are already
+ * device-id-keyed, so this only affects the visible label. Pure.
  */
-internal fun disambiguatedDeviceNames(columns: List<DeviceColumn>): Map<String, String> {
-  val counts = columns.groupingBy { it.name }.eachCount()
-  return columns.associate { column ->
-    val display =
-      if ((counts[column.name] ?: 0) > 1) "${column.name} (${shortDeviceId(column.deviceId)})"
-      else column.name
-    column.deviceId to display
-  }
+internal fun disambiguatedDeviceNames(columns: List<DeviceColumn>): Map<String, String> = buildMap {
+  columns
+    .groupBy { it.name }
+    .forEach { (name, group) ->
+      if (group.size == 1) {
+        put(group.single().deviceId, name)
+      } else {
+        val length = shortestDistinguishingLength(group.map { it.deviceId })
+        group.forEach { column ->
+          put(column.deviceId, "$name (${column.deviceId.takeLast(length)})")
+        }
+      }
+    }
 }
 
-/** A short, human-scannable slice of a device id for label disambiguation. */
-private fun shortDeviceId(deviceId: String): String =
-  if (deviceId.length <= SHORT_DEVICE_ID_LENGTH) deviceId
-  else deviceId.takeLast(SHORT_DEVICE_ID_LENGTH)
-
-private const val SHORT_DEVICE_ID_LENGTH = 6
+/**
+ * The shortest id-suffix length whose `takeLast` values are all distinct across [deviceIds], so a
+ * duplicate-name group gets the minimal readable disambiguator. Falls back to the longest id length
+ * (the full id) when no shorter suffix separates them.
+ */
+private fun shortestDistinguishingLength(deviceIds: List<String>): Int {
+  val maxLength = deviceIds.maxOf { it.length }
+  return (1..maxLength).firstOrNull { length ->
+    deviceIds.mapTo(mutableSetOf()) { it.takeLast(length) }.size == deviceIds.size
+  } ?: maxLength
+}
 
 /**
  * The commands available for the current workspace [state]: open the picker, focus/close each

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPalette.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPalette.kt
@@ -181,7 +181,8 @@ fun CommandPalette(
                 selectedIndex = (safeIndex - 1 + results.size) % results.size
               true
             }
-            Key.Enter -> {
+            Key.Enter,
+            Key.NumPadEnter -> {
               results.getOrNull(safeIndex)?.let {
                 it.run()
                 onDismiss()

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPalette.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPalette.kt
@@ -13,7 +13,8 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
@@ -29,6 +30,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
@@ -43,6 +49,29 @@ internal fun filterCommands(commands: List<PaletteCommand>, query: String): List
 }
 
 /**
+ * Human-readable display names for [columns], keyed by device id. When two columns share a display
+ * name (common for iOS simulators, which surface identical labels like "iPhone 15"), the colliding
+ * ones get a short device-id suffix so palette labels stay distinguishable. Unique names are left
+ * untouched. Command ids are already device-id-keyed, so this only affects the visible label. Pure.
+ */
+internal fun disambiguatedDeviceNames(columns: List<DeviceColumn>): Map<String, String> {
+  val counts = columns.groupingBy { it.name }.eachCount()
+  return columns.associate { column ->
+    val display =
+      if ((counts[column.name] ?: 0) > 1) "${column.name} (${shortDeviceId(column.deviceId)})"
+      else column.name
+    column.deviceId to display
+  }
+}
+
+/** A short, human-scannable slice of a device id for label disambiguation. */
+private fun shortDeviceId(deviceId: String): String =
+  if (deviceId.length <= SHORT_DEVICE_ID_LENGTH) deviceId
+  else deviceId.takeLast(SHORT_DEVICE_ID_LENGTH)
+
+private const val SHORT_DEVICE_ID_LENGTH = 6
+
+/**
  * The commands available for the current workspace [state]: open the picker, focus/close each
  * observed device, open any tool on the focused device, and (with >1 device) compare the focused
  * device's active tool. Each command dispatches an existing workspace action, so the palette needs
@@ -55,23 +84,26 @@ fun buildWorkspaceCommands(
 ): List<PaletteCommand> = buildList {
   add(PaletteCommand("open-devices", "Open Devices", onOpenPicker))
   val content = state as? WorkspaceUiState.Content ?: return@buildList
+  val displayNames = disambiguatedDeviceNames(content.columns)
   content.columns.forEach { column ->
+    val name = displayNames[column.deviceId] ?: column.name
     add(
-      PaletteCommand("focus-${column.deviceId}", "Focus ${column.name}") {
+      PaletteCommand("focus-${column.deviceId}", "Focus $name") {
         onAction(WorkspaceAction.FocusDevice(column.deviceId))
       }
     )
     add(
-      PaletteCommand("close-${column.deviceId}", "Close ${column.name}") {
+      PaletteCommand("close-${column.deviceId}", "Close $name") {
         onAction(WorkspaceAction.CloseDevice(column.deviceId))
       }
     )
   }
   val focused = content.columns.firstOrNull { it.deviceId == content.focusedDeviceId }
   if (focused != null) {
+    val focusedName = displayNames[focused.deviceId] ?: focused.name
     Tool.entries.forEach { tool ->
       add(
-        PaletteCommand("tool-${tool.name}", "Open ${tool.label} on ${focused.name}") {
+        PaletteCommand("tool-${tool.name}", "Open ${tool.label} on $focusedName") {
           onAction(WorkspaceAction.SelectTool(focused.deviceId, tool))
         }
       )
@@ -91,6 +123,11 @@ fun buildWorkspaceCommands(
 /**
  * Quick-jump command palette (⌘K): a search field over a filtered command list, on a dimmed shell.
  * Selecting a command runs it and dismisses; clicking the scrim dismisses.
+ *
+ * Keyboard: Up/Down move a highlighted selection through the filtered results (wrapping at the
+ * ends), Enter runs the highlighted command, and Esc dismisses. The handler is a *preview* handler
+ * on the palette root so it sees keys before the focused search field, letting the arrows navigate
+ * results rather than move the text cursor.
  */
 @Composable
 fun CommandPalette(
@@ -100,14 +137,51 @@ fun CommandPalette(
 ) {
   var query by remember { mutableStateOf("") }
   val results = filterCommands(commands, query)
+  var selectedIndex by remember { mutableStateOf(0) }
+  // A narrowing filter can leave the selection past the end of the shorter list; clamp it back into
+  // range (or to 0 when empty) so Enter and the highlight never read out of bounds.
+  val safeIndex = selectedIndex.coerceIn(0, (results.size - 1).coerceAtLeast(0))
+  // Reset the highlight to the top whenever the filter changes the result set.
+  LaunchedEffect(query) { selectedIndex = 0 }
   // Focus the search field as soon as the palette opens, so the user can type immediately.
   val searchFocus = remember { FocusRequester() }
   LaunchedEffect(Unit) { searchFocus.requestFocus() }
+  val listState = rememberLazyListState()
+  // Keep the highlighted row visible as the selection moves.
+  LaunchedEffect(safeIndex, results.size) {
+    if (results.isNotEmpty()) listState.animateScrollToItem(safeIndex)
+  }
   Box(
     modifier =
       modifier
         .fillMaxSize()
         .background(Color.Black.copy(alpha = 0.5f))
+        .onPreviewKeyEvent { event ->
+          if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+          when (event.key) {
+            Key.DirectionDown -> {
+              if (results.isNotEmpty()) selectedIndex = (safeIndex + 1) % results.size
+              true
+            }
+            Key.DirectionUp -> {
+              if (results.isNotEmpty())
+                selectedIndex = (safeIndex - 1 + results.size) % results.size
+              true
+            }
+            Key.Enter -> {
+              results.getOrNull(safeIndex)?.let {
+                it.run()
+                onDismiss()
+              }
+              true
+            }
+            Key.Escape -> {
+              onDismiss()
+              true
+            }
+            else -> false
+          }
+        }
         .clickable(
           interactionSource = remember { MutableInteractionSource() },
           indication = null,
@@ -140,12 +214,15 @@ fun CommandPalette(
           },
       )
       Spacer(Modifier.height(8.dp))
-      LazyColumn(Modifier.heightIn(max = 360.dp)) {
-        items(results, key = { it.id }) { command ->
+      LazyColumn(state = listState, modifier = Modifier.heightIn(max = 360.dp)) {
+        itemsIndexed(results, key = { _, command -> command.id }) { index, command ->
+          val highlight =
+            if (index == safeIndex) MaterialTheme.colorScheme.surfaceVariant else Color.Transparent
           Text(
             command.label,
             modifier =
               Modifier.fillMaxWidth()
+                .background(highlight)
                 .clickable {
                   command.run()
                   onDismiss()

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPalette.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPalette.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 
@@ -228,8 +229,9 @@ fun CommandPalette(
       Spacer(Modifier.height(8.dp))
       LazyColumn(state = listState, modifier = Modifier.heightIn(max = 360.dp)) {
         itemsIndexed(results, key = { _, command -> command.id }) { index, command ->
+          val isSelected = index == safeIndex
           val highlight =
-            if (index == safeIndex) MaterialTheme.colorScheme.surfaceVariant else Color.Transparent
+            if (isSelected) MaterialTheme.colorScheme.surfaceVariant else Color.Transparent
           Text(
             command.label,
             modifier =
@@ -239,6 +241,8 @@ fun CommandPalette(
                   command.run()
                   onDismiss()
                 }
+                // Announce the keyboard highlight to assistive tech, not just visually.
+                .semantics { selected = isSelected }
                 .padding(vertical = 8.dp, horizontal = 4.dp),
           )
         }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPaletteTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPaletteTest.kt
@@ -154,4 +154,17 @@ class CommandPaletteTest {
     assertEquals(2, focusLabels.size)
     assertEquals(focusLabels.size, focusLabels.toSet().size)
   }
+
+  @Test
+  fun `same-name devices whose ids share their final six chars still get distinct labels`() {
+    val state =
+      WorkspaceUiState.Content(
+        columns = listOf(column("A-15-ABCDEF", "iPhone 15"), column("B-15-ABCDEF", "iPhone 15")),
+        focusedDeviceId = "A-15-ABCDEF",
+      )
+    val focusLabels =
+      buildWorkspaceCommands(state, {}, {}).filter { it.id.startsWith("focus-") }.map { it.label }
+    assertEquals(2, focusLabels.size)
+    assertEquals(focusLabels.size, focusLabels.toSet().size)
+  }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPaletteTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPaletteTest.kt
@@ -1,12 +1,16 @@
 package dev.jasonpearson.automobile.desktop.core.workspace
 
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performKeyInput
 import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.pressKey
 import androidx.compose.ui.test.runComposeUiTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -89,5 +93,65 @@ class CommandPaletteTest {
     onNodeWithText("Close Pixel").performClick()
     assertEquals("b", ran)
     assertTrue(dismissed)
+  }
+
+  @Test
+  fun `arrow down then enter runs the second command and dismisses`() = runComposeUiTest {
+    var ran: String? = null
+    var dismissed = false
+    val commands =
+      listOf(
+        PaletteCommand("a", "Open Devices") { ran = "a" },
+        PaletteCommand("b", "Close Pixel") { ran = "b" },
+      )
+    setContent { MaterialTheme { CommandPalette(commands, onDismiss = { dismissed = true }) } }
+    onNodeWithContentDescription("Command search").assertIsFocused()
+    onRoot().performKeyInput {
+      pressKey(Key.DirectionDown)
+      pressKey(Key.Enter)
+    }
+    assertEquals("b", ran)
+    assertTrue(dismissed)
+  }
+
+  @Test
+  fun `arrow up from the top wraps to the last command`() = runComposeUiTest {
+    var ran: String? = null
+    val commands =
+      listOf(
+        PaletteCommand("a", "Open Devices") { ran = "a" },
+        PaletteCommand("b", "Close Pixel") { ran = "b" },
+        PaletteCommand("c", "Open Logs") { ran = "c" },
+      )
+    setContent { MaterialTheme { CommandPalette(commands, onDismiss = {}) } }
+    onNodeWithContentDescription("Command search").assertIsFocused()
+    onRoot().performKeyInput {
+      pressKey(Key.DirectionUp)
+      pressKey(Key.Enter)
+    }
+    assertEquals("c", ran)
+  }
+
+  @Test
+  fun `escape closes the palette`() = runComposeUiTest {
+    var dismissed = false
+    val commands = listOf(PaletteCommand("a", "Open Devices") {})
+    setContent { MaterialTheme { CommandPalette(commands, onDismiss = { dismissed = true }) } }
+    onNodeWithContentDescription("Command search").assertIsFocused()
+    onRoot().performKeyInput { pressKey(Key.Escape) }
+    assertTrue(dismissed)
+  }
+
+  @Test
+  fun `identically named devices get distinct labels`() {
+    val state =
+      WorkspaceUiState.Content(
+        columns = listOf(column("sim-A", "iPhone 15"), column("sim-B", "iPhone 15")),
+        focusedDeviceId = "sim-A",
+      )
+    val focusLabels =
+      buildWorkspaceCommands(state, {}, {}).filter { it.id.startsWith("focus-") }.map { it.label }
+    assertEquals(2, focusLabels.size)
+    assertEquals(focusLabels.size, focusLabels.toSet().size)
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPaletteTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPaletteTest.kt
@@ -4,6 +4,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotSelected
+import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.onRoot
@@ -131,6 +133,23 @@ class CommandPaletteTest {
     }
     assertEquals("c", ran)
   }
+
+  @Test
+  fun `the highlighted row carries selected semantics and moves with arrow keys`() =
+    runComposeUiTest {
+      val commands =
+        listOf(
+          PaletteCommand("a", "Open Devices") {},
+          PaletteCommand("b", "Close Pixel") {},
+        )
+      setContent { MaterialTheme { CommandPalette(commands, onDismiss = {}) } }
+      onNodeWithContentDescription("Command search").assertIsFocused()
+      onNodeWithText("Open Devices").assertIsSelected()
+      onNodeWithText("Close Pixel").assertIsNotSelected()
+      onRoot().performKeyInput { pressKey(Key.DirectionDown) }
+      onNodeWithText("Close Pixel").assertIsSelected()
+      onNodeWithText("Open Devices").assertIsNotSelected()
+    }
 
   @Test
   fun `escape closes the palette`() = runComposeUiTest {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPaletteTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPaletteTest.kt
@@ -117,6 +117,25 @@ class CommandPaletteTest {
   }
 
   @Test
+  fun `numpad enter runs the selected command and dismisses`() = runComposeUiTest {
+    var ran: String? = null
+    var dismissed = false
+    val commands =
+      listOf(
+        PaletteCommand("a", "Open Devices") { ran = "a" },
+        PaletteCommand("b", "Close Pixel") { ran = "b" },
+      )
+    setContent { MaterialTheme { CommandPalette(commands, onDismiss = { dismissed = true }) } }
+    onNodeWithContentDescription("Command search").assertIsFocused()
+    onRoot().performKeyInput {
+      pressKey(Key.DirectionDown)
+      pressKey(Key.NumPadEnter)
+    }
+    assertEquals("b", ran)
+    assertTrue(dismissed)
+  }
+
+  @Test
   fun `arrow up from the top wraps to the last command`() = runComposeUiTest {
     var ran: String? = null
     val commands =


### PR DESCRIPTION
## What

Two of the three parts of [#4776](https://github.com/kaeawc/auto-mobile/issues/4776), scoped to `CommandPalette.kt` and its test only.

### 1. In-palette keyboard navigation
- **Up / Down** move a highlighted selection through the filtered results, **wrapping** at the ends.
- **Enter** runs the highlighted command (then dismisses) — the *selected* command, not always the first.
- **Esc** dismisses the palette (`onDismiss`).
- The `LazyColumn` auto-scrolls (`animateScrollToItem`) to keep the selection visible, and the selected row is highlighted.
- Handled via `Modifier.onPreviewKeyEvent` on the palette root, so arrows are claimed before the focused search field (they navigate results rather than move the text cursor). Existing autofocus of the search field is preserved.
- The highlight resets to the top when the filter changes (`LaunchedEffect(query)`) and is clamped (`coerceIn`) so a narrowing filter never reads out of bounds.

### 2. Disambiguate identically-named devices
- `buildWorkspaceCommands` now derives display names via `disambiguatedDeviceNames`: when two observed devices share a name (common for iOS simulators, e.g. two "iPhone 15"), the colliding ones get a short device-id suffix so `Focus` / `Close` / `Open <tool> on <device>` labels stay distinct. Unique names are untouched. Command ids were already device-id-keyed, so only the human-readable label changes.

## Tests
`CommandPaletteTest` (9 tests total; 4 new):
- Down then Enter runs the 2nd filtered command and dismisses.
- Up from the top wraps to the last command.
- Esc calls `onDismiss`.
- Two devices with the same name produce two distinct labels.

## Validation
- `bash scripts/ktfmt/apply_ktfmt.sh`
- `android/gradlew -p android :desktop-core:detektMain :desktop-core:test` — BUILD SUCCESSFUL (full, unscoped `:desktop-core:test`).

## Out of scope / deferred
The **global ⌘K window-level binding** (part 1 of #4776) is intentionally left for the host chain (desktop-app / WorkspaceShell / window-level code). This PR does not touch those and does **not** close #4776.
