### PR TITLE
feat(desktop): progressive status — status dot expands to a health sheet

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -165,13 +165,17 @@ private fun TopBar(
             .padding(horizontal = 8.dp, vertical = 4.dp),
       )
     }
+    // Visible dot stays 12dp; the clickable target is enlarged to 32dp. For a green status (no
+    // inline line) the dot is the only entry point to the health sheet.
     Box(
       modifier =
-        Modifier.size(12.dp)
-          .background(status.color(), CircleShape)
+        Modifier.size(32.dp)
           .clickable { onStatusClick() }
-          .semantics { contentDescription = "Status: ${status.name}" }
-    )
+          .semantics { contentDescription = "Status: ${status.name}" },
+      contentAlignment = Alignment.Center,
+    ) {
+      Box(Modifier.size(12.dp).background(status.color(), CircleShape))
+    }
   }
 }
 
@@ -233,10 +237,21 @@ private fun HealthSheetOverlay(onDismiss: () -> Unit, content: @Composable () ->
 private fun DefaultHealthSheetBody() {
   var connectedProcess by remember { mutableStateOf<McpProcess?>(null) }
   Column(Modifier.fillMaxSize()) {
-    McpProcessesPanel(useRealData = true, onProcessConnected = { connectedProcess = it })
+    // suppressAutoSelect: opening a diagnostic overlay must not mutate device selection. Without
+    // it,
+    // McpProcessesPanel calls setActiveDevice when exactly one device is booted.
+    // Both children are weighted so a tall process list can't push the dashboard out of view.
+    Box(Modifier.weight(1f)) {
+      McpProcessesPanel(
+        useRealData = true,
+        suppressAutoSelect = true,
+        onProcessConnected = { connectedProcess = it },
+      )
+    }
     DiagnosticsDashboard(
       connectedMcpProcess = connectedProcess,
       dataSourceMode = DataSourceMode.Real,
+      modifier = Modifier.weight(1f),
     )
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -35,10 +36,13 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import dev.jasonpearson.automobile.desktop.core.McpProcessesPanel
 import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
 import dev.jasonpearson.automobile.desktop.core.diagnostics.DiagnosticsDashboard
+import dev.jasonpearson.automobile.desktop.core.mcp.McpConnectionType
 import dev.jasonpearson.automobile.desktop.core.mcp.McpProcess
+import dev.jasonpearson.automobile.desktop.core.mcp.RealMcpProcessDetector
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 private val StatusGreen = Color(0xFF40C057)
 private val StatusYellow = Color(0xFFF0C000)
@@ -235,25 +239,23 @@ private fun HealthSheetOverlay(onDismiss: () -> Unit, content: @Composable () ->
  */
 @Composable
 private fun DefaultHealthSheetBody() {
-  var connectedProcess by remember { mutableStateOf<McpProcess?>(null) }
-  Column(Modifier.fillMaxSize()) {
-    // suppressAutoSelect: opening a diagnostic overlay must not mutate device selection. Without
-    // it,
-    // McpProcessesPanel calls setActiveDevice when exactly one device is booted.
-    // Both children are weighted so a tall process list can't push the dashboard out of view.
-    Box(Modifier.weight(1f)) {
-      McpProcessesPanel(
-        useRealData = true,
-        suppressAutoSelect = true,
-        onProcessConnected = { connectedProcess = it },
-      )
-    }
-    DiagnosticsDashboard(
-      connectedMcpProcess = connectedProcess,
-      dataSourceMode = DataSourceMode.Real,
-      modifier = Modifier.weight(1f),
-    )
+  var daemonProcess by remember { mutableStateOf<McpProcess?>(null) }
+  // Read-only detection only. We deliberately do NOT use McpProcessesPanel here: its auto-connect
+  // effect can call setActiveDevice and DesktopDaemonLifecycle.ensureVersionMatchedDaemon (which
+  // may
+  // restart the daemon), and merely opening a diagnostic overlay must never mutate daemon or device
+  // state. RealMcpProcessDetector.detectProcesses() just inspects the process/socket table.
+  LaunchedEffect(Unit) {
+    val detected = withContext(Dispatchers.IO) { RealMcpProcessDetector().detectProcesses() }
+    daemonProcess =
+      detected.firstOrNull { it.connectionType == McpConnectionType.UnixSocket }
+        ?: detected.firstOrNull()
   }
+  DiagnosticsDashboard(
+    connectedMcpProcess = daemonProcess,
+    dataSourceMode = DataSourceMode.Real,
+    modifier = Modifier.fillMaxSize(),
+  )
 }
 
 @Composable

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -170,7 +170,10 @@ private fun TopBar(
         maxLines = 1,
         overflow = TextOverflow.Ellipsis,
         modifier =
-          Modifier.widthIn(max = 260.dp)
+          // weight(fill = false): when the window narrows, the detail ellipsizes and yields space
+          // rather than measuring first and pushing the fixed-size status dot off the row.
+          Modifier.weight(1f, fill = false)
+            .widthIn(max = 260.dp)
             .clickable { onStatusClick() }
             .semantics { contentDescription = "Status detail: $statusDetail" }
             .padding(horizontal = 8.dp, vertical = 4.dp),

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -170,10 +170,10 @@ private fun TopBar(
         maxLines = 1,
         overflow = TextOverflow.Ellipsis,
         modifier =
-          // weight(fill = false): when the window narrows, the detail ellipsizes and yields space
-          // rather than measuring first and pushing the fixed-size status dot off the row.
-          Modifier.weight(1f, fill = false)
-            .widthIn(max = 260.dp)
+          // Content-sized and capped at 260dp with ellipsis. The leading weighted Spacer pushes
+          // this trailing cluster right, so the dot (the last child) stays hard-right; a weight
+          // here would leave an unfilled allocation that shifts the dot left for short details.
+          Modifier.widthIn(max = 260.dp)
             .clickable { onStatusClick() }
             .semantics { contentDescription = "Status detail: $statusDetail" }
             .padding(horizontal = 8.dp, vertical = 4.dp),

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -42,12 +42,16 @@ import dev.jasonpearson.automobile.desktop.core.mcp.McpConnectionType
 import dev.jasonpearson.automobile.desktop.core.mcp.McpProcess
 import dev.jasonpearson.automobile.desktop.core.mcp.RealMcpProcessDetector
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 
 private val StatusGreen = Color(0xFF40C057)
 private val StatusYellow = Color(0xFFF0C000)
 private val StatusRed = Color(0xFFFA5252)
 private val Accent = Color(0xFF4DABF7)
+
+// How often the open health sheet re-scans for the daemon process (read-only).
+private const val HEALTH_SHEET_REFRESH_MS = 5_000L
 
 /**
  * Root of the device-tab workspace. Device identity lives in each column header (no top tab bar); a
@@ -159,7 +163,10 @@ private fun TopBar(
       Text(
         statusDetail,
         style = MaterialTheme.typography.labelMedium,
-        color = status.color(),
+        // Legibility over the top bar's surfaceVariant: the status color lives on the dot; the
+        // detail text uses onSurfaceVariant so it stays readable in both light and dark themes
+        // (status yellow #F0C000 on the light surfaceVariant is ~1.5:1, unreadable).
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
         maxLines = 1,
         overflow = TextOverflow.Ellipsis,
         modifier =
@@ -227,15 +234,17 @@ private fun HealthSheetOverlay(onDismiss: () -> Unit, content: @Composable () ->
         )
       }
       Spacer(Modifier.height(8.dp))
-      content()
+      // Constrain the body to the height below the title row so a fillMaxSize() body can't overflow
+      // the header out of the panel.
+      Box(Modifier.weight(1f).fillMaxWidth()) { content() }
     }
   }
 }
 
 /**
- * Default health-sheet body: the live [DiagnosticsDashboard], fed the MCP process detected by
- * [McpProcessesPanel]. Tests inject their own `healthSheetContent`, so this real, system-touching
- * path is exercised only in production / manual runs.
+ * Default health-sheet body: the live [DiagnosticsDashboard], fed the Unix-socket daemon found by a
+ * read-only [RealMcpProcessDetector] scan. Tests inject their own `healthSheetContent`, so this
+ * real, system-touching path is exercised only in production / manual runs.
  */
 @Composable
 private fun DefaultHealthSheetBody() {
@@ -244,12 +253,16 @@ private fun DefaultHealthSheetBody() {
   // effect can call setActiveDevice and DesktopDaemonLifecycle.ensureVersionMatchedDaemon (which
   // may
   // restart the daemon), and merely opening a diagnostic overlay must never mutate daemon or device
-  // state. RealMcpProcessDetector.detectProcesses() just inspects the process/socket table.
+  // state. RealMcpProcessDetector.detectProcesses() just inspects the process/socket table. Re-scan
+  // on an interval so the sheet reflects a daemon started/stopped/restarted while it stays open.
   LaunchedEffect(Unit) {
-    val detected = withContext(Dispatchers.IO) { RealMcpProcessDetector().detectProcesses() }
-    daemonProcess =
-      detected.firstOrNull { it.connectionType == McpConnectionType.UnixSocket }
-        ?: detected.firstOrNull()
+    while (true) {
+      val detected = withContext(Dispatchers.IO) { RealMcpProcessDetector().detectProcesses() }
+      // Only a Unix-socket daemon is the desktop's real connection; a detected STDIO process is not
+      // "connected", so surface null rather than mislabel it as connected.
+      daemonProcess = detected.firstOrNull { it.connectionType == McpConnectionType.UnixSocket }
+      delay(HEALTH_SHEET_REFRESH_MS)
+    }
   }
   DiagnosticsDashboard(
     connectedMcpProcess = daemonProcess,

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.automobile.desktop.core.workspace
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,12 +16,17 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -29,6 +35,10 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import dev.jasonpearson.automobile.desktop.core.McpProcessesPanel
+import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
+import dev.jasonpearson.automobile.desktop.core.diagnostics.DiagnosticsDashboard
+import dev.jasonpearson.automobile.desktop.core.mcp.McpProcess
 
 private val StatusGreen = Color(0xFF40C057)
 private val StatusYellow = Color(0xFFF0C000)
@@ -46,6 +56,8 @@ fun WorkspaceShell(
   onAction: (WorkspaceAction) -> Unit,
   onOpenPicker: () -> Unit,
   status: WorkspaceStatus = WorkspaceStatus.Green,
+  // A terse reason for a non-green status, shown inline next to the dot ("yellow = one line").
+  statusDetail: String? = null,
   onOpenPalette: () -> Unit = {},
   modifier: Modifier = Modifier,
   // Renders the docked facet body for a pane's active tool. Hoisted so the host can supply real
@@ -53,29 +65,48 @@ fun WorkspaceShell(
   facetContent: @Composable (DeviceColumn, Tool) -> Unit = { _, tool ->
     WorkspaceFacetPlaceholder(tool)
   },
+  // Body of the health sheet opened by clicking the status dot. Hoisted like [facetContent] so the
+  // host (or a test) can substitute content; defaults to the live [DiagnosticsDashboard].
+  healthSheetContent: @Composable () -> Unit = { DefaultHealthSheetBody() },
 ) {
-  Column(modifier.fillMaxSize()) {
-    TopBar(status = status, onOpenPicker = onOpenPicker, onOpenPalette = onOpenPalette)
-    when (state) {
-      is WorkspaceUiState.Empty -> EmptyState(onOpenPicker, Modifier.weight(1f).fillMaxWidth())
-      is WorkspaceUiState.Content ->
-        Row(Modifier.weight(1f).fillMaxWidth()) {
-          val canDiff = state.columns.size > 1
-          state.columns.forEach { column ->
-            // Key by deviceId so a surviving pane keeps its own remembered state + facet
-            // connection when another pane closes (unkeyed = positional identity churns survivors).
-            key(column.deviceId) {
-              DeviceColumnView(
-                column = column,
-                focused = column.deviceId == state.focusedDeviceId,
-                onAction = onAction,
-                facetContent = facetContent,
-                canDiff = canDiff,
-                modifier = Modifier.weight(1f).fillMaxHeight(),
-              )
+  var showHealthSheet by remember { mutableStateOf(false) }
+  Box(modifier.fillMaxSize()) {
+    Column(Modifier.fillMaxSize()) {
+      TopBar(
+        status = status,
+        statusDetail = statusDetail,
+        onOpenPicker = onOpenPicker,
+        onOpenPalette = onOpenPalette,
+        onStatusClick = { showHealthSheet = true },
+      )
+      when (state) {
+        is WorkspaceUiState.Empty -> EmptyState(onOpenPicker, Modifier.weight(1f).fillMaxWidth())
+        is WorkspaceUiState.Content ->
+          Row(Modifier.weight(1f).fillMaxWidth()) {
+            val canDiff = state.columns.size > 1
+            state.columns.forEach { column ->
+              // Key by deviceId so a surviving pane keeps its own remembered state + facet
+              // connection when another pane closes (unkeyed = positional identity churns
+              // survivors).
+              key(column.deviceId) {
+                DeviceColumnView(
+                  column = column,
+                  focused = column.deviceId == state.focusedDeviceId,
+                  onAction = onAction,
+                  facetContent = facetContent,
+                  canDiff = canDiff,
+                  modifier = Modifier.weight(1f).fillMaxHeight(),
+                )
+              }
             }
           }
-        }
+      }
+    }
+    if (showHealthSheet) {
+      HealthSheetOverlay(
+        onDismiss = { showHealthSheet = false },
+        content = healthSheetContent,
+      )
     }
   }
 }
@@ -83,8 +114,10 @@ fun WorkspaceShell(
 @Composable
 private fun TopBar(
   status: WorkspaceStatus,
+  statusDetail: String?,
   onOpenPicker: () -> Unit,
   onOpenPalette: () -> Unit,
+  onStatusClick: () -> Unit,
 ) {
   Row(
     modifier =
@@ -116,11 +149,94 @@ private fun TopBar(
           .padding(horizontal = 8.dp, vertical = 4.dp),
     )
     Spacer(Modifier.width(8.dp))
+    // "Yellow = one inline line": a non-green status shows a terse reason next to the dot; green
+    // stays a bare dot. The dot (and the line) open the health sheet on click.
+    if (status != WorkspaceStatus.Green && statusDetail != null) {
+      Text(
+        statusDetail,
+        style = MaterialTheme.typography.labelMedium,
+        color = status.color(),
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        modifier =
+          Modifier.widthIn(max = 260.dp)
+            .clickable { onStatusClick() }
+            .semantics { contentDescription = "Status detail: $statusDetail" }
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+      )
+    }
     Box(
       modifier =
-        Modifier.size(12.dp).background(status.color(), CircleShape).semantics {
-          contentDescription = "Status: ${status.name}"
-        }
+        Modifier.size(12.dp)
+          .background(status.color(), CircleShape)
+          .clickable { onStatusClick() }
+          .semantics { contentDescription = "Status: ${status.name}" }
+    )
+  }
+}
+
+/**
+ * Full-window overlay for the workspace health sheet: a dimmed scrim (click-away to dismiss) with a
+ * centered panel that hosts [content] and a ✕ close affordance. Mirrors the command palette
+ * overlay.
+ */
+@Composable
+private fun HealthSheetOverlay(onDismiss: () -> Unit, content: @Composable () -> Unit) {
+  Box(
+    modifier =
+      Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.5f)).clickable(
+        interactionSource = remember { MutableInteractionSource() },
+        indication = null,
+      ) {
+        onDismiss()
+      },
+    contentAlignment = Alignment.Center,
+  ) {
+    Column(
+      modifier =
+        Modifier.fillMaxWidth(0.6f)
+          .fillMaxHeight(0.8f)
+          .background(MaterialTheme.colorScheme.surface, RoundedCornerShape(12.dp))
+          // Swallow clicks on the panel so they don't dismiss via the scrim.
+          .clickable(
+            interactionSource = remember { MutableInteractionSource() },
+            indication = null,
+          ) {}
+          .padding(16.dp)
+          .semantics { contentDescription = "Health sheet" }
+    ) {
+      Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        Text("Health", style = MaterialTheme.typography.titleMedium)
+        Spacer(Modifier.weight(1f))
+        Text(
+          "✕",
+          style = MaterialTheme.typography.titleMedium,
+          color = MaterialTheme.colorScheme.onSurface,
+          modifier =
+            Modifier.clickable { onDismiss() }
+              .semantics { contentDescription = "Close health sheet" }
+              .padding(horizontal = 8.dp, vertical = 4.dp),
+        )
+      }
+      Spacer(Modifier.height(8.dp))
+      content()
+    }
+  }
+}
+
+/**
+ * Default health-sheet body: the live [DiagnosticsDashboard], fed the MCP process detected by
+ * [McpProcessesPanel]. Tests inject their own `healthSheetContent`, so this real, system-touching
+ * path is exercised only in production / manual runs.
+ */
+@Composable
+private fun DefaultHealthSheetBody() {
+  var connectedProcess by remember { mutableStateOf<McpProcess?>(null) }
+  Column(Modifier.fillMaxSize()) {
+    McpProcessesPanel(useRealData = true, onProcessConnected = { connectedProcess = it })
+    DiagnosticsDashboard(
+      connectedMcpProcess = connectedProcess,
+      dataSourceMode = DataSourceMode.Real,
     )
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
@@ -281,4 +281,94 @@ class WorkspaceShellUiTest {
     setContent { MaterialTheme { WorkspaceShell(state = state, onAction = {}, onOpenPicker = {}) } }
     onNodeWithText("Performance — coming soon", substring = true).assertIsDisplayed()
   }
+
+  @Test
+  fun `green status shows no inline detail line`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(
+          state = WorkspaceUiState.Empty,
+          onAction = {},
+          onOpenPicker = {},
+          status = WorkspaceStatus.Green,
+          statusDetail = "Daemon reconnecting",
+        )
+      }
+    }
+    // "Expands only when not green": the detail line stays hidden even if a detail is supplied.
+    onNodeWithContentDescription("Status detail: Daemon reconnecting").assertDoesNotExist()
+  }
+
+  @Test
+  fun `non-green status shows the inline detail line`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(
+          state = WorkspaceUiState.Empty,
+          onAction = {},
+          onOpenPicker = {},
+          status = WorkspaceStatus.Yellow,
+          statusDetail = "Daemon reconnecting",
+        )
+      }
+    }
+    onNodeWithContentDescription("Status detail: Daemon reconnecting").assertIsDisplayed()
+  }
+
+  @Test
+  fun `clicking the status dot opens the health sheet`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(
+          state = WorkspaceUiState.Empty,
+          onAction = {},
+          onOpenPicker = {},
+          status = WorkspaceStatus.Green,
+          healthSheetContent = { Text("fake-health-body") },
+        )
+      }
+    }
+    onNodeWithText("fake-health-body").assertDoesNotExist()
+    onNodeWithContentDescription("Status: Green").performClick()
+    onNodeWithContentDescription("Health sheet").assertIsDisplayed()
+    onNodeWithText("fake-health-body").assertIsDisplayed()
+  }
+
+  @Test
+  fun `closing the health sheet dismisses it`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(
+          state = WorkspaceUiState.Empty,
+          onAction = {},
+          onOpenPicker = {},
+          status = WorkspaceStatus.Red,
+          statusDetail = "Device offline",
+          healthSheetContent = { Text("fake-health-body") },
+        )
+      }
+    }
+    onNodeWithContentDescription("Status: Red").performClick()
+    onNodeWithText("fake-health-body").assertIsDisplayed()
+    onNodeWithContentDescription("Close health sheet").performClick()
+    onNodeWithText("fake-health-body").assertDoesNotExist()
+  }
+
+  @Test
+  fun `clicking the inline detail line also opens the health sheet`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(
+          state = WorkspaceUiState.Empty,
+          onAction = {},
+          onOpenPicker = {},
+          status = WorkspaceStatus.Yellow,
+          statusDetail = "Daemon reconnecting",
+          healthSheetContent = { Text("fake-health-body") },
+        )
+      }
+    }
+    onNodeWithContentDescription("Status detail: Daemon reconnecting").performClick()
+    onNodeWithText("fake-health-body").assertIsDisplayed()
+  }
 }


### PR DESCRIPTION
Closes [#4843](https://github.com/kaeawc/auto-mobile/issues/4843). Wireframe frames 09 + 14 / exploration `14-progressive-status`.

In the device-tab workspace the bottom status bar is gone — status is **one dot, top-right, that expands only when not green**. This lands the progressive drill-in:
- **Not-green status → one inline line** next to the dot (terse reason); green stays a bare dot.
- **Clicking the dot (or the line) → a health sheet** — a dimmed, click-away/✕-dismissable overlay hosting the existing `DiagnosticsDashboard` (system requirements, MCP daemon status, connection health, process list).

## Design
Mirrors the existing hoisted-slot pattern (`facetContent`): `WorkspaceShell` gains `statusDetail: String?` and a `healthSheetContent: @Composable () -> Unit` slot **defaulting to the live `DiagnosticsDashboard`** (fed by `McpProcessesPanel` detection), so production is wired with no host change while tests inject a fast fake — the real system-touching path never runs in unit tests.

## Acceptance criteria → tests (WorkspaceShellUiTest, +5)
- Green → no inline line → `green status shows no inline detail line`
- Non-green + detail → inline line shown → `non-green status shows the inline detail line`
- Click dot → sheet appears → `clicking the status dot opens the health sheet`
- ✕ dismisses → `closing the health sheet dismisses it`
- Click line → sheet opens → `clicking the inline detail line also opens the health sheet`

## Validation
- ktfmt + `:desktop-core:detektMain` + full `:desktop-core:test` (green, incl. the 5 new) + `:desktop-app:compileKotlin` — all green locally.

## Deferred
Deriving the real `WorkspaceStatus` + detail from live connection health (status stays injected here) — follow-up filed separately.