### PR TITLE
fix(video-server): Detekt ImplicitDefaultLocale in VideoSessionLeaseTest (un-red main)

### DIFF
--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoSessionLeaseTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoSessionLeaseTest.kt
@@ -2,6 +2,7 @@ package dev.jasonpearson.automobile.video
 
 import java.io.File
 import java.security.MessageDigest
+import java.util.HexFormat
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -49,11 +50,8 @@ class VideoSessionLeaseTest {
     )
 
   private fun expectedHash(token: String): String =
-    MessageDigest.getInstance("SHA-256").digest(token.toByteArray(Charsets.US_ASCII)).joinToString(
-      ""
-    ) {
-      "%02x".format(it.toInt() and 0xFF)
-    }
+    HexFormat.of()
+      .formatHex(MessageDigest.getInstance("SHA-256").digest(token.toByteArray(Charsets.US_ASCII)))
 
   @Test
   fun writesHeartbeatInDeviceElapsedRealtimeDomainAndRemovesLeaseOnStop() {


### PR DESCRIPTION
## Un-reds main: Detekt `ImplicitDefaultLocale` in a test file

Main's full-tree Detekt job (`detektMain detektTest`) went red after #4731 merged. The PR-scoped Detekt check runs **`detektMain` only** (main sources), so a duplicate `"%02x".format(...)` hex helper in `VideoSessionLeaseTest.kt:55` — mirroring the production one already fixed to `HexFormat` in #4731 — slipped through the PR gate and only failed on the full-tree main run.

Fix: use `java.util.HexFormat` in the test helper, matching the production code. Only error-severity violation in the whole tree (verified against the failed run's detekt report).

Validated locally (JDK 21): `:video-server:detektMain`, `:video-server:detektTest`, and `:video-server:test` all BUILD SUCCESSFUL.

**Follow-up worth considering:** run `detektTest` (not just `detektMain`) on PRs so test-source violations are caught pre-merge.
