### PR TITLE
fix(video): harden capture buffer arithmetic and redact leaked paths (#4765)

### DIFF
--- a/ios/screen-capture/Sources/ScreenCaptureCore/AudioPcm16Encoder.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/AudioPcm16Encoder.swift
@@ -3,6 +3,25 @@ import Foundation
 /// Converts the Float32 little-endian PCM emitted by ScreenCaptureKit into
 /// signed little-endian PCM16 for the shared WebRTC PCMU packetizer.
 public enum AudioPcm16Encoder {
+    /// Bounds how many PCM bytes may be copied out of a CoreMedia audio buffer.
+    ///
+    /// The sample count reported by `CMSampleBufferGetNumSamples` and the byte
+    /// count reported by `mDataByteSize` can disagree for a short/partially
+    /// packed buffer. Copying `sampleCount * bytesPerSample` blindly would then
+    /// over-read adjacent heap memory (info leak) or truncate. Returns `nil`
+    /// when the buffer is shorter than the sample count requires, signalling the
+    /// caller to drop the buffer rather than emit over-read/partial audio.
+    public static func safeCopyByteCount(
+        sampleCount: Int,
+        bytesPerSample: Int,
+        availableBytes: Int
+    ) -> Int? {
+        guard sampleCount >= 0, bytesPerSample > 0, availableBytes >= 0 else { return nil }
+        let (requested, overflow) = sampleCount.multipliedReportingOverflow(by: bytesPerSample)
+        guard !overflow, availableBytes >= requested else { return nil }
+        return requested
+    }
+
     public static func encodeFloat32LE(_ input: Data) -> Data? {
         guard input.count.isMultiple(of: MemoryLayout<Float>.size) else { return nil }
 

--- a/ios/screen-capture/Sources/ScreenCaptureCore/FrameWriter.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureCore/FrameWriter.swift
@@ -107,21 +107,31 @@ public final class FrameWriter {
         baseAddress: UnsafeRawPointer,
         timestamp: Date = Date()
     ) -> Bool {
-        let payloadLength = bytesPerRow * height
         let elapsedMs = max(0, timestamp.timeIntervalSince(startTime) * 1000)
         let captureTimestampMs = UInt32(truncatingIfNeeded: UInt64(elapsedMs))
-        guard payloadLength <= configuration.maximumPendingFrameBytes else {
-            stateLock.lock()
-            latestCaptureTimestampMs = captureTimestampMs
-            droppedFrames += 1
-            stateLock.unlock()
+
+        // `bytesPerRow * height` can overflow Int for pathological geometry;
+        // compute it defensively and drop the frame instead of trapping, before
+        // the memory-budget cap so the cap never sees a wrapped value.
+        let (payloadLength, overflow) = bytesPerRow.multipliedReportingOverflow(by: height)
+        guard !overflow, payloadLength <= configuration.maximumPendingFrameBytes else {
+            recordDroppedFrame(captureTimestampMs: captureTimestampMs)
+            return false
+        }
+
+        // The header fields are UInt32; a value that doesn't fit would trap on
+        // conversion, so drop the frame instead.
+        guard let headerWidth = UInt32(exactly: width),
+              let headerHeight = UInt32(exactly: height),
+              let headerBytesPerRow = UInt32(exactly: bytesPerRow) else {
+            recordDroppedFrame(captureTimestampMs: captureTimestampMs)
             return false
         }
 
         let header = FrameProtocol.encodeHeader(FrameProtocol.Header(
-            width: UInt32(width),
-            height: UInt32(height),
-            bytesPerRow: UInt32(bytesPerRow),
+            width: headerWidth,
+            height: headerHeight,
+            bytesPerRow: headerBytesPerRow,
             timestampMs: captureTimestampMs
         ))
         // The capture callback owns the pixel-buffer lock. This one copy lets it
@@ -188,6 +198,13 @@ public final class FrameWriter {
     /// orderly shutdown; production capture never blocks its callback on this.
     public func flush() {
         outputQueue.sync {}
+    }
+
+    private func recordDroppedFrame(captureTimestampMs: UInt32) {
+        stateLock.lock()
+        latestCaptureTimestampMs = captureTimestampMs
+        droppedFrames += 1
+        stateLock.unlock()
     }
 
     private func enqueueFrame(_ record: PendingRecord) {

--- a/ios/screen-capture/Sources/ScreenCaptureHelper/AudioSampleBuffer.swift
+++ b/ios/screen-capture/Sources/ScreenCaptureHelper/AudioSampleBuffer.swift
@@ -28,13 +28,24 @@ func pcm16leAudio(sampleBuffer: CMSampleBuffer) -> Data? {
     guard result == noErr, let input = audioBufferList.mBuffers.mData else { return nil }
 
     let sampleCount = CMSampleBufferGetNumSamples(sampleBuffer)
+    let availableBytes = Int(audioBufferList.mBuffers.mDataByteSize)
     if asbd.mBitsPerChannel == 16 {
-        return Data(bytes: input, count: sampleCount * MemoryLayout<Int16>.size)
+        guard let count = AudioPcm16Encoder.safeCopyByteCount(
+            sampleCount: sampleCount,
+            bytesPerSample: MemoryLayout<Int16>.size,
+            availableBytes: availableBytes
+        ) else { return nil }
+        return Data(bytes: input, count: count)
     }
     if asbd.mBitsPerChannel == 32,
        (asbd.mFormatFlags & kAudioFormatFlagIsFloat) != 0 {
+        guard let count = AudioPcm16Encoder.safeCopyByteCount(
+            sampleCount: sampleCount,
+            bytesPerSample: MemoryLayout<Float>.size,
+            availableBytes: availableBytes
+        ) else { return nil }
         return AudioPcm16Encoder.encodeFloat32LE(
-            Data(bytes: input, count: sampleCount * MemoryLayout<Float>.size)
+            Data(bytes: input, count: count)
         )
     }
     return nil

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/AudioPcm16EncoderTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/AudioPcm16EncoderTests.swift
@@ -14,4 +14,40 @@ final class AudioPcm16EncoderTests: XCTestCase {
     func testRejectsTruncatedFloat32Input() {
         XCTAssertNil(AudioPcm16Encoder.encodeFloat32LE(Data([0, 0, 0])))
     }
+
+    func testSafeCopyByteCountReturnsRequestedWhenBufferIsLargeEnough() {
+        // 4 Int16 samples need 8 bytes and the buffer reports exactly 8.
+        XCTAssertEqual(
+            AudioPcm16Encoder.safeCopyByteCount(sampleCount: 4, bytesPerSample: 2, availableBytes: 8),
+            8
+        )
+        // A buffer that reports more bytes than needed still copies only what
+        // the sample count requires (the extra is padding).
+        XCTAssertEqual(
+            AudioPcm16Encoder.safeCopyByteCount(sampleCount: 4, bytesPerSample: 2, availableBytes: 16),
+            8
+        )
+    }
+
+    func testSafeCopyByteCountDropsShortBuffer() {
+        // 4 Int16 samples need 8 bytes but the buffer only holds 6: copying 8
+        // would over-read adjacent heap memory, so drop the buffer.
+        XCTAssertNil(
+            AudioPcm16Encoder.safeCopyByteCount(sampleCount: 4, bytesPerSample: 2, availableBytes: 6)
+        )
+    }
+
+    func testSafeCopyByteCountRejectsMalformedArguments() {
+        XCTAssertNil(
+            AudioPcm16Encoder.safeCopyByteCount(sampleCount: -1, bytesPerSample: 2, availableBytes: 8)
+        )
+        XCTAssertNil(
+            AudioPcm16Encoder.safeCopyByteCount(sampleCount: 4, bytesPerSample: 0, availableBytes: 8)
+        )
+        XCTAssertNil(
+            AudioPcm16Encoder.safeCopyByteCount(
+                sampleCount: Int.max, bytesPerSample: 2, availableBytes: Int.max
+            )
+        )
+    }
 }

--- a/ios/screen-capture/Tests/ScreenCaptureCoreTests/FrameWriterTests.swift
+++ b/ios/screen-capture/Tests/ScreenCaptureCoreTests/FrameWriterTests.swift
@@ -168,6 +168,50 @@ final class FrameWriterTests: XCTestCase {
         XCTAssertEqual(writer.metrics().bytesQueued, 0)
     }
 
+    func testDropsFrameWhenPayloadLengthOverflows() {
+        let sink = BufferSink()
+        let writer = FrameWriter(sink: sink, startTime: Date(timeIntervalSince1970: 0))
+        let scratch: [UInt8] = [0]
+
+        let accepted = scratch.withUnsafeBufferPointer { ptr in
+            // bytesPerRow * height overflows Int; the frame must drop, not trap.
+            writer.write(
+                width: 1,
+                height: 2,
+                bytesPerRow: Int.max,
+                baseAddress: UnsafeRawPointer(ptr.baseAddress!),
+                timestamp: Date(timeIntervalSince1970: 0.1)
+            )
+        }
+        writer.flush()
+
+        XCTAssertFalse(accepted)
+        XCTAssertEqual(sink.data.count, 0)
+        XCTAssertEqual(writer.metrics().droppedFrames, 1)
+    }
+
+    func testDropsFrameWhenDimensionExceedsUInt32() {
+        let sink = BufferSink()
+        let writer = FrameWriter(sink: sink, startTime: Date(timeIntervalSince1970: 0))
+        let scratch: [UInt8] = [0, 0, 0, 0]
+
+        let accepted = scratch.withUnsafeBufferPointer { ptr in
+            // Small payload passes the cap, but width does not fit UInt32.
+            writer.write(
+                width: Int(UInt32.max) + 1,
+                height: 1,
+                bytesPerRow: 4,
+                baseAddress: UnsafeRawPointer(ptr.baseAddress!),
+                timestamp: Date(timeIntervalSince1970: 0.1)
+            )
+        }
+        writer.flush()
+
+        XCTAssertFalse(accepted)
+        XCTAssertEqual(sink.data.count, 0)
+        XCTAssertEqual(writer.metrics().droppedFrames, 1)
+    }
+
     func testSlowSinkDiscardsEmptyAudioRecords() {
         let sink = BlockingPayloadSink()
         let writer = FrameWriter(

--- a/src/features/video/PlatformVideoCaptureBackend.ts
+++ b/src/features/video/PlatformVideoCaptureBackend.ts
@@ -184,7 +184,9 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
     }
 
     const sizeBytes = await getFileSize(handle.outputPath);
-    logger.info(`[VideoCapture] Final file size: ${sizeBytes} bytes at ${handle.outputPath}`);
+    logger.info(`[VideoCapture] Final file size: ${sizeBytes} bytes`);
+    // Absolute host path leaks the local username; keep it diagnostic-only.
+    logger.debug(`[VideoCapture] Output file at ${handle.outputPath}`);
 
     const codec = "h264";
 
@@ -242,9 +244,12 @@ export class PlatformVideoCaptureBackend implements VideoCaptureBackend {
 
     args.push(deviceTempPath);
 
-    logger.info(`[VideoCapture] Starting Android recording: ${args.join(" ")}`);
-    logger.info(`[VideoCapture] Device temp path: ${deviceTempPath}`);
-    logger.info(`[VideoCapture] Output path: ${config.outputPath}`);
+    logger.info(`[VideoCapture] Starting Android recording`);
+    // The argv, device temp path and host output path embed the recording id
+    // and local username; keep them diagnostic-only.
+    logger.debug(`[VideoCapture] Screenrecord argv: ${args.join(" ")}`);
+    logger.debug(`[VideoCapture] Device temp path: ${deviceTempPath}`);
+    logger.debug(`[VideoCapture] Output path: ${config.outputPath}`);
     logger.info(`[VideoCapture] Bitrate: ${bitrateKbps}kbps (${bitrateBps}bps), Time limit: ${timeLimitSeconds}s`);
 
     const process = await adb.spawn(args);

--- a/src/server/videoRecordingManager.ts
+++ b/src/server/videoRecordingManager.ts
@@ -19,6 +19,7 @@ import {
 } from "../features/video";
 import { serverConfig } from "../utils/ServerConfig";
 import { logger } from "../utils/logger";
+import { redactHomeDir } from "../utils/redactPath";
 import { defaultTimer, type Timer } from "../utils/SystemTimer";
 import { createTimestampedId } from "../utils/IdGenerator";
 import { ResourceRegistry } from "./resourceRegistry";
@@ -715,7 +716,7 @@ async function getFileSize(filePath: string): Promise<number> {
     const stats = await fsPromises.stat(filePath);
     return stats.size;
   } catch {
-    logger.warn(`[VideoRecording] Missing recording file at ${filePath}`);
+    logger.warn(`[VideoRecording] Missing recording file at ${redactHomeDir(filePath)}`);
     return 0;
   }
 }

--- a/src/utils/redactPath.ts
+++ b/src/utils/redactPath.ts
@@ -1,0 +1,16 @@
+import { homedir } from "node:os";
+
+/**
+ * Replaces a leading home-directory prefix in a path with `~` so diagnostic
+ * logs don't leak the local username. Only the home prefix is redacted; the
+ * remainder of the path is preserved so the trace stays actionable.
+ *
+ * @param value - Path (or message containing a path) to redact.
+ * @param home - Home directory to anchor the redaction on (injectable for tests).
+ */
+export function redactHomeDir(value: string, home: string = homedir()): string {
+  if (home.length > 0 && value.startsWith(home)) {
+    return "~" + value.slice(home.length);
+  }
+  return value;
+}

--- a/test/server/videoRecordingManager.test.ts
+++ b/test/server/videoRecordingManager.test.ts
@@ -353,13 +353,18 @@ describe("videoRecordingManager", () => {
 
     const drainAsyncUntil = async (
       predicate: () => Promise<boolean>,
-      attempts = 40
+      attempts = 100
     ): Promise<void> => {
       for (let attempt = 0; attempt < attempts; attempt++) {
         if (await predicate()) {
           return;
         }
-        await new Promise(resolve => setImmediate(resolve));
+        // Real 1ms sleep, not setImmediate: the size-cap stop chain is fire-and-
+        // forget async, and setImmediate can be starved under macOS CI I/O load,
+        // intermittently timing out this drain (#4762). Mirrors the proven
+        // waitForRecordingCount approach above. On success the loop returns early,
+        // so the 1ms cost is only paid while genuinely waiting.
+        await defaultTimer.sleep(1);
       }
       throw new Error("drainAsyncUntil timed out");
     };

--- a/test/utils/redactPath.test.ts
+++ b/test/utils/redactPath.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "bun:test";
+import { redactHomeDir } from "../../src/utils/redactPath";
+
+describe("redactHomeDir", () => {
+  it("replaces a leading home-directory prefix with ~", () => {
+    expect(redactHomeDir("/Users/alice/.auto-mobile/video-archive/case-1.mp4", "/Users/alice")).toBe(
+      "~/.auto-mobile/video-archive/case-1.mp4"
+    );
+  });
+
+  it("leaves a path without the home prefix unchanged", () => {
+    expect(redactHomeDir("/var/tmp/case-1.mp4", "/Users/alice")).toBe("/var/tmp/case-1.mp4");
+  });
+
+  it("does not redact when the home directory is empty", () => {
+    expect(redactHomeDir("/Users/alice/x", "")).toBe("/Users/alice/x");
+  });
+
+  it("only redacts the leading occurrence of the home prefix", () => {
+    expect(redactHomeDir("/home/bob/a/home/bob/b", "/home/bob")).toBe("~/a/home/bob/b");
+  });
+});


### PR DESCRIPTION
Low-severity capture-hardening batch for [#4765](https://github.com/kaeawc/auto-mobile/issues/4765). Items 1, 2, and 4 only. Item 3 is intentionally omitted (see below).

## Item 1 — Audio buffer over-read (Swift)
`pcm16leAudio` in `AudioSampleBuffer.swift` copied `sampleCount * MemoryLayout<…>.size` bytes out of the CoreMedia buffer without consulting `mBuffers.mDataByteSize`. A short/partially-packed buffer over-read adjacent heap memory into the audio stream (info leak); a long one truncated.

Fix: added a pure, unit-tested `AudioPcm16Encoder.safeCopyByteCount(sampleCount:bytesPerSample:availableBytes:)` that returns the requested byte count only when the reported buffer is large enough, and `nil` (drop the buffer, matching the surrounding `return nil` skip path) when it is short or the multiply overflows. Both the 16-bit and Float32 paths now go through it.

## Item 2 — Absolute paths / device IDs logged at INFO (TypeScript)
- `PlatformVideoCaptureBackend.ts`: the full screenrecord argv, the `/sdcard/...` device temp path (embeds the recording id), and the absolute host output path were logged at `info`. These are purely diagnostic, so they moved `info` → `debug`. The final-file-size line keeps its `info` level but no longer appends the absolute path (a separate `debug` line carries it).
- `videoRecordingManager.ts` "missing recording file" trace is a real failure at `warn`, so per the repo error-handling convention the level is preserved and the home-dir prefix is redacted instead, via a new shared `redactHomeDir` helper.

`VideoRecorderService.ts` no longer contains any logger calls (refactored away since the issue was filed), so nothing to change there.

Raw frame/video bytes are still never logged.

## Item 4 — Unchecked overflow arithmetic (Swift)
`FrameWriter.write` computed `payloadLength = bytesPerRow * height` before the memory-budget cap, and the `UInt32(width/height/bytesPerRow)` header conversions trapped on out-of-range geometry.

Fix: `bytesPerRow.multipliedReportingOverflow(by: height)` drops the frame on overflow before the cap check, and the header fields use `UInt32(exactly:)` guards that drop the frame if any value doesn't fit — reusing the existing dropped-frame accounting (extracted into a `recordDroppedFrame` helper).

## Item 3 — intentionally omitted
Resource-path confinement (`assertWithinArchiveRoot`) was already implemented by merged [#4752](https://github.com/kaeawc/auto-mobile/pull/4752) in `src/server/videoRecordingResources.ts`. Not touched here.

## Validation
- Swift: `swift build` + `swift test` (AudioPcm16EncoderTests, FrameWriterTests) pass. New tests cover the audio short-buffer drop and both frame-overflow drop paths.
- TS: `bun test test/utils/redactPath.test.ts test/features/video/ test/server/videoRecordingManager.test.ts` — 118 pass / 0 fail.
- `bun run typecheck` — no new type errors.
- ESLint on changed files — clean.


Closes https://github.com/kaeawc/auto-mobile/issues/4765
