### PR TITLE
fix(docs): sync daemon docs to default CtrlProxy version 0.0.48 (un-red main)

### DIFF
--- a/docs/design-docs/mcp/daemon/client-frame-snapshot.md
+++ b/docs/design-docs/mcp/daemon/client-frame-snapshot.md
@@ -205,7 +205,7 @@ non-null contexts alongside `captureSequence`, then echoes that exact value on
 request. The token is opaque, device-specific, and must never be synthesized or
 compared across reconnects.
 
-The default `0.0.47` CtrlProxy artifacts predate this protocol. A client must
+The default `0.0.48` CtrlProxy artifacts predate this protocol. A client must
 treat those artifacts as legacy and remain in inspector mode until its runner
 publishes `frameContext`.
 

--- a/docs/design-docs/mcp/daemon/client-screen-control.md
+++ b/docs/design-docs/mcp/daemon/client-screen-control.md
@@ -224,7 +224,7 @@ also what lets the retained-frame rule below notice a transition *into* an unkno
   snapshot. Keep its mirror in inspector mode rather than omitting `frameContext` from an input
   request and guessing. The optional field remains compatible with generic, non-screen-control
   socket clients that do not have an observation snapshot.
-- **Release availability:** the default `0.0.47` CtrlProxy artifacts predate `frameContext`
+- **Release availability:** the default `0.0.48` CtrlProxy artifacts predate `frameContext`
   support. Use runners built from a revision that publishes the field before enabling this control
   flow; otherwise treat the runner as legacy and keep the mirror in inspector mode.
 - **Active device:** every message's `deviceId` identifies its device. Subscribe with the selected

--- a/docs/design-docs/mcp/daemon/unix-socket-api.md
+++ b/docs/design-docs/mcp/daemon/unix-socket-api.md
@@ -379,7 +379,7 @@ after the response frame is printed. A screen-control client must replace
 `android-generation-42` with the opaque `frameContext` from its paired screenshot
 and hierarchy; it is illustrative and cannot be reused for another frame.
 These `frameContext` examples require a runner that publishes the field; the
-default `0.0.47` CtrlProxy artifacts are legacy and cannot supply one.
+default `0.0.48` CtrlProxy artifacts are legacy and cannot supply one.
 
 ```bash
 export AUTOMOBILE_DAEMON_SOCKET_PATH="${AUTOMOBILE_DAEMON_SOCKET_PATH:-/tmp/auto-mobile-daemon-$(id -u).sock}"


### PR DESCRIPTION
## Un-reds `main`: sync daemon docs to default CtrlProxy version 0.0.48

The v0.0.48 version bump (`RELEASE_CHECKSUM_REGISTRY[0].version = "0.0.48"`) left the daemon design docs still referencing the old default `0.0.47`. `test/docs/daemonInputApiExamples.test.ts` asserts the docs mention the **current** default (derived from the registry), so `main` went red on *"daemon input API consumer docs > documents frame-context pairing…"* — the known doc-prose-coupling hazard (same class as #4701).

Synced the three asserted lines (`client-screen-control.md`, `unix-socket-api.md`, `client-frame-snapshot.md`) `0.0.47` → `0.0.48`. `frameContext` (#4596) is not yet shipped in the runner, so *"the default 0.0.48 artifacts predate frameContext"* remains accurate — a version-number sync, not a semantic change.

Validated: `bun test test/docs/daemonInputApiExamples.test.ts` → **7 pass / 0 fail**.

Unblocks the in-flight video-security PR sequence (new PRs off `main` were inheriting this red). The red was introduced by the concurrent v0.0.48 release, not by the video work.
