### PR TITLE
docs: document tool capabilities and registration-flag gating

### DIFF
--- a/docs/using/environment-variables.md
+++ b/docs/using/environment-variables.md
@@ -74,6 +74,24 @@ here for discoverability; most are diagnostic or for advanced testing.
 | `AUTOMOBILE_SKIP_CTRL_PROXY_DOWNLOAD` | Skips Android and iOS CtrlProxy downloads/prefetches when set to `1` or `true`. |
 | `AUTOMOBILE_SKIP_ACCESSIBILITY_DOWNLOAD_IF_INSTALLED` | Skips the accessibility service download when it is already installed. |
 
+## Tool capability defaults (`AUTOMOBILE_TOOLSET_*`)
+
+Advanced tools are hidden behind opt-in **tool capabilities** — off by default so
+a fresh MCP session sees only the core surface. These variables set which
+capabilities are enabled the moment a session connects; both forms are consulted
+and their effects union. Unlike most `AUTOMOBILE_*` variables, they have **no**
+legacy `AUTO_MOBILE_*` alias.
+
+| Variable | Purpose |
+|----------|---------|
+| `AUTOMOBILE_TOOLSET_DEFAULTS` | Comma-separated capability names to enable by default (e.g. `clipboard,telephony`). Unknown names are ignored. |
+| `AUTOMOBILE_TOOLSET_<CAP>` | Enable one capability when set to `1`. `<CAP>` is the capability name upper-cased with hyphens replaced by underscores (e.g. `AUTOMOBILE_TOOLSET_ADVANCED_INTERACTION=1`). |
+
+These are only a fallback: an explicit `setToolCapability` choice for a session is
+persisted and overrides the default. See
+[Tool Capabilities & Registration Flags](tool-capabilities.md) for the full list
+of capabilities, the tools each one exposes, and how to toggle them at runtime.
+
 ## Device provisioning opt-in
 
 AutoMobile never creates a simulator or emulator by default — spawning devices on

--- a/docs/using/tool-capabilities.md
+++ b/docs/using/tool-capabilities.md
@@ -1,0 +1,208 @@
+# Tool Capabilities & Registration Flags
+
+<kbd>✅ Implemented</kbd>
+
+> **Current state:** Session tool capabilities are enabled at runtime with the
+> `setToolCapability` MCP tool and, at startup, via `AUTOMOBILE_TOOLSET_*`
+> environment variables. The process-level `--debug` / `--embedded-sdk` gates are
+> CLI args. See the [Status Glossary](../design-docs/status-glossary.md) for chip
+> definitions.
+
+AutoMobile deliberately exposes only a small **core** set of tools to a fresh MCP
+session. Everything else is gated, so a client sees a lean, task-relevant tool
+list instead of the full surface (dozens of tools) on first connect. This page
+explains the gates, which tools each one controls, and how to turn them on.
+
+## The core surface (always available)
+
+These tools are never gated — they are present the moment you connect:
+
+`observe`, `tapOn`, `tapAny`, `swipeOn`, `inputText`, `clearText`, `keyboard`,
+`pressButton`, `homeScreen`, `recentApps`, `launchApp`, `terminateApp`,
+`installApp`, `uninstallApp`, `listApps`, `listDevices`, `listDeviceImages`,
+`startDevice`, `killDevice`, `setActiveDevice`, `wakeAndUnlock`, and the
+capability control tool `setToolCapability`.
+
+Everything beyond this is reached through one of the three gates below.
+
+## The three gates at a glance
+
+| Gate | Granularity | Default | Turned on by | Hides from `tools/list`? |
+|---|---|---|---|---|
+| **Tool capabilities** | Group of tools, per MCP session | Off (empty) | `setToolCapability` tool, or `AUTOMOBILE_TOOLSET_*` at startup | Yes, until opted in |
+| **`debugOnly`** | Per tool, process-wide | Off | `--debug` CLI arg, or `AUTOMOBILE_DEBUG=1` | Yes, unless debug is on |
+| **`embeddedSdkOnly`** | Per tool, process-wide | Off | `--embedded-sdk` CLI arg | Yes, unless embedded-SDK is on |
+| **`planOnly`** | Per tool | Always hidden | *(not user-toggleable)* | Yes, always (callable only inside plans) |
+
+The gates are **independent and cumulative**. A tool tagged with more than one
+gate stays hidden until *every* gate on it is satisfied — this is the single most
+common source of "I enabled the capability but the tool still isn't there"
+confusion. See [Why isn't my tool showing up?](#why-isnt-my-tool-showing-up)
+below.
+
+---
+
+## Tool capabilities (the primary registration flags)
+
+Advanced tools are grouped into **14 capabilities**. Each is **off by default**;
+an agent opts into the ones it needs for the current session. Opting in is
+cheap, reversible, and scoped to the session — it does not change what any other
+connected client sees.
+
+### The 14 capabilities
+
+| Capability | Tools it exposes | Extra process gate on some tools |
+|---|---|---|
+| `clipboard` | `clipboard`, `selectAllText` | — |
+| `advanced-interaction` | `openLink`, `imeAction`, `dragAndDrop`, `pinchOn`, `shake`, `rotate` | — |
+| `app-permissions` | `getAppPermissions`, `setAppPermissions` | — |
+| `device-settings` | `changeLocalization`, `getDeviceState`, `setDeviceState` | — |
+| `app-data-interop` | `putAppFile`, `getPreference`, `setPreference`, `sqlQuery`, `setKeyValue`, `removeKeyValue`, `clearKeyValueFile` | `sqlQuery`, `setKeyValue`, `removeKeyValue`, `clearKeyValueFile` also need **`--embedded-sdk`** |
+| `notifications` | `systemTray`, `postNotification`, `getNotificationPolicy`, `setNotificationPolicy` | — |
+| `telephony` | `phoneCall`, `sendSms` | — |
+| `accessibility-tools` | `accessibility`, `accessibilityFocus` | `accessibilityFocus` also needs **`--debug`** |
+| `screen-artifacts` | `videoRecording`, `deviceSnapshot`, `highlight` | — |
+| `test-authoring` | `executePlan`, `startTestRecording`, `exportPlan`, `recordSteps`, `barrier`, `criticalSection` | `barrier` / `criticalSection` are **plan-only** and registered only in daemon mode (see below) |
+| `network-inspection` | `network`, `mockNetwork`, `clearMockNetwork`, `getNetworkGraph` | all four also need **`--embedded-sdk`** |
+| `app-routing` | `getDeepLinks` | — |
+| `navigation-modeling` | `navigateTo`, `getNavigationGraph`, `explore` | all three also need **`--debug`** *and* **`--embedded-sdk`** |
+| `biometric-auth` | `biometricAuth` | — |
+
+A tool that is not in any group is part of the core surface and is always
+available (subject only to any process gate it carries).
+
+### Enabling a capability at runtime
+
+Call the always-available `setToolCapability` tool. It enables the capability for
+the **current MCP session**, persists the choice, and emits
+`notifications/tools/list_changed` so a directly connected client re-fetches its
+tool list and sees the newly-exposed tools:
+
+```jsonc
+// Enable clipboard tools for this session
+{ "name": "setToolCapability", "arguments": { "capability": "clipboard" } }
+```
+
+Parameters:
+
+- **`capability`** *(required)* — one of the 14 names above.
+- **`enabled`** *(optional, default `true`)* — set `false` to turn a capability
+  back off.
+- **`sessionUuid`** *(optional)* — the session profile to update. Omit it to
+  update the profile for the connection making the call; that is the normal case.
+  When provided it must identify the calling connection's own active capability
+  or routing-session profile.
+
+```jsonc
+// Turn it back off
+{ "name": "setToolCapability", "arguments": { "capability": "clipboard", "enabled": false } }
+```
+
+### Setting capability defaults at startup
+
+To have a set of capabilities enabled the moment any session connects — useful
+for a CI runner or an IDE integration with a known workflow — set environment
+variables before the daemon starts. Two forms are read (both are consulted; their
+effects union):
+
+| Form | Example | Effect |
+|---|---|---|
+| `AUTOMOBILE_TOOLSET_DEFAULTS` | `AUTOMOBILE_TOOLSET_DEFAULTS=clipboard,telephony` | Comma-separated list of capability names. Unknown names are ignored. |
+| `AUTOMOBILE_TOOLSET_<CAP>=1` | `AUTOMOBILE_TOOLSET_ADVANCED_INTERACTION=1` | Enable one capability. `<CAP>` is the capability name upper-cased with hyphens turned into underscores. Only the value `1` enables it. |
+
+So `app-data-interop` becomes `AUTOMOBILE_TOOLSET_APP_DATA_INTEROP=1`, and
+`network-inspection` becomes `AUTOMOBILE_TOOLSET_NETWORK_INSPECTION=1`.
+
+```bash
+# Start every session with clipboard + notifications enabled
+export AUTOMOBILE_TOOLSET_DEFAULTS=clipboard,notifications
+# Equivalent, one capability at a time
+export AUTOMOBILE_TOOLSET_CLIPBOARD=1
+export AUTOMOBILE_TOOLSET_NOTIFICATIONS=1
+```
+
+> Unlike most `AUTOMOBILE_*` variables, the `AUTOMOBILE_TOOLSET_*` names have **no**
+> legacy `AUTO_MOBILE_*` alias — they are read under the `AUTOMOBILE_` spelling
+> only.
+
+### Persistence and precedence
+
+- A per-session choice made with `setToolCapability` is **persisted** (in the
+  SQLite store) and **survives daemon restarts**.
+- The `AUTOMOBILE_TOOLSET_*` environment defaults are only a **fallback** for
+  capabilities a session has not made an explicit choice about. An explicit
+  `setToolCapability` call therefore always wins over the startup default — even
+  after a restart — until it is explicitly changed again.
+- Capabilities are scoped per session profile, so one client enabling a
+  capability does not widen the surface another client sees.
+
+---
+
+## Process-level gates
+
+These are set once, when the MCP server (daemon) starts, and apply to every
+session in that process.
+
+### `debugOnly` — `--debug` / `AUTOMOBILE_DEBUG=1`
+
+Hides diagnostic and introspection tools unless debug mode is on. Tools behind
+this gate include `debugSearch`, `bugReport`, `identifyInteractions`, `setUIState`,
+`accessibilityFocus`, and the navigation tools (`navigateTo`, `getNavigationGraph`,
+`explore`). Enable with the `--debug` CLI arg or `AUTOMOBILE_DEBUG=1`.
+
+### `embeddedSdkOnly` — `--embedded-sdk`
+
+Hides tools intended for the embedded-SDK integration until the server is started
+with `--embedded-sdk`. Tools behind this gate include `sqlQuery`, the key-value
+storage tools (`setKeyValue`, `removeKeyValue`, `clearKeyValueFile`), the network
+tools (`network`, `mockNetwork`, `clearMockNetwork`, `getNetworkGraph`), and the
+navigation tools.
+
+### `planOnly` — structural, not user-toggleable
+
+`barrier` and `criticalSection` are always hidden from tool discovery: they are
+callable only from **inside a plan**, never as a standalone `tools/call`. They are
+also registered only when the server runs in **daemon mode**. There is no flag to
+surface them in `tools/list` — this is by design.
+
+> **Related runtime action gate:** `recordSteps` is *visible* once
+> `test-authoring` is enabled, but its `begin`/`end` actions require the
+> `mcp-recording` feature flag (`--mcp-recording`) to be on; its `status` action
+> always works. This gates the *action*, not tool discovery.
+
+---
+
+## Why isn't my tool showing up?
+
+Because the gates are cumulative, work through them in order:
+
+1. **Is it a capability tool?** Find the tool in the
+   [14-capability table](#the-14-capabilities). If it's there, enable that
+   capability — `setToolCapability` for this session, or `AUTOMOBILE_TOOLSET_*`
+   at startup.
+2. **Does it carry an extra process gate?** The right-hand column of that table
+   flags the tools that *also* need `--debug` and/or `--embedded-sdk`. For example
+   `navigateTo` needs the `navigation-modeling` capability **and** `--debug`
+   **and** `--embedded-sdk` — enabling the capability alone is not enough.
+3. **Is it `planOnly`?** `barrier` / `criticalSection` will never appear in
+   `tools/list`; use them from within a plan.
+4. **Did the client refresh its tool list?** `setToolCapability` emits
+   `notifications/tools/list_changed`. A directly connected client should
+   re-fetch `tools/list`. In the default **proxy topology**, the daemon proxy
+   does not yet forward that notification, so a proxy-mode client may need to
+   reconnect (or the daemon may need a restart) to observe capability tools that
+   were toggled after it connected — a known limitation shared with the feature
+   flags (see below).
+
+---
+
+## Related documentation
+
+- **[Feature Flags](../design-docs/mcp/feature-flags.md)** — the CLI/env feature
+  flags (`--debug`, `--embedded-sdk`, output-size reduction, observe scope) and
+  the `tools/list_changed` mechanics and proxy-mode caveats referenced above.
+- **[Environment Variables](environment-variables.md)** — the full
+  `AUTOMOBILE_*` environment surface, including the `AUTOMOBILE_TOOLSET_*`
+  defaults described here.
+- **[MCP Tools reference](../design-docs/mcp/tools.md)** — what each individual
+  tool does.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
       - 'Reproducing Bugs': using/reproducing-bugs.md
       - 'UI Tests': using/ui-tests.md
       - 'Hermetic CI Pinning': using/hermetic-ci-pinning.md
+      - 'Tool Capabilities & Registration Flags': using/tool-capabilities.md
       - 'WebRTC Screen Streaming': webrtc-streaming-ci-worker.md
       - 'Environment Variables': using/environment-variables.md
       - 'Performance Analysis':


### PR DESCRIPTION
## What

Adds a user-facing documentation page explaining the **tool registration flags** that gate which MCP tools AutoMobile exposes, so users can figure out which ones to enable and how.

AutoMobile deliberately exposes only a lean **core** tool surface on connect; everything else is gated. Until now the session tool-capabilities layer (added in #4601 / #4634 / #4655) had no user-facing docs.

## The page

[`docs/using/tool-capabilities.md`](docs/using/tool-capabilities.md) documents all three gates:

- **Tool capabilities** — the 14 opt-in groups (off by default), with a full capability→tools table, `setToolCapability` usage (enable/disable, `sessionUuid`), the `AUTOMOBILE_TOOLSET_DEFAULTS` / `AUTOMOBILE_TOOLSET_<CAP>=1` startup env vars, and persistence/precedence semantics.
- **Process gates** — `debugOnly` (`--debug` / `AUTOMOBILE_DEBUG=1`), `embeddedSdkOnly` (`--embedded-sdk`), and structural `planOnly`.
- **"Why isn't my tool showing up?"** — the cumulative-gating troubleshooting section (e.g. `navigateTo` needs the `navigation-modeling` capability **and** `--debug` **and** `--embedded-sdk`), plus the proxy-mode `tools/list_changed` caveat.

## Supporting changes

- `mkdocs.yml` — wired the page into the "Using AutoMobile" nav.
- `docs/using/environment-variables.md` — added an `AUTOMOBILE_TOOLSET_*` section cross-linking the new page.

## Accuracy notes (verified against source, not assumed)

- `AUTOMOBILE_TOOLSET_*` has **no** legacy `AUTO_MOBILE_*` alias — the reader (`getEnvironmentDefaultToolCapabilities`) only checks the `AUTOMOBILE_` spelling.
- `recordSteps` is *visible* once `test-authoring` is enabled, but its `begin`/`end` actions are separately gated by `--mcp-recording`; documented as an action gate, not a discovery gate.

## Validation

`mkdocs build --strict` produces **zero** warnings for the new page or any of its links. (The build's pre-existing anchor warnings in `client-screen-control.md` / `screen-control-mapping.md` are unrelated to this change.)
