### PR TITLE
feat(desktop): derive workspace status from live connection health

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -42,6 +42,7 @@ import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerAct
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerEffect
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerViewModel
 import dev.jasonpearson.automobile.desktop.theme.AutoMobileTheme
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -67,6 +68,10 @@ private fun rememberDaemonConnectionState(client: AutoMobileClient): ConnectionS
         try {
           withContext(Dispatchers.IO) { client.getDaemonStatus() }
           ConnectionState.Connected()
+        } catch (cancellation: CancellationException) {
+          // Disposal cancels this effect; propagate it instead of logging a false daemon failure
+          // and flipping the dot to disconnected during teardown.
+          throw cancellation
         } catch (error: Exception) {
           // A failed status call means the daemon socket is unreachable; surface it as
           // disconnected so the status dot goes red. Logged so there is a trace behind the dot.

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -13,6 +13,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
+import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import dev.jasonpearson.automobile.desktop.core.mcp.DaemonMcpResourceClient
@@ -34,13 +36,48 @@ import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceFacetPlacehol
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceShell
 import dev.jasonpearson.automobile.desktop.core.workspace.WorkspaceViewModel
 import dev.jasonpearson.automobile.desktop.core.workspace.buildWorkspaceCommands
+import dev.jasonpearson.automobile.desktop.core.workspace.deriveWorkspaceStatus
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePicker
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerAction
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerEffect
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerViewModel
 import dev.jasonpearson.automobile.desktop.theme.AutoMobileTheme
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 
 private val LOG = LoggerFactory.getLogger("AutoMobileDesktopApp")
+
+// How often the top-bar status dot re-probes daemon connectivity. Matches the health sheet's
+// read-only refresh cadence (WorkspaceShell.HEALTH_SHEET_REFRESH_MS).
+private const val DAEMON_STATUS_POLL_MS = 5_000L
+
+/**
+ * Live daemon connectivity as a [ConnectionState], polled from [AutoMobileClient.getDaemonStatus].
+ * A successful status call means the daemon socket is reachable ([ConnectionState.Connected]); a
+ * throw means it is not ([ConnectionState.Disconnected]). Starts as [ConnectionState.Connecting]
+ * until the first probe resolves.
+ */
+@Composable
+private fun rememberDaemonConnectionState(client: AutoMobileClient): ConnectionState {
+  var state by remember(client) { mutableStateOf<ConnectionState>(ConnectionState.Connecting) }
+  LaunchedEffect(client) {
+    while (true) {
+      state =
+        try {
+          withContext(Dispatchers.IO) { client.getDaemonStatus() }
+          ConnectionState.Connected()
+        } catch (error: Exception) {
+          // A failed status call means the daemon socket is unreachable; surface it as
+          // disconnected so the status dot goes red. Logged so there is a trace behind the dot.
+          LOG.warn("Daemon status poll failed: ${error.message}", error)
+          ConnectionState.Disconnected(error.message)
+        }
+      delay(DAEMON_STATUS_POLL_MS)
+    }
+  }
+  return state
+}
 
 /**
  * Wraps a [SettingsProvider] so that [themeMode] is backed by Compose snapshot state, enabling
@@ -127,11 +164,23 @@ fun AutoMobileDesktopApp(
           )
         else ->
           Box(Modifier.fillMaxSize()) {
+            // Roll live connection health up into the top-bar status dot. The daemon signal is
+            // polled here; per-device stream health is not yet fed in — device streams are
+            // facet-owned and carry screenshots, so opening extra status-only streams would be
+            // wasteful. deriveWorkspaceStatus already handles the device dimension, so it can be
+            // fed once a central per-device stream registry exists (follow-up).
+            val daemonState = rememberDaemonConnectionState(graph.autoMobileClient)
+            val workspaceStatus =
+              remember(daemonState) {
+                deriveWorkspaceStatus(daemon = daemonState, devices = emptyList())
+              }
             WorkspaceShell(
               state = workspaceState,
               onAction = workspaceViewModel::onAction,
               onOpenPicker = workspaceViewModel::openPicker,
               onOpenPalette = { paletteOpen = true },
+              status = workspaceStatus.status,
+              statusDetail = workspaceStatus.detail,
               facetContent = { column, tool -> WorkspaceFacet(column, tool) },
             )
             if (paletteOpen) {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceStatusDerivation.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceStatusDerivation.kt
@@ -45,8 +45,9 @@ fun deriveWorkspaceStatus(
  */
 private fun deriveFromDevices(devices: List<ConnectionState>): WorkspaceStatusResult {
   val offline = devices.count { it is ConnectionState.Disconnected || it is ConnectionState.Error }
-  val reconnecting =
-    devices.count { it is ConnectionState.Connecting || it is ConnectionState.Reconnecting }
+  val reconnecting = devices.count {
+    it is ConnectionState.Connecting || it is ConnectionState.Reconnecting
+  }
   return when {
     offline > 0 -> WorkspaceStatusResult(WorkspaceStatus.Yellow, devicePhrase(offline, "offline"))
     reconnecting > 0 ->

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceStatusDerivation.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceStatusDerivation.kt
@@ -1,0 +1,60 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
+
+/**
+ * Outcome of rolling up connection health into the top-bar status dot: the [WorkspaceStatus] color
+ * and a terse [detail] line shown inline for a non-green status ("yellow = one line"). [detail] is
+ * null for [WorkspaceStatus.Green], which renders a bare dot.
+ */
+data class WorkspaceStatusResult(
+  val status: WorkspaceStatus,
+  val detail: String?,
+)
+
+/**
+ * Pure roll-up of live connection health into the workspace status dot. Data in, data out — no
+ * Compose, no I/O — so the whole mapping is unit-testable with plain values.
+ *
+ * Priority: the daemon dominates. If the MCP daemon connection is down or errored the workspace is
+ * [WorkspaceStatus.Red] regardless of device health, because without the daemon nothing else can be
+ * trusted. A daemon that is mid-(re)connect is [WorkspaceStatus.Yellow]. Only once the daemon is
+ * [ConnectionState.Connected] do per-device streams decide the color: any offline or (re)connecting
+ * device stream is [WorkspaceStatus.Yellow]; all-connected is [WorkspaceStatus.Green].
+ */
+fun deriveWorkspaceStatus(
+  daemon: ConnectionState,
+  devices: List<ConnectionState>,
+): WorkspaceStatusResult =
+  when (daemon) {
+    is ConnectionState.Disconnected ->
+      WorkspaceStatusResult(WorkspaceStatus.Red, "Daemon disconnected")
+    is ConnectionState.Error -> WorkspaceStatusResult(WorkspaceStatus.Red, "Daemon error")
+    is ConnectionState.Connecting ->
+      WorkspaceStatusResult(WorkspaceStatus.Yellow, "Daemon connecting")
+    is ConnectionState.Reconnecting ->
+      WorkspaceStatusResult(WorkspaceStatus.Yellow, "Daemon reconnecting")
+    // Daemon is up: device streams decide the color.
+    is ConnectionState.Connected -> deriveFromDevices(devices)
+  }
+
+/**
+ * Roll up per-device stream health once the daemon is connected. Offline (disconnected/errored)
+ * streams take wording priority over mid-(re)connect ones, since offline is the more actionable
+ * problem; either keeps the workspace [WorkspaceStatus.Yellow].
+ */
+private fun deriveFromDevices(devices: List<ConnectionState>): WorkspaceStatusResult {
+  val offline = devices.count { it is ConnectionState.Disconnected || it is ConnectionState.Error }
+  val reconnecting =
+    devices.count { it is ConnectionState.Connecting || it is ConnectionState.Reconnecting }
+  return when {
+    offline > 0 -> WorkspaceStatusResult(WorkspaceStatus.Yellow, devicePhrase(offline, "offline"))
+    reconnecting > 0 ->
+      WorkspaceStatusResult(WorkspaceStatus.Yellow, devicePhrase(reconnecting, "reconnecting"))
+    else -> WorkspaceStatusResult(WorkspaceStatus.Green, null)
+  }
+}
+
+/** Terse "N device(s) <adjective>" line with singular/plural agreement. */
+private fun devicePhrase(count: Int, adjective: String): String =
+  "$count device${if (count == 1) "" else "s"} $adjective"

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceStatusDerivationTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceStatusDerivationTest.kt
@@ -1,0 +1,145 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Pure roll-up of daemon + per-device connection health into the workspace status dot. No Compose,
+ * no I/O — plain values in, [WorkspaceStatusResult] out.
+ */
+class WorkspaceStatusDerivationTest {
+
+  private val connected = ConnectionState.Connected()
+
+  @Test
+  fun `daemon connected with no devices is green`() {
+    val result = deriveWorkspaceStatus(daemon = connected, devices = emptyList())
+    assertEquals(WorkspaceStatus.Green, result.status)
+    assertNull(result.detail)
+  }
+
+  @Test
+  fun `daemon connected and all devices connected is green`() {
+    val result =
+      deriveWorkspaceStatus(daemon = connected, devices = listOf(connected, connected, connected))
+    assertEquals(WorkspaceStatus.Green, result.status)
+    assertNull(result.detail)
+  }
+
+  @Test
+  fun `a connected-but-not-subscribed device still counts as healthy`() {
+    val result =
+      deriveWorkspaceStatus(
+        daemon = connected,
+        devices = listOf(ConnectionState.Connected(subscribed = false)),
+      )
+    assertEquals(WorkspaceStatus.Green, result.status)
+    assertNull(result.detail)
+  }
+
+  @Test
+  fun `daemon disconnected is red`() {
+    val result =
+      deriveWorkspaceStatus(daemon = ConnectionState.Disconnected(), devices = listOf(connected))
+    assertEquals(WorkspaceStatus.Red, result.status)
+    assertEquals("Daemon disconnected", result.detail)
+  }
+
+  @Test
+  fun `daemon error is red`() {
+    val result =
+      deriveWorkspaceStatus(daemon = ConnectionState.Error("boom"), devices = listOf(connected))
+    assertEquals(WorkspaceStatus.Red, result.status)
+    assertEquals("Daemon error", result.detail)
+  }
+
+  @Test
+  fun `daemon down overrides healthy devices`() {
+    val result =
+      deriveWorkspaceStatus(
+        daemon = ConnectionState.Disconnected(),
+        devices = listOf(connected, connected),
+      )
+    assertEquals(WorkspaceStatus.Red, result.status)
+  }
+
+  @Test
+  fun `daemon connecting is yellow`() {
+    val result = deriveWorkspaceStatus(daemon = ConnectionState.Connecting, devices = emptyList())
+    assertEquals(WorkspaceStatus.Yellow, result.status)
+    assertEquals("Daemon connecting", result.detail)
+  }
+
+  @Test
+  fun `daemon reconnecting is yellow`() {
+    val result =
+      deriveWorkspaceStatus(
+        daemon = ConnectionState.Reconnecting(attempt = 2, nextRetryMs = 1000),
+        devices = listOf(connected),
+      )
+    assertEquals(WorkspaceStatus.Yellow, result.status)
+    assertEquals("Daemon reconnecting", result.detail)
+  }
+
+  @Test
+  fun `one offline device is yellow with a singular detail`() {
+    val result =
+      deriveWorkspaceStatus(
+        daemon = connected,
+        devices = listOf(connected, ConnectionState.Disconnected()),
+      )
+    assertEquals(WorkspaceStatus.Yellow, result.status)
+    assertEquals("1 device offline", result.detail)
+  }
+
+  @Test
+  fun `two offline devices is yellow with a plural detail`() {
+    val result =
+      deriveWorkspaceStatus(
+        daemon = connected,
+        devices = listOf(ConnectionState.Disconnected(), ConnectionState.Error("x")),
+      )
+    assertEquals(WorkspaceStatus.Yellow, result.status)
+    assertEquals("2 devices offline", result.detail)
+  }
+
+  @Test
+  fun `a device error counts as offline`() {
+    val result =
+      deriveWorkspaceStatus(daemon = connected, devices = listOf(ConnectionState.Error("x")))
+    assertEquals(WorkspaceStatus.Yellow, result.status)
+    assertEquals("1 device offline", result.detail)
+  }
+
+  @Test
+  fun `one reconnecting device is yellow with a reconnecting detail`() {
+    val result =
+      deriveWorkspaceStatus(
+        daemon = connected,
+        devices = listOf(connected, ConnectionState.Reconnecting(attempt = 1, nextRetryMs = 500)),
+      )
+    assertEquals(WorkspaceStatus.Yellow, result.status)
+    assertEquals("1 device reconnecting", result.detail)
+  }
+
+  @Test
+  fun `a connecting device counts as reconnecting`() {
+    val result =
+      deriveWorkspaceStatus(daemon = connected, devices = listOf(ConnectionState.Connecting))
+    assertEquals(WorkspaceStatus.Yellow, result.status)
+    assertEquals("1 device reconnecting", result.detail)
+  }
+
+  @Test
+  fun `offline wins the wording over reconnecting when both are present`() {
+    val result =
+      deriveWorkspaceStatus(
+        daemon = connected,
+        devices = listOf(ConnectionState.Disconnected(), ConnectionState.Connecting),
+      )
+    assertEquals(WorkspaceStatus.Yellow, result.status)
+    assertEquals("1 device offline", result.detail)
+  }
+}


### PR DESCRIPTION
## What

Completes the progressive-status health sheet from [#4844](https://github.com/kaeawc/auto-mobile/pull/4844) by deriving the workspace `WorkspaceStatus` (+ terse detail line) from live connection health, replacing the hardcoded `WorkspaceStatus.Green` default injected into `WorkspaceShell`.

## How

- New pure, testable roll-up `deriveWorkspaceStatus(daemon: ConnectionState, devices: List<ConnectionState>): WorkspaceStatusResult` in `desktop-core` (`core/workspace/WorkspaceStatusDerivation.kt`). Data in, data out — no Compose, no I/O.
  - **Red** — daemon disconnected (`Daemon disconnected`) or errored (`Daemon error`).
  - **Yellow** — daemon mid-(re)connect (`Daemon connecting` / `Daemon reconnecting`), or (daemon up and) ≥1 device stream offline (`N device(s) offline`) or reconnecting (`N device(s) reconnecting`).
  - **Green** — daemon connected and all device streams connected; detail `null`.
  - The daemon dominates: a down/errored daemon is Red regardless of device health. `when(daemon)` is exhaustive over the sealed `ConnectionState`.
- Host wiring in `AutoMobileDesktopApp`: `rememberDaemonConnectionState` polls `getDaemonStatus()` every 5s (success → `Connected`, throw → `Disconnected`, `Connecting` until the first probe), and the derived `status`/`statusDetail` are passed into `WorkspaceShell`. `WorkspaceShell`'s params stay injected, so its existing tests are untouched.

## Testing

- 14 pure unit tests (`WorkspaceStatusDerivationTest`) covering all-green, empty devices, connected-but-not-subscribed, daemon down/errored/(re)connecting, one/two offline devices (singular/plural), device error as offline, one reconnecting/connecting device, offline-wins-wording, and daemon-overrides-devices. No Compose, no DB/network, <100ms.
- RED-first (confirmed unresolved-reference compile failure before implementing).

Validation (all green locally): `ktfmt`, `:desktop-core:detektMain :desktop-core:detektTest :desktop-app:detektMain`, full `:desktop-core:test`, `:desktop-app:compileKotlin`.

## Deferral

Per-device stream health is fully implemented and unit-tested in the pure roll-up but **not yet fed in production** — device streams are facet-owned and carry screenshots, so opening extra status-only streams solely for a status dot would be wasteful. The function already handles the device dimension, so it can be fed once a central per-device stream registry exists. Failing-diagnostic-check rollup (a third signal named in the issue) is likewise not wired.

Closes [#4845](https://github.com/kaeawc/auto-mobile/issues/4845)
