### PR TITLE
fix(release): repair broken quoting in Create release notes step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -277,19 +277,16 @@ jobs:
             NOTES="Release v${VERSION}"
           fi
 
-          # Add checksum to notes
-          NOTES="${NOTES}"$'\n\n'"## CtrlProxy APK"$'\n\n'\
-            '"**SHA256 Checksum:** \`${APK_CHECKSUM}\`"$'\n\n'\
-            '"Download the APK from the release assets below."
-          NOTES="${NOTES}"$'\n\n'"## CtrlProxy iOS IPA"$'\n\n'\
-            '"**SHA256 Checksum:** \`${IPA_CHECKSUM}\`"$'\n\n'\
-            '"Download the IPA from the release assets below."
-          NOTES="${NOTES}"$'\n\n'"## video-server jar"$'\n\n'\
-            '"**SHA256 Checksum:** \`${VIDEO_JAR_CHECKSUM}\`"$'\n\n'\
-            '"Download automobile-video.jar from the release assets below."
-          NOTES="${NOTES}"$'\n\n'"## macOS screen-capture-helper"$'\n\n'\
-            '"**SHA256 Checksum:** \`${SCREEN_CAPTURE_HELPER_CHECKSUM}\`"$'\n\n'\
-            '"Download screen-capture-helper-macos-universal.zip from the release assets below."
+          # Add checksum to notes. Each section is a single-line concatenation of
+          # adjacent quoted strings ("..."$'\n\n'"..."). Do NOT split these across
+          # backslash-continued lines: the continuation indentation inserts an
+          # unquoted space between tokens, which ends the NOTES= assignment early
+          # and makes bash try to run the remainder as a command (exit 127). The
+          # Desktop App line below is the canonical form to match.
+          NOTES="${NOTES}"$'\n\n'"## CtrlProxy APK"$'\n\n'"**SHA256 Checksum:** \`${APK_CHECKSUM}\`"$'\n\n'"Download the APK from the release assets below."
+          NOTES="${NOTES}"$'\n\n'"## CtrlProxy iOS IPA"$'\n\n'"**SHA256 Checksum:** \`${IPA_CHECKSUM}\`"$'\n\n'"Download the IPA from the release assets below."
+          NOTES="${NOTES}"$'\n\n'"## video-server jar"$'\n\n'"**SHA256 Checksum:** \`${VIDEO_JAR_CHECKSUM}\`"$'\n\n'"Download automobile-video.jar from the release assets below."
+          NOTES="${NOTES}"$'\n\n'"## macOS screen-capture-helper"$'\n\n'"**SHA256 Checksum:** \`${SCREEN_CAPTURE_HELPER_CHECKSUM}\`"$'\n\n'"Download screen-capture-helper-macos-universal.zip from the release assets below."
           NOTES="${NOTES}"$'\n\n'"## Desktop App"$'\n\n'"Native installers are attached below: macOS \`.dmg\` (signed & notarized), Windows \`.msi\`, and Linux \`.deb\`."
 
           # Save to file for GitHub release


### PR DESCRIPTION
## Problem

The Release run for tag `0.0.47` ([30555363484](https://github.com/kaeawc/auto-mobile/actions/runs/30555363484)) failed in `verify-and-release` at **step 19, Create release notes**, with exit 127:

```
line 19: $'"**SHA256 Checksum:** `${APK_CHECKSUM}`"$nn\n  Download the APK...': command not found
```

Prepare Release ([30554462191](https://github.com/kaeawc/auto-mobile/actions/runs/30554462191)) succeeded — this is purely the publish-side notes step.

**Root cause:** the APK/IPA/jar/helper checksum sections were written as backslash-continued multi-line assignments with a stray leading `'` on each continuation line:

```bash
NOTES="${NOTES}"$'\n\n'"## CtrlProxy APK"$'\n\n'\
  '"**SHA256 Checksum:** \`${APK_CHECKSUM}\`"$'\n\n'\
  '"Download the APK from the release assets below."
```

After the line-continuation, the continuation **indentation inserts an unquoted space** between tokens. That space ends the `NOTES=` assignment's value early, so bash treats the remainder of the line as a **command** and fails with "command not found". (The mangled `$nn` in the CI error is the tell: `\n` outside quotes collapses to a literal `n`.) The `## Desktop App` line right below was already written correctly as a single line — it was never part of the breakage.

## Fix

Rewrite each of the four sections as a single-line concatenation of adjacent quoted strings, matching the canonical Desktop App line. No behavior change to the intended notes content.

## Blast radius

Nothing was published in the failed run — **every step after Create release notes was skipped** (Build TS, npm publish, Homebrew, MCP Registry, Maven Central, Docker, Create GitHub Release all `skipped`). The only side effect was the `0.0.47` git tag, which is being deleted for a clean re-cut.

## Validation

- Reproduced the exit-127 failure locally with the old form; confirmed the new single-line form emits valid release-notes markdown (exit 0), with no leading-space headings.
- `scripts/all_fast_validate_checks.sh` — all 27 checks pass.
