### PR TITLE
fix(video-server): recreate capture/encoder on device rotation

### DIFF
--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/RotationMonitor.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/RotationMonitor.kt
@@ -1,0 +1,139 @@
+package dev.jasonpearson.automobile.video
+
+/**
+ * Reads the current display rotation (a `Surface.ROTATION_*` value). Production reads it from
+ * `DisplayControl.getDisplayInfo().rotation`; tests inject a fake that returns scripted rotations
+ * so the change-detection logic runs without a real display.
+ */
+fun interface RotationReader {
+  fun currentRotation(): Int
+}
+
+/**
+ * Registers a framework display-change callback if the runtime allows it, returning an unregister
+ * lambda, or null when unavailable so the caller relies on the poll fallback. Production delegates
+ * to `DisplayControl.registerDisplayListener`; tests inject a fake to exercise either the listener
+ * path or the null (poll-only) path.
+ */
+fun interface DisplayChangeRegistrar {
+  /**
+   * Register [onChanged]; return a stop-lambda on success, or null if no listener was registered.
+   */
+  fun register(onChanged: () -> Unit): (() -> Unit)?
+}
+
+/**
+ * Detects device-rotation changes so the capture path can be recreated at the new orientation's
+ * dimensions (issue #4785). The video server computes output dimensions once at startup; without
+ * this monitor a mid-stream rotation leaves the `VirtualDisplay` and encoder surface at the
+ * original orientation, so mirrored content stays squished/letterboxed for the rest of the session.
+ *
+ * Two detection mechanisms funnel through the same coalescing [poll]:
+ * 1. A [DisplayChangeRegistrar] listener (`DisplayManager.DisplayListener`) is the primary,
+ *    low-latency signal.
+ * 2. A poll thread over [RotationReader] is the fallback, because under `app_process`/shell uid the
+ *    framework listener may never register or fire. It always runs; [poll]'s change coalescing
+ *    means a listener callback and a poll tick that observe the same rotation dispatch a single
+ *    swap.
+ *
+ * The rotation-change decision ([poll]) is a pure, synchronized function testable without a real
+ * display or real timers. The poll loop's sleep is injected so it can be driven deterministically.
+ */
+class RotationMonitor(
+  private val reader: RotationReader,
+  private val registrar: DisplayChangeRegistrar = DisplayChangeRegistrar { null },
+  private val pollIntervalMs: Long = DEFAULT_POLL_INTERVAL_MS,
+  // Injected so the poll loop carries no real wall-clock dependency; production sleeps the thread.
+  private val sleeper: (Long) -> Unit = { Thread.sleep(it) },
+) {
+  private val lock = Any()
+  private var started = false
+  private var lastRotation = ROTATION_UNSET
+
+  @Volatile private var stopped = false
+  @Volatile private var onRotationChanged: ((Int) -> Unit)? = null
+  @Volatile private var unregister: (() -> Unit)? = null
+  @Volatile private var pollThread: Thread? = null
+
+  /**
+   * Report the new rotation if it differs from the last observed value, else null. Synchronized and
+   * side-effect-free beyond advancing the last-seen rotation, so a listener callback and a poll
+   * tick that race on the same change collapse to one dispatch: whichever calls first advances
+   * [lastRotation] and returns the new value; the other observes no change and returns null.
+   */
+  fun poll(): Int? =
+    synchronized(lock) {
+      val current = reader.currentRotation()
+      if (current == lastRotation) {
+        null
+      } else {
+        lastRotation = current
+        current
+      }
+    }
+
+  /**
+   * Begin monitoring. Seeds the last-seen rotation from the current reading (so the startup
+   * orientation is never mistaken for a change), registers the framework listener when available,
+   * and always starts the poll fallback thread. Idempotent: a second call is ignored.
+   */
+  fun start(onRotationChanged: (Int) -> Unit) {
+    synchronized(lock) {
+      if (started) return
+      started = true
+      lastRotation = reader.currentRotation()
+      this.onRotationChanged = onRotationChanged
+    }
+    unregister = registrar.register { dispatch() }
+    pollThread =
+      Thread({ runPollLoop() }, "video-rotation-poll").apply {
+        isDaemon = true
+        start()
+      }
+  }
+
+  /** Stop monitoring: unregister the listener and let the poll thread unwind. Idempotent. */
+  fun stop() {
+    stopped = true
+    try {
+      unregister?.invoke()
+    } catch (error: Exception) {
+      // Best-effort unregister during shutdown; a failure here must not sink teardown.
+      System.err.println("RotationMonitor unregister failed: ${error.message}")
+    }
+    unregister = null
+    pollThread?.interrupt()
+    pollThread = null
+  }
+
+  private fun runPollLoop() {
+    while (!stopped) {
+      try {
+        sleeper(pollIntervalMs)
+      } catch (_: InterruptedException) {
+        Thread.currentThread().interrupt()
+        return
+      }
+      if (stopped) return
+      dispatch()
+    }
+  }
+
+  /** Read a fresh rotation and, only on a real change, notify the listener with the new value. */
+  private fun dispatch() {
+    val newRotation = poll() ?: return
+    onRotationChanged?.invoke(newRotation)
+  }
+
+  companion object {
+    /** Sentinel that no rotation has been observed yet, so the first reading is not a "change". */
+    const val ROTATION_UNSET = -1
+
+    /**
+     * Poll cadence for the fallback. Rotation is a rare, human-scale event, so a coarse interval
+     * keeps the fallback cheap; the framework listener (when registered) provides the low-latency
+     * path.
+     */
+    const val DEFAULT_POLL_INTERVAL_MS = 500L
+  }
+}

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoServer.kt
@@ -37,6 +37,17 @@ object VideoServer {
   @Volatile private var audioCapture: AudioCapture? = null
   @Volatile private var streamWriter: VideoStreamWriter? = null
   @Volatile private var sessionLease: VideoSessionLease? = null
+  @Volatile private var rotationMonitor: RotationMonitor? = null
+
+  // The output dimensions the current encoder/capture were created at. The encode loop compares a
+  // freshly-recomputed pair against these to decide whether a rotation actually changed the output
+  // size (#4785); 0<->180 and 90<->270 rotations leave the size unchanged and need no swap.
+  @Volatile private var currentOutputWidth = 0
+  @Volatile private var currentOutputHeight = 0
+
+  // Set by the rotation monitor when the display rotates; consumed on the encode-loop thread, which
+  // owns the encoder/capture lifecycle, so the swap never races concurrent MediaCodec access.
+  @Volatile private var rotationPending = false
 
   @JvmStatic
   fun main(args: Array<String>) {
@@ -92,6 +103,8 @@ object VideoServer {
         fps,
         audioEnabled,
         session,
+        quality,
+        sizeOverride,
       )
     } catch (e: Exception) {
       System.err.println("Error: ${e.message}")
@@ -186,7 +199,26 @@ object VideoServer {
     )
   }
 
-  private fun calculateOutputDimensions(
+  /**
+   * Resolve the effective output dimensions for a display reading. An explicit `--size` override
+   * pins the exact WxH regardless of orientation (the least-surprising behavior for an explicit
+   * request: the operator asked for a specific frame size, so rotation must not silently swap it);
+   * with `--size` set, a rotation therefore never changes the resolved size and no encoder swap
+   * occurs — the mirror is letterboxed within the pinned surface. Otherwise the dimensions are
+   * derived from the current display size scaled by the preset, so re-reading [displayInfo] after a
+   * rotation yields the correctly-oriented output size (issue #4785).
+   */
+  internal fun resolveOutputDimensions(
+    displayInfo: DisplayControl.DisplayInfo,
+    quality: QualityPreset,
+    sizeOverride: Pair<Int, Int>?,
+  ): Pair<Int, Int> = sizeOverride ?: calculateOutputDimensions(displayInfo, quality)
+
+  /** True when a re-read produced a different output size, i.e. a swap is warranted (#4785). */
+  internal fun dimensionsChanged(current: Pair<Int, Int>, next: Pair<Int, Int>): Boolean =
+    current != next
+
+  internal fun calculateOutputDimensions(
     displayInfo: DisplayControl.DisplayInfo,
     quality: QualityPreset,
   ): Pair<Int, Int> {
@@ -227,20 +259,11 @@ object VideoServer {
     fps: Int,
     audioEnabled: Boolean,
     session: VideoSessionOptions,
+    quality: QualityPreset,
+    sizeOverride: Pair<Int, Int>?,
   ) {
-    // Create encoder
-    encoder =
-      VideoEncoder(
-        width = width,
-        height = height,
-        bitrate = bitrate,
-        fps = fps,
-      )
-    val surface = encoder!!.start()
-
-    // Create screen capture
-    capture = ScreenCapture(width, height, densityDpi)
-    capture!!.start(surface)
+    // Create the initial encoder + capture at the startup dimensions.
+    createEncoderAndCapture(width, height, densityDpi, bitrate, fps)
 
     // Backstop for idle-screen frame starvation (#4383): on a static screen the mirror
     // stops submitting buffers, so KEY_REPEAT_PREVIOUS_FRAME_AFTER alone does not reliably
@@ -296,6 +319,17 @@ object VideoServer {
       )
     }
 
+    // Detect rotation and recreate capture/encoder at the new orientation's dimensions (#4785).
+    // The monitor only flags the change; the swap runs on this encode-loop thread, which owns the
+    // encoder/capture lifecycle, so it never races concurrent MediaCodec access. FrameHeartbeat and
+    // VideoSessionLease are untouched by the swap and keep running across it.
+    rotationMonitor =
+      RotationMonitor(
+          reader = { DisplayControl.getDisplayInfo().rotation },
+          registrar = { onChanged -> DisplayControl.registerDisplayListener(onChanged) },
+        )
+        .also { it.start { rotationPending = true } }
+
     println("Streaming started")
 
     // Encoding loop
@@ -304,6 +338,10 @@ object VideoServer {
       // Snapshot the volatile streamWriter the shutdown hook nulls concurrently; a null
       // means teardown has begun, so exit the loop cleanly instead of throwing (#4748).
       val currentWriter = encodeLoopSnapshot(streamWriter) ?: break
+      if (rotationPending) {
+        rotationPending = false
+        swapCaptureForRotation(quality, sizeOverride, bitrate, fps, heartbeat)
+      }
       val index = encoder!!.dequeueOutputBuffer(bufferInfo, 100_000) // 100ms timeout
       if (index >= 0) {
         val buffer = encoder!!.getOutputBuffer(index)
@@ -340,6 +378,70 @@ object VideoServer {
   }
 
   /**
+   * Create the encoder and screen capture at [width]x[height] and record the pair as the current
+   * output dimensions. Shared by the initial startup path and the rotation swap so both build the
+   * capture stack identically.
+   */
+  private fun createEncoderAndCapture(
+    width: Int,
+    height: Int,
+    densityDpi: Int,
+    bitrate: Int,
+    fps: Int,
+  ) {
+    val newEncoder = VideoEncoder(width = width, height = height, bitrate = bitrate, fps = fps)
+    val surface = newEncoder.start()
+    val newCapture = ScreenCapture(width, height, densityDpi)
+    newCapture.start(surface)
+    encoder = newEncoder
+    capture = newCapture
+    currentOutputWidth = width
+    currentOutputHeight = height
+  }
+
+  /**
+   * Recreate the encoder and VirtualDisplay at the current display orientation's dimensions after a
+   * rotation (issue #4785). Runs on the encode-loop thread so it owns the encoder/capture lifecycle
+   * exclusively.
+   *
+   * Re-reads the display to get the post-rotation size, recomputes the output dimensions with the
+   * SAME preset scaling used at startup, and returns early when the size is unchanged (0<->180 and
+   * 90<->270 rotations, or an explicit `--size` that pins WxH) so no needless swap churns the
+   * stream. On a real size change it resets the writer's replay cache atomically BEFORE tearing
+   * down the old encoder, so a client attaching mid-swap can never replay the new SPS/PPS against
+   * the stale pre-rotation IDR; the new encoder's config+IDR then repopulate the cache and flow to
+   * any attached client live, and to a reconnecting client via replay. Rotating back recomputes the
+   * original dimensions and swaps again, so repeated rotations restore prior sizes.
+   */
+  private fun swapCaptureForRotation(
+    quality: QualityPreset,
+    sizeOverride: Pair<Int, Int>?,
+    bitrate: Int,
+    fps: Int,
+    heartbeat: FrameHeartbeat,
+  ) {
+    val displayInfo = DisplayControl.getDisplayInfo()
+    val next = resolveOutputDimensions(displayInfo, quality, sizeOverride)
+    val current = currentOutputWidth to currentOutputHeight
+    if (!dimensionsChanged(current, next)) {
+      return
+    }
+    val (newWidth, newHeight) = next
+    println(
+      "VIDEO_ROTATION_SWAP rotation=${displayInfo.rotation} " +
+        "from=${current.first}x${current.second} to=${newWidth}x$newHeight"
+    )
+    // Atomic w.r.t. the writer: clear the stale replay cache before the old encoder is gone so no
+    // reconnecting client can be replayed a new-SPS/old-IDR mismatch mid-swap.
+    streamWriter?.resetReplayCacheForResize()
+    capture?.stop()
+    encoder?.stop()
+    createEncoderAndCapture(newWidth, newHeight, displayInfo.densityDpi, bitrate, fps)
+    // Nudge a prompt fresh IDR so a static post-rotation screen does not starve viewers.
+    heartbeat.onKeyFrameRequested()
+  }
+
+  /**
    * Snapshot a volatile field the shutdown hook may null on another thread. The encode loop calls
    * this instead of a `!!` deref so a concurrent null observed mid-shutdown yields a clean stop
    * signal (null) rather than a [NullPointerException] (#4748). Kept as a seam so the loop's
@@ -349,11 +451,13 @@ object VideoServer {
 
   private fun shutdown() {
     running = false
+    rotationMonitor?.stop()
     audioCapture?.stop()
     streamWriter?.stop()
     capture?.stop()
     encoder?.stop()
 
+    rotationMonitor = null
     audioCapture = null
     streamWriter = null
     capture = null

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/VideoStreamWriter.kt
@@ -504,6 +504,22 @@ class VideoStreamWriter(
    */
   fun reconnectWindowExpired(): Boolean = reconnectWindow.isExpired()
 
+  /**
+   * Atomically clear the replay cache for a device-rotation encoder swap (issue #4785).
+   *
+   * Held under the same `lock` that guards client attach (`acceptClients` ->
+   * `replayCachedVideoLocked`), so the swap is atomic with respect to the writer: a client
+   * attaching mid-swap serializes either fully before this reset (replays the old encoder's
+   * coherent config+IDR) or fully after it (replays nothing yet, then requests a keyframe), and can
+   * never observe the new encoder's SPS/PPS paired with the stale pre-rotation IDR. The caller
+   * resets here after tearing down the old encoder and before starting the new one; the new
+   * encoder's config+IDR then repopulate the cache through the normal [writePacket] path, so a
+   * later reconnect replays the new coherent pair.
+   */
+  fun resetReplayCacheForResize() {
+    synchronized(lock) { packetCache.reset() }
+  }
+
   private fun writeStreamHeaderLocked() {
     val header =
       if (audioEnabled) {
@@ -631,6 +647,19 @@ internal class VideoPacketCache {
     if ((packet.ptsAndFlags and VideoStreamProtocol.PACKET_FLAG_KEY_FRAME) != 0L) {
       idr = packet.copyPacket()
     }
+  }
+
+  /**
+   * Drop the cached decoder state so the next [replay] starts empty. Used by the rotation-triggered
+   * encoder swap (#4785): the old encoder's SPS/PPS + IDR describe the pre-rotation dimensions, so
+   * they must not be replayed once a new encoder at the new dimensions is coming up. Clearing both
+   * halves together (never one) keeps every [replay] snapshot self-consistent — a reconnecting
+   * client can only ever see the old coherent pair, nothing, or the new coherent pair, never a new
+   * SPS paired with the old IDR.
+   */
+  fun reset() {
+    config = null
+    idr = null
   }
 
   fun replay(): List<CachedVideoPacket> {

--- a/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/wrappers/DisplayControl.kt
+++ b/android/video-server/src/main/kotlin/dev/jasonpearson/automobile/video/wrappers/DisplayControl.kt
@@ -135,6 +135,47 @@ object DisplayControl {
   }
 
   /**
+   * Register a framework callback that fires when the default display changes (issue #4785),
+   * primarily to observe rotation. Returns a stop-lambda that unregisters the listener, or null
+   * when registration is unavailable so the caller falls back to polling [getDisplayInfo].
+   *
+   * Under `app_process`/shell uid a real [android.hardware.display.DisplayManager] and a main
+   * `Looper` may or may not be reachable; registration is best-effort and any failure degrades
+   * cleanly to the poll fallback rather than aborting capture.
+   *
+   * @param onDisplayChanged invoked (on the framework Handler thread) whenever display 0 changes.
+   * @return an unregister lambda on success, or null if no listener could be registered.
+   */
+  fun registerDisplayListener(onDisplayChanged: () -> Unit): (() -> Unit)? {
+    return try {
+      val displayManager =
+        systemContext.getSystemService(android.hardware.display.DisplayManager::class.java)
+          ?: return null
+      val looper = android.os.Looper.getMainLooper() ?: return null
+      val handler = android.os.Handler(looper)
+      val listener =
+        object : android.hardware.display.DisplayManager.DisplayListener {
+          override fun onDisplayAdded(displayId: Int) = Unit
+
+          override fun onDisplayRemoved(displayId: Int) = Unit
+
+          override fun onDisplayChanged(displayId: Int) {
+            if (displayId == DEFAULT_DISPLAY_ID) onDisplayChanged()
+          }
+        }
+      displayManager.registerDisplayListener(listener, handler)
+      return { displayManager.unregisterDisplayListener(listener) }
+    } catch (error: Exception) {
+      // Best-effort capability probe: under shell uid the DisplayManager or a usable Looper may be
+      // unavailable. Swallow and return null so the poll fallback covers rotation detection.
+      System.err.println("registerDisplayListener unavailable: ${error.message}")
+      null
+    }
+  }
+
+  private const val DEFAULT_DISPLAY_ID = 0
+
+  /**
    * Create a VirtualDisplay that mirrors the specified display.
    *
    * @param name The name of the virtual display

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/RotationMonitorTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/RotationMonitorTest.kt
@@ -1,0 +1,98 @@
+package dev.jasonpearson.automobile.video
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit-tests the rotation change-detection seam for issue #4785 without a real display or real
+ * timers. [RotationMonitor.poll] is a pure, coalescing change detector; the listener and poll-loop
+ * paths both funnel through it, so a fake [RotationReader] plus an injected sleeper exercises the
+ * full detection contract deterministically.
+ */
+class RotationMonitorTest {
+
+  @Test
+  fun pollReturnsNewRotationOnlyOnChangeAndCoalescesRepeats() {
+    val rotation = AtomicInteger(0)
+    val monitor = RotationMonitor(reader = { rotation.get() })
+
+    // First read establishes the baseline as a change from the ROTATION_UNSET sentinel.
+    assertEquals(0, monitor.poll())
+    // No movement -> no dispatch.
+    assertNull(monitor.poll())
+
+    rotation.set(1)
+    assertEquals("a real rotation change is reported once", 1, monitor.poll())
+    assertNull("the same rotation is not reported again (coalesced)", monitor.poll())
+
+    // Rotating back is itself a change and must be reported.
+    rotation.set(0)
+    assertEquals("rotating back is a fresh change", 0, monitor.poll())
+  }
+
+  @Test
+  fun listenerCallbackDispatchesRotationChangeWithNewValue() {
+    val rotation = AtomicInteger(0)
+    var listenerCallback: (() -> Unit)? = null
+    val observed = AtomicInteger(NONE)
+    // Park the poll loop indefinitely so this test isolates the framework-listener path; the latch
+    // (not a wall-clock sleep) blocks the thread deterministically until teardown.
+    val park = CountDownLatch(1)
+    val monitor =
+      RotationMonitor(
+        reader = { rotation.get() },
+        registrar = { onChanged ->
+          listenerCallback = onChanged
+          {}
+        },
+        sleeper = { park.await() },
+      )
+
+    monitor.start { observed.set(it) }
+    // Simulate a framework display change after the device rotates to landscape.
+    rotation.set(3)
+    listenerCallback?.invoke()
+
+    assertEquals("the listener path must dispatch the new rotation", 3, observed.get())
+
+    park.countDown()
+    monitor.stop()
+  }
+
+  @Test
+  fun pollFallbackDetectsRotationWhenListenerRegistrationUnavailable() {
+    val rotation = AtomicInteger(0)
+    val dispatched = CountDownLatch(1)
+    val observed = AtomicInteger(NONE)
+    // registrar returns null -> no framework listener, so the poll loop is the only detector. Each
+    // injected "sleep" advances the display one step to landscape; no real timer is involved.
+    val monitor =
+      RotationMonitor(
+        reader = { rotation.get() },
+        registrar = { null },
+        sleeper = { rotation.set(1) },
+      )
+
+    monitor.start {
+      observed.set(it)
+      dispatched.countDown()
+    }
+
+    assertTrue(
+      "the poll fallback must detect the rotation without a framework listener",
+      dispatched.await(2, TimeUnit.SECONDS),
+    )
+    assertEquals(1, observed.get())
+
+    monitor.stop()
+  }
+
+  private companion object {
+    const val NONE = -99
+  }
+}

--- a/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoServerRotationSwapTest.kt
+++ b/android/video-server/src/test/kotlin/dev/jasonpearson/automobile/video/VideoServerRotationSwapTest.kt
@@ -1,0 +1,109 @@
+package dev.jasonpearson.automobile.video
+
+import dev.jasonpearson.automobile.video.wrappers.DisplayControl
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit-tests the pure rotation-swap decision logic for issue #4785: recomputing output dimensions
+ * for a new orientation with the SAME preset scaling used at startup, and deciding whether that
+ * change actually warrants recreating the encoder/capture. Runs without MediaCodec or a real
+ * VirtualDisplay — the framework-touching swap orchestration is a thin wrapper over these seams.
+ */
+class VideoServerRotationSwapTest {
+
+  private fun display(width: Int, height: Int, rotation: Int) =
+    DisplayControl.DisplayInfo(
+      width = width,
+      height = height,
+      densityDpi = 420,
+      rotation = rotation,
+    )
+
+  @Test
+  fun presetScalingSwapsWidthAndHeightWhenPortraitRotatesToLandscape() {
+    val portrait = display(width = 1080, height = 2400, rotation = 0)
+    val landscape = display(width = 2400, height = 1080, rotation = 1)
+
+    val portraitDims = VideoServer.resolveOutputDimensions(portrait, QualityPreset.MEDIUM, null)
+    val landscapeDims = VideoServer.resolveOutputDimensions(landscape, QualityPreset.MEDIUM, null)
+
+    // MEDIUM caps the long edge at 720; the short edge scales proportionally and rounds to even.
+    assertEquals(324 to 720, portraitDims)
+    assertEquals(720 to 324, landscapeDims)
+    assertTrue(
+      "a portrait->landscape rotation changes the output size and must swap",
+      VideoServer.dimensionsChanged(portraitDims, landscapeDims),
+    )
+  }
+
+  @Test
+  fun oneEightyRotationLeavesDimensionsUnchangedSoNoSwap() {
+    val portrait0 = display(width = 1080, height = 2400, rotation = 0)
+    val portrait180 = display(width = 1080, height = 2400, rotation = 2)
+
+    val dims0 = VideoServer.resolveOutputDimensions(portrait0, QualityPreset.MEDIUM, null)
+    val dims180 = VideoServer.resolveOutputDimensions(portrait180, QualityPreset.MEDIUM, null)
+
+    assertFalse(
+      "0<->180 keeps the same logical size, so no encoder swap is needed",
+      VideoServer.dimensionsChanged(dims0, dims180),
+    )
+  }
+
+  @Test
+  fun explicitSizeOverridePinsDimensionsRegardlessOfOrientation() {
+    val portrait = display(width = 1080, height = 2400, rotation = 0)
+    val landscape = display(width = 2400, height = 1080, rotation = 1)
+    val pinned = 640 to 480
+
+    val portraitDims = VideoServer.resolveOutputDimensions(portrait, QualityPreset.MEDIUM, pinned)
+    val landscapeDims = VideoServer.resolveOutputDimensions(landscape, QualityPreset.MEDIUM, pinned)
+
+    // Least-surprising behavior for an explicit --size: the operator asked for a specific frame
+    // size, so rotation must not silently swap it; both orientations resolve to the pinned WxH.
+    assertEquals(pinned, portraitDims)
+    assertEquals(pinned, landscapeDims)
+    assertFalse(
+      "--size pins WxH across rotation, so no swap occurs",
+      VideoServer.dimensionsChanged(portraitDims, landscapeDims),
+    )
+  }
+
+  @Test
+  fun rotatingBackRestoresOriginalDimensions() {
+    val portrait = display(width = 1080, height = 2400, rotation = 0)
+    val landscape = display(width = 2400, height = 1080, rotation = 1)
+
+    val portraitDims = VideoServer.resolveOutputDimensions(portrait, QualityPreset.MEDIUM, null)
+    val landscapeDims = VideoServer.resolveOutputDimensions(landscape, QualityPreset.MEDIUM, null)
+    val backToPortraitDims =
+      VideoServer.resolveOutputDimensions(portrait, QualityPreset.MEDIUM, null)
+
+    assertTrue(VideoServer.dimensionsChanged(portraitDims, landscapeDims))
+    assertEquals("rotating back restores the original dimensions", portraitDims, backToPortraitDims)
+    assertTrue(VideoServer.dimensionsChanged(landscapeDims, backToPortraitDims))
+  }
+
+  @Test
+  fun replayCacheResetClearsDecoderStateSoNoNewSpsIsPairedWithStaleIdr() {
+    // The rotation swap resets the writer's replay cache
+    // (VideoStreamWriter.resetReplayCacheForResize
+    // -> VideoPacketCache.reset) so a client reconnecting mid-swap never replays the new encoder's
+    // SPS/PPS against the old encoder's IDR. Verify the reset clears both halves together.
+    val cache = VideoPacketCache()
+    val config =
+      CachedVideoPacket(VideoStreamProtocol.PACKET_FLAG_CONFIG or 10L, byteArrayOf(1, 2, 3))
+    val idr =
+      CachedVideoPacket(VideoStreamProtocol.PACKET_FLAG_KEY_FRAME or 20L, byteArrayOf(4, 5, 6))
+    cache.remember(config)
+    cache.remember(idr)
+    assertEquals("config + IDR are both cached before reset", 2, cache.replay().size)
+
+    cache.reset()
+
+    assertTrue("reset clears the replay cache entirely", cache.replay().isEmpty())
+  }
+}


### PR DESCRIPTION
## Summary

Fixes the capture-path half of [#4785](https://github.com/kaeawc/auto-mobile/issues/4785): the video server computed output dimensions once in `main()` and never reacted to rotation, so the `VirtualDisplay` and encoder surface stayed at the startup orientation. A mid-stream rotation therefore left mirrored content squished/letterboxed for the rest of the session. This is purely the visual-distortion fix — **no wire-protocol change** (the protocol/attestation half is [#4786](https://github.com/kaeawc/auto-mobile/issues/4786), out of scope here).

## Rotation detection (listener + poll fallback)

New `RotationMonitor` (interface + fake seam) funnels two mechanisms through a single coalescing `poll()`:

- **Primary:** a `DisplayManager.DisplayListener` (`onDisplayChanged`) registered via `DisplayControl.registerDisplayListener`, which returns an unregister lambda or `null` when registration is unavailable.
- **Fallback:** a poll thread over `DisplayControl.getDisplayInfo().rotation`, always running because under `app_process`/shell uid the framework listener may never register or fire. `poll()` is a pure, synchronized change detector, so a listener callback and a poll tick that observe the same rotation collapse to one dispatch.

The monitor only flags `rotationPending`; the actual swap runs on the encode-loop thread, which owns the encoder/capture lifecycle exclusively, so it never races concurrent `MediaCodec` access.

## Atomic-swap design

On a flagged rotation the encode loop re-reads the display, recomputes output dimensions with the **same preset scaling used at startup**, and returns early when the size is unchanged. On a real change it:

1. Calls `VideoStreamWriter.resetReplayCacheForResize()` — which clears the replay cache **under the writer's own `lock`**, the same lock that guards client attach/replay. This is the atomicity guarantee: a client attaching mid-swap serializes either fully before the reset (replays the old coherent config+IDR) or fully after it (replays nothing, then requests a keyframe), and can **never** observe the new encoder's SPS/PPS paired with the stale pre-rotation IDR.
2. Tears down the old `ScreenCapture`/`VirtualDisplay` and encoder.
3. Recreates both at the new dimensions. The new encoder's SPS/PPS + IDR flow to any attached client live and repopulate the replay cache for reconnecting clients (the writer cache self-heals, per the issue).

`FrameHeartbeat` and `VideoSessionLease` are untouched by the swap and keep running across it. Rotating back recomputes the original dimensions and swaps again; repeated rotations are handled.

## `--size` decision

An explicit `--size` override **pins WxH regardless of orientation** — the least-surprising behavior for an explicit request: the operator asked for a specific frame size, so rotation must not silently swap it. With `--size` set, a rotation resolves to the same size and no swap occurs (the mirror letterboxes within the pinned surface). Documented in `resolveOutputDimensions`.

## Test seams

- `RotationMonitorTest` — `poll()` change detection + coalescing, the listener-callback dispatch path, and the poll-fallback path when registration returns `null`. No real timers: the poll loop's sleep is injected, and threads are gated by `CountDownLatch`.
- `VideoServerRotationSwapTest` — preset scaling swaps W/H on portrait↔landscape; 0↔180 leaves size unchanged (no swap); `--size` pins across orientation; rotating back restores dims; the replay-cache reset clears decoder state.

End-to-end rotation on a device is manual/out-of-CI; the logic above is unit-covered.

## Validation

- `./gradlew :video-server:compileKotlin` — PASS
- `./gradlew :video-server:test` — PASS (includes the new rotation/swap tests)
- `./gradlew :video-server:detektMain :video-server:detektTest` — 0 violations
- ktfmt validator (`scripts/ktfmt/validate_ktfmt.sh`) — 0 diffs

Closes [#4785](https://github.com/kaeawc/auto-mobile/issues/4785).
