### PR TITLE
feat(video-server): decouple session token from socket name and require a token handshake

### DIFF
--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoHandshake.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoHandshake.kt
@@ -1,0 +1,110 @@
+package dev.jasonpearson.automobile.video
+
+import java.security.MessageDigest
+
+/**
+ * Pre-stream token handshake for the video-server LocalSocket (issue #4729).
+ *
+ * The abstract socket name no longer embeds the session token (the host now names the socket with
+ * an opaque random id), which closes the `/proc/net/unix` disclosure. To retain a per-connection
+ * secret the client must present the session token as the very first bytes after connect, before
+ * the server emits any stream header or frame. The server reads it with a bounded deadline,
+ * compares in constant time, and on any mismatch/timeout closes the connection with zero bytes
+ * written.
+ *
+ * ## Wire frame (client -> server), sent immediately after connect
+ *
+ * ```
+ * offset 0  MAGIC      4 bytes  0x41 0x56 0x4D 0x48  ("AVMH")
+ * offset 4  VERSION    1 byte   protocol version (currently 1)
+ * offset 5  TOKEN_LEN  1 byte   token length N, 8..80 (uint8)
+ * offset 6  TOKEN      N bytes  ASCII session token (matches SAFE_TOKEN)
+ * ```
+ *
+ * Total = [PREFIX_SIZE] + N bytes. The token is length-prefixed rather than fixed-length so the
+ * frame stays compact and self-delimiting.
+ *
+ * ## Version negotiation
+ * The primary, out-of-band negotiation happens BEFORE connect: the server advertises
+ * `proto=<version>` on its `VIDEO_SESSION_READY` stdout line. A handshake-aware host reads that
+ * field and only sends the frame when the device advertises a version it understands; a host
+ * talking to a pre-handshake device (no `proto=`) skips the frame and streams without it
+ * (defense-in-depth degrades, streaming does not hard-break). The in-band MAGIC + VERSION bytes are
+ * the secondary, defensive layer: they let the server distinguish an unsupported-version or
+ * malformed handshake from a legitimate one and log an actionable reason instead of silently
+ * hanging. A pre-handshake host against a handshake-requiring device sends no frame and is rejected
+ * on the bounded timeout — its existing bounded reconnect budget then falls back to screenrecord
+ * rather than looping forever.
+ */
+object VideoHandshake {
+  /** Current handshake protocol version advertised via `proto=` and encoded in the frame. */
+  const val PROTOCOL_VERSION = 1
+
+  /** "AVMH": AutoMobile Video Media Handshake. */
+  val MAGIC = byteArrayOf(0x41, 0x56, 0x4D, 0x48)
+
+  /** Fixed prefix size: MAGIC(4) + VERSION(1) + TOKEN_LEN(1). */
+  const val PREFIX_SIZE = 6
+
+  const val MIN_TOKEN_LENGTH = 8
+  const val MAX_TOKEN_LENGTH = 80
+
+  /** Mirrors `VideoSessionArguments.SAFE_TOKEN`; the on-wire token must satisfy the same shape. */
+  private val SAFE_TOKEN = Regex("[A-Za-z0-9-]{8,80}")
+
+  sealed interface Result {
+    /** A well-formed handshake carrying the expected token arrived. */
+    object Accepted : Result
+
+    /** The handshake was absent, malformed, version-skewed, or carried the wrong token. */
+    data class Rejected(val reason: String) : Result
+  }
+
+  /**
+   * Read and validate the client handshake from [connection] within [timeoutMs] total, comparing
+   * the presented token against [expectedToken] in constant time. Returns [Result.Accepted] only
+   * for a well-formed, correctly-versioned frame carrying the expected token; otherwise
+   * [Result.Rejected] with a short machine-parseable reason. Never writes to [connection].
+   *
+   * [nowMs] supplies the monotonic clock for splitting the deadline across the prefix and token
+   * reads so tests can drive it deterministically; the seam's [VideoClientConnection.readFully]
+   * enforces the per-read timeout.
+   */
+  fun read(
+    connection: VideoClientConnection,
+    expectedToken: String,
+    timeoutMs: Long,
+    nowMs: () -> Long = System::currentTimeMillis,
+  ): Result {
+    val deadline = nowMs() + timeoutMs
+    val prefix =
+      connection.readFully(PREFIX_SIZE, timeoutMs) ?: return Result.Rejected("timeout-or-eof")
+    if (!prefix.copyOfRange(0, MAGIC.size).contentEquals(MAGIC)) {
+      return Result.Rejected("bad-magic")
+    }
+    val version = prefix[4].toInt() and 0xFF
+    if (version != PROTOCOL_VERSION) {
+      return Result.Rejected("unsupported-version=$version")
+    }
+    val tokenLength = prefix[5].toInt() and 0xFF
+    if (tokenLength < MIN_TOKEN_LENGTH || tokenLength > MAX_TOKEN_LENGTH) {
+      return Result.Rejected("bad-token-length=$tokenLength")
+    }
+    val remainingMs = (deadline - nowMs()).coerceAtLeast(1)
+    val tokenBytes =
+      connection.readFully(tokenLength, remainingMs)
+        ?: return Result.Rejected("token-timeout-or-eof")
+    val token = String(tokenBytes, Charsets.US_ASCII)
+    if (!SAFE_TOKEN.matches(token)) {
+      return Result.Rejected("unsafe-token")
+    }
+    // MessageDigest.isEqual is the JDK's constant-time byte-array compare: it does not
+    // short-circuit
+    // on the first differing byte (nor, on JDK 17+, leak via a length branch), so a wrong token is
+    // not recoverable one byte at a time from response timing.
+    if (!MessageDigest.isEqual(expectedToken.toByteArray(Charsets.US_ASCII), tokenBytes)) {
+      return Result.Rejected("token-mismatch")
+    }
+    return Result.Accepted
+  }
+}

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
@@ -252,7 +252,14 @@ object VideoServer {
 
     // The writer keeps the encoder alive while its LocalSocket client reconnects, replays cached
     // decoder state, and requests a new IDR at attach.
-    streamWriter = VideoStreamWriter(session.socketName, width, height, audioEnabled)
+    streamWriter =
+      VideoStreamWriter(
+        session.socketName,
+        width,
+        height,
+        audioEnabled,
+        expectedToken = session.token,
+      )
     streamWriter!!.startCommandReader { command ->
       if (command == VideoStreamProtocol.COMMAND_REQUEST_KEY_FRAME) {
         encoder?.requestKeyFrame()
@@ -270,8 +277,11 @@ object VideoServer {
       throw error
     }
     session.token?.let {
+      // `proto=` advertises the pre-stream token-handshake version so a handshake-aware host can
+      // negotiate before connecting (issue #4729); a pre-handshake host simply ignores the field.
       println(
-        "VIDEO_SESSION_READY token=$it pid=${android.os.Process.myPid()} socket=${session.socketName}"
+        "VIDEO_SESSION_READY token=$it pid=${android.os.Process.myPid()} " +
+          "socket=${session.socketName} proto=${VideoHandshake.PROTOCOL_VERSION}"
       )
     }
 

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServerSocketSeam.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServerSocketSeam.kt
@@ -2,8 +2,10 @@ package dev.jasonpearson.automobile.video
 
 import android.net.LocalServerSocket
 import android.net.LocalSocket
+import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
+import java.net.SocketTimeoutException
 
 /**
  * Narrow seam over `android.net.LocalServerSocket` / `android.net.LocalSocket` so
@@ -45,6 +47,17 @@ interface VideoClientConnection {
    */
   val peerUid: Int
 
+  /**
+   * Read exactly [count] bytes from the peer into a fresh array within [timeoutMs] total elapsed
+   * time, returning `null` on timeout, EOF, or I/O error. This is the only inbound-read capability
+   * the writer needs before the stream starts: it reads the pre-stream token handshake
+   * (issue #4729) with a bounded deadline so a silent connector cannot hold the accept slot open.
+   * Kept on the seam (rather than exposing raw blocking-read + `SO_TIMEOUT` plumbing) so the
+   * handshake is driven by fakes in unit tests. The command-channel reader continues to use
+   * [inputStream] directly once the stream is live.
+   */
+  fun readFully(count: Int, timeoutMs: Long): ByteArray?
+
   fun close()
 }
 
@@ -72,6 +85,46 @@ internal class LocalSocketConnection(private val socket: LocalSocket) : VideoCli
 
   override val peerUid: Int
     get() = socket.peerCredentials.uid
+
+  /**
+   * Bounded, total-deadline blocking read of exactly [count] bytes. `SO_TIMEOUT` bounds each
+   * individual blocking read; the deadline loop re-arms it to the remaining budget so the whole
+   * read can never exceed [timeoutMs], even across a partial-read boundary. Returns `null` on
+   * timeout, EOF (a peer that connected but sent a short/absent handshake), or any I/O error — the
+   * caller treats every `null` as a rejected handshake and closes without emitting stream bytes.
+   */
+  override fun readFully(count: Int, timeoutMs: Long): ByteArray? {
+    if (count <= 0) return ByteArray(0)
+    val deadline = System.nanoTime() + timeoutMs * 1_000_000L
+    val buffer = ByteArray(count)
+    var read = 0
+    val input = socket.inputStream
+    val previousTimeout = socket.soTimeout
+    try {
+      while (read < count) {
+        val remainingMs = (deadline - System.nanoTime()) / 1_000_000L
+        if (remainingMs <= 0) return null
+        socket.soTimeout = remainingMs.coerceAtMost(Int.MAX_VALUE.toLong()).toInt().coerceAtLeast(1)
+        val n =
+          try {
+            input.read(buffer, read, count - read)
+          } catch (_: SocketTimeoutException) {
+            return null
+          }
+        if (n < 0) return null
+        read += n
+      }
+      return buffer
+    } catch (_: IOException) {
+      return null
+    } finally {
+      try {
+        socket.soTimeout = previousTimeout
+      } catch (_: IOException) {
+        // Restoring the prior timeout is best-effort; the connection is about to stream or close.
+      }
+    }
+  }
 
   override fun close() {
     socket.close()

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
@@ -60,6 +60,10 @@ class VideoStreamWriter(
   private val width: Int,
   private val height: Int,
   private val audioEnabled: Boolean = false,
+  // The session token the connecting client must present in the pre-stream handshake (issue #4729).
+  // Null disables the handshake (a token-less/legacy launch), preserving prior behavior; the host
+  // always launches with a token, so production always requires the handshake.
+  private val expectedToken: String? = null,
   private val nowMs: () -> Long = { SystemClock.elapsedRealtime() },
   private val socketFactory: VideoServerSocketFactory = LocalServerSocketFactory,
 ) {
@@ -118,6 +122,14 @@ class VideoStreamWriter(
 
     /** Sentinel for [writeStartedAtMs] meaning no client write is currently in flight. */
     const val NO_WRITE_IN_PROGRESS = Long.MIN_VALUE
+
+    /**
+     * Upper bound on the pre-stream token handshake read (issue #4729). A silent connector that
+     * holds the accept slot without presenting the token is force-rejected after this deadline so
+     * it cannot wedge the acceptor. Kept short: the legitimate host writes the handshake
+     * immediately on connect.
+     */
+    const val HANDSHAKE_READ_TIMEOUT_MS = 2_000L
 
     /**
      * Peer UIDs allowed to receive the screen stream, checked against `SO_PEERCRED` on every
@@ -283,6 +295,21 @@ class VideoStreamWriter(
         continue
       }
 
+      // Require the token handshake before displacing the current client or writing a byte (issue
+      // #4729). Reading happens off `lock` (it is a bounded blocking read) and ahead of the
+      // closeClientLocked() eviction, so a wrong/absent token neither evicts the legitimate client
+      // nor
+      // leaks any stream bytes — the same authenticate-before-evict ordering the UID gate above
+      // keeps.
+      if (!handshakeAccepted(client)) {
+        try {
+          client.close()
+        } catch (_: IOException) {
+          // Best-effort close of a rejected peer; nothing was written, so a failure here is benign.
+        }
+        continue
+      }
+
       val attached =
         synchronized(lock) {
           closeClientLocked()
@@ -307,6 +334,27 @@ class VideoStreamWriter(
       println("Client connected, writing stream header")
       startCommandReaderFor(client)
       onClientConnected()
+    }
+  }
+
+  /**
+   * Validate the client's pre-stream token handshake. Returns true when no token is configured (the
+   * handshake is disabled) or the client presented a well-formed frame carrying the expected token;
+   * false on any mismatch/timeout, logging a machine-parseable reason. Extracted so [acceptClients]
+   * stays under the complexity ratchet and the accept path reads as gate -> gate -> attach.
+   */
+  internal fun handshakeAccepted(client: VideoClientConnection): Boolean {
+    val token = expectedToken ?: return true
+    return when (
+      val result = VideoHandshake.read(client, token, HANDSHAKE_READ_TIMEOUT_MS, nowMs)
+    ) {
+      is VideoHandshake.Result.Accepted -> true
+      is VideoHandshake.Result.Rejected -> {
+        println(
+          "VIDEO_CLIENT_HANDSHAKE_REJECTED socket=$socketName reason=${result.reason}; disconnecting"
+        )
+        false
+      }
     }
   }
 

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoHandshakeTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoHandshakeTest.kt
@@ -1,0 +1,109 @@
+package dev.jasonpearson.automobile.video
+
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VideoHandshakeTest {
+  /**
+   * Serves a scripted handshake to [VideoHandshake.read] via [readFully]; a null [bytes] models a
+   * silent connector so every read returns null. Never used for output.
+   */
+  private class FakeConnection(private val bytes: ByteArray?) : VideoClientConnection {
+    override val outputStream: OutputStream = ByteArrayOutputStream()
+    override val inputStream: InputStream = InputStream.nullInputStream()
+    override val peerUid: Int = 2000
+    private var offset = 0
+
+    override fun readFully(count: Int, timeoutMs: Long): ByteArray? {
+      val source = bytes ?: return null
+      if (offset + count > source.size) return null
+      val slice = source.copyOfRange(offset, offset + count)
+      offset += count
+      return slice
+    }
+
+    override fun close() {}
+  }
+
+  private fun frame(
+    token: String,
+    version: Int = VideoHandshake.PROTOCOL_VERSION,
+    magic: ByteArray = VideoHandshake.MAGIC,
+    tokenLengthOverride: Int? = null,
+  ): ByteArray {
+    val tokenBytes = token.toByteArray(Charsets.US_ASCII)
+    val out = ByteArrayOutputStream()
+    out.write(magic)
+    out.write(version)
+    out.write(tokenLengthOverride ?: tokenBytes.size)
+    out.write(tokenBytes)
+    return out.toByteArray()
+  }
+
+  private fun read(
+    bytes: ByteArray?,
+    expectedToken: String = "session-0001",
+  ): VideoHandshake.Result =
+    VideoHandshake.read(FakeConnection(bytes), expectedToken, timeoutMs = 2_000L, nowMs = { 0L })
+
+  @Test
+  fun acceptsAWellFormedFrameCarryingTheExpectedToken() {
+    assertEquals(VideoHandshake.Result.Accepted, read(frame("session-0001")))
+  }
+
+  @Test
+  fun rejectsAWrongToken() {
+    val result = read(frame("session-9999"))
+    assertTrue(result is VideoHandshake.Result.Rejected)
+    assertEquals("token-mismatch", (result as VideoHandshake.Result.Rejected).reason)
+  }
+
+  @Test
+  fun rejectsASilentConnector() {
+    val result = read(null)
+    assertTrue(result is VideoHandshake.Result.Rejected)
+    assertEquals("timeout-or-eof", (result as VideoHandshake.Result.Rejected).reason)
+  }
+
+  @Test
+  fun rejectsBadMagic() {
+    val result = read(frame("session-0001", magic = byteArrayOf(0, 0, 0, 0)))
+    assertTrue(result is VideoHandshake.Result.Rejected)
+    assertEquals("bad-magic", (result as VideoHandshake.Result.Rejected).reason)
+  }
+
+  @Test
+  fun rejectsAnUnsupportedVersion() {
+    val result = read(frame("session-0001", version = 99))
+    assertTrue(result is VideoHandshake.Result.Rejected)
+    assertEquals("unsupported-version=99", (result as VideoHandshake.Result.Rejected).reason)
+  }
+
+  @Test
+  fun rejectsAnOutOfRangeTokenLength() {
+    // A declared length below the minimum is rejected before any token read.
+    val result = read(frame("short", tokenLengthOverride = 5))
+    assertTrue(result is VideoHandshake.Result.Rejected)
+    assertEquals("bad-token-length=5", (result as VideoHandshake.Result.Rejected).reason)
+  }
+
+  @Test
+  fun rejectsATruncatedTokenBody() {
+    // Prefix declares a longer token than the frame carries: the token read runs short and rejects.
+    val result = read(frame("session-0001", tokenLengthOverride = 40))
+    assertTrue(result is VideoHandshake.Result.Rejected)
+    assertEquals("token-timeout-or-eof", (result as VideoHandshake.Result.Rejected).reason)
+  }
+
+  @Test
+  fun rejectsAnUnsafeTokenShape() {
+    // 8 bytes so the length gate passes, but the space fails SAFE_TOKEN's character class.
+    val result = read(frame("bad tok!", tokenLengthOverride = 8), expectedToken = "bad tok!")
+    assertTrue(result is VideoHandshake.Result.Rejected)
+    assertEquals("unsafe-token", (result as VideoHandshake.Result.Rejected).reason)
+  }
+}

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriterTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriterTest.kt
@@ -170,11 +170,28 @@ class VideoStreamWriterTest {
     // Default to the shell UID (2000) so existing tests exercise the allowed path; the UID-gating
     // tests below override it with an app-range UID to drive rejection (issue #4728).
     override val peerUid: Int = 2000,
+    // Scripted response for the pre-stream handshake read (issue #4729). Null means the peer sends
+    // no
+    // bytes, so every readFully returns null (a silent connector -> rejected on timeout/EOF); a
+    // short
+    // array also returns null once exhausted.
+    private val handshake: ByteArray? = null,
     private val onClose: () -> Unit = {},
   ) : VideoClientConnection {
     @Volatile var closed = false
     private val closedLatch = CountDownLatch(1)
+    private var handshakeOffset = 0
     override val inputStream: InputStream = input ?: BlockingUntilClosedInputStream(closedLatch)
+
+    override fun readFully(count: Int, timeoutMs: Long): ByteArray? {
+      val source = handshake ?: return null
+      if (handshakeOffset + count > source.size) {
+        return null
+      }
+      val slice = source.copyOfRange(handshakeOffset, handshakeOffset + count)
+      handshakeOffset += count
+      return slice
+    }
 
     override fun close() {
       if (!closed) {
@@ -208,15 +225,112 @@ class VideoStreamWriterTest {
     now: () -> Long,
     serverSocket: VideoServerSocket,
     audioEnabled: Boolean = false,
+    expectedToken: String? = null,
   ): VideoStreamWriter =
     VideoStreamWriter(
       socketName = "test_socket",
       width = 480,
       height = 800,
       audioEnabled = audioEnabled,
+      expectedToken = expectedToken,
       nowMs = now,
       socketFactory = { serverSocket },
     )
+
+  private fun handshakeFrame(
+    token: String,
+    version: Int = VideoHandshake.PROTOCOL_VERSION,
+  ): ByteArray {
+    val tokenBytes = token.toByteArray(Charsets.US_ASCII)
+    val out = ByteArrayOutputStream()
+    out.write(VideoHandshake.MAGIC)
+    out.write(version)
+    out.write(tokenBytes.size)
+    out.write(tokenBytes)
+    return out.toByteArray()
+  }
+
+  // --- token handshake (issue #4729) ----------------------------------------------------------
+
+  @Test
+  fun validHandshakeAttachesAndReceivesStreamHeader() {
+    var now = 1_000L
+    val token = "session-0001"
+    val output = ScriptedOutputStream()
+    val connection = FakeClientConnection(outputStream = output, handshake = handshakeFrame(token))
+    val attachCount = AtomicInteger()
+    val subject = writer({ now }, FakeServerSocket(listOf({ connection })), expectedToken = token)
+
+    subject.bindServerSocket()
+    subject.acceptClients { attachCount.incrementAndGet() }
+
+    assertEquals("a valid handshake must attach", 1, attachCount.get())
+    assertTrue("an authenticated client must receive the stream header", output.writeCount > 0)
+    assertFalse("an authenticated client stays connected", connection.closed)
+  }
+
+  @Test
+  fun wrongTokenReceivesNoBytesAndIsDisconnected() {
+    var now = 1_000L
+    val output = ScriptedOutputStream()
+    // A well-formed frame carrying the wrong token must be rejected with zero stream bytes.
+    val connection =
+      FakeClientConnection(outputStream = output, handshake = handshakeFrame("session-9999"))
+    val attachCount = AtomicInteger()
+    val subject =
+      writer({ now }, FakeServerSocket(listOf({ connection })), expectedToken = "session-0001")
+
+    subject.bindServerSocket()
+    subject.acceptClients { attachCount.incrementAndGet() }
+
+    assertEquals("a wrong-token peer must never attach", 0, attachCount.get())
+    assertEquals("a wrong-token peer must receive no stream bytes", 0, output.writeCount)
+    assertTrue("a wrong-token peer must be disconnected", connection.closed)
+  }
+
+  @Test
+  fun absentHandshakeWithinTimeoutReceivesNoBytesAndIsDisconnected() {
+    var now = 1_000L
+    val output = ScriptedOutputStream()
+    // handshake = null: the peer presents no bytes, so the bounded read returns null (timeout/EOF).
+    val connection = FakeClientConnection(outputStream = output, handshake = null)
+    val attachCount = AtomicInteger()
+    val subject =
+      writer({ now }, FakeServerSocket(listOf({ connection })), expectedToken = "session-0001")
+
+    subject.bindServerSocket()
+    subject.acceptClients { attachCount.incrementAndGet() }
+
+    assertEquals("a silent connector must never attach", 0, attachCount.get())
+    assertEquals("a silent connector must receive no stream bytes", 0, output.writeCount)
+    assertTrue("a silent connector must be disconnected", connection.closed)
+  }
+
+  @Test
+  fun handshakeRejectionDoesNotDisplaceTheCurrentAuthenticatedClient() {
+    var now = 1_000L
+    val token = "session-0001"
+    val authenticated = FakeClientConnection(handshake = handshakeFrame(token))
+    val intruder = FakeClientConnection(handshake = handshakeFrame("session-9999"))
+    val attachCount = AtomicInteger()
+    val subject =
+      writer(
+        { now },
+        FakeServerSocket(listOf({ authenticated }, { intruder })),
+        expectedToken = token,
+      )
+
+    subject.bindServerSocket()
+    subject.acceptClients { attachCount.incrementAndGet() }
+
+    assertEquals("only the authenticated client attaches", 1, attachCount.get())
+    assertFalse(
+      "the authenticated client must not be displaced by a bad handshake",
+      authenticated.closed,
+    )
+    assertTrue("the intruder must be disconnected", intruder.closed)
+    subject.stop()
+  }
 
   @Test
   fun writeFailureDetachesClientButKeepsEncoderAlive() {

--- a/src/features/webrtc/PersistentEncoderH264Source.ts
+++ b/src/features/webrtc/PersistentEncoderH264Source.ts
@@ -1,7 +1,7 @@
 import { connect as netConnect } from "node:net";
 import { ActionableError, type BootedDevice } from "../../models";
 import { logger } from "../../utils/logger";
-import { defaultIdGenerator } from "../../utils/IdGenerator";
+import { defaultIdGenerator, type IdGenerator } from "../../utils/IdGenerator";
 import { shellQuote } from "../../utils/shellQuote";
 import { defaultTimer, type Timer } from "../../utils/SystemTimer";
 import {
@@ -48,7 +48,11 @@ const STALE_LEASE_WALL_CLOCK_MS = 5 * 60_000;
  * `*.json.tmp` may be mid-rename by a live server; younger files are left alone.
  */
 const STALE_LEASE_FILE_SWEEP_MS = 5 * 60_000;
-const SESSION_READY_PATTERN = /^VIDEO_SESSION_READY token=([^ ]+) pid=(\d+) socket=([^ ]+)$/;
+// The optional trailing `proto=<v>` is the handshake version negotiation channel
+// (issue #4729): a pre-handshake device omits it, a handshake-capable device
+// advertises it. Non-greedy socket capture so the optional group binds correctly.
+const SESSION_READY_PATTERN =
+  /^VIDEO_SESSION_READY token=([^ ]+) pid=(\d+) socket=([^ ]+?)(?: proto=(\d+))?$/;
 /** Server stdout line printed after capture has fully started. */
 const STREAMING_STARTED_MARKER = "Streaming started";
 
@@ -58,6 +62,18 @@ const STREAMING_STARTED_MARKER = "Streaming started";
  * `VideoStreamProtocol.COMMAND_REQUEST_KEY_FRAME` in the Kotlin video-server.
  */
 export const VIDEO_SERVER_COMMAND_REQUEST_KEY_FRAME = 0x01;
+/**
+ * Handshake protocol version this client speaks. The server advertises its own
+ * supported version via `proto=<v>` on the readiness line; the client only sends
+ * a handshake when the device advertises a version it understands. Keep in sync
+ * with `VideoHandshake.PROTOCOL_VERSION` in the Kotlin video-server.
+ */
+export const VIDEO_SERVER_HANDSHAKE_VERSION = 1;
+/**
+ * Magic prefix of the pre-stream token handshake frame ("AVMH"). Keep in sync
+ * with `VideoHandshake.MAGIC` in the Kotlin video-server.
+ */
+const VIDEO_SERVER_HANDSHAKE_MAGIC = Buffer.from([0x41, 0x56, 0x4d, 0x48]);
 /** Retry a replaced local ADB socket without tearing down the device encoder. */
 export const DEFAULT_LOCAL_SOCKET_RECONNECT_WINDOW_MS = 5_000;
 export const DEFAULT_LOCAL_SOCKET_RECONNECT_RETRY_MS = 100;
@@ -261,6 +277,13 @@ export interface PersistentEncoderH264SourceOptions {
   /** Injectable session token source for deterministic tests. */
   sessionTokenFactory?: () => string;
   /**
+   * Injectable opaque-socket-name source for deterministic tests. Defaults to a
+   * fresh random id from the canonical {@link IdGenerator}, decoupled from the
+   * session token so the token is never disclosed via `/proc/net/unix` (issue
+   * #4729).
+   */
+  socketNameFactory?: () => string;
+  /**
    * How many bounded, backed-off relaunches of the on-device server to attempt
    * (cumulatively over the source's lifetime) after a post-start server exit
    * before giving up the persistent encoder. Defaults to
@@ -283,8 +306,32 @@ export interface PersistentEncoderH264SourceOptions {
 
 const DEFAULT_READY_TIMEOUT_MS = 10_000;
 
-function socketNameForToken(token: string): string {
-  return `${VIDEO_SERVER_SOCKET_PREFIX}_${token.replaceAll("-", "")}`;
+/**
+ * Build an opaque abstract-socket name whose suffix is a fresh random id from the
+ * canonical {@link IdGenerator}, deliberately unrelated to the session token
+ * (issue #4729). Because abstract socket names are world-readable via
+ * `/proc/net/unix`, embedding the token there would publish the secret; a random
+ * id reveals nothing usable. The `automobile_video_` prefix is retained so the
+ * orphan-forward sweep can still recognize our forwards, and dashes are stripped
+ * so the suffix satisfies the server's `SAFE_SOCKET_NAME` (`[A-Za-z0-9_.-]{1,100}`).
+ */
+function makeOpaqueSocketName(idGenerator: IdGenerator): string {
+  return `${VIDEO_SERVER_SOCKET_PREFIX}_${idGenerator.next().replaceAll("-", "")}`;
+}
+
+/**
+ * Assemble the pre-stream token handshake frame the client sends immediately on
+ * connect (issue #4729): MAGIC(4) + VERSION(1) + TOKEN_LEN(1) + token bytes. Keep
+ * in sync with `VideoHandshake` in the Kotlin video-server.
+ */
+function buildHandshakeFrame(token: string, version: number): Buffer {
+  const tokenBytes = Buffer.from(token, "ascii");
+  const frame = Buffer.alloc(VIDEO_SERVER_HANDSHAKE_MAGIC.length + 2 + tokenBytes.length);
+  let offset = VIDEO_SERVER_HANDSHAKE_MAGIC.copy(frame, 0);
+  offset = frame.writeUInt8(version, offset);
+  offset = frame.writeUInt8(tokenBytes.length, offset);
+  tokenBytes.copy(frame, offset);
+  return frame;
 }
 
 /**
@@ -312,6 +359,9 @@ function parseVideoForwardLine(line: string): { port: number; socketName: string
 function isSafeSessionToken(value: string): boolean {
   return /^[A-Za-z0-9-]{8,80}$/.test(value);
 }
+
+/** Mirrors `VideoSessionArguments.SAFE_SOCKET_NAME` on the device side. */
+const SAFE_SOCKET_NAME_PATTERN = /^[A-Za-z0-9_.-]{1,100}$/;
 
 function isPositiveInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isInteger(value) && value > 0;
@@ -434,6 +484,7 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
   private readonly localSocketReconnectWindowMs: number;
   private readonly localSocketReconnectRetryMs: number;
   private readonly sessionTokenFactory: () => string;
+  private readonly socketNameFactory: () => string;
   private readonly activeVideoSessionRegistry: ActiveVideoSessionRegistry;
   private readonly maxServerRelaunchAttempts: number;
   private readonly serverRelaunchBackoff: BackoffPolicy;
@@ -443,6 +494,13 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
   private forwardedPort: number | null = null;
   private session: VideoServerSession | null = null;
   private deviceProcessId: number | null = null;
+  /**
+   * Handshake protocol version negotiated from the device's readiness line
+   * (issue #4729). `null` means the device advertised no `proto=` field (a
+   * pre-handshake jar): the client then connects without sending a handshake so
+   * streaming degrades gracefully instead of hard-breaking.
+   */
+  private negotiatedHandshakeVersion: number | null = null;
   private running = false;
   private teardownPromise: Promise<void> | null = null;
   private resolveStartupAudioHeader: ((header: VideoServerStreamHeader) => void) | undefined;
@@ -478,6 +536,8 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     this.localSocketReconnectRetryMs =
       options.localSocketReconnectRetryMs ?? DEFAULT_LOCAL_SOCKET_RECONNECT_RETRY_MS;
     this.sessionTokenFactory = options.sessionTokenFactory ?? (() => defaultIdGenerator.next());
+    this.socketNameFactory =
+      options.socketNameFactory ?? (() => makeOpaqueSocketName(defaultIdGenerator));
     this.activeVideoSessionRegistry =
       options.activeVideoSessionRegistry ?? defaultActiveVideoSessionRegistry;
     const relaunchPolicy = PersistentEncoderH264Source.resolveRelaunchPolicy(options);
@@ -706,7 +766,9 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
       }
     });
 
-    this.deviceProcessId = await this.waitForReady(server);
+    const ready = await this.waitForReady(server);
+    this.deviceProcessId = ready.pid;
+    this.negotiatedHandshakeVersion = this.resolveHandshakeVersion(ready.protocolVersion);
     this.serverStartupInProgress = server;
     this.watchServer(server);
     return this.running ? server : null;
@@ -748,6 +810,8 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
         return;
       }
       this.socket = socket;
+      // Authenticate the connection before anything reads the stream header.
+      this.sendHandshake(socket);
       const startupAudioReady = this.options.audioEnabled
         ? this.waitForStartupAudioReady()
         : null;
@@ -871,20 +935,46 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     if (!isSafeSessionToken(token)) {
       throw new Error("Video server session token factory returned an unsafe token.");
     }
+    const socketName = this.socketNameFactory();
+    if (!SAFE_SOCKET_NAME_PATTERN.test(socketName)) {
+      throw new Error("Video server socket-name factory returned an unsafe socket name.");
+    }
     return {
       token,
-      socketName: socketNameForToken(token),
+      socketName,
       ownerPid: process.pid,
       deviceSerial: this.options.device.deviceId,
     };
   }
 
-  private waitForReady(server: AdbProcess): Promise<number> {
+  /**
+   * Reconcile the device-advertised handshake version with the version this
+   * client speaks (issue #4729). A `null` advertisement (pre-handshake device)
+   * yields `null` — the client will skip the handshake and stream anyway
+   * (graceful degrade). An advertised version this client does not support is
+   * clamped down to the client's version when the client is newer, or accepted
+   * as-is; the on-wire VERSION byte lets the server reject a frame it cannot
+   * parse with an actionable reason rather than a resync storm.
+   */
+  private resolveHandshakeVersion(advertised: number | null): number | null {
+    if (advertised === null) {
+      logger.warn(
+        "[PersistentEncoderH264Source] device advertised no handshake protocol; " +
+        "streaming without a token handshake (defense-in-depth degraded, UID gating still applies)"
+      );
+      return null;
+    }
+    return Math.min(advertised, VIDEO_SERVER_HANDSHAKE_VERSION);
+  }
+
+  private waitForReady(
+    server: AdbProcess
+  ): Promise<{ pid: number; protocolVersion: number | null }> {
     const token = this.session?.token;
     if (!token) {
       throw new Error("Video server session token was unavailable.");
     }
-    return new Promise<number>((resolve, reject) => {
+    return new Promise<{ pid: number; protocolVersion: number | null }>((resolve, reject) => {
       let settled = false;
       let stdoutBuffer = "";
       const finish = (fn: () => void): void => {
@@ -935,7 +1025,8 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
             finish(() => reject(new ActionableError("video-server returned an invalid session PID")));
             return;
           }
-          finish(() => resolve(pid));
+          const protocolVersion = match[4] !== undefined ? Number.parseInt(match[4], 10) : null;
+          finish(() => resolve({ pid, protocolVersion }));
           return;
         }
       };
@@ -1059,6 +1150,30 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     });
   }
 
+  /**
+   * Send the pre-stream token handshake as the FIRST bytes on a freshly-connected
+   * socket, before the server emits (or the client reads) any stream header (issue
+   * #4729). Skipped when the device advertised no handshake support
+   * ({@link negotiatedHandshakeVersion} is `null`), so a new host degrades
+   * gracefully against a pre-handshake device instead of hard-breaking the stream.
+   * Called on every accept — the initial connect and each socket reconnect — because
+   * the server requires the handshake on every `accept()`.
+   */
+  private sendHandshake(socket: StreamSocket): void {
+    const session = this.session;
+    const version = this.negotiatedHandshakeVersion;
+    if (!session || version === null) {
+      return;
+    }
+    try {
+      socket.write(buildHandshakeFrame(session.token, version));
+    } catch (error) {
+      // A write failure on a just-connected socket surfaces via its own error/close
+      // handler wired immediately after; do not double-report here.
+      logger.debug(`[PersistentEncoderH264Source] handshake write failed: ${error}`);
+    }
+  }
+
   private wireSocket(
     socket: StreamSocket,
     onSocketFailure: (error: Error) => void,
@@ -1175,6 +1290,8 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
           return;
         }
         this.socket = socket;
+        // The retained server requires the handshake on every accept, including reconnects.
+        this.sendHandshake(socket);
         this.wireSocket(socket, error => this.reconnectSocket(socket, error));
         logger.info("[PersistentEncoderH264Source] reconnected to retained video-server socket");
         return;

--- a/test/features/webrtc/PersistentEncoderH264Source.test.ts
+++ b/test/features/webrtc/PersistentEncoderH264Source.test.ts
@@ -4,6 +4,7 @@ import { PassThrough } from "node:stream";
 import {
   InMemoryActiveVideoSessionRegistry,
   PersistentEncoderH264Source,
+  VIDEO_SERVER_HANDSHAKE_VERSION,
   VIDEO_SERVER_LEASE_DIRECTORY,
   VIDEO_SERVER_SOCKET_PREFIX,
   type ActiveVideoSessionRegistry,
@@ -39,8 +40,16 @@ class FakeProcess extends EventEmitter implements SpawnedProcess {
     this.killed.push(signal ?? "SIGTERM");
     return true;
   }
-  ready(token: string = SESSION_TOKEN, socketName: string = SESSION_SOCKET, pid: number = 1234): void {
-    this.stdout.write(Buffer.from(`VIDEO_SESSION_READY token=${token} pid=${pid} socket=${socketName}\n`));
+  ready(
+    token: string = SESSION_TOKEN,
+    socketName: string = SESSION_SOCKET,
+    pid: number = 1234,
+    proto: number | null = VIDEO_SERVER_HANDSHAKE_VERSION
+  ): void {
+    const protoSuffix = proto === null ? "" : ` proto=${proto}`;
+    this.stdout.write(
+      Buffer.from(`VIDEO_SESSION_READY token=${token} pid=${pid} socket=${socketName}${protoSuffix}\n`)
+    );
     this.stdout.write(Buffer.from(`Waiting for client connection on localabstract:${socketName}\n`));
   }
   readyAndStreamingStarted(): void {
@@ -71,6 +80,20 @@ class FakeSocket extends EventEmitter implements StreamSocket {
   feed(chunk: Buffer): void {
     this.emit("data", chunk);
   }
+}
+
+/** Expected pre-stream handshake frame (issue #4729): MAGIC + VERSION + LEN + token. */
+function handshakeFrame(
+  token: string = SESSION_TOKEN,
+  version: number = VIDEO_SERVER_HANDSHAKE_VERSION
+): Buffer {
+  const tokenBytes = Buffer.from(token, "ascii");
+  const frame = Buffer.alloc(6 + tokenBytes.length);
+  Buffer.from([0x41, 0x56, 0x4d, 0x48]).copy(frame, 0);
+  frame.writeUInt8(version, 4);
+  frame.writeUInt8(tokenBytes.length, 5);
+  tokenBytes.copy(frame, 6);
+  return frame;
 }
 
 function streamHeader(width: number, height: number): Buffer {
@@ -224,6 +247,10 @@ function makeSource(overrides: Record<string, unknown> = {}) {
     connector,
     timer,
     sessionTokenFactory: () => SESSION_TOKEN,
+    // Decoupled from the token (issue #4729): a deterministic opaque socket name so
+    // existing forward/socket-name assertions stay stable while the production
+    // default derives it from the canonical IdGenerator.
+    socketNameFactory: () => SESSION_SOCKET,
     ...overrides,
     activeVideoSessionRegistry,
   });
@@ -303,12 +330,13 @@ describe("PersistentEncoderH264Source", () => {
     await startReady(ctx);
 
     expect(ctx.source.requestKeyFrame()).toBe(true);
-    expect(ctx.sockets[0].written).toEqual([Buffer.from([0x01])]);
+    // The handshake frame is written first on connect (issue #4729), then the command byte.
+    expect(ctx.sockets[0].written).toEqual([handshakeFrame(), Buffer.from([0x01])]);
 
     await ctx.source.stop();
     // After stop, no socket is available; the request is a safe no-op.
     expect(ctx.source.requestKeyFrame()).toBe(false);
-    expect(ctx.sockets[0].written).toEqual([Buffer.from([0x01])]);
+    expect(ctx.sockets[0].written).toEqual([handshakeFrame(), Buffer.from([0x01])]);
   });
 
   test("reports null-before-initialization and then precise IDR readiness telemetry", async () => {
@@ -634,7 +662,8 @@ describe("PersistentEncoderH264Source", () => {
     expect(ctx.source.isRunning).toBe(true);
 
     ctx.sockets[1].feed(streamHeader(480, 1040));
-    expect(ctx.sockets[1].written).toEqual([Buffer.from([0x01])]);
+    // The reconnected socket re-sends the handshake before the keyframe request (issue #4729).
+    expect(ctx.sockets[1].written).toEqual([handshakeFrame(), Buffer.from([0x01])]);
 
     await ctx.source.stop();
   });
@@ -1445,9 +1474,15 @@ describe("PersistentEncoderH264Source", () => {
   });
 
   test("uses separate socket leases for separate device sources", async () => {
-    const first = makeSource({ sessionTokenFactory: () => "first-session" });
+    // Socket name is now decoupled from the token (issue #4729), so each source is
+    // given its own opaque name explicitly rather than deriving it from the token.
+    const first = makeSource({
+      sessionTokenFactory: () => "first-session",
+      socketNameFactory: () => `${VIDEO_SERVER_SOCKET_PREFIX}_firstsession`,
+    });
     const second = makeSource({
       sessionTokenFactory: () => "second-session",
+      socketNameFactory: () => `${VIDEO_SERVER_SOCKET_PREFIX}_secondsession`,
       device: { ...DEVICE, deviceId: "emulator-5556" },
     });
 
@@ -1537,6 +1572,59 @@ describe("PersistentEncoderH264Source", () => {
     test("rejects construction with a non-positive command timeout", () => {
       expect(() => makeSource({ commandTimeoutMs: 0 })).toThrow();
       expect(() => makeSource({ teardownTimeoutMs: -1 })).toThrow();
+    });
+  });
+
+  describe("token handshake and opaque socket name (issue #4729)", () => {
+    test("names the abstract socket opaquely, decoupled from the session token", async () => {
+      const OPAQUE = `${VIDEO_SERVER_SOCKET_PREFIX}_deadbeefcafef00d`;
+      const ctx = makeSource({
+        sessionTokenFactory: () => "secret-token-1234",
+        socketNameFactory: () => OPAQUE,
+      });
+      const startPromise = ctx.source.start();
+      await tick();
+      ctx.processes[0].ready("secret-token-1234", OPAQUE);
+      await tick();
+      await startPromise;
+
+      expect(ctx.sessionSocket()).toBe(OPAQUE);
+      expect(ctx.commands).toContain(`forward tcp:0 localabstract:${OPAQUE}`);
+      const args = ctx.spawnArgs[0].join(" ");
+      expect(args).toContain(`--socket-name ${OPAQUE}`);
+      expect(args).toContain("--session-token secret-token-1234");
+      // The /proc/net/unix disclosure fix: the socket name must not embed the token.
+      expect(ctx.sessionSocket()).not.toContain("secret-token-1234");
+
+      await ctx.source.stop();
+    });
+
+    test("sends the token handshake as the first bytes on connect", async () => {
+      const ctx = makeSource();
+      await startReady(ctx);
+
+      // The handshake is written on connect, before any stream header is read.
+      expect(ctx.sockets[0].written).toEqual([handshakeFrame()]);
+
+      await ctx.source.stop();
+    });
+
+    test("skips the handshake and still streams when the device advertises no proto", async () => {
+      const ctx = makeSource();
+      const startPromise = ctx.source.start();
+      await tick();
+      // A pre-handshake device omits `proto=` on its readiness line.
+      ctx.processes[0].ready(SESSION_TOKEN, SESSION_SOCKET, 1234, null);
+      await tick();
+      await startPromise;
+
+      expect(ctx.sockets[0].written).toEqual([]);
+      // Streaming still works (graceful degrade; UID gating remains the barrier).
+      ctx.sockets[0].feed(streamHeader(480, 1040));
+      ctx.sockets[0].feed(framedPacket(Buffer.from([0x09])));
+      expect(ctx.chunks).toEqual([Buffer.from([0x09])]);
+
+      await ctx.source.stop();
     });
   });
 });


### PR DESCRIPTION
Closes [#4729](https://github.com/kaeawc/auto-mobile/issues/4729)

## Summary

The video-server abstract socket name embedded the session token
(`automobile_video_<token>`). Abstract socket names are world-readable via
`/proc/net/unix`, so the token — the intended per-connection secret — was
public to any local process. This PR (a) decouples the socket name from the
token and (b) requires a token handshake before the server emits any stream
byte, coordinated across the Kotlin video-server and the TypeScript client.

## Verify-against-current-main findings

- **[#4728](https://github.com/kaeawc/auto-mobile/issues/4728) (just merged)**
  added `SO_PEERCRED` UID gating in `acceptClients()` through
  `VideoClientConnection.peerUid` (`ALLOWED_PEER_UIDS = {0, 2000}`). The new
  handshake runs **after** that UID gate and **before** the
  `closeClientLocked()` eviction + `writeStreamHeaderLocked()`, so a bad token
  neither displaces the current legitimate client nor leaks a byte — the same
  authenticate-before-evict ordering the UID gate keeps
  ([#4730](https://github.com/kaeawc/auto-mobile/issues/4730)).
- The seam `VideoClientConnection` previously exposed only `outputStream`,
  `inputStream`, `peerUid`, `close()`. I added one narrow inbound-read
  capability, `readFully(count, timeoutMs)`, rather than leaking raw
  `SO_TIMEOUT` plumbing — fake-testable, matching the existing seam style.
- `socketNameForToken()` built `automobile_video_<token>`. Replaced with an
  opaque name from the canonical `IdGenerator` (`defaultIdGenerator`), keeping
  the `automobile_video_` prefix the orphan-forward sweep matches on.
- `VideoSessionArguments.SAFE_SOCKET_NAME` / `SAFE_TOKEN` and the client
  `isSafeSessionToken` are all retained; the opaque suffix (UUID, dashes
  stripped) satisfies `SAFE_SOCKET_NAME`.

## Handshake design

Wire frame (client → server), first bytes after connect:

```
offset 0  MAGIC      4 bytes  0x41 0x56 0x4D 0x48  ("AVMH")
offset 4  VERSION    1 byte   protocol version (currently 1)
offset 5  TOKEN_LEN  1 byte   token length N, 8..80 (uint8)
offset 6  TOKEN      N bytes  ASCII session token (matches SAFE_TOKEN)
```

- **Server** (`VideoHandshake.read`, driven from `VideoStreamWriter.acceptClients`
  via `handshakeAccepted`): reads the 6-byte prefix then the N-byte token under a
  single bounded deadline (`HANDSHAKE_READ_TIMEOUT_MS = 2000ms`, split across the
  two reads via the injected clock). Validates MAGIC, VERSION, length bounds,
  `SAFE_TOKEN` shape, then compares against the expected token with
  `MessageDigest.isEqual` (JDK constant-time; no early-exit and no length leak on
  JDK 17+). Any mismatch/timeout → close with **zero bytes written** and a
  `VIDEO_CLIENT_HANDSHAKE_REJECTED socket=… reason=…` log. A silent connector
  cannot hold the accept slot past the deadline.
- **Client** (`PersistentEncoderH264Source.sendHandshake`): sends the frame
  immediately on connect, before the stream header is read, on **every** accept —
  the initial connect and each socket reconnect (the retained server requires it
  on every `accept()`).
- The handshake is enabled only when the writer has a token (`expectedToken`),
  which production always supplies via `--session-token`; a token-less/legacy
  launch skips it, preserving prior behavior.

## Version-negotiation fallback (default)

Two layers, primary is out-of-band and pre-connect:

1. **Readiness line** — the server appends `proto=<version>` to
   `VIDEO_SESSION_READY`. The client parses it in `waitForReady` and
   `resolveHandshakeVersion(min(advertised, client))`:
   - **new host + new device** — `proto=1` present → client sends the handshake.
   - **new host + old device** — no `proto=` → client streams **without** a
     handshake (`negotiatedHandshakeVersion = null`), logging a warning. The
     socket-name disclosure fix still applies (host passes `--socket-name`), and
     the #4728 UID gate remains the barrier. Streaming does not hard-break.
2. **In-band MAGIC + VERSION** — the secondary/defensive layer lets the server
   reject a malformed or unsupported-version frame with an actionable reason
   instead of hanging.

- **old host + new device** — the old host sends no frame; the device rejects on
  the bounded timeout with zero bytes. The old host's existing bounded reconnect
  budget (5s window, 3 relaunch attempts) then falls back to screenrecord — a
  bounded, clearly-terminating path, not a resync storm.

## Dependency note

If the token becomes the on-wire secret, the lease file must stop storing it in
cleartext — that is [#4731](https://github.com/kaeawc/auto-mobile/issues/4731)
(separate, **not** implemented here). This change is compatible with it.

## What changed

- `android/.../VideoHandshake.kt` (new) — frame parsing + constant-time validate.
- `android/.../VideoServerSocketSeam.kt` — `readFully(count, timeoutMs)` on
  `VideoClientConnection`; production `LocalSocketConnection` implements it with a
  total-deadline `SO_TIMEOUT` read loop.
- `android/.../VideoStreamWriter.kt` — `expectedToken` ctor arg;
  `handshakeAccepted()` gate wired into `acceptClients` after the UID gate;
  `HANDSHAKE_READ_TIMEOUT_MS`.
- `android/.../VideoServer.kt` — passes `session.token`; appends `proto=` to the
  readiness line.
- `src/features/webrtc/PersistentEncoderH264Source.ts` — opaque
  `makeOpaqueSocketName` (canonical `IdGenerator`) + injectable
  `socketNameFactory`; `buildHandshakeFrame` / `sendHandshake`;
  `resolveHandshakeVersion`; readiness pattern captures `proto`; `SAFE_SOCKET_NAME`
  guard on the generated name.
- Kotlin + TS tests (see below).

## Validation

- Kotlin: `:video-server:test` green (new `VideoHandshakeTest` +
  `VideoStreamWriterTest` cases: valid handshake attaches; **wrong token** →
  0 bytes + disconnect; **no token within timeout** → 0 bytes + disconnect; a bad
  handshake does not displace the current authenticated client; bad-magic /
  unsupported-version / bad-length / truncated / unsafe-token reasons). ktfmt
  clean.
- TS: `bun run typecheck` — no new errors. `turbo run lint build` green.
  `turbo run test` — 12292 pass / 0 fail (device-gated integration tests skipped).
  New cases: opaque socket name decoupled from the token; handshake sent as first
  bytes on connect; graceful degrade (no `proto=` → no handshake, still streams).

Do not merge / automerge — flagged for a human merge decision (wire-protocol change).
