### PR TITLE
feat(desktop): wire Navigation as an app-sourced per-pane facet

### DIFF
--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/AutoMobileDesktopApp.kt
@@ -24,6 +24,7 @@ import dev.jasonpearson.automobile.desktop.core.workspace.CommandPalette
 import dev.jasonpearson.automobile.desktop.core.workspace.DeviceColumn
 import dev.jasonpearson.automobile.desktop.core.workspace.FailuresFacet
 import dev.jasonpearson.automobile.desktop.core.workspace.LogsFacet
+import dev.jasonpearson.automobile.desktop.core.workspace.NavigationFacet
 import dev.jasonpearson.automobile.desktop.core.workspace.NetworkFacet
 import dev.jasonpearson.automobile.desktop.core.workspace.OnboardingScreen
 import dev.jasonpearson.automobile.desktop.core.workspace.PerformanceFacet
@@ -222,9 +223,10 @@ fun AutoMobileDesktopApp(
 /**
  * Real docked-facet content for a pane, wired to the per-device facets in desktop-core: Logs
  * (telemetry), Storage (auto-resolved app, Android-only), Network (per-device `getNetworkGraph`
- * tool call), Performance (per-device observation stream, filtered by deviceId), and Failures
- * (cross-device aggregate). Navigation (#4837 — nav updates lack a deviceId and broadcast to all
- * panes) and Test (per-device daemon resource, #4715) fall back to the placeholder for now.
+ * tool call), Performance (per-device observation stream, filtered by deviceId), Failures
+ * (cross-device aggregate), and Navigation (#4837 Phase C — app-scoped graph pulled by the pane
+ * device's foreground app). Test (per-device daemon resource, #4715) falls back to the placeholder
+ * for now.
  */
 @Composable
 private fun WorkspaceFacet(column: DeviceColumn, tool: Tool) {
@@ -240,10 +242,11 @@ private fun WorkspaceFacet(column: DeviceColumn, tool: Tool) {
     Tool.Network -> NetworkFacet(column)
     Tool.Performance -> PerformanceFacet(column)
     Tool.Failures -> FailuresFacet(column)
-    // Navigation is intentionally NOT wired: nav-graph stream updates carry no deviceId and the
-    // daemon broadcasts them to all panes, so two panes would cross-contaminate (#4837). The facet
-    // + streamOnly support exist; wire once the deviceId contract lands. Test (per-device daemon
-    // resource, #4715) likewise stays on the placeholder.
+    // Navigation is app-scoped (#4837 Phase C): the facet resolves the pane device's foreground app
+    // from the stream, then pulls that app's persisted graph by appId — so same-app panes share the
+    // graph and a foreign broadcast can't overwrite a pane (the #4838 contamination). Test
+    // (per-device daemon resource, #4715) still falls back to the placeholder.
+    Tool.Navigation -> NavigationFacet(column)
     else -> WorkspaceFacetPlaceholder(tool)
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FakeObservationStream.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/FakeObservationStream.kt
@@ -12,8 +12,12 @@ import kotlinx.coroutines.flow.asStateFlow
 /**
  * In-memory [ObservationStream] for UI tests: records subscription lifecycle (connect/disconnect/
  * dispose, requested navigation graph) and lets tests emit updates onto each flow, with no socket.
+ *
+ * When [failConnect] is true, [connect] leaves the stream disconnected (mirroring the real client
+ * swallowing a socket-unavailable failure) so tests can exercise the retryable connection-error
+ * path.
  */
-class FakeObservationStream : ObservationStream {
+class FakeObservationStream(private val failConnect: Boolean = false) : ObservationStream {
   private fun <T> flow() =
     MutableSharedFlow<T>(
       replay = 1,
@@ -61,8 +65,18 @@ class FakeObservationStream : ObservationStream {
   override fun connect(deviceId: String?) {
     connectCallCount++
     lastConnectedDeviceId = deviceId
+    if (failConnect) {
+      connected = false
+      _connectionState.value = ConnectionState.Disconnected("Socket not found")
+      return
+    }
     connected = true
     _connectionState.value = ConnectionState.Connected()
+  }
+
+  /** Push a connection-state transition onto [connectionState] (e.g. a mid-session drop). */
+  fun emitConnectionState(state: ConnectionState) {
+    _connectionState.value = state
   }
 
   override fun disconnect() {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationCanvasView.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationCanvasView.kt
@@ -58,6 +58,8 @@ import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -837,7 +839,11 @@ fun NavigationCanvasView(
             .padding(start = 12.dp, top = 44.dp)
             .graphicsLayer { alpha = if (fogEnabled) 1f else 0.4f }
             .background(colors.text.normal.copy(alpha = 0.1f), RoundedCornerShape(8.dp))
-            .padding(8.dp),
+            .padding(8.dp)
+            .semantics {
+              contentDescription =
+                if (fogEnabled) "Fog focus available" else "Fog focus unavailable"
+            },
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         verticalAlignment = Alignment.CenterVertically,
       ) {

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationDashboard.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationDashboard.kt
@@ -50,6 +50,11 @@ fun NavigationDashboard(
   // panes correct: the active-device fetch would otherwise briefly show the wrong device's graph
   // until the first stream push. The default preserves the existing (non-facet) fetch behavior.
   streamOnly: Boolean = false,
+  // When non-null the caller has already resolved the graph to render (e.g. an app-scoped pull in
+  // [dev.jasonpearson.automobile.desktop.core.workspace.NavigationFacet]); the dashboard renders it
+  // directly and runs neither the internal data-source fetch nor the stream collector. The default
+  // (null) preserves the existing self-fetching behavior.
+  providedGraph: NavigationGraph? = null,
 ) {
   val graph = LocalAutoMobileGraph.current
   var currentSection by remember { mutableStateOf(NavigationSection.FlowMap) }
@@ -71,11 +76,23 @@ fun NavigationDashboard(
   var fitToViewTrigger by remember { mutableStateOf(0) }
 
   // Fetch navigation data from data source
-  var navigationGraph by remember { mutableStateOf<NavigationGraph?>(null) }
-  var isLoading by remember { mutableStateOf(true) }
+  var navigationGraph by remember { mutableStateOf(providedGraph) }
+  var isLoading by remember { mutableStateOf(providedGraph == null) }
   var error by remember { mutableStateOf<String?>(null) }
 
-  LaunchedEffect(dataSourceMode, clientProvider, selectedAppId, streamOnly) {
+  // Caller-provided graph wins: render it directly and keep it in sync across recompositions,
+  // bypassing the internal fetch and stream collector below.
+  LaunchedEffect(providedGraph) {
+    if (providedGraph != null) {
+      navigationGraph = providedGraph
+      isLoading = false
+      error = null
+    }
+  }
+
+  LaunchedEffect(dataSourceMode, clientProvider, selectedAppId, streamOnly, providedGraph) {
+    // A caller-provided graph is authoritative; never run the internal fetch.
+    if (providedGraph != null) return@LaunchedEffect
     // Stream-only: never run the active-device data-source fetch — the graph is driven solely by
     // this pane's per-device stream. Gated on streamOnly directly (not stream presence): the facet
     // attaches its stream via DisposableEffect AFTER first composition, so keying on the attached
@@ -124,7 +141,8 @@ fun NavigationDashboard(
   }
 
   // Request latest navigation graph on composition entry and when stream client becomes available
-  LaunchedEffect(observationStreamClient) {
+  LaunchedEffect(observationStreamClient, providedGraph) {
+    if (providedGraph != null) return@LaunchedEffect
     if (observationStreamClient != null) {
       kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
         observationStreamClient.requestNavigationGraph()
@@ -133,7 +151,8 @@ fun NavigationDashboard(
   }
 
   // Collect real-time navigation updates from the stream
-  LaunchedEffect(observationStreamClient, selectedAppId) {
+  LaunchedEffect(observationStreamClient, selectedAppId, providedGraph) {
+    if (providedGraph != null) return@LaunchedEffect
     if (observationStreamClient == null) return@LaunchedEffect
 
     LOG.info("Starting navigation updates collection from stream client")

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationDashboard.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationDashboard.kt
@@ -55,6 +55,11 @@ fun NavigationDashboard(
   // directly and runs neither the internal data-source fetch nor the stream collector. The default
   // (null) preserves the existing self-fetching behavior.
   providedGraph: NavigationGraph? = null,
+  // The active screen to pair with [providedGraph]. Because a provided graph bypasses the internal
+  // stream collector (which normally sets `currentObservedScreen`), the caller must pass the
+  // current screen here or the canvas's Fog toggle + auto-focus (both gated on a non-null current
+  // screen) stay dead. Only consulted when [providedGraph] is non-null.
+  providedCurrentScreen: String? = null,
 ) {
   val graph = LocalAutoMobileGraph.current
   var currentSection by remember { mutableStateOf(NavigationSection.FlowMap) }
@@ -69,8 +74,11 @@ fun NavigationDashboard(
   // Fog mode settings - read from persisted settings (fog+auto are one combined toggle)
   var fogModeEnabled by remember { mutableStateOf(settingsProvider.fogModeEnabled) }
 
-  // Track current screen and app from navigation stream
-  var currentObservedScreen by remember { mutableStateOf<String?>(null) }
+  // Track current screen and app from navigation stream (or, under the provided-graph path, from
+  // [providedCurrentScreen] — the stream collector is skipped there).
+  var currentObservedScreen by remember {
+    mutableStateOf(if (providedGraph != null) providedCurrentScreen else null)
+  }
   var lastObservedAppId by remember { mutableStateOf<String?>(null) }
   // Incremented when we want the canvas to re-fit to show the entire graph
   var fitToViewTrigger by remember { mutableStateOf(0) }
@@ -81,10 +89,12 @@ fun NavigationDashboard(
   var error by remember { mutableStateOf<String?>(null) }
 
   // Caller-provided graph wins: render it directly and keep it in sync across recompositions,
-  // bypassing the internal fetch and stream collector below.
-  LaunchedEffect(providedGraph) {
+  // bypassing the internal fetch and stream collector below. The paired current screen is threaded
+  // through so Fog/auto-focus stay live even though the stream collector is skipped.
+  LaunchedEffect(providedGraph, providedCurrentScreen) {
     if (providedGraph != null) {
       navigationGraph = providedGraph
+      currentObservedScreen = providedCurrentScreen
       isLoading = false
       error = null
     }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
@@ -119,13 +119,17 @@ fun NavigationFacet(
   // retryable ConnectionError instead of a crash. Reset per stream attempt so Retry clears it.
   var streamError by remember(column.deviceId, streamAttempt) { mutableStateOf<String?>(null) }
 
-  // Foreground app for THIS pane's device, resolved from the nav stream. Reset when the pane's
-  // device changes so a new device re-resolves its own foreground app.
-  var foregroundAppId by remember(column.deviceId) { mutableStateOf<String?>(null) }
+  // Foreground app for THIS pane's device, resolved from the nav stream. Keyed on streamAttempt as
+  // well as deviceId so a reconnect (Retry) DISCARDS the pre-outage app: otherwise a stream that
+  // drops after resolving app A, while the user switches to app B, would immediately re-pull and
+  // flash stale A on retry (and stay on A if B's first update carries no appId). On reconnect this
+  // resets to null so the facet returns to Resolving/NoApp and re-resolves from the fresh stream.
+  var foregroundAppId by remember(column.deviceId, streamAttempt) { mutableStateOf<String?>(null) }
   // The active screen reported alongside the resolved app. Carried into NavigationDashboard so the
   // canvas's Fog toggle + auto-focus (both gated on a non-null current screen) work under the
-  // app-scoped-pull path, which otherwise bypasses the dashboard's own stream collector.
-  var currentScreen by remember(column.deviceId) { mutableStateOf<String?>(null) }
+  // app-scoped-pull path, which otherwise bypasses the dashboard's own stream collector. Reset on
+  // reconnect alongside foregroundAppId so it can't outlive the app it belonged to.
+  var currentScreen by remember(column.deviceId, streamAttempt) { mutableStateOf<String?>(null) }
   // True once the connected stream has reported that no app has navigated yet (appId == null).
   // Distinguishes the onboarding "no app" case (-> NoApp) from "haven't heard yet" (-> Loading).
   var noNavigationApp by remember(column.deviceId, streamAttempt) { mutableStateOf(false) }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
@@ -133,6 +133,11 @@ fun NavigationFacet(
   // True once the connected stream has reported that no app has navigated yet (appId == null).
   // Distinguishes the onboarding "no app" case (-> NoApp) from "haven't heard yet" (-> Loading).
   var noNavigationApp by remember(column.deviceId, streamAttempt) { mutableStateOf(false) }
+  // Incremented on every navigation_update carrying an app so the app-scoped pull re-runs even when
+  // foregroundAppId is unchanged — otherwise a same-app update (app A discovers a new
+  // screen/transition) would only re-assign the identical appId and the graph would never grow
+  // live until retry/app-switch/reopen. Keyed into the pull effect below alongside appId.
+  var updateGeneration by remember(column.deviceId, streamAttempt) { mutableStateOf(0) }
   LaunchedEffect(stream) {
     val current = stream ?: return@LaunchedEffect
     try {
@@ -142,6 +147,8 @@ fun NavigationFacet(
           foregroundAppId = appId
           currentScreen = update.currentScreen
           noNavigationApp = false
+          // Force a re-pull of the app-scoped snapshot for this update (see updateGeneration).
+          updateGeneration++
         } else if (foregroundAppId == null) {
           // Stream says the current app is null and we've never resolved one — onboarding case.
           noNavigationApp = true
@@ -192,6 +199,7 @@ fun NavigationFacet(
     connectionState,
     streamError,
     noNavigationApp,
+    updateGeneration,
   ) {
     // A stream failure is retryable *regardless of whether an app already resolved*. Handling it
     // only when foregroundAppId == null would let a socket EOF after resolution
@@ -221,7 +229,14 @@ fun NavigationFacet(
       state = if (noNavigationApp) NavigationFacetState.NoApp else NavigationFacetState.Loading
       return@LaunchedEffect
     }
-    state = NavigationFacetState.Loading
+    // Only show the Loading spinner for the FIRST pull of an app. A live re-pull (same app, new
+    // updateGeneration) keeps the currently-rendered graph on screen until the fresh snapshot
+    // arrives, so the graph grows in place rather than blanking on every navigation step. A
+    // superseded in-flight pull is cancelled by LaunchedEffect when the keys change (its
+    // CancellationException propagates, so it never writes stale state).
+    if (state !is NavigationFacetState.Resolved) {
+      state = NavigationFacetState.Loading
+    }
     // Read off the UI thread: the resource read hits the daemon and would otherwise block
     // recomposition. Injected test data sources run inline (deterministic). The pull is wrapped so
     // a throwing data source becomes a retryable Error state rather than crashing the Recomposer.

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
@@ -56,7 +56,12 @@ private sealed interface NavigationFacetState {
 
   data class Error(val message: String) : NavigationFacetState
 
-  data class Resolved(val graph: NavigationGraph) : NavigationFacetState
+  /**
+   * A rendered graph, tagged with the [appId] it belongs to. The tag lets a live re-pull retain the
+   * on-screen graph only when it's the SAME app (a generation refresh); an in-place app switch (A
+   * -> B) must instead hide A's graph and show Loading until B's snapshot arrives.
+   */
+  data class Resolved(val appId: String, val graph: NavigationGraph) : NavigationFacetState
 }
 
 /**
@@ -229,12 +234,16 @@ fun NavigationFacet(
       state = if (noNavigationApp) NavigationFacetState.NoApp else NavigationFacetState.Loading
       return@LaunchedEffect
     }
-    // Only show the Loading spinner for the FIRST pull of an app. A live re-pull (same app, new
-    // updateGeneration) keeps the currently-rendered graph on screen until the fresh snapshot
-    // arrives, so the graph grows in place rather than blanking on every navigation step. A
-    // superseded in-flight pull is cancelled by LaunchedEffect when the keys change (its
-    // CancellationException propagates, so it never writes stale state).
-    if (state !is NavigationFacetState.Resolved) {
+    // Retain the on-screen graph during a pull ONLY for a same-app refresh (a new
+    // updateGeneration for the already-displayed app): the graph then grows in place rather than
+    // blanking on every navigation step. For the FIRST pull of an app OR an in-place app switch
+    // (A -> B, appId changed) we must hide the old graph and show Loading until the new snapshot
+    // arrives — otherwise B would render stale A while getNavigationGraph(B) runs. A superseded
+    // in-flight pull is cancelled by LaunchedEffect when the keys change (its CancellationException
+    // propagates, so it never writes stale state).
+    val displayed = state
+    val sameAppRefresh = displayed is NavigationFacetState.Resolved && displayed.appId == appId
+    if (!sameAppRefresh) {
       state = NavigationFacetState.Loading
     }
     // Read off the UI thread: the resource read hits the daemon and would otherwise block
@@ -247,7 +256,7 @@ fun NavigationFacet(
         ) {
           is Result.Success ->
             if (result.data.screens.isEmpty()) NavigationFacetState.Empty
-            else NavigationFacetState.Resolved(result.data)
+            else NavigationFacetState.Resolved(appId, result.data)
           is Result.Error ->
             NavigationFacetState.Error(result.message ?: "Failed to load navigation graph")
           // A one-shot read resolves to Success/Error; treat a stray Loading as retryable.

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
@@ -41,6 +41,13 @@ private sealed interface NavigationFacetState {
   /** No foreground app resolved yet, or the app-scoped pull is in flight. */
   data object Loading : NavigationFacetState
 
+  /**
+   * The stream is connected but reports no app has navigated yet (fresh daemon / onboarding): the
+   * `navigation_update`'s appId is null. Distinct from [Loading] ("haven't heard from the stream
+   * yet") so the first-run case doesn't hang on an indefinite spinner.
+   */
+  data object NoApp : NavigationFacetState
+
   /** The resolved app has no recorded navigation graph. */
   data object Empty : NavigationFacetState
 
@@ -115,12 +122,26 @@ fun NavigationFacet(
   // Foreground app for THIS pane's device, resolved from the nav stream. Reset when the pane's
   // device changes so a new device re-resolves its own foreground app.
   var foregroundAppId by remember(column.deviceId) { mutableStateOf<String?>(null) }
+  // The active screen reported alongside the resolved app. Carried into NavigationDashboard so the
+  // canvas's Fog toggle + auto-focus (both gated on a non-null current screen) work under the
+  // app-scoped-pull path, which otherwise bypasses the dashboard's own stream collector.
+  var currentScreen by remember(column.deviceId) { mutableStateOf<String?>(null) }
+  // True once the connected stream has reported that no app has navigated yet (appId == null).
+  // Distinguishes the onboarding "no app" case (-> NoApp) from "haven't heard yet" (-> Loading).
+  var noNavigationApp by remember(column.deviceId, streamAttempt) { mutableStateOf(false) }
   LaunchedEffect(stream) {
     val current = stream ?: return@LaunchedEffect
     try {
       current.navigationUpdates.collect { update ->
         val appId = update.appId
-        if (appId != null) foregroundAppId = appId
+        if (appId != null) {
+          foregroundAppId = appId
+          currentScreen = update.currentScreen
+          noNavigationApp = false
+        } else if (foregroundAppId == null) {
+          // Stream says the current app is null and we've never resolved one — onboarding case.
+          noNavigationApp = true
+        }
       }
     } catch (c: CancellationException) {
       // Normal cancellation on dispose / device change — must propagate.
@@ -160,7 +181,14 @@ fun NavigationFacet(
   var state by
     remember(column.deviceId) { mutableStateOf<NavigationFacetState>(NavigationFacetState.Loading) }
 
-  LaunchedEffect(column.deviceId, foregroundAppId, attempt, connectionState, streamError) {
+  LaunchedEffect(
+    column.deviceId,
+    foregroundAppId,
+    attempt,
+    connectionState,
+    streamError,
+    noNavigationApp,
+  ) {
     // A stream failure is retryable *regardless of whether an app already resolved*. Handling it
     // only when foregroundAppId == null would let a socket EOF after resolution
     // (Disconnected("Stream ended")) silently retain a dead stream and miss later foreground-app
@@ -183,9 +211,10 @@ fun NavigationFacet(
     val appId = foregroundAppId
     if (appId == null) {
       // Stream is healthy but no foreground app resolved yet. We resolve the appId *from* the
-      // stream, so stay in Loading until it reports one. Never pull with a null app id (that would
-      // surface the wrong/global graph).
-      state = NavigationFacetState.Loading
+      // stream, so never pull with a null app id (that would surface the wrong/global graph). If
+      // the stream has explicitly reported "no current app" show the NoApp guidance; otherwise
+      // we simply haven't heard yet, so stay in Loading.
+      state = if (noNavigationApp) NavigationFacetState.NoApp else NavigationFacetState.Loading
       return@LaunchedEffect
     }
     state = NavigationFacetState.Loading
@@ -220,6 +249,8 @@ fun NavigationFacet(
 
   when (val current = state) {
     NavigationFacetState.Loading -> NavigationFacetNote("Resolving navigation graph…")
+    NavigationFacetState.NoApp ->
+      NavigationFacetNote("Open an app on this device to build its navigation graph")
     NavigationFacetState.Empty ->
       NavigationFacetNote("No navigation graph recorded for this app yet")
     is NavigationFacetState.ConnectionError ->
@@ -240,6 +271,7 @@ fun NavigationFacet(
     is NavigationFacetState.Resolved ->
       NavigationDashboard(
         providedGraph = current.graph,
+        providedCurrentScreen = currentScreen,
         clientProvider = clientProvider,
         settingsProvider = graph.settingsProvider,
         selectedAppId = foregroundAppId,

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
@@ -33,9 +33,18 @@ import dev.jasonpearson.automobile.desktop.core.navigation.NavigationDashboard
 import dev.jasonpearson.automobile.desktop.core.navigation.NavigationScreenshotLoader
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 
 private val LOG = LoggerFactory.getLogger("NavigationFacet")
+
+/**
+ * How long to wait, after connecting, for the daemon to deliver a navigation payload before giving
+ * up. Backstops a "connected but silently no payload" daemon response (e.g. the on-demand export
+ * throws and is swallowed to null — daemon-side fix tracked in #4918) so the facet doesn't sit on
+ * "Resolving…" forever.
+ */
+private const val RESOLVE_TIMEOUT_MS = 10_000L
 
 private sealed interface NavigationFacetState {
   /** No foreground app resolved yet, or the app-scoped pull is in flight. */
@@ -95,6 +104,8 @@ fun NavigationFacet(
   column: DeviceColumn,
   observationStreamFactory: (String) -> ObservationStream = { ObservationStreamClient() },
   navigationDataSourceProvider: ((String) -> NavigationDataSource)? = null,
+  // Injectable so the resolution-timeout backstop is testable without a real 10s wait.
+  resolveTimeoutMs: Long = RESOLVE_TIMEOUT_MS,
 ) {
   val graph = LocalAutoMobileGraph.current
 
@@ -185,6 +196,38 @@ fun NavigationFacet(
       LOG.warn("Connection-state collection failed: ${e.message}", e)
       streamError = e.message ?: "Connection-state stream error"
     }
+  }
+
+  // Resolution-timeout backstop: if the socket is Connected but no navigation payload resolves
+  // within resolveTimeoutMs (no appId, no "no app" signal, no failure), give up and surface a
+  // retryable ConnectionError instead of sitting on "Resolving…" forever. This covers any
+  // "connected but silently no payload" cause; the specific daemon bug (on-demand export throws
+  // and is swallowed to null) is tracked as a daemon-side fix in #4918. The effect is cancelled
+  // (and thus never false-fires) the moment an app resolves, the stream reports "no app",
+  // disconnects/errors, or the stream is recreated — all of which change its keys.
+  LaunchedEffect(stream, connectionState, foregroundAppId, noNavigationApp, streamError) {
+    if (streamError != null) return@LaunchedEffect
+    if (foregroundAppId != null || noNavigationApp) return@LaunchedEffect
+    if (connectionState !is ConnectionState.Connected) return@LaunchedEffect
+    delay(resolveTimeoutMs)
+    // Still unresolved after the window (any resolution would have cancelled this effect).
+    streamError = "No navigation data received from the daemon"
+  }
+
+  // Foreground-app-change fog reset for the provided-graph path. NavigationDashboard's stream
+  // collector disables fog on every A -> B foreground switch, but the provided-graph path bypasses
+  // that collector; and because the switch remounts the dashboard via the Loading transition, B's
+  // fresh dashboard would otherwise read the persisted fog setting and inherit A's fog focus.
+  // Reset the persisted setting here, where the switch is observed, so B starts with fog disabled
+  // (full graph). First resolution (null -> A) keeps A's persisted preference.
+  var fogResetApp by remember(column.deviceId) { mutableStateOf<String?>(null) }
+  LaunchedEffect(foregroundAppId) {
+    val app = foregroundAppId ?: return@LaunchedEffect
+    val previous = fogResetApp
+    if (previous != null && previous != app) {
+      graph.settingsProvider.fogModeEnabled = false
+    }
+    fogResetApp = app
   }
 
   val sourceProvider =

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
 import dev.jasonpearson.automobile.desktop.core.datasource.NavigationDataSource
@@ -38,6 +39,9 @@ private sealed interface NavigationFacetState {
 
   /** The resolved app has no recorded navigation graph. */
   data object Empty : NavigationFacetState
+
+  /** The observation stream never connected (e.g. daemon socket unavailable); retryable. */
+  data class ConnectionError(val message: String) : NavigationFacetState
 
   data class Error(val message: String) : NavigationFacetState
 
@@ -78,8 +82,13 @@ fun NavigationFacet(
 ) {
   val graph = LocalAutoMobileGraph.current
 
+  // Bumped by the connection-error Retry to tear down and recreate the stream. The full automatic
+  // reconnect-on-recovery (backoff, no user action) is the shared workspace-facet reconnect
+  // lifecycle tracked in #4868 — deliberately not built here; a manual retry is enough for now.
+  var streamAttempt by remember(column.deviceId) { mutableStateOf(0) }
+
   var stream by remember(column.deviceId) { mutableStateOf<ObservationStream?>(null) }
-  DisposableEffect(column.deviceId) {
+  DisposableEffect(column.deviceId, streamAttempt) {
     val connected =
       observationStreamFactory(column.deviceId).also { it.connect(deviceId = column.deviceId) }
     // Prompt the daemon to emit the current foreground app so we can resolve which app's graph to
@@ -103,6 +112,18 @@ fun NavigationFacet(
     }
   }
 
+  // Mirror the stream's connection state so a socket that never connects surfaces a retryable
+  // connection-error instead of an indefinite "Resolving…". Reset per stream attempt so a stale
+  // Disconnected doesn't leak across a reconnect.
+  var connectionState by
+    remember(column.deviceId, streamAttempt) {
+      mutableStateOf<ConnectionState>(ConnectionState.Connecting)
+    }
+  LaunchedEffect(stream) {
+    val current = stream ?: return@LaunchedEffect
+    current.connectionState.collect { connectionState = it }
+  }
+
   val sourceProvider =
     navigationDataSourceProvider
       ?: { appId ->
@@ -113,12 +134,25 @@ fun NavigationFacet(
   var state by
     remember(column.deviceId) { mutableStateOf<NavigationFacetState>(NavigationFacetState.Loading) }
 
-  LaunchedEffect(column.deviceId, foregroundAppId, attempt) {
+  LaunchedEffect(column.deviceId, foregroundAppId, attempt, connectionState) {
     val appId = foregroundAppId
     if (appId == null) {
-      // No foreground app resolved yet: never pull with a null app id (that would surface the
-      // wrong/global graph). Stay in Loading until the stream reports the foreground app.
-      state = NavigationFacetState.Loading
+      // No foreground app resolved yet. We resolve the appId *from* the stream, so a stream that
+      // never connects would otherwise hang here forever (the daemon-socket-unavailable dead-end).
+      // Surface a retryable connection-error in that case; otherwise stay in Loading until the
+      // stream reports the foreground app. Never pull with a null app id (that would surface the
+      // wrong/global graph).
+      state =
+        when (connectionState) {
+          is ConnectionState.Disconnected ->
+            NavigationFacetState.ConnectionError(
+              (connectionState as ConnectionState.Disconnected).reason
+                ?: "Not connected to the AutoMobile daemon"
+            )
+          is ConnectionState.Error ->
+            NavigationFacetState.ConnectionError((connectionState as ConnectionState.Error).message)
+          else -> NavigationFacetState.Loading
+        }
       return@LaunchedEffect
     }
     state = NavigationFacetState.Loading
@@ -147,7 +181,21 @@ fun NavigationFacet(
     NavigationFacetState.Loading -> NavigationFacetNote("Resolving navigation graph…")
     NavigationFacetState.Empty ->
       NavigationFacetNote("No navigation graph recorded for this app yet")
-    is NavigationFacetState.Error -> NavigationFacetError(current.message) { attempt++ }
+    is NavigationFacetState.ConnectionError ->
+      // Retry tears down and recreates the stream, re-attempting connect + appId resolution.
+      NavigationFacetError(
+        message = current.message,
+        retryContentDescription = "Retry connecting to the AutoMobile daemon",
+      ) {
+        streamAttempt++
+      }
+    is NavigationFacetState.Error ->
+      NavigationFacetError(
+        message = current.message,
+        retryContentDescription = "Retry loading navigation graph",
+      ) {
+        attempt++
+      }
     is NavigationFacetState.Resolved ->
       NavigationDashboard(
         providedGraph = current.graph,
@@ -168,9 +216,15 @@ private fun NavigationFacetNote(text: String) {
   }
 }
 
-/** Error state with a Retry affordance that re-runs the app-scoped navigation-graph pull. */
+/**
+ * Error state with a Retry affordance; [retryContentDescription] names what the retry re-attempts.
+ */
 @Composable
-private fun NavigationFacetError(message: String, onRetry: () -> Unit) {
+private fun NavigationFacetError(
+  message: String,
+  retryContentDescription: String,
+  onRetry: () -> Unit,
+) {
   Column(
     Modifier.fillMaxSize(),
     verticalArrangement = Arrangement.Center,
@@ -182,7 +236,7 @@ private fun NavigationFacetError(message: String, onRetry: () -> Unit) {
       color = MaterialTheme.colorScheme.primary,
       modifier =
         Modifier.padding(top = 8.dp).clickable(onClick = onRetry).semantics {
-          contentDescription = "Retry loading navigation graph"
+          contentDescription = retryContentDescription
         },
     )
   }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
@@ -161,26 +161,31 @@ fun NavigationFacet(
     remember(column.deviceId) { mutableStateOf<NavigationFacetState>(NavigationFacetState.Loading) }
 
   LaunchedEffect(column.deviceId, foregroundAppId, attempt, connectionState, streamError) {
+    // A stream failure is retryable *regardless of whether an app already resolved*. Handling it
+    // only when foregroundAppId == null would let a socket EOF after resolution
+    // (Disconnected("Stream ended")) silently retain a dead stream and miss later foreground-app
+    // changes. So surface the retryable ConnectionError on any Disconnected/Error (or a
+    // mid-collect throw captured in streamError); Retry recreates the stream (streamAttempt) and
+    // re-resolves. Automatic reconnect-on-recovery (backoff, no user action) is #4868 — not built
+    // here. Note: transient Connecting/Reconnecting are NOT failures and fall through.
+    val failureMessage =
+      streamError
+        ?: when (val cs = connectionState) {
+          is ConnectionState.Disconnected -> cs.reason ?: "Not connected to the AutoMobile daemon"
+          is ConnectionState.Error -> cs.message
+          else -> null
+        }
+    if (failureMessage != null) {
+      state = NavigationFacetState.ConnectionError(failureMessage)
+      return@LaunchedEffect
+    }
+
     val appId = foregroundAppId
     if (appId == null) {
-      // No foreground app resolved yet. We resolve the appId *from* the stream, so a stream that
-      // never connects (or throws mid-collect) would otherwise hang here forever (the
-      // daemon-socket-unavailable dead-end). Surface a retryable connection-error in that case;
-      // otherwise stay in Loading until the stream reports the foreground app. Never pull with a
-      // null app id (that would surface the wrong/global graph).
-      val error = streamError
-      state =
-        when {
-          error != null -> NavigationFacetState.ConnectionError(error)
-          connectionState is ConnectionState.Disconnected ->
-            NavigationFacetState.ConnectionError(
-              (connectionState as ConnectionState.Disconnected).reason
-                ?: "Not connected to the AutoMobile daemon"
-            )
-          connectionState is ConnectionState.Error ->
-            NavigationFacetState.ConnectionError((connectionState as ConnectionState.Error).message)
-          else -> NavigationFacetState.Loading
-        }
+      // Stream is healthy but no foreground app resolved yet. We resolve the appId *from* the
+      // stream, so stay in Loading until it reports one. Never pull with a null app id (that would
+      // surface the wrong/global graph).
+      state = NavigationFacetState.Loading
       return@LaunchedEffect
     }
     state = NavigationFacetState.Loading

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
@@ -1,64 +1,189 @@
 package dev.jasonpearson.automobile.desktop.core.workspace
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStreamClient
-import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
+import dev.jasonpearson.automobile.desktop.core.datasource.NavigationDataSource
+import dev.jasonpearson.automobile.desktop.core.datasource.NavigationGraph
+import dev.jasonpearson.automobile.desktop.core.datasource.RealNavigationDataSource
+import dev.jasonpearson.automobile.desktop.core.datasource.Result
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
 import dev.jasonpearson.automobile.desktop.core.navigation.NavigationDashboard
 import dev.jasonpearson.automobile.desktop.core.navigation.NavigationScreenshotLoader
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private sealed interface NavigationFacetState {
+  /** No foreground app resolved yet, or the app-scoped pull is in flight. */
+  data object Loading : NavigationFacetState
+
+  /** The resolved app has no recorded navigation graph. */
+  data object Empty : NavigationFacetState
+
+  data class Error(val message: String) : NavigationFacetState
+
+  data class Resolved(val graph: NavigationGraph) : NavigationFacetState
+}
 
 /**
- * Docked-facet body for [Tool.Navigation]: the navigation dashboard scoped to a single pane's
- * device. An [ObservationStream] is created via [observationStreamFactory] and connected to
- * [column]'s device while the facet is shown, then disposed when it leaves composition or the
- * device changes — mirroring [LogsFacet]'s per-device connect/dispose lifecycle.
+ * Docked-facet body for [Tool.Navigation]. Navigation is **app-scoped**, not device-scoped (Phase C
+ * of the nav-graph model, #4837): the daemon persists one graph per app, so this facet renders the
+ * app-level graph for whichever app is in the foreground on the pane's device.
  *
- * [observationStreamFactory] is injected (defaulting to a real per-device
- * [ObservationStreamClient]) so the connect/dispose/request lifecycle can be verified with
- * [dev.jasonpearson.automobile.desktop .core.daemon.FakeObservationStream] instead of real socket
- * I/O.
+ * Mechanism — **app-scoped pull** (the contamination-safe option from #4909). A per-device
+ * [ObservationStream] is connected while the facet is shown (mirroring [LogsFacet]'s
+ * connect/dispose lifecycle, keyed on [DeviceColumn.deviceId]) purely to (a) satisfy that
+ * per-device lifecycle and (b) resolve which app is in the foreground on this pane's device (from
+ * the stream's `appId`). The graph itself is then **pulled** by app id via a [NavigationDataSource]
+ * (default [RealNavigationDataSource], which reads the daemon's app-keyed
+ * `automobile:navigation/graph?appId=…` resource). This is a stable snapshot: two panes observing
+ * the *same* app pull the same app-keyed graph and therefore render identical data (correct under
+ * the app-level model), and a foreign app's broadcast can never overwrite a pane's rendered graph
+ * the way the raw stream did (#4838).
  *
- * [selectedAppId] is left null so the stream's foreground-app-change logic drives which app's graph
- * is shown; no package needs to be pre-resolved. Navigation is platform-agnostic, so — unlike
- * [StorageFacet] — no Android-only guard is required.
+ * Known caveat (deferred to the `(app, build)` phase, #4837): `NavigationGraphStreamUpdate` carries
+ * an `appId` but no `deviceId`, so when two panes run *different* apps a foreground-app update
+ * broadcast for one device can be misattributed to the other pane. Full disambiguation needs the
+ * deviceId/build discriminator that lands in a later phase; we do not block on it here.
+ *
+ * [observationStreamFactory] and [navigationDataSourceProvider] are injected so the whole
+ * lifecycle + loading/empty/error/resolved behavior is testable with a
+ * [dev.jasonpearson.automobile.desktop.core.daemon.FakeObservationStream] and a fake data source,
+ * with no socket or live MCP daemon.
  */
 @Composable
 fun NavigationFacet(
   column: DeviceColumn,
   observationStreamFactory: (String) -> ObservationStream = { ObservationStreamClient() },
+  navigationDataSourceProvider: ((String) -> NavigationDataSource)? = null,
 ) {
   val graph = LocalAutoMobileGraph.current
+
   var stream by remember(column.deviceId) { mutableStateOf<ObservationStream?>(null) }
   DisposableEffect(column.deviceId) {
     val connected =
       observationStreamFactory(column.deviceId).also { it.connect(deviceId = column.deviceId) }
+    // Prompt the daemon to emit the current foreground app so we can resolve which app's graph to
+    // pull; the emitted update carries the appId.
+    connected.requestNavigationGraph()
     stream = connected
     onDispose {
       connected.dispose()
       stream = null
     }
   }
-  // Stable across recompositions so NavigationDashboard's data-source effect (keyed on the provider
-  // identity) doesn't relaunch and clobber stream-driven graph updates.
+
+  // Foreground app for THIS pane's device, resolved from the nav stream. Reset when the pane's
+  // device changes so a new device re-resolves its own foreground app.
+  var foregroundAppId by remember(column.deviceId) { mutableStateOf<String?>(null) }
+  LaunchedEffect(stream) {
+    val current = stream ?: return@LaunchedEffect
+    current.navigationUpdates.collect { update ->
+      val appId = update.appId
+      if (appId != null) foregroundAppId = appId
+    }
+  }
+
+  val sourceProvider =
+    navigationDataSourceProvider
+      ?: { appId ->
+        RealNavigationDataSource(clientProvider = { graph.autoMobileClient }, appId = appId)
+      }
+
+  var attempt by remember(column.deviceId) { mutableStateOf(0) }
+  var state by
+    remember(column.deviceId) { mutableStateOf<NavigationFacetState>(NavigationFacetState.Loading) }
+
+  LaunchedEffect(column.deviceId, foregroundAppId, attempt) {
+    val appId = foregroundAppId
+    if (appId == null) {
+      // No foreground app resolved yet: never pull with a null app id (that would surface the
+      // wrong/global graph). Stay in Loading until the stream reports the foreground app.
+      state = NavigationFacetState.Loading
+      return@LaunchedEffect
+    }
+    state = NavigationFacetState.Loading
+    // Read off the UI thread: the resource read hits the daemon and would otherwise block
+    // recomposition. Injected test data sources run inline (deterministic).
+    state =
+      when (
+        val result = withContext(Dispatchers.IO) { sourceProvider(appId).getNavigationGraph() }
+      ) {
+        is Result.Success ->
+          if (result.data.screens.isEmpty()) NavigationFacetState.Empty
+          else NavigationFacetState.Resolved(result.data)
+        is Result.Error ->
+          NavigationFacetState.Error(result.message ?: "Failed to load navigation graph")
+        // A one-shot read resolves to Success/Error; treat a stray Loading as retryable.
+        Result.Loading -> NavigationFacetState.Error("Navigation graph is still loading")
+      }
+  }
+
   val clientProvider = remember { { graph.autoMobileClient } }
   // Remembered per device so its LRU cache survives facet toggles.
   val screenshotLoader =
     remember(column.deviceId) { NavigationScreenshotLoader(clientProvider = clientProvider) }
-  NavigationDashboard(
-    observationStreamClient = stream,
-    dataSourceMode = DataSourceMode.Real,
-    clientProvider = clientProvider,
-    settingsProvider = graph.settingsProvider,
-    selectedAppId = null,
-    screenshotLoader = screenshotLoader,
-    // Drive the graph solely from this pane's per-device stream so a second pane on another device
-    // never shows the active device's graph.
-    streamOnly = true,
-  )
+
+  when (val current = state) {
+    NavigationFacetState.Loading -> NavigationFacetNote("Resolving navigation graph…")
+    NavigationFacetState.Empty ->
+      NavigationFacetNote("No navigation graph recorded for this app yet")
+    is NavigationFacetState.Error -> NavigationFacetError(current.message) { attempt++ }
+    is NavigationFacetState.Resolved ->
+      NavigationDashboard(
+        providedGraph = current.graph,
+        clientProvider = clientProvider,
+        settingsProvider = graph.settingsProvider,
+        selectedAppId = foregroundAppId,
+        screenshotLoader = screenshotLoader,
+        streamOnly = true,
+      )
+  }
+}
+
+/** Centered single-line note for the facet's transient (loading) or empty states. */
+@Composable
+private fun NavigationFacetNote(text: String) {
+  Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    Text(text, color = MaterialTheme.colorScheme.outline)
+  }
+}
+
+/** Error state with a Retry affordance that re-runs the app-scoped navigation-graph pull. */
+@Composable
+private fun NavigationFacetError(message: String, onRetry: () -> Unit) {
+  Column(
+    Modifier.fillMaxSize(),
+    verticalArrangement = Arrangement.Center,
+    horizontalAlignment = Alignment.CenterHorizontally,
+  ) {
+    Text(message, color = MaterialTheme.colorScheme.error)
+    Text(
+      "Retry",
+      color = MaterialTheme.colorScheme.primary,
+      modifier =
+        Modifier.padding(top = 8.dp).clickable(onClick = onRetry).semantics {
+          contentDescription = "Retry loading navigation graph"
+        },
+    )
+  }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
@@ -28,10 +28,14 @@ import dev.jasonpearson.automobile.desktop.core.datasource.NavigationGraph
 import dev.jasonpearson.automobile.desktop.core.datasource.RealNavigationDataSource
 import dev.jasonpearson.automobile.desktop.core.datasource.Result
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import dev.jasonpearson.automobile.desktop.core.navigation.NavigationDashboard
 import dev.jasonpearson.automobile.desktop.core.navigation.NavigationScreenshotLoader
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+
+private val LOG = LoggerFactory.getLogger("NavigationFacet")
 
 private sealed interface NavigationFacetState {
   /** No foreground app resolved yet, or the app-scoped pull is in flight. */
@@ -101,14 +105,29 @@ fun NavigationFacet(
     }
   }
 
+  // A throw surfaced by either stream-collection flow (socket read error, parse failure) below.
+  // Compose does NOT isolate exceptions thrown inside a LaunchedEffect — an unguarded `collect`
+  // that throws propagates to the Recomposer root and crashes the app. So both collectors funnel
+  // any non-cancellation throw into this state, which the state-gating effect turns into a
+  // retryable ConnectionError instead of a crash. Reset per stream attempt so Retry clears it.
+  var streamError by remember(column.deviceId, streamAttempt) { mutableStateOf<String?>(null) }
+
   // Foreground app for THIS pane's device, resolved from the nav stream. Reset when the pane's
   // device changes so a new device re-resolves its own foreground app.
   var foregroundAppId by remember(column.deviceId) { mutableStateOf<String?>(null) }
   LaunchedEffect(stream) {
     val current = stream ?: return@LaunchedEffect
-    current.navigationUpdates.collect { update ->
-      val appId = update.appId
-      if (appId != null) foregroundAppId = appId
+    try {
+      current.navigationUpdates.collect { update ->
+        val appId = update.appId
+        if (appId != null) foregroundAppId = appId
+      }
+    } catch (c: CancellationException) {
+      // Normal cancellation on dispose / device change — must propagate.
+      throw c
+    } catch (e: Exception) {
+      LOG.warn("Navigation stream collection failed: ${e.message}", e)
+      streamError = e.message ?: "Navigation stream error"
     }
   }
 
@@ -121,7 +140,14 @@ fun NavigationFacet(
     }
   LaunchedEffect(stream) {
     val current = stream ?: return@LaunchedEffect
-    current.connectionState.collect { connectionState = it }
+    try {
+      current.connectionState.collect { connectionState = it }
+    } catch (c: CancellationException) {
+      throw c
+    } catch (e: Exception) {
+      LOG.warn("Connection-state collection failed: ${e.message}", e)
+      streamError = e.message ?: "Connection-state stream error"
+    }
   }
 
   val sourceProvider =
@@ -134,22 +160,24 @@ fun NavigationFacet(
   var state by
     remember(column.deviceId) { mutableStateOf<NavigationFacetState>(NavigationFacetState.Loading) }
 
-  LaunchedEffect(column.deviceId, foregroundAppId, attempt, connectionState) {
+  LaunchedEffect(column.deviceId, foregroundAppId, attempt, connectionState, streamError) {
     val appId = foregroundAppId
     if (appId == null) {
       // No foreground app resolved yet. We resolve the appId *from* the stream, so a stream that
-      // never connects would otherwise hang here forever (the daemon-socket-unavailable dead-end).
-      // Surface a retryable connection-error in that case; otherwise stay in Loading until the
-      // stream reports the foreground app. Never pull with a null app id (that would surface the
-      // wrong/global graph).
+      // never connects (or throws mid-collect) would otherwise hang here forever (the
+      // daemon-socket-unavailable dead-end). Surface a retryable connection-error in that case;
+      // otherwise stay in Loading until the stream reports the foreground app. Never pull with a
+      // null app id (that would surface the wrong/global graph).
+      val error = streamError
       state =
-        when (connectionState) {
-          is ConnectionState.Disconnected ->
+        when {
+          error != null -> NavigationFacetState.ConnectionError(error)
+          connectionState is ConnectionState.Disconnected ->
             NavigationFacetState.ConnectionError(
               (connectionState as ConnectionState.Disconnected).reason
                 ?: "Not connected to the AutoMobile daemon"
             )
-          is ConnectionState.Error ->
+          connectionState is ConnectionState.Error ->
             NavigationFacetState.ConnectionError((connectionState as ConnectionState.Error).message)
           else -> NavigationFacetState.Loading
         }
@@ -157,18 +185,26 @@ fun NavigationFacet(
     }
     state = NavigationFacetState.Loading
     // Read off the UI thread: the resource read hits the daemon and would otherwise block
-    // recomposition. Injected test data sources run inline (deterministic).
+    // recomposition. Injected test data sources run inline (deterministic). The pull is wrapped so
+    // a throwing data source becomes a retryable Error state rather than crashing the Recomposer.
     state =
-      when (
-        val result = withContext(Dispatchers.IO) { sourceProvider(appId).getNavigationGraph() }
-      ) {
-        is Result.Success ->
-          if (result.data.screens.isEmpty()) NavigationFacetState.Empty
-          else NavigationFacetState.Resolved(result.data)
-        is Result.Error ->
-          NavigationFacetState.Error(result.message ?: "Failed to load navigation graph")
-        // A one-shot read resolves to Success/Error; treat a stray Loading as retryable.
-        Result.Loading -> NavigationFacetState.Error("Navigation graph is still loading")
+      try {
+        when (
+          val result = withContext(Dispatchers.IO) { sourceProvider(appId).getNavigationGraph() }
+        ) {
+          is Result.Success ->
+            if (result.data.screens.isEmpty()) NavigationFacetState.Empty
+            else NavigationFacetState.Resolved(result.data)
+          is Result.Error ->
+            NavigationFacetState.Error(result.message ?: "Failed to load navigation graph")
+          // A one-shot read resolves to Success/Error; treat a stray Loading as retryable.
+          Result.Loading -> NavigationFacetState.Error("Navigation graph is still loading")
+        }
+      } catch (c: CancellationException) {
+        throw c
+      } catch (e: Exception) {
+        LOG.warn("Navigation graph pull failed: ${e.message}", e)
+        NavigationFacetState.Error(e.message ?: "Failed to load navigation graph")
       }
   }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacet.kt
@@ -104,8 +104,10 @@ fun NavigationFacet(
   column: DeviceColumn,
   observationStreamFactory: (String) -> ObservationStream = { ObservationStreamClient() },
   navigationDataSourceProvider: ((String) -> NavigationDataSource)? = null,
-  // Injectable so the resolution-timeout backstop is testable without a real 10s wait.
-  resolveTimeoutMs: Long = RESOLVE_TIMEOUT_MS,
+  // The resolution-timeout backstop's wait, injected as a suspend seam so tests can drive it
+  // deterministically (e.g. awaiting a CompletableDeferred) with zero wall time instead of a real
+  // 10s delay under a real-clock test dispatcher. Production uses the real delay.
+  resolveTimeout: suspend () -> Unit = { delay(RESOLVE_TIMEOUT_MS) },
 ) {
   val graph = LocalAutoMobileGraph.current
 
@@ -209,7 +211,7 @@ fun NavigationFacet(
     if (streamError != null) return@LaunchedEffect
     if (foregroundAppId != null || noNavigationApp) return@LaunchedEffect
     if (connectionState !is ConnectionState.Connected) return@LaunchedEffect
-    delay(resolveTimeoutMs)
+    resolveTimeout()
     // Still unresolved after the window (any resolution would have cancelled this effect).
     streamError = "No navigation data received from the daemon"
   }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.SharedFlow
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -771,6 +772,93 @@ class NavigationFacetTest {
           .isEmpty(),
       )
     }
+
+  @Test
+  fun `times out to a retryable error when the daemon never sends a navigation payload`() =
+    runComposeUiTest {
+      val created = mutableListOf<FakeObservationStream>()
+      setContent {
+        CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+          MaterialTheme {
+            NavigationFacet(
+              column = column(),
+              observationStreamFactory = { FakeObservationStream().also { created.add(it) } },
+              navigationDataSourceProvider = {
+                StubNavigationDataSource(Result.Success(NavigationGraph(emptyList(), emptyList())))
+              },
+              // Small window so the backstop fires fast; no real 10s wait.
+              resolveTimeoutMs = 200L,
+            )
+          }
+        }
+      }
+
+      // The stream connects but the daemon never sends a navigation payload (silently no update).
+      // Without the backstop the facet would sit on "Resolving…" forever; instead it must surface
+      // the retryable error.
+      waitUntil(timeoutMillis = 5_000) {
+        onAllNodesWithText("No navigation data received", substring = true)
+          .fetchSemanticsNodes()
+          .isNotEmpty()
+      }
+      onNodeWithText("No navigation data received", substring = true).assertExists()
+      onNodeWithContentDescription("Retry connecting to the AutoMobile daemon").assertExists()
+      assertTrue(
+        "the timeout must not leave the facet stuck on Resolving",
+        onAllNodesWithText("Resolving navigation graph", substring = true)
+          .fetchSemanticsNodes()
+          .isEmpty(),
+      )
+
+      // Retry recreates the stream and re-requests.
+      onNodeWithContentDescription("Retry connecting to the AutoMobile daemon").performClick()
+      waitUntil(timeoutMillis = 5_000) { created.size >= 2 }
+      assertTrue("retry should recreate the observation stream", created.size >= 2)
+    }
+
+  @Test
+  fun `switching apps resets fog so the new app starts with the full graph`() = runComposeUiTest {
+    // App A starts with fog enabled (persisted). Switching to B must not carry A's fog into B.
+    val settings = FakeSettingsProvider(fogModeEnabled = true)
+    val client = FakeAutoMobileClient()
+    val graphProvider =
+      object : AutoMobileGraphProvider {
+        override val autoMobileClient = client
+        override val settingsProvider = settings
+        override val dataSourceFactory = DefaultDataSourceFactory(client)
+      }
+    val fake = FakeObservationStream()
+    setContent {
+      CompositionLocalProvider(LocalAutoMobileGraph provides graphProvider) {
+        MaterialTheme {
+          NavigationFacet(
+            column = column(),
+            observationStreamFactory = { fake },
+            navigationDataSourceProvider = { appId ->
+              val label = if (appId == "com.example.b") "Beta" else "Alpha"
+              StubNavigationDataSource(
+                Result.Success(NavigationGraph(listOf(screen(label)), emptyList()))
+              )
+            },
+          )
+        }
+      }
+    }
+    waitForIdle()
+
+    fake.emitNavigation(navUpdate("com.example.a", currentScreen = "Alpha"))
+    waitUntil(timeoutMillis = 5_000) {
+      onAllNodesWithText("Alpha").fetchSemanticsNodes().isNotEmpty()
+    }
+    assertTrue("precondition: app A has fog enabled", settings.fogModeEnabled)
+
+    // Foreground switches to app B: fog must be reset so B shows the full graph, not A's fog focus.
+    fake.emitNavigation(navUpdate("com.example.b", currentScreen = "Beta"))
+    waitUntil(timeoutMillis = 5_000) {
+      onAllNodesWithText("Beta").fetchSemanticsNodes().isNotEmpty()
+    }
+    assertFalse("switching to a new app must reset fog", settings.fogModeEnabled)
+  }
 
   @Test
   fun `reconnects to a new device when the column device changes`() = runComposeUiTest {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
@@ -24,6 +24,7 @@ import dev.jasonpearson.automobile.desktop.core.navigation.ScreenNode
 import dev.jasonpearson.automobile.desktop.core.settings.FakeSettingsProvider
 import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
 import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.SharedFlow
 import org.junit.Assert.assertEquals
@@ -214,6 +215,119 @@ class NavigationFacetTest {
       onNodeWithText("Details").assertExists()
       assertEquals("a same-app update must trigger a second app-scoped pull", 2, calls.get())
     }
+
+  @Test
+  fun `an in-place app switch hides the previous app graph and shows Loading until the new one resolves`() =
+    runComposeUiTest {
+      // App B's pull is gated so it stays in-flight while we assert app A's graph is hidden.
+      val gateB = CompletableDeferred<Unit>()
+      val aSource =
+        StubNavigationDataSource(
+          Result.Success(NavigationGraph(listOf(screen("Alpha")), emptyList()))
+        )
+      val bSource =
+        object : NavigationDataSource {
+          override suspend fun getNavigationGraph(): Result<NavigationGraph> {
+            gateB.await()
+            return Result.Success(NavigationGraph(listOf(screen("Beta")), emptyList()))
+          }
+        }
+      val fake = FakeObservationStream()
+      setContent {
+        CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+          MaterialTheme {
+            NavigationFacet(
+              column = column(),
+              observationStreamFactory = { fake },
+              navigationDataSourceProvider = { appId ->
+                if (appId == "com.example.b") bSource else aSource
+              },
+            )
+          }
+        }
+      }
+      waitForIdle()
+
+      // Resolve app A; its graph renders.
+      fake.emitNavigation(navUpdate("com.example.a"))
+      waitUntil(timeoutMillis = 5_000) {
+        onAllNodesWithText("Alpha").fetchSemanticsNodes().isNotEmpty()
+      }
+
+      // Foreground switches to app B (no disconnect). While B's pull is suspended the facet must
+      // hide A's graph and show Loading — not keep rendering stale A.
+      fake.emitNavigation(navUpdate("com.example.b"))
+      waitUntil(timeoutMillis = 5_000) {
+        onAllNodesWithText("Resolving navigation graph", substring = true)
+          .fetchSemanticsNodes()
+          .isNotEmpty()
+      }
+      assertTrue(
+        "an in-place app switch must hide the previous app's graph",
+        onAllNodesWithText("Alpha").fetchSemanticsNodes().isEmpty(),
+      )
+
+      // Once B resolves it renders B.
+      gateB.complete(Unit)
+      waitUntil(timeoutMillis = 5_000) {
+        onAllNodesWithText("Beta").fetchSemanticsNodes().isNotEmpty()
+      }
+      onNodeWithText("Beta").assertExists()
+    }
+
+  @Test
+  fun `a same-app refresh keeps the current graph on screen while re-pulling`() = runComposeUiTest {
+    // The 2nd (same-app) pull is gated so we can observe the in-flight refresh window.
+    val gate = CompletableDeferred<Unit>()
+    val calls = AtomicInteger(0)
+    val refreshingSource =
+      object : NavigationDataSource {
+        override suspend fun getNavigationGraph(): Result<NavigationGraph> {
+          if (calls.incrementAndGet() >= 2) {
+            gate.await()
+            return Result.Success(
+              NavigationGraph(listOf(screen("Home"), screen("Details")), emptyList())
+            )
+          }
+          return Result.Success(NavigationGraph(listOf(screen("Home")), emptyList()))
+        }
+      }
+    val fake = FakeObservationStream()
+    setContent {
+      CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+        MaterialTheme {
+          NavigationFacet(
+            column = column(),
+            observationStreamFactory = { fake },
+            navigationDataSourceProvider = { refreshingSource },
+          )
+        }
+      }
+    }
+    waitForIdle()
+
+    fake.emitNavigation(navUpdate("com.example.app"))
+    waitUntil(timeoutMillis = 5_000) {
+      onAllNodesWithText("Home").fetchSemanticsNodes().isNotEmpty()
+    }
+
+    // Same-app refresh: the 2nd pull is suspended on the gate. The existing graph must stay on
+    // screen (no Loading blank) — this is the round-6 behavior we must not regress.
+    fake.emitNavigation(navUpdate("com.example.app"))
+    waitUntil(timeoutMillis = 5_000) { calls.get() >= 2 }
+    onNodeWithText("Home").assertExists()
+    assertTrue(
+      "a same-app refresh must not blank the graph to Loading",
+      onAllNodesWithText("Resolving navigation graph", substring = true)
+        .fetchSemanticsNodes()
+        .isEmpty(),
+    )
+
+    gate.complete(Unit)
+    waitUntil(timeoutMillis = 5_000) {
+      onAllNodesWithText("Details").fetchSemanticsNodes().isNotEmpty()
+    }
+  }
 
   @Test
   fun `shows the no-app guidance when a connected stream reports a null current app`() =

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
@@ -290,6 +290,52 @@ class NavigationFacetTest {
   }
 
   @Test
+  fun `surfaces a retryable connection error when the stream never connects and retry recreates it`() =
+    runComposeUiTest {
+      val created = mutableListOf<FakeObservationStream>()
+      setContent {
+        CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+          MaterialTheme {
+            NavigationFacet(
+              column = column(),
+              observationStreamFactory = {
+                FakeObservationStream(failConnect = true).also { created.add(it) }
+              },
+              navigationDataSourceProvider = {
+                StubNavigationDataSource(Result.Success(NavigationGraph(emptyList(), emptyList())))
+              },
+            )
+          }
+        }
+      }
+
+      // The socket never connects and the facet resolves the app id FROM the stream, so without
+      // this path it would hang on "Resolving…" forever. Instead it must surface a retryable
+      // connection error.
+      waitUntil(timeoutMillis = 5_000) {
+        onAllNodesWithText("Socket not found", substring = true).fetchSemanticsNodes().isNotEmpty()
+      }
+      onNodeWithText("Socket not found", substring = true).assertExists()
+      assertTrue(
+        "must not be stuck on the indefinite Resolving state",
+        onAllNodesWithText("Resolving navigation graph", substring = true)
+          .fetchSemanticsNodes()
+          .isEmpty(),
+      )
+      onNodeWithContentDescription("Retry connecting to the AutoMobile daemon").assertExists()
+      assertEquals(1, created.size)
+
+      // Retry tears down and recreates the stream (re-attempting connect + appId resolution).
+      onNodeWithContentDescription("Retry connecting to the AutoMobile daemon").performClick()
+      waitUntil(timeoutMillis = 5_000) { created.size >= 2 }
+      assertTrue("retry should recreate the observation stream", created.size >= 2)
+      assertTrue(
+        "recreated stream should have been connected",
+        created.last().connectCallCount >= 1,
+      )
+    }
+
+  @Test
   fun `reconnects to a new device when the column device changes`() = runComposeUiTest {
     val streams = mutableMapOf<String, FakeObservationStream>()
     val deviceId = mutableStateOf("dev-1")

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
@@ -171,6 +171,51 @@ class NavigationFacetTest {
     }
 
   @Test
+  fun `re-pulls the app graph when a same-app update arrives so the graph grows live`() =
+    runComposeUiTest {
+      // A stateful source whose snapshot grows on the 2nd pull: Home -> Home + Details. If the
+      // facet only re-pulls on appId change, a same-app update would leave callCount at 1 and
+      // Details would never render.
+      val calls = AtomicInteger(0)
+      val growingSource =
+        object : NavigationDataSource {
+          override suspend fun getNavigationGraph(): Result<NavigationGraph> {
+            val screens =
+              if (calls.incrementAndGet() >= 2) listOf(screen("Home"), screen("Details"))
+              else listOf(screen("Home"))
+            return Result.Success(NavigationGraph(screens, emptyList()))
+          }
+        }
+      val fake = FakeObservationStream()
+      setContent {
+        CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+          MaterialTheme {
+            NavigationFacet(
+              column = column(),
+              observationStreamFactory = { fake },
+              navigationDataSourceProvider = { growingSource },
+            )
+          }
+        }
+      }
+      waitForIdle()
+
+      // First app-A update: pull #1 renders the initial graph.
+      fake.emitNavigation(navUpdate("com.example.app"))
+      waitUntil(timeoutMillis = 5_000) {
+        onAllNodesWithText("Home").fetchSemanticsNodes().isNotEmpty()
+      }
+
+      // Second app-A update (app A discovered a new screen): must re-pull and render Details.
+      fake.emitNavigation(navUpdate("com.example.app"))
+      waitUntil(timeoutMillis = 5_000) {
+        onAllNodesWithText("Details").fetchSemanticsNodes().isNotEmpty()
+      }
+      onNodeWithText("Details").assertExists()
+      assertEquals("a same-app update must trigger a second app-scoped pull", 2, calls.get())
+    }
+
+  @Test
   fun `shows the no-app guidance when a connected stream reports a null current app`() =
     runComposeUiTest {
       val fake = FakeObservationStream()

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
@@ -5,20 +5,22 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onAllNodesWithText
-import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
-import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
 import dev.jasonpearson.automobile.desktop.core.daemon.FakeObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.NavigationGraphStreamUpdate
-import dev.jasonpearson.automobile.desktop.core.daemon.NavigationNodeData
-import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceFactory
-import dev.jasonpearson.automobile.desktop.core.datasource.DataSourceMode
 import dev.jasonpearson.automobile.desktop.core.datasource.DefaultDataSourceFactory
 import dev.jasonpearson.automobile.desktop.core.datasource.NavigationDataSource
+import dev.jasonpearson.automobile.desktop.core.datasource.NavigationGraph
+import dev.jasonpearson.automobile.desktop.core.datasource.Result
 import dev.jasonpearson.automobile.desktop.core.di.AutoMobileGraphProvider
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
+import dev.jasonpearson.automobile.desktop.core.navigation.ScreenNode
 import dev.jasonpearson.automobile.desktop.core.settings.FakeSettingsProvider
 import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
+import java.util.concurrent.atomic.AtomicInteger
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -26,36 +28,48 @@ import org.junit.Test
 @OptIn(ExperimentalTestApi::class)
 class NavigationFacetTest {
 
-  /**
-   * [DataSourceFactory] that counts navigation-data-source creations, delegating everything else. A
-   * non-zero count means the dashboard ran its active-device fetch path — which a stream-only facet
-   * must never do.
-   */
-  private class CountingNavigationFactory(private val delegate: DataSourceFactory) :
-    DataSourceFactory by delegate {
-    var navigationDataSourceCreations = 0
-      private set
-
-    override fun createNavigationDataSource(
-      mode: DataSourceMode,
-      clientProvider: (() -> AutoMobileClient)?,
-      appId: String?,
-      cacheTtlMs: Long,
-    ): NavigationDataSource {
-      navigationDataSourceCreations++
-      return delegate.createNavigationDataSource(mode, clientProvider, appId, cacheTtlMs)
-    }
-  }
-
-  /** In-memory graph so the dashboard's data-source load hits a fake client, never a socket. */
-  private fun testGraph(factory: DataSourceFactory? = null): AutoMobileGraphProvider {
+  /** In-memory graph so nothing the facet touches reaches a real socket. */
+  private fun testGraph(): AutoMobileGraphProvider {
     val client = FakeAutoMobileClient()
     return object : AutoMobileGraphProvider {
       override val autoMobileClient = client
       override val settingsProvider = FakeSettingsProvider()
-      override val dataSourceFactory = factory ?: DefaultDataSourceFactory(client)
+      override val dataSourceFactory = DefaultDataSourceFactory(client)
     }
   }
+
+  private fun column(deviceId: String = "dev-1") =
+    DeviceColumn(deviceId = deviceId, name = "Pixel", platform = Platform.Android)
+
+  private fun screen(name: String) =
+    ScreenNode(
+      id = name.lowercase(),
+      name = name,
+      type = "Activity",
+      packageName = "com.example.app",
+      transitionCount = 0,
+      discoveredAt = 0L,
+    )
+
+  /** A [NavigationDataSource] that returns a fixed result and counts invocations. */
+  private class StubNavigationDataSource(private val result: Result<NavigationGraph>) :
+    NavigationDataSource {
+    val callCount = AtomicInteger(0)
+
+    override suspend fun getNavigationGraph(): Result<NavigationGraph> {
+      callCount.incrementAndGet()
+      return result
+    }
+  }
+
+  private fun navUpdate(appId: String?) =
+    NavigationGraphStreamUpdate(
+      timestamp = 1L,
+      appId = appId,
+      nodes = emptyList(),
+      edges = emptyList(),
+      currentScreen = null,
+    )
 
   @Test
   fun `connects the stream to the pane device, requests the graph, and disposes on removal`() =
@@ -67,9 +81,13 @@ class NavigationFacetTest {
           MaterialTheme {
             if (visible.value) {
               NavigationFacet(
-                column =
-                  DeviceColumn(deviceId = "dev-1", name = "Pixel", platform = Platform.Android),
+                column = column(),
                 observationStreamFactory = { fake },
+                navigationDataSourceProvider = {
+                  StubNavigationDataSource(
+                    Result.Success(NavigationGraph(emptyList(), emptyList()))
+                  )
+                },
               )
             }
           }
@@ -77,16 +95,13 @@ class NavigationFacetTest {
       }
       waitForIdle()
 
-      // (1) Connected exactly once, scoped to this pane's device.
       assertEquals(1, fake.connectCallCount)
       assertEquals("dev-1", fake.lastConnectedDeviceId)
-      // (2) The dashboard requested the navigation graph on entry.
       assertTrue(
-        "expected requestNavigationGraph to be issued",
+        "expected requestNavigationGraph to be issued on connect",
         fake.navigationRequestCount >= 1,
       )
 
-      // (4) Leaving composition disposes the stream (dispose -> disconnect).
       runOnIdle { visible.value = false }
       waitForIdle()
       assertTrue(
@@ -96,38 +111,182 @@ class NavigationFacetTest {
     }
 
   @Test
-  fun `renders screen nodes emitted on the navigation stream`() = runComposeUiTest {
+  fun `does not pull the app graph until a foreground app is resolved`() = runComposeUiTest {
     val fake = FakeObservationStream()
+    val source =
+      StubNavigationDataSource(Result.Success(NavigationGraph(listOf(screen("Home")), emptyList())))
     setContent {
       CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
         MaterialTheme {
           NavigationFacet(
-            column = DeviceColumn(deviceId = "dev-1", name = "Pixel", platform = Platform.Android),
+            column = column(),
             observationStreamFactory = { fake },
+            navigationDataSourceProvider = { source },
           )
         }
       }
     }
     waitForIdle()
 
-    fake.emitNavigation(
-      NavigationGraphStreamUpdate(
-        timestamp = 1L,
-        appId = "com.example.app",
-        // Node labels render truncated to 12 chars on the canvas, so keep this short.
-        nodes = listOf(NavigationNodeData(id = 1, screenName = "Login", visitCount = 2)),
-        edges = emptyList(),
-        currentScreen = "Login",
-      )
-    )
+    // No stream update has arrived, so no foreground app is known and the app-scoped pull that
+    // would otherwise show the wrong app's graph must not fire.
+    assertEquals(0, source.callCount.get())
 
-    // Poll rather than a single waitForIdle: the render depends on the async chain
-    // SharedFlow collect -> state update -> recompose -> canvas layout, which a lone waitForIdle
-    // does not deterministically await (flaked under CI load).
-    waitUntil(timeoutMillis = 5_000) {
-      onAllNodesWithText("Login").fetchSemanticsNodes().isNotEmpty()
+    fake.emitNavigation(navUpdate("com.example.app"))
+    waitUntil(timeoutMillis = 5_000) { source.callCount.get() >= 1 }
+    assertTrue(source.callCount.get() >= 1)
+  }
+
+  @Test
+  fun `renders the app graph pulled from the data source once the foreground app resolves`() =
+    runComposeUiTest {
+      val fake = FakeObservationStream()
+      setContent {
+        CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+          MaterialTheme {
+            NavigationFacet(
+              column = column(),
+              observationStreamFactory = { fake },
+              navigationDataSourceProvider = {
+                StubNavigationDataSource(
+                  Result.Success(NavigationGraph(listOf(screen("Home")), emptyList()))
+                )
+              },
+            )
+          }
+        }
+      }
+      waitForIdle()
+      fake.emitNavigation(navUpdate("com.example.app"))
+
+      waitUntil(timeoutMillis = 5_000) {
+        onAllNodesWithText("Home").fetchSemanticsNodes().isNotEmpty()
+      }
+      onAllNodesWithText("Home").fetchSemanticsNodes().isNotEmpty()
     }
-    onAllNodesWithText("Login").onFirst().assertExists()
+
+  @Test
+  fun `two same-app panes render the same shared app graph`() = runComposeUiTest {
+    val shared = NavigationGraph(listOf(screen("Home")), emptyList())
+    val streamA = FakeObservationStream()
+    val streamB = FakeObservationStream()
+    setContent {
+      CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+        MaterialTheme {
+          NavigationFacet(
+            column = column("dev-1"),
+            observationStreamFactory = { streamA },
+            navigationDataSourceProvider = { StubNavigationDataSource(Result.Success(shared)) },
+          )
+          NavigationFacet(
+            column = column("dev-2"),
+            observationStreamFactory = { streamB },
+            navigationDataSourceProvider = { StubNavigationDataSource(Result.Success(shared)) },
+          )
+        }
+      }
+    }
+    waitForIdle()
+    streamA.emitNavigation(navUpdate("com.example.app"))
+    streamB.emitNavigation(navUpdate("com.example.app"))
+
+    // Both panes resolve the same app and pull the same app-keyed graph, so the shared node
+    // renders in both.
+    waitUntil(timeoutMillis = 5_000) {
+      onAllNodesWithText("Home").fetchSemanticsNodes().size >= 2
+    }
+    assertTrue(
+      "both same-app panes should render the shared graph's Home node",
+      onAllNodesWithText("Home").fetchSemanticsNodes().size >= 2,
+    )
+  }
+
+  @Test
+  fun `shows the empty state when the resolved app has no recorded graph`() = runComposeUiTest {
+    val fake = FakeObservationStream()
+    setContent {
+      CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+        MaterialTheme {
+          NavigationFacet(
+            column = column(),
+            observationStreamFactory = { fake },
+            navigationDataSourceProvider = {
+              StubNavigationDataSource(Result.Success(NavigationGraph(emptyList(), emptyList())))
+            },
+          )
+        }
+      }
+    }
+    waitForIdle()
+    fake.emitNavigation(navUpdate("com.example.app"))
+
+    waitUntil(timeoutMillis = 5_000) {
+      onAllNodesWithText("No navigation graph recorded", substring = true)
+        .fetchSemanticsNodes()
+        .isNotEmpty()
+    }
+    onNodeWithText("No navigation graph recorded", substring = true).assertExists()
+  }
+
+  @Test
+  fun `surfaces a retryable error when the app graph fails to load`() = runComposeUiTest {
+    val fake = FakeObservationStream()
+    setContent {
+      CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+        MaterialTheme {
+          NavigationFacet(
+            column = column(),
+            observationStreamFactory = { fake },
+            navigationDataSourceProvider = {
+              StubNavigationDataSource(Result.Error(RuntimeException("daemon down"), "daemon down"))
+            },
+          )
+        }
+      }
+    }
+    waitForIdle()
+    fake.emitNavigation(navUpdate("com.example.app"))
+
+    waitUntil(timeoutMillis = 5_000) {
+      onAllNodesWithText("daemon down", substring = true).fetchSemanticsNodes().isNotEmpty()
+    }
+    onNodeWithText("daemon down", substring = true).assertExists()
+    onNodeWithContentDescription("Retry loading navigation graph").assertExists()
+  }
+
+  @Test
+  fun `retry re-invokes the loader and renders the recovered graph`() = runComposeUiTest {
+    val fake = FakeObservationStream()
+    val attempts = AtomicInteger(0)
+    val recovering =
+      object : NavigationDataSource {
+        override suspend fun getNavigationGraph(): Result<NavigationGraph> =
+          if (attempts.getAndIncrement() == 0)
+            Result.Error(RuntimeException("daemon down"), "daemon down")
+          else Result.Success(NavigationGraph(listOf(screen("Home")), emptyList()))
+      }
+    setContent {
+      CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+        MaterialTheme {
+          NavigationFacet(
+            column = column(),
+            observationStreamFactory = { fake },
+            navigationDataSourceProvider = { recovering },
+          )
+        }
+      }
+    }
+    waitForIdle()
+    fake.emitNavigation(navUpdate("com.example.app"))
+    waitUntil(timeoutMillis = 5_000) {
+      onAllNodesWithText("daemon down", substring = true).fetchSemanticsNodes().isNotEmpty()
+    }
+
+    onNodeWithContentDescription("Retry loading navigation graph").performClick()
+    waitUntil(timeoutMillis = 5_000) {
+      onAllNodesWithText("Home").fetchSemanticsNodes().isNotEmpty()
+    }
+    onAllNodesWithText("Home").fetchSemanticsNodes().isNotEmpty()
   }
 
   @Test
@@ -138,9 +297,11 @@ class NavigationFacetTest {
       CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
         MaterialTheme {
           NavigationFacet(
-            column =
-              DeviceColumn(deviceId = deviceId.value, name = "Pixel", platform = Platform.Android),
+            column = column(deviceId.value),
             observationStreamFactory = { id -> streams.getOrPut(id) { FakeObservationStream() } },
+            navigationDataSourceProvider = {
+              StubNavigationDataSource(Result.Success(NavigationGraph(emptyList(), emptyList())))
+            },
           )
         }
       }
@@ -151,37 +312,8 @@ class NavigationFacetTest {
     runOnIdle { deviceId.value = "dev-2" }
     waitForIdle()
 
-    // Old stream disposed, new stream connected to the new device.
     assertTrue(streams.getValue("dev-1").disconnectCallCount >= 1)
     assertEquals(1, streams.getValue("dev-2").connectCallCount)
     assertEquals("dev-2", streams.getValue("dev-2").lastConnectedDeviceId)
   }
-
-  @Test
-  fun `never queries the active-device data source, even during the on-mount window`() =
-    runComposeUiTest {
-      val factory = CountingNavigationFactory(DefaultDataSourceFactory(FakeAutoMobileClient()))
-      setContent {
-        CompositionLocalProvider(LocalAutoMobileGraph provides testGraph(factory)) {
-          MaterialTheme {
-            NavigationFacet(
-              column =
-                DeviceColumn(deviceId = "dev-1", name = "Pixel", platform = Platform.Android),
-              observationStreamFactory = { FakeObservationStream() },
-            )
-          }
-        }
-      }
-      waitForIdle()
-
-      // The facet attaches its stream via DisposableEffect AFTER first composition, so on mount
-      // observationStreamClient is still null. A count > 0 would mean the dashboard fell back to
-      // the active-device fetch during that window (the old stream-presence gate) — briefly showing
-      // the wrong device's graph. Gating on streamOnly directly keeps this at 0.
-      assertEquals(
-        "stream-only facet must never create the active-device navigation data source",
-        0,
-        factory.navigationDataSourceCreations,
-      )
-    }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
@@ -777,6 +777,10 @@ class NavigationFacetTest {
   fun `times out to a retryable error when the daemon never sends a navigation payload`() =
     runComposeUiTest {
       val created = mutableListOf<FakeObservationStream>()
+      // Drive the timeout deterministically with zero wall time: the seam awaits this gate, and the
+      // test completes it to fire the timeout. No real delay() under the real-clock test
+      // dispatcher.
+      val fireTimeout = CompletableDeferred<Unit>()
       setContent {
         CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
           MaterialTheme {
@@ -786,16 +790,17 @@ class NavigationFacetTest {
               navigationDataSourceProvider = {
                 StubNavigationDataSource(Result.Success(NavigationGraph(emptyList(), emptyList())))
               },
-              // Small window so the backstop fires fast; no real 10s wait.
-              resolveTimeoutMs = 200L,
+              resolveTimeout = { fireTimeout.await() },
             )
           }
         }
       }
+      waitForIdle()
 
       // The stream connects but the daemon never sends a navigation payload (silently no update).
-      // Without the backstop the facet would sit on "Resolving…" forever; instead it must surface
-      // the retryable error.
+      // Fire the timeout; without the backstop the facet would sit on "Resolving…" forever, but it
+      // must instead surface the retryable error.
+      fireTimeout.complete(Unit)
       waitUntil(timeoutMillis = 5_000) {
         onAllNodesWithText("No navigation data received", substring = true)
           .fetchSemanticsNodes()

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.connection.ConnectionState
 import dev.jasonpearson.automobile.desktop.core.daemon.FakeObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.NavigationGraphStreamUpdate
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
@@ -336,6 +337,51 @@ class NavigationFacetTest {
         "recreated stream should have been connected",
         created.last().connectCallCount >= 1,
       )
+    }
+
+  @Test
+  fun `surfaces the reconnect affordance when the stream drops after an app resolved`() =
+    runComposeUiTest {
+      val created = mutableListOf<FakeObservationStream>()
+      setContent {
+        CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+          MaterialTheme {
+            NavigationFacet(
+              column = column(),
+              observationStreamFactory = { FakeObservationStream().also { created.add(it) } },
+              navigationDataSourceProvider = {
+                StubNavigationDataSource(
+                  Result.Success(NavigationGraph(listOf(screen("Home")), emptyList()))
+                )
+              },
+            )
+          }
+        }
+      }
+      waitForIdle()
+
+      // App resolves and its graph renders.
+      created.first().emitNavigation(navUpdate("com.example.app"))
+      waitUntil(timeoutMillis = 5_000) {
+        onAllNodesWithText("Home").fetchSemanticsNodes().isNotEmpty()
+      }
+
+      // Socket EOF *after* resolution: without post-resolution handling the facet would silently
+      // retain a dead stream. It must instead expose the retryable reconnect affordance.
+      runOnIdle {
+        created.first().emitConnectionState(ConnectionState.Disconnected("Stream ended"))
+      }
+      waitUntil(timeoutMillis = 5_000) {
+        onAllNodesWithText("Stream ended", substring = true).fetchSemanticsNodes().isNotEmpty()
+      }
+      onNodeWithText("Stream ended", substring = true).assertExists()
+      onNodeWithContentDescription("Retry connecting to the AutoMobile daemon").assertExists()
+      assertEquals(1, created.size)
+
+      // Retry recreates the stream (reusing the streamAttempt mechanism).
+      onNodeWithContentDescription("Retry connecting to the AutoMobile daemon").performClick()
+      waitUntil(timeoutMillis = 5_000) { created.size >= 2 }
+      assertTrue("retry should recreate the observation stream", created.size >= 2)
     }
 
   /** A [SharedFlow] that throws on collection, to simulate a stream read/parse failure. */

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import dev.jasonpearson.automobile.desktop.core.daemon.FakeObservationStream
 import dev.jasonpearson.automobile.desktop.core.daemon.NavigationGraphStreamUpdate
+import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
 import dev.jasonpearson.automobile.desktop.core.datasource.DefaultDataSourceFactory
 import dev.jasonpearson.automobile.desktop.core.datasource.NavigationDataSource
 import dev.jasonpearson.automobile.desktop.core.datasource.NavigationGraph
@@ -21,6 +22,8 @@ import dev.jasonpearson.automobile.desktop.core.navigation.ScreenNode
 import dev.jasonpearson.automobile.desktop.core.settings.FakeSettingsProvider
 import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
 import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.SharedFlow
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -332,6 +335,52 @@ class NavigationFacetTest {
       assertTrue(
         "recreated stream should have been connected",
         created.last().connectCallCount >= 1,
+      )
+    }
+
+  /** A [SharedFlow] that throws on collection, to simulate a stream read/parse failure. */
+  private fun throwingNavFlow(error: Throwable): SharedFlow<NavigationGraphStreamUpdate> =
+    object : SharedFlow<NavigationGraphStreamUpdate> {
+      override val replayCache: List<NavigationGraphStreamUpdate> = emptyList()
+
+      override suspend fun collect(collector: FlowCollector<NavigationGraphStreamUpdate>): Nothing =
+        throw error
+    }
+
+  @Test
+  fun `routes a throwing stream collection to the retryable error state instead of crashing`() =
+    runComposeUiTest {
+      // A stream whose navigation-updates flow throws on collect. An unguarded LaunchedEffect
+      // collect would propagate this to the Recomposer root and crash the app; the facet must
+      // instead land in the retryable error state.
+      val throwing =
+        object : ObservationStream by FakeObservationStream() {
+          override val navigationUpdates = throwingNavFlow(RuntimeException("stream read error"))
+        }
+      setContent {
+        CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+          MaterialTheme {
+            NavigationFacet(
+              column = column(),
+              observationStreamFactory = { throwing },
+              navigationDataSourceProvider = {
+                StubNavigationDataSource(Result.Success(NavigationGraph(emptyList(), emptyList())))
+              },
+            )
+          }
+        }
+      }
+
+      waitUntil(timeoutMillis = 5_000) {
+        onAllNodesWithText("stream read error", substring = true).fetchSemanticsNodes().isNotEmpty()
+      }
+      onNodeWithText("stream read error", substring = true).assertExists()
+      onNodeWithContentDescription("Retry connecting to the AutoMobile daemon").assertExists()
+      assertTrue(
+        "must not be stuck on the indefinite Resolving state",
+        onAllNodesWithText("Resolving navigation graph", substring = true)
+          .fetchSemanticsNodes()
+          .isEmpty(),
       )
     }
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
@@ -66,13 +67,13 @@ class NavigationFacetTest {
     }
   }
 
-  private fun navUpdate(appId: String?) =
+  private fun navUpdate(appId: String?, currentScreen: String? = null) =
     NavigationGraphStreamUpdate(
       timestamp = 1L,
       appId = appId,
       nodes = emptyList(),
       edges = emptyList(),
-      currentScreen = null,
+      currentScreen = currentScreen,
     )
 
   @Test
@@ -167,6 +168,73 @@ class NavigationFacetTest {
         onAllNodesWithText("Home").fetchSemanticsNodes().isNotEmpty()
       }
       onAllNodesWithText("Home").fetchSemanticsNodes().isNotEmpty()
+    }
+
+  @Test
+  fun `shows the no-app guidance when a connected stream reports a null current app`() =
+    runComposeUiTest {
+      val fake = FakeObservationStream()
+      setContent {
+        CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+          MaterialTheme {
+            NavigationFacet(
+              column = column(),
+              observationStreamFactory = { fake },
+              navigationDataSourceProvider = {
+                StubNavigationDataSource(Result.Success(NavigationGraph(emptyList(), emptyList())))
+              },
+            )
+          }
+        }
+      }
+      waitForIdle()
+
+      // Fresh daemon / onboarding: the stream is connected but reports no current app (appId null).
+      // The facet must guide the user rather than hang on the indefinite Resolving spinner.
+      fake.emitNavigation(navUpdate(appId = null))
+      waitUntil(timeoutMillis = 5_000) {
+        onAllNodesWithText("Open an app on this device", substring = true)
+          .fetchSemanticsNodes()
+          .isNotEmpty()
+      }
+      onNodeWithText("Open an app on this device", substring = true).assertExists()
+      assertTrue(
+        "null-app must not leave the facet stuck on Resolving",
+        onAllNodesWithText("Resolving navigation graph", substring = true)
+          .fetchSemanticsNodes()
+          .isEmpty(),
+      )
+    }
+
+  @Test
+  fun `carries the current screen into the dashboard so Fog and auto-focus are enabled`() =
+    runComposeUiTest {
+      val fake = FakeObservationStream()
+      setContent {
+        CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+          MaterialTheme {
+            NavigationFacet(
+              column = column(),
+              observationStreamFactory = { fake },
+              navigationDataSourceProvider = {
+                StubNavigationDataSource(
+                  Result.Success(NavigationGraph(listOf(screen("Home")), emptyList()))
+                )
+              },
+            )
+          }
+        }
+      }
+      waitForIdle()
+
+      // The nav update carries both the resolved app and its current screen. Under the
+      // app-scoped-pull path the dashboard bypasses its own stream collector, so unless the facet
+      // threads currentScreen through, the canvas's Fog toggle stays disabled.
+      fake.emitNavigation(navUpdate(appId = "com.example.app", currentScreen = "Home"))
+      waitUntil(timeoutMillis = 5_000) {
+        onAllNodesWithContentDescription("Fog focus available").fetchSemanticsNodes().isNotEmpty()
+      }
+      onNodeWithContentDescription("Fog focus available").assertExists()
     }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/NavigationFacetTest.kt
@@ -452,6 +452,121 @@ class NavigationFacetTest {
       assertTrue("retry should recreate the observation stream", created.size >= 2)
     }
 
+  @Test
+  fun `retry after an outage re-resolves the replacement app and never retains the pre-outage app`() =
+    runComposeUiTest {
+      val created = mutableListOf<FakeObservationStream>()
+      setContent {
+        CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+          MaterialTheme {
+            NavigationFacet(
+              column = column(),
+              observationStreamFactory = { FakeObservationStream().also { created.add(it) } },
+              navigationDataSourceProvider = { appId ->
+                // Distinct graph per app so a stale render is detectable by screen name.
+                val label = if (appId == "com.example.b") "Beta" else "Alpha"
+                StubNavigationDataSource(
+                  Result.Success(NavigationGraph(listOf(screen(label)), emptyList()))
+                )
+              },
+            )
+          }
+        }
+      }
+      waitForIdle()
+
+      // Resolve app A; its graph renders.
+      created.first().emitNavigation(navUpdate("com.example.a"))
+      waitUntil(timeoutMillis = 5_000) {
+        onAllNodesWithText("Alpha").fetchSemanticsNodes().isNotEmpty()
+      }
+
+      // Stream drops mid-session (user then switches to app B during the outage).
+      runOnIdle {
+        created.first().emitConnectionState(ConnectionState.Disconnected("Stream ended"))
+      }
+      waitUntil(timeoutMillis = 5_000) {
+        onAllNodesWithContentDescription("Retry connecting to the AutoMobile daemon")
+          .fetchSemanticsNodes()
+          .isNotEmpty()
+      }
+
+      // Retry recreates the stream. The pre-outage app A must be discarded (back to Resolving),
+      // never flashed or retained.
+      onNodeWithContentDescription("Retry connecting to the AutoMobile daemon").performClick()
+      waitUntil(timeoutMillis = 5_000) { created.size >= 2 }
+      waitUntil(timeoutMillis = 5_000) {
+        onAllNodesWithText("Resolving navigation graph", substring = true)
+          .fetchSemanticsNodes()
+          .isNotEmpty()
+      }
+      assertTrue(
+        "stale pre-outage app A must not survive a reconnect",
+        onAllNodesWithText("Alpha").fetchSemanticsNodes().isEmpty(),
+      )
+
+      // The fresh stream resolves app B; the facet ends on B, never reverting to A.
+      created.last().emitNavigation(navUpdate("com.example.b"))
+      waitUntil(timeoutMillis = 5_000) {
+        onAllNodesWithText("Beta").fetchSemanticsNodes().isNotEmpty()
+      }
+      assertTrue(
+        "must not retain app A after resolving app B",
+        onAllNodesWithText("Alpha").fetchSemanticsNodes().isEmpty(),
+      )
+    }
+
+  @Test
+  fun `retry after an outage with a null-app stream shows the no-app guidance not the stale app`() =
+    runComposeUiTest {
+      val created = mutableListOf<FakeObservationStream>()
+      setContent {
+        CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+          MaterialTheme {
+            NavigationFacet(
+              column = column(),
+              observationStreamFactory = { FakeObservationStream().also { created.add(it) } },
+              navigationDataSourceProvider = {
+                StubNavigationDataSource(
+                  Result.Success(NavigationGraph(listOf(screen("Alpha")), emptyList()))
+                )
+              },
+            )
+          }
+        }
+      }
+      waitForIdle()
+
+      created.first().emitNavigation(navUpdate("com.example.a"))
+      waitUntil(timeoutMillis = 5_000) {
+        onAllNodesWithText("Alpha").fetchSemanticsNodes().isNotEmpty()
+      }
+      runOnIdle {
+        created.first().emitConnectionState(ConnectionState.Disconnected("Stream ended"))
+      }
+      waitUntil(timeoutMillis = 5_000) {
+        onAllNodesWithContentDescription("Retry connecting to the AutoMobile daemon")
+          .fetchSemanticsNodes()
+          .isNotEmpty()
+      }
+
+      onNodeWithContentDescription("Retry connecting to the AutoMobile daemon").performClick()
+      waitUntil(timeoutMillis = 5_000) { created.size >= 2 }
+
+      // Fresh stream reports no current app: the facet must show the no-app guidance, not the
+      // stale pre-outage app.
+      created.last().emitNavigation(navUpdate(appId = null))
+      waitUntil(timeoutMillis = 5_000) {
+        onAllNodesWithText("Open an app on this device", substring = true)
+          .fetchSemanticsNodes()
+          .isNotEmpty()
+      }
+      assertTrue(
+        "stale pre-outage app must not survive a reconnect that resolves no app",
+        onAllNodesWithText("Alpha").fetchSemanticsNodes().isEmpty(),
+      )
+    }
+
   /** A [SharedFlow] that throws on collection, to simulate a stream read/parse failure. */
   private fun throwingNavFlow(error: Throwable): SharedFlow<NavigationGraphStreamUpdate> =
     object : SharedFlow<NavigationGraphStreamUpdate> {


### PR DESCRIPTION
Closes [#4909](https://github.com/kaeawc/auto-mobile/issues/4909).

Phase C of the nav-graph model ([#4837](https://github.com/kaeawc/auto-mobile/issues/4837)): Navigation is **app-scoped**, not per-device. Re-wires the built-but-dormant `NavigationFacet` (unwired in [#4838](https://github.com/kaeawc/auto-mobile/issues/4838) for cross-contamination) so it sources the **app-level** graph.

## Mechanism chosen: app-scoped pull

The facet keeps the per-device `ObservationStream` connect/dispose lifecycle (keyed on `column.deviceId`) **only** to (a) satisfy that per-device lifecycle and (b) resolve which app is in the foreground on the pane's device (from the stream update's `appId`). The graph itself is then **pulled by app id** via a `NavigationDataSource` (default `RealNavigationDataSource`, which reads the daemon's app-keyed `automobile:navigation/graph?appId=…` resource).

Why the pull over rendering the raw stream (the [#4838](https://github.com/kaeawc/auto-mobile/issues/4838) contamination path):

- It is a stable **snapshot**. A foreign app's broadcast can never overwrite a pane's rendered graph — the pane only re-pulls when *its* resolved app id changes (or on retry).
- Same-app panes pull the **same app-keyed graph** and therefore render identical data — correct under the app-level model, not contamination.
- The facet **never pulls with a null app id**, so no wrong/global graph flashes before the foreground app resolves (it stays in the Loading state).

`NavigationDashboard` gains a backwards-compatible `providedGraph: NavigationGraph? = null` param: when non-null it renders that graph directly and skips its internal data-source fetch and stream collector. Default `null` preserves the existing self-fetching behavior, so `NavigationDashboardUiTest` is unaffected.

## Known caveat (documented, deferred)

`NavigationGraphStreamUpdate` carries an `appId` but no `deviceId`, so two panes running **different** apps can't be fully disambiguated: a foreground-app broadcast for one device can be misattributed to the other pane. Full disambiguation needs the deviceId/build discriminator from the `(app, build)` phase ([#4837](https://github.com/kaeawc/auto-mobile/issues/4837)). Not blocking here.

## Acceptance criteria → tests

`NavigationFacetTest` (8 tests, all green):

- Map `Tool.Navigation -> NavigationFacet` in the host `WorkspaceFacet` when-block — wired in `AutoMobileDesktopApp.kt`.
- App-level graph for the foreground app — `renders the app graph pulled from the data source once the foreground app resolves`.
- Same-app panes show the same shared graph — `two same-app panes render the same shared app graph`.
- No contamination window — `does not pull the app graph until a foreground app is resolved` (0 pulls before a stream update).
- Per-device connect/dispose lifecycle — `connects the stream to the pane device, requests the graph, and disposes on removal` + `reconnects to a new device when the column device changes`.
- Loading / empty / error states — `shows the empty state when the resolved app has no recorded graph`, `surfaces a retryable error when the app graph fails to load`, `retry re-invokes the loader and renders the recovered graph`.

## Validation

```
android/gradlew -p android :desktop-core:detektMain :desktop-core:test :desktop-app:compileKotlin
```

BUILD SUCCESSFUL. Full `:desktop-core:test` green; touched `.kt` formatted with pinned ktfmt 0.64 (clean diff).
