### PR TITLE
feat(desktop): wire LayoutFacet into pane Inspect mode

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -73,6 +73,10 @@ fun WorkspaceShell(
   facetContent: @Composable (DeviceColumn, Tool) -> Unit = { _, tool ->
     WorkspaceFacetPlaceholder(tool)
   },
+  // Pane content shown while a column is in Inspect mode: the per-device Layout inspector (view
+  // hierarchy + device mirror) replaces the stream. Hoisted like [facetContent] so a test can drive
+  // it with a fake; the default is the real [LayoutFacet], so the host needs no extra wiring.
+  inspectContent: @Composable (DeviceColumn) -> Unit = { LayoutFacet(it) },
   // Body of the health sheet opened by clicking the status dot. Hoisted like [facetContent] so the
   // host (or a test) can substitute content; defaults to the live [DiagnosticsDashboard].
   healthSheetContent: @Composable () -> Unit = { DefaultHealthSheetBody() },
@@ -102,6 +106,7 @@ fun WorkspaceShell(
                   focused = column.deviceId == state.focusedDeviceId,
                   onAction = onAction,
                   facetContent = facetContent,
+                  inspectContent = inspectContent,
                   canDiff = canDiff,
                   modifier = Modifier.weight(1f).fillMaxHeight(),
                 )
@@ -313,6 +318,7 @@ private fun DeviceColumnView(
   focused: Boolean,
   onAction: (WorkspaceAction) -> Unit,
   facetContent: @Composable (DeviceColumn, Tool) -> Unit,
+  inspectContent: @Composable (DeviceColumn) -> Unit,
   canDiff: Boolean,
   modifier: Modifier,
 ) {
@@ -326,14 +332,33 @@ private fun DeviceColumnView(
     DeviceColumnHeader(column, onAction)
     val tool = column.activeTool
     if (tool == null) {
-      StreamArea(column, onAction, Modifier.weight(1f))
+      PaneMainContent(column, onAction, inspectContent, Modifier.weight(1f))
     } else {
-      // With a tool active the pane splits stream + docked facet; ⤡ shrink flips the split so the
-      // stream collapses to grow the facet.
+      // With a tool active the pane splits main content + docked facet; ⤡ shrink flips the split so
+      // the main content collapses to grow the facet.
       val facetFraction = facetHeightFraction(column.shrunk)
-      StreamArea(column, onAction, Modifier.weight(1f - facetFraction))
+      PaneMainContent(column, onAction, inspectContent, Modifier.weight(1f - facetFraction))
       DockedFacet(column, tool, onAction, facetContent, canDiff, Modifier.weight(facetFraction))
     }
+  }
+}
+
+/**
+ * The pane's primary content above any docked facet. In [InteractionMode.Input] this is the device
+ * [StreamArea]; in [InteractionMode.Inspect] the stream is replaced by [inspectContent] (the
+ * per-device Layout inspector), so the wireframe's 🔍 toggle gains behavior without adding a Tool.
+ */
+@Composable
+private fun PaneMainContent(
+  column: DeviceColumn,
+  onAction: (WorkspaceAction) -> Unit,
+  inspectContent: @Composable (DeviceColumn) -> Unit,
+  modifier: Modifier,
+) {
+  if (column.mode == InteractionMode.Inspect) {
+    Box(modifier.fillMaxWidth()) { inspectContent(column) }
+  } else {
+    StreamArea(column, onAction, modifier)
   }
 }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
@@ -2,6 +2,7 @@ package dev.jasonpearson.automobile.desktop.core.workspace
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -280,6 +281,72 @@ class WorkspaceShellUiTest {
       )
     setContent { MaterialTheme { WorkspaceShell(state = state, onAction = {}, onOpenPicker = {}) } }
     onNodeWithText("Performance — coming soon", substring = true).assertIsDisplayed()
+  }
+
+  @Test
+  fun `Inspect mode renders the injected inspect content in place of the stream`() =
+    runComposeUiTest {
+      val state =
+        WorkspaceUiState.Content(
+          columns = listOf(col("a", "Pixel 8").copy(mode = InteractionMode.Inspect)),
+          focusedDeviceId = "a",
+        )
+      setContent {
+        MaterialTheme {
+          WorkspaceShell(
+            state = state,
+            onAction = {},
+            onOpenPicker = {},
+            inspectContent = { column -> Text("inspect-slot:${column.deviceId}") },
+          )
+        }
+      }
+      onNodeWithText("inspect-slot:a").assertIsDisplayed()
+      // The device stream is replaced by the inspector while in Inspect mode.
+      onNodeWithText("stream").assertDoesNotExist()
+    }
+
+  @Test
+  fun `Input mode renders the stream and not the inspect content`() = runComposeUiTest {
+    val state =
+      WorkspaceUiState.Content(columns = listOf(col("a", "Pixel 8")), focusedDeviceId = "a")
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(
+          state = state,
+          onAction = {},
+          onOpenPicker = {},
+          inspectContent = { Text("inspect-slot") },
+        )
+      }
+    }
+    onNodeWithText("stream").assertIsDisplayed()
+    onNodeWithText("inspect-slot").assertDoesNotExist()
+  }
+
+  @Test
+  fun `toggling Inspect back to Input swaps the stream back in`() = runComposeUiTest {
+    val mode = mutableStateOf(InteractionMode.Inspect)
+    setContent {
+      MaterialTheme {
+        val state =
+          WorkspaceUiState.Content(
+            columns = listOf(col("a", "Pixel 8").copy(mode = mode.value)),
+            focusedDeviceId = "a",
+          )
+        WorkspaceShell(
+          state = state,
+          onAction = {},
+          onOpenPicker = {},
+          inspectContent = { Text("inspect-slot") },
+        )
+      }
+    }
+    onNodeWithText("inspect-slot").assertIsDisplayed()
+    onNodeWithText("stream").assertDoesNotExist()
+    runOnIdle { mode.value = InteractionMode.Input }
+    onNodeWithText("inspect-slot").assertDoesNotExist()
+    onNodeWithText("stream").assertIsDisplayed()
   }
 
   @Test


### PR DESCRIPTION
## Summary

Gives the desktop workspace pane's 🔍 **Inspect** toggle real behavior (issue [#4836](https://github.com/kaeawc/auto-mobile/issues/4836), **Option A** — the wireframe-aligned approach, no 8th `Tool`).

- When a column's `mode == InteractionMode.Inspect`, the device stream area is replaced by the per-device `LayoutFacet` (view hierarchy + device mirror, merged in [#4827](https://github.com/kaeawc/auto-mobile/pull/4827)).
- When `mode == InteractionMode.Input`, the pane keeps the normal stream/content.
- The 7-tool set (🧭 📄 💾 🌐 🧪 💥 ⚡) is untouched — layout inspection lives in Inspect mode, not a Tool.

The Inspect body is a hoisted `inspectContent: @Composable (DeviceColumn) -> Unit = { LayoutFacet(it) }` slot on `WorkspaceShell`, mirroring the existing `facetContent` hoist. The default is the real `LayoutFacet`, so the host (`AutoMobileDesktopApp`) needs no wiring change; `WorkspaceShellUiTest` injects a fake so the branch is verified without a live daemon. Per-device lifecycle is preserved: panes are already keyed by `deviceId`, and `LayoutFacet` connects/disposes its own stream per device.

A docked tool facet still coexists with Inspect mode — the inspector replaces only the main (stream) content, the same split the stream had.

## Acceptance criteria → tests

Added to `WorkspaceShellUiTest`:
- `Inspect mode renders the injected inspect content in place of the stream` — asserts the injected fake node shows and `stream` does not.
- `Input mode renders the stream and not the inspect content` — asserts the stream shows and the inspect slot does not.
- `toggling Inspect back to Input swaps the stream back in` — flips `mode` and asserts the swap both ways.

`:desktop-core:test` (full) green — `WorkspaceShellUiTest` at 28 tests.

## Validation

- `ktfmt` (CI fat JAR v0.64) — clean, no churn
- `:desktop-core:detektMain :desktop-core:test :desktop-app:compileKotlin` — BUILD SUCCESSFUL

Closes #4836
