### PR TITLE
ci(release): make ancillary publish channels non-blocking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,7 +325,14 @@ jobs:
           REPO: ${{ github.repository }}
         run: bash scripts/release/update-brew-formula.sh
 
+      # MCP Registry, Maven Central, and the Docker image are best-effort
+      # distribution channels: a failure in any of them must not block the
+      # canonical GitHub Release (and its artifacts) that runs after them.
+      # continue-on-error neutralizes their failures so `success()` stays true
+      # for the GitHub Release step, while the failed step still shows red in the
+      # UI so the drift is visible and fixable.
       - name: Install mcp-publisher
+        continue-on-error: true
         run: |
           URL="https://github.com/modelcontextprotocol/registry"
           URL="$URL/releases/latest/download"
@@ -333,6 +340,7 @@ jobs:
           curl -L "$URL" | tar xz mcp-publisher
 
       - name: Publish to MCP Registry
+        continue-on-error: true
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
@@ -348,6 +356,7 @@ jobs:
           ./mcp-publisher publish
 
       - name: Set up Java
+        continue-on-error: true
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
@@ -355,18 +364,22 @@ jobs:
           cache: 'gradle'
 
       - name: Setup Android SDK
+        continue-on-error: true
         uses: android-actions/setup-android@v3
 
       - name: Make gradlew executable
+        continue-on-error: true
         run: chmod +x android/gradlew
 
       - name: Setup Release Keystore
+        continue-on-error: true
         run: |
           mkdir -p android/keystore
           echo "${{ secrets.RELEASE_KEYSTORE_BASE64 }}" | \
             base64 -d > android/keystore/release.keystore
 
       - name: Publish Android Libraries to Maven Central
+        continue-on-error: true
         env:
           VERSION: ${{ steps.version.outputs.version }}
           ORG_GRADLE_PROJECT_mavenCentralUsername:
@@ -407,6 +420,7 @@ jobs:
             --no-configuration-cache
 
       - name: Free Disk Space
+        continue-on-error: true
         uses: endersonmenezes/free-disk-space@v3
         with:
           remove_android: true      # ~14 GB
@@ -418,21 +432,26 @@ jobs:
           use_rmz: true            # 3x faster deletion
 
       - name: Clean up Docker
+        continue-on-error: true
         run: docker system prune -af --volumes
 
       - name: Set up QEMU
+        continue-on-error: true
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
+        continue-on-error: true
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
+        continue-on-error: true
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract Docker metadata
+        continue-on-error: true
         id: docker_meta
         uses: docker/metadata-action@v5
         with:
@@ -444,6 +463,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
+        continue-on-error: true
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
## Problem

`verify-and-release` publishes to several channels **sequentially** and ends with **Create GitHub Release** — so any earlier channel failure skips the GitHub Release and all its artifacts. The workflow has never completed end-to-end:

- Homebrew was fixed to skip when unconfigured (#4862).
- `0.0.47` then reached **MCP Registry** ([run 30580772627](https://github.com/kaeawc/auto-mobile/actions/runs/30580772627)) and failed on a DNS-key/secret drift (`signature verification failed`), which skipped **Maven Central, Docker, and the GitHub Release**.

npm `0.0.47` is already published; the remaining deliverable is the GitHub Release with the built artifacts.

## Change

Mark the ancillary / never-validated channels `continue-on-error: true` so their failures no longer fail the run — `success()` stays true and **Create GitHub Release still runs**. Failed channels remain visibly red for follow-up.

Non-blocking now:
- Install mcp-publisher + Publish to MCP Registry
- Set up Java / Android SDK / gradlew / keystore (Maven prep) + Publish Android Libraries to Maven Central
- Free Disk Space / Clean up Docker / QEMU / Buildx / Docker Hub login / metadata / Build and push

Still hard-blocking: setup, Build TypeScript, **Publish to npm**, and **Create GitHub Release** (it *is* the release).

## Maintainer decisions (this release)

- Homebrew, MCP (DNS drift), Maven Central, and Docker are treated as best-effort until each is verified.
- MCP DNS fix for later: update the `jasonpearson.dev` TXT record to `p=X2S3+LrvAQ2kzxhJBIUPJMIXxLywc+ZbFt+OvOwPBoQ=` (matching `MCP_DNS_PRIVATE_KEY`), or rotate the secret to match the published key.

## Validation

- `release.yml` parses; 14 `continue-on-error` markers on the intended steps; GitHub Release unchanged (default `if: success()`).
- `scripts/all_fast_validate_checks.sh` — all checks pass.
