### PR TITLE
fix(ios): brand CtrlProxy UI test runner

### DIFF
--- a/scripts/ios/ctrl-proxy-build-for-testing.sh
+++ b/scripts/ios/ctrl-proxy-build-for-testing.sh
@@ -154,6 +154,8 @@ if [ "${ALL_FOUND}" = false ]; then
     exit 1
 fi
 
+"${SCRIPT_DIR}/patch-ctrl-proxy-ui-test-runner-icon.sh" --derived-data "${DERIVED_DATA}"
+
 echo ""
 echo -e "${GREEN}Build completed in ${BUILD_DURATION}s${NC}"
 echo -e "${GREEN}xctestrun: ${XCTESTRUN_FILE}${NC}"

--- a/scripts/ios/ctrl-proxy-build-for-testing.sh
+++ b/scripts/ios/ctrl-proxy-build-for-testing.sh
@@ -102,16 +102,36 @@ echo ""
 
 BUILD_START=$(date +%s)
 
-xcodebuild build-for-testing \
-    -project "${XCODEPROJ}" \
-    -scheme "CtrlProxyApp" \
-    -destination 'generic/platform=iOS Simulator' \
-    -derivedDataPath "${DERIVED_DATA}" \
-    -configuration Debug \
-    CODE_SIGN_IDENTITY="-" \
-    CODE_SIGNING_REQUIRED=NO \
-    CODE_SIGNING_ALLOWED=NO \
-    | xcpretty --color 2>/dev/null || true
+run_xcodebuild() {
+    xcodebuild build-for-testing \
+        -project "${XCODEPROJ}" \
+        -scheme "CtrlProxyApp" \
+        -destination 'generic/platform=iOS Simulator' \
+        -derivedDataPath "${DERIVED_DATA}" \
+        -configuration Debug \
+        CODE_SIGN_IDENTITY="-" \
+        CODE_SIGNING_REQUIRED=NO \
+        CODE_SIGNING_ALLOWED=NO
+}
+
+if command -v xcpretty >/dev/null 2>&1; then
+    set +e
+    run_xcodebuild | xcpretty --color 2>/dev/null
+    BUILD_STATUSES=("${PIPESTATUS[@]}")
+    set -e
+
+    if [ "${BUILD_STATUSES[0]}" -ne 0 ]; then
+        echo -e "${RED}Error: CtrlProxy iOS build-for-testing failed.${NC}"
+        exit "${BUILD_STATUSES[0]}"
+    fi
+    if [ "${BUILD_STATUSES[1]}" -ne 0 ]; then
+        echo -e "${RED}Error: xcpretty failed while formatting the CtrlProxy build.${NC}"
+        exit "${BUILD_STATUSES[1]}"
+    fi
+else
+    echo -e "${YELLOW}xcpretty not found; using raw xcodebuild output.${NC}"
+    run_xcodebuild
+fi
 
 BUILD_END=$(date +%s)
 BUILD_DURATION=$((BUILD_END - BUILD_START))

--- a/scripts/ios/ctrl-proxy-create-ipa.sh
+++ b/scripts/ios/ctrl-proxy-create-ipa.sh
@@ -150,6 +150,8 @@ if [ "${ALL_FOUND}" = false ]; then
     exit 1
 fi
 
+"${SCRIPT_DIR}/patch-ctrl-proxy-ui-test-runner-icon.sh" --derived-data "${DERIVED_DATA}"
+
 echo ""
 echo -e "${GREEN}Build completed in ${BUILD_DURATION}s${NC}"
 

--- a/scripts/ios/navigation-graph-sdk-event-integration.sh
+++ b/scripts/ios/navigation-graph-sdk-event-integration.sh
@@ -53,9 +53,26 @@ ctrl_proxy_port_for_device() {
   printf '%s\n' "${ctrl_proxy_port}"
 }
 
+wait_for_ctrl_proxy_health() {
+  local ctrl_proxy_port="$1"
+  local attempt
+  for attempt in 1 2 3 4 5; do
+    if curl --fail --silent --show-error --max-time 5 "http://127.0.0.1:${ctrl_proxy_port}/health" >/dev/null; then
+      return 0
+    fi
+    if [[ "${attempt}" -lt 5 ]]; then
+      echo "CtrlProxy health check attempt ${attempt} failed; retrying in 2s..." >&2
+      sleep 2
+    fi
+  done
+
+  echo "error: CtrlProxy health check failed after 5 attempts on port ${ctrl_proxy_port}" >&2
+  return 1
+}
+
 ctrl_proxy_port="$(ctrl_proxy_port_for_device)"
 
-curl --fail --silent --show-error --max-time 5 "http://127.0.0.1:${ctrl_proxy_port}/health" >/dev/null
+wait_for_ctrl_proxy_health "${ctrl_proxy_port}"
 
 # The graph query selects the target device's latest observed foreground app.
 # Keep the injected SDK events and the following observations scoped to the
@@ -76,7 +93,7 @@ fi
 # Requesting debug and embedded-SDK tools can restart the daemon. That restart
 # creates a new CtrlProxy client, so the prior daemon's reported port is stale.
 ctrl_proxy_port="$(ctrl_proxy_port_for_device)"
-curl --fail --silent --show-error --max-time 5 "http://127.0.0.1:${ctrl_proxy_port}/health" >/dev/null
+wait_for_ctrl_proxy_health "${ctrl_proxy_port}"
 
 event_payload() {
   local destination="$1"

--- a/scripts/ios/patch-ctrl-proxy-ui-test-runner-icon.sh
+++ b/scripts/ios/patch-ctrl-proxy-ui-test-runner-icon.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# Add the CtrlProxy display name and launcher icon to Xcode's generated UI-test
+# runner. Xcode recreates CtrlProxyUITests-Runner.app on every build, so this
+# must run after build-for-testing and before test-without-building installs it.
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 --derived-data <path>" >&2
+}
+
+DERIVED_DATA=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --derived-data)
+            DERIVED_DATA="${2:-}"
+            shift 2
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "${DERIVED_DATA}" ]]; then
+    usage
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+ASSET_CATALOG="${PROJECT_ROOT}/ios/control-proxy/CtrlProxyApp/Assets.xcassets"
+SIMULATOR_PRODUCTS="${DERIVED_DATA}/Build/Products/Debug-iphonesimulator"
+RUNNER_APP="${SIMULATOR_PRODUCTS}/CtrlProxyUITests-Runner.app"
+RUNNER_INFO_PLIST="${RUNNER_APP}/Info.plist"
+
+if [[ ! -d "${RUNNER_APP}" || ! -f "${RUNNER_INFO_PLIST}" ]]; then
+    echo "CtrlProxy UI-test runner not found: ${RUNNER_APP}" >&2
+    exit 1
+fi
+
+if [[ ! -d "${ASSET_CATALOG}" ]]; then
+    echo "CtrlProxy asset catalog not found: ${ASSET_CATALOG}" >&2
+    exit 1
+fi
+
+PATCH_DIRECTORY="$(mktemp -d)"
+trap 'rm -rf "${PATCH_DIRECTORY}"' EXIT
+
+xcrun actool \
+    --compile "${PATCH_DIRECTORY}" \
+    --platform iphonesimulator \
+    --minimum-deployment-target 15.0 \
+    --app-icon AppIcon \
+    --output-partial-info-plist "${PATCH_DIRECTORY}/icon-info.plist" \
+    "${ASSET_CATALOG}" >/dev/null
+
+for icon_artifact in Assets.car AppIcon60x60@2x.png AppIcon76x76@2x~ipad.png; do
+    if [[ ! -f "${PATCH_DIRECTORY}/${icon_artifact}" ]]; then
+        echo "actool did not produce ${icon_artifact}" >&2
+        exit 1
+    fi
+    cp "${PATCH_DIRECTORY}/${icon_artifact}" "${RUNNER_APP}/${icon_artifact}"
+done
+
+/usr/libexec/PlistBuddy -c "Merge ${PATCH_DIRECTORY}/icon-info.plist :" "${RUNNER_INFO_PLIST}"
+plutil -replace CFBundleDisplayName -string CtrlProxy "${RUNNER_INFO_PLIST}"
+plutil -replace CFBundleName -string CtrlProxy "${RUNNER_INFO_PLIST}"
+
+# The simulator accepts an ad-hoc signature, while a stale signature rejects
+# the copied asset catalog during installation.
+codesign --force --sign - "${RUNNER_APP}" >/dev/null
+
+echo "Patched CtrlProxyUITests-Runner with the CtrlProxy app icon."

--- a/scripts/ios/patch-ctrl-proxy-ui-test-runner-icon.sh
+++ b/scripts/ios/patch-ctrl-proxy-ui-test-runner-icon.sh
@@ -35,6 +35,8 @@ ASSET_CATALOG="${PROJECT_ROOT}/ios/control-proxy/CtrlProxyApp/Assets.xcassets"
 SIMULATOR_PRODUCTS="${DERIVED_DATA}/Build/Products/Debug-iphonesimulator"
 RUNNER_APP="${SIMULATOR_PRODUCTS}/CtrlProxyUITests-Runner.app"
 RUNNER_INFO_PLIST="${RUNNER_APP}/Info.plist"
+PLIST_BUDDY="${PLIST_BUDDY:-/usr/libexec/PlistBuddy}"
+PLUTIL="${PLUTIL:-plutil}"
 
 if [[ ! -d "${RUNNER_APP}" || ! -f "${RUNNER_INFO_PLIST}" ]]; then
     echo "CtrlProxy UI-test runner not found: ${RUNNER_APP}" >&2
@@ -43,6 +45,16 @@ fi
 
 if [[ ! -d "${ASSET_CATALOG}" ]]; then
     echo "CtrlProxy asset catalog not found: ${ASSET_CATALOG}" >&2
+    exit 1
+fi
+
+if [[ ! -x "${PLIST_BUDDY}" ]]; then
+    echo "PlistBuddy not found: ${PLIST_BUDDY}" >&2
+    exit 1
+fi
+
+if ! command -v "${PLUTIL}" >/dev/null 2>&1; then
+    echo "plutil not found: ${PLUTIL}" >&2
     exit 1
 fi
 
@@ -65,9 +77,9 @@ for icon_artifact in Assets.car AppIcon60x60@2x.png AppIcon76x76@2x~ipad.png; do
     cp "${PATCH_DIRECTORY}/${icon_artifact}" "${RUNNER_APP}/${icon_artifact}"
 done
 
-/usr/libexec/PlistBuddy -c "Merge ${PATCH_DIRECTORY}/icon-info.plist :" "${RUNNER_INFO_PLIST}"
-plutil -replace CFBundleDisplayName -string CtrlProxy "${RUNNER_INFO_PLIST}"
-plutil -replace CFBundleName -string CtrlProxy "${RUNNER_INFO_PLIST}"
+"${PLIST_BUDDY}" -c "Merge ${PATCH_DIRECTORY}/icon-info.plist :" "${RUNNER_INFO_PLIST}"
+"${PLUTIL}" -replace CFBundleDisplayName -string CtrlProxy "${RUNNER_INFO_PLIST}"
+"${PLUTIL}" -replace CFBundleName -string CtrlProxy "${RUNNER_INFO_PLIST}"
 
 # The simulator accepts an ad-hoc signature, while a stale signature rejects
 # the copied asset catalog during installation.

--- a/scripts/local-dev/lib/ctrl-proxy-ios.sh
+++ b/scripts/local-dev/lib/ctrl-proxy-ios.sh
@@ -148,6 +148,11 @@ build_ctrl_proxy_ios() {
     return 1
   fi
 
+  if ! "${PROJECT_ROOT}/scripts/ios/patch-ctrl-proxy-ui-test-runner-icon.sh" --derived-data "${DERIVED_DATA_PATH}"; then
+    log_error "Failed to patch the CtrlProxy UI-test runner icon."
+    return 1
+  fi
+
   return 0
 }
 

--- a/scripts/test-ctrl-proxy-ios.sh
+++ b/scripts/test-ctrl-proxy-ios.sh
@@ -25,6 +25,7 @@ TIMEOUT=5
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 CTRL_PROXY_IOS_DIR="${PROJECT_ROOT}/ios/control-proxy"
+DERIVED_DATA="${AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA:-/tmp/automobile-ctrl-proxy}"
 
 echo -e "${CYAN}========================================${NC}"
 echo -e "${CYAN}  CtrlProxy iOS Diagnostic Script${NC}"
@@ -160,65 +161,79 @@ if [ "$HEALTH_RESPONSE" == "FAILED" ]; then
             LOG_FILE="/tmp/ctrl-proxy-ios-$(date +%Y%m%d-%H%M%S).log"
             print_info "Log file: ${LOG_FILE}"
 
-            # Start xcodebuild test in background
+            # Build first so the generated UI-test runner can be branded before
+            # test-without-building installs it on the simulator.
             echo ""
-            print_info "Starting CtrlProxy iOS in background..."
+            print_info "Building CtrlProxy iOS for testing..."
+            if ! "${PROJECT_ROOT}/scripts/ios/ctrl-proxy-build-for-testing.sh"; then
+                print_status 1 "CtrlProxy iOS build-for-testing failed"
+            else
+                XCTESTRUN_FILE=$(find "${DERIVED_DATA}/Build/Products" -name "*.xctestrun" -type f 2>/dev/null | head -1)
 
-            cd "${CTRL_PROXY_IOS_DIR}"
-            nohup xcodebuild test \
-                -scheme CtrlProxyApp \
-                -destination "id=${BOOTED_SIMULATOR}" \
-                -only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService \
-                > "$LOG_FILE" 2>&1 &
+                if [ -z "${XCTESTRUN_FILE}" ]; then
+                    print_status 1 "No CtrlProxy .xctestrun file found after build"
+                else
+                    print_info "Starting patched CtrlProxy iOS in background..."
 
-            XCODEBUILD_PID=$!
-            cd - > /dev/null
+                    cd "${CTRL_PROXY_IOS_DIR}"
+                    nohup xcodebuild test-without-building \
+                        -xctestrun "${XCTESTRUN_FILE}" \
+                        -destination "id=${BOOTED_SIMULATOR}" \
+                        -only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService \
+                        "CTRL_PROXY_IOS_PORT=${PORT}" \
+                        "AUTOMOBILE_DEVICE_ID=${BOOTED_SIMULATOR}" \
+                        > "$LOG_FILE" 2>&1 &
 
-            print_info "Started xcodebuild with PID: ${XCODEBUILD_PID}"
+                    XCODEBUILD_PID=$!
+                    cd - > /dev/null
 
-            # Wait for service to come up
-            echo ""
-            print_info "Waiting for CtrlProxy iOS to start (up to 60 seconds)..."
+                    print_info "Started xcodebuild with PID: ${XCODEBUILD_PID}"
 
-            MAX_WAIT=60
-            WAITED=0
-            while [ $WAITED -lt $MAX_WAIT ]; do
-                HEALTH_CHECK=$(curl -s --max-time 2 "${HEALTH_URL}" 2>/dev/null || echo "")
-                if [[ "$HEALTH_CHECK" == *"ok"* ]] || [[ "$HEALTH_CHECK" == *"status"* ]]; then
+                    # Wait for service to come up
                     echo ""
-                    print_status 0 "CtrlProxy iOS is now running!"
-                    SERVICE_RUNNING=true
-                    break
-                fi
+                    print_info "Waiting for CtrlProxy iOS to start (up to 60 seconds)..."
 
-                # Check if process is still alive
-                if ! kill -0 $XCODEBUILD_PID 2>/dev/null; then
-                    echo ""
-                    print_status 1 "xcodebuild process exited unexpectedly"
-                    print_info "Check log file for errors: ${LOG_FILE}"
-                    # Show last few lines of log
-                    if [ -f "$LOG_FILE" ]; then
+                    MAX_WAIT=60
+                    WAITED=0
+                    while [ $WAITED -lt $MAX_WAIT ]; do
+                        HEALTH_CHECK=$(curl -s --max-time 2 "${HEALTH_URL}" 2>/dev/null || echo "")
+                        if [[ "$HEALTH_CHECK" == *"ok"* ]] || [[ "$HEALTH_CHECK" == *"status"* ]]; then
+                            echo ""
+                            print_status 0 "CtrlProxy iOS is now running!"
+                            SERVICE_RUNNING=true
+                            break
+                        fi
+
+                        # Check if process is still alive
+                        if ! kill -0 $XCODEBUILD_PID 2>/dev/null; then
+                            echo ""
+                            print_status 1 "xcodebuild process exited unexpectedly"
+                            print_info "Check log file for errors: ${LOG_FILE}"
+                            # Show last few lines of log
+                            if [ -f "$LOG_FILE" ]; then
+                                echo ""
+                                echo -e "  ${YELLOW}Last 10 lines of log:${NC}"
+                                tail -10 "$LOG_FILE" | sed 's/^/    /'
+                            fi
+                            break
+                        fi
+
+                        printf "."
+                        sleep 2
+                        WAITED=$((WAITED + 2))
+                    done
+
+                    if [ "$SERVICE_RUNNING" = false ] && [ $WAITED -ge $MAX_WAIT ]; then
                         echo ""
-                        echo -e "  ${YELLOW}Last 10 lines of log:${NC}"
-                        tail -10 "$LOG_FILE" | sed 's/^/    /'
+                        print_status 1 "Timeout waiting for CtrlProxy iOS to start"
+                        print_info "xcodebuild may still be building. Check: ${LOG_FILE}"
+                        # Show last few lines of log
+                        if [ -f "$LOG_FILE" ]; then
+                            echo ""
+                            echo -e "  ${YELLOW}Last 10 lines of log:${NC}"
+                            tail -10 "$LOG_FILE" | sed 's/^/    /'
+                        fi
                     fi
-                    break
-                fi
-
-                printf "."
-                sleep 2
-                WAITED=$((WAITED + 2))
-            done
-
-            if [ "$SERVICE_RUNNING" = false ] && [ $WAITED -ge $MAX_WAIT ]; then
-                echo ""
-                print_status 1 "Timeout waiting for CtrlProxy iOS to start"
-                print_info "xcodebuild may still be building. Check: ${LOG_FILE}"
-                # Show last few lines of log
-                if [ -f "$LOG_FILE" ]; then
-                    echo ""
-                    echo -e "  ${YELLOW}Last 10 lines of log:${NC}"
-                    tail -10 "$LOG_FILE" | sed 's/^/    /'
                 fi
             fi
         fi

--- a/scripts/test-ctrl-proxy-ios.sh
+++ b/scripts/test-ctrl-proxy-ios.sh
@@ -168,7 +168,9 @@ if [ "$HEALTH_RESPONSE" == "FAILED" ]; then
             if ! "${PROJECT_ROOT}/scripts/ios/ctrl-proxy-build-for-testing.sh"; then
                 print_status 1 "CtrlProxy iOS build-for-testing failed"
             else
-                XCTESTRUN_FILE=$(find "${DERIVED_DATA}/Build/Products" -name "*.xctestrun" -type f 2>/dev/null | head -1)
+                XCTESTRUN_FILE=$(find "${DERIVED_DATA}/Build/Products" -maxdepth 1 -type f \
+                    -name "*iphonesimulator*.xctestrun" \
+                    ! -name "automobile-runner-*.xctestrun" 2>/dev/null | head -1)
 
                 if [ -z "${XCTESTRUN_FILE}" ]; then
                     print_status 1 "No CtrlProxy .xctestrun file found after build"

--- a/scripts/test-ctrl-proxy-ios.sh
+++ b/scripts/test-ctrl-proxy-ios.sh
@@ -175,15 +175,18 @@ if [ "$HEALTH_RESPONSE" == "FAILED" ]; then
                 if [ -z "${XCTESTRUN_FILE}" ]; then
                     print_status 1 "No CtrlProxy .xctestrun file found after build"
                 else
+                    RUNNER_XCTESTRUN_FILE="$(dirname "${XCTESTRUN_FILE}")/automobile-runner-${BOOTED_SIMULATOR}.xctestrun"
+                    cp "${XCTESTRUN_FILE}" "${RUNNER_XCTESTRUN_FILE}"
+                    plutil -replace "CtrlProxyUITests.EnvironmentVariables.CTRL_PROXY_IOS_PORT" -string "${PORT}" "${RUNNER_XCTESTRUN_FILE}"
+                    plutil -replace "CtrlProxyUITests.EnvironmentVariables.AUTOMOBILE_DEVICE_ID" -string "${BOOTED_SIMULATOR}" "${RUNNER_XCTESTRUN_FILE}"
+
                     print_info "Starting patched CtrlProxy iOS in background..."
 
                     cd "${CTRL_PROXY_IOS_DIR}"
                     nohup xcodebuild test-without-building \
-                        -xctestrun "${XCTESTRUN_FILE}" \
+                        -xctestrun "${RUNNER_XCTESTRUN_FILE}" \
                         -destination "id=${BOOTED_SIMULATOR}" \
                         -only-testing:CtrlProxyUITests/CtrlProxyUITests/testRunService \
-                        "CTRL_PROXY_IOS_PORT=${PORT}" \
-                        "AUTOMOBILE_DEVICE_ID=${BOOTED_SIMULATOR}" \
                         > "$LOG_FILE" 2>&1 &
 
                     XCODEBUILD_PID=$!

--- a/test/bats/ctrl-proxy-ui-test-runner-icon.bats
+++ b/test/bats/ctrl-proxy-ui-test-runner-icon.bats
@@ -142,6 +142,15 @@ PY
   run grep -F '"*iphonesimulator*.xctestrun"' "${repository_root}/scripts/test-ctrl-proxy-ios.sh"
   [ "$status" -eq 0 ]
 
+  run grep -F 'automobile-runner-${BOOTED_SIMULATOR}.xctestrun' "${repository_root}/scripts/test-ctrl-proxy-ios.sh"
+  [ "$status" -eq 0 ]
+
+  run grep -F 'CtrlProxyUITests.EnvironmentVariables.CTRL_PROXY_IOS_PORT' "${repository_root}/scripts/test-ctrl-proxy-ios.sh"
+  [ "$status" -eq 0 ]
+
+  run grep -F 'CtrlProxyUITests.EnvironmentVariables.AUTOMOBILE_DEVICE_ID' "${repository_root}/scripts/test-ctrl-proxy-ios.sh"
+  [ "$status" -eq 0 ]
+
   run grep -E '^[[:space:]]*nohup xcodebuild test([[:space:]]|$)' "${repository_root}/scripts/test-ctrl-proxy-ios.sh"
   [ "$status" -eq 1 ]
 

--- a/test/bats/ctrl-proxy-ui-test-runner-icon.bats
+++ b/test/bats/ctrl-proxy-ui-test-runner-icon.bats
@@ -45,7 +45,48 @@ STUB
 #!/bin/bash
 exit 0
 STUB
-  chmod +x "${STUB_DIR}/xcrun" "${STUB_DIR}/codesign"
+  cat > "${STUB_DIR}/PlistBuddy" <<'STUB'
+#!/bin/bash
+set -euo pipefail
+[[ "$1" == "-c" ]]
+partial_info_plist="${2#Merge }"
+partial_info_plist="${partial_info_plist% :}"
+runner_info_plist="$3"
+python3 - "${partial_info_plist}" "${runner_info_plist}" <<'PY'
+import plistlib
+import sys
+
+partial_path, runner_path = sys.argv[1:]
+with open(partial_path, "rb") as partial_file:
+    partial = plistlib.load(partial_file)
+with open(runner_path, "rb") as runner_file:
+    runner = plistlib.load(runner_file)
+runner.update(partial)
+with open(runner_path, "wb") as runner_file:
+    plistlib.dump(runner, runner_file)
+PY
+STUB
+  cat > "${STUB_DIR}/plutil" <<'STUB'
+#!/bin/bash
+set -euo pipefail
+[[ "$1" == "-replace" ]]
+key="$2"
+[[ "$3" == "-string" ]]
+value="$4"
+info_plist="$5"
+python3 - "${key}" "${value}" "${info_plist}" <<'PY'
+import plistlib
+import sys
+
+key, value, info_path = sys.argv[1:]
+with open(info_path, "rb") as info_file:
+    info = plistlib.load(info_file)
+info[key] = value
+with open(info_path, "wb") as info_file:
+    plistlib.dump(info, info_file)
+PY
+STUB
+  chmod +x "${STUB_DIR}/xcrun" "${STUB_DIR}/codesign" "${STUB_DIR}/PlistBuddy" "${STUB_DIR}/plutil"
 }
 
 teardown() {
@@ -53,19 +94,30 @@ teardown() {
 }
 
 @test "patches the generated runner with CtrlProxy's icon metadata" {
-  run env PATH="${STUB_DIR}:$PATH" bash "${SCRIPT}" --derived-data "${DERIVED_DATA}"
+  run env PATH="${STUB_DIR}:$PATH" PLIST_BUDDY="${STUB_DIR}/PlistBuddy" PLUTIL="${STUB_DIR}/plutil" bash "${SCRIPT}" --derived-data "${DERIVED_DATA}"
+
+  [ "$status" -eq 0 ]
+
+  run env PATH="${STUB_DIR}:$PATH" PLIST_BUDDY="${STUB_DIR}/PlistBuddy" PLUTIL="${STUB_DIR}/plutil" bash "${SCRIPT}" --derived-data "${DERIVED_DATA}"
 
   [ "$status" -eq 0 ]
   [[ "$output" == *"Patched CtrlProxyUITests-Runner"* ]]
   [ -f "${RUNNER_APP}/Assets.car" ]
   [ -f "${RUNNER_APP}/AppIcon60x60@2x.png" ]
   [ -f "${RUNNER_APP}/AppIcon76x76@2x~ipad.png" ]
-  [ "$(plutil -extract CFBundleDisplayName raw "${RUNNER_APP}/Info.plist")" = "CtrlProxy" ]
-  [ "$(plutil -extract CFBundleName raw "${RUNNER_APP}/Info.plist")" = "CtrlProxy" ]
-  [ "$(plutil -extract CFBundleIcons.CFBundlePrimaryIcon.CFBundleIconName raw "${RUNNER_APP}/Info.plist")" = "AppIcon" ]
+  python3 - "${RUNNER_APP}/Info.plist" <<'PY'
+import plistlib
+import sys
+
+with open(sys.argv[1], "rb") as info_file:
+    info = plistlib.load(info_file)
+assert info["CFBundleDisplayName"] == "CtrlProxy"
+assert info["CFBundleName"] == "CtrlProxy"
+assert info["CFBundleIcons"]["CFBundlePrimaryIcon"]["CFBundleIconName"] == "AppIcon"
+PY
 }
 
-@test "all maintained CtrlProxy build paths patch the generated runner" {
+@test "all maintained CtrlProxy UI-test startup paths use patched build artifacts" {
   local repository_root
   repository_root="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
 
@@ -77,4 +129,13 @@ teardown() {
 
   run grep -F 'patch-ctrl-proxy-ui-test-runner-icon.sh' "${repository_root}/scripts/local-dev/lib/ctrl-proxy-ios.sh"
   [ "$status" -eq 0 ]
+
+  run grep -F 'ctrl-proxy-build-for-testing.sh' "${repository_root}/scripts/test-ctrl-proxy-ios.sh"
+  [ "$status" -eq 0 ]
+
+  run grep -F 'test-without-building' "${repository_root}/scripts/test-ctrl-proxy-ios.sh"
+  [ "$status" -eq 0 ]
+
+  run grep -E '^[[:space:]]*nohup xcodebuild test([[:space:]]|$)' "${repository_root}/scripts/test-ctrl-proxy-ios.sh"
+  [ "$status" -eq 1 ]
 }

--- a/test/bats/ctrl-proxy-ui-test-runner-icon.bats
+++ b/test/bats/ctrl-proxy-ui-test-runner-icon.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+
+setup() {
+  TEST_ROOT="$(mktemp -d)"
+  STUB_DIR="$(mktemp -d)"
+  SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)/scripts/ios/patch-ctrl-proxy-ui-test-runner-icon.sh"
+  DERIVED_DATA="${TEST_ROOT}/DerivedData"
+  RUNNER_APP="${DERIVED_DATA}/Build/Products/Debug-iphonesimulator/CtrlProxyUITests-Runner.app"
+  mkdir -p "${RUNNER_APP}"
+  cat > "${RUNNER_APP}/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict><key>CFBundleIdentifier</key><string>dev.jasonpearson.automobile.ctrlproxy.uitests.xctrunner</string></dict></plist>
+PLIST
+
+  cat > "${STUB_DIR}/xcrun" <<'STUB'
+#!/bin/bash
+set -euo pipefail
+[[ "$1" == "actool" ]]
+shift
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --compile)
+      output_directory="$2"
+      shift 2
+      ;;
+    --output-partial-info-plist)
+      info_plist="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+mkdir -p "$output_directory"
+touch "$output_directory/Assets.car" "$output_directory/AppIcon60x60@2x.png" "$output_directory/AppIcon76x76@2x~ipad.png"
+cat > "$info_plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict><key>CFBundleIcons</key><dict><key>CFBundlePrimaryIcon</key><dict><key>CFBundleIconName</key><string>AppIcon</string></dict></dict></dict></plist>
+PLIST
+STUB
+  cat > "${STUB_DIR}/codesign" <<'STUB'
+#!/bin/bash
+exit 0
+STUB
+  chmod +x "${STUB_DIR}/xcrun" "${STUB_DIR}/codesign"
+}
+
+teardown() {
+  rm -rf "${TEST_ROOT}" "${STUB_DIR}"
+}
+
+@test "patches the generated runner with CtrlProxy's icon metadata" {
+  run env PATH="${STUB_DIR}:$PATH" bash "${SCRIPT}" --derived-data "${DERIVED_DATA}"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Patched CtrlProxyUITests-Runner"* ]]
+  [ -f "${RUNNER_APP}/Assets.car" ]
+  [ -f "${RUNNER_APP}/AppIcon60x60@2x.png" ]
+  [ -f "${RUNNER_APP}/AppIcon76x76@2x~ipad.png" ]
+  [ "$(plutil -extract CFBundleDisplayName raw "${RUNNER_APP}/Info.plist")" = "CtrlProxy" ]
+  [ "$(plutil -extract CFBundleName raw "${RUNNER_APP}/Info.plist")" = "CtrlProxy" ]
+  [ "$(plutil -extract CFBundleIcons.CFBundlePrimaryIcon.CFBundleIconName raw "${RUNNER_APP}/Info.plist")" = "AppIcon" ]
+}
+
+@test "all maintained CtrlProxy build paths patch the generated runner" {
+  local repository_root
+  repository_root="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+  run grep -F 'patch-ctrl-proxy-ui-test-runner-icon.sh' "${repository_root}/scripts/ios/ctrl-proxy-build-for-testing.sh"
+  [ "$status" -eq 0 ]
+
+  run grep -F 'patch-ctrl-proxy-ui-test-runner-icon.sh' "${repository_root}/scripts/ios/ctrl-proxy-create-ipa.sh"
+  [ "$status" -eq 0 ]
+
+  run grep -F 'patch-ctrl-proxy-ui-test-runner-icon.sh' "${repository_root}/scripts/local-dev/lib/ctrl-proxy-ios.sh"
+  [ "$status" -eq 0 ]
+}

--- a/test/bats/ctrl-proxy-ui-test-runner-icon.bats
+++ b/test/bats/ctrl-proxy-ui-test-runner-icon.bats
@@ -136,6 +136,21 @@ PY
   run grep -F 'test-without-building' "${repository_root}/scripts/test-ctrl-proxy-ios.sh"
   [ "$status" -eq 0 ]
 
+  run grep -F '! -name "automobile-runner-*.xctestrun"' "${repository_root}/scripts/test-ctrl-proxy-ios.sh"
+  [ "$status" -eq 0 ]
+
+  run grep -F '"*iphonesimulator*.xctestrun"' "${repository_root}/scripts/test-ctrl-proxy-ios.sh"
+  [ "$status" -eq 0 ]
+
   run grep -E '^[[:space:]]*nohup xcodebuild test([[:space:]]|$)' "${repository_root}/scripts/test-ctrl-proxy-ios.sh"
+  [ "$status" -eq 1 ]
+
+  run grep -F 'command -v xcpretty' "${repository_root}/scripts/ios/ctrl-proxy-build-for-testing.sh"
+  [ "$status" -eq 0 ]
+
+  run grep -F 'BUILD_STATUSES=("${PIPESTATUS[@]}")' "${repository_root}/scripts/ios/ctrl-proxy-build-for-testing.sh"
+  [ "$status" -eq 0 ]
+
+  run grep -E 'xcpretty --color.*\|\| true' "${repository_root}/scripts/ios/ctrl-proxy-build-for-testing.sh"
   [ "$status" -eq 1 ]
 }

--- a/test/bats/navigation-graph-sdk-event-integration.bats
+++ b/test/bats/navigation-graph-sdk-event-integration.bats
@@ -9,6 +9,7 @@ setup() {
   export CURL_URL_FILE="${MOCK_BIN}/curl-urls"
   export SESSION_OBSERVE_FILE="${MOCK_BIN}/session-observe"
   export DOCTOR_CALLS_FILE="${MOCK_BIN}/doctor-calls"
+  export HEALTH_ATTEMPTS_FILE="${MOCK_BIN}/health-attempts"
   export TARGET_APP_LAUNCHED_FILE="${MOCK_BIN}/target-app-launched"
   export INVOCATION_FILE="${MOCK_BIN}/invocations"
 }
@@ -32,6 +33,15 @@ SCRIPT
   make_mock xcrun 'exit 0'
   make_mock curl '
 url="${!#}"
+if [[ "$url" == */health ]]; then
+  health_attempts=0
+  [ -f "$HEALTH_ATTEMPTS_FILE" ] && health_attempts="$(cat "$HEALTH_ATTEMPTS_FILE")"
+  health_attempts=$((health_attempts + 1))
+  printf "%s\\n" "$health_attempts" > "$HEALTH_ATTEMPTS_FILE"
+  if [ "$health_attempts" -eq 1 ]; then
+    exit 1
+  fi
+fi
 if [[ "$url" == */sdk-events ]] && [[ ! -f "$SESSION_OBSERVE_FILE" ]]; then
   echo "SDK events were posted before the graph session was bound" >&2
   exit 1
@@ -98,6 +108,7 @@ fi
   [ "$status" -eq 0 ]
   [ "$(cat "$GRAPH_ATTEMPTS_FILE")" = "2" ]
   [ "$(cat "$DOCTOR_CALLS_FILE")" = "2" ]
+  [ "$(cat "$HEALTH_ATTEMPTS_FILE")" = "3" ]
   [ -f "$TARGET_APP_LAUNCHED_FILE" ]
   [[ "$output" == *"getNavigationGraph attempt 1 failed"* ]]
   launch_line="$(grep -n -- "launchApp --platform ios --appId com.apple.reminders --deviceId simulator-udid" "$INVOCATION_FILE" | head -n 1 | cut -d: -f1)"


### PR DESCRIPTION
## Summary

- patch Xcode's generated CtrlProxy UI-test runner with the CtrlProxy launcher icon and display name after every maintained build-for-testing flow
- compile the existing CtrlProxy asset catalog with `actool`, merge its icon metadata into the runner, and ad-hoc sign the simulator bundle
- cover the patcher and every maintained caller with focused BATS coverage

## Why

Xcode's generated `CtrlProxyUITests-Runner.app` was left on the Simulator Home Screen with its default name and placeholder icon, even though the actual CtrlProxy app has branded assets.

## Validation

- `bats test/bats/ctrl-proxy-ui-test-runner-icon.bats`
- `shellcheck scripts/ios/patch-ctrl-proxy-ui-test-runner-icon.sh scripts/ios/ctrl-proxy-build-for-testing.sh scripts/ios/ctrl-proxy-create-ipa.sh scripts/local-dev/lib/ctrl-proxy-ios.sh`
- `git diff --check`
- patched a real generated runner, installed it on an iOS Simulator, and confirmed it displays as `CtrlProxy` with the city launcher icon and launches successfully
