### PR TITLE
feat(webrtc): recover from post-start on-device encoder crashes (#4742)

### DIFF
--- a/src/features/webrtc/PersistentEncoderH264Source.ts
+++ b/src/features/webrtc/PersistentEncoderH264Source.ts
@@ -5,6 +5,12 @@ import { defaultIdGenerator } from "../../utils/IdGenerator";
 import { shellQuote } from "../../utils/shellQuote";
 import { defaultTimer, type Timer } from "../../utils/SystemTimer";
 import {
+  exponentialBackoff,
+  normalizeBackoff,
+  type BackoffInput,
+  type BackoffPolicy,
+} from "../../utils/Backoff";
+import {
   defaultAdbClientFactory,
   type AdbClientFactory,
 } from "../../utils/android-cmdline-tools/AdbClientFactory";
@@ -67,6 +73,24 @@ export const DEFAULT_LAUNCH_COMMAND_TIMEOUT_MS = 20_000;
  * reconciliation handles any orphaned device resources.
  */
 export const DEFAULT_TEARDOWN_COMMAND_TIMEOUT_MS = 5_000;
+/**
+ * Default number of bounded, backed-off on-device server relaunch attempts made
+ * across a source's lifetime before it gives up the persistent encoder and falls
+ * back to screenrecord (or, when no fallback is wired, fails via `onError`). The
+ * budget is cumulative — a persistently-broken device that keeps losing its
+ * encoder cannot hot-loop restarts, it exhausts this budget and stops.
+ */
+export const DEFAULT_MAX_SERVER_RELAUNCH_ATTEMPTS = 3;
+/**
+ * Default backoff between post-start server relaunch attempts. Exponential so a
+ * transient hiccup recovers quickly while a hard-broken device backs off before
+ * the budget is spent.
+ */
+export const DEFAULT_SERVER_RELAUNCH_BACKOFF: BackoffInput = exponentialBackoff({
+  initialDelayMs: 1_000,
+  multiplier: 2,
+  maxDelayMs: 8_000,
+});
 
 /** Minimal socket surface the source needs, for injectable testing. */
 export interface StreamSocket {
@@ -236,6 +260,25 @@ export interface PersistentEncoderH264SourceOptions {
   localSocketReconnectRetryMs?: number;
   /** Injectable session token source for deterministic tests. */
   sessionTokenFactory?: () => string;
+  /**
+   * How many bounded, backed-off relaunches of the on-device server to attempt
+   * (cumulatively over the source's lifetime) after a post-start server exit
+   * before giving up the persistent encoder. Defaults to
+   * {@link DEFAULT_MAX_SERVER_RELAUNCH_ATTEMPTS}. Set to `0` to disable relaunch
+   * and surface a post-start loss immediately (fallback/`onError`).
+   */
+  maxServerRelaunchAttempts?: number;
+  /** Backoff between post-start server relaunch attempts. */
+  serverRelaunchBackoff?: BackoffInput;
+  /**
+   * Invoked when relaunch attempts are exhausted, to hand the stream to
+   * screenrecord via the SAME mechanism the initial-start path uses (see
+   * `FallbackH264CaptureSource`). When it resolves, the persistent source is
+   * considered gracefully superseded and does NOT fire `onError`. When it
+   * rejects — or when it is not wired (e.g. the audio path, which requires the
+   * jar) — the post-start loss surfaces via `onError` instead.
+   */
+  onScreenrecordFallback?: (error: Error) => Promise<void>;
 }
 
 const DEFAULT_READY_TIMEOUT_MS = 10_000;
@@ -392,6 +435,8 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
   private readonly localSocketReconnectRetryMs: number;
   private readonly sessionTokenFactory: () => string;
   private readonly activeVideoSessionRegistry: ActiveVideoSessionRegistry;
+  private readonly maxServerRelaunchAttempts: number;
+  private readonly serverRelaunchBackoff: BackoffPolicy;
 
   private server: AdbProcess | null = null;
   private socket: StreamSocket | null = null;
@@ -416,6 +461,9 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
   private sawStreamingStarted = false;
   private serverStartupInProgress: AdbProcess | null = null;
   private serverStartupFailure: { server: AdbProcess; error: Error } | null = null;
+  private serverRelaunchAttempts = 0;
+  private relaunching = false;
+  private relaunchAbortController: AbortController | null = null;
 
   constructor(options: PersistentEncoderH264SourceOptions) {
     this.options = options;
@@ -432,7 +480,25 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     this.sessionTokenFactory = options.sessionTokenFactory ?? (() => defaultIdGenerator.next());
     this.activeVideoSessionRegistry =
       options.activeVideoSessionRegistry ?? defaultActiveVideoSessionRegistry;
+    const relaunchPolicy = PersistentEncoderH264Source.resolveRelaunchPolicy(options);
+    this.maxServerRelaunchAttempts = relaunchPolicy.maxAttempts;
+    this.serverRelaunchBackoff = relaunchPolicy.backoff;
     this.validateTimings();
+  }
+
+  /**
+   * Resolve the post-start relaunch policy from options, defaulting the budget
+   * and backoff. Extracted from the constructor so the option-defaulting `??`
+   * branches do not count against the constructor's complexity ratchet.
+   */
+  private static resolveRelaunchPolicy(options: PersistentEncoderH264SourceOptions): {
+    maxAttempts: number;
+    backoff: BackoffPolicy;
+  } {
+    return {
+      maxAttempts: options.maxServerRelaunchAttempts ?? DEFAULT_MAX_SERVER_RELAUNCH_ATTEMPTS,
+      backoff: normalizeBackoff(options.serverRelaunchBackoff ?? DEFAULT_SERVER_RELAUNCH_BACKOFF),
+    };
   }
 
   /**
@@ -446,6 +512,9 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     }
     if (this.localSocketReconnectWindowMs <= 0 || this.localSocketReconnectRetryMs <= 0) {
       throw new ActionableError("Local socket reconnect timings must be positive milliseconds.");
+    }
+    if (!Number.isInteger(this.maxServerRelaunchAttempts) || this.maxServerRelaunchAttempts < 0) {
+      throw new ActionableError("Server relaunch attempts must be a non-negative integer.");
     }
   }
 
@@ -496,6 +565,9 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
       return;
     }
     this.running = false;
+    // Cancel any in-flight relaunch wait/loop so stop() settles promptly instead
+    // of blocking on a backoff delay or a relaunch launch attempt.
+    this.relaunchAbortController?.abort();
     await this.beginTeardown();
   }
 
@@ -744,14 +816,14 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
         };
         return;
       }
-      this.failIfRunning(new Error(`video-server exited (code=${code}, signal=${signal})`));
+      this.handlePostStartServerLoss(new Error(`video-server exited (code=${code}, signal=${signal})`));
     });
     server.once("error", (error: Error) => {
       if (this.serverStartupInProgress === server) {
         this.serverStartupFailure = { server, error };
         return;
       }
-      this.failIfRunning(error);
+      this.handlePostStartServerLoss(error);
     });
   }
 
@@ -1117,7 +1189,18 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
       await this.waitForReconnectRetry(Math.min(this.localSocketReconnectRetryMs, remainingMs), signal);
     }
 
-    if (signal.aborted) {
+    this.failReconnectIfServerRetained(signal, lastError);
+  }
+
+  /**
+   * Terminal decision for the socket-reconnect loop. A socket-only drop against a
+   * still-retained server that never reconnects is fatal. But an aborted signal
+   * (teardown) or a `null` server (the server process itself exited) means this
+   * path does not own the outcome: teardown or the post-start relaunch path
+   * (handlePostStartServerLoss) does, so it must not also fail the source.
+   */
+  private failReconnectIfServerRetained(signal: AbortSignal, lastError: Error): void {
+    if (signal.aborted || this.server === null) {
       return;
     }
     this.failIfRunning(
@@ -1198,6 +1281,147 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
         // that late local socket open after either deadline or source teardown.
         void connection.then(socket => socket.destroy(), () => {});
       }
+    }
+  }
+
+  /**
+   * Handle a post-start loss of the on-device server process. Instead of failing
+   * the source immediately, attempt a bounded, backed-off relaunch of the server
+   * (issue #4742); when the relaunch budget is spent, hand the stream to
+   * screenrecord (or fail via `onError` when no fallback is wired). Re-entrant
+   * losses while a relaunch is already in flight are ignored — the in-flight
+   * recovery owns the lifecycle.
+   */
+  private handlePostStartServerLoss(error: Error): void {
+    if (!this.running || this.relaunching) {
+      return;
+    }
+    this.relaunching = true;
+    this.relaunchAbortController = new AbortController();
+    void this.recoverFromServerLoss(error).finally(() => {
+      this.relaunching = false;
+    });
+  }
+
+  private async recoverFromServerLoss(initialError: Error): Promise<void> {
+    const signal = this.relaunchAbortController?.signal ?? new AbortController().signal;
+    let lastError = initialError;
+    while (this.canAttemptRelaunch(signal)) {
+      this.serverRelaunchAttempts++;
+      const outcome = await this.attemptRelaunch(this.serverRelaunchAttempts, lastError, signal);
+      if (outcome.status !== "retry") {
+        // "recovered" (streaming again) or "aborted" (stopped mid-relaunch):
+        // either way the loop is done and no screenrecord fallback is warranted.
+        return;
+      }
+      lastError = outcome.error;
+    }
+    if (this.running && !signal.aborted) {
+      await this.fallBackAfterRelaunchExhausted(lastError);
+    }
+  }
+
+  private canAttemptRelaunch(signal: AbortSignal): boolean {
+    return (
+      this.running &&
+      !signal.aborted &&
+      this.serverRelaunchAttempts < this.maxServerRelaunchAttempts
+    );
+  }
+
+  /**
+   * Run one relaunch attempt: back off, tear down the dead session, then launch a
+   * fresh one. A fresh launch (rather than reusing the retained forward in place)
+   * lets the launch-path reconcile sweep any orphan forward/lease the dead server
+   * left behind — reuse-in-place is the optional optimization the issue defers.
+   */
+  private async attemptRelaunch(
+    attempt: number,
+    lastError: Error,
+    signal: AbortSignal
+  ): Promise<{ status: "recovered" | "aborted" | "retry"; error: Error }> {
+    const delayMs = this.serverRelaunchBackoff.delayForAttempt(attempt);
+    logger.warn(
+      `[PersistentEncoderH264Source] on-device server lost post-start (${lastError.message}); ` +
+      `relaunch attempt ${attempt}/${this.maxServerRelaunchAttempts} after ${delayMs}ms`
+    );
+    await this.delayBeforeRelaunch(delayMs, signal);
+    if (!this.running || signal.aborted) {
+      return { status: "aborted", error: lastError };
+    }
+    await this.beginTeardown();
+    if (!this.running || signal.aborted) {
+      return { status: "aborted", error: lastError };
+    }
+    try {
+      await this.launch();
+      if (!this.running) {
+        return { status: "aborted", error: lastError };
+      }
+      logger.info(
+        `[PersistentEncoderH264Source] on-device server relaunched after ${attempt} attempt(s)`
+      );
+      return { status: "recovered", error: lastError };
+    } catch (error) {
+      const relaunchError = error instanceof Error ? error : new Error(String(error));
+      logger.warn(
+        `[PersistentEncoderH264Source] relaunch attempt ${attempt} failed: ${relaunchError.message}`,
+        error
+      );
+      return { status: "retry", error: relaunchError };
+    }
+  }
+
+  /**
+   * Wait for the backoff interval before the next relaunch, resolving early if
+   * the source is torn down. Zero/negative delays resolve immediately so a
+   * disabled backoff does not schedule a needless timer. Deterministic under
+   * `FakeTimer`.
+   */
+  private delayBeforeRelaunch(ms: number, signal: AbortSignal): Promise<void> {
+    if (ms <= 0 || signal.aborted) {
+      return Promise.resolve();
+    }
+    return new Promise<void>(resolve => {
+      const finish = (): void => {
+        this.timer.clearTimeout(handle);
+        signal.removeEventListener("abort", finish);
+        resolve();
+      };
+      const handle = this.timer.setTimeout(finish, ms);
+      signal.addEventListener("abort", finish, { once: true });
+    });
+  }
+
+  /**
+   * Relaunch budget spent: hand the stream to screenrecord via the injected
+   * fallback (the same mechanism the initial-start path uses), or — when no
+   * fallback is wired (e.g. the audio path) or the fallback itself fails —
+   * surface the loss via `onError`.
+   */
+  private async fallBackAfterRelaunchExhausted(error: Error): Promise<void> {
+    if (!this.running) {
+      return;
+    }
+    const fallback = this.options.onScreenrecordFallback;
+    if (!fallback) {
+      this.failIfRunning(error);
+      return;
+    }
+    logger.warn(
+      `[PersistentEncoderH264Source] relaunch budget of ${this.maxServerRelaunchAttempts} spent; ` +
+      `falling back to screenrecord: ${error.message}`
+    );
+    // Stop feeding persistent data and release device resources, but do NOT fire
+    // onError: the stream continues on the screenrecord source the fallback owns.
+    this.running = false;
+    await this.beginTeardown();
+    try {
+      await fallback(error);
+    } catch (fallbackError) {
+      this.options.onError?.(
+        fallbackError instanceof Error ? fallbackError : new Error(String(fallbackError))
+      );
     }
   }
 

--- a/src/features/webrtc/androidH264CaptureSourceFactory.ts
+++ b/src/features/webrtc/androidH264CaptureSourceFactory.ts
@@ -22,19 +22,29 @@ const defaultDeps: AndroidH264CaptureSourceDeps = {
 
 /**
  * A capture source that prefers the persistent on-device encoder and
- * transparently falls back to segment-rotated `screenrecord` when the persistent
- * encoder is unavailable or fails to START. A failure AFTER a successful start
- * is NOT caught here — it propagates via the source's `onError` so the publisher
- * runs its normal reconnect loop, exactly as the screenrecord source does.
+ * transparently falls back to segment-rotated `screenrecord` in two cases:
+ *
+ * 1. the persistent encoder is unavailable or fails to START, and
+ * 2. a post-start on-device encoder/server loss exhausts the persistent source's
+ *    bounded relaunch budget (issue #4742) — signalled through the
+ *    `onScreenrecordFallback` callback the persistent source is built with.
+ *
+ * Both cases route through the SAME `switchToScreenrecord` path, so a mid-stream
+ * encoder crash degrades to screenrecord instead of dropping the viewer to
+ * screenshots. A post-start loss that is still WITHIN the relaunch budget is
+ * handled inside the persistent source and never reaches here.
  */
 class FallbackH264CaptureSource implements H264CaptureSource {
   private active: H264CaptureSource | null = null;
   private stopped = false;
+  private readonly persistent: H264CaptureSource;
 
   constructor(
-    private readonly persistent: H264CaptureSource,
+    buildPersistent: (onScreenrecordFallback: (error: Error) => Promise<void>) => H264CaptureSource,
     private readonly buildScreenrecord: () => H264CaptureSource
-  ) {}
+  ) {
+    this.persistent = buildPersistent(error => this.switchToScreenrecord(error));
+  }
 
   async start(): Promise<void> {
     this.stopped = false;
@@ -42,18 +52,28 @@ class FallbackH264CaptureSource implements H264CaptureSource {
     try {
       await this.persistent.start();
     } catch (error) {
-      if (this.stopped || this.active !== this.persistent) {
-        return;
-      }
-      logger.warn(
-        `[webrtc] persistent encoder unavailable, falling back to screenrecord: ${
-          error instanceof Error ? error.message : String(error)
-        }`
-      );
-      const screenrecord = this.buildScreenrecord();
-      this.active = screenrecord;
-      await screenrecord.start();
+      await this.switchToScreenrecord(error instanceof Error ? error : new Error(String(error)));
     }
+  }
+
+  /**
+   * Replace the persistent source with a fresh screenrecord source and start it.
+   * Idempotent and safe against teardown: a no-op once stopped or once the active
+   * source is no longer the persistent one (already switched). A throw from
+   * `screenrecord.start()` propagates to the caller — the initial-start path
+   * (publisher) or the persistent source's exhaustion handler (which reports it
+   * via `onError`).
+   */
+  private async switchToScreenrecord(error: Error): Promise<void> {
+    if (this.stopped || this.active !== this.persistent) {
+      return;
+    }
+    logger.warn(
+      `[webrtc] persistent encoder unavailable, falling back to screenrecord: ${error.message}`
+    );
+    const screenrecord = this.buildScreenrecord();
+    this.active = screenrecord;
+    await screenrecord.start();
   }
 
   async stop(): Promise<void> {
@@ -94,24 +114,9 @@ export function createAndroidH264CaptureSource(
     return deps.createScreenrecord(options);
   }
 
-  if (options.audioEnabled) {
-    return deps.createPersistent({
-      device: options.device,
-      onData: options.onData,
-      onAudioData: options.onAudioData,
-      onError: options.onError,
-      bitrateBps: options.bitrateBps,
-      size: options.size,
-      quality: options.quality,
-      fps: options.fps,
-      audioEnabled: true,
-      adbFactory: options.adbFactory,
-      timer: options.timer,
-      jarPath,
-    });
-  }
-
-  const persistent = deps.createPersistent({
+  const persistentOptions = (
+    onScreenrecordFallback?: (error: Error) => Promise<void>
+  ): PersistentEncoderH264SourceOptions => ({
     device: options.device,
     onData: options.onData,
     onAudioData: options.onAudioData,
@@ -124,6 +129,18 @@ export function createAndroidH264CaptureSource(
     adbFactory: options.adbFactory,
     timer: options.timer,
     jarPath,
+    onScreenrecordFallback,
   });
-  return new FallbackH264CaptureSource(persistent, () => deps.createScreenrecord(options));
+
+  if (options.audioEnabled) {
+    // Audio requires the persistent jar (screenrecord cannot carry PCM), so there
+    // is no screenrecord fallback to hand off to: a spent relaunch budget surfaces
+    // via onError and the publisher runs its normal reconnect loop.
+    return deps.createPersistent(persistentOptions());
+  }
+
+  return new FallbackH264CaptureSource(
+    onScreenrecordFallback => deps.createPersistent(persistentOptions(onScreenrecordFallback)),
+    () => deps.createScreenrecord(options)
+  );
 }

--- a/test/features/webrtc/PersistentEncoderH264Source.test.ts
+++ b/test/features/webrtc/PersistentEncoderH264Source.test.ts
@@ -749,12 +749,128 @@ describe("PersistentEncoderH264Source", () => {
     expect(lateSocket.destroyed).toBe(true);
   });
 
-  test("surfaces a post-start server exit via onError", async () => {
-    const ctx = makeSource();
+  test("surfaces a post-start server exit via onError when relaunch is disabled", async () => {
+    const ctx = makeSource({ maxServerRelaunchAttempts: 0 });
     await startReady(ctx);
     ctx.processes[0].exit(137, "SIGKILL");
+    await tick();
     expect(ctx.errors).toHaveLength(1);
     expect(ctx.errors[0].message).toContain("video-server exited");
+    expect(ctx.source.isRunning).toBe(false);
+  });
+
+  test("relaunches the on-device server after a single transient post-start exit", async () => {
+    const ctx = makeSource({ serverRelaunchBackoff: 500, maxServerRelaunchAttempts: 3 });
+    await startReady(ctx);
+
+    ctx.processes[0].exit(137, "SIGKILL");
+    await tick();
+    // Backoff has not elapsed: no relaunch spawn yet, and the source is not failed.
+    expect(ctx.processes).toHaveLength(1);
+    expect(ctx.errors).toEqual([]);
+
+    ctx.timer.advanceTime(500);
+    await tick();
+    await tick(); // teardown of the dead session + fresh launch + spawn
+    expect(ctx.processes).toHaveLength(2);
+
+    ctx.processes[1].ready();
+    await tick();
+    await tick(); // readiness resolves, forward + reconnect
+
+    expect(ctx.source.isRunning).toBe(true);
+    expect(ctx.errors).toEqual([]);
+
+    // Streaming resumes on the relaunched server's socket.
+    const latestSocket = ctx.sockets[ctx.sockets.length - 1];
+    latestSocket.feed(streamHeader(480, 1040));
+    latestSocket.feed(framedPacket(Buffer.from([0, 0, 0, 1, 0x67])));
+    expect(ctx.chunks).toEqual([Buffer.from([0, 0, 0, 1, 0x67])]);
+
+    await ctx.source.stop();
+  });
+
+  test("falls back to screenrecord after repeated post-start exits exhaust the relaunch budget", async () => {
+    const fellBackWith: Error[] = [];
+    const ctx = makeSource({
+      serverRelaunchBackoff: 0,
+      maxServerRelaunchAttempts: 2,
+      onScreenrecordFallback: async (error: Error) => {
+        fellBackWith.push(error);
+      },
+    });
+    await startReady(ctx);
+
+    // Relaunch 1: exit -> recovered on a fresh server.
+    ctx.processes[0].exit(1, null);
+    await tick();
+    await tick();
+    ctx.processes[1].ready();
+    await tick();
+    await tick();
+    expect(ctx.source.isRunning).toBe(true);
+
+    // Relaunch 2: exit -> recovered again (budget now spent).
+    ctx.processes[1].exit(1, null);
+    await tick();
+    await tick();
+    ctx.processes[2].ready();
+    await tick();
+    await tick();
+    expect(ctx.source.isRunning).toBe(true);
+    expect(ctx.processes).toHaveLength(3);
+
+    // Third exit: budget spent -> screenrecord fallback, NOT onError.
+    ctx.processes[2].exit(1, null);
+    await tick();
+    await tick();
+
+    expect(fellBackWith).toHaveLength(1);
+    expect(fellBackWith[0].message).toContain("video-server exited");
+    expect(ctx.errors).toEqual([]);
+    expect(ctx.processes).toHaveLength(3); // no further relaunch attempt
+    expect(ctx.source.isRunning).toBe(false);
+  });
+
+  test("surfaces onError only after the relaunch budget is spent when no fallback is wired", async () => {
+    const ctx = makeSource({ serverRelaunchBackoff: 0, maxServerRelaunchAttempts: 1 });
+    await startReady(ctx);
+
+    // Relaunch 1 recovers.
+    ctx.processes[0].exit(1, null);
+    await tick();
+    await tick();
+    ctx.processes[1].ready();
+    await tick();
+    await tick();
+    expect(ctx.source.isRunning).toBe(true);
+    expect(ctx.errors).toEqual([]);
+
+    // Budget spent: the next exit surfaces via onError.
+    ctx.processes[1].exit(1, null);
+    await tick();
+    await tick();
+    expect(ctx.errors).toHaveLength(1);
+    expect(ctx.errors[0].message).toContain("video-server exited");
+    expect(ctx.source.isRunning).toBe(false);
+    expect(ctx.processes).toHaveLength(2);
+  });
+
+  test("stopping during a relaunch backoff cancels the relaunch without failing", async () => {
+    const ctx = makeSource({ serverRelaunchBackoff: 5000, maxServerRelaunchAttempts: 3 });
+    await startReady(ctx);
+
+    ctx.processes[0].exit(1, null);
+    await tick();
+    expect(ctx.processes).toHaveLength(1); // waiting out the backoff
+
+    await ctx.source.stop();
+    // The backoff never elapses; the relaunch is aborted and no new server spawns.
+    ctx.timer.advanceTime(5000);
+    await tick();
+    expect(ctx.processes).toHaveLength(1);
+    expect(ctx.errors).toEqual([]);
+    expect(ctx.source.isRunning).toBe(false);
   });
 
   test("handles a server error while socket connection is pending", async () => {

--- a/test/features/webrtc/androidH264CaptureSourceFactory.test.ts
+++ b/test/features/webrtc/androidH264CaptureSourceFactory.test.ts
@@ -124,6 +124,51 @@ describe("createAndroidH264CaptureSource", () => {
     expect(persistent.stopped).toBe(0);
   });
 
+  test("hands off to screenrecord when the persistent source signals relaunch exhaustion", async () => {
+    let onScreenrecordFallback: ((error: Error) => Promise<void>) | undefined;
+    const persistent = new FakeSource();
+    const screenrecord = new FakeSource();
+    const deps: AndroidH264CaptureSourceDeps = {
+      createPersistent: options => {
+        onScreenrecordFallback = options.onScreenrecordFallback;
+        return persistent;
+      },
+      createScreenrecord: () => screenrecord,
+    };
+    const source = createAndroidH264CaptureSource(baseOptions(), "/tmp/automobile-video.jar", deps);
+    await source.start();
+
+    expect(persistent.started).toBe(1);
+    expect(screenrecord.started).toBe(0);
+    expect(onScreenrecordFallback).toBeDefined();
+
+    // Simulate the persistent source exhausting its relaunch budget mid-stream.
+    await onScreenrecordFallback?.(new Error("encoder crashed; relaunch budget spent"));
+    expect(screenrecord.started).toBe(1);
+
+    // stop() now terminates the active (screenrecord) source, not the superseded one.
+    await source.stop();
+    expect(screenrecord.stopped).toBe(1);
+    expect(persistent.stopped).toBe(0);
+  });
+
+  test("does not wire a screenrecord fallback on the audio-enabled persistent path", () => {
+    let captured: PersistentEncoderH264SourceOptions | undefined;
+    const deps: AndroidH264CaptureSourceDeps = {
+      createPersistent: options => {
+        captured = options;
+        return new FakeSource();
+      },
+      createScreenrecord: () => new FakeSource(),
+    };
+    createAndroidH264CaptureSource(
+      { ...baseOptions(), audioEnabled: true },
+      "/tmp/automobile-video.jar",
+      deps
+    );
+    expect(captured?.onScreenrecordFallback).toBeUndefined();
+  });
+
   test("stops the selected source when stop races its startup", async () => {
     let releaseStart: (() => void) | undefined;
     const persistent = new FakeSource(


### PR DESCRIPTION
Closes [#4742](https://github.com/kaeawc/auto-mobile/issues/4742)

## Summary

There was no recovery from a post-start on-device encoder/server crash. A
transient `MediaCodec`/server exit tore down the whole persistent source and
fired `onError` with **no server relaunch and no fallback to screenrecord**,
dropping the WHEP viewer to screenshots until a fully new stream was requested.
This PR adds the host-side recovery the issue recommends as the primary,
lower-risk fix:

- On a post-start server exit/error within the source's own lifetime, attempt a
  **bounded, backed-off** number of server relaunches.
- When the relaunch budget is spent, **fall back to screenrecord** via the same
  mechanism the initial-`start()` path uses (`FallbackH264CaptureSource`),
  instead of terminating the stream.
- The budget is **cumulative across the source's lifetime**, so a persistently
  broken device cannot hot-loop restarts — it exhausts the budget and stops.

## Verify against current main (re-analysis)

I read the current `watchServer` / `failIfRunning` in
`PersistentEncoderH264Source.ts` and the factory in
`androidH264CaptureSourceFactory.ts` on top of the recent siblings (#4741
bounded ADB/socket timeouts, #4749 writer thread/handoff, #4784 device-side
write-stall watchdog, #4753 forward-orphan sweep). The gap was still real:

- `watchServer` post-start exit/error handlers called `failIfRunning`, which
  runs a full teardown and fires `onError` — no relaunch, no screenrecord
  fallback.
- The screenrecord fallback (`FallbackH264CaptureSource`) only caught the
  **initial** `start()` throwing; a post-start loss bypassed it entirely.
- The socket-reconnect path (#4749) only handles a socket-only drop against a
  **retained** server; when the server *process* exits, `this.server` is nulled
  and that path also fell through to `failIfRunning`.

## Design decision

Per the issue's "small design decision", I prioritized the **host-side bounded
relaunch + screenrecord fallback** as primary and left the Kotlin-side
`CodecException.isRecoverable`/`reset()`/`reconfigure()` work as a follow-up.
This PR is **host-side only** — no Kotlin touched, so it does not overlap or
conflict with #4784's device-side watchdog.

I chose a **fresh relaunch** (teardown of the dead session, then a clean
`launch()`) rather than reusing the retained forward/lease in place. The issue
marks in-place reuse as optional ("where still valid"); a fresh launch reuses the
battle-tested lifecycle and its reconcile sweep cleans up the dead server's
orphan forward/lease, avoiding a delicate partial-state relaunch racing the
socket-reconnect path. In-place-forward reuse is noted as a possible future
optimization.

## What changed

`src/features/webrtc/PersistentEncoderH264Source.ts`
- New options: `maxServerRelaunchAttempts` (default 3), `serverRelaunchBackoff`
  (default exponential 1s→8s, reusing the canonical `Backoff` primitive via
  `normalizeBackoff`), and `onScreenrecordFallback`.
- `watchServer` post-start exit/error now routes to `handlePostStartServerLoss`
  instead of `failIfRunning`. That drives `recoverFromServerLoss`, which loops
  bounded relaunch attempts (`attemptRelaunch`) with `Timer`-driven backoff
  (`delayBeforeRelaunch`, deterministic under `FakeTimer`), then
  `fallBackAfterRelaunchExhausted`.
- On exhaustion: hand off via `onScreenrecordFallback` (no `onError`); if no
  fallback is wired (the audio path — screenrecord cannot carry PCM) or the
  fallback itself throws, surface via `onError`.
- The socket-reconnect terminal decision now defers to the server-loss path when
  `this.server === null` (server process gone), so the two paths don't both
  fail the source.
- `stop()` aborts an in-flight relaunch (backoff wait / attempt) so teardown
  settles promptly.

`src/features/webrtc/androidH264CaptureSourceFactory.ts`
- `FallbackH264CaptureSource` now builds the persistent source with an
  `onScreenrecordFallback` bound to a shared `switchToScreenrecord`, so both the
  initial-start failure and a post-start exhaustion route through one
  screenrecord hand-off. The audio path wires no fallback (unchanged behavior:
  audio requires the jar).

## Validation

- `bun run typecheck` — no new type errors (baseline unchanged).
- `turbo run lint build test` — all three tasks pass (extracted helpers to stay
  under the complexity ratchet; catch logs per the error-handling convention).
- New/updated unit tests (injected ADB + `FakeTimer`, <100ms, no real device):
  - single transient exit → recovered on a relaunched server (backoff honored:
    no relaunch spawn until the backoff elapses).
  - repeated exits → recovered per attempt, then on budget exhaustion → fallback
    to screenrecord, **no** `onError`, and no further relaunch.
  - budget spent with no fallback wired → `onError` only after the budget.
  - relaunch disabled (`maxServerRelaunchAttempts: 0`) → immediate `onError`.
  - stopping during a backoff cancels the relaunch cleanly.
  - factory: a persistent-source exhaustion signal hands the stream to
    screenrecord; audio path wires no fallback.

No Kotlin was touched, so no Kotlin gate was required.
