### PR TITLE
Harden filesystem permissions on ~/.auto-mobile, sockets, and video recordings (0o700/0o600)

### DIFF
--- a/src/daemon/socketServer.ts
+++ b/src/daemon/socketServer.ts
@@ -2,6 +2,8 @@ import { createServer, Server as NetServer, Socket } from "node:net";
 import { randomUUID } from "node:crypto";
 import { unlink } from "node:fs/promises";
 import { existsSync, statSync } from "node:fs";
+import path from "node:path";
+import { ensureSecureDir, secureFile } from "../utils/filesystem/securePermissions";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {
   StreamableHTTPClientTransport,
@@ -289,6 +291,12 @@ export class UnixSocketServer {
    * Start the Unix socket server
    */
   async start(): Promise<void> {
+    // Owner-only (0o700) socket directory so the control socket is not
+    // world-traversable. On macOS socket-file permission bits are not reliably
+    // enforced on connect(), so the containing directory's mode is the primary
+    // access control (issue #4750).
+    await ensureSecureDir(path.dirname(this.socketPath));
+
     // Remove existing socket file if it exists
     if (existsSync(this.socketPath)) {
       await unlink(this.socketPath);
@@ -319,7 +327,12 @@ export class UnixSocketServer {
       this.server!.listen(this.socketPath, () => {
         this.socketFileIdentity = this.readSocketFileIdentity();
         logger.info(`Unix socket server listening on ${this.socketPath}`);
-        resolve();
+        // Restrict the bound socket to the owner (0o600) before start() resolves,
+        // so no client can connect while it is still world-accessible. listen()
+        // creates the socket at the umask default (issue #4750).
+        secureFile(this.socketPath)
+          .then(resolve)
+          .catch(reject);
       });
 
       this.server!.on("error", error => {

--- a/src/daemon/socketServer/BaseSocketServer.ts
+++ b/src/daemon/socketServer/BaseSocketServer.ts
@@ -1,9 +1,10 @@
 import { createServer, Server as NetServer, Socket } from "node:net";
 import { existsSync, statSync } from "node:fs";
-import { unlink, mkdir } from "node:fs/promises";
+import { unlink } from "node:fs/promises";
 import path from "node:path";
 import { logger } from "../../utils/logger";
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
+import { ensureSecureDir, secureFile } from "../../utils/filesystem/securePermissions";
 import { DEFAULT_SOCKET_IDLE_TIMEOUT_MS } from "./SocketServerTypes";
 
 /**
@@ -37,9 +38,10 @@ export abstract class BaseSocketServer {
    */
   async start(): Promise<void> {
     const directory = path.dirname(this.socketPath);
-    if (!existsSync(directory)) {
-      await mkdir(directory, { recursive: true });
-    }
+    // Owner-only (0o700) so the control socket is not world-traversable. On macOS
+    // socket-file permission bits are not reliably enforced on connect(), so the
+    // containing directory's mode is the primary access control (issue #4750).
+    await ensureSecureDir(directory);
 
     if (existsSync(this.socketPath)) {
       await unlink(this.socketPath);
@@ -53,8 +55,15 @@ export abstract class BaseSocketServer {
       this.server!.listen(this.socketPath, () => {
         logger.info(`[${this.serverName}] Socket listening on ${this.socketPath}`);
         this.socketFileIdentity = this.readSocketFileIdentity();
-        this.onServerStarted();
-        resolve();
+        // Restrict the bound socket to the owner (0o600) before start() resolves,
+        // so no client can connect while it is still world-accessible. listen()
+        // creates the socket at the umask default (issue #4750).
+        secureFile(this.socketPath)
+          .then(() => {
+            this.onServerStarted();
+            resolve();
+          })
+          .catch(reject);
       });
 
       this.server!.on("error", error => {

--- a/src/features/video/VideoRecorderService.ts
+++ b/src/features/video/VideoRecorderService.ts
@@ -12,6 +12,10 @@ import type {
 } from "../../models";
 import { logger, type Logger } from "../../utils/logger";
 import { defaultIdGenerator, type IdGenerator } from "../../utils/IdGenerator";
+import {
+  defaultSecurePermissions,
+  type SecurePermissions,
+} from "../../utils/filesystem/securePermissions";
 
 export interface VideoCaptureConfig extends VideoRecordingConfig {
   recordingId: string;
@@ -67,6 +71,7 @@ export interface VideoRecorderServiceDependencies {
   logger?: Pick<Logger, "info" | "warn" | "error" | "debug">;
   idGenerator?: IdGenerator | (() => string);
   now?: () => Date;
+  securePermissions?: SecurePermissions;
 }
 
 interface ActiveRecordingState extends ActiveVideoRecording {
@@ -133,6 +138,7 @@ export class VideoRecorderService {
   private log: Pick<Logger, "info" | "warn" | "error" | "debug">;
   private idGenerator: IdGenerator;
   private now: () => Date;
+  private securePermissions: SecurePermissions;
   private activeRecordings = new Map<string, ActiveRecordingState>();
 
   constructor(dependencies: VideoRecorderServiceDependencies) {
@@ -143,6 +149,7 @@ export class VideoRecorderService {
     this.log = dependencies.logger ?? logger;
     this.idGenerator = normalizeIdGenerator(dependencies.idGenerator);
     this.now = dependencies.now ?? (() => new Date());
+    this.securePermissions = dependencies.securePermissions ?? defaultSecurePermissions;
   }
 
   async startRecording(
@@ -159,7 +166,9 @@ export class VideoRecorderService {
     const nameSlug = label ? `${label}-${recordingId}` : recordingId;
     const recordingDir = this.getRecordingDir(nameSlug);
 
-    await fsPromises.mkdir(recordingDir, { recursive: true });
+    // Owner-only (0o700): recordings routinely contain OTPs, credentials, and PII,
+    // so the per-recording directory must not be world-traversable (issue #4750).
+    await this.securePermissions.ensureSecureDir(recordingDir);
 
     const fileName = buildRecordingFileName(nameSlug, startedAt, config.format);
     const outputPath = path.join(recordingDir, fileName);
@@ -210,6 +219,11 @@ export class VideoRecorderService {
     const endedAt = stopResult.endedAt ?? this.now().toISOString();
     const outputPath = stopResult.outputPath || active.outputPath;
     const fileName = path.basename(outputPath);
+
+    // Restrict the finalized recording to the owner (0o600). The backend writes
+    // it via `adb pull` / `simctl recordVideo` / ffmpeg at the default
+    // world-readable mode; tighten it now that capture is complete (issue #4750).
+    await this.securePermissions.secureFile(outputPath);
     const fileStats = await this.safeStat(outputPath);
     const sizeBytes = stopResult.sizeBytes ?? fileStats?.size ?? 0;
 

--- a/src/utils/filesystem/securePermissions.ts
+++ b/src/utils/filesystem/securePermissions.ts
@@ -1,0 +1,90 @@
+import { promises as fsPromises } from "node:fs";
+import os from "node:os";
+import { logger } from "../logger";
+
+/**
+ * Shared owner-only filesystem permission helpers.
+ *
+ * AutoMobile writes sensitive material to `~/.auto-mobile` — Unix control
+ * sockets and screen recordings that routinely contain OTPs, credentials, and
+ * PII. Left at the default umask (`0o755` dirs / `0o644` files) these are
+ * world-readable and, for sockets on macOS, potentially `connect()`-able by any
+ * local user (issue #4750). These helpers centralize the `0o700`/`0o600`
+ * convention already used ad hoc across the repo (`tempDir.ts`,
+ * `DefaultFileSystem.ts`, `daemon.ts`, `ScreenCaptureHelperProvider.ts`) so the
+ * capture paths get the same restrictive modes.
+ *
+ * Cross-platform: Windows has no POSIX mode bits — `fs.chmod` there only toggles
+ * the read-only attribute — so the chmod syscalls are skipped on `win32` to
+ * avoid clobbering writability. Access control on Windows is handled by ACLs,
+ * outside the scope of these bits.
+ */
+
+/** Owner-only directory permissions (`rwx------`). */
+export const SECURE_DIR_MODE = 0o700;
+
+/** Owner-only file permissions (`rw-------`). */
+export const SECURE_FILE_MODE = 0o600;
+
+const isWindows = (): boolean => os.platform() === "win32";
+
+/**
+ * Seam over the owner-only permission operations, so callers can inject a spy in
+ * tests and assert the intended modes deterministically on any host OS.
+ */
+export interface SecurePermissions {
+  /** Create `dirPath` (recursively) with owner-only (`0o700`) permissions. */
+  ensureSecureDir(dirPath: string): Promise<void>;
+  /** Restrict an existing file to owner-only (`0o600`) permissions. */
+  secureFile(filePath: string): Promise<void>;
+}
+
+/**
+ * Create a directory tree with owner-only permissions.
+ *
+ * `mkdir`'s `mode` is masked by the process umask and is ignored entirely for a
+ * pre-existing directory, so on POSIX an explicit `chmod` follows to guarantee
+ * `0o700` regardless of umask or prior state. Best-effort: a chmod failure is
+ * logged but never aborts the caller's primary operation.
+ */
+export async function ensureSecureDir(dirPath: string): Promise<void> {
+  await fsPromises.mkdir(dirPath, { recursive: true, mode: SECURE_DIR_MODE });
+  if (isWindows()) {
+    return;
+  }
+  try {
+    await fsPromises.chmod(dirPath, SECURE_DIR_MODE);
+  } catch (error) {
+    // A directory we just created should always be chmod-able; if it is not
+    // (e.g. a race with removal), the looser mode is a hardening gap, not a
+    // functional failure — log and continue.
+    logger.warn(`Failed to set 0o700 on directory ${dirPath}: ${normalize(error)}`, error);
+  }
+}
+
+/**
+ * Restrict an existing file to owner-only permissions.
+ *
+ * Best-effort: a finalized recording or a bound socket is already on disk, and a
+ * chmod failure (missing file, unusual filesystem) must not fail the surrounding
+ * capture/serve flow — it is logged so the hardening gap is traceable.
+ */
+export async function secureFile(filePath: string): Promise<void> {
+  if (isWindows()) {
+    return;
+  }
+  try {
+    await fsPromises.chmod(filePath, SECURE_FILE_MODE);
+  } catch (error) {
+    logger.warn(`Failed to set 0o600 on file ${filePath}: ${normalize(error)}`, error);
+  }
+}
+
+const normalize = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+/** Default implementation backed by the real filesystem. */
+export const defaultSecurePermissions: SecurePermissions = {
+  ensureSecureDir,
+  secureFile,
+};

--- a/test/daemon/socketServerPermissions.test.ts
+++ b/test/daemon/socketServerPermissions.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, statSync } from "node:fs";
+import { mkdtemp, rm, unlink } from "node:fs/promises";
+import { platform, tmpdir } from "node:os";
+import { join } from "node:path";
+import { UnixSocketServer } from "../../src/daemon/socketServer";
+import { FakeTimer } from "../fakes/FakeTimer";
+
+const isWindows = platform() === "win32";
+
+function createFakeDaemonState() {
+  return {
+    isInitialized: () => true,
+    getSessionManager: () => ({ getSession: () => null, releaseSession: async () => null }),
+    getDevicePool: () => ({
+      refreshDevices: async () => 0,
+      getStats: () => ({ total: 0, idle: 0, assigned: 0, error: 0 }),
+      releaseDevice: async () => {},
+    }),
+  };
+}
+
+// Real POSIX mode bits are not enforced on Windows, so these assertions are
+// POSIX-only. The hardening still runs on Windows (chmod is skipped there).
+describe("UnixSocketServer filesystem permissions (issue #4750)", () => {
+  let socketDir: string;
+  let socketPath: string;
+  let server: UnixSocketServer;
+
+  beforeEach(async () => {
+    // Keep the total path short: macOS caps Unix socket paths at ~104 chars.
+    socketDir = await mkdtemp(join(tmpdir(), "sp-"));
+    socketPath = join(socketDir, "n", "s.sock");
+    server = new UnixSocketServer(
+      socketPath,
+      "http://localhost:0/mcp",
+      createFakeDaemonState(),
+      new FakeTimer(),
+    );
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.close();
+    if (existsSync(socketPath)) {
+      await unlink(socketPath);
+    }
+    await rm(socketDir, { recursive: true, force: true });
+  });
+
+  (isWindows ? test.skip : test)("creates the socket directory with 0o700", () => {
+    const dir = join(socketDir, "n");
+    expect(statSync(dir).mode & 0o777).toBe(0o700);
+  });
+
+  (isWindows ? test.skip : test)("restricts the bound socket file to 0o600", () => {
+    expect(statSync(socketPath).mode & 0o777).toBe(0o600);
+  });
+});

--- a/test/fakes/FakeSecurePermissions.ts
+++ b/test/fakes/FakeSecurePermissions.ts
@@ -1,0 +1,28 @@
+import { promises as fsPromises } from "node:fs";
+import type { SecurePermissions } from "../../src/utils/filesystem/securePermissions";
+
+/**
+ * Spy implementation of {@link SecurePermissions} for deterministic assertions on
+ * any host OS (including windows-latest, where real POSIX mode bits are absent).
+ *
+ * By default it still creates directories on disk (so callers that immediately
+ * write into them keep working) but records every call so tests can assert that
+ * the owner-only hardening was requested for the right paths.
+ */
+export class FakeSecurePermissions implements SecurePermissions {
+  readonly ensureSecureDirCalls: string[] = [];
+  readonly secureFileCalls: string[] = [];
+
+  constructor(private readonly createDirsOnDisk: boolean = true) {}
+
+  async ensureSecureDir(dirPath: string): Promise<void> {
+    this.ensureSecureDirCalls.push(dirPath);
+    if (this.createDirsOnDisk) {
+      await fsPromises.mkdir(dirPath, { recursive: true });
+    }
+  }
+
+  async secureFile(filePath: string): Promise<void> {
+    this.secureFileCalls.push(filePath);
+  }
+}

--- a/test/features/video/VideoRecorderService.test.ts
+++ b/test/features/video/VideoRecorderService.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../src/features/video/VideoRecorderService";
 import { CountingIdGenerator } from "../../../src/utils/IdGenerator";
 import { FakeVideoCaptureBackend } from "../../fakes/FakeVideoCaptureBackend";
+import { FakeSecurePermissions } from "../../fakes/FakeSecurePermissions";
 
 describe("parseVideoRecordingConfig", () => {
   test("returns defaults for null input", () => {
@@ -107,16 +108,19 @@ describe("VideoRecorderService", () => {
   let backend: FakeVideoCaptureBackend;
   let service: VideoRecorderService;
   let archiveRoot: string;
+  let securePermissions: FakeSecurePermissions;
 
   beforeEach(async () => {
     backend = new FakeVideoCaptureBackend();
-    archiveRoot = path.join(os.tmpdir(), `video-test-${Date.now()}`);
+    archiveRoot = path.join(os.tmpdir(), `video-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    securePermissions = new FakeSecurePermissions();
 
     service = new VideoRecorderService({
       backend,
       archiveRoot,
       idGenerator: new CountingIdGenerator("rec"),
       now: () => new Date("2024-01-15T10:30:00.000Z"),
+      securePermissions,
     });
   });
 
@@ -174,6 +178,14 @@ describe("VideoRecorderService", () => {
       expect(r1.recordingId).toBe("rec-1");
       expect(r2.recordingId).toBe("rec-2");
     });
+
+    test("creates the per-recording directory with owner-only (0o700) permissions", async () => {
+      const result = await service.startRecording({ outputName: "case A" });
+      const recordingDir = path.dirname(result.outputPath);
+      // Hardening is requested through the injected seam, so the assertion holds
+      // on any host OS regardless of POSIX mode-bit support (issue #4750).
+      expect(securePermissions.ensureSecureDirCalls).toContain(recordingDir);
+    });
   });
 
   describe("stopRecording", () => {
@@ -228,6 +240,15 @@ describe("VideoRecorderService", () => {
 
       expect(backend.stopCalls).toHaveLength(1);
       expect(backend.stopCalls[0].recordingId).toBe("rec-1");
+    });
+
+    test("restricts the finalized recording file to owner-only (0o600)", async () => {
+      const recording = await service.startRecording();
+      const metadata = await service.stopRecording(recording.recordingId);
+
+      // The finalized MP4 (written by adb pull / simctl / ffmpeg at the default
+      // world-readable mode) must be chmod'd through the seam (issue #4750).
+      expect(securePermissions.secureFileCalls).toContain(metadata.filePath);
     });
   });
 });

--- a/test/utils/filesystem/securePermissions.test.ts
+++ b/test/utils/filesystem/securePermissions.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { promises as fsPromises, statSync } from "node:fs";
+import { platform, tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import {
+  SECURE_DIR_MODE,
+  SECURE_FILE_MODE,
+  ensureSecureDir,
+  secureFile,
+  defaultSecurePermissions,
+} from "../../../src/utils/filesystem/securePermissions";
+
+const isWindows = platform() === "win32";
+const created: string[] = [];
+
+function tempPath(prefix: string): string {
+  const p = join(tmpdir(), `${prefix}-${randomUUID()}`);
+  created.push(p);
+  return p;
+}
+
+afterEach(async () => {
+  for (const p of created.splice(0)) {
+    await fsPromises.rm(p, { recursive: true, force: true }).catch(() => undefined);
+  }
+});
+
+describe("securePermissions", () => {
+  test("exposes the owner-only mode constants", () => {
+    expect(SECURE_DIR_MODE).toBe(0o700);
+    expect(SECURE_FILE_MODE).toBe(0o600);
+  });
+
+  test("defaultSecurePermissions is backed by the real helpers", () => {
+    expect(defaultSecurePermissions.ensureSecureDir).toBe(ensureSecureDir);
+    expect(defaultSecurePermissions.secureFile).toBe(secureFile);
+  });
+
+  test("ensureSecureDir creates a directory recursively", async () => {
+    const dir = tempPath("secure-dir");
+    const nested = join(dir, "a", "b");
+
+    await ensureSecureDir(nested);
+
+    expect(statSync(nested).isDirectory()).toBe(true);
+  });
+
+  (isWindows ? test.skip : test)("ensureSecureDir sets 0o700 on the directory", async () => {
+    const dir = tempPath("secure-dir-mode");
+
+    await ensureSecureDir(dir);
+
+    expect(statSync(dir).mode & 0o777).toBe(0o700);
+  });
+
+  (isWindows ? test.skip : test)("ensureSecureDir repairs a pre-existing loose directory", async () => {
+    const dir = tempPath("secure-dir-repair");
+    await fsPromises.mkdir(dir, { recursive: true, mode: 0o755 });
+
+    await ensureSecureDir(dir);
+
+    expect(statSync(dir).mode & 0o777).toBe(0o700);
+  });
+
+  (isWindows ? test.skip : test)("secureFile sets 0o600 on the file", async () => {
+    const dir = tempPath("secure-file");
+    await fsPromises.mkdir(dir, { recursive: true });
+    const file = join(dir, "recording.mp4");
+    await fsPromises.writeFile(file, "data", { mode: 0o644 });
+
+    await secureFile(file);
+
+    expect(statSync(file).mode & 0o777).toBe(0o600);
+  });
+
+  test("secureFile swallows a missing-file error (best-effort)", async () => {
+    const missing = join(tempPath("secure-missing"), "nope.mp4");
+
+    await expect(secureFile(missing)).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Closes [#4750](https://github.com/kaeawc/auto-mobile/issues/4750).

`~/.auto-mobile`, the daemon's Unix control sockets, and finalized video recordings were all created at the default umask (`0o755` dirs / `0o644` files). On a multi-user host that makes screen recordings — which routinely contain OTPs, credentials, and PII — world-readable, and on macOS widens the socket attack surface (socket-file permission bits are not reliably enforced on `connect()`, so the containing directory's mode is the real access control).

This PR applies the owner-only `0o700`/`0o600` convention that already exists ad hoc elsewhere in the repo (`tempDir.ts`, `DefaultFileSystem.ts`, `daemon.ts` PID file, `ScreenCaptureHelperProvider.ts`) to the capture and socket paths.

## What changed

- **New shared helper** `src/utils/filesystem/securePermissions.ts` — consolidates the `0o700`/`0o600` constants plus a small `SecurePermissions` seam (`ensureSecureDir` / `secureFile`) so callers can inject a spy and assert the intended modes deterministically on any host OS. `ensureSecureDir` follows `mkdir` with an explicit `chmod` so it also repairs a pre-existing loose directory (umask masks `mkdir`'s mode and it is ignored for existing dirs). Both operations are best-effort (logged, never abort the primary flow).
- **Both socket servers** — the legacy `UnixSocketServer` (`src/daemon/socketServer.ts`, the one the daemon actually runs) and `BaseSocketServer` (`src/daemon/socketServer/BaseSocketServer.ts`) now create the socket directory with `0o700` and `chmod` the bound socket to `0o600` **before `start()` resolves**, so no client can connect while it is still world-accessible.
- **`VideoRecorderService`** — creates each per-recording directory with `0o700` (injected seam) and `chmod`s the finalized MP4 to `0o600` in `stopRecording()`, immediately after the backend (`adb pull` / `simctl recordVideo` / ffmpeg) materializes it. This is the single DRY consumer of both the Platform (Android) and Ffmpeg (Android + iOS) backends, so one chmod site covers every finalize path.

## Verify-real findings (against current main)

The issue's line numbers had drifted; confirmed the real state before implementing:

- `BaseSocketServer.ts` created the socket dir via `mkdir(dir, { recursive: true })` with **no mode** — but it is not the only socket server. The production daemon uses the **legacy `UnixSocketServer` in `src/daemon/socketServer.ts`**, which did not create the directory at all and listened at the default mode. Both are now hardened.
- `VideoRecorderService.ts` created the per-recording dir with `mkdir(recordingDir, { recursive: true })` and no mode — confirmed.
- `PlatformVideoCaptureBackend.ts` — #4773 removed the dead iOS branch; it now handles Android only (finalizes via `adb pull`), and rejects iOS explicitly. iOS goes through `FfmpegVideoProcessingBackend` (`simctl recordVideo` → ffmpeg). Both write to `handle.outputPath`, whose owner is `VideoRecorderService.stopRecording()` — the chosen single chmod site.
- Confirmed **zero** pre-existing `chmod` / `mode:` / `umask` on any of these three paths, matching the issue's grep.

## Cross-platform handling

- `chmod` is skipped on `win32` (no POSIX mode bits; `fs.chmod` there only toggles the read-only attribute, so calling it could clobber writability). ACL-based access control on Windows is out of scope.
- The real-filesystem mode assertions (socket + helper tests) are `test.skip`'d on Windows, matching the existing `socketServerClose.test.ts` convention. The seam-based `VideoRecorderService` assertions run on every OS.

## Validation

- `bun run typecheck` — no new type errors (196 known baseline).
- `turbo run lint build test` — 3/3 tasks successful; **12374 pass, 0 fail, 13 skip** (device-integration only).
- New tests: `securePermissions.test.ts` (helper modes + best-effort), `socketServerPermissions.test.ts` (dir `0o700` + socket `0o600`), and added `VideoRecorderService` cases asserting the dir/file hardening via the injected seam.
