### PR TITLE
fix(release): validate brew-fetch retry overrides are base-10 integers

### DIFF
--- a/scripts/release/update-brew-formula.sh
+++ b/scripts/release/update-brew-formula.sh
@@ -50,6 +50,19 @@ trap 'rm -rf "$tmp"' EXIT
 # not fail the release; genuine failures still surface, just later.
 max_attempts="${BREW_TARBALL_FETCH_ATTEMPTS:-30}"
 retry_delay="${BREW_TARBALL_FETCH_DELAY_SECONDS:-10}"
+# Reject non-base-10 / zero-padded overrides up front. A value like "08" is an
+# invalid octal in bash arithmetic, so the `-ge` comparison below errors; because
+# that comparison is the `while` loop's condition, `set -e` does not fire and the
+# error is swallowed, turning the attempt cap into an infinite loop. Validate
+# here as scripts/ci/run-gradle-with-retry.sh does.
+if ! [[ "$max_attempts" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Invalid BREW_TARBALL_FETCH_ATTEMPTS='${max_attempts}' (want a positive base-10 integer)" >&2
+  exit 1
+fi
+if ! [[ "$retry_delay" =~ ^[0-9]+$ ]]; then
+  echo "Invalid BREW_TARBALL_FETCH_DELAY_SECONDS='${retry_delay}' (want a non-negative base-10 integer)" >&2
+  exit 1
+fi
 attempt=1
 while ! curl -fsSL "$TARBALL_URL" -o "$tmp/auto-mobile.tgz"; do
   if [[ "$attempt" -ge "$max_attempts" ]]; then

--- a/test/bats/update-brew-formula.bats
+++ b/test/bats/update-brew-formula.bats
@@ -41,6 +41,37 @@ teardown() {
   [[ "$output" == *"skipping Homebrew formula publish"* ]]
 }
 
+@test "rejects a zero-padded BREW_TARBALL_FETCH_ATTEMPTS override" {
+  cd "$TEST_ROOT"
+  # "08" is invalid octal in bash arithmetic; without up-front validation the
+  # retry loop would spin forever. Must fail fast, before any fetch.
+  run env TAG=v0.0.26 REPO=kaeawc/auto-mobile GH_TOKEN=x \
+    BREW_TARBALL_FETCH_ATTEMPTS=08 \
+    bash scripts/release/update-brew-formula.sh
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"BREW_TARBALL_FETCH_ATTEMPTS"* ]]
+}
+
+@test "rejects a non-numeric BREW_TARBALL_FETCH_DELAY_SECONDS override" {
+  cd "$TEST_ROOT"
+  run env TAG=v0.0.26 REPO=kaeawc/auto-mobile GH_TOKEN=x \
+    BREW_TARBALL_FETCH_DELAY_SECONDS=abc \
+    bash scripts/release/update-brew-formula.sh
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"BREW_TARBALL_FETCH_DELAY_SECONDS"* ]]
+}
+
+@test "exhausts the retry cap for a missing tarball and fails" {
+  cd "$TEST_ROOT"
+  # A version that will never resolve on the registry: the loop should try the
+  # configured number of attempts, then exit non-zero with the count.
+  run env TAG=v0.0.0-does-not-exist REPO=kaeawc/auto-mobile GH_TOKEN=x \
+    BREW_TARBALL_FETCH_ATTEMPTS=2 BREW_TARBALL_FETCH_DELAY_SECONDS=0 \
+    bash scripts/release/update-brew-formula.sh
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"after 2 attempts"* ]]
+}
+
 @test "RENDER_ONLY writes a formula with the resolved sha256" {
   cd "$TEST_ROOT"
   run env TAG=v0.0.26 REPO=kaeawc/auto-mobile RENDER_ONLY=1 \


### PR DESCRIPTION
Follow-up to the `BREW_TARBALL_FETCH_ATTEMPTS` / `BREW_TARBALL_FETCH_DELAY_SECONDS` overrides added in #4862 (flagged by a codex review).

## Problem

A zero-padded override like `BREW_TARBALL_FETCH_ATTEMPTS=08` is an **invalid octal** in bash arithmetic, so the cap check `[[ "$attempt" -ge "$max_attempts" ]]` errors. Because that comparison is the retry loop's `while` condition, `set -e` does **not** fire (a failing condition is not an error under `set -e`) and the error is swallowed — the cap never trips, so the loop spins until the job is externally killed instead of exhausting the intended attempts.

## Fix

Validate both overrides up front — positive base-10 integer for attempts, non-negative for delay — mirroring `is_positive_integer` in `scripts/ci/run-gradle-with-retry.sh`. A malformed value now fails fast with a clear message instead of hanging.

## Tests

`test/bats/update-brew-formula.bats` (now 7): added a zero-padded attempts override (rejected), a non-numeric delay override (rejected), and valid cap exhaustion (fails after N attempts).

## Priority

Low — the defaults (`30`/`10`) are valid and the release path never sets these, so this does **not** block the 0.0.47 release. Pure hardening against a malformed operator override.
