### PR TITLE
feat(video): TTL retention sweep, in-progress size cap, secure-delete docs (#4762)

### DIFF
--- a/docs/design-docs/mcp/observe/video-recording.md
+++ b/docs/design-docs/mcp/observe/video-recording.md
@@ -99,8 +99,47 @@ Platform-specific capture sources:
 
 - Archive directory: `~/.auto-mobile/video-archive`.
 - Store recording metadata in SQLite (`~/.auto-mobile/auto-mobile.db`).
-- Enforce `maxArchiveSizeMb` with LRU eviction (oldest first).
+- Enforce `maxArchiveSizeMb` with LRU eviction (oldest first). Eviction only
+  removes *other completed* recordings and only fires on stop or config change.
 - Provide stable filenames (`recordingId` + timestamp).
+
+### Time-based retention (TTL)
+
+Size-based eviction alone lets sensitive recordings persist indefinitely while
+the archive stays under `maxArchiveSizeMb`, and it never runs on a long-idle
+daemon (it only fires on stop/config-change). A periodic **TTL sweep** (issue
+[#4762](https://github.com/kaeawc/auto-mobile/issues/4762)) runs on an injected
+timer and deletes completed/interrupted recordings whose age (relative to
+`createdAt`) exceeds the retention window.
+
+| Setting | Env var (either prefix) | Default |
+| --- | --- | --- |
+| Retention window | `AUTOMOBILE_VIDEO_RETENTION_DAYS` / `AUTO_MOBILE_VIDEO_RETENTION_DAYS` | `7` days (`0` disables the sweep) |
+| Sweep interval | `AUTOMOBILE_VIDEO_RETENTION_SWEEP_MINUTES` / `AUTO_MOBILE_VIDEO_RETENTION_SWEEP_MINUTES` | `60` minutes |
+| In-progress size-check interval | `AUTOMOBILE_VIDEO_INPROGRESS_CHECK_SECONDS` / `AUTO_MOBILE_VIDEO_INPROGRESS_CHECK_SECONDS` | `15` seconds |
+
+Invalid or negative values fall back to the defaults (a warning is logged).
+
+### In-progress size cap
+
+A single long capture (iOS `simctl recordVideo` runs up to
+`IOS_MAX_DURATION_SECONDS = 3600`) is not covered by archive eviction, which only
+considers *other completed* recordings — so one uncapped recording can fill the
+disk (a local DoS). Each live recording is monitored against the archive cap
+(`maxArchiveSizeMb`); when its on-disk file reaches the cap the recording is
+stopped (and finalized) rather than allowed to grow unbounded.
+
+### Secure delete (known limitation)
+
+Deletion (`deleteVideoRecording`, eviction, and the TTL sweep) uses
+`fs.rm(recordingDir, { recursive: true, force: true })`. **This is not a secure
+delete:** it unlinks the directory entry but does not overwrite the underlying
+blocks, so screen-capture bytes — which may contain OTPs, credentials, or PII —
+can remain recoverable from the raw storage device until the filesystem reuses
+those blocks. An opt-in **"sensitive mode"** that overwrites recording bytes
+before unlinking is intentionally left as a follow-up (see the flagged hook in
+`deleteVideoRecording`) rather than paid as an unconditional cost on every
+delete.
 
 ## Video recording configuration socket
 
@@ -117,3 +156,9 @@ Platform-specific capture sources:
 
 - Recording is opt-in only (explicit tool call or CLI flag).
 - Sensitive metadata must be scrubbed from filenames.
+- Recordings are stored owner-only (per-recording dir `0o700`, finalized file
+  `0o600`; issue [#4750](https://github.com/kaeawc/auto-mobile/issues/4750)).
+- Recordings are pruned on a time-based TTL (default 7 days) so sensitive content
+  does not persist indefinitely; see [Time-based retention (TTL)](#time-based-retention-ttl).
+- Deletion is a plain unlink, **not** a secure/overwrite delete; see
+  [Secure delete (known limitation)](#secure-delete-known-limitation).

--- a/src/server/videoRecordingManager.ts
+++ b/src/server/videoRecordingManager.ts
@@ -46,6 +46,85 @@ export const IOS_MAX_DURATION_SECONDS = 3600;
 const ANDROID_HIGHLIGHT_ANIMATION_DURATION_MS = 6000;
 const IOS_HIGHLIGHT_ANIMATION_DURATION_MS = 3000;
 
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+// Retention defaults (issue #4762). The archive was previously size-only: a
+// long-idle daemon never pruned, and a single uncapped in-progress capture could
+// fill the disk. These add a time-based TTL sweep and a live in-progress size cap.
+// All three are overridable via env so operators can tune retention without a
+// rebuild (documented in docs/design-docs/mcp/observe/video-recording.md).
+const DEFAULT_RETENTION_DAYS = 7;
+const DEFAULT_RETENTION_SWEEP_INTERVAL_MINUTES = 60;
+const DEFAULT_IN_PROGRESS_SIZE_CHECK_SECONDS = 15;
+
+/**
+ * Time-based retention + in-progress size-cap policy for the video archive
+ * (issue #4762). Injected via the manager dependencies so tests drive the TTL
+ * sweep and size monitor deterministically with FakeTimer; defaults resolve from
+ * the environment (see {@link resolveVideoRetentionPolicy}).
+ */
+export interface VideoRetentionPolicy {
+  /**
+   * Delete completed/interrupted recordings whose age (relative to `createdAt`)
+   * exceeds this. `0` disables the time-based sweep entirely.
+   */
+  ttlMs: number;
+  /** How often the TTL sweep timer fires. */
+  sweepIntervalMs: number;
+  /** How often an in-progress recording's on-disk size is checked against the cap. */
+  inProgressCheckIntervalMs: number;
+}
+
+function parseEnvNumber(
+  raw: string | undefined,
+  fallback: number,
+  allowZero: boolean
+): number {
+  if (raw === undefined || raw.trim() === "") {
+    return fallback;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0 || (!allowZero && parsed === 0)) {
+    logger.warn(
+      `[VideoRecording] Ignoring invalid retention env value "${raw}"; using ${fallback}`
+    );
+    return fallback;
+  }
+  return parsed;
+}
+
+/**
+ * Resolve the retention policy from the environment, falling back to the
+ * documented defaults. Exported for tests; the manager calls it when no explicit
+ * policy is injected.
+ */
+export function resolveVideoRetentionPolicy(
+  env: NodeJS.ProcessEnv = process.env
+): VideoRetentionPolicy {
+  const days = parseEnvNumber(
+    env.AUTOMOBILE_VIDEO_RETENTION_DAYS ?? env.AUTO_MOBILE_VIDEO_RETENTION_DAYS,
+    DEFAULT_RETENTION_DAYS,
+    true
+  );
+  const sweepMinutes = parseEnvNumber(
+    env.AUTOMOBILE_VIDEO_RETENTION_SWEEP_MINUTES ??
+      env.AUTO_MOBILE_VIDEO_RETENTION_SWEEP_MINUTES,
+    DEFAULT_RETENTION_SWEEP_INTERVAL_MINUTES,
+    false
+  );
+  const checkSeconds = parseEnvNumber(
+    env.AUTOMOBILE_VIDEO_INPROGRESS_CHECK_SECONDS ??
+      env.AUTO_MOBILE_VIDEO_INPROGRESS_CHECK_SECONDS,
+    DEFAULT_IN_PROGRESS_SIZE_CHECK_SECONDS,
+    false
+  );
+  return {
+    ttlMs: Math.max(0, Math.floor(days * MS_PER_DAY)),
+    sweepIntervalMs: Math.max(1000, Math.floor(sweepMinutes * 60_000)),
+    inProgressCheckIntervalMs: Math.max(1000, Math.floor(checkSeconds * 1000)),
+  };
+}
+
 interface StartVideoRecordingRequest {
   device: BootedDevice;
   configOverrides?: VideoRecordingConfigInput;
@@ -83,6 +162,18 @@ interface VideoRecordingManagerDependencies {
   highlightClient: VisualHighlightClient;
   timer: Timer;
   now: () => Date;
+  /**
+   * Time-based retention + in-progress size-cap policy (issue #4762). Injected so
+   * tests can drive the sweep/monitor with FakeTimer; defaults come from
+   * {@link resolveVideoRetentionPolicy}.
+   */
+  retentionPolicy: VideoRetentionPolicy;
+  /**
+   * On-disk size of a recording file, in bytes. Seam over `fs.stat` so the
+   * in-progress size cap is testable without real capture I/O. Returns 0 for a
+   * missing file.
+   */
+  statFileSize: (filePath: string) => Promise<number>;
 }
 
 interface RecordedHighlightEntry {
@@ -108,6 +199,13 @@ let managerInitialized = false;
 const autoStopTimers = new Map<string, { timer: Timer; handle: NodeJS.Timeout }>();
 const highlightSessions = new Map<string, VideoRecordingHighlightSession>();
 const highlightSessionsByDeviceId = new Map<string, string>();
+// In-progress size-cap monitors, keyed by recordingId (issue #4762). Each is a
+// periodic timer that stops a live capture once it reaches its cap so one long
+// recording cannot fill the disk.
+const inProgressSizeMonitors = new Map<string, { timer: Timer; handle: NodeJS.Timeout }>();
+// The single periodic TTL sweep timer (issue #4762). Armed lazily on first init,
+// cleared on manager reset.
+let retentionSweepTimer: { timer: Timer; handle: NodeJS.Timeout } | null = null;
 
 async function selectBackend(): Promise<VideoCaptureBackend> {
   logger.debug("[VideoRecording] Using HybridVideoCaptureBackend (iOS FFmpeg, Android platform)");
@@ -126,6 +224,8 @@ async function initializeVideoRecordingState(
     return;
   }
   managerInitialized = true;
+
+  ensureRetentionSweep(deps);
 
   const active = await deps.recordingRepository.listRecordings({ status: "recording" });
   if (active.length === 0) {
@@ -160,6 +260,8 @@ async function getVideoRecordingDependencies(): Promise<VideoRecordingManagerDep
       highlightClient: new VisualHighlightClient(),
       timer: defaultTimer,
       now: () => new Date(),
+      retentionPolicy: resolveVideoRetentionPolicy(),
+      statFileSize: getFileSize,
     };
   }
 
@@ -177,6 +279,8 @@ export async function setVideoRecordingManagerDependencies(
     highlightClient: deps.highlightClient ?? new VisualHighlightClient(),
     timer: deps.timer ?? defaultTimer,
     now: deps.now ?? (() => new Date()),
+    retentionPolicy: deps.retentionPolicy ?? resolveVideoRetentionPolicy(),
+    statFileSize: deps.statFileSize ?? getFileSize,
   };
   moduleDependencies = {
     videoRecorderService: deps.videoRecorderService ?? current.videoRecorderService,
@@ -185,6 +289,8 @@ export async function setVideoRecordingManagerDependencies(
     highlightClient: deps.highlightClient ?? current.highlightClient,
     timer: deps.timer ?? current.timer,
     now: deps.now ?? current.now,
+    retentionPolicy: deps.retentionPolicy ?? current.retentionPolicy,
+    statFileSize: deps.statFileSize ?? current.statFileSize,
   };
   resetVideoRecordingManagerState();
 }
@@ -194,6 +300,14 @@ function resetVideoRecordingManagerState(): void {
     timer.clearTimeout(handle);
   }
   autoStopTimers.clear();
+  for (const { timer, handle } of inProgressSizeMonitors.values()) {
+    timer.clearInterval(handle);
+  }
+  inProgressSizeMonitors.clear();
+  if (retentionSweepTimer) {
+    retentionSweepTimer.timer.clearInterval(retentionSweepTimer.handle);
+    retentionSweepTimer = null;
+  }
   for (const session of highlightSessions.values()) {
     for (const handle of session.timers) {
       session.timer.clearTimeout(handle);
@@ -296,6 +410,130 @@ function clearAutoStop(recordingId: string): void {
     entry.timer.clearTimeout(entry.handle);
     autoStopTimers.delete(recordingId);
   }
+}
+
+/**
+ * Arm the single periodic TTL sweep (issue #4762). Runs on a timer — not only on
+ * stop/config-change — so a long-idle daemon still prunes recordings older than
+ * the retention TTL. A `ttlMs` of 0 disables the sweep.
+ */
+function ensureRetentionSweep(deps: VideoRecordingManagerDependencies): void {
+  if (retentionSweepTimer) {
+    return;
+  }
+  const { retentionPolicy, timer } = deps;
+  if (retentionPolicy.ttlMs <= 0) {
+    return;
+  }
+  const handle = timer.setInterval(() => {
+    void runRetentionSweep().catch(error => {
+      logger.warn(`[VideoRecording] TTL retention sweep failed: ${error}`);
+    });
+  }, retentionPolicy.sweepIntervalMs);
+  retentionSweepTimer = { timer, handle };
+}
+
+/**
+ * Delete completed/interrupted recordings whose age (relative to `createdAt`)
+ * exceeds the retention TTL (issue #4762). Exported so tests can trigger a sweep
+ * directly and the daemon can force one on demand. Returns the pruned ids.
+ */
+export async function runRetentionSweep(): Promise<string[]> {
+  const deps = await getVideoRecordingDependencies();
+  const { recordingRepository, retentionPolicy, now } = deps;
+  if (retentionPolicy.ttlMs <= 0) {
+    return [];
+  }
+
+  const cutoffMs = now().getTime() - retentionPolicy.ttlMs;
+  const recordings = await recordingRepository.listRecordings({
+    status: ["completed", "interrupted"],
+  });
+
+  const prunedRecordingIds: string[] = [];
+  for (const recording of recordings) {
+    const createdMs = Date.parse(recording.createdAt);
+    if (Number.isNaN(createdMs) || createdMs > cutoffMs) {
+      continue;
+    }
+    try {
+      const deleted = await deleteVideoRecording(recording.recordingId);
+      if (deleted) {
+        prunedRecordingIds.push(recording.recordingId);
+      }
+    } catch (error) {
+      logger.warn(
+        `[VideoRecording] Failed to prune expired recording ${recording.recordingId}: ${error}`
+      );
+    }
+  }
+
+  if (prunedRecordingIds.length > 0) {
+    logger.info(
+      `[VideoRecording] TTL sweep pruned ${prunedRecordingIds.length} recording(s) older than ` +
+        `${retentionPolicy.ttlMs} ms`
+    );
+  }
+
+  return prunedRecordingIds;
+}
+
+/**
+ * Arm a periodic monitor that stops a live capture once its on-disk file reaches
+ * the archive cap (issue #4762). Without this, an uncapped in-progress recording
+ * (iOS `simctl recordVideo` runs up to an hour) could fill the disk before any
+ * eviction — which only ever considers *other completed* recordings — could run.
+ * `capBytes <= 0` disables the monitor for that recording.
+ */
+function scheduleInProgressSizeCap(
+  recordingId: string,
+  filePath: string,
+  capBytes: number,
+  deps: VideoRecordingManagerDependencies
+): void {
+  if (!Number.isFinite(capBytes) || capBytes <= 0) {
+    return;
+  }
+  const { timer, retentionPolicy } = deps;
+  const handle = timer.setInterval(() => {
+    void enforceInProgressSizeCap(recordingId, filePath, capBytes).catch(error => {
+      logger.warn(
+        `[VideoRecording] In-progress size check failed for ${recordingId}: ${error}`
+      );
+    });
+  }, retentionPolicy.inProgressCheckIntervalMs);
+  inProgressSizeMonitors.set(recordingId, { timer, handle });
+}
+
+function clearInProgressSizeCap(recordingId: string): void {
+  const entry = inProgressSizeMonitors.get(recordingId);
+  if (entry) {
+    entry.timer.clearInterval(entry.handle);
+    inProgressSizeMonitors.delete(recordingId);
+  }
+}
+
+async function enforceInProgressSizeCap(
+  recordingId: string,
+  filePath: string,
+  capBytes: number
+): Promise<void> {
+  // A tick may fire after the recording already stopped (cleared monitor); skip.
+  if (!inProgressSizeMonitors.has(recordingId)) {
+    return;
+  }
+  const { statFileSize } = await getVideoRecordingDependencies();
+  const sizeBytes = await statFileSize(filePath);
+  if (sizeBytes < capBytes) {
+    return;
+  }
+
+  logger.warn(
+    `[VideoRecording] In-progress recording ${recordingId} reached size cap ` +
+      `(${sizeBytes} >= ${capBytes} bytes); stopping to protect disk.`
+  );
+  clearInProgressSizeCap(recordingId);
+  await stopVideoRecording(recordingId);
 }
 
 function getHighlightSessionByDevice(deviceId: string): VideoRecordingHighlightSession | null {
@@ -621,6 +859,9 @@ export async function startVideoRecording(
 
   await scheduleAutoStop(active.recordingId, maxDurationSeconds);
 
+  const capBytes = Math.floor((active.config.maxArchiveSizeMb ?? 0) * 1024 * 1024);
+  scheduleInProgressSizeCap(active.recordingId, active.outputPath, capBytes, deps);
+
   return active;
 }
 
@@ -632,6 +873,7 @@ export async function stopVideoRecording(
   const resolvedId = await resolveActiveRecordingId(recordingId);
 
   clearAutoStop(resolvedId);
+  clearInProgressSizeCap(resolvedId);
 
   const metadata = await videoRecorderService.stopRecording(resolvedId);
   const highlightSession = disposeHighlightSession(resolvedId);
@@ -669,6 +911,7 @@ export async function stopVideoRecording(
 export async function interruptVideoRecording(recordingId: string): Promise<void> {
   const { recordingRepository, now } = await getVideoRecordingDependencies();
   clearAutoStop(recordingId);
+  clearInProgressSizeCap(recordingId);
 
   const record = await recordingRepository.getRecording(recordingId);
   if (!record || record.status !== "recording") {
@@ -779,6 +1022,13 @@ async function deleteVideoRecording(recordingId: string): Promise<boolean> {
 
   const recordingDir = path.dirname(record.filePath);
   if (await pathExists(recordingDir)) {
+    // NOTE (issue #4762): `rm` unlinks the directory entry but does NOT overwrite
+    // the underlying blocks, so screen-capture bytes (which may contain OTPs,
+    // credentials, or PII) can remain recoverable from the raw device until the
+    // filesystem reuses them. This is documented as a known limitation in
+    // docs/design-docs/mcp/observe/video-recording.md. A future opt-in
+    // "sensitive mode" would overwrite-before-unlink here; it is deliberately a
+    // follow-up (see the doc) rather than an unconditional cost on every delete.
     await fsPromises.rm(recordingDir, { recursive: true, force: true });
   }
 

--- a/test/server/videoRecordingManager.test.ts
+++ b/test/server/videoRecordingManager.test.ts
@@ -447,7 +447,17 @@ describe("videoRecordingManager", () => {
       expect(fakeTimer.getPendingIntervalCount()).toBe(1);
 
       fakeTimer.advanceTime(1000);
-      await drainAsyncUntil(async () => fakeBackend.stopCalls.length === 1);
+      // The interval fires enforceInProgressSizeCap → stopVideoRecording, which
+      // stops the backend, THEN persists status "completed", THEN enforces the
+      // archive limit — a chain that settles across several microtasks. Drain
+      // until the capture is fully finalized (visible in the completed listing),
+      // not merely until backend.stop() was called: `stopCalls` is bumped inside
+      // stopRecording and races ahead of the "completed" status write, so a
+      // stopCalls-only predicate reads the recording mid-stop (still "recording",
+      // filtered out of the listing) under CI event-loop pressure (#4762 macOS flake).
+      await drainAsyncUntil(async () =>
+        (await listVideoRecordings()).some(record => record.recordingId === active.recordingId)
+      );
 
       expect(fakeBackend.stopCalls.length).toBe(1);
       const recordings = await listVideoRecordings();

--- a/test/server/videoRecordingManager.test.ts
+++ b/test/server/videoRecordingManager.test.ts
@@ -14,10 +14,14 @@ import {
   interruptVideoRecording,
   recordVideoRecordingHighlightAdded,
   resetVideoRecordingManagerDependencies,
+  resolveVideoRetentionPolicy,
+  runRetentionSweep,
   setVideoRecordingManagerDependencies,
   startVideoRecording,
   stopVideoRecording,
+  type VideoRetentionPolicy,
 } from "../../src/server/videoRecordingManager";
+import type { VideoRecordingRecord } from "../../src/db/videoRecordingRepository";
 import { defaultTimer } from "../../src/utils/SystemTimer";
 
 describe("videoRecordingManager", () => {
@@ -300,6 +304,173 @@ describe("videoRecordingManager", () => {
         timeline: { appearedAtSeconds: 0.5, disappearedAtSeconds: 1 },
       },
     ]);
+  });
+
+  describe("retention: TTL sweep + in-progress size cap (#4762)", () => {
+    const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+    const baseConfig = {
+      qualityPreset: "low" as const,
+      targetBitrateKbps: 1000,
+      maxThroughputMbps: 5,
+      fps: 15,
+      maxArchiveSizeMb: 100,
+      format: "mp4" as const,
+    };
+
+    const seedCompletedRecording = async (
+      recordingId: string,
+      createdAtMs: number
+    ): Promise<void> => {
+      const iso = new Date(createdAtMs).toISOString();
+      const record: VideoRecordingRecord = {
+        recordingId,
+        deviceId: "test-device",
+        platform: "android",
+        status: "completed",
+        fileName: `${recordingId}.mp4`,
+        filePath: path.join(archiveRoot, recordingId, `${recordingId}.mp4`),
+        format: "mp4",
+        sizeBytes: 1024,
+        createdAt: iso,
+        startedAt: iso,
+        endedAt: iso,
+        lastAccessedAt: iso,
+        config: baseConfig,
+      };
+      await fakeRepository.insertRecording(record);
+    };
+
+    const reconfigureRetention = async (
+      policy: VideoRetentionPolicy,
+      statFileSize?: (filePath: string) => Promise<number>
+    ): Promise<void> => {
+      await setVideoRecordingManagerDependencies({
+        retentionPolicy: policy,
+        ...(statFileSize ? { statFileSize } : {}),
+      });
+    };
+
+    const drainAsyncUntil = async (
+      predicate: () => Promise<boolean>,
+      attempts = 40
+    ): Promise<void> => {
+      for (let attempt = 0; attempt < attempts; attempt++) {
+        if (await predicate()) {
+          return;
+        }
+        await new Promise(resolve => setImmediate(resolve));
+      }
+      throw new Error("drainAsyncUntil timed out");
+    };
+
+    test("resolveVideoRetentionPolicy uses documented defaults and env overrides", () => {
+      const defaults = resolveVideoRetentionPolicy({});
+      expect(defaults.ttlMs).toBe(7 * MS_PER_DAY);
+      expect(defaults.sweepIntervalMs).toBe(60 * 60_000);
+      expect(defaults.inProgressCheckIntervalMs).toBe(15 * 1000);
+
+      const overridden = resolveVideoRetentionPolicy({
+        AUTOMOBILE_VIDEO_RETENTION_DAYS: "2",
+        AUTOMOBILE_VIDEO_RETENTION_SWEEP_MINUTES: "5",
+        AUTOMOBILE_VIDEO_INPROGRESS_CHECK_SECONDS: "3",
+      });
+      expect(overridden.ttlMs).toBe(2 * MS_PER_DAY);
+      expect(overridden.sweepIntervalMs).toBe(5 * 60_000);
+      expect(overridden.inProgressCheckIntervalMs).toBe(3 * 1000);
+
+      // 0 days disables the sweep; garbage falls back to the default.
+      expect(resolveVideoRetentionPolicy({ AUTOMOBILE_VIDEO_RETENTION_DAYS: "0" }).ttlMs).toBe(0);
+      expect(
+        resolveVideoRetentionPolicy({ AUTOMOBILE_VIDEO_RETENTION_DAYS: "nonsense" }).ttlMs
+      ).toBe(7 * MS_PER_DAY);
+    });
+
+    test("runRetentionSweep prunes recordings older than the TTL and keeps fresh ones", async () => {
+      fakeTimer.setCurrentTime(30 * MS_PER_DAY);
+      await reconfigureRetention({
+        ttlMs: 7 * MS_PER_DAY,
+        sweepIntervalMs: 60_000,
+        inProgressCheckIntervalMs: 60_000,
+      });
+
+      await seedCompletedRecording("old-recording", fakeTimer.now() - 8 * MS_PER_DAY);
+      await seedCompletedRecording("fresh-recording", fakeTimer.now() - 1 * MS_PER_DAY);
+
+      const pruned = await runRetentionSweep();
+
+      expect(pruned).toEqual(["old-recording"]);
+      const remaining = await listVideoRecordings();
+      expect(remaining.map(r => r.recordingId)).toEqual(["fresh-recording"]);
+    });
+
+    test("TTL sweep prunes an expired recording on the injected FakeTimer", async () => {
+      fakeTimer.setCurrentTime(30 * MS_PER_DAY);
+      await reconfigureRetention({
+        ttlMs: 7 * MS_PER_DAY,
+        sweepIntervalMs: 1000,
+        inProgressCheckIntervalMs: 60_000,
+      });
+
+      await seedCompletedRecording("expired", fakeTimer.now() - 10 * MS_PER_DAY);
+
+      // Arm the sweep by resolving dependencies (init), then confirm it is present.
+      expect((await listVideoRecordings()).map(r => r.recordingId)).toEqual(["expired"]);
+      expect(fakeTimer.getPendingIntervalCount()).toBeGreaterThanOrEqual(1);
+
+      // Nothing prunes before the sweep interval elapses.
+      fakeTimer.advanceTime(999);
+      await new Promise(resolve => setImmediate(resolve));
+      expect((await listVideoRecordings()).length).toBe(1);
+
+      // Crossing the interval fires the timer-driven sweep.
+      fakeTimer.advanceTime(1);
+      await drainAsyncUntil(async () => (await listVideoRecordings()).length === 0);
+      expect((await listVideoRecordings()).length).toBe(0);
+    });
+
+    test("in-progress size cap stops a runaway capture on the FakeTimer", async () => {
+      const capBytes = baseConfig.maxArchiveSizeMb * 1024 * 1024;
+      // Live capture already twice the archive cap; the monitor must stop it.
+      await reconfigureRetention(
+        { ttlMs: 0, sweepIntervalMs: 60_000, inProgressCheckIntervalMs: 1000 },
+        async () => capBytes * 2
+      );
+
+      const active = await startVideoRecording({
+        device: testDevice,
+        maxDurationSeconds: 300,
+      });
+
+      expect(fakeBackend.stopCalls.length).toBe(0);
+      // One in-progress-check interval is armed (TTL sweep disabled via ttlMs: 0).
+      expect(fakeTimer.getPendingIntervalCount()).toBe(1);
+
+      fakeTimer.advanceTime(1000);
+      await drainAsyncUntil(async () => fakeBackend.stopCalls.length === 1);
+
+      expect(fakeBackend.stopCalls.length).toBe(1);
+      const recordings = await listVideoRecordings();
+      expect(recordings.map(r => r.recordingId)).toEqual([active.recordingId]);
+      // Monitor is cleared once the capture stops.
+      expect(fakeTimer.getPendingIntervalCount()).toBe(0);
+    });
+
+    test("in-progress recording under the cap keeps running", async () => {
+      await reconfigureRetention(
+        { ttlMs: 0, sweepIntervalMs: 60_000, inProgressCheckIntervalMs: 1000 },
+        async () => 1024
+      );
+
+      await startVideoRecording({ device: testDevice, maxDurationSeconds: 300 });
+
+      fakeTimer.advanceTime(5000);
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(fakeBackend.stopCalls.length).toBe(0);
+      // Monitor remains armed while under the cap.
+      expect(fakeTimer.getPendingIntervalCount()).toBe(1);
+    });
   });
 
   describe("maxDuration per-platform cap (#3906)", () => {


### PR DESCRIPTION
Closes [#4762](https://github.com/kaeawc/auto-mobile/issues/4762)

## Summary

Video recording retention was size-only, with no time-based TTL, a plain-unlink delete, and no cap on the in-progress recording. This adds the three controls the issue asks for, composing with owner-scoping ([#4752](https://github.com/kaeawc/auto-mobile/issues/4752)) and the hardened FS perms ([#4750](https://github.com/kaeawc/auto-mobile/issues/4750)).

1. **Time-based TTL retention sweep** — a periodic, injected-`Timer`-driven sweep (`runRetentionSweep`) prunes completed/interrupted recordings whose age (relative to `createdAt`) exceeds a configurable retention window. It runs on a timer, not only on stop/config-change, so a long-idle daemon still prunes. Default **7 days**.
2. **In-progress size cap** — each live recording is monitored on a timer against the archive cap (`maxArchiveSizeMb`); when its on-disk file reaches the cap the recording is stopped/finalized, so one long capture can't fill the disk.
3. **Secure-delete docs** — documents that `fs.rm` is not a secure delete (unlink, no overwrite) and leaves a clearly-flagged optional "sensitive mode" overwrite-before-unlink hook as a follow-up. No overwrite implemented now.

## Verify-real findings (current `main`)

- `enforceArchiveLimit` is the only cleanup: evicts oldest-by-`lastAccessedAt` **only when total exceeds `maxArchiveSizeMb`** (default 100 MB). No TTL. Confirmed it fires only from `stopVideoRecording` and `updateVideoRecordingConfig` — a long-idle daemon never prunes.
- `deleteVideoRecording` uses `fsPromises.rm(recordingDir, { recursive: true, force: true })` — plain unlink, no overwrite.
- In-progress recording not size-capped; `IOS_MAX_DURATION_SECONDS = 3600`, and eviction only considers *other completed* recordings, so one capture can blow past the cap.
- Line numbers had drifted from the issue (perms/owner-scoping landed): `enforceArchiveLimit` now ~`:792`, `deleteVideoRecording` ~`:768`. Composed with `securePermissions` (#4750) and unscoped whole-archive reads used by eviction/owner-scoping (#4752).

## What changed

- `src/server/videoRecordingManager.ts`
  - New injected seams on the manager deps: `retentionPolicy: VideoRetentionPolicy` and `statFileSize`, so the TTL sweep and size monitor are **FakeTimer-driven** in tests. Defaults resolve from env via `resolveVideoRetentionPolicy` (exported).
  - `ensureRetentionSweep` arms a single `setInterval` sweep on init; `runRetentionSweep` (exported) prunes expired recordings via the existing `deleteVideoRecording`.
  - `scheduleInProgressSizeCap` / `enforceInProgressSizeCap` monitor the live file; cleared on stop, interrupt, and manager reset.
  - Flagged secure-delete comment + sensitive-mode follow-up hook at the `rm` call site.
- `docs/design-docs/mcp/observe/video-recording.md` — TTL, in-progress cap, env-var table, and a "Secure delete (known limitation)" section documenting `rm` ≠ secure-delete.
- `test/server/videoRecordingManager.test.ts` — 5 new FakeTimer tests.

### Configuration (env, either prefix; documented)

| Setting | Env var | Default |
| --- | --- | --- |
| Retention window | `AUTOMOBILE_VIDEO_RETENTION_DAYS` | 7 days (`0` disables) |
| Sweep interval | `AUTOMOBILE_VIDEO_RETENTION_SWEEP_MINUTES` | 60 min |
| In-progress size-check interval | `AUTOMOBILE_VIDEO_INPROGRESS_CHECK_SECONDS` | 15 s |

## AC coverage / tests

- TTL sweep prunes recordings older than the TTL and keeps fresh ones (direct + timer-driven via FakeTimer).
- In-progress size cap stops a runaway capture on the FakeTimer; under-cap keeps running; monitor cleared on stop.
- `resolveVideoRetentionPolicy` defaults + env overrides + invalid-value fallback.
- Docs note `rm` is not secure-delete.

## Validation

- `bun run typecheck` — no new type errors (196 baseline).
- `turbo run lint build` — pass.
- `bun test` video suites (manager, resources, VideoRecorderService, segmented tool) — 67 pass, 0 fail.

## Windows portability

All paths built/asserted via `node:path`; no POSIX-only FS calls added. The size monitor reads size via the injected `statFileSize` seam (default `fs.stat`), so tests need no real capture I/O and run on windows-latest.

No merge.
