### PR TITLE
fix(ios): deterministic teardown and bounded recovery on mid-stream capture failure

### DIFF
--- a/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorCaptureSession.swift
@@ -207,8 +207,9 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
     // MARK: - Internals
 
     private func reconfigure(width: Int, height: Int) {
-        // Fire-and-forget: if the update fails we keep using the old config and
-        // either resync on the next size change or stop with a delegate error.
+        // Detached task: the retry inside `performReconfiguration` bounds the
+        // recovery so a single transient `updateConfiguration` failure does not
+        // silently strand the stream at stale dimensions (issue #4768).
         Task {
             await performReconfiguration(width: width, height: height)
         }
@@ -233,10 +234,23 @@ final class SimulatorCaptureSession: NSObject, SCStreamOutput, SCStreamDelegate 
         updated.sampleRate = 8_000
         updated.channelCount = 1
 
+        // Retry once on failure before giving up: `updateConfiguration` can fail
+        // transiently while ScreenCaptureKit is mid-frame, and silently keeping
+        // the stale config would drift delivered pixels away from the size the
+        // supervisor expects — which the TS side then kills on as a mismatch.
+        // The new dimensions are already recorded above, so on ultimate failure
+        // the next size change still attempts a correcting update.
+        do {
+            try await stream.updateConfiguration(updated)
+            return
+        } catch {
+            diagnosticSink("warn: stream configuration update failed; retrying once: \(error)\n")
+        }
+
         do {
             try await stream.updateConfiguration(updated)
         } catch {
-            diagnosticSink("warn: failed to update stream configuration: \(error)\n")
+            diagnosticSink("warn: failed to update stream configuration after retry: \(error)\n")
         }
     }
 

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
@@ -12,6 +12,18 @@ import ScreenCaptureCore
 // latency is not misreported as a missing Screen Recording entitlement.
 let simulatorPermissionTimeoutSeconds: TimeInterval = 10.0
 
+// Exit status used when a capture stream dies *after* it started delivering
+// frames (a mid-stream `SCStream`/`AVCaptureSession` fatal error). The helper
+// deliberately exits with a non-zero, non-`1` code instead of leaving a dead
+// stream spinning `RunLoop.main`: the parent supervisor (`IosH264Source`) owns
+// bounded reconnect and re-launches a fresh helper on any non-zero exit, so a
+// deterministic process signal is a stronger contract than a live-but-silent
+// process the supervisor can only detect by string-matching an `error:` stderr
+// line. `1` is already used for startup failures; `70` (EX_SOFTWARE) marks the
+// distinct "was running, then the stream failed" case for log triage. See
+// issue #4768.
+let midStreamFatalExitCode: Int32 = 70
+
 // A command-line process has no AppKit application by default. ScreenCaptureKit
 // reaches CoreGraphics when creating an SCStream, and CoreGraphics aborts with
 // CGS_REQUIRE_INIT unless this connection is initialized first.
@@ -185,7 +197,11 @@ case .captureSimulator(let windowID, let fps, let audio):
     let metricsReporter = FrameMetricsReporter(writer: writer, output: logError)
     metricsReporter.start()
     let simSession = SimulatorCaptureSession(writer: writer) { error in
+        // A mid-stream ScreenCaptureKit fatal error: exit deterministically so
+        // the supervisor's bounded reconnect re-establishes capture, rather than
+        // leaving RunLoop.main spinning on a dead stream (issue #4768).
         logError("error: ScreenCaptureKit stream stopped: \(error)")
+        exit(midStreamFatalExitCode)
     }
     let firstFrameSignal = simSession.firstFrameSignal
 
@@ -260,7 +276,12 @@ case .capture(let deviceID):
     let metricsReporter = FrameMetricsReporter(writer: writer, output: logError)
     metricsReporter.start()
     let captureSession = DeviceCaptureSession(writer: writer) { error in
+        // A mid-stream AVCaptureSession fatal error (runtime error / interruption
+        // once running): exit deterministically so the supervisor's bounded
+        // reconnect re-establishes capture instead of leaving a dead session
+        // spinning RunLoop.main (issue #4768).
         logError("error: iOS device capture failed: \(error)")
+        exit(midStreamFatalExitCode)
     }
 
     do {

--- a/ios/screen-capture/Tests/ScreenCaptureHelperTests/SimulatorCaptureSessionTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureHelperTests/SimulatorCaptureSessionTests.swift
@@ -40,7 +40,11 @@ final class SimulatorCaptureSessionTests: XCTestCase {
         private(set) var updatedConfigurations: [SCStreamConfiguration] = []
 
         var startCaptureError: Error?
+        /// When set, every `updateConfiguration` call throws it.
         var updateConfigurationError: Error?
+        /// Throws on the first N `updateConfiguration` calls, then succeeds —
+        /// models a transient failure that a single retry recovers from.
+        var updateConfigurationTransientFailures = 0
 
         func addStreamOutput(
             _ output: SCStreamOutput,
@@ -66,6 +70,10 @@ final class SimulatorCaptureSessionTests: XCTestCase {
 
         func updateConfiguration(_ configuration: SCStreamConfiguration) async throws {
             updatedConfigurations.append(configuration)
+            if updateConfigurationTransientFailures > 0 {
+                updateConfigurationTransientFailures -= 1
+                throw StubError(id: -1)
+            }
             if let error = updateConfigurationError { throw error }
         }
     }
@@ -204,7 +212,7 @@ final class SimulatorCaptureSessionTests: XCTestCase {
         XCTAssertTrue(diagnostics.lines.isEmpty)
     }
 
-    func testReconfigureFailureIsSwallowedWithWarningButDimensionsStick() async {
+    func testReconfigureRetriesOnceThenWarnsButDimensionsStick() async {
         let diagnostics = DiagnosticRecorder()
         let session = makeSession(diagnostics: diagnostics)
         let fake = FakeCaptureStream()
@@ -217,11 +225,41 @@ final class SimulatorCaptureSessionTests: XCTestCase {
         // failed update does not resurrect the stale size.
         XCTAssertEqual(session.configuredPixelWidth, 640)
         XCTAssertEqual(session.configuredPixelHeight, 480)
-        XCTAssertEqual(diagnostics.lines.count, 1)
-        let warning = diagnostics.lines.first ?? ""
+        // A persistent failure is retried exactly once (two total attempts).
+        XCTAssertEqual(fake.updatedConfigurations.count, 2)
+        XCTAssertEqual(diagnostics.lines.count, 2)
         XCTAssertTrue(
-            warning.hasPrefix("warn: failed to update stream configuration:"),
-            "unexpected diagnostic line: \(warning)"
+            diagnostics.lines[0].hasPrefix("warn: stream configuration update failed; retrying once:"),
+            "unexpected first diagnostic line: \(diagnostics.lines[0])"
+        )
+        XCTAssertTrue(
+            diagnostics.lines[1].hasPrefix("warn: failed to update stream configuration after retry:"),
+            "unexpected second diagnostic line: \(diagnostics.lines[1])"
+        )
+    }
+
+    func testReconfigureRecoversOnRetryWithoutFinalWarning() async {
+        let diagnostics = DiagnosticRecorder()
+        let session = makeSession(diagnostics: diagnostics)
+        let fake = FakeCaptureStream()
+        // Fail the first update, succeed on the retry.
+        fake.updateConfigurationTransientFailures = 1
+        session.stream = fake
+
+        await session.performReconfiguration(width: 800, height: 600)
+
+        XCTAssertEqual(session.configuredPixelWidth, 800)
+        XCTAssertEqual(session.configuredPixelHeight, 600)
+        // Two attempts: the transient failure plus the successful retry.
+        XCTAssertEqual(fake.updatedConfigurations.count, 2)
+        XCTAssertEqual(fake.updatedConfigurations.last?.width, 800)
+        XCTAssertEqual(fake.updatedConfigurations.last?.height, 600)
+        // Only the "retrying once" notice; no ultimate-failure line, since the
+        // retry applied the new configuration.
+        XCTAssertEqual(diagnostics.lines.count, 1)
+        XCTAssertTrue(
+            diagnostics.lines[0].hasPrefix("warn: stream configuration update failed; retrying once:"),
+            "unexpected diagnostic line: \(diagnostics.lines[0])"
         )
     }
 

--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -29,6 +29,12 @@ import {
   type FfmpegProcess,
 } from "../../utils/media/FfmpegClient";
 import { defaultTimer, type Timer } from "../../utils/SystemTimer";
+import {
+  exponentialBackoff,
+  normalizeBackoff,
+  type BackoffInput,
+  type BackoffPolicy,
+} from "../../utils/Backoff";
 import type {
   H264CaptureSource,
   H264CaptureSourceMetrics,
@@ -77,6 +83,25 @@ export const IOS_FORCED_KEYFRAME_MIN_INTERVAL_MS = 3000;
  * ({@link IOS_HELPER_STOP_GRACE_MS}).
  */
 export const IOS_ENCODER_RESTART_GRACE_MS = 2_000;
+/**
+ * Bounded reconnect attempts for a *running-phase* capture failure before the
+ * source finally surfaces `onError`. A long-lived automation stream should
+ * survive a transient helper crash / encoder blip by re-establishing capture
+ * in-process, mirroring how {@link AndroidH264Source} owns its persistent
+ * segment-rotated session rather than ending the WHIP session on the first
+ * hiccup (PR #4413). The initial startup is deliberately *not* covered — a
+ * failure there surfaces so a genuine misconfiguration (denied permission,
+ * wrong window) is not masked by a silent retry loop, matching
+ * {@link ReconnectController}'s "initial attempt is not retried" philosophy.
+ * See issue #4768.
+ */
+export const IOS_RUNNING_RECONNECT_MAX_ATTEMPTS = 2;
+/** Default backoff between running-phase reconnect attempts: 500ms→1s→2s (cap). */
+export const IOS_RUNNING_RECONNECT_BACKOFF: BackoffInput = exponentialBackoff({
+  initialDelayMs: 500,
+  multiplier: 2,
+  maxDelayMs: 2_000,
+});
 /** H.264 macroblock edge, in pixels. */
 const H264_MACROBLOCK_SIZE = 16;
 /** Smallest dimension ffmpeg can encode as 4:2:0 chroma-subsampled video. */
@@ -207,6 +232,14 @@ export interface IosH264SourceOptions extends H264CaptureSourceOptions {
   firstFrameTimeoutMs?: number;
   /** Host-scoped warm helper pool. Supplying createHelper bypasses it for tests. */
   simulatorHelperPool?: IOSSimulatorCaptureHelperPool;
+  /**
+   * Running-phase reconnect attempts before surfacing `onError`. Defaults to
+   * {@link IOS_RUNNING_RECONNECT_MAX_ATTEMPTS}; `0` restores the legacy
+   * fail-fast behavior (a running failure tears the source down immediately).
+   */
+  runningReconnectMaxAttempts?: number;
+  /** Backoff schedule between running-phase reconnect attempts. */
+  runningReconnectBackoff?: BackoffInput;
 }
 
 interface SimulatorWindowInfo {
@@ -223,7 +256,7 @@ export interface EncoderSize {
 
 export interface IosH264FrameMetrics extends H264CaptureSourceMetrics {}
 
-type IosH264SourcePhase = "idle" | "starting" | "running" | "stopping";
+type IosH264SourcePhase = "idle" | "starting" | "running" | "reconnecting" | "stopping";
 
 export interface ScreenCaptureHelperEnsurer {
   ensure(): Promise<string | null>;
@@ -245,6 +278,8 @@ export class IosH264Source implements H264CaptureSource {
   private readonly firstFrameTimeoutMs: number;
   private readonly pendingFrames: LatestFrameQueue;
   private readonly simulatorHelperPool: IOSSimulatorCaptureHelperPool;
+  private readonly runningReconnectMaxAttempts: number;
+  private readonly runningReconnectBackoff: BackoffPolicy;
 
   private helper: IosFrameCaptureHelper | null = null;
   private captureKind: CaptureTarget["kind"] | null = null;
@@ -269,6 +304,15 @@ export class IosH264Source implements H264CaptureSource {
   private encoderIdrParser = new H264AnnexBParser();
   private encoderHasProducedIdr = false;
   private phase: IosH264SourcePhase = "idle";
+  /**
+   * True once `start()` has fully resolved (first frame — and, when enabled,
+   * first audio — delivered). Running-phase reconnect only covers steady-state
+   * failures after this point; a failure during the initial handshake surfaces
+   * so a genuine misconfiguration is not hidden behind a retry loop.
+   */
+  private startupComplete = false;
+  /** Cancels an in-flight reconnect backoff wait; resolves it as "cancelled". */
+  private cancelReconnectDelay: (() => void) | null = null;
 
   constructor(private readonly options: IosH264SourceOptions) {
     this.helperPath = options.helperPath;
@@ -298,10 +342,23 @@ export class IosH264Source implements H264CaptureSource {
       now: () => this.timer.now(),
     });
     this.simulatorHelperPool = options.simulatorHelperPool ?? iosSimulatorCaptureHelperPool;
+    const reconnect = IosH264Source.resolveRunningReconnect(options);
+    this.runningReconnectMaxAttempts = reconnect.maxAttempts;
+    this.runningReconnectBackoff = reconnect.backoff;
     this.simulatorWindowResolver =
       options.simulatorWindowResolver ??
       ((helperPath, device, audioEnabled, signal) =>
         defaultResolveSimulatorWindowId(helperPath, device, this.commandRunner, audioEnabled, signal));
+  }
+
+  /** Resolve running-phase reconnect options against their defaults. */
+  private static resolveRunningReconnect(
+    options: IosH264SourceOptions
+  ): { maxAttempts: number; backoff: BackoffPolicy } {
+    return {
+      maxAttempts: options.runningReconnectMaxAttempts ?? IOS_RUNNING_RECONNECT_MAX_ATTEMPTS,
+      backoff: normalizeBackoff(options.runningReconnectBackoff ?? IOS_RUNNING_RECONNECT_BACKOFF),
+    };
   }
 
   /** Snapshot of each bounded handoff from capture through VideoToolbox. */
@@ -319,6 +376,7 @@ export class IosH264Source implements H264CaptureSource {
     }
     await this.teardownPromise;
     this.phase = "starting";
+    this.startupComplete = false;
     this.lastHelperStderr = null;
     this.lastReadinessPhase = null;
     this.helperFrameMetrics = null;
@@ -326,20 +384,31 @@ export class IosH264Source implements H264CaptureSource {
     this.lastHelperFrame = null;
 
     try {
-      const helperPath = await this.resolveHelperPath();
-      await validateFfmpegAvailability(this.ffmpegClient, this.ffmpegPath, this.options.commandRunner);
-      const target = await this.resolveCaptureTarget(helperPath);
-      this.captureKind = target.kind;
-      if (!this.isActive()) {
-        return;
-      }
-
-      await this.startCaptureWithSimulatorRetry(helperPath, target);
+      await this.establishCapture();
+      this.startupComplete = this.phaseNow() === "running";
     } catch (error) {
       this.phase = "stopping";
       await this.beginTeardown();
       throw error;
     }
+  }
+
+  /**
+   * Resolve the helper + capture target and bring capture up to the first
+   * frame. Shared by the initial {@link start} and the running-phase reconnect
+   * loop so both establish capture through exactly the same path. On success the
+   * phase is `"running"` (set by the first-frame handler); a `stop()` that races
+   * the handshake leaves it non-`"running"`, which callers treat as "not up".
+   */
+  private async establishCapture(): Promise<void> {
+    const helperPath = await this.resolveHelperPath();
+    await validateFfmpegAvailability(this.ffmpegClient, this.ffmpegPath, this.options.commandRunner);
+    const target = await this.resolveCaptureTarget(helperPath);
+    this.captureKind = target.kind;
+    if (!this.isActive()) {
+      return;
+    }
+    await this.startCaptureWithSimulatorRetry(helperPath, target);
   }
 
   async stop(): Promise<void> {
@@ -348,6 +417,8 @@ export class IosH264Source implements H264CaptureSource {
       return;
     }
     this.phase = "stopping";
+    this.startupComplete = false;
+    this.cancelReconnectDelay?.();
     this.cancelFirstFrameWait?.();
     this.cancelFirstAudioWait?.();
     await this.beginTeardown();
@@ -760,15 +831,40 @@ export class IosH264Source implements H264CaptureSource {
       this.encoderSize &&
       (this.encoderSize.width !== size.width || this.encoderSize.height !== size.height)
     ) {
-      this.failIfRunning(
-        new Error(
-          `iOS capture frame changed size from ${this.encoderSize.width}x${this.encoderSize.height} to ${size.width}x${size.height}`
-        )
-      );
-      return;
+      // A mid-stream size change (device rotation, the Swift helper's own
+      // reconfigure) is a recoverable reconfigure, not a fatal error: restart
+      // the encoder at the new geometry (a fresh SPS/PPS + IDR) rather than
+      // tearing the whole source down. See issue #4768.
+      this.reconfigureEncoderSize(size);
     }
 
     this.writeFrameToEncoder(frame);
+  }
+
+  /**
+   * Restart the ffmpeg encoder at a new capture geometry, in place. ffmpeg's
+   * `-s WxH` input size is fixed for the life of a process, so a size change
+   * requires a fresh encoder — but only the encoder, not the capture helper.
+   * The replacement begins its output with SPS/PPS + an IDR on the next frame,
+   * which is exactly what a resolution change needs downstream. Mirrors the
+   * on-demand restart in {@link requestKeyFrame}; the outgoing encoder's guarded
+   * exit/error handlers no-op once `this.encoder` is replaced.
+   */
+  private reconfigureEncoderSize(newSize: EncoderSize): void {
+    const previous = this.encoderSize;
+    logger.info(
+      `[IosH264Source] capture frame size changed from ${previous?.width}x${previous?.height} ` +
+      `to ${newSize.width}x${newSize.height}; restarting encoder at the new size`
+    );
+    const oldEncoder = this.encoder;
+    // Queued frames carry the old geometry; drop them so the new encoder is not
+    // fed a frame sized for the previous configuration.
+    this.pendingFrames.clear(true);
+    this.reportFrameMetrics();
+    this.startEncoder(newSize);
+    if (oldEncoder) {
+      void this.reapOutgoingEncoder(oldEncoder);
+    }
   }
 
   private writeFrameToEncoder(frame: DecodedFrame): void {
@@ -873,12 +969,9 @@ export class IosH264Source implements H264CaptureSource {
       this.encoderSize &&
       (this.encoderSize.width !== size.width || this.encoderSize.height !== size.height)
     ) {
-      this.failIfRunning(
-        new Error(
-          `iOS capture frame changed size from ${this.encoderSize.width}x${this.encoderSize.height} to ${size.width}x${size.height}`
-        )
-      );
-      return;
+      // A dequeued frame can also carry a new geometry; reconfigure rather than
+      // fail (issue #4768).
+      this.reconfigureEncoderSize(size);
     }
     this.writeFrameToEncoder(frame);
   }
@@ -1029,10 +1122,101 @@ export class IosH264Source implements H264CaptureSource {
     if (this.phase !== "running") {
       return;
     }
+    // Only a steady-state failure (after start() resolved) is eligible for a
+    // bounded reconnect; a failure still inside the initial handshake surfaces
+    // immediately so a real misconfiguration is not masked by a retry loop.
+    if (this.startupComplete && this.runningReconnectMaxAttempts > 0) {
+      this.phase = "reconnecting";
+      this.startupComplete = false;
+      void this.runReconnect(error);
+      return;
+    }
+    this.failNow(error);
+  }
+
+  /** Terminal failure: tear the source down and surface `onError`. */
+  private failNow(error: Error): void {
     this.rejectFirstAudioWait?.(error);
     this.phase = "stopping";
+    this.startupComplete = false;
     void this.beginTeardown();
     this.options.onError?.(error);
+  }
+
+  /**
+   * Bounded running-phase reconnect. Tears down the failed helper/encoder, then
+   * re-establishes capture up to {@link runningReconnectMaxAttempts} times with
+   * {@link runningReconnectBackoff} between attempts. On success the source
+   * resumes running with no `onError`; on exhaustion the original failure is
+   * surfaced. A `stop()` at any point cancels the cycle. This keeps a long-lived
+   * automation stream alive across a transient blip, mirroring how
+   * {@link AndroidH264Source} re-establishes its persistent session (PR #4413).
+   */
+  private async runReconnect(initialError: Error): Promise<void> {
+    logger.warn(
+      `[IosH264Source] running-phase capture failure; attempting bounded reconnect ` +
+      `(up to ${this.runningReconnectMaxAttempts}): ${initialError.message}`
+    );
+    await this.beginTeardown();
+
+    for (
+      let attempt = 1;
+      this.phase === "reconnecting" && attempt <= this.runningReconnectMaxAttempts;
+      attempt++
+    ) {
+      const delayMs = this.runningReconnectBackoff.delayForAttempt(attempt);
+      const cancelled = await this.waitReconnectBackoff(delayMs);
+      if (cancelled || this.phase !== "reconnecting") {
+        return; // stop() intervened during the backoff wait.
+      }
+      this.phase = "starting";
+      try {
+        await this.establishCapture();
+        if (this.phaseNow() === "running") {
+          this.startupComplete = true;
+          logger.info(
+            `[IosH264Source] running-phase reconnect succeeded on attempt ${attempt}`
+          );
+          return;
+        }
+        // A stop() raced the handshake; teardown is owned by stop().
+        return;
+      } catch (error) {
+        logger.warn(
+          `[IosH264Source] reconnect attempt ${attempt}/${this.runningReconnectMaxAttempts} failed: ` +
+          `${error instanceof Error ? error.message : String(error)}`
+        );
+        await this.beginTeardown();
+        const phase = this.phaseNow();
+        if (phase === "stopping" || phase === "idle") {
+          return; // stop() won during the attempt.
+        }
+        this.phase = "reconnecting";
+      }
+    }
+
+    if (this.phase === "reconnecting") {
+      this.failNow(initialError);
+    }
+  }
+
+  /**
+   * Resolve after `delayMs`, or immediately with `true` if {@link cancelReconnectDelay}
+   * fires first (a `stop()` during the backoff). Uses the injected {@link Timer}
+   * so reconnect timing is deterministic under a FakeTimer.
+   */
+  private waitReconnectBackoff(delayMs: number): Promise<boolean> {
+    return new Promise(resolve => {
+      const handle = this.timer.setTimeout(() => {
+        this.cancelReconnectDelay = null;
+        resolve(false);
+      }, delayMs);
+      this.cancelReconnectDelay = (): void => {
+        this.timer.clearTimeout(handle);
+        this.cancelReconnectDelay = null;
+        resolve(true);
+      };
+    });
   }
 
   private failIfCurrentHelper(helper: IosFrameCaptureHelper, error: Error): void {
@@ -1043,7 +1227,18 @@ export class IosH264Source implements H264CaptureSource {
   }
 
   private isActive(): boolean {
-    return this.phase === "starting" || this.phase === "running";
+    return this.phase === "starting" || this.phase === "running" || this.phase === "reconnecting";
+  }
+
+  /**
+   * Read the current phase through a method boundary so a comparison after an
+   * `await` is not defeated by TypeScript's flow narrowing: an async callback
+   * (a frame handler flipping the phase to `"running"`, a `stop()`) can mutate
+   * `this.phase` while an `await` is suspended, which control-flow analysis
+   * cannot see.
+   */
+  private phaseNow(): IosH264SourcePhase {
+    return this.phase;
   }
 
   private beginTeardown(): Promise<void> {

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -240,6 +240,42 @@ function createRestartHarness(
   return { source, helper, encoders, encoderSpawns, chunks, errors };
 }
 
+// A harness that hands out a *fresh* helper per createHelper call and a fresh
+// encoder per spawn, so a running-phase reconnect (which tears down the failed
+// helper/encoder and establishes new ones) is observable as additional
+// helper/encoder instances rather than re-listening on a shared emitter.
+function createReconnectHarness(
+  overrides: Partial<ConstructorParameters<typeof IosH264Source>[0]> = {}
+) {
+  const helpers: FakeFrameCaptureHelper[] = [];
+  const encoders: FakeChildProcess[] = [];
+  const encoderSpawns: Array<{ command: string; args: string[] }> = [];
+  const chunks: Buffer[] = [];
+  const errors: Error[] = [];
+  const source = new IosH264Source({
+    device: IOS_DEVICE,
+    helperPath: FAKE_HELPER_PATH,
+    helperPathExists: fakeHelperPathExists,
+    onData: chunk => chunks.push(chunk),
+    onError: error => errors.push(error),
+    createHelper: () => {
+      const helper = new FakeFrameCaptureHelper();
+      helpers.push(helper);
+      return helper;
+    },
+    spawner: (command, args) => {
+      encoderSpawns.push({ command, args });
+      const encoder = new FakeChildProcess();
+      encoders.push(encoder);
+      return encoder as unknown as ChildProcessWithoutNullStreams;
+    },
+    simulatorWindowResolver: async () => 42,
+    commandRunner: successfulCommandRunner,
+    ...overrides,
+  });
+  return { source, helpers, encoders, encoderSpawns, chunks, errors };
+}
+
 async function successfulCommandRunner(_command: string, args: string[]) {
   if (args.includes("-encoders")) {
     return {
@@ -1106,7 +1142,11 @@ describe("IosH264Source", () => {
   });
 
   test("reports post-start encoder exits with buffered stderr as source failures", async () => {
-    const { source, helper, encoder, errors } = createHarness();
+    // Reconnect disabled so this asserts the terminal failure surface directly;
+    // the bounded-reconnect path has dedicated coverage below.
+    const { source, helper, encoder, errors } = createHarness(IOS_DEVICE, {
+      runningReconnectMaxAttempts: 0,
+    });
 
     await startWithFrame(source, helper, frame(1, 1, 0x11));
     encoder.stderr.push("Error: cannot create VideoToolbox compression session\n");
@@ -1122,7 +1162,9 @@ describe("IosH264Source", () => {
   });
 
   test("reports a fatal capture-helper diagnostic after startup", async () => {
-    const { source, helper, errors } = createHarness();
+    const { source, helper, errors } = createHarness(IOS_DEVICE, {
+      runningReconnectMaxAttempts: 0,
+    });
 
     await startWithFrame(source, helper, frame(1, 1, 0x11));
     helper.emitStderr("Error: AVCaptureSession runtime error: media services were reset");
@@ -1145,6 +1187,7 @@ describe("IosH264Source", () => {
       createHelper: () => helper,
       spawner: () => encoder as unknown as ChildProcessWithoutNullStreams,
       commandRunner: successfulCommandRunner,
+      runningReconnectMaxAttempts: 0,
     });
 
     await startWithFrame(source, helper, frame(1, 1, 0x11));
@@ -1279,14 +1322,119 @@ describe("IosH264Source", () => {
     expect(helper.stopped).toBe(true);
   });
 
-  test("fails when frame dimensions change after the encoder starts", async () => {
-    const { source, helper, errors } = createHarness();
+  test("reconfigures the encoder in place when frame dimensions change mid-stream", async () => {
+    // A size change (rotation) restarts only the encoder at the new geometry
+    // rather than failing the whole source (issue #4768). Use the restart
+    // harness so the second encoder spawn is observable.
+    const { source, helper, encoders, encoderSpawns, errors } = createRestartHarness();
 
-    await startWithFrame(source, helper, frame(2, 1, 0x11));
-    helper.emitFrame(frame(3, 1, 0x22));
+    const started = source.start();
+    await flush();
+    helper.emitFrame(frame(4, 2, 0x11));
+    await started;
+
+    helper.emitFrame(frame(6, 4, 0x22));
     await flush();
 
-    expect(errors[0].message).toContain("changed size");
+    // A second encoder was spawned at the new size, and no error was surfaced.
+    expect(errors).toEqual([]);
+    expect(encoderSpawns).toHaveLength(2);
+    expect(encoderSpawns[0].args.join(" ")).toContain("-s 4x2");
+    expect(encoderSpawns[1].args.join(" ")).toContain("-s 6x4");
+    // The outgoing encoder is reaped (SIGTERM sent).
+    expect(encoders[0].killed).toBe(true);
+    // The new frame was written to the fresh encoder.
+    expect(encoders[1].getStdinData().length).toBeGreaterThan(0);
+  });
+
+  test("reconnects after a running-phase helper exit and resumes without onError", async () => {
+    const timer = new FakeTimer();
+    const { source, helpers, encoders, errors } = createReconnectHarness({ timer });
+
+    const started = source.start();
+    await flush();
+    helpers[0].emitFrame(frame(2, 2, 0x11));
+    await started;
+    expect(helpers).toHaveLength(1);
+
+    // A mid-stream helper exit triggers a bounded reconnect, not a teardown.
+    helpers[0].emit("exit", { code: 70, signal: null });
+    await flush();
+    expect(errors).toEqual([]);
+
+    // First backoff (500ms) elapses and capture is re-established.
+    timer.advanceTime(500);
+    await flush();
+    expect(helpers).toHaveLength(2);
+    expect(helpers[1].started).toBe(true);
+
+    helpers[1].emitFrame(frame(2, 2, 0x22));
+    await flush();
+
+    // The reconnected helper's frame is encoded; no error was ever surfaced.
+    expect(errors).toEqual([]);
+    expect(encoders).toHaveLength(2);
+    expect(encoders[1].getStdinData().length).toBeGreaterThan(0);
+    expect(helpers[0].stopped).toBe(true);
+  });
+
+  test("surfaces onError after exhausting bounded reconnect attempts", async () => {
+    const timer = new FakeTimer();
+    const { source, helpers, errors } = createReconnectHarness({
+      timer,
+      firstFrameTimeoutMs: 50,
+      runningReconnectMaxAttempts: 2,
+    });
+
+    const started = source.start();
+    await flush();
+    helpers[0].emitFrame(frame(2, 2, 0x11));
+    await started;
+
+    helpers[0].emit("exit", { code: 70, signal: null });
+    await flush();
+
+    // Attempt 1: backoff 500ms, then the re-established helper never produces a
+    // frame and times out.
+    timer.advanceTime(500);
+    await flush();
+    expect(helpers).toHaveLength(2);
+    timer.advanceTime(50);
+    await flush();
+
+    // Attempt 2: backoff 1000ms, then times out again — exhausting the budget.
+    timer.advanceTime(1000);
+    await flush();
+    expect(helpers).toHaveLength(3);
+    timer.advanceTime(50);
+    await flush();
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain("screen-capture-helper exited");
+  });
+
+  test("a stop() during the reconnect backoff cancels the cycle", async () => {
+    const timer = new FakeTimer();
+    const { source, helpers, errors } = createReconnectHarness({ timer });
+
+    const started = source.start();
+    await flush();
+    helpers[0].emitFrame(frame(2, 2, 0x11));
+    await started;
+
+    helpers[0].emit("exit", { code: 70, signal: null });
+    await flush();
+
+    // Stop while the first backoff is still pending.
+    await source.stop();
+
+    // Advancing past the backoff must not spin up a replacement helper.
+    timer.advanceTime(5_000);
+    await flush();
+
+    expect(helpers).toHaveLength(1);
+    expect(errors).toEqual([]);
+    expect(helpers[0].stopped).toBe(true);
   });
 
   test("rejects startup when simulator capture reports missing Screen Recording permission", async () => {


### PR DESCRIPTION
Closes [#4768](https://github.com/kaeawc/auto-mobile/issues/4768)

## Summary

Hardens the iOS screen-capture pipeline so a capture failure that happens
*after* frames are flowing recovers instead of leaving a live-but-silent helper
or ending the whole stream on the first blip. Three parts, matching the issue's
acceptance criteria:

1. **Swift fatal-error path — deterministic exit.** On a mid-stream
   `SCStream`/`AVCaptureSession` fatal error the helper now `exit(70)` after
   logging, instead of writing a stderr line and returning (which left
   `RunLoop.main` spinning on a dead stream).
2. **Swift reconfigure — retry once.** `performReconfiguration` retries
   `updateConfiguration` once on failure before warning, so a transient failure
   no longer silently strands the stream at stale dimensions.
3. **TS running-phase reconnect.** `IosH264Source` now attempts a bounded
   reconnect with backoff on a steady-state failure before surfacing `onError`,
   reusing the canonical `Backoff` primitive. A mid-stream frame-size change is
   now an in-place **encoder reconfigure** (restart at the new geometry) rather
   than a fatal error.

## Verify-against-current-main findings

Both prerequisite PRs were read on current `main` and built on, not fought:

- **#4764** (bounded `startCapture()` deadline + no-frames watchdog armed *after*
  capture-started, on a dedicated queue). Left untouched — the watchdog ordering
  and `startCaptureDeadlineSeconds` race are unchanged. The new deterministic
  exit is orthogonal: it fires from the `SCStreamDelegate` fatal callback, which
  is a *post-start* path, so it never races the start deadline.
- **#4771** (`ScreenCaptureHelperTests` target + `CaptureStream` protocol seam
  over `SCStream`). The new Swift tests drive the reconfigure retry entirely
  through that seam's `FakeCaptureStream` — no real Simulator, `SCStream`, or
  Screen Recording permission. Extended the fake with a
  `updateConfigurationTransientFailures` counter to model "fail once, then
  succeed".

## Design decision: exit vs. in-process restart (chose exit)

The issue offered either an in-process stream restart **or** `exit(nonzero)`.
**Chose `exit(70)`** because:

- The TS supervisor (`IosH264Source`) already watches helper `exit` events and
  now *owns* bounded reconnect — it re-launches a fresh helper (and, for a
  Simulator, re-resolves the possibly-changed `CGWindowID`). An in-process Swift
  restart would duplicate that ownership and add a second, harder-to-test
  recovery path around the single-window `SCStream` lifecycle.
- A deterministic non-zero exit is a stronger contract than the previous
  reliance on string-matching an `error:` stderr line to infer death.
- It mirrors the existing precedent where the `startCapture()` deadline path
  already leans on process exit for the parent to reap.
- Code `70` (EX_SOFTWARE) is distinct from `1` (already used for startup
  failures), so log triage can tell "was running, then the stream failed" apart
  from "never started".

**Frame-size change decision:** treated as a bounded **reconfigure**, not a
reconnect or a fatal. ffmpeg's `-s WxH` input size is fixed per process, so a
size change restarts only the encoder (fresh SPS/PPS + IDR on the next frame),
reusing the same guarded-restart machinery as `requestKeyFrame()`. This is
strictly cheaper than a full helper reconnect and keeps the helper streaming
through a rotation.

**Reconnect scope:** only *steady-state* failures (after `start()` fully
resolved) reconnect. A failure during the initial handshake still surfaces, so a
genuine misconfiguration (denied permission, wrong window) is not masked by a
retry loop — matching `ReconnectController`'s "initial attempt is not retried"
philosophy and PR #4413's persistent-session model.

## What changed

**Swift**
- `main.swift`: both fatal-error closures (simulator + device) log then
  `exit(midStreamFatalExitCode)`; added the `midStreamFatalExitCode = 70`
  constant with rationale.
- `SimulatorCaptureSession.swift`: `performReconfiguration` retries
  `updateConfiguration` once; distinct diagnostics for the retry notice vs. the
  ultimate failure. New dimensions are still recorded before the attempt so a
  later size change can still correct.
- `SimulatorCaptureSessionTests.swift`: updated the failure test to expect the
  retry (2 attempts, 2 diagnostics) and added a transient-recovery test
  (fail-once-then-succeed → 1 diagnostic, no ultimate-failure line).

**TypeScript** (`IosH264Source.ts`)
- New `runningReconnectMaxAttempts` (default 2) and `runningReconnectBackoff`
  (default exponential 500ms→2s) options; resolution extracted to a static
  helper to stay under the constructor complexity ratchet.
- `failIfRunning` now routes a steady-state failure into a bounded `runReconnect`
  loop (teardown → backoff via injected `Timer` → re-establish capture), only
  surfacing `onError` on exhaustion (`failNow`). New `"reconnecting"` phase;
  `stop()` cancels an in-flight backoff.
- Frame-size change (both live and drained-queue paths) now calls
  `reconfigureEncoderSize` instead of `failIfRunning`.
- Extracted `establishCapture` so the initial start and the reconnect share one
  path; added a `phaseNow()` reader to keep phase comparisons correct across
  `await` boundaries.
- Tests: rewrote the size-change test to assert an in-place encoder restart with
  no error; added running-phase reconnect tests (success, exhaustion → onError,
  stop-during-backoff cancels) on a fresh-helper-per-attempt + FakeTimer harness.
  The three existing terminal-failure tests opt out via
  `runningReconnectMaxAttempts: 0` so they keep asserting the terminal surface.

## Validation

- **TS:** `bun run typecheck` — no new errors (baseline unchanged). `turbo run
  lint build` — pass. Full `bun test` — **12285 pass, 0 fail**
  (`IosH264Source.test.ts`: 80 pass).
- **Swift:** `./scripts/ios/swift-build.sh` — all packages built.
  `swift build` + `swift test` for `screen-capture` — **55 pass, 0 fail**.
  SwiftLint on `ios/screen-capture` — clean (only a pre-existing
  `CommandLineOptions.swift` complexity warning, untouched here).
- `swift-test.sh` reports one failure in the **unrelated** `XCTestRunner`
  package (`RemindersAddPlanTests testAddReminderPlan` — "Set text timed out",
  the known simulator-dependent Reminders flake #2998/#3592). No screen-capture
  changes touch that package.

## Helper re-cut requirement

The Swift changes ship in the `screen-capture-helper` binary, which is delivered
as a **checksum-pinned GitHub Release asset** — not built at runtime. **This PR
does not attempt the re-cut.** A new signed/notarized helper build with an
updated checksum is required before the deterministic-exit behavior reaches the
released path; until then, `IosH264Source`'s new reconnect still improves the TS
side against the current helper (which today only emits the stderr line).
