### PR TITLE
feat(video-server): rate-limit the client accept loop against connection storms (#4730)

### DIFF
--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
@@ -51,6 +51,41 @@ internal class ReconnectWindow(
 }
 
 /**
+ * Sliding-window admission limiter for the accept loop (issue #4730). Bounds how many connections
+ * the single `video-client-acceptor` thread will carry into the bounded token handshake per
+ * [windowMs], so a connection storm cannot wedge that thread inside repeated
+ * [VideoStreamWriter.HANDSHAKE_READ_TIMEOUT_MS] reads or churn CPU. Timestamps are supplied by an
+ * injected monotonic clock so the limit is deterministically fake-testable; only the acceptor
+ * thread touches an instance, so it needs no internal synchronization.
+ */
+internal class ConnectionRateLimiter(
+  private val clock: () -> Long,
+  private val maxConnections: Int,
+  private val windowMs: Long,
+) {
+  // Bounded by maxConnections: a rejected attempt records nothing, so the deque never grows beyond
+  // the admitted set still inside the trailing window.
+  private val admittedAtMs = ArrayDeque<Long>()
+
+  /**
+   * Record an admission at the current time and report whether it is within the rate. Evicts
+   * timestamps that fell out of the trailing [windowMs] first, then admits (and remembers) the
+   * attempt only while fewer than [maxConnections] remain in the window; otherwise returns false
+   * and remembers nothing, so a sustained storm neither grows the deque nor advances the window.
+   */
+  fun tryAdmit(): Boolean {
+    val now = clock()
+    val cutoff = now - windowMs
+    while (admittedAtMs.isNotEmpty() && admittedAtMs.first() <= cutoff) {
+      admittedAtMs.removeFirst()
+    }
+    if (admittedAtMs.size >= maxConnections) return false
+    admittedAtMs.addLast(now)
+    return true
+  }
+}
+
+/**
  * Writes encoded video packets to a LocalSocket using the VideoStreamProtocol binary framing. A
  * disconnected client is replaceable: the writer retains codec configuration plus the latest
  * complete keyframe and replays them before live packets to the next client.
@@ -82,6 +117,9 @@ class VideoStreamWriter(
   private val lock = Any()
   private val packetCache = VideoPacketCache()
   private val reconnectWindow = ReconnectWindow(nowMs, CLIENT_RECONNECT_WINDOW_MS)
+  // Bounds the accept loop's per-connection handshake work against a storm (issue #4730).
+  private val connectionRateLimiter =
+    ConnectionRateLimiter(nowMs, MAX_ACCEPTS_PER_RATE_WINDOW, ACCEPT_RATE_WINDOW_MS)
 
   // Decouple encode from transport (#4749): the encode loop offers to a drop-oldest single-slot
   // handoff and returns immediately; this dedicated thread drains it into the socket, so a stalled
@@ -130,6 +168,19 @@ class VideoStreamWriter(
      * immediately on connect.
      */
     const val HANDSHAKE_READ_TIMEOUT_MS = 2_000L
+
+    /**
+     * Admission ceiling for the accept loop: at most this many connections per
+     * [ACCEPT_RATE_WINDOW_MS] are carried into the bounded token handshake (issue #4730). A
+     * connection storm past this budget is dropped in O(1) — after the cheap UID gate, before the
+     * blocking handshake read — so it can neither wedge the single acceptor thread inside repeated
+     * [HANDSHAKE_READ_TIMEOUT_MS] reads nor churn CPU. Generous relative to legitimate reconnects,
+     * which arrive at most a few times per session recovery.
+     */
+    const val MAX_ACCEPTS_PER_RATE_WINDOW = 10
+
+    /** Trailing window over which [MAX_ACCEPTS_PER_RATE_WINDOW] admissions are counted. */
+    const val ACCEPT_RATE_WINDOW_MS = 1_000L
 
     /**
      * Peer UIDs allowed to receive the screen stream, checked against `SO_PEERCRED` on every
@@ -291,6 +342,26 @@ class VideoStreamWriter(
           client.close()
         } catch (_: IOException) {
           // Best-effort close of a rejected peer; nothing was written, so a failure here is benign.
+        }
+        continue
+      }
+
+      // Bound the accept loop against a connection storm (issue #4730). The check sits after the
+      // O(1) UID gate — so untrusted app-UID floods are already filtered and never consume the
+      // budget or throttle a legitimate host reconnect — and ahead of the blocking token handshake,
+      // which is the expensive per-connection work a flood would otherwise use to wedge this single
+      // acceptor thread for HANDSHAKE_READ_TIMEOUT_MS each. Over-budget connections are dropped in
+      // O(1) without touching shared state, so the attached client is undisturbed.
+      if (!connectionRateLimiter.tryAdmit()) {
+        println(
+          "VIDEO_CLIENT_RATE_LIMITED socket=$socketName exceeded " +
+            "$MAX_ACCEPTS_PER_RATE_WINDOW accepts/${ACCEPT_RATE_WINDOW_MS}ms; disconnecting"
+        )
+        try {
+          client.close()
+        } catch (_: IOException) {
+          // Best-effort close of a throttled peer; nothing was written, so a failure here is
+          // benign.
         }
         continue
       }

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriterTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriterTest.kt
@@ -203,6 +203,29 @@ class VideoStreamWriterTest {
   }
 
   /**
+   * A connection whose [readFully] increments [handshakeReads] and always returns null (a silent
+   * peer). Lets a test assert that a rate-limited connection is dropped *before* the token
+   * handshake ever reads from it, i.e. the guard bounds the expensive per-connection work, not just
+   * the attach.
+   */
+  private class HandshakeCountingConnection(override val peerUid: Int = 2000) :
+    VideoClientConnection {
+    val handshakeReads = AtomicInteger()
+    @Volatile var closed = false
+    override val outputStream: OutputStream = ByteArrayOutputStream()
+    override val inputStream: InputStream = ByteArrayInputStream(ByteArray(0))
+
+    override fun readFully(count: Int, timeoutMs: Long): ByteArray? {
+      handshakeReads.incrementAndGet()
+      return null
+    }
+
+    override fun close() {
+      closed = true
+    }
+  }
+
+  /**
    * Drives [VideoStreamWriter.acceptClients] deterministically: each queued action produces the
    * next `accept()` result (a connection, a thrown [IOException], or the end of the queue which
    * returns `null` so the acceptor loop stops).
@@ -514,6 +537,84 @@ class VideoStreamWriterTest {
     assertEquals("only the allowed client attaches", 1, attachCount.get())
     assertFalse("the allowed client must not be displaced by a rejected peer", allowed.closed)
     assertTrue("the intruder must be disconnected", intruder.closed)
+    subject.stop()
+  }
+
+  // --- connection-storm rate limit (issue #4730) ----------------------------------------------
+
+  @Test
+  fun rateLimiterAdmitsUpToMaxThenRejectsWithinWindow() {
+    var now = 1_000L
+    val limiter = ConnectionRateLimiter({ now }, maxConnections = 3, windowMs = 1_000L)
+
+    assertTrue(limiter.tryAdmit())
+    assertTrue(limiter.tryAdmit())
+    assertTrue(limiter.tryAdmit())
+    assertFalse("a 4th admission in the same window is throttled", limiter.tryAdmit())
+
+    // Still inside the window: capacity has not returned.
+    now = 1_500L
+    assertFalse("mid-window the budget is still exhausted", limiter.tryAdmit())
+
+    // Once the window slides past the earliest admissions, capacity frees up again.
+    now = 2_001L
+    assertTrue("capacity returns after the window slides past old admissions", limiter.tryAdmit())
+  }
+
+  @Test
+  fun connectionStormBeyondRateLimitIsDroppedWithoutDisturbingAdmittedClients() {
+    val now = 1_000L
+    val max = VideoStreamWriter.MAX_ACCEPTS_PER_RATE_WINDOW
+    // Every connection is an allowed peer with the handshake disabled, so only the rate limit — not
+    // the UID gate or token handshake — can reject one. A storm of max + 5 lands in one window.
+    val connections = List(max + 5) { FakeClientConnection() }
+    val attachCount = AtomicInteger()
+    val subject = writer({ now }, FakeServerSocket(connections.map { conn -> { conn } }))
+
+    subject.bindServerSocket()
+    subject.acceptClients { attachCount.incrementAndGet() }
+
+    assertEquals("only the rate-limit budget of connections is admitted", max, attachCount.get())
+    // The last admitted connection is the current client and stays attached.
+    assertFalse("the last admitted client stays attached", connections[max - 1].closed)
+    // Earlier admits were displaced by the reconnect of the next admitted client.
+    for (i in 0 until max - 1) {
+      assertTrue("displaced admitted connection $i must be closed", connections[i].closed)
+    }
+    // Every connection beyond the budget is dropped in O(1) without ever attaching.
+    for (i in max until connections.size) {
+      assertTrue("throttled connection $i must be closed", connections[i].closed)
+    }
+    subject.stop()
+  }
+
+  @Test
+  fun throttledConnectionNeverReachesTheTokenHandshake() {
+    val now = 1_000L
+    val max = VideoStreamWriter.MAX_ACCEPTS_PER_RATE_WINDOW
+    val token = "session-0001"
+    // Fill the budget with allowed peers that carry no handshake bytes: with the handshake enabled
+    // they would each block for the full HANDSHAKE_READ_TIMEOUT_MS. Once the budget is exhausted
+    // the
+    // storm connections must be dropped by the rate limit BEFORE that blocking read, proving the
+    // guard bounds the expensive per-connection work rather than merely the attach.
+    val budgetFillers = List(max) { FakeClientConnection(handshake = handshakeFrame(token)) }
+    val stormBeyondBudget = List(3) { HandshakeCountingConnection() }
+    val actions: List<() -> VideoClientConnection?> =
+      budgetFillers.map { c -> { c } } + stormBeyondBudget.map { c -> { c } }
+    val subject = writer({ now }, FakeServerSocket(actions), expectedToken = token)
+
+    subject.bindServerSocket()
+    subject.acceptClients {}
+
+    for ((i, conn) in stormBeyondBudget.withIndex()) {
+      assertEquals(
+        "throttled storm connection $i must be dropped before the handshake read",
+        0,
+        conn.handshakeReads.get(),
+      )
+      assertTrue("throttled storm connection $i must be closed", conn.closed)
+    }
     subject.stop()
   }
 


### PR DESCRIPTION
Closes [#4730](https://github.com/kaeawc/auto-mobile/issues/4730)

## Verify-against-current-main: the ordering AC is already satisfied

I re-read the current `acceptClients()` before writing any code. The primary acceptance criteria of this issue — *authenticate before evicting the current client* — are **already met on `main`** by the two merged prerequisites:

- [#4728](https://github.com/kaeawc/auto-mobile/issues/4728) added the `SO_PEERCRED` UID gate.
- [#4729](https://github.com/kaeawc/auto-mobile/issues/4729) added the pre-stream token handshake.

Both checks run **before** the `synchronized(lock) { closeClientLocked(); clientSocket = client; ... }` eviction/install block. Concretely, the accept path is now:

```
accept() -> UID gate -> token handshake -> [evict prior + install new]
```

A rejected peer (bad UID, or bad/absent/timed-out token) hits `continue` and closes its own socket **without ever reaching `closeClientLocked()`**, so the currently-attached legitimate client is neither evicted nor sent a byte. This is already covered by two existing tests:

- `disallowedPeerDoesNotDisplaceTheCurrentAllowedClient` (rejected UID leaves the attached client undisturbed)
- `handshakeRejectionDoesNotDisplaceTheCurrentAuthenticatedClient` (same, via the token gate)

The handshake is already **bounded** — `HANDSHAKE_READ_TIMEOUT_MS = 2_000L`, enforced by the seam's total-deadline `readFully` — so a silent connector cannot hold the accept slot open indefinitely. That confirms the "timeout" half of the issue's "bound the accept/handshake work (timeout + simple rate limit)" ask.

**`CLIENT_RECONNECT_WINDOW_MS` does not widen a hijack race.** Because authentication now precedes eviction, a rogue connector cannot displace the current client at all — during the 5s warm window a replacement connection must still pass the UID gate and token handshake before it can attach. The warm window only keeps the encoder/VirtualDisplay alive; it grants no privilege, so it does not open a hijack window.

## What this PR adds: the remaining rate-limit / storm-guard residual

The only thing the issue asked for that was **not** already present is the *simple rate limit* to keep a connection storm from wedging the acceptor thread or churning CPU. This PR adds it.

- New `ConnectionRateLimiter` (sliding window, injected monotonic clock, no internal locking — only the single acceptor thread touches it). `tryAdmit()` evicts timestamps outside the trailing window, admits while under `MAX_ACCEPTS_PER_RATE_WINDOW` (10) per `ACCEPT_RATE_WINDOW_MS` (1000ms), and records nothing when over budget (so a sustained storm neither grows the deque nor advances the window).
- The check is placed **after the O(1) UID gate** and **ahead of the blocking token handshake**:
  - Untrusted app-UID floods (UID >= 10000) are already filtered by the UID gate, so they never consume the budget and can never throttle a legitimate host reconnect.
  - The budget therefore protects the *expensive* per-connection work — the up-to-2s handshake read — which is what a flood would otherwise use to serialize/wedge the single `video-client-acceptor` thread.
  - Over-budget connections are dropped in O(1) without touching any shared state, so the attached client is undisturbed.

The clock is the already-injected `nowMs` seam, so the limiter is deterministically fake-testable (no real time, no flakes).

## Tests

- `rateLimiterAdmitsUpToMaxThenRejectsWithinWindow` — admits up to the budget, rejects within the window, and regains capacity once the window slides past old admissions.
- `connectionStormBeyondRateLimitIsDroppedWithoutDisturbingAdmittedClients` — a storm of `budget + 5` connections in one window is capped at the budget; the last admitted client stays attached and every over-budget connection is closed.
- `throttledConnectionNeverReachesTheTokenHandshake` — a rate-limited connection is dropped **before** its handshake `readFully` is ever called (asserts the guard bounds the expensive work, not merely the attach).

The pre-existing auth-before-evict tests remain and continue to cover the ordering AC.

## Validation

- `sdk.dir` set in `android/local.properties`, JDK 21 (Zulu 21.0.9).
- `./gradlew :video-server:test` — **BUILD SUCCESSFUL**, `VideoStreamWriterTest` 23 tests, 0 failures / 0 skipped (3 new tests confirmed executed in the JUnit XML report).
- `ktfmt --google-style` (pinned 0.64) — clean on both changed files.
