### PR TITLE
perf(webrtc): retain lastHelperFrame by reference instead of per-frame copy

### DIFF
--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -781,10 +781,17 @@ export class IosH264Source implements H264CaptureSource {
       this.outputWriteHighWaterDurationMs,
       this.lastOutputWriteDurationMs
     );
-    this.lastHelperFrame = {
-      header: { ...frame.header },
-      pixels: Buffer.from(frame.pixels),
-    };
+    // Retain the reference rather than copying the whole frame every frame.
+    // `lastHelperFrame` is only re-read in `requestKeyFrame()` to reprime a
+    // replacement encoder, so paying a full-frame allocation + memcpy on 100%
+    // of frames to serve that rare PLI path is wasteful (~7 MB/frame at
+    // 910x1940 BGRA). This is safe because `frame.pixels` is a fresh
+    // per-frame allocation from `FrameDecoder.takeDetached`, the single-slot
+    // `LatestFrameQueue` never reuses an emitted buffer, and nothing mutates
+    // `frame.pixels` after handoff (`tightlyPackBgraFrame` returns the same
+    // buffer unpadded or a fresh packed buffer, and the pipe write does not
+    // mutate in place). See issue #4735.
+    this.lastHelperFrame = frame;
     if (accepted === false) {
       this.encoderBackpressured = true;
     }

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -1527,7 +1527,6 @@ describe("IosH264Source", () => {
     const firstFrame = frame(2, 2, 0x11);
     await startWithFrame(source, helper, firstFrame);
     expect(encoderSpawns).toHaveLength(1);
-    firstFrame.pixels.fill(0xff);
     emitIdr(encoders[0]);
     await flush();
 
@@ -1555,6 +1554,34 @@ describe("IosH264Source", () => {
 
     expect(chunks).toContainEqual(Buffer.from([0, 0, 0, 1, 0x65]));
     // The deliberate restart must not surface as a source failure.
+    expect(errors).toEqual([]);
+  });
+
+  // Issue #4735: `lastHelperFrame` retains the incoming frame by reference
+  // instead of deep-copying it every frame. Each frame carries its own
+  // `FrameDecoder.takeDetached` allocation and the single-slot queue never
+  // reuses a buffer, so processing later frames must leave the retained
+  // frame's pixels intact and replay them exactly on the next PLI.
+  test("replays the retained latest frame intact after subsequent frames are processed (#4735 no-copy)", async () => {
+    const { source, helper, encoders, encoderSpawns, errors } = createRestartHarness();
+
+    // First frame primes the encoder and becomes `lastHelperFrame`.
+    await startWithFrame(source, helper, frame(2, 2, 0x11));
+    expect(encoderSpawns).toHaveLength(1);
+
+    // Subsequent frames each arrive as independent allocations (mirroring
+    // production `takeDetached` buffers) and advance `lastHelperFrame`.
+    helper.emitFrame(frame(2, 2, 0x22));
+    helper.emitFrame(frame(2, 2, 0x33));
+
+    emitIdr(encoders[0]);
+    await flush();
+
+    // The retained reference must still decode to the latest frame's exact
+    // bytes — not a buffer clobbered by a later frame — when replayed twice
+    // into the replacement encoder.
+    expect(source.requestKeyFrame()).toBe(true);
+    expect(encoders[1].getStdinData()).toEqual(Buffer.alloc(32, 0x33));
     expect(errors).toEqual([]);
   });
 


### PR DESCRIPTION
Closes [#4735](https://github.com/kaeawc/auto-mobile/issues/4735)

## Summary

`IosH264Source.writeFrameToEncoder` allocated and deep-copied a whole frame on
every frame to retain `lastHelperFrame`, which is only ever re-read when a
viewer PLI triggers `requestKeyFrame()`. This removes one full-frame allocation
+ `memcpy` per frame by retaining the incoming frame by reference:

```ts
// before — full-frame copy, every frame
this.lastHelperFrame = { header: { ...frame.header }, pixels: Buffer.from(frame.pixels) };
// after
this.lastHelperFrame = frame;
```

At 910x1940 BGRA that eliminates a ~7 MB allocation + copy per frame
(~106 MB/s of churn at 15 fps), paid purely for the rare standby PLI path.

## Verify-real findings (against current `src/features/webrtc/IosH264Source.ts`)

- The per-frame full copy still exists — it had drifted to lines 784-787
  (issue cited ~:696), inside `writeFrameToEncoder`.
- `lastHelperFrame` is still consumed only in `requestKeyFrame()` (lines
  401-403, replayed twice to reprime the replacement encoder). Otherwise it is
  only nulled on reset (lines 326, 1060).
- The ffmpeg / `lastHelperFrame` re-injection path is intact on `main` — #4727
  has not landed, so this quick win is still applicable.

## Safety (each condition confirmed in current source)

- **Fresh per-frame buffer:** `frame.pixels` originates from
  `FrameDecoder.takeDetached` (`src/features/screen-stream/frameProtocol.ts:170`),
  which calls `BufferQueue.takeDetached` — a fresh `Buffer.allocUnsafe` +
  copy + discard (`src/utils/BufferQueue.ts:37-45`). No later frame reuses the
  buffer.
- **Single-slot queue holds distinct objects:** `LatestFrameQueue` stores one
  `DecodedFrame` at a time and replaces (never reuses) the buffer on enqueue.
- **No write-back after handoff:** `tightlyPackBgraFrame` returns the same
  buffer when unpadded (`bytesPerRow === width*4`) or a fresh packed buffer
  otherwise — neither mutates the source (`IosH264Source.ts:1193-1210`). The
  `encoder.stdin.write` pipe write does not mutate its input buffer in place.

All conditions hold, so retaining the reference is safe.

## Tests

- **New guard** (`test/features/webrtc/IosH264Source.test.ts`): "replays the
  retained latest frame intact after subsequent frames are processed
  (#4735 no-copy)" — primes with one frame, processes two more independent
  frames, then asserts `requestKeyFrame()` replays the latest frame's exact
  bytes twice into the replacement encoder (retained reference not clobbered).
- **Updated** the existing "requestKeyFrame preloads a replacement encoder with
  two defensive copies of the latest frame" test: dropped its
  `firstFrame.pixels.fill(0xff)` line. That mutation-after-handoff simulated
  something that never happens in production (the buffer is never mutated after
  handoff) and only existed to assert the now-removed deep copy. The two-copy
  replay assertion is unchanged.

## Validation

- `bun run typecheck` — pass (no new type errors; 196 baseline).
- `turbo run lint build test` — 3/3 successful; 12282 pass, 0 fail, 13 skip.
- `bun test test/features/webrtc/IosH264Source.test.ts` — 77 pass, 0 fail.
