### PR TITLE
fix(daemon): propagate on-demand navigation-graph export failures through the stream

### DIFF
--- a/src/daemon/daemon.ts
+++ b/src/daemon/daemon.ts
@@ -44,7 +44,7 @@ import { startDeviceSnapshotSocketServer, stopDeviceSnapshotSocketServer } from 
 import { startAppearanceSocketServer, stopAppearanceSocketServer } from "./appearanceSocketServer";
 import { startPerformanceStreamSocketServer, stopPerformanceStreamSocketServer } from "./performanceStreamSocketServer";
 import { startPerformancePushSocketServer, stopPerformancePushSocketServer } from "./performancePushSocketServer";
-import { startDeviceDataStreamSocketServer, stopDeviceDataStreamSocketServer, getDeviceDataStreamServer, type NavigationGraphStreamData } from "./deviceDataStreamSocketServer";
+import { startDeviceDataStreamSocketServer, stopDeviceDataStreamSocketServer, getDeviceDataStreamServer } from "./deviceDataStreamSocketServer";
 import { startFailuresStreamSocketServer, stopFailuresStreamSocketServer } from "./failuresStreamSocketServer";
 import { startFailuresPushSocketServer, stopFailuresPushSocketServer } from "./failuresPushSocketServer";
 import { startTelemetryPushSocketServer, stopTelemetryPushSocketServer } from "./telemetryPushSocketServer";
@@ -59,6 +59,10 @@ import {
   type ObservationStreamIosClient,
 } from "./observationInitialFrame";
 import { NavigationGraphManager } from "../features/navigation/NavigationGraphManager";
+import {
+  convertSummaryToStreamData,
+  createNavigationGraphRequestHandler,
+} from "./navigationGraphRequestHandler";
 import { RealObserveScreen } from "../features/observe/ObserveScreen";
 import type { InstalledAppsStore } from "../db/installedAppsRepository";
 import { InstalledAppsRepository } from "../db/installedAppsRepository";
@@ -1001,18 +1005,11 @@ export class Daemon {
       }
     });
 
-    // Wire up on-demand navigation graph requests from IDE plugins
-    server.setOnNavigationGraphRequested(async (appId?: string | null) => {
-      try {
-        const summary = appId
-          ? await navGraphManager.exportGraphSummaryForApp(appId)
-          : await navGraphManager.exportGraphSummary();
-        return convertSummaryToStreamData(summary);
-      } catch (error) {
-        logger.warn(`[Daemon] Failed to export navigation graph on request: ${error}`);
-        return null;
-      }
-    });
+    // Wire up on-demand navigation graph requests from IDE plugins. A failed export must NOT be
+    // swallowed to null (issue #4918): the handler rethrows so the stream server's existing error
+    // path surfaces a typed `error` frame, letting a stream-driven client distinguish "export
+    // failed" from "no app / empty graph".
+    server.setOnNavigationGraphRequested(createNavigationGraphRequestHandler(navGraphManager));
 
     logger.info("[Daemon] Navigation graph stream listener configured");
   }
@@ -1653,34 +1650,6 @@ export class Daemon {
   getDevicePool(): DevicePool {
     return this.devicePool;
   }
-}
-
-/**
- * Convert a NavigationGraphManager summary to the stream data format.
- */
-function convertSummaryToStreamData(summary: {
-  appId: string | null;
-  nodes: Array<{ id: number; screenName: string; visitCount: number; screenshotPath?: string | null }>;
-  edges: Array<{ id: number; from: string; to: string; toolName: string | null; traversalCount: number }>;
-  currentScreen: string | null;
-}): NavigationGraphStreamData {
-  return {
-    appId: summary.appId,
-    nodes: summary.nodes.map(node => ({
-      id: node.id,
-      screenName: node.screenName,
-      visitCount: node.visitCount,
-      screenshotPath: node.screenshotPath,
-    })),
-    edges: summary.edges.map(edge => ({
-      id: edge.id,
-      from: edge.from,
-      to: edge.to,
-      toolName: edge.toolName,
-      traversalCount: edge.traversalCount,
-    })),
-    currentScreen: summary.currentScreen,
-  };
 }
 
 /**

--- a/src/daemon/navigationGraphRequestHandler.ts
+++ b/src/daemon/navigationGraphRequestHandler.ts
@@ -1,0 +1,77 @@
+import { logger } from "../utils/logger";
+import { toActionableError } from "../models/ActionableError";
+import type { NavigationGraphSummary } from "../utils/interfaces/NavigationGraph";
+import type {
+  NavigationGraphStreamData,
+  OnNavigationGraphRequestedCallback,
+} from "./deviceDataStreamSocketServer";
+
+/**
+ * Minimal exporter contract the on-demand navigation-graph request handler needs.
+ *
+ * Narrower than {@link import("../utils/interfaces/NavigationGraph").NavigationGraphSummaryProvider}
+ * on purpose (YAGNI): the handler only ever exports a summary — for a specific app when the
+ * requester names one, or for the current foreground app otherwise. `NavigationGraphManager`
+ * satisfies this directly.
+ */
+export interface NavigationGraphSummaryExporter {
+  exportGraphSummary(): Promise<NavigationGraphSummary>;
+  exportGraphSummaryForApp(appId: string | null): Promise<NavigationGraphSummary>;
+}
+
+/**
+ * Convert a NavigationGraphManager summary to the stream data format.
+ */
+export function convertSummaryToStreamData(summary: {
+  appId: string | null;
+  nodes: Array<{ id: number; screenName: string; visitCount: number; screenshotPath?: string | null }>;
+  edges: Array<{ id: number; from: string; to: string; toolName: string | null; traversalCount: number }>;
+  currentScreen: string | null;
+}): NavigationGraphStreamData {
+  return {
+    appId: summary.appId,
+    nodes: summary.nodes.map(node => ({
+      id: node.id,
+      screenName: node.screenName,
+      visitCount: node.visitCount,
+      screenshotPath: node.screenshotPath,
+    })),
+    edges: summary.edges.map(edge => ({
+      id: edge.id,
+      from: edge.from,
+      to: edge.to,
+      toolName: edge.toolName,
+      traversalCount: edge.traversalCount,
+    })),
+    currentScreen: summary.currentScreen,
+  };
+}
+
+/**
+ * Build the on-demand navigation-graph request handler wired into the device-data stream server.
+ *
+ * On success it returns the exported summary as stream data (an empty/no-app graph is still a
+ * non-null summary, so the caller emits a `navigation_update` — distinguishable from failure).
+ *
+ * On export failure it logs a `warn` for traceability and RETHROWS (issue #4918): the previous
+ * behavior swallowed the error and returned `null`, which the stream server reports as a plain
+ * success ack with no `navigation_update`, leaving a stream-driven client (the desktop Navigation
+ * facet) unable to tell "export failed" from "no app / empty graph". Rethrowing routes the failure
+ * into the stream server's existing error path, which emits a typed `error` frame keyed to the
+ * request id — a contract existing clients already decode.
+ */
+export function createNavigationGraphRequestHandler(
+  exporter: NavigationGraphSummaryExporter
+): OnNavigationGraphRequestedCallback {
+  return async (appId?: string | null) => {
+    try {
+      const summary = appId
+        ? await exporter.exportGraphSummaryForApp(appId)
+        : await exporter.exportGraphSummary();
+      return convertSummaryToStreamData(summary);
+    } catch (error) {
+      logger.warn(`[Daemon] Failed to export navigation graph on request: ${error}`);
+      throw toActionableError(error, "Failed to export navigation graph on request");
+    }
+  };
+}

--- a/test/daemon/navigationGraphRequestHandler.test.ts
+++ b/test/daemon/navigationGraphRequestHandler.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach, spyOn } from "bun:test";
+import {
+  createNavigationGraphRequestHandler,
+  convertSummaryToStreamData,
+  type NavigationGraphSummaryExporter,
+} from "../../src/daemon/navigationGraphRequestHandler";
+import { ActionableError } from "../../src/models/ActionableError";
+import type { NavigationGraphSummary } from "../../src/utils/interfaces/NavigationGraph";
+import { logger } from "../../src/utils/logger";
+import { DeviceDataStreamSocketServer, type NavigationGraphStreamData } from "../../src/daemon/deviceDataStreamSocketServer";
+import { FakeTimer } from "../fakes/FakeTimer";
+import { FakeSocket } from "../fakes/FakeNetServer";
+import { Socket } from "node:net";
+
+const EMPTY_SUMMARY: NavigationGraphSummary = {
+  appId: null,
+  nodes: [],
+  edges: [],
+  currentScreen: null,
+};
+
+const POPULATED_SUMMARY: NavigationGraphSummary = {
+  appId: "com.example.app",
+  nodes: [{ id: 1, screenName: "Home", visitCount: 3 }],
+  edges: [{ id: 1, from: "Home", to: "Settings", toolName: "tapOn", traversalCount: 2 }],
+  currentScreen: "Home",
+};
+
+class FakeExporter implements NavigationGraphSummaryExporter {
+  public exportAllCalls = 0;
+  public exportForAppCalls: Array<string | null> = [];
+
+  constructor(
+    private readonly result:
+      | { kind: "resolve"; summary: NavigationGraphSummary }
+      | { kind: "reject"; error: unknown }
+  ) {}
+
+  async exportGraphSummary(): Promise<NavigationGraphSummary> {
+    this.exportAllCalls++;
+    return this.settle();
+  }
+
+  async exportGraphSummaryForApp(appId: string | null): Promise<NavigationGraphSummary> {
+    this.exportForAppCalls.push(appId);
+    return this.settle();
+  }
+
+  private async settle(): Promise<NavigationGraphSummary> {
+    if (this.result.kind === "reject") {
+      throw this.result.error;
+    }
+    return this.result.summary;
+  }
+}
+
+/** Minimal test double exposing processLine so the wired handler can be exercised end-to-end. */
+class TestableServer extends DeviceDataStreamSocketServer {
+  constructor(timer: FakeTimer) {
+    super("/fake/path/nav-handler.sock", timer);
+  }
+
+  async processLineForTest(socket: FakeSocket, line: string): Promise<void> {
+    await this.processLine(socket as unknown as Socket, line);
+  }
+}
+
+describe("createNavigationGraphRequestHandler", () => {
+  let warnSpy: ReturnType<typeof spyOn<typeof logger, "warn">>;
+
+  beforeEach(() => {
+    warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+    warnSpy.mockClear();
+  });
+
+  it("rethrows an ActionableError when the export fails, instead of swallowing to null", async () => {
+    const exporter = new FakeExporter({ kind: "reject", error: new Error("boom") });
+    const handler = createNavigationGraphRequestHandler(exporter);
+
+    const call = handler(null);
+    await expect(call).rejects.toBeInstanceOf(ActionableError);
+    await expect(call).rejects.toThrow(/Failed to export navigation graph on request: boom/);
+  });
+
+  it("keeps the warn log for traceability when the export fails", async () => {
+    const exporter = new FakeExporter({ kind: "reject", error: new Error("boom") });
+    const handler = createNavigationGraphRequestHandler(exporter);
+
+    await expect(handler(null)).rejects.toThrow();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("Failed to export navigation graph on request");
+  });
+
+  it("returns a non-null empty graph on the no-app / empty-graph success path", async () => {
+    const exporter = new FakeExporter({ kind: "resolve", summary: EMPTY_SUMMARY });
+    const handler = createNavigationGraphRequestHandler(exporter);
+
+    const result = await handler(null);
+    expect(result).not.toBeNull();
+    expect(result?.appId).toBeNull();
+    expect(result?.nodes).toHaveLength(0);
+    expect(result?.edges).toHaveLength(0);
+    expect(exporter.exportAllCalls).toBe(1);
+  });
+
+  it("routes to exportGraphSummaryForApp when an appId is supplied", async () => {
+    const exporter = new FakeExporter({ kind: "resolve", summary: POPULATED_SUMMARY });
+    const handler = createNavigationGraphRequestHandler(exporter);
+
+    const result = await handler("com.example.app");
+    expect(result?.appId).toBe("com.example.app");
+    expect(exporter.exportForAppCalls).toEqual(["com.example.app"]);
+    expect(exporter.exportAllCalls).toBe(0);
+  });
+
+  describe("wired into the stream server (issue #4918)", () => {
+    let server: TestableServer;
+
+    beforeEach(() => {
+      server = new TestableServer(new FakeTimer());
+    });
+
+    it("emits a typed error frame (not a silent success ack) when the export fails", async () => {
+      server.setOnNavigationGraphRequested(
+        createNavigationGraphRequestHandler(new FakeExporter({ kind: "reject", error: new Error("db down") }))
+      );
+      const socket = new FakeSocket();
+
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({ id: "req-err", command: "request_navigation_graph" })
+      );
+
+      const msgs = socket.getWrittenMessages<{ id?: string; type: string; success?: boolean; error?: string }>();
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].type).toBe("error");
+      expect(msgs[0].id).toBe("req-err");
+      expect(msgs[0].success).toBe(false);
+      expect(msgs[0].error).toContain("db down");
+    });
+
+    it("emits a navigation_update for the empty-graph success path (distinct from failure)", async () => {
+      server.setOnNavigationGraphRequested(
+        createNavigationGraphRequestHandler(new FakeExporter({ kind: "resolve", summary: EMPTY_SUMMARY }))
+      );
+      const socket = new FakeSocket();
+
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({ id: "req-empty", command: "request_navigation_graph" })
+      );
+
+      const msgs = socket.getWrittenMessages<{ id?: string; type: string; navigationGraph?: NavigationGraphStreamData }>();
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].type).toBe("navigation_update");
+      expect(msgs[0].id).toBe("req-empty");
+      expect(msgs[0].navigationGraph?.appId).toBeNull();
+      expect(msgs[0].navigationGraph?.nodes).toHaveLength(0);
+    });
+
+    it("serializes the error frame so an unknown-frame-tolerant decoder handles it without throwing", async () => {
+      server.setOnNavigationGraphRequested(
+        createNavigationGraphRequestHandler(new FakeExporter({ kind: "reject", error: new Error("db down") }))
+      );
+      const socket = new FakeSocket();
+
+      await server.processLineForTest(
+        socket,
+        JSON.stringify({ id: "req-decode", command: "request_navigation_graph" })
+      );
+
+      // Round-trip the raw wire bytes exactly as a client would receive them.
+      const rawLine = socket.getWrittenDataString().trim();
+      const decoded = JSON.parse(rawLine) as { type: string; success?: boolean; error?: string; id?: string };
+
+      // Mirror the desktop client's `when (type) { ... else -> ignore }` dispatch: every known
+      // frame type routes, and any unrecognized type is silently ignored rather than throwing.
+      const decode = (frame: { type: string }): string => {
+        switch (frame.type) {
+          case "navigation_update":
+            return "handled-navigation";
+          case "error":
+            return "handled-error";
+          default:
+            return "ignored-unknown";
+        }
+      };
+
+      expect(decoded.type).toBe("error");
+      expect(decode(decoded)).toBe("handled-error");
+      // A future/unknown frame type must not throw in the same decoder.
+      expect(decode({ type: "some_future_frame" })).toBe("ignored-unknown");
+    });
+  });
+});
+
+describe("convertSummaryToStreamData", () => {
+  it("preserves node and edge fields and current screen", () => {
+    const streamData = convertSummaryToStreamData(POPULATED_SUMMARY);
+    expect(streamData.appId).toBe("com.example.app");
+    expect(streamData.currentScreen).toBe("Home");
+    expect(streamData.nodes[0]).toMatchObject({ id: 1, screenName: "Home", visitCount: 3 });
+    expect(streamData.edges[0]).toMatchObject({ from: "Home", to: "Settings", toolName: "tapOn", traversalCount: 2 });
+  });
+});


### PR DESCRIPTION
## Summary

The daemon's on-demand navigation-graph request handler
(`setOnNavigationGraphRequested` in `src/daemon/daemon.ts`) swallowed export
failures: the `catch` logged a `logger.warn` and returned `null`. The
device-data stream server reports a `null` callback result as a plain
`subscription_response` success ack with **no** `navigation_update` frame, so a
client that resolves state from the navigation stream (the desktop Navigation
facet, [#4909](https://github.com/kaeawc/auto-mobile/issues/4909)) gets neither
an `appId` nor an error and sits on "Resolving navigation graph…" indefinitely.

This routes the failure into the stream contract so a requesting client can
distinguish **"export failed"** from **"no app / empty graph"**.

## Changes

- New `src/daemon/navigationGraphRequestHandler.ts`:
  - `createNavigationGraphRequestHandler(exporter)` — extracts the previously
    inline callback. On success it returns the summary as stream data; on
    failure it keeps the `logger.warn` for traceability and **rethrows** via
    `toActionableError` instead of returning `null`.
  - `convertSummaryToStreamData` — moved here (was a private function in
    `daemon.ts`) and now exported for reuse and unit testing.
  - `NavigationGraphSummaryExporter` — a narrow interface (YAGNI) exposing just
    the two export methods the handler needs; `NavigationGraphManager` satisfies
    it directly.
- `src/daemon/daemon.ts`: wires the extracted handler
  (`server.setOnNavigationGraphRequested(createNavigationGraphRequestHandler(navGraphManager))`)
  and imports `convertSummaryToStreamData` from the new module. Removed the now
  unused `NavigationGraphStreamData` import.

### Contract choice: reuse the existing `error` frame (not a new type)

The stream server's `request_navigation_graph` handler
(`deviceDataStreamSocketServer.ts`) **already** wraps a thrown callback error in
a typed `error` frame — `{ type: "error", success: false, error: <message>, id:
<requestId> }` — keyed to the request id. The only reason clients never saw it
was that the daemon callback swallowed the error before that path could run.
Rethrowing reuses that existing, already-decoded serialization path: no new
frame type, no new field, correlated to the request via `id`. This is strictly
cleaner and safer than inventing a `navigation_error` type.

## Backward compatibility / version skew

**Additive and version-skew safe. No new frame type or field.**

An old client against the new daemon degrades to today's behavior or better,
never worse — verified by reading the decode paths:

- **Desktop (Kotlin) `ObservationStreamClient.handleMessage`**: dispatches on
  `when (response.type)` with an `else -> log "Unknown message type"`, and
  `type`/`success`/`error`/`id` are all pre-existing `StreamResponse` fields. On
  the export-failure path it now receives the `error` frame, decodes it fine,
  logs `"Observation stream error: <msg>"`, and (since the message is not
  `DEVICE_CONNECTION_LOST_ERROR`) emits nothing to the navigation flow — i.e. it
  falls back to the bounded resolution-timeout backstop shipped in
  [#4912](https://github.com/kaeawc/auto-mobile/issues/4912). Same end state as
  today, plus a real log line. It never throws.
- Because no field/type is added, kotlinx.serialization decode cannot fail on an
  unknown key, and any future/unknown frame type hits the `else` branch and is
  ignored. A round-trip test asserts this tolerance explicitly.

The **success** path is unchanged: a no-app / empty graph still returns a
non-null summary, so the daemon still emits a `navigation_update` (with an empty
graph) — distinguishable from the `error` frame.

Wiring explicit desktop **consumption** of this signal is a follow-up, not this
PR. This is a daemon-only change.

## Scope: daemon↔client stream only — no runner re-cut

This is the **daemon↔client** navigation stream (`DeviceDataStreamSocketServer`,
a Unix socket for IDE/desktop clients), **not** the Android/iOS CtrlProxy runner
wire. No runner re-cut is needed. The frame types are internal socket messages
and do not appear in generated `schemas/`, so nothing to regenerate.

## Testing

- New `test/daemon/navigationGraphRequestHandler.test.ts` (8 tests, all
  sub-millisecond; interface + fakes, no real DB):
  - **(TDD red-first)** handler rethrows an `ActionableError` on export failure
    instead of resolving to `null`, and keeps the `warn` log.
  - no-app / empty-graph success returns a non-null empty graph (distinct from
    failure).
  - `appId` routes to `exportGraphSummaryForApp`, otherwise `exportGraphSummary`.
  - wired into the stream server: export failure emits a typed `error` frame
    (not a silent success ack); empty graph emits a `navigation_update`.
  - decode/round-trip: the serialized `error` frame is handled by an
    unknown-frame-tolerant (`switch … default`) decoder without throwing.
- `bun test` (whole suite): **12479 pass, 13 skip, 0 fail**.
- `test/daemon/deviceDataStreamSocketServer.test.ts`: 94 pass (unchanged).
- `bun run typecheck`: no new type errors.
- `bun run lint`: clean.

## Acceptance criteria

- [x] Export failure is propagated through the stream contract (typed `error`
      frame) rather than swallowed to `null`.
- [x] "export failed" is distinguishable from "no app / empty graph".
- [x] Existing `logger.warn` retained for traceability.
- [x] Additive / backward-compatible; old clients degrade to today's behavior or
      better (proven by reading the decode paths).
- [x] Daemon-only; desktop untouched; no runner re-cut; no schema regen.

Closes [#4918](https://github.com/kaeawc/auto-mobile/issues/4918)
