### PR TITLE
fix(release): make Homebrew publish non-blocking (skip on missing token + wider fetch retry)

### DIFF
--- a/scripts/release/update-brew-formula.sh
+++ b/scripts/release/update-brew-formula.sh
@@ -27,18 +27,24 @@ TARBALL_URL="https://registry.npmjs.org/${PKG}/-/auto-mobile-${VERSION}.tgz"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
-# Pull the just-published tarball and compute its sha256. Retries cover
-# the brief window where the npm CDN hasn't propagated the new version
-# yet immediately after `npm publish`.
+# Pull the just-published tarball and compute its sha256. Retries cover the
+# window where the npm CDN hasn't propagated the new version yet immediately
+# after `npm publish`. The previous budget (10 x 6s ~= 1 min) was too tight:
+# npm publish returns before the tarball is fetchable at the registry URL, and
+# propagation has been observed to take several minutes, 404ing the whole
+# release (run 30568093771). Widen to ~5 min so a slow-but-normal publish does
+# not fail the release; genuine failures still surface, just later.
+max_attempts="${BREW_TARBALL_FETCH_ATTEMPTS:-30}"
+retry_delay="${BREW_TARBALL_FETCH_DELAY_SECONDS:-10}"
 attempt=1
 while ! curl -fsSL "$TARBALL_URL" -o "$tmp/auto-mobile.tgz"; do
-  if [[ "$attempt" -ge 10 ]]; then
+  if [[ "$attempt" -ge "$max_attempts" ]]; then
     echo "ERROR: failed to fetch ${TARBALL_URL} after ${attempt} attempts" >&2
     exit 1
   fi
-  echo "tarball not yet available, retrying in 6s (attempt ${attempt})" >&2
+  echo "tarball not yet available, retrying in ${retry_delay}s (attempt ${attempt}/${max_attempts})" >&2
   attempt=$((attempt + 1))
-  sleep 6
+  sleep "$retry_delay"
 done
 
 SHA="$(shasum -a 256 "$tmp/auto-mobile.tgz" | awk '{print $1}')"

--- a/scripts/release/update-brew-formula.sh
+++ b/scripts/release/update-brew-formula.sh
@@ -3,11 +3,13 @@
 # kaeawc/homebrew-tap repository.
 #
 # Required env:
-#   GH_TOKEN  PAT with Contents:Write on kaeawc/homebrew-tap
 #   TAG       Release tag (e.g. v0.1.0)
 #   REPO      Source repo, owner/name (e.g. kaeawc/auto-mobile)
 #
 # Optional env:
+#   GH_TOKEN       PAT with Contents:Write on kaeawc/homebrew-tap. When unset,
+#                  the publish is skipped cleanly (exit 0) so this optional
+#                  channel does not block the rest of the release.
 #   RENDER_ONLY=1  Write the rendered formula to ./auto-mobile.rb in the
 #                  current directory and exit without git operations. Used
 #                  by tests; in CI the unset default does the full publish.
@@ -19,6 +21,18 @@ set -euo pipefail
 
 : "${TAG:?TAG is required}"
 : "${REPO:?REPO is required}"
+
+# Homebrew publishing is an optional release channel. The tap token
+# (HOMEBREW_TAP_TOKEN -> GH_TOKEN) is not always configured, in which case there
+# is nowhere to push the formula. Skip cleanly rather than hard-failing, so a
+# missing optional channel does not block the rest of the release (Maven
+# Central, Docker, and the GitHub Release all run after this step). RENDER_ONLY
+# (tests) never pushes, so it does not need the token. When the token IS set,
+# any clone/push failure below still fails the step under `set -e`.
+if [[ "${RENDER_ONLY:-0}" != "1" && -z "${GH_TOKEN:-}" ]]; then
+  echo "GH_TOKEN (HOMEBREW_TAP_TOKEN) is not set; skipping Homebrew formula publish." >&2
+  exit 0
+fi
 
 VERSION="${TAG#v}"
 PKG="@kaeawc/auto-mobile"
@@ -83,8 +97,8 @@ if [[ "${RENDER_ONLY:-0}" == "1" ]]; then
   exit 0
 fi
 
-: "${GH_TOKEN:?GH_TOKEN is required}"
-
+# GH_TOKEN presence is enforced early (see the skip guard near the top); a
+# non-RENDER_ONLY run reaches here only when the token is set.
 WORKDIR="$(mktemp -d)"
 trap 'rm -rf "$tmp" "$WORKDIR"' EXIT
 cd "$WORKDIR"

--- a/test/bats/update-brew-formula.bats
+++ b/test/bats/update-brew-formula.bats
@@ -31,6 +31,16 @@ teardown() {
   [[ "$output" == *"REPO"* ]]
 }
 
+@test "skips cleanly when GH_TOKEN is unset (optional channel)" {
+  cd "$TEST_ROOT"
+  # No GH_TOKEN and not RENDER_ONLY: the publish is skipped before any network
+  # or git work, so a missing tap token does not fail the release.
+  run env -u GH_TOKEN -u RENDER_ONLY TAG=v0.0.26 REPO=kaeawc/auto-mobile \
+    bash scripts/release/update-brew-formula.sh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"skipping Homebrew formula publish"* ]]
+}
+
 @test "RENDER_ONLY writes a formula with the resolved sha256" {
   cd "$TEST_ROOT"
   run env TAG=v0.0.26 REPO=kaeawc/auto-mobile RENDER_ONLY=1 \


### PR DESCRIPTION
Hardens the `Publish Homebrew formula` step (`scripts/release/update-brew-formula.sh`), which blocked the 0.0.47 release ([run 30568093771](https://github.com/kaeawc/auto-mobile/actions/runs/30568093771)) in two successive ways.

## 1. Skip cleanly when the tap token is unset (the actual blocker)

On the re-run, the tarball fetch succeeded but the step then failed at:

```
scripts/release/update-brew-formula.sh: line 80: GH_TOKEN: GH_TOKEN is required
```

`HOMEBREW_TAP_TOKEN` is **not configured** in the repo, so `GH_TOKEN` is empty and the `${GH_TOKEN:?}` guard aborted the step — which skips every publish after it (MCP Registry, Maven Central, Docker, **GitHub Release**). Homebrew publishing has in fact never worked here: `kaeawc/homebrew-tap` has no `auto-mobile` formula, and the 0.0.46 Release run failed earlier (at an APK checksum step) without ever reaching Homebrew.

Homebrew is now an **optional channel**: when `GH_TOKEN` is unset, the script skips cleanly (exit 0, before any network/git work) so a missing tap token no longer blocks the release. When the token **is** set, any clone/push failure still fails the step under `set -e`. Adds a BATS case for the skip path; `GH_TOKEN` moves from Required to Optional in the header.

Wiring up the tap later is just: create a PAT with `Contents:Write` on `kaeawc/homebrew-tap`, set it as the `HOMEBREW_TAP_TOKEN` repo secret — the step then publishes with no further code change.

## 2. Wider npm-tarball fetch retry budget

The first failure of the same step was a 404 fetching the just-published tarball for its sha256: `npm publish` returns before the registry URL is fetchable, and propagation exceeded the ~1 min budget (10 × 6s). Widened to ~5 min (30 × 10s), overridable via `BREW_TARBALL_FETCH_ATTEMPTS` / `BREW_TARBALL_FETCH_DELAY_SECONDS`.

## Validation

- `shellcheck` clean.
- `test/bats/update-brew-formula.bats` — 4/4 pass (added the skip-when-unset case).
- Behavioral checks: no token + not RENDER_ONLY → skip exit 0; token set + missing tarball → fails as before.

## Note on 0.0.47

npm `0.0.47` is already published. Once this merges and the tag is re-cut from updated `main`, the Release run will skip Homebrew and proceed to Maven Central, Docker, and the GitHub Release.
