### PR TITLE
fix(webrtc): keep PersistentEncoderH264Source constructor under complexity ratchet

### DIFF
--- a/src/features/webrtc/PersistentEncoderH264Source.ts
+++ b/src/features/webrtc/PersistentEncoderH264Source.ts
@@ -270,17 +270,26 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     this.readyTimeoutMs = options.readyTimeoutMs ?? DEFAULT_READY_TIMEOUT_MS;
     this.commandTimeoutMs = options.commandTimeoutMs ?? DEFAULT_LAUNCH_COMMAND_TIMEOUT_MS;
     this.teardownTimeoutMs = options.teardownTimeoutMs ?? DEFAULT_TEARDOWN_COMMAND_TIMEOUT_MS;
-    if (this.commandTimeoutMs <= 0 || this.teardownTimeoutMs <= 0) {
-      throw new ActionableError("Video server command timeouts must be positive milliseconds.");
-    }
     this.localSocketReconnectWindowMs =
       options.localSocketReconnectWindowMs ?? DEFAULT_LOCAL_SOCKET_RECONNECT_WINDOW_MS;
     this.localSocketReconnectRetryMs =
       options.localSocketReconnectRetryMs ?? DEFAULT_LOCAL_SOCKET_RECONNECT_RETRY_MS;
+    this.sessionTokenFactory = options.sessionTokenFactory ?? (() => defaultIdGenerator.next());
+    this.validateTimings();
+  }
+
+  /**
+   * Fail fast on non-positive timing options. Extracted from the constructor so the constructor
+   * stays under the cyclomatic-complexity ratchet; every branch here is a validation guard, not
+   * constructor control flow.
+   */
+  private validateTimings(): void {
+    if (this.commandTimeoutMs <= 0 || this.teardownTimeoutMs <= 0) {
+      throw new ActionableError("Video server command timeouts must be positive milliseconds.");
+    }
     if (this.localSocketReconnectWindowMs <= 0 || this.localSocketReconnectRetryMs <= 0) {
       throw new ActionableError("Local socket reconnect timings must be positive milliseconds.");
     }
-    this.sessionTokenFactory = options.sessionTokenFactory ?? (() => defaultIdGenerator.next());
   }
 
   get isRunning(): boolean {


### PR DESCRIPTION
## Problem

`main` is red on the required **Node TypeScript Build and Test** check. The
lifecycle-bounding changes in [#4826](https://github.com/kaeawc/auto-mobile/pull/4826)
pushed the `PersistentEncoderH264Source` constructor to a cyclomatic complexity
of **14**, over the repo's `complexity` ratchet of **12**:

```
src/features/webrtc/PersistentEncoderH264Source.ts
  265:3  error  Constructor has a complexity of 14. Maximum allowed is 12  complexity
```

This blocks the required lint gate on every open PR.

## Fix

Extract the two timing-validation guards into a private `validateTimings()`
helper called at the end of the constructor. Behavior is unchanged — same
throws, same messages, and validation still runs after all fields are assigned.
The constructor drops to complexity **10**.

## Validation

- `bunx eslint src/features/webrtc/PersistentEncoderH264Source.ts` — clean
- `bun test test/features/webrtc/PersistentEncoderH264Source.test.ts` — 42 pass, 0 fail
