### PR TITLE
ci(release): use plain semver GitHub release titles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -481,7 +481,8 @@ jobs:
           # Releases requires a tag" on a non-tag ref, and this step runs after
           # npm/Homebrew/MCP/Maven/Docker have already published irreversibly.
           tag_name: ${{ needs.validate-release-tag.outputs.tag }}
-          name: AutoMobile v${{ steps.version.outputs.version }}
+          # Plain semver title (e.g. "0.0.47") to match every prior release.
+          name: ${{ steps.version.outputs.version }}
           body_path: release_notes.txt
           files: |
             /tmp/control-proxy-debug.apk


### PR DESCRIPTION
## What changed

The "Create GitHub Release" step in [`.github/workflows/release.yml`](https://github.com/kaeawc/auto-mobile/blob/main/.github/workflows/release.yml) now sets the release `name` to the bare version (`${{ steps.version.outputs.version }}`) instead of `AutoMobile v${{ ... }}`.

## Why

The first fully-automated release titled itself **AutoMobile v0.0.47**, unlike every prior release, which used a plain semver title (`0.0.46`, `0.0.45`, …). This one-line change makes future automated releases match the established convention.

## Reviewer notes

- Release tags in this repo are already bare semver (`0.0.47`, no `v` prefix), and `steps.version.outputs.version` is derived directly from the tag, so the resulting title is exactly `0.0.47`.
- This only affects releases cut from here on. The already-published v0.0.47 release keeps its title unless renamed manually.
- YAML fast-validation (`scripts/all_fast_validate_checks.sh --only yaml`) passes.