### PR TITLE
security(video-server): harden lease file — no cleartext token at rest (#4731)

### DIFF
--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoSessionLease.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoSessionLease.kt
@@ -4,6 +4,7 @@ import android.os.SystemClock
 import android.system.Os
 import java.io.File
 import java.security.MessageDigest
+import java.util.HexFormat
 import org.json.JSONObject
 
 /**
@@ -68,11 +69,8 @@ private object JsonVideoSessionLeaseSerializer : VideoSessionLeaseSerializer {
  * re-derives to prove ownership.
  */
 internal fun sessionTokenSha256Hex(token: String): String =
-  MessageDigest.getInstance("SHA-256").digest(token.toByteArray(Charsets.US_ASCII)).joinToString(
-    ""
-  ) {
-    "%02x".format(it.toInt() and 0xFF)
-  }
+  HexFormat.of()
+    .formatHex(MessageDigest.getInstance("SHA-256").digest(token.toByteArray(Charsets.US_ASCII)))
 
 object VideoSessionArguments {
   private const val DEFAULT_SOCKET_NAME = "automobile_video"

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoSessionLease.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoSessionLease.kt
@@ -1,15 +1,21 @@
 package dev.jasonpearson.automobile.video
 
 import android.os.SystemClock
+import android.system.Os
 import java.io.File
+import java.security.MessageDigest
 import org.json.JSONObject
 
 /**
  * Device-side record of one host-owned video-server process.
  *
- * The host uses these records only after their heartbeat expires. The token is included in both
- * this file and the process command line so a reused PID can never make stale cleanup terminate an
- * unrelated process.
+ * The host uses these records only after their heartbeat expires. To identify the process for
+ * targeted cleanup a reused PID can never spoof, the lease records the opaque per-session
+ * `socketName` (also the on-disk filename and a `--socket-name` argv token) rather than the raw
+ * session token: the token is now the on-wire auth secret (issue #4729), so it is never written to
+ * disk in cleartext (issue #4731). Only its SHA-256 hash is persisted, which a lease owner can
+ * re-derive from the token it holds to confirm ownership without the file ever disclosing the
+ * secret.
  */
 data class VideoSessionOptions(
   val socketName: String,
@@ -21,7 +27,7 @@ data class VideoSessionOptions(
 
 data class VideoSessionLeaseRecord(
   val socketName: String,
-  val sessionToken: String,
+  val sessionTokenHash: String,
   val pid: Int,
   val ownerPid: Long?,
   val deviceSerial: String?,
@@ -38,9 +44,12 @@ fun interface VideoSessionLeaseSerializer {
 private object JsonVideoSessionLeaseSerializer : VideoSessionLeaseSerializer {
   override fun serialize(record: VideoSessionLeaseRecord): String =
     JSONObject()
-      .put("version", 1)
+      // Bumped from 1: the record now carries `sessionTokenHash` in place of the raw
+      // `sessionToken` (issue #4731). Older-shape leases lack `sessionTokenHash`; the host
+      // validator rejects them and its `*.json` sweep reclaims them.
+      .put("version", 2)
       .put("socketName", record.socketName)
-      .put("sessionToken", record.sessionToken)
+      .put("sessionTokenHash", record.sessionTokenHash)
       .put("pid", record.pid)
       .put("ownerPid", record.ownerPid)
       .put("deviceSerial", record.deviceSerial)
@@ -50,6 +59,20 @@ private object JsonVideoSessionLeaseSerializer : VideoSessionLeaseSerializer {
       .put("heartbeatElapsedRealtimeMs", record.heartbeatElapsedRealtimeMs)
       .toString()
 }
+
+/**
+ * SHA-256 hex of a session token, the only token-derived value ever written to a lease file
+ * (issue #4731). `MessageDigest` is the JDK's canonical digest primitive (the same one
+ * [VideoHandshake] uses for its constant-time compare); the host mirrors this with
+ * `createHash("sha256")` over the ASCII bytes so both ends agree on the hash a lease owner
+ * re-derives to prove ownership.
+ */
+internal fun sessionTokenSha256Hex(token: String): String =
+  MessageDigest.getInstance("SHA-256").digest(token.toByteArray(Charsets.US_ASCII)).joinToString(
+    ""
+  ) {
+    "%02x".format(it.toInt() and 0xFF)
+  }
 
 object VideoSessionArguments {
   private const val DEFAULT_SOCKET_NAME = "automobile_video"
@@ -85,9 +108,16 @@ class VideoSessionLease(
   private val elapsedRealtimeMs: () -> Long = SystemClock::elapsedRealtime,
   private val leaseDirectory: File = File(LEASE_DIRECTORY),
   private val serializer: VideoSessionLeaseSerializer = JsonVideoSessionLeaseSerializer,
+  // Injected so JVM unit tests (where `android.system.Os` is only a compile stub) can supply a
+  // recording fake. On device the default delegates to the real syscall.
+  private val chmod: (path: String, mode: Int) -> Unit = { path, mode -> Os.chmod(path, mode) },
 ) {
   private val token = requireNotNull(options.token)
-  private val leaseFile = File(leaseDirectory, "$token.json")
+  private val sessionTokenHash = sessionTokenSha256Hex(token)
+  // The filename is the opaque, non-secret socket name (issue #4731), never the token. It is
+  // world-readable via `/proc/net/unix` already, so it discloses nothing the token did not, and it
+  // is the stable id the host reconcile/sweep matches a lease to its session and forward on.
+  private val leaseFile = File(leaseDirectory, "${options.socketName}.json")
   private val startedAtMs = nowMs()
 
   @Volatile private var running = false
@@ -98,6 +128,8 @@ class VideoSessionLease(
     if (!leaseDirectory.mkdirs() && !leaseDirectory.isDirectory) {
       throw IllegalStateException("Unable to create video session lease directory")
     }
+    // Tighten the directory to owner-only so a peer process cannot even enumerate lease files.
+    restrictPermissions(leaseDirectory, DIRECTORY_MODE)
 
     running = true
     writeHeartbeat()
@@ -139,7 +171,7 @@ class VideoSessionLease(
         serializer.serialize(
           VideoSessionLeaseRecord(
             socketName = options.socketName,
-            sessionToken = token,
+            sessionTokenHash = sessionTokenHash,
             pid = processId,
             ownerPid = options.ownerPid,
             deviceSerial = options.deviceSerial,
@@ -151,12 +183,37 @@ class VideoSessionLease(
         )
       val temporary = File(leaseFile.parentFile, "${leaseFile.name}.tmp")
       temporary.writeText(payload)
+      // Restrict the temp file to owner-only BEFORE the atomic rename so the lease is never visible
+      // to another process, not even for the instant between create and rename (issue #4731).
+      restrictPermissions(temporary, FILE_MODE)
       if (!temporary.renameTo(leaseFile)) {
         temporary.copyTo(leaseFile, overwrite = true)
+        // copyTo creates a fresh destination inode with default perms; re-tighten it.
+        restrictPermissions(leaseFile, FILE_MODE)
         temporary.delete()
       }
     } catch (error: Exception) {
-      System.err.println("VIDEO_SESSION_HEARTBEAT_FAILED token=$token error=${error.message}")
+      // The socket name (not the secret token) identifies the failing session in logs.
+      System.err.println(
+        "VIDEO_SESSION_HEARTBEAT_FAILED socket=${options.socketName} error=${error.message}"
+      )
+    }
+  }
+
+  /**
+   * Best-effort `chmod` to [mode]. A failure here (e.g. an exotic ROM where `/data/local/tmp`
+   * denies the syscall) must not sink the heartbeat, whose liveness value outweighs the hardening:
+   * it is logged and swallowed so the lease still lands. The `.tmp` file is created by this same
+   * owner-only process, so even without the chmod the exposure window is narrow.
+   */
+  private fun restrictPermissions(file: File, mode: Int) {
+    try {
+      chmod(file.absolutePath, mode)
+    } catch (error: Exception) {
+      System.err.println(
+        "VIDEO_SESSION_CHMOD_FAILED socket=${options.socketName} path=${file.absolutePath} " +
+          "mode=$mode error=${error.message}"
+      )
     }
   }
 
@@ -164,11 +221,20 @@ class VideoSessionLease(
     const val LEASE_DIRECTORY = "/data/local/tmp/automobile-video-sessions"
     private const val HEARTBEAT_INTERVAL_MS = 5_000L
 
+    /** `0700`: owner-only rwx on the lease directory (issue #4731). */
+    private const val DIRECTORY_MODE = 448
+
+    /** `0600`: owner-only rw on each lease file (issue #4731). */
+    private const val FILE_MODE = 384
+
     /**
      * Describes a lease that owns [socketName], if one exists for another token. This is
      * diagnostic-only: collision handling never kills a process.
      */
     fun collisionDiagnostic(socketName: String, requestedToken: String?): String? {
+      // Compare hashes, never the raw token: the lease stores only `sessionTokenHash` (issue
+      // #4731), so a mismatch is detected by hashing the requested token and comparing digests.
+      val requestedTokenHash = requestedToken?.let(::sessionTokenSha256Hex)
       val record =
         File(LEASE_DIRECTORY)
           .listFiles { file -> file.extension == "json" }
@@ -182,15 +248,15 @@ class VideoSessionLease(
           }
           ?.firstOrNull {
             it.optString("socketName") == socketName &&
-              it.optString("sessionToken") != requestedToken
+              it.optString("sessionTokenHash") != requestedTokenHash
           } ?: return null
 
       val heartbeatAtMs = record.optLong("heartbeatAtMs", 0)
       val ageMs = (System.currentTimeMillis() - heartbeatAtMs).coerceAtLeast(0)
       return ("VIDEO_SESSION_COLLISION socket=$socketName " +
         "existingOwnerPid=${record.optLong("ownerPid", -1)} " +
-        "existingToken=${record.optString("sessionToken")} " +
-        "requestedToken=$requestedToken tokenMismatch=true ageMs=$ageMs")
+        "existingTokenHash=${record.optString("sessionTokenHash")} " +
+        "tokenMismatch=true ageMs=$ageMs")
     }
   }
 }

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoSessionLeaseTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoSessionLeaseTest.kt
@@ -1,6 +1,7 @@
 package dev.jasonpearson.automobile.video
 
 import java.io.File
+import java.security.MessageDigest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -11,37 +12,121 @@ import org.junit.rules.TemporaryFolder
 class VideoSessionLeaseTest {
   @get:Rule val temporaryFolder = TemporaryFolder()
 
+  private val chmodCalls = mutableListOf<Pair<String, Int>>()
+  private val recordingChmod: (String, Int) -> Unit = { path, mode -> chmodCalls.add(path to mode) }
+
+  // The production serializer uses `org.json.JSONObject`, which is only an android.jar compile stub
+  // and unavailable on the JVM test runtime. Inject a capturing serializer so tests exercise the
+  // real record shape and file lifecycle without loading org.json.
+  private var capturedRecord: VideoSessionLeaseRecord? = null
+  private val capturingSerializer = VideoSessionLeaseSerializer { record ->
+    capturedRecord = record
+    // A minimal but valid stand-in payload; the record itself is asserted, not these bytes.
+    "{\"sessionTokenHash\":\"${record.sessionTokenHash}\",\"socketName\":\"${record.socketName}\"}"
+  }
+
+  private fun leaseWith(
+    leaseDirectory: File,
+    chmod: (String, Int) -> Unit = recordingChmod,
+    socketName: String = "automobile_video_session",
+    token: String = "session-0001",
+  ): VideoSessionLease =
+    VideoSessionLease(
+      options =
+        VideoSessionOptions(
+          socketName = socketName,
+          token = token,
+          ownerPid = 456,
+          deviceSerial = "emulator-5554",
+          forwardPort = 61234,
+        ),
+      processId = 123,
+      nowMs = { 1_000L },
+      elapsedRealtimeMs = { 42_000L },
+      leaseDirectory = leaseDirectory,
+      serializer = capturingSerializer,
+      chmod = chmod,
+    )
+
+  private fun expectedHash(token: String): String =
+    MessageDigest.getInstance("SHA-256").digest(token.toByteArray(Charsets.US_ASCII)).joinToString(
+      ""
+    ) {
+      "%02x".format(it.toInt() and 0xFF)
+    }
+
   @Test
   fun writesHeartbeatInDeviceElapsedRealtimeDomainAndRemovesLeaseOnStop() {
     val leaseDirectory = File(temporaryFolder.root, "leases")
-    var writtenRecord: VideoSessionLeaseRecord? = null
-    val lease =
-      VideoSessionLease(
-        options =
-          VideoSessionOptions(
-            socketName = "automobile_video_session",
-            token = "session-0001",
-            ownerPid = 456,
-            deviceSerial = "emulator-5554",
-            forwardPort = 61234,
-          ),
-        processId = 123,
-        nowMs = { 1_000L },
-        elapsedRealtimeMs = { 42_000L },
-        leaseDirectory = leaseDirectory,
-        serializer =
-          VideoSessionLeaseSerializer { record ->
-            writtenRecord = record
-            "{}"
-          },
-      )
+    val lease = leaseWith(leaseDirectory)
 
     lease.start()
 
-    val leaseFile = File(leaseDirectory, "session-0001.json")
+    // The on-disk filename is derived from the non-secret socket name, never the token (#4731).
+    val leaseFile = File(leaseDirectory, "automobile_video_session.json")
     assertTrue(leaseFile.exists())
-    assertEquals(42_000L, writtenRecord?.heartbeatElapsedRealtimeMs)
-    assertEquals(1_000L, writtenRecord?.heartbeatAtMs)
+    assertEquals(42_000L, capturedRecord?.heartbeatElapsedRealtimeMs)
+    assertEquals(1_000L, capturedRecord?.heartbeatAtMs)
+
+    lease.stop()
+    assertFalse(leaseFile.exists())
+  }
+
+  @Test
+  fun persistsOnlyTheTokenHashNeverTheRawToken() {
+    val leaseDirectory = File(temporaryFolder.root, "leases")
+    val token = "session-0001"
+    val lease = leaseWith(leaseDirectory, token = token)
+
+    lease.start()
+
+    // The record carries the SHA-256 hash, never the raw token (issue #4731).
+    val record = requireNotNull(capturedRecord)
+    assertEquals(expectedHash(token), record.sessionTokenHash)
+    assertFalse(record.sessionTokenHash == token)
+
+    // Nothing written to disk (filename or contents) discloses the raw token.
+    val leaseFile = File(leaseDirectory, "automobile_video_session.json")
+    val contents = leaseFile.readText()
+    assertFalse(contents.contains(token))
+    assertFalse(leaseFile.absolutePath.contains(token))
+    assertTrue(contents.contains(expectedHash(token)))
+
+    lease.stop()
+  }
+
+  @Test
+  fun restrictsDirectoryAndFilePermissionsWithTheTempFileTightenedBeforeRename() {
+    val leaseDirectory = File(temporaryFolder.root, "leases")
+    val lease = leaseWith(leaseDirectory)
+
+    lease.start()
+
+    val dirPath = leaseDirectory.absolutePath
+    val tmpPath = File(leaseDirectory, "automobile_video_session.json.tmp").absolutePath
+    // Directory tightened to 0700 (448).
+    assertTrue(chmodCalls.contains(dirPath to 448))
+    // The temp file is tightened to 0600 (384) BEFORE it is renamed into place: there is no
+    // world-readable window on the final lease file (issue #4731).
+    assertTrue(chmodCalls.contains(tmpPath to 384))
+    val dirIndex = chmodCalls.indexOf(dirPath to 448)
+    val tmpIndex = chmodCalls.indexOf(tmpPath to 384)
+    assertTrue("directory chmod precedes the file chmod", dirIndex < tmpIndex)
+
+    lease.stop()
+  }
+
+  @Test
+  fun heartbeatSurvivesAChmodFailure() {
+    val leaseDirectory = File(temporaryFolder.root, "leases")
+    val lease =
+      leaseWith(leaseDirectory, chmod = { _, _ -> throw RuntimeException("chmod denied") })
+
+    lease.start()
+
+    // A chmod failure is swallowed; the lease still lands so liveness is preserved.
+    val leaseFile = File(leaseDirectory, "automobile_video_session.json")
+    assertTrue(leaseFile.exists())
 
     lease.stop()
     assertFalse(leaseFile.exists())

--- a/src/features/webrtc/PersistentEncoderH264Source.ts
+++ b/src/features/webrtc/PersistentEncoderH264Source.ts
@@ -1,4 +1,5 @@
 import { connect as netConnect } from "node:net";
+import { createHash } from "node:crypto";
 import { ActionableError, type BootedDevice } from "../../models";
 import { logger } from "../../utils/logger";
 import { defaultIdGenerator, type IdGenerator } from "../../utils/IdGenerator";
@@ -191,7 +192,13 @@ export const defaultActiveVideoSessionRegistry: ActiveVideoSessionRegistry =
 
 interface RawVideoServerLease {
   socketName: string;
-  sessionToken: string;
+  /**
+   * SHA-256 hex of the session token (issue #4731). The lease never stores the raw token — it is
+   * the on-wire auth secret (issue #4729), so cleartext-at-rest would be a disclosure path. A lease
+   * owner re-derives this hash from the token it holds (see {@link hashSessionToken}) to confirm
+   * ownership; foreign-lease reclaim matches on the non-secret `socketName` instead.
+   */
+  sessionTokenHash: string;
   ownerPid: number;
   deviceSerial: string;
   pid: number;
@@ -201,7 +208,20 @@ interface RawVideoServerLease {
   heartbeatElapsedRealtimeMs?: number;
 }
 
-interface VideoServerLease extends VideoServerSession, Omit<RawVideoServerLease, "sessionToken"> {}
+/**
+ * A validated lease read back from the device. Identical to the on-disk record: the raw token is no
+ * longer recoverable from disk, so a parsed lease carries only the non-secret `socketName` (the
+ * filename/id the reconcile+sweep match on) and the token's hash.
+ */
+type VideoServerLease = RawVideoServerLease;
+
+/**
+ * SHA-256 hex of a session token, matching the device's `sessionTokenSha256Hex` (issue #4731). Used
+ * to confirm an owned lease belongs to this session without the token ever touching disk.
+ */
+function hashSessionToken(token: string): string {
+  return createHash("sha256").update(token, "ascii").digest("hex");
+}
 
 const defaultConnector: SocketConnector = (port, signal) =>
   new Promise<StreamSocket>((resolve, reject) => {
@@ -360,6 +380,11 @@ function isSafeSessionToken(value: string): boolean {
   return /^[A-Za-z0-9-]{8,80}$/.test(value);
 }
 
+/** Lowercase SHA-256 hex, the only token-derived value now persisted (issue #4731). */
+function isSessionTokenHash(value: unknown): value is string {
+  return typeof value === "string" && /^[a-f0-9]{64}$/.test(value);
+}
+
 /** Mirrors `VideoSessionArguments.SAFE_SOCKET_NAME` on the device side. */
 const SAFE_SOCKET_NAME_PATTERN = /^[A-Za-z0-9_.-]{1,100}$/;
 
@@ -383,9 +408,11 @@ function isVideoServerLease(value: unknown): value is RawVideoServerLease {
   }
   const lease = value as Record<string, unknown>;
   return [
-    typeof lease.sessionToken === "string",
-    typeof lease.sessionToken === "string" && isSafeSessionToken(lease.sessionToken),
+    isSessionTokenHash(lease.sessionTokenHash),
     typeof lease.socketName === "string",
+    // The socket name is the on-disk filename/id (issue #4731); require the safe shape so it is
+    // never interpolated into a `cat`/`rm` path we did not expect.
+    typeof lease.socketName === "string" && SAFE_SOCKET_NAME_PATTERN.test(lease.socketName),
     typeof lease.deviceSerial === "string",
     isPositiveInteger(lease.ownerPid),
     isPositiveInteger(lease.pid),
@@ -405,12 +432,7 @@ function parseLeases(output: string): VideoServerLease[] {
         if (!isVideoServerLease(parsed)) {
           return [];
         }
-        return [
-          {
-            ...parsed,
-            token: parsed.sessionToken,
-          },
-        ];
+        return [parsed];
       } catch (error) {
         logger.debug(`[PersistentEncoderH264Source] ignoring malformed video session lease: ${error}`);
         return [];
@@ -1616,7 +1638,7 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
 
     // Sweep corrupt/orphaned files regardless of how many leases parsed: a
     // wholly-unparseable directory yields zero leases but still needs cleanup.
-    await this.sweepOrphanLeaseFiles(adb, new Set(leases.map(lease => `${lease.token}.json`)));
+    await this.sweepOrphanLeaseFiles(adb, new Set(leases.map(lease => `${lease.socketName}.json`)));
 
     // Sweep host forwards with no backing lease at all (device server
     // self-expired and deleted its own lease, or the daemon was SIGKILLed). Runs
@@ -1638,7 +1660,7 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
         continue;
       }
       logger.info(
-        `[PersistentEncoderH264Source] stale-session-cleanup token=${lease.token} reason=${decision}`
+        `[PersistentEncoderH264Source] stale-session-cleanup socket=${lease.socketName} reason=${decision}`
       );
       await this.removeForwardIfMatching(adb, lease.forwardPort, lease.socketName);
       await this.terminateProcessIfMatching(adb, lease);
@@ -1802,7 +1824,7 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     expectedProcessId: number | null
   ): Promise<void> {
     const adb = this.adbFactory.create(this.options.device);
-    const lease = await this.readLease(adb, session.token);
+    const lease = await this.readLease(adb, session.socketName);
     if (lease && this.isOwnedSessionLease(lease, session, expectedProcessId)) {
       await this.removeForwardIfMatching(adb, lease.forwardPort, lease.socketName);
       await this.removeOwnedForward(adb, port, session.socketName, lease.forwardPort);
@@ -1812,7 +1834,7 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     }
     if (lease) {
       logger.warn(
-        `[PersistentEncoderH264Source] refusing owned-session process cleanup token=${session.token}: lease identity or PID mismatch`
+        `[PersistentEncoderH264Source] refusing owned-session process cleanup socket=${session.socketName}: lease identity or PID mismatch`
       );
       await this.removeOwnedForward(adb, port, session.socketName);
       return;
@@ -1828,7 +1850,9 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     // A cancellation can arrive after the server persisted its lease but before
     // VIDEO_SESSION_READY handed its PID back to the host. The lease identity
     // plus terminateProcessIfMatching's argv check still make owned cleanup safe.
-    return lease.token === session.token &&
+    // The token itself is no longer on disk (issue #4731), so ownership is confirmed by
+    // re-hashing this session's token and matching the persisted hash.
+    return lease.sessionTokenHash === hashSessionToken(session.token) &&
       lease.socketName === session.socketName &&
       lease.ownerPid === session.ownerPid &&
       lease.deviceSerial === session.deviceSerial &&
@@ -1848,15 +1872,15 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
 
   private async readLease(
     adb: ReturnType<AdbClientFactory["create"]>,
-    token: string
+    socketName: string
   ): Promise<VideoServerLease | null> {
     try {
       const result = await this.withTimeout(
-        adb.executeCommand(`shell cat ${VIDEO_SERVER_LEASE_DIRECTORY}/${token}.json`),
+        adb.executeCommand(`shell cat ${VIDEO_SERVER_LEASE_DIRECTORY}/${socketName}.json`),
         this.teardownTimeoutMs,
         "adb read owned video session lease"
       );
-      return parseLeases(result.stdout).find(lease => lease.token === token) ?? null;
+      return parseLeases(result.stdout).find(lease => lease.socketName === socketName) ?? null;
     } catch (error) {
       logger.debug(`[PersistentEncoderH264Source] unable to read owned video session lease: ${error}`);
       return null;
@@ -1874,16 +1898,19 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
         "adb read video-server process cmdline"
       );
       const argv = commandLine.stdout.split("\u0000");
+      // Match the non-secret `--socket-name` argv token, not `--session-token` (issue #4731): the
+      // lease no longer carries the raw token, and the opaque socket name gives the same PID-reuse
+      // protection — a recycled PID running something else will not carry our socket name.
       const ownsSession = argv.some(
         (argument, index) =>
-          argument === "--session-token" && argv[index + 1] === lease.token
+          argument === "--socket-name" && argv[index + 1] === lease.socketName
       );
       if (
         !argv.includes(VIDEO_SERVER_MAIN_CLASS) ||
         !ownsSession
       ) {
         logger.warn(
-          `[PersistentEncoderH264Source] refusing stale-session process cleanup token=${lease.token}: PID/token mismatch`
+          `[PersistentEncoderH264Source] refusing stale-session process cleanup socket=${lease.socketName}: PID/socket mismatch`
         );
         return;
       }
@@ -1894,7 +1921,7 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
       );
     } catch (error) {
       logger.debug(
-        `[PersistentEncoderH264Source] stale-session process cleanup skipped token=${lease.token}: ${error}`
+        `[PersistentEncoderH264Source] stale-session process cleanup skipped socket=${lease.socketName}: ${error}`
       );
     }
   }
@@ -1936,17 +1963,17 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     adb: ReturnType<AdbClientFactory["create"]>,
     lease: VideoServerLease
   ): Promise<void> {
-    const current = await this.readLease(adb, lease.token);
+    const current = await this.readLease(adb, lease.socketName);
     if (
-      current?.token !== lease.token ||
-      current.socketName !== lease.socketName ||
+      current?.socketName !== lease.socketName ||
+      current.sessionTokenHash !== lease.sessionTokenHash ||
       current.pid !== lease.pid
     ) {
       return;
     }
     try {
       await this.withTimeout(
-        adb.executeCommand(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/${lease.token}.json`),
+        adb.executeCommand(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/${lease.socketName}.json`),
         this.teardownTimeoutMs,
         "adb remove video session lease"
       );

--- a/test/features/webrtc/PersistentEncoderH264Source.test.ts
+++ b/test/features/webrtc/PersistentEncoderH264Source.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { EventEmitter } from "node:events";
+import { createHash } from "node:crypto";
 import { PassThrough } from "node:stream";
 import {
   InMemoryActiveVideoSessionRegistry,
@@ -28,6 +29,9 @@ const FORWARD_PORT = "45999";
 const SESSION_TOKEN = "session-0001";
 const SESSION_SOCKET = `${VIDEO_SERVER_SOCKET_PREFIX}_session0001`;
 const VIDEO_SERVER_MAIN_CLASS = "dev.jasonpearson.automobile.video.VideoServer";
+// SHA-256 hex of a session token, matching the device's `sessionTokenSha256Hex` (issue #4731). The
+// lease persists only this hash, so fixtures build `sessionTokenHash` from it.
+const hashToken = (token: string): string => createHash("sha256").update(token, "ascii").digest("hex");
 // Flush the nextTick + microtask queues so the source's async launch steps and
 // the PassThrough `data` emissions settle (no fake timer involved here).
 const tick = (): Promise<void> => new Promise(resolve => setImmediate(resolve));
@@ -153,7 +157,7 @@ function makeSource(overrides: Record<string, unknown> = {}) {
     | undefined;
   const processCommandLine =
     (overrides.processCommandLine as string | undefined) ??
-    `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--session-token\u0000stale-session`;
+    `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--socket-name\u0000automobile_video_stale`;
 
   // Command substrings whose ADB call should hang forever, exercising the
   // injected withTimeout bound under FakeTimer (never a real wait).
@@ -585,7 +589,7 @@ describe("PersistentEncoderH264Source", () => {
     const lease = JSON.stringify({
       version: 1,
       socketName: SESSION_SOCKET,
-      sessionToken: SESSION_TOKEN,
+      sessionTokenHash: hashToken(SESSION_TOKEN),
       pid: 1234,
       ownerPid: process.pid,
       deviceSerial: DEVICE.deviceId,
@@ -597,7 +601,7 @@ describe("PersistentEncoderH264Source", () => {
     const ctx = makeSource({
       leaseOutput: lease,
       processCommandLine:
-        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--session-token\u0000${SESSION_TOKEN}`,
+        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--socket-name\u0000${SESSION_SOCKET}`,
     });
 
     const startPromise = ctx.source.start();
@@ -607,7 +611,7 @@ describe("PersistentEncoderH264Source", () => {
     await expect(startPromise).rejects.toThrow(/exited before ready/);
 
     expect(ctx.commands).toContain("shell kill -2 1234");
-    expect(ctx.commands).toContain(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/${SESSION_TOKEN}.json`);
+    expect(ctx.commands).toContain(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/${SESSION_SOCKET}.json`);
   });
 
   test("rejects start when the server exits before ready", async () => {
@@ -927,11 +931,14 @@ describe("PersistentEncoderH264Source", () => {
     expect(lateSocket.destroyed).toBe(true);
   });
 
-  test("removes this source's forward when a matching-token lease has different identity", async () => {
+  test("removes this source's forward when the lease for this socket has a different session identity", async () => {
+    // The lease file is named by our socket, but its persisted token hash belongs to a different
+    // session (a socket-name reuse). Ownership fails the hash check (issue #4731), so we clean only
+    // our own forward and never kill the other session's process.
     const mismatchedLease = JSON.stringify({
-      version: 1,
-      socketName: "automobile_video_replacement",
-      sessionToken: SESSION_TOKEN,
+      version: 2,
+      socketName: SESSION_SOCKET,
+      sessionTokenHash: hashToken("someone-elses-token"),
       pid: 5678,
       ownerPid: process.pid,
       deviceSerial: DEVICE.deviceId,
@@ -966,7 +973,7 @@ describe("PersistentEncoderH264Source", () => {
     const staleLease = JSON.stringify({
       version: 1,
       socketName: "automobile_video_stale",
-      sessionToken: "stale-session",
+      sessionTokenHash: hashToken("stale-session"),
       pid: 987,
       ownerPid: 456,
       deviceSerial: DEVICE.deviceId,
@@ -979,7 +986,7 @@ describe("PersistentEncoderH264Source", () => {
       leaseOutput: staleLease,
       forwardListOutput: `${DEVICE.deviceId} tcp:61234 localabstract:automobile_video_stale\n`,
       processCommandLine:
-        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--session-token\u0000stale-session`,
+        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--socket-name\u0000automobile_video_stale`,
     });
 
     const startPromise = ctx.source.start();
@@ -987,7 +994,7 @@ describe("PersistentEncoderH264Source", () => {
 
     expect(ctx.commands).toContain("forward --remove tcp:61234");
     expect(ctx.commands).toContain("shell kill -2 987");
-    expect(ctx.commands).toContain(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/stale-session.json`);
+    expect(ctx.commands).toContain(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/automobile_video_stale.json`);
 
     ctx.processes[0].ready();
     await startPromise;
@@ -998,7 +1005,7 @@ describe("PersistentEncoderH264Source", () => {
     const staleLease = JSON.stringify({
       version: 1,
       socketName: "automobile_video_stale",
-      sessionToken: "stale-session",
+      sessionTokenHash: hashToken("stale-session"),
       pid: 987,
       ownerPid: 456,
       deviceSerial: DEVICE.deviceId,
@@ -1010,7 +1017,7 @@ describe("PersistentEncoderH264Source", () => {
     const freshLease = JSON.stringify({
       version: 1,
       socketName: "automobile_video_fresh",
-      sessionToken: "fresh-session",
+      sessionTokenHash: hashToken("fresh-session"),
       pid: 988,
       ownerPid: 456,
       deviceSerial: DEVICE.deviceId,
@@ -1023,7 +1030,7 @@ describe("PersistentEncoderH264Source", () => {
       leaseOutput: `${staleLease}\n${freshLease}\n`,
       forwardListOutput: `${DEVICE.deviceId} tcp:61234 localabstract:automobile_video_stale\n`,
       processCommandLine:
-        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--session-token\u0000stale-session`,
+        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--socket-name\u0000automobile_video_stale`,
     });
 
     const startPromise = ctx.source.start();
@@ -1044,7 +1051,7 @@ describe("PersistentEncoderH264Source", () => {
     const staleLease = JSON.stringify({
       version: 1,
       socketName: "automobile_video_stale",
-      sessionToken: "stale-session",
+      sessionTokenHash: hashToken("stale-session"),
       pid: 987,
       ownerPid: 456,
       deviceSerial: DEVICE.deviceId,
@@ -1057,7 +1064,7 @@ describe("PersistentEncoderH264Source", () => {
       leaseOutput: staleLease,
       forwardListOutput: `${DEVICE.deviceId} tcp:61234 localabstract:someone_elses_socket\n`,
       processCommandLine:
-        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--session-token\u0000stale-session`,
+        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--socket-name\u0000automobile_video_stale`,
     });
 
     const startPromise = ctx.source.start();
@@ -1134,7 +1141,7 @@ describe("PersistentEncoderH264Source", () => {
     const liveLease = JSON.stringify({
       version: 1,
       socketName: "automobile_video_live",
-      sessionToken: "live-session",
+      sessionTokenHash: hashToken("live-session"),
       pid: 4321,
       ownerPid: 456,
       deviceSerial: DEVICE.deviceId,
@@ -1169,11 +1176,11 @@ describe("PersistentEncoderH264Source", () => {
     expect(registry.active(DEVICE.deviceId).has(SESSION_SOCKET)).toBe(false);
   });
 
-  test("refuses stale cleanup when the PID command line does not contain the lease token", async () => {
+  test("refuses stale cleanup when the PID command line does not contain the lease socket name", async () => {
     const staleLease = JSON.stringify({
       version: 1,
       socketName: "automobile_video_stale",
-      sessionToken: "stale-session",
+      sessionTokenHash: hashToken("stale-session"),
       pid: 987,
       ownerPid: 456,
       deviceSerial: DEVICE.deviceId,
@@ -1186,7 +1193,7 @@ describe("PersistentEncoderH264Source", () => {
       leaseOutput: staleLease,
       forwardListOutput: `${DEVICE.deviceId} tcp:61234 localabstract:automobile_video_stale\n`,
       processCommandLine:
-        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--session-token\u0000another-session`,
+        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--socket-name\u0000automobile_video_other`,
     });
 
     const startPromise = ctx.source.start();
@@ -1200,11 +1207,11 @@ describe("PersistentEncoderH264Source", () => {
     await ctx.source.stop();
   });
 
-  test("refuses stale cleanup when the lease token is not the --session-token value", async () => {
+  test("refuses stale cleanup when the lease socket name is not the --socket-name value", async () => {
     const staleLease = JSON.stringify({
       version: 1,
       socketName: "automobile_video_stale",
-      sessionToken: "stale-session",
+      sessionTokenHash: hashToken("stale-session"),
       pid: 987,
       ownerPid: 456,
       deviceSerial: DEVICE.deviceId,
@@ -1217,7 +1224,7 @@ describe("PersistentEncoderH264Source", () => {
       leaseOutput: staleLease,
       forwardListOutput: `${DEVICE.deviceId} tcp:61234 localabstract:automobile_video_stale\n`,
       processCommandLine:
-        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--session-token\u0000other-session\u0000--quality\u0000stale-session`,
+        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--socket-name\u0000automobile_video_other\u0000--quality\u0000automobile_video_stale`,
     });
 
     const startPromise = ctx.source.start();
@@ -1235,7 +1242,7 @@ describe("PersistentEncoderH264Source", () => {
     const freshLeaseWithOldWallClock = JSON.stringify({
       version: 1,
       socketName: "automobile_video_fresh",
-      sessionToken: "fresh-session",
+      sessionTokenHash: hashToken("fresh-session"),
       pid: 987,
       ownerPid: 456,
       deviceSerial: DEVICE.deviceId,
@@ -1264,7 +1271,7 @@ describe("PersistentEncoderH264Source", () => {
     const staleLeaseBeforeReboot = JSON.stringify({
       version: 1,
       socketName: "automobile_video_stale",
-      sessionToken: "stale-session",
+      sessionTokenHash: hashToken("stale-session"),
       pid: 987,
       ownerPid: 456,
       deviceSerial: DEVICE.deviceId,
@@ -1278,7 +1285,7 @@ describe("PersistentEncoderH264Source", () => {
       deviceUptimeMs: 5_000,
       forwardListOutput: `${DEVICE.deviceId} tcp:61234 localabstract:automobile_video_stale\n`,
       processCommandLine:
-        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--session-token\u0000stale-session`,
+        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--socket-name\u0000automobile_video_stale`,
     });
 
     const startPromise = ctx.source.start();
@@ -1286,7 +1293,7 @@ describe("PersistentEncoderH264Source", () => {
 
     expect(ctx.commands).toContain("forward --remove tcp:61234");
     expect(ctx.commands).toContain("shell kill -2 987");
-    expect(ctx.commands).toContain(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/stale-session.json`);
+    expect(ctx.commands).toContain(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/automobile_video_stale.json`);
 
     ctx.processes[0].ready();
     await startPromise;
@@ -1299,7 +1306,7 @@ describe("PersistentEncoderH264Source", () => {
     const leaseNoElapsed = JSON.stringify({
       version: 1,
       socketName: "automobile_video_stale",
-      sessionToken: "stale-session",
+      sessionTokenHash: hashToken("stale-session"),
       pid: 987,
       ownerPid: 456,
       deviceSerial: DEVICE.deviceId,
@@ -1311,14 +1318,14 @@ describe("PersistentEncoderH264Source", () => {
       leaseOutput: leaseNoElapsed,
       forwardListOutput: `${DEVICE.deviceId} tcp:61234 localabstract:automobile_video_stale\n`,
       processCommandLine:
-        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--session-token\u0000stale-session`,
+        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--socket-name\u0000automobile_video_stale`,
     });
 
     const startPromise = ctx.source.start();
     await tick();
 
     expect(ctx.commands).toContain("shell kill -2 987");
-    expect(ctx.commands).toContain(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/stale-session.json`);
+    expect(ctx.commands).toContain(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/automobile_video_stale.json`);
 
     ctx.processes[0].ready();
     await startPromise;
@@ -1330,7 +1337,7 @@ describe("PersistentEncoderH264Source", () => {
     const freshNoElapsed = JSON.stringify({
       version: 1,
       socketName: "automobile_video_fresh",
-      sessionToken: "fresh-session",
+      sessionTokenHash: hashToken("fresh-session"),
       pid: 987,
       ownerPid: 456,
       deviceSerial: DEVICE.deviceId,
@@ -1357,7 +1364,7 @@ describe("PersistentEncoderH264Source", () => {
     const staleLeaseOldSerial = JSON.stringify({
       version: 1,
       socketName: "automobile_video_stale",
-      sessionToken: "stale-session",
+      sessionTokenHash: hashToken("stale-session"),
       pid: 987,
       ownerPid: 456,
       deviceSerial: "emulator-5556",
@@ -1371,7 +1378,7 @@ describe("PersistentEncoderH264Source", () => {
       deviceUptimeMs: 5_000,
       forwardListOutput: `${DEVICE.deviceId} tcp:61234 localabstract:automobile_video_stale\n`,
       processCommandLine:
-        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--session-token\u0000stale-session`,
+        `app_process\u0000/\u0000${VIDEO_SERVER_MAIN_CLASS}\u0000--socket-name\u0000automobile_video_stale`,
     });
 
     const startPromise = ctx.source.start();
@@ -1379,7 +1386,7 @@ describe("PersistentEncoderH264Source", () => {
 
     expect(ctx.commands).toContain("forward --remove tcp:61234");
     expect(ctx.commands).toContain("shell kill -2 987");
-    expect(ctx.commands).toContain(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/stale-session.json`);
+    expect(ctx.commands).toContain(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/automobile_video_stale.json`);
 
     ctx.processes[0].ready();
     await startPromise;
@@ -1392,7 +1399,7 @@ describe("PersistentEncoderH264Source", () => {
     const freshOtherSerial = JSON.stringify({
       version: 1,
       socketName: "automobile_video_other",
-      sessionToken: "other-session",
+      sessionTokenHash: hashToken("other-session"),
       pid: 987,
       ownerPid: 456,
       deviceSerial: "emulator-5556",
@@ -1441,7 +1448,7 @@ describe("PersistentEncoderH264Source", () => {
     const validLease = JSON.stringify({
       version: 1,
       socketName: "automobile_video_fresh",
-      sessionToken: "fresh-session",
+      sessionTokenHash: hashToken("fresh-session"),
       pid: 988,
       ownerPid: 456,
       deviceSerial: DEVICE.deviceId,
@@ -1457,7 +1464,7 @@ describe("PersistentEncoderH264Source", () => {
         `NOW 1000000\n` +
         `${youngMtime} ${VIDEO_SERVER_LEASE_DIRECTORY}/corrupt.json\n` +
         `${youngMtime} ${VIDEO_SERVER_LEASE_DIRECTORY}/leftover.json.tmp\n` +
-        `990000 ${VIDEO_SERVER_LEASE_DIRECTORY}/fresh-session.json\n`,
+        `990000 ${VIDEO_SERVER_LEASE_DIRECTORY}/automobile_video_fresh.json\n`,
     });
 
     const startPromise = ctx.source.start();
@@ -1466,7 +1473,7 @@ describe("PersistentEncoderH264Source", () => {
     expect(ctx.commands).not.toContain(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/corrupt.json`);
     expect(ctx.commands).not.toContain(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/leftover.json.tmp`);
     // A valid, current lease file is never swept even though its mtime is old.
-    expect(ctx.commands).not.toContain(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/fresh-session.json`);
+    expect(ctx.commands).not.toContain(`shell rm -f ${VIDEO_SERVER_LEASE_DIRECTORY}/automobile_video_fresh.json`);
 
     ctx.processes[0].ready();
     await startPromise;
@@ -1557,7 +1564,7 @@ describe("PersistentEncoderH264Source", () => {
       // readLease's `shell cat <lease>.json` is only hit during cleanup, so it
       // hangs teardown without affecting the successful start.
       const ctx = makeSource({
-        hangCommands: [`shell cat ${VIDEO_SERVER_LEASE_DIRECTORY}/${SESSION_TOKEN}.json`],
+        hangCommands: [`shell cat ${VIDEO_SERVER_LEASE_DIRECTORY}/${SESSION_SOCKET}.json`],
       });
       await startReady(ctx);
 


### PR DESCRIPTION
Closes [#4731](https://github.com/kaeawc/auto-mobile/issues/4731)

## Summary

Hardens the per-session video lease file so the session token (now the on-wire auth secret per [#4729](https://github.com/kaeawc/auto-mobile/issues/4729)) is never written to disk in cleartext, and locks down the lease directory/file permissions.

Change is in `android/video-server/.../video/VideoSessionLease.kt`, coordinated with the host-side reconcile/sweep in `src/features/webrtc/PersistentEncoderH264Source.ts` (which reads and reclaims these lease files).

## Acceptance criteria

- **No raw secret at rest** — the record now stores `sessionTokenHash` (SHA-256 hex) instead of the raw `sessionToken`, and the on-disk filename is derived from the opaque, non-secret `socketName` rather than the token. A lease owner re-derives the hash from the token it holds to confirm ownership.
- **Restrictive perms** — the lease directory is `chmod` 0700 and each lease file 0600, applied to the `.tmp` file **before** the atomic `renameTo` so there is no world-readable window. The `chmod` syscall is injected (interface + fake) so JVM unit tests stay deterministic.
- **Lifecycle preserved** — heartbeat, stale-cleanup, wall-clock fallback, previous-boot/serial precedence, and the orphan-forward sweep are unchanged.
- **Coverage updated** — Kotlin tests assert the hash-only record, the socket-derived filename, the 0700-dir-then-0600-tmp-before-rename ordering, and that a chmod failure does not sink the heartbeat. The host reconcile/sweep tests were migrated to the new record shape.

## Verify-against-current-main / compatibility analysis

`VideoSessionLease.kt` and the reconcile/sweep paths moved after this issue was filed, so I re-derived the change against current `main`:

- **[#4729](https://github.com/kaeawc/auto-mobile/issues/4729) (merged)** promoted the token to the on-wire auth secret and already decoupled the abstract socket name from the token (opaque `automobile_video_<randomid>`). That made this issue genuinely needed (cleartext token at rest is now a real leak) **and** handed us the right non-secret matching key: the `socketName`, which is already world-readable via `/proc/net/unix`, so using it as the filename/id discloses nothing new.
- **The host reads and reconciles these leases** in `PersistentEncoderH264Source.ts`. Everything that previously keyed on the raw token now keys on `socketName`, so the reconcile still matches leases to sessions/forwards after the change:
  - `parseLeases`/`isVideoServerLease` — validates `sessionTokenHash` (64-hex) instead of `sessionToken`, and additionally requires `socketName` to match the safe pattern (it is now interpolated into `cat`/`rm` paths).
  - **`reconcileExpiredLeases`** — stale classification (`previous-boot` via negative elapsed-realtime, `wall-clock-stale` fallback, `elapsed-stale`, same-serial precedence) is untouched; only the log line and the `${socketName}.json` filename changed.
  - **[#4783](https://github.com/kaeawc/auto-mobile/issues/4783) `sweepOrphanLeaseFiles`** — the "known lease files" set is now `${lease.socketName}.json`; unparseable `*.json` / orphaned `*.json.tmp` sweep and the mtime threshold are unchanged. Old-shape leases (raw `sessionToken`, no hash) now fail validation and are reclaimed by this sweep after the conservative age window.
  - **[#4753](https://github.com/kaeawc/auto-mobile/issues/4753) `sweepOrphanForwards`** — unchanged; it already matched on `socketName` and the `automobile_video_*` prefix, both preserved.
  - **Owned-session cleanup** — `isOwnedSessionLease` now confirms ownership by hashing this session's token and comparing to `sessionTokenHash` (plus socketName/ownerPid/serial/pid); `readLease`/`removeLeaseIfMatching` read/delete `${socketName}.json`; the process-liveness cross-check matches the `--socket-name` argv token instead of `--session-token`, giving identical PID-reuse protection with no secret involved. The server is still launched with `--session-token` (unchanged) — the token lives only in argv, not on disk.
- **Wire/format compatibility**: on-disk record `version` bumped 1 → 2; field `sessionToken` → `sessionTokenHash`; filename `<token>.json` → `<socketName>.json`. Host and jar ship together, so the coordinated change is consistent end to end. The SHA-256 hash is computed identically on both ends (ASCII bytes, lowercase hex): `MessageDigest` in Kotlin, `createHash("sha256")` in TS — the canonical primitives already used in each codebase (no new hash helper invented).

## Validation

- `bun test test/features/webrtc/PersistentEncoderH264Source.test.ts` — 61 pass
- `bun run typecheck` — no new type errors
- `turbo run lint build` — green
- `./gradlew :video-server:test` (JDK 21) — green
- `ktfmt --google-style` (repo `validate_ktfmt.sh`) — clean on both Kotlin files
