### PR TITLE
feat(desktop): wire the Network facet into the pane tool switch

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -22,6 +22,7 @@ import dev.jasonpearson.automobile.desktop.core.workspace.CommandPalette
 import dev.jasonpearson.automobile.desktop.core.workspace.DeviceColumn
 import dev.jasonpearson.automobile.desktop.core.workspace.FailuresFacet
 import dev.jasonpearson.automobile.desktop.core.workspace.LogsFacet
+import dev.jasonpearson.automobile.desktop.core.workspace.NetworkFacet
 import dev.jasonpearson.automobile.desktop.core.workspace.OnboardingScreen
 import dev.jasonpearson.automobile.desktop.core.workspace.PerformanceFacet
 import dev.jasonpearson.automobile.desktop.core.workspace.Platform
@@ -152,10 +153,10 @@ fun AutoMobileDesktopApp(
 
 /**
  * Real docked-facet content for a pane, wired to the per-device facets in desktop-core: Logs
- * (telemetry), Storage (auto-resolved app, Android-only), Performance (per-device observation
- * stream, filtered by deviceId), and Failures (cross-device aggregate). Navigation (#4837 — nav
- * updates lack a deviceId and broadcast to all panes), Network (#4834 decode), and Test (per-device
- * daemon resource, #4715) fall back to the placeholder for now.
+ * (telemetry), Storage (auto-resolved app, Android-only), Network (per-device `getNetworkGraph`
+ * tool call), Performance (per-device observation stream, filtered by deviceId), and Failures
+ * (cross-device aggregate). Navigation (#4837 — nav updates lack a deviceId and broadcast to all
+ * panes) and Test (per-device daemon resource, #4715) fall back to the placeholder for now.
  */
 @Composable
 private fun WorkspaceFacet(column: DeviceColumn, tool: Tool) {
@@ -166,12 +167,15 @@ private fun WorkspaceFacet(column: DeviceColumn, tool: Tool) {
     Tool.Storage ->
       if (column.platform == Platform.Android) StorageFacet(column)
       else WorkspaceFacetPlaceholder(tool)
+    // Network reads per-device via the getNetworkGraph MCP tool call (deviceId is an argument),
+    // not the broadcast observation stream, so panes don't cross-contaminate.
+    Tool.Network -> NetworkFacet(column)
     Tool.Performance -> PerformanceFacet(column)
     Tool.Failures -> FailuresFacet(column)
     // Navigation is intentionally NOT wired: nav-graph stream updates carry no deviceId and the
     // daemon broadcasts them to all panes, so two panes would cross-contaminate (#4837). The facet
-    // + streamOnly support exist; wire once the deviceId contract lands. Network (#4834 decode) and
-    // Test (per-device daemon resource, #4715) likewise stay on the placeholder.
+    // + streamOnly support exist; wire once the deviceId contract lands. Test (per-device daemon
+    // resource, #4715) likewise stays on the placeholder.
     else -> WorkspaceFacetPlaceholder(tool)
   }
 }


### PR DESCRIPTION
Makes the merged Network facet ([#4834](https://github.com/kaeawc/auto-mobile/pull/4834)) reachable from the workspace by mapping `Tool.Network -> NetworkFacet(column)` in `WorkspaceFacet`.

**Why Network is safe to wire (unlike Navigation).** `NetworkFacet` reads per-device through the `getNetworkGraph` MCP tool call, where `deviceId` is an explicit argument — not the broadcast observation stream. So each pane fetches its own device's graph and two observed devices can't cross-contaminate. (Navigation stays unwired precisely because its stream updates carry no `deviceId` and the daemon broadcasts to all panes — [#4837](https://github.com/kaeawc/auto-mobile/issues/4837).)

## Changes
- `AutoMobileDesktopApp.kt`: import `NetworkFacet`; add `Tool.Network -> NetworkFacet(column)`; update the `WorkspaceFacet` KDoc + placeholder comment (Network moves from placeholder → wired; only Navigation/Test remain on the placeholder).

## Validation
- `:desktop-app:detektMain` + `:desktop-app:compileKotlin` + ktfmt — green.