### PR TITLE
fix(screen-capture): verify captured window belongs to the Simulator at capture time

### DIFF
--- a/ios/screen-capture/Sources/ScreenCaptureCore/SimulatorWindowInfo.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/SimulatorWindowInfo.swift
@@ -41,6 +41,15 @@ public struct SimulatorWindowListResponse: Codable, Equatable {
 /// Bundle identifier of the iOS Simulator host application on macOS.
 public let simulatorBundleIdentifier = "com.apple.iphonesimulator"
 
+/// Returns true when a window's owning-application bundle identifier belongs to
+/// the iOS Simulator host. Used to re-verify a resolved `CGWindowID` at capture
+/// time: macOS recycles window IDs, so a stale `--simulator-window <id>` can
+/// resolve to an unrelated application's window. Re-checking here lets the
+/// caller fail closed instead of silently capturing the wrong window (#4763).
+public func isSimulatorWindow(bundleIdentifier: String?) -> Bool {
+    bundleIdentifier == simulatorBundleIdentifier
+}
+
 /// ScreenCaptureKit cannot isolate a single Simulator window's audio from the
 /// Simulator host application, so audio capture is safe only with one window.
 public enum SimulatorAudioCaptureAvailability {

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorWindowDiscovery.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorWindowDiscovery.swift
@@ -2,6 +2,16 @@ import Foundation
 import ScreenCaptureKit
 import ScreenCaptureCore
 
+/// Outcome of resolving a `CGWindowID` to a capturable window. `find` returns
+/// this instead of a bare `SCWindow?` so the caller can distinguish a recycled
+/// or unknown window id (`.notFound`) from a live window that is owned by some
+/// other application (`.notSimulatorWindow`) and fail closed in both cases.
+enum SimulatorWindowResolution {
+    case resolved(SCWindow)
+    case notFound
+    case notSimulatorWindow(bundleIdentifier: String?)
+}
+
 enum SimulatorWindowDiscovery {
     /// Discovers visible iOS Simulator windows via ScreenCaptureKit.
     /// Requires screen-recording permission; throws if the user has not granted it.
@@ -15,12 +25,25 @@ enum SimulatorWindowDiscovery {
             .map(toInfo)
     }
 
-    static func find(windowID: UInt32) async throws -> SCWindow? {
+    /// Resolves a `CGWindowID` and re-verifies at capture time that the window is
+    /// still owned by the iOS Simulator. macOS recycles window IDs, so a stale
+    /// `--simulator-window <id>` can point at an unrelated window (a browser,
+    /// password manager, chat client); without this re-check the helper would
+    /// capture it silently. The bundle-identifier predicate is shared with
+    /// `discover()` via `isSimulatorWindow` so the two paths cannot drift (#4763).
+    static func find(windowID: UInt32) async throws -> SimulatorWindowResolution {
         let content = try await SCShareableContent.excludingDesktopWindows(
             false,
             onScreenWindowsOnly: true
         )
-        return content.windows.first { $0.windowID == windowID }
+        guard let window = content.windows.first(where: { $0.windowID == windowID }) else {
+            return .notFound
+        }
+        let bundleIdentifier = window.owningApplication?.bundleIdentifier
+        guard isSimulatorWindow(bundleIdentifier: bundleIdentifier) else {
+            return .notSimulatorWindow(bundleIdentifier: bundleIdentifier)
+        }
+        return .resolved(window)
     }
 
     static func toInfo(_ window: SCWindow) -> SimulatorWindowInfo {

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/main.swift
@@ -178,15 +178,24 @@ case .captureSimulator(let windowID, let fps, let audio):
     logError(CaptureStartupMarker.line(.resolvingWindow(windowID: windowID)))
     let window: SCWindow
     switch runBlocking({ try await SimulatorWindowDiscovery.find(windowID: windowID) }) {
-    case .success(.some(let resolved)):
+    case .success(.resolved(let resolved)):
         window = resolved
         logError(CaptureStartupMarker.line(.resolvedWindow(
             windowID: windowID,
             width: Int(resolved.frame.width),
             height: Int(resolved.frame.height)
         )))
-    case .success(.none):
+    case .success(.notFound):
         logError("error: no window with CGWindowID \(windowID)")
+        exit(1)
+    case .success(.notSimulatorWindow(let bundleIdentifier)):
+        // Fail closed: the window id resolves to a live window that is not owned
+        // by the iOS Simulator (a recycled/stale window id). Capturing it would
+        // silently leak an unrelated window's contents (#4763).
+        logError(
+            "error: window with CGWindowID \(windowID) is not an iOS Simulator window"
+            + " (owning bundle: \(bundleIdentifier ?? "unknown")); refusing to capture"
+        )
         exit(1)
     case .failure(let error):
         logError("error: failed to query simulator windows: \(error)")

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/IsSimulatorWindowTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/IsSimulatorWindowTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import ScreenCaptureCore
+
+/// Guards the capture-time re-verification predicate that closes the windowID
+/// reuse / TOCTOU gap (#4763): a recycled `CGWindowID` may resolve to a live
+/// window owned by some other application, and the helper must fail closed
+/// rather than capture it.
+final class IsSimulatorWindowTests: XCTestCase {
+    func testAcceptsSimulatorBundleIdentifier() {
+        XCTAssertTrue(isSimulatorWindow(bundleIdentifier: simulatorBundleIdentifier))
+    }
+
+    func testRejectsNonSimulatorBundleIdentifier() {
+        XCTAssertFalse(isSimulatorWindow(bundleIdentifier: "com.google.Chrome"))
+        XCTAssertFalse(isSimulatorWindow(bundleIdentifier: "com.1password.1password"))
+        XCTAssertFalse(isSimulatorWindow(bundleIdentifier: "com.tinyspeck.slackmacgap"))
+    }
+
+    func testRejectsMissingBundleIdentifier() {
+        XCTAssertFalse(isSimulatorWindow(bundleIdentifier: nil))
+    }
+
+    func testRejectsEmptyBundleIdentifier() {
+        XCTAssertFalse(isSimulatorWindow(bundleIdentifier: ""))
+    }
+}


### PR DESCRIPTION
## The TOCTOU gap

The screen-capture helper confirmed that a window belonged to the iOS Simulator only during *enumeration* (`SimulatorWindowDiscovery.discover()` filters on `bundleIdentifier == com.apple.iphonesimulator`), but never re-checked at *capture* time. `find(windowID:)` matched purely on `windowID`. Because macOS recycles `CGWindowID`s, a stale or wrong `--simulator-window <id>` could resolve to an unrelated, still-live window (a browser, password manager, chat client) and be captured **silently, with no error** — a fail-open information-leak (severity: medium).

## The fail-closed change

- Extracted a shared pure predicate `isSimulatorWindow(bundleIdentifier:)` in `ScreenCaptureCore`, checking against the same `simulatorBundleIdentifier` constant `discover()` already uses (no second copy of the string).
- `find(windowID:)` now returns a `SimulatorWindowResolution` enum — `.resolved(SCWindow)`, `.notFound`, or `.notSimulatorWindow(bundleIdentifier:)` — re-verifying the resolved window's owning bundle id via that shared predicate before returning it.
- `main.swift` **fails closed** on both non-capture outcomes with a non-zero exit: `.notFound` keeps the existing "no window with CGWindowID" message; `.notSimulatorWindow` errors with a distinct "is not an iOS Simulator window (owning bundle: …); refusing to capture" message instead of capturing.

## Test approach

`SCShareableContent` / `SCWindow` cannot be faked without a live macOS window server, so the security-critical decision was factored into the pure `isSimulatorWindow(bundleIdentifier:)` predicate, which is unit-tested directly in `IsSimulatorWindowTests` (ScreenCaptureCoreTests): the Simulator bundle id is accepted, and non-Simulator ids (Chrome, 1Password, Slack), `nil`, and empty string are all rejected (fail-closed). No test requires a live window server.

## Validation

- `swift build` — passes.
- `swift test` — 63 tests pass (4 new).
- `scripts/swiftlint/validate_swiftlint.sh` — passes (0 violations, force_unwrapping clean; no force-unwraps introduced).

## Files changed

- `ios/screen-capture/Sources/ScreenCaptureCore/SimulatorWindowInfo.swift` — new pure `isSimulatorWindow` predicate.
- `ios/screen-capture/Sources/ScreenCaptureHelper/SimulatorWindowDiscovery.swift` — `SimulatorWindowResolution` enum; `find` re-verifies bundle id.
- `ios/screen-capture/Sources/ScreenCaptureHelper/main.swift` — fail-closed handling of `.notSimulatorWindow`.
- `ios/screen-capture/Tests/ScreenCaptureCoreTests/IsSimulatorWindowTests.swift` — new unit tests for the predicate.

Closes [#4763](https://github.com/kaeawc/auto-mobile/issues/4763).
