### PR TITLE
perf(android-video): relax the 2s GOP and rely on on-demand IDR

### DIFF
--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoEncoder.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoEncoder.kt
@@ -42,9 +42,16 @@ class VideoEncoder(
         // Frame rate hint (actual rate is variable based on display updates)
         setInteger(MediaFormat.KEY_FRAME_RATE, fps)
 
-        // Keep late WebRTC readers within one short GOP of a decodable IDR.
-        // Idle displays still repeat frames below, so this remains bounded.
-        setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, 2)
+        // Periodic IDR cadence. This is deliberately longer than a single short
+        // GOP because IDRs are already served on demand: a downstream viewer PLI
+        // is relayed as requestKeyFrame() (PARAMETER_KEY_REQUEST_SYNC_FRAME), and
+        // a reattaching client is replayed cached SPS/PPS plus the latest IDR. A
+        // late WebRTC reader therefore recovers via those paths rather than by
+        // waiting for the periodic keyframe, so the periodic interval can relax
+        // from 2s to 5s to save bandwidth at high bitrate without regressing
+        // late-viewer recovery. Idle displays still repeat frames below, so the
+        // stream remains bounded.
+        setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, 5)
 
         // Surface input (zero-copy from GPU)
         setInteger(
@@ -113,10 +120,10 @@ class VideoEncoder(
   }
 
   /**
-   * Ask the encoder to emit an IDR as soon as possible, rather than waiting for the 2s I-frame
-   * interval. Serves a downstream keyframe request (a WHEP viewer PLI relayed by the host) so a
-   * late or recovering viewer decodes promptly. Safe to call from any thread and after the codec
-   * has been released.
+   * Ask the encoder to emit an IDR as soon as possible, rather than waiting for the periodic
+   * I-frame interval. Serves a downstream keyframe request (a WHEP viewer PLI relayed by the host)
+   * so a late or recovering viewer decodes promptly. Safe to call from any thread and after the
+   * codec has been released.
    */
   fun requestKeyFrame() {
     try {


### PR DESCRIPTION
Closes [#4757](https://github.com/kaeawc/auto-mobile/issues/4757)

## Summary

The H.264 encoder emitted a periodic IDR every 2 seconds. Because IDRs are
already served **on demand**, that periodic keyframe is partly redundant and, at
high bitrate, expensive. This relaxes the periodic cadence to 5 seconds and
leans on the existing on-demand IDR paths to keep late/recovering viewers
correct.

The change is deliberately surgical — a single `KEY_I_FRAME_INTERVAL` value plus
comment updates in `VideoEncoder.kt` — to minimize conflicts with the sibling
PRs ([#4739](https://github.com/kaeawc/auto-mobile/pull/4739) /
[#4740](https://github.com/kaeawc/auto-mobile/pull/4740) /
[#4756](https://github.com/kaeawc/auto-mobile/pull/4756)) that also touch this
file.

## Change

- `setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, 2)` → `5` in
  `android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoEncoder.kt`.
- Updated the adjacent comment to document *why* the longer periodic cadence is
  safe (on-demand IDR), and refreshed the `requestKeyFrame()` doc comment that
  previously referred to the hard-coded "2s I-frame interval".

## Recovery paths preserved (do not regress)

The 2s interval was deliberately short to keep late WebRTC readers within one
short GOP of a decodable IDR. The increase leans entirely on the on-demand IDR
paths, which are unchanged:

- **PLI-driven IDR** — a relayed WHEP viewer PLI becomes `requestKeyFrame()` via
  `PARAMETER_KEY_REQUEST_SYNC_FRAME` (`VideoEncoder.kt`), host side in
  `src/features/webrtc/PersistentEncoderH264Source.ts`.
- **Reconnect-window IDR replay** — a reattaching client is replayed cached
  SPS/PPS plus the latest IDR (`VideoStreamWriter.kt`).
- **Startup IDR** — `start()` still calls `requestKeyFrame()` so the first
  submission is a decodable IDR.

A late or recovering viewer therefore recovers via those paths, not by waiting
out the periodic keyframe.

## Validation (local)

- `android/local.properties` created (sdk.dir), JDK 21 (Zulu 21.0.9).
- `./gradlew :video-server:test` — **BUILD SUCCESSFUL** (compile + test pass).
- `ktfmt --google-style` applied to the touched file; re-run is clean (idempotent).
- No existing test asserts the interval literal, so the change is self-contained.

## Device-lane caveat (gate before merge)

This is **medium risk**: a regression manifests as slow-to-recover viewers, which
the local JVM test suite cannot detect (no MediaCodec, no real WebRTC path). It
lands after the [#4758](https://github.com/kaeawc/auto-mobile/issues/4758)
baseline gate (merged), but the device lane cannot run locally.

**Before merge, the [#4758](https://github.com/kaeawc/auto-mobile/issues/4758)
baseline on the device lane must assert BOTH:**
1. **steady-state bitrate** improvement/no-regression at high bitrate, AND
2. **late-viewer keyframe-recovery latency** (PLI → IDR and reattach → first
   decodable frame) is not regressed by the longer periodic cadence.

Merging without the second assertion would risk shipping the exact regression
this issue's caveat warns against.
