### PR TITLE
fix(android-video): enforce reconnect-window expiry independently of the encode loop (blocked-write starvation)

### DIFF
--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
@@ -14,8 +14,11 @@ internal class ReconnectWindow(
   private val clock: () -> Long,
   private val durationMs: Long,
 ) {
-  private var clientlessSinceMs: Long? = null
-  private var clientAttached = false
+  // @Volatile: expiry is polled off the write lock (VideoStreamWriter.reconnectWindowExpired) so a
+  // transport write wedged while holding that lock can never starve the self-expiry check (issue
+  // #4784). Mutations still happen under the writer's lock; only these reads are lock-free.
+  @Volatile private var clientlessSinceMs: Long = NO_CLIENTLESS
+  @Volatile private var clientAttached = false
 
   fun start() {
     clientAttached = false
@@ -24,7 +27,7 @@ internal class ReconnectWindow(
 
   fun onClientAttached() {
     clientAttached = true
-    clientlessSinceMs = null
+    clientlessSinceMs = NO_CLIENTLESS
   }
 
   fun onClientDetached() {
@@ -33,8 +36,17 @@ internal class ReconnectWindow(
   }
 
   fun isExpired(): Boolean {
-    val clientlessSince = clientlessSinceMs ?: return false
-    return !clientAttached && clock() - clientlessSince >= durationMs
+    if (clientAttached) return false
+    val clientlessSince = clientlessSinceMs
+    if (clientlessSince == NO_CLIENTLESS) return false
+    return clock() - clientlessSince >= durationMs
+  }
+
+  private companion object {
+    /**
+     * Sentinel for "a client is (or may be) attached", i.e. the clientless window is not running.
+     */
+    const val NO_CLIENTLESS = Long.MIN_VALUE
   }
 }
 
@@ -74,6 +86,16 @@ class VideoStreamWriter(
   // @Volatile: assigned on the thread that calls start(), read by stop() on the shutdown hook.
   @Volatile private var writerThread: Thread? = null
 
+  // Write-stall watchdog (#4784): a half-open transport (host suspended, adb dropped without RST)
+  // lets output.write() block forever while the writer thread holds `lock`. Neither the write (no
+  // IOException) nor the command reader (no EOF) observes the dead consumer, so the reconnect
+  // window never resumes. We stamp when a client write enters the blocking call and clear it on
+  // return; the watchdog reads the stamp off the lock and force-closes the client when a write has
+  // been in flight past the deadline, which makes the wedged write throw and run the normal detach.
+  // @Volatile: written under `lock` on the writer/acceptor thread, read off-lock by the watchdog.
+  @Volatile private var writeStartedAtMs: Long = NO_WRITE_IN_PROGRESS
+  @Volatile private var watchdogThread: Thread? = null
+
   @Volatile private var stopped = false
 
   companion object {
@@ -82,6 +104,20 @@ class VideoStreamWriter(
 
     /** Upper bound on how long [stop] waits for the transport writer thread to unwind. */
     const val WRITER_JOIN_TIMEOUT_MS = 200L
+
+    /**
+     * A client write in flight longer than this is treated as a wedged half-open transport: the
+     * watchdog force-closes the client so the blocked write throws and the normal detach +
+     * reconnect window runs. Kept in the reconnect-window order of magnitude so a genuinely
+     * slow-but-alive consumer is not detached for a transient congestion blip.
+     */
+    const val WRITE_STALL_TIMEOUT_MS = 5_000L
+
+    /** How often the watchdog thread polls for a stalled write. */
+    const val WRITE_STALL_POLL_MS = 500L
+
+    /** Sentinel for [writeStartedAtMs] meaning no client write is currently in flight. */
+    const val NO_WRITE_IN_PROGRESS = Long.MIN_VALUE
 
     /** "h264" as big-endian int: 0x68323634 */
     const val CODEC_ID_H264 = VideoStreamProtocol.CODEC_ID_H264
@@ -115,6 +151,11 @@ class VideoStreamWriter(
         isDaemon = true
         start()
       }
+    watchdogThread =
+      Thread({ runWriteWatchdog() }, "video-write-watchdog").apply {
+        isDaemon = true
+        start()
+      }
     Thread(
         { acceptClients(onClientConnected) },
         "video-client-acceptor",
@@ -133,6 +174,49 @@ class VideoStreamWriter(
       val frame = handoff.take() ?: break
       synchronized(lock) { writePacketDataLocked(TRACK_ID_VIDEO, frame.ptsAndFlags, frame.data) }
     }
+  }
+
+  /**
+   * The write-stall watchdog loop. Polls [checkWriteStall] off the write lock so it can act while
+   * the writer thread is wedged inside a blocking [OutputStream.write] holding `lock`. Runs on its
+   * own daemon thread; unit tests call [checkWriteStall] directly with an injected clock instead.
+   */
+  private fun runWriteWatchdog() {
+    while (!stopped) {
+      checkWriteStall()
+      try {
+        Thread.sleep(WRITE_STALL_POLL_MS)
+      } catch (_: InterruptedException) {
+        Thread.currentThread().interrupt()
+        return
+      }
+    }
+  }
+
+  /**
+   * Force-detach a client whose transport write has been in flight past [WRITE_STALL_TIMEOUT_MS].
+   *
+   * Deliberately lock-free: the wedged write holds `lock`, so this must NOT take `lock`. Closing
+   * the client socket makes the blocked `output.write` throw [IOException], which runs the writer
+   * thread's own catch ([closeClientLocked] + [ReconnectWindow.onClientDetached]) and lets the
+   * reconnect window resume counting toward self-expiry.
+   *
+   * @return true when it force-closed a stalled client this call, false otherwise.
+   */
+  internal fun checkWriteStall(): Boolean {
+    val startedAt = writeStartedAtMs
+    if (startedAt == NO_WRITE_IN_PROGRESS) return false
+    if (nowMs() - startedAt < WRITE_STALL_TIMEOUT_MS) return false
+    val client = clientSocket ?: return false
+    println(
+      "VIDEO_CLIENT_WRITE_STALL socket=$socketName force-closing after ${nowMs() - startedAt}ms"
+    )
+    try {
+      client.close()
+    } catch (_: IOException) {
+      // Already gone; the wedged write will still observe the close and throw.
+    }
+    return true
   }
 
   /**
@@ -252,26 +336,44 @@ class VideoStreamWriter(
       writePacketDataLocked(TRACK_ID_AUDIO, ptsUs and PTS_MASK, data)
     }
 
-  /** True once the initial or replacement client misses the bounded reconnect window. */
-  fun reconnectWindowExpired(): Boolean =
-    synchronized(lock) {
-      reconnectWindow.isExpired()
-    }
+  /**
+   * True once the initial or replacement client misses the bounded reconnect window.
+   *
+   * Lock-free by design (#4784): [ReconnectWindow] state is volatile, so a transport write wedged
+   * inside `lock` on the writer thread cannot starve the encode loop's self-expiry poll.
+   */
+  fun reconnectWindowExpired(): Boolean = reconnectWindow.isExpired()
 
   private fun writeStreamHeaderLocked() {
-    if (audioEnabled) {
-      outputStream!!.write(
+    val header =
+      if (audioEnabled) {
         VideoStreamProtocol.muxHeader(
           width,
           height,
           AudioCapture.SAMPLE_RATE_HZ,
           AudioCapture.CHANNELS,
         )
-      )
-    } else {
-      outputStream!!.write(VideoStreamProtocol.legacyHeader(width, height))
+      } else {
+        VideoStreamProtocol.legacyHeader(width, height)
+      }
+    trackingWriteStall {
+      outputStream!!.write(header)
+      outputStream!!.flush()
     }
-    outputStream!!.flush()
+  }
+
+  /**
+   * Run a blocking client I/O action while advertising to the watchdog that a write is in flight. A
+   * stamp of [nowMs] is published before the action and cleared after (success or throw) so
+   * [checkWriteStall] can force-close a client whose write never returns.
+   */
+  private inline fun trackingWriteStall(action: () -> Unit) {
+    writeStartedAtMs = nowMs()
+    try {
+      action()
+    } finally {
+      writeStartedAtMs = NO_WRITE_IN_PROGRESS
+    }
   }
 
   private fun replayCachedVideoLocked() {
@@ -293,8 +395,11 @@ class VideoStreamWriter(
     try {
       // One write per packet: header + payload are framed into a single buffer so each packet
       // costs one syscall instead of two and the header is never split from its payload across
-      // TCP segments (issue #4743).
-      output.write(VideoStreamProtocol.framedPacket(audioEnabled, trackId, ptsAndFlags, data))
+      // TCP segments (issue #4743). Stamped for the write-stall watchdog (#4784) so a wedged
+      // half-open transport is force-detached instead of orphaning the server.
+      trackingWriteStall {
+        output.write(VideoStreamProtocol.framedPacket(audioEnabled, trackId, ptsAndFlags, data))
+      }
       return true
     } catch (e: IOException) {
       println("Error writing packet: ${e.message}")
@@ -337,6 +442,9 @@ class VideoStreamWriter(
       }
     }
     writerThread = null
+    // The watchdog only sleeps and reads volatiles; interrupt its sleep so it exits promptly.
+    watchdogThread?.interrupt()
+    watchdogThread = null
     synchronized(lock) {
       closeClientLocked()
     }

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriterTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriterTest.kt
@@ -32,6 +32,104 @@ class VideoStreamWriterTest {
     assertTrue(window.isExpired())
   }
 
+  // --- write-stall watchdog (#4784) -----------------------------------------------------------
+
+  /**
+   * Succeeds for the first [blockFromWriteIndex] writes, then parks the writer inside `write()`
+   * until [release] (invoked when the owning connection is force-closed), whereupon it throws to
+   * mimic a socket closed under a blocked write. Rendezvous latches only coordinate the two
+   * threads; the stall deadline itself is driven purely by the injected clock.
+   */
+  private class BlockingOutputStream(private val blockFromWriteIndex: Int) : OutputStream() {
+    private var writeCount = 0
+    private val writeEntered = CountDownLatch(1)
+    private val unblock = CountDownLatch(1)
+
+    fun awaitWriteEntered(t: Long, u: TimeUnit): Boolean = writeEntered.await(t, u)
+
+    fun release() = unblock.countDown()
+
+    override fun write(b: Int) = record()
+
+    override fun write(b: ByteArray) = record()
+
+    override fun write(b: ByteArray, off: Int, len: Int) = record()
+
+    private fun record() {
+      if (writeCount >= blockFromWriteIndex) {
+        writeEntered.countDown()
+        unblock.await()
+        throw IOException("socket closed during blocked write")
+      }
+      writeCount++
+    }
+  }
+
+  @Test
+  fun blockedWriteIsForceClosedByWatchdogAndWindowExpiresLockFree() {
+    var now = 1_000L
+    // Header (write index 0) lands; the next packet write parks until the client is force-closed.
+    val blocking = BlockingOutputStream(blockFromWriteIndex = 1)
+    val connection = FakeClientConnection(outputStream = blocking, onClose = blocking::release)
+    val subject = writer({ now }, FakeServerSocket(listOf({ connection })))
+
+    subject.bindServerSocket()
+    subject.acceptClients {}
+    assertFalse(connection.closed)
+
+    // Simulate the transport writer thread wedged in a blocking packet write.
+    val writeThread = Thread { subject.writeAudioPacket(byteArrayOf(1, 2, 3), ptsUs = 0) }
+    writeThread.start()
+    assertTrue(
+      "the packet write must reach the blocking output stream",
+      blocking.awaitWriteEntered(2, TimeUnit.SECONDS),
+    )
+
+    // Expiry polling is lock-free: it returns even while the write holds `lock` (a client is
+    // attached, so it is simply not expired yet).
+    assertFalse(subject.reconnectWindowExpired())
+
+    // Before the stall deadline the watchdog leaves the client alone.
+    now = 1_000L + VideoStreamWriter.WRITE_STALL_TIMEOUT_MS - 1
+    assertFalse(subject.checkWriteStall())
+    assertFalse(connection.closed)
+
+    // At the deadline the watchdog force-closes the client out of band.
+    now = 1_000L + VideoStreamWriter.WRITE_STALL_TIMEOUT_MS
+    val stallStartMs = now
+    assertTrue(subject.checkWriteStall())
+    assertTrue("stalled write must force-close the client", connection.closed)
+
+    // The wedged write unblocks (throws), runs the detach path, and the writer thread finishes.
+    writeThread.join(TimeUnit.SECONDS.toMillis(2))
+    assertFalse("the force-close must unblock the wedged write", writeThread.isAlive)
+
+    // The reconnect window now counts from the detach; advancing past it self-expires — lock-free.
+    now = stallStartMs + VideoStreamWriter.CLIENT_RECONNECT_WINDOW_MS
+    assertTrue(subject.reconnectWindowExpired())
+
+    subject.stop()
+  }
+
+  @Test
+  fun watchdogIgnoresWritesThatMakeProgress() {
+    var now = 1_000L
+    val connection = FakeClientConnection()
+    val subject = writer({ now }, FakeServerSocket(listOf({ connection })))
+
+    subject.bindServerSocket()
+    subject.acceptClients {}
+
+    // A write that completed promptly leaves no in-flight stamp, so no matter how far the clock
+    // advances the watchdog must not tear down a healthy client.
+    assertTrue(subject.writeAudioPacket(byteArrayOf(1, 2, 3), ptsUs = 0))
+    now = 1_000_000L
+    assertFalse(subject.checkWriteStall())
+    assertFalse(connection.closed)
+
+    subject.stop()
+  }
+
   // --- socket/stream seam driven by fakes -----------------------------------------------------
 
   /**
@@ -69,6 +167,7 @@ class VideoStreamWriterTest {
   private class FakeClientConnection(
     override val outputStream: OutputStream = ByteArrayOutputStream(),
     input: InputStream? = null,
+    private val onClose: () -> Unit = {},
   ) : VideoClientConnection {
     @Volatile var closed = false
     private val closedLatch = CountDownLatch(1)
@@ -78,6 +177,7 @@ class VideoStreamWriterTest {
       if (!closed) {
         closed = true
         closedLatch.countDown()
+        onClose()
       }
     }
   }


### PR DESCRIPTION
Closes [#4784](https://github.com/kaeawc/auto-mobile/issues/4784)

## Verify-against-current-main findings

The issue was written before [#4749](https://github.com/kaeawc/auto-mobile/issues/4749) landed, so I re-analyzed the actual starvation on current `main`. **The starvation is still real — #4749 did not close it; it relocated it.**

- The issue body says the *encode loop* blocks inside `writePacket` -> `output.write`. That is now stale: post-#4749 `writePacket()` is non-blocking (it copies the buffer, caches decoder state, and offers to the drop-oldest `FrameHandoff`).
- But the dedicated `video-transport-writer` thread runs `drainToTransport()`, which does `synchronized(lock) { writePacketDataLocked(...) }` and blocks on `output.write` **while holding `lock`**. On a half-open transport (host suspended, adb dropped without RST) the socket buffer fills and that write never returns.
- The encode loop still polls `currentWriter.reconnectWindowExpired()` at `VideoServer.kt:323`, and on `main` that method was `synchronized(lock) { reconnectWindow.isExpired() }`. So it **contends on the exact lock the wedged writer holds** and blocks there — the self-expiry check is starved, and the `app_process`, its lease file, and its forward stay alive indefinitely.
- The issue's stated design trap ("a watchdog that calls `reconnectWindowExpired()` deadlocks on the same lock the stuck write holds") therefore still applies verbatim.
- Additional wrinkle: with a client *attached* when the transport half-opens, the reconnect window never even begins counting. `onClientDetached()` is only reached when the write throws (never — no RST) or the command reader observes EOF (never — `input.read()` blocks with no data and no EOF). So neither path detects the dead consumer.

`stop()` already closes the client socket out-of-band (a #4749 addition), but `stop()` only runs at shutdown; nothing proactively unblocks a wedged write mid-session.

## Changes

**Lock-free expiry check.** `ReconnectWindow`'s `clientlessSinceMs`/`clientAttached` state is now `@Volatile` (with a `NO_CLIENTLESS = Long.MIN_VALUE` sentinel), and `VideoStreamWriter.reconnectWindowExpired()` no longer takes `lock`. Mutations still happen under the writer's `lock`; only the poll reads are lock-free, so a write wedged inside `lock` can never starve the encode loop's expiry check.

**Out-of-band write-stall watchdog.** A new `video-write-watchdog` daemon thread stamps `writeStartedAtMs` (volatile) around every in-flight client write and clears it on return (success or throw), via a small `trackingWriteStall { ... }` helper wrapping the header write and the packet write. `checkWriteStall()` reads that stamp **off the lock** and, when a write has been in flight past `WRITE_STALL_TIMEOUT_MS` (5s, the reconnect-window order of magnitude so a merely-slow-but-alive consumer is not evicted on a congestion blip), force-closes the client socket. The out-of-band close makes the blocked `output.write` throw `IOException`, which runs the existing `writePacketDataLocked` catch -> `closeClientLocked()` + `reconnectWindow.onClientDetached()`. The reconnect window then resumes counting and the server self-expires through the normal path. `stop()` interrupts and clears the watchdog thread.

**Out of scope (as the issue specifies):** no "owner PID gone -> self-terminate" check — the lease's `ownerPid` is the *host* daemon's PID and a device-side process cannot observe host liveness. Client attachment remains the only device-observable owner proxy.

Reconnect/replay semantics (cached SPS/PPS + IDR replay on reattach) are unchanged.

## Validation

- `./gradlew :video-server:test` (JDK 21, `android/local.properties` sdk.dir set): **BUILD SUCCESSFUL**, 12 tests, 0 skipped / 0 failures / 0 errors.
- `ktfmt --google-style` on both touched files: clean (applied).

New tests (injected `nowMs`, no real wall-clock waits — latches only rendezvous the two threads; the deadline is driven purely by the injected clock):

- `blockedWriteIsForceClosedByWatchdogAndWindowExpiresLockFree` — a `BlockingOutputStream` parks a packet write; `reconnectWindowExpired()` still returns while the write holds `lock` (proving lock-free polling); before the deadline `checkWriteStall()` is a no-op; at `WRITE_STALL_TIMEOUT_MS` it force-closes the client, the wedged write throws and detaches, and advancing past `CLIENT_RECONNECT_WINDOW_MS` self-expires.
- `watchdogIgnoresWritesThatMakeProgress` — a write that completed leaves no in-flight stamp, so no clock advance tears down a healthy client.
