### PR TITLE
fix(daemon): authenticate + session-scope the stream sockets and harden WHIP policy (#4751)

### DIFF
--- a/docs/using/environment-variables.md
+++ b/docs/using/environment-variables.md
@@ -127,7 +127,7 @@ overridden per request on the `webrtc-stream.sock` control socket.
 
 | Variable | Purpose | Default |
 |----------|---------|---------|
-| `AUTOMOBILE_WEBRTC_WHIP_ENDPOINT` | WHIP ingest URL. For MediaMTX use a per-stream path, e.g. `http://host:8889/<stream>/whip` (the stock config is plain HTTP; enable `webrtcEncryption` for `https://`). Required to start a stream unless passed per request. | unset |
+| `AUTOMOBILE_WEBRTC_WHIP_ENDPOINT` | WHIP ingest URL. For MediaMTX use a per-stream path, e.g. `https://host:8889/<stream>/whip`. **Policy (issue #4751):** `https:` is required; plaintext `http:` is permitted **only** for loopback hosts (`127.0.0.0/8`, `localhost`, `::1`) because the bearer token and SDP would otherwise travel in cleartext. Set `AUTOMOBILE_WEBRTC_ALLOW_INSECURE_WHIP=1` to re-permit non-loopback `http:`. Required to start a stream unless passed per request. | unset |
 | `AUTOMOBILE_WEBRTC_WHIP_TOKEN` | Bearer token sent as `Authorization: Bearer <token>` on WHIP ingest. | unset |
 | `AUTOMOBILE_WEBRTC_ICE_SERVERS` | Comma-separated STUN/TURN URLs, or a JSON array of `{urls,username,credential}`. | `stun:stun.l.google.com:19302` |
 | `AUTOMOBILE_WEBRTC_BITRATE_KBPS` | Target encoder bitrate (kbps). | encoder default |
@@ -141,6 +141,9 @@ overridden per request on the `webrtc-stream.sock` control socket.
 | `AUTOMOBILE_IOS_WEBRTC_FFMPEG` | Path to the `ffmpeg` binary used to encode iOS helper BGRA frames into H.264 Annex-B. | `ffmpeg` on `PATH` |
 | `AUTOMOBILE_WEBRTC_TRICKLE_ICE` | Enable trickle ICE: publish the WHIP offer immediately and PATCH candidates incrementally instead of blocking on ICE gathering. Requires an ingest server supporting the WHIP trickle extension. | `false` |
 | `AUTOMOBILE_WEBRTC_AUDIO` | Enable optional audio alongside video. Android requires the persistent `video-server` jar and captures shell-privileged `REMOTE_SUBMIX`; iOS supports Simulator-window audio through ScreenCaptureKit. Both emit 8 kHz mono PCM16LE and publish as PCMU. Physical iOS playback capture is unavailable through public APIs. | `false` |
+| `AUTOMOBILE_WEBRTC_WHIP_ALLOWED_ORIGINS` | Comma-separated allow-list of origins (or bare `host[:port]`) that a `whipEndpoint` supplied **over the wire** to the `webrtc-stream` socket may target (issue #4751). Loopback and the daemon's own `AUTOMOBILE_WEBRTC_WHIP_ENDPOINT` origin are always trusted. An override to any other origin is rejected so a local process cannot exfiltrate the screen to a destination of its choosing. | unset (only the configured endpoint + loopback allowed) |
+| `AUTOMOBILE_WEBRTC_ALLOW_INSECURE_WHIP` | **Escape hatch (issue #4751).** When `1`/`true`, re-permits non-loopback plaintext `http:` WHIP endpoints **and** accepts an arbitrary (non allow-listed) `whipEndpoint` override from the wire. For advanced setups only — the bearer token and SDP travel in cleartext over `http:`. | `false` |
+| `AUTOMOBILE_DAEMON_STREAM_AUTH` | Governs authentication of the two live-screen daemon sockets (`webrtc-stream`, `video-stream`). When enabled (the default), a `start`/`subscribe` request must carry a `sessionUuid` that resolves to a live daemon session, and may only target a device owned by that same session (issue #4751, extending the #4655 session mechanism). Set to `0`/`false` to disable the check for clients that cannot yet supply a session UUID. | enabled |
 
 ### `automobile-video.jar` resolution
 

--- a/src/daemon/streamSocketAuth.ts
+++ b/src/daemon/streamSocketAuth.ts
@@ -1,0 +1,139 @@
+import { ActionableError } from "../models";
+import { DaemonState } from "./daemonState";
+import { resolveCapabilityBaseSessionUuid } from "../features/toolCapabilities/capabilitySessionResolver";
+
+/**
+ * Authentication + session-scoping for the two live-screen daemon sockets
+ * (`webrtc-stream.sock`, `video-stream.sock`).
+ *
+ * These sockets historically accepted `start`/`subscribe` from any local process
+ * with no identity check, so any process running as the user could publish the
+ * device screen to an attacker-controlled WHIP server or silently subscribe to
+ * the raw H.264 stream (issue #4751). This module extends the SAME session
+ * identity mechanism the main daemon socket uses (issue #4655): a request must
+ * carry a `sessionUuid` that resolves to a live daemon session, and it may only
+ * target a device that is unowned or owned by that same session — a subscriber
+ * cannot ride along on another session's capture.
+ *
+ * Enforcement is on by default; `AUTOMOBILE_DAEMON_STREAM_AUTH=0` disables it,
+ * mirroring the daemon handshake's `AUTOMOBILE_DAEMON_HANDSHAKE`-style opt-out
+ * for setups whose clients cannot yet supply a session UUID.
+ */
+
+/** Env flag that opts a daemon out of stream-socket authentication. */
+export const STREAM_SOCKET_AUTH_ENV = "AUTOMOBILE_DAEMON_STREAM_AUTH";
+
+/**
+ * The narrow SessionManager surface the authenticator needs. Kept minimal
+ * (YAGNI) and structurally satisfied by the real `SessionManager`, so the same
+ * live registry that #4655 tracks backs the check.
+ */
+export interface StreamAuthSessionManager {
+  getSession(sessionUuid: string): unknown | null;
+  getSessionForDevice(deviceId: string): string | null;
+  getDeviceLabels(sessionUuid: string): Record<string, string> | undefined;
+}
+
+export interface StreamAuthorizeInput {
+  /** Session UUID declared on the wire; the caller's proof of daemon admission. */
+  sessionUuid?: string;
+  /** Target device, when the request names one. */
+  deviceId?: string;
+}
+
+export interface StreamSocketAuthenticator {
+  /**
+   * Authorize a stream control request. Throws {@link ActionableError} when the
+   * request is unauthenticated, names an unknown/expired session, or targets a
+   * device bound to a different session.
+   */
+  authorize(input: StreamAuthorizeInput): void;
+}
+
+function authEnforced(env: NodeJS.ProcessEnv): boolean {
+  const raw = (env[STREAM_SOCKET_AUTH_ENV] ?? "").trim().toLowerCase();
+  return !(raw === "0" || raw === "false" || raw === "no" || raw === "off");
+}
+
+/**
+ * Authenticates against the daemon's live session registry. A request must
+ * carry a `sessionUuid` resolving to an active session; when it also names a
+ * device, that device must be unowned or owned by the same base session.
+ */
+export class SessionScopedStreamAuthenticator implements StreamSocketAuthenticator {
+  constructor(
+    private readonly resolveSessionManager: () => StreamAuthSessionManager | null,
+    private readonly operation: string,
+    private readonly env: NodeJS.ProcessEnv = process.env
+  ) {}
+
+  authorize({ sessionUuid, deviceId }: StreamAuthorizeInput): void {
+    if (!authEnforced(this.env)) {
+      return;
+    }
+
+    const uuid = typeof sessionUuid === "string" ? sessionUuid.trim() : "";
+    if (!uuid) {
+      throw new ActionableError(
+        `${this.operation} requires an authenticated daemon session. Connect through the AutoMobile ` +
+          `daemon and include its sessionUuid on the request; set ${STREAM_SOCKET_AUTH_ENV}=0 to disable ` +
+          `this check (not recommended).`
+      );
+    }
+
+    const sessionManager = this.resolveSessionManager();
+    if (!sessionManager) {
+      throw new ActionableError(
+        `${this.operation} cannot be authenticated: the daemon session registry is unavailable. ` +
+          `Ensure the request is made against a running AutoMobile daemon.`
+      );
+    }
+
+    // Resolve derived `${base}:${label}` device-label sessions to the base whose
+    // identity the daemon tracks, exactly as the main socket does (#4611/#4655).
+    const baseSessionUuid = resolveCapabilityBaseSessionUuid(uuid, sessionManager) ?? uuid;
+    if (!sessionManager.getSession(baseSessionUuid)) {
+      throw new ActionableError(
+        `${this.operation} rejected: session ${uuid} is not an active daemon session (unknown or expired).`
+      );
+    }
+
+    if (deviceId) {
+      this.assertDeviceScope(sessionManager, deviceId, baseSessionUuid);
+    }
+  }
+
+  /**
+   * A subscriber may only target a device that is unowned or owned by its own
+   * base session — it cannot ride along on another session's capture.
+   */
+  private assertDeviceScope(
+    sessionManager: StreamAuthSessionManager,
+    deviceId: string,
+    baseSessionUuid: string
+  ): void {
+    const owner = sessionManager.getSessionForDevice(deviceId) ?? undefined;
+    if (!owner) {
+      return;
+    }
+    const ownerBase = resolveCapabilityBaseSessionUuid(owner, sessionManager) ?? owner;
+    if (ownerBase !== baseSessionUuid) {
+      throw new ActionableError(
+        `${this.operation} rejected: device ${deviceId} is bound to a different daemon session; ` +
+          `a subscriber cannot attach to another session's capture without authorization.`
+      );
+    }
+  }
+}
+
+/**
+ * The production authenticator, wired to the daemon's singleton session
+ * registry. Fails closed: when the daemon is not initialized the registry is
+ * unavailable and every request is rejected.
+ */
+export function createDefaultStreamSocketAuthenticator(operation: string): StreamSocketAuthenticator {
+  return new SessionScopedStreamAuthenticator(() => {
+    const state = DaemonState.getInstance();
+    return state.isInitialized() ? state.getSessionManager() : null;
+  }, operation);
+}

--- a/src/daemon/videoStreamSocketServer.ts
+++ b/src/daemon/videoStreamSocketServer.ts
@@ -13,6 +13,10 @@ import { H264AnnexBParser, nalUnitType, NAL_TYPE_IDR, NAL_TYPE_PPS, NAL_TYPE_SPS
 import { VIDEO_STREAM_SOCKET_CONFIG } from "./daemonFiles";
 import { BaseSocketServer, getSocketPath } from "./socketServer/index";
 import {
+  createDefaultStreamSocketAuthenticator,
+  type StreamSocketAuthenticator,
+} from "./streamSocketAuth";
+import {
   encodePacket,
   encodePtsAndFlags,
   encodeStreamHeader,
@@ -76,14 +80,18 @@ export class VideoStreamSocketServer extends BaseSocketServer {
   private readonly captures = new Map<string, DeviceCapture>();
   private readonly socketDeviceIds = new Map<Socket, string>();
 
+  private readonly authenticator: StreamSocketAuthenticator;
+
   constructor(
     private readonly deps: VideoStreamSocketServerDependencies,
     socketPath: string = getSocketPath(VIDEO_STREAM_SOCKET_CONFIG),
-    timer: Timer = defaultTimer
+    timer: Timer = defaultTimer,
+    authenticator: StreamSocketAuthenticator = createDefaultStreamSocketAuthenticator("video-stream subscribe")
   ) {
     // Idle timeout disabled: this stream is outbound-only after the handshake, and a viewer that
     // never sends another byte is the normal case, not a dead peer.
     super(socketPath, timer, "VideoStream", 0);
+    this.authenticator = authenticator;
   }
 
   /** Devices with an active capture, for diagnostics and tests. */
@@ -134,6 +142,10 @@ export class VideoStreamSocketServer extends BaseSocketServer {
     }
 
     try {
+      // Authenticate before starting or attaching to any capture (issue #4751):
+      // an unauthenticated or cross-session subscribe is rejected here so it can
+      // never ride along on the raw H.264 screen stream.
+      this.authenticator.authorize({ sessionUuid: request.sessionUuid, deviceId: request.deviceId });
       const device = await this.deps.resolveDevice(request.deviceId);
       const capture = await this.attach(socket, device, request);
 

--- a/src/daemon/videoStreamSocketTypes.ts
+++ b/src/daemon/videoStreamSocketTypes.ts
@@ -17,6 +17,13 @@ export type VideoStreamAction = "subscribe" | "unsubscribe";
 export interface VideoStreamSocketRequest {
   id?: string;
   action: VideoStreamAction;
+  /**
+   * Session UUID admitting this subscribe request (issue #4751). The daemon
+   * authenticates against its live session registry (the #4655 session
+   * mechanism) so an unauthenticated process cannot ride along on the raw H.264
+   * screen stream, and rejects a subscribe to a device owned by another session.
+   */
+  sessionUuid?: string;
   /** Device to mirror. Defaults to the sole connected device when omitted. */
   deviceId?: string;
   /** Encoder bitrate hint, passed through to the capture source. */

--- a/src/daemon/webrtcStreamSocketServer.ts
+++ b/src/daemon/webrtcStreamSocketServer.ts
@@ -19,6 +19,11 @@ import type {
   WebRtcStreamSocketResponse,
 } from "./webrtcStreamSocketTypes";
 import type { WebRtcStreamingOverrides } from "../features/webrtc";
+import { assertWhipOverrideAllowed } from "../features/webrtc/webrtcStreamingConfig";
+import {
+  createDefaultStreamSocketAuthenticator,
+  type StreamSocketAuthenticator,
+} from "./streamSocketAuth";
 
 /** Injectable dependencies so the server can be tested without a device pool. */
 export interface WebRtcStreamSocketServerDependencies {
@@ -124,14 +129,17 @@ export class WebRtcStreamSocketServer extends RequestResponseSocketServer<
 > {
   private readonly injectedDeps?: WebRtcStreamSocketServerDependencies;
   private resolvedDeps: WebRtcStreamSocketServerDependencies | null = null;
+  private readonly authenticator: StreamSocketAuthenticator;
 
   constructor(
     socketPath: string = getSocketPath(WEBRTC_STREAM_SOCKET_CONFIG),
     timer: Timer = defaultTimer,
-    deps?: WebRtcStreamSocketServerDependencies
+    deps?: WebRtcStreamSocketServerDependencies,
+    authenticator: StreamSocketAuthenticator = createDefaultStreamSocketAuthenticator("webrtcStream")
   ) {
     super(socketPath, timer, "WebRtcStream");
     this.injectedDeps = deps;
+    this.authenticator = authenticator;
   }
 
   /** Resolve dependencies, lazily loading the (werift-heavy) manager on first use. */
@@ -156,6 +164,9 @@ export class WebRtcStreamSocketServer extends RequestResponseSocketServer<
   protected async handleRequest(
     request: WebRtcStreamSocketRequest
   ): Promise<WebRtcStreamSocketResponse> {
+    // Authenticate before touching device state or the WebRTC stack (issue
+    // #4751). An unauthenticated or cross-session request is rejected here.
+    this.authenticator.authorize({ sessionUuid: request.sessionUuid, deviceId: request.deviceId });
     const deps = await this.getDeps();
     switch (request.action) {
       case "start":
@@ -185,6 +196,12 @@ export class WebRtcStreamSocketServer extends RequestResponseSocketServer<
     deps: WebRtcStreamSocketServerDependencies,
     request: WebRtcStreamSocketRequest
   ): Promise<WebRtcStreamSocketResponse> {
+    // A WHIP endpoint supplied over the wire may only target a trusted origin
+    // (issue #4751); the protocol (https-or-loopback) is enforced downstream in
+    // resolveWebRtcStreamingConfig.
+    if (request.whipEndpoint) {
+      assertWhipOverrideAllowed(request.whipEndpoint);
+    }
     const device = await deps.resolveDevice(request.deviceId, request.platform ?? "android");
     const stream = await deps.startStream({
       device,

--- a/src/daemon/webrtcStreamSocketTypes.ts
+++ b/src/daemon/webrtcStreamSocketTypes.ts
@@ -17,6 +17,13 @@ export interface WebRtcIceServerInput {
  */
 export interface WebRtcStreamSocketRequest extends SocketRequest {
   action: WebRtcStreamAction;
+  /**
+   * Session UUID admitting this request (issue #4751). The daemon authenticates
+   * every action against its live session registry (the #4655 session mechanism)
+   * and rejects a request whose session is absent, unknown, or bound to a
+   * different device.
+   */
+  sessionUuid?: string;
   /** Target device id (defaults to the sole connected Android device). */
   deviceId?: string;
   platform?: "android" | "ios";

--- a/src/features/webrtc/webrtcStreamingConfig.ts
+++ b/src/features/webrtc/webrtcStreamingConfig.ts
@@ -98,6 +98,20 @@ export const WEBRTC_ENV = {
   ANDROID_FPS: "AUTOMOBILE_WEBRTC_ANDROID_FPS",
   TRICKLE_ICE: "AUTOMOBILE_WEBRTC_TRICKLE_ICE",
   AUDIO: "AUTOMOBILE_WEBRTC_AUDIO",
+  /**
+   * Escape hatch (issue #4751). When truthy, re-permits plaintext `http://`
+   * WHIP endpoints on non-loopback hosts AND accepts an arbitrary (non
+   * allow-listed) WHIP override from the wire. Off by default; the bearer token
+   * and SDP travel in cleartext over `http://`, so this is for advanced setups
+   * only.
+   */
+  ALLOW_INSECURE_WHIP: "AUTOMOBILE_WEBRTC_ALLOW_INSECURE_WHIP",
+  /**
+   * Comma-separated allow-list of origins (or bare `host[:port]`) that a WHIP
+   * endpoint supplied over the wire may target (issue #4751). Loopback and the
+   * daemon's own {@link WHIP_ENDPOINT} origin are always trusted.
+   */
+  WHIP_ALLOWED_ORIGINS: "AUTOMOBILE_WEBRTC_WHIP_ALLOWED_ORIGINS",
 } as const;
 
 const DEFAULT_ICE_SERVERS: RTCIceServer[] = [{ urls: "stun:stun.l.google.com:19302" }];
@@ -215,7 +229,7 @@ export function resolveWebRtcStreamingConfig(
   const audioEnabled = overrides.audioEnabled ?? parseBooleanFlag(env[WEBRTC_ENV.AUDIO]);
 
   return {
-    whipEndpoint: validateWhipEndpoint(whipEndpoint),
+    whipEndpoint: validateWhipEndpoint(whipEndpoint, env),
     bearerToken: overrides.bearerToken ?? env[WEBRTC_ENV.WHIP_TOKEN] ?? undefined,
     iceServers,
     bitrateKbps,
@@ -292,15 +306,125 @@ function validateSize(size: { width: number; height: number }): { width: number;
   return { width, height };
 }
 
-function validateWhipEndpoint(endpoint: string): string {
+const LOOPBACK_WHIP_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1"]);
+
+/**
+ * Whether a WHIP endpoint hostname is loopback, for which plaintext `http://` is
+ * acceptable (dev/CI on the same host). Covers `localhost`, the whole
+ * `127.0.0.0/8` block, and IPv6 `::1` (with or without brackets).
+ */
+export function isLoopbackWhipHost(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[/, "").replace(/\]$/, "");
+  if (LOOPBACK_WHIP_HOSTNAMES.has(host)) {
+    return true;
+  }
+  return /^127(?:\.\d{1,3}){3}$/.test(host);
+}
+
+/** Whether the plaintext/arbitrary-WHIP escape hatch (issue #4751) is enabled. */
+export function isInsecureWhipAllowed(env: NodeJS.ProcessEnv = process.env): boolean {
+  return parseBooleanFlag(env[WEBRTC_ENV.ALLOW_INSECURE_WHIP]);
+}
+
+function whipUrlOrThrow(endpoint: string): URL {
   const trimmed = endpoint.trim();
+  let url: URL;
   try {
-    const url = new URL(trimmed);
-    if (url.protocol !== "http:" && url.protocol !== "https:") {
-      throw new Error("unsupported protocol");
-    }
+    url = new URL(trimmed);
   } catch {
     throw new ActionableError(`Invalid WHIP endpoint "${trimmed}"; expected an absolute http(s) URL.`);
   }
-  return trimmed;
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new ActionableError(`Invalid WHIP endpoint "${trimmed}"; expected an absolute http(s) URL.`);
+  }
+  return url;
+}
+
+/**
+ * Validate a WHIP endpoint's protocol (issue #4751): require `https:`, allowing
+ * plaintext `http:` only for explicit loopback. The
+ * {@link WEBRTC_ENV.ALLOW_INSECURE_WHIP} escape hatch re-permits `http:`
+ * everywhere for advanced setups.
+ */
+function validateWhipEndpoint(endpoint: string, env: NodeJS.ProcessEnv = process.env): string {
+  const url = whipUrlOrThrow(endpoint);
+  if (
+    url.protocol === "http:" &&
+    !isLoopbackWhipHost(url.hostname) &&
+    !isInsecureWhipAllowed(env)
+  ) {
+    throw new ActionableError(
+      `Refusing plaintext WHIP endpoint "${endpoint.trim()}": http:// is only permitted for loopback ` +
+        `(127.0.0.1/localhost/::1) because the bearer token and SDP would travel in cleartext. Use https://, ` +
+        `or set ${WEBRTC_ENV.ALLOW_INSECURE_WHIP}=1 to allow insecure endpoints (not recommended).`
+    );
+  }
+  return endpoint.trim();
+}
+
+function parseWhipAllowedOrigins(raw: string | undefined): string[] {
+  if (!raw || !raw.trim()) {
+    return [];
+  }
+  return raw
+    .split(",")
+    .map(entry => entry.trim())
+    .filter(entry => entry.length > 0);
+}
+
+function toOrigin(candidate: string): string | undefined {
+  // Permit bare `host[:port]` allow-list entries by assuming https; an entry
+  // with an explicit scheme is parsed as-is. `canParse` avoids a throwing parse
+  // on a malformed allow-list entry (which is skipped, not an error).
+  const normalized = candidate.includes("://") ? candidate : `https://${candidate}`;
+  if (!URL.canParse(normalized)) {
+    return undefined;
+  }
+  const origin = new URL(normalized).origin;
+  return origin === "null" ? undefined : origin;
+}
+
+/**
+ * Restrict a WHIP endpoint supplied OVER THE WIRE to trusted origins (issue
+ * #4751) so a local process cannot exfiltrate the screen to a destination of its
+ * choosing. Trust anchors: loopback (always), the daemon's own configured
+ * {@link WEBRTC_ENV.WHIP_ENDPOINT} origin, and any origins in
+ * {@link WEBRTC_ENV.WHIP_ALLOWED_ORIGINS}. Fully bypassed by the
+ * {@link WEBRTC_ENV.ALLOW_INSECURE_WHIP} escape hatch.
+ */
+export function assertWhipOverrideAllowed(
+  endpoint: string,
+  env: NodeJS.ProcessEnv = process.env
+): void {
+  if (isInsecureWhipAllowed(env)) {
+    return;
+  }
+  const url = whipUrlOrThrow(endpoint);
+  if (isLoopbackWhipHost(url.hostname)) {
+    return;
+  }
+
+  const allowedOrigins = new Set<string>();
+  const configured = env[WEBRTC_ENV.WHIP_ENDPOINT];
+  if (configured && configured.trim()) {
+    const origin = toOrigin(configured.trim());
+    if (origin) {
+      allowedOrigins.add(origin);
+    }
+  }
+  for (const entry of parseWhipAllowedOrigins(env[WEBRTC_ENV.WHIP_ALLOWED_ORIGINS])) {
+    const origin = toOrigin(entry);
+    if (origin) {
+      allowedOrigins.add(origin);
+    }
+  }
+
+  if (!allowedOrigins.has(url.origin)) {
+    throw new ActionableError(
+      `Refusing WHIP endpoint override "${endpoint.trim()}": its origin ${url.origin} is not allow-listed. ` +
+        `Add it to ${WEBRTC_ENV.WHIP_ALLOWED_ORIGINS} (comma-separated origins), align it with the daemon's ` +
+        `${WEBRTC_ENV.WHIP_ENDPOINT}, or set ${WEBRTC_ENV.ALLOW_INSECURE_WHIP}=1 to accept arbitrary ` +
+        `destinations (not recommended).`
+    );
+  }
 }

--- a/test/daemon/streamSocketAuth.test.ts
+++ b/test/daemon/streamSocketAuth.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import {
+  SessionScopedStreamAuthenticator,
+  STREAM_SOCKET_AUTH_ENV,
+  type StreamAuthSessionManager,
+} from "../../src/daemon/streamSocketAuth";
+import { ActionableError } from "../../src/models";
+
+function sessionManager(overrides: Partial<StreamAuthSessionManager> = {}): StreamAuthSessionManager {
+  return {
+    getSession: sessionUuid => (sessionUuid === "live" ? {} : null),
+    getSessionForDevice: () => null,
+    getDeviceLabels: () => undefined,
+    ...overrides,
+  };
+}
+
+function authenticator(
+  sm: StreamAuthSessionManager | null,
+  env: NodeJS.ProcessEnv = {} as NodeJS.ProcessEnv
+): SessionScopedStreamAuthenticator {
+  return new SessionScopedStreamAuthenticator(() => sm, "test op", env);
+}
+
+describe("SessionScopedStreamAuthenticator", () => {
+  test("rejects a missing sessionUuid", () => {
+    expect(() => authenticator(sessionManager()).authorize({})).toThrow(ActionableError);
+    expect(() => authenticator(sessionManager()).authorize({ sessionUuid: "  " })).toThrow(
+      /authenticated daemon session/
+    );
+  });
+
+  test("rejects an unknown/expired session", () => {
+    expect(() => authenticator(sessionManager()).authorize({ sessionUuid: "ghost" })).toThrow(
+      /not an active daemon session/
+    );
+  });
+
+  test("accepts a live session with no device", () => {
+    expect(() => authenticator(sessionManager()).authorize({ sessionUuid: "live" })).not.toThrow();
+  });
+
+  test("fails closed when the session registry is unavailable", () => {
+    expect(() => authenticator(null).authorize({ sessionUuid: "live" })).toThrow(
+      /session registry is unavailable/
+    );
+  });
+
+  test("permits a device that is unowned", () => {
+    expect(() =>
+      authenticator(sessionManager()).authorize({ sessionUuid: "live", deviceId: "emu" })
+    ).not.toThrow();
+  });
+
+  test("permits a device owned by the same session", () => {
+    const sm = sessionManager({ getSessionForDevice: () => "live" });
+    expect(() =>
+      authenticator(sm).authorize({ sessionUuid: "live", deviceId: "emu" })
+    ).not.toThrow();
+  });
+
+  test("rejects a device owned by a different session", () => {
+    const sm = sessionManager({ getSessionForDevice: () => "other" });
+    expect(() =>
+      authenticator(sm).authorize({ sessionUuid: "live", deviceId: "emu" })
+    ).toThrow(/different daemon session/);
+  });
+
+  test("resolves a derived device-label session to its base for the registry check", () => {
+    const sm = sessionManager({
+      getSession: sessionUuid => (sessionUuid === "live" ? {} : null),
+      getDeviceLabels: sessionUuid =>
+        sessionUuid === "live" ? { phone: "live:phone" } : undefined,
+    });
+    expect(() => authenticator(sm).authorize({ sessionUuid: "live:phone" })).not.toThrow();
+  });
+
+  test("the escape hatch disables enforcement entirely", () => {
+    const env = { [STREAM_SOCKET_AUTH_ENV]: "0" } as unknown as NodeJS.ProcessEnv;
+    expect(() => authenticator(sessionManager(), env).authorize({})).not.toThrow();
+  });
+});

--- a/test/daemon/videoStreamSocketServer.test.ts
+++ b/test/daemon/videoStreamSocketServer.test.ts
@@ -7,6 +7,11 @@ import { defaultTimer } from "../../src/utils/SystemTimer";
 import type { BootedDevice } from "../../src/models";
 import type { H264CaptureSource } from "../../src/features/webrtc/H264CaptureSource";
 import { VideoStreamSocketServer } from "../../src/daemon/videoStreamSocketServer";
+import {
+  SessionScopedStreamAuthenticator,
+  type StreamAuthSessionManager,
+  type StreamSocketAuthenticator,
+} from "../../src/daemon/streamSocketAuth";
 import { CODEC_ID_H264 } from "../../src/daemon/videoStreamFraming";
 import { SIMULATOR_FPS_DEFAULT } from "../../src/features/screen-stream/IOSScreenCaptureHelper";
 import { WEBRTC_IOS_SIMULATOR_FPS_DEFAULT } from "../../src/features/webrtc/webrtcStreamingConfig";
@@ -46,8 +51,15 @@ interface Harness {
 
 const harnesses: Harness[] = [];
 
+/** Accepts every request; auth enforcement is exercised in dedicated tests below. */
+const allowAllAuthenticator: StreamSocketAuthenticator = { authorize: () => {} };
+
 async function startHarness(
-  options: { startError?: Error; resolveError?: Error } = {}
+  options: {
+    startError?: Error;
+    resolveError?: Error;
+    authenticator?: StreamSocketAuthenticator;
+  } = {}
 ): Promise<Harness> {
   const dir = mkdtempSync(path.join(tmpdir(), "amvs-"));
   const socketPath = path.join(dir, "video-stream.sock");
@@ -73,7 +85,9 @@ async function startHarness(
       },
       nowUs: () => 1_000n,
     },
-    socketPath
+    socketPath,
+    defaultTimer,
+    options.authenticator ?? allowAllAuthenticator
   );
   await server.start();
 
@@ -240,7 +254,9 @@ describe("VideoStreamSocketServer", () => {
           },
           nowUs: () => 1_000n,
         },
-        socketPath
+        socketPath,
+        defaultTimer,
+        allowAllAuthenticator
       );
       void server.start().then(() => {
         harnesses.push({
@@ -289,7 +305,9 @@ describe("VideoStreamSocketServer", () => {
         },
         nowUs: () => 1_000n,
       },
-      socketPath
+      socketPath,
+      defaultTimer,
+      allowAllAuthenticator
     );
     await server.start();
     harnesses.push({
@@ -454,5 +472,78 @@ describe("VideoStreamSocketServer", () => {
 
     expect(h.sources[0].stopped).toBe(true);
     expect(h.server.activeDeviceIds()).toHaveLength(0);
+  });
+
+  describe("authentication (issue #4751)", () => {
+    function fakeSessionManager(
+      overrides: Partial<StreamAuthSessionManager> = {}
+    ): StreamAuthSessionManager {
+      return {
+        getSession: sessionUuid => (sessionUuid === "session-1" ? {} : null),
+        getSessionForDevice: () => null,
+        getDeviceLabels: () => undefined,
+        ...overrides,
+      };
+    }
+
+    function enforcing(sm: StreamAuthSessionManager): StreamSocketAuthenticator {
+      return new SessionScopedStreamAuthenticator(() => sm, "video-stream subscribe", {} as NodeJS.ProcessEnv);
+    }
+
+    test("rejects an unauthenticated subscribe and starts no capture", async () => {
+      const h = await startHarness({ authenticator: enforcing(fakeSessionManager()) });
+
+      const { ack } = await subscribe(h.socketPath);
+
+      expect(ack.success).toBe(false);
+      expect(String(ack.error)).toContain("authenticated daemon session");
+      expect(h.server.activeDeviceIds()).toHaveLength(0);
+      expect(h.sources).toHaveLength(0);
+    });
+
+    test("rejects a subscribe whose session is unknown/expired", async () => {
+      const h = await startHarness({ authenticator: enforcing(fakeSessionManager()) });
+
+      const { ack } = await subscribe(h.socketPath, {
+        action: "subscribe",
+        deviceId: DEVICE.deviceId,
+        sessionUuid: "ghost",
+      });
+
+      expect(ack.success).toBe(false);
+      expect(String(ack.error)).toContain("not an active daemon session");
+      expect(h.sources).toHaveLength(0);
+    });
+
+    test("accepts a subscribe with a live session", async () => {
+      const h = await startHarness({ authenticator: enforcing(fakeSessionManager()) });
+
+      const { ack } = await subscribe(h.socketPath, {
+        action: "subscribe",
+        deviceId: DEVICE.deviceId,
+        sessionUuid: "session-1",
+      });
+
+      expect(ack.success).toBe(true);
+      expect(h.server.activeDeviceIds()).toEqual([DEVICE.deviceId]);
+    });
+
+    test("rejects riding along on a device owned by another session", async () => {
+      const h = await startHarness({
+        authenticator: enforcing(
+          fakeSessionManager({ getSessionForDevice: () => "other-session" })
+        ),
+      });
+
+      const { ack } = await subscribe(h.socketPath, {
+        action: "subscribe",
+        deviceId: DEVICE.deviceId,
+        sessionUuid: "session-1",
+      });
+
+      expect(ack.success).toBe(false);
+      expect(String(ack.error)).toContain("different daemon session");
+      expect(h.sources).toHaveLength(0);
+    });
   });
 });

--- a/test/daemon/webrtcStreamSocketServer.test.ts
+++ b/test/daemon/webrtcStreamSocketServer.test.ts
@@ -1,4 +1,10 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { WEBRTC_ENV } from "../../src/features/webrtc/webrtcStreamingConfig";
+import {
+  SessionScopedStreamAuthenticator,
+  type StreamAuthSessionManager,
+  type StreamSocketAuthenticator,
+} from "../../src/daemon/streamSocketAuth";
 import { Socket } from "node:net";
 import {
   resolveWebRtcStreamDevice,
@@ -62,9 +68,15 @@ function descriptor(streamId: string, state: WebRtcStreamDescriptor["state"] = "
   };
 }
 
+/** Accepts every request; auth enforcement is exercised in dedicated tests below. */
+const allowAllAuthenticator: StreamSocketAuthenticator = { authorize: () => {} };
+
 class TestableServer extends WebRtcStreamSocketServer {
-  constructor(deps: WebRtcStreamSocketServerDependencies) {
-    super("/fake/webrtc-stream.sock", new FakeTimer(), deps);
+  constructor(
+    deps: WebRtcStreamSocketServerDependencies,
+    authenticator: StreamSocketAuthenticator = allowAllAuthenticator
+  ) {
+    super("/fake/webrtc-stream.sock", new FakeTimer(), deps, authenticator);
   }
   async simulate(socket: FakeSocket, request: WebRtcStreamSocketRequest): Promise<void> {
     await (this as any).processLine(socket as unknown as Socket, JSON.stringify(request));
@@ -104,6 +116,22 @@ function makeDeps(overrides: Partial<WebRtcStreamSocketServerDependencies> = {})
     ...overrides,
   };
 }
+
+// The `https://coord` origin is the trusted coordination server these tests
+// publish to; allow-list it so wire overrides pointing at it pass the #4751
+// origin policy. Loopback overrides are always permitted regardless.
+let previousAllowedOrigins: string | undefined;
+beforeAll(() => {
+  previousAllowedOrigins = process.env[WEBRTC_ENV.WHIP_ALLOWED_ORIGINS];
+  process.env[WEBRTC_ENV.WHIP_ALLOWED_ORIGINS] = "https://coord";
+});
+afterAll(() => {
+  if (previousAllowedOrigins === undefined) {
+    delete process.env[WEBRTC_ENV.WHIP_ALLOWED_ORIGINS];
+  } else {
+    process.env[WEBRTC_ENV.WHIP_ALLOWED_ORIGINS] = previousAllowedOrigins;
+  }
+});
 
 afterEach(() => {
   started = [];
@@ -394,5 +422,111 @@ describe("WebRtcStreamSocketServer", () => {
     const response = lastResponse(socket);
     expect(response.success).toBe(false);
     expect(response.error).toContain("Invalid JSON");
+  });
+
+  describe("authentication (issue #4751)", () => {
+    function fakeSessionManager(
+      overrides: Partial<StreamAuthSessionManager> = {}
+    ): StreamAuthSessionManager {
+      return {
+        getSession: sessionUuid => (sessionUuid === "session-1" ? {} : null),
+        getSessionForDevice: () => null,
+        getDeviceLabels: () => undefined,
+        ...overrides,
+      };
+    }
+
+    function enforcingServer(sm: StreamAuthSessionManager): TestableServer {
+      return new TestableServer(
+        makeDeps(),
+        new SessionScopedStreamAuthenticator(() => sm, "webrtcStream", {} as NodeJS.ProcessEnv)
+      );
+    }
+
+    test("rejects a start with no sessionUuid", async () => {
+      const server = enforcingServer(fakeSessionManager());
+      const socket = new FakeSocket();
+      await server.simulate(socket, { id: "1", action: "start", whipEndpoint: "https://coord/whip" });
+      const response = lastResponse(socket);
+      expect(response.success).toBe(false);
+      expect(response.error).toContain("authenticated daemon session");
+      expect(started).toHaveLength(0);
+    });
+
+    test("rejects a start whose session is unknown/expired", async () => {
+      const server = enforcingServer(fakeSessionManager());
+      const socket = new FakeSocket();
+      await server.simulate(socket, {
+        id: "2",
+        action: "start",
+        sessionUuid: "ghost",
+        whipEndpoint: "https://coord/whip",
+      });
+      const response = lastResponse(socket);
+      expect(response.success).toBe(false);
+      expect(response.error).toContain("not an active daemon session");
+      expect(started).toHaveLength(0);
+    });
+
+    test("accepts a start with a live session", async () => {
+      const server = enforcingServer(fakeSessionManager());
+      const socket = new FakeSocket();
+      await server.simulate(socket, {
+        id: "3",
+        action: "start",
+        sessionUuid: "session-1",
+        whipEndpoint: "https://coord/whip",
+      });
+      expect(lastResponse(socket).success).toBe(true);
+      expect(started).toHaveLength(1);
+    });
+
+    test("rejects targeting a device owned by another session", async () => {
+      const server = enforcingServer(
+        fakeSessionManager({ getSessionForDevice: () => "other-session" })
+      );
+      const socket = new FakeSocket();
+      await server.simulate(socket, {
+        id: "4",
+        action: "start",
+        sessionUuid: "session-1",
+        deviceId: "emulator-5554",
+        whipEndpoint: "https://coord/whip",
+      });
+      const response = lastResponse(socket);
+      expect(response.success).toBe(false);
+      expect(response.error).toContain("different daemon session");
+      expect(started).toHaveLength(0);
+    });
+  });
+
+  describe("WHIP override policy (issue #4751)", () => {
+    test("rejects an arbitrary non-allow-listed WHIP override from the wire", async () => {
+      const server = new TestableServer(makeDeps());
+      const socket = new FakeSocket();
+      await server.simulate(socket, {
+        id: "w1",
+        action: "start",
+        sessionUuid: "session-1",
+        whipEndpoint: "https://attacker.example/whip",
+      });
+      const response = lastResponse(socket);
+      expect(response.success).toBe(false);
+      expect(response.error).toContain("not allow-listed");
+      expect(started).toHaveLength(0);
+    });
+
+    test("permits a loopback http WHIP override", async () => {
+      const server = new TestableServer(makeDeps());
+      const socket = new FakeSocket();
+      await server.simulate(socket, {
+        id: "w2",
+        action: "start",
+        sessionUuid: "session-1",
+        whipEndpoint: "http://127.0.0.1:8000/whip",
+      });
+      expect(lastResponse(socket).success).toBe(true);
+      expect(started).toHaveLength(1);
+    });
   });
 });

--- a/test/features/webrtc/webrtcStreamingConfig.test.ts
+++ b/test/features/webrtc/webrtcStreamingConfig.test.ts
@@ -10,6 +10,8 @@ import {
   parseIceServers,
   parseSize,
   resolveWebRtcStreamingConfig,
+  assertWhipOverrideAllowed,
+  isLoopbackWhipHost,
 } from "../../../src/features/webrtc/webrtcStreamingConfig";
 import { SIMULATOR_FPS_DEFAULT } from "../../../src/features/screen-stream/IOSScreenCaptureHelper";
 
@@ -249,5 +251,84 @@ describe("resolveWebRtcStreamingConfig", () => {
     expect(() => resolveWebRtcStreamingConfig({}, {} as NodeJS.ProcessEnv)).toThrow(
       /WHIP endpoint/
     );
+  });
+});
+
+describe("WHIP endpoint protocol policy (issue #4751)", () => {
+  const env = { [WEBRTC_ENV.WHIP_ENDPOINT]: "https://coord/whip" } as NodeJS.ProcessEnv;
+
+  test("permits https on any host", () => {
+    const config = resolveWebRtcStreamingConfig({ whipEndpoint: "https://remote.example/whip" }, env);
+    expect(config.whipEndpoint).toBe("https://remote.example/whip");
+  });
+
+  test("permits http only on loopback hosts", () => {
+    for (const endpoint of [
+      "http://127.0.0.1:8000/whip",
+      "http://localhost:8000/whip",
+      "http://[::1]:8000/whip",
+    ]) {
+      expect(resolveWebRtcStreamingConfig({ whipEndpoint: endpoint }, env).whipEndpoint).toBe(endpoint);
+    }
+  });
+
+  test("rejects plaintext http on a non-loopback host", () => {
+    expect(() =>
+      resolveWebRtcStreamingConfig({ whipEndpoint: "http://remote.example/whip" }, env)
+    ).toThrow(/only permitted for loopback/);
+  });
+
+  test("the escape hatch re-permits plaintext http anywhere", () => {
+    const hatchEnv = {
+      ...env,
+      [WEBRTC_ENV.ALLOW_INSECURE_WHIP]: "1",
+    } as NodeJS.ProcessEnv;
+    expect(
+      resolveWebRtcStreamingConfig({ whipEndpoint: "http://remote.example/whip" }, hatchEnv).whipEndpoint
+    ).toBe("http://remote.example/whip");
+  });
+
+  test("isLoopbackWhipHost recognizes the loopback block", () => {
+    expect(isLoopbackWhipHost("127.0.0.1")).toBe(true);
+    expect(isLoopbackWhipHost("127.5.5.5")).toBe(true);
+    expect(isLoopbackWhipHost("localhost")).toBe(true);
+    expect(isLoopbackWhipHost("::1")).toBe(true);
+    expect(isLoopbackWhipHost("example.com")).toBe(false);
+    expect(isLoopbackWhipHost("10.0.0.1")).toBe(false);
+  });
+});
+
+describe("assertWhipOverrideAllowed (issue #4751)", () => {
+  test("always permits loopback overrides", () => {
+    expect(() =>
+      assertWhipOverrideAllowed("http://127.0.0.1:8000/whip", {} as NodeJS.ProcessEnv)
+    ).not.toThrow();
+  });
+
+  test("rejects an arbitrary origin with no allow-list configured", () => {
+    expect(() =>
+      assertWhipOverrideAllowed("https://attacker.example/whip", {} as NodeJS.ProcessEnv)
+    ).toThrow(/not allow-listed/);
+  });
+
+  test("permits an origin matching the daemon's configured endpoint", () => {
+    const env = { [WEBRTC_ENV.WHIP_ENDPOINT]: "https://coord.example/whip" } as NodeJS.ProcessEnv;
+    expect(() =>
+      assertWhipOverrideAllowed("https://coord.example/whip?streamId=1", env)
+    ).not.toThrow();
+  });
+
+  test("permits an explicitly allow-listed origin, including a bare host entry", () => {
+    const env = {
+      [WEBRTC_ENV.WHIP_ALLOWED_ORIGINS]: "https://a.example, b.example:9000",
+    } as NodeJS.ProcessEnv;
+    expect(() => assertWhipOverrideAllowed("https://a.example/whip", env)).not.toThrow();
+    expect(() => assertWhipOverrideAllowed("https://b.example:9000/whip", env)).not.toThrow();
+    expect(() => assertWhipOverrideAllowed("https://c.example/whip", env)).toThrow(/not allow-listed/);
+  });
+
+  test("the escape hatch accepts any origin", () => {
+    const env = { [WEBRTC_ENV.ALLOW_INSECURE_WHIP]: "1" } as NodeJS.ProcessEnv;
+    expect(() => assertWhipOverrideAllowed("https://attacker.example/whip", env)).not.toThrow();
   });
 });


### PR DESCRIPTION
Closes [#4751](https://github.com/kaeawc/auto-mobile/issues/4751)

## Summary

The `webrtc-stream` and `video-stream` daemon sockets accepted `start`/`subscribe`
with **no authentication, session identity, or capability check**, so any local
process running as the user could publish the live device screen to an
attacker-controlled WHIP server or silently subscribe to the raw H.264 stream.
This PR authenticates both sockets behind the existing daemon session mechanism
(extending [#4655](https://github.com/kaeawc/auto-mobile/issues/4655)) and hardens
the WHIP endpoint policy.

## Verify-against-current-main findings

The vulnerable code was still present on `main`; only line numbers had drifted
(and [#4750](https://github.com/kaeawc/auto-mobile/issues/4750) had hardened the
socket-**dir** perms, an OS-level control, not the app-level auth this issue asks
for):

- `src/daemon/webrtcStreamSocketServer.ts` — `handleRequest`/`handleStart` had zero
  auth; `resolveStartOverrides` copied wire `whipEndpoint`/`whipToken` straight
  into the stream config.
- `src/daemon/videoStreamSocketServer.ts` — `processLine` relayed raw H.264 on a
  bare `subscribe` line with no token/capability check.
- `src/features/webrtc/webrtcStreamingConfig.ts` — `validateWhipEndpoint` permitted
  `http://` on any host.

### How #4655's mechanism works, and how this extends it

#4655 established per-session identity in the **main** daemon socket: each session
is a UUID tracked in `SessionManager` (`getSession(uuid)`, `getSessionForDevice`,
`getDeviceLabels`), and the socket resolves derived `${base}:${label}` device-label
sessions to their base via `resolveCapabilityBaseSessionUuid` before any capability
enforcement (`assertSocketToolEnabled`). The two stream sockets are separate Unix
sockets that were never wired into that mechanism.

Rather than invent a parallel auth scheme, this PR reuses the **same** session
registry. New `src/daemon/streamSocketAuth.ts` exposes a
`SessionScopedStreamAuthenticator` that:

1. requires a `sessionUuid` on the wire request (rejects unauthenticated),
2. resolves it to its base with the shared `resolveCapabilityBaseSessionUuid` and
   verifies `SessionManager.getSession(base)` is live (rejects unknown/expired),
3. **session-scopes** the target device: a request may only target a device that is
   unowned or owned by the same base session (via `getSessionForDevice`), so a
   subscriber cannot ride along on another session's capture.

The production authenticator resolves the registry from `DaemonState` and **fails
closed** (rejects everything when the daemon is not initialized). Both socket
servers now call `authorize(...)` before touching device state or the WebRTC stack.

## WHIP endpoint policy defaults (issue AC)

- **Protocol** (`validateWhipEndpoint`, applies to env- and wire-sourced endpoints):
  require `https:`; permit plaintext `http:` **only** for loopback
  (`127.0.0.0/8`, `localhost`, `::1`).
- **Origin allow-list** for wire overrides (`assertWhipOverrideAllowed`, enforced in
  `handleStart`): a `whipEndpoint` supplied over the wire may only target loopback,
  the daemon's own configured `AUTOMOBILE_WEBRTC_WHIP_ENDPOINT` origin, or an origin
  in `AUTOMOBILE_WEBRTC_WHIP_ALLOWED_ORIGINS` — not an arbitrary attacker
  destination.

## Escape hatch flags (documented in `docs/using/environment-variables.md`)

- **`AUTOMOBILE_WEBRTC_ALLOW_INSECURE_WHIP`** — re-permits non-loopback plaintext
  `http:` **and** accepts an arbitrary (non allow-listed) wire `whipEndpoint`
  override. Off by default.
- **`AUTOMOBILE_WEBRTC_WHIP_ALLOWED_ORIGINS`** — comma-separated allow-list of
  origins (or bare `host[:port]`) for wire overrides.
- **`AUTOMOBILE_DAEMON_STREAM_AUTH`** — governs stream-socket authentication;
  enabled by default, set `0`/`false` to opt out (for clients that cannot yet supply
  a session UUID, e.g. the Kotlin desktop client — a follow-up to plumb `sessionUuid`
  from that client).

## What changed

- `src/daemon/streamSocketAuth.ts` (new) — shared `SessionScopedStreamAuthenticator`,
  `StreamAuthSessionManager` seam, `createDefaultStreamSocketAuthenticator`.
- `src/daemon/webrtcStreamSocketServer.ts` — authorize every action; enforce the WHIP
  override allow-list on `start`.
- `src/daemon/videoStreamSocketServer.ts` — authorize before resolving/attaching a
  capture.
- `src/features/webrtc/webrtcStreamingConfig.ts` — https-or-loopback protocol policy,
  `assertWhipOverrideAllowed`, `isLoopbackWhipHost`, escape-hatch + allow-list env.
- `*SocketTypes.ts` — add `sessionUuid` to both wire request types.
- Tests: new `test/daemon/streamSocketAuth.test.ts`; auth + WHIP-policy suites added to
  the two socket-server tests and the config test (injectable authenticator + fake
  `SessionManager`, no real DB/daemon).
- `docs/using/environment-variables.md` — documents the policy and all three flags.

## Not changed (issue says already sound)

DTLS-SRTP media (no plaintext-RTP fallback), the strict WHIP-answer validation (no
SSRF), and the `H264AnnexBParser` 4 MB bound were left as-is.

## Validation

- `bun run typecheck` — no new errors (196 baseline).
- `turbo run lint build` — pass.
- `turbo run test` — **12403 pass / 0 fail** (13 skipped device-integration suites),
  including the new AC coverage: unauthenticated `start`/`subscribe` rejected;
  unknown/expired session rejected; cross-session device rejected; `http://`
  non-loopback WHIP rejected; loopback `http://` permitted; arbitrary
  non-allow-listed override rejected; escape hatch re-permits both.
