### PR TITLE
feat(desktop): boot a shut-down device when its picker card is clicked

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -41,6 +41,7 @@ import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePicker
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerAction
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerEffect
 import dev.jasonpearson.automobile.desktop.core.workspace.picker.DevicePickerViewModel
+import dev.jasonpearson.automobile.desktop.core.workspace.picker.RealDeviceBootController
 import dev.jasonpearson.automobile.desktop.theme.AutoMobileTheme
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -111,8 +112,11 @@ fun AutoMobileDesktopApp(
   val workspaceState by workspaceViewModel.state.collectAsState()
 
   val resourceClient = remember(graph) { DaemonMcpResourceClient(graph.autoMobileClient) }
+  val bootController = remember(graph) { RealDeviceBootController(graph.autoMobileClient) }
   val pickerViewModel =
-    remember(scope, resourceClient) { DevicePickerViewModel(resourceClient, scope) }
+    remember(scope, resourceClient, bootController) {
+      DevicePickerViewModel(resourceClient, bootController, scope)
+    }
   val pickerState by pickerViewModel.state.collectAsState()
   var pickerOpen by remember { mutableStateOf(false) }
   var paletteOpen by remember { mutableStateOf(false) }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DeviceBootController.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DeviceBootController.kt
@@ -46,15 +46,26 @@ class RealDeviceBootController(
             platform = device.platform.wireName(),
             deviceId = device.id,
           )
-        if (result.success) {
-          // Prefer the daemon's authoritative runtime id; fall back to the requested id only if the
-          // daemon omitted it (older builds), which keeps auto-select best-effort rather than
-          // broken.
-          Result.success(result.deviceId ?: device.id)
-        } else {
-          val message = result.message ?: "Failed to boot ${device.name}"
-          LOG.warn("startDevice reported failure for ${device.name}: $message")
-          Result.failure(IllegalStateException(message))
+        val runtimeId = result.deviceId
+        when {
+          !result.success -> {
+            val message = result.message ?: "Failed to boot ${device.name}"
+            LOG.warn("startDevice reported failure for ${device.name}: $message")
+            Result.failure(IllegalStateException(message))
+          }
+          runtimeId == null -> {
+            // Reject rather than fabricate an id. The shut-down source id would fail
+            // reloadAfterBoot's exact-id match against the real runtime serial, so a booted
+            // device would read "Boot did not complete" and stay unselected; a failure surfaces
+            // a retryable "Boot failed" affordance instead. Only older daemons omit deviceId.
+            LOG.warn("startDevice succeeded for ${device.name} but reported no runtime deviceId")
+            Result.failure(
+              IllegalStateException(
+                "Device booted but the daemon didn't report a runtime id; can't verify it"
+              )
+            )
+          }
+          else -> Result.success(runtimeId)
         }
       } catch (c: CancellationException) {
         // Never swallow structured-concurrency cancellation — let it propagate.

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DeviceBootController.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DeviceBootController.kt
@@ -1,0 +1,86 @@
+package dev.jasonpearson.automobile.desktop.core.workspace.picker
+
+import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import dev.jasonpearson.automobile.desktop.core.workspace.Platform
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Boot seam for the device picker. Clicking a shut-down card asks this controller to bring the
+ * device up (via the `startDevice` MCP tool in the real impl). Kept as a narrow interface so the
+ * [DevicePickerViewModel] is unit-testable without a running daemon.
+ */
+interface DeviceBootController {
+  /** Boot [device]. Returns success once the daemon reports the device started, else a failure. */
+  suspend fun boot(device: PickerDevice): Result<Unit>
+}
+
+private val LOG = LoggerFactory.getLogger("DeviceBootController")
+
+private fun Platform.wireName(): String = if (this == Platform.Ios) "ios" else "android"
+
+/**
+ * Real boot controller backed by the daemon [AutoMobileClient]. The picker's device id is the AVD
+ * name (Android) or simulator id (iOS) taken from the device-images resource, so it is passed as
+ * both the match `name` and `deviceId` — the daemon matcher accepts either.
+ */
+class RealDeviceBootController(
+  private val client: AutoMobileClient,
+  private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : DeviceBootController {
+  override suspend fun boot(device: PickerDevice): Result<Unit> =
+    withContext(ioDispatcher) {
+      try {
+        val result =
+          client.startDevice(
+            name = device.name,
+            platform = device.platform.wireName(),
+            deviceId = device.id,
+          )
+        if (result.success) {
+          Result.success(Unit)
+        } else {
+          val message = result.message ?: "Failed to boot ${device.name}"
+          LOG.warn("startDevice reported failure for ${device.name}: $message")
+          Result.failure(IllegalStateException(message))
+        }
+      } catch (e: Exception) {
+        LOG.warn("startDevice threw for ${device.name}: ${e.message}", e)
+        Result.failure(e)
+      }
+    }
+}
+
+/**
+ * Test fake. By default a boot completes immediately with [result]; set [autoComplete] to false to
+ * hold the boot open (observe the transient "booting" state) and release it later with [complete].
+ * [onSuccess] lets a test mutate its resource fake so the reload sees the device as booted.
+ */
+class FakeDeviceBootController : DeviceBootController {
+  val bootRequests: MutableList<PickerDevice> = mutableListOf()
+  var result: Result<Unit> = Result.success(Unit)
+  var autoComplete: Boolean = true
+  var onSuccess: (PickerDevice) -> Unit = {}
+  private var gate: CompletableDeferred<Unit>? = null
+
+  override suspend fun boot(device: PickerDevice): Result<Unit> {
+    bootRequests += device
+    if (!autoComplete) {
+      val deferred = CompletableDeferred<Unit>()
+      gate = deferred
+      deferred.await()
+    }
+    if (result.isSuccess) {
+      onSuccess(device)
+    }
+    return result
+  }
+
+  /** Release a boot that was held open by [autoComplete] = false. */
+  fun complete() {
+    gate?.complete(Unit)
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DeviceBootController.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DeviceBootController.kt
@@ -15,8 +15,13 @@ import kotlinx.coroutines.withContext
  * [DevicePickerViewModel] is unit-testable without a running daemon.
  */
 interface DeviceBootController {
-  /** Boot [device]. Returns success once the daemon reports the device started, else a failure. */
-  suspend fun boot(device: PickerDevice): Result<Unit>
+  /**
+   * Boot [device]. On success returns the **runtime device id** the daemon assigned the started
+   * device (e.g. `emulator-5556`) — the authoritative handle for auto-selecting it, which is not
+   * the shut-down AVD id and must not be inferred from the display name (ambiguous for
+   * identically-named devices). Returns a failure if the boot did not start.
+   */
+  suspend fun boot(device: PickerDevice): Result<String>
 }
 
 private val LOG = LoggerFactory.getLogger("DeviceBootController")
@@ -32,7 +37,7 @@ class RealDeviceBootController(
   private val client: AutoMobileClient,
   private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : DeviceBootController {
-  override suspend fun boot(device: PickerDevice): Result<Unit> =
+  override suspend fun boot(device: PickerDevice): Result<String> =
     withContext(ioDispatcher) {
       try {
         val result =
@@ -42,7 +47,10 @@ class RealDeviceBootController(
             deviceId = device.id,
           )
         if (result.success) {
-          Result.success(Unit)
+          // Prefer the daemon's authoritative runtime id; fall back to the requested id only if the
+          // daemon omitted it (older builds), which keeps auto-select best-effort rather than
+          // broken.
+          Result.success(result.deviceId ?: device.id)
         } else {
           val message = result.message ?: "Failed to boot ${device.name}"
           LOG.warn("startDevice reported failure for ${device.name}: $message")
@@ -61,26 +69,31 @@ class RealDeviceBootController(
 /**
  * Test fake. By default a boot completes immediately with [result]; set [autoComplete] to false to
  * hold the boot open (observe the transient "booting" state) and release it later with [complete].
- * [onSuccess] lets a test mutate its resource fake so the reload sees the device as booted.
+ * On success the returned runtime id is [result]'s value, or the device's own id when that value is
+ * blank. [onSuccess] lets a test mutate its resource fake so the reload sees the device as booted.
  */
 class FakeDeviceBootController : DeviceBootController {
   val bootRequests: MutableList<PickerDevice> = mutableListOf()
-  var result: Result<Unit> = Result.success(Unit)
+  var result: Result<String> = Result.success("")
   var autoComplete: Boolean = true
   var onSuccess: (PickerDevice) -> Unit = {}
   private var gate: CompletableDeferred<Unit>? = null
 
-  override suspend fun boot(device: PickerDevice): Result<Unit> {
+  override suspend fun boot(device: PickerDevice): Result<String> {
     bootRequests += device
     if (!autoComplete) {
       val deferred = CompletableDeferred<Unit>()
       gate = deferred
       deferred.await()
     }
-    if (result.isSuccess) {
+    val current = result
+    val runtimeId = current.getOrNull()
+    return if (current.isSuccess) {
       onSuccess(device)
+      Result.success(if (runtimeId.isNullOrEmpty()) device.id else runtimeId)
+    } else {
+      current
     }
-    return result
   }
 
   /** Release a boot that was held open by [autoComplete] = false. */

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DeviceBootController.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DeviceBootController.kt
@@ -3,6 +3,7 @@ package dev.jasonpearson.automobile.desktop.core.workspace.picker
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import dev.jasonpearson.automobile.desktop.core.workspace.Platform
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -47,6 +48,9 @@ class RealDeviceBootController(
           LOG.warn("startDevice reported failure for ${device.name}: $message")
           Result.failure(IllegalStateException(message))
         }
+      } catch (c: CancellationException) {
+        // Never swallow structured-concurrency cancellation — let it propagate.
+        throw c
       } catch (e: Exception) {
         LOG.warn("startDevice threw for ${device.name}: ${e.message}", e)
         Result.failure(e)

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePicker.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePicker.kt
@@ -236,15 +236,31 @@ private fun DeviceGrid(
       DeviceCard(
         device = device,
         selected = device.id in content.selectedIds,
-        onClick = { onAction(DevicePickerAction.ToggleSelect(device.id)) },
+        booting = device.id in content.bootingIds,
+        error = content.bootErrors[device.id],
+        onClick = {
+          if (device.state == DeviceState.Booted) {
+            onAction(DevicePickerAction.ToggleSelect(device.id))
+          } else {
+            onAction(DevicePickerAction.BootDevice(device.id))
+          }
+        },
       )
     }
   }
 }
 
 @Composable
-private fun DeviceCard(device: PickerDevice, selected: Boolean, onClick: () -> Unit) {
+private fun DeviceCard(
+  device: PickerDevice,
+  selected: Boolean,
+  booting: Boolean,
+  error: String?,
+  onClick: () -> Unit,
+) {
   val booted = device.state == DeviceState.Booted
+  // A shut-down card boots on click (unless a boot is already in flight); a booted card selects.
+  val clickable = booted || !booting
   Column(
     modifier =
       Modifier.fillMaxWidth()
@@ -253,11 +269,8 @@ private fun DeviceCard(device: PickerDevice, selected: Boolean, onClick: () -> U
           color = if (selected) Accent else MaterialTheme.colorScheme.outlineVariant,
           shape = RoundedCornerShape(6.dp),
         )
-        .then(if (booted) Modifier.clickable(onClick = onClick) else Modifier)
-        .semantics {
-          contentDescription =
-            if (booted) "Select ${device.name}" else "${device.name} (not booted)"
-        }
+        .then(if (clickable) Modifier.clickable(onClick = onClick) else Modifier)
+        .semantics { contentDescription = cardDescription(device, booted, booting, error) }
         .padding(12.dp)
   ) {
     Text("${device.platform.emoji}  ${device.name}", style = MaterialTheme.typography.bodyLarge)
@@ -267,7 +280,7 @@ private fun DeviceCard(device: PickerDevice, selected: Boolean, onClick: () -> U
           if (device.platform == Platform.Ios) "iOS" else "Android",
           device.osLabel,
           device.architecture,
-          if (booted) "booted" else "shutdown",
+          if (booted) "booted" else "Shut down",
         )
         .joinToString(" · ")
     Text(
@@ -277,13 +290,33 @@ private fun DeviceCard(device: PickerDevice, selected: Boolean, onClick: () -> U
     )
     if (!booted) {
       Text(
-        "Boot to observe (soon)",
+        bootAffordance(booting, error),
         style = MaterialTheme.typography.labelSmall,
-        color = MaterialTheme.colorScheme.outline,
+        color = if (error != null) MaterialTheme.colorScheme.error else Accent,
       )
     }
   }
 }
+
+private fun cardDescription(
+  device: PickerDevice,
+  booted: Boolean,
+  booting: Boolean,
+  error: String?,
+): String =
+  when {
+    booted -> "Select ${device.name}"
+    booting -> "Booting ${device.name}"
+    error != null -> "Retry boot ${device.name}"
+    else -> "Boot ${device.name}"
+  }
+
+private fun bootAffordance(booting: Boolean, error: String?): String =
+  when {
+    booting -> "Booting…"
+    error != null -> "Boot failed · Click to retry"
+    else -> "Click to boot"
+  }
 
 private fun toggle(
   dimension: FilterDimension,

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
@@ -1,6 +1,8 @@
 package dev.jasonpearson.automobile.desktop.core.workspace.picker
 
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import dev.jasonpearson.automobile.desktop.core.mcp.BootedDeviceInfo
+import dev.jasonpearson.automobile.desktop.core.mcp.DeviceImageInfo
 import dev.jasonpearson.automobile.desktop.core.mcp.DeviceResourceParser
 import dev.jasonpearson.automobile.desktop.core.mcp.McpResourceClient
 import dev.jasonpearson.automobile.desktop.core.mcp.ResourceReadResult
@@ -96,6 +98,12 @@ class DevicePickerViewModel(
   private var bootingIds: Set<String> = emptySet()
   private var bootErrors: Map<String, String> = emptyMap()
 
+  // Monotonic load/emission generation. Every load() and reloadAfterBoot() claims the next value at
+  // its start; an in-flight load that resumes after a newer one has begun drops its emission rather
+  // than clobbering fresher post-boot state (a stale Refresh restoring the shut-down card and
+  // dropping the just-booted selection).
+  private var loadGeneration: Long = 0
+
   init {
     load()
   }
@@ -121,33 +129,47 @@ class DevicePickerViewModel(
   }
 
   private fun load() {
+    val generation = ++loadGeneration
     _state.value = DevicePickerUiState.Loading
     scope.launch {
       try {
         val devices = fetchDevices()
+        if (generation != loadGeneration) return@launch // superseded by a newer load/reload
         LOG.info("Picker loaded ${devices.size} devices")
         emitContent(devices)
       } catch (c: CancellationException) {
         throw c // don't turn cancellation into a load error
       } catch (e: Exception) {
         LOG.warn("Failed to load picker devices: ${e.message}", e)
-        _state.value = DevicePickerUiState.Error(e.message ?: "Failed to load devices")
+        if (generation == loadGeneration) {
+          _state.value = DevicePickerUiState.Error(e.message ?: "Failed to load devices")
+        }
       }
     }
   }
 
-  // Resource reads hit the daemon (blocking) — keep them off the UI thread.
+  // Resource reads hit the daemon (blocking) — keep them off the UI thread. A read that returns
+  // ResourceReadResult.Error throws rather than degrading to an empty list: a partial read (booted
+  // fails, images succeed) must NOT reconstruct a just-booted device as Shutdown, and a total
+  // failure must not empty the picker and prune live boot state — callers retain the prior
+  // snapshot.
   private suspend fun fetchDevices(): List<PickerDevice> =
-    withContext(ioDispatcher) {
-      val booted =
-        (resourceClient.readResource(BOOTED_URI) as? ResourceReadResult.Success)?.let {
-          DeviceResourceParser.parseBootedDevices(it.content)?.devices
-        } ?: emptyList()
-      val images =
-        (resourceClient.readResource(IMAGES_URI) as? ResourceReadResult.Success)?.let {
-          DeviceResourceParser.parseDeviceImages(it.content)?.images
-        } ?: emptyList()
-      buildPickerDevices(booted, images)
+    withContext(ioDispatcher) { buildPickerDevices(readBootedDevices(), readDeviceImages()) }
+
+  private suspend fun readBootedDevices(): List<BootedDeviceInfo> =
+    when (val result = resourceClient.readResource(BOOTED_URI)) {
+      is ResourceReadResult.Success ->
+        DeviceResourceParser.parseBootedDevices(result.content)?.devices ?: emptyList()
+      is ResourceReadResult.Error ->
+        throw IllegalStateException("Failed to read booted devices: ${result.message}")
+    }
+
+  private suspend fun readDeviceImages(): List<DeviceImageInfo> =
+    when (val result = resourceClient.readResource(IMAGES_URI)) {
+      is ResourceReadResult.Success ->
+        DeviceResourceParser.parseDeviceImages(result.content)?.images ?: emptyList()
+      is ResourceReadResult.Error ->
+        throw IllegalStateException("Failed to read device images: ${result.message}")
     }
 
   /**
@@ -193,8 +215,9 @@ class DevicePickerViewModel(
     syncBootState()
     scope.launch {
       val result = bootController.boot(device)
-      if (result.isSuccess) {
-        reloadAfterBoot(device)
+      val runtimeDeviceId = result.getOrNull()
+      if (runtimeDeviceId != null) {
+        reloadAfterBoot(device, runtimeDeviceId)
       } else {
         val message = result.exceptionOrNull()?.message ?: "Failed to boot ${device.name}"
         bootingIds = bootingIds - deviceId
@@ -205,11 +228,14 @@ class DevicePickerViewModel(
   }
 
   /**
-   * Reload after a boot succeeded and auto-select the now-booted device so Observe is usable. A
-   * booted device is re-keyed by the daemon (its id becomes a runtime serial), so it is matched
-   * back by name, not by the shut-down id.
+   * Reload after a boot succeeded and auto-select the started device so Observe is usable. The
+   * device is selected by [runtimeDeviceId] — the exact id the daemon assigned it — never by
+   * display name, which is ambiguous when two identically-named devices boot concurrently. A read
+   * failure retains the prior snapshot (see [fetchDevices]) rather than fabricating a shut-down
+   * card.
    */
-  private suspend fun reloadAfterBoot(bootedDevice: PickerDevice) {
+  private suspend fun reloadAfterBoot(bootedDevice: PickerDevice, runtimeDeviceId: String) {
+    val generation = ++loadGeneration
     val devices =
       try {
         fetchDevices()
@@ -223,15 +249,16 @@ class DevicePickerViewModel(
         return
       }
     val nowBooted = devices.firstOrNull {
-      it.name == bootedDevice.name && it.state == DeviceState.Booted
+      it.id == runtimeDeviceId && it.state == DeviceState.Booted
     }
     bootingIds = bootingIds - bootedDevice.id
     bootErrors =
       if (nowBooted != null) bootErrors - bootedDevice.id
       else bootErrors + (bootedDevice.id to "Boot did not complete")
+    if (generation != loadGeneration) return // a newer load/reload will emit fresher state
     emitContent(devices)
     if (nowBooted != null) {
-      updateContent { it.copy(selectedIds = it.selectedIds + nowBooted.id) }
+      updateContent { it.copy(selectedIds = it.selectedIds + runtimeDeviceId) }
     }
   }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
@@ -29,6 +29,12 @@ sealed interface DevicePickerUiState {
     val devices: List<PickerDevice>,
     val filters: PickerFilters = PickerFilters(),
     val selectedIds: Set<String> = emptySet(),
+    /**
+     * Ids of devices whose boot is currently in flight (UI-only transient, not a [DeviceState]).
+     */
+    val bootingIds: Set<String> = emptySet(),
+    /** Per-device boot failure message; presence marks a card as retryable. */
+    val bootErrors: Map<String, String> = emptyMap(),
   ) : DevicePickerUiState
 
   data class Error(val message: String) : DevicePickerUiState
@@ -49,6 +55,9 @@ sealed interface DevicePickerAction {
 
   data class ToggleSelect(val deviceId: String) : DevicePickerAction
 
+  /** Boot a shut-down device (its card was clicked). Ignored for already-booted/booting devices. */
+  data class BootDevice(val deviceId: String) : DevicePickerAction
+
   data object ClearSelection : DevicePickerAction
 
   data object ObserveSelected : DevicePickerAction
@@ -68,6 +77,7 @@ sealed interface DevicePickerEffect {
  */
 class DevicePickerViewModel(
   private val resourceClient: McpResourceClient,
+  private val bootController: DeviceBootController,
   private val scope: CoroutineScope,
   private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
@@ -94,6 +104,7 @@ class DevicePickerViewModel(
       is DevicePickerAction.SetQuery -> updateFilters { it.copy(query = action.query) }
       is DevicePickerAction.ClearFilter -> clearFilter(action.dimension)
       is DevicePickerAction.ToggleSelect -> toggleSelect(action.deviceId)
+      is DevicePickerAction.BootDevice -> bootDevice(action.deviceId)
       is DevicePickerAction.ClearSelection -> updateContent { it.copy(selectedIds = emptySet()) }
       is DevicePickerAction.ObserveSelected -> observeSelected()
       is DevicePickerAction.Refresh -> load()
@@ -104,25 +115,87 @@ class DevicePickerViewModel(
     _state.value = DevicePickerUiState.Loading
     scope.launch {
       try {
-        // Resource reads hit the daemon (blocking) — keep them off the UI thread.
-        val devices =
-          withContext(ioDispatcher) {
-            val booted =
-              (resourceClient.readResource(BOOTED_URI) as? ResourceReadResult.Success)?.let {
-                DeviceResourceParser.parseBootedDevices(it.content)?.devices
-              } ?: emptyList()
-            val images =
-              (resourceClient.readResource(IMAGES_URI) as? ResourceReadResult.Success)?.let {
-                DeviceResourceParser.parseDeviceImages(it.content)?.images
-              } ?: emptyList()
-            buildPickerDevices(booted, images)
-          }
+        val devices = fetchDevices()
         LOG.info("Picker loaded ${devices.size} devices")
         _state.value = DevicePickerUiState.Content(devices)
       } catch (e: Exception) {
         LOG.warn("Failed to load picker devices: ${e.message}", e)
         _state.value = DevicePickerUiState.Error(e.message ?: "Failed to load devices")
       }
+    }
+  }
+
+  // Resource reads hit the daemon (blocking) — keep them off the UI thread.
+  private suspend fun fetchDevices(): List<PickerDevice> =
+    withContext(ioDispatcher) {
+      val booted =
+        (resourceClient.readResource(BOOTED_URI) as? ResourceReadResult.Success)?.let {
+          DeviceResourceParser.parseBootedDevices(it.content)?.devices
+        } ?: emptyList()
+      val images =
+        (resourceClient.readResource(IMAGES_URI) as? ResourceReadResult.Success)?.let {
+          DeviceResourceParser.parseDeviceImages(it.content)?.images
+        } ?: emptyList()
+      buildPickerDevices(booted, images)
+    }
+
+  private fun bootDevice(deviceId: String) {
+    val content = _state.value as? DevicePickerUiState.Content ?: return
+    if (deviceId in content.bootingIds) return // already booting — no double-boot
+    val device = content.devices.firstOrNull { it.id == deviceId } ?: return
+    if (device.state != DeviceState.Shutdown) return // only shut-down cards boot
+    updateContent {
+      it.copy(bootingIds = it.bootingIds + deviceId, bootErrors = it.bootErrors - deviceId)
+    }
+    scope.launch {
+      val result = bootController.boot(device)
+      if (result.isSuccess) {
+        reloadAfterBoot(device)
+      } else {
+        val message = result.exceptionOrNull()?.message ?: "Failed to boot ${device.name}"
+        updateContent {
+          it.copy(
+            bootingIds = it.bootingIds - deviceId,
+            bootErrors = it.bootErrors + (deviceId to message),
+          )
+        }
+      }
+    }
+  }
+
+  /**
+   * Reload after a boot succeeded and auto-select the now-booted device so Observe is usable. A
+   * booted device is re-keyed by the daemon (its id becomes a runtime serial), so it is matched
+   * back by name, not by the shut-down id.
+   */
+  private suspend fun reloadAfterBoot(bootedDevice: PickerDevice) {
+    val devices =
+      try {
+        fetchDevices()
+      } catch (e: Exception) {
+        LOG.warn("Reload after boot failed for ${bootedDevice.name}: ${e.message}", e)
+        updateContent {
+          it.copy(
+            bootingIds = it.bootingIds - bootedDevice.id,
+            bootErrors =
+              it.bootErrors + (bootedDevice.id to (e.message ?: "Reload after boot failed")),
+          )
+        }
+        return
+      }
+    val nowBooted = devices.firstOrNull {
+      it.name == bootedDevice.name && it.state == DeviceState.Booted
+    }
+    updateContent { content ->
+      content.copy(
+        devices = devices,
+        bootingIds = prunedBootingIds(content.bootingIds - bootedDevice.id, devices),
+        selectedIds =
+          if (nowBooted != null) content.selectedIds + nowBooted.id else content.selectedIds,
+        bootErrors =
+          if (nowBooted != null) content.bootErrors - bootedDevice.id
+          else content.bootErrors + (bootedDevice.id to "Boot did not complete"),
+      )
     }
   }
 
@@ -171,3 +244,9 @@ class DevicePickerViewModel(
 }
 
 private fun <T> Set<T>.toggle(value: T): Set<T> = if (value in this) this - value else this + value
+
+/** Drop any in-flight boot ids that a reload now reports as booted. */
+private fun prunedBootingIds(bootingIds: Set<String>, devices: List<PickerDevice>): Set<String> {
+  val bootedIds = devices.filter { it.state == DeviceState.Booted }.map { it.id }.toSet()
+  return bootingIds - bootedIds
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
@@ -6,6 +6,7 @@ import dev.jasonpearson.automobile.desktop.core.mcp.McpResourceClient
 import dev.jasonpearson.automobile.desktop.core.mcp.ResourceReadResult
 import dev.jasonpearson.automobile.desktop.core.workspace.DeviceColumn
 import dev.jasonpearson.automobile.desktop.core.workspace.Platform
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -87,6 +88,14 @@ class DevicePickerViewModel(
   private val _effect = Channel<DevicePickerEffect>(Channel.BUFFERED)
   val effect = _effect.receiveAsFlow()
 
+  // Active-boot state is authoritative here, NOT on the replaceable Content. load() swaps Content
+  // out for Loading and back (e.g. a Refresh while the picker is reopened mid cold-boot); keeping
+  // the guard on Content would discard it on that swap — re-arming a device for a second
+  // startDevice and losing a completion that resolves while Loading. These fields survive load()
+  // and are merged (pruned against the fresh device list) into every emitted Content.
+  private var bootingIds: Set<String> = emptySet()
+  private var bootErrors: Map<String, String> = emptyMap()
+
   init {
     load()
   }
@@ -117,7 +126,9 @@ class DevicePickerViewModel(
       try {
         val devices = fetchDevices()
         LOG.info("Picker loaded ${devices.size} devices")
-        _state.value = DevicePickerUiState.Content(devices)
+        emitContent(devices)
+      } catch (c: CancellationException) {
+        throw c // don't turn cancellation into a load error
       } catch (e: Exception) {
         LOG.warn("Failed to load picker devices: ${e.message}", e)
         _state.value = DevicePickerUiState.Error(e.message ?: "Failed to load devices")
@@ -139,26 +150,56 @@ class DevicePickerViewModel(
       buildPickerDevices(booted, images)
     }
 
+  /**
+   * Emit a fresh [DevicePickerUiState.Content] from a reloaded device list, preserving the prior
+   * filters/selection and merging the ViewModel-level boot guard — pruned against the new list so
+   * ids that are now booted or gone are dropped. This is the single place Content is rebuilt, so a
+   * mid-boot reload never drops the "Booting…"/error guard.
+   */
+  private fun emitContent(devices: List<PickerDevice>) {
+    pruneBootState(devices)
+    val bootedIds = devices.filter { it.state == DeviceState.Booted }.map { it.id }.toSet()
+    _state.update { current ->
+      val prev = current as? DevicePickerUiState.Content
+      DevicePickerUiState.Content(
+        devices = devices,
+        filters = prev?.filters ?: PickerFilters(),
+        selectedIds = (prev?.selectedIds ?: emptySet()) intersect bootedIds,
+        bootingIds = bootingIds,
+        bootErrors = bootErrors,
+      )
+    }
+  }
+
+  /** Drop boot guard/error entries for devices that are no longer shut down (booted or gone). */
+  private fun pruneBootState(devices: List<PickerDevice>) {
+    val shutdownIds = devices.filter { it.state == DeviceState.Shutdown }.map { it.id }.toSet()
+    bootingIds = bootingIds intersect shutdownIds
+    bootErrors = bootErrors.filterKeys { it in shutdownIds }
+  }
+
+  /** Reflect the current boot fields onto the live Content (no device reload). */
+  private fun syncBootState() {
+    updateContent { it.copy(bootingIds = bootingIds, bootErrors = bootErrors) }
+  }
+
   private fun bootDevice(deviceId: String) {
+    if (deviceId in bootingIds) return // already booting — no double-boot
     val content = _state.value as? DevicePickerUiState.Content ?: return
-    if (deviceId in content.bootingIds) return // already booting — no double-boot
     val device = content.devices.firstOrNull { it.id == deviceId } ?: return
     if (device.state != DeviceState.Shutdown) return // only shut-down cards boot
-    updateContent {
-      it.copy(bootingIds = it.bootingIds + deviceId, bootErrors = it.bootErrors - deviceId)
-    }
+    bootingIds = bootingIds + deviceId
+    bootErrors = bootErrors - deviceId
+    syncBootState()
     scope.launch {
       val result = bootController.boot(device)
       if (result.isSuccess) {
         reloadAfterBoot(device)
       } else {
         val message = result.exceptionOrNull()?.message ?: "Failed to boot ${device.name}"
-        updateContent {
-          it.copy(
-            bootingIds = it.bootingIds - deviceId,
-            bootErrors = it.bootErrors + (deviceId to message),
-          )
-        }
+        bootingIds = bootingIds - deviceId
+        bootErrors = bootErrors + (deviceId to message)
+        syncBootState()
       }
     }
   }
@@ -172,30 +213,25 @@ class DevicePickerViewModel(
     val devices =
       try {
         fetchDevices()
+      } catch (c: CancellationException) {
+        throw c // don't turn cancellation into a boot failure
       } catch (e: Exception) {
         LOG.warn("Reload after boot failed for ${bootedDevice.name}: ${e.message}", e)
-        updateContent {
-          it.copy(
-            bootingIds = it.bootingIds - bootedDevice.id,
-            bootErrors =
-              it.bootErrors + (bootedDevice.id to (e.message ?: "Reload after boot failed")),
-          )
-        }
+        bootingIds = bootingIds - bootedDevice.id
+        bootErrors = bootErrors + (bootedDevice.id to (e.message ?: "Reload after boot failed"))
+        syncBootState()
         return
       }
     val nowBooted = devices.firstOrNull {
       it.name == bootedDevice.name && it.state == DeviceState.Booted
     }
-    updateContent { content ->
-      content.copy(
-        devices = devices,
-        bootingIds = prunedBootingIds(content.bootingIds - bootedDevice.id, devices),
-        selectedIds =
-          if (nowBooted != null) content.selectedIds + nowBooted.id else content.selectedIds,
-        bootErrors =
-          if (nowBooted != null) content.bootErrors - bootedDevice.id
-          else content.bootErrors + (bootedDevice.id to "Boot did not complete"),
-      )
+    bootingIds = bootingIds - bootedDevice.id
+    bootErrors =
+      if (nowBooted != null) bootErrors - bootedDevice.id
+      else bootErrors + (bootedDevice.id to "Boot did not complete")
+    emitContent(devices)
+    if (nowBooted != null) {
+      updateContent { it.copy(selectedIds = it.selectedIds + nowBooted.id) }
     }
   }
 
@@ -244,9 +280,3 @@ class DevicePickerViewModel(
 }
 
 private fun <T> Set<T>.toggle(value: T): Set<T> = if (value in this) this - value else this + value
-
-/** Drop any in-flight boot ids that a reload now reports as booted. */
-private fun prunedBootingIds(bootingIds: Set<String>, devices: List<PickerDevice>): Set<String> {
-  val bootedIds = devices.filter { it.state == DeviceState.Booted }.map { it.id }.toSet()
-  return bootingIds - bootedIds
-}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
@@ -101,6 +101,12 @@ class DevicePickerViewModel(
   private var selectedIds: Set<String> = emptySet()
   private var filters: PickerFilters = PickerFilters()
 
+  // In-session boot attribution: source image id -> the runtime id the daemon assigned it on boot.
+  // Lets the merge hide a re-keyed booted device's EXACT source image (not a positional same-named
+  // guess). Pruned to devices still booted; devices booted outside this session fall back to the
+  // name heuristic in buildPickerDevices.
+  private var bootedImageRuntimeIds: Map<String, String> = emptyMap()
+
   // Monotonic load/emission generation, claimed at the start of every load()/reloadAfterBoot(). It
   // guards ONLY the stale device-LIST emission: a fetch that resumes after a newer one began does
   // not overwrite the fresher list. It never gates the persistent state above (recorded before the
@@ -149,17 +155,20 @@ class DevicePickerViewModel(
   }
 
   // Resource reads hit the daemon (blocking) — keep them off the UI thread. A read that returns
-  // ResourceReadResult.Error throws rather than degrading to an empty list: a partial read (booted
-  // fails, images succeed) must NOT reconstruct a just-booted device as Shutdown, and a total
-  // failure must not empty the picker and prune live boot state — callers retain the prior
-  // snapshot.
+  // ResourceReadResult.Error, or a Success whose payload fails to parse (malformed/truncated JSON),
+  // throws rather than degrading to an empty list: a partial/garbled read must NOT reconstruct a
+  // just-booted device as Shutdown (which would permit a duplicate start), and a total failure must
+  // not empty the picker and prune live boot state — callers retain the prior snapshot.
   private suspend fun fetchDevices(): List<PickerDevice> =
-    withContext(ioDispatcher) { buildPickerDevices(readBootedDevices(), readDeviceImages()) }
+    withContext(ioDispatcher) {
+      buildPickerDevices(readBootedDevices(), readDeviceImages(), bootedImageRuntimeIds)
+    }
 
   private suspend fun readBootedDevices(): List<BootedDeviceInfo> =
     when (val result = resourceClient.readResource(BOOTED_URI)) {
       is ResourceReadResult.Success ->
-        DeviceResourceParser.parseBootedDevices(result.content)?.devices ?: emptyList()
+        DeviceResourceParser.parseBootedDevices(result.content)?.devices
+          ?: throw IllegalStateException("Malformed booted-devices payload")
       is ResourceReadResult.Error ->
         throw IllegalStateException("Failed to read booted devices: ${result.message}")
     }
@@ -167,7 +176,8 @@ class DevicePickerViewModel(
   private suspend fun readDeviceImages(): List<DeviceImageInfo> =
     when (val result = resourceClient.readResource(IMAGES_URI)) {
       is ResourceReadResult.Success ->
-        DeviceResourceParser.parseDeviceImages(result.content)?.images ?: emptyList()
+        DeviceResourceParser.parseDeviceImages(result.content)?.images
+          ?: throw IllegalStateException("Malformed device-images payload")
       is ResourceReadResult.Error ->
         throw IllegalStateException("Failed to read device images: ${result.message}")
     }
@@ -229,6 +239,8 @@ class DevicePickerViewModel(
     bootingIds = bootingIds intersect shutdownIds
     bootErrors = bootErrors.filterKeys { it in shutdownIds }
     selectedIds = selectedIds intersect bootedIds
+    // Keep only attributions whose runtime device is still booted (drop killed/replaced ids).
+    bootedImageRuntimeIds = bootedImageRuntimeIds.filterValues { it in bootedIds }
   }
 
   /** Reflect the persistent state onto the live Content (no device reload). */
@@ -244,7 +256,11 @@ class DevicePickerViewModel(
   }
 
   private fun bootDevice(deviceId: String) {
-    if (deviceId in bootingIds) return // already booting — no double-boot
+    // Boots are serialized: at most one in flight. A click on any shut-down card while a boot is
+    // running is a no-op. This structurally removes overlapping reloads (and their generation
+    // reordering hazards); the next card can boot once this one finishes. A failed boot leaves
+    // bootingIds empty, so retrying (clicking the same card again) is still allowed.
+    if (bootingIds.isNotEmpty()) return
     val content = _state.value as? DevicePickerUiState.Content ?: return
     val device = content.devices.firstOrNull { it.id == deviceId } ?: return
     if (device.state != DeviceState.Shutdown) return // only shut-down cards boot
@@ -269,12 +285,16 @@ class DevicePickerViewModel(
    * Reload after a boot succeeded and auto-select the started device so Observe is usable.
    * Selection keys on [runtimeDeviceId] — the exact id the daemon assigned — never the display name
    * (ambiguous for identically-named devices). The selection is recorded in the persistent state
-   * BEFORE the generation guard, so two overlapping boots both stick even if their emissions are
-   * superseded. A read failure resolves to a terminal state (retained snapshot or Error), never a
+   * BEFORE the generation guard, so a concurrent Refresh that supersedes this reload's list
+   * emission still carries the selection (boots themselves are serialized, so reloads never
+   * overlap). A read failure resolves to a terminal state (retained snapshot or Error), never a
    * stranded Loading, and never fabricates a shut-down card from a partial read (see
    * [fetchDevices]).
    */
   private suspend fun reloadAfterBoot(bootedDevice: PickerDevice, runtimeDeviceId: String) {
+    // Record the exact source-image -> runtime-id attribution BEFORE the reload, so this very fetch
+    // hides the started device's own source image by id (not a positional same-name guess).
+    bootedImageRuntimeIds = bootedImageRuntimeIds + (bootedDevice.id to runtimeDeviceId)
     val generation = ++loadGeneration
     val devices =
       try {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
@@ -90,18 +90,21 @@ class DevicePickerViewModel(
   private val _effect = Channel<DevicePickerEffect>(Channel.BUFFERED)
   val effect = _effect.receiveAsFlow()
 
-  // Active-boot state is authoritative here, NOT on the replaceable Content. load() swaps Content
-  // out for Loading and back (e.g. a Refresh while the picker is reopened mid cold-boot); keeping
-  // the guard on Content would discard it on that swap — re-arming a device for a second
-  // startDevice and losing a completion that resolves while Loading. These fields survive load()
-  // and are merged (pruned against the fresh device list) into every emitted Content.
+  // Persistent, accumulating UI state that is authoritative HERE, not on the replaceable Content.
+  // load() swaps Content out for Loading and back (e.g. a Refresh while the picker is reopened mid
+  // cold-boot); keeping these on Content would discard them on that swap — re-arming a device for a
+  // second startDevice, or dropping selections made across earlier boots. They survive every load()
+  // and are merged, pruned against the fresh device list, into every emitted Content. Loads replace
+  // only the device LIST, never these.
   private var bootingIds: Set<String> = emptySet()
   private var bootErrors: Map<String, String> = emptyMap()
+  private var selectedIds: Set<String> = emptySet()
 
-  // Monotonic load/emission generation. Every load() and reloadAfterBoot() claims the next value at
-  // its start; an in-flight load that resumes after a newer one has begun drops its emission rather
-  // than clobbering fresher post-boot state (a stale Refresh restoring the shut-down card and
-  // dropping the just-booted selection).
+  // Monotonic load/emission generation, claimed at the start of every load()/reloadAfterBoot(). It
+  // guards ONLY the stale device-LIST emission: a fetch that resumes after a newer one began does
+  // not overwrite the fresher list. It never gates the persistent state above (recorded before the
+  // guard), nor the rule that the newest generation ends terminal (Content or Error) — a failure is
+  // never dropped into a stranded Loading.
   private var loadGeneration: Long = 0
 
   init {
@@ -122,7 +125,7 @@ class DevicePickerViewModel(
       is DevicePickerAction.ClearFilter -> clearFilter(action.dimension)
       is DevicePickerAction.ToggleSelect -> toggleSelect(action.deviceId)
       is DevicePickerAction.BootDevice -> bootDevice(action.deviceId)
-      is DevicePickerAction.ClearSelection -> updateContent { it.copy(selectedIds = emptySet()) }
+      is DevicePickerAction.ClearSelection -> clearSelection()
       is DevicePickerAction.ObserveSelected -> observeSelected()
       is DevicePickerAction.Refresh -> load()
     }
@@ -134,16 +137,12 @@ class DevicePickerViewModel(
     scope.launch {
       try {
         val devices = fetchDevices()
-        if (generation != loadGeneration) return@launch // superseded by a newer load/reload
-        LOG.info("Picker loaded ${devices.size} devices")
-        emitContent(devices)
+        emitIfCurrent(generation, devices)
       } catch (c: CancellationException) {
         throw c // don't turn cancellation into a load error
       } catch (e: Exception) {
         LOG.warn("Failed to load picker devices: ${e.message}", e)
-        if (generation == loadGeneration) {
-          _state.value = DevicePickerUiState.Error(e.message ?: "Failed to load devices")
-        }
+        resolveFetchFailure(generation, e)
       }
     }
   }
@@ -173,36 +172,70 @@ class DevicePickerViewModel(
     }
 
   /**
-   * Emit a fresh [DevicePickerUiState.Content] from a reloaded device list, preserving the prior
-   * filters/selection and merging the ViewModel-level boot guard — pruned against the new list so
-   * ids that are now booted or gone are dropped. This is the single place Content is rebuilt, so a
-   * mid-boot reload never drops the "Booting…"/error guard.
+   * Emit the reloaded device list as [DevicePickerUiState.Content] — but ONLY if [generation] is
+   * still the newest. A stale success is dropped: its persistent selection/boot state was already
+   * recorded and a newer emission carries it, so dropping the stale LIST cannot lose it.
    */
+  private fun emitIfCurrent(generation: Long, devices: List<PickerDevice>) {
+    if (generation != loadGeneration) return
+    LOG.info("Picker loaded ${devices.size} devices")
+    emitContent(devices)
+  }
+
+  /**
+   * Resolve a failed fetch to a TERMINAL state for the newest generation so a failure is never left
+   * stranded as [DevicePickerUiState.Loading]: retain the previous [DevicePickerUiState.Content]
+   * snapshot (merging the updated persistent state, e.g. a boot marked failed) when one exists,
+   * else a retryable [DevicePickerUiState.Error]. A stale-generation failure is dropped — the newer
+   * generation will resolve terminally.
+   */
+  private fun resolveFetchFailure(generation: Long, error: Throwable) {
+    if (generation != loadGeneration) return
+    _state.value =
+      when (val current = _state.value) {
+        is DevicePickerUiState.Content ->
+          current.copy(
+            selectedIds = selectedIds,
+            bootingIds = bootingIds,
+            bootErrors = bootErrors,
+          )
+        else -> DevicePickerUiState.Error(error.message ?: "Failed to load devices")
+      }
+  }
+
+  /** Rebuild Content from a device list, merging the pruned persistent state. */
   private fun emitContent(devices: List<PickerDevice>) {
-    pruneBootState(devices)
-    val bootedIds = devices.filter { it.state == DeviceState.Booted }.map { it.id }.toSet()
+    pruneState(devices)
     _state.update { current ->
       val prev = current as? DevicePickerUiState.Content
       DevicePickerUiState.Content(
         devices = devices,
         filters = prev?.filters ?: PickerFilters(),
-        selectedIds = (prev?.selectedIds ?: emptySet()) intersect bootedIds,
+        selectedIds = selectedIds,
         bootingIds = bootingIds,
         bootErrors = bootErrors,
       )
     }
   }
 
-  /** Drop boot guard/error entries for devices that are no longer shut down (booted or gone). */
-  private fun pruneBootState(devices: List<PickerDevice>) {
+  /**
+   * Prune the persistent state against the live list: boot guard/error entries survive only while
+   * their device is still shut down (drop once booted or gone); a selection survives only while its
+   * device is still present and booted.
+   */
+  private fun pruneState(devices: List<PickerDevice>) {
     val shutdownIds = devices.filter { it.state == DeviceState.Shutdown }.map { it.id }.toSet()
+    val bootedIds = devices.filter { it.state == DeviceState.Booted }.map { it.id }.toSet()
     bootingIds = bootingIds intersect shutdownIds
     bootErrors = bootErrors.filterKeys { it in shutdownIds }
+    selectedIds = selectedIds intersect bootedIds
   }
 
-  /** Reflect the current boot fields onto the live Content (no device reload). */
-  private fun syncBootState() {
-    updateContent { it.copy(bootingIds = bootingIds, bootErrors = bootErrors) }
+  /** Reflect the persistent state onto the live Content (no device reload). */
+  private fun syncState() {
+    updateContent {
+      it.copy(selectedIds = selectedIds, bootingIds = bootingIds, bootErrors = bootErrors)
+    }
   }
 
   private fun bootDevice(deviceId: String) {
@@ -212,7 +245,7 @@ class DevicePickerViewModel(
     if (device.state != DeviceState.Shutdown) return // only shut-down cards boot
     bootingIds = bootingIds + deviceId
     bootErrors = bootErrors - deviceId
-    syncBootState()
+    syncState()
     scope.launch {
       val result = bootController.boot(device)
       val runtimeDeviceId = result.getOrNull()
@@ -222,17 +255,19 @@ class DevicePickerViewModel(
         val message = result.exceptionOrNull()?.message ?: "Failed to boot ${device.name}"
         bootingIds = bootingIds - deviceId
         bootErrors = bootErrors + (deviceId to message)
-        syncBootState()
+        syncState()
       }
     }
   }
 
   /**
-   * Reload after a boot succeeded and auto-select the started device so Observe is usable. The
-   * device is selected by [runtimeDeviceId] — the exact id the daemon assigned it — never by
-   * display name, which is ambiguous when two identically-named devices boot concurrently. A read
-   * failure retains the prior snapshot (see [fetchDevices]) rather than fabricating a shut-down
-   * card.
+   * Reload after a boot succeeded and auto-select the started device so Observe is usable.
+   * Selection keys on [runtimeDeviceId] — the exact id the daemon assigned — never the display name
+   * (ambiguous for identically-named devices). The selection is recorded in the persistent state
+   * BEFORE the generation guard, so two overlapping boots both stick even if their emissions are
+   * superseded. A read failure resolves to a terminal state (retained snapshot or Error), never a
+   * stranded Loading, and never fabricates a shut-down card from a partial read (see
+   * [fetchDevices]).
    */
   private suspend fun reloadAfterBoot(bootedDevice: PickerDevice, runtimeDeviceId: String) {
     val generation = ++loadGeneration
@@ -245,37 +280,39 @@ class DevicePickerViewModel(
         LOG.warn("Reload after boot failed for ${bootedDevice.name}: ${e.message}", e)
         bootingIds = bootingIds - bootedDevice.id
         bootErrors = bootErrors + (bootedDevice.id to (e.message ?: "Reload after boot failed"))
-        syncBootState()
+        resolveFetchFailure(generation, e)
         return
       }
-    val nowBooted = devices.firstOrNull {
-      it.id == runtimeDeviceId && it.state == DeviceState.Booted
-    }
+    val nowBooted = devices.any { it.id == runtimeDeviceId && it.state == DeviceState.Booted }
     bootingIds = bootingIds - bootedDevice.id
-    bootErrors =
-      if (nowBooted != null) bootErrors - bootedDevice.id
-      else bootErrors + (bootedDevice.id to "Boot did not complete")
-    if (generation != loadGeneration) return // a newer load/reload will emit fresher state
-    emitContent(devices)
-    if (nowBooted != null) {
-      updateContent { it.copy(selectedIds = it.selectedIds + runtimeDeviceId) }
+    if (nowBooted) {
+      selectedIds = selectedIds + runtimeDeviceId // recorded before the guard — never lost
+      bootErrors = bootErrors - bootedDevice.id
+    } else {
+      bootErrors = bootErrors + (bootedDevice.id to "Boot did not complete")
     }
+    emitIfCurrent(generation, devices)
   }
 
   private fun toggleSelect(deviceId: String) {
-    updateContent { content ->
-      // Booted-only: ignore selection of non-booted devices.
-      val device = content.devices.firstOrNull { it.id == deviceId } ?: return@updateContent content
-      if (device.state != DeviceState.Booted) return@updateContent content
-      content.copy(selectedIds = content.selectedIds.toggle(deviceId))
-    }
+    val content = _state.value as? DevicePickerUiState.Content ?: return
+    // Booted-only: ignore selection of non-booted devices.
+    val device = content.devices.firstOrNull { it.id == deviceId } ?: return
+    if (device.state != DeviceState.Booted) return
+    selectedIds = selectedIds.toggle(deviceId)
+    syncState()
+  }
+
+  private fun clearSelection() {
+    selectedIds = emptySet()
+    syncState()
   }
 
   private fun observeSelected() {
     val content = _state.value as? DevicePickerUiState.Content ?: return
     val columns =
       content.devices
-        .filter { it.id in content.selectedIds && it.state == DeviceState.Booted }
+        .filter { it.id in selectedIds && it.state == DeviceState.Booted }
         .map { DeviceColumn(deviceId = it.id, name = it.name, platform = it.platform) }
     if (columns.isNotEmpty()) {
       scope.launch { _effect.send(DevicePickerEffect.Observe(columns)) }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
@@ -99,6 +99,7 @@ class DevicePickerViewModel(
   private var bootingIds: Set<String> = emptySet()
   private var bootErrors: Map<String, String> = emptyMap()
   private var selectedIds: Set<String> = emptySet()
+  private var filters: PickerFilters = PickerFilters()
 
   // Monotonic load/emission generation, claimed at the start of every load()/reloadAfterBoot(). It
   // guards ONLY the stale device-LIST emission: a fetch that resumes after a newer one began does
@@ -195,6 +196,7 @@ class DevicePickerViewModel(
       when (val current = _state.value) {
         is DevicePickerUiState.Content ->
           current.copy(
+            filters = filters,
             selectedIds = selectedIds,
             bootingIds = bootingIds,
             bootErrors = bootErrors,
@@ -206,16 +208,14 @@ class DevicePickerViewModel(
   /** Rebuild Content from a device list, merging the pruned persistent state. */
   private fun emitContent(devices: List<PickerDevice>) {
     pruneState(devices)
-    _state.update { current ->
-      val prev = current as? DevicePickerUiState.Content
+    _state.value =
       DevicePickerUiState.Content(
         devices = devices,
-        filters = prev?.filters ?: PickerFilters(),
+        filters = filters,
         selectedIds = selectedIds,
         bootingIds = bootingIds,
         bootErrors = bootErrors,
       )
-    }
   }
 
   /**
@@ -234,7 +234,12 @@ class DevicePickerViewModel(
   /** Reflect the persistent state onto the live Content (no device reload). */
   private fun syncState() {
     updateContent {
-      it.copy(selectedIds = selectedIds, bootingIds = bootingIds, bootErrors = bootErrors)
+      it.copy(
+        filters = filters,
+        selectedIds = selectedIds,
+        bootingIds = bootingIds,
+        bootErrors = bootErrors,
+      )
     }
   }
 
@@ -336,7 +341,8 @@ class DevicePickerViewModel(
   }
 
   private fun updateFilters(transform: (PickerFilters) -> PickerFilters) {
-    updateContent { it.copy(filters = transform(it.filters)) }
+    filters = transform(filters)
+    syncState()
   }
 
   private fun updateContent(

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModel.kt
@@ -291,6 +291,11 @@ class DevicePickerViewModel(
     } else {
       bootErrors = bootErrors + (bootedDevice.id to "Boot did not complete")
     }
+    // Persistent state (esp. the selection) is reflected onto the CURRENT Content unconditionally,
+    // so it never diverges from what observeSelected() reads — even when this reload's device-LIST
+    // emission is dropped as stale below. Selection is persistent state, not tied to which list
+    // wins.
+    syncState()
     emitIfCurrent(generation, devices)
   }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerModels.kt
@@ -56,12 +56,13 @@ private fun osOfImage(image: DeviceImageInfo): Pair<String?, String?> =
 /**
  * Merge the booted-devices and device-images resources into one picker list. A booted device wins
  * over the specific image it came from, reconciled by IDENTITY, not display name: an image is
- * hidden only when its own id is booted, or — because the daemon re-keys a booted device to a
- * runtime serial that no longer matches its image id — when it is the source of a re-keyed booted
- * device of the same name (one image per such device, not all same-named images). This keeps
- * distinct devices that merely share a display name (common for simulators) from vanishing when a
- * sibling boots. Booted devices carry no OS/architecture from the daemon today, so Android API is
- * best-effort parsed from the name.
+ * hidden only when its own id is booted, or — because the daemon re-keys a booted VIRTUAL device to
+ * a runtime serial that no longer matches its image id — when it is the source of a re-keyed
+ * virtual device of the same name (one image per such device, not all same-named images). Physical
+ * devices are not re-keyed, so they dedup by exact id only and never hide a same-named shut-down
+ * image. This keeps distinct devices that merely share a display name (common for simulators) from
+ * vanishing when a sibling boots. Booted devices carry no OS/architecture from the daemon today, so
+ * Android API is best-effort parsed from the name.
  */
 fun buildPickerDevices(
   booted: List<BootedDeviceInfo>,
@@ -84,9 +85,12 @@ fun buildPickerDevices(
     )
   }
 
-  // Count, per display name, the booted devices whose runtime id is NOT itself an image id — these
-  // were re-keyed on boot, so each hides exactly ONE same-named image (its source).
-  val hideByName = booted.filter { it.deviceId !in imageIds }.groupingBy { it.name }.eachCount()
+  // Per display name, count the booted VIRTUAL devices whose runtime id is not itself an image id:
+  // these were re-keyed on boot, so each hides exactly ONE same-named image (its source). Physical
+  // devices are excluded — they are not re-keyed, so they dedup by exact id (above) only and must
+  // not hide a distinct same-named shut-down image.
+  val hideByName =
+    booted.filter { it.isVirtual && it.deviceId !in imageIds }.groupingBy { it.name }.eachCount()
 
   val shutdownDevices =
     images

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerModels.kt
@@ -54,16 +54,21 @@ private fun osOfImage(image: DeviceImageInfo): Pair<String?, String?> =
   }
 
 /**
- * Merge the booted-devices and device-images resources into one picker list. Booted devices win
- * over their image entry (deduped by id and by name). Booted devices carry no OS/architecture from
- * the daemon today, so Android API is best-effort parsed from the name.
+ * Merge the booted-devices and device-images resources into one picker list. A booted device wins
+ * over the specific image it came from, reconciled by IDENTITY, not display name: an image is
+ * hidden only when its own id is booted, or — because the daemon re-keys a booted device to a
+ * runtime serial that no longer matches its image id — when it is the source of a re-keyed booted
+ * device of the same name (one image per such device, not all same-named images). This keeps
+ * distinct devices that merely share a display name (common for simulators) from vanishing when a
+ * sibling boots. Booted devices carry no OS/architecture from the daemon today, so Android API is
+ * best-effort parsed from the name.
  */
 fun buildPickerDevices(
   booted: List<BootedDeviceInfo>,
   images: List<DeviceImageInfo>,
 ): List<PickerDevice> {
   val bootedIds = booted.map { it.deviceId }.toSet()
-  val bootedNames = booted.map { it.name }.toSet()
+  val imageIds = images.map { it.deviceId ?: it.name }.toSet()
 
   val bootedDevices = booted.map { device ->
     val api =
@@ -79,9 +84,15 @@ fun buildPickerDevices(
     )
   }
 
+  // Count, per display name, the booted devices whose runtime id is NOT itself an image id — these
+  // were re-keyed on boot, so each hides exactly ONE same-named image (its source).
+  val hideByName = booted.filter { it.deviceId !in imageIds }.groupingBy { it.name }.eachCount()
+
   val shutdownDevices =
     images
-      .filter { (it.deviceId ?: it.name) !in bootedIds && it.name !in bootedNames }
+      .filter { (it.deviceId ?: it.name) !in bootedIds } // exact identity already booted
+      .groupBy { it.name }
+      .flatMap { (name, sameName) -> sameName.drop(hideByName[name] ?: 0) }
       .map { image ->
         val (osKey, osLabel) = osOfImage(image)
         PickerDevice(

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerModels.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerModels.kt
@@ -55,21 +55,30 @@ private fun osOfImage(image: DeviceImageInfo): Pair<String?, String?> =
 
 /**
  * Merge the booted-devices and device-images resources into one picker list. A booted device wins
- * over the specific image it came from, reconciled by IDENTITY, not display name: an image is
- * hidden only when its own id is booted, or — because the daemon re-keys a booted VIRTUAL device to
- * a runtime serial that no longer matches its image id — when it is the source of a re-keyed
- * virtual device of the same name (one image per such device, not all same-named images). Physical
- * devices are not re-keyed, so they dedup by exact id only and never hide a same-named shut-down
- * image. This keeps distinct devices that merely share a display name (common for simulators) from
- * vanishing when a sibling boots. Booted devices carry no OS/architecture from the daemon today, so
- * Android API is best-effort parsed from the name.
+ * over the specific image it came from, reconciled by IDENTITY, not display name:
+ * - an image is hidden when its own id is booted (exact match — e.g. iOS simulators keep their UDID
+ *   across boot); or
+ * - when [sourceImageToRuntimeId] attributes a booted runtime id to that exact source image (an
+ *   in-session boot: `BootDevice(sourceImageId)` -> `StartDeviceResult.deviceId`), so re-keyed
+ *   devices hide their EXACT source, never a positional same-name guess; or
+ * - as a FALLBACK for a booted VIRTUAL device not attributed in-session (already-running /
+ *   externally booted) that the daemon re-keyed off its image id — one same-named image per such
+ *   device, not all same-named images.
+ *
+ * Physical devices are not re-keyed, so they dedup by exact id only and never hide a distinct
+ * same-named shut-down image. This keeps devices that merely share a display name (common for
+ * simulators) from vanishing when a sibling boots. Booted devices carry no OS/architecture from the
+ * daemon today, so Android API is best-effort parsed from the name.
  */
 fun buildPickerDevices(
   booted: List<BootedDeviceInfo>,
   images: List<DeviceImageInfo>,
+  sourceImageToRuntimeId: Map<String, String> = emptyMap(),
 ): List<PickerDevice> {
   val bootedIds = booted.map { it.deviceId }.toSet()
   val imageIds = images.map { it.deviceId ?: it.name }.toSet()
+  val runtimeToSourceImage =
+    sourceImageToRuntimeId.entries.associate { (source, rt) -> rt to source }
 
   val bootedDevices = booted.map { device ->
     val api =
@@ -85,16 +94,24 @@ fun buildPickerDevices(
     )
   }
 
-  // Per display name, count the booted VIRTUAL devices whose runtime id is not itself an image id:
-  // these were re-keyed on boot, so each hides exactly ONE same-named image (its source). Physical
-  // devices are excluded — they are not re-keyed, so they dedup by exact id (above) only and must
-  // not hide a distinct same-named shut-down image.
+  // Exact source images hidden via in-session boot attribution (runtime id -> its source image id).
+  val attributedSourceIds = booted.mapNotNull { runtimeToSourceImage[it.deviceId] }.toSet()
+
+  // Fallback name heuristic ONLY for re-keyed VIRTUAL devices with no in-session attribution
+  // (already-running / externally booted): each hides exactly one same-named image, not all.
+  // Physical devices are excluded — they are not re-keyed and must not hide a distinct sibling.
   val hideByName =
-    booted.filter { it.isVirtual && it.deviceId !in imageIds }.groupingBy { it.name }.eachCount()
+    booted
+      .filter {
+        it.isVirtual && it.deviceId !in imageIds && it.deviceId !in runtimeToSourceImage
+      }
+      .groupingBy { it.name }
+      .eachCount()
 
   val shutdownDevices =
     images
       .filter { (it.deviceId ?: it.name) !in bootedIds } // exact identity already booted
+      .filter { (it.deviceId ?: it.name) !in attributedSourceIds } // exact in-session source
       .groupBy { it.name }
       .flatMap { (name, sameName) -> sameName.drop(hideByName[name] ?: 0) }
       .map { image ->

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerUiTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import dev.jasonpearson.automobile.desktop.core.workspace.Platform
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -23,8 +24,11 @@ class DevicePickerUiTest {
       PickerDevice("i15", "iPhone 15", Platform.Ios, DeviceState.Shutdown, "17", "iOS 17", "arm64"),
     )
 
-  private fun content(selected: Set<String> = emptySet()) =
-    DevicePickerUiState.Content(devices, PickerFilters(), selected)
+  private fun content(
+    selected: Set<String> = emptySet(),
+    bootingIds: Set<String> = emptySet(),
+    bootErrors: Map<String, String> = emptyMap(),
+  ) = DevicePickerUiState.Content(devices, PickerFilters(), selected, bootingIds, bootErrors)
 
   @Test
   fun `renders rail options and device cards`() = runComposeUiTest {
@@ -33,7 +37,53 @@ class DevicePickerUiTest {
     onNodeWithContentDescription("Select filter Android").assertIsDisplayed()
     onNodeWithText("Pixel 8", substring = true).assertIsDisplayed()
     onNodeWithContentDescription("Select Pixel 8").assertIsDisplayed()
-    onNodeWithContentDescription("iPhone 15 (not booted)").assertIsDisplayed()
+    onNodeWithContentDescription("Boot iPhone 15").assertIsDisplayed()
+    onNodeWithText("Click to boot").assertIsDisplayed()
+  }
+
+  @Test
+  fun `clicking a shut-down card dispatches BootDevice`() = runComposeUiTest {
+    var action: DevicePickerAction? = null
+    setContent {
+      MaterialTheme { DevicePicker(content(), onAction = { action = it }, onClose = {}) }
+    }
+    onNodeWithContentDescription("Boot iPhone 15").performClick()
+    assertEquals(DevicePickerAction.BootDevice("i15"), action)
+  }
+
+  @Test
+  fun `a booting card shows Booting and is not re-triggerable`() = runComposeUiTest {
+    var action: DevicePickerAction? = null
+    setContent {
+      MaterialTheme {
+        DevicePicker(
+          content(bootingIds = setOf("i15")),
+          onAction = { action = it },
+          onClose = {},
+        )
+      }
+    }
+    onNodeWithText("Booting…").assertIsDisplayed()
+    onNodeWithContentDescription("Boot iPhone 15").assertDoesNotExist()
+    onNodeWithContentDescription("Booting iPhone 15").performClick()
+    assertNull(action) // a boot in flight is not clickable
+  }
+
+  @Test
+  fun `a failed card offers a retry that dispatches BootDevice`() = runComposeUiTest {
+    var action: DevicePickerAction? = null
+    setContent {
+      MaterialTheme {
+        DevicePicker(
+          content(bootErrors = mapOf("i15" to "boom")),
+          onAction = { action = it },
+          onClose = {},
+        )
+      }
+    }
+    onNodeWithText("Boot failed · Click to retry").assertIsDisplayed()
+    onNodeWithContentDescription("Retry boot iPhone 15").performClick()
+    assertEquals(DevicePickerAction.BootDevice("i15"), action)
   }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerUiTest.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import dev.jasonpearson.automobile.desktop.core.workspace.Platform
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -52,21 +51,17 @@ class DevicePickerUiTest {
   }
 
   @Test
-  fun `a booting card shows Booting and is not re-triggerable`() = runComposeUiTest {
-    var action: DevicePickerAction? = null
+  fun `a booting card shows Booting and offers no boot affordance`() = runComposeUiTest {
     setContent {
       MaterialTheme {
-        DevicePicker(
-          content(bootingIds = setOf("i15")),
-          onAction = { action = it },
-          onClose = {},
-        )
+        DevicePicker(content(bootingIds = setOf("i15")), onAction = {}, onClose = {})
       }
     }
+    // No boot/retry affordance while a boot is in flight — the card is a passive "Booting…".
     onNodeWithText("Booting…").assertIsDisplayed()
+    onNodeWithText("Click to boot").assertDoesNotExist()
     onNodeWithContentDescription("Boot iPhone 15").assertDoesNotExist()
-    onNodeWithContentDescription("Booting iPhone 15").performClick()
-    assertNull(action) // a boot in flight is not clickable
+    onNodeWithContentDescription("Retry boot iPhone 15").assertDoesNotExist()
   }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
@@ -40,9 +40,15 @@ class DevicePickerViewModelTest {
 
   private fun content(vm: DevicePickerViewModel) = vm.state.value as DevicePickerUiState.Content
 
+  private fun vm(
+    resourceClient: FakeMcpResourceClient = fake(),
+    bootController: DeviceBootController = FakeDeviceBootController(),
+  ) = DevicePickerViewModel(resourceClient, bootController, testScope, UnconfinedTestDispatcher())
+
   @Test
   fun `loads and unifies booted + images with dedupe and iOS architecture`() = testScope.runTest {
-    val vm = DevicePickerViewModel(fake(), this, UnconfinedTestDispatcher())
+    val vm =
+      DevicePickerViewModel(fake(), FakeDeviceBootController(), this, UnconfinedTestDispatcher())
     val c = content(vm)
     assertEquals(listOf("emulator-5554", "Pixel_6_API_33", "iphone-15"), c.devices.map { it.id })
     val pixel8 = c.devices.first { it.id == "emulator-5554" }
@@ -56,7 +62,8 @@ class DevicePickerViewModelTest {
 
   @Test
   fun `toggling a platform updates the filters`() = testScope.runTest {
-    val vm = DevicePickerViewModel(fake(), this, UnconfinedTestDispatcher())
+    val vm =
+      DevicePickerViewModel(fake(), FakeDeviceBootController(), this, UnconfinedTestDispatcher())
     vm.onAction(DevicePickerAction.TogglePlatform(Platform.Ios))
     assertEquals(setOf(Platform.Ios), content(vm).filters.platforms)
     vm.onAction(DevicePickerAction.TogglePlatform(Platform.Ios))
@@ -65,7 +72,8 @@ class DevicePickerViewModelTest {
 
   @Test
   fun `only booted devices can be selected`() = testScope.runTest {
-    val vm = DevicePickerViewModel(fake(), this, UnconfinedTestDispatcher())
+    val vm =
+      DevicePickerViewModel(fake(), FakeDeviceBootController(), this, UnconfinedTestDispatcher())
     vm.onAction(DevicePickerAction.ToggleSelect("iphone-15")) // shutdown — ignored
     assertTrue(content(vm).selectedIds.isEmpty())
     vm.onAction(DevicePickerAction.ToggleSelect("emulator-5554")) // booted
@@ -74,7 +82,8 @@ class DevicePickerViewModelTest {
 
   @Test
   fun `observe selected emits one column per selected booted device`() = testScope.runTest {
-    val vm = DevicePickerViewModel(fake(), this, UnconfinedTestDispatcher())
+    val vm =
+      DevicePickerViewModel(fake(), FakeDeviceBootController(), this, UnconfinedTestDispatcher())
     vm.effect.test {
       vm.onAction(DevicePickerAction.ToggleSelect("emulator-5554"))
       vm.onAction(DevicePickerAction.ObserveSelected)
@@ -89,7 +98,8 @@ class DevicePickerViewModelTest {
 
   @Test
   fun `clear filter resets that dimension`() = testScope.runTest {
-    val vm = DevicePickerViewModel(fake(), this, UnconfinedTestDispatcher())
+    val vm =
+      DevicePickerViewModel(fake(), FakeDeviceBootController(), this, UnconfinedTestDispatcher())
     vm.onAction(DevicePickerAction.TogglePlatform(Platform.Android))
     vm.onAction(DevicePickerAction.ToggleOs("35"))
     vm.onAction(DevicePickerAction.ClearFilter(FilterDimension.Platform))
@@ -97,5 +107,74 @@ class DevicePickerViewModelTest {
     assertTrue(f.platforms.isEmpty())
     assertTrue(f.osKeys.isEmpty()) // clearing platform also clears the gated OS selection
     assertNull(f.states.firstOrNull())
+  }
+
+  @Test
+  fun `booting a shut-down card marks it booting until the boot resolves`() = testScope.runTest {
+    val boot = FakeDeviceBootController().apply { autoComplete = false }
+    val v = vm(bootController = boot)
+    v.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33"))
+    assertEquals(setOf("Pixel_6_API_33"), content(v).bootingIds)
+    assertEquals(listOf("Pixel_6_API_33"), boot.bootRequests.map { it.id })
+    boot.complete() // let the held boot resolve so runTest can finish
+  }
+
+  @Test
+  fun `successful boot reloads to booted, auto-selects the new id, and clears booting`() =
+    testScope.runTest {
+      val resources = fake()
+      val boot =
+        FakeDeviceBootController().apply {
+          // The daemon re-keys a booted device to a runtime serial (emulator-5556), not the AVD id.
+          onSuccess = {
+            resources.bootedDevicesResponse =
+              """
+              {"totalCount":2,"androidCount":2,"iosCount":0,"virtualCount":2,"physicalCount":0,
+               "lastUpdated":"x","devices":[
+                 {"name":"Pixel 8 API 35","platform":"android","deviceId":"emulator-5554",
+                  "source":"local","isVirtual":true,"status":"booted"},
+                 {"name":"Pixel 6 API 33","platform":"android","deviceId":"emulator-5556",
+                  "source":"local","isVirtual":true,"status":"booted"}]}
+              """
+                .trimIndent()
+          }
+        }
+      val v = vm(resourceClient = resources, bootController = boot)
+      v.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33"))
+      val c = content(v)
+      assertTrue("emulator-5556" in c.selectedIds)
+      assertTrue(c.bootingIds.isEmpty())
+      assertTrue(c.devices.any { it.id == "emulator-5556" && it.state == DeviceState.Booted })
+      assertTrue(c.devices.none { it.id == "Pixel_6_API_33" }) // shut-down entry replaced by booted
+    }
+
+  @Test
+  fun `failed boot clears booting and exposes a retryable error`() = testScope.runTest {
+    val boot =
+      FakeDeviceBootController().apply { result = Result.failure(RuntimeException("boom")) }
+    val v = vm(bootController = boot)
+    v.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33"))
+    val c = content(v)
+    assertTrue(c.bootingIds.isEmpty())
+    assertEquals("boom", c.bootErrors["Pixel_6_API_33"])
+  }
+
+  @Test
+  fun `booting a device that is already booting is a no-op`() = testScope.runTest {
+    val boot = FakeDeviceBootController().apply { autoComplete = false }
+    val v = vm(bootController = boot)
+    v.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33"))
+    v.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33"))
+    assertEquals(1, boot.bootRequests.size)
+    boot.complete() // let the held boot resolve so runTest can finish
+  }
+
+  @Test
+  fun `booting an already-booted device is ignored`() = testScope.runTest {
+    val boot = FakeDeviceBootController()
+    val v = vm(bootController = boot)
+    v.onAction(DevicePickerAction.BootDevice("emulator-5554")) // already booted
+    assertTrue(boot.bootRequests.isEmpty())
+    assertTrue(content(v).bootingIds.isEmpty())
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
@@ -231,52 +231,17 @@ class DevicePickerViewModelTest {
     }
 
   @Test
-  fun `concurrent boots of two same-named devices each auto-select their own runtime id`() =
+  fun `boots are serialized - a second boot while one is in flight is ignored`() =
     testScope.runTest {
-      // Two shut-down AVDs share a display name; only the exact runtime id disambiguates them.
-      val resources =
-        FakeMcpResourceClient().apply {
-          bootedDevicesResponse = bootedJson()
-          deviceImagesResponse =
-            """
-            {"totalCount":2,"androidCount":2,"iosCount":0,"lastUpdated":"x","images":[
-              {"name":"Pixel 8","platform":"android","deviceId":"avd_a","target":"android-34"},
-              {"name":"Pixel 8","platform":"android","deviceId":"avd_b","target":"android-34"}]}
-            """
-              .trimIndent()
-        }
-      // Runtime ids the "daemon" assigns; a name-based auto-select could not tell these apart.
-      val runtimeIds = mapOf("avd_a" to "emu-A", "avd_b" to "emu-B")
-      val bootedSoFar = mutableListOf<String>()
-      val boot =
-        object : DeviceBootController {
-          val gates = mutableMapOf<String, CompletableDeferred<Unit>>()
-          val requests = mutableListOf<PickerDevice>()
-
-          override suspend fun boot(device: PickerDevice): Result<String> {
-            requests += device
-            val gate = CompletableDeferred<Unit>()
-            gates[device.id] = gate
-            gate.await()
-            val runtimeId = runtimeIds.getValue(device.id)
-            bootedSoFar += runtimeId
-            resources.bootedDevicesResponse = bootedJson(*bootedSoFar.toTypedArray())
-            return Result.success(runtimeId)
-          }
-        }
-      val v = DevicePickerViewModel(resources, boot, testScope, UnconfinedTestDispatcher())
-
-      v.onAction(DevicePickerAction.BootDevice("avd_a")) // in flight
-      v.onAction(DevicePickerAction.BootDevice("avd_b")) // in flight, both booting
-      boot.gates.getValue("avd_a").complete(Unit)
-      boot.gates.getValue("avd_b").complete(Unit)
-
-      val c = content(v)
-      // Each completion selected ITS OWN runtime id — the second did not re-select the first.
-      assertEquals(setOf("emu-A", "emu-B"), c.selectedIds)
-      assertTrue(c.devices.any { it.id == "emu-A" && it.state == DeviceState.Booted })
-      assertTrue(c.devices.any { it.id == "emu-B" && it.state == DeviceState.Booted })
-      assertEquals(2, boot.requests.size)
+      // A boot is held open; a click on another shut-down card must be a no-op (no 2nd
+      // startDevice).
+      val boot = FakeDeviceBootController().apply { autoComplete = false }
+      val v = vm(bootController = boot)
+      v.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33")) // in flight (held)
+      v.onAction(DevicePickerAction.BootDevice("iphone-15")) // ignored — a boot is already running
+      assertEquals(listOf("Pixel_6_API_33"), boot.bootRequests.map { it.id })
+      assertEquals(setOf("Pixel_6_API_33"), content(v).bootingIds)
+      boot.complete() // release so runTest can finish
     }
 
   @Test
@@ -453,42 +418,87 @@ class DevicePickerViewModelTest {
     }
 
   @Test
-  fun `a superseded boot reload still syncs its selection into the current Content`() =
+  fun `a boot reload superseded by a refresh still syncs its selection`() = testScope.runTest {
+    // Boots are serialized, but a Refresh can still supersede a boot's reload list emission. The
+    // selection must survive that via syncState, not only via the (dropped) list emission.
+    val client =
+      ScriptableResourceClient(bootedJson = SINGLE_BOOTED_PIXEL8, imagesJson = THREE_IMAGES)
+    val boot =
+      FakeDeviceBootController().apply {
+        autoComplete = false
+        result = Result.success("emulator-5556")
+        onSuccess = { client.bootedJson = TWO_BOOTED_PIXEL8_AND_6 }
+      }
+    val v = DevicePickerViewModel(client, boot, testScope, UnconfinedTestDispatcher())
+    v.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33")) // boot in flight (held)
+
+    // Let the boot resolve so its reload starts, then stall that reload on the images gate.
+    val reloadGate = CompletableDeferred<Unit>()
+    client.imagesGate = reloadGate
+    boot.complete() // reloadAfterBoot (gen N) reads booted, stalls on the images gate
+    client.imagesGate = null
+
+    v.onAction(DevicePickerAction.Refresh) // gen N+1: reads (ungated) and emits — no selection yet
+    assertTrue("emulator-5556" !in content(v).selectedIds)
+
+    reloadGate.complete(Unit) // reload resumes: records selection + syncs; stale list emit dropped
+    val c = content(v)
+    assertTrue("emulator-5556" in c.selectedIds) // selection synced despite the dropped list emit
+    assertEquals(
+      setOf("emulator-5556"),
+      c.devices
+        .filter { it.id in c.selectedIds && it.state == DeviceState.Booted }
+        .map { it.id }
+        .toSet(),
+    )
+  }
+
+  @Test
+  fun `booting the second of two same-named images hides that source, not the first`() =
+    testScope.runTest {
+      val resources =
+        FakeMcpResourceClient().apply {
+          bootedDevicesResponse = bootedJson()
+          deviceImagesResponse = TWO_SAMENAME_IMAGES // avd_a, avd_b both "Pixel 8"
+        }
+      val boot =
+        FakeDeviceBootController().apply {
+          result = Result.success("emu-b")
+          onSuccess = { resources.bootedDevicesResponse = bootedJsonNamed("Pixel 8" to "emu-b") }
+        }
+      val v = vm(resourceClient = resources, bootController = boot)
+
+      v.onAction(DevicePickerAction.BootDevice("avd_b")) // boot the SECOND same-named image
+      val c = content(v)
+      // The started device shows once; its EXACT source (avd_b) is hidden; avd_a stays bootable.
+      assertTrue(c.devices.any { it.id == "emu-b" && it.state == DeviceState.Booted })
+      assertTrue(c.devices.any { it.id == "avd_a" && it.state == DeviceState.Shutdown })
+      assertTrue(c.devices.none { it.id == "avd_b" })
+      assertEquals(1, c.devices.count { it.state == DeviceState.Booted })
+    }
+
+  @Test
+  fun `a malformed booted payload after boot retains the snapshot, not a fabricated shutdown`() =
     testScope.runTest {
       val client =
-        ScriptableResourceClient(bootedJson = bootedJson(), imagesJson = TWO_SAMENAME_IMAGES)
-      val bootedRuntime = mutableListOf<String>()
-      val boot = GatedBootController(mapOf("avd_a" to "emu-a", "avd_b" to "emu-b"))
-      boot.onBooted = { runtimeId ->
-        bootedRuntime += runtimeId
-        client.bootedJson = bootedJsonNamed(*bootedRuntime.map { "Pixel 8" to it }.toTypedArray())
-      }
+        ScriptableResourceClient(bootedJson = SINGLE_BOOTED_PIXEL8, imagesJson = TWO_IMAGES_8_6)
+      val boot =
+        FakeDeviceBootController().apply {
+          result = Result.success("emulator-5556")
+          onSuccess = { client.bootedJson = "{ not valid json" } // malformed Success -> parse null
+        }
       val v = DevicePickerViewModel(client, boot, testScope, UnconfinedTestDispatcher())
-      v.onAction(DevicePickerAction.BootDevice("avd_a")) // in flight
-      v.onAction(DevicePickerAction.BootDevice("avd_b")) // in flight
-
-      // A's reload claims the earlier generation, reads booted, then stalls on the images gate.
-      val imagesGate = CompletableDeferred<Unit>()
-      client.imagesGate = imagesGate
-      boot.release("avd_a")
-      client.imagesGate = null // B's newer reload is not gated
-
-      boot.release("avd_b") // B (newer generation) reloads and emits — only B selected so far
-      assertEquals(setOf("emu-b"), content(v).selectedIds)
-
-      imagesGate.complete(
-        Unit
-      ) // A resumes: its stale LIST emission is dropped, but its selection syncs
-      val c = content(v)
-      // The emitted Content selection must match what observeSelected() would use — BOTH ids.
-      assertEquals(setOf("emu-a", "emu-b"), c.selectedIds)
-      assertEquals(
-        setOf("emu-a", "emu-b"),
-        c.devices
-          .filter { it.id in c.selectedIds && it.state == DeviceState.Booted }
-          .map { it.id }
-          .toSet(),
+      assertTrue(
+        content(v).devices.any { it.id == "emulator-5554" && it.state == DeviceState.Booted }
       )
+
+      v.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33"))
+      val c = content(v)
+      // Parse-null takes the same failure path as a read Error: prior snapshot retained + retry,
+      // NOT
+      // a fabricated shut-down card that would permit a duplicate start.
+      assertTrue(c.devices.any { it.id == "emulator-5554" && it.state == DeviceState.Booted })
+      assertTrue(c.bootErrors.containsKey("Pixel_6_API_33"))
     }
 
   @Test
@@ -586,30 +596,4 @@ private class ScriptableResourceClient(var bootedJson: String, private val image
   override suspend fun listResources(): List<ResourceInfo> = emptyList()
 
   override fun close() {}
-}
-
-/**
- * Boot controller whose per-device completions are individually gated ([release]) so a test can
- * reorder overlapping boots. On completion it returns the mapped runtime id and invokes [onBooted]
- * (typically to append that id to a resource fake's booted list).
- */
-private class GatedBootController(private val runtimeIds: Map<String, String>) :
-  DeviceBootController {
-  val requests: MutableList<PickerDevice> = mutableListOf()
-  var onBooted: (String) -> Unit = {}
-  private val gates = mutableMapOf<String, CompletableDeferred<Unit>>()
-
-  override suspend fun boot(device: PickerDevice): Result<String> {
-    requests += device
-    val gate = CompletableDeferred<Unit>()
-    gates[device.id] = gate
-    gate.await()
-    val runtimeId = runtimeIds.getValue(device.id)
-    onBooted(runtimeId)
-    return Result.success(runtimeId)
-  }
-
-  fun release(deviceId: String) {
-    gates.getValue(deviceId).complete(Unit)
-  }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
@@ -419,6 +419,78 @@ class DevicePickerViewModelTest {
       assertTrue(v.state.value is DevicePickerUiState.Error)
     }
 
+  @Test
+  fun `booting one of two same-named shut-down devices leaves the other bootable`() =
+    testScope.runTest {
+      val resources =
+        FakeMcpResourceClient().apply {
+          bootedDevicesResponse = bootedJson()
+          deviceImagesResponse = TWO_SAMENAME_IMAGES
+        }
+      val boot = FakeDeviceBootController()
+      val v = vm(resourceClient = resources, bootController = boot)
+      assertEquals(
+        setOf("avd_a", "avd_b"),
+        content(v).devices.filter { it.state == DeviceState.Shutdown }.map { it.id }.toSet(),
+      )
+
+      boot.result = Result.success("emu-a")
+      boot.onSuccess = { resources.bootedDevicesResponse = bootedJsonNamed("Pixel 8" to "emu-a") }
+      v.onAction(DevicePickerAction.BootDevice("avd_a"))
+
+      // Booting avd_a must NOT make its same-named sibling avd_b disappear (the round bug).
+      val afterFirst = content(v)
+      assertTrue(afterFirst.devices.any { it.id == "emu-a" && it.state == DeviceState.Booted })
+      assertTrue(afterFirst.devices.any { it.id == "avd_b" && it.state == DeviceState.Shutdown })
+
+      boot.result = Result.success("emu-b")
+      boot.onSuccess = {
+        resources.bootedDevicesResponse =
+          bootedJsonNamed("Pixel 8" to "emu-a", "Pixel 8" to "emu-b")
+      }
+      v.onAction(DevicePickerAction.BootDevice("avd_b")) // the sibling really is still bootable
+      assertTrue(content(v).devices.any { it.id == "emu-b" && it.state == DeviceState.Booted })
+    }
+
+  @Test
+  fun `a superseded boot reload still syncs its selection into the current Content`() =
+    testScope.runTest {
+      val client =
+        ScriptableResourceClient(bootedJson = bootedJson(), imagesJson = TWO_SAMENAME_IMAGES)
+      val bootedRuntime = mutableListOf<String>()
+      val boot = GatedBootController(mapOf("avd_a" to "emu-a", "avd_b" to "emu-b"))
+      boot.onBooted = { runtimeId ->
+        bootedRuntime += runtimeId
+        client.bootedJson = bootedJsonNamed(*bootedRuntime.map { "Pixel 8" to it }.toTypedArray())
+      }
+      val v = DevicePickerViewModel(client, boot, testScope, UnconfinedTestDispatcher())
+      v.onAction(DevicePickerAction.BootDevice("avd_a")) // in flight
+      v.onAction(DevicePickerAction.BootDevice("avd_b")) // in flight
+
+      // A's reload claims the earlier generation, reads booted, then stalls on the images gate.
+      val imagesGate = CompletableDeferred<Unit>()
+      client.imagesGate = imagesGate
+      boot.release("avd_a")
+      client.imagesGate = null // B's newer reload is not gated
+
+      boot.release("avd_b") // B (newer generation) reloads and emits — only B selected so far
+      assertEquals(setOf("emu-b"), content(v).selectedIds)
+
+      imagesGate.complete(
+        Unit
+      ) // A resumes: its stale LIST emission is dropped, but its selection syncs
+      val c = content(v)
+      // The emitted Content selection must match what observeSelected() would use — BOTH ids.
+      assertEquals(setOf("emu-a", "emu-b"), c.selectedIds)
+      assertEquals(
+        setOf("emu-a", "emu-b"),
+        c.devices
+          .filter { it.id in c.selectedIds && it.state == DeviceState.Booted }
+          .map { it.id }
+          .toSet(),
+      )
+    }
+
   private companion object {
     const val SINGLE_BOOTED_PIXEL8 =
       """{"totalCount":1,"androidCount":1,"iosCount":0,"virtualCount":1,"physicalCount":0,""" +
@@ -443,6 +515,12 @@ class DevicePickerViewModelTest {
       """{"totalCount":2,"androidCount":2,"iosCount":0,"lastUpdated":"x","images":[""" +
         """{"name":"Pixel 8 API 35","platform":"android","deviceId":"Pixel_8_API_35","target":"android-35"},""" +
         """{"name":"Pixel 6 API 33","platform":"android","deviceId":"Pixel_6_API_33","target":"android-33"}]}"""
+
+    // Two DISTINCT images that share a display name — the simulator/AVD sibling case.
+    const val TWO_SAMENAME_IMAGES =
+      """{"totalCount":2,"androidCount":2,"iosCount":0,"lastUpdated":"x","images":[""" +
+        """{"name":"Pixel 8","platform":"android","deviceId":"avd_a","target":"android-34"},""" +
+        """{"name":"Pixel 8","platform":"android","deviceId":"avd_b","target":"android-34"}]}"""
 
     fun bootedJson(vararg deviceIds: String): String =
       bootedJsonNamed(*deviceIds.map { "Pixel 8" to it }.toTypedArray())
@@ -488,4 +566,30 @@ private class ScriptableResourceClient(var bootedJson: String, private val image
   override suspend fun listResources(): List<ResourceInfo> = emptyList()
 
   override fun close() {}
+}
+
+/**
+ * Boot controller whose per-device completions are individually gated ([release]) so a test can
+ * reorder overlapping boots. On completion it returns the mapped runtime id and invokes [onBooted]
+ * (typically to append that id to a resource fake's booted list).
+ */
+private class GatedBootController(private val runtimeIds: Map<String, String>) :
+  DeviceBootController {
+  val requests: MutableList<PickerDevice> = mutableListOf()
+  var onBooted: (String) -> Unit = {}
+  private val gates = mutableMapOf<String, CompletableDeferred<Unit>>()
+
+  override suspend fun boot(device: PickerDevice): Result<String> {
+    requests += device
+    val gate = CompletableDeferred<Unit>()
+    gates[device.id] = gate
+    gate.await()
+    val runtimeId = runtimeIds.getValue(device.id)
+    onBooted(runtimeId)
+    return Result.success(runtimeId)
+  }
+
+  fun release(deviceId: String) {
+    gates.getValue(deviceId).complete(Unit)
+  }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
@@ -491,6 +491,26 @@ class DevicePickerViewModelTest {
       )
     }
 
+  @Test
+  fun `applied filters and search query survive a refresh`() = testScope.runTest {
+    val v = vm()
+    v.onAction(DevicePickerAction.TogglePlatform(Platform.Android))
+    v.onAction(DevicePickerAction.ToggleState(DeviceState.Booted))
+    v.onAction(DevicePickerAction.SetQuery("pixel"))
+    with(content(v).filters) {
+      assertEquals(setOf(Platform.Android), platforms)
+      assertTrue(DeviceState.Booted in states)
+      assertEquals("pixel", query)
+    }
+
+    v.onAction(DevicePickerAction.Refresh) // Content -> Loading -> Content swap
+    with(content(v).filters) {
+      assertEquals(setOf(Platform.Android), platforms) // survived the swap (persistent field)
+      assertTrue(DeviceState.Booted in states)
+      assertEquals("pixel", query)
+    }
+  }
+
   private companion object {
     const val SINGLE_BOOTED_PIXEL8 =
       """{"totalCount":1,"androidCount":1,"iosCount":0,"virtualCount":1,"physicalCount":0,""" +

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
@@ -177,4 +177,46 @@ class DevicePickerViewModelTest {
     assertTrue(boot.bootRequests.isEmpty())
     assertTrue(content(v).bootingIds.isEmpty())
   }
+
+  @Test
+  fun `a refresh mid-boot preserves the guard and cannot issue a second startDevice`() =
+    testScope.runTest {
+      val boot = FakeDeviceBootController().apply { autoComplete = false } // hold the boot open
+      val v = vm(bootController = boot)
+      v.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33"))
+      assertEquals(setOf("Pixel_6_API_33"), content(v).bootingIds)
+      // Reopen/refresh while the boot is still in flight — load() swaps Content out and back.
+      v.onAction(DevicePickerAction.Refresh)
+      assertEquals(setOf("Pixel_6_API_33"), content(v).bootingIds) // guard survived the reload
+      v.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33")) // clicking again must not re-boot
+      assertEquals(1, boot.bootRequests.size)
+      boot.complete() // release; device still shut down on reload -> boot did not complete
+    }
+
+  @Test
+  fun `a boot completing after a mid-boot refresh still auto-selects the booted device`() =
+    testScope.runTest {
+      val resources = fake()
+      val boot = FakeDeviceBootController().apply { autoComplete = false }
+      val v = vm(resourceClient = resources, bootController = boot)
+      v.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33"))
+      v.onAction(DevicePickerAction.Refresh) // state cycled Loading -> Content, guard preserved
+      assertEquals(setOf("Pixel_6_API_33"), content(v).bootingIds)
+      // The daemon finished the boot; it now reports the device booted under a runtime serial.
+      resources.bootedDevicesResponse =
+        """
+        {"totalCount":2,"androidCount":2,"iosCount":0,"virtualCount":2,"physicalCount":0,
+         "lastUpdated":"x","devices":[
+           {"name":"Pixel 8 API 35","platform":"android","deviceId":"emulator-5554",
+            "source":"local","isVirtual":true,"status":"booted"},
+           {"name":"Pixel 6 API 33","platform":"android","deviceId":"emulator-5556",
+            "source":"local","isVirtual":true,"status":"booted"}]}
+        """
+          .trimIndent()
+      boot.complete() // reloadAfterBoot fetches -> device booted -> auto-select by name
+      val c = content(v)
+      assertTrue("emulator-5556" in c.selectedIds)
+      assertTrue(c.bootingIds.isEmpty())
+      assertTrue(c.devices.any { it.id == "emulator-5556" && it.state == DeviceState.Booted })
+    }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
@@ -2,7 +2,11 @@ package dev.jasonpearson.automobile.desktop.core.workspace.picker
 
 import app.cash.turbine.test
 import dev.jasonpearson.automobile.desktop.core.mcp.FakeMcpResourceClient
+import dev.jasonpearson.automobile.desktop.core.mcp.McpResourceClient
+import dev.jasonpearson.automobile.desktop.core.mcp.ResourceInfo
+import dev.jasonpearson.automobile.desktop.core.mcp.ResourceReadResult
 import dev.jasonpearson.automobile.desktop.core.workspace.Platform
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -125,7 +129,9 @@ class DevicePickerViewModelTest {
       val resources = fake()
       val boot =
         FakeDeviceBootController().apply {
-          // The daemon re-keys a booted device to a runtime serial (emulator-5556), not the AVD id.
+          // The daemon re-keys a booted device to a runtime serial (emulator-5556), not the AVD id,
+          // and returns that exact id from startDevice — auto-select keys on it, not the name.
+          result = Result.success("emulator-5556")
           onSuccess = {
             resources.bootedDevicesResponse =
               """
@@ -197,7 +203,11 @@ class DevicePickerViewModelTest {
   fun `a boot completing after a mid-boot refresh still auto-selects the booted device`() =
     testScope.runTest {
       val resources = fake()
-      val boot = FakeDeviceBootController().apply { autoComplete = false }
+      val boot =
+        FakeDeviceBootController().apply {
+          autoComplete = false
+          result = Result.success("emulator-5556")
+        }
       val v = vm(resourceClient = resources, bootController = boot)
       v.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33"))
       v.onAction(DevicePickerAction.Refresh) // state cycled Loading -> Content, guard preserved
@@ -213,10 +223,214 @@ class DevicePickerViewModelTest {
             "source":"local","isVirtual":true,"status":"booted"}]}
         """
           .trimIndent()
-      boot.complete() // reloadAfterBoot fetches -> device booted -> auto-select by name
+      boot.complete() // reloadAfterBoot fetches -> device booted -> auto-select by runtime id
       val c = content(v)
       assertTrue("emulator-5556" in c.selectedIds)
       assertTrue(c.bootingIds.isEmpty())
       assertTrue(c.devices.any { it.id == "emulator-5556" && it.state == DeviceState.Booted })
     }
+
+  @Test
+  fun `concurrent boots of two same-named devices each auto-select their own runtime id`() =
+    testScope.runTest {
+      // Two shut-down AVDs share a display name; only the exact runtime id disambiguates them.
+      val resources =
+        FakeMcpResourceClient().apply {
+          bootedDevicesResponse = bootedJson()
+          deviceImagesResponse =
+            """
+            {"totalCount":2,"androidCount":2,"iosCount":0,"lastUpdated":"x","images":[
+              {"name":"Pixel 8","platform":"android","deviceId":"avd_a","target":"android-34"},
+              {"name":"Pixel 8","platform":"android","deviceId":"avd_b","target":"android-34"}]}
+            """
+              .trimIndent()
+        }
+      // Runtime ids the "daemon" assigns; a name-based auto-select could not tell these apart.
+      val runtimeIds = mapOf("avd_a" to "emu-A", "avd_b" to "emu-B")
+      val bootedSoFar = mutableListOf<String>()
+      val boot =
+        object : DeviceBootController {
+          val gates = mutableMapOf<String, CompletableDeferred<Unit>>()
+          val requests = mutableListOf<PickerDevice>()
+
+          override suspend fun boot(device: PickerDevice): Result<String> {
+            requests += device
+            val gate = CompletableDeferred<Unit>()
+            gates[device.id] = gate
+            gate.await()
+            val runtimeId = runtimeIds.getValue(device.id)
+            bootedSoFar += runtimeId
+            resources.bootedDevicesResponse = bootedJson(*bootedSoFar.toTypedArray())
+            return Result.success(runtimeId)
+          }
+        }
+      val v = DevicePickerViewModel(resources, boot, testScope, UnconfinedTestDispatcher())
+
+      v.onAction(DevicePickerAction.BootDevice("avd_a")) // in flight
+      v.onAction(DevicePickerAction.BootDevice("avd_b")) // in flight, both booting
+      boot.gates.getValue("avd_a").complete(Unit)
+      boot.gates.getValue("avd_b").complete(Unit)
+
+      val c = content(v)
+      // Each completion selected ITS OWN runtime id — the second did not re-select the first.
+      assertEquals(setOf("emu-A", "emu-B"), c.selectedIds)
+      assertTrue(c.devices.any { it.id == "emu-A" && it.state == DeviceState.Booted })
+      assertTrue(c.devices.any { it.id == "emu-B" && it.state == DeviceState.Booted })
+      assertEquals(2, boot.requests.size)
+    }
+
+  @Test
+  fun `a stale load resuming after a boot completion cannot clobber the fresh state`() =
+    testScope.runTest {
+      val client =
+        GatedResourceClient(
+          bootedJson = SINGLE_BOOTED_PIXEL8,
+          imagesJson = THREE_IMAGES,
+        )
+      val boot =
+        FakeDeviceBootController().apply {
+          autoComplete = false
+          result = Result.success("emulator-5556")
+          onSuccess = { client.bootedJson = TWO_BOOTED_PIXEL8_AND_6 }
+        }
+      val v = DevicePickerViewModel(client, boot, testScope, UnconfinedTestDispatcher())
+      v.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33")) // boot in flight (gated)
+
+      // Start a Refresh that reads the OLD booted list, then stalls before it can emit.
+      val staleGate = CompletableDeferred<Unit>()
+      client.imagesGate = staleGate
+      v.onAction(DevicePickerAction.Refresh)
+      client.imagesGate = null // the post-boot reload must not be gated
+
+      boot.complete() // reloadAfterBoot fetches fresh, emits + selects the booted device
+      assertTrue("emulator-5556" in content(v).selectedIds)
+
+      staleGate.complete(Unit) // stale Refresh resumes with the OLD (shut-down) list — dropped
+      val c = content(v)
+      assertTrue("emulator-5556" in c.selectedIds) // fresh post-boot state survived
+      assertTrue(c.devices.any { it.id == "emulator-5556" && it.state == DeviceState.Booted })
+      assertTrue(c.devices.none { it.id == "Pixel_6_API_33" }) // stale shut-down card not restored
+
+      v.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33")) // gone -> no second startDevice
+      assertEquals(1, boot.bootRequests.size)
+    }
+
+  @Test
+  fun `a booted-read error after boot retains the snapshot instead of fabricating a shutdown card`() =
+    testScope.runTest {
+      val client = ToggleErrorResourceClient()
+      val boot =
+        FakeDeviceBootController().apply {
+          result = Result.success("emulator-5556")
+          onSuccess = { client.failBooted = true } // the post-boot booted read errors transiently
+        }
+      val v = DevicePickerViewModel(client, boot, testScope, UnconfinedTestDispatcher())
+      // Initial load is healthy: Pixel 8 booted, Pixel 6 shut down.
+      assertTrue(
+        content(v).devices.any { it.id == "emulator-5554" && it.state == DeviceState.Booted }
+      )
+
+      v.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33"))
+      val c = content(v)
+      // The failed booted read did NOT rebuild from the images-only read (which would have shown
+      // the
+      // still-booted Pixel 8 as shut down). Previous snapshot retained; a retry is surfaced.
+      assertTrue(c.devices.any { it.id == "emulator-5554" && it.state == DeviceState.Booted })
+      assertTrue(c.bootingIds.isEmpty())
+      assertTrue(c.bootErrors.containsKey("Pixel_6_API_33"))
+    }
+
+  @Test
+  fun `a resource read error surfaces as Error state rather than an empty picker`() =
+    testScope.runTest {
+      val client = ToggleErrorResourceClient().apply { failBooted = true }
+      val v =
+        DevicePickerViewModel(
+          client,
+          FakeDeviceBootController(),
+          testScope,
+          UnconfinedTestDispatcher(),
+        )
+      assertTrue(v.state.value is DevicePickerUiState.Error)
+    }
+
+  private companion object {
+    const val SINGLE_BOOTED_PIXEL8 =
+      """{"totalCount":1,"androidCount":1,"iosCount":0,"virtualCount":1,"physicalCount":0,""" +
+        """"lastUpdated":"x","devices":[{"name":"Pixel 8 API 35","platform":"android",""" +
+        """"deviceId":"emulator-5554","source":"local","isVirtual":true,"status":"booted"}]}"""
+
+    const val TWO_BOOTED_PIXEL8_AND_6 =
+      """{"totalCount":2,"androidCount":2,"iosCount":0,"virtualCount":2,"physicalCount":0,""" +
+        """"lastUpdated":"x","devices":[""" +
+        """{"name":"Pixel 8 API 35","platform":"android","deviceId":"emulator-5554",""" +
+        """"source":"local","isVirtual":true,"status":"booted"},""" +
+        """{"name":"Pixel 6 API 33","platform":"android","deviceId":"emulator-5556",""" +
+        """"source":"local","isVirtual":true,"status":"booted"}]}"""
+
+    const val THREE_IMAGES =
+      """{"totalCount":3,"androidCount":2,"iosCount":1,"lastUpdated":"x","images":[""" +
+        """{"name":"Pixel 8 API 35","platform":"android","deviceId":"Pixel_8_API_35","target":"android-35"},""" +
+        """{"name":"Pixel 6 API 33","platform":"android","deviceId":"Pixel_6_API_33","target":"android-33"},""" +
+        """{"name":"iPhone 15","platform":"ios","deviceId":"iphone-15","iosVersion":"17.2"}]}"""
+
+    fun bootedJson(vararg deviceIds: String): String {
+      val devices =
+        deviceIds.joinToString(",") { id ->
+          """{"name":"Pixel 8","platform":"android","deviceId":"$id",""" +
+            """"source":"local","isVirtual":true,"status":"booted"}"""
+        }
+      val n = deviceIds.size
+      return """{"totalCount":$n,"androidCount":$n,"iosCount":0,"virtualCount":$n,""" +
+        """"physicalCount":0,"lastUpdated":"x","devices":[$devices]}"""
+    }
+  }
+}
+
+/** Resource fake whose device-images read can be gated to reorder a load against a boot. */
+private class GatedResourceClient(var bootedJson: String, private val imagesJson: String) :
+  McpResourceClient {
+  var imagesGate: CompletableDeferred<Unit>? = null
+
+  override suspend fun readResource(uri: String): ResourceReadResult =
+    when (uri) {
+      "automobile:devices/booted" -> ResourceReadResult.Success(bootedJson, "application/json")
+      "automobile:devices/images" -> {
+        imagesGate?.await()
+        ResourceReadResult.Success(imagesJson, "application/json")
+      }
+      else -> ResourceReadResult.Error("unknown resource: $uri")
+    }
+
+  override suspend fun listResources(): List<ResourceInfo> = emptyList()
+
+  override fun close() {}
+}
+
+/** Resource fake whose booted read can be flipped to an error to exercise partial-read handling. */
+private class ToggleErrorResourceClient : McpResourceClient {
+  var failBooted: Boolean = false
+
+  private val bootedJson =
+    """{"totalCount":1,"androidCount":1,"iosCount":0,"virtualCount":1,"physicalCount":0,""" +
+      """"lastUpdated":"x","devices":[{"name":"Pixel 8 API 35","platform":"android",""" +
+      """"deviceId":"emulator-5554","source":"local","isVirtual":true,"status":"booted"}]}"""
+
+  private val imagesJson =
+    """{"totalCount":2,"androidCount":2,"iosCount":0,"lastUpdated":"x","images":[""" +
+      """{"name":"Pixel 8 API 35","platform":"android","deviceId":"Pixel_8_API_35","target":"android-35"},""" +
+      """{"name":"Pixel 6 API 33","platform":"android","deviceId":"Pixel_6_API_33","target":"android-33"}]}"""
+
+  override suspend fun readResource(uri: String): ResourceReadResult =
+    when (uri) {
+      "automobile:devices/booted" ->
+        if (failBooted) ResourceReadResult.Error("transient booted-read failure")
+        else ResourceReadResult.Success(bootedJson, "application/json")
+      "automobile:devices/images" -> ResourceReadResult.Success(imagesJson, "application/json")
+      else -> ResourceReadResult.Error("unknown resource: $uri")
+    }
+
+  override suspend fun listResources(): List<ResourceInfo> = emptyList()
+
+  override fun close() {}
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/DevicePickerViewModelTest.kt
@@ -283,10 +283,7 @@ class DevicePickerViewModelTest {
   fun `a stale load resuming after a boot completion cannot clobber the fresh state`() =
     testScope.runTest {
       val client =
-        GatedResourceClient(
-          bootedJson = SINGLE_BOOTED_PIXEL8,
-          imagesJson = THREE_IMAGES,
-        )
+        ScriptableResourceClient(bootedJson = SINGLE_BOOTED_PIXEL8, imagesJson = THREE_IMAGES)
       val boot =
         FakeDeviceBootController().apply {
           autoComplete = false
@@ -318,7 +315,8 @@ class DevicePickerViewModelTest {
   @Test
   fun `a booted-read error after boot retains the snapshot instead of fabricating a shutdown card`() =
     testScope.runTest {
-      val client = ToggleErrorResourceClient()
+      val client =
+        ScriptableResourceClient(bootedJson = SINGLE_BOOTED_PIXEL8, imagesJson = TWO_IMAGES_8_6)
       val boot =
         FakeDeviceBootController().apply {
           result = Result.success("emulator-5556")
@@ -343,7 +341,9 @@ class DevicePickerViewModelTest {
   @Test
   fun `a resource read error surfaces as Error state rather than an empty picker`() =
     testScope.runTest {
-      val client = ToggleErrorResourceClient().apply { failBooted = true }
+      val client =
+        ScriptableResourceClient(bootedJson = SINGLE_BOOTED_PIXEL8, imagesJson = TWO_IMAGES_8_6)
+          .apply { failBooted = true }
       val v =
         DevicePickerViewModel(
           client,
@@ -351,6 +351,71 @@ class DevicePickerViewModelTest {
           testScope,
           UnconfinedTestDispatcher(),
         )
+      assertTrue(v.state.value is DevicePickerUiState.Error)
+    }
+
+  @Test
+  fun `boot selections accumulate across boots and survive a refresh`() = testScope.runTest {
+    // Two differently-named shut-down devices so both can coexist (booted + shutdown) in the list.
+    val resources =
+      FakeMcpResourceClient().apply {
+        bootedDevicesResponse = bootedJson()
+        deviceImagesResponse =
+          """
+          {"totalCount":2,"androidCount":2,"iosCount":0,"lastUpdated":"x","images":[
+            {"name":"Pixel 6","platform":"android","deviceId":"avd_6","target":"android-33"},
+            {"name":"Pixel 5","platform":"android","deviceId":"avd_5","target":"android-32"}]}
+          """
+            .trimIndent()
+      }
+    val boot = FakeDeviceBootController()
+    val v = vm(resourceClient = resources, bootController = boot)
+
+    boot.result = Result.success("emu-6")
+    boot.onSuccess = {
+      resources.bootedDevicesResponse = bootedJsonNamed("Pixel 6" to "emu-6")
+    }
+    v.onAction(DevicePickerAction.BootDevice("avd_6"))
+    assertEquals(setOf("emu-6"), content(v).selectedIds)
+
+    boot.result = Result.success("emu-5")
+    boot.onSuccess = {
+      resources.bootedDevicesResponse = bootedJsonNamed("Pixel 6" to "emu-6", "Pixel 5" to "emu-5")
+    }
+    v.onAction(DevicePickerAction.BootDevice("avd_5"))
+    assertEquals(setOf("emu-6", "emu-5"), content(v).selectedIds) // accumulated, not replaced
+
+    // A refresh replaces only the device LIST; the accumulated selection must survive the
+    // Loading->Content swap (it lives on the ViewModel, not the discarded Content).
+    v.onAction(DevicePickerAction.Refresh)
+    val c = content(v)
+    assertEquals(setOf("emu-6", "emu-5"), c.selectedIds)
+    assertTrue(c.devices.any { it.id == "emu-6" && it.state == DeviceState.Booted })
+    assertTrue(c.devices.any { it.id == "emu-5" && it.state == DeviceState.Booted })
+  }
+
+  @Test
+  fun `a refresh during boot whose post-boot read fails ends in Error, not stuck Loading`() =
+    testScope.runTest {
+      val client =
+        ScriptableResourceClient(bootedJson = SINGLE_BOOTED_PIXEL8, imagesJson = TWO_IMAGES_8_6)
+      val boot = FakeDeviceBootController().apply { autoComplete = false }
+      val v = DevicePickerViewModel(client, boot, testScope, UnconfinedTestDispatcher())
+      v.onAction(DevicePickerAction.BootDevice("Pixel_6_API_33")) // boot in flight (gated)
+
+      // A Refresh sets Loading and stalls mid-read, so state is Loading when the boot resolves.
+      val staleGate = CompletableDeferred<Unit>()
+      client.imagesGate = staleGate
+      v.onAction(DevicePickerAction.Refresh)
+      client.imagesGate = null
+
+      // The post-boot reload's booted read now fails: the newest generation must still resolve to a
+      // terminal Error (retryable) — never leave the Refresh's Loading stranded.
+      client.failBooted = true
+      boot.complete()
+      assertTrue(v.state.value is DevicePickerUiState.Error)
+
+      staleGate.complete(Unit) // stale Refresh resumes; its emission is dropped, Error stands
       assertTrue(v.state.value is DevicePickerUiState.Error)
     }
 
@@ -374,59 +439,49 @@ class DevicePickerViewModelTest {
         """{"name":"Pixel 6 API 33","platform":"android","deviceId":"Pixel_6_API_33","target":"android-33"},""" +
         """{"name":"iPhone 15","platform":"ios","deviceId":"iphone-15","iosVersion":"17.2"}]}"""
 
-    fun bootedJson(vararg deviceIds: String): String {
-      val devices =
-        deviceIds.joinToString(",") { id ->
-          """{"name":"Pixel 8","platform":"android","deviceId":"$id",""" +
+    const val TWO_IMAGES_8_6 =
+      """{"totalCount":2,"androidCount":2,"iosCount":0,"lastUpdated":"x","images":[""" +
+        """{"name":"Pixel 8 API 35","platform":"android","deviceId":"Pixel_8_API_35","target":"android-35"},""" +
+        """{"name":"Pixel 6 API 33","platform":"android","deviceId":"Pixel_6_API_33","target":"android-33"}]}"""
+
+    fun bootedJson(vararg deviceIds: String): String =
+      bootedJsonNamed(*deviceIds.map { "Pixel 8" to it }.toTypedArray())
+
+    fun bootedJsonNamed(vararg devices: Pair<String, String>): String {
+      val entries =
+        devices.joinToString(",") { (name, id) ->
+          """{"name":"$name","platform":"android","deviceId":"$id",""" +
             """"source":"local","isVirtual":true,"status":"booted"}"""
         }
-      val n = deviceIds.size
+      val n = devices.size
       return """{"totalCount":$n,"androidCount":$n,"iosCount":0,"virtualCount":$n,""" +
-        """"physicalCount":0,"lastUpdated":"x","devices":[$devices]}"""
+        """"physicalCount":0,"lastUpdated":"x","devices":[$entries]}"""
     }
   }
 }
 
-/** Resource fake whose device-images read can be gated to reorder a load against a boot. */
-private class GatedResourceClient(var bootedJson: String, private val imagesJson: String) :
+/**
+ * Flexible resource fake: the booted-devices JSON is mutable (a boot "completes" by rewriting it),
+ * either read can be flipped to an error ([failBooted]/[failImages]) to exercise partial/total read
+ * failures, and the device-images read can be gated ([imagesGate]) to reorder a load against a boot
+ * completion.
+ */
+private class ScriptableResourceClient(var bootedJson: String, private val imagesJson: String) :
   McpResourceClient {
   var imagesGate: CompletableDeferred<Unit>? = null
-
-  override suspend fun readResource(uri: String): ResourceReadResult =
-    when (uri) {
-      "automobile:devices/booted" -> ResourceReadResult.Success(bootedJson, "application/json")
-      "automobile:devices/images" -> {
-        imagesGate?.await()
-        ResourceReadResult.Success(imagesJson, "application/json")
-      }
-      else -> ResourceReadResult.Error("unknown resource: $uri")
-    }
-
-  override suspend fun listResources(): List<ResourceInfo> = emptyList()
-
-  override fun close() {}
-}
-
-/** Resource fake whose booted read can be flipped to an error to exercise partial-read handling. */
-private class ToggleErrorResourceClient : McpResourceClient {
   var failBooted: Boolean = false
-
-  private val bootedJson =
-    """{"totalCount":1,"androidCount":1,"iosCount":0,"virtualCount":1,"physicalCount":0,""" +
-      """"lastUpdated":"x","devices":[{"name":"Pixel 8 API 35","platform":"android",""" +
-      """"deviceId":"emulator-5554","source":"local","isVirtual":true,"status":"booted"}]}"""
-
-  private val imagesJson =
-    """{"totalCount":2,"androidCount":2,"iosCount":0,"lastUpdated":"x","images":[""" +
-      """{"name":"Pixel 8 API 35","platform":"android","deviceId":"Pixel_8_API_35","target":"android-35"},""" +
-      """{"name":"Pixel 6 API 33","platform":"android","deviceId":"Pixel_6_API_33","target":"android-33"}]}"""
+  var failImages: Boolean = false
 
   override suspend fun readResource(uri: String): ResourceReadResult =
     when (uri) {
       "automobile:devices/booted" ->
         if (failBooted) ResourceReadResult.Error("transient booted-read failure")
         else ResourceReadResult.Success(bootedJson, "application/json")
-      "automobile:devices/images" -> ResourceReadResult.Success(imagesJson, "application/json")
+      "automobile:devices/images" -> {
+        imagesGate?.await()
+        if (failImages) ResourceReadResult.Error("transient images-read failure")
+        else ResourceReadResult.Success(imagesJson, "application/json")
+      }
       else -> ResourceReadResult.Error("unknown resource: $uri")
     }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerModelsTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerModelsTest.kt
@@ -46,6 +46,21 @@ class PickerModelsTest {
   }
 
   @Test
+  fun `an in-session attribution hides the exact source image, not a positional same-named one`() {
+    // Booting the SECOND same-named image: the map attributes avd_b -> emu-b, so avd_a must
+    // survive.
+    val devices =
+      buildPickerDevices(
+        booted = listOf(booted("Pixel 8", "emu-b", isVirtual = true)),
+        images = listOf(image("Pixel 8", "avd_a"), image("Pixel 8", "avd_b")),
+        sourceImageToRuntimeId = mapOf("avd_b" to "emu-b"),
+      )
+    assertTrue(devices.any { it.id == "emu-b" && it.state == DeviceState.Booted })
+    assertTrue(devices.any { it.id == "avd_a" && it.state == DeviceState.Shutdown })
+    assertTrue(devices.none { it.id == "avd_b" })
+  }
+
+  @Test
   fun `an image whose exact id is booted is hidden regardless of virtual flag`() {
     // e.g. an iOS simulator whose UDID is stable across boot — dedup by exact identity.
     val devices =

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerModelsTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/PickerModelsTest.kt
@@ -1,0 +1,59 @@
+package dev.jasonpearson.automobile.desktop.core.workspace.picker
+
+import dev.jasonpearson.automobile.desktop.core.mcp.BootedDeviceInfo
+import dev.jasonpearson.automobile.desktop.core.mcp.DeviceImageInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PickerModelsTest {
+
+  private fun booted(name: String, deviceId: String, isVirtual: Boolean) =
+    BootedDeviceInfo(
+      name = name,
+      platform = "android",
+      deviceId = deviceId,
+      source = "local",
+      isVirtual = isVirtual,
+      status = "booted",
+    )
+
+  private fun image(name: String, deviceId: String) =
+    DeviceImageInfo(name = name, platform = "android", deviceId = deviceId)
+
+  @Test
+  fun `a re-keyed virtual device hides exactly one same-named image, not both`() {
+    val devices =
+      buildPickerDevices(
+        booted = listOf(booted("Pixel 8", "emulator-5554", isVirtual = true)),
+        images = listOf(image("Pixel 8", "avd_a"), image("Pixel 8", "avd_b")),
+      )
+    assertTrue(devices.any { it.id == "emulator-5554" && it.state == DeviceState.Booted })
+    // Virtual re-key hides one same-named image; the distinct sibling remains bootable.
+    assertEquals(1, devices.count { it.state == DeviceState.Shutdown && it.name == "Pixel 8" })
+  }
+
+  @Test
+  fun `a physical booted device does not hide a same-named shutdown image`() {
+    val devices =
+      buildPickerDevices(
+        booted = listOf(booted("Pixel 8", "serial-123", isVirtual = false)),
+        images = listOf(image("Pixel 8", "avd_x")),
+      )
+    assertTrue(devices.any { it.id == "serial-123" && it.state == DeviceState.Booted })
+    // Physical devices are not re-keyed: the distinct same-named image is NOT mis-hidden.
+    assertTrue(devices.any { it.id == "avd_x" && it.state == DeviceState.Shutdown })
+  }
+
+  @Test
+  fun `an image whose exact id is booted is hidden regardless of virtual flag`() {
+    // e.g. an iOS simulator whose UDID is stable across boot — dedup by exact identity.
+    val devices =
+      buildPickerDevices(
+        booted = listOf(booted("iPhone 15", "udid-1", isVirtual = true)),
+        images = listOf(image("iPhone 15", "udid-1")),
+      )
+    assertEquals(listOf("udid-1"), devices.map { it.id })
+    assertTrue(devices.single().state == DeviceState.Booted)
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/RealDeviceBootControllerTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/picker/RealDeviceBootControllerTest.kt
@@ -1,0 +1,58 @@
+package dev.jasonpearson.automobile.desktop.core.workspace.picker
+
+import dev.jasonpearson.automobile.desktop.core.daemon.StartDeviceResult
+import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
+import dev.jasonpearson.automobile.desktop.core.workspace.Platform
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RealDeviceBootControllerTest {
+
+  private val device =
+    PickerDevice(
+      id = "Pixel_6_API_33",
+      name = "Pixel 6 API 33",
+      platform = Platform.Android,
+      state = DeviceState.Shutdown,
+    )
+
+  private fun controller(client: FakeAutoMobileClient) =
+    RealDeviceBootController(client, UnconfinedTestDispatcher())
+
+  @Test
+  fun `boot returns the daemon runtime id on success`() = runTest {
+    val client =
+      FakeAutoMobileClient().apply {
+        startDeviceResult = StartDeviceResult(success = true, deviceId = "emulator-5556")
+      }
+    assertEquals("emulator-5556", controller(client).boot(device).getOrNull())
+  }
+
+  @Test
+  fun `boot rejects a success with no runtime deviceId instead of fabricating one`() = runTest {
+    // Older daemons may omit deviceId. Fabricating the shut-down source id would fail the exact-id
+    // match in reloadAfterBoot, so the device would read "Boot did not complete" while running.
+    val client =
+      FakeAutoMobileClient().apply {
+        startDeviceResult = StartDeviceResult(success = true, deviceId = null)
+      }
+    val result = controller(client).boot(device)
+    assertTrue(result.isFailure)
+    assertNull(result.getOrNull()) // no fabricated id — surfaces a retryable failure instead
+  }
+
+  @Test
+  fun `boot fails when the daemon reports failure`() = runTest {
+    val client =
+      FakeAutoMobileClient().apply {
+        startDeviceResult = StartDeviceResult(success = false, message = "no matching device")
+      }
+    assertTrue(controller(client).boot(device).isFailure)
+  }
+}


### PR DESCRIPTION
## Problem
On first run with no device already running, the desktop device picker was a dead-end: every device is `Shutdown`, each card showed the stub **"Boot to observe (soon)"**, `toggleSelect` ignored non-booted devices, and **Observe** stayed disabled — so there was no in-app way to get a device into an observable state. (Reported by a user stuck in onboarding with 14 shut-down Android AVDs.)

## Change
Clicking a shut-down device card now **boots it** through an injected, testable seam, and the copy plainly states the device is shut down and that clicking boots it.

## Acceptance criteria → implementation
1. **Copy** — a shut-down card's meta line now ends in `· Shut down` and the affordance reads **"Click to boot"** (was "Boot to observe (soon)"). Booted cards unchanged. (`DevicePicker.kt`)
2. **Click boots** — a shut-down card dispatches the new `DevicePickerAction.BootDevice(deviceId)`; the ViewModel boots via an injected `DeviceBootController` (interface + `RealDeviceBootController` + `FakeDeviceBootController`). The real impl calls `AutoMobileClient.startDevice(name, platform, deviceId)` (the `startDevice` MCP tool).
3. **Transient booting UI** — in flight the card shows **"Booting…"** and is not clickable. Modeled as a UI-only `bootingIds: Set<String>` on `Content`; no `Booting` value added to the daemon `DeviceState` enum.
4. **On success** — the list reloads, the now-booted device is **auto-selected** so Observe is immediately usable; on **failure** the booting state clears and the card offers a retry ("Boot failed · Click to retry", clicking retries).
5. **Booted cards unchanged** — clicking a booted card still toggles observe-selection.

### Note on device identity
A booted emulator is re-keyed by the daemon to a runtime serial (e.g. `emulator-5556`), not its AVD id (`Pixel_6_API_33`). Auto-select therefore matches the reloaded booted device **by name** and selects its new id; the stale shut-down id is dropped from `bootingIds`. The real boot passes the picker device id as both `name` and `deviceId` to `startDevice` (the daemon matcher accepts either).

## Tests (interface + fake, no daemon)
- ViewModel (`DevicePickerViewModelTest`): boot marks `bootingIds`; success reloads to Booted + auto-selects the new id + clears booting; failure clears booting and exposes a retryable error; double-click while booting is a no-op; booting an already-booted device is ignored.
- UI (`DevicePickerUiTest`): shut-down card shows "Click to boot" and dispatches `BootDevice`; a booting card shows "Booting…" and is not re-triggerable; a failed card offers a retry that dispatches `BootDevice`.

## Validation
`:desktop-core:detektMain :desktop-core:test :desktop-app:compileKotlin` — BUILD SUCCESSFUL (full `:desktop-core:test`, 1081 tests). Touched `.kt` formatted with pinned ktfmt 0.64; `git diff` clean.

Closes #4879
