### PR TITLE
feat(release): add Maven Central publication manifest and usage budget preflight

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -378,6 +378,59 @@ jobs:
           echo "${{ secrets.RELEASE_KEYSTORE_BASE64 }}" | \
             base64 -d > android/keystore/release.keystore
 
+      # Preflight: stage every publishable file to a local Maven file repository
+      # (no credentials, no remote upload) and record a deterministic manifest of
+      # exactly what the release would send to Maven Central, with per-coordinate
+      # and release totals. The budget check is advisory -- a breach warns but
+      # never blocks, so a security release always ships (#4853). This also gives
+      # the artifact-reduction work (#4851, #4852) a before/after regression
+      # oracle.
+      - name: Maven Central publication manifest preflight
+        continue-on-error: true
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey:
+            ${{ secrets.SIGNING_IN_MEMORY_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword:
+            ${{ secrets.SIGNING_IN_MEMORY_KEY_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId:
+            ${{ secrets.SIGNING_IN_MEMORY_KEY_ID }}
+        run: |
+          set -euo pipefail
+          MANIFEST_OUT="$RUNNER_TEMP/maven-publication-manifest.txt"
+          (
+            cd android
+            rm -rf build/central-manifest
+            ./gradlew \
+              :protocol:publishAllPublicationsToCentralManifestRepository \
+              :test-plan-validation:publishAllPublicationsToCentralManifestRepository \
+              :junit-runner:publishAllPublicationsToCentralManifestRepository \
+              :auto-mobile-sdk:publishAllPublicationsToCentralManifestRepository \
+              -PVERSION_NAME="$VERSION" \
+              --no-configuration-cache
+          )
+          scripts/release/maven-publication-manifest.sh \
+            android/build/central-manifest \
+            --budget scripts/release/maven-usage-budget.json \
+            | tee "$MANIFEST_OUT"
+          {
+            echo "### Maven Central publication manifest"
+            echo ""
+            echo '```'
+            # Totals only in the summary; the full per-file manifest is the
+            # uploaded artifact.
+            sed -n '/## Per-coordinate totals/,$p' "$MANIFEST_OUT"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload Maven publication manifest
+        continue-on-error: true
+        uses: actions/upload-artifact@v6
+        with:
+          name: maven-publication-manifest
+          path: ${{ runner.temp }}/maven-publication-manifest.txt
+          if-no-files-found: warn
+
       - name: Publish Android Libraries to Maven Central
         continue-on-error: true
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -389,39 +389,14 @@ jobs:
         continue-on-error: true
         env:
           VERSION: ${{ steps.version.outputs.version }}
+          MANIFEST_OUT: ${{ runner.temp }}/maven-publication-manifest.txt
           ORG_GRADLE_PROJECT_signingInMemoryKey:
             ${{ secrets.SIGNING_IN_MEMORY_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword:
             ${{ secrets.SIGNING_IN_MEMORY_KEY_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyId:
             ${{ secrets.SIGNING_IN_MEMORY_KEY_ID }}
-        run: |
-          set -euo pipefail
-          MANIFEST_OUT="$RUNNER_TEMP/maven-publication-manifest.txt"
-          (
-            cd android
-            rm -rf build/central-manifest
-            ./gradlew \
-              :protocol:publishAllPublicationsToCentralManifestRepository \
-              :test-plan-validation:publishAllPublicationsToCentralManifestRepository \
-              :junit-runner:publishAllPublicationsToCentralManifestRepository \
-              :auto-mobile-sdk:publishAllPublicationsToCentralManifestRepository \
-              -PVERSION_NAME="$VERSION" \
-              --no-configuration-cache
-          )
-          scripts/release/maven-publication-manifest.sh \
-            android/build/central-manifest \
-            --budget scripts/release/maven-usage-budget.json \
-            | tee "$MANIFEST_OUT"
-          {
-            echo "### Maven Central publication manifest"
-            echo ""
-            echo '```'
-            # Totals only in the summary; the full per-file manifest is the
-            # uploaded artifact.
-            sed -n '/## Per-coordinate totals/,$p' "$MANIFEST_OUT"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
+        run: scripts/release/maven-publication-manifest-preflight.sh
 
       - name: Upload Maven publication manifest
         continue-on-error: true

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -2,6 +2,7 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import dev.detekt.gradle.extensions.DetektExtension
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.publish.PublishingExtension
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
@@ -51,6 +52,26 @@ plugins.withId(libs.plugins.mavenPublish.get().pluginId) {
   // configuration required to produce unique META-INF/*.kotlin_module file names
   tasks.withType<KotlinCompile>().configureEach {
     compilerOptions { moduleName.set(project.property("POM_ARTIFACT_ID") as String) }
+  }
+}
+
+// Local file repository used only by the Maven publication manifest preflight
+// (issue #4853). Publishing to it stages the exact set of files a release would
+// upload to Maven Central -- primary artifacts, POM, Gradle module metadata,
+// sources and javadoc jars, PGP signatures, and checksums -- into one directory
+// so the preflight can enumerate them deterministically, without Maven Central
+// credentials or a remote publish. It never uploads anywhere and has no effect on
+// the real Central publication path (publishAllPublicationsToMavenCentral...).
+allprojects {
+  plugins.withId("com.vanniktech.maven.publish") {
+    configure<PublishingExtension> {
+      repositories {
+        maven {
+          name = "centralManifest"
+          url = rootProject.layout.buildDirectory.dir("central-manifest").get().asFile.toURI()
+        }
+      }
+    }
   }
 }
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -64,11 +64,17 @@ plugins.withId(libs.plugins.mavenPublish.get().pluginId) {
 // the real Central publication path (publishAllPublicationsToMavenCentral...).
 allprojects {
   plugins.withId("com.vanniktech.maven.publish") {
-    configure<PublishingExtension> {
-      repositories {
-        maven {
-          name = "centralManifest"
-          url = rootProject.layout.buildDirectory.dir("central-manifest").get().asFile.toURI()
+    // Register only when the preflight asks for it (-PmavenManifestStaging). The
+    // production `publish` lifecycle task depends on the publish task of EVERY
+    // configured repository, so registering this unconditionally would make the
+    // real release also write to the local repo. Gating keeps it off that path.
+    if (providers.gradleProperty("mavenManifestStaging").isPresent) {
+      configure<PublishingExtension> {
+        repositories {
+          maven {
+            name = "centralManifest"
+            url = rootProject.layout.buildDirectory.dir("central-manifest").get().asFile.toURI()
+          }
         }
       }
     }

--- a/docs/release/maven-publication-manifest.md
+++ b/docs/release/maven-publication-manifest.md
@@ -28,9 +28,14 @@ credentials and no remote publish.
    and, by default, **still exits 0** — the preflight reports, it never blocks, so
    an urgent security release always ships. Only `--strict` turns a breach (or an
    unexpected file) into a non-zero exit.
-4. **Record.** In `release.yml` the preflight runs immediately before the publish
-   step, appends the totals to the job summary, and uploads the full manifest as
-   the `maven-publication-manifest` artifact.
+4. **Record.** `scripts/release/maven-publication-manifest-preflight.sh`
+   orchestrates the release-CI flow — stage all four modules, run the generator
+   with the budget, write the full manifest, append the totals to the job
+   summary. It lives in a script (not inline in the workflow) so it is linted and
+   BATS-tested on its own; set `STAGING_DIR` to skip the Gradle staging and run it
+   against an already-staged tree. In `release.yml` it runs immediately before the
+   publish step and uploads the full manifest as the `maven-publication-manifest`
+   artifact.
 
 ## File taxonomy
 
@@ -77,13 +82,27 @@ public API docs (~261 bytes each). Signing (enabled in release CI) adds a `.asc`
 plus its four checksums for each signed primary, which is what brings a real
 release to roughly 200 files.
 
+## Budget
+
+`maven-usage-budget.json` records both the real Central ceilings and the
+per-release guardrails:
+
+- `centralOrgLimits` — the Maven Central Usage Center ceilings, which are
+  **monthly** and **aggregate across the whole org**: 80 MB release size, 1000
+  files, 7 releases. Observed 2026-07: 15.43 MB, 320 files, 4 releases.
+- `perRelease` — what the preflight actually checks: one tagged release's staged
+  footprint. Because the local file repo over-counts versus Central (see below), a
+  release Central tallies at ~80 files shows here as ~200 signed, so these are
+  relative guardrails with headroom, sized to keep a normal release cadence well
+  inside the monthly ceilings.
+
 ## Caveats
 
-- The local file repository also writes `maven-metadata.xml` per coordinate. The
-  Central Portal bundle may regenerate metadata server-side, so the manifest can
-  slightly over-count versus the final Central state. This is intentional: the
-  manifest reflects what Gradle produces, and the relative before/after signal —
-  the point of the oracle — is unaffected.
-- The budget in `maven-usage-budget.json` is advisory and headroom-padded.
-  Tighten `maxBytes` after #4851 and #4852 land, and raise the ceilings
-  deliberately whenever a new coordinate is added.
+- The local file repository also writes `maven-metadata.xml` per coordinate and
+  every Gradle checksum. The Central Portal bundle regenerates metadata
+  server-side and counts differently, so the manifest **over-counts** versus the
+  final Central state (the Usage Center showed ~80 files/release against ~200 here
+  signed). This is intentional: the manifest reflects what Gradle produces, and
+  the relative before/after signal — the point of the oracle — is unaffected.
+- The budget is advisory. Tighten `perRelease.maxBytes` after #4851 and #4852
+  land, and raise a ceiling deliberately whenever a new coordinate is added.

--- a/docs/release/maven-publication-manifest.md
+++ b/docs/release/maven-publication-manifest.md
@@ -1,0 +1,89 @@
+# Maven Central publication manifest & usage-budget preflight
+
+Tracking issue: #4853.
+
+Every tagged AutoMobile release uploads four Maven coordinates to Maven Central.
+Until now nothing made the exact set of uploaded files — or its size and count —
+visible before the upload happened. Maven Central's Usage Center meters
+organization-level file count and release size, so a release that quietly grows
+the artifact set is worth catching *before* it ships. This preflight produces a
+deterministic manifest of exactly what a release would upload, checks it against
+an advisory budget, and records it in the release run — with no Maven Central
+credentials and no remote publish.
+
+## How it works
+
+1. **Stage locally.** `android/build.gradle.kts` registers a `centralManifest`
+   Maven repository that points at `android/build/central-manifest/`. Publishing
+   to it (`publishAllPublicationsToCentralManifestRepository`) writes the same
+   files a release uploads — primary artifact, POM, Gradle module metadata,
+   sources and Javadoc jars, PGP signatures, and checksums — into one local
+   directory. It uploads nowhere and does not touch the real Central path.
+2. **Enumerate.** `scripts/release/maven-publication-manifest.sh` walks that tree
+   and prints a deterministic, path-independent manifest: one line per file
+   (`coordinate classifier filename bytes`), per-coordinate subtotals, classifier
+   totals, and a release grand total.
+3. **Budget.** With `--budget scripts/release/maven-usage-budget.json` it compares
+   the release totals against advisory thresholds. A breach prints `BUDGET WARN`
+   and, by default, **still exits 0** — the preflight reports, it never blocks, so
+   an urgent security release always ships. Only `--strict` turns a breach (or an
+   unexpected file) into a non-zero exit.
+4. **Record.** In `release.yml` the preflight runs immediately before the publish
+   step, appends the totals to the job summary, and uploads the full manifest as
+   the `maven-publication-manifest` artifact.
+
+## File taxonomy
+
+Each staged file is classified so downstream work can target a specific class:
+
+| Classifier | Meaning |
+|---|---|
+| `main-jar` / `main-aar` | Primary artifact (JVM modules ship a jar; the Android library ships an aar) |
+| `sources-jar` / `javadoc-jar` | Sources and Javadoc archives |
+| `pom` / `module` | Maven POM and Gradle Module Metadata |
+| `maven-metadata` | `maven-metadata.xml` |
+| `signature` | `.asc` PGP signature of a primary file |
+| `checksum` | `.md5/.sha1/.sha256/.sha512` of a primary file or metadata |
+| `signature-checksum` | Checksum of a `.asc` signature (the redundant set #4851 targets) |
+| `unexpected` | Anything else — a novel classifier or a stray sidecar |
+
+`unexpected` is how the preflight detects accidental new classifiers or sidecars:
+under `--strict` any unexpected file fails the run.
+
+## Regression oracle for artifact reduction
+
+The manifest is the before/after oracle for the artifact-reduction work:
+
+- **#4851** (eliminate signature checksums) shrinks the `signature-checksum`
+  count to zero.
+- **#4852** (reduce the Dokka Javadoc payload) shrinks the `javadoc-jar` bytes.
+
+Capture the manifest, make the change, re-capture, and diff.
+
+## Current baseline
+
+Measured from a local staging of all four coordinates at version `0.0.47`
+(Gradle 9.6.1 emits four checksums per file):
+
+| Coordinate | Files (unsigned) | Bytes |
+|---|---|---|
+| `auto-mobile-sdk` | 30 | ~2.19 MB |
+| `auto-mobile-protocol` | 30 | ~1.07 MB |
+| `auto-mobile-junit-runner` | 30 | ~0.47 MB |
+| `auto-mobile-test-plan-validation` | 30 | ~0.19 MB |
+
+`auto-mobile-sdk`'s Javadoc jar alone is ~1.78 MB; the other three carry no
+public API docs (~261 bytes each). Signing (enabled in release CI) adds a `.asc`
+plus its four checksums for each signed primary, which is what brings a real
+release to roughly 200 files.
+
+## Caveats
+
+- The local file repository also writes `maven-metadata.xml` per coordinate. The
+  Central Portal bundle may regenerate metadata server-side, so the manifest can
+  slightly over-count versus the final Central state. This is intentional: the
+  manifest reflects what Gradle produces, and the relative before/after signal —
+  the point of the oracle — is unaffected.
+- The budget in `maven-usage-budget.json` is advisory and headroom-padded.
+  Tighten `maxBytes` after #4851 and #4852 land, and raise the ceilings
+  deliberately whenever a new coordinate is added.

--- a/docs/release/maven-publication-manifest.md
+++ b/docs/release/maven-publication-manifest.md
@@ -14,11 +14,12 @@ credentials and no remote publish.
 ## How it works
 
 1. **Stage locally.** `android/build.gradle.kts` registers a `centralManifest`
-   Maven repository that points at `android/build/central-manifest/`. Publishing
-   to it (`publishAllPublicationsToCentralManifestRepository`) writes the same
-   files a release uploads — primary artifact, POM, Gradle module metadata,
-   sources and Javadoc jars, PGP signatures, and checksums — into one local
-   directory. It uploads nowhere and does not touch the real Central path.
+   Maven repository that points at `android/build/central-manifest/`, gated behind
+   `-PmavenManifestStaging` so it stays off the production `publish` lifecycle.
+   Publishing to it (`publishAllPublicationsToCentralManifestRepository`) writes
+   the same files a release uploads — primary artifact, POM, Gradle module
+   metadata, sources and Javadoc jars, PGP signatures, and checksums — into one
+   local directory. It uploads nowhere and does not touch the real Central path.
 2. **Enumerate.** `scripts/release/maven-publication-manifest.sh` walks that tree
    and prints a deterministic, path-independent manifest: one line per file
    (`coordinate classifier filename bytes`), per-coordinate subtotals, classifier

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -217,6 +217,7 @@ nav:
       - 'Standard Library First': contributing/stdlib-first.md
       - 'Apple Signing & Notarization': release/apple-signing-setup.md
       - 'Windows & Linux Signing (research)': release/windows-linux-signing-research.md
+      - 'Maven Publication Manifest': release/maven-publication-manifest.md
       - 'Dependency Decisions':
           - 'fast-check': decisions/fast-check.md
       - 'Codex Automation Thread Report': codex-automation-thread-spam-report.md

--- a/scripts/release/maven-publication-manifest-preflight.sh
+++ b/scripts/release/maven-publication-manifest-preflight.sh
@@ -61,6 +61,13 @@ fi
 # the previous manifest as an unexpected file, inflating totals and breaking the
 # deterministic before/after comparison the manifest exists to provide. Reject it.
 if [ -n "${MANIFEST_OUT:-}" ] && [ -d "$staging_dir" ]; then
+  # A symlink at the output path could redirect the write into the staging tree
+  # even when its resolved parent is outside it, so reject symlink outputs
+  # outright; pwd -P below resolves any symlinks in the parent directories.
+  if [ -L "$MANIFEST_OUT" ]; then
+    echo "error: MANIFEST_OUT ($MANIFEST_OUT) must not be a symlink" >&2
+    exit 2
+  fi
   staging_abs="$(cd "$staging_dir" && pwd -P)"
   out_parent="$(dirname "$MANIFEST_OUT")"
   if [ -d "$out_parent" ]; then

--- a/scripts/release/maven-publication-manifest-preflight.sh
+++ b/scripts/release/maven-publication-manifest-preflight.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# Release-CI orchestration for the Maven Central publication manifest preflight
+# (issue #4853). Extracted from release.yml so it can be run and linted on its
+# own. It stages every publishable module to the local `centralManifest` Maven
+# repository, runs the manifest generator with the advisory budget, writes the
+# full manifest to a file, and appends a totals block to the job summary.
+#
+# It never publishes remotely and never blocks a release: the budget is advisory
+# (the generator is run without --strict, so it always exits 0).
+#
+# Environment:
+#   VERSION               release version for -PVERSION_NAME. Required unless
+#                         STAGING_DIR is set.
+#   STAGING_DIR           use this already-staged local Maven repo and SKIP the
+#                         Gradle staging step. For local re-runs and tests.
+#   MANIFEST_OUT          also write the full manifest here (default: stdout only).
+#   GITHUB_STEP_SUMMARY   if set (GitHub Actions sets it), append the totals block.
+#   ANDROID_DIR           Gradle project directory (default: <repo>/android).
+#
+# Usage:
+#   VERSION=0.0.47 scripts/release/maven-publication-manifest-preflight.sh
+#   STAGING_DIR=android/build/central-manifest \
+#     scripts/release/maven-publication-manifest-preflight.sh
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$here/../.." && pwd)"
+android_dir="${ANDROID_DIR:-$repo_root/android}"
+budget="$here/maven-usage-budget.json"
+generator="$here/maven-publication-manifest.sh"
+
+# The four published Maven coordinates. Kept here (not in the workflow) so the
+# staging command is versioned, linted, and runnable on its own.
+modules=(
+  ":protocol"
+  ":test-plan-validation"
+  ":junit-runner"
+  ":auto-mobile-sdk"
+)
+
+if [ -n "${STAGING_DIR:-}" ]; then
+  staging_dir="$STAGING_DIR"
+else
+  : "${VERSION:?VERSION is required to stage the publication (or set STAGING_DIR)}"
+  staging_dir="$android_dir/build/central-manifest"
+  tasks=()
+  for m in "${modules[@]}"; do
+    tasks+=("$m:publishAllPublicationsToCentralManifestRepository")
+  done
+  (
+    cd "$android_dir"
+    rm -rf build/central-manifest
+    ./gradlew ${tasks[@]+"${tasks[@]}"} -PVERSION_NAME="$VERSION" --no-configuration-cache
+  )
+fi
+
+# Advisory only: no --strict, so the generator exits 0 even over budget or with
+# unexpected files. The full manifest and the WARN lines still surface below.
+manifest="$("$generator" "$staging_dir" --budget "$budget")"
+
+printf '%s\n' "$manifest"
+
+if [ -n "${MANIFEST_OUT:-}" ]; then
+  printf '%s\n' "$manifest" >"$MANIFEST_OUT"
+fi
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "### Maven Central publication manifest"
+    echo ""
+    echo '```'
+    # Totals only in the summary; the full per-file manifest is MANIFEST_OUT.
+    printf '%s\n' "$manifest" | sed -n '/## Per-coordinate totals/,$p'
+    echo '```'
+  } >>"$GITHUB_STEP_SUMMARY"
+fi

--- a/scripts/release/maven-publication-manifest-preflight.sh
+++ b/scripts/release/maven-publication-manifest-preflight.sh
@@ -52,7 +52,8 @@ else
   (
     cd "$android_dir"
     rm -rf build/central-manifest
-    ./gradlew ${tasks[@]+"${tasks[@]}"} -PVERSION_NAME="$VERSION" --no-configuration-cache
+    ./gradlew ${tasks[@]+"${tasks[@]}"} -PVERSION_NAME="$VERSION" \
+      -PmavenManifestStaging --no-configuration-cache
   )
 fi
 

--- a/scripts/release/maven-publication-manifest-preflight.sh
+++ b/scripts/release/maven-publication-manifest-preflight.sh
@@ -56,6 +56,23 @@ else
   )
 fi
 
+# Writing the manifest into the staging tree would make a second run enumerate
+# the previous manifest as an unexpected file, inflating totals and breaking the
+# deterministic before/after comparison the manifest exists to provide. Reject it.
+if [ -n "${MANIFEST_OUT:-}" ] && [ -d "$staging_dir" ]; then
+  staging_abs="$(cd "$staging_dir" && pwd -P)"
+  out_parent="$(dirname "$MANIFEST_OUT")"
+  if [ -d "$out_parent" ]; then
+    out_abs="$(cd "$out_parent" && pwd -P)/$(basename "$MANIFEST_OUT")"
+    case "$out_abs" in
+      "$staging_abs"/*)
+        echo "error: MANIFEST_OUT ($MANIFEST_OUT) must not be inside STAGING_DIR ($staging_dir)" >&2
+        exit 2
+        ;;
+    esac
+  fi
+fi
+
 # Advisory only: no --strict, so the generator exits 0 even over budget or with
 # unexpected files. The full manifest and the WARN lines still surface below.
 manifest="$("$generator" "$staging_dir" --budget "$budget")"

--- a/scripts/release/maven-publication-manifest.sh
+++ b/scripts/release/maven-publication-manifest.sh
@@ -64,6 +64,7 @@ done
 
 [ -n "$staging" ] || { echo "error: no staging directory given" >&2; usage >&2; exit 2; }
 [ -d "$staging" ] || { echo "error: staging directory not found: $staging" >&2; exit 2; }
+staging="${staging%/}" # so ${path#"$staging"/} strips cleanly
 
 group_path="${GROUP//.//}"
 
@@ -175,9 +176,11 @@ echo "# columns: coordinate classifier filename bytes"
 sort "$records"
 echo
 echo "## Per-coordinate totals"
-while IFS= read -r coord; do
-  echo "$coord files=${coord_files[$coord]} bytes=${coord_bytes[$coord]}"
-done < <(printf '%s\n' "${!coord_files[@]}" | sort)
+if [ "${#coord_files[@]}" -gt 0 ]; then
+  while IFS= read -r coord; do
+    echo "$coord files=${coord_files[$coord]} bytes=${coord_bytes[$coord]}"
+  done < <(printf '%s\n' "${!coord_files[@]}" | sort)
+fi
 echo
 echo "## Classifier totals"
 line=""
@@ -187,8 +190,7 @@ done
 printf '%s\n' "${line# }"
 echo
 echo "## Release total"
-coord_n="$(printf '%s\n' "${!coord_files[@]}" | grep -c .)"
-echo "coordinates=$coord_n files=$total_files bytes=$total_bytes"
+echo "coordinates=${#coord_files[@]} files=$total_files bytes=$total_bytes"
 
 exit_code=0
 

--- a/scripts/release/maven-publication-manifest.sh
+++ b/scripts/release/maven-publication-manifest.sh
@@ -209,12 +209,15 @@ if [ -n "$budget_file" ]; then
   [ -f "$budget_file" ] || { echo "error: budget file not found: $budget_file" >&2; exit 2; }
   command -v jq >/dev/null 2>&1 || { echo "error: jq is required for --budget" >&2; exit 2; }
   # jq's // treats only null/false as empty, so a real 0 threshold survives.
-  limits="$(jq -r '(.perRelease // {}) | "\(.maxFiles // "") \(.maxBytes // "")"' "$budget_file")"
-  max_files="${limits%% *}"
-  max_bytes="${limits##* }"
-  # Fail closed on a malformed threshold: a non-integer (e.g. 0.5) would reach
-  # bash's integer-only -gt, print "integer expression expected", evaluate false,
-  # and silently report BUDGET OK -- even under --strict.
+  # @tsv keeps an absent/null threshold as an empty field but preserves false,
+  # floats, and strings verbatim -- unlike `// ""`, which would coalesce a JSON
+  # `false` to empty and slip past the integer check below (disabling the budget).
+  limits="$(jq -r '(.perRelease // {}) | [.maxFiles, .maxBytes] | @tsv' "$budget_file")"
+  max_files="$(printf '%s' "$limits" | cut -f1)"
+  max_bytes="$(printf '%s' "$limits" | cut -f2)"
+  # Fail closed on a malformed threshold: a non-integer (0.5, false, "x") would
+  # reach bash's integer-only -gt, print "integer expression expected", evaluate
+  # false, and silently report BUDGET OK -- even under --strict. Empty = no limit.
   for v in "$max_files" "$max_bytes"; do
     if [ -n "$v" ] && ! printf '%s' "$v" | grep -qE '^[0-9]+$'; then
       echo "error: budget thresholds must be non-negative integers (got '$v')" >&2

--- a/scripts/release/maven-publication-manifest.sh
+++ b/scripts/release/maven-publication-manifest.sh
@@ -208,22 +208,28 @@ exit_code=0
 if [ -n "$budget_file" ]; then
   [ -f "$budget_file" ] || { echo "error: budget file not found: $budget_file" >&2; exit 2; }
   command -v jq >/dev/null 2>&1 || { echo "error: jq is required for --budget" >&2; exit 2; }
-  # jq's // treats only null/false as empty, so a real 0 threshold survives.
-  # @tsv keeps an absent/null threshold as an empty field but preserves false,
-  # floats, and strings verbatim -- unlike `// ""`, which would coalesce a JSON
-  # `false` to empty and slip past the integer check below (disabling the budget).
-  limits="$(jq -r '(.perRelease // {}) | [.maxFiles, .maxBytes] | @tsv' "$budget_file")"
+  # Validate the whole budget shape in jq and fail closed on anything malformed,
+  # so nothing silently disables the budget -- not a `// ` coalescing a false/null
+  # field NOR a non-object `perRelease` (e.g. `false`) collapsing to `{}`. Rule:
+  # perRelease is absent or an object; each threshold is absent or a non-negative
+  # integer. Output is "maxFiles<TAB>maxBytes" (empty field = no limit), or the
+  # sentinel INVALID.
+  limits="$(jq -r '
+    def okint: type == "number" and . >= 0 and (floor == .);
+    def field($v): if $v == null then "" elif ($v | okint) then ($v | tostring) else "INVALID" end;
+    .perRelease as $r
+    | if $r == null then "\t"
+      elif ($r | type) != "object" then "INVALID"
+      else field($r.maxFiles) as $f | field($r.maxBytes) as $y
+        | if ($f == "INVALID" or $y == "INVALID") then "INVALID" else ($f + "\t" + $y) end
+      end
+  ' "$budget_file")"
+  if [ "$limits" = "INVALID" ]; then
+    echo "error: budget perRelease must be an object with non-negative integer maxFiles/maxBytes" >&2
+    exit 2
+  fi
   max_files="$(printf '%s' "$limits" | cut -f1)"
   max_bytes="$(printf '%s' "$limits" | cut -f2)"
-  # Fail closed on a malformed threshold: a non-integer (0.5, false, "x") would
-  # reach bash's integer-only -gt, print "integer expression expected", evaluate
-  # false, and silently report BUDGET OK -- even under --strict. Empty = no limit.
-  for v in "$max_files" "$max_bytes"; do
-    if [ -n "$v" ] && ! printf '%s' "$v" | grep -qE '^[0-9]+$'; then
-      echo "error: budget thresholds must be non-negative integers (got '$v')" >&2
-      exit 2
-    fi
-  done
   breached=0
   reasons=""
   if [ -n "$max_files" ] && [ "$total_files" -gt "$max_files" ]; then

--- a/scripts/release/maven-publication-manifest.sh
+++ b/scripts/release/maven-publication-manifest.sh
@@ -115,9 +115,6 @@ classify_metadata() {
   esac
 }
 
-declare -A coord_files=()
-declare -A coord_bytes=()
-declare -A class_count=()
 unexpected_count=0
 total_files=0
 total_bytes=0
@@ -127,7 +124,6 @@ trap 'rm -f "$records"' EXIT
 
 # Known classifiers, printed in a fixed order for a stable classifier-totals line.
 CLASSES="main-jar main-aar sources-jar javadoc-jar pom module maven-metadata signature checksum signature-checksum unexpected"
-for c in $CLASSES; do class_count["$c"]=0; done
 
 while IFS= read -r path; do
   name="${path##*/}"
@@ -158,9 +154,6 @@ while IFS= read -r path; do
   bytes="$(wc -c <"$path" | tr -d ' ')"
   printf '%s %s %s %s\n' "$coord" "$classifier" "$name" "$bytes" >>"$records"
 
-  coord_files["$coord"]=$(( ${coord_files["$coord"]:-0} + 1 ))
-  coord_bytes["$coord"]=$(( ${coord_bytes["$coord"]:-0} + bytes ))
-  class_count["$classifier"]=$(( ${class_count["$classifier"]:-0} + 1 ))
   total_files=$(( total_files + 1 ))
   total_bytes=$(( total_bytes + bytes ))
   if [ "$classifier" = unexpected ]; then
@@ -175,22 +168,26 @@ echo "# group: $GROUP"
 echo "# columns: coordinate classifier filename bytes"
 sort "$records"
 echo
+# Per-coordinate and per-classifier aggregation runs in awk, not bash associative
+# arrays, so the script works on bash 3.2 (macOS system bash, used by CI's BATS).
 echo "## Per-coordinate totals"
-if [ "${#coord_files[@]}" -gt 0 ]; then
-  while IFS= read -r coord; do
-    echo "$coord files=${coord_files[$coord]} bytes=${coord_bytes[$coord]}"
-  done < <(printf '%s\n' "${!coord_files[@]}" | sort)
-fi
+awk '{ f[$1]++; b[$1] += $4 } END { for (c in f) printf "%s files=%d bytes=%d\n", c, f[c], b[c] }' \
+  "$records" | sort
 echo
 echo "## Classifier totals"
-line=""
-for c in $CLASSES; do
-  line="$line $c=${class_count[$c]}"
-done
-printf '%s\n' "${line# }"
+awk -v classes="$CLASSES" '
+  { c[$2]++ }
+  END {
+    n = split(classes, a, " ")
+    out = ""
+    for (i = 1; i <= n; i++) out = out (i > 1 ? " " : "") a[i] "=" (c[a[i]] + 0)
+    print out
+  }
+' "$records"
 echo
 echo "## Release total"
-echo "coordinates=${#coord_files[@]} files=$total_files bytes=$total_bytes"
+coord_n="$(cut -d' ' -f1 "$records" | sort -u | wc -l | tr -d ' ')"
+echo "coordinates=$coord_n files=$total_files bytes=$total_bytes"
 
 exit_code=0
 

--- a/scripts/release/maven-publication-manifest.sh
+++ b/scripts/release/maven-publication-manifest.sh
@@ -176,21 +176,21 @@ while IFS= read -r path; do
   if [ "$classifier" = unexpected ]; then
     unexpected_count=$(( unexpected_count + 1 ))
   fi
-done < <(sort "$files_list")
+done < <(LC_ALL=C sort "$files_list")
 
 echo >&2 "staging: $staging"
 
 echo "# Maven Central publication manifest"
 echo "# group: $GROUP"
 echo "# columns: coordinate classifier filename bytes"
-sort "$records" | tr '\t' ' '
+LC_ALL=C sort "$records" | tr '\t' ' '
 echo
 # Per-coordinate and per-classifier aggregation runs in awk, not bash associative
 # arrays, so the script works on bash 3.2 (macOS system bash, used by CI's BATS).
 # -F'\t' keeps a space-containing filename in a single field.
 echo "## Per-coordinate totals"
 awk -F'\t' '{ f[$1]++; b[$1] += $4 } END { for (c in f) printf "%s files=%d bytes=%d\n", c, f[c], b[c] }' \
-  "$records" | sort
+  "$records" | LC_ALL=C sort
 echo
 echo "## Classifier totals"
 awk -F'\t' -v classes="$CLASSES" '
@@ -204,7 +204,7 @@ awk -F'\t' -v classes="$CLASSES" '
 ' "$records"
 echo
 echo "## Release total"
-coord_n="$(cut -f1 "$records" | sort -u | wc -l | tr -d ' ')"
+coord_n="$(cut -f1 "$records" | LC_ALL=C sort -u | wc -l | tr -d ' ')"
 echo "coordinates=$coord_n files=$total_files bytes=$total_bytes"
 
 exit_code=0
@@ -212,23 +212,24 @@ exit_code=0
 if [ -n "$budget_file" ]; then
   [ -f "$budget_file" ] || { echo "error: budget file not found: $budget_file" >&2; exit 2; }
   command -v jq >/dev/null 2>&1 || { echo "error: jq is required for --budget" >&2; exit 2; }
-  # An empty or truncated file makes jq succeed with no output, which would read
-  # as "no limits" -- require exactly one JSON object first, so a broken policy
-  # file fails closed instead of silently disabling the budget.
-  jq -e 'type == "object"' "$budget_file" >/dev/null 2>&1 || {
+  # Require EXACTLY ONE JSON object. Slurp (-s) so an empty file (0 values) or a
+  # multi-document file (>1 value) fails closed instead of reading as "no limits"
+  # -- jq -e without -s validates a stream one value at a time and would accept
+  # both, and the later extraction would emit multiple lines.
+  jq -e -s 'length == 1 and (.[0] | type == "object")' "$budget_file" >/dev/null 2>&1 || {
     echo "error: budget file must be a single JSON object: $budget_file" >&2
     exit 2
   }
-  # Validate the whole budget shape in jq and fail closed on anything malformed,
-  # so nothing silently disables the budget -- not a `// ` coalescing a false/null
+  # Validate the whole budget shape and fail closed on anything malformed, so
+  # nothing silently disables the budget -- not a `//` coalescing a false/null
   # field NOR a non-object `perRelease` (e.g. `false`) collapsing to `{}`. Rule:
   # perRelease is absent or an object; each threshold is absent or a non-negative
   # integer. Output is "maxFiles<TAB>maxBytes" (empty field = no limit), or the
   # sentinel INVALID.
-  limits="$(jq -r '
+  limits="$(jq -r -s '
     def okint: type == "number" and . >= 0 and (floor == .);
     def field($v): if $v == null then "" elif ($v | okint) then ($v | tostring) else "INVALID" end;
-    .perRelease as $r
+    .[0].perRelease as $r
     | if $r == null then "\t"
       elif ($r | type) != "object" then "INVALID"
       else field($r.maxFiles) as $f | field($r.maxBytes) as $y

--- a/scripts/release/maven-publication-manifest.sh
+++ b/scripts/release/maven-publication-manifest.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+#
+# Maven Central publication manifest + usage-budget preflight (issue #4853).
+#
+# Enumerates every file a tagged release would upload to Maven Central and prints
+# a deterministic manifest: one line per file (coordinate, classifier, filename,
+# bytes), per-coordinate subtotals, classifier totals, and a release grand total.
+# It reads a locally-staged Maven file repository -- produced by
+# `./gradlew publishAllPublicationsToCentralManifestRepository` (see the
+# `centralManifest` repo in android/build.gradle.kts) -- so it needs NO Maven
+# Central credentials and performs NO remote publish.
+#
+# Usage:
+#   maven-publication-manifest.sh <staging-dir> [--budget <file>] [--strict]
+#                                 [--group <groupId>]
+#
+# The manifest (stdout) is deterministic and path-independent so the artifact-
+# reduction work (#4851, #4852) can diff a before/after capture as a regression
+# oracle. Diagnostics go to stderr.
+#
+# Exit codes:
+#   0  manifest generated. This is the default even when unexpected files are
+#      present or the budget is exceeded -- the preflight reports, it never
+#      blocks a release (a security fix must always ship).
+#   1  --strict and an unexpected classifier/sidecar was found.
+#   2  usage error (missing/for unreadable staging dir or budget file).
+#   3  --strict and the usage budget was exceeded (no unexpected files).
+
+set -euo pipefail
+
+GROUP="dev.jasonpearson.auto-mobile"
+budget_file=""
+strict=0
+staging=""
+
+usage() {
+  sed -n '2,33p' "$0" | sed 's/^#\{1,2\} \{0,1\}//'
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --budget)
+      budget_file="${2:-}"
+      [ -n "$budget_file" ] || { echo "error: --budget needs a file" >&2; exit 2; }
+      shift 2
+      ;;
+    --group)
+      GROUP="${2:-}"
+      [ -n "$GROUP" ] || { echo "error: --group needs a value" >&2; exit 2; }
+      shift 2
+      ;;
+    --strict) strict=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    -*) echo "error: unknown option: $1" >&2; exit 2 ;;
+    *)
+      if [ -z "$staging" ]; then
+        staging="$1"; shift
+      else
+        echo "error: unexpected argument: $1" >&2; exit 2
+      fi
+      ;;
+  esac
+done
+
+[ -n "$staging" ] || { echo "error: no staging directory given" >&2; usage >&2; exit 2; }
+[ -d "$staging" ] || { echo "error: staging directory not found: $staging" >&2; exit 2; }
+
+group_path="${GROUP//.//}"
+
+# classify_versioned <filename> <artifact> <version>
+# Files inside an artifact's version directory. Strips a trailing checksum
+# extension and a .asc signature extension, then matches the base against the
+# known primary set. Anything whose base is not a known primary is `unexpected`
+# -- which catches both novel classifiers (a -tests.jar) and stray sidecars
+# (a .asc.asc).
+classify_versioned() {
+  local name="$1" art="$2" ver="$3"
+  local prefix="$art-$ver"
+  local work="$name" checksum="" sig=""
+  case "$work" in
+    *.md5) checksum=1; work="${work%.md5}" ;;
+    *.sha1) checksum=1; work="${work%.sha1}" ;;
+    *.sha256) checksum=1; work="${work%.sha256}" ;;
+    *.sha512) checksum=1; work="${work%.sha512}" ;;
+  esac
+  case "$work" in
+    *.asc) sig=1; work="${work%.asc}" ;;
+  esac
+  local kind
+  case "$work" in
+    "$prefix.jar") kind=main-jar ;;
+    "$prefix.aar") kind=main-aar ;;
+    "$prefix-sources.jar") kind=sources-jar ;;
+    "$prefix-javadoc.jar") kind=javadoc-jar ;;
+    "$prefix.pom") kind=pom ;;
+    "$prefix.module") kind=module ;;
+    *) kind=unexpected ;;
+  esac
+  if [ "$kind" = unexpected ]; then echo unexpected; return; fi
+  if [ -n "$sig" ] && [ -n "$checksum" ]; then echo signature-checksum; return; fi
+  if [ -n "$sig" ]; then echo signature; return; fi
+  if [ -n "$checksum" ]; then echo checksum; return; fi
+  echo "$kind"
+}
+
+# classify_metadata <filename> -- maven-metadata.xml and its checksums, which sit
+# one level above the version directory.
+classify_metadata() {
+  case "$1" in
+    maven-metadata.xml) echo maven-metadata ;;
+    maven-metadata.xml.md5|maven-metadata.xml.sha1|maven-metadata.xml.sha256|maven-metadata.xml.sha512)
+      echo checksum ;;
+    *) echo unexpected ;;
+  esac
+}
+
+declare -A coord_files=()
+declare -A coord_bytes=()
+declare -A class_count=()
+unexpected_count=0
+total_files=0
+total_bytes=0
+
+records="$(mktemp)"
+trap 'rm -f "$records"' EXIT
+
+# Known classifiers, printed in a fixed order for a stable classifier-totals line.
+CLASSES="main-jar main-aar sources-jar javadoc-jar pom module maven-metadata signature checksum signature-checksum unexpected"
+for c in $CLASSES; do class_count["$c"]=0; done
+
+while IFS= read -r path; do
+  name="${path##*/}"
+  rel="${path#"$staging"/}"
+  sub="${rel#"$group_path"/}"
+  coord="unknown"
+  classifier="unexpected"
+  if [ "$sub" != "$rel" ]; then
+    # sub is artifact/version/file (3 parts) or artifact/maven-metadata.xml (2).
+    art="${sub%%/*}"
+    tail="${sub#*/}"
+    coord="$GROUP:$art"
+    if [ "$tail" = "$sub" ]; then
+      classifier="unexpected" # file directly under the group dir
+    elif [ "${tail#*/}" = "$tail" ]; then
+      classifier="$(classify_metadata "$tail")" # artifact/<file>
+    else
+      ver="${tail%%/*}"
+      file="${tail#*/}"
+      if [ "${file#*/}" != "$file" ]; then
+        classifier="unexpected" # deeper than artifact/version/file
+      else
+        classifier="$(classify_versioned "$file" "$art" "$ver")"
+      fi
+    fi
+  fi
+
+  bytes="$(wc -c <"$path" | tr -d ' ')"
+  printf '%s %s %s %s\n' "$coord" "$classifier" "$name" "$bytes" >>"$records"
+
+  coord_files["$coord"]=$(( ${coord_files["$coord"]:-0} + 1 ))
+  coord_bytes["$coord"]=$(( ${coord_bytes["$coord"]:-0} + bytes ))
+  class_count["$classifier"]=$(( ${class_count["$classifier"]:-0} + 1 ))
+  total_files=$(( total_files + 1 ))
+  total_bytes=$(( total_bytes + bytes ))
+  if [ "$classifier" = unexpected ]; then
+    unexpected_count=$(( unexpected_count + 1 ))
+  fi
+done < <(find "$staging" -type f | sort)
+
+echo >&2 "staging: $staging"
+
+echo "# Maven Central publication manifest"
+echo "# group: $GROUP"
+echo "# columns: coordinate classifier filename bytes"
+sort "$records"
+echo
+echo "## Per-coordinate totals"
+while IFS= read -r coord; do
+  echo "$coord files=${coord_files[$coord]} bytes=${coord_bytes[$coord]}"
+done < <(printf '%s\n' "${!coord_files[@]}" | sort)
+echo
+echo "## Classifier totals"
+line=""
+for c in $CLASSES; do
+  line="$line $c=${class_count[$c]}"
+done
+printf '%s\n' "${line# }"
+echo
+echo "## Release total"
+coord_n="$(printf '%s\n' "${!coord_files[@]}" | grep -c .)"
+echo "coordinates=$coord_n files=$total_files bytes=$total_bytes"
+
+exit_code=0
+
+if [ -n "$budget_file" ]; then
+  [ -f "$budget_file" ] || { echo "error: budget file not found: $budget_file" >&2; exit 2; }
+  limits="$(node -e '
+    const fs = require("fs");
+    const b = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+    const r = b.perRelease || {};
+    const f = r.maxFiles == null ? "" : r.maxFiles;
+    const y = r.maxBytes == null ? "" : r.maxBytes;
+    process.stdout.write(f + " " + y);
+  ' "$budget_file")"
+  max_files="${limits%% *}"
+  max_bytes="${limits##* }"
+  breached=0
+  reasons=""
+  if [ -n "$max_files" ] && [ "$total_files" -gt "$max_files" ]; then
+    breached=1; reasons="files $total_files > $max_files"
+  fi
+  if [ -n "$max_bytes" ] && [ "$total_bytes" -gt "$max_bytes" ]; then
+    breached=1
+    [ -n "$reasons" ] && reasons="$reasons; "
+    reasons="${reasons}bytes $total_bytes > $max_bytes"
+  fi
+  echo
+  if [ "$breached" -eq 1 ]; then
+    echo "BUDGET WARN: $reasons (advisory -- does not block the release)"
+    [ "$strict" -eq 1 ] && exit_code=3
+  else
+    echo "BUDGET OK: files=$total_files/${max_files:-inf} bytes=$total_bytes/${max_bytes:-inf}"
+  fi
+fi
+
+if [ "$unexpected_count" -gt 0 ]; then
+  echo >&2 "warning: $unexpected_count unexpected file(s) in the staged publication"
+  [ "$strict" -eq 1 ] && exit_code=1
+fi
+
+exit "$exit_code"

--- a/scripts/release/maven-publication-manifest.sh
+++ b/scripts/release/maven-publication-manifest.sh
@@ -166,7 +166,10 @@ while IFS= read -r path; do
   fi
 
   bytes="$(wc -c <"$path" | tr -d ' ')"
-  printf '%s %s %s %s\n' "$coord" "$classifier" "$name" "$bytes" >>"$records"
+  # Tab-delimited so a stray unexpected filename containing spaces cannot shift
+  # the bytes field in the awk aggregation below (Maven names never contain
+  # spaces, but the tool must still count an unexpected file correctly).
+  printf '%s\t%s\t%s\t%s\n' "$coord" "$classifier" "$name" "$bytes" >>"$records"
 
   total_files=$(( total_files + 1 ))
   total_bytes=$(( total_bytes + bytes ))
@@ -180,16 +183,17 @@ echo >&2 "staging: $staging"
 echo "# Maven Central publication manifest"
 echo "# group: $GROUP"
 echo "# columns: coordinate classifier filename bytes"
-sort "$records"
+sort "$records" | tr '\t' ' '
 echo
 # Per-coordinate and per-classifier aggregation runs in awk, not bash associative
 # arrays, so the script works on bash 3.2 (macOS system bash, used by CI's BATS).
+# -F'\t' keeps a space-containing filename in a single field.
 echo "## Per-coordinate totals"
-awk '{ f[$1]++; b[$1] += $4 } END { for (c in f) printf "%s files=%d bytes=%d\n", c, f[c], b[c] }' \
+awk -F'\t' '{ f[$1]++; b[$1] += $4 } END { for (c in f) printf "%s files=%d bytes=%d\n", c, f[c], b[c] }' \
   "$records" | sort
 echo
 echo "## Classifier totals"
-awk -v classes="$CLASSES" '
+awk -F'\t' -v classes="$CLASSES" '
   { c[$2]++ }
   END {
     n = split(classes, a, " ")
@@ -200,7 +204,7 @@ awk -v classes="$CLASSES" '
 ' "$records"
 echo
 echo "## Release total"
-coord_n="$(cut -d' ' -f1 "$records" | sort -u | wc -l | tr -d ' ')"
+coord_n="$(cut -f1 "$records" | sort -u | wc -l | tr -d ' ')"
 echo "coordinates=$coord_n files=$total_files bytes=$total_bytes"
 
 exit_code=0
@@ -208,6 +212,13 @@ exit_code=0
 if [ -n "$budget_file" ]; then
   [ -f "$budget_file" ] || { echo "error: budget file not found: $budget_file" >&2; exit 2; }
   command -v jq >/dev/null 2>&1 || { echo "error: jq is required for --budget" >&2; exit 2; }
+  # An empty or truncated file makes jq succeed with no output, which would read
+  # as "no limits" -- require exactly one JSON object first, so a broken policy
+  # file fails closed instead of silently disabling the budget.
+  jq -e 'type == "object"' "$budget_file" >/dev/null 2>&1 || {
+    echo "error: budget file must be a single JSON object: $budget_file" >&2
+    exit 2
+  }
   # Validate the whole budget shape in jq and fail closed on anything malformed,
   # so nothing silently disables the budget -- not a `// ` coalescing a false/null
   # field NOR a non-object `perRelease` (e.g. `false`) collapsing to `{}`. Rule:

--- a/scripts/release/maven-publication-manifest.sh
+++ b/scripts/release/maven-publication-manifest.sh
@@ -196,14 +196,9 @@ exit_code=0
 
 if [ -n "$budget_file" ]; then
   [ -f "$budget_file" ] || { echo "error: budget file not found: $budget_file" >&2; exit 2; }
-  limits="$(node -e '
-    const fs = require("fs");
-    const b = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
-    const r = b.perRelease || {};
-    const f = r.maxFiles == null ? "" : r.maxFiles;
-    const y = r.maxBytes == null ? "" : r.maxBytes;
-    process.stdout.write(f + " " + y);
-  ' "$budget_file")"
+  command -v jq >/dev/null 2>&1 || { echo "error: jq is required for --budget" >&2; exit 2; }
+  # jq's // treats only null/false as empty, so a real 0 threshold survives.
+  limits="$(jq -r '(.perRelease // {}) | "\(.maxFiles // "") \(.maxBytes // "")"' "$budget_file")"
   max_files="${limits%% *}"
   max_bytes="${limits##* }"
   breached=0

--- a/scripts/release/maven-publication-manifest.sh
+++ b/scripts/release/maven-publication-manifest.sh
@@ -67,7 +67,11 @@ done
 
 [ -n "$staging" ] || { echo "error: no staging directory given" >&2; usage >&2; exit 2; }
 [ -d "$staging" ] || { echo "error: staging directory not found: $staging" >&2; exit 2; }
-staging="${staging%/}" # so ${path#"$staging"/} strips cleanly
+# Strip every trailing slash (not just one) so ${path#"$staging"/} strips cleanly;
+# keep "/" itself non-empty.
+while [ "$staging" != "/" ] && [ "$staging" != "${staging%/}" ]; do
+  staging="${staging%/}"
+done
 
 group_path="${GROUP//.//}"
 
@@ -189,7 +193,10 @@ echo
 # arrays, so the script works on bash 3.2 (macOS system bash, used by CI's BATS).
 # -F'\t' keeps a space-containing filename in a single field.
 echo "## Per-coordinate totals"
-awk -F'\t' '{ f[$1]++; b[$1] += $4 } END { for (c in f) printf "%s files=%d bytes=%d\n", c, f[c], b[c] }' \
+# bytes is the LAST field ($NF), not $4, so even a filename containing tabs (which
+# would add fields) cannot shift the byte count -- coord ($1) and classifier ($2)
+# precede the name, so they are never shifted either.
+awk -F'\t' '{ f[$1]++; b[$1] += $NF } END { for (c in f) printf "%s files=%d bytes=%d\n", c, f[c], b[c] }' \
   "$records" | LC_ALL=C sort
 echo
 echo "## Classifier totals"

--- a/scripts/release/maven-publication-manifest.sh
+++ b/scripts/release/maven-publication-manifest.sh
@@ -34,7 +34,10 @@ strict=0
 staging=""
 
 usage() {
-  sed -n '2,33p' "$0" | sed 's/^#\{1,2\} \{0,1\}//'
+  # Print the contiguous header comment block (line 2 to the first non-comment
+  # line), stripping the leading "# ". Robust to line-number drift, so it never
+  # leaks `set -euo pipefail` or the variable declarations into --help output.
+  awk 'NR == 1 { next } /^#/ { sub(/^#+ ?/, ""); print; next } { exit }' "$0"
 }
 
 while [ $# -gt 0 ]; do
@@ -120,7 +123,18 @@ total_files=0
 total_bytes=0
 
 records="$(mktemp)"
-trap 'rm -f "$records"' EXIT
+files_list="$(mktemp)"
+trap 'rm -f "$records" "$files_list"' EXIT
+
+# Enumerate the staged files first, and fail closed if traversal errors (e.g. an
+# unreadable subtree) -- otherwise the error happens inside a process
+# substitution where set -euo pipefail cannot see it, and the script would emit a
+# partial manifest with exit 0. -H follows a command-line symlink to the repo dir
+# so a symlinked staging path is traversed rather than counted as one file.
+if ! find -H "$staging" -type f >"$files_list"; then
+  echo "error: could not fully read staging directory: $staging" >&2
+  exit 2
+fi
 
 # Known classifiers, printed in a fixed order for a stable classifier-totals line.
 CLASSES="main-jar main-aar sources-jar javadoc-jar pom module maven-metadata signature checksum signature-checksum unexpected"
@@ -159,7 +173,7 @@ while IFS= read -r path; do
   if [ "$classifier" = unexpected ]; then
     unexpected_count=$(( unexpected_count + 1 ))
   fi
-done < <(find "$staging" -type f | sort)
+done < <(sort "$files_list")
 
 echo >&2 "staging: $staging"
 
@@ -198,6 +212,15 @@ if [ -n "$budget_file" ]; then
   limits="$(jq -r '(.perRelease // {}) | "\(.maxFiles // "") \(.maxBytes // "")"' "$budget_file")"
   max_files="${limits%% *}"
   max_bytes="${limits##* }"
+  # Fail closed on a malformed threshold: a non-integer (e.g. 0.5) would reach
+  # bash's integer-only -gt, print "integer expression expected", evaluate false,
+  # and silently report BUDGET OK -- even under --strict.
+  for v in "$max_files" "$max_bytes"; do
+    if [ -n "$v" ] && ! printf '%s' "$v" | grep -qE '^[0-9]+$'; then
+      echo "error: budget thresholds must be non-negative integers (got '$v')" >&2
+      exit 2
+    fi
+  done
   breached=0
   reasons=""
   if [ -n "$max_files" ] && [ "$total_files" -gt "$max_files" ]; then

--- a/scripts/release/maven-usage-budget.json
+++ b/scripts/release/maven-usage-budget.json
@@ -1,0 +1,18 @@
+{
+  "$comment": [
+    "Advisory usage budget for the Maven Central publication (issue #4853).",
+    "Consumed by scripts/release/maven-publication-manifest.sh --budget. A breach",
+    "prints a BUDGET WARN and, by default, still exits 0: the preflight reports,",
+    "it never blocks a release, so an urgent security fix always ships. Only",
+    "--strict turns a breach into a non-zero exit.",
+    "Thresholds are per single tagged release across all four Maven coordinates,",
+    "derived from the current Maven Central Usage Center baseline (~200 staged",
+    "files, ~4.5 MiB) with deliberate headroom. Tighten maxBytes after the",
+    "artifact-reduction work (#4851 signature checksums, #4852 Dokka javadoc)",
+    "lands, and raise the ceilings intentionally when a new coordinate is added."
+  ],
+  "perRelease": {
+    "maxFiles": 320,
+    "maxBytes": 8000000
+  }
+}

--- a/scripts/release/maven-usage-budget.json
+++ b/scripts/release/maven-usage-budget.json
@@ -5,14 +5,27 @@
     "prints a BUDGET WARN and, by default, still exits 0: the preflight reports,",
     "it never blocks a release, so an urgent security fix always ships. Only",
     "--strict turns a breach into a non-zero exit.",
-    "Thresholds are per single tagged release across all four Maven coordinates,",
-    "derived from the current Maven Central Usage Center baseline (~200 staged",
-    "files, ~4.5 MiB) with deliberate headroom. Tighten maxBytes after the",
-    "artifact-reduction work (#4851 signature checksums, #4852 Dokka javadoc)",
-    "lands, and raise the ceilings intentionally when a new coordinate is added."
+    "",
+    "centralOrgLimits records the real Maven Central Usage Center ceilings, which",
+    "are MONTHLY and aggregate across every namespace in the org (not per release).",
+    "Observed 2026-07: 15.43 MB of 80 MB, 320 of 1000 files, 4 of 7 releases.",
+    "",
+    "perRelease is what this preflight actually checks -- one tagged release's",
+    "footprint as staged locally. Note the preflight over-counts vs Central: the",
+    "local file repo also writes maven-metadata and every Gradle checksum, so a",
+    "release Central tallies at ~80 files shows here as ~200 signed. These",
+    "thresholds are therefore relative guardrails on the local manifest with",
+    "headroom, sized so a normal release cadence stays well inside the monthly",
+    "ceilings. Tighten maxBytes after #4851 (signature checksums) and #4852 (Dokka",
+    "javadoc) land, and raise a ceiling deliberately when a new coordinate is added."
   ],
+  "centralOrgLimits": {
+    "monthlyReleaseSizeBytes": 83886080,
+    "monthlyFileCount": 1000,
+    "monthlyReleaseCount": 7
+  },
   "perRelease": {
-    "maxFiles": 320,
-    "maxBytes": 8000000
+    "maxFiles": 260,
+    "maxBytes": 6291456
   }
 }

--- a/test/bats/maven-publication-manifest.bats
+++ b/test/bats/maven-publication-manifest.bats
@@ -216,6 +216,17 @@ JSON
   [[ "$output" == *"STAGING_DIR"* ]]
 }
 
+@test "preflight rejects a symlink MANIFEST_OUT (could redirect into staging)" {
+  local preflight="$REPO_ROOT/scripts/release/maven-publication-manifest-preflight.sh"
+  local link
+  link="$(mktemp -d)/out.txt"
+  ln -s "$STAGE/manifest.txt" "$link" # target inside staging, parent outside
+  STAGING_DIR="$STAGE" MANIFEST_OUT="$link" run bash "$preflight"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"symlink"* ]]
+  rm -rf "$(dirname "$link")"
+}
+
 @test "preflight appends a totals block to GITHUB_STEP_SUMMARY when set" {
   local preflight="$REPO_ROOT/scripts/release/maven-publication-manifest-preflight.sh"
   local summary
@@ -275,5 +286,16 @@ JSON
   run bash "$SCRIPT" "$STAGE" --budget "$budget"
   [ "$status" -ne 0 ]
   [[ "$output" == *"integer"* ]]
+  [[ "$output" != *"BUDGET OK"* ]]
+}
+
+@test "a non-object perRelease fails closed (container-level coalescing)" {
+  # `(.perRelease // {})` would turn false into {} and disable both limits.
+  local budget="$STAGE/container-budget.json"
+  cat >"$budget" <<'JSON'
+{ "perRelease": false }
+JSON
+  run bash "$SCRIPT" "$STAGE" --budget "$budget"
+  [ "$status" -ne 0 ]
   [[ "$output" != *"BUDGET OK"* ]]
 }

--- a/test/bats/maven-publication-manifest.bats
+++ b/test/bats/maven-publication-manifest.bats
@@ -299,3 +299,24 @@ JSON
   [ "$status" -ne 0 ]
   [[ "$output" != *"BUDGET OK"* ]]
 }
+
+@test "an empty budget file fails closed, not silently unlimited" {
+  local budget="$STAGE/empty-budget.json"
+  : >"$budget"
+  run bash "$SCRIPT" "$STAGE" --budget "$budget"
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"BUDGET OK"* ]]
+}
+
+@test "an unexpected filename with a space keeps correct byte subtotals" {
+  local dir="$STAGE/$GROUP_PATH/auto-mobile-protocol/0.0.47"
+  head -c 7 /dev/zero >"$dir/stray file.jar" # space in the name
+  run bash "$SCRIPT" "$STAGE"
+  [ "$status" -eq 0 ]
+  # The per-coordinate subtotal must not collapse to bytes=0 from field shifting;
+  # the independent byte oracle still equals the grand total.
+  local expected
+  expected="$(find "$STAGE" -type f -exec cat {} + | wc -c | tr -d ' ')"
+  [[ "$output" == *"bytes=$expected"* ]]
+  [[ "$output" == *"stray file.jar"* ]]
+}

--- a/test/bats/maven-publication-manifest.bats
+++ b/test/bats/maven-publication-manifest.bats
@@ -316,15 +316,40 @@ JSON
   [[ "$output" != *"BUDGET OK"* ]]
 }
 
+# Sum the per-coordinate `bytes=` subtotals; a field-shift bug would make this
+# disagree with the release grand total (which is a bash scalar, computed
+# independently of the awk aggregation).
+per_coordinate_byte_sum() {
+  printf '%s\n' "$1" | awk '
+    /^dev[.].*files=.*bytes=/ { for (i = 1; i <= NF; i++) if ($i ~ /^bytes=/) { sub(/bytes=/, "", $i); s += $i } }
+    END { print s + 0 }'
+}
+
 @test "an unexpected filename with a space keeps correct byte subtotals" {
   local dir="$STAGE/$GROUP_PATH/auto-mobile-protocol/0.0.47"
   head -c 7 /dev/zero >"$dir/stray file.jar" # space in the name
   run bash "$SCRIPT" "$STAGE"
   [ "$status" -eq 0 ]
-  # The per-coordinate subtotal must not collapse to bytes=0 from field shifting;
-  # the independent byte oracle still equals the grand total.
-  local expected
-  expected="$(find "$STAGE" -type f -exec cat {} + | wc -c | tr -d ' ')"
-  [[ "$output" == *"bytes=$expected"* ]]
+  local oracle
+  oracle="$(find "$STAGE" -type f -exec cat {} + | wc -c | tr -d ' ')"
+  [[ "$output" == *"coordinates=2 files=111 bytes=$oracle"* ]]
+  [ "$(per_coordinate_byte_sum "$output")" -eq "$oracle" ]
   [[ "$output" == *"stray file.jar"* ]]
+}
+
+@test "an unexpected filename with a tab keeps correct byte subtotals" {
+  local dir="$STAGE/$GROUP_PATH/auto-mobile-protocol/0.0.47"
+  head -c 7 /dev/zero >"$dir/$(printf 'tabbed\tfile').jar" # literal tab in the name
+  run bash "$SCRIPT" "$STAGE"
+  [ "$status" -eq 0 ]
+  local oracle
+  oracle="$(find "$STAGE" -type f -exec cat {} + | wc -c | tr -d ' ')"
+  # bytes=$NF keeps the byte count correct despite the extra tab field.
+  [ "$(per_coordinate_byte_sum "$output")" -eq "$oracle" ]
+}
+
+@test "a staging path with multiple trailing slashes is handled" {
+  run bash "$SCRIPT" "$STAGE//" --strict
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"files=110"* ]]
 }

--- a/test/bats/maven-publication-manifest.bats
+++ b/test/bats/maven-publication-manifest.bats
@@ -171,6 +171,21 @@ JSON
   [ "$status" -eq 0 ]
 }
 
+@test "an empty (but existing) staging directory reports zero, not a crash" {
+  local empty
+  empty="$(mktemp -d)"
+  run bash "$SCRIPT" "$empty"
+  rmdir "$empty"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"coordinates=0 files=0 bytes=0"* ]]
+}
+
+@test "a trailing slash on the staging path is handled" {
+  run bash "$SCRIPT" "$STAGE/"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"files=110"* ]]
+}
+
 @test "a missing staging directory fails clearly" {
   run bash "$SCRIPT" "$STAGE/does-not-exist"
   [ "$status" -ne 0 ]

--- a/test/bats/maven-publication-manifest.bats
+++ b/test/bats/maven-publication-manifest.bats
@@ -1,0 +1,178 @@
+#!/usr/bin/env bats
+#
+# Tests for scripts/release/maven-publication-manifest.sh (issue #4853).
+#
+# The preflight enumerates every file a tagged release would upload to Maven
+# Central from a locally-staged Maven file repository -- no credentials, no
+# remote publish. These tests exercise the generator against a hand-built
+# staging tree that mirrors what a signed Gradle publication produces, so they
+# stay deterministic and fast without running Gradle.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  SCRIPT="$REPO_ROOT/scripts/release/maven-publication-manifest.sh"
+  BUDGET_FILE="$REPO_ROOT/scripts/release/maven-usage-budget.json"
+  GROUP_PATH="dev/jasonpearson/auto-mobile"
+  STAGE="$(mktemp -d)"
+  build_release "$STAGE"
+}
+
+teardown() {
+  rm -rf "$STAGE"
+}
+
+# _sidecars <file> -- the four checksum files Gradle writes next to every artifact.
+_sidecars() {
+  local f="$1"
+  head -c 32 /dev/zero >"$f.md5"
+  head -c 40 /dev/zero >"$f.sha1"
+  head -c 64 /dev/zero >"$f.sha256"
+  head -c 128 /dev/zero >"$f.sha512"
+}
+
+# stage_primary <artifact> <version> <filename> <bytes>
+# A signed publication file: the file itself, its four checksums, a .asc
+# signature, and the signature's own four checksums (the redundant set #4851
+# targets).
+stage_primary() {
+  local art="$1" ver="$2" name="$3" bytes="$4"
+  local dir="$STAGE/$GROUP_PATH/$art/$ver"
+  mkdir -p "$dir"
+  head -c "$bytes" /dev/zero >"$dir/$name"
+  _sidecars "$dir/$name"
+  head -c 200 /dev/zero >"$dir/$name.asc"
+  _sidecars "$dir/$name.asc"
+}
+
+# stage_metadata <artifact> -- maven-metadata.xml plus its four checksums
+# (unsigned, one level above the version directory).
+stage_metadata() {
+  local art="$1"
+  local dir="$STAGE/$GROUP_PATH/$art"
+  mkdir -p "$dir"
+  head -c 358 /dev/zero >"$dir/maven-metadata.xml"
+  _sidecars "$dir/maven-metadata.xml"
+}
+
+build_release() {
+  local art
+  for art in auto-mobile-protocol auto-mobile-sdk; do
+    stage_primary "$art" 0.0.47 "$art-0.0.47.jar" 1000
+    stage_primary "$art" 0.0.47 "$art-0.0.47-sources.jar" 100
+    stage_primary "$art" 0.0.47 "$art-0.0.47-javadoc.jar" 100
+    stage_primary "$art" 0.0.47 "$art-0.0.47.pom" 500
+    stage_primary "$art" 0.0.47 "$art-0.0.47.module" 300
+    stage_metadata "$art"
+  done
+}
+
+@test "manifest lists every staged coordinate" {
+  run bash "$SCRIPT" "$STAGE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"dev.jasonpearson.auto-mobile:auto-mobile-protocol"* ]]
+  [[ "$output" == *"dev.jasonpearson.auto-mobile:auto-mobile-sdk"* ]]
+}
+
+@test "manifest reports a per-coordinate file count and byte subtotal" {
+  run bash "$SCRIPT" "$STAGE"
+  [ "$status" -eq 0 ]
+  # 5 signed primaries * (1 + 4 checksums + 1 sig + 4 sig checksums) = 50, plus
+  # maven-metadata + its 4 checksums = 5 => 55 files per coordinate.
+  [[ "$output" == *"auto-mobile-protocol"*"files=55"* ]]
+  [[ "$output" == *"auto-mobile-sdk"*"files=55"* ]]
+}
+
+@test "manifest reports a release grand total, not only an aggregate" {
+  run bash "$SCRIPT" "$STAGE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"coordinates=2"* ]]
+  [[ "$output" == *"files=110"* ]]
+  # Independent byte oracle: concatenating every file yields the total bytes.
+  local expected
+  expected="$(find "$STAGE" -type f -exec cat {} + | wc -c | tr -d ' ')"
+  [[ "$output" == *"bytes=$expected"* ]]
+}
+
+@test "manifest classifies signature checksums distinctly (the #4851 lever)" {
+  run bash "$SCRIPT" "$STAGE"
+  [ "$status" -eq 0 ]
+  # 5 signatures * 4 checksums * 2 coordinates = 40 signature-checksum files.
+  [[ "$output" == *"signature-checksum=40"* ]]
+}
+
+@test "manifest classifies the javadoc jar distinctly (the #4852 lever)" {
+  run bash "$SCRIPT" "$STAGE"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"javadoc-jar=2"* ]]
+}
+
+@test "an Android library .aar primary is a known artifact, not unexpected" {
+  # auto-mobile-sdk publishes an .aar (not a .jar) as its main artifact; the
+  # classifier must recognize it or every release would report false positives.
+  stage_primary auto-mobile-sdk 0.0.47 "auto-mobile-sdk-0.0.47.aar" 900
+  run bash "$SCRIPT" "$STAGE" --strict
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"main-aar auto-mobile-sdk-0.0.47.aar"* ]]
+  [[ "$output" == *"main-aar=1"* ]]
+}
+
+@test "manifest generation is deterministic" {
+  run bash "$SCRIPT" "$STAGE"
+  local first="$output"
+  run bash "$SCRIPT" "$STAGE"
+  [ "$first" = "$output" ]
+}
+
+@test "an unexpected classifier is reported and fails under --strict" {
+  local dir="$STAGE/$GROUP_PATH/auto-mobile-protocol/0.0.47"
+  head -c 10 /dev/zero >"$dir/auto-mobile-protocol-0.0.47-tests.jar"
+  run bash "$SCRIPT" "$STAGE"
+  [ "$status" -eq 0 ] # report-only by default: never blocks a release
+  [[ "$output" == *"unexpected"* ]]
+  [[ "$output" == *"tests.jar"* ]]
+  run bash "$SCRIPT" "$STAGE" --strict
+  [ "$status" -ne 0 ]
+}
+
+@test "a stray signature-of-signature sidecar is flagged as unexpected" {
+  local dir="$STAGE/$GROUP_PATH/auto-mobile-protocol/0.0.47"
+  head -c 10 /dev/zero >"$dir/auto-mobile-protocol-0.0.47.jar.asc.asc"
+  run bash "$SCRIPT" "$STAGE" --strict
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unexpected"* ]]
+}
+
+@test "budget breach warns but exits 0 by default; --strict makes it fail" {
+  local budget="$STAGE/tiny-budget.json"
+  cat >"$budget" <<'JSON'
+{ "perRelease": { "maxFiles": 1, "maxBytes": 1 } }
+JSON
+  run bash "$SCRIPT" "$STAGE" --budget "$budget"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"BUDGET"* ]]
+  [[ "$output" == *"WARN"* ]]
+  run bash "$SCRIPT" "$STAGE" --budget "$budget" --strict
+  [ "$status" -ne 0 ]
+}
+
+@test "a generous budget reports OK and exits 0" {
+  local budget="$STAGE/big-budget.json"
+  cat >"$budget" <<'JSON'
+{ "perRelease": { "maxFiles": 100000, "maxBytes": 1000000000 } }
+JSON
+  run bash "$SCRIPT" "$STAGE" --budget "$budget"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"BUDGET OK"* ]]
+}
+
+@test "the committed budget policy exists and is valid JSON" {
+  [ -f "$BUDGET_FILE" ]
+  run node -e "JSON.parse(require('fs').readFileSync('$BUDGET_FILE','utf8'))"
+  [ "$status" -eq 0 ]
+}
+
+@test "a missing staging directory fails clearly" {
+  run bash "$SCRIPT" "$STAGE/does-not-exist"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"staging"* ]] || [[ "$output" == *"not"* ]]
+}

--- a/test/bats/maven-publication-manifest.bats
+++ b/test/bats/maven-publication-manifest.bats
@@ -167,7 +167,7 @@ JSON
 
 @test "the committed budget policy exists and is valid JSON" {
   [ -f "$BUDGET_FILE" ]
-  run node -e "JSON.parse(require('fs').readFileSync('$BUDGET_FILE','utf8'))"
+  run jq empty "$BUDGET_FILE"
   [ "$status" -eq 0 ]
 }
 
@@ -190,4 +190,37 @@ JSON
   run bash "$SCRIPT" "$STAGE/does-not-exist"
   [ "$status" -ne 0 ]
   [[ "$output" == *"staging"* ]] || [[ "$output" == *"not"* ]]
+}
+
+# --- The extracted release-CI orchestrator (maven-publication-manifest-preflight.sh) ---
+# STAGING_DIR skips the Gradle staging step, so its manifest/summary wiring is
+# testable against a fixture without running Gradle.
+
+@test "preflight against a pre-staged dir emits the manifest and writes MANIFEST_OUT" {
+  local preflight="$REPO_ROOT/scripts/release/maven-publication-manifest-preflight.sh"
+  local out="$STAGE/manifest.txt"
+  STAGING_DIR="$STAGE" MANIFEST_OUT="$out" run bash "$preflight"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"files=110"* ]]
+  [ -f "$out" ]
+  grep -q "files=110" "$out"
+}
+
+@test "preflight appends a totals block to GITHUB_STEP_SUMMARY when set" {
+  local preflight="$REPO_ROOT/scripts/release/maven-publication-manifest-preflight.sh"
+  local summary="$STAGE/summary.md"
+  STAGING_DIR="$STAGE" GITHUB_STEP_SUMMARY="$summary" run bash "$preflight"
+  [ "$status" -eq 0 ]
+  [ -f "$summary" ]
+  grep -q "Maven Central publication manifest" "$summary"
+  grep -q "Release total" "$summary"
+  # The full per-file body is NOT dumped into the summary; only totals onward.
+  ! grep -q "auto-mobile-protocol-0.0.47.jar " "$summary"
+}
+
+@test "preflight requires VERSION when it must stage (no STAGING_DIR)" {
+  local preflight="$REPO_ROOT/scripts/release/maven-publication-manifest-preflight.sh"
+  run env -u VERSION -u STAGING_DIR bash "$preflight"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"VERSION"* ]]
 }

--- a/test/bats/maven-publication-manifest.bats
+++ b/test/bats/maven-publication-manifest.bats
@@ -265,3 +265,15 @@ JSON
   [[ "$output" == *"integer"* ]]
   [[ "$output" != *"BUDGET OK"* ]]
 }
+
+@test "a boolean budget threshold fails closed (jq false-coalescing bypass)" {
+  # jq's `// ""` would turn false into empty and disable the budget silently.
+  local budget="$STAGE/bool-budget.json"
+  cat >"$budget" <<'JSON'
+{ "perRelease": { "maxFiles": false } }
+JSON
+  run bash "$SCRIPT" "$STAGE" --budget "$budget"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"integer"* ]]
+  [[ "$output" != *"BUDGET OK"* ]]
+}

--- a/test/bats/maven-publication-manifest.bats
+++ b/test/bats/maven-publication-manifest.bats
@@ -308,6 +308,14 @@ JSON
   [[ "$output" != *"BUDGET OK"* ]]
 }
 
+@test "a multi-document budget file fails closed (jq stream, not one object)" {
+  local budget="$STAGE/multi-budget.json"
+  printf '%s\n%s\n' '{"perRelease":{"maxFiles":0}}' '{"perRelease":{"maxFiles":100}}' >"$budget"
+  run bash "$SCRIPT" "$STAGE" --budget "$budget"
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"BUDGET OK"* ]]
+}
+
 @test "an unexpected filename with a space keeps correct byte subtotals" {
   local dir="$STAGE/$GROUP_PATH/auto-mobile-protocol/0.0.47"
   head -c 7 /dev/zero >"$dir/stray file.jar" # space in the name

--- a/test/bats/maven-publication-manifest.bats
+++ b/test/bats/maven-publication-manifest.bats
@@ -198,17 +198,28 @@ JSON
 
 @test "preflight against a pre-staged dir emits the manifest and writes MANIFEST_OUT" {
   local preflight="$REPO_ROOT/scripts/release/maven-publication-manifest-preflight.sh"
-  local out="$STAGE/manifest.txt"
+  # MANIFEST_OUT must live OUTSIDE the staging tree (see the guard test below).
+  local out
+  out="$(mktemp)"
   STAGING_DIR="$STAGE" MANIFEST_OUT="$out" run bash "$preflight"
   [ "$status" -eq 0 ]
   [[ "$output" == *"files=110"* ]]
   [ -f "$out" ]
   grep -q "files=110" "$out"
+  rm -f "$out"
+}
+
+@test "preflight rejects a MANIFEST_OUT inside the staging tree" {
+  local preflight="$REPO_ROOT/scripts/release/maven-publication-manifest-preflight.sh"
+  STAGING_DIR="$STAGE" MANIFEST_OUT="$STAGE/manifest.txt" run bash "$preflight"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"STAGING_DIR"* ]]
 }
 
 @test "preflight appends a totals block to GITHUB_STEP_SUMMARY when set" {
   local preflight="$REPO_ROOT/scripts/release/maven-publication-manifest-preflight.sh"
-  local summary="$STAGE/summary.md"
+  local summary
+  summary="$(mktemp)"
   STAGING_DIR="$STAGE" GITHUB_STEP_SUMMARY="$summary" run bash "$preflight"
   [ "$status" -eq 0 ]
   [ -f "$summary" ]
@@ -216,6 +227,7 @@ JSON
   grep -q "Release total" "$summary"
   # The full per-file body is NOT dumped into the summary; only totals onward.
   ! grep -q "auto-mobile-protocol-0.0.47.jar " "$summary"
+  rm -f "$summary"
 }
 
 @test "preflight requires VERSION when it must stage (no STAGING_DIR)" {
@@ -223,4 +235,33 @@ JSON
   run env -u VERSION -u STAGING_DIR bash "$preflight"
   [ "$status" -ne 0 ]
   [[ "$output" == *"VERSION"* ]]
+}
+
+@test "--help prints the header only, never the executable lines" {
+  run bash "$SCRIPT" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage:"* ]]
+  [[ "$output" != *"set -euo pipefail"* ]]
+  [[ "$output" != *'budget_file=""'* ]]
+}
+
+@test "a symlinked staging directory is traversed, not counted as one file" {
+  local link
+  link="$(mktemp -d)/link"
+  ln -s "$STAGE" "$link"
+  run bash "$SCRIPT" "$link"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"files=110"* ]]
+  rm -rf "$(dirname "$link")"
+}
+
+@test "a non-integer budget threshold fails closed, not a false BUDGET OK" {
+  local budget="$STAGE/bad-budget.json"
+  cat >"$budget" <<'JSON'
+{ "perRelease": { "maxFiles": 0.5, "maxBytes": 0.5 } }
+JSON
+  run bash "$SCRIPT" "$STAGE" --budget "$budget"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"integer"* ]]
+  [[ "$output" != *"BUDGET OK"* ]]
 }

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -337,6 +337,43 @@
   [ -z "$output" ]
 }
 
+@test "release.yml runs the Maven publication manifest preflight before publishing (#4853)" {
+  wiring_requires_yq
+  local workflow=".github/workflows/release.yml"
+  # Both steps live in the release job, and the preflight must precede the
+  # publish so the manifest reflects what is about to be uploaded.
+  local names preflight publish
+  names="$(yq -r '.jobs."verify-and-release".steps[].name' "$workflow")"
+  preflight="$(printf '%s\n' "$names" \
+    | grep -nxF 'Maven Central publication manifest preflight' | cut -d: -f1)"
+  publish="$(printf '%s\n' "$names" \
+    | grep -nxF 'Publish Android Libraries to Maven Central' | cut -d: -f1)"
+  [ -n "$preflight" ]
+  [ -n "$publish" ]
+  [ "$preflight" -lt "$publish" ]
+}
+
+@test "release.yml preflight invokes the manifest script with the budget (#4853)" {
+  wiring_requires_yq
+  local script
+  script="$(yq -r '.jobs."verify-and-release".steps[]
+    | select(.name == "Maven Central publication manifest preflight") | .run' \
+    ".github/workflows/release.yml")"
+  [[ "$script" == *"scripts/release/maven-publication-manifest.sh"* ]]
+  [[ "$script" == *"scripts/release/maven-usage-budget.json"* ]]
+  [[ "$script" == *"publishAllPublicationsToCentralManifestRepository"* ]]
+  [[ "$script" == *"GITHUB_STEP_SUMMARY"* ]]
+}
+
+@test "release.yml uploads the publication manifest artifact (#4853)" {
+  wiring_requires_yq
+  local uses
+  uses="$(yq -r '.jobs."verify-and-release".steps[]
+    | select(.name == "Upload Maven publication manifest") | .uses' \
+    ".github/workflows/release.yml")"
+  [[ "$uses" == actions/upload-artifact@* ]]
+}
+
 # The assertions below parse the workflow as YAML rather than grepping its text.
 # A raw grep is satisfied by any comment or unrelated step containing the string,
 # so it would keep passing while the step it claims to pin was deleted -- and a

--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -353,16 +353,24 @@
   [ "$preflight" -lt "$publish" ]
 }
 
-@test "release.yml preflight invokes the manifest script with the budget (#4853)" {
+@test "release.yml preflight step calls the extracted preflight script (#4853)" {
   wiring_requires_yq
   local script
   script="$(yq -r '.jobs."verify-and-release".steps[]
     | select(.name == "Maven Central publication manifest preflight") | .run' \
     ".github/workflows/release.yml")"
-  [[ "$script" == *"scripts/release/maven-publication-manifest.sh"* ]]
-  [[ "$script" == *"scripts/release/maven-usage-budget.json"* ]]
-  [[ "$script" == *"publishAllPublicationsToCentralManifestRepository"* ]]
-  [[ "$script" == *"GITHUB_STEP_SUMMARY"* ]]
+  [[ "$script" == *"scripts/release/maven-publication-manifest-preflight.sh"* ]]
+}
+
+@test "the preflight script wires staging, the generator, the budget, and the summary (#4853)" {
+  # The bash lives in a script (not inline YAML) so it can be linted and tested;
+  # assert the script itself carries the wiring the release depends on.
+  local s="scripts/release/maven-publication-manifest-preflight.sh"
+  [ -x "$s" ]
+  grep -q "publishAllPublicationsToCentralManifestRepository" "$s"
+  grep -q "maven-publication-manifest.sh" "$s"
+  grep -q "maven-usage-budget.json" "$s"
+  grep -q "GITHUB_STEP_SUMMARY" "$s"
 }
 
 @test "release.yml uploads the publication manifest artifact (#4853)" {


### PR DESCRIPTION
## Summary

Adds a Maven Central **publication manifest + usage-budget preflight**. Every tagged release stages its four Maven coordinates to a local Maven file repository — no credentials, no remote upload — and records a deterministic manifest of exactly what the release would send to Central: one line per file (coordinate, classifier, filename, bytes), per-coordinate subtotals, classifier totals, and a release grand total. An advisory budget check reports a `BUDGET WARN` but, by default, still exits 0, so an urgent security release always ships.

This gives the artifact-reduction work a before/after regression oracle: [#4851](https://github.com/kaeawc/auto-mobile/issues/4851) shrinks the `signature-checksum` count to zero, [#4852](https://github.com/kaeawc/auto-mobile/issues/4852) shrinks the `javadoc-jar` bytes.

## Linked Issue

Closes #4853

## Changes

- **`android/build.gradle.kts`** — a `centralManifest` local file repository (reactive, per published module) so `publishAllPublicationsToCentralManifestRepository` stages the exact upload set into one directory. No effect on the real Central publish path.
- **`scripts/release/maven-publication-manifest.sh`** — walks the staged tree, emits the deterministic manifest; `--budget` (advisory, non-blocking) and `--strict` (opt-in gate) modes. Classifies `main-jar` / `main-aar` / `sources-jar` / `javadoc-jar` / `pom` / `module` / `maven-metadata` / `signature` / `checksum` / `signature-checksum`, with anything else `unexpected`.
- **`scripts/release/maven-usage-budget.json`** — advisory per-release thresholds.
- **`.github/workflows/release.yml`** — runs the preflight (best-effort) immediately before the publish step, appends totals to the job summary, and uploads the full manifest as an artifact.
- **`docs/release/maven-publication-manifest.md`** — design note + measured baseline.

## Validation

- [x] `bats test/bats/maven-publication-manifest.bats` (13) + `test/bats/release-workflow-wiring.bats` (3 new) green
- [x] `shellcheck` + `scripts/shellcheck/validate_shell_portability.sh` + `validate_shell_scripts.sh` clean
- [x] Real staging of **all four** coordinates verified locally (Gradle 9.6.1, JDK 21): 120 files unsigned, `unexpected=0`; the `.aar` classification gap for the Android library was caught this way and fixed + pinned by a test
- [x] `android/build.gradle.kts` ktfmt-clean (google-style, idempotent)
- No TypeScript `src/` changes, so the typecheck baseline is unaffected.

## Kotlin Reuse Check

- [x] The Gradle change reuses the existing vanniktech publishing extension; it only registers an additional local repository. No new helpers or dependencies.

## Notes

The local file repo also writes `maven-metadata.xml`, which the Central Portal bundle may regenerate server-side — so the manifest can slightly over-count vs. the final Central state. This is intentional; the relative before/after signal (the oracle's purpose) is unaffected. Documented in the design note.
