### PR TITLE
fix(video-server): gate video LocalSocket clients on SO_PEERCRED UID (#4728)

### DIFF
--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServerSocketSeam.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServerSocketSeam.kt
@@ -37,6 +37,14 @@ interface VideoClientConnection {
   val outputStream: OutputStream
   val inputStream: InputStream
 
+  /**
+   * The connecting peer's OS-level process UID, read from `SO_PEERCRED`
+   * (`LocalSocket.getPeerCredentials().getUid()`). Abstract-namespace local sockets carry no
+   * filesystem ACL, so this kernel-supplied credential is the only trustworthy peer identity the
+   * writer can gate on before emitting any stream bytes (issue #4728).
+   */
+  val peerUid: Int
+
   fun close()
 }
 
@@ -61,6 +69,9 @@ internal class LocalSocketConnection(private val socket: LocalSocket) : VideoCli
 
   override val inputStream: InputStream
     get() = socket.inputStream
+
+  override val peerUid: Int
+    get() = socket.peerCredentials.uid
 
   override fun close() {
     socket.close()

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
@@ -119,6 +119,18 @@ class VideoStreamWriter(
     /** Sentinel for [writeStartedAtMs] meaning no client write is currently in flight. */
     const val NO_WRITE_IN_PROGRESS = Long.MIN_VALUE
 
+    /**
+     * Peer UIDs allowed to receive the screen stream, checked against `SO_PEERCRED` on every
+     * `accept()` before any byte is written (issue #4728).
+     *
+     * The legitimate host always reaches the abstract socket through `adbd`, which runs as shell
+     * (AID_SHELL, UID 2000); root (AID_ROOT, UID 0) covers `adb root` and eng/rooted builds where
+     * the daemon is relayed as root. Every normal app connects under its own app UID (>= 10000) and
+     * is therefore structurally excluded. Abstract-namespace local sockets have no filesystem
+     * permissions, so this kernel-supplied credential is the only access-control barrier available.
+     */
+    val ALLOWED_PEER_UIDS = setOf(0, 2000)
+
     /** "h264" as big-endian int: 0x68323634 */
     const val CODEC_ID_H264 = VideoStreamProtocol.CODEC_ID_H264
     /** "amux" as big-endian int: 0x616d7578 */
@@ -252,6 +264,24 @@ class VideoStreamWriter(
           }
           return
         }
+
+      // Gate on the peer's SO_PEERCRED UID before touching any shared state or writing a byte
+      // (issue #4728). Rejecting here — ahead of the closeClientLocked() eviction below — means an
+      // unauthorized peer neither displaces the current client nor observes any stream bytes, so it
+      // also avoids worsening the authenticate-before-evict ordering tracked by issue #4730.
+      val peerUid = client.peerUid
+      if (peerUid !in ALLOWED_PEER_UIDS) {
+        println(
+          "VIDEO_CLIENT_REJECTED socket=$socketName uid=$peerUid not in allowed set " +
+            "$ALLOWED_PEER_UIDS; disconnecting"
+        )
+        try {
+          client.close()
+        } catch (_: IOException) {
+          // Best-effort close of a rejected peer; nothing was written, so a failure here is benign.
+        }
+        continue
+      }
 
       val attached =
         synchronized(lock) {

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriterTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriterTest.kt
@@ -167,6 +167,9 @@ class VideoStreamWriterTest {
   private class FakeClientConnection(
     override val outputStream: OutputStream = ByteArrayOutputStream(),
     input: InputStream? = null,
+    // Default to the shell UID (2000) so existing tests exercise the allowed path; the UID-gating
+    // tests below override it with an app-range UID to drive rejection (issue #4728).
+    override val peerUid: Int = 2000,
     private val onClose: () -> Unit = {},
   ) : VideoClientConnection {
     @Volatile var closed = false
@@ -328,6 +331,76 @@ class VideoStreamWriterTest {
       received.await(2, TimeUnit.SECONDS),
     )
     assertEquals(VideoStreamProtocol.COMMAND_REQUEST_KEY_FRAME, lastCommand.get())
+  }
+
+  // --- peer-UID gating (SO_PEERCRED, issue #4728) ---------------------------------------------
+
+  @Test
+  fun disallowedPeerUidReceivesNoBytesAndIsDisconnected() {
+    var now = 1_000L
+    val output = ScriptedOutputStream()
+    // A normal app connects under its own app-range UID (>= 10000); it must be refused.
+    val connection = FakeClientConnection(outputStream = output, peerUid = 10123)
+    val attachCount = AtomicInteger()
+    val subject = writer({ now }, FakeServerSocket(listOf({ connection })))
+
+    subject.bindServerSocket()
+    subject.acceptClients { attachCount.incrementAndGet() }
+
+    assertEquals("a disallowed peer must never be reported as connected", 0, attachCount.get())
+    assertEquals("a disallowed peer must receive no stream bytes", 0, output.writeCount)
+    assertTrue("a disallowed peer must be disconnected", connection.closed)
+  }
+
+  @Test
+  fun allowedShellPeerUidAttachesAndReceivesStreamHeader() {
+    var now = 1_000L
+    val output = ScriptedOutputStream()
+    val connection = FakeClientConnection(outputStream = output, peerUid = 2000)
+    val attachCount = AtomicInteger()
+    val subject = writer({ now }, FakeServerSocket(listOf({ connection })))
+
+    subject.bindServerSocket()
+    subject.acceptClients { attachCount.incrementAndGet() }
+
+    assertEquals("an allowed shell peer must attach", 1, attachCount.get())
+    assertTrue("an allowed peer must receive the stream header", output.writeCount > 0)
+    assertFalse("an allowed peer stays connected", connection.closed)
+  }
+
+  @Test
+  fun allowedRootPeerUidAttaches() {
+    var now = 1_000L
+    val connection = FakeClientConnection(peerUid = 0)
+    val attachCount = AtomicInteger()
+    val subject = writer({ now }, FakeServerSocket(listOf({ connection })))
+
+    subject.bindServerSocket()
+    subject.acceptClients { attachCount.incrementAndGet() }
+
+    assertEquals("an allowed root peer must attach", 1, attachCount.get())
+    assertFalse(connection.closed)
+    subject.stop()
+  }
+
+  @Test
+  fun disallowedPeerDoesNotDisplaceTheCurrentAllowedClient() {
+    var now = 1_000L
+    // An allowed client attaches first; a disallowed peer then connects. Rejecting the intruder
+    // ahead of the eviction step must leave the legitimate client attached (does not worsen the
+    // authenticate-before-evict ordering of issue #4730).
+    val allowed = FakeClientConnection(peerUid = 2000)
+    val intruder = FakeClientConnection(peerUid = 10222)
+    val attachCount = AtomicInteger()
+    val subject = writer({ now }, FakeServerSocket(listOf({ allowed }, { intruder })))
+
+    subject.bindServerSocket()
+    subject.acceptClients { attachCount.incrementAndGet() }
+
+    assertEquals("only the allowed client attaches", 1, attachCount.get())
+    assertFalse("the allowed client must not be displaced by a rejected peer", allowed.closed)
+    assertTrue("the intruder must be disconnected", intruder.closed)
+    subject.stop()
   }
 
   // --- writePacket success/failure contract (pinning the decision) ----------------------------


### PR DESCRIPTION
Closes [#4728](https://github.com/kaeawc/auto-mobile/issues/4728)

## Summary

The Android video server serves the encoded screen (and optional audio) stream over an abstract-namespace `LocalServerSocket`, which carries **no filesystem permissions and no access control**. While a capture session was live, any process of any UID on the device could `connect()` and immediately receive the full H.264 screen mirror (and, with `--audio`, playback audio). The socket name is not secret — abstract socket names are world-readable in `/proc/net/unix` — so the name was the only, ineffective, barrier.

This change gates `acceptClients()` on the connecting peer's OS-level `SO_PEERCRED` UID and rejects any peer outside an allowed set **before writing a single stream byte**, disconnecting and logging the offending UID.

## Verify-against-current-main findings

The issue was written against an older `VideoStreamWriter.kt` (it cited `LocalServerSocket(socketName)` at line 100 and a raw `acceptClients()` that touched `LocalSocket` directly). The file has since changed substantially, so I re-analysed current `main` before implementing:

- **#4822 socket seam** — `LocalSocket`/`LocalServerSocket` are no longer touched directly by the writer. Accept/read/write go through `VideoServerSocketFactory` → `VideoServerSocket` → `VideoClientConnection` (`VideoServerSocketSeam.kt`). Tests inject a fake factory. I implemented the UID gate **through this seam** rather than reaching around it.
- **#4749 writer thread + `FrameHandoff`** — encode is decoupled from transport via a dedicated `video-transport-writer` thread draining a drop-oldest handoff; `acceptClients()` still runs on the `video-client-acceptor` thread and is what accepts + attaches clients.
- **#4808 single framed write / #4743 buffered writes** — packets are framed into one buffer per write (`VideoStreamProtocol.framedPacket`).
- **#4784 write-stall watchdog + lock-free expiry** — `ReconnectWindow` uses volatile monotonic state polled off the write lock; a `checkWriteStall()` watchdog force-closes a wedged half-open transport.

In current `main`, `acceptClients()` accepts a `VideoClientConnection`, then inside `synchronized(lock)` calls `closeClientLocked()` (evicts the prior client), assigns `clientSocket`, and writes the stream header + replays cached video. There was no peer check anywhere in the module.

## What changed

- **`VideoServerSocketSeam.kt`** — added `val peerUid: Int` to the `VideoClientConnection` interface, implemented in the production `LocalSocketConnection` as `socket.peerCredentials.uid` (`SO_PEERCRED`). Keeps the seam the single boundary over the framework socket and keeps the gate fake-testable.
- **`VideoStreamWriter.kt`** — added `ALLOWED_PEER_UIDS = setOf(0, 2000)` and, in `acceptClients()`, a UID check immediately after `accept()` and **before** the `synchronized(lock)` block. A disallowed peer is logged (`VIDEO_CLIENT_REJECTED … uid=…`), closed, and skipped via `continue`, so it never reaches `closeClientLocked()` or any write.
- **`VideoStreamWriterTest.kt`** — added `peerUid` (default `2000`) to the test fake and four tests driving `acceptClients` synchronously through the injected factory.

No wire-protocol change — this is an OS-level `SO_PEERCRED` check.

## Allowed-UID justification

`ALLOWED_PEER_UIDS = { 0, 2000 }`:

- **2000 (AID_SHELL)** — the legitimate host always reaches the abstract socket through `adbd`, which runs as shell. This is the normal path (`adb forward … localabstract:<name>`).
- **0 (AID_ROOT)** — covers `adb root` and eng/rooted builds where the daemon is relayed as root.

Every normal app connects under its own app UID (>= 10000) and is therefore structurally excluded. Because abstract-namespace sockets have no filesystem ACL, this kernel-supplied credential is the only access-control barrier available.

## Ordering note (#4730)

The gate runs **before** the `closeClientLocked()` eviction, so a rejected peer neither displaces the current client nor observes any bytes. This does not implement the separate authenticate-before-evict fix (#4730) but is deliberately placed so it does not worsen it — a test pins that a rejected intruder does not displace the attached allowed client.

## Validation

- `./gradlew :video-server:test --tests dev.jasonpearson.automobile.video.VideoStreamWriterTest` — **BUILD SUCCESSFUL** (JDK 21, worktree `android/local.properties` with `sdk.dir`).
- `scripts/ktfmt/validate_ktfmt.sh` on the three touched files — **All Kotlin source files are properly formatted.**

New tests: `disallowedPeerUidReceivesNoBytesAndIsDisconnected`, `allowedShellPeerUidAttachesAndReceivesStreamHeader`, `allowedRootPeerUidAttaches`, `disallowedPeerDoesNotDisplaceTheCurrentAllowedClient`.
