### PR TITLE
test(webrtc): PR-gate H.264 profile negotiation across all sources (#4884)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -440,6 +440,12 @@ jobs:
               - 'test/integration/mediamtxWebRtcPublisher.integration.test.ts'
               - 'test/bats/mediamtx-webrtc-integration.bats'
               - 'scripts/webrtc/**'
+              # Native encoder sources decide the on-the-wire H.264 profile the
+              # publisher must accept. A profile change here (e.g. Baseline ->
+              # Main) is exactly the #4877 class of regression this job guards, so
+              # exercise it when the native encoders change (issue #4884).
+              - 'android/video-server/**/VideoEncoder.kt'
+              - 'ios/screen-capture/**'
               # This workflow controls WebRTC-job gating, so a change to it must
               # exercise the job rather than being silently skipped.
               - '.github/workflows/pull_request.yml'

--- a/src/features/webrtc/WebRtcPublisher.ts
+++ b/src/features/webrtc/WebRtcPublisher.ts
@@ -13,8 +13,7 @@ import { ReconnectController, type ReconnectState } from "./ReconnectController"
 import { RtpH264TrackWriter } from "./RtpH264TrackWriter";
 import { RtpPcmuTrackWriter } from "./RtpPcmuTrackWriter";
 import {
-  h264SpsProfileLevelId,
-  h264SpsLevelIdc,
+  evaluateH264SpsForSend,
   isCompatibleConstrainedBaselineProfile,
   WEBRTC_H264_LEVEL_IDC,
   WEBRTC_H264_PROFILE_LEVEL_ID,
@@ -445,17 +444,9 @@ export class WebRtcPublisher {
         mtu: this.config.mtu ?? DEFAULT_RTP_MTU,
         timer: this.timer,
         onSps: sps => {
-          const profileLevelId = h264SpsProfileLevelId(sps);
-          if (profileLevelId && !isCompatibleConstrainedBaselineProfile(profileLevelId)) {
-            throw new Error(
-              `H.264 SPS profile ${profileLevelId.slice(0, 4)} is incompatible with negotiated constrained baseline.`
-            );
-          }
-          const levelIdc = h264SpsLevelIdc(sps);
-          if (levelIdc !== undefined && levelIdc > WEBRTC_H264_LEVEL_IDC) {
-            throw new Error(
-              `H.264 SPS level ${levelIdc} exceeds negotiated level ${WEBRTC_H264_LEVEL_IDC}.`
-            );
+          const spsCompatibility = evaluateH264SpsForSend(sps);
+          if (!spsCompatibility.compatible) {
+            throw new Error(spsCompatibility.reason);
           }
         },
         onAccessUnit: event => this.recordAccessUnit(event),

--- a/src/features/webrtc/h264Level.ts
+++ b/src/features/webrtc/h264Level.ts
@@ -30,6 +30,43 @@ export function h264SpsLevelIdc(nal: Buffer): number | undefined {
   return profileLevelId ? Number.parseInt(profileLevelId.slice(4, 6), 16) : undefined;
 }
 
+/** Result of validating an encoded SPS against the negotiated send profile. */
+export interface H264SpsSendCompatibility {
+  /** Whether the SPS may be sent over the negotiated constrained-baseline track. */
+  compatible: boolean;
+  /** Human-readable reason when `compatible` is false; omitted when compatible. */
+  reason?: string;
+}
+
+/**
+ * Decide whether an encoded SPS NAL from a capture source may be sent on the
+ * WHIP track, given the profile and level AutoMobile negotiates.
+ *
+ * This is the single source of truth for the runtime acceptance gate: the
+ * publisher's `onSps` hook delegates here so the decision cannot drift between
+ * the real send path and the fast profile-negotiation test. A source whose SPS
+ * this function rejects will never render — that is exactly the #4877 regression
+ * (a global Main-profile switch made this reject the Baseline SPS that the iOS
+ * ffmpeg and synthetic sources actually emit).
+ */
+export function evaluateH264SpsForSend(sps: Buffer): H264SpsSendCompatibility {
+  const profileLevelId = h264SpsProfileLevelId(sps);
+  if (profileLevelId && !isCompatibleConstrainedBaselineProfile(profileLevelId)) {
+    return {
+      compatible: false,
+      reason: `H.264 SPS profile ${profileLevelId.slice(0, 4)} is incompatible with negotiated constrained baseline.`,
+    };
+  }
+  const levelIdc = h264SpsLevelIdc(sps);
+  if (levelIdc !== undefined && levelIdc > WEBRTC_H264_LEVEL_IDC) {
+    return {
+      compatible: false,
+      reason: `H.264 SPS level ${levelIdc} exceeds negotiated level ${WEBRTC_H264_LEVEL_IDC}.`,
+    };
+  }
+  return { compatible: true };
+}
+
 /** Whether a profile-level-id is compatible with AutoMobile constrained baseline. */
 export function isCompatibleConstrainedBaselineProfile(profileLevelId: string): boolean {
   // Accept the whole Baseline family (profile_idc 66 / 0x42), regardless of the

--- a/test/features/webrtc/h264ProfileNegotiation.test.ts
+++ b/test/features/webrtc/h264ProfileNegotiation.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "bun:test";
+import type { RTCPeerConnection } from "werift";
+import {
+  evaluateH264SpsForSend,
+  h264SpsLevelIdc,
+  h264SpsProfileLevelId,
+  isCompatibleConstrainedBaselineProfile,
+  WEBRTC_H264_LEVEL_IDC,
+  WEBRTC_H264_PROFILE_LEVEL_ID,
+} from "../../../src/features/webrtc/h264Level";
+import { WebRtcPublisher } from "../../../src/features/webrtc/WebRtcPublisher";
+import type { WhipClient } from "../../../src/features/webrtc/WhipClient";
+
+/**
+ * Cross-source H.264 profile-negotiation guard (issue #4884).
+ *
+ * PR #4877 globally switched the advertised profile / acceptance gate to Main
+ * and made the gate REJECT Baseline (`0x42`). But every real capture source
+ * still emits Baseline: Android MediaCodec is configured with
+ * `AVCProfileBaseline`, the iOS ffmpeg path passes `-profile:v baseline`, and
+ * the synthetic MediaMTX test frames use `libx264 -profile:v baseline`. That
+ * mismatch broke WebRtcPublisher -> MediaMTX and was only caught by a
+ * merge-only integration job, so #4877 merged green and had to be reverted
+ * (#4883).
+ *
+ * This test is fast, deterministic, and runs on every PR via `bun test`. It
+ * asserts that BOTH the advertised offer (`WEBRTC_H264_PROFILE_LEVEL_ID`) and
+ * the runtime acceptance gate accept the exact SPS each real source produces. A
+ * future global-profile switch that rejects a profile a real source emits must
+ * fail here on PR CI, before it can reach `main`.
+ */
+
+/**
+ * The exact H.264 profile each real capture source emits, captured as a 4-byte
+ * SPS NAL: [nal header 0x67, profile_idc, profile-iop/constraint flags,
+ * level_idc]. Only `profile_idc` (byte 1) is load-bearing for the acceptance
+ * gate; the constraint byte is representative of what each encoder writes.
+ *
+ * profile_idc 0x42 == Baseline (profile 66). These constants are the ground
+ * truth against which the gate is validated: they must NOT be derived from
+ * `WEBRTC_H264_PROFILE_LEVEL_ID`, otherwise a global switch of both the offer
+ * and this table would hide a real-source regression.
+ */
+interface RealH264Source {
+  readonly name: string;
+  /** Where the encoder profile is configured, for failure triage. */
+  readonly origin: string;
+  /** A representative SPS NAL the source's encoder emits. */
+  readonly sps: Buffer;
+}
+
+const REAL_H264_SOURCES: readonly RealH264Source[] = [
+  {
+    name: "Android MediaCodec (AVCProfileBaseline)",
+    origin: "android/video-server/.../VideoEncoder.kt",
+    // Plain Baseline as Android device encoders routinely emit it
+    // (constraint_set0 only, constraint_set1 clear), level 4.0. This is the
+    // representation #4877's gate rejected outright.
+    sps: Buffer.from([0x67, 0x42, 0x80, 0x28]),
+  },
+  {
+    name: "iOS ffmpeg (-profile:v baseline -level:v 4.2)",
+    origin: "src/features/webrtc/IosH264Source.ts",
+    // VideoToolbox/ffmpeg baseline at the advertised Level 4.2 ceiling.
+    sps: Buffer.from([0x67, 0x42, 0xc0, 0x2a]),
+  },
+  {
+    name: "Synthetic MediaMTX frames (libx264 -profile:v baseline -level:v 3.1)",
+    origin: "test/integration/mediamtxWebRtcPublisher.integration.test.ts",
+    sps: Buffer.from([0x67, 0x42, 0xc0, 0x1f]),
+  },
+] as const;
+
+/** Baseline profile_idc; the family every real source encodes and every viewer must decode. */
+const BASELINE_PROFILE_IDC = 0x42;
+
+describe("H.264 cross-source profile negotiation (#4884)", () => {
+  test("the advertised offer profile is itself Baseline and gate-compatible", () => {
+    // The offer we send viewers must advertise the same profile family our
+    // sources encode; otherwise a viewer negotiates a profile it will never
+    // actually receive. #4877 advertised Main here while sources stayed Baseline.
+    const offerProfileIdc = Number.parseInt(WEBRTC_H264_PROFILE_LEVEL_ID.slice(0, 2), 16);
+    expect(offerProfileIdc).toBe(BASELINE_PROFILE_IDC);
+    expect(isCompatibleConstrainedBaselineProfile(WEBRTC_H264_PROFILE_LEVEL_ID)).toBe(true);
+  });
+
+  for (const source of REAL_H264_SOURCES) {
+    describe(source.name, () => {
+      test("emits a Baseline SPS (documents ground truth)", () => {
+        const profileLevelId = h264SpsProfileLevelId(source.sps);
+        expect(profileLevelId).toBeDefined();
+        const profileIdc = Number.parseInt(profileLevelId!.slice(0, 2), 16);
+        expect(profileIdc).toBe(BASELINE_PROFILE_IDC);
+        // Its encoded level must not exceed the negotiated ceiling, or onSps rejects it.
+        expect(h264SpsLevelIdc(source.sps)!).toBeLessThanOrEqual(WEBRTC_H264_LEVEL_IDC);
+      });
+
+      test("acceptance gate accepts the SPS it produces", () => {
+        // Direct guard: if a global switch makes the gate reject Baseline, this
+        // fails on PR CI — the durable fix for the #4877 incident.
+        const profileLevelId = h264SpsProfileLevelId(source.sps)!;
+        expect(isCompatibleConstrainedBaselineProfile(profileLevelId)).toBe(true);
+      });
+
+      test("runtime send guard (onSps) accepts the SPS it produces", () => {
+        // evaluateH264SpsForSend is the exact function WebRtcPublisher.onSps
+        // delegates to, so this exercises the runtime acceptance decision that
+        // #4877 turned into a fatal throw for Baseline sources.
+        expect(evaluateH264SpsForSend(source.sps)).toEqual({ compatible: true });
+      });
+
+      test("publisher negotiates and connects for this source's advertised profile", async () => {
+        // End-to-end SDP leg: a WHEP answer echoing our offer profile must be
+        // accepted so the publisher reaches `connected`. Exercises the
+        // acceptsLocalH264Send / sdpOffersCompatibleH264 negotiation path.
+        const pc = new NegotiationFakePeerConnection();
+        const answerSdp = [
+          "v=0",
+          "m=video 9 UDP/TLS/RTP/SAVPF 102",
+          "a=recvonly",
+          "a=rtpmap:102 H264/90000",
+          `a=fmtp:102 packetization-mode=1;profile-level-id=${WEBRTC_H264_PROFILE_LEVEL_ID}`,
+        ].join("\r\n");
+        const publisher = new WebRtcPublisher(
+          { streamId: "s", whipEndpoint: "https://coord/whip", maxReconnectAttempts: 1 },
+          {
+            createPeerConnection: () => pc as unknown as RTCPeerConnection,
+            createWhipClient: () =>
+              ({
+                publish: async () => ({ answerSdp, resourceUrl: "https://coord/whip/s" }),
+                delete: async () => {},
+              }) as unknown as WhipClient,
+          }
+        );
+
+        await publisher.start();
+        expect(publisher.getState()).toBe("connected");
+        await publisher.stop();
+      });
+    });
+  }
+
+  test("gate still rejects a genuinely different profile a source never emits", () => {
+    // Negative control: proves the gate is discriminating, not accept-all. Main
+    // (0x4d) and High (0x64) SPS are rejected because no AutoMobile source emits
+    // them; if a source ever did, its entry above would fail first.
+    const mainProfileSps = Buffer.from([0x67, 0x4d, 0x40, 0x1f]);
+    const highProfileSps = Buffer.from([0x67, 0x64, 0x00, 0x1f]);
+    expect(evaluateH264SpsForSend(mainProfileSps).compatible).toBe(false);
+    expect(evaluateH264SpsForSend(highProfileSps).compatible).toBe(false);
+  });
+});
+
+/** Minimal fake peer connection whose offer/publish path succeeds up to connect. */
+class NegotiationFakePeerConnection {
+  closed = false;
+  connectionState = "new";
+  iceGatheringState = "complete";
+  connectionStateChange = { subscribe: () => {} };
+  iceGatheringStateChange = { watch: async () => {} };
+  localDescription = { sdp: "v=0" };
+  addTransceiver() {
+    return {
+      sender: {
+        ssrc: 1,
+        onPictureLossIndication: { subscribe: () => {} },
+      },
+    };
+  }
+  async createOffer() {
+    return { type: "offer", sdp: "v=0" };
+  }
+  async setLocalDescription() {}
+  async setRemoteDescription() {}
+  async close() {
+    this.closed = true;
+  }
+}


### PR DESCRIPTION
Closes [#4884](https://github.com/kaeawc/auto-mobile/issues/4884)

## Problem

The *WebRTC Publisher Integration (MediaMTX)* job catches H.264 profile-negotiation regressions, but it is heavy/flaky and **advisory** (not in the required-checks ruleset). [#4877](https://github.com/kaeawc/auto-mobile/pull/4877) globally switched the advertised H.264 profile / acceptance gate to Main and made `isCompatibleConstrainedBaselineProfile` **reject** Baseline (`0x42`) — yet every real capture source still emits Baseline:

- **Android MediaCodec** — configured with `AVCProfileBaseline` (`android/video-server/.../VideoEncoder.kt`)
- **iOS ffmpeg** — `-profile:v baseline` (`src/features/webrtc/IosH264Source.ts`)
- **Synthetic MediaMTX frames** — `libx264 -profile:v baseline` (integration test)

The mismatch broke `WebRtcPublisher -> MediaMTX`, but because the guard ran too late (merge/advisory), #4877 merged green and only failed on `main`, forcing a revert ([#4883](https://github.com/kaeawc/auto-mobile/pull/4883)).

## Approach — durable fast test first, path-gate second

I implemented **both** deliverables, prioritizing the durable fast guard.

### 1. Fast, deterministic, PR-gating test (the durable guard)

`test/features/webrtc/h264ProfileNegotiation.test.ts` runs on every PR via `bun test` / `turbo run test` (a required check) — no MediaMTX, no headless Chrome, ~180ms. It encodes the **ground-truth SPS each real source emits** as constants (deliberately NOT derived from `WEBRTC_H264_PROFILE_LEVEL_ID`, so a global switch of the offer can't hide a real-source regression) and asserts, per source:

- the advertised offer profile is in the same Baseline family the source encodes;
- the acceptance gate (`isCompatibleConstrainedBaselineProfile`) accepts the source's profile;
- the runtime send guard (`evaluateH264SpsForSend`, the exact function `WebRtcPublisher.onSps` delegates to) accepts the source's SPS;
- the publisher negotiates to `connected` for the advertised profile (exercises the `acceptsLocalH264Send` / `sdpOffersCompatibleH264` SDP path).

A negative-control test proves the gate still rejects Main/High profiles no source emits, so it isn't accept-all.

To make the runtime leg genuinely single-sourced (CLAUDE.md: "one canonical primitive per concern"), I extracted the inline profile+level check in `onSps` into `evaluateH264SpsForSend()` in `h264Level.ts` and had the publisher delegate to it — preserving the exact error messages. The test exercises that real decision function rather than a parallel reimplementation.

### 2. Path-gate the heavy MediaMTX job on native-encoder changes

The MediaMTX PR job (`webrtc-integration-test` in `pull_request.yml`) was already path-gated on `src/features/webrtc/**` (covers `h264*.ts`). I added the **native encoder sources** that decide the on-the-wire profile — `android/video-server/**/VideoEncoder.kt` and `ios/screen-capture/**` — so a Baseline->Main change in those also triggers the heavy job. The merge-only job in `merge.yml` is kept as the belt-and-braces backstop.

I did **not** widen the heavy job to all PRs: it's browser+SFU+FFmpeg+UDP and flaky, so per the issue I rely on the fast test (1) for universal PR coverage and only extend the heavy job's path trigger.

## Regression proof

Simulating #4877 locally (gate `profileIdc === 0x4d`, offer `4d402a`) makes the new test **fail hard — 8 of 14 failures** across all three sources' runtime-guard/gate assertions and the negative control. Reverting restores 14/14 green. The guard demonstrably blocks the exact regression on PR CI.

## Validation

- `bun run typecheck` — no new type errors (196 baseline)
- `turbo run lint build` — pass (lint + all boundary checks + build)
- `bun test test/features/webrtc/` — 345 pass / 0 fail
- New test alone — 14 pass / 0 fail (~180ms)
- `actionlint` / `python yaml` — no new errors in the edited filter region (pre-existing actionlint noise is from the repo's custom `background:`/`wait:` runner syntax elsewhere in the file)

The workflow trigger change is verified by this PR's own CI run.
