### PR TITLE
feat(desktop): two-device compare — side-by-side inspectors + hierarchy diff

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FakeObservationStream.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FakeObservationStream.kt
@@ -98,4 +98,6 @@ class FakeObservationStream : ObservationStream {
   fun emitStorage(update: StorageStreamUpdate): Boolean = _storageUpdates.tryEmit(update)
 
   fun emitHierarchy(update: HierarchyStreamUpdate): Boolean = _hierarchyUpdates.tryEmit(update)
+
+  fun emitDeviceEvent(event: DeviceStreamEvent): Boolean = _deviceEvents.tryEmit(event)
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiff.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiff.kt
@@ -1,0 +1,135 @@
+package dev.jasonpearson.automobile.desktop.core.layout
+
+/**
+ * How a node in one hierarchy relates to the matching node (by structural key) in the other.
+ * - [OnlyInA] / [OnlyInB]: the key exists in exactly one tree.
+ * - [Changed]: the key exists in both, but a compared semantic attribute differs.
+ * - [Equal]: the key exists in both and all compared attributes match.
+ */
+enum class NodeDiffStatus {
+  OnlyInA,
+  OnlyInB,
+  Changed,
+  Equal,
+}
+
+/**
+ * One node's classification in a two-hierarchy diff. [key] is the stable structural path key (see
+ * [diffHierarchies]); [a] and [b] are the matched nodes, one of which is null for
+ * [NodeDiffStatus. OnlyInA]/[NodeDiffStatus.OnlyInB].
+ */
+data class HierarchyDiffEntry(
+  val key: String,
+  val status: NodeDiffStatus,
+  val a: UIElementInfo?,
+  val b: UIElementInfo?,
+)
+
+/**
+ * The result of diffing two view hierarchies. [entries] are deterministic: A's nodes in pre-order,
+ * then B-only nodes in B's pre-order. Convenience counters summarise the classification.
+ */
+data class HierarchyDiff(val entries: List<HierarchyDiffEntry>) {
+  val onlyInA: Int
+    get() = entries.count { it.status == NodeDiffStatus.OnlyInA }
+
+  val onlyInB: Int
+    get() = entries.count { it.status == NodeDiffStatus.OnlyInB }
+
+  val changed: Int
+    get() = entries.count { it.status == NodeDiffStatus.Changed }
+
+  val equal: Int
+    get() = entries.count { it.status == NodeDiffStatus.Equal }
+
+  val hasDifferences: Boolean
+    get() = onlyInA > 0 || onlyInB > 0 || changed > 0
+}
+
+private const val PATH_SEPARATOR = "/"
+
+/**
+ * Diff two view hierarchies into a flat, deterministic classification.
+ *
+ * Node identity is a **structural path key**: each node contributes the segment
+ * `className:resourceId#siblingIndex`, and a node's key is the `/`-joined chain of its ancestors'
+ * segments plus its own. Because every segment carries the sibling index, keys are unique within a
+ * tree, so matched keys pair the node at the same tree position across the two devices.
+ *
+ * Consequences of this first-cut identity (richer heuristics are deferred):
+ * - **Bounds are intentionally excluded** from the [NodeDiffStatus.Changed] test. Two devices
+ *   usually differ in resolution, so every node's geometry differs; comparing bounds would flag the
+ *   whole tree as changed and drown out the meaningful diffs. Only semantic attributes (text,
+ *   content-description, and the boolean state flags) are compared.
+ * - **Reordering is positional.** Swapping two siblings changes their sibling indexes, so the moved
+ *   nodes surface as `OnlyInA` + `OnlyInB` at the affected positions rather than as a move.
+ *
+ * The result is deterministic (stable pre-order) and symmetric in classification: `diffHierarchies(
+ * a, b)` and `diffHierarchies(b, a)` agree once A/B roles are swapped (an `OnlyInA` key in one is
+ * exactly an `OnlyInB` key in the other; `Changed`/`Equal` key sets are identical).
+ */
+fun diffHierarchies(a: UIElementInfo, b: UIElementInfo): HierarchyDiff {
+  val mapA = indexByPathKey(a)
+  val mapB = indexByPathKey(b)
+  val entries = ArrayList<HierarchyDiffEntry>(mapA.size + mapB.size)
+  for ((key, nodeA) in mapA) {
+    val nodeB = mapB[key]
+    entries.add(HierarchyDiffEntry(key, classifyMatched(nodeA, nodeB), nodeA, nodeB))
+  }
+  for ((key, nodeB) in mapB) {
+    if (!mapA.containsKey(key)) {
+      entries.add(HierarchyDiffEntry(key, NodeDiffStatus.OnlyInB, null, nodeB))
+    }
+  }
+  return HierarchyDiff(entries)
+}
+
+/** Classify a node from A against its same-key counterpart in B (null when absent from B). */
+private fun classifyMatched(nodeA: UIElementInfo, nodeB: UIElementInfo?): NodeDiffStatus =
+  when {
+    nodeB == null -> NodeDiffStatus.OnlyInA
+    nodeAttributesDiffer(nodeA, nodeB) -> NodeDiffStatus.Changed
+    else -> NodeDiffStatus.Equal
+  }
+
+/**
+ * Build a stable key -> node map in pre-order. Keys are unique within one tree by construction (the
+ * per-level sibling index disambiguates siblings, and the ancestor chain disambiguates subtrees).
+ */
+private fun indexByPathKey(root: UIElementInfo): LinkedHashMap<String, UIElementInfo> {
+  val map = LinkedHashMap<String, UIElementInfo>()
+  addSubtree(map, root, parentKey = "", siblingIndex = 0)
+  return map
+}
+
+private fun addSubtree(
+  map: LinkedHashMap<String, UIElementInfo>,
+  node: UIElementInfo,
+  parentKey: String,
+  siblingIndex: Int,
+) {
+  val key = pathKey(parentKey, node, siblingIndex)
+  map[key] = node
+  node.children.forEachIndexed { index, child -> addSubtree(map, child, key, index) }
+}
+
+private fun pathKey(parentKey: String, node: UIElementInfo, siblingIndex: Int): String {
+  val segment = "${node.className}:${node.resourceId ?: ""}#$siblingIndex"
+  return if (parentKey.isEmpty()) segment else "$parentKey$PATH_SEPARATOR$segment"
+}
+
+/**
+ * Whether two same-key nodes differ in a compared semantic attribute. Bounds and children are
+ * deliberately excluded (see [diffHierarchies]); className and resourceId are already equal because
+ * they are part of the key.
+ */
+private fun nodeAttributesDiffer(a: UIElementInfo, b: UIElementInfo): Boolean =
+  a.text != b.text ||
+    a.contentDescription != b.contentDescription ||
+    a.isClickable != b.isClickable ||
+    a.isEnabled != b.isEnabled ||
+    a.isFocused != b.isFocused ||
+    a.isSelected != b.isSelected ||
+    a.isScrollable != b.isScrollable ||
+    a.isCheckable != b.isCheckable ||
+    a.isChecked != b.isChecked

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TwoDeviceCompareView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TwoDeviceCompareView.kt
@@ -32,6 +32,8 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
+import dev.jasonpearson.automobile.desktop.core.daemon.DeviceStreamEvent
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
 import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
@@ -122,6 +124,12 @@ fun TwoDeviceCompareView(
  * One device's pane in the compare view. Owns a per-device [ObservationStream] with the same
  * connect/dispose lifecycle as [LayoutFacet], collects its hierarchy updates into a parsed tree
  * reported via [onHierarchy], and renders the pane body via [sideContent].
+ *
+ * Device loss and confirmed disconnection are surfaced out-of-band (via
+ * [ObservationStream. deviceEvents] and [ObservationStream.connectionState]), NOT as a null
+ * hierarchy update, so this side also watches those signals and clears its hierarchy (reports null)
+ * on loss/disconnect. Otherwise the last parsed hierarchy would linger and the still-live device
+ * would keep diffing against a stale snapshot forever.
  */
 @Composable
 private fun CompareSide(
@@ -146,6 +154,22 @@ private fun CompareSide(
       val json = update.data ?: return@collect
       val parsed = withContext(Dispatchers.Default) { parseHierarchyFromJson(json) }
       if (parsed != null) onHierarchy(parsed)
+    }
+  }
+  LaunchedEffect(activeStream) {
+    activeStream.deviceEvents.collect { event ->
+      when (event) {
+        // Device unplugged/offline: retire the snapshot so the diff shows "waiting" until a fresh
+        // frame arrives, rather than diffing the live device against a dead one's stale tree.
+        is DeviceStreamEvent.DeviceConnectionLost -> onHierarchy(null)
+      }
+    }
+  }
+  LaunchedEffect(activeStream) {
+    activeStream.connectionState.collect { state ->
+      // Only a confirmed disconnect clears; Connecting/Reconnecting/Error keep the last snapshot so
+      // a brief stream blip does not flush a still-valid hierarchy.
+      if (state is ConnectionState.Disconnected) onHierarchy(null)
     }
   }
   Box(modifier) { sideContent(column, activeStream) }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TwoDeviceCompareView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TwoDeviceCompareView.kt
@@ -1,0 +1,259 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
+import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
+import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
+import dev.jasonpearson.automobile.desktop.core.layout.HierarchyDiff
+import dev.jasonpearson.automobile.desktop.core.layout.HierarchyDiffEntry
+import dev.jasonpearson.automobile.desktop.core.layout.LayoutInspectorDashboard
+import dev.jasonpearson.automobile.desktop.core.layout.NodeDiffStatus
+import dev.jasonpearson.automobile.desktop.core.layout.ParsedHierarchy
+import dev.jasonpearson.automobile.desktop.core.layout.diffHierarchies
+import dev.jasonpearson.automobile.desktop.core.layout.parseHierarchyFromJson
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private val OnlyInAColor = Color(0xFF4CAF50) // green: present on the left device only
+private val OnlyInBColor = Color(0xFF4DABF7) // blue: present on the right device only
+private val ChangedColor = Color(0xFFFFC107) // amber: same position, differing attribute
+
+private const val DIFF_STRIP_HEIGHT_DP = 140
+
+/**
+ * First-cut two-device compare surface: the [columnA] and [columnB] Layout inspectors side by side
+ * (each with its own per-device observation stream, so panes never bleed into each other) over a
+ * [HierarchyDiffStrip] that classifies nodes present/absent/changed between the two devices' view
+ * hierarchies via the pure [diffHierarchies].
+ *
+ * Both the per-side stream and the per-side dashboard body are injected:
+ * - [observationStreamFactory] hands out a fresh [ObservationStream] per pane (defaulting to a real
+ *   per-device [ObservationStreamClient]), mirroring [LayoutFacet], so tests drive it with a
+ *   `FakeObservationStream`.
+ * - [sideContent] renders a pane's mirror + hierarchy (defaulting to [LayoutInspectorDashboard]); a
+ *   test can swap in a lightweight body so the diff strip can be asserted without the full
+ *   inspector.
+ *
+ * The diff itself is computed here from each stream's parsed hierarchy, independently of
+ * [sideContent], so it surfaces even when the side bodies are stubbed.
+ */
+@Composable
+fun TwoDeviceCompareView(
+  columnA: DeviceColumn,
+  columnB: DeviceColumn,
+  modifier: Modifier = Modifier,
+  observationStreamFactory: () -> ObservationStream = { ObservationStreamClient() },
+  sideContent: @Composable (DeviceColumn, ObservationStream) -> Unit = { column, stream ->
+    LayoutInspectorDashboard(
+      dataSourceMode = DataSourceMode.Real,
+      observationStream = stream,
+      deviceId = column.deviceId,
+      platform = if (column.platform == Platform.Ios) "ios" else "android",
+    )
+  },
+) {
+  var hierarchyA by remember(columnA.deviceId) { mutableStateOf<ParsedHierarchy?>(null) }
+  var hierarchyB by remember(columnB.deviceId) { mutableStateOf<ParsedHierarchy?>(null) }
+  val diff =
+    remember(hierarchyA, hierarchyB) {
+      val a = hierarchyA
+      val b = hierarchyB
+      if (a != null && b != null) diffHierarchies(a.root, b.root) else null
+    }
+
+  Column(modifier.fillMaxSize().semantics { contentDescription = "Two-device compare" }) {
+    Row(Modifier.weight(1f).fillMaxWidth()) {
+      CompareSide(
+        column = columnA,
+        observationStreamFactory = observationStreamFactory,
+        sideContent = sideContent,
+        onHierarchy = { hierarchyA = it },
+        modifier = Modifier.weight(1f).fillMaxHeight(),
+      )
+      CompareSide(
+        column = columnB,
+        observationStreamFactory = observationStreamFactory,
+        sideContent = sideContent,
+        onHierarchy = { hierarchyB = it },
+        modifier = Modifier.weight(1f).fillMaxHeight(),
+      )
+    }
+    HierarchyDiffStrip(
+      diff = diff,
+      labelA = columnA.name,
+      labelB = columnB.name,
+      modifier = Modifier.fillMaxWidth().height(DIFF_STRIP_HEIGHT_DP.dp),
+    )
+  }
+}
+
+/**
+ * One device's pane in the compare view. Owns a per-device [ObservationStream] with the same
+ * connect/dispose lifecycle as [LayoutFacet], collects its hierarchy updates into a parsed tree
+ * reported via [onHierarchy], and renders the pane body via [sideContent].
+ */
+@Composable
+private fun CompareSide(
+  column: DeviceColumn,
+  observationStreamFactory: () -> ObservationStream,
+  sideContent: @Composable (DeviceColumn, ObservationStream) -> Unit,
+  onHierarchy: (ParsedHierarchy?) -> Unit,
+  modifier: Modifier,
+) {
+  var stream by remember(column.deviceId) { mutableStateOf<ObservationStream?>(null) }
+  DisposableEffect(column.deviceId) {
+    val connected = observationStreamFactory().also { it.connect(deviceId = column.deviceId) }
+    stream = connected
+    onDispose {
+      connected.dispose()
+      stream = null
+    }
+  }
+  val activeStream = stream ?: return
+  LaunchedEffect(activeStream) {
+    activeStream.hierarchyUpdates.collect { update ->
+      val json = update.data ?: return@collect
+      val parsed = withContext(Dispatchers.Default) { parseHierarchyFromJson(json) }
+      if (parsed != null) onHierarchy(parsed)
+    }
+  }
+  Box(modifier) { sideContent(column, activeStream) }
+}
+
+/**
+ * The diff summary strip beneath the two panes: a one-line count summary plus a scrollable list of
+ * the differing nodes (equal nodes are omitted to keep the strip focused). Renders loading and
+ * matched states so a single-device or still-loading compare never shows an empty strip.
+ */
+@Composable
+private fun HierarchyDiffStrip(
+  diff: HierarchyDiff?,
+  labelA: String,
+  labelB: String,
+  modifier: Modifier,
+) {
+  Column(
+    modifier
+      .background(MaterialTheme.colorScheme.surface)
+      .padding(horizontal = 12.dp, vertical = 8.dp)
+      .semantics { contentDescription = "Hierarchy diff" }
+  ) {
+    if (diff == null) {
+      Text(
+        "Waiting for both device hierarchies…",
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    } else {
+      DiffSummaryLine(diff, labelA, labelB)
+      Spacer(Modifier.height(6.dp))
+      DiffEntryList(diff, labelA, labelB)
+    }
+  }
+}
+
+@Composable
+private fun DiffSummaryLine(diff: HierarchyDiff, labelA: String, labelB: String) {
+  Text(
+    "⧉ $labelA vs $labelB — +${diff.onlyInA} only in $labelA, " +
+      "-${diff.onlyInB} only in $labelB, ~${diff.changed} changed",
+    style = MaterialTheme.typography.labelLarge,
+    fontWeight = FontWeight.SemiBold,
+    maxLines = 1,
+    overflow = TextOverflow.Ellipsis,
+  )
+}
+
+@Composable
+private fun DiffEntryList(diff: HierarchyDiff, labelA: String, labelB: String) {
+  val differing = diff.entries.filter { it.status != NodeDiffStatus.Equal }
+  if (differing.isEmpty()) {
+    Text(
+      "Hierarchies match",
+      style = MaterialTheme.typography.labelMedium,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    return
+  }
+  Column(
+    Modifier.fillMaxWidth().verticalScroll(rememberScrollState()),
+    verticalArrangement = Arrangement.spacedBy(2.dp),
+  ) {
+    for (entry in differing) {
+      DiffEntryRow(entry, labelA, labelB)
+    }
+  }
+}
+
+@Composable
+private fun DiffEntryRow(entry: HierarchyDiffEntry, labelA: String, labelB: String) {
+  val description = diffRowDescription(entry, labelA, labelB)
+  Row(
+    modifier = Modifier.fillMaxWidth().semantics { contentDescription = description },
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Box(Modifier.size(10.dp).background(diffColor(entry.status)))
+    Spacer(Modifier.width(8.dp))
+    Text(
+      description,
+      style = MaterialTheme.typography.labelMedium,
+      maxLines = 1,
+      overflow = TextOverflow.Ellipsis,
+    )
+  }
+}
+
+private fun diffColor(status: NodeDiffStatus): Color =
+  when (status) {
+    NodeDiffStatus.OnlyInA -> OnlyInAColor
+    NodeDiffStatus.OnlyInB -> OnlyInBColor
+    NodeDiffStatus.Changed -> ChangedColor
+    NodeDiffStatus.Equal -> Color.Transparent
+  }
+
+private fun diffRowDescription(entry: HierarchyDiffEntry, labelA: String, labelB: String): String {
+  val node = entry.a ?: entry.b
+  val label =
+    node?.resourceId?.takeIf { it.isNotBlank() }
+      ?: node?.text?.takeIf { it.isNotBlank() }
+      ?: node?.contentDescription?.takeIf { it.isNotBlank() }
+      ?: node?.className
+      ?: "node"
+  return when (entry.status) {
+    NodeDiffStatus.OnlyInA -> "Only in $labelA: $label"
+    NodeDiffStatus.OnlyInB -> "Only in $labelB: $label"
+    NodeDiffStatus.Changed -> "Changed: $label"
+    NodeDiffStatus.Equal -> label
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TwoDeviceCompareView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TwoDeviceCompareView.kt
@@ -13,8 +13,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -44,8 +44,10 @@ import dev.jasonpearson.automobile.desktop.core.layout.NodeDiffStatus
 import dev.jasonpearson.automobile.desktop.core.layout.ParsedHierarchy
 import dev.jasonpearson.automobile.desktop.core.layout.diffHierarchies
 import dev.jasonpearson.automobile.desktop.core.layout.parseHierarchyFromJson
+import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.JsonElement
 
 private val OnlyInAColor = Color(0xFF4CAF50) // green: present on the left device only
 private val OnlyInBColor = Color(0xFF4DABF7) // blue: present on the right device only
@@ -84,6 +86,11 @@ fun TwoDeviceCompareView(
       platform = if (column.platform == Platform.Ios) "ios" else "android",
     )
   },
+  // Parses a hierarchy stream frame off the main thread. Injected so a test can deterministically
+  // interleave a slow parse with a device-loss to exercise the stale-restore guard.
+  parseHierarchy: suspend (JsonElement) -> ParsedHierarchy? = { json ->
+    withContext(Dispatchers.Default) { parseHierarchyFromJson(json) }
+  },
 ) {
   var hierarchyA by remember(columnA.deviceId) { mutableStateOf<ParsedHierarchy?>(null) }
   var hierarchyB by remember(columnB.deviceId) { mutableStateOf<ParsedHierarchy?>(null) }
@@ -100,6 +107,7 @@ fun TwoDeviceCompareView(
         column = columnA,
         observationStreamFactory = observationStreamFactory,
         sideContent = sideContent,
+        parseHierarchy = parseHierarchy,
         onHierarchy = { hierarchyA = it },
         modifier = Modifier.weight(1f).fillMaxHeight(),
       )
@@ -107,6 +115,7 @@ fun TwoDeviceCompareView(
         column = columnB,
         observationStreamFactory = observationStreamFactory,
         sideContent = sideContent,
+        parseHierarchy = parseHierarchy,
         onHierarchy = { hierarchyB = it },
         modifier = Modifier.weight(1f).fillMaxHeight(),
       )
@@ -130,12 +139,19 @@ fun TwoDeviceCompareView(
  * hierarchy update, so this side also watches those signals and clears its hierarchy (reports null)
  * on loss/disconnect. Otherwise the last parsed hierarchy would linger and the still-live device
  * would keep diffing against a stale snapshot forever.
+ *
+ * A per-side **connection-generation** token closes the parse-vs-clear race: [parseHierarchy]
+ * suspends, so a clear can land while a parse is in flight. Each clear bumps the generation; a
+ * parse captures the generation before it starts and applies its result only if the generation is
+ * unchanged on completion, so a parse that resumes after a clear is discarded rather than restoring
+ * the dead device's stale snapshot.
  */
 @Composable
 private fun CompareSide(
   column: DeviceColumn,
   observationStreamFactory: () -> ObservationStream,
   sideContent: @Composable (DeviceColumn, ObservationStream) -> Unit,
+  parseHierarchy: suspend (JsonElement) -> ParsedHierarchy?,
   onHierarchy: (ParsedHierarchy?) -> Unit,
   modifier: Modifier,
 ) {
@@ -149,11 +165,19 @@ private fun CompareSide(
     }
   }
   val activeStream = stream ?: return
+  // Reset per stream instance; a reconnect creates a fresh stream and thus a fresh token.
+  val generation = remember(activeStream) { AtomicInteger(0) }
+  val clearHierarchy = {
+    generation.incrementAndGet()
+    onHierarchy(null)
+  }
   LaunchedEffect(activeStream) {
     activeStream.hierarchyUpdates.collect { update ->
       val json = update.data ?: return@collect
-      val parsed = withContext(Dispatchers.Default) { parseHierarchyFromJson(json) }
-      if (parsed != null) onHierarchy(parsed)
+      val launchGeneration = generation.get()
+      val parsed = parseHierarchy(json)
+      // Drop a result whose generation was invalidated by a clear while the parse was suspended.
+      if (parsed != null && generation.get() == launchGeneration) onHierarchy(parsed)
     }
   }
   LaunchedEffect(activeStream) {
@@ -161,7 +185,7 @@ private fun CompareSide(
       when (event) {
         // Device unplugged/offline: retire the snapshot so the diff shows "waiting" until a fresh
         // frame arrives, rather than diffing the live device against a dead one's stale tree.
-        is DeviceStreamEvent.DeviceConnectionLost -> onHierarchy(null)
+        is DeviceStreamEvent.DeviceConnectionLost -> clearHierarchy()
       }
     }
   }
@@ -169,7 +193,7 @@ private fun CompareSide(
     activeStream.connectionState.collect { state ->
       // Only a confirmed disconnect clears; Connecting/Reconnecting/Error keep the last snapshot so
       // a brief stream blip does not flush a still-valid hierarchy.
-      if (state is ConnectionState.Disconnected) onHierarchy(null)
+      if (state is ConnectionState.Disconnected) clearHierarchy()
     }
   }
   Box(modifier) { sideContent(column, activeStream) }
@@ -230,13 +254,16 @@ private fun DiffEntryList(diff: HierarchyDiff, labelA: String, labelB: String) {
     )
     return
   }
-  Column(
-    Modifier.fillMaxWidth().verticalScroll(rememberScrollState()),
+  // LazyColumn (not a scrolling Column) so only the visible rows compose/measure: a live diff can
+  // carry hundreds of differing nodes and a plain Column would build every offscreen row per
+  // update.
+  // Entry keys are unique within a diff (A's keys plus disjoint B-only keys), so they are stable
+  // item keys.
+  LazyColumn(
+    Modifier.fillMaxWidth().fillMaxHeight(),
     verticalArrangement = Arrangement.spacedBy(2.dp),
   ) {
-    for (entry in differing) {
-      DiffEntryRow(entry, labelA, labelB)
-    }
+    items(differing, key = { it.key }) { entry -> DiffEntryRow(entry, labelA, labelB) }
   }
 }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -145,17 +145,26 @@ fun WorkspaceShell(
 }
 
 /**
- * Pick the two device columns to compare: the focused column plus the first other observed column.
- * Returns null when fewer than two devices are observed, so the ⧉ Compare entry stays hidden and
- * the overlay never opens with an incomplete pair. If more than two devices are observed, only the
- * focused device and one other are compared (N-way compare is deferred).
+ * Pick the two device columns to compare: the focused column plus the first other observed column
+ * **of the same platform**. Returns null when there is no same-platform second device, so the ⧉
+ * Compare entry stays hidden and the overlay never opens with an incomparable pair. If more than
+ * two same-platform devices are observed, only the focused device and one other are compared (N-way
+ * compare is deferred).
+ *
+ * Same-platform only because the structural diff key embeds `className`, which is platform-specific
+ * (`android.widget.FrameLayout` vs `XCUIElementTypeApplication`): an Android-to-iOS pair would
+ * share no keys and every node would read as only-in-one, a meaningless diff. Cross-platform
+ * structural-role normalization is deferred to issue #4872.
  */
 internal fun compareColumns(content: WorkspaceUiState.Content): Pair<DeviceColumn, DeviceColumn>? {
-  if (content.columns.size < 2) return null
   val focused =
     content.columns.firstOrNull { it.deviceId == content.focusedDeviceId }
-      ?: content.columns.first()
-  val other = content.columns.firstOrNull { it.deviceId != focused.deviceId } ?: return null
+      ?: content.columns.firstOrNull()
+      ?: return null
+  val other =
+    content.columns.firstOrNull {
+      it.deviceId != focused.deviceId && it.platform == focused.platform
+    } ?: return null
   return focused to other
 }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -80,8 +80,18 @@ fun WorkspaceShell(
   // Body of the health sheet opened by clicking the status dot. Hoisted like [facetContent] so the
   // host (or a test) can substitute content; defaults to the live [DiagnosticsDashboard].
   healthSheetContent: @Composable () -> Unit = { DefaultHealthSheetBody() },
+  // Two-device compare surface opened by the top-bar ⧉ Compare glyph. Hoisted like the other bodies
+  // so a test can assert routing without opening real streams; defaults to [TwoDeviceCompareView].
+  compareContent: @Composable (DeviceColumn, DeviceColumn) -> Unit = { a, b ->
+    TwoDeviceCompareView(columnA = a, columnB = b)
+  },
 ) {
   var showHealthSheet by remember { mutableStateOf(false) }
+  var showCompare by remember { mutableStateOf(false) }
+  val comparePair = (state as? WorkspaceUiState.Content)?.let(::compareColumns)
+  // A pane closing can drop the observed count below two; retire any open compare so it can't
+  // linger with a stale pair.
+  if (comparePair == null && showCompare) showCompare = false
   Box(modifier.fillMaxSize()) {
     Column(Modifier.fillMaxSize()) {
       TopBar(
@@ -90,6 +100,8 @@ fun WorkspaceShell(
         onOpenPicker = onOpenPicker,
         onOpenPalette = onOpenPalette,
         onStatusClick = { showHealthSheet = true },
+        canCompare = comparePair != null,
+        onCompare = { showCompare = true },
       )
       when (state) {
         is WorkspaceUiState.Empty -> EmptyState(onOpenPicker, Modifier.weight(1f).fillMaxWidth())
@@ -121,7 +133,30 @@ fun WorkspaceShell(
         content = healthSheetContent,
       )
     }
+    if (showCompare && comparePair != null) {
+      CompareOverlay(
+        columnA = comparePair.first,
+        columnB = comparePair.second,
+        onDismiss = { showCompare = false },
+        content = compareContent,
+      )
+    }
   }
+}
+
+/**
+ * Pick the two device columns to compare: the focused column plus the first other observed column.
+ * Returns null when fewer than two devices are observed, so the ⧉ Compare entry stays hidden and
+ * the overlay never opens with an incomplete pair. If more than two devices are observed, only the
+ * focused device and one other are compared (N-way compare is deferred).
+ */
+internal fun compareColumns(content: WorkspaceUiState.Content): Pair<DeviceColumn, DeviceColumn>? {
+  if (content.columns.size < 2) return null
+  val focused =
+    content.columns.firstOrNull { it.deviceId == content.focusedDeviceId }
+      ?: content.columns.first()
+  val other = content.columns.firstOrNull { it.deviceId != focused.deviceId } ?: return null
+  return focused to other
 }
 
 @Composable
@@ -131,6 +166,8 @@ private fun TopBar(
   onOpenPicker: () -> Unit,
   onOpenPalette: () -> Unit,
   onStatusClick: () -> Unit,
+  canCompare: Boolean,
+  onCompare: () -> Unit,
 ) {
   Row(
     modifier =
@@ -151,6 +188,20 @@ private fun TopBar(
       Text("  +", color = Accent, fontWeight = FontWeight.Bold)
     }
     Spacer(Modifier.weight(1f))
+    // ⧉ Compare opens the two-device hierarchy-diff surface; only meaningful with >1 device, so it
+    // is shown only when at least two devices are observed.
+    if (canCompare) {
+      Text(
+        "⧉",
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier =
+          Modifier.clickable { onCompare() }
+            .semantics { contentDescription = "Compare two devices" }
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+      )
+      Spacer(Modifier.width(8.dp))
+    }
     // Quick-jump command palette (⌘K).
     Text(
       "⌘K",
@@ -245,6 +296,63 @@ private fun HealthSheetOverlay(onDismiss: () -> Unit, content: @Composable () ->
       // Constrain the body to the height below the title row so a fillMaxSize() body can't overflow
       // the header out of the panel.
       Box(Modifier.weight(1f).fillMaxWidth()) { content() }
+    }
+  }
+}
+
+/**
+ * Full-window overlay hosting the two-device compare surface: a dimmed scrim (click-away to
+ * dismiss) with a large centered panel that renders [content] for the chosen [columnA]/[columnB].
+ * Mirrors [HealthSheetOverlay]; sized larger because it hosts two device panes side by side.
+ */
+@Composable
+private fun CompareOverlay(
+  columnA: DeviceColumn,
+  columnB: DeviceColumn,
+  onDismiss: () -> Unit,
+  content: @Composable (DeviceColumn, DeviceColumn) -> Unit,
+) {
+  Box(
+    modifier =
+      Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.5f)).clickable(
+        interactionSource = remember { MutableInteractionSource() },
+        indication = null,
+      ) {
+        onDismiss()
+      },
+    contentAlignment = Alignment.Center,
+  ) {
+    Column(
+      modifier =
+        Modifier.fillMaxWidth(0.95f)
+          .fillMaxHeight(0.9f)
+          .background(MaterialTheme.colorScheme.surface, RoundedCornerShape(12.dp))
+          // Swallow clicks on the panel so they don't dismiss via the scrim.
+          .clickable(
+            interactionSource = remember { MutableInteractionSource() },
+            indication = null,
+          ) {}
+          .padding(16.dp)
+          .semantics { contentDescription = "Compare devices" }
+    ) {
+      Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        Text(
+          "Compare — ${columnA.name} vs ${columnB.name}",
+          style = MaterialTheme.typography.titleMedium,
+        )
+        Spacer(Modifier.weight(1f))
+        Text(
+          "✕",
+          style = MaterialTheme.typography.titleMedium,
+          color = MaterialTheme.colorScheme.onSurface,
+          modifier =
+            Modifier.clickable { onDismiss() }
+              .semantics { contentDescription = "Close compare" }
+              .padding(horizontal = 8.dp, vertical = 4.dp),
+        )
+      }
+      Spacer(Modifier.height(8.dp))
+      Box(Modifier.weight(1f).fillMaxWidth()) { content(columnA, columnB) }
     }
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt
@@ -181,6 +181,42 @@ class HierarchyDiffTest {
   }
 
   @Test
+  fun `same-platform trees with realistic class names yield a mixed non-disjoint diff`() {
+    // Real Android class names on BOTH sides: the shared structure matches by key, so the diff is a
+    // meaningful mix of equal/changed/only-in rather than the all-disjoint result a cross-platform
+    // pair (android.widget.* vs XCUIElementType*) would produce.
+    val a =
+      node(
+        "android.widget.FrameLayout",
+        "content",
+        children =
+          listOf(
+            node("android.widget.TextView", "title", text = "Home"),
+            node("android.widget.Button", "submit", isClickable = true),
+          ),
+      )
+    val b =
+      node(
+        "android.widget.FrameLayout",
+        "content",
+        children =
+          listOf(
+            node("android.widget.TextView", "title", text = "Home"), // equal
+            node("android.widget.Button", "submit", isClickable = false), // changed flag
+            node("android.widget.ProgressBar", "loading"), // only in B
+          ),
+      )
+    val diff = diffHierarchies(a, b)
+
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "TextView:title"))
+    assertEquals(NodeDiffStatus.Changed, statusOf(diff, "Button:submit"))
+    assertEquals(NodeDiffStatus.OnlyInB, statusOf(diff, "ProgressBar:loading"))
+    assertEquals(0, diff.onlyInA)
+    // Not all-disjoint: the shared FrameLayout + TextView remain equal.
+    assertTrue(diff.equal >= 2)
+  }
+
+  @Test
   fun `entries preorder lists A nodes before B-only nodes`() {
     val a = node("Root", "root", children = listOf(node("A", "a")))
     val b = node("Root", "root", children = listOf(node("A", "a"), node("Bonly", "bo")))

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/layout/HierarchyDiffTest.kt
@@ -1,0 +1,193 @@
+package dev.jasonpearson.automobile.desktop.core.layout
+
+import dev.jasonpearson.automobile.desktop.domain.ElementBounds
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Pure, fast tests for the structural hierarchy diff. No Compose, no I/O. */
+class HierarchyDiffTest {
+
+  private fun node(
+    className: String,
+    resourceId: String? = null,
+    text: String? = null,
+    contentDescription: String? = null,
+    bounds: ElementBounds = ElementBounds(0, 0, 10, 10),
+    isClickable: Boolean = false,
+    isChecked: Boolean = false,
+    children: List<UIElementInfo> = emptyList(),
+  ): UIElementInfo =
+    UIElementInfo(
+      id = "$className:${resourceId ?: ""}:${text ?: ""}",
+      className = className,
+      resourceId = resourceId,
+      text = text,
+      contentDescription = contentDescription,
+      bounds = bounds,
+      isClickable = isClickable,
+      isEnabled = true,
+      isFocused = false,
+      isSelected = false,
+      isScrollable = false,
+      isCheckable = false,
+      isChecked = isChecked,
+      children = children,
+      depth = 0,
+    )
+
+  private fun statusOf(diff: HierarchyDiff, keySubstring: String): NodeDiffStatus? =
+    diff.entries.firstOrNull { it.key.contains(keySubstring) }?.status
+
+  @Test
+  fun `identical trees are all equal`() {
+    val tree = node("Root", "root", children = listOf(node("Text", "title", text = "Hello")))
+    val diff = diffHierarchies(tree, tree)
+
+    assertEquals(0, diff.onlyInA)
+    assertEquals(0, diff.onlyInB)
+    assertEquals(0, diff.changed)
+    assertEquals(2, diff.equal)
+    assertFalse(diff.hasDifferences)
+  }
+
+  @Test
+  fun `node present only in A is classified OnlyInA`() {
+    val a =
+      node(
+        "Root",
+        "root",
+        children = listOf(node("Text", "title", text = "Hi"), node("Button", "extra")),
+      )
+    val b = node("Root", "root", children = listOf(node("Text", "title", text = "Hi")))
+    val diff = diffHierarchies(a, b)
+
+    assertEquals(1, diff.onlyInA)
+    assertEquals(0, diff.onlyInB)
+    assertEquals(NodeDiffStatus.OnlyInA, statusOf(diff, "Button:extra"))
+    assertTrue(diff.hasDifferences)
+  }
+
+  @Test
+  fun `node present only in B is classified OnlyInB`() {
+    val a = node("Root", "root", children = listOf(node("Text", "title", text = "Hi")))
+    val b =
+      node(
+        "Root",
+        "root",
+        children = listOf(node("Text", "title", text = "Hi"), node("Button", "extra")),
+      )
+    val diff = diffHierarchies(a, b)
+
+    assertEquals(0, diff.onlyInA)
+    assertEquals(1, diff.onlyInB)
+    assertEquals(NodeDiffStatus.OnlyInB, statusOf(diff, "Button:extra"))
+  }
+
+  @Test
+  fun `same-position node with changed text is Changed`() {
+    val a = node("Root", "root", children = listOf(node("Text", "title", text = "Hi")))
+    val b = node("Root", "root", children = listOf(node("Text", "title", text = "Bye")))
+    val diff = diffHierarchies(a, b)
+
+    assertEquals(NodeDiffStatus.Changed, statusOf(diff, "Text:title"))
+    assertEquals(0, diff.onlyInA)
+    assertEquals(0, diff.onlyInB)
+    assertEquals(1, diff.changed)
+  }
+
+  @Test
+  fun `changed boolean state flag is Changed`() {
+    val a = node("Root", "root", children = listOf(node("Box", "toggle", isChecked = false)))
+    val b = node("Root", "root", children = listOf(node("Box", "toggle", isChecked = true)))
+    val diff = diffHierarchies(a, b)
+
+    assertEquals(NodeDiffStatus.Changed, statusOf(diff, "Box:toggle"))
+  }
+
+  @Test
+  fun `differing bounds alone do not mark a node Changed`() {
+    // Two devices with different resolutions: geometry differs but structure and semantics match.
+    val a = node("Root", "root", bounds = ElementBounds(0, 0, 1080, 1920))
+    val b = node("Root", "root", bounds = ElementBounds(0, 0, 1440, 3120))
+    val diff = diffHierarchies(a, b)
+
+    assertEquals(NodeDiffStatus.Equal, statusOf(diff, "Root:root"))
+    assertFalse(diff.hasDifferences)
+  }
+
+  @Test
+  fun `reordered siblings surface positionally as OnlyInA and OnlyInB`() {
+    val a = node("Root", "root", children = listOf(node("A", "a"), node("B", "b")))
+    val b = node("Root", "root", children = listOf(node("B", "b"), node("A", "a")))
+    val diff = diffHierarchies(a, b)
+
+    // Positional identity: A#0 vs B#0 and A#1 vs B#1 differ by className (part of key),
+    // so each position has one node only-in-A and one only-in-B. No move detection (deferred).
+    assertEquals(2, diff.onlyInA)
+    assertEquals(2, diff.onlyInB)
+    assertEquals(0, diff.changed)
+  }
+
+  @Test
+  fun `siblings sharing a resource-id are disambiguated by index`() {
+    // RecyclerView-style rows commonly share a resource-id; the index keeps keys unique.
+    val row = { t: String -> node("Row", "item", text = t) }
+    val a = node("List", "list", children = listOf(row("one"), row("two")))
+    val b = node("List", "list", children = listOf(row("one"), row("two")))
+    val diff = diffHierarchies(a, b)
+
+    assertEquals(3, diff.equal) // list + 2 rows
+    assertEquals(0, diff.changed)
+    // Distinct keys for the two same-resource-id rows.
+    assertEquals(diff.entries.size, diff.entries.map { it.key }.toSet().size)
+  }
+
+  @Test
+  fun `classification is symmetric when A and B are swapped`() {
+    val a =
+      node(
+        "Root",
+        "root",
+        children = listOf(node("Text", "title", text = "Hi"), node("OnlyA", "oa")),
+      )
+    val b =
+      node(
+        "Root",
+        "root",
+        children = listOf(node("Text", "title", text = "Bye"), node("OnlyB", "ob")),
+      )
+    val ab = diffHierarchies(a, b)
+    val ba = diffHierarchies(b, a)
+
+    fun keys(diff: HierarchyDiff, status: NodeDiffStatus) =
+      diff.entries.filter { it.status == status }.map { it.key }.toSet()
+
+    assertEquals(keys(ab, NodeDiffStatus.OnlyInA), keys(ba, NodeDiffStatus.OnlyInB))
+    assertEquals(keys(ab, NodeDiffStatus.OnlyInB), keys(ba, NodeDiffStatus.OnlyInA))
+    assertEquals(keys(ab, NodeDiffStatus.Changed), keys(ba, NodeDiffStatus.Changed))
+    assertEquals(keys(ab, NodeDiffStatus.Equal), keys(ba, NodeDiffStatus.Equal))
+  }
+
+  @Test
+  fun `diff is deterministic across repeated runs`() {
+    val a = node("Root", "root", children = listOf(node("A", "a"), node("B", "b"), node("C", "c")))
+    val b = node("Root", "root", children = listOf(node("A", "a"), node("C", "c")))
+
+    val first = diffHierarchies(a, b).entries.map { it.key to it.status }
+    val second = diffHierarchies(a, b).entries.map { it.key to it.status }
+    assertEquals(first, second)
+  }
+
+  @Test
+  fun `entries preorder lists A nodes before B-only nodes`() {
+    val a = node("Root", "root", children = listOf(node("A", "a")))
+    val b = node("Root", "root", children = listOf(node("A", "a"), node("Bonly", "bo")))
+    val entries = diffHierarchies(a, b).entries
+
+    // Root, then A (both from A's pre-order), then the B-only node appended last.
+    assertEquals(NodeDiffStatus.OnlyInB, entries.last().status)
+    assertTrue(entries.last().key.contains("Bonly:bo"))
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TwoDeviceCompareViewTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TwoDeviceCompareViewTest.kt
@@ -4,9 +4,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.daemon.DeviceStreamEvent
 import dev.jasonpearson.automobile.desktop.core.daemon.FakeObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.HierarchyStreamUpdate
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
@@ -123,4 +125,40 @@ class TwoDeviceCompareViewTest {
     onNodeWithContentDescription("Only in Pixel: onlyA").assertExists()
     onNodeWithContentDescription("Only in iPhone: onlyB").assertExists()
   }
+
+  @Test
+  fun `device loss on one side clears its hierarchy so no stale diff persists`() =
+    runComposeUiTest {
+      val fakeA = FakeObservationStream()
+      val fakeB = FakeObservationStream()
+      setContent {
+        MaterialTheme {
+          TwoDeviceCompareView(
+            columnA = columnA(),
+            columnB = columnB(),
+            observationStreamFactory = QueuedStreamFactory(fakeA, fakeB),
+            sideContent = { column, _ -> Text(column.name) },
+          )
+        }
+      }
+      emit(fakeA, "dev-a", "onlyA")
+      emit(fakeB, "dev-b", "onlyB")
+      waitUntil {
+        onAllNodesWithContentDescription("Only in Pixel: onlyA").fetchSemanticsNodes().isNotEmpty()
+      }
+
+      // Device loss arrives out-of-band as a deviceEvent, not a null hierarchy update: side A must
+      // clear so the diff retires instead of comparing the live device against a stale snapshot.
+      runOnIdle {
+        fakeA.emitDeviceEvent(
+          DeviceStreamEvent.DeviceConnectionLost("dev-a", 2L, "connection lost")
+        )
+      }
+      waitUntil {
+        onAllNodesWithText("Waiting for both device hierarchies", substring = true)
+          .fetchSemanticsNodes()
+          .isNotEmpty()
+      }
+      onNodeWithContentDescription("Only in Pixel: onlyA").assertDoesNotExist()
+    }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TwoDeviceCompareViewTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TwoDeviceCompareViewTest.kt
@@ -12,6 +12,8 @@ import dev.jasonpearson.automobile.desktop.core.daemon.DeviceStreamEvent
 import dev.jasonpearson.automobile.desktop.core.daemon.FakeObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.HierarchyStreamUpdate
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
+import dev.jasonpearson.automobile.desktop.core.layout.parseHierarchyFromJson
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import org.junit.Assert.assertEquals
@@ -160,5 +162,48 @@ class TwoDeviceCompareViewTest {
           .isNotEmpty()
       }
       onNodeWithContentDescription("Only in Pixel: onlyA").assertDoesNotExist()
+    }
+
+  @Test
+  fun `device loss during an in-flight parse does not restore the stale hierarchy`() =
+    runComposeUiTest {
+      val fakeA = FakeObservationStream()
+      val fakeB = FakeObservationStream()
+      // Gates ONLY side A's parse so it is suspended in flight when the device is lost.
+      val gate = CompletableDeferred<Unit>()
+      setContent {
+        MaterialTheme {
+          TwoDeviceCompareView(
+            columnA = columnA(),
+            columnB = columnB(),
+            observationStreamFactory = QueuedStreamFactory(fakeA, fakeB),
+            sideContent = { column, _ -> Text(column.name) },
+            parseHierarchy = { json ->
+              if (json.toString().contains("gated")) gate.await()
+              parseHierarchyFromJson(json)
+            },
+          )
+        }
+      }
+      // B parses immediately; A's parse suspends on the gate.
+      emit(fakeB, "dev-b", "onlyB")
+      emit(fakeA, "dev-a", "gated")
+      waitForIdle()
+
+      // Device A is lost while its parse is still suspended: the clear bumps A's generation.
+      runOnIdle {
+        fakeA.emitDeviceEvent(
+          DeviceStreamEvent.DeviceConnectionLost("dev-a", 2L, "connection lost")
+        )
+      }
+      waitForIdle()
+
+      // Let the stale parse complete; its result must be discarded (generation changed), so A's
+      // snapshot is never restored and the diff stays in the waiting state.
+      runOnIdle { gate.complete(Unit) }
+      waitForIdle()
+
+      onNodeWithText("Waiting for both device hierarchies", substring = true).assertExists()
+      onNodeWithContentDescription("Only in Pixel: gated").assertDoesNotExist()
     }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TwoDeviceCompareViewTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/TwoDeviceCompareViewTest.kt
@@ -1,0 +1,126 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.daemon.FakeObservationStream
+import dev.jasonpearson.automobile.desktop.core.daemon.HierarchyStreamUpdate
+import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class TwoDeviceCompareViewTest {
+
+  /** Hands out queued fakes in order so the two sides get distinct, addressable streams. */
+  private class QueuedStreamFactory(vararg fakes: FakeObservationStream) : () -> ObservationStream {
+    val created = fakes.toList()
+    private var index = 0
+
+    override fun invoke(): ObservationStream = created[index++]
+  }
+
+  private fun columnA() =
+    DeviceColumn(deviceId = "dev-a", name = "Pixel", platform = Platform.Android)
+
+  private fun columnB() = DeviceColumn(deviceId = "dev-b", name = "iPhone", platform = Platform.Ios)
+
+  /**
+   * A minimal two-child hierarchy: a shared `title` node plus a second child whose resource-id
+   * distinguishes the two devices, yielding one only-in-A and one only-in-B node in the diff.
+   */
+  private fun hierarchyJson(secondChildResourceId: String): JsonElement {
+    val raw =
+      """
+      {"hierarchy":{"node":{
+        "class":"android.widget.FrameLayout","resource-id":"root",
+        "bounds":{"left":0,"top":0,"right":100,"bottom":200},
+        "node":[
+          {"class":"android.widget.TextView","resource-id":"title","text":"Hi",
+           "bounds":{"left":0,"top":0,"right":50,"bottom":20}},
+          {"class":"android.widget.Button","resource-id":"$secondChildResourceId",
+           "bounds":{"left":0,"top":30,"right":50,"bottom":60}}
+        ]
+      }}}
+      """
+        .trimIndent()
+    return Json.parseToJsonElement(raw)
+  }
+
+  private fun emit(fake: FakeObservationStream, deviceId: String, resourceId: String) {
+    fake.emitHierarchy(
+      HierarchyStreamUpdate(deviceId = deviceId, timestamp = 1L, data = hierarchyJson(resourceId))
+    )
+  }
+
+  @Test
+  fun `each side connects its own stream scoped to its device`() = runComposeUiTest {
+    val fakeA = FakeObservationStream()
+    val fakeB = FakeObservationStream()
+    setContent {
+      MaterialTheme {
+        TwoDeviceCompareView(
+          columnA = columnA(),
+          columnB = columnB(),
+          observationStreamFactory = QueuedStreamFactory(fakeA, fakeB),
+          sideContent = { column, _ -> Text(column.name) },
+        )
+      }
+    }
+    waitForIdle()
+    assertEquals("dev-a", fakeA.lastConnectedDeviceId)
+    assertEquals("dev-b", fakeB.lastConnectedDeviceId)
+    assertEquals(1, fakeA.connectCallCount)
+    assertEquals(1, fakeB.connectCallCount)
+  }
+
+  @Test
+  fun `waits for both hierarchies before showing a diff`() = runComposeUiTest {
+    val fakeA = FakeObservationStream()
+    val fakeB = FakeObservationStream()
+    setContent {
+      MaterialTheme {
+        TwoDeviceCompareView(
+          columnA = columnA(),
+          columnB = columnB(),
+          observationStreamFactory = QueuedStreamFactory(fakeA, fakeB),
+          sideContent = { column, _ -> Text(column.name) },
+        )
+      }
+    }
+    // Only one side has reported: the strip stays in its loading state.
+    emit(fakeA, "dev-a", "onlyA")
+    waitForIdle()
+    onNodeWithText("Waiting for both device hierarchies", substring = true).assertExists()
+  }
+
+  @Test
+  fun `surfaces only-in-A and only-in-B nodes once both hierarchies arrive`() = runComposeUiTest {
+    val fakeA = FakeObservationStream()
+    val fakeB = FakeObservationStream()
+    setContent {
+      MaterialTheme {
+        TwoDeviceCompareView(
+          columnA = columnA(),
+          columnB = columnB(),
+          observationStreamFactory = QueuedStreamFactory(fakeA, fakeB),
+          sideContent = { column, _ -> Text(column.name) },
+        )
+      }
+    }
+    emit(fakeA, "dev-a", "onlyA")
+    emit(fakeB, "dev-b", "onlyB")
+
+    waitUntil {
+      onAllNodesWithContentDescription("Only in Pixel: onlyA").fetchSemanticsNodes().isNotEmpty()
+    }
+    onNodeWithContentDescription("Only in Pixel: onlyA").assertExists()
+    onNodeWithContentDescription("Only in iPhone: onlyB").assertExists()
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceCompareEntryTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceCompareEntryTest.kt
@@ -26,16 +26,46 @@ class WorkspaceCompareEntryTest {
   }
 
   @Test
-  fun `compareColumns pairs the focused device with the first other`() {
+  fun `compareColumns pairs the focused device with the first same-platform other`() {
     val content =
       WorkspaceUiState.Content(
-        columns = listOf(col("a", "Pixel"), col("b", "iPhone"), col("c", "Tab")),
-        focusedDeviceId = "b",
+        columns =
+          listOf(
+            col("a", "Pixel", Platform.Android),
+            col("b", "iPhone", Platform.Ios),
+            col("c", "Tab", Platform.Android),
+          ),
+        focusedDeviceId = "a",
       )
     val pair = compareColumns(content)
-    assertEquals("b", pair?.first?.deviceId)
-    assertEquals("a", pair?.second?.deviceId)
+    // Skips the iOS device b (cross-platform diff is meaningless) and pairs with the Android c.
+    assertEquals("a", pair?.first?.deviceId)
+    assertEquals("c", pair?.second?.deviceId)
   }
+
+  @Test
+  fun `compareColumns is null when the only other device is a different platform`() {
+    val content =
+      WorkspaceUiState.Content(
+        columns = listOf(col("a", "Pixel", Platform.Android), col("b", "iPhone", Platform.Ios)),
+        focusedDeviceId = "a",
+      )
+    assertNull(compareColumns(content))
+  }
+
+  @Test
+  fun `compare glyph is hidden when the only other device is a different platform`() =
+    runComposeUiTest {
+      val state =
+        WorkspaceUiState.Content(
+          columns = listOf(col("a", "Pixel", Platform.Android), col("b", "iPhone", Platform.Ios)),
+          focusedDeviceId = "a",
+        )
+      setContent {
+        MaterialTheme { WorkspaceShell(state = state, onAction = {}, onOpenPicker = {}) }
+      }
+      onNodeWithContentDescription("Compare two devices").assertDoesNotExist()
+    }
 
   @Test
   fun `compare glyph is hidden with a single device`() = runComposeUiTest {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceCompareEntryTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceCompareEntryTest.kt
@@ -1,0 +1,94 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class WorkspaceCompareEntryTest {
+
+  private fun col(id: String, name: String, platform: Platform = Platform.Android) =
+    DeviceColumn(deviceId = id, name = name, platform = platform)
+
+  @Test
+  fun `compareColumns is null with a single device`() {
+    val content =
+      WorkspaceUiState.Content(columns = listOf(col("a", "Pixel")), focusedDeviceId = "a")
+    assertNull(compareColumns(content))
+  }
+
+  @Test
+  fun `compareColumns pairs the focused device with the first other`() {
+    val content =
+      WorkspaceUiState.Content(
+        columns = listOf(col("a", "Pixel"), col("b", "iPhone"), col("c", "Tab")),
+        focusedDeviceId = "b",
+      )
+    val pair = compareColumns(content)
+    assertEquals("b", pair?.first?.deviceId)
+    assertEquals("a", pair?.second?.deviceId)
+  }
+
+  @Test
+  fun `compare glyph is hidden with a single device`() = runComposeUiTest {
+    val state = WorkspaceUiState.Content(columns = listOf(col("a", "Pixel")), focusedDeviceId = "a")
+    setContent { MaterialTheme { WorkspaceShell(state = state, onAction = {}, onOpenPicker = {}) } }
+    onNodeWithContentDescription("Compare two devices").assertDoesNotExist()
+  }
+
+  @Test
+  fun `compare glyph opens the compare surface for the focused device and one other`() =
+    runComposeUiTest {
+      val state =
+        WorkspaceUiState.Content(
+          columns = listOf(col("a", "Pixel"), col("b", "iPhone")),
+          focusedDeviceId = "a",
+        )
+      setContent {
+        MaterialTheme {
+          WorkspaceShell(
+            state = state,
+            onAction = {},
+            onOpenPicker = {},
+            compareContent = { a, b -> Text("compare ${a.deviceId} vs ${b.deviceId}") },
+          )
+        }
+      }
+      onNodeWithContentDescription("Compare two devices").assertIsDisplayed()
+      onNodeWithContentDescription("Compare two devices").performClick()
+
+      onNodeWithContentDescription("Compare devices").assertIsDisplayed()
+      onNodeWithText("compare a vs b").assertIsDisplayed()
+    }
+
+  @Test
+  fun `compare overlay closes on the close affordance`() = runComposeUiTest {
+    val state =
+      WorkspaceUiState.Content(
+        columns = listOf(col("a", "Pixel"), col("b", "iPhone")),
+        focusedDeviceId = "a",
+      )
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(
+          state = state,
+          onAction = {},
+          onOpenPicker = {},
+          compareContent = { _, _ -> Text("compare-body") },
+        )
+      }
+    }
+    onNodeWithContentDescription("Compare two devices").performClick()
+    onNodeWithText("compare-body").assertIsDisplayed()
+    onNodeWithContentDescription("Close compare").performClick()
+    onNodeWithText("compare-body").assertDoesNotExist()
+  }
+}


### PR DESCRIPTION
Ships a minimal, reviewable first cut of the two-device compare surface (wireframe exploration `13-two-device-compare`).

Closes [#4866](https://github.com/kaeawc/auto-mobile/issues/4866).

## What's built

**1. Pure, exhaustively-tested hierarchy diff** — `HierarchyDiff.kt`
- `diffHierarchies(a, b): HierarchyDiff` classifies every node as `OnlyInA` / `OnlyInB` / `Changed` / `Equal`.
- **Node identity = structural path key.** Each node contributes `className:resourceId#siblingIndex`; a node's key is the `/`-joined chain from the root. The per-level sibling index makes keys unique within a tree (so list rows that share a `resource-id` don't collide) and stable against unrelated-subtree edits.
- **Bounds are intentionally excluded** from the `Changed` test: two devices differ in resolution, so comparing geometry would flag the whole tree. Only semantic attributes (text, content-description, the boolean state flags) are compared.
- Deterministic (stable pre-order) and symmetric in classification — `diff(a,b)` and `diff(b,a)` agree with A/B roles swapped.

**2. Compare view** — `TwoDeviceCompareView.kt`
- Two per-device Layout inspectors side by side, each owning its **own** observation stream (same connect/dispose lifecycle as `LayoutFacet`), so panes never bleed into each other.
- A diff strip beneath the panes: a count summary (`+N only in A, -M only in B, ~K changed`) plus a scrollable list of the differing nodes, each color-coded with a semantics label. Loading (`Waiting for both device hierarchies…`) and matched (`Hierarchies match`) states handled.
- Both the per-side stream factory and the per-side dashboard body are injected for testing.

**3. Entry point** — `WorkspaceShell.kt`
- A ⧉ **Compare two devices** glyph in the top bar, shown only when ≥2 devices are observed; it opens a full-window compare overlay (mirrors the existing health-sheet overlay).
- `compareColumns()` picks the **focused device + the first other observed device**. If a pane closes and the count drops below two, any open compare retires itself.

## Design calls
- **Dedicated compare entry rather than reusing the facet ⧉ Diff.** The existing `WorkspaceAction.DiffTool` opens the same *tool facet* across panes; the compare surface is about the Layout *inspector* (a mode, not a tool), so folding it into `DiffTool` would have been a worse fit. A separate top-bar glyph + overlay is the smaller, self-contained change and leaves the facet-diff behavior untouched.
- **>2 devices:** compare the focused device and one other (documented in `compareColumns`).
- **Changed excludes bounds** (see above).

## Deferred (follow-ups, not built)
- Shared-slice selector.
- Richer diff heuristics: fuzzy matching, move/reorder detection (reordering currently surfaces positionally as only-in-A + only-in-B), geometry-aware diff.
- N>2 device compare.
- Live-synced split scrub.
- The compare view re-parses each stream's hierarchy independently of the inspector body (a second parse of the same JSON); a shared parsed-hierarchy hand-off could avoid the duplicate.

## Tests (all green)
- `HierarchyDiffTest` (11 pure tests): identical/only-in-A/only-in-B/changed-text/changed-flag/bounds-excluded/reordered/shared-resource-id/symmetry/determinism/pre-order.
- `TwoDeviceCompareViewTest` (3 UI tests): per-device stream scoping, loading state, only-in-A/only-in-B surfacing via fake streams.
- `WorkspaceCompareEntryTest` (5 tests): `compareColumns` pairing, glyph hidden with 1 device, overlay opens for focused+other, overlay closes.

## Validation
`:desktop-core:detektMain :desktop-core:test :desktop-app:compileKotlin` — BUILD SUCCESSFUL. Touched `.kt` formatted with pinned ktfmt 0.64.
