### PR TITLE
Sweep orphaned adb forward entries left by video-server self-expiry

### DIFF
--- a/src/features/webrtc/PersistentEncoderH264Source.ts
+++ b/src/features/webrtc/PersistentEncoderH264Source.ts
@@ -88,6 +88,67 @@ export interface VideoServerSession {
   deviceSerial: string;
 }
 
+/**
+ * Process-lived memory of which `automobile_video_*` abstract socket names are
+ * currently owned by an in-flight or live capture session on a device.
+ *
+ * The orphan-forward sweep (`sweepOrphanForwards`) uses this to distinguish a
+ * genuinely stranded `adb forward` — one whose device server self-expired and
+ * deleted its own lease, or whose daemon was SIGKILLed — from the forward of a
+ * *concurrently starting* session, which necessarily exists before that
+ * session has written its lease. A session registers its socket name the moment
+ * it is created (before its forward is opened) and unregisters it on teardown,
+ * so any forward reachable during that write-before-lease gap is protected.
+ *
+ * Injected so unit tests stay isolated; the daemon uses a single process-lived
+ * instance so registrations are visible across sibling sessions. A daemon crash
+ * clears the in-memory instance along with the process, which is exactly
+ * correct — the sessions it tracked are dead and their forwards are the orphans
+ * the next `start()` should reclaim.
+ */
+export interface ActiveVideoSessionRegistry {
+  /** Mark a session's abstract socket name as owned on a device. */
+  add(deviceId: string, socketName: string): void;
+  /** Clear a session's socket name once its resources are torn down. */
+  remove(deviceId: string, socketName: string): void;
+  /** Socket names currently owned by a live/in-flight session on the device. */
+  active(deviceId: string): ReadonlySet<string>;
+}
+
+const EMPTY_SOCKET_NAME_SET: ReadonlySet<string> = new Set<string>();
+
+export class InMemoryActiveVideoSessionRegistry implements ActiveVideoSessionRegistry {
+  private readonly byDevice = new Map<string, Set<string>>();
+
+  add(deviceId: string, socketName: string): void {
+    const existing = this.byDevice.get(deviceId);
+    if (existing) {
+      existing.add(socketName);
+      return;
+    }
+    this.byDevice.set(deviceId, new Set([socketName]));
+  }
+
+  remove(deviceId: string, socketName: string): void {
+    const existing = this.byDevice.get(deviceId);
+    if (!existing) {
+      return;
+    }
+    existing.delete(socketName);
+    if (existing.size === 0) {
+      this.byDevice.delete(deviceId);
+    }
+  }
+
+  active(deviceId: string): ReadonlySet<string> {
+    return this.byDevice.get(deviceId) ?? EMPTY_SOCKET_NAME_SET;
+  }
+}
+
+/** Shared across sibling capture sessions in the daemon process. */
+export const defaultActiveVideoSessionRegistry: ActiveVideoSessionRegistry =
+  new InMemoryActiveVideoSessionRegistry();
+
 interface RawVideoServerLease {
   socketName: string;
   sessionToken: string;
@@ -157,6 +218,12 @@ export interface PersistentEncoderH264SourceOptions {
   adbFactory?: AdbClientFactory;
   connector?: SocketConnector;
   timer?: Timer;
+  /**
+   * Registry of socket names owned by live/in-flight sessions, used by the
+   * orphan-forward sweep to avoid removing a concurrently-starting session's
+   * forward. Defaults to a process-lived singleton shared across sessions.
+   */
+  activeVideoSessionRegistry?: ActiveVideoSessionRegistry;
   /** How long to wait for the server to signal readiness (ms). */
   readyTimeoutMs?: number;
   /** Bounded time for a blocking launch-path ADB/socket call (ms). */
@@ -175,6 +242,28 @@ const DEFAULT_READY_TIMEOUT_MS = 10_000;
 
 function socketNameForToken(token: string): string {
   return `${VIDEO_SERVER_SOCKET_PREFIX}_${token.replaceAll("-", "")}`;
+}
+
+/**
+ * Parse one `adb forward --list` row (`<serial> tcp:<port> localabstract:<name>`)
+ * into a video forward, or `null` when the row is not an `automobile_video_*`
+ * TCP forward. Field order is not assumed — the `tcp:`/`localabstract:` tokens
+ * are matched positionally-agnostically, mirroring `removeForwardIfMatching`.
+ */
+function parseVideoForwardLine(line: string): { port: number; socketName: string } | null {
+  const fields = line.trim().split(/\s+/);
+  const destination = fields.find(field =>
+    field.startsWith(`localabstract:${VIDEO_SERVER_SOCKET_PREFIX}_`)
+  );
+  const portField = fields.find(field => field.startsWith("tcp:"));
+  if (destination === undefined || portField === undefined) {
+    return null;
+  }
+  const port = Number.parseInt(portField.slice("tcp:".length), 10);
+  if (!Number.isInteger(port) || port <= 0) {
+    return null;
+  }
+  return { port, socketName: destination.slice("localabstract:".length) };
 }
 
 function isSafeSessionToken(value: string): boolean {
@@ -302,6 +391,7 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
   private readonly localSocketReconnectWindowMs: number;
   private readonly localSocketReconnectRetryMs: number;
   private readonly sessionTokenFactory: () => string;
+  private readonly activeVideoSessionRegistry: ActiveVideoSessionRegistry;
 
   private server: AdbProcess | null = null;
   private socket: StreamSocket | null = null;
@@ -340,6 +430,8 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     this.localSocketReconnectRetryMs =
       options.localSocketReconnectRetryMs ?? DEFAULT_LOCAL_SOCKET_RECONNECT_RETRY_MS;
     this.sessionTokenFactory = options.sessionTokenFactory ?? (() => defaultIdGenerator.next());
+    this.activeVideoSessionRegistry =
+      options.activeVideoSessionRegistry ?? defaultActiveVideoSessionRegistry;
     this.validateTimings();
   }
 
@@ -490,6 +582,10 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     const session = this.createSession();
     this.session = session;
     this.deviceProcessId = null;
+    // Claim this session's socket name BEFORE reconcile opens/owns any forward,
+    // so a sibling session's concurrent orphan sweep can never mistake our
+    // about-to-be-created forward for a stranded one. Cleared in teardown().
+    this.activeVideoSessionRegistry.add(this.options.device.deviceId, session.socketName);
     await this.reconcileExpiredLeases(adb);
     if (!this.running) {return null;}
     await this.withTimeout(
@@ -1150,6 +1246,9 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     this.session = null;
     if (session) {
       await this.cleanupOwnedSession(session, port, deviceProcessId);
+      // Release the socket-name claim only after cleanup removed our forward, so
+      // a sibling sweep cannot reclaim it during the stop()-during-spawn window.
+      this.activeVideoSessionRegistry.remove(this.options.device.deviceId, session.socketName);
     } else if (port !== null) {
       logger.warn(
         `[PersistentEncoderH264Source] refusing forward cleanup port=${port}: session identity is unavailable`
@@ -1177,6 +1276,11 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     // Sweep corrupt/orphaned files regardless of how many leases parsed: a
     // wholly-unparseable directory yields zero leases but still needs cleanup.
     await this.sweepOrphanLeaseFiles(adb, new Set(leases.map(lease => `${lease.token}.json`)));
+
+    // Sweep host forwards with no backing lease at all (device server
+    // self-expired and deleted its own lease, or the daemon was SIGKILLed). Runs
+    // regardless of lease count — the whole point is that the lease is gone.
+    await this.sweepOrphanForwards(adb, new Set(leases.map(lease => lease.socketName)));
 
     if (leases.length === 0) {
       return;
@@ -1296,6 +1400,58 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
       } catch (error) {
         logger.debug(`[PersistentEncoderH264Source] stale-lease-file sweep failed name=${file.name}: ${error}`);
       }
+    }
+  }
+
+  /**
+   * Sweep host `adb forward` entries pointing at an `automobile_video_*` abstract
+   * socket that have no backing lease and are not owned by a live/in-flight
+   * session. This is the only path that can reclaim a forward whose lease is
+   * already gone — the lease-driven loop above removes only forwards *named in*
+   * lease files, so a self-expired server's forward (lease self-deleted) or a
+   * SIGKILLed daemon's forward would otherwise leak until the adb server
+   * restarts (issue #4753).
+   *
+   * `removeForwardIfMatching` re-verifies the port↔destination before removing,
+   * so a port reused by an unrelated service is never touched.
+   */
+  private async sweepOrphanForwards(
+    adb: ReturnType<AdbClientFactory["create"]>,
+    leaseBackedSocketNames: ReadonlySet<string>
+  ): Promise<void> {
+    let stdout: string;
+    try {
+      const listed = await this.withTimeout(
+        adb.executeCommand("forward --list"),
+        this.teardownTimeoutMs,
+        "adb forward --list for orphan sweep"
+      );
+      stdout = listed.stdout;
+    } catch (error) {
+      logger.debug(`[PersistentEncoderH264Source] unable to list forwards for orphan sweep: ${error}`);
+      return;
+    }
+
+    const activeSocketNames = this.activeVideoSessionRegistry.active(this.options.device.deviceId);
+    const orphans: { port: number; socketName: string }[] = [];
+    for (const line of stdout.split(/\r?\n/)) {
+      const forward = parseVideoForwardLine(line);
+      if (forward === null) {
+        continue;
+      }
+      // A lease-backed forward is reclaimed by the lease-driven loop; a forward
+      // owned by a live/in-flight session (including this one) is not stranded.
+      if (leaseBackedSocketNames.has(forward.socketName) || activeSocketNames.has(forward.socketName)) {
+        continue;
+      }
+      orphans.push(forward);
+    }
+
+    for (const orphan of orphans) {
+      logger.info(
+        `[PersistentEncoderH264Source] orphan-forward-sweep port=${orphan.port} socket=${orphan.socketName}`
+      );
+      await this.removeForwardIfMatching(adb, orphan.port, orphan.socketName);
     }
   }
 

--- a/test/features/webrtc/PersistentEncoderH264Source.test.ts
+++ b/test/features/webrtc/PersistentEncoderH264Source.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, test } from "bun:test";
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
 import {
+  InMemoryActiveVideoSessionRegistry,
   PersistentEncoderH264Source,
   VIDEO_SERVER_LEASE_DIRECTORY,
   VIDEO_SERVER_SOCKET_PREFIX,
+  type ActiveVideoSessionRegistry,
   type SocketConnector,
   type StreamSocket,
 } from "../../../src/features/webrtc/PersistentEncoderH264Source";
@@ -205,6 +207,13 @@ function makeSource(overrides: Record<string, unknown> = {}) {
     return socket;
   };
 
+  // Default to a fresh registry per source so the process-lived singleton never
+  // leaks socket-name claims across tests; individual tests may inject a shared
+  // one to exercise sibling-session behavior.
+  const activeVideoSessionRegistry =
+    (overrides.activeVideoSessionRegistry as ActiveVideoSessionRegistry | undefined) ??
+    new InMemoryActiveVideoSessionRegistry();
+
   const source = new PersistentEncoderH264Source({
     device: DEVICE,
     onData: chunk => chunks.push(chunk),
@@ -216,6 +225,7 @@ function makeSource(overrides: Record<string, unknown> = {}) {
     timer,
     sessionTokenFactory: () => SESSION_TOKEN,
     ...overrides,
+    activeVideoSessionRegistry,
   });
 
   return {
@@ -229,6 +239,7 @@ function makeSource(overrides: Record<string, unknown> = {}) {
     errors,
     timer,
     audioEnabled,
+    activeVideoSessionRegistry,
     sessionSocket: () => forwardedSocket,
   };
 }
@@ -913,6 +924,104 @@ describe("PersistentEncoderH264Source", () => {
     ctx.processes[0].ready();
     await startPromise;
     await ctx.source.stop();
+  });
+
+  test("sweeps an orphaned forward whose lease is gone after a simulated daemon SIGKILL", async () => {
+    // Device server self-expired: it deleted its own lease, so no lease names
+    // this forward — the lease-driven loop can never reclaim it (issue #4753).
+    const orphanSocket = `${VIDEO_SERVER_SOCKET_PREFIX}_orphaned`;
+    const ctx = makeSource({
+      leaseOutput: "",
+      forwardListOutput: `${DEVICE.deviceId} tcp:52001 localabstract:${orphanSocket}\n`,
+    });
+
+    const startPromise = ctx.source.start();
+    await tick();
+
+    expect(ctx.commands).toContain("forward --remove tcp:52001");
+
+    ctx.processes[0].ready();
+    await startPromise;
+    await ctx.source.stop();
+  });
+
+  test("does not sweep a concurrently-starting session's forward (forward exists, lease not yet written)", async () => {
+    // A sibling session claimed its socket name before opening its forward; its
+    // lease has not landed yet. The sweep must leave that forward alone.
+    const registry = new InMemoryActiveVideoSessionRegistry();
+    const concurrentSocket = `${VIDEO_SERVER_SOCKET_PREFIX}_concurrent`;
+    registry.add(DEVICE.deviceId, concurrentSocket);
+    const ctx = makeSource({
+      activeVideoSessionRegistry: registry,
+      leaseOutput: "",
+      forwardListOutput: `${DEVICE.deviceId} tcp:52002 localabstract:${concurrentSocket}\n`,
+    });
+
+    const startPromise = ctx.source.start();
+    await tick();
+
+    expect(ctx.commands).toContain("forward --list");
+    expect(ctx.commands).not.toContain("forward --remove tcp:52002");
+
+    ctx.processes[0].ready();
+    await startPromise;
+    await ctx.source.stop();
+  });
+
+  test("never touches a forward whose destination is not an automobile_video socket", async () => {
+    const ctx = makeSource({
+      leaseOutput: "",
+      forwardListOutput: `${DEVICE.deviceId} tcp:52003 localabstract:some_other_service\n`,
+    });
+
+    const startPromise = ctx.source.start();
+    await tick();
+
+    expect(ctx.commands).toContain("forward --list");
+    expect(ctx.commands).not.toContain("forward --remove tcp:52003");
+
+    ctx.processes[0].ready();
+    await startPromise;
+    await ctx.source.stop();
+  });
+
+  test("does not sweep a forward that is still backed by a live lease", async () => {
+    const liveLease = JSON.stringify({
+      version: 1,
+      socketName: "automobile_video_live",
+      sessionToken: "live-session",
+      pid: 4321,
+      ownerPid: 456,
+      deviceSerial: DEVICE.deviceId,
+      forwardPort: 52004,
+      startedAtMs: 95_000,
+      heartbeatAtMs: 100_000,
+      heartbeatElapsedRealtimeMs: 95_000,
+    });
+    const ctx = makeSource({
+      leaseOutput: liveLease,
+      forwardListOutput: `${DEVICE.deviceId} tcp:52004 localabstract:automobile_video_live\n`,
+    });
+
+    const startPromise = ctx.source.start();
+    await tick();
+
+    expect(ctx.commands).not.toContain("forward --remove tcp:52004");
+
+    ctx.processes[0].ready();
+    await startPromise;
+    await ctx.source.stop();
+  });
+
+  test("clears the session's socket claim on teardown so a later orphan can be swept", async () => {
+    const registry = new InMemoryActiveVideoSessionRegistry();
+    const ctx = makeSource({ activeVideoSessionRegistry: registry });
+
+    await startReady(ctx);
+    expect(registry.active(DEVICE.deviceId).has(SESSION_SOCKET)).toBe(true);
+
+    await ctx.source.stop();
+    expect(registry.active(DEVICE.deviceId).has(SESSION_SOCKET)).toBe(false);
   });
 
   test("refuses stale cleanup when the PID command line does not contain the lease token", async () => {


### PR DESCRIPTION
Closes [#4753](https://github.com/kaeawc/auto-mobile/issues/4753)

## Summary

When the on-device video-server self-expires (the normal recovery path after a daemon crash) it deletes its own lease file, and when the daemon is SIGKILLed no cleanup runs at all. In both cases the host `adb forward tcp:<port> localabstract:automobile_video_<token>` entry survives indefinitely: `reconcileExpiredLeases` only removes forwards *named in lease files*, so a forward whose lease is already gone is never reclaimed and accumulates until the adb server restarts.

This adds `sweepOrphanForwards`, called from `reconcileExpiredLeases`, which:

1. Enumerates `adb forward --list` and matches destinations of the form `localabstract:automobile_video_*` (via the new `parseVideoForwardLine`, field-order-agnostic like `removeForwardIfMatching`).
2. Skips any forward whose socket name is backed by a parsed lease (handled by the existing lease-driven loop) or owned by a live/in-flight session.
3. Removes the remainder through the existing `removeForwardIfMatching`, which re-verifies the port↔destination so a port reused by an unrelated service is never touched.

The sweep runs even when zero leases parse — that is the whole point, since the lease is gone.

### Guarding the concurrent-start race

A session opens its forward *before* it writes its lease (`prepareSession` forwards at `:502`, the device server writes the lease later), so during that gap the forward looks lease-less and is indistinguishable from a genuine orphan by lease state alone. To protect it, a new process-lived `ActiveVideoSessionRegistry` records each session's abstract socket name the moment the session is created — before its forward opens — and clears it on teardown after cleanup. The sweep skips any socket still claimed, so a concurrently-starting session's forward is never mistaken for an orphan. A daemon crash clears the in-memory registry along with the process, which is exactly correct: the sessions it tracked are dead and their forwards are the orphans the next `start()` should reclaim.

The registry is injected (interface + `InMemoryActiveVideoSessionRegistry` fake); the daemon uses a single process-lived `defaultActiveVideoSessionRegistry` shared across sibling sessions.

## Verify against current main (after #4783 / #4784)

I re-read `reconcileExpiredLeases`, `sweepOrphanLeaseFiles`, `classifyLeaseForReclaim`, and `cleanupOwnedSession` on current `main` (`origin/main` @ `8aec32209`, which includes both siblings):

- **[#4783](https://github.com/kaeawc/auto-mobile/issues/4783) (lease-file hygiene)** added `sweepOrphanLeaseFiles` (unparseable `*.json` / orphaned `*.json.tmp` removal), the wall-clock fallback in `classifyLeaseForReclaim`, and previous-boot-vs-serial precedence. All of this operates on **lease files** — it never enumerates `adb forward --list`, so a forward whose lease was already deleted is untouched.
- **[#4784](https://github.com/kaeawc/auto-mobile/issues/4784) (device-side reconnect-window self-expiry)** is Kotlin; it is precisely the trigger that *deletes the lease and leaves the forward*, so it makes the residual more common, not less.

**Residual confirmed to still exist:** a forward with no backing lease is reachable by no existing path. This PR is the genuine fix, not speculative.

## Tests

Five new device-free unit tests through the injected ADB seam + `FakeTimer` (full file: 54 pass, `[162ms]`):

- sweeps an orphaned forward whose lease is gone after a simulated daemon SIGKILL (AC 1)
- does not sweep a concurrently-starting session's forward — forward exists, lease not yet written (AC 2)
- never touches a forward whose destination is not an `automobile_video` socket (AC 3)
- does not sweep a forward still backed by a live lease
- clears the session's socket claim on teardown so a later orphan can be swept

## Validation

- `bun run typecheck` — no new errors (196 baseline)
- `turbo run lint build test` — 3/3 successful; **12275 pass / 13 skip / 0 fail**
