### PR TITLE
test(release): fix BATS wiring test after validate-finalized-release removal

### DIFF
--- a/test/bats/release-workflow-wiring.bats
+++ b/test/bats/release-workflow-wiring.bats
@@ -187,25 +187,24 @@
   [ "$output" = "90" ]
 }
 
-@test "prepare-release validates the finalized tree before tagging and can rerun provenance upload (#4686)" {
+@test "prepare-release verifies the prepared artifacts on the finalized tree before tagging and can rerun provenance upload (#4686)" {
   wiring_requires_yq
   local workflow=".github/workflows/prepare-release.yml"
 
-  run yq -r '.jobs."validate-finalized-release".needs' "$workflow"
+  # verify-prepared-release gates tagging on the finalized release tree. Generic
+  # CI (test/lint/build/smoke) is intentionally NOT re-run in this pipeline: it
+  # already gates every PR and merge into main before a release is cut, so the
+  # release pipeline runs only release-specific verification (see #4935).
+  run yq -r '.jobs."verify-prepared-release".needs' "$workflow"
   [ "$status" -eq 0 ]
   [[ "$output" == *"finalize-release"* ]]
 
-  run yq -r '.jobs."verify-prepared-release".needs' "$workflow"
+  # The release-specific gate: prepared-artifact checksums and release integrity
+  # are verified against the actual built artifacts before the tag is promoted.
+  run yq -r '.jobs."verify-prepared-release".steps[] | select(.name == "Verify prepared release artifacts") | .run' "$workflow"
   [ "$status" -eq 0 ]
-  [[ "$output" == *"validate-finalized-release"* ]]
-
-  local step_names
-  step_names="$(yq -r '.jobs."validate-finalized-release".steps[].name' "$workflow")"
-  [[ "$step_names" == *"Run tests"* ]]
-  [[ "$step_names" == *"Run lint"* ]]
-  [[ "$step_names" == *"Build TypeScript"* ]]
-  [[ "$step_names" == *"Run Bun MCP startup smoke"* ]]
-  [[ "$step_names" == *"Run Bun image runtime smoke"* ]]
+  [[ "$output" == *"verify-artifact-sha256.sh"* ]]
+  [[ "$output" == *"verify-release-integrity.sh"* ]]
 
   run yq -r '.jobs."verify-prepared-release".steps[] | select(.name == "Upload release artifact provenance") | .with.overwrite' "$workflow"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## What

Fixes `main` (red on **BATS Shell Tests**) by aligning the #4686 release-wiring test with the workflow as it now stands after #4935.

## Why main went red

#4935 removed the `validate-finalized-release` job from `prepare-release.yml` (it re-ran the full test/lint/build suite plus the Bun startup/image smokes — generic CI that already gates every PR and merge into `main`). But `test/bats/release-workflow-wiring.bats` still asserted that job and its five steps exist:

```
run yq -r '.jobs."validate-finalized-release".needs' "$workflow"   # job no longer exists
...
[[ "$step_names" == *"Run tests"* ]]                                # steps no longer exist
```

So the wiring test failed the moment #4935 merged, turning `main` red on BATS and blocking every open PR on CI.

## The fix

Rewrite the test to assert the contract that actually remains — stated positively, not just deleted:

- `verify-prepared-release` gates tagging on the finalized tree (`needs: finalize-release`).
- It runs the **release-specific** verification against the built artifacts: `verify-artifact-sha256.sh` and `verify-release-integrity.sh`.
- The existing provenance-upload `overwrite: true` guard is preserved.

The now-invalid `validate-finalized-release` assertions are dropped.

## Tradeoff (accepted)

This finalizes #4935's decision to run only release-specific checks in the release pipeline. The finalized-tree validation gate is gone, so a future release is no longer blocked at prepare-time by breakage introduced by the version bump itself (e.g. version-coupled doc drift in `daemonInputApiExamples.test.ts`). Those checks still run on `main` via the normal PR/merge CI.

## Validation

- `bats test/bats/release-workflow-wiring.bats` → 34/34 pass, 0 failures (including the rewritten test #12).
