### PR TITLE
feat(desktop): always-on filter bar for the Logs facet

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanel.kt
@@ -12,8 +12,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
@@ -187,7 +188,9 @@ fun LogsPanel(
     remember(platform, activeDeviceId) {
       derivedStateOf { filterLogs(logs, enabledLevels, query, platform) }
     }
-  val listState = rememberLazyListState()
+  // Per-device scroll state: recreated on a device switch so a device left scrolled up does not
+  // carry its scroll offset (and suppress auto-follow) into the next device.
+  val listState = remember(activeDeviceId) { LazyListState() }
 
   LaunchedEffect(telemetryPushClient, activeDeviceId, maxRows) {
     val client = telemetryPushClient ?: return@LaunchedEffect
@@ -364,19 +367,26 @@ private fun LogRow(event: TelemetryDisplayEvent.Log, textColor: Color, platform:
       color = Color(level.color),
     )
     Spacer(Modifier.width(6.dp))
+    // Bound the tag so a long tag can't consume the whole row and starve the message of width.
     Text(
       event.tag,
       fontSize = 11.sp,
       fontFamily = FontFamily.Monospace,
       color = textColor.copy(alpha = 0.6f),
       maxLines = 1,
+      modifier = Modifier.widthIn(max = 140.dp),
     )
     Spacer(Modifier.width(6.dp))
+    // Message takes the remaining width and stays a single compact line (like the replaced
+    // dashboard): keeps every row a uniform height so tail-follow's scrollToItem lands on the
+    // true bottom instead of a tall wrapped row that leaves canScrollForward true.
     Text(
       event.message,
       fontSize = 11.sp,
       fontFamily = FontFamily.Monospace,
       color = textColor.copy(alpha = 0.9f),
+      maxLines = 1,
+      modifier = Modifier.weight(1f),
     )
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanel.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -41,6 +42,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.jasonpearson.automobile.desktop.core.components.SearchBar
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import dev.jasonpearson.automobile.desktop.core.daemon.TelemetryPushClient
 import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
 
@@ -58,31 +60,57 @@ enum class LogLevel(val label: String, val letter: String, val color: Long) {
 }
 
 /**
- * Maps an Android log-priority int to its [LogLevel] bucket. Every int maps to exactly one bucket
- * so that "all chips enabled" is a true no-op filter: unknown/low priorities fall back to
- * [Verbose], and Assert (7) or higher folds into [Error].
+ * Which platform's numeric log-priority scale a row's `level` field uses. A telemetry panel is
+ * scoped to a single device, so every row it shows shares one scale — the caller supplies it rather
+ * than the (platform-less) row carrying it. Android and iOS number their levels differently, so the
+ * same int means different severities on each.
  */
-fun logLevelOf(level: Int): LogLevel =
-  when {
-    level <= 2 -> LogLevel.Verbose
-    level == 3 -> LogLevel.Debug
-    level == 4 -> LogLevel.Info
-    level == 5 -> LogLevel.Warn
-    else -> LogLevel.Error
+enum class LogPlatform {
+  Android,
+  Ios,
+}
+
+/**
+ * Maps a raw log-priority int to its [LogLevel] bucket for the given [platform]. Every int maps to
+ * exactly one bucket so that "all chips enabled" is a true no-op filter.
+ *
+ * Android uses `Log.VERBOSE`=2 .. `Log.ASSERT`=7; iOS's `LogLevel` uses `verbose`=0 .. `fault`=5
+ * (see `ios/auto-mobile-sdk/.../Events/SdkEvent.swift`). Both fold their top severities (Android
+ * Assert, iOS Fault) into [Error], and unknown/low priorities into [Verbose].
+ */
+fun logLevelOf(level: Int, platform: LogPlatform = LogPlatform.Android): LogLevel =
+  when (platform) {
+    LogPlatform.Android ->
+      when {
+        level <= 2 -> LogLevel.Verbose
+        level == 3 -> LogLevel.Debug
+        level == 4 -> LogLevel.Info
+        level == 5 -> LogLevel.Warn
+        else -> LogLevel.Error
+      }
+    LogPlatform.Ios ->
+      when {
+        level <= 0 -> LogLevel.Verbose
+        level == 1 -> LogLevel.Debug
+        level == 2 -> LogLevel.Info
+        level == 3 -> LogLevel.Warn
+        else -> LogLevel.Error // 4 = error, 5 = fault
+      }
   }
 
 /**
- * Client-side filter over already-streamed log rows. A row survives when its [LogLevel] is in
- * [enabledLevels] and its tag/message matches [query] (case-insensitive substring). A blank [query]
- * and the full level set together return the input unchanged, so an untouched filter bar shows
- * everything.
+ * Client-side filter over already-streamed log rows. A row survives when its [LogLevel] (bucketed
+ * for [platform]) is in [enabledLevels] and its tag/message matches [query] (case-insensitive
+ * substring). A blank [query] and the full level set together return the input unchanged, so an
+ * untouched filter bar shows everything.
  */
 fun filterLogs(
   logs: List<TelemetryDisplayEvent.Log>,
   enabledLevels: Set<LogLevel>,
   query: String,
+  platform: LogPlatform = LogPlatform.Android,
 ): List<TelemetryDisplayEvent.Log> = logs.filter {
-  logLevelOf(it.level) in enabledLevels && it.matchesSearch(query)
+  logLevelOf(it.level, platform) in enabledLevels && it.matchesSearch(query)
 }
 
 /**
@@ -108,43 +136,80 @@ fun appendBounded(
 }
 
 /**
+ * Human-readable status for a non-healthy telemetry [ConnectionState], or `null` when
+ * [ConnectionState.Connected] (nothing to surface). Pure so the mapping is unit-testable and the
+ * panel never mislabels a connecting/errored socket as an empty-but-healthy stream.
+ */
+fun connectionStatusText(state: ConnectionState): String? =
+  when (state) {
+    is ConnectionState.Connecting -> "Connecting..."
+    is ConnectionState.Reconnecting -> "Reconnecting (attempt ${state.attempt})..."
+    is ConnectionState.Disconnected -> "Disconnected" + (state.reason?.let { ": $it" } ?: "")
+    is ConnectionState.Error -> "Error: ${state.message}"
+    is ConnectionState.Connected -> null
+  }
+
+/**
  * Logs facet body: a logs-only event stream with an always-on filter bar (per-level chips +
  * free-text search) applied client-side over the rows already received from [telemetryPushClient].
  * Filtering never touches the daemon protocol — it only narrows what is already in memory.
  *
  * The client is owned by the caller (the facet connects/disposes it per device). Streamed rows are
- * kept per [activeDeviceId]; switching devices clears the buffer.
+ * kept per [activeDeviceId]; switching devices clears the buffer. [platform] selects the numeric
+ * log-level scale used to bucket rows into filter chips (see [logLevelOf]).
  */
 @Composable
 fun LogsPanel(
   telemetryPushClient: TelemetryPushClient?,
   activeDeviceId: String? = null,
+  platform: LogPlatform = LogPlatform.Android,
   modifier: Modifier = Modifier,
 ) {
   val colors = SharedTheme.globalColors
   val logs = remember(activeDeviceId) { mutableStateListOf<TelemetryDisplayEvent.Log>() }
   var query by remember { mutableStateOf("") }
   var enabledLevels by remember { mutableStateOf(LogLevel.entries.toSet()) }
+  var connectionState by remember(activeDeviceId) { mutableStateOf<ConnectionState?>(null) }
+  // Tail-follow *intent*: preserved across filter changes and reset only when the user scrolls away
+  // from the bottom, so clearing a filter that had anchored the list on an old row still follows
+  // the next live row.
+  var followTail by remember(activeDeviceId) { mutableStateOf(true) }
 
-  val filtered by remember { derivedStateOf { filterLogs(logs, enabledLevels, query) } }
+  val filtered by remember {
+    derivedStateOf { filterLogs(logs, enabledLevels, query, platform) }
+  }
   val listState = rememberLazyListState()
 
   LaunchedEffect(telemetryPushClient, activeDeviceId) {
     val client = telemetryPushClient ?: return@LaunchedEffect
     client.telemetryEvents.collect { event ->
-      if (event is TelemetryDisplayEvent.Log) {
-        // Sample tail-follow intent *before* the append shifts the layout: only keep following
-        // when the viewport is already pinned to the bottom, so a user who scrolled up to read
-        // history is never yanked back down.
-        val wasAtBottom = !listState.canScrollForward
-        appendBounded(logs, event)
-        val rows = filtered
-        if (wasAtBottom && rows.isNotEmpty()) {
-          listState.scrollToItem(rows.lastIndex)
-        }
-      }
+      if (event is TelemetryDisplayEvent.Log) appendBounded(logs, event)
     }
   }
+
+  LaunchedEffect(telemetryPushClient) {
+    val client = telemetryPushClient ?: return@LaunchedEffect
+    client.connectionState.collect { connectionState = it }
+  }
+
+  // Re-derive follow intent whenever a scroll settles: we follow iff the viewport rests at the
+  // bottom. A user drag that stops mid-list clears it; reaching the bottom (or a programmatic
+  // tail scroll) re-arms it. Filter changes do not scroll, so they never clear the intent.
+  LaunchedEffect(listState) {
+    snapshotFlow { listState.isScrollInProgress }
+      .collect { inProgress -> if (!inProgress) followTail = !listState.canScrollForward }
+  }
+
+  // Follow the tail when following: fires on new rows (size change) and on filter changes (which
+  // re-anchor the list), so the newest visible row stays in view without fighting a scrolled-up
+  // user.
+  LaunchedEffect(filtered.size, query, enabledLevels, followTail) {
+    if (followTail && filtered.isNotEmpty()) {
+      listState.scrollToItem(filtered.lastIndex)
+    }
+  }
+
+  val statusText = connectionState?.let { connectionStatusText(it) }
 
   Column(modifier = modifier.fillMaxSize()) {
     LogsFilterBar(
@@ -156,13 +221,26 @@ fun LogsPanel(
       },
     )
 
+    if (statusText != null) {
+      Box(
+        modifier =
+          Modifier.fillMaxWidth()
+            .background(Color(0xFF5C4033).copy(alpha = 0.3f))
+            .padding(horizontal = 8.dp, vertical = 2.dp)
+      ) {
+        Text(statusText, fontSize = 10.sp, color = Color(0xFFE0A040))
+      }
+    }
+
     if (filtered.isEmpty()) {
       Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         val message =
-          if (query.isBlank() && enabledLevels == LogLevel.entries.toSet()) {
-            "No logs yet"
-          } else {
-            "No logs match the filter"
+          when {
+            // A non-healthy socket is why there are no rows — say so instead of the misleading
+            // "No logs yet" (which implies a healthy but quiet stream).
+            statusText != null -> statusText
+            query.isBlank() && enabledLevels == LogLevel.entries.toSet() -> "No logs yet"
+            else -> "No logs match the filter"
           }
         Text(message, fontSize = 12.sp, color = colors.text.normal.copy(alpha = 0.4f))
       }
@@ -175,7 +253,7 @@ fun LogsPanel(
             "${event.timestamp}_${System.identityHashCode(event)}"
           },
         ) { index ->
-          LogRow(filtered[index], colors.text.normal)
+          LogRow(filtered[index], colors.text.normal, platform)
         }
       }
     }
@@ -256,8 +334,8 @@ private fun LevelChip(level: LogLevel, isEnabled: Boolean, onToggle: () -> Unit)
 
 /** Single log row: level letter, tag, and message, matching the dashboard's compact styling. */
 @Composable
-private fun LogRow(event: TelemetryDisplayEvent.Log, textColor: Color) {
-  val level = logLevelOf(event.level)
+private fun LogRow(event: TelemetryDisplayEvent.Log, textColor: Color, platform: LogPlatform) {
+  val level = logLevelOf(event.level, platform)
   Row(
     modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 2.dp),
     verticalAlignment = Alignment.Top,

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanel.kt
@@ -1,0 +1,226 @@
+package dev.jasonpearson.automobile.desktop.core.telemetry
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import dev.jasonpearson.automobile.desktop.core.components.SearchBar
+import dev.jasonpearson.automobile.desktop.core.daemon.TelemetryPushClient
+import dev.jasonpearson.automobile.desktop.core.theme.SharedTheme
+
+/**
+ * A log severity bucket surfaced as an always-on filter chip. Android's raw priority ints
+ * (`Log.VERBOSE`=2 .. `Log.ASSERT`=7) collapse into these five canonical buckets via [logLevelOf];
+ * [color] mirrors the palette used by the telemetry dashboard's log summaries.
+ */
+enum class LogLevel(val label: String, val letter: String, val color: Long) {
+  Verbose("Verbose", "V", 0xFF9E9E9E),
+  Debug("Debug", "D", 0xFF74C0FC),
+  Info("Info", "I", 0xFF51CF66),
+  Warn("Warn", "W", 0xFFE0C040),
+  Error("Error", "E", 0xFFE06060),
+}
+
+/**
+ * Maps an Android log-priority int to its [LogLevel] bucket. Every int maps to exactly one bucket
+ * so that "all chips enabled" is a true no-op filter: unknown/low priorities fall back to
+ * [Verbose], and Assert (7) or higher folds into [Error].
+ */
+fun logLevelOf(level: Int): LogLevel =
+  when {
+    level <= 2 -> LogLevel.Verbose
+    level == 3 -> LogLevel.Debug
+    level == 4 -> LogLevel.Info
+    level == 5 -> LogLevel.Warn
+    else -> LogLevel.Error
+  }
+
+/**
+ * Client-side filter over already-streamed log rows. A row survives when its [LogLevel] is in
+ * [enabledLevels] and its tag/message matches [query] (case-insensitive substring). A blank [query]
+ * and the full level set together return the input unchanged, so an untouched filter bar shows
+ * everything.
+ */
+fun filterLogs(
+  logs: List<TelemetryDisplayEvent.Log>,
+  enabledLevels: Set<LogLevel>,
+  query: String,
+): List<TelemetryDisplayEvent.Log> = logs.filter {
+  logLevelOf(it.level) in enabledLevels && it.matchesSearch(query)
+}
+
+/**
+ * Logs facet body: a logs-only event stream with an always-on filter bar (per-level chips +
+ * free-text search) applied client-side over the rows already received from [telemetryPushClient].
+ * Filtering never touches the daemon protocol — it only narrows what is already in memory.
+ *
+ * The client is owned by the caller (the facet connects/disposes it per device). Streamed rows are
+ * kept per [activeDeviceId]; switching devices clears the buffer.
+ */
+@Composable
+fun LogsPanel(
+  telemetryPushClient: TelemetryPushClient?,
+  activeDeviceId: String? = null,
+  modifier: Modifier = Modifier,
+) {
+  val colors = SharedTheme.globalColors
+  val logs = remember(activeDeviceId) { mutableStateListOf<TelemetryDisplayEvent.Log>() }
+  var query by remember { mutableStateOf("") }
+  var enabledLevels by remember { mutableStateOf(LogLevel.entries.toSet()) }
+
+  LaunchedEffect(telemetryPushClient, activeDeviceId) {
+    val client = telemetryPushClient ?: return@LaunchedEffect
+    client.telemetryEvents.collect { event ->
+      if (event is TelemetryDisplayEvent.Log) logs.add(event)
+    }
+  }
+
+  val filtered by remember {
+    derivedStateOf { filterLogs(logs, enabledLevels, query) }
+  }
+  val listState = rememberLazyListState()
+
+  Column(modifier = modifier.fillMaxSize()) {
+    LogsFilterBar(
+      query = query,
+      onQueryChange = { query = it },
+      enabledLevels = enabledLevels,
+      onToggleLevel = { level ->
+        enabledLevels = if (level in enabledLevels) enabledLevels - level else enabledLevels + level
+      },
+    )
+
+    if (filtered.isEmpty()) {
+      Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        val message =
+          if (query.isBlank() && enabledLevels == LogLevel.entries.toSet()) {
+            "No logs yet"
+          } else {
+            "No logs match the filter"
+          }
+        Text(message, fontSize = 12.sp, color = colors.text.normal.copy(alpha = 0.4f))
+      }
+    } else {
+      LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
+        items(
+          count = filtered.size,
+          key = { index ->
+            val event = filtered[index]
+            "${event.timestamp}_${System.identityHashCode(event)}"
+          },
+        ) { index ->
+          LogRow(filtered[index], colors.text.normal)
+        }
+      }
+    }
+  }
+}
+
+/** Always-on filter bar: a free-text search field plus one toggle chip per [LogLevel]. */
+@Composable
+private fun LogsFilterBar(
+  query: String,
+  onQueryChange: (String) -> Unit,
+  enabledLevels: Set<LogLevel>,
+  onToggleLevel: (LogLevel) -> Unit,
+) {
+  Row(
+    modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 4.dp),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(4.dp),
+  ) {
+    SearchBar(
+      query = query,
+      onQueryChange = onQueryChange,
+      placeholder = "Filter logs...",
+      modifier = Modifier.weight(1f),
+    )
+    LogLevel.entries.forEach { level ->
+      val isEnabled = level in enabledLevels
+      Box(
+        modifier =
+          Modifier.background(
+              if (isEnabled) Color(level.color).copy(alpha = 0.18f) else Color.Transparent,
+              RoundedCornerShape(4.dp),
+            )
+            .clickable { onToggleLevel(level) }
+            .pointerHoverIcon(PointerIcon.Hand)
+            .padding(horizontal = 6.dp, vertical = 4.dp)
+            .clearAndSetSemantics { contentDescription = "Toggle ${level.label} logs" }
+      ) {
+        Text(
+          level.letter,
+          fontSize = 11.sp,
+          fontFamily = FontFamily.Monospace,
+          fontWeight = FontWeight.SemiBold,
+          color =
+            if (isEnabled) Color(level.color)
+            else SharedTheme.globalColors.text.normal.copy(alpha = 0.35f),
+        )
+      }
+    }
+  }
+}
+
+/** Single log row: level letter, tag, and message, matching the dashboard's compact styling. */
+@Composable
+private fun LogRow(event: TelemetryDisplayEvent.Log, textColor: Color) {
+  val level = logLevelOf(event.level)
+  Row(
+    modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 2.dp),
+    verticalAlignment = Alignment.Top,
+  ) {
+    Text(
+      level.letter,
+      fontSize = 11.sp,
+      fontFamily = FontFamily.Monospace,
+      fontWeight = FontWeight.SemiBold,
+      color = Color(level.color),
+    )
+    Spacer(Modifier.width(6.dp))
+    Text(
+      event.tag,
+      fontSize = 11.sp,
+      fontFamily = FontFamily.Monospace,
+      color = textColor.copy(alpha = 0.6f),
+      maxLines = 1,
+    )
+    Spacer(Modifier.width(6.dp))
+    Text(
+      event.message,
+      fontSize = 11.sp,
+      fontFamily = FontFamily.Monospace,
+      color = textColor.copy(alpha = 0.9f),
+    )
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanel.kt
@@ -2,6 +2,7 @@ package dev.jasonpearson.automobile.desktop.core.telemetry
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -28,8 +30,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -80,6 +86,28 @@ fun filterLogs(
 }
 
 /**
+ * Upper bound on retained live log rows. A high-volume device can stream logs indefinitely; without
+ * a cap the buffer — and the per-append [filterLogs] cost over it — would grow until the UI stalls.
+ */
+const val MAX_LOG_ROWS = 5000
+
+/**
+ * Appends [event] to [logs] with ring-buffer semantics: once the buffer exceeds [max] the oldest
+ * rows are dropped, so only the most recent [max] rows are retained. Kept pure (operates on any
+ * [MutableList]) so the bound is unit-testable without Compose.
+ */
+fun appendBounded(
+  logs: MutableList<TelemetryDisplayEvent.Log>,
+  event: TelemetryDisplayEvent.Log,
+  max: Int = MAX_LOG_ROWS,
+) {
+  logs.add(event)
+  while (logs.size > max) {
+    logs.removeAt(0)
+  }
+}
+
+/**
  * Logs facet body: a logs-only event stream with an always-on filter bar (per-level chips +
  * free-text search) applied client-side over the rows already received from [telemetryPushClient].
  * Filtering never touches the daemon protocol — it only narrows what is already in memory.
@@ -98,17 +126,25 @@ fun LogsPanel(
   var query by remember { mutableStateOf("") }
   var enabledLevels by remember { mutableStateOf(LogLevel.entries.toSet()) }
 
+  val filtered by remember { derivedStateOf { filterLogs(logs, enabledLevels, query) } }
+  val listState = rememberLazyListState()
+
   LaunchedEffect(telemetryPushClient, activeDeviceId) {
     val client = telemetryPushClient ?: return@LaunchedEffect
     client.telemetryEvents.collect { event ->
-      if (event is TelemetryDisplayEvent.Log) logs.add(event)
+      if (event is TelemetryDisplayEvent.Log) {
+        // Sample tail-follow intent *before* the append shifts the layout: only keep following
+        // when the viewport is already pinned to the bottom, so a user who scrolled up to read
+        // history is never yanked back down.
+        val wasAtBottom = !listState.canScrollForward
+        appendBounded(logs, event)
+        val rows = filtered
+        if (wasAtBottom && rows.isNotEmpty()) {
+          listState.scrollToItem(rows.lastIndex)
+        }
+      }
     }
   }
-
-  val filtered by remember {
-    derivedStateOf { filterLogs(logs, enabledLevels, query) }
-  }
-  val listState = rememberLazyListState()
 
   Column(modifier = modifier.fillMaxSize()) {
     LogsFilterBar(
@@ -146,7 +182,12 @@ fun LogsPanel(
   }
 }
 
-/** Always-on filter bar: a free-text search field plus one toggle chip per [LogLevel]. */
+/**
+ * Always-on filter bar: a full-width free-text search field over a horizontally-scrollable row of
+ * per-[LogLevel] toggle chips. Keeping the chips on their own scrolling row means they can never
+ * clip or squeeze the search field in a narrow device column — the search stays fully usable and
+ * the overflowing chips scroll instead.
+ */
 @Composable
 private fun LogsFilterBar(
   query: String,
@@ -154,41 +195,62 @@ private fun LogsFilterBar(
   enabledLevels: Set<LogLevel>,
   onToggleLevel: (LogLevel) -> Unit,
 ) {
-  Row(
+  Column(
     modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp, vertical = 4.dp),
-    verticalAlignment = Alignment.CenterVertically,
-    horizontalArrangement = Arrangement.spacedBy(4.dp),
+    verticalArrangement = Arrangement.spacedBy(4.dp),
   ) {
     SearchBar(
       query = query,
       onQueryChange = onQueryChange,
       placeholder = "Filter logs...",
-      modifier = Modifier.weight(1f),
+      modifier = Modifier.fillMaxWidth(),
     )
-    LogLevel.entries.forEach { level ->
-      val isEnabled = level in enabledLevels
-      Box(
-        modifier =
-          Modifier.background(
-              if (isEnabled) Color(level.color).copy(alpha = 0.18f) else Color.Transparent,
-              RoundedCornerShape(4.dp),
-            )
-            .clickable { onToggleLevel(level) }
-            .pointerHoverIcon(PointerIcon.Hand)
-            .padding(horizontal = 6.dp, vertical = 4.dp)
-            .clearAndSetSemantics { contentDescription = "Toggle ${level.label} logs" }
-      ) {
-        Text(
-          level.letter,
-          fontSize = 11.sp,
-          fontFamily = FontFamily.Monospace,
-          fontWeight = FontWeight.SemiBold,
-          color =
-            if (isEnabled) Color(level.color)
-            else SharedTheme.globalColors.text.normal.copy(alpha = 0.35f),
+    Row(
+      modifier = Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+      LogLevel.entries.forEach { level ->
+        LevelChip(
+          level = level,
+          isEnabled = level in enabledLevels,
+          onToggle = { onToggleLevel(level) },
         )
       }
     }
+  }
+}
+
+/** A single toggle chip for one [LogLevel], with switch-role selected semantics for a11y. */
+@Composable
+private fun LevelChip(level: LogLevel, isEnabled: Boolean, onToggle: () -> Unit) {
+  Box(
+    modifier =
+      Modifier.background(
+          if (isEnabled) Color(level.color).copy(alpha = 0.18f) else Color.Transparent,
+          RoundedCornerShape(4.dp),
+        )
+        .clickable { onToggle() }
+        .pointerHoverIcon(PointerIcon.Hand)
+        .padding(horizontal = 6.dp, vertical = 4.dp)
+        .clearAndSetSemantics {
+          // Stable label so tests/AT can find the chip, plus role + selected/state so its on/off
+          // state is announced rather than a bare static "Toggle …" label.
+          contentDescription = "Toggle ${level.label} logs"
+          stateDescription = if (isEnabled) "Shown" else "Hidden"
+          selected = isEnabled
+          role = Role.Switch
+        }
+  ) {
+    Text(
+      level.letter,
+      fontSize = 11.sp,
+      fontFamily = FontFamily.Monospace,
+      fontWeight = FontWeight.SemiBold,
+      color =
+        if (isEnabled) Color(level.color)
+        else SharedTheme.globalColors.text.normal.copy(alpha = 0.35f),
+    )
   }
 }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanel.kt
@@ -155,14 +155,15 @@ fun connectionStatusText(state: ConnectionState): String? =
  * Filtering never touches the daemon protocol — it only narrows what is already in memory.
  *
  * The client is owned by the caller (the facet connects/disposes it per device). Streamed rows are
- * kept per [activeDeviceId]; switching devices clears the buffer. [platform] selects the numeric
- * log-level scale used to bucket rows into filter chips (see [logLevelOf]).
+ * kept per [activeDeviceId] (capped at [maxRows]); switching devices clears the buffer. [platform]
+ * selects the numeric log-level scale used to bucket rows into filter chips (see [logLevelOf]).
  */
 @Composable
 fun LogsPanel(
   telemetryPushClient: TelemetryPushClient?,
   activeDeviceId: String? = null,
   platform: LogPlatform = LogPlatform.Android,
+  maxRows: Int = MAX_LOG_ROWS,
   modifier: Modifier = Modifier,
 ) {
   val colors = SharedTheme.globalColors
@@ -170,20 +171,30 @@ fun LogsPanel(
   var query by remember { mutableStateOf("") }
   var enabledLevels by remember { mutableStateOf(LogLevel.entries.toSet()) }
   var connectionState by remember(activeDeviceId) { mutableStateOf<ConnectionState?>(null) }
+  // Monotonic append counter: unlike filtered.size it keeps advancing once the buffer is pinned at
+  // maxRows, so the tail-follow effect below still re-fires on every appended row at the cap.
+  var appendCount by remember(activeDeviceId) { mutableStateOf(0) }
   // Tail-follow *intent*: preserved across filter changes and reset only when the user scrolls away
   // from the bottom, so clearing a filter that had anchored the list on an old row still follows
   // the next live row.
   var followTail by remember(activeDeviceId) { mutableStateOf(true) }
 
-  val filtered by remember {
-    derivedStateOf { filterLogs(logs, enabledLevels, query, platform) }
-  }
+  // Keyed on `platform` so a platform change re-creates the derived state with the new scale;
+  // `logs`, `enabledLevels`, and `query` are Compose State reads that derivedStateOf tracks on
+  // its own, so they are intentionally not remember keys.
+  val filtered by
+    remember(platform) {
+      derivedStateOf { filterLogs(logs, enabledLevels, query, platform) }
+    }
   val listState = rememberLazyListState()
 
-  LaunchedEffect(telemetryPushClient, activeDeviceId) {
+  LaunchedEffect(telemetryPushClient, activeDeviceId, maxRows) {
     val client = telemetryPushClient ?: return@LaunchedEffect
     client.telemetryEvents.collect { event ->
-      if (event is TelemetryDisplayEvent.Log) appendBounded(logs, event)
+      if (event is TelemetryDisplayEvent.Log) {
+        appendBounded(logs, event, maxRows)
+        appendCount++
+      }
     }
   }
 
@@ -200,10 +211,10 @@ fun LogsPanel(
       .collect { inProgress -> if (!inProgress) followTail = !listState.canScrollForward }
   }
 
-  // Follow the tail when following: fires on new rows (size change) and on filter changes (which
-  // re-anchor the list), so the newest visible row stays in view without fighting a scrolled-up
-  // user.
-  LaunchedEffect(filtered.size, query, enabledLevels, followTail) {
+  // Follow the tail when following: fires on every appended row (via appendCount, which advances
+  // even at the buffer cap) and on filter changes (which re-anchor the list), so the newest
+  // visible row stays in view without fighting a scrolled-up user.
+  LaunchedEffect(appendCount, query, enabledLevels, followTail) {
     if (followTail && filtered.isNotEmpty()) {
       listState.scrollToItem(filtered.lastIndex)
     }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanel.kt
@@ -179,11 +179,12 @@ fun LogsPanel(
   // the next live row.
   var followTail by remember(activeDeviceId) { mutableStateOf(true) }
 
-  // Keyed on `platform` so a platform change re-creates the derived state with the new scale;
-  // `logs`, `enabledLevels`, and `query` are Compose State reads that derivedStateOf tracks on
-  // its own, so they are intentionally not remember keys.
+  // Keyed on `platform` (new scale) and `activeDeviceId` (a device switch swaps `logs` for a fresh
+  // remembered list, so the derived state must re-capture it — otherwise it keeps reading the old
+  // device's buffer). `enabledLevels` and `query` are Compose State reads that derivedStateOf
+  // tracks on its own, so they are intentionally not remember keys.
   val filtered by
-    remember(platform) {
+    remember(platform, activeDeviceId) {
       derivedStateOf { filterLogs(logs, enabledLevels, query, platform) }
     }
   val listState = rememberLazyListState()
@@ -198,23 +199,27 @@ fun LogsPanel(
     }
   }
 
-  LaunchedEffect(telemetryPushClient) {
+  // Keyed on activeDeviceId as well as the client: the client is recreated per device by the
+  // facet (so identity already changes on switch), but keying on the device id too makes the reset
+  // explicit and re-seeds the remembered connectionState for the new device.
+  LaunchedEffect(telemetryPushClient, activeDeviceId) {
     val client = telemetryPushClient ?: return@LaunchedEffect
     client.connectionState.collect { connectionState = it }
   }
 
   // Re-derive follow intent whenever a scroll settles: we follow iff the viewport rests at the
   // bottom. A user drag that stops mid-list clears it; reaching the bottom (or a programmatic
-  // tail scroll) re-arms it. Filter changes do not scroll, so they never clear the intent.
-  LaunchedEffect(listState) {
+  // tail scroll) re-arms it. Filter changes do not scroll, so they never clear the intent. Keyed
+  // on activeDeviceId so a device switch restarts the observer against the reset follow state.
+  LaunchedEffect(listState, activeDeviceId) {
     snapshotFlow { listState.isScrollInProgress }
       .collect { inProgress -> if (!inProgress) followTail = !listState.canScrollForward }
   }
 
   // Follow the tail when following: fires on every appended row (via appendCount, which advances
-  // even at the buffer cap) and on filter changes (which re-anchor the list), so the newest
-  // visible row stays in view without fighting a scrolled-up user.
-  LaunchedEffect(appendCount, query, enabledLevels, followTail) {
+  // even at the buffer cap) and on filter/platform changes (which re-anchor the list), so the
+  // newest visible row stays in view without fighting a scrolled-up user.
+  LaunchedEffect(appendCount, query, enabledLevels, platform, followTail) {
     if (followTail && filtered.isNotEmpty()) {
       listState.scrollToItem(filtered.lastIndex)
     }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/LogsFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/LogsFacet.kt
@@ -8,7 +8,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import dev.jasonpearson.automobile.desktop.core.daemon.TelemetryPushClient
 import dev.jasonpearson.automobile.desktop.core.daemon.TelemetryPushSocketClient
+import dev.jasonpearson.automobile.desktop.core.telemetry.LogPlatform
 import dev.jasonpearson.automobile.desktop.core.telemetry.LogsPanel
+
+/**
+ * The log-level numeric scale this device's logs use (Android and iOS number levels differently).
+ */
+private fun Platform.toLogPlatform(): LogPlatform =
+  if (this == Platform.Ios) LogPlatform.Ios else LogPlatform.Android
 
 /**
  * Docked-facet body for [Tool.Logs]: a logs-only event stream with an always-on filter bar
@@ -38,5 +45,6 @@ fun LogsFacet(
   LogsPanel(
     telemetryPushClient = client,
     activeDeviceId = column.deviceId,
+    platform = column.platform.toLogPlatform(),
   )
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/LogsFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/LogsFacet.kt
@@ -8,13 +8,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import dev.jasonpearson.automobile.desktop.core.daemon.TelemetryPushClient
 import dev.jasonpearson.automobile.desktop.core.daemon.TelemetryPushSocketClient
-import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
-import dev.jasonpearson.automobile.desktop.core.telemetry.TelemetryDashboard
+import dev.jasonpearson.automobile.desktop.core.telemetry.LogsPanel
 
 /**
- * Docked-facet body for [Tool.Logs]: the telemetry dashboard scoped to a single pane's device. A
- * [TelemetryPushClient] is created via [telemetryClientFactory] and connected to [column]'s device
- * while the facet is shown, then disposed when it leaves composition or the device changes.
+ * Docked-facet body for [Tool.Logs]: a logs-only event stream with an always-on filter bar
+ * (per-level chips + free-text search), scoped to a single pane's device. A [TelemetryPushClient]
+ * is created via [telemetryClientFactory] and connected to [column]'s device while the facet is
+ * shown, then disposed when it leaves composition or the device changes.
  *
  * [telemetryClientFactory] is injected (defaulting to a real per-device
  * [TelemetryPushSocketClient]) so the per-device connect/dispose lifecycle can be verified with a
@@ -35,9 +35,8 @@ fun LogsFacet(
       client = null
     }
   }
-  TelemetryDashboard(
+  LogsPanel(
     telemetryPushClient = client,
-    dataSourceMode = DataSourceMode.Real,
     activeDeviceId = column.deviceId,
   )
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanelTest.kt
@@ -1,6 +1,9 @@
 package dev.jasonpearson.automobile.desktop.core.telemetry
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotSelected
@@ -13,6 +16,8 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import dev.jasonpearson.automobile.desktop.core.daemon.FakeTelemetryPushClient
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -108,6 +113,27 @@ class LogsPanelTest {
     assertEquals(listOf("m10", "m11"), filtered.map { it.message })
   }
 
+  @Test
+  fun `logLevelOf buckets ios levels on the ios scale`() {
+    assertEquals(LogLevel.Verbose, logLevelOf(0, LogPlatform.Ios))
+    assertEquals(LogLevel.Debug, logLevelOf(1, LogPlatform.Ios))
+    assertEquals(LogLevel.Info, logLevelOf(2, LogPlatform.Ios))
+    assertEquals(LogLevel.Warn, logLevelOf(3, LogPlatform.Ios))
+    assertEquals(LogLevel.Error, logLevelOf(4, LogPlatform.Ios))
+    // iOS fault (5) is the top severity → Error.
+    assertEquals(LogLevel.Error, logLevelOf(5, LogPlatform.Ios))
+    // The same int buckets differently per platform: 5 = Warn on Android, Error (fault) on iOS.
+    assertEquals(LogLevel.Warn, logLevelOf(5, LogPlatform.Android))
+  }
+
+  @Test
+  fun `filterLogs buckets ios rows on the ios scale`() {
+    val logs = listOf(log(3, "T", "ios warning", 1), log(5, "T", "ios fault", 2))
+    // On the iOS scale level 3 = Warn and level 5 = Error (fault).
+    assertEquals(listOf(logs[0]), filterLogs(logs, setOf(LogLevel.Warn), "", LogPlatform.Ios))
+    assertEquals(listOf(logs[1]), filterLogs(logs, setOf(LogLevel.Error), "", LogPlatform.Ios))
+  }
+
   // -- Compose UI tests --
 
   @Test
@@ -189,5 +215,56 @@ class LogsPanelTest {
     onNodeWithContentDescription("Toggle Warn logs").assertIsNotSelected()
     onNodeWithContentDescription("Toggle Warn logs").performClick()
     onNodeWithContentDescription("Toggle Warn logs").assertIsSelected()
+  }
+
+  @Test
+  fun `surfaces a connection banner instead of a misleading no-logs-yet`() = runComposeUiTest {
+    val fake = FakeTelemetryPushClient()
+    setContent {
+      MaterialTheme { LogsPanel(telemetryPushClient = fake, activeDeviceId = "dev-1") }
+    }
+    fake.setConnectionState(ConnectionState.Connecting)
+    waitUntil(timeoutMillis = 2_000) {
+      onAllNodesWithText("Connecting...").fetchSemanticsNodes().isNotEmpty()
+    }
+    // The connecting status is surfaced; the healthy-but-empty text is not shown.
+    onNodeWithText("No logs yet").assertDoesNotExist()
+  }
+
+  @Test
+  fun `tail-follow survives filtering to an old row then clearing`() = runComposeUiTest {
+    val fake = FakeTelemetryPushClient()
+    setContent {
+      MaterialTheme {
+        // Constrain height so the row list overflows and scroll position actually matters.
+        Box(Modifier.height(120.dp)) {
+          LogsPanel(telemetryPushClient = fake, activeDeviceId = "dev-1")
+        }
+      }
+    }
+    waitForIdle()
+    for (i in 0 until 30) {
+      fake.emitEvent(log(4, "T", "row $i", i.toLong()))
+    }
+    // Following the tail, the newest row is visible.
+    waitUntil(timeoutMillis = 2_000) {
+      onAllNodesWithText("row 29").fetchSemanticsNodes().isNotEmpty()
+    }
+    onNodeWithText("row 29").assertIsDisplayed()
+
+    // Filter down to an old row, then clear the query.
+    onNode(hasSetTextAction()).performTextInput("row 0")
+    waitUntil(timeoutMillis = 2_000) {
+      onAllNodesWithText("row 0").fetchSemanticsNodes().isNotEmpty()
+    }
+    onNode(hasSetTextAction()).performTextClearance()
+    waitForIdle()
+
+    // The next live row is still followed to the bottom, not stranded below the fold.
+    fake.emitEvent(log(4, "T", "row 30", 30L))
+    waitUntil(timeoutMillis = 2_000) {
+      onAllNodesWithText("row 30").fetchSemanticsNodes().isNotEmpty()
+    }
+    onNodeWithText("row 30").assertIsDisplayed()
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanelTest.kt
@@ -331,4 +331,28 @@ class LogsPanelTest {
     }
     onNodeWithText("level five").assertIsDisplayed()
   }
+
+  @Test
+  fun `switching device resets the log buffer`() = runComposeUiTest {
+    val fake = FakeTelemetryPushClient()
+    val deviceId = mutableStateOf("dev-1")
+    setContent {
+      MaterialTheme {
+        LogsPanel(telemetryPushClient = fake, activeDeviceId = deviceId.value)
+      }
+    }
+    waitForIdle()
+    fake.emitEvent(log(4, "T", "device one row", 1))
+    waitUntil(timeoutMillis = 2_000) {
+      onAllNodesWithText("device one row").fetchSemanticsNodes().isNotEmpty()
+    }
+
+    // Switching devices must clear the per-device buffer (and re-arm the collect against the new
+    // device), so the previous device's rows disappear and the empty state returns.
+    runOnIdle { deviceId.value = "dev-2" }
+    waitUntil(timeoutMillis = 2_000) {
+      onAllNodesWithText("device one row").fetchSemanticsNodes().isEmpty()
+    }
+    onNodeWithText("No logs yet").assertIsDisplayed()
+  }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanelTest.kt
@@ -1,0 +1,161 @@
+package dev.jasonpearson.automobile.desktop.core.telemetry
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.daemon.FakeTelemetryPushClient
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class LogsPanelTest {
+
+  private fun log(level: Int, tag: String, message: String, timestamp: Long) =
+    TelemetryDisplayEvent.Log(
+      timestamp = timestamp,
+      level = level,
+      tag = tag,
+      message = message,
+    )
+
+  // -- Pure filter tests (no Compose) --
+
+  @Test
+  fun `logLevelOf maps android levels to canonical buckets`() {
+    assertEquals(LogLevel.Verbose, logLevelOf(2))
+    assertEquals(LogLevel.Debug, logLevelOf(3))
+    assertEquals(LogLevel.Info, logLevelOf(4))
+    assertEquals(LogLevel.Warn, logLevelOf(5))
+    assertEquals(LogLevel.Error, logLevelOf(6))
+    // Assert (7) and anything above fold into Error so every row maps to a chip.
+    assertEquals(LogLevel.Error, logLevelOf(7))
+    // Unknown/low values fall back to Verbose so nothing is silently dropped.
+    assertEquals(LogLevel.Verbose, logLevelOf(0))
+  }
+
+  @Test
+  fun `empty filter shows every log`() {
+    val logs =
+      listOf(
+        log(4, "A", "info message", 1),
+        log(5, "B", "warn message", 2),
+        log(6, "C", "error message", 3),
+      )
+    val result = filterLogs(logs, LogLevel.entries.toSet(), "")
+    assertEquals(logs, result)
+  }
+
+  @Test
+  fun `search narrows by case-insensitive substring over tag and message`() {
+    val logs =
+      listOf(
+        log(4, "Network", "connected to host", 1),
+        log(4, "Ui", "button tapped", 2),
+        log(4, "Db", "NETWORK cache miss", 3),
+      )
+    // Matches tag of row 0 and message of row 2 (case-insensitive), not row 1.
+    val result = filterLogs(logs, LogLevel.entries.toSet(), "network")
+    assertEquals(listOf(logs[0], logs[2]), result)
+  }
+
+  @Test
+  fun `disabling a level hides only that level`() {
+    val logs =
+      listOf(
+        log(4, "A", "info message", 1),
+        log(5, "B", "warn message", 2),
+        log(6, "C", "error message", 3),
+      )
+    val result = filterLogs(logs, LogLevel.entries.toSet() - LogLevel.Warn, "")
+    assertEquals(listOf(logs[0], logs[2]), result)
+  }
+
+  @Test
+  fun `level and search compose together`() {
+    val logs =
+      listOf(
+        log(4, "A", "keep me", 1),
+        log(5, "B", "keep me", 2),
+        log(4, "C", "drop me", 3),
+      )
+    val result = filterLogs(logs, setOf(LogLevel.Info), "keep")
+    assertEquals(listOf(logs[0]), result)
+  }
+
+  // -- Compose UI tests --
+
+  @Test
+  fun `search field narrows the visible rows and clearing restores them`() = runComposeUiTest {
+    val fake = FakeTelemetryPushClient()
+    setContent {
+      MaterialTheme { LogsPanel(telemetryPushClient = fake, activeDeviceId = "dev-1") }
+    }
+    waitForIdle()
+    fake.emitEvent(log(4, "Net", "alpha connected", 10))
+    fake.emitEvent(log(4, "Ui", "beta tapped", 20))
+    waitUntil(timeoutMillis = 2_000) {
+      onAllNodesWithText("alpha connected").fetchSemanticsNodes().isNotEmpty() &&
+        onAllNodesWithText("beta tapped").fetchSemanticsNodes().isNotEmpty()
+    }
+
+    // Typing a query hides the non-matching row.
+    onNode(hasSetTextAction()).performTextInput("alpha")
+    waitUntil(timeoutMillis = 2_000) {
+      onAllNodesWithText("beta tapped").fetchSemanticsNodes().isEmpty()
+    }
+    onNodeWithText("alpha connected").assertIsDisplayed()
+
+    // Clearing the query restores all rows.
+    onNode(hasSetTextAction()).performTextClearance()
+    waitUntil(timeoutMillis = 2_000) {
+      onAllNodesWithText("beta tapped").fetchSemanticsNodes().isNotEmpty()
+    }
+    onNodeWithText("alpha connected").assertIsDisplayed()
+    onNodeWithText("beta tapped").assertIsDisplayed()
+  }
+
+  @Test
+  fun `toggling a level chip off hides logs of that level`() = runComposeUiTest {
+    val fake = FakeTelemetryPushClient()
+    setContent {
+      MaterialTheme { LogsPanel(telemetryPushClient = fake, activeDeviceId = "dev-1") }
+    }
+    waitForIdle()
+    fake.emitEvent(log(4, "Net", "info line", 10))
+    fake.emitEvent(log(5, "Net", "warn line", 20))
+    waitUntil(timeoutMillis = 2_000) {
+      onAllNodesWithText("info line").fetchSemanticsNodes().isNotEmpty() &&
+        onAllNodesWithText("warn line").fetchSemanticsNodes().isNotEmpty()
+    }
+
+    // Turning off the Warn chip hides the warn row but keeps the info row.
+    onNodeWithContentDescription("Toggle Warn logs").performClick()
+    waitUntil(timeoutMillis = 2_000) {
+      onAllNodesWithText("warn line").fetchSemanticsNodes().isEmpty()
+    }
+    onNodeWithText("info line").assertIsDisplayed()
+
+    // Turning it back on restores the warn row.
+    onNodeWithContentDescription("Toggle Warn logs").performClick()
+    waitUntil(timeoutMillis = 2_000) {
+      onAllNodesWithText("warn line").fetchSemanticsNodes().isNotEmpty()
+    }
+    onNodeWithText("warn line").assertIsDisplayed()
+  }
+
+  @Test
+  fun `shows empty state before any logs arrive`() = runComposeUiTest {
+    setContent {
+      MaterialTheme { LogsPanel(telemetryPushClient = null, activeDeviceId = "dev-1") }
+    }
+    onNodeWithText("No logs yet").assertIsDisplayed()
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanelTest.kt
@@ -3,6 +3,8 @@ package dev.jasonpearson.automobile.desktop.core.telemetry
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotSelected
+import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -90,6 +92,22 @@ class LogsPanelTest {
     assertEquals(listOf(logs[0]), result)
   }
 
+  @Test
+  fun `appendBounded keeps only the most recent rows past the cap`() {
+    val buffer = mutableListOf<TelemetryDisplayEvent.Log>()
+    val max = 5
+    for (i in 0 until 12) {
+      appendBounded(buffer, log(4, "T", "m$i", i.toLong()), max)
+    }
+    // Only the most recent `max` rows survive, oldest dropped first.
+    assertEquals(max, buffer.size)
+    assertEquals(listOf("m7", "m8", "m9", "m10", "m11"), buffer.map { it.message })
+
+    // Filtering still works over the bounded buffer (substring "m1" matches m10 and m11).
+    val filtered = filterLogs(buffer, LogLevel.entries.toSet(), "m1")
+    assertEquals(listOf("m10", "m11"), filtered.map { it.message })
+  }
+
   // -- Compose UI tests --
 
   @Test
@@ -157,5 +175,19 @@ class LogsPanelTest {
       MaterialTheme { LogsPanel(telemetryPushClient = null, activeDeviceId = "dev-1") }
     }
     onNodeWithText("No logs yet").assertIsDisplayed()
+  }
+
+  @Test
+  fun `level chip exposes a selected state that flips when toggled`() = runComposeUiTest {
+    setContent {
+      MaterialTheme { LogsPanel(telemetryPushClient = null, activeDeviceId = "dev-1") }
+    }
+    // Chips start enabled (selected); toggling off flips selected to false, toggling on restores
+    // it.
+    onNodeWithContentDescription("Toggle Warn logs").assertIsSelected()
+    onNodeWithContentDescription("Toggle Warn logs").performClick()
+    onNodeWithContentDescription("Toggle Warn logs").assertIsNotSelected()
+    onNodeWithContentDescription("Toggle Warn logs").performClick()
+    onNodeWithContentDescription("Toggle Warn logs").assertIsSelected()
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanelTest.kt
@@ -9,11 +9,13 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsSelected
+import androidx.compose.ui.test.hasScrollToIndexAction
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.runComposeUiTest
@@ -355,4 +357,43 @@ class LogsPanelTest {
     }
     onNodeWithText("No logs yet").assertIsDisplayed()
   }
+
+  @Test
+  fun `switching device after scrolling up still auto-follows on the new device`() =
+    runComposeUiTest {
+      val fake = FakeTelemetryPushClient()
+      val deviceId = mutableStateOf("dev-A")
+      setContent {
+        MaterialTheme {
+          Box(Modifier.height(120.dp)) {
+            LogsPanel(telemetryPushClient = fake, activeDeviceId = deviceId.value)
+          }
+        }
+      }
+      waitForIdle()
+      for (i in 0 until 30) {
+        fake.emitEvent(log(4, "A", "a-row $i", i.toLong()))
+      }
+      waitUntil(timeoutMillis = 2_000) {
+        onAllNodesWithText("a-row 29").fetchSemanticsNodes().isNotEmpty()
+      }
+      // Scroll device A away from the tail so its follow intent is cleared. Target the log list's
+      // scroll action specifically (the chip row is also horizontally scrollable).
+      onNode(hasScrollToIndexAction()).performScrollToIndex(0)
+      waitUntil(timeoutMillis = 2_000) {
+        onAllNodesWithText("a-row 0").fetchSemanticsNodes().isNotEmpty()
+      }
+
+      // Switch to a fresh device: its list state and follow intent must reset, so its own new
+      // logs auto-follow rather than inheriting device A's scrolled-up position.
+      runOnIdle { deviceId.value = "dev-B" }
+      waitForIdle()
+      for (i in 0 until 30) {
+        fake.emitEvent(log(4, "B", "b-row $i", (100 + i).toLong()))
+      }
+      waitUntil(timeoutMillis = 2_000) {
+        onAllNodesWithText("b-row 29").fetchSemanticsNodes().isNotEmpty()
+      }
+      onNodeWithText("b-row 29").assertIsDisplayed()
+    }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/telemetry/LogsPanelTest.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.automobile.desktop.core.telemetry
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
@@ -266,5 +267,68 @@ class LogsPanelTest {
       onAllNodesWithText("row 30").fetchSemanticsNodes().isNotEmpty()
     }
     onNodeWithText("row 30").assertIsDisplayed()
+  }
+
+  @Test
+  fun `tail-follow keeps following once the buffer is at its cap`() = runComposeUiTest {
+    val fake = FakeTelemetryPushClient()
+    setContent {
+      MaterialTheme {
+        Box(Modifier.height(120.dp)) {
+          // Tiny cap so the buffer pins quickly and `filtered.size` stops changing on append.
+          LogsPanel(telemetryPushClient = fake, activeDeviceId = "dev-1", maxRows = 4)
+        }
+      }
+    }
+    waitForIdle()
+    for (i in 0 until 10) {
+      fake.emitEvent(log(4, "T", "row $i", i.toLong()))
+    }
+    waitUntil(timeoutMillis = 2_000) {
+      onAllNodesWithText("row 9").fetchSemanticsNodes().isNotEmpty()
+    }
+    onNodeWithText("row 9").assertIsDisplayed()
+
+    // Buffer is pinned at 4 rows now; the next append does not change filtered.size, but the
+    // newest row must still be followed (regression guard for the size-keyed follow effect).
+    fake.emitEvent(log(4, "T", "row 10", 10L))
+    waitUntil(timeoutMillis = 2_000) {
+      onAllNodesWithText("row 10").fetchSemanticsNodes().isNotEmpty()
+    }
+    onNodeWithText("row 10").assertIsDisplayed()
+  }
+
+  @Test
+  fun `changing platform re-buckets rows without going stale`() = runComposeUiTest {
+    val fake = FakeTelemetryPushClient()
+    val platform = mutableStateOf(LogPlatform.Android)
+    setContent {
+      MaterialTheme {
+        LogsPanel(
+          telemetryPushClient = fake,
+          activeDeviceId = "dev-1",
+          platform = platform.value,
+        )
+      }
+    }
+    waitForIdle()
+    fake.emitEvent(log(5, "T", "level five", 1))
+    waitUntil(timeoutMillis = 2_000) {
+      onAllNodesWithText("level five").fetchSemanticsNodes().isNotEmpty()
+    }
+
+    // On the Android scale level 5 = Warn, so disabling Warn hides the row.
+    onNodeWithContentDescription("Toggle Warn logs").performClick()
+    waitUntil(timeoutMillis = 2_000) {
+      onAllNodesWithText("level five").fetchSemanticsNodes().isEmpty()
+    }
+
+    // Flipping to iOS after first composition must re-bucket: level 5 = fault → Error (Warn still
+    // off), so the row reappears — proving the derived filter is not stale on `platform`.
+    runOnIdle { platform.value = LogPlatform.Ios }
+    waitUntil(timeoutMillis = 2_000) {
+      onAllNodesWithText("level five").fetchSemanticsNodes().isNotEmpty()
+    }
+    onNodeWithText("level five").assertIsDisplayed()
   }
 }


### PR DESCRIPTION
Closes [#4841](https://github.com/kaeawc/auto-mobile/issues/4841).

## What

Replaces the generic `TelemetryDashboard` in the desktop app's **Logs facet** with a dedicated, logs-only `LogsPanel` that has an **always-on filter bar**, per wireframe exploration `12-logs-filtering`.

The filter bar has:
- **Per-level chips** — Verbose / Debug / Info / Warn / Error, click to include/exclude a level.
- **Free-text search** — case-insensitive substring over each row's tag + message (reuses the existing `SearchBar` component and the `TelemetryDisplayEvent.matchesSearch` helper).

Filtering is **client-side over already-streamed rows** — the daemon protocol is untouched. Android priority ints (`VERBOSE`=2 .. `ASSERT`=7) collapse into the five chips via `logLevelOf`, which maps every int to exactly one bucket so "all chips on + blank query" is a true no-op filter.

The shared `TelemetryDashboard` is left as-is (still used by `AutoMobileContent`); only the Logs facet body changed.

## Files

- `core/telemetry/LogsPanel.kt` (new) — `LogLevel` enum, `logLevelOf`, the pure `filterLogs`, and the `LogsPanel` / filter-bar / row composables.
- `core/workspace/LogsFacet.kt` — renders `LogsPanel` instead of `TelemetryDashboard`; the injected-factory + `DisposableEffect(deviceId)` connect/dispose lifecycle is unchanged.
- `core/telemetry/LogsPanelTest.kt` (new) — 8 tests.

## Acceptance criteria → tests

| Criterion | Test |
| --- | --- |
| Search narrows to matching tag/message (case-insensitive); clearing restores | UI: `search field narrows the visible rows and clearing restores them`; pure: `search narrows by case-insensitive substring over tag and message` |
| Level toggle hides only that level; re-enable restores | UI: `toggling a level chip off hides logs of that level`; pure: `disabling a level hides only that level` |
| Untouched filter shows everything | pure: `empty filter shows every log`; `logLevelOf maps android levels to canonical buckets` |
| Level + search compose | pure: `level and search compose together` |
| Empty state before rows | UI: `shows empty state before any logs arrive` |

Per-device lifecycle is covered by the existing `LogsFacetTest` (connect once / dispose on removal), which still passes unchanged.

## Validation

- `bash scripts/ktfmt/apply_ktfmt.sh`
- `:desktop-core:detektMain` — pass
- Full `:desktop-core:test` — 988 tests, 0 failures (8 new)

## Deferred

The wireframe's "composable filter builder + saved views" (persisted, named filter sets) is deferred — see [#4841](https://github.com/kaeawc/auto-mobile/issues/4841). No persistence is introduced here.
