### PR TITLE
Whitelist video-server command-channel bytes (#4732)

### DIFF
--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamProtocol.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamProtocol.kt
@@ -21,6 +21,17 @@ object VideoStreamProtocol {
    */
   const val COMMAND_REQUEST_KEY_FRAME = 0x01
 
+  /**
+   * The whitelist of host→device command bytes the control channel accepts. Bytes outside this set
+   * are unknown control input and must be ignored rather than forwarded to the handler
+   * (issue #4732), keeping the control surface minimal and making future command additions safe by
+   * construction.
+   */
+  val KNOWN_COMMANDS = setOf(COMMAND_REQUEST_KEY_FRAME)
+
+  /** True when [command] is a recognized control byte that may reach the command handler. */
+  fun isKnownCommand(command: Int): Boolean = command in KNOWN_COMMANDS
+
   /** Bit 63: codec configuration data */
   const val PACKET_FLAG_CONFIG = 1L shl 63
 

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
@@ -437,6 +437,17 @@ class VideoStreamWriter(
             while (!stopped && isCurrentClient(client)) {
               val command = input.read()
               if (command < 0) break
+              // Whitelist control bytes before forwarding (issue #4732). Unknown values are
+              // unauthenticated control input on the shared socket; ignoring (and debug-logging)
+              // them keeps the control surface minimal. Once the #4729 handshake authenticates the
+              // connection this channel is implicitly authenticated too, but we validate anyway for
+              // defense-in-depth. The reader still reads one byte per iteration and buffers
+              // nothing,
+              // so an unknown-byte flood cannot grow memory or wedge the daemon-threaded reader.
+              if (!VideoStreamProtocol.isKnownCommand(command)) {
+                println("VIDEO_COMMAND_IGNORED socket=$socketName unknown command byte=$command")
+                continue
+              }
               commandHandler?.invoke(command)
             }
           } catch (_: IOException) {

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamProtocolTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamProtocolTest.kt
@@ -2,9 +2,28 @@ package dev.jasonpearson.automobile.video
 
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class VideoStreamProtocolTest {
+  @Test
+  fun onlyTheRequestKeyFrameByteIsAKnownCommand() {
+    assertTrue(VideoStreamProtocol.isKnownCommand(VideoStreamProtocol.COMMAND_REQUEST_KEY_FRAME))
+    assertEquals(
+      setOf(VideoStreamProtocol.COMMAND_REQUEST_KEY_FRAME),
+      VideoStreamProtocol.KNOWN_COMMANDS,
+    )
+    // Every other byte the reader could pull off input.read() (0x00 and 0x02..0xFF) is unknown.
+    assertFalse(VideoStreamProtocol.isKnownCommand(0x00))
+    for (byte in 0x02..0xFF) {
+      assertFalse(
+        "byte $byte must not be a known command",
+        VideoStreamProtocol.isKnownCommand(byte),
+      )
+    }
+  }
+
   @Test
   fun legacyHeaderUsesH264WidthAndHeight() {
     val expected =

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriterTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriterTest.kt
@@ -5,6 +5,7 @@ import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
@@ -468,6 +469,49 @@ class VideoStreamWriterTest {
       received.await(2, TimeUnit.SECONDS),
     )
     assertEquals(VideoStreamProtocol.COMMAND_REQUEST_KEY_FRAME, lastCommand.get())
+  }
+
+  @Test
+  fun commandReaderIgnoresUnknownBytesButStillForwardsKeyFrameRequests() {
+    var now = 1_000L
+    val keyFrameReceived = CountDownLatch(1)
+    val forwarded = CopyOnWriteArrayList<Int>()
+    // An unknown control byte (0x02) precedes the sole known command (0x01), then EOF. The unknown
+    // byte must never reach the handler; the keyframe request still must (issue #4732).
+    val unknownCommand: Int = VideoStreamProtocol.COMMAND_REQUEST_KEY_FRAME + 1
+    val connection =
+      FakeClientConnection(
+        input =
+          ByteArrayInputStream(
+            byteArrayOf(
+              unknownCommand.toByte(),
+              VideoStreamProtocol.COMMAND_REQUEST_KEY_FRAME.toByte(),
+            )
+          )
+      )
+    val subject = writer({ now }, FakeServerSocket(listOf({ connection })))
+
+    subject.startCommandReader { command ->
+      forwarded.add(command)
+      if (command == VideoStreamProtocol.COMMAND_REQUEST_KEY_FRAME) {
+        keyFrameReceived.countDown()
+      }
+    }
+    subject.bindServerSocket()
+    subject.acceptClients {}
+
+    assertTrue(
+      "the whitelisted keyframe request must still be forwarded",
+      keyFrameReceived.await(2, TimeUnit.SECONDS),
+    )
+    // The unknown byte was read before the known one; by the time 0x01 arrives it would already
+    // have
+    // been forwarded if it were not filtered. So the handler must have seen only the known command.
+    assertEquals(
+      "only the whitelisted command byte may reach the handler",
+      listOf(VideoStreamProtocol.COMMAND_REQUEST_KEY_FRAME),
+      forwarded.toList(),
+    )
   }
 
   // --- peer-UID gating (SO_PEERCRED, issue #4728) ---------------------------------------------


### PR DESCRIPTION
Closes [#4732](https://github.com/kaeawc/auto-mobile/issues/4732)

## Summary

The video-server command channel forwarded **every** non-EOF byte read from the client straight to the command handler. Only `0x01` (`COMMAND_REQUEST_KEY_FRAME`) is meaningful, so this was unauthenticated, unvalidated control input on the shared socket. This PR whitelists the command byte and ignores (and logs) anything outside the known set.

## Verify-real findings (against current `main`)

Line numbers had drifted after [#4728](https://github.com/kaeawc/auto-mobile/issues/4728)–[#4731](https://github.com/kaeawc/auto-mobile/issues/4731), so I re-read the source rather than trusting the issue's line refs:

- `VideoStreamWriter.startCommandReaderFor()` (now ~L432-457) looped on `input.read()`, broke only on EOF (`command < 0`), and called `commandHandler?.invoke(command)` for **any** other byte value — confirmed still true.
- `VideoStreamProtocol.COMMAND_REQUEST_KEY_FRAME = 0x01` (L22) is the only defined command — confirmed.
- The reader is already daemon-threaded, reads one byte per iteration, and buffers nothing, so there was no unbounded growth to fix; the ignore path is a bounded `continue`.

## What changed

- `VideoStreamProtocol.kt`: added `KNOWN_COMMANDS = setOf(COMMAND_REQUEST_KEY_FRAME)` and `isKnownCommand(command: Int)`. The whitelist is derived from the named command constant (no magic byte literals), keeping future command additions safe by construction.
- `VideoStreamWriter.kt`: the command reader now gates on `VideoStreamProtocol.isKnownCommand(command)` — unknown bytes are ignored and logged (`VIDEO_COMMAND_IGNORED …`, matching the file's existing `println` machine-parseable log convention) instead of forwarded. Comment notes the [#4729](https://github.com/kaeawc/auto-mobile/issues/4729) handshake dependency (channel is implicitly authenticated once the connection is; whitelist is defense-in-depth) and the bounded/no-growth reasoning.

## Tests

- `VideoStreamProtocolTest.onlyTheRequestKeyFrameByteIsAKnownCommand` — `0x01` is known; `0x00` and `0x02..0xFF` are not.
- `VideoStreamWriterTest.commandReaderIgnoresUnknownBytesButStillForwardsKeyFrameRequests` — an unknown byte preceding `0x01` in the stream is a no-op (never reaches the handler); the whitelisted keyframe request still is forwarded. Reuses the existing injected socket/stream fake seam (`FakeClientConnection` / `FakeServerSocket`).

## Validation (JDK 21, `android/local.properties` set)

- `./gradlew :video-server:test` — **PASS**
- `./gradlew :video-server:detektMain --no-configuration-cache` — **PASS** (no MagicNumber/ImplicitDefaultLocale violations; byte values come from named constants, no string formatting added)
- `ktfmt --google-style` on all four touched files — **clean**
