### PR TITLE
feat(desktop): per-request Network table + detail pane (frame 03)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/NetworkRequestsDataSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/NetworkRequestsDataSource.kt
@@ -1,0 +1,144 @@
+package dev.jasonpearson.automobile.desktop.core.datasource
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A single captured network request, projected from the daemon's `automobile:network/traffic`
+ * resource (the per-request event log, not the aggregated `getNetworkGraph` tree). One row per
+ * captured HTTP call. [id] is the daemon-side event id, used to fetch the [NetworkRequestDetail].
+ */
+data class NetworkRequestRow(
+  val id: Long,
+  val method: String,
+  val host: String,
+  val path: String,
+  val statusCode: Int,
+  val durationMs: Long,
+  val timestamp: Long,
+  val contentType: String?,
+  val error: String?,
+)
+
+/**
+ * Request/response detail for a single captured call, projected from
+ * `automobile:network/request/{id}`. Carries the header maps and timing the detail pane renders.
+ * Bodies are available in the resource but intentionally omitted from this first cut (see the issue
+ * follow-ups).
+ */
+data class NetworkRequestDetail(
+  val id: Long,
+  val method: String,
+  val url: String,
+  val host: String,
+  val path: String,
+  val statusCode: Int,
+  val durationMs: Long,
+  val protocol: String?,
+  val contentType: String?,
+  val requestHeaders: Map<String, String>,
+  val responseHeaders: Map<String, String>,
+  val error: String?,
+)
+
+/**
+ * Reads per-request captured network events for a single device. Injected as an interface so the
+ * facet is testable without a live MCP daemon (see [FakeNetworkRequestsDataSource]). Mirrors the
+ * [NetworkGraphDataSource] seam but resolves per-request rows rather than the aggregated graph.
+ */
+interface NetworkRequestsDataSource {
+  /** Latest captured requests for this device, newest first. */
+  suspend fun getRequests(): Result<List<NetworkRequestRow>>
+
+  /** Full request/response detail (headers/timing) for a captured event [id]. */
+  suspend fun getRequestDetail(id: Long): Result<NetworkRequestDetail>
+}
+
+/** Test double: returns canned results (default: an empty request list). */
+class FakeNetworkRequestsDataSource(
+  private val requests: Result<List<NetworkRequestRow>> = Result.Success(emptyList()),
+  private val details: Map<Long, Result<NetworkRequestDetail>> = emptyMap(),
+) : NetworkRequestsDataSource {
+  override suspend fun getRequests(): Result<List<NetworkRequestRow>> = requests
+
+  override suspend fun getRequestDetail(id: Long): Result<NetworkRequestDetail> =
+    details[id] ?: Result.Error(IllegalStateException("No detail configured for request $id"))
+}
+
+// --- MCP response models (mirror src/server/networkResources.ts eventToSummary/eventToDetail) ---
+
+/**
+ * `automobile:network/traffic` payload: `{ events: EventSummary[], count, hasMore }`. A failed
+ * query returns `{ error }` instead, which the data source surfaces as a typed failure. Nullable
+ * string fields mirror the daemon shape — `host`/`path`/`contentType`/`error` are `null` when
+ * absent.
+ */
+@Serializable
+data class TrafficResponse(
+  val events: List<TrafficEventSummary> = emptyList(),
+  val error: String? = null,
+)
+
+@Serializable
+data class TrafficEventSummary(
+  val id: Long = 0,
+  val timestamp: Long = 0,
+  val method: String = "",
+  val url: String? = null,
+  val host: String? = null,
+  val path: String? = null,
+  val statusCode: Int = 0,
+  val durationMs: Long = 0,
+  val contentType: String? = null,
+  val error: String? = null,
+)
+
+/**
+ * `automobile:network/request/{id}` payload (eventToDetail). Header maps are `null` when the event
+ * carried no headers. A `{ error }` shape (invalid/missing id) is surfaced as a typed failure.
+ */
+@Serializable
+data class RequestDetailResponse(
+  val id: Long = 0,
+  val method: String = "",
+  val url: String? = null,
+  val host: String? = null,
+  val path: String? = null,
+  val statusCode: Int = 0,
+  val durationMs: Long = 0,
+  val protocol: String? = null,
+  val contentType: String? = null,
+  val requestHeaders: Map<String, String>? = null,
+  val responseHeaders: Map<String, String>? = null,
+  val error: String? = null,
+)
+
+/** Project a wire summary into a table row, coalescing absent host/path to empty strings. */
+fun TrafficEventSummary.toRow(): NetworkRequestRow =
+  NetworkRequestRow(
+    id = id,
+    method = method,
+    host = host ?: "",
+    path = path ?: "",
+    statusCode = statusCode,
+    durationMs = durationMs,
+    timestamp = timestamp,
+    contentType = contentType,
+    error = error,
+  )
+
+/** Project a wire detail into the detail model, coalescing absent header maps to empty. */
+fun RequestDetailResponse.toDetail(): NetworkRequestDetail =
+  NetworkRequestDetail(
+    id = id,
+    method = method,
+    url = url ?: "",
+    host = host ?: "",
+    path = path ?: "",
+    statusCode = statusCode,
+    durationMs = durationMs,
+    protocol = protocol,
+    contentType = contentType,
+    requestHeaders = requestHeaders ?: emptyMap(),
+    responseHeaders = responseHeaders ?: emptyMap(),
+    error = error,
+  )

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/NetworkRequestsDataSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/NetworkRequestsDataSource.kt
@@ -1,5 +1,6 @@
 package dev.jasonpearson.automobile.desktop.core.datasource
 
+import kotlin.math.roundToLong
 import kotlinx.serialization.Serializable
 
 /**
@@ -71,6 +72,11 @@ class FakeNetworkRequestsDataSource(
  * query returns `{ error }` instead, which the data source surfaces as a typed failure. Nullable
  * string fields mirror the daemon shape — `host`/`path`/`contentType`/`error` are `null` when
  * absent.
+ *
+ * Timing fields (`timestamp`, `durationMs`) decode as [Double]: iOS captures compute a fractional
+ * `durationMs` (e.g. `34.125`) that the daemon serializes un-rounded, and kotlinx throws on the
+ * whole payload if a `Long` field meets a fractional number — which would hide the entire table
+ * behind a spurious load error. The projectors round to `Long` for display.
  */
 @Serializable
 data class TrafficResponse(
@@ -81,20 +87,26 @@ data class TrafficResponse(
 @Serializable
 data class TrafficEventSummary(
   val id: Long = 0,
-  val timestamp: Long = 0,
+  val timestamp: Double = 0.0,
   val method: String = "",
   val url: String? = null,
   val host: String? = null,
   val path: String? = null,
   val statusCode: Int = 0,
-  val durationMs: Long = 0,
+  val durationMs: Double = 0.0,
   val contentType: String? = null,
   val error: String? = null,
 )
 
 /**
  * `automobile:network/request/{id}` payload (eventToDetail). Header maps are `null` when the event
- * carried no headers. A `{ error }` shape (invalid/missing id) is surfaced as a typed failure.
+ * carried no headers. `durationMs` is a [Double] for the same fractional-timing reason as
+ * [TrafficEventSummary].
+ *
+ * A non-null [error] does NOT mark an invalid/not-found envelope — a request that failed at the
+ * transport layer still returns a *successful* detail (valid [id], headers, protocol) alongside a
+ * non-null `error`. The true not-found/invalid envelope is `{ error }` with no `id`, distinguished
+ * by a missing/default [id] (see `RealNetworkRequestsDataSource.getRequestDetail`).
  */
 @Serializable
 data class RequestDetailResponse(
@@ -104,7 +116,7 @@ data class RequestDetailResponse(
   val host: String? = null,
   val path: String? = null,
   val statusCode: Int = 0,
-  val durationMs: Long = 0,
+  val durationMs: Double = 0.0,
   val protocol: String? = null,
   val contentType: String? = null,
   val requestHeaders: Map<String, String>? = null,
@@ -120,8 +132,8 @@ fun TrafficEventSummary.toRow(): NetworkRequestRow =
     host = host ?: "",
     path = path ?: "",
     statusCode = statusCode,
-    durationMs = durationMs,
-    timestamp = timestamp,
+    durationMs = durationMs.roundToLong(),
+    timestamp = timestamp.roundToLong(),
     contentType = contentType,
     error = error,
   )
@@ -135,7 +147,7 @@ fun RequestDetailResponse.toDetail(): NetworkRequestDetail =
     host = host ?: "",
     path = path ?: "",
     statusCode = statusCode,
-    durationMs = durationMs,
+    durationMs = durationMs.roundToLong(),
     protocol = protocol,
     contentType = contentType,
     requestHeaders = requestHeaders ?: emptyMap(),

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealNetworkRequestsDataSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealNetworkRequestsDataSource.kt
@@ -78,8 +78,14 @@ class RealNetworkRequestsDataSource(
               RuntimeException("No detail returned for request $id")
             )
         val response = json.decodeFromString(serializer<RequestDetailResponse>(), text)
-        if (response.error != null) {
-          return@withContext Result.Error(RuntimeException(response.error))
+        // The true not-found/invalid envelope is `{ error }` with no `id` (getNetworkEventById
+        // miss / invalid requestId). A transport-level request failure still returns a full
+        // detail (valid id, headers, protocol) *with* a non-null `error`, so gate on the missing
+        // id — NOT the presence of `error` — and surface that error inside the detail.
+        if (response.id == 0L) {
+          return@withContext Result.Error(
+            RuntimeException(response.error ?: "Network request $id not found")
+          )
         }
         Result.Success(response.toDetail())
       }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealNetworkRequestsDataSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealNetworkRequestsDataSource.kt
@@ -1,0 +1,105 @@
+package dev.jasonpearson.automobile.desktop.core.datasource
+
+import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.daemon.McpConnectionException
+import dev.jasonpearson.automobile.desktop.core.daemon.encodeResourceUriComponent
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
+
+private val LOG = LoggerFactory.getLogger("RealNetworkRequestsDataSource")
+
+/**
+ * Per-request network data source backed by the daemon's `automobile:network/traffic` resource (the
+ * per-request event log) and the `automobile:network/request/{id}` detail resource.
+ *
+ * Reads are scoped to [deviceId] via the resource's `deviceId` query filter so a device pane never
+ * shows another device's traffic. The traffic query keys must be emitted in the order the daemon
+ * registers its templates (`limit` before `deviceId`, per `TRAFFIC_QUERY_KEYS` in
+ * `src/server/networkResources.ts`), otherwise the anchored template regex will not match.
+ *
+ * @param clientProvider Provides an [AutoMobileClient] for MCP access.
+ * @param deviceId The device to scope traffic reads to.
+ * @param limit Max requests to fetch (daemon caps this at 200; default matches the daemon default).
+ */
+class RealNetworkRequestsDataSource(
+  private val clientProvider: (() -> AutoMobileClient)? = null,
+  private val deviceId: String? = null,
+  private val limit: Int = DEFAULT_LIMIT,
+) : NetworkRequestsDataSource {
+  private val json = Json { ignoreUnknownKeys = true }
+
+  override suspend fun getRequests(): Result<List<NetworkRequestRow>> {
+    val provider =
+      clientProvider
+        ?: return Result.Error(
+          IllegalStateException("Not connected to MCP server. Please select a device first.")
+        )
+    val device = deviceId ?: return Result.Error(IllegalStateException("No device ID provided"))
+
+    return try {
+      withContext(Dispatchers.IO) {
+        val client = provider()
+        val uri = buildTrafficUri(device, limit)
+        val text =
+          client.readResource(uri).firstOrNull()?.text
+            ?: return@withContext Result.Success(emptyList())
+        val response = json.decodeFromString(serializer<TrafficResponse>(), text)
+        if (response.error != null) {
+          return@withContext Result.Error(RuntimeException(response.error))
+        }
+        Result.Success(response.events.map { it.toRow() })
+      }
+    } catch (e: McpConnectionException) {
+      LOG.warn("getRequests: MCP connection error: ${e.message}", e)
+      Result.Error(e, "MCP server not available: ${e.message}")
+    } catch (e: Exception) {
+      // Let coroutine cancellation propagate so this suspend call stays cancellable.
+      if (e is CancellationException) throw e
+      LOG.warn("getRequests: Exception: ${e.message}", e)
+      Result.Error(e, "Failed to load network requests: ${e.message}")
+    }
+  }
+
+  override suspend fun getRequestDetail(id: Long): Result<NetworkRequestDetail> {
+    val provider =
+      clientProvider ?: return Result.Error(IllegalStateException("Not connected to MCP server."))
+
+    return try {
+      withContext(Dispatchers.IO) {
+        val client = provider()
+        val uri = "automobile:network/request/$id"
+        val text =
+          client.readResource(uri).firstOrNull()?.text
+            ?: return@withContext Result.Error(
+              RuntimeException("No detail returned for request $id")
+            )
+        val response = json.decodeFromString(serializer<RequestDetailResponse>(), text)
+        if (response.error != null) {
+          return@withContext Result.Error(RuntimeException(response.error))
+        }
+        Result.Success(response.toDetail())
+      }
+    } catch (e: McpConnectionException) {
+      LOG.warn("getRequestDetail: MCP connection error: ${e.message}", e)
+      Result.Error(e, "MCP server not available: ${e.message}")
+    } catch (e: Exception) {
+      if (e is CancellationException) throw e
+      LOG.warn("getRequestDetail: Exception: ${e.message}", e)
+      Result.Error(e, "Failed to load request detail: ${e.message}")
+    }
+  }
+
+  private fun buildTrafficUri(deviceId: String, limit: Int): String {
+    val encodedDevice = encodeResourceUriComponent(deviceId)
+    return "automobile:network/traffic?limit=$limit&deviceId=$encodedDevice"
+  }
+
+  companion object {
+    /** Matches the daemon's default traffic page size (`parseTrafficParams`). */
+    const val DEFAULT_LIMIT = 50
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NetworkFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NetworkFacet.kt
@@ -1,15 +1,20 @@
 package dev.jasonpearson.automobile.desktop.core.workspace
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -22,9 +27,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import dev.jasonpearson.automobile.desktop.core.datasource.NetworkEndpointRow
-import dev.jasonpearson.automobile.desktop.core.datasource.RealNetworkGraphDataSource
+import dev.jasonpearson.automobile.desktop.core.datasource.NetworkRequestDetail
+import dev.jasonpearson.automobile.desktop.core.datasource.NetworkRequestRow
+import dev.jasonpearson.automobile.desktop.core.datasource.NetworkRequestsDataSource
+import dev.jasonpearson.automobile.desktop.core.datasource.RealNetworkRequestsDataSource
 import dev.jasonpearson.automobile.desktop.core.datasource.Result
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
 import kotlinx.coroutines.Dispatchers
@@ -37,84 +45,241 @@ private sealed interface NetworkFacetState {
 
   data class Error(val message: String) : NetworkFacetState
 
-  data class Resolved(val rows: List<NetworkEndpointRow>) : NetworkFacetState
+  data class Resolved(val rows: List<NetworkRequestRow>) : NetworkFacetState
 }
 
 /**
- * Docked-facet body for [Tool.Network]: a first-cut flat list of the captured network endpoints for
- * a pane's device, read from the `getNetworkGraph` MCP tool. This is intentionally minimal — a flat
- * host/method/path list, not the full host → path tree dashboard.
+ * Docked-facet body for [Tool.Network]: a per-request table (method · host/path · status · timing)
+ * with a detail pane (headers/timing) for the selected row. Reads the daemon's
+ * `automobile:network/traffic` resource scoped to the pane's device — the per-request event log,
+ * not the aggregated `getNetworkGraph` tree.
  *
- * The graph read is injected via [loadNetworkGraph] so the loading/empty/error states are testable
- * without a live MCP daemon; the default reads through a [RealNetworkGraphDataSource] built from
- * the DI graph. The tool is embedded-SDK-only and returns an empty graph when no traffic was
- * captured, which is surfaced as an explicit empty state rather than an error.
+ * The data source is injected via [dataSource] so the loading/empty/error/selection states are
+ * testable without a live MCP daemon; the default reads through a [RealNetworkRequestsDataSource]
+ * built from the DI graph and scoped to [DeviceColumn.deviceId]. Everything is keyed on the device
+ * id so switching panes never bleeds one device's traffic into another.
+ *
+ * This is a one-shot fetch of the latest N requests; live streaming of new requests and the
+ * correlation/events strip (frame 03 lower region) are tracked as follow-ups.
  */
 @Composable
-fun NetworkFacet(
-  column: DeviceColumn,
-  loadNetworkGraph: (suspend (String) -> Result<List<NetworkEndpointRow>>)? = null,
-) {
+fun NetworkFacet(column: DeviceColumn, dataSource: NetworkRequestsDataSource? = null) {
   val graph = LocalAutoMobileGraph.current
-  val loader: suspend (String) -> Result<List<NetworkEndpointRow>> =
-    loadNetworkGraph
-      ?: { deviceId ->
-        // Read off the UI thread: the tool call hits the daemon and would otherwise block
-        // recomposition. Injected test loaders run inline (deterministic).
-        withContext(Dispatchers.IO) {
-          RealNetworkGraphDataSource({ graph.autoMobileClient }, deviceId).getNetworkGraph()
-        }
-      }
+  val source: NetworkRequestsDataSource =
+    remember(column.deviceId, dataSource) {
+      dataSource ?: RealNetworkRequestsDataSource({ graph.autoMobileClient }, column.deviceId)
+    }
+
   var attempt by remember(column.deviceId) { mutableStateOf(0) }
   var state by
     remember(column.deviceId, attempt) {
       mutableStateOf<NetworkFacetState>(NetworkFacetState.Loading)
     }
+  var selectedId by remember(column.deviceId, attempt) { mutableStateOf<Long?>(null) }
+
   LaunchedEffect(column.deviceId, attempt) {
+    // Read off the UI thread: the resource read hits the daemon and would otherwise block
+    // recomposition. Injected test data sources run inline (deterministic).
     state =
-      when (val result = loader(column.deviceId)) {
+      when (val result = withContext(Dispatchers.IO) { source.getRequests() }) {
         is Result.Success ->
           if (result.data.isEmpty()) NetworkFacetState.Empty
           else NetworkFacetState.Resolved(result.data)
         is Result.Error ->
-          NetworkFacetState.Error(result.message ?: "Failed to load the network graph")
-        // A one-shot tool call resolves to Success/Error; treat a stray Loading as retryable.
-        Result.Loading -> NetworkFacetState.Error("Network graph is still loading")
+          NetworkFacetState.Error(result.message ?: "Failed to load network requests")
+        // A one-shot read resolves to Success/Error; treat a stray Loading as retryable.
+        Result.Loading -> NetworkFacetState.Error("Network requests are still loading")
       }
   }
+
   when (val current = state) {
     NetworkFacetState.Loading -> NetworkFacetNote("Loading network activity…")
     NetworkFacetState.Empty -> NetworkFacetNote("No network activity captured on this device")
     is NetworkFacetState.Error -> NetworkFacetError(current.message) { attempt++ }
-    is NetworkFacetState.Resolved -> NetworkEndpointList(current.rows)
-  }
-}
-
-/** Flat list of captured endpoints, one row per method+path. */
-@Composable
-private fun NetworkEndpointList(rows: List<NetworkEndpointRow>) {
-  LazyColumn(Modifier.fillMaxSize().padding(8.dp)) {
-    items(rows) { row -> NetworkEndpointRowItem(row) }
-  }
-}
-
-@Composable
-private fun NetworkEndpointRowItem(row: NetworkEndpointRow) {
-  Column(Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
-    Row {
-      Text(
-        row.method ?: "—",
-        style = MaterialTheme.typography.labelMedium,
-        color = MaterialTheme.colorScheme.primary,
-        modifier = Modifier.padding(end = 8.dp),
+    is NetworkFacetState.Resolved ->
+      NetworkRequestsBody(
+        rows = current.rows,
+        source = source,
+        selectedId = selectedId,
+        onSelect = { selectedId = it },
       )
-      Text("${row.host}${row.path}", style = MaterialTheme.typography.bodyMedium)
+  }
+}
+
+/** Split view: a selectable request table on the left, the selected row's detail on the right. */
+@Composable
+private fun NetworkRequestsBody(
+  rows: List<NetworkRequestRow>,
+  source: NetworkRequestsDataSource,
+  selectedId: Long?,
+  onSelect: (Long) -> Unit,
+) {
+  Row(Modifier.fillMaxSize()) {
+    Box(Modifier.weight(1f).fillMaxHeight()) {
+      NetworkRequestTable(rows = rows, selectedId = selectedId, onSelect = onSelect)
     }
+    Box(Modifier.weight(1f).fillMaxHeight().padding(8.dp)) {
+      val selected = rows.firstOrNull { it.id == selectedId }
+      if (selected == null) {
+        NetworkFacetNote("Select a request to inspect headers and timing")
+      } else {
+        NetworkRequestDetailPane(source = source, row = selected)
+      }
+    }
+  }
+}
+
+/** Selectable table, one row per captured request. */
+@Composable
+private fun NetworkRequestTable(
+  rows: List<NetworkRequestRow>,
+  selectedId: Long?,
+  onSelect: (Long) -> Unit,
+) {
+  LazyColumn(Modifier.fillMaxSize().padding(8.dp)) {
+    items(rows, key = { it.id }) { row ->
+      NetworkRequestRowItem(
+        row = row,
+        selected = row.id == selectedId,
+        onSelect = { onSelect(row.id) },
+      )
+    }
+  }
+}
+
+@Composable
+private fun NetworkRequestRowItem(row: NetworkRequestRow, selected: Boolean, onSelect: () -> Unit) {
+  val background =
+    if (selected) MaterialTheme.colorScheme.secondaryContainer
+    else MaterialTheme.colorScheme.surface
+  Row(
+    Modifier.fillMaxWidth()
+      .background(background)
+      .clickable(onClick = onSelect)
+      .semantics { contentDescription = "Network request ${row.method} ${row.host}${row.path}" }
+      .padding(vertical = 6.dp, horizontal = 4.dp),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
     Text(
-      "✓ ${row.success}  ✗ ${row.errors}  p50 ${row.p50}ms  p95 ${row.p95}ms",
+      row.method,
+      style = MaterialTheme.typography.labelMedium,
+      color = MaterialTheme.colorScheme.primary,
+      modifier = Modifier.width(52.dp),
+    )
+    Text(
+      "${row.host}${row.path}",
+      style = MaterialTheme.typography.bodyMedium,
+      maxLines = 1,
+      overflow = TextOverflow.Ellipsis,
+      modifier = Modifier.weight(1f).padding(horizontal = 8.dp),
+    )
+    Text(
+      statusLabel(row),
+      style = MaterialTheme.typography.labelMedium,
+      color = statusColor(row),
+      modifier = Modifier.width(44.dp),
+    )
+    Text(
+      "${row.durationMs}ms",
       style = MaterialTheme.typography.labelSmall,
       color = MaterialTheme.colorScheme.outline,
+      modifier = Modifier.width(64.dp),
     )
+  }
+}
+
+/** A dash for an in-flight/uncaptured status (0); otherwise the numeric code. */
+private fun statusLabel(row: NetworkRequestRow): String =
+  if (row.statusCode == 0) "—" else row.statusCode.toString()
+
+@Composable
+private fun statusColor(row: NetworkRequestRow) =
+  if (row.statusCode >= 400 || row.error != null) MaterialTheme.colorScheme.error
+  else MaterialTheme.colorScheme.onSurface
+
+/**
+ * Detail pane for a selected row. Loads the full detail (headers) lazily off the summary row's id;
+ * shows the summary immediately while the detail read is in flight so the pane never blanks.
+ */
+@Composable
+private fun NetworkRequestDetailPane(source: NetworkRequestsDataSource, row: NetworkRequestRow) {
+  var detail by remember(row.id) { mutableStateOf<Result<NetworkRequestDetail>>(Result.Loading) }
+  LaunchedEffect(row.id) {
+    detail = withContext(Dispatchers.IO) { source.getRequestDetail(row.id) }
+  }
+
+  Column(Modifier.fillMaxSize().verticalScroll(rememberScrollState())) {
+    Text(
+      "${row.method} ${row.host}${row.path}",
+      style = MaterialTheme.typography.titleSmall,
+      modifier = Modifier.semantics { contentDescription = "Selected request detail" },
+    )
+    Text(
+      "${statusLabel(row)} · ${row.durationMs}ms",
+      style = MaterialTheme.typography.labelMedium,
+      color = statusColor(row),
+      modifier = Modifier.padding(top = 2.dp),
+    )
+    row.error?.let {
+      Text(
+        it,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.error,
+        modifier = Modifier.padding(top = 4.dp),
+      )
+    }
+
+    when (val current = detail) {
+      Result.Loading -> DetailNote("Loading request detail…")
+      is Result.Error -> DetailNote(current.message ?: "Failed to load request detail")
+      is Result.Success -> {
+        val data = current.data
+        data.contentType?.let { HeaderLine("Content-Type", it) }
+        data.protocol?.let { HeaderLine("Protocol", it) }
+        HeaderSection("Request headers", data.requestHeaders)
+        HeaderSection("Response headers", data.responseHeaders)
+      }
+    }
+  }
+}
+
+@Composable
+private fun DetailNote(text: String) {
+  Text(
+    text,
+    style = MaterialTheme.typography.bodySmall,
+    color = MaterialTheme.colorScheme.outline,
+    modifier = Modifier.padding(top = 8.dp),
+  )
+}
+
+@Composable
+private fun HeaderSection(title: String, headers: Map<String, String>) {
+  Text(
+    title,
+    style = MaterialTheme.typography.labelLarge,
+    color = MaterialTheme.colorScheme.primary,
+    modifier = Modifier.padding(top = 12.dp, bottom = 2.dp),
+  )
+  if (headers.isEmpty()) {
+    DetailNote("None")
+  } else {
+    for ((name, value) in headers) {
+      HeaderLine(name, value)
+    }
+  }
+}
+
+@Composable
+private fun HeaderLine(name: String, value: String) {
+  Row(Modifier.fillMaxWidth().padding(vertical = 1.dp)) {
+    Text(
+      "$name:",
+      style = MaterialTheme.typography.labelSmall,
+      color = MaterialTheme.colorScheme.outline,
+      modifier = Modifier.width(120.dp),
+    )
+    Text(value, style = MaterialTheme.typography.bodySmall, modifier = Modifier.weight(1f))
   }
 }
 
@@ -126,7 +291,7 @@ private fun NetworkFacetNote(text: String) {
   }
 }
 
-/** Error state with a Retry affordance that re-runs the network-graph load. */
+/** Error state with a Retry affordance that re-runs the network requests load. */
 @Composable
 private fun NetworkFacetError(message: String, onRetry: () -> Unit) {
   Column(
@@ -140,7 +305,7 @@ private fun NetworkFacetError(message: String, onRetry: () -> Unit) {
       color = MaterialTheme.colorScheme.primary,
       modifier =
         Modifier.padding(top = 8.dp).clickable(onClick = onRetry).semantics {
-          contentDescription = "Retry loading network graph"
+          contentDescription = "Retry loading network requests"
         },
     )
   }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealNetworkRequestsDataSourceTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealNetworkRequestsDataSourceTest.kt
@@ -1,0 +1,253 @@
+package dev.jasonpearson.automobile.desktop.core.datasource
+
+import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.daemon.McpResourceContent
+import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RealNetworkRequestsDataSourceTest {
+
+  private val trafficJson =
+    """
+    {
+      "events": [
+        {
+          "id": 7,
+          "timestamp": 1000,
+          "method": "GET",
+          "url": "https://api.example.com/users/42",
+          "host": "api.example.com",
+          "path": "/users/42",
+          "statusCode": 200,
+          "durationMs": 34,
+          "contentType": "application/json",
+          "error": null
+        },
+        {
+          "id": 8,
+          "timestamp": 900,
+          "method": "POST",
+          "url": "https://api.example.com/login",
+          "host": "api.example.com",
+          "path": "/login",
+          "statusCode": 500,
+          "durationMs": 812,
+          "contentType": null,
+          "error": "boom"
+        }
+      ],
+      "count": 2,
+      "hasMore": false
+    }
+    """
+      .trimIndent()
+
+  private val detailJson =
+    """
+    {
+      "id": 7,
+      "timestamp": 1000,
+      "method": "GET",
+      "url": "https://api.example.com/users/42",
+      "statusCode": 200,
+      "durationMs": 34,
+      "host": "api.example.com",
+      "path": "/users/42",
+      "protocol": "h2",
+      "contentType": "application/json",
+      "requestHeaders": {"accept": "application/json"},
+      "responseHeaders": {"content-type": "application/json", "x-cache": "HIT"}
+    }
+    """
+      .trimIndent()
+
+  @Test
+  fun `returns error when no clientProvider`() = runBlocking {
+    val result = RealNetworkRequestsDataSource().getRequests()
+
+    assertTrue(result is Result.Error)
+    assertTrue((result as Result.Error).message!!.contains("Not connected"))
+  }
+
+  @Test
+  fun `returns error when no deviceId`() = runBlocking {
+    val client = FakeAutoMobileClient()
+    val result =
+      RealNetworkRequestsDataSource(clientProvider = { client }, deviceId = null).getRequests()
+
+    assertTrue(result is Result.Error)
+    assertTrue((result as Result.Error).message!!.contains("device"))
+  }
+
+  @Test
+  fun `parses traffic events into rows and scopes the read to the deviceId`() = runBlocking {
+    var capturedUri: String? = null
+    val client =
+      object : AutoMobileClient by FakeAutoMobileClient() {
+        override fun readResource(uri: String): List<McpResourceContent> {
+          capturedUri = uri
+          return listOf(
+            McpResourceContent(uri = uri, mimeType = "application/json", text = trafficJson)
+          )
+        }
+      }
+
+    val result =
+      RealNetworkRequestsDataSource(
+          clientProvider = { client },
+          deviceId = "emulator-5554",
+          limit = 25,
+        )
+        .getRequests()
+
+    assertTrue(result is Result.Success)
+    val rows = (result as Result.Success).data
+    assertEquals(2, rows.size)
+    assertEquals(7L, rows.first().id)
+    assertEquals("GET", rows.first().method)
+    assertEquals("api.example.com", rows.first().host)
+    assertEquals("/users/42", rows.first().path)
+    assertEquals(200, rows.first().statusCode)
+    assertEquals(34L, rows.first().durationMs)
+    assertEquals(500, rows[1].statusCode)
+    assertEquals("boom", rows[1].error)
+
+    // Scoped to device; limit precedes deviceId to match the daemon's template key order.
+    assertEquals("automobile:network/traffic?limit=25&deviceId=emulator-5554", capturedUri)
+  }
+
+  @Test
+  fun `missing host and path coalesce to empty strings`() = runBlocking {
+    val client = FakeAutoMobileClient()
+    client.setResourceResponseWithText(
+      "automobile:network/traffic?limit=50&deviceId=emulator-5554",
+      """{"events":[{"id":1,"method":"GET","statusCode":204,"durationMs":5}],"count":1}""",
+    )
+
+    val result =
+      RealNetworkRequestsDataSource(clientProvider = { client }, deviceId = "emulator-5554")
+        .getRequests()
+
+    assertTrue(result is Result.Success)
+    val row = (result as Result.Success).data.single()
+    assertEquals("", row.host)
+    assertEquals("", row.path)
+    assertEquals(null, row.contentType)
+  }
+
+  @Test
+  fun `an empty traffic log resolves to no rows`() = runBlocking {
+    val client = FakeAutoMobileClient()
+    client.setResourceResponseWithText(
+      "automobile:network/traffic?limit=50&deviceId=emulator-5554",
+      """{"events":[],"count":0,"hasMore":false}""",
+    )
+
+    val result =
+      RealNetworkRequestsDataSource(clientProvider = { client }, deviceId = "emulator-5554")
+        .getRequests()
+
+    assertTrue(result is Result.Success)
+    assertTrue((result as Result.Success).data.isEmpty())
+  }
+
+  @Test
+  fun `surfaces an error field from the traffic response as a failure`() = runBlocking {
+    val client = FakeAutoMobileClient()
+    client.setResourceResponseWithText(
+      "automobile:network/traffic?limit=50&deviceId=emulator-5554",
+      """{"error":"Failed to query traffic: db locked"}""",
+    )
+
+    val result =
+      RealNetworkRequestsDataSource(clientProvider = { client }, deviceId = "emulator-5554")
+        .getRequests()
+
+    assertTrue(result is Result.Error)
+    assertTrue((result as Result.Error).message!!.contains("db locked"))
+  }
+
+  @Test
+  fun `an empty resource response resolves to no rows`() = runBlocking {
+    val client = FakeAutoMobileClient() // no response registered -> empty content list
+
+    val result =
+      RealNetworkRequestsDataSource(clientProvider = { client }, deviceId = "emulator-5554")
+        .getRequests()
+
+    assertTrue(result is Result.Success)
+    assertTrue((result as Result.Success).data.isEmpty())
+  }
+
+  @Test
+  fun `getRequestDetail parses headers and timing`() = runBlocking {
+    var capturedUri: String? = null
+    val client =
+      object : AutoMobileClient by FakeAutoMobileClient() {
+        override fun readResource(uri: String): List<McpResourceContent> {
+          capturedUri = uri
+          return listOf(
+            McpResourceContent(uri = uri, mimeType = "application/json", text = detailJson)
+          )
+        }
+      }
+
+    val result =
+      RealNetworkRequestsDataSource(clientProvider = { client }, deviceId = "emulator-5554")
+        .getRequestDetail(7)
+
+    assertTrue(result is Result.Success)
+    val detail = (result as Result.Success).data
+    assertEquals(7L, detail.id)
+    assertEquals("h2", detail.protocol)
+    assertEquals("application/json", detail.requestHeaders["accept"])
+    assertEquals("HIT", detail.responseHeaders["x-cache"])
+    assertEquals("automobile:network/request/7", capturedUri)
+  }
+
+  @Test
+  fun `getRequestDetail coalesces absent header maps to empty`() = runBlocking {
+    val client = FakeAutoMobileClient()
+    client.setResourceResponseWithText(
+      "automobile:network/request/9",
+      """{"id":9,"method":"GET","url":"https://x/y","host":"x","path":"/y","statusCode":200,"durationMs":1}""",
+    )
+
+    val result =
+      RealNetworkRequestsDataSource(clientProvider = { client }, deviceId = "emulator-5554")
+        .getRequestDetail(9)
+
+    assertTrue(result is Result.Success)
+    val detail = (result as Result.Success).data
+    assertTrue(detail.requestHeaders.isEmpty())
+    assertTrue(detail.responseHeaders.isEmpty())
+  }
+
+  @Test
+  fun `getRequestDetail surfaces an error field as a failure`() = runBlocking {
+    val client = FakeAutoMobileClient()
+    client.setResourceResponseWithText(
+      "automobile:network/request/404",
+      """{"error":"Network request 404 not found"}""",
+    )
+
+    val result =
+      RealNetworkRequestsDataSource(clientProvider = { client }, deviceId = "emulator-5554")
+        .getRequestDetail(404)
+
+    assertTrue(result is Result.Error)
+    assertTrue((result as Result.Error).message!!.contains("not found"))
+  }
+
+  @Test
+  fun `getRequestDetail returns error when no clientProvider`() = runBlocking {
+    val result = RealNetworkRequestsDataSource().getRequestDetail(1)
+
+    assertTrue(result is Result.Error)
+    assertFalse((result as Result.Error).message.isNullOrBlank())
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealNetworkRequestsDataSourceTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealNetworkRequestsDataSourceTest.kt
@@ -228,7 +228,7 @@ class RealNetworkRequestsDataSourceTest {
   }
 
   @Test
-  fun `getRequestDetail surfaces an error field as a failure`() = runBlocking {
+  fun `getRequestDetail treats the no-id not-found envelope as a failure`() = runBlocking {
     val client = FakeAutoMobileClient()
     client.setResourceResponseWithText(
       "automobile:network/request/404",
@@ -250,4 +250,49 @@ class RealNetworkRequestsDataSourceTest {
     assertTrue(result is Result.Error)
     assertFalse((result as Result.Error).message.isNullOrBlank())
   }
+
+  @Test
+  fun `a fractional durationMs decodes into a row instead of failing the whole table`() =
+    runBlocking {
+      // iOS captures serialize a fractional durationMs (and timestamp); a Long wire field would
+      // throw on the whole payload and hide every row. It must decode and round for display.
+      val client = FakeAutoMobileClient()
+      client.setResourceResponseWithText(
+        "automobile:network/traffic?limit=50&deviceId=emulator-5554",
+        """{"events":[{"id":3,"timestamp":1000.5,"method":"GET","host":"h","path":"/p","statusCode":200,"durationMs":34.125}],"count":1}""",
+      )
+
+      val result =
+        RealNetworkRequestsDataSource(clientProvider = { client }, deviceId = "emulator-5554")
+          .getRequests()
+
+      assertTrue(result is Result.Success)
+      val row = (result as Result.Success).data.single()
+      assertEquals(3L, row.id)
+      assertEquals(34L, row.durationMs)
+      assertEquals(1001L, row.timestamp)
+    }
+
+  @Test
+  fun `getRequestDetail on a transport-failed request returns the detail with its error`() =
+    runBlocking {
+      // A request that failed at the transport layer still returns a full, successful detail
+      // (valid id, headers, protocol) alongside a non-null error — it must NOT be mistaken for
+      // the not-found envelope.
+      val client = FakeAutoMobileClient()
+      client.setResourceResponseWithText(
+        "automobile:network/request/11",
+        """{"id":11,"method":"GET","url":"https://x/y","host":"x","path":"/y","statusCode":0,"durationMs":0,"protocol":"h2","requestHeaders":{"accept":"*/*"},"error":"Connection reset"}""",
+      )
+
+      val result =
+        RealNetworkRequestsDataSource(clientProvider = { client }, deviceId = "emulator-5554")
+          .getRequestDetail(11)
+
+      assertTrue(result is Result.Success)
+      val detail = (result as Result.Success).data
+      assertEquals(11L, detail.id)
+      assertEquals("Connection reset", detail.error)
+      assertEquals("*/*", detail.requestHeaders["accept"])
+    }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NetworkFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NetworkFacetTest.kt
@@ -7,7 +7,9 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
-import dev.jasonpearson.automobile.desktop.core.datasource.NetworkEndpointRow
+import dev.jasonpearson.automobile.desktop.core.datasource.FakeNetworkRequestsDataSource
+import dev.jasonpearson.automobile.desktop.core.datasource.NetworkRequestDetail
+import dev.jasonpearson.automobile.desktop.core.datasource.NetworkRequestRow
 import dev.jasonpearson.automobile.desktop.core.datasource.Result
 import java.util.concurrent.atomic.AtomicInteger
 import org.junit.Test
@@ -17,24 +19,50 @@ class NetworkFacetTest {
 
   private fun column() = DeviceColumn(deviceId = "d", name = "Pixel", platform = Platform.Android)
 
-  private fun row(host: String, path: String, method: String = "GET") =
-    NetworkEndpointRow(
-      scheme = "https",
+  private fun row(
+    id: Long,
+    host: String,
+    path: String,
+    method: String = "GET",
+    status: Int = 200,
+    duration: Long = 12,
+  ) =
+    NetworkRequestRow(
+      id = id,
+      method = method,
       host = host,
       path = path,
-      method = method,
-      type = "application/json",
-      success = 3,
-      errors = 1,
-      p50 = 10,
-      p95 = 20,
+      statusCode = status,
+      durationMs = duration,
+      timestamp = 0,
+      contentType = "application/json",
+      error = null,
+    )
+
+  private fun detail(id: Long) =
+    NetworkRequestDetail(
+      id = id,
+      method = "GET",
+      url = "https://api.example.com/users",
+      host = "api.example.com",
+      path = "/users",
+      statusCode = 200,
+      durationMs = 12,
+      protocol = "h2",
+      contentType = "application/json",
+      requestHeaders = mapOf("accept" to "application/json"),
+      responseHeaders = mapOf("x-cache" to "HIT"),
+      error = null,
     )
 
   @Test
-  fun `shows the empty state when the graph has no captured traffic`() = runComposeUiTest {
+  fun `shows the empty state when there is no captured traffic`() = runComposeUiTest {
     setContent {
       MaterialTheme {
-        NetworkFacet(column = column(), loadNetworkGraph = { Result.Success(emptyList()) })
+        NetworkFacet(
+          column = column(),
+          dataSource = FakeNetworkRequestsDataSource(requests = Result.Success(emptyList())),
+        )
       }
     }
     waitForIdle()
@@ -42,14 +70,15 @@ class NetworkFacetTest {
   }
 
   @Test
-  fun `renders a row per captured endpoint`() = runComposeUiTest {
+  fun `renders a row per captured request`() = runComposeUiTest {
     setContent {
       MaterialTheme {
         NetworkFacet(
           column = column(),
-          loadNetworkGraph = {
-            Result.Success(listOf(row("api.example.com", "/users/{id}")))
-          },
+          dataSource =
+            FakeNetworkRequestsDataSource(
+              requests = Result.Success(listOf(row(1, "api.example.com", "/users/{id}")))
+            ),
         )
       }
     }
@@ -58,18 +87,44 @@ class NetworkFacetTest {
   }
 
   @Test
-  fun `surfaces a retryable error when the graph fails to load`() = runComposeUiTest {
+  fun `selecting a row shows its detail with headers`() = runComposeUiTest {
     setContent {
       MaterialTheme {
         NetworkFacet(
           column = column(),
-          loadNetworkGraph = { Result.Error(RuntimeException("daemon down")) },
+          dataSource =
+            FakeNetworkRequestsDataSource(
+              requests = Result.Success(listOf(row(1, "api.example.com", "/users"))),
+              details = mapOf(1L to Result.Success(detail(1))),
+            ),
+        )
+      }
+    }
+    waitForIdle()
+    // Before selection the detail pane prompts for a selection.
+    onNodeWithText("Select a request to inspect", substring = true).assertIsDisplayed()
+
+    onNodeWithContentDescription("Network request GET api.example.com/users").performClick()
+    waitForIdle()
+
+    onNodeWithText("Request headers", substring = true).assertIsDisplayed()
+    onNodeWithText("x-cache", substring = true).assertIsDisplayed()
+  }
+
+  @Test
+  fun `surfaces a retryable error when the requests fail to load`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        NetworkFacet(
+          column = column(),
+          dataSource =
+            FakeNetworkRequestsDataSource(requests = Result.Error(RuntimeException("daemon down"))),
         )
       }
     }
     waitForIdle()
     onNodeWithText("daemon down", substring = true).assertIsDisplayed()
-    onNodeWithContentDescription("Retry loading network graph").assertIsDisplayed()
+    onNodeWithContentDescription("Retry loading network requests").assertIsDisplayed()
   }
 
   @Test
@@ -77,21 +132,47 @@ class NetworkFacetTest {
     val attempts = AtomicInteger(0)
     setContent {
       MaterialTheme {
-        NetworkFacet(
-          column = column(),
-          loadNetworkGraph = {
-            if (attempts.getAndIncrement() == 0) Result.Error(RuntimeException("daemon down"))
-            else Result.Success(listOf(row("api.example.com", "/health")))
-          },
-        )
+        val recovering =
+          object : dev.jasonpearson.automobile.desktop.core.datasource.NetworkRequestsDataSource {
+            override suspend fun getRequests(): Result<List<NetworkRequestRow>> =
+              if (attempts.getAndIncrement() == 0) Result.Error(RuntimeException("daemon down"))
+              else Result.Success(listOf(row(1, "api.example.com", "/health")))
+
+            override suspend fun getRequestDetail(id: Long): Result<NetworkRequestDetail> =
+              Result.Success(detail(id))
+          }
+        NetworkFacet(column = column(), dataSource = recovering)
       }
     }
     waitForIdle()
     onNodeWithText("daemon down", substring = true).assertIsDisplayed()
 
-    onNodeWithContentDescription("Retry loading network graph").performClick()
+    onNodeWithContentDescription("Retry loading network requests").performClick()
     waitForIdle()
 
     onNodeWithText("api.example.com/health", substring = true).assertIsDisplayed()
+  }
+
+  @Test
+  fun `detail pane surfaces a detail-load failure without blanking`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        NetworkFacet(
+          column = column(),
+          dataSource =
+            FakeNetworkRequestsDataSource(
+              requests = Result.Success(listOf(row(5, "api.example.com", "/slow"))),
+              details = mapOf(5L to Result.Error(RuntimeException("detail unavailable"))),
+            ),
+        )
+      }
+    }
+    waitForIdle()
+    onNodeWithContentDescription("Network request GET api.example.com/slow").performClick()
+    waitForIdle()
+
+    // The summary header stays visible; the error is shown inline in the detail pane.
+    onNodeWithContentDescription("Selected request detail").assertIsDisplayed()
+    onNodeWithText("detail unavailable", substring = true).assertIsDisplayed()
   }
 }


### PR DESCRIPTION
## What

Upgrades the Compose Desktop **Network facet** (frame 03) from the first-cut flat endpoint-aggregation list (`getNetworkGraph` → `NetworkEndpointRow`) to a **per-request table + detail pane**, backed by the daemon's per-request network **resource** rather than the aggregated tool.

## How

- **New `NetworkRequestsDataSource`** (interface + `FakeNetworkRequestsDataSource`), mirroring the existing `NetworkGraphDataSource`/`RealNetworkGraphDataSource` seam:
  - `getRequests()` reads `automobile:network/traffic?limit=N&deviceId=<id>` — **scoped to the pane's deviceId** — and projects the event summaries into `NetworkRequestRow` (id, method, host, path, status, duration, timestamp, contentType, error). Query keys are emitted in the daemon's registered template order (`limit` before `deviceId`) so the anchored template regex matches.
  - `getRequestDetail(id)` reads `automobile:network/request/{id}` for the request/response header maps + protocol/timing.
- **`NetworkFacet`** now renders a selectable request table (method · host/path · status · timing) beside a detail pane that lazily loads headers/timing for the selected row. Loading / empty / error states are preserved and everything is keyed on `column.deviceId`. The detail read is lazy per-selection and shows the summary immediately so the pane never blanks.

## Testing

- `RealNetworkRequestsDataSourceTest` (11 tests): traffic JSON → rows, deviceId scoping + exact URI, missing host/path/header coalescing, empty log, empty response, `{error}` surfaced as typed failure, detail header/timing parse, detail URI, no-clientProvider/no-deviceId errors.
- `NetworkFacetTest` (6 tests): empty state, row-per-request, select-row-shows-detail-with-headers, retryable error + retry recovery, detail-load failure surfaced inline without blanking.

All green via `:desktop-core:detektMain :desktop-core:test :desktop-app:compileKotlin`.

## Deferred (follow-ups, not built)

- Live streaming/subscription of new requests (this is a one-shot fetch of the latest N).
- The events strip / correlation timeline (frame 03 lower region).
- Request/response **bodies** in the detail pane (available in the resource; omitted from this first cut).

Closes [#4865](https://github.com/kaeawc/auto-mobile/issues/4865)
