### PR TITLE
Desktop stream clients: sessionUuid wire seam for #4751 auth (blocked on session-identity decision)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/WebRtcStreamSocketClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/WebRtcStreamSocketClient.kt
@@ -93,10 +93,21 @@ interface WebRtcStreamClient {
   fun isAvailable(): Boolean
 }
 
-/** Client for `~/.auto-mobile/webrtc-stream.sock`. One request per connection. */
+/**
+ * Client for `~/.auto-mobile/webrtc-stream.sock`. One request per connection.
+ *
+ * [sessionUuidProvider] supplies the daemon session UUID that authenticates each `start`/`stop`/
+ * `status`/`list` request against the stream-socket session guard (issue #4751). It is resolved per
+ * request so a session established after this client is constructed is still picked up. When it
+ * returns null the `sessionUuid` field is omitted from the wire request (`DaemonJson` drops nulls);
+ * the daemon then rejects the request unless it was started with `AUTOMOBILE_DAEMON_STREAM_AUTH=0`.
+ * The default provider returns null because the desktop does not yet hold a daemon session identity
+ * to send -- see [WebRtcStreamSocketRequest.sessionUuid] and issue #4924.
+ */
 class WebRtcStreamSocketClient(
   private val socketPathValue: String = AutoMobileSocketPaths.socketPath(WEBRTC_STREAM_SOCKET_FILE),
   private val json: Json = DaemonJson,
+  private val sessionUuidProvider: () -> String? = { null },
 ) : WebRtcStreamClient {
 
   override fun isAvailable(): Boolean = Files.exists(File(socketPathValue).toPath())
@@ -120,6 +131,7 @@ class WebRtcStreamSocketClient(
     WebRtcStreamSocketRequest(
       id = UUID.randomUUID().toString(),
       action = action,
+      sessionUuid = sessionUuidProvider(),
       deviceId = deviceId,
       streamId = streamId,
     )
@@ -161,6 +173,13 @@ class WebRtcStreamSocketClient(
 internal data class WebRtcStreamSocketRequest(
   val id: String,
   val action: String,
+  /**
+   * Daemon session UUID that authenticates this request against the stream-socket session guard
+   * (issue #4751). Null is serialized as an omitted field by `DaemonJson`, matching a pre-#4751
+   * daemon and the escape-hatch path; a non-null value must resolve to a live daemon session or the
+   * daemon rejects the request. See issue #4924 for why the desktop cannot yet populate it.
+   */
+  val sessionUuid: String? = null,
   val deviceId: String? = null,
   val streamId: String? = null,
 )

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClient.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClient.kt
@@ -95,6 +95,14 @@ class VideoStreamClient(
     encodeDefaults = true
   },
   private val decoderFactory: () -> H264Decoder = { H264Decoder() },
+  /**
+   * Supplies the daemon session UUID that authenticates the `subscribe` request against the
+   * stream-socket session guard (issue #4751). Resolved at connect time so a session established
+   * after construction is still used. Null (the default) omits the `sessionUuid` field via
+   * [explicitNulls] = false, so the daemon rejects the subscribe unless it was started with
+   * `AUTOMOBILE_DAEMON_STREAM_AUTH=0`. The desktop cannot yet populate it -- see issue #4924.
+   */
+  private val sessionUuidProvider: () -> String? = { null },
 ) : VideoStreamSource {
 
   private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -161,7 +169,11 @@ class VideoStreamClient(
         writer.write(
           json.encodeToString(
             serializer<VideoStreamRequest>(),
-            VideoStreamRequest(id = UUID.randomUUID().toString(), deviceId = deviceId),
+            VideoStreamRequest(
+              id = UUID.randomUUID().toString(),
+              sessionUuid = sessionUuidProvider(),
+              deviceId = deviceId,
+            ),
           )
         )
         writer.newLine()
@@ -254,6 +266,12 @@ class VideoStreamClient(
 internal data class VideoStreamRequest(
   val id: String,
   val action: String = "subscribe",
+  /**
+   * Daemon session UUID authenticating this subscribe against the stream-socket session guard
+   * (issue #4751). Omitted when null (see [explicitNulls] = false above), matching the escape-hatch
+   * path; a non-null value must resolve to a live daemon session. See issue #4924.
+   */
+  val sessionUuid: String? = null,
   val deviceId: String? = null,
 )
 

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/WebRtcStreamSocketClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/daemon/WebRtcStreamSocketClientTest.kt
@@ -62,6 +62,36 @@ class WebRtcStreamSocketClientTest {
   }
 
   @Test
+  fun `start carries the session uuid the provider supplies`() {
+    // #4751 stream-socket auth: a resolved daemon session UUID authenticates the request.
+    server("""{"action":"start"}""").use { s ->
+      runCatching {
+        WebRtcStreamSocketClient(
+            socketPathValue = s.socketPath.toString(),
+            sessionUuidProvider = { "session-abc" },
+          )
+          .startStream("emulator-5554")
+      }
+
+      assertEquals("session-abc", s.awaitRequest()["sessionUuid"]?.jsonPrimitive?.content)
+    }
+  }
+
+  @Test
+  fun `start omits the session uuid when the provider returns null`() {
+    // The default (no desktop session identity yet, issue #4924) must not send an empty field, so a
+    // pre-#4751 daemon still accepts the request unchanged.
+    server("""{"action":"start"}""").use { s ->
+      runCatching {
+        WebRtcStreamSocketClient(socketPathValue = s.socketPath.toString())
+          .startStream("emulator-5554")
+      }
+
+      assertTrue(!s.awaitRequest().containsKey("sessionUuid"))
+    }
+  }
+
+  @Test
   fun `stop carries the stream id when one is given`() {
     server("""{"action":"start"}""").use { s ->
       runCatching {

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClientTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/video/VideoStreamClientTest.kt
@@ -99,6 +99,37 @@ class VideoStreamClientTest {
   }
 
   @Test
+  fun `subscribe carries the session uuid the provider supplies`() = runBlocking {
+    // #4751 stream-socket auth: a resolved daemon session UUID authenticates the subscribe.
+    val server = relay(payload = sampleH264())
+    val client =
+      VideoStreamClient(
+        socketPathValue = server.socketPath.toString(),
+        sessionUuidProvider = { "session-abc" },
+      )
+
+    client.connect("emulator-5554")
+    server.awaitFirstFrameFrom(client)
+
+    assertEquals("session-abc", server.awaitRequest()["sessionUuid"]?.jsonPrimitive?.content)
+    client.dispose()
+  }
+
+  @Test
+  fun `subscribe omits the session uuid when the provider returns null`() = runBlocking {
+    // Default: the desktop holds no daemon session identity yet (issue #4924); the field must be
+    // omitted so a pre-#4751 daemon still accepts the subscribe.
+    val server = relay(payload = sampleH264())
+    val client = VideoStreamClient(socketPathValue = server.socketPath.toString())
+
+    client.connect("emulator-5554")
+    server.awaitFirstFrameFrom(client)
+
+    assertTrue(!server.awaitRequest().containsKey("sessionUuid"))
+    client.dispose()
+  }
+
+  @Test
   fun `a refused subscribe surfaces the daemon's reason`() = runBlocking {
     val server = relay(success = false, error = "No connected device with id ghost.")
     val client = VideoStreamClient(socketPathValue = server.socketPath.toString())


### PR DESCRIPTION
## Summary

Refs [#4924](https://github.com/kaeawc/auto-mobile/issues/4924). **Opened as a DRAFT: the desktop cannot yet cleanly obtain a valid daemon `sessionUuid`, so the functional gap opened by [#4751](https://github.com/kaeawc/auto-mobile/issues/4751) (PR [#4923](https://github.com/kaeawc/auto-mobile/pull/4923)) cannot be closed without a design decision.** This PR lands the *wire seam* — an injectable session-UUID provider and the `sessionUuid` wire field on both desktop stream clients — so that once the session-identity decision is made, the remaining work is a one-line wiring. The escape hatch `AUTOMOBILE_DAEMON_STREAM_AUTH=0` remains the interim answer.

## Trace findings — how the desktop would get its `sessionUuid` (and why it can't today)

**Daemon side (what auth now requires).** `SessionScopedStreamAuthenticator.authorize()` in `src/daemon/streamSocketAuth.ts` reads `request.sessionUuid` (camelCase) off the wire request, resolves any derived `${base}:${label}` session via `resolveCapabilityBaseSessionUuid`, and then calls `sessionManager.getSession(baseSessionUuid)` — **it only reads the live session registry; it never creates a session.** If the device is named and already owned by a *different* base session, it also rejects. Wire field confirmed in `src/daemon/webrtcStreamSocketTypes.ts` (`sessionUuid?: string`); both servers pass `request.sessionUuid` into `authorize()` (`webrtcStreamSocketServer.ts:169`, `videoStreamSocketServer.ts:148`).

**Consequence:** the `sessionUuid` the desktop sends must **already be a live daemon session** (created earlier on the main socket). Sending it only to the stream socket cannot work — the stream socket does not register sessions.

**Desktop side (what it holds).** The only daemon session identity the desktop code models is `McpDaemonClient.capabilityProfileUuid` — the `sessionUuid` returned by `setToolCapability` (the [#4655](https://github.com/kaeawc/auto-mobile/issues/4655)/[#4611](https://github.com/kaeawc/auto-mobile/issues/4611) capability-profile mechanism). Three facts make it unusable as-is:

1. **The desktop mints a throwaway `McpDaemonClient` per call.** `AutoMobileContent.kt:639-660` — `clientProvider` returns `{ McpDaemonClient(socketPath) }`, invoked fresh for every tool call. Any `capabilityProfileUuid` learned on one call is discarded with that client instance.
2. **The desktop never populates it.** `enableToolCapability` is never called anywhere in `desktop-core`/`desktop-app`, so `capabilityProfileUuid` stays `null`.
3. **Ordinary desktop tool calls register no named session.** They pass no `sessionUuid`, and `createToolExecutionContext` (`src/server/ToolExecutionContext.ts:79-81`) returns `{}` when `sessionUuid` is undefined — no `getOrCreateSession`, no device binding. So the mirrored device is *unowned*, but the desktop also owns no session UUID that `getSession` would recognize.

There is no long-lived daemon/session client or shared session holder in `desktop-core` (searched the whole `daemon/` package). The CLI reference path (`daemonMcpProxy.ts`) holds a `boundSessionUuid`, but it only *remembers* a UUID the MCP client/agent supplies — it does not invent one. The desktop has no such external agent.

## Blocker — the design decision this needs

To send a UUID that passes `getSession`, the desktop must **establish** a daemon session on the main socket and reuse its UUID. The clean way is to give the desktop a stable per-app-run session identity and thread it through its main-socket tool calls (so `getOrCreateSession` registers it), then hand the same UUID to the stream clients. That has real blast radius and is a product/architecture call:

- Threading a `sessionUuid` through the desktop's main-socket calls means the daemon would **bind the mirrored device to the desktop session** (`getOrCreateSession` acquires the device), which can block a concurrent CLI/agent client on the same device and interacts with the existing device-control session lifecycle (`AutoMobileContent.kt` `deviceControlSession`).
- It also requires making the desktop's `McpDaemonClient` long-lived (or introducing a dedicated session holder) rather than the current per-call throwaway.

Rather than fabricate a UUID that would fail `getSession` (or silently change device-ownership semantics), this PR stops at the seam and surfaces the decision.

## What changed

- `WebRtcStreamSocketClient` and `VideoStreamClient`: added a `sessionUuidProvider: () -> String?` constructor seam (default `{ null }`) and a `sessionUuid` field on their wire request data classes. The provider is resolved per request/connect, so a session established after construction is still picked up. Both wire JSON configs drop nulls (`DaemonJson` `explicitNulls = false`; `VideoStreamClient`'s local `Json` likewise), so the default omits the field and a pre-#4751 daemon / the escape-hatch path is unchanged.
- No construction site changed: `AutoMobileContent.kt` still builds both clients with the default null provider, so desktop streaming behavior is identical to today (still requires the escape hatch). Wiring the provider to a real session is deferred to the design decision above.
- Tests: added coverage on both clients proving the `sessionUuid` field is sent when the provider supplies one and omitted when it returns null.

## Validation

- `./gradlew :desktop-core:test --tests "*WebRtcStreamSocketClientTest" --tests "*VideoStreamClientTest"` — **BUILD SUCCESSFUL** (JDK 21).
- `./gradlew :desktop-core:detektMain :desktop-core:detektTest --no-configuration-cache` — **BUILD SUCCESSFUL** for **both** `detektMain` and `detektTest`, no violations. (Detekt prints its usual "compiler errors during analysis" type-resolution caveat on this Compose module; the real Kotlin compile + tests pass cleanly.)
- `ktfmt --google-style` on all four touched files — clean.
