### PR TITLE
feat(desktop): offline navigation browse with no active device (#4911)

### DIFF
--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/CachedNavigationDataSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/CachedNavigationDataSource.kt
@@ -11,13 +11,21 @@ class CachedNavigationDataSource(
 ) : NavigationDataSource {
 
   private val cache = InMemoryCache<Unit, Result<NavigationGraph>>(ttlMs, clock)
+  // Separate cache keyspace: the apps list is app-independent, so it must not share the graph's
+  // Unit key or one would evict/return the other.
+  private val appsCache = InMemoryCache<Unit, Result<List<NavigationAppSummary>>>(ttlMs, clock)
 
   override suspend fun getNavigationGraph(): Result<NavigationGraph> {
     return cache.get(Unit) { delegate.getNavigationGraph() }
   }
 
+  override suspend fun listApps(): Result<List<NavigationAppSummary>> {
+    return appsCache.get(Unit) { delegate.listApps() }
+  }
+
   /** Force the next call to re-fetch from the delegate. */
   fun invalidate() {
     cache.invalidate(Unit)
+    appsCache.invalidate(Unit)
   }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/FakeNavigationDataSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/FakeNavigationDataSource.kt
@@ -16,4 +16,24 @@ class FakeNavigationDataSource : NavigationDataSource {
       )
     )
   }
+
+  override suspend fun listApps(): Result<List<NavigationAppSummary>> {
+    delay(100)
+    // Newest-first, mirroring the daemon's ordering; one entry has a null displayName so UI
+    // development exercises the appId fallback.
+    return Result.Success(
+      listOf(
+        NavigationAppSummary(
+          appId = "com.example.shopping",
+          displayName = "Shopping",
+          lastUpdated = "2026-01-03T12:00:00.000Z",
+        ),
+        NavigationAppSummary(
+          appId = "com.example.banking",
+          displayName = null,
+          lastUpdated = "2026-01-01T09:30:00.000Z",
+        ),
+      )
+    )
+  }
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/NavigationDataSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/NavigationDataSource.kt
@@ -2,6 +2,37 @@ package dev.jasonpearson.automobile.desktop.core.datasource
 
 typealias NavigationGraph = dev.jasonpearson.automobile.desktop.domain.NavigationGraph
 
+/**
+ * Summary of one app that has a persisted navigation graph, as surfaced by the device-optional
+ * `automobile:navigation/apps` daemon resource. Used by the offline-browse surface (Phase C
+ * of #4837) to let the user pick an app to inspect from persisted data with no live device.
+ *
+ * @param appId The app's package/bundle id (stable key used to pull its graph).
+ * @param displayName Human-friendly label if the daemon knows one; null when unknown (fall back to
+ *   [appId] in the UI).
+ * @param lastUpdated ISO-8601 timestamp of the most recent recorded navigation for this app. The
+ *   daemon orders the list newest-first; kept as the raw string (no parsing) since it is
+ *   display-only here.
+ */
+data class NavigationAppSummary(
+  val appId: String,
+  val displayName: String?,
+  val lastUpdated: String,
+)
+
 interface NavigationDataSource {
   suspend fun getNavigationGraph(): Result<NavigationGraph>
+
+  /**
+   * Lists apps that have a persisted navigation graph, newest-first. Device-independent: the
+   * `automobile:navigation/apps` resource does not require an observed device, so this backs
+   * offline browsing.
+   *
+   * Defaulted so the many app-scoped [NavigationDataSource] implementations that only ever serve a
+   * single app's graph (e.g. the per-app sources created by
+   * [dev.jasonpearson.automobile.desktop.core.workspace.NavigationFacet]) need not implement it.
+   * The meaningful implementations are [RealNavigationDataSource], [FakeNavigationDataSource], and
+   * [CachedNavigationDataSource]; the offline browser is the only consumer.
+   */
+  suspend fun listApps(): Result<List<NavigationAppSummary>> = Result.Success(emptyList())
 }

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealNavigationDataSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealNavigationDataSource.kt
@@ -5,6 +5,7 @@ import dev.jasonpearson.automobile.desktop.core.daemon.McpConnectionException
 import dev.jasonpearson.automobile.desktop.core.daemon.encodeResourceUriComponent
 import dev.jasonpearson.automobile.desktop.core.navigation.ScreenNode
 import dev.jasonpearson.automobile.desktop.core.navigation.ScreenTransition
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
@@ -49,6 +50,14 @@ class RealNavigationDataSource(
       // Parse the MCP navigation graph response
       val response = json.decodeFromString(serializer<McpNavigationGraphResponse>(), graphText)
 
+      // The daemon signals failure with an `{ "error": ... }` envelope (not a throw). Because
+      // decoding uses ignoreUnknownKeys, that envelope would otherwise parse into an all-defaults
+      // response and masquerade as a genuinely-empty graph. A present error field means failure; a
+      // real empty graph ({ "nodes": [], "edges": [] }) has a null error and stays Success.
+      response.error?.let {
+        return Result.Error(RuntimeException(it), it)
+      }
+
       // Count outgoing edges per screen for transitionCount
       val outgoingEdgeCounts = response.edges.groupBy { it.from }.mapValues { it.value.size }
 
@@ -84,6 +93,9 @@ class RealNavigationDataSource(
       Result.Success(NavigationGraph(screens = screens, transitions = transitions))
     } catch (e: McpConnectionException) {
       Result.Error(e, "MCP server not available: ${e.message}")
+    } catch (c: CancellationException) {
+      // Let coroutine cancellation propagate so this suspend call stays cancellable.
+      throw c
     } catch (e: Exception) {
       Result.Error(e, "Failed to load navigation graph: ${e.message}")
     }
@@ -100,6 +112,12 @@ class RealNavigationDataSource(
       val text = contents.firstOrNull()?.text ?: return Result.Success(emptyList())
 
       val response = json.decodeFromString(serializer<McpNavigationAppsResponse>(), text)
+      // A present `error` field is the daemon's failure envelope; a genuinely-empty result
+      // ({ "apps": [] }) has a null error and stays Success. See getNavigationGraph for why the
+      // envelope must be detected explicitly under ignoreUnknownKeys.
+      response.error?.let {
+        return Result.Error(RuntimeException(it), it)
+      }
       val apps =
         response.apps.map { app ->
           NavigationAppSummary(
@@ -111,6 +129,8 @@ class RealNavigationDataSource(
       Result.Success(apps)
     } catch (e: McpConnectionException) {
       Result.Error(e, "MCP server not available: ${e.message}")
+    } catch (c: CancellationException) {
+      throw c
     } catch (e: Exception) {
       Result.Error(e, "Failed to load saved navigation apps: ${e.message}")
     }
@@ -152,6 +172,8 @@ private data class McpNavigationGraphResponse(
   val nodes: List<McpNavigationNode> = emptyList(),
   val edges: List<McpNavigationEdge> = emptyList(),
   val currentScreen: String? = null,
+  // Present only on the daemon's `{ "error": ... }` failure envelope; null on a real graph.
+  val error: String? = null,
 )
 
 @Serializable
@@ -176,7 +198,11 @@ private data class McpNavigationEdge(
 // newest-first.
 
 @Serializable
-private data class McpNavigationAppsResponse(val apps: List<McpNavigationAppSummary> = emptyList())
+private data class McpNavigationAppsResponse(
+  val apps: List<McpNavigationAppSummary> = emptyList(),
+  // Present only on the daemon's `{ "error": ... }` failure envelope; null on a real list.
+  val error: String? = null,
+)
 
 @Serializable
 private data class McpNavigationAppSummary(

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealNavigationDataSource.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealNavigationDataSource.kt
@@ -89,6 +89,33 @@ class RealNavigationDataSource(
     }
   }
 
+  override suspend fun listApps(): Result<List<NavigationAppSummary>> {
+    val provider = clientProvider ?: return Result.Success(emptyList())
+
+    return try {
+      val client = provider()
+      // Device-optional resource: the daemon returns every app with a persisted graph,
+      // newest-first.
+      val contents = client.readResource("automobile:navigation/apps")
+      val text = contents.firstOrNull()?.text ?: return Result.Success(emptyList())
+
+      val response = json.decodeFromString(serializer<McpNavigationAppsResponse>(), text)
+      val apps =
+        response.apps.map { app ->
+          NavigationAppSummary(
+            appId = app.appId,
+            displayName = app.displayName,
+            lastUpdated = app.lastUpdated,
+          )
+        }
+      Result.Success(apps)
+    } catch (e: McpConnectionException) {
+      Result.Error(e, "MCP server not available: ${e.message}")
+    } catch (e: Exception) {
+      Result.Error(e, "Failed to load saved navigation apps: ${e.message}")
+    }
+  }
+
   /** Infer screen type from screen name patterns. */
   private fun inferScreenType(screenName: String): String {
     val lowerName = screenName.lowercase()
@@ -142,4 +169,18 @@ private data class McpNavigationEdge(
   val to: String,
   val toolName: String?,
   val traversalCount: Int = 1,
+)
+
+// Matches the device-optional `automobile:navigation/apps` resource (issue #4910 contract):
+// { "apps": [ { "appId": "...", "displayName": null, "lastUpdated": "<ISO-8601>" } ] }
+// newest-first.
+
+@Serializable
+private data class McpNavigationAppsResponse(val apps: List<McpNavigationAppSummary> = emptyList())
+
+@Serializable
+private data class McpNavigationAppSummary(
+  val appId: String,
+  val displayName: String? = null,
+  val lastUpdated: String,
 )

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationDashboard.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/navigation/NavigationDashboard.kt
@@ -1,14 +1,24 @@
 package dev.jasonpearson.automobile.desktop.core.navigation
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import dev.jasonpearson.automobile.desktop.core.daemon.AutoMobileClient
 import dev.jasonpearson.automobile.desktop.core.daemon.NavigationGraphStreamUpdate
 import dev.jasonpearson.automobile.desktop.core.daemon.ObservationStream
@@ -60,6 +70,16 @@ fun NavigationDashboard(
   // current screen here or the canvas's Fog toggle + auto-focus (both gated on a non-null current
   // screen) stay dead. Only consulted when [providedGraph] is non-null.
   providedCurrentScreen: String? = null,
+  // Read-only (offline) browse: when true the graph is inspectable — browsing, panning, zooming,
+  // and
+  // drilling into screen/transition detail all work — but device-side navigate actions (which need
+  // a
+  // live device) are unavailable and a "Navigate actions disabled (offline)" badge is shown. Used
+  // by
+  // the offline-browse surface (Phase C of #4837), which renders a persisted graph via
+  // [providedGraph] with no observed device. Any future live "navigate device to this screen"
+  // affordance must gate on this flag.
+  readOnly: Boolean = false,
 ) {
   val graph = LocalAutoMobileGraph.current
   var currentSection by remember { mutableStateOf(NavigationSection.FlowMap) }
@@ -213,63 +233,97 @@ fun NavigationDashboard(
     }
   }
 
-  when (currentSection) {
-    NavigationSection.FlowMap ->
-      Box(modifier = Modifier.fillMaxSize()) {
-        NavigationCanvasView(
-          screens = screens,
-          transitions = transitions,
-          onScreenSelected = { screenId ->
-            selectedScreenId = screenId
-            currentSection = NavigationSection.ScreenDetail
-            onHighlightCleared()
-          },
-          externalHighlightedScreens = highlightedScreens,
-          currentReplayScreen = currentStepScreen,
-          screenshotLoader = screenshotLoader,
-          fogModeEnabled = fogModeEnabled,
-          currentObservedScreen = currentObservedScreen,
-          onFogModeToggled = { enabled ->
-            fogModeEnabled = enabled
-            settingsProvider.fogModeEnabled = enabled
-          },
-          fitToViewTrigger = fitToViewTrigger,
-        )
+  // Wrap the section content so the read-only (offline) badge can overlay every section: navigate
+  // actions are unavailable in the whole dashboard offline, not just the flow map.
+  Box(modifier = Modifier.fillMaxSize()) {
+    when (currentSection) {
+      NavigationSection.FlowMap ->
+        Box(modifier = Modifier.fillMaxSize()) {
+          NavigationCanvasView(
+            screens = screens,
+            transitions = transitions,
+            onScreenSelected = { screenId ->
+              selectedScreenId = screenId
+              currentSection = NavigationSection.ScreenDetail
+              onHighlightCleared()
+            },
+            externalHighlightedScreens = highlightedScreens,
+            currentReplayScreen = currentStepScreen,
+            screenshotLoader = screenshotLoader,
+            fogModeEnabled = fogModeEnabled,
+            currentObservedScreen = currentObservedScreen,
+            onFogModeToggled = { enabled ->
+              fogModeEnabled = enabled
+              settingsProvider.fogModeEnabled = enabled
+            },
+            fitToViewTrigger = fitToViewTrigger,
+          )
+        }
+
+      NavigationSection.ScreenDetail -> {
+        val screen =
+          screens.find { it.id == selectedScreenId }
+            ?: screens.find { it.name == selectedScreenId }
+            ?: screens.firstOrNull()
+
+        if (screen != null) {
+          ScreenDetailView(
+            screen = screen,
+            transitions = transitions,
+            onBack = { currentSection = NavigationSection.FlowMap },
+            onScreenSelected = navigateToScreen,
+            screenshotLoader = screenshotLoader,
+          )
+        } else {
+          currentSection = NavigationSection.FlowMap
+        }
       }
 
-    NavigationSection.ScreenDetail -> {
-      val screen =
-        screens.find { it.id == selectedScreenId }
-          ?: screens.find { it.name == selectedScreenId }
-          ?: screens.firstOrNull()
+      NavigationSection.TransitionDetail -> {
+        val transition =
+          transitions.find { it.id == selectedTransitionId } ?: transitions.firstOrNull()
 
-      if (screen != null) {
-        ScreenDetailView(
-          screen = screen,
-          transitions = transitions,
-          onBack = { currentSection = NavigationSection.FlowMap },
-          onScreenSelected = navigateToScreen,
-          screenshotLoader = screenshotLoader,
-        )
-      } else {
-        currentSection = NavigationSection.FlowMap
+        if (transition != null) {
+          TransitionDetailView(
+            transition = transition,
+            onBack = { currentSection = NavigationSection.FlowMap },
+            onScreenSelected = navigateToScreen,
+          )
+        } else {
+          currentSection = NavigationSection.FlowMap
+        }
       }
     }
 
-    NavigationSection.TransitionDetail -> {
-      val transition =
-        transitions.find { it.id == selectedTransitionId } ?: transitions.firstOrNull()
-
-      if (transition != null) {
-        TransitionDetailView(
-          transition = transition,
-          onBack = { currentSection = NavigationSection.FlowMap },
-          onScreenSelected = navigateToScreen,
-        )
-      } else {
-        currentSection = NavigationSection.FlowMap
-      }
+    if (readOnly) {
+      ReadOnlyOfflineBadge(Modifier.align(Alignment.TopEnd).padding(12.dp))
     }
+  }
+}
+
+/**
+ * Corner badge shown while browsing a persisted graph with no live device. Communicates that
+ * navigate actions (which need a device) are unavailable; browsing/panning still work. Its stable
+ * content description is the offline read-only signal the UI tests assert on.
+ */
+@Composable
+private fun ReadOnlyOfflineBadge(modifier: Modifier = Modifier) {
+  Box(
+    modifier =
+      modifier
+        .background(
+          MaterialTheme.colorScheme.surfaceVariant,
+          RoundedCornerShape(6.dp),
+        )
+        .padding(horizontal = 8.dp, vertical = 4.dp)
+        .semantics { contentDescription = "Navigate actions disabled (offline)" }
+  ) {
+    Text(
+      "Read-only · offline",
+      style = MaterialTheme.typography.labelSmall,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+      fontSize = 11.sp,
+    )
   }
 }
 

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OfflineNavigationBrowser.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OfflineNavigationBrowser.kt
@@ -1,0 +1,319 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import dev.jasonpearson.automobile.desktop.core.datasource.NavigationAppSummary
+import dev.jasonpearson.automobile.desktop.core.datasource.NavigationDataSource
+import dev.jasonpearson.automobile.desktop.core.datasource.NavigationGraph
+import dev.jasonpearson.automobile.desktop.core.datasource.RealNavigationDataSource
+import dev.jasonpearson.automobile.desktop.core.datasource.Result
+import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
+import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
+import dev.jasonpearson.automobile.desktop.core.navigation.NavigationDashboard
+import dev.jasonpearson.automobile.desktop.core.navigation.NavigationScreenshotLoader
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private val LOG = LoggerFactory.getLogger("OfflineNavigationBrowser")
+
+/** State of the app-list step of the offline browser. */
+private sealed interface AppListState {
+  data object Loading : AppListState
+
+  data object Empty : AppListState
+
+  data class Error(val message: String) : AppListState
+
+  data class Loaded(val apps: List<NavigationAppSummary>) : AppListState
+}
+
+/** State of the per-app graph step once an app is selected. */
+private sealed interface AppGraphState {
+  data object Loading : AppGraphState
+
+  data object Empty : AppGraphState
+
+  data class Error(val message: String) : AppGraphState
+
+  data class Resolved(val graph: NavigationGraph) : AppGraphState
+}
+
+/**
+ * Offline navigation browser (Phase C of #4837). Reachable from the workspace empty state when **no
+ * device is observed**: it lists apps that have a persisted navigation graph (via the
+ * device-optional `automobile:navigation/apps` resource, read through
+ * [NavigationDataSource.listApps]) and, on selecting one, renders that app's persisted graph
+ * through the existing [NavigationDashboard] with `providedGraph` — no live device required.
+ *
+ * The dashboard is rendered `readOnly = true`: browsing, panning, zooming, and drilling into
+ * screen/transition detail all work, but device-side navigate actions (which need a live device)
+ * are unavailable and surfaced as disabled.
+ *
+ * [navigationDataSourceProvider] is injected (interface + fake) so the whole loading / empty /
+ * error / resolved behavior is testable with a fake data source and no socket or MCP daemon. The
+ * argument is the app id to scope a graph pull; it is `null` for the app-independent [listApps]
+ * call.
+ */
+@Composable
+fun OfflineNavigationBrowser(
+  navigationDataSourceProvider: ((String?) -> NavigationDataSource)? = null,
+  reloadTrigger: Int = 0,
+) {
+  val graph = LocalAutoMobileGraph.current
+  val provider: (String?) -> NavigationDataSource =
+    navigationDataSourceProvider
+      ?: { appId ->
+        RealNavigationDataSource(clientProvider = { graph.autoMobileClient }, appId = appId)
+      }
+
+  // Which app the user drilled into, if any. Null = show the app list.
+  var selectedApp by remember { mutableStateOf<NavigationAppSummary?>(null) }
+
+  if (selectedApp == null) {
+    AppListStep(
+      provider = provider,
+      reloadTrigger = reloadTrigger,
+      onSelect = { selectedApp = it },
+    )
+  } else {
+    val app = selectedApp
+    if (app != null) {
+      AppGraphStep(app = app, provider = provider, onBack = { selectedApp = null })
+    }
+  }
+}
+
+@Composable
+private fun AppListStep(
+  provider: (String?) -> NavigationDataSource,
+  reloadTrigger: Int,
+  onSelect: (NavigationAppSummary) -> Unit,
+) {
+  var attempt by remember { mutableStateOf(0) }
+  var state by remember { mutableStateOf<AppListState>(AppListState.Loading) }
+
+  LaunchedEffect(reloadTrigger, attempt) {
+    state = AppListState.Loading
+    // Read off the UI thread: the resource read hits the daemon. Injected fakes run inline
+    // (deterministic). A throw becomes a retryable Error rather than crashing the Recomposer.
+    state =
+      try {
+        when (val result = withContext(Dispatchers.IO) { provider(null).listApps() }) {
+          is Result.Success ->
+            if (result.data.isEmpty()) AppListState.Empty else AppListState.Loaded(result.data)
+          is Result.Error ->
+            AppListState.Error(result.message ?: "Failed to load saved navigation graphs")
+          Result.Loading -> AppListState.Error("Saved navigation graphs are still loading")
+        }
+      } catch (c: CancellationException) {
+        throw c
+      } catch (e: Exception) {
+        LOG.warn("Offline app-list load failed: ${e.message}", e)
+        AppListState.Error(e.message ?: "Failed to load saved navigation graphs")
+      }
+  }
+
+  Column(Modifier.fillMaxSize()) {
+    Text("Browse navigation history", style = MaterialTheme.typography.titleMedium)
+    Spacer(Modifier.height(4.dp))
+    Text(
+      "Inspect a persisted navigation graph from a past session — no device required.",
+      style = MaterialTheme.typography.bodySmall,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Spacer(Modifier.height(12.dp))
+
+    when (val current = state) {
+      AppListState.Loading -> CenteredNote("Loading saved navigation graphs…")
+      AppListState.Empty -> CenteredNote("No saved navigation graphs")
+      is AppListState.Error ->
+        RetryableError(
+          message = current.message,
+          retryContentDescription = "Retry loading saved navigation graphs",
+        ) {
+          attempt++
+        }
+      is AppListState.Loaded ->
+        LazyColumn(
+          Modifier.fillMaxSize(),
+          verticalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+          items(current.apps, key = { it.appId }) { app -> AppRow(app = app, onClick = onSelect) }
+        }
+    }
+  }
+}
+
+@Composable
+private fun AppRow(app: NavigationAppSummary, onClick: (NavigationAppSummary) -> Unit) {
+  val label = app.displayName ?: app.appId
+  Row(
+    modifier =
+      Modifier.fillMaxWidth()
+        .clickable { onClick(app) }
+        .semantics { contentDescription = "Open navigation graph for $label" }
+        .background(
+          MaterialTheme.colorScheme.surfaceVariant,
+          RoundedCornerShape(6.dp),
+        )
+        .padding(horizontal = 12.dp, vertical = 8.dp),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Column(Modifier.weight(1f)) {
+      Text(label, style = MaterialTheme.typography.bodyMedium)
+      if (app.displayName != null) {
+        Text(
+          app.appId,
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      }
+    }
+    Text(
+      app.lastUpdated,
+      style = MaterialTheme.typography.bodySmall,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+  }
+}
+
+@Composable
+private fun AppGraphStep(
+  app: NavigationAppSummary,
+  provider: (String?) -> NavigationDataSource,
+  onBack: () -> Unit,
+) {
+  val graph = LocalAutoMobileGraph.current
+  var attempt by remember(app.appId) { mutableStateOf(0) }
+  var state by remember(app.appId) { mutableStateOf<AppGraphState>(AppGraphState.Loading) }
+
+  LaunchedEffect(app.appId, attempt) {
+    state = AppGraphState.Loading
+    state =
+      try {
+        when (
+          val result = withContext(Dispatchers.IO) { provider(app.appId).getNavigationGraph() }
+        ) {
+          is Result.Success ->
+            if (result.data.screens.isEmpty()) AppGraphState.Empty
+            else AppGraphState.Resolved(result.data)
+          is Result.Error ->
+            AppGraphState.Error(result.message ?: "Failed to load navigation graph")
+          Result.Loading -> AppGraphState.Error("Navigation graph is still loading")
+        }
+      } catch (c: CancellationException) {
+        throw c
+      } catch (e: Exception) {
+        LOG.warn("Offline app-graph load failed: ${e.message}", e)
+        AppGraphState.Error(e.message ?: "Failed to load navigation graph")
+      }
+  }
+
+  // Remembered per app so its LRU screenshot cache survives recomposition.
+  val screenshotLoader =
+    remember(app.appId) {
+      NavigationScreenshotLoader(clientProvider = { graph.autoMobileClient })
+    }
+
+  Column(Modifier.fillMaxSize()) {
+    Row(
+      Modifier.fillMaxWidth().padding(bottom = 8.dp),
+      verticalAlignment = Alignment.CenterVertically,
+    ) {
+      Text(
+        "← Back",
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.primary,
+        modifier =
+          Modifier.clickable(onClick = onBack)
+            .semantics { contentDescription = "Back to saved navigation graphs" }
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+      )
+      Spacer(Modifier.weight(1f))
+      Text(
+        app.displayName ?: app.appId,
+        style = MaterialTheme.typography.labelLarge,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    }
+
+    Box(Modifier.weight(1f).fillMaxWidth()) {
+      when (val current = state) {
+        AppGraphState.Loading -> CenteredNote("Loading navigation graph…")
+        AppGraphState.Empty -> CenteredNote("No navigation graph recorded for this app")
+        is AppGraphState.Error ->
+          RetryableError(
+            message = current.message,
+            retryContentDescription = "Retry loading navigation graph",
+          ) {
+            attempt++
+          }
+        is AppGraphState.Resolved ->
+          NavigationDashboard(
+            providedGraph = current.graph,
+            screenshotLoader = screenshotLoader,
+            settingsProvider = graph.settingsProvider,
+            selectedAppId = app.appId,
+            // Offline: device-side navigate actions are unavailable; browsing/panning still work.
+            readOnly = true,
+          )
+      }
+    }
+  }
+}
+
+@Composable
+private fun CenteredNote(text: String) {
+  Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+    Text(text, color = MaterialTheme.colorScheme.outline)
+  }
+}
+
+@Composable
+private fun RetryableError(
+  message: String,
+  retryContentDescription: String,
+  onRetry: () -> Unit,
+) {
+  Column(
+    Modifier.fillMaxSize(),
+    verticalArrangement = Arrangement.Center,
+    horizontalAlignment = Alignment.CenterHorizontally,
+  ) {
+    Text(message, color = MaterialTheme.colorScheme.error)
+    Text(
+      "Retry",
+      color = MaterialTheme.colorScheme.primary,
+      modifier =
+        Modifier.padding(top = 8.dp).clickable(onClick = onRetry).semantics {
+          contentDescription = retryContentDescription
+        },
+    )
+  }
+}

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OfflineNavigationBrowser.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OfflineNavigationBrowser.kt
@@ -84,6 +84,14 @@ fun OfflineNavigationBrowser(
   navigationDataSourceProvider: ((String?) -> NavigationDataSource)? = null
 ) {
   val graph = LocalAutoMobileGraph.current
+  // Construct RealNavigationDataSource directly rather than routing through
+  // DefaultDataSourceFactory.createNavigationDataSource (which wraps it in
+  // CachedNavigationDataSource) — intentionally bypassing the cache. Two reasons: (1) each fetch
+  // runs once per (appId, attempt) inside a LaunchedEffect, not per recomposition, so there is no
+  // recomposition-driven refetch storm for a cache to absorb; and (2) CachedNavigationDataSource
+  // caches Result.Error alongside success, so a retry (attempt++) would replay the STALE cached
+  // error instead of re-fetching, defeating the error -> retry -> success flow. Caching here would
+  // buy nothing and would need invalidation-on-retry to stay correct.
   val provider: (String?) -> NavigationDataSource =
     navigationDataSourceProvider
       ?: { appId ->

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OfflineNavigationBrowser.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OfflineNavigationBrowser.kt
@@ -35,7 +35,6 @@ import dev.jasonpearson.automobile.desktop.core.datasource.Result
 import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
 import dev.jasonpearson.automobile.desktop.core.logging.LoggerFactory
 import dev.jasonpearson.automobile.desktop.core.navigation.NavigationDashboard
-import dev.jasonpearson.automobile.desktop.core.navigation.NavigationScreenshotLoader
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -114,8 +113,9 @@ private fun AppListStep(
 
   LaunchedEffect(attempt) {
     state = AppListState.Loading
-    // Read off the UI thread: the resource read hits the daemon. Injected fakes run inline
-    // (deterministic). A throw becomes a retryable Error rather than crashing the Recomposer.
+    // Read off the UI thread: the resource read hits the daemon, so it runs on Dispatchers.IO
+    // (injected fakes hop the same dispatcher; tests stay deterministic via their waitUntil
+    // polling). A throw becomes a retryable Error rather than crashing the Recomposer.
     state =
       try {
         when (val result = withContext(Dispatchers.IO) { provider(null).listApps() }) {
@@ -123,7 +123,8 @@ private fun AppListStep(
             if (result.data.isEmpty()) AppListState.Empty else AppListState.Loaded(result.data)
           is Result.Error ->
             AppListState.Error(result.message ?: "Failed to load saved navigation graphs")
-          Result.Loading -> AppListState.Error("Saved navigation graphs are still loading")
+          // A one-shot read resolves to Success/Error; a stray Loading just keeps the spinner.
+          Result.Loading -> AppListState.Loading
         }
       } catch (c: CancellationException) {
         throw c
@@ -219,7 +220,8 @@ private fun AppGraphStep(
             else AppGraphState.Resolved(result.data)
           is Result.Error ->
             AppGraphState.Error(result.message ?: "Failed to load navigation graph")
-          Result.Loading -> AppGraphState.Error("Navigation graph is still loading")
+          // A one-shot read resolves to Success/Error; a stray Loading just keeps the spinner.
+          Result.Loading -> AppGraphState.Loading
         }
       } catch (c: CancellationException) {
         throw c
@@ -228,12 +230,6 @@ private fun AppGraphStep(
         AppGraphState.Error(e.message ?: "Failed to load navigation graph")
       }
   }
-
-  // Remembered per app so its LRU screenshot cache survives recomposition.
-  val screenshotLoader =
-    remember(app.appId) {
-      NavigationScreenshotLoader(clientProvider = { graph.autoMobileClient })
-    }
 
   Column(Modifier.fillMaxSize()) {
     Row(
@@ -271,7 +267,14 @@ private fun AppGraphStep(
         is AppGraphState.Resolved ->
           NavigationDashboard(
             providedGraph = current.graph,
-            screenshotLoader = screenshotLoader,
+            // No screenshot loader offline (screenshotLoader defaults to null → placeholder). The
+            // daemon's automobile:navigation/nodes/{id}/screenshot resource resolves the image via
+            // NavigationGraphManager.getCurrentAppId() + screenName, not the browsed app, so a
+            // node whose screen name collides with the daemon's current app (Home, MainActivity, …)
+            // would render the WRONG app's thumbnail — and not-found otherwise. Node ids are
+            // globally unique so the graph structure is correct; only per-node screenshots are
+            // mis-scoped. App-scoped offline screenshots are the follow-up #4933 (add ?appId= to
+            // the daemon resource); until then browse without thumbnails.
             settingsProvider = graph.settingsProvider,
             selectedAppId = app.appId,
             // Offline: device-side navigate actions are unavailable; browsing/panning still work.

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OfflineNavigationBrowser.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OfflineNavigationBrowser.kt
@@ -82,8 +82,7 @@ private sealed interface AppGraphState {
  */
 @Composable
 fun OfflineNavigationBrowser(
-  navigationDataSourceProvider: ((String?) -> NavigationDataSource)? = null,
-  reloadTrigger: Int = 0,
+  navigationDataSourceProvider: ((String?) -> NavigationDataSource)? = null
 ) {
   val graph = LocalAutoMobileGraph.current
   val provider: (String?) -> NavigationDataSource =
@@ -96,11 +95,7 @@ fun OfflineNavigationBrowser(
   var selectedApp by remember { mutableStateOf<NavigationAppSummary?>(null) }
 
   if (selectedApp == null) {
-    AppListStep(
-      provider = provider,
-      reloadTrigger = reloadTrigger,
-      onSelect = { selectedApp = it },
-    )
+    AppListStep(provider = provider, onSelect = { selectedApp = it })
   } else {
     val app = selectedApp
     if (app != null) {
@@ -112,13 +107,12 @@ fun OfflineNavigationBrowser(
 @Composable
 private fun AppListStep(
   provider: (String?) -> NavigationDataSource,
-  reloadTrigger: Int,
   onSelect: (NavigationAppSummary) -> Unit,
 ) {
   var attempt by remember { mutableStateOf(0) }
   var state by remember { mutableStateOf<AppListState>(AppListState.Loading) }
 
-  LaunchedEffect(reloadTrigger, attempt) {
+  LaunchedEffect(attempt) {
     state = AppListState.Loading
     // Read off the UI thread: the resource read hits the daemon. Injected fakes run inline
     // (deterministic). A throw becomes a retryable Error rather than crashing the Recomposer.

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -98,6 +98,10 @@ fun WorkspaceShell(
   // A pane closing can drop the observed count below two; retire any open compare so it can't
   // linger with a stale pair.
   if (comparePair == null && showCompare) showCompare = false
+  // Offline browse is only meaningful with no device observed; if one is observed mid-browse
+  // (Empty -> Content) retire the overlay so it can't linger (with its offline badge) over a live
+  // workspace.
+  if (state !is WorkspaceUiState.Empty && showOfflineBrowse) showOfflineBrowse = false
   Box(modifier.fillMaxSize()) {
     Column(Modifier.fillMaxSize()) {
       TopBar(

--- a/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
+++ b/android/desktop-core/src/main/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShell.kt
@@ -85,9 +85,15 @@ fun WorkspaceShell(
   compareContent: @Composable (DeviceColumn, DeviceColumn) -> Unit = { a, b ->
     TwoDeviceCompareView(columnA = a, columnB = b)
   },
+  // Body of the offline-browse overlay opened from the empty state's "Browse navigation history"
+  // affordance. Lets the user inspect a persisted navigation graph with no device observed (Phase C
+  // of #4837). Hoisted like the other bodies so a test can drive it with a fake data source;
+  // defaults to the real [OfflineNavigationBrowser].
+  offlineBrowseContent: @Composable () -> Unit = { OfflineNavigationBrowser() },
 ) {
   var showHealthSheet by remember { mutableStateOf(false) }
   var showCompare by remember { mutableStateOf(false) }
+  var showOfflineBrowse by remember { mutableStateOf(false) }
   val comparePair = (state as? WorkspaceUiState.Content)?.let(::compareColumns)
   // A pane closing can drop the observed count below two; retire any open compare so it can't
   // linger with a stale pair.
@@ -104,7 +110,12 @@ fun WorkspaceShell(
         onCompare = { showCompare = true },
       )
       when (state) {
-        is WorkspaceUiState.Empty -> EmptyState(onOpenPicker, Modifier.weight(1f).fillMaxWidth())
+        is WorkspaceUiState.Empty ->
+          EmptyState(
+            onOpenPicker = onOpenPicker,
+            onBrowseHistory = { showOfflineBrowse = true },
+            modifier = Modifier.weight(1f).fillMaxWidth(),
+          )
         is WorkspaceUiState.Content ->
           Row(Modifier.weight(1f).fillMaxWidth()) {
             val canDiff = state.columns.size > 1
@@ -139,6 +150,12 @@ fun WorkspaceShell(
         columnB = comparePair.second,
         onDismiss = { showCompare = false },
         content = compareContent,
+      )
+    }
+    if (showOfflineBrowse) {
+      OfflineBrowseOverlay(
+        onDismiss = { showOfflineBrowse = false },
+        content = offlineBrowseContent,
       )
     }
   }
@@ -397,7 +414,7 @@ private fun DefaultHealthSheetBody() {
 }
 
 @Composable
-private fun EmptyState(onOpenPicker: () -> Unit, modifier: Modifier) {
+private fun EmptyState(onOpenPicker: () -> Unit, onBrowseHistory: () -> Unit, modifier: Modifier) {
   Column(
     modifier = modifier,
     verticalArrangement = Arrangement.Center,
@@ -417,6 +434,66 @@ private fun EmptyState(onOpenPicker: () -> Unit, modifier: Modifier) {
           .padding(horizontal = 20.dp, vertical = 10.dp)
     ) {
       Text("Open Devices", color = Color.White)
+    }
+    Spacer(Modifier.height(12.dp))
+    // Offline path (Phase C of #4837): inspect a persisted navigation graph with no device
+    // observed.
+    Text(
+      "Browse navigation history",
+      style = MaterialTheme.typography.labelLarge,
+      color = Accent,
+      modifier =
+        Modifier.clickable { onBrowseHistory() }
+          .semantics { contentDescription = "Browse navigation history" }
+          .padding(horizontal = 12.dp, vertical = 8.dp),
+    )
+  }
+}
+
+/**
+ * Full-window overlay hosting the offline navigation browser: a dimmed scrim (click-away to
+ * dismiss) with a centered panel that renders [content]. Mirrors [HealthSheetOverlay].
+ */
+@Composable
+private fun OfflineBrowseOverlay(onDismiss: () -> Unit, content: @Composable () -> Unit) {
+  Box(
+    modifier =
+      Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.5f)).clickable(
+        interactionSource = remember { MutableInteractionSource() },
+        indication = null,
+      ) {
+        onDismiss()
+      },
+    contentAlignment = Alignment.Center,
+  ) {
+    Column(
+      modifier =
+        Modifier.fillMaxWidth(0.7f)
+          .fillMaxHeight(0.85f)
+          .background(MaterialTheme.colorScheme.surface, RoundedCornerShape(12.dp))
+          // Swallow clicks on the panel so they don't dismiss via the scrim.
+          .clickable(
+            interactionSource = remember { MutableInteractionSource() },
+            indication = null,
+          ) {}
+          .padding(16.dp)
+          .semantics { contentDescription = "Offline navigation browser" }
+    ) {
+      Row(Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        Text("Navigation history", style = MaterialTheme.typography.titleMedium)
+        Spacer(Modifier.weight(1f))
+        Text(
+          "✕",
+          style = MaterialTheme.typography.titleMedium,
+          color = MaterialTheme.colorScheme.onSurface,
+          modifier =
+            Modifier.clickable { onDismiss() }
+              .semantics { contentDescription = "Close navigation history" }
+              .padding(horizontal = 8.dp, vertical = 4.dp),
+        )
+      }
+      Spacer(Modifier.height(8.dp))
+      Box(Modifier.weight(1f).fillMaxWidth()) { content() }
     }
   }
 }

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealNavigationDataSourceListAppsTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealNavigationDataSourceListAppsTest.kt
@@ -1,0 +1,83 @@
+package dev.jasonpearson.automobile.desktop.core.datasource
+
+import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Covers [RealNavigationDataSource.listApps] against the locked `automobile:navigation/apps`
+ * resource contract (issue #4910): `{ "apps":
+ * [ { "appId", "displayName": null?, "lastUpdated": <ISO-8601> } ] }`, ordered newest-first.
+ * Exercised with a [FakeAutoMobileClient] so no socket / MCP daemon is touched.
+ */
+class RealNavigationDataSourceListAppsTest {
+
+  private val appsUri = "automobile:navigation/apps"
+
+  @Test
+  fun `parses apps preserving order and nullable displayName`() = runBlocking {
+    val client = FakeAutoMobileClient()
+    client.setResourceResponseWithText(
+      appsUri,
+      """
+      {
+        "apps": [
+          { "appId": "com.example.shopping", "displayName": "Shopping", "lastUpdated": "2026-01-03T12:00:00.000Z" },
+          { "appId": "com.example.banking", "displayName": null, "lastUpdated": "2026-01-01T09:30:00.000Z" }
+        ]
+      }
+      """
+        .trimIndent(),
+    )
+    val source = RealNavigationDataSource(clientProvider = { client })
+
+    val result = source.listApps()
+
+    assertTrue(result is Result.Success)
+    val apps = (result as Result.Success).data
+    assertEquals(2, apps.size)
+    // Newest-first order is preserved.
+    assertEquals("com.example.shopping", apps[0].appId)
+    assertEquals("Shopping", apps[0].displayName)
+    assertEquals("2026-01-03T12:00:00.000Z", apps[0].lastUpdated)
+    assertEquals("com.example.banking", apps[1].appId)
+    assertNull(apps[1].displayName)
+  }
+
+  @Test
+  fun `returns empty success when no apps have a graph`() = runBlocking {
+    val client = FakeAutoMobileClient()
+    client.setResourceResponseWithText(appsUri, """{ "apps": [] }""")
+    val source = RealNavigationDataSource(clientProvider = { client })
+
+    val result = source.listApps()
+
+    assertTrue(result is Result.Success)
+    assertTrue((result as Result.Success).data.isEmpty())
+  }
+
+  @Test
+  fun `returns empty success with no client provider`() = runBlocking {
+    val source = RealNavigationDataSource(clientProvider = null)
+
+    val result = source.listApps()
+
+    assertTrue(result is Result.Success)
+    assertTrue((result as Result.Success).data.isEmpty())
+  }
+
+  @Test
+  fun `surfaces a typed error when the resource read throws`() = runBlocking {
+    val client = FakeAutoMobileClient()
+    client.throwOnReadResource = RuntimeException("daemon down")
+    val source = RealNavigationDataSource(clientProvider = { client })
+
+    val result = source.listApps()
+
+    assertTrue(result is Result.Error)
+    assertTrue((result as Result.Error).message.orEmpty().contains("daemon down"))
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealNavigationDataSourceListAppsTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/datasource/RealNavigationDataSourceListAppsTest.kt
@@ -70,6 +70,46 @@ class RealNavigationDataSourceListAppsTest {
   }
 
   @Test
+  fun `surfaces an error when the daemon returns an error envelope`() = runBlocking {
+    // The daemon signals failure with { "error": ... } rather than throwing. Under
+    // ignoreUnknownKeys this would otherwise decode to an all-defaults (empty apps) object and
+    // masquerade as a genuinely-empty list, so it must be detected as an error.
+    val client = FakeAutoMobileClient()
+    client.setResourceResponseWithText(
+      appsUri,
+      """{ "error": "Failed to list apps with navigation graph: boom" }""",
+    )
+    val source = RealNavigationDataSource(clientProvider = { client })
+
+    val result = source.listApps()
+
+    assertTrue(result is Result.Error)
+    assertTrue((result as Result.Error).message.orEmpty().contains("boom"))
+  }
+
+  @Test
+  fun `getNavigationGraph surfaces an error envelope but keeps a genuinely-empty graph as success`() =
+    runBlocking {
+      val graphUri = "automobile:navigation/graph"
+      val client = FakeAutoMobileClient()
+
+      // Error envelope -> Result.Error.
+      client.setResourceResponseWithText(
+        graphUri,
+        """{ "error": "Failed to retrieve navigation graph: boom" }""",
+      )
+      val errored = RealNavigationDataSource(clientProvider = { client }).getNavigationGraph()
+      assertTrue(errored is Result.Error)
+      assertTrue((errored as Result.Error).message.orEmpty().contains("boom"))
+
+      // Genuinely-empty graph -> Result.Success(empty).
+      client.setResourceResponseWithText(graphUri, """{ "nodes": [], "edges": [] }""")
+      val empty = RealNavigationDataSource(clientProvider = { client }).getNavigationGraph()
+      assertTrue(empty is Result.Success)
+      assertTrue((empty as Result.Success).data.screens.isEmpty())
+    }
+
+  @Test
   fun `surfaces a typed error when the resource read throws`() = runBlocking {
     val client = FakeAutoMobileClient()
     client.throwOnReadResource = RuntimeException("daemon down")

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OfflineNavigationBrowserTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OfflineNavigationBrowserTest.kt
@@ -1,0 +1,200 @@
+package dev.jasonpearson.automobile.desktop.core.workspace
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import dev.jasonpearson.automobile.desktop.core.datasource.DefaultDataSourceFactory
+import dev.jasonpearson.automobile.desktop.core.datasource.NavigationAppSummary
+import dev.jasonpearson.automobile.desktop.core.datasource.NavigationDataSource
+import dev.jasonpearson.automobile.desktop.core.datasource.NavigationGraph
+import dev.jasonpearson.automobile.desktop.core.datasource.Result
+import dev.jasonpearson.automobile.desktop.core.di.AutoMobileGraphProvider
+import dev.jasonpearson.automobile.desktop.core.di.LocalAutoMobileGraph
+import dev.jasonpearson.automobile.desktop.core.navigation.NavigationDashboard
+import dev.jasonpearson.automobile.desktop.core.navigation.ScreenNode
+import dev.jasonpearson.automobile.desktop.core.settings.FakeSettingsProvider
+import dev.jasonpearson.automobile.desktop.core.testing.FakeAutoMobileClient
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalTestApi::class)
+class OfflineNavigationBrowserTest {
+
+  private fun testGraph(): AutoMobileGraphProvider {
+    val client = FakeAutoMobileClient()
+    return object : AutoMobileGraphProvider {
+      override val autoMobileClient = client
+      override val settingsProvider = FakeSettingsProvider()
+      override val dataSourceFactory = DefaultDataSourceFactory(client)
+    }
+  }
+
+  private fun screen(name: String) =
+    ScreenNode(
+      id = name.lowercase(),
+      name = name,
+      type = "Activity",
+      packageName = "com.example.app",
+      transitionCount = 0,
+      discoveredAt = 0L,
+    )
+
+  /** A configurable fake serving both listApps and per-app getNavigationGraph. */
+  private class FakeBrowserDataSource(
+    private val appsResult: Result<List<NavigationAppSummary>>,
+    private val graphResult: Result<NavigationGraph> =
+      Result.Success(NavigationGraph(emptyList(), emptyList())),
+  ) : NavigationDataSource {
+    val graphCalls = AtomicInteger(0)
+
+    override suspend fun getNavigationGraph(): Result<NavigationGraph> {
+      graphCalls.incrementAndGet()
+      return graphResult
+    }
+
+    override suspend fun listApps(): Result<List<NavigationAppSummary>> = appsResult
+  }
+
+  private fun appSummary(appId: String, displayName: String?, lastUpdated: String = "2026-01-01") =
+    NavigationAppSummary(appId = appId, displayName = displayName, lastUpdated = lastUpdated)
+
+  @Test
+  fun `lists apps offline with displayName falling back to appId`() = runComposeUiTest {
+    val source =
+      FakeBrowserDataSource(
+        Result.Success(
+          listOf(
+            appSummary("com.example.shopping", "Shopping"),
+            appSummary("com.example.banking", null),
+          )
+        )
+      )
+    setContent {
+      CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+        MaterialTheme { OfflineNavigationBrowser(navigationDataSourceProvider = { source }) }
+      }
+    }
+
+    waitUntil(timeoutMillis = 5_000) {
+      onAllNodesWithText("Shopping").fetchSemanticsNodes().isNotEmpty()
+    }
+    onNodeWithText("Shopping").assertExists()
+    // Null displayName falls back to the appId as the primary label.
+    onNodeWithText("com.example.banking").assertExists()
+  }
+
+  @Test
+  fun `selecting an app renders the NavigationDashboard from the returned graph`() =
+    runComposeUiTest {
+      val source =
+        FakeBrowserDataSource(
+          appsResult = Result.Success(listOf(appSummary("com.example.app", "Sample"))),
+          graphResult = Result.Success(NavigationGraph(listOf(screen("Alpha")), emptyList())),
+        )
+      setContent {
+        CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+          MaterialTheme { OfflineNavigationBrowser(navigationDataSourceProvider = { source }) }
+        }
+      }
+      waitUntil(timeoutMillis = 5_000) {
+        onAllNodesWithText("Sample").fetchSemanticsNodes().isNotEmpty()
+      }
+
+      onNodeWithContentDescription("Open navigation graph for Sample").performClick()
+
+      // The persisted graph is rendered through NavigationDashboard (its canvas draws screen
+      // names).
+      waitUntil(timeoutMillis = 5_000) {
+        onAllNodesWithText("Alpha").fetchSemanticsNodes().isNotEmpty()
+      }
+      onAllNodesWithText("Alpha").fetchSemanticsNodes().isNotEmpty()
+      assertTrue("graph should be pulled from the data source", source.graphCalls.get() >= 1)
+    }
+
+  @Test
+  fun `navigate actions are disabled offline once an app is opened`() = runComposeUiTest {
+    val source =
+      FakeBrowserDataSource(
+        appsResult = Result.Success(listOf(appSummary("com.example.app", "Sample"))),
+        graphResult = Result.Success(NavigationGraph(listOf(screen("Alpha")), emptyList())),
+      )
+    setContent {
+      CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+        MaterialTheme { OfflineNavigationBrowser(navigationDataSourceProvider = { source }) }
+      }
+    }
+    waitUntil(timeoutMillis = 5_000) {
+      onAllNodesWithText("Sample").fetchSemanticsNodes().isNotEmpty()
+    }
+    onNodeWithContentDescription("Open navigation graph for Sample").performClick()
+
+    waitUntil(timeoutMillis = 5_000) {
+      onAllNodesWithContentDescription("Navigate actions disabled (offline)")
+        .fetchSemanticsNodes()
+        .isNotEmpty()
+    }
+    onNodeWithContentDescription("Navigate actions disabled (offline)").assertExists()
+  }
+
+  @Test
+  fun `shows the empty state when no saved graphs exist`() = runComposeUiTest {
+    val source = FakeBrowserDataSource(Result.Success(emptyList()))
+    setContent {
+      CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+        MaterialTheme { OfflineNavigationBrowser(navigationDataSourceProvider = { source }) }
+      }
+    }
+
+    waitUntil(timeoutMillis = 5_000) {
+      onAllNodesWithText("No saved navigation graphs").fetchSemanticsNodes().isNotEmpty()
+    }
+    onNodeWithText("No saved navigation graphs").assertExists()
+  }
+
+  @Test
+  fun `shows a retryable error when the app list fails to load`() = runComposeUiTest {
+    val source = FakeBrowserDataSource(Result.Error(RuntimeException("daemon down"), "daemon down"))
+    setContent {
+      CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+        MaterialTheme { OfflineNavigationBrowser(navigationDataSourceProvider = { source }) }
+      }
+    }
+
+    waitUntil(timeoutMillis = 5_000) {
+      onAllNodesWithText("daemon down", substring = true).fetchSemanticsNodes().isNotEmpty()
+    }
+    onNodeWithText("daemon down", substring = true).assertExists()
+    onNodeWithContentDescription("Retry loading saved navigation graphs").assertExists()
+  }
+
+  @Test
+  fun `read-only badge is absent when the dashboard is online`() = runComposeUiTest {
+    setContent {
+      CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+        MaterialTheme {
+          NavigationDashboard(
+            providedGraph = NavigationGraph(listOf(screen("Alpha")), emptyList()),
+            readOnly = false,
+          )
+        }
+      }
+    }
+    waitUntil(timeoutMillis = 5_000) {
+      onAllNodesWithText("Alpha").fetchSemanticsNodes().isNotEmpty()
+    }
+    // Online: no offline read-only badge.
+    assertTrue(
+      "navigate actions must not be marked disabled when online",
+      onAllNodesWithContentDescription("Navigate actions disabled (offline)")
+        .fetchSemanticsNodes()
+        .isEmpty(),
+    )
+  }
+}

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OfflineNavigationBrowserTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/OfflineNavigationBrowserTest.kt
@@ -62,6 +62,20 @@ class OfflineNavigationBrowserTest {
     override suspend fun listApps(): Result<List<NavigationAppSummary>> = appsResult
   }
 
+  /** A fake whose results come from suppliers, so a test can flip error -> success across calls. */
+  private class SuppliedDataSource(
+    private val apps: () -> Result<List<NavigationAppSummary>> = {
+      Result.Success(emptyList())
+    },
+    private val graph: () -> Result<NavigationGraph> = {
+      Result.Success(NavigationGraph(emptyList(), emptyList()))
+    },
+  ) : NavigationDataSource {
+    override suspend fun getNavigationGraph(): Result<NavigationGraph> = graph()
+
+    override suspend fun listApps(): Result<List<NavigationAppSummary>> = apps()
+  }
+
   private fun appSummary(appId: String, displayName: String?, lastUpdated: String = "2026-01-01") =
     NavigationAppSummary(appId = appId, displayName = displayName, lastUpdated = lastUpdated)
 
@@ -172,6 +186,157 @@ class OfflineNavigationBrowserTest {
     }
     onNodeWithText("daemon down", substring = true).assertExists()
     onNodeWithContentDescription("Retry loading saved navigation graphs").assertExists()
+  }
+
+  @Test
+  fun `app list error then retry loads the apps`() = runComposeUiTest {
+    val attempts = AtomicInteger(0)
+    val source =
+      SuppliedDataSource(
+        apps = {
+          if (attempts.getAndIncrement() == 0)
+            Result.Error(RuntimeException("daemon down"), "daemon down")
+          else Result.Success(listOf(appSummary("com.example.app", "Sample")))
+        }
+      )
+    setContent {
+      CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+        MaterialTheme { OfflineNavigationBrowser(navigationDataSourceProvider = { source }) }
+      }
+    }
+    waitUntil(timeoutMillis = 5_000) {
+      onAllNodesWithText("daemon down", substring = true).fetchSemanticsNodes().isNotEmpty()
+    }
+
+    onNodeWithContentDescription("Retry loading saved navigation graphs").performClick()
+    waitUntil(timeoutMillis = 5_000) {
+      onAllNodesWithText("Sample").fetchSemanticsNodes().isNotEmpty()
+    }
+    onNodeWithText("Sample").assertExists()
+  }
+
+  @Test
+  fun `app graph error then retry renders the graph`() = runComposeUiTest {
+    val attempts = AtomicInteger(0)
+    val source =
+      SuppliedDataSource(
+        apps = { Result.Success(listOf(appSummary("com.example.app", "Sample"))) },
+        graph = {
+          if (attempts.getAndIncrement() == 0)
+            Result.Error(RuntimeException("graph gone"), "graph gone")
+          else Result.Success(NavigationGraph(listOf(screen("Alpha")), emptyList()))
+        },
+      )
+    setContent {
+      CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+        MaterialTheme { OfflineNavigationBrowser(navigationDataSourceProvider = { source }) }
+      }
+    }
+    waitUntil(timeoutMillis = 5_000) {
+      onAllNodesWithText("Sample").fetchSemanticsNodes().isNotEmpty()
+    }
+    onNodeWithContentDescription("Open navigation graph for Sample").performClick()
+    waitUntil(timeoutMillis = 5_000) {
+      onAllNodesWithText("graph gone", substring = true).fetchSemanticsNodes().isNotEmpty()
+    }
+
+    onNodeWithContentDescription("Retry loading navigation graph").performClick()
+    waitUntil(timeoutMillis = 5_000) {
+      onAllNodesWithText("Alpha").fetchSemanticsNodes().isNotEmpty()
+    }
+    onAllNodesWithText("Alpha").fetchSemanticsNodes().isNotEmpty()
+  }
+
+  @Test
+  fun `switching apps after Back renders the new app graph not the previous one`() =
+    runComposeUiTest {
+      // Distinct graph per appId so a stale render is detectable by screen name.
+      val provider: (String?) -> NavigationDataSource = { appId ->
+        when (appId) {
+          null ->
+            SuppliedDataSource(
+              apps = {
+                Result.Success(
+                  listOf(appSummary("com.example.a", "AppA"), appSummary("com.example.b", "AppB"))
+                )
+              }
+            )
+          "com.example.a" ->
+            SuppliedDataSource(
+              graph = { Result.Success(NavigationGraph(listOf(screen("Alpha")), emptyList())) }
+            )
+          else ->
+            SuppliedDataSource(
+              graph = { Result.Success(NavigationGraph(listOf(screen("Beta")), emptyList())) }
+            )
+        }
+      }
+      setContent {
+        CompositionLocalProvider(LocalAutoMobileGraph provides testGraph()) {
+          MaterialTheme { OfflineNavigationBrowser(navigationDataSourceProvider = provider) }
+        }
+      }
+      waitUntil(timeoutMillis = 5_000) {
+        onAllNodesWithText("AppA").fetchSemanticsNodes().isNotEmpty()
+      }
+
+      onNodeWithContentDescription("Open navigation graph for AppA").performClick()
+      waitUntil(timeoutMillis = 5_000) {
+        onAllNodesWithText("Alpha").fetchSemanticsNodes().isNotEmpty()
+      }
+
+      onNodeWithContentDescription("Back to saved navigation graphs").performClick()
+      waitUntil(timeoutMillis = 5_000) {
+        onAllNodesWithText("AppB").fetchSemanticsNodes().isNotEmpty()
+      }
+
+      onNodeWithContentDescription("Open navigation graph for AppB").performClick()
+      waitUntil(timeoutMillis = 5_000) {
+        onAllNodesWithText("Beta").fetchSemanticsNodes().isNotEmpty()
+      }
+      assertTrue(
+        "app B's graph must render, not the previously-opened app A's",
+        onAllNodesWithText("Alpha").fetchSemanticsNodes().isEmpty(),
+      )
+    }
+
+  @Test
+  fun `offline browse does not fetch a mis-scoped node screenshot`() = runComposeUiTest {
+    // The daemon's node-screenshot resource resolves via getCurrentAppId(), not the browsed app,
+    // so offline thumbnails could render the wrong app's image. The offline path wires no
+    // screenshot loader; prove it never reads the screenshot resource even when a node carries a
+    // screenshotUri. A real loader would call client.readResource on render of the node card.
+    val client = FakeAutoMobileClient()
+    val graphProvider =
+      object : AutoMobileGraphProvider {
+        override val autoMobileClient = client
+        override val settingsProvider = FakeSettingsProvider()
+        override val dataSourceFactory = DefaultDataSourceFactory(client)
+      }
+    val nodeWithShot =
+      screen("Alpha").copy(screenshotUri = "automobile:navigation/nodes/1/screenshot")
+    val source =
+      FakeBrowserDataSource(
+        appsResult = Result.Success(listOf(appSummary("com.example.app", "Sample"))),
+        graphResult = Result.Success(NavigationGraph(listOf(nodeWithShot), emptyList())),
+      )
+    setContent {
+      CompositionLocalProvider(LocalAutoMobileGraph provides graphProvider) {
+        MaterialTheme { OfflineNavigationBrowser(navigationDataSourceProvider = { source }) }
+      }
+    }
+    waitUntil(timeoutMillis = 5_000) {
+      onAllNodesWithText("Sample").fetchSemanticsNodes().isNotEmpty()
+    }
+    onNodeWithContentDescription("Open navigation graph for Sample").performClick()
+    waitUntil(timeoutMillis = 5_000) {
+      onAllNodesWithText("Alpha").fetchSemanticsNodes().isNotEmpty()
+    }
+
+    assertTrue(
+      "offline browse must not read the (mis-scoped) node-screenshot resource",
+      client.calls.none { it == "readResource" },
+    )
   }
 
   @Test

--- a/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
+++ b/android/desktop-core/src/test/kotlin/dev/jasonpearson/automobile/desktop/core/workspace/WorkspaceShellUiTest.kt
@@ -438,4 +438,31 @@ class WorkspaceShellUiTest {
     onNodeWithContentDescription("Status detail: Daemon reconnecting").performClick()
     onNodeWithText("fake-health-body").assertIsDisplayed()
   }
+
+  @Test
+  fun `empty state offers a Browse navigation history affordance`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(state = WorkspaceUiState.Empty, onAction = {}, onOpenPicker = {})
+      }
+    }
+    onNodeWithContentDescription("Browse navigation history").assertIsDisplayed()
+  }
+
+  @Test
+  fun `Browse navigation history opens the offline browse overlay`() = runComposeUiTest {
+    setContent {
+      MaterialTheme {
+        WorkspaceShell(
+          state = WorkspaceUiState.Empty,
+          onAction = {},
+          onOpenPicker = {},
+          offlineBrowseContent = { Text("offline-browse-body") },
+        )
+      }
+    }
+    // Overlay body is not present until the affordance is clicked.
+    onNodeWithContentDescription("Browse navigation history").performClick()
+    onNodeWithText("offline-browse-body").assertIsDisplayed()
+  }
 }


### PR DESCRIPTION
## Summary

Phase C of the desktop nav-graph model ([#4837](https://github.com/kaeawc/auto-mobile/issues/4837)): with **no device booted/observed**, let users still browse a persisted navigation graph from past sessions.

Reachable from the workspace **empty state** — the natural "no device observed" surface (`WorkspaceUiState.Empty`) — via a new **"Browse navigation history"** affordance that opens an overlay (mirroring the existing health-sheet / compare overlays). Chosen over the device picker because the picker is a modal for *booting/observing* devices; offline browse is a distinct read-only flow that shouldn't require the picker to be open.

> Depends on [#4928](https://github.com/kaeawc/auto-mobile/pull/4928) ([#4910](https://github.com/kaeawc/auto-mobile/issues/4910)), which adds the daemon `automobile:navigation/apps` resource. Built against that locked contract; tests use fakes so they pass without it merged. **Must merge after #4928** — the real data source reads that resource at runtime. Do not auto-merge.

## Changes

- **`NavigationDataSource.listApps()`** — new device-independent method returning `List<NavigationAppSummary>` (`appId: String`, `displayName: String?`, `lastUpdated: String`), backed by the device-optional `automobile:navigation/apps` resource (contract: `{ "apps": [ { "appId", "displayName": null?, "lastUpdated": <ISO-8601> } ] }`, newest-first).
  - `RealNavigationDataSource` reads + parses it (mirrors the existing `navigation/graph?appId=` read + error handling).
  - `FakeNavigationDataSource` and `CachedNavigationDataSource` (separate cache keyspace) implement it.
  - Defaulted on the interface so the many app-scoped implementers stay untouched.
- **`OfflineNavigationBrowser`** — facet-pattern stateless composable with an injected `(String?) -> NavigationDataSource` provider (defaults to Real, fake for tests). Lists apps (`displayName ?: appId` + `lastUpdated`); on select, pulls `getNavigationGraph()` and renders the **existing `NavigationDashboard`** via `providedGraph` (no fork). Loading / empty (`No saved navigation graphs`) / error states.
- **`NavigationDashboard` gains `readOnly`** — offline, device-side navigate actions are unavailable (surfaced as a `Navigate actions disabled (offline)` badge overlaying all sections); browsing/panning/zoom/detail still work. Any future live "navigate to this screen" affordance gates on this flag.
- **`WorkspaceShell`** — empty state affordance + hoisted `offlineBrowseContent` overlay body (default real, fake for tests).

## Testing

`JAVA_HOME=azul-21` · `./gradlew :desktop-core:detektMain :desktop-core:test :desktop-app:compileKotlin` → **BUILD SUCCESSFUL**.

- `RealNavigationDataSourceListAppsTest` (4) — parses/preserves newest-first order + nullable `displayName`, empty success, no-client, typed error on throw.
- `OfflineNavigationBrowserTest` (6) — lists apps offline (displayName→appId fallback), select → dashboard renders the returned graph, navigate-disabled-offline badge, empty state, retryable error, and badge absent when online.
- `WorkspaceShellUiTest` (+2) — empty-state affordance present, click opens the offline-browse overlay.

## Acceptance criteria

- [x] Surface reachable with no device observed that lists apps with a persisted graph (via the new list-apps capability) and opens a selected app's Navigation view from persisted data (reuses `NavigationDashboard`).
- [x] Read-only: `navigateTo` actions disabled/greyed offline; browsing/panning works.
- [x] Loading / empty (`No saved navigation graphs`) / error states, with a fake data source.

Closes #4911
