### PR TITLE
perf(android-video): use VBR instead of CBR for bursty screen content

### DIFF
--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoEncoder.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoEncoder.kt
@@ -13,7 +13,8 @@ import android.view.Surface
  * Configures the encoder for low-latency streaming with:
  * - H.264 Baseline profile for maximum compatibility
  * - Surface input for zero-copy GPU rendering
- * - CBR bitrate mode for consistent bandwidth
+ * - VBR bitrate mode so bursty screen content lets idle frames stay cheap and transitions borrow
+ *   headroom
  * - Frame repeat for idle screen optimization
  */
 class VideoEncoder(
@@ -64,10 +65,16 @@ class VideoEncoder(
           MediaCodecInfo.CodecProfileLevel.AVCProfileBaseline,
         )
 
-        // CBR for consistent bitrate
+        // VBR (not CBR) for bursty screen-automation content. The transport is
+        // adb forward over USB, so CBR's predictable pacing buys little here while
+        // it pads idle frames to hit the target bitrate and starves transitions of
+        // headroom (#4740). VBR treats KEY_BIT_RATE as a ceiling: idle stretches
+        // stay cheap and transitions borrow the headroom. CQ (constant quality)
+        // was evaluated but rejected — it swaps the bitrate target for KEY_QUALITY
+        // tuning that varies per device and cannot be bounded on the egress path.
         setInteger(
           MediaFormat.KEY_BITRATE_MODE,
-          MediaCodecInfo.EncoderCapabilities.BITRATE_MODE_CBR,
+          MediaCodecInfo.EncoderCapabilities.BITRATE_MODE_VBR,
         )
 
         // Request low latency mode on Android 11+ (API 30)


### PR DESCRIPTION
## Summary

Switches the on-device H.264 encoder default from constant bitrate (`BITRATE_MODE_CBR`) to variable bitrate (`BITRATE_MODE_VBR`).

Screen-automation content is bursty — long static stretches punctuated by transitions. CBR pads idle frames to hit the target bitrate and can starve real transitions of headroom. The transport is `adb forward` over USB ([PersistentEncoderH264Source.ts:361](https://github.com/kaeawc/auto-mobile/blob/main/src/features/webrtc/PersistentEncoderH264Source.ts#L361)), so CBR's predictable pacing buys little here — encode cost and latency are the real constraints, not link bandwidth. VBR treats `KEY_BIT_RATE` as a ceiling: idle stretches stay cheap and transitions borrow the headroom.

## Change

- `android/video-server/.../video/VideoEncoder.kt`: `setInteger(KEY_BITRATE_MODE, BITRATE_MODE_VBR)` in place of `BITRATE_MODE_CBR`, with an explanatory comment and an updated class-doc bullet. Everything else in the encoder config (bitrate, frame rate, I-frame interval, color format, frame repeat, baseline profile, low-latency) is preserved.

CQ (constant quality) was evaluated per the issue but rejected: it swaps the bitrate target for per-device `KEY_QUALITY` tuning that cannot be bounded on the WebRTC egress path. The `low`-preset CBR fallback was left out to keep the diff surgical; it can be added if a pacing regression is measured.

Surgical by design — sibling PRs #4739 / #4756 / #4757 also touch `VideoEncoder.kt`, so this diff is limited to the bitrate-mode line and its comment.

## Validation

- `ktfmt --google-style` on the touched file: pass.
- `./gradlew :video-server:test` (JDK 21): `BUILD SUCCESSFUL`, all tests pass; `:video-server:compileKotlin` compiles clean.

### Device-lane caveat

The measured pacing/jitter verification against the perf baseline runs on the WebRTC device lane / CI (this lands after the #4758 baseline gate so the win is measured there). That lane cannot run locally, so the pacing/jitter non-regression check is deferred to CI / the device lane.

Closes [#4740](https://github.com/kaeawc/auto-mobile/issues/4740)
