### PR TITLE
feat(navigation): add automobile:navigation/apps MCP resource

### DIFF
--- a/docs/design-docs/mcp/resources.md
+++ b/docs/design-docs/mcp/resources.md
@@ -34,6 +34,47 @@ Returns the current navigation graph showing:
 
 See [Navigation Graph](nav/index.md) for details.
 
+### Navigation Apps
+
+**URI**: `automobile:navigation/apps`
+
+Lists the apps that have a **persisted** navigation graph, so an agent (or the
+desktop's offline app picker) can choose an app to browse. This resource is
+**device-independent** — it reads persisted data only and requires no connected
+device. An app appears only when it has at least one recorded screen; an empty
+database returns an empty list rather than an error.
+
+Each entry provides:
+
+- `appId` — the application package id (e.g. `com.example.app`)
+- `displayName` — human-readable name when known; currently always `null`
+  because the persisted schema has no display-name column
+- `lastUpdated` — ISO-8601 timestamp of the app record's `updated_at`
+
+Entries are ordered newest-first by the app record's `updated_at`.
+
+**Response shape**:
+
+```json
+{
+  "apps": [
+    {
+      "appId": "com.example.app",
+      "displayName": null,
+      "lastUpdated": "2026-01-02T00:00:00.000Z"
+    }
+  ]
+}
+```
+
+> **`lastUpdated` caveat**: this field reflects the app record's
+> `navigation_apps.updated_at`, which is bumped on the main navigation-recording
+> paths but not by every graph mutation (e.g. `promoteSuggestion`,
+> `updateNodeScreenshot`, `recordBackStack`). It can therefore lag those changes,
+> and the `updated_at` ordering can too — do not treat it as the exact time of
+> the most recent graph mutation. Tracked by
+> [#4931](https://github.com/kaeawc/auto-mobile/issues/4931).
+
 ### Booted Devices
 
 **URI**: `automobile:devices/booted`

--- a/src/db/navigationRepository.ts
+++ b/src/db/navigationRepository.ts
@@ -123,6 +123,31 @@ export class NavigationRepository {
   }
 
   /**
+   * List every app that has a persisted navigation graph, newest-updated first.
+   *
+   * Device-independent: reads only persisted rows so the desktop can populate an
+   * offline app picker. "Has a graph" means at least one recorded screen, so a
+   * bare app row created by `getOrCreateApp`/`setCurrentApp` with no nodes is
+   * excluded via a single EXISTS subquery over navigation_nodes (no row-by-row
+   * probing). app_id is the PRIMARY KEY, so results are already distinct.
+   */
+  async listApps(): Promise<Array<Pick<NavigationApp, "app_id" | "updated_at">>> {
+    const db = this.getDb();
+    return db
+      .selectFrom("navigation_apps")
+      .select(["app_id", "updated_at"])
+      .where(({ exists, selectFrom }) =>
+        exists(
+          selectFrom("navigation_nodes")
+            .select("navigation_nodes.id")
+            .whereRef("navigation_nodes.app_id", "=", "navigation_apps.app_id")
+        )
+      )
+      .orderBy("updated_at", "desc")
+      .execute();
+  }
+
+  /**
    * Get or create a navigation node (screen).
    */
   async getOrCreateNode(

--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -27,6 +27,8 @@ import {
   NavigationGraphNodeDetail,
   NavigationGraphNodeResource,
   NavigationGraphNodeResourceProvider,
+  NavigationAppSummary,
+  NavigationAppListProvider,
   NavigationSuggestionInfo,
   UIState,
   ScrollPosition,
@@ -45,7 +47,7 @@ export type {
  * Provides methods for tracking screen visits, recording navigation events,
  * and querying navigation paths.
  */
-export interface NavigationGraphService extends NavigationGraph, NavigationGraphSummaryProvider, NavigationGraphHistoryProvider, NavigationGraphNodeResourceProvider {
+export interface NavigationGraphService extends NavigationGraph, NavigationGraphSummaryProvider, NavigationGraphHistoryProvider, NavigationGraphNodeResourceProvider, NavigationAppListProvider {
   // App management
   setCurrentApp(appId: string): Promise<void>;
   getCurrentAppId(): string | null;
@@ -1302,6 +1304,21 @@ export class NavigationGraphManager implements NavigationGraphService {
       edges,
       currentScreen: appId === this.currentAppId ? this.currentScreen : null,
     };
+  }
+
+  /**
+   * List every app that has a persisted navigation graph, newest-updated first.
+   * Device-independent (reads persisted rows only) so the desktop can populate an
+   * offline app picker. displayName is null: the persisted schema has no
+   * display-name column (see NavigationAppSummary).
+   */
+  public async listAppsWithGraph(): Promise<NavigationAppSummary[]> {
+    const apps = await this.repository.listApps();
+    return apps.map(app => ({
+      appId: app.app_id,
+      displayName: null,
+      lastUpdated: app.updated_at,
+    }));
   }
 
   /**

--- a/src/features/navigation/NavigationGraphManager.ts
+++ b/src/features/navigation/NavigationGraphManager.ts
@@ -1307,10 +1307,13 @@ export class NavigationGraphManager implements NavigationGraphService {
   }
 
   /**
-   * List every app that has a persisted navigation graph, newest-updated first.
-   * Device-independent (reads persisted rows only) so the desktop can populate an
-   * offline app picker. displayName is null: the persisted schema has no
-   * display-name column (see NavigationAppSummary).
+   * List every app that has a persisted navigation graph, ordered by the app
+   * record's `navigation_apps.updated_at` (newest first). Device-independent
+   * (reads persisted rows only) so the desktop can populate an offline app
+   * picker. displayName is null: the persisted schema has no display-name column
+   * (see NavigationAppSummary). Note that `updated_at` is not bumped by every
+   * graph mutation, so both `lastUpdated` and this ordering can lag some changes
+   * (issue #4931).
    */
   public async listAppsWithGraph(): Promise<NavigationAppSummary[]> {
     const apps = await this.repository.listApps();

--- a/src/server/navigationResources.ts
+++ b/src/server/navigationResources.ts
@@ -7,12 +7,15 @@ import {
   NavigationGraphSummaryProvider,
   NavigationGraphNodeResource,
   NavigationGraphNodeResourceProvider,
-  NavigationGraphHistoryProvider
+  NavigationGraphHistoryProvider,
+  NavigationAppSummary,
+  NavigationAppListProvider
 } from "../utils/interfaces/NavigationGraph";
 import { logger } from "../utils/logger";
 import { defaultTimer } from "../utils/SystemTimer";
 
 export const NAVIGATION_RESOURCE_URIS = {
+  APPS: "automobile:navigation/apps",
   GRAPH: "automobile:navigation/graph",
   GRAPH_WITH_APP_ID: "automobile:navigation/graph?appId={appId}",
   NODE_BY_ID: "automobile:navigation/nodes/{nodeId}",
@@ -27,13 +30,17 @@ export const NAVIGATION_RESOURCE_URIS = {
 
 export type NavigationGraphResourceContent = NavigationGraphSummary;
 export type NavigationNodeResourceContent = NavigationGraphNodeResource;
+export interface NavigationAppsResourceContent {
+  apps: NavigationAppSummary[];
+}
 
 const GRAPH_RESOURCE_UPDATE_DEBOUNCE_MS = 1000;
 
 type NavigationGraphResourceProvider =
   NavigationGraphSummaryProvider &
   NavigationGraphNodeResourceProvider &
-  NavigationGraphHistoryProvider;
+  NavigationGraphHistoryProvider &
+  NavigationAppListProvider;
 
 let navigationGraphProvider: NavigationGraphResourceProvider | null = null;
 
@@ -51,6 +58,7 @@ function scheduleNavigationGraphUpdate(): void {
   updateTimeout = defaultTimer.setTimeout(() => {
     updateTimeout = null;
     void ResourceRegistry.notifyResourcesUpdated([
+      NAVIGATION_RESOURCE_URIS.APPS,
       NAVIGATION_RESOURCE_URIS.GRAPH,
       NAVIGATION_RESOURCE_URIS.HISTORY,
     ]);
@@ -101,6 +109,29 @@ async function getNavigationGraphResource(appId?: string): Promise<ResourceConte
       mimeType: "application/json",
       text: JSON.stringify({
         error: `Failed to retrieve navigation graph: ${error}`
+      }, null, 2)
+    };
+  }
+}
+
+async function getNavigationAppsResource(): Promise<ResourceContent> {
+  const uri = NAVIGATION_RESOURCE_URIS.APPS;
+
+  try {
+    const apps = await getNavigationGraphProvider().listAppsWithGraph();
+    const payload: NavigationAppsResourceContent = { apps };
+    return {
+      uri,
+      mimeType: "application/json",
+      text: JSON.stringify(payload, null, 2)
+    };
+  } catch (error) {
+    logger.error(`[NavigationResources] Failed to list apps with navigation graph: ${error}`);
+    return {
+      uri,
+      mimeType: "application/json",
+      text: JSON.stringify({
+        error: `Failed to list apps with navigation graph: ${error}`
       }, null, 2)
     };
   }
@@ -277,6 +308,14 @@ export function registerNavigationResources(options: {
   }
 
   attachGraphUpdateListener(getNavigationGraphProvider());
+
+  ResourceRegistry.register(
+    NAVIGATION_RESOURCE_URIS.APPS,
+    "Navigation Apps",
+    "Apps that have a persisted navigation graph (appId, displayName, lastUpdated). No connected device required.",
+    "application/json",
+    () => getNavigationAppsResource()
+  );
 
   ResourceRegistry.register(
     NAVIGATION_RESOURCE_URIS.GRAPH,

--- a/src/server/navigationResources.ts
+++ b/src/server/navigationResources.ts
@@ -30,6 +30,13 @@ export const NAVIGATION_RESOURCE_URIS = {
 
 export type NavigationGraphResourceContent = NavigationGraphSummary;
 export type NavigationNodeResourceContent = NavigationGraphNodeResource;
+/**
+ * Payload of the `automobile:navigation/apps` resource: apps that have a
+ * persisted navigation graph. Each entry's `lastUpdated` reflects the app
+ * record's `navigation_apps.updated_at`, which can lag graph mutations that do
+ * not touch the parent timestamp (issue #4931); it is not the exact time of the
+ * most recent graph change.
+ */
 export interface NavigationAppsResourceContent {
   apps: NavigationAppSummary[];
 }

--- a/src/utils/interfaces/NavigationGraph.ts
+++ b/src/utils/interfaces/NavigationGraph.ts
@@ -245,6 +245,31 @@ export interface NavigationGraphHistoryPage {
 }
 
 /**
+ * Summary of an app that has a persisted navigation graph. Enables enumerating
+ * apps for an offline picker without a connected device.
+ */
+export interface NavigationAppSummary {
+  /** Application package id (e.g. "com.example.app"). */
+  appId: string;
+  /**
+   * Human-readable name when known. The persisted navigation schema has no
+   * display-name column, so this is currently always null; the field exists so
+   * a name source can be wired without a breaking response-shape change.
+   */
+  displayName: string | null;
+  /** ISO-8601 timestamp of the app's most recent navigation-graph update. */
+  lastUpdated: string;
+}
+
+/**
+ * Provider that enumerates apps which have a persisted navigation graph.
+ * Device-independent — reads only persisted rows.
+ */
+export interface NavigationAppListProvider {
+  listAppsWithGraph(): Promise<NavigationAppSummary[]>;
+}
+
+/**
  * Provider interface for navigation graph summaries.
  */
 export interface NavigationGraphSummaryProvider {

--- a/src/utils/interfaces/NavigationGraph.ts
+++ b/src/utils/interfaces/NavigationGraph.ts
@@ -257,7 +257,13 @@ export interface NavigationAppSummary {
    * a name source can be wired without a breaking response-shape change.
    */
   displayName: string | null;
-  /** ISO-8601 timestamp of the app's most recent navigation-graph update. */
+  /**
+   * ISO-8601 timestamp of the app record's `navigation_apps.updated_at`. This is
+   * bumped on the main navigation-recording paths but NOT by every graph mutation
+   * (e.g. promoteSuggestion / updateNodeScreenshot / recordBackStack do not touch
+   * it), so it can lag those changes. Do not treat it as the exact time of the
+   * most recent graph mutation. Tracked by issue #4931.
+   */
   lastUpdated: string;
 }
 

--- a/test/db/navigationRepository.test.ts
+++ b/test/db/navigationRepository.test.ts
@@ -543,4 +543,51 @@ describe("NavigationRepository", () => {
       expect(new Set(seenIds).size).toBe(4);
     });
   });
+
+  describe("listApps", () => {
+    test("returns an empty list when no apps exist", async () => {
+      const apps = await repo.listApps();
+      expect(apps).toEqual([]);
+    });
+
+    test("returns distinct apps that have persisted nodes, newest-updated first", async () => {
+      await repo.getOrCreateApp("com.example.a");
+      await repo.getOrCreateNode("com.example.a", "HomeA", 1000);
+      await repo.getOrCreateApp("com.example.b");
+      await repo.getOrCreateNode("com.example.b", "HomeB", 1000);
+      // Revisiting a screen must not duplicate the app row.
+      await repo.getOrCreateNode("com.example.b", "HomeB", 2000);
+
+      // Pin distinct updated_at values so ordering is deterministic.
+      await db
+        .updateTable("navigation_apps")
+        .set({ updated_at: "2026-01-01T00:00:00.000Z" })
+        .where("app_id", "=", "com.example.a")
+        .execute();
+      await db
+        .updateTable("navigation_apps")
+        .set({ updated_at: "2026-01-02T00:00:00.000Z" })
+        .where("app_id", "=", "com.example.b")
+        .execute();
+
+      const apps = await repo.listApps();
+
+      expect(apps).toEqual([
+        { app_id: "com.example.b", updated_at: "2026-01-02T00:00:00.000Z" },
+        { app_id: "com.example.a", updated_at: "2026-01-01T00:00:00.000Z" },
+      ]);
+    });
+
+    test("excludes apps that have no persisted nodes", async () => {
+      // Bare app row with no recorded screens (e.g. setCurrentApp only).
+      await repo.getOrCreateApp("com.example.empty");
+      await repo.getOrCreateApp("com.example.withnodes");
+      await repo.getOrCreateNode("com.example.withnodes", "Home", 1000);
+
+      const apps = await repo.listApps();
+
+      expect(apps).toHaveLength(1);
+      expect(apps[0]?.app_id).toBe("com.example.withnodes");
+    });
+  });
 });

--- a/test/fakes/FakeNavigationGraphManager.ts
+++ b/test/fakes/FakeNavigationGraphManager.ts
@@ -15,14 +15,16 @@ import {
   NavigationGraphSummaryProvider,
   NavigationGraphNodeDetail,
   NavigationGraphNodeResource,
-  NavigationGraphNodeResourceProvider
+  NavigationGraphNodeResourceProvider,
+  NavigationAppSummary,
+  NavigationAppListProvider
 } from "../../src/utils/interfaces/NavigationGraph";
 
 /**
  * Fake implementation of NavigationGraph for testing.
  * Allows full control over navigation graph state and behavior.
  */
-export class FakeNavigationGraphManager implements NavigationGraph, NavigationGraphSummaryProvider, NavigationGraphNodeResourceProvider {
+export class FakeNavigationGraphManager implements NavigationGraph, NavigationGraphSummaryProvider, NavigationGraphNodeResourceProvider, NavigationAppListProvider {
   private currentAppId: string | null = null;
   private currentScreen: string | null = null;
   private nodes: Map<string, NavigationNode> = new Map();
@@ -33,6 +35,7 @@ export class FakeNavigationGraphManager implements NavigationGraph, NavigationGr
   private nextNodeId = 1;
   private nextEdgeId = 1;
   private graphUpdateListeners: Array<() => void> = [];
+  private appsWithGraph: NavigationAppSummary[] = [];
 
   // Call tracking
   private methodCalls: Map<string, any[][]> = new Map();
@@ -77,6 +80,13 @@ export class FakeNavigationGraphManager implements NavigationGraph, NavigationGr
       to: edge.to,
       toolName: edge.interaction?.toolName ?? null
     });
+  }
+
+  /**
+   * Set the apps that listAppsWithGraph will return.
+   */
+  setAppsWithGraph(apps: NavigationAppSummary[]): void {
+    this.appsWithGraph = [...apps];
   }
 
   /**
@@ -145,7 +155,13 @@ export class FakeNavigationGraphManager implements NavigationGraph, NavigationGr
     this.nextEdgeId = 1;
     this.graphUpdateListeners = [];
     this.pathResult = null;
+    this.appsWithGraph = [];
     this.methodCalls.clear();
+  }
+
+  async listAppsWithGraph(): Promise<NavigationAppSummary[]> {
+    this.trackCall("listAppsWithGraph", []);
+    return [...this.appsWithGraph];
   }
 
   // ==================== NavigationGraph Interface ====================

--- a/test/features/navigation/NavigationGraphManager.test.ts
+++ b/test/features/navigation/NavigationGraphManager.test.ts
@@ -79,6 +79,35 @@ describe("NavigationGraphManager", () => {
     });
   });
 
+  describe("listAppsWithGraph", () => {
+    test("maps persisted apps with nodes to summaries and omits display name", async () => {
+      const repo = new NavigationRepository(harness.db);
+      await repo.getOrCreateApp("com.example.graph");
+      await repo.getOrCreateNode("com.example.graph", "Home", 1000);
+      await harness.db
+        .updateTable("navigation_apps")
+        .set({ updated_at: "2026-01-05T00:00:00.000Z" })
+        .where("app_id", "=", "com.example.graph")
+        .execute();
+
+      const apps = await manager.listAppsWithGraph();
+
+      const seeded = apps.find(app => app.appId === "com.example.graph");
+      expect(seeded).toEqual({
+        appId: "com.example.graph",
+        displayName: null,
+        lastUpdated: "2026-01-05T00:00:00.000Z",
+      });
+    });
+
+    test("excludes apps that have a row but no persisted nodes", async () => {
+      // beforeEach sets current app "com.test.app" via setCurrentApp, which
+      // creates the app row but records no nodes — so it must not appear.
+      const apps = await manager.listAppsWithGraph();
+      expect(apps.some(app => app.appId === "com.test.app")).toBe(false);
+    });
+  });
+
   describe("setCurrentApp", () => {
     test("should set the current app", async () => {
       await manager.setCurrentApp("com.example.app");

--- a/test/server/resources/navigationGraph.test.ts
+++ b/test/server/resources/navigationGraph.test.ts
@@ -4,6 +4,7 @@ import {
   NAVIGATION_RESOURCE_URIS,
   NavigationGraphResourceContent,
   NavigationNodeResourceContent,
+  NavigationAppsResourceContent,
   setNavigationGraphProvider
 } from "../../../src/server/navigationResources";
 import { FakeNavigationGraphManager } from "../../fakes/FakeNavigationGraphManager";
@@ -196,6 +197,91 @@ describe("MCP Navigation Graph Resource", () => {
     expect(nodeResource.isCurrentScreen).toBe(true);
     expect(nodeResource.edgesFrom).toHaveLength(1);
     expect(nodeResource.edgesTo).toHaveLength(0);
+  });
+
+  test("should include navigation apps resource in list", async () => {
+    const { client } = fixture.getContext();
+
+    const listResourcesResponseSchema = z.object({
+      resources: z.array(z.object({
+        uri: z.string(),
+        name: z.string().optional(),
+        description: z.string().optional(),
+        mimeType: z.string().optional()
+      }))
+    });
+
+    const result = await client.request({
+      method: "resources/list",
+      params: {}
+    }, listResourcesResponseSchema);
+
+    const resource = result.resources.find(
+      (r: any) => r.uri === NAVIGATION_RESOURCE_URIS.APPS
+    );
+
+    expect(resource).toBeDefined();
+    expect(resource?.name).toBe("Navigation Apps");
+    expect(resource?.mimeType).toBe("application/json");
+  });
+
+  test("should list apps that have a persisted navigation graph", async () => {
+    fakeGraph.setAppsWithGraph([
+      { appId: "com.example.b", displayName: null, lastUpdated: "2026-01-02T00:00:00.000Z" },
+      { appId: "com.example.a", displayName: null, lastUpdated: "2026-01-01T00:00:00.000Z" }
+    ]);
+
+    const { client } = fixture.getContext();
+    const readResourceResponseSchema = z.object({
+      contents: z.array(z.object({
+        uri: z.string(),
+        mimeType: z.string().optional(),
+        text: z.string().optional()
+      }))
+    });
+
+    const result = await client.request({
+      method: "resources/read",
+      params: {
+        uri: NAVIGATION_RESOURCE_URIS.APPS
+      }
+    }, readResourceResponseSchema);
+
+    const content = result.contents[0];
+    expect(content.uri).toBe(NAVIGATION_RESOURCE_URIS.APPS);
+    expect(content.mimeType).toBe("application/json");
+    expect(content.text).toBeDefined();
+
+    const payload: NavigationAppsResourceContent = JSON.parse(content.text!);
+    expect(payload.apps).toHaveLength(2);
+    expect(payload.apps[0]?.appId).toBe("com.example.b");
+    expect(payload.apps[0]?.lastUpdated).toBe("2026-01-02T00:00:00.000Z");
+    expect(payload.apps[0]?.displayName).toBeNull();
+    expect(payload.apps[1]?.appId).toBe("com.example.a");
+  });
+
+  test("should return an empty list when no apps have a persisted graph", async () => {
+    const { client } = fixture.getContext();
+    const readResourceResponseSchema = z.object({
+      contents: z.array(z.object({
+        uri: z.string(),
+        mimeType: z.string().optional(),
+        text: z.string().optional()
+      }))
+    });
+
+    const result = await client.request({
+      method: "resources/read",
+      params: {
+        uri: NAVIGATION_RESOURCE_URIS.APPS
+      }
+    }, readResourceResponseSchema);
+
+    const content = result.contents[0];
+    expect(content.text).toBeDefined();
+
+    const payload: NavigationAppsResourceContent = JSON.parse(content.text!);
+    expect(payload.apps).toEqual([]);
   });
 
   test("should return navigation node resource by screen name", async () => {


### PR DESCRIPTION
## Summary

Adds an MCP **resource** `automobile:navigation/apps` that enumerates apps which have a **persisted** navigation graph, with no connected device required. This closes the only remaining gap for the desktop's offline Navigation browse (Phase C of [#4837](https://github.com/kaeawc/auto-mobile/issues/4837)): the per-app read (`automobile:navigation/graph?appId=…`) was already device-optional, so this PR supplies the enumeration.

Closes [#4910](https://github.com/kaeawc/auto-mobile/issues/4910).

## Changes

- **`NavigationRepository.listApps()`** (`src/db/navigationRepository.ts`) — a single query over the persisted nav data: selects `app_id` + `updated_at` from `navigation_apps`, filtered by an `EXISTS` subquery over `navigation_nodes` so an app row with no recorded screens is excluded, ordered newest-updated first. No row-by-row probing. `app_id` is the PRIMARY KEY, so rows are distinct.
- **`NavigationGraphManager.listAppsWithGraph()`** (`src/features/navigation/NavigationGraphManager.ts`) — maps repository rows to `NavigationAppSummary` (`appId`, `displayName`, `lastUpdated`). `displayName` is always `null`: the `navigation_apps` schema has no display-name column, so no column was invented; the nullable field exists so a name source can be wired later without a breaking response-shape change.
- **`automobile:navigation/apps` resource** (`src/server/navigationResources.ts`) — registered alongside the existing navigation resources and included in the debounced update-notification set. Reads via the existing device-optional provider pattern; an empty DB yields `{ "apps": [] }`, not an error. Errors are logged and returned as a typed error payload, matching the sibling handlers.
- New interfaces `NavigationAppSummary` / `NavigationAppListProvider` (`src/utils/interfaces/NavigationGraph.ts`); `NavigationGraphService` now extends the list provider so the manager is compile-enforced to implement it.

### Response shape

`automobile:navigation/apps` (mimeType `application/json`):

```json
{
  "apps": [
    { "appId": "com.example.b", "displayName": null, "lastUpdated": "2026-01-02T00:00:00.000Z" },
    { "appId": "com.example.a", "displayName": null, "lastUpdated": "2026-01-01T00:00:00.000Z" }
  ]
}
```

## Testing

- `bun test test/db/navigationRepository.test.ts test/server/resources/navigationGraph.test.ts test/features/navigation/NavigationGraphManager.test.ts` — 137 pass, 0 fail (new tests run sub-millisecond, in-memory / fake DB).
- `bun test` (full suite) — 12411 pass, 13 skip, 0 fail.
- `bun run typecheck` — no new type errors.
- `bun run lint` — clean (all boundary guards pass).

New tests (written red-first against the acceptance criteria):
- Repository: empty DB → `[]`; distinct apps with nodes ordered newest-first; app rows without nodes excluded.
- Manager: rows map to `NavigationAppSummary` with `displayName: null`; a current-app row with no nodes is excluded.
- Resource: listed in `resources/list` as "Navigation Apps"; lists apps with `appId` + `lastUpdated`; empty DB → empty list. Existing graph/history/node resource tests remain green (non-regression).

## Acceptance criteria

- [x] MCP resource `automobile:navigation/apps` lists apps with a persisted nav graph: `appId` + display name (null; schema has no column) + `lastUpdated`. No connected device required.
- [x] Backed by a repository query (`NavigationRepository.listApps()`) over the persisted nav data keyed by `app_id`.
- [x] Does not regress existing navigation resources/tools. Unit-tested (interface + fake DB / in-memory DB).

## Notes

- Protocol / public-surface change → **hand-off merge to the maintainer** per ship-issue. Auto-merge is not enabled.
- MCP resources are not represented in `schemas/tool-definitions.json` (that artifact is tools-only; the pre-commit regenerator confirmed it unchanged), so no schema regeneration was required.
- The context-threshold benchmark is report-only (no thresholds configured, not wired into PR CI), so adding a resource does not trip a gate. The `metadata.baseline.resources` figure in `scripts/context-thresholds.json` will drift slightly; left untouched since it is informational and not enforced.
