### PR TITLE
perf(android-video): move H.264 encoder off Constrained Baseline to Main profile

### DIFF
--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoEncoder.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoEncoder.kt
@@ -55,13 +55,16 @@ class VideoEncoder(
         // Repeat frame after 100ms of no changes (reduces idle bandwidth)
         setLong(MediaFormat.KEY_REPEAT_PREVIOUS_FRAME_AFTER, 100_000)
 
-        // Request baseline profile but let MediaCodec choose a supported level
-        // for this device and capture size. The publisher validates the emitted
-        // SPS before forwarding it, so an unsupported encoder level reconnects
-        // safely instead of making MediaCodec.configure() fail up front.
+        // Request Main profile (CABAC entropy coding, no B-frames requested) for
+        // ~10-30% bitrate savings over Baseline at equal quality, but let
+        // MediaCodec choose a supported level for this device and capture size.
+        // The publisher validates the emitted SPS before forwarding it, so an
+        // unsupported encoder profile/level reconnects safely instead of making
+        // MediaCodec.configure() fail up front. Kept in lockstep with the
+        // negotiated SDP profile-level-id (4d002a) in h264Level.ts.
         setInteger(
           MediaFormat.KEY_PROFILE,
-          MediaCodecInfo.CodecProfileLevel.AVCProfileBaseline,
+          MediaCodecInfo.CodecProfileLevel.AVCProfileMain,
         )
 
         // CBR for consistent bitrate

--- a/docs/design-docs/plat/android/screen-streaming.md
+++ b/docs/design-docs/plat/android/screen-streaming.md
@@ -133,8 +133,10 @@ val format = MediaFormat.createVideoFormat(MediaFormat.MIMETYPE_VIDEO_AVC, width
         setInteger(KEY_LOW_LATENCY, 1)
     }
 
-    // H.264 Baseline profile for maximum compatibility
-    setInteger(KEY_PROFILE, MediaCodecInfo.CodecProfileLevel.AVCProfileBaseline)
+    // H.264 Main profile (CABAC) for ~10-30% bitrate savings over Baseline at
+    // equal quality; both decode targets (werift, Chromium) support it. Kept in
+    // lockstep with the negotiated SDP profile-level-id (4d002a).
+    setInteger(KEY_PROFILE, MediaCodecInfo.CodecProfileLevel.AVCProfileMain)
     setInteger(KEY_LEVEL, MediaCodecInfo.CodecProfileLevel.AVCLevel31)
 
     // CBR for consistent bitrate

--- a/src/features/webrtc/WebRtcPublisher.ts
+++ b/src/features/webrtc/WebRtcPublisher.ts
@@ -15,7 +15,7 @@ import { RtpPcmuTrackWriter } from "./RtpPcmuTrackWriter";
 import {
   h264SpsProfileLevelId,
   h264SpsLevelIdc,
-  isCompatibleConstrainedBaselineProfile,
+  isCompatibleMainProfile,
   WEBRTC_H264_LEVEL_IDC,
   WEBRTC_H264_PROFILE_LEVEL_ID,
 } from "./h264Level";
@@ -446,9 +446,9 @@ export class WebRtcPublisher {
         timer: this.timer,
         onSps: sps => {
           const profileLevelId = h264SpsProfileLevelId(sps);
-          if (profileLevelId && !isCompatibleConstrainedBaselineProfile(profileLevelId)) {
+          if (profileLevelId && !isCompatibleMainProfile(profileLevelId)) {
             throw new Error(
-              `H.264 SPS profile ${profileLevelId.slice(0, 4)} is incompatible with negotiated constrained baseline.`
+              `H.264 SPS profile ${profileLevelId.slice(0, 4)} is incompatible with negotiated Main profile.`
             );
           }
           const levelIdc = h264SpsLevelIdc(sps);
@@ -914,7 +914,7 @@ function isAcceptedCodecRtpMap(
   }
   // AutoMobile packetizes H.264 at the RFC 6184 fixed 90 kHz clock rate and
   // uses FU-A, which requires packetization-mode=1. The local werift codec is
-  // constrained-baseline 42e0xx; level may differ when asymmetry is negotiated.
+  // Main profile 4d00xx; level may differ when asymmetry is negotiated.
   return match[3] === "90000" && attributeLines.some(fmtp => {
     if (!fmtp.startsWith(`a=fmtp:${match[1]} `)) {
       return false;
@@ -931,7 +931,7 @@ function h264CodecParameters(): string {
 }
 
 function acceptsLocalH264Send(parameters: string, profileLevelId: string): boolean {
-  if (!isCompatibleConstrainedBaselineProfile(profileLevelId)) {
+  if (!isCompatibleMainProfile(profileLevelId)) {
     return false;
   }
   const answerLevelIdc = Number.parseInt(profileLevelId.slice(4, 6), 16);
@@ -945,7 +945,7 @@ function acceptsLocalH264Send(parameters: string, profileLevelId: string): boole
   const maxReceiveLevel = /(?:^|;)\s*max-recv-level\s*=\s*([0-9a-f]{4})(?:;|$)/i.exec(parameters)?.[1];
   // RFC 6184 §8.2.2 encodes max-recv-level as the two hexadecimal bytes after
   // profile_idc in an SPS: profile-iop followed by level_idc (for example,
-  // e02a for constrained-baseline Level 4.2). It is not a decimal level number.
+  // 002a for Main Level 4.2). It is not a decimal level number.
   const maxReceiveLevelIdc = maxReceiveLevel
     ? Number.parseInt(maxReceiveLevel.slice(2), 16)
     : Number.NaN;

--- a/src/features/webrtc/h264Level.ts
+++ b/src/features/webrtc/h264Level.ts
@@ -1,12 +1,18 @@
 /**
- * The constrained-baseline level advertised by AutoMobile's WebRTC sender.
+ * The Main-profile level advertised by AutoMobile's WebRTC sender.
+ *
+ * `4d002a`: profile_idc `0x4d` (Main, 77), profile-iop `0x00` (Main sets no
+ * constraint flags), level_idc `0x2a` (Level 4.2). Main enables CABAC over
+ * Baseline's CAVLC for ~10-30% bitrate savings at equal quality with no added
+ * latency (no B-frames requested), and both decode targets — werift and
+ * Chromium — support it.
  *
  * Level 4.2 supports 8,192 macroblocks per picture and 522,240 macroblocks
  * per second (RFC 6184 §8.2.2 and ITU-T H.264 Annex A). That covers AutoMobile's
  * 1080p/60 Android preset while keeping the SDP offer truthful.
  * https://www.rfc-editor.org/rfc/rfc6184.html#section-8.2.2
  */
-export const WEBRTC_H264_PROFILE_LEVEL_ID = "42e02a";
+export const WEBRTC_H264_PROFILE_LEVEL_ID = "4d002a";
 export const WEBRTC_H264_LEVEL_IDC = 0x2a;
 export const WEBRTC_H264_MAX_MACROBLOCKS_PER_FRAME = 8_192;
 
@@ -30,18 +36,20 @@ export function h264SpsLevelIdc(nal: Buffer): number | undefined {
   return profileLevelId ? Number.parseInt(profileLevelId.slice(4, 6), 16) : undefined;
 }
 
-/** Whether a profile-level-id is compatible with AutoMobile constrained baseline. */
-export function isCompatibleConstrainedBaselineProfile(profileLevelId: string): boolean {
-  // Accept the whole Baseline family (profile_idc 66 / 0x42), regardless of the
-  // constraint flags. Constrained Baseline (constraint_set1_flag set) is a subset
-  // of Baseline and decodes identically for a screen-capture stream; the earlier
-  // `(iop & 0x4f) === 0x40` check rejected the plain-Baseline SPS that Android
-  // device encoders routinely emit (`42 80 xx`, constraint_set0 only, or
-  // `42 00 xx`). Because reconnecting cannot change a fixed-profile encoder, that
-  // rejection turned into an endless reconnect loop that never rendered a frame.
-  // Non-Baseline profiles (Main 0x4d, High 0x64) are still rejected — those
-  // genuinely differ and are handled by the caller.
+/** Whether a profile-level-id is compatible with AutoMobile's Main-profile sender. */
+export function isCompatibleMainProfile(profileLevelId: string): boolean {
+  // Accept the whole Main family (profile_idc 77 / 0x4d), regardless of the
+  // profile-iop constraint flags. AutoMobile's encoder now requests Main
+  // (`4d xx yy`); a device encoder may echo varying constraint-flag bytes, all
+  // of which decode identically for a screen-capture stream. Only profile_idc is
+  // significant here because reconnecting cannot change a fixed-profile encoder —
+  // an over-strict iop check turns into an endless reconnect loop that never
+  // renders a frame.
+  //
+  // Baseline (0x42) is deliberately rejected now that we send Main: a decoder
+  // that only advertises Baseline cannot decode a Main-profile stream. Higher
+  // profiles (High 0x64) genuinely differ and are handled by the caller.
   // https://www.rfc-editor.org/rfc/rfc6184.html#section-8.2.2
   const profileIdc = Number.parseInt(profileLevelId.slice(0, 2), 16);
-  return profileIdc === 0x42;
+  return profileIdc === 0x4d;
 }

--- a/test/features/webrtc/WebRtcPublisher.loopback.test.ts
+++ b/test/features/webrtc/WebRtcPublisher.loopback.test.ts
@@ -32,8 +32,8 @@ function nal(type: number, size: number, fill: number): Buffer {
 /** A keyframe access unit (SPS + PPS + large IDR) followed by the next start code. */
 function keyframeStream(): Buffer {
   return Buffer.concat([
-    // Constrained-baseline Level 4.2, matching the publisher's SDP contract.
-    START, Buffer.from([0x67, 0x42, 0xe0, 0x2a, 0x11, 0x11, 0x11, 0x11]),
+    // Main profile Level 4.2, matching the publisher's SDP contract.
+    START, Buffer.from([0x67, 0x4d, 0x00, 0x2a, 0x11, 0x11, 0x11, 0x11]),
     START, nal(8, 6, 0x22), // PPS
     START, nal(5, 4000, 0x33), // IDR large enough to force FU-A fragmentation
     START, // trailing start code so the IDR NAL is emitted immediately

--- a/test/features/webrtc/WebRtcPublisher.test.ts
+++ b/test/features/webrtc/WebRtcPublisher.test.ts
@@ -12,7 +12,7 @@ const ACCEPTED_VIDEO_ANSWER = [
   "m=video 9 UDP/TLS/RTP/SAVPF 102",
   "a=recvonly",
   "a=rtpmap:102 H264/90000",
-  "a=fmtp:102 packetization-mode=1;profile-level-id=42e02a",
+  "a=fmtp:102 packetization-mode=1;profile-level-id=4d002a",
 ].join("\r\n");
 const ACCEPTED_VIDEO_AND_AUDIO_ANSWER = [
   ACCEPTED_VIDEO_ANSWER,
@@ -186,11 +186,11 @@ describe("WebRtcPublisher WHIP answer validation", () => {
     await expectRejectedAnswer(ACCEPTED_VIDEO_ANSWER.replace("a=recvonly", "a=sendrecv"));
   });
 
-  test("rejects an H.264 profile incompatible with the constrained-baseline sender", async () => {
-    await expectRejectedAnswer(ACCEPTED_VIDEO_ANSWER.replace("42e02a", "64001f"));
+  test("rejects an H.264 profile incompatible with the Main-profile sender", async () => {
+    await expectRejectedAnswer(ACCEPTED_VIDEO_ANSWER.replace("4d002a", "64001f"));
   });
 
-  test("accepts every RFC 6184 constrained-baseline profile representation", async () => {
+  test("accepts every RFC 6184 Main profile representation", async () => {
     const pc = new FakePeerConnection();
     const publisher = new WebRtcPublisher(
       { streamId: "s", whipEndpoint: "https://coord/whip" },
@@ -198,7 +198,7 @@ describe("WebRtcPublisher WHIP answer validation", () => {
         createPeerConnection: () => pc as unknown as RTCPeerConnection,
         createWhipClient: () => ({
           publish: async () => ({
-            answerSdp: ACCEPTED_VIDEO_ANSWER.replace("42e02a", "42c02a"),
+            answerSdp: ACCEPTED_VIDEO_ANSWER.replace("4d002a", "4dc02a"),
             resourceUrl: "https://coord/whip/s",
           }),
           delete: async () => {},
@@ -211,7 +211,7 @@ describe("WebRtcPublisher WHIP answer validation", () => {
     await publisher.stop();
   });
 
-  test("accepts a conforming Baseline level-1b profile variation with a sufficient receive ceiling", async () => {
+  test("accepts a conforming Main level-1b profile variation with a sufficient receive ceiling", async () => {
     const pc = new FakePeerConnection();
     const publisher = new WebRtcPublisher(
       { streamId: "s", whipEndpoint: "https://coord/whip" },
@@ -220,8 +220,8 @@ describe("WebRtcPublisher WHIP answer validation", () => {
         createWhipClient: () => ({
           publish: async () => ({
             answerSdp: ACCEPTED_VIDEO_ANSWER.replace(
-              "profile-level-id=42e02a",
-              "profile-level-id=42f00b;level-asymmetry-allowed=1;max-recv-level=f02a"
+              "profile-level-id=4d002a",
+              "profile-level-id=4df00b;level-asymmetry-allowed=1;max-recv-level=f02a"
             ),
             resourceUrl: "https://coord/whip/s",
           }),
@@ -236,7 +236,7 @@ describe("WebRtcPublisher WHIP answer validation", () => {
   });
 
   test("rejects an answer whose receive level is below AutoMobile's source capability", async () => {
-    await expectRejectedAnswer(ACCEPTED_VIDEO_ANSWER.replace("42e02a", "42e01f"));
+    await expectRejectedAnswer(ACCEPTED_VIDEO_ANSWER.replace("4d002a", "4d001f"));
   });
 
   test("accepts an asymmetric answer that explicitly supports the source level", async () => {
@@ -250,8 +250,8 @@ describe("WebRtcPublisher WHIP answer validation", () => {
             publish: async () => ({
               resourceUrl: "https://coord/resource",
               answerSdp: ACCEPTED_VIDEO_ANSWER.replace(
-                "profile-level-id=42e02a",
-                "profile-level-id=42e01f;level-asymmetry-allowed=1;max-recv-level=e02a"
+                "profile-level-id=4d002a",
+                "profile-level-id=4d001f;level-asymmetry-allowed=1;max-recv-level=002a"
               ),
             }),
             delete: async () => {},
@@ -266,8 +266,8 @@ describe("WebRtcPublisher WHIP answer validation", () => {
   test("rejects a decimal max-recv-level because RFC 6184 requires hexadecimal SPS bytes", async () => {
     await expectRejectedAnswer(
       ACCEPTED_VIDEO_ANSWER.replace(
-        "profile-level-id=42e02a",
-        "profile-level-id=42e01f;level-asymmetry-allowed=1;max-recv-level=42"
+        "profile-level-id=4d002a",
+        "profile-level-id=4d001f;level-asymmetry-allowed=1;max-recv-level=42"
       )
     );
   });
@@ -337,7 +337,7 @@ describe("WebRtcPublisher.notifySourceFailed", () => {
     let recoveries = 0;
     internals.notifySourceFailed = () => { recoveries++; };
 
-    // A High-profile SPS must not be forwarded under the constrained-baseline
+    // A High-profile SPS must not be forwarded under the Main-profile
     // profile-level-id advertised in the negotiated SDP.
     publisher.writeH264Chunk(Buffer.from([0, 0, 0, 1, 0x67, 0x64, 0x00, 0x1f, 0, 0, 0, 1]));
 
@@ -365,7 +365,7 @@ describe("WebRtcPublisher.notifySourceFailed", () => {
 
     publisher.writeH264Chunk(Buffer.from([0, 0, 0, 1, 0x67, 0x64, 0x00, 0x1f, 0, 0, 0, 1]));
 
-    expect(failure?.message).toContain("incompatible with negotiated constrained baseline");
+    expect(failure?.message).toContain("incompatible with negotiated Main profile");
     await publisher.stop();
   });
 
@@ -389,7 +389,7 @@ describe("WebRtcPublisher.notifySourceFailed", () => {
     const pFrame = Buffer.from([0x41, 0x80]);
 
     publisher.writeH264Chunk(Buffer.concat([
-      startCode, Buffer.from([0x67, 0x42, 0xe0, 0x2a]),
+      startCode, Buffer.from([0x67, 0x4d, 0x00, 0x2a]),
       startCode, Buffer.from([0x68, 0xce, 0x3c, 0x80]),
       startCode, Buffer.from([0x65, 0x80, 0x00]),
       startCode, pFrame,
@@ -463,7 +463,7 @@ describe("WebRtcPublisher keyframe requests", () => {
     const start = Buffer.from([0, 0, 0, 1]);
     publisher.writeH264Chunk(
       Buffer.concat([
-        start, Buffer.from([0x67, 0x42, 0xe0, 0x2a]),
+        start, Buffer.from([0x67, 0x4d, 0x00, 0x2a]),
         start, Buffer.from([0x68, 0xce, 0x3c, 0x80]),
         start, Buffer.from([0x65, 0x80, 0x00]),
         start, Buffer.from([0x41, 0x80, 0x01]),
@@ -551,10 +551,10 @@ describe("WebRtcPublisher frame-stall watchdog", () => {
 
     await publisher.start();
     const START = Buffer.from([0, 0, 0, 1]);
-    // SPS(42e02a) + PPS + IDR — a real keyframe the writer accepts.
+    // SPS(4d002a) + PPS + IDR — a real keyframe the writer accepts.
     publisher.writeH264Chunk(
       Buffer.concat([
-        START, Buffer.from([0x67, 0x42, 0xe0, 0x2a]),
+        START, Buffer.from([0x67, 0x4d, 0x00, 0x2a]),
         START, Buffer.from([0x68, 0xce, 0x3c, 0x80]),
         START, Buffer.from([0x65, 0x80, 0x00]),
       ])

--- a/test/features/webrtc/h264Level.property.test.ts
+++ b/test/features/webrtc/h264Level.property.test.ts
@@ -4,7 +4,7 @@ import {
   h264MacroblocksPerFrame,
   h264SpsLevelIdc,
   h264SpsProfileLevelId,
-  isCompatibleConstrainedBaselineProfile
+  isCompatibleMainProfile
 } from "../../../src/features/webrtc/h264Level";
 
 // Property-based tests. See test/utils/Backoff.property.test.ts for the pinned-seed rationale.
@@ -74,31 +74,31 @@ describe("h264SpsProfileLevelId / h264SpsLevelIdc (property-based)", () => {
   });
 });
 
-describe("isCompatibleConstrainedBaselineProfile (property-based)", () => {
-  test("accepts exactly the Baseline family (first byte 0x42) parsed from an SPS", () => {
+describe("isCompatibleMainProfile (property-based)", () => {
+  test("accepts exactly the Main family (first byte 0x4d) parsed from an SPS", () => {
     fc.assert(
       fc.property(validSps, ({ nal, p }) => {
         const id = h264SpsProfileLevelId(nal)!;
-        return isCompatibleConstrainedBaselineProfile(id) === (p === 0x42);
+        return isCompatibleMainProfile(id) === (p === 0x4d);
       }),
       RUN_OPTIONS
     );
   });
 
-  test("accepts any 0x42-prefixed profile-level-id, including plain-Baseline (#reconnect-loop fix)", () => {
+  test("accepts any 0x4d-prefixed profile-level-id, ignoring the profile-iop byte", () => {
     const suffix = fc.string({ unit: fc.constantFrom("0", "2", "8", "a", "e", "f"), minLength: 4, maxLength: 4 });
     fc.assert(
-      fc.property(suffix, s => isCompatibleConstrainedBaselineProfile(`42${s}`)),
+      fc.property(suffix, s => isCompatibleMainProfile(`4d${s}`)),
       RUN_OPTIONS
     );
   });
 
-  test("rejects non-Baseline profiles (Main 0x4d, High 0x64, and any non-0x42 first byte)", () => {
-    const nonBaselineByte = fc.integer({ min: 0, max: 255 }).filter(b => b !== 0x42);
+  test("rejects non-Main profiles (Baseline 0x42, High 0x64, and any non-0x4d first byte)", () => {
+    const nonMainByte = fc.integer({ min: 0, max: 255 }).filter(b => b !== 0x4d);
     const suffix = fc.string({ unit: fc.constantFrom("0", "1", "e", "a", "f"), minLength: 4, maxLength: 4 });
     fc.assert(
-      fc.property(nonBaselineByte, suffix, (b, s) =>
-        isCompatibleConstrainedBaselineProfile(`${b.toString(16).padStart(2, "0")}${s}`) === false
+      fc.property(nonMainByte, suffix, (b, s) =>
+        isCompatibleMainProfile(`${b.toString(16).padStart(2, "0")}${s}`) === false
       ),
       RUN_OPTIONS
     );

--- a/test/features/webrtc/h264Level.test.ts
+++ b/test/features/webrtc/h264Level.test.ts
@@ -2,26 +2,27 @@ import { describe, expect, test } from "bun:test";
 import {
   h264SpsLevelIdc,
   h264SpsProfileLevelId,
-  isCompatibleConstrainedBaselineProfile,
+  isCompatibleMainProfile,
 } from "../../../src/features/webrtc/h264Level";
 
 describe("H.264 SDP and SPS capability helpers", () => {
   test("reads the profile and level fields from an SPS", () => {
-    const sps = Buffer.from([0x67, 0x42, 0xe0, 0x2a]);
-    expect(h264SpsProfileLevelId(sps)).toBe("42e02a");
+    const sps = Buffer.from([0x67, 0x4d, 0x00, 0x2a]);
+    expect(h264SpsProfileLevelId(sps)).toBe("4d002a");
     expect(h264SpsLevelIdc(sps)).toBe(0x2a);
   });
 
-  test("accepts the whole Baseline family but rejects a different profile", () => {
-    expect(isCompatibleConstrainedBaselineProfile("42e02a")).toBe(true);
-    expect(isCompatibleConstrainedBaselineProfile("42f00b")).toBe(true);
-    expect(isCompatibleConstrainedBaselineProfile("42c02a")).toBe(true);
-    // Plain Baseline as Android device encoders emit it (constraint_set1 clear):
-    // previously rejected, which caused an endless reconnect loop with no video.
-    expect(isCompatibleConstrainedBaselineProfile("428028")).toBe(true);
-    expect(isCompatibleConstrainedBaselineProfile("42001f")).toBe(true);
-    // Main (0x4d) and High (0x64) are still rejected — genuinely different profiles.
-    expect(isCompatibleConstrainedBaselineProfile("64001f")).toBe(false);
-    expect(isCompatibleConstrainedBaselineProfile("4d401f")).toBe(false);
+  test("accepts the whole Main family but rejects a different profile", () => {
+    expect(isCompatibleMainProfile("4d002a")).toBe(true);
+    // Any profile-iop constraint-flag byte a device encoder may emit is accepted;
+    // only profile_idc (first byte) is significant, matching the reconnect-safe gate.
+    expect(isCompatibleMainProfile("4d401f")).toBe(true);
+    expect(isCompatibleMainProfile("4de02a")).toBe(true);
+    expect(isCompatibleMainProfile("4d001f")).toBe(true);
+    // Baseline (0x42) is now rejected — a Baseline-only decoder cannot decode Main.
+    expect(isCompatibleMainProfile("42e02a")).toBe(false);
+    expect(isCompatibleMainProfile("428028")).toBe(false);
+    // High (0x64) is still rejected — a genuinely different profile.
+    expect(isCompatibleMainProfile("64001f")).toBe(false);
   });
 });

--- a/test/helpers/webrtcFakes.ts
+++ b/test/helpers/webrtcFakes.ts
@@ -5,7 +5,7 @@ export const VIDEO_ONLY_WHIP_ANSWER = [
   "m=video 9 UDP/TLS/RTP/SAVPF 96",
   "a=recvonly",
   "a=rtpmap:96 H264/90000",
-  "a=fmtp:96 packetization-mode=1;profile-level-id=42e02a",
+  "a=fmtp:96 packetization-mode=1;profile-level-id=4d002a",
   "",
 ].join("\r\n");
 

--- a/test/package/webrtcRuntimeMetadata.test.ts
+++ b/test/package/webrtcRuntimeMetadata.test.ts
@@ -72,7 +72,7 @@ const publisher = new WebRtcPublisher(
             status: 201,
             ok: true,
             headers: { get: name => (name.toLowerCase() === "location" ? "/whip/resource/debug-1" : null) },
-            text: async () => ["v=0", "m=video 9 UDP/TLS/RTP/SAVPF 96", "a=recvonly", "a=rtpmap:96 H264/90000", "a=fmtp:96 packetization-mode=1;profile-level-id=42e02a", ""].join("\\r\\n"),
+            text: async () => ["v=0", "m=video 9 UDP/TLS/RTP/SAVPF 96", "a=recvonly", "a=rtpmap:96 H264/90000", "a=fmtp:96 packetization-mode=1;profile-level-id=4d002a", ""].join("\\r\\n"),
           };
         },
       }),


### PR DESCRIPTION
Closes [#4756](https://github.com/kaeawc/auto-mobile/issues/4756)

## Summary

Moves the Android video encoder off H.264 **Constrained Baseline** to **Main**
profile, and moves the negotiated SDP `profile-level-id` and the
`acceptsLocalH264Send` capability gate **in lockstep**. Baseline uses CAVLC and
no CABAC; Main enables CABAC for ~10-30% bitrate savings at equal quality with
no added latency (no B-frames requested). **Level 4.2 is unchanged.**

This is the risky, coupled change of the perf batch: the encoder profile, the
negotiated SDP `profile-level-id`, and the capability gate must agree, and
decoder compatibility (werift + Chromium) must hold. All three moved together:

- **Encoder** (`android/video-server/.../VideoEncoder.kt`): `KEY_PROFILE`
  `AVCProfileBaseline` -> `AVCProfileMain`. Diff kept surgical (profile setting +
  comment only) to avoid conflicts with sibling PRs #4739/#4740/#4757 that also
  touch this file.
- **Negotiated SDP** (`src/features/webrtc/h264Level.ts`):
  `WEBRTC_H264_PROFILE_LEVEL_ID` `42e02a` -> `4d002a` (profile_idc `0x4d` Main,
  profile-iop `0x00`, level_idc `0x2a` = Level 4.2, unchanged).
- **Capability gate** (`src/features/webrtc/WebRtcPublisher.ts` +
  `h264Level.ts`): `isCompatibleConstrainedBaselineProfile` ->
  `isCompatibleMainProfile`, now accepting profile_idc `0x4d` (Main) and
  rejecting Baseline `0x42` (a Baseline-only decoder cannot decode a Main stream)
  and High `0x64`. Used by both the local `onSps` SPS validator and the remote
  answer `acceptsLocalH264Send` gate, so the encoder output and the negotiated
  answer are checked against the same Main-profile contract.

Design doc `docs/design-docs/plat/android/screen-streaming.md` updated to match.

## Validation (local)

- TS: `bun run typecheck` — no new type errors (196 baseline).
- TS: `turbo run lint build test` — all green (12217 pass, 0 fail).
- WebRTC suite specifically: `test/features/webrtc/**` + `test/package/**` all
  pass, including the **in-process werift loopback** test
  (`WebRtcPublisher.loopback.test.ts`) which exercises a real WHIP offer/answer +
  RTP transport. werift mirrors the offer's `profile-level-id`, so the loopback
  confirms the Main-profile SPS is accepted and forwarded end-to-end at the
  werift level.
- Kotlin: JDK 21 + `./gradlew :video-server:test` — BUILD SUCCESSFUL (encoder
  recompiled). `ktfmt` on the touched Kotlin file — properly formatted.

## Needs careful review — device-lane verification gaps (MUST hold before merge)

The following CANNOT run locally and are **not** covered by the local validation
above. They must be verified on the **`webrtc-device-integration`** lane and
behind the **#4758** perf baseline gate before merge:

1. **Real decoder compatibility** — that **Chromium** (WHEP viewer) and werift
   decode the Main-profile stream produced by a real Android MediaCodec encoder.
   The device-backed integration tests that would prove this are skipped locally:
   `MediaMTX WebRTC publisher integration (#4290)` and
   `device capture -> WHIP -> MediaMTX -> WHEP (#4308)`.
2. **SDP renegotiation** — that the full offer/answer with `profile-level-id=4d002a`
   negotiates correctly against the real coordination server / MediaMTX ingest,
   not just the in-process werift loopback.
3. **Device encoder support** — that target devices' MediaCodec H.264 encoders
   actually honor `AVCProfileMain` and emit an SPS with profile_idc `0x4d`. The
   publisher already reconnects safely if an encoder emits an unexpected profile,
   but a device that silently ignores the profile request should be confirmed on
   real hardware.

Please review the profile/level arithmetic and the gate semantics closely — this
is a lockstep, decoder-compatibility-sensitive change.
