### PR TITLE
security: session-scope the recording archive and recording/test-recording sockets

### DIFF
--- a/src/daemon/socketServer/ConfigSocketServer.ts
+++ b/src/daemon/socketServer/ConfigSocketServer.ts
@@ -1,6 +1,7 @@
 import { Timer, defaultTimer } from "../../utils/SystemTimer";
 import { RequestResponseSocketServer } from "./RequestResponseSocketServer";
 import { SocketRequest, SocketResponse } from "./SocketServerTypes";
+import type { StreamSocketAuthenticator } from "../streamSocketAuth";
 
 export type ConfigSocketMethod = "config/get" | "config/set";
 
@@ -11,6 +12,8 @@ export interface ConfigSocketRequest<
   id: string;
   type: TRequestType;
   method: ConfigSocketMethod;
+  /** Daemon session on whose behalf a mutating request is made (issue #4752). */
+  sessionUuid?: string;
   params?: {
     config?: TInput | null;
   };
@@ -54,6 +57,13 @@ interface ConfigSocketServerOptions<
   methodLabel: string;
   getConfig: () => Promise<TConfig>;
   updateConfig: (update: TInput | null) => Promise<ConfigSocketUpdateResult<TConfig>>;
+  /**
+   * Authorizes mutating (`config/set`) requests (issue #4752). When provided, an
+   * unauthenticated or cross-session request is rejected before the config
+   * change — which can trigger global archive eviction — is applied. Omitted by
+   * sockets that carry no session-scoped side effects.
+   */
+  authenticator?: StreamSocketAuthenticator;
 }
 
 /**
@@ -75,6 +85,7 @@ export class ConfigSocketServer<
   private readonly methodLabel: string;
   private readonly getConfig: () => Promise<TConfig>;
   private readonly updateConfig: (update: TInput | null) => Promise<ConfigSocketUpdateResult<TConfig>>;
+  private readonly authenticator?: StreamSocketAuthenticator;
 
   constructor(
     options: ConfigSocketServerOptions<TConfig, TInput, TResponseType, TEvictedKey>
@@ -85,6 +96,7 @@ export class ConfigSocketServer<
     this.methodLabel = options.methodLabel;
     this.getConfig = options.getConfig;
     this.updateConfig = options.updateConfig;
+    this.authenticator = options.authenticator;
   }
 
   protected async handleRequest(
@@ -101,6 +113,10 @@ export class ConfigSocketServer<
         };
       }
       case "config/set": {
+        // Authorize before the mutation: lowering maxArchiveSizeMb here triggers
+        // global archive eviction, so a cross-session request must be rejected
+        // first (issue #4752).
+        this.authenticator?.authorize({ sessionUuid: request.sessionUuid });
         if (!request.params || !("config" in request.params)) {
           throw new Error("config/set requires params.config");
         }

--- a/src/daemon/testRecordingSocketServer.ts
+++ b/src/daemon/testRecordingSocketServer.ts
@@ -12,6 +12,10 @@ import {
   TestRecordingResponse,
 } from "./testRecordingSocketTypes";
 import { TEST_RECORDING_SOCKET_CONFIG } from "./daemonFiles";
+import {
+  createDefaultStreamSocketAuthenticator,
+  type StreamSocketAuthenticator,
+} from "./streamSocketAuth";
 
 const resolveDevice = async (
   deviceId?: string,
@@ -52,8 +56,15 @@ export class TestRecordingSocketServer extends RequestResponseSocketServer<
   TestRecordingCommand,
   TestRecordingResponse
 > {
-  constructor(socketPath: string = getSocketPath(TEST_RECORDING_SOCKET_CONFIG), timer: Timer = defaultTimer) {
+  private readonly authenticator: StreamSocketAuthenticator;
+
+  constructor(
+    socketPath: string = getSocketPath(TEST_RECORDING_SOCKET_CONFIG),
+    timer: Timer = defaultTimer,
+    authenticator: StreamSocketAuthenticator = createDefaultStreamSocketAuthenticator("testRecording")
+  ) {
     super(socketPath, timer, "TestRecording");
+    this.authenticator = authenticator;
   }
 
   protected async handleRequest(
@@ -66,6 +77,10 @@ export class TestRecordingSocketServer extends RequestResponseSocketServer<
 
     switch (command) {
       case "start": {
+        // Authorize before touching device state: an unauthenticated or
+        // cross-session caller cannot start a recording on another session's
+        // device (issue #4752).
+        this.authenticator.authorize({ sessionUuid: request.sessionUuid, deviceId: request.deviceId });
         const platform = ensurePlatform(request.platform);
         const device = await resolveDevice(request.deviceId, platform);
         const result = await startTestRecording(device);
@@ -78,6 +93,15 @@ export class TestRecordingSocketServer extends RequestResponseSocketServer<
         };
       }
       case "stop": {
+        // Authorize the stop against the active recording's device so a session
+        // that does not own it cannot stop another session's recording — the
+        // recordingId-only guard in stopTestRecording is not an ownership check
+        // (issue #4752).
+        const active = getTestRecordingStatus();
+        this.authenticator.authorize({
+          sessionUuid: request.sessionUuid,
+          deviceId: request.deviceId ?? active?.deviceId,
+        });
         const result = await stopTestRecording(request.recordingId, request.planName);
         return {
           success: true,
@@ -93,6 +117,9 @@ export class TestRecordingSocketServer extends RequestResponseSocketServer<
         };
       }
       case "status": {
+        // Status reveals the active recording's device/id; require a live
+        // session so it is not readable by an unauthenticated caller (issue #4752).
+        this.authenticator.authorize({ sessionUuid: request.sessionUuid, deviceId: request.deviceId });
         const recording = getTestRecordingStatus();
         if (!recording) {
           return { success: true };

--- a/src/daemon/testRecordingSocketTypes.ts
+++ b/src/daemon/testRecordingSocketTypes.ts
@@ -7,6 +7,8 @@ export interface TestRecordingCommand {
   platform?: Platform;
   recordingId?: string;
   planName?: string;
+  /** Daemon session on whose behalf the command is made (issue #4752). */
+  sessionUuid?: string;
 }
 
 export interface TestRecordingResponse {

--- a/src/daemon/videoRecordingSocketServer.ts
+++ b/src/daemon/videoRecordingSocketServer.ts
@@ -2,6 +2,10 @@ import { Timer, defaultTimer } from "../utils/SystemTimer";
 import { ConfigSocketServer, getSocketPath } from "./socketServer/index";
 import { getVideoRecordingConfig, updateVideoRecordingConfig } from "../server/videoRecordingManager";
 import { VIDEO_RECORDING_SOCKET_CONFIG } from "./daemonFiles";
+import {
+  createDefaultStreamSocketAuthenticator,
+  type StreamSocketAuthenticator,
+} from "./streamSocketAuth";
 import type { VideoRecordingConfig, VideoRecordingConfigInput } from "../models";
 
 interface VideoRecordingSocketServerDependencies {
@@ -31,7 +35,10 @@ export class VideoRecordingSocketServer extends ConfigSocketServer<
   constructor(
     socketPath: string = getSocketPath(VIDEO_RECORDING_SOCKET_CONFIG),
     timer: Timer = defaultTimer,
-    dependencies: VideoRecordingSocketServerDependencies = defaultDependencies
+    dependencies: VideoRecordingSocketServerDependencies = defaultDependencies,
+    authenticator: StreamSocketAuthenticator = createDefaultStreamSocketAuthenticator(
+      "videoRecording config/set"
+    )
   ) {
     super({
       socketPath,
@@ -45,6 +52,7 @@ export class VideoRecordingSocketServer extends ConfigSocketServer<
         const { config, evictedRecordingIds } = await dependencies.updateConfig(update);
         return { config, evictedItems: evictedRecordingIds };
       },
+      authenticator,
     });
   }
 }

--- a/src/db/migrations/2026_07_31_000_video_recordings_owner_session.ts
+++ b/src/db/migrations/2026_07_31_000_video_recordings_owner_session.ts
@@ -1,0 +1,35 @@
+import type { Kysely } from "kysely";
+
+/**
+ * Session-scope the video recording archive (issue #4752).
+ *
+ * Adds a nullable `owner_session_uuid` column recording the daemon session that
+ * started a recording. The column is deliberately nullable: rows that predate
+ * this migration have no known owner and keep a NULL owner. The read policy
+ * (see `VideoRecordingRepository`) treats a NULL-owner row as legacy/unowned and
+ * readable by any session, while a row with a non-null owner is only returned to
+ * that owner — so this migration hardens new recordings without orphaning the
+ * existing archive.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("video_recordings")
+    .addColumn("owner_session_uuid", "text")
+    .execute();
+
+  await db.schema
+    .createIndex("idx_video_recordings_owner_session")
+    .ifNotExists()
+    .on("video_recordings")
+    .column("owner_session_uuid")
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropIndex("idx_video_recordings_owner_session").execute();
+
+  await db.schema
+    .alterTable("video_recordings")
+    .dropColumn("owner_session_uuid")
+    .execute();
+}

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -545,6 +545,10 @@ export interface VideoRecordingsTable {
   last_accessed_at: string;
   config_json: string;
   highlights_json: string | null;
+  // Daemon session that started the recording (issue #4752). Nullable: rows that
+  // predate the owner-scoping migration have no known owner and are treated as
+  // legacy/unowned.
+  owner_session_uuid: string | null;
 }
 
 export interface VideoRecordingConfigsTable {

--- a/src/db/videoRecordingRepository.ts
+++ b/src/db/videoRecordingRepository.ts
@@ -1,4 +1,4 @@
-import type { Kysely } from "kysely";
+import type { Kysely, SelectQueryBuilder } from "kysely";
 import { ensureMigrations, getDatabase } from "./database";
 import type {
   VideoFormat,
@@ -16,9 +16,26 @@ export interface VideoRecordingRecord extends VideoRecordingMetadata {
   deviceId: string;
   platform: "android" | "ios";
   status: VideoRecordingStatus;
+  /**
+   * Daemon session that started the recording (issue #4752). Absent for legacy
+   * rows written before owner-scoping, which stay readable by any session.
+   */
+  ownerSessionUuid?: string;
 }
 
-export interface VideoRecordingQuery {
+/**
+ * Owner scoping for a read (issue #4752). When `ownerSessionUuid` is set, the
+ * query is restricted to rows the caller may see: rows owned by that session,
+ * plus legacy rows with a NULL owner (which predate scoping and would otherwise
+ * become permanently unreadable). When absent, no owner filter is applied and
+ * callers see every row — reserved for internal/maintenance paths (eviction,
+ * restart interruption sweep) that operate on the whole archive.
+ */
+export interface VideoRecordingOwnerScope {
+  ownerSessionUuid?: string;
+}
+
+export interface VideoRecordingQuery extends VideoRecordingOwnerScope {
   status?: VideoRecordingStatus | VideoRecordingStatus[];
   deviceId?: string;
   platform?: "android" | "ios";
@@ -70,7 +87,29 @@ function toRecord(row: DbVideoRecording): VideoRecordingRecord {
     lastAccessedAt: row.last_accessed_at,
     config: parseConfig(row.config_json),
     highlights: parseHighlights(row.highlights_json ?? null),
+    ownerSessionUuid: row.owner_session_uuid ?? undefined,
   };
+}
+
+/**
+ * Restrict a `video_recordings` select to rows the given session may read
+ * (issue #4752): rows it owns, plus legacy NULL-owner rows that predate scoping.
+ * A no-op when `ownerSessionUuid` is undefined, preserving the unscoped
+ * whole-archive reads used by internal maintenance paths.
+ */
+function applyOwnerScope<O>(
+  builder: SelectQueryBuilder<Database, "video_recordings", O>,
+  ownerSessionUuid?: string
+): SelectQueryBuilder<Database, "video_recordings", O> {
+  if (!ownerSessionUuid) {
+    return builder;
+  }
+  return builder.where(eb =>
+    eb.or([
+      eb("owner_session_uuid", "is", null),
+      eb("owner_session_uuid", "=", ownerSessionUuid),
+    ])
+  );
 }
 
 function buildUpdatePayload(update: Partial<VideoRecordingRecord>): VideoRecordingUpdate {
@@ -124,6 +163,9 @@ function buildUpdatePayload(update: Partial<VideoRecordingRecord>): VideoRecordi
   if (update.highlights !== undefined) {
     payload.highlights_json = JSON.stringify(update.highlights ?? []);
   }
+  if (update.ownerSessionUuid !== undefined) {
+    payload.owner_session_uuid = update.ownerSessionUuid ?? null;
+  }
 
   return payload;
 }
@@ -163,6 +205,7 @@ export class VideoRecordingRepository {
       last_accessed_at: record.lastAccessedAt,
       config_json: JSON.stringify(record.config),
       highlights_json: record.highlights ? JSON.stringify(record.highlights) : null,
+      owner_session_uuid: record.ownerSessionUuid ?? null,
     };
 
     await db
@@ -189,6 +232,7 @@ export class VideoRecordingRepository {
           last_accessed_at: row.last_accessed_at,
           config_json: row.config_json,
           highlights_json: row.highlights_json,
+          owner_session_uuid: row.owner_session_uuid,
         })
       )
       .execute();
@@ -210,13 +254,17 @@ export class VideoRecordingRepository {
       .execute();
   }
 
-  async getRecording(recordingId: string): Promise<VideoRecordingRecord | null> {
+  async getRecording(
+    recordingId: string,
+    scope: VideoRecordingOwnerScope = {}
+  ): Promise<VideoRecordingRecord | null> {
     const db = await this.getDb();
-    const row = await db
+    let builder = db
       .selectFrom("video_recordings")
       .selectAll()
-      .where("recording_id", "=", recordingId)
-      .executeTakeFirst();
+      .where("recording_id", "=", recordingId);
+    builder = applyOwnerScope(builder, scope.ownerSessionUuid);
+    const row = await builder.executeTakeFirst();
 
     return row ? toRecord(row) : null;
   }
@@ -227,6 +275,7 @@ export class VideoRecordingRepository {
       .selectFrom("video_recordings")
       .selectAll();
 
+    builder = applyOwnerScope(builder, query.ownerSessionUuid);
     if (query.status !== undefined) {
       const statuses = Array.isArray(query.status) ? query.status : [query.status];
       builder = builder.where("status", "in", statuses);

--- a/src/server/videoRecordingManager.ts
+++ b/src/server/videoRecordingManager.ts
@@ -52,6 +52,12 @@ interface StartVideoRecordingRequest {
   outputName?: string;
   maxDurationSeconds?: number;
   highlights?: VideoRecordingHighlightInput[];
+  /**
+   * Daemon session that owns this recording (issue #4752). Persisted so later
+   * reads/stops can be scoped to the owner; omitted for internal callers that
+   * do not carry a session (the recording stays legacy/unowned).
+   */
+  ownerSessionUuid?: string;
 }
 
 interface StopVideoRecordingResult {
@@ -597,6 +603,7 @@ export async function startVideoRecording(
     endedAt: undefined,
     lastAccessedAt: active.startedAt,
     config: active.config,
+    ownerSessionUuid: request.ownerSessionUuid,
   });
 
   const highlightSession = createHighlightSession(
@@ -710,21 +717,26 @@ export async function listActiveVideoRecordings(
   });
 }
 
-export async function listVideoRecordings(): Promise<VideoRecordingMetadata[]> {
+export async function listVideoRecordings(
+  scope: { ownerSessionUuid?: string } = {}
+): Promise<VideoRecordingMetadata[]> {
   const { recordingRepository } = await getVideoRecordingDependencies();
   const recordings = await recordingRepository.listRecordings({
     status: ["completed", "interrupted"],
     orderByLastAccessed: "desc",
+    ownerSessionUuid: scope.ownerSessionUuid,
   });
   return recordings.map(toMetadata);
 }
 
 export async function getVideoRecordingMetadata(
   recordingId: string,
-  options?: { touch?: boolean }
+  options?: { touch?: boolean; ownerSessionUuid?: string }
 ): Promise<VideoRecordingMetadata | null> {
   const { recordingRepository, now } = await getVideoRecordingDependencies();
-  const record = await recordingRepository.getRecording(recordingId);
+  const record = await recordingRepository.getRecording(recordingId, {
+    ownerSessionUuid: options?.ownerSessionUuid,
+  });
   if (!record || record.status === "recording") {
     return null;
   }
@@ -740,10 +752,17 @@ export async function getVideoRecordingMetadata(
   return metadata;
 }
 
-export async function getLatestVideoRecordingMetadata(): Promise<VideoRecordingMetadata | null> {
+export async function getLatestVideoRecordingMetadata(
+  scope: { ownerSessionUuid?: string } = {}
+): Promise<VideoRecordingMetadata | null> {
   const { recordingRepository } = await getVideoRecordingDependencies();
-  const latest = await recordingRepository.getLatestRecording();
-  return latest ? toMetadata(latest) : null;
+  const recordings = await recordingRepository.listRecordings({
+    status: ["completed", "interrupted"],
+    orderByLastAccessed: "desc",
+    limit: 1,
+    ownerSessionUuid: scope.ownerSessionUuid,
+  });
+  return recordings[0] ? toMetadata(recordings[0]) : null;
 }
 
 async function deleteVideoRecording(recordingId: string): Promise<boolean> {

--- a/src/server/videoRecordingResources.ts
+++ b/src/server/videoRecordingResources.ts
@@ -7,7 +7,45 @@ import {
 import { buildVideoArchiveItemUri, VIDEO_RESOURCE_URIS } from "./videoRecordingResourceUris";
 import { logger } from "../utils/logger";
 import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
 import type { VideoRecordingMetadata } from "../models";
+
+/**
+ * Absolute root every archived recording must live under. A DB row's
+ * `file_path` is resolved against this and rejected if it escapes — closing the
+ * arbitrary-file-read + base64-exfil vector where a poisoned/absolute
+ * `file_path` would otherwise be read straight off disk (issue #4752, the
+ * defense-in-depth confinement item). Mirrors `VideoRecorderService`'s archive
+ * root so a legitimately-stored recording always resolves inside it.
+ */
+export const DEFAULT_VIDEO_ARCHIVE_ROOT = path.join(
+  os.homedir(),
+  ".auto-mobile",
+  "video-archive"
+);
+
+/**
+ * Resolve a stored file path and assert it is contained within `archiveRoot`.
+ * Throws when the path escapes the archive (absolute path outside the root,
+ * `..` traversal, or a symlink-style sibling), so the read never reaches
+ * arbitrary files. Returns the resolved, confined absolute path.
+ */
+export function assertWithinArchiveRoot(filePath: string, archiveRoot: string): string {
+  const resolvedRoot = path.resolve(archiveRoot);
+  const resolved = path.resolve(resolvedRoot, filePath);
+  const relative = path.relative(resolvedRoot, resolved);
+  const escapes =
+    relative === ".." ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative);
+  if (escapes) {
+    throw new Error(
+      `Refusing to read recording file outside the archive root: ${filePath}`
+    );
+  }
+  return resolved;
+}
 
 /**
  * The data-store surface the resource handlers depend on. Injecting it keeps the
@@ -15,10 +53,15 @@ import type { VideoRecordingMetadata } from "../models";
  * database (issue #3067) or touching the real filesystem.
  */
 export interface VideoRecordingResourceStore {
-  getLatest(): Promise<VideoRecordingMetadata | null>;
-  getById(recordingId: string, options?: { touch?: boolean }): Promise<VideoRecordingMetadata | null>;
-  list(): Promise<VideoRecordingMetadata[]>;
+  getLatest(scope?: { ownerSessionUuid?: string }): Promise<VideoRecordingMetadata | null>;
+  getById(
+    recordingId: string,
+    options?: { touch?: boolean; ownerSessionUuid?: string }
+  ): Promise<VideoRecordingMetadata | null>;
+  list(scope?: { ownerSessionUuid?: string }): Promise<VideoRecordingMetadata[]>;
   readFile(filePath: string): Promise<Buffer>;
+  /** Root every recording file must be confined to before it is read. */
+  archiveRoot: string;
 }
 
 const defaultVideoRecordingResourceStore: VideoRecordingResourceStore = {
@@ -26,6 +69,7 @@ const defaultVideoRecordingResourceStore: VideoRecordingResourceStore = {
   getById: getVideoRecordingMetadata,
   list: listVideoRecordings,
   readFile: fs.readFile,
+  archiveRoot: DEFAULT_VIDEO_ARCHIVE_ROOT,
 };
 
 function getVideoMimeType(metadata: VideoRecordingMetadata): string {
@@ -52,7 +96,11 @@ export async function buildVideoResourceContent(
   }
 
   try {
-    const fileBuffer = await store.readFile(metadata.filePath);
+    // Confine the read to the archive root before touching disk: a poisoned or
+    // absolute `file_path` must not turn this resource into an arbitrary-file
+    // read + base64 exfil (issue #4752).
+    const confinedPath = assertWithinArchiveRoot(metadata.filePath, store.archiveRoot);
+    const fileBuffer = await store.readFile(confinedPath);
     const blob = fileBuffer.toString("base64");
     return {
       uri,

--- a/src/server/videoRecordingTools.ts
+++ b/src/server/videoRecordingTools.ts
@@ -412,6 +412,7 @@ export function registerVideoRecordingTools(): void {
             outputName: args.outputName,
             maxDurationSeconds: args.maxDuration,
             highlights: args.highlights,
+            ownerSessionUuid: args.sessionUuid,
           });
 
           recordings.push({

--- a/test/daemon/socketServer/ConfigSocketServer.test.ts
+++ b/test/daemon/socketServer/ConfigSocketServer.test.ts
@@ -274,16 +274,23 @@ describe("config socket wrappers", () => {
     const socket = new FakeSocket();
     const config = { format: "mp4" } as VideoRecordingConfig;
     const updates: Array<VideoRecordingConfigInput | null> = [];
-    const server = new VideoRecordingSocketServer("/fake/path/video.sock", timer, {
-      getConfig: async () => config,
-      updateConfig: async update => {
-        updates.push(update);
-        return {
-          config,
-          evictedRecordingIds: ["recording-a"],
-        };
+    const server = new VideoRecordingSocketServer(
+      "/fake/path/video.sock",
+      timer,
+      {
+        getConfig: async () => config,
+        updateConfig: async update => {
+          updates.push(update);
+          return {
+            config,
+            evictedRecordingIds: ["recording-a"],
+          };
+        },
       },
-    });
+      // This suite exercises the config wrapper, not the auth gate (covered in
+      // videoRecordingSocketServerAuth.test.ts); inject a permissive authenticator.
+      { authorize: () => {} }
+    );
     const request: VideoRecordingSocketRequest = {
       id: "video-set",
       type: "video_recording_request",

--- a/test/daemon/testRecordingSocketServerAuth.test.ts
+++ b/test/daemon/testRecordingSocketServerAuth.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { TestRecordingSocketServer } from "../../src/daemon/testRecordingSocketServer";
+import type { StreamSocketAuthenticator } from "../../src/daemon/streamSocketAuth";
+import type { TestRecordingCommand } from "../../src/daemon/testRecordingSocketTypes";
+import { ActionableError } from "../../src/models";
+
+/**
+ * The socket server's handleRequest is protected; a thin subclass exposes it so
+ * the authorization gate can be exercised without opening a real Unix socket or
+ * driving a real recorder.
+ */
+class TestableServer extends TestRecordingSocketServer {
+  invoke(request: TestRecordingCommand) {
+    return this.handleRequest(request);
+  }
+}
+
+function recordingAuthenticator(
+  calls: Array<{ sessionUuid?: string; deviceId?: string }>
+): StreamSocketAuthenticator {
+  return {
+    authorize: input => {
+      calls.push(input);
+      if (input.sessionUuid !== "live") {
+        throw new ActionableError(`rejected session ${input.sessionUuid}`);
+      }
+    },
+  };
+}
+
+describe("TestRecordingSocketServer authorization (issue #4752)", () => {
+  test("rejects a start from an unauthenticated caller before any device work", async () => {
+    const calls: Array<{ sessionUuid?: string; deviceId?: string }> = [];
+    const server = new TestableServer(undefined, undefined, recordingAuthenticator(calls));
+    await expect(
+      server.invoke({ command: "start", deviceId: "emu-1", platform: "android" })
+    ).rejects.toThrow(/rejected session/);
+    // Authorized against the request's own device, before resolveDevice/start.
+    expect(calls).toEqual([{ sessionUuid: undefined, deviceId: "emu-1" }]);
+  });
+
+  test("rejects a stop from a caller with no live session before stopTestRecording runs", async () => {
+    const calls: Array<{ sessionUuid?: string; deviceId?: string }> = [];
+    const server = new TestableServer(undefined, undefined, recordingAuthenticator(calls));
+    // The auth gate must reject a non-live session BEFORE stopTestRecording runs.
+    // The scoped device is whatever the current active recording reports (or
+    // undefined), so assert on the caller identity, not on cross-suite global
+    // recording state.
+    await expect(
+      server.invoke({ command: "stop", sessionUuid: "intruder" })
+    ).rejects.toThrow(/rejected session/);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].sessionUuid).toBe("intruder");
+  });
+
+  test("rejects status from an unauthenticated caller", async () => {
+    const calls: Array<{ sessionUuid?: string; deviceId?: string }> = [];
+    const server = new TestableServer(undefined, undefined, recordingAuthenticator(calls));
+    await expect(server.invoke({ command: "status" })).rejects.toThrow(/rejected session/);
+    expect(calls).toEqual([{ sessionUuid: undefined, deviceId: undefined }]);
+  });
+
+  test("a live session passes the gate; status then returns the (empty) recording state", async () => {
+    const calls: Array<{ sessionUuid?: string; deviceId?: string }> = [];
+    const server = new TestableServer(undefined, undefined, recordingAuthenticator(calls));
+    const response = await server.invoke({ command: "status", sessionUuid: "live" });
+    expect(response.success).toBe(true);
+    expect(calls).toEqual([{ sessionUuid: "live", deviceId: undefined }]);
+  });
+});

--- a/test/daemon/videoRecordingSocketServerAuth.test.ts
+++ b/test/daemon/videoRecordingSocketServerAuth.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import { VideoRecordingSocketServer } from "../../src/daemon/videoRecordingSocketServer";
+import type { StreamSocketAuthenticator } from "../../src/daemon/streamSocketAuth";
+import type { VideoRecordingConfig, VideoRecordingConfigInput } from "../../src/models";
+import { ActionableError } from "../../src/models";
+
+function makeConfig(overrides: Partial<VideoRecordingConfig> = {}): VideoRecordingConfig {
+  return {
+    qualityPreset: "low",
+    targetBitrateKbps: 1000,
+    maxThroughputMbps: 5,
+    fps: 15,
+    maxArchiveSizeMb: 100,
+    format: "mp4",
+    ...overrides,
+  };
+}
+
+class TestableServer extends VideoRecordingSocketServer {
+  invoke(request: Parameters<TestableServer["handleRequest"]>[0]) {
+    return this.handleRequest(request);
+  }
+}
+
+function authenticator(
+  calls: Array<{ sessionUuid?: string }>
+): StreamSocketAuthenticator {
+  return {
+    authorize: input => {
+      calls.push({ sessionUuid: input.sessionUuid });
+      if (input.sessionUuid !== "live") {
+        throw new ActionableError(`rejected session ${input.sessionUuid}`);
+      }
+    },
+  };
+}
+
+describe("VideoRecordingSocketServer config authorization (issue #4752)", () => {
+  test("rejects config/set from an unauthenticated caller before eviction can run", async () => {
+    const calls: Array<{ sessionUuid?: string }> = [];
+    let updateCalled = false;
+    const server = new TestableServer(
+      undefined,
+      undefined,
+      {
+        getConfig: async () => makeConfig(),
+        updateConfig: async () => {
+          updateCalled = true;
+          return { config: makeConfig(), evictedRecordingIds: ["evicted"] };
+        },
+      },
+      authenticator(calls)
+    );
+
+    await expect(
+      server.invoke({
+        id: "1",
+        type: "video_recording_request",
+        method: "config/set",
+        params: { config: { maxArchiveSizeMb: 1 } as VideoRecordingConfigInput },
+      })
+    ).rejects.toThrow(/rejected session/);
+    expect(updateCalled).toBe(false);
+    expect(calls).toEqual([{ sessionUuid: undefined }]);
+  });
+
+  test("allows config/set from a live session", async () => {
+    const calls: Array<{ sessionUuid?: string }> = [];
+    const server = new TestableServer(
+      undefined,
+      undefined,
+      {
+        getConfig: async () => makeConfig(),
+        updateConfig: async () => ({ config: makeConfig({ maxArchiveSizeMb: 1 }), evictedRecordingIds: [] }),
+      },
+      authenticator(calls)
+    );
+
+    const response = await server.invoke({
+      id: "2",
+      type: "video_recording_request",
+      method: "config/set",
+      sessionUuid: "live",
+      params: { config: { maxArchiveSizeMb: 1 } as VideoRecordingConfigInput },
+    });
+    expect(response.success).toBe(true);
+    expect(response.result?.config.maxArchiveSizeMb).toBe(1);
+    expect(calls).toEqual([{ sessionUuid: "live" }]);
+  });
+
+  test("config/get is not gated by the authenticator", async () => {
+    const calls: Array<{ sessionUuid?: string }> = [];
+    const server = new TestableServer(
+      undefined,
+      undefined,
+      {
+        getConfig: async () => makeConfig({ fps: 30 }),
+        updateConfig: async () => ({ config: makeConfig(), evictedRecordingIds: [] }),
+      },
+      authenticator(calls)
+    );
+
+    const response = await server.invoke({
+      id: "3",
+      type: "video_recording_request",
+      method: "config/get",
+    });
+    expect(response.success).toBe(true);
+    expect(response.result?.config.fps).toBe(30);
+    expect(calls).toEqual([]);
+  });
+});

--- a/test/db/videoRecordingRepository.test.ts
+++ b/test/db/videoRecordingRepository.test.ts
@@ -67,6 +67,52 @@ describe("VideoRecordingRepository", () => {
     expect(result!.config.fps).toBe(15);
   });
 
+  describe("owner-session scoping (issue #4752)", () => {
+    beforeEach(async () => {
+      await repo.insertRecording(
+        makeRecord({ recordingId: "owned-a", status: "completed", ownerSessionUuid: "session-a" })
+      );
+      await repo.insertRecording(
+        makeRecord({ recordingId: "owned-b", status: "completed", ownerSessionUuid: "session-b" })
+      );
+      await repo.insertRecording(
+        makeRecord({ recordingId: "legacy", status: "completed" })
+      );
+    });
+
+    test("insertRecording round-trips the owning session", async () => {
+      const owned = await repo.getRecording("owned-a");
+      expect(owned!.ownerSessionUuid).toBe("session-a");
+      const legacy = await repo.getRecording("legacy");
+      expect(legacy!.ownerSessionUuid).toBeUndefined();
+    });
+
+    test("getRecording rejects a cross-session read but allows the owner and legacy rows", async () => {
+      expect(await repo.getRecording("owned-b", { ownerSessionUuid: "session-a" })).toBeNull();
+      expect((await repo.getRecording("owned-a", { ownerSessionUuid: "session-a" }))!.recordingId).toBe(
+        "owned-a"
+      );
+      // Legacy (null-owner) rows stay readable by any session for back-compat.
+      expect((await repo.getRecording("legacy", { ownerSessionUuid: "session-a" }))!.recordingId).toBe(
+        "legacy"
+      );
+    });
+
+    test("listRecordings owner filter returns only the caller's rows plus legacy rows", async () => {
+      const rows = await repo.listRecordings({
+        status: "completed",
+        ownerSessionUuid: "session-a",
+      });
+      const ids = rows.map(row => row.recordingId).sort();
+      expect(ids).toEqual(["legacy", "owned-a"]);
+    });
+
+    test("listRecordings without an owner scope returns every row (internal maintenance path)", async () => {
+      const rows = await repo.listRecordings({ status: "completed" });
+      expect(rows.map(row => row.recordingId).sort()).toEqual(["legacy", "owned-a", "owned-b"]);
+    });
+  });
+
   test("insertRecording upserts an existing recording id", async () => {
     await repo.insertRecording(makeRecord());
 

--- a/test/fakes/FakeVideoRecordingRepository.ts
+++ b/test/fakes/FakeVideoRecordingRepository.ts
@@ -1,8 +1,20 @@
 import type {
   VideoRecordingRepository,
+  VideoRecordingOwnerScope,
   VideoRecordingQuery,
   VideoRecordingRecord,
 } from "../../src/db/videoRecordingRepository";
+
+/**
+ * Mirror the repository's owner scoping (issue #4752): a scoped read sees rows it
+ * owns plus legacy NULL-owner rows; an unscoped read sees everything.
+ */
+function ownerVisible(record: VideoRecordingRecord, ownerSessionUuid?: string): boolean {
+  if (!ownerSessionUuid) {
+    return true;
+  }
+  return record.ownerSessionUuid === undefined || record.ownerSessionUuid === ownerSessionUuid;
+}
 
 type VideoRecordingRepositoryContract = Pick<
   VideoRecordingRepository,
@@ -44,8 +56,15 @@ export class FakeVideoRecordingRepository implements VideoRecordingRepositoryCon
     this.records.set(recordingId, updated);
   }
 
-  async getRecording(recordingId: string): Promise<VideoRecordingRecord | null> {
-    return this.records.get(recordingId) ?? null;
+  async getRecording(
+    recordingId: string,
+    scope: VideoRecordingOwnerScope = {}
+  ): Promise<VideoRecordingRecord | null> {
+    const record = this.records.get(recordingId) ?? null;
+    if (record && !ownerVisible(record, scope.ownerSessionUuid)) {
+      return null;
+    }
+    return record;
   }
 
   async listRecordings(query: VideoRecordingQuery = {}): Promise<VideoRecordingRecord[]> {
@@ -55,6 +74,7 @@ export class FakeVideoRecordingRepository implements VideoRecordingRepositoryCon
 
     let results = Array.from(this.records.values());
 
+    results = results.filter(record => ownerVisible(record, query.ownerSessionUuid));
     if (statuses) {
       results = results.filter(record => statuses.includes(record.status));
     }

--- a/test/server/videoRecordingResources.test.ts
+++ b/test/server/videoRecordingResources.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  assertWithinArchiveRoot,
   buildVideoResourceContent,
   getLatestVideoRecording,
   getVideoArchiveItem,
@@ -12,11 +13,13 @@ import {
 } from "../../src/server/videoRecordingResourceUris";
 import type { VideoRecordingMetadata } from "../../src/models";
 
+const ARCHIVE_ROOT = "/tmp/video-archive";
+
 function metadata(overrides: Partial<VideoRecordingMetadata> = {}): VideoRecordingMetadata {
   return {
     recordingId: "rec-1",
     fileName: "rec-1.mp4",
-    filePath: "/tmp/rec-1.mp4",
+    filePath: `${ARCHIVE_ROOT}/rec-1/rec-1.mp4`,
     format: "mp4",
     sizeBytes: 1024,
     createdAt: "2026-01-01T00:00:00.000Z",
@@ -33,6 +36,7 @@ function store(overrides: Partial<VideoRecordingResourceStore> = {}): VideoRecor
     getById: async () => null,
     list: async () => [],
     readFile: async () => Buffer.from("video-bytes"),
+    archiveRoot: ARCHIVE_ROOT,
     ...overrides,
   };
 }
@@ -101,6 +105,30 @@ describe("getVideoArchiveItem", () => {
   });
 });
 
+describe("assertWithinArchiveRoot", () => {
+  const root = "/home/user/.auto-mobile/video-archive";
+
+  test("returns the resolved path for a file inside the archive root", () => {
+    expect(assertWithinArchiveRoot(`${root}/rec-1/rec-1.mp4`, root)).toBe(
+      `${root}/rec-1/rec-1.mp4`
+    );
+  });
+
+  test("resolves a relative path against the archive root", () => {
+    expect(assertWithinArchiveRoot("rec-1/rec-1.mp4", root)).toBe(`${root}/rec-1/rec-1.mp4`);
+  });
+
+  test("throws for an absolute path outside the archive root", () => {
+    expect(() => assertWithinArchiveRoot("/etc/passwd", root)).toThrow(/outside the archive root/);
+  });
+
+  test("throws for a traversal escaping the archive root", () => {
+    expect(() => assertWithinArchiveRoot("../../etc/passwd", root)).toThrow(
+      /outside the archive root/
+    );
+  });
+});
+
 describe("buildVideoResourceContent", () => {
   test("reports a missing-file error when the metadata has no file path", async () => {
     const content = await buildVideoResourceContent(
@@ -110,6 +138,40 @@ describe("buildVideoResourceContent", () => {
     );
     expect(content.mimeType).toBe("application/json");
     expect(parse(content.text).error).toBe("Missing file path for recording no-file");
+    expect(content.blob).toBeUndefined();
+  });
+
+  test("refuses to read a poisoned file path outside the archive root, before touching disk", async () => {
+    let readCalled = false;
+    const content = await buildVideoResourceContent(
+      metadata({ filePath: "/etc/passwd", recordingId: "poisoned" }),
+      VIDEO_RESOURCE_URIS.LATEST,
+      store({
+        readFile: async () => {
+          readCalled = true;
+          return Buffer.from("secret");
+        },
+      })
+    );
+    expect(readCalled).toBe(false);
+    expect(content.blob).toBeUndefined();
+    expect(content.mimeType).toBe("application/json");
+    expect(parse(content.text).error).toContain("Failed to read video data");
+  });
+
+  test("refuses a relative traversal escaping the archive root", async () => {
+    let readCalled = false;
+    const content = await buildVideoResourceContent(
+      metadata({ filePath: "../../etc/passwd", recordingId: "traversal" }),
+      VIDEO_RESOURCE_URIS.LATEST,
+      store({
+        readFile: async () => {
+          readCalled = true;
+          return Buffer.from("secret");
+        },
+      })
+    );
+    expect(readCalled).toBe(false);
     expect(content.blob).toBeUndefined();
   });
 

--- a/test/server/videoRecordingResources.test.ts
+++ b/test/server/videoRecordingResources.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import * as path from "node:path";
 import {
   assertWithinArchiveRoot,
   buildVideoResourceContent,
@@ -109,13 +110,15 @@ describe("assertWithinArchiveRoot", () => {
   const root = "/home/user/.auto-mobile/video-archive";
 
   test("returns the resolved path for a file inside the archive root", () => {
-    expect(assertWithinArchiveRoot(`${root}/rec-1/rec-1.mp4`, root)).toBe(
-      `${root}/rec-1/rec-1.mp4`
-    );
+    // Assert via node:path so the expectation matches on Windows (backslashes /
+    // drive letter) as well as POSIX — mirrors assertWithinArchiveRoot's own path.resolve.
+    const input = path.join(root, "rec-1", "rec-1.mp4");
+    expect(assertWithinArchiveRoot(input, root)).toBe(path.resolve(root, input));
   });
 
   test("resolves a relative path against the archive root", () => {
-    expect(assertWithinArchiveRoot("rec-1/rec-1.mp4", root)).toBe(`${root}/rec-1/rec-1.mp4`);
+    const input = path.join("rec-1", "rec-1.mp4");
+    expect(assertWithinArchiveRoot(input, root)).toBe(path.resolve(root, input));
   });
 
   test("throws for an absolute path outside the archive root", () => {


### PR DESCRIPTION
Closes [#4752](https://github.com/kaeawc/auto-mobile/issues/4752)

## Summary

The video recording archive and its daemon sockets were global and unscoped: any MCP client or local process could enumerate and download every recording (bytes + absolute path), and any session could start/stop/evict another session's recordings. This is the recording-side counterpart of the socket-authorization gap closed for the main daemon in [#4655](https://github.com/kaeawc/auto-mobile/issues/4655) and the live streams in [#4751](https://github.com/kaeawc/auto-mobile/issues/4751).

This PR closes the three gaps from the issue's proposed change.

### 1. Owning-session column + owner-scoped reads

- New migration `2026_07_31_000_video_recordings_owner_session.ts` adds a **nullable** `owner_session_uuid` column plus an index. Applied through the repo's `FileMigrationProvider` migration system (no registry to touch), and exercised by every `createTestDatabase()` (`:memory:` runs all migrations).
- `VideoRecordingRepository.listRecordings` / `getRecording` now accept an owner scope and filter with `owner_session_uuid IS NULL OR owner_session_uuid = ?`.
- `startVideoRecording` persists the owner (`args.sessionUuid` from the `videoRecording` tool). The manager's `listVideoRecordings` / `getVideoRecordingMetadata` / `getLatestVideoRecordingMetadata` accept an owner scope and thread it to the repository.

### 2. Session-capability enforcement on the recording sockets

Reuses the existing `SessionScopedStreamAuthenticator` / `createDefaultStreamSocketAuthenticator` from `streamSocketAuth.ts` ([#4751](https://github.com/kaeawc/auto-mobile/issues/4751)/[#4655](https://github.com/kaeawc/auto-mobile/issues/4655)) — no parallel mechanism invented.

- **Test-recording socket** (`testRecordingSocketServer.ts`): `start` / `stop` / `status` now authorize `{ sessionUuid, deviceId }` before any work. `stop` is scoped against the **active recording's** device (not a client-supplied one), so the recordingId-only guard in `stopTestRecording` can no longer be bypassed cross-session.
- **Video-recording config socket** (`ConfigSocketServer` + `videoRecordingSocketServer.ts`): `config/set` — which can lower `maxArchiveSizeMb` and trigger global eviction — is authorized before the mutation. `config/get` is unchanged (non-destructive). `ConfigSocketServer` gained an optional `authenticator`; the `deviceSnapshot` socket is unaffected (it passes none).
- Both carry `sessionUuid` on their wire types. Enforcement is fail-closed by default and shares the `AUTOMOBILE_DAEMON_STREAM_AUTH=0` opt-out from #4751.

### 3. Archive-root confinement (this PR owns the [#4765](https://github.com/kaeawc/auto-mobile/issues/4765) item-3 fix)

- `assertWithinArchiveRoot()` in `videoRecordingResources.ts` `path.resolve`s the stored `file_path` against the archive root and rejects any path that escapes (absolute path outside the root, `..` traversal). `buildVideoResourceContent` calls it **before** `store.readFile(...)`, so a poisoned/absolute `file_path` can never become an arbitrary-file-read + base64 exfil over the MCP resource channel. The archive root is injectable on the store for testing.

## Verify-against-current-main findings

- The auth mechanism from #4751 landed as `SessionScopedStreamAuthenticator` + `createDefaultStreamSocketAuthenticator` in `src/daemon/streamSocketAuth.ts`, wired into `webrtcStreamSocketServer` / `videoStreamSocketServer`. I reuse it verbatim rather than inventing anything.
- FS-perms hardening from #4750 lives in `VideoRecorderService` (owner-only recording dirs) and is orthogonal to this change.
- Paths matched the issue: `videoRecordingResources.ts`, `videoRecordingRepository.ts`, `videoRecordingSocketServer.ts` + `ConfigSocketServer.ts`, `testRecordingSocketServer.ts`.
- **Architectural note (scope):** the MCP `resources/read` channel carries only a URI — no daemon session — so resource reads have no per-request session to enforce against today. The resource-side fix therefore lands as (a) unconditional archive-root confinement (closes the file-read vector regardless of caller) and (b) owner-scoped read plumbing through the store/manager/repository ready for a session-aware resource channel. The session-*authorization* is enforced where identity actually exists on the wire — the two recording sockets — which is also where the higher-severity lifecycle-control threats (cross-session stop / eviction) live.

## Migration + back-compat decision

`owner_session_uuid` is **nullable**. Rows written before this migration have no known owner and keep a `NULL` owner. Read policy: a **`NULL`-owner (legacy) row is readable by any session**; a row **with** an owner is only returned to that owner. This hardens all new recordings without orphaning the existing archive. Unscoped reads (no owner in the query) still see everything and are reserved for internal maintenance paths (restart-interruption sweep, archive eviction) that legitimately operate on the whole archive.

## Validation

- `bun run typecheck` — no new type errors (196 baseline).
- `bun run build` — success.
- `bun run lint` — clean (all boundary checks pass).
- `bun test` — **12420 pass / 0 fail** (full suite).
- New/updated coverage: repository owner filtering (cross-session get/list rejected, owner + legacy rows allowed, unscoped sees all); resource confinement (absolute + traversal paths rejected before disk read); test-recording socket auth (start/stop/status rejected for non-live sessions, stop scoped to the active device); config socket auth (config/set gated before eviction, config/get ungated). Migration applies cleanly via `createTestDatabase()`.
