### PR TITLE
ci(release): drop redundant generic-CI validation from prepare-release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -259,67 +259,18 @@ jobs:
           git push --force origin "HEAD:refs/heads/$STAGING_REF"
           echo "release_commit=$local_head" >> "$GITHUB_OUTPUT"
 
-  validate-finalized-release:
-    runs-on: ubuntu-latest
-    needs: finalize-release
-    steps:
-      - name: Checkout finalized release
-        uses: actions/checkout@v6
-        with:
-          lfs: false
-          ref: ${{ needs.finalize-release.outputs.release_commit }}
-          # Full history so origin/main resolves. `bun run lint` chains
-          # diff-based ratchet boundary scripts (check-host-shell-boundary.ts
-          # et al.) that require a base ref; a shallow single-ref checkout of
-          # the release commit lacks origin/main and makes them throw.
-          fetch-depth: 0
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.9
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Run tests
-        env:
-          TURBO_TELEMETRY_DISABLED: "1"
-          TURBO_NO_UPDATE_NOTIFIER: "1"
-          DO_NOT_TRACK: "1"
-          NO_COLOR: "1"
-        run: bun run turbo:test -- --output-logs=errors-only
-
-      - name: Run lint
-        env:
-          TURBO_TELEMETRY_DISABLED: "1"
-          TURBO_NO_UPDATE_NOTIFIER: "1"
-          DO_NOT_TRACK: "1"
-          NO_COLOR: "1"
-        run: bun run turbo:lint -- --output-logs=errors-only
-
-      - name: Build TypeScript
-        env:
-          TURBO_TELEMETRY_DISABLED: "1"
-          TURBO_NO_UPDATE_NOTIFIER: "1"
-          DO_NOT_TRACK: "1"
-          NO_COLOR: "1"
-        run: bun run turbo:build -- --force --output-logs=errors-only
-
-      - name: Run Bun MCP startup smoke
-        run: bun run test:startup:bun
-
-      - name: Run Bun image runtime smoke
-        run: bun run test:image:bun
+  # No generic-CI validation job here (lint/build/test/smoke). Those checks are
+  # not specific to releasing: the full test suite, lint, build, and the Bun
+  # startup/image smokes already gate every PR and merge into main before a
+  # release is ever cut (see pull_request.yml). Re-running them against the
+  # version-bumped release commit added no release-specific signal and was
+  # brittle (e.g. the doc-prose-coupled daemonInputApiExamples test). The only
+  # release-specific verification — artifact checksums and release integrity —
+  # runs in verify-prepared-release below against the actual built artifacts.
 
   verify-prepared-release:
     runs-on: ubuntu-latest
-    needs: [prepare-version, finalize-release, validate-finalized-release, build-candidate-ctrl-proxy-ios-ipa, build-candidate-control-proxy-apk, build-candidate-video-server-jar, build-candidate-screen-capture-helper, build-candidate-desktop-app-installers]
+    needs: [prepare-version, finalize-release, build-candidate-ctrl-proxy-ios-ipa, build-candidate-control-proxy-apk, build-candidate-video-server-jar, build-candidate-screen-capture-helper, build-candidate-desktop-app-installers]
     permissions:
       contents: write
       actions: write


### PR DESCRIPTION
## What

Removes the `validate-finalized-release` job from `prepare-release.yml` and drops it from `verify-prepared-release`'s `needs` list.

## Why

The job re-ran the full `turbo:test` / `turbo:lint` / `turbo:build` suite plus the Bun startup/image smokes against the version-bumped release commit. None of that is specific to releasing:

- The full test suite, lint, and build already gate **every PR and merge into `main`** before a release is ever cut.
- `test:startup:bun` and `test:image:bun` also already run in `pull_request.yml`.

So the job added no release-specific signal and only imported unrelated flakiness into the release path. The most recent [Prepare Release run](https://github.com/kaeawc/auto-mobile/actions/runs/30675240023/job/91302025277) failed here on `test/docs/daemonInputApiExamples.test.ts`, which asserts exact daemon-doc prose that had drifted — a general-CI concern that has nothing to do with cutting a release.

## What's preserved

The only genuinely release-specific verification — artifact checksum validation (`verify-artifact-sha256.sh`) and release integrity (`verify-release-integrity.sh`) — still runs in `verify-prepared-release` against the actual built artifacts. That job now depends on `finalize-release` directly instead of transitively through the removed job.

## Validation

- `scripts/all_fast_validate_checks.sh` passes (full suite, exit 0), including the YAML workflow lint.
