### PR TITLE
feat(desktop): wire branded app icon into installers + dev-run Dock

### DIFF
--- a/android/desktop-app/build.gradle.kts
+++ b/android/desktop-app/build.gradle.kts
@@ -152,6 +152,7 @@ dependencies {
   // Test dependencies
   testImplementation(libs.kotlin.test)
   testImplementation(libs.kotlinx.coroutines.test)
+  testImplementation(libs.junit)
 }
 
 compose.desktop {

--- a/android/desktop-app/build.gradle.kts
+++ b/android/desktop-app/build.gradle.kts
@@ -164,11 +164,8 @@ compose.desktop {
       description = "AutoMobile Desktop - Device automation and testing dashboard"
       vendor = "AutoMobile"
 
-      // Custom installer icons are intentionally omitted for now: the committed
-      // app-icon.{icns,ico,png} are 1x1 placeholder stubs (the .icns is in fact a
-      // PNG), which jpackage would reject or embed as a broken icon. jpackage
-      // falls back to its default icon until real branded assets replace them.
       macOS {
+        iconFile.set(project.file("src/main/resources/icons/app-icon.icns"))
         bundleID = "dev.jasonpearson.automobile.desktop"
         // jpackage rejects a 0 major on macOS; use the floored version here.
         packageVersion = desktopMacPackageVersion
@@ -186,12 +183,14 @@ compose.desktop {
         }
       }
       windows {
+        iconFile.set(project.file("src/main/resources/icons/app-icon.ico"))
         // Stable Windows Installer UpgradeCode. jpackage generates a fresh UUID
         // per build when this is unset, so consecutive MSIs would not recognize
         // each other as upgrades and would install side-by-side. This value must
         // stay constant across all future releases.
         upgradeUuid = "D3041B43-B2F0-413F-980F-A05C6DC370B2"
       }
+      linux { iconFile.set(project.file("src/main/resources/icons/app-icon.png")) }
     }
   }
 }

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/DockIcon.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/DockIcon.kt
@@ -46,14 +46,20 @@ internal fun loadBundledImage(resourcePath: String): BufferedImage? =
  * [java.awt.Taskbar.getTaskbar], which initializes the AWT toolkit, so this must run only after
  * `apple.awt.application.name` has been set.
  *
- * The [installer] and [imageLoader] parameters default to the production platform implementations;
- * tests inject fakes to exercise the supported / missing-resource / throwing paths
- * deterministically.
+ * The [installer], [imageLoader], and [isPackaged] parameters default to the production platform
+ * implementations; tests inject fakes to exercise the packaged / supported / missing-resource /
+ * throwing paths deterministically.
  */
 internal fun setDockIcon(
   installer: DockIconInstaller = TaskbarDockIconInstaller(),
   imageLoader: (String) -> BufferedImage? = ::loadBundledImage,
+  isPackaged: Boolean = System.getProperty("jpackage.app-path") != null,
 ) {
+  // A packaged app already gets its padded/masked ICNS from the bundle; overriding at runtime with
+  // the full-bleed PNG (kept full-bleed for Linux) would undo that macOS branding. Only brand
+  // unbundled dev runs, where macOS otherwise shows the generic Java icon. jpackage launchers set
+  // `jpackage.app-path`; gradle run/hotRun never do.
+  if (isPackaged) return
   if (!installer.isSupported) return
   val image = imageLoader("/icons/app-icon.png") ?: return
   try {

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/DockIcon.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/DockIcon.kt
@@ -1,0 +1,65 @@
+package dev.jasonpearson.automobile.desktop
+
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import java.awt.Taskbar
+import java.awt.image.BufferedImage
+import javax.imageio.ImageIO
+
+private val LOG = LoggerFactory.getLogger("DockIcon")
+
+/**
+ * Narrow seam over the macOS Dock-icon platform API so the startup icon logic is testable off-Mac.
+ *
+ * [java.awt.Taskbar] is a `final` JDK class with a private constructor, so it cannot be faked
+ * directly — this thin interface is the fake-able boundary.
+ */
+internal interface DockIconInstaller {
+  val isSupported: Boolean
+
+  fun install(image: BufferedImage)
+}
+
+/** Production installer backed by [java.awt.Taskbar]. */
+internal class TaskbarDockIconInstaller : DockIconInstaller {
+  // Short-circuit: getTaskbar() may only be called once isTaskbarSupported() is true.
+  override val isSupported: Boolean
+    get() =
+      Taskbar.isTaskbarSupported() && Taskbar.getTaskbar().isSupported(Taskbar.Feature.ICON_IMAGE)
+
+  override fun install(image: BufferedImage) {
+    Taskbar.getTaskbar().iconImage = image
+  }
+}
+
+/**
+ * Loads a classpath resource as an image; `null` if the resource is absent or undecodable. Pure and
+ * headless-safe, so it can be exercised in unit tests off-Mac.
+ */
+internal fun loadBundledImage(resourcePath: String): BufferedImage? =
+  TaskbarDockIconInstaller::class.java.getResourceAsStream(resourcePath)?.use { ImageIO.read(it) }
+
+/**
+ * Sets the macOS Dock icon from the bundled PNG. Guarded so non-macOS / unsupported platforms are a
+ * no-op and never throw.
+ *
+ * Ordering constraint: [DockIconInstaller.isSupported] / [DockIconInstaller.install] touch
+ * [java.awt.Taskbar.getTaskbar], which initializes the AWT toolkit, so this must run only after
+ * `apple.awt.application.name` has been set.
+ *
+ * The [installer] and [imageLoader] parameters default to the production platform implementations;
+ * tests inject fakes to exercise the supported / missing-resource / throwing paths
+ * deterministically.
+ */
+internal fun setDockIcon(
+  installer: DockIconInstaller = TaskbarDockIconInstaller(),
+  imageLoader: (String) -> BufferedImage? = ::loadBundledImage,
+) {
+  if (!installer.isSupported) return
+  val image = imageLoader("/icons/app-icon.png") ?: return
+  try {
+    installer.install(image)
+  } catch (e: UnsupportedOperationException) {
+    // Some platforms report ICON_IMAGE support but still throw here; ignore but leave a trace.
+    LOG.warn("Setting the Dock icon is unsupported on this platform", e)
+  }
+}

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/Main.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/Main.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
 import dev.jasonpearson.automobile.desktop.core.daemon.McpConnectionException
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
-import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import dev.jasonpearson.automobile.desktop.core.shell.MenuBarActions
 import dev.jasonpearson.automobile.desktop.core.workspace.isCommandPaletteShortcut
 import dev.jasonpearson.automobile.desktop.di.AutoMobileGraph
@@ -68,33 +67,6 @@ private fun acquireSingleInstanceLock(): Boolean {
     true
   }
 }
-
-/** Logger for main-entrypoint diagnostics (Dock icon setup, etc.). */
-private val LOG = LoggerFactory.getLogger("Main")
-
-/**
- * Sets the macOS Dock icon from the bundled PNG. Guarded so non-macOS / unsupported platforms are a
- * no-op and never throw.
- *
- * Ordering constraint: [java.awt.Taskbar.getTaskbar] initializes the AWT toolkit, so this must run
- * only after `apple.awt.application.name` has been set.
- */
-private fun setDockIcon() {
-  if (!java.awt.Taskbar.isTaskbarSupported()) return
-  val taskbar = java.awt.Taskbar.getTaskbar()
-  if (!taskbar.isSupported(java.awt.Taskbar.Feature.ICON_IMAGE)) return
-  val stream = Main::class.java.getResourceAsStream("/icons/app-icon.png") ?: return
-  val image = stream.use { javax.imageio.ImageIO.read(it) } ?: return
-  try {
-    taskbar.iconImage = image
-  } catch (e: UnsupportedOperationException) {
-    // Some platforms report ICON_IMAGE support but still throw here; ignore but leave a trace.
-    LOG.warn("Setting the Dock icon is unsupported on this platform", e)
-  }
-}
-
-/** Marker class used to resolve bundled resources from the classpath. */
-private class Main
 
 fun main() {
   // Must run before any AWT toolkit initialization so the app name is picked up.

--- a/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/Main.kt
+++ b/android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/Main.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
 import dev.jasonpearson.automobile.desktop.core.daemon.McpConnectionException
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import dev.jasonpearson.automobile.desktop.core.shell.MenuBarActions
 import dev.jasonpearson.automobile.desktop.core.workspace.isCommandPaletteShortcut
 import dev.jasonpearson.automobile.desktop.di.AutoMobileGraph
@@ -68,7 +69,37 @@ private fun acquireSingleInstanceLock(): Boolean {
   }
 }
 
+/** Logger for main-entrypoint diagnostics (Dock icon setup, etc.). */
+private val LOG = LoggerFactory.getLogger("Main")
+
+/**
+ * Sets the macOS Dock icon from the bundled PNG. Guarded so non-macOS / unsupported platforms are a
+ * no-op and never throw.
+ *
+ * Ordering constraint: [java.awt.Taskbar.getTaskbar] initializes the AWT toolkit, so this must run
+ * only after `apple.awt.application.name` has been set.
+ */
+private fun setDockIcon() {
+  if (!java.awt.Taskbar.isTaskbarSupported()) return
+  val taskbar = java.awt.Taskbar.getTaskbar()
+  if (!taskbar.isSupported(java.awt.Taskbar.Feature.ICON_IMAGE)) return
+  val stream = Main::class.java.getResourceAsStream("/icons/app-icon.png") ?: return
+  val image = stream.use { javax.imageio.ImageIO.read(it) } ?: return
+  try {
+    taskbar.iconImage = image
+  } catch (e: UnsupportedOperationException) {
+    // Some platforms report ICON_IMAGE support but still throw here; ignore but leave a trace.
+    LOG.warn("Setting the Dock icon is unsupported on this platform", e)
+  }
+}
+
+/** Marker class used to resolve bundled resources from the classpath. */
+private class Main
+
 fun main() {
+  // Must run before any AWT toolkit initialization so the app name is picked up.
+  System.setProperty("apple.awt.application.name", "AutoMobile")
+
   if (!acquireSingleInstanceLock()) {
     System.err.println("AutoMobile Desktop is already running. Exiting.")
     return
@@ -85,6 +116,10 @@ fun main() {
     System.setProperty("apple.awt.fullWindowContent", "true")
     System.setProperty("apple.awt.transparentTitleBar", "true")
   }
+
+  // Set the macOS Dock icon. Runs after apple.awt.application.name is set above, since
+  // Taskbar.getTaskbar() initializes the AWT toolkit.
+  setDockIcon()
 
   application {
     var isWindowVisible by remember { mutableStateOf(true) }

--- a/android/desktop-app/src/test/kotlin/dev/jasonpearson/automobile/desktop/DockIconTest.kt
+++ b/android/desktop-app/src/test/kotlin/dev/jasonpearson/automobile/desktop/DockIconTest.kt
@@ -38,21 +38,39 @@ class DockIconTest {
   private fun oneByOneImage() = BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB)
 
   @Test
-  fun `unsupported installer never consults the loader and installs nothing`() {
-    val installer = FakeDockIconInstaller(isSupported = false)
+  fun `packaged run is a no-op even when supported`() {
+    val installer = FakeDockIconInstaller(isSupported = true)
 
-    setDockIcon(installer) { fail("image loader must not be consulted when unsupported") }
+    setDockIcon(
+      installer = installer,
+      imageLoader = { fail("image loader must not be consulted when packaged") },
+      isPackaged = true,
+    )
 
     assertEquals(0, installer.installCount)
     assertNull(installer.installedImage)
   }
 
   @Test
-  fun `supported installer receives the exact loaded image`() {
+  fun `unsupported installer never consults the loader and installs nothing`() {
+    val installer = FakeDockIconInstaller(isSupported = false)
+
+    setDockIcon(
+      installer = installer,
+      imageLoader = { fail("image loader must not be consulted when unsupported") },
+      isPackaged = false,
+    )
+
+    assertEquals(0, installer.installCount)
+    assertNull(installer.installedImage)
+  }
+
+  @Test
+  fun `supported dev run installs the exact loaded image`() {
     val installer = FakeDockIconInstaller(isSupported = true)
     val expected = oneByOneImage()
 
-    setDockIcon(installer) { expected }
+    setDockIcon(installer = installer, imageLoader = { expected }, isPackaged = false)
 
     assertEquals(1, installer.installCount)
     assertSame(expected, installer.installedImage)
@@ -62,7 +80,7 @@ class DockIconTest {
   fun `missing resource installs nothing and does not throw`() {
     val installer = FakeDockIconInstaller(isSupported = true)
 
-    setDockIcon(installer) { null }
+    setDockIcon(installer = installer, imageLoader = { null }, isPackaged = false)
 
     assertEquals(0, installer.installCount)
     assertNull(installer.installedImage)
@@ -73,7 +91,7 @@ class DockIconTest {
     val installer = FakeDockIconInstaller(isSupported = true, throwOnInstall = true)
 
     // Must return normally despite install() throwing.
-    setDockIcon(installer) { oneByOneImage() }
+    setDockIcon(installer = installer, imageLoader = { oneByOneImage() }, isPackaged = false)
 
     assertEquals(1, installer.installCount)
     assertNull(installer.installedImage)

--- a/android/desktop-app/src/test/kotlin/dev/jasonpearson/automobile/desktop/DockIconTest.kt
+++ b/android/desktop-app/src/test/kotlin/dev/jasonpearson/automobile/desktop/DockIconTest.kt
@@ -1,0 +1,94 @@
+package dev.jasonpearson.automobile.desktop
+
+import java.awt.image.BufferedImage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.fail
+
+/**
+ * Covers [setDockIcon] and [loadBundledImage] off-Mac by injecting a fake for the unfakeable
+ * [java.awt.Taskbar] platform boundary. All cases are headless-safe and finish well under 100ms.
+ */
+class DockIconTest {
+
+  /**
+   * Records what [setDockIcon] installs; [throwOnInstall] simulates a platform that lies about
+   * support.
+   */
+  private class FakeDockIconInstaller(
+    override val isSupported: Boolean,
+    private val throwOnInstall: Boolean = false,
+  ) : DockIconInstaller {
+    var installedImage: BufferedImage? = null
+      private set
+
+    var installCount = 0
+      private set
+
+    override fun install(image: BufferedImage) {
+      installCount++
+      if (throwOnInstall) throw UnsupportedOperationException("simulated unsupported platform")
+      installedImage = image
+    }
+  }
+
+  private fun oneByOneImage() = BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB)
+
+  @Test
+  fun `unsupported installer never consults the loader and installs nothing`() {
+    val installer = FakeDockIconInstaller(isSupported = false)
+
+    setDockIcon(installer) { fail("image loader must not be consulted when unsupported") }
+
+    assertEquals(0, installer.installCount)
+    assertNull(installer.installedImage)
+  }
+
+  @Test
+  fun `supported installer receives the exact loaded image`() {
+    val installer = FakeDockIconInstaller(isSupported = true)
+    val expected = oneByOneImage()
+
+    setDockIcon(installer) { expected }
+
+    assertEquals(1, installer.installCount)
+    assertSame(expected, installer.installedImage)
+  }
+
+  @Test
+  fun `missing resource installs nothing and does not throw`() {
+    val installer = FakeDockIconInstaller(isSupported = true)
+
+    setDockIcon(installer) { null }
+
+    assertEquals(0, installer.installCount)
+    assertNull(installer.installedImage)
+  }
+
+  @Test
+  fun `install throwing UnsupportedOperationException is caught, not propagated`() {
+    val installer = FakeDockIconInstaller(isSupported = true, throwOnInstall = true)
+
+    // Must return normally despite install() throwing.
+    setDockIcon(installer) { oneByOneImage() }
+
+    assertEquals(1, installer.installCount)
+    assertNull(installer.installedImage)
+  }
+
+  @Test
+  fun `bundled dock icon resource is present and decodable on the classpath`() {
+    assertNotNull(
+      loadBundledImage("/icons/app-icon.png"),
+      "the branded dock icon must be bundled on the runtime classpath",
+    )
+  }
+
+  @Test
+  fun `absent resource loads as null`() {
+    assertNull(loadBundledImage("/icons/does-not-exist.png"))
+  }
+}


### PR DESCRIPTION
## Summary

Wires the branded desktop icon assets (committed in [#4855](https://github.com/kaeawc/auto-mobile/pull/4855)) into both the packaged installers and the dev-run experience. Before this change `iconFile` was never set, so jpackage fell back to its default icon — the installed app showed the generic Java "coffee cup" in the Dock and attributed its notification prompt to "java". A bare-JVM dev run (`./gradlew :desktop-app:run`) had the same problem because `Main.kt` never set the Dock icon or application name.

Closes [#4920](https://github.com/kaeawc/auto-mobile/issues/4920).

## Changes

- **`android/desktop-app/build.gradle.kts`** — In `nativeDistributions`:
  - Removed the now-stale comment claiming the committed assets are "1×1 placeholder stubs". They are real today: `app-icon.icns` (real `icns` container, 1024×1024), `app-icon.ico` (6 images up to 256×256, 32bpp), `app-icon.png` (512×512).
  - `macOS { iconFile.set(app-icon.icns) }`, `windows { iconFile.set(app-icon.ico) }`, and a new `linux { iconFile.set(app-icon.png) }` block (Deb is already in `targetFormats`).
- **`android/desktop-app/src/main/kotlin/dev/jasonpearson/automobile/desktop/Main.kt`**
  - Sets `apple.awt.application.name = "AutoMobile"` as the very first statement of `main()`, before the single-instance lock and any AWT touch, so it is picked up before the AWT toolkit initializes.
  - Adds a private `setDockIcon()` helper that loads `/icons/app-icon.png` and sets the macOS Dock icon via `Taskbar`, guarded by `isTaskbarSupported()` + `isSupported(Feature.ICON_IMAGE)` so non-macOS / unsupported platforms are a no-op. The `iconImage` set is wrapped in a `try/catch (UnsupportedOperationException)` (some platforms report support then throw) that logs at `warn` via the desktop `LoggerFactory` rather than swallowing silently. No `!!` introduced.
  - Calls `setDockIcon()` immediately before `application { }`, i.e. after the app-name property is set (since `Taskbar.getTaskbar()` initializes the AWT toolkit).

## Testing

Run with `JAVA_HOME=azul-21.0.9` from `android/`:

- `./gradlew :desktop-core:detektMain :desktop-app:compileKotlin :desktop-app:test :desktop-core:test` → BUILD SUCCESSFUL
- `./gradlew :desktop-app:detektMain` → BUILD SUCCESSFUL (confirms the `!!` ban and other rules on the touched `Main.kt`)
- `./gradlew :desktop-app:createDistributable` → BUILD SUCCESSFUL
- Touched `.kt` formatted with the pinned `ktfmt-0.64-with-dependencies.jar --google-style`.

## Acceptance criteria

1. ✅ `nativeDistributions` wires the real assets for macOS/Windows/Linux; stale "placeholder stub" comment removed.
2. ✅ `createDistributable` produces `AutoMobile.app` with a branded icon:
   ```
   $ ls AutoMobile.app/Contents/Resources/
   AutoMobile.icns          # 2801763 bytes — identical to source app-icon.icns

   $ grep -A1 CFBundleIconFile AutoMobile.app/Contents/Info.plist
       <key>CFBundleIconFile</key>
       <string>AutoMobile.icns</string>
   ```
3. ✅ `Main.kt` sets `apple.awt.application.name` before AWT init and sets the Dock icon via `Taskbar`, guarded by `isTaskbarSupported()` + `isSupported(Feature.ICON_IMAGE)`.
4. ✅ `:desktop-app:compileKotlin` and the desktop test suites stay green.

## Known limitation

For a **packaged** `.app`, notification identity comes from the bundle (`bundleID` + `CFBundleName` + the now-wired icon), so notifications are branded there. For a pure **dev-run** (`./gradlew run`, no bundle), notification attribution may still fall back to "java" — inherent to running unbundled; the Dock icon and menu-bar name are still fixed by `Taskbar.setIconImage` + `apple.awt.application.name`.
