### PR TITLE
perf(ios-capture): poll for physical-device readiness instead of fixed 500ms sleep

### DIFF
--- a/ios/screen-capture/Sources/ScreenCaptureCore/DeviceReadinessPolling.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/DeviceReadinessPolling.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Bounded polling for physical-device readiness on capture startup.
+///
+/// After `CMIOSystem.enableScreenCaptureDevices()` a freshly-connected USB iOS
+/// device needs a brief moment to register with AVFoundation before it appears
+/// in a `DiscoverySession`. The helper previously paid an unconditional
+/// `Thread.sleep(forTimeInterval: 0.5)` for this on every physical-device
+/// `--list-devices` / `--capture` start (issue #4737). This polls the same
+/// deadline instead and returns as soon as the device enumerates, falling back
+/// to the deadline if it never appears.
+///
+/// The clock and sleep are injected so the loop can be unit-tested with fakes;
+/// production callers use the wall clock and `Thread.sleep`.
+public enum DeviceReadinessPolling {
+    /// Polls `isReady` on a short interval until it returns `true` or `deadline`
+    /// seconds elapse.
+    ///
+    /// - Parameters:
+    ///   - deadline: overall budget in seconds. Matches the historical fixed
+    ///     sleep so the worst case is unchanged.
+    ///   - interval: gap between probes in seconds.
+    ///   - now: monotonic-ish clock reading in seconds (injected for tests).
+    ///   - sleep: blocks for the given number of seconds (injected for tests).
+    ///   - isReady: probe that reports whether the device has enumerated.
+    /// - Returns: `true` if `isReady` succeeded before the deadline, otherwise
+    ///   `false` (the deadline lapsed).
+    @discardableResult
+    public static func waitUntilReady(
+        deadline: TimeInterval = 0.5,
+        interval: TimeInterval = 0.05,
+        now: () -> TimeInterval = { ProcessInfo.processInfo.systemUptime },
+        sleep: (TimeInterval) -> Void = { Thread.sleep(forTimeInterval: $0) },
+        isReady: () -> Bool
+    ) -> Bool {
+        let start = now()
+        if isReady() {
+            return true
+        }
+        while true {
+            let remaining = deadline - (now() - start)
+            if remaining <= 0 {
+                return false
+            }
+            sleep(min(interval, remaining))
+            if isReady() {
+                return true
+            }
+        }
+    }
+}

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
@@ -132,8 +132,9 @@ case .help:
 
 case .listDevices:
     CMIOSystem.enableScreenCaptureDevices()
-    // Allow a brief moment for the system to register USB devices.
-    Thread.sleep(forTimeInterval: 0.5)
+    // Poll briefly for the system to register USB devices instead of an
+    // unconditional 0.5s sleep; return as soon as one enumerates (issue #4737).
+    DeviceReadinessPolling.waitUntilReady { !DeviceDiscovery.discover().isEmpty }
     let infos = DeviceDiscovery.discover().map(DeviceDiscovery.toInfo)
     writeJSON(DeviceListResponse(devices: infos))
     exit(0)
@@ -253,7 +254,14 @@ case .captureSimulator(let windowID, let fps, let audio):
 
 case .capture(let deviceID):
     CMIOSystem.enableScreenCaptureDevices()
-    Thread.sleep(forTimeInterval: 0.5)
+    // Poll briefly for the requested device to register instead of an
+    // unconditional 0.5s sleep; return as soon as it enumerates (issue #4737).
+    DeviceReadinessPolling.waitUntilReady {
+        if let id = deviceID {
+            return DeviceDiscovery.find(uniqueID: id) != nil
+        }
+        return !DeviceDiscovery.discover().isEmpty
+    }
 
     let resolved: AVCaptureDevice?
     if let id = deviceID {

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/DeviceReadinessPollingTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/DeviceReadinessPollingTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import ScreenCaptureCore
+
+final class DeviceReadinessPollingTests: XCTestCase {
+    /// A fake clock/sleep pair: `sleep` advances the virtual clock so the loop
+    /// terminates deterministically without real wall-clock time.
+    private final class FakeClock {
+        private(set) var current: TimeInterval = 0
+        private(set) var sleepCalls = 0
+
+        func now() -> TimeInterval { current }
+
+        func sleep(_ seconds: TimeInterval) {
+            sleepCalls += 1
+            current += seconds
+        }
+    }
+
+    func testReturnsImmediatelyWhenReadyUpFront() {
+        let clock = FakeClock()
+        let result = DeviceReadinessPolling.waitUntilReady(
+            now: clock.now,
+            sleep: clock.sleep,
+            isReady: { true }
+        )
+        XCTAssertTrue(result)
+        XCTAssertEqual(clock.sleepCalls, 0, "should not sleep when device is already present")
+    }
+
+    func testReturnsTrueAsSoonAsDeviceAppears() {
+        let clock = FakeClock()
+        var probes = 0
+        let result = DeviceReadinessPolling.waitUntilReady(
+            deadline: 0.5,
+            interval: 0.125,
+            now: clock.now,
+            sleep: clock.sleep,
+            isReady: {
+                probes += 1
+                return probes >= 3
+            }
+        )
+        XCTAssertTrue(result)
+        // Ready on the 3rd probe: immediate probe + 2 poll iterations.
+        XCTAssertEqual(clock.sleepCalls, 2)
+    }
+
+    func testReturnsFalseWhenDeadlineLapses() {
+        let clock = FakeClock()
+        // Binary-exact interval so the accumulated clock hits the deadline
+        // precisely (no floating-point drift adding a spurious final probe).
+        let result = DeviceReadinessPolling.waitUntilReady(
+            deadline: 0.5,
+            interval: 0.125,
+            now: clock.now,
+            sleep: clock.sleep,
+            isReady: { false }
+        )
+        XCTAssertFalse(result)
+        // 0.5s budget / 0.125s interval = 4 sleeps before the deadline lapses.
+        XCTAssertEqual(clock.sleepCalls, 4)
+    }
+
+    func testNeverSleepsPastTheDeadline() {
+        let clock = FakeClock()
+        _ = DeviceReadinessPolling.waitUntilReady(
+            deadline: 0.5,
+            interval: 0.2,
+            now: clock.now,
+            sleep: clock.sleep,
+            isReady: { false }
+        )
+        XCTAssertLessThanOrEqual(clock.current, 0.5, "must not overshoot the deadline")
+    }
+}


### PR DESCRIPTION
## Summary

Closes [#4737](https://github.com/kaeawc/auto-mobile/issues/4737).

The Swift `screen-capture-helper` paid an unconditional `Thread.sleep(forTimeInterval: 0.5)` on every physical-device `--list-devices` and `--capture` start, to let USB devices register with AVFoundation after `CMIOSystem.enableScreenCaptureDevices()`. That added a fixed 500 ms to every physical-device stream/list start.

This replaces the fixed sleep with bounded polling that returns as soon as the device enumerates, falling back to the same 0.5 s deadline if it never appears. Startup cost only, not the frame hot path.

**Physical-device only.** The Simulator/ScreenCaptureKit path is unaffected, and the [#4764](https://github.com/kaeawc/auto-mobile/issues/4764) permission-hint watchdog and [#4768](https://github.com/kaeawc/auto-mobile/issues/4768) mid-stream fatal-exit logic are untouched.

## What changed

- New `DeviceReadinessPolling.waitUntilReady(...)` in `ScreenCaptureCore` — a pure helper that polls an `isReady` probe on a short interval (default 50 ms) up to a deadline (default 0.5 s), returning `true` as soon as the probe succeeds and `false` if the deadline lapses. Clock and sleep are injected so the loop is unit-testable with fakes; production callers use the wall clock and `Thread.sleep`.
- `main.swift`:
  - `--list-devices`: `DeviceReadinessPolling.waitUntilReady { !DeviceDiscovery.discover().isEmpty }`
  - `--capture`: polls `DeviceDiscovery.find(uniqueID:) != nil` for a requested device, else `!DeviceDiscovery.discover().isEmpty`.
- `DeviceReadinessPollingTests` — 4 tests (immediate-ready, ready-mid-poll, deadline-lapse count, never-overshoot-deadline) using a fake clock/sleep. Binary-exact intervals avoid floating-point drift.

## Verify-real findings

Confirmed both fixed `Thread.sleep(forTimeInterval: 0.5)` calls still existed on the physical-device paths in current `origin/main` before the change — `main.swift` at the `--list-devices` (`.listDevices`) branch and the device `--capture` (`.capture`) branch (the issue cited ~:124 / ~:227; after [#4764](https://github.com/kaeawc/auto-mobile/issues/4764)/[#4768](https://github.com/kaeawc/auto-mobile/issues/4768) they had moved to :136 and :256). The Simulator `.captureSimulator` branch has no such sleep and was left alone.

## Validation

Ran locally in this worktree (Swift/Xcode toolchain available):

- `./scripts/ios/swift-build.sh` — pass (all packages built).
- `cd ios/screen-capture && swift build` — pass.
- `cd ios/screen-capture && swift test` — pass, 59 tests incl. the 4 new `DeviceReadinessPollingTests`.
- SwiftLint on touched files — clean. (One `line_length` warning at `main.swift:156` is pre-existing on the Simulator permission string, not in this diff, and not a serious violation under the repo config.)
- SwiftFormat not run (pin is broken per repo convention); diff kept minimal.

## Ship note

This is a helper (`screen-capture-helper`) source change. It requires a **checksum-pinned helper re-cut** (release asset) to actually ship, per the repo's iOS runner/helper delivery gate. I did **not** attempt the re-cut. Natural candidate to bundle with another helper change such as [#4727](https://github.com/kaeawc/auto-mobile/issues/4727).
