### PR TITLE
docs(agents): scope GitHub-reference linking to AI prose; exempt docs & comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,12 +4,17 @@ Bun TypeScript MCP server providing Android & iOS device automation capabilities
 
 ## Key Rules
 - TypeScript only (no JavaScript)
-- Always write GitHub issue and pull request references as clickable Markdown links.
-  This governs prose surfaces — issue and PR bodies, review comments, commit
-  messages, and Markdown docs. It does NOT apply to references inside source
-  code comments, where the bare `#NNNN` form is the established convention
-  (625 bare references in `src/`, zero linked). Linking there renders as noise
-  in an editor and would make the touched file the only inconsistent one.
+- Write GitHub issue and pull request references as clickable Markdown links only
+  in AI-authored prose a human reads directly — issue and PR bodies, review
+  comments, commit messages, and assistant chat responses — where a clickable
+  link genuinely aids navigation for the reader. Do NOT require links in
+  checked-in repository content: neither source code comments (bare `#NNNN` is
+  the established convention — 625 references in `src/`, zero linked) nor Markdown
+  documentation files (under `docs/` and elsewhere), where bare `#NNNN` is
+  likewise fine. Forcing explicit links into committed files renders as noise in
+  an editor and makes the touched file the only inconsistent one. Automated
+  reviewers (e.g. Codex) must NOT flag bare `#NNNN` references that appear in
+  source-code comments or Markdown files; treat those as compliant.
 - After implementation changes, run relevant validation commands
 - Write terminal output to `scratch/` when not visible
 - Local validation scripts live under `scripts/` and should almost always be written in bash with shellcheck validation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,17 @@ Node TypeScript MCP server providing Android Debug Bridge (ADB) capabilities thr
 
 ## Key Rules
 - TypeScript only (no JavaScript)
-- Always write GitHub issue and pull request references as clickable Markdown links.
-  This governs prose surfaces — issue and PR bodies, review comments, commit
-  messages, and Markdown docs. It does NOT apply to references inside source
-  code comments, where the bare `#NNNN` form is the established convention
-  (625 bare references in `src/`, zero linked). Linking there renders as noise
-  in an editor and would make the touched file the only inconsistent one.
+- Write GitHub issue and pull request references as clickable Markdown links only
+  in AI-authored prose a human reads directly — issue and PR bodies, review
+  comments, commit messages, and assistant chat responses — where a clickable
+  link genuinely aids navigation for the reader. Do NOT require links in
+  checked-in repository content: neither source code comments (bare `#NNNN` is
+  the established convention — 625 references in `src/`, zero linked) nor Markdown
+  documentation files (under `docs/` and elsewhere), where bare `#NNNN` is
+  likewise fine. Forcing explicit links into committed files renders as noise in
+  an editor and makes the touched file the only inconsistent one. Automated
+  reviewers (e.g. Codex) must NOT flag bare `#NNNN` references that appear in
+  source-code comments or Markdown files; treat those as compliant.
 - After implementation changes, run relevant validation commands
 - Write terminal output to `scratch/` when not visible
 - Local validation scripts live under `scripts/` and should almost always be written in bash with shellcheck validation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,7 +55,14 @@ markdown_extensions:
       smart_enable: all
   - pymdownx.caret
   - pymdownx.inlinehilite
-  - pymdownx.magiclink
+  - pymdownx.magiclink:
+      # Auto-link bare `#NNNN` issue/PR references (and commit hashes) to this
+      # repo in the rendered docs, so committed Markdown can keep the clean bare
+      # form while readers still get clickable links. Pairs with the AGENTS.md /
+      # CLAUDE.md rule that exempts Markdown files from explicit links.
+      repo_url_shorthand: true
+      user: kaeawc
+      repo: auto-mobile
   - pymdownx.smartsymbols
   - pymdownx.superfences:
       custom_fences:


### PR DESCRIPTION
## Why

The `Key Rules` block in `AGENTS.md` / `CLAUDE.md` required issue/PR references to be clickable Markdown links in **Markdown documentation files**. Codex enforces that block on the diff, so bare `#NNNN` references in committed docs get flagged as P1 findings — e.g. on [#4894](https://github.com/kaeawc/auto-mobile/pull/4894) it flagged a bare `#3223` in a docs file.

Clickable links only help a human when they're reading AI-authored prose in a place that navigates (a PR/issue body, a review comment, a chat response). In committed files — source-code comments and Markdown docs alike — bare `#NNNN` is the established convention and forced links read as noise. The rule already exempted source-code comments; this extends the same treatment to Markdown files.

## Change

Rescope the rule in both `AGENTS.md` and `CLAUDE.md` (identical `Key Rules` blocks):

- **Requires links:** AI-authored prose a human reads directly — issue/PR bodies, review comments, commit messages, and assistant chat responses.
- **Exempt (bare `#NNNN` is fine):** source-code comments **and** Markdown documentation files.
- Adds an explicit instruction that automated reviewers (e.g. Codex, which reads `AGENTS.md`) must not flag bare references in comments or Markdown files.

## Notes

- No repo-side lint/CI rule enforces the linking convention — Codex enforces it solely by reading `AGENTS.md`, so updating the guidance is the whole fix.
- No content changes needed elsewhere: bare doc references (like the `#3223` on [#4894](https://github.com/kaeawc/auto-mobile/pull/4894)) become compliant under the revised rule.


## Also: auto-link bare refs in the rendered docs

Enables `pymdownx.magiclink` `repo_url_shorthand` (`user: kaeawc`, `repo: auto-mobile`) in `mkdocs.yml` so bare `#NNNN` references auto-link to the corresponding GitHub issue/PR in the rendered docs site. This delivers the clickability the automated reviewer was after — readers still get links — while committed Markdown keeps the clean bare form.

Verified against the rendered output: `#NNNN` resolves to `issues`/`pull` links, and no bare `@mention` is mis-linked (every `@Test`/`@kaeawc`/npm-scope occurrence is inside a code span, which magiclink skips).
