### PR TITLE
fix: invalidate Android installed apps cache

### DIFF
--- a/src/features/action/InstallApp.ts
+++ b/src/features/action/InstallApp.ts
@@ -193,7 +193,7 @@ export class InstallApp {
       }
     }
 
-    await this.markInstalledAppsCacheStale();
+    await this.markInstalledAppsCacheStale(success);
 
     perf.end();
     const warning = warnings.length > 0 ? warnings.join(" ") : undefined;
@@ -206,7 +206,11 @@ export class InstallApp {
     };
   }
 
-  private async markInstalledAppsCacheStale(): Promise<void> {
+  private async markInstalledAppsCacheStale(installSucceeded: boolean): Promise<void> {
+    if (!installSucceeded) {
+      return;
+    }
+
     try {
       await getDbWriteBarrier().track(() =>
         this.installedAppsRepository.markDeviceStale(this.device.deviceId)

--- a/src/features/action/InstallApp.ts
+++ b/src/features/action/InstallApp.ts
@@ -15,6 +15,8 @@ import { logger } from "../../utils/logger";
 import { resolvePathFromDaemonLaunchWorkingDirectory } from "../../utils/workingDirectory";
 import { PlistClient, type PlistReader } from "../../utils/ios-cmdline-tools/PlistClient";
 import { IOSCtrlProxyClient } from "../observe/ios";
+import { InstalledAppsRepository, type InstalledAppsStore } from "../../db/installedAppsRepository";
+import { getDbWriteBarrier } from "../../db/dbWriteBarrier";
 
 export interface DeviceAppInstaller {
   installApp(deviceUdid: string, artifactPath: string): Promise<void>;
@@ -29,6 +31,7 @@ export class InstallApp {
   private device: BootedDevice;
   private deviceAppInstaller: DeviceAppInstaller;
   private plist: PlistReader;
+  private installedAppsRepository: InstalledAppsStore = new InstalledAppsRepository();
 
   constructor(
     device: BootedDevice,
@@ -190,6 +193,8 @@ export class InstallApp {
       }
     }
 
+    await this.markInstalledAppsCacheStale();
+
     perf.end();
     const warning = warnings.length > 0 ? warnings.join(" ") : undefined;
     return {
@@ -199,6 +204,16 @@ export class InstallApp {
       packageName: packageName,
       warning: warning
     };
+  }
+
+  private async markInstalledAppsCacheStale(): Promise<void> {
+    try {
+      await getDbWriteBarrier().track(() =>
+        this.installedAppsRepository.markDeviceStale(this.device.deviceId)
+      );
+    } catch (error) {
+      logger.warn(`[InstallApp] Failed to invalidate installed-apps cache: ${error}`);
+    }
   }
 
   private static readonly ANDROID_DOWNGRADE_MARKER = "INSTALL_FAILED_VERSION_DOWNGRADE";

--- a/src/features/action/UninstallApp.ts
+++ b/src/features/action/UninstallApp.ts
@@ -10,6 +10,8 @@ import { isIosSimulatorUdid } from "../../utils/ios-cmdline-tools/iosDeviceType"
 import { createGlobalPerformanceTracker } from "../../utils/PerformanceTracker";
 import { logger } from "../../utils/logger";
 import { IOSCtrlProxyClient } from "../observe/ios";
+import { InstalledAppsRepository, type InstalledAppsStore } from "../../db/installedAppsRepository";
+import { getDbWriteBarrier } from "../../db/dbWriteBarrier";
 
 export interface DeviceAppUninstaller {
   uninstallApp(deviceUdid: string, bundleId: string, isSimulator?: boolean): Promise<void>;
@@ -21,18 +23,21 @@ export class UninstallApp {
   private adb: AdbExecutor;
   private simctl: SimCtlClient;
   private deviceAppUninstaller: DeviceAppUninstaller;
+  private installedAppsRepository: InstalledAppsStore;
 
   constructor(
     device: BootedDevice,
     adbFactory: AdbClientFactory = defaultAdbClientFactory,
     simctl: SimCtlClient | null = null,
-    deviceAppUninstaller: DeviceAppUninstaller | null = null
+    deviceAppUninstaller: DeviceAppUninstaller | null = null,
+    installedAppsRepository: InstalledAppsStore = new InstalledAppsRepository()
   ) {
     this.device = device;
     this.adbFactory = adbFactory;
     this.adb = adbFactory.create(device);
     this.simctl = simctl || new SimCtlClient(device);
     this.deviceAppUninstaller = deviceAppUninstaller || new DeviceAppManager();
+    this.installedAppsRepository = installedAppsRepository;
   }
 
   private isSimulator(): boolean {
@@ -190,6 +195,8 @@ export class UninstallApp {
         };
       }
 
+      await this.markInstalledAppsCacheStale();
+
       return {
         success: true,
         packageName,
@@ -205,6 +212,16 @@ export class UninstallApp {
         keepData,
         error: "Error occurred during application uninstallation"
       };
+    }
+  }
+
+  private async markInstalledAppsCacheStale(): Promise<void> {
+    try {
+      await getDbWriteBarrier().track(() =>
+        this.installedAppsRepository.markDeviceStale(this.device.deviceId)
+      );
+    } catch (error) {
+      logger.warn(`[UninstallApp] Failed to invalidate installed-apps cache: ${error}`);
     }
   }
 

--- a/test/features/action/UninstallApp.test.ts
+++ b/test/features/action/UninstallApp.test.ts
@@ -3,6 +3,7 @@ import { UninstallApp, DeviceAppUninstaller } from "../../../src/features/action
 import type { BootedDevice } from "../../../src/models";
 import { FakeSimctl } from "../../fakes/FakeSimctl";
 import { FakeAdbClient } from "../../fakes/FakeAdbClient";
+import { FakeInstalledAppsRepository } from "../../fakes/FakeInstalledAppsRepository";
 
 class FakeDeviceAppUninstaller implements DeviceAppUninstaller {
   public calls: Array<{ deviceUdid: string; bundleId: string; isSimulator?: boolean }> = [];
@@ -212,6 +213,28 @@ describe("UninstallApp (Android)", () => {
     expect(commands).toContain("shell am force-stop --user 0 com.example.app");
     expect(commands).toContain("shell pm uninstall --user 0 com.example.app");
     expect(commands).not.toContain("shell pm uninstall --user 0 -k com.example.app");
+  });
+
+  test("invalidates the installed-apps cache after a successful Android uninstall", async () => {
+    const repository = new FakeInstalledAppsRepository();
+    await repository.upsertInstalledApp(androidDevice.deviceId, 0, "com.cached.app", false, 1);
+    fakeAdb.setForegroundApp({ packageName: "com.example.app", userId: 0 });
+    fakeAdb.setUsers([{ userId: 0, name: "Owner", running: true }]);
+    fakeAdb.setCommandResultSequence("shell pm list packages --user 0", [
+      { stdout: "package:com.example.app\npackage:com.android.settings" },
+      { stdout: "package:com.android.settings" }
+    ]);
+
+    const uninstall = new UninstallApp(
+      androidDevice,
+      fakeAdbFactory(fakeAdb),
+      null,
+      null,
+      repository
+    );
+    await uninstall.execute("com.example.app");
+
+    expect(await repository.getLatestVerification(androidDevice.deviceId)).toBe(0);
   });
 
   test("emits pm uninstall -k when keepData is requested", async () => {

--- a/test/features/observe/ListInstalledApps.test.ts
+++ b/test/features/observe/ListInstalledApps.test.ts
@@ -360,5 +360,41 @@ describe("ListInstalledApps", function() {
       expect(stored.some(row => row.package_name === "com.example.fresh")).toBe(true);
       expect(stored.some(row => row.package_name === "com.stale.app")).toBe(false);
     });
+
+    test("should rebuild immediately after a package mutation invalidates the cache", async function() {
+      const repo = new FakeInstalledAppsRepository();
+      const timer = new FakeTimer();
+      const now = timer.now();
+      await repo.replaceInstalledApps(mockDevice.deviceId, [{
+        device_id: mockDevice.deviceId,
+        user_id: 0,
+        package_name: "com.removed.app",
+        is_system: 0,
+        installed_at: now,
+        last_verified_at: now
+      }]);
+      await repo.markDeviceStale(mockDevice.deviceId);
+
+      fakeAdb.setUsers([{ userId: 0, name: "Owner", flags: 13, running: true }]);
+      fakeAdb.setCommandResponse("shell pm list packages --user 0", {
+        stdout: "package:com.installed.app\n",
+        stderr: ""
+      });
+      fakeAdb.setCommandResponse("shell pm list packages -s --user 0", {
+        stdout: "",
+        stderr: ""
+      });
+
+      const cachedList = new ListInstalledApps(
+        mockDevice,
+        new FakeAdbClientFactory(fakeAdb),
+        null,
+        { cacheEnabled: true, installedAppsRepository: repo, timer }
+      );
+      const result = await cachedList.executeDetailed();
+
+      expect(result.profiles[0].map(app => app.packageName)).toEqual(["com.installed.app"]);
+      expect(fakeAdb.wasCommandExecuted("shell pm list packages --user 0")).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Invalidate Android's persisted installed-app cache after an install or successful uninstall.
- Route the invalidation through the DB write barrier so the next `listApps` call rebuilds from the device instead of serving a stale package set.

## Root cause
The app actions cleared only the 60-second resource cache. The five-minute `installed_apps` database cache remained fresh after package mutations.

## Validation
- `bun test test/features/action/InstallApp.test.ts test/features/action/UninstallApp.test.ts test/features/observe/ListInstalledApps.test.ts`
- `bun run lint`
- `bun run typecheck`

Fixes [#4897](https://github.com/kaeawc/auto-mobile/issues/4897).
