### PR TITLE
fix(ios): fail helper release on rejected notarization verdict

### DIFF
--- a/scripts/ios/build-screen-capture-helper-release.sh
+++ b/scripts/ios/build-screen-capture-helper-release.sh
@@ -69,10 +69,32 @@ codesign --verify --strict --verbose=2 "${helper_path}"
   ditto -c -k --keepParent "screen-capture-helper" "${archive_path}"
 )
 
-xcrun notarytool submit "${archive_path}" \
-  --key "${APPLE_NOTARY_KEY_PATH}" \
-  --key-id "${APPLE_NOTARY_KEY_ID}" \
-  --issuer "${APPLE_NOTARY_ISSUER_ID}" \
-  --wait
+# `notarytool submit --wait` exits 0 even when Apple's verdict is Invalid, so
+# parsing the JSON result is the only way to catch a rejection: the helper zip
+# is never stapled, so nothing downstream would notice an unnotarized binary.
+# Anything but Accepted fails the script, after dumping the notary log so the
+# per-file rejection reasons land in the output.
+submission_json="$(
+  xcrun notarytool submit "${archive_path}" \
+    --key "${APPLE_NOTARY_KEY_PATH}" \
+    --key-id "${APPLE_NOTARY_KEY_ID}" \
+    --issuer "${APPLE_NOTARY_ISSUER_ID}" \
+    --wait \
+    --output-format json
+)"
+echo "${submission_json}"
+submission_id="$(jq -r '.id // empty' <<<"${submission_json}")"
+status="$(jq -r '.status // empty' <<<"${submission_json}")"
+if [[ "${status}" != "Accepted" ]]; then
+  echo "Notarization verdict: ${status:-unknown} (submission ${submission_id:-unknown})" >&2
+  if [[ -n "${submission_id}" ]]; then
+    # Best-effort: the log service can lag right after the verdict.
+    xcrun notarytool log "${submission_id}" \
+      --key "${APPLE_NOTARY_KEY_PATH}" \
+      --key-id "${APPLE_NOTARY_KEY_ID}" \
+      --issuer "${APPLE_NOTARY_ISSUER_ID}" >&2 || true
+  fi
+  exit 1
+fi
 
 mv "${archive_path}" "${output_path}"

--- a/test/bats/build-screen-capture-helper-release.bats
+++ b/test/bats/build-screen-capture-helper-release.bats
@@ -29,8 +29,14 @@ archive_path="${!#}"
 mkdir -p "$(dirname "${archive_path}")"
 printf 'archive\n' > "${archive_path}"
 SCRIPT
+  # notarytool submit emits a JSON verdict; the status is controlled per-test
+  # via SCREEN_CAPTURE_HELPER_TEST_NOTARY_STATUS (default Accepted).
   cat > "${MOCK_BIN}/xcrun" <<'SCRIPT'
 #!/usr/bin/env bash
+if [[ "$1" == "notarytool" && "$2" == "submit" ]]; then
+  printf '{"id":"sub-123","status":"%s"}\n' \
+    "${SCREEN_CAPTURE_HELPER_TEST_NOTARY_STATUS:-Accepted}"
+fi
 exit 0
 SCRIPT
   chmod +x "${MOCK_BIN}/"{swift,lipo,codesign,ditto,xcrun}
@@ -49,4 +55,16 @@ SCRIPT
 
   [ "${status}" -eq 0 ]
   [ -f "${CALLER_DIR}/artifacts/screen-capture-helper.zip" ]
+}
+
+@test "fails and leaves no output when notarization is rejected" {
+  export SCREEN_CAPTURE_HELPER_TEST_NOTARY_STATUS="Invalid"
+
+  run bash -c 'cd "$1" && "$2" "$3"' _ \
+    "${CALLER_DIR}" "${SCRIPT}" "artifacts/screen-capture-helper.zip"
+
+  [ "${status}" -eq 1 ]
+  [[ "${output}" == *"Notarization verdict: Invalid (submission sub-123)"* ]]
+  # The rejected archive must not be promoted to the final output path.
+  [ ! -f "${CALLER_DIR}/artifacts/screen-capture-helper.zip" ]
 }


### PR DESCRIPTION
## Problem

`scripts/ios/build-screen-capture-helper-release.sh` calls `xcrun notarytool submit … --wait` and then proceeds unconditionally. `notarytool submit --wait` exits `0` even when Apple's verdict is **Invalid**, so a rejected notarization would go unnoticed: unlike the desktop DMG flow, the helper zip is never stapled, so nothing downstream catches an unnotarized binary.

## Fix

Apply the same pattern PR #4805 added to [`build-desktop-app-installers.yml`](.github/workflows/build-desktop-app-installers.yml):

- Capture the submission result with `--output-format json`.
- Parse `.status` (and `.id`) with `jq` — already a standard dependency across `scripts/`.
- On any non-`Accepted` verdict, print the verdict to stderr, dump `xcrun notarytool log <id>` (best-effort, `|| true`), and `exit 1` — before the `mv` that promotes the archive to the final output path.

The `jq '… // empty'` fallbacks mean a malformed/empty response also fails closed (empty status ≠ `Accepted`).

## Tests

- `test/bats/build-screen-capture-helper-release.bats`: the `xcrun` mock now emits a JSON verdict whose status is driven by `SCREEN_CAPTURE_HELPER_TEST_NOTARY_STATUS` (default `Accepted`), plus a new failure-path test asserting an `Invalid` verdict makes the script exit 1, log the verdict, and leave no output zip behind.

## Validation

- `shellcheck scripts/ios/build-screen-capture-helper-release.sh` — clean
- `bats test/bats/build-screen-capture-helper-release.bats` — both tests pass
