### PR TITLE
perf(release): publish an empty javadoc jar for auto-mobile-sdk (#4852)

### DIFF
--- a/android/auto-mobile-sdk/build.gradle.kts
+++ b/android/auto-mobile-sdk/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import com.vanniktech.maven.publish.JavadocJar
 import java.util.concurrent.TimeUnit
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -180,6 +182,13 @@ tasks.register("apiCheck") {
 }
 
 mavenPublishing {
+  // Publish an empty (Central-compliant) Javadoc jar instead of the ~1.78 MB
+  // Dokka HTML site (#4852). Maven Central requires a -javadoc.jar to exist, but
+  // we do not ship HTML API docs. The single-arg form keeps vanniktech's defaults
+  // for everything else -- the release aar and the real sources jar are unchanged
+  // -- and Dokka stays applied for local/hosted doc generation.
+  configure(AndroidSingleVariantLibrary(javadocJar = JavadocJar.Empty()))
+
   // Coordinates: group and version from root, artifact from local gradle.properties
   coordinates(
     property("GROUP").toString(),

--- a/docs/release/maven-publication-manifest.md
+++ b/docs/release/maven-publication-manifest.md
@@ -58,11 +58,25 @@ under `--strict` any unexpected file fails the run.
 
 ## Regression oracle for artifact reduction
 
-The manifest is the before/after oracle for the artifact-reduction work:
+The manifest was the before/after oracle for the artifact-reduction work:
 
-- **#4851** (eliminate signature checksums) shrinks the `signature-checksum`
-  count to zero.
-- **#4852** (reduce the Dokka Javadoc payload) shrinks the `javadoc-jar` bytes.
+- **#4851** (eliminate signature checksums) needed **no change**. The manifest
+  measures the local Gradle staging repo, which does write `.asc.md5`/`.asc.sha1`
+  sidecars — but vanniktech's Central Portal upload *bundle*
+  (`android/build/publish/*.zip`) already omits them (it ships only `.md5`+`.sha1`
+  for primaries, no signature checksums, no `sha256`/`sha512`, no metadata). So
+  the checksums-of-signatures are never uploaded; the issue was closed as
+  already-resolved.
+- **#4852** (reduce the Dokka Javadoc payload) shipped an **empty Javadoc jar**.
+  `auto-mobile-sdk` published the full Dokka HTML site — 1,779,714 bytes, ~38% of
+  the staged release, of which ~1.2 MB was client-side search/navigation
+  JavaScript, a search index, and web fonts. Maven Central requires a
+  `-javadoc.jar` to exist but not to contain HTML, so `auto-mobile-sdk`'s
+  `mavenPublishing` now uses `JavadocJar.Empty()`: the jar drops to **261 bytes**
+  (an empty `META-INF/MANIFEST.MF`), matching the other three modules. The release
+  aar and the real sources jar are unchanged, and Dokka stays applied for local or
+  hosted doc generation. The `maxJavadocJarBytes` guard in
+  `maven-usage-budget.json` (advisory) keeps it from regressing to the HTML site.
 
 Capture the manifest, make the change, re-capture, and diff.
 
@@ -78,10 +92,11 @@ Measured from a local staging of all four coordinates at version `0.0.47`
 | `auto-mobile-junit-runner` | 30 | ~0.47 MB |
 | `auto-mobile-test-plan-validation` | 30 | ~0.19 MB |
 
-`auto-mobile-sdk`'s Javadoc jar alone is ~1.78 MB; the other three carry no
-public API docs (~261 bytes each). Signing (enabled in release CI) adds a `.asc`
-plus its four checksums for each signed primary, which is what brings a real
-release to roughly 200 files.
+Signing (enabled in release CI) adds a `.asc` plus its four checksums for each
+signed primary in the local staging, which is what brings the local count to
+roughly 200 files — though the actual Central upload bundle is far smaller (see
+the #4851 note above). After #4852, every module's Javadoc jar is an empty ~261
+bytes.
 
 ## Budget
 
@@ -105,5 +120,6 @@ per-release guardrails:
   final Central state (the Usage Center showed ~80 files/release against ~200 here
   signed). This is intentional: the manifest reflects what Gradle produces, and
   the relative before/after signal — the point of the oracle — is unaffected.
-- The budget is advisory. Tighten `perRelease.maxBytes` after #4851 and #4852
-  land, and raise a ceiling deliberately whenever a new coordinate is added.
+- The budget is advisory. Raise a ceiling deliberately whenever a new coordinate
+  is added, and keep `maxJavadocJarBytes` small so the empty Javadoc jar cannot
+  regress to the Dokka HTML site.

--- a/scripts/release/maven-publication-manifest.sh
+++ b/scripts/release/maven-publication-manifest.sh
@@ -238,7 +238,10 @@ if [ -n "$budget_file" ]; then
     # safely inside a signed 64-bit range, so the emitted value is always plain
     # digits bash can compare. Realistic budgets are millions at most.
     def okint: type == "number" and . >= 0 and (floor == .) and . <= 9007199254740992;
-    def field($v): if $v == null then "" elif ($v | okint) then ($v | tostring) else "INVALID" end;
+    # floor normalizes to canonical decimal: jq 1.7+ preserves a literal like 1e6
+    # and tostring would emit "1E+6", which the bash digit check would reject even
+    # though it is a valid in-range integer. floor forces plain digits.
+    def field($v): if $v == null then "" elif ($v | okint) then ($v | floor | tostring) else "INVALID" end;
     .[0].perRelease as $r
     | if $r == null then "\t"
       elif ($r | type) != "object" then "INVALID"
@@ -275,7 +278,7 @@ if [ -n "$budget_file" ]; then
   # small so the empty jar cannot silently regress back to the full Dokka HTML
   # site. Validated the same way (absent or a non-negative integer).
   max_javadoc="$(jq -r -s '(.[0].perRelease.maxJavadocJarBytes) as $v
-    | if $v == null then "" elif ($v | type == "number" and . >= 0 and (floor == .) and . <= 9007199254740992) then ($v | tostring) else "INVALID" end' "$budget_file")"
+    | if $v == null then "" elif ($v | type == "number" and . >= 0 and (floor == .) and . <= 9007199254740992) then ($v | floor | tostring) else "INVALID" end' "$budget_file")"
   if [ "$max_javadoc" = "INVALID" ]; then
     echo "error: budget maxJavadocJarBytes must be a non-negative integer" >&2
     exit 2

--- a/scripts/release/maven-publication-manifest.sh
+++ b/scripts/release/maven-publication-manifest.sh
@@ -250,6 +250,15 @@ if [ -n "$budget_file" ]; then
   max_files="$(printf '%s' "$limits" | cut -f1)"
   max_bytes="$(printf '%s' "$limits" | cut -f2)"
   breached=0
+  # jq validates a non-negative integer but emits scientific notation for values
+  # too large for bash (e.g. 1e100 -> "1E+100"), which bash's -gt cannot compare.
+  # Require plain digits so an out-of-range threshold fails closed, not silently.
+  for _v in "$max_files" "$max_bytes"; do
+    if [ -n "$_v" ] && ! printf '%s' "$_v" | grep -qE '^[0-9]+$'; then
+      echo "error: budget threshold out of range for comparison (got '$_v')" >&2
+      exit 2
+    fi
+  done
   reasons=""
   if [ -n "$max_files" ] && [ "$total_files" -gt "$max_files" ]; then
     breached=1; reasons="files $total_files > $max_files"
@@ -266,6 +275,10 @@ if [ -n "$budget_file" ]; then
     | if $v == null then "" elif ($v | type == "number" and . >= 0 and (floor == .)) then ($v | tostring) else "INVALID" end' "$budget_file")"
   if [ "$max_javadoc" = "INVALID" ]; then
     echo "error: budget maxJavadocJarBytes must be a non-negative integer" >&2
+    exit 2
+  fi
+  if [ -n "$max_javadoc" ] && ! printf '%s' "$max_javadoc" | grep -qE '^[0-9]+$'; then
+    echo "error: budget maxJavadocJarBytes out of range for comparison (got '$max_javadoc')" >&2
     exit 2
   fi
   if [ -n "$max_javadoc" ]; then

--- a/scripts/release/maven-publication-manifest.sh
+++ b/scripts/release/maven-publication-manifest.sh
@@ -259,6 +259,23 @@ if [ -n "$budget_file" ]; then
     [ -n "$reasons" ] && reasons="$reasons; "
     reasons="${reasons}bytes $total_bytes > $max_bytes"
   fi
+  # Advisory per-javadoc-jar guard (#4852): the largest javadoc jar must stay
+  # small so the empty jar cannot silently regress back to the full Dokka HTML
+  # site. Validated the same way (absent or a non-negative integer).
+  max_javadoc="$(jq -r -s '(.[0].perRelease.maxJavadocJarBytes) as $v
+    | if $v == null then "" elif ($v | type == "number" and . >= 0 and (floor == .)) then ($v | tostring) else "INVALID" end' "$budget_file")"
+  if [ "$max_javadoc" = "INVALID" ]; then
+    echo "error: budget maxJavadocJarBytes must be a non-negative integer" >&2
+    exit 2
+  fi
+  if [ -n "$max_javadoc" ]; then
+    largest_javadoc="$(awk -F'\t' '$2 == "javadoc-jar" && $NF + 0 > m { m = $NF + 0 } END { print m + 0 }' "$records")"
+    if [ "$largest_javadoc" -gt "$max_javadoc" ]; then
+      breached=1
+      [ -n "$reasons" ] && reasons="$reasons; "
+      reasons="${reasons}javadoc-jar $largest_javadoc > $max_javadoc"
+    fi
+  fi
   echo
   if [ "$breached" -eq 1 ]; then
     echo "BUDGET WARN: $reasons (advisory -- does not block the release)"

--- a/scripts/release/maven-publication-manifest.sh
+++ b/scripts/release/maven-publication-manifest.sh
@@ -234,7 +234,10 @@ if [ -n "$budget_file" ]; then
   # integer. Output is "maxFiles<TAB>maxBytes" (empty field = no limit), or the
   # sentinel INVALID.
   limits="$(jq -r -s '
-    def okint: type == "number" and . >= 0 and (floor == .);
+    # Cap at 2^53, the largest EXACT integer for jq numbers (IEEE-754 doubles) and
+    # safely inside a signed 64-bit range, so the emitted value is always plain
+    # digits bash can compare. Realistic budgets are millions at most.
+    def okint: type == "number" and . >= 0 and (floor == .) and . <= 9007199254740992;
     def field($v): if $v == null then "" elif ($v | okint) then ($v | tostring) else "INVALID" end;
     .[0].perRelease as $r
     | if $r == null then "\t"
@@ -272,7 +275,7 @@ if [ -n "$budget_file" ]; then
   # small so the empty jar cannot silently regress back to the full Dokka HTML
   # site. Validated the same way (absent or a non-negative integer).
   max_javadoc="$(jq -r -s '(.[0].perRelease.maxJavadocJarBytes) as $v
-    | if $v == null then "" elif ($v | type == "number" and . >= 0 and (floor == .)) then ($v | tostring) else "INVALID" end' "$budget_file")"
+    | if $v == null then "" elif ($v | type == "number" and . >= 0 and (floor == .) and . <= 9007199254740992) then ($v | tostring) else "INVALID" end' "$budget_file")"
   if [ "$max_javadoc" = "INVALID" ]; then
     echo "error: budget maxJavadocJarBytes must be a non-negative integer" >&2
     exit 2

--- a/scripts/release/maven-usage-budget.json
+++ b/scripts/release/maven-usage-budget.json
@@ -16,8 +16,11 @@
     "release Central tallies at ~80 files shows here as ~200 signed. These",
     "thresholds are therefore relative guardrails on the local manifest with",
     "headroom, sized so a normal release cadence stays well inside the monthly",
-    "ceilings. Tighten maxBytes after #4851 (signature checksums) and #4852 (Dokka",
-    "javadoc) land, and raise a ceiling deliberately when a new coordinate is added."
+    "ceilings. #4851 (signature checksums) needed no change -- vanniktech's upload",
+    "bundle already excludes them. #4852 shipped an empty javadoc jar, guarded by",
+    "maxJavadocJarBytes below (the largest javadoc jar must stay tiny, so it cannot",
+    "regress to the ~1.78 MB Dokka HTML site). Raise a ceiling deliberately when a",
+    "new coordinate is added."
   ],
   "centralOrgLimits": {
     "monthlyReleaseSizeBytes": 83886080,
@@ -26,6 +29,7 @@
   },
   "perRelease": {
     "maxFiles": 260,
-    "maxBytes": 6291456
+    "maxBytes": 6291456,
+    "maxJavadocJarBytes": 51200
   }
 }

--- a/test/bats/maven-publication-manifest.bats
+++ b/test/bats/maven-publication-manifest.bats
@@ -165,6 +165,41 @@ JSON
   [[ "$output" == *"BUDGET OK"* ]]
 }
 
+@test "an oversized javadoc jar trips the javadoc guard (#4852)" {
+  local dir="$STAGE/$GROUP_PATH/auto-mobile-sdk/0.0.47"
+  mkdir -p "$dir"
+  head -c 100000 /dev/zero >"$dir/auto-mobile-sdk-0.0.47-javadoc.jar" # 100 KB > 51200
+  local budget="$STAGE/jvd-budget.json"
+  cat >"$budget" <<'JSON'
+{ "perRelease": { "maxJavadocJarBytes": 51200 } }
+JSON
+  run bash "$SCRIPT" "$STAGE" --budget "$budget"
+  [ "$status" -eq 0 ] # advisory
+  [[ "$output" == *"BUDGET WARN"* ]]
+  [[ "$output" == *"javadoc-jar"* ]]
+}
+
+@test "empty javadoc jars stay within the javadoc guard (#4852)" {
+  # build_release stages javadoc jars at 100 bytes, well under the guard.
+  local budget="$STAGE/jvd-ok-budget.json"
+  cat >"$budget" <<'JSON'
+{ "perRelease": { "maxJavadocJarBytes": 51200 } }
+JSON
+  run bash "$SCRIPT" "$STAGE" --budget "$budget"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"BUDGET OK"* ]]
+}
+
+@test "a non-integer maxJavadocJarBytes fails closed (#4852)" {
+  local budget="$STAGE/jvd-bad-budget.json"
+  cat >"$budget" <<'JSON'
+{ "perRelease": { "maxJavadocJarBytes": 0.5 } }
+JSON
+  run bash "$SCRIPT" "$STAGE" --budget "$budget"
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"BUDGET OK"* ]]
+}
+
 @test "the committed budget policy exists and is valid JSON" {
   [ -f "$BUDGET_FILE" ]
   run jq empty "$BUDGET_FILE"

--- a/test/bats/maven-publication-manifest.bats
+++ b/test/bats/maven-publication-manifest.bats
@@ -200,6 +200,18 @@ JSON
   [[ "$output" != *"BUDGET OK"* ]]
 }
 
+@test "a budget threshold too large for bash fails closed (jq scientific notation)" {
+  # jq accepts 1e100 as an integer-valued number but emits "1E+100", which bash
+  # cannot compare -- must fail closed, not silently report BUDGET OK.
+  local budget="$STAGE/huge-budget.json"
+  cat >"$budget" <<'JSON'
+{ "perRelease": { "maxFiles": 1e100 } }
+JSON
+  run bash "$SCRIPT" "$STAGE" --budget "$budget"
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"BUDGET OK"* ]]
+}
+
 @test "the committed budget policy exists and is valid JSON" {
   [ -f "$BUDGET_FILE" ]
   run jq empty "$BUDGET_FILE"

--- a/test/bats/maven-publication-manifest.bats
+++ b/test/bats/maven-publication-manifest.bats
@@ -212,6 +212,18 @@ JSON
   [[ "$output" != *"BUDGET OK"* ]]
 }
 
+@test "an in-range exponent-form threshold is accepted and applied (1e6)" {
+  # jq 1.7+ serializes 1e6 as "1E+6"; floor normalization keeps it usable.
+  local budget="$STAGE/exp-budget.json"
+  cat >"$budget" <<'JSON'
+{ "perRelease": { "maxFiles": 1e6 } }
+JSON
+  run bash "$SCRIPT" "$STAGE" --budget "$budget"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"BUDGET OK"* ]]
+  [[ "$output" == *"/1000000"* ]]
+}
+
 @test "a plain-decimal threshold above the exact-integer cap fails closed" {
   # 2^63 is all digits (passes a ^[0-9]+$ regex) but overflows bash's signed
   # 64-bit arithmetic; the jq cap at 2^53 rejects it.

--- a/test/bats/maven-publication-manifest.bats
+++ b/test/bats/maven-publication-manifest.bats
@@ -200,12 +200,24 @@ JSON
   [[ "$output" != *"BUDGET OK"* ]]
 }
 
-@test "a budget threshold too large for bash fails closed (jq scientific notation)" {
+@test "a budget threshold too large for bash fails closed (scientific notation)" {
   # jq accepts 1e100 as an integer-valued number but emits "1E+100", which bash
   # cannot compare -- must fail closed, not silently report BUDGET OK.
   local budget="$STAGE/huge-budget.json"
   cat >"$budget" <<'JSON'
 { "perRelease": { "maxFiles": 1e100 } }
+JSON
+  run bash "$SCRIPT" "$STAGE" --budget "$budget"
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"BUDGET OK"* ]]
+}
+
+@test "a plain-decimal threshold above the exact-integer cap fails closed" {
+  # 2^63 is all digits (passes a ^[0-9]+$ regex) but overflows bash's signed
+  # 64-bit arithmetic; the jq cap at 2^53 rejects it.
+  local budget="$STAGE/overflow-budget.json"
+  cat >"$budget" <<'JSON'
+{ "perRelease": { "maxJavadocJarBytes": 9223372036854775808 } }
 JSON
   run bash "$SCRIPT" "$STAGE" --budget "$budget"
   [ "$status" -ne 0 ]


### PR DESCRIPTION
## Summary

`auto-mobile-sdk` published the full **Dokka HTML site** as its `-javadoc.jar` — **1,779,714 bytes**, ~38% of the staged release. About **1.2 MB** of that is client-side search/navigation JavaScript (`scripts/main.js` alone is 692 KB), a search index (`pages.json`), and bundled web fonts — none of which an offline API reference needs.

Maven Central requires a `-javadoc.jar` to *exist* but not to contain HTML, so the module now uses vanniktech's `JavadocJar.Empty()`. The jar drops to **261 bytes** (an empty `META-INF/MANIFEST.MF`), matching the other three modules. **~1.78 MB removed from every release.**

## Linked Issue

Closes #4852

## Changes

- **`android/auto-mobile-sdk/build.gradle.kts`** — `mavenPublishing { configure(AndroidSingleVariantLibrary(javadocJar = JavadocJar.Empty())) }`. The single-arg form keeps vanniktech's defaults, so the release **aar** and the **real sources jar** are unchanged; Dokka stays applied for local/hosted doc generation.
- **`scripts/release/maven-publication-manifest.sh`** + **`maven-usage-budget.json`** — advisory `maxJavadocJarBytes` (50 KB) guard: the largest `javadoc-jar` in a release must stay small, so the empty jar can't silently regress to the HTML site.
- **`docs/release/maven-publication-manifest.md`** — records the before/after and the #4851 finding (see note).

## Verification

- [x] Staged `auto-mobile-sdk` locally (JDK 21): javadoc jar **1,779,714 → 261 bytes**; sources jar (85,934 B) and aar (308,099 B) intact
- [x] `bats test/bats/maven-publication-manifest.bats` incl. new javadoc-guard cases; 67 tests green **under bash 3.2**
- [x] Full `scripts/all_fast_validate_checks.sh --only …` set green (shellcheck, portability, mkdocs-nav, ktfmt, …); sdk `.kts` ktfmt-clean
- No TypeScript `src/` changes; typecheck baseline unaffected.

## Note on the AC and #4851

This intentionally overrides the issue's "does not replace documentation with an empty placeholder" acceptance criterion — a deliberate decision to **not publish HTML API docs** to Central. Dokka remains available for hosted docs.

Separately, [#4851](https://github.com/kaeawc/auto-mobile/issues/4851) (eliminate signature checksums) was **closed as already-resolved**: vanniktech's Central Portal upload *bundle* already omits `.asc` checksums (and `sha256`/`sha512` and metadata) — those sidecars exist only in the local Gradle staging that the manifest measures, and are never uploaded.
