### PR TITLE
fix(webrtc): reconcile hygiene for video-server leases (#4783)

### DIFF
--- a/src/features/webrtc/PersistentEncoderH264Source.ts
+++ b/src/features/webrtc/PersistentEncoderH264Source.ts
@@ -27,6 +27,21 @@ const VIDEO_SERVER_MAIN_CLASS = "dev.jasonpearson.automobile.video.VideoServer";
 export const VIDEO_SERVER_LEASE_DIRECTORY = "/data/local/tmp/automobile-video-sessions";
 /** A device heartbeat older than this is eligible for owned stale cleanup. */
 const STALE_LEASE_MS = 30_000;
+/**
+ * Fallback staleness threshold for a lease that predates the
+ * `heartbeatElapsedRealtimeMs` field (see `hasValidLeaseHeartbeat`). The
+ * monotonic elapsed-realtime clock is unavailable, so we fall back to the
+ * always-written wall-clock `heartbeatAtMs`. Wall clock can jump (NTP, manual
+ * set, timezone), so this is deliberately several minutes rather than the 30 s
+ * monotonic window — a jump smaller than this cannot cause a false reclaim.
+ */
+const STALE_LEASE_WALL_CLOCK_MS = 5 * 60_000;
+/**
+ * A lease *file* (unparseable `*.json` or orphaned `*.json.tmp`) whose mtime is
+ * older than this is swept during reconcile. Conservative because a
+ * `*.json.tmp` may be mid-rename by a live server; younger files are left alone.
+ */
+const STALE_LEASE_FILE_SWEEP_MS = 5 * 60_000;
 const SESSION_READY_PATTERN = /^VIDEO_SESSION_READY token=([^ ]+) pid=(\d+) socket=([^ ]+)$/;
 /** Server stdout line printed after capture has fully started. */
 const STREAMING_STARTED_MARKER = "Streaming started";
@@ -219,6 +234,49 @@ function parseLeases(output: string): VideoServerLease[] {
         return [];
       }
     });
+}
+
+/** Basenames the sweep is allowed to `rm`; guards against odd device output. */
+const LEASE_FILE_NAME_PATTERN = /^[A-Za-z0-9_.-]+\.json(?:\.tmp)?$/;
+
+/**
+ * Parse the `sweepOrphanLeaseFiles` listing: a leading `NOW <epochSeconds>`
+ * line emitted by `date +%s`, followed by `<mtimeSeconds> <path>` rows from
+ * `stat -c '%Y %n'`. Returns the device wall clock in ms plus each file's
+ * basename and mtime in ms. Rows whose basename fails the safe-name pattern are
+ * dropped so the caller never issues a surprising `rm`.
+ */
+function parseLeaseFileListing(output: string): {
+  nowEpochMs: number | null;
+  files: { name: string; mtimeMs: number }[];
+} {
+  let nowEpochMs: number | null = null;
+  const files: { name: string; mtimeMs: number }[] = [];
+  for (const line of output.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+    if (trimmed.startsWith("NOW ")) {
+      const seconds = Number.parseInt(trimmed.slice(4).trim(), 10);
+      if (Number.isFinite(seconds) && seconds >= 0) {
+        nowEpochMs = seconds * 1_000;
+      }
+      continue;
+    }
+    const separator = trimmed.indexOf(" ");
+    if (separator <= 0) {
+      continue;
+    }
+    const mtimeSeconds = Number.parseInt(trimmed.slice(0, separator), 10);
+    const path = trimmed.slice(separator + 1).trim();
+    const name = path.slice(path.lastIndexOf("/") + 1);
+    if (!Number.isFinite(mtimeSeconds) || mtimeSeconds < 0 || !LEASE_FILE_NAME_PATTERN.test(name)) {
+      continue;
+    }
+    files.push({ name, mtimeMs: mtimeSeconds * 1_000 });
+  }
+  return { nowEpochMs, files };
 }
 
 /**
@@ -1116,6 +1174,10 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
       return;
     }
 
+    // Sweep corrupt/orphaned files regardless of how many leases parsed: a
+    // wholly-unparseable directory yields zero leases but still needs cleanup.
+    await this.sweepOrphanLeaseFiles(adb, new Set(leases.map(lease => `${lease.token}.json`)));
+
     if (leases.length === 0) {
       return;
     }
@@ -1126,25 +1188,114 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     }
 
     for (const lease of leases) {
-      const heartbeatElapsedRealtimeMs = lease.heartbeatElapsedRealtimeMs;
-      if (
-        lease.deviceSerial !== this.options.device.deviceId ||
-        heartbeatElapsedRealtimeMs === undefined
-      ) {
-        continue;
-      }
-      const ageMs = deviceElapsedRealtimeMs - heartbeatElapsedRealtimeMs;
-      // elapsedRealtime resets when Android reboots. A negative age therefore
-      // proves this persisted lease belongs to a previous boot.
-      if (ageMs >= 0 && ageMs < STALE_LEASE_MS) {
+      const decision = this.classifyLeaseForReclaim(lease, deviceElapsedRealtimeMs);
+      if (decision === null) {
         continue;
       }
       logger.info(
-        `[PersistentEncoderH264Source] stale-session-cleanup token=${lease.token} ageMs=${ageMs}`
+        `[PersistentEncoderH264Source] stale-session-cleanup token=${lease.token} reason=${decision}`
       );
       await this.removeForwardIfMatching(adb, lease.forwardPort, lease.socketName);
       await this.terminateProcessIfMatching(adb, lease);
       await this.removeLeaseIfMatching(adb, lease);
+    }
+  }
+
+  /**
+   * Decide whether a parsed lease should be reclaimed, returning a short reason
+   * string when it should and `null` when it should be left alone.
+   *
+   * Precedence deliberately puts the reboot check FIRST: emulator serials are
+   * port-based (`emulator-5554` -> `emulator-5556` across restarts), so a lease
+   * written under a prior serial is on the SAME device filesystem and must not
+   * be stranded. A negative elapsed-realtime age proves the lease predates the
+   * current boot, which is safe to reclaim regardless of the recorded serial.
+   * Only for leases NOT provably from a previous boot do we fall back to the
+   * conservative same-serial staleness checks.
+   */
+  private classifyLeaseForReclaim(
+    lease: VideoServerLease,
+    deviceElapsedRealtimeMs: number
+  ): string | null {
+    const elapsedRealtimeMs = lease.heartbeatElapsedRealtimeMs;
+    if (elapsedRealtimeMs !== undefined && deviceElapsedRealtimeMs - elapsedRealtimeMs < 0) {
+      // elapsedRealtime resets when Android reboots. A negative age therefore
+      // proves this persisted lease belongs to a previous boot.
+      return "previous-boot";
+    }
+
+    if (lease.deviceSerial !== this.options.device.deviceId) {
+      // Same-boot lease under a different serial: too ambiguous to reclaim.
+      return null;
+    }
+
+    if (elapsedRealtimeMs === undefined) {
+      // Legacy/edge lease without the monotonic field. Fall back to the
+      // always-written wall clock with a conservative multi-minute threshold so
+      // the validator's tolerance and this loop stop disagreeing (issue #4783).
+      const wallAgeMs = this.timer.now() - lease.heartbeatAtMs;
+      return wallAgeMs >= STALE_LEASE_WALL_CLOCK_MS ? "wall-clock-stale" : null;
+    }
+
+    const ageMs = deviceElapsedRealtimeMs - elapsedRealtimeMs;
+    return ageMs >= STALE_LEASE_MS ? "elapsed-stale" : null;
+  }
+
+  /**
+   * Remove lease files that can never be reconciled through the normal path:
+   * unparseable `*.json` (basename not among the parsed lease tokens) and
+   * orphaned `*.json.tmp` files left by a SIGKILL between `writeText` and
+   * `renameTo`. Only files older than `STALE_LEASE_FILE_SWEEP_MS` (by device
+   * mtime) are swept, so a file mid-rename by a live server is left alone.
+   */
+  private async sweepOrphanLeaseFiles(
+    adb: ReturnType<AdbClientFactory["create"]>,
+    knownLeaseFileNames: ReadonlySet<string>
+  ): Promise<void> {
+    let listing: { nowEpochMs: number | null; files: { name: string; mtimeMs: number }[] };
+    try {
+      const command =
+        `printf 'NOW %s\\n' "$(date +%s)"; ` +
+        `for f in ${VIDEO_SERVER_LEASE_DIRECTORY}/*.json ${VIDEO_SERVER_LEASE_DIRECTORY}/*.json.tmp; do ` +
+        '[ -f "$f" ] || continue; stat -c \'%Y %n\' "$f"; done';
+      const result = await this.withTimeout(
+        adb.executeCommand(`shell sh -c ${shellQuote(command)}`),
+        this.teardownTimeoutMs,
+        "adb list stale video session lease files"
+      );
+      listing = parseLeaseFileListing(result.stdout);
+    } catch (error) {
+      logger.debug(`[PersistentEncoderH264Source] unable to list video session lease files: ${error}`);
+      return;
+    }
+
+    if (listing.nowEpochMs === null) {
+      logger.debug("[PersistentEncoderH264Source] lease-file sweep skipped: no device clock in listing");
+      return;
+    }
+
+    for (const file of listing.files) {
+      const isTmp = file.name.endsWith(".json.tmp");
+      // A parseable, known `*.json` lease is handled by the reconcile loop.
+      if (!isTmp && knownLeaseFileNames.has(file.name)) {
+        continue;
+      }
+      const ageMs = listing.nowEpochMs - file.mtimeMs;
+      if (ageMs < STALE_LEASE_FILE_SWEEP_MS) {
+        continue;
+      }
+      logger.info(
+        `[PersistentEncoderH264Source] stale-lease-file-sweep name=${file.name} ageMs=${ageMs}`
+      );
+      try {
+        await this.withTimeout(
+          adb.executeCommand(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/${file.name}`),
+          this.teardownTimeoutMs,
+          "adb remove stale video session lease file"
+        );
+      } catch (error) {
+        logger.debug(`[PersistentEncoderH264Source] stale-lease-file sweep failed name=${file.name}: ${error}`);
+      }
     }
   }
 

--- a/test/features/webrtc/PersistentEncoderH264Source.test.ts
+++ b/test/features/webrtc/PersistentEncoderH264Source.test.ts
@@ -175,6 +175,14 @@ function makeSource(overrides: Record<string, unknown> = {}) {
           : "");
       return { stdout, stderr: "", exitCode: 0 };
     }
+    if (command.includes("stat -c")) {
+      // The orphan-file sweep listing (`NOW <epoch>` + `<mtime> <path>` rows).
+      return {
+        stdout: (overrides.leaseFileListing as string | undefined) ?? "",
+        stderr: "",
+        exitCode: 0,
+      };
+    }
     if (command.includes(`for f in ${VIDEO_SERVER_LEASE_DIRECTORY}/*.json`)) {
       return { stdout: leaseOutput, stderr: "", exitCode: 0 };
     }
@@ -1025,6 +1033,186 @@ describe("PersistentEncoderH264Source", () => {
     expect(ctx.commands).toContain("forward --remove tcp:61234");
     expect(ctx.commands).toContain("shell kill -2 987");
     expect(ctx.commands).toContain(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/stale-session.json`);
+
+    ctx.processes[0].ready();
+    await startPromise;
+    await ctx.source.stop();
+  });
+
+  test("reconciles a lease with valid wall clock but no elapsed-realtime via the wall-clock fallback", async () => {
+    // heartbeatElapsedRealtimeMs absent (validator tolerates it). FakeTimer.now()
+    // is 0, so heartbeatAtMs=-400_000 => 400s wall age >= 5min threshold => stale.
+    const leaseNoElapsed = JSON.stringify({
+      version: 1,
+      socketName: "automobile_video_stale",
+      sessionToken: "stale-session",
+      pid: 987,
+      ownerPid: 456,
+      deviceSerial: DEVICE.deviceId,
+      forwardPort: 61234,
+      startedAtMs: -400_000,
+      heartbeatAtMs: -400_000,
+    });
+    const ctx = makeSource({
+      leaseOutput: leaseNoElapsed,
+      forwardListOutput: `${DEVICE.deviceId} tcp:61234 localabstract:automobile_video_stale\n`,
+      processCommandLine:
+        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--session-token\u0000stale-session`,
+    });
+
+    const startPromise = ctx.source.start();
+    await tick();
+
+    expect(ctx.commands).toContain("shell kill -2 987");
+    expect(ctx.commands).toContain(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/stale-session.json`);
+
+    ctx.processes[0].ready();
+    await startPromise;
+    await ctx.source.stop();
+  });
+
+  test("does NOT reconcile a lease with no elapsed-realtime whose wall clock is recent", async () => {
+    // heartbeatAtMs=-1_000 => 1s wall age (now()=0) << 5min threshold => keep.
+    const freshNoElapsed = JSON.stringify({
+      version: 1,
+      socketName: "automobile_video_fresh",
+      sessionToken: "fresh-session",
+      pid: 987,
+      ownerPid: 456,
+      deviceSerial: DEVICE.deviceId,
+      forwardPort: 61234,
+      startedAtMs: -1_000,
+      heartbeatAtMs: -1_000,
+    });
+    const ctx = makeSource({ leaseOutput: freshNoElapsed });
+
+    const startPromise = ctx.source.start();
+    await tick();
+
+    expect(ctx.commands).not.toContain("shell kill -2 987");
+    expect(ctx.commands).not.toContain("forward --remove tcp:61234");
+
+    ctx.processes[0].ready();
+    await startPromise;
+    await ctx.source.stop();
+  });
+
+  test("reconciles a previous-boot lease written under a renumbered emulator serial", async () => {
+    // Serial differs (emulator-5556 vs the device's emulator-5554), but a
+    // negative elapsed age proves it predates the current boot => reclaim.
+    const staleLeaseOldSerial = JSON.stringify({
+      version: 1,
+      socketName: "automobile_video_stale",
+      sessionToken: "stale-session",
+      pid: 987,
+      ownerPid: 456,
+      deviceSerial: "emulator-5556",
+      forwardPort: 61234,
+      startedAtMs: -40_000,
+      heartbeatAtMs: -31_000,
+      heartbeatElapsedRealtimeMs: 120_000,
+    });
+    const ctx = makeSource({
+      leaseOutput: staleLeaseOldSerial,
+      deviceUptimeMs: 5_000,
+      forwardListOutput: `${DEVICE.deviceId} tcp:61234 localabstract:automobile_video_stale\n`,
+      processCommandLine:
+        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--session-token\u0000stale-session`,
+    });
+
+    const startPromise = ctx.source.start();
+    await tick();
+
+    expect(ctx.commands).toContain("forward --remove tcp:61234");
+    expect(ctx.commands).toContain("shell kill -2 987");
+    expect(ctx.commands).toContain(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/stale-session.json`);
+
+    ctx.processes[0].ready();
+    await startPromise;
+    await ctx.source.stop();
+  });
+
+  test("does NOT reconcile a same-boot lease under a different serial", async () => {
+    // Positive, fresh elapsed age (not previous-boot) + a different serial is
+    // too ambiguous to reclaim.
+    const freshOtherSerial = JSON.stringify({
+      version: 1,
+      socketName: "automobile_video_other",
+      sessionToken: "other-session",
+      pid: 987,
+      ownerPid: 456,
+      deviceSerial: "emulator-5556",
+      forwardPort: 61234,
+      startedAtMs: 95_000,
+      heartbeatAtMs: 95_000,
+      heartbeatElapsedRealtimeMs: 95_000,
+    });
+    const ctx = makeSource({ leaseOutput: freshOtherSerial, deviceUptimeMs: 100_000 });
+
+    const startPromise = ctx.source.start();
+    await tick();
+
+    expect(ctx.commands).not.toContain("shell kill -2 987");
+
+    ctx.processes[0].ready();
+    await startPromise;
+    await ctx.source.stop();
+  });
+
+  test("sweeps an unparseable *.json and an orphaned *.json.tmp older than the age threshold", async () => {
+    // Directory has a corrupt .json (not a valid lease => not in known tokens)
+    // and an orphaned .json.tmp. Device clock is 1_000_000s; both files are old.
+    const oldMtime = 1_000_000 - 600; // 600s old >= 5min threshold
+    const ctx = makeSource({
+      leaseOutput: "not-json-at-all\n",
+      leaseFileListing:
+        `NOW 1000000\n` +
+        `${oldMtime} ${VIDEO_SERVER_LEASE_DIRECTORY}/corrupt.json\n` +
+        `${oldMtime} ${VIDEO_SERVER_LEASE_DIRECTORY}/leftover.json.tmp\n`,
+    });
+
+    const startPromise = ctx.source.start();
+    await tick();
+
+    expect(ctx.commands).toContain(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/corrupt.json`);
+    expect(ctx.commands).toContain(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/leftover.json.tmp`);
+
+    ctx.processes[0].ready();
+    await startPromise;
+    await ctx.source.stop();
+  });
+
+  test("leaves young unparseable/.tmp files and valid leases alone during the sweep", async () => {
+    const youngMtime = 1_000_000 - 10; // 10s old << 5min threshold
+    const validLease = JSON.stringify({
+      version: 1,
+      socketName: "automobile_video_fresh",
+      sessionToken: "fresh-session",
+      pid: 988,
+      ownerPid: 456,
+      deviceSerial: DEVICE.deviceId,
+      forwardPort: 61235,
+      startedAtMs: 95_000,
+      heartbeatAtMs: 95_000,
+      heartbeatElapsedRealtimeMs: 95_000,
+    });
+    const ctx = makeSource({
+      leaseOutput: validLease,
+      deviceUptimeMs: 100_000,
+      leaseFileListing:
+        `NOW 1000000\n` +
+        `${youngMtime} ${VIDEO_SERVER_LEASE_DIRECTORY}/corrupt.json\n` +
+        `${youngMtime} ${VIDEO_SERVER_LEASE_DIRECTORY}/leftover.json.tmp\n` +
+        `990000 ${VIDEO_SERVER_LEASE_DIRECTORY}/fresh-session.json\n`,
+    });
+
+    const startPromise = ctx.source.start();
+    await tick();
+
+    expect(ctx.commands).not.toContain(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/corrupt.json`);
+    expect(ctx.commands).not.toContain(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/leftover.json.tmp`);
+    // A valid, current lease file is never swept even though its mtime is old.
+    expect(ctx.commands).not.toContain(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/fresh-session.json`);
 
     ctx.processes[0].ready();
     await startPromise;


### PR DESCRIPTION
Closes [#4783](https://github.com/kaeawc/auto-mobile/issues/4783)

## Summary

Fixes the three one-way stranding traps in `reconcileExpiredLeases`
(`src/features/webrtc/PersistentEncoderH264Source.ts`). Each gap could leave a
lease file — and, in rare cases, the process/forward it names — un-reconcilable
forever. All new behavior is driven through the injected ADB seam and `Timer`
(no real device, waits, or filesystem in tests).

1. **Wall-clock fallback for a missing `heartbeatElapsedRealtimeMs`.** The loop
   used to `continue` any lease without the monotonic field, even though the
   validator (`hasValidLeaseHeartbeat`) tolerates its absence. It now falls back
   to the always-written wall-clock `heartbeatAtMs` with a conservative
   **5-minute** threshold (`STALE_LEASE_WALL_CLOCK_MS`) — deliberately minutes,
   not the 30s monotonic window, because wall clock can jump. **Chose the
   reconcile branch over rejecting in the validator:** rejecting would drop the
   lease from processing and strand it (it stays valid-JSON the sweep would not
   touch), whereas the fallback actively reclaims it, which is what the AC's
   "reconciled via the wall-clock fallback" asks for.

2. **Sweep unparseable `*.json` and orphaned `*.json.tmp`.** A new
   `sweepOrphanLeaseFiles` lists lease files with device mtime
   (`stat -c '%Y %n'`) plus the device clock (`date +%s`), and `rm`s any
   `*.json.tmp` or any `*.json` whose basename is not among the parsed lease
   tokens, but only when older than `STALE_LEASE_FILE_SWEEP_MS` (5 min). A file
   mid-rename by a live server is younger than that and left alone. Basenames
   are validated against a strict pattern before any `rm`. The sweep runs even
   when zero leases parse (a wholly-corrupt directory).

3. **Serial-vs-reboot precedence.** The previous-boot check (negative
   elapsed-realtime) now runs **before** the `deviceSerial` guard, so a lease
   provably from a prior boot is reclaimed even when the emulator serial was
   renumbered (`emulator-5554` -> `emulator-5556`). A same-boot lease under a
   different serial stays conservatively untouched. Extracted into
   `classifyLeaseForReclaim` for clarity.

## Verify-real findings (this is a bug issue)

All three gaps were real in `origin/main` before this change:

- **Gap 1 real.** The loop `continue`d when `heartbeatElapsedRealtimeMs === undefined`
  while `hasValidLeaseHeartbeat` returns `true` for that case — a genuine
  disagreement. Population is empty today: the Kotlin `VideoSessionLease.writeHeartbeat`
  writes the field unconditionally (`android/.../VideoSessionLease.kt:149`), both
  sides landed in [#4413](https://github.com/kaeawc/auto-mobile/pull/4413). So this
  is belt-and-braces consistency, as the issue states.
- **Gap 2 real.** `parseLeases` drops malformed JSON with only a debug log; nothing
  ever removed the file. The lease-listing glob (`*.json`) never matched
  `*.json.tmp`, and the Kotlin writer does leave `<token>.json.tmp` on a
  SIGKILL between `writeText` and `renameTo` (`VideoSessionLease.kt:152-154`).
- **Gap 3 real.** The `deviceSerial !== device.deviceId` guard was evaluated before
  the negative-elapsed reboot check, so a prior-boot lease under an old serial was
  permanently skipped.

## Validation

- `bun run typecheck` — pass (no new errors; 196 baseline).
- `turbo run lint build` — pass (all boundary checks green).
- `turbo run test` — **12270 pass, 13 skip, 0 fail** (869 files).
- Target suite `PersistentEncoderH264Source.test.ts` — 49 pass (6 new tests:
  wall-clock reclaim + keep-young, renumbered-serial reclaim + same-boot-keep,
  sweep old corrupt/.tmp + keep young/valid).
