### PR TITLE
security: close iOS helper download integrity bypasses (#4761)

### DIFF
--- a/docs/using/hermetic-ci-pinning.md
+++ b/docs/using/hermetic-ci-pinning.md
@@ -67,6 +67,13 @@ registry-known version. For a version **not** in the registry there is nothing t
 against, so the download fails closed (see the `AUTOMOBILE_VERSION` notes above) — a
 mirror can only serve unverified assets if you deliberately opt out of verification.
 
+`AUTOMOBILE_ASSET_BASE_URL` (and the iOS-only `AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_URL`
+bundle override) **must use `https://`** (issue [#4761](https://github.com/kaeawc/auto-mobile/issues/4761)).
+A plaintext `http://` base is rejected because asset fetches over cleartext are a
+confidentiality/downgrade risk even though the pinned checksum still blocks
+substitution. For a trusted loopback/dev mirror (e.g. `http://127.0.0.1:8080`),
+set `AUTOMOBILE_ALLOW_INSECURE_ASSET_URL=1` to opt back into `http://`.
+
 ## Android hermetic recipe
 
 1. **Pin the runner + daemon:**

--- a/src/constants/release.ts
+++ b/src/constants/release.ts
@@ -376,10 +376,57 @@ export const AUTOMOBILE_VERSION_ENV = "AUTOMOBILE_VERSION";
 /** Environment variable that mirrors the APK/IPA download host for offline CI. */
 export const AUTOMOBILE_ASSET_BASE_URL_ENV = "AUTOMOBILE_ASSET_BASE_URL";
 
+/**
+ * Opt-out that permits a plaintext `http://` asset base/bundle URL (issue #4761).
+ * DEFAULT = require `https:`; asset downloads over cleartext are a
+ * confidentiality/downgrade risk (a network attacker can observe the fetch and,
+ * combined with a redirect, weaken the delivery path even though the pinned
+ * checksum still blocks substitution). Set to `1`/`true` ONLY for a trusted
+ * loopback/dev mirror (e.g. `http://127.0.0.1:8080` or `http://localhost`).
+ */
+export const AUTOMOBILE_ALLOW_INSECURE_ASSET_URL_ENV = "AUTOMOBILE_ALLOW_INSECURE_ASSET_URL";
+
 /** Default GitHub Releases base for versioned asset downloads. */
 export const DEFAULT_ASSET_BASE_URL = "https://github.com/kaeawc/auto-mobile/releases/download";
 
 type EnvLike = Record<string, string | undefined>;
+
+/** True when the plaintext-http opt-out ({@link AUTOMOBILE_ALLOW_INSECURE_ASSET_URL_ENV}) is set. */
+function isInsecureAssetUrlAllowed(env: EnvLike): boolean {
+  const value = env[AUTOMOBILE_ALLOW_INSECURE_ASSET_URL_ENV];
+  return value === "1" || value?.toLowerCase() === "true";
+}
+
+/**
+ * Enforce `https:` on an asset download URL (issue #4761). Rejects `http://` and
+ * any other non-TLS scheme unless {@link AUTOMOBILE_ALLOW_INSECURE_ASSET_URL_ENV}
+ * opts into plaintext for a trusted loopback/dev mirror. Throws
+ * {@link ActionableError} — used both for the `AUTOMOBILE_ASSET_BASE_URL` mirror
+ * and the iOS bundle-URL override.
+ *
+ * @param label the env var / knob name to name in the error message.
+ */
+export function assertHttpsAssetUrl(url: string, label: string, env: EnvLike = process.env): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new ActionableError(
+      `${label} must be an absolute URL, for example https://mirror.example/auto-mobile.`
+    );
+  }
+  if (parsed.protocol === "https:") {
+    return;
+  }
+  if (isInsecureAssetUrlAllowed(env)) {
+    return;
+  }
+  throw new ActionableError(
+    `${label} must use https:// (got ${parsed.protocol}//). Plaintext/non-TLS asset downloads are a ` +
+    `confidentiality and downgrade risk. Set ${AUTOMOBILE_ALLOW_INSECURE_ASSET_URL_ENV}=1 to opt out ` +
+    `for a trusted loopback/dev mirror.`
+  );
+}
 
 /**
  * Resolve the pinned version from `AUTOMOBILE_VERSION`. Returns the trimmed value
@@ -445,6 +492,8 @@ export function resolveAssetBaseUrl(env: EnvLike = process.env): string {
         `use a path-only base URL such as ${parsed.origin}${parsed.pathname.replace(/\/+$/, "")}.`
       );
     }
+    // Require https:// unless the plaintext opt-out is set (issue #4761).
+    assertHttpsAssetUrl(`${parsed.origin}${parsed.pathname}`, AUTOMOBILE_ASSET_BASE_URL_ENV, env);
     return `${parsed.origin}${parsed.pathname}`.replace(/\/+$/, "");
   }
   return DEFAULT_ASSET_BASE_URL;

--- a/src/utils/IOSCtrlProxyBuilder.ts
+++ b/src/utils/IOSCtrlProxyBuilder.ts
@@ -7,6 +7,7 @@ import { NoOpPerformanceTracker, type PerformanceTracker } from "./PerformanceTr
 import {
   IOS_CTRL_PROXY_APP_HASH,
   LATEST_RELEASE_VERSION,
+  assertHttpsAssetUrl,
   isExplicitPin,
   isPinnedVersionKnown,
   resolveAssetVersion,
@@ -807,6 +808,9 @@ export class IOSCtrlProxyBuilder {
   private getBundleUrl(): string {
     const override = process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_URL?.trim();
     if (override) {
+      // Reject a plaintext http:// bundle override unless the opt-out is set
+      // (issue #4761); resolveIpaUrl already enforces https on the mirror knob.
+      assertHttpsAssetUrl(override, "AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_URL");
       return override;
     }
     return resolveIpaUrl();
@@ -898,6 +902,12 @@ export class IOSCtrlProxyBuilder {
         } catch (error) {
           if (isLatest && cachedBundleExists) {
             logger.warn(`[IOSCtrlProxyBuilder] Download failed, using cached bundle: ${error instanceof Error ? error.message : String(error)}`);
+            // `cachedBundleExists` only proves the cached IPA is size-valid — NOT
+            // that its checksum matches. build() skips extractBundle+verifyBundle
+            // for the fallback path, so checksum-verify here before reuse instead
+            // of trusting a size-valid-but-unverified cached IPA (issue #4761).
+            // A mismatch throws and fails closed rather than reusing it silently.
+            await this.verifyBundle(bundlePath);
             return { bundlePath, usedCachedFallback: true };
           }
           throw error;
@@ -1104,10 +1114,13 @@ export class IOSCtrlProxyBuilder {
       logger.warn(`[IOSCtrlProxyBuilder] App bundle hash verification skipped for ${platform} (no hash provided)`);
     }
 
-    // Verify the release-selected runner executable SHA256 for simulator.
-    if (platform === "simulator") {
-      await this.assertRunnerBinaryHash(platform, "post-extract");
-    }
+    // Verify the release-selected runner executable SHA256 for BOTH simulator
+    // and device (issue #4761). On device the app-bundle hash check above is
+    // skipped because IOS_CTRL_PROXY_APP_HASH ships empty, so re-hashing the
+    // runner executable is the only independent post-extract integrity signal
+    // there — previously it ran for simulator only. `assertRunnerBinaryHash`
+    // still no-ops with a warning when no runner checksum is configured.
+    await this.assertRunnerBinaryHash(platform, "post-extract");
   }
 
   /**

--- a/src/utils/IOSCtrlProxyBundleDownloader.ts
+++ b/src/utils/IOSCtrlProxyBundleDownloader.ts
@@ -1,10 +1,37 @@
 import * as fs from "fs/promises";
+import * as path from "path";
 import AdmZip from "adm-zip";
 import { type FileDownloader, DefaultFileDownloader } from "./FileDownloader";
 import { type ChecksumCalculator, type Sha256Source, DefaultChecksumCalculator } from "./ChecksumCalculator";
 import { ensureSecureDir } from "./filesystem/securePermissions";
+import { ActionableError } from "../models/ActionableError";
 
 export type { Sha256Source };
+
+/**
+ * Defensive zip-slip containment check (issue #4761). adm-zip >= 0.5.10 already
+ * sanitizes entry names in `extractAllTo` (`canonical` + `sanitize`), but this
+ * bundle only reaches extraction on the unverified fallback/override paths, so a
+ * malicious archive is worth a second, explicit gate: reject any entry that
+ * resolves outside the destination BEFORE writing a single file. Belt-and-braces
+ * on top of the library guard, independent of the installed adm-zip version.
+ */
+export function assertZipEntriesContained(zip: AdmZip, destination: string): void {
+  const resolvedRoot = path.resolve(destination);
+  for (const entry of zip.getEntries()) {
+    const target = path.resolve(resolvedRoot, entry.entryName);
+    const relative = path.relative(resolvedRoot, target);
+    const escapes = relative === ".." ||
+      relative.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relative);
+    if (escapes) {
+      throw new ActionableError(
+        `Refusing to extract CtrlProxy bundle: entry "${entry.entryName}" resolves outside the ` +
+        `extraction directory ${resolvedRoot} (zip-slip / path traversal).`
+      );
+    }
+  }
+}
 
 export interface CtrlProxyIosBundleDownloader {
   download(url: string, destination: string): Promise<void>;
@@ -40,6 +67,7 @@ export class DefaultIOSCtrlProxyBundleDownloader implements CtrlProxyIosBundleDo
     await ensureSecureDir(destination);
 
     const zip = new AdmZip(bundlePath);
+    assertZipEntriesContained(zip, destination);
     zip.extractAllTo(destination, true);
   }
 }

--- a/test/constants/release.test.ts
+++ b/test/constants/release.test.ts
@@ -4,8 +4,10 @@ import { join } from "path";
 import {
   APK_SHA256_CHECKSUM,
   APK_URL,
+  AUTOMOBILE_ALLOW_INSECURE_ASSET_URL_ENV,
   DAEMON_PACKAGE_NAME,
   DEFAULT_ASSET_BASE_URL,
+  assertHttpsAssetUrl,
   IOS_CTRL_PROXY_IPA_URL,
   IOS_CTRL_PROXY_RUNNER_SHA256_CHECKSUM,
   IOS_CTRL_PROXY_SHA256_CHECKSUM,
@@ -204,6 +206,48 @@ describe("resolveAssetBaseUrl (AUTOMOBILE_ASSET_BASE_URL mirror knob)", function
   test("rejects non-absolute mirror bases", function() {
     expect(() => resolveAssetBaseUrl({ AUTOMOBILE_ASSET_BASE_URL: "/mirror/am" }))
       .toThrow("AUTOMOBILE_ASSET_BASE_URL must be an absolute URL");
+  });
+
+  test("rejects a plaintext http:// mirror base by default (#4761)", function() {
+    expect(() => resolveAssetBaseUrl({ AUTOMOBILE_ASSET_BASE_URL: "http://mirror.test/am" }))
+      .toThrow("AUTOMOBILE_ASSET_BASE_URL must use https://");
+  });
+
+  test("allows a plaintext http:// mirror base when the opt-out is set (#4761)", function() {
+    expect(resolveAssetBaseUrl({
+      AUTOMOBILE_ASSET_BASE_URL: "http://127.0.0.1:8080/am/",
+      [AUTOMOBILE_ALLOW_INSECURE_ASSET_URL_ENV]: "1",
+    })).toBe("http://127.0.0.1:8080/am");
+  });
+});
+
+describe("assertHttpsAssetUrl (#4761 https enforcement)", function() {
+  test("accepts an https:// URL", function() {
+    expect(() => assertHttpsAssetUrl("https://mirror.test/am/control-proxy.ipa", "LABEL", {}))
+      .not.toThrow();
+  });
+
+  test("rejects an http:// URL by default", function() {
+    expect(() => assertHttpsAssetUrl("http://mirror.test/am/control-proxy.ipa", "LABEL", {}))
+      .toThrow("LABEL must use https://");
+  });
+
+  test("rejects a non-http(s) scheme by default", function() {
+    expect(() => assertHttpsAssetUrl("ftp://mirror.test/am/control-proxy.ipa", "LABEL", {}))
+      .toThrow("LABEL must use https://");
+  });
+
+  test("permits http:// under the AUTOMOBILE_ALLOW_INSECURE_ASSET_URL opt-out", function() {
+    expect(() => assertHttpsAssetUrl(
+      "http://localhost:8080/control-proxy.ipa",
+      "LABEL",
+      { [AUTOMOBILE_ALLOW_INSECURE_ASSET_URL_ENV]: "true" }
+    )).not.toThrow();
+  });
+
+  test("rejects a non-absolute URL", function() {
+    expect(() => assertHttpsAssetUrl("/relative/path", "LABEL", {}))
+      .toThrow("LABEL must be an absolute URL");
   });
 });
 

--- a/test/fakes/FakeIOSCtrlProxyBundleDownloader.ts
+++ b/test/fakes/FakeIOSCtrlProxyBundleDownloader.ts
@@ -12,6 +12,8 @@ export class FakeIOSCtrlProxyBundleDownloader implements CtrlProxyIosBundleDownl
   public checksummedFilePaths: string[] = [];
   public checksumSource: Sha256Source = "node";
   public extractedSubdir: string = "";
+  /** When true, also emit Debug-iphoneos products + a device xctestrun (issue #4761 AC3). */
+  public includeDeviceProducts: boolean = false;
 
   public async download(url: string, destination: string): Promise<void> {
     this.downloadedUrls.push(url);
@@ -48,5 +50,20 @@ export class FakeIOSCtrlProxyBundleDownloader implements CtrlProxyIosBundleDownl
     await fs.mkdir(path.dirname(xctestBinary), { recursive: true });
     await fs.writeFile(xctestBinary, "fake CtrlProxy code");
     await fs.mkdir(path.join(productsDir, "CtrlProxyTests.xctest"), { recursive: true });
+
+    if (this.includeDeviceProducts) {
+      const deviceDir = path.join(extractionRoot, "Build", "Products", "Debug-iphoneos");
+      await fs.mkdir(deviceDir, { recursive: true });
+      const deviceXctestrun = path.join(extractionRoot, "Build", "Products", "CtrlProxyApp_iphoneos.xctestrun");
+      await fs.writeFile(deviceXctestrun, "fake device xctestrun");
+      await fs.mkdir(path.join(deviceDir, "CtrlProxyApp.app"), { recursive: true });
+      const deviceRunnerDir = path.join(deviceDir, "CtrlProxyUITests-Runner.app");
+      await fs.mkdir(deviceRunnerDir, { recursive: true });
+      await fs.writeFile(path.join(deviceRunnerDir, "CtrlProxyUITests-Runner"), "fake device runner");
+      const deviceXctestBinary = path.join(deviceRunnerDir, "PlugIns", "CtrlProxyUITests.xctest", "CtrlProxyUITests");
+      await fs.mkdir(path.dirname(deviceXctestBinary), { recursive: true });
+      await fs.writeFile(deviceXctestBinary, "fake device CtrlProxy code");
+      await fs.mkdir(path.join(deviceDir, "CtrlProxyTests.xctest"), { recursive: true });
+    }
   }
 }

--- a/test/utils/IOSCtrlProxyBuilder.test.ts
+++ b/test/utils/IOSCtrlProxyBuilder.test.ts
@@ -1026,5 +1026,157 @@ describe("IOSCtrlProxyBuilder", function() {
         size: 12000,
       });
     });
+
+    test("refuses a checksum-mismatched cached bundle on the download-failed fallback (#4761)", async function() {
+      // A size-valid but checksum-mismatched cached IPA already exists. Previously,
+      // when the latest-mode download failed, build() reused it WITHOUT any checksum
+      // check (usedCachedFallback skips extract+verify). Now verifyBundle runs on the
+      // fallback bundle before reuse, so the stale/tampered cache is rejected.
+      const derivedDataPath = path.join(tempDir, "DerivedData");
+      const cacheDir = path.join(tempDir, "cache");
+      await fs.mkdir(cacheDir, { recursive: true });
+      await fs.writeFile(path.join(cacheDir, "control-proxy.ipa"), "a".repeat(12000));
+
+      const downloader = new FakeIOSCtrlProxyBundleDownloader();
+      downloader.checksum = "cached-different-checksum";
+      downloader.download = async () => {
+        throw new Error("network unreachable");
+      };
+
+      IOSCtrlProxyBuilder.setExpectedChecksumForTesting("expected-checksum");
+      const builder = IOSCtrlProxyBuilder.getInstance(
+        { derivedDataPath, bundleCacheDir: cacheDir },
+        { downloader }
+      );
+
+      const result = await builder.build("simulator");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("checksum verification failed");
+    });
+
+    test("verifies then reuses a checksum-valid cached bundle on the download-failed fallback (#4761)", async function() {
+      // Pre-existing extracted artifacts + a cached IPA. The latest-mode download
+      // fails; the cached IPA is checksum-verified and only then reused (extraction
+      // is skipped for the fallback path, so the downloader never re-extracts).
+      const derivedDataPath = path.join(tempDir, "DerivedData");
+      const productsDir = path.join(derivedDataPath, "Build", "Products");
+      await fs.mkdir(path.join(productsDir, "Debug-iphonesimulator"), { recursive: true });
+      await fs.writeFile(path.join(productsDir, "CtrlProxyApp_iphonesimulator.xctestrun"), "mock");
+
+      const cacheDir = path.join(tempDir, "cache");
+      await fs.mkdir(cacheDir, { recursive: true });
+      await fs.writeFile(path.join(cacheDir, "control-proxy.ipa"), "a".repeat(12000));
+
+      const downloader = new FakeIOSCtrlProxyBundleDownloader();
+      downloader.download = async () => {
+        throw new Error("network unreachable");
+      };
+      // First hash (pre-download validity probe) mismatches to force the download
+      // attempt; the verifyBundle re-hash on the fallback path matches and passes.
+      let shaCalls = 0;
+      downloader.computeFileSha256 = async () => {
+        shaCalls++;
+        return { checksum: shaCalls === 1 ? "stale-checksum" : "expected-checksum", source: "node" as const };
+      };
+
+      IOSCtrlProxyBuilder.setExpectedChecksumForTesting("expected-checksum");
+      const builder = IOSCtrlProxyBuilder.getInstance(
+        { derivedDataPath, bundleCacheDir: cacheDir },
+        { downloader }
+      );
+
+      const result = await builder.build("simulator");
+
+      expect(result.success).toBe(true);
+      // verifyBundle re-hashed the cached bundle (a second computeFileSha256 call).
+      expect(shaCalls).toBeGreaterThanOrEqual(2);
+      // Fallback path skips extraction entirely.
+      expect(downloader.extractedPaths).toHaveLength(0);
+    });
+
+    test("rejects a plaintext http:// bundle URL override by default (#4761)", async function() {
+      const prevUrl = process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_URL;
+      process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_URL = "http://mirror.test/control-proxy.ipa";
+      try {
+        const derivedDataPath = path.join(tempDir, "DerivedData");
+        const cacheDir = path.join(tempDir, "cache");
+        const downloader = new FakeIOSCtrlProxyBundleDownloader();
+        downloader.checksum = "expected-checksum";
+        IOSCtrlProxyBuilder.setExpectedChecksumForTesting("expected-checksum");
+        const builder = IOSCtrlProxyBuilder.getInstance(
+          { derivedDataPath, bundleCacheDir: cacheDir },
+          { downloader }
+        );
+
+        const result = await builder.build("simulator");
+
+        expect(result.success).toBe(false);
+        expect(result.error).toContain("must use https://");
+      } finally {
+        if (prevUrl === undefined) {
+          delete process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_URL;
+        } else {
+          process.env.AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_URL = prevUrl;
+        }
+      }
+    });
+
+    test("re-hashes the device runner executable post-extract, not just simulator (#4761)", async function() {
+      const derivedDataPath = path.join(tempDir, "DerivedData");
+      const cacheDir = path.join(tempDir, "cache");
+      const downloader = new FakeIOSCtrlProxyBundleDownloader();
+      downloader.checksum = "expected-checksum";
+      downloader.includeDeviceProducts = true;
+      downloader.runnerChecksum = "xctest-checksum";
+
+      IOSCtrlProxyBuilder.setExpectedChecksumForTesting("expected-checksum");
+      IOSCtrlProxyBuilder.setExpectedRunnerChecksumForTesting("xctest-checksum", "xctest");
+      const builder = IOSCtrlProxyBuilder.getInstance(
+        { derivedDataPath, bundleCacheDir: cacheDir },
+        { downloader }
+      );
+
+      const result = await builder.build("device");
+
+      expect(result.success).toBe(true);
+      // The device runner executable under Debug-iphoneos was independently hashed.
+      expect(downloader.checksummedFilePaths).toContain(
+        path.join(
+          derivedDataPath, "Build", "Products", "Debug-iphoneos",
+          "CtrlProxyUITests-Runner.app", "PlugIns", "CtrlProxyUITests.xctest", "CtrlProxyUITests"
+        )
+      );
+    });
+
+    test("fails closed when the device runner executable hash differs (#4761)", async function() {
+      const derivedDataPath = path.join(tempDir, "DerivedData");
+      const cacheDir = path.join(tempDir, "cache");
+      const downloader = new FakeIOSCtrlProxyBundleDownloader();
+      downloader.checksum = "expected-checksum";
+      downloader.includeDeviceProducts = true;
+      // Only the device runner executable is tampered; the simulator one matches.
+      downloader.computeFileSha256 = async (filePath: string) => {
+        if (path.basename(filePath) === "CtrlProxyUITests") {
+          return {
+            checksum: filePath.includes("Debug-iphoneos") ? "tampered-device-checksum" : "xctest-checksum",
+            source: "node" as const,
+          };
+        }
+        return { checksum: "expected-checksum", source: "node" as const };
+      };
+
+      IOSCtrlProxyBuilder.setExpectedChecksumForTesting("expected-checksum");
+      IOSCtrlProxyBuilder.setExpectedRunnerChecksumForTesting("xctest-checksum", "xctest");
+      const builder = IOSCtrlProxyBuilder.getInstance(
+        { derivedDataPath, bundleCacheDir: cacheDir },
+        { downloader }
+      );
+
+      const result = await builder.build("device");
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("runner binary SHA256 mismatch");
+    });
   });
 });

--- a/test/utils/IOSCtrlProxyBundleDownloader.test.ts
+++ b/test/utils/IOSCtrlProxyBundleDownloader.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "fs/promises";
+import * as path from "path";
+import os from "os";
+import AdmZip from "adm-zip";
+import {
+  DefaultIOSCtrlProxyBundleDownloader,
+  assertZipEntriesContained,
+} from "../../src/utils/IOSCtrlProxyBundleDownloader";
+
+describe("IOSCtrlProxyBundleDownloader zip-slip containment (#4761)", function() {
+  let tempDir: string;
+
+  beforeEach(async function() {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ctrl-proxy-zipslip-test-"));
+  });
+
+  afterEach(async function() {
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  describe("assertZipEntriesContained", function() {
+    test("accepts entries that stay inside the destination", function() {
+      const zip = new AdmZip();
+      zip.addFile("Build/Products/app.txt", Buffer.from("ok"));
+      zip.addFile("nested/dir/file.bin", Buffer.from("ok"));
+      const destination = path.join(tempDir, "out");
+      expect(() => assertZipEntriesContained(zip, destination)).not.toThrow();
+    });
+
+    test("rejects a parent-directory traversal entry", function() {
+      const zip = new AdmZip();
+      // adm-zip canonicalizes `../` on addFile, so a crafted archive is simulated
+      // by forcing the raw traversal entryName (survives a toBuffer round-trip).
+      zip.addFile("escapee.txt", Buffer.from("evil"));
+      zip.getEntries()[0].entryName = "../escapee.txt";
+      const destination = path.join(tempDir, "out");
+      expect(() => assertZipEntriesContained(zip, destination))
+        .toThrow("zip-slip / path traversal");
+    });
+
+    test("rejects a deep parent-directory traversal entry", function() {
+      const zip = new AdmZip();
+      zip.addFile("evil.txt", Buffer.from("evil"));
+      zip.getEntries()[0].entryName = "a/../../../../etc/evil.txt";
+      const destination = path.join(tempDir, "out");
+      expect(() => assertZipEntriesContained(zip, destination))
+        .toThrow("zip-slip / path traversal");
+    });
+  });
+
+  describe("extractBundle", function() {
+    test("extracts a well-formed archive into an owner-only directory", async function() {
+      const zip = new AdmZip();
+      zip.addFile("Build/Products/marker.txt", Buffer.from("hello"));
+      const bundlePath = path.join(tempDir, "bundle.zip");
+      await fs.writeFile(bundlePath, zip.toBuffer());
+
+      const destination = path.join(tempDir, "extract");
+      const downloader = new DefaultIOSCtrlProxyBundleDownloader();
+      await downloader.extractBundle(bundlePath, destination);
+
+      const extracted = await fs.readFile(
+        path.join(destination, "Build", "Products", "marker.txt"),
+        "utf-8"
+      );
+      expect(extracted).toBe("hello");
+    });
+
+    test("refuses to extract an archive with a path-traversal entry (#4761)", async function() {
+      const zip = new AdmZip();
+      zip.addFile("escapee.txt", Buffer.from("evil"));
+      zip.getEntries()[0].entryName = "../escapee.txt";
+      const bundlePath = path.join(tempDir, "malicious.zip");
+      await fs.writeFile(bundlePath, zip.toBuffer());
+
+      const destination = path.join(tempDir, "extract");
+      const downloader = new DefaultIOSCtrlProxyBundleDownloader();
+
+      await expect(downloader.extractBundle(bundlePath, destination))
+        .rejects.toThrow("zip-slip / path traversal");
+
+      // The traversal target must not have been written to the parent directory.
+      await expect(fs.access(path.join(tempDir, "escapee.txt"))).rejects.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
Closes [#4761](https://github.com/kaeawc/auto-mobile/issues/4761)

## Summary

Closes three integrity bypasses on the iOS CtrlProxy helper download path (plus the defensive zip-slip check from the issue Notes), composing with — not fighting — the recently-landed hardening: [#4759](https://github.com/kaeawc/auto-mobile/issues/4759) (extract/launch off `/tmp`, uid + hash pre-launch checks) and [#4760](https://github.com/kaeawc/auto-mobile/issues/4760) (codesign warn-gate).

## Verify-real findings (against current `main`)

All three bypasses reproduced as described; line numbers had drifted from the issue body but the code shape matched:

- **Cached-fallback skips verification** — `ensureBundleDownloaded` returns `{ usedCachedFallback: true }` when a `latest`-mode download fails and a cached bundle exists (`IOSCtrlProxyBuilder.ts` ~L899), and `build()` skips `extractBundle`+`verifyBundle` for that path (~L566). `cachedBundleExists` came from `isBundleValid(bundlePath, "")` — **size-only**, no checksum.
- **Plaintext/redirect download** — `resolveAssetBaseUrl` (`release.ts` ~L431) accepted any absolute URL incl. `http://`; `getBundleUrl`'s `AUTOMOBILE_CTRL_PROXY_IOS_BUNDLE_URL` override was returned unchecked. `FileDownloader` handles `http:` and follows up to 5 redirects.
- **Device-runner hash gap** — `verifyPlatformArtifacts` re-hashed the runner **only** when `platform === "simulator"` (~L1108). On device, `getExpectedAppHash("device")` returns the empty `IOS_CTRL_PROXY_APP_HASH`, so nothing was hash-verified post-extract.
- **Zip-slip** — confirmed installed `adm-zip@0.6.0` includes the `canonical` + `sanitize` guard in `extractAllTo`; added a defensive per-entry containment check anyway (the bundle only reaches extraction on the unverified fallback/override paths).

## What changed

1. **Cached-fallback checksum-verified before reuse** — the download-failed fallback now runs `verifyBundle(bundlePath)` before returning `usedCachedFallback: true`. A size-valid-but-checksum-mismatched (stale/tampered) cached IPA is now rejected (fails closed) instead of silently reused.
2. **Require `https:`** — new shared `assertHttpsAssetUrl(url, label, env)` in `release.ts`, wired into `resolveAssetBaseUrl` and `getBundleUrl`. Plaintext `http://` (and any non-TLS scheme) is rejected **by default**. Opt-out for a trusted loopback/dev mirror: **`AUTOMOBILE_ALLOW_INSECURE_ASSET_URL=1`** (documented in `docs/using/hermetic-ci-pinning.md`).
3. **Device runner re-hashed** — `verifyPlatformArtifacts` now calls `assertRunnerBinaryHash(platform, "post-extract")` for both simulator **and** device. `assertRunnerBinaryHash` still no-ops with a warning when no runner checksum is configured.
4. **Defensive zip-slip guard** — `assertZipEntriesContained(zip, destination)` rejects any entry resolving outside the destination before `extractAllTo`, on top of the adm-zip library guard.

Ship-a-real-hash follow-up: `IOS_CTRL_PROXY_APP_HASH` (device app-bundle hash) still ships empty, so the device **app-bundle** hash check remains skip-with-warning; this PR closes the device **runner-binary** gap. Baking a real per-release device app hash is captured as a follow-up.

## Validation

- `bun run typecheck` — no new type errors (196 in baseline).
- `bunx turbo run lint build` — pass (all boundary scans green).
- Affected suites (full suite deferred to CI to avoid host contention):
  - `test/utils/IOSCtrlProxyBuilder.test.ts`, `test/utils/IOSCtrlProxyBundleDownloader.test.ts` (new), `test/constants/release.test.ts` — 142 pass.
  - `test/utils/FileDownloader.test.ts`, `test/utils/CtrlProxyManager.test.ts`, `test/doctor/**` — pass.

New tests cover: cached-fallback rejects a checksum-mismatched cache and verifies-then-reuses a valid one; `http://` base URL + bundle-URL override rejected (and permitted under the opt-out); device runner executable independently hashed and fails closed on mismatch; `assertHttpsAssetUrl` scheme matrix; zip-slip containment (direct + via `extractBundle`).

## Windows portability

All new test paths are built/asserted with `node:path` (`path.join`/`path.sep`/`path.relative`), no hardcoded POSIX slashes. The zip-slip check uses `path.relative` + `path.isAbsolute` so a cross-drive escape on Windows is also caught. POSIX-only behavior (uid ownership) was untouched and its tests remain guarded.
