### PR TITLE
fix(ios): match Simulator capture window by exact device name first (#4772)

### DIFF
--- a/src/features/screen-stream/frameProtocol.ts
+++ b/src/features/screen-stream/frameProtocol.ts
@@ -117,6 +117,11 @@ export class FrameDecoder {
       // a synthetic or unusually coalesced stdout chunk carries many frames.
       const available = FRAME_HEADER_SIZE + MAX_RAW_FRAME_BYTES - this.buffer.length;
       if (available === 0) {
+        // Backstop against an unbounded buffer. A corrupt or oversized frame does
+        // NOT reach here: `fieldBoundsError` caps a validated payload at
+        // MAX_RAW_FRAME_BYTES, and `resynchronize` compacts garbage that carries
+        // no validating marker — so every full-buffer state drains, leaving this
+        // throw an infinite-loop guard rather than a real teardown path (#4772).
         if (!this.decodeAvailable(frames, onMalformed, onAudio, onFrame)) {
           throw new Error("FrameDecoder reached its raw-frame buffer limit without a complete frame");
         }

--- a/src/features/webrtc/IosH264Source.ts
+++ b/src/features/webrtc/IosH264Source.ts
@@ -1525,8 +1525,23 @@ async function defaultResolveSimulatorWindowId(
     );
   }
 
-  const deviceName = device.name.toLowerCase();
-  const matches = windows.filter(window => window.title?.toLowerCase().includes(deviceName));
+  // Prefer a window whose title *names* this device exactly, falling back to a
+  // substring match only when nothing matches exactly. A bare substring match
+  // is ambiguous for overlapping device names ("iPhone 15" also occurs in an
+  // "iPhone 15 Pro" title), which would otherwise trip the many-match guard and
+  // fail to capture even though the right window is present. The window list
+  // exposes no UDID, so the title is the only identifier available.
+  const deviceName = device.name.trim().toLowerCase();
+  const titledWindows = windows.filter(
+    (window): window is SimulatorWindowInfo & { title: string } =>
+      typeof window.title === "string" && window.title.trim().length > 0
+  );
+  const exactMatches = titledWindows.filter(window =>
+    simulatorTitleNamesDeviceExactly(window.title, deviceName)
+  );
+  const matches = exactMatches.length > 0
+    ? exactMatches
+    : titledWindows.filter(window => window.title.toLowerCase().includes(deviceName));
   if (matches.length === 1) {
     return matches[0].windowID;
   }
@@ -1538,5 +1553,23 @@ async function defaultResolveSimulatorWindowId(
   throw new ActionableError(
     `Multiple iOS Simulator windows matched ${device.name}; close extras or use a more specific device.`
   );
+}
+
+/**
+ * True when a Simulator window title names exactly this device rather than
+ * merely containing its name. Matches the bare device-name title the Simulator
+ * uses ("iPhone 15 Pro") and a title that appends a runtime segment after a
+ * dash separator ("iPhone 15 Pro — 17.0"), so "iPhone 15" no longer matches an
+ * "iPhone 15 Pro" window. `deviceName` is expected already trimmed + lowercased.
+ */
+function simulatorTitleNamesDeviceExactly(title: string, deviceName: string): boolean {
+  const normalized = title.trim().toLowerCase();
+  if (normalized === deviceName) {
+    return true;
+  }
+  // Simulator titles may append " — <runtime>" (em/en dash or hyphen) after the
+  // device name; compare the leading segment before that separator exactly.
+  const [leadingSegment] = normalized.split(/\s+[—–-]\s+/, 1);
+  return leadingSegment.trim() === deviceName;
 }
 import { spawn as nodeSpawn } from "node:child_process";

--- a/test/features/webrtc/IosH264Source.test.ts
+++ b/test/features/webrtc/IosH264Source.test.ts
@@ -276,6 +276,47 @@ function createReconnectHarness(
   return { source, helpers, encoders, encoderSpawns, chunks, errors };
 }
 
+// A harness that exercises the real default Simulator-window resolver (no
+// `simulatorWindowResolver` override) against a scripted `--list-simulators`
+// window list, capturing the resolved capture target.
+function createResolverHarness(
+  deviceName: string,
+  windows: Array<{ windowID: number; title: string }>
+) {
+  const helper = new FakeFrameCaptureHelper();
+  const encoder = new FakeChildProcess();
+  const helperTargets: CaptureTarget[] = [];
+  const source = new IosH264Source({
+    device: { ...IOS_SIMULATOR, name: deviceName } as BootedDevice,
+    helperPath: FAKE_HELPER_PATH,
+    helperPathExists: fakeHelperPathExists,
+    onData: () => {},
+    createHelper: options => {
+      helperTargets.push(options.target);
+      return helper;
+    },
+    spawner: () => encoder as unknown as ChildProcessWithoutNullStreams,
+    commandRunner: async (command, args) => {
+      if (command === FAKE_HELPER_PATH && args.includes("--list-simulators")) {
+        return {
+          stdout: JSON.stringify({
+            windows: windows.map(window => ({
+              ...window,
+              applicationName: "Simulator",
+              bundleIdentifier: "com.apple.iphonesimulator",
+            })),
+          }),
+          stderr: "",
+          exitCode: 0,
+          signal: null,
+        };
+      }
+      return successfulCommandRunner(command, args);
+    },
+  });
+  return { source, helper, helperTargets };
+}
+
 async function successfulCommandRunner(_command: string, args: string[]) {
   if (args.includes("-encoders")) {
     return {
@@ -1524,6 +1565,56 @@ describe("IosH264Source", () => {
     });
 
     await expect(source.start()).rejects.toThrow(new RegExp(IOS_WEBRTC_FFMPEG_ENV));
+    expect(helper.started).toBe(false);
+  });
+
+  test("prefers an exact device-name window over an overlapping substring window", async () => {
+    // "iPhone 15" is a substring of the "iPhone 15 Pro" title, so a pure
+    // substring match would flag both windows and fail the many-match guard.
+    const { source, helper, helperTargets } = createResolverHarness("iPhone 15", [
+      { windowID: 42, title: "iPhone 15" },
+      { windowID: 99, title: "iPhone 15 Pro" },
+    ]);
+
+    await startWithFrame(source, helper, frame(1, 1, 0x11));
+
+    expect(helperTargets).toEqual([
+      { kind: "simulator", windowID: 42, fps: WEBRTC_IOS_SIMULATOR_FPS_DEFAULT },
+    ]);
+  });
+
+  test("matches the exact device even when the title appends a runtime segment", async () => {
+    const { source, helper, helperTargets } = createResolverHarness("iPhone 15", [
+      { windowID: 7, title: "iPhone 15 — 17.0" },
+      { windowID: 8, title: "iPhone 15 Pro — 17.0" },
+    ]);
+
+    await startWithFrame(source, helper, frame(1, 1, 0x11));
+
+    expect(helperTargets).toEqual([
+      { kind: "simulator", windowID: 7, fps: WEBRTC_IOS_SIMULATOR_FPS_DEFAULT },
+    ]);
+  });
+
+  test("falls back to a substring match when no title names the device exactly", async () => {
+    const { source, helper, helperTargets } = createResolverHarness("iPhone 15", [
+      { windowID: 5, title: "Simulator - iPhone 15 (Booted)" },
+    ]);
+
+    await startWithFrame(source, helper, frame(1, 1, 0x11));
+
+    expect(helperTargets).toEqual([
+      { kind: "simulator", windowID: 5, fps: WEBRTC_IOS_SIMULATOR_FPS_DEFAULT },
+    ]);
+  });
+
+  test("still rejects when two windows name the same device exactly", async () => {
+    const { source, helper } = createResolverHarness("iPhone 15", [
+      { windowID: 1, title: "iPhone 15" },
+      { windowID: 2, title: "iPhone 15" },
+    ]);
+
+    await expect(source.start()).rejects.toThrow(/Multiple iOS Simulator windows matched iPhone 15/);
     expect(helper.started).toBe(false);
   });
 


### PR DESCRIPTION
Closes [#4772](https://github.com/kaeawc/auto-mobile/issues/4772)

## Summary

Two low-priority iOS screen-capture streaming hardening follow-ups. **Item 1 shipped; item 2 split out** with justification below.

### Item 1 — Simulator window matched by exact device name first (shipped)

`defaultResolveSimulatorWindowId` in `src/features/webrtc/IosH264Source.ts` selected the
capture window by a case-insensitive **substring** of `device.name` in the window title.
That is fragile for overlapping device names: capturing `iPhone 15` while an `iPhone 15 Pro`
window is also open matches *both* titles, trips the many-match guard, and fails to capture
even though the right window is present.

Tightened to **exact-match-then-substring fallback**:

- Prefer windows whose title *names* the device exactly — either the bare device name
  (`iPhone 15 Pro`) or the device name followed by a runtime segment after a dash separator
  (`iPhone 15 Pro — 17.0`).
- Fall back to the previous substring match only when no title matches exactly.
- The existing **0 / 1 / many** guards are unchanged, including on the exact-match path
  (two windows naming the same device still reject with the "Multiple ..." error).

The helper's window list (`SimulatorWindowInfo`) exposes only `windowID`, `title`,
`applicationName`, and `bundleIdentifier` — **no UDID** — so the title remains the only
usable identifier; hence the exact-title approach the issue offered as the alternative.

### Item 2 — decoder resync (split into a follow-up)

The issue asks the `FrameDecoder` (`src/features/screen-stream/frameProtocol.ts`) to
resync-and-skip past a single corrupt/oversized frame rather than tearing down capture at
the 32 MiB raw-frame buffer limit.

**This is already implemented in current `main`.** Marker-based resync-and-skip was added by
[#4225](https://github.com/kaeawc/auto-mobile/issues/4225) /
[#4268](https://github.com/kaeawc/auto-mobile/issues/4268) and the raw-frame bound by
[#4412](https://github.com/kaeawc/auto-mobile/issues/4412) — line numbers in the issue
predate that work. `resynchronize()` scans forward to the next `AMF1` marker whose CRC-32
validates and resumes there; `fieldBoundsError` rejects an oversized payload
(`> MAX_RAW_FRAME_BYTES`) as malformed, which routes into the same resync rather than a throw.

I verified empirically that the specific throw the issue cites
(`"FrameDecoder reached its raw-frame buffer limit without a complete frame"`) is
**unreachable through `push()`**: a validated payload is capped below the buffer limit, and a
full buffer of garbage is compacted by `resynchronize()`, so every full-buffer state drains
before the guard fires. Scenarios probed (all "NO THROW"): garbage == limit in one chunk,
garbage > limit, sustained garbage across 40 chunks, a valid max-size header with a
split payload, and a marker-with-bad-checksum stream filling past the limit.

Because the behavioral change the issue wants already exists, and touching that throw would
add code no `push()` input can exercise (so it cannot be covered by a test), I split item 2
out and instead **documented** the throw as an unreachable infinite-loop backstop. If a
separate hardening of that guard is still wanted, it can be tracked as its own follow-up.

## Verify-real findings (against current `main`)

- Item 1 lives at `defaultResolveSimulatorWindowId` (drifted from the issue's cited
  `IosH264Source.ts:1203`); logic confirmed as case-insensitive substring on `device.name`.
- Item 2's resync-and-skip is already present; the cited throw is a defensive, unreachable
  backstop (see empirical probe above).

## Changes

- `src/features/webrtc/IosH264Source.ts` — exact-match-then-substring window resolution +
  `simulatorTitleNamesDeviceExactly` helper (handles the `— <runtime>` suffix form).
- `src/features/screen-stream/frameProtocol.ts` — comment documenting the buffer-limit throw
  as an unreachable backstop (no behavior change).
- `test/features/webrtc/IosH264Source.test.ts` — 4 new tests via a `createResolverHarness`
  that drives the real resolver: exact wins over an overlapping substring window; exact match
  with a runtime segment in the title; substring fallback when nothing matches exactly; and
  the many-match guard still rejects two exact-name windows.

## Validation

- `bun run typecheck` — no new type errors (196 known in baseline).
- `turbo run lint build test` — lint + build cache-clean pass; **12289 pass, 13 skip, 0 fail**
  across 869 files.
