### PR TITLE
Verify on-device video-server jar before app_process launch + skip redundant push

### DIFF
--- a/docs/design-docs/plat/android/screen-streaming.md
+++ b/docs/design-docs/plat/android/screen-streaming.md
@@ -78,6 +78,38 @@ The accessibility service can only do on-demand `takeScreenshot()` or request `M
    - Decodes frames to tightly packed BGRA
    - Copied into a Skia raster image and drawn by Compose (no SwingPanel needed)
 
+## On-device JAR integrity + push-skip
+
+The persistent encoder is a DEX jar executed via `app_process` as the shell user
+([#4733](https://github.com/kaeawc/auto-mobile/issues/4733)). Two properties are
+enforced around that push/launch, both driven by a single on-device hash:
+
+- **Integrity before launch (defense-in-depth / TOCTOU).** Because the jar runs
+  in the screen/audio-capture context, anything able to write
+  `/data/local/tmp/automobile-video.jar` could substitute code. Before
+  `app_process` is spawned, the host hashes the remote jar
+  (`sha256sum` + `wc -c`, through the injectable ADB seam, bounded by the
+  launch-command timeout) and compares it against the host-known expected sha256
+  and byte size. On a **definitive mismatch** the launch is refused with an
+  `ActionableError` and the source degrades to `screenrecord`; an *unreadable*
+  probe (a device lacking `sha256sum`/`wc`, or a probe timeout) is not a mismatch
+  — the push already overwrote the remote with trusted bytes, so it logs and
+  proceeds (mirrors the handshake graceful-degrade).
+
+- **Skip the redundant push (startup latency).** The same probe runs once *before*
+  the push: when the remote copy is already byte-identical (size **and** hash),
+  the ~2.5 MB `adb push` is skipped and that match doubles as the pre-launch gate
+  (the happy path hashes the remote once). Any mismatch **or** uncertainty
+  (unreadable/absent remote) pushes — correctness is never traded for the
+  optimization.
+
+The expected sha256/size come from `VideoServerJarProvider.computeLocalJarIntegrity()`,
+which hashes the actual local bytes the host would push (the same canonical
+`ChecksumCalculator` used to verify downloads). This is correct for every
+resolution source — cached download, `AUTOMOBILE_VIDEO_SERVER_JAR` override, and
+local Gradle build — because it never trusts the release registry for jars that
+were never checked against it. The value is memoized across relaunches.
+
 ## Protocol Specification
 
 ### Video Stream Header (12 bytes)

--- a/src/features/webrtc/PersistentEncoderH264Source.ts
+++ b/src/features/webrtc/PersistentEncoderH264Source.ts
@@ -16,6 +16,11 @@ import {
   type AdbClientFactory,
 } from "../../utils/android-cmdline-tools/AdbClientFactory";
 import type { AdbProcess } from "../../utils/android-cmdline-tools/interfaces/AdbExecutor";
+import {
+  VideoServerJarProvider,
+  type JarIntegrityProbe,
+  type VideoServerJarIntegrity,
+} from "./VideoServerJarProvider";
 import type { H264CaptureSource, H264CaptureSourceTelemetry } from "./H264CaptureSource";
 import {
   VIDEO_SERVER_CODEC_ID_H264,
@@ -275,6 +280,15 @@ export interface PersistentEncoderH264SourceOptions {
   fps?: number;
   /** Local path to the built `automobile-video.jar`. Required to run. */
   jarPath: string;
+  /**
+   * Source of the host-known expected sha256 + size of {@link jarPath} (issue
+   * #4733), used to skip a redundant push when the on-device copy already matches
+   * and to verify remote integrity before `app_process` launch. Injected for
+   * device-free tests; defaults to the shared {@link VideoServerJarProvider}
+   * singleton, which hashes the local jar with the same canonical calculator it
+   * verifies downloads with.
+   */
+  jarIntegrityProvider?: JarIntegrityProbe;
   adbFactory?: AdbClientFactory;
   connector?: SocketConnector;
   timer?: Timer;
@@ -374,6 +388,36 @@ function parseVideoForwardLine(line: string): { port: number; socketName: string
     return null;
   }
   return { port, socketName: destination.slice("localabstract:".length) };
+}
+
+/**
+ * Parse the on-device jar-integrity probe output (issue #4733): the combined
+ * stdout of `sha256sum <jar>` (a `<64-hex>  <path>` line) and `wc -c < <jar>` (a
+ * bare byte count). Order-independent. Returns `null` on any missing/garbled
+ * field — a partial or absent result (jar missing, `sha256sum`/`wc` unavailable)
+ * is treated by the caller as "push needed", never as a match.
+ */
+function parseRemoteJarIntegrity(output: string): VideoServerJarIntegrity | null {
+  let sha256: string | null = null;
+  let size: number | null = null;
+  for (const rawLine of output.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line.length === 0) {
+      continue;
+    }
+    if (/^[0-9]+$/.test(line)) {
+      size = Number.parseInt(line, 10);
+      continue;
+    }
+    const shaMatch = /^([a-f0-9]{64})(?:\s|$)/.exec(line);
+    if (shaMatch) {
+      sha256 = shaMatch[1];
+    }
+  }
+  if (sha256 === null || size === null || !Number.isInteger(size) || size < 0) {
+    return null;
+  }
+  return { sha256, size };
 }
 
 function isSafeSessionToken(value: string): boolean {
@@ -510,6 +554,26 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
   private readonly activeVideoSessionRegistry: ActiveVideoSessionRegistry;
   private readonly maxServerRelaunchAttempts: number;
   private readonly serverRelaunchBackoff: BackoffPolicy;
+  /**
+   * Injected host-integrity source, or `undefined` to lazily default to the
+   * shared {@link VideoServerJarProvider} singleton. Resolved on first use rather
+   * than in the constructor so the `??` default does not count against the
+   * constructor's complexity ratchet.
+   */
+  private readonly jarIntegrityProvider: JarIntegrityProbe | undefined;
+
+  /**
+   * Host-known expected sha256 + size of the local jar (issue #4733), memoized
+   * across relaunches because the on-disk jar does not change during a source's
+   * lifetime.
+   */
+  private expectedJarIntegrity: VideoServerJarIntegrity | null = null;
+  /**
+   * True once the on-device jar has been confirmed byte-identical to the expected
+   * host copy for the current launch. Set when the pre-push probe matches (push
+   * skipped) so the pre-launch verify can reuse that result; reset per session.
+   */
+  private remoteJarVerified = false;
 
   private server: AdbProcess | null = null;
   private socket: StreamSocket | null = null;
@@ -562,6 +626,7 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
       options.socketNameFactory ?? (() => makeOpaqueSocketName(defaultIdGenerator));
     this.activeVideoSessionRegistry =
       options.activeVideoSessionRegistry ?? defaultActiveVideoSessionRegistry;
+    this.jarIntegrityProvider = options.jarIntegrityProvider;
     const relaunchPolicy = PersistentEncoderH264Source.resolveRelaunchPolicy(options);
     this.maxServerRelaunchAttempts = relaunchPolicy.maxAttempts;
     this.serverRelaunchBackoff = relaunchPolicy.backoff;
@@ -736,17 +801,14 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     const session = this.createSession();
     this.session = session;
     this.deviceProcessId = null;
+    this.remoteJarVerified = false;
     // Claim this session's socket name BEFORE reconcile opens/owns any forward,
     // so a sibling session's concurrent orphan sweep can never mistake our
     // about-to-be-created forward for a stranded one. Cleared in teardown().
     this.activeVideoSessionRegistry.add(this.options.device.deviceId, session.socketName);
     await this.reconcileExpiredLeases(adb);
     if (!this.running) {return null;}
-    await this.withTimeout(
-      adb.executeCommand(`push "${this.options.jarPath}" ${VIDEO_SERVER_REMOTE_JAR_PATH}`),
-      this.commandTimeoutMs,
-      "adb push video-server jar"
-    );
+    await this.ensureRemoteJar(adb);
     if (!this.running) {return null;}
     const forward = await this.withTimeout(
       adb.executeCommand(`forward tcp:0 localabstract:${session.socketName}`),
@@ -767,9 +829,130 @@ export class PersistentEncoderH264Source implements H264CaptureSource {
     return port;
   }
 
+  /**
+   * Push the jar to `/data/local/tmp` only when the on-device copy does not
+   * already match the verified host bytes (issue #4733). The remote jar is
+   * sha256summed + sized through the ADB seam and compared against the host-known
+   * expected {@link VideoServerJarIntegrity}; a byte-identical remote copy skips
+   * the ~2.5 MB USB push (first-frame latency), otherwise the push runs. Any
+   * mismatch OR uncertainty (unreadable remote, missing `sha256sum`/`wc`, a probe
+   * timeout) pushes — correctness is never traded for the optimization. A skip is
+   * recorded in {@link remoteJarVerified} so the pre-launch verify can reuse it
+   * (the happy path hashes the remote once). Bounded by the launch-command
+   * timeout (issue #4741) like every other launch-path ADB call.
+   */
+  private async ensureRemoteJar(adb: ReturnType<AdbClientFactory["create"]>): Promise<void> {
+    const expected = await this.resolveExpectedJarIntegrity();
+    const remote = await this.statAndHashRemoteJar(adb);
+    if (remote !== null && remote.size === expected.size && remote.sha256 === expected.sha256) {
+      this.remoteJarVerified = true;
+      logger.info(
+        `[PersistentEncoderH264Source] on-device video-server jar already matches ` +
+        `(sha256=${expected.sha256}, size=${expected.size}); skipping push`
+      );
+      return;
+    }
+    if (remote !== null) {
+      logger.info(
+        `[PersistentEncoderH264Source] on-device video-server jar differs ` +
+        `(expected sha256=${expected.sha256} size=${expected.size}, ` +
+        `remote sha256=${remote.sha256} size=${remote.size}); pushing`
+      );
+    }
+    await this.withTimeout(
+      adb.executeCommand(`push "${this.options.jarPath}" ${VIDEO_SERVER_REMOTE_JAR_PATH}`),
+      this.commandTimeoutMs,
+      "adb push video-server jar"
+    );
+  }
+
+  /**
+   * Refuse to `app_process`-launch a jar whose on-device bytes DEFINITIVELY do
+   * not match the verified host copy (issue #4733) — a supply-chain / TOCTOU
+   * guard, since the jar runs in the screen/audio-capture context. Reuses the
+   * pre-push match when the push was skipped ({@link remoteJarVerified}); `adb
+   * forward` does not touch the jar, so that match still holds as the launch gate.
+   * Otherwise (a push just ran) it re-hashes the remote jar and throws an
+   * {@link ActionableError} on a definitive mismatch. An unreadable probe (device
+   * without `sha256sum`/`wc`, or a probe timeout) is not a mismatch: the push has
+   * already overwritten the remote with our trusted bytes, so — mirroring the
+   * handshake graceful-degrade — it logs and proceeds rather than regressing every
+   * such device to screenrecord.
+   */
+  private async verifyRemoteJarBeforeLaunch(adb: ReturnType<AdbClientFactory["create"]>): Promise<void> {
+    if (this.remoteJarVerified) {
+      return;
+    }
+    const expected = await this.resolveExpectedJarIntegrity();
+    const remote = await this.statAndHashRemoteJar(adb);
+    if (remote === null) {
+      logger.warn(
+        `[PersistentEncoderH264Source] could not hash the on-device jar at ${VIDEO_SERVER_REMOTE_JAR_PATH} ` +
+        "before launch; proceeding on the just-pushed trusted bytes (integrity verification degraded)"
+      );
+      return;
+    }
+    if (remote.size !== expected.size || remote.sha256 !== expected.sha256) {
+      throw new ActionableError(
+        `Refusing to launch video-server: the on-device jar at ${VIDEO_SERVER_REMOTE_JAR_PATH} failed ` +
+        `integrity verification (expected sha256=${expected.sha256} size=${expected.size}, got ` +
+        `sha256=${remote.sha256} size=${remote.size}). The bytes on the device do not match the ` +
+        "verified host copy; app_process will not be launched."
+      );
+    }
+    this.remoteJarVerified = true;
+  }
+
+  /**
+   * Host-known expected sha256 + size of the local jar, memoized (issue #4733).
+   * Delegates to the injected {@link JarIntegrityProbe}, which hashes the actual
+   * bytes at {@link PersistentEncoderH264SourceOptions.jarPath} with the canonical
+   * calculator — correct for cache, override, and local-build jars alike.
+   */
+  private async resolveExpectedJarIntegrity(): Promise<VideoServerJarIntegrity> {
+    if (this.expectedJarIntegrity === null) {
+      const provider = this.jarIntegrityProvider ?? VideoServerJarProvider.getInstance();
+      const integrity = await provider.computeLocalJarIntegrity(this.options.jarPath);
+      this.expectedJarIntegrity = { sha256: integrity.sha256.toLowerCase(), size: integrity.size };
+    }
+    return this.expectedJarIntegrity;
+  }
+
+  /**
+   * Read the on-device jar's sha256 + byte size through the ADB seam, or `null`
+   * when it cannot be determined (issue #4733). A single `sh -c` runs
+   * `sha256sum` + `wc -c` on the constant remote path (no interpolation), bounded
+   * by the launch-command timeout. A missing jar, absent tooling, or a timeout
+   * yields `null` — the callers treat that as "push"/"refuse", never as a match.
+   */
+  private async statAndHashRemoteJar(
+    adb: ReturnType<AdbClientFactory["create"]>
+  ): Promise<VideoServerJarIntegrity | null> {
+    const probe =
+      `sha256sum ${VIDEO_SERVER_REMOTE_JAR_PATH} 2>/dev/null; ` +
+      `wc -c < ${VIDEO_SERVER_REMOTE_JAR_PATH} 2>/dev/null`;
+    try {
+      const result = await this.withTimeout(
+        adb.executeCommand(`shell sh -c ${shellQuote(probe)}`),
+        this.commandTimeoutMs,
+        "adb hash video-server jar"
+      );
+      return parseRemoteJarIntegrity(result.stdout);
+    } catch (error) {
+      // Uncertainty is not fatal here: the caller pushes (or refuses to launch)
+      // on a null probe, so a wedged/absent probe never yields a false match.
+      logger.debug(`[PersistentEncoderH264Source] unable to hash on-device video-server jar: ${error}`);
+      return null;
+    }
+  }
+
   private async spawnAndWaitForServer(
     adb: ReturnType<AdbClientFactory["create"]>
   ): Promise<AdbProcess | null> {
+    await this.verifyRemoteJarBeforeLaunch(adb);
+    if (!this.running) {
+      return null;
+    }
     const server = await this.withTimeout(
       adb.spawn(this.buildServerArgs()),
       this.commandTimeoutMs,

--- a/src/features/webrtc/VideoServerJarProvider.ts
+++ b/src/features/webrtc/VideoServerJarProvider.ts
@@ -37,6 +37,31 @@ export interface VideoServerJarMetadata {
   downloadedAt: number;
 }
 
+/**
+ * Host-known integrity descriptor of a local `automobile-video.jar` — the exact
+ * bytes the host would push to `/data/local/tmp`. Used by the on-device jar-hash
+ * mechanism (issue #4733) to decide whether the remote copy already matches
+ * (skip the push) and to verify the remote bytes before `app_process` launch.
+ */
+export interface VideoServerJarIntegrity {
+  /** Lowercase sha256 hex of the jar's bytes. */
+  sha256: string;
+  /** Byte size of the jar. */
+  size: number;
+}
+
+/**
+ * The single method {@link PersistentEncoderH264Source} needs to learn the
+ * host-known expected sha256 + size of the jar it is about to push/launch. A
+ * narrow interface (YAGNI) so tests can inject a fake without the download
+ * machinery. The production default is {@link VideoServerJarProvider}, which
+ * computes it with the same canonical {@link ChecksumCalculator} it uses to
+ * verify downloads.
+ */
+export interface JarIntegrityProbe {
+  computeLocalJarIntegrity(jarPath: string): Promise<VideoServerJarIntegrity>;
+}
+
 export interface VideoServerJarProviderDeps {
   downloader?: FileDownloader;
   checksumCalculator?: ChecksumCalculator;
@@ -102,6 +127,23 @@ export class VideoServerJarProvider {
    */
   public static setExpectedChecksumForTesting(checksum: string | null): void {
     VideoServerJarProvider.expectedChecksumOverride = checksum;
+  }
+
+  /**
+   * Compute the host-known sha256 + size of a resolved local jar (issue #4733).
+   * Works for any resolution source — cached download, `AUTOMOBILE_VIDEO_SERVER_JAR`
+   * override, or local Gradle build — because it hashes the actual bytes that
+   * will be pushed rather than trusting the release registry (which override/build
+   * jars are never checked against). Reuses the same canonical
+   * {@link ChecksumCalculator} the download path verifies with, so the "expected"
+   * value is derived identically everywhere.
+   */
+  public async computeLocalJarIntegrity(jarPath: string): Promise<VideoServerJarIntegrity> {
+    const [{ checksum }, stats] = await Promise.all([
+      this.checksumCalculator.computeFileSha256(jarPath),
+      fs.stat(jarPath),
+    ]);
+    return { sha256: checksum.toLowerCase(), size: stats.size };
   }
 
   private get cachedJarPath(): string {

--- a/test/features/webrtc/PersistentEncoderH264Source.test.ts
+++ b/test/features/webrtc/PersistentEncoderH264Source.test.ts
@@ -26,6 +26,13 @@ import { FakeTimer } from "../../fakes/FakeTimer";
 
 const DEVICE: BootedDevice = { deviceId: "emulator-5554", platform: "android", name: "t" } as BootedDevice;
 const FORWARD_PORT = "45999";
+const REMOTE_JAR_PATH = "/data/local/tmp/automobile-video.jar";
+// Host-known expected integrity of the local jar the source would push (issue #4733).
+const EXPECTED_JAR_SHA256 = "a".repeat(64);
+const EXPECTED_JAR_SIZE = 2_500_000;
+// Combined `sha256sum` + `wc -c` probe stdout the on-device jar-hash helper parses.
+const remoteJarProbeOutput = (sha256: string, size: number): string =>
+  `${sha256}  ${REMOTE_JAR_PATH}\n${size}\n`;
 const SESSION_TOKEN = "session-0001";
 const SESSION_SOCKET = `${VIDEO_SERVER_SOCKET_PREFIX}_session0001`;
 const VIDEO_SERVER_MAIN_CLASS = "dev.jasonpearson.automobile.video.VideoServer";
@@ -164,6 +171,31 @@ function makeSource(overrides: Record<string, unknown> = {}) {
   const hangCommands = (overrides.hangCommands as string[] | undefined) ?? [];
   const neverResolves = <T>(): Promise<T> => new Promise<T>(() => {});
 
+  // Models the on-device jar (issue #4733): the remote copy matches the expected
+  // host bytes only after a push has landed, unless a test opts into a specific
+  // pre-push state (already-matching, always-mismatching, or a raw probe string).
+  let pushed = false;
+  const remoteJarProbeStdout = (): string => {
+    if (overrides.remoteJarProbe !== undefined) {
+      return overrides.remoteJarProbe as string;
+    }
+    if (overrides.remoteJarAlwaysMismatch === true) {
+      return remoteJarProbeOutput("b".repeat(64), 999);
+    }
+    if (overrides.remoteJarMatchesBeforePush === true) {
+      return remoteJarProbeOutput(EXPECTED_JAR_SHA256, EXPECTED_JAR_SIZE);
+    }
+    if (pushed) {
+      return remoteJarProbeOutput(EXPECTED_JAR_SHA256, EXPECTED_JAR_SIZE);
+    }
+    // A valid-but-different remote jar before the push (vs. an absent/unreadable
+    // one, the default empty probe) — both must push, but this exercises the
+    // "differs" branch specifically.
+    return overrides.remoteJarDiffersBeforePush === true
+      ? remoteJarProbeOutput("c".repeat(64), 42)
+      : "";
+  };
+
   const adbFactory: AdbClientFactory = {
     create() {
       return {
@@ -172,6 +204,13 @@ function makeSource(overrides: Record<string, unknown> = {}) {
           commands.push(command);
           if (hangCommands.some(sub => command.includes(sub))) {
             return neverResolves<{ stdout: string; stderr: string; exitCode: number }>();
+          }
+          if (command.startsWith("push")) {
+            pushed = true;
+            return Promise.resolve({ stdout: "", stderr: "", exitCode: 0 });
+          }
+          if (command.includes("sha256sum") && command.includes("automobile-video.jar")) {
+            return Promise.resolve({ stdout: remoteJarProbeStdout(), stderr: "", exitCode: 0 });
           }
           if (command.startsWith("forward tcp:0")) {
             forwardedSocket = command.split("localabstract:")[1] ?? null;
@@ -247,6 +286,15 @@ function makeSource(overrides: Record<string, unknown> = {}) {
     onAudioData: chunk => audioChunks.push(chunk),
     onError: error => errors.push(error),
     jarPath: "/tmp/automobile-video.jar",
+    // Host-known expected jar integrity (issue #4733) via a fake so no real file
+    // is hashed; individual tests override for override/build-path coverage.
+    jarIntegrityProvider: {
+      computeLocalJarIntegrity: async () =>
+        (overrides.expectedJarIntegrity as { sha256: string; size: number } | undefined) ?? {
+          sha256: EXPECTED_JAR_SHA256,
+          size: EXPECTED_JAR_SIZE,
+        },
+    },
     adbFactory,
     connector,
     timer,
@@ -292,6 +340,97 @@ async function startReady(ctx: ReturnType<typeof makeSource>): Promise<void> {
     ctx.audioChunks.length = 0;
   }
 }
+
+describe("PersistentEncoderH264Source on-device jar integrity (issue #4733)", () => {
+  const pushCommands = (ctx: ReturnType<typeof makeSource>): string[] =>
+    ctx.commands.filter(c => c.startsWith("push") && c.includes(REMOTE_JAR_PATH));
+  const probeCommands = (ctx: ReturnType<typeof makeSource>): string[] =>
+    ctx.commands.filter(c => c.includes("sha256sum") && c.includes("automobile-video.jar"));
+
+  test("skips the push when the on-device jar already matches the expected bytes", async () => {
+    const ctx = makeSource({ remoteJarMatchesBeforePush: true });
+    await startReady(ctx);
+
+    // Byte-identical remote copy: no USB push, and the pre-push match doubles as
+    // the pre-launch integrity gate (a single probe on the happy path).
+    expect(pushCommands(ctx)).toHaveLength(0);
+    expect(probeCommands(ctx)).toHaveLength(1);
+    // Launch still proceeds.
+    expect(ctx.spawnArgs).toHaveLength(1);
+
+    await ctx.source.stop();
+  });
+
+  test("pushes when the on-device jar differs, then launches after re-verify", async () => {
+    // A valid-but-different remote jar pre-push; the fake device updates to the
+    // expected bytes once the push lands, so the pre-launch verify passes.
+    const ctx = makeSource({ remoteJarDiffersBeforePush: true });
+    await startReady(ctx);
+
+    expect(pushCommands(ctx)).toHaveLength(1);
+    // Two probes: the pre-push comparison and the post-push pre-launch verify.
+    expect(probeCommands(ctx)).toHaveLength(2);
+    expect(ctx.spawnArgs).toHaveLength(1);
+
+    await ctx.source.stop();
+  });
+
+  test("pushes when the remote jar cannot be hashed (uncertainty), never skips", async () => {
+    // Perma-empty probe => integrity unknown at both the pre-push comparison and
+    // the pre-launch verify. Uncertainty never skips the push; and because the
+    // push overwrote the remote with trusted bytes, the unverifiable pre-launch
+    // check degrades-and-proceeds (device may lack sha256sum/wc) rather than
+    // regressing to screenrecord.
+    const ctx = makeSource({ remoteJarProbe: "" });
+    await startReady(ctx);
+
+    expect(pushCommands(ctx).length).toBeGreaterThanOrEqual(1);
+    expect(ctx.spawnArgs).toHaveLength(1);
+
+    await ctx.source.stop();
+  });
+
+  test("does not skip the push when only the size matches but the hash differs", async () => {
+    // A same-size, different-bytes remote jar (a targeted swap) must still push.
+    const ctx = makeSource({
+      remoteJarProbe: remoteJarProbeOutput("d".repeat(64), EXPECTED_JAR_SIZE),
+    });
+    // The pre-push probe (wrong hash) forces a push; after the push the fake would
+    // keep returning the override, so this scenario also refuses at pre-launch —
+    // exactly the tamper guard. Assert the push happened.
+    let thrown: unknown;
+    try {
+      await ctx.source.start();
+    } catch (error) {
+      thrown = error;
+    }
+    expect(pushCommands(ctx)).toHaveLength(1);
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toContain("failed integrity verification");
+
+    await ctx.source.stop();
+  });
+
+  test("refuses to launch when the post-push on-device jar fails integrity verification", async () => {
+    // The remote jar never matches, even after the push: a tamper/TOCTOU signal.
+    const ctx = makeSource({ remoteJarAlwaysMismatch: true });
+    const errors: Error[] = [];
+
+    let thrown: unknown;
+    try {
+      await ctx.source.start();
+    } catch (error) {
+      thrown = error;
+    }
+    // start() tears down and rethrows so the factory can fall back to screenrecord.
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toContain("failed integrity verification");
+    // app_process must NOT have been spawned.
+    expect(ctx.spawnArgs).toHaveLength(0);
+    expect(ctx.source.isRunning).toBe(false);
+    void errors;
+  });
+});
 
 describe("PersistentEncoderH264Source", () => {
   test("pushes the jar, launches the server with overrides, forwards, and forwards frames", async () => {

--- a/test/features/webrtc/VideoServerJarProvider.test.ts
+++ b/test/features/webrtc/VideoServerJarProvider.test.ts
@@ -86,6 +86,21 @@ describe("VideoServerJarProvider (#3831)", function() {
     expect(meta.size).toBe(stats.size);
   });
 
+  test("computeLocalJarIntegrity returns the lowercased sha256 and byte size of a local jar (#4733)", async function() {
+    // A real on-disk jar so the fs.stat size is genuine; the sha comes from the
+    // injected canonical calculator (here forced to a known value).
+    const localJar = path.join(cacheDir, "override-automobile-video.jar");
+    const bytes = validJarBuffer();
+    await fs.writeFile(localJar, bytes);
+    checksum.setFileChecksum(localJar, "A".repeat(64)); // upper-case in => lower-case out
+
+    const integrity = await makeProvider().computeLocalJarIntegrity(localJar);
+
+    expect(integrity.sha256).toBe("a".repeat(64));
+    expect(integrity.size).toBe(bytes.length);
+    expect(checksum.computedFiles).toContain(localJar);
+  });
+
   test("invalidates the cache and re-downloads when the on-disk jar size no longer matches the sidecar", async function() {
     const jarPath = (await makeProvider().ensure())!;
     expect(downloader.downloadedUrls).toHaveLength(1);


### PR DESCRIPTION
Closes [#4733](https://github.com/kaeawc/auto-mobile/issues/4733) (which absorbed [#4755](https://github.com/kaeawc/auto-mobile/issues/4755)).

## Summary

Adds one shared on-device jar-hash mechanism to `PersistentEncoderH264Source` that serves both halves of the issue:

1. **Integrity before launch (defense-in-depth / TOCTOU).** Before `app_process` spawns the DEX jar as the shell user, the host hashes the remote `/data/local/tmp/automobile-video.jar` (`sha256sum` + `wc -c`, through the existing injectable ADB seam, bounded by the launch-command timeout from [#4741](https://github.com/kaeawc/auto-mobile/issues/4741)) and compares it against the host-known expected sha256 + byte size. A definitive mismatch is refused with an `ActionableError`; the source then degrades to `screenrecord`.
2. **Skip the redundant push (startup latency).** The same probe runs once *before* the push: when the remote copy is already byte-identical (size **and** hash), the ~2.5 MB `adb push` is skipped and that match doubles as the pre-launch gate (the happy path hashes the remote once). Any mismatch **or** uncertainty pushes.

### Plumbing

`PersistentEncoderH264Source` previously received only `jarPath`. It now resolves the expected sha256/size via `VideoServerJarProvider.computeLocalJarIntegrity()` — a new method that hashes the actual local bytes with the same canonical `ChecksumCalculator` the download path verifies with. This is correct for every resolution source (cached download, `AUTOMOBILE_VIDEO_SERVER_JAR` override, and local Gradle build) because it never trusts the release registry for jars that were never checked against it. The provider is injected (narrow `JarIntegrityProbe` interface) for device-free tests and the expected value is memoized across relaunches.

### Uncertainty policy

- **Push decision:** any mismatch OR uncertainty (unreadable remote, missing `sha256sum`/`wc`, probe timeout) pushes — correctness is never traded for the optimization.
- **Pre-launch verify:** refuses only on a *definitive* mismatch (remote readable but different bytes). An *unreadable* probe is not a mismatch — the push already overwrote the remote with trusted bytes, so it logs and proceeds, mirroring this file's existing handshake graceful-degrade rather than regressing every device that lacks `sha256sum` to `screenrecord`.

## Verify-against-current-main findings

`PersistentEncoderH264Source.ts` has changed substantially since the issue was filed. I re-read the current code rather than the issue's line numbers:

- `prepareSession()` (not `:359`) is where the push lives; it now runs `reconcileExpiredLeases` (forward sweep [#4753](https://github.com/kaeawc/auto-mobile/issues/4753) / reconcile [#4783](https://github.com/kaeawc/auto-mobile/issues/4783)) before the push, and is reached on the relaunch path ([#4742](https://github.com/kaeawc/auto-mobile/issues/4742)) as well as initial start — so the flag is reset per session and the expected-integrity hash is memoized across relaunches.
- Launch args are built in `buildServerArgs()` and spawned in `spawnAndWaitForServer()` (opaque socket name + handshake, [#4729](https://github.com/kaeawc/auto-mobile/issues/4729)); I inserted the pre-launch verify at the top of `spawnAndWaitForServer()`, before `buildServerArgs()`/`adb.spawn`.
- All launch-path ADB calls are already wrapped in the `withTimeout` bound ([#4741](https://github.com/kaeawc/auto-mobile/issues/4741)); the new hash probe reuses it, and a probe timeout is caught → treated as uncertainty.
- The source still received only `jarPath` (no checksum), matching the issue's premise.

The issue mentions "video-recording design doc"; that doc (`mcp/observe/video-recording.md`) covers the `videoRecording` MCP tool (simctl / dex recording), not this WebRTC persistent-encoder push/launch path. The accurate home for this behavior is `docs/design-docs/plat/android/screen-streaming.md`, which already documents the jar push + `app_process` + shell-UID model; I added an "On-device JAR integrity + push-skip" section there.

## Tests (TDD, all fakes, <100ms each)

New `PersistentEncoderH264Source` cases: remote matches -> push skipped + launch proceeds (single probe); remote differs -> push + re-verify + launch; unreadable pre-push probe -> push, never skip; same-size/different-hash -> push then refuse; post-push definitive mismatch -> refuse with `ActionableError`, `app_process` never spawned. New `VideoServerJarProvider.computeLocalJarIntegrity` case (lowercased sha + real byte size).

## Validation

- `bun run typecheck` — no new type errors (196 baseline).
- `turbo run lint build test` — lint clean, build ok, 12340 pass / 0 fail.
