### PR TITLE
security(ios): move CtrlProxy helper extraction/launch off world-writable /tmp and re-verify hash before launch (TOCTOU)

### DIFF
--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -23,6 +23,8 @@ import {
 } from "./IOSCtrlProxyBundleDownloader";
 import { hashAppBundle } from "./ios-cmdline-tools/AppBundleHasher";
 import { resolvePathFromDaemonLaunchWorkingDirectory } from "./workingDirectory";
+import { getTempDir } from "./tempDir";
+import { ensureSecureDir } from "./filesystem/securePermissions";
 import {
   buildPlist,
   injectUITestEnvironment,
@@ -96,7 +98,16 @@ export class IOSCtrlProxyBuilder {
    */
   private static readonly RUNNER_XCTESTRUN_PREFIX = "automobile-runner-";
   private static readonly DEFAULT_PROJECT_ROOT = process.cwd();
-  private static readonly DEFAULT_DERIVED_DATA_PATH = "/tmp/automobile-ctrl-proxy";
+  /**
+   * Subdirectory under the uid-private auto-mobile base (`~/.auto-mobile`) where
+   * the runner bundle is extracted and later launched from. Replaces the former
+   * world-writable, predictable `/tmp/automobile-ctrl-proxy` default: on a shared
+   * host any other uid could pre-seed that path or swap the runner/xctest binary
+   * between the integrity check and launch (TOCTOU, issue #4759). Resolved lazily
+   * via {@link getTempDir} so an `AUTOMOBILE_DATA_DIR` override set after module
+   * load is honored.
+   */
+  private static readonly DEFAULT_DERIVED_DATA_SUBDIR = "derived-data";
   private static readonly DEFAULT_SCHEME = "CtrlProxyApp";
   private static readonly DEFAULT_DESTINATION = "generic/platform=iOS Simulator";
   private static readonly DEFAULT_BUNDLE_CACHE_DIR = path.join(os.homedir(), ".automobile", "ctrl-proxy-ios");
@@ -146,7 +157,7 @@ export class IOSCtrlProxyBuilder {
   ) {
     this.config = {
       projectRoot: config.projectRoot || process.env.AUTOMOBILE_PROJECT_ROOT || IOSCtrlProxyBuilder.DEFAULT_PROJECT_ROOT,
-      derivedDataPath: config.derivedDataPath || process.env.AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA || IOSCtrlProxyBuilder.DEFAULT_DERIVED_DATA_PATH,
+      derivedDataPath: config.derivedDataPath || process.env.AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA || getTempDir(IOSCtrlProxyBuilder.DEFAULT_DERIVED_DATA_SUBDIR),
       scheme: config.scheme || IOSCtrlProxyBuilder.DEFAULT_SCHEME,
       destination: config.destination || IOSCtrlProxyBuilder.DEFAULT_DESTINATION,
       bundleCacheDir: config.bundleCacheDir || process.env.AUTOMOBILE_CTRL_PROXY_IOS_CACHE_DIR || IOSCtrlProxyBuilder.DEFAULT_BUNDLE_CACHE_DIR,
@@ -796,7 +807,7 @@ export class IOSCtrlProxyBuilder {
   }
 
   private async ensureBundleDownloaded(): Promise<{ bundlePath: string; usedCachedFallback: boolean }> {
-    await fs.mkdir(this.config.bundleCacheDir, { recursive: true });
+    await ensureSecureDir(this.config.bundleCacheDir);
     const bundlePath = this.getBundlePath();
 
     const overridePath = this.getBundlePathOverride();
@@ -915,7 +926,15 @@ export class IOSCtrlProxyBuilder {
   }
 
   private async extractBundle(bundlePath: string): Promise<void> {
+    // Fail closed before wiping/repopulating the tree if it is owned by another
+    // uid — extracting into a directory we do not own reopens the TOCTOU window
+    // this hardening closes (issue #4759).
+    await this.assertDerivedDataDirOwnedByCurrentUid();
     await this.downloader.extractBundle(bundlePath, this.config.derivedDataPath);
+    // Authoritatively restrict the extraction tree to owner-only (0o700),
+    // independent of the downloader implementation: the runner is launched from
+    // here, so other uids must not be able to read or swap its binaries (#4759).
+    await ensureSecureDir(this.config.derivedDataPath);
     await this.normalizeExtractedBundle();
     await this.verifyExtractedArtifacts();
 
@@ -964,7 +983,7 @@ export class IOSCtrlProxyBuilder {
     const targetBuildDir = path.join(this.config.derivedDataPath, "Build");
 
     await fs.rm(targetBuildDir, { recursive: true, force: true });
-    await fs.mkdir(this.config.derivedDataPath, { recursive: true });
+    await ensureSecureDir(this.config.derivedDataPath);
 
     try {
       await fs.rename(sourceBuildDir, targetBuildDir);
@@ -1027,21 +1046,92 @@ export class IOSCtrlProxyBuilder {
 
     // Verify the release-selected runner executable SHA256 for simulator.
     if (platform === "simulator") {
-      const expectedRunnerSha256 = this.getExpectedRunnerChecksum();
-      if (expectedRunnerSha256 && expectedRunnerSha256.length > 0) {
-        const runnerChecksumTarget = this.getExpectedRunnerChecksumTarget();
-        const runnerBinaryPath = await this.getRunnerBinaryPath(platform, runnerChecksumTarget);
-        if (!runnerBinaryPath) {
-          throw new Error(`CtrlProxy runner binary missing for ${platform}`);
-        }
-        const { checksum } = await this.downloader.computeFileSha256(runnerBinaryPath);
-        if (checksum.toLowerCase() !== expectedRunnerSha256.toLowerCase()) {
-          throw new Error(`CtrlProxy runner binary SHA256 mismatch for ${platform}. Expected: ${expectedRunnerSha256}, Got: ${checksum}`);
-        }
-        logger.info("[IOSCtrlProxyBuilder] Runner binary SHA256 verified", { platform, checksum });
-      } else {
-        logger.warn(`[IOSCtrlProxyBuilder] Runner binary SHA256 verification skipped for ${platform} (no hash provided)`);
-      }
+      await this.assertRunnerBinaryHash(platform, "post-extract");
+    }
+  }
+
+  /**
+   * Verify the runner executable's SHA256 against the release-selected expected
+   * hash. Shared by the post-extract check and the pre-launch re-verification
+   * (issue #4759). A no-op when no expected hash is configured (mirrors the prior
+   * skip-with-warning behavior); throws {@link ActionableError} on mismatch so the
+   * caller fails closed rather than launching a tampered binary.
+   *
+   * @param phase - which verification window this is, for log/error context.
+   */
+  private async assertRunnerBinaryHash(
+    platform: IOSCtrlProxyPlatform,
+    phase: "post-extract" | "pre-launch"
+  ): Promise<void> {
+    const expectedRunnerSha256 = this.getExpectedRunnerChecksum();
+    if (!expectedRunnerSha256 || expectedRunnerSha256.length === 0) {
+      logger.warn(`[IOSCtrlProxyBuilder] Runner binary SHA256 verification skipped for ${platform} (no hash provided)`);
+      return;
+    }
+    const runnerChecksumTarget = this.getExpectedRunnerChecksumTarget();
+    const runnerBinaryPath = await this.getRunnerBinaryPath(platform, runnerChecksumTarget);
+    if (!runnerBinaryPath) {
+      throw new ActionableError(`CtrlProxy runner binary missing for ${platform}`);
+    }
+    const { checksum } = await this.downloader.computeFileSha256(runnerBinaryPath);
+    if (checksum.toLowerCase() !== expectedRunnerSha256.toLowerCase()) {
+      throw new ActionableError(
+        `CtrlProxy runner binary SHA256 mismatch (${phase}) for ${platform}. ` +
+        `Expected: ${expectedRunnerSha256}, Got: ${checksum}. Refusing to launch a runner whose ` +
+        `binary changed since it was verified (possible TOCTOU tampering).`
+      );
+    }
+    logger.info(`[IOSCtrlProxyBuilder] Runner binary SHA256 verified (${phase})`, { platform, checksum });
+  }
+
+  /**
+   * Re-verify the runner binary hash and derived-data ownership IMMEDIATELY
+   * before launch (issue #4759). Post-extract verification alone leaves a
+   * verify→execute window in which a local attacker on a shared host can swap the
+   * runner/xctest binary before `xcodebuild test-without-building` runs it.
+   * {@link IOSCtrlProxyManager} calls this right before spawning the runner to
+   * close that window. Fails closed (throws {@link ActionableError}) on a foreign
+   * uid or a hash mismatch.
+   */
+  public async verifyRunnerBinaryBeforeLaunch(platform: IOSCtrlProxyPlatform): Promise<void> {
+    await this.assertDerivedDataDirOwnedByCurrentUid();
+    await this.assertRunnerBinaryHash(platform, "pre-launch");
+  }
+
+  /**
+   * Fail closed (issue #4759) when the derived-data directory already exists but
+   * is owned by a different uid. On a shared host another user could pre-seed the
+   * directory (the old `/tmp` default was world-writable and predictable) and swap
+   * the runner/xctest binaries out from under our integrity check. Reusing a
+   * directory we do not own reopens that TOCTOU window, so we refuse to extract
+   * into or launch from it.
+   *
+   * POSIX-only: Windows has no `st_uid`/`process.getuid`, so the check no-ops
+   * there — access control on Windows is via ACLs, outside the scope of these
+   * bits (matching {@link ensureSecureDir}'s cross-platform contract).
+   */
+  private async assertDerivedDataDirOwnedByCurrentUid(): Promise<void> {
+    const getuid = process.getuid?.bind(process);
+    if (process.platform === "win32" || !getuid) {
+      return;
+    }
+    let stats;
+    try {
+      stats = await fs.stat(this.config.derivedDataPath);
+    } catch (error) {
+      // Directory does not exist yet (first extraction) — nothing to refuse. Any
+      // other stat error is treated the same: the create step that follows will
+      // surface a real failure with a clearer message.
+      logger.debug(`[IOSCtrlProxyBuilder] derived-data stat failed (treated as absent): ${error}`, error);
+      return;
+    }
+    const currentUid = getuid();
+    if (stats.uid !== currentUid) {
+      throw new ActionableError(
+        `Refusing to reuse CtrlProxy derived-data directory ${this.config.derivedDataPath}: it is ` +
+        `owned by uid ${stats.uid}, not the current uid ${currentUid}. Another user may have pre-seeded ` +
+        `or tampered with it. Delete it, or set AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA to a directory you own.`
+      );
     }
   }
 

--- a/src/utils/IOSCtrlProxyBundleDownloader.ts
+++ b/src/utils/IOSCtrlProxyBundleDownloader.ts
@@ -2,6 +2,7 @@ import * as fs from "fs/promises";
 import AdmZip from "adm-zip";
 import { type FileDownloader, DefaultFileDownloader } from "./FileDownloader";
 import { type ChecksumCalculator, type Sha256Source, DefaultChecksumCalculator } from "./ChecksumCalculator";
+import { ensureSecureDir } from "./filesystem/securePermissions";
 
 export type { Sha256Source };
 
@@ -33,7 +34,10 @@ export class DefaultIOSCtrlProxyBundleDownloader implements CtrlProxyIosBundleDo
 
   public async extractBundle(bundlePath: string, destination: string): Promise<void> {
     await fs.rm(destination, { recursive: true, force: true });
-    await fs.mkdir(destination, { recursive: true });
+    // Owner-only (0o700) instead of the umask default: the extracted runner is
+    // launched from here, so other uids must not be able to swap its binaries
+    // between verification and launch (TOCTOU, issue #4759).
+    await ensureSecureDir(destination);
 
     const zip = new AdmZip(bundlePath);
     zip.extractAllTo(destination, true);

--- a/src/utils/IOSCtrlProxyManager.ts
+++ b/src/utils/IOSCtrlProxyManager.ts
@@ -1320,6 +1320,11 @@ export class IOSCtrlProxyManager implements CtrlProxyIosManager {
       throw new Error("CtrlProxy xctestrun not found for simulator. Download the CtrlProxy bundle before starting.");
     }
 
+    // Re-verify the runner binary hash (and refuse a foreign-owned derived-data
+    // tree) IMMEDIATELY before launch, closing the verify→execute TOCTOU window
+    // left by post-extract verification alone (issue #4759).
+    await this.builder.verifyRunnerBinaryBeforeLaunch("simulator");
+
     const timeout = process.env.CTRL_PROXY_IOS_TIMEOUT || "86400";
     const bundleId = this.resolveTargetBundleId();
     this.ensureLocalServicePortAllocatedAndAvailable();

--- a/test/utils/IOSCtrlProxyBuilder.test.ts
+++ b/test/utils/IOSCtrlProxyBuilder.test.ts
@@ -1,6 +1,7 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { IOSCtrlProxyBuilder } from "../../src/utils/IOSCtrlProxyBuilder";
 import { FakeIOSCtrlProxyBundleDownloader } from "../fakes/FakeIOSCtrlProxyBundleDownloader";
+import { getTempDir } from "../../src/utils/tempDir";
 import * as fs from "fs/promises";
 import * as path from "path";
 import os from "os";
@@ -113,7 +114,11 @@ describe("IOSCtrlProxyBuilder", function() {
 
       expect(config.scheme).toBe("CtrlProxyApp");
       expect(config.destination).toBe("generic/platform=iOS Simulator");
-      expect(config.derivedDataPath).toBe("/tmp/automobile-ctrl-proxy");
+      // Off the world-writable /tmp default onto a uid-private ~/.auto-mobile
+      // subdir (issue #4759). Compare against getTempDir() so the assertion is
+      // path-separator agnostic and honors AUTOMOBILE_DATA_DIR on CI.
+      expect(config.derivedDataPath).toBe(getTempDir("derived-data"));
+      expect(config.derivedDataPath).not.toContain("/tmp/");
       expect(config.bundleCacheDir).toBe(path.join(os.homedir(), ".automobile", "ctrl-proxy-ios"));
     });
 
@@ -678,6 +683,102 @@ describe("IOSCtrlProxyBuilder", function() {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain("runner binary SHA256 mismatch");
+    });
+
+    test("extracts the runner into a uid-private 0o700 directory, not /tmp (#4759)", async function() {
+      const derivedDataPath = path.join(tempDir, "DerivedData");
+      const cacheDir = path.join(tempDir, "cache");
+      const downloader = new FakeIOSCtrlProxyBundleDownloader();
+      downloader.checksum = "expected-checksum";
+
+      IOSCtrlProxyBuilder.setExpectedChecksumForTesting("expected-checksum");
+      const builder = IOSCtrlProxyBuilder.getInstance(
+        { derivedDataPath, bundleCacheDir: cacheDir },
+        { downloader }
+      );
+
+      const result = await builder.build("simulator");
+      expect(result.success).toBe(true);
+
+      // Windows has no POSIX mode bits (fs.chmod only toggles read-only), so the
+      // 0o700 assertion is POSIX-only.
+      if (process.platform !== "win32") {
+        const stats = await fs.stat(derivedDataPath);
+        expect(stats.mode & 0o777).toBe(0o700);
+      }
+    });
+
+    test("verifyRunnerBinaryBeforeLaunch re-verifies the hash and passes when unchanged (#4759)", async function() {
+      const derivedDataPath = path.join(tempDir, "DerivedData");
+      const cacheDir = path.join(tempDir, "cache");
+      const downloader = new FakeIOSCtrlProxyBundleDownloader();
+      downloader.checksum = "expected-checksum";
+      downloader.runnerChecksum = "xctest-checksum";
+
+      IOSCtrlProxyBuilder.setExpectedChecksumForTesting("expected-checksum");
+      IOSCtrlProxyBuilder.setExpectedRunnerChecksumForTesting("xctest-checksum", "xctest");
+      const builder = IOSCtrlProxyBuilder.getInstance(
+        { derivedDataPath, bundleCacheDir: cacheDir },
+        { downloader }
+      );
+
+      await builder.build("simulator");
+      const before = downloader.checksummedFilePaths.length;
+
+      // Must not throw, and must re-hash the runner binary (a second computeFileSha256).
+      await builder.verifyRunnerBinaryBeforeLaunch("simulator");
+      expect(downloader.checksummedFilePaths.length).toBeGreaterThan(before);
+    });
+
+    test("verifyRunnerBinaryBeforeLaunch refuses launch when the runner binary changed after extraction (#4759)", async function() {
+      const derivedDataPath = path.join(tempDir, "DerivedData");
+      const cacheDir = path.join(tempDir, "cache");
+      const downloader = new FakeIOSCtrlProxyBundleDownloader();
+      downloader.checksum = "expected-checksum";
+      downloader.runnerChecksum = "xctest-checksum";
+
+      IOSCtrlProxyBuilder.setExpectedChecksumForTesting("expected-checksum");
+      IOSCtrlProxyBuilder.setExpectedRunnerChecksumForTesting("xctest-checksum", "xctest");
+      const builder = IOSCtrlProxyBuilder.getInstance(
+        { derivedDataPath, bundleCacheDir: cacheDir },
+        { downloader }
+      );
+
+      await builder.build("simulator");
+
+      // Simulate a TOCTOU swap: the on-disk runner binary now hashes differently
+      // than it did at extraction time.
+      downloader.runnerChecksum = "swapped-attacker-checksum";
+
+      await expect(builder.verifyRunnerBinaryBeforeLaunch("simulator"))
+        .rejects.toThrow("runner binary SHA256 mismatch (pre-launch)");
+    });
+
+    test("refuses to reuse a derived-data directory owned by another uid (#4759)", async function() {
+      if (process.platform === "win32" || typeof process.getuid !== "function") {
+        // st_uid/getuid are POSIX-only; ownership refusal no-ops on win32.
+        return;
+      }
+
+      const derivedDataPath = path.join(tempDir, "ForeignDerivedData");
+      const cacheDir = path.join(tempDir, "cache");
+      await fs.mkdir(derivedDataPath, { recursive: true });
+
+      const builder = IOSCtrlProxyBuilder.getInstance(
+        { derivedDataPath, bundleCacheDir: cacheDir },
+        { downloader: new FakeIOSCtrlProxyBundleDownloader() }
+      );
+
+      const foreignUid = process.getuid()! + 1;
+      const statSpy = spyOn(fs, "stat").mockResolvedValue(
+        { uid: foreignUid } as Awaited<ReturnType<typeof fs.stat>>
+      );
+      try {
+        await expect(builder.verifyRunnerBinaryBeforeLaunch("simulator"))
+          .rejects.toThrow(`owned by uid ${foreignUid}`);
+      } finally {
+        statSpy.mockRestore();
+      }
     });
 
     test("fails closed when AUTOMOBILE_VERSION is pinned to an unknown version (#2746)", async function() {

--- a/test/utils/IOSCtrlProxyManager.test.ts
+++ b/test/utils/IOSCtrlProxyManager.test.ts
@@ -162,6 +162,8 @@ function createFakeBuilder(xctestrunPath = "/tmp/CtrlProxy.xctestrun") {
   return {
     getXctestrunPath: async () => xctestrunPath,
     getRunnerBinaryPath: async () => null,
+    // Pre-launch TOCTOU re-verify seam (#4759); a no-op in the default fake.
+    verifyRunnerBinaryBeforeLaunch: async () => {},
     writeRunnerEnvironment: fakeWriteRunnerEnvironment,
     needsRebuild: async () => false,
     build: async () => ({ success: true, message: "built" }),
@@ -1282,6 +1284,7 @@ describe("IOSCtrlProxyManager", function() {
       const fakeBuilder = {
         getXctestrunPath: async () => null,
         getRunnerBinaryPath: async () => null,
+        verifyRunnerBinaryBeforeLaunch: async () => {},
         writeRunnerEnvironment: fakeWriteRunnerEnvironment,
       } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
 
@@ -1305,6 +1308,7 @@ describe("IOSCtrlProxyManager", function() {
       const fakeBuilder = {
         getXctestrunPath: async () => "/tmp/test.xctestrun",
         getRunnerBinaryPath: async () => null,
+        verifyRunnerBinaryBeforeLaunch: async () => {},
         writeRunnerEnvironment: fakeWriteRunnerEnvironment,
       } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
 
@@ -1335,6 +1339,7 @@ describe("IOSCtrlProxyManager", function() {
             throw new Error("should not build when an external CtrlProxy process is reused");
           },
           getRunnerBinaryPath: async () => null,
+          verifyRunnerBinaryBeforeLaunch: async () => {},
           writeRunnerEnvironment: fakeWriteRunnerEnvironment,
         } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
         const manager = IOSCtrlProxyManager.createForTestingWithDeps(
@@ -1371,6 +1376,7 @@ describe("IOSCtrlProxyManager", function() {
         const fakeBuilder = {
           getXctestrunPath: async () => "/tmp/test.xctestrun",
           getRunnerBinaryPath: async () => null,
+          verifyRunnerBinaryBeforeLaunch: async () => {},
           writeRunnerEnvironment: fakeWriteRunnerEnvironment,
         } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
         const manager = IOSCtrlProxyManager.createForTestingWithDeps(
@@ -1407,6 +1413,7 @@ describe("IOSCtrlProxyManager", function() {
         const fakeBuilder = {
           getXctestrunPath: async () => "/tmp/test.xctestrun",
           getRunnerBinaryPath: async () => null,
+          verifyRunnerBinaryBeforeLaunch: async () => {},
           writeRunnerEnvironment: fakeWriteRunnerEnvironment,
         } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
         const manager = IOSCtrlProxyManager.createForTestingWithDeps(
@@ -1436,6 +1443,7 @@ describe("IOSCtrlProxyManager", function() {
           throw new Error("should not build when an external CtrlProxy process is reused");
         },
         getRunnerBinaryPath: async () => null,
+        verifyRunnerBinaryBeforeLaunch: async () => {},
         writeRunnerEnvironment: fakeWriteRunnerEnvironment,
       } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
@@ -1476,6 +1484,7 @@ describe("IOSCtrlProxyManager", function() {
           throw new Error("should not build when an external CtrlProxy process is reused");
         },
         getRunnerBinaryPath: async () => null,
+        verifyRunnerBinaryBeforeLaunch: async () => {},
         writeRunnerEnvironment: fakeWriteRunnerEnvironment,
       } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
@@ -1516,6 +1525,7 @@ describe("IOSCtrlProxyManager", function() {
           throw new Error("should not build when an external CtrlProxy process is reused");
         },
         getRunnerBinaryPath: async () => null,
+        verifyRunnerBinaryBeforeLaunch: async () => {},
         writeRunnerEnvironment: fakeWriteRunnerEnvironment,
       } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
@@ -1558,6 +1568,7 @@ describe("IOSCtrlProxyManager", function() {
           throw new Error("should not build when an external CtrlProxy process is reused");
         },
         getRunnerBinaryPath: async () => null,
+        verifyRunnerBinaryBeforeLaunch: async () => {},
         writeRunnerEnvironment: fakeWriteRunnerEnvironment,
       } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
@@ -1590,6 +1601,7 @@ describe("IOSCtrlProxyManager", function() {
       const fakeBuilder = {
         getXctestrunPath: async () => "/tmp/test.xctestrun",
         getRunnerBinaryPath: async () => null,
+        verifyRunnerBinaryBeforeLaunch: async () => {},
         writeRunnerEnvironment: fakeWriteRunnerEnvironment,
       } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
       const manager = IOSCtrlProxyManager.createForTestingWithDeps(
@@ -1622,6 +1634,7 @@ describe("IOSCtrlProxyManager", function() {
         const fakeBuilder = {
           getXctestrunPath: async () => "/tmp/test.xctestrun",
           getRunnerBinaryPath: async () => null,
+          verifyRunnerBinaryBeforeLaunch: async () => {},
           writeRunnerEnvironment: async (xctestrunPath: string, env: Record<string, string>, deviceId: string) => {
             writeCalls.push({ xctestrunPath, env, deviceId });
             return "/tmp/automobile-runner-SIM.xctestrun";
@@ -1677,6 +1690,7 @@ describe("IOSCtrlProxyManager", function() {
         const fakeBuilder = {
           getXctestrunPath: async () => "/tmp/test.xctestrun",
           getRunnerBinaryPath: async () => null,
+          verifyRunnerBinaryBeforeLaunch: async () => {},
           writeRunnerEnvironment: fakeWriteRunnerEnvironment,
         } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
         const manager = IOSCtrlProxyManager.createForTestingWithDeps(
@@ -1724,6 +1738,7 @@ describe("IOSCtrlProxyManager", function() {
         const fakeBuilder = {
           getXctestrunPath: async () => sourceXctestrun,
           getRunnerBinaryPath: async () => null,
+          verifyRunnerBinaryBeforeLaunch: async () => {},
           writeRunnerEnvironment: (p: string, env: Record<string, string>, id: string) =>
             realBuilder.writeRunnerEnvironment(p, env, id),
         } as unknown as IOSCtrlProxyBuilder;
@@ -1768,6 +1783,7 @@ describe("IOSCtrlProxyManager", function() {
         const fakeBuilder = {
           getXctestrunPath: async () => "/tmp/device.xctestrun",
           getRunnerBinaryPath: async () => null,
+          verifyRunnerBinaryBeforeLaunch: async () => {},
           writeRunnerEnvironment: async (_p: string, env: Record<string, string>, deviceId: string) => {
             writeCalls.push({ env, deviceId });
             return "/tmp/automobile-runner-DEV.xctestrun";
@@ -1882,6 +1898,7 @@ describe("IOSCtrlProxyManager", function() {
             throw new Error("should not build when an external direct runner is reused");
           },
           getRunnerBinaryPath: async () => null,
+          verifyRunnerBinaryBeforeLaunch: async () => {},
           writeRunnerEnvironment: fakeWriteRunnerEnvironment,
         } as unknown as import("../../src/utils/IOSCtrlProxyBuilder").IOSCtrlProxyBuilder;
         const manager = IOSCtrlProxyManager.createForTestingWithDeps(


### PR DESCRIPTION
## Summary

Closes [#4759](https://github.com/kaeawc/auto-mobile/issues/4759).

Hardens the prebuilt iOS CtrlProxy helper's extract/launch path against a
local-attacker TOCTOU. The runner was extracted to and launched from a
**predictable, world-writable** `/tmp/automobile-ctrl-proxy`, so any other uid
on a shared host could pre-seed the directory or swap the runner / xctest binary
between the post-extract integrity check and the `xcodebuild test-without-building`
launch.

Three defenses, matching the issue's acceptance criteria:

1. **Off `/tmp` onto a uid-private directory.** The default derived-data path is
   now `~/.auto-mobile/derived-data` (via the existing `getTempDir` helper), and
   the extraction tree is created/chmod-ed owner-only (`0o700`) through the shared
   `ensureSecureDir` helper (issue #4750) rather than inheriting the umask.
2. **Refuse a foreign-owned directory (fail closed).** Before extracting into or
   launching from a pre-existing derived-data directory, we `stat` it and throw an
   `ActionableError` if its `st_uid` is not the current uid.
3. **Re-verify the runner hash immediately before launch.** `IOSCtrlProxyManager`
   now calls `builder.verifyRunnerBinaryBeforeLaunch("simulator")` right before
   spawning the runner, re-hashing the runner binary (and re-checking ownership) to
   close the verify→execute window. A mismatch refuses the launch with an
   `ActionableError`.

## Verify-real findings (against current `main`)

Confirmed on `origin/main` before implementing (line numbers had drifted):

- `IOSCtrlProxyBuilder.ts:99` — `DEFAULT_DERIVED_DATA_PATH = "/tmp/automobile-ctrl-proxy"` (world-writable, predictable). Confirmed.
- `IOSCtrlProxyBuilder.ts:799` (`ensureBundleDownloaded`) and `967` (`normalizeExtractedBundle`) — `fs.mkdir(..., { recursive: true })` with no explicit `mode`. Confirmed.
- `IOSCtrlProxyBundleDownloader.ts:34-40` (`extractBundle`) — `fs.mkdir` with no mode; this is where the IPA is extracted. Confirmed.
- `IOSCtrlProxyBuilder.ts:1028-1044` (`verifyPlatformArtifacts`) — runner SHA256 hashed post-extract, simulator only. Confirmed.
- `IOSCtrlProxyManager.ts` `startOnSimulator`/`startOnDevice` — launch `xcodebuild test-without-building` from the same tree with **no** re-hash between verify and execute. Confirmed the TOCTOU window.

The pre-existing secure helpers were reused as instructed: `ensureSecureDir`
(`src/utils/filesystem/securePermissions.ts`), `getTempDir` (`src/utils/tempDir.ts`),
and `ChecksumCalculator` (already injected into the downloader) — no new hashing,
temp-dir, or permission primitives were invented.

## What changed

- **`src/utils/IOSCtrlProxyBuilder.ts`**
  - Replaced the `/tmp` default with `getTempDir("derived-data")` (`~/.auto-mobile/derived-data`); env override `AUTOMOBILE_CTRL_PROXY_IOS_DERIVED_DATA` still honored.
  - `ensureBundleDownloaded` and `normalizeExtractedBundle` now use `ensureSecureDir` (0o700) instead of default-mode `fs.mkdir`.
  - `extractBundle` asserts uid ownership before wiping the tree and re-applies `ensureSecureDir` after extraction (authoritative, independent of the downloader).
  - Extracted the post-extract runner-hash check into `assertRunnerBinaryHash(platform, phase)` (now throwing `ActionableError`), and added public `verifyRunnerBinaryBeforeLaunch(platform)` plus private `assertDerivedDataDirOwnedByCurrentUid()`.
- **`src/utils/IOSCtrlProxyBundleDownloader.ts`** — `extractBundle` creates the destination via `ensureSecureDir` (0o700).
- **`src/utils/IOSCtrlProxyManager.ts`** — `startOnSimulator` calls `verifyRunnerBinaryBeforeLaunch("simulator")` immediately before spawning `xcodebuild`.
- **Tests** — new coverage in `IOSCtrlProxyBuilder.test.ts` for: uid-private 0o700 extraction (not `/tmp`), pre-launch re-verify pass, refuse-on-changed-binary (`pre-launch` mismatch → throws), and refuse foreign-owned dir; updated the default-path assertion; added the seam to the manager test fakes.

## Portability (macOS runtime, cross-platform CI)

- All expected paths in tests are built with `node:path` / `getTempDir` — no hardcoded POSIX separators — so `windows-latest` (backslashes + drive letter) passes. The default-path test also asserts the path no longer contains `/tmp/`.
- `assertDerivedDataDirOwnedByCurrentUid` and the `st_uid` refusal no-op on `win32` / when `process.getuid` is absent (Windows uses ACLs, out of scope for POSIX mode bits — matching `ensureSecureDir`'s existing contract).
- The 0o700 mode assertion and the foreign-uid test are POSIX-guarded (`process.platform !== "win32"`); they `return` early on Windows.

## Validation

- `bun run typecheck` — pass (no new type errors; 196 baseline).
- `turbo run lint build` — pass.
- `bun test test/utils/IOSCtrlProxyBuilder.test.ts` — 44 pass.
- `bun test test/utils/IOSCtrlProxyManager.test.ts test/utils/CtrlProxyManager.test.ts` — 189 pass.
- `bun test test/doctor/ios.test.ts` — 72 pass.
- `turbo run test` — full suite left running locally (very long under `--isolate` on this host); the affected suites above are green and CI runs the full suite on this PR.
