### PR TITLE
feat(desktop): global Cmd+K/Ctrl+K opens command palette

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -101,7 +101,8 @@ private class ObservableSettingsProvider(private val delegate: SettingsProvider)
 
 @Composable
 fun AutoMobileDesktopApp(
-  @Suppress("UNUSED_PARAMETER") menuBarActions: MenuBarActions = remember { MenuBarActions() }
+  @Suppress("UNUSED_PARAMETER") menuBarActions: MenuBarActions = remember { MenuBarActions() },
+  openPaletteRequest: Int = 0,
 ) {
   val graph = LocalAutoMobileGraph.current
   val settings = remember(graph) { ObservableSettingsProvider(graph.settingsProvider) }
@@ -116,6 +117,15 @@ fun AutoMobileDesktopApp(
   var pickerOpen by remember { mutableStateOf(false) }
   var paletteOpen by remember { mutableStateOf(false) }
   var showOnboarding by remember { mutableStateOf(!settings.hasSeenOnboarding) }
+
+  // Window-level ⌘K/Ctrl+K (Main.kt) bumps openPaletteRequest; open the palette in response, but
+  // only while the workspace is showing — onboarding and the device picker own the screen and have
+  // no palette. The `> 0` guard skips the initial composition (the counter starts at 0).
+  LaunchedEffect(openPaletteRequest) {
+    if (openPaletteRequest > 0 && !showOnboarding && !pickerOpen) {
+      paletteOpen = true
+    }
+  }
 
   // OpenPicker (from the empty state or the Devices launcher) shows the picker; observing selected
   // devices turns them into workspace columns.

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/Main.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/Main.kt
@@ -8,7 +8,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.KeyShortcut
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.MenuBar
@@ -19,6 +24,7 @@ import androidx.compose.ui.window.rememberWindowState
 import dev.jasonpearson.automobile.desktop.core.daemon.McpConnectionException
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
 import dev.jasonpearson.automobile.desktop.core.shell.MenuBarActions
+import dev.jasonpearson.automobile.desktop.core.workspace.isCommandPaletteShortcut
 import dev.jasonpearson.automobile.desktop.di.AutoMobileGraph
 import dev.zacsweers.metro.createGraphFactory
 import java.io.IOException
@@ -120,11 +126,28 @@ fun main() {
     // object, so the menu items below toggle real UI state.
     val menuBarActions = remember { MenuBarActions() }
 
+    // Global ⌘K/Ctrl+K opens the command palette. The window key handler only decides *whether* the
+    // shortcut fired (via the pure, tested isCommandPaletteShortcut) and bumps this counter; the
+    // workspace observes the bump and opens the palette (guarding onboarding/picker). A counter,
+    // not a Boolean, so repeat presses each register even while the palette is already open.
+    var openPaletteRequest by remember { mutableStateOf(0) }
+
     Window(
       onCloseRequest = { isWindowVisible = false },
       title = "AutoMobile",
       state = windowState,
       visible = isWindowVisible,
+      onPreviewKeyEvent = { event ->
+        if (
+          event.type == KeyEventType.KeyDown &&
+            isCommandPaletteShortcut(event.key, event.isMetaPressed, event.isCtrlPressed)
+        ) {
+          openPaletteRequest++
+          true
+        } else {
+          false
+        }
+      },
     ) {
       CompositionLocalProvider(LocalAutoMobileGraph provides graph) {
         MenuBar {
@@ -191,7 +214,10 @@ fun main() {
             Item("About AutoMobile", onClick = { /* TODO: show about dialog */ })
           }
         }
-        AutoMobileDesktopApp(menuBarActions = menuBarActions)
+        AutoMobileDesktopApp(
+          menuBarActions = menuBarActions,
+          openPaletteRequest = openPaletteRequest,
+        )
       }
     }
   }

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/Main.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/Main.kt
@@ -193,9 +193,13 @@ fun main() {
               shortcut = platformShortcut(Key.F, shift = true),
             )
             Item(
+              // ⌘K/Ctrl+K is handled by the window-level onPreviewKeyEvent below (opens the command
+              // palette). No shortcut here — a duplicate Key.K accelerator on this (currently
+              // inert)
+              // item would race the window handler. Re-wiring this menu item + restoring its
+              // shortcut is tracked in #4670.
               "Quick Jump",
               onClick = { menuBarActions.showQuickJump = true },
-              shortcut = platformShortcut(Key.K),
             )
             Separator()
             Item(

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPalette.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPalette.kt
@@ -43,6 +43,17 @@ import androidx.compose.ui.unit.dp
 /** A single command in the palette: a stable [id], a display [label], and its [run] action. */
 data class PaletteCommand(val id: String, val label: String, val run: () -> Unit)
 
+/**
+ * True when a key event should open the command palette: the "K" key together with the platform
+ * accelerator modifier — Meta (⌘) on macOS or Ctrl elsewhere. Accepting either modifier keeps this
+ * platform-agnostic (⌘K and Ctrl+K both match) without needing to know the host OS here. Any other
+ * key, or "K" with no accelerator, returns false so the event propagates normally.
+ *
+ * Pure over its inputs so the window-level key binding stays thin, testable glue.
+ */
+fun isCommandPaletteShortcut(key: Key, isMetaPressed: Boolean, isCtrlPressed: Boolean): Boolean =
+  key == Key.K && (isMetaPressed || isCtrlPressed)
+
 /** Commands matching [query] by case-insensitive substring; blank query returns all. Pure. */
 internal fun filterCommands(commands: List<PaletteCommand>, query: String): List<PaletteCommand> {
   val q = query.trim()

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPaletteTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/CommandPaletteTest.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.test.performTextInput
 import androidx.compose.ui.test.pressKey
 import androidx.compose.ui.test.runComposeUiTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -25,6 +26,16 @@ class CommandPaletteTest {
 
   private fun column(id: String, name: String, activeTool: Tool? = null) =
     DeviceColumn(deviceId = id, name = name, platform = Platform.Android, activeTool = activeTool)
+
+  @Test
+  fun `command-palette shortcut matches K with meta or ctrl only`() {
+    assertTrue(isCommandPaletteShortcut(Key.K, isMetaPressed = true, isCtrlPressed = false))
+    assertTrue(isCommandPaletteShortcut(Key.K, isMetaPressed = false, isCtrlPressed = true))
+    assertTrue(isCommandPaletteShortcut(Key.K, isMetaPressed = true, isCtrlPressed = true))
+    assertFalse(isCommandPaletteShortcut(Key.K, isMetaPressed = false, isCtrlPressed = false))
+    assertFalse(isCommandPaletteShortcut(Key.J, isMetaPressed = true, isCtrlPressed = false))
+    assertFalse(isCommandPaletteShortcut(Key.P, isMetaPressed = false, isCtrlPressed = true))
+  }
 
   @Test
   fun `filter matches label substring case-insensitively and blank returns all`() {


### PR DESCRIPTION
## Summary

Completes issue #4776 — the final part: a **global ⌘K / Ctrl+K binding** that opens the command palette from anywhere in the workspace. Parts 2 and 3 (in-palette arrow/Enter navigation and identical-device-label disambiguation) shipped in [#4839](https://github.com/kaeawc/auto-mobile/pull/4839).

A window-level `onPreviewKeyEvent` handler in `Main.kt` detects the shortcut and bumps an `openPaletteRequest` counter that `AutoMobileDesktopApp` observes, opening the palette — but only while the workspace is shown (not during onboarding or the device picker). The palette already handles Esc-to-close and arrow/Enter.

The shortcut **decision** is extracted into a pure, unit-tested function in desktop-core so the composition-root binding stays thin glue (consistent with the rest of the untested `Main.kt`):

```kotlin
fun isCommandPaletteShortcut(key: Key, isMetaPressed: Boolean, isCtrlPressed: Boolean): Boolean =
  key == Key.K && (isMetaPressed || isCtrlPressed)
```

Accepting Meta **or** Ctrl keeps it platform-agnostic without the root needing to know the host OS. The handler returns `true` only when it consumes the shortcut, so all other keys propagate normally.

Uses the `Window` key-handler path (not a MenuBar item) deliberately, to avoid entangling with the inert `MenuBarActions` re-wire tracked in #4670.

## Acceptance criteria → tests

- **⌘K opens the palette from anywhere in the workspace; Esc closes it.** — ⌘K wiring covered by the new pure-function unit test `command-palette shortcut matches K with meta or ctrl only` (⌘K true, Ctrl+K true, both true, plain K false, ⌘J false, Ctrl+P false); the window binding itself is composition-root glue (untested, consistent with `Main.kt`). Esc-close is already covered by `escape closes the palette` (#4839).
- Up/Down + Enter navigation — already shipped and tested in #4839.
- Identical-device-label disambiguation — already shipped and tested in #4839.

## Validation

`android/gradlew :desktop-core:detektMain :desktop-core:test :desktop-app:compileKotlin` — BUILD SUCCESSFUL. Full `:desktop-core:test` green; `CommandPaletteTest` now 13 tests. Touched `.kt` files formatted with the pinned ktfmt 0.64 fat JAR.

Closes #4776
